### PR TITLE
Fix RemoveUnusedForwardOutputs

### DIFF
--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -15,11 +15,12 @@ namespace {
 void InitXlaModuleBindings(py::module m) {
   py::class_<XlaModule, std::shared_ptr<XlaModule>>(m, "XlaModule")
       .def(py::init([](const std::shared_ptr<script::Module> module,
-                       bool use_full_conv_precision) {
-             return std::make_shared<XlaModule>(module,
-                                                use_full_conv_precision);
+                       bool use_full_conv_precision, bool differentiate) {
+             return std::make_shared<XlaModule>(module, use_full_conv_precision,
+                                                differentiate);
            }),
-           py::arg("module"), py::arg("use_full_conv_precision") = false)
+           py::arg("module"), py::arg("use_full_conv_precision") = false,
+           py::arg("differentiate") = true)
       .def("__call__",
            [](XlaModule& xla_module, py::args args) -> py::object {
              auto inputs = XlaCreateTensorList(args);
@@ -60,7 +61,8 @@ void InitXlaModuleBindings(py::module m) {
            const std::vector<std::string>& devices) {
           return XLATensor::CreateTensors(tensors, devices);
         });
-  m.def("_xla_metrics_report", []() { return xla::metrics::CreateMetricReport(); });
+  m.def("_xla_metrics_report",
+        []() { return xla::metrics::CreateMetricReport(); });
 }
 
 void InitXlaPassesBindings(py::module m) {
@@ -78,7 +80,8 @@ void InitXlaTensorBindings(py::module m) {
            py::arg("tensor"), py::arg("device") = "")
       .def("to_tensor", [](XLATensor& s) { return s.toTensor(); })
       .def("size", [](const XLATensor& s) { return s.Size(); })
-      .def("device", [](const XLATensor& s) { return s.GetDevice().ToString(); })
+      .def("device",
+           [](const XLATensor& s) { return s.GetDevice().ToString(); })
       .def("__add__", [](std::shared_ptr<XLATensor> self,
                          XLATensor& other) { return self->add(other, 1.0); })
       .def("add", [](std::shared_ptr<XLATensor> self, double alpha,

--- a/torch_xla/csrc/module.h
+++ b/torch_xla/csrc/module.h
@@ -25,7 +25,7 @@ struct XlaModule : public std::enable_shared_from_this<XlaModule> {
   // "use_full_conv_precision" controls whether to use maximum precision
   // available in hardware for convolutions.
   XlaModule(const std::shared_ptr<script::Module> module,
-            bool use_full_conv_precision);
+            bool use_full_conv_precision, bool differentiate);
 
   TensorBatchVector forward(const TensorBatchVector& inputs);
   // For the given gradient outputs, compute the gradient of input and
@@ -129,6 +129,8 @@ struct XlaModule : public std::enable_shared_from_this<XlaModule> {
   // to false on failure. Mitigates doing redundant work (compute gradients we
   // can't use) after the first training step, if the fusion fails.
   bool enable_trace_fusion_;
+  // Whether to differentiate the graph or not.
+  bool differentiate_;
   // Unique identifier for the module, used to keep track of tensors originating
   // from its forward method.
   uint64_t module_id_;

--- a/torch_xla/csrc/passes/remove_unused_forward_outputs.cpp
+++ b/torch_xla/csrc/passes/remove_unused_forward_outputs.cpp
@@ -9,20 +9,24 @@ namespace {
 
 // Remove an unused input from the backward graph from both the outputs and
 // captured outputs sections of its input.
-void RemoveInputFromBackwardGraph(Gradient& gradient, const size_t output_idx,
+void RemoveInputFromBackwardGraph(Gradient& gradient,
+                                  const at::optional<size_t> output_idx_maybe,
                                   const size_t captured_output_idx) {
   const auto backward_inputs = gradient.df->inputs();
-  const Value* grad_output = backward_inputs[output_idx];
+  const Value* grad_output =
+      output_idx_maybe ? backward_inputs[*output_idx_maybe] : nullptr;
   const Value* captured_output = backward_inputs[captured_output_idx];
   // Remove grad_output and captured_output from the inputs of the backward
   // graph.
   for (auto it = gradient.df->nodes().begin(), end = gradient.df->nodes().end();
        it != end; ++it) {
     const auto node_inputs = it->inputs();
-    const auto grad_output_it =
-        std::find(node_inputs.begin(), node_inputs.end(), grad_output);
-    // Assert that grad_output doesn't have remaining uses.
-    JIT_ASSERT(grad_output_it == node_inputs.end());
+    if (grad_output) {
+      const auto grad_output_it =
+          std::find(node_inputs.begin(), node_inputs.end(), grad_output);
+      // Assert that grad_output doesn't have remaining uses.
+      JIT_ASSERT(grad_output_it == node_inputs.end());
+    }
     const auto captured_output_it =
         std::find(node_inputs.begin(), node_inputs.end(), captured_output);
     if (captured_output_it != node_inputs.end()) {
@@ -36,10 +40,27 @@ void RemoveInputFromBackwardGraph(Gradient& gradient, const size_t output_idx,
   // points inside the outputs section. We thus have captured_output_idx >
   // output_idx because outputs come before captured outputs. Remove the
   // captured_output_idx first to avoid invalidation of indices.
-  JIT_ASSERT(captured_output_idx > output_idx);
+  JIT_ASSERT(!output_idx_maybe || captured_output_idx > *output_idx_maybe);
   gradient.df->eraseInput(captured_output_idx);
-  gradient.df->eraseInput(output_idx);
+  if (output_idx_maybe) {
+    gradient.df->eraseInput(*output_idx_maybe);
+  }
 }
+
+namespace {
+
+// Counts the number of additional outputs after the "real" outputs used by
+// differentiation the same way autodiff does.
+size_t IntermediateRequireGradOutputsCount(const Gradient& gradient) {
+  const auto forward_outputs = gradient.f->outputs();
+  return std::count_if(forward_outputs.begin() + gradient.f_real_outputs,
+                       forward_outputs.end(),
+                       [](const Value* intermediate_output) {
+                         return intermediate_output->requires_grad();
+                       });
+}
+
+}  // namespace
 
 // Remove the unused output specified by node_output_idx from the given node,
 // with subsequent removal from the backward graph input as well.
@@ -54,17 +75,23 @@ void RemoveNodeOutputFromGradient(Node* node, const size_t node_output_idx,
   if (output_it == forward_outputs.end()) {
     return;
   }
-  size_t output_idx = output_it - forward_outputs.begin();
+  const size_t output_idx = output_it - forward_outputs.begin();
+  const auto output_idx_maybe = (*output_it)->requires_grad()
+                                    ? at::optional<size_t>(output_idx)
+                                    : at::nullopt;
+
+  // Find the captured_output_idx absolute index of the backward graph input to
+  // remove. First, position it at the beginning of the captured outputs, right
+  // after the outputs of the forward graph and the captureed inputs.
+  size_t captured_output_idx = gradient.f_real_outputs +
+                               IntermediateRequireGradOutputsCount(gradient) +
+                               gradient.df_input_captured_inputs.size();
+
   // Remove the given output from the graph outputs.
   gradient.f->eraseOutput(output_idx);
   // Remove the given output from the node outputs.
   node->eraseOutput(node_output_idx);
 
-  // Find the captured_output_idx absolute index of the backward graph input to
-  // remove. First, position it at the beginning of the captured outputs, right
-  // after the outputs of the forward graph and the captureed inputs.
-  size_t captured_output_idx =
-      forward_outputs.size() + gradient.df_input_captured_inputs.size();
   // Next, find the index and value in df_input_captured_outputs of the node to
   // remove. Use it to adjust captured_output_idx and update
   // df_input_captured_outputs.
@@ -92,8 +119,10 @@ void RemoveNodeOutputFromGradient(Node* node, const size_t node_output_idx,
   }
 
   // Finally, remove the node from all inputs of the backward graph.
-  RemoveInputFromBackwardGraph(/*gradient=*/gradient, /*output_idx=*/output_idx,
-                               /*captured_output_idx=*/captured_output_idx);
+  RemoveInputFromBackwardGraph(
+      /*gradient=*/gradient,
+      /*output_idx_maybe=*/output_idx_maybe,
+      /*captured_output_idx=*/captured_output_idx);
 }
 
 }  // namespace


### PR DESCRIPTION
Also undo autodiff hacks compensating for the fixed bug and allow
modules to run forward only to salvage TestStack, which relied on said
hacks and doesn't occur yet in the models we run.