### PR TITLE
Insert implicit expands for add, mul in the trace

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,10 @@ torch_xla_sources = [
     'torch_xla/csrc/torch_util.cpp',
     'torch_xla/csrc/translator.cpp',
     'torch_xla/csrc/passes/eval_static_size.cpp',
+    'torch_xla/csrc/passes/insert_explicit_expand.cpp',
     'torch_xla/csrc/passes/remove_unused_forward_outputs.cpp',
     'torch_xla/csrc/passes/replace_untraced_operators.cpp',
+    'torch_xla/csrc/passes/set_mat_mul_output_shape.cpp',
     'torch_xla/csrc/passes/threshold_backward_peephole.cpp',
 ]
 

--- a/torch_xla/csrc/data_ops.h
+++ b/torch_xla/csrc/data_ops.h
@@ -17,12 +17,6 @@ xla::XlaOp BuildView(const Node* node, const xla::XlaOp& input);
 // specified by the "size" attribute of the given node.
 xla::XlaOp BuildExpand(const Node* node, const xla::XlaOp& input);
 
-// Same semantics as BuildExpand, but the output size is specified by the given
-// output instead. No-op if the input is a scalar or of higher rank than the
-// output.
-xla::XlaOp BuildImplicitExpand(const xla::XlaOp& input,
-                               const xla::XlaOp& output);
-
 // Concatenates a list of tensors along a new dimension specified by the "dim"
 // attribute of the given node.
 xla::XlaOp BuildStack(const Node* node,

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -1,34 +1,17 @@
 #include "elementwise.h"
-#include "data_ops.h"
 #include "helpers.h"
 
 namespace torch {
 namespace jit {
 
-namespace {
-
-xla::XlaOp DoBinaryOpWithImplicitExpand(
-    const xla::XlaOp& lhs, const xla::XlaOp& rhs,
-    std::function<xla::XlaOp(const xla::XlaOp&, const xla::XlaOp&)> op_fun) {
-  return op_fun(BuildImplicitExpand(lhs, rhs), BuildImplicitExpand(rhs, lhs));
-}
-
-}  // namespace
-
 xla::XlaOp BuildArithmeticOp(const Node* node, const xla::XlaOp& lhs,
                              const xla::XlaOp& rhs) {
   switch (node->kind()) {
     case aten::add: {
-      return DoBinaryOpWithImplicitExpand(
-          lhs, rhs, [](const xla::XlaOp& lhs, const xla::XlaOp& rhs) {
-            return lhs + rhs;
-          });
+      return lhs + rhs;
     }
     case aten::mul: {
-      return DoBinaryOpWithImplicitExpand(
-          lhs, rhs, [](const xla::XlaOp& lhs, const xla::XlaOp& rhs) {
-            return lhs * rhs;
-          });
+      return lhs * rhs;
     }
     default:
       LOG(FATAL) << "Invalid binary operator kind: " << node->kind();

--- a/torch_xla/csrc/passes/insert_explicit_expand.cpp
+++ b/torch_xla/csrc/passes/insert_explicit_expand.cpp
@@ -1,0 +1,40 @@
+#include "insert_explicit_expand.h"
+
+namespace torch {
+namespace jit {
+
+namespace {
+
+void InsertExplicitExpand(Block* block) {
+  for (auto it = block->nodes().begin(), end = block->nodes().end(); it != end;
+       ++it) {
+    for (auto sub_block : it->blocks()) {
+      InsertExplicitExpand(sub_block);
+    }
+    if (it->kind() == aten::add || it->kind() == aten::mul) {
+      const auto lhs_type = it->input(0)->type()->cast<CompleteTensorType>();
+      const auto rhs_type = it->input(1)->type()->cast<CompleteTensorType>();
+      const auto output_type =
+          it->output(0)->type()->cast<CompleteTensorType>();
+      if (lhs_type && rhs_type && output_type &&
+          lhs_type->sizes() != rhs_type->sizes()) {
+        WithInsertPoint insert_point_guard(*it);
+        auto graph = block->owningGraph();
+        const auto tensor_sizes = graph->insertConstant(rhs_type->sizes());
+        const auto expand =
+            graph->insert(aten::expand, {it->input(0), tensor_sizes});
+        it->replaceInput(0, expand);
+        it->output(0)->setType(output_type->withRequiresGrad(true));
+      }
+    }
+  }
+}
+
+}  // namespace
+
+void InsertExplicitExpand(const std::shared_ptr<Graph>& graph) {
+  InsertExplicitExpand(graph->block());
+}
+
+}  // namespace jit
+}  // namespace torch

--- a/torch_xla/csrc/passes/insert_explicit_expand.h
+++ b/torch_xla/csrc/passes/insert_explicit_expand.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "torch/csrc/jit/ir.h"
+
+namespace torch {
+namespace jit {
+
+// Insert aten::expand as needed for aten::{add, mul} operations.
+void InsertExplicitExpand(const std::shared_ptr<Graph>& graph);
+
+}  // namespace jit
+}  // namespace torch

--- a/torch_xla/csrc/passes/set_mat_mul_output_shape.cpp
+++ b/torch_xla/csrc/passes/set_mat_mul_output_shape.cpp
@@ -1,0 +1,33 @@
+#include "set_mat_mul_output_shape.h"
+
+namespace torch {
+namespace jit {
+
+namespace {
+
+void SetMatMulOutputShape(Block* block) {
+  for (auto it = block->nodes().begin(), end = block->nodes().end(); it != end;
+       ++it) {
+    for (auto sub_block : it->blocks()) {
+      SetMatMulOutputShape(sub_block);
+    }
+    if (it->kind() == aten::mm) {
+      const auto lhs_type = it->input(0)->type()->cast<CompleteTensorType>();
+      const auto rhs_type = it->input(1)->type()->cast<CompleteTensorType>();
+      JIT_ASSERT(lhs_type->sizes().size() == 2 &&
+                 rhs_type->sizes().size() == 2);
+      it->output()->setType(CompleteTensorType::create(
+          lhs_type->scalarType(), lhs_type->device(),
+          at::IntList{lhs_type->sizes().at(0), rhs_type->sizes().at(1)}));
+    }
+  }
+}
+
+}  // namespace
+
+void SetMatMulOutputShape(const std::shared_ptr<Graph>& graph) {
+  SetMatMulOutputShape(graph->block());
+}
+
+}  // namespace jit
+}  // namespace torch

--- a/torch_xla/csrc/passes/set_mat_mul_output_shape.h
+++ b/torch_xla/csrc/passes/set_mat_mul_output_shape.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "torch/csrc/jit/ir.h"
+
+namespace torch {
+namespace jit {
+
+// Set the output shape of aten::mm.
+void SetMatMulOutputShape(const std::shared_ptr<Graph>& graph);
+
+}  // namespace jit
+}  // namespace torch


### PR DESCRIPTION
The implicit behavior is wrong when taking the gradient of a linear
layer. Instead of that, add explicit expands for add and mul operators
in the trace.