### PR TITLE
Format all Python files with autopep8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,8 @@ include_dirs = [
 include_dirs += [
     pytorch_source_path,
     os.path.join(pytorch_source_path, 'torch', 'csrc'),
-    os.path.join(pytorch_source_path, 'torch', 'lib', 'tmp_install', 'include'),
+    os.path.join(pytorch_source_path, 'torch',
+                 'lib', 'tmp_install', 'include'),
 ]
 
 library_dirs = []
@@ -120,7 +121,8 @@ extra_link_args += ['-lxla_computation_client']
 
 version = '0.1'
 try:
-    sha = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=cwd).decode('ascii').strip()
+    sha = subprocess.check_output(
+        ['git', 'rev-parse', 'HEAD'], cwd=cwd).decode('ascii').strip()
     version += '+' + sha[:7]
 except Exception:
     pass
@@ -141,7 +143,8 @@ setup(
             include_dirs=include_dirs,
             extra_compile_args=extra_compile_args,
             library_dirs=library_dirs,
-            extra_link_args=extra_link_args + [make_relative_rpath('torch_xla/lib')],
+            extra_link_args=extra_link_args + \
+                [make_relative_rpath('torch_xla/lib')],
         ),
     ],
     package_data={

--- a/test/test_train_cifar.py
+++ b/test/test_train_cifar.py
@@ -64,7 +64,8 @@ class ResNet(nn.Module):
         super(ResNet, self).__init__()
         self.in_planes = 64
 
-        self.conv1 = nn.Conv2d(3, 64, kernel_size=3, stride=1, padding=1, bias=False)
+        self.conv1 = nn.Conv2d(3, 64, kernel_size=3,
+                               stride=1, padding=1, bias=False)
         self.bn1 = nn.BatchNorm2d(64)
         self.layer1 = self._make_layer(block, 64, num_blocks[0], stride=1)
         self.layer2 = self._make_layer(block, 128, num_blocks[1], stride=2)
@@ -102,12 +103,14 @@ def train_cifar():
         transforms.RandomCrop(32, padding=4),
         transforms.RandomHorizontalFlip(),
         transforms.ToTensor(),
-        transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
+        transforms.Normalize((0.4914, 0.4822, 0.4465),
+                             (0.2023, 0.1994, 0.2010)),
     ])
 
     transform_test = transforms.Compose([
         transforms.ToTensor(),
-        transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
+        transforms.Normalize((0.4914, 0.4822, 0.4465),
+                             (0.2023, 0.1994, 0.2010)),
     ])
 
     trainset = torchvision.datasets.CIFAR10(

--- a/test/test_train_mnist.py
+++ b/test/test_train_mnist.py
@@ -80,7 +80,8 @@ def train_mnist():
     target = torch.zeros(FLAGS.batch_size, dtype=torch.int64)
     xla_model = xm.XlaModel(model, [inputs], loss_fn=F.nll_loss, target=target,
                             num_cores=FLAGS.num_cores, devices=devices)
-    optimizer = optim.SGD(xla_model.parameters_list(), lr=lr, momentum=momentum)
+    optimizer = optim.SGD(xla_model.parameters_list(),
+                          lr=lr, momentum=momentum)
 
     for epoch in range(1, FLAGS.num_epochs + 1):
         xla_model.train(train_loader, optimizer, FLAGS.batch_size,

--- a/torch_xla_py/xla_model.py
+++ b/torch_xla_py/xla_model.py
@@ -40,7 +40,8 @@ class ToXlaTensorArena(object):
                 self._tensors, self._devices)
         elif type(self._tensors[0]) == torch_xla._C.XLATensor:
             assert not self._devices
-            self._converted_tensors = torch_xla._C._xla_to_tensors(self._tensors)
+            self._converted_tensors = torch_xla._C._xla_to_tensors(
+                self._tensors)
         else:
             self._converted_tensors = self._tensors
 
@@ -111,7 +112,8 @@ def convert_to_xla_tensors(inputs, devices=None):
 
 def convert_to_tensors(inputs):
     arena = ToXlaTensorArena()
-    tensors = _collect_tensors(arena, torch_xla._C.XLATensor, inputs, device=None)
+    tensors = _collect_tensors(
+        arena, torch_xla._C.XLATensor, inputs, device=None)
     arena.convert()
     return _replace_tensors(arena, tensors)
 
@@ -245,7 +247,8 @@ def xla_loss(loss_fn, output_xla_tensors, labels):
             flat_tensors[flat_index].requires_grad = True
             replica_outputs.append(flat_tensors[flat_index])
             flat_index += 1
-        replica_outputs_and_label = _append_label_to_tensor_list(replica_outputs, labels[i])
+        replica_outputs_and_label = _append_label_to_tensor_list(
+            replica_outputs, labels[i])
         losses.append(loss_fn(*replica_outputs_and_label))
         outputs.append(tuple(replica_outputs))
     return losses, tuple(outputs)


### PR DESCRIPTION
Specified --max-line-length 79 to take care of long lines.