### PR TITLE
Move the metric snapshotting after the release handles call, since th…

### DIFF
--- a/third_party/xla_client/xla_computation_client.cc
+++ b/third_party/xla_client/xla_computation_client.cc
@@ -52,8 +52,8 @@ XlaComputationClient::XlaComputationClient(
 std::vector<std::shared_ptr<ComputationClient::Data>>
 XlaComputationClient::TransferToServer(
     tensorflow::gtl::ArraySlice<const LiteralDevice> literals) {
-  metrics::TimedSection timed(TransferToServerMetric());
   FlushReleasedHandles();
+  metrics::TimedSection timed(TransferToServerMetric());
 
   // This can be made parallel, WRT literal creation.
   int64 total_size = 0;
@@ -76,8 +76,8 @@ XlaComputationClient::TransferToServer(
 
 std::vector<Literal> XlaComputationClient::TransferFromServer(
     tensorflow::gtl::ArraySlice<const std::shared_ptr<Data>> handles) {
-  metrics::TimedSection timed(TransferFromServerMetric());
   FlushReleasedHandles();
+  metrics::TimedSection timed(TransferFromServerMetric());
 
   int64 total_size = 0;
   std::vector<Literal> results;
@@ -97,8 +97,8 @@ XlaComputationClient::ExecuteComputation(
     const XlaComputation& computation,
     tensorflow::gtl::ArraySlice<Data*> arguments, const string& device,
     const Shape* output_shape) {
-  metrics::TimedSection timed(ExecuteMetric());
   FlushReleasedHandles();
+  metrics::TimedSection timed(ExecuteMetric());
 
   std::string effective_device = GetEffectiveDevice(device);
   std::vector<GlobalData*> arguments_data =

--- a/third_party/xla_client/xrt_computation_client.cc
+++ b/third_party/xla_client/xrt_computation_client.cc
@@ -40,8 +40,8 @@ XrtComputationClient::XrtComputationClient(
 std::vector<std::shared_ptr<ComputationClient::Data>>
 XrtComputationClient::TransferToServer(
     tensorflow::gtl::ArraySlice<const LiteralDevice> literals) {
-  metrics::TimedSection timed(TransferToServerMetric());
   ApiCallInitialize();
+  metrics::TimedSection timed(TransferToServerMetric());
 
   std::mutex lock;
   XrtSessionCache::SessionMap session_map;
@@ -105,8 +105,8 @@ XrtComputationClient::TransferToServer(
 
 std::vector<Literal> XrtComputationClient::TransferFromServer(
     tensorflow::gtl::ArraySlice<const std::shared_ptr<Data>> handles) {
-  metrics::TimedSection timed(TransferFromServerMetric());
   ApiCallInitialize();
+  metrics::TimedSection timed(TransferFromServerMetric());
 
   XrtSessionCache::SessionMap session_map;
   std::map<XrtSession*, SessionWork> session_work_map;
@@ -149,8 +149,8 @@ XrtComputationClient::ExecuteComputation(
     const XlaComputation& computation,
     tensorflow::gtl::ArraySlice<Data*> arguments, const string& device,
     const Shape* output_shape) {
-  metrics::TimedSection timed(ExecuteMetric());
   ApiCallInitialize();
+  metrics::TimedSection timed(ExecuteMetric());
 
   XrtSessionCache::SessionMap session_map;
   string effective_device = GetEffectiveDevice(device);
@@ -179,8 +179,8 @@ XrtComputationClient::ExecuteReplicated(
     const std::vector<std::vector<Data*>>& arguments,
     tensorflow::gtl::ArraySlice<const string> devices,
     const Shape* output_shape) {
-  metrics::TimedSection timed(ExecuteReplicatedMetric());
   ApiCallInitialize();
+  metrics::TimedSection timed(ExecuteReplicatedMetric());
 
   XrtSessionCache::SessionMap session_map;
   tensorflow::ClientSession::FeedType feed_inputs;
@@ -247,8 +247,8 @@ XrtComputationClient::ExecuteParallel(
     const std::vector<std::vector<Data*>>& arguments,
     tensorflow::gtl::ArraySlice<const string> devices,
     tensorflow::gtl::ArraySlice<const Shape* const> output_shapes) {
-  metrics::TimedSection timed(ExecuteParallelMetric());
   ApiCallInitialize();
+  metrics::TimedSection timed(ExecuteParallelMetric());
 
   XrtSessionCache::SessionMap session_map;
   tensorflow::ClientSession::FeedType feed_inputs;
@@ -266,8 +266,8 @@ XrtComputationClient::ExecuteParallel(
 std::vector<std::vector<std::shared_ptr<ComputationClient::Data>>>
 XrtComputationClient::DeconstructTuple(
     tensorflow::gtl::ArraySlice<const std::shared_ptr<Data>> tuples) {
-  metrics::TimedSection timed(DeconstructTupleMetric());
   ApiCallInitialize();
+  metrics::TimedSection timed(DeconstructTupleMetric());
 
   XrtSessionCache::SessionMap session_map;
   std::map<XrtSession*, SessionWork> session_work_map;


### PR DESCRIPTION
…at already has its metric.