### PR TITLE
Sketch IR interface.

### DIFF
--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -1,0 +1,88 @@
+#include "ir.h"
+
+#include <sstream>
+
+#include "tensorflow/compiler/xla/xla_client/debug_macros.h"
+
+namespace torch_xla {
+namespace ir {
+
+bool Use::operator<(const Use& rhs) const {
+  int cmp = node->op().compare(rhs.node->op());
+  if (cmp != 0) {
+    return cmp < 0;
+  }
+  if (operand_index != rhs.operand_index) {
+    return operand_index < rhs.operand_index;
+  }
+  return index < rhs.index;
+}
+
+std::string Use::ToString() const {
+  std::stringstream ss;
+  ss << node->ToString() << ";o=" << operand_index << ";i=" << index;
+  return ss.str();
+}
+
+std::string Output::ToString() const {
+  std::stringstream ss;
+  ss << node->ToString() << ";i=" << index;
+  return ss.str();
+}
+
+Node::Node(std::string op,
+           tensorflow::gtl::ArraySlice<const NodeOperand> operands,
+           size_t num_outputs)
+    : op_(std::move(op)), num_outputs_(num_outputs) {
+  for (auto& operand : operands) {
+    AddOperand(operand.node, operand.index);
+  }
+}
+
+Node::~Node() {
+  for (size_t i = 0; i < operands_as_outputs_.size(); ++i) {
+    operands_as_outputs_[i].node->RemoveUse(
+        Use(this, i, operands_as_outputs_[i].index));
+  }
+}
+
+void Node::AddOperand(NodePtr node, size_t index) {
+  XLA_CHECK_LT(index, node->num_outputs());
+  operands_.push_back(std::move(node));
+  operands_as_outputs_.push_back(Output(operands_.back().get(), index));
+  operands_.back()->AddUse(Use(this, operands_.size() - 1, index));
+}
+
+void Node::ReplaceOperand(size_t operand_no, NodePtr node, size_t index) {
+  XLA_CHECK_LT(index, node->num_outputs());
+  Output* output = &operands_as_outputs_.at(operand_no);
+  output->node->RemoveUse(Use(this, operand_no, output->index));
+  node->AddUse(Use(this, operand_no, index));
+  *output = Output(node.get(), index);
+  operands_[operand_no] = std::move(node);
+}
+
+void Node::ReplaceAllUsesWith(NodePtr node, size_t index) {
+  // A call to ReplaceOperand() will end up calling RemoveUse() into the
+  // current node, so snapshot the current uses and iterate over them.
+  std::vector<Use> current_uses(uses_.begin(), uses_.end());
+  for (auto& use : current_uses) {
+    use.node->ReplaceOperand(use.operand_index, node, index);
+  }
+}
+
+std::string Node::ToString() const {
+  std::stringstream ss;
+  ss << op();
+  if (num_outputs() > 1) {
+    ss << ";n=" << num_outputs();
+  }
+  return ss.str();
+}
+
+XlaOpVector Node::Lower(LoweringContext* loctx) const {
+  XLA_ERROR() << "Lowering not implemented for node: " << *this;
+}
+
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -1,0 +1,157 @@
+#pragma once
+
+#include <iostream>
+#include <memory>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "tensorflow/compiler/xla/client/xla_builder.h"
+#include "tensorflow/core/lib/gtl/array_slice.h"
+#include "tensorflow/core/lib/gtl/inlined_vector.h"
+
+namespace torch_xla {
+namespace ir {
+
+class Node;
+class LoweringContext;
+
+using NodePtr = std::shared_ptr<Node>;
+
+using XlaOpVector = tensorflow::gtl::InlinedVector<xla::XlaOp, 1>;
+
+// Represents a use of the output of a given node.
+// If use U is within node N, it means that node U.node is using the output
+// U.index of the node N.
+struct Use {
+  Use() = default;
+  Use(Node* node, size_t operand_index, size_t index)
+      : node(node), operand_index(operand_index), index(index) {}
+
+  bool operator<(const Use& rhs) const;
+
+  std::string ToString() const;
+
+  // The node using the output of the node this use belongs to.
+  Node* node = nullptr;
+  // The operand index, within node's operands, which this use refers to.
+  size_t operand_index = 0;
+  // The index within output the user node refers to.
+  size_t index = 0;
+};
+
+inline std::ostream& operator<<(std::ostream& stream, const Use& use) {
+  stream << use.ToString();
+  return stream;
+}
+
+// Represents a specific output produced by a node. Since the output of a node
+// can be composed by multiple outputs, the node+index coordinates fully qualify
+// each single output.
+struct Output {
+  struct Hasher {
+    size_t operator()(const Output& output) const {
+      size_t h = reinterpret_cast<std::ptrdiff_t>(output.node);
+      return h ^ (h >> 11) ^ output.index;
+    }
+  };
+
+  Output() = default;
+  explicit Output(Node* node, size_t index = 0) : node(node), index(index) {}
+
+  bool operator==(const Output& rhs) const {
+    return node == rhs.node && index == rhs.index;
+  }
+  bool operator!=(const Output& rhs) const { return !operator==(rhs); }
+
+  std::string ToString() const;
+
+  // The node providing the output.
+  Node* node = nullptr;
+  // The index in the node's output this output refers to.
+  size_t index = 0;
+};
+
+inline std::ostream& operator<<(std::ostream& stream, const Output& output) {
+  stream << output.ToString();
+  return stream;
+}
+
+using OutputSet = std::unordered_set<Output, Output::Hasher>;
+
+template <typename T>
+using OutputMap = std::unordered_map<Output, T, Output::Hasher>;
+
+// Represents an input/operand for a Node object.
+struct NodeOperand {
+  NodeOperand() = default;
+  explicit NodeOperand(NodePtr node, size_t index = 0)
+      : node(std::move(node)), index(index) {}
+
+  NodePtr node;
+  size_t index = 0;
+};
+
+// A node in the graph. Nodes for operations which requires extra data to be
+// stored for lowering, should inherit from this class and add operation
+// specific member there. For example, a constant might create a new
+// NodeConstant class (inheriting from Node) with an extra xla::Literal field,
+// or a tensor value might create a new NodeTensor with computation client data
+// handle in it.
+class Node {
+ public:
+  // Creates a new node with the given op name. The op name is a unique
+  // identifier for the operation, which in the PyTorch case will be the full
+  // operation signature which is currently used throughout the code base.
+  // The num_outputs tells how many outputs a given operation generates.
+  Node(std::string op, tensorflow::gtl::ArraySlice<const NodeOperand> operands,
+       size_t num_outputs = 1);
+
+  virtual ~Node();
+
+  const std::string& op() const { return op_; }
+
+  size_t num_outputs() const { return num_outputs_; }
+
+  const std::vector<Output>& operands() const { return operands_as_outputs_; }
+
+  const std::set<Use>& uses() const { return uses_; }
+
+  void ReplaceOperand(size_t operand_no, NodePtr node, size_t index = 0);
+
+  void ReplaceAllUsesWith(NodePtr node, size_t index = 0);
+
+  virtual std::string ToString() const;
+
+  virtual XlaOpVector Lower(LoweringContext* loctx) const;
+
+ private:
+  // Adds node's index output number as operand.
+  void AddOperand(NodePtr node, size_t index = 0);
+
+  void AddUse(Use use) { uses_.insert(std::move(use)); }
+
+  void RemoveUse(const Use& use) { uses_.erase(use); }
+
+  // The name/ID of the operation captured by this node.
+  const std::string op_;
+  const size_t num_outputs_ = 1;
+  // A node holds a real reference to its operands.
+  std::vector<NodePtr> operands_;
+  // Outputs do not hold references on the nodes, and neither do the uses, since
+  // otherwise we get into circular reference counting.
+  std::vector<Output> operands_as_outputs_;
+  // We use a set for uses, as we want deterministic use sequencing.
+  std::set<Use> uses_;
+};
+
+inline std::ostream& operator<<(std::ostream& stream, const Node& node) {
+  stream << node.ToString();
+  return stream;
+}
+
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/lowering_context.cpp
+++ b/torch_xla/csrc/lowering_context.cpp
@@ -1,0 +1,61 @@
+#include "lowering_context.h"
+
+#include "tensorflow/compiler/xla/xla_client/debug_macros.h"
+
+namespace torch_xla {
+namespace ir {
+
+xla::XlaOp LoweringContext::GetParameter(
+    const std::shared_ptr<xla::ComputationClient::Data>& data) {
+  auto it = parameters_map_.find(data.get());
+  if (it == parameters_map_.end()) {
+    xla::XlaOp param =
+        xla::Parameter(builder(), parameters_.size(), data->shape(),
+                       absl::StrCat("param_", parameters_.size()));
+    parameters_.push_back(data);
+    it = parameters_map_.emplace(data.get(), param).first;
+  }
+  return it->second;
+}
+
+std::vector<xla::ComputationClient::Data*> LoweringContext::GetParametersData()
+    const {
+  std::vector<xla::ComputationClient::Data*> parameters;
+  for (auto& param : parameters_) {
+    parameters.push_back(param.get());
+  }
+  return parameters;
+}
+
+xla::int64 LoweringContext::AddResult(xla::XlaOp op) {
+  root_tuple_.push_back(std::move(op));
+  return root_tuple_.size() - 1;
+}
+
+xla::StatusOr<xla::XlaComputation> LoweringContext::Build() {
+  if (!root_tuple_.empty()) {
+    auto root = xla::Tuple(builder(), root_tuple_);
+    return builder()->Build(root);
+  }
+  return builder()->Build();
+}
+
+xla::StatusOr<xla::XlaComputation> LoweringContext::Build(
+    const xla::XlaOp& root) {
+  XLA_CHECK(root_tuple_.empty());
+  return builder()->Build(root);
+}
+
+void LoweringContext::AssignOutputOp(const Output& output, xla::XlaOp op) {
+  emitted_outputs_[output] = op;
+}
+
+xla::XlaOp LoweringContext::GetOutputOp(const Output& output) const {
+  auto it = emitted_outputs_.find(output);
+  XLA_CHECK(it != emitted_outputs_.end())
+      << "No XLA operation amitted for output: " << output;
+  return it->second;
+}
+
+}  // namespace ir
+}  // namespace torch_xla


### PR DESCRIPTION
A sketch of the IR interface that allows us to have a real graph structure instead of the current functor generator black-boxes.
The LoweringContext will replace the current XlaGraphContext.
The Node will replace the XlaGraphNode.
The lowering logic will be in the Lower() API.
For silly lowering (+,-,*,... - w/out extra Node metadata) we will have a Node inheritance that accept a functor, similar to the current one.

We will replace the current logic in XLATensor first, and then scale XLATensor (or a reincarnation of it) to the tensor interface.
