### PR TITLE
Xrt tensor alloc

### DIFF
--- a/third_party/xla_client/util.h
+++ b/third_party/xla_client/util.h
@@ -58,6 +58,16 @@ std::vector<typename C::value_type::element_type*> GetSharedPointers(
   return pointers;
 }
 
+template <typename T, typename C>
+std::vector<T> GetArrayAsVector(const C& array) {
+  std::vector<T> elements;
+  elements.reserve(array.size());
+  for (auto& value : array) {
+    elements.push_back(static_cast<T>(value));
+  }
+  return elements;
+}
+
 }  // namespace util
 }  // namespace xla
 

--- a/third_party/xla_client/xrt_computation_client.h
+++ b/third_party/xla_client/xrt_computation_client.h
@@ -338,6 +338,8 @@ class XrtComputationClient : public ComputationClient {
   // Converts an XLA data type to a tensorflow data type.
   static tensorflow::DataType XlaTypeToDataType(PrimitiveType dtype);
 
+  static tensorflow::TensorShape MakeEquivalentTensorShape(const Shape& shape);
+
   // Builds an argument vector usable in a replicated context, out of a single
   // replica argument vector. Essentially turns a [N] into a [1][N].
   static std::vector<std::vector<Data*>> BuildParallelArguments(

--- a/third_party/xla_client/xrt_computation_client.h
+++ b/third_party/xla_client/xrt_computation_client.h
@@ -27,6 +27,7 @@
 #include "tensorflow/compiler/xrt/cc/ops/xrt_state_ops.h"
 #include "tensorflow/compiler/xrt/xrt.pb.h"
 #include "tensorflow/contrib/tpu/proto/topology.pb.h"
+#include "tensorflow/core/framework/tensor.h"
 
 namespace xla {
 
@@ -282,17 +283,19 @@ class XrtComputationClient : public ComputationClient {
                                             const tensorflow::Scope& scope,
                                             const string& device) const;
 
-  // Creates an XRTAllocate node:
+  // Creates an XRTAllocateFromTensor node for creating a device tensor with
+  // the given shape and layout:
   //
-  //  XRTAllocate(
+  //  XRTAllocateFromTensor(
   //    holders[0]
   //  )
   //
   // With:
-  //  holders[0] = xrt::XLAAllocation place-holder (DT_STRING)
+  //  holders[0] = Tensor place-holder (DT_* - depends on shape type)
   const XrtSession::CachedNode& GetAllocateNode(XrtSession* session,
                                                 const tensorflow::Scope& scope,
-                                                const string& device) const;
+                                                const string& device,
+                                                const Shape& shape) const;
 
   // Creates an XRTReleaseAllocationHandle node:
   //
@@ -331,6 +334,9 @@ class XrtComputationClient : public ComputationClient {
   const XrtSession::CachedNode& GetSubTupleNode(XrtSession* session,
                                                 const tensorflow::Scope& scope,
                                                 const string& device) const;
+
+  // Converts an XLA data type to a tensorflow data type.
+  static tensorflow::DataType XlaTypeToDataType(PrimitiveType dtype);
 
   // Builds an argument vector usable in a replicated context, out of a single
   // replica argument vector. Essentially turns a [N] into a [1][N].


### PR DESCRIPTION
I am not 100% happy with the current status.
We have a computation client interface which takes a Literal, which means we have to convert to Literal, then to Tensor.
Ideally we would want to read (to-server) and write (from-server) directly from/to an ATEN tensor buffer. So that'll will be done in a near future.
Having the computation client interface accept ATEN tensors (plus requested on-device shape+layout, for to-server) might be the obvious choice, but that's a problem on itself due to bazel building ATEN stuff.
