### PR TITLE
Add thnn_conv2d_forward to ATen XLA tensor

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -104,6 +104,20 @@ at::Tensor AtenXlaType::conv2d(const at::Tensor& input,
   }
 }
 
+std::tuple<at::Tensor, at::Tensor, at::Tensor> AtenXlaType::thnn_conv2d_forward(
+    const at::Tensor& self, const at::Tensor& weight,
+    at::IntArrayRef kernel_size, const at::Tensor& bias, at::IntArrayRef stride,
+    at::IntArrayRef padding) const {
+  at::Tensor undefined = at::empty({});
+  // TODO(asuhan): double check it's ok to return undefined for finput and
+  // fgrad_input.
+  return std::make_tuple(
+      conv2d(/*input=*/self, /*weight=*/weight, /*bias=*/bias,
+             /*stride=*/stride, /*padding=*/padding, /*dilation=*/{1, 1},
+             /*groups=*/1),
+      undefined, undefined);
+}
+
 std::tuple<at::Tensor, at::Tensor, at::Tensor>
 AtenXlaType::thnn_conv2d_backward(const at::Tensor& grad_output,
                                   const at::Tensor& self,

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -41,6 +41,11 @@ class AtenXlaType : public AtenXlaTypeBase {
                     at::IntList padding, at::IntList dilation,
                     int64_t groups) const override;
 
+  std::tuple<at::Tensor, at::Tensor, at::Tensor> thnn_conv2d_forward(
+      const at::Tensor& self, const at::Tensor& weight,
+      at::IntArrayRef kernel_size, const at::Tensor& bias,
+      at::IntArrayRef stride, at::IntArrayRef padding) const override;
+
   std::tuple<at::Tensor, at::Tensor, at::Tensor> thnn_conv2d_backward(
       const at::Tensor& grad_output, const at::Tensor& self,
       const at::Tensor& weight, at::IntList kernel_size, at::IntList stride,


### PR DESCRIPTION
Used for convolutions when the input requires gradient.