### PR TITLE
Move hasher implementation to CPP file to reuse the hash combiner, in…

### DIFF
--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -27,6 +27,11 @@ std::string Use::ToString() const {
   return ss.str();
 }
 
+size_t Output::Hasher::operator()(const Output& output) const {
+  return xla::util::HashCombine(reinterpret_cast<std::ptrdiff_t>(output.node),
+                                output.index);
+}
+
 std::string Output::ToString() const {
   std::stringstream ss;
   ss << node->ToString() << ", index=" << index;

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -57,10 +57,7 @@ inline std::ostream& operator<<(std::ostream& stream, const Use& use) {
 // each single output.
 struct Output {
   struct Hasher {
-    size_t operator()(const Output& output) const {
-      size_t h = reinterpret_cast<std::ptrdiff_t>(output.node);
-      return h ^ (output.index + 0x9e3779b97f4a7c15 + (h << 6) + (h >> 2));
-    }
+    size_t operator()(const Output& output) const;
   };
 
   Output() = default;


### PR DESCRIPTION
…stead of copying its code.