### PR TITLE
Use Value::shape() instead of implicit cast and Node::shape()

### DIFF
--- a/torch_xla/csrc/ops/avg_pool2d.cpp
+++ b/torch_xla/csrc/ops/avg_pool2d.cpp
@@ -26,7 +26,7 @@ xla::Shape NodeOutputShape(
     return BuildAvgPool2d(operands[0], kernel_size, stride, padding,
                           count_include_pad);
   };
-  return InferOutputShape({input->shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.shape()}, lower_for_shape_fn);
 }
 
 }  // namespace

--- a/torch_xla/csrc/ops/avg_pool2d_backward.cpp
+++ b/torch_xla/csrc/ops/avg_pool2d_backward.cpp
@@ -26,7 +26,7 @@ xla::Shape NodeOutputShape(
                                   /*input=*/operands[1], kernel_size, stride,
                                   padding, count_include_pad);
   };
-  return InferOutputShape({grad_output->shape(), input->shape()},
+  return InferOutputShape({grad_output.shape(), input.shape()},
                           lower_for_shape_fn);
 }
 

--- a/torch_xla/csrc/ops/batch_norm_forward.cpp
+++ b/torch_xla/csrc/ops/batch_norm_forward.cpp
@@ -14,7 +14,7 @@ BatchNormForward::BatchNormForward(const Value& input, const Value& weight,
                                    const Value& running_var, double momentum,
                                    double eps)
     : Node(ir::OpKind(at::aten::batch_norm),
-           {input, weight, bias, running_mean, running_var}, input->shape(),
+           {input, weight, bias, running_mean, running_var}, input.shape(),
            /*num_outputs=*/1, xla::util::MHash(momentum, eps)),
       momentum_(momentum),
       eps_(eps) {}

--- a/torch_xla/csrc/ops/conv2d.cpp
+++ b/torch_xla/csrc/ops/conv2d.cpp
@@ -26,8 +26,7 @@ xla::Shape NodeOutputShape(
     return BuildConvolution(operands[0], operands[1], stride, padding,
                             xla::PrecisionConfig::DEFAULT);
   };
-  return InferOutputShape({input->shape(), weight->shape()},
-                          lower_for_shape_fn);
+  return InferOutputShape({input.shape(), weight.shape()}, lower_for_shape_fn);
 }
 
 xla::PrecisionConfig::Precision MakePrecisionConfig(

--- a/torch_xla/csrc/ops/conv2d_backward.cpp
+++ b/torch_xla/csrc/ops/conv2d_backward.cpp
@@ -28,9 +28,8 @@ xla::Shape NodeOutputShape(
     return xla::Tuple(operands[0].builder(),
                       {grads.grad_input, grads.grad_weight, grads.grad_bias});
   };
-  return InferOutputShape(
-      {grad_output->shape(), input->shape(), weight->shape()},
-      lower_for_shape_fn);
+  return InferOutputShape({grad_output.shape(), input.shape(), weight.shape()},
+                          lower_for_shape_fn);
 }
 
 xla::PrecisionConfig::Precision MakePrecisionConfig(

--- a/torch_xla/csrc/ops/cross_replica_sum.cpp
+++ b/torch_xla/csrc/ops/cross_replica_sum.cpp
@@ -10,7 +10,7 @@ namespace ops {
 
 CrossReplicaSum::CrossReplicaSum(const Value& operand,
                                  std::vector<std::vector<xla::int64>> groups)
-    : Node(xla_cross_replica_sum, {operand}, operand->shape(),
+    : Node(xla_cross_replica_sum, {operand}, operand.shape(),
            /*num_outputs=*/1, xla::util::MHash(groups)),
       groups_(std::move(groups)) {}
 

--- a/torch_xla/csrc/ops/max_pool2d.cpp
+++ b/torch_xla/csrc/ops/max_pool2d.cpp
@@ -24,7 +24,7 @@ xla::Shape NodeOutputShape(
         << "Unexpected number of operands: " << operands.size();
     return BuildMaxPool2d(operands[0], kernel_size, stride, padding);
   };
-  return InferOutputShape({input->shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.shape()}, lower_for_shape_fn);
 }
 
 }  // namespace

--- a/torch_xla/csrc/ops/max_pool2d_backward.cpp
+++ b/torch_xla/csrc/ops/max_pool2d_backward.cpp
@@ -24,7 +24,7 @@ xla::Shape NodeOutputShape(
                                   /*input=*/operands[1], kernel_size, stride,
                                   padding);
   };
-  return InferOutputShape({grad_output->shape(), input->shape()},
+  return InferOutputShape({grad_output.shape(), input.shape()},
                           lower_for_shape_fn);
 }
 

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -24,7 +24,7 @@ NodePtr ReluOp(const Value& input) {
     return BuildRelu(operands[0]);
   };
   xla::Shape output_shape =
-      ir::ops::InferOutputShape({input->shape()}, lower_for_shape_fn);
+      ir::ops::InferOutputShape({input.shape()}, lower_for_shape_fn);
   return ir::ops::GenericOp(ir::OpKind(at::aten::relu), ir::OpList{input},
                             output_shape, std::move(lower_fn));
 }
@@ -42,7 +42,7 @@ NodePtr TransposeOp(const Value& input) {
     return xla::Transpose(operands[0], {1, 0});
   };
   xla::Shape output_shape =
-      ir::ops::InferOutputShape({input->shape()}, lower_for_shape_fn);
+      ir::ops::InferOutputShape({input.shape()}, lower_for_shape_fn);
   return ir::ops::GenericOp(ir::OpKind(at::aten::t), ir::OpList{input},
                             output_shape, std::move(lower_fn));
 }
@@ -78,7 +78,7 @@ NodePtr AddMatMulOp(const Value& input, const Value& weight, const Value& bias,
     return xla::Dot(operands[0], operands[1]);
   };
   xla::Shape output_shape = ir::ops::InferOutputShape(
-      {input->shape(), weight->shape()}, lower_for_shape_fn);
+      {input.shape(), weight.shape()}, lower_for_shape_fn);
   return ir::ops::GenericOp(ir::OpKind(at::aten::addmm),
                             ir::OpList{input, weight, bias}, output_shape,
                             std::move(lower_fn));
@@ -106,7 +106,7 @@ NodePtr MatMulOp(const Value& input, const Value& weight,
     return xla::Dot(operands[0], operands[1]);
   };
   xla::Shape output_shape = ir::ops::InferOutputShape(
-      {input->shape(), weight->shape()}, lower_for_shape_fn);
+      {input.shape(), weight.shape()}, lower_for_shape_fn);
   return ir::ops::GenericOp(ir::OpKind(at::aten::mm), ir::OpList{input, weight},
                             output_shape, std::move(lower_fn));
 }
@@ -125,7 +125,7 @@ NodePtr NllLossOp(const Value& logits, const Value& labels) {
     return BuildNllLoss(/*logits=*/operands[0], /*labels=*/operands[1]);
   };
   xla::Shape output_shape = ir::ops::InferOutputShape(
-      {logits->shape(), labels->shape()}, lower_for_shape_fn);
+      {logits.shape(), labels.shape()}, lower_for_shape_fn);
   return ir::ops::GenericOp(ir::OpKind(at::aten::nll_loss),
                             ir::OpList{logits, labels}, output_shape,
                             std::move(lower_fn));
@@ -145,7 +145,7 @@ NodePtr NllLossBackwardOp(const Value& logits, const Value& labels) {
     return BuildNllLossBackward(/*logits=*/operands[0], /*labels=*/operands[1]);
   };
   xla::Shape output_shape = ir::ops::InferOutputShape(
-      {logits->shape(), labels->shape()}, lower_for_shape_fn);
+      {logits.shape(), labels.shape()}, lower_for_shape_fn);
   return ir::ops::GenericOp(ir::OpKind(at::aten::nll_loss_backward),
                             ir::OpList{logits, labels}, output_shape,
                             std::move(lower_fn));

--- a/torch_xla/csrc/ops/select.cpp
+++ b/torch_xla/csrc/ops/select.cpp
@@ -12,8 +12,7 @@ namespace {
 
 xla::Shape GetSelectShape(const xla::Shape& input_shape, xla::int64 dim,
                           xla::int64 index) {
-  auto new_dims =
-      XlaHelpers::DropDimensions(input_shape.dimensions(), {dim});
+  auto new_dims = XlaHelpers::DropDimensions(input_shape.dimensions(), {dim});
   return xla::ShapeUtil::MakeShape(input_shape.element_type(), new_dims);
 }
 
@@ -21,7 +20,7 @@ xla::Shape GetSelectShape(const xla::Shape& input_shape, xla::int64 dim,
 
 Select::Select(const Value& input, xla::int64 dim, xla::int64 index)
     : Node(ir::OpKind(at::aten::select), {input},
-           GetSelectShape(input->shape(), dim, index),
+           GetSelectShape(input.shape(), dim, index),
            /*num_outputs=*/1, xla::util::MHash(dim, index)),
       dim_(dim),
       index_(index) {}

--- a/torch_xla/csrc/ops/softmax.cpp
+++ b/torch_xla/csrc/ops/softmax.cpp
@@ -19,7 +19,7 @@ xla::Shape NodeOutputShape(const Value& input, xla::int64 dim) {
         << "Unexpected number of operands: " << operands.size();
     return BuildLogSoftmax(operands[0], dim);
   };
-  return InferOutputShape({input->shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.shape()}, lower_for_shape_fn);
 }
 
 }  // namespace

--- a/torch_xla/csrc/ops/softmax_backward.cpp
+++ b/torch_xla/csrc/ops/softmax_backward.cpp
@@ -20,7 +20,7 @@ xla::Shape NodeOutputShape(const Value& grad_output, const Value& output,
     return BuildLogSoftmaxGrad(/*grad_output=*/operands[0],
                                /*output=*/operands[1], dim);
   };
-  return InferOutputShape({grad_output.node->shape(), output.node->shape()},
+  return InferOutputShape({grad_output.shape(), output.shape()},
                           lower_for_shape_fn);
 }
 

--- a/torch_xla/csrc/ops/threshold.cpp
+++ b/torch_xla/csrc/ops/threshold.cpp
@@ -8,7 +8,7 @@ namespace ir {
 namespace ops {
 
 Threshold::Threshold(const Value& input, float threshold, float value)
-    : Node(ir::OpKind(at::aten::threshold), {input}, input->shape(),
+    : Node(ir::OpKind(at::aten::threshold), {input}, input.shape(),
            /*num_outputs=*/1, xla::util::MHash(threshold, value)),
       threshold_(threshold),
       value_(value) {}

--- a/torch_xla/csrc/ops/threshold_backward.cpp
+++ b/torch_xla/csrc/ops/threshold_backward.cpp
@@ -10,7 +10,7 @@ namespace ops {
 ThresholdBackward::ThresholdBackward(const Value& grad_output,
                                      const Value& input, float threshold)
     : Node(ir::OpKind(at::aten::threshold_backward), {grad_output, input},
-           input->shape(), /*num_outputs=*/1, xla::util::MHash(threshold)),
+           input.shape(), /*num_outputs=*/1, xla::util::MHash(threshold)),
       threshold_(threshold) {}
 
 XlaOpVector ThresholdBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/view.cpp
+++ b/torch_xla/csrc/ops/view.cpp
@@ -22,7 +22,7 @@ xla::Shape NodeOutputShape(
         << "Unexpected number of operands: " << operands.size();
     return BuildView(operands[0], output_sizes);
   };
-  return InferOutputShape({input->shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.shape()}, lower_for_shape_fn);
 }
 
 }  // namespace


### PR DESCRIPTION
This was an error prone pattern which could fetch the shape at index 0
since Node::shape() has that default.