### PR TITLE
Add bmm to ATen XLA tensor

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -780,6 +780,18 @@ TEST_F(AtenXlaTensorTest, TestMatmulBcast) {
   });
 }
 
+TEST_F(AtenXlaTensorTest, TestBatchMatMul) {
+  at::Tensor a = at::rand({3, 6, 4}, at::TensorOptions(at::kFloat));
+  at::Tensor b = at::rand({3, 4, 5}, at::TensorOptions(at::kFloat));
+  at::Tensor c = at::bmm(a, b);
+  ForEachDevice([&](const Device& device) {
+    at::Tensor xla_a = bridge::CreateXlaTensor(a, device);
+    at::Tensor xla_b = bridge::CreateXlaTensor(b, device);
+    at::Tensor xla_c = at::bmm(xla_a, xla_b);
+    AllClose(c, xla_c, /*rtol=*/1e-3, /*atol=*/1e-4);
+  });
+}
+
 TEST_F(AtenXlaTensorTest, TestEinsumOuter) {
   at::Tensor a = at::rand({5}, at::TensorOptions(at::kFloat));
   at::Tensor b = at::rand({5}, at::TensorOptions(at::kFloat));

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -724,6 +724,12 @@ at::Tensor AtenXlaType::matmul(const at::Tensor& self,
       bridge::GetXlaTensor(self), bridge::GetXlaTensor(other)));
 }
 
+at::Tensor AtenXlaType::bmm(const at::Tensor& self,
+                            const at::Tensor& mat2) const {
+  return bridge::AtenFromXlaTensor(
+      XLATensor::bmm(bridge::GetXlaTensor(self), bridge::GetXlaTensor(mat2)));
+}
+
 at::Tensor AtenXlaType::einsum(std::string equation,
                                at::TensorList tensors) const {
   if (tensors.size() != 2 || !ir::ops::Einsum::SupportsEquation(equation)) {

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -251,6 +251,8 @@ class AtenXlaType : public AtenXlaTypeBase {
   at::Tensor matmul(const at::Tensor& self,
                     const at::Tensor& other) const override;
 
+  at::Tensor bmm(const at::Tensor& self, const at::Tensor& mat2) const override;
+
   at::Tensor einsum(std::string equation,
                     at::TensorList tensors) const override;
 

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -309,6 +309,11 @@ class XLATensor {
 
   static XLATensor matmul(const XLATensor& input, const XLATensor& other);
 
+  // Batch matrix multiplication. Both tensors must be 3D, the batch size must
+  // match and the remaining two dimensions must be compatible for matrix
+  // multiplication.
+  static XLATensor bmm(const XLATensor& batch1, const XLATensor& batch2);
+
   // A generalized contraction between tensors of arbitrary dimension defined by
   // the given equation and applied to the input tensors.
   static XLATensor einsum(const std::string& equation,
@@ -634,6 +639,18 @@ class XLATensor {
       std::shared_ptr<xla::ComputationClient::Data> data);
 
   static xla::int64 GetNextTensorId();
+
+  // Checks a tensor rank against an expectation and throws an error on
+  // mismatch.
+  static void CheckRank(const XLATensor& t, xla::int64 expected_rank,
+                        const std::string& tag, const std::string& arg_name,
+                        int arg_number);
+
+  // Checks a tensor dimension size against an expectation and throws an error
+  // on mismatch.
+  static void CheckDimensionSize(const XLATensor& t, xla::int64 dim,
+                                 xla::int64 size, const std::string& tag,
+                                 const std::string& arg_name, int arg_number);
 
   std::shared_ptr<Data> data_;
 };


### PR DESCRIPTION
Can reuse matmul, just needs additional checks. Required by the einsum
lowering in PyTorch.