### PR TITLE
Complete support for einsum via PyTorch lowering

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -747,7 +747,7 @@ at::Tensor AtenXlaType::bmm(const at::Tensor& self,
 at::Tensor AtenXlaType::einsum(std::string equation,
                                at::TensorList tensors) const {
   if (tensors.size() != 2 || !ir::ops::Einsum::SupportsEquation(equation)) {
-    return AtenXlaTypeBase::einsum(equation, tensors);
+    return at::native::einsum(equation, tensors);
   }
   std::vector<XLATensor> xla_tensors;
   for (const auto& tensor : tensors) {


### PR DESCRIPTION
Just go directly to at::native::einsum to allow PyTorch lowering to use lazy tensors, we have already implemented the tensor methods used by it.