### PR TITLE
Add masked_fill to ATen XLA tensor

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1369,6 +1369,18 @@ class TestAtenXlaTensor(XlaTestCase):
     x_slice = x[:, :, -1]
     self.assertEqual(t_slice.data, x_slice.data.cpu())
 
+  def test_masked_fill_with_tensor(self):
+    input = _gen_tensor(2, 5, 4, 3)
+    mask = torch.randint(0, 2, input.size(), dtype=torch.uint8)
+    value = torch.tensor(42)
+    xla_input = input.to(xm.xla_device())
+    xla_mask = mask.to(xm.xla_device())
+    xla_value = value.to(xm.xla_device())
+    result = torch.masked_fill(input, mask, value)
+    xla_result = torch.masked_fill(xla_input, xla_mask, xla_value)
+    self.assertEqual(input.data, xla_input.data.cpu())
+    self.assertEqual(result.data, xla_result.data.cpu())
+
 
 if __name__ == '__main__':
   torch.set_default_tensor_type('torch.FloatTensor')

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1426,6 +1426,37 @@ at::Tensor AtenXlaType::unsqueeze(const at::Tensor& self, int64_t dim) const {
       XLATensor::unsqueeze(bridge::GetXlaTensor(self), dim));
 }
 
+at::Tensor& AtenXlaType::masked_fill_(at::Tensor& self, const at::Tensor& mask,
+                                      at::Scalar value) const {
+  XLATensor self_tensor = bridge::GetXlaTensor(self);
+  XLATensor::masked_fill_(self_tensor, bridge::GetXlaTensor(mask), value);
+  return self;
+}
+
+at::Tensor AtenXlaType::masked_fill(const at::Tensor& self,
+                                    const at::Tensor& mask,
+                                    at::Scalar value) const {
+  return bridge::AtenFromXlaTensor(XLATensor::masked_fill(
+      bridge::GetXlaTensor(self), bridge::GetXlaTensor(mask), value));
+}
+
+at::Tensor& AtenXlaType::masked_fill_(at::Tensor& self, const at::Tensor& mask,
+                                      const at::Tensor& value) const {
+  XLA_CHECK_EQ(value.dim(), 0) << "masked_fill_ only supports a 0-dimensional "
+                               << "value tensor, but got tensor "
+                               << "with " << value.dim() << " dimension(s).";
+  return masked_fill_(self, mask, value.item());
+}
+
+at::Tensor AtenXlaType::masked_fill(const at::Tensor& self,
+                                    const at::Tensor& mask,
+                                    const at::Tensor& value) const {
+  XLA_CHECK_EQ(value.dim(), 0) << "masked_fill only supports a 0-dimensional "
+                               << "value tensor, but got tensor "
+                               << "with " << value.dim() << " dimension(s).";
+  return masked_fill(self, mask, value.item());
+}
+
 at::Tensor AtenXlaType::where(const at::Tensor& condition,
                               const at::Tensor& self,
                               const at::Tensor& other) const {

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -472,6 +472,18 @@ class AtenXlaType : public AtenXlaTypeBase {
 
   at::Tensor unsqueeze(const at::Tensor& self, int64_t dim) const override;
 
+  at::Tensor& masked_fill_(at::Tensor& self, const at::Tensor& mask,
+                           at::Scalar value) const override;
+
+  at::Tensor masked_fill(const at::Tensor& self, const at::Tensor& mask,
+                         at::Scalar value) const override;
+
+  at::Tensor& masked_fill_(at::Tensor& self, const at::Tensor& mask,
+                           const at::Tensor& value) const override;
+
+  at::Tensor masked_fill(const at::Tensor& self, const at::Tensor& mask,
+                         const at::Tensor& value) const override;
+
   at::Tensor where(const at::Tensor& condition, const at::Tensor& self,
                    const at::Tensor& other) const override;
 

--- a/torch_xla/csrc/cross_replica_reduces.cpp
+++ b/torch_xla/csrc/cross_replica_reduces.cpp
@@ -9,7 +9,7 @@ xla::XlaOp BuildCrossReplicaSum(const xla::XlaOp& operand, int num_replicas) {
   auto shape = XlaHelpers::ShapeOfXlaOp(operand);
   auto scaling_value = XlaHelpers::ScalarValue<float>(
       1.0 / num_replicas, shape.element_type(), operand.builder());
-  return crs * xla::Broadcast(scaling_value, XlaHelpers::ShapeSizes(shape));
+  return crs * xla::Broadcast(scaling_value, shape.dimensions());
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/helpers.cpp
+++ b/torch_xla/csrc/helpers.cpp
@@ -181,7 +181,9 @@ xla::Shape XlaHelpers::ShapeOfXlaOp(const xla::XlaOp& op) {
 }
 
 std::vector<xla::int64> XlaHelpers::SizesOfXlaOp(const xla::XlaOp& op) {
-  return ShapeSizes(ShapeOfXlaOp(op));
+  xla::Shape op_shape = ShapeOfXlaOp(op);
+  return std::vector<xla::int64>(op_shape.dimensions().begin(),
+                                 op_shape.dimensions().end());
 }
 
 xla::PrimitiveType XlaHelpers::TypeOfXlaOp(const xla::XlaOp& op) {

--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -75,11 +75,6 @@ class XlaHelpers {
                        builder);
   }
 
-  // Returns the list of dimension sizes for the given shape.
-  static std::vector<xla::int64> ShapeSizes(const xla::Shape& shape) {
-    return xla::util::ToVector<xla::int64>(shape.dimensions());
-  }
-
   // Returns the shape of the given XLA operation.
   static xla::Shape ShapeOfXlaOp(const xla::XlaOp& op);
 
@@ -98,7 +93,7 @@ class XlaHelpers {
                                     xla::XlaBuilder* builder) {
     xla::XlaOp scalar_op =
         ScalarValue<T>(scalar_value, shape.element_type(), builder);
-    return xla::Broadcast(scalar_op, ShapeSizes(shape));
+    return xla::Broadcast(scalar_op, shape.dimensions());
   }
 
   // Creates a convolution or dot precision configuration.

--- a/torch_xla/csrc/ops/masked_fill.cpp
+++ b/torch_xla/csrc/ops/masked_fill.cpp
@@ -1,0 +1,39 @@
+#include "torch_xla/csrc/ops/masked_fill.h"
+#include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch_xla/csrc/helpers.h"
+#include "torch_xla/csrc/lowering_context.h"
+#include "torch_xla/csrc/ops/scalar.h"
+
+namespace torch_xla {
+namespace ir {
+namespace ops {
+
+MaskedFill::MaskedFill(const Value& input, const Value& mask, at::Scalar value)
+    : Node(OpKind(at::aten::masked_fill), {input, mask}, input.shape(),
+           /*num_outputs=*/1, ScalarHash(value)),
+      value_(std::move(value)) {}
+
+XlaOpVector MaskedFill::Lower(LoweringContext* loctx) const {
+  xla::XlaOp input = loctx->GetOutputOp(operand(0));
+  xla::XlaOp mask = loctx->GetOutputOp(operand(1));
+  xla::XlaOp zero = XlaHelpers::ScalarValue(
+      0, XlaHelpers::ShapeOfXlaOp(mask).element_type(), loctx->builder());
+  xla::XlaOp mask_pred = xla::Ne(mask, zero);
+  // Input shape is the same as output shape.
+  const xla::Shape& input_shape = shape();
+  xla::XlaOp value =
+      xla::Broadcast(XlaHelpers::ScalarValue(value_, input_shape.element_type(),
+                                             input.builder()),
+                     input_shape.dimensions());
+  return ReturnOp(xla::Select(mask_pred, value, input), loctx);
+}
+
+std::string MaskedFill::ToString() const {
+  std::stringstream ss;
+  ss << Node::ToString() << ", value=" << value_;
+  return ss.str();
+}
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/masked_fill.h
+++ b/torch_xla/csrc/ops/masked_fill.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <c10/core/Scalar.h>
+
+#include "torch_xla/csrc/ir.h"
+
+namespace torch_xla {
+namespace ir {
+namespace ops {
+
+class MaskedFill : public Node {
+ public:
+  MaskedFill(const Value& input, const Value& mask, at::Scalar value);
+
+  std::string ToString() const override;
+
+  XlaOpVector Lower(LoweringContext* loctx) const override;
+
+  const at::Scalar& value() const { return value_; }
+
+ private:
+  at::Scalar value_;
+};
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/scalar.cpp
+++ b/torch_xla/csrc/ops/scalar.cpp
@@ -71,7 +71,7 @@ XlaOpVector Scalar::Lower(LoweringContext* loctx) const {
 
   xla::XlaOp op = xla::ConstantLiteral(loctx->builder(), literal);
   if (shape().rank() > 0) {
-    op = xla::Broadcast(op, XlaHelpers::ShapeSizes(shape()));
+    op = xla::Broadcast(op, shape().dimensions());
   }
   return ReturnOp(op, loctx);
 }

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1371,7 +1371,7 @@ XLATensor XLATensor::masked_fill(const XLATensor& input, const XLATensor& mask,
                                  const at::Scalar& value) {
   // Expand mask to be the same size as input.
   ir::NodePtr expanded_mask = ir::MakeNode<ir::ops::Expand>(
-      mask.GetIrValue(), XlaHelpers::ShapeSizes(input.shape()));
+      mask.GetIrValue(), input.shape().get().dimensions());
   return input.CreateFrom(ir::MakeNode<ir::ops::MaskedFill>(
       input.GetIrValue(), expanded_mask, value));
 }
@@ -1380,7 +1380,7 @@ void XLATensor::masked_fill_(XLATensor& input, const XLATensor& mask,
                              const at::Scalar& value) {
   // Expand mask to be the same size as input.
   ir::NodePtr expanded_mask = ir::MakeNode<ir::ops::Expand>(
-      mask.GetIrValue(), XlaHelpers::ShapeSizes(input.shape()));
+      mask.GetIrValue(), input.shape().get().dimensions());
   input.SetIrValue(ir::MakeNode<ir::ops::MaskedFill>(input.GetIrValue(),
                                                      expanded_mask, value));
 }

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -513,6 +513,16 @@ class XLATensor {
   // Insert a dimension of size one at the specified position.
   static XLATensor unsqueeze(const XLATensor& input, xla::int64 dim);
 
+  // Fills elements of the input tensor with the provided value where mask is
+  // one. The shape of mask must be broadcastable with the shape of the
+  // underlying tensor.
+  static XLATensor masked_fill(const XLATensor& input, const XLATensor& mask,
+                               const at::Scalar& value);
+
+  // In-place version of the method above.
+  static void masked_fill_(XLATensor& input, const XLATensor& mask,
+                           const at::Scalar& value);
+
   // Returns the upper triangular part of a matrix (2-D tensor) or batch of
   // matrices input, the other elements of the result tensor out are set to 0.
   static XLATensor triu(const XLATensor& input, xla::int64 diagonal);


### PR DESCRIPTION
I had to add a Python test to exercise the 0-dimensional tensor fill value, there's no good way to do that from C++.