### PR TITLE
Re-route mul_ with other of rank 0 to the scalar overload

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -456,6 +456,9 @@ at::Tensor AtenXlaType::mul(const at::Tensor& self,
 }
 
 at::Tensor& AtenXlaType::mul_(at::Tensor& self, const at::Tensor& other) const {
+  if (other.dim() == 0) {
+    return mul_(self, other.item());
+  }
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::mul_(self_tensor,
                   bridge::GetOrCreateXlaTensor(other, self_tensor.GetDevice()));


### PR DESCRIPTION
For autograd variables, the mul_ with scalar is normalized to a mul_
with two tensors which ends up triggering an expensive
torch_xla::CopyTensors and creates XLA data for a tensor with one
element. This hurts the SGD optimizer significantly.