### PR TITLE
Negative dim for aten::cat & cat empty tensors.

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1369,6 +1369,22 @@ class TestAtenXlaTensor(XlaTestCase):
     x_slice = x[:, :, -1]
     self.assertEqual(t_slice.data, x_slice.data.cpu())
 
+  def test_negative_cat(self):
+    t = _gen_tensor(2, 5, 3)
+    x = t.to(xm.xla_device())
+    t_cat = torch.cat([t, t], -1)
+    x_cat = torch.cat([x, x], -1)
+    self.assertEqual(t_cat.data, x_cat.data.cpu())
+
+  def test_cat_empty_tensor(self):
+    t = _gen_tensor(2, 5, 3)
+    empty_tensor = torch.Tensor()
+    x = t.to(xm.xla_device())
+    empty_tensor_xla = empty_tensor.to(xm.xla_device())
+    t_cat = torch.cat([t, empty_tensor], 0)
+    x_cat = torch.cat([x, empty_tensor_xla], 0)
+    self.assertEqual(t_cat.data, x_cat.data.cpu())
+
   def test_masked_fill_with_tensor(self):
     input = _gen_tensor(2, 5, 4, 3)
     mask = torch.randint(0, 2, input.size(), dtype=torch.uint8)

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1114,9 +1114,18 @@ XLATensor XLATensor::cat(tensorflow::gtl::ArraySlice<const XLATensor> tensors,
                          xla::int64 dim) {
   XLA_CHECK_GT(tensors.size(), 0);
   std::vector<ir::Value> values;
+
+  bool set_dim = false;
   for (auto& tensor : tensors) {
-    values.push_back(tensor.GetIrValue());
+    if (xla::ShapeUtil::ElementsIn(tensor.shape()) > 0) {
+      if (!set_dim) {
+        dim = GetCanonicalDimension(tensor, dim);
+        set_dim = true;
+      }
+      values.push_back(tensor.GetIrValue());
+    }
   }
+
   return tensors[0].CreateFrom(ir::MakeNode<ir::ops::Cat>(values, dim));
 }
 

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1114,18 +1114,12 @@ XLATensor XLATensor::cat(tensorflow::gtl::ArraySlice<const XLATensor> tensors,
                          xla::int64 dim) {
   XLA_CHECK_GT(tensors.size(), 0);
   std::vector<ir::Value> values;
-
-  bool set_dim = false;
   for (auto& tensor : tensors) {
     if (xla::ShapeUtil::ElementsIn(tensor.shape()) > 0) {
-      if (!set_dim) {
-        dim = GetCanonicalDimension(tensor, dim);
-        set_dim = true;
-      }
+      dim = GetCanonicalDimension(tensor, dim);
       values.push_back(tensor.GetIrValue());
     }
   }
-
   return tensors[0].CreateFrom(ir::MakeNode<ir::ops::Cat>(values, dim));
 }
 


### PR DESCRIPTION
`aten::cat` supports negative dim and cat empty tensors. 
This PR fixes the following minimal repro script:
```
import torch
import torch_xla
import torch_xla_py.utils as xu
import torch_xla_py.xla_model as xm

a = torch.Tensor() # EMPTY tensor!

b = torch.rand(2, 2)
xla_device = xm.xla_device()

a = a.to(xla_device)
b = b.to(xla_device)
e = torch.cat([a, b, a], -1) # Negative index!

print(e)
```
I'm not fully familiar with all available APIs in the codebase yet, feel free to let me know if there is a better way to fix it. 
Thanks!