### PR TITLE
Use XLA build versioning only when needed, to avoid spamming the Cond…

### DIFF
--- a/kokoro_build.sh
+++ b/kokoro_build.sh
@@ -9,7 +9,7 @@ set -x
 git submodule update --init --recursive
 
 # Build torch_xla wheel in conda environment
-export NO_CUDA=1
+export NO_CUDA=1 VERSIONED_XLA_BUILD=1
 python setup.py bdist_wheel
 
 # Artifacts for pytorch-tpu wheel build collected (as nightly and with date)

--- a/setup.py
+++ b/setup.py
@@ -182,13 +182,14 @@ if DEBUG:
 
 extra_link_args += ['-lxla_computation_client']
 
-version = '0.1'
-try:
-  sha = subprocess.check_output(['git', 'rev-parse', 'HEAD'],
-                                cwd=base_dir).decode('ascii').strip()
-  version += '+' + sha[:7]
-except Exception:
-  pass
+version = os.getenv('TORCH_XLA_VERSION', '0.1')
+if _check_env_flag('VERSIONED_XLA_BUILD', default='0'):
+  try:
+    sha = subprocess.check_output(['git', 'rev-parse', 'HEAD'],
+                                  cwd=base_dir).decode('ascii').strip()
+    version += '+' + sha[:7]
+  except Exception:
+    pass
 
 setup(
     name='torch_xla',


### PR DESCRIPTION
…a env folder.