### PR TITLE
Fix XLATensorImpl size w/r/t in-place shape changing operations

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -2780,6 +2780,10 @@ TEST_F(AtenXlaTensorTest, TestSqueezeAllInPlace) {
     at::Tensor xla_output = xla_input.squeeze_();
     AllClose(output, xla_output);
     AllClose(input, xla_input);
+    ASSERT_EQ(input.dim(), xla_input.dim());
+    for (int64_t dim_idx = 0; dim_idx < input.dim(); ++dim_idx) {
+      ASSERT_EQ(input.size(dim_idx), xla_input.size(dim_idx));
+    }
   });
 }
 
@@ -2806,6 +2810,10 @@ TEST_F(AtenXlaTensorTest, TestSqueezeOneInPlace) {
       at::Tensor xla_output = xla_input.squeeze_(dim);
       AllClose(output, xla_output);
       AllClose(input, xla_input);
+      ASSERT_EQ(input.dim(), xla_input.dim());
+      for (int64_t dim_idx = 0; dim_idx < input.dim(); ++dim_idx) {
+        ASSERT_EQ(input.size(dim_idx), xla_input.size(dim_idx));
+      }
     });
   }
 }
@@ -2833,6 +2841,10 @@ TEST_F(AtenXlaTensorTest, TestUnsqueezeInPlace) {
       at::Tensor xla_output = xla_input.unsqueeze_(dim);
       AllClose(output, xla_output);
       AllClose(input, xla_input);
+      ASSERT_EQ(input.dim(), xla_input.dim());
+      for (int64_t dim_idx = 0; dim_idx < input.dim(); ++dim_idx) {
+        ASSERT_EQ(input.size(dim_idx), xla_input.size(dim_idx));
+      }
     });
   }
 }

--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -75,10 +75,30 @@ c10::intrusive_ptr<c10::TensorImpl> XLATensorImpl::shallow_copy_and_detach()
   return impl;
 }
 
+at::IntArrayRef XLATensorImpl::sizes() const {
+  const_cast<XLATensorImpl*>(this)->SetupSizeProperties();
+  return c10::TensorImpl::sizes();
+}
+
+int64_t XLATensorImpl::dim() const {
+  const_cast<XLATensorImpl*>(this)->SetupSizeProperties();
+  return c10::TensorImpl::dim();
+}
+
+int64_t XLATensorImpl::numel() const {
+  const_cast<XLATensorImpl*>(this)->SetupSizeProperties();
+  return c10::TensorImpl::numel();
+}
+
 bool XLATensorImpl::is_contiguous() const {
   // Only check that the storage is already contiguous.
   XLA_CHECK(is_contiguous_) << "Non-contiguous storage for XLA tensor";
   return true;
+}
+
+int64_t XLATensorImpl::size(int64_t d) const {
+  const_cast<XLATensorImpl*>(this)->SetupSizeProperties();
+  return c10::TensorImpl::size(d);
 }
 
 void XLATensorImpl::SetupSizeProperties() {

--- a/torch_xla/csrc/tensor_impl.h
+++ b/torch_xla/csrc/tensor_impl.h
@@ -20,7 +20,15 @@ class XLATensorImpl : public c10::TensorImpl {
 
   c10::intrusive_ptr<c10::TensorImpl> shallow_copy_and_detach() const override;
 
+  at::IntArrayRef sizes() const override;
+
+  int64_t dim() const override;
+
+  int64_t numel() const override;
+
   bool is_contiguous() const override;
+
+  int64_t size(int64_t d) const override;
 
  private:
   void SetupSizeProperties();


### PR DESCRIPTION
Not so sure about the `const_cast` and calling `SetupSizeProperties` all the time, but alternatives looked worse.