### PR TITLE
fix aten::mean dim

### DIFF
--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1372,6 +1372,9 @@ XLATensor XLATensor::mean(const XLATensor& input,
                           std::vector<xla::int64> dimensions,
                           bool keep_reduced_dimensions,
                           c10::optional<at::ScalarType> dtype) {
+  for (auto& d : dimensions) {
+    d = GetCanonicalDimension(input, d);
+  }
   return input.CreateFrom(
       ir::MakeNode<ir::ops::Mean>(input.GetIrValue(), std::move(dimensions),
                                   keep_reduced_dimensions, dtype));


### PR DESCRIPTION
similar to previous issues. This came up when I ran BERT models.

I plan to scan all current implemented APIs and fix all negative dim issues I can find in one followup PR. 

Please also help make sure this is consistent with https://pytorch.org/docs/stable/tensors.html when adding new ops ;) Thanks! 