### PR TITLE
Add linear to ATen XLA tensor

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -1642,6 +1642,25 @@ TEST_F(AtenXlaTensorTest, TestChainMatMul) {
   });
 }
 
+TEST_F(AtenXlaTensorTest, TestLinear) {
+  at::Tensor input = at::rand({2, 4}, at::TensorOptions(at::kFloat));
+  at::Tensor weight = at::rand({3, 4}, at::TensorOptions(at::kFloat));
+  at::Tensor bias = at::rand({3});
+  at::Tensor result = at::linear(input, weight);
+  at::Tensor result_with_bias = at::linear(input, weight, bias);
+  ForEachDevice([&](const Device& device) {
+    at::Tensor xla_input = bridge::CreateXlaTensor(input, device);
+    at::Tensor xla_weight = bridge::CreateXlaTensor(weight, device);
+    at::Tensor xla_bias = bridge::CreateXlaTensor(bias, device);
+    at::Tensor xla_result = at::linear(xla_input, xla_weight);
+    at::Tensor xla_result_with_bias =
+        at::linear(xla_input, xla_weight, xla_bias);
+    AllClose(result, xla_result, /*rtol=*/1e-3, /*atol=*/1e-4);
+    AllClose(result_with_bias, xla_result_with_bias, /*rtol=*/1e-3,
+             /*atol=*/1e-4);
+  });
+}
+
 TEST_F(AtenXlaTensorTest, TestEinsumOuter) {
   at::Tensor a = at::rand({5}, at::TensorOptions(at::kFloat));
   at::Tensor b = at::rand({5}, at::TensorOptions(at::kFloat));

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1575,6 +1575,12 @@ at::Tensor AtenXlaType::chain_matmul(at::TensorList matrices) const {
   return at::native::chain_matmul(matrices);
 }
 
+at::Tensor AtenXlaType::linear(const at::Tensor& input,
+                               const at::Tensor& weight,
+                               const at::Tensor& bias) const {
+  return at::native::linear(input, weight, bias);
+}
+
 std::vector<at::Tensor> AtenXlaType::broadcast_tensors(
     at::TensorList tensors) const {
   return bridge::AtenFromXlaTensors(

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -478,6 +478,9 @@ class AtenXlaType : public AtenXlaTypeBase {
 
   at::Tensor chain_matmul(at::TensorList matrices) const override;
 
+  at::Tensor linear(const at::Tensor& input, const at::Tensor& weight,
+                    const at::Tensor& bias) const override;
+
   std::vector<at::Tensor> broadcast_tensors(
       at::TensorList tensors) const override;
 


### PR DESCRIPTION
Just route it to `at::native::linear`.