### PR TITLE
Add tensordot to ATen XLA tensor

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -1614,6 +1614,20 @@ TEST_F(AtenXlaTensorTest, TestDot) {
   });
 }
 
+TEST_F(AtenXlaTensorTest, TestTensorDot) {
+  at::Tensor a = at::rand({6, 4, 8}, at::TensorOptions(at::kFloat));
+  at::Tensor b = at::rand({4, 7, 8}, at::TensorOptions(at::kFloat));
+  std::vector<int64_t> dims_a = {1, 2};
+  std::vector<int64_t> dims_b = {0, 2};
+  at::Tensor c = at::tensordot(a, b, dims_a, dims_b);
+  ForEachDevice([&](const Device& device) {
+    at::Tensor xla_a = bridge::CreateXlaTensor(a, device);
+    at::Tensor xla_b = bridge::CreateXlaTensor(b, device);
+    at::Tensor xla_c = at::tensordot(xla_a, xla_b, dims_a, dims_b);
+    AllClose(c, xla_c);
+  });
+}
+
 TEST_F(AtenXlaTensorTest, TestBatchMatMul) {
   at::Tensor a = at::rand({3, 6, 4}, at::TensorOptions(at::kFloat));
   at::Tensor b = at::rand({3, 4, 5}, at::TensorOptions(at::kFloat));

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1598,6 +1598,13 @@ at::Tensor AtenXlaType::linear(const at::Tensor& input,
   return at::native::linear(input, weight, bias);
 }
 
+at::Tensor AtenXlaType::tensordot(const at::Tensor& self,
+                                  const at::Tensor& other,
+                                  at::IntArrayRef dims_self,
+                                  at::IntArrayRef dims_other) const {
+  return at::native::tensordot(self, other, dims_self, dims_other);
+}
+
 std::vector<at::Tensor> AtenXlaType::broadcast_tensors(
     at::TensorList tensors) const {
   return bridge::AtenFromXlaTensors(

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -487,6 +487,10 @@ class AtenXlaType : public AtenXlaTypeBase {
   at::Tensor linear(const at::Tensor& input, const at::Tensor& weight,
                     const at::Tensor& bias) const override;
 
+  at::Tensor tensordot(const at::Tensor& self, const at::Tensor& other,
+                       at::IntArrayRef dims_self,
+                       at::IntArrayRef dims_other) const override;
+
   std::vector<at::Tensor> broadcast_tensors(
       at::TensorList tensors) const override;
 


### PR DESCRIPTION
It's sufficient to just route it to at::native::tensordot.