### PR TITLE
Add nuclear_norm to ATen XLA tensors

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -1047,6 +1047,18 @@ TEST_F(AtenXlaTensorTest, TestFrobeniusNormInDims) {
   }
 }
 
+TEST_F(AtenXlaTensorTest, TestNuclearNorm) {
+  at::Tensor a = at::rand({4, 3}, at::TensorOptions(at::kFloat));
+  at::Tensor b = at::nuclear_norm(a);
+  for (bool keepdim : {false, true}) {
+    ForEachDevice([&](const Device& device) {
+      at::Tensor xla_a = bridge::CreateXlaTensor(a, device);
+      at::Tensor xla_b = at::nuclear_norm(xla_a);
+      AllClose(b, xla_b);
+    });
+  }
+}
+
 TEST_F(AtenXlaTensorTest, TestProd) {
   at::Tensor a = at::rand({4, 3, 4}, at::TensorOptions(at::kFloat));
   at::Tensor b = at::prod(a);

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1753,6 +1753,11 @@ at::Tensor AtenXlaType::frobenius_norm(const at::Tensor& self,
   return at::native::frobenius_norm(self, dim, keepdim);
 }
 
+at::Tensor AtenXlaType::nuclear_norm(const at::Tensor& self,
+                                     bool keepdim) const {
+  return at::native::nuclear_norm(self, keepdim);
+}
+
 at::Tensor AtenXlaType::log_softmax(const at::Tensor& self, int64_t dim) const {
   return bridge::AtenFromXlaTensor(
       XLATensor::log_softmax(bridge::GetXlaTensor(self), dim));

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -550,6 +550,8 @@ class AtenXlaType : public AtenXlaTypeBase {
   at::Tensor frobenius_norm(const at::Tensor& self, at::IntArrayRef dim,
                             bool keepdim) const override;
 
+  at::Tensor nuclear_norm(const at::Tensor& self, bool keepdim) const override;
+
   at::Tensor log_softmax(const at::Tensor& self, int64_t dim) const override;
   at::Tensor _log_softmax(const at::Tensor& self, int64_t dim,
                           bool half_to_float) const override;


### PR DESCRIPTION
It's sufficient to just route it to at::native::nuclear_norm.