### PR TITLE
Add bilinear to ATen XLA tensor

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -1833,6 +1833,30 @@ TEST_F(AtenXlaTensorTest, TestEinsumPyTorchLowerRepeatedAxis) {
   });
 }
 
+TEST_F(AtenXlaTensorTest, TestBilinear) {
+  int batch_size = 16;
+  int in1_features = 4;
+  int in2_features = 6;
+  int out_features = 8;
+  at::Tensor input1 =
+      at::rand({batch_size, in1_features}, at::TensorOptions(at::kFloat));
+  at::Tensor input2 =
+      at::rand({batch_size, in2_features}, at::TensorOptions(at::kFloat));
+  at::Tensor weight = at::rand({out_features, in1_features, in2_features},
+                               at::TensorOptions(at::kFloat));
+  at::Tensor bias = at::rand({out_features}, at::TensorOptions(at::kFloat));
+  ForEachDevice([&](const Device& device) {
+    at::Tensor xla_input1 = bridge::CreateXlaTensor(input1, device);
+    at::Tensor xla_input2 = bridge::CreateXlaTensor(input2, device);
+    at::Tensor xla_weight = bridge::CreateXlaTensor(weight, device);
+    at::Tensor xla_bias = bridge::CreateXlaTensor(bias, device);
+    at::Tensor result = at::bilinear(input1, input2, weight, bias);
+    at::Tensor xla_result =
+        at::bilinear(xla_input1, xla_input2, xla_weight, xla_bias);
+    AllClose(result, xla_result);
+  });
+}
+
 TEST_F(AtenXlaTensorTest, TestAddCMul) {
   at::Tensor a = at::rand({2, 2}, at::TensorOptions(at::kFloat));
   at::Tensor b = at::rand({2, 2}, at::TensorOptions(at::kFloat));

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -297,6 +297,14 @@ at::Tensor AtenXlaType::_softmax_backward_data(const at::Tensor& grad_output,
       bridge::GetXlaTensor(grad_output), bridge::GetXlaTensor(output), dim));
 }
 
+at::Tensor AtenXlaType::_trilinear(
+    const at::Tensor& i1, const at::Tensor& i2, const at::Tensor& i3,
+    at::IntArrayRef expand1, at::IntArrayRef expand2, at::IntArrayRef expand3,
+    at::IntArrayRef sumdim, int64_t unroll_dim) const {
+  return at::native::_trilinear(i1, i2, i3, expand1, expand2, expand3, sumdim,
+                                unroll_dim);
+}
+
 at::Tensor AtenXlaType::abs(const at::Tensor& self) const {
   return bridge::AtenFromXlaTensor(XLATensor::abs(bridge::GetXlaTensor(self)));
 }
@@ -577,6 +585,13 @@ at::Tensor AtenXlaType::batch_norm(
       bridge::GetXlaTensor(input), bridge::GetXlaTensor(weight),
       bridge::GetXlaTensor(bias), bridge::GetXlaTensor(running_mean),
       bridge::GetXlaTensor(running_var), momentum, eps));
+}
+
+at::Tensor AtenXlaType::bilinear(const at::Tensor& input1,
+                                 const at::Tensor& input2,
+                                 const at::Tensor& weight,
+                                 const at::Tensor& bias) const {
+  return at::native::bilinear(input1, input2, weight, bias);
 }
 
 at::Tensor AtenXlaType::bmm(const at::Tensor& self,

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -109,6 +109,12 @@ class AtenXlaType : public AtenXlaTypeBase {
                                     const at::Tensor& output, int64_t dim,
                                     const at::Tensor& self) const override;
 
+  at::Tensor _trilinear(const at::Tensor& i1, const at::Tensor& i2,
+                        const at::Tensor& i3, at::IntArrayRef expand1,
+                        at::IntArrayRef expand2, at::IntArrayRef expand3,
+                        at::IntArrayRef sumdim,
+                        int64_t unroll_dim) const override;
+
   at::Tensor abs(const at::Tensor& self) const override;
 
   at::Tensor& abs_(at::Tensor& self) const override;
@@ -217,6 +223,10 @@ class AtenXlaType : public AtenXlaTypeBase {
                         const at::Tensor& running_var, bool training,
                         double momentum, double eps,
                         bool cudnn_enabled) const override;
+
+  at::Tensor bilinear(const at::Tensor& input1, const at::Tensor& input2,
+                      const at::Tensor& weight,
+                      const at::Tensor& bias) const override;
 
   at::Tensor bmm(const at::Tensor& self, const at::Tensor& mat2) const override;
 


### PR DESCRIPTION
It's sufficient to just route it to at::native::bilinear. Calls
_trilinear in the implementation, which can also be routed to
at::native::_trilinear.