### PR TITLE
Add _unsafe_view to ATen XLA tensor

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -3181,6 +3181,16 @@ TEST_F(AtenXlaTensorTest, TestViewSqueezeAddInPlace) {
   });
 }
 
+TEST_F(AtenXlaTensorTest, TestUnsafeView) {
+  at::Tensor input = at::rand({32, 20, 4, 4}, at::TensorOptions(at::kFloat));
+  at::Tensor output = at::_unsafe_view(input, {-1, 320});
+  ForEachDevice([&](const Device& device) {
+    at::Tensor xla_input = bridge::CreateXlaTensor(input, device);
+    at::Tensor xla_output = at::_unsafe_view(xla_input, {-1, 320});
+    AllClose(output, xla_output);
+  });
+}
+
 TEST_F(AtenXlaTensorTest, TestNarrow) {
   at::Tensor a = at::rand({8, 10, 4, 4}, at::TensorOptions(at::kFloat));
   for (xla::int64 dim : {1, -3}) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -295,6 +295,11 @@ at::Tensor AtenXlaType::_trilinear(
                                 unroll_dim);
 }
 
+at::Tensor AtenXlaType::_unsafe_view(const at::Tensor& self,
+                                     at::IntArrayRef size) const {
+  return view(self, size);
+}
+
 at::Tensor AtenXlaType::abs(const at::Tensor& self) const {
   return bridge::AtenFromXlaTensor(XLATensor::abs(bridge::GetXlaTensor(self)));
 }

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -109,6 +109,9 @@ class AtenXlaType : public AtenXlaTypeBase {
                         at::IntArrayRef sumdim,
                         int64_t unroll_dim) const override;
 
+  at::Tensor _unsafe_view(const at::Tensor& self,
+                          at::IntArrayRef size) const override;
+
   at::Tensor abs(const at::Tensor& self) const override;
 
   at::Tensor& abs_(at::Tensor& self) const override;


### PR DESCRIPTION
_unsafe_view is exactly the same as view except that the returned tensor
is not treated like a view for autograd. It's supposed to be used when
the viewed tensor is immediately discarded.