### PR TITLE
Add most of the remaining loss, norm and distance functions

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -1263,6 +1263,26 @@ TEST_F(AtenXlaTensorTest, TestCosineSimilarity) {
   }
 }
 
+TEST_F(AtenXlaTensorTest, TestCosineEmbeddingLoss) {
+  at::Tensor input1 = at::rand({4, 3}, at::TensorOptions(at::kFloat));
+  at::Tensor input2 = at::rand({4, 3}, at::TensorOptions(at::kFloat));
+  at::Tensor target = at::rand({4}, at::TensorOptions(at::kFloat));
+  for (Reduction::Reduction reduction : {Reduction::Mean, Reduction::Sum}) {
+    for (double margin : {0., 0.2}) {
+      ForEachDevice([&](const Device& device) {
+        at::Tensor output = at::cosine_embedding_loss(input1, input2, target,
+                                                      margin, reduction);
+        at::Tensor xla_input1 = bridge::CreateXlaTensor(input1, device);
+        at::Tensor xla_input2 = bridge::CreateXlaTensor(input2, device);
+        at::Tensor xla_target = bridge::CreateXlaTensor(target, device);
+        at::Tensor xla_output = at::cosine_embedding_loss(
+            xla_input1, xla_input2, xla_target, margin, reduction);
+        AllClose(output, xla_output);
+      });
+    }
+  }
+}
+
 TEST_F(AtenXlaTensorTest, TestProd) {
   at::Tensor a = at::rand({4, 3, 4}, at::TensorOptions(at::kFloat));
   at::Tensor b = at::prod(a);

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -1247,6 +1247,22 @@ TEST_F(AtenXlaTensorTest, TestPairwiseDistance) {
   }
 }
 
+TEST_F(AtenXlaTensorTest, TestCosineSimilarity) {
+  at::Tensor x1 = at::rand({4, 3}, at::TensorOptions(at::kFloat));
+  at::Tensor x2 = at::rand({4, 3}, at::TensorOptions(at::kFloat));
+  double eps = 1e-8;
+  int rank = x1.dim();
+  for (int dim = -rank; dim < rank; ++dim) {
+    ForEachDevice([&](const Device& device) {
+      at::Tensor output = at::cosine_similarity(x1, x2, dim, eps);
+      at::Tensor xla_x1 = bridge::CreateXlaTensor(x1, device);
+      at::Tensor xla_x2 = bridge::CreateXlaTensor(x2, device);
+      at::Tensor xla_output = at::cosine_similarity(xla_x1, xla_x2, dim, eps);
+      AllClose(output, xla_output);
+    });
+  }
+}
+
 TEST_F(AtenXlaTensorTest, TestProd) {
   at::Tensor a = at::rand({4, 3, 4}, at::TensorOptions(at::kFloat));
   at::Tensor b = at::prod(a);

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -1380,6 +1380,20 @@ TEST_F(AtenXlaTensorTest, TestBCEWithLogits) {
   }
 }
 
+TEST_F(AtenXlaTensorTest, TestKlDiv) {
+  at::Tensor input = at::rand({4, 3}, at::TensorOptions(at::kFloat));
+  at::Tensor target = at::rand({4, 3}, at::TensorOptions(at::kFloat));
+  for (Reduction::Reduction reduction : {Reduction::Mean, Reduction::Sum}) {
+    ForEachDevice([&](const Device& device) {
+      at::Tensor output = at::kl_div(input, target, reduction);
+      at::Tensor xla_input = bridge::CreateXlaTensor(input, device);
+      at::Tensor xla_target = bridge::CreateXlaTensor(target, device);
+      at::Tensor xla_output = at::kl_div(xla_input, xla_target, reduction);
+      AllClose(output, xla_output);
+    });
+  }
+}
+
 TEST_F(AtenXlaTensorTest, TestProd) {
   at::Tensor a = at::rand({4, 3, 4}, at::TensorOptions(at::kFloat));
   at::Tensor b = at::prod(a);

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -1229,6 +1229,24 @@ TEST_F(AtenXlaTensorTest, TestNuclearNorm) {
   }
 }
 
+TEST_F(AtenXlaTensorTest, TestPairwiseDistance) {
+  at::Tensor x1 = at::rand({4, 3}, at::TensorOptions(at::kFloat));
+  at::Tensor x2 = at::rand({4, 3}, at::TensorOptions(at::kFloat));
+  double eps = 1e-6;
+  for (bool keepdim : {false, true}) {
+    for (double p : {1, 2, 3, 4}) {
+      ForEachDevice([&](const Device& device) {
+        at::Tensor output = at::pairwise_distance(x1, x2, p, eps, keepdim);
+        at::Tensor xla_x1 = bridge::CreateXlaTensor(x1, device);
+        at::Tensor xla_x2 = bridge::CreateXlaTensor(x2, device);
+        at::Tensor xla_output =
+            at::pairwise_distance(xla_x1, xla_x2, p, eps, keepdim);
+        AllClose(output, xla_output);
+      });
+    }
+  }
+}
+
 TEST_F(AtenXlaTensorTest, TestProd) {
   at::Tensor a = at::rand({4, 3, 4}, at::TensorOptions(at::kFloat));
   at::Tensor b = at::prod(a);

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -1283,6 +1283,24 @@ TEST_F(AtenXlaTensorTest, TestCosineEmbeddingLoss) {
   }
 }
 
+TEST_F(AtenXlaTensorTest, TestHingeEmbeddingLoss) {
+  at::Tensor input = at::rand({4, 3}, at::TensorOptions(at::kFloat));
+  at::Tensor target = at::rand({4, 3}, at::TensorOptions(at::kFloat));
+  for (Reduction::Reduction reduction : {Reduction::Mean, Reduction::Sum}) {
+    for (double margin : {0., 0.2}) {
+      ForEachDevice([&](const Device& device) {
+        at::Tensor output =
+            at::hinge_embedding_loss(input, target, margin, reduction);
+        at::Tensor xla_input = bridge::CreateXlaTensor(input, device);
+        at::Tensor xla_target = bridge::CreateXlaTensor(target, device);
+        at::Tensor xla_output =
+            at::hinge_embedding_loss(xla_input, xla_target, margin, reduction);
+        AllClose(output, xla_output);
+      });
+    }
+  }
+}
+
 TEST_F(AtenXlaTensorTest, TestProd) {
   at::Tensor a = at::rand({4, 3, 4}, at::TensorOptions(at::kFloat));
   at::Tensor b = at::prod(a);

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -1167,6 +1167,27 @@ TEST_F(AtenXlaTensorTest, TestGroupNorm) {
   }
 }
 
+TEST_F(AtenXlaTensorTest, TestLayerNorm) {
+  int num_channels = 5;
+  std::vector<int64_t> normalized_shape = {10, 10};
+  at::Tensor input =
+      at::rand({20, num_channels, 10, 10}, at::TensorOptions(at::kFloat));
+  at::Tensor weight = at::rand(normalized_shape, at::TensorOptions(at::kFloat));
+  at::Tensor bias = at::rand(normalized_shape, at::TensorOptions(at::kFloat));
+  double eps = 1e-05;
+  at::Tensor output = at::layer_norm(input, normalized_shape, weight, bias, eps,
+                                     /*cudnn_enabled=*/false);
+  ForEachDevice([&](const Device& device) {
+    at::Tensor xla_input = bridge::CreateXlaTensor(input, device);
+    at::Tensor xla_weight = bridge::CreateXlaTensor(weight, device);
+    at::Tensor xla_bias = bridge::CreateXlaTensor(bias, device);
+    at::Tensor xla_output =
+        at::layer_norm(xla_input, normalized_shape, xla_weight, xla_bias, eps,
+                       /*cudnn_enabled=*/false);
+    AllClose(output, xla_output, /*rtol=*/1e-3, /*atol=*/1e-5);
+  });
+}
+
 TEST_F(AtenXlaTensorTest, TestNuclearNorm) {
   at::Tensor a = at::rand({4, 3}, at::TensorOptions(at::kFloat));
   at::Tensor b = at::nuclear_norm(a);

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -6021,5 +6021,18 @@ TEST_F(AtenXlaTensorTest, TestBCEWithLogitsBackward) {
   }
 }
 
+TEST_F(AtenXlaTensorTest, TestKlDivBackward) {
+  at::Tensor input = at::rand({4, 3}, at::TensorOptions(at::kFloat));
+  at::Tensor target = at::rand({4, 3}, at::TensorOptions(at::kFloat));
+  for (Reduction::Reduction reduction : {Reduction::Mean, Reduction::Sum}) {
+    auto testfn = [&](const std::vector<at::Tensor>& inputs) -> at::Tensor {
+      return at::kl_div(/*self=*/inputs[0], /*target=*/inputs[1], reduction);
+    };
+    ForEachDevice([&](const Device& device) {
+      TestBackward({input, target}, device, testfn);
+    });
+  }
+}
+
 }  // namespace cpp_test
 }  // namespace torch_xla

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -1330,6 +1330,26 @@ TEST_F(AtenXlaTensorTest, TestTripletMarginLoss) {
   }
 }
 
+TEST_F(AtenXlaTensorTest, TestMarginRankingLoss) {
+  at::Tensor input1 = at::rand({4, 3}, at::TensorOptions(at::kFloat));
+  at::Tensor input2 = at::rand({4, 3}, at::TensorOptions(at::kFloat));
+  at::Tensor target = at::rand({4, 3}, at::TensorOptions(at::kFloat));
+  for (Reduction::Reduction reduction : {Reduction::Mean, Reduction::Sum}) {
+    for (double margin : {0., 0.2}) {
+      ForEachDevice([&](const Device& device) {
+        at::Tensor output =
+            at::margin_ranking_loss(input1, input2, target, margin, reduction);
+        at::Tensor xla_input1 = bridge::CreateXlaTensor(input1, device);
+        at::Tensor xla_input2 = bridge::CreateXlaTensor(input2, device);
+        at::Tensor xla_target = bridge::CreateXlaTensor(target, device);
+        at::Tensor xla_output = at::margin_ranking_loss(
+            xla_input1, xla_input2, xla_target, margin, reduction);
+        AllClose(output, xla_output);
+      });
+    }
+  }
+}
+
 TEST_F(AtenXlaTensorTest, TestProd) {
   at::Tensor a = at::rand({4, 3, 4}, at::TensorOptions(at::kFloat));
   at::Tensor b = at::prod(a);

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -849,6 +849,12 @@ at::Tensor& AtenXlaType::cosh_(at::Tensor& self) const {
   return self;
 }
 
+at::Tensor AtenXlaType::cosine_similarity(const at::Tensor& x1,
+                                          const at::Tensor& x2, int64_t dim,
+                                          double eps) const {
+  return at::native::cosine_similarity(x1, x2, dim, eps);
+}
+
 at::Tensor AtenXlaType::cross(const at::Tensor& self, const at::Tensor& other,
                               c10::optional<int64_t> dim) const {
   return bridge::AtenFromXlaTensor(

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2779,6 +2779,16 @@ at::Tensor& AtenXlaType::tril_(at::Tensor& self, int64_t diagonal) const {
   return self;
 }
 
+at::Tensor AtenXlaType::triplet_margin_loss(const at::Tensor& anchor,
+                                            const at::Tensor& positive,
+                                            const at::Tensor& negative,
+                                            double margin, double p, double eps,
+                                            bool swap,
+                                            int64_t reduction) const {
+  return at::native::triplet_margin_loss(anchor, positive, negative, margin, p,
+                                         eps, swap, reduction);
+}
+
 at::Tensor AtenXlaType::triu(const at::Tensor& self, int64_t diagonal) const {
   return bridge::AtenFromXlaTensor(
       XLATensor::triu(bridge::GetXlaTensor(self), diagonal));

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1495,6 +1495,11 @@ at::Tensor AtenXlaType::instance_norm(const at::Tensor& input,
                                    cudnn_enabled);
 }
 
+at::Tensor AtenXlaType::kl_div(const at::Tensor& self, const at::Tensor& target,
+                               int64_t reduction) const {
+  return at::native::kl_div(self, target, reduction);
+}
+
 std::tuple<at::Tensor, at::Tensor> AtenXlaType::kthvalue(const at::Tensor& self,
                                                          int64_t k, int64_t dim,
                                                          bool keepdim) const {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2055,6 +2055,12 @@ at::Tensor AtenXlaType::ones_like(const at::Tensor& self,
   return full_like(self, 1, options);
 }
 
+at::Tensor AtenXlaType::pairwise_distance(const at::Tensor& x1,
+                                          const at::Tensor& x2, double p,
+                                          double eps, bool keepdim) const {
+  return at::native::pairwise_distance(x1, x2, p, eps, keepdim);
+}
+
 at::Tensor AtenXlaType::permute(const at::Tensor& self,
                                 at::IntArrayRef dims) const {
   return bridge::AtenFromXlaTensor(XLATensor::permute(

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1500,6 +1500,15 @@ at::Tensor AtenXlaType::kl_div(const at::Tensor& self, const at::Tensor& target,
   return at::native::kl_div(self, target, reduction);
 }
 
+at::Tensor AtenXlaType::kl_div_backward(const at::Tensor& grad_output,
+                                        const at::Tensor& self,
+                                        const at::Tensor& target,
+                                        int64_t reduction) const {
+  return bridge::AtenFromXlaTensor(XLATensor::kl_div_backward(
+      bridge::GetXlaTensor(grad_output), bridge::GetXlaTensor(self),
+      bridge::GetXlaTensor(target), reduction));
+}
+
 std::tuple<at::Tensor, at::Tensor> AtenXlaType::kthvalue(const at::Tensor& self,
                                                          int64_t k, int64_t dim,
                                                          bool keepdim) const {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -657,6 +657,21 @@ at::Tensor AtenXlaType::bilinear(const at::Tensor& input1,
   return at::native::bilinear(input1, input2, weight, bias);
 }
 
+at::Tensor AtenXlaType::binary_cross_entropy_with_logits(
+    const at::Tensor& self, const at::Tensor& target, const at::Tensor& weight,
+    const at::Tensor& pos_weight, int64_t reduction) const {
+  return at::native::binary_cross_entropy_with_logits(self, target, weight,
+                                                      pos_weight, reduction);
+}
+
+at::Tensor AtenXlaType::binary_cross_entropy_with_logits_backward(
+    const at::Tensor& grad_output, const at::Tensor& self,
+    const at::Tensor& target, const at::Tensor& weight,
+    const at::Tensor& pos_weight, int64_t reduction) const {
+  return at::native::binary_cross_entropy_with_logits_backward(
+      grad_output, self, target, weight, pos_weight, reduction);
+}
+
 at::Tensor AtenXlaType::blackman_window(
     int64_t window_length, const at::TensorOptions& options) const {
   return at::native::blackman_window(window_length, options);

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1348,6 +1348,13 @@ at::Tensor AtenXlaType::hardtanh_backward(const at::Tensor& grad_output,
       max_val));
 }
 
+at::Tensor AtenXlaType::hinge_embedding_loss(const at::Tensor& self,
+                                             const at::Tensor& target,
+                                             double margin,
+                                             int64_t reduction) const {
+  return at::native::hinge_embedding_loss(self, target, margin, reduction);
+}
+
 at::Tensor AtenXlaType::index(const at::Tensor& self,
                               at::TensorList indices) const {
   CanonicalIndexInfo canonical_index_info =

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1640,6 +1640,15 @@ at::Tensor& AtenXlaType::lt_(at::Tensor& self, const at::Tensor& other) const {
   return self;
 }
 
+at::Tensor AtenXlaType::margin_ranking_loss(const at::Tensor& input1,
+                                            const at::Tensor& input2,
+                                            const at::Tensor& target,
+                                            double margin,
+                                            int64_t reduction) const {
+  return at::native::margin_ranking_loss(input1, input2, target, margin,
+                                         reduction);
+}
+
 at::Tensor AtenXlaType::masked_fill(const at::Tensor& self,
                                     const at::Tensor& mask,
                                     at::Scalar value) const {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -849,6 +849,15 @@ at::Tensor& AtenXlaType::cosh_(at::Tensor& self) const {
   return self;
 }
 
+at::Tensor AtenXlaType::cosine_embedding_loss(const at::Tensor& input1,
+                                              const at::Tensor& input2,
+                                              const at::Tensor& target,
+                                              double margin,
+                                              int64_t reduction) const {
+  return at::native::cosine_embedding_loss(input1, input2, target, margin,
+                                           reduction);
+}
+
 at::Tensor AtenXlaType::cosine_similarity(const at::Tensor& x1,
                                           const at::Tensor& x2, int64_t dim,
                                           double eps) const {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1443,6 +1443,15 @@ std::tuple<at::Tensor, at::Tensor> AtenXlaType::kthvalue(const at::Tensor& self,
                          bridge::AtenFromXlaTensor(std::get<1>(results)));
 }
 
+at::Tensor AtenXlaType::layer_norm(const at::Tensor& input,
+                                   at::IntArrayRef normalized_shape,
+                                   const at::Tensor& weight,
+                                   const at::Tensor& bias, double eps,
+                                   bool cudnn_enable) const {
+  return at::native::layer_norm(input, normalized_shape, weight, bias, eps,
+                                cudnn_enable);
+}
+
 at::Tensor AtenXlaType::le(const at::Tensor& self, at::Scalar other) const {
   return bridge::AtenFromXlaTensor(
       XLATensor::le(bridge::GetXlaTensor(self), other));

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1227,6 +1227,14 @@ at::Tensor& AtenXlaType::ge_(at::Tensor& self, const at::Tensor& other) const {
   return self;
 }
 
+at::Tensor AtenXlaType::group_norm(const at::Tensor& input, int64_t num_groups,
+                                   const at::Tensor& weight,
+                                   const at::Tensor& bias, double eps,
+                                   bool cudnn_enabled) const {
+  return at::native::group_norm(input, num_groups, weight, bias, eps,
+                                cudnn_enabled);
+}
+
 at::Tensor AtenXlaType::gt(const at::Tensor& self, at::Scalar other) const {
   return bridge::AtenFromXlaTensor(
       XLATensor::gt(bridge::GetXlaTensor(self), other));

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -1079,6 +1079,12 @@ class AtenXlaType : public AtenXlaTypeBase {
 
   at::Tensor& tril_(at::Tensor& self, int64_t diagonal) const override;
 
+  at::Tensor triplet_margin_loss(const at::Tensor& anchor,
+                                 const at::Tensor& positive,
+                                 const at::Tensor& negative, double margin,
+                                 double p, double eps, bool swap,
+                                 int64_t reduction) const override;
+
   at::Tensor triu(const at::Tensor& self, int64_t diagonal) const override;
 
   at::Tensor& triu_(at::Tensor& self, int64_t diagonal) const override;

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -786,6 +786,10 @@ class AtenXlaType : public AtenXlaTypeBase {
   at::Tensor ones_like(const at::Tensor& self,
                        const at::TensorOptions& options) const override;
 
+  at::Tensor pairwise_distance(const at::Tensor& x1, const at::Tensor& x2,
+                               double p, double eps,
+                               bool keepdim) const override;
+
   at::Tensor permute(const at::Tensor& self,
                      at::IntArrayRef dims) const override;
 

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -317,6 +317,9 @@ class AtenXlaType : public AtenXlaTypeBase {
 
   at::Tensor& cosh_(at::Tensor& self) const override;
 
+  at::Tensor cosine_similarity(const at::Tensor& x1, const at::Tensor& x2,
+                               int64_t dim, double eps) const override;
+
   at::Tensor cross(const at::Tensor& self, const at::Tensor& other,
                    c10::optional<int64_t> dim) const override;
 

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -317,6 +317,11 @@ class AtenXlaType : public AtenXlaTypeBase {
 
   at::Tensor& cosh_(at::Tensor& self) const override;
 
+  at::Tensor cosine_embedding_loss(const at::Tensor& input1,
+                                   const at::Tensor& input2,
+                                   const at::Tensor& target, double margin,
+                                   int64_t reduction) const override;
+
   at::Tensor cosine_similarity(const at::Tensor& x1, const at::Tensor& x2,
                                int64_t dim, double eps) const override;
 

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -520,6 +520,10 @@ class AtenXlaType : public AtenXlaTypeBase {
                                const at::Tensor& self, at::Scalar min_val,
                                at::Scalar max_val) const override;
 
+  at::Tensor hinge_embedding_loss(const at::Tensor& self,
+                                  const at::Tensor& target, double margin,
+                                  int64_t reduction) const override;
+
   at::Tensor index(const at::Tensor& self,
                    at::TensorList indices) const override;
 

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -590,6 +590,10 @@ class AtenXlaType : public AtenXlaTypeBase {
   at::Tensor kl_div(const at::Tensor& self, const at::Tensor& target,
                     int64_t reduction) const override;
 
+  at::Tensor kl_div_backward(const at::Tensor& grad_output,
+                             const at::Tensor& self, const at::Tensor& target,
+                             int64_t reduction) const override;
+
   std::tuple<at::Tensor, at::Tensor> kthvalue(const at::Tensor& self, int64_t k,
                                               int64_t dim,
                                               bool keepdim) const override;

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -155,6 +155,8 @@ class AtenXlaType : public AtenXlaTypeBase {
                    const at::Tensor& mat2, at::Scalar beta,
                    at::Scalar alpha) const override;
 
+  at::Tensor alias(const at::Tensor& self) const override;
+
   at::Tensor all(const at::Tensor& self) const override;
 
   at::Tensor all(const at::Tensor& self, int64_t dim,
@@ -303,6 +305,9 @@ class AtenXlaType : public AtenXlaTypeBase {
 
   at::Tensor copy(const at::Tensor& src, bool non_blocking,
                   at::optional<c10::Device> to_device) const override;
+
+  at::Tensor& copy_(at::Tensor& self, const at::Tensor& src,
+                    bool non_blocking) const override;
 
   at::Tensor cos(const at::Tensor& self) const override;
 
@@ -551,6 +556,13 @@ class AtenXlaType : public AtenXlaTypeBase {
 
   at::Tensor index_select(const at::Tensor& self, int64_t dim,
                           const at::Tensor& index) const override;
+
+  at::Tensor instance_norm(const at::Tensor& input, const at::Tensor& weight,
+                           const at::Tensor& bias,
+                           const at::Tensor& running_mean,
+                           const at::Tensor& running_var, bool use_input_stats,
+                           double momentum, double eps,
+                           bool cudnn_enabled) const override;
 
   std::tuple<at::Tensor, at::Tensor> kthvalue(const at::Tensor& self, int64_t k,
                                               int64_t dim,

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -587,6 +587,9 @@ class AtenXlaType : public AtenXlaTypeBase {
                            double momentum, double eps,
                            bool cudnn_enabled) const override;
 
+  at::Tensor kl_div(const at::Tensor& self, const at::Tensor& target,
+                    int64_t reduction) const override;
+
   std::tuple<at::Tensor, at::Tensor> kthvalue(const at::Tensor& self, int64_t k,
                                               int64_t dim,
                                               bool keepdim) const override;

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -556,6 +556,11 @@ class AtenXlaType : public AtenXlaTypeBase {
                                               int64_t dim,
                                               bool keepdim) const override;
 
+  at::Tensor layer_norm(const at::Tensor& input,
+                        at::IntArrayRef normalized_shape,
+                        const at::Tensor& weight, const at::Tensor& bias,
+                        double eps, bool cudnn_enable) const override;
+
   at::Tensor le(const at::Tensor& self, at::Scalar other) const override;
 
   at::Tensor le(const at::Tensor& self, const at::Tensor& other) const override;

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -464,6 +464,10 @@ class AtenXlaType : public AtenXlaTypeBase {
 
   at::Tensor& ge_(at::Tensor& self, const at::Tensor& other) const override;
 
+  at::Tensor group_norm(const at::Tensor& input, int64_t num_groups,
+                        const at::Tensor& weight, const at::Tensor& bias,
+                        double eps, bool cudnn_enabled) const override;
+
   at::Tensor gt(const at::Tensor& self, at::Scalar other) const override;
 
   at::Tensor gt(const at::Tensor& self, const at::Tensor& other) const override;

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -641,6 +641,11 @@ class AtenXlaType : public AtenXlaTypeBase {
 
   at::Tensor& lt_(at::Tensor& self, const at::Tensor& other) const override;
 
+  at::Tensor margin_ranking_loss(const at::Tensor& input1,
+                                 const at::Tensor& input2,
+                                 const at::Tensor& target, double margin,
+                                 int64_t reduction) const override;
+
   at::Tensor masked_fill(const at::Tensor& self, const at::Tensor& mask,
                          at::Scalar value) const override;
 

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -247,6 +247,17 @@ class AtenXlaType : public AtenXlaTypeBase {
                       const at::Tensor& weight,
                       const at::Tensor& bias) const override;
 
+  at::Tensor binary_cross_entropy_with_logits(const at::Tensor& self,
+                                              const at::Tensor& target,
+                                              const at::Tensor& weight,
+                                              const at::Tensor& pos_weight,
+                                              int64_t reduction) const override;
+
+  at::Tensor binary_cross_entropy_with_logits_backward(
+      const at::Tensor& grad_output, const at::Tensor& self,
+      const at::Tensor& target, const at::Tensor& weight,
+      const at::Tensor& pos_weight, int64_t reduction) const override;
+
   at::Tensor blackman_window(int64_t window_length,
                              const at::TensorOptions& options) const override;
   at::Tensor blackman_window(int64_t window_length, bool periodic,

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -498,6 +498,11 @@ class XLATensor {
   static XLATensor index_select(const XLATensor& input, xla::int64 dim,
                                 const XLATensor& index);
 
+  static XLATensor kl_div_backward(const XLATensor& grad_output,
+                                   const XLATensor& input,
+                                   const XLATensor& target,
+                                   xla::int64 reduction);
+
   static XLATensor le(const XLATensor& input, at::Scalar other);
   static void le_(XLATensor& input, at::Scalar other);
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1085,6 +1085,13 @@ XLATensor XLATensor::index_select(const XLATensor& input, xla::int64 dim,
       index.GetIrValue()));
 }
 
+XLATensor XLATensor::kl_div_backward(const XLATensor& grad_output,
+                                     const XLATensor& input,
+                                     const XLATensor& target,
+                                     xla::int64 reduction) {
+  return tensor_ops::KlDivBackward(grad_output, input, target, reduction);
+}
+
 std::tuple<XLATensor, XLATensor> XLATensor::kthvalue(const XLATensor& input,
                                                      xla::int64 k,
                                                      xla::int64 dim,

--- a/torch_xla/csrc/tensor_ops.h
+++ b/torch_xla/csrc/tensor_ops.h
@@ -12,6 +12,9 @@ namespace tensor_ops {
 XLATensor Cross(const XLATensor& input, const XLATensor& other,
                 c10::optional<xla::int64> dim);
 
+XLATensor KlDivBackward(const XLATensor& grad_output, const XLATensor& input,
+                        const XLATensor& target, xla::int64 reduction);
+
 XLATensor MakeMatrixWithDiagonal(const XLATensor& input, xla::int64 diagonal);
 
 XLATensor SmoothL1Loss(const XLATensor& input, const XLATensor& target,


### PR DESCRIPTION
Just route them to at::native, `kl_div`, `kl_div_backward`, `copy_` and `alias` are the interesting overrides here.