### PR TITLE
Add base support for ATEN Bool tensor type.

### DIFF
--- a/build_torch_xla_libs.sh
+++ b/build_torch_xla_libs.sh
@@ -10,6 +10,11 @@ BASE_DIR="$PWD"
 echo $BASE_DIR
 THIRD_PARTY_DIR="$BASE_DIR/third_party"
 
+MODE="opt"
+if [[ "$XLA_DEBUG" == "1" ]]; then
+  MODE="dbg"
+fi
+
 OPTS=(--cxxopt="-std=c++14")
 if [[ "$CC" =~ ^clang ]]; then
   OPTS+=(--cxxopt="-Wno-c++11-narrowing")
@@ -23,7 +28,7 @@ else
   cp -r -u -p $THIRD_PARTY_DIR/xla_client $THIRD_PARTY_DIR/tensorflow/tensorflow/compiler/xla/
 
   pushd $THIRD_PARTY_DIR/tensorflow
-  bazel build --define framework_shared_object=false -c opt "${OPTS[@]}" \
+  bazel build --define framework_shared_object=false -c "$MODE" "${OPTS[@]}" \
     //tensorflow/compiler/xla/xla_client:libxla_computation_client.so
 
   popd

--- a/scripts/gen.py
+++ b/scripts/gen.py
@@ -283,6 +283,7 @@ namespace torch_xla {{
 {instances}
 static inline void RegisterAtenXlaTypes() {{
   auto& context = at::globalContext();
+  context.registerType(at::Backend::XLA, at::ScalarType::Bool, GetXLATypeBool());
   context.registerType(at::Backend::XLA, at::ScalarType::Byte, GetXLATypeByte());
   context.registerType(at::Backend::XLA, at::ScalarType::Char, GetXLATypeChar());
   context.registerType(at::Backend::XLA, at::ScalarType::Short, GetXLATypeShort());
@@ -433,6 +434,11 @@ def is_write_param(fnopts, pname, defval):
 
 def create_type_instances():
   code = ''
+  code += _CLASS_INST_HEADER.format(
+      type_name='XLATypeBool',
+      scalar_type='at::ScalarType::Bool',
+      tensorid='c10::XLATensorId()',
+      typeid='at::TypeID::XLABool')
   code += _CLASS_INST_HEADER.format(
       type_name='XLATypeByte',
       scalar_type='at::ScalarType::Byte',

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -23,7 +23,6 @@ ExternalProject_Add(
   GIT_TAG master
   SOURCE_DIR "${GTEST_DIR}/src/googletest-src"
   BINARY_DIR "${GTEST_DIR}/src/googletest-build"
-  CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
   # Disable install step
   INSTALL_COMMAND ""
   LOG_DOWNLOAD ON

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -2,13 +2,18 @@
 set -ex
 RUNDIR="$(cd "$(dirname "$0")" ; pwd -P)"
 BUILDDIR="$RUNDIR/build"
+BUILDTYPE="Release"
 VERB=
 FILTER=
 BUILD_ONLY=0
 RMBUILD=1
 LOGFILE=/tmp/pytorch_cpp_test.log
 
-while getopts 'VLKBF:' OPTION
+if [ "$DEBUG" == "1" ]; then
+  BUILDTYPE="Debug"
+fi
+
+while getopts 'VLDKBF:' OPTION
 do
   case $OPTION in
     V)
@@ -16,6 +21,9 @@ do
       ;;
     L)
       LOGFILE=
+      ;;
+    D)
+      BUILDTYPE="Debug"
       ;;
     K)
       RMBUILD=0
@@ -34,8 +42,9 @@ rm -rf "$BUILDDIR"
 mkdir "$BUILDDIR" 2>/dev/null
 pushd "$BUILDDIR"
 cmake "$RUNDIR" \
-    -DPYTHON_INCLUDE_DIR=$(python -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())")\
-    -DPYTHON_LIBRARY=$(python -c "import distutils.sysconfig as sysconfig; print(sysconfig.get_config_var('LIBDIR') + '/' + sysconfig.get_config_var('LDLIBRARY'))")
+  -DCMAKE_BUILD_TYPE=$BUILDTYPE \
+  -DPYTHON_INCLUDE_DIR=$(python -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())") \
+  -DPYTHON_LIBRARY=$(python -c "import distutils.sysconfig as sysconfig; print(sysconfig.get_config_var('LIBDIR') + '/' + sysconfig.get_config_var('LDLIBRARY'))")
 make -j $VERB
 if [ $BUILD_ONLY -eq 0 ]; then
   if [ "$LOGFILE" != "" ]; then

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -2601,7 +2601,8 @@ TEST_F(AtenXlaTensorTest, TestSCopy) {
   ForEachDevice([&](const Device& device) {
     at::Tensor xla_source = bridge::CreateXlaTensor(source, device);
     at::Tensor xla_destination =
-        at::empty({size}, at::TensorOptions(at::kFloat).device(at::kXLA));
+        at::empty({size}, at::TensorOptions(at::kFloat)
+                              .device(bridge::XlaDeviceToAtenDevice(device)));
     at::s_copy_(xla_destination, xla_source);
     EXPECT_TRUE(EqualValues(destination, xla_destination));
   });
@@ -2614,7 +2615,8 @@ TEST_F(AtenXlaTensorTest, TestSCopyTransfer) {
   at::s_copy_(destination, source);
   ForEachDevice([&](const Device& device) {
     at::Tensor xla_destination =
-        at::empty({size}, at::TensorOptions(at::kFloat).device(at::kXLA));
+        at::empty({size}, at::TensorOptions(at::kFloat)
+                              .device(bridge::XlaDeviceToAtenDevice(device)));
     at::s_copy_(xla_destination, source);
     EXPECT_TRUE(EqualValues(destination, xla_destination));
   });
@@ -2628,7 +2630,8 @@ TEST_F(AtenXlaTensorTest, TestSCopyFrom) {
   ForEachDevice([&](const Device& device) {
     at::Tensor xla_source = bridge::CreateXlaTensor(source, device);
     at::Tensor xla_destination =
-        at::empty({size}, at::TensorOptions(at::kFloat).device(at::kXLA));
+        at::empty({size}, at::TensorOptions(at::kFloat)
+                              .device(bridge::XlaDeviceToAtenDevice(device)));
     at::_s_copy_from(xla_source, xla_destination);
     EXPECT_TRUE(EqualValues(destination, xla_destination));
   });

--- a/third_party/xla_client/xrt_computation_client.cc
+++ b/third_party/xla_client/xrt_computation_client.cc
@@ -1032,6 +1032,8 @@ const XrtSession::CachedNode& XrtComputationClient::GetSubTupleNode(
 tensorflow::DataType XrtComputationClient::XlaTypeToDataType(
     PrimitiveType dtype) {
   switch (dtype) {
+    case PRED:
+      return tensorflow::DT_BOOL;
     case S8:
       return tensorflow::DT_INT8;
     case U8:

--- a/torch_xla/csrc/ops/triangular_solve.cpp
+++ b/torch_xla/csrc/ops/triangular_solve.cpp
@@ -1,6 +1,7 @@
 #include "torch_xla/csrc/ops/triangular_solve.h"
 
 #include "tensorflow/compiler/xla/client/xla_builder.h"
+#include "tensorflow/compiler/xla/layout_util.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/lowering_context.h"
@@ -28,6 +29,8 @@ std::pair<xla::Shape, xla::Shape> InferTriangularSolveShape(
   if (xla::ShapeUtil::Compatible(lhs_batch_shape, rhs_batch_shape)) {
     rhs_batch_shape.add_dimensions(nrhs);
     lhs_batch_shape.add_dimensions(n);
+    xla::LayoutUtil::SetToDefaultLayout(&rhs_batch_shape);
+    xla::LayoutUtil::SetToDefaultLayout(&lhs_batch_shape);
     return std::pair<xla::Shape, xla::Shape>(rhs_batch_shape, lhs_batch_shape);
   }
   // Obtain the promoted shapes and add back the trailing dimension.
@@ -36,6 +39,8 @@ std::pair<xla::Shape, xla::Shape> InferTriangularSolveShape(
   xla::Shape lhs_batch_promoted_shape(rhs_batch_promoted_shape);
   rhs_batch_promoted_shape.add_dimensions(nrhs);
   lhs_batch_promoted_shape.add_dimensions(n);
+  xla::LayoutUtil::SetToDefaultLayout(&rhs_batch_promoted_shape);
+  xla::LayoutUtil::SetToDefaultLayout(&lhs_batch_promoted_shape);
   return std::pair<xla::Shape, xla::Shape>(rhs_batch_promoted_shape,
                                            lhs_batch_promoted_shape);
 }


### PR DESCRIPTION
Added debug build support for TF and C++ tests.
Changed s_copy_() tests as currently remote TF XLA_CPU device has issues.
Fixed TriangularSolve to clear the layouts when adding shape's dimensions.
Fixed device data caching to be per-device.