### PR TITLE
Use gcc 7

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -42,7 +42,7 @@ sudo add-apt-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-7
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
 sudo apt-get -qq update
 
-sudo apt-get -qq install clang-7 clang++-7
+sudo apt-get -qq install gcc-7 g++-7
 # Bazel dependencies
 sudo apt-get -qq install pkg-config zip zlib1g-dev unzip
 # XLA build requires Bazel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ linux_default: &linux_default
         echo "declare -x XLA_CACHE_S3_BUCKET_NAME=${XLA_CACHE_S3_BUCKET_NAME}" >> /home/circleci/project/env
         echo "declare -x CIRCLE_JOB=${CIRCLE_JOB}" >> /home/circleci/project/env
         echo "declare -x MAX_JOBS=8" >> /home/circleci/project/env
-        echo "declare -x CC=clang-7 CXX=clang++-7" >> /home/circleci/project/xla_env
+        echo "declare -x CC=gcc-7 CXX=g++-7" >> /home/circleci/project/xla_env
         echo "declare -x XLA_USE_XRT=1" >> /home/circleci/project/xla_env
         echo "declare -x XRT_DEVICE_MAP=\"CPU:0;/job:localservice/replica:0/task:0/device:XLA_CPU:0\"" >> /home/circleci/project/xla_env
         echo "declare -x export XRT_WORKERS=\"localservice:0;grpc://localhost:40934\"" >> /home/circleci/project/xla_env


### PR DESCRIPTION
After a recent update of the repos, our build, using Clang 7, fails with:

ERROR: /var/lib/jenkins/.cache/bazel/_bazel_jenkins/547b8eb1540275b25d5dbad1964ae973/external/zlib_archive/BUILD.bazel:5:1: undeclared inclusion(s) in rule '@zlib_archive//:zlib':
this rule is missing dependency declarations for the following files included by 'external/zlib_archive/uncompr.c':
  '/usr/lib/clang/7.0.1/include/stddef.h'
  '/usr/lib/clang/7.0.1/include/__stddef_max_align_t.h'
  '/usr/lib/clang/7.0.1/include/limits.h'
  '/usr/lib/clang/7.0.1/include/stdarg.h'
Target //tensorflow/compiler/xla/xla_client:libxla_computation_client.so failed to build

Fortunately gcc 7 works again.