### PR TITLE
 Tune hyper params for ResNet18 on cifar

### DIFF
--- a/test/test_train_cifar.py
+++ b/test/test_train_cifar.py
@@ -3,9 +3,9 @@ import test_utils
 FLAGS = test_utils.parse_common_options(
     datadir='/tmp/cifar-data',
     batch_size=128,
-    num_epochs=18,
+    num_epochs=20,
     momentum=0.9,
-    lr=0.1,
+    lr=0.2,
     target_accuracy=80.0)
 
 from common_utils import TestCase, run_tests


### PR DESCRIPTION
Baseline accuracy: 68.0881

Experiments
18 epochs:
  lr → 0.05: 68.09
  lr → 0.15: 78.50
  lr → 0.20: 79.91
  lr → 0.25: 79.32
  lr → 0.30: 79.06
  lr → 0.40: 79.34
  lr → 0.50: 77.27
  lr → 0.20; momentum → 0.95: 77.12
  lr → 0.20; momentum → 0.99: 73.35
  lr → 0.30; momentum → 0.80: 78.50
20 epochs:
  lr → 0.20: 81.05