### PR TITLE
Added GRPC service to coordinate hosts in a client mesh.

### DIFF
--- a/test/cpp/cpp_test_util.cpp
+++ b/test/cpp/cpp_test_util.cpp
@@ -88,8 +88,10 @@ bool CloseValues(at::Tensor tensor1, at::Tensor tensor2, double rtol,
 
 void WithAllDevices(
     DeviceType device_type,
-    const std::function<void(const std::vector<Device>&)>& devfn) {
+    const std::function<void(const std::vector<Device>&,
+                             const std::vector<Device>&)>& devfn) {
   std::vector<Device> devices;
+  std::vector<Device> all_devices;
   for (const auto& device_str :
        xla::ComputationClient::Get()->GetLocalDevices()) {
     Device device(device_str);
@@ -97,8 +99,15 @@ void WithAllDevices(
       devices.push_back(device);
     }
   }
+  for (const auto& device_str :
+       xla::ComputationClient::Get()->GetAllDevices()) {
+    Device device(device_str);
+    if (device.hw_type == device_type) {
+      all_devices.push_back(device);
+    }
+  }
   if (!devices.empty()) {
-    devfn(devices);
+    devfn(devices, all_devices);
   }
 }
 

--- a/test/cpp/cpp_test_util.h
+++ b/test/cpp/cpp_test_util.h
@@ -45,7 +45,8 @@ void ForEachDevice(const std::function<void(const Device&)>& devfn);
 
 void WithAllDevices(
     DeviceType device_type,
-    const std::function<void(const std::vector<Device>&)>& devfn);
+    const std::function<void(const std::vector<Device>&,
+                             const std::vector<Device>&)>& devfn);
 
 std::string GetTensorTextGraph(at::Tensor tensor);
 

--- a/third_party/xla_client/BUILD
+++ b/third_party/xla_client/BUILD
@@ -2,14 +2,36 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//tensorflow:internal"])
 
-load("//tensorflow:tensorflow.bzl", "tf_cc_test")
-load("//tensorflow:tensorflow.bzl", "tf_cc_binary")
-load("//tensorflow:tensorflow.bzl", "tf_cc_shared_object")
+load(
+    "//tensorflow:tensorflow.bzl",
+    "tf_cc_test",
+    "tf_cc_binary",
+    "tf_cc_shared_object",
+)
+load(
+    "//tensorflow/core:platform/default/build_config.bzl",
+    "tf_additional_all_protos",
+    "tf_proto_library",
+    "tf_proto_library_cc",
+    "tf_proto_library_py",
+)
+load("//tensorflow/compiler/xla:xla.bzl", "xla_proto_library")
 
 exports_files(
     [
         "tf_version_script.lds",
         "tf_exported_symbols.lds",
+    ],
+)
+
+tf_proto_library_cc(
+    name = "mesh_service_proto",
+    srcs = ["mesh_service.proto"],
+    has_services = 1,
+    cc_api_version = 2,
+    cc_grpc_version = 1,
+    protodeps = [
+        "//tensorflow/core/protobuf/tpu:topology_proto",
     ],
 )
 
@@ -45,6 +67,7 @@ cc_library(
     name = "computation_client_impl",
     srcs = [
         "computation_client.cc",
+        "mesh_service.cc",
         "metrics.cc",
         "multi_wait.cc",
         "sys_util.cc",
@@ -61,6 +84,7 @@ cc_library(
         "cache.h",
         "computation_client.h",
         "debug_macros.h",
+        "mesh_service.h",
         "metrics.h",
         "multi_wait.h",
         "sys_util.h",
@@ -76,6 +100,9 @@ cc_library(
         "xrt_session_cache.h",
     ],
     deps = [
+        ":mesh_service_proto_cc",
+        "//tensorflow:grpc",
+        "//tensorflow:grpc++",
         "//tensorflow/cc:cc_ops",
         "//tensorflow/cc:client_session",
         "//tensorflow/cc:ops",

--- a/third_party/xla_client/mesh_service.cc
+++ b/third_party/xla_client/mesh_service.cc
@@ -1,0 +1,192 @@
+#include "tensorflow/compiler/xla/xla_client/mesh_service.h"
+
+#include <grpc/grpc.h>
+#include <grpcpp/channel.h>
+#include <grpcpp/client_context.h>
+#include <grpcpp/create_channel.h>
+#include <grpcpp/security/server_credentials.h>
+#include <grpcpp/server.h>
+#include <grpcpp/server_builder.h>
+#include <grpcpp/server_context.h>
+
+#include <atomic>
+#include <iostream>
+#include <mutex>
+#include <unordered_map>
+
+#include "tensorflow/compiler/xla/status.h"
+#include "tensorflow/compiler/xla/xla_client/debug_macros.h"
+#include "tensorflow/compiler/xla/xla_client/mesh_service.grpc.pb.h"
+#include "tensorflow/compiler/xla/xla_client/multi_wait.h"
+#include "tensorflow/compiler/xla/xla_client/sys_util.h"
+#include "tensorflow/compiler/xla/xla_client/thread_pool.h"
+
+namespace xla {
+namespace service {
+namespace {
+
+#define GRPC_CHECK_OK(expr)   \
+  do {                        \
+    auto s = expr;            \
+    if (!s.ok()) {            \
+      return ToGrpcStatus(s); \
+    }                         \
+  } while (0)
+
+::grpc::Status ToGrpcStatus(const Status& status) {
+  return status.ok()
+             ? ::grpc::Status::OK
+             : ::grpc::Status(static_cast<::grpc::StatusCode>(status.code()),
+                              status.error_message());
+}
+
+std::ostream& operator<<(std::ostream& ostrm, const ::grpc::Status& status) {
+  if (status.ok()) {
+    ostrm << "OK";
+  } else {
+    ostrm << status.error_message() << " ("
+          << static_cast<int>(status.error_code()) << ")";
+  }
+  return ostrm;
+}
+
+class MeshServiceImpl : public grpc::MeshService::Service {
+ public:
+  MeshServiceImpl(grpc::Config config) : config_(std::move(config)) {}
+
+  ::grpc::Status GetConfig(::grpc::ServerContext* context,
+                           const grpc::GetConfigRequest* request,
+                           grpc::GetConfigResponse* response) override;
+
+  ::grpc::Status Rendezvous(::grpc::ServerContext* context,
+                            const grpc::RendezvousRequest* request,
+                            grpc::RendezvousResponse* response) override;
+
+ private:
+  struct RendezvousData {
+    explicit RendezvousData(size_t count) : mwait(count), release_count(0) {}
+
+    util::MultiWait mwait;
+    std::atomic<size_t> release_count;
+  };
+
+  std::shared_ptr<RendezvousData> GetRendezvous(const string& tag) {
+    std::lock_guard<std::mutex> lock(lock_);
+    auto it = rendezvous_map_.find(tag);
+    if (it == rendezvous_map_.end()) {
+      it =
+          rendezvous_map_
+              .emplace(tag,
+                       std::make_shared<RendezvousData>(config_.workers_size()))
+              .first;
+    }
+    return it->second;
+  }
+
+  void ReleaseRendezvous(const string& tag,
+                         const std::shared_ptr<RendezvousData>& rendezvous) {
+    if (rendezvous->release_count.fetch_add(1) == 0) {
+      std::lock_guard<std::mutex> lock(lock_);
+      rendezvous_map_.erase(tag);
+    }
+  }
+
+  std::mutex lock_;
+  grpc::Config config_;
+  std::unordered_map<string, std::shared_ptr<RendezvousData>> rendezvous_map_;
+};
+
+::grpc::Status MeshServiceImpl::GetConfig(::grpc::ServerContext* context,
+                                          const grpc::GetConfigRequest* request,
+                                          grpc::GetConfigResponse* response) {
+  response->mutable_config()->CopyFrom(config_);
+  return ::grpc::Status::OK;
+}
+
+::grpc::Status MeshServiceImpl::Rendezvous(
+    ::grpc::ServerContext* context, const grpc::RendezvousRequest* request,
+    grpc::RendezvousResponse* response) {
+  auto rendezvous = GetRendezvous(request->tag());
+  rendezvous->mwait.Done();
+  TF_VLOG(3) << "Entering rendezvous: tag=" << request->tag()
+             << " peer=" << context->peer();
+  ::grpc::Status status = ToGrpcStatus(rendezvous->mwait.Wait());
+  TF_VLOG(3) << "Exiting rendezvous: tag=" << request->tag()
+             << " peer=" << context->peer() << " status=" << status;
+  ReleaseRendezvous(request->tag(), rendezvous);
+  return status;
+}
+
+}  // namespace
+
+struct MeshService::Impl {
+  Impl(const string& address, grpc::Config config) : impl(std::move(config)) {
+    ::grpc::ServerBuilder builder;
+    builder.AddListeningPort(address, ::grpc::InsecureServerCredentials());
+    builder.RegisterService(&impl);
+    server = builder.BuildAndStart();
+  }
+
+  MeshServiceImpl impl;
+  std::unique_ptr<::grpc::Server> server;
+};
+
+MeshService::MeshService(const string& address, grpc::Config config)
+    : impl_(new Impl(address, std::move(config))) {}
+
+MeshService::~MeshService() {}
+
+struct MeshClient::Impl {
+  explicit Impl(const string& address) : address(address) {
+    std::shared_ptr<::grpc::Channel> channel =
+        ::grpc::CreateChannel(address, ::grpc::InsecureChannelCredentials());
+    stub = grpc::MeshService::NewStub(channel);
+  }
+
+  std::unique_ptr<grpc::MeshService::Stub> stub;
+  string address;
+};
+
+MeshClient* MeshClient::Get() {
+  auto create_client = []() {
+    string mesh_service_address =
+        sys_util::GetEnvString("XRT_MESH_SERVICE_ADDRESS", "");
+    return !mesh_service_address.empty() ? new MeshClient(mesh_service_address)
+                                         : nullptr;
+  };
+  static MeshClient* client = create_client();
+  return client;
+}
+
+MeshClient::MeshClient(const string& address) : impl_(new Impl(address)) {}
+
+MeshClient::~MeshClient() {}
+
+const string& MeshClient::address() const { return impl_->address; }
+
+grpc::Config MeshClient::GetConfig() const {
+  ::grpc::ClientContext context;
+  grpc::GetConfigRequest reqeust;
+  grpc::GetConfigResponse response;
+  ::grpc::Status status = impl_->stub->GetConfig(&context, reqeust, &response);
+  if (!status.ok()) {
+    XLA_ERROR() << "Failed to retrieve mesh configuration: " << status;
+  }
+  return std::move(*response.mutable_config());
+}
+
+void MeshClient::Rendezvous(const string& tag) const {
+  ::grpc::ClientContext context;
+  grpc::RendezvousRequest reqeust;
+  grpc::RendezvousResponse response;
+  reqeust.set_tag(tag);
+  TF_VLOG(3) << "Waiting for rendezvous: " << tag;
+  ::grpc::Status status = impl_->stub->Rendezvous(&context, reqeust, &response);
+  TF_VLOG(3) << "Rendezvous wait complete: " << tag;
+  if (!status.ok()) {
+    XLA_ERROR() << "Failed to meet rendezvous '" << tag << "': " << status;
+  }
+}
+
+}  // namespace service
+}  // namespace xla

--- a/third_party/xla_client/mesh_service.h
+++ b/third_party/xla_client/mesh_service.h
@@ -1,0 +1,48 @@
+#ifndef TENSORFLOW_COMPILER_XLA_RPC_XRT_MESH_SERVICE_H_
+#define TENSORFLOW_COMPILER_XLA_RPC_XRT_MESH_SERVICE_H_
+
+#include <memory>
+#include <string>
+
+#include "tensorflow/compiler/xla/types.h"
+#include "tensorflow/compiler/xla/xla_client/mesh_service.pb.h"
+
+namespace xla {
+namespace service {
+
+class MeshService {
+  struct Impl;
+
+ public:
+  MeshService(const string& address, grpc::Config config);
+
+  ~MeshService();
+
+ private:
+  std::unique_ptr<Impl> impl_;
+};
+
+class MeshClient {
+  struct Impl;
+
+ public:
+  static MeshClient* Get();
+
+  const string& address() const;
+
+  grpc::Config GetConfig() const;
+
+  void Rendezvous(const string& tag) const;
+
+ private:
+  MeshClient(const string& address);
+
+  ~MeshClient();
+
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace service
+}  // namespace xla
+
+#endif  // TENSORFLOW_COMPILER_XLA_RPC_XRT_MESH_SERVICE_H_

--- a/third_party/xla_client/mesh_service.proto
+++ b/third_party/xla_client/mesh_service.proto
@@ -1,0 +1,41 @@
+syntax = "proto2";
+
+import "tensorflow/core/protobuf/tpu/topology.proto";
+
+package xla.service.grpc;
+
+message Device {
+  required string local_name = 1;
+  required string global_name = 2;
+}
+
+message Worker {
+  required string name = 1;
+  required int32 task_no = 2;
+  required string address = 3;
+  repeated Device devices = 4;
+}
+
+message Config {
+  required tensorflow.tpu.TopologyProto proto = 1;
+  repeated Worker workers = 2;
+}
+
+message GetConfigRequest {
+}
+
+message GetConfigResponse {
+  required Config config = 1;
+}
+
+message RendezvousRequest {
+  required string tag = 1;
+}
+
+message RendezvousResponse {
+}
+
+service MeshService {
+  rpc GetConfig(GetConfigRequest) returns (GetConfigResponse) {}
+  rpc Rendezvous(RendezvousRequest) returns (RendezvousResponse) {}
+}

--- a/third_party/xla_client/multi_wait.h
+++ b/third_party/xla_client/multi_wait.h
@@ -24,6 +24,9 @@ class MultiWait {
   // happened.
   Status Wait();
 
+  // Same as above, but waits up to wait_seconds.
+  Status Wait(double wait_seconds);
+
   // Resets the threshold counter for the MultiWait object. The completed count
   // is also reset to zero.
   void Reset(size_t count);

--- a/torch_xla/csrc/ops/scalar.h
+++ b/torch_xla/csrc/ops/scalar.h
@@ -2,6 +2,8 @@
 
 #include <c10/core/Scalar.h>
 
+#include <iostream>
+
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {


### PR DESCRIPTION
This PR provides the initial base infrastructure to enable PyTorch to train on multi-host TPU setups (POD and slices), feeding data from multiple PyTorch client VMs.
