### PR TITLE
imagenet: add a --model flag to use any (supported) torchvision model

### DIFF
--- a/test/test_train_imagenet.py
+++ b/test/test_train_imagenet.py
@@ -33,7 +33,6 @@ import torch_xla_py.utils as xu
 import torch_xla_py.xla_model as xm
 import unittest
 
-
 DEFAULT_KWARGS = dict(
     batch_size=128,
     num_epochs=18,
@@ -45,11 +44,10 @@ MODEL_SPECIFIC_DEFAULTS = {
     RESNET50: DEFAULT_KWARGS,
 }
 
-
 default_value_dict = MODEL_SPECIFIC_DEFAULTS.get(FLAGS.model, DEFAULT_KWARGS)
 for arg, value in default_value_dict.items():
-    if getattr(FLAGS, arg) is None:
-        setattr(FLAGS, arg, value)
+  if getattr(FLAGS, arg) is None:
+    setattr(FLAGS, arg, value)
 
 
 def train_imagenet():
@@ -98,9 +96,7 @@ def train_imagenet():
   devices = xm.get_xla_supported_devices(max_devices=FLAGS.num_cores)
   # Pass [] as device_ids to run using the PyTorch/CPU engine.
   torchvision_model = getattr(torchvision.models, FLAGS.model)
-  model_parallel = dp.DataParallel(
-      torchvision_model, device_ids=devices
-  )
+  model_parallel = dp.DataParallel(torchvision_model, device_ids=devices)
 
   def train_loop_fn(model, loader, device, context):
     loss_fn = nn.CrossEntropyLoss()

--- a/test/test_train_imagenet.py
+++ b/test/test_train_imagenet.py
@@ -1,12 +1,23 @@
 import test_utils
 
+
+SUPPORTED_MODELS = ['resnet50']
+MODEL_OPTS = {
+    '--model': {
+        'choices': SUPPORTED_MODELS,
+        'default': 'resnet50',
+    }
+}
 FLAGS = test_utils.parse_common_options(
     datadir='/tmp/imagenet',
     batch_size=128,
     num_epochs=18,
     momentum=0.9,
     lr=0.1,
-    target_accuracy=0.0)
+    target_accuracy=0.0,
+    opts=MODEL_OPTS.items(),
+)
+
 
 from common_utils import TestCase, run_tests
 import os
@@ -69,8 +80,10 @@ def train_imagenet():
 
   devices = xm.get_xla_supported_devices(max_devices=FLAGS.num_cores)
   # Pass [] as device_ids to run using the PyTorch/CPU engine.
+  torchvision_model = getattr(torchvision.models, FLAGS.model)
   model_parallel = dp.DataParallel(
-      torchvision.models.resnet50, device_ids=devices)
+      torchvision_model, device_ids=devices
+  )
 
   def train_loop_fn(model, loader, device, context):
     loss_fn = nn.CrossEntropyLoss()

--- a/test/test_train_imagenet.py
+++ b/test/test_train_imagenet.py
@@ -1,23 +1,22 @@
 import test_utils
 
-
-SUPPORTED_MODELS = ['resnet50']
+RESNET50 = 'resnet50'
+SUPPORTED_MODELS = [RESNET50]
 MODEL_OPTS = {
     '--model': {
         'choices': SUPPORTED_MODELS,
-        'default': 'resnet50',
+        'default': RESNET50,
     }
 }
 FLAGS = test_utils.parse_common_options(
     datadir='/tmp/imagenet',
-    batch_size=128,
-    num_epochs=18,
-    momentum=0.9,
-    lr=0.1,
-    target_accuracy=0.0,
+    batch_size=None,
+    num_epochs=None,
+    momentum=None,
+    lr=None,
+    target_accuracy=None,
     opts=MODEL_OPTS.items(),
 )
-
 
 from common_utils import TestCase, run_tests
 import os
@@ -33,6 +32,24 @@ import torch_xla_py.data_parallel as dp
 import torch_xla_py.utils as xu
 import torch_xla_py.xla_model as xm
 import unittest
+
+
+DEFAULT_KWARGS = dict(
+    batch_size=128,
+    num_epochs=18,
+    momentum=0.9,
+    lr=0.1,
+    target_accuracy=0.0,
+)
+MODEL_SPECIFIC_DEFAULTS = {
+    RESNET50: DEFAULT_KWARGS,
+}
+
+
+default_value_dict = MODEL_SPECIFIC_DEFAULTS.get(FLAGS.model, DEFAULT_KWARGS)
+for arg, value in default_value_dict.items():
+    if getattr(FLAGS, arg) is None:
+        setattr(FLAGS, arg, value)
 
 
 def train_imagenet():


### PR DESCRIPTION
tested with:

```bash
python $code_source/test/test_train_imagenet.py \
  --datadir='$data_source' --model='resnet50'
```

for now only supported model is resnet50 as I have not tested anything else.