### PR TITLE
Expanded the supported models list per tests

### DIFF
--- a/test/test_train_imagenet.py
+++ b/test/test_train_imagenet.py
@@ -21,7 +21,7 @@ SUPPORTED_MODELS = [
     'vgg16',
     'vgg16_bn',
     'vgg19',
-    'vgg19_bn,
+    'vgg19_bn',
 ]
 
 MODEL_OPTS = {

--- a/test/test_train_imagenet.py
+++ b/test/test_train_imagenet.py
@@ -75,7 +75,7 @@ MODEL_PROPERTIES = {
         'model_fn': lambda: torchvision.models.inception_v3(aux_logits=False)
     },
     'DEFAULT': {
-        'img_dim': 299,
+        'img_dim': 224,
         'model_fn': getattr(torchvision.models, FLAGS.model)
     }
 }

--- a/test/test_train_imagenet.py
+++ b/test/test_train_imagenet.py
@@ -21,7 +21,7 @@ SUPPORTED_MODELS = [
     'vgg16',
     'vgg16_bn',
     'vgg19',
-    'vgg19_bn',
+    'vgg19_bn'
 ]
 
 MODEL_OPTS = {
@@ -70,14 +70,14 @@ for arg, value in default_value_dict.items():
     setattr(FLAGS, arg, value)
 
 MODEL_PROPERTIES = {
-  'inception_v3': {
-    'img_dim': 299,
-    'model_fn': lambda: torchvision.models.inception_v3(aux_logits=False)
-  },
-  'DEFAULT': {
-    'img_dim': 299,
-    'model_fn': getattr(torchvision.models, FLAGS.model)
-  }
+    'inception_v3': {
+        'img_dim': 299,
+        'model_fn': lambda: torchvision.models.inception_v3(aux_logits=False)
+    },
+    'DEFAULT': {
+        'img_dim': 299,
+        'model_fn': getattr(torchvision.models, FLAGS.model)
+    }
 }
 
 


### PR DESCRIPTION
Tested all the TV models. All of them work, except for squeezenet. I'm going to look at why that failed next.

I added them to the supported models list in the imagenet train script.

I had to change some parts for inception as its preprocessing requires
special handling.

I trained on 64 vCPUs, 240 GB memory machine (200g shm w/ docker), 8 tpu cores 

```bash
#!/bin/bash

image="gcr.io/tpu-pytorch/xla:nightly"
docker_args="--shm-size 200G -e XRT_TPU_CONFIG=\"tpu_worker;0;$GREENVMIP:8470\""
docker_args="$docker_args --name inceptionv3 --rm=true "

pytorch_cmd="python $code_source/test/test_train_imagenet.py \
  --datadir='$data_source' --model='$1' --num_epochs=1 --metrics_debug"

ssh -i ~/.ssh/google_compute_engine taylanbil@$REDVMIP -t \
  "docker run -it $docker_args $image $pytorch_cmd"
```