### PR TITLE
Install clang-7 from LLVM directly

### DIFF
--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -17,12 +17,13 @@ function install_bazel() {
   export PATH="$PATH:$HOME/bin"
 }
 
-function install_clang() {
-  if ! grep -Fxq "deb http://deb.debian.org/debian/ testing main" /etc/apt/sources.list; then
-    sudo bash -c 'echo "deb http://deb.debian.org/debian/ testing main" >> /etc/apt/sources.list'
-  fi
+function install_llvm_clang() {
+  sudo apt-get -y install wget
+  sudo bash -c 'echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-7 main" >> /etc/apt/sources.list'
+  sudo bash -c 'echo "deb-src http://apt.llvm.org/stretch/ llvm-toolchain-stretch-7 main" >> /etc/apt/sources.list'
+  wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
   sudo apt-get update
-  sudo apt-get install -y clang-7 clang++-7
+  sudo apt-get -y install clang-7 clang++-7
   export CC=clang-7 CXX=clang++-7
 }
 
@@ -79,7 +80,7 @@ function build_and_install_torch_xla() {
 }
 
 function main() {
-  install_clang
+  install_llvm_clang
   install_req_packages
   install_and_setup_conda
   build_and_install_torch


### PR DESCRIPTION
Before we were installing from testing apt as clang-7 is not part of
debian stretch stable. Consuming from testing introduces multiple
issues at install time of the wheels on other platforms since testing
introduces incompatible packages such as libc6=2.28 which is not
available in stable debian9/Ubuntu18.04(colab). Specifically
something like:

"ImportError: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found"

Installing from LLVM since there were no backports of clang-7 for
deb9. With this, only libomp and libopenblas need to be installed on
vanilla deb9 for installing and running with wheels. 

All tested mnist, cifar, and operations (Python 3.6 with conda &
Python 3.5 without conda).