### PR TITLE
fix breakage PT#20994

### DIFF
--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -1039,22 +1039,13 @@ class AtenXlaType {
       at::IntArrayRef stride, at::IntArrayRef padding);
 
   static std::tuple<at::Tensor, at::Tensor, at::Tensor>
-  thnn_conv_transpose2d_backward(
+  conv_transpose2d_backward(
       const at::Tensor& grad_output, const at::Tensor& self,
       const at::Tensor& weight, at::IntArrayRef kernel_size,
       at::IntArrayRef stride, at::IntArrayRef padding,
       at::IntArrayRef output_padding, at::IntArrayRef dilation,
       const at::Tensor& columns, const at::Tensor& ones,
       std::array<bool, 3> output_mask);
-
-  static std::tuple<at::Tensor, at::Tensor, at::Tensor>
-  thnn_conv_transpose2d_forward(const at::Tensor& self,
-                                const at::Tensor& weight,
-                                at::IntArrayRef kernel_size,
-                                const at::Tensor& bias, at::IntArrayRef stride,
-                                at::IntArrayRef padding,
-                                at::IntArrayRef output_padding,
-                                at::IntArrayRef dilation);
 
   static at::Tensor threshold(const at::Tensor& self, at::Scalar threshold,
                               at::Scalar value);

--- a/torch_xla/csrc/ops/conv_transpose2d_backward.cpp
+++ b/torch_xla/csrc/ops/conv_transpose2d_backward.cpp
@@ -35,7 +35,7 @@ ConvTranspose2dBackward::ConvTranspose2dBackward(
     const Value& grad_output, const Value& input, const Value& weight,
     std::vector<xla::int64> stride, std::vector<xla::int64> padding)
     : Node(
-          ir::OpKind(at::aten::thnn_conv_transpose2d_backward),
+          ir::OpKind(at::aten::conv_transpose2d_backward),
           {grad_output, input, weight},
           [&]() {
             return NodeOutputShape(grad_output, input, weight, stride, padding);


### PR DESCRIPTION
Fix changes introduced by https://github.com/pytorch/pytorch/pull/20994. 
Test is already on `conv_transpose2d` so that's still fine. We just remove one intermediate function `thnn_conv_transpose2d_forward`