### PR TITLE
Add release_version variable for stable builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,18 +2,20 @@ FROM debian:stretch
 
 ARG python_version="3.6"
 ARG cloud_build="false"
+ARG release_version="nightly"
 
 RUN apt-get update
 RUN apt-get install -y git sudo python-pip python3-pip
-RUN git clone --recursive https://github.com/pytorch/pytorch
+RUN git clone https://github.com/pytorch/pytorch
 
 # To get around issue of Cloud Build with recursive submodule update
 # clone recursively from pytorch/xla if building docker image with
 # cloud build. Otherwise, just use local.
 # https://github.com/GoogleCloudPlatform/cloud-builders/issues/435
 COPY . /pytorch/xla
-RUN if [ "${cloud_build}" = true ]; then cd /pytorch && rm -rf xla && \
-	git clone --recursive https://github.com/pytorch/xla; fi
+RUN if [ "${cloud_build}" = true ]; then github_branch="${release_version}" && \
+  if [ "${release_version}" = "nightly" ]; then github_branch="master"; fi && \
+  cd /pytorch && rm -rf xla && git clone -b "${github_branch}" --recursive https://github.com/pytorch/xla; fi
 
 RUN cd pytorch && bash xla/scripts/build_torch_wheels.sh ${python_version}
 

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -7,25 +7,27 @@ steps:
           'build',
           '--build-arg', 'python_version=${_PYTHON_VERSION}',
           '--build-arg', 'cloud_build=true',
-          '-t', 'gcr.io/tpu-pytorch/xla:nightly',
+          '--build-arg', 'release_version=${_RELEASE_VERSION}',
+          '-t', 'gcr.io/tpu-pytorch/xla:${_RELEASE_VERSION}',
           '-f', 'docker/Dockerfile', '.'
         ]
   timeout: 14400s
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: bash
-  args: ['-c', 'docker tag gcr.io/tpu-pytorch/xla:nightly gcr.io/tpu-pytorch/xla:$(date -u +nightly_%Y%m%d)']
-- name: 'gcr.io/tpu-pytorch/xla:nightly'
-  entrypoint: 'bash'
+  args: ['-c', 'docker tag gcr.io/tpu-pytorch/xla:${_RELEASE_VERSION} gcr.io/tpu-pytorch/xla:${_RELEASE_VERSION}_$(date -u +%Y%m%d)']
+- name: 'gcr.io/tpu-pytorch/xla:${_RELEASE_VERSION}'
+  entrypoint: bash
   args: ['-c', 'source /pytorch/xla/docker/common.sh && run_deployment_tests']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'gcr.io/tpu-pytorch/xla']
   timeout: 1200s
-- name: 'gcr.io/tpu-pytorch/xla:nightly'
+- name: 'gcr.io/tpu-pytorch/xla:${_RELEASE_VERSION}'
   entrypoint: 'bash'
-  args: ['-c', 'source /pytorch/xla/docker/common.sh && collect_wheels']
+  args: ['-c', 'source /pytorch/xla/docker/common.sh && collect_wheels ${_RELEASE_VERSION}']
 
 substitutions:
-    _PYTHON_VERSION: '3.6' # default value
+    _PYTHON_VERSION: '3.6'
+    _RELEASE_VERSION: 'nightly'  # or rX.Y
 options:
     machineType: 'N1_HIGHCPU_32'
 timeout: 15000s

--- a/docker/common.sh
+++ b/docker/common.sh
@@ -10,25 +10,31 @@ function run_deployment_tests() {
 }
 
 function collect_wheels() {
+  release_version=$1
+  wheel_version="${release_version}"
+  if [ "${release_version}" != "nightly" ]; then
+    wheel_version=$( echo "${release_version}" | grep -oP '\d+.\d+' )
+  fi
+
   mkdir /tmp/staging-wheels
 
   pushd /tmp/staging-wheels
   cp /pytorch/dist/*.whl .
-  rename -v "s/torch-.*\+\w{7}/torch-nightly/" *.whl
+  rename -v "s/torch-.*\+\w{7}/torch-${wheel_version}/" *.whl
   popd
   mv /tmp/staging-wheels/* .
   pushd /tmp/staging-wheels
   cp /pytorch/xla/dist/*.whl .
-  rename -v "s/torch_xla-.*\+\w{7}/torch_xla-nightly/" *.whl
+  rename -v "s/torch_xla-.*\+\w{7}/torch_xla-${wheel_version}/" *.whl
   popd
   mv /tmp/staging-wheels/* .
   rm -rf /tmp/staging-wheels
 
   pushd /pytorch/dist
-  rename -v "s/^torch/torch-$(date -u +%Y%m%d)/" *.whl
+  rename -v "s/^torch/torch-${wheel_version}+$(date -u +%Y%m%d)/" *.whl
   popd
   pushd /pytorch/xla/dist
-  rename -v "s/^torch_xla/torch_xla-$(date -u +%Y%m%d)/" *.whl
+  rename -v "s/^torch_xla/torch_xla-${wheel_version}+$(date -u +%Y%m%d)/" *.whl
   popd
   cp /pytorch/dist/*.whl ./ && cp /pytorch/xla/dist/*.whl ./
 }

--- a/docker/run_deployment_tests.sh
+++ b/docker/run_deployment_tests.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-export XRT_DEVICE_MAP="CPU:0;/job:localservice/replica:0/task:0/device:XLA_CPU:0"
-export XRT_WORKERS="localservice:0;grpc://localhost:40934"
-
-time python pytorch/xla/test/test_train_mnist.py
-time bash pytorch/xla/test/run_tests.sh
-time bash pytorch/xla/test/cpp/run_tests.sh

--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -59,12 +59,13 @@ function install_and_setup_conda() {
 }
 
 function build_and_install_torch() {
-  git submodule update --init --recursive
   # Checkout the PT commit ID if we have one.
   COMMITID_FILE="xla/.torch_commit_id"
   if [ -e "$COMMITID_FILE" ]; then
     git checkout $(cat "$COMMITID_FILE")
   fi
+  # Only checkout dependencies once PT commit ID checked out.
+  git submodule update --init --recursive
   # Apply patches to PT which are required by the XLA support.
   xla/scripts/apply_patches.sh
   export NO_CUDA=1 NO_MKLDNN=1


### PR DESCRIPTION
With this and creating a build trigger on GCP Build, should make releasing stables (docker img and wheels; not quite vm images) simpler. Tested with Google Cloud Builds.