### PR TITLE
Catch and properly report errors in threads

### DIFF
--- a/torch_xla_py/data_parallel.py
+++ b/torch_xla_py/data_parallel.py
@@ -202,9 +202,8 @@ class DataParallel(object):
     xm.set_replication(self._replication)
     try:
       result.result = loop_fn(module, loader, torch.device(device), context)
-    except Exception as e:
-      result.result = e
-      self._handle_runner_exception(device, e)
+    except:
+      self._handle_runner_exception(device, traceback.format_exc())
 
   def __call__(self, loop_fn, loader):
     context = dict()


### PR DESCRIPTION
Previously we were silently swallowing errors such as NameError, ValueError, etc. since eg. isinstance(NameError, Exception) == False.