### PR TITLE
add a testcase for printing tensors on xla

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -583,6 +583,11 @@ class TestAtenXlaTensor(XlaTestCase):
     finally:
       os.remove(x_file)
 
+  def test_print(self):
+    xla_device = xm.xla_device()
+    x = torch.tensor([5], device=xla_device)
+    expected_str = 'tensor([5], device=\'' + str(xla_device) + '\')'
+    self.assertExpectedInline(str(x), expected_str)
 
 class MNISTComparator(nn.Module):
 


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/22094 has landed, and now printing xla tensors will show `device=xla` to make it look different from cpu tensors. 
Add a test case here to prevent regression. 