### PR TITLE
build wheels script bug fix

### DIFF
--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -42,7 +42,7 @@ function install_and_setup_conda() {
     rm Anaconda3-5.2.0-Linux-x86_64.sh
   fi
   echo 'export PATH="$HOME/anaconda3/bin:$PATH"' >> ~/.bashrc
-  source ~/.bashrc
+  export PATH="$HOME/anaconda3/bin:$PATH"
   ENVNAME="pytorch"
   if conda env list | awk '{print $1}' | grep "^$ENVNAME$"; then
     conda remove --name "$ENVNAME" --all
@@ -67,7 +67,8 @@ function build_and_install_torch() {
   # Only checkout dependencies once PT commit ID checked out.
   git submodule update --init --recursive
   # Apply patches to PT which are required by the XLA support.
-  xla/scripts/apply_patches.sh
+  # xla/scripts/apply_patches.sh
+  $(echo $0 | sed s/build_torch_wheels/apply_patches/)
   export NO_CUDA=1 NO_MKLDNN=1
   python setup.py bdist_wheel
   pip install dist/*.whl

--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -67,8 +67,7 @@ function build_and_install_torch() {
   # Only checkout dependencies once PT commit ID checked out.
   git submodule update --init --recursive
   # Apply patches to PT which are required by the XLA support.
-  # xla/scripts/apply_patches.sh
-  $(echo $0 | sed s/build_torch_wheels/apply_patches/)
+  $(dirname $0)/apply_patches.sh
   export NO_CUDA=1 NO_MKLDNN=1
   python setup.py bdist_wheel
   pip install dist/*.whl


### PR DESCRIPTION
script currently quits because it cannot find conda
somehow the `source ~/.bashrc` line is not changing the path within
script, so it quits when it cannot find conda.

apply_patches was executed using a relative path, made that
semi-absolute.