### PR TITLE
Use clang-format-7 friendly config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,155 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+#AllowAllArgumentsOnNextLine: true
+#AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+#AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+#AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  #AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+#SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+#StatementMacros:
+#  - Q_UNUSED
+#  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseTab:          Never

--- a/torch_xla/csrc/batch_norm.cpp
+++ b/torch_xla/csrc/batch_norm.cpp
@@ -1,4 +1,5 @@
 #include "torch_xla/csrc/batch_norm.h"
+
 #include "torch_xla/csrc/helpers.h"
 
 namespace torch_xla {

--- a/torch_xla/csrc/cross_replica_reduces.cpp
+++ b/torch_xla/csrc/cross_replica_reduces.cpp
@@ -1,6 +1,7 @@
 #include "torch_xla/csrc/cross_replica_reduces.h"
 
 #include <vector>
+
 #include "torch_xla/csrc/helpers.h"
 
 namespace torch_xla {

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -242,52 +242,47 @@ void InitXlaModuleBindings(py::module m) {
   m.def("_xla_set_default_device",
         [](const std::string& device) { return SetCurrentDevice(device); });
   m.def("_xla_get_default_device", []() { return GetCurrentDevice(); });
-  m.def(
-      "_xla_sync_multi",
-      [](const std::vector<at::Tensor>& tensors,
-         const std::vector<std::string>& devices, bool wait,
-         bool sync_xla_data) {
-        NoGilSection nogil;
-        SyncTensors(tensors, devices, wait, sync_xla_data);
-      },
-      py::arg("tensors"), py::arg("devices"), py::arg("wait") = true,
-      py::arg("sync_xla_data") = true);
-  m.def(
-      "_xla_sync_live_tensors",
-      [](const std::string& device, const std::vector<std::string>& devices,
-         bool wait) {
-        NoGilSection nogil;
-        SyncLiveTensors(device, devices, wait);
-      },
-      py::arg("device") = "", py::arg("devices"), py::arg("wait") = true);
-  m.def(
-      "_xla_step_marker",
-      [](const std::string& device, const std::vector<std::string>& devices,
-         bool wait) {
-        NoGilSection nogil;
-        StepMarker(device, devices, wait);
-      },
-      py::arg("device") = "", py::arg("devices"), py::arg("wait") = true);
+  m.def("_xla_sync_multi",
+        [](const std::vector<at::Tensor>& tensors,
+           const std::vector<std::string>& devices, bool wait,
+           bool sync_xla_data) {
+          NoGilSection nogil;
+          SyncTensors(tensors, devices, wait, sync_xla_data);
+        },
+        py::arg("tensors"), py::arg("devices"), py::arg("wait") = true,
+        py::arg("sync_xla_data") = true);
+  m.def("_xla_sync_live_tensors",
+        [](const std::string& device, const std::vector<std::string>& devices,
+           bool wait) {
+          NoGilSection nogil;
+          SyncLiveTensors(device, devices, wait);
+        },
+        py::arg("device") = "", py::arg("devices"), py::arg("wait") = true);
+  m.def("_xla_step_marker",
+        [](const std::string& device, const std::vector<std::string>& devices,
+           bool wait) {
+          NoGilSection nogil;
+          StepMarker(device, devices, wait);
+        },
+        py::arg("device") = "", py::arg("devices"), py::arg("wait") = true);
   m.def("_xla_counter_value", [](const std::string& name) -> py::object {
     xla::metrics::CounterData* data = xla::metrics::GetCounter(name);
     return data != nullptr ? py::cast<int64_t>(data->Value()) : py::none();
   });
   m.def("_xla_metrics_report",
         []() { return xla::metrics::CreateMetricReport(); });
-  m.def(
-      "_xla_tensors_report",
-      [](size_t nodes_threshold, const std::string& device) {
-        return GetLiveTensorsReport(nodes_threshold, device);
-      },
-      py::arg("nodes_threshold") = 100, py::arg("device") = "");
-  m.def(
-      "_xla_set_use_full_mat_mul_precision",
-      [](bool use_full_mat_mul_precision) {
-        XlaHelpers::set_mat_mul_precision(use_full_mat_mul_precision
-                                              ? xla::PrecisionConfig::HIGHEST
-                                              : xla::PrecisionConfig::DEFAULT);
-      },
-      py::arg("use_full_mat_mul_precision") = true);
+  m.def("_xla_tensors_report",
+        [](size_t nodes_threshold, const std::string& device) {
+          return GetLiveTensorsReport(nodes_threshold, device);
+        },
+        py::arg("nodes_threshold") = 100, py::arg("device") = "");
+  m.def("_xla_set_use_full_mat_mul_precision",
+        [](bool use_full_mat_mul_precision) {
+          XlaHelpers::set_mat_mul_precision(
+              use_full_mat_mul_precision ? xla::PrecisionConfig::HIGHEST
+                                         : xla::PrecisionConfig::DEFAULT);
+        },
+        py::arg("use_full_mat_mul_precision") = true);
 }
 
 }  // namespace

--- a/torch_xla/csrc/matrix.cpp
+++ b/torch_xla/csrc/matrix.cpp
@@ -1,4 +1,5 @@
 #include "torch_xla/csrc/matrix.h"
+
 #include "tensorflow/compiler/xla/client/lib/constants.h"
 #include "tensorflow/compiler/xla/client/lib/matrix.h"
 #include "torch_xla/csrc/helpers.h"

--- a/torch_xla/csrc/ops/adaptive_avg_pool2d.cpp
+++ b/torch_xla/csrc/ops/adaptive_avg_pool2d.cpp
@@ -1,4 +1,5 @@
 #include "torch_xla/csrc/ops/adaptive_avg_pool2d.h"
+
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
 #include "torch_xla/csrc/lowering_context.h"
@@ -26,10 +27,9 @@ xla::Shape NodeOutputShape(
 
 AdaptiveAvgPool2d::AdaptiveAvgPool2d(const Value& input,
                                      std::vector<xla::int64> output_size)
-    : Node(
-          ir::OpKind(at::aten::adaptive_avg_pool2d), {input},
-          [&]() { return NodeOutputShape(input, output_size); },
-          /*num_outputs=*/1, xla::util::MHash(output_size)),
+    : Node(ir::OpKind(at::aten::adaptive_avg_pool2d), {input},
+           [&]() { return NodeOutputShape(input, output_size); },
+           /*num_outputs=*/1, xla::util::MHash(output_size)),
       output_size_(std::move(output_size)) {}
 
 NodePtr AdaptiveAvgPool2d::Clone(OpList operands) const {

--- a/torch_xla/csrc/ops/arg_max.cpp
+++ b/torch_xla/csrc/ops/arg_max.cpp
@@ -20,10 +20,9 @@ xla::Shape NodeOutputShape(const Value& input, xla::int64 dim, bool keepdim) {
 }  // namespace
 
 ArgMax::ArgMax(const Value& input, xla::int64 dim, bool keepdim)
-    : Node(
-          ir::OpKind(at::aten::argmax), {input},
-          [&]() { return NodeOutputShape(input, dim, keepdim); },
-          /*num_outputs=*/1, xla::util::MHash(dim, keepdim)),
+    : Node(ir::OpKind(at::aten::argmax), {input},
+           [&]() { return NodeOutputShape(input, dim, keepdim); },
+           /*num_outputs=*/1, xla::util::MHash(dim, keepdim)),
       dim_(dim),
       keepdim_(keepdim) {}
 

--- a/torch_xla/csrc/ops/arg_min.cpp
+++ b/torch_xla/csrc/ops/arg_min.cpp
@@ -20,10 +20,9 @@ xla::Shape NodeOutputShape(const Value& input, xla::int64 dim, bool keepdim) {
 }  // namespace
 
 ArgMin::ArgMin(const Value& input, xla::int64 dim, bool keepdim)
-    : Node(
-          ir::OpKind(at::aten::argmin), {input},
-          [&]() { return NodeOutputShape(input, dim, keepdim); },
-          /*num_outputs=*/1, xla::util::MHash(dim, keepdim)),
+    : Node(ir::OpKind(at::aten::argmin), {input},
+           [&]() { return NodeOutputShape(input, dim, keepdim); },
+           /*num_outputs=*/1, xla::util::MHash(dim, keepdim)),
       dim_(dim),
       keepdim_(keepdim) {}
 

--- a/torch_xla/csrc/ops/as_strided.cpp
+++ b/torch_xla/csrc/ops/as_strided.cpp
@@ -45,12 +45,11 @@ xla::Shape NodeOutputShape(const Value& input,
 
 AsStrided::AsStrided(const Value& input, std::vector<xla::int64> size,
                      c10::optional<xla::int64> storage_offset)
-    : Node(
-          ir::OpKind(at::aten::as_strided), {input},
-          [&]() { return NodeOutputShape(input, size, storage_offset); },
-          /*num_outputs=*/1,
-          xla::util::MHash(size,
-                           OptionalOr<xla::int64>(storage_offset, 0x311bd6))),
+    : Node(ir::OpKind(at::aten::as_strided), {input},
+           [&]() { return NodeOutputShape(input, size, storage_offset); },
+           /*num_outputs=*/1,
+           xla::util::MHash(size,
+                            OptionalOr<xla::int64>(storage_offset, 0x311bd6))),
       size_(std::move(size)),
       storage_offset_(storage_offset) {}
 

--- a/torch_xla/csrc/ops/as_strided.h
+++ b/torch_xla/csrc/ops/as_strided.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <vector>
-
 #include <c10/util/Optional.h>
+
+#include <vector>
 
 #include "tensorflow/compiler/xla/types.h"
 #include "torch_xla/csrc/ir.h"

--- a/torch_xla/csrc/ops/avg_pool_nd.cpp
+++ b/torch_xla/csrc/ops/avg_pool_nd.cpp
@@ -50,16 +50,15 @@ AvgPoolNd::AvgPoolNd(const Value& input, xla::int64 spatial_dim_count,
                      std::vector<xla::int64> stride,
                      std::vector<xla::int64> padding, bool ceil_mode,
                      bool count_include_pad)
-    : Node(
-          ir::OpKind(AvgPoolNdSymbol(spatial_dim_count)), {input},
-          [&]() {
-            return NodeOutputShape(input, spatial_dim_count, kernel_size,
-                                   stride, padding, ceil_mode,
-                                   count_include_pad);
-          },
-          /*num_outputs=*/1,
-          xla::util::MHash(spatial_dim_count, kernel_size, stride, padding,
-                           ceil_mode, count_include_pad)),
+    : Node(ir::OpKind(AvgPoolNdSymbol(spatial_dim_count)), {input},
+           [&]() {
+             return NodeOutputShape(input, spatial_dim_count, kernel_size,
+                                    stride, padding, ceil_mode,
+                                    count_include_pad);
+           },
+           /*num_outputs=*/1,
+           xla::util::MHash(spatial_dim_count, kernel_size, stride, padding,
+                            ceil_mode, count_include_pad)),
       spatial_dim_count_(spatial_dim_count),
       kernel_size_(std::move(kernel_size)),
       stride_(std::move(stride)),

--- a/torch_xla/csrc/ops/avg_pool_nd_backward.cpp
+++ b/torch_xla/csrc/ops/avg_pool_nd_backward.cpp
@@ -49,16 +49,15 @@ AvgPoolNdBackward::AvgPoolNdBackward(
     const Value& grad_output, const Value& input, xla::int64 spatial_dim_count,
     std::vector<xla::int64> kernel_size, std::vector<xla::int64> stride,
     std::vector<xla::int64> padding, bool ceil_mode, bool count_include_pad)
-    : Node(
-          OpKind(AvgNdBackwardSymbol(spatial_dim_count)), {grad_output, input},
-          [&]() {
-            return NodeOutputShape(grad_output, input, spatial_dim_count,
-                                   kernel_size, stride, padding, ceil_mode,
-                                   count_include_pad);
-          },
-          /*num_outputs=*/1,
-          xla::util::MHash(spatial_dim_count, kernel_size, stride, padding,
-                           ceil_mode, count_include_pad)),
+    : Node(OpKind(AvgNdBackwardSymbol(spatial_dim_count)), {grad_output, input},
+           [&]() {
+             return NodeOutputShape(grad_output, input, spatial_dim_count,
+                                    kernel_size, stride, padding, ceil_mode,
+                                    count_include_pad);
+           },
+           /*num_outputs=*/1,
+           xla::util::MHash(spatial_dim_count, kernel_size, stride, padding,
+                            ceil_mode, count_include_pad)),
       spatial_dim_count_(spatial_dim_count),
       kernel_size_(std::move(kernel_size)),
       stride_(std::move(stride)),

--- a/torch_xla/csrc/ops/cat.cpp
+++ b/torch_xla/csrc/ops/cat.cpp
@@ -27,10 +27,9 @@ xla::Shape NodeOutputShape(tensorflow::gtl::ArraySlice<const ir::Value> values,
 }  // namespace
 
 Cat::Cat(tensorflow::gtl::ArraySlice<const ir::Value> values, xla::int64 dim)
-    : Node(
-          ir::OpKind(at::aten::cat), values,
-          [&]() { return NodeOutputShape(values, dim); },
-          /*num_outputs=*/1, xla::util::MHash(dim)),
+    : Node(ir::OpKind(at::aten::cat), values,
+           [&]() { return NodeOutputShape(values, dim); },
+           /*num_outputs=*/1, xla::util::MHash(dim)),
       dim_(dim) {}
 
 NodePtr Cat::Clone(OpList operands) const {

--- a/torch_xla/csrc/ops/constant_pad_nd.cpp
+++ b/torch_xla/csrc/ops/constant_pad_nd.cpp
@@ -32,10 +32,9 @@ xla::Shape NodeOutputShape(const Value& input,
 
 ConstantPadNd::ConstantPadNd(const Value& input, std::vector<xla::int64> pad,
                              at::Scalar value)
-    : Node(
-          ir::OpKind(at::aten::constant_pad_nd), OpList{input},
-          [&]() { return NodeOutputShape(input, pad); },
-          /*num_outputs=*/1, xla::util::MHash(pad, ScalarHash(value))),
+    : Node(ir::OpKind(at::aten::constant_pad_nd), OpList{input},
+           [&]() { return NodeOutputShape(input, pad); },
+           /*num_outputs=*/1, xla::util::MHash(pad, ScalarHash(value))),
       pad_(std::move(pad)),
       value_(value) {}
 

--- a/torch_xla/csrc/ops/conv2d.cpp
+++ b/torch_xla/csrc/ops/conv2d.cpp
@@ -31,19 +31,17 @@ xla::Shape NodeOutputShape(
 
 Conv2d::Conv2d(const Value& input, const Value& weight, const Value& bias,
                std::vector<xla::int64> stride, std::vector<xla::int64> padding)
-    : Node(
-          ir::OpKind(at::aten::convolution), {input, weight, bias},
-          [&]() { return NodeOutputShape(input, weight, stride, padding); },
-          /*num_outputs=*/1, xla::util::MHash(stride, padding)),
+    : Node(ir::OpKind(at::aten::convolution), {input, weight, bias},
+           [&]() { return NodeOutputShape(input, weight, stride, padding); },
+           /*num_outputs=*/1, xla::util::MHash(stride, padding)),
       stride_(std::move(stride)),
       padding_(std::move(padding)) {}
 
 Conv2d::Conv2d(const Value& input, const Value& weight,
                std::vector<xla::int64> stride, std::vector<xla::int64> padding)
-    : Node(
-          ir::OpKind(at::aten::convolution), {input, weight},
-          [&]() { return NodeOutputShape(input, weight, stride, padding); },
-          /*num_outputs=*/1, xla::util::MHash(stride, padding)),
+    : Node(ir::OpKind(at::aten::convolution), {input, weight},
+           [&]() { return NodeOutputShape(input, weight, stride, padding); },
+           /*num_outputs=*/1, xla::util::MHash(stride, padding)),
       stride_(std::move(stride)),
       padding_(std::move(padding)) {}
 

--- a/torch_xla/csrc/ops/conv2d_backward.cpp
+++ b/torch_xla/csrc/ops/conv2d_backward.cpp
@@ -37,13 +37,13 @@ Conv2dBackward::Conv2dBackward(const Value& grad_output, const Value& input,
                                const Value& weight,
                                std::vector<xla::int64> stride,
                                std::vector<xla::int64> padding)
-    : Node(
-          ir::OpKind(at::aten::thnn_conv2d_backward),
-          {grad_output, input, weight},
-          [&]() {
-            return NodeOutputShape(grad_output, input, weight, stride, padding);
-          },
-          /*num_outputs=*/3, xla::util::MHash(stride, padding)),
+    : Node(ir::OpKind(at::aten::thnn_conv2d_backward),
+           {grad_output, input, weight},
+           [&]() {
+             return NodeOutputShape(grad_output, input, weight, stride,
+                                    padding);
+           },
+           /*num_outputs=*/3, xla::util::MHash(stride, padding)),
       stride_(std::move(stride)),
       padding_(std::move(padding)) {}
 

--- a/torch_xla/csrc/ops/conv_transpose2d.cpp
+++ b/torch_xla/csrc/ops/conv_transpose2d.cpp
@@ -34,20 +34,18 @@ ConvTranspose2d::ConvTranspose2d(const Value& input, const Value& weight,
                                  const Value& bias,
                                  std::vector<xla::int64> stride,
                                  std::vector<xla::int64> padding)
-    : Node(
-          ir::OpKind(at::aten::conv_transpose2d), {input, weight, bias},
-          [&]() { return NodeOutputShape(input, weight, stride, padding); },
-          /*num_outputs=*/1, xla::util::MHash(stride, padding)),
+    : Node(ir::OpKind(at::aten::conv_transpose2d), {input, weight, bias},
+           [&]() { return NodeOutputShape(input, weight, stride, padding); },
+           /*num_outputs=*/1, xla::util::MHash(stride, padding)),
       stride_(std::move(stride)),
       padding_(std::move(padding)) {}
 
 ConvTranspose2d::ConvTranspose2d(const Value& input, const Value& weight,
                                  std::vector<xla::int64> stride,
                                  std::vector<xla::int64> padding)
-    : Node(
-          ir::OpKind(at::aten::convolution), {input, weight},
-          [&]() { return NodeOutputShape(input, weight, stride, padding); },
-          /*num_outputs=*/1, xla::util::MHash(stride, padding)),
+    : Node(ir::OpKind(at::aten::convolution), {input, weight},
+           [&]() { return NodeOutputShape(input, weight, stride, padding); },
+           /*num_outputs=*/1, xla::util::MHash(stride, padding)),
       stride_(std::move(stride)),
       padding_(std::move(padding)) {}
 

--- a/torch_xla/csrc/ops/conv_transpose2d_backward.cpp
+++ b/torch_xla/csrc/ops/conv_transpose2d_backward.cpp
@@ -34,13 +34,13 @@ xla::Shape NodeOutputShape(
 ConvTranspose2dBackward::ConvTranspose2dBackward(
     const Value& grad_output, const Value& input, const Value& weight,
     std::vector<xla::int64> stride, std::vector<xla::int64> padding)
-    : Node(
-          ir::OpKind(at::aten::conv_transpose2d_backward),
-          {grad_output, input, weight},
-          [&]() {
-            return NodeOutputShape(grad_output, input, weight, stride, padding);
-          },
-          /*num_outputs=*/3, xla::util::MHash(stride, padding)),
+    : Node(ir::OpKind(at::aten::conv_transpose2d_backward),
+           {grad_output, input, weight},
+           [&]() {
+             return NodeOutputShape(grad_output, input, weight, stride,
+                                    padding);
+           },
+           /*num_outputs=*/3, xla::util::MHash(stride, padding)),
       stride_(std::move(stride)),
       padding_(std::move(padding)) {}
 

--- a/torch_xla/csrc/ops/cumprod.cpp
+++ b/torch_xla/csrc/ops/cumprod.cpp
@@ -37,10 +37,10 @@ xla::Shape NodeOutputShape(const Value& input,
 
 CumProd::CumProd(const Value& input, xla::int64 dim,
                  c10::optional<at::ScalarType> dtype)
-    : Node(
-          ir::OpKind(at::aten::cumprod), {input},
-          [&]() { return NodeOutputShape(input, dtype); },
-          /*num_outputs=*/1, xla::util::MHash(dim, OptionalOr<int>(dtype, -1))),
+    : Node(ir::OpKind(at::aten::cumprod), {input},
+           [&]() { return NodeOutputShape(input, dtype); },
+           /*num_outputs=*/1,
+           xla::util::MHash(dim, OptionalOr<int>(dtype, -1))),
       dim_(dim),
       dtype_(dtype) {}
 

--- a/torch_xla/csrc/ops/cumsum.cpp
+++ b/torch_xla/csrc/ops/cumsum.cpp
@@ -37,10 +37,10 @@ xla::Shape NodeOutputShape(const Value& input,
 
 CumSum::CumSum(const Value& input, xla::int64 dim,
                c10::optional<at::ScalarType> dtype)
-    : Node(
-          ir::OpKind(at::aten::cumsum), {input},
-          [&]() { return NodeOutputShape(input, dtype); },
-          /*num_outputs=*/1, xla::util::MHash(dim, OptionalOr<int>(dtype, -1))),
+    : Node(ir::OpKind(at::aten::cumsum), {input},
+           [&]() { return NodeOutputShape(input, dtype); },
+           /*num_outputs=*/1,
+           xla::util::MHash(dim, OptionalOr<int>(dtype, -1))),
       dim_(dim),
       dtype_(dtype) {}
 

--- a/torch_xla/csrc/ops/diagonal.cpp
+++ b/torch_xla/csrc/ops/diagonal.cpp
@@ -28,10 +28,9 @@ xla::Shape NodeOutputShape(const Value& input, xla::int64 offset,
 
 Diagonal::Diagonal(const Value& input, xla::int64 offset, xla::int64 dim1,
                    xla::int64 dim2)
-    : Node(
-          ir::OpKind(at::aten::diagonal), {input},
-          [&]() { return NodeOutputShape(input, offset, dim1, dim2); },
-          /*num_outputs=*/1, xla::util::MHash(offset, dim1, dim2)),
+    : Node(ir::OpKind(at::aten::diagonal), {input},
+           [&]() { return NodeOutputShape(input, offset, dim1, dim2); },
+           /*num_outputs=*/1, xla::util::MHash(offset, dim1, dim2)),
       offset_(offset),
       dim1_(dim1),
       dim2_(dim2) {}

--- a/torch_xla/csrc/ops/einsum.cpp
+++ b/torch_xla/csrc/ops/einsum.cpp
@@ -34,10 +34,9 @@ xla::Shape NodeOutputShape(tensorflow::gtl::ArraySlice<const ir::Value> values,
 
 Einsum::Einsum(const std::string& equation,
                tensorflow::gtl::ArraySlice<const ir::Value> values)
-    : Node(
-          ir::OpKind(at::aten::einsum), values,
-          [&]() { return NodeOutputShape(values, equation); },
-          /*num_outputs=*/1, xla::util::MHash(equation)),
+    : Node(ir::OpKind(at::aten::einsum), values,
+           [&]() { return NodeOutputShape(values, equation); },
+           /*num_outputs=*/1, xla::util::MHash(equation)),
       equation_(equation) {}
 
 NodePtr Einsum::Clone(OpList operands) const {

--- a/torch_xla/csrc/ops/expand.cpp
+++ b/torch_xla/csrc/ops/expand.cpp
@@ -23,10 +23,9 @@ xla::Shape NodeOutputShape(const Value& input,
 }  // namespace
 
 Expand::Expand(const Value& input, std::vector<xla::int64> size)
-    : Node(
-          ir::OpKind(at::aten::expand), {input},
-          [&]() { return NodeOutputShape(input, size); },
-          /*num_outputs=*/1, xla::util::MHash(size)),
+    : Node(ir::OpKind(at::aten::expand), {input},
+           [&]() { return NodeOutputShape(input, size); },
+           /*num_outputs=*/1, xla::util::MHash(size)),
       size_(std::move(size)) {}
 
 NodePtr Expand::Clone(OpList operands) const {

--- a/torch_xla/csrc/ops/gather.cpp
+++ b/torch_xla/csrc/ops/gather.cpp
@@ -22,10 +22,9 @@ xla::Shape NodeOutputShape(const Value& input, const Value& index,
 }  // namespace
 
 Gather::Gather(const Value& input, xla::int64 dim, const Value& index)
-    : Node(
-          ir::OpKind(at::aten::gather), {input, index},
-          [&]() { return NodeOutputShape(input, index, dim); },
-          /*num_outputs=*/1, xla::util::MHash(dim)),
+    : Node(ir::OpKind(at::aten::gather), {input, index},
+           [&]() { return NodeOutputShape(input, index, dim); },
+           /*num_outputs=*/1, xla::util::MHash(dim)),
       dim_(dim) {}
 
 NodePtr Gather::Clone(OpList operands) const {

--- a/torch_xla/csrc/ops/generic_slice.cpp
+++ b/torch_xla/csrc/ops/generic_slice.cpp
@@ -28,10 +28,9 @@ GenericSlice::GenericSlice(
     const Value& input,
     tensorflow::gtl::ArraySlice<const xla::int64> base_indices,
     tensorflow::gtl::ArraySlice<const xla::int64> sizes)
-    : Node(
-          xla_generic_slice, {input},
-          [&]() { return NodeOutputShape(input, base_indices, sizes); },
-          /*num_outputs=*/1, xla::util::MHash(base_indices, sizes)),
+    : Node(xla_generic_slice, {input},
+           [&]() { return NodeOutputShape(input, base_indices, sizes); },
+           /*num_outputs=*/1, xla::util::MHash(base_indices, sizes)),
       base_indices_(base_indices.begin(), base_indices.end()),
       sizes_(sizes.begin(), sizes.end()) {}
 

--- a/torch_xla/csrc/ops/index_get.cpp
+++ b/torch_xla/csrc/ops/index_get.cpp
@@ -26,10 +26,9 @@ xla::Shape NodeOutputShape(const Value& base, const Value& indices,
 
 IndexGet::IndexGet(const ir::Value& base, const ir::Value& indices,
                    xla::int64 start_dim)
-    : Node(
-          OpKind(at::aten::index), {base, indices},
-          [&]() { return NodeOutputShape(base, indices, start_dim); },
-          /*num_outputs=*/1, xla::util::MHash(start_dim)),
+    : Node(OpKind(at::aten::index), {base, indices},
+           [&]() { return NodeOutputShape(base, indices, start_dim); },
+           /*num_outputs=*/1, xla::util::MHash(start_dim)),
       start_dim_(start_dim) {}
 
 std::string IndexGet::ToString() const {

--- a/torch_xla/csrc/ops/index_select.cpp
+++ b/torch_xla/csrc/ops/index_select.cpp
@@ -24,10 +24,9 @@ xla::Shape NodeOutputShape(const Value& input, const Value& index,
 }  // namespace
 
 IndexSelect::IndexSelect(const Value& input, xla::int64 dim, const Value& index)
-    : Node(
-          ir::OpKind(at::aten::index_select), {input, index},
-          [&]() { return NodeOutputShape(input, index, dim); },
-          /*num_outputs=*/1, xla::util::MHash(dim)),
+    : Node(ir::OpKind(at::aten::index_select), {input, index},
+           [&]() { return NodeOutputShape(input, index, dim); },
+           /*num_outputs=*/1, xla::util::MHash(dim)),
       dim_(dim) {}
 
 NodePtr IndexSelect::Clone(OpList operands) const {

--- a/torch_xla/csrc/ops/infer_output_shape.cpp
+++ b/torch_xla/csrc/ops/infer_output_shape.cpp
@@ -1,4 +1,5 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
+
 #include "torch_xla/csrc/helpers.h"
 
 namespace torch_xla {

--- a/torch_xla/csrc/ops/kth_value.cpp
+++ b/torch_xla/csrc/ops/kth_value.cpp
@@ -25,10 +25,9 @@ xla::Shape NodeOutputShape(const Value& input, xla::int64 k, xla::int64 dim,
 
 KthValue::KthValue(const Value& input, xla::int64 k, xla::int64 dim,
                    bool keepdim)
-    : Node(
-          ir::OpKind(at::aten::kthvalue), {input},
-          [&]() { return NodeOutputShape(input, k, dim, keepdim); },
-          /*num_outputs=*/2, xla::util::MHash(k, dim, keepdim)),
+    : Node(ir::OpKind(at::aten::kthvalue), {input},
+           [&]() { return NodeOutputShape(input, k, dim, keepdim); },
+           /*num_outputs=*/2, xla::util::MHash(k, dim, keepdim)),
       k_(k),
       dim_(dim),
       keepdim_(keepdim) {}

--- a/torch_xla/csrc/ops/log_softmax.cpp
+++ b/torch_xla/csrc/ops/log_softmax.cpp
@@ -31,10 +31,10 @@ xla::Shape NodeOutputShape(const Value& input,
 
 LogSoftmax::LogSoftmax(const Value& input, xla::int64 dim,
                        c10::optional<at::ScalarType> dtype)
-    : Node(
-          ir::OpKind(at::aten::log_softmax), {input},
-          [&]() { return NodeOutputShape(input, dtype); },
-          /*num_outputs=*/1, xla::util::MHash(dim, OptionalOr<int>(dtype, -1))),
+    : Node(ir::OpKind(at::aten::log_softmax), {input},
+           [&]() { return NodeOutputShape(input, dtype); },
+           /*num_outputs=*/1,
+           xla::util::MHash(dim, OptionalOr<int>(dtype, -1))),
       dim_(dim),
       dtype_(dtype) {}
 

--- a/torch_xla/csrc/ops/max_in_dim.cpp
+++ b/torch_xla/csrc/ops/max_in_dim.cpp
@@ -24,10 +24,9 @@ xla::Shape NodeOutputShape(const Value& input, xla::int64 dim, bool keepdim) {
 }  // namespace
 
 MaxInDim::MaxInDim(const Value& input, xla::int64 dim, bool keepdim)
-    : Node(
-          ir::OpKind(at::aten::max), {input},
-          [&]() { return NodeOutputShape(input, dim, keepdim); },
-          /*num_outputs=*/2, xla::util::MHash(dim, keepdim)),
+    : Node(ir::OpKind(at::aten::max), {input},
+           [&]() { return NodeOutputShape(input, dim, keepdim); },
+           /*num_outputs=*/2, xla::util::MHash(dim, keepdim)),
       dim_(dim),
       keepdim_(keepdim) {}
 

--- a/torch_xla/csrc/ops/max_pool_nd.cpp
+++ b/torch_xla/csrc/ops/max_pool_nd.cpp
@@ -48,15 +48,14 @@ MaxPoolNd::MaxPoolNd(const Value& input, xla::int64 spatial_dim_count,
                      std::vector<xla::int64> kernel_size,
                      std::vector<xla::int64> stride,
                      std::vector<xla::int64> padding, bool ceil_mode)
-    : Node(
-          ir::OpKind(MaxPoolNdSymbol(spatial_dim_count)), {input},
-          [&]() {
-            return NodeOutputShape(input, spatial_dim_count, kernel_size,
-                                   stride, padding, ceil_mode);
-          },
-          /*num_outputs=*/1,
-          xla::util::MHash(spatial_dim_count, kernel_size, stride, padding,
-                           ceil_mode)),
+    : Node(ir::OpKind(MaxPoolNdSymbol(spatial_dim_count)), {input},
+           [&]() {
+             return NodeOutputShape(input, spatial_dim_count, kernel_size,
+                                    stride, padding, ceil_mode);
+           },
+           /*num_outputs=*/1,
+           xla::util::MHash(spatial_dim_count, kernel_size, stride, padding,
+                            ceil_mode)),
       spatial_dim_count_(spatial_dim_count),
       kernel_size_(std::move(kernel_size)),
       stride_(std::move(stride)),

--- a/torch_xla/csrc/ops/max_pool_nd_backward.cpp
+++ b/torch_xla/csrc/ops/max_pool_nd_backward.cpp
@@ -46,16 +46,15 @@ MaxPoolNdBackward::MaxPoolNdBackward(
     const Value& grad_output, const Value& input, xla::int64 spatial_dim_count,
     std::vector<xla::int64> kernel_size, std::vector<xla::int64> stride,
     std::vector<xla::int64> padding, bool ceil_mode)
-    : Node(
-          ir::OpKind(MaxPoolNdBackwardSymbol(spatial_dim_count)),
-          {grad_output, input},
-          [&]() {
-            return NodeOutputShape(grad_output, input, spatial_dim_count,
-                                   kernel_size, stride, padding, ceil_mode);
-          },
-          /*num_outputs=*/1,
-          xla::util::MHash(spatial_dim_count, kernel_size, stride, padding,
-                           ceil_mode)),
+    : Node(ir::OpKind(MaxPoolNdBackwardSymbol(spatial_dim_count)),
+           {grad_output, input},
+           [&]() {
+             return NodeOutputShape(grad_output, input, spatial_dim_count,
+                                    kernel_size, stride, padding, ceil_mode);
+           },
+           /*num_outputs=*/1,
+           xla::util::MHash(spatial_dim_count, kernel_size, stride, padding,
+                            ceil_mode)),
       spatial_dim_count_(spatial_dim_count),
       kernel_size_(std::move(kernel_size)),
       stride_(std::move(stride)),

--- a/torch_xla/csrc/ops/mean.cpp
+++ b/torch_xla/csrc/ops/mean.cpp
@@ -40,15 +40,14 @@ xla::Shape NodeOutputShape(const Value& input,
 
 Mean::Mean(const Value& input, std::vector<xla::int64> dimensions,
            bool keep_reduced_dimensions, c10::optional<at::ScalarType> dtype)
-    : Node(
-          ir::OpKind(at::aten::mean), {input},
-          [&]() {
-            return NodeOutputShape(input, dimensions, keep_reduced_dimensions,
-                                   dtype);
-          },
-          /*num_outputs=*/1,
-          xla::util::MHash(dimensions, keep_reduced_dimensions,
-                           OptionalOr<int>(dtype, -1))),
+    : Node(ir::OpKind(at::aten::mean), {input},
+           [&]() {
+             return NodeOutputShape(input, dimensions, keep_reduced_dimensions,
+                                    dtype);
+           },
+           /*num_outputs=*/1,
+           xla::util::MHash(dimensions, keep_reduced_dimensions,
+                            OptionalOr<int>(dtype, -1))),
       dimensions_(std::move(dimensions)),
       keep_reduced_dimensions_(keep_reduced_dimensions),
       dtype_(dtype) {}

--- a/torch_xla/csrc/ops/min_in_dim.cpp
+++ b/torch_xla/csrc/ops/min_in_dim.cpp
@@ -24,10 +24,9 @@ xla::Shape NodeOutputShape(const Value& input, xla::int64 dim, bool keepdim) {
 }  // namespace
 
 MinInDim::MinInDim(const Value& input, xla::int64 dim, bool keepdim)
-    : Node(
-          ir::OpKind(at::aten::min), {input},
-          [&]() { return NodeOutputShape(input, dim, keepdim); },
-          /*num_outputs=*/2, xla::util::MHash(dim, keepdim)),
+    : Node(ir::OpKind(at::aten::min), {input},
+           [&]() { return NodeOutputShape(input, dim, keepdim); },
+           /*num_outputs=*/2, xla::util::MHash(dim, keepdim)),
       dim_(dim),
       keepdim_(keepdim) {}
 

--- a/torch_xla/csrc/ops/native_batch_norm_backward.cpp
+++ b/torch_xla/csrc/ops/native_batch_norm_backward.cpp
@@ -33,14 +33,13 @@ xla::Shape NodeOutputShape(const Value& grad_out, const Value& input,
 NativeBatchNormBackward::NativeBatchNormBackward(
     const Value& grad_out, const Value& input, const Value& weight,
     const Value& save_mean, const Value& save_invstd, double eps)
-    : Node(
-          ir::OpKind(at::aten::native_batch_norm_backward),
-          {grad_out, input, weight, save_mean, save_invstd},
-          [&]() {
-            return NodeOutputShape(grad_out, input, weight, save_mean,
-                                   save_invstd);
-          },
-          /*num_outputs=*/3, xla::util::MHash(eps)),
+    : Node(ir::OpKind(at::aten::native_batch_norm_backward),
+           {grad_out, input, weight, save_mean, save_invstd},
+           [&]() {
+             return NodeOutputShape(grad_out, input, weight, save_mean,
+                                    save_invstd);
+           },
+           /*num_outputs=*/3, xla::util::MHash(eps)),
       eps_(eps) {}
 
 NodePtr NativeBatchNormBackward::Clone(OpList operands) const {

--- a/torch_xla/csrc/ops/native_batch_norm_forward.cpp
+++ b/torch_xla/csrc/ops/native_batch_norm_forward.cpp
@@ -32,10 +32,9 @@ NativeBatchNormForward::NativeBatchNormForward(const Value& input,
                                                const Value& weight,
                                                const Value& bias,
                                                double momentum, double eps)
-    : Node(
-          ir::OpKind(at::aten::native_batch_norm), {input, weight, bias},
-          [&]() { return NodeOutputShape(input, weight, bias); },
-          /*num_outputs=*/3, xla::util::MHash(momentum, eps)),
+    : Node(ir::OpKind(at::aten::native_batch_norm), {input, weight, bias},
+           [&]() { return NodeOutputShape(input, weight, bias); },
+           /*num_outputs=*/3, xla::util::MHash(momentum, eps)),
       momentum_(momentum),
       eps_(eps) {}
 

--- a/torch_xla/csrc/ops/permute.cpp
+++ b/torch_xla/csrc/ops/permute.cpp
@@ -24,10 +24,9 @@ xla::Shape NodeOutputShape(const Value& input,
 }  // namespace
 
 Permute::Permute(const Value& input, std::vector<xla::int64> dims)
-    : Node(
-          ir::OpKind(at::aten::permute), {input},
-          [&]() { return NodeOutputShape(input, dims); },
-          /*num_outputs=*/1, xla::util::MHash(dims)),
+    : Node(ir::OpKind(at::aten::permute), {input},
+           [&]() { return NodeOutputShape(input, dims); },
+           /*num_outputs=*/1, xla::util::MHash(dims)),
       dims_(std::move(dims)) {}
 
 NodePtr Permute::Clone(OpList operands) const {

--- a/torch_xla/csrc/ops/prod.cpp
+++ b/torch_xla/csrc/ops/prod.cpp
@@ -46,15 +46,14 @@ xla::Shape NodeOutputShape(const Value& input,
 
 Prod::Prod(const Value& input, std::vector<xla::int64> dimensions,
            bool keep_reduced_dimensions, c10::optional<at::ScalarType> dtype)
-    : Node(
-          ir::OpKind(at::aten::prod), {input},
-          [&]() {
-            return NodeOutputShape(input, dimensions, keep_reduced_dimensions,
-                                   dtype);
-          },
-          /*num_outputs=*/1,
-          xla::util::MHash(dimensions, keep_reduced_dimensions,
-                           OptionalOr<int>(dtype, -1))),
+    : Node(ir::OpKind(at::aten::prod), {input},
+           [&]() {
+             return NodeOutputShape(input, dimensions, keep_reduced_dimensions,
+                                    dtype);
+           },
+           /*num_outputs=*/1,
+           xla::util::MHash(dimensions, keep_reduced_dimensions,
+                            OptionalOr<int>(dtype, -1))),
       dimensions_(std::move(dimensions)),
       keep_reduced_dimensions_(keep_reduced_dimensions),
       dtype_(dtype) {}

--- a/torch_xla/csrc/ops/qr.cpp
+++ b/torch_xla/csrc/ops/qr.cpp
@@ -47,10 +47,9 @@ xla::Shape NodeOutputShape(const Value& input, bool some) {
 }  // namespace
 
 QR::QR(const Value& input, bool some)
-    : Node(
-          ir::OpKind(at::aten::qr), {input},
-          [&]() { return NodeOutputShape(input, some); },
-          /*num_outputs=*/2, xla::util::MHash(some)),
+    : Node(ir::OpKind(at::aten::qr), {input},
+           [&]() { return NodeOutputShape(input, some); },
+           /*num_outputs=*/2, xla::util::MHash(some)),
       some_(some) {}
 
 NodePtr QR::Clone(OpList operands) const {

--- a/torch_xla/csrc/ops/repeat.cpp
+++ b/torch_xla/csrc/ops/repeat.cpp
@@ -25,10 +25,9 @@ xla::Shape NodeOutputShape(
 }  // namespace
 
 Repeat::Repeat(const Value& input, std::vector<xla::int64> repeats)
-    : Node(
-          ir::OpKind(at::aten::repeat), {input},
-          [&]() { return NodeOutputShape(input, repeats); },
-          /*num_outputs=*/1, xla::util::MHash(repeats)),
+    : Node(ir::OpKind(at::aten::repeat), {input},
+           [&]() { return NodeOutputShape(input, repeats); },
+           /*num_outputs=*/1, xla::util::MHash(repeats)),
       repeats_(std::move(repeats)) {}
 
 NodePtr Repeat::Clone(OpList operands) const {

--- a/torch_xla/csrc/ops/resize.cpp
+++ b/torch_xla/csrc/ops/resize.cpp
@@ -19,10 +19,9 @@ xla::Shape NodeOutputShape(const Value& input,
 }  // namespace
 
 Resize::Resize(const Value& input, std::vector<xla::int64> size)
-    : Node(
-          ir::OpKind(at::aten::resize_), {input},
-          [&]() { return NodeOutputShape(input, size); },
-          /*num_outputs=*/1, xla::util::MHash(size)),
+    : Node(ir::OpKind(at::aten::resize_), {input},
+           [&]() { return NodeOutputShape(input, size); },
+           /*num_outputs=*/1, xla::util::MHash(size)),
       size_(std::move(size)) {}
 
 NodePtr Resize::Clone(OpList operands) const {

--- a/torch_xla/csrc/ops/select.cpp
+++ b/torch_xla/csrc/ops/select.cpp
@@ -22,12 +22,11 @@ xla::int64 GetStride(xla::int64 start, xla::int64 end, xla::int64 stride) {
 
 Select::Select(const Value& input, xla::int64 dim, xla::int64 start,
                xla::int64 end, xla::int64 stride)
-    : Node(
-          xla_select, {input},
-          [&]() {
-            return MakeSelectShape(input.shape(), dim, start, end, stride);
-          },
-          /*num_outputs=*/1, xla::util::MHash(dim, start, end, stride)),
+    : Node(xla_select, {input},
+           [&]() {
+             return MakeSelectShape(input.shape(), dim, start, end, stride);
+           },
+           /*num_outputs=*/1, xla::util::MHash(dim, start, end, stride)),
       dim_(dim),
       start_(start),
       end_(end),

--- a/torch_xla/csrc/ops/softmax.cpp
+++ b/torch_xla/csrc/ops/softmax.cpp
@@ -31,10 +31,10 @@ xla::Shape NodeOutputShape(const Value& input,
 
 Softmax::Softmax(const Value& input, xla::int64 dim,
                  c10::optional<at::ScalarType> dtype)
-    : Node(
-          ir::OpKind(at::aten::softmax), {input},
-          [&]() { return NodeOutputShape(input, dtype); },
-          /*num_outputs=*/1, xla::util::MHash(dim, OptionalOr<int>(dtype, -1))),
+    : Node(ir::OpKind(at::aten::softmax), {input},
+           [&]() { return NodeOutputShape(input, dtype); },
+           /*num_outputs=*/1,
+           xla::util::MHash(dim, OptionalOr<int>(dtype, -1))),
       dim_(dim),
       dtype_(dtype) {}
 

--- a/torch_xla/csrc/ops/split.cpp
+++ b/torch_xla/csrc/ops/split.cpp
@@ -28,11 +28,10 @@ xla::Shape NodeOutputShape(const Value& input,
 
 Split::Split(const Value& input, std::vector<xla::int64> split_sizes,
              xla::int64 dim)
-    : Node(
-          ir::OpKind(at::aten::split), {input},
-          [&]() { return NodeOutputShape(input, split_sizes, dim); },
-          ComputeSplitCount(input.shape().dimensions(dim), split_sizes),
-          xla::util::MHash(split_sizes, dim)),
+    : Node(ir::OpKind(at::aten::split), {input},
+           [&]() { return NodeOutputShape(input, split_sizes, dim); },
+           ComputeSplitCount(input.shape().dimensions(dim), split_sizes),
+           xla::util::MHash(split_sizes, dim)),
       split_sizes_(std::move(split_sizes)),
       dim_(dim) {}
 

--- a/torch_xla/csrc/ops/squeeze.cpp
+++ b/torch_xla/csrc/ops/squeeze.cpp
@@ -32,10 +32,9 @@ xla::Shape NodeOutputShape(const Value& input, int dim) {
 }  // namespace
 
 Squeeze::Squeeze(const Value& input, int dim)
-    : Node(
-          ir::OpKind(at::aten::squeeze), {input},
-          [&]() { return NodeOutputShape(input, dim); },
-          /*num_outputs=*/1, xla::util::MHash(dim)),
+    : Node(ir::OpKind(at::aten::squeeze), {input},
+           [&]() { return NodeOutputShape(input, dim); },
+           /*num_outputs=*/1, xla::util::MHash(dim)),
       dim_(dim) {}
 
 NodePtr Squeeze::Clone(OpList operands) const {

--- a/torch_xla/csrc/ops/stack.cpp
+++ b/torch_xla/csrc/ops/stack.cpp
@@ -28,10 +28,9 @@ xla::Shape NodeOutputShape(tensorflow::gtl::ArraySlice<const ir::Value> values,
 
 Stack::Stack(tensorflow::gtl::ArraySlice<const ir::Value> values,
              xla::int64 dim)
-    : Node(
-          ir::OpKind(at::aten::stack), values,
-          [&]() { return NodeOutputShape(values, dim); },
-          /*num_outputs=*/1, xla::util::MHash(dim)),
+    : Node(ir::OpKind(at::aten::stack), values,
+           [&]() { return NodeOutputShape(values, dim); },
+           /*num_outputs=*/1, xla::util::MHash(dim)),
       dim_(dim) {}
 
 NodePtr Stack::Clone(OpList operands) const {

--- a/torch_xla/csrc/ops/sum.cpp
+++ b/torch_xla/csrc/ops/sum.cpp
@@ -39,15 +39,14 @@ xla::Shape NodeOutputShape(
 
 Sum::Sum(const Value& input, std::vector<xla::int64> dimensions,
          bool keep_reduced_dimensions, c10::optional<at::ScalarType> dtype)
-    : Node(
-          ir::OpKind(at::aten::sum), {input},
-          [&]() {
-            return NodeOutputShape(input, dimensions, keep_reduced_dimensions,
-                                   dtype);
-          },
-          /*num_outputs=*/1,
-          xla::util::MHash(dimensions, keep_reduced_dimensions,
-                           OptionalOr<int>(dtype, -1))),
+    : Node(ir::OpKind(at::aten::sum), {input},
+           [&]() {
+             return NodeOutputShape(input, dimensions, keep_reduced_dimensions,
+                                    dtype);
+           },
+           /*num_outputs=*/1,
+           xla::util::MHash(dimensions, keep_reduced_dimensions,
+                            OptionalOr<int>(dtype, -1))),
       dimensions_(std::move(dimensions)),
       keep_reduced_dimensions_(keep_reduced_dimensions),
       dtype_(dtype) {}

--- a/torch_xla/csrc/ops/svd.cpp
+++ b/torch_xla/csrc/ops/svd.cpp
@@ -68,10 +68,9 @@ xla::Shape NodeOutputShape(const Value& input, bool some, bool compute_uv) {
 }  // namespace
 
 SVD::SVD(const Value& input, bool some, bool compute_uv)
-    : Node(
-          ir::OpKind(at::aten::svd), {input},
-          [&]() { return NodeOutputShape(input, some, compute_uv); },
-          /*num_outputs=*/3, xla::util::MHash(some, compute_uv)),
+    : Node(ir::OpKind(at::aten::svd), {input},
+           [&]() { return NodeOutputShape(input, some, compute_uv); },
+           /*num_outputs=*/3, xla::util::MHash(some, compute_uv)),
       some_(some),
       compute_uv_(compute_uv) {}
 

--- a/torch_xla/csrc/ops/symeig.cpp
+++ b/torch_xla/csrc/ops/symeig.cpp
@@ -39,10 +39,9 @@ xla::Shape NodeOutputShape(const Value& input, bool eigenvectors, bool lower) {
 }  // namespace
 
 SymEig::SymEig(const Value& input, bool eigenvectors, bool lower)
-    : Node(
-          ir::OpKind(at::aten::symeig), {input},
-          [&]() { return NodeOutputShape(input, eigenvectors, lower); },
-          /*num_outputs=*/2, xla::util::MHash(eigenvectors, lower)),
+    : Node(ir::OpKind(at::aten::symeig), {input},
+           [&]() { return NodeOutputShape(input, eigenvectors, lower); },
+           /*num_outputs=*/2, xla::util::MHash(eigenvectors, lower)),
       eigenvectors_(eigenvectors),
       lower_(lower) {}
 

--- a/torch_xla/csrc/ops/topk.cpp
+++ b/torch_xla/csrc/ops/topk.cpp
@@ -25,10 +25,9 @@ xla::Shape NodeOutputShape(const Value& input, xla::int64 k, xla::int64 dim,
 
 TopK::TopK(const Value& input, xla::int64 k, xla::int64 dim, bool largest,
            bool sorted)
-    : Node(
-          ir::OpKind(at::aten::topk), {input},
-          [&]() { return NodeOutputShape(input, k, dim, largest, sorted); },
-          /*num_outputs=*/2, xla::util::MHash(k, dim, largest, sorted)),
+    : Node(ir::OpKind(at::aten::topk), {input},
+           [&]() { return NodeOutputShape(input, k, dim, largest, sorted); },
+           /*num_outputs=*/2, xla::util::MHash(k, dim, largest, sorted)),
       k_(k),
       dim_(dim),
       largest_(largest),

--- a/torch_xla/csrc/ops/triangular_solve.cpp
+++ b/torch_xla/csrc/ops/triangular_solve.cpp
@@ -78,11 +78,10 @@ xla::Shape NodeOutputShape(const Value& rhs, const Value& lhs) {
 TriangularSolve::TriangularSolve(const Value& rhs, const Value& lhs,
                                  bool left_side, bool lower, bool transpose,
                                  bool unit_diagonal)
-    : Node(
-          ir::OpKind(at::aten::triangular_solve), {rhs, lhs},
-          [&]() { return NodeOutputShape(rhs, lhs); },
-          /*num_outputs=*/2,
-          xla::util::MHash(left_side, lower, transpose, unit_diagonal)),
+    : Node(ir::OpKind(at::aten::triangular_solve), {rhs, lhs},
+           [&]() { return NodeOutputShape(rhs, lhs); },
+           /*num_outputs=*/2,
+           xla::util::MHash(left_side, lower, transpose, unit_diagonal)),
       left_side_(left_side),
       lower_(lower),
       transpose_(transpose),

--- a/torch_xla/csrc/ops/unsqueeze.cpp
+++ b/torch_xla/csrc/ops/unsqueeze.cpp
@@ -18,10 +18,9 @@ xla::Shape NodeOutputShape(const Value& input, int dim) {
 }  // namespace
 
 Unsqueeze::Unsqueeze(const Value& input, int dim)
-    : Node(
-          ir::OpKind(at::aten::unsqueeze), {input},
-          [&]() { return NodeOutputShape(input, dim); },
-          /*num_outputs=*/1, xla::util::MHash(dim)),
+    : Node(ir::OpKind(at::aten::unsqueeze), {input},
+           [&]() { return NodeOutputShape(input, dim); },
+           /*num_outputs=*/1, xla::util::MHash(dim)),
       dim_(dim) {}
 
 NodePtr Unsqueeze::Clone(OpList operands) const {

--- a/torch_xla/csrc/ops/update_slice.cpp
+++ b/torch_xla/csrc/ops/update_slice.cpp
@@ -28,10 +28,9 @@ xla::Shape NodeOutputShape(
 UpdateSlice::UpdateSlice(
     const Value& input, const Value& source,
     tensorflow::gtl::ArraySlice<const xla::int64> base_indices)
-    : Node(
-          xla_update_slice, {input, source},
-          [&]() { return NodeOutputShape(input, source, base_indices); },
-          /*num_outputs=*/1, xla::util::MHash(base_indices)),
+    : Node(xla_update_slice, {input, source},
+           [&]() { return NodeOutputShape(input, source, base_indices); },
+           /*num_outputs=*/1, xla::util::MHash(base_indices)),
       base_indices_(base_indices.begin(), base_indices.end()) {}
 
 NodePtr UpdateSlice::Clone(OpList operands) const {

--- a/torch_xla/csrc/ops/view.cpp
+++ b/torch_xla/csrc/ops/view.cpp
@@ -28,10 +28,9 @@ xla::Shape NodeOutputShape(
 }  // namespace
 
 View::View(const Value& input, std::vector<xla::int64> output_size)
-    : Node(
-          ir::OpKind(at::aten::view), {input},
-          [&]() { return NodeOutputShape(input, output_size); },
-          /*num_outputs=*/1, xla::util::MHash(output_size)),
+    : Node(ir::OpKind(at::aten::view), {input},
+           [&]() { return NodeOutputShape(input, output_size); },
+           /*num_outputs=*/1, xla::util::MHash(output_size)),
       output_size_(std::move(output_size)) {}
 
 XlaOpVector View::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/python_util.h
+++ b/torch_xla/csrc/python_util.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <c10/util/Optional.h>
+
 #include <iostream>
 #include <string>
 #include <vector>
-
-#include <c10/util/Optional.h>
 
 namespace torch_xla {
 

--- a/torch_xla/csrc/softmax_builder.cpp
+++ b/torch_xla/csrc/softmax_builder.cpp
@@ -1,4 +1,5 @@
 #include "torch_xla/csrc/softmax_builder.h"
+
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "torch_xla/csrc/helpers.h"
 


### PR DESCRIPTION
Based on a `.clang-format` Davide sent me, I commented  out a few configs which are only available in `clang-format-9`. This config currently runs fine with my `clang-format-7` in my environment. And I feel it's also more friendly to our OSS contributors in the future. :D
I put the following lines in my `.zshrc` to format the whole folder. Running `formatxla` will pick up this `.clang-format` config automatically. 

```
 formatxla() {
   find -name '*.cpp' -o -name '*.h' | xargs clang-format-7 -i -style=file
 }
``` 
In general I'm happy to use whatever style config as long as it's available in https://releases.llvm.org/7.0.0/tools/clang/docs/ClangFormatStyleOptions.html. :D 