### PR TITLE
The BN backward might miss running_{mean,var} data, and since we are …

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2002,7 +2002,6 @@ AtenXlaType::native_batch_norm_backward(
   auto gradients = XLATensor::native_batch_norm_backward(
       bridge::GetXlaTensor(grad_out), bridge::GetXlaTensor(input),
       bridge::GetOrCreateXlaTensor(weight, device),
-      bridge::GetXlaTensor(running_mean), bridge::GetXlaTensor(running_var),
       bridge::GetXlaTensor(save_mean), bridge::GetXlaTensor(save_invstd), train,
       eps);
   at::Tensor undefined;

--- a/torch_xla/csrc/batch_norm.cpp
+++ b/torch_xla/csrc/batch_norm.cpp
@@ -48,11 +48,12 @@ xla::XlaOp BuildBatchNormInference(
                                  1);
 }
 
-BatchNormGrads BuildBatchNormBackward(
-    const xla::XlaOp& grad, const xla::XlaOp& input, const xla::XlaOp& weight,
-    const xla::XlaOp& running_mean, const xla::XlaOp& running_var,
-    const xla::XlaOp& save_mean, const xla::XlaOp& save_invstd, bool training,
-    float eps_value) {
+BatchNormGrads BuildBatchNormBackward(const xla::XlaOp& grad,
+                                      const xla::XlaOp& input,
+                                      const xla::XlaOp& weight,
+                                      const xla::XlaOp& save_mean,
+                                      const xla::XlaOp& save_invstd,
+                                      bool training, float eps_value) {
   xla::XlaOp grads = xla::BatchNormGrad(input, weight, save_mean,
                                         VarianceRecover(save_invstd, eps_value),
                                         grad, eps_value, 1);

--- a/torch_xla/csrc/batch_norm.h
+++ b/torch_xla/csrc/batch_norm.h
@@ -28,10 +28,11 @@ xla::XlaOp BuildBatchNormInference(const xla::XlaOp& input,
                                    const xla::XlaOp& mean,
                                    const xla::XlaOp& variance, float eps_value);
 
-BatchNormGrads BuildBatchNormBackward(
-    const xla::XlaOp& grad, const xla::XlaOp& input, const xla::XlaOp& weight,
-    const xla::XlaOp& running_mean, const xla::XlaOp& running_var,
-    const xla::XlaOp& save_mean, const xla::XlaOp& save_invstd,
-    bool training, float eps_value);
+BatchNormGrads BuildBatchNormBackward(const xla::XlaOp& grad,
+                                      const xla::XlaOp& input,
+                                      const xla::XlaOp& weight,
+                                      const xla::XlaOp& save_mean,
+                                      const xla::XlaOp& save_invstd,
+                                      bool training, float eps_value);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/native_batch_norm_backward.cpp
+++ b/torch_xla/csrc/ops/native_batch_norm_backward.cpp
@@ -12,60 +12,53 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& grad_out, const Value& input,
-                           const Value& weight, const Value& running_mean,
-                           const Value& running_var, const Value& save_mean,
+                           const Value& weight, const Value& save_mean,
                            const Value& save_invstd, bool training) {
   auto lower_for_shape_fn =
       [&](tensorflow::gtl::ArraySlice<const xla::XlaOp> operands)
       -> xla::XlaOp {
-    BatchNormGrads xla_outputs = BuildBatchNormBackward(
-        operands[0], operands[1], operands[2], operands[3], operands[4],
-        operands[5], operands[6], training, 0.5);
+    BatchNormGrads xla_outputs =
+        BuildBatchNormBackward(operands[0], operands[1], operands[2],
+                               operands[3], operands[4], training, 0.5);
     return xla::Tuple(operands[0].builder(),
                       {xla_outputs.grad_input, xla_outputs.grad_weight,
                        xla_outputs.grad_bias});
   };
-  return InferOutputShape(
-      {grad_out.shape(), input.shape(), weight.shape(), running_mean.shape(),
-       running_var.shape(), save_mean.shape(), save_invstd.shape()},
-      lower_for_shape_fn);
+  return InferOutputShape({grad_out.shape(), input.shape(), weight.shape(),
+                           save_mean.shape(), save_invstd.shape()},
+                          lower_for_shape_fn);
 }
 
 }  // namespace
 
 NativeBatchNormBackward::NativeBatchNormBackward(
     const Value& grad_out, const Value& input, const Value& weight,
-    const Value& running_mean, const Value& running_var, const Value& save_mean,
-    const Value& save_invstd, bool training, double eps)
-    : Node(ir::OpKind(at::aten::native_batch_norm_backward),
-           {grad_out, input, weight, running_mean, running_var, save_mean,
-            save_invstd},
-           [&]() {
-             return NodeOutputShape(grad_out, input, weight, running_mean,
-                                    running_var, save_mean, save_invstd,
-                                    training);
-           },
-           /*num_outputs=*/3, xla::util::MHash(training, eps)),
+    const Value& save_mean, const Value& save_invstd, bool training, double eps)
+    : Node(
+          ir::OpKind(at::aten::native_batch_norm_backward),
+          {grad_out, input, weight, save_mean, save_invstd},
+          [&]() {
+            return NodeOutputShape(grad_out, input, weight, save_mean,
+                                   save_invstd, training);
+          },
+          /*num_outputs=*/3, xla::util::MHash(training, eps)),
       training_(training),
       eps_(eps) {}
 
 NodePtr NativeBatchNormBackward::Clone(OpList operands) const {
-  return MakeNode<NativeBatchNormBackward>(
-      operands.at(0), operands.at(1), operands.at(2), operands.at(3),
-      operands.at(4), operands.at(5), operands.at(6), training_, eps_);
+  return MakeNode<NativeBatchNormBackward>(operands.at(0), operands.at(1),
+                                           operands.at(2), operands.at(3),
+                                           operands.at(4), training_, eps_);
 }
 
 XlaOpVector NativeBatchNormBackward::Lower(LoweringContext* loctx) const {
   xla::XlaOp grad_out = loctx->GetOutputOp(operand(0));
   xla::XlaOp input = loctx->GetOutputOp(operand(1));
   xla::XlaOp weight = loctx->GetOutputOp(operand(2));
-  xla::XlaOp running_mean = loctx->GetOutputOp(operand(3));
-  xla::XlaOp running_var = loctx->GetOutputOp(operand(4));
-  xla::XlaOp save_mean = loctx->GetOutputOp(operand(5));
-  xla::XlaOp save_invstd = loctx->GetOutputOp(operand(6));
-  BatchNormGrads grads =
-      BuildBatchNormBackward(grad_out, input, weight, running_mean, running_var,
-                             save_mean, save_invstd, training_, eps_);
+  xla::XlaOp save_mean = loctx->GetOutputOp(operand(3));
+  xla::XlaOp save_invstd = loctx->GetOutputOp(operand(4));
+  BatchNormGrads grads = BuildBatchNormBackward(
+      grad_out, input, weight, save_mean, save_invstd, training_, eps_);
   return ReturnOps({std::move(grads.grad_input), std::move(grads.grad_weight),
                     std::move(grads.grad_bias)},
                    loctx);

--- a/torch_xla/csrc/ops/native_batch_norm_backward.h
+++ b/torch_xla/csrc/ops/native_batch_norm_backward.h
@@ -10,8 +10,7 @@ namespace ops {
 class NativeBatchNormBackward : public Node {
  public:
   NativeBatchNormBackward(const Value& grad_out, const Value& input,
-                          const Value& weight, const Value& running_mean,
-                          const Value& running_var, const Value& save_mean,
+                          const Value& weight, const Value& save_mean,
                           const Value& save_invstd, bool training, double eps);
 
   NodePtr Clone(OpList operands) const override;

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -636,8 +636,7 @@ class XLATensor {
   // Returns the input, weight and bias gradients.
   static std::tuple<XLATensor, XLATensor, XLATensor> native_batch_norm_backward(
       const XLATensor& grad_out, const XLATensor& input,
-      const XLATensor& weight, const XLATensor& running_mean,
-      const XLATensor& running_var, const XLATensor& save_mean,
+      const XLATensor& weight, const XLATensor& save_mean,
       const XLATensor& save_invstd, bool training, double eps);
 
   static XLATensor ne(const XLATensor& input, at::Scalar other);

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1487,17 +1487,17 @@ std::tuple<XLATensor, XLATensor, XLATensor> XLATensor::native_batch_norm(
 }
 
 std::tuple<XLATensor, XLATensor, XLATensor>
-XLATensor::native_batch_norm_backward(
-    const XLATensor& grad_out, const XLATensor& input, const XLATensor& weight,
-    const XLATensor& running_mean, const XLATensor& running_var,
-    const XLATensor& save_mean, const XLATensor& save_invstd, bool training,
-    double eps) {
+XLATensor::native_batch_norm_backward(const XLATensor& grad_out,
+                                      const XLATensor& input,
+                                      const XLATensor& weight,
+                                      const XLATensor& save_mean,
+                                      const XLATensor& save_invstd,
+                                      bool training, double eps) {
   xla::Shape features_shape = BatchNormFeaturesShape(input);
   ir::Value weight_value =
       GetIrValueOrDefault(weight, 1, features_shape, input.GetDevice());
   ir::NodePtr node = ir::MakeNode<ir::ops::NativeBatchNormBackward>(
       grad_out.GetIrValue(), input.GetIrValue(), weight_value,
-      running_mean.GetIrValue(), running_var.GetIrValue(),
       save_mean.GetIrValue(), save_invstd.GetIrValue(), training, eps);
   XLATensor grad_input = input.CreateFrom(ir::Value(node, 0));
   XLATensor grad_weight = input.CreateFrom(ir::Value(node, 1));


### PR DESCRIPTION
…not using it ATM, drop it from passing it downstream.

Fixes #827