### PR TITLE
Pickup clang-7 by default

### DIFF
--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -24,6 +24,7 @@ function install_llvm_clang() {
   wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
   sudo apt-get update
   sudo apt-get -y install clang-7 clang++-7
+  echo 'export CC=clang-7 CXX=clang++-7' >> ~/.bashrc
   export CC=clang-7 CXX=clang++-7
 }
 


### PR DESCRIPTION
Current internal TPU tests are broken since test/cpp/run_tests.sh currently picks up gcc and errors out. clang-7 doesn't face this.