### PR TITLE
Eval loader transforms

### DIFF
--- a/test/test_train_imagenet.py
+++ b/test/test_train_imagenet.py
@@ -98,8 +98,8 @@ def train_imagenet():
     test_dataset = torchvision.datasets.ImageFolder(
         os.path.join(FLAGS.datadir, 'val'),
         # Matches Torchvision's eval transforms except Torchvision uses size
-        # 256 resize for all models and just crashes for 299x299 images, e.g.
-        # inception_v3.
+        # 256 resize for all models both here and in the train loader. Their
+        # version crashes during training on 299x299 images, e.g. inception.
         transforms.Compose([
             transforms.Resize(max(img_dim, 256)),
             transforms.CenterCrop(img_dim),

--- a/test/test_train_imagenet.py
+++ b/test/test_train_imagenet.py
@@ -97,16 +97,19 @@ def train_imagenet():
         num_workers=FLAGS.num_workers)
     test_dataset = torchvision.datasets.ImageFolder(
         os.path.join(FLAGS.datadir, 'val'),
+        # Matches Torchvision's eval transforms except Torchvision uses size
+        # 256 resize for all models and just crashes for 299x299 images, e.g.
+        # inception_v3.
         transforms.Compose([
-            transforms.RandomResizedCrop(img_dim),
-            transforms.RandomHorizontalFlip(),
+            transforms.Resize(max(img_dim, 256)),
+            transforms.CenterCrop(img_dim),
             transforms.ToTensor(),
             normalize,
         ]))
     test_loader = torch.utils.data.DataLoader(
         test_dataset,
         batch_size=FLAGS.batch_size,
-        shuffle=True,
+        shuffle=False,
         num_workers=FLAGS.num_workers)
 
   torch.manual_seed(42)

--- a/test/test_train_imagenet.py
+++ b/test/test_train_imagenet.py
@@ -95,13 +95,14 @@ def train_imagenet():
         batch_size=FLAGS.batch_size,
         shuffle=True,
         num_workers=FLAGS.num_workers)
+    resize_dim = max(img_dim, 256)
     test_dataset = torchvision.datasets.ImageFolder(
         os.path.join(FLAGS.datadir, 'val'),
         # Matches Torchvision's eval transforms except Torchvision uses size
         # 256 resize for all models both here and in the train loader. Their
         # version crashes during training on 299x299 images, e.g. inception.
         transforms.Compose([
-            transforms.Resize(max(img_dim, 256)),
+            transforms.Resize(resize_dim),
             transforms.CenterCrop(img_dim),
             transforms.ToTensor(),
             normalize,


### PR DESCRIPTION
Verified that transformed images during eval loop match those of Torchvision's train/eval script:
https://github.com/pytorch/examples/blob/master/imagenet/main.py#L219

Verified that inception_v3 does not crash during training or eval in our version like it does in Torchvision's example script