### PR TITLE
RateTracker smooth every time we report instead of every time we update

### DIFF
--- a/torch_xla_py/xla_model.py
+++ b/torch_xla_py/xla_model.py
@@ -143,7 +143,7 @@ class RateTracker(object):
     self._partial_time = self._start_time
     self._partial_count = 0
     self._partial_rate = None
-    self._count = 0
+    self._count = 0.0
 
   def _update(self, now, rate):
     self._partial_count += self._count
@@ -158,15 +158,15 @@ class RateTracker(object):
     if self._partial_rate is None:
       smoothed_rate = current_rate
     else:
-      smoothed_rate = (1 - self._smooth_factor) * current_rate
-      smoothed_rate += self._smooth_factor * self._partial_rate
+      smoothed_rate = ((1 - self._smooth_factor) * current_rate +
+                       self._smooth_factor * self._partial_rate)
     return smoothed_rate
 
   def rate(self):
     now = time.time()
     delta = now - self._partial_time
     report_rate = 0.0
-    if delta > 0
+    if delta > 0:
       current_rate = self._count / delta
       report_rate = self.smooth(current_rate)
       self._update(now, report_rate)

--- a/torch_xla_py/xla_model.py
+++ b/torch_xla_py/xla_model.py
@@ -157,7 +157,7 @@ class RateTracker(object):
   def add(self, count):
     self._count += count
 
-  def smooth(self, current_rate):
+  def _smooth(self, current_rate):
     if self._partial_rate is None:
       smoothed_rate = current_rate
     else:
@@ -170,8 +170,7 @@ class RateTracker(object):
     delta = now - self._partial_time
     report_rate = 0.0
     if delta > 0:
-      current_rate = self._count / delta
-      report_rate = self.smooth(current_rate)
+      report_rate = self._smooth(self._count / delta)
       self._update(now, report_rate)
     return report_rate
 

--- a/torch_xla_py/xla_model.py
+++ b/torch_xla_py/xla_model.py
@@ -141,13 +141,13 @@ class RateTracker(object):
     self._smooth_factor = smooth_factor
     self._start_time = time.time()
     self._partial_time = self._start_time
-    self._partial_count = 0
+    self._partial_count = 0.0
     self._partial_rate = None
     self._count = 0.0
 
   def _update(self, now, rate):
     self._partial_count += self._count
-    self._count = 0
+    self._count = 0.0
     self._partial_time = now
     self._partial_rate = rate
 
@@ -173,7 +173,7 @@ class RateTracker(object):
     return report_rate
 
   def global_rate(self):
-    delta = self._partial_time - self._start_time
+    delta = time.time() - self._start_time
     count = self._partial_count + self._count
     return count / delta if delta > 0 else 0.0
 


### PR DESCRIPTION
re: Issue #882 

```python
tracker = RateTracker()

for i in range(20):
  #tracker.add(1000 if i == 10 else 10)
  tracker.add(i)
  tracker.add(i)
  print(i, tracker.rate(), tracker.global_rate())
  time.sleep(1)
```
```bash
taylanbil@DESKTOP:~/tmp/github/xla on trackersmooth
% python tmp.py                                                 [190813 |11:56AM]
(0, 0.0, 0.0)
(1, 0.3995676903298575, 1.9978284597520806)
(2, 1.1191257844192246, 2.997380519320114)
(3, 2.094672104065118, 3.996973104737993)
(4, 3.2742875065177595, 4.996029314108234)
(5, 4.617172824232731, 5.99483372545623)
(6, 6.091110714702468, 6.993699901232682)
(7, 7.671813526152137, 7.993389419538777)
(8, 9.336942021218446, 8.993313396495111)
(9, 11.065584038029243, 9.992170640542614)
(10, 12.848135569214172, 10.991057638123014)
(11, 14.673827371311262, 11.98997088007052)
(12, 16.536500931988005, 12.989462440393295)
(13, 18.423662369644653, 13.988377727431777)
(14, 20.332945506399845, 14.987291995653704)
(15, 22.259984528450484, 15.986215651625235)
(16, 24.203134433221027, 16.985463780822453)
(17, 26.15529902881382, 17.984391603671664)
(18, 28.116615239722684, 18.983322027434802)
(19, 30.085260927168115, 19.982255831314905)
```