### PR TITLE
Add override for `empty_strided`

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -6588,6 +6588,19 @@ TEST_F(AtenXlaTensorTest, TestAsStridedWithInplaceCopy) {
   });
 }
 
+TEST_F(AtenXlaTensorTest, TestEmptyStrided) {
+  std::vector<int64_t> size = {4, 4, 2};
+  std::vector<int64_t> stride = {8, 2, 1};
+  torch::Tensor output = torch::empty_strided(/*size=*/size, /*stride=*/stride);
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_output =
+        torch::empty_strided(/*size=*/size, /*stride=*/stride);
+    AllClose(output, xla_output);
+    EXPECT_EQ(output.sizes(), xla_output.sizes());
+    EXPECT_EQ(output.strides(), xla_output.strides());
+  });
+}
+
 TEST_F(AtenXlaTensorTest, TestAvgPool2DBackward) {
   int kernel_size = 2;
   for (int stride = 1; stride <= 2; ++stride) {

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -6595,7 +6595,6 @@ TEST_F(AtenXlaTensorTest, TestEmptyStrided) {
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor xla_output =
         torch::empty_strided(/*size=*/size, /*stride=*/stride);
-    AllClose(output, xla_output);
     EXPECT_EQ(output.sizes(), xla_output.sizes());
     EXPECT_EQ(output.strides(), xla_output.strides());
   });

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -21,6 +21,7 @@ sys.path.insert(0, _XLA_FOLDER)
 # Normal imports section starts here.
 import collections
 from common_utils import TestCase, run_tests, iter_indices
+import copy
 import itertools
 import numpy
 import re
@@ -499,6 +500,35 @@ class TestAtenXlaTensor(XlaTestCase):
     result = base[:, torch.empty(0, 6, dtype=torch.int64)]
     xla_result = xla_base[:, torch.empty(0, 6, dtype=torch.int64)]
     self.assertEqual(result, xla_result)
+
+  def test_grad_gradInput(self):
+    xla_device = xm.xla_device()
+    m = nn.Conv1d(4, 6, kernel_size=3, groups=2)
+    a = torch.rand(2, 4, 6, requires_grad=True)
+    xla_m = copy.deepcopy(m).to(xla_device)
+    xla_a = a.clone().to(xla_device).detach()
+    xla_a.requires_grad = True
+    output = m(a)
+    gradInput = torch.autograd.grad(
+            output,
+            (a, ) + tuple(m.parameters()),
+            output,
+            create_graph=True)
+    grad_gradInput = torch.autograd.grad(
+            output.sum() + sum(map(lambda x: x.sum(), gradInput)),
+            (a, output) + tuple(m.parameters()),
+            retain_graph=True)
+    xla_output = xla_m(xla_a)
+    xla_gradInput = torch.autograd.grad(
+            xla_output,
+            (xla_a, ) + tuple(xla_m.parameters()),
+            xla_output,
+            create_graph=True)
+    xla_grad_gradInput = torch.autograd.grad(
+            xla_output.sum() + sum(map(lambda x: x.sum(), xla_gradInput)),
+            (xla_a, xla_output) + tuple(xla_m.parameters()),
+            retain_graph=True)
+    self.assertEqual(grad_gradInput, xla_grad_gradInput)
 
   def test_clamp(self):
     a = torch.randn(3, 3)

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -501,7 +501,7 @@ class TestAtenXlaTensor(XlaTestCase):
     xla_result = xla_base[:, torch.empty(0, 6, dtype=torch.int64)]
     self.assertEqual(result, xla_result)
 
-  def test_grad_gradInput(self):
+  def test_empty_strided(self):
     xla_device = xm.xla_device()
     m = nn.Conv1d(4, 6, kernel_size=3, groups=2)
     a = torch.rand(2, 4, 6, requires_grad=True)
@@ -509,26 +509,26 @@ class TestAtenXlaTensor(XlaTestCase):
     xla_a = a.clone().to(xla_device).detach()
     xla_a.requires_grad = True
     output = m(a)
-    gradInput = torch.autograd.grad(
+    grad_input = torch.autograd.grad(
             output,
             (a, ) + tuple(m.parameters()),
             output,
             create_graph=True)
-    grad_gradInput = torch.autograd.grad(
-            output.sum() + sum(map(lambda x: x.sum(), gradInput)),
+    grad_grad_input = torch.autograd.grad(
+            output.sum() + sum(map(lambda x: x.sum(), grad_input)),
             (a, output) + tuple(m.parameters()),
             retain_graph=True)
     xla_output = xla_m(xla_a)
-    xla_gradInput = torch.autograd.grad(
+    xla_grad_input = torch.autograd.grad(
             xla_output,
             (xla_a, ) + tuple(xla_m.parameters()),
             xla_output,
             create_graph=True)
-    xla_grad_gradInput = torch.autograd.grad(
-            xla_output.sum() + sum(map(lambda x: x.sum(), xla_gradInput)),
+    xla_grad_grad_input = torch.autograd.grad(
+            xla_output.sum() + sum(map(lambda x: x.sum(), xla_grad_input)),
             (xla_a, xla_output) + tuple(xla_m.parameters()),
             retain_graph=True)
-    self.assertEqual(grad_gradInput, xla_grad_gradInput)
+    self.assertEqual(grad_grad_input, xla_grad_grad_input)
 
   def test_clamp(self):
     a = torch.randn(3, 3)

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1078,6 +1078,13 @@ at::Tensor AtenXlaType::empty_like(
   return full_like(self, 0, options);
 }
 
+at::Tensor AtenXlaType::empty_strided(at::IntArrayRef size,
+                                      at::IntArrayRef stride,
+                                      const at::TensorOptions& options) {
+  at::Tensor t = full(size, 0, options);
+  return as_strided(t, size, stride, /*storage_offset=*/0);
+}
+
 at::Tensor AtenXlaType::eq(const at::Tensor& self, at::Scalar other) {
   return bridge::AtenFromXlaTensor(
       XLATensor::eq(bridge::GetXlaTensor(self), other));

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -385,6 +385,9 @@ class AtenXlaType {
                                const at::TensorOptions& options,
                                c10::optional<at::MemoryFormat> memory_format);
 
+  static at::Tensor empty_strided(at::IntArrayRef size, at::IntArrayRef stride,
+                                  const at::TensorOptions& options);
+
   static at::Tensor eq(const at::Tensor& self, at::Scalar other);
 
   static at::Tensor eq(const at::Tensor& self, const at::Tensor& other);


### PR DESCRIPTION
Fix #911 
- Add override for `empty_strided`
- Add cpp test for `empty_strided`
- Add python test where this issue was triggered.

ps: we probably need another PR to format python test files with flake8.  