### PR TITLE
better error message for split

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -726,6 +726,13 @@ class TestAtenXlaTensor(XlaTestCase):
 
     self.runAtenTest(torch.zeros([4, 4]), test_fn)
 
+  def test_split_zero_throw(self):
+    xla_device = xm.xla_device()
+    xla_a = torch.rand(1, 3, device=xla_device)
+    with self.assertRaisesRegex(RuntimeError,
+            'split_size can only be 0 if dimension size is 0'):
+      xla_b = torch.split(xla_a, 0, dim=0)
+
   def test_save(self):
     xla_device = xm.xla_device()
     x = torch.randn(5, device=xla_device)

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1921,7 +1921,9 @@ std::vector<XLATensor> XLATensor::split(const XLATensor& input,
   if (split_size == 0) {
     // Deal with 0 split size, it's a corner case which is only allowed when the
     // dimension size is 0 as well.
-    XLA_CHECK_EQ(dim_size, 0);
+    XLA_CHECK_EQ(dim_size, 0) << "split_size can only be 0 if dimension size "
+                                 "is 0, but got dimension size of "
+                              << dim_size;
     xla::Literal literal(input_shape.get());
     return {
         input.CreateFrom(ir::MakeNode<ir::ops::Constant>(std::move(literal)))};


### PR DESCRIPTION
Pytorch has a test regexing the error message thrown for this case. 