### PR TITLE
Shard datasets for distributed training.

### DIFF
--- a/test/test_train_cifar.py
+++ b/test/test_train_cifar.py
@@ -132,21 +132,26 @@ def train_cifar():
         train=False,
         download=True,
         transform=transform_test)
-    train_sampler = torch.utils.data.distributed.DistributedSampler(
-        train_dataset, num_replicas=xm.xrt_world_size(),
-        rank=xm.get_ordinal(), shuffle=True)
-    test_sampler = torch.utils.data.distributed.DistributedSampler(
-        test_dataset, num_replicas=xm.xrt_world_size(),
-        rank=xm.get_ordinal(), shuffle=False)
+    train_sampler = None
+    test_sampler = None
+    if xm.xrt_world_size() > 1:
+      train_sampler = torch.utils.data.distributed.DistributedSampler(
+          train_dataset, num_replicas=xm.xrt_world_size(),
+          rank=xm.get_ordinal(), shuffle=True)
+      test_sampler = torch.utils.data.distributed.DistributedSampler(
+          test_dataset, num_replicas=xm.xrt_world_size(),
+          rank=xm.get_ordinal(), shuffle=False)
     train_loader = torch.utils.data.DataLoader(
         train_dataset,
         batch_size=FLAGS.batch_size,
         sampler=train_sampler,
+        shuffle=False if train_sampler else True,
         num_workers=FLAGS.num_workers)
     test_loader = torch.utils.data.DataLoader(
         test_dataset,
         batch_size=FLAGS.batch_size,
         sampler=test_sampler,
+        shuffle=False,
         num_workers=FLAGS.num_workers)
 
   torch.manual_seed(42)

--- a/torch_xla_py/xla_dist.py
+++ b/torch_xla_py/xla_dist.py
@@ -428,8 +428,8 @@ class DistributedExecutor(object):
   MASTER_IDX = 0
   MESH_SERVICE_PORT = 8477  # Use single port to disallow concurrent runs
   DIST_ENV_VARS = [
-      'XRT_TPU_CONFIG', 'XRT_LOCAL_WORKER',
-      'XRT_MESH_SERVICE_ADDRESS', 'XRT_NUM_WORKERS',
+      'XRT_TPU_CONFIG', 'XRT_LOCAL_WORKER', 'XRT_MESH_SERVICE_ADDRESS',
+      'XRT_SHARD_WORLD_SIZE', 'XRT_SHARD_ORDINAL',
   ]
   DEFAULT_CONTAINER_NAME = 'pytorchtpudistrunner'
   DEFAULT_USER_NAME = 'pytorchtpudistrunner'
@@ -560,7 +560,8 @@ class DistributedExecutor(object):
             'c_tpu_worker:{}'.format(worker_idx),
         'XRT_MESH_SERVICE_ADDRESS':
             '{}:{}'.format(client_master._internal_ip, self.MESH_SERVICE_PORT),
-        'XRT_NUM_WORKERS': len(self._cluster._client_workers),
+        'XRT_SHARD_WORLD_SIZE': len(self._cluster._client_workers),
+        'XRT_SHARD_ORDINAL': worker_idx,
     }
     # Only for master
     if worker_idx == self.MASTER_IDX:

--- a/torch_xla_py/xla_dist.py
+++ b/torch_xla_py/xla_dist.py
@@ -428,7 +428,8 @@ class DistributedExecutor(object):
   MASTER_IDX = 0
   MESH_SERVICE_PORT = 8477  # Use single port to disallow concurrent runs
   DIST_ENV_VARS = [
-      'XRT_TPU_CONFIG', 'XRT_LOCAL_WORKER', 'XRT_MESH_SERVICE_ADDRESS'
+      'XRT_TPU_CONFIG', 'XRT_LOCAL_WORKER',
+      'XRT_MESH_SERVICE_ADDRESS', 'XRT_NUM_WORKERS',
   ]
   DEFAULT_CONTAINER_NAME = 'pytorchtpudistrunner'
   DEFAULT_USER_NAME = 'pytorchtpudistrunner'
@@ -558,7 +559,8 @@ class DistributedExecutor(object):
         'XRT_LOCAL_WORKER':
             'c_tpu_worker:{}'.format(worker_idx),
         'XRT_MESH_SERVICE_ADDRESS':
-            '{}:{}'.format(client_master._internal_ip, self.MESH_SERVICE_PORT)
+            '{}:{}'.format(client_master._internal_ip, self.MESH_SERVICE_PORT),
+        'XRT_NUM_WORKERS': len(self._cluster._client_workers),
     }
     # Only for master
     if worker_idx == self.MASTER_IDX:

--- a/torch_xla_py/xla_model.py
+++ b/torch_xla_py/xla_model.py
@@ -84,11 +84,11 @@ def get_xla_supported_devices(devkind=None, max_devices=None):
 
 
 def xrt_world_size():
-  return int(os.getenv('XRT_NUM_WORKERS', 1))
+  return int(os.getenv('XRT_SHARD_WORLD_SIZE', 1))
 
 
 def get_ordinal():
-  return int(os.getenv('XRT_LOCAL_WORKER', ':0').split(':')[1])
+  return int(os.getenv('XRT_SHARD_ORDINAL', 0))
 
 
 def xla_device(n=None, devkind=None):

--- a/torch_xla_py/xla_model.py
+++ b/torch_xla_py/xla_model.py
@@ -83,6 +83,14 @@ def get_xla_supported_devices(devkind=None, max_devices=None):
       return kind_devices[:max_devices] if max_devices else kind_devices
 
 
+def xrt_world_size():
+  return int(os.getenv('XRT_NUM_WORKERS', 1))
+
+
+def get_ordinal():
+  return int(os.getenv('XRT_LOCAL_WORKER', ':0').split(':')[1])
+
+
 def xla_device(n=None, devkind=None):
   if n is None:
     devices = get_xla_supported_devices(devkind=devkind)


### PR DESCRIPTION
Added torch.utils.data.distributed.DistributedSampler usage to our
MNIST, CIFAR, and IMAGENET examples and tested for training accuracy
improvements with larger LR and that each shard had a different loss
(data parallelism).

Verified no performance regressions on v3-8/n1-standard-64:
* Baseline (no sharding):
https://gist.github.com/jysohn23/8077aab85474ef3e7bfcb54851280d8c
* Sharding (single-shard):
https://gist.github.com/jysohn23/e0900d888534598f06b2eec3da598d14

Tested on v3-32 & 4 x n1-standard-64
(May suffer from lower accuracy since larger global batch sizes; all
use real data)
MNIST: https://gist.github.com/jysohn23/0ba2d58c2da553828c29461e89f8d1da
CIFAR: https://gist.github.com/jysohn23/0b6b57e50007e57189b35032ed654a4f
IMAGENET (ResNet50):
https://gist.github.com/fb5a50abea01b273fc55599ce6994559