### PR TITLE
punt back to cpu for xla::dot related ops with int input

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -621,14 +621,14 @@ class TestAtenXlaTensor(XlaTestCase):
     vset = b.sum().item()
     self.assertEqual(a.sum().item(), 10.0 * vset + (4.0 - vset))
 
-  def test_fall_back_integer_types(self):
-    # pow
+  def test_pow_integer_types(self):
     self.runAtenTest(torch.randint(10, (2, 2)), lambda x: torch.pow(x, 2))
     self.runAtenTest(torch.randint(10, (2, 2)), lambda x: torch.pow(2, x))
     self.runAtenTest(torch.randint(10, (2, 2)), lambda x: torch.pow(x, x))
     self.runAtenTest(torch.randint(10, (2, 2)), lambda x: x.pow_(2))
     self.runAtenTest(torch.randint(10, (2, 2)), lambda x: x.pow_(x))
 
+  def test_matmul_integer_types(self):
     # all variance of matmul: dot/mv/mm/bmm
     self.runAtenTest(
         (torch.randint(10, (2,)), torch.randint(10, (2,))),
@@ -646,7 +646,7 @@ class TestAtenXlaTensor(XlaTestCase):
         (torch.randint(10, (10, 3, 4)), torch.randint(10, (4, 5))),
         lambda x, y: torch.matmul(x, y))
 
-    # addmm
+  def test_addmm_integer_types(self):
     self.runAtenTest(
         (torch.randint(10, (2, 3)), torch.randint(10, (2, 3)), torch.randint(10, (3, 3))),
         lambda x, y, z: torch.addmm(x, y, z))

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -621,12 +621,35 @@ class TestAtenXlaTensor(XlaTestCase):
     vset = b.sum().item()
     self.assertEqual(a.sum().item(), 10.0 * vset + (4.0 - vset))
 
-  def test_pow_integer_types(self):
+  def test_fall_back_integer_types(self):
+    # pow
     self.runAtenTest(torch.randint(10, (2, 2)), lambda x: torch.pow(x, 2))
     self.runAtenTest(torch.randint(10, (2, 2)), lambda x: torch.pow(2, x))
     self.runAtenTest(torch.randint(10, (2, 2)), lambda x: torch.pow(x, x))
     self.runAtenTest(torch.randint(10, (2, 2)), lambda x: x.pow_(2))
     self.runAtenTest(torch.randint(10, (2, 2)), lambda x: x.pow_(x))
+
+    # all variance of matmul: dot/mv/mm/bmm
+    self.runAtenTest(
+        (torch.randint(10, (2,)), torch.randint(10, (2,))),
+        lambda x, y: torch.matmul(x, y))
+    self.runAtenTest(
+        (torch.randint(10, (3, 4)), torch.randint(10, (4,))),
+        lambda x, y: torch.matmul(x, y))
+    self.runAtenTest(
+        (torch.randint(10, (10, 3, 4)), torch.randint(10, (4,))),
+        lambda x, y: torch.matmul(x, y))
+    self.runAtenTest(
+        (torch.randint(10, (10, 3, 4)), torch.randint(10, (10, 4, 5))),
+        lambda x, y: torch.matmul(x, y))
+    self.runAtenTest(
+        (torch.randint(10, (10, 3, 4)), torch.randint(10, (4, 5))),
+        lambda x, y: torch.matmul(x, y))
+
+    # addmm
+    self.runAtenTest(
+        (torch.randint(10, (2, 3)), torch.randint(10, (2, 3)), torch.randint(10, (3, 3))),
+        lambda x, y, z: torch.addmm(x, y, z))
 
   def test_pred_type(self):
     xla_device = xm.xla_device()

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -399,7 +399,10 @@ at::Tensor& AtenXlaType::addcmul_(at::Tensor& self, const at::Tensor& tensor1,
 at::Tensor AtenXlaType::addmm(const at::Tensor& self, const at::Tensor& mat1,
                               const at::Tensor& mat2, at::Scalar beta,
                               at::Scalar alpha) {
-  if (beta.to<double>() != 1 || alpha.to<double>() != 1) {
+  // xla::dot doesn't support integer types.
+  if (beta.to<double>() != 1 || alpha.to<double>() != 1 ||
+      !self.is_floating_point() || !mat1.is_floating_point() ||
+      !mat2.is_floating_point()) {
     return AtenXlaTypeDefault::addmm(self, mat1, mat2, beta, alpha);
   }
   return bridge::AtenFromXlaTensor(
@@ -723,6 +726,10 @@ at::Tensor AtenXlaType::blackman_window(int64_t window_length, bool periodic,
 }
 
 at::Tensor AtenXlaType::bmm(const at::Tensor& self, const at::Tensor& mat2) {
+  // xla::dot doesn't support integer types.
+  if (!self.is_floating_point() || !mat2.is_floating_point()) {
+    return AtenXlaTypeDefault::bmm(self, mat2);
+  }
   return bridge::AtenFromXlaTensor(
       XLATensor::bmm(bridge::GetXlaTensor(self), bridge::GetXlaTensor(mat2)));
 }
@@ -1732,6 +1739,10 @@ at::Tensor& AtenXlaType::masked_fill_(at::Tensor& self, const at::Tensor& mask,
 
 at::Tensor AtenXlaType::matmul(const at::Tensor& self,
                                const at::Tensor& other) {
+  // xla::dot doesn't support integer types.
+  if (!self.is_floating_point() || !other.is_floating_point()) {
+    return AtenXlaTypeDefault::matmul(self, other);
+  }
   return bridge::AtenFromXlaTensor(XLATensor::matmul(
       bridge::GetXlaTensor(self), bridge::GetXlaTensor(other)));
 }
@@ -1926,6 +1937,10 @@ std::tuple<at::Tensor, at::Tensor> AtenXlaType::min(const at::Tensor& self,
 }
 
 at::Tensor AtenXlaType::mm(const at::Tensor& self, const at::Tensor& mat2) {
+  // xla::dot doesn't support integer types.
+  if (!self.is_floating_point() || !mat2.is_floating_point()) {
+    return AtenXlaTypeDefault::mm(self, mat2);
+  }
   return bridge::AtenFromXlaTensor(
       XLATensor::mm(/*input=*/bridge::GetXlaTensor(self),
                     /*weight=*/bridge::GetXlaTensor(mat2)));


### PR DESCRIPTION
fixes #861 
(we don't have lowering for `mv` yet so that's all cpu).