### PR TITLE
Only log TPU topology from the master worker

### DIFF
--- a/third_party/xla_client/xrt_computation_client.cc
+++ b/third_party/xla_client/xrt_computation_client.cc
@@ -1088,9 +1088,9 @@ void XrtComputationClient::InitializeDevices(
             std::move(worker_topology_proto));
       }
     }
-  }
-  if (topology_proto != nullptr) {
-    TF_LOG(INFO) << "TPU topology: " << topology_proto->DebugString();
+    if (topology_proto != nullptr) {
+      TF_LOG(INFO) << "TPU topology: " << topology_proto->DebugString();
+    }
   }
   for (const auto& dev_target : options_.global_device_map) {
     tensorflow::DeviceNameUtils::ParsedName parsed_device =


### PR DESCRIPTION
Currently logs at mesh initialization time on the client side has lots of duplicated logs: [example](https://gist.githubusercontent.com/jysohn23/fda8cc58d47cc03e1ab22fb91ea1b33b/raw/c31b14b2a19ee64ad56ba09e46fb21834bc31ced/v3-32-resnet50-real-data-numworkers64-n1standard64-bs256-bf16-sharded.txt). Will do similar around `XrtComputationClient` constructor too.