### PR TITLE
better error message for arange

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -546,6 +546,12 @@ class TestAtenXlaTensor(XlaTestCase):
         xla_a[:, s::e] = 2
         self.assertEqual(a.data, xla_a.data.cpu())
 
+  def test_arange_nan(self):
+    with self.assertRaisesRegex(RuntimeError, r"unsupported range"):
+      a = torch.arange(-5, float('nan'), device=xm.xla_device())
+    with self.assertRaisesRegex(RuntimeError, r"unsupported range"):
+      a = torch.arange(float('nan'), 5, device=xm.xla_device())
+
   def test_empty_advanced_indexing(self):
     xla_device = xm.xla_device()
     base = torch.randn(2, 3, 4, 5)

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -341,6 +341,8 @@ NodePtr ARange(at::Scalar start, at::Scalar end, at::Scalar step,
                at::ScalarType scalar_type) {
   xla::PrimitiveType type = MakeXlaPrimitiveType(scalar_type,
                                                  /*device=*/nullptr);
+  XLA_CHECK(!isnan(start.toDouble()) && !isnan(end.toDouble()))
+      << "unsupported range: " << start.toDouble() << " -> " << end.toDouble();
   xla::Literal values;
   switch (type) {
     case xla::PrimitiveType::BF16:

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -341,7 +341,7 @@ NodePtr ARange(at::Scalar start, at::Scalar end, at::Scalar step,
                at::ScalarType scalar_type) {
   xla::PrimitiveType type = MakeXlaPrimitiveType(scalar_type,
                                                  /*device=*/nullptr);
-  XLA_CHECK(!isnan(start.toDouble()) && !isnan(end.toDouble()))
+  XLA_CHECK(!std::isnan(start.toDouble()) && !std::isnan(end.toDouble()))
       << "unsupported range: " << start.toDouble() << " -> " << end.toDouble();
   xla::Literal values;
   switch (type) {


### PR DESCRIPTION
Pytorch has regex checking this error message..
And the old message `RuntimeError: vector::reserve` is not helpful.
fixes #877 