### PR TITLE
fix pred promotion for arithmetic ops

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -676,15 +676,13 @@ class TestAtenXlaTensor(XlaTestCase):
     xla_f = xla_e.sum().item()
     self.assertEqual(f, xla_f)
 
-    # PRED cannot be automatically promoted to other dtypes.
-    # Test both cpu and xla here to make sure we get notified
-    # once PyTorch changes its behavior.
+    # PRED can be automatically promoted in arithmetic ops.
+    self.runAtenTest(c, lambda x: x + x.byte())
+    # PRED cannot be automatically promoted to other dtypes in bitwise ops.
+    # This is not aligned with numpy behavior which means it might change
+    # in the future.
     self.assertRaises(RuntimeError, lambda: c & c.byte())
-    self.assertRaises(RuntimeError, lambda: c + c.byte())
     self.assertRaises(RuntimeError, lambda: xla_c & xla_c.byte())
-    # RuntimeError is triggered in execution instead of lowering,
-    # thus print is required.
-    self.assertRaises(RuntimeError, lambda: print(xla_c + xla_c.byte()))
 
   def test_bitwise_type(self):
     xla_device = xm.xla_device()

--- a/torch_xla/csrc/helpers.cpp
+++ b/torch_xla/csrc/helpers.cpp
@@ -387,7 +387,9 @@ xla::XlaOp XlaHelpers::PromotedBinaryOp(
     const xla::XlaOp& op1, const xla::XlaOp& op2,
     const std::function<xla::XlaOp(const xla::XlaOp&, const xla::XlaOp&)>&
         bin_op) {
-  std::pair<xla::XlaOp, xla::XlaOp> vops = PromoteSecond(op1, op2);
+  xla::XlaOp numeric_op1 = ConvertToNumeric(op1);
+  xla::XlaOp numeric_op2 = ConvertToNumeric(op2);
+  std::pair<xla::XlaOp, xla::XlaOp> vops = PromoteSecond(numeric_op1, numeric_op2);
   return bin_op(vops.first, vops.second);
 }
 


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/22273 allows pred to be promoted in arithmetic ops