### PR TITLE
allow copy.copy() to return xla tensor

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -848,6 +848,12 @@ class TestAtenXlaTensor(XlaTestCase):
     finally:
       os.remove(x_file)
 
+  def test_copy(self):
+    xla_device = xm.xla_device()
+    x = torch.rand(5, device=xla_device)
+    y = copy.copy(x)
+    self.assertEqual(x, y)
+
   def test_print(self):
     xla_device = xm.xla_device()
     x = torch.tensor([5], device=xla_device)

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -848,6 +848,19 @@ class TestAtenXlaTensor(XlaTestCase):
     finally:
       os.remove(x_file)
 
+  def test_save_tuple(self):
+    xla_device = xm.xla_device()
+    x = torch.randn(5, device=xla_device)
+    number = 3
+    x_file = tempfile.mktemp()
+    try:
+      torch.save((x, number), x_file)
+      x_loaded, number_loaded = torch.load(x_file)
+      self.assertEqual(x, x_loaded)
+      self.assertEqual(number, number_loaded)
+    finally:
+      os.remove(x_file)
+
   def test_copy(self):
     xla_device = xm.xla_device()
     x = torch.rand(5, device=xla_device)

--- a/torch_patches/X10-torch_save.diff
+++ b/torch_patches/X10-torch_save.diff
@@ -1,13 +1,51 @@
+diff --git a/torch/_utils.py b/torch/_utils.py
+index 657102ed1..a246f23aa 100644
+--- a/torch/_utils.py
++++ b/torch/_utils.py
+@@ -140,6 +140,12 @@ def _rebuild_tensor_v2(storage, storage_offset, size, stride, requires_grad, bac
+     tensor._backward_hooks = backward_hooks
+     return tensor
+ 
++def _rebuild_xlatensor(storage, storage_offset, size, stride, requires_grad, backward_hooks, device):
++    tensor = _rebuild_tensor(storage, storage_offset, size, stride).to(device)
++    tensor.requires_grad = requires_grad
++    tensor._backward_hooks = backward_hooks
++    return tensor
++
+ def _rebuild_qtensor(storage, storage_offset, size, stride, scale, zero_point, requires_grad, backward_hooks):
+     tensor = torch._empty_affine_quantized(size, scale=scale, zero_point=zero_point, dtype=storage.dtype)
+     tensor.set_(storage, storage_offset, size, stride)
+diff --git a/torch/serialization.py b/torch/serialization.py
+index 8b168b694..4ccfb93c1 100644
+--- a/torch/serialization.py
++++ b/torch/serialization.py
+@@ -257,6 +257,8 @@ def save(obj, f, pickle_module=pickle, pickle_protocol=DEFAULT_PROTOCOL):
+         >>> buffer = io.BytesIO()
+         >>> torch.save(x, buffer)
+     """
++    if obj.device.type == 'xla':
++        obj = obj.cpu()
+     return _with_file_like(f, "wb", lambda f: _save(obj, f, pickle_module, pickle_protocol))
+ 
+ 
 diff --git a/torch/tensor.py b/torch/tensor.py
-index 0c3286078b..cf0752c89a 100644
+index a7724a4a3..7e31988ec 100644
 --- a/torch/tensor.py
 +++ b/torch/tensor.py
-@@ -38,6 +38,8 @@ class Tensor(torch._C._TensorBase):
-     def __reduce_ex__(self, proto):
+@@ -40,6 +40,16 @@ class Tensor(torch._C._TensorBase):
+         _check_serializing_named_tensor(self)
          # See Note [Don't serialize hooks]
          torch.utils.hooks.warn_if_has_hooks(self)
 +        if self.device.type == 'xla':
-+            self = self.cpu()
++            self_cpu = self.cpu()
++            args = (self_cpu.storage(),
++                    self_cpu.storage_offset(),
++                    tuple(self.size()),
++                    self_cpu.stride(),
++                    self.requires_grad,
++                    OrderedDict(),
++                    self.device)
++            return (torch._utils._rebuild_xlatensor, args)
          if self.is_quantized:
              args = (self.storage(),
                      self.storage_offset(),

--- a/torch_patches/X10-torch_save.diff
+++ b/torch_patches/X10-torch_save.diff
@@ -16,17 +16,27 @@ index 657102ed1..a246f23aa 100644
      tensor = torch._empty_affine_quantized(size, scale=scale, zero_point=zero_point, dtype=storage.dtype)
      tensor.set_(storage, storage_offset, size, stride)
 diff --git a/torch/serialization.py b/torch/serialization.py
-index 8b168b694..4ccfb93c1 100644
+index 8b168b694..4213d4b0a 100644
 --- a/torch/serialization.py
 +++ b/torch/serialization.py
-@@ -257,6 +257,8 @@ def save(obj, f, pickle_module=pickle, pickle_protocol=DEFAULT_PROTOCOL):
-         >>> buffer = io.BytesIO()
-         >>> torch.save(x, buffer)
-     """
-+    if obj.device.type == 'xla':
-+        obj = obj.cpu()
-     return _with_file_like(f, "wb", lambda f: _save(obj, f, pickle_module, pickle_protocol))
+@@ -312,6 +312,8 @@ def _save(obj, f, pickle_module, pickle_protocol):
+                     location,
+                     obj.size(),
+                     view_metadata)
++        elif isinstance(obj, torch.device) and obj.type == 'xla':
++               return ('OpaqueDevice', 'cpu')
+         return None
  
+     sys_info = dict(
+@@ -578,6 +580,9 @@ def _load(f, map_location, pickle_module, **pickle_load_args):
+                 return deserialized_objects[view_key]
+             else:
+                 return storage
++        elif typename == 'OpaqueDevice':
++            device_name = data[0]
++            return torch.device(device_name)
+         else:
+             raise RuntimeError("Unknown saved id type: %s" % saved_id[0])
  
 diff --git a/torch/tensor.py b/torch/tensor.py
 index a7724a4a3..7e31988ec 100644


### PR DESCRIPTION
Tentative fix for #876 
Pytorch serilalize storage instead of tensor itself
Here's PT load logic: [code pointer](https://github.com/pytorch/pytorch/blob/master/torch/serialization.py#L609)
1. First use `__reduce_ex__` to construct a empty new Tensor.
2. Update Tensor storage inplace with the loaded content. 

This won't work out of box for xla tensor as XLA tensor doesn't have storage. 
This PR allows `__reduce_ex__` to return a XLA tensor, but in `save/load` it has to be a CPU tensor to pick up the storage update. 
This patch is definitely not ideal, I'll try to refine and upstream this patch to PT if possible. But submitting this PR first to see how people like this solution.