### PR TITLE
Make add_scatter_combiner a std::function

### DIFF
--- a/torch_xla/csrc/ops/index_put.cpp
+++ b/torch_xla/csrc/ops/index_put.cpp
@@ -29,8 +29,8 @@ NodePtr IndexPut::Clone(OpList operands) const {
 }
 
 XlaOpVector IndexPut::Lower(LoweringContext* loctx) const {
-  auto add_scatter_combiner = [](const xla::XlaOp& x,
-                                 const xla::XlaOp& y) -> xla::XlaOp {
+  std::function<xla::XlaOp(xla::XlaOp, xla::XlaOp)> add_scatter_combiner =
+      [](const xla::XlaOp& x, const xla::XlaOp& y) -> xla::XlaOp {
     return x + y;
   };
 


### PR DESCRIPTION
Ternary between lambda and nullptr doesn't work with g++-7.