### PR TITLE
initialize only one summary writer in the multiprocess case

### DIFF
--- a/test/test_train_mp_imagenet.py
+++ b/test/test_train_mp_imagenet.py
@@ -153,7 +153,9 @@ def train_imagenet():
 
   device = xm.xla_device()
   model = get_model_property('model_fn')().to(device)
-  writer = SummaryWriter(log_dir=FLAGS.logdir) if FLAGS.logdir else None
+  writer = None
+  if FLAGS.logdir and test_utils.is_first_device(device, [str(device)]):
+    writer = SummaryWriter(log_dir=FLAGS.logdir)
   optimizer = optim.SGD(
       model.parameters(),
       lr=FLAGS.lr,
@@ -168,8 +170,7 @@ def train_imagenet():
       scheduler_divide_every_n_epochs=getattr(
           FLAGS, 'lr_scheduler_divide_every_n_epochs', None),
       num_steps_per_epoch=num_training_steps_per_epoch,
-      summary_writer=writer if test_utils.is_first_device(
-          device, [str(device)]) else None)
+      summary_writer=writer)
   loss_fn = nn.CrossEntropyLoss()
 
   def train_loop_fn(loader):


### PR DESCRIPTION
In the multiprocess case, it seems the every call to SummaryWriter() creates an events file. In the multiprocess case, we end up with lots of events files but only 1 of them has the real data.

This PR fixes this by initializing SummaryWriter only once in the multiprocess case. Tested locally and now we only get 1 events file per call to test_train_mp_imagenet.py