### PR TITLE
Adds XLA to device type testing framework

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -31,7 +31,9 @@ export TRIM_GRAPH_CHECK_FREQUENCY=$GRAPH_CHECK_FREQUENCY
 if [ "$LOGFILE" != "" ]; then
   python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY 2>&1 | tee $LOGFILE
   python3 "$CDIR/test_mp_replication.py" "$@" 2>&1 | tee $LOGFILE
+  python3 "$CDIR/../../test/test_torch.py" "$@" -v TestTorchDeviceTypeXLA 2>&1 | tee $LOGFILE
 else
   python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   python3 "$CDIR/test_mp_replication.py" "$@"
+  python3 "$CDIR/../../test/test_torch.py" "$@" -v TestTorchDeviceTypeXLA
 fi

--- a/torch_patches/X10-device_test.diff
+++ b/torch_patches/X10-device_test.diff
@@ -1,0 +1,131 @@
+diff --git a/test/common_device_type.py b/test/common_device_type.py
+index 2b47282a5f..024863d8de 100644
+--- a/test/common_device_type.py
++++ b/test/common_device_type.py
+@@ -4,6 +4,8 @@ import unittest
+ import torch
+ from common_utils import TestCase, TEST_WITH_ROCM, TEST_MKL, \
+     skipCUDANonDefaultStreamIf
++import torch_xla
++assert torch_xla  # silences flake8
+
+ # Note: Generic Device-Type Testing
+ #
+@@ -113,10 +115,117 @@ class CUDATestBase(DeviceTypeTestBase):
+         cls.no_magma = not torch.cuda.has_magma
+
+
++class XLATestBase(DeviceTypeTestBase):
++    device_type = 'xla'
++
++    allowed_tests = {
++        'test_addcdiv',
++        'test_addcmul',
++        'test_diagonal',
++        'test_isinf',
++        'test_inverse_many_batches',
++        'test_matrix_power',
++        'test_chain_matmul',
++        'test_solve',
++        'test_solve_batched',
++        'test_solve_batched_non_contiguous',
++        'test_solve_batched_many_batches',
++        'test_solve_batched_broadcasting',
++        'test_cholesky_solve',
++        'test_cholesky_solve_batched',
++        'test_cholesky_solve_batched_many_batches',
++        'test_cholesky_solve_batched_broadcasting',
++        'test_cholesky_inverse',
++        'test_cholesky_batched_many_batches',
++        'test_cholesky',
++        'test_rot90',
++        'test_signal_window_functions',
++        'test_broadcast_fused_matmul',
++        'test_index',
++        'test_advancedindex_big',
++        'test_kthvalue',
++        'test_lu_solve_batched_many_batches',
++        'test_lu_solve_batched_broadcasting',
++        'test_dim_reduction',
++        'test_remainder_overflow',
++        'test_rpow',
++        'test_lerp',
++        'test_nuclear_norm_exceptions',
++        'test_geqrf',
++        'test_triangular_solve',
++        'test_random_neg_values',
++        'test_multinomial_alias',
++        'test_lapack_empty',
++        'test_nonzero_empty',
++        'test_normal',
++        'test_logical_any',
++        'test_logical_all',
++        'test_log_normal',
++        'test_geometric',
++        'test_cdist_empty',
++        'test_cdist_large',
++        'test_cdist_large_batch',
++        'test_multinomial_constraints',
++        'test_mul',
++        'test_cumprod',
++        'test_std_mean',
++        'test_std_mean_all_dims',
++        'test_var_mean',
++        'test_var_mean_all_dims',
++        'test_std_mean_some_dims',
++        'test_zeros_like',
++        'test_histc',
++        'test_bool_tensor_comparison_ops',
++        'test_bool_tensor_value_change',
++        'test_addcmul',
++        'test_tensordot',
++        'test_narrow_empty',
++        'test_linspace',
++        'test_index_fill',
++        'test_take_empty',
++        'test_put_empty',
++        'test_scatter_to_large_input',
++        'test_scatter_add_to_large_input',
++        'test_scatter_bool',
++        'test_scatter_add_bool',
++        'test_masked_scatter_bool_tensor',
++        'test_atan2',
++        'test_atan2_edgecases',
++        'test_trapz',
++        'test_addcdiv',
++        'test_unary_out_op_mem_overlap',
++        'test_binary_op_mem_overlap',
++        'test_ternary_op_mem_overlap',
++        'test_int_pow',
++        'test_int_tensor_pow_neg_ints',
++        'test_long_tensor_pow_floats',
++        'test_var_mean_some_dims'
++    }
++
++    # Overrides to instantiate tests that are known to run quickly
++    # and correctly on XLA.
++    @classmethod
++    def instantiate_test(cls, test):
++        if test.__name__ in cls.allowed_tests:
++            super().instantiate_test(test)
++        else:
++            test_name = test.__name__ + "_" + cls.device_type
++
++            assert not hasattr(cls, test_name), "Redefinition of test {0}".format(test_name)
++
++            @wraps(test)
++            def disallowed_test(self, test=test):
++                raise unittest.SkipTest("skipped on XLA")
++                return test(self, cls.device_type)
++
++            setattr(cls, test_name, disallowed_test)
++
++
+ # Adds available device-type-specific test base classes
+ device_type_test_bases.append(CPUTestBase)
+ if torch.cuda.is_available():
+     device_type_test_bases.append(CUDATestBase)
++device_type_test_bases.append(XLATestBase)
+
+
+ # Adds 'instantiated' device-specific test cases to the given scope.


### PR DESCRIPTION
- Adds XLA device type to device type testing framework
- Currently uses an explicit "allowable tests" list developed via manual review

Test by applying patches and building as normal, then running test_torch.py. XLA tests should run in addition to CPU and CUDA (if available) test variants. 