### PR TITLE
Only override pytorch/xla sys.path when required

### DIFF
--- a/test/args_parse.py
+++ b/test/args_parse.py
@@ -29,6 +29,7 @@ def parse_common_options(datadir=None,
   parser.add_argument('--fake_data', action='store_true')
   parser.add_argument('--tidy', action='store_true')
   parser.add_argument('--metrics_debug', action='store_true')
+  parser.add_argument('--local_torch_xla_changes', action='store_true')
   if opts:
     for name, aopts in opts:
       parser.add_argument(name, **aopts)
@@ -37,5 +38,6 @@ def parse_common_options(datadir=None,
   # Setup import folders.
   xla_folder = os.path.dirname(os.path.dirname(os.path.abspath(sys.argv[0])))
   sys.path.append(os.path.join(os.path.dirname(xla_folder), 'test'))
-  sys.path.insert(0, xla_folder)
+  if args.local_torch_xla_changes:
+    sys.path.insert(0, xla_folder)
   return args

--- a/test/args_parse.py
+++ b/test/args_parse.py
@@ -29,7 +29,6 @@ def parse_common_options(datadir=None,
   parser.add_argument('--fake_data', action='store_true')
   parser.add_argument('--tidy', action='store_true')
   parser.add_argument('--metrics_debug', action='store_true')
-  parser.add_argument('--local_torch_xla_changes', action='store_true')
   if opts:
     for name, aopts in opts:
       parser.add_argument(name, **aopts)
@@ -38,6 +37,6 @@ def parse_common_options(datadir=None,
   # Setup import folders.
   xla_folder = os.path.dirname(os.path.dirname(os.path.abspath(sys.argv[0])))
   sys.path.append(os.path.join(os.path.dirname(xla_folder), 'test'))
-  if args.local_torch_xla_changes:
+  if os.path.isfile(os.path.join(xla_folder, 'torch_xla/version.py')):
     sys.path.insert(0, xla_folder)
   return args

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -1,5 +1,10 @@
 import torch
-from .version import __version__
 import _XLAC
+
+try:
+  from .version import __version__
+except ImportError:
+  # Only wheel installation has torch_xla.version module
+  __version__ = ''
 
 _XLAC._initialize_aten_bindings()

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -1,10 +1,5 @@
 import torch
+from .version import __version__
 import _XLAC
-
-try:
-  from .version import __version__
-except ImportError:
-  # Only wheel installation has torch_xla.version module
-  __version__ = ''
 
 _XLAC._initialize_aten_bindings()


### PR DESCRIPTION
Currenlty we always override `torch_xla` where version.py doesn't live
locally and thus fail to import `__version__` which is only in the
distributed egg so we also add try-catch there and set empty version
when using local changes.