### PR TITLE
Unbreak tests - importing common_utils fails

### DIFF
--- a/test/args_parse.py
+++ b/test/args_parse.py
@@ -34,4 +34,7 @@ def parse_common_options(datadir=None,
       parser.add_argument(name, **aopts)
   args, leftovers = parser.parse_known_args()
   sys.argv = [sys.argv[0]] + leftovers
+  # Setup import folders.
+  xla_folder = os.path.dirname(os.path.dirname(os.path.abspath(sys.argv[0])))
+  sys.path.append(os.path.join(os.path.dirname(xla_folder), 'test'))
   return args


### PR DESCRIPTION
`common_utils` is in upstream `pytorch/test` and we can't find it without adding it to sys.path. Synced with ailzhang@ offline. We'll find a way to not mess with sys.path but unbreak tests for now.