### PR TITLE
Move the metrics report into a dedicated xla_model API.

### DIFF
--- a/API_GUIDE.md
+++ b/API_GUIDE.md
@@ -74,11 +74,12 @@ Code for multiprocessing looks like:
 
 ```python
 import torch_xla.core.xla_model as xm
+import torch_xla.distributed.parallel_loader as pl
 import torch_xla.distributed.xla_multiprocessing as xmp
 
 def _mp_fn(index):
   device = xm.xla_device()
-  para_loader = dp.ParallelLoader(train_loader, [device])
+  para_loader = pl.ParallelLoader(train_loader, [device])
 
   model = MNIST()
   loss_fn = nn.NLLLoss()

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -14,7 +14,9 @@ report sent to us if you have it.
 Put the following line in your program to generate a report:
 
 ```Python
-print(torch_xla._XLAC._xla_metrics_report())
+import torch_xla.debug.metrics as met
+
+print(met.metrics_report())
 ```
 
 ## Understand The Metrics Report

--- a/test/bench.py
+++ b/test/bench.py
@@ -18,6 +18,7 @@ import torch.nn as nn
 import torch.optim as optim
 import torch_xla
 import torch_xla.distributed.data_parallel as dp
+import torch_xla.debug.metrics as met
 import torch_xla.debug.model_comparator as mc
 import torch_xla.distributed.parallel_loader as pl
 import torch_xla.utils.utils as xu
@@ -68,7 +69,7 @@ class BaseBench(object):
         now = time.time()
       print('{}: {:.3f}ms per loop'.format(bench_name,
                                            1000.0 * (now - start) / count))
-      xu.get_print_fn()(torch_xla._XLAC._xla_metrics_report())
+      xu.get_print_fn()(met.metrics_report())
     except Exception as e:
       xu.eprint('Failed running benchmark "{}": {}'.format(bench_name, e))
 

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -31,6 +31,7 @@ import torch.nn.functional as F
 import torch.optim as optim
 import torch_xla
 import torch_xla.distributed.data_parallel as dp
+import torch_xla.debug.metrics as met
 import torch_xla.debug.model_comparator as mc
 import torch_xla.distributed.parallel_loader as pl
 import torch_xla.utils.utils as xu
@@ -251,17 +252,18 @@ class TestToXlaTensorArena(XlaTestCase):
 class TestParallelLoader(XlaTestCase):
 
   def test(self):
-    devices = xm.get_xla_supported_devices()
+    devices = [torch.device(x) for x in xm.get_xla_supported_devices()]
     A = 3.11
     B = 4.09
     batch_size = 128 * len(devices)
     gen = xu.FnDataGenerator(
         lambda x: x * A + B, batch_size, _gen_tensor, dims=[8], count=10)
-    para_loader = pl.ParallelLoader(gen, batch_size, devices)
-    for x, (data, target) in para_loader:
-      for device in devices:
-        dx = para_loader.to(data, device)
-        self.assertEqual(dx.device, torch.device(device))
+    para_loader = pl.ParallelLoader(gen, devices)
+    for device in devices:
+      loader = para_loader.per_device_loader(device)
+      for x, (data, target) in loader:
+        self.assertEqual(data.device, device)
+        self.assertEqual(target.device, device)
 
 
 class TestAtenTensorTo(XlaTestCase):
@@ -989,5 +991,5 @@ if __name__ == '__main__':
       use_full_mat_mul_precision=True)
   test = unittest.main(verbosity=FLAGS.verbosity, exit=False)
   if xu.getenv_as('METRICS_DEBUG', bool, defval=False):
-    print(torch_xla._XLAC._xla_metrics_report())
+    print(met.metrics_report())
   sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/test_train_cifar.py
+++ b/test/test_train_cifar.py
@@ -24,6 +24,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 import torch_xla
+import torch_xla.debug.metrics as met
 import torch_xla.distributed.data_parallel as dp
 import torch_xla.utils.utils as xu
 import torch_xla.core.xla_model as xm
@@ -215,7 +216,7 @@ def train_cifar():
     accuracy = sum(accuracies) / len(accuracies)
     print("Epoch: {}, Mean Accuracy: {:.2f}%".format(epoch, accuracy))
     if FLAGS.metrics_debug:
-      print(torch_xla._XLAC._xla_metrics_report())
+      print(met.metrics_report())
 
   return accuracy
 

--- a/test/test_train_imagenet.py
+++ b/test/test_train_imagenet.py
@@ -49,6 +49,7 @@ from torch.utils.tensorboard import SummaryWriter
 import torchvision
 import torchvision.transforms as transforms
 import torch_xla
+import torch_xla.debug.metrics as met
 import torch_xla.distributed.data_parallel as dp
 import torch_xla.utils.utils as xu
 import torch_xla.core.xla_model as xm
@@ -232,7 +233,7 @@ def train_imagenet():
     test_utils.add_scalar_to_summary(writer, 'Accuracy/test', accuracy,
                                      global_step)
     if FLAGS.metrics_debug:
-      print(torch_xla._XLAC._xla_metrics_report())
+      print(met.metrics_report())
 
   return accuracy
 

--- a/test/test_train_mnist.py
+++ b/test/test_train_mnist.py
@@ -20,6 +20,7 @@ import torch.optim as optim
 from torchvision import datasets, transforms
 import torch_xla
 import torch_xla.distributed.data_parallel as dp
+import torch_xla.debug.metrics as met
 import torch_xla.utils.utils as xu
 import torch_xla.core.xla_model as xm
 import unittest
@@ -149,7 +150,7 @@ def train_mnist():
     accuracies = model_parallel(test_loop_fn, test_loader)
     accuracy = sum(accuracies) / len(accuracies)
     if FLAGS.metrics_debug:
-      print(torch_xla._XLAC._xla_metrics_report())
+      print(met.metrics_report())
 
   return accuracy
 

--- a/test/test_train_mp_imagenet.py
+++ b/test/test_train_mp_imagenet.py
@@ -49,7 +49,9 @@ from torch.utils.tensorboard import SummaryWriter
 import torchvision
 import torchvision.transforms as transforms
 import torch_xla
+import torch_xla.debug.metrics as met
 import torch_xla.distributed.data_parallel as dp
+import torch_xla.distributed.parallel_loader as pl
 import torch_xla.utils.utils as xu
 import torch_xla.core.xla_model as xm
 import torch_xla.distributed.xla_multiprocessing as xmp
@@ -207,16 +209,16 @@ def train_imagenet():
 
   accuracy = 0.0
   for epoch in range(1, FLAGS.num_epochs + 1):
-    para_loader = dp.ParallelLoader(train_loader, [device])
+    para_loader = pl.ParallelLoader(train_loader, [device])
     train_loop_fn(para_loader.per_device_loader(device))
 
-    para_loader = dp.ParallelLoader(test_loader, [device])
+    para_loader = pl.ParallelLoader(test_loader, [device])
     accuracy = test_loop_fn(para_loader.per_device_loader(device))
     print('Epoch: {}, Mean Accuracy: {:.2f}%'.format(epoch, accuracy))
     test_utils.add_scalar_to_summary(writer, 'Accuracy/test', accuracy, epoch)
 
     if FLAGS.metrics_debug:
-      print(torch_xla._XLAC._xla_metrics_report())
+      print(met.metrics_report())
 
   return accuracy
 

--- a/test/test_train_mp_mnist.py
+++ b/test/test_train_mp_mnist.py
@@ -19,7 +19,9 @@ import torch.nn.functional as F
 import torch.optim as optim
 from torchvision import datasets, transforms
 import torch_xla
+import torch_xla.debug.metrics as met
 import torch_xla.distributed.data_parallel as dp
+import torch_xla.distributed.parallel_loader as pl
 import torch_xla.utils.utils as xu
 import torch_xla.core.xla_model as xm
 import torch_xla.distributed.xla_multiprocessing as xmp
@@ -133,13 +135,13 @@ def train_mnist():
 
   accuracy = 0.0
   for epoch in range(1, FLAGS.num_epochs + 1):
-    para_loader = dp.ParallelLoader(train_loader, [device])
+    para_loader = pl.ParallelLoader(train_loader, [device])
     train_loop_fn(para_loader.per_device_loader(device))
 
-    para_loader = dp.ParallelLoader(test_loader, [device])
+    para_loader = pl.ParallelLoader(test_loader, [device])
     accuracy = test_loop_fn(para_loader.per_device_loader(device))
     if FLAGS.metrics_debug:
-      print(torch_xla._XLAC._xla_metrics_report())
+      print(met.metrics_report())
 
   return accuracy
 

--- a/torch_xla/debug/metrics.py
+++ b/torch_xla/debug/metrics.py
@@ -1,0 +1,7 @@
+from __future__ import print_function
+
+import torch_xla
+
+
+def metrics_report():
+  return torch_xla._XLAC._xla_metrics_report()

--- a/torch_xla/debug/metrics_saver.py
+++ b/torch_xla/debug/metrics_saver.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import os
 import threading
 import torch_xla
+import torch_xla.debug.metrics as met
 
 _STEP_METRICS_FILE = os.environ.get('XLA_METRICS_FILE', None)
 _STEP_METRICS_FILE_LOCK = threading.Lock()
@@ -12,7 +13,7 @@ def save_metrics(metrics_file=None):
   if metrics_file is None:
     metrics_file = _STEP_METRICS_FILE
   if metrics_file is not None:
-    metrics_data = torch_xla._XLAC._xla_metrics_report()
+    metrics_data = met.metrics_report()
     if metrics_file == 'STDERR':
       print(metrics_data, file=sys.stderr)
     elif metrics_file == 'STDOUT':

--- a/torch_xla/distributed/data_parallel.py
+++ b/torch_xla/distributed/data_parallel.py
@@ -2,14 +2,13 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-from six import iteritems, itervalues
 from copy import deepcopy
 import sys
 import threading
 import torch
 import torch.autograd
 import torch_xla
-import torch_xla.utils.keyd_queue as kq
+import torch_xla.distributed.parallel_loader as pl
 import torch_xla.utils.utils as xu
 import torch_xla.core.xla_model as xm
 import traceback
@@ -32,145 +31,6 @@ class ThreadResult(object):
 
   def __init__(self):
     self.result = None
-
-
-class PerDeviceQueue(object):
-
-  def __init__(self, device, loader_prefetch_size, device_prefetch_size):
-    self.device = device
-    self.batch_number = 0
-    self.loader_queue = kq.Queue(maxsize=loader_prefetch_size)
-    self.queue = kq.Queue(maxsize=device_prefetch_size)
-
-
-class PerDeviceLoader(object):
-
-  def __init__(self, loader, device):
-    self._loader = loader
-    self._device = device
-
-  def __iter__(self):
-    return self
-
-  def __next__(self):
-    return self.next()
-
-  def next(self):
-    xm.mark_step()
-    item = self._loader.next_item(self._device)
-    if item is None:
-      raise StopIteration
-    return item
-
-
-class ParallelLoader(object):
-
-  def __init__(self,
-               loader,
-               devices,
-               batchdim=0,
-               fixed_batch_size=False,
-               loader_prefetch_size=8,
-               device_prefetch_size=4):
-    self._loader = loader
-    self._devices = list(devices)
-    self._batchdim = batchdim
-    self._fixed_batch_size = fixed_batch_size
-    self._done = False
-    self._queues = dict()
-    for device in self._devices:
-      self._queues[device] = PerDeviceQueue(device, loader_prefetch_size,
-                                            device_prefetch_size)
-    thread = threading.Thread(target=self._loader_worker)
-    thread.daemon = True
-    thread.start()
-    for dqueue in itervalues(self._queues):
-      thread = threading.Thread(target=self._worker, args=(dqueue,))
-      thread.daemon = True
-      thread.start()
-
-  def per_device_loader(self, device):
-    return PerDeviceLoader(self, device)
-
-  def next_item(self, device):
-    dqueue = self._queues[device]
-    return dqueue.queue.get()
-
-  def close(self):
-    self._done = True
-    for dqueue in itervalues(self._queues):
-      dqueue.queue.close()
-      dqueue.loader_queue.close()
-
-  def _get_batch_size(self, data, dim):
-    size = []
-
-    def fn(v):
-      csize = v.size()[dim]
-      if not size:
-        size.append(csize)
-      else:
-        assert csize == size[0]
-
-    xu.for_each_instance(data, torch.Tensor, fn)
-    return size[0] if size else None
-
-  def _send_data_to(self, data, device):
-
-    def convert_fn(tensors):
-      devices = [str(device)] * len(tensors)
-      return torch_xla._XLAC._xla_tensors_from_aten(tensors, devices)
-
-    def select_fn(v):
-      return type(v) == torch.Tensor
-
-    return xm.ToXlaTensorArena(convert_fn, select_fn).transform(data)
-
-  def _loader_worker(self):
-    batch_number = 0
-    queues = list(self._queues.values())
-    data_iter = enumerate(self._loader)
-    batch_size = None
-    batch = []
-    while not self._done:
-      try:
-        _, data = next(data_iter)
-      except StopIteration:
-        break
-      if self._fixed_batch_size:
-        if batch_size is None:
-          batch_size = self._get_batch_size(data, self._batchdim)
-        elif batch_size != self._get_batch_size(data, self._batchdim):
-          break
-      batch.append((batch_number, data))
-      batch_number += 1
-      if len(batch) == len(self._devices):
-        for queue_no, device_batch in enumerate(batch):
-          queues[queue_no].loader_queue.put(device_batch)
-        batch = []
-    for dqueue in queues:
-      dqueue.loader_queue.close_write()
-
-  def _get_batch(self, dqueue):
-    batch = []
-    while dqueue.queue.max_size() > len(batch):
-      item = dqueue.loader_queue.get()
-      if item is None:
-        break
-      batch.append(item[1])
-    return batch
-
-  def _worker(self, dqueue):
-    device = torch.device(dqueue.device)
-    while True:
-      batch = self._get_batch(dqueue)
-      if not batch:
-        break
-      batch = self._send_data_to(batch, device)
-      for data in batch:
-        dqueue.queue.put((dqueue.batch_number, data))
-        dqueue.batch_number += 1
-    dqueue.queue.close_write()
 
 
 class DataParallel(object):
@@ -239,7 +99,7 @@ class DataParallel(object):
                   torch.device(self._device_ids[0]), self._contexts[0])
       ]
 
-    para_loader = ParallelLoader(
+    para_loader = pl.ParallelLoader(
         loader,
         self._device_ids,
         batchdim=self._batchdim,


### PR DESCRIPTION
Remove the old ParallelLoader, and move the new one into the proper file.