### PR TITLE
Throw proper error for viewing empty tensor.

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -658,6 +658,14 @@ class TestAtenXlaTensor(XlaTestCase):
         10, (2, 3)), torch.randint(10, (3, 3))),
                      lambda x, y, z: torch.addmm(x, y, z))
 
+  def test_view_empty(self):
+    # These used to throw floating point exception.
+    empty = torch.empty(0, device=xm.xla_device())
+    with self.assertRaisesRegex(RuntimeError, r'unspecified dimension size -1 can be any value'):
+        empty.view(-1, 0)
+    with self.assertRaisesRegex(RuntimeError, r'unspecified dimension size -1 can be any value'):
+        empty.view(3, 0, -1, 0)
+
   def test_pred_type(self):
     xla_device = xm.xla_device()
     a = torch.rand(4)

--- a/torch_xla/csrc/data_ops.cpp
+++ b/torch_xla/csrc/data_ops.cpp
@@ -38,6 +38,10 @@ std::vector<xla::int64> GetCompleteShape(
         << absl::StrJoin(input_sizes, ", ") << "]";
     return xla::util::ToVector<xla::int64>(output_sizes);
   }
+  XLA_CHECK_GT(incomplete_element_count, 0)
+      << "Cannot reshape tensor of 0 elements into shape "
+      << "[" << absl::StrJoin(output_sizes, ", ")
+      << "] because the unspecified dimension size -1 can be any value";
   XLA_CHECK_EQ(total_element_count % incomplete_element_count, 0)
       << "[" << absl::StrJoin(output_sizes, ", ") << "] vs. ["
       << absl::StrJoin(input_sizes, ", ") << "]";


### PR DESCRIPTION
The corresponding pytorch tests checks for non-compatible strided view which is not applicable to XLA (assume contiguous to users). 
So I just port the part of test is valuable, that viewing empty tensor used to throw floating point exception(divide by 0), now it has a proper error message. 