### PR TITLE
Revert "Remove override of Tensor::numel since this goes directly to TensorIm…"

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -81,6 +81,11 @@ void AtenInitialize() {
 
 }  // namespace
 
+int64_t AtenXlaType::numel(const at::Tensor& self) {
+  XLATensor self_tensor = bridge::GetXlaTensor(self);
+  return xla::ShapeUtil::ElementsIn(self_tensor.shape());
+}
+
 at::Tensor AtenXlaType::__and__(const at::Tensor& self, at::Scalar other) {
   return bridge::AtenFromXlaTensor(
       XLATensor::__and__(bridge::GetXlaTensor(self), other));

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -799,6 +799,8 @@ class AtenXlaType {
 
   static at::Tensor nuclear_norm(const at::Tensor& self, bool keepdim);
 
+  static int64_t numel(const at::Tensor& self);
+
   static at::Tensor one_hot(const at::Tensor& self, int64_t num_classes);
 
   static at::Tensor ones(at::IntArrayRef size,


### PR DESCRIPTION
Reverts pytorch/xla#1136