### PR TITLE
Added missing documentation to replace PLACEHOLDERs.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,10 +23,12 @@ distributed
 .. automodule:: torch_xla.distributed.parallel_loader
 
 .. autoclass:: ParallelLoader
+	       :members: per_device_loader
 
 .. automodule:: torch_xla.distributed.data_parallel
 
 .. autoclass:: DataParallel
+	       :members: __call__
 
 .. automodule:: torch_xla.distributed.xla_multiprocessing
 

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -30,7 +30,17 @@ def parse_xla_device(device):
 
 
 def get_xla_supported_devices(devkind=None, max_devices=None):
-  """get_xla_supported_devices (PLACEHOLDER)"""
+  """Returns a list of supported devices of a given kind.
+
+  Args:
+    devkind (string..., optional): If specified, one of `TPU`, `GPU` or `CPU`
+      (the 'GPU' XLA device is currently not implemented).
+    max_devices (int, optional): The maximum number of devices to be returned of
+      that kind.
+
+  Returns:
+    The list of device strings.
+  """
 
   xla_devices = torch_xla._XLAC._xla_get_devices()
   devkind = devkind or ['TPU', 'GPU', 'CPU']
@@ -44,19 +54,43 @@ def get_xla_supported_devices(devkind=None, max_devices=None):
 
 
 def xrt_world_size(defval=1):
-  """xrt_world_size (PLACEHOLDER)"""
+  """Retrieves the number of devices which is taking part of the replication.
+
+  Args:
+    defval (int, optional): The default value to be returned in case there is no
+      replication information available.
+      Default: 1
+
+  Returns:
+    The number of devices which is taking part of the replication.
+  """
 
   return xu.getenv_as(xenv.WORLD_SIZE, int, defval=defval)
 
 
 def get_ordinal(defval=0):
-  """get_ordinal (PLACEHOLDER)"""
+  """Retrieves the replication ordinal of the current process.
+
+  The ordinals range from 0 to `xrt_world_size()` minus 1.
+
+  Args:
+    defval (int, optional): The default value to be returned in case there is no
+      replication information available.
+      Default: 0
+
+  Returns:
+    The replication ordinal of the current process.
+  """
 
   return xu.getenv_as(xenv.ORDINAL, int, defval=defval)
 
 
 def is_master_ordinal():
-  """is_master_ordinal (PLACEHOLDER)"""
+  """Checks whether the current process is the master ordinal (0).
+
+  Returns:
+    A boolean indicating whether the current process is the master ordinal.
+  """
 
   ordinal = get_ordinal(defval=-1)
   if ordinal >= 0:
@@ -72,7 +106,18 @@ def master_print(s, fd=sys.stdout):
 
 
 def xla_device(n=None, devkind=None):
-  """xla_device (PLACEHOLDER)"""
+  """Returns a given instance of an XLA device.
+
+  Args:
+    n (int, optional): The specific instance (ordinal) to be returned. If
+      specified, the specific XLA device instance will be returned. Otherwise
+      the first device of `devkind` will be returned.
+    devkind (string..., optional): If specified, one of `TPU`, `GPU` or `CPU`
+      (the 'GPU' XLA device is currently not implemented).
+
+  Returns:
+    A `torch.device` with the requested instance.
+  """
 
   if n is None:
     devices = get_xla_supported_devices(devkind=devkind)
@@ -81,9 +126,10 @@ def xla_device(n=None, devkind=None):
     # to just have a single device to run on. Set the default device so that
     # the tensor barrier can work correctly and avoid growing graphs surprises.
     device = devices[0]
-    torch_xla._XLAC._xla_set_default_device(device)
-    return torch.device(device)
-  return torch.device('xla:{}'.format(n))
+  else:
+    device = 'xla:{}'.format(n)
+  torch_xla._XLAC._xla_set_default_device(device)
+  return torch.device(device)
 
 
 def xla_real_devices(devices):
@@ -377,7 +423,23 @@ def mark_step():
 
 
 def optimizer_step(optimizer, barrier=False, optimizer_args={}):
-  """optimizer_step (PLACEHOLDER)"""
+  """Run the provided optimizer step and issue the XLA device step computation.
+
+  Args:
+    optimizer (:class:`torch.Optimizer`): The `torch.Optimizer` instance whose
+      `step()` function needs to be called. The `step()` function will be called
+      with the `optimizer_args` named arguments.
+    barrier (bool, optional): Whether the XLA tensor barrier should be issued in
+      this API. If using the PyTorch XLA `ParallelLoader` or `DataParallel`
+      support, this is not necessary as the barrier will be issued by the XLA
+      data loader iterator `next()` call.
+      Default: False
+    optimizer_args (dict, optional): Named arguments dictionary for the
+      `optimizer.step()` call.
+
+  Returns:
+    The same value returned by the `optimizer.step()` call.
+  """
 
   gradients = _fetch_gradients(optimizer)
   count = torch_xla._XLAC._xla_get_replication_devices_count()

--- a/torch_xla/distributed/xla_multiprocessing.py
+++ b/torch_xla/distributed/xla_multiprocessing.py
@@ -116,7 +116,24 @@ def _start_fn(index, fn, args):
 
 
 def spawn(fn, args=(), nprocs=None, join=True, daemon=False):
-  """spawn (PLACEHOLDER)"""
+  """Enables multi processing based replication.
+
+  Args:
+    fn: The function to be called for each device which takes part of the
+      replication. The function will be called with a first argument being the
+      global index of the process within the replication, followed by the
+      arguments passed in `args`.
+    args: The arguments for `fn`.
+    nprocs: The number of processes/devices for the replication. At the moment,
+      if specified, can be either 1 or the maximum number of devices.
+    join: Whether the call should block waiting for the completion of the
+      processes which have being spawned.
+    daemon: Whether the processes being spawned should have the `daemon` flag
+      set (see Python multi-processing API).
+
+  Returns:
+    The same object returned by the `torch.multiprocessing.spawn` API.
+  """
 
   if not _is_tpu_config():
     # If this is not an TPU setup, jump to normal multi-processing.

--- a/torch_xla/utils/utils.py
+++ b/torch_xla/utils/utils.py
@@ -25,7 +25,14 @@ class TmpFolder(object):
 
 
 class SampleGenerator(object):
-  """SampleGenerator (PLACEHOLDER)"""
+  """Iterator which returns multiple samples of a given input data.
+
+  Can be used in place of a PyTorch `DataLoader` to generate synthetic data.
+
+  Args:
+    data: The data which should be returned at each iterator step.
+    sample_count: The maximum number of `data` samples to be returned.
+  """
 
   def __init__(self, data, sample_count):
     self._data = data


### PR DESCRIPTION
@mruberry The `DataParallel.__call__()` did not have a PLACEHOLDER but I added documentation as well, and this need to be public.
