### PR TITLE
Update colab notebooks

### DIFF
--- a/contrib/colab/mnist-training-xrt-1-15.ipynb
+++ b/contrib/colab/mnist-training-xrt-1-15.ipynb
@@ -5,7 +5,8 @@
     "colab": {
       "name": "[PT Devcon 2019] PyTorch/TPU MNIST",
       "provenance": [],
-      "collapsed_sections": []
+      "collapsed_sections": [],
+      "machine_shape": "hm"
     },
     "kernelspec": {
       "name": "python3",
@@ -17,7 +18,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "FuwrbN1PHChL",
+        "id": "0WzFpOKDmURO",
         "colab_type": "text"
       },
       "source": [
@@ -29,19 +30,45 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "tGGfJA4ACw07",
+        "id": "xOp9jBEumdvC",
         "colab_type": "text"
       },
       "source": [
-        "### (RUNME) Install Colab TPU compatible PyTorch/TPU wheels and dependencies\n",
-        "This may take up to ~2 minutes\n",
-        "\n"
+        "<h3>  &nbsp;&nbsp;Use Colab Cloud TPU&nbsp;&nbsp; <a href=\"https://cloud.google.com/tpu/\"><img valign=\"middle\" src=\"https://raw.githubusercontent.com/GoogleCloudPlatform/tensorflow-without-a-phd/master/tensorflow-rl-pong/images/tpu-hexagon.png\" width=\"50\"></a></h3>\n",
+        "\n",
+        "* On the main menu, click Runtime and select **Change runtime type**. Set \"TPU\" as the hardware accelerator.\n",
+        "* The cell below makes sure you have access to a TPU on Colab.\n"
       ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "id": "un5d9etDG7tO",
+        "id": "Hx4YVNHametU",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "import os\n",
+        "assert os.environ['COLAB_TPU_ADDR'], 'Make sure to select TPU from Edit > Notebook settings > Hardware accelerator'"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "YofXQrnxmf5r",
+        "colab_type": "text"
+      },
+      "source": [
+        "### [RUNME] Install Colab TPU compatible PyTorch/TPU wheels and dependencies\n",
+        "This may take up to ~2 minutes"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "sPJVqAKyml5W",
         "colab_type": "code",
         "colab": {}
       },
@@ -67,18 +94,17 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "hPCPnjflCpq-",
+        "id": "iwoK4kGUmoHL",
         "colab_type": "text"
       },
       "source": [
-        "### Define Parameters\n",
-        "\n"
+        "### Define Parameters\n"
       ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "id": "jvLoRbYpClnx",
+        "id": "kNh-oEmHmorI",
         "colab_type": "code",
         "colab": {}
       },
@@ -99,7 +125,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "Vrb08STUO5Pz",
+        "id": "pTmxZL5ymp8P",
         "colab_type": "code",
         "colab": {}
       },
@@ -212,7 +238,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "EBRzfYprFDbo",
+        "id": "ALSuICwVmrOA",
         "colab_type": "code",
         "colab": {}
       },
@@ -236,7 +262,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "zaaW5RWAJQO2",
+        "id": "MznTE72_mthI",
         "colab_type": "text"
       },
       "source": [
@@ -246,7 +272,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "5bHyp9HWJPoz",
+        "id": "Qp23aPMOmu0E",
         "colab_type": "code",
         "colab": {}
       },

--- a/contrib/colab/resnet18-training-xrt-1-15.ipynb
+++ b/contrib/colab/resnet18-training-xrt-1-15.ipynb
@@ -5,7 +5,8 @@
     "colab": {
       "name": "[PT Devcon 2019] PyTorch/TPU ResNet18/CIFAR10",
       "provenance": [],
-      "collapsed_sections": []
+      "collapsed_sections": [],
+      "machine_shape": "hm"
     },
     "kernelspec": {
       "name": "python3",
@@ -17,7 +18,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "FuwrbN1PHChL",
+        "id": "YX1hxqUQn47M",
         "colab_type": "text"
       },
       "source": [
@@ -29,11 +30,24 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "tGGfJA4ACw07",
+        "id": "QYOlFL-Sn5cq",
         "colab_type": "text"
       },
       "source": [
-        "### (RUNME) Install Colab TPU compatible PyTorch/TPU wheels and dependencies\n",
+        "<h3>  &nbsp;&nbsp;Use Colab Cloud TPU&nbsp;&nbsp; <a href=\"https://cloud.google.com/tpu/\"><img valign=\"middle\" src=\"https://raw.githubusercontent.com/GoogleCloudPlatform/tensorflow-without-a-phd/master/tensorflow-rl-pong/images/tpu-hexagon.png\" width=\"50\"></a></h3>\n",
+        "\n",
+        "* On the main menu, click Runtime and select **Change runtime type**. Set \"TPU\" as the hardware accelerator.\n",
+        "* The cell below makes sure you have access to a TPU on Colab.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "pLQPoJ6Fn8wF",
+        "colab_type": "text"
+      },
+      "source": [
+        "### [RUNME] Install Colab TPU compatible PyTorch/TPU wheels and dependencies\n",
         "This may take up to ~2 minutes\n",
         "\n"
       ]
@@ -41,7 +55,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "un5d9etDG7tO",
+        "id": "O53lrJMDn9Rd",
         "colab_type": "code",
         "colab": {}
       },
@@ -67,7 +81,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "hPCPnjflCpq-",
+        "id": "rroH9yiAn-XE",
         "colab_type": "text"
       },
       "source": [
@@ -78,7 +92,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "jvLoRbYpClnx",
+        "id": "iMdPRFXIn_jH",
         "colab_type": "code",
         "colab": {}
       },
@@ -112,7 +126,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "IJd5YtDMTJsL",
+        "id": "Micd3xZvoA-c",
         "colab_type": "code",
         "colab": {}
       },
@@ -191,7 +205,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "Vrb08STUO5Pz",
+        "id": "8vMl96KLoCq8",
         "colab_type": "code",
         "colab": {}
       },
@@ -283,7 +297,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "EBRzfYprFDbo",
+        "id": "_2nL4HmloEyl",
         "colab_type": "code",
         "colab": {}
       },
@@ -307,7 +321,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "urPfjQ-xJZph",
+        "id": "_wt7wEVJoFmf",
         "colab_type": "text"
       },
       "source": [
@@ -317,7 +331,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "od5mOHfy4bHK",
+        "id": "mSdVUMPjoGhy",
         "colab_type": "code",
         "colab": {}
       },

--- a/contrib/colab/resnet50-inference-xrt-1-15.ipynb
+++ b/contrib/colab/resnet50-inference-xrt-1-15.ipynb
@@ -5,9 +5,8 @@
     "colab": {
       "name": "[PT Devcon 2019] PyTorch/TPU ResNet50 Inference",
       "provenance": [],
-      "collapsed_sections": [
-        "u3aMc9awWYB8"
-      ]
+      "collapsed_sections": [],
+      "machine_shape": "hm"
     },
     "kernelspec": {
       "name": "python3",
@@ -19,7 +18,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "FuwrbN1PHChL",
+        "id": "UHKEkDHRpKcN",
         "colab_type": "text"
       },
       "source": [
@@ -32,11 +31,38 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "tGGfJA4ACw07",
+        "id": "tWj3au5upQh1",
         "colab_type": "text"
       },
       "source": [
-        "### (RUNME) Install Colab TPU compatible PyTorch/TPU wheels and dependencies\n",
+        "<h3>  &nbsp;&nbsp;Use Colab Cloud TPU&nbsp;&nbsp; <a href=\"https://cloud.google.com/tpu/\"><img valign=\"middle\" src=\"https://raw.githubusercontent.com/GoogleCloudPlatform/tensorflow-without-a-phd/master/tensorflow-rl-pong/images/tpu-hexagon.png\" width=\"50\"></a></h3>\n",
+        "\n",
+        "* On the main menu, click Runtime and select **Change runtime type**. Set \"TPU\" as the hardware accelerator.\n",
+        "* The cell below makes sure you have access to a TPU on Colab.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "n0ycw8UJpSSc",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "import os\n",
+        "assert os.environ['COLAB_TPU_ADDR'], 'Make sure to select TPU from Edit > Notebook settings > Hardware accelerator'"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "XOBxO6smpTjx",
+        "colab_type": "text"
+      },
+      "source": [
+        "### [RUNME] Install Colab TPU compatible PyTorch/TPU wheels and dependencies\n",
         "This may take up to ~2 minutes\n",
         "\n"
       ]
@@ -44,7 +70,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "un5d9etDG7tO",
+        "id": "37F_yGAYpV8d",
         "colab_type": "code",
         "colab": {}
       },
@@ -70,7 +96,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "pFYWJwU4C-0j",
+        "id": "ZZv23uP1pWrG",
         "colab_type": "text"
       },
       "source": [
@@ -80,7 +106,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "CVauk1HAC9xK",
+        "id": "GXD87Wk7pYWc",
         "colab_type": "code",
         "colab": {}
       },
@@ -102,13 +128,12 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "dYo_0MzbDFRN",
+        "id": "kDgDdSOQpaOr",
         "colab_type": "code",
         "colab": {}
       },
       "source": [
         "import torch\n",
-        "import torch_xla\n",
         "import torch_xla.core.xla_model as xm\n",
         "\n",
         "model = torch.hub.load('pytorch/vision', 'resnet50', pretrained=True)\n",
@@ -126,7 +151,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "DJovKUjKDuKP",
+        "id": "SyuBVxzdpb1-",
         "colab_type": "code",
         "colab": {}
       },
@@ -165,17 +190,17 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "u3aMc9awWYB8",
+        "id": "mqhGuZfipeOZ",
         "colab_type": "text"
       },
       "source": [
-        "### (RunMe) Imagenet Class Labels "
+        "### [RUNME] Imagenet Class Labels "
       ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "id": "FJ7Zxu3RWjxv",
+        "id": "AqSzhj7OpjG-",
         "colab_type": "code",
         "colab": {}
       },
@@ -1187,7 +1212,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "ZMO5F40rWgWO",
+        "id": "y8uYEgkLpo7K",
         "colab_type": "text"
       },
       "source": [
@@ -1199,7 +1224,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "5JMZrmZuR4uW",
+        "id": "xjBwB6Z-poFk",
         "colab_type": "code",
         "colab": {}
       },
@@ -1216,7 +1241,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "mkQImixJYoqT",
+        "id": "SDmMjCkDprEh",
         "colab_type": "text"
       },
       "source": [
@@ -1230,15 +1255,15 @@
         "\n",
         "| Hardware | p50    | p90    | p99    |\n",
         "| -------- | -----  | ------ | ----   |\n",
-        "|  GPU     | 433.23 | 433.90 | 434.45 |\n",
-        "|  1/8 TPU | 75.88  |  76.71 |  77.25 |\n",
-        "|  Lift    | 5.71x  | 5.66x  | 5.62x  | \n"
+        "|  GPU     | 213.52 | 214.34 | 214.56 |\n",
+        "|  1/8 TPU | 53.25  |  54.11 |  61.81 |\n",
+        "|  Lift    | 4.01x  | 3.96x  | 3.47x  | \n"
       ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "id": "Z4Cw2FqSZKvl",
+        "id": "eYA6z44Hpsl_",
         "colab_type": "code",
         "colab": {}
       },
@@ -1247,7 +1272,7 @@
         "import time\n",
         "import torch_xla.distributed.data_parallel as dp\n",
         "\n",
-        "batch_size = 64\n",
+        "batch_size = 32\n",
         "input_batch_tensor = input_tensor.repeat(batch_size, 1, 1, 1)\n",
         "\n",
         "times = []\n",
@@ -1267,17 +1292,37 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "hEDgxEjPwZ9Z",
+        "id": "GZqlNzuopvWN",
         "colab_type": "text"
       },
       "source": [
-        "### [GPU] Benchmarking"
+        "### [GPU] Benchmarking\n",
+        "Before running click on: Runtime > Reset all runtimes...\n",
+        "\n",
+        "And then select: Runtime > Change runtime type > Hardware accelerator > GPU\n",
+        "\n",
+        "Skip all the above cells and start from this cell."
       ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "id": "NL54sIh_x5dL",
+        "id": "zt7h51tFpwMI",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Need newer torch version: https://github.com/pytorch/pytorch/issues/26608\n",
+        "!pip uninstall -y torch\n",
+        "!pip install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cu100/torch_nightly.html"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "hEU5YcB_px9U",
         "colab_type": "code",
         "colab": {}
       },
@@ -1297,7 +1342,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "bt3brDt3yj9s",
+        "id": "h_UmAqRfpzAP",
         "colab_type": "code",
         "colab": {}
       },
@@ -1314,12 +1359,12 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "UKrdQNQ5wZfM",
+        "id": "LA4X1f-tp2U5",
         "colab_type": "code",
         "colab": {}
       },
       "source": [
-        "batch_size = 64\n",
+        "batch_size = 32\n",
         "\n",
         "from torchvision import transforms\n",
         "norm = transforms.Normalize(\n",
@@ -1344,7 +1389,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "A4d4RU34xVX3",
+        "id": "3j2LHsSmp3o2",
         "colab_type": "code",
         "colab": {}
       },


### PR DESCRIPTION
Added a cell to check TPU runtime is selected.
Reduced inference batch size (HBM OOM).
Also, b/141328994.

Notebook previews:
* [MNIST training](https://nbviewer.jupyter.org/github/pytorch/xla/blob/colab-xrt1-15/contrib/colab/mnist-training-xrt-1-15.ipynb?flush_cache=true)
* [CIFAR/ResNet18 training](https://nbviewer.jupyter.org/github/pytorch/xla/blob/colab-xrt1-15/contrib/colab/resnet50-inference-xrt-1-15.ipynb?flush_cache=true)
* [ResNet50 pretrained torch hub inference](https://nbviewer.jupyter.org/github/pytorch/xla/blob/colab-xrt1-15/contrib/colab/resnet18-training-xrt-1-15.ipynb?flush_cache=true)