### PR TITLE
Add missing TPU check cell on ResNet18 colab

### DIFF
--- a/contrib/colab/resnet18-training-xrt-1-15.ipynb
+++ b/contrib/colab/resnet18-training-xrt-1-15.ipynb
@@ -41,6 +41,20 @@
       ]
     },
     {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Hx4YVNHametU",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "import os\n",
+        "assert os.environ['COLAB_TPU_ADDR'], 'Make sure to select TPU from Edit > Notebook settings > Hardware accelerator'"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
       "cell_type": "markdown",
       "metadata": {
         "id": "pLQPoJ6Fn8wF",


### PR DESCRIPTION
Notebook preview:
* [CIFAR/ResNet18 training](https://nbviewer.jupyter.org/github/pytorch/xla/blob/colab-xrt1-15/contrib/colab/resnet50-inference-xrt-1-15.ipynb?flush_cache=true)