### PR TITLE
Fix MP iterating through the dataloader

### DIFF
--- a/API_GUIDE.md
+++ b/API_GUIDE.md
@@ -122,7 +122,7 @@ def _mp_fn(index):
   loss_fn = nn.NLLLoss()
   optimizer = optim.SGD(model.parameters(), lr=lr, momentum=momentum)
 
-  for data, target in para_loader.per_device_loader(device):
+  for _, (data, target) in para_loader.per_device_loader(device):
     optimizer.zero_grad()
     output = model(data)
     loss = loss_fn(output, target)


### PR DESCRIPTION
Correct me if I am wrong, but when I tried using the multiprocessing version of PyTorch XLA, iterating through ParallelLoader returns the index as well as the data and target. Updated this API guide to reflect that.