### PR TITLE
Log thread IDs by default.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,7 @@ RUN cd pytorch && bash xla/scripts/build_torch_wheels.sh ${python_version} ${rel
 
 # Use conda environment on startup or when running scripts.
 RUN echo "conda activate pytorch" >> ~/.bashrc
+RUN echo "export TF_CPP_LOG_THREAD_ID=1" >> ~/.bashrc
 ENV PATH /root/anaconda3/envs/pytorch/bin/:$PATH
 
 # Define entrypoint and cmd

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -7,6 +7,7 @@
 source ~/.bashrc
 
 # Activate pytorch conda env at entry by default.
+# TODO: This should not be needed as it is already sourced from the .bashrc above.
 conda activate pytorch
 
 exec "$@"


### PR DESCRIPTION
Seems to me that given that we are sourcing the `.bashrc` anyway, we could avoid running it explicitly.
Also, is there a way to get that export to our VMs as well?
