### PR TITLE
Fix IsLocalDevice check for MP case

### DIFF
--- a/third_party/xla_client/computation_client.cc
+++ b/third_party/xla_client/computation_client.cc
@@ -66,7 +66,9 @@ bool IsLocalDevice(
     return true;
   }
   Device device = ParseDevice(mp_device);
-  return device.ordinal == parsed_device.id &&
+  const int devices_per_worker = sys_util::GetEnvInt("TPU_NUM_DEVICES", 8);
+  return device.ordinal ==
+             (devices_per_worker * parsed_device.task + parsed_device.id) &&
          device.kind == parsed_device.type;
 }
 


### PR DESCRIPTION
Fixes MP + Pods.

Essentially the problem was that we were only using the `parsed_device.id` which is in `[0, devices_per_worker)` when comparing to global MP device ID which is in `[0, num_workers * devices_per_worker)`.