### PR TITLE
Return all the matching changes and move the logging into a separate …

### DIFF
--- a/test/cpp/metrics_snapshot.cpp
+++ b/test/cpp/metrics_snapshot.cpp
@@ -22,9 +22,10 @@ MetricsSnapshot::MetricsSnapshot() {
   }
 }
 
-bool MetricsSnapshot::CounterChanged(
+std::vector<MetricsSnapshot::ChangedCounter> MetricsSnapshot::CounterChanged(
     const std::string& counter_regex, const MetricsSnapshot& after,
     const std::unordered_set<std::string>* ignore_set) const {
+  std::vector<ChangedCounter> changed;
   std::regex cregex(counter_regex);
   for (auto& name_counter : after.counters_map_) {
     std::smatch match;
@@ -33,14 +34,12 @@ bool MetricsSnapshot::CounterChanged(
       xla::int64 start_value =
           xla::util::FindOr(counters_map_, name_counter.first, 0);
       if (name_counter.second != start_value) {
-        TF_LOG(INFO) << "Counter '" << name_counter.first
-                     << "' changed: " << start_value << " -> "
-                     << name_counter.second;
-        return true;
+        changed.push_back(
+            {name_counter.first, start_value, name_counter.second});
       }
     }
   }
-  return false;
+  return changed;
 }
 
 }  // namespace cpp_test

--- a/test/cpp/metrics_snapshot.h
+++ b/test/cpp/metrics_snapshot.h
@@ -13,11 +13,17 @@ namespace cpp_test {
 
 class MetricsSnapshot {
  public:
+  struct ChangedCounter {
+    std::string name;
+    xla::int64 before = 0;
+    xla::int64 after = 0;
+  };
+
   MetricsSnapshot();
 
-  bool CounterChanged(const std::string& counter_regex,
-                      const MetricsSnapshot& after,
-                      const std::unordered_set<std::string>* ignore_set) const;
+  std::vector<ChangedCounter> CounterChanged(
+      const std::string& counter_regex, const MetricsSnapshot& after,
+      const std::unordered_set<std::string>* ignore_set) const;
 
  private:
   struct MetricSamples {

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -86,8 +86,7 @@ TEST_F(AtenXlaTensorTest, TestCastByte) {
     torch::Tensor xla_b = torch::_cast_Byte(xla_a);
     AllEqual(b, xla_b);
   });
-
-  EXPECT_FALSE(CounterChanged("aten::.*", cpp_test::GetIgnoredCounters()));
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestCastChar) {
@@ -100,7 +99,7 @@ TEST_F(AtenXlaTensorTest, TestCastChar) {
     AllEqual(b, xla_b);
   });
 
-  EXPECT_FALSE(CounterChanged("aten::.*", cpp_test::GetIgnoredCounters()));
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestCastShort) {
@@ -113,7 +112,7 @@ TEST_F(AtenXlaTensorTest, TestCastShort) {
     AllEqual(b, xla_b);
   });
 
-  EXPECT_FALSE(CounterChanged("aten::.*", cpp_test::GetIgnoredCounters()));
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestCastInt) {
@@ -126,7 +125,7 @@ TEST_F(AtenXlaTensorTest, TestCastInt) {
     AllEqual(b, xla_b);
   });
 
-  EXPECT_FALSE(CounterChanged("aten::.*", cpp_test::GetIgnoredCounters()));
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestCastLong) {
@@ -139,7 +138,7 @@ TEST_F(AtenXlaTensorTest, TestCastLong) {
     AllEqual(b, xla_b);
   });
 
-  EXPECT_FALSE(CounterChanged("aten::.*", cpp_test::GetIgnoredCounters()));
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestCastFloat) {
@@ -152,7 +151,7 @@ TEST_F(AtenXlaTensorTest, TestCastFloat) {
     AllEqual(b, xla_b);
   });
 
-  EXPECT_FALSE(CounterChanged("aten::.*", cpp_test::GetIgnoredCounters()));
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestRetainType) {
@@ -223,7 +222,7 @@ TEST_F(AtenXlaTensorTest, TestAddZeroSizeDim) {
     AllClose(c, xla_c);
   });
 
-  EXPECT_FALSE(CounterChanged("aten::.*", cpp_test::GetIgnoredCounters()));
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestSub) {
@@ -2187,7 +2186,7 @@ TEST_F(AtenXlaTensorTest, TestBitwiseNot) {
     }
   });
 
-  EXPECT_FALSE(CounterChanged("aten::.*", cpp_test::GetIgnoredCounters()));
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestBitwiseNotInPlace) {
@@ -2205,7 +2204,7 @@ TEST_F(AtenXlaTensorTest, TestBitwiseNotInPlace) {
     }
   });
 
-  EXPECT_FALSE(CounterChanged("aten::.*", cpp_test::GetIgnoredCounters()));
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestSign) {
@@ -2288,7 +2287,7 @@ TEST_F(AtenXlaTensorTest, TestARange) {
     AllClose(a, xla_a);
   });
 
-  EXPECT_FALSE(CounterChanged("aten::.*", cpp_test::GetIgnoredCounters()));
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestARangeOut) {

--- a/test/cpp/torch_xla_test.h
+++ b/test/cpp/torch_xla_test.h
@@ -17,8 +17,9 @@ class XlaTest : public ::testing::Test {
 
   static void CommonSetup();
 
-  bool CounterChanged(const std::string& counter_regex,
-                      const std::unordered_set<std::string>* ignore_set);
+  void ExpectCounterNotChanged(
+      const std::string& counter_regex,
+      const std::unordered_set<std::string>* ignore_set);
 
  private:
   void MakeEndSnapshot();


### PR DESCRIPTION
…API, since the same core API will be used to positively or negatively assert.