### PR TITLE
Backout memory for zeros_like.

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3496,17 +3496,15 @@ at::Tensor AtenXlaType::zeros(at::IntArrayRef size,
   return full(size, 0, options);
 }
 
-at::Tensor AtenXlaType::zeros_like(
-    const at::Tensor& self, c10::optional<at::MemoryFormat> memory_format) {
+at::Tensor AtenXlaType::zeros_like(const at::Tensor& self) {
   XLA_FN_COUNTER("xla::");
-  return full_like(self, 0, memory_format);
+  return full_like(self, 0, c10::nullopt);
 }
 
-at::Tensor AtenXlaType::zeros_like(
-    const at::Tensor& self, const at::TensorOptions& options,
-    c10::optional<at::MemoryFormat> memory_format) {
+at::Tensor AtenXlaType::zeros_like(const at::Tensor& self,
+                                   const at::TensorOptions& options) {
   XLA_FN_COUNTER("xla::");
-  return full_like(self, 0, options, memory_format);
+  return full_like(self, 0, options, c10::nullopt);
 }
 
 void AtenXlaType::InitializeAtenBindings() {

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -1144,12 +1144,10 @@ class AtenXlaType {
   static at::Tensor zeros(at::IntArrayRef size,
                           const at::TensorOptions& options);
 
-  static at::Tensor zeros_like(const at::Tensor& self,
-                               c10::optional<at::MemoryFormat> memory_format);
+  static at::Tensor zeros_like(const at::Tensor& self);
 
   static at::Tensor zeros_like(const at::Tensor& self,
-                               const at::TensorOptions& options,
-                               c10::optional<at::MemoryFormat> memory_format);
+                               const at::TensorOptions& options);
 };
 
 }  // namespace torch_xla


### PR DESCRIPTION
Upstream is being reverted, https://github.com/pytorch/pytorch/pull/28748, so this PR temporarily revert zeros_like to keep CI green