### PR TITLE
Remove override of argsort, its leaf at::sort is already done.

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -906,6 +906,8 @@ TEST_F(AtenXlaTensorTest, TestArgSort) {
       }
     }
   }
+
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestMin) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -529,12 +529,6 @@ at::Tensor AtenXlaType::argmin(const at::Tensor& self,
                    XLATensor::argmin(bridge::GetXlaTensor(self)));
 }
 
-at::Tensor AtenXlaType::argsort(const at::Tensor& self, int64_t dim,
-                                bool descending) {
-  XLA_FN_COUNTER("xla::");
-  return std::get<1>(sort(self, dim, descending));
-}
-
 at::Tensor AtenXlaType::as_strided(const at::Tensor& self, at::IntArrayRef size,
                                    at::IntArrayRef stride,
                                    c10::optional<int64_t> storage_offset) {

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -154,9 +154,6 @@ class AtenXlaType {
   static at::Tensor argmin(const at::Tensor& self, c10::optional<int64_t> dim,
                            bool keepdim);
 
-  static at::Tensor argsort(const at::Tensor& self, int64_t dim,
-                            bool descending);
-
   static at::Tensor as_strided(const at::Tensor& self, at::IntArrayRef size,
                                at::IntArrayRef stride,
                                c10::optional<int64_t> storage_offset);


### PR DESCRIPTION
#1225 