### PR TITLE
Remove override for binary_cross_entropy_with_logits_backward.

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -1631,6 +1631,11 @@ TEST_F(AtenXlaTensorTest, TestBCEWithLogits) {
           torch::Tensor xla_output = torch::binary_cross_entropy_with_logits(
               xla_input, xla_target, xla_weight, xla_pos_weight, reduction);
         });
+
+        ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+        // binary_cross_entropy_with_logits is composed of
+        // sub/mul_/add_/exp_/add_/log_/... ops in upstream pytorch.
+        ExpectCounterChanged("xla::mul", cpp_test::GetIgnoredCounters());
       }
     }
   }
@@ -7824,6 +7829,10 @@ TEST_F(AtenXlaTensorTest, TestBCEWithLogitsBackward) {
           TestBackward({input, target, weight, pos_weight}, device, testfn,
                        /*rtol=*/1e-3, /*atol=*/1e-5);
         });
+        ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+        // binary_cross_entropy_with_logits_backward is composed of
+        // sub/mul_/add_/exp_/add_/log_/... ops in upstream pytorch.
+        ExpectCounterChanged("xla::add", cpp_test::GetIgnoredCounters());
       }
     }
   }

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -758,15 +758,6 @@ at::Tensor AtenXlaType::binary_cross_entropy_with_logits(
                                                       pos_weight, reduction);
 }
 
-at::Tensor AtenXlaType::binary_cross_entropy_with_logits_backward(
-    const at::Tensor& grad_output, const at::Tensor& self,
-    const at::Tensor& target, const at::Tensor& weight,
-    const at::Tensor& pos_weight, int64_t reduction) {
-  XLA_FN_COUNTER("xla::");
-  return at::native::binary_cross_entropy_with_logits_backward(
-      grad_output, self, target, weight, pos_weight, reduction);
-}
-
 at::Tensor AtenXlaType::blackman_window(int64_t window_length,
                                         const at::TensorOptions& options) {
   XLA_FN_COUNTER("xla::");

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -225,11 +225,6 @@ class AtenXlaType {
       const at::Tensor& weight, const at::Tensor& pos_weight,
       int64_t reduction);
 
-  static at::Tensor binary_cross_entropy_with_logits_backward(
-      const at::Tensor& grad_output, const at::Tensor& self,
-      const at::Tensor& target, const at::Tensor& weight,
-      const at::Tensor& pos_weight, int64_t reduction);
-
   static at::Tensor blackman_window(int64_t window_length,
                                     const at::TensorOptions& options);
   static at::Tensor blackman_window(int64_t window_length, bool periodic,


### PR DESCRIPTION
We also have a fake override for binary_cross_entropy_with_logits. But I'll leave it there since it's a leaf node. But its backward is not, so removing in this PR. 
#1225 