### PR TITLE
Remove override of broadcast_tensors.

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -3229,6 +3229,9 @@ TEST_F(AtenXlaTensorTest, TestBroadcastTensors) {
       AllClose(c[i], xla_c[i]);
     }
   });
+
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::expand", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestOneIndex) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -789,12 +789,6 @@ at::Tensor AtenXlaType::bmm(const at::Tensor& self, const at::Tensor& mat2) {
       XLATensor::bmm(bridge::GetXlaTensor(self), bridge::GetXlaTensor(mat2)));
 }
 
-std::vector<at::Tensor> AtenXlaType::broadcast_tensors(at::TensorList tensors) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensors(
-      XLATensor::broadcast_tensors(bridge::GetXlaTensors(tensors)));
-}
-
 at::Tensor AtenXlaType::cat(at::TensorList tensors, int64_t dim) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -237,8 +237,6 @@ class AtenXlaType {
 
   static at::Tensor bmm(const at::Tensor& self, const at::Tensor& mat2);
 
-  static std::vector<at::Tensor> broadcast_tensors(at::TensorList tensors);
-
   static at::Tensor cat(at::TensorList tensors, int64_t dim);
 
   static at::Tensor ceil(const at::Tensor& self);


### PR DESCRIPTION
The XLATensor op is still used in a few other places. So just keep it there for now. 
#1225 