### PR TITLE
Add `drop_last=True` in DataLoaders inside `ls test_train*`

### DIFF
--- a/test/args_parse.py
+++ b/test/args_parse.py
@@ -26,6 +26,7 @@ def parse_common_options(datadir=None,
   parser.add_argument('--lr', type=float, default=lr)
   parser.add_argument('--momentum', type=float, default=momentum)
   parser.add_argument('--target_accuracy', type=float, default=target_accuracy)
+  parser.add_argument('--drop_last', action='store_true')
   parser.add_argument('--fake_data', action='store_true')
   parser.add_argument('--tidy', action='store_true')
   parser.add_argument('--metrics_debug', action='store_true')

--- a/test/test_train_cifar.py
+++ b/test/test_train_cifar.py
@@ -158,14 +158,14 @@ def train_cifar():
         train_dataset,
         batch_size=FLAGS.batch_size,
         sampler=train_sampler,
-        drop_last=True,
+        drop_last=FLAGS.drop_last,
         shuffle=False if train_sampler else True,
         num_workers=FLAGS.num_workers)
     test_loader = torch.utils.data.DataLoader(
         test_dataset,
         batch_size=FLAGS.batch_size,
         sampler=test_sampler,
-        drop_last=True,
+        drop_last=FLAGS.drop_last,
         shuffle=False,
         num_workers=FLAGS.num_workers)
 

--- a/test/test_train_imagenet.py
+++ b/test/test_train_imagenet.py
@@ -153,14 +153,14 @@ def train_imagenet():
         train_dataset,
         batch_size=FLAGS.batch_size,
         sampler=train_sampler,
-        drop_last=True,
+        drop_last=FLAGS.drop_last,
         shuffle=False if train_sampler else True,
         num_workers=FLAGS.num_workers)
     test_loader = torch.utils.data.DataLoader(
         test_dataset,
         batch_size=FLAGS.test_set_batch_size,
         sampler=test_sampler,
-        drop_last=True,
+        drop_last=FLAGS.drop_last,
         shuffle=False,
         num_workers=FLAGS.num_workers)
 

--- a/test/test_train_mnist.py
+++ b/test/test_train_mnist.py
@@ -97,14 +97,14 @@ def train_mnist():
         train_dataset,
         batch_size=FLAGS.batch_size,
         sampler=train_sampler,
-        drop_last=True,
+        drop_last=FLAGS.drop_last,
         shuffle=False if train_sampler else True,
         num_workers=FLAGS.num_workers)
     test_loader = torch.utils.data.DataLoader(
         test_dataset,
         batch_size=FLAGS.batch_size,
         sampler=test_sampler,
-        drop_last=True,
+        drop_last=FLAGS.drop_last,
         shuffle=False,
         num_workers=FLAGS.num_workers)
 

--- a/test/test_train_mp_imagenet.py
+++ b/test/test_train_mp_imagenet.py
@@ -146,13 +146,13 @@ def train_imagenet():
         train_dataset,
         batch_size=FLAGS.batch_size,
         sampler=train_sampler,
-        drop_last=True,
+        drop_last=FLAGS.drop_last,
         shuffle=False if train_sampler else True,
         num_workers=FLAGS.num_workers)
     test_loader = torch.utils.data.DataLoader(
         test_dataset,
         batch_size=FLAGS.test_set_batch_size,
-        drop_last=True,
+        drop_last=FLAGS.drop_last,
         shuffle=False,
         num_workers=FLAGS.num_workers)
 

--- a/test/test_train_mp_mnist.py
+++ b/test/test_train_mp_mnist.py
@@ -88,13 +88,13 @@ def train_mnist():
         train_dataset,
         batch_size=FLAGS.batch_size,
         sampler=train_sampler,
-        drop_last=True,
+        drop_last=FLAGS.drop_last,
         shuffle=False if train_sampler else True,
         num_workers=FLAGS.num_workers)
     test_loader = torch.utils.data.DataLoader(
         test_dataset,
         batch_size=FLAGS.batch_size,
-        drop_last=True,
+        drop_last=FLAGS.drop_last,
         shuffle=False,
         num_workers=FLAGS.num_workers)
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -43,7 +43,7 @@ def get_summary_writer(logdir):
   Args:
     logdir: Str. File location where logs will be written or None. If None,
         no writer is created.
-  
+
   Returns:
     Instance of `torch.utils.tensorboard.SummaryWriter`.
   """


### PR DESCRIPTION
without drop_last, loaders produce a batch of different size in last step.