### PR TITLE
Save metrics

### DIFF
--- a/test/args_parse.py
+++ b/test/args_parse.py
@@ -6,6 +6,9 @@ import sys
 
 def parse_common_options(datadir=None,
                          logdir=None,
+                         golden_metrics_filename=None,
+                         metrics_output_filename=None,
+                         service_account_filename=None,
                          num_cores=None,
                          batch_size=128,
                          num_epochs=10,
@@ -18,6 +21,12 @@ def parse_common_options(datadir=None,
   parser = argparse.ArgumentParser(add_help=False)
   parser.add_argument('--datadir', type=str, default=datadir)
   parser.add_argument('--logdir', type=str, default=logdir)
+  parser.add_argument('--golden_metrics_filename', type=str,
+                      default=golden_metrics_filename)
+  parser.add_argument('--metrics_output_filename', type=str,
+                      default=metrics_output_filename)
+  parser.add_argument('--service_account_filename', type=str,
+                      default=service_account_filename)
   parser.add_argument('--num_cores', type=int, default=num_cores)
   parser.add_argument('--batch_size', type=int, default=batch_size)
   parser.add_argument('--num_epochs', type=int, default=num_epochs)

--- a/test/gcs_utils.py
+++ b/test/gcs_utils.py
@@ -1,0 +1,41 @@
+"""Utility methods to interact with Google Cloud Storage."""
+from os import path
+
+from google.cloud import storage
+
+_GCS_PREFIX = "gcs://"
+
+
+def write_to_gcs(service_account_filename,
+                 output_gcs_path,
+                 contents):
+  """Write `contents` to a file in GCS.
+  
+  Args:
+    service_account_filename (string): Filename of the JSON service account
+      key to authenticate writes.
+    output_gcs_path (string): GCS path to write to. Should consist of prefix,
+      bucket name, and filename. E.g. "gcs://bucket_name/filename".
+    contents (string): Payload to write to the file.
+
+  Raises:
+    ValueError if output_gcs_path has an unexpected format.
+  """
+  output_gcs_path = output_gcs_path.replace(_GCS_PREFIX, "")
+  path_components = path.normpath(output_gcs_path).split(path.sep)
+  if len(path_components) < 2:
+    raise ValueError("output_gcs_path should contain at least "
+                     "bucket and filename.")
+  output_bucket_name = path_components[0]
+
+  # GCS has a flat file structure. Slashes can be used in the filename
+  # to simulate nested directories, e.g. 'metrics/model2/20191104.txt'.
+  # Combine everything after the bucket name into a single slash-delimited
+  # filename.
+  output_filename = path.sep.join(path_components[1:])
+
+  storage_client = storage.Client.from_service_account_json(
+      service_account_filename)
+  bucket = storage_client.get_bucket(output_bucket_name)
+  blob = bucket.blob(output_filename)
+  blob.upload_from_string(contents)

--- a/test/metrics_comparator.py
+++ b/test/metrics_comparator.py
@@ -1,0 +1,65 @@
+"""Methods for tracking and comparing XLA metrics over time."""
+
+_GCS_PREFIX = "gcs://"
+
+def metrics_have_regressed(current_metrics, golden_metrics_filename,
+                           output_filename=None, prefix=None,
+                           service_account_filename=None):
+  """Return True if current_metrics regressed compared to golden metrics.
+
+  TODO(zcain): More detail on which regressions we check for.
+
+  Optionally save a copy of current_metrics to disk.
+
+  Args:
+    current_metrics (string): Output of XLA metrics report.
+    golden_metrics_filename (string): File containing the golden metrics to
+      compare to current_metrics. Note for Google Cloud Storage: this should
+      be in the format "gcs://bucket_name/filename".
+    output_filename (string, optional): If provided, the current_metrtics
+      will be written out to this file.
+    prefix (string, optional): If provided, this prefix will precede
+      current_metrics in the output file.
+    service_account_filename (string, optional): Filename of the JSON service
+      account key to authenticate reads/writes to Google Cloud Storage.
+
+  Returns:
+    True if current_metrics shows regression compared to golden metrics.
+  """
+  if output_filename:
+    try:
+      _write_metrics_to_file(current_metrics, output_filename, prefix=prefix,
+                            service_account_filename=service_account_filename)
+    except Exception as e:
+      print("Failure writing metrics to disk: {}".format(e))
+
+  # TODO(zcain): Define regression, add functionality to read metrics, add
+  # logic to compare metrics.
+  return False
+  
+
+def _write_metrics_to_file(metrics, filename, prefix=None,
+                           service_account_filename=None):
+  """Write metrics to GCS or to local filesystem.
+
+  Args:
+    metrics (string): Metrics to write to file.
+    filename (string): Write destination. Note for Google Cloud Storage: this
+      should be in the format "gcs://bucket_name/filename".
+    prefix (string, optional): Optional text to be written to the output file
+      just before the metrics.
+    service_account_filename (string, optional): Filename of the JSON service
+      account key to authenticate writes to Google Cloud Storage. Not necessary
+      for writing to local filesytem.
+  """
+  output_string = "Metrics:\n{}".format(metrics)
+  if prefix:
+    output_string = "{}\n\n{}".format(prefix, output_string)
+  if filename.find(_GCS_PREFIX) >= 0:
+    import gcs_utils
+    gcs_utils.write_to_gcs(service_account_filename,
+                           filename,
+                           output_string)
+  else:
+    with open(filename, 'w') as outfile:
+      outfile.write(output_string)

--- a/test/test_train_cifar.py
+++ b/test/test_train_cifar.py
@@ -18,6 +18,7 @@ FLAGS = args_parse.parse_common_options(
 from common_utils import TestCase, run_tests
 import os
 from statistics import mean
+import metrics_comparator
 import shutil
 import test_utils
 import torch
@@ -242,7 +243,15 @@ class TrainCIFAR10(TestCase):
       shutil.rmtree(FLAGS.datadir)
 
   def test_accurracy(self):
-    self.assertGreaterEqual(train_cifar(), FLAGS.target_accuracy)
+    accuracy = train_cifar()
+    if FLAGS.golden_metrics_filename:
+      self.assertFalse(metrics_comparator.metrics_have_regressed(
+          met.metrics_report(),
+          FLAGS.golden_metrics_filename,
+          output_filename=FLAGS.metrics_output_filename,
+          prefix=str(FLAGS),
+          service_account_filename=FLAGS.service_account_filename))
+    self.assertGreaterEqual(accuracy, FLAGS.target_accuracy)
 
 
 # Run the tests.

--- a/test/test_train_imagenet.py
+++ b/test/test_train_imagenet.py
@@ -40,6 +40,7 @@ from common_utils import TestCase, run_tests
 import os
 import schedulers
 from statistics import mean
+import metrics_comparator
 import test_utils
 import torch
 import torch.nn as nn
@@ -244,7 +245,15 @@ class TrainImageNet(TestCase):
     super(TrainImageNet, self).tearDown()
 
   def test_accurracy(self):
-    self.assertGreaterEqual(train_imagenet(), FLAGS.target_accuracy)
+    accuracy = train_imagenet()
+    if FLAGS.golden_metrics_filename:
+      self.assertFalse(metrics_comparator.metrics_have_regressed(
+          met.metrics_report(),
+          FLAGS.golden_metrics_filename,
+          output_filename=FLAGS.metrics_output_filename,
+          prefix=str(FLAGS),
+          service_account_filename=FLAGS.service_account_filename))
+    self.assertGreaterEqual(accuracy, FLAGS.target_accuracy)
 
 
 # Run the tests.

--- a/test/test_train_mnist.py
+++ b/test/test_train_mnist.py
@@ -11,6 +11,7 @@ FLAGS = args_parse.parse_common_options(
 from common_utils import TestCase, run_tests
 import os
 from statistics import mean
+import metrics_comparator
 import shutil
 import test_utils
 import time
@@ -177,8 +178,15 @@ class TrainMnist(TestCase):
       shutil.rmtree(FLAGS.datadir)
 
   def test_accurracy(self):
-    self.assertGreaterEqual(train_mnist(), FLAGS.target_accuracy)
-
+    accuracy = train_mnist()
+    if FLAGS.golden_metrics_filename:
+      self.assertFalse(metrics_comparator.metrics_have_regressed(
+          met.metrics_report(),
+          FLAGS.golden_metrics_filename,
+          output_filename=FLAGS.metrics_output_filename,
+          prefix=str(FLAGS),
+          service_account_filename=FLAGS.service_account_filename))
+    self.assertGreaterEqual(accuracy, FLAGS.target_accuracy)
 
 # Run the tests.
 torch.set_default_tensor_type('torch.FloatTensor')


### PR DESCRIPTION
- Add skeleton for metrics regression test code
- Allow test_train_mnist, test_train_cifar, and test_train_imagenet to save metrics to file

Tested that the 3 files can write to GCS or to disk with this change.