### PR TITLE
Remove override for narrow.

### DIFF
--- a/scripts/gen.py
+++ b/scripts/gen.py
@@ -87,6 +87,14 @@ _FN_BLACKLIST = set([
     'zero_',
     'zeros',
     'zeros_like',
+    # FIXME: Remove functions below when we switch to override leaf nodes only.
+    # The function names below might map to multiple function overrloads.
+    # If the function overload is a leaf node, we must have it in AtenXlaType::
+    # so that we still override them.
+    # Otherwise they're non leaves that we shouldn't generate override for them.
+    # They're blacklisted to avoid creating AtenXlaTypeDefault::func,
+    # so that we can fall back to TypeDefault:: in PyTorch.
+    'narrow',
 ])
 
 _FN_BLACKLIST_REGEX = [

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -2430,7 +2430,7 @@ TEST_F(AtenXlaTensorTest, TestBartlettWindow) {
       torch::Tensor xla_output = torch::bartlett_window(
           window_length, periodic,
           torch::TensorOptions(torch::kFloat).device(device));
-      AllClose(output, xla_output);
+      AllClose(output, xla_output, /*rtol=*/1e-5, /*atol=*/1e-7);
     });
   }
 }

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -5209,6 +5209,9 @@ TEST_F(AtenXlaTensorTest, TestNarrow) {
         torch::Tensor xla_b = xla_a.narrow(dim, start, 6);
         AllClose(b, xla_b);
       });
+
+      ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+      ExpectCounterChanged("xla::slice", cpp_test::GetIgnoredCounters());
     }
   }
 }
@@ -5230,6 +5233,9 @@ TEST_F(AtenXlaTensorTest, TestNarrowUpdate) {
         xla_c.add_(xla_b, 1.0);
         AllClose(c, xla_c);
       });
+
+      ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+      ExpectCounterChanged("xla::slice", cpp_test::GetIgnoredCounters());
     }
   }
 }
@@ -5251,6 +5257,9 @@ TEST_F(AtenXlaTensorTest, TestNarrowUpdateBaseCheck) {
         xla_c.add_(xla_b, 1.0);
         AllClose(a, xla_a);
       });
+
+      ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+      ExpectCounterChanged("xla::slice", cpp_test::GetIgnoredCounters());
     }
   }
 }
@@ -5281,6 +5290,9 @@ TEST_F(AtenXlaTensorTest, TestNarrowUpdateTwoSlices) {
           AllClose(e, xla_e);
           AllClose(a, xla_a);
         });
+
+        ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+        ExpectCounterChanged("xla::slice", cpp_test::GetIgnoredCounters());
       }
     }
   }
@@ -5305,6 +5317,9 @@ TEST_F(AtenXlaTensorTest, TestNarrowUpdateView) {
         xla_d.add_(xla_b, 1.0);
         AllClose(d, xla_d);
       });
+
+      ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+      ExpectCounterChanged("xla::slice", cpp_test::GetIgnoredCounters());
     }
   }
 }
@@ -5329,6 +5344,9 @@ TEST_F(AtenXlaTensorTest, TestNarrowInNarrowUpdate) {
           xla_d.add_(xla_b, 1.0);
           AllClose(a, xla_a);
         });
+
+        ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+        ExpectCounterChanged("xla::slice", cpp_test::GetIgnoredCounters());
       }
     }
   }

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1999,13 +1999,6 @@ at::Tensor& AtenXlaType::mv_out(at::Tensor& out, const at::Tensor& self,
   return out;
 }
 
-at::Tensor AtenXlaType::narrow(const at::Tensor& self, int64_t dim,
-                               int64_t start, int64_t length) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(
-      XLATensor::narrow(bridge::GetXlaTensor(self), dim, start, length));
-}
-
 at::Tensor AtenXlaType::narrow_copy(const at::Tensor& self, int64_t dim,
                                     int64_t start, int64_t length) {
   XLA_FN_COUNTER("xla::");

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -636,9 +636,6 @@ class AtenXlaType {
   static at::Tensor& mv_out(at::Tensor& out, const at::Tensor& self,
                             const at::Tensor& vec);
 
-  static at::Tensor narrow(const at::Tensor& self, int64_t dim, int64_t start,
-                           int64_t length);
-
   static at::Tensor narrow_copy(const at::Tensor& self, int64_t dim,
                                 int64_t start, int64_t length);
 


### PR DESCRIPTION
`XLATensor::narrow` is still used by `Select`, so we're not removing it at tensor level.