### PR TITLE
Adds a notice for handling shared weights

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -136,7 +136,12 @@ tensors across device types does not preserve view relationships. Instead,
 views should be reconstructed as necessary after the tensors are loaded.
 
 1. **Copying an XLA Tensor with Python's copy.copy returns a deep copy, not a
-shallow copy**. Use a view of an XLA tensor to get a shallow copy of it.
+shallow copy.** Use a view of an XLA tensor to get a shallow copy of it.
+
+1. **Handling shared weights.** Modules can share weights by setting the
+Parameters of one module to another. This "tying" of module weights should
+be done **AFTER** the modules are moved to an XLA device. Otherwise two
+independent copies of the shared tensor will be made on the XLA device.
 
 ## More Debugging Tools
 


### PR DESCRIPTION
In response to Issue #1245.

This behavior is divergent from current CUDA behavior, but we intend to change that behavior in the future to be like the PyTorch/XLA behavior. See https://github.com/pytorch/pytorch/blob/466ab93ef55ce05da99c251ea88cdcfc8f1c2cfa/torch/nn/modules/module.py#L203. 



