### PR TITLE
Move the API that sends from CPU to XLA device into a xm API.

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1352,7 +1352,7 @@ class TestGeneric(XlaTestCase):
     def collect(x):
       ids.append(id(x))
 
-    xu.for_each_instance(data, lambda x: True, collect)
+    xu.for_each_instance(data, lambda x: isinstance(x, (int, str)), collect)
 
     wids = []
 
@@ -1360,7 +1360,9 @@ class TestGeneric(XlaTestCase):
       wids.append(id(x))
       return x
 
-    xu.for_each_instance_rewrite(data, lambda x: True, convert)
+    xu.for_each_instance_rewrite(data, lambda x: isinstance(x, (int, str)),
+                                 convert)
+    self.assertEqual(len(ids), 30)
     self.assertEqual(ids, wids)
 
 

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -453,3 +453,15 @@ def save(data, file_or_path, master_only=True):
       torch.save(cpu_data, file_or_path)
   else:
     torch.save(cpu_data, file_or_path)
+
+
+def send_cpu_data_to_device(data, device):
+
+  def convert_fn(tensors):
+    devices = [str(device)] * len(tensors)
+    return torch_xla._XLAC._xla_tensors_from_aten(tensors, devices)
+
+  def select_fn(v):
+    return type(v) == torch.Tensor and v.device.type == 'cpu'
+
+  return ToXlaTensorArena(convert_fn, select_fn).transform(data)

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -206,13 +206,7 @@ std::ptrdiff_t GetTensorId(const at::Tensor& tensor) {
 std::vector<at::Tensor> GetXlaTensorsFromAten(
     const std::vector<at::Tensor>& aten_tensors,
     const std::vector<std::string>& devices) {
-  std::vector<at::Tensor> tensors;
-  tensors.reserve(aten_tensors.size());
-  for (auto& aten_tensor : aten_tensors) {
-    tensors.push_back(aten_tensor);
-  }
-
-  auto data_handles = CreateTensorsData(tensors, GetXlaDevices(devices));
+  auto data_handles = CreateTensorsData(aten_tensors, GetXlaDevices(devices));
 
   std::vector<at::Tensor> xla_tensors;
   xla_tensors.reserve(data_handles.size());


### PR DESCRIPTION
Remove unnecessary tensor vector copy.
Test object count in utils.py for_each PI.