### PR TITLE
Disable python operations tests that fail on TPU

### DIFF
--- a/test/torch_test_meta.py
+++ b/test/torch_test_meta.py
@@ -109,15 +109,18 @@ disabled_torch_tests = {
     'test_matrix_rank',  # slow
     'test_triu_tril',
     'test_tensor_shape_empty',  # LLVM OOM in CI
-    'test_cholesky_inverse_xla_float64',  # precision (1e-6)
-    'test_cholesky_solve_batched_xla_float64',  # precision (1e-5)
-    'test_cholesky_solve_xla_float64',  # precision (1e-5)
-    'test_lu_solve_batched_xla_float64',  # precision (1e-6)
-    'test_lu_solve_xla_float64',  # precision (1e-7)
-    'test_solve_batched_xla_float64',  # precision (1e-6)
-    'test_solve_xla_float64',  # precison (1e-7)
-    'test_triangular_solve_batched_xla_float64',  # precision (1e-6)
-    'test_triangular_solve_xla_float64',  # precision (1e-7)
+    'test_cholesky_inverse',  # precision (1e-6)
+    'test_cholesky_solve_batched_broadcasting',  # precision
+    'test_cholesky_solve_batched_many_batches',  # precision
+    'test_cholesky_solve_batched',  # precision (1e-5)
+    'test_cholesky_solve',  # precision (1e-5)
+    'test_lu_solve_batched',  # precision (1e-6)
+    'test_lu_solve',  # precision (1e-7)
+    'test_solve_batched',  # precision (1e-6)
+    'test_solve',  # precison (1e-7)
+    'test_triangular_solve_batched',  # precision (1e-6)
+    'test_triangular_solve_batched_many_batches',  # precision
+    'test_triangular_solve',  # precision (1e-7)
     'test_scalar_check',  # runtime error
 
     # test_indexing.py

--- a/test/torch_test_meta.py
+++ b/test/torch_test_meta.py
@@ -110,8 +110,8 @@ disabled_torch_tests = {
     'test_triu_tril',
     'test_tensor_shape_empty',  # LLVM OOM in CI
     'test_cholesky_inverse',  # precision (1e-6)
-    'test_cholesky_solve_batched_broadcasting',  # precision
-    'test_cholesky_solve_batched_many_batches',  # precision
+    'test_cholesky_solve_batched_broadcasting',  # 0.0039 vs 0.001
+    'test_cholesky_solve_batched_many_batches',  # 0.36 vs 0.001
     'test_cholesky_solve_batched',  # precision (1e-5)
     'test_cholesky_solve',  # precision (1e-5)
     'test_lu_solve_batched',  # precision (1e-6)
@@ -119,7 +119,7 @@ disabled_torch_tests = {
     'test_solve_batched',  # precision (1e-6)
     'test_solve',  # precison (1e-7)
     'test_triangular_solve_batched',  # precision (1e-6)
-    'test_triangular_solve_batched_many_batches',  # precision
+    'test_triangular_solve_batched_many_batches',  # 1.02 vs 0.001
     'test_triangular_solve',  # precision (1e-7)
     'test_scalar_check',  # runtime error
 


### PR DESCRIPTION
Also remove the `_xla_float64` suffix from some tests so that they actually get disabled