### PR TITLE
Implement aten::nonzero and aten::masked_select for TPU.

### DIFF
--- a/test/cpp/cpp_test_util.cpp
+++ b/test/cpp/cpp_test_util.cpp
@@ -118,6 +118,8 @@ void ForEachDevice(const std::function<void(const torch::Device&)>& devfn) {
 
 bool CloseValues(at::Tensor tensor1, at::Tensor tensor2, double rtol,
                  double atol) {
+  tensor1 = ToCpuTensor(tensor1);
+  tensor2 = ToCpuTensor(tensor2);
   if (tensor1.sizes() != tensor2.sizes() ||
       tensor1.dtype() != tensor2.dtype()) {
     std::cerr << "Different shape:\n"
@@ -125,8 +127,6 @@ bool CloseValues(at::Tensor tensor1, at::Tensor tensor2, double rtol,
               << tensor2.dtype() << " " << tensor2.sizes() << "\n";
     return false;
   }
-  tensor1 = ToCpuTensor(tensor1);
-  tensor2 = ToCpuTensor(tensor2);
   bool equal = tensor1.allclose(tensor2, rtol, atol);
   if (!equal) {
     DumpDifferences(tensor1, tensor2);

--- a/test/cpp/cpp_test_util.h
+++ b/test/cpp/cpp_test_util.h
@@ -10,9 +10,17 @@
 
 #include "tensorflow/compiler/xla/xla_client/computation_client.h"
 #include "tensorflow/core/lib/gtl/array_slice.h"
+#include "torch_xla/csrc/debug_util.h"
 #include "torch_xla/csrc/device.h"
 #include "torch_xla/csrc/ir.h"
 #include "torch_xla/csrc/tensor.h"
+
+#define XLA_CPP_TEST_ENABLED(name)                          \
+  do {                                                      \
+    if (!::torch_xla::DebugUtil::ExperimentEnabled(name)) { \
+      GTEST_SKIP();                                         \
+    }                                                       \
+  } while (0)
 
 namespace torch_xla {
 namespace cpp_test {

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -511,6 +511,9 @@ class AtenXlaType {
   static at::Tensor& masked_fill_(at::Tensor& self, const at::Tensor& mask,
                                   const at::Tensor& value);
 
+  static at::Tensor masked_select(const at::Tensor& self,
+                                  const at::Tensor& mask);
+
   static at::Tensor max(const at::Tensor& self, const at::Tensor& other);
 
   static at::Tensor max(const at::Tensor& self);
@@ -638,6 +641,8 @@ class AtenXlaType {
   static std::tuple<at::Tensor, at::Tensor> nll_loss_forward(
       const at::Tensor& self, const at::Tensor& target,
       const at::Tensor& weight, int64_t reduction, int64_t ignore_index);
+
+  static at::Tensor nonzero(const at::Tensor& self);
 
   static at::Tensor norm(const at::Tensor& self, c10::optional<at::Scalar> p,
                          at::ScalarType dtype);

--- a/torch_xla/csrc/data_ops.h
+++ b/torch_xla/csrc/data_ops.h
@@ -2,12 +2,18 @@
 
 #include <vector>
 
+#include "absl/types/optional.h"
 #include "tensorflow/compiler/xla/client/xla_builder.h"
 #include "tensorflow/core/lib/gtl/array_slice.h"
 
 // Collection of XLA lowerings for operations which only involve some form of
 // data movement and no computation.
 namespace torch_xla {
+
+struct DynamicReshapeInfo {
+  xla::Shape output_shape;
+  xla::int64 dynamic_dimension = -1;
+};
 
 bool IsSparseGather(const xla::XlaOp& input, const xla::XlaOp& index,
                     xla::int64 dim);
@@ -19,6 +25,10 @@ bool IsSparseGather(const xla::XlaOp& input, const xla::XlaOp& index,
 std::vector<xla::int64> GetCompleteShape(
     tensorflow::gtl::ArraySlice<const xla::int64> output_sizes,
     tensorflow::gtl::ArraySlice<const xla::int64> input_sizes);
+
+absl::optional<DynamicReshapeInfo> GetDynamicReshapeInfo(
+    const xla::Shape& input_shape,
+    tensorflow::gtl::ArraySlice<const xla::int64> output_sizes);
 
 // Creates a new tensor with the same data as the input tensor and the specified
 // output size.

--- a/torch_xla/csrc/debug_util.cpp
+++ b/torch_xla/csrc/debug_util.cpp
@@ -3,7 +3,10 @@
 #include <fstream>
 #include <mutex>
 #include <sstream>
+#include <unordered_set>
 
+#include "absl/memory/memory.h"
+#include "absl/strings/str_split.h"
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/sys_util.h"
 #include "torch_xla/csrc/ir.h"
@@ -25,6 +28,17 @@ DebugUtil::GraphFormat DefaultGraphFormat() {
     return DebugUtil::GraphFormat::kDot;
   }
   XLA_ERROR() << "Invalid save graph format: " << fmt_str;
+}
+
+std::unordered_set<std::string>* LoadExperiments() {
+  std::unique_ptr<std::unordered_set<std::string>> xset =
+      absl::make_unique<std::unordered_set<std::string>>();
+  std::string experiments = xla::sys_util::GetEnvString("XLA_EXPERIMENTAL", "");
+  std::vector<std::string> experiment_list = absl::StrSplit(experiments, ':');
+  for (auto& name : experiment_list) {
+    xset->insert(name);
+  }
+  return xset.release();
 }
 
 }  // namespace
@@ -87,6 +101,11 @@ void DebugUtil::SaveTensorsGraphInfo(
     std::ofstream graph_file(save_file, std::ios_base::app);
     graph_file << "[" << name << "]\n" << info << "\n";
   }
+}
+
+bool DebugUtil::ExperimentEnabled(const std::string& name) {
+  static const std::unordered_set<std::string>* xset = LoadExperiments();
+  return xset->find(name) != xset->end();
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/debug_util.h
+++ b/torch_xla/csrc/debug_util.h
@@ -34,6 +34,8 @@ class DebugUtil {
       const char* name, tensorflow::gtl::ArraySlice<const XLATensor> tensors,
       const std::vector<size_t>* indices,
       GraphFormat format = GetDefaultGraphFormat());
+
+  static bool ExperimentEnabled(const std::string& name);
 };
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -147,6 +147,9 @@ class XlaHelpers {
       tensorflow::gtl::ArraySlice<const xla::int64> dimensions, xla::int64 dim,
       xla::int64 pos);
 
+  // Retrieves the dynamic dimension of an input shape, or returns -1 if none.
+  static xla::int64 GetDynamicDimension(const xla::Shape& shape);
+
   // Retrieves type's minimum and maximum values.
   static MinMax MinMaxValues(xla::PrimitiveType type);
 
@@ -231,6 +234,10 @@ class XlaHelpers {
   //   shape1       = [9, 7, 6, 1, 2]
   //   shape2       =       [6, 5, 2]
   //   result_shape = [9, 7, 6, 5, 2]
+  static std::vector<xla::int64> GetPromotedShape(
+      tensorflow::gtl::ArraySlice<const xla::int64> shape1_dims,
+      tensorflow::gtl::ArraySlice<const xla::int64> shape2_dims);
+
   static xla::Shape GetPromotedShape(const xla::Shape& shape1,
                                      const xla::Shape& shape2);
 

--- a/torch_xla/csrc/ops/get_dimension_size.cpp
+++ b/torch_xla/csrc/ops/get_dimension_size.cpp
@@ -1,0 +1,36 @@
+#include "torch_xla/csrc/ops/get_dimension_size.h"
+
+#include "tensorflow/compiler/xla/shape_util.h"
+#include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch_xla/csrc/lowering_context.h"
+#include "torch_xla/csrc/ops/xla_ops.h"
+
+namespace torch_xla {
+namespace ir {
+namespace ops {
+
+GetDimensionSize::GetDimensionSize(const Value& input, xla::int64 dimension)
+    : Node(xla_get_dimension_size, {input},
+           xla::ShapeUtil::MakeShape(xla::PrimitiveType::S32, {}),
+           /*num_outputs=*/1, xla::util::MHash(dimension)),
+      dimension_(dimension) {}
+
+NodePtr GetDimensionSize::Clone(OpList operands) const {
+  return MakeNode<GetDimensionSize>(operands.at(0), dimension_);
+}
+
+XlaOpVector GetDimensionSize::Lower(LoweringContext* loctx) const {
+  xla::XlaOp input = loctx->GetOutputOp(operand(0));
+  xla::XlaOp output = xla::GetDimensionSize(input, dimension_);
+  return ReturnOp(output, loctx);
+}
+
+std::string GetDimensionSize::ToString() const {
+  std::stringstream ss;
+  ss << Node::ToString() << ", dimension=" << dimension_;
+  return ss.str();
+}
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/get_dimension_size.h
+++ b/torch_xla/csrc/ops/get_dimension_size.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "torch_xla/csrc/ir.h"
+
+namespace torch_xla {
+namespace ir {
+namespace ops {
+
+class GetDimensionSize : public Node {
+ public:
+  GetDimensionSize(const Value& input, xla::int64 dimension);
+
+  NodePtr Clone(OpList operands) const override;
+
+  XlaOpVector Lower(LoweringContext* loctx) const override;
+
+  std::string ToString() const override;
+
+  xla::int64 dimension() const { return dimension_; }
+
+ private:
+  xla::int64 dimension_;
+};
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/masked_select.cpp
+++ b/torch_xla/csrc/ops/masked_select.cpp
@@ -1,0 +1,42 @@
+#include "torch_xla/csrc/ops/masked_select.h"
+
+#include "tensorflow/compiler/xla/shape_util.h"
+#include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch_xla/csrc/lowering_context.h"
+#include "torch_xla/csrc/xla_lower_util.h"
+
+namespace torch_xla {
+namespace ir {
+namespace ops {
+namespace {
+
+xla::Shape NodeOutputShape(const Value& input) {
+  const xla::Shape& input_shape = input.shape();
+  xla::int64 input_elements = xla::ShapeUtil::ElementsIn(input_shape);
+  xla::Shape result_shape =
+      xla::ShapeUtil::MakeShape(input_shape.element_type(), {input_elements});
+  result_shape.set_dynamic_dimension(0, true);
+  return xla::ShapeUtil::MakeTupleShape(
+      {result_shape, xla::ShapeUtil::MakeShape(xla::PrimitiveType::S32, {})});
+}
+
+}  // namespace
+
+MaskedSelect::MaskedSelect(const Value& input, const Value& mask)
+    : Node(ir::OpKind(at::aten::masked_select), {input, mask},
+           NodeOutputShape(input),
+           /*num_outputs=*/2) {}
+
+NodePtr MaskedSelect::Clone(OpList operands) const {
+  return MakeNode<MaskedSelect>(operands.at(0), operands.at(1));
+}
+
+XlaOpVector MaskedSelect::Lower(LoweringContext* loctx) const {
+  xla::XlaOp input = loctx->GetOutputOp(operand(0));
+  xla::XlaOp mask = loctx->GetOutputOp(operand(1));
+  return ReturnOps(BuildMaskedSelect(input, mask), loctx);
+}
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/masked_select.h
+++ b/torch_xla/csrc/ops/masked_select.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "torch_xla/csrc/ir.h"
+
+namespace torch_xla {
+namespace ir {
+namespace ops {
+
+// This node has no metadata, so it could have been implemented as generic-op in
+// ops.cpp, but since this might require special handling from upper IR layers,
+// it gets its own IR node class.
+class MaskedSelect : public Node {
+ public:
+  MaskedSelect(const Value& input, const Value& mask);
+
+  NodePtr Clone(OpList operands) const override;
+
+  XlaOpVector Lower(LoweringContext* loctx) const override;
+};
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/nonzero.cpp
+++ b/torch_xla/csrc/ops/nonzero.cpp
@@ -1,0 +1,40 @@
+#include "torch_xla/csrc/ops/nonzero.h"
+
+#include "tensorflow/compiler/xla/shape_util.h"
+#include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch_xla/csrc/lowering_context.h"
+#include "torch_xla/csrc/xla_lower_util.h"
+
+namespace torch_xla {
+namespace ir {
+namespace ops {
+namespace {
+
+xla::Shape NodeOutputShape(const Value& input) {
+  const xla::Shape& input_shape = input.shape();
+  xla::int64 index_elements = xla::ShapeUtil::ElementsIn(input_shape);
+  xla::Shape result_shape = xla::ShapeUtil::MakeShape(
+      xla::PrimitiveType::S32, {index_elements, input_shape.rank()});
+  result_shape.set_dynamic_dimension(0, true);
+  return xla::ShapeUtil::MakeTupleShape(
+      {result_shape, xla::ShapeUtil::MakeShape(xla::PrimitiveType::S32, {})});
+}
+
+}  // namespace
+
+NonZero::NonZero(const Value& input)
+    : Node(ir::OpKind(at::aten::nonzero), {input}, NodeOutputShape(input),
+           /*num_outputs=*/2) {}
+
+NodePtr NonZero::Clone(OpList operands) const {
+  return MakeNode<NonZero>(operands.at(0));
+}
+
+XlaOpVector NonZero::Lower(LoweringContext* loctx) const {
+  xla::XlaOp input = loctx->GetOutputOp(operand(0));
+  return ReturnOps(BuildNonZero(input), loctx);
+}
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/nonzero.h
+++ b/torch_xla/csrc/ops/nonzero.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "torch_xla/csrc/ir.h"
+
+namespace torch_xla {
+namespace ir {
+namespace ops {
+
+// This node has no metadata, so it could have been implemented as generic-op in
+// ops.cpp, but since this might require special handling from upper IR layers,
+// it gets its own IR node class.
+class NonZero : public Node {
+ public:
+  NonZero(const Value& input);
+
+  NodePtr Clone(OpList operands) const override;
+
+  XlaOpVector Lower(LoweringContext* loctx) const override;
+};
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/xla_ops.cpp
+++ b/torch_xla/csrc/ops/xla_ops.cpp
@@ -10,6 +10,7 @@ const OpKindWrapper xla_cross_replica_sum("xla::cross_replica_sum");
 const OpKindWrapper xla_device_data("xla::device_data");
 const OpKindWrapper xla_diagonal_view_update("xla::diagonal_view_update");
 const OpKindWrapper xla_generic_slice("xla::generic_slice");
+const OpKindWrapper xla_get_dimension_size("xla::xla_get_dimension_size");
 const OpKindWrapper xla_moving_average("xla::moving_average");
 const OpKindWrapper xla_not_supported("xla::not_supported");
 const OpKindWrapper xla_select("xla::select");

--- a/torch_xla/csrc/ops/xla_ops.h
+++ b/torch_xla/csrc/ops/xla_ops.h
@@ -34,6 +34,7 @@ extern const OpKindWrapper xla_cross_replica_sum;
 extern const OpKindWrapper xla_device_data;
 extern const OpKindWrapper xla_diagonal_view_update;
 extern const OpKindWrapper xla_generic_slice;
+extern const OpKindWrapper xla_get_dimension_size;
 extern const OpKindWrapper xla_moving_average;
 extern const OpKindWrapper xla_not_supported;
 extern const OpKindWrapper xla_select;

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -602,6 +602,8 @@ class XLATensor {
   static void masked_fill_(XLATensor& input, const XLATensor& mask,
                            at::Scalar value);
 
+  static XLATensor masked_select(const XLATensor& input, const XLATensor& mask);
+
   static XLATensor matmul(const XLATensor& input, const XLATensor& other);
 
   static XLATensor max(const XLATensor& input, const XLATensor& other);
@@ -699,6 +701,8 @@ class XLATensor {
                                      const XLATensor& weight,
                                      xla::int64 reduction, int ignore_index,
                                      const XLATensor& total_weight);
+
+  static XLATensor nonzero(const XLATensor& input);
 
   static XLATensor norm(const XLATensor& input, c10::optional<at::Scalar> p,
                         c10::optional<at::ScalarType> dtype,

--- a/torch_xla/csrc/xla_lower_util.h
+++ b/torch_xla/csrc/xla_lower_util.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include "tensorflow/compiler/xla/client/xla_builder.h"
 #include "tensorflow/core/lib/gtl/array_slice.h"
 
@@ -59,5 +61,10 @@ xla::XlaOp CreateScatter(const xla::XlaOp& input, const xla::XlaOp& index,
 
 xla::XlaOp CreatePut(const xla::XlaOp& input, const xla::XlaOp& index,
                      const xla::XlaOp& source, bool accumulate);
+
+std::vector<xla::XlaOp> BuildNonZero(const xla::XlaOp& input);
+
+std::vector<xla::XlaOp> BuildMaskedSelect(const xla::XlaOp& input,
+                                          const xla::XlaOp& mask);
 
 }  // namespace torch_xla


### PR DESCRIPTION
Support in experimental mode (for op-by-op requires an incoming XLA change):

```Shell
export XLA_EXPERIMENTAL=nonzero:masked_select
```
