### PR TITLE
Remove a trivially-copyable type move

### DIFF
--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -253,7 +253,7 @@ ViewInfo CreateAsStridedViewInfo(
     as_strided_info.offset = *storage_offset;
   }
   return ViewInfo(ViewInfo::Type::kAsStrided, std::move(result_shape),
-                  input_shape, std::move(as_strided_info));
+                  input_shape, as_strided_info);
 }
 
 }  // namespace


### PR DESCRIPTION
clang-tidy doesn't like it:
http://clang.llvm.org/extra/clang-tidy/checks/performance-move-const-arg.html