### PR TITLE
Fix to print out the max accuracy correctly (on testing examples)

### DIFF
--- a/test/test_train_cifar.py
+++ b/test/test_train_cifar.py
@@ -240,7 +240,7 @@ def train_cifar():
       print(met.metrics_report())
 
   test_utils.close_summary_writer(writer)
-  print('Max Accuracy: {:.2f}%'.format(accuracy))
+  print('Max Accuracy: {:.2f}%'.format(max_accuracy))
   return max_accuracy
 
 

--- a/test/test_train_imagenet.py
+++ b/test/test_train_imagenet.py
@@ -241,7 +241,7 @@ def train_imagenet():
       print(met.metrics_report())
 
   test_utils.close_summary_writer(writer)
-  print('Max Accuracy: {:.2f}%'.format(accuracy))
+  print('Max Accuracy: {:.2f}%'.format(max_accuracy))
   return max_accuracy
 
 

--- a/test/test_train_mnist.py
+++ b/test/test_train_mnist.py
@@ -171,7 +171,7 @@ def train_mnist():
       print(met.metrics_report())
 
   test_utils.close_summary_writer(writer)
-  print('Max Accuracy: {:.2f}%'.format(accuracy))
+  print('Max Accuracy: {:.2f}%'.format(max_accuracy))
   return max_accuracy
 
 

--- a/test/test_train_mp_imagenet.py
+++ b/test/test_train_mp_imagenet.py
@@ -231,7 +231,7 @@ def train_imagenet():
       print(met.metrics_report())
 
   test_utils.close_summary_writer(writer)
-  xm.master_print('Max Accuracy: {:.2f}%'.format(accuracy))
+  xm.master_print('Max Accuracy: {:.2f}%'.format(max_accuracy))
   return max_accuracy
 
 

--- a/test/test_train_mp_mnist.py
+++ b/test/test_train_mp_mnist.py
@@ -160,7 +160,7 @@ def train_mnist():
       print(met.metrics_report())
 
   test_utils.close_summary_writer(writer)
-  xm.master_print('Max Accuracy: {:.2f}%'.format(accuracy))
+  xm.master_print('Max Accuracy: {:.2f}%'.format(max_accuracy))
   return max_accuracy
 
 


### PR DESCRIPTION
https://github.com/pytorch/xla/blob/13e0151814cfc251a5819cfd0c0ea1bde49bd662/test/test_train_mnist.py#L157-L175

Hi:)

In testing examples (line 174 in above), it looks like the `current accuracy` is printed out instead of `max accuracy`.

I've found this typo on five testing files, and fixed them:)