### PR TITLE
Adds README preamble highlighting Colabs and README sections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,3 +114,31 @@ If your PR touches the Python source files, please run the following command bef
 #TODO:
 ```
 
+### Running the Tests
+
+To run the tests, follow __one__ of the options below:
+
+* Run on local CPU using the XRT client:
+
+  ```Shell
+  export XRT_DEVICE_MAP="CPU:0;/job:localservice/replica:0/task:0/device:XLA_CPU:0"
+  export XRT_WORKERS="localservice:0;grpc://localhost:40934"
+  ```
+
+  Select any free TCP port you prefer instead of 40934 (totally arbitrary).
+
+* Run on Cloud TPU using the XRT client, set the XRT_TPU_CONFIG environment variable:
+
+  ```Shell
+  export XRT_TPU_CONFIG="tpu_worker;0;<IP of the TPU node>:8470"
+  ```
+
+Note that the IP of the TPU node can change if the TPU node is reset. If _PyTorch_
+seem to hang at startup, verify that the IP of your TPU node is still the same of
+the one you have configured.
+
+If you are planning to be building from source and hence using the latest _PyTorch/TPU_ code base,
+it is suggested for you to select the _Nightly_ builds when you create a Cloud TPU instance.
+
+Then run `test/run_tests.sh` and `test/cpp/run_tests.sh` to verify the setup is working.
+

--- a/README.md
+++ b/README.md
@@ -1,29 +1,63 @@
-[![CircleCI](https://circleci.com/gh/pytorch/xla.svg?style=svg)](https://circleci.com/gh/pytorch/xla)
+# PyTorch/XLA
 
-For information regarding system architecture, please refer to the
-[Cloud TPU System Architecture](https://cloud.google.com/tpu/docs/system-architecture) page.
+<b>Current CI status:</b>  [![CircleCI](https://circleci.com/gh/pytorch/xla.svg?style=svg)](https://circleci.com/gh/pytorch/xla)
 
-# How to Run PyTorch with Single TPU Nodes
+PyTorch/XLA is a Python package that uses the
+[XLA deep learning compiler](https://www.tensorflow.org/xla)
+to connect the [PyTorch deep learning framework](https://pytorch.org/) and
+[Cloud TPUs](https://cloud.google.com/tpu/). You can try it right now, for free,
+on a single Cloud TPU with [Google Colab](https://colab.research.google.com/),
+and use it in production and on Cloud TPU Pods
+with [Google Cloud](https://cloud.google.com/gcp).
 
-You can either follow these tutorials available on Google Cloud website:
+Take a look at one of our Colab notebooks to quickly try different PyTorch networks
+running on Cloud TPUs and learn how to use Cloud TPUs as PyTorch devices:
+
+* [Getting Started with PyTorch on Cloud TPUs](https://colab.research.google.com/github/pytorch/xla/blob/master/contrib/colab/getting-started.ipynb)
+* [Fast Neural Style Transfer (NeurIPS 2019 Demo)](https://colab.research.google.com/github/pytorch/xla/blob/master/contrib/colab/style_transfer_inference-xrt-1-15.ipynb)
+* [Training A Simple Convolutional Network on MNIST](https://colab.research.google.com/github/pytorch/xla/blob/master/contrib/colab/mnist-training-xrt-1-15.ipynb)
+* [Training a ResNet18 Network on CIFAR10](https://colab.research.google.com/github/pytorch/xla/blob/master/contrib/colab/resnet18-training-xrt-1-15.ipynb)
+* [ImageNet Inference with ResNet50](https://colab.research.google.com/github/pytorch/xla/blob/master/contrib/colab/resnet50-inference-xrt-1-15.ipynb)
+
+The rest of this README covers:
+
+* [Running PyTorch on Cloud TPUs in production on Google Cloud.](#Cloud)
+Google Cloud also runs networks faster than Google Colab.
+* [API & Best Practices](#API)
+* [Troubleshooting](#Troubleshooting)
+* [Providing Feedback](#Feedback)
+* [Building and Contributing to PyTorch/XLA](#Contributing)
+
+Additional information on PyTorch/XLA, including a description of its
+semantics and functions, is available at [PyTorch.org](http://pytorch.org/xla/).
+
+## <a name="Cloud"></a> Running PyTorch on Cloud TPUs with Google Cloud Platform
+
+Google Cloud Platform lets you deploy PyTorch networks running on Cloud TPUs.
+This guide is split into two parts:
+
+* [Runnining on a single Cloud TPU](#CloudSingle)
+* [Running on a Cloud TPU Pod](#Pod)
+
+## <a name="CloudSingle"></a> Running on a Single Cloud TPU
+
+The following tutorials are available to help you train models on a single
+Cloud TPU:
 
 * [Training FairSeq Transformer on Cloud TPUs](https://cloud.google.com/tpu/docs/tutorials/transformer-pytorch)
 * [Training Resnet50 on Cloud TPUs](https://cloud.google.com/tpu/docs/tutorials/resnet-alpha-py)
-* [Training PyTorch models on Cloud TPU Pods](https://cloud.google.com/tpu/docs/tutorials/pytorch-pod)
 
-Or the following README to run your model.
-
-First [create your Cloud TPU node](https://cloud.google.com/tpu/docs/tutorials/resnet-alpha-py#create_tpu) with the corresponding release you wish to consume (TPU software version: ex. `pytorch-0.5`):
+To start, [you create a Cloud TPU node](https://cloud.google.com/tpu/docs/tutorials/resnet-alpha-py#create_tpu) with the corresponding release you wish to consume (TPU software version: ex. `pytorch-0.5`):
 
 Once you've created a Cloud TPU node, you can train your PyTorch models by either:
 
-* [Consuming prebuilt docker images (*recommended*)](#consume-prebuilt-docker-images)
-* [Consuming prebuilt Compute VM Images](#consume-prebuilt-compute-vm-images)
+* [Consuming prebuilt docker images (*recommended*)](#DockerImage)
+* [Consuming prebuilt Compute VM Images](#VMImage)
 
 
-## Consume Prebuilt Docker Images
+### <a name="DockerImage"></a> Consume Prebuilt Docker Images
 
-Follow these steps to train a PyTorch model with Docker on a TPU:
+Follow these steps to train a PyTorch model with Docker on a Cloud TPU:
 
 1. Create a Compute VM and install docker (or use COS VM image)
     * *Note: make sure the Compute VM is within the **same** zone as the TPU node you created or else performance will suffer, also ideally create a VM that has at least 16 cores (`n1-standard-16`) to not be VM compute/network bound.*
@@ -36,7 +70,7 @@ Follow these steps to train a PyTorch model with Docker on a TPU:
     * `gcr.io/tpu-pytorch/xla:r0.5`: The current stable version.
     * `gcr.io/tpu-pytorch/xla:nightly`: Nightly version.
     * `gcr.io/tpu-pytorch/xla:nightly_YYYYMMDD (e.g.: gcr.io/tpu-pytorch/xla:nightly_20190531)`: The nightly version of the given day.
-    
+
     At this time is recommended to use nightly versions and eventually switch to the stable version in case there are issues with nightly.
     Remember to create a TPU with `pytorch-nightly` version when using nightly.
 
@@ -68,7 +102,9 @@ Follow these steps to train a PyTorch model with Docker on a TPU:
       (pytorch) root@CONTAINERID:/$ python pytorch/xla/test/test_train_mnist.py
       ```
 
-## Consume Prebuilt Compute VM Images
+### <a name="VMImage"></a> Consume Prebuilt Compute VM Images
+
+Follow these steps to train a PyTorch model with a VM Image on a Cloud TPU:
 
 1. Create a Compute VM with PyTorch/XLA Image.
 
@@ -107,10 +143,11 @@ Follow these steps to train a PyTorch model with Docker on a TPU:
 
 ---
 
-# How to Run on TPU Pods (distributed training)
+## <a name="Pod"></a> How to Run on TPU Pods (distributed training)
 
 Whereas the previous section focused on training on a single TPU node,
-this section discusses distributed training in TPU Pods.
+this section discusses distributed training in TPU Pods. The tutorial,
+[Training PyTorch models on Cloud TPU Pods](https://cloud.google.com/tpu/docs/tutorials/pytorch-pod), is a great place to start.
 
 The recommended setup for running distributed training on TPU Pods uses the
 pairing of Compute VM [Instance
@@ -125,7 +162,8 @@ Training on pods can be broken down to largely 3 different steps:
 2. [Create your TPU Pod](#create-your-tpu-pod)
 3. [Start distributed training](#start-distributed-training)
 
-## Create your instance group
+### Create your instance group
+
 1. Create an instance template.
 * During creation, make sure to go to section "Identity and API access" → "Access Scopes" and select "Allow full access to all Cloud APIs".
 * If you have already have a VM instance running that you used to train PyTorch/TPU workloads and want to use that exact setup for distributed training: [instructions](https://cloud.google.com/compute/docs/instance-templates/create-instance-templates#based-on-existing-instance).
@@ -136,12 +174,12 @@ Training on pods can be broken down to largely 3 different steps:
 * Make sure to (a) create the instance group in a single zone (same zone as the TPU Pod you'll create), (b) no autoscaling or health-checks, (c) number of instances (size of instance group) should be number of cores / 8 (ex. for a v3-32 you'd create an instance group of size 32/8 = 4).
 * Here are the instructions for creating an instance group: [instructions](https://cloud.google.com/compute/docs/instance-groups/creating-groups-of-managed-instances#create_managed_group).
 
-## Create your TPU Pod
+### Create your TPU Pod
 1. [Create](https://pantheon.corp.google.com/compute/tpus) a TPU pod (same as creating regular TPUs, just select more cores when selecting TPU type).
 * Make sure that the TPU is in the same zone as the instance group.
 * Make sure that the size of your instance group follows: # instances in group = number of TPU cores / 8.
 
-## Start distributed training
+### Start distributed training
 1. SSH into any of the VMs in the instance group and get in an environment where you have `torch` and `torch_xla` installed (whether that's a [conda environment](#consume-prebuilt-compute-vm-images) or [docker container](#consume-prebuilt-docker-images)).
 2. Let's say the command you ran to run a v3-8 was: `XLA_USE_BF16=1 python test/test_train_imagenet.py --fake_data`.
 * To distribute training as a conda environment process:
@@ -155,7 +193,7 @@ Training on pods can be broken down to largely 3 different steps:
 (torch-xla-nightly)$ python -m torch_xla.distributed.xla_dist --tpu=$TPU_POD_NAME --docker-image=gcr.io/tpu-pytorch/xla:nightly --docker-run-flag=--rm=true --docker-run-flag=--shm-size=50GB --env=XLA_USE_BF16=1 -- python test/test_train_imagenet.py --fake_data
 ```
 
-## List of VMs
+### List of VMs
 If you up to not use an [instance group](#create-your-instance-group), you can decide to use a list of VM instances that you may have already created (or can create individually). Make sure that you create all the VM instances in the same zone as the TPU node, and also make sure that the VMs have the same configuration (datasets, VM size, disk size, etc.). Then you can [start distributed training](#start-distributed-training) after creating your TPU pod. The difference is in the `python -m torch_xla.distributed.xla_dist` command. For example, to use a list of VMs run the following command (ex. conda with v3-32):
 ```
 (torch-xla-nightly)$ cd /usr/share/torch-xla-nightly/pytorch/xla
@@ -163,61 +201,26 @@ If you up to not use an [instance group](#create-your-instance-group), you can d
 ```
 
 To learn more about TPU Pods check out this [blog
-post](https://cloud.google.com/blog/products/ai-machine-learning/googles-scalable-supercomputers-for-machine-learning-cloud-tpu-pods-are-now-publicly-available-in-beta).
+post](https://cloud.google.com/blog/products/ai-machine-learning/googles-scalable-supercomputers-for-machine-learning-cloud-tpu-pods-are-now-publicly-available-in-beta). For more information regarding system architecture, please refer to the
+[Cloud TPU System Architecture](https://cloud.google.com/tpu/docs/system-architecture) page.
 
----
+## <a name="API"></a> API & Best Practices
 
-# Running on Colab
+See the [API Guide](API_GUIDE.md) for best practices when writing networks that
+run on Cloud TPUs and Cloud TPU Pods.
 
-You can also run your models on [Colab](https://github.com/pytorch/xla/tree/master/contrib/colab). However, do note that performance may at times be severely impacted when running on Colab compared to creating your own VM and TPU pair.
+## <a name="Troubleshooting"></a> Troubleshooting
 
----
+If PyTorch/XLA isn't performing as expected, see the
+[troubleshooting guide](TROUBLESHOOTING.md), which has suggestions for
+debugging and optimizing your network(s).
 
-# Build Manually
+## <a name="Feedback"></a> Providing Feedback
 
-Please note that we have nightly releases available so users usually don't have to build manually. This is mainly for OSS contributors.
-Please refer to [contribution guide](CONTRIBUTING.md) for instructions to build from source.
+The PyTorch/XLA team is always happy to hear from users and OSS contributors!
+The best way to reach out is by filing an issue on this Github. Questions,
+bug reports, feature requests, build issues, etc. are all welcome!
 
-# Tests
+## <a name="Contributing"></a> Contributing
 
-To run the tests, follow __one__ of the options below:
-
-* Run on local CPU using the XRT client:
-
-  ```Shell
-  export XRT_DEVICE_MAP="CPU:0;/job:localservice/replica:0/task:0/device:XLA_CPU:0"
-  export XRT_WORKERS="localservice:0;grpc://localhost:40934"
-  ```
-
-  Select any free TCP port you prefer instead of 40934 (totally arbitrary).
-
-* Run on Cloud TPU using the XRT client, set the XRT_TPU_CONFIG environment variable:
-
-  ```Shell
-  export XRT_TPU_CONFIG="tpu_worker;0;<IP of the TPU node>:8470"
-  ```
-
-Note that the IP of the TPU node can change if the TPU node is reset. If _PyTorch_
-seem to hang at startup, verify that the IP of your TPU node is still the same of
-the one you have configured.
-
-If you are planning to be building from source and hence using the latest _PyTorch/TPU_ code base,
-it is suggested for you to select the _Nightly_ builds when you create a Cloud TPU instance.
-
-Then run `test/run_tests.sh` and `test/cpp/run_tests.sh` to verify the setup is working.
-
-# PyTorch/XLA API And Best Practices
-
-Please check out the [API Guideline](API_GUIDE.md) for the best practices to write models to run on TPU & TPU Pod devices.
-
-# Troubleshooting
-
-If you see bad performance when using PyTorch/XLA, please check out the [troubleshooting guide](TROUBLESHOOTING.md) for how to avoid common pitfalls and how to debug.
-
-# Communication
-
-We use github issues to communicate with users and open source contributors. Please file an issue for questions, bug reports, feature requests, install issues, RFCs, thoughts, etc.
-
-# Contributing
-
-Please refer to [contribution guide](CONTRIBUTING.md) for detailed instructions.
+See the [contribution guide](CONTRIBUTING.md).


### PR DESCRIPTION
This PR:

- Adds a PyTorch/XLA overview section at the beginning of the README. This section summarizes the package and highlights our Colab notebooks. It also provides organizational links into the rest of the README's sections.
- Moves the section on testing to CONTRIBUTING.md
- Moves the Cloud TPU Pod tutorial link to the section on Cloud TPU Pods
