### PR TITLE
Write an initial event to Tensorboard when tests start up. This allow…

### DIFF
--- a/torch_xla/test/test_utils.py
+++ b/torch_xla/test/test_utils.py
@@ -69,9 +69,8 @@ def get_summary_writer(logdir):
   if logdir:
     from tensorboardX import SummaryWriter
     writer = SummaryWriter(log_dir=logdir)
-    current_time = time.time()
     write_to_summary(writer, 0, dict_to_write={
-        'TensorboardStartTimestamp': current_time})
+        'TensorboardStartTimestamp': time.time()})
     return writer
 
 

--- a/torch_xla/test/test_utils.py
+++ b/torch_xla/test/test_utils.py
@@ -70,7 +70,8 @@ def get_summary_writer(logdir):
     from tensorboardX import SummaryWriter
     writer = SummaryWriter(log_dir=logdir)
     current_time = time.time()
-    write_to_summary(writer, 0, dict_to_write={'StartupTime': current_time})
+    write_to_summary(writer, 0, dict_to_write={
+        'TensorboardStartTimestamp': current_time})
     return writer
 
 

--- a/torch_xla/test/test_utils.py
+++ b/torch_xla/test/test_utils.py
@@ -68,7 +68,9 @@ def get_summary_writer(logdir):
   """
   if logdir:
     from tensorboardX import SummaryWriter
-    return SummaryWriter(log_dir=logdir)
+    writer = SummaryWriter(log_dir=logdir)
+    write_to_summary(writer, 0, dict_to_write={'StartupTime': 0})
+    return writer
 
 
 def print_training_update(device, step_num, loss, rate, global_rate):

--- a/torch_xla/test/test_utils.py
+++ b/torch_xla/test/test_utils.py
@@ -69,7 +69,8 @@ def get_summary_writer(logdir):
   if logdir:
     from tensorboardX import SummaryWriter
     writer = SummaryWriter(log_dir=logdir)
-    write_to_summary(writer, 0, dict_to_write={'StartupTime': 0})
+    current_time = time.time()
+    write_to_summary(writer, 0, dict_to_write={'StartupTime': current_time})
     return writer
 
 


### PR DESCRIPTION
…s us to determine the wall time of a test from the Tensorboard summary alone.

Tested by running test_train_mnist.py and making sure the Tensorboard summary contains the new entry as it's first entry.