### PR TITLE
Update clip patch.

### DIFF
--- a/torch_patches/X10-clip_grad.diff
+++ b/torch_patches/X10-clip_grad.diff
@@ -1,27 +1,19 @@
 diff --git a/torch/nn/utils/clip_grad.py b/torch/nn/utils/clip_grad.py
-index ec5f62179e..6b860a9274 100644
+index ec5f62179e..0d5bd34e25 100644
 --- a/torch/nn/utils/clip_grad.py
 +++ b/torch/nn/utils/clip_grad.py
-@@ -24,14 +24,18 @@ def clip_grad_norm_(parameters, max_norm, norm_type=2):
-     parameters = list(filter(lambda p: p.grad is not None, parameters))
-     max_norm = float(max_norm)
-     norm_type = float(norm_type)
-+    device = parameters[0].device if parameters else torch.device('cpu')
-     if norm_type == inf:
+@@ -28,10 +28,10 @@ def clip_grad_norm_(parameters, max_norm, norm_type=2):
          total_norm = max(p.grad.detach().abs().max() for p in parameters)
      else:
--        total_norm = torch.norm(torch.stack([torch.norm(p.grad.detach(), norm_type) for p in parameters]), norm_type)
+         total_norm = torch.norm(torch.stack([torch.norm(p.grad.detach(), norm_type) for p in parameters]), norm_type)
 -    clip_coef = max_norm / (total_norm + 1e-6)
 -    if clip_coef < 1:
-+        total_norm = torch.zeros([], device=device if parameters else None)
-         for p in parameters:
+-        for p in parameters:
 -            p.grad.detach().mul_(clip_coef)
-+            param_norm = p.grad.data.norm(norm_type) ** norm_type
-+            total_norm.add_(param_norm)
-+        total_norm = (total_norm ** (1. / norm_type))
++    device = parameters[0].device if parameters else torch.device('cpu')
 +    clip_coef = torch.tensor(max_norm, device=device) / (total_norm + 1e-6)
 +    for p in parameters:
-+        p.grad.data.mul_(torch.where(clip_coef < 1, clip_coef, torch.tensor(1., device=device)))
++        p.grad.detach().mul_(torch.where(clip_coef < 1, clip_coef, torch.tensor(1., device=device)))
      return total_norm
  
  


### PR DESCRIPTION
Tested locally with a small benchmark:

```
import torch
import time
import torch.nn as nn
from torch._six import inf
import torch_xla

def test_clip_grad_norm(device='cpu'):
    l = nn.Linear(10, 10).to(device)
    max_norm = 2

    grads = torch.arange(1., 101, device=device).view(10, 10), torch.ones(10, device=device).div(1000)
    start = time.time()
    for _ in range(100):
        for norm_type in [0.5]:
            for p, g in zip(l.parameters(), grads):
                p._grad = g.clone().view_as(p.data)
            norm = nn.utils.clip_grad_norm_(l.parameters(), max_norm, norm_type=norm_type)
    print(time.time() - start)

test_clip_grad_norm('xla:0')
```
And perf shows no regression after removing the patch. This is mainly because we removed calls to `.item()` after this https://github.com/pytorch/pytorch/pull/32020. I think fairseq models perf won't be affected cc: @taylanbil , but happy to double check before landing if necessary.