### PR TITLE
Recover from dead and hanging client-side workers

### DIFF
--- a/test/xla_dist_test.py
+++ b/test/xla_dist_test.py
@@ -312,7 +312,7 @@ class ClusterResolverTest(unittest.TestCase):
   def setUp(self):
     super(ClusterResolverTest, self).setUp()
     self.addCleanup(mock.patch.stopall)
-    mock.patch.object(ClusterResolver, '_get_instance_metadata',
+    mock.patch.object(ClusterResolver, 'get_instance_metadata',
                       mock_request_metadata).start()
     mock.patch.object(GoogleCredentials, 'get_application_default',
                       lambda *args, **kwargs: None).start()

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -13,7 +13,6 @@ import torch_xla.debug.metrics_saver as ms
 import torch_xla.utils.utils as xu
 import torch_xla.utils.keyd_queue as kq
 
-MARK_STEP_TOKEN = 'torch_xla.core.xla_model::mark_step'
 _TLS = threading.local()
 
 
@@ -405,7 +404,7 @@ def _run_step_closures():
 
 def mark_step():
   if xu.getenv_as('XLA_EMIT_STEPLOG', bool, False):
-    print(MARK_STEP_TOKEN, flush=True)
+    print('torch_xla.core.xla_model::mark_step', file=sys.stderr, flush=True)
   torch_xla._XLAC._xla_step_marker(
       torch_xla._XLAC._xla_get_default_device(), [],
       wait=xu.getenv_as('XLA_SYNC_WAIT', bool, False))

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -403,6 +403,8 @@ def _run_step_closures():
 
 
 def mark_step():
+  if xu.getenv_as('XLA_EMIT_STEPLOG', bool, False):
+    print('torch_xla.core.xla_model::mark_step', flush=True)
   torch_xla._XLAC._xla_step_marker(
       torch_xla._XLAC._xla_get_default_device(), [],
       wait=xu.getenv_as('XLA_SYNC_WAIT', bool, False))

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -13,6 +13,7 @@ import torch_xla.debug.metrics_saver as ms
 import torch_xla.utils.utils as xu
 import torch_xla.utils.keyd_queue as kq
 
+MARK_STEP_TOKEN = 'torch_xla.core.xla_model::mark_step'
 _TLS = threading.local()
 
 
@@ -404,7 +405,7 @@ def _run_step_closures():
 
 def mark_step():
   if xu.getenv_as('XLA_EMIT_STEPLOG', bool, False):
-    print('torch_xla.core.xla_model::mark_step', flush=True)
+    print(MARK_STEP_TOKEN, flush=True)
   torch_xla._XLAC._xla_step_marker(
       torch_xla._XLAC._xla_get_default_device(), [],
       wait=xu.getenv_as('XLA_SYNC_WAIT', bool, False))

--- a/torch_xla/distributed/worker.py
+++ b/torch_xla/distributed/worker.py
@@ -6,7 +6,7 @@ class Worker(object):
   def __init__(self, internal_ip, machine_type, zone):
     if not isinstance(internal_ip, str):
       raise ValueError('internal_ip must be of type str')
-    self._internal_ip = internal_ip
+    self.internal_ip = internal_ip
     if not isinstance(machine_type, str):
       raise ValueError('machine_type must be of type str')
     self._machine_type = machine_type
@@ -26,13 +26,13 @@ class ClientWorker(Worker):
   def __repr__(self):
     return ('{{{internal_ip}, {machine_type}, {zone},'
             ' {hostname}}}').format(
-                internal_ip=self._internal_ip,
+                internal_ip=self.internal_ip,
                 machine_type=self._machine_type,
                 zone=self._zone,
                 hostname=self._hostname)
 
   def __eq__(self, other):
-    return (self._internal_ip == other._internal_ip and
+    return (self.internal_ip == other.internal_ip and
             self._machine_type == other._machine_type and
             self._zone == other._zone and self._hostname == other._hostname)
 
@@ -45,13 +45,13 @@ class ClientWorker(Worker):
   def __repr__(self):
     return ('{{{internal_ip}, {machine_type}, {zone},'
             ' {hostname}}}').format(
-                internal_ip=self._internal_ip,
+                internal_ip=self.internal_ip,
                 machine_type=self._machine_type,
                 zone=self._zone,
                 hostname=self._hostname)
 
   def __eq__(self, other):
-    return (self._internal_ip == other._internal_ip and
+    return (self.internal_ip == other.internal_ip and
             self._machine_type == other._machine_type and
             self._zone == other._zone and self._hostname == other._hostname)
 
@@ -78,7 +78,7 @@ class ServiceWorker(Worker):
   def __repr__(self):
     return ('{{{internal_ip}, {port}, {machine_type}, {zone},'
             ' {runtime_version}, {tpu}}}').format(
-                internal_ip=self._internal_ip,
+                internal_ip=self.internal_ip,
                 port=self._port,
                 machine_type=self._machine_type,
                 zone=self._zone,
@@ -86,7 +86,7 @@ class ServiceWorker(Worker):
                 tpu=self._tpu)
 
   def __eq__(self, other):
-    return (self._internal_ip == other._internal_ip and
+    return (self.internal_ip == other.internal_ip and
             self._port == other._port and
             self._machine_type == other._machine_type and
             self._zone == other._zone and

--- a/torch_xla/distributed/worker.py
+++ b/torch_xla/distributed/worker.py
@@ -6,13 +6,19 @@ class Worker(object):
   def __init__(self, internal_ip, machine_type, zone):
     if not isinstance(internal_ip, str):
       raise ValueError('internal_ip must be of type str')
-    self.internal_ip = internal_ip
+    self._internal_ip = internal_ip
     if not isinstance(machine_type, str):
       raise ValueError('machine_type must be of type str')
     self._machine_type = machine_type
     if not isinstance(zone, str):
       raise ValueError('zone must be of type str')
     self._zone = zone
+
+  def get_internal_ip(self):
+    return self._internal_ip
+
+  def get_zone(self):
+    return self._zone
 
 
 class ClientWorker(Worker):
@@ -23,16 +29,19 @@ class ClientWorker(Worker):
       raise ValueError('hostname must be of type str')
     self._hostname = hostname
 
+  def get_hostname(self):
+    return self._hostname
+
   def __repr__(self):
     return ('{{{internal_ip}, {machine_type}, {zone},'
             ' {hostname}}}').format(
-                internal_ip=self.internal_ip,
+                internal_ip=self._internal_ip,
                 machine_type=self._machine_type,
                 zone=self._zone,
                 hostname=self._hostname)
 
   def __eq__(self, other):
-    return (self.internal_ip == other.internal_ip and
+    return (self._internal_ip == other._internal_ip and
             self._machine_type == other._machine_type and
             self._zone == other._zone and self._hostname == other._hostname)
 
@@ -45,13 +54,13 @@ class ClientWorker(Worker):
   def __repr__(self):
     return ('{{{internal_ip}, {machine_type}, {zone},'
             ' {hostname}}}').format(
-                internal_ip=self.internal_ip,
+                internal_ip=self._internal_ip,
                 machine_type=self._machine_type,
                 zone=self._zone,
                 hostname=self._hostname)
 
   def __eq__(self, other):
-    return (self.internal_ip == other.internal_ip and
+    return (self._internal_ip == other._internal_ip and
             self._machine_type == other._machine_type and
             self._zone == other._zone and self._hostname == other._hostname)
 
@@ -75,10 +84,13 @@ class ServiceWorker(Worker):
       raise ValueError('tpu must be of type str')
     self._tpu = tpu
 
+  def get_port(self):
+    return self._port
+
   def __repr__(self):
     return ('{{{internal_ip}, {port}, {machine_type}, {zone},'
             ' {runtime_version}, {tpu}}}').format(
-                internal_ip=self.internal_ip,
+                internal_ip=self._internal_ip,
                 port=self._port,
                 machine_type=self._machine_type,
                 zone=self._zone,
@@ -86,7 +98,7 @@ class ServiceWorker(Worker):
                 tpu=self._tpu)
 
   def __eq__(self, other):
-    return (self.internal_ip == other.internal_ip and
+    return (self._internal_ip == other._internal_ip and
             self._port == other._port and
             self._machine_type == other._machine_type and
             self._zone == other._zone and

--- a/torch_xla/distributed/xla_dist.py
+++ b/torch_xla/distributed/xla_dist.py
@@ -133,7 +133,8 @@ class DistributedExecutor(object):
         std_line = std.decode('utf-8').rstrip('\n')
         if 'torch_xla.core.xla_model::mark_step' in std_line:
           hb_stream = self._last_heartbeats[client_ip]
-          hb_stream['last_time'] = time.time()  # atomic update operations
+          # Only single thread updates each of these, so there is no race
+          hb_stream['last_time'] = time.time()
           hb_stream['count'] += 1
           continue
         log_fn(

--- a/torch_xla/utils/utils.py
+++ b/torch_xla/utils/utils.py
@@ -233,7 +233,7 @@ def parallel_work(num_workers, fn, *args):
   """
   with futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
     results = executor.map(fn, *args)
-    return [res.result() for res in results if res]
+    return [res for res in results]  # Iterating to re-raise any exceptions
 
 
 class TimedScope(object):

--- a/torch_xla/utils/utils.py
+++ b/torch_xla/utils/utils.py
@@ -1,6 +1,7 @@
 from __future__ import division
 from __future__ import print_function
 
+from concurrent import futures
 import copy
 import os
 import shutil
@@ -217,6 +218,22 @@ def timed(fn, msg='', printfn=eprint):
   result = fn()
   printfn('{}{:.3f}ms'.format(msg, 1000.0 * (time.time() - s)))
   return result
+
+
+def parallel_work(num_workers, fn, *args):
+  """Executes fn in parallel threads with args and returns result list.
+
+  Args:
+    num_workers: number of workers in thread pool to execute work.
+    fn: python function for each thread to execute.
+    *args: arguments used to call executor.map with.
+
+  Raises:
+    Exception: re-raises any exceptions that may have been raised by workers.
+  """
+  with futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
+    results = executor.map(fn, *args)
+    return [res.result() for res in results if res]
 
 
 class TimedScope(object):


### PR DESCRIPTION
PR implements feature to re-start training in the following cases:
* SSH connection to one of the workers is severed. This covers cases such as HostErrors where the VM is terminated due to either bugs in the VM layer or hardware failures. Also covers failures due to ssh network failures.
* Hanging steps. This PR has all of the client-side workers mark step 'tokens' that get's checked by the xla_dist process. Assumption is that all the mark_step tokens should come within O(10s). If they don't come all within O(10s), training is killed and restarted.

TESTED=Manually `sudo shutdown`-ing from GCE VM to have training resume eventually.