### PR TITLE
Keep the memory used for sending tensors to device under control, to …

### DIFF
--- a/torch_xla/utils/utils.py
+++ b/torch_xla/utils/utils.py
@@ -9,6 +9,13 @@ import tempfile
 import time
 
 
+class Object(object):
+
+  def __init__(self, defs={}):
+    for k, v in defs.items():
+      setattr(self, k, v)
+
+
 class Cleaner(object):
 
   def __init__(self, func):


### PR DESCRIPTION
…avoid tripping over the ProtocolBuffer 2GB time bomb.