### PR TITLE
Revert "Keep the memory used for sending tensors to device under control, to …"

### DIFF
--- a/torch_xla/distributed/parallel_loader.py
+++ b/torch_xla/distributed/parallel_loader.py
@@ -10,16 +10,6 @@ import torch_xla.utils.utils as xu
 import torch_xla.core.xla_model as xm
 
 
-def _get_input_size(data):
-  obj = xu.Object({'size': 0})
-
-  def fn(v):
-    obj.size += v.numel() * v.element_size()
-
-  xu.for_each_instance(data, lambda x: type(x) == torch.Tensor, fn)
-  return obj.size
-
-
 class PerDeviceQueue(object):
 
   def __init__(self, device, loader_prefetch_size, device_prefetch_size):
@@ -71,9 +61,6 @@ class ParallelLoader(object):
       where the worker threads deposit tensors which have already been sent to
       devices.
       Default: 4
-    max_device_prefetch_mem (int, optional): The maximum memory a single device
-      data upload can use.
-      Default: 1500000000
   """
 
   def __init__(self,
@@ -82,13 +69,11 @@ class ParallelLoader(object):
                batchdim=0,
                fixed_batch_size=False,
                loader_prefetch_size=8,
-               device_prefetch_size=4,
-               max_device_prefetch_mem=1500000000):
+               device_prefetch_size=4):
     self._loader = loader
     self._devices = [torch.device(x) for x in devices]
     self._batchdim = batchdim
     self._fixed_batch_size = fixed_batch_size
-    self._max_device_prefetch_mem = max_device_prefetch_mem
     self._done = False
     self._queues = dict()
     for device in self._devices:
@@ -127,17 +112,17 @@ class ParallelLoader(object):
       dqueue.loader_queue.close()
 
   def _get_batch_size(self, data, dim):
-    obj = xu.Object({'size': -1})
+    size = []
 
     def fn(v):
       csize = v.size()[dim]
-      if obj.size < 0:
-        obj.size = csize
+      if not size:
+        size.append(csize)
       else:
-        assert csize == obj.size
+        assert csize == size[0]
 
     xu.for_each_instance(data, lambda x: type(x) == torch.Tensor, fn)
-    return obj.size if obj.size >= 0 else None
+    return size[0] if size else None
 
   def _loader_worker(self):
     queues = list(self._queues.values())
@@ -163,17 +148,11 @@ class ParallelLoader(object):
       dqueue.loader_queue.close_write()
 
   def _get_batch(self, dqueue):
-    item_size, mem_size = 0, 0
     batch = []
     while dqueue.queue.max_size() > len(batch):
-      if batch and (mem_size + item_size) > self._max_device_prefetch_mem:
-        break
       item = dqueue.loader_queue.get()
       if item is None:
         break
-      if item_size == 0:
-        item_size = _get_input_size(item)
-      mem_size += item_size
       batch.append(item)
     return batch
 

--- a/torch_xla/utils/utils.py
+++ b/torch_xla/utils/utils.py
@@ -9,13 +9,6 @@ import tempfile
 import time
 
 
-class Object(object):
-
-  def __init__(self, defs={}):
-    for k, v in defs.items():
-      setattr(self, k, v)
-
-
 class Cleaner(object):
 
   def __init__(self, func):


### PR DESCRIPTION
Reverts pytorch/xla#1643

This will have to be taken care on the C++ side, as we have a similar issue there.
