### PR TITLE
Emit the tensors graph before compiling to make sure some level of de…

### DIFF
--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1217,9 +1217,6 @@ std::shared_ptr<XLATensor::Async> XLATensor::ScheduleSyncTensorsGraph(
     SyncTensorCollection* coll,
     std::vector<xla::ComputationClient::DataPtr> parameters_data,
     std::string device, ComputationCache::TypePtr cached_computation) {
-  DebugUtil::SaveTensorsGraphInfo("ScheduleSyncTensorsGraph", *tensors,
-                                  &coll->indices);
-
   auto tensors_data = FetchTensorData(tensors, config, coll->indices);
   return ScheduleSyncTensorsGraph(coll, std::move(parameters_data),
                                   std::move(tensors_data),
@@ -1382,6 +1379,9 @@ std::shared_ptr<XLATensor::Async> XLATensor::SyncTensorsGraphInternal(
   if (coll.indices.empty()) {
     return nullptr;
   }
+  DebugUtil::SaveTensorsGraphInfo("ScheduleSyncTensorsGraph", *tensors,
+                                  &coll.indices);
+
   std::shared_ptr<Async> async = TryRunCachedSync(tensors, config, &coll);
   if (async != nullptr) {
     return async;


### PR DESCRIPTION
…bugging can be done on the TEXT graph in case of XLA lowering errors.