### PR TITLE
Revert "Fix copy from xla to CPU"

### DIFF
--- a/test/torch_test_meta.py
+++ b/test/torch_test_meta.py
@@ -9,8 +9,9 @@ disabled_torch_tests = {
     # TestDevicePrecision
     'test_sum_cpu_device_mismatch',  # doesn't raise
     'test_solve_methods_arg_device',  # doesn't raise
-    'test_min_max_nan',  # XLA min/max ignores Nans.
-    'test_min_max_binary_op_nan',  # XLA min/max ignores Nans.
+    'test_min_max_nan',
+    'test_min_max_binary_op_nan',
+    'test_copy_noncontig',
     'test_copy_broadcast',
     'test_digamma',  # Precision issue at the first assert, then NAN handling (both on TPU)
 
@@ -73,7 +74,7 @@ disabled_torch_tests = {
     'test_lstsq',
     'test_is_set_to',
     'test_inverse',
-    'test_empty_tensor_props',  # stride
+    'test_empty_tensor_props',
     'test_dist',
     'test_dim_function_empty',
     'test_diagflat',

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -835,15 +835,14 @@ at::Tensor& AtenXlaType::copy_(at::Tensor& self, const at::Tensor& src,
     XLA_CHECK(self_tensor);
     self_tensor->UpdateFromTensor(CopyTensor(src, self.scalar_type()));
   } else if (!self_tensor) {
+    // TODO: Is self_tensor good enough?  I don't think so... therefore
+    // the hack below:
     std::vector<at::Tensor> tensors = {src};
     auto xla_tensors = bridge::XlaCreateTensorList(tensors);
+    // Hack in an overwrite of a const tensor.
     at::Tensor t = CopyTensor(xla_tensors.front(), self.scalar_type());
-    // Both `self` and `t` are on CPU now, simply redispatch to the CPU
-    // copy_ implementation.
-    // Note the old way of calling shallow_copy_from only moves the storage
-    // pointer, it doesn't work if `self` is a view of existing storage as
-    // updates won't be propogated back to the storage!
-    self.copy_(t);
+    const_cast<at::Tensor&>(self).unsafeGetTensorImpl()->shallow_copy_from(
+        t.getIntrusivePtr());
   } else {
     XLATensor::copy_(*self_tensor, *src_tensor);
     bridge::ReplaceXlaTensor(self, *self_tensor);


### PR DESCRIPTION
Reverts pytorch/xla#1645

@ailzhang This one break dynamic shapes (only available on TPU ATM).

We can revisit later eventually.
```
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: C++ exception with description "The size of tensor a (8) must match the size of tensor b (3) at non-singleton dimension 0 (infer_size at /pytorch/aten/src/ATen/ExpandUtils.cpp:24)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) + 0x4a (0x7fdcaa2646ca in /pytorch/torch/lib/libc10.so)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #1: at::infer_size(c10::ArrayRef<long>, c10::ArrayRef<long>) + 0x358 (0x7fdc95948d88 in /pytorch/torch/lib/libtorch_cpu.so)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #2: at::TensorIterator::compute_shape() + 0x11a (0x7fdc95dfc0ea in /pytorch/torch/lib/libtorch_cpu.so)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #3: at::TensorIterator::build() + 0x89 (0x7fdc95dfa269 in /pytorch/torch/lib/libtorch_cpu.so)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #4: <unknown function> + 0xa302ce (0x7fdc95acb2ce in /pytorch/torch/lib/libtorch_cpu.so)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #5: at::native::copy_(at::Tensor&, at::Tensor const&, bool) + 0x43 (0x7fdc95acad63 in /pytorch/torch/lib/libtorch_cpu.so)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #6: at::Tensor& c10::KernelFunction::callUnboxed<at::Tensor&, at::Tensor&, at::Tensor const&, bool>(c10::OperatorHandle const&, at::Tensor&, at::Tensor const&, bool) const + 0x104 (0x7377d4 in ./test_ptxla)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #7: torch_xla::AtenXlaType::copy_(at::Tensor&, at::Tensor const&, bool) + 0x265 (0x7fdca9b6f495 in /pytorch/xla/build/lib.linux-x86_64-3.6/libptxla.so)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #8: <unknown function> + 0x95c1a7 (0x7fdc959f71a7 in /pytorch/torch/lib/libtorch_cpu.so)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #9: <unknown function> + 0x383449e (0x7fdc988cf49e in /pytorch/torch/lib/libtorch_cpu.so)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #10: <unknown function> + 0x95c1a7 (0x7fdc959f71a7 in /pytorch/torch/lib/libtorch_cpu.so)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #11: <unknown function> + 0xd32c62 (0x7fdc95dcdc62 in /pytorch/torch/lib/libtorch_cpu.so)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #12: at::native::to(at::Tensor const&, c10::TensorOptions const&, bool, bool, c10::optional<c10::MemoryFormat>) + 0x201 (0x7fdc95dcd511 in /pytorch/torch/lib/libtorch_cpu.so)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #13: <unknown function> + 0x113c166 (0x7fdc961d7166 in /pytorch/torch/lib/libtorch_cpu.so)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #14: <unknown function> + 0x31bc011 (0x7fdc98257011 in /pytorch/torch/lib/libtorch_cpu.so)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #15: <unknown function> + 0xfe351c (0x7fdc9607e51c in /pytorch/torch/lib/libtorch_cpu.so)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #16: at::Tensor c10::KernelFunction::callUnboxed<at::Tensor, at::Tensor const&, c10::TensorOptions const&, bool, bool, c10::optional<c10::MemoryFormat> >(c10::OperatorHandle const&, at::Tensor const&, c10::TensorOptions const&, bool, bool, c10::optional<c10::MemoryFormat>) const + 0x78 (0x5840a8 in ./test_ptxla)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #17: at::Tensor c10::Dispatcher::callUnboxed<at::Tensor, at::Tensor const&, c10::TensorOptions const&, bool, bool, c10::optional<c10::MemoryFormat> >(c10::OperatorHandle const&, at::Tensor const&, c10::TensorOptions const&, bool, bool, c10::optional<c10::MemoryFormat>) const + 0x166 (0x582476 in ./test_ptxla)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #18: torch_xla::cpp_test::ToCpuTensor(at::Tensor const&) + 0x91 (0x57aec1 in ./test_ptxla)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #19: torch_xla::cpp_test::CloseValues(at::Tensor, at::Tensor, double, double) + 0xd1 (0x57c5d1 in ./test_ptxla)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #20: ./test_ptxla() [0x6386a7]
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #21: ./test_ptxla() [0x688a45]
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #22: torch_xla::cpp_test::ForEachDevice(std::function<void (c10::Device const&)> const&) + 0x2d (0x57c4ed in ./test_ptxla)
Feb 16 13:56:40 tputest-pytorch-cpp-operations-b7e54000-0e0e-4d-client tf_test[3968]: frame #23: torch_xla::cpp_test::AtenXlaTensorTest_TestNonzero_Test::TestBody() + 0x411 (0x5eeb01 in ./test_ptxla)
```
