### PR TITLE
Removed svd tests from skipped list.

### DIFF
--- a/test/torch_test_meta.py
+++ b/test/torch_test_meta.py
@@ -9,19 +9,13 @@ disabled_torch_tests = {
     # TestDevicePrecision
     'test_sum_cpu_device_mismatch',  # doesn't raise
     'test_solve_methods_arg_device',  # doesn't raise
-    'test_min_max_nan',
-    'test_min_max_binary_op_nan',
+    'test_min_max_nan',  # XLA min/max ignores Nans.
+    'test_min_max_binary_op_nan',  # XLA min/max ignores Nans.
     'test_copy_noncontig',
     'test_copy_broadcast',
     'test_digamma',  # Precision issue at the first assert, then NAN handling (both on TPU)
 
     # TestTensorDeviceOps
-    'test_svd_tall_some_xla',
-    'test_svd_tall_some_col_maj_xla',
-    'test_svd_tall_all_xla',
-    'test_svd_tall_all_col_maj_xla',
-    'test_svd_square_xla',
-    'test_svd_square_col_maj_xla',
     'test_prod_neg_dim_xla',
     'test_prod_dim_xla',
     'test_cumprod_xla',
@@ -75,7 +69,7 @@ disabled_torch_tests = {
     'test_lstsq',
     'test_is_set_to',
     'test_inverse',
-    'test_empty_tensor_props',
+    'test_empty_tensor_props',  # stride
     'test_dist',
     'test_dim_function_empty',
     'test_diagflat',


### PR DESCRIPTION
We fixed a few `torch.svd` tests on PyTorch side in https://github.com/pytorch/pytorch/pull/33470. Now they should be passing for XLA. 
This PR removes them from the skipped list. 