### PR TITLE
Sync checkpoints dir prior to restarting the job in `xla_dist`

### DIFF
--- a/torch_xla/distributed/xla_dist.py
+++ b/torch_xla/distributed/xla_dist.py
@@ -541,8 +541,6 @@ class DistributedExecutor(object):
 
         script_map = self._prepare_scripts(cmd)
         self._sync_checkpoints()
-        import pdb
-        pdb.set_trace()
         proc = multiprocessing.Process(target=self._run_cmd, args=(script_map,))
         proc.start()
         while True:


### PR DESCRIPTION
For the time being, assumes master's copy is healthy.
Assumes user has implemented logic to load checkpoints safely in their code.

Adds an argument specifying which directory to sync, and then the logic to sync is as follows:
  * get the last modified file/dir in path
  * get the files/dirs that are within 10 mins of that file/dir.
  * get sizes for the same files from remote hosts
  * compare sizes
  * for all remote hosts that has a drastically different copy
    * scp over from healthy host

tested the following cases:

* chpt dir doesn't exist anywhere
* chpt dir doesn't exist on one remote
* chpt dir doesn't exist on master
* all chpt dirs are empty
* add new file to an existing dir
* add new dir and new files in that dir
* remove old file, no sync