### PR TITLE
Use bazelisk from npm.

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -54,20 +54,17 @@ wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
 sudo apt-get -qq update
 sudo apt-get -qq install clang-8 clang++-8
 
-# XLA build requires Bazel
-# We use bazelisk to avoid updating Bazel version manually.
-sudo add-apt-repository ppa:longsleep/golang-backports
-sudo apt-get update
-sudo apt-get -qq install golang-go
-go get github.com/bazelbuild/bazelisk
-export PATH=$PATH:$(go env GOPATH)/bin
-sudo ln -s `which bazelisk` /usr/bin/bazel
-
-# Install bazels3cache for cloud cache
 sudo apt-get -qq install npm
 npm config set strict-ssl false
 curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
 sudo apt-get install -qq nodejs
+
+# XLA build requires Bazel
+# We use bazelisk to avoid updating Bazel version manually.
+sudo npm install -g @bazel/bazelisk
+sudo ln -s "$(command -v bazelisk)" /usr/bin/bazel
+
+# Install bazels3cache for cloud cache
 sudo npm install -g bazels3cache
 BAZELS3CACHE="$(which bazels3cache)"
 if [ -z "${BAZELS3CACHE}" ]; then

--- a/test/torch_test_meta.py
+++ b/test/torch_test_meta.py
@@ -51,6 +51,7 @@ disabled_torch_tests = {
     'test_eig_with_eigvec_xla_float64',  # Precision: tensor(1.1798, dtype=torch.float64) not less than or equal to 0.001
 
     # TestTorchDeviceType
+    'test_addmm_sizes',  # FIXME: very slow compile
     'test_clamp',  # slow
     'test_lu_unpack',  # very slow compile
     'test_view',  # doesn't raise


### PR DESCRIPTION
- npm also has a bazelisk package which is simpler than installing from go.  
- ~Update wheel to use bazelisk as well. cc: @jysohn23 Probably need your thorough review to make sure it doesn't break anything. ;)~