### PR TITLE
Add checkpoint tagger utility

### DIFF
--- a/torch_xla/test/metrics_test_wrapper.py
+++ b/torch_xla/test/metrics_test_wrapper.py
@@ -121,7 +121,7 @@ def _write_to_disk_or_gcs(output_string, output_filename):
   if not output_filename:
     return
   try:
-    gcsfs.write_to_disk_or_gcs(output_string, output_filename)
+    gcsfs.generic_write(output_string, output_filename)
     print('Succeeded writing metrics to file: {}'.format(output_filename))
   except Exception as e:
     print('Failed writing metrics to file: {}'.format(e))

--- a/torch_xla/test/metrics_test_wrapper.py
+++ b/torch_xla/test/metrics_test_wrapper.py
@@ -121,7 +121,7 @@ def _write_to_disk_or_gcs(output_string, output_filename):
   if not output_filename:
     return
   try:
-    xu.write_to_disk_or_gcs(output_string, output_filename)
+    gcsfs.write_to_disk_or_gcs(output_string, output_filename)
     print('Succeeded writing metrics to file: {}'.format(output_filename))
   except Exception as e:
     print('Failed writing metrics to file: {}'.format(e))

--- a/torch_xla/test/metrics_test_wrapper.py
+++ b/torch_xla/test/metrics_test_wrapper.py
@@ -55,6 +55,7 @@ import tempfile
 
 import torch_xla.debug.metrics_compare_utils as mcu
 import torch_xla.utils.gcsfs as gcsfs
+import torch_xla.utils.utils as xu
 
 try:
   import google.api_core.exceptions
@@ -72,7 +73,6 @@ Also follow the instructions in the link below to configure authentication:
   raise
 
 
-_CLOUD_STORAGE_PREFIX = 'gs://'
 _METRICS_HISTORY_DIR_NAME = 'metrics_history'
 _XLA_METRICS_FILE = 'XLA_METRICS_FILE'
 _METRICS_FILE_PATTERN = r'.*\d{4}_\d{2}_\d{2}'
@@ -117,15 +117,11 @@ def _run_subprocess(cmd):
   return metrics, sp_return_code
 
 
-def _write_to_disk(output_string, output_filename):
+def _write_to_disk_or_gcs(output_string, output_filename):
   if not output_filename:
     return
   try:
-    if output_filename.find(_CLOUD_STORAGE_PREFIX) == 0:
-      gcsfs.write(output_filename, output_string)
-    else:
-      with open(output_filename, 'w') as outfile:
-        outfile.write(output_string)
+    xu.write_to_disk_or_gcs(output_string, output_filename)
     print('Succeeded writing metrics to file: {}'.format(output_filename))
   except Exception as e:
     print('Failed writing metrics to file: {}'.format(e))
@@ -213,7 +209,7 @@ if __name__ == '__main__':
     output_string = '{}\n\n{}'.format(FLAGS, metrics)
     output_filename = os.path.join(
         metrics_storage_dir, datetime.datetime.utcnow().strftime('%Y_%m_%d'))
-    _write_to_disk(output_string, output_filename)
+    _write_to_disk_or_gcs(output_string, output_filename)
 
   if regression_report:
     raise AssertionError(

--- a/torch_xla/utils/checkpoint_tagger.py
+++ b/torch_xla/utils/checkpoint_tagger.py
@@ -1,14 +1,14 @@
 from __future__ import division
 from __future__ import print_function
 
-from collections import defaultdict
+import collections
 import json
 
 class CheckpointTagger(object):
 
   def __init__(self, remover=None):
     self._tags = dict()
-    self._refcount = defaultdict(int)
+    self._refcount = collections.defaultdict(int)
     remover = (lambda x: None) if remover is None else remover
     assert callable(remover)
     self._remover = remover
@@ -23,19 +23,16 @@ class CheckpointTagger(object):
         self._remover(old_path)
     self._tags[name] = path
 
-  def dump(self):
+  def get_tag(self, tag):
+    return self._tags.get(tag)
+
+  def save_to_json(self):
     return json.dumps(self._tags)
 
   @classmethod
-  def load(cls, dat, remover=None):
+  def load_from_json(cls, str_json, remover=None):
     instance = cls(remover=remover)
-    if isinstance(dat, bytes):
-      dat = dat.decode()
-    if isinstance(dat, str):
-      try:
-        dat = json.loads(dat)
-      except json.decoder.JSONDecodeError as e:
-        raise type(e)(e.message + '\n\twas a filename passed?')
+    dat = json.loads(str_json)
     for name, path in dat.items():
       instance.tag(name, path)
     return instance

--- a/torch_xla/utils/checkpoint_tagger.py
+++ b/torch_xla/utils/checkpoint_tagger.py
@@ -1,0 +1,41 @@
+from __future__ import division
+from __future__ import print_function
+
+from collections import defaultdict
+import json
+
+class CheckpointTagger(object):
+
+  def __init__(self, remover=None):
+    self._tags = dict()
+    self._refcount = defaultdict(int)
+    remover = (lambda x: None) if remover is None else remover
+    assert callable(remover)
+    self._remover = remover
+
+  def tag(self, name, path):
+    self._refcount[path] += 1
+    old_path = self._tags.get(name)
+    if old_path is not None:
+      self._refcount[old_path] -= 1
+      if self._refcount[old_path] == 0:
+        self._refcount.pop(old_path)
+        self._remover(old_path)
+    self._tags[name] = path
+
+  def dump(self):
+    return json.dumps(self._tags)
+
+  @classmethod
+  def load(cls, dat, remover=None):
+    instance = cls(remover=remover)
+    if isinstance(dat, bytes):
+      dat = dat.decode()
+    if isinstance(dat, str):
+      try:
+        dat = json.loads(dat)
+      except json.decoder.JSONDecodeError as e:
+        raise type(e)(e.message + '\n\twas a filename passed?')
+    for name, path in dat.items():
+      instance.tag(name, path)
+    return instance

--- a/torch_xla/utils/checkpoint_tagger.py
+++ b/torch_xla/utils/checkpoint_tagger.py
@@ -23,8 +23,9 @@ class CheckpointTagger(object):
         self._remover(old_path)
     self._tags[name] = path
 
-  def get_tag(self, tag):
-    return self._tags.get(tag)
+  @property
+  def tags(self):
+    return self._tags
 
   def save_to_json(self):
     return json.dumps(self._tags)

--- a/torch_xla/utils/gcsfs.py
+++ b/torch_xla/utils/gcsfs.py
@@ -10,6 +10,7 @@ import sys
 import torch_xla
 
 GcsBlob = collections.namedtuple('GcsBlob', 'path size mtime isdir')
+CLOUD_STORAGE_PREFIX = 'gs://'
 
 
 def _mkblob(path, fstat):

--- a/torch_xla/utils/gcsfs.py
+++ b/torch_xla/utils/gcsfs.py
@@ -215,3 +215,20 @@ def write(path, content):
   gcs_file = torch_xla._XLAC._xla_tffile_create(path)
   torch_xla._XLAC._xla_tffile_write(gcs_file, content)
   torch_xla._XLAC._xla_tffile_flush(gcs_file)
+
+
+def write_to_disk_or_gcs(output_string, output_path):
+  if not output_path:
+    return
+  if output_path.startswith(CLOUD_STORAGE_PREFIX):
+    write(output_path, output_string)
+  else:
+    with open(output_path, 'w') as outfile:
+      outfile.write(output_string)
+
+
+def read_from_disk_or_gcs(path):
+  if path.startswith(CLOUD_STORAGE_PREFIX):
+    return read(path)
+  with open(path, 'r') as f:
+    return f.read()

--- a/torch_xla/utils/gcsfs.py
+++ b/torch_xla/utils/gcsfs.py
@@ -230,8 +230,8 @@ def generic_write(output_string, output_path):
   if output_path.startswith(CLOUD_STORAGE_PREFIX):
     write(output_path, output_string)
   else:
-    with open(output_path, 'w') as outfile:
-      outfile.write(output_string)
+    with open(output_path, 'w') as fd:
+      fd.write(output_string)
 
 
 def generic_read(path):
@@ -246,5 +246,5 @@ def generic_read(path):
   """
   if path.startswith(CLOUD_STORAGE_PREFIX):
     return read(path)
-  with open(path, 'r') as f:
-    return f.read()
+  with open(path, 'r') as fd:
+    return fd.read()

--- a/torch_xla/utils/utils.py
+++ b/torch_xla/utils/utils.py
@@ -8,42 +8,6 @@ import shutil
 import sys
 import tempfile
 import time
-import json
-from collections import defaultdict
-
-import torch_xla.utils.gcsfs as gcsfs
-
-
-class CheckpointTagger(object):
-
-  def __init__(self, tags=None, refcount=None, remover=None):
-    self.tags = dict() if tags is None else tags
-    self._refcount = defaultdict(int) if refcount is None else refcount
-    self.set_remover(remover)
-
-  def tag(self, name, path):
-    self._refcount[path] += 1
-    old_path = self.tags.get(name)
-    if old_path is not None:
-      self._refcount[old_path] -= 1
-      if self._refcount[old_path] == 0:
-        self._refcount.pop(old_path)
-        self._remover(old_path)
-    self.tags[name] = path
-
-  def set_remover(self, remover):
-    remover = (lambda x: None) if remover is None else remover
-    assert callable(remover)
-    self._remover = remover
-
-  def save(self, filename):
-    dat = json.dumps({'tags': self.tags, 'refcount': self._refcount})
-    write_to_disk_or_gcs(dat, filename)
-
-  @classmethod
-  def load(cls, path):
-    dat = json.loads(read_from_disk_or_gcs(path))
-    return cls(tags=dat['tags'], refcount=dat['refcount'])
 
 
 class Cleaner(object):
@@ -254,23 +218,6 @@ def timed(fn, msg='', printfn=eprint):
   result = fn()
   printfn('{}{:.3f}ms'.format(msg, 1000.0 * (time.time() - s)))
   return result
-
-
-def write_to_disk_or_gcs(output_string, output_path):
-  if not output_path:
-    return
-  if output_path.startswith(gcsfs.CLOUD_STORAGE_PREFIX):
-    gcsfs.write(output_path, output_string)
-  else:
-    with open(output_path, 'w') as outfile:
-      outfile.write(output_string)
-
-
-def read_from_disk_or_gcs(path):
-  if path.startswith(gcsfs.CLOUD_STORAGE_PREFIX):
-    return gcsfs.read(path)
-  with open(path, 'r') as f:
-    return f.read()
 
 
 def parallel_work(num_workers, fn, *args):


### PR DESCRIPTION
* Add a checkpoint tagger utility class to keep track of checkpoints
  * Can remove old/obsolete checkpoints
  * Can be saved/loaded so enables easy restarts of training jobs
  * Can interact with local disk and gcs

* Added utility functions to read/write from disk or gcs.
  * Made the metrics_wrapper use those functions