### PR TITLE
Reset heartbeat timer on rendezvous call

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -521,4 +521,7 @@ def rendezvous(tag, payload=b''):
     tag (string): The name of the rendezvous to join.
     payload (bytes, optional): The payload to be sent to the rendezvous.
   """
-  return torch_xla._XLAC._xla_rendezvous(get_ordinal(), tag, payload)
+  res = torch_xla._XLAC._xla_rendezvous(get_ordinal(), tag, payload)
+  if xu.getenv_as('XLA_EMIT_STEPLOG', bool, False) and is_master_ordinal(local=False):
+    print('torch_xla.core.xla_model::rendezvous', file=sys.stderr, flush=True)
+  return res


### PR DESCRIPTION
Takes care of case where:

```
t_0 = 0 last mark_step in epoch 1
t_1=t_0+1 start checkpointing (after epoch 1)
t_2=t_1 rendezvous call blocking on others
t_3=t_2+uneven_heartbeat_timeout checkpointing done + rendezvous returns
t_4=t_3+1 mark_step only by worker 0 (w_0)
t_5=t_4+1 check heartbeat process starts -> errors with unhealthy
  since for all w_i, s.t. i!=0, w_i.last_heartbeat = t_0 and
  t_4 - t_0 = uneven_heartbeat_timeout + 2 >  uneven_heartbeat_timeout
```

So at `t_3` we reset `w_i.last_heartbeat = now` for all `i`.

This should fix https://github.com/pytorch/xla/issues/1690