### PR TITLE
Fix copy_ from XLA to CPU.

### DIFF
--- a/test/torch_test_meta.py
+++ b/test/torch_test_meta.py
@@ -11,7 +11,6 @@ disabled_torch_tests = {
     'test_solve_methods_arg_device',  # doesn't raise
     'test_min_max_nan',  # XLA min/max ignores Nans.
     'test_min_max_binary_op_nan',  # XLA min/max ignores Nans.
-    'test_copy_noncontig',
     'test_copy_broadcast',
     'test_digamma',  # Precision issue at the first assert, then NAN handling (both on TPU)
 


### PR DESCRIPTION
Resubmit of reverted https://github.com/pytorch/xla/pull/1656. 
It passed TPU tests for me. Marking as "DO NOT MERGE" for now until we double check. 