### PR TITLE
Add type promotion check for the binary inplace operations

### DIFF
--- a/test/torch_test_meta.py
+++ b/test/torch_test_meta.py
@@ -207,7 +207,7 @@ disabled_torch_tests = {
     # test_type_promotion.py
     # TestTypePromotion
     'test_many_promotions', # stride
-    'test_inplace', # FIXME! XLA allows adding int and double inplace
+    'test_inplace', # expecting a different runtime error
     'test_indexing', # FIXME! XLA allows int to double type promotion
     'test_alternate_result', # expecting a different runtime error
     'test_half',  # half support

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -93,6 +93,28 @@ at::Tensor DoBinaryOp(const at::Tensor& self, const at::Tensor& other,
   return bridge::AtenFromXlaTensor(result);
 }
 
+template <typename B>
+at::Tensor DoBinaryOp(const at::Tensor& self, const at::Scalar& other,
+                      const B& bin_op) {
+  at::ScalarType dtype = at::result_type(self, other);
+  XLATensor self_tensor = bridge::GetXlaTensor(self);
+  XLATensor result = bin_op(self_tensor, other);
+  result.SetScalarType(dtype);
+  return bridge::AtenFromXlaTensor(result);
+}
+
+void CheckBinaryOpTypePromotion(const at::Tensor& out, const at::Tensor& self,
+                                const at::Tensor& other) {
+  at::ScalarType resultType = at::result_type(self, other);
+  XLA_CHECK(at::canCast(/*from=*/resultType, /*to=*/out.scalar_type()));
+}
+
+void CheckBinaryOpTypePromotion(const at::Tensor& out, const at::Tensor& self,
+                                const at::Scalar& other) {
+  at::ScalarType resultType = at::result_type(self, other);
+  XLA_CHECK(at::canCast(/*from=*/resultType, /*to=*/out.scalar_type()));
+}
+
 void AtenInitialize() {
   TF_VLOG(1) << "PyTorch GIT revision: " << TORCH_GITREV;
   TF_VLOG(1) << "XLA GIT revision: " << XLA_GITREV;
@@ -113,6 +135,7 @@ at::Tensor& AtenXlaType::__ilshift__(at::Tensor& self, at::Scalar other) {
 at::Tensor& AtenXlaType::__ilshift__(at::Tensor& self,
                                      const at::Tensor& other) {
   XLA_FN_COUNTER("xla::");
+  CheckBinaryOpTypePromotion(self, self, other);
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::__ilshift__(self_tensor, bridge::GetXlaTensor(other));
   return self;
@@ -120,6 +143,7 @@ at::Tensor& AtenXlaType::__ilshift__(at::Tensor& self,
 
 at::Tensor& AtenXlaType::__irshift__(at::Tensor& self, at::Scalar other) {
   XLA_FN_COUNTER("xla::");
+  CheckBinaryOpTypePromotion(self, self, other);
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::__irshift__(self_tensor, other);
   return self;
@@ -128,6 +152,7 @@ at::Tensor& AtenXlaType::__irshift__(at::Tensor& self, at::Scalar other) {
 at::Tensor& AtenXlaType::__irshift__(at::Tensor& self,
                                      const at::Tensor& other) {
   XLA_FN_COUNTER("xla::");
+  CheckBinaryOpTypePromotion(self, self, other);
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::__irshift__(self_tensor, bridge::GetXlaTensor(other));
   return self;
@@ -135,28 +160,36 @@ at::Tensor& AtenXlaType::__irshift__(at::Tensor& self,
 
 at::Tensor AtenXlaType::__lshift__(const at::Tensor& self, at::Scalar other) {
   XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(
-      XLATensor::__lshift__(bridge::GetXlaTensor(self), other));
+  return DoBinaryOp(self, other,
+                    [&](const XLATensor& xself, const at::Scalar& other) {
+                      return XLATensor::__lshift__(xself, other);
+                    });
 }
 
 at::Tensor AtenXlaType::__lshift__(const at::Tensor& self,
                                    const at::Tensor& other) {
   XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(XLATensor::__lshift__(
-      bridge::GetXlaTensor(self), bridge::GetXlaTensor(other)));
+  return DoBinaryOp(self, other,
+                    [&](const XLATensor& xself, const XLATensor& xother) {
+                      return XLATensor::__lshift__(xself, xother);
+                    });
 }
 
 at::Tensor AtenXlaType::__rshift__(const at::Tensor& self, at::Scalar other) {
   XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(
-      XLATensor::__rshift__(bridge::GetXlaTensor(self), other));
+  return DoBinaryOp(self, other,
+                    [&](const XLATensor& xself, const at::Scalar& other) {
+                      return XLATensor::__rshift__(xself, other);
+                    });
 }
 
 at::Tensor AtenXlaType::__rshift__(const at::Tensor& self,
                                    const at::Tensor& other) {
   XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(XLATensor::__rshift__(
-      bridge::GetXlaTensor(self), bridge::GetXlaTensor(other)));
+  return DoBinaryOp(self, other,
+                    [&](const XLATensor& xself, const XLATensor& xother) {
+                      return XLATensor::__rshift__(xself, xother);
+                    });
 }
 
 at::Tensor AtenXlaType::_adaptive_avg_pool2d(const at::Tensor& self,
@@ -285,22 +318,26 @@ at::Tensor AtenXlaType::add(const at::Tensor& self, const at::Tensor& other,
                             at::Scalar alpha) {
   XLA_FN_COUNTER("xla::");
   at::native::alpha_check(at::result_type(self, other), alpha);
-  return DoBinaryOp(self, other, [&](XLATensor& xself, XLATensor& xother) {
-    return XLATensor::add(xself, xother, alpha);
-  });
+  return DoBinaryOp(self, other,
+                    [&](const XLATensor& xself, const XLATensor& xother) {
+                      return XLATensor::add(xself, xother, alpha);
+                    });
 }
 
 at::Tensor AtenXlaType::add(const at::Tensor& self, at::Scalar other,
                             at::Scalar alpha) {
   XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(
-      XLATensor::add(bridge::GetXlaTensor(self), other, alpha));
+  return DoBinaryOp(self, other,
+                    [&](const XLATensor& xself, const at::Scalar& other) {
+                      return XLATensor::add(xself, other, alpha);
+                    });
 }
 
 at::Tensor& AtenXlaType::add_(at::Tensor& self, const at::Tensor& other,
                               at::Scalar alpha) {
   XLA_FN_COUNTER("xla::");
   at::native::alpha_check(at::result_type(self, other), alpha);
+  CheckBinaryOpTypePromotion(self, self, other);
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::add_(self_tensor,
                   bridge::GetOrCreateXlaTensor(other, self_tensor.GetDevice()),
@@ -311,6 +348,7 @@ at::Tensor& AtenXlaType::add_(at::Tensor& self, const at::Tensor& other,
 at::Tensor& AtenXlaType::add_(at::Tensor& self, at::Scalar other,
                               at::Scalar alpha) {
   XLA_FN_COUNTER("xla::");
+  CheckBinaryOpTypePromotion(self, self, other);
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::add_(self_tensor, other, alpha);
   return self;
@@ -478,12 +516,15 @@ at::Tensor AtenXlaType::atan(const at::Tensor& self) {
 
 at::Tensor AtenXlaType::atan2(const at::Tensor& self, const at::Tensor& other) {
   XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(XLATensor::atan2(
-      bridge::GetXlaTensor(self), bridge::GetXlaTensor(other)));
+  return DoBinaryOp(self, other,
+                    [&](const XLATensor& xself, const XLATensor& xother) {
+                      return XLATensor::atan2(xself, xother);
+                    });
 }
 
 at::Tensor& AtenXlaType::atan2_(at::Tensor& self, const at::Tensor& other) {
   XLA_FN_COUNTER("xla::");
+  CheckBinaryOpTypePromotion(self, self, other);
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::atan2_(self_tensor, bridge::GetXlaTensor(other));
   return self;
@@ -636,6 +677,7 @@ at::Tensor& AtenXlaType::bitwise_and_out(at::Tensor& out,
                                          const at::Tensor& self,
                                          at::Scalar other) {
   XLA_FN_COUNTER("xla::");
+  CheckBinaryOpTypePromotion(out, self, other);
   XLATensor out_tensor = bridge::GetXlaTensor(out);
   XLATensor::bitwise_and_out(out_tensor, bridge::GetXlaTensor(self), other);
   return out;
@@ -645,6 +687,7 @@ at::Tensor& AtenXlaType::bitwise_and_out(at::Tensor& out,
                                          const at::Tensor& self,
                                          const at::Tensor& other) {
   XLA_FN_COUNTER("xla::");
+  CheckBinaryOpTypePromotion(out, self, other);
   XLATensor out_tensor = bridge::GetXlaTensor(out);
   XLATensor::bitwise_and_out(out_tensor, bridge::GetXlaTensor(self),
                              bridge::GetXlaTensor(other));
@@ -663,6 +706,7 @@ at::Tensor& AtenXlaType::bitwise_not_out(at::Tensor& out,
 at::Tensor& AtenXlaType::bitwise_or_out(at::Tensor& out, const at::Tensor& self,
                                         at::Scalar other) {
   XLA_FN_COUNTER("xla::");
+  CheckBinaryOpTypePromotion(out, self, other);
   XLATensor out_tensor = bridge::GetXlaTensor(out);
   XLATensor::bitwise_or_out(out_tensor, bridge::GetXlaTensor(self), other);
   return out;
@@ -671,6 +715,7 @@ at::Tensor& AtenXlaType::bitwise_or_out(at::Tensor& out, const at::Tensor& self,
 at::Tensor& AtenXlaType::bitwise_or_out(at::Tensor& out, const at::Tensor& self,
                                         const at::Tensor& other) {
   XLA_FN_COUNTER("xla::");
+  CheckBinaryOpTypePromotion(out, self, other);
   XLATensor out_tensor = bridge::GetXlaTensor(out);
   XLATensor::bitwise_or_out(out_tensor, bridge::GetXlaTensor(self),
                             bridge::GetXlaTensor(other));
@@ -681,6 +726,7 @@ at::Tensor& AtenXlaType::bitwise_xor_out(at::Tensor& out,
                                          const at::Tensor& self,
                                          at::Scalar other) {
   XLA_FN_COUNTER("xla::");
+  CheckBinaryOpTypePromotion(out, self, other);
   XLATensor out_tensor = bridge::GetXlaTensor(out);
   XLATensor::bitwise_xor_out(out_tensor, bridge::GetXlaTensor(self), other);
   return out;
@@ -690,6 +736,7 @@ at::Tensor& AtenXlaType::bitwise_xor_out(at::Tensor& out,
                                          const at::Tensor& self,
                                          const at::Tensor& other) {
   XLA_FN_COUNTER("xla::");
+  CheckBinaryOpTypePromotion(out, self, other);
   XLATensor out_tensor = bridge::GetXlaTensor(out);
   XLATensor::bitwise_xor_out(out_tensor, bridge::GetXlaTensor(self),
                              bridge::GetXlaTensor(other));
@@ -924,19 +971,23 @@ at::Tensor AtenXlaType::diagonal(const at::Tensor& self, int64_t offset,
 
 at::Tensor AtenXlaType::div(const at::Tensor& self, const at::Tensor& other) {
   XLA_FN_COUNTER("xla::");
-  return DoBinaryOp(self, other, [&](XLATensor& xself, XLATensor& xother) {
-    return XLATensor::div(xself, xother);
-  });
+  return DoBinaryOp(self, other,
+                    [&](const XLATensor& xself, const XLATensor& xother) {
+                      return XLATensor::div(xself, xother);
+                    });
 }
 
 at::Tensor AtenXlaType::div(const at::Tensor& self, at::Scalar other) {
   XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(
-      XLATensor::div(bridge::GetXlaTensor(self), other));
+  return DoBinaryOp(self, other,
+                    [&](const XLATensor& xself, const at::Scalar& other) {
+                      return XLATensor::div(xself, other);
+                    });
 }
 
 at::Tensor& AtenXlaType::div_(at::Tensor& self, const at::Tensor& other) {
   XLA_FN_COUNTER("xla::");
+  CheckBinaryOpTypePromotion(self, self, other);
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::div_(self_tensor,
                   bridge::GetOrCreateXlaTensor(other, self_tensor.GetDevice()));
@@ -945,6 +996,7 @@ at::Tensor& AtenXlaType::div_(at::Tensor& self, const at::Tensor& other) {
 
 at::Tensor& AtenXlaType::div_(at::Tensor& self, at::Scalar other) {
   XLA_FN_COUNTER("xla::");
+  CheckBinaryOpTypePromotion(self, self, other);
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::div_(self_tensor, other);
   return self;
@@ -1191,18 +1243,23 @@ at::Tensor& AtenXlaType::floor_(at::Tensor& self) {
 
 at::Tensor AtenXlaType::fmod(const at::Tensor& self, const at::Tensor& other) {
   XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(
-      XLATensor::fmod(bridge::GetXlaTensor(self), bridge::GetXlaTensor(other)));
+  return DoBinaryOp(self, other,
+                    [&](const XLATensor& xself, const XLATensor& xother) {
+                      return XLATensor::fmod(xself, xother);
+                    });
 }
 
 at::Tensor AtenXlaType::fmod(const at::Tensor& self, at::Scalar other) {
   XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(
-      XLATensor::fmod(bridge::GetXlaTensor(self), other));
+  return DoBinaryOp(self, other,
+                    [&](const XLATensor& xself, const at::Scalar& other) {
+                      return XLATensor::fmod(xself, other);
+                    });
 }
 
 at::Tensor& AtenXlaType::fmod_(at::Tensor& self, const at::Tensor& other) {
   XLA_FN_COUNTER("xla::");
+  CheckBinaryOpTypePromotion(self, self, other);
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::fmod_(self_tensor, bridge::GetXlaTensor(other));
   return self;
@@ -1210,6 +1267,7 @@ at::Tensor& AtenXlaType::fmod_(at::Tensor& self, const at::Tensor& other) {
 
 at::Tensor& AtenXlaType::fmod_(at::Tensor& self, at::Scalar other) {
   XLA_FN_COUNTER("xla::");
+  CheckBinaryOpTypePromotion(self, self, other);
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::fmod_(self_tensor, other);
   return self;
@@ -1867,19 +1925,23 @@ at::Tensor AtenXlaType::mse_loss_backward(const at::Tensor& grad_output,
 
 at::Tensor AtenXlaType::mul(const at::Tensor& self, const at::Tensor& other) {
   XLA_FN_COUNTER("xla::");
-  return DoBinaryOp(self, other, [&](XLATensor& xself, XLATensor& xother) {
-    return XLATensor::mul(xself, xother);
-  });
+  return DoBinaryOp(self, other,
+                    [&](const XLATensor& xself, const XLATensor& xother) {
+                      return XLATensor::mul(xself, xother);
+                    });
 }
 
 at::Tensor AtenXlaType::mul(const at::Tensor& self, at::Scalar other) {
   XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(
-      XLATensor::mul(bridge::GetXlaTensor(self), other));
+  return DoBinaryOp(self, other,
+                    [&](const XLATensor& xself, const at::Scalar& other) {
+                      return XLATensor::mul(xself, other);
+                    });
 }
 
 at::Tensor& AtenXlaType::mul_(at::Tensor& self, const at::Tensor& other) {
   XLA_FN_COUNTER("xla::");
+  CheckBinaryOpTypePromotion(self, self, other);
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::mul_(self_tensor,
                   bridge::GetOrCreateXlaTensor(other, self_tensor.GetDevice()));
@@ -1888,6 +1950,7 @@ at::Tensor& AtenXlaType::mul_(at::Tensor& self, const at::Tensor& other) {
 
 at::Tensor& AtenXlaType::mul_(at::Tensor& self, at::Scalar other) {
   XLA_FN_COUNTER("xla::");
+  CheckBinaryOpTypePromotion(self, self, other);
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::mul_(self_tensor, other);
   return self;
@@ -2422,9 +2485,10 @@ at::Tensor AtenXlaType::rsub(const at::Tensor& self, const at::Tensor& other,
                              at::Scalar alpha) {
   XLA_FN_COUNTER("xla::");
   CheckSubOperandTypes(self.scalar_type(), other.scalar_type());
-  return DoBinaryOp(self, other, [&](XLATensor& xself, XLATensor& xother) {
-    return XLATensor::rsub(xself, xother, alpha);
-  });
+  return DoBinaryOp(self, other,
+                    [&](const XLATensor& xself, const XLATensor& xother) {
+                      return XLATensor::rsub(xself, xother, alpha);
+                    });
 }
 
 at::Tensor AtenXlaType::rsub(const at::Tensor& self, at::Scalar other,
@@ -2674,22 +2738,26 @@ at::Tensor AtenXlaType::sub(const at::Tensor& self, const at::Tensor& other,
   XLA_FN_COUNTER("xla::");
   CheckSubOperandTypes(self.scalar_type(), other.scalar_type());
   at::native::alpha_check(at::result_type(self, other), alpha);
-  return DoBinaryOp(self, other, [&](XLATensor& xself, XLATensor& xother) {
-    return XLATensor::sub(xself, xother, alpha);
-  });
+  return DoBinaryOp(self, other,
+                    [&](const XLATensor& xself, const XLATensor& xother) {
+                      return XLATensor::sub(xself, xother, alpha);
+                    });
 }
 
 at::Tensor AtenXlaType::sub(const at::Tensor& self, at::Scalar other,
                             at::Scalar alpha) {
   XLA_FN_COUNTER("xla::");
   CheckSubOperandTypes(self.scalar_type(), GetScalarType(other));
-  return bridge::AtenFromXlaTensor(
-      XLATensor::sub(bridge::GetXlaTensor(self), other, alpha));
+  return DoBinaryOp(self, other,
+                    [&](const XLATensor& xself, const at::Scalar& other) {
+                      return XLATensor::sub(xself, other, alpha);
+                    });
 }
 
 at::Tensor& AtenXlaType::sub_(at::Tensor& self, const at::Tensor& other,
                               at::Scalar alpha) {
   XLA_FN_COUNTER("xla::");
+  CheckBinaryOpTypePromotion(self, self, other);
   at::native::alpha_check(at::result_type(self, other), alpha);
   CheckSubOperandTypes(self.scalar_type(), other.scalar_type());
   XLATensor self_tensor = bridge::GetXlaTensor(self);
@@ -2702,6 +2770,7 @@ at::Tensor& AtenXlaType::sub_(at::Tensor& self, const at::Tensor& other,
 at::Tensor& AtenXlaType::sub_(at::Tensor& self, at::Scalar other,
                               at::Scalar alpha) {
   XLA_FN_COUNTER("xla::");
+  CheckBinaryOpTypePromotion(self, self, other);
   CheckSubOperandTypes(self.scalar_type(), GetScalarType(other));
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::sub_(self_tensor, other, alpha);


### PR DESCRIPTION
Previous conversion in https://github.com/pytorch/xla/pull/1724.

@dlibenzi Should we have a scalar version of doBinaryOp? like
DoBinaryOp(const at::Tensor& self, const at::Scalar& other, const B& bin_op)
I am calling CheckBinaryOpTypePromotion for the scalar version of the binary operations. Although it seems like xla is doing its own type promotion there but it might be better if we follow the same type promotion logic (by calling at::result_type) for these scalar binary ops as well.