### PR TITLE
Promote to kLong if prod input is integral type.

### DIFF
--- a/scripts/gen.py
+++ b/scripts/gen.py
@@ -108,6 +108,7 @@ _FN_OUT = {
     'log_out': FuncOpts(),
     'masked_select_out': FuncOpts(),
     'pow_out': FuncOpts(),
+    'prod_out': FuncOpts(),
     'nonzero_out': FuncOpts(),
     'normal_out': FuncOpts(),
     'take_out': FuncOpts(),

--- a/test/torch_test_meta.py
+++ b/test/torch_test_meta.py
@@ -16,8 +16,6 @@ disabled_torch_tests = {
     'test_digamma',  # Precision issue at the first assert, then NAN handling (both on TPU)
 
     # TestTensorDeviceOps
-    'test_prod_neg_dim_xla',
-    'test_prod_dim_xla',
     'test_cumprod_xla',
     'test_cumprod_neg_dim_xla',
     'test_mean_64bit_indexing_xla',  # protobuf limit exceeded


### PR DESCRIPTION
PyTorch promotes some outputs to kLong when input is integral type for some ops. prod is one of them. Will add more in followup PRs. 