### PR TITLE
Disable test for indexing with uint8 tensor.

### DIFF
--- a/test/torch_test_meta.py
+++ b/test/torch_test_meta.py
@@ -168,6 +168,7 @@ disabled_torch_tests = {
     'test_byte_mask_accumulate', # expecting a different runtime error
     'test_bool_indices', # expecting a different runtime error
     'test_index_getitem_copy_bools_slices',  # storage
+    'test_index_put_byte_indices',  # FIXME: Indexing with uint8 tensor is no longer allowed.
     'test_getitem_scalars',  # storage
     'test_empty_ndim_index',  # expecting a different runtime error
 


### PR DESCRIPTION
This behavior was deprecated and will be removed in https://github.com/pytorch/pytorch/pull/34418. We should fix this later. 