### PR TITLE
Disable test_true_divide since it is trying to cast from/to float64, whi…

### DIFF
--- a/test/torch_test_meta.py
+++ b/test/torch_test_meta.py
@@ -212,4 +212,5 @@ disabled_torch_tests = {
     'test_indexing', # FIXME! XLA allows int to double type promotion
     'test_alternate_result', # expecting a different runtime error
     'test_half',  # half support
+    'test_true_divide', # float64 casting
 }


### PR DESCRIPTION
…ch is not fully supported on TPU.

Verified that rest of the test in type_promotion is passing.