### PR TITLE
Fix type casting issues.

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2991,16 +2991,14 @@ at::Tensor AtenXlaType::true_divide(const at::Tensor& self,
                                     const at::Tensor& other) {
   XLA_FN_COUNTER("xla::");
   std::pair<XLATensor, XLATensor> operands = GetBinaryOperands(self, other);
-  XLATensor result = XLATensor::true_divide(operands.first, operands.second);
-  result.SetScalarType(at::typeMetaToScalarType(c10::get_default_dtype()));
-  return bridge::AtenFromXlaTensor(result);
+  return bridge::AtenFromXlaTensor(
+      XLATensor::true_divide(operands.first, operands.second));
 }
 
 at::Tensor AtenXlaType::true_divide(const at::Tensor& self, at::Scalar other) {
   XLA_FN_COUNTER("xla::");
-  XLATensor result = XLATensor::true_divide(bridge::GetXlaTensor(self), other);
-  result.SetScalarType(at::typeMetaToScalarType(c10::get_default_dtype()));
-  return bridge::AtenFromXlaTensor(result);
+  return bridge::AtenFromXlaTensor(
+      XLATensor::true_divide(bridge::GetXlaTensor(self), other));
 }
 
 at::Tensor AtenXlaType::trunc(const at::Tensor& self) {

--- a/torch_xla/csrc/convert_ops.h
+++ b/torch_xla/csrc/convert_ops.h
@@ -13,8 +13,8 @@ xla::XlaOp ConvertTo(xla::XlaOp op, xla::PrimitiveType from,
                      xla::PrimitiveType to, const Device* device);
 
 xla::XlaOp ConvertToRaw(xla::XlaOp op, xla::PrimitiveType from,
-                        xla::PrimitiveType to, xla::PrimitiveType raw_to,
-                        const Device* device);
+                        xla::PrimitiveType raw_from, xla::PrimitiveType to,
+                        xla::PrimitiveType raw_to, const Device* device);
 
 xla::XlaOp ConvertToNumeric(xla::XlaOp op, xla::PrimitiveType from);
 

--- a/torch_xla/csrc/ops/cast.cpp
+++ b/torch_xla/csrc/ops/cast.cpp
@@ -9,6 +9,7 @@
 #include "torch_xla/csrc/ops/xla_ops.h"
 #include "torch_xla/csrc/reduction.h"
 #include "torch_xla/csrc/tensor_util.h"
+#include "torch_xla/csrc/torch_util.h"
 
 namespace torch_xla {
 namespace ir {
@@ -28,26 +29,31 @@ Cast::Cast(const Value& input, xla::PrimitiveType type)
            /*num_outputs=*/1, xla::util::MHash(static_cast<int>(type))),
       type_(type) {}
 
-Cast::Cast(const Value& input, at::ScalarType dtype)
+Cast::Cast(const Value& input, at::ScalarType dtype,
+           c10::optional<at::ScalarType> stype)
     : Node(xla_cast, {input},
            NodeOutputShape(input,
                            MakeXlaPrimitiveType(dtype, /*device=*/nullptr)),
-           /*num_outputs=*/1, xla::util::MHash(101, static_cast<int>(dtype))),
+           /*num_outputs=*/1,
+           xla::util::MHash(101, static_cast<int>(dtype),
+                            OptionalOr<int>(stype, -1))),
       type_(MakeXlaPrimitiveType(dtype, /*device=*/nullptr)),
-      dtype_(dtype) {}
+      dtype_(dtype),
+      stype_(stype) {}
 
 NodePtr Cast::Clone(OpList operands) const {
-  return dtype_ ? MakeNode<Cast>(operands.at(0), *dtype_)
+  return dtype_ ? MakeNode<Cast>(operands.at(0), *dtype_, stype_)
                 : MakeNode<Cast>(operands.at(0), type_);
 }
 
 XlaOpVector Cast::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
-  xla::PrimitiveType raw_type =
-      dtype_ ? TensorTypeToRawXlaType(*dtype_) : type_;
+  xla::PrimitiveType raw_from =
+      stype_ ? TensorTypeToRawXlaType(*stype_) : input_shape.element_type();
+  xla::PrimitiveType raw_to = dtype_ ? TensorTypeToRawXlaType(*dtype_) : type_;
   xla::XlaOp output =
-      ConvertToRaw(input, input_shape.element_type(), type_, raw_type,
+      ConvertToRaw(input, input_shape.element_type(), raw_from, type_, raw_to,
                    /*device=*/nullptr);
   return ReturnOp(output, loctx);
 }
@@ -58,6 +64,9 @@ std::string Cast::ToString() const {
      << ", type=" << xla::primitive_util::LowercasePrimitiveTypeName(type_);
   if (dtype_) {
     ss << ", dtype=" << *dtype_;
+  }
+  if (stype_) {
+    ss << ", stype=" << *stype_;
   }
   return ss.str();
 }

--- a/torch_xla/csrc/ops/cast.h
+++ b/torch_xla/csrc/ops/cast.h
@@ -12,7 +12,8 @@ namespace ops {
 class Cast : public Node {
  public:
   Cast(const Value& input, xla::PrimitiveType type);
-  Cast(const Value& input, at::ScalarType dtype);
+  Cast(const Value& input, at::ScalarType dtype,
+       c10::optional<at::ScalarType> stype = c10::nullopt);
 
   std::string ToString() const override;
 
@@ -24,9 +25,12 @@ class Cast : public Node {
 
   const c10::optional<at::ScalarType>& dtype() const { return dtype_; };
 
+  const c10::optional<at::ScalarType>& stype() const { return stype_; };
+
  private:
   xla::PrimitiveType type_;
   c10::optional<at::ScalarType> dtype_;
+  c10::optional<at::ScalarType> stype_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -59,6 +59,7 @@ class XLATensor {
   void UpdateFromTensorOut(const XLATensor& tensor);
 
   at::ScalarType dtype() const;
+  c10::optional<at::ScalarType> dtype_optional() const;
 
   // Set logical_element_type which is visible to upstream PyTorch.
   void SetScalarType(c10::optional<at::ScalarType> logical_element_type);
@@ -1142,6 +1143,10 @@ class XLATensor {
   XLATensor CreateViewTensor(ViewInfo view_info) const;
 
   XLATensor CopyTensorToDevice(const Device& device);
+
+  ir::Value MaybeCastIrValue(
+      ir::Value ir_value, const Device& device,
+      c10::optional<at::ScalarType> logical_element_type) const;
 
   // Create a new XLA tensor with the same metadata of the input tensor (with
   // possible overrides), and the new IR value.

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -766,6 +766,18 @@ xla::PrimitiveType MakeXlaPrimitiveType(at::ScalarType scalar_type,
   }
 }
 
+bool RequiresRawTypeCasting(at::ScalarType scalar_type, const Device* device) {
+  switch (scalar_type) {
+    case at::ScalarType::Byte:
+    case at::ScalarType::Char:
+    case at::ScalarType::Short:
+      return MakeXlaPrimitiveType(scalar_type, device) !=
+             TensorTypeToRawXlaType(scalar_type);
+    default:
+      return false;
+  }
+}
+
 xla::PrimitiveType GetShapeDimensionType(const Device* device) {
   Device xla_device = GetDeviceOrCurrent(device);
   return xla_device.hw_type == DeviceType::CPU ? xla::PrimitiveType::S64

--- a/torch_xla/csrc/tensor_util.h
+++ b/torch_xla/csrc/tensor_util.h
@@ -67,6 +67,8 @@ xla::PrimitiveType GetDevicePrimitiveType(xla::PrimitiveType type,
 xla::PrimitiveType MakeXlaPrimitiveType(at::ScalarType scalar_type,
                                         const Device* device);
 
+bool RequiresRawTypeCasting(at::ScalarType scalar_type, const Device* device);
+
 xla::PrimitiveType GetShapeDimensionType(const Device* device);
 
 }  // namespace torch_xla


### PR DESCRIPTION
Today on TPU we map 8 and 16 bit types to 32 bit, but we do not clamp the result of operations.
So if `a == 255` and `b == 1` are `Byte`, hence mapped to U32, `c = a + b` is 256 (0x100).
When we move data out the result is fine as we automatically cast the incoming U32 values to `uint8`, but if for example we are comparing `c` with `Int` 0, the cast that we do on `c` to S32 will turn `c` to 256 (a noop essentially), and compare that to 0.

It is possible that XLA might add 8 bit and 16 bit support for TPU, but for now we need casts for correctness.
