### PR TITLE
Enable true divide python test

### DIFF
--- a/test/torch_test_meta.py
+++ b/test/torch_test_meta.py
@@ -219,8 +219,6 @@ disabled_torch_tests = {
     'test_indexing', # FIXME! XLA allows int to double type promotion
     'test_alternate_result', # expecting a different runtime error
     'test_half',  # half support
-    'test_true_divide', # float64 casting
-    'test_true_divide_out',  # FIXME: wrong result
     'test_complex_promotion',  # complex support
     'test_complex_scalar_mult_tensor_promotion',  # complex support
 }


### PR DESCRIPTION
`test_true_divide_out` now only runs on cpu and cuda. I verified that all variants of `test_true_divide` are passing on TPU after https://github.com/pytorch/xla/pull/1787 and https://github.com/pytorch/xla/pull/1796