### PR TITLE
Index_put should not promote the rhs

### DIFF
--- a/test/torch_test_meta.py
+++ b/test/torch_test_meta.py
@@ -175,7 +175,6 @@ disabled_torch_tests = {
     'test_byte_mask_accumulate', # expecting a different runtime error
     'test_bool_indices', # expecting a different runtime error
     'test_index_getitem_copy_bools_slices',  # storage
-    'test_index_put_byte_indices',  # FIXME: Indexing with uint8 tensor is no longer allowed.
     'test_getitem_scalars',  # storage
     'test_empty_ndim_index',  # expecting a different runtime error
 
@@ -216,7 +215,7 @@ disabled_torch_tests = {
     # TestTypePromotion
     'test_many_promotions', # stride
     'test_inplace', # expecting a different runtime error
-    'test_indexing', # FIXME! XLA allows int to double type promotion
+    'test_indexing', # expecting a different runtime error
     'test_alternate_result', # expecting a different runtime error
     'test_half',  # half support
     'test_true_divide', # float64 casting

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1473,6 +1473,7 @@ at::Tensor& AtenXlaType::index_fill_(at::Tensor& self, int64_t dim,
 at::Tensor& AtenXlaType::index_put_(at::Tensor& self, at::TensorList indices,
                                     const at::Tensor& values, bool accumulate) {
   XLA_FN_COUNTER("xla::");
+  XLA_CHECK(self.scalar_type() == values.scalar_type());
   CanonicalIndexInfo canonical_index_info =
       GetCanonicalIndexInfo(self, indices);
   XLATensor self_tensor = bridge::GetXlaTensor(self);


### PR DESCRIPTION
In `test_indexing` they have
```
       a = torch.ones(5, 2, dtype=torch.double, device=device)                                                                                                                                                                                                              
        b = torch.zeros(5, dtype=torch.int, device=device)                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                              
        # lambda cannot contain assignment                                                                                                                                                                                                                                    
        def f():                                                                                                                                                                                                                                                              
            a[:, [1]] = b.unsqueeze(-1)                                                                                                                                                                                                                                     
        # https://github.com/pytorch/pytorch/issues/28010                                                                                                                                                                                                                     
        self.assertRaisesRegex(RuntimeError, 'expected dtype',                                                                                                                                                                                                                
                               lambda: f())         
```

pytorch's index_put type promotion check is done through `TensorIterator`. It is being set in https://github.com/pytorch/pytorch/blob/027d7f7ba55ce2617aace11330c5345b0d58b2f0/aten/src/ATen/native/TensorAdvancedIndexing.cpp#L217 and check in https://github.com/pytorch/pytorch/blob/027d7f7ba55ce2617aace11330c5345b0d58b2f0/aten/src/ATen/native/TensorIterator.cpp#L132. XLA can not directly call its check so we will still have a different runtime error than the test expcted. 

`test_index_put_byte_indices` has been removed so I remove it from our skip test list.