### PR TITLE
Revise the look of test_train* scripts' stdout.

### DIFF
--- a/test/test_train_mp_imagenet.py
+++ b/test/test_train_mp_imagenet.py
@@ -97,8 +97,8 @@ def get_model_property(key):
 
 
 def _train_update(device, step, loss, tracker, epoch):
-  test_utils.print_training_update(
-      device, step, loss.item(), tracker.rate(), tracker.global_rate(), epoch)
+  test_utils.print_training_update(device, step, loss.item(), tracker.rate(),
+                                   tracker.global_rate(), epoch)
 
 
 def train_imagenet():
@@ -199,7 +199,7 @@ def train_imagenet():
         lr_scheduler.step()
       if step % FLAGS.log_steps == 0:
         xm.add_step_closure(
-            _train_update, args=(device, step , loss, tracker, epoch))
+            _train_update, args=(device, step, loss, tracker, epoch))
 
   def test_loop_fn(loader, epoch):
     total_samples, correct = 0, 0
@@ -226,9 +226,11 @@ def train_imagenet():
     accuracy = test_loop_fn(para_loader.per_device_loader(device), epoch)
     xm.master_print('Epoch {} test end {}'.format(epoch, test_utils.now()))
     max_accuracy = max(accuracy, max_accuracy)
-    test_utils.write_to_summary(writer, epoch,
-                                dict_to_write={'Accuracy/test': accuracy},
-                                write_xla_metrics=True)
+    test_utils.write_to_summary(
+        writer,
+        epoch,
+        dict_to_write={'Accuracy/test': accuracy},
+        write_xla_metrics=True)
     if FLAGS.metrics_debug:
       xm.master_print(met.metrics_report())
 

--- a/test/test_train_mp_mnist.py
+++ b/test/test_train_mp_mnist.py
@@ -146,18 +146,14 @@ def train_mnist():
   accuracy = 0.0
   max_accuracy = 0.0
   for epoch in range(1, FLAGS.num_epochs + 1):
-    xm.master_print(
-        'Epoch {} training begin {}'.format(epoch, test_utils.now()))
+    xm.master_print('Epoch {} train begin {}'.format(epoch, test_utils.now()))
     para_loader = pl.ParallelLoader(train_loader, [device])
     train_loop_fn(para_loader.per_device_loader(device))
-    xm.rendezvous('epoch-train-end')
-    xm.master_print('Epoch {} training end {}'.format(epoch, test_utils.now()))
+    xm.master_print('Epoch {} train end {}'.format(epoch, test_utils.now()))
 
     para_loader = pl.ParallelLoader(test_loader, [device])
     accuracy = test_loop_fn(para_loader.per_device_loader(device))
-    xm.rendezvous('epoch-valid-end')
-    xm.master_print(
-        'Epoch {} validation end {}'.format(epoch, test_utils.now()))
+    xm.master_print('Epoch {} test end {}'.format(epoch, test_utils.now()))
     max_accuracy = max(accuracy, max_accuracy)
     test_utils.write_to_summary(writer, epoch,
                                 dict_to_write={'Accuracy/test': accuracy},

--- a/test/test_train_mp_mnist.py
+++ b/test/test_train_mp_mnist.py
@@ -155,9 +155,11 @@ def train_mnist():
     accuracy = test_loop_fn(para_loader.per_device_loader(device))
     xm.master_print('Epoch {} test end {}'.format(epoch, test_utils.now()))
     max_accuracy = max(accuracy, max_accuracy)
-    test_utils.write_to_summary(writer, epoch,
-                                dict_to_write={'Accuracy/test': accuracy},
-                                write_xla_metrics=True)
+    test_utils.write_to_summary(
+        writer,
+        epoch,
+        dict_to_write={'Accuracy/test': accuracy},
+        write_xla_metrics=True)
     if FLAGS.metrics_debug:
       xm.master_print(met.metrics_report())
 

--- a/test/test_train_mp_mnist.py
+++ b/test/test_train_mp_mnist.py
@@ -119,15 +119,15 @@ def train_mnist():
     tracker = xm.RateTracker()
 
     model.train()
-    for x, (data, target) in enumerate(loader):
+    for step, (data, target) in enumerate(loader):
       optimizer.zero_grad()
       output = model(data)
       loss = loss_fn(output, target)
       loss.backward()
       xm.optimizer_step(optimizer)
       tracker.add(FLAGS.batch_size)
-      if x % FLAGS.log_steps == 0:
-        xm.add_step_closure(_train_update, args=(device, x, loss, tracker))
+      if step % FLAGS.log_steps == 0:
+        xm.add_step_closure(_train_update, args=(device, step, loss, tracker))
 
   def test_loop_fn(loader):
     total_samples = 0
@@ -146,12 +146,18 @@ def train_mnist():
   accuracy = 0.0
   max_accuracy = 0.0
   for epoch in range(1, FLAGS.num_epochs + 1):
+    xm.master_print(
+        'Epoch {} training begin {}'.format(epoch, test_utils.now()))
     para_loader = pl.ParallelLoader(train_loader, [device])
     train_loop_fn(para_loader.per_device_loader(device))
-    xm.master_print('Finished training epoch {}'.format(epoch))
+    xm.rendezvous('epoch-train-end')
+    xm.master_print('Epoch {} training end {}'.format(epoch, test_utils.now()))
 
     para_loader = pl.ParallelLoader(test_loader, [device])
     accuracy = test_loop_fn(para_loader.per_device_loader(device))
+    xm.rendezvous('epoch-valid-end')
+    xm.master_print(
+        'Epoch {} validation end {}'.format(epoch, test_utils.now()))
     max_accuracy = max(accuracy, max_accuracy)
     test_utils.write_to_summary(writer, epoch,
                                 dict_to_write={'Accuracy/test': accuracy},

--- a/torch_xla/test/test_utils.py
+++ b/torch_xla/test/test_utils.py
@@ -92,14 +92,12 @@ def print_training_update(device, step, loss, rate, global_rate, epoch=None):
   """
   update_data = [
       'Training', 'Device={}'.format(_get_device_spec(device)),
-      'Epoch={}'.format(epoch) if epoch else None, 'Step={}'.format(step),
-      'Loss={:.5f}'.format(loss), 'Rate={:.2f}'.format(rate),
-      'GlobalRate={:.2f}'.format(global_rate), 'Time={}'.format(now())
+      'Epoch={}'.format(epoch) if epoch is not None else None,
+      'Step={}'.format(step), 'Loss={:.5f}'.format(loss),
+      'Rate={:.2f}'.format(rate), 'GlobalRate={:.2f}'.format(global_rate),
+      'Time={}'.format(now())
   ]
-  print(
-      '|',
-      ' '.join(item for item in update_data if item is not None),
-      flush=True)
+  print('|', ' '.join(item for item in update_data if item), flush=True)
 
 
 def print_test_update(device, accuracy, epoch=None, step=None):
@@ -111,12 +109,9 @@ def print_test_update(device, accuracy, epoch=None, step=None):
   """
   update_data = [
       'Test', 'Device={}'.format(_get_device_spec(device)),
-      'Step={}'.format(step) if step else None,
-      'Epoch={}'.format(epoch) if epoch else None,
-      'Accuracy={:.2f}'.format(accuracy) if accuracy else None,
+      'Step={}'.format(step) if step is not None else None,
+      'Epoch={}'.format(epoch) if epoch is not None else None,
+      'Accuracy={:.2f}'.format(accuracy) if accuracy is not None else None,
       'Time={}'.format(now())
   ]
-  print(
-      '|',
-      ' '.join(item for item in update_data if item is not None),
-      flush=True)
+  print('|', ' '.join(item for item in update_data if item), flush=True)

--- a/torch_xla/test/test_utils.py
+++ b/torch_xla/test/test_utils.py
@@ -71,13 +71,13 @@ def get_summary_writer(logdir):
   if logdir:
     from tensorboardX import SummaryWriter
     writer = SummaryWriter(log_dir=logdir)
-    write_to_summary(writer, 0, dict_to_write={
-        'TensorboardStartTimestamp': time.time()})
+    write_to_summary(
+        writer, 0, dict_to_write={'TensorboardStartTimestamp': time.time()})
     return writer
 
 
 def now(format='%H:%M:%S'):
-    return datetime.now().strftime(format)
+  return datetime.now().strftime(format)
 
 
 def print_training_update(device, step, loss, rate, global_rate, epoch=None):
@@ -91,15 +91,15 @@ def print_training_update(device, step, loss, rate, global_rate, epoch=None):
     global_rate: Float. The average examples/sec rate since training began.
   """
   update_data = [
-      'Training',
-      'Device={}'.format(_get_device_spec(device)),
-      'Epoch={}'.format(epoch) if epoch else None,
-      'Step={}'.format(step),
-      'Loss={:.5f}'.format(loss),
-      'Rate={:.2f}'.format(rate),
-      'GlobalRate={:.2f}'.format(global_rate),
-      'Time={}'.format(now())]
-  print('|', ' '.join(item for item in update_data if item), flush=True)
+      'Training', 'Device={}'.format(_get_device_spec(device)),
+      'Epoch={}'.format(epoch) if epoch else None, 'Step={}'.format(step),
+      'Loss={:.5f}'.format(loss), 'Rate={:.2f}'.format(rate),
+      'GlobalRate={:.2f}'.format(global_rate), 'Time={}'.format(now())
+  ]
+  print(
+      '|',
+      ' '.join(item for item in update_data if item is not None),
+      flush=True)
 
 
 def print_test_update(device, accuracy, epoch=None, step=None):
@@ -110,10 +110,13 @@ def print_test_update(device, accuracy, epoch=None, step=None):
     accuracy: Float.
   """
   update_data = [
-      'Test',
-      'Device={}'.format(_get_device_spec(device)),
+      'Test', 'Device={}'.format(_get_device_spec(device)),
       'Step={}'.format(step) if step else None,
       'Epoch={}'.format(epoch) if epoch else None,
       'Accuracy={:.2f}'.format(accuracy) if accuracy else None,
-      'Time={}'.format(now())]
-  print('|', ' '.join(item for item in update_data if item), flush=True)
+      'Time={}'.format(now())
+  ]
+  print(
+      '|',
+      ' '.join(item for item in update_data if item is not None),
+      flush=True)

--- a/torch_xla/test/test_utils.py
+++ b/torch_xla/test/test_utils.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import time
+from datetime import datetime
+
 import torch_xla.core.xla_model as xm
 import torch_xla.debug.metrics as met
 import torch_xla.debug.metrics_compare_utils as mcu
@@ -74,7 +76,11 @@ def get_summary_writer(logdir):
     return writer
 
 
-def print_training_update(device, step_num, loss, rate, global_rate):
+def now(format='%H:%M:%S'):
+    return datetime.now().strftime(format)
+
+
+def print_training_update(device, step, loss, rate, global_rate, epoch=None):
   """Prints the training metrics at a given step.
 
   Args:
@@ -84,20 +90,30 @@ def print_training_update(device, step_num, loss, rate, global_rate):
     rate: Float. The examples/sec rate for the current batch.
     global_rate: Float. The average examples/sec rate since training began.
   """
-  print(
-      '[{}]({}) Loss={:.5f} Rate={:.2f} GlobalRate={:.2f} Time={}'.format(
-          _get_device_spec(device), step_num, loss, rate, global_rate,
-          time.asctime()),
-      flush=True)
+  update_data = [
+      'Training',
+      'Device={}'.format(_get_device_spec(device)),
+      'Epoch={}'.format(epoch) if epoch else None,
+      'Step={}'.format(step),
+      'Loss={:.5f}'.format(loss),
+      'Rate={:.2f}'.format(rate),
+      'GlobalRate={:.2f}'.format(global_rate),
+      'Time={}'.format(now())]
+  print('|', ' '.join(item for item in update_data if item), flush=True)
 
 
-def print_test_update(device, accuracy):
+def print_test_update(device, accuracy, epoch=None, step=None):
   """Prints single-core test metrics.
 
   Args:
     device: Instance of `torch.device`.
     accuracy: Float.
   """
-  print(
-      '[{}] Accuracy={:.2f}%'.format(_get_device_spec(device), accuracy),
-      flush=True)
+  update_data = [
+      'Test',
+      'Device={}'.format(_get_device_spec(device)),
+      'Step={}'.format(step) if step else None,
+      'Epoch={}'.format(epoch) if epoch else None,
+      'Accuracy={:.2f}'.format(accuracy) if accuracy else None,
+      'Time={}'.format(now())]
+  print('|', ' '.join(item for item in update_data if item), flush=True)


### PR DESCRIPTION
While verifying performance of resnet50, I had trouble calculating epoch
times from the logs easily. I thought if we had lines to grep that
easily gives information, it would be useful.

* Changed the training and test updates.
  * added test updates inside `test_loop_fn`, so we know where we are with the validation loop.
* Added training begin, end, validation end statements per epoch.
* Added rendezvous so prints look sort of in sync. (still some
scrambling happening, master print comes later than non-master etc.)
* Now we can grep and easily understand:
  * epoch begin/end
  * split epoch time into training/validation
  * which accuracy belongs to which epoch
  * how many steps to go during training until the end of epoch
* Below is how stdout of MP-imgnet looks:

```
[taylanbil]% cat mp-imgnet.txt
==> Preparing data..
| Training Device=xla:0/6 Epoch=1 Step=0/11 Loss=6.89059 Rate=141.80
GlobalRate=141.80 Time=00:03:00
==> Preparing data..
| Training Device=xla:0/4 Epoch=1 Step=0/11 Loss=6.89059 Rate=84.10
GlobalRate=84.09 Time=00:03:00
==> Preparing data..
Epoch 1 training begin 00:02:56
| Training Device=xla:1/0 Epoch=1 Step=0/11 Loss=6.89059 Rate=32.79
GlobalRate=32.79 Time=00:03:00
==> Preparing data..
| Training Device=xla:0/3 Epoch=1 Step=0/11 Loss=6.89059 Rate=180.53
GlobalRate=180.53 Time=00:03:00
==> Preparing data..
| Training Device=xla:0/7 Epoch=1 Step=0/11 Loss=6.89059 Rate=117.95
GlobalRate=117.95 Time=00:03:00
==> Preparing data..
| Training Device=xla:0/2 Epoch=1 Step=0/11 Loss=6.89059 Rate=122.05
GlobalRate=122.05 Time=00:03:00
==> Preparing data..
| Training Device=xla:0/1 Epoch=1 Step=0/11 Loss=6.89059 Rate=56.54
GlobalRate=56.54 Time=00:03:00
==> Preparing data..
| Training Device=xla:0/5 Epoch=1 Step=0/11 Loss=6.89059 Rate=80.66
GlobalRate=80.66 Time=00:03:00
| Training Device=xla:1/0 Epoch=1 Step=2/11 Loss=6.50214 Rate=243.80
GlobalRate=84.03 Time=00:03:01
| Training Device=xla:0/3 Epoch=1 Step=2/11 Loss=6.50214 Rate=302.39
GlobalRate=279.00 Time=00:03:01
| Training Device=xla:0/2 Epoch=1 Step=2/11 Loss=6.50214 Rate=279.05
GlobalRate=223.79 Time=00:03:01
| Training Device=xla:0/5 Epoch=1 Step=2/11 Loss=6.50214 Rate=265.45
GlobalRate=171.00 Time=00:03:01
| Training Device=xla:0/4 Epoch=1 Step=2/11 Loss=6.50214 Rate=263.41
GlobalRate=175.30 Time=00:03:01

.... (removed)

| Training Device=xla:0/2 Epoch=1 Step=10/11 Loss=0.00128 Rate=512.78
GlobalRate=377.78 Time=00:03:03
| Training Device=xla:0/4 Epoch=1 Step=10/11 Loss=0.00128 Rate=512.13
GlobalRate=335.02 Time=00:03:03
| Training Device=xla:0/1 Epoch=1 Step=10/11 Loss=0.00128 Rate=510.39
GlobalRate=285.26 Time=00:03:03
| Test Device=xla:0/3 Step=0/4 Epoch=1 Time=00:03:03
| Test Device=xla:0/6 Step=0/4 Epoch=1 Time=00:03:03
| Test Device=xla:0/5 Step=0/4 Epoch=1 Time=00:03:03
| Test Device=xla:0/2 Step=0/4 Epoch=1 Time=00:03:03
Epoch 1 training end 00:03:03
| Test Device=xla:1/0 Step=0/4 Epoch=1 Time=00:03:03
| Test Device=xla:0/1 Step=0/4 Epoch=1 Time=00:03:03
| Test Device=xla:0/4 Step=0/4 Epoch=1 Time=00:03:03
| Test Device=xla:0/3 Step=2/4 Epoch=1 Time=00:03:03
| Test Device=xla:0/6 Step=2/4 Epoch=1 Time=00:03:03
| Test Device=xla:0/5 Step=2/4 Epoch=1 Time=00:03:03
| Test Device=xla:1/0 Step=2/4 Epoch=1 Time=00:03:03
| Test Device=xla:0/2 Step=2/4 Epoch=1 Time=00:03:03
| Test Device=xla:0/4 Step=2/4 Epoch=1 Time=00:03:03
| Test Device=xla:0/1 Step=2/4 Epoch=1 Time=00:03:03
| Test Device=xla:0/7 Step=0/4 Epoch=1 Time=00:03:03
| Test Device=xla:0/3 Epoch=1 Accuracy=100.00 Time=00:03:03
| Test Device=xla:0/6 Epoch=1 Accuracy=100.00 Time=00:03:03
| Test Device=xla:0/5 Epoch=1 Accuracy=100.00 Time=00:03:03
| Test Device=xla:0/2 Epoch=1 Accuracy=100.00 Time=00:03:03
| Test Device=xla:1/0 Epoch=1 Accuracy=100.00 Time=00:03:03
| Test Device=xla:0/4 Epoch=1 Accuracy=100.00 Time=00:03:03
| Test Device=xla:0/1 Epoch=1 Accuracy=100.00 Time=00:03:03
| Test Device=xla:0/7 Step=2/4 Epoch=1 Time=00:03:03
| Test Device=xla:0/7 Epoch=1 Accuracy=100.00 Time=00:03:03
| Training Device=xla:0/5 Epoch=2 Step=0/11 Loss=0.00020 Rate=160.09
GlobalRate=160.09 Time=00:03:04
| Training Device=xla:0/1 Epoch=2 Step=0/11 Loss=0.00020 Rate=159.97
GlobalRate=159.96 Time=00:03:04
| Training Device=xla:0/6 Epoch=2 Step=0/11 Loss=0.00020 Rate=159.90
GlobalRate=159.90 Time=00:03:04
| Training Device=xla:0/4 Epoch=2 Step=0/11 Loss=0.00020 Rate=159.99
GlobalRate=159.99 Time=00:03:04
Epoch 1 validation end 00:03:03
Epoch 2 training begin 00:03:03
| Training Device=xla:1/0 Epoch=2 Step=0/11 Loss=0.00020 Rate=159.83
GlobalRate=159.83 Time=00:03:04
| Training Device=xla:0/2 Epoch=2 Step=0/11 Loss=0.00020 Rate=159.79
GlobalRate=159.79 Time=00:03:04
| Training Device=xla:0/3 Epoch=2 Step=0/11 Loss=0.00020 Rate=159.80
GlobalRate=159.79 Time=00:03:04
| Training Device=xla:0/7 Epoch=2 Step=0/11 Loss=0.00020 Rate=159.28
GlobalRate=159.28 Time=00:03:04
| Training Device=xla:0/5 Epoch=2 Step=2/11 Loss=0.00001 Rate=380.40
GlobalRate=298.81 Time=00:03:05
| Training Device=xla:0/3 Epoch=2 Step=2/11 Loss=0.00001 Rate=381.09
GlobalRate=298.76 Time=00:03:05
| Training Device=xla:0/7 Epoch=2 Step=2/11 Loss=0.00001 Rate=381.71
GlobalRate=298.45 Time=00:03:05

.... (removed)

| Training Device=xla:0/3 Epoch=2 Step=10/11 Loss=0.00000 Rate=514.62
GlobalRate=431.63 Time=00:03:07
| Training Device=xla:0/1 Epoch=2 Step=10/11 Loss=0.00000 Rate=513.43
GlobalRate=431.64 Time=00:03:07
| Training Device=xla:0/6 Epoch=2 Step=10/11 Loss=0.00000 Rate=510.92
GlobalRate=431.16 Time=00:03:07
| Test Device=xla:0/7 Step=0/4 Epoch=2 Time=00:03:07
| Test Device=xla:0/3 Step=0/4 Epoch=2 Time=00:03:07
| Test Device=xla:0/6 Step=0/4 Epoch=2 Time=00:03:07
| Test Device=xla:0/1 Step=0/4 Epoch=2 Time=00:03:07
| Test Device=xla:0/4 Step=0/4 Epoch=2 Time=00:03:07
| Test Device=xla:0/5 Step=0/4 Epoch=2 Time=00:03:07
| Test Device=xla:0/2 Step=0/4 Epoch=2 Time=00:03:07
Epoch 2 training end 00:03:07
| Test Device=xla:1/0 Step=0/4 Epoch=2 Time=00:03:07
| Test Device=xla:0/7 Step=2/4 Epoch=2 Time=00:03:07
| Test Device=xla:0/3 Step=2/4 Epoch=2 Time=00:03:07
| Test Device=xla:0/6 Step=2/4 Epoch=2 Time=00:03:07
| Test Device=xla:0/1 Step=2/4 Epoch=2 Time=00:03:07
| Test Device=xla:0/4 Step=2/4 Epoch=2 Time=00:03:07
| Test Device=xla:0/5 Step=2/4 Epoch=2 Time=00:03:07
| Test Device=xla:0/2 Step=2/4 Epoch=2 Time=00:03:07
| Test Device=xla:1/0 Step=2/4 Epoch=2 Time=00:03:07
| Test Device=xla:0/7 Epoch=2 Accuracy=100.00 Time=00:03:07
| Test Device=xla:0/6 Epoch=2 Accuracy=100.00 Time=00:03:07
| Test Device=xla:0/3 Epoch=2 Accuracy=100.00 Time=00:03:07
| Test Device=xla:0/4 Epoch=2 Accuracy=100.00 Time=00:03:07
| Test Device=xla:0/1 Epoch=2 Accuracy=100.00 Time=00:03:07
| Test Device=xla:0/5 Epoch=2 Accuracy=100.00 Time=00:03:07
| Test Device=xla:0/2 Epoch=2 Accuracy=100.00 Time=00:03:07
| Test Device=xla:1/0 Epoch=2 Accuracy=100.00 Time=00:03:07
Epoch 2 validation end 00:03:07
Max Accuracy: 100.00%
```

[Here](https://drive.google.com/a/google.com/file/d/1CaJrpiHvXK3s09rQbA_Uimfm5jb-CMOi/view?usp=sharing) are sample outputs from out MT/MP-mnist/imgnet and MT-cifar scripts.