### PR TITLE
Perform type promotion for normal op to prevent mix precision mul

### DIFF
--- a/test/torch_test_meta.py
+++ b/test/torch_test_meta.py
@@ -152,9 +152,8 @@ disabled_torch_tests = {
     'test_argminmax_large_axis',  # OOM, and the test is grepping "memory" in the exception message
     'test_trapz', # precision (1e-5), test use np.allClose
     'test_random_from_to_xla_int32', # precision, TPU does not have real F64
-    'test_randn_xla_float32', # FIXME: randn(out=) not working
-    'test_randn_xla_float64', # FIXME: randn(out=) not working
-    'test_normal_xla_float64', # FIXME: mixed precision
+    'test_randn_xla_float32', # xla doesn't support manual_seed, as_stride
+    'test_randn_xla_float64', # xla doesn't support manual_seed, as_stride
 
     # TestViewOps
     'test_contiguous_nonview',

--- a/torch_xla/csrc/random.cpp
+++ b/torch_xla/csrc/random.cpp
@@ -105,7 +105,7 @@ xla::XlaOp RngNormal(xla::XlaOp seed, const xla::Shape& shape, xla::XlaOp mean,
       xla::XlaOp rng = xla::NormalFloatingPointDistribution(
                            seed, initial_state, GetBitGenerator(), shape)
                            .value;
-      return mean + rng * std;
+      return XlaHelpers::PromotedAdd(mean, XlaHelpers::PromotedMul(rng, std));
     }
     case xla::PrimitiveType::C64:
     case xla::PrimitiveType::C128: {
@@ -125,7 +125,7 @@ xla::XlaOp RngNormal(xla::XlaOp seed, const xla::Shape& shape, xla::XlaOp mean,
       if (shape.element_type() == xla::PrimitiveType::C128) {
         rng = xla::ConvertElementType(rng, xla::PrimitiveType::C128);
       }
-      return mean + rng * std;
+      return XlaHelpers::PromotedAdd(mean, XlaHelpers::PromotedMul(rng, std));
     }
     default:
       XLA_ERROR() << "RngNormal not implemented for type "


### PR DESCRIPTION
Verifed test_normal_xla_float64 also passes on TPU