### PR TITLE
Allow only disable the test if it is running with the TPU device

### DIFF
--- a/test/torch_test_meta.py
+++ b/test/torch_test_meta.py
@@ -6,27 +6,16 @@ torch_test_precisions = {
     'test_pow_xla_float64': 0.0045,
 }
 
-disabled_torch_tests = {
+disabled_torch_tests_tpu = {
     # test_torch.py
     # TestDevicePrecision
-    'test_sum_cpu_device_mismatch',  # doesn't raise
-    'test_solve_methods_arg_device',  # doesn't raise
-    'test_min_max_nan',  # XLA min/max ignores Nans.
-    'test_min_max_binary_op_nan',  # XLA min/max ignores Nans.
-    'test_copy_noncontig',
-    'test_copy_broadcast',
     'test_digamma',  # Precision issue at the first assert, then NAN handling (both on TPU)
 
-    # TestTensorDeviceOps
-    'test_block_diag_scipy',  #FIXME: RuntimeError: Error while lowering: f32[1,6]{1,0} xla::unselect, dim=1, start=2, end=2, stride=0
-    'test_cumprod_xla',  # FIXME: TPU X64Rewriter doesn't support reduce-window
-    'test_cumprod_neg_dim_xla', # FIXME: TPU X64Rewriter doesn't support reduce-window
-    'test_mean_64bit_indexing_xla',  # protobuf limit exceeded
+    #TestTensorDeviceOps
     'test_pow_inplace_xla',  # (TPU) 0.0032 vs 0.001
     'test_pow_inplace_3_xla',  # (TPU) 0.0028 vs 0.001
     'test_pow_3_xla',  # (TPU) 0.0028 vs 0.001
     'test_pow_-2_xla',  # (TPU) 0.391 vs 0.001
-    'test_topk_neg_dim_sort_xla',  # (TPU) unimplemented HLO for X64
     'test_topk_dim_sort_xla',  # (TPU) unimplemented HLO for X64
     'test_topk_dim_desc_sort_xla',  # (TPU) unimplemented HLO for X64
     'test_sort_xla',  # (TPU) unimplemented HLO for X64
@@ -38,6 +27,39 @@ disabled_torch_tests = {
     'test_kthvalue_neg_dim_xla',  # (TPU) unimplemented HLO for X64
     'test_kthvalue_dim_xla',  # (TPU) unimplemented HLO for X64
     'test_eig_with_eigvec_xla_float64',  # Precision: tensor(1.1798, dtype=torch.float64) not less than or equal to 0.001
+    'test_cumprod_xla',  # FIXME: TPU X64Rewriter doesn't support reduce-window
+    'test_cumprod_neg_dim_xla', # FIXME: TPU X64Rewriter doesn't support reduce-window
+    'test_topk_neg_dim_sort_xla',  # (TPU) unimplemented HLO for X64
+
+    #TestTorchDeviceType
+    'test_cholesky_solve_batched_broadcasting',  # (TPU) 0.0039 vs 0.001
+    'test_cholesky_solve_batched_many_batches',  # (TPU) 0.36 vs 0.001
+    'test_cholesky_solve',  # (TPU) precision (1e-5)
+    'test_lu_solve_batched',  # (TPU) precision (1e-6)
+    'test_lu_solve',  # (TPU) precision (1e-7)
+    'test_solve_batched',  # (TPU) precision (1e-6)
+    'test_solve',  # (TPU) precison (1e-7)
+    'test_triangular_solve_batched',  # (TPU) precision (1e-6)
+    'test_triangular_solve_batched_many_batches',  # (TPU) 1.02 vs 0.001
+    'test_triangular_solve_batched_broadcasting',  # (TPU) 1.5 vs 0.001
+    'test_random_from_to_xla_int32', # precision, TPU does not have real F64
+
+}
+
+disabled_torch_tests = {
+    # test_torch.py
+    # TestDevicePrecision
+    'test_sum_cpu_device_mismatch',  # doesn't raise
+    'test_solve_methods_arg_device',  # doesn't raise
+    'test_min_max_nan',  # XLA min/max ignores Nans.
+    'test_min_max_binary_op_nan',  # XLA min/max ignores Nans.
+    'test_copy_noncontig',
+    'test_copy_broadcast',
+
+    # TestTensorDeviceOps
+    'test_block_diag_scipy',  #FIXME: RuntimeError: Error while lowering: f32[1,6]{1,0} xla::unselect, dim=1, start=2, end=2, stride=0
+    'test_mean_64bit_indexing_xla',  # protobuf limit exceeded
+
 
     # TestTorchDeviceType
     'test_addmm_sizes',  # FIXME: very slow compile
@@ -139,22 +161,11 @@ disabled_torch_tests = {
     'test_stft',  # librosa (?!?) missing
     'test_tensor_shape_empty',  # LLVM OOM in CI
     'test_cholesky_inverse',  # precision (1e-6)
-    'test_cholesky_solve_batched_broadcasting',  # (TPU) 0.0039 vs 0.001
-    'test_cholesky_solve_batched_many_batches',  # (TPU) 0.36 vs 0.001
-    'test_cholesky_solve_batched',  # (TPU) precision (1e-5)
-    'test_cholesky_solve',  # (TPU) precision (1e-5)
-    'test_lu_solve_batched',  # (TPU) precision (1e-6)
-    'test_lu_solve',  # (TPU) precision (1e-7)
-    'test_solve_batched',  # (TPU) precision (1e-6)
-    'test_solve',  # (TPU) precison (1e-7)
-    'test_triangular_solve_batched',  # (TPU) precision (1e-6)
-    'test_triangular_solve_batched_many_batches',  # (TPU) 1.02 vs 0.001
-    'test_triangular_solve',  # (TPU) precision (1e-7)
-    'test_triangular_solve_batched_broadcasting',  # (TPU) 1.5 vs 0.001
+    'test_cholesky_solve_batched',  # precision (2e-12)
+    'test_triangular_solve',  # precision (4e-12)
     'test_scalar_check',  # runtime error
     'test_argminmax_large_axis',  # OOM, and the test is grepping "memory" in the exception message
     'test_trapz', # precision (1e-5), test use np.allClose
-    'test_random_from_to_xla_int32', # precision, TPU does not have real F64
     'test_randn_xla_float32', # xla doesn't support manual_seed, as_stride
     'test_randn_xla_float64', # xla doesn't support manual_seed, as_stride
     'test_rand_xla_float32',  # xla doesn't support manual_seed, as_stride

--- a/torch_patches/X10-device_test.diff
+++ b/torch_patches/X10-device_test.diff
@@ -1,8 +1,8 @@
 diff --git a/torch/testing/_internal/common_device_type.py b/torch/testing/_internal/common_device_type.py
-index 01973711e7..457f0bf373 100644
+index 01973711e7..1a39556487 100644
 --- a/torch/testing/_internal/common_device_type.py
 +++ b/torch/testing/_internal/common_device_type.py
-@@ -270,10 +270,129 @@ class CUDATestBase(DeviceTypeTestBase):
+@@ -270,10 +270,142 @@ class CUDATestBase(DeviceTypeTestBase):
          cls.primary_device = 'cuda:{0}'.format(torch.cuda.current_device())
  
  
@@ -20,9 +20,11 @@ index 01973711e7..457f0bf373 100644
 +xla_meta = run_path(xla_meta_path)
 +assert xla_meta, "XLA metadata not found!"
 +disabled_torch_tests = xla_meta.get('disabled_torch_tests', None)
++disabled_torch_tests_tpu = xla_meta.get('disabled_torch_tests_tpu', None)
 +torch_test_precisions = xla_meta.get('torch_test_precisions', None)
 +DEFAULT_FLOATING_PRECISION = xla_meta.get('DEFAULT_FLOATING_PRECISION', None)
 +assert disabled_torch_tests is not None, "XLA tests not found!"
++assert disabled_torch_tests_tpu is not None, "XLA TPU tests not found!"
 +assert torch_test_precisions is not None, "XLA test precisions not found!"
 +assert DEFAULT_FLOATING_PRECISION is not None, "DEFAULT_FLOATING_PRECISION not found!"
 +
@@ -44,13 +46,24 @@ index 01973711e7..457f0bf373 100644
 +    @classmethod
 +    def instantiate_test(cls, name, test):
 +        test_name = name + "_" + cls.device_type
++        real_device = xm.xla_real_devices([str(xm.xla_device())])[0]
++        isTpuDevice = 'TPU' in real_device
 +
 +        @wraps(test)
 +        def disallowed_test(self, test=test):
 +            raise unittest.SkipTest("skipped on XLA")
 +            return test(self, cls.device_type)
 +
-+        if test_name in disabled_torch_tests or test.__name__ in disabled_torch_tests:
++        def test_in_disabled_list():
++            shouldSkip = test_name in disabled_torch_tests or test.__name__ in disabled_torch_tests
++            if not shouldSkip and isTpuDevice:
++                shouldSkip = test_name in disabled_torch_tests_tpu or test.__name__ in disabled_torch_tests_tpu
++            return shouldSkip
++
++        def test_with_dtype_in_disabled_list(dtype_test_name):
++            return dtype_test_name in disabled_torch_tests or (isTpuDevice and dtype_test_name in disabled_torch_tests_tpu)
++
++        if test_in_disabled_list():
 +            assert not hasattr(cls, test_name), "Redefinition of test {0}".format(test_name)
 +            setattr(cls, test_name, disallowed_test)
 +        else:  # Test is allowed
@@ -74,7 +87,7 @@ index 01973711e7..457f0bf373 100644
 +
 +                        assert not hasattr(cls, dtype_test_name), "Redefinition of test {0}".format(dtype_test_name)
 +                        setattr(cls, dtype_test_name, skipped_test)
-+                    elif dtype_test_name in disabled_torch_tests:
++                    elif test_with_dtype_in_disabled_list(dtype_test_name):
 +                        setattr(cls, dtype_test_name, disallowed_test)
 +                    else:
 +                        xla_dtypes.append(dtype)
@@ -132,7 +145,7 @@ index 01973711e7..457f0bf373 100644
  
  PYTORCH_CUDA_MEMCHECK = os.getenv('PYTORCH_CUDA_MEMCHECK', '0') == '1'
  
-@@ -320,7 +439,7 @@ def instantiate_device_type_tests(generic_test_class, scope, except_for=None):
+@@ -320,7 +452,7 @@ def instantiate_device_type_tests(generic_test_class, scope, except_for=None):
                  assert inspect.isfunction(test), "Couldn't extract function from '{0}'".format(name)
  
                  # Instantiates the device-specific tests


### PR DESCRIPTION
Tests with TPU and confirmed that tests are still skipped on TPU. Verified on CPU that test are being run and passed.

diff on diff can be hard to read, please refer to the below image for better color highlight.

![image](https://user-images.githubusercontent.com/59073027/77976356-a3235100-72b1-11ea-8e38-8eb7661bed57.png)
