### PR TITLE
disable test_uniform_from_to_xla_float64 on TPU

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -241,6 +241,7 @@ DISABLED_TORCH_TESTS_TPU = DISABLED_TORCH_TESTS_ANY | {
     'test_triangular_solve_batched_many_batches',  # (TPU) 1.02 vs 0.001
     'test_triangular_solve_batched_broadcasting',  # (TPU) 1.5 vs 0.001
     'test_random_from_to_xla_int32',  # precision, TPU does not have real F64
+    'test_uniform_from_to_xla_float64', # float64 limit, TPU does not have real F64
 }
 
 DISABLED_TORCH_TESTS_CPU = DISABLED_TORCH_TESTS_ANY


### PR DESCRIPTION
It is a new test added recently. Here is the minimum repo of the failure
```
import torch, torch_xla 
import torch_xla.core.xla_model as xm 

d = xm.xla_device() 
double_min = torch.finfo(torch.double).min 
torch.tensor(1.0, device=d) == double_min 
```
The rhs of the comparison has the value float64_min but since TPU does not support float64, it will try to create a Scalar with type float32. Float64_min will overflow Float32, hence the runtime error occurred. 
```
MakeXlaPrimitiveType(c10::ScalarType::Double, TPU)` -> xla::F32
```
Disable this test since it is the hardware limitation, float32 version of the test will pass.