### PR TITLE
Disable test_bucketization_xla

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -145,6 +145,7 @@ DISABLED_TORCH_TESTS_ANY = {
     'test_rand_xla_float64',  # xla doesn't support manual_seed, as_stride
     'test_normal_xla_float64',  # AssertionError: 0.22364577306378963 not less than or equal to 0.2
     'test_uniform_from_to',  # Checks for error strings.
+    'test_bucketization', # test expect an non-contiguous tensor but xla permute op will return a contigous tensor
 
     # TestViewOps
     'test_contiguous_nonview',


### PR DESCRIPTION
test is added in https://github.com/pytorch/pytorch/pull/34577 (not merged yet but will fail xla).
 the failure is on
```
        # type promotion and non contiguous tensors
        values_3d_permute = values_3d.permute(2, 1, 0).to(torch.int32)
        boundaries_permute = values_3d.permute(2, 1, 0).to(torch.float64)
        expected_result = torch.tensor([[[0, 0], [0, 1]], [[2, 0], [0, 1]], [[2, 0], [0, 0]]], device=device)
        self.assertWarnsRegex(
            lambda: self.assertEqual(torch.searchsorted(boundaries_permute, values_3d_permute), expected_result),
            "tensor is non-contiguous")
```

test was expecting `values_3d_permute` and `boundaries_permute` being non-contiguous after permute op and trigger the warning message added in https://github.com/pytorch/pytorch/pull/34577/files#diff-1a15d0b6636f51fcd87bd513892aa820R19. However xla permute does not use as_stride and tensor after permute is still contiguous so the warning message is not being trigged. I checked that test will pass if I disable the warning check