### PR TITLE
Disable test_topk_integral_xla_int64 on TPU

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -244,6 +244,7 @@ DISABLED_TORCH_TESTS_TPU = DISABLED_TORCH_TESTS_ANY | {
     'test_triangular_solve_batched_broadcasting',  # (TPU) 1.5 vs 0.001
     'test_random_from_to_xla_int32',  # precision, TPU does not have real F64
     'test_uniform_from_to_xla_float64', # float64 limit, TPU does not have real F64
+    'test_topk_integral_xla_int64', # s64_tensor.sort() is currently not supported on TPU
 }
 
 DISABLED_TORCH_TESTS_CPU = DISABLED_TORCH_TESTS_ANY


### PR DESCRIPTION
Disable since s64_tensor.sort() is currently not supported on TPU.