### PR TITLE
Disable test_index_fill_xla

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -143,9 +143,10 @@ DISABLED_TORCH_TESTS_ANY = {
     'test_randn_xla_float64',  # xla doesn't support manual_seed, as_stride
     'test_rand_xla_float32',  # xla doesn't support manual_seed, as_stride
     'test_rand_xla_float64',  # xla doesn't support manual_seed, as_stride
-    'test_normal_xla_float64',  # AssertionError: 0.22364577306378963 not less than or equal to 0.2
+    'test_normal',  # AssertionError: 0.22364577306378963 not less than or equal to 0.2
     'test_uniform_from_to',  # Checks for error strings.
     'test_bucketization', # test expect an non-contiguous tensor but xla permute op will return a contigous tensor
+    'test_index_fill_xla', # half support
 
     # TestViewOps
     'test_contiguous_nonview',


### PR DESCRIPTION
`test_index_fill_xla`'s `half` type check was enabled in https://github.com/pytorch/pytorch/pull/36335/files#diff-9996665f82f52030836eb8657057cfadL10897 and will fail xla. `test_normal_xla_float32` also fail on the same run. We disabled `test_normal_xla_float64` last week due to the precision and now we see the similar precision error on `float32` version. I tried run it locally with latest pt/xla but still can not reproduce the error, the tolerance might be too low for xla, disable the test for now.