### PR TITLE
Disable large tensor test

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -252,6 +252,10 @@ DISABLED_TORCH_TESTS_TPU = DISABLED_TORCH_TESTS_ANY | {
     'test_random_from_to_xla_int32',  # precision, TPU does not have real F64
     'test_uniform_from_to_xla_float64', # float64 limit, TPU does not have real F64
     'test_topk_integral_xla_int64', # (TPU) unimplemented HLO for X64
+
+    # test_indexing.py
+    # TestIndexing
+    'test_index_put_accumulate_large_tensor_xla', # memory limit exceeded on v2-8
 }
 
 DISABLED_TORCH_TESTS_CPU = DISABLED_TORCH_TESTS_ANY


### PR DESCRIPTION
This test will cause the memory limit exceed on v2-8
```
======================================================================
ERROR: test_index_put_accumulate_large_tensor_xla (__main__.TestIndexingXLA)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/anaconda3/envs/pytorch/lib/python3.6/site-packages/torch/testing/_internal/common_device_type.py", line 207, in instantiated_test
    return test(self, device_arg)
  File "/pytorch/xla/test/../../test/test_indexing.py", line 96, in test_index_put_accumulate_large_tensor
    self.assertEqual(a[0], 11)
  File "/root/anaconda3/envs/pytorch/lib/python3.6/site-packages/torch/testing/_internal/common_device_type.py", line 378, in assertEqual
    x = x.cpu()
RuntimeError: Resource exhausted: From /job:tpu_worker/replica:0/task:0:
Ran out of memory in memory space hbm. Used 8.00G of 7.98G hbm. Exceeded hbm capacity by 17.02M.

Total hbm usage >= 8.02G:
    reserved         17.00M 
    program           8.00G 
    arguments       unknown size 
```