### PR TITLE
Randomize bernoulli and dropout ops.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,6 +23,7 @@ xla_model
 .. autofunction:: save
 .. autofunction:: rendezvous
 .. autofunction:: mesh_reduce
+.. autofunction:: set_rng_seed
 
 distributed
 ----------------------------------

--- a/test/cpp/torch_xla_test.cpp
+++ b/test/cpp/torch_xla_test.cpp
@@ -6,13 +6,16 @@
 #include "tensorflow/compiler/xla/xla_client/sys_util.h"
 #include "tensorflow/compiler/xla/xla_client/tf_logging.h"
 #include "torch_xla/csrc/aten_xla_type.h"
+#include "torch_xla/csrc/device.h"
 #include "torch_xla/csrc/helpers.h"
+#include "torch_xla/csrc/tensor.h"
 
 namespace torch_xla {
 namespace cpp_test {
 
 void XlaTest::SetUp() {
   at::manual_seed(42);
+  XLATensor::SetRngSeed(GetDefaultDevice(), 42);
   start_msnap_ = absl::make_unique<MetricsSnapshot>();
 }
 

--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -348,6 +348,10 @@ class XLATestBase(DeviceTypeTestBase):
     torch_xla._XLAC._xla_set_use_full_mat_mul_precision(
         use_full_mat_mul_precision=True)
 
+  def setUp(self):
+    super().setUp()
+    xm.set_rng_seed(101)
+
   def prepare_for_compare(self, tx, ty):
     print_tensors = xu.getenv_as('TEST_PRINT_TENSORS', bool, defval=False)
     x, y = tx, ty

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -371,9 +371,9 @@ def all_reduce(reduce_type, inputs, scale=1.0, groups=None):
       Default: 1.0
     groups (list, optional): A list of list, representing the replica groups for
       the `all_reduce()` operation. Example: `[[0, 1, 2, 3], [4, 5, 6, 7]]`
-      defines two groups, one with the `[0, 1, 2, 3]` replicas and one with the
-      `[4, 5, 6, 7]` replicas. If `None` there will be only one group with all
-      the replicas in it.
+        defines two groups, one with the `[0, 1, 2, 3]` replicas and one with
+        the `[4, 5, 6, 7]` replicas. If `None` there will be only one group with
+        all the replicas in it.
   """
   _TLS.all_reduce_token = torch_xla._XLAC._xla_all_reduce(
       reduce_type, inputs, _get_all_reduce_token(), scale, groups or [])
@@ -395,9 +395,9 @@ def all_to_all(value,
     split_count (int): The split count.
     groups (list, optional): A list of list, representing the replica groups for
       the `all_reduce()` operation. Example: `[[0, 1, 2, 3], [4, 5, 6, 7]]`
-      defines two groups, one with the `[0, 1, 2, 3]` replicas and one with the
-      `[4, 5, 6, 7]` replicas. If `None` there will be only one group with all
-      the replicas in it.
+        defines two groups, one with the `[0, 1, 2, 3]` replicas and one with
+        the `[4, 5, 6, 7]` replicas. If `None` there will be only one group with
+        all the replicas in it.
 
   Returns:
     The result `torch.Tensor` of the `all_to_all()` operation.
@@ -419,8 +419,8 @@ def collective_permute(value, pairs):
     pairs (list): A list of (source_replica_id, target_replica_id) pairs,
       representing the sender and receiver for the `collective_permute()`
       operation. Example: `[[0, 1], [1, 2], [2, 0]]` defines three pairs. The
-      tensor will be send from replidca 0 to replidca 1, replidca 1 to replidca
-      2, and replidca 2 to replidca 0.
+        tensor will be send from replidca 0 to replidca 1, replidca 1 to
+        replidca 2, and replidca 2 to replidca 0.
 
   Returns:
     The result `torch.Tensor` of the `collective_permute()` operation.
@@ -501,9 +501,9 @@ def reduce_gradients(optimizer, groups=None):
       containing the gradients to be reduced.
     groups (list, optional): A list of list, representing the replica groups for
       the `all_reduce()` operation. Example: `[[0, 1, 2, 3], [4, 5, 6, 7]]`
-      defines two groups, one with the `[0, 1, 2, 3]` replicas and one with the
-      `[4, 5, 6, 7]` replicas. If `None` there will be only one group with all
-      the replicas in it.
+        defines two groups, one with the `[0, 1, 2, 3]` replicas and one with
+        the `[4, 5, 6, 7]` replicas. If `None` there will be only one group with
+        all the replicas in it.
   """
   count = torch_xla._XLAC._xla_get_replication_devices_count()
   if count > 1:
@@ -527,9 +527,9 @@ def optimizer_step(optimizer, barrier=False, optimizer_args={}, groups=None):
       `optimizer.step()` call.
     groups (list, optional): A list of list, representing the replica groups for
       the `all_reduce()` operation. Example: `[[0, 1, 2, 3], [4, 5, 6, 7]]`
-      defines two groups, one with the `[0, 1, 2, 3]` replicas and one with the
-      `[4, 5, 6, 7]` replicas. If `None` there will be only one group with all
-      the replicas in it.
+        defines two groups, one with the `[0, 1, 2, 3]` replicas and one with
+        the `[4, 5, 6, 7]` replicas. If `None` there will be only one group with
+        all the replicas in it.
 
   Returns:
     The same value returned by the `optimizer.step()` call.
@@ -637,3 +637,16 @@ def mesh_reduce(tag, data, reduce_fn):
     xbio = io.BytesIO(xd)
     xldata.append(torch.load(xbio))
   return reduce_fn(xldata) if xldata else cpu_data
+
+
+def set_rng_seed(seed, device=None):
+  """Sets the random number generator seed.
+
+  Args:
+    seed (integer): The seed to be set.
+    device (string, optional): The device where the seed needs to be set. If
+      missing the default device seed will be set.
+  """
+  if device is None:
+    device = torch_xla._XLAC._xla_get_default_device()
+  torch_xla._XLAC._xla_set_rng_seed(seed, str(device) if device else '')

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -206,6 +206,12 @@ void StepMarker(const std::string& device_str,
   XLATensor::MarkStep(device);
 }
 
+void SetRngSeed(xla::uint64 seed, const std::string& device_str) {
+  auto opt_device = GetOptionalDevice(device_str);
+  const Device* device = opt_device ? &opt_device.value() : nullptr;
+  XLATensor::SetRngSeed(device, seed);
+}
+
 std::string GetTensorsHloGraph(const std::vector<at::Tensor>& tensors) {
   std::vector<XLATensor> xtensors = GetXlaTensors(tensors, /*want_all=*/false);
   return XLATensor::DumpHloComputation(xtensors);
@@ -627,6 +633,11 @@ void InitXlaModuleBindings(py::module m) {
     return SetCurrentThreadDevice(device);
   });
   m.def("_xla_get_default_device", []() { return GetCurrentThreadDevice(); });
+  m.def("_xla_set_rng_seed",
+        [](xla::uint64 seed, const std::string& device) {
+          SetRngSeed(seed, device);
+        },
+        py::arg("seed") = 101, py::arg("device") = "");
   m.def("_xla_sync_multi",
         [](const std::vector<at::Tensor>& tensors,
            const std::vector<std::string>& devices, bool wait,

--- a/torch_xla/csrc/ops/bernoulli.cpp
+++ b/torch_xla/csrc/ops/bernoulli.cpp
@@ -1,0 +1,36 @@
+#include "torch_xla/csrc/ops/bernoulli.h"
+
+#include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch_xla/csrc/helpers.h"
+#include "torch_xla/csrc/lowering_context.h"
+#include "torch_xla/csrc/xla_lower_util.h"
+
+namespace torch_xla {
+namespace ir {
+namespace ops {
+
+Bernoulli::Bernoulli(const Value& probability, const Value& seed,
+                     xla::Shape shape)
+    : Node(ir::OpKind(at::aten::bernoulli), {probability, seed},
+           std::move(shape)) {}
+
+NodePtr Bernoulli::Clone(OpList operands) const {
+  return MakeNode<Bernoulli>(operands.at(0), operands.at(1), shape());
+}
+
+XlaOpVector Bernoulli::Lower(LoweringContext* loctx) const {
+  xla::XlaOp probability = loctx->GetOutputOp(operand(0));
+  xla::XlaOp rng_seed = loctx->GetOutputOp(operand(1));
+  const xla::Shape& probability_shape = XlaHelpers::ShapeOfXlaOp(probability);
+  xla::Shape bcast_shape(shape());
+  bcast_shape.set_element_type(probability_shape.element_type());
+  xla::XlaOp bcast_probability = XlaHelpers::ImplicitBroadcast(
+      probability, probability_shape, bcast_shape);
+  return ReturnOp(
+      BuildBernoulli(bcast_probability, rng_seed, shape().element_type()),
+      loctx);
+}
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/bernoulli.h
+++ b/torch_xla/csrc/ops/bernoulli.h
@@ -6,10 +6,9 @@ namespace torch_xla {
 namespace ir {
 namespace ops {
 
-class Uniform : public Node {
+class Bernoulli : public Node {
  public:
-  Uniform(const Value& from, const Value& to, const Value& seed,
-          const xla::Shape& rng_shape);
+  Bernoulli(const Value& probability, const Value& seed, xla::Shape shape);
 
   NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/mean.cpp
+++ b/torch_xla/csrc/ops/mean.cpp
@@ -25,7 +25,7 @@ xla::XlaOp LowerMean(xla::XlaOp input,
 }
 
 xla::Shape NodeOutputShape(const Value& input,
-                           std::vector<xla::int64>& dimensions,
+                           const std::vector<xla::int64>& dimensions,
                            bool keep_reduced_dimensions,
                            const c10::optional<at::ScalarType>& dtype) {
   auto lower_for_shape_fn =

--- a/torch_xla/csrc/ops/normal.cpp
+++ b/torch_xla/csrc/ops/normal.cpp
@@ -9,28 +9,19 @@ namespace torch_xla {
 namespace ir {
 namespace ops {
 
-Normal::Normal(const Value& mean, const Value& std, xla::uint64 seed)
-    : Node(ir::OpKind(at::aten::normal), {mean, std}, mean.shape(),
-           /*num_outputs=*/1, xla::util::MHash(seed)),
-      seed_(seed) {}
+Normal::Normal(const Value& mean, const Value& std, const Value& seed)
+    : Node(ir::OpKind(at::aten::normal), {mean, std, seed}, mean.shape()) {}
 
 NodePtr Normal::Clone(OpList operands) const {
-  return MakeNode<Normal>(operands.at(0), operands.at(1), seed_);
+  return MakeNode<Normal>(operands.at(0), operands.at(1), operands.at(2));
 }
 
 XlaOpVector Normal::Lower(LoweringContext* loctx) const {
   xla::XlaOp mean = loctx->GetOutputOp(operand(0));
   xla::XlaOp std = loctx->GetOutputOp(operand(1));
-  xla::XlaOp rng_seed =
-      XlaHelpers::ScalarValue(seed_, xla::PrimitiveType::U64, mean.builder());
+  xla::XlaOp rng_seed = loctx->GetOutputOp(operand(2));
   return ReturnOp(
       RngNormal(rng_seed, XlaHelpers::ShapeOfXlaOp(mean), mean, std), loctx);
-}
-
-std::string Normal::ToString() const {
-  std::stringstream ss;
-  ss << Node::ToString() << ", seed=" << seed_;
-  return ss.str();
 }
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/normal.h
+++ b/torch_xla/csrc/ops/normal.h
@@ -8,18 +8,11 @@ namespace ops {
 
 class Normal : public Node {
  public:
-  Normal(const Value& mean, const Value& std, xla::uint64 seed);
-
-  std::string ToString() const override;
+  Normal(const Value& mean, const Value& std, const Value& seed);
 
   NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
-
-  xla::uint64 seed() const { return seed_; }
-
- private:
-  xla::uint64 seed_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -610,20 +610,6 @@ NodePtr MinUnary(const Value& input) {
                    std::move(lower_fn));
 }
 
-NodePtr Bernoulli(const Value& input, const Value& probability) {
-  auto lower_fn = [](const Node& node, LoweringContext* loctx) -> XlaOpVector {
-    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
-    xla::XlaOp xla_probability = loctx->GetOutputOp(node.operand(1));
-    xla::XlaOp result =
-        BuildBernoulli(xla_probability, XlaHelpers::ShapeOfXlaOp(xla_input));
-    return node.ReturnOp(result, loctx);
-  };
-  NodePtr probability_expanded = MakeNode<Expand>(
-      probability, xla::util::ToVector<xla::int64>(input.shape().dimensions()));
-  return GenericOp(OpKind(at::aten::bernoulli), {input, probability_expanded},
-                   input.shape(), std::move(lower_fn));
-}
-
 NodePtr Take(const Value& input, const Value& index) {
   auto lower_fn = [](const Node& node, LoweringContext* loctx) -> XlaOpVector {
     xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -184,8 +184,6 @@ NodePtr MaxUnary(const Value& input);
 
 NodePtr MinUnary(const Value& input);
 
-NodePtr Bernoulli(const Value& input, const Value& probability);
-
 NodePtr Take(const Value& input, const Value& index);
 
 NodePtr LogDet(const Value& input);

--- a/torch_xla/csrc/ops/rrelu_with_noise.cpp
+++ b/torch_xla/csrc/ops/rrelu_with_noise.cpp
@@ -10,28 +10,25 @@ namespace torch_xla {
 namespace ir {
 namespace ops {
 
-RreluWithNoise::RreluWithNoise(const Value& input, at::Scalar lower,
-                               at::Scalar upper, bool training,
-                               xla::uint64 seed)
-    : Node(ir::OpKind(at::aten::rrelu_with_noise), {input},
+RreluWithNoise::RreluWithNoise(const Value& input, const Value& seed,
+                               at::Scalar lower, at::Scalar upper,
+                               bool training)
+    : Node(ir::OpKind(at::aten::rrelu_with_noise), {input, seed},
            xla::ShapeUtil::MakeTupleShape({input.shape(), input.shape()}),
            /*num_outputs=*/2,
-           xla::util::MHash(ScalarHash(lower), ScalarHash(upper), training,
-                            seed)),
+           xla::util::MHash(ScalarHash(lower), ScalarHash(upper), training)),
       lower_(std::move(lower)),
       upper_(std::move(upper)),
-      training_(training),
-      seed_(seed) {}
+      training_(training) {}
 
 NodePtr RreluWithNoise::Clone(OpList operands) const {
-  return MakeNode<RreluWithNoise>(operands.at(0), lower_, upper_, training_,
-                                  seed_);
+  return MakeNode<RreluWithNoise>(operands.at(0), operands.at(1), lower_,
+                                  upper_, training_);
 }
 
 XlaOpVector RreluWithNoise::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
-  xla::XlaOp rng_seed =
-      XlaHelpers::ScalarValue(seed_, xla::PrimitiveType::U64, input.builder());
+  xla::XlaOp rng_seed = loctx->GetOutputOp(operand(1));
   return ReturnOps(BuildRrelu(input, lower_, upper_, training_, rng_seed),
                    loctx);
 }
@@ -39,7 +36,7 @@ XlaOpVector RreluWithNoise::Lower(LoweringContext* loctx) const {
 std::string RreluWithNoise::ToString() const {
   std::stringstream ss;
   ss << Node::ToString() << ", lower=" << lower_ << ", upper=" << upper_
-     << ", training=" << training_ << ", seed=" << seed_;
+     << ", training=" << training_;
   return ss.str();
 }
 

--- a/torch_xla/csrc/ops/rrelu_with_noise.h
+++ b/torch_xla/csrc/ops/rrelu_with_noise.h
@@ -11,8 +11,8 @@ namespace ops {
 
 class RreluWithNoise : public Node {
  public:
-  RreluWithNoise(const Value& input, at::Scalar lower, at::Scalar upper,
-                 bool training, xla::uint64 seed);
+  RreluWithNoise(const Value& input, const Value& seed, at::Scalar lower,
+                 at::Scalar upper, bool training);
 
   std::string ToString() const override;
 
@@ -26,13 +26,10 @@ class RreluWithNoise : public Node {
 
   bool training() const { return training_; }
 
-  xla::uint64 seed() const { return seed_; }
-
  private:
   at::Scalar lower_;
   at::Scalar upper_;
   bool training_;
-  xla::uint64 seed_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/scalar.cpp
+++ b/torch_xla/csrc/ops/scalar.cpp
@@ -5,6 +5,7 @@
 
 #include "tensorflow/compiler/xla/shape_util.h"
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
+#include "tensorflow/compiler/xla/xla_client/util.h"
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/lowering_context.h"
 
@@ -89,6 +90,15 @@ XlaOpVector Scalar::Lower(LoweringContext* loctx) const {
     op = xla::Broadcast(op, shape().dimensions());
   }
   return ReturnOp(op, loctx);
+}
+
+xla::hash_t ScalarHash(at::Scalar s) {
+  return s.isFloatingPoint() ? xla::util::Hash(s.toDouble())
+                             : xla::util::Hash(s.toLong());
+}
+
+std::ostream& operator<<(std::ostream& ostrm, at::Scalar s) {
+  return ostrm << (s.isFloatingPoint() ? s.toDouble() : s.toLong());
 }
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/scalar.h
+++ b/torch_xla/csrc/ops/scalar.h
@@ -4,20 +4,12 @@
 
 #include <iostream>
 
+#include "tensorflow/compiler/xla/xla_client/types.h"
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
 namespace ir {
 namespace ops {
-
-inline std::ostream& operator<<(std::ostream& ostrm, at::Scalar s) {
-  return ostrm << (s.isFloatingPoint() ? s.toDouble() : s.toLong());
-}
-
-inline size_t ScalarHash(at::Scalar s) {
-  return s.isFloatingPoint() ? std::hash<double>()(s.toDouble())
-                             : std::hash<long>()(s.toLong());
-}
 
 // Differently from Constant, this is a scalar value broadcasted to a shape.
 // Even though a Constant could have been used, for simple scalars broadcasted
@@ -39,6 +31,10 @@ class Scalar : public Node {
  private:
   at::Scalar value_;
 };
+
+xla::hash_t ScalarHash(at::Scalar s);
+
+std::ostream& operator<<(std::ostream& ostrm, at::Scalar s);
 
 }  // namespace ops
 }  // namespace ir

--- a/torch_xla/csrc/ops/uniform.cpp
+++ b/torch_xla/csrc/ops/uniform.cpp
@@ -1,6 +1,7 @@
 #include "torch_xla/csrc/ops/uniform.h"
 
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "tensorflow/compiler/xla/xla_client/xla_util.h"
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/random.h"
@@ -9,28 +10,21 @@ namespace torch_xla {
 namespace ir {
 namespace ops {
 
-Uniform::Uniform(const Value& from, const Value& to,
-                 const xla::Shape& rng_shape, xla::uint64 seed)
-    : Node(ir::OpKind(at::aten::uniform), {from, to}, rng_shape,
-           /*num_outputs=*/1, xla::util::MHash(seed)),
-      seed_(seed) {}
+Uniform::Uniform(const Value& from, const Value& to, const Value& seed,
+                 const xla::Shape& rng_shape)
+    : Node(ir::OpKind(at::aten::uniform), {from, to, seed}, rng_shape,
+           /*num_outputs=*/1, xla::util::ShapeHash(rng_shape)) {}
 
 NodePtr Uniform::Clone(OpList operands) const {
-  return MakeNode<Uniform>(operands.at(0), operands.at(1), shape(), seed_);
+  return MakeNode<Uniform>(operands.at(0), operands.at(1), operands.at(2),
+                           shape());
 }
 
 XlaOpVector Uniform::Lower(LoweringContext* loctx) const {
   xla::XlaOp from = loctx->GetOutputOp(operand(0));
   xla::XlaOp to = loctx->GetOutputOp(operand(1));
-  xla::XlaOp rng_seed =
-      XlaHelpers::ScalarValue(seed_, xla::PrimitiveType::U64, from.builder());
+  xla::XlaOp rng_seed = loctx->GetOutputOp(operand(2));
   return ReturnOp(RngUniform(rng_seed, shape(), from, to), loctx);
-}
-
-std::string Uniform::ToString() const {
-  std::stringstream ss;
-  ss << Node::ToString() << ", seed=" << seed_;
-  return ss.str();
 }
 
 }  // namespace ops

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -109,6 +109,10 @@ class XLATensor {
                                        const xla::Shape& shape,
                                        const Device& device);
 
+  static ir::Value GetRngSeed(const Device& device);
+
+  static void SetRngSeed(const Device* device, xla::uint64 seed);
+
   // Dispatches a comparison operator, setting the logical type of the result
   // appropriately.
   static XLATensor DispatchComparisonOp(c10::Symbol kind,
@@ -1290,8 +1294,6 @@ class XLATensor {
       const SyncTensorsConfig& config);
 
   static xla::int64 GetNextTensorId();
-
-  static xla::uint64 GenRngSeed();
 
   std::shared_ptr<Data> data_;
 };

--- a/torch_xla/csrc/xla_lower_util.h
+++ b/torch_xla/csrc/xla_lower_util.h
@@ -25,9 +25,10 @@ xla::XlaOp BuildMatMul(xla::XlaOp lhs, xla::XlaOp rhs, xla::XlaOp bias);
 
 xla::XlaOp BuildDot(xla::XlaOp lhs, xla::XlaOp rhs);
 
-xla::XlaOp BuildBernoulli(xla::XlaOp probability, const xla::Shape& shape);
+xla::XlaOp BuildBernoulli(xla::XlaOp probability, xla::XlaOp seed,
+                          xla::PrimitiveType type);
 
-xla::XlaOp BuildDropout(xla::XlaOp input, float probability);
+xla::XlaOp BuildDropout(xla::XlaOp input, float probability, xla::XlaOp seed);
 
 std::vector<xla::XlaOp> CreateBroadcastTensors(
     absl::Span<const xla::XlaOp> operands);


### PR DESCRIPTION
We used to embed the RNG seeds within the graphs, and in order to avoid recompilations, we'd reset the master seed at every step.
This makes compilations stable, but things are not working as one would expect.
Every step will generate the same random numbers at a given position in the graph, which means things like Dropout will not work as intended.
This PR uses an XLA parameter (device data) as master seed, which gets pushed forward at every step, allowing stable compilations and progressive number generation.
