### PR TITLE
Handle the complex float in uniform and normal

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -253,7 +253,7 @@ DISABLED_TORCH_TESTS_TPU = DISABLED_TORCH_TESTS_ANY | {
     'test_random_from_to_xla_int32',  # precision, TPU does not have real F64
     'test_uniform_from_to_xla_float64',  # float64 limit, TPU does not have real F64
     'test_topk_integral_xla_int64',  # (TPU) unimplemented HLO for X64
-    'test_float_to_int_conversion_finite_xla' # different behavior than numpy when casting float_max/min to int types
+    'test_float_to_int_conversion_finite_xla', # different behavior than numpy when casting float_max/min to int types
 
     # test_indexing.py
     # TestIndexing

--- a/torch_xla/csrc/random.cpp
+++ b/torch_xla/csrc/random.cpp
@@ -35,60 +35,74 @@ xla::XlaOp MakeSeed(xla::XlaOp seed) {
   return xla::ConvertElementType(seed, xla::PrimitiveType::U64);
 }
 
+xla::XlaOp MakeUniformBoundaryValue(xla::XlaOp val) {
+  xla::PrimitiveType element_type = XlaHelpers::TypeOfXlaOp(val);
+  if (element_type == xla::PrimitiveType::BF16) {
+    return xla::ConvertElementType(val, xla::PrimitiveType::F32);
+  } else if (xla::primitive_util::IsComplexType(element_type)) {
+    return xla::Real(val);
+  }
+  return val;
+}
+
+xla::Shape MakeRngShape(const xla::Shape& shape) {
+  xla::PrimitiveType element_type = shape.element_type();
+  xla::Shape rng_shape(shape);
+  if (element_type == xla::PrimitiveType::BF16) {
+    rng_shape.set_element_type(xla::PrimitiveType::F32);
+  } else if (xla::primitive_util::IsComplexType(element_type)) {
+    rng_shape.set_element_type(
+        xla::primitive_util::ComplexComponentType(element_type));
+  }
+  return rng_shape;
+}
+
 }  // namespace
 
 xla::XlaOp RngUniform(xla::XlaOp seed, const xla::Shape& shape,
                       xla::XlaOp minval, xla::XlaOp maxval) {
   xla::XlaOp rng_seed = MakeSeed(seed);
+  xla::Shape rng_shape = MakeRngShape(shape);
+  xla::XlaOp rng_minval = MakeUniformBoundaryValue(minval);
+  xla::XlaOp rng_maxval = MakeUniformBoundaryValue(maxval);
   xla::XlaOp initial_state =
       xla::Zero(rng_seed.builder(), xla::PrimitiveType::U64);
   switch (shape.element_type()) {
     case xla::PrimitiveType::BF16: {
-      xla::Shape f32_shape(shape);
-      f32_shape.set_element_type(xla::PrimitiveType::F32);
-      xla::XlaOp f32_minval = MaybeConvertTo(minval, xla::PrimitiveType::F32);
-      xla::XlaOp f32_maxval = MaybeConvertTo(maxval, xla::PrimitiveType::F32);
       xla::XlaOp rng = xla::UniformFloatingPointDistribution(
                            rng_seed, initial_state, GetBitGenerator(),
-                           f32_minval, f32_maxval, f32_shape)
+                           rng_minval, rng_maxval, rng_shape)
                            .value;
       return xla::ConvertElementType(rng, xla::PrimitiveType::BF16);
     }
     case xla::PrimitiveType::F32:
     case xla::PrimitiveType::F64:
-      return xla::UniformFloatingPointDistribution(rng_seed, initial_state,
-                                                   GetBitGenerator(), minval,
-                                                   maxval, shape)
+      return xla::UniformFloatingPointDistribution(
+                 rng_seed, initial_state, GetBitGenerator(), rng_minval,
+                 rng_maxval, rng_shape)
           .value;
     case xla::PrimitiveType::C64:
     case xla::PrimitiveType::C128: {
       xla::XlaOp k_seed = XlaHelpers::ScalarValue<xla::uint64>(
           17, XlaHelpers::TypeOfXlaOp(rng_seed), rng_seed.builder());
-      xla::Shape rng_shape(shape);
-      rng_shape.set_element_type(xla::PrimitiveType::F32);
-      xla::XlaOp f32_minval = MaybeConvertTo(minval, xla::PrimitiveType::F32);
-      xla::XlaOp f32_maxval = MaybeConvertTo(maxval, xla::PrimitiveType::F32);
       xla::XlaOp rng_real = xla::UniformFloatingPointDistribution(
                                 rng_seed, initial_state, GetBitGenerator(),
-                                f32_minval, f32_maxval, rng_shape)
+                                rng_minval, rng_maxval, rng_shape)
                                 .value;
       xla::XlaOp rng_imag =
           xla::UniformFloatingPointDistribution(
-              rng_seed * k_seed, initial_state, GetBitGenerator(), f32_minval,
-              f32_maxval, rng_shape)
+              rng_seed * k_seed, initial_state, GetBitGenerator(), rng_minval,
+              rng_maxval, rng_shape)
               .value;
-      xla::XlaOp rng = xla::Complex(rng_real, rng_imag);
-      return shape.element_type() == xla::PrimitiveType::C64
-                 ? rng
-                 : xla::ConvertElementType(rng, xla::PrimitiveType::C128);
+      return xla::Complex(rng_real, rng_imag);
     }
     case xla::PrimitiveType::S32:
     case xla::PrimitiveType::U32:
     case xla::PrimitiveType::S64:
     case xla::PrimitiveType::U64:
       return xla::UniformIntDistribution(rng_seed, initial_state,
-                                         GetBitGenerator(), minval, maxval,
-                                         shape)
+                                         GetBitGenerator(), rng_minval,
+                                         rng_maxval, rng_shape)
           .value;
     default:
       XLA_ERROR() << "RngUniform not implemented for type "
@@ -100,34 +114,32 @@ xla::XlaOp RngUniform(xla::XlaOp seed, const xla::Shape& shape,
 xla::XlaOp RngNormal(xla::XlaOp seed, const xla::Shape& shape, xla::XlaOp mean,
                      xla::XlaOp std) {
   xla::XlaOp rng_seed = MakeSeed(seed);
+  xla::Shape rng_shape = MakeRngShape(shape);
   xla::XlaOp initial_state =
       xla::Zero(rng_seed.builder(), xla::PrimitiveType::U64);
   switch (shape.element_type()) {
     case xla::PrimitiveType::BF16: {
-      xla::Shape f32_shape(shape);
-      f32_shape.set_element_type(xla::PrimitiveType::F32);
       xla::XlaOp f32_mean = MaybeConvertTo(mean, xla::PrimitiveType::F32);
       xla::XlaOp f32_std = MaybeConvertTo(std, xla::PrimitiveType::F32);
       xla::XlaOp rng =
           xla::NormalFloatingPointDistribution(rng_seed, initial_state,
-                                               GetBitGenerator(), f32_shape)
+                                               GetBitGenerator(), rng_shape)
               .value;
       return xla::ConvertElementType(f32_mean + rng * f32_std,
                                      xla::PrimitiveType::BF16);
     }
     case xla::PrimitiveType::F32:
     case xla::PrimitiveType::F64: {
-      xla::XlaOp rng = xla::NormalFloatingPointDistribution(
-                           rng_seed, initial_state, GetBitGenerator(), shape)
-                           .value;
+      xla::XlaOp rng =
+          xla::NormalFloatingPointDistribution(rng_seed, initial_state,
+                                               GetBitGenerator(), rng_shape)
+              .value;
       return XlaHelpers::PromotedAdd(mean, XlaHelpers::PromotedMul(rng, std));
     }
     case xla::PrimitiveType::C64:
     case xla::PrimitiveType::C128: {
       xla::XlaOp k_seed = XlaHelpers::ScalarValue<xla::uint64>(
           17, XlaHelpers::TypeOfXlaOp(rng_seed), rng_seed.builder());
-      xla::Shape rng_shape(shape);
-      rng_shape.set_element_type(xla::PrimitiveType::F32);
       xla::XlaOp rng_real =
           xla::NormalFloatingPointDistribution(rng_seed, initial_state,
                                                GetBitGenerator(), rng_shape)
@@ -137,10 +149,12 @@ xla::XlaOp RngNormal(xla::XlaOp seed, const xla::Shape& shape, xla::XlaOp mean,
                                                GetBitGenerator(), rng_shape)
               .value;
       xla::XlaOp rng = xla::Complex(rng_real, rng_imag);
-      if (shape.element_type() == xla::PrimitiveType::C128) {
-        rng = xla::ConvertElementType(rng, xla::PrimitiveType::C128);
-      }
-      return XlaHelpers::PromotedAdd(mean, XlaHelpers::PromotedMul(rng, std));
+      // Variance for normal distribution of the real and imaginary values is
+      // half of the input variance.
+      xla::XlaOp sqrtTwo = XlaHelpers::ScalarValue(
+          std::sqrt(2), XlaHelpers::TypeOfXlaOp(std), rng_seed.builder());
+      return XlaHelpers::PromotedAdd(
+          mean, XlaHelpers::PromotedMul(rng, std / sqrtTwo));
     }
     default:
       XLA_ERROR() << "RngNormal not implemented for type "


### PR DESCRIPTION
verified `rand`, `uniform` and `normal` works. Thinking about adding formal c++ tests for complex types but that could be in a different pr. 
```
>>> x1 = torch.rand(2, 2, dtype=torch.complex64, device='xla:0')
>>> x1
tensor([[(0.5526+0.3920j), (0.3979+0.4389j)],
        [(0.2409+0.4744j), (0.3918+0.2904j)]], device='xla:0',
>>> x1.uniform_(0, 10)
tensor([[(8.9376+8.5000j), (9.1608+9.9034j)],
        [(7.9996+5.9927j), (5.2919+1.0915j)]], device='xla:0',
       dtype=torch.complex64)
>>> x1.normal_(1, 1)
tensor([[(0.7900+0.7625j), (1.9446+0.4353j)],
        [(1.3156+0.3884j), (0.7684-0.1768j)]], device='xla:0',
       dtype=torch.complex64)
```