### PR TITLE
Disable test_dim_arg_reduction_scalar_xla

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -147,6 +147,7 @@ DISABLED_TORCH_TESTS_ANY = {
     'test_normal',  # AssertionError: 0.22364577306378963 not less than or equal to 0.2
     'test_uniform_from_to',  # Checks for error strings.
     'test_index_fill_xla',  # half support
+    'test_dim_arg_reduction_scalar_xla', # access dim 0 of scalar tensors
 
     # TestViewOps
     'test_contiguous_nonview',


### PR DESCRIPTION
Test is added in https://github.com/pytorch/pytorch/pull/37214 (not merged yet). Test trys to call `argmax` on dim 0 of a scalar tensor. Similar to https://github.com/pytorch/xla/issues/1958. Disable the test for now. 