### PR TITLE
Revert "Install cmake from conda"

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -4,8 +4,8 @@ set -ex
 
 source ./env
 
-# System default cmake 3.10 cannot find mkl, so install it from conda
-conda install -q -y cmake
+# System default cmake 3.10 cannot find mkl, so point it to the right place.
+export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}
 
 SCCACHE="$(which sccache)"
 if [ -z "${SCCACHE}" ]; then


### PR DESCRIPTION
Reverts pytorch/xla#1975
I think this should be fine now as https://github.com/pytorch/pytorch/pull/37417 is landed. 