### PR TITLE
Support scalar tensor in pytorch ops requires dim

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -147,7 +147,6 @@ DISABLED_TORCH_TESTS_ANY = {
     'test_normal',  # AssertionError: 0.22364577306378963 not less than or equal to 0.2
     'test_uniform_from_to',  # Checks for error strings.
     'test_index_fill_xla',  # half support
-    'test_dim_arg_reduction_scalar_xla', # access dim 0 of scalar tensors
 
     # TestViewOps
     'test_contiguous_nonview',

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1347,6 +1347,33 @@ class TestAtenXlaTensor(XlaTestCase):
         [torch.randn(0, 1, 2, 0),
          torch.tensor([], dtype=torch.long)], test_fn)
 
+  def test_scalar_tensor_0dim(self):
+    a = torch.tensor(2.1)
+    b = torch.tensor(0)
+    self.runAtenTest(a, lambda x: torch.cumprod(x, 0))
+    self.runAtenTest(a, lambda x: torch.cumsum(x, 0))
+    self.runAtenTest(a, lambda x: torch.squeeze(x, 0))
+    self.runAtenTest(a, lambda x: torch.topk(x, 1))
+    self.runAtenTest(a, lambda x: torch.argmax(x, 0))
+    self.runAtenTest(a, lambda x: torch.argmin(x, 0))
+    self.runAtenTest(a, lambda x: torch.sort(x))
+    self.runAtenTest([a, b], lambda x, y: torch.gather(x, 0, y))
+    self.runAtenTest([a, b], lambda x, y: torch.index_add(x, 0, y, x))
+    self.runAtenTest([a, b], lambda x, y: torch.index_copy(x, 0, y, x))
+    self.runAtenTest([a, b], lambda x, y: torch.index_fill(x, 0, y, 2))
+    self.runAtenTest([a, b], lambda x, y: torch.index_select(x, 0, y))
+    self.runAtenTest([a, b], lambda x, y: torch.scatter_add(x, 0, y, x))
+    self.runAtenTest([a, b], lambda x, y: torch.scatter(x, 0, y, x))
+    for keepdim in [True, False]:
+      self.runAtenTest(a, lambda x: torch.kthvalue(x, 1, keepdim=keepdim))
+      self.runAtenTest(a, lambda x: torch.logsumexp(x, 0, keepdim=keepdim))
+      self.runAtenTest(a, lambda x: torch.max(x, 0, keepdim=keepdim))
+      self.runAtenTest(a, lambda x: torch.mean(x, 0, keepdim=keepdim))
+      self.runAtenTest(a, lambda x: torch.min(x, 0, keepdim=keepdim))
+      self.runAtenTest(a, lambda x: torch.norm(x, 2, 0, keepdim=keepdim))
+      self.runAtenTest(a, lambda x: torch.prod(x, 0, keepdim=keepdim))
+      self.runAtenTest(a, lambda x: torch.sum(x, 0, keepdim=keepdim))
+
   def test_scatter_add_small_target(self):
 
     def test_fn(t, s, i):

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2719,8 +2719,9 @@ std::tuple<at::Tensor, at::Tensor> AtenXlaType::sort(const at::Tensor& self,
                                                      int64_t dim,
                                                      bool descending) {
   XLA_FN_COUNTER("xla::");
-  auto results = XLATensor::topk(bridge::GetXlaTensor(self), self.size(dim),
-                                 dim, descending, true);
+  auto results =
+      XLATensor::topk(bridge::GetXlaTensor(self),
+                      GetSizeInDimNoScalar(self, dim), dim, descending, true);
   return std::make_tuple(bridge::AtenFromXlaTensor(std::get<0>(results)),
                          bridge::AtenFromXlaTensor(std::get<1>(results)));
 }

--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -153,6 +153,16 @@ class XlaHelpers {
 
   static xla::XlaOp DynamicReshapeAs(xla::XlaOp input, const xla::Shape& shape);
 
+  static xla::XlaOp MaybeReshapeAs(xla::XlaOp input, const xla::Shape& shape);
+
+  // Reshape the input to scalar if origional_shape is scalar.
+  static xla::XlaOp MaybeReshapeToScalar(xla::XlaOp input,
+                                         const xla::Shape& origional_shape);
+
+  // Reshape each input to scalar if origional_shape is scalar.
+  static std::vector<xla::XlaOp> MaybeReshapeToScalar(
+      std::vector<xla::XlaOp> inputs, const xla::Shape& origional_shape);
+
   static bool SameStaticDimensions(const xla::Shape& shape1,
                                    const xla::Shape& shape2);
 
@@ -170,6 +180,15 @@ class XlaHelpers {
     return opt ? c10::optional<xla::int64>(*opt) : c10::nullopt;
   }
 
+  // Reshape input as a 1d array if it is a scalar.
+  static xla::XlaOp MakeArray(xla::XlaOp input,
+                              xla::Shape* input_shape = nullptr);
+
+  // Reshape input as a 1d array if it is a scalar and dimensions are not empty.
+  static xla::XlaOp MaybeMakeArray(
+      xla::XlaOp input, const absl::Span<const xla::int64>& dimensions,
+      xla::Shape* input_shape = nullptr);
+
   // Creates an XLA padding configuration from a n-dimensional padding list.
   static xla::PaddingConfig MakeXlaPaddingConfigFromNdPadding(
       absl::Span<const xla::int64> padding);
@@ -180,7 +199,8 @@ class XlaHelpers {
       absl::Span<const xla::int64> drop_dims);
 
   // Get the canonical dimension index in the [0, rank) interval. Negative
-  // indices are interpreted as follows: -1 is rank-1, -2 is rank-2 etc.
+  // indices are interpreted as follows: -1 is rank-1, -2 is rank-2 etc. Rank=0
+  // (Scalar value) is interpreted as rank=1 (1d array).
   static xla::int64 GetCanonicalDimensionIndex(xla::int64 dim, xla::int64 rank);
 
   // Same as above, for multiple dimensions.

--- a/torch_xla/csrc/ops/arg_max.cpp
+++ b/torch_xla/csrc/ops/arg_max.cpp
@@ -1,6 +1,7 @@
 #include "torch_xla/csrc/ops/arg_max.h"
 
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 #include "torch_xla/csrc/reduction.h"
@@ -13,7 +14,10 @@ namespace {
 xla::Shape NodeOutputShape(const Value& input, xla::int64 dim, bool keepdim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
-    return BuildArgMax(operands[0], dim, keepdim);
+    xla::Shape input_shape;
+    xla::XlaOp output = BuildArgMax(
+        XlaHelpers::MakeArray(operands[0], &input_shape), dim, keepdim);
+    return XlaHelpers::MaybeReshapeToScalar(output, input_shape);
   };
   return InferOutputShape({input.shape()}, lower_for_shape_fn);
 }
@@ -33,7 +37,10 @@ NodePtr ArgMax::Clone(OpList operands) const {
 
 XlaOpVector ArgMax::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
-  return ReturnOp(BuildArgMax(input, dim_, keepdim_), loctx);
+  xla::Shape input_shape;
+  xla::XlaOp output =
+      BuildArgMax(XlaHelpers::MakeArray(input, &input_shape), dim_, keepdim_);
+  return ReturnOp(XlaHelpers::MaybeReshapeToScalar(output, input_shape), loctx);
 }
 
 std::string ArgMax::ToString() const {

--- a/torch_xla/csrc/ops/cumprod.cpp
+++ b/torch_xla/csrc/ops/cumprod.cpp
@@ -50,7 +50,10 @@ NodePtr CumProd::Clone(OpList operands) const {
 
 XlaOpVector CumProd::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
-  return ReturnOp(LowerCumProd(input, dim_, dtype_), loctx);
+  xla::Shape input_shape;
+  xla::XlaOp output =
+      LowerCumProd(XlaHelpers::MakeArray(input, &input_shape), dim_, dtype_);
+  return ReturnOp(XlaHelpers::MaybeReshapeAs(output, input_shape), loctx);
 }
 
 std::string CumProd::ToString() const {

--- a/torch_xla/csrc/ops/cumsum.cpp
+++ b/torch_xla/csrc/ops/cumsum.cpp
@@ -50,7 +50,10 @@ NodePtr CumSum::Clone(OpList operands) const {
 
 XlaOpVector CumSum::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
-  return ReturnOp(LowerCumSum(input, dim_, dtype_), loctx);
+  xla::Shape input_shape;
+  xla::XlaOp output =
+      LowerCumSum(XlaHelpers::MakeArray(input, &input_shape), dim_, dtype_);
+  return ReturnOp(XlaHelpers::MaybeReshapeAs(output, input_shape), loctx);
 }
 
 std::string CumSum::ToString() const {

--- a/torch_xla/csrc/ops/gather.cpp
+++ b/torch_xla/csrc/ops/gather.cpp
@@ -16,8 +16,13 @@ xla::Shape NodeOutputShape(const Value& input, const Value& index,
                            xla::int64 dim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
-    return xla::TorchGather(operands[0], operands[1], dim,
-                            IsSparseGather(operands[0], operands[1], dim));
+    xla::Shape input_shape;
+    xla::XlaOp array_input = XlaHelpers::MakeArray(operands[0], &input_shape);
+    xla::XlaOp array_index = XlaHelpers::MakeArray(operands[1]);
+    xla::XlaOp output =
+        xla::TorchGather(array_input, array_index, dim,
+                         IsSparseGather(array_input, array_index, dim));
+    return XlaHelpers::MaybeReshapeToScalar(output, input_shape);
   };
   return InferOutputShape({input.shape(), index.shape()}, lower_for_shape_fn);
 }
@@ -35,11 +40,15 @@ NodePtr Gather::Clone(OpList operands) const {
 }
 
 XlaOpVector Gather::Lower(LoweringContext* loctx) const {
-  xla::XlaOp input = loctx->GetOutputOp(operand(0));
-  xla::XlaOp index = loctx->GetOutputOp(operand(1));
-  return ReturnOp(
-      xla::TorchGather(input, index, dim_, IsSparseGather(input, index, dim_)),
-      loctx);
+  xla::Shape input_shape;
+  xla::XlaOp array_input =
+      XlaHelpers::MakeArray(loctx->GetOutputOp(operand(0)), &input_shape);
+  xla::XlaOp array_index =
+      XlaHelpers::MakeArray(loctx->GetOutputOp(operand(1)));
+  xla::XlaOp output =
+      xla::TorchGather(array_input, array_index, dim_,
+                       IsSparseGather(array_input, array_index, dim_));
+  return ReturnOp(XlaHelpers::MaybeReshapeToScalar(output, input_shape), loctx);
 }
 
 std::string Gather::ToString() const {

--- a/torch_xla/csrc/ops/index_ops.cpp
+++ b/torch_xla/csrc/ops/index_ops.cpp
@@ -149,15 +149,23 @@ ir::NodePtr IndexFillOp(const ir::Value& buffer, xla::int64 dim,
                         const ir::Value& index, const ir::Value& value) {
   auto lower_fn = [dim](const ir::Node& node,
                         ir::LoweringContext* loctx) -> ir::XlaOpVector {
+    xla::Shape base_shape;
     xla::XlaOp xla_base = loctx->GetOutputOp(node.operand(0));
     xla::XlaOp xla_index = loctx->GetOutputOp(node.operand(1));
     xla::XlaOp xla_value = loctx->GetOutputOp(node.operand(2));
-    return node.ReturnOp(CreateIndexFill(xla_base, dim, xla_index, xla_value),
+    xla::XlaOp output =
+        CreateIndexFill(XlaHelpers::MakeArray(xla_base, &base_shape), dim,
+                        xla_index, xla_value);
+    return node.ReturnOp(XlaHelpers::MaybeReshapeToScalar(output, base_shape),
                          loctx);
   };
   auto lower_for_shape_fn =
       [dim](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
-    return CreateIndexFill(operands[0], dim, operands[1], operands[2]);
+    xla::Shape base_shape;
+    xla::XlaOp output =
+        CreateIndexFill(XlaHelpers::MakeArray(operands[0], &base_shape), dim,
+                        operands[1], operands[2]);
+    return XlaHelpers::MaybeReshapeToScalar(output, base_shape);
   };
   ir::Value index_rank1 = EnsureRank1(index);
   return ir::ops::GenericOp(
@@ -174,15 +182,23 @@ ir::NodePtr IndexAddOp(const ir::Value& buffer, xla::int64 dim,
                        const ir::Value& index, const ir::Value& source) {
   auto lower_fn = [dim](const ir::Node& node,
                         ir::LoweringContext* loctx) -> ir::XlaOpVector {
+    xla::Shape base_shape;
     xla::XlaOp xla_base = loctx->GetOutputOp(node.operand(0));
     xla::XlaOp xla_index = loctx->GetOutputOp(node.operand(1));
     xla::XlaOp xla_source = loctx->GetOutputOp(node.operand(2));
-    return node.ReturnOp(CreateIndexAdd(xla_base, dim, xla_index, xla_source),
+    xla::XlaOp output = CreateIndexAdd(
+        XlaHelpers::MakeArray(xla_base, &base_shape), dim,
+        XlaHelpers::MakeArray(xla_index), XlaHelpers::MakeArray(xla_source));
+    return node.ReturnOp(XlaHelpers::MaybeReshapeToScalar(output, base_shape),
                          loctx);
   };
   auto lower_for_shape_fn =
       [dim](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
-    return CreateIndexAdd(operands[0], dim, operands[1], operands[2]);
+    xla::Shape base_shape;
+    xla::XlaOp output = CreateIndexAdd(
+        XlaHelpers::MakeArray(operands[0], &base_shape), dim,
+        XlaHelpers::MakeArray(operands[1]), XlaHelpers::MakeArray(operands[2]));
+    return XlaHelpers::MaybeReshapeToScalar(output, base_shape);
   };
   ir::Value index_rank1 = EnsureRank1(index);
   return ir::ops::GenericOp(
@@ -199,15 +215,23 @@ ir::NodePtr IndexCopyOp(const ir::Value& buffer, xla::int64 dim,
                         const ir::Value& index, const ir::Value& source) {
   auto lower_fn = [dim](const ir::Node& node,
                         ir::LoweringContext* loctx) -> ir::XlaOpVector {
+    xla::Shape base_shape;
     xla::XlaOp xla_base = loctx->GetOutputOp(node.operand(0));
     xla::XlaOp xla_index = loctx->GetOutputOp(node.operand(1));
     xla::XlaOp xla_source = loctx->GetOutputOp(node.operand(2));
-    return node.ReturnOp(CreateIndexCopy(xla_base, dim, xla_index, xla_source),
+    xla::XlaOp output = CreateIndexCopy(
+        XlaHelpers::MakeArray(xla_base, &base_shape), dim,
+        XlaHelpers::MakeArray(xla_index), XlaHelpers::MakeArray(xla_source));
+    return node.ReturnOp(XlaHelpers::MaybeReshapeToScalar(output, base_shape),
                          loctx);
   };
   auto lower_for_shape_fn =
       [dim](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
-    return CreateIndexCopy(operands[0], dim, operands[1], operands[2]);
+    xla::Shape base_shape;
+    xla::XlaOp output = CreateIndexCopy(
+        XlaHelpers::MakeArray(operands[0], &base_shape), dim,
+        XlaHelpers::MakeArray(operands[1]), XlaHelpers::MakeArray(operands[2]));
+    return XlaHelpers::MaybeReshapeToScalar(output, base_shape);
   };
   ir::Value index_rank1 = EnsureRank1(index);
   return ir::ops::GenericOp(

--- a/torch_xla/csrc/ops/kth_value.cpp
+++ b/torch_xla/csrc/ops/kth_value.cpp
@@ -1,6 +1,7 @@
 #include "torch_xla/csrc/ops/kth_value.h"
 
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 #include "torch_xla/csrc/xla_lower_util.h"
@@ -14,8 +15,11 @@ xla::Shape NodeOutputShape(const Value& input, xla::int64 k, xla::int64 dim,
                            bool keepdim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
+    xla::Shape input_shape;
+    std::vector<xla::XlaOp> outputs = CreateKthValue(
+        XlaHelpers::MakeArray(operands[0], &input_shape), k, dim, keepdim);
     return xla::Tuple(operands[0].builder(),
-                      CreateKthValue(operands[0], k, dim, keepdim));
+                      XlaHelpers::MaybeReshapeToScalar(outputs, input_shape));
   };
   return InferOutputShape({input.shape()}, lower_for_shape_fn);
 }
@@ -36,8 +40,12 @@ NodePtr KthValue::Clone(OpList operands) const {
 }
 
 XlaOpVector KthValue::Lower(LoweringContext* loctx) const {
+  xla::Shape input_shape;
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
-  return ReturnOps(CreateKthValue(input, k_, dim_, keepdim_), loctx);
+  std::vector<xla::XlaOp> outputs = CreateKthValue(
+      XlaHelpers::MakeArray(input, &input_shape), k_, dim_, keepdim_);
+  return ReturnOps(XlaHelpers::MaybeReshapeToScalar(outputs, input_shape),
+                   loctx);
 }
 
 std::string KthValue::ToString() const {

--- a/torch_xla/csrc/ops/min_in_dim.cpp
+++ b/torch_xla/csrc/ops/min_in_dim.cpp
@@ -1,6 +1,7 @@
 #include "torch_xla/csrc/ops/min_in_dim.h"
 
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 #include "torch_xla/csrc/reduction.h"
@@ -13,9 +14,14 @@ namespace {
 xla::Shape NodeOutputShape(const Value& input, xla::int64 dim, bool keepdim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
-    xla::XlaOp values = BuildMinInDim(operands[0], dim, keepdim);
-    xla::XlaOp indices = BuildArgMin(operands[0], dim, keepdim);
-    return xla::Tuple(values.builder(), {values, indices});
+    xla::Shape input_shape;
+    xla::XlaOp values = BuildMinInDim(
+        XlaHelpers::MakeArray(operands[0], &input_shape), dim, keepdim);
+    xla::XlaOp indices =
+        BuildArgMin(XlaHelpers::MakeArray(operands[0]), dim, keepdim);
+    return xla::Tuple(values.builder(),
+                      {XlaHelpers::MaybeReshapeToScalar(values, input_shape),
+                       XlaHelpers::MaybeReshapeToScalar(indices, input_shape)});
   };
   return InferOutputShape({input.shape()}, lower_for_shape_fn);
 }
@@ -34,10 +40,15 @@ NodePtr MinInDim::Clone(OpList operands) const {
 }
 
 XlaOpVector MinInDim::Lower(LoweringContext* loctx) const {
+  xla::Shape input_shape;
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
-  xla::XlaOp values = BuildMinInDim(input, dim_, keepdim_);
-  xla::XlaOp indices = BuildArgMin(input, dim_, keepdim_);
-  return ReturnOps({values, indices}, loctx);
+  xla::XlaOp values =
+      BuildMinInDim(XlaHelpers::MakeArray(input, &input_shape), dim_, keepdim_);
+  xla::XlaOp indices =
+      BuildArgMin(XlaHelpers::MakeArray(input), dim_, keepdim_);
+  return ReturnOps({XlaHelpers::MaybeReshapeToScalar(values, input_shape),
+                    XlaHelpers::MaybeReshapeToScalar(indices, input_shape)},
+                   loctx);
 }
 
 std::string MinInDim::ToString() const {

--- a/torch_xla/csrc/ops/scatter_add.cpp
+++ b/torch_xla/csrc/ops/scatter_add.cpp
@@ -26,8 +26,14 @@ XlaOpVector ScatterAdd::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
   xla::XlaOp index = loctx->GetOutputOp(operand(1));
   xla::XlaOp src = loctx->GetOutputOp(operand(2));
-  return ReturnOp(CreateScatter(input, index, src, dim_, NumericAddCombiner()),
-                  loctx);
+  xla::Shape input_shape;
+  return ReturnOp(
+      XlaHelpers::MaybeReshapeAs(
+          CreateScatter(XlaHelpers::MakeArray(input, &input_shape),
+                        XlaHelpers::MakeArray(index),
+                        XlaHelpers::MakeArray(src), dim_, NumericAddCombiner()),
+          input_shape),
+      loctx);
 }
 
 std::string ScatterAdd::ToString() const {

--- a/torch_xla/csrc/ops/squeeze.cpp
+++ b/torch_xla/csrc/ops/squeeze.cpp
@@ -3,6 +3,7 @@
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
 #include "torch_xla/csrc/data_ops.h"
+#include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
@@ -23,7 +24,7 @@ xla::Shape NodeOutputShape(const Value& input, int dim) {
   auto lower_for_shape_fn =
       [dim](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     XLA_CHECK_EQ(operands.size(), 1);
-    return LowerSqueeze(operands[0], dim);
+    return LowerSqueeze(XlaHelpers::MakeArray(operands[0]), dim);
   };
   return InferOutputShape({input.shape()}, lower_for_shape_fn);
 }
@@ -42,7 +43,7 @@ NodePtr Squeeze::Clone(OpList operands) const {
 
 XlaOpVector Squeeze::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
-  xla::XlaOp output = LowerSqueeze(input, dim_);
+  xla::XlaOp output = LowerSqueeze(XlaHelpers::MakeArray(input), dim_);
   return ReturnOp(output, loctx);
 }
 

--- a/torch_xla/csrc/torch_util.cpp
+++ b/torch_xla/csrc/torch_util.cpp
@@ -27,4 +27,9 @@ at::ScalarType GetScalarType(at::Scalar scalar) {
   XLA_ERROR() << "Unknown type for scalar";
 }
 
+int64_t GetSizeInDimNoScalar(const at::Tensor& input, int64_t dim) {
+  int64_t wrapped_dim = at::maybe_wrap_dim(dim, input.dim());
+  return (input.dim() == 0 && wrapped_dim == 0) ? 1 : input.size(dim);
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/torch_util.h
+++ b/torch_xla/csrc/torch_util.h
@@ -16,6 +16,10 @@ at::Tensor CopyTensor(const at::Tensor& ref, at::ScalarType dest_type,
 // Return at::ScalarType from at::Scalar
 at::ScalarType GetScalarType(at::Scalar scalar);
 
+// Return the size of the input tensor in the given dimension. Scalar tensor is
+// interpreted as 1d tensor.
+int64_t GetSizeInDimNoScalar(const at::Tensor& input, int64_t dim);
+
 template <typename T, typename S>
 T OptionalOr(const c10::optional<S>& value, T defval) {
   return value ? static_cast<T>(*value) : defval;


### PR DESCRIPTION
fix https://github.com/pytorch/xla/issues/1960 and https://github.com/pytorch/xla/issues/1958 except `torch.transpose` which is a bit tricky since it returns a view. Waiting for the test on CI to pass (need my local machine to run something else) before requesting reviews.