### PR TITLE
Convert scalar to desired dtype before type promotion.

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1494,6 +1494,20 @@ class TestAtenXlaTensor(XlaTestCase):
     expected_str = 'tensor([5], device=\'' + str(xla_device) + '\')'
     self.assertEqual(str(x), expected_str)
 
+    def test_type_promotion_issue_1929(self):
+
+      def test_fn(m, x):
+        x = torch.matmul(x, m)
+        x *= 0.5
+        loss = x.sum()
+        loss.backward()
+        return m.grad
+
+      self.runAtenTest([
+          torch.rand(5, 10, requires_grad=True),
+          torch.rand(8, 5, requires_grad=True)
+      ], test_fn)
+
   def test_as_strided_r1(self):
 
     def test_fn(r):

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -108,7 +108,8 @@ template <typename B>
 at::Tensor DoBinaryOp(const at::Tensor& self, const at::Tensor& other,
                       const B& bin_op) {
   at::ScalarType dtype = at::result_type(self, other);
-  std::pair<XLATensor, XLATensor> operands = GetBinaryOperands(self, other);
+  std::pair<XLATensor, XLATensor> operands =
+      GetBinaryOperands(self, UnwrapNumber(other, dtype));
   XLATensor result = bin_op(operands.first, operands.second, dtype);
   return bridge::AtenFromXlaTensor(result);
 }

--- a/torch_xla/csrc/torch_util.cpp
+++ b/torch_xla/csrc/torch_util.cpp
@@ -27,4 +27,9 @@ at::ScalarType GetScalarType(at::Scalar scalar) {
   XLA_ERROR() << "Unknown type for scalar";
 }
 
+at::Tensor UnwrapNumber(const at::Tensor& tensor, at::ScalarType dtype) {
+  return tensor.unsafeGetTensorImpl()->is_wrapped_number() ? tensor.to(dtype)
+                                                           : tensor;
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/torch_util.h
+++ b/torch_xla/csrc/torch_util.h
@@ -21,4 +21,7 @@ T OptionalOr(const c10::optional<S>& value, T defval) {
   return value ? static_cast<T>(*value) : defval;
 }
 
+// Unwraps tensor to target dtype if it's a wrapped number.
+at::Tensor UnwrapNumber(const at::Tensor& tensor, at::ScalarType dtype);
+
 }  // namespace torch_xla


### PR DESCRIPTION
fixes #1929
I hit this problem in other places as well so took another look to fix. 
The root cause here is not pytorch call into (Tensor, Tensor) version of binary ops for scalar, since `at::result_type` correctly returns a dtype that doesn't consider scalar.  
The root cause is rather for all scalars we default its dtype to highest precision in the same category, e.g. in this case the scalar should really be `bfloat16` rather than `double`. This hurts because we do type promotion at in pytorch/xla which promotes to the higher one (while pytorch will know it's a scalar and doesn't promote). 