### PR TITLE
Fix our docker build breakage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,14 @@
 # Use nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04 or later for CUDA.
+# Warning: All ARGs placed before FROM will only be scoped up unitl FROM statement.
+# https://github.com/docker/cli/blob/3c7ede6a68941f64c3a154c9a753eb7a9b1c2c3e/docs/reference/builder.md#understand-how-arg-and-from-interact
 ARG base_image="debian:stretch"
+FROM "${base_image}"
+
 ARG python_version="3.6"
 ARG cloud_build="false"
 ARG release_version="nightly"
 ARG cuda="0"
 ARG cuda_compute="7.0,7.5"
-
-FROM "${base_image}"
 
 RUN apt-get update
 RUN apt-get install -y git sudo python-pip python3-pip


### PR DESCRIPTION
ARG context gets reset after FROM:
https://github.com/docker/cli/blob/3c7ede6a68941f64c3a154c9a753eb7a9b1c2c3e/docs/reference/builder.md#understand-how-arg-and-from-interact