### PR TITLE
Dsiable test_block_diag_scipy on TPU

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -266,6 +266,7 @@ DISABLED_TORCH_TESTS_TPU_ONLY = {
         'test_uniform_from_to_xla_float64',  # float64 limit, TPU does not have real F64
         'test_topk_integral_xla_int64',  # (TPU) unimplemented HLO for X64
         'test_float_to_int_conversion_finite_xla',  # different behavior than numpy when casting float_max/min to int types
+        'test_block_diag_scipy',  # failed to handle np.complex128 as input to tensor.
     },
 
     # test_indexing.py


### PR DESCRIPTION
Dsiable the test to unblock the python tests on the weekend, will dig a bit more Monday. 

Minimum repo of the issue
```
import torch                                                                                                                                                                                                                            
import torch_xla                                                                                                                                                                                                                        
import torch_xla.core.xla_model as xm                                                                                                                                                                                                   
import numpy as np                                                                                                                                                                                                                      
from torch.testing._internal.common_utils import torch_to_numpy_dtype_dict                                                                                                                                                              
dd = xm.xla_device()                                                                                                                                                                                                                    
                                                                                                                                                                                                                                        
c = np.complex128(3j)                                                                                                                                                                                                                   
print(torch.tensor(c))                                                                                                                                                                                                                  
print(torch.tensor(c, device=dd))  
```
```
tensor((0.+3.j), dtype=torch.complex128)
tensor((0.+0.j), device='xla:1', dtype=torch.complex128)
```

it seems like we didn't handle no.complex128 correctly, using python native `complex` works as expected.