### PR TITLE
Base Docker names off of release + python version. Needed for 3.7 whe…

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -8,26 +8,27 @@ steps:
           '--build-arg', 'python_version=${_PYTHON_VERSION}',
           '--build-arg', 'cloud_build=true',
           '--build-arg', 'release_version=${_RELEASE_VERSION}',
-          '-t', 'gcr.io/tpu-pytorch/xla:${_RELEASE_VERSION}',
+          '-t', 'gcr.io/tpu-pytorch/xla:${_IMAGE_NAME}',
           '-f', 'docker/Dockerfile', '.'
         ]
   timeout: 14400s
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: bash
-  args: ['-c', 'docker tag gcr.io/tpu-pytorch/xla:${_RELEASE_VERSION} gcr.io/tpu-pytorch/xla:${_RELEASE_VERSION}_$(date -u +%Y%m%d)']
-- name: 'gcr.io/tpu-pytorch/xla:${_RELEASE_VERSION}'
+  args: ['-c', 'docker tag gcr.io/tpu-pytorch/xla:${_IMAGE_NAME} gcr.io/tpu-pytorch/xla:${_IMAGE_NAME}_$(date -u +%Y%m%d)']
+- name: 'gcr.io/tpu-pytorch/xla:${_IMAGE_NAME}'
   entrypoint: bash
   args: ['-c', 'source /pytorch/xla/docker/common.sh && run_deployment_tests']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'gcr.io/tpu-pytorch/xla']
   timeout: 1200s
-- name: 'gcr.io/tpu-pytorch/xla:${_RELEASE_VERSION}'
+- name: 'gcr.io/tpu-pytorch/xla:${_IMAGE_NAME}'
   entrypoint: 'bash'
   args: ['-c', 'source /pytorch/xla/docker/common.sh && collect_wheels ${_RELEASE_VERSION}']
 
 substitutions:
     _PYTHON_VERSION: '3.6'
     _RELEASE_VERSION: 'nightly'  # or rX.Y
+    _IMAGE_NAME: '${_RELEASE_VERSION}_${_PYTHON_VERSION}'
 options:
     machineType: 'N1_HIGHCPU_32'
 timeout: 15000s


### PR DESCRIPTION
…els.

TESTED=Ran for a bit to make sure the syntax is OK.

Logs for that run [here](https://console.cloud.google.com/cloud-build/builds/455e3f79-c165-4e3e-a57f-6dee8f0c658b?project=1030754782689)

Substitution looks OK, e.g. I see `-c docker tag gcr.io/tpu-pytorch/xla:nightly_3.6 gcr.io/tpu-pytorch/xla:nightly_3.6_$(date -u +%Y%m%d)`