### PR TITLE
Fix multiple typos in docs

### DIFF
--- a/API_GUIDE.md
+++ b/API_GUIDE.md
@@ -139,7 +139,7 @@ single device snippet:
 - `xmp.spawn()` creates the processes that each run an XLA device.
 - `ParallelLoader` loads the training data onto each device.
 - `xm.optimizer_step(optimizer)` no longer needs a barrier. ParallelLoader
-automatically creates an XLA barrier that evalutes the graph.
+automatically creates an XLA barrier that evaluates the graph.
 
 The model definition, optimizer definition and training loop remain the same.
 
@@ -248,7 +248,7 @@ import torch_xla.core.xla_model as xm
 xm.save(model.state_dict(), path)
 ```
 
-In case of multple devices, the above API will only save the data for the master
+In case of multiple devices, the above API will only save the data for the master
 device ordinal (0).
 
 Directly saving XLA tensors is possible but not recommended. XLA

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -602,7 +602,7 @@ def optimizer_step(optimizer, barrier=False, optimizer_args={}, groups=None):
 def save(data, file_or_path, master_only=True, global_master=False):
   """Saves the input data into a file.
 
-  The saved data is transfered to PyTorch CPU device before being saved, so a
+  The saved data is transferred to PyTorch CPU device before being saved, so a
   following `torch.load()` will load CPU data.
 
   Args:

--- a/torch_xla/distributed/data_parallel.py
+++ b/torch_xla/distributed/data_parallel.py
@@ -111,7 +111,7 @@ class DataParallel(object):
         assigned to each device taking part of the replication. The function
         will be called with the `def loop_fn(model, device_loader, device,
         context)` signature. Where `model` is the per device network as passed
-        to the `DataParallel` contructor. The `device_loader` is the
+        to the `DataParallel` constructor. The `device_loader` is the
         `ParallelLoader` which will be returning samples for the current
         `device`. And the `context` is a per thread/device context which has the
         lifetime of the `DataParallel` object, and can be used by the `loop_fn`


### PR DESCRIPTION
Hello all! I found 4 more typos in the docs, so I thought I'll just make a simple pull request.

1. <code>evalutes</code> -> <code>evaluates</code> in <code>API_GUIDE.md</code>
2. <code>transfered</code> -> <code>transferred</code> in <code>torch_xla/core/xla_model.py</code>
3. <code>multple</code> -> <code>multiple</code> in <code>torch_xla/core/xla_model.py</code>
4. <code>contructor</code> -> <code>constructor</code> in <code>torch_xla/distributed/data_parallel.py</code>

Thank you!