### PR TITLE
Dsiable test_logical_not_out_xla since constant with f16 and f64 is n…

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -267,6 +267,7 @@ DISABLED_TORCH_TESTS_TPU_ONLY = {
         'test_float_to_int_conversion_finite_xla',  # different behavior than numpy when casting float_max/min to int types
         'test_block_diag_scipy',  # failed to handle np.complex128 as input to tensor.
         'test_remainder_fmod_large_dividend_xla',  # precision, remainder with 1e9 gives incorrect answer
+        'test_logical_not_out_xla',  # constant with type f16 and f64 is not supported
     },
 
     # test_indexing.py


### PR DESCRIPTION
…ot supported on TPU.

Test is trying to create constant with fp16 and f64 with
```
out_np = np.empty(a.shape, dtype=torch_to_numpy_dtype_dict[out_dtype])
```
which is not supported on TPU. 

Disable the whole test as this test does the type expansion twice so the test that is currently failing are
```
test_logical_not_out_xla_xxx_float16
test_logical_not_out_xla_float16_xxxx
test_logical_not_out_xla_xxx_float64
test_logical_not_out_xla_float64_xxxx
```
and we don't have a way to disable the test by regex yet.