### PR TITLE
Capture server side metrics in utils.

### DIFF
--- a/torch_xla/debug/metrics_compare_utils.py
+++ b/torch_xla/debug/metrics_compare_utils.py
@@ -89,13 +89,14 @@ def parse_metrics_report(report, dehumanize=True):
   # Parse metrics into data points.
   metric_match_gd = [m.groupdict() for m in re.finditer(_METRIC_REGEX, report)]
   server_metric_match_gd = [
-      m.groupdict() for m in re.finditer(_SERVER_METRIC_REGEX, report)]
+      m.groupdict() for m in re.finditer(_SERVER_METRIC_REGEX, report)
+  ]
   for gd in itertools.chain(metric_match_gd, server_metric_match_gd):
     metric_name = gd.pop('metric_name')
     for k, v in gd.items():
       parsed_v, units = _metric_str_to_number(v)
-      full_key = '{}__{}{}{}'.format(
-        metric_name, k, '_' if units else '', units)
+      full_key = '{}__{}{}{}'.format(metric_name, k, '_' if units else '',
+                                     units)
       data_points[full_key] = parsed_v if dehumanize else v
 
   # Parse counters into data points.


### PR DESCRIPTION
Add regex for server side metrics.
Add option to not convert metrics to numbers in report (to be used downstream by the comparison script)

```
# BEFORE
(torch-xla-nightly) pytorch-xla-europe➜  20200514-bisectregression  ᐅ  python metrics_compare.py rob-0420-rng-tf0429.txt rob-daviderevert.txt -t -1 -c 50000 -p 5000   | grep Xrt
                      XrtSessionCount               10               11        10.0
                     XrtCompile_Empty              144              144         0.0
              XrtExecuteChained_Empty              144              144         0.0
                     XrtExecute_Empty              144              144         0.0
                        XrtRead_Empty              144              144         0.0
     XrtReleaseAllocationHandle_Empty              144              144         0.0
        XrtReleaseCompileHandle_Empty              144              144         0.0
                    XrtSubTuple_Empty              144              144         0.0

# AFTER
(torch-xla-nightly) pytorch-xla-europe➜  20200514-bisectregression  ᐅ  python metrics_compare.py rob-0420-rng-tf0429.txt rob-daviderevert.txt -t -1 -c 50000 -p 5000   | grep Xrt
          XrtAllocateFromTensor.Total       15 minutes       31 minutes       107.6
                 XrtReadLiteral.Count             4352             8153        87.3
                     XrtCompile.Count              168              280        66.7
                 XrtReadLiteral.Total            2 sec            4 sec        64.2
                     XrtExecute.Count            48360            77647        60.6
          XrtAllocateFromTensor.Count           223421           330258        47.8
           XrtReleaseAllocation.Total        3 minutes        4 minutes        27.7
           XrtReleaseAllocation.Count           450584           535848        18.9
                     XrtExecute.Total          4 hours          5 hours        18.1
                     XrtCompile.Total       19 minutes       16 minutes       -15.1
                      XrtSessionCount               10               11        10.0
                     XrtCompile_Empty              144              144         0.0
              XrtExecuteChained_Empty              144              144         0.0
                     XrtExecute_Empty              144              144         0.0
                        XrtRead_Empty              144              144         0.0
     XrtReleaseAllocationHandle_Empty              144              144         0.0
        XrtReleaseCompileHandle_Empty              144              144         0.0
                    XrtSubTuple_Empty              144              144         0.0
```