### PR TITLE
Disable test_logcumsumexp_xla due to precision issue on TPU

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -266,6 +266,7 @@ DISABLED_TORCH_TESTS_TPU_ONLY = {
         'test_topk_integral_xla_int64',  # (TPU) unimplemented HLO for X64
         'test_float_to_int_conversion_finite_xla',  # different behavior than numpy when casting float_max/min to int types
         'test_block_diag_scipy',  # failed to handle np.complex128 as input to tensor.
+        'test_logcumsumexp_xla',  # precision (1e-5), test use torch.allClose
         'test_remainder_fmod_large_dividend_xla',  # precision, remainder with 1e9 gives incorrect answer
     },
 


### PR DESCRIPTION
test uses
```
self.assertTrue(torch.allclose(expected, actual))
```
which does not takes xla's precision overwrite. Using `self.assertEqual(expected, actual)` works. @ailzhang has a pr to enhance `allClose`. Disable the test until her change merged to pytorch.