### PR TITLE
Pass in args as *args for `do_on_ordinals`

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -697,7 +697,7 @@ def do_on_ordinals(target, data=(), ordinals=(0,)):
   running = get_ordinal() in ordinals
   cpu_data = _maybe_convert_to_cpu(data, convert=running)
   if running:
-    result = target(cpu_data)
+    result = target(*cpu_data)
   else:
     result = None
   rendezvous('torch_xla.core.xla_model.do_on_ordinals')


### PR DESCRIPTION
Repro:
```
import torch_xla.distributed.xla_multiprocessing as xmp
import torch_xla.core.xla_model as xm

def _mp_fn(rank):
    def fn(a, b, c):
        print(f'a: {a}, b: {b}, c: {c}')

    a, b, c = 1, 2, 3

    xm.do_on_ordinals(fn, data=(a, b, c))

if __name__ == '__main__':
    xmp.spawn(_mp_fn, nprocs=8)
```

Error:
```
Traceback (most recent call last):
  File "/home/jysohn/anaconda3/envs/pytorch/lib/python3.6/site-packages/torch_xla-1.6-py3.6-linux-x86_64.egg/torch_xla/distributed/xla_multiprocessing.py", line 231, in _start_fn
    fn(gindex, *args)
  File "/home/jysohn/tmp/pytorch/do_on_ordinals.py", line 10, in _mp_fn
    xm.do_on_ordinals(fn, data=(a, b, c))
  File "/home/jysohn/anaconda3/envs/pytorch/lib/python3.6/site-packages/torch_xla-1.6-py3.6-linux-x86_64.egg/torch_xla/core/xla_model.py", line 686, in do_on_ordinals
    result = target(cpu_data)
TypeError: fn() missing 2 required positional arguments: 'b' and 'c'
```