### PR TITLE
Fix testIndexAdd on GPU

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -4691,19 +4691,17 @@ TEST_F(AtenXlaTensorTest, TestIndexAdd) {
               : torch::randint(100, value_sizes,
                                torch::TensorOptions(scalar_type));
       torch::Tensor result = torch::index_add(base, dim, index, value);
-      ForEachDevice(
-          {DeviceType::CPU, DeviceType::TPU}, [&](const torch::Device& device) {
-            torch::Tensor xla_base = CopyToDevice(base, device);
-            torch::Tensor xla_index = CopyToDevice(index, device);
-            torch::Tensor xla_value = CopyToDevice(value, device);
-            torch::Tensor xla_result =
-                torch::index_add(xla_base, dim, xla_index, xla_value);
-            AllEqual(result, xla_result);
+      ForEachDevice([&](const torch::Device& device) {
+        torch::Tensor xla_base = CopyToDevice(base, device);
+        torch::Tensor xla_index = CopyToDevice(index, device);
+        torch::Tensor xla_value = CopyToDevice(value, device);
+        torch::Tensor xla_result =
+            torch::index_add(xla_base, dim, xla_index, xla_value);
+        AllClose(result, xla_result);
 
-            ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-            ExpectCounterChanged("xla::index_add_",
-                                 cpp_test::GetIgnoredCounters());
-          });
+        ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+        ExpectCounterChanged("xla::index_add_", cpp_test::GetIgnoredCounters());
+      });
     }
   }
 }
@@ -4715,39 +4713,36 @@ TEST_F(AtenXlaTensorTest, TestIndexAddInPlace) {
        {torch::kFloat, torch::kByte, torch::kChar, torch::kShort, torch::kInt,
         torch::kLong}) {
     for (int dim = -rank; dim < rank; ++dim) {
-      ForEachDevice(
-          {DeviceType::CPU, DeviceType::TPU}, [&](const torch::Device& device) {
-            torch::Tensor base =
-                isFloatingType(scalar_type)
-                    ? torch::rand({5, 3, 7}, torch::TensorOptions(scalar_type))
-                    : torch::randint(100, {5, 3, 7},
-                                     torch::TensorOptions(scalar_type));
-            torch::Tensor index =
-                torch::randint(0, base.size(dim), {index_size},
-                               torch::TensorOptions(torch::kLong));
-            std::vector<int64_t> value_sizes(base.sizes().begin(),
-                                             base.sizes().end());
-            int canonical_dim = dim < 0 ? dim + rank : dim;
-            value_sizes[canonical_dim] = index_size;
-            torch::Tensor value =
-                isFloatingType(scalar_type)
-                    ? torch::rand(value_sizes,
-                                  torch::TensorOptions(scalar_type))
-                    : torch::randint(100, value_sizes,
-                                     torch::TensorOptions(scalar_type));
-            torch::Tensor xla_base = CopyToDevice(base.clone(), device);
-            torch::Tensor result = base.index_add_(dim, index, value);
-            torch::Tensor xla_index = CopyToDevice(index, device);
-            torch::Tensor xla_value = CopyToDevice(value, device);
-            torch::Tensor xla_result =
-                xla_base.index_add_(dim, xla_index, xla_value);
-            AllEqual(result, xla_result);
-            AllEqual(base, xla_base);
+      ForEachDevice([&](const torch::Device& device) {
+        torch::Tensor base =
+            isFloatingType(scalar_type)
+                ? torch::rand({5, 3, 7}, torch::TensorOptions(scalar_type))
+                : torch::randint(100, {5, 3, 7},
+                                 torch::TensorOptions(scalar_type));
+        torch::Tensor index =
+            torch::randint(0, base.size(dim), {index_size},
+                           torch::TensorOptions(torch::kLong));
+        std::vector<int64_t> value_sizes(base.sizes().begin(),
+                                         base.sizes().end());
+        int canonical_dim = dim < 0 ? dim + rank : dim;
+        value_sizes[canonical_dim] = index_size;
+        torch::Tensor value =
+            isFloatingType(scalar_type)
+                ? torch::rand(value_sizes, torch::TensorOptions(scalar_type))
+                : torch::randint(100, value_sizes,
+                                 torch::TensorOptions(scalar_type));
+        torch::Tensor xla_base = CopyToDevice(base.clone(), device);
+        torch::Tensor result = base.index_add_(dim, index, value);
+        torch::Tensor xla_index = CopyToDevice(index, device);
+        torch::Tensor xla_value = CopyToDevice(value, device);
+        torch::Tensor xla_result =
+            xla_base.index_add_(dim, xla_index, xla_value);
+        AllClose(result, xla_result);
+        AllClose(base, xla_base);
 
-            ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-            ExpectCounterChanged("xla::index_add_",
-                                 cpp_test::GetIgnoredCounters());
-          });
+        ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+        ExpectCounterChanged("xla::index_add_", cpp_test::GetIgnoredCounters());
+      });
     }
   }
 }

--- a/torch_xla/csrc/ops/scatter.cpp
+++ b/torch_xla/csrc/ops/scatter.cpp
@@ -23,8 +23,10 @@ XlaOpVector Scatter::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
   xla::XlaOp index = loctx->GetOutputOp(operand(1));
   xla::XlaOp src = loctx->GetOutputOp(operand(2));
+
+  ScatterOptions options(/*combiner=*/nullptr);
   return ReturnOp(
-      CreateScatter(loctx->device(), input, index, src, dim_, nullptr), loctx);
+      CreateScatter(loctx->device(), input, index, src, dim_, options), loctx);
 }
 
 std::string Scatter::ToString() const {

--- a/torch_xla/csrc/ops/scatter_add.cpp
+++ b/torch_xla/csrc/ops/scatter_add.cpp
@@ -26,9 +26,9 @@ XlaOpVector ScatterAdd::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
   xla::XlaOp index = loctx->GetOutputOp(operand(1));
   xla::XlaOp src = loctx->GetOutputOp(operand(2));
-  return ReturnOp(CreateScatter(loctx->device(), input, index, src, dim_,
-                                NumericAddCombiner()),
-                  loctx);
+  ScatterOptions options(NumericAddCombiner());
+  return ReturnOp(
+      CreateScatter(loctx->device(), input, index, src, dim_, options), loctx);
 }
 
 std::string ScatterAdd::ToString() const {

--- a/torch_xla/csrc/xla_lower_util.h
+++ b/torch_xla/csrc/xla_lower_util.h
@@ -60,10 +60,18 @@ using XlaOpCombiner = std::function<xla::XlaOp(xla::XlaOp, xla::XlaOp)>;
 
 XlaOpCombiner NumericAddCombiner();
 
-// Used to lower scatter and scatter_add.
+struct ScatterOptions {
+  explicit ScatterOptions(XlaOpCombiner combiner)
+      : combiner(std::move(combiner)) {}
+
+  XlaOpCombiner combiner;
+  absl::optional<xla::XlaOp> init_value;
+  bool indices_are_unique = true;
+};
+
 xla::XlaOp CreateScatter(const Device& device, xla::XlaOp input,
                          xla::XlaOp index, xla::XlaOp source, xla::int64 dim,
-                         const XlaOpCombiner& combiner);
+                         const ScatterOptions& options);
 
 xla::XlaOp CreatePut(const Device& device, xla::XlaOp input, xla::XlaOp index,
                      xla::XlaOp source, bool accumulate);


### PR DESCRIPTION
IndexAdd failure on XLA:GPU is related to the precision, change to `AllClose` which has default `rtol` set to `1e-5`