### PR TITLE
Ability to master_print many args.

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -123,9 +123,9 @@ def is_master_ordinal(local=True):
   return ordinal == 0
 
 
-def master_print(s, fd=sys.stdout, local=True, flush=False):
+def master_print(*s, fd=sys.stdout, local=True, flush=False):
   if is_master_ordinal(local=local):
-    print(s, file=fd, flush=flush)
+    print(*s, file=fd, flush=flush)
 
 
 def xla_device(n=None, devkind=None):

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -123,9 +123,9 @@ def is_master_ordinal(local=True):
   return ordinal == 0
 
 
-def master_print(*s, fd=sys.stdout, local=True, flush=False):
+def master_print(*args, fd=sys.stdout, local=True, flush=False):
   if is_master_ordinal(local=local):
-    print(*s, file=fd, flush=flush)
+    print(*args, file=fd, flush=flush)
 
 
 def xla_device(n=None, devkind=None):


### PR DESCRIPTION
Before, using master_print w/ many args,
i.e. `xm.master_print('a', 'b')`, errored with
```
AttributeError: 'str' object has no attribute 'write'
```

Now it prints.