### PR TITLE
Skip NN memory overlap check tests

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -228,6 +228,8 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_fold',  # The gradient check code errors out on type() call, and code is slow on XLA
         'test_unfold',  # The gradient check code errors out on type() call, and code is slow on XLA
         'test_hardsigmoid_grad_xla',  # gradient check is slow
+        'test_leaky_relu_inplace_overlap_xla',  # doesn't raise
+        'test_threshold_inplace_overlap_xla',  # doesn't raise
     },
 
     # test_type_promotion.py


### PR DESCRIPTION
Follow up to #2230, two more tests added in pytorch/pytorch#39878 which need skips.