### PR TITLE
Minor fix in build system and document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ To build from source:
   pip install lark-parser
   ```
 
-* Currently _PyTorch_ does not build with _GCC_ 6.x, 7.x, and 8.x (various kind of ICEs). _CLANG_ 7.x and 8.x are known to be working, so install that in your VM:
+* Currently _PyTorch_ does not build with _GCC_ 6.x, 7.x, and 8.x (various kind of ICEs). _CLANG_ 7, 8, 9 and 10 are known to be working, so install that in your VM:
 
   ```Shell
   sudo apt-get install clang-8 clang++-8

--- a/build_torch_xla_libs.sh
+++ b/build_torch_xla_libs.sh
@@ -26,7 +26,7 @@ if [[ "$XLA_CUDA" == "1" ]] && [[ "$CLOUD_BUILD" == "true" ]]; then
 fi
 
 OPTS=(--cxxopt="-std=c++14")
-if [[ "$CC" =~ ^clang ]]; then
+if [ $(basename -- $CC) =~ ^clang ]; then
   OPTS+=(--cxxopt="-Wno-c++11-narrowing")
 fi
 


### PR DESCRIPTION
A more accurate check to see if $CC is a clang compiler or not. Previous check doesn't work when $CC contains full clang path like /path/to/clang.

Also updated document to reflect that clang versions 7-10 are all verified.