### PR TITLE
Fix a syntax error in build_torch_xla_libs.sh

### DIFF
--- a/build_torch_xla_libs.sh
+++ b/build_torch_xla_libs.sh
@@ -26,7 +26,7 @@ if [[ "$XLA_CUDA" == "1" ]] && [[ "$CLOUD_BUILD" == "true" ]]; then
 fi
 
 OPTS=(--cxxopt="-std=c++14")
-if [ $(basename -- $CC) =~ ^clang ]; then
+if [[ $(basename -- $CC) =~ ^clang ]]; then
   OPTS+=(--cxxopt="-Wno-c++11-narrowing")
 fi
 


### PR DESCRIPTION
Tested locally:

+ OPTS=(--cxxopt="-std=c++14")
++ basename -- /scratch/ycao/clang/bin/clang
+ [[ clang =~ ^clang ]]
+ OPTS+=(--cxxopt="-Wno-c++11-narrowing")