### PR TITLE
Support building for different Operating Systems, from your scripts

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -23,10 +23,18 @@ else
   pip install mkl pyyaml
 fi
 
-SCCACHE="$(which sccache)"
+SCCACHE="$(command -v sccache)"
+if [ -z "${SCCACHE}" ]; then
+  SCCACHE_VERSION='0.2.13'
+  target='/tmp/sccache-x86_64-unknown-linux-musl.tar.gz'
+  curl -L 'https://github.com/mozilla/sccache/releases/download/'"$SCCACHE_VERSION"'/sccache-'"$SCCACHE_VERSION"'-x86_64-unknown-linux-musl.tar.gz' -o "$target"
+  sudo tar --strip-components 1 -C '/usr/local/bin' -xvzf '/tmp/sccache-x86_64-unknown-linux-musl.tar.gz' 'sccache-'"$SCCACHE_VERSION"'-x86_64-unknown-linux-musl/sccache'
+fi
+
+SCCACHE="$(command -v sccache)"
 if [ -z "${SCCACHE}" ]; then
   echo "Unable to find sccache..."
-  exit 1
+  >&2 exit 1
 fi
 
 if which sccache > /dev/null; then
@@ -48,7 +56,7 @@ if ! git config --global --get user.email; then
   git config --global user.name "CircleCI"
 fi
 
-eval "${SUDO}"' '"${PKG_MGR_EXEC}"' install jq curl'
+eval "${SUDO}"' '"${PKG_MGR_EXEC}"' '"${PKG_MGR_INSTALL_CMD}"' jq curl'
 
 # Only rebase on runs triggered by PR checks not post-submits.
 if [[ -z "${CIRCLE_PROJECT_USERNAME-}" && ! -z "${CIRCLE_PULL_REQUEST-}" ]]; then

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -20,7 +20,7 @@ else
   source "$VENV"'/bin/activate'
   pip install -U pip
   pip install -U setuptools wheel
-  pip install mkl
+  pip install mkl pyyaml
 fi
 
 SCCACHE="$(which sccache)"

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -84,7 +84,7 @@ python setup.py build develop
 sccache --show-stats
 
 # Bazel doesn't work with sccache gcc. https://github.com/bazelbuild/bazel/issues/3642
-if ! comamnd -v node; then
+if ! command -v node; then
   curl -L https://git.io/n-install | bash -s -- -y lts
   export PATH="$PATH:$HOME/n/bin"
   NPM_SUDO=0

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -9,6 +9,11 @@ function setup_env() {
 
 function clone_pytorch() {
   setup_env
-  git clone --quiet https://github.com/pytorch/pytorch.git "$PYTORCH_DIR"
-  cp -r "$PWD" "$XLA_DIR"
+    
+  if [ -d "$PYTORCH_DIR"'/.git' ]; then
+    GIT_DIR="$PYTORCH_DIR"'/.git' GIT_WORK_TREE="$PYTORCH_DIR" git pull
+  else
+    git clone --quiet --depth=10 https://github.com/pytorch/pytorch "$PYTORCH_DIR"
+    cp -r "$PWD" "$XLA_DIR"
+  fi
 }

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -ex
+set -euo pipefail
 
 function setup_env() {
-  export PYTORCH_DIR=/tmp/pytorch
-  export XLA_DIR="$PYTORCH_DIR/xla"
+  export PYTORCH_DIR='/tmp/pytorch'
+  export XLA_DIR="$PYTORCH_DIR"'/xla'
 }
 
 function clone_pytorch() {

--- a/.circleci/doc_push.sh
+++ b/.circleci/doc_push.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/.circleci/doc_push.sh
+++ b/.circleci/doc_push.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -euo pipefail
 
 cd /tmp/pytorch/xla
 

--- a/.circleci/install_deps.sh
+++ b/.circleci/install_deps.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+declare -r REPO_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
+
+source "$REPO_ROOT"'/.circleci/pkg_mgr.sh'
+
+function pkg_names() {
+    case "$PKG_MGR" in
+        brew) PKGS='git sccache gnu-sed python@3' ;;
+        apt-get) PKGS='git build-essential python3-dev python3 python3-venv' ;;
+    esac
+}
+
+pkg_names
+eval "${SUDO}"' '"${PKG_MGR_EXEC}"' install '"${PKGS}"

--- a/.circleci/install_deps.sh
+++ b/.circleci/install_deps.sh
@@ -8,10 +8,11 @@ source "$REPO_ROOT"'/.circleci/pkg_mgr.sh'
 
 function pkg_names() {
     case "$PKG_MGR" in
-        brew) PKGS='git sccache gnu-sed python@3' ;;
-        apt-get) PKGS='git build-essential python3-dev python3 python3-venv' ;;
+        brew) PKGS='git sccache gnu-sed python@3 cmake' ;;
+        apt-get) PKGS='git build-essential python3-dev python3 python3-venv cmake' ;;
     esac
 }
 
 pkg_names
 eval "${SUDO}"' '"${PKG_MGR_EXEC}"' install '"${PKGS}"
+eval "${SUDO}"' '"${PKG_MGR_EXEC}"' '"${PKG_MGR_INSTALL_CMD}"' '"${PKGS}"

--- a/.circleci/pkg_mgr.sh
+++ b/.circleci/pkg_mgr.sh
@@ -2,8 +2,11 @@
 
 function get_pkg_mgr() {
   export SUDO='sudo '
+  export PKG_MGR_INSTALL_CMD='install'
+
   if PKG_MGR_EXEC="$(command -v apt-get 2>/dev/null)"; then
     export PKG_MGR='apt-get'
+    export PKG_MGR_INSTALL_CMD='install -y'
   elif PKG_MGR_EXEC="$(command -v dnf 2>/dev/null)"; then
     export PKG_MGR='dnf'
   elif PKG_MGR_EXEC="$(command -v zypper 2>/dev/null)"; then

--- a/.circleci/pkg_mgr.sh
+++ b/.circleci/pkg_mgr.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+
+function get_pkg_mgr() {
+  export SUDO='sudo '
+  if PKG_MGR_EXEC="$(command -v apt-get 2>/dev/null)"; then
+    export PKG_MGR='apt-get'
+  elif PKG_MGR_EXEC="$(command -v dnf 2>/dev/null)"; then
+    export PKG_MGR='dnf'
+  elif PKG_MGR_EXEC="$(command -v zypper 2>/dev/null)"; then
+    export PKG_MGR='zypper'
+  elif PKG_MGR_EXEC="$(command -v pacman 2>/dev/null)"; then
+    export PKG_MGR='pacman'
+  elif PKG_MGR_EXEC="$(command -v port 2>/dev/null)"; then
+    export PKG_MGR='port'
+    export SUDO=''
+  elif PKG_MGR_EXEC="$(command -v brew 2>/dev/null)"; then
+    export PKG_MGR='brew'
+    export SUDO=''
+  fi
+  export PKG_MGR_EXEC="$PKG_MGR_EXEC"
+}
+
+get_pkg_mgr

--- a/.circleci/setup_ci_environment.sh
+++ b/.circleci/setup_ci_environment.sh
@@ -1,4 +1,7 @@
-set -e
+#!/usr/bin/env bash
+
+set -euo pipefail
+
 pyenv local 3.5.2
 pip install --upgrade pip
 pip install pyyaml -qqq
@@ -67,4 +70,3 @@ if [ -n "${USE_CUDA_DOCKER_RUNTIME:-}" ]; then
   sudo /bin/bash "$DRIVER_FN" -s --no-drm || (sudo cat /var/log/nvidia-installer.log && false)
   nvidia-smi
 fi
-

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -euo pipefail
 
 source ./xla_env
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The following tutorials are available to help you train models on a single
 Cloud TPU:
 
 * [Training FairSeq Transformer on Cloud TPUs](https://cloud.google.com/tpu/docs/tutorials/transformer-pytorch)
-* [Training Resnet50 on Cloud TPUs](https://cloud.google.com/tpu/docs/tutorials/resnet-alpha-py)
+* [Training Resnet50 on Cloud TPUs](https://cloud.google.com/tpu/docs/tutorials/resnet-pytorch)
 
 To start, [you create a Cloud TPU node](https://cloud.google.com/tpu/docs/tutorials/resnet-alpha-py#create_tpu) with the corresponding release you wish to consume (TPU software version: ex. `pytorch-1.5`):
 

--- a/build_torch_xla_libs.sh
+++ b/build_torch_xla_libs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -euo pipefail
 
 CMD="${1:-install}"
 

--- a/docker/common.sh
+++ b/docker/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function run_deployment_tests() {
   export XRT_DEVICE_MAP="CPU:0;/job:localservice/replica:0/task:0/device:XLA_CPU:0"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Explicitly source bashrc even when running commands directly.
 # Since commands run as a separate subshell, we need to source manually.

--- a/scripts/apply_patches.sh
+++ b/scripts/apply_patches.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/scripts/apply_patches.sh
+++ b/scripts/apply_patches.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -euo pipefail
 
 CDIR="$(cd "$(dirname "$0")" ; pwd -P)"
 XDIR=$CDIR/..

--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e  # Fail on any error.
 set -x  # Display commands being run.

--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e  # Fail on any error.
+set -euo pipefail
 set -x  # Display commands being run.
 
 PYTHON_VERSION=$1

--- a/scripts/generate_code.sh
+++ b/scripts/generate_code.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CDIR="$(cd "$(dirname "$0")" ; pwd -P)"
 XDIR="$CDIR/.."

--- a/scripts/update_nightly_torch_wheels.sh
+++ b/scripts/update_nightly_torch_wheels.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/scripts/update_nightly_torch_wheels.sh
+++ b/scripts/update_nightly_torch_wheels.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-set -e
-set -x
+
+set -euo pipefail
 
 # Activate torch-xla-nightly conda env if not already in it
 if [ "$CONDA_DEFAULT_ENV" != "torch-xla-nightly" ]; then

--- a/scripts/update_torch_wheels.sh
+++ b/scripts/update_torch_wheels.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/scripts/update_torch_wheels.sh
+++ b/scripts/update_torch_wheels.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-set -e
-set -x
+
+set -euo pipefail
 
 DIST_BUCKET="gs://tpu-pytorch/wheels"
 TORCH_WHEEL="torch-nightly-cp36-cp36m-linux_x86_64.whl"

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 RUNDIR="$(cd "$(dirname "$0")" ; pwd -P)"
 BUILDDIR="$RUNDIR/build"

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -euo pipefail
 RUNDIR="$(cd "$(dirname "$0")" ; pwd -P)"
 BUILDDIR="$RUNDIR/build"
 BUILDTYPE="Release"

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -exo pipefail
 CDIR="$(cd "$(dirname "$0")" ; pwd -P)"
 LOGFILE=/tmp/pytorch_py_test.log


### PR DESCRIPTION
Your README.md contains no guide on how to build xla. So I have begun retrofitting your CircleCI scripts to support running outside a CircleCI environment… and whilst I'm there, added support for other OSs and Linux distributions.

Various Linux distributions and macOS should be straightforward. BSDs probably don't matter due to their lack of good graphics support. Windows—BSD, and macOS for that matter—doesn't actually support TPUs AFAIK, so guess that doesn't matter either for the shell scripts.

Want me to update the CircleCI config to build for other OSs?

The latest commit works fine on macOS, just run `build.sh` and it'll mostly succeed. I'm currently—as of 810e255—stuck on this one error, at the last `python setup.py install` of `build.sh` (got to the same point on Debian with f3f8fbc):
```
/tmp/pytorch/xla /tmp/pytorch ~/repos/xla
Building torch_xla version: 1.6
XLA Commit ID: aa084dee304d6217a2bf0e18e2db48c0c37b5a98
PyTorch Commit ID: 502ec8f7f76619e6cbb1efb0e23eb8c5438daed2
/private/tmp/pytorch/xla/scripts/gen.py:16: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
  if isinstance(default_values, collections.Mapping):
Extracted 1398 functions (0 errors) from /private/tmp/pytorch/xla/scripts/../../torch/csrc/autograd/generated/RegistrationDeclarations.h
352 function overrides in /private/tmp/pytorch/xla/scripts/../torch_xla/csrc/aten_xla_type.h
Generated 1398 wrappers for /private/tmp/pytorch/xla/scripts/../../torch/csrc/autograd/generated/RegistrationDeclarations.h
/private/tmp/pytorch/xla
cp: cannot create directory '/private/tmp/pytorch/xla/third_party/tensorflow/tensorflow/compiler/xla/': No such file or directory
Failed to build external libraries: ['/private/tmp/pytorch/xla/build_torch_xla_libs.sh', 'install']
```