### PR TITLE
Store CUDA wheels separately

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Use nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04 or later for CUDA.
+# Use nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04 or later for CUDA.
 # Warning: All ARGs placed before FROM will only be scoped up unitl FROM statement.
 # https://github.com/docker/cli/blob/3c7ede6a68941f64c3a154c9a753eb7a9b1c2c3e/docs/reference/builder.md#understand-how-arg-and-from-interact
 ARG base_image="debian:stretch"

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -33,10 +33,14 @@ substitutions:
     _PYTHON_VERSION: '3.6'
     _RELEASE_VERSION: 'nightly'  # or rX.Y
     _IMAGE_NAME: '${_RELEASE_VERSION}_${_PYTHON_VERSION}'
+    _UPLOAD_SUBDIR: ''
 options:
     machineType: 'N1_HIGHCPU_32'
+    dynamic_substitutions: true
+    substitution_option: 'ALLOW_LOOSE'
 timeout: 18000s
 artifacts:
   objects:
-    location: 'gs://tpu-pytorch/wheels'
+    # CUDA wheels exported under `wheels/cuda/<cuda_version>`
+    location: 'gs://tpu-pytorch/wheels/$_UPLOAD_SUBDIR'
     paths: ['/**/*.whl']


### PR DESCRIPTION
Ran e2e test release and wheels exported under `gs://tpu-pytorch/wheels/cuda/101/` properly.