### PR TITLE
Disable TestGroupNormBackward on CPU DeviceType

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -1492,18 +1492,18 @@ TEST_F(AtenXlaTensorTest, TestGroupNormBackward) {
             /*cudnn_enabled=*/false);
       };
       torch::Tensor undef;
-      ForEachDevice({DeviceType::GPU, DeviceType::TPU}, [&](const torch::Device& device) {
+      ForEachDevice({DeviceType::GPU, DeviceType::TPU},
+                    [&](const torch::Device& device) {
         TestBackward(
             {input, undef_weight ? undef : weight, undef_weight ? undef : bias},
             device, testfn,
             /*rtol=*/1e-3, /*atol=*/1e-4);
+        ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+        ExpectCounterChanged("xla::native_group_norm",
+                             cpp_test::GetIgnoredCounters());
+        ExpectCounterChanged("xla::native_group_norm_backward",
+                             cpp_test::GetIgnoredCounters());
       });
-
-      ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-      ExpectCounterChanged("xla::native_group_norm",
-                           cpp_test::GetIgnoredCounters());
-      ExpectCounterChanged("xla::native_group_norm_backward",
-                           cpp_test::GetIgnoredCounters());
     }
   }
 }

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -1492,7 +1492,7 @@ TEST_F(AtenXlaTensorTest, TestGroupNormBackward) {
             /*cudnn_enabled=*/false);
       };
       torch::Tensor undef;
-      ForEachDevice([&](const torch::Device& device) {
+      ForEachDevice({DeviceType::GPU, DeviceType::TPU}, [&](const torch::Device& device) {
         TestBackward(
             {input, undef_weight ? undef : weight, undef_weight ? undef : bias},
             device, testfn,

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -1492,18 +1492,18 @@ TEST_F(AtenXlaTensorTest, TestGroupNormBackward) {
             /*cudnn_enabled=*/false);
       };
       torch::Tensor undef;
-      ForEachDevice({DeviceType::GPU, DeviceType::TPU},
-                    [&](const torch::Device& device) {
-        TestBackward(
-            {input, undef_weight ? undef : weight, undef_weight ? undef : bias},
-            device, testfn,
-            /*rtol=*/1e-3, /*atol=*/1e-4);
-        ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-        ExpectCounterChanged("xla::native_group_norm",
-                             cpp_test::GetIgnoredCounters());
-        ExpectCounterChanged("xla::native_group_norm_backward",
-                             cpp_test::GetIgnoredCounters());
-      });
+      ForEachDevice(
+          {DeviceType::GPU, DeviceType::TPU}, [&](const torch::Device& device) {
+            TestBackward({input, undef_weight ? undef : weight,
+                          undef_weight ? undef : bias},
+                         device, testfn,
+                         /*rtol=*/1e-3, /*atol=*/1e-4);
+            ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+            ExpectCounterChanged("xla::native_group_norm",
+                                 cpp_test::GetIgnoredCounters());
+            ExpectCounterChanged("xla::native_group_norm_backward",
+                                 cpp_test::GetIgnoredCounters());
+          });
     }
   }
 }


### PR DESCRIPTION
The previous tensorflow update (https://github.com/pytorch/xla/commit/62eb0b1ca5c9932a6ca63778b4618e58f1b5d357) appears to have caused a 30+ minute runtime regression on the CPU test for AtenXlaTensorTest.TestGroupNormBackward. Because a forward fix is unknown at this time, disable the test for CPU devices in CircleCI.

Test plan: check that the runtime of pytorch_xla_linux_bionic_py3_6_clang9_CPU_test_and_push_doc does not exceed 1.5 hours.