### PR TITLE
disable_test_scatter_add_non_unique_index_xla

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -285,6 +285,7 @@ DISABLED_TORCH_TESTS_TPU_ONLY = {
         'test_block_diag_scipy',  # failed to handle np.complex128 as input to tensor.
         'test_remainder_fmod_large_dividend_xla',  # precision, remainder with 1e9 gives incorrect answer
         'test_logical_not_out_xla',  # constant with type f16 and f64 is not supported
+        'test_scatter_add_non_unique_index_xla',  # Ran out of memory in memory space vmem
     },
 
     # test_indexing.py


### PR DESCRIPTION
test_scatter_add_non_unique_index_xla is currently failing on TPU with message `(1) Resource exhausted: Ran out of memory in memory space vmem. It should not be possible to run out of vmem - please file a bug against XLA`.  It is doing a scatter add with 2 tensor of size [2, 65536]. I managed to get it pass with size [2, 2000]. Disable the test while waiting for XLA team to take a look.