### PR TITLE
[WIP]Implement the lowering of unfold, working on backward

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -81,6 +81,7 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_bincount',
         'test_view_all_dtypes_and_devices',  # uses half
         'test_unfold_all_devices_and_dtypes',  # uses half
+        'test_unfold_scalars_xla',  # treat scalar as tensor
         'test_tensor_pow_tensor',  # lowering
         'test_tensor_factories_empty',  # uses half
         'test_symeig',

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -663,6 +663,19 @@ class TestSelect(XlaTestCase):
     self.assertEqual(tx, sx.data.cpu())
 
 
+class TestUnfold(XlaTestCase):
+
+  def test_unfold(self):
+    x = _gen_tensor(5, 6, 7, device=xm.xla_device())
+    t = x.data.cpu()
+    for dim in [-1, 0, 2]:
+      for size in [2, 4]:
+        for step in [1, 2, 3]:
+          sx = x.unfold(dim, size, step)
+          tx = t.unfold(dim, size, step)
+          self.assertEqual(tx, sx.data.cpu())
+
+
 class TestDynamicShape(XlaTestCase):
 
   def test_nonzero_shape(self):

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3113,6 +3113,13 @@ std::vector<at::Tensor> AtenXlaType::unbind(const at::Tensor& self,
       XLATensor::unbind(bridge::GetXlaTensor(self), dim));
 }
 
+at::Tensor AtenXlaType::unfold(const at::Tensor& self, int64_t dimension,
+                               int64_t size, int64_t step) {
+  XLA_FN_COUNTER("xla::");
+  return bridge::AtenFromXlaTensor(
+      XLATensor::unfold(bridge::GetXlaTensor(self), dimension, size, step));
+}
+
 at::Tensor& AtenXlaType::uniform_(at::Tensor& self, double from, double to,
                                   c10::optional<at::Generator> generator) {
   XLA_FN_COUNTER("xla::");

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -1002,6 +1002,9 @@ class AtenXlaType {
 
   static std::vector<at::Tensor> unbind(const at::Tensor& self, int64_t dim);
 
+  static at::Tensor unfold(const at::Tensor& self, int64_t dimension,
+                           int64_t size, int64_t step);
+
   static at::Tensor& uniform_(at::Tensor& self, double from, double to,
                               c10::optional<at::Generator> generator);
 

--- a/torch_xla/csrc/data_ops.h
+++ b/torch_xla/csrc/data_ops.h
@@ -84,6 +84,9 @@ xla::XlaOp BuildResize(xla::XlaOp input, absl::Span<const xla::int64> size);
 xla::XlaOp BuildUnselect(xla::XlaOp target, xla::XlaOp source, xla::int64 dim,
                          xla::int64 start, xla::int64 end, xla::int64 stride);
 
+xla::XlaOp BuildUnfold(xla::XlaOp input, xla::int64 dimension, xla::int64 size,
+                       xla::int64 step);
+
 xla::XlaOp BuildReflectionPad2d(xla::XlaOp input,
                                 absl::Span<const xla::int64> padding);
 

--- a/torch_xla/csrc/ops/unfold.cpp
+++ b/torch_xla/csrc/ops/unfold.cpp
@@ -1,0 +1,51 @@
+#include "torch_xla/csrc/ops/unfold.h"
+
+#include "absl/strings/str_join.h"
+#include "tensorflow/compiler/xla/xla_client/debug_macros.h"
+#include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch_xla/csrc/data_ops.h"
+#include "torch_xla/csrc/lowering_context.h"
+#include "torch_xla/csrc/ops/infer_output_shape.h"
+
+namespace torch_xla {
+namespace ir {
+namespace ops {
+
+xla::Shape NodeOutputShape(const Value& input, xla::int64 dimension,
+                           xla::int64 size, xla::int64 step) {
+  auto lower_for_shape_fn =
+      [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
+    return BuildUnfold(operands[0], dimension, size, step);
+  };
+  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+}
+
+Unfold::Unfold(const Value& input, xla::int64 dimension, xla::int64 size,
+               xla::int64 step)
+    : Node(ir::OpKind(at::aten::unfold), {input},
+           [&]() { return NodeOutputShape(input, dimension, size, step); },
+           /*num_outputs=*/1, xla::util::MHash(dimension, size, step)),
+      dimension_(dimension),
+      size_(size),
+      step_(step) {}
+
+NodePtr Unfold::Clone(OpList operands) const {
+  return MakeNode<Unfold>(operands.at(0), dimension_, size_, step_);
+}
+
+XlaOpVector Unfold::Lower(LoweringContext* loctx) const {
+  xla::XlaOp input = loctx->GetOutputOp(operand(0));
+  xla::XlaOp output = BuildUnfold(input, dimension_, size_, step_);
+  return ReturnOp(output, loctx);
+}
+
+std::string Unfold::ToString() const {
+  std::stringstream ss;
+  ss << Node::ToString() << ", dimension=" << dimension_ << ", size=" << size_
+     << ", step=" << step_;
+  return ss.str();
+}
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/unfold.h
+++ b/torch_xla/csrc/ops/unfold.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "torch_xla/csrc/ir.h"
+
+namespace torch_xla {
+namespace ir {
+namespace ops {
+
+class Unfold : public Node {
+ public:
+  Unfold(const Value& input, xla::int64 dimension, xla::int64 size,
+         xla::int64 step);
+
+  NodePtr Clone(OpList operands) const override;
+
+  XlaOpVector Lower(LoweringContext* loctx) const override;
+
+  std::string ToString() const override;
+
+  xla::int64 dimension() const { return dimension_; }
+
+  xla::int64 size() const { return size_; }
+
+  xla::int64 step() const { return step_; }
+
+ private:
+  xla::int64 dimension_;
+  xla::int64 size_;
+  xla::int64 step_;
+};
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -1070,6 +1070,9 @@ class XLATensor {
   // removed.
   static std::vector<XLATensor> unbind(const XLATensor& input, xla::int64 dim);
 
+  static XLATensor unfold(const XLATensor& input, int64_t dimension,
+                          int64_t size, int64_t step);
+
   static void uniform_(XLATensor& input, double from, double to);
 
   // Insert a dimension of size one at the specified position.


### PR DESCRIPTION
Per request in https://github.com/pytorch/xla/issues/2239
I plan to add the lowering of the unfold_backward in a separate pr.

Pytorch does not expose the `torch::unfold` nor `at::unfold` c++ api and we disabled couple existing `unfold` python tests for different reasons (treat scalar as 1d tensor, test tensor with couple dimension size ==0 and test the unfold as a view tensor ), adding a python test to increase the coverage.

The high level idea is using the convolution with masks with single `1` to extract elements efficiently. 

python tests now passed on CPU, running on TPU to verify


