### PR TITLE
Dsiable test_clamp_propagates_nans_xla

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -34,6 +34,7 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_addmm_sizes',  # FIXME: very slow compile
         'test_addcmul',  # FIXME: complex dtype
         'test_clamp',  # slow
+        'test_clamp_propagates_nans_xla',  # XLA min/max ignores Nans.
         'test_lu_unpack',  # very slow compile
         'test_view',  # doesn't raise
         'test_sub_typing',  # doesn't raise


### PR DESCRIPTION
This is to unblock https://github.com/pytorch/pytorch/pull/32587

XLA clamp always returns min if the input is nan, my small repo
```
import torch                                                                                                                                                                                                                                         
import torch.nn as nn                                                                                                                                                                                                                                
import torch_xla                                                                                                                                                                                                                                     
import torch_xla.core.xla_model as xm                                                                                                                                                                                                                
from torch._six import inf, nan                                                                                                                                                                                                                      
xla_device = xm.xla_device()                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                     
t1 = torch.tensor((nan), device=xla_device)                                                                                                                                                                                                          
print(t1.clamp(-1, 1))                                                                                                                                                                                                                               
print(t1.cpu().clamp(-1, 1))                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                     
min_val = torch.tensor(-1, device=xla_device)                                                                                                                                                                                                        
max_val = torch.tensor(1, device=xla_device)                                                                                                                                                                                                         
print(t1.clamp(min_val, max_val))                                                                                                                                                                                                                    
print(t1.cpu().clamp(min_val.cpu(), max_val.cpu()))  
```
the result is
```
tensor(-1., device='xla:0')
tensor(nan)
tensor(nan, device='xla:0')
tensor(nan)
```
The reason that second `clamp` returns nan is that xla has not lower the `clamp_with_tensors` nodes added in the pr mentioned above so it calls pytorch implementation. This is a known xla behavior so I think I will disable this test on the XLA side.