### PR TITLE
Pad the input on transposed conv forward with output_padding

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -8606,7 +8606,7 @@ TEST_F(AtenXlaTensorTest, TestTransposedConv2DBackward) {
     for (int padding = 0; padding <= 1; ++padding) {
       for (int dilation = 1; dilation <= 2; ++dilation) {
         for (int output_padding = 0;
-             output_padding < std::min(stride, dilation); ++output_padding) {
+             output_padding < std::max(stride, dilation); ++output_padding) {
           for (bool with_bias : {true, false}) {
             for (int groups :
                  {1, 2, 4}) {  // covers normal, grouped, depthwise conv.
@@ -8693,7 +8693,7 @@ TEST_F(AtenXlaTensorTest, TestTransposedConv3DBackward) {
     for (int padding = 0; padding <= 1; ++padding) {
       for (int dilation = 1; dilation <= 2; ++dilation) {
         for (int output_padding = 0;
-             output_padding < std::min(stride, dilation); ++output_padding) {
+             output_padding < std::max(stride, dilation); ++output_padding) {
           for (bool with_bias : {true, false}) {
             for (int groups :
                  {1, 2, 4}) {  // covers normal, grouped, depthwise conv.

--- a/torch_xla/csrc/xla_lower_util.cpp
+++ b/torch_xla/csrc/xla_lower_util.cpp
@@ -304,9 +304,8 @@ xla::XlaOp PadToSize(xla::XlaOp input, absl::Span<const xla::int64> size,
     auto* dims = padding_config.add_dimensions();
     dims->set_edge_padding_low(0);
     dims->set_interior_padding(0);
-    XLA_CHECK_GE(size[i], input_shape.dimensions(i));
     dims->set_edge_padding_high(size[i] - input_shape.dimensions(i));
-    has_padding = has_padding || dims->edge_padding_high() > 0;
+    has_padding = has_padding || dims->edge_padding_high() != 0;
   }
   return has_padding ? xla::Pad(input, *pad_value, padding_config) : input;
 }


### PR DESCRIPTION
This pr is to solve the issue brought up in https://github.com/pytorch/xla/issues/2333.

On `transposed_conv_forward` we added `output_padding` to the output size. Therefore we also need to pad the input to match the output size and unpad the grad_input(on `transposed_conv_backward`) to make it match the input size.