### PR TITLE
Enable test_scatter_add_non_unique_index_xla on TPU

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -284,7 +284,6 @@ DISABLED_TORCH_TESTS_TPU_ONLY = {
         'test_block_diag_scipy',  # failed to handle np.complex128 as input to tensor.
         'test_remainder_fmod_large_dividend_xla',  # precision, remainder with 1e9 gives incorrect answer
         'test_logical_not_out_xla',  # constant with type f16 and f64 is not supported
-        'test_scatter_add_non_unique_index_xla',  # Ran out of memory in memory space vmem
     },
 
     # test_indexing.py


### PR DESCRIPTION
TPU side change went in, verified that test no longer error out with `Ran out of memory in memory space vmem`. Reenable the test.