### PR TITLE
Remove all_to_all and collective_permute from the official API.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,8 +16,6 @@ xla_model
 .. autofunction:: xrt_world_size
 .. autofunction:: all_reduce
 .. autofunction:: all_gather
-.. autofunction:: all_to_all
-.. autofunction:: collective_permute
 .. autofunction:: add_step_closure
 .. autofunction:: wait_device_ops
 .. autofunction:: optimizer_step

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -619,6 +619,9 @@ def all_to_all(value,
                groups=None):
   """Performs an XLA `AllToAll()` operation on the input tensor.
 
+  WARNING: This function is not very reliable, may produce wrong results under
+           certain inputs. Use it at your own risk.
+
   See: https://www.tensorflow.org/xla/operation_semantics#alltoall
 
   Args:
@@ -645,6 +648,9 @@ def all_to_all(value,
 
 def collective_permute(value, pairs):
   """Performs a XLA `CollectivePermute()` operation on the input tensor.
+
+  WARNING: This function is not very reliable, may produce wrong results under
+           certain inputs. Use it at your own risk.
 
   See: https://www.tensorflow.org/xla/operation_semantics#collectivepermute
 


### PR DESCRIPTION
- Removed from the official docs.
- Keep the functions, but added a discouraging note in the docstring.