### PR TITLE
Disable CXX 11 ABI when building wheels

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -8,6 +8,9 @@ source .circleci/common.sh
 # System default cmake 3.10 cannot find mkl, so point it to the right place.
 export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}
 
+# Disable the use of CXX 11 ABI to avoid symbol mismatch with `libxla_computation_client.so`
+export CFLAGS="${CFLAGS} -D_GLIBCXX_USE_CXX11_ABI=0" CXXFLAGS="${CXXFLAGS} -D_GLIBCXX_USE_CXX11_ABI=0"
+
 SCCACHE="$(which sccache)"
 if [ -z "${SCCACHE}" ]; then
   echo "Unable to find sccache..."

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -8,9 +8,6 @@ source .circleci/common.sh
 # System default cmake 3.10 cannot find mkl, so point it to the right place.
 export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}
 
-# Disable the use of CXX 11 ABI to avoid symbol mismatch with `libxla_computation_client.so`
-export CFLAGS="${CFLAGS} -D_GLIBCXX_USE_CXX11_ABI=0" CXXFLAGS="${CXXFLAGS} -D_GLIBCXX_USE_CXX11_ABI=0"
-
 SCCACHE="$(which sccache)"
 if [ -z "${SCCACHE}" ]; then
   echo "Unable to find sccache..."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,10 @@ launch_docker_and_build: &launch_docker_and_build
     echo "declare -x CIRCLE_PROJECT_USERNAME=${CIRCLE_PROJECT_USERNAME}" >> /home/circleci/project/env
     echo "declare -x CIRCLE_PROJECT_REPONAME=${CIRCLE_PROJECT_REPONAME}" >> /home/circleci/project/env
 
+    # Disable the use of CXX 11 ABI to avoid symbol mismatch with `libxla_computation_client.so`
+    echo "declare -x CFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0" >> /home/circleci/project/env
+    echo "declare -x CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0" >> /home/circleci/project/env
+
     pid=$(docker run -t -d -w $WORKDIR ${DOCKER_IMAGE})
     docker cp /home/circleci/project/. "$pid:$WORKDIR"
     docker exec -u jenkins ${pid} sudo chown -R jenkins ${WORKDIR}

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -2,6 +2,7 @@
 
 set -ex
 
+source ./env
 source ./xla_env
 
 if [ -x "$(command -v nvidia-smi)" ]; then

--- a/build_torch_xla_libs.sh
+++ b/build_torch_xla_libs.sh
@@ -43,8 +43,8 @@ else
   cp -r -u -p $THIRD_PARTY_DIR/xla_client $THIRD_PARTY_DIR/tensorflow/tensorflow/compiler/xla/
 
   pushd $THIRD_PARTY_DIR/tensorflow
-  bazel build $MAX_JOBS $VERBOSE --define framework_shared_object=false -c "$MODE" "${OPTS[@]}" $XLA_CUDA_CFG \
-    //tensorflow/compiler/xla/xla_client:libxla_computation_client.so
+  bazel build $MAX_JOBS $VERBOSE --define framework_shared_object=false -c "$MODE" --copt="-D_GLIBCXX_USE_CXX11_ABI=0" \
+    "${OPTS[@]}" $XLA_CUDA_CFG //tensorflow/compiler/xla/xla_client:libxla_computation_client.so
 
   popd
   mkdir -p torch_xla/lib

--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -211,9 +211,14 @@ function main() {
   install_req_packages
   install_llvm_clang
   install_and_setup_conda
+
+  # Upstream PyTorch is released with CXX11 ABI disabled
+  # so to avoid symbol mismatch errors we must do the same.
+  export CFLAGS="${CFLAGS} -D_GLIBCXX_USE_CXX11_ABI=0" CXXFLAGS="${CXXFLAGS} -D_GLIBCXX_USE_CXX11_ABI=0"
   build_and_install_torch
   pushd xla
   build_and_install_torch_xla
+
   popd
   install_torchvision_from_source
   install_gcloud


### PR DESCRIPTION
Upstream vanilla torch wheels are built and released without CXX 11 ABI
as they support RHEL7 distro. Without this we get symbols with CXX 11
ABI and symbols from `_XLAC` not found errors.