### PR TITLE
Remove hacky copy_ registration & added a backward test for einsum.

### DIFF
--- a/scripts/gen.py
+++ b/scripts/gen.py
@@ -80,7 +80,7 @@ _PARSER = lark.Lark(_GRAMMAR, parser='lalr', propagate_positions=True)
 _XPARSER = lark.Lark(
     _GRAMMAR, parser='lalr', propagate_positions=True, keep_all_tokens=True)
 
-# _FN_WHITELIST/_FN_FULL_OVERRIDE/_FN_BLACKLIST takes either name or mapsig.
+# _FN_FULL_OVERRIDE/_FN_FULL_OVERRIDE/_FN_BLACKLIST takes either name or mapsig.
 _FN_BLACKLIST = set([])
 
 # List of non-leaf ops we want to override both forward + backward.
@@ -88,12 +88,6 @@ _FN_BLACKLIST = set([])
 _FN_FULL_OVERRIDE = set([
     'max_pool2d(Tensor, IntArrayRef, IntArrayRef, IntArrayRef, IntArrayRef, bool) -> Tensor',
     'max_pool3d(Tensor, IntArrayRef, IntArrayRef, IntArrayRef, IntArrayRef, bool) -> Tensor',
-])
-
-# List of non-leaf ops we want to override forward.
-# TODO(#1362, #1364)
-_FN_WHITELIST = _FN_FULL_OVERRIDE | set([
-    'copy_(Tensor, Tensor, bool) -> Tensor',
 ])
 
 _FN_BLACKLIST_REGEX = [
@@ -1033,7 +1027,7 @@ TORCH_LIBRARY_IMPL(aten, XLAPreAutograd, m) {
 
 # XLA is only able to override leaf ops and whitelisted non-leaf ops.
 def is_overrideable(fgen):
-  return fgen.leaf or fgen.mapsig in _FN_WHITELIST or fgen.func in _FN_WHITELIST
+  return fgen.leaf or fgen.mapsig in _FN_FULL_OVERRIDE or fgen.func in _FN_FULL_OVERRIDE
 
 
 def generate_functions(fgens):

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -261,9 +261,6 @@ class AtenXlaType {
       at::IntArrayRef padding, at::IntArrayRef dilation, bool transposed,
       at::IntArrayRef output_padding, int64_t groups);
 
-  static at::Tensor& copy_(at::Tensor& self, const at::Tensor& src,
-                           bool non_blocking);
-
   static at::Tensor cos(const at::Tensor& self);
 
   static at::Tensor& cos_(at::Tensor& self);


### PR DESCRIPTION
fixes https://github.com/pytorch/xla/issues/1362
After https://github.com/pytorch/pytorch/pull/42386 we no longer need to register a hacky `copy_` and `_copy_from` is properly device dispatch point for us.
Also added a backward einsum test (not very important). 