### PR TITLE
Cherrypick fix for DLRM real dataset crash

### DIFF
--- a/third_party/xla_client/multi_wait.cc
+++ b/third_party/xla_client/multi_wait.cc
@@ -7,13 +7,9 @@ namespace xla {
 namespace util {
 
 void MultiWait::Done() {
-  bool notify = false;
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    completed_count_ += 1;
-    notify = completed_count_ >= count_;
-  }
-  if (notify) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  completed_count_ += 1;
+  if (completed_count_ == count_) {
     cv_.notify_all();
   }
 }

--- a/third_party/xla_client/multi_wait.h
+++ b/third_party/xla_client/multi_wait.h
@@ -43,6 +43,8 @@ class MultiWait {
                                          std::function<void()> func);
 
  private:
+  void Complete(const std::function<void()>& func);
+
   std::mutex mutex_;
   std::condition_variable cv_;
   size_t count_ = 0;

--- a/third_party/xla_client/multi_wait.h
+++ b/third_party/xla_client/multi_wait.h
@@ -3,6 +3,7 @@
 
 #include <condition_variable>
 #include <functional>
+#include <memory>
 #include <mutex>
 
 #include "tensorflow/compiler/xla/types.h"
@@ -31,8 +32,15 @@ class MultiWait {
 
   // Creates a completer functor which signals the mult wait object once func
   // has completed. Handles exceptions by signaling the multi wait with the
-  // proper status value.
+  // proper status value. This API returns a function which captures a MultiWait
+  // reference, so care must be taken such that the reference remains valid for
+  // the whole lifetime of the returned function.
   std::function<void()> Completer(std::function<void()> func);
+
+  // Similar as the above API, but with explicit capture of the MultiWait shared
+  // pointer.
+  static std::function<void()> Completer(std::shared_ptr<MultiWait> mwait,
+                                         std::function<void()> func);
 
  private:
   std::mutex mutex_;


### PR DESCRIPTION
Manifested in DLRM dataset, but not limited to specific model/dataset, so cherrypicking into r1.6.