### PR TITLE
New cloudbuild file for hourly image to use for debugging/bisection.

### DIFF
--- a/docker/debug_cloudbuild.yaml
+++ b/docker/debug_cloudbuild.yaml
@@ -1,0 +1,33 @@
+# Cloud Build Configuration which:
+# Builds and pushes gcr.io/tpu-pytorch/xla_debug image.
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: [
+          'build',
+          '--build-arg', 'base_image=${_DOCKER_BASE_IMAGE}',
+          '--build-arg', 'cuda=${_CUDA}',
+          '--build-arg', 'python_version=${_PYTHON_VERSION}',
+          '--build-arg', 'cloud_build=true',
+          '--build-arg', 'release_version=${_RELEASE_VERSION}',
+          '-t', 'gcr.io/tpu-pytorch/xla:${_IMAGE_NAME}',
+          '-f', 'docker/Dockerfile', '.'
+        ]
+  timeout: 14400s
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: bash
+  args: ['-c', 'docker tag gcr.io/tpu-pytorch/xla_debug:${_IMAGE_NAME}_$(date -u +%Y%m%d_%H_%M)']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['push', 'gcr.io/tpu-pytorch/xla_debug']
+  timeout: 1800s
+
+substitutions:
+    _DOCKER_BASE_IMAGE: 'debian:stretch'
+    _CUDA: '0'
+    _PYTHON_VERSION: '3.6'
+    _RELEASE_VERSION: 'nightly'  # or rX.Y
+    _IMAGE_NAME: '${_RELEASE_VERSION}_${_PYTHON_VERSION}'
+options:
+    machineType: 'N1_HIGHCPU_32'
+    dynamic_substitutions: true
+    substitution_option: 'ALLOW_LOOSE'
+timeout: 18000s

--- a/docker/debug_cloudbuild.yaml
+++ b/docker/debug_cloudbuild.yaml
@@ -9,7 +9,7 @@ steps:
           '--build-arg', 'python_version=${_PYTHON_VERSION}',
           '--build-arg', 'cloud_build=true',
           '--build-arg', 'release_version=${_RELEASE_VERSION}',
-          '-t', 'gcr.io/tpu-pytorch/xla:${_IMAGE_NAME}',
+          '-t', 'gcr.io/tpu-pytorch/xla_debug:${_IMAGE_NAME}',
           '-f', 'docker/Dockerfile', '.'
         ]
   timeout: 14400s


### PR DESCRIPTION
Pushing to `gcr.io/tpu-pytorch/xla_debug` so this should not disrupt our other tagged images under `gcr.io/tpu-pytorch/xla`.

Skip tests, skip pushing wheels, skip saving cuda artifacts. These docker images will be used for debugging and bisection and I plan on making a trigger+scheduler to trigger them every hour. I also plan to make a cloud scheduler to delete `xla_debug` images that are older than some number of days (maybe 60?)