### PR TITLE
.circleci: Make the grabbing of the docker tag dynamic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,15 @@ download_docker: &download_docker
     fi
     echo ${pid} > .docker_pid
 
+calculate_docker_image: &calculate_docker_image
+  name: Calculate docker image
+  command: |
+    git clone --quiet https://github.com/pytorch/pytorch.git "/tmp/pytorch"
+    # Just a quick smoke test to see if we can actually extract the tag
+    git -C /tmp/pytorch rev-parse HEAD:.circleci/docker
+    DOCKER_TAG=$(git -C /tmp/pytorch rev-parse HEAD:.circleci/docker)
+    echo "declare -x DOCKER_IMAGE=308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-cuda10.2-cudnn7-py3.6-clang9:${DOCKER_TAG}" >> "${BASH_ENV}"
+
 run_build: &run_build
   resource_class: xlarge
   machine:
@@ -76,6 +85,8 @@ run_build: &run_build
       <<: *update_submodule
   - run:
       <<: *setup_base_docker
+  - run:
+      <<: *calculate_docker_image
   - run:
       <<: *launch_docker_and_build
 
@@ -88,6 +99,8 @@ run_test: &run_test
       <<: *update_submodule
   - run:
       <<: *setup_base_docker
+  - run:
+      <<: *calculate_docker_image
   - run:
       <<: *download_docker
   - run:
@@ -105,6 +118,8 @@ run_test_and_push_doc: &run_test_and_push_doc
       <<: *update_submodule
   - run:
       <<: *setup_base_docker
+  - run:
+      <<: *calculate_docker_image
   - run:
       <<: *download_docker
   - run:

--- a/.circleci/setup_ci_environment.sh
+++ b/.circleci/setup_ci_environment.sh
@@ -2,10 +2,6 @@ set -e
 pyenv local 3.5.2
 pip install --upgrade pip
 pip install pyyaml -qqq
-# This corresponds to the output of $(git rev-parse HEAD:.circleci/docker) from the main pytorch repository
-DOCKER_TAG="ab1632df-fa59-40e6-8c23-98e004f61148"
-DOCKER_IMAGE="308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-cuda10.2-cudnn7-py3.6-clang9:${DOCKER_TAG}"
-echo "export DOCKER_IMAGE=${DOCKER_IMAGE}" >> $BASH_ENV
 echo "export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_FOR_ECR_READ_WRITE}" >> $BASH_ENV
 echo "export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY_FOR_ECR_READ_WRITE}" >> $BASH_ENV
 echo "export WORKDIR=/var/lib/jenkins/workspace" >> $BASH_ENV


### PR DESCRIPTION
upstream docker tags were changed to be based on the output of pytorch's
`git rev-parse HEAD:.circleci/docker` so we should calculate docker tags
here the same way since we want to use the most up to date upstream
image.

This is no guarantee that the image will actually be there, but if this
image is borked then upstream is most likely borked as well so we'll
just need to fix it all around.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>