### PR TITLE
Set the datetime tag in initial docker build rather than docker tag.

### DIFF
--- a/docker/debug_cloudbuild.yaml
+++ b/docker/debug_cloudbuild.yaml
@@ -9,13 +9,10 @@ steps:
           '--build-arg', 'python_version=${_PYTHON_VERSION}',
           '--build-arg', 'cloud_build=true',
           '--build-arg', 'release_version=${_RELEASE_VERSION}',
-          '-t', 'gcr.io/tpu-pytorch/xla_debug:${_IMAGE_NAME}',
+          '-t', 'gcr.io/tpu-pytorch/xla_debug:${_IMAGE_NAME}_$(date -u +%Y%m%d_%H_%M)',
           '-f', 'docker/Dockerfile', '.'
         ]
   timeout: 14400s
-- name: 'gcr.io/cloud-builders/docker'
-  entrypoint: bash
-  args: ['-c', 'docker tag gcr.io/tpu-pytorch/xla_debug:${_IMAGE_NAME}_$(date -u +%Y%m%d_%H_%M)']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'gcr.io/tpu-pytorch/xla_debug']
   timeout: 1800s


### PR DESCRIPTION
I don't see any use for the `xla_debug:nightly_3.6` tagged image. All we need are the datetime-tagged images.

Skip the `docker tag` and just do the datetime tagging in the `docker build` step