### PR TITLE
Fix debug_cloudbuild

### DIFF
--- a/docker/debug_cloudbuild.yaml
+++ b/docker/debug_cloudbuild.yaml
@@ -2,7 +2,7 @@
 # Builds and pushes gcr.io/tpu-pytorch/xla_debug image.
 steps:
 - name: 'ubuntu'
-  args: ['bash', '-c', 'echo ${_IMAGE_NAME)']
+  args: ['bash', '-c', 'echo ${_TAG_NAME)']
 - name: 'gcr.io/cloud-builders/docker'
   args: [
           'build',
@@ -11,7 +11,7 @@ steps:
           '--build-arg', 'python_version=${_PYTHON_VERSION}',
           '--build-arg', 'cloud_build=true',
           '--build-arg', 'release_version=${_RELEASE_VERSION}',
-          '-t', 'gcr.io/tpu-pytorch/xla_debug:${_IMAGE_NAME}',
+          '-t', 'gcr.io/tpu-pytorch/xla_debug:${_TAG_NAME}',
           '-f', 'docker/Dockerfile', '.'
         ]
   timeout: 14400s
@@ -28,5 +28,5 @@ substitutions:
     _CUDA: '0'
     _PYTHON_VERSION: '3.6'
     _RELEASE_VERSION: 'nightly'  # or rX.Y
-    _IMAGE_NAME: '${_RELEASE_VERSION}_${_PYTHON_VERSION}_$(date +%s)'
+    _TAG_NAME: '${_RELEASE_VERSION}_${_PYTHON_VERSION}'
 timeout: 18000s

--- a/docker/debug_cloudbuild.yaml
+++ b/docker/debug_cloudbuild.yaml
@@ -1,6 +1,8 @@
 # Cloud Build Configuration which:
 # Builds and pushes gcr.io/tpu-pytorch/xla_debug image.
 steps:
+- name: 'ubuntu'
+  args: ['bash', '-c', 'echo ${_IMAGE_NAME)']
 - name: 'gcr.io/cloud-builders/docker'
   args: [
           'build',
@@ -9,7 +11,7 @@ steps:
           '--build-arg', 'python_version=${_PYTHON_VERSION}',
           '--build-arg', 'cloud_build=true',
           '--build-arg', 'release_version=${_RELEASE_VERSION}',
-          '-t', 'gcr.io/tpu-pytorch/xla_debug:${_IMAGE_NAME}_$(date -u +%Y%m%d_%H_%M)',
+          '-t', 'gcr.io/tpu-pytorch/xla_debug:${_IMAGE_NAME}',
           '-f', 'docker/Dockerfile', '.'
         ]
   timeout: 14400s
@@ -17,14 +19,14 @@ steps:
   args: ['push', 'gcr.io/tpu-pytorch/xla_debug']
   timeout: 1800s
 
+options:
+    machineType: 'N1_HIGHCPU_32'
+    dynamic_substitutions: true
+    substitution_option: 'ALLOW_LOOSE'
 substitutions:
     _DOCKER_BASE_IMAGE: 'debian:stretch'
     _CUDA: '0'
     _PYTHON_VERSION: '3.6'
     _RELEASE_VERSION: 'nightly'  # or rX.Y
-    _IMAGE_NAME: '${_RELEASE_VERSION}_${_PYTHON_VERSION}'
-options:
-    machineType: 'N1_HIGHCPU_32'
-    dynamic_substitutions: true
-    substitution_option: 'ALLOW_LOOSE'
+    _IMAGE_NAME: '${_RELEASE_VERSION}_${_PYTHON_VERSION}_$(date -u +%Y%m%d_%H_%M)'
 timeout: 18000s

--- a/docker/debug_cloudbuild.yaml
+++ b/docker/debug_cloudbuild.yaml
@@ -1,8 +1,6 @@
 # Cloud Build Configuration which:
 # Builds and pushes gcr.io/tpu-pytorch/xla_debug image.
 steps:
-- name: 'ubuntu'
-  args: ['bash', '-c', 'echo ${_TAG_NAME)']
 - name: 'gcr.io/cloud-builders/docker'
   args: [
           'build',

--- a/docker/debug_cloudbuild.yaml
+++ b/docker/debug_cloudbuild.yaml
@@ -28,5 +28,5 @@ substitutions:
     _CUDA: '0'
     _PYTHON_VERSION: '3.6'
     _RELEASE_VERSION: 'nightly'  # or rX.Y
-    _IMAGE_NAME: '${_RELEASE_VERSION}_${_PYTHON_VERSION}_$(date -u +%Y%m%d_%H_%M)'
+    _IMAGE_NAME: '${_RELEASE_VERSION}_${_PYTHON_VERSION}_$(date +%s)'
 timeout: 18000s


### PR DESCRIPTION
Remove the `date` from bisection image tag. It was giving cloudbuild syntax issues and I won't actually use it for bisection. Each image already has a timestamp that can be seen when you run `gcloud container images list-tags gcr.io/...`

Ran manually using the trigger pointing to this branch and the build was able to start up and begin without previous syntax errors from the last version