### PR TITLE
Lower `aten::round` operator

### DIFF
--- a/scripts/gen.py
+++ b/scripts/gen.py
@@ -113,6 +113,7 @@ _FN_OUT = {
     'pow_out': FuncOpts(),
     'prod_out': FuncOpts(),
     'nonzero_out': FuncOpts(),
+    'round_out': FuncOpts(),
     'normal_out': FuncOpts(),
     'take_out': FuncOpts(),
     'true_divide_out': FuncOpts(),

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -2410,6 +2410,9 @@ TEST_F(AtenXlaTensorTest, TestRound) {
     torch::Tensor xla_b = torch::round(xla_a);
     AllClose(b, xla_b);
   });
+
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::round", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestTrunc) {

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -2397,6 +2397,21 @@ TEST_F(AtenXlaTensorTest, TestFloor) {
   });
 }
 
+TEST_F(AtenXlaTensorTest, TestRound) {
+  torch::Tensor a = torch::cat(
+      {torch::randn({8}, torch::TensorOptions(torch::kFloat)) * 100.0,
+       // Special case: 0.5, -0.5. xla::Round impl rounds to -1/1 whereas
+       // xla::RoundToEven properly implements bankers rounding.
+       torch::tensor({-0.5, 0.5}, torch::TensorOptions(torch::kFloat))},
+      0);
+  torch::Tensor b = torch::round(a);
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_a = CopyToDevice(a, device);
+    torch::Tensor xla_b = torch::round(xla_a);
+    AllClose(b, xla_b);
+  });
+}
+
 TEST_F(AtenXlaTensorTest, TestTrunc) {
   torch::Tensor a =
       torch::randn({2, 2}, torch::TensorOptions(torch::kFloat)) * 100.0;

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2592,6 +2592,19 @@ at::Tensor& AtenXlaType::resize_(
   return self;
 }
 
+at::Tensor AtenXlaType::round(const at::Tensor& self) {
+  XLA_FN_COUNTER("xla::");
+  return bridge::AtenFromXlaTensor(
+      XLATensor::round(bridge::GetXlaTensor(self)));
+}
+
+at::Tensor& AtenXlaType::round_(at::Tensor& self) {
+  XLA_FN_COUNTER("xla::");
+  XLATensor self_tensor = bridge::GetXlaTensor(self);
+  XLATensor::round_(self_tensor);
+  return self;
+}
+
 at::Tensor AtenXlaType::rrelu_with_noise(
     const at::Tensor& self, const at::Tensor& noise, at::Scalar lower,
     at::Scalar upper, bool training, c10::optional<at::Generator> generator) {

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -827,6 +827,10 @@ class AtenXlaType {
   static at::Tensor& resize_(at::Tensor& self, at::IntArrayRef size,
                              c10::optional<at::MemoryFormat> memory_format);
 
+  static at::Tensor round(const at::Tensor& self);
+
+  static at::Tensor& round_(at::Tensor& self);
+
   static at::Tensor rrelu_with_noise(const at::Tensor& self,
                                      const at::Tensor& noise, at::Scalar lower,
                                      at::Scalar upper, bool training,

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -85,6 +85,7 @@ PTXLA_UNARY_OP(Sqrt, at::aten::sqrt, xla::Sqrt);
 PTXLA_UNARY_OP(Rsqrt, at::aten::rsqrt, xla::Rsqrt);
 PTXLA_UNARY_OP(Ceil, at::aten::ceil, xla::Ceil);
 PTXLA_UNARY_OP(Floor, at::aten::floor, xla::Floor);
+PTXLA_UNARY_OP(Round, at::aten::round, xla::RoundToEven);
 PTXLA_UNARY_OP(Not, at::aten::bitwise_not, xla::Not);
 
 PTXLA_BINARY_OP(Min, at::aten::min, xla::Min);

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -134,6 +134,8 @@ NodePtr Ceil(const Value& input);
 
 NodePtr Floor(const Value& input);
 
+NodePtr Round(const Value& input);
+
 NodePtr Trunc(const Value& input);
 
 NodePtr FracOp(const Value& input);

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -894,6 +894,9 @@ class XLATensor {
 
   static void resize_(XLATensor& input, std::vector<xla::int64> size);
 
+  static XLATensor round(const XLATensor& input);
+  static void round_(XLATensor& input);
+
   static XLATensor rrelu_with_noise(const XLATensor& input, XLATensor& noise,
                                     at::Scalar lower, at::Scalar upper,
                                     bool training);

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2111,6 +2111,14 @@ void XLATensor::resize_(XLATensor& input, std::vector<xla::int64> size) {
   }
 }
 
+XLATensor XLATensor::round(const XLATensor& input) {
+  return input.CreateFrom(ir::ops::Round(input.GetIrValue()));
+}
+
+void XLATensor::round_(XLATensor& input) {
+  input.SetInPlaceIrValue(ir::ops::Round(input.GetIrValue()));
+}
+
 XLATensor XLATensor::rrelu_with_noise(const XLATensor& input, XLATensor& noise,
                                       at::Scalar lower, at::Scalar upper,
                                       bool training) {


### PR DESCRIPTION
Implements Bankers Rounding, where it round to the nearest even integer
if equidistant from 2 integers, matching `aten::round`.

Used in DLRM (cc: @taylanbil).