### PR TITLE
Allow forwarding args to data loader and train/test function, plus allow "-" and "." in node name

### DIFF
--- a/torch_xla/distributed/xla_multiprocessing.py
+++ b/torch_xla/distributed/xla_multiprocessing.py
@@ -55,7 +55,7 @@ def _parse_workers_config(config):
   # XRT_WORKERS='worker:0;ismz9:25822'
   workers = collections.OrderedDict()
   for worker in config.split('|'):
-    m = re.match(r'(\w+):(\d+);((grpc://)?[\w.]+:\d+)', worker)
+    m = re.match(r'(\w+):(\d+);((grpc://)?[a-zA-Z0-9_\-\.]+:\d+)', worker)
     if not m:
       raise ValueError('Bad worker syntax: {}'.format(worker))
     workers['{}:{}'.format(m.group(1), m.group(2))] = WorkerConfigEntry(
@@ -67,7 +67,7 @@ def _parse_tpu_config(config):
   # XRT_TPU_CONFIG='tpu_worker;0;ismz9:25822'
   workers = collections.OrderedDict()
   for worker in config.split('|'):
-    m = re.match(r'(\w+);(\d+);([\w.]+:\d+)', worker)
+    m = re.match(r'(\w+);(\d+);([a-zA-Z0-9_\-\.]+:\d+)', worker)
     if not m:
       raise ValueError('Bad worker syntax: {}'.format(worker))
     workers['{}:{}'.format(m.group(1), m.group(2))] = WorkerConfigEntry(


### PR DESCRIPTION
1) Allow passing args to loader, such as: 
```python
    model_parallel = dp.DataParallel(
      model,
      device_ids=devices,
      loader_prefetch_size=FLAGS.loader_prefetch_size,
      device_prefetch_size=FLAGS.device_prefetch_size,
    )
```
As well as to train function:
```python
def train(model, data_loader, device, context, args=None, writer=None):
  .
  .
  .

def main():
  .
  .
  .
  model_parallel(train, train_device_loader, args=args, writer=writer)
```
2) Allow regex for node names such as "chriso-monster" or "dev1.company.net"
