### PR TITLE
Update doc to build docker inside xla directory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,8 @@ To build from source:
   following:
 
   ```Shell
-  docker build -t torch-xla -f xla/docker/Dockerfile .
+  cd xla/
+  docker build -t torch-xla -f docker/Dockerfile .
   ```
 
 ### Building With Script
@@ -142,4 +143,3 @@ If you are planning to be building from source and hence using the latest _PyTor
 it is suggested for you to select the _Nightly_ builds when you create a Cloud TPU instance.
 
 Then run `test/run_tests.sh` and `test/cpp/run_tests.sh` to verify the setup is working.
-


### PR DESCRIPTION
Since we do a COPY in 
https://github.com/pytorch/xla/blob/df0a2776e42ab144cfb00485c50852ea70f2b9b8/docker/Dockerfile#L35 we should be in xla directory instead of the pytorch directory. 