### PR TITLE
Disable test_addmm_xla_bfloat16

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -186,6 +186,7 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_maximum_minimum_type_promotion_xla_*_float16',  # doesn't raise
         'test_index_add_mem_overlap',  # doesn't raise
         'test_shift_mem_overlap',  # doesn't raise
+        'test_addmm_xla_bfloat16',  # precision
     },
     'TestViewOpsXLA': {
         'test_contiguous_nonview',


### PR DESCRIPTION
Test currently fail because of precision in https://github.com/pytorch/pytorch/pull/43831, ideally pt/xla should take pt precision if it is bigger than pt default bfloat16 precision, looking into that.