### PR TITLE
Only overwrite test precision if the pt/xla tolerance is larger

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -444,7 +444,9 @@ class XLATestBase(DeviceTypeTestBase):
                   TORCH_TEST_PRECIIONS,
                   [dtype_test_name, test_name, test.__name__],
                   DEFAULT_FLOATING_PRECISION)
-              test.precision_overrides[dtype] = floating_precision
+              if dtype not in test.precision_overrides or test.precision_overrides[
+                  dtype] < floating_precision:
+                test.precision_overrides[dtype] = floating_precision
 
           if match_name(dtype_test_name, disabled_torch_tests[class_name]):
             skipped = True


### PR DESCRIPTION
This is to fix https://github.com/pytorch/pytorch/pull/43831#issuecomment-685083254.