### PR TITLE
Handle unordered reduce dimensions

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1360,6 +1360,11 @@ class TestAtenXlaTensor(XlaTestCase):
     self.assertRaises(RuntimeError, lambda: torch.min(xla_a, dim=1))
     self.assertRaises(RuntimeError, lambda: torch.min(xla_a))
 
+  def test_reduction_unordered_dim(self):
+    self.runAtenTest(
+        torch.rand(4, 3, 4, 2),
+        lambda x: torch.mean(x, (-1, -3, -2), keepdim=True))
+
   def test_index_select_0dim(self):
 
     def test_fn(s, i):

--- a/torch_xla/csrc/reduction.cpp
+++ b/torch_xla/csrc/reduction.cpp
@@ -1,6 +1,7 @@
 #include "torch_xla/csrc/reduction.h"
 
 #include <cmath>
+#include <unordered_set>
 
 #include "tensorflow/compiler/xla/client/lib/arithmetic.h"
 #include "tensorflow/compiler/xla/client/lib/constants.h"
@@ -26,10 +27,10 @@ ReductionInfo GetReductionInfo(xla::XlaOp input, const xla::Shape& shape,
                                absl::Span<const xla::int64> dimensions,
                                bool keep_reduced_dimensions) {
   ReductionInfo rinfo;
-  size_t idim = 0;
+  std::unordered_set<xla::int64> reduced_dimensions(dimensions.begin(),
+                                                    dimensions.end());
   for (xla::int64 i = 0; i < shape.rank(); ++i) {
-    if (idim < dimensions.size() && dimensions[idim] == i) {
-      ++idim;
+    if (reduced_dimensions.count(i) > 0) {
       if (keep_reduced_dimensions) {
         rinfo.new_dimensions.push_back(1);
       }


### PR DESCRIPTION
Currently GetReductionInfo expects reduce dimension coming in at a increasing order which doesn't always hold true.