### PR TITLE
Add TriangularSolve to XLABuilder OP

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1818,6 +1818,30 @@ class TestOpBuilder(XlaTestCase):
         aten_fn=aten_fn,
         kwargs={'limit': 10})
 
+  def test_triangular_solve(self):
+
+    def op_fn(b, A, lower, unit_diagonal, transpose_a):
+      return A.triangualr_solve(b, True, lower, unit_diagonal, transpose_a)
+
+    def aten_fn(b, A, lower, unit_diagonal, transpose_a):
+      return torch.triangular_solve(
+          b,
+          A,
+          upper=not lower,
+          unitriangular=unit_diagonal,
+          transpose=transpose_a)
+
+    self.runOpBuilderTest(
+        'test_triangular_solve',
+        [torch.randn(2, 3), torch.randn(2, 2).triu()],
+        op_fn,
+        aten_fn=aten_fn,
+        kwargs={
+            'lower': False,
+            'unit_diagonal': False,
+            'transpose_a': False
+        })
+
 
 class MpDecoratorTest(XlaTestCase):
 

--- a/torch_xla/core/xla_builder.py
+++ b/torch_xla/core/xla_builder.py
@@ -504,6 +504,19 @@ class Op(object):
   def transpose(self, permutation):
     return mkop('Transpose', (self.op,), permutation=permutation)
 
+  def triangualr_solve(self,
+                       b,
+                       left_side=None,
+                       lower=None,
+                       unit_diagonal=None,
+                       transpose_a=None):
+    return mkop(
+        'TriangularSolve', (self.op, b.op),
+        left_side=left_side,
+        lower=lower,
+        unit_diagonal=unit_diagonal,
+        transpose_a=transpose_a)
+
   def clamp(self, min_value, max_value):
     return mkop('Clamp', (self.op, min_value.op, max_value.op))
 

--- a/torch_xla/csrc/xla_op_builder.cpp
+++ b/torch_xla/csrc/xla_op_builder.cpp
@@ -710,6 +710,18 @@ xla::XlaOp BitcastConvert(const BuilderPtr& builder,
   return xla::BitcastConvertType(operands.at(0)->op, xla_type);
 }
 
+xla::XlaOp TriangularSolve(const BuilderPtr& builder,
+                           const std::vector<OpPtr>& operands, py::dict args) {
+  bool left_side = ArgOrDefault<bool>(args, "left_side", true);
+  bool lower = ArgOrDefault<bool>(args, "lower", false);
+  bool unit_diagonal = ArgOrDefault<bool>(args, "unit_diagonal", false);
+  bool transpose_a = ArgOrDefault<bool>(args, "transpose_a", false);
+  return xla::TriangularSolve(
+      operands.at(0)->op, operands.at(1)->op, left_side, lower, unit_diagonal,
+      transpose_a ? xla::TriangularSolveOptions::TRANSPOSE
+                  : xla::TriangularSolveOptions::NO_TRANSPOSE);
+}
+
 const XlaOpFunctionMap* CreateXlaOpFunctionMap() {
   XlaOpFunctionMap* fn_map = new XlaOpFunctionMap();
 
@@ -801,6 +813,7 @@ const XlaOpFunctionMap* CreateXlaOpFunctionMap() {
   XLA_OPADD(Tan);
   XLA_OPADD(Tanh);
   XLA_OPADD(Transpose);
+  XLA_OPADD(TriangularSolve);
   XLA_OPADD(Tuple);
   XLA_OPADD(While);
   XLA_OPADD(Xor);


### PR DESCRIPTION
per https://github.com/pytorch/xla/issues/2498 request. A simple example of using a XlaBuilder:TriangularSolve would be

```
import torch                                                                                                                                                                                                                               
import torch_xla.core.xla_builder as xb                                                                                                                                                                                                    
import torch_xla.core.xla_op_registry as xor                                                                                                                                                                                               
import torch_xla.core.xla_model as xm                                                                                                                                                                                                      
import torch_xla.utils.utils as xu 

# new custom op that perform the xla::triangular_solve
def op_fn(b, A, left_side, lower, unit_diagonal, transpose_a):                                                                                                                                                                             
    return A.triangualr_solve(b, True, lower, unit_diagonal, transpose_a)                                                                                                                                                                  

# register this op                                                                                                                                                                                                                                           
op = xor.register('xla_triangualr_solve', op_fn) 

# setup parameters                                                                                                                                                                                          
device = xm.xla_device()                                                                                                                                                                                                                   
A = torch.randn(2, 2).triu()                                                                                                                                                                                                               
b = torch.randn(2, 3)                                                                                                                                                                                                                      
args = {                                                                                                                                                                                                                                   
    'left_side': True,                                                                                                                                                                                                                     
    'lower': True,                                                                                                                                                                                                                         
    'unit_diagonal': False,                                                                                                                                                                                                                
    'transpose_a': False                                                                                                                                                                                                                   
}                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                           
res = op(*[b.to(device), A.to(device)], **args)                                                                                                                                                                                            
print(res)  
```