### PR TITLE
Fix VLOGs being disabled

### DIFF
--- a/test/cpp/torch_xla_test.cpp
+++ b/test/cpp/torch_xla_test.cpp
@@ -28,7 +28,7 @@ void XlaTest::TearDown() {
     std::string diffs = start_msnap_->DumpDifferences(*end_msnap_,
                                                       /*ignore_se=*/nullptr);
     if (!diffs.empty()) {
-      TF_LOG(INFO)
+      TF_VLOG(1)
           << ::testing::UnitTest::GetInstance()->current_test_info()->name()
           << " Metrics Differences:\n"
           << diffs;
@@ -43,9 +43,9 @@ void XlaTest::ExpectCounterNotChanged(
   auto changed =
       start_msnap_->CounterChanged(counter_regex, *end_msnap_, ignore_set);
   for (auto& change_counter : changed) {
-    TF_LOG(INFO) << "Counter '" << change_counter.name
-                 << "' changed: " << change_counter.before << " -> "
-                 << change_counter.after;
+    TF_VLOG(1) << "Counter '" << change_counter.name
+               << "' changed: " << change_counter.before << " -> "
+               << change_counter.after;
   }
   EXPECT_TRUE(changed.empty());
 }

--- a/third_party/xla_client/computation_client.cc
+++ b/third_party/xla_client/computation_client.cc
@@ -200,10 +200,10 @@ bool ParseMeshConfig(
       XrtComputationClient::ParseWorker(local_worker_env);
   int host_ordinal = sys_util::GetEnvInt(env::kEnvHostOrdinal, 0);
 
-  TF_LOG(INFO) << "Fetching mesh configuration for worker " << local_worker.name
-               << " (host_ordinal=" << host_ordinal
-               << "):" << local_worker.task_no << " from mesh service at "
-               << client->address();
+  TF_VLOG(1) << "Fetching mesh configuration for worker " << local_worker.name
+             << " (host_ordinal=" << host_ordinal
+             << "):" << local_worker.task_no << " from mesh service at "
+             << client->address();
   service::grpc::Config config = client->GetConfig(host_ordinal);
   TF_VLOG(3) << "Mesh Config: " << config.DebugString();
 

--- a/third_party/xla_client/mesh_service.cc
+++ b/third_party/xla_client/mesh_service.cc
@@ -309,8 +309,8 @@ MeshClient* MeshClient::Get() {
 MeshClient::MeshClient(const std::string& address) : impl_(new Impl(address)) {
   int64 connect_wait_seconds =
       sys_util::GetEnvInt("XRT_MESH_CONNECT_WAIT", 300);
-  TF_LOG(INFO) << "Waiting to connect to client mesh master ("
-               << connect_wait_seconds << " seconds) " << address;
+  TF_VLOG(1) << "Waiting to connect to client mesh master ("
+             << connect_wait_seconds << " seconds) " << address;
   XLA_CHECK(impl_->channel->WaitForConnected(
       std::chrono::system_clock::now() +
       std::chrono::seconds(connect_wait_seconds)))

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -32,17 +32,7 @@ def _setup_xla_flags():
   os.environ['XLA_FLAGS'] = ' '.join(flags)
 
 
-def _set_missing_env(name, value):
-  if name not in os.environ:
-    os.environ[name] = value
-
-
-def _setup_default_env():
-  _set_missing_env('TF_CPP_MIN_LOG_LEVEL', '1')
-
-
 # These needs to be called before the _XLAC module is loaded.
-_setup_default_env()
 _setup_grpc()
 _setup_xla_flags()
 


### PR DESCRIPTION
Our TF_VLOGs had been disabled due to a conflict between
`TF_CPP_MIN_LOG_LEVEL` and `TF_VLOG` since `TF_VLOG` logs 
with `tf::INFO`, which ends up getting logged nowhere 
because of this check: https://github.com/tensorflow/tensorflow/blob/efff893c709b585da9771cb3a2997321efef36ae/tensorflow/core/platform/default/logging.cc#L195

Also, moves some `TF_LOG(INFO)` to `VLOG` since original
PR for `TF_CPP_MIN_LOG_LEVEL` was cut to silence those.  