### PR TITLE
Option to allow all constant scalars to be baked into the graph

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -46,6 +46,11 @@ function run_dynamic {
   XLA_EXPERIMENTAL="nonzero:masked_select" run_test "$@"
 }
 
+function run_all_scalars_special {
+  echo "Running in 'All Scalars Special' mode: $@"
+  XLA_EXPERIMENTAL="allscalarspec" run_test "$@"
+}
+
 function run_all_tests {
   run_dynamic python3 "$CDIR/../../test/test_torch.py" "$@" -v TestViewOpsXLA
   run_test python3 "$CDIR/../../test/test_torch.py" "$@" -v TestTorchDeviceTypeXLA
@@ -57,6 +62,7 @@ function run_all_tests {
   run_dynamic python3 "$CDIR/../../test/test_type_promotion.py" "$@" -v TestTypePromotionXLA
   run_dynamic python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_opbyop python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  run_all_scalars_special python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_test python3 "$CDIR/test_mp_replication.py"
   run_test python3 "$CDIR/test_mp_all_to_all.py"
   run_test python3 "$CDIR/test_mp_collective_permute.py"

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -244,7 +244,7 @@ bool IsSpecialScalar(at::Scalar value) {
       xla::sys_util::GetEnvBool("XLA_NO_SPECIAL_SCALARS", false);
   if (!no_scalars && (value.isIntegral() || value.isFloatingPoint())) {
     static bool all_scalar_numbers_special =
-        xla::sys_util::GetEnvBool("XLA_ALL_NUMBERS_SPECIAL_SCALARS", false);
+        DebugUtil::ExperimentEnabled("allscalarspec");
     if (all_scalar_numbers_special) {
       return true;
     }

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -243,6 +243,11 @@ bool IsSpecialScalar(at::Scalar value) {
   static bool no_scalars =
       xla::sys_util::GetEnvBool("XLA_NO_SPECIAL_SCALARS", false);
   if (!no_scalars && (value.isIntegral() || value.isFloatingPoint())) {
+    static bool all_scalar_numbers_special =
+        xla::sys_util::GetEnvBool("XLA_ALL_NUMBERS_SPECIAL_SCALARS", false);
+    if (all_scalar_numbers_special) {
+      return true;
+    }
     double scalar_value = value.toDouble();
     return scalar_value == 0.0 || std::fabs(scalar_value) == 1.0;
   }


### PR DESCRIPTION
I know that this seems like a bit of a restrictive option, but could you please allow this option to allow all constant scalars to be "baked" into the graph rather than streaming them in?  I have some use-cases where streaming a lot of values scalars can be problematic for a number of reasons, including network overhead.  I have been using this change in my branch for many months without incident.

Note that this does not affect things such as GetRngSeed
