### PR TITLE
Revert "Rename math to default to align with RegistrationDeclarations.h."

### DIFF
--- a/scripts/gen.py
+++ b/scripts/gen.py
@@ -26,11 +26,11 @@ class ArgTemplate(string.Template):
 
 
 FuncDef = namedtuple_with_defaults('FuncDef',
-                                   'cpp_sig, aten_sig, dispatch, default')
+                                   'cpp_sig, aten_sig, dispatch, math')
 
 FuncGen = namedtuple_with_defaults(
     'FuncGen',
-    'tree, xtree, rwxtree, func, xfunc, code, sig, rwsig, cppsig, funsig, mapsig, aten_sig, dispatch, default'
+    'tree, xtree, rwxtree, func, xfunc, code, sig, rwsig, cppsig, funsig, mapsig, aten_sig, dispatch, math'
 )
 
 FuncOpts = namedtuple_with_defaults(
@@ -931,7 +931,7 @@ def get_xla_wrapper(fndef, ctx):
       funsig=create_stdfunc_sig(rwxtree, rwsig),
       aten_sig=fndef.aten_sig,
       dispatch=fndef.dispatch,
-      default=fndef.default)
+      math=fndef.math)
 
 
 def is_tensor_api(fndef):
@@ -947,7 +947,7 @@ def create_funcdef(fndef, jdata):
       cpp_sig=fndef,
       aten_sig=fields['schema'],
       dispatch=fields.get('dispatch', 'False') == 'True',
-      default=fields.get('default', 'False') == 'True')
+      math=fields.get('math', 'False') == 'True')
 
 
 def extract_functions(path):
@@ -1050,7 +1050,7 @@ def generate_registrations(fgens, overrides):
 #     Backends should only use this when Autograd kernel in PyTorch codebase doesn't fit.
 #     E.g max_pool2d which enforce materializing indices for backward pass to use.
 def requires_registration(fgen, overrides):
-  requires_lowering = fgen.dispatch and not fgen.default
+  requires_lowering = fgen.dispatch and not fgen.math
   has_xla_lowering = get_mapsig_key(fgen.mapsig) in overrides
   has_autogradxla = fgen.mapsig in _FN_AUTOGRAD_XLA or fgen.func in _FN_AUTOGRAD_XLA
   return requires_lowering or has_xla_lowering or has_autogradxla


### PR DESCRIPTION
Reverts pytorch/xla#2539