### PR TITLE
Handle Duplicated tensors in sync list and interop tensors

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -691,6 +691,20 @@ class TestNllLossLimitValue(XlaTestCase):
     self.runAtenTest([logits, target], test_fn)
 
 
+class TestInterOpSyncTensors(XlaTestCase):
+
+  def test_inter_op_sync(self):
+
+    def test_fn(x):
+      # logaddexp can be replaced with any op that does not have
+      # xla lowering.
+      y = torch.logaddexp(x, x)
+      return torch.masked_select(y, y.eq(0))
+
+    x = torch.tensor([1., 2., 3.])
+    self.runAtenTest([x], test_fn)
+
+
 class TestDynamicShape(XlaTestCase):
 
   def test_nonzero_shape(self):

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -1338,6 +1338,10 @@ class XLATensor {
       std::vector<XLATensor>* tensors, const SyncTensorsConfig& config,
       absl::Span<const size_t> indices);
 
+  static std::vector<at::Tensor> FetchTensors(
+      std::vector<XLATensor>* tensors, absl::Span<const xla::Literal> literals,
+      const std::vector<size_t>* indices);
+
   // Schedules the execution of a sync tensors operation in background. The
   // asynchronous operation will hold the device locks by capturing the ones
   // present within the coll structure.


### PR DESCRIPTION
This pr is to address the corner case brought up by Alex in [here](https://github.com/pytorch/xla/commit/a3387469b71718c1112acafe08ce48d139763436), note that `add` lowering is removed. I used a slightly different example here

```
import torch
import torch_xla

torch.manual_seed(42)

device = 'xla'
x = torch.tensor([1,2,3], device=device)
y = x + x
z = torch.masked_select(y, y.eq(0))
```

There are two problems in this code
1. in `y = x + x`, we will try to sync the value of `x` twice (since default implemantion of add is used in this case), this is unnecessary. We can use a `unordered_set` in sync and a `unordered_map` in `GatherTensorsXlaData` to avoid execute the same ir_graph twice.

2. during `torch.masked_select(y, y.eq(0))`, `y` has `ir_value` and `tensor_data` but does not have `xla_data`.
Here is the debugging output when `z = torch.masked_select(y, y.eq(0))` is executed

```
Length of the tensors to be sync = 2

tensorID: 3
ir value: s64[3]{0} xla::device_data, location=<module>@example.py:20, device=CPU:0
with xla data: False
tensor data: 
 2
 4
 6
[ CPULongType{3} ]

tensorID: 4
ir value, pred[3]{0} aten::eq, location=<module>@example.py:20
with xla data: False
with tensor data: False
```

Currently in `CollectSyncTensors ` we only check `ir_value`
https://github.com/pytorch/xla/blob/44268fa4d749e82a28283c9f5fda26f18b277493/torch_xla/csrc/tensor.cpp#L1119

but in fact we should only sync the tensor if it 
1. does not have `xla_data`
2. does not have `tensor_data`
3. has `ir_value`