### PR TITLE
Disable test_EmbeddingBag_empty_per_sample_weights_and_offsets_xla

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -319,6 +319,7 @@ DISABLED_TORCH_TESTS_TPU_ONLY = {
     # test_nn.py
     'TestNNDeviceTypeXLA': {
         'test_embedding_bag_empty_input_xla',  # server side crash
+        'test_EmbeddingBag_empty_per_sample_weights_and_offsets_xla',  # server side crash
     },
 
     # test_type_promotion.py


### PR DESCRIPTION
Same server side crashed as `test_embedding_bag_empty_input_xla`, I reached out to XLA team regarding crash again, disable the test until the fix is merged.