### PR TITLE
adaptive_avg_pool3d op lowering

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -7002,7 +7002,7 @@ TEST_F(AtenXlaTensorTest, TestAvgPool3DNoBatch) {
 TEST_F(AtenXlaTensorTest, TestAdaptiveAvgPool2D) {
   torch::Tensor input =
       torch::rand({4, 1, 28, 28}, torch::TensorOptions(torch::kFloat));
-  for (int64_t output_size : {7, 8}) {
+  for (int64_t output_size : {7, 4}) {
     torch::Tensor output =
         torch::adaptive_avg_pool2d(input, {output_size, output_size});
     ForEachDevice([&](const torch::Device& device) {
@@ -7012,11 +7012,50 @@ TEST_F(AtenXlaTensorTest, TestAdaptiveAvgPool2D) {
       AllClose(output, xla_output);
     });
   }
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::_adaptive_avg_pool2d",
+                       cpp_test::GetIgnoredCounters());
+}
+
+TEST_F(AtenXlaTensorTest, TestAdaptiveAvgPool3D) {
+  torch::Tensor input =
+      torch::rand({9, 4, 56, 28, 28}, torch::TensorOptions(torch::kFloat));
+  for (int64_t output_size : {7, 4}) {
+    torch::Tensor output = torch::adaptive_avg_pool3d(
+        input, {output_size, output_size, output_size});
+    ForEachDevice([&](const torch::Device& device) {
+      torch::Tensor xla_input = CopyToDevice(input, device);
+      torch::Tensor xla_output = torch::adaptive_avg_pool3d(
+          xla_input, {output_size, output_size, output_size});
+      AllClose(output, xla_output);
+    });
+  }
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::adaptive_avg_pool3d",
+                       cpp_test::GetIgnoredCounters());
+}
+
+TEST_F(AtenXlaTensorTest, TestAdaptiveAvgPool3DNoBatch) {
+  torch::Tensor input =
+      torch::rand({3, 56, 28, 28}, torch::TensorOptions(torch::kFloat));
+  for (int64_t output_size : {7, 4}) {
+    torch::Tensor output = torch::adaptive_avg_pool3d(
+        input, {output_size, output_size, output_size});
+    ForEachDevice([&](const torch::Device& device) {
+      torch::Tensor xla_input = CopyToDevice(input, device);
+      torch::Tensor xla_output = torch::adaptive_avg_pool3d(
+          xla_input, {output_size, output_size, output_size});
+      AllClose(output, xla_output);
+    });
+  }
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::adaptive_avg_pool3d",
+                       cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestAdaptiveAvgPool2DNoBatch) {
   torch::Tensor input =
-      torch::rand({1, 28, 28}, torch::TensorOptions(torch::kFloat));
+      torch::rand({1, 56, 56}, torch::TensorOptions(torch::kFloat));
   for (int64_t output_size : {7, 8}) {
     torch::Tensor output =
         torch::adaptive_avg_pool2d(input, {output_size, output_size});
@@ -7027,6 +7066,9 @@ TEST_F(AtenXlaTensorTest, TestAdaptiveAvgPool2DNoBatch) {
       AllClose(output, xla_output);
     });
   }
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::_adaptive_avg_pool2d",
+                       cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestMaxUnpool2D) {
@@ -8834,6 +8876,46 @@ TEST_F(AtenXlaTensorTest, TestAvgPool3DNoBatchBackward) {
   }
 }
 
+TEST_F(AtenXlaTensorTest, TestAdaptiveAvgPool3DNoBatchBackward) {
+  for (int64_t output_size : {7, 4}) {
+    auto testfn =
+        [&](const std::vector<torch::Tensor>& inputs) -> torch::Tensor {
+      return torch::adaptive_avg_pool3d(
+          inputs[0], {output_size, output_size, output_size});
+    };
+    ForEachDevice([&](const torch::Device& device) {
+      TestBackward(
+          {torch::rand(
+              {1, 56, 28, 28},
+              torch::TensorOptions(torch::kFloat).requires_grad(true))},
+          device, testfn);
+    });
+  }
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::adaptive_avg_pool3d",
+                       cpp_test::GetIgnoredCounters());
+}
+
+TEST_F(AtenXlaTensorTest, TestAdaptiveAvgPool3DBackward) {
+  for (int64_t output_size : {7, 4}) {
+    auto testfn =
+        [&](const std::vector<torch::Tensor>& inputs) -> torch::Tensor {
+      return torch::adaptive_avg_pool3d(
+          inputs[0], {output_size, output_size, output_size});
+    };
+    ForEachDevice([&](const torch::Device& device) {
+      TestBackward(
+          {torch::rand(
+              {4, 1, 56, 28, 28},
+              torch::TensorOptions(torch::kFloat).requires_grad(true))},
+          device, testfn);
+    });
+  }
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::adaptive_avg_pool3d",
+                       cpp_test::GetIgnoredCounters());
+}
+
 TEST_F(AtenXlaTensorTest, TestAdaptiveAvgPool2DBackward) {
   for (int64_t output_size : {7, 8}) {
     auto testfn =
@@ -8843,11 +8925,14 @@ TEST_F(AtenXlaTensorTest, TestAdaptiveAvgPool2DBackward) {
     ForEachDevice([&](const torch::Device& device) {
       TestBackward(
           {torch::rand(
-              {4, 1, 28, 28},
+              {4, 1, 56, 56},
               torch::TensorOptions(torch::kFloat).requires_grad(true))},
           device, testfn);
     });
   }
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::_adaptive_avg_pool2d",
+                       cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestAdaptiveAvgPool2DNoBatchBackward) {
@@ -8857,11 +8942,14 @@ TEST_F(AtenXlaTensorTest, TestAdaptiveAvgPool2DNoBatchBackward) {
       return torch::adaptive_avg_pool2d(inputs[0], {output_size, output_size});
     };
     ForEachDevice([&](const torch::Device& device) {
-      TestBackward({torch::rand({1, 28, 28}, torch::TensorOptions(torch::kFloat)
+      TestBackward({torch::rand({1, 56, 56}, torch::TensorOptions(torch::kFloat)
                                                  .requires_grad(true))},
                    device, testfn);
     });
   }
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::_adaptive_avg_pool2d",
+                       cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestConv2DBackward) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -211,12 +211,39 @@ at::Tensor AtenXlaType::__rshift__(const at::Tensor& self,
                     });
 }
 
+at::Tensor AtenXlaType::adaptive_avg_pool3d(const at::Tensor& self,
+                                            at::IntArrayRef output_size) {
+  XLA_FN_COUNTER("xla::");
+  auto output_size_list = XlaHelpers::I64List(output_size);
+  if (!IsSupportedAdaptiveAvgPool(XlaHelpers::I64List(self.sizes()),
+                                  output_size_list, /*pool_dim=*/3)) {
+    return AtenXlaTypeDefault::adaptive_avg_pool3d(self, output_size);
+  }
+  return bridge::AtenFromXlaTensor(XLATensor::adaptive_avg_pool3d(
+      bridge::GetXlaTensor(self), output_size_list));
+}
+
+at::Tensor AtenXlaType::adaptive_avg_pool3d_backward(
+    const at::Tensor& grad_output, const at::Tensor& self) {
+  XLA_FN_COUNTER("xla::");
+  int64_t rank = grad_output.dim();
+  std::vector<xla::int64> output_size{grad_output.size(rank - 3),
+                                      grad_output.size(rank - 2),
+                                      grad_output.size(rank - 1)};
+  if (!IsSupportedAdaptiveAvgPool(XlaHelpers::I64List(self.sizes()),
+                                  output_size, /*pool_dim=*/3)) {
+    return AtenXlaTypeDefault::adaptive_avg_pool3d_backward(grad_output, self);
+  }
+  return bridge::AtenFromXlaTensor(XLATensor::adaptive_avg_pool3d_backward(
+      bridge::GetXlaTensor(grad_output), bridge::GetXlaTensor(self)));
+}
+
 at::Tensor AtenXlaType::_adaptive_avg_pool2d(const at::Tensor& self,
                                              at::IntArrayRef output_size) {
   XLA_FN_COUNTER("xla::");
   auto output_size_list = XlaHelpers::I64List(output_size);
-  if (!IsSupportedAdaptiveAvgPool2d(XlaHelpers::I64List(self.sizes()),
-                                    output_size_list)) {
+  if (!IsSupportedAdaptiveAvgPool(XlaHelpers::I64List(self.sizes()),
+                                  output_size_list, /*pool_dim=*/2)) {
     return AtenXlaTypeDefault::_adaptive_avg_pool2d(self, output_size);
   }
   return bridge::AtenFromXlaTensor(XLATensor::_adaptive_avg_pool2d(
@@ -229,8 +256,8 @@ at::Tensor AtenXlaType::_adaptive_avg_pool2d_backward(
   int64_t rank = grad_output.dim();
   std::vector<xla::int64> output_size{grad_output.size(rank - 2),
                                       grad_output.size(rank - 1)};
-  if (!IsSupportedAdaptiveAvgPool2d(XlaHelpers::I64List(self.sizes()),
-                                    output_size)) {
+  if (!IsSupportedAdaptiveAvgPool(XlaHelpers::I64List(self.sizes()),
+                                  output_size, /*pool_dim=*/2)) {
     return AtenXlaTypeDefault::_adaptive_avg_pool2d_backward(grad_output, self);
   }
   return bridge::AtenFromXlaTensor(XLATensor::_adaptive_avg_pool2d_backward(

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -31,6 +31,12 @@ class AtenXlaType {
 
   static at::Tensor __rshift__(const at::Tensor& self, const at::Tensor& other);
 
+  static at::Tensor adaptive_avg_pool3d(const at::Tensor& self,
+                                        at::IntArrayRef output_size);
+
+  static at::Tensor adaptive_avg_pool3d_backward(const at::Tensor& grad_output,
+                                                 const at::Tensor& self);
+
   static at::Tensor _adaptive_avg_pool2d(const at::Tensor& self,
                                          at::IntArrayRef output_size);
 

--- a/torch_xla/csrc/ops/adaptive_avg_pool3d.cpp
+++ b/torch_xla/csrc/ops/adaptive_avg_pool3d.cpp
@@ -1,0 +1,52 @@
+#include "torch_xla/csrc/ops/adaptive_avg_pool3d.h"
+
+#include "tensorflow/compiler/xla/xla_client/debug_macros.h"
+#include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch_xla/csrc/lowering_context.h"
+#include "torch_xla/csrc/ops/infer_output_shape.h"
+#include "torch_xla/csrc/pooling.h"
+
+namespace torch_xla {
+namespace ir {
+namespace ops {
+namespace {
+
+xla::Shape NodeOutputShape(const Value& input,
+                           absl::Span<const xla::int64> output_size) {
+  auto lower_for_shape_fn =
+      [output_size](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
+    XLA_CHECK_EQ(operands.size(), 1);
+    return BuildAdaptiveAvgPool3d(operands[0], output_size);
+  };
+  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+}
+
+}  // namespace
+
+AdaptiveAvgPool3d::AdaptiveAvgPool3d(const Value& input,
+                                     std::vector<xla::int64> output_size)
+    : Node(ir::OpKind(at::aten::adaptive_avg_pool3d), {input},
+           [&]() { return NodeOutputShape(input, output_size); },
+           /*num_outputs=*/1, xla::util::MHash(output_size)),
+      output_size_(std::move(output_size)) {}
+
+NodePtr AdaptiveAvgPool3d::Clone(OpList operands) const {
+  return MakeNode<AdaptiveAvgPool3d>(operands.at(0), output_size_);
+}
+
+XlaOpVector AdaptiveAvgPool3d::Lower(LoweringContext* loctx) const {
+  xla::XlaOp input = loctx->GetOutputOp(operand(0));
+  xla::XlaOp output = BuildAdaptiveAvgPool3d(input, output_size_);
+  return ReturnOp(output, loctx);
+}
+
+std::string AdaptiveAvgPool3d::ToString() const {
+  std::stringstream ss;
+  ss << Node::ToString() << ", output_size=("
+     << absl::StrJoin(output_size_, ", ") << ")";
+  return ss.str();
+}
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/adaptive_avg_pool3d.h
+++ b/torch_xla/csrc/ops/adaptive_avg_pool3d.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <vector>
+
+#include "absl/types/span.h"
+#include "tensorflow/compiler/xla/xla_data.pb.h"
+#include "torch_xla/csrc/ir.h"
+
+namespace torch_xla {
+namespace ir {
+namespace ops {
+
+class AdaptiveAvgPool3d : public Node {
+ public:
+  AdaptiveAvgPool3d(const Value& input, std::vector<xla::int64> output_size);
+
+  NodePtr Clone(OpList operands) const override;
+
+  XlaOpVector Lower(LoweringContext* loctx) const override;
+
+  std::string ToString() const override;
+
+  const std::vector<xla::int64>& output_size() const { return output_size_; }
+
+ private:
+  std::vector<xla::int64> output_size_;
+};
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -156,6 +156,8 @@ NodePtr MatMul(const Value& lhs, const Value& rhs);
 
 NodePtr AdaptiveAvgPool2dBackward(const Value& grad_output, const Value& input);
 
+NodePtr AdaptiveAvgPool3dBackward(const Value& grad_output, const Value& input);
+
 NodePtr ComparisonOp(c10::Symbol kind, const Value& input, const Value& other);
 
 NodePtr Where(const Value& condition, const Value& input, const Value& other);

--- a/torch_xla/csrc/pooling.cpp
+++ b/torch_xla/csrc/pooling.cpp
@@ -78,11 +78,11 @@ PoolingOpAttributes MakePoolingOpAttributes(
 // from the given input_size, when the stride is the same as the kernel size.
 std::vector<xla::int64> AdaptiveAvgPoolKernelSize(
     absl::Span<const xla::int64> input_size,
-    absl::Span<const xla::int64> output_size) {
+    absl::Span<const xla::int64> output_size, int pool_dim) {
   // Create a NCHW kernel size with 1 for batch size and feature.
   std::vector<xla::int64> kernel_size(2, 1);
-  xla::int64 spatial_dim_off = input_size.size() - 2;
-  for (int spatial_dim = 0; spatial_dim < 2; ++spatial_dim) {
+  xla::int64 spatial_dim_off = input_size.size() - pool_dim;
+  for (int spatial_dim = 0; spatial_dim < pool_dim; ++spatial_dim) {
     XLA_CHECK_EQ(
         input_size[spatial_dim_off + spatial_dim] % output_size[spatial_dim], 0)
         << "Target output size " << output_size[spatial_dim]
@@ -348,11 +348,15 @@ xla::XlaOp ComputeMaxPoolIndices(
 
 }  // namespace
 
-bool IsSupportedAdaptiveAvgPool2d(absl::Span<const xla::int64> input_size,
-                                  absl::Span<const xla::int64> output_size) {
+bool IsSupportedAdaptiveAvgPool(absl::Span<const xla::int64> input_size,
+                                absl::Span<const xla::int64> output_size,
+                                int pool_dim) {
   xla::int64 rank = input_size.size();
-  for (int spatial_dim = 0; spatial_dim < 2; ++spatial_dim) {
-    if (input_size[rank - 2 + spatial_dim] % output_size[spatial_dim] != 0) {
+  XLA_CHECK_EQ(output_size.size(), pool_dim)
+      << "Output shape MUST be" << pool_dim;
+  for (int spatial_dim = 0; spatial_dim < pool_dim; ++spatial_dim) {
+    if (input_size[rank - pool_dim + spatial_dim] % output_size[spatial_dim] !=
+        0) {
       return false;
     }
   }
@@ -538,59 +542,93 @@ xla::XlaOp BuildAvgPoolNdBackward(xla::XlaOp out_backprop, xla::XlaOp input,
                             /*spatial_dim_count=*/spatial_dim_count);
 }
 
-xla::XlaOp BuildAdaptiveAvgPool2d(xla::XlaOp input,
-                                  absl::Span<const xla::int64> output_size) {
-  XLA_CHECK_EQ(output_size.size(), 2) << "Invalid output size rank";
-  const auto input_size = XlaHelpers::SizesOfXlaOp(input);
-  XLA_CHECK(input_size.size() == 4 || input_size.size() == 3)
-      << "Only 4D or 3D tensors supported";
-  const auto kernel_size = AdaptiveAvgPoolKernelSize(input_size, output_size);
-  std::vector<std::pair<xla::int64, xla::int64>> no_padding(2);
+xla::XlaOp BuildAdaptiveAvgPool(xla::XlaOp input,
+                                absl::Span<const xla::int64> output_size,
+                                int pool_dim) {
+  const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
+  const auto kernel_size = AdaptiveAvgPoolKernelSize(input_shape.dimensions(),
+                                                     output_size, pool_dim);
+  std::vector<std::pair<xla::int64, xla::int64>> no_padding(pool_dim);
   BatchInput batch_input_info =
-      CreateBatchInput(input, /*spatial_dim_count=*/2);
+      CreateBatchInput(input, /*spatial_dim_count=*/pool_dim);
   xla::XlaOp batch_result = xla::AvgPool(
       /*operand=*/batch_input_info.batch_input,
       /*kernel_size=*/kernel_size,
       /*stride=*/kernel_size,
       /*padding=*/no_padding,
-      /*data_format=*/MakeNCHWFormat(2),
+      /*data_format=*/MakeNCHWFormat(pool_dim),
       /*counts_include_padding=*/false);
   return RemoveTrivialBatch(/*batch=*/batch_result,
                             /*original_rank=*/batch_input_info.original_rank,
-                            /*spatial_dim_count=*/2);
+                            /*spatial_dim_count=*/pool_dim);
 }
 
-xla::XlaOp BuildAdaptiveAvgPool2dBackward(xla::XlaOp out_backprop,
-                                          xla::XlaOp input) {
-  BatchInput batch_out_backprop_info =
-      CreateBatchInput(/*input=*/out_backprop, /*spatial_dim_count=*/2);
-  const auto out_backprop_size =
-      XlaHelpers::SizesOfXlaOp(batch_out_backprop_info.batch_input);
-  XLA_CHECK_EQ(out_backprop_size.size(), 4)
-      << "Invalid rank of gradient output";
-  std::vector<xla::int64> output_size{out_backprop_size[2],
-                                      out_backprop_size[3]};
-  auto gradients_size = XlaHelpers::SizesOfXlaOp(input);
-  XLA_CHECK(gradients_size.size() == 4 || gradients_size.size() == 3)
+xla::XlaOp BuildAdaptiveAvgPool3d(xla::XlaOp input,
+                                  absl::Span<const xla::int64> output_size) {
+  XLA_CHECK_EQ(output_size.size(), 3) << "Invalid output size rank";
+  const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
+  XLA_CHECK(input_shape.rank() == 4 || input_shape.rank() == 5)
+      << "Only 4D or 5D tensors supported";
+  return BuildAdaptiveAvgPool(input, output_size, /*pool_dim=*/3);
+}
+
+xla::XlaOp BuildAdaptiveAvgPool2d(xla::XlaOp input,
+                                  absl::Span<const xla::int64> output_size) {
+  XLA_CHECK_EQ(output_size.size(), 2) << "Invalid output size rank";
+  const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
+  XLA_CHECK(input_shape.rank() == 4 || input_shape.rank() == 3)
       << "Only 4D or 3D tensors supported";
-  if (gradients_size.size() == 3) {
+  return BuildAdaptiveAvgPool(input, output_size, /*pool_dim=*/2);
+}
+
+xla::XlaOp BuildAdaptiveAvgPoolBackward(xla::XlaOp out_backprop,
+                                        xla::XlaOp input, int pool_dim) {
+  BatchInput batch_out_backprop_info =
+      CreateBatchInput(/*input=*/out_backprop, /*spatial_dim_count=*/pool_dim);
+  const xla::Shape& out_backprop_shape =
+      XlaHelpers::ShapeOfXlaOp(batch_out_backprop_info.batch_input);
+  XLA_CHECK_EQ(out_backprop_shape.rank(), pool_dim + 2)
+      << "Invalid rank of gradient output";
+  std::vector<xla::int64> output_size(
+      out_backprop_shape.dimensions().begin() + 2,
+      out_backprop_shape.dimensions().end());
+  auto gradients_size = XlaHelpers::SizesOfXlaOp(input);
+  if (gradients_size.size() == pool_dim + 1) {
     gradients_size.insert(gradients_size.begin(), 1);
   }
   const auto kernel_size =
-      AdaptiveAvgPoolKernelSize(gradients_size, output_size);
-  std::vector<std::pair<xla::int64, xla::int64>> no_padding(2);
+      AdaptiveAvgPoolKernelSize(gradients_size, output_size, pool_dim);
+  std::vector<std::pair<xla::int64, xla::int64>> no_padding(pool_dim);
   xla::XlaOp batch_result = xla::AvgPoolGrad(
       /*out_backprop=*/batch_out_backprop_info.batch_input,
       /*gradients_size=*/gradients_size,
       /*kernel_size=*/kernel_size,
       /*stride=*/kernel_size,
       /*spatial_padding=*/no_padding,
-      /*data_format=*/MakeNCHWFormat(2),
+      /*data_format=*/MakeNCHWFormat(pool_dim),
       /*counts_include_padding=*/false);
   return RemoveTrivialBatch(
       /*batch=*/batch_result,
       /*original_rank=*/batch_out_backprop_info.original_rank,
-      /*spatial_dim_count=*/2);
+      /*spatial_dim_count=*/pool_dim);
+}
+
+xla::XlaOp BuildAdaptiveAvgPool3dBackward(xla::XlaOp out_backprop,
+                                          xla::XlaOp input) {
+  const xla::Shape& gradients_shape = XlaHelpers::ShapeOfXlaOp(input);
+  XLA_CHECK(gradients_shape.rank() == 4 || gradients_shape.rank() == 5)
+      << "Only 4D or 5D tensors supported";
+  return BuildAdaptiveAvgPoolBackward(out_backprop, input,
+                                      /*pool_dim=*/3);
+}
+
+xla::XlaOp BuildAdaptiveAvgPool2dBackward(xla::XlaOp out_backprop,
+                                          xla::XlaOp input) {
+  const xla::Shape& gradients_shape = XlaHelpers::ShapeOfXlaOp(input);
+  XLA_CHECK(gradients_shape.rank() == 4 || gradients_shape.rank() == 3)
+      << "Only 4D or 3D tensors supported";
+  return BuildAdaptiveAvgPoolBackward(out_backprop, input,
+                                      /*pool_dim=*/2);
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/pooling.cpp
+++ b/torch_xla/csrc/pooling.cpp
@@ -352,8 +352,7 @@ bool IsSupportedAdaptiveAvgPool(absl::Span<const xla::int64> input_size,
                                 absl::Span<const xla::int64> output_size,
                                 int pool_dim) {
   xla::int64 rank = input_size.size();
-  XLA_CHECK_EQ(output_size.size(), pool_dim)
-      << "Output shape MUST be" << pool_dim;
+  XLA_CHECK_EQ(output_size.size(), pool_dim);
   for (int spatial_dim = 0; spatial_dim < pool_dim; ++spatial_dim) {
     if (input_size[rank - pool_dim + spatial_dim] % output_size[spatial_dim] !=
         0) {

--- a/torch_xla/csrc/pooling.h
+++ b/torch_xla/csrc/pooling.h
@@ -50,6 +50,14 @@ xla::XlaOp BuildMaxUnpoolNdBackward(xla::XlaOp grad_output, xla::XlaOp input,
                                     absl::Span<const xla::int64> output_size);
 
 // Computes adaptive average pooling for the given input and output size.
+xla::XlaOp BuildAdaptiveAvgPool3d(xla::XlaOp input,
+                                  absl::Span<const xla::int64> output_size);
+
+// Computes the gradient for adaptive average pooling.
+xla::XlaOp BuildAdaptiveAvgPool3dBackward(xla::XlaOp out_backprop,
+                                          xla::XlaOp input);
+
+// Computes adaptive average pooling for the given input and output size.
 xla::XlaOp BuildAdaptiveAvgPool2d(xla::XlaOp input,
                                   absl::Span<const xla::int64> output_size);
 
@@ -59,7 +67,8 @@ xla::XlaOp BuildAdaptiveAvgPool2dBackward(xla::XlaOp out_backprop,
 
 // Returns true if XLA lowering is supported for the given input and output size
 // combination.
-bool IsSupportedAdaptiveAvgPool2d(absl::Span<const xla::int64> input_size,
-                                  absl::Span<const xla::int64> output_size);
+bool IsSupportedAdaptiveAvgPool(absl::Span<const xla::int64> input_size,
+                                absl::Span<const xla::int64> output_size,
+                                int pool_dim);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -234,6 +234,12 @@ class XLATensor {
       const XLATensor& input, const XLATensor& other,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
 
+  static XLATensor adaptive_avg_pool3d(const XLATensor& input,
+                                       std::vector<xla::int64> output_size);
+
+  static XLATensor adaptive_avg_pool3d_backward(const XLATensor& grad_output,
+                                                const XLATensor& input);
+
   static XLATensor _adaptive_avg_pool2d(const XLATensor& input,
                                         std::vector<xla::int64> output_size);
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -17,6 +17,7 @@
 #include "torch_xla/csrc/layout_manager.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/ops/adaptive_avg_pool2d.h"
+#include "torch_xla/csrc/ops/adaptive_avg_pool3d.h"
 #include "torch_xla/csrc/ops/all.h"
 #include "torch_xla/csrc/ops/all_reduce.h"
 #include "torch_xla/csrc/ops/all_to_all.h"
@@ -440,6 +441,18 @@ XLATensor XLATensor::__rshift__(
   return input.CreateFrom(
       ir::ops::Rshift(input.GetIrValue(), other.GetIrValue()),
       logical_element_type);
+}
+
+XLATensor XLATensor::adaptive_avg_pool3d(const XLATensor& input,
+                                         std::vector<xla::int64> output_size) {
+  return input.CreateFrom(ir::MakeNode<ir::ops::AdaptiveAvgPool3d>(
+      input.GetIrValue(), std::move(output_size)));
+}
+
+XLATensor XLATensor::adaptive_avg_pool3d_backward(const XLATensor& grad_output,
+                                                  const XLATensor& input) {
+  return input.CreateFrom(ir::ops::AdaptiveAvgPool3dBackward(
+      grad_output.GetIrValue(), input.GetIrValue()));
 }
 
 XLATensor XLATensor::_adaptive_avg_pool2d(const XLATensor& input,


### PR DESCRIPTION
@JackCaoG , here are the changes for #2592.
Since adaptive_pool_2d code was highly reusable I tried to create dimension independent functions to implement.
Also add the cpp test.
The test itself is not comprehensive. 
But I have tested more scenarios with python.
IsSupported function returns falls if the output dimension do not fully divide the corresponding input dimensions.
This was the behavior with 2d implementation.
I have kept it the same.