### PR TITLE
Lowering of random_(discrete uniform)

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -187,6 +187,9 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_matrix_exp_analytic_xla',  # server side crash
         'test_muldiv_scalar_xla_bfloat16',  # FIXME
         'test_kthvalue_xla_.*',  # FIXME
+        'test_random_from_to_bool',  # doesn't raise
+        'test_random_from_to_xla',  # doesn't raise
+        'test_random_to_xla',  # doesn't raise
     },
     'TestViewOpsXLA': {
         'test_contiguous_nonview',

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -664,6 +664,17 @@ class TestSelect(XlaTestCase):
     self.assertEqual(tx, sx.data.cpu())
 
 
+class TestRandom(XlaTestCase):
+
+  def test_random_from_to_bool(self):
+    for from_val, to_val in [[0, 1], [0, 2], [1, 2]]:
+      x = _gen_tensor(10, device=xm.xla_device())
+      x.random_(from_val, to_val)
+      delta = 1
+      self.assertTrue(from_val <= x.to(torch.int).min() < (from_val + delta))
+      self.assertTrue((to_val - delta) <= x.to(torch.int).max() < to_val)
+
+
 class TestBinaryCrossEntropyLimitValue(XlaTestCase):
 
   def test_cross_entropy_loss(self):

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -68,6 +68,44 @@ c10::optional<at::ScalarType> PromoteIntegralType(
                                                                    : opt_dtype;
 }
 
+bool IsTypeWithLargerRangeThanLong(torch::ScalarType dtype) {
+  return dtype == at::ScalarType::BFloat16 || dtype == at::ScalarType::Float ||
+         dtype == at::ScalarType::Double;
+}
+
+// Return the upper limit for a given type. For floating point typesreturn
+// 2^mantissa to ensure that every value is representable.
+int64_t GetIntegerUpperLimitForType(torch::ScalarType dtype) {
+  xla::PrimitiveType xla_type = TensorTypeToRawXlaType(dtype);
+  switch (xla_type) {
+    case xla::PrimitiveType::F16:
+      return static_cast<int64_t>(1) << std::numeric_limits<xla::half>::digits;
+    case xla::PrimitiveType::BF16:
+      return static_cast<int64_t>(1)
+             << std::numeric_limits<xla::bfloat16>::digits;
+    case xla::PrimitiveType::F32:
+      return static_cast<int64_t>(1) << std::numeric_limits<float>::digits;
+    case xla::PrimitiveType::F64:
+      return static_cast<int64_t>(1) << std::numeric_limits<double>::digits;
+    default:
+      return XlaHelpers::MinMaxValues(xla_type).max.toLong();
+  }
+}
+
+void CheckRangeValues(torch::ScalarType dtype, int64_t from, int64_t to) {
+  XlaHelpers::MinMax min_max;
+  // Bound the min_max by int64 since types of "from" and "to" are int64.
+  if (IsTypeWithLargerRangeThanLong(dtype)) {
+    min_max = XlaHelpers::MinMaxValues(xla::PrimitiveType::S64);
+  } else {
+    min_max = XlaHelpers::MinMaxValues(TensorTypeToRawXlaType(dtype));
+  }
+  XLA_CHECK_GE(from, min_max.min.toLong());
+  XLA_CHECK_LE(from, min_max.max.toLong());
+  XLA_CHECK_GE(to, min_max.min.toLong());
+  XLA_CHECK_LE(to, min_max.max.toLong());
+}
+
 std::pair<XLATensor, XLATensor> GetBinaryOperands(const at::Tensor& self,
                                                   const at::Tensor& other) {
   XLATensor self_tensor;
@@ -2549,6 +2587,54 @@ std::tuple<at::Tensor, at::Tensor> AtenXlaType::qr(const at::Tensor& self,
                          bridge::AtenFromXlaTensor(std::get<1>(results)));
 }
 
+// The value generated should be within (from, to].
+at::Tensor& AtenXlaType::random_(at::Tensor& self, int64_t from,
+                                 c10::optional<int64_t> to,
+                                 c10::optional<at::Generator> generator) {
+  XLA_FN_COUNTER("xla::");
+  if (generator.has_value() && generator->defined()) {
+    return AtenXlaTypeDefault::random_(self, from, to, generator);
+  }
+  XLATensor self_tensor = bridge::GetXlaTensor(self);
+  at::ScalarType dtype = self_tensor.dtype();
+  // Prevent "to_val" from overflowing with at::ScalarType::Long.
+  int64_t inc = (dtype == at::ScalarType::Long) ? 0 : 1;
+  int64_t to_val = (to) ? *to : GetIntegerUpperLimitForType(dtype) + inc;
+  XLA_CHECK_LE(from, to_val);
+  CheckRangeValues(self_tensor.dtype(), from, to_val - 1);
+  XLATensor::random_(self_tensor, from, to_val);
+  return self;
+}
+
+// The value generated should be in (0, to].
+at::Tensor& AtenXlaType::random_(at::Tensor& self, int64_t to,
+                                 c10::optional<at::Generator> generator) {
+  XLA_FN_COUNTER("xla::");
+  if (generator.has_value() && generator->defined()) {
+    return AtenXlaTypeDefault::random_(self, to, generator);
+  }
+  XLATensor self_tensor = bridge::GetXlaTensor(self);
+  XLA_CHECK_GT(to, 0);
+  CheckRangeValues(self_tensor.dtype(), 0, to - 1);
+  XLATensor::random_(self_tensor, 0, to);
+  return self;
+}
+
+// The value generated should be in (self_type_min, self_type_max).
+at::Tensor& AtenXlaType::random_(at::Tensor& self,
+                                 c10::optional<at::Generator> generator) {
+  XLA_FN_COUNTER("xla::");
+  if (generator.has_value() && generator->defined()) {
+    return AtenXlaTypeDefault::random_(self, generator);
+  }
+  XLATensor self_tensor = bridge::GetXlaTensor(self);
+  at::ScalarType dtype = self_tensor.dtype();
+  // Prevent "to_val" from overflowing with at::ScalarType::Long.
+  int64_t inc = (dtype == at::ScalarType::Long) ? 0 : 1;
+  XLATensor::random_(self_tensor, 0, GetIntegerUpperLimitForType(dtype) + inc);
+  return self;
+}
+
 at::Tensor AtenXlaType::reciprocal(const at::Tensor& self) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
@@ -3254,8 +3340,8 @@ at::Tensor AtenXlaType::upsample_bilinear2d(const at::Tensor& self,
                                             c10::optional<double> scales_w) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
-  // Only the XLA TPU backend for now implements the CustomCall required by our
-  // XLA lowering.
+  // Only the XLA TPU backend for now implements the CustomCall required by
+  // our XLA lowering.
   if (self_tensor.GetDevice().hw_type != DeviceType::TPU ||
       (scales_h && *scales_h != 1.0) || (scales_w && *scales_w != 1.0)) {
     return AtenXlaTypeDefault::upsample_bilinear2d(
@@ -3272,8 +3358,8 @@ at::Tensor AtenXlaType::upsample_bilinear2d_backward(
     c10::optional<double> scales_h, c10::optional<double> scales_w) {
   XLA_FN_COUNTER("xla::");
   XLATensor grad_output_tensor = bridge::GetXlaTensor(grad_output);
-  // Only the XLA TPU backend for now implements the CustomCall required by our
-  // XLA lowering.
+  // Only the XLA TPU backend for now implements the CustomCall required by
+  // our XLA lowering.
   if (grad_output_tensor.GetDevice().hw_type != DeviceType::TPU ||
       (scales_h && *scales_h != 1.0) || (scales_w && *scales_w != 1.0)) {
     return AtenXlaTypeDefault::upsample_bilinear2d_backward(
@@ -3329,8 +3415,8 @@ at::Tensor AtenXlaType::upsample_nearest2d(const at::Tensor& self,
                                            c10::optional<double> scales_w) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
-  // Only the XLA TPU backend for now implements the CustomCall required by our
-  // XLA lowering.
+  // Only the XLA TPU backend for now implements the CustomCall required by
+  // our XLA lowering.
   if (self_tensor.GetDevice().hw_type != DeviceType::TPU ||
       (scales_h && *scales_h != 1.0) || (scales_w && *scales_w != 1.0)) {
     return AtenXlaTypeDefault::upsample_nearest2d(self, output_size, scales_h,
@@ -3346,8 +3432,8 @@ at::Tensor AtenXlaType::upsample_nearest2d_backward(
     c10::optional<double> scales_w) {
   XLA_FN_COUNTER("xla::");
   XLATensor grad_output_tensor = bridge::GetXlaTensor(grad_output);
-  // Only the XLA TPU backend for now implements the CustomCall required by our
-  // XLA lowering.
+  // Only the XLA TPU backend for now implements the CustomCall required by
+  // our XLA lowering.
   if (grad_output_tensor.GetDevice().hw_type != DeviceType::TPU ||
       (scales_h && *scales_h != 1.0) || (scales_w && *scales_w != 1.0)) {
     return AtenXlaTypeDefault::upsample_nearest2d_backward(

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -793,6 +793,16 @@ class AtenXlaType {
   static std::tuple<at::Tensor, at::Tensor> qr(const at::Tensor& self,
                                                bool some);
 
+  static at::Tensor& random_(at::Tensor& self, int64_t from,
+                             c10::optional<int64_t> to,
+                             c10::optional<at::Generator> generator);
+
+  static at::Tensor& random_(at::Tensor& self, int64_t to,
+                             c10::optional<at::Generator> generator);
+
+  static at::Tensor& random_(at::Tensor& self,
+                             c10::optional<at::Generator> generator);
+
   static at::Tensor reciprocal(const at::Tensor& self);
 
   static at::Tensor& reciprocal_(at::Tensor& self);

--- a/torch_xla/csrc/ops/discrete_uniform.cpp
+++ b/torch_xla/csrc/ops/discrete_uniform.cpp
@@ -1,0 +1,32 @@
+#include "torch_xla/csrc/ops/discrete_uniform.h"
+
+#include "tensorflow/compiler/xla/xla_client/util.h"
+#include "tensorflow/compiler/xla/xla_client/xla_util.h"
+#include "torch_xla/csrc/helpers.h"
+#include "torch_xla/csrc/lowering_context.h"
+#include "torch_xla/csrc/random.h"
+
+namespace torch_xla {
+namespace ir {
+namespace ops {
+
+DiscreteUniform::DiscreteUniform(const Value& from, const Value& to,
+                                 const Value& seed, const xla::Shape& rng_shape)
+    : Node(ir::OpKind(at::aten::random), {from, to, seed}, rng_shape,
+           /*num_outputs=*/1, xla::util::ShapeHash(rng_shape)) {}
+
+NodePtr DiscreteUniform::Clone(OpList operands) const {
+  return MakeNode<DiscreteUniform>(operands.at(0), operands.at(1),
+                                   operands.at(2), shape());
+}
+
+XlaOpVector DiscreteUniform::Lower(LoweringContext* loctx) const {
+  xla::XlaOp from = loctx->GetOutputOp(operand(0));
+  xla::XlaOp to = loctx->GetOutputOp(operand(1));
+  xla::XlaOp rng_seed = loctx->GetOutputOp(operand(2));
+  return ReturnOp(RngDiscreteUniform(rng_seed, shape(), from, to), loctx);
+}
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/discrete_uniform.h
+++ b/torch_xla/csrc/ops/discrete_uniform.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "torch_xla/csrc/ir.h"
+
+namespace torch_xla {
+namespace ir {
+namespace ops {
+
+class DiscreteUniform : public Node {
+ public:
+  DiscreteUniform(const Value& from, const Value& to, const Value& seed,
+                  const xla::Shape& rng_shape);
+
+  NodePtr Clone(OpList operands) const override;
+
+  XlaOpVector Lower(LoweringContext* loctx) const override;
+};
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/random.cpp
+++ b/torch_xla/csrc/random.cpp
@@ -69,6 +69,29 @@ xla::Shape MakeRngShape(const xla::Shape& shape) {
 
 }  // namespace
 
+xla::XlaOp RngDiscreteUniform(xla::XlaOp seed, const xla::Shape& shape,
+                              xla::XlaOp minval, xla::XlaOp maxval) {
+  xla::PrimitiveType minval_type = XlaHelpers::TypeOfXlaOp(minval);
+  xla::PrimitiveType maxval_type = XlaHelpers::TypeOfXlaOp(maxval);
+  XLA_CHECK_EQ(minval_type, maxval_type);
+  XLA_CHECK(minval_type == xla::PrimitiveType::S64 ||
+            minval_type == xla::PrimitiveType::U64 ||
+            minval_type == xla::PrimitiveType::S32 ||
+            minval_type == xla::PrimitiveType::U32)
+      << "RngDiscreteUniform not implemented for type "
+      << xla::primitive_util::LowercasePrimitiveTypeName(minval_type);
+  xla::XlaOp rng_seed = MakeSeed(seed);
+  xla::XlaOp initial_state =
+      xla::Zero(rng_seed.builder(), xla::PrimitiveType::U64);
+  xla::Shape rng_shape(shape);
+  rng_shape.set_element_type(minval_type);
+  xla::XlaOp result =
+      xla::UniformIntDistribution(rng_seed, initial_state, GetBitGenerator(),
+                                  minval, maxval, rng_shape)
+          .value;
+  return MaybeConvertTo(result, shape.element_type());
+}
+
 xla::XlaOp RngUniform(xla::XlaOp seed, const xla::Shape& shape,
                       xla::XlaOp minval, xla::XlaOp maxval) {
   xla::XlaOp rng_seed = MakeSeed(seed);

--- a/torch_xla/csrc/random.h
+++ b/torch_xla/csrc/random.h
@@ -7,6 +7,9 @@ namespace torch_xla {
 xla::XlaOp RngUniform(xla::XlaOp seed, const xla::Shape& shape,
                       xla::XlaOp minval, xla::XlaOp maxval);
 
+xla::XlaOp RngDiscreteUniform(xla::XlaOp seed, const xla::Shape& shape,
+                              xla::XlaOp minval, xla::XlaOp maxval);
+
 xla::XlaOp RngNormal(xla::XlaOp seed, const xla::Shape& shape, xla::XlaOp mean,
                      xla::XlaOp std);
 

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -872,6 +872,8 @@ class XLATensor {
 
   static std::tuple<XLATensor, XLATensor> qr(const XLATensor& input, bool some);
 
+  static void random_(XLATensor& input, int64_t from, int64_t to);
+
   static XLATensor randperm(xla::int64 n, const Device& device,
                             at::ScalarType scalar_type);
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -43,6 +43,7 @@
 #include "torch_xla/csrc/ops/cumsum.h"
 #include "torch_xla/csrc/ops/device_data.h"
 #include "torch_xla/csrc/ops/diagonal.h"
+#include "torch_xla/csrc/ops/discrete_uniform.h"
 #include "torch_xla/csrc/ops/expand.h"
 #include "torch_xla/csrc/ops/exponential.h"
 #include "torch_xla/csrc/ops/flip.h"
@@ -2112,6 +2113,15 @@ std::tuple<XLATensor, XLATensor> XLATensor::qr(const XLATensor& input,
   ir::NodePtr node = ir::MakeNode<ir::ops::QR>(input.GetIrValue(), some);
   return std::make_tuple(input.CreateFrom(ir::Value(node, 0)),
                          input.CreateFrom(ir::Value(node, 1)));
+}
+
+void XLATensor::random_(XLATensor& input, int64_t from, int64_t to) {
+  XLA_CHECK_LE(from, to);
+  auto input_shape = input.shape();
+  input.SetInPlaceIrValue(ir::MakeNode<ir::ops::DiscreteUniform>(
+      GetIrValueForScalar(from, xla::PrimitiveType::S64, input.GetDevice()),
+      GetIrValueForScalar(to, xla::PrimitiveType::S64, input.GetDevice()),
+      GetRngSeed(input.GetDevice()), input_shape));
 }
 
 XLATensor XLATensor::reciprocal(const XLATensor& input) {


### PR DESCRIPTION
Per https://github.com/pytorch/xla/issues/2603 request

Logic of `GetUpperLimitForType ` is borrow from pytorch in https://github.com/pytorch/pytorch/blob/c88ac2567935c37780e21c65ab4c43ea9f817373/aten/src/ATen/native/DistributionTemplates.h#L113 since the logic is a bit messy to reimplement with xla type. We could force the user always pass `from` and `to` to get rid of this slightly ugly code.