### PR TITLE
Add dynamic shape support for nms op

### DIFF
--- a/torch_xla/csrc/nms_op.cpp
+++ b/torch_xla/csrc/nms_op.cpp
@@ -235,6 +235,11 @@ NmsResult BuildNms(xla::XlaOp boxes, xla::XlaOp scores,
   xla::XlaOp iou_threshold_mask = xla::Gt(iou, iou_threshold + square_zero);
   xla::XlaOp included_iou =
       xla::Broadcast(xla::ConstantR0<bool>(builder, true), {num_boxes});
+  if (boxes_shape.is_dynamic_dimension(0)) {
+    // Update included_iou's size to match boxes actual size.
+    included_iou = xla::SetDimensionSize(
+        included_iou, XlaHelpers::GetDimensionsSize({boxes}, {0}).size, 0);
+  }
 
   xla::XlaOp zero_s32 = xla::Zero(builder, xla::PrimitiveType::S32);
   xla::XlaOp one_s32 = xla::One(builder, xla::PrimitiveType::S32);


### PR DESCRIPTION
Thanks @yunxing for the help. This is to fix https://github.com/pytorch/xla/issues/2602.

This broadcast generated 
```
%broadcast.200 = pred[5]{0} broadcast(pred[] %constant.199), dimensions={}, metadata={op_type="xla::nms" source_file="nms@functions.py" source_line=107}
```
in nms is static shaped(and boxes is dynamic shaped in above example). This `broadcast` will be used in `while` and caused problem if its shape mismatched with the boxes. Set the dimension 0 size to be boxes' dimension 0 size.

Full repo
```
import torch
import torch_xla
import torch_xla.core.xla_model as xm
import torch_xla.distributed.xla_multiprocessing as xmp
import torch_xla.core.functions as xf
def remove_small_boxes(boxes, min_size):
    # type: (Tensor, float) -> Tensor
    """
    Remove boxes which contains at least one side smaller than min_size.
    Arguments:
        boxes (Tensor[N, 4]): boxes in (x1, y1, x2, y2) format
        min_size (float): minimum size
    Returns:
        keep (Tensor[K]): indices of the boxes that have both sides
            larger than min_size
    """
    ws, hs = boxes[:, 2] - boxes[:, 0], boxes[:, 3] - boxes[:, 1]
    keep = (ws >= min_size) & (hs >= min_size)
    keep = keep.nonzero().squeeze(1)
    return keep
def test_nms():
    BOXES = (
        (0, 0, 3, 2),
        (3, 3, 11, 7),
        (2, 2, 5, 7),
        (7, 4, 15, 12),
        (1, 1, 2, 2)
    )
    SCORES = (0.9, 0.5, 0.95, 0.4, 0.3)
    SCORE_THRESHOLD = 0.1
    IOU_THRESHOLD = 0.08
    xla_device = xm.xla_device()
    boxes = torch.tensor(BOXES, dtype=torch.float).to(xla_device)
    scores = torch.tensor(SCORES, dtype=torch.float).to(xla_device)
    keep = remove_small_boxes(boxes, 1.2)
    
    boxes = boxes[keep]
    scores = scores[keep]
    
    keep = xf.nms(boxes, scores, torch.tensor(0, device=xla_device, dtype=torch.float), torch.tensor(IOU_THRESHOLD, device=xla_device, dtype=torch.float), len(box
es))[0]
    print(keep)

if __name__ == "__main__":
    test_nms()
```