### PR TITLE
Disable test_kthvalue_xla_* to unblock the master build

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -186,6 +186,7 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_shift_mem_overlap',  # doesn't raise
         'test_matrix_exp_analytic_xla',  # server side crash
         'test_muldiv_scalar_xla_bfloat16',  # FIXME
+        'test_kthvalue_xla_.*',  # FIXME
     },
     'TestViewOpsXLA': {
         'test_contiguous_nonview',


### PR DESCRIPTION
This is related to https://github.com/pytorch/xla/issues/2620. Disable the test before I can work on a fix