### PR TITLE
Fix `global_device_map` sorting

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -292,7 +292,9 @@ def xla_replication_devices(local_devices):
       raise RuntimeError('Invalid device format: {}'.format(device))
     if xdev[0] == device_type:
       replication_devices.append(device)
-  return replication_devices
+  sorted_by_ordinal = sorted(
+      replication_devices, key=lambda device: parse_xla_device(device)[1])
+  return sorted_by_ordinal
 
 
 def unlazy(tensors):


### PR DESCRIPTION
Fixes #2601. Previously sorted lexicographically, causing wrong
DeviceAssignment and wrong result in `all_to_all` collective.

cc: @taylanbil 