### PR TITLE
Default master_print to global ordinal prints only.

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -209,7 +209,7 @@ def is_master_ordinal(local=True):
   return ordinal == 0
 
 
-def master_print(*args, fd=sys.stdout, local=True, flush=False):
+def master_print(*args, fd=sys.stdout, local=False, flush=False):
   if is_master_ordinal(local=local):
     print(*args, file=fd, flush=flush)
 


### PR DESCRIPTION
Printing metrics reports, accuracies etc from every local master ordinal causes spam in pods training. We can default to one print only imho.