### PR TITLE
updates to enable viewing metrics graphs in tensorboard

### DIFF
--- a/scripts/debug_run.py
+++ b/scripts/debug_run.py
@@ -110,6 +110,15 @@ def grab_graphs(args):
       fd.write(report)
 
 
+def metrics_to_tensorboard(args):
+  script_path = os.path.join(get_scripts_path(), 'metrics_to_tensorboard.py')
+  log_dir = os.path.join(args.outdir, 'tensorboard')
+  subprocess.run([
+      script_path, '--logdir={}'.format(log_dir),
+      '--imgdir={}'.format(get_metrics_imgdir_path(args.outdir))
+  ])
+
+
 def grab_metrics(args):
   metrics_file = get_first_file(get_metrics_file_path(args.outdir))
   if metrics_file is not None:
@@ -121,6 +130,7 @@ def grab_metrics(args):
     ]).decode('utf-8')
     with open(get_metrics_report_path(args.outdir), 'w') as fd:
       fd.write(report)
+    metrics_to_tensorboard(args)
 
 
 def create_temp_folder():

--- a/scripts/metrics_to_tensorboard.py
+++ b/scripts/metrics_to_tensorboard.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# Add metrics images to tensorboard summary for easy viewing/comparisons
+
+import argparse
+import os
+
+from PIL import Image
+from pathlib import Path
+
+from torch.utils.tensorboard import SummaryWriter
+from torchvision.transforms import ToTensor
+
+
+def generate_tensorboard_img_summary(logdir, imgdir):
+  writer = SummaryWriter(logdir)
+  all_metrics_graphs = list(Path(imgdir).rglob("*.png"))
+
+  for img in all_metrics_graphs:
+    tag = os.path.basename(img)
+    img_tensor = ToTensor()(Image.open(img))
+    writer.add_image(tag, img_tensor, 0)
+  writer.close()
+
+
+if __name__ == '__main__':
+  arg_parser = argparse.ArgumentParser()
+  arg_parser.add_argument('--logdir', type=str)
+  arg_parser.add_argument('--imgdir', type=str)
+  args = arg_parser.parse_args()
+  generate_tensorboard_img_summary(args.logdir, args.imgdir)


### PR DESCRIPTION
This feature enables viewing metrics graph images in tensorboard. In remote terminal environment, tensorboard image summaries can be very helpful. Each metrics image is also tagged with metrics image name for easy filtering in tensorboard.