### PR TITLE
Quick fix for is_non_overlapping_and_dense_.

### DIFF
--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -55,7 +55,9 @@ XLATensorImpl::XLATensorImpl(XLATensor tensor)
                                           c10::DispatchKey::AutogradXLA},
                       GetTypeMeta(tensor),
                       bridge::XlaDeviceToAtenDevice(tensor.GetDevice())),
-      tensor_(std::move(tensor)) {}
+      tensor_(std::move(tensor)) {
+  is_non_overlapping_and_dense_ = false;
+}
 
 void XLATensorImpl::set_tensor(XLATensor xla_tensor) {
   tensor_ = std::move(xla_tensor);


### PR DESCRIPTION
Master is broken by https://github.com/pytorch/pytorch/pull/48625 but CI passed on the original pytorch PR. I need to find out what's the difference between the two CI environments (mine and @JackCaoG also produced different behavior) so that we can catch this next time. 
I want to make this change so that we get pytorch/xla CI back to green, a proper fix will likely land on pytorch side I think. 