### PR TITLE
add SiLU to fix #2717

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -3067,6 +3067,18 @@ TEST_F(AtenXlaTensorTest, TestLogsumexp) {
   }
 }
 
+TEST_F(AtenXlaTensorTest, TestSiLU) {
+  torch::Tensor a = torch::rand({2, 2}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor b = torch::silu(a);
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_a = CopyToDevice(a, device);
+    torch::Tensor xla_b = torch::silu(xla_a);
+    AllClose(b, xla_b, /*rtol=*/1e-3, /*atol=*/1e-5);
+  });
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::silu_out", cpp_test::GetIgnoredCounters());
+}
+
 TEST_F(AtenXlaTensorTest, TestSigmoid) {
   torch::Tensor a = torch::rand({2, 2}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::sigmoid(a);

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2866,6 +2866,14 @@ at::Tensor AtenXlaType::select(const at::Tensor& self, int64_t dim,
       XLATensor::select(bridge::GetXlaTensor(self), dim, index));
 }
 
+at::Tensor& AtenXlaType::silu_out(const at::Tensor& self, at::Tensor& out) {
+  XLA_FN_COUNTER("xla::");
+  XLATensor out_tensor = bridge::GetXlaTensor(out);
+  XLATensor self_tensor = bridge::GetXlaTensor(self);
+  XLATensor::silu_out(self_tensor, out_tensor);
+  return out;
+}
+
 at::Tensor AtenXlaType::sigmoid(const at::Tensor& self) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -872,6 +872,8 @@ class AtenXlaType {
 
   static at::Tensor select(const at::Tensor& self, int64_t dim, int64_t index);
 
+  static at::Tensor& silu_out(const at::Tensor& self, at::Tensor& out);
+
   static at::Tensor sigmoid(const at::Tensor& self);
 
   static at::Tensor& sigmoid_(at::Tensor& self);

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -206,6 +206,15 @@ NodePtr LogSigmoidBackward(const Value& grad_output, const Value& input,
   return grad_output * (Neg(max_deriv) - sign * (buffer - one) / buffer);
 }
 
+NodePtr SiLU(const Value& input) {
+  auto lower_fn = [](const Node& node, LoweringContext* loctx) -> XlaOpVector {
+    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
+    return node.ReturnOp(xla_input * BuildSigmoid(xla_input), loctx);
+  };
+  return GenericOp(OpKind(at::aten::silu), {input}, input.shape(),
+                   std::move(lower_fn));
+}
+
 NodePtr Sigmoid(const Value& input) {
   auto lower_fn = [](const Node& node, LoweringContext* loctx) -> XlaOpVector {
     xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -126,6 +126,8 @@ NodePtr LogSigmoidBackward(const Value& grad_output, const Value& input,
 
 NodePtr Sigmoid(const Value& input);
 
+NodePtr SiLU(const Value& input);
+
 NodePtr SigmoidBackward(const Value& grad_output, const Value& output);
 
 NodePtr LogSoftmaxBackwardOp(const Value& grad_output, const Value& output,

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -956,6 +956,7 @@ class XLATensor {
   static XLATensor select(const XLATensor& input, xla::int64 dim,
                           xla::int64 index);
 
+  static void silu_out(XLATensor& input, XLATensor& out);
   static XLATensor sigmoid(const XLATensor& input);
   static void sigmoid_(XLATensor& input);
   static XLATensor sigmoid_backward(const XLATensor& grad_output,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2337,9 +2337,8 @@ XLATensor XLATensor::select(const XLATensor& input, xla::int64 dim,
   return tensor_ops::Select(input, dim, index);
 }
 
-void XLATensor::silu_out(XLATensor& input, XLATensor& out){
-  auto value = input.GetIrValue() * ir::ops::Sigmoid(input.GetIrValue());
-  out.SetInPlaceIrValue(value);
+void XLATensor::silu_out(XLATensor& input, XLATensor& out) {
+  out.SetInPlaceIrValue(ir::ops::SiLU(input.GetIrValue()));
 }
 
 XLATensor XLATensor::sigmoid(const XLATensor& input) {

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2337,6 +2337,11 @@ XLATensor XLATensor::select(const XLATensor& input, xla::int64 dim,
   return tensor_ops::Select(input, dim, index);
 }
 
+void XLATensor::silu_out(XLATensor& input, XLATensor& out){
+  auto value = input.GetIrValue() * ir::ops::Sigmoid(input.GetIrValue());
+  out.SetInPlaceIrValue(value);
+}
+
 XLATensor XLATensor::sigmoid(const XLATensor& input) {
   return input.CreateFrom(ir::ops::Sigmoid(input.GetIrValue()));
 }


### PR DESCRIPTION
I had this version and also one implemented with `mul` and `sigmoid` directly in `aten_xla_type` without going "down" to `tensor_methods` as this one is that preffered?

I dont think I need to add a test case, but if I need to where I add it or what I would need to test?

My local test was something like

```python
import torch
from torch.nn import SiLU
import torch_xla.core.xla_model as xm


dede=xm.xla_device()
m = SiLU()
m = m.to(dede)
input = torch.randn(2)
print('input', input)
input2 = input.clone()
input = input.to(dede)
output = m(input)
print(output)
print(output.device)
m2 = SiLU()
print("normal")
print('input2', input2)
o2 = m2(input2)
print(o2)
```

it prints 

```
input tensor([0.0087, 0.1275])
tensor([0.0044, 0.0678], device='xla:1')
xla:1
normal
input2 tensor([0.0087, 0.1275])
tensor([0.0044, 0.0678])
```

Waiting for review.

For the issue #2717 