### PR TITLE
Fix broken CircleCI python version

### DIFF
--- a/.circleci/setup_ci_environment.sh
+++ b/.circleci/setup_ci_environment.sh
@@ -1,5 +1,5 @@
 set -e
-pyenv local 3.5.2
+pyenv local 3.6.5
 pip install --upgrade pip
 pip install pyyaml -qqq
 echo "export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_FOR_ECR_READ_WRITE}" >> $BASH_ENV


### PR DESCRIPTION
With the release of pypi.org/project/pip/21.0 it started including pypa/pip#9361 where the project started using python3 f-strings, which are only added since py3.6. On our CI we use python 3.5.2 https://github.com/pytorch/xla/blob/master/.circleci/setup_ci_environment.sh#L2 so our CI is failing. Sample failure: https://app.circleci.com/pipelines/github/pytorch/xla/8222/workflows/7e72ffdc-bada-4cb8-8767-452f75e14073/jobs/15243