### PR TITLE
Add op metadata on XLA graphs for analysis/tracing

### DIFF
--- a/test/test_profile_mp_mnist.py
+++ b/test/test_profile_mp_mnist.py
@@ -41,13 +41,16 @@ class MNIST(nn.Module):
     self.fc2 = nn.Linear(50, 10)
 
   def forward(self, x):
-    x = F.relu(F.max_pool2d(self.conv1(x), 2))
-    x = self.bn1(x)
-    x = F.relu(F.max_pool2d(self.conv2(x), 2))
-    x = self.bn2(x)
-    x = torch.flatten(x, 1)
-    x = F.relu(self.fc1(x))
-    x = self.fc2(x)
+    with xp.Trace('conv1'):
+      x = F.relu(F.max_pool2d(self.conv1(x), 2))
+      x = self.bn1(x)
+    with xp.Trace('conv2'):
+      x = F.relu(F.max_pool2d(self.conv2(x), 2))
+      x = self.bn2(x)
+    with xp.Trace('dense'):
+      x = torch.flatten(x, 1)
+      x = F.relu(self.fc1(x))
+      x = self.fc2(x)
     return F.log_softmax(x, dim=1)
 
 

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -36,6 +36,7 @@
 #include "torch_xla/csrc/computation.h"
 #include "torch_xla/csrc/device.h"
 #include "torch_xla/csrc/helpers.h"
+#include "torch_xla/csrc/ir.h"
 #include "torch_xla/csrc/ir_dump_util.h"
 #include "torch_xla/csrc/ir_util.h"
 #include "torch_xla/csrc/python_util.h"
@@ -682,6 +683,13 @@ void BuildProfilerSubmodule(py::module* m) {
       .def("set_metadata", &tensorflow::profiler::TraceMeWrapper::SetMetadata)
       .def_static("is_enabled",
                   &tensorflow::profiler::TraceMeWrapper::IsEnabled);
+
+  py::class_<ir::ScopePusher, std::unique_ptr<ir::ScopePusher>>
+      scope_pusher_class(profiler, "ScopePusher");
+  profiler.def("scope_pusher",
+               [](const std::string& name) -> std::unique_ptr<ir::ScopePusher> {
+                 return absl::make_unique<ir::ScopePusher>(name);
+               });
 }
 
 void InitXlaModuleBindings(py::module m) {


### PR DESCRIPTION
Accompanied by internal TF cl. Sample TPU side trace profiled using Tensorboard plugin (profiling server runs at `$TPU_IP_ADDR:8466`)
![image](https://user-images.githubusercontent.com/19496130/106196350-50d7e880-617f-11eb-902a-c5f77f16d474.png)

Need to run with `XLA_HLO_DEBUG=1`.