### PR TITLE
Add `XLATensor::Compile` trace with graph hash

### DIFF
--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1497,6 +1497,13 @@ XLATensor::CompilationResult XLATensor::Compile(
     const std::vector<XLATensor>& tensors,
     absl::Span<const std::string> devices, const SyncTensorCollection& coll,
     PostOrderData* po_data) {
+  tensorflow::profiler::TraceMe activity(
+      [&] {
+        return tensorflow::profiler::TraceMeEncode(
+            "XLATensor::Compile",
+            {{"graph_hash", xla::util::HexHash(coll.hash)}});
+      },
+      tensorflow::profiler::TraceMeLevel::kInfo);
   static const bool enable_aliasing =
       xla::sys_util::GetEnvBool("XLA_ENABLE_PARAM_ALIASING", true);
   ir::LoweringContext lowering_ctx("SyncTensorsGraph", coll.device,


### PR DESCRIPTION
Run with `TF_CPP_MIN_LOG_LEVEL=0 TF_CPP_VMODULE=tensor=5`:
```
...
2021-01-28 21:20:23.689100: I   42783 torch_xla/csrc/tensor.cpp:1554] Compiling IR graph hash a62f04e8cf52b37ceec7ac1eeba7b8be on device TPU:5 ...
2021-01-28 21:20:23.691490: I   42780 torch_xla/csrc/tensor.cpp:1554] Compiling IR graph hash a62f04e8cf52b37ceec7ac1eeba7b8be on device TPU:2 ......
```

Corresponding compile trace:
![image](https://user-images.githubusercontent.com/19496130/106200915-b0d18d80-6185-11eb-81ca-5d761a2a41b2.png)
