### PR TITLE
Mark step before exiting the loader.

### DIFF
--- a/torch_xla/distributed/parallel_loader.py
+++ b/torch_xla/distributed/parallel_loader.py
@@ -49,6 +49,7 @@ class PerDeviceLoader(object):
 
     item = self._loader.next_item(self._device)
     if item is None:
+      xm.mark_step()
       raise StopIteration
     return item
 


### PR DESCRIPTION
Currently our for loop exits w/o marking step.