### PR TITLE
Shutdown Localserver gracefully

### DIFF
--- a/third_party/xla_client/xrt_computation_client.h
+++ b/third_party/xla_client/xrt_computation_client.h
@@ -21,6 +21,7 @@
 #include "tensorflow/compiler/xla/xla_client/metrics.h"
 #include "tensorflow/compiler/xla/xla_client/triggered_task.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "tensorflow/compiler/xla/xla_client/xrt_local_service.h"
 #include "tensorflow/compiler/xla/xla_client/xrt_session.h"
 #include "tensorflow/compiler/xla/xla_client/xrt_session_cache.h"
 #include "tensorflow/compiler/xla/xla_data.pb.h"
@@ -491,7 +492,7 @@ class XrtComputationClient : public ComputationClient {
   static std::string GetLocalTarget(const Options& options);
 
   // Checks whether a local GRPC service is required, and starts it if need it.
-  static void MaybeCreateLocalService(const Options& options);
+  void MaybeCreateLocalService(const Options& options);
 
   Options options_;
   std::mutex lock_;
@@ -499,6 +500,7 @@ class XrtComputationClient : public ComputationClient {
   std::unique_ptr<XrtSessionCache> session_cache_;
   std::unique_ptr<XrtSessionCache> alloc_session_cache_;
   std::unique_ptr<util::TriggeredTask> triggered_task_;
+  std::unique_ptr<XrtLocalService> local_service_;
   util::Cache<CompilationCacheKey, Computation, CompilationCacheKey::Hash>
       compilation_cache_;
   std::atomic<size_t> rng_seed_;


### PR DESCRIPTION
Currently local_server will not be gracefully shutdown due to it is a raw pointer. Changing the `XrtLocalService` to a `unique_ptr` to make sure destructor (https://github.com/tensorflow/tensorflow/blob/50316308851f9e6049167dc6b475e0f9a9a4274d/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc#L97) will be called upon `XrtComputationClient` being destroyed(process exit)