### PR TITLE
Change xla_dist ssh commands user to $USER.

### DIFF
--- a/torch_xla/distributed/xla_dist.py
+++ b/torch_xla/distributed/xla_dist.py
@@ -171,7 +171,7 @@ class DistributedExecutor(object):
         '--internal-ip',
         '--zone={}'.format(client_worker.get_zone()),
         local_path,
-        '{}:{}'.format(client_worker.get_hostname(), remote_path),
+        '{}@{}:{}'.format(os.getlogin(), client_worker.get_hostname(), remote_path),
     ]
 
   def _build_ssh_cmd(self, remote_cmd, client_worker):
@@ -184,7 +184,7 @@ class DistributedExecutor(object):
         'ssh',
         '--internal-ip',
         '--zone={}'.format(client_worker.get_zone()),
-        '{}'.format(client_worker.get_hostname()),
+        '{}@{}'.format(os.getlogin(), client_worker.get_hostname()),
         '--command',
         '\'{}\''.format(remote_cmd),
     ]


### PR DESCRIPTION
We've had reports of pod users complaining about restarts erroring w/ authentication error. AFAIU xla_dist currently uses the service account to fire up remote jobs.