### PR TITLE
Remove gcloud dependency in xla_dist retries.

### DIFF
--- a/torch_xla/distributed/xla_dist.py
+++ b/torch_xla/distributed/xla_dist.py
@@ -162,30 +162,51 @@ class DistributedExecutor(object):
     stdout.join()
     stderr.join()
 
+  def _is_retry(self):
+    return self.trials >= 1
+
   def _build_scp_cmd(self, local_path, remote_path, client_worker):
+    if not self._is_retry():
+      return [
+          'gcloud',
+          '-q',
+          'compute',
+          'scp',
+          '--internal-ip',
+          '--zone={}'.format(client_worker.get_zone()),
+          local_path,
+          '{}:{}'.format(client_worker.get_hostname(), remote_path),
+      ]
     return [
-        'gcloud',
-        '-q',
-        'compute',
         'scp',
-        '--internal-ip',
-        '--zone={}'.format(client_worker.get_zone()),
+        '-oStrictHostKeyChecking=no',
+        '-i',
+        '~/.ssh/google_compute_engine',
         local_path,
-        '{}:{}'.format(client_worker.get_hostname(), remote_path),
+        '{}@{}:{}'.format(os.getlogin(), client_worker.get_internal_ip(), remote_path),
     ]
 
   def _build_ssh_cmd(self, remote_cmd, client_worker):
     if isinstance(remote_cmd, list):
       remote_cmd = concat_cmd_list(remote_cmd)
+    if not self._is_retry():
+      return [
+          'gcloud',
+          '-q',
+          'compute',
+          'ssh',
+          '--internal-ip',
+          '--zone={}'.format(client_worker.get_zone()),
+          '{}'.format(client_worker.get_hostname()),
+          '--command',
+          '\'{}\''.format(remote_cmd),
+      ]
     return [
-        'gcloud',
-        '-q',
-        'compute',
         'ssh',
-        '--internal-ip',
-        '--zone={}'.format(client_worker.get_zone()),
-        '{}'.format(client_worker.get_hostname()),
-        '--command',
+        '-oStrictHostKeyChecking=no',
+        '-i',
+        '~/.ssh/google_compute_engine',
+        '{}@{}'.format(os.getlogin(), client_worker.get_internal_ip()),
         '\'{}\''.format(remote_cmd),
     ]
 
@@ -396,8 +417,8 @@ class DistributedExecutor(object):
       sys.exit(128 + signal.SIGINT)
 
   def run(self, cmd):
-    trials = 0
-    while trials <= self.MAX_TPU_RETRY:
+    self.trials = 0
+    while self.trials <= self.MAX_TPU_RETRY:
       try:
         self.logger.info(
             'Command to distribute: {}'.format(concat_cmd_list(cmd)),
@@ -438,7 +459,7 @@ class DistributedExecutor(object):
         self._cleanup(script_map)
         proc.terminate()
         self._cluster.wait_for_healthy_service()
-        trials += 1
+        self.trials += 1
       except KeyboardInterrupt:
         self.logger.info(
             'Cleaning up processes (takes a couple of seconds)',

--- a/torch_xla/distributed/xla_dist.py
+++ b/torch_xla/distributed/xla_dist.py
@@ -183,7 +183,8 @@ class DistributedExecutor(object):
         '-i',
         '~/.ssh/google_compute_engine',
         local_path,
-        '{}@{}:{}'.format(os.getlogin(), client_worker.get_internal_ip(), remote_path),
+        '{}@{}:{}'.format(os.getlogin(), client_worker.get_internal_ip(),
+                          remote_path),
     ]
 
   def _build_ssh_cmd(self, remote_cmd, client_worker):


### PR DESCRIPTION
Sometimes `xla_dist` job restarts fail with

```
ERROR: (gcloud.compute.ssh) You do not currently have an active account selected.
Please run:

  $ gcloud auth login

to obtain new credentials.

If you have already logged in with a different account:

    $ gcloud config set account ACCOUNT

to select an already authenticated account to use.
```

This is due to gcloud command unnecessarily looking for renewed credentials. We don't need this to restart an already started job, so I'm removing gcloud dependency in restarts in this PR.

The first ssh command is performed using gcloud as it sets up ssh keys etc, which is needed to fire up the job initially.

TESTED=Tried w/ `test_train_mp_imagenet --fake_data` pod run, triggered maintenance event and observed a successful restart.