### PR TITLE
Sync the tensors before an .item() call.

### DIFF
--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -27,5 +27,5 @@ echo "Running Python Tests"
 echo "Running C++ Tests"
 pushd test/cpp
 ./run_tests.sh
-./run_tests.sh -X early_sync -F AtenXlaTensorTest.TestEarlySyncLiveTensors
+./run_tests.sh -X early_sync -F AtenXlaTensorTest.TestEarlySyncLiveTensors -L""
 popd

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -27,5 +27,8 @@ echo "Running Python Tests"
 echo "Running C++ Tests"
 pushd test/cpp
 ./run_tests.sh
-./run_tests.sh -X early_sync -F AtenXlaTensorTest.TestEarlySyncLiveTensors -L""
+if [ -x "$(command -v nvidia-smi)"  ]
+then
+  ./run_tests.sh -X early_sync -F AtenXlaTensorTest.TestEarlySyncLiveTensors -L""
+fi
 popd

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -27,7 +27,7 @@ echo "Running Python Tests"
 echo "Running C++ Tests"
 pushd test/cpp
 ./run_tests.sh
-if [ -x "$(command -v nvidia-smi)"  ]
+if ! [ -x "$(command -v nvidia-smi)"  ]
 then
   ./run_tests.sh -X early_sync -F AtenXlaTensorTest.TestEarlySyncLiveTensors -L""
 fi

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -27,4 +27,5 @@ echo "Running Python Tests"
 echo "Running C++ Tests"
 pushd test/cpp
 ./run_tests.sh
+./run_tests.sh -X early_sync -F AtenXlaTensorTest.TestEarlySyncLiveTensors
 popd

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -9,7 +9,7 @@ BUILD_ONLY=0
 RMBUILD=1
 LOGFILE=/tmp/pytorch_cpp_test.log
 XLA_EXPERIMENTAL="nonzero:masked_select"
-XLA_SYNC_BEFORE_ITEM_CALL=1
+export XLA_SYNC_BEFORE_ITEM_CALL=1
 
 if [ "$DEBUG" == "1" ]; then
   BUILDTYPE="Debug"

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -9,6 +9,7 @@ BUILD_ONLY=0
 RMBUILD=1
 LOGFILE=/tmp/pytorch_cpp_test.log
 XLA_EXPERIMENTAL="nonzero:masked_select"
+XLA_SYNC_BEFORE_ITEM_CALL=1
 
 if [ "$DEBUG" == "1" ]; then
   BUILDTYPE="Debug"

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -9,7 +9,7 @@ BUILD_ONLY=0
 RMBUILD=1
 LOGFILE=/tmp/pytorch_cpp_test.log
 XLA_EXPERIMENTAL="nonzero:masked_select"
-export XLA_SYNC_BEFORE_ITEM_CALL=1
+export XLA_SYNC_BEFORE_ITEM_CALL=0
 
 if [ "$DEBUG" == "1" ]; then
   BUILDTYPE="Debug"

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -9,7 +9,6 @@ BUILD_ONLY=0
 RMBUILD=1
 LOGFILE=/tmp/pytorch_cpp_test.log
 XLA_EXPERIMENTAL="nonzero:masked_select"
-export XLA_SYNC_BEFORE_ITEM_CALL=0
 
 if [ "$DEBUG" == "1" ]; then
   BUILDTYPE="Debug"
@@ -60,10 +59,8 @@ make -j $VERB
 if [ $BUILD_ONLY -eq 0 ]; then
   if [ "$LOGFILE" != "" ]; then
     ./test_ptxla ${FILTER:+"$FILTER"} 2>$LOGFILE
-    XLA_SYNC_BEFORE_ITEM_CALL=1 ./test_ptxla --gtest_filter=AtenXlaTensorTest.TestEarlySyncLiveTensors 2>>$LOGFILE
   else
     ./test_ptxla ${FILTER:+"$FILTER"}
-    XLA_SYNC_BEFORE_ITEM_CALL=1 ./test_ptxla --gtest_filter=AtenXlaTensorTest.TestEarlySyncLiveTensors
   fi
 fi
 popd

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -58,7 +58,7 @@ make -j $VERB
 
 if [ $BUILD_ONLY -eq 0 ]; then
   if [ "$LOGFILE" != "" ]; then
-    ./test_ptxla ${FILTER:+"$FILTER"} 2>$LOGFILE
+    ./test_ptxla ${FILTER:+"$FILTER"} 2>> $LOGFILE
   else
     ./test_ptxla ${FILTER:+"$FILTER"}
   fi

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -58,7 +58,7 @@ make -j $VERB
 
 if [ $BUILD_ONLY -eq 0 ]; then
   if [ "$LOGFILE" != "" ]; then
-    ./test_ptxla ${FILTER:+"$FILTER"} 2>> $LOGFILE
+    ./test_ptxla ${FILTER:+"$FILTER"} 2> $LOGFILE
   else
     ./test_ptxla ${FILTER:+"$FILTER"}
   fi

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -60,8 +60,10 @@ make -j $VERB
 if [ $BUILD_ONLY -eq 0 ]; then
   if [ "$LOGFILE" != "" ]; then
     ./test_ptxla ${FILTER:+"$FILTER"} 2>$LOGFILE
+    XLA_SYNC_BEFORE_ITEM_CALL=1 ./test_ptxla --gtest_filter=AtenXlaTensorTest.TestEarlySyncLiveTensors 2>>$LOGFILE
   else
     ./test_ptxla ${FILTER:+"$FILTER"}
+    XLA_SYNC_BEFORE_ITEM_CALL=1 ./test_ptxla --gtest_filter=AtenXlaTensorTest.TestEarlySyncLiveTensors
   fi
 fi
 popd

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -10119,9 +10119,7 @@ TEST_F(AtenXlaTensorTest, TestEarlySyncLiveTensors) {
     torch::Scalar scalar2 = xla_scalar_tensor.item();
     ASSERT_EQ(scalar1.to<float>(), scalar2.to<float>());
   });
-  static bool sync =
-      xla::sys_util::GetEnvBool("XLA_SYNC_BEFORE_ITEM_CALL", false);
-  if (sync) {
+  if (DebugUtil::ExperimentEnabled("early_sync")) {
     ExpectCounterChanged("EarlySyncLiveTensorsCount",
                          cpp_test::GetIgnoredCounters());
   } else {

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -10108,6 +10108,7 @@ TEST_F(AtenXlaTensorTest, TestAmpUpdateScale) {
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
   ExpectCounterChanged("xla::_amp_update_scale",
                        cpp_test::GetIgnoredCounters());
+}
 
 TEST_F(AtenXlaTensorTest, TestEarlySyncLiveTensors) {
   torch::Tensor scalar_tensor =

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -10114,7 +10114,9 @@ TEST_F(AtenXlaTensorTest, TestEarlySyncLiveTensors) {
       torch::scalar_tensor(1., torch::TensorOptions(torch::kFloat));
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor xla_scalar_tensor = CopyToDevice(scalar_tensor, device);
-    torch::Scalar scalar = xla_scalar_tensor.item();
+    torch::Scalar scalar1 = xla_scalar_tensor.item();
+    torch::Scalar scalar2 = scalar_tensor.item();
+    ASSERT_EQ(scalar1.to<float>(), scalar2.to<float>());
   });
   static bool sync =
       xla::sys_util::GetEnvBool("XLA_SYNC_BEFORE_ITEM_CALL", true);
@@ -10126,6 +10128,8 @@ TEST_F(AtenXlaTensorTest, TestEarlySyncLiveTensors) {
     ExpectCounterNotChanged("EarlySyncLiveTensorsCount",
                             cpp_test::GetIgnoredCounters());
   }
+  ExpectCounterChanged("aten::_local_scalar_dense",
+                       cpp_test::GetIgnoredCounters());
 }
 
 }  // namespace cpp_test

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -10112,10 +10112,10 @@ TEST_F(AtenXlaTensorTest, TestAmpUpdateScale) {
 TEST_F(AtenXlaTensorTest, TestEarlySyncLiveTensors) {
   torch::Tensor scalar_tensor =
       torch::scalar_tensor(1., torch::TensorOptions(torch::kFloat));
+  torch::Scalar scalar1 = scalar_tensor.item();
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor xla_scalar_tensor = CopyToDevice(scalar_tensor, device);
-    torch::Scalar scalar1 = xla_scalar_tensor.item();
-    torch::Scalar scalar2 = scalar_tensor.item();
+    torch::Scalar scalar2 = xla_scalar_tensor.item();
     ASSERT_EQ(scalar1.to<float>(), scalar2.to<float>());
   });
   static bool sync =

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -10123,7 +10123,6 @@ TEST_F(AtenXlaTensorTest, TestEarlySyncLiveTensors) {
   if (sync) {
     ExpectCounterChanged("EarlySyncLiveTensorsCount",
                          cpp_test::GetIgnoredCounters());
-
   } else {
     ExpectCounterNotChanged("EarlySyncLiveTensorsCount",
                             cpp_test::GetIgnoredCounters());

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -10108,6 +10108,25 @@ TEST_F(AtenXlaTensorTest, TestAmpUpdateScale) {
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
   ExpectCounterChanged("xla::_amp_update_scale",
                        cpp_test::GetIgnoredCounters());
+
+TEST_F(AtenXlaTensorTest, TestEarlySyncLiveTensors) {
+  torch::Tensor scalar_tensor =
+      torch::scalar_tensor(1., torch::TensorOptions(torch::kFloat));
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_scalar_tensor = CopyToDevice(scalar_tensor, device);
+    torch::Scalar scalar = xla_scalar_tensor.item();
+  });
+  static bool sync =
+      xla::sys_util::GetEnvBool("XLA_SYNC_BEFORE_ITEM_CALL", true);
+  if (sync) {
+    ExpectCounterChanged(
+        "EarlySyncLiveTensorsCount", cpp_test::GetIgnoredCounters());
+
+  } else {
+    ExpectCounterNotChanged(
+        "EarlySyncLiveTensorsCount", cpp_test::GetIgnoredCounters());
+
+  }
 }
 
 }  // namespace cpp_test

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -10120,7 +10120,7 @@ TEST_F(AtenXlaTensorTest, TestEarlySyncLiveTensors) {
     ASSERT_EQ(scalar1.to<float>(), scalar2.to<float>());
   });
   static bool sync =
-      xla::sys_util::GetEnvBool("XLA_SYNC_BEFORE_ITEM_CALL", true);
+      xla::sys_util::GetEnvBool("XLA_SYNC_BEFORE_ITEM_CALL", false);
   if (sync) {
     ExpectCounterChanged("EarlySyncLiveTensorsCount",
                          cpp_test::GetIgnoredCounters());

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -10119,13 +10119,12 @@ TEST_F(AtenXlaTensorTest, TestEarlySyncLiveTensors) {
   static bool sync =
       xla::sys_util::GetEnvBool("XLA_SYNC_BEFORE_ITEM_CALL", true);
   if (sync) {
-    ExpectCounterChanged(
-        "EarlySyncLiveTensorsCount", cpp_test::GetIgnoredCounters());
+    ExpectCounterChanged("EarlySyncLiveTensorsCount",
+                         cpp_test::GetIgnoredCounters());
 
   } else {
-    ExpectCounterNotChanged(
-        "EarlySyncLiveTensorsCount", cpp_test::GetIgnoredCounters());
-
+    ExpectCounterNotChanged("EarlySyncLiveTensorsCount",
+                            cpp_test::GetIgnoredCounters());
   }
 }
 

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3559,13 +3559,13 @@ at::Tensor& AtenXlaType::zero_(at::Tensor& self) {
 
 at::Scalar AtenXlaType::_local_scalar_dense(const at::Tensor & self) {
   static bool sync =
-        xla::sys_util::GetEnvBool("XLA_SYNC_BEFORE_ITEM_CALL", true);
+      xla::sys_util::GetEnvBool("XLA_SYNC_BEFORE_ITEM_CALL", true);
   if (sync) {
-      XLA_FN_COUNTER("xla::");
       // sync tensors in order to save computation when step is marked later.
       XLATensor self_tensor = bridge::GetXlaTensor(self);
       XLATensor::SyncLiveTensorsGraph(
         &self_tensor.GetDevice(), /*devices=*/{}, /*wait=*/true);
+      XLA_COUNTER("EarlySyncLiveTensorsCount", 1);
   }
   return AtenXlaTypeDefault::_local_scalar_dense(self);
 }

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3558,9 +3558,7 @@ at::Tensor& AtenXlaType::zero_(at::Tensor& self) {
 }
 
 at::Scalar AtenXlaType::_local_scalar_dense(const at::Tensor& self) {
-  static bool sync =
-      xla::sys_util::GetEnvBool("XLA_SYNC_BEFORE_ITEM_CALL", false);
-  if (sync) {
+  if (DebugUtil::ExperimentEnabled("early_sync")) {
     // sync tensors in order to save computation when step is marked later.
     XLATensor self_tensor = bridge::GetXlaTensor(self);
     XLATensor::SyncLiveTensorsGraph(&self_tensor.GetDevice(), /*devices=*/{},

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3557,15 +3557,15 @@ at::Tensor& AtenXlaType::zero_(at::Tensor& self) {
   return self;
 }
 
-at::Scalar AtenXlaType::_local_scalar_dense(const at::Tensor & self) {
+at::Scalar AtenXlaType::_local_scalar_dense(const at::Tensor& self) {
   static bool sync =
       xla::sys_util::GetEnvBool("XLA_SYNC_BEFORE_ITEM_CALL", true);
   if (sync) {
-      // sync tensors in order to save computation when step is marked later.
-      XLATensor self_tensor = bridge::GetXlaTensor(self);
-      XLATensor::SyncLiveTensorsGraph(
-        &self_tensor.GetDevice(), /*devices=*/{}, /*wait=*/true);
-      XLA_COUNTER("EarlySyncLiveTensorsCount", 1);
+    // sync tensors in order to save computation when step is marked later.
+    XLATensor self_tensor = bridge::GetXlaTensor(self);
+    XLATensor::SyncLiveTensorsGraph(&self_tensor.GetDevice(), /*devices=*/{},
+                                    /*wait=*/true);
+    XLA_COUNTER("EarlySyncLiveTensorsCount", 1);
   }
   return AtenXlaTypeDefault::_local_scalar_dense(self);
 }

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3557,6 +3557,19 @@ at::Tensor& AtenXlaType::zero_(at::Tensor& self) {
   return self;
 }
 
+at::Scalar AtenXlaType::_local_scalar_dense(const at::Tensor & self) {
+  static bool sync =
+        xla::sys_util::GetEnvBool("XLA_SYNC_BEFORE_ITEM_CALL", true);
+  if (sync) {
+      XLA_FN_COUNTER("xla::");
+      // sync tensors in order to save computation when step is marked later.
+      XLATensor self_tensor = bridge::GetXlaTensor(self);
+      XLATensor::SyncLiveTensorsGraph(
+        &self_tensor.GetDevice(), /*devices=*/{}, /*wait=*/true);
+  }
+  return AtenXlaTypeDefault::_local_scalar_dense(self);
+}
+
 void AtenXlaType::InitializeAtenBindings() {
   static std::once_flag once;
   std::call_once(once, []() { AtenInitialize(); });

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3559,7 +3559,7 @@ at::Tensor& AtenXlaType::zero_(at::Tensor& self) {
 
 at::Scalar AtenXlaType::_local_scalar_dense(const at::Tensor& self) {
   static bool sync =
-      xla::sys_util::GetEnvBool("XLA_SYNC_BEFORE_ITEM_CALL", true);
+      xla::sys_util::GetEnvBool("XLA_SYNC_BEFORE_ITEM_CALL", false);
   if (sync) {
     // sync tensors in order to save computation when step is marked later.
     XLATensor self_tensor = bridge::GetXlaTensor(self);

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -1106,7 +1106,7 @@ class AtenXlaType {
 
   static at::Tensor& zero_(at::Tensor& self);
 
-  static at::Scalar _local_scalar_dense(const at::Tensor & self);
+  static at::Scalar _local_scalar_dense(const at::Tensor& self);
 };
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -1105,6 +1105,8 @@ class AtenXlaType {
   static at::Tensor view(const at::Tensor& self, at::IntArrayRef size);
 
   static at::Tensor& zero_(at::Tensor& self);
+
+  static at::Scalar _local_scalar_dense(const at::Tensor & self);
 };
 
 }  // namespace torch_xla


### PR DESCRIPTION
# DESCRIPTON:

Often times PT code is written in a way that doesn't assume async execution. Example:
```python
loss = loss_fn(out, target)
print("LOSS", loss.item())
```
this is a very common use case and to get around this, we advise users to "log less often" and also we have offered the "[step closure](https://github.com/pytorch/xla/blob/master/test/test_train_mp_imagenet.py#L214)"s, which as far as I know, is not very popular among most users. Step closure takes the .item() call and moves it at the end of the step, as exemplified [here](https://github.com/pytorch/xla/blob/master/torch_xla/core/xla_model.py#L673).

The usage of this requires the user to know about async execution, and often times it requires code change to adapt GPU-compatible code to TPUs.

If users don't do this change, this happens:

1. We compile and execute the graph up to this point, and get the scalar value to be printed.
2. The next time we mark step, the already executed, smaller graph to get the scalars, gets executed again, causing inefficiency.

This problem is even more pronounced if there is a print statement where more than 1 tensors are printed for example.

This PR injects a SyncTensors before `aten::_local_scalar_dense`, so next time we mark_step, there's no unnecessary executions of an already executed sub-graph.

This way, non-power users will have an easier time adapting GPU compatible code to TPUs/XLA.

Of course, constructing the large graph once and executing that only will yield better performance. Power users will still have the option to do that via `xm.step_closure`.

# TESTS:

I added the following diff to `test_train_mp_imagenet.py`:

```diff
diff --git a/test/test_train_mp_imagenet.py b/test/test_train_mp_imagenet.py
index c2622823..4313806b 100644
--- a/test/test_train_mp_imagenet.py
+++ b/test/test_train_mp_imagenet.py
@@ -211,8 +211,12 @@ def train_imagenet():
       if lr_scheduler:
         lr_scheduler.step()
       if step % FLAGS.log_steps == 0:
-        xm.add_step_closure(
-            _train_update, args=(device, step, loss, tracker, epoch, writer))
+        for incrmt in range(int(os.getenv('ITEM_N_TIMES'))):
+            if loss < 100.:
+                pass
+        _train_update(device, step, loss, tracker, epoch, writer)
+      if step == 100:
+          raise

   def test_loop_fn(loader, epoch):
     total_samples, correct = 0, 0
```

and ran using:

```bash
for sync in 0 1
do
    for pnt in 0 1 10 100
    do
        export ITEM_N_TIMES=$pnt
        export XLA_SYNC_BEFORE_ITEM_CALL=$sync
        echo "MODE:"
        echo "ITEM_N_TIMES=$ITEM_N_TIMES"
        echo "XLA_SYNC_BEFORE_ITEM_CALL=$XLA_SYNC_BEFORE_ITEM_CALL"
        time python test_train_mp_imagenet.py --fake_data --log_steps 1 --num_epochs 1 > log-print${ITEM_N_TIMES}-sync$XLA_SYNC_BEFORE_ITEM_CALL.txt
        sleep 5
    done
done
```

and here are measurements of
- `xm.Tracker`s `Rate` in 100th step
- `xm.Tracker`s `GlobalRate`
- Time Delta in seconds b/w first and last print w/ cold tpu.

### Rate in 100th step
| Extra Item Calls  |     Rate No Sync     |  Rate Sync | GlobalRate No Sync     |  GlobalRate Sync | TimeDelta No Sync     |  TimeDelta Sync|
|----------|:-------------:|------:|:-------------:|------:|:-------------:|------:|
| 0 | 452.82 | 500.00| 392.85 | 426.89 | 32s | 25s |
| 1  |   376.73   |   354.47 |347.87 | 344.47 | 37s | 37s |
| 10 | 148.26 |   452.21 | 138.07 | 420.38 | 93s | 27s |
| 100 | 21.18 |    257.81|20.96 | 234.63 | 611s | 51s |

For good measure I also tested the regular imagenet script via

```bash
for sync in 0 1
do
   export XLA_SYNC_BEFORE_ITEM_CALL=$sync
   python test_train_mp_imagenet.py --fake_data --log_steps 100 --num_epochs 2 > fullrun-log-sync$sync.txt
done
```

and the GlobalRate for that at the end of epoch 2 was 594 w/ sync vs 592 w/o sync.