### PR TITLE
Only optionally dump entire HLO graph

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -196,7 +196,7 @@ only be enabled for debugging.
   when sending to the _TPU_ device. Note that when using `XLA_USE_BF16=1` tensor arithmetic will
   be done in reduced precision and so tensors will not be accurate if accumulated over time.
   For example:
-  
+
   ```
   # In reduced bfloat16 precision
   >>> torch.tensor(4096, dtype=torch.bfloat16) + torch.tensor(1, dtype=torch.bfloat16)
@@ -237,6 +237,9 @@ only be enabled for debugging.
 * ```TF_CPP_MIN_LOG_LEVEL```: Level to print messages for. `TF_CPP_MIN_LOG_LEVEL=0` will turn
   on INFO logging, `TF_CPP_MIN_LOG_LEVEL=1` WARNING and so on. Our PyTorch/XLA `TF_VLOG` uses
   `tensorflow::INFO` level by default so to see VLOGs set `TF_CPP_MIN_LOG_LEVEL=0`.
+
+* ```XLA_DUMP_HLO_GRAPH```: If set to `=1` in case of a compilation or execution error the
+  offending HLO graph will be dumped as part of the runtime error raised by `xla_util.cc`.
 
 ### Retrieving Stack Traces
 


### PR DESCRIPTION
The graphs that are dumped from computation errors are pretty much
useless for our users but end up spamming their console with tens to
hundreds of thousands of lines of HLO dump. Instead only dump it
in case of `XLA_DUMP_HLO_GRAPH=1` explicitly provided.

Tried causing HBM OOM with something like:
```
python test/test_train_mp_imagenet.py --fake_data --num_cores=8 --batch_size=2048
```

Output size with `XLA_DUMP_HLO_GRAPH=1`:
```
% wc /tmp/logs_.txt                                                                                                            
   58387  1091087 18023572 /tmp/logs_.txt
```
With `XLA_DUMP_HLO_GRAPH=0`:
```
% wc /tmp/logs2_.txt                                
  1364   7715 121413 /tmp/logs2_.txt
```
^ Is for 8 cores, and the output is basically showing the stack trace and HBM OOM allocation top offenders like:
```
  (0) Resource exhausted: Ran out of memory in memory space hbm. Used 52.84G of 15.98G hbm. Exceeded hbm capacity by 36.86G.

Total hbm usage >= 52.86G:
    reserved         18.00M 
    program          52.84G 
    arguments            0B 

Output size 0B; shares 0B with arguments.

Program hbm requirement 52.84G:
    global            20.0K
    HLO temp         52.84G (100.0% utilization: Unpadded (52.84G) Padded (52.84G), 0.0% fragmentation (5.17M))

  Largest program allocations in hbm:

  1. Size: 6.12G
     Shape: f32[2048,256,56,56]{1,0,3,2:T(8,128)}
     Unpadded size: 6.12G
     XLA label: %fusion.6.remat.1.remat.1 = (bf16[2048,256,56,56]{1,0,3,2:T(8,128)(2,1)}, f32[2048,256,56,56]{1,0,3,2:T(8,128)}, f32[2048,256,56,56]{1,0,3,2:T(8,128)}) fusion(f32[256]{0:T(256)} %p48.290, f32[256]{0:T(256)} %p49.291, f32[256]{0:T(256)} %get-tuple-element.5...
     Allocation type: HLO temp
     ==========================
...
```
Which is the actual error users would be interested in.