### PR TITLE
Sync TF: libtpu.so API breakage

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 
 #include "cpp_test_util.h"
+#include "tensorflow/compiler/xla/permutation_util.h"
 #include "tensorflow/compiler/xla/util.h"
 #include "tensorflow/compiler/xla/xla_client/metrics.h"
 #include "torch_xla/csrc/aten_xla_bridge.h"
@@ -3856,7 +3857,7 @@ TEST_F(AtenXlaTensorTest, TestRandperm) {
   torch::Tensor shuffle_cpu = CopyToDevice(shuffle, torch::kCPU);
   std::vector<xla::int64> shuffle_data(shuffle_cpu.data_ptr<int64_t>(),
                                        shuffle_cpu.data_ptr<int64_t>() + n);
-  EXPECT_TRUE(xla::IsPermutation(shuffle_data, n));
+  EXPECT_TRUE(shuffle_data.size() == n && xla::IsPermutation(shuffle_data));
   ExpectCounterNotChanged("aten::(?!randperm_out).*",
                           cpp_test::GetIgnoredCounters());
 }

--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -11,6 +11,7 @@
 #include "absl/types/span.h"
 #include "tensorflow/compiler/xla/client/xla_builder.h"
 #include "tensorflow/compiler/xla/literal_util.h"
+#include "tensorflow/compiler/xla/permutation_util.h"
 #include "tensorflow/compiler/xla/types.h"
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
@@ -239,7 +240,8 @@ class XlaHelpers {
   static std::vector<typename Container::value_type> Permute(
       absl::Span<const xla::int64> permutation, const Container& input) {
     using T = typename Container::value_type;
-    XLA_CHECK(xla::IsPermutation(permutation, input.size()))
+    XLA_CHECK(input.size() == permutation.size() &&
+              xla::IsPermutation(permutation))
         << "Invalid permutation specified";
     std::vector<T> output(input.size());
     for (size_t i = 0; i < permutation.size(); ++i) {

--- a/torch_xla/csrc/ops/as_strided.cpp
+++ b/torch_xla/csrc/ops/as_strided.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 
+#include "tensorflow/compiler/xla/permutation_util.h"
 #include "tensorflow/compiler/xla/shape_util.h"
 #include "tensorflow/compiler/xla/util.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"

--- a/torch_xla/csrc/ops/index_ops.cpp
+++ b/torch_xla/csrc/ops/index_ops.cpp
@@ -3,6 +3,7 @@
 #include <ATen/ExpandUtils.h>
 #include <ATen/Functions.h>
 
+#include "tensorflow/compiler/xla/permutation_util.h"
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
 #include "torch_xla/csrc/aten_xla_bridge.h"


### PR DESCRIPTION
Nightly TPUVM broken due to API mismatch (https://github.com/tensorflow/tensorflow/commit/b70b22739cc41c004e9ff6a0ad6b599b308d47dd).

Also, XLA changed API and location for permutation utils we used to use:
* https://github.com/tensorflow/tensorflow/commit/231d3ab44db8c9d23525dcf454527e306794d2e8
* https://github.com/tensorflow/tensorflow/commit/9fcf66e16dfbd32ebf739bac3e2dd1db59c67360

We'll need to cherry-pick this one and others into r1.8 as public preview libtpu.so will be cut later.