### PR TITLE
1VM: Unbreak libtpu.so API, XLA, profiler

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 
 #include "cpp_test_util.h"
+#include "tensorflow/compiler/xla/permutation_util.h"
 #include "tensorflow/compiler/xla/util.h"
 #include "tensorflow/compiler/xla/xla_client/metrics.h"
 #include "torch_xla/csrc/aten_xla_bridge.h"
@@ -3856,7 +3857,7 @@ TEST_F(AtenXlaTensorTest, TestRandperm) {
   torch::Tensor shuffle_cpu = CopyToDevice(shuffle, torch::kCPU);
   std::vector<xla::int64> shuffle_data(shuffle_cpu.data_ptr<int64_t>(),
                                        shuffle_cpu.data_ptr<int64_t>() + n);
-  EXPECT_TRUE(xla::IsPermutation(shuffle_data, n));
+  EXPECT_TRUE(shuffle_data.size() == n && xla::IsPermutation(shuffle_data));
   ExpectCounterNotChanged("aten::(?!randperm_out).*",
                           cpp_test::GetIgnoredCounters());
 }

--- a/test/test_profile_mp_mnist.py
+++ b/test/test_profile_mp_mnist.py
@@ -129,8 +129,9 @@ def train_mnist(flags,
   optimizer = optim.SGD(model.parameters(), lr=lr, momentum=flags.momentum)
   loss_fn = nn.NLLLoss()
 
-  # Start up client side profiler server.
-  server = xp.start_server(flags.profiler_port)
+  # Only start up profiler server once *per* host.
+  if xm.is_master_ordinal():
+    server = xp.start_server(flags.profiler_port)
   # Testing purpose only: set event for synchronization.
   if worker_started:
     worker_started.set()

--- a/test/test_profile_mp_mnist.py
+++ b/test/test_profile_mp_mnist.py
@@ -129,9 +129,7 @@ def train_mnist(flags,
   optimizer = optim.SGD(model.parameters(), lr=lr, momentum=flags.momentum)
   loss_fn = nn.NLLLoss()
 
-  # Only start up profiler server once *per* host.
-  if xm.is_master_ordinal():
-    server = xp.start_server(flags.profiler_port)
+  server = xp.start_server(flags.profiler_port)
   # Testing purpose only: set event for synchronization.
   if worker_started:
     worker_started.set()

--- a/third_party/xla_client/BUILD
+++ b/third_party/xla_client/BUILD
@@ -7,6 +7,7 @@ load(
     "tf_cc_binary",
     "tf_cc_shared_object",
     "tf_cc_test",
+    "if_with_tpu_support",
 )
 load(
     "//tensorflow/core/platform/default:build_config.bzl",
@@ -167,6 +168,9 @@ cc_library(
     ] + if_cuda_is_configured([
         "@local_config_nccl//:nccl",
         "//tensorflow/compiler/jit:xla_gpu_device",
+    ]) + if_with_tpu_support([
+        "//tensorflow/compiler/jit:xla_tpu_device",
+        "//tensorflow/compiler/jit:xla_tpu_jit",
     ]),
     alwayslink = 1,
 )

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -40,6 +40,7 @@ def _set_missing_env(name, value):
 
 def _setup_default_env():
   _set_missing_env('TF_CPP_MIN_LOG_LEVEL', '1')
+  _set_missing_env('TPU_HOST_BOUNDS', '1,1,1')
 
 
 _fd, _tmp_fname = -1, ''

--- a/torch_xla/csrc/convolution.cpp
+++ b/torch_xla/csrc/convolution.cpp
@@ -240,10 +240,11 @@ xla::XlaOp BuildConvBackwardWeight(
     absl::Span<const xla::int64> spatial_dilation, xla::int64 groups) {
   tensorflow::ConvOpAttrs conv_op_attrs =
       MakeConvOpAttrs(spatial_stride, spatial_padding, spatial_dilation, false);
-  auto inv_transpose_permutation =
-      xla::InversePermutation(FilterTransposePermutation(kernel_shape.rank()));
+  auto transpose_permutation = FilterTransposePermutation(kernel_shape.rank());
+  auto inv_transpose_permutation = xla::InversePermutation(
+      transpose_permutation);
   xla::Shape transposed_weight_shape = xla::ShapeUtil::PermuteDimensions(
-      inv_transpose_permutation, kernel_shape);
+      transpose_permutation, kernel_shape);
   xla::PrecisionConfig precision_config =
       XlaHelpers::BuildPrecisionConfig(XlaHelpers::mat_mul_precision());
   xla::XlaOp conv = ConsumeValue(tensorflow::MakeXlaBackpropFilterConvOp(

--- a/torch_xla/csrc/convolution.cpp
+++ b/torch_xla/csrc/convolution.cpp
@@ -241,10 +241,10 @@ xla::XlaOp BuildConvBackwardWeight(
   tensorflow::ConvOpAttrs conv_op_attrs =
       MakeConvOpAttrs(spatial_stride, spatial_padding, spatial_dilation, false);
   auto transpose_permutation = FilterTransposePermutation(kernel_shape.rank());
-  auto inv_transpose_permutation = xla::InversePermutation(
-      transpose_permutation);
-  xla::Shape transposed_weight_shape = xla::ShapeUtil::PermuteDimensions(
-      transpose_permutation, kernel_shape);
+  auto inv_transpose_permutation =
+      xla::InversePermutation(transpose_permutation);
+  xla::Shape transposed_weight_shape =
+      xla::ShapeUtil::PermuteDimensions(transpose_permutation, kernel_shape);
   xla::PrecisionConfig precision_config =
       XlaHelpers::BuildPrecisionConfig(XlaHelpers::mat_mul_precision());
   xla::XlaOp conv = ConsumeValue(tensorflow::MakeXlaBackpropFilterConvOp(

--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -11,6 +11,7 @@
 #include "absl/types/span.h"
 #include "tensorflow/compiler/xla/client/xla_builder.h"
 #include "tensorflow/compiler/xla/literal_util.h"
+#include "tensorflow/compiler/xla/permutation_util.h"
 #include "tensorflow/compiler/xla/types.h"
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
@@ -239,7 +240,8 @@ class XlaHelpers {
   static std::vector<typename Container::value_type> Permute(
       absl::Span<const xla::int64> permutation, const Container& input) {
     using T = typename Container::value_type;
-    XLA_CHECK(xla::IsPermutation(permutation, input.size()))
+    XLA_CHECK(input.size() == permutation.size() &&
+              xla::IsPermutation(permutation))
         << "Invalid permutation specified";
     std::vector<T> output(input.size());
     for (size_t i = 0; i < permutation.size(); ++i) {

--- a/torch_xla/csrc/ops/as_strided.cpp
+++ b/torch_xla/csrc/ops/as_strided.cpp
@@ -33,7 +33,7 @@ xla::XlaOp LowerAsStrided(xla::XlaOp input, absl::Span<const xla::int64> size,
 
   std::vector<xla::int64> permutation = xla::InversePermutation(
       AsStrided::GetArrayStridePermutation(stride, size));
-  std::vector<xla::int64> new_sizes = xla::Permute(permutation, size);
+  std::vector<xla::int64> new_sizes = xla::PermuteInverse(size, permutation);
   xla::XlaOp reshaped_input = XlaHelpers::DynamicReshape(off_input, new_sizes);
   return xla::IsIdentityPermutation(permutation)
              ? reshaped_input

--- a/torch_xla/csrc/ops/index_ops.cpp
+++ b/torch_xla/csrc/ops/index_ops.cpp
@@ -3,6 +3,7 @@
 #include <ATen/ExpandUtils.h>
 #include <ATen/Functions.h>
 
+#include "tensorflow/compiler/xla/permutation_util.h"
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
 #include "torch_xla/csrc/aten_xla_bridge.h"

--- a/torch_xla/csrc/resize_ops.cpp
+++ b/torch_xla/csrc/resize_ops.cpp
@@ -58,7 +58,7 @@ xla::XlaOp LowerForward2d(const std::string& target, xla::XlaOp input,
   std::vector<xla::int64> transpose_permute({0, 3, 2, 1});
   auto inv_transpose_permute = xla::InversePermutation(transpose_permute);
   xla::Shape resized_shape =
-      xla::ShapeUtil::PermuteDimensions(inv_transpose_permute, output_shape);
+      xla::ShapeUtil::PermuteDimensions(transpose_permute, output_shape);
   xla::XlaOp tinput = xla::Transpose(input, transpose_permute);
   xla::XlaOp resised =
       xla::CustomCall(input.builder(), target, {tinput}, resized_shape,
@@ -81,7 +81,7 @@ xla::XlaOp LowerBackward2d(const std::string& target, xla::XlaOp input,
   std::vector<xla::int64> transpose_permute({0, 3, 2, 1});
   auto inv_transpose_permute = xla::InversePermutation(transpose_permute);
   xla::Shape resized_shape =
-      xla::ShapeUtil::PermuteDimensions(inv_transpose_permute, output_shape);
+      xla::ShapeUtil::PermuteDimensions(transpose_permute, output_shape);
   xla::XlaOp tinput = xla::Transpose(input, transpose_permute);
   std::string backend_config =
       GetBackendConfig(align_corners, half_pixel_centers);

--- a/torch_xla/debug/profiler.py
+++ b/torch_xla/debug/profiler.py
@@ -16,7 +16,7 @@ def get_tracer_marked_step() -> bool:
   return _TRACER_MARKED_STEP
 
 
-def start_server(port: int) -> object:
+def start_server(port: int, only_on_master: Optional[bool] = True) -> object:
   """Start a profiler server on the client side on provided port.
 
   Users can then use the tensorboard profiler plugin
@@ -26,7 +26,9 @@ def start_server(port: int) -> object:
 
   Args:
     port (int): the port to start the profiler server on. An exception is
-    raised if the provided port is invalid or busy.
+      raised if the provided port is invalid or busy.
+    only_on_master (optional(bool)): whether to only startup server from
+      local master ordinal.
   Returns:
     A `ProfilerServer` instance that dictates the lifecycle of the profiler
     server. If this object is garbage collected, the profiler server is
@@ -34,7 +36,8 @@ def start_server(port: int) -> object:
   Raises:
     RuntimeError: Raised if the port is invalid or busy already.
   """
-  return torch_xla._XLAC.profiler.start_server(port)
+  if not only_on_master or xm.is_master_ordinal():
+    return torch_xla._XLAC.profiler.start_server(port)
 
 
 def trace(service_addr: str,


### PR DESCRIPTION
Syncing TF to latest as well as supporting TPU 1VM + profiler:
* Nightly TPUVM broken due to API mismatch on `libtpu.so` (https://github.com/tensorflow/tensorflow/commit/b70b22739cc41c004e9ff6a0ad6b599b308d47dd).
* Not able to find any TPU devices in 1VM: dependency from `:tpu_node_device`, `:tpu_system_device` removed from `tpu_api_dlsym_initializer` target (https://github.com/tensorflow/tensorflow/commit/c5f474d1c8b4956dae0585960a388dc948221662).
* Not able to load more multiple TPU devices on single host: TF added lockfile to guard `libtpu.so` to single process per host as this works for JAX and TF (https://github.com/tensorflow/tensorflow/commit/d426f1b26fe2d2c48d900a57119c7681e70fe79b). Addressed using 2x2's `TPU_HOST_BOUNDS`.
* XLA changed API and location for permutation utils we used to use:
  * https://github.com/tensorflow/tensorflow/commit/231d3ab44db8c9d23525dcf454527e306794d2e8
  * https://github.com/tensorflow/tensorflow/commit/9fcf66e16dfbd32ebf739bac3e2dd1db59c67360
* `xla::Permute` implementation inverted: https://github.com/tensorflow/tensorflow/commit/6d24ecfdcc166f1fdec20009931c8650a6f27de8
* `xla::ShapeUtil::PermuteDimensions` implementation inverted: https://github.com/tensorflow/tensorflow/commit/a85d5a5b1b1fd0ccd4732184823b1215bb26aacc
* TF profiler server currently requires only one server being opened per host to collect XRT host and TPU device traces. Guard server spawning with master check. Sample profile with both client/server and TPU device traces collected on single request and displayed on same trace viewer:
![image](https://user-images.githubusercontent.com/19496130/109252303-31060580-77bb-11eb-8802-def0b365570d.png)


Will be cherry-picking into r1.8 branch as well.