### PR TITLE
[r.18]Set default GRPC_VERBOSITY

### DIFF
--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -93,6 +93,7 @@ def _set_missing_env(name, value):
 def _setup_default_env():
   _set_missing_env('TF_CPP_MIN_LOG_LEVEL', '1')
   _set_missing_env('TPU_HOST_BOUNDS', '1,1,1')
+  _set_missing_env('GRPC_VERBOSITY', 'ERROR')
 
 
 _fd, _tmp_fname = -1, ''


### PR DESCRIPTION
defualt GRPC_VERBOSITY to `ERROR` so we won't see logs like 
```
D0301 23:22:33.361062235    5005 lb_policy_registry.cc:42]   registering LB policy factory for "cds_experimental"
D0301 23:22:33.361066123    5005 lb_policy_registry.cc:42]   registering LB policy factory for "xds_cluster_impl_experimental"
D0301 23:22:33.361069596    5005 lb_policy_registry.cc:42]   registering LB policy factory for "xds_cluster_resolver_experimental"
D0301 23:22:33.361073758    5005 lb_policy_registry.cc:42]   registering LB policy factory for "xds_cluster_manager_experimental"
```