### PR TITLE
Fix code generation for new ScalarList type

### DIFF
--- a/scripts/gen.py
+++ b/scripts/gen.py
@@ -182,6 +182,7 @@ _TYPE_NSMAP = {
     'Tensor': 'at::Tensor',
     'TensorList': 'at::TensorList',
     'Scalar': 'at::Scalar',
+    'ScalarList': 'at::ScalarList',
     'Storage': 'at::Storage',
     'IntList': 'at::IntList',
     'IntArrayRef': 'at::IntArrayRef',


### PR DESCRIPTION
We are going to introduce ScalarList = ArrayRef<Scalar> in PyTorch.

See https://github.com/pytorch/pytorch/pull/53470 for context. 