### PR TITLE
Pass Scalar by reference

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -178,7 +178,8 @@ void AtenInitialize() {
 
 }  // namespace
 
-at::Tensor& AtenXlaType::__ilshift__(at::Tensor& self, at::Scalar other) {
+at::Tensor& AtenXlaType::__ilshift__(at::Tensor& self,
+                                     const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::__ilshift__(self_tensor, other);
@@ -194,7 +195,8 @@ at::Tensor& AtenXlaType::__ilshift__(at::Tensor& self,
   return self;
 }
 
-at::Tensor& AtenXlaType::__irshift__(at::Tensor& self, at::Scalar other) {
+at::Tensor& AtenXlaType::__irshift__(at::Tensor& self,
+                                     const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   CheckBinaryOpTypePromotion(self, self, other);
   XLATensor self_tensor = bridge::GetXlaTensor(self);
@@ -211,7 +213,8 @@ at::Tensor& AtenXlaType::__irshift__(at::Tensor& self,
   return self;
 }
 
-at::Tensor AtenXlaType::__lshift__(const at::Tensor& self, at::Scalar other) {
+at::Tensor AtenXlaType::__lshift__(const at::Tensor& self,
+                                   const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   return DoBinaryOp(self, other,
                     [&](const XLATensor& xself, const at::Scalar& other,
@@ -230,7 +233,8 @@ at::Tensor AtenXlaType::__lshift__(const at::Tensor& self,
                     });
 }
 
-at::Tensor AtenXlaType::__rshift__(const at::Tensor& self, at::Scalar other) {
+at::Tensor AtenXlaType::__rshift__(const at::Tensor& self,
+                                   const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   return DoBinaryOp(self, other,
                     [&](const XLATensor& xself, const at::Scalar& other,
@@ -456,7 +460,7 @@ at::Tensor& AtenXlaType::acosh_(at::Tensor& self) {
 }
 
 at::Tensor AtenXlaType::add(const at::Tensor& self, const at::Tensor& other,
-                            at::Scalar alpha) {
+                            const at::Scalar& alpha) {
   XLA_FN_COUNTER("xla::");
   at::native::alpha_check(at::result_type(self, other), alpha);
   return DoBinaryOp(self, other,
@@ -466,8 +470,8 @@ at::Tensor AtenXlaType::add(const at::Tensor& self, const at::Tensor& other,
                     });
 }
 
-at::Tensor AtenXlaType::add(const at::Tensor& self, at::Scalar other,
-                            at::Scalar alpha) {
+at::Tensor AtenXlaType::add(const at::Tensor& self, const at::Scalar& other,
+                            const at::Scalar& alpha) {
   XLA_FN_COUNTER("xla::");
   return DoBinaryOp(self, other,
                     [&](const XLATensor& xself, const at::Scalar& other,
@@ -477,7 +481,7 @@ at::Tensor AtenXlaType::add(const at::Tensor& self, at::Scalar other,
 }
 
 at::Tensor& AtenXlaType::add_(at::Tensor& self, const at::Tensor& other,
-                              at::Scalar alpha) {
+                              const at::Scalar& alpha) {
   XLA_FN_COUNTER("xla::");
   at::native::alpha_check(at::result_type(self, other), alpha);
   CheckBinaryOpTypePromotion(self, self, other);
@@ -488,8 +492,8 @@ at::Tensor& AtenXlaType::add_(at::Tensor& self, const at::Tensor& other,
   return self;
 }
 
-at::Tensor& AtenXlaType::add_(at::Tensor& self, at::Scalar other,
-                              at::Scalar alpha) {
+at::Tensor& AtenXlaType::add_(at::Tensor& self, const at::Scalar& other,
+                              const at::Scalar& alpha) {
   XLA_FN_COUNTER("xla::");
   CheckBinaryOpTypePromotion(self, self, other);
   XLATensor self_tensor = bridge::GetXlaTensor(self);
@@ -499,7 +503,8 @@ at::Tensor& AtenXlaType::add_(at::Tensor& self, at::Scalar other,
 
 at::Tensor AtenXlaType::addcdiv(const at::Tensor& self,
                                 const at::Tensor& tensor1,
-                                const at::Tensor& tensor2, at::Scalar value) {
+                                const at::Tensor& tensor2,
+                                const at::Scalar& value) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::addcdiv(
       bridge::GetXlaTensor(self), value, bridge::GetXlaTensor(tensor1),
@@ -507,7 +512,8 @@ at::Tensor AtenXlaType::addcdiv(const at::Tensor& self,
 }
 
 at::Tensor& AtenXlaType::addcdiv_(at::Tensor& self, const at::Tensor& tensor1,
-                                  const at::Tensor& tensor2, at::Scalar value) {
+                                  const at::Tensor& tensor2,
+                                  const at::Scalar& value) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::addcdiv_(self_tensor, value, bridge::GetXlaTensor(tensor1),
@@ -517,7 +523,8 @@ at::Tensor& AtenXlaType::addcdiv_(at::Tensor& self, const at::Tensor& tensor1,
 
 at::Tensor AtenXlaType::addcmul(const at::Tensor& self,
                                 const at::Tensor& tensor1,
-                                const at::Tensor& tensor2, at::Scalar value) {
+                                const at::Tensor& tensor2,
+                                const at::Scalar& value) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::addcmul(
       bridge::GetXlaTensor(self), value, bridge::GetXlaTensor(tensor1),
@@ -525,7 +532,8 @@ at::Tensor AtenXlaType::addcmul(const at::Tensor& self,
 }
 
 at::Tensor& AtenXlaType::addcmul_(at::Tensor& self, const at::Tensor& tensor1,
-                                  const at::Tensor& tensor2, at::Scalar value) {
+                                  const at::Tensor& tensor2,
+                                  const at::Scalar& value) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::addcmul_(self_tensor, value, bridge::GetXlaTensor(tensor1),
@@ -534,8 +542,8 @@ at::Tensor& AtenXlaType::addcmul_(at::Tensor& self, const at::Tensor& tensor1,
 }
 
 at::Tensor AtenXlaType::addmm(const at::Tensor& self, const at::Tensor& mat1,
-                              const at::Tensor& mat2, at::Scalar beta,
-                              at::Scalar alpha) {
+                              const at::Tensor& mat2, const at::Scalar& beta,
+                              const at::Scalar& alpha) {
   XLA_FN_COUNTER("xla::");
   // xla::dot doesn't support integer types.
   if (beta.to<double>() != 1 || alpha.to<double>() != 1 ||
@@ -585,8 +593,9 @@ at::Tensor AtenXlaType::any(const at::Tensor& self, int64_t dim, bool keepdim) {
       XLATensor::any(bridge::GetXlaTensor(self), {dim}, keepdim));
 }
 
-at::Tensor& AtenXlaType::arange_out(at::Scalar start, at::Scalar end,
-                                    at::Scalar step, at::Tensor& out) {
+at::Tensor& AtenXlaType::arange_out(const at::Scalar& start,
+                                    const at::Scalar& end,
+                                    const at::Scalar& step, at::Tensor& out) {
   XLA_FN_COUNTER("xla::");
   XLATensor out_tensor = bridge::GetXlaTensor(out);
   XLATensor::arange_out(out_tensor, start, end, step, out.scalar_type());
@@ -792,8 +801,9 @@ at::Tensor AtenXlaType::avg_pool3d_backward(
 
 at::Tensor AtenXlaType::baddbmm(const at::Tensor& self,
                                 const at::Tensor& batch1,
-                                const at::Tensor& batch2, at::Scalar beta,
-                                at::Scalar alpha) {
+                                const at::Tensor& batch2,
+                                const at::Scalar& beta,
+                                const at::Scalar& alpha) {
   XLA_FN_COUNTER("xla::");
   // xla::dot doesn't support integer types.
   if (!at::native::is_floating_point(batch1) ||
@@ -806,8 +816,9 @@ at::Tensor AtenXlaType::baddbmm(const at::Tensor& self,
 }
 
 at::Tensor& AtenXlaType::baddbmm_(at::Tensor& self, const at::Tensor& batch1,
-                                  const at::Tensor& batch2, at::Scalar beta,
-                                  at::Scalar alpha) {
+                                  const at::Tensor& batch2,
+                                  const at::Scalar& beta,
+                                  const at::Scalar& alpha) {
   XLA_FN_COUNTER("xla::");
   // xla::dot doesn't support integer types.
   if (!at::native::is_floating_point(batch1) ||
@@ -887,7 +898,8 @@ at::Tensor AtenXlaType::binary_cross_entropy_with_logits(
 }
 
 at::Tensor& AtenXlaType::bitwise_and_out(const at::Tensor& self,
-                                         at::Scalar other, at::Tensor& out) {
+                                         const at::Scalar& other,
+                                         at::Tensor& out) {
   XLA_FN_COUNTER("xla::");
   CheckBinaryOpTypePromotion(out, self, other);
   XLATensor out_tensor = bridge::GetXlaTensor(out);
@@ -916,7 +928,8 @@ at::Tensor& AtenXlaType::bitwise_not_out(const at::Tensor& self,
 }
 
 at::Tensor& AtenXlaType::bitwise_or_out(const at::Tensor& self,
-                                        at::Scalar other, at::Tensor& out) {
+                                        const at::Scalar& other,
+                                        at::Tensor& out) {
   XLA_FN_COUNTER("xla::");
   CheckBinaryOpTypePromotion(out, self, other);
   XLATensor out_tensor = bridge::GetXlaTensor(out);
@@ -936,7 +949,8 @@ at::Tensor& AtenXlaType::bitwise_or_out(const at::Tensor& self,
 }
 
 at::Tensor& AtenXlaType::bitwise_xor_out(const at::Tensor& self,
-                                         at::Scalar other, at::Tensor& out) {
+                                         const at::Scalar& other,
+                                         at::Tensor& out) {
   XLA_FN_COUNTER("xla::");
   CheckBinaryOpTypePromotion(out, self, other);
   XLATensor out_tensor = bridge::GetXlaTensor(out);
@@ -991,41 +1005,44 @@ at::Tensor AtenXlaType::cholesky(const at::Tensor& self, bool upper) {
 }
 
 at::Tensor AtenXlaType::clamp(const at::Tensor& self,
-                              c10::optional<at::Scalar> min,
-                              c10::optional<at::Scalar> max) {
+                              const c10::optional<at::Scalar>& min,
+                              const c10::optional<at::Scalar>& max) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
       XLATensor::clamp(bridge::GetXlaTensor(self), min, max));
 }
 
-at::Tensor& AtenXlaType::clamp_(at::Tensor& self, c10::optional<at::Scalar> min,
-                                c10::optional<at::Scalar> max) {
+at::Tensor& AtenXlaType::clamp_(at::Tensor& self,
+                                const c10::optional<at::Scalar>& min,
+                                const c10::optional<at::Scalar>& max) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::clamp_(self_tensor, min, max);
   return self;
 }
 
-at::Tensor AtenXlaType::clamp_max(const at::Tensor& self, at::Scalar max) {
+at::Tensor AtenXlaType::clamp_max(const at::Tensor& self,
+                                  const at::Scalar& max) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
       XLATensor::clamp(bridge::GetXlaTensor(self), c10::nullopt, max));
 }
 
-at::Tensor& AtenXlaType::clamp_max_(at::Tensor& self, at::Scalar max) {
+at::Tensor& AtenXlaType::clamp_max_(at::Tensor& self, const at::Scalar& max) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::clamp_(self_tensor, c10::nullopt, max);
   return self;
 }
 
-at::Tensor AtenXlaType::clamp_min(const at::Tensor& self, at::Scalar min) {
+at::Tensor AtenXlaType::clamp_min(const at::Tensor& self,
+                                  const at::Scalar& min) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
       XLATensor::clamp(bridge::GetXlaTensor(self), min, c10::nullopt));
 }
 
-at::Tensor& AtenXlaType::clamp_min_(at::Tensor& self, at::Scalar min) {
+at::Tensor& AtenXlaType::clamp_min_(at::Tensor& self, const at::Scalar& min) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::clamp_(self_tensor, min, c10::nullopt);
@@ -1041,7 +1058,8 @@ at::Tensor AtenXlaType::clone(
 }
 
 at::Tensor AtenXlaType::constant_pad_nd(const at::Tensor& self,
-                                        at::IntArrayRef pad, at::Scalar value) {
+                                        at::IntArrayRef pad,
+                                        const at::Scalar& value) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::constant_pad_nd(
       bridge::GetXlaTensor(self), XlaHelpers::I64List(pad), value));
@@ -1175,7 +1193,7 @@ at::Tensor AtenXlaType::div(const at::Tensor& self, const at::Tensor& other,
       XLATensor::div(operands.first, operands.second, rounding_mode, dtype));
 }
 
-at::Tensor AtenXlaType::div(const at::Tensor& self, at::Scalar other) {
+at::Tensor AtenXlaType::div(const at::Tensor& self, const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
       XLATensor::div(bridge::GetXlaTensor(self), other));
@@ -1196,7 +1214,7 @@ at::Tensor& AtenXlaType::div_(at::Tensor& self, const at::Tensor& other,
   return self;
 }
 
-at::Tensor& AtenXlaType::div_(at::Tensor& self, at::Scalar other) {
+at::Tensor& AtenXlaType::div_(at::Tensor& self, const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   CheckBinaryOpTypePromotion(self, self, other);
   XLATensor self_tensor = bridge::GetXlaTensor(self);
@@ -1219,15 +1237,17 @@ at::Tensor AtenXlaType::dot(const at::Tensor& self, const at::Tensor& tensor) {
       bridge::GetXlaTensor(self), bridge::GetXlaTensor(tensor)));
 }
 
-at::Tensor AtenXlaType::elu(const at::Tensor& self, at::Scalar alpha,
-                            at::Scalar scale, at::Scalar input_scale) {
+at::Tensor AtenXlaType::elu(const at::Tensor& self, const at::Scalar& alpha,
+                            const at::Scalar& scale,
+                            const at::Scalar& input_scale) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
       XLATensor::elu(bridge::GetXlaTensor(self), alpha, scale, input_scale));
 }
 
-at::Tensor& AtenXlaType::elu_(at::Tensor& self, at::Scalar alpha,
-                              at::Scalar scale, at::Scalar input_scale) {
+at::Tensor& AtenXlaType::elu_(at::Tensor& self, const at::Scalar& alpha,
+                              const at::Scalar& scale,
+                              const at::Scalar& input_scale) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::elu_(self_tensor, alpha, scale, input_scale);
@@ -1235,8 +1255,9 @@ at::Tensor& AtenXlaType::elu_(at::Tensor& self, at::Scalar alpha,
 }
 
 at::Tensor AtenXlaType::elu_backward(const at::Tensor& grad_output,
-                                     at::Scalar alpha, at::Scalar scale,
-                                     at::Scalar input_scale, bool self,
+                                     const at::Scalar& alpha,
+                                     const at::Scalar& scale,
+                                     const at::Scalar& input_scale, bool self,
                                      const at::Tensor& self_or_result) {
   XLA_FN_COUNTER("xla::");
   XLA_CHECK(!self || alpha.to<double>() >= 0.0)
@@ -1296,7 +1317,7 @@ at::Tensor AtenXlaType::empty_strided(at::IntArrayRef size,
   return as_strided(t, size, stride, /*storage_offset=*/0);
 }
 
-at::Tensor AtenXlaType::eq(const at::Tensor& self, at::Scalar other) {
+at::Tensor AtenXlaType::eq(const at::Tensor& self, const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
       XLATensor::eq(bridge::GetXlaTensor(self), other));
@@ -1308,7 +1329,7 @@ at::Tensor AtenXlaType::eq(const at::Tensor& self, const at::Tensor& other) {
       XLATensor::eq(bridge::GetXlaTensor(self), bridge::GetXlaTensor(other)));
 }
 
-at::Tensor& AtenXlaType::eq_(at::Tensor& self, at::Scalar other) {
+at::Tensor& AtenXlaType::eq_(at::Tensor& self, const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::eq_(self_tensor, other);
@@ -1417,7 +1438,7 @@ at::Tensor& AtenXlaType::eye_out(int64_t n, int64_t m, at::Tensor& out) {
   return out;
 }
 
-at::Tensor& AtenXlaType::fill_(at::Tensor& self, at::Scalar value) {
+at::Tensor& AtenXlaType::fill_(at::Tensor& self, const at::Scalar& value) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::fill_(self_tensor, value);
@@ -1460,7 +1481,7 @@ at::Tensor AtenXlaType::fmod(const at::Tensor& self, const at::Tensor& other) {
                     });
 }
 
-at::Tensor AtenXlaType::fmod(const at::Tensor& self, at::Scalar other) {
+at::Tensor AtenXlaType::fmod(const at::Tensor& self, const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   return DoBinaryOp(self, other,
                     [&](const XLATensor& xself, const at::Scalar& other,
@@ -1477,7 +1498,7 @@ at::Tensor& AtenXlaType::fmod_(at::Tensor& self, const at::Tensor& other) {
   return self;
 }
 
-at::Tensor& AtenXlaType::fmod_(at::Tensor& self, at::Scalar other) {
+at::Tensor& AtenXlaType::fmod_(at::Tensor& self, const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   CheckBinaryOpTypePromotion(self, self, other);
   XLATensor self_tensor = bridge::GetXlaTensor(self);
@@ -1505,7 +1526,7 @@ at::Tensor AtenXlaType::gather(const at::Tensor& self, int64_t dim,
       bridge::GetXlaTensor(self), dim, bridge::GetXlaTensor(index)));
 }
 
-at::Tensor AtenXlaType::ge(const at::Tensor& self, at::Scalar other) {
+at::Tensor AtenXlaType::ge(const at::Tensor& self, const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
       XLATensor::ge(bridge::GetXlaTensor(self), other));
@@ -1517,7 +1538,7 @@ at::Tensor AtenXlaType::ge(const at::Tensor& self, const at::Tensor& other) {
       XLATensor::ge(bridge::GetXlaTensor(self), bridge::GetXlaTensor(other)));
 }
 
-at::Tensor& AtenXlaType::ge_(at::Tensor& self, at::Scalar other) {
+at::Tensor& AtenXlaType::ge_(at::Tensor& self, const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::ge_(self_tensor, other);
@@ -1549,7 +1570,7 @@ at::Tensor AtenXlaType::ger(const at::Tensor& self, const at::Tensor& vec2) {
       XLATensor::ger(bridge::GetXlaTensor(self), bridge::GetXlaTensor(vec2)));
 }
 
-at::Tensor AtenXlaType::gt(const at::Tensor& self, at::Scalar other) {
+at::Tensor AtenXlaType::gt(const at::Tensor& self, const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
       XLATensor::gt(bridge::GetXlaTensor(self), other));
@@ -1561,7 +1582,7 @@ at::Tensor AtenXlaType::gt(const at::Tensor& self, const at::Tensor& other) {
       XLATensor::gt(bridge::GetXlaTensor(self), bridge::GetXlaTensor(other)));
 }
 
-at::Tensor& AtenXlaType::gt_(at::Tensor& self, at::Scalar other) {
+at::Tensor& AtenXlaType::gt_(at::Tensor& self, const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::gt_(self_tensor, other);
@@ -1575,7 +1596,8 @@ at::Tensor& AtenXlaType::gt_(at::Tensor& self, const at::Tensor& other) {
   return self;
 }
 
-at::Tensor AtenXlaType::hardshrink(const at::Tensor& self, at::Scalar lambda) {
+at::Tensor AtenXlaType::hardshrink(const at::Tensor& self,
+                                   const at::Scalar& lambda) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
       XLATensor::hardshrink(bridge::GetXlaTensor(self), lambda));
@@ -1603,21 +1625,22 @@ at::Tensor AtenXlaType::hardsigmoid_backward(const at::Tensor& grad_output,
 
 at::Tensor AtenXlaType::hardshrink_backward(const at::Tensor& grad_out,
                                             const at::Tensor& self,
-                                            at::Scalar lambda) {
+                                            const at::Scalar& lambda) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::hardshrink_backward(
       bridge::GetXlaTensor(grad_out), bridge::GetXlaTensor(self), lambda));
 }
 
-at::Tensor AtenXlaType::hardtanh(const at::Tensor& self, at::Scalar min_val,
-                                 at::Scalar max_val) {
+at::Tensor AtenXlaType::hardtanh(const at::Tensor& self,
+                                 const at::Scalar& min_val,
+                                 const at::Scalar& max_val) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
       XLATensor::clamp(bridge::GetXlaTensor(self), min_val, max_val));
 }
 
-at::Tensor& AtenXlaType::hardtanh_(at::Tensor& self, at::Scalar min_val,
-                                   at::Scalar max_val) {
+at::Tensor& AtenXlaType::hardtanh_(at::Tensor& self, const at::Scalar& min_val,
+                                   const at::Scalar& max_val) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::clamp_(self_tensor, min_val, max_val);
@@ -1626,8 +1649,8 @@ at::Tensor& AtenXlaType::hardtanh_(at::Tensor& self, at::Scalar min_val,
 
 at::Tensor AtenXlaType::hardtanh_backward(const at::Tensor& grad_output,
                                           const at::Tensor& self,
-                                          at::Scalar min_val,
-                                          at::Scalar max_val) {
+                                          const at::Scalar& min_val,
+                                          const at::Scalar& max_val) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::hardtanh_backward(
       bridge::GetXlaTensor(grad_output), bridge::GetXlaTensor(self), min_val,
@@ -1668,7 +1691,7 @@ at::Tensor& AtenXlaType::index_copy_(at::Tensor& self, int64_t dim,
 
 at::Tensor& AtenXlaType::index_fill_(at::Tensor& self, int64_t dim,
                                      const at::Tensor& index,
-                                     at::Scalar value) {
+                                     const at::Scalar& value) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::index_fill_(self_tensor, dim, bridge::GetXlaTensor(index), value);
@@ -1757,7 +1780,7 @@ at::Tensor AtenXlaType::l1_loss_backward(const at::Tensor& grad_output,
       bridge::GetXlaTensor(target), reduction));
 }
 
-at::Tensor AtenXlaType::le(const at::Tensor& self, at::Scalar other) {
+at::Tensor AtenXlaType::le(const at::Tensor& self, const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
       XLATensor::le(bridge::GetXlaTensor(self), other));
@@ -1769,7 +1792,7 @@ at::Tensor AtenXlaType::le(const at::Tensor& self, const at::Tensor& other) {
       XLATensor::le(bridge::GetXlaTensor(self), bridge::GetXlaTensor(other)));
 }
 
-at::Tensor& AtenXlaType::le_(at::Tensor& self, at::Scalar other) {
+at::Tensor& AtenXlaType::le_(at::Tensor& self, const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::le_(self_tensor, other);
@@ -1784,14 +1807,14 @@ at::Tensor& AtenXlaType::le_(at::Tensor& self, const at::Tensor& other) {
 }
 
 at::Tensor AtenXlaType::leaky_relu(const at::Tensor& self,
-                                   at::Scalar negative_slope) {
+                                   const at::Scalar& negative_slope) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::leaky_relu(
       bridge::GetXlaTensor(self), negative_slope.to<double>()));
 }
 
 at::Tensor& AtenXlaType::leaky_relu_(at::Tensor& self,
-                                     at::Scalar negative_slope) {
+                                     const at::Scalar& negative_slope) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::leaky_relu_(self_tensor, negative_slope.to<double>());
@@ -1800,7 +1823,7 @@ at::Tensor& AtenXlaType::leaky_relu_(at::Tensor& self,
 
 at::Tensor AtenXlaType::leaky_relu_backward(const at::Tensor& grad_output,
                                             const at::Tensor& self,
-                                            at::Scalar negative_slope,
+                                            const at::Scalar& negative_slope,
                                             bool self_is_result) {
   XLA_FN_COUNTER("xla::");
   XLA_CHECK(!self_is_result || negative_slope.to<double>() > 0.0);
@@ -1892,7 +1915,7 @@ at::Tensor AtenXlaType::logdet(const at::Tensor& self) {
       XLATensor::logdet(bridge::GetXlaTensor(self)));
 }
 
-at::Tensor AtenXlaType::lt(const at::Tensor& self, at::Scalar other) {
+at::Tensor AtenXlaType::lt(const at::Tensor& self, const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
       XLATensor::lt(bridge::GetXlaTensor(self), other));
@@ -1904,7 +1927,7 @@ at::Tensor AtenXlaType::lt(const at::Tensor& self, const at::Tensor& other) {
       XLATensor::lt(bridge::GetXlaTensor(self), bridge::GetXlaTensor(other)));
 }
 
-at::Tensor& AtenXlaType::lt_(at::Tensor& self, at::Scalar other) {
+at::Tensor& AtenXlaType::lt_(at::Tensor& self, const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::lt_(self_tensor, other);
@@ -1919,7 +1942,7 @@ at::Tensor& AtenXlaType::lt_(at::Tensor& self, const at::Tensor& other) {
 }
 
 at::Tensor& AtenXlaType::masked_fill_(at::Tensor& self, const at::Tensor& mask,
-                                      at::Scalar value) {
+                                      const at::Scalar& value) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::masked_fill_(self_tensor, bridge::GetXlaTensor(mask), value);
@@ -2217,7 +2240,7 @@ at::Tensor AtenXlaType::mul(const at::Tensor& self, const at::Tensor& other) {
                     });
 }
 
-at::Tensor AtenXlaType::mul(const at::Tensor& self, at::Scalar other) {
+at::Tensor AtenXlaType::mul(const at::Tensor& self, const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   return DoBinaryOp(self, other,
                     [&](const XLATensor& xself, const at::Scalar& other,
@@ -2235,7 +2258,7 @@ at::Tensor& AtenXlaType::mul_(at::Tensor& self, const at::Tensor& other) {
   return self;
 }
 
-at::Tensor& AtenXlaType::mul_(at::Tensor& self, at::Scalar other) {
+at::Tensor& AtenXlaType::mul_(at::Tensor& self, const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   CheckBinaryOpTypePromotion(self, self, other);
   XLATensor self_tensor = bridge::GetXlaTensor(self);
@@ -2317,7 +2340,7 @@ AtenXlaType::native_batch_norm_backward(
                      : undefined);
 }
 
-at::Tensor AtenXlaType::ne(const at::Tensor& self, at::Scalar other) {
+at::Tensor AtenXlaType::ne(const at::Tensor& self, const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
       XLATensor::ne(bridge::GetXlaTensor(self), other));
@@ -2329,7 +2352,7 @@ at::Tensor AtenXlaType::ne(const at::Tensor& self, const at::Tensor& other) {
       XLATensor::ne(bridge::GetXlaTensor(self), bridge::GetXlaTensor(other)));
 }
 
-at::Tensor& AtenXlaType::ne_(at::Tensor& self, at::Scalar other) {
+at::Tensor& AtenXlaType::ne_(at::Tensor& self, const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::ne_(self_tensor, other);
@@ -2440,7 +2463,7 @@ at::Tensor AtenXlaType::nonzero(const at::Tensor& self) {
 }
 
 at::Tensor AtenXlaType::norm(const at::Tensor& self,
-                             c10::optional<at::Scalar> p,
+                             const c10::optional<at::Scalar>& p,
                              at::ScalarType dtype) {
   XLA_FN_COUNTER("xla::");
   // If p==0 it is a torch.nonzero(), which is not lowered to XLA due to dynamic
@@ -2452,7 +2475,7 @@ at::Tensor AtenXlaType::norm(const at::Tensor& self,
       bridge::GetXlaTensor(self), p, dtype, {}, /*keepdim=*/false));
 }
 
-at::Tensor AtenXlaType::norm(const at::Tensor& self, at::Scalar p) {
+at::Tensor AtenXlaType::norm(const at::Tensor& self, const at::Scalar& p) {
   XLA_FN_COUNTER("xla::");
   // If p==0 it is a torch.nonzero(), which is not lowered to XLA due to dynamic
   // shapes issue.
@@ -2464,8 +2487,9 @@ at::Tensor AtenXlaType::norm(const at::Tensor& self, at::Scalar p) {
 }
 
 at::Tensor AtenXlaType::norm(const at::Tensor& self,
-                             c10::optional<at::Scalar> p, at::IntArrayRef dim,
-                             bool keepdim, at::ScalarType dtype) {
+                             const c10::optional<at::Scalar>& p,
+                             at::IntArrayRef dim, bool keepdim,
+                             at::ScalarType dtype) {
   XLA_FN_COUNTER("xla::");
   // If p==0 it is a torch.nonzero(), which is not lowered to XLA due to dynamic
   // shapes issue.
@@ -2477,8 +2501,8 @@ at::Tensor AtenXlaType::norm(const at::Tensor& self,
 }
 
 at::Tensor AtenXlaType::norm(const at::Tensor& self,
-                             c10::optional<at::Scalar> p, at::IntArrayRef dim,
-                             bool keepdim) {
+                             const c10::optional<at::Scalar>& p,
+                             at::IntArrayRef dim, bool keepdim) {
   XLA_FN_COUNTER("xla::");
   // If p==0 it is a torch.nonzero(), which is not lowered to XLA due to dynamic
   // shapes issue.
@@ -2536,7 +2560,8 @@ at::Tensor AtenXlaType::permute(const at::Tensor& self, at::IntArrayRef dims) {
       bridge::GetXlaTensor(self), XlaHelpers::I64List(dims)));
 }
 
-at::Tensor AtenXlaType::pow(const at::Tensor& self, at::Scalar exponent) {
+at::Tensor AtenXlaType::pow(const at::Tensor& self,
+                            const at::Scalar& exponent) {
   XLA_FN_COUNTER("xla::");
   // xla::Pow() doesn't support integer types.
   if (!at::native::is_floating_point(self)) {
@@ -2557,7 +2582,8 @@ at::Tensor AtenXlaType::pow(const at::Tensor& self,
       bridge::GetXlaTensor(self), bridge::GetXlaTensor(exponent)));
 }
 
-at::Tensor AtenXlaType::pow(at::Scalar self, const at::Tensor& exponent) {
+at::Tensor AtenXlaType::pow(const at::Scalar& self,
+                            const at::Tensor& exponent) {
   XLA_FN_COUNTER("xla::");
   // xla::Pow() doesn't support integer types.
   if (!self.isFloatingPoint()) {
@@ -2567,7 +2593,7 @@ at::Tensor AtenXlaType::pow(at::Scalar self, const at::Tensor& exponent) {
       XLATensor::pow(self, bridge::GetXlaTensor(exponent)));
 }
 
-at::Tensor& AtenXlaType::pow_(at::Tensor& self, at::Scalar exponent) {
+at::Tensor& AtenXlaType::pow_(at::Tensor& self, const at::Scalar& exponent) {
   XLA_FN_COUNTER("xla::");
   // xla::Pow() doesn't support integer types.
   if (!at::native::is_floating_point(self)) {
@@ -2720,7 +2746,8 @@ at::Tensor AtenXlaType::remainder(const at::Tensor& self,
       bridge::GetXlaTensor(self), bridge::GetXlaTensor(other)));
 }
 
-at::Tensor AtenXlaType::remainder(const at::Tensor& self, at::Scalar other) {
+at::Tensor AtenXlaType::remainder(const at::Tensor& self,
+                                  const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
       XLATensor::remainder(bridge::GetXlaTensor(self), other));
@@ -2733,7 +2760,7 @@ at::Tensor& AtenXlaType::remainder_(at::Tensor& self, const at::Tensor& other) {
   return self;
 }
 
-at::Tensor& AtenXlaType::remainder_(at::Tensor& self, at::Scalar other) {
+at::Tensor& AtenXlaType::remainder_(at::Tensor& self, const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::remainder_(self_tensor, other);
@@ -2802,8 +2829,9 @@ at::Tensor& AtenXlaType::round_(at::Tensor& self) {
 }
 
 at::Tensor AtenXlaType::rrelu_with_noise(
-    const at::Tensor& self, const at::Tensor& noise, at::Scalar lower,
-    at::Scalar upper, bool training, c10::optional<at::Generator> generator) {
+    const at::Tensor& self, const at::Tensor& noise, const at::Scalar& lower,
+    const at::Scalar& upper, bool training,
+    c10::optional<at::Generator> generator) {
   XLA_FN_COUNTER("xla::");
   if (generator.has_value() && generator->defined()) {
     // The fallback path for rrelu_with_noise when training=true is wrong
@@ -2818,8 +2846,8 @@ at::Tensor AtenXlaType::rrelu_with_noise(
 
 at::Tensor AtenXlaType::rrelu_with_noise_backward(
     const at::Tensor& grad_output, const at::Tensor& self,
-    const at::Tensor& noise, at::Scalar lower, at::Scalar upper, bool training,
-    bool self_is_result) {
+    const at::Tensor& noise, const at::Scalar& lower, const at::Scalar& upper,
+    bool training, bool self_is_result) {
   XLA_FN_COUNTER("xla::");
   double negative_slope = (lower.to<double>() + upper.to<double>()) / 2;
   XLA_CHECK(!self_is_result || negative_slope > 0.0);
@@ -2843,7 +2871,7 @@ at::Tensor& AtenXlaType::rsqrt_(at::Tensor& self) {
 }
 
 at::Tensor AtenXlaType::rsub(const at::Tensor& self, const at::Tensor& other,
-                             at::Scalar alpha) {
+                             const at::Scalar& alpha) {
   XLA_FN_COUNTER("xla::");
   CheckSubOperandTypes(self.scalar_type(), other.scalar_type());
   return DoBinaryOp(self, other,
@@ -2853,8 +2881,8 @@ at::Tensor AtenXlaType::rsub(const at::Tensor& self, const at::Tensor& other,
                     });
 }
 
-at::Tensor AtenXlaType::rsub(const at::Tensor& self, at::Scalar other,
-                             at::Scalar alpha) {
+at::Tensor AtenXlaType::rsub(const at::Tensor& self, const at::Scalar& other,
+                             const at::Scalar& alpha) {
   XLA_FN_COUNTER("xla::");
   CheckSubOperandTypes(self.scalar_type(), GetScalarType(other));
   return bridge::AtenFromXlaTensor(
@@ -2872,7 +2900,8 @@ at::Tensor& AtenXlaType::scatter_(at::Tensor& self, int64_t dim,
 }
 
 at::Tensor& AtenXlaType::scatter_(at::Tensor& self, int64_t dim,
-                                  const at::Tensor& index, at::Scalar value) {
+                                  const at::Tensor& index,
+                                  const at::Scalar& value) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::scatter_(self_tensor, dim, bridge::GetXlaTensor(index), value);
@@ -2990,8 +3019,8 @@ at::Tensor AtenXlaType::smooth_l1_loss_backward(const at::Tensor& grad_output,
       bridge::GetXlaTensor(target), reduction, beta));
 }
 
-at::Tensor AtenXlaType::softplus(const at::Tensor& self, at::Scalar beta,
-                                 at::Scalar threshold) {
+at::Tensor AtenXlaType::softplus(const at::Tensor& self, const at::Scalar& beta,
+                                 const at::Scalar& threshold) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
       XLATensor::softplus(bridge::GetXlaTensor(self), beta, threshold));
@@ -2999,7 +3028,8 @@ at::Tensor AtenXlaType::softplus(const at::Tensor& self, at::Scalar beta,
 
 at::Tensor AtenXlaType::softplus_backward(const at::Tensor& grad_output,
                                           const at::Tensor& self,
-                                          at::Scalar beta, at::Scalar threshold,
+                                          const at::Scalar& beta,
+                                          const at::Scalar& threshold,
                                           const at::Tensor& output) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::softplus_backward(
@@ -3007,7 +3037,8 @@ at::Tensor AtenXlaType::softplus_backward(const at::Tensor& grad_output,
       threshold, bridge::GetXlaTensor(output)));
 }
 
-at::Tensor AtenXlaType::softshrink(const at::Tensor& self, at::Scalar lambda) {
+at::Tensor AtenXlaType::softshrink(const at::Tensor& self,
+                                   const at::Scalar& lambda) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
       XLATensor::softshrink(bridge::GetXlaTensor(self), lambda));
@@ -3015,7 +3046,7 @@ at::Tensor AtenXlaType::softshrink(const at::Tensor& self, at::Scalar lambda) {
 
 at::Tensor AtenXlaType::softshrink_backward(const at::Tensor& grad_out,
                                             const at::Tensor& self,
-                                            at::Scalar lambda) {
+                                            const at::Scalar& lambda) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::softshrink_backward(
       bridge::GetXlaTensor(grad_out), bridge::GetXlaTensor(self), lambda));
@@ -3109,7 +3140,7 @@ at::Tensor AtenXlaType::std(const at::Tensor& self, at::IntArrayRef dim,
 }
 
 at::Tensor AtenXlaType::sub(const at::Tensor& self, const at::Tensor& other,
-                            at::Scalar alpha) {
+                            const at::Scalar& alpha) {
   XLA_FN_COUNTER("xla::");
   CheckSubOperandTypes(self.scalar_type(), other.scalar_type());
   at::native::alpha_check(at::result_type(self, other), alpha);
@@ -3120,8 +3151,8 @@ at::Tensor AtenXlaType::sub(const at::Tensor& self, const at::Tensor& other,
                     });
 }
 
-at::Tensor AtenXlaType::sub(const at::Tensor& self, at::Scalar other,
-                            at::Scalar alpha) {
+at::Tensor AtenXlaType::sub(const at::Tensor& self, const at::Scalar& other,
+                            const at::Scalar& alpha) {
   XLA_FN_COUNTER("xla::");
   CheckSubOperandTypes(self.scalar_type(), GetScalarType(other));
   return DoBinaryOp(self, other,
@@ -3132,7 +3163,7 @@ at::Tensor AtenXlaType::sub(const at::Tensor& self, at::Scalar other,
 }
 
 at::Tensor& AtenXlaType::sub_(at::Tensor& self, const at::Tensor& other,
-                              at::Scalar alpha) {
+                              const at::Scalar& alpha) {
   XLA_FN_COUNTER("xla::");
   CheckBinaryOpTypePromotion(self, self, other);
   at::native::alpha_check(at::result_type(self, other), alpha);
@@ -3144,8 +3175,8 @@ at::Tensor& AtenXlaType::sub_(at::Tensor& self, const at::Tensor& other,
   return self;
 }
 
-at::Tensor& AtenXlaType::sub_(at::Tensor& self, at::Scalar other,
-                              at::Scalar alpha) {
+at::Tensor& AtenXlaType::sub_(at::Tensor& self, const at::Scalar& other,
+                              const at::Scalar& alpha) {
   XLA_FN_COUNTER("xla::");
   CheckBinaryOpTypePromotion(self, self, other);
   CheckSubOperandTypes(self.scalar_type(), GetScalarType(other));
@@ -3241,15 +3272,17 @@ at::Tensor AtenXlaType::tanh_backward(const at::Tensor& grad_output,
       bridge::GetXlaTensor(grad_output), bridge::GetXlaTensor(output)));
 }
 
-at::Tensor AtenXlaType::threshold(const at::Tensor& self, at::Scalar threshold,
-                                  at::Scalar value) {
+at::Tensor AtenXlaType::threshold(const at::Tensor& self,
+                                  const at::Scalar& threshold,
+                                  const at::Scalar& value) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::threshold(
       bridge::GetXlaTensor(self), threshold.to<double>(), value.to<double>()));
 }
 
-at::Tensor& AtenXlaType::threshold_(at::Tensor& self, at::Scalar threshold,
-                                    at::Scalar value) {
+at::Tensor& AtenXlaType::threshold_(at::Tensor& self,
+                                    const at::Scalar& threshold,
+                                    const at::Scalar& value) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor::threshold_(self_tensor, threshold.to<double>(),
@@ -3259,7 +3292,7 @@ at::Tensor& AtenXlaType::threshold_(at::Tensor& self, at::Scalar threshold,
 
 at::Tensor AtenXlaType::threshold_backward(const at::Tensor& grad_output,
                                            const at::Tensor& self,
-                                           at::Scalar threshold) {
+                                           const at::Scalar& threshold) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::threshold_backward(
       bridge::GetXlaTensor(grad_output), bridge::GetXlaTensor(self),

--- a/torch_xla/csrc/aten_xla_type.h
+++ b/torch_xla/csrc/aten_xla_type.h
@@ -15,19 +15,19 @@ class AtenXlaType {
   // pytorch folder file:
   //   torch/csrc/autograd/generated/RegistrationDeclarations.h
   /////////////////////////////////////////////////////////////////////////////
-  static at::Tensor& __ilshift__(at::Tensor& self, at::Scalar other);
+  static at::Tensor& __ilshift__(at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor& __ilshift__(at::Tensor& self, const at::Tensor& other);
 
-  static at::Tensor& __irshift__(at::Tensor& self, at::Scalar other);
+  static at::Tensor& __irshift__(at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor& __irshift__(at::Tensor& self, const at::Tensor& other);
 
-  static at::Tensor __lshift__(const at::Tensor& self, at::Scalar other);
+  static at::Tensor __lshift__(const at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor __lshift__(const at::Tensor& self, const at::Tensor& other);
 
-  static at::Tensor __rshift__(const at::Tensor& self, at::Scalar other);
+  static at::Tensor __rshift__(const at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor __rshift__(const at::Tensor& self, const at::Tensor& other);
 
@@ -101,31 +101,34 @@ class AtenXlaType {
   static at::Tensor& acosh_(at::Tensor& self);
 
   static at::Tensor add(const at::Tensor& self, const at::Tensor& other,
-                        at::Scalar alpha);
+                        const at::Scalar& alpha);
 
-  static at::Tensor add(const at::Tensor& self, at::Scalar other,
-                        at::Scalar alpha);
+  static at::Tensor add(const at::Tensor& self, const at::Scalar& other,
+                        const at::Scalar& alpha);
 
   static at::Tensor& add_(at::Tensor& self, const at::Tensor& other,
-                          at::Scalar alpha);
+                          const at::Scalar& alpha);
 
-  static at::Tensor& add_(at::Tensor& self, at::Scalar other, at::Scalar alpha);
+  static at::Tensor& add_(at::Tensor& self, const at::Scalar& other,
+                          const at::Scalar& alpha);
 
   static at::Tensor addcdiv(const at::Tensor& self, const at::Tensor& tensor1,
-                            const at::Tensor& tensor2, at::Scalar value);
+                            const at::Tensor& tensor2, const at::Scalar& value);
 
   static at::Tensor& addcdiv_(at::Tensor& self, const at::Tensor& tensor1,
-                              const at::Tensor& tensor2, at::Scalar value);
+                              const at::Tensor& tensor2,
+                              const at::Scalar& value);
 
   static at::Tensor addcmul(const at::Tensor& self, const at::Tensor& tensor1,
-                            const at::Tensor& tensor2, at::Scalar value);
+                            const at::Tensor& tensor2, const at::Scalar& value);
 
   static at::Tensor& addcmul_(at::Tensor& self, const at::Tensor& tensor1,
-                              const at::Tensor& tensor2, at::Scalar value);
+                              const at::Tensor& tensor2,
+                              const at::Scalar& value);
 
   static at::Tensor addmm(const at::Tensor& self, const at::Tensor& mat1,
-                          const at::Tensor& mat2, at::Scalar beta,
-                          at::Scalar alpha);
+                          const at::Tensor& mat2, const at::Scalar& beta,
+                          const at::Scalar& alpha);
 
   static at::Tensor alias(const at::Tensor& self);
 
@@ -137,8 +140,8 @@ class AtenXlaType {
 
   static at::Tensor any(const at::Tensor& self, int64_t dim, bool keepdim);
 
-  static at::Tensor& arange_out(at::Scalar start, at::Scalar end,
-                                at::Scalar step, at::Tensor& out);
+  static at::Tensor& arange_out(const at::Scalar& start, const at::Scalar& end,
+                                const at::Scalar& step, at::Tensor& out);
 
   static at::Tensor argmax(const at::Tensor& self, c10::optional<int64_t> dim,
                            bool keepdim);
@@ -199,11 +202,11 @@ class AtenXlaType {
       c10::optional<int64_t> divisor_override);
 
   static at::Tensor baddbmm(const at::Tensor& self, const at::Tensor& batch1,
-                            const at::Tensor& batch2, at::Scalar beta,
-                            at::Scalar alpha);
+                            const at::Tensor& batch2, const at::Scalar& beta,
+                            const at::Scalar& alpha);
   static at::Tensor& baddbmm_(at::Tensor& self, const at::Tensor& batch1,
-                              const at::Tensor& batch2, at::Scalar beta,
-                              at::Scalar alpha);
+                              const at::Tensor& batch2, const at::Scalar& beta,
+                              const at::Scalar& alpha);
 
   static at::Tensor bernoulli(const at::Tensor& self,
                               c10::optional<at::Generator> generator);
@@ -232,19 +235,19 @@ class AtenXlaType {
   static at::Tensor& bitwise_and_out(const at::Tensor& self,
                                      const at::Tensor& other, at::Tensor& out);
 
-  static at::Tensor& bitwise_and_out(const at::Tensor& self, at::Scalar other,
-                                     at::Tensor& out);
+  static at::Tensor& bitwise_and_out(const at::Tensor& self,
+                                     const at::Scalar& other, at::Tensor& out);
 
   static at::Tensor& bitwise_not_out(const at::Tensor& self, at::Tensor& out);
 
   static at::Tensor& bitwise_or_out(const at::Tensor& self,
                                     const at::Tensor& other, at::Tensor& out);
 
-  static at::Tensor& bitwise_or_out(const at::Tensor& self, at::Scalar other,
-                                    at::Tensor& out);
+  static at::Tensor& bitwise_or_out(const at::Tensor& self,
+                                    const at::Scalar& other, at::Tensor& out);
 
-  static at::Tensor& bitwise_xor_out(const at::Tensor& self, at::Scalar other,
-                                     at::Tensor& out);
+  static at::Tensor& bitwise_xor_out(const at::Tensor& self,
+                                     const at::Scalar& other, at::Tensor& out);
 
   static at::Tensor& bitwise_xor_out(const at::Tensor& self,
                                      const at::Tensor& other, at::Tensor& out);
@@ -259,25 +262,27 @@ class AtenXlaType {
 
   static at::Tensor cholesky(const at::Tensor& self, bool upper);
 
-  static at::Tensor clamp(const at::Tensor& self, c10::optional<at::Scalar> min,
-                          c10::optional<at::Scalar> max);
+  static at::Tensor clamp(const at::Tensor& self,
+                          const c10::optional<at::Scalar>& min,
+                          const c10::optional<at::Scalar>& max);
 
-  static at::Tensor& clamp_(at::Tensor& self, c10::optional<at::Scalar> min,
-                            c10::optional<at::Scalar> max);
+  static at::Tensor& clamp_(at::Tensor& self,
+                            const c10::optional<at::Scalar>& min,
+                            const c10::optional<at::Scalar>& max);
 
-  static at::Tensor clamp_max(const at::Tensor& self, at::Scalar max);
+  static at::Tensor clamp_max(const at::Tensor& self, const at::Scalar& max);
 
-  static at::Tensor& clamp_max_(at::Tensor& self, at::Scalar max);
+  static at::Tensor& clamp_max_(at::Tensor& self, const at::Scalar& max);
 
-  static at::Tensor clamp_min(const at::Tensor& self, at::Scalar min);
+  static at::Tensor clamp_min(const at::Tensor& self, const at::Scalar& min);
 
-  static at::Tensor& clamp_min_(at::Tensor& self, at::Scalar min);
+  static at::Tensor& clamp_min_(at::Tensor& self, const at::Scalar& min);
 
   static at::Tensor clone(const at::Tensor& self,
                           c10::optional<at::MemoryFormat> memory_format);
 
   static at::Tensor constant_pad_nd(const at::Tensor& self, at::IntArrayRef pad,
-                                    at::Scalar value);
+                                    const at::Scalar& value);
 
   static std::tuple<at::Tensor, at::Tensor, at::Tensor>
   convolution_backward_overrideable(
@@ -319,26 +324,28 @@ class AtenXlaType {
   static at::Tensor div(const at::Tensor& self, const at::Tensor& other,
                         std::string rounding_mode);
 
-  static at::Tensor div(const at::Tensor& self, at::Scalar other);
+  static at::Tensor div(const at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor& div_(at::Tensor& self, const at::Tensor& other);
 
   static at::Tensor& div_(at::Tensor& self, const at::Tensor& other,
                           std::string rounding_mode);
 
-  static at::Tensor& div_(at::Tensor& self, at::Scalar other);
+  static at::Tensor& div_(at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor dot(const at::Tensor& self, const at::Tensor& tensor);
 
-  static at::Tensor elu(const at::Tensor& self, at::Scalar alpha,
-                        at::Scalar scale, at::Scalar input_scale);
+  static at::Tensor elu(const at::Tensor& self, const at::Scalar& alpha,
+                        const at::Scalar& scale, const at::Scalar& input_scale);
 
-  static at::Tensor& elu_(at::Tensor& self, at::Scalar alpha, at::Scalar scale,
-                          at::Scalar input_scale);
+  static at::Tensor& elu_(at::Tensor& self, const at::Scalar& alpha,
+                          const at::Scalar& scale,
+                          const at::Scalar& input_scale);
 
   static at::Tensor elu_backward(const at::Tensor& grad_output,
-                                 at::Scalar alpha, at::Scalar scale,
-                                 at::Scalar input_scale, bool self,
+                                 const at::Scalar& alpha,
+                                 const at::Scalar& scale,
+                                 const at::Scalar& input_scale, bool self,
                                  const at::Tensor& self_or_result);
 
   static at::Tensor embedding(const at::Tensor& weight,
@@ -364,11 +371,11 @@ class AtenXlaType {
                                   c10::optional<at::Device> device,
                                   c10::optional<bool> pin_memory);
 
-  static at::Tensor eq(const at::Tensor& self, at::Scalar other);
+  static at::Tensor eq(const at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor eq(const at::Tensor& self, const at::Tensor& other);
 
-  static at::Tensor& eq_(at::Tensor& self, at::Scalar other);
+  static at::Tensor& eq_(at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor& eq_(at::Tensor& self, const at::Tensor& other);
 
@@ -402,7 +409,7 @@ class AtenXlaType {
 
   static at::Tensor& eye_out(int64_t n, int64_t m, at::Tensor& out);
 
-  static at::Tensor& fill_(at::Tensor& self, at::Scalar value);
+  static at::Tensor& fill_(at::Tensor& self, const at::Scalar& value);
 
   static at::Tensor& fill_(at::Tensor& self, const at::Tensor& value);
 
@@ -414,11 +421,11 @@ class AtenXlaType {
 
   static at::Tensor fmod(const at::Tensor& self, const at::Tensor& other);
 
-  static at::Tensor fmod(const at::Tensor& self, at::Scalar other);
+  static at::Tensor fmod(const at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor& fmod_(at::Tensor& self, const at::Tensor& other);
 
-  static at::Tensor& fmod_(at::Tensor& self, at::Scalar other);
+  static at::Tensor& fmod_(at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor frac(const at::Tensor& self);
 
@@ -427,11 +434,11 @@ class AtenXlaType {
   static at::Tensor gather(const at::Tensor& self, int64_t dim,
                            const at::Tensor& index, bool sparse_grad);
 
-  static at::Tensor ge(const at::Tensor& self, at::Scalar other);
+  static at::Tensor ge(const at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor ge(const at::Tensor& self, const at::Tensor& other);
 
-  static at::Tensor& ge_(at::Tensor& self, at::Scalar other);
+  static at::Tensor& ge_(at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor& ge_(at::Tensor& self, const at::Tensor& other);
 
@@ -442,19 +449,20 @@ class AtenXlaType {
 
   static at::Tensor ger(const at::Tensor& self, const at::Tensor& vec2);
 
-  static at::Tensor gt(const at::Tensor& self, at::Scalar other);
+  static at::Tensor gt(const at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor gt(const at::Tensor& self, const at::Tensor& other);
 
-  static at::Tensor& gt_(at::Tensor& self, at::Scalar other);
+  static at::Tensor& gt_(at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor& gt_(at::Tensor& self, const at::Tensor& other);
 
-  static at::Tensor hardshrink(const at::Tensor& self, at::Scalar lambda);
+  static at::Tensor hardshrink(const at::Tensor& self,
+                               const at::Scalar& lambda);
 
   static at::Tensor hardshrink_backward(const at::Tensor& grad_out,
                                         const at::Tensor& self,
-                                        at::Scalar lambda);
+                                        const at::Scalar& lambda);
 
   static at::Tensor hardsigmoid(const at::Tensor& self);
 
@@ -463,15 +471,16 @@ class AtenXlaType {
   static at::Tensor hardsigmoid_backward(const at::Tensor& grad_output,
                                          const at::Tensor& self);
 
-  static at::Tensor hardtanh(const at::Tensor& self, at::Scalar min_val,
-                             at::Scalar max_val);
+  static at::Tensor hardtanh(const at::Tensor& self, const at::Scalar& min_val,
+                             const at::Scalar& max_val);
 
-  static at::Tensor& hardtanh_(at::Tensor& self, at::Scalar min_val,
-                               at::Scalar max_val);
+  static at::Tensor& hardtanh_(at::Tensor& self, const at::Scalar& min_val,
+                               const at::Scalar& max_val);
 
   static at::Tensor hardtanh_backward(const at::Tensor& grad_output,
                                       const at::Tensor& self,
-                                      at::Scalar min_val, at::Scalar max_val);
+                                      const at::Scalar& min_val,
+                                      const at::Scalar& max_val);
 
   static at::Tensor index(const at::Tensor& self,
                           const c10::List<c10::optional<at::Tensor>>& indices);
@@ -485,7 +494,8 @@ class AtenXlaType {
                                  const at::Tensor& source);
 
   static at::Tensor& index_fill_(at::Tensor& self, int64_t dim,
-                                 const at::Tensor& index, at::Scalar value);
+                                 const at::Tensor& index,
+                                 const at::Scalar& value);
 
   static at::Tensor& index_fill_(at::Tensor& self, int64_t dim,
                                  const at::Tensor& index,
@@ -520,22 +530,23 @@ class AtenXlaType {
                                      const at::Tensor& target,
                                      int64_t reduction);
 
-  static at::Tensor le(const at::Tensor& self, at::Scalar other);
+  static at::Tensor le(const at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor le(const at::Tensor& self, const at::Tensor& other);
 
-  static at::Tensor& le_(at::Tensor& self, at::Scalar other);
+  static at::Tensor& le_(at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor& le_(at::Tensor& self, const at::Tensor& other);
 
   static at::Tensor leaky_relu(const at::Tensor& self,
-                               at::Scalar negative_slope);
+                               const at::Scalar& negative_slope);
 
-  static at::Tensor& leaky_relu_(at::Tensor& self, at::Scalar negative_slope);
+  static at::Tensor& leaky_relu_(at::Tensor& self,
+                                 const at::Scalar& negative_slope);
 
   static at::Tensor leaky_relu_backward(const at::Tensor& grad_output,
                                         const at::Tensor& self,
-                                        at::Scalar negative_slope,
+                                        const at::Scalar& negative_slope,
                                         bool self_is_result);
 
   static at::Tensor log(const at::Tensor& self);
@@ -566,16 +577,16 @@ class AtenXlaType {
   static at::Tensor logsumexp(const at::Tensor& self, at::IntArrayRef dim,
                               bool keepdim);
 
-  static at::Tensor lt(const at::Tensor& self, at::Scalar other);
+  static at::Tensor lt(const at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor lt(const at::Tensor& self, const at::Tensor& other);
 
-  static at::Tensor& lt_(at::Tensor& self, at::Scalar other);
+  static at::Tensor& lt_(at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor& lt_(at::Tensor& self, const at::Tensor& other);
 
   static at::Tensor& masked_fill_(at::Tensor& self, const at::Tensor& mask,
-                                  at::Scalar value);
+                                  const at::Scalar& value);
 
   static at::Tensor& masked_fill_(at::Tensor& self, const at::Tensor& mask,
                                   const at::Tensor& value);
@@ -682,11 +693,11 @@ class AtenXlaType {
 
   static at::Tensor mul(const at::Tensor& self, const at::Tensor& other);
 
-  static at::Tensor mul(const at::Tensor& self, at::Scalar other);
+  static at::Tensor mul(const at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor& mul_(at::Tensor& self, const at::Tensor& other);
 
-  static at::Tensor& mul_(at::Tensor& self, at::Scalar other);
+  static at::Tensor& mul_(at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor mv(const at::Tensor& self, const at::Tensor& vec);
 
@@ -711,11 +722,11 @@ class AtenXlaType {
                              bool train, double eps,
                              std::array<bool, 3> output_mask);
 
-  static at::Tensor ne(const at::Tensor& self, at::Scalar other);
+  static at::Tensor ne(const at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor ne(const at::Tensor& self, const at::Tensor& other);
 
-  static at::Tensor& ne_(at::Tensor& self, at::Scalar other);
+  static at::Tensor& ne_(at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor& ne_(at::Tensor& self, const at::Tensor& other);
 
@@ -749,16 +760,19 @@ class AtenXlaType {
 
   static at::Tensor nonzero(const at::Tensor& self);
 
-  static at::Tensor norm(const at::Tensor& self, c10::optional<at::Scalar> p,
+  static at::Tensor norm(const at::Tensor& self,
+                         const c10::optional<at::Scalar>& p,
                          at::ScalarType dtype);
 
-  static at::Tensor norm(const at::Tensor& self, at::Scalar p);
+  static at::Tensor norm(const at::Tensor& self, const at::Scalar& p);
 
-  static at::Tensor norm(const at::Tensor& self, c10::optional<at::Scalar> p,
+  static at::Tensor norm(const at::Tensor& self,
+                         const c10::optional<at::Scalar>& p,
                          at::IntArrayRef dim, bool keepdim,
                          at::ScalarType dtype);
 
-  static at::Tensor norm(const at::Tensor& self, c10::optional<at::Scalar> p,
+  static at::Tensor norm(const at::Tensor& self,
+                         const c10::optional<at::Scalar>& p,
                          at::IntArrayRef dim, bool keepdim);
 
   static at::Tensor normal(const at::Tensor& mean, double std,
@@ -775,13 +789,13 @@ class AtenXlaType {
 
   static at::Tensor permute(const at::Tensor& self, at::IntArrayRef dims);
 
-  static at::Tensor pow(const at::Tensor& self, at::Scalar exponent);
+  static at::Tensor pow(const at::Tensor& self, const at::Scalar& exponent);
 
   static at::Tensor pow(const at::Tensor& self, const at::Tensor& exponent);
 
-  static at::Tensor pow(at::Scalar self, const at::Tensor& exponent);
+  static at::Tensor pow(const at::Scalar& self, const at::Tensor& exponent);
 
-  static at::Tensor& pow_(at::Tensor& self, at::Scalar exponent);
+  static at::Tensor& pow_(at::Tensor& self, const at::Scalar& exponent);
 
   static at::Tensor& pow_(at::Tensor& self, const at::Tensor& exponent);
 
@@ -824,11 +838,11 @@ class AtenXlaType {
 
   static at::Tensor remainder(const at::Tensor& self, const at::Tensor& other);
 
-  static at::Tensor remainder(const at::Tensor& self, at::Scalar other);
+  static at::Tensor remainder(const at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor& remainder_(at::Tensor& self, const at::Tensor& other);
 
-  static at::Tensor& remainder_(at::Tensor& self, at::Scalar other);
+  static at::Tensor& remainder_(at::Tensor& self, const at::Scalar& other);
 
   static at::Tensor repeat(const at::Tensor& self, at::IntArrayRef repeats);
 
@@ -852,32 +866,31 @@ class AtenXlaType {
   static at::Tensor& round_(at::Tensor& self);
 
   static at::Tensor rrelu_with_noise(const at::Tensor& self,
-                                     const at::Tensor& noise, at::Scalar lower,
-                                     at::Scalar upper, bool training,
+                                     const at::Tensor& noise,
+                                     const at::Scalar& lower,
+                                     const at::Scalar& upper, bool training,
                                      c10::optional<at::Generator> generator);
 
-  static at::Tensor rrelu_with_noise_backward(const at::Tensor& grad_output,
-                                              const at::Tensor& self,
-                                              const at::Tensor& noise,
-                                              at::Scalar lower,
-                                              at::Scalar upper, bool training,
-                                              bool self_is_result);
+  static at::Tensor rrelu_with_noise_backward(
+      const at::Tensor& grad_output, const at::Tensor& self,
+      const at::Tensor& noise, const at::Scalar& lower, const at::Scalar& upper,
+      bool training, bool self_is_result);
 
   static at::Tensor rsqrt(const at::Tensor& self);
 
   static at::Tensor& rsqrt_(at::Tensor& self);
 
   static at::Tensor rsub(const at::Tensor& self, const at::Tensor& other,
-                         at::Scalar alpha);
+                         const at::Scalar& alpha);
 
-  static at::Tensor rsub(const at::Tensor& self, at::Scalar other,
-                         at::Scalar alpha);
+  static at::Tensor rsub(const at::Tensor& self, const at::Scalar& other,
+                         const at::Scalar& alpha);
 
   static at::Tensor& scatter_(at::Tensor& self, int64_t dim,
                               const at::Tensor& index, const at::Tensor& src);
 
   static at::Tensor& scatter_(at::Tensor& self, int64_t dim,
-                              const at::Tensor& index, at::Scalar value);
+                              const at::Tensor& index, const at::Scalar& value);
 
   static at::Tensor& scatter_add_(at::Tensor& self, int64_t dim,
                                   const at::Tensor& index,
@@ -919,19 +932,21 @@ class AtenXlaType {
                                             const at::Tensor& target,
                                             int64_t reduction, double beta);
 
-  static at::Tensor softplus(const at::Tensor& self, at::Scalar beta,
-                             at::Scalar threshold);
+  static at::Tensor softplus(const at::Tensor& self, const at::Scalar& beta,
+                             const at::Scalar& threshold);
 
   static at::Tensor softplus_backward(const at::Tensor& grad_output,
-                                      const at::Tensor& self, at::Scalar beta,
-                                      at::Scalar threshold,
+                                      const at::Tensor& self,
+                                      const at::Scalar& beta,
+                                      const at::Scalar& threshold,
                                       const at::Tensor& output);
 
-  static at::Tensor softshrink(const at::Tensor& self, at::Scalar lambda);
+  static at::Tensor softshrink(const at::Tensor& self,
+                               const at::Scalar& lambda);
 
   static at::Tensor softshrink_backward(const at::Tensor& grad_output,
                                         const at::Tensor& self,
-                                        at::Scalar lambda);
+                                        const at::Scalar& lambda);
 
   static std::tuple<at::Tensor, at::Tensor> sort(const at::Tensor& self,
                                                  int64_t dim, bool descending);
@@ -963,15 +978,16 @@ class AtenXlaType {
                         bool unbiased, bool keepdim);
 
   static at::Tensor sub(const at::Tensor& self, const at::Tensor& other,
-                        at::Scalar alpha);
+                        const at::Scalar& alpha);
 
-  static at::Tensor sub(const at::Tensor& self, at::Scalar other,
-                        at::Scalar alpha);
+  static at::Tensor sub(const at::Tensor& self, const at::Scalar& other,
+                        const at::Scalar& alpha);
 
   static at::Tensor& sub_(at::Tensor& self, const at::Tensor& other,
-                          at::Scalar alpha);
+                          const at::Scalar& alpha);
 
-  static at::Tensor& sub_(at::Tensor& self, at::Scalar other, at::Scalar alpha);
+  static at::Tensor& sub_(at::Tensor& self, const at::Scalar& other,
+                          const at::Scalar& alpha);
 
   static at::Tensor sum(const at::Tensor& self,
                         c10::optional<at::ScalarType> dtype);
@@ -1003,15 +1019,16 @@ class AtenXlaType {
   static at::Tensor tanh_backward(const at::Tensor& grad_output,
                                   const at::Tensor& output);
 
-  static at::Tensor threshold(const at::Tensor& self, at::Scalar threshold,
-                              at::Scalar value);
+  static at::Tensor threshold(const at::Tensor& self,
+                              const at::Scalar& threshold,
+                              const at::Scalar& value);
 
-  static at::Tensor& threshold_(at::Tensor& self, at::Scalar threshold,
-                                at::Scalar value);
+  static at::Tensor& threshold_(at::Tensor& self, const at::Scalar& threshold,
+                                const at::Scalar& value);
 
   static at::Tensor threshold_backward(const at::Tensor& grad_output,
                                        const at::Tensor& self,
-                                       at::Scalar threshold);
+                                       const at::Scalar& threshold);
 
   static std::tuple<at::Tensor, at::Tensor> topk(const at::Tensor& self,
                                                  int64_t k, int64_t dim,

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -10,7 +10,8 @@
 namespace torch_xla {
 namespace {
 
-xla::XlaOp Between(xla::XlaOp input, at::Scalar min_val, at::Scalar max_val) {
+xla::XlaOp Between(xla::XlaOp input, const at::Scalar& min_val,
+                   const at::Scalar& max_val) {
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(input);
   xla::PrimitiveType element_type = shape.element_type();
   xla::XlaBuilder* builder = input.builder();
@@ -65,7 +66,7 @@ xla::XlaOp BuildRelu(xla::XlaOp input) {
                              0, input_shape.element_type(), input.builder()));
 }
 
-xla::XlaOp BuildHardshrink(xla::XlaOp input, at::Scalar lambda) {
+xla::XlaOp BuildHardshrink(xla::XlaOp input, const at::Scalar& lambda) {
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(input);
   xla::XlaOp zero = xla::Zero(input.builder(), shape.element_type());
   return xla::Select(Between(input, -lambda, lambda), zero, input);
@@ -89,7 +90,7 @@ xla::XlaOp BuildHardSigmoidBackward(xla::XlaOp grad_output, xla::XlaOp input) {
   return xla::Select(Between(input, -3.0, 3.0), grad_output / six, zero);
 }
 
-xla::XlaOp BuildSoftshrink(xla::XlaOp input, at::Scalar lambda) {
+xla::XlaOp BuildSoftshrink(xla::XlaOp input, const at::Scalar& lambda) {
   xla::XlaBuilder* builder = input.builder();
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(input);
   xla::XlaOp zero = xla::Zero(input.builder(), shape.element_type());
@@ -102,14 +103,15 @@ xla::XlaOp BuildSoftshrink(xla::XlaOp input, at::Scalar lambda) {
 }
 
 xla::XlaOp BuildShrinkBackward(xla::XlaOp grad_output, xla::XlaOp input,
-                               at::Scalar lambda) {
+                               const at::Scalar& lambda) {
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(input);
   xla::XlaOp zero = xla::Zero(input.builder(), shape.element_type());
   return xla::Select(Between(input, -lambda, lambda), zero, grad_output);
 }
 
 xla::XlaOp BuildHardtanhBackward(xla::XlaOp grad_output, xla::XlaOp input,
-                                 at::Scalar min_val, at::Scalar max_val) {
+                                 const at::Scalar& min_val,
+                                 const at::Scalar& max_val) {
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(grad_output);
   xla::XlaOp zero = xla::Zero(input.builder(), shape.element_type());
   return xla::Select(Between(input, min_val, max_val), grad_output, zero);
@@ -119,8 +121,8 @@ xla::XlaOp BuildLeakyRelu(xla::XlaOp input, double negative_slope_value) {
   return BuildLeakyReluBackward(input, input, negative_slope_value);
 }
 
-std::vector<xla::XlaOp> BuildRrelu(xla::XlaOp input, at::Scalar lower,
-                                   at::Scalar upper, bool training,
+std::vector<xla::XlaOp> BuildRrelu(xla::XlaOp input, const at::Scalar& lower,
+                                   const at::Scalar& upper, bool training,
                                    xla::XlaOp rng_seed) {
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(input);
   xla::XlaOp zero = xla::Zero(input.builder(), shape.element_type());
@@ -146,8 +148,8 @@ std::vector<xla::XlaOp> BuildRrelu(xla::XlaOp input, at::Scalar lower,
 }
 
 xla::XlaOp BuildRreluBackward(xla::XlaOp grad_output, xla::XlaOp input,
-                              xla::XlaOp noise, at::Scalar lower,
-                              at::Scalar upper, bool training) {
+                              xla::XlaOp noise, const at::Scalar& lower,
+                              const at::Scalar& upper, bool training) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   xla::XlaOp zero = xla::Zero(input.builder(), input_shape.element_type());
   xla::XlaOp grad_input;

--- a/torch_xla/csrc/elementwise.h
+++ b/torch_xla/csrc/elementwise.h
@@ -18,23 +18,24 @@ xla::XlaOp BuildThreshold(xla::XlaOp input, xla::XlaOp output,
 // Computes the rectified linear unit (replace negative elements with 0).
 xla::XlaOp BuildRelu(xla::XlaOp input);
 
-std::vector<xla::XlaOp> BuildRrelu(xla::XlaOp input, at::Scalar lower,
-                                   at::Scalar upper, bool training,
+std::vector<xla::XlaOp> BuildRrelu(xla::XlaOp input, const at::Scalar& lower,
+                                   const at::Scalar& upper, bool training,
                                    xla::XlaOp rng_seed);
 
 xla::XlaOp BuildRreluBackward(xla::XlaOp grad_output, xla::XlaOp input,
-                              xla::XlaOp noise, at::Scalar lower,
-                              at::Scalar upper, bool training);
+                              xla::XlaOp noise, const at::Scalar& lower,
+                              const at::Scalar& upper, bool training);
 
-xla::XlaOp BuildHardshrink(xla::XlaOp input, at::Scalar lambda);
+xla::XlaOp BuildHardshrink(xla::XlaOp input, const at::Scalar& lambda);
 xla::XlaOp BuildHardSigmoid(xla::XlaOp input);
 xla::XlaOp BuildHardSigmoidBackward(xla::XlaOp grad_output, xla::XlaOp input);
-xla::XlaOp BuildSoftshrink(xla::XlaOp input, at::Scalar lambda);
+xla::XlaOp BuildSoftshrink(xla::XlaOp input, const at::Scalar& lambda);
 xla::XlaOp BuildShrinkBackward(xla::XlaOp grad_output, xla::XlaOp input,
-                               at::Scalar lambda);
+                               const at::Scalar& lambda);
 
 xla::XlaOp BuildHardtanhBackward(xla::XlaOp grad_output, xla::XlaOp input,
-                                 at::Scalar min_val, at::Scalar max_val);
+                                 const at::Scalar& min_val,
+                                 const at::Scalar& max_val);
 
 // Computes the leaky rectified linear unit:
 // LeakyReLU(x) = max(0, input) + negative_slope ∗ min(0, input).

--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -91,7 +91,7 @@ class XlaHelpers {
     return xla::ConstantLiteral(builder, ScalarLiteral(scalar_value, type));
   }
 
-  static xla::XlaOp ScalarValue(at::Scalar scalar_value,
+  static xla::XlaOp ScalarValue(const at::Scalar& scalar_value,
                                 xla::PrimitiveType type,
                                 xla::XlaBuilder* builder) {
     if (scalar_value.isFloatingPoint()) {

--- a/torch_xla/csrc/ops/constant_pad_nd.cpp
+++ b/torch_xla/csrc/ops/constant_pad_nd.cpp
@@ -35,7 +35,7 @@ xla::Shape NodeOutputShape(const Value& input, const at::Scalar& value,
 }  // namespace
 
 ConstantPadNd::ConstantPadNd(const Value& input, std::vector<xla::int64> pad,
-                             at::Scalar value)
+                             const at::Scalar& value)
     : Node(ir::OpKind(at::aten::constant_pad_nd), {input},
            [&]() { return NodeOutputShape(input, value, pad); },
            /*num_outputs=*/1, xla::util::MHash(pad, ScalarHash(value))),

--- a/torch_xla/csrc/ops/constant_pad_nd.h
+++ b/torch_xla/csrc/ops/constant_pad_nd.h
@@ -11,7 +11,7 @@ namespace ops {
 class ConstantPadNd : public Node {
  public:
   ConstantPadNd(const Value& input, std::vector<xla::int64> pad,
-                at::Scalar value);
+                const at::Scalar& value);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/hardshrink.cpp
+++ b/torch_xla/csrc/ops/hardshrink.cpp
@@ -9,7 +9,7 @@ namespace torch_xla {
 namespace ir {
 namespace ops {
 
-Hardshrink::Hardshrink(const Value& input, at::Scalar lambda)
+Hardshrink::Hardshrink(const Value& input, const at::Scalar& lambda)
     : Node(OpKind(at::aten::hardshrink), {input}, input.shape(),
            /*num_outputs=*/1, ScalarHash(lambda)),
       lambda_(std::move(lambda)) {}

--- a/torch_xla/csrc/ops/hardshrink.h
+++ b/torch_xla/csrc/ops/hardshrink.h
@@ -10,7 +10,7 @@ namespace ops {
 
 class Hardshrink : public Node {
  public:
-  Hardshrink(const Value& input, at::Scalar lambda);
+  Hardshrink(const Value& input, const at::Scalar& lambda);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/hardtanh_backward.cpp
+++ b/torch_xla/csrc/ops/hardtanh_backward.cpp
@@ -10,7 +10,8 @@ namespace ir {
 namespace ops {
 
 HardtanhBackward::HardtanhBackward(const Value& grad_output, const Value& input,
-                                   at::Scalar min_val, at::Scalar max_val)
+                                   const at::Scalar& min_val,
+                                   const at::Scalar& max_val)
     : Node(OpKind(at::aten::hardtanh_backward), {grad_output, input},
            grad_output.shape(), /*num_outputs=*/1,
            xla::util::MHash(ScalarHash(min_val), ScalarHash(max_val))),

--- a/torch_xla/csrc/ops/hardtanh_backward.h
+++ b/torch_xla/csrc/ops/hardtanh_backward.h
@@ -11,7 +11,7 @@ namespace ops {
 class HardtanhBackward : public Node {
  public:
   HardtanhBackward(const Value& grad_output, const Value& input,
-                   at::Scalar min_val, at::Scalar max_val);
+                   const at::Scalar& min_val, const at::Scalar& max_val);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/index_ops.cpp
+++ b/torch_xla/csrc/ops/index_ops.cpp
@@ -290,7 +290,7 @@ ir::Value IndexPutByTensors(const XLATensor& base,
 }
 
 ir::NodePtr IndexFill(const XLATensor& base, xla::int64 dim,
-                      const XLATensor& index, at::Scalar value) {
+                      const XLATensor& index, const at::Scalar& value) {
   XLA_CHECK_EQ(index.dtype(), at::ScalarType::Long)
       << "Fill index is expected to be of scalar type Long, but it is "
       << index.dtype();

--- a/torch_xla/csrc/ops/index_ops.h
+++ b/torch_xla/csrc/ops/index_ops.h
@@ -65,7 +65,7 @@ ir::Value IndexPutByTensors(const XLATensor& base,
                             absl::Span<const xla::int64> result_permutation);
 
 ir::NodePtr IndexFill(const XLATensor& base, xla::int64 dim,
-                      const XLATensor& index, at::Scalar value);
+                      const XLATensor& index, const at::Scalar& value);
 
 ir::NodePtr IndexFill(const XLATensor& base, xla::int64 dim,
                       const XLATensor& index, const XLATensor& value);

--- a/torch_xla/csrc/ops/masked_fill.cpp
+++ b/torch_xla/csrc/ops/masked_fill.cpp
@@ -10,7 +10,8 @@ namespace torch_xla {
 namespace ir {
 namespace ops {
 
-MaskedFill::MaskedFill(const Value& input, const Value& mask, at::Scalar value)
+MaskedFill::MaskedFill(const Value& input, const Value& mask,
+                       const at::Scalar& value)
     : Node(OpKind(at::aten::masked_fill), {input, mask}, input.shape(),
            /*num_outputs=*/1, ScalarHash(value)),
       value_(std::move(value)) {}

--- a/torch_xla/csrc/ops/masked_fill.h
+++ b/torch_xla/csrc/ops/masked_fill.h
@@ -10,7 +10,7 @@ namespace ops {
 
 class MaskedFill : public Node {
  public:
-  MaskedFill(const Value& input, const Value& mask, at::Scalar value);
+  MaskedFill(const Value& input, const Value& mask, const at::Scalar& value);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -421,8 +421,8 @@ NodePtr Where(const Value& condition, const Value& input, const Value& other) {
                    input.shape(), std::move(lower_fn));
 }
 
-NodePtr ARange(at::Scalar start, at::Scalar end, at::Scalar step,
-               at::ScalarType scalar_type) {
+NodePtr ARange(const at::Scalar& start, const at::Scalar& end,
+               const at::Scalar& step, at::ScalarType scalar_type) {
   xla::PrimitiveType type = MakeXlaPrimitiveType(scalar_type,
                                                  /*device=*/nullptr);
   XLA_CHECK_NE(step.toDouble(), 0.0);
@@ -507,7 +507,7 @@ NodePtr BroadcastTensors(absl::Span<const Value> tensors) {
       std::move(lower_fn), /*num_outputs=*/tensors.size());
 }
 
-NodePtr Norm(const Value& input, c10::optional<at::Scalar> p,
+NodePtr Norm(const Value& input, const c10::optional<at::Scalar>& p,
              c10::optional<at::ScalarType> dtype,
              absl::Span<const xla::int64> dims, bool keepdim) {
   ScopePusher ir_scope(at::aten::norm.toQualString());
@@ -557,8 +557,8 @@ NodePtr Identity(xla::int64 lines, xla::int64 cols,
                    xla::util::MHash(lines, cols));
 }
 
-NodePtr Elu(const Value& input, at::Scalar alpha, at::Scalar scale,
-            at::Scalar input_scale) {
+NodePtr Elu(const Value& input, const at::Scalar& alpha,
+            const at::Scalar& scale, const at::Scalar& input_scale) {
   ScopePusher ir_scope(at::aten::elu.toQualString());
   const xla::Shape& shape = input.shape();
   NodePtr scaled_input = input * ScalarOp(input_scale, shape);
@@ -571,8 +571,8 @@ NodePtr Elu(const Value& input, at::Scalar alpha, at::Scalar scale,
 }
 
 NodePtr EluBackward(const Value& grad_output, const Value& output,
-                    at::Scalar alpha, at::Scalar scale,
-                    at::Scalar input_scale) {
+                    const at::Scalar& alpha, const at::Scalar& scale,
+                    const at::Scalar& input_scale) {
   ScopePusher ir_scope(at::aten::elu_backward.toQualString());
   const xla::Shape& shape = grad_output.shape();
   NodePtr negative_output_branch =
@@ -602,7 +602,7 @@ NodePtr GeluBackward(const Value& grad, const Value& input) {
                  input * dinput * ScalarOp(kAlpha, shape));
 }
 
-NodePtr Lshift(const Value& input, at::Scalar other) {
+NodePtr Lshift(const Value& input, const at::Scalar& other) {
   ScopePusher ir_scope(at::aten::__lshift__.toQualString());
   return input * ScalarOp(pow(2, other.to<double>()), input.shape());
 }
@@ -612,7 +612,7 @@ NodePtr Lshift(const Value& input, const Value& other) {
   return input * Pow(ScalarOp(2, input.shape()), other);
 }
 
-NodePtr Rshift(const Value& input, at::Scalar other) {
+NodePtr Rshift(const Value& input, const at::Scalar& other) {
   ScopePusher ir_scope(at::aten::__rshift__.toQualString());
   return input / ScalarOp(pow(2, other.to<double>()), input.shape());
 }

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -14,10 +14,10 @@ namespace torch_xla {
 namespace ir {
 namespace ops {
 
-inline NodePtr ScalarOp(at::Scalar value, xla::Shape shape) {
+inline NodePtr ScalarOp(const at::Scalar& value, xla::Shape shape) {
   return MakeNode<Scalar>(value, std::move(shape));
 }
-inline NodePtr ScalarOp(at::Scalar value, xla::PrimitiveType type) {
+inline NodePtr ScalarOp(const at::Scalar& value, xla::PrimitiveType type) {
   return MakeNode<Scalar>(value, type);
 }
 
@@ -164,33 +164,34 @@ NodePtr ComparisonOp(c10::Symbol kind, const Value& input, const Value& other);
 
 NodePtr Where(const Value& condition, const Value& input, const Value& other);
 
-NodePtr ARange(at::Scalar start, at::Scalar end, at::Scalar step,
-               at::ScalarType scalar_type);
+NodePtr ARange(const at::Scalar& start, const at::Scalar& end,
+               const at::Scalar& step, at::ScalarType scalar_type);
 
 NodePtr BroadcastTensors(absl::Span<const Value> tensors);
 
-NodePtr Norm(const Value& input, c10::optional<at::Scalar> p,
+NodePtr Norm(const Value& input, const c10::optional<at::Scalar>& p,
              c10::optional<at::ScalarType> dtype,
              absl::Span<const xla::int64> dims, bool keepdim);
 
 NodePtr Identity(xla::int64 lines, xla::int64 cols,
                  xla::PrimitiveType element_type);
 
-NodePtr Elu(const Value& input, at::Scalar alpha, at::Scalar scale,
-            at::Scalar input_scale);
+NodePtr Elu(const Value& input, const at::Scalar& alpha,
+            const at::Scalar& scale, const at::Scalar& input_scale);
 
 NodePtr EluBackward(const Value& grad_output, const Value& output,
-                    at::Scalar alpha, at::Scalar scale, at::Scalar input_scale);
+                    const at::Scalar& alpha, const at::Scalar& scale,
+                    const at::Scalar& input_scale);
 
 NodePtr Gelu(const Value& input);
 
 NodePtr GeluBackward(const Value& grad, const Value& input);
 
-NodePtr Lshift(const Value& input, at::Scalar other);
+NodePtr Lshift(const Value& input, const at::Scalar& other);
 
 NodePtr Lshift(const Value& input, const Value& other);
 
-NodePtr Rshift(const Value& input, at::Scalar other);
+NodePtr Rshift(const Value& input, const at::Scalar& other);
 
 NodePtr Rshift(const Value& input, const Value& other);
 

--- a/torch_xla/csrc/ops/rrelu_with_noise.cpp
+++ b/torch_xla/csrc/ops/rrelu_with_noise.cpp
@@ -11,7 +11,7 @@ namespace ir {
 namespace ops {
 
 RreluWithNoise::RreluWithNoise(const Value& input, const Value& seed,
-                               at::Scalar lower, at::Scalar upper,
+                               const at::Scalar& lower, const at::Scalar& upper,
                                bool training)
     : Node(ir::OpKind(at::aten::rrelu_with_noise), {input, seed},
            xla::ShapeUtil::MakeTupleShape({input.shape(), input.shape()}),

--- a/torch_xla/csrc/ops/rrelu_with_noise.h
+++ b/torch_xla/csrc/ops/rrelu_with_noise.h
@@ -11,8 +11,8 @@ namespace ops {
 
 class RreluWithNoise : public Node {
  public:
-  RreluWithNoise(const Value& input, const Value& seed, at::Scalar lower,
-                 at::Scalar upper, bool training);
+  RreluWithNoise(const Value& input, const Value& seed, const at::Scalar& lower,
+                 const at::Scalar& upper, bool training);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/rrelu_with_noise_backward.cpp
+++ b/torch_xla/csrc/ops/rrelu_with_noise_backward.cpp
@@ -9,11 +9,9 @@ namespace torch_xla {
 namespace ir {
 namespace ops {
 
-RreluWithNoiseBackward::RreluWithNoiseBackward(const Value& grad_output,
-                                               const Value& input,
-                                               const Value& noise,
-                                               at::Scalar lower,
-                                               at::Scalar upper, bool training)
+RreluWithNoiseBackward::RreluWithNoiseBackward(
+    const Value& grad_output, const Value& input, const Value& noise,
+    const at::Scalar& lower, const at::Scalar& upper, bool training)
     : Node(ir::OpKind(at::aten::rrelu_with_noise_backward),
            {grad_output, input, noise}, input.shape(),
            /*num_outputs=*/1,

--- a/torch_xla/csrc/ops/rrelu_with_noise_backward.h
+++ b/torch_xla/csrc/ops/rrelu_with_noise_backward.h
@@ -11,8 +11,8 @@ namespace ops {
 class RreluWithNoiseBackward : public Node {
  public:
   RreluWithNoiseBackward(const Value& grad_output, const Value& input,
-                         const Value& noise, at::Scalar lower, at::Scalar upper,
-                         bool training);
+                         const Value& noise, const at::Scalar& lower,
+                         const at::Scalar& upper, bool training);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/scalar.cpp
+++ b/torch_xla/csrc/ops/scalar.cpp
@@ -13,12 +13,12 @@ namespace torch_xla {
 namespace ir {
 namespace ops {
 
-Scalar::Scalar(at::Scalar value, xla::Shape shape)
+Scalar::Scalar(const at::Scalar& value, xla::Shape shape)
     : Node(OpKind(at::prim::Constant), std::move(shape), /*num_outputs=*/1,
            ScalarHash(value)),
       value_(std::move(value)) {}
 
-Scalar::Scalar(at::Scalar value, xla::PrimitiveType type)
+Scalar::Scalar(const at::Scalar& value, xla::PrimitiveType type)
     : Node(OpKind(at::prim::Constant), xla::ShapeUtil::MakeShape(type, {}),
            /*num_outputs=*/1, ScalarHash(value)),
       value_(std::move(value)) {}
@@ -95,7 +95,7 @@ XlaOpVector Scalar::Lower(LoweringContext* loctx) const {
   return ReturnOp(op, loctx);
 }
 
-xla::hash_t ScalarHash(at::Scalar s) {
+xla::hash_t ScalarHash(const at::Scalar& s) {
   return s.isFloatingPoint() ? xla::util::Hash(s.toDouble())
                              : xla::util::Hash(s.toLong());
 }

--- a/torch_xla/csrc/ops/scalar.h
+++ b/torch_xla/csrc/ops/scalar.h
@@ -17,8 +17,8 @@ namespace ops {
 // graph.
 class Scalar : public Node {
  public:
-  Scalar(at::Scalar value, xla::Shape shape);
-  Scalar(at::Scalar value, xla::PrimitiveType type);
+  Scalar(const at::Scalar& value, xla::Shape shape);
+  Scalar(const at::Scalar& value, xla::PrimitiveType type);
 
   std::string ToString() const override;
 
@@ -32,7 +32,7 @@ class Scalar : public Node {
   at::Scalar value_;
 };
 
-xla::hash_t ScalarHash(at::Scalar s);
+xla::hash_t ScalarHash(const at::Scalar& s);
 
 std::ostream& operator<<(std::ostream& ostrm, at::Scalar s);
 

--- a/torch_xla/csrc/ops/shrink_backward.cpp
+++ b/torch_xla/csrc/ops/shrink_backward.cpp
@@ -10,7 +10,7 @@ namespace ir {
 namespace ops {
 
 ShrinkBackward::ShrinkBackward(OpKind kind, const Value& grad_output,
-                               const Value& input, at::Scalar lambda)
+                               const Value& input, const at::Scalar& lambda)
     : Node(kind, {grad_output, input}, input.shape(), /*num_outputs=*/1,
            ScalarHash(lambda)),
       lambda_(std::move(lambda)) {}

--- a/torch_xla/csrc/ops/shrink_backward.h
+++ b/torch_xla/csrc/ops/shrink_backward.h
@@ -11,7 +11,7 @@ namespace ops {
 class ShrinkBackward : public Node {
  public:
   ShrinkBackward(OpKind kind, const Value& grad_output, const Value& input,
-                 at::Scalar lambda);
+                 const at::Scalar& lambda);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/softshrink.cpp
+++ b/torch_xla/csrc/ops/softshrink.cpp
@@ -9,7 +9,7 @@ namespace torch_xla {
 namespace ir {
 namespace ops {
 
-Softshrink::Softshrink(const Value& input, at::Scalar lambda)
+Softshrink::Softshrink(const Value& input, const at::Scalar& lambda)
     : Node(OpKind(at::aten::softshrink), {input}, input.shape(),
            /*num_outputs=*/1, ScalarHash(lambda)),
       lambda_(std::move(lambda)) {}

--- a/torch_xla/csrc/ops/softshrink.h
+++ b/torch_xla/csrc/ops/softshrink.h
@@ -10,7 +10,7 @@ namespace ops {
 
 class Softshrink : public Node {
  public:
-  Softshrink(const Value& input, at::Scalar lambda);
+  Softshrink(const Value& input, const at::Scalar& lambda);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -205,7 +205,7 @@ XlaDataCacheArena::XlaDataCache* GetXlaDataCache(const Device& device) {
   return arena->Get(device);
 }
 
-ir::Value IrValueFromScalar(at::Scalar value, at::ScalarType scalar_type,
+ir::Value IrValueFromScalar(const at::Scalar& value, at::ScalarType scalar_type,
                             const Device& device) {
   at::Tensor tensor = at::scalar_tensor(value, at::TensorOptions(scalar_type));
   xla::ComputationClient::DataPtr device_data = TensorToXlaData(tensor, device);
@@ -225,7 +225,7 @@ xla::ComputationClient::DataPtr GetDeviceData(const at::Tensor& tensor,
   return device_data;
 }
 
-xla::ComputationClient::DataPtr GetDeviceData(at::Scalar value,
+xla::ComputationClient::DataPtr GetDeviceData(const at::Scalar& value,
                                               at::ScalarType scalar_type,
                                               const Device& device) {
   // Workaround since at::scalar_tensor doesn't support bfloat16 yet.
@@ -241,7 +241,7 @@ xla::ComputationClient::DataPtr GetDeviceData(at::Scalar value,
 // hits, but it can prevent the compiler to perform optimizations. So tensor
 // values which are within a given set, are routed to constant scalars if this
 // API returns true.
-bool IsSpecialScalar(at::Scalar value) {
+bool IsSpecialScalar(const at::Scalar& value) {
   static bool no_scalars =
       xla::sys_util::GetEnvBool("XLA_NO_SPECIAL_SCALARS", false);
   if (!no_scalars && (value.isIntegral() || value.isFloatingPoint())) {
@@ -711,7 +711,7 @@ ir::Value XLATensor::GetIrValueForTensor(const at::Tensor& tensor,
   return CreateTensorNode(std::move(data), read_only);
 }
 
-ir::Value XLATensor::GetDeviceDataIrValue(at::Scalar value,
+ir::Value XLATensor::GetDeviceDataIrValue(const at::Scalar& value,
                                           xla::PrimitiveType type,
                                           const Device& device) {
   xla::ComputationClient::DataPtr data =
@@ -721,7 +721,7 @@ ir::Value XLATensor::GetDeviceDataIrValue(at::Scalar value,
   return ir::MakeNode<ir::ops::DeviceData>(std::move(data));
 }
 
-ir::Value XLATensor::GetIrValueForScalar(at::Scalar value,
+ir::Value XLATensor::GetIrValueForScalar(const at::Scalar& value,
                                          xla::PrimitiveType type,
                                          const Device& device) {
   if (IsSpecialScalar(value)) {
@@ -730,14 +730,14 @@ ir::Value XLATensor::GetIrValueForScalar(at::Scalar value,
   return GetDeviceDataIrValue(value, type, device);
 }
 
-ir::Value XLATensor::GetIrValueForScalar(at::Scalar value,
+ir::Value XLATensor::GetIrValueForScalar(const at::Scalar& value,
                                          const Device& device) {
   return GetIrValueForScalar(
       value, MakeXlaPrimitiveType(GetScalarType(value), &device), device);
 }
 
 ir::Value XLATensor::GetIrValueForScalar(
-    at::Scalar value, xla::PrimitiveType type,
+    const at::Scalar& value, xla::PrimitiveType type,
     absl::Span<const xla::int64> dimensions, const Device& device) {
   ir::Value ir_value = GetIrValueForScalar(value, type, device);
   if (!dimensions.empty()) {
@@ -747,7 +747,7 @@ ir::Value XLATensor::GetIrValueForScalar(
   return ir_value;
 }
 
-ir::Value XLATensor::GetIrValueForScalar(at::Scalar value,
+ir::Value XLATensor::GetIrValueForScalar(const at::Scalar& value,
                                          const xla::Shape& shape,
                                          const Device& device) {
   return GetIrValueForScalar(value, shape.element_type(), shape.dimensions(),
@@ -755,7 +755,7 @@ ir::Value XLATensor::GetIrValueForScalar(at::Scalar value,
 }
 
 ir::Value XLATensor::GetIrValueForScalar(
-    at::Scalar value, const xla::Shape& shape,
+    const at::Scalar& value, const xla::Shape& shape,
     c10::optional<at::ScalarType> logical_element_type, const Device& device) {
   xla::PrimitiveType type =
       logical_element_type

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -100,22 +100,23 @@ class XLATensor {
   // Applies the queue of operations in preparation for using the data.
   void ApplyPendingGraph();
 
-  static ir::Value GetDeviceDataIrValue(at::Scalar value,
+  static ir::Value GetDeviceDataIrValue(const at::Scalar& value,
                                         xla::PrimitiveType type,
                                         const Device& device);
-  static ir::Value GetIrValueForScalar(at::Scalar value,
+  static ir::Value GetIrValueForScalar(const at::Scalar& value,
                                        xla::PrimitiveType type,
                                        const Device& device);
-  static ir::Value GetIrValueForScalar(at::Scalar value, const Device& device);
-  static ir::Value GetIrValueForScalar(at::Scalar value,
+  static ir::Value GetIrValueForScalar(const at::Scalar& value,
+                                       const Device& device);
+  static ir::Value GetIrValueForScalar(const at::Scalar& value,
                                        xla::PrimitiveType type,
                                        absl::Span<const xla::int64> dimensions,
                                        const Device& device);
-  static ir::Value GetIrValueForScalar(at::Scalar value,
+  static ir::Value GetIrValueForScalar(const at::Scalar& value,
                                        const xla::Shape& shape,
                                        const Device& device);
   static ir::Value GetIrValueForScalar(
-      at::Scalar value, const xla::Shape& shape,
+      const at::Scalar& value, const xla::Shape& shape,
       c10::optional<at::ScalarType> logical_element_type, const Device& device);
 
   static ir::Value GetRngSeed(const Device& device);
@@ -128,7 +129,7 @@ class XLATensor {
   // appropriately.
   static XLATensor DispatchComparisonOp(c10::Symbol kind,
                                         const XLATensor& input,
-                                        at::Scalar other);
+                                        const at::Scalar& other);
 
   // Same as above, with the second input a tensor as well.
   static XLATensor DispatchComparisonOp(c10::Symbol kind,
@@ -214,21 +215,21 @@ class XLATensor {
   //////////////////////////////////////////////////////////////////////////////
   // ATEN operators follows here, listed in alphabetical order.
   //////////////////////////////////////////////////////////////////////////////
-  static void __ilshift__(XLATensor& input, at::Scalar other);
+  static void __ilshift__(XLATensor& input, const at::Scalar& other);
   static void __ilshift__(XLATensor& input, const XLATensor& other);
 
-  static void __irshift__(XLATensor& input, at::Scalar other);
+  static void __irshift__(XLATensor& input, const at::Scalar& other);
   static void __irshift__(XLATensor& input, const XLATensor& other);
 
   static XLATensor __lshift__(
-      const XLATensor& input, at::Scalar other,
+      const XLATensor& input, const at::Scalar& other,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
   static XLATensor __lshift__(
       const XLATensor& input, const XLATensor& other,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
 
   static XLATensor __rshift__(
-      const XLATensor& input, at::Scalar other,
+      const XLATensor& input, const at::Scalar& other,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
   static XLATensor __rshift__(
       const XLATensor& input, const XLATensor& other,
@@ -267,22 +268,24 @@ class XLATensor {
   static void acosh_(XLATensor& input);
 
   static XLATensor add(
-      const XLATensor& input, const XLATensor& other, at::Scalar alpha,
+      const XLATensor& input, const XLATensor& other, const at::Scalar& alpha,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
-  static void add_(XLATensor& input, const XLATensor& other, at::Scalar alpha);
+  static void add_(XLATensor& input, const XLATensor& other,
+                   const at::Scalar& alpha);
   static XLATensor add(
-      const XLATensor& input, at::Scalar other, at::Scalar alpha,
+      const XLATensor& input, const at::Scalar& other, const at::Scalar& alpha,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
-  static void add_(XLATensor& input, at::Scalar other, at::Scalar alpha);
+  static void add_(XLATensor& input, const at::Scalar& other,
+                   const at::Scalar& alpha);
 
-  static XLATensor addcdiv(const XLATensor& input, at::Scalar value,
+  static XLATensor addcdiv(const XLATensor& input, const at::Scalar& value,
                            const XLATensor& tensor1, const XLATensor& tensor2);
-  static void addcdiv_(XLATensor& input, at::Scalar value,
+  static void addcdiv_(XLATensor& input, const at::Scalar& value,
                        const XLATensor& tensor1, const XLATensor& tensor2);
 
-  static XLATensor addcmul(const XLATensor& input, at::Scalar value,
+  static XLATensor addcmul(const XLATensor& input, const at::Scalar& value,
                            const XLATensor& tensor1, const XLATensor& tensor2);
-  static void addcmul_(XLATensor& input, at::Scalar value,
+  static void addcmul_(XLATensor& input, const at::Scalar& value,
                        const XLATensor& tensor1, const XLATensor& tensor2);
 
   static XLATensor addmm(const XLATensor& input, const XLATensor& weight,
@@ -296,8 +299,9 @@ class XLATensor {
                        std::vector<xla::int64> dimensions,
                        bool keep_reduced_dimensions);
 
-  static void arange_out(XLATensor& out, at::Scalar start, at::Scalar end,
-                         at::Scalar step, at::ScalarType scalar_type);
+  static void arange_out(XLATensor& out, const at::Scalar& start,
+                         const at::Scalar& end, const at::Scalar& step,
+                         at::ScalarType scalar_type);
 
   static XLATensor argmax(const XLATensor& input, xla::int64 dim, bool keepdim);
   static XLATensor argmax(const XLATensor& input);
@@ -350,11 +354,11 @@ class XLATensor {
                                         bool ceil_mode, bool count_include_pad);
 
   static XLATensor baddbmm(const XLATensor& input, const XLATensor& batch1,
-                           const XLATensor& batch2, at::Scalar beta,
-                           at::Scalar alpha);
+                           const XLATensor& batch2, const at::Scalar& beta,
+                           const at::Scalar& alpha);
   static void baddbmm_(XLATensor& input, const XLATensor& batch1,
-                       const XLATensor& batch2, at::Scalar beta,
-                       at::Scalar alpha);
+                       const XLATensor& batch2, const at::Scalar& beta,
+                       const at::Scalar& alpha);
 
   static XLATensor bernoulli(const XLATensor& input, double probability);
   static XLATensor bernoulli(const XLATensor& input);
@@ -373,7 +377,7 @@ class XLATensor {
                                                  xla::int64 reduction);
 
   static void bitwise_and_out(XLATensor& out, const XLATensor& input,
-                              at::Scalar other);
+                              const at::Scalar& other);
 
   static void bitwise_and_out(XLATensor& out, const XLATensor& input,
                               const XLATensor& other);
@@ -381,13 +385,13 @@ class XLATensor {
   static void bitwise_not_out(XLATensor& out, const XLATensor& input);
 
   static void bitwise_or_out(XLATensor& out, const XLATensor& input,
-                             at::Scalar other);
+                             const at::Scalar& other);
 
   static void bitwise_or_out(XLATensor& out, const XLATensor& input,
                              const XLATensor& other);
 
   static void bitwise_xor_out(XLATensor& out, const XLATensor& input,
-                              at::Scalar other);
+                              const at::Scalar& other);
 
   static void bitwise_xor_out(XLATensor& out, const XLATensor& input,
                               const XLATensor& other);
@@ -408,10 +412,11 @@ class XLATensor {
 
   static XLATensor cholesky(const XLATensor& input, bool upper);
 
-  static XLATensor clamp(const XLATensor& input, c10::optional<at::Scalar> min,
-                         c10::optional<at::Scalar> max);
-  static void clamp_(XLATensor& input, c10::optional<at::Scalar> min,
-                     c10::optional<at::Scalar> max);
+  static XLATensor clamp(const XLATensor& input,
+                         const c10::optional<at::Scalar>& min,
+                         const c10::optional<at::Scalar>& max);
+  static void clamp_(XLATensor& input, const c10::optional<at::Scalar>& min,
+                     const c10::optional<at::Scalar>& max);
 
   static XLATensor clone(const XLATensor& input);
 
@@ -419,7 +424,7 @@ class XLATensor {
   // high paddings.
   static XLATensor constant_pad_nd(const XLATensor& input,
                                    absl::Span<const xla::int64> pad,
-                                   at::Scalar value);
+                                   const at::Scalar& value);
 
   static XLATensor convolution_overrideable(
       const XLATensor& input, const XLATensor& weight, const XLATensor& bias,
@@ -475,22 +480,24 @@ class XLATensor {
       const XLATensor& input, const XLATensor& other,
       std::string rounding_mode = "true",
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
-  static XLATensor div(const XLATensor& input, at::Scalar other);
+  static XLATensor div(const XLATensor& input, const at::Scalar& other);
   static void div_(XLATensor& input, const XLATensor& other,
                    std::string rounding_mode = "true");
-  static void div_(XLATensor& input, at::Scalar other);
+  static void div_(XLATensor& input, const at::Scalar& other);
 
   // A generalized contraction between tensors of arbitrary dimension defined by
   // the given equation and applied to the input tensors.
   static XLATensor einsum(const std::string& equation,
                           absl::Span<const XLATensor> tensors);
 
-  static XLATensor elu(const XLATensor& input, at::Scalar alpha,
-                       at::Scalar scale, at::Scalar input_scale);
-  static void elu_(XLATensor& input, at::Scalar alpha, at::Scalar scale,
-                   at::Scalar input_scale);
-  static XLATensor elu_backward(const XLATensor& grad_output, at::Scalar alpha,
-                                at::Scalar scale, at::Scalar input_scale,
+  static XLATensor elu(const XLATensor& input, const at::Scalar& alpha,
+                       const at::Scalar& scale, const at::Scalar& input_scale);
+  static void elu_(XLATensor& input, const at::Scalar& alpha,
+                   const at::Scalar& scale, const at::Scalar& input_scale);
+  static XLATensor elu_backward(const XLATensor& grad_output,
+                                const at::Scalar& alpha,
+                                const at::Scalar& scale,
+                                const at::Scalar& input_scale,
                                 const XLATensor& output);
 
   static XLATensor embedding_dense_backward(const XLATensor& grad_output,
@@ -499,8 +506,8 @@ class XLATensor {
                                             xla::int64 padding_idx,
                                             bool scale_grad_by_freq);
 
-  static XLATensor eq(const XLATensor& input, at::Scalar other);
-  static void eq_(XLATensor& input, at::Scalar other);
+  static XLATensor eq(const XLATensor& input, const at::Scalar& other);
+  static void eq_(XLATensor& input, const at::Scalar& other);
 
   static XLATensor eq(const XLATensor& input, const XLATensor& other);
   static void eq_(XLATensor& input, const XLATensor& other);
@@ -531,7 +538,7 @@ class XLATensor {
   static void eye_out(XLATensor& out, xla::int64 lines, xla::int64 cols);
 
   // Fills the input with the given value.
-  static void fill_(XLATensor& input, at::Scalar value);
+  static void fill_(XLATensor& input, const at::Scalar& value);
 
   // Flips (reverses) the values in the dimensions of the input tensor.
   static XLATensor flip(const XLATensor& input,
@@ -544,26 +551,26 @@ class XLATensor {
       const XLATensor& input, const XLATensor& other,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
   static XLATensor fmod(
-      const XLATensor& input, at::Scalar other,
+      const XLATensor& input, const at::Scalar& other,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
   static void fmod_(XLATensor& input, const XLATensor& other);
-  static void fmod_(XLATensor& input, at::Scalar other);
+  static void fmod_(XLATensor& input, const at::Scalar& other);
 
   static XLATensor frac(const XLATensor& input);
   static void frac_(XLATensor& input);
 
   static XLATensor full(absl::Span<const xla::int64> size,
-                        at::Scalar fill_value, const Device& device,
+                        const at::Scalar& fill_value, const Device& device,
                         at::ScalarType scalar_type);
-  static XLATensor full_like(const XLATensor& input, at::Scalar fill_value,
-                             const Device& device,
+  static XLATensor full_like(const XLATensor& input,
+                             const at::Scalar& fill_value, const Device& device,
                              c10::optional<at::ScalarType> scalar_type);
 
   static XLATensor gather(const XLATensor& input, xla::int64 dim,
                           const XLATensor& index);
 
-  static XLATensor ge(const XLATensor& input, at::Scalar other);
-  static void ge_(XLATensor& input, at::Scalar other);
+  static XLATensor ge(const XLATensor& input, const at::Scalar& other);
+  static void ge_(XLATensor& input, const at::Scalar& other);
 
   static XLATensor ge(const XLATensor& input, const XLATensor& other);
   static void ge_(XLATensor& input, const XLATensor& other);
@@ -573,8 +580,8 @@ class XLATensor {
 
   static XLATensor ger(const XLATensor& input, const XLATensor& vec2);
 
-  static XLATensor gt(const XLATensor& input, at::Scalar other);
-  static void gt_(XLATensor& input, at::Scalar other);
+  static XLATensor gt(const XLATensor& input, const at::Scalar& other);
+  static void gt_(XLATensor& input, const at::Scalar& other);
 
   static XLATensor gt(const XLATensor& input, const XLATensor& other);
   static void gt_(XLATensor& input, const XLATensor& other);
@@ -604,7 +611,7 @@ class XLATensor {
   // dimension, at positions given by the index. The index must be a rank-1
   // tensor.
   static XLATensor index_fill(const XLATensor& input, xla::int64 dim,
-                              const XLATensor& index, at::Scalar value);
+                              const XLATensor& index, const at::Scalar& value);
 
   // Same as above, but the value is wrapped as a rank-0 tensor.
   static XLATensor index_fill(const XLATensor& input, xla::int64 dim,
@@ -614,7 +621,7 @@ class XLATensor {
                           const XLATensor& index, const XLATensor& value);
 
   static void index_fill_(XLATensor& input, xla::int64 dim,
-                          const XLATensor& index, at::Scalar value);
+                          const XLATensor& index, const at::Scalar& value);
 
   // Puts values into the input tensor using the given indices (a tuple of
   // tensors) and returns the result.
@@ -652,16 +659,16 @@ class XLATensor {
                                     const XLATensor& target,
                                     xla::int64 reduction);
 
-  static XLATensor le(const XLATensor& input, at::Scalar other);
-  static void le_(XLATensor& input, at::Scalar other);
+  static XLATensor le(const XLATensor& input, const at::Scalar& other);
+  static void le_(XLATensor& input, const at::Scalar& other);
 
   static XLATensor le(const XLATensor& input, const XLATensor& other);
   static void le_(XLATensor& input, const XLATensor& other);
 
-  static XLATensor hardshrink(const XLATensor& input, at::Scalar lambda);
+  static XLATensor hardshrink(const XLATensor& input, const at::Scalar& lambda);
   static XLATensor hardshrink_backward(const XLATensor& grad_out,
                                        const XLATensor& input,
-                                       at::Scalar lambda);
+                                       const at::Scalar& lambda);
 
   static XLATensor hardsigmoid(const XLATensor& input);
 
@@ -671,8 +678,9 @@ class XLATensor {
                                         const XLATensor& input);
 
   static XLATensor hardtanh_backward(const XLATensor& grad_output,
-                                     const XLATensor& input, at::Scalar min_val,
-                                     at::Scalar max_val);
+                                     const XLATensor& input,
+                                     const at::Scalar& min_val,
+                                     const at::Scalar& max_val);
 
   static XLATensor leaky_relu(const XLATensor& input, double negative_slope);
   static XLATensor leaky_relu_backward(const XLATensor& grad_output,
@@ -709,15 +717,15 @@ class XLATensor {
                              std::vector<xla::int64> dimensions,
                              bool keep_reduced_dimensions);
 
-  static XLATensor lt(const XLATensor& input, at::Scalar other);
-  static void lt_(XLATensor& input, at::Scalar other);
+  static XLATensor lt(const XLATensor& input, const at::Scalar& other);
+  static void lt_(XLATensor& input, const at::Scalar& other);
 
   static XLATensor lt(const XLATensor& input, const XLATensor& other);
   static void lt_(XLATensor& input, const XLATensor& other);
 
   // In-place version of the method above.
   static void masked_fill_(XLATensor& input, const XLATensor& mask,
-                           at::Scalar value);
+                           const at::Scalar& value);
 
   static void masked_scatter_(XLATensor& input, const XLATensor& mask,
                               const XLATensor& source);
@@ -790,10 +798,10 @@ class XLATensor {
       const XLATensor& input, const XLATensor& other,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
   static XLATensor mul(
-      const XLATensor& input, at::Scalar other,
+      const XLATensor& input, const at::Scalar& other,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
   static void mul_(XLATensor& input, const XLATensor& other);
-  static void mul_(XLATensor& input, at::Scalar other);
+  static void mul_(XLATensor& input, const at::Scalar& other);
 
   static XLATensor mv(const XLATensor& input, const XLATensor& vec);
   static void mv_out(XLATensor& out, const XLATensor& input,
@@ -817,8 +825,8 @@ class XLATensor {
       const XLATensor& weight, const XLATensor& save_mean,
       const XLATensor& save_invstd, bool training, double eps);
 
-  static XLATensor ne(const XLATensor& input, at::Scalar other);
-  static void ne_(XLATensor& input, at::Scalar other);
+  static XLATensor ne(const XLATensor& input, const at::Scalar& other);
+  static void ne_(XLATensor& input, const at::Scalar& other);
 
   static XLATensor ne(const XLATensor& input, const XLATensor& other);
   static void ne_(XLATensor& input, const XLATensor& other);
@@ -856,7 +864,8 @@ class XLATensor {
 
   static XLATensor nonzero(const XLATensor& input);
 
-  static XLATensor norm(const XLATensor& input, c10::optional<at::Scalar> p,
+  static XLATensor norm(const XLATensor& input,
+                        const c10::optional<at::Scalar>& p,
                         c10::optional<at::ScalarType> dtype,
                         at::IntArrayRef dim, bool keepdim);
 
@@ -875,10 +884,10 @@ class XLATensor {
   static XLATensor permute(const XLATensor& input,
                            absl::Span<const xla::int64> dims);
 
-  static XLATensor pow(const XLATensor& input, at::Scalar exponent);
+  static XLATensor pow(const XLATensor& input, const at::Scalar& exponent);
   static XLATensor pow(const XLATensor& input, const XLATensor& exponent);
-  static XLATensor pow(at::Scalar input, const XLATensor& exponent);
-  static void pow_(XLATensor& input, at::Scalar exponent);
+  static XLATensor pow(const at::Scalar& input, const XLATensor& exponent);
+  static void pow_(XLATensor& input, const at::Scalar& exponent);
   static void pow_(XLATensor& input, const XLATensor& exponent);
 
   static XLATensor prod(const XLATensor& input,
@@ -910,9 +919,9 @@ class XLATensor {
   static void relu_(XLATensor& input);
 
   static XLATensor remainder(const XLATensor& input, const XLATensor& other);
-  static XLATensor remainder(const XLATensor& input, at::Scalar other);
+  static XLATensor remainder(const XLATensor& input, const at::Scalar& other);
   static void remainder_(XLATensor& input, const XLATensor& other);
-  static void remainder_(XLATensor& input, at::Scalar other);
+  static void remainder_(XLATensor& input, const at::Scalar& other);
 
   // Repeats the input tensor along each dimension by the given number of
   // repeats.
@@ -937,23 +946,24 @@ class XLATensor {
   static void round_(XLATensor& input);
 
   static XLATensor rrelu_with_noise(const XLATensor& input, XLATensor& noise,
-                                    at::Scalar lower, at::Scalar upper,
-                                    bool training);
+                                    const at::Scalar& lower,
+                                    const at::Scalar& upper, bool training);
 
   static XLATensor rrelu_with_noise_backward(const XLATensor& grad_output,
                                              const XLATensor& input,
                                              const XLATensor& noise,
-                                             at::Scalar lower, at::Scalar upper,
+                                             const at::Scalar& lower,
+                                             const at::Scalar& upper,
                                              bool training);
 
   static XLATensor rsqrt(const XLATensor& input);
   static void rsqrt_(XLATensor& input);
 
   static XLATensor rsub(
-      const XLATensor& input, const XLATensor& other, at::Scalar alpha,
+      const XLATensor& input, const XLATensor& other, const at::Scalar& alpha,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
   static XLATensor rsub(
-      const XLATensor& input, at::Scalar other, at::Scalar alpha,
+      const XLATensor& input, const at::Scalar& other, const at::Scalar& alpha,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
 
   static void copy_(XLATensor& input, XLATensor& src);
@@ -961,7 +971,7 @@ class XLATensor {
   static void scatter_(XLATensor& input, xla::int64 dim, const XLATensor& index,
                        const XLATensor& src);
   static void scatter_(XLATensor& input, xla::int64 dim, const XLATensor& index,
-                       at::Scalar value);
+                       const at::Scalar& value);
 
   static void scatter_add_(XLATensor& input, xla::int64 dim,
                            const XLATensor& index, const XLATensor& src);
@@ -1004,17 +1014,18 @@ class XLATensor {
   static XLATensor softmax_backward(const XLATensor& grad_output,
                                     const XLATensor& output, xla::int64 dim);
 
-  static XLATensor softplus(const XLATensor& input, at::Scalar beta,
-                            at::Scalar threshold);
+  static XLATensor softplus(const XLATensor& input, const at::Scalar& beta,
+                            const at::Scalar& threshold);
   static XLATensor softplus_backward(const XLATensor& grad_output,
-                                     const XLATensor& input, at::Scalar beta,
-                                     at::Scalar threshold,
+                                     const XLATensor& input,
+                                     const at::Scalar& beta,
+                                     const at::Scalar& threshold,
                                      const XLATensor& output);
 
-  static XLATensor softshrink(const XLATensor& input, at::Scalar lambda);
+  static XLATensor softshrink(const XLATensor& input, const at::Scalar& lambda);
   static XLATensor softshrink_backward(const XLATensor& grad_out,
                                        const XLATensor& input,
-                                       at::Scalar lambda);
+                                       const at::Scalar& lambda);
 
   static std::vector<XLATensor> split(const XLATensor& input,
                                       xla::int64 split_size, xla::int64 dim);
@@ -1044,13 +1055,15 @@ class XLATensor {
                        bool keep_reduced_dimensions, bool unbiased);
 
   static XLATensor sub(
-      const XLATensor& input, const XLATensor& other, at::Scalar alpha,
+      const XLATensor& input, const XLATensor& other, const at::Scalar& alpha,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
-  static void sub_(XLATensor& input, const XLATensor& other, at::Scalar alpha);
+  static void sub_(XLATensor& input, const XLATensor& other,
+                   const at::Scalar& alpha);
   static XLATensor sub(
-      const XLATensor& input, at::Scalar other, at::Scalar alpha,
+      const XLATensor& input, const at::Scalar& other, const at::Scalar& alpha,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
-  static void sub_(XLATensor& input, at::Scalar other, at::Scalar alpha);
+  static void sub_(XLATensor& input, const at::Scalar& other,
+                   const at::Scalar& alpha);
 
   static XLATensor sum(const XLATensor& input,
                        std::vector<xla::int64> dimensions,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -149,16 +149,12 @@ MinMaxValues GetMinMaxValues(const XLATensor& tensor,
       << "At least one of \'min\' or \'max\' must not be None";
   xla::PrimitiveType raw_element_type = TensorTypeToRawXlaType(tensor.dtype());
   XlaHelpers::MinMax min_max = XlaHelpers::MinMaxValues(raw_element_type);
-  if (!min) {
-    min = min_max.min;
-  }
-  if (!max) {
-    max = min_max.max;
-  }
   auto shape = tensor.shape();
-  return {XLATensor::GetIrValueForScalar(*min, shape.get().element_type(),
+  return {XLATensor::GetIrValueForScalar(min ? *min : min_max.min, 
+                                         shape.get().element_type(),
                                          tensor.GetDevice()),
-          XLATensor::GetIrValueForScalar(*max, shape.get().element_type(),
+          XLATensor::GetIrValueForScalar(max ? *max : min_max.max, 
+                                         shape.get().element_type(),
                                          tensor.GetDevice())};
 }
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -143,17 +143,17 @@ struct MinMaxValues {
 };
 
 MinMaxValues GetMinMaxValues(const XLATensor& tensor,
-                             c10::optional<at::Scalar> min,
-                             c10::optional<at::Scalar> max) {
+                             const c10::optional<at::Scalar>& min,
+                             const c10::optional<at::Scalar>& max) {
   XLA_CHECK(min || max)
       << "At least one of \'min\' or \'max\' must not be None";
   xla::PrimitiveType raw_element_type = TensorTypeToRawXlaType(tensor.dtype());
   XlaHelpers::MinMax min_max = XlaHelpers::MinMaxValues(raw_element_type);
   auto shape = tensor.shape();
-  return {XLATensor::GetIrValueForScalar(min ? *min : min_max.min, 
+  return {XLATensor::GetIrValueForScalar(min ? *min : min_max.min,
                                          shape.get().element_type(),
                                          tensor.GetDevice()),
-          XLATensor::GetIrValueForScalar(max ? *max : min_max.max, 
+          XLATensor::GetIrValueForScalar(max ? *max : min_max.max,
                                          shape.get().element_type(),
                                          tensor.GetDevice())};
 }
@@ -253,7 +253,8 @@ xla::Shape BatchNormFeaturesShape(const XLATensor& input) {
 
 // Returns the IR for the given input or the provided default value broadcasted
 // to the default shape, if the input is undefined.
-ir::Value GetIrValueOrDefault(const XLATensor& input, at::Scalar default_value,
+ir::Value GetIrValueOrDefault(const XLATensor& input,
+                              const at::Scalar& default_value,
                               const xla::Shape& default_shape,
                               const Device& device) {
   return input.is_null() ? XLATensor::GetIrValueForScalar(default_value,
@@ -394,7 +395,7 @@ std::vector<XLATensor> XLATensor::user_computation(
 //////////////////////////////////////////////////////////////////////////////
 // ATEN operators follows here, listed in alphabetical order.
 //////////////////////////////////////////////////////////////////////////////
-void XLATensor::__ilshift__(XLATensor& input, at::Scalar other) {
+void XLATensor::__ilshift__(XLATensor& input, const at::Scalar& other) {
   input.SetInPlaceIrValue(ir::ops::Lshift(input.GetIrValue(), other));
 }
 
@@ -403,7 +404,7 @@ void XLATensor::__ilshift__(XLATensor& input, const XLATensor& other) {
       ir::ops::Lshift(input.GetIrValue(), other.GetIrValue()));
 }
 
-void XLATensor::__irshift__(XLATensor& input, at::Scalar other) {
+void XLATensor::__irshift__(XLATensor& input, const at::Scalar& other) {
   input.SetInPlaceIrValue(ir::ops::Rshift(input.GetIrValue(), other));
 }
 
@@ -413,7 +414,7 @@ void XLATensor::__irshift__(XLATensor& input, const XLATensor& other) {
 }
 
 XLATensor XLATensor::__lshift__(
-    const XLATensor& input, at::Scalar other,
+    const XLATensor& input, const at::Scalar& other,
     c10::optional<at::ScalarType> logical_element_type) {
   return input.CreateFrom(ir::ops::Lshift(input.GetIrValue(), other),
                           logical_element_type);
@@ -428,7 +429,7 @@ XLATensor XLATensor::__lshift__(
 }
 
 XLATensor XLATensor::__rshift__(
-    const XLATensor& input, at::Scalar other,
+    const XLATensor& input, const at::Scalar& other,
     c10::optional<at::ScalarType> logical_element_type) {
   return input.CreateFrom(ir::ops::Rshift(input.GetIrValue(), other),
                           logical_element_type);
@@ -521,7 +522,7 @@ void XLATensor::acosh_(XLATensor& input) {
 }
 
 XLATensor XLATensor::add(const XLATensor& input, const XLATensor& other,
-                         at::Scalar alpha,
+                         const at::Scalar& alpha,
                          c10::optional<at::ScalarType> logical_element_type) {
   ir::Value constant = GetIrValueForScalar(
       alpha, other.shape(), logical_element_type, input.GetDevice());
@@ -530,14 +531,14 @@ XLATensor XLATensor::add(const XLATensor& input, const XLATensor& other,
 }
 
 void XLATensor::add_(XLATensor& input, const XLATensor& other,
-                     at::Scalar alpha) {
+                     const at::Scalar& alpha) {
   ir::Value constant =
       GetIrValueForScalar(alpha, other.shape(), input.GetDevice());
   input.SetInPlaceIrValue(input.GetIrValue() + other.GetIrValue() * constant);
 }
 
-XLATensor XLATensor::add(const XLATensor& input, at::Scalar other,
-                         at::Scalar alpha,
+XLATensor XLATensor::add(const XLATensor& input, const at::Scalar& other,
+                         const at::Scalar& alpha,
                          c10::optional<at::ScalarType> logical_element_type) {
   ir::Value other_constant = GetIrValueForScalar(
       other, input.shape(), logical_element_type, input.GetDevice());
@@ -547,7 +548,8 @@ XLATensor XLATensor::add(const XLATensor& input, at::Scalar other,
                           logical_element_type);
 }
 
-void XLATensor::add_(XLATensor& input, at::Scalar other, at::Scalar alpha) {
+void XLATensor::add_(XLATensor& input, const at::Scalar& other,
+                     const at::Scalar& alpha) {
   ir::Value other_constant =
       GetIrValueForScalar(other, input.shape(), input.GetDevice());
   ir::Value alpha_constant =
@@ -555,7 +557,7 @@ void XLATensor::add_(XLATensor& input, at::Scalar other, at::Scalar alpha) {
   input.SetInPlaceIrValue(input.GetIrValue() + other_constant * alpha_constant);
 }
 
-void XLATensor::addcmul_(XLATensor& input, at::Scalar value,
+void XLATensor::addcmul_(XLATensor& input, const at::Scalar& value,
                          const XLATensor& tensor1, const XLATensor& tensor2) {
   ir::Value constant = GetIrValueForScalar(
       value, tensor1.shape().get().element_type(), input.GetDevice());
@@ -563,7 +565,7 @@ void XLATensor::addcmul_(XLATensor& input, at::Scalar value,
   input.SetInPlaceIrValue(input.GetIrValue() + mul * constant);
 }
 
-XLATensor XLATensor::addcdiv(const XLATensor& input, at::Scalar value,
+XLATensor XLATensor::addcdiv(const XLATensor& input, const at::Scalar& value,
                              const XLATensor& tensor1,
                              const XLATensor& tensor2) {
   ir::Value constant = GetIrValueForScalar(
@@ -572,7 +574,7 @@ XLATensor XLATensor::addcdiv(const XLATensor& input, at::Scalar value,
   return input.CreateFrom(input.GetIrValue() + div * constant);
 }
 
-void XLATensor::addcdiv_(XLATensor& input, at::Scalar value,
+void XLATensor::addcdiv_(XLATensor& input, const at::Scalar& value,
                          const XLATensor& tensor1, const XLATensor& tensor2) {
   ir::Value constant = GetIrValueForScalar(
       value, tensor1.shape().get().element_type(), input.GetDevice());
@@ -580,7 +582,7 @@ void XLATensor::addcdiv_(XLATensor& input, at::Scalar value,
   input.SetInPlaceIrValue(input.GetIrValue() + div * constant);
 }
 
-XLATensor XLATensor::addcmul(const XLATensor& input, at::Scalar value,
+XLATensor XLATensor::addcmul(const XLATensor& input, const at::Scalar& value,
                              const XLATensor& tensor1,
                              const XLATensor& tensor2) {
   ir::Value constant = GetIrValueForScalar(
@@ -623,8 +625,9 @@ XLATensor XLATensor::any(const XLATensor& input,
       result_type);
 }
 
-void XLATensor::arange_out(XLATensor& out, at::Scalar start, at::Scalar end,
-                           at::Scalar step, at::ScalarType scalar_type) {
+void XLATensor::arange_out(XLATensor& out, const at::Scalar& start,
+                           const at::Scalar& end, const at::Scalar& step,
+                           at::ScalarType scalar_type) {
   out.SetIrValue(ir::ops::ARange(start, end, step, scalar_type));
   out.SetScalarType(scalar_type);
 }
@@ -755,8 +758,8 @@ XLATensor XLATensor::avg_pool_nd_backward(
 }
 
 XLATensor XLATensor::baddbmm(const XLATensor& input, const XLATensor& batch1,
-                             const XLATensor& batch2, at::Scalar beta,
-                             at::Scalar alpha) {
+                             const XLATensor& batch2, const at::Scalar& beta,
+                             const at::Scalar& alpha) {
   CheckBmmDimension(/*tag=*/"baddbmm", batch1, batch2);
   ir::Value product_multiplier = XLATensor::GetIrValueForScalar(
       alpha, batch1.shape().get().element_type(), batch1.GetDevice());
@@ -768,8 +771,8 @@ XLATensor XLATensor::baddbmm(const XLATensor& input, const XLATensor& batch1,
 }
 
 void XLATensor::baddbmm_(XLATensor& input, const XLATensor& batch1,
-                         const XLATensor& batch2, at::Scalar beta,
-                         at::Scalar alpha) {
+                         const XLATensor& batch2, const at::Scalar& beta,
+                         const at::Scalar& alpha) {
   CheckBmmDimension(/*tag=*/"baddbmm_", batch1, batch2);
   ir::Value product_multiplier = XLATensor::GetIrValueForScalar(
       alpha, batch1.shape().get().element_type(), batch1.GetDevice());
@@ -825,7 +828,7 @@ XLATensor XLATensor::binary_cross_entropy_backward(const XLATensor& grad_output,
 }
 
 void XLATensor::bitwise_and_out(XLATensor& out, const XLATensor& input,
-                                at::Scalar other) {
+                                const at::Scalar& other) {
   CheckIsIntegralOrPred(input.shape(), "__and__");
   ir::Value constant =
       GetIrValueForScalar(other, input.shape(), input.GetDevice());
@@ -843,7 +846,7 @@ void XLATensor::bitwise_not_out(XLATensor& out, const XLATensor& input) {
 }
 
 void XLATensor::bitwise_or_out(XLATensor& out, const XLATensor& input,
-                               at::Scalar other) {
+                               const at::Scalar& other) {
   CheckIsIntegralOrPred(input.shape(), "__or__");
   ir::Value constant =
       GetIrValueForScalar(other, input.shape(), input.GetDevice());
@@ -857,7 +860,7 @@ void XLATensor::bitwise_or_out(XLATensor& out, const XLATensor& input,
 }
 
 void XLATensor::bitwise_xor_out(XLATensor& out, const XLATensor& input,
-                                at::Scalar other) {
+                                const at::Scalar& other) {
   CheckIsIntegralOrPred(input.shape(), "__xor__");
   ir::Value constant =
       GetIrValueForScalar(other, input.shape(), input.GetDevice());
@@ -932,15 +935,15 @@ XLATensor XLATensor::cholesky(const XLATensor& input, bool upper) {
 }
 
 XLATensor XLATensor::clamp(const XLATensor& input,
-                           c10::optional<at::Scalar> min,
-                           c10::optional<at::Scalar> max) {
+                           const c10::optional<at::Scalar>& min,
+                           const c10::optional<at::Scalar>& max) {
   MinMaxValues min_max = GetMinMaxValues(input, min, max);
   return input.CreateFrom(
       ir::ops::Clamp(input.GetIrValue(), min_max.min, min_max.max));
 }
 
-void XLATensor::clamp_(XLATensor& input, c10::optional<at::Scalar> min,
-                       c10::optional<at::Scalar> max) {
+void XLATensor::clamp_(XLATensor& input, const c10::optional<at::Scalar>& min,
+                       const c10::optional<at::Scalar>& max) {
   MinMaxValues min_max = GetMinMaxValues(input, min, max);
   input.SetInPlaceIrValue(
       ir::ops::Clamp(input.GetIrValue(), min_max.min, min_max.max));
@@ -952,7 +955,7 @@ XLATensor XLATensor::clone(const XLATensor& input) {
 
 XLATensor XLATensor::constant_pad_nd(const XLATensor& input,
                                      absl::Span<const xla::int64> pad,
-                                     at::Scalar value) {
+                                     const at::Scalar& value) {
   std::vector<xla::int64> complete_pad(pad.begin(), pad.end());
   complete_pad.resize(2 * input.shape().get().rank());
   return input.CreateFrom(ir::MakeNode<ir::ops::ConstantPadNd>(
@@ -1110,7 +1113,7 @@ XLATensor XLATensor::div(const XLATensor& input, const XLATensor& other,
   }
 }
 
-XLATensor XLATensor::div(const XLATensor& input, at::Scalar other) {
+XLATensor XLATensor::div(const XLATensor& input, const at::Scalar& other) {
   at::ScalarType scalar_type =
       at::typeMetaToScalarType(c10::get_default_dtype());
   ir::Value input_value = GetFloatingIrValue(input, scalar_type);
@@ -1137,7 +1140,7 @@ void XLATensor::div_(XLATensor& input, const XLATensor& other,
   input.SetInPlaceIrValue(res);
 }
 
-void XLATensor::div_(XLATensor& input, at::Scalar other) {
+void XLATensor::div_(XLATensor& input, const at::Scalar& other) {
   at::ScalarType scalar_type =
       at::typeMetaToScalarType(c10::get_default_dtype());
   ir::Value input_value = GetFloatingIrValue(input, scalar_type);
@@ -1146,11 +1149,11 @@ void XLATensor::div_(XLATensor& input, at::Scalar other) {
   input.SetInPlaceIrValue(input_value / other_value);
 }
 
-XLATensor XLATensor::eq(const XLATensor& input, at::Scalar other) {
+XLATensor XLATensor::eq(const XLATensor& input, const at::Scalar& other) {
   return DispatchComparisonOp(at::aten::eq, input, other);
 }
 
-void XLATensor::eq_(XLATensor& input, at::Scalar other) {
+void XLATensor::eq_(XLATensor& input, const at::Scalar& other) {
   ir::NodePtr cmp_result =
       ir::ops::ComparisonOp(at::aten::eq, input.GetIrValue(),
                             GetIrValueForScalar(other, input.GetDevice()));
@@ -1167,21 +1170,23 @@ void XLATensor::eq_(XLATensor& input, const XLATensor& other) {
   input.SetIrValue(ir::MakeNode<ir::ops::Cast>(cmp_result, input.dtype()));
 }
 
-XLATensor XLATensor::elu(const XLATensor& input, at::Scalar alpha,
-                         at::Scalar scale, at::Scalar input_scale) {
+XLATensor XLATensor::elu(const XLATensor& input, const at::Scalar& alpha,
+                         const at::Scalar& scale,
+                         const at::Scalar& input_scale) {
   return input.CreateFrom(
       ir::ops::Elu(input.GetIrValue(), alpha, scale, input_scale));
 }
 
-void XLATensor::elu_(XLATensor& input, at::Scalar alpha, at::Scalar scale,
-                     at::Scalar input_scale) {
+void XLATensor::elu_(XLATensor& input, const at::Scalar& alpha,
+                     const at::Scalar& scale, const at::Scalar& input_scale) {
   input.SetInPlaceIrValue(
       ir::ops::Elu(input.GetIrValue(), alpha, scale, input_scale));
 }
 
 XLATensor XLATensor::elu_backward(const XLATensor& grad_output,
-                                  at::Scalar alpha, at::Scalar scale,
-                                  at::Scalar input_scale,
+                                  const at::Scalar& alpha,
+                                  const at::Scalar& scale,
+                                  const at::Scalar& input_scale,
                                   const XLATensor& output) {
   return grad_output.CreateFrom(ir::ops::EluBackward(grad_output.GetIrValue(),
                                                      output.GetIrValue(), alpha,
@@ -1268,7 +1273,7 @@ void XLATensor::eye_out(XLATensor& out, xla::int64 lines, xla::int64 cols) {
                                                &out.GetDevice())));
 }
 
-void XLATensor::fill_(XLATensor& input, at::Scalar value) {
+void XLATensor::fill_(XLATensor& input, const at::Scalar& value) {
   ir::Value constant =
       GetIrValueForScalar(value, input.shape(), input.GetDevice());
   input.SetInPlaceIrValue(std::move(constant));
@@ -1298,7 +1303,7 @@ XLATensor XLATensor::fmod(const XLATensor& input, const XLATensor& other,
                           logical_element_type);
 }
 
-XLATensor XLATensor::fmod(const XLATensor& input, at::Scalar other,
+XLATensor XLATensor::fmod(const XLATensor& input, const at::Scalar& other,
                           c10::optional<at::ScalarType> logical_element_type) {
   ir::Value constant = GetIrValueForScalar(
       other, input.shape(), logical_element_type, input.GetDevice());
@@ -1311,7 +1316,7 @@ void XLATensor::fmod_(XLATensor& input, const XLATensor& other) {
       ir::ops::Fmod(input.GetIrValue(), other.GetIrValue()));
 }
 
-void XLATensor::fmod_(XLATensor& input, at::Scalar other) {
+void XLATensor::fmod_(XLATensor& input, const at::Scalar& other) {
   ir::Value constant =
       GetIrValueForScalar(other, input.shape(), input.GetDevice());
   input.SetInPlaceIrValue(ir::ops::Fmod(input.GetIrValue(), constant));
@@ -1326,7 +1331,7 @@ void XLATensor::frac_(XLATensor& input) {
 }
 
 XLATensor XLATensor::full(absl::Span<const xla::int64> size,
-                          at::Scalar fill_value, const Device& device,
+                          const at::Scalar& fill_value, const Device& device,
                           at::ScalarType scalar_type) {
   CheckShapeDimensions(size);
   xla::Shape shape = MakeArrayShapeFromDimensions(
@@ -1336,7 +1341,8 @@ XLATensor XLATensor::full(absl::Span<const xla::int64> size,
                 scalar_type);
 }
 
-XLATensor XLATensor::full_like(const XLATensor& input, at::Scalar fill_value,
+XLATensor XLATensor::full_like(const XLATensor& input,
+                               const at::Scalar& fill_value,
                                const Device& device,
                                c10::optional<at::ScalarType> scalar_type) {
   xla::Shape tensor_shape = input.shape();
@@ -1357,11 +1363,11 @@ XLATensor XLATensor::gather(const XLATensor& input, xla::int64 dim,
       index.GetIrValue()));
 }
 
-XLATensor XLATensor::ge(const XLATensor& input, at::Scalar other) {
+XLATensor XLATensor::ge(const XLATensor& input, const at::Scalar& other) {
   return DispatchComparisonOp(at::aten::ge, input, other);
 }
 
-void XLATensor::ge_(XLATensor& input, at::Scalar other) {
+void XLATensor::ge_(XLATensor& input, const at::Scalar& other) {
   ir::NodePtr cmp_result =
       ir::ops::ComparisonOp(at::aten::ge, input.GetIrValue(),
                             GetIrValueForScalar(other, input.GetDevice()));
@@ -1392,11 +1398,11 @@ XLATensor XLATensor::ger(const XLATensor& input, const XLATensor& vec2) {
   return input.CreateFrom(ir::ops::Ger(input.GetIrValue(), vec2.GetIrValue()));
 }
 
-XLATensor XLATensor::gt(const XLATensor& input, at::Scalar other) {
+XLATensor XLATensor::gt(const XLATensor& input, const at::Scalar& other) {
   return DispatchComparisonOp(at::aten::gt, input, other);
 }
 
-void XLATensor::gt_(XLATensor& input, at::Scalar other) {
+void XLATensor::gt_(XLATensor& input, const at::Scalar& other) {
   ir::NodePtr cmp_result =
       ir::ops::ComparisonOp(at::aten::gt, input.GetIrValue(),
                             GetIrValueForScalar(other, input.GetDevice()));
@@ -1450,7 +1456,8 @@ void XLATensor::index_copy_(XLATensor& input, xla::int64 dim,
 }
 
 XLATensor XLATensor::index_fill(const XLATensor& input, xla::int64 dim,
-                                const XLATensor& index, at::Scalar value) {
+                                const XLATensor& index,
+                                const at::Scalar& value) {
   xla::int64 canonical_dim =
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   return input.CreateFrom(IndexFill(input, canonical_dim, index, value));
@@ -1472,7 +1479,7 @@ void XLATensor::index_fill_(XLATensor& input, xla::int64 dim,
 }
 
 void XLATensor::index_fill_(XLATensor& input, xla::int64 dim,
-                            const XLATensor& index, at::Scalar value) {
+                            const XLATensor& index, const at::Scalar& value) {
   xla::int64 canonical_dim =
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   input.SetIrValue(IndexFill(input, canonical_dim, index, value));
@@ -1544,11 +1551,11 @@ XLATensor XLATensor::l1_loss_backward(const XLATensor& grad_output,
       GetXlaReductionMode(reduction)));
 }
 
-XLATensor XLATensor::le(const XLATensor& input, at::Scalar other) {
+XLATensor XLATensor::le(const XLATensor& input, const at::Scalar& other) {
   return DispatchComparisonOp(at::aten::le, input, other);
 }
 
-void XLATensor::le_(XLATensor& input, at::Scalar other) {
+void XLATensor::le_(XLATensor& input, const at::Scalar& other) {
   ir::NodePtr cmp_result =
       ir::ops::ComparisonOp(at::aten::le, input.GetIrValue(),
                             GetIrValueForScalar(other, input.GetDevice()));
@@ -1565,14 +1572,15 @@ void XLATensor::le_(XLATensor& input, const XLATensor& other) {
   input.SetIrValue(ir::MakeNode<ir::ops::Cast>(cmp_result, input.dtype()));
 }
 
-XLATensor XLATensor::hardshrink(const XLATensor& input, at::Scalar lambda) {
+XLATensor XLATensor::hardshrink(const XLATensor& input,
+                                const at::Scalar& lambda) {
   return input.CreateFrom(
       ir::MakeNode<ir::ops::Hardshrink>(input.GetIrValue(), lambda));
 }
 
 XLATensor XLATensor::hardshrink_backward(const XLATensor& grad_out,
                                          const XLATensor& input,
-                                         at::Scalar lambda) {
+                                         const at::Scalar& lambda) {
   return input.CreateFrom(ir::MakeNode<ir::ops::ShrinkBackward>(
       ir::OpKind(at::aten::hardshrink_backward), grad_out.GetIrValue(),
       input.GetIrValue(), lambda));
@@ -1594,7 +1602,8 @@ XLATensor XLATensor::hardsigmoid_backward(const XLATensor& grad_output,
 
 XLATensor XLATensor::hardtanh_backward(const XLATensor& grad_output,
                                        const XLATensor& input,
-                                       at::Scalar min_val, at::Scalar max_val) {
+                                       const at::Scalar& min_val,
+                                       const at::Scalar& max_val) {
   return grad_output.CreateFrom(ir::MakeNode<ir::ops::HardtanhBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), min_val, max_val));
 }
@@ -1693,11 +1702,11 @@ XLATensor XLATensor::logsumexp(const XLATensor& input,
       keep_reduced_dimensions));
 }
 
-XLATensor XLATensor::lt(const XLATensor& input, at::Scalar other) {
+XLATensor XLATensor::lt(const XLATensor& input, const at::Scalar& other) {
   return DispatchComparisonOp(at::aten::lt, input, other);
 }
 
-void XLATensor::lt_(XLATensor& input, at::Scalar other) {
+void XLATensor::lt_(XLATensor& input, const at::Scalar& other) {
   ir::NodePtr cmp_result =
       ir::ops::ComparisonOp(at::aten::lt, input.GetIrValue(),
                             GetIrValueForScalar(other, input.GetDevice()));
@@ -1715,7 +1724,7 @@ void XLATensor::lt_(XLATensor& input, const XLATensor& other) {
 }
 
 void XLATensor::masked_fill_(XLATensor& input, const XLATensor& mask,
-                             at::Scalar value) {
+                             const at::Scalar& value) {
   ir::ScopePusher ir_scope(at::aten::masked_fill.toQualString());
   input.SetIrValue(ir::MakeNode<ir::ops::MaskedFill>(
       input.GetIrValue(), MaybeExpand(mask.GetIrValue(), input.shape()),
@@ -1891,7 +1900,7 @@ XLATensor XLATensor::mul(const XLATensor& input, const XLATensor& other,
                           logical_element_type);
 }
 
-XLATensor XLATensor::mul(const XLATensor& input, at::Scalar other,
+XLATensor XLATensor::mul(const XLATensor& input, const at::Scalar& other,
                          c10::optional<at::ScalarType> logical_element_type) {
   ir::Value constant = GetIrValueForScalar(
       other, input.shape(), logical_element_type, input.GetDevice());
@@ -1902,7 +1911,7 @@ void XLATensor::mul_(XLATensor& input, const XLATensor& other) {
   input.SetInPlaceIrValue(input.GetIrValue() * other.GetIrValue());
 }
 
-void XLATensor::mul_(XLATensor& input, at::Scalar other) {
+void XLATensor::mul_(XLATensor& input, const at::Scalar& other) {
   ir::Value constant =
       GetIrValueForScalar(other, input.shape(), input.GetDevice());
   input.SetInPlaceIrValue(input.GetIrValue() * constant);
@@ -1989,11 +1998,11 @@ XLATensor::native_batch_norm_backward(const XLATensor& grad_out,
                          std::move(grad_bias));
 }
 
-XLATensor XLATensor::ne(const XLATensor& input, at::Scalar other) {
+XLATensor XLATensor::ne(const XLATensor& input, const at::Scalar& other) {
   return DispatchComparisonOp(at::aten::ne, input, other);
 }
 
-void XLATensor::ne_(XLATensor& input, at::Scalar other) {
+void XLATensor::ne_(XLATensor& input, const at::Scalar& other) {
   ir::NodePtr cmp_result =
       ir::ops::ComparisonOp(at::aten::ne, input.GetIrValue(),
                             GetIrValueForScalar(other, input.GetDevice()));
@@ -2076,7 +2085,8 @@ XLATensor XLATensor::nonzero(const XLATensor& input) {
   return input.CreateFrom(ir::Value(node, 0), at::ScalarType::Long);
 }
 
-XLATensor XLATensor::norm(const XLATensor& input, c10::optional<at::Scalar> p,
+XLATensor XLATensor::norm(const XLATensor& input,
+                          const c10::optional<at::Scalar>& p,
                           c10::optional<at::ScalarType> dtype,
                           at::IntArrayRef dim, bool keepdim) {
   auto canonical_dims = XlaHelpers::GetCanonicalDimensionIndices(
@@ -2130,7 +2140,7 @@ XLATensor XLATensor::permute(const XLATensor& input,
   return input.CreateViewTensor(std::move(view_info));
 }
 
-XLATensor XLATensor::pow(const XLATensor& input, at::Scalar exponent) {
+XLATensor XLATensor::pow(const XLATensor& input, const at::Scalar& exponent) {
   ir::Value exponent_node =
       GetIrValueForScalar(exponent, input.shape(), input.GetDevice());
   return input.CreateFrom(ir::ops::Pow(input.GetIrValue(), exponent_node));
@@ -2141,13 +2151,13 @@ XLATensor XLATensor::pow(const XLATensor& input, const XLATensor& exponent) {
       ir::ops::Pow(input.GetIrValue(), exponent.GetIrValue()));
 }
 
-XLATensor XLATensor::pow(at::Scalar input, const XLATensor& exponent) {
+XLATensor XLATensor::pow(const at::Scalar& input, const XLATensor& exponent) {
   ir::Value input_node =
       GetIrValueForScalar(input, exponent.shape(), exponent.GetDevice());
   return exponent.CreateFrom(ir::ops::Pow(input_node, exponent.GetIrValue()));
 }
 
-void XLATensor::pow_(XLATensor& input, at::Scalar exponent) {
+void XLATensor::pow_(XLATensor& input, const at::Scalar& exponent) {
   ir::Value exponent_node =
       GetIrValueForScalar(exponent, input.shape(), input.GetDevice());
   input.SetInPlaceIrValue(ir::ops::Pow(input.GetIrValue(), exponent_node));
@@ -2229,7 +2239,8 @@ XLATensor XLATensor::remainder(const XLATensor& input, const XLATensor& other) {
       ir::ops::Remainder(input.GetIrValue(), other.GetIrValue()));
 }
 
-XLATensor XLATensor::remainder(const XLATensor& input, at::Scalar other) {
+XLATensor XLATensor::remainder(const XLATensor& input,
+                               const at::Scalar& other) {
   ir::Value constant =
       GetIrValueForScalar(other, input.shape(), input.GetDevice());
   return input.CreateFrom(ir::ops::Remainder(input.GetIrValue(), constant));
@@ -2240,7 +2251,7 @@ void XLATensor::remainder_(XLATensor& input, const XLATensor& other) {
       ir::ops::Remainder(input.GetIrValue(), other.GetIrValue()));
 }
 
-void XLATensor::remainder_(XLATensor& input, at::Scalar other) {
+void XLATensor::remainder_(XLATensor& input, const at::Scalar& other) {
   ir::Value constant =
       GetIrValueForScalar(other, input.shape(), input.GetDevice());
   input.SetInPlaceIrValue(ir::ops::Remainder(input.GetIrValue(), constant));
@@ -2301,8 +2312,8 @@ void XLATensor::round_(XLATensor& input) {
 }
 
 XLATensor XLATensor::rrelu_with_noise(const XLATensor& input, XLATensor& noise,
-                                      at::Scalar lower, at::Scalar upper,
-                                      bool training) {
+                                      const at::Scalar& lower,
+                                      const at::Scalar& upper, bool training) {
   ir::NodePtr output_node = ir::MakeNode<ir::ops::RreluWithNoise>(
       input.GetIrValue(), GetRngSeed(input.GetDevice()), lower, upper,
       training);
@@ -2310,9 +2321,12 @@ XLATensor XLATensor::rrelu_with_noise(const XLATensor& input, XLATensor& noise,
   return input.CreateFrom(ir::Value(output_node, 0));
 }
 
-XLATensor XLATensor::rrelu_with_noise_backward(
-    const XLATensor& grad_output, const XLATensor& input,
-    const XLATensor& noise, at::Scalar lower, at::Scalar upper, bool training) {
+XLATensor XLATensor::rrelu_with_noise_backward(const XLATensor& grad_output,
+                                               const XLATensor& input,
+                                               const XLATensor& noise,
+                                               const at::Scalar& lower,
+                                               const at::Scalar& upper,
+                                               bool training) {
   return grad_output.CreateFrom(ir::MakeNode<ir::ops::RreluWithNoiseBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), noise.GetIrValue(), lower,
       upper, training));
@@ -2327,7 +2341,7 @@ void XLATensor::rsqrt_(XLATensor& input) {
 }
 
 XLATensor XLATensor::rsub(const XLATensor& input, const XLATensor& other,
-                          at::Scalar alpha,
+                          const at::Scalar& alpha,
                           c10::optional<at::ScalarType> logical_element_type) {
   ir::Value alpha_xla = GetIrValueForScalar(
       alpha, other.shape(), logical_element_type, other.GetDevice());
@@ -2335,8 +2349,8 @@ XLATensor XLATensor::rsub(const XLATensor& input, const XLATensor& other,
                           logical_element_type);
 }
 
-XLATensor XLATensor::rsub(const XLATensor& input, at::Scalar other,
-                          at::Scalar alpha,
+XLATensor XLATensor::rsub(const XLATensor& input, const at::Scalar& other,
+                          const at::Scalar& alpha,
                           c10::optional<at::ScalarType> logical_element_type) {
   ir::Value alpha_xla = GetIrValueForScalar(
       alpha, input.shape(), logical_element_type, input.GetDevice());
@@ -2375,7 +2389,7 @@ void XLATensor::scatter_(XLATensor& input, xla::int64 dim,
 }
 
 void XLATensor::scatter_(XLATensor& input, xla::int64 dim,
-                         const XLATensor& index, at::Scalar value) {
+                         const XLATensor& index, const at::Scalar& value) {
   ir::Value constant =
       GetIrValueForScalar(value, input.shape(), input.GetDevice());
   input.SetIrValue(ir::MakeNode<ir::ops::Scatter>(
@@ -2491,27 +2505,29 @@ XLATensor XLATensor::softmax_backward(const XLATensor& grad_output,
       grad_output.GetIrValue(), output.GetIrValue(), dim));
 }
 
-XLATensor XLATensor::softplus(const XLATensor& input, at::Scalar beta,
-                              at::Scalar threshold) {
+XLATensor XLATensor::softplus(const XLATensor& input, const at::Scalar& beta,
+                              const at::Scalar& threshold) {
   return tensor_ops::Softplus(input, beta, threshold);
 }
 
 XLATensor XLATensor::softplus_backward(const XLATensor& grad_output,
-                                       const XLATensor& input, at::Scalar beta,
-                                       at::Scalar threshold,
+                                       const XLATensor& input,
+                                       const at::Scalar& beta,
+                                       const at::Scalar& threshold,
                                        const XLATensor& output) {
   return tensor_ops::SoftplusBackward(grad_output, input, beta, threshold,
                                       output);
 }
 
-XLATensor XLATensor::softshrink(const XLATensor& input, at::Scalar lambda) {
+XLATensor XLATensor::softshrink(const XLATensor& input,
+                                const at::Scalar& lambda) {
   return input.CreateFrom(
       ir::MakeNode<ir::ops::Softshrink>(input.GetIrValue(), lambda));
 }
 
 XLATensor XLATensor::softshrink_backward(const XLATensor& grad_out,
                                          const XLATensor& input,
-                                         at::Scalar lambda) {
+                                         const at::Scalar& lambda) {
   return input.CreateFrom(ir::MakeNode<ir::ops::ShrinkBackward>(
       ir::OpKind(at::aten::softshrink_backward), grad_out.GetIrValue(),
       input.GetIrValue(), lambda));
@@ -2608,7 +2624,7 @@ XLATensor XLATensor::std(const XLATensor& input,
 }
 
 XLATensor XLATensor::sub(const XLATensor& input, const XLATensor& other,
-                         at::Scalar alpha,
+                         const at::Scalar& alpha,
                          c10::optional<at::ScalarType> logical_element_type) {
   ir::Value constant = GetIrValueForScalar(
       alpha, other.shape(), logical_element_type, other.GetDevice());
@@ -2617,14 +2633,14 @@ XLATensor XLATensor::sub(const XLATensor& input, const XLATensor& other,
 }
 
 void XLATensor::sub_(XLATensor& input, const XLATensor& other,
-                     at::Scalar alpha) {
+                     const at::Scalar& alpha) {
   ir::Value constant =
       GetIrValueForScalar(alpha, other.shape(), other.GetDevice());
   input.SetInPlaceIrValue(input.GetIrValue() - other.GetIrValue() * constant);
 }
 
-XLATensor XLATensor::sub(const XLATensor& input, at::Scalar other,
-                         at::Scalar alpha,
+XLATensor XLATensor::sub(const XLATensor& input, const at::Scalar& other,
+                         const at::Scalar& alpha,
                          c10::optional<at::ScalarType> logical_element_type) {
   ir::Value other_constant = GetIrValueForScalar(
       other, input.shape(), logical_element_type, input.GetDevice());
@@ -2634,7 +2650,8 @@ XLATensor XLATensor::sub(const XLATensor& input, at::Scalar other,
                           logical_element_type);
 }
 
-void XLATensor::sub_(XLATensor& input, at::Scalar other, at::Scalar alpha) {
+void XLATensor::sub_(XLATensor& input, const at::Scalar& other,
+                     const at::Scalar& alpha) {
   ir::Value other_constant =
       GetIrValueForScalar(other, input.shape(), input.GetDevice());
   ir::Value alpha_constant =
@@ -2918,7 +2935,7 @@ XLATensor XLATensor::where(const XLATensor& condition, const XLATensor& input,
 
 XLATensor XLATensor::DispatchComparisonOp(c10::Symbol kind,
                                           const XLATensor& input,
-                                          at::Scalar other) {
+                                          const at::Scalar& other) {
   ir::NodePtr node = ir::ops::ComparisonOp(
       kind, input.GetIrValue(), GetIrValueForScalar(other, input.GetDevice()));
   return Create(node, input.GetDevice(), at::ScalarType::Bool);

--- a/torch_xla/csrc/tensor_ops.cpp
+++ b/torch_xla/csrc/tensor_ops.cpp
@@ -171,8 +171,8 @@ XLATensor SmoothL1LossBackward(const XLATensor& grad_output,
   }
 }
 
-XLATensor Softplus(const XLATensor& input, at::Scalar beta,
-                   at::Scalar threshold) {
+XLATensor Softplus(const XLATensor& input, const at::Scalar& beta,
+                   const at::Scalar& threshold) {
   return XLATensor::where(
       XLATensor::gt(XLATensor::mul(input, beta), threshold), input,
       XLATensor::div(
@@ -180,7 +180,7 @@ XLATensor Softplus(const XLATensor& input, at::Scalar beta,
 }
 
 XLATensor SoftplusBackward(const XLATensor& grad_output, const XLATensor& input,
-                           at::Scalar beta, at::Scalar threshold,
+                           const at::Scalar& beta, const at::Scalar& threshold,
                            const XLATensor& output) {
   XLATensor scaled_output = XLATensor::mul(output, beta);
   XLATensor z = XLATensor::exp(scaled_output);

--- a/torch_xla/csrc/tensor_ops.h
+++ b/torch_xla/csrc/tensor_ops.h
@@ -26,11 +26,11 @@ XLATensor SmoothL1LossBackward(const XLATensor& grad_output,
                                const XLATensor& input, const XLATensor& target,
                                ReductionMode reduction, double beta);
 
-XLATensor Softplus(const XLATensor& input, at::Scalar beta,
-                   at::Scalar threshold);
+XLATensor Softplus(const XLATensor& input, const at::Scalar& beta,
+                   const at::Scalar& threshold);
 
 XLATensor SoftplusBackward(const XLATensor& grad_output, const XLATensor& input,
-                           at::Scalar beta, at::Scalar threshold,
+                           const at::Scalar& beta, const at::Scalar& threshold,
                            const XLATensor& output);
 
 XLATensor Select(const XLATensor& input, xla::int64 dim, xla::int64 index);

--- a/torch_xla/csrc/torch_util.cpp
+++ b/torch_xla/csrc/torch_util.cpp
@@ -14,7 +14,7 @@ at::Tensor CopyTensor(const at::Tensor& ref, at::ScalarType dest_type,
   return ref.to(ref.options().dtype(dest_type), /*non_blocking=*/false, copy);
 }
 
-at::ScalarType GetScalarType(at::Scalar scalar) {
+at::ScalarType GetScalarType(const at::Scalar& scalar) {
   if (scalar.isFloatingPoint()) {
     return at::kDouble;
   } else if (scalar.isIntegral(/*includeBool=*/false)) {

--- a/torch_xla/csrc/torch_util.h
+++ b/torch_xla/csrc/torch_util.h
@@ -14,7 +14,7 @@ at::Tensor CopyTensor(const at::Tensor& ref, at::ScalarType dest_type,
                       bool copy = true);
 
 // Return at::ScalarType from at::Scalar
-at::ScalarType GetScalarType(at::Scalar scalar);
+at::ScalarType GetScalarType(const at::Scalar& scalar);
 
 template <typename T>
 at::Scalar MakeIntScalar(T value) {


### PR DESCRIPTION
Commands used:
```
fastmod  '([a-zA-Z_+]\([^)]*,?\s*)at::Scalar (\w+)' '${1}const at::Scalar& ${2}'
fastmod  '([a-zA-Z_+]\([^)]*,?\s*)c10::optional<at::Scalar> (\w+)' '${1}const c10::optional<at::Scalar>& ${2}'
```

Then run clang-format-7:
```
clang-format-7 -i -style=file \
    torch_xla/csrc/aten_xla_type.cpp \
    torch_xla/csrc/aten_xla_type.h \
    torch_xla/csrc/elementwise.cpp \
    torch_xla/csrc/elementwise.h \
    torch_xla/csrc/ops/hardtanh_backward.cpp \
    torch_xla/csrc/ops/masked_fill.cpp \
    torch_xla/csrc/ops/ops.cpp \
    torch_xla/csrc/ops/ops.h \
    torch_xla/csrc/ops/rrelu_with_noise_backward.cpp \
    torch_xla/csrc/ops/rrelu_with_noise_backward.h \
    torch_xla/csrc/tensor.h \
    torch_xla/csrc/tensor_methods.cpp
```

----------------------------------------

Merge need to be coordinated with https://github.com/pytorch/pytorch/pull/53583

---------------------

torch pin needs to be removed before merge