### PR TITLE
Fix quotes in bash command.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ run_clang_format: &run_clang_format
     find -name '*.cpp' -o -name '*.h' | xargs clang-format-7 -i -style=file
     git_status=$(git status --porcelain)
     if [[ $git_status ]]; then
-      echo "clang-format-7 is not happy, please run `clang-format-7 -i -style /PATH/TO/foo.cpp` to the following files"
+      echo "clang-format-7 is not happy, please run \"clang-format-7 -i -style /PATH/TO/foo.cpp\" to the following files"
       echo "${git_status}"
       exit 1
     else


### PR DESCRIPTION
@wenleix found out that it's not printing out command correctly when clang-format fails. Thanks! 