### PR TITLE
Patch tf for pt/xla 1.8.1

### DIFF
--- a/scripts/apply_patches.sh
+++ b/scripts/apply_patches.sh
@@ -5,6 +5,7 @@ set -ex
 CDIR="$(cd "$(dirname "$0")" ; pwd -P)"
 XDIR=$CDIR/..
 PTDIR=$XDIR/..
+TFDIR=$XDIR/third_party/tensorflow
 
 TORCH_PIN="$XDIR/torch_patches/.torch_pin"
 if [ -f "$TORCH_PIN" ]; then
@@ -36,3 +37,7 @@ fi
 python $CDIR/cond_patch.py \
   $XDIR/torch_patches \
   $PTDIR
+
+python $CDIR/cond_patch.py \
+  $XDIR/tf_patches \
+  $TFDIR

--- a/tf_patches/LookupStream.diff
+++ b/tf_patches/LookupStream.diff
@@ -1,0 +1,35 @@
+diff --git a/tensorflow/stream_executor/tpu/tpu_executable.cc b/tensorflow/stream_executor/tpu/tpu_executable.cc
+index 6408d37b9902f..5072f27c9584e 100644
+--- a/tensorflow/stream_executor/tpu/tpu_executable.cc
++++ b/tensorflow/stream_executor/tpu/tpu_executable.cc
+@@ -73,7 +73,7 @@ Status TpuExecutable::LoadProgramAndEnqueueToStream(
+ 
+   auto platform = tensorflow::down_cast<tensorflow::tpu::TpuPlatform*>(
+       tensorflow::tpu::TpuPlatformInterface::GetRegisteredPlatform());
+-  auto stream = platform->stream_map()->at(
++  auto stream = platform->LookupStream(
+       run_options.run_options().stream()->implementation());
+   StatusHelper status;
+ 
+diff --git a/tensorflow/stream_executor/tpu/tpu_transfer_manager.cc b/tensorflow/stream_executor/tpu/tpu_transfer_manager.cc
+index dd516cf58aa7c..1c1685db015eb 100644
+--- a/tensorflow/stream_executor/tpu/tpu_transfer_manager.cc
++++ b/tensorflow/stream_executor/tpu/tpu_transfer_manager.cc
+@@ -78,7 +78,7 @@ Status TpuTransferManager::TransferLiteralToDeviceAsync(
+ 
+   tpu::ExecutorApiFn()->TpuTransferManager_TransferLiteralToDeviceAsyncFn(
+       manager_,
+-      TpuPlatform::GetRegisteredPlatform()->stream_map()->at(
++      TpuPlatform::GetRegisteredPlatform()->LookupStream(
+           stream->implementation()),
+       &c_literal, &c_device_buffer, status.c_status);
+   ApiConverter::Free(&c_device_buffer);
+@@ -284,7 +284,7 @@ Status TpuTransferManager::WriteSingleTupleIndexTable(
+ 
+   tpu::ExecutorApiFn()->TpuTransferManager_WriteSingleTupleIndexTableFn(
+       manager_,
+-      TpuPlatform::GetRegisteredPlatform()->stream_map()->at(
++      TpuPlatform::GetRegisteredPlatform()->LookupStream(
+           stream->implementation()),
+       elements_bases, elements.size(), &c_shape, &region_base, status.c_status);
+ 


### PR DESCRIPTION
This is to bring https://github.com/tensorflow/tensorflow/commit/3c5b4a1637a5452d52d088e0b1c064322efc03e4 to pt/xla 1.8.1.

apply_patches.sh will be called upon circleCI build and wheel build.