### PR TITLE
Adding an env var to disbale starting the xrt server in the same process

### DIFF
--- a/third_party/xla_client/env_vars.cc
+++ b/third_party/xla_client/env_vars.cc
@@ -15,6 +15,7 @@ const char* const kEnvWorldSize = "XRT_SHARD_WORLD_SIZE";
 const char* const kEnvMpDevice = "XRT_MULTI_PROCESSING_DEVICE";
 const char* const kEnvHostOrdinal = "XRT_HOST_ORDINAL";
 const char* const kEnvShardOrdinal = "XRT_SHARD_ORDINAL";
+const char* const kEnvStartService = "XRT_START_LOCAL_SERVER";
 const char* const kEnvTpuvmMode = "TPUVM_MODE";
 
 }  // namespace env

--- a/third_party/xla_client/env_vars.h
+++ b/third_party/xla_client/env_vars.h
@@ -16,6 +16,7 @@ extern const char* const kEnvWorldSize;
 extern const char* const kEnvMpDevice;
 extern const char* const kEnvHostOrdinal;
 extern const char* const kEnvShardOrdinal;
+extern const char* const kEnvStartService; 
 extern const char* const kEnvTpuvmMode;
 
 }  // namespace env

--- a/third_party/xla_client/env_vars.h
+++ b/third_party/xla_client/env_vars.h
@@ -16,7 +16,7 @@ extern const char* const kEnvWorldSize;
 extern const char* const kEnvMpDevice;
 extern const char* const kEnvHostOrdinal;
 extern const char* const kEnvShardOrdinal;
-extern const char* const kEnvStartService; 
+extern const char* const kEnvStartService;
 extern const char* const kEnvTpuvmMode;
 
 }  // namespace env

--- a/third_party/xla_client/xrt_computation_client.cc
+++ b/third_party/xla_client/xrt_computation_client.cc
@@ -164,6 +164,9 @@ bool ShouldStartLocalService(const std::set<std::string>& devices) {
   if (tpuvm_mode && (shard_ordinal % 8 == 0) && (world_size > 8)) {
     return false;
   }
+  if (!sys_util::GetEnvBool(env::kEnvStartService, true)) {
+    return false;
+  }
   // Only the process with CPU device and GPU device should start the local
   // service.
   for (const std::string& device : devices) {


### PR DESCRIPTION
With this, one can use `python -m torch_xla.core.xrt_run_server 51011`(or a different port) to start the xrt local service in a different process.

I am building the wheel right now.