### PR TITLE
Redirect separate process tf server log to a file

### DIFF
--- a/torch_xla/core/xrt_run_server.py
+++ b/torch_xla/core/xrt_run_server.py
@@ -1,10 +1,43 @@
+import argparse
+import re
+import time
+import os
 import subprocess
 import sys
+from pathlib import Path
 
 if __name__ == '__main__':
-  assert len(sys.argv) == 2, 'Need to provide the local service port'
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '--port', type=str, help='Port that XRT local service will be using.')
+  parser.add_argument(
+      '--env',
+      action='append',
+      type=str,
+      help='List of environment variables to distribute.')
+  FLAGS = parser.parse_args()
+
+  my_env = os.environ.copy()
+  # Enable the basic logging by defualt
+  my_env['TF_CPP_MIN_LOG_LEVEL'] = '0'
+  my_env[
+      'TF_CPP_VMODULE'] = 'tpu_configuration_ops=1,tpu_execute_op=1,tpu_compile_op=1,tpu_compile_op_impl=1,tpu_compile_op_common=1,tpu_compile_ops=1,master=1'
+
+  env_vars = list(FLAGS.env) if FLAGS.env else []
+  for env_var in env_vars:
+    if re.match(r'\w*=\w*', env_var) is None:
+      raise ValueError(('Environment variable to distribute ({}) should follow '
+                        'the form: X=Y').format(env_var))
+    (env, var) = env_var.split('=', 1)
+    my_env[env] = var
+
+  Path("/tmp/tf_server_log").mkdir(parents=True, exist_ok=True)
+  log_file = open(
+      "/tmp/tf_server_log/server_{}.log".format(time.strftime("%Y%m%d-%H%M%S")),
+      "w")
   subprocess.Popen(
-      ["python", "-m", "torch_xla.core._xrt_run_server", sys.argv[1]],
+      ["python", "-m", "torch_xla.core._xrt_run_server", FLAGS.port],
       stdout=subprocess.PIPE,
-      stderr=subprocess.PIPE,
+      stderr=log_file,
+      env=my_env,
       start_new_session=True)

--- a/torch_xla/core/xrt_run_server.py
+++ b/torch_xla/core/xrt_run_server.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
   # Enable the basic logging by defualt
   my_env['TF_CPP_MIN_LOG_LEVEL'] = '0'
   my_env[
-      'TF_CPP_VMODULE'] = 'tpu_configuration_ops=1,tpu_execute_op=1,tpu_compile_op=1,tpu_compile_op_impl=1,tpu_compile_op_common=1,tpu_compile_ops=1,master=1'
+      'TF_CPP_VMODULE'] = 'tpu_configuration_ops=1,tpu_execute_op=1,tpu_compile_op=1,tpu_compile_op_impl=1,tpu_compile_op_common=1,tpu_compile_ops=1,master=1,computation_client=5'
 
   env_vars = list(FLAGS.env) if FLAGS.env else []
   for env_var in env_vars:
@@ -31,13 +31,15 @@ if __name__ == '__main__':
     (env, var) = env_var.split('=', 1)
     my_env[env] = var
 
-  Path("/tmp/tf_server_log").mkdir(parents=True, exist_ok=True)
-  log_file = open(
-      "/tmp/tf_server_log/server_{}.log".format(time.strftime("%Y%m%d-%H%M%S")),
-      "w")
+  Path("/tmp/xrt_server_log").mkdir(parents=True, exist_ok=True)
+  time_str = time.strftime("%Y%m%d-%H%M%S")
+  stderr_file = open("/tmp/xrt_server_log/server_err_{}.log".format(time_str),
+                     "w")
+  stdout_file = open("/tmp/xrt_server_log/server_out_{}.log".format(time_str),
+                     "w")
   subprocess.Popen(
       ["python", "-m", "torch_xla.core._xrt_run_server", FLAGS.port],
-      stdout=subprocess.PIPE,
-      stderr=log_file,
+      stdout=stdout_file,
+      stderr=stderr_file,
       env=my_env,
       start_new_session=True)

--- a/torch_xla/distributed/xla_dist.py
+++ b/torch_xla/distributed/xla_dist.py
@@ -362,7 +362,7 @@ class DistributedExecutor(object):
       if self.tpuvm_mode:
         # Start the local tf server if it is not already running.
         script.append([
-            'python', '-m', self.XRT_RUN_SERVER_CMD,
+            'python', '-m', self.XRT_RUN_SERVER_CMD, '--port',
             str(self.tpuvm_server_port)
         ])
       if self.docker_image:


### PR DESCRIPTION
When starting the server in a separate process, we still want to see the server side logging. It seems like with OSS TF, we can't pass the `--logdir` so I workaround it with redirect stderr of server process to a file under /tmp. `/tmp/tflogs` is filled with garbages so I used a different directory.