### PR TITLE
Revert "Fix code generation for new ScalarList type (#2816)"

### DIFF
--- a/scripts/gen.py
+++ b/scripts/gen.py
@@ -182,7 +182,6 @@ _TYPE_NSMAP = {
     'Tensor': 'at::Tensor',
     'TensorList': 'at::TensorList',
     'Scalar': 'at::Scalar',
-    'ScalarList': 'at::ScalarList',
     'Storage': 'at::Storage',
     'IntList': 'at::IntList',
     'IntArrayRef': 'at::IntArrayRef',


### PR DESCRIPTION
This reverts commit e537eed0f7ad7a33f698fde447770bc530c5fe32.

We decide not to introduce ScalarList as an alias for ArrayRef<Scalar>
but to use ArrayRef<Scalar> directly in
https://github.com/pytorch/pytorch/pull/53583.

The original commit is no longer needed.