### PR TITLE
On retries use hostname instead of Internal IPs

### DIFF
--- a/torch_xla/distributed/xla_dist.py
+++ b/torch_xla/distributed/xla_dist.py
@@ -192,7 +192,7 @@ class DistributedExecutor(object):
         '-i',
         '~/.ssh/google_compute_engine',
         local_path,
-        '{}@{}:{}'.format(os.getlogin(), client_worker.get_internal_ip(),
+        '{}@{}:{}'.format(os.getlogin(), client_worker.get_hostname(),
                           remote_path),
     ]
 
@@ -232,7 +232,7 @@ class DistributedExecutor(object):
         '-oStrictHostKeyChecking=no',
         '-i',
         '~/.ssh/google_compute_engine',
-        '{}@{}'.format(os.getlogin(), client_worker.get_internal_ip()),
+        '{}@{}'.format(os.getlogin(), client_worker.get_hostname()),
         '\'{}\''.format(remote_cmd),
     ]
 


### PR DESCRIPTION
In case instances don't use static internal IPs.