### PR TITLE
Only get length of loader when requested

### DIFF
--- a/torch_xla/distributed/parallel_loader.py
+++ b/torch_xla/distributed/parallel_loader.py
@@ -86,7 +86,6 @@ class ParallelLoader(object):
     self._devices = [torch.device(x) for x in devices]
     self._batchdim = batchdim
     self._batches_per_execution = batches_per_execution
-    self._per_device_samples = len(loader) // len(devices)
     self._done = False
     self._queues = dict()
     for device in self._devices:
@@ -115,7 +114,7 @@ class ParallelLoader(object):
     return PerDeviceLoader(self, torch.device(device))
 
   def per_device_samples(self):
-    return self._per_device_samples
+    return len(loader) // len(devices)
 
   def next_item(self, device):
     dqueue = self._queues[device]


### PR DESCRIPTION
Iterable datasets which don't have len aren't able to be used currently
even though user may not ask for length.

Fixes https://github.com/pytorch/xla/issues/2866

