### PR TITLE
pip install pgrep during build_torch_wheels.sh

### DIFF
--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -172,6 +172,7 @@ function install_and_setup_conda() {
   /usr/bin/yes | pip install lark-parser
   /usr/bin/yes | pip install cloud-tpu-client
   /usr/bin/yes | pip install tensorboardX
+  /usr/bin/yes | pip install pgrep
 }
 
 function build_and_install_torch() {


### PR DESCRIPTION
This should make `pgrep` available in the `pytorch` conda env that we use for running tests