### PR TITLE
Update clamp with tensor to use min max directly

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -27,7 +27,6 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_min_max_nan',  # XLA min/max ignores Nans.
         'test_min_max_binary_op_nan',  # XLA min/max ignores Nans.
         'test_copy_broadcast',
-        'test_clamp_xla',  # TODO: reenable.
     },
     'TestTensorDeviceOpsXLA': {
         'test_block_diag_scipy',  #FIXME: RuntimeError: Error while lowering: f32[1,6]{1,0} xla::unselect, dim=1, start=2, end=2, stride=0


### PR DESCRIPTION
The issue with the original implementional is that it can only handle one way broadcast (min/max -> input). For test cases like

```
            # Test broadcasting x                                                                                                                                                                                                       
            expect = x[..., :1].max(lb).min(ub)                                                                                                                                                                                         
            actual = x[..., :1].clamp(lb, ub)                                                                                                                                                                                           
            self.assertEqual(expect, actual) 
```

we will fail outright. There isn't a easy way to figure out the common broadcast-able shape for 2/3 tensors(There is a xla helper function but requires some hack). It might be easier to use `min` and `max` directly since xla will handle the binary op broadcasting for us.