### PR TITLE
pytorch core should be built with install instead of develop

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -62,7 +62,7 @@ pip install cloud-tpu-client
 
 # Install Pytorch without MKLDNN
 xla/scripts/apply_patches.sh
-python setup.py build develop
+python setup.py build install
 sccache --show-stats
 
 # Bazel doesn't work with sccache gcc. https://github.com/bazelbuild/bazel/issues/3642


### PR DESCRIPTION
Context: We have integration tests to cover the interaction between `pytorch/pytorch` and `pytorch/xla`, and these integration tests run on every PR in both the `pytorch/pytorch` and `pytorch/xla` repositories.

Right now the xla tests in `pytorch/pytorch` build pytorch using `python setup.py install`, but the xla tests in `pytorch/xla` build pytorch using `python setup.py develop`. That divergence can cause tests to pass on one repo but fail on the other (example [here](https://app.circleci.com/pipelines/github/pytorch/pytorch/319132/workflows/1fa4ce4d-3f02-4453-aa5d-2cdc4bd31bbf/jobs/13306791)).

In that specific case, the use of `python setup.py develop` adds the root pytorch directory to `sys.path`, which we shouldn't assume will always happen. So `python setup.py install` is probably the better way to build in CI.