### PR TITLE
Asynchronous Step Closures

### DIFF
--- a/test/args_parse.py
+++ b/test/args_parse.py
@@ -32,6 +32,7 @@ def parse_common_options(datadir=None,
   parser.add_argument('--fake_data', action='store_true')
   parser.add_argument('--tidy', action='store_true')
   parser.add_argument('--metrics_debug', action='store_true')
+  parser.add_argument('--async_closures', action='store_true')
   if opts:
     for name, aopts in opts:
       parser.add_argument(name, **aopts)

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -69,6 +69,7 @@ function run_all_tests {
   run_test python3 "$CDIR/test_mp_rendezvous.py"
   run_test python3 "$CDIR/test_mp_save.py"
   run_test python3 "$CDIR/test_mp_mesh_reduce.py"
+  run_test python3 "$CDIR/test_async_closures.py"
   run_test python3 "$CDIR/test_xla_dist.py"
   run_test python3 "$CDIR/test_profiler.py"
 }

--- a/test/test_async_closures.py
+++ b/test/test_async_closures.py
@@ -1,0 +1,91 @@
+"""Tests for xla_dist."""
+from __future__ import division
+from __future__ import print_function
+from threading import Event
+from time import sleep
+
+import unittest
+from unittest import mock
+
+import torch
+import torch_xla.core.xla_model as xm
+
+class AsyncClosuresTest(unittest.TestCase):
+
+  def test_synchronous(self):
+    flag = Event()
+    assert not flag.is_set()
+
+    def closure():
+      sleep(1)
+      assert not flag.is_set()
+      flag.set()
+
+    xm.add_step_closure(closure)
+    xm.mark_step()
+
+    # should not get to this part before closure is finished running
+    assert flag.is_set()
+
+  def test_asynchronous(self):
+    flag = Event()
+    assert not flag.is_set()
+
+    def closure():
+      sleep(1)
+      assert flag.is_set()
+
+    xm.add_step_closure(closure, run_async=True)
+    xm.mark_step()
+
+    # should get to this part and complete before closure is finished running
+    assert not flag.is_set()
+    flag.set()
+
+  def test_synchronous_exception(self):
+    flag = Event()
+    assert not flag.is_set()
+
+    try:
+      def closure():
+        flag.set()
+        raise RuntimeError("Simulating exception in closure")
+
+      xm.add_step_closure(closure)
+      xm.mark_step()
+
+      assert False  # Should not reach here
+    except RuntimeError as e:
+      assert flag.is_set(), "Should have caught exception from closure"
+   
+  def test_asynchronous_exception(self):
+    flag = Event()
+    assert not flag.is_set()
+
+    def closure1():
+      raise RuntimeError("Simulating exception in closure1")
+
+    xm.add_step_closure(closure1, run_async=True)
+    xm.mark_step()
+
+    sleep(1)
+
+    try:
+      def closure2():  # Should never execute
+        flag.set()
+
+      xm.add_step_closure(closure2, run_async=True)
+      xm.mark_step()
+
+      assert False  # Should not reach here
+    except RuntimeError as e:
+      # Should have caught exception from closure1
+      pass
+
+    assert not flag.is_set()
+    
+
+
+if __name__ == '__main__':
+  test = unittest.main()
+  sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/test_async_closures.py
+++ b/test/test_async_closures.py
@@ -10,6 +10,7 @@ from unittest import mock
 import torch
 import torch_xla.core.xla_model as xm
 
+
 class AsyncClosuresTest(unittest.TestCase):
 
   def test_synchronous(self):
@@ -47,6 +48,7 @@ class AsyncClosuresTest(unittest.TestCase):
     assert not flag.is_set()
 
     try:
+
       def closure():
         flag.set()
         raise RuntimeError("Simulating exception in closure")
@@ -57,7 +59,7 @@ class AsyncClosuresTest(unittest.TestCase):
       assert False  # Should not reach here
     except RuntimeError as e:
       assert flag.is_set(), "Should have caught exception from closure"
-   
+
   def test_asynchronous_exception(self):
     flag = Event()
     assert not flag.is_set()
@@ -71,6 +73,7 @@ class AsyncClosuresTest(unittest.TestCase):
     sleep(1)
 
     try:
+
       def closure2():  # Should never execute
         flag.set()
 
@@ -83,7 +86,6 @@ class AsyncClosuresTest(unittest.TestCase):
       pass
 
     assert not flag.is_set()
-    
 
 
 if __name__ == '__main__':

--- a/test/test_async_closures.py
+++ b/test/test_async_closures.py
@@ -1,13 +1,9 @@
-"""Tests for xla_dist."""
-from __future__ import division
-from __future__ import print_function
+"""Tests for asynchronous closures."""
 from threading import Event
 from time import sleep
 
 import unittest
-from unittest import mock
 
-import torch
 import torch_xla.core.xla_model as xm
 
 

--- a/test/test_train_mp_mnist.py
+++ b/test/test_train_mp_mnist.py
@@ -131,7 +131,7 @@ def train_mnist(flags, **kwargs):
       tracker.add(flags.batch_size)
       if step % flags.log_steps == 0:
         xm.add_step_closure(
-            _train_update, args=(device, step, loss, tracker, writer))
+            _train_update, args=(device, step, loss, tracker, writer), run_async=FLAGS.async_closures)
 
   def test_loop_fn(loader):
     total_samples = 0

--- a/test/test_train_mp_mnist.py
+++ b/test/test_train_mp_mnist.py
@@ -131,7 +131,9 @@ def train_mnist(flags, **kwargs):
       tracker.add(flags.batch_size)
       if step % flags.log_steps == 0:
         xm.add_step_closure(
-            _train_update, args=(device, step, loss, tracker, writer), run_async=FLAGS.async_closures)
+            _train_update,
+            args=(device, step, loss, tracker, writer),
+            run_async=FLAGS.async_closures)
 
   def test_loop_fn(loader):
     total_samples = 0

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -692,7 +692,7 @@ def add_step_closure(closure, args=(), run_async=False):
   Args:
     closure (callable): The function to be called.
     args (tuple): The arguments to be passed to the closure.
-    run_async: If True, run the closure asynchronously
+    run_async: If True, run the closure asynchronously.
   """
   devctx = _get_device_context()
   closures_type = 'async_step_closures' if run_async else 'step_closures'

--- a/torch_xla/utils/closures.py
+++ b/torch_xla/utils/closures.py
@@ -1,0 +1,72 @@
+import abc
+import queue
+import threading
+
+class ClosureHandler(abc.ABC):
+
+  def __init__(self):
+    pass
+
+  @abc.abstractmethod
+  def run(self, closure):
+    """Run closure function
+    
+    Args:
+      closure: callable function to run
+    """
+    pass
+
+  def run_all(self, closures):
+    for closure in closures:
+      self.run(closure)
+
+class AsyncClosureHandler(ClosureHandler):
+  """Handler for Asynchronous Step Closures
+
+  Args:
+    max_queue_size: The maximum length of the closure queue after which
+      the training loop will block until closures are evaluated.
+      By default, no limit on queue size
+  """
+
+  def __init__(self, max_queue_size=-1):
+    super().__init__()
+    self._closure_queue = queue.Queue(max_queue_size)
+    self._closure_exception = queue.Queue()
+    self._closure_event_loop = None
+
+  def start_event_loop(self):
+    """Start closure event loop if not started"""
+    if self._closure_event_loop is None:
+      def event_loop():
+        # Run loop until closure event is set and closure queue is empty
+        while not self._closure_queue.empty():
+          try:
+            closure = self._closure_queue.get(block=True, timeout=3)
+            closure()
+            self._closure_queue.task_done()
+          except queue.Empty:
+            pass
+          except Exception as e:
+            self._closure_exception.put(e)
+            break
+
+      self._closure_event_loop = threading.Thread(target=event_loop)
+      self._closure_event_loop.start()
+
+  def run(self, closure):
+    if (
+      self._closure_event_loop is None
+      or not self._closure_event_loop.is_alive()
+    ):
+      try:
+        e = self._closure_exception.get(block=False)
+        raise RuntimeError(
+          "Cannot run asynchronous closure due to previously raised exception"
+        ) from e
+      except queue.Empty:
+        self._closure_event_loop = None
+        self.start_event_loop()
+
+    self._closure_queue.put(closure, block=True)
+    return

--- a/torch_xla/utils/closures.py
+++ b/torch_xla/utils/closures.py
@@ -1,4 +1,5 @@
 import abc
+import os
 import queue
 import threading
 
@@ -28,13 +29,18 @@ class AsyncClosureHandler(ClosureHandler):
   Args:
     max_queue_size: The maximum length of the closure queue after which
       the training loop will block until closures are evaluated.
-      By default, no limit on queue size
+      By default, a reasonable limit of a maximum of 100 on the queue.
+      This value can be set using the `XLA_MAX_ASYNC_QUEUE` environment
+      variable.
   """
 
-  def __init__(self, max_queue_size=-1):
+  def __init__(self, max_queue_size=100):
     super().__init__()
-    self._closure_queue = queue.Queue(max_queue_size)
+    self._closure_queue = queue.Queue(
+        os.environ.get("XLA_MAX_ASYNC_QUEUE", max_queue_size))
     self._closure_exception = queue.Queue()
+    self._closure_lock = threading.Lock()
+    self._closure_event_loop_finished = threading.Event()
     self._closure_event_loop = None
 
   def start_event_loop(self):
@@ -43,31 +49,35 @@ class AsyncClosureHandler(ClosureHandler):
 
       def event_loop():
         # Run loop until closure event is set and closure queue is empty
-        while not self._closure_queue.empty():
+        while True:
           try:
             closure = self._closure_queue.get(block=True, timeout=3)
             closure()
             self._closure_queue.task_done()
           except queue.Empty:
-            pass
+            with self._closure_lock:
+              if self._closure_queue.empty():
+                self._closure_event_loop_finished.set()
+                return
           except Exception as e:
             self._closure_exception.put(e)
-            break
+            return
 
       self._closure_event_loop = threading.Thread(target=event_loop)
       self._closure_event_loop.start()
 
   def run(self, closure):
-    if (self._closure_event_loop is None or
-        not self._closure_event_loop.is_alive()):
-      try:
-        e = self._closure_exception.get(block=False)
-        raise RuntimeError(
-            "Cannot run asynchronous closure due to previously raised exception"
-        ) from e
-      except queue.Empty:
-        self._closure_event_loop = None
-        self.start_event_loop()
+    with self._closure_lock:
+      self._closure_queue.put(closure, block=True)
+      if (self._closure_event_loop is None or
+          not self._closure_event_loop.is_alive()):
+        try:
+          e = self._closure_exception.get(block=False)
+          raise RuntimeError(
+              "Cannot run asynchronous closure due to previously raised exception"
+          ) from e
+        except queue.Empty:
+          self._closure_event_loop = None
+          self.start_event_loop()
 
-    self._closure_queue.put(closure, block=True)
     return

--- a/torch_xla/utils/closures.py
+++ b/torch_xla/utils/closures.py
@@ -2,6 +2,7 @@ import abc
 import queue
 import threading
 
+
 class ClosureHandler(abc.ABC):
 
   def __init__(self):
@@ -19,6 +20,7 @@ class ClosureHandler(abc.ABC):
   def run_all(self, closures):
     for closure in closures:
       self.run(closure)
+
 
 class AsyncClosureHandler(ClosureHandler):
   """Handler for Asynchronous Step Closures
@@ -38,6 +40,7 @@ class AsyncClosureHandler(ClosureHandler):
   def start_event_loop(self):
     """Start closure event loop if not started"""
     if self._closure_event_loop is None:
+
       def event_loop():
         # Run loop until closure event is set and closure queue is empty
         while not self._closure_queue.empty():
@@ -55,14 +58,12 @@ class AsyncClosureHandler(ClosureHandler):
       self._closure_event_loop.start()
 
   def run(self, closure):
-    if (
-      self._closure_event_loop is None
-      or not self._closure_event_loop.is_alive()
-    ):
+    if (self._closure_event_loop is None or
+        not self._closure_event_loop.is_alive()):
       try:
         e = self._closure_exception.get(block=False)
         raise RuntimeError(
-          "Cannot run asynchronous closure due to previously raised exception"
+            "Cannot run asynchronous closure due to previously raised exception"
         ) from e
       except queue.Empty:
         self._closure_event_loop = None


### PR DESCRIPTION
This pull request contains the implementation for asynchronous step closures. Currently, the PyTorch/XLA repo only implements synchronous closures. Asynchronous step closures allow the training loop to never have to stop to run the step closures. While the next iteration of training continues, the closures are run separately in another thread.

### Usage

By default, the step closures have been left turned off in order to prevent breaking any existing usages. However, for anyone that wants to turn them on, they can simply set the `run_async` to be `True`, e.g.
```python
xm.add_step_closure(closure, run_async=True)
```
and the closures will automatically be run asynchronously the next time `xm.optimizer_step()` or `xm.mark_step()` is called. 

### Performance Benefits

The initial need for asynchronous closures came from a private use case where the closures that were being run were large enough that they would often hold up the training loop. Asynchronous step closures helped to eliminate this barrier.

I have put together a basic timing test to demonstrate the performance benefits of the asynchronous step closures.

Using the pre-existing `test_train_mp_mnist.py` test in the `test/` directory, I ran 2 epochs of training and testing of the mnist model where `log_steps=5`:
```bash
python test/test_train_mp_mnist.py --num_epochs=2 --log_steps=5
python test/test_train_mp_mnist.py --num_epochs=2 --log_steps=5 --async_closures
```
Note: I added the command line argument `--async_closures` to enable the async closures from the command line.

The timing results of this test are as follows:

| Closure Type   | Time (mean ± std) (seconds) |
| -------------- | ---------------------------- |
| Synchronous   | 26.7 ± 0.2                                 |
| Asynchronous | 25.76 ± 0.2                               |

Now, the asynchronous test results are faster, but only by around one second. However, consider that this test was only for 2 epochs and logging every 5 steps. In cases where there are far more epochs, or if the client wants to log every step the benefits of the asynchronous closures become more apparent. In addition, the closures that are run in this test are fairly basic and don't take up too much time. Much like the private use case for which the asynchronous closures were originally developed, the client could choose to run closures that are far more complex and take up significantly more time. This is not even to mention that the above tests were conducted with the CPU. In scenarios where GPU(s) or other hardware accelerators are used, the extra time take by the closures is more significant.

### Correctness

A number of tests were also included to test for basic correctness as well.
