### PR TITLE
Disable some TPU python tests

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -343,6 +343,8 @@ DISABLED_TORCH_TESTS_TPU_ONLY = {
     'TestNNDeviceTypeXLA': {
         'test_embedding_bag_empty_input_xla',  # server side crash
         'test_EmbeddingBag_empty_per_sample_weights_and_offsets_xla',  # server side crash
+        'test_softplus_low_threshold',  # grad check failure
+        'test_Dropout',  # too slow
     },
 
     # test_type_promotion.py


### PR DESCRIPTION
Manually verified that python op tests passed on TPU with this change. Looking into CPP test failures.