### PR TITLE
Add curl which is used (seems missing) in build libs script for Docker build:

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ ARG cloud_build="false"
 ARG release_version="nightly"
 
 RUN apt-get update
-RUN apt-get install -y git sudo python-pip python3-pip
+RUN apt-get install -y git sudo python-pip python3-pip curl
 RUN git clone https://github.com/pytorch/pytorch
 
 # To get around issue of Cloud Build with recursive submodule update


### PR DESCRIPTION
```
 ---> 70be86e4a604
Step 19/25 : RUN cd /pytorch && bash xla/scripts/build_torch_wheels.sh ${python_version} ${release_version}
 ---> Running in 6081d42d01cd
+ PYTHON_VERSION=3.6
+ RELEASE_VERSION=nightly
+ DEFAULT_PYTHON_VERSION=3.7
+ DEBIAN_FRONTEND=noninteractive
+ main
+ install_and_setup_conda
+ test -d /root/anaconda3
+ CONDA_VERSION=5.3.1
+ curl -O https://repo.anaconda.com/archive/Anaconda3-5.3.1-Linux-x86_64.sh
xla/scripts/build_torch_wheels.sh: line 151: curl: command not found
```