### PR TITLE
Make AMP test not run on TPU

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -10142,6 +10142,10 @@ TEST_F(AtenXlaTensorTest, TestEmbeddingBackward) {
 }
 
 TEST_F(AtenXlaTensorTest, TestAmpForeachNonFiniteCheckAndUnscale) {
+  DeviceType hw_type = GetDefaultDevice()->hw_type;
+  if (hw_type != DeviceType::GPU && hw_type != DeviceType::CPU) {
+    return;
+  }
   torch::Tensor grads0 =
       torch::tensor({1, 2, 3, 4}, torch::TensorOptions(torch::kFloat));
   torch::Tensor grads1 = torch::tensor({1.0, 2.0, std::nan("1"), 4.0},
@@ -10175,6 +10179,10 @@ TEST_F(AtenXlaTensorTest, TestAmpForeachNonFiniteCheckAndUnscale) {
 }
 
 TEST_F(AtenXlaTensorTest, TestAmpUpdateScale) {
+  DeviceType hw_type = GetDefaultDevice()->hw_type;
+  if (hw_type != DeviceType::GPU && hw_type != DeviceType::CPU) {
+    return;
+  }
   torch::Tensor growth_tracker =
       torch::scalar_tensor(0, torch::TensorOptions(torch::kInt32));
   torch::Tensor current_scale =

--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -326,6 +326,7 @@ DISABLED_TORCH_TESTS_TPU_ONLY = {
         'test_take_xla_bfloat16',  # (TPU) -6.53125 vs. -6.5625
         'test_multinomial_constraints',  # server side crash
         'test_multinomial_invalid_distribution',  # server side crash
+        'test_multinomial_invalid_xla',  # TODO: only fail on xlml
         'test_softplus_low_threshold_xla',  # server side crash
         'test_put_xla_float64',  # slow on TPU (~16 min)
         'test_put_xla_int16',  # slow on TPU (~13 min)


### PR DESCRIPTION
AMP will error out on TPU(intentionally) so we should disable related tests on TPU.