### PR TITLE
Move xla test commands to a function.

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -4,11 +4,10 @@ set -ex
 
 source ./env
 source .circleci/common.sh
-clone_pytorch
+PYTORCH_DIR=/tmp/pytorch
+XLA_DIR=$PYTORCH_DIR/xla
+clone_pytorch $PYTORCH_DIR $XLA_DIR
 source "$PYTORCH_DIR/.jenkins/pytorch/common_utils.sh"
-
-# System default cmake 3.10 cannot find mkl, so point it to the right place.
-export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}
 
 SCCACHE="$(which sccache)"
 if [ -z "${SCCACHE}" ]; then

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -2,10 +2,45 @@
 
 set -ex
 
-export PYTORCH_DIR=/tmp/pytorch
-export XLA_DIR="$PYTORCH_DIR/xla"
+# System default cmake 3.10 cannot find mkl, so point it to the right place.
+export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}
 
 function clone_pytorch() {
+  PYTORCH_DIR=$1
+  XLA_DIR=$2
   git clone --quiet https://github.com/pytorch/pytorch.git "$PYTORCH_DIR"
   cp -r "$PWD" "$XLA_DIR"
+}
+
+function run_torch_xla_tests() {
+  PYTORCH_DIR=$1
+  XLA_DIR=$2
+  if [ -x "$(command -v nvidia-smi)" ]; then
+    export GPU_NUM_DEVICES=2
+  else
+    export XRT_DEVICE_MAP="CPU:0;/job:localservice/replica:0/task:0/device:XLA_CPU:0"
+    XLA_PORT=$(shuf -i 40701-40999 -n 1)
+    export XRT_WORKERS="localservice:0;grpc://localhost:$XLA_PORT"
+  fi
+  export PYTORCH_TESTING_DEVICE_ONLY_FOR="xla"
+
+  pushd $XLA_DIR
+    echo "Running Python Tests"
+    ./test/run_tests.sh
+
+    # echo "Running MNIST Test"
+    # python test/test_train_mp_mnist.py --tidy
+    # if [ -x "$(command -v nvidia-smi)" ]; then
+    #   python test/test_train_mp_mnist_amp.py --fake_data
+    # fi
+
+    pushd test/cpp
+    CC=clang-9 CXX=clang++-9 ./run_tests.sh
+
+    if ! [ -x "$(command -v nvidia-smi)"  ]
+    then
+      ./run_tests.sh -X early_sync -F AtenXlaTensorTest.TestEarlySyncLiveTensors -L""
+    fi
+    popd
+  popd
 }

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -3,33 +3,8 @@
 set -ex
 
 source ./xla_env
+source .circleci/common.sh
 
-if [ -x "$(command -v nvidia-smi)" ]; then
-  export GPU_NUM_DEVICES=2
-else
-  export XRT_DEVICE_MAP="CPU:0;/job:localservice/replica:0/task:0/device:XLA_CPU:0"
-  export XRT_WORKERS="localservice:0;grpc://localhost:40934"
-fi
-
-export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}
-export PYTORCH_TESTING_DEVICE_ONLY_FOR="xla"
-
-cd /tmp/pytorch/xla
-
-echo "Running Python Tests"
-./test/run_tests.sh
-
-# echo "Running MNIST Test"
-# python test/test_train_mp_mnist.py --tidy
-# if [ -x "$(command -v nvidia-smi)" ]; then
-#   python test/test_train_mp_mnist_amp.py --fake_data
-# fi
-
-echo "Running C++ Tests"
-pushd test/cpp
-./run_tests.sh
-if ! [ -x "$(command -v nvidia-smi)"  ]
-then
-  ./run_tests.sh -X early_sync -F AtenXlaTensorTest.TestEarlySyncLiveTensors -L""
-fi
-popd
+PYTORCH_DIR=/tmp/pytorch
+XLA_DIR=$PYTORCH_DIR/xla
+run_torch_xla_tests $PYTORCH_DIR $XLA_DIR


### PR DESCRIPTION
Plan is to move these commands into a function so that it can be reused in pytorch/pytorch CI as well. This used to be a common source of "passed one CI but fails on the other". 