### PR TITLE
Add  `XLA_DOWNCAST_BF16` and `XLA_DOWNCAST_FP16` 

### DIFF
--- a/API_GUIDE.md
+++ b/API_GUIDE.md
@@ -178,12 +178,13 @@ PyTorch/XLA can use the
 [bfloat16](https://en.wikipedia.org/wiki/Bfloat16_floating-point_format)
 datatype when running on TPUs. In fact, PyTorch/XLA handles float types
 (`torch.float` and `torch.double`) differently on TPUs. This behavior is
-controlled by the `XLA_USE_BF16` environment variable:
+controlled by the `XLA_USE_BF16` and `XLA_DOWNCAST_BF16` environment variable:
 
 - By default both `torch.float` and `torch.double` are
 `torch.float` on TPUs.
 - If `XLA_USE_BF16` is set, then `torch.float` and `torch.double` are both
 `bfloat16` on TPUs.
+- If `XLA_DOWNCAST_BF16` is set, then `torch.float` is `bfloat16` on TPUs and `torch.double` is `float32` on TPUs.
 - If a PyTorch tensor has `torch.bfloat16` data type, this will be directly
 mapped to the TPU `bfloat16` (XLA `BF16` primitive type).
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -41,6 +41,16 @@ function run_opbyop {
   XLA_GET_TENSORS_OPBYOP=1 XLA_SYNC_TENSORS_OPBYOP=1 run_test "$@"
 }
 
+function run_use_bf16 {
+  echo "Running with XLA_USE_BF16: $@"
+  XLA_USE_BF16=1 run_test "$@"
+}
+
+function run_downcast_bf16 {
+  echo "Running with XLA_DOWNCAST_BF16: $@"
+  XLA_DOWNCAST_BF16=1 run_test "$@"
+}
+
 function run_dynamic {
   if [[ "$TPUVM_MODE" == "1" ]]; then
     run_test "$@"
@@ -72,6 +82,8 @@ function run_all_tests {
   run_test python3 "$CDIR/test_async_closures.py"
   run_test python3 "$CDIR/test_xla_dist.py"
   run_test python3 "$CDIR/test_profiler.py"
+  run_use_bf16 python3 "$CDIR/test_data_type.py"
+  run_downcast_bf16 python3 "$CDIR/test_data_type.py"
 }
 
 if [ "$LOGFILE" != "" ]; then

--- a/test/test_data_type.py
+++ b/test/test_data_type.py
@@ -1,0 +1,49 @@
+import os
+
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.utils.utils as xu
+import unittest
+
+
+class XlaDataTypeTest(unittest.TestCase):
+
+  def test_datatype_f32(self):
+    t1 = torch.tensor([2.0, 3.0], dtype=torch.float, device=xm.xla_device())
+    t2 = torch.tensor([2.0, 3.0], dtype=torch.float, device=xm.xla_device())
+    t3 = torch.div(t1, t2, rounding_mode='floor')
+    assert t3.dtype == torch.float
+
+    hlo_text = torch_xla._XLAC._get_xla_tensors_text([t3])
+    device_data_hlo = hlo_text.split('\n')[1]
+    assert 'xla::device_data' in device_data_hlo
+    if os.getenv('XLA_USE_BF16') or os.getenv('XLA_DOWNCAST_BF16'):
+      assert 'bf16' in device_data_hlo
+    elif os.getenv('XLA_USE_FP16') or os.getenv('XLA_DOWNCAST_FP16'):
+      assert 'f16' in device_data_hlo
+    else:
+      assert 'f32' in device_data_hlo
+
+  def test_datatype_f64(self):
+    t1 = torch.tensor([2.0, 3.0], dtype=torch.double, device=xm.xla_device())
+    t2 = torch.tensor([2.0, 3.0], dtype=torch.double, device=xm.xla_device())
+    t3 = torch.div(t1, t2, rounding_mode='floor')
+    assert t3.dtype == torch.double
+
+    hlo_text = torch_xla._XLAC._get_xla_tensors_text([t3])
+    device_data_hlo = hlo_text.split('\n')[1]
+    assert 'xla::device_data' in device_data_hlo
+    if os.getenv('XLA_USE_BF16'):
+      assert 'bf16' in device_data_hlo
+    elif os.getenv('XLA_USE_FP16'):
+      assert 'f16' in device_data_hlo
+    elif os.getenv('XLA_DOWNCAST_BF16') or os.getenv('XLA_DOWNCAST_FP16'):
+      assert 'f32' in device_data_hlo
+    else:
+      assert 'f64' in device_data_hlo
+
+
+if __name__ == '__main__':
+  test = unittest.main()
+  sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -38,6 +38,22 @@ bool ShouldUseF16() {
   return use_fp16;
 }
 
+bool ShouldDowncastToBF16() {
+  bool downcast_bf16 = xla::sys_util::GetEnvBool("XLA_DOWNCAST_BF16", false);
+  if (downcast_bf16) {
+    TF_LOG(INFO) << "Downcasting floating point values, F64->F32, F32->BF16";
+  }
+  return downcast_bf16;
+}
+
+bool ShouldDowncastToF16() {
+  bool downcast_fp16 = xla::sys_util::GetEnvBool("XLA_DOWNCAST_FP16", false);
+  if (downcast_fp16) {
+    TF_LOG(INFO) << "Downcasting floating point values, F64->F32, F32->FP16";
+  }
+  return downcast_fp16;
+}
+
 bool ShouldUse32BitLong() {
   bool use_32bit_long = xla::sys_util::GetEnvBool("XLA_USE_32BIT_LONG", false);
   if (use_32bit_long) {
@@ -54,6 +70,16 @@ bool UseBF16() {
 bool UseF16() {
   static bool use_fp16 = ShouldUseF16();
   return use_fp16;
+}
+
+bool DowncastBF16() {
+  static bool downcast_bf16 = ShouldDowncastToBF16();
+  return downcast_bf16;
+}
+
+bool DowncastF16() {
+  static bool downcast_fp16 = ShouldDowncastToF16();
+  return downcast_fp16;
 }
 
 bool Use32BitLong() {
@@ -854,11 +880,14 @@ xla::Shape CreateComputationShapeFromTensor(const at::Tensor& tensor,
 at::ScalarType TensorTypeFromXlaType(xla::PrimitiveType xla_type) {
   switch (xla_type) {
     case xla::PrimitiveType::BF16:
-      return UseBF16() ? at::ScalarType::Float : at::ScalarType::BFloat16;
+      return UseBF16() || DowncastBF16() ? at::ScalarType::Float
+                                         : at::ScalarType::BFloat16;
     case xla::PrimitiveType::F16:
-      return UseF16() ? at::ScalarType::Float : at::ScalarType::Half;
+      return UseF16() || DowncastF16() ? at::ScalarType::Float
+                                       : at::ScalarType::Half;
     case xla::PrimitiveType::F32:
-      return at::ScalarType::Float;
+      return DowncastBF16() || DowncastF16() ? at::ScalarType::Double
+                                             : at::ScalarType::Float;
     case xla::PrimitiveType::F64:
       return at::ScalarType::Double;
     case xla::PrimitiveType::PRED:
@@ -927,13 +956,17 @@ xla::PrimitiveType GetDevicePrimitiveType(xla::PrimitiveType type,
       if (UseBF16()) {
         return xla::PrimitiveType::BF16;
       }
+      if (DowncastBF16() || DowncastF16()) {
+        return xla::PrimitiveType::F32;
+      }
       return xla_device.hw_type != DeviceType::TPU ? xla::PrimitiveType::F64
                                                    : xla::PrimitiveType::F32;
     case xla::PrimitiveType::F32:
-      if (UseF16()) {
+      if (UseF16() || DowncastF16()) {
         return xla::PrimitiveType::F16;
       }
-      return UseBF16() ? xla::PrimitiveType::BF16 : xla::PrimitiveType::F32;
+      return UseBF16() || DowncastBF16() ? xla::PrimitiveType::BF16
+                                         : xla::PrimitiveType::F32;
     case xla::PrimitiveType::U16:
       return xla_device.hw_type != DeviceType::TPU ? xla::PrimitiveType::U16
                                                    : xla::PrimitiveType::U32;


### PR DESCRIPTION
This is to solve the issue where with `XLA_USE_BF16` all tensors are casted to `BF16` and make many metric / tracking / etc values that use tensors unusable.