### PR TITLE
Change test order

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -83,6 +83,11 @@ function run_all_tests {
   run_test python3 "$CDIR/test_xla_dist.py"
   run_test python3 "$CDIR/test_profiler.py"
   run_downcast_bf16 python3 "$CDIR/test_data_type.py"
+  # `run_use_bf16` should be run after the `run_downcast_bf16` version.
+  # In XLML test there seems to be an env var leakage where `XLA_USE_BF16=1`
+  # will be picked up by `test_data_type.py` (but not the C++ code) when we
+  # run the `run_use_bf16` version and causing test to expect `bf16` for `f64`
+  # data.
   run_use_bf16 python3 "$CDIR/test_data_type.py"
 }
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -82,8 +82,8 @@ function run_all_tests {
   run_test python3 "$CDIR/test_async_closures.py"
   run_test python3 "$CDIR/test_xla_dist.py"
   run_test python3 "$CDIR/test_profiler.py"
-  run_use_bf16 python3 "$CDIR/test_data_type.py"
   run_downcast_bf16 python3 "$CDIR/test_data_type.py"
+  run_use_bf16 python3 "$CDIR/test_data_type.py"
 }
 
 if [ "$LOGFILE" != "" ]; then


### PR DESCRIPTION
For some reason in the xlml test `run_downcast_bf16 python3 "$CDIR/test_data_type.py"` failed because python test think `XLA_USE_BF16` is set which has higher priority than `XLA_DOWNCAST_BF16` hence test expect the data type to be casted to `bf16`.  I am guessing this is due to `run_use_bf16 python3 "$CDIR/test_data_type.py"`'s env var somehow leak to the next test. Swap the order of these two test should work around this issue for now. I am not able to repo this issue on my dev machne and TPU machine.