### PR TITLE
fix transpose_

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -197,8 +197,6 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_expand_as_view',
         'test_expand_view',
         'test_reshape_nonview',
-        'test_t_inplace_view',  # FIXME
-        'test_transpose_inplace_view',  # FIXME
         'test_unfold_view',
     },
 

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -159,12 +159,6 @@ NodePtr ReluOp(const Value& input) {
       std::move(lower_fn));
 }
 
-NodePtr TransposeOp(const Value& input, xla::int64 dim0, xla::int64 dim1) {
-  return MakeNode<Permute>(input, XlaHelpers::MakeTransposePermutation(
-                                      /*dim0=*/dim0, /*dim1=*/dim1,
-                                      /*rank=*/input.shape().rank()));
-}
-
 NodePtr HardSigmoid(const Value& input) {
   auto lower_fn = [](const Node& node, LoweringContext* loctx) -> XlaOpVector {
     xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -113,8 +113,6 @@ NodePtr Fmod(const Value& dividend, const Value& divisor);
 
 NodePtr Not(const Value& input);
 
-NodePtr TransposeOp(const Value& input, xla::int64 dim0, xla::int64 dim1);
-
 NodePtr HardSigmoid(const Value& input);
 
 NodePtr HardSigmoidBackward(const Value& grad_output, const Value& input);

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -801,8 +801,8 @@ void XLATensor::ModifyCurrentView(ViewInfo view_info) const {
   // in place, we need to turn this existing tensor into a view.
   ir::Value ir_value = GetIrValue();
   std::shared_ptr<Alias> alias = std::make_shared<Alias>(ir_value);
-  data()->view = std::make_shared<View>(ir_value.shape(), alias,
-                                        std::move(view_info));
+  data()->view =
+      std::make_shared<View>(ir_value.shape(), alias, std::move(view_info));
   AssignIrValue(ir::Value());
 }
 

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -792,6 +792,20 @@ void XLATensor::SetSubView(ViewInfo view_info) const {
   data()->generation += 1;
 }
 
+void XLATensor::ModifyCurrentView(ViewInfo view_info) const {
+  if (data()->view != nullptr) {
+    data()->view = data()->view->CreateSubView(view_info.shape, view_info);
+    return;
+  }
+  // This node is not a view. Since this function is meant to modify a view
+  // in place, we need to turn this existing tensor into a view.
+  ir::Value ir_value = GetIrValue();
+  std::shared_ptr<Alias> alias = std::make_shared<Alias>(ir_value);
+  data()->view = std::make_shared<View>(ir_value.shape(), alias,
+                                        std::move(view_info));
+  AssignIrValue(ir::Value());
+}
+
 std::shared_ptr<View> XLATensor::CreateView(ViewInfo view_info) const {
   if (data()->view != nullptr) {
     return data()->view->CreateSubView(view_info.shape, view_info);

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -1258,6 +1258,7 @@ class XLATensor {
                                    ir::Value ir_value) const;
 
   void SetSubView(ViewInfo view_info) const;
+  void ModifyCurrentView(ViewInfo view_info) const;
   std::shared_ptr<View> CreateView(ViewInfo view_info) const;
   XLATensor CreateViewTensor(ViewInfo view_info) const;
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2543,7 +2543,11 @@ XLATensor XLATensor::transpose(const XLATensor& input, xla::int64 dim0,
 }
 
 void XLATensor::transpose_(XLATensor& input, xla::int64 dim0, xla::int64 dim1) {
-  input.SetIrValue(ir::ops::TransposeOp(input.GetIrValue(), dim0, dim1));
+  auto input_shape = input.shape();
+  auto permute_dims = XlaHelpers::MakeTransposePermutation(
+      /*dim0=*/dim0, /*dim1=*/dim1, /*rank=*/input_shape.get().rank());
+  ViewInfo view_info(ViewInfo::Type::kPermute, input_shape, permute_dims);
+  return input.ModifyCurrentView(std::move(view_info));
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::triangular_solve(


### PR DESCRIPTION
This should fix the `transpose_` tests that were failing and got removed in https://github.com/pytorch/xla/pull/3007. I used this as an opportunity to spend some time trying to get a better understanding of how view replaying works in pytorch/xla.

**How view/inplace works in pytorch/xla (as I understand it)**
Whenever you construct a view in pt/xla, you're creating a new `XLATensor`. We need to make sure that all of the `XLATensor` objects that correspond to views of the same underlying tensor are "aware" of each other, since if one gets modified in place, the others might also need those modifications too.

It looks like the way that happens is through a shared `Alias` object. Each `XLATensor` that has a view contains a `View` field (stored in `data()->view`), and all related views hold a shared pointer to the same `Alias` object. Getting the final IR of a view corresponds to looking up the alias, generating IR to apply any changes that we need to make to it from on any other views that were mutated, and finally applying whatever shape transformations that the current view made.

It looks like `Alias::SyncUpdateOperations()` ([link](https://github.com/pytorch/xla/blob/4367aa7a88a9e96c09331688bed45eb3e4af24e5/torch_xla/csrc/view.cpp#L179)) is responsible for applying each mutation from all of the relevant views. It does that by reshaping the underlying IR to whatever the view sees, applying the mutation, and undoing the reshape to get whatever the change to the base IR is. Then, to get the final value of a view when we're materializing it, we take the updated IR, which is now in its base form, and apply the shape transformations relevant to the current view, which happens here: https://github.com/pytorch/xla/blob/4367aa7a88a9e96c09331688bed45eb3e4af24e5/torch_xla/csrc/view.cpp#L216.

**This change**
`torch.transpose_` is weird because it's both a view and mutation. I interpret that to mean that it mutates the metadata on the existing tensor. So for a normal `at::Tensor`, that would correspond to changing the strides of the tensor in-place. For an `XLATensor`, I think that corresponds to taking the current view that's linked to the `XLATensor`, and giving it a brand new one that contains the original list of shape transformations along with the new one. If the `XLATensor` doesn't have a view yet, we give it one (without generating a new `XLATensor`).

I did that by adding a new method, `XLATensor::ModifyCurrentView`. I'm not sure if this is overkill just to handle `transpose_`, but it might be useful in case there are any other inplace-view ops.

For the following code snippet:
```
device = xm.xla_device()
a = torch.ones(2, 2, device=device)
b = a.view_as(a).t_()
b[0, 1] = 0
print(torch_xla._XLAC._get_xla_tensors_text([a]))
```

The original outputted IR was this:
```
IR {
  %0 = f32[] prim::Constant(), value=0
  %1 = f32[1]{0} aten::view(%0), output_size=(1)
  %2 = f32[] prim::Constant(), value=1
  %3 = f32[2,2]{1,0} aten::expand(%2), size=(2, 2)
  %4 = f32[2,2]{1,0} aten::view(%3), output_size=(2, 2)
  %5 = f32[2,2]{0,1} aten::permute(%4), dims=(1, 0)
  %6 = f32[2,2]{1,0} aten::view(%5), output_size=(2, 2)
  %7 = f32[2,2]{1,0} aten::view(%6), output_size=(2, 2)
  %8 = f32[1,2]{1,0} xla::generic_slice(%7), base_indices=(0, 0), sizes=(1, 2)
  %9 = f32[2]{0} aten::view(%8), output_size=(2)
  %10 = f32[2]{0} xla::update_slice(%9, %1), base_indices=(1)
  %11 = f32[1,2]{1,0} aten::view(%10), output_size=(1, 2)
  %12 = f32[2,2]{1,0} xla::update_slice(%7, %11), base_indices=(0, 0)
  %13 = f32[2,2]{1,0} aten::view(%12), output_size=(2, 2), ROOT=0
}
```

After this change, the outputted IR looks like this:
```
IR {
  %0 = f32[] prim::Constant(), value=0
  %1 = f32[1]{0} aten::view(%0), output_size=(1)
  %2 = f32[] prim::Constant(), value=1
  %3 = f32[2,2]{1,0} aten::expand(%2), size=(2, 2)
  %4 = f32[2,2]{1,0} aten::view(%3), output_size=(2, 2)
  %5 = f32[2,2]{0,1} aten::permute(%4), dims=(1, 0)
  %6 = f32[1,2]{1,0} xla::generic_slice(%5), base_indices=(0, 0), sizes=(1, 2)
  %7 = f32[2]{0} aten::view(%6), output_size=(2)
  %8 = f32[2]{0} xla::update_slice(%7, %1), base_indices=(1)
  %9 = f32[1,2]{1,0} aten::view(%8), output_size=(1, 2)
  %10 = f32[2,2]{0,1} xla::update_slice(%5, %9), base_indices=(0, 0)
  %11 = f32[2,2]{1,0} aten::permute(%10), dims=(1, 0)
  %12 = f32[2,2]{1,0} aten::view(%11), output_size=(2, 2), ROOT=0
}
```

You can see a second `aten::permute()` node that un-does the original `aten::permute`, which corresponds to the view replay logic  at https://github.com/pytorch/xla/blob/4367aa7a88a9e96c09331688bed45eb3e4af24e5/torch_xla/csrc/view.cpp#L72.