### PR TITLE
Wrap tensorboardx install with try/except.

### DIFF
--- a/torch_xla/test/test_utils.py
+++ b/torch_xla/test/test_utils.py
@@ -101,11 +101,17 @@ def get_summary_writer(logdir):
     Instance of Tensorboard SummaryWriter.
   """
   if logdir:
-    from tensorboardX import SummaryWriter
-    writer = SummaryWriter(log_dir=logdir)
-    write_to_summary(
-        writer, 0, dict_to_write={'TensorboardStartTimestamp': time.time()})
-    return writer
+    try:
+      from tensorboardX import SummaryWriter
+      writer = SummaryWriter(log_dir=logdir)
+      write_to_summary(
+          writer, 0, dict_to_write={'TensorboardStartTimestamp': time.time()})
+      return writer
+    except Exception as e:
+      print("Failed to initialize Tensorboard SummaryWriter: %s" % str(e),
+            flush=True)
+      return None
+
 
 
 def now(format='%H:%M:%S'):


### PR DESCRIPTION
Tested: ran new code on 2VM setup once with tensorboardx installed and once without. Either case worked (this was `test_train_mp_mnist.py`)