### PR TITLE
Add fp16 support for ARange op

### DIFF
--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -440,10 +440,10 @@ NodePtr ARange(const at::Scalar& start, const at::Scalar& end,
           static_cast<tensorflow::bfloat16>(step.toFloat()));
       break;
     case xla::PrimitiveType::F16:
-      values = XlaHelpers::Range<xla::half>(
-          static_cast<xla::half>(start.toHalf()),
-          static_cast<xla::half>(end.toHalf()),
-          static_cast<xla::half>(step.toHalf()));
+      values =
+          XlaHelpers::Range<xla::half>(static_cast<xla::half>(start.toHalf()),
+                                       static_cast<xla::half>(end.toHalf()),
+                                       static_cast<xla::half>(step.toHalf()));
       break;
     case xla::PrimitiveType::F32:
       values = XlaHelpers::Range<float>(start.toFloat(), end.toFloat(),

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -439,6 +439,12 @@ NodePtr ARange(const at::Scalar& start, const at::Scalar& end,
           static_cast<tensorflow::bfloat16>(end.toFloat()),
           static_cast<tensorflow::bfloat16>(step.toFloat()));
       break;
+    case xla::PrimitiveType::F16:
+      values = XlaHelpers::Range<xla::half>(
+          static_cast<xla::half>(start.toHalf()),
+          static_cast<xla::half>(end.toHalf()),
+          static_cast<xla::half>(step.toHalf()));
+      break;
     case xla::PrimitiveType::F32:
       values = XlaHelpers::Range<float>(start.toFloat(), end.toFloat(),
                                         step.toFloat());


### PR DESCRIPTION
The ARange op defined in csrc/ops/ops.cpp does not support dtype of float16, see issue https://github.com/pytorch/xla/issues/3025. This PR fix this.