### PR TITLE
Disable test_cov on TPU due to precision issue

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -335,6 +335,7 @@ DISABLED_TORCH_TESTS_TPU_ONLY = {
         'test_put_xla_int32',  # slow on TPU (~22 min)
         'test_put_xla_int64',  # slow on TPU (~15 min)
         'test_put_xla_int8',  # slow on TPU (~15 min)
+        'test_cov_xla',  # precision (9.53674e-07 vs 0)
     },
 
     # test_indexing.py


### PR DESCRIPTION
Repo script
```
import torch
import torch_xla
import torch_xla.core.xla_model as xm
import torch_xla.distributed.xla_multiprocessing as xmp
import torch_xla.core.functions as xf
import torch_xla.debug.metrics as met
import time

device = xm.xla_device()
for device in [xm.xla_device(), 'cpu']:
  t = torch.tensor([[3],[-9]], device=device, dtype=torch.int32)
  fweights = torch.tensor([2], device=device)
  aweights = torch.tensor([6.5751552582], device=device)
  correction = 2
  res = torch.cov(t, correction=correction, fweights=fweights, aweights=aweights)
  print(res)
```

With this input, `norm factor` is `9.53674e-07` on XLA::TPU but `0` on CPU(same on XLA:CPU and XLA:GPU). This result in TPU `cov` return `0` while CPU returns `nan`. It is a precision issue, we can skip this test on TPU.