### PR TITLE
Add some loging to make sync and get tensor more clear

### DIFF
--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -964,6 +964,8 @@ std::vector<at::Tensor> XLATensor::GetTensorsOpByOp(
 }
 
 std::vector<at::Tensor> XLATensor::GetTensors(std::vector<XLATensor>* tensors) {
+  TF_VLOG(4) << "Trying to get the value of " << tensors->size()
+             << " tensor(s)";
   static const bool op_by_op =
       xla::sys_util::GetEnvBool("XLA_GET_TENSORS_OPBYOP", false);
   return op_by_op ? GetTensorsOpByOp(tensors) : GetTensorsFused(tensors);
@@ -1359,6 +1361,8 @@ std::shared_ptr<XLATensor::Async> XLATensor::ScheduleSyncTensorsGraph(
 void XLATensor::SyncTensorsGraph(std::vector<XLATensor>* tensors,
                                  absl::Span<const std::string> devices,
                                  bool wait, bool sync_xla_data) {
+  TF_VLOG(4) << "Trying to sync the value of " << tensors->size()
+             << " tensor(s)";
   tensorflow::profiler::TraceMe activity(
       "SyncTensorsGraph", tensorflow::profiler::TraceMeLevel::kInfo);
   static const bool op_by_op =


### PR DESCRIPTION
There are 2 sources of `compilation/execution` in pt/xla, they are `GetTensor` and `SyncTensor`. GetTensor is usually caused by user trying to access the value of the tensor before the materialization (`item`, `print` or `if`). GetTensor will not truncate the ir graph own by the tensor. SyncTensor is usually caused by `xm.mark_step()` and will materialize tensors to `xla::DeviceData`.  It would be helpful for us to figure out the source of `compilation/execution`.

With this pr we will see

```
-> t2 = t1 * 2
(Pdb) n
> /usr/local/google/home/jackcao/Desktop/test/test.py(14)<module>()
-> print(t2)
(Pdb) 
2021-07-12 21:00:28.468214: I 1981076 /usr/local/google/home/jackcao/Desktop/gitProj2/pytorch/xla/torch_xla/csrc/tensor.cpp:967] Trying to get the value of 1 tensor(s)
2021-07-12 21:00:28.468340: I 1981076 /usr/local/google/home/jackcao/Desktop/gitProj2/pytorch/xla/torch_xla/csrc/tensor.cpp:1138] Waiting on device barrier for device CPU:0 ...
2021-07-12 21:00:28.468447: I 1981076 /usr/local/google/home/jackcao/Desktop/gitProj2/pytorch/xla/torch_xla/csrc/tensor.cpp:1144] Waiting on device barrier for device CPU:0 done!
2021-07-12 21:00:28.468687: I 1981076 /usr/local/google/home/jackcao/Desktop/gitProj2/pytorch/xla/torch_xla/csrc/tensor.cpp:1184] Tensors graph hash 28154e545cda11bab37107b9f995e0f on device CPU:0
........

> /usr/local/google/home/jackcao/Desktop/test/test.py(16)<module>()
-> xm.mark_step()
(Pdb) n
2021-07-12 21:00:34.697171: I 1981076 /usr/local/google/home/jackcao/Desktop/gitProj2/pytorch/xla/torch_xla/csrc/tensor.cpp:1391] 2 live tensors: devices=()
2021-07-12 21:00:34.697258: I 1981076 /usr/local/google/home/jackcao/Desktop/gitProj2/pytorch/xla/torch_xla/csrc/tensor.cpp:1364] Trying to sync the value of 2 tensor(s)
2021-07-12 21:00:34.697320: I 1981076 /usr/local/google/home/jackcao/Desktop/gitProj2/pytorch/xla/torch_xla/csrc/tensor.cpp:1138] Waiting on device barrier for device CPU:0 ...
2021-07-12 21:00:34.697406: I 1981076 /usr/local/google/home/jackcao/Desktop/gitProj2/pytorch/xla/torch_xla/csrc/tensor.cpp:1144] Waiting on device barrier for device CPU:0 done!
.....
```