### PR TITLE
Do not always enable verbose for bazel build

### DIFF
--- a/build_torch_xla_libs.sh
+++ b/build_torch_xla_libs.sh
@@ -29,11 +29,10 @@ if [[ "$XLA_DEBUG" == "1" ]]; then
   MODE="dbg"
 fi
 
-# VERBOSE=
-# if [[ "$XLA_BAZEL_VERBOSE" == "1" ]]; then
-#   VERBOSE="-s"
-# fi
-VERBOSE="-s"
+VERBOSE=
+if [[ "$XLA_BAZEL_VERBOSE" == "1" ]]; then
+  VERBOSE="-s"
+fi
 
 TPUVM_FLAG=
 if [[ "$TPUVM_MODE" == "1" ]]; then


### PR DESCRIPTION
This was unintentional and was meant to debug a build error on circle CI for https://github.com/pytorch/xla/commit/4078c745574443aee3b13bac1f5ab24162ac6021#diff-227655881fc8052373149ace0b1846c3ecfccb1c103cb76c616b76be1cf2b870, revert my change.