### PR TITLE
Lowering for LogicalAnd

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -900,6 +900,16 @@ at::Tensor XLANativeFunctions::binary_cross_entropy_with_logits(
       IsDefined(pos_weight) ? *pos_weight : at::Tensor(), reduction);
 }
 
+at::Tensor& XLANativeFunctions::logical_and_out(const at::Tensor& self,
+                                                const at::Tensor& other,
+                                                at::Tensor& out) {
+  XLA_FN_COUNTER("xla::");
+  XLATensor out_tensor = bridge::GetXlaTensor(out);
+  XLATensor::logical_and_out(out_tensor, bridge::GetXlaTensor(self),
+                             bridge::GetXlaTensor(other));
+  return out;
+}
+
 at::Tensor XLANativeFunctions::bitwise_and(const at::Tensor& self,
                                            const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");

--- a/torch_xla/csrc/helpers.cpp
+++ b/torch_xla/csrc/helpers.cpp
@@ -650,4 +650,14 @@ xla::XlaOp XlaHelpers::PromotedBinaryOp(
   return ConvertBinaryOpResult(op1, op2, result);
 }
 
+xla::XlaOp XlaHelpers::PromotedLogicalBinaryOp(
+    xla::XlaOp op1, xla::XlaOp op2,
+    const std::function<xla::XlaOp(xla::XlaOp, xla::XlaOp)>& bin_op) {
+  // XLA only supports bitwise_and/or/xor so we need to cast inputs to
+  // PRED first.
+  op1 = xla::ConvertElementType(op1, xla::PrimitiveType::PRED);
+  op2 = xla::ConvertElementType(op2, xla::PrimitiveType::PRED);
+  return bin_op(op1, op2);
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -340,6 +340,10 @@ class XlaHelpers {
         op1, op2, [](xla::XlaOp op1, xla::XlaOp op2) { return op1 / op2; });
   }
 
+  static xla::XlaOp PromotedLogicalBinaryOp(
+      xla::XlaOp op1, xla::XlaOp op2,
+      const std::function<xla::XlaOp(xla::XlaOp, xla::XlaOp)>& bin_op);
+
   template <typename T>
   static xla::Literal Range(T start, T end, T step) {
     return xla::LiteralUtil::CreateR1<T>(xla::util::Range<T>(start, end, step));

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -212,6 +212,8 @@ NodePtr BaddBmm(const Value& lhs, const Value& rhs, const Value& bias,
 
 NodePtr Lerp(const Value& start, const Value& end, const Value& weight);
 
+NodePtr LogicalAnd(const Value& input, const Value& other);
+
 }  // namespace ops
 }  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -367,6 +367,9 @@ class XLATensor {
                                                  const XLATensor& weight,
                                                  xla::int64 reduction);
 
+  static void logical_and_out(XLATensor& out, const XLATensor& input,
+                              const XLATensor& other);
+
   static XLATensor bitwise_and(const XLATensor& input, const at::Scalar& other);
 
   static XLATensor bitwise_and(const XLATensor& input, const XLATensor& other);

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -782,6 +782,11 @@ XLATensor XLATensor::binary_cross_entropy_backward(const XLATensor& grad_output,
       GetOptionalIrValue(weight), GetXlaReductionMode(reduction)));
 }
 
+void XLATensor::logical_and_out(XLATensor& out, const XLATensor& input,
+                                const XLATensor& other) {
+  out.SetIrValue(ir::ops::LogicalAnd(input.GetIrValue(), other.GetIrValue()));
+}
+
 XLATensor XLATensor::bitwise_and(const XLATensor& input,
                                  const at::Scalar& other) {
   CheckIsIntegralOrPred(input.shape(), "__and__");

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -316,6 +316,7 @@ supported:
   - ger
   - lerp.Scalar
   - lerp.Tensor
+  - logical_and.out
 autograd:
   - max_pool2d
   - max_pool3d


### PR DESCRIPTION
Fix https://github.com/pytorch/xla/issues/3050, I also need to add `logical_and` to [aten_interned_strings.h ](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/core/aten_interned_strings.h). Currently I am using `bitwise_and`. (actual `bitwse_and` use `aten::__and__` which is a symbol for `bitwise_and`). Hack it for now to merge it to unblock the customer.