### PR TITLE
Add AMP test

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -99,9 +99,10 @@ function run_torch_xla_tests() {
 
     # echo "Running MNIST Test"
     # python test/test_train_mp_mnist.py --tidy
-    # if [ -x "$(command -v nvidia-smi)" ]; then
-    #   python test/test_train_mp_mnist_amp.py --fake_data
-    # fi
+    if [ -x "$(command -v nvidia-smi)" ]; then
+      python test/test_autocast.py
+      # python test/test_train_mp_mnist_amp.py --fake_data
+    fi
 
     pushd test/cpp
     CC=clang-9 CXX=clang++-9 ./run_tests.sh

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -342,8 +342,8 @@ class TestAutocastBase(unittest.TestCase):
         if isinstance(output_method, torch.Tensor):
           self.assertTrue(
               out_type == output_method.dtype,
-              "autocast for torch.{} produced {}, should produce torch.{}"
-              .format(op, output_method.dtype, out_type))
+              "autocast for torch.{} produced {}, should produce torch.{}".
+              format(op, output_method.dtype, out_type))
 
       self.assertTrue((output is not None) or (
           output_method is not None

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -3,18 +3,303 @@ import torch_xla
 import torch_xla.core.xla_model as xm
 import collections
 import unittest
-from torch.testing._internal.autocast_test_lists import AutocastTestLists
 from torch_xla.amp import autocast, GradScaler
+
+
+class AutocastTestLists(object):
+
+  def _rnn_cell_args(self, n, num_chunks, is_lstm, dev, dtype):
+    input = (torch.randn((n, n), device=dev, dtype=torch.float32),)
+
+    hx = ((torch.randn((n, n), device=dev, dtype=torch.float32),
+           torch.randn((n, n), device=dev, dtype=torch.float32))
+          if is_lstm else torch.randn((n, n), device=dev, dtype=torch.float32),)
+
+    weights = (
+        torch.randn((num_chunks * n, n), device=dev,
+                    dtype=torch.float32),  # weight_ih
+        torch.randn((num_chunks * n, n), device=dev,
+                    dtype=torch.float32),  # weight_hh
+        torch.randn((num_chunks * n), device=dev,
+                    dtype=torch.float32),  # bias_ih
+        torch.randn((num_chunks * n), device=dev,
+                    dtype=torch.float32))  # bias_hh
+
+    # returns args as a tuple
+    return input + hx + weights
+
+  # Supplies ops and arguments for test_autocast_* in test/test_cuda.py
+  def __init__(self, dev):
+    super().__init__()
+    n = 8
+    # Utility arguments, created as one-element tuples
+    pointwise0_fp16 = (torch.randn(n, dtype=torch.float16, device=dev),)
+    pointwise1_fp16 = (torch.randn(n, dtype=torch.float16, device=dev),)
+    pointwise2_fp16 = (torch.randn(n, dtype=torch.float16, device=dev),)
+    mat0_fp16 = (torch.randn((n, n), dtype=torch.float16, device=dev),)
+    mat1_fp16 = (torch.randn((n, n), dtype=torch.float16, device=dev),)
+    mat2_fp16 = (torch.randn((n, n), dtype=torch.float16, device=dev),)
+
+    dimsets = ((n, n, n), (n, n, n, n), (n, n, n, n, n))
+    conv_args_fp32 = [(torch.randn(dimset, dtype=torch.float32, device=dev),
+                       torch.randn(dimset, dtype=torch.float32, device=dev))
+                      for dimset in dimsets]
+    bias_fp32 = (torch.randn((n,), dtype=torch.float32, device=dev),)
+    element0_fp32 = (torch.randn(1, dtype=torch.float32, device=dev),)
+    pointwise0_fp32 = (torch.randn(n, dtype=torch.float32, device=dev),)
+    pointwise1_fp32 = (torch.randn(n, dtype=torch.float32, device=dev),)
+    mat0_fp32 = (torch.randn((n, n), dtype=torch.float32, device=dev),)
+    mat1_fp32 = (torch.randn((n, n), dtype=torch.float32, device=dev),)
+    mat2_fp32 = (torch.randn((n, n), dtype=torch.float32, device=dev),)
+    mat3_fp32 = (torch.randn((n, n), dtype=torch.float32, device=dev),)
+
+    # The lists below organize ops that autocast needs to test.
+    # self.list_name corresponds to test_autocast_list_name in test/test_cuda.py.
+    # Each op is associated with a tuple of valid arguments.
+    # In addition, cudnn conv ops are not supported on ROCm and hence will
+    # be skipped by passing TEST_WITH_ROCM flag to those ops in self.torch_fp16 list.
+
+    # Some ops implement built-in type promotion.  These don't need autocasting,
+    # but autocasting relies on their promotion, so we include tests to double-check.
+    self.torch_expect_builtin_promote = [
+        ("eq", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+        ("ge", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+        ("gt", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+        ("le", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+        ("lt", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+        ("ne", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+        ("add", pointwise0_fp32 + pointwise1_fp16, torch.float32),
+        ("div", pointwise0_fp32 + pointwise1_fp16, torch.float32),
+        ("mul", pointwise0_fp32 + pointwise1_fp16, torch.float32),
+        # cat andequal currently requires all input tensors to be the same type
+        # ("cat", (pointwise0_fp16 + pointwise1_fp32,), torch.float32),
+        # ("equal", pointwise0_fp32 + pointwise1_fp16, torch.float32),
+        # return f16 instead of f32
+        # ("stack", (pointwise0_fp16 + pointwise1_fp32,), torch.float32),
+    ]
+    self.methods_expect_builtin_promote = [
+        ("__eq__", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+        ("__ge__", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+        ("__gt__", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+        ("__le__", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+        ("__lt__", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+        ("__ne__", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+        ("__add__", pointwise0_fp32 + pointwise1_fp16, torch.float32),
+        ("__div__", pointwise0_fp32 + pointwise1_fp16, torch.float32),
+        ("__mul__", pointwise0_fp32 + pointwise1_fp16, torch.float32),
+    ]
+
+    # The remaining lists organize ops that autocast treats explicitly.
+    self.torch_fp16 = [
+        # deprecated _convolution
+        ("_convolution",
+         conv_args_fp32[1] + bias_fp32 + ((1, 1), (0, 0), (1, 1), False,
+                                          (0, 0), 1, False, True, True)),
+        # the current  _convolution
+        ("_convolution",
+         conv_args_fp32[1] + bias_fp32 + ((1, 1), (0, 0), (1, 1), False,
+                                          (0, 0), 1, False, True, True, True)),
+        # ("_convolution_nogroup", conv_args_fp32[1] + bias_fp32 + ((1, 1), (0, 0), (1, 1), False, (0, 0))),
+        ("conv1d", conv_args_fp32[0]),
+        ("conv2d", conv_args_fp32[1]),
+        ("conv3d", conv_args_fp32[2]),
+        ("conv_tbc", conv_args_fp32[0] + bias_fp32),
+        ("conv_transpose1d", conv_args_fp32[0]),
+        ("conv_transpose2d", conv_args_fp32[1]),
+        ("conv_transpose3d", conv_args_fp32[2]),
+        ("convolution",
+         conv_args_fp32[1] + bias_fp32 + ((1, 1), (0, 0), (1, 1), False,
+                                          (0, 0), 1)),
+        # need lowering
+        # ("prelu", pointwise0_fp32 + element0_fp32),
+        ("addmm", mat1_fp32 + mat2_fp32 + mat3_fp32),
+        # need lowering
+        # ("addmv", pointwise0_fp32 + mat2_fp32 + pointwise1_fp32),
+        ("addr", mat0_fp32 + pointwise0_fp32 + pointwise1_fp32),
+        ("matmul", mat0_fp32 + mat1_fp32),
+        ("mm", mat0_fp32 + mat1_fp32),
+        ("mv", mat0_fp32 + pointwise0_fp32),
+        ("chain_matmul", mat0_fp32 + mat1_fp32 + mat2_fp32),
+        ("addbmm",
+         mat0_fp32 + (torch.randn((n, n, n), device=dev, dtype=torch.float32),
+                      torch.randn((n, n, n), device=dev, dtype=torch.float32))),
+        ("baddbmm", (torch.randn((n, n, n), device=dev, dtype=torch.float32),
+                     torch.randn((n, n, n), device=dev, dtype=torch.float32),
+                     torch.randn((n, n, n), device=dev, dtype=torch.float32))),
+        ("bmm", (torch.randn((n, n, n), device=dev, dtype=torch.float32),
+                 torch.randn((n, n, n), device=dev, dtype=torch.float32))),
+        # _thnn_fused_lstm_cell and _thnn_fused_gru_cell are not Python-exposed as far as I can tell.
+        # ("_thnn_fused_lstm_cell", mat0_fp32 + mat1_fp32 + mat2_fp32 + pointwise0_fp32 + pointwise1_fp32),
+        # ("_thnn_fused_gru_cell", mat0_fp32 + mat1_fp32 + mat2_fp32 + pointwise0_fp32 + pointwise1_fp32),
+        ("lstm_cell",
+         self._rnn_cell_args(
+             n, num_chunks=4, is_lstm=True, dev=dev, dtype=torch.float32)),
+        ("gru_cell",
+         self._rnn_cell_args(
+             n, num_chunks=3, is_lstm=False, dev=dev, dtype=torch.float32)),
+        ("rnn_tanh_cell",
+         self._rnn_cell_args(
+             n, num_chunks=1, is_lstm=False, dev=dev, dtype=torch.float32)),
+        ("rnn_relu_cell",
+         self._rnn_cell_args(
+             n, num_chunks=1, is_lstm=False, dev=dev, dtype=torch.float32)),
+    ]
+    self.torch_fp32 = [
+        ("acos", (pointwise0_fp16[0].clamp(-.9, 0.9),)),
+        ("asin", (pointwise0_fp16[0].clamp(-.9, 0.9),)),
+        ("cosh", pointwise0_fp16),
+        ("erfinv", (pointwise0_fp16[0].clamp(-.9, .9),)),
+        ("exp", pointwise0_fp16),
+        ("expm1", pointwise0_fp16),
+        ("log", (pointwise0_fp16[0].clamp(0.1, 100.0),)),
+        ("log10", (pointwise0_fp16[0].clamp(0.1, 100.0),)),
+        ("log2", (pointwise0_fp16[0].clamp(0.1, 100.0),)),
+        ("log1p", (pointwise0_fp16[0].clamp(-0.9, 100.0),)),
+        ("reciprocal", pointwise0_fp16),
+        ("rsqrt", (pointwise0_fp16[0].clamp(0.0, 100.0),)),
+        ("sinh", pointwise0_fp16),
+        ("tan", (pointwise0_fp16[0].clamp(-3.1 / 2, 3.1 / 2),)),
+        ("pow",
+         ((pointwise0_fp16[0] + 1.).clamp(0.0, 100.0),) + pointwise1_fp16),
+        ("pow", ((pointwise0_fp16[0] + 1.).clamp(0.0, 100.0),) + (1.7,)),
+        # ("pow", (1.7,) + pointwise0_fp16), # This variant has a backend, but is not documented in the API.
+        ("softmax", pointwise0_fp16 + (0,)),
+        ("log_softmax", pointwise0_fp16 + (0,)),
+        ("layer_norm", pointwise0_fp16 + ((pointwise0_fp16[0].numel(),),)),
+        ("group_norm", mat0_fp16 + (1,)),
+        ("norm", pointwise0_fp16),
+        ("norm", pointwise0_fp16, {
+            "dim": 0
+        }),
+        # these need magma
+        # ("norm", mat0_fp16, {"p": "nuc"}),
+        # ("norm", mat0_fp16, {"p": "nuc", "dim": 0}),
+        # produce f16 instead of f32
+        # ("norm", pointwise0_fp16, {"p": 1}),
+        # ("norm", pointwise0_fp16, {"p": 1, "dim": 0}),
+        ("cosine_similarity", mat0_fp16 + mat1_fp16),
+        ("poisson_nll_loss", mat0_fp16 + mat1_fp16 +
+         (True, False, 1.e-8, torch.nn._reduction.get_enum("mean"))),
+        ("cosine_embedding_loss", (torch.tensor([[1, 2, 3]],
+                                                device=dev,
+                                                dtype=torch.float16),
+                                   torch.tensor([[1, 3, 4]],
+                                                device=dev,
+                                                dtype=torch.float16),
+                                   torch.tensor([1],
+                                                device=dev,
+                                                dtype=torch.int))),
+        ("hinge_embedding_loss",
+         mat0_fp16 + (torch.ones(n, device=dev, dtype=torch.int),)),
+        ("kl_div", mat0_fp16 + (torch.rand(
+            (n, n), device=dev, dtype=torch.float16),)),
+        ("margin_ranking_loss", mat0_fp16 + mat1_fp16 + (torch.ones(
+            (n,), device=dev, dtype=torch.float16),)),
+        ("triplet_margin_loss", mat0_fp16 + mat1_fp16 + mat2_fp16),
+        ("binary_cross_entropy_with_logits", mat0_fp16 + (torch.rand(
+            (n, n), device=dev, dtype=torch.float16),)),
+        ("cumprod", pointwise0_fp16 + (0,)),
+        ("cumsum", pointwise0_fp16 + (0,)),
+        ("dist", pointwise0_fp16 + pointwise1_fp16),
+        ("pdist", mat0_fp16),
+        ("cdist", mat0_fp16 + mat1_fp16),
+        ("prod", pointwise0_fp16),
+        ("prod", pointwise0_fp16 + (0,)),
+        ("renorm", mat0_fp16 + (2, 0, 1.0)),
+        ("sum", pointwise0_fp16),
+        ("sum", mat0_fp16 + (1,)),
+    ]
+    self.torch_need_autocast_promote = [
+        ("addcdiv", pointwise0_fp32 + pointwise1_fp16 +
+         (pointwise2_fp16[0].clamp(0.1, 100),)),
+        ("addcmul", pointwise0_fp32 + pointwise1_fp16 + pointwise2_fp16),
+        ("atan2", pointwise0_fp32 + (pointwise1_fp16[0].clamp(0.1, 100),)),
+        ("bilinear", (torch.randn((1, 2), dtype=torch.float16, device=dev),
+                      torch.randn((1, 2), dtype=torch.float32, device=dev),
+                      torch.randn((1, 2, 2), dtype=torch.float16, device=dev),
+                      torch.randn((1,), dtype=torch.float32, device=dev))),
+        ("cross", (torch.randn(3, dtype=torch.float32, device=dev),
+                   torch.randn(3, dtype=torch.float16, device=dev))),
+        ("dot", pointwise0_fp16 + pointwise1_fp32),
+        ("grid_sampler", (torch.randn((2, 3, 33, 22),
+                                      dtype=torch.float16,
+                                      device=dev),
+                          torch.randn((2, 22, 11, 2),
+                                      dtype=torch.float32,
+                                      device=dev), 0, 0, False)),
+        ("index_put",
+         pointwise0_fp32 + ((torch.tensor([1], device=dev, dtype=torch.long),),
+                            torch.randn(1, device=dev, dtype=torch.float16))),
+        ("index_put",
+         pointwise0_fp16 + ((torch.tensor([1], device=dev, dtype=torch.long),),
+                            torch.randn(1, device=dev, dtype=torch.float32))),
+        ("tensordot", (torch.randn((2, 2, 2), dtype=torch.float32, device=dev),
+                       torch.randn((2, 2, 2), dtype=torch.float16,
+                                   device=dev))),
+        ("scatter_add", (torch.zeros(2, 2, 2, dtype=torch.float32,
+                                     device=dev), 0,
+                         torch.randint(0, 2, (2, 2, 2), device=dev),
+                         torch.randn((2, 2, 2), dtype=torch.float16,
+                                     device=dev))),
+        # cat currently requires all input tensors to be the same type
+        # ("scatter_add", (torch.zeros(2, 2, 2, dtype=torch.float16, device=dev),
+        #                  0,
+        #                  torch.randint(0, 2, (2, 2, 2), device=dev),
+        #                  torch.randn((2, 2, 2), dtype=torch.float32, device=dev))),
+    ]
+    self.nn_fp16 = [
+        ("linear", mat0_fp32 + mat1_fp32 + mat2_fp32),
+    ]
+    self.nn_fp32 = [
+        ("softplus", pointwise0_fp16),
+        ("nll_loss", (torch.rand((n, n), device=dev, dtype=torch.float),
+                      torch.zeros((n,), device=dev, dtype=torch.long))),
+        ("nll_loss2d", (torch.rand((n, n, n, n), device=dev, dtype=torch.half),
+                        torch.zeros((n, n, n), device=dev, dtype=torch.long))),
+        ("l1_loss", mat0_fp16 + mat1_fp16),
+        ("smooth_l1_loss", mat0_fp16 + mat1_fp16),
+        ("mse_loss", mat0_fp16 + mat1_fp16),
+        ("multilabel_margin_loss", mat0_fp16 + (torch.ones(
+            (n, n), device=dev, dtype=torch.long),)),
+        ("soft_margin_loss", mat0_fp16 + (torch.ones(
+            (n, n), device=dev, dtype=torch.long),)),
+        ("multi_margin_loss", mat0_fp16 + (torch.ones(
+            (n,), device=dev, dtype=torch.long),)),
+    ]
+    self.linalg_fp16 = [
+        ("linalg_multi_dot", (mat0_fp32 + mat1_fp32 + mat2_fp32,)),
+    ]
+    self.methods_fp16 = [("__matmul__", mat0_fp32 + mat1_fp32)]
+    self.methods_fp32 = [
+        ("__pow__", (torch.rand(n, device=dev, dtype=torch.float16), 1.5)),
+    ]
+    self.banned = [
+        ("binary_cross_entropy", (torch.rand((n, n),
+                                             device=dev,
+                                             dtype=torch.float32),
+                                  torch.rand(
+                                      (n, n), device=dev,
+                                      dtype=torch.float32)), torch._C._nn),
+    ]
+
 
 class TestAutocastBase(unittest.TestCase):
 
   def setUp(self):
     super(TestAutocastBase, self).setUp()
-    self.autocast_lists = AutocastTestLists(torch.device("xla:0"))
+    self.autocast_lists = AutocastTestLists(
+        torch.device(xm.xla_device(devkind="GPU")))
+    self.skip_list = []
 
   def tearDown(self):
     del self.autocast_lists
     super(TestAutocastBase, self).tearDown()
+
+  def args_maybe_kwargs(self, op_with_args):
+    if len(op_with_args) == 2:
+      return op_with_args[0], op_with_args[1], {}
+    else:
+      return op_with_args[0], op_with_args[1], op_with_args[2]
 
   def _run_autocast_outofplace(self,
                                op,
@@ -107,12 +392,59 @@ class TestAutocast(TestAutocastBase):
   def test_autocast_torch_fp16(self):
     with torch.backends.cudnn.flags(enabled=True, deterministic=True):
       for op_with_args in self.autocast_lists.torch_fp16:
-        skip_test = False
         op, args = op_with_args[0], op_with_args[1]
-        if len(op_with_args) == 3:
-          skip_test = op_with_args[2]  # TEST_WITH_ROCM
-        if not skip_test:
-          self._run_autocast_outofplace(op, args, torch.float16)
+        self._run_autocast_outofplace(op, args, torch.float16)
+
+  def test_autocast_torch_fp32(self):
+    for op_with_args in self.autocast_lists.torch_fp32:
+      op, args, maybe_kwargs = self.args_maybe_kwargs(op_with_args)
+      self._run_autocast_outofplace(
+          op, args, torch.float32, add_kwargs=maybe_kwargs)
+
+  def test_autocast_torch_need_autocast_promote(self):
+    for op, args in self.autocast_lists.torch_need_autocast_promote:
+      self._run_autocast_outofplace(op, args, torch.float32)
+
+  def test_autocast_torch_expect_builtin_promote(self):
+    for op, args, out_type in self.autocast_lists.torch_expect_builtin_promote:
+      self._run_autocast_outofplace(op, args, torch.float32, out_type=out_type)
+
+  def test_autocast_nn_fp16(self):
+    with torch.backends.cudnn.flags(enabled=True, deterministic=True):
+      for op, args in self.autocast_lists.nn_fp16:
+        self._run_autocast_outofplace(
+            op, args, torch.float16, module=torch._C._nn)
+
+  def test_autocast_nn_fp32(self):
+    for op, args in self.autocast_lists.nn_fp32:
+      self._run_autocast_outofplace(
+          op, args, torch.float32, module=torch._C._nn)
+
+  def test_autocast_linalg_fp16(self):
+    with torch.backends.cudnn.flags(enabled=True, deterministic=True):
+      for op, args in self.autocast_lists.linalg_fp16:
+        self._run_autocast_outofplace(
+            op, args, torch.float16, module=torch._C._linalg)
+
+  def test_autocast_methods_fp16(self):
+    with torch.backends.cudnn.flags(enabled=True, deterministic=True):
+      for op, args in self.autocast_lists.methods_fp16:
+        self._run_autocast_outofplace(op, args, torch.float16, module=None)
+
+  def test_autocast_methods_fp32(self):
+    for op, args in self.autocast_lists.methods_fp32:
+      self._run_autocast_outofplace(op, args, torch.float32, module=None)
+
+  def test_autocast_methods_expect_builtin_promote(self):
+    for op, args, out_type in self.autocast_lists.methods_expect_builtin_promote:
+      self._run_autocast_outofplace(
+          op, args, torch.float32, module=None, out_type=out_type)
+
+  def test_autocast_banned(self):
+    with torch.cuda.amp.autocast():
+      for op, args, module in self.autocast_lists.banned:
+        with self.assertRaises(RuntimeError):
+          getattr(module, op)(*args)
 
 
 if __name__ == "__main__":

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -1,286 +1,50 @@
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(add_help=False)
+parser.add_argument('--verbosity', type=int, default=0)
+FLAGS, leftovers = parser.parse_known_args()
+sys.argv = [sys.argv[0]] + leftovers
+
 import torch
 import torch_xla
 import torch_xla.core.xla_model as xm
 import collections
 import unittest
+from torch.testing._internal.autocast_test_lists import AutocastTestLists
 from torch_xla.amp import autocast, GradScaler
 
 
-class AutocastTestLists(object):
+class AutocastTestUnsupportedLists(object):
 
-  def _rnn_cell_args(self, n, num_chunks, is_lstm, dev, dtype):
-    input = (torch.randn((n, n), device=dev, dtype=torch.float32),)
-
-    hx = ((torch.randn((n, n), device=dev, dtype=torch.float32),
-           torch.randn((n, n), device=dev, dtype=torch.float32))
-          if is_lstm else torch.randn((n, n), device=dev, dtype=torch.float32),)
-
-    weights = (
-        torch.randn((num_chunks * n, n), device=dev,
-                    dtype=torch.float32),  # weight_ih
-        torch.randn((num_chunks * n, n), device=dev,
-                    dtype=torch.float32),  # weight_hh
-        torch.randn((num_chunks * n), device=dev,
-                    dtype=torch.float32),  # bias_ih
-        torch.randn((num_chunks * n), device=dev,
-                    dtype=torch.float32))  # bias_hh
-
-    # returns args as a tuple
-    return input + hx + weights
-
-  # Supplies ops and arguments for test_autocast_* in test/test_cuda.py
-  def __init__(self, dev):
+  def __init__(self):
     super().__init__()
-    n = 8
     # Utility arguments, created as one-element tuples
-    pointwise0_fp16 = (torch.randn(n, dtype=torch.float16, device=dev),)
-    pointwise1_fp16 = (torch.randn(n, dtype=torch.float16, device=dev),)
-    pointwise2_fp16 = (torch.randn(n, dtype=torch.float16, device=dev),)
-    mat0_fp16 = (torch.randn((n, n), dtype=torch.float16, device=dev),)
-    mat1_fp16 = (torch.randn((n, n), dtype=torch.float16, device=dev),)
-    mat2_fp16 = (torch.randn((n, n), dtype=torch.float16, device=dev),)
-
-    dimsets = ((n, n, n), (n, n, n, n), (n, n, n, n, n))
-    conv_args_fp32 = [(torch.randn(dimset, dtype=torch.float32, device=dev),
-                       torch.randn(dimset, dtype=torch.float32, device=dev))
-                      for dimset in dimsets]
-    bias_fp32 = (torch.randn((n,), dtype=torch.float32, device=dev),)
-    element0_fp32 = (torch.randn(1, dtype=torch.float32, device=dev),)
-    pointwise0_fp32 = (torch.randn(n, dtype=torch.float32, device=dev),)
-    pointwise1_fp32 = (torch.randn(n, dtype=torch.float32, device=dev),)
-    mat0_fp32 = (torch.randn((n, n), dtype=torch.float32, device=dev),)
-    mat1_fp32 = (torch.randn((n, n), dtype=torch.float32, device=dev),)
-    mat2_fp32 = (torch.randn((n, n), dtype=torch.float32, device=dev),)
-    mat3_fp32 = (torch.randn((n, n), dtype=torch.float32, device=dev),)
-
-    # The lists below organize ops that autocast needs to test.
-    # self.list_name corresponds to test_autocast_list_name in test/test_cuda.py.
-    # Each op is associated with a tuple of valid arguments.
-    # In addition, cudnn conv ops are not supported on ROCm and hence will
-    # be skipped by passing TEST_WITH_ROCM flag to those ops in self.torch_fp16 list.
-
-    # Some ops implement built-in type promotion.  These don't need autocasting,
-    # but autocasting relies on their promotion, so we include tests to double-check.
     self.torch_expect_builtin_promote = [
-        ("eq", pointwise0_fp32 + pointwise1_fp16, torch.bool),
-        ("ge", pointwise0_fp32 + pointwise1_fp16, torch.bool),
-        ("gt", pointwise0_fp32 + pointwise1_fp16, torch.bool),
-        ("le", pointwise0_fp32 + pointwise1_fp16, torch.bool),
-        ("lt", pointwise0_fp32 + pointwise1_fp16, torch.bool),
-        ("ne", pointwise0_fp32 + pointwise1_fp16, torch.bool),
-        ("add", pointwise0_fp32 + pointwise1_fp16, torch.float32),
-        ("div", pointwise0_fp32 + pointwise1_fp16, torch.float32),
-        ("mul", pointwise0_fp32 + pointwise1_fp16, torch.float32),
-        # cat andequal currently requires all input tensors to be the same type
-        # ("cat", (pointwise0_fp16 + pointwise1_fp32,), torch.float32),
-        # ("equal", pointwise0_fp32 + pointwise1_fp16, torch.float32),
-        # return f16 instead of f32
-        # ("stack", (pointwise0_fp16 + pointwise1_fp32,), torch.float32),
+        "cat",  # requires all input tensors to be the same type
+        "equal",  # requires all input tensors to be the same type
+        "stack",  # return f16 instead of f32
     ]
-    self.methods_expect_builtin_promote = [
-        ("__eq__", pointwise0_fp32 + pointwise1_fp16, torch.bool),
-        ("__ge__", pointwise0_fp32 + pointwise1_fp16, torch.bool),
-        ("__gt__", pointwise0_fp32 + pointwise1_fp16, torch.bool),
-        ("__le__", pointwise0_fp32 + pointwise1_fp16, torch.bool),
-        ("__lt__", pointwise0_fp32 + pointwise1_fp16, torch.bool),
-        ("__ne__", pointwise0_fp32 + pointwise1_fp16, torch.bool),
-        ("__add__", pointwise0_fp32 + pointwise1_fp16, torch.float32),
-        ("__div__", pointwise0_fp32 + pointwise1_fp16, torch.float32),
-        ("__mul__", pointwise0_fp32 + pointwise1_fp16, torch.float32),
-    ]
+    self.methods_expect_builtin_promote = []
 
     # The remaining lists organize ops that autocast treats explicitly.
     self.torch_fp16 = [
-        # deprecated _convolution
-        ("_convolution",
-         conv_args_fp32[1] + bias_fp32 + ((1, 1), (0, 0), (1, 1), False,
-                                          (0, 0), 1, False, True, True)),
-        # the current  _convolution
-        ("_convolution",
-         conv_args_fp32[1] + bias_fp32 + ((1, 1), (0, 0), (1, 1), False,
-                                          (0, 0), 1, False, True, True, True)),
-        # ("_convolution_nogroup", conv_args_fp32[1] + bias_fp32 + ((1, 1), (0, 0), (1, 1), False, (0, 0))),
-        ("conv1d", conv_args_fp32[0]),
-        ("conv2d", conv_args_fp32[1]),
-        ("conv3d", conv_args_fp32[2]),
-        ("conv_tbc", conv_args_fp32[0] + bias_fp32),
-        ("conv_transpose1d", conv_args_fp32[0]),
-        ("conv_transpose2d", conv_args_fp32[1]),
-        ("conv_transpose3d", conv_args_fp32[2]),
-        ("convolution",
-         conv_args_fp32[1] + bias_fp32 + ((1, 1), (0, 0), (1, 1), False,
-                                          (0, 0), 1)),
-        # need lowering
-        # ("prelu", pointwise0_fp32 + element0_fp32),
-        ("addmm", mat1_fp32 + mat2_fp32 + mat3_fp32),
-        # need lowering
-        # ("addmv", pointwise0_fp32 + mat2_fp32 + pointwise1_fp32),
-        ("addr", mat0_fp32 + pointwise0_fp32 + pointwise1_fp32),
-        ("matmul", mat0_fp32 + mat1_fp32),
-        ("mm", mat0_fp32 + mat1_fp32),
-        ("mv", mat0_fp32 + pointwise0_fp32),
-        ("chain_matmul", mat0_fp32 + mat1_fp32 + mat2_fp32),
-        ("addbmm",
-         mat0_fp32 + (torch.randn((n, n, n), device=dev, dtype=torch.float32),
-                      torch.randn((n, n, n), device=dev, dtype=torch.float32))),
-        ("baddbmm", (torch.randn((n, n, n), device=dev, dtype=torch.float32),
-                     torch.randn((n, n, n), device=dev, dtype=torch.float32),
-                     torch.randn((n, n, n), device=dev, dtype=torch.float32))),
-        ("bmm", (torch.randn((n, n, n), device=dev, dtype=torch.float32),
-                 torch.randn((n, n, n), device=dev, dtype=torch.float32))),
-        # _thnn_fused_lstm_cell and _thnn_fused_gru_cell are not Python-exposed as far as I can tell.
-        # ("_thnn_fused_lstm_cell", mat0_fp32 + mat1_fp32 + mat2_fp32 + pointwise0_fp32 + pointwise1_fp32),
-        # ("_thnn_fused_gru_cell", mat0_fp32 + mat1_fp32 + mat2_fp32 + pointwise0_fp32 + pointwise1_fp32),
-        ("lstm_cell",
-         self._rnn_cell_args(
-             n, num_chunks=4, is_lstm=True, dev=dev, dtype=torch.float32)),
-        ("gru_cell",
-         self._rnn_cell_args(
-             n, num_chunks=3, is_lstm=False, dev=dev, dtype=torch.float32)),
-        ("rnn_tanh_cell",
-         self._rnn_cell_args(
-             n, num_chunks=1, is_lstm=False, dev=dev, dtype=torch.float32)),
-        ("rnn_relu_cell",
-         self._rnn_cell_args(
-             n, num_chunks=1, is_lstm=False, dev=dev, dtype=torch.float32)),
+        "_convolution_nogroup",  # need lowering
+        "prelu",  # need lowering
+        "addmv",  # need lowering
     ]
     self.torch_fp32 = [
-        ("acos", (pointwise0_fp16[0].clamp(-.9, 0.9),)),
-        ("asin", (pointwise0_fp16[0].clamp(-.9, 0.9),)),
-        ("cosh", pointwise0_fp16),
-        ("erfinv", (pointwise0_fp16[0].clamp(-.9, .9),)),
-        ("exp", pointwise0_fp16),
-        ("expm1", pointwise0_fp16),
-        ("log", (pointwise0_fp16[0].clamp(0.1, 100.0),)),
-        ("log10", (pointwise0_fp16[0].clamp(0.1, 100.0),)),
-        ("log2", (pointwise0_fp16[0].clamp(0.1, 100.0),)),
-        ("log1p", (pointwise0_fp16[0].clamp(-0.9, 100.0),)),
-        ("reciprocal", pointwise0_fp16),
-        ("rsqrt", (pointwise0_fp16[0].clamp(0.0, 100.0),)),
-        ("sinh", pointwise0_fp16),
-        ("tan", (pointwise0_fp16[0].clamp(-3.1 / 2, 3.1 / 2),)),
-        ("pow",
-         ((pointwise0_fp16[0] + 1.).clamp(0.0, 100.0),) + pointwise1_fp16),
-        ("pow", ((pointwise0_fp16[0] + 1.).clamp(0.0, 100.0),) + (1.7,)),
-        # ("pow", (1.7,) + pointwise0_fp16), # This variant has a backend, but is not documented in the API.
-        ("softmax", pointwise0_fp16 + (0,)),
-        ("log_softmax", pointwise0_fp16 + (0,)),
-        ("layer_norm", pointwise0_fp16 + ((pointwise0_fp16[0].numel(),),)),
-        ("group_norm", mat0_fp16 + (1,)),
-        ("norm", pointwise0_fp16),
-        ("norm", pointwise0_fp16, {
-            "dim": 0
-        }),
-        # these need magma
-        # ("norm", mat0_fp16, {"p": "nuc"}),
-        # ("norm", mat0_fp16, {"p": "nuc", "dim": 0}),
-        # produce f16 instead of f32
-        # ("norm", pointwise0_fp16, {"p": 1}),
-        # ("norm", pointwise0_fp16, {"p": 1, "dim": 0}),
-        ("cosine_similarity", mat0_fp16 + mat1_fp16),
-        ("poisson_nll_loss", mat0_fp16 + mat1_fp16 +
-         (True, False, 1.e-8, torch.nn._reduction.get_enum("mean"))),
-        ("cosine_embedding_loss", (torch.tensor([[1, 2, 3]],
-                                                device=dev,
-                                                dtype=torch.float16),
-                                   torch.tensor([[1, 3, 4]],
-                                                device=dev,
-                                                dtype=torch.float16),
-                                   torch.tensor([1],
-                                                device=dev,
-                                                dtype=torch.int))),
-        ("hinge_embedding_loss",
-         mat0_fp16 + (torch.ones(n, device=dev, dtype=torch.int),)),
-        ("kl_div", mat0_fp16 + (torch.rand(
-            (n, n), device=dev, dtype=torch.float16),)),
-        ("margin_ranking_loss", mat0_fp16 + mat1_fp16 + (torch.ones(
-            (n,), device=dev, dtype=torch.float16),)),
-        ("triplet_margin_loss", mat0_fp16 + mat1_fp16 + mat2_fp16),
-        ("binary_cross_entropy_with_logits", mat0_fp16 + (torch.rand(
-            (n, n), device=dev, dtype=torch.float16),)),
-        ("cumprod", pointwise0_fp16 + (0,)),
-        ("cumsum", pointwise0_fp16 + (0,)),
-        ("dist", pointwise0_fp16 + pointwise1_fp16),
-        ("pdist", mat0_fp16),
-        ("cdist", mat0_fp16 + mat1_fp16),
-        ("prod", pointwise0_fp16),
-        ("prod", pointwise0_fp16 + (0,)),
-        ("renorm", mat0_fp16 + (2, 0, 1.0)),
-        ("sum", pointwise0_fp16),
-        ("sum", mat0_fp16 + (1,)),
+        "norm",  # produce f16 instead of f32
     ]
     self.torch_need_autocast_promote = [
-        ("addcdiv", pointwise0_fp32 + pointwise1_fp16 +
-         (pointwise2_fp16[0].clamp(0.1, 100),)),
-        ("addcmul", pointwise0_fp32 + pointwise1_fp16 + pointwise2_fp16),
-        ("atan2", pointwise0_fp32 + (pointwise1_fp16[0].clamp(0.1, 100),)),
-        ("bilinear", (torch.randn((1, 2), dtype=torch.float16, device=dev),
-                      torch.randn((1, 2), dtype=torch.float32, device=dev),
-                      torch.randn((1, 2, 2), dtype=torch.float16, device=dev),
-                      torch.randn((1,), dtype=torch.float32, device=dev))),
-        ("cross", (torch.randn(3, dtype=torch.float32, device=dev),
-                   torch.randn(3, dtype=torch.float16, device=dev))),
-        ("dot", pointwise0_fp16 + pointwise1_fp32),
-        ("grid_sampler", (torch.randn((2, 3, 33, 22),
-                                      dtype=torch.float16,
-                                      device=dev),
-                          torch.randn((2, 22, 11, 2),
-                                      dtype=torch.float32,
-                                      device=dev), 0, 0, False)),
-        ("index_put",
-         pointwise0_fp32 + ((torch.tensor([1], device=dev, dtype=torch.long),),
-                            torch.randn(1, device=dev, dtype=torch.float16))),
-        ("index_put",
-         pointwise0_fp16 + ((torch.tensor([1], device=dev, dtype=torch.long),),
-                            torch.randn(1, device=dev, dtype=torch.float32))),
-        ("tensordot", (torch.randn((2, 2, 2), dtype=torch.float32, device=dev),
-                       torch.randn((2, 2, 2), dtype=torch.float16,
-                                   device=dev))),
-        ("scatter_add", (torch.zeros(2, 2, 2, dtype=torch.float32,
-                                     device=dev), 0,
-                         torch.randint(0, 2, (2, 2, 2), device=dev),
-                         torch.randn((2, 2, 2), dtype=torch.float16,
-                                     device=dev))),
-        # cat currently requires all input tensors to be the same type
-        # ("scatter_add", (torch.zeros(2, 2, 2, dtype=torch.float16, device=dev),
-        #                  0,
-        #                  torch.randint(0, 2, (2, 2, 2), device=dev),
-        #                  torch.randn((2, 2, 2), dtype=torch.float32, device=dev))),
+        "scatter_add",  # cat currently requires all input tensors to be the same type
     ]
-    self.nn_fp16 = [
-        ("linear", mat0_fp32 + mat1_fp32 + mat2_fp32),
-    ]
-    self.nn_fp32 = [
-        ("softplus", pointwise0_fp16),
-        ("nll_loss", (torch.rand((n, n), device=dev, dtype=torch.float),
-                      torch.zeros((n,), device=dev, dtype=torch.long))),
-        ("nll_loss2d", (torch.rand((n, n, n, n), device=dev, dtype=torch.half),
-                        torch.zeros((n, n, n), device=dev, dtype=torch.long))),
-        ("l1_loss", mat0_fp16 + mat1_fp16),
-        ("smooth_l1_loss", mat0_fp16 + mat1_fp16),
-        ("mse_loss", mat0_fp16 + mat1_fp16),
-        ("multilabel_margin_loss", mat0_fp16 + (torch.ones(
-            (n, n), device=dev, dtype=torch.long),)),
-        ("soft_margin_loss", mat0_fp16 + (torch.ones(
-            (n, n), device=dev, dtype=torch.long),)),
-        ("multi_margin_loss", mat0_fp16 + (torch.ones(
-            (n,), device=dev, dtype=torch.long),)),
-    ]
-    self.linalg_fp16 = [
-        ("linalg_multi_dot", (mat0_fp32 + mat1_fp32 + mat2_fp32,)),
-    ]
-    self.methods_fp16 = [("__matmul__", mat0_fp32 + mat1_fp32)]
-    self.methods_fp32 = [
-        ("__pow__", (torch.rand(n, device=dev, dtype=torch.float16), 1.5)),
-    ]
-    self.banned = [
-        ("binary_cross_entropy", (torch.rand((n, n),
-                                             device=dev,
-                                             dtype=torch.float32),
-                                  torch.rand(
-                                      (n, n), device=dev,
-                                      dtype=torch.float32)), torch._C._nn),
-    ]
+    self.nn_fp16 = []
+    self.nn_fp32 = []
+    self.linalg_fp16 = []
+    self.methods_fp16 = []
+    self.methods_fp32 = []
+    self.banned = []
 
 
 class TestAutocastBase(unittest.TestCase):
@@ -289,11 +53,18 @@ class TestAutocastBase(unittest.TestCase):
     super(TestAutocastBase, self).setUp()
     self.autocast_lists = AutocastTestLists(
         torch.device(xm.xla_device(devkind="GPU")))
+    self.autocast_unsupported_lists = AutocastTestUnsupportedLists()
     self.skip_list = []
 
   def tearDown(self):
     del self.autocast_lists
     super(TestAutocastBase, self).tearDown()
+
+  def get_autocast_list(self, list_name):
+    return [
+        tp for tp in getattr(self.autocast_lists, list_name)
+        if tp[0] not in getattr(self.autocast_unsupported_lists, list_name)
+    ]
 
   def args_maybe_kwargs(self, op_with_args):
     if len(op_with_args) == 2:
@@ -391,62 +162,67 @@ class TestAutocast(TestAutocastBase):
 
   def test_autocast_torch_fp16(self):
     with torch.backends.cudnn.flags(enabled=True, deterministic=True):
-      for op_with_args in self.autocast_lists.torch_fp16:
+      for op_with_args in self.get_autocast_list('torch_fp16'):
+        if len(op_with_args) == 3:
+          # TEST_WITH_ROCM
+          continue
         op, args = op_with_args[0], op_with_args[1]
         self._run_autocast_outofplace(op, args, torch.float16)
 
   def test_autocast_torch_fp32(self):
-    for op_with_args in self.autocast_lists.torch_fp32:
+    for op_with_args in self.get_autocast_list('torch_fp32'):
       op, args, maybe_kwargs = self.args_maybe_kwargs(op_with_args)
       self._run_autocast_outofplace(
           op, args, torch.float32, add_kwargs=maybe_kwargs)
 
   def test_autocast_torch_need_autocast_promote(self):
-    for op, args in self.autocast_lists.torch_need_autocast_promote:
+    for op, args in self.get_autocast_list('torch_need_autocast_promote'):
       self._run_autocast_outofplace(op, args, torch.float32)
 
   def test_autocast_torch_expect_builtin_promote(self):
-    for op, args, out_type in self.autocast_lists.torch_expect_builtin_promote:
+    for op, args, out_type in self.get_autocast_list(
+        'torch_expect_builtin_promote'):
       self._run_autocast_outofplace(op, args, torch.float32, out_type=out_type)
 
   def test_autocast_nn_fp16(self):
     with torch.backends.cudnn.flags(enabled=True, deterministic=True):
-      for op, args in self.autocast_lists.nn_fp16:
+      for op, args in self.get_autocast_list('nn_fp16'):
         self._run_autocast_outofplace(
             op, args, torch.float16, module=torch._C._nn)
 
   def test_autocast_nn_fp32(self):
-    for op, args in self.autocast_lists.nn_fp32:
+    for op, args in self.get_autocast_list('nn_fp32'):
       self._run_autocast_outofplace(
           op, args, torch.float32, module=torch._C._nn)
 
   def test_autocast_linalg_fp16(self):
     with torch.backends.cudnn.flags(enabled=True, deterministic=True):
-      for op, args in self.autocast_lists.linalg_fp16:
+      for op, args in self.get_autocast_list('linalg_fp16'):
         self._run_autocast_outofplace(
             op, args, torch.float16, module=torch._C._linalg)
 
   def test_autocast_methods_fp16(self):
     with torch.backends.cudnn.flags(enabled=True, deterministic=True):
-      for op, args in self.autocast_lists.methods_fp16:
+      for op, args in self.get_autocast_list('methods_fp16'):
         self._run_autocast_outofplace(op, args, torch.float16, module=None)
 
   def test_autocast_methods_fp32(self):
-    for op, args in self.autocast_lists.methods_fp32:
+    for op, args in self.get_autocast_list('methods_fp32'):
       self._run_autocast_outofplace(op, args, torch.float32, module=None)
 
   def test_autocast_methods_expect_builtin_promote(self):
-    for op, args, out_type in self.autocast_lists.methods_expect_builtin_promote:
+    for op, args, out_type in self.get_autocast_list(
+        'methods_expect_builtin_promote'):
       self._run_autocast_outofplace(
           op, args, torch.float32, module=None, out_type=out_type)
 
   def test_autocast_banned(self):
     with torch.cuda.amp.autocast():
-      for op, args, module in self.autocast_lists.banned:
+      for op, args, module in self.get_autocast_list('banned'):
         with self.assertRaises(RuntimeError):
           getattr(module, op)(*args)
 
 
 if __name__ == "__main__":
-  test = unittest.main()
+  test = unittest.main(verbosity=FLAGS.verbosity, exit=False)
   sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -1,0 +1,120 @@
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+import collections
+import unittest
+from torch.testing._internal.autocast_test_lists import AutocastTestLists
+from torch_xla.amp import autocast, GradScaler
+
+class TestAutocastBase(unittest.TestCase):
+
+  def setUp(self):
+    super(TestAutocastBase, self).setUp()
+    self.autocast_lists = AutocastTestLists(torch.device("xla:0"))
+
+  def tearDown(self):
+    del self.autocast_lists
+    super(TestAutocastBase, self).tearDown()
+
+  def _run_autocast_outofplace(self,
+                               op,
+                               args,
+                               run_as_type,
+                               out_type=None,
+                               module=torch,
+                               add_kwargs=None):
+    # helper to cast args
+    def cast(val, to_type):
+      if isinstance(val, torch.Tensor):
+        return val.to(to_type) if val.is_floating_point() else val
+      elif isinstance(val, collections.abc.Iterable):
+        return type(val)(cast(v, to_type) for v in val)
+      else:
+        return val
+
+    if add_kwargs is None:
+      add_kwargs = {}
+
+    self.assertFalse(torch.is_autocast_enabled())
+    with autocast():
+      self.assertTrue(torch.is_autocast_enabled())
+
+      out_type = out_type if out_type is not None else run_as_type
+      output = output_method = None
+
+      # Try module.* variant, if requested:
+      if module is not None and hasattr(module, op):
+        output = getattr(module, op)(*args, **add_kwargs)
+        if isinstance(output, torch.Tensor):
+          self.assertTrue(
+              out_type == output.dtype,
+              "autocast for torch.{} produced {}, should produce {}".format(
+                  op, output.dtype, out_type))
+
+      # Try Tensor.* variant:
+      if hasattr(torch.Tensor, op):
+        output_method = getattr(args[0], op)(*args[1:], **add_kwargs)
+        if isinstance(output_method, torch.Tensor):
+          self.assertTrue(
+              out_type == output_method.dtype,
+              "autocast for torch.{} produced {}, should produce torch.{}"
+              .format(op, output_method.dtype, out_type))
+
+      self.assertTrue((output is not None) or (
+          output_method is not None
+      ), "{} not found as an attribute on either Tensor or the requested module {}"
+                      .format(op, module))
+
+      # Accounts for ops that return Tensors, iterables, and other non-Tensors.
+      # For example, lstm_cell returns a tuple and equal returns bool.
+      def compare(first, second):
+        if isinstance(first, torch.Tensor):
+          return torch.equal(first, second)
+        elif isinstance(first, collections.abc.Iterable):
+          return all(compare(f, s) for f, s in zip(first, second))
+        else:
+          return first == second
+
+      # If both torch.* and Tensor.* variants were found, check outputs are identical
+      if (output is not None) and (output_method is not None):
+        self.assertTrue(type(output) == type(output_method))
+        comparison = compare(output, output_method)
+        self.assertTrue(
+            comparison,
+            "torch.{0} result did not match Tensor.{0} result".format(op))
+
+      # Compare numerics to Python-side "autocasting" that (we expect) does the same thing
+      # as the C++-side autocasting, and should be bitwise accurate.
+      output_to_compare = output if output is not None else output_method
+      with autocast(enabled=False):
+        self.assertFalse(torch.is_autocast_enabled())
+
+        if module is not None and hasattr(module, op):
+          control = getattr(module, op)(*cast(args, run_as_type), **add_kwargs)
+        else:
+          control = getattr(args[0].to(run_as_type),
+                            op)(*cast(args[1:], run_as_type), **add_kwargs)
+        self.assertTrue(type(output_to_compare) == type(control))
+        comparison = compare(output_to_compare, control)
+        self.assertTrue(comparison,
+                        "torch.{} result did not match control".format(op))
+      self.assertTrue(torch.is_autocast_enabled())
+    self.assertFalse(torch.is_autocast_enabled())
+
+
+class TestAutocast(TestAutocastBase):
+
+  def test_autocast_torch_fp16(self):
+    with torch.backends.cudnn.flags(enabled=True, deterministic=True):
+      for op_with_args in self.autocast_lists.torch_fp16:
+        skip_test = False
+        op, args = op_with_args[0], op_with_args[1]
+        if len(op_with_args) == 3:
+          skip_test = op_with_args[2]  # TEST_WITH_ROCM
+        if not skip_test:
+          self._run_autocast_outofplace(op, args, torch.float16)
+
+
+if __name__ == "__main__":
+  test = unittest.main()
+  sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/torch_xla/csrc/random.cpp
+++ b/torch_xla/csrc/random.cpp
@@ -152,6 +152,7 @@ xla::XlaOp RngNormal(xla::XlaOp seed, const xla::Shape& shape, xla::XlaOp mean,
   xla::XlaOp initial_state =
       xla::Zero(rng_seed.builder(), xla::PrimitiveType::U64);
   switch (shape.element_type()) {
+    case xla::PrimitiveType::F16:
     case xla::PrimitiveType::BF16: {
       xla::XlaOp f32_mean = MaybeConvertTo(mean, xla::PrimitiveType::F32);
       xla::XlaOp f32_std = MaybeConvertTo(std, xla::PrimitiveType::F32);
@@ -160,7 +161,7 @@ xla::XlaOp RngNormal(xla::XlaOp seed, const xla::Shape& shape, xla::XlaOp mean,
                                                GetBitGenerator(), rng_shape)
               .value;
       return xla::ConvertElementType(f32_mean + rng * f32_std,
-                                     xla::PrimitiveType::BF16);
+                                     shape.element_type());
     }
     case xla::PrimitiveType::F32:
     case xla::PrimitiveType::F64: {


### PR DESCRIPTION
Original issue: https://github.com/pytorch/xla/issues/3031. 

Add amp test to check the correct autocast behavior. The test is coped from [test_cuda.py](https://github.com/pytorch/pytorch/blob/master/test/test_cuda.py#L2775). PyTorch cpu also does similar thing in [test_autocast.py](https://github.com/pytorch/pytorch/blob/master/test/test_autocast.py).

I decided to copy the `AutocastTestLists ` to pt/xla since we don't support all of the cuda amp cases. For those we currently don't support, I commented out the op and add a comment explain the gap (for example we don't have lowering for`prelu` so op will fallback to cpu and f16 is not well supported in pytorch CPU).  This test is only intended to be run on `xla:GPU` since pt/xla currently share the same amp rules with CUDA. I made it clear by requires a `xla:GPU` device in the test.

FYI
@yaochengji @ezyang 