### PR TITLE
Add amp flag to imagenet test for GPU

### DIFF
--- a/test/test_train_mp_imagenet.py
+++ b/test/test_train_mp_imagenet.py
@@ -212,6 +212,7 @@ def train_imagenet():
     tracker = xm.RateTracker()
     model.train()
     for step, (data, target) in enumerate(loader):
+      optimizer.zero_grad()
       if FLAGS.amp:
         with autocast():
           output = model(data)


### PR DESCRIPTION
I benchark on a `v100` + `cuda 11.2` with `--batch_size 256 --fake_data --amp` and got  `~1230 img/sec`. We should set up the amp run on nightly.