### PR TITLE
Update logical_and opkind

### DIFF
--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -759,7 +759,7 @@ NodePtr LogicalAnd(const Value& input, const Value& other) {
         [](xla::XlaOp lhs, xla::XlaOp rhs) { return xla::And(lhs, rhs); });
   };
   return GenericOp(
-      OpKind(at::aten::bitwise_and), {input, other},
+      OpKind(at::aten::logical_and), {input, other},
       [&]() {
         return InferOutputShape({input.shape(), other.shape()}, shape_fn);
       },


### PR DESCRIPTION
Correct the OPKind for `logical_and` since https://github.com/pytorch/pytorch/pull/62063 is merged. I will find time to finish the remaining logical ops.