### PR TITLE
Bump up time limit for test_async_closures

### DIFF
--- a/test/test_async_closures.py
+++ b/test/test_async_closures.py
@@ -66,7 +66,7 @@ class AsyncClosuresTest(unittest.TestCase):
     xm.add_step_closure(closure1, run_async=True)
     xm.mark_step()
 
-    sleep(1)
+    sleep(3)
 
     try:
 

--- a/test/test_async_closures.py
+++ b/test/test_async_closures.py
@@ -61,17 +61,18 @@ class AsyncClosuresTest(unittest.TestCase):
     assert not flag.is_set()
 
     def closure1():
+      flag.set()
       raise RuntimeError("Simulating exception in closure1")
 
     xm.add_step_closure(closure1, run_async=True)
     xm.mark_step()
 
-    sleep(3)
+    flag.wait(timeout=5)
 
     try:
 
       def closure2():  # Should never execute
-        flag.set()
+        flag.clear()
 
       xm.add_step_closure(closure2, run_async=True)
       xm.mark_step()
@@ -81,7 +82,7 @@ class AsyncClosuresTest(unittest.TestCase):
       # Should have caught exception from closure1
       pass
 
-    assert not flag.is_set()
+    assert flag.is_set()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Have seen this test failures a couple times in last month, one example would be in [here](https://app.circleci.com/pipelines/github/pytorch/pytorch/357826/workflows/08965b2d-9119-4a0b-805e-6bbc2641be49/jobs/15089954). Bumping up the sleep time to avoid this.