### PR TITLE
Adaptive max pool

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -7422,7 +7422,7 @@ TEST_F(AtenXlaTensorTest, TestAdaptiveMaxPool2D) {
     }
   }
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::adaptive_max_pool2d_out",
+  ExpectCounterChanged("xla::adaptive_max_pool2d",
                        cpp_test::GetIgnoredCounters());
 }
 
@@ -7450,7 +7450,7 @@ TEST_F(AtenXlaTensorTest, TestAdaptiveMaxPool2DBackward) {
     });
   }
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::adaptive_max_pool2d_out",
+  ExpectCounterChanged("xla::adaptive_max_pool2d",
                        cpp_test::GetIgnoredCounters());
 }
 

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -7426,6 +7426,26 @@ TEST_F(AtenXlaTensorTest, TestAdaptiveMaxPool2D) {
                        cpp_test::GetIgnoredCounters());
 }
 
+TEST_F(AtenXlaTensorTest, TestAdaptiveMaxPool2DBackward) {
+  for (int64_t output_size : {2, 5}) {
+    auto testfn =
+        [&](const std::vector<torch::Tensor>& inputs) -> torch::Tensor {
+      return std::get<0>(
+          torch::adaptive_max_pool2d(inputs[0], {output_size, output_size}));
+    };
+    ForEachDevice([&](const torch::Device& device) {
+      TestBackward(
+          {torch::rand(
+              {4, 1, 10, 10},
+              torch::TensorOptions(torch::kFloat).requires_grad(true))},
+          device, testfn);
+    });
+  }
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::adaptive_max_pool2d_out",
+                       cpp_test::GetIgnoredCounters());
+}
+
 TEST_F(AtenXlaTensorTest, TestAdaptiveAvgPool2D) {
   torch::Tensor input =
       torch::rand({4, 1, 28, 28}, torch::TensorOptions(torch::kFloat));

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -7401,6 +7401,31 @@ TEST_F(AtenXlaTensorTest, TestAvgPool3DNoBatch) {
   }
 }
 
+TEST_F(AtenXlaTensorTest, TestAdaptiveMaxPool2D) {
+  std::vector<torch::Tensor> inputs = {
+      torch::rand({2, 10, 10}, torch::TensorOptions(torch::kFloat)),
+      torch::rand({2, 2, 10, 10}, torch::TensorOptions(torch::kFloat)),
+  };
+  std::vector<std::vector<int64_t>> dim_sizes = {{2, 2}, {5, 2}, {5, 5}};
+
+  for (torch::Tensor input : inputs) {
+    for (auto output_size : dim_sizes) {
+      std::tuple<at::Tensor, at::Tensor> output =
+          torch::adaptive_max_pool2d(input, output_size);
+      ForEachDevice([&](const torch::Device& device) {
+        torch::Tensor xla_input = CopyToDevice(input, device);
+        std::tuple<at::Tensor, at::Tensor> xla_output =
+            torch::adaptive_max_pool2d(xla_input, output_size);
+        AllClose(std::get<0>(output), std::get<0>(xla_output));
+        AllClose(std::get<1>(output), std::get<1>(xla_output));
+      });
+    }
+  }
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::adaptive_max_pool2d_out",
+                       cpp_test::GetIgnoredCounters());
+}
+
 TEST_F(AtenXlaTensorTest, TestAdaptiveAvgPool2D) {
   torch::Tensor input =
       torch::rand({4, 1, 28, 28}, torch::TensorOptions(torch::kFloat));

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -7450,7 +7450,7 @@ TEST_F(AtenXlaTensorTest, TestAdaptiveMaxPool2DBackward) {
     });
   }
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::adaptive_max_pool2d",
+  ExpectCounterChanged("xla::adaptive_max_pool2d_backward",
                        cpp_test::GetIgnoredCounters());
 }
 

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -364,14 +364,14 @@ at::Tensor& XLANativeFunctions::adaptive_max_pool2d_backward_out(
   int64_t rank = grad_output.dim();
   std::vector<xla::int64> output_size{grad_output.size(rank - 2),
                                       grad_output.size(rank - 1)};
-  // if (!IsSupportedAdaptivePool(XlaHelpers::I64List(self.sizes()),
-  //                              output_size, /*pool_dim=*/2)) {
-  //   return at::native::call_fallback_fn<
-  //       &xla_cpu_fallback,
-  //       ATEN_OP(adaptive_max_pool2d_backward_out)>::call(grad_output, self,
-  //                                                        indices,
-  //                                                        grad_input);
-  // }
+  if (!IsSupportedAdaptivePool(XlaHelpers::I64List(self.sizes()), output_size,
+                               /*pool_dim=*/2)) {
+    return at::native::call_fallback_fn<
+        &xla_cpu_fallback,
+        ATEN_OP(adaptive_max_pool2d_backward_grad_input)>::call(grad_output,
+                                                                self, indices,
+                                                                grad_input);
+  }
   XLATensor grad_input_tensor = bridge::GetXlaTensor(grad_input);
   XLATensor::adaptive_max_pool2d_backward_out(grad_input_tensor,
                                               bridge::GetXlaTensor(grad_output),

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -357,6 +357,28 @@ XLANativeFunctions::adaptive_max_pool2d_out(const at::Tensor& self,
   return {out, indices};
 }
 
+at::Tensor& XLANativeFunctions::adaptive_max_pool2d_backward_out(
+    const at::Tensor& grad_output, const at::Tensor& self,
+    const at::Tensor& indices, at::Tensor& grad_input) {
+  XLA_FN_COUNTER("xla::");
+  int64_t rank = grad_output.dim();
+  std::vector<xla::int64> output_size{grad_output.size(rank - 2),
+                                      grad_output.size(rank - 1)};
+  // if (!IsSupportedAdaptivePool(XlaHelpers::I64List(self.sizes()),
+  //                              output_size, /*pool_dim=*/2)) {
+  //   return at::native::call_fallback_fn<
+  //       &xla_cpu_fallback,
+  //       ATEN_OP(adaptive_max_pool2d_backward_out)>::call(grad_output, self,
+  //                                                        indices,
+  //                                                        grad_input);
+  // }
+  XLATensor grad_input_tensor = bridge::GetXlaTensor(grad_input);
+  XLATensor::adaptive_max_pool2d_backward_out(grad_input_tensor,
+                                              bridge::GetXlaTensor(grad_output),
+                                              bridge::GetXlaTensor(self));
+  return grad_input;
+}
+
 void XLANativeFunctions::_amp_foreach_non_finite_check_and_unscale_(
     at::TensorList self, at::Tensor& found_inf, const at::Tensor& inv_scale) {
   XLA_FN_COUNTER("xla::");

--- a/torch_xla/csrc/ops/adaptive_max_pool2d.cpp
+++ b/torch_xla/csrc/ops/adaptive_max_pool2d.cpp
@@ -1,0 +1,53 @@
+#include "torch_xla/csrc/ops/adaptive_max_pool2d.h"
+
+#include "tensorflow/compiler/xla/xla_client/debug_macros.h"
+#include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch_xla/csrc/lowering_context.h"
+#include "torch_xla/csrc/ops/infer_output_shape.h"
+#include "torch_xla/csrc/pooling.h"
+
+namespace torch_xla {
+namespace ir {
+namespace ops {
+namespace {
+
+xla::Shape NodeOutputShape(const Value& input,
+                           absl::Span<const xla::int64> output_size) {
+  auto lower_for_shape_fn =
+      [output_size](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
+    XLA_CHECK_EQ(operands.size(), 1);
+    MaxPoolResult result = BuildAdaptiveMaxPoolNd(operands[0], output_size, 2);
+    return xla::Tuple(operands[0].builder(), {result.result, result.indices});
+  };
+  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+}
+
+}  // namespace
+
+AdaptiveMaxPool2d::AdaptiveMaxPool2d(const Value& input,
+                                     std::vector<xla::int64> output_size)
+    : Node(ir::OpKind(at::aten::adaptive_max_pool2d), {input},
+           [&]() { return NodeOutputShape(input, output_size); },
+           /*num_outputs=*/2, xla::util::MHash(output_size)),
+      output_size_(std::move(output_size)) {}
+
+NodePtr AdaptiveMaxPool2d::Clone(OpList operands) const {
+  return MakeNode<AdaptiveMaxPool2d>(operands.at(0), output_size_);
+}
+
+XlaOpVector AdaptiveMaxPool2d::Lower(LoweringContext* loctx) const {
+  xla::XlaOp input = loctx->GetOutputOp(operand(0));
+  MaxPoolResult result = BuildAdaptiveMaxPoolNd(input, output_size_, 2);
+  return ReturnOps({result.result, result.indices}, loctx);
+}
+
+std::string AdaptiveMaxPool2d::ToString() const {
+  std::stringstream ss;
+  ss << Node::ToString() << ", output_size=("
+     << absl::StrJoin(output_size_, ", ") << ")";
+  return ss.str();
+}
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/adaptive_max_pool2d.h
+++ b/torch_xla/csrc/ops/adaptive_max_pool2d.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <vector>
+
+#include "torch_xla/csrc/ir.h"
+
+namespace torch_xla {
+namespace ir {
+namespace ops {
+
+class AdaptiveMaxPool2d : public Node {
+ public:
+  AdaptiveMaxPool2d(const Value& input, std::vector<xla::int64> output_size);
+
+  NodePtr Clone(OpList operands) const override;
+
+  XlaOpVector Lower(LoweringContext* loctx) const override;
+
+  std::string ToString() const override;
+
+  const std::vector<xla::int64>& output_size() const { return output_size_; }
+
+ private:
+  std::vector<xla::int64> output_size_;
+};
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -154,6 +154,8 @@ NodePtr Dot(const Value& input, const Value& weight);
 
 NodePtr MatMul(const Value& lhs, const Value& rhs);
 
+NodePtr AdaptiveMaxPool2dBackward(const Value& grad_output, const Value& input);
+
 NodePtr AdaptiveAvgPool2dBackward(const Value& grad_output, const Value& input);
 
 NodePtr AdaptiveAvgPool3dBackward(const Value& grad_output, const Value& input);

--- a/torch_xla/csrc/pooling.h
+++ b/torch_xla/csrc/pooling.h
@@ -54,6 +54,10 @@ MaxPoolResult BuildAdaptiveMaxPoolNd(xla::XlaOp input,
                                      absl::Span<const xla::int64> output_size,
                                      int pool_dim);
 
+// Computes the gradient for adaptive max pooling.
+xla::XlaOp BuildAdaptiveMaxPoolNdBackward(xla::XlaOp out_backprop,
+                                          xla::XlaOp input, int pool_dim);
+
 // Computes adaptive average pooling for the given input and output size.
 xla::XlaOp BuildAdaptiveAvgPool3d(xla::XlaOp input,
                                   absl::Span<const xla::int64> output_size);

--- a/torch_xla/csrc/pooling.h
+++ b/torch_xla/csrc/pooling.h
@@ -49,6 +49,11 @@ xla::XlaOp BuildMaxUnpoolNdBackward(xla::XlaOp grad_output, xla::XlaOp input,
                                     xla::XlaOp indices,
                                     absl::Span<const xla::int64> output_size);
 
+// Computes adaptive max pooling for the given input and output size.
+MaxPoolResult BuildAdaptiveMaxPoolNd(xla::XlaOp input,
+                                     absl::Span<const xla::int64> output_size,
+                                     int pool_dim);
+
 // Computes adaptive average pooling for the given input and output size.
 xla::XlaOp BuildAdaptiveAvgPool3d(xla::XlaOp input,
                                   absl::Span<const xla::int64> output_size);
@@ -67,8 +72,8 @@ xla::XlaOp BuildAdaptiveAvgPool2dBackward(xla::XlaOp out_backprop,
 
 // Returns true if XLA lowering is supported for the given input and output size
 // combination.
-bool IsSupportedAdaptiveAvgPool(absl::Span<const xla::int64> input_size,
-                                absl::Span<const xla::int64> output_size,
-                                int pool_dim);
+bool IsSupportedAdaptivePool(absl::Span<const xla::int64> input_size,
+                             absl::Span<const xla::int64> output_size,
+                             int pool_dim);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -239,6 +239,10 @@ class XLATensor {
                                       const XLATensor& input,
                                       std::vector<xla::int64> output_size);
 
+  static void adaptive_max_pool2d_backward_out(XLATensor& grad_input,
+                                               const XLATensor& grad_output,
+                                               const XLATensor& input);
+
   static XLATensor adaptive_avg_pool3d(const XLATensor& input,
                                        std::vector<xla::int64> output_size);
 

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -235,13 +235,11 @@ class XLATensor {
       const XLATensor& input, const XLATensor& other,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
 
-  static void adaptive_max_pool2d_out(XLATensor& out, XLATensor& indices,
-                                      const XLATensor& input,
-                                      std::vector<xla::int64> output_size);
+  static std::tuple<XLATensor, XLATensor> adaptive_max_pool2d(
+      const XLATensor& input, std::vector<xla::int64> output_size);
 
-  static void adaptive_max_pool2d_backward_out(XLATensor& grad_input,
-                                               const XLATensor& grad_output,
-                                               const XLATensor& input);
+  static XLATensor adaptive_max_pool2d_backward(const XLATensor& grad_output,
+                                                const XLATensor& input);
 
   static XLATensor adaptive_avg_pool3d(const XLATensor& input,
                                        std::vector<xla::int64> output_size);

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -235,6 +235,10 @@ class XLATensor {
       const XLATensor& input, const XLATensor& other,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
 
+  static void adaptive_max_pool2d_out(XLATensor& out, XLATensor& indices,
+                                      const XLATensor& input,
+                                      std::vector<xla::int64> output_size);
+
   static XLATensor adaptive_avg_pool3d(const XLATensor& input,
                                        std::vector<xla::int64> output_size);
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -449,21 +449,19 @@ XLATensor XLATensor::__rshift__(
       logical_element_type);
 }
 
-void XLATensor::adaptive_max_pool2d_out(XLATensor& out, XLATensor& indices,
-                                        const XLATensor& input,
-                                        std::vector<xla::int64> output_size) {
+std::tuple<XLATensor, XLATensor> XLATensor::adaptive_max_pool2d(
+    const XLATensor& input, std::vector<xla::int64> output_size) {
   ir::NodePtr node =
       ir::MakeNode<ir::ops::AdaptiveMaxPool2d>(input.GetIrValue(), output_size);
-  out.SetIrValue(ir::Value(node, 0));
-  indices.SetIrValue(
-      indices.MaybeCastIrValue(ir::Value(node, 1), indices.GetDevice(),
-                               /*logical_element_type=*/at::ScalarType::Long));
+  XLATensor out = input.CreateFrom(ir::Value(node, 0));
+  XLATensor indices =
+      input.CreateFrom(ir::Value(node, 1), at::ScalarType::Long);
+  return std::make_tuple(std::move(out), std::move(indices));
 }
 
-void XLATensor::adaptive_max_pool2d_backward_out(XLATensor& grad_input,
-                                                 const XLATensor& grad_output,
-                                                 const XLATensor& input) {
-  grad_input.SetIrValue(ir::ops::AdaptiveMaxPool2dBackward(
+XLATensor XLATensor::adaptive_max_pool2d_backward(const XLATensor& grad_output,
+                                                  const XLATensor& input) {
+  return input.CreateFrom(ir::ops::AdaptiveMaxPool2dBackward(
       grad_output.GetIrValue(), input.GetIrValue()));
 }
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -460,6 +460,13 @@ void XLATensor::adaptive_max_pool2d_out(XLATensor& out, XLATensor& indices,
                                /*logical_element_type=*/at::ScalarType::Long));
 }
 
+void XLATensor::adaptive_max_pool2d_backward_out(XLATensor& grad_input,
+                                                 const XLATensor& grad_output,
+                                                 const XLATensor& input) {
+  grad_input.SetIrValue(ir::ops::AdaptiveMaxPool2dBackward(
+      grad_output.GetIrValue(), input.GetIrValue()));
+}
+
 XLATensor XLATensor::adaptive_avg_pool3d(const XLATensor& input,
                                          std::vector<xla::int64> output_size) {
   return input.CreateFrom(ir::MakeNode<ir::ops::AdaptiveAvgPool3d>(

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -19,6 +19,7 @@
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/ops/adaptive_avg_pool2d.h"
 #include "torch_xla/csrc/ops/adaptive_avg_pool3d.h"
+#include "torch_xla/csrc/ops/adaptive_max_pool2d.h"
 #include "torch_xla/csrc/ops/all.h"
 #include "torch_xla/csrc/ops/all_reduce.h"
 #include "torch_xla/csrc/ops/all_to_all.h"
@@ -446,6 +447,17 @@ XLATensor XLATensor::__rshift__(
   return input.CreateFrom(
       ir::ops::Rshift(input.GetIrValue(), other.GetIrValue()),
       logical_element_type);
+}
+
+void XLATensor::adaptive_max_pool2d_out(XLATensor& out, XLATensor& indices,
+                                        const XLATensor& input,
+                                        std::vector<xla::int64> output_size) {
+  ir::NodePtr node =
+      ir::MakeNode<ir::ops::AdaptiveMaxPool2d>(input.GetIrValue(), output_size);
+  out.SetIrValue(ir::Value(node, 0));
+  indices.SetIrValue(
+      indices.MaybeCastIrValue(ir::Value(node, 1), indices.GetDevice(),
+                               /*logical_element_type=*/at::ScalarType::Long));
 }
 
 XLATensor XLATensor::adaptive_avg_pool3d(const XLATensor& input,

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -318,6 +318,7 @@ supported:
   - lerp.Tensor
   - logical_and.out
   - adaptive_max_pool2d.out
+  - adaptive_max_pool2d_backward.grad_input
 autograd:
   - max_pool2d
   - max_pool3d

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -317,8 +317,8 @@ supported:
   - lerp.Scalar
   - lerp.Tensor
   - logical_and.out
-  - adaptive_max_pool2d.out
-  - adaptive_max_pool2d_backward.grad_input
+  - adaptive_max_pool2d
+  - adaptive_max_pool2d_backward
 autograd:
   - max_pool2d
   - max_pool3d

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -317,6 +317,7 @@ supported:
   - lerp.Scalar
   - lerp.Tensor
   - logical_and.out
+  - adaptive_max_pool2d.out
 autograd:
   - max_pool2d
   - max_pool3d


### PR DESCRIPTION
This is to fix https://github.com/pytorch/xla/issues/3049 and provide `adaptive_max_pool_2d` lowering. This pr only supports non-overlapping windows due to the reason stated in https://github.com/pytorch/xla/issues/3049#issuecomment-895425633.

I will try to find time to finish the `adaptive_max_pool3d` lowering since it will be a minor tweak of this one.