### PR TITLE
Minor reorder of std_mean member

### DIFF
--- a/torch_xla/csrc/ops/std_mean.h
+++ b/torch_xla/csrc/ops/std_mean.h
@@ -22,14 +22,14 @@ class StdMean : public Node {
 
   const std::vector<xla::int64>& dimensions() const { return dimensions_; }
 
-  bool keep_reduced_dimensions() const { return keep_reduced_dimensions_; }
-
   xla::int64 correction() const { return correction_; }
+
+  bool keep_reduced_dimensions() const { return keep_reduced_dimensions_; }
 
  private:
   std::vector<xla::int64> dimensions_;
-  bool keep_reduced_dimensions_;
   xla::int64 correction_;
+  bool keep_reduced_dimensions_;
 };
 
 }  // namespace ops


### PR DESCRIPTION
This is to get rid of the warning message
```
/usr/local/google/home/jackcao/Desktop/gitProj2/pytorch/xla/torch_xla/csrc/ops/std_mean.cpp:41:7: warning: field 'correction_' will be initialized after field 'keep_reduced_dimensions_' [-Wreorder]

      correction_(correction),

      ^

1 warning generated.
```