### PR TITLE
update op lowering guide, update scatter ops to lower out-of-place in…

### DIFF
--- a/OP_LOWERING_GUIDE.md
+++ b/OP_LOWERING_GUIDE.md
@@ -79,6 +79,8 @@ at::Tensor & wrapper_Scalar_lerp_(at::Tensor & self, const at::Tensor & end, con
 
 ```
 
-`lerp_.Scalar` will use our `lerp.Scalar` implementation without us providing explictly lowering.
+The codegen will automatically generate lowerings for`lerp_.Scalar` and `lerp.Scalar_out` that use our `lerp.Scalar` implementation, without us having to provide an explictly lowering.
+
+In general, if there is an operator in pytorch core that has both an out-of-place and an out= variant, it's better to write a lowering for the out-of-place variant, since you'll get a code-generated out= lowering for free.
 
 For each node we need to pass an `ir::OpKind`. Here is an ([example](https://github.com/pytorch/xla/blob/5ce99bff336325feb41a982dc80299fb53166b29/torch_xla/csrc/ops/var_mean.cpp#L36)). You can find the `OpKind` definition in [aten_interned_strings.h](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/core/aten_interned_strings.h) or [interned_strings.h](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/core/interned_strings.h). If the aten symbol is missing, you can submit a PR like [this](https://github.com/pytorch/pytorch/pull/36851).

--- a/OP_LOWERING_GUIDE.md
+++ b/OP_LOWERING_GUIDE.md
@@ -79,7 +79,7 @@ at::Tensor & wrapper_Scalar_lerp_(at::Tensor & self, const at::Tensor & end, con
 
 ```
 
-The codegen will automatically generate lowerings for`lerp_.Scalar` and `lerp.Scalar_out` that use our `lerp.Scalar` implementation, without us having to provide an explictly lowering.
+The codegen will automatically generate lowerings for `lerp_.Scalar` and `lerp.Scalar_out` that use our `lerp.Scalar` implementation, without us having to provide an explicit lowering.
 
 In general, if there is an operator in pytorch core that has both an out-of-place and an out= variant, it's better to write a lowering for the out-of-place variant, since you'll get a code-generated out= lowering for free.
 

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -4252,7 +4252,7 @@ TEST_F(AtenXlaTensorTest, TestScatter) {
     });
   }
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::scatter_out", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::scatter", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterR1) {
@@ -4271,7 +4271,7 @@ TEST_F(AtenXlaTensorTest, TestScatterR1) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::scatter_out", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::scatter", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterR3) {
@@ -4295,7 +4295,7 @@ TEST_F(AtenXlaTensorTest, TestScatterR3) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::scatter_out", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::scatter", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterBiggerSource) {
@@ -4319,7 +4319,7 @@ TEST_F(AtenXlaTensorTest, TestScatterBiggerSource) {
   }
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::scatter_out", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::scatter", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterScalar) {
@@ -4342,7 +4342,7 @@ TEST_F(AtenXlaTensorTest, TestScatterScalar) {
   }
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::scatter_out", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::scatter", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceAdd) {
@@ -4366,7 +4366,7 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceAdd) {
   }
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::scatter_out", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::scatter", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterAdd) {
@@ -4390,7 +4390,7 @@ TEST_F(AtenXlaTensorTest, TestScatterAdd) {
   }
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::scatter_add_out", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::scatter_add", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterAddInPlace) {
@@ -4415,7 +4415,7 @@ TEST_F(AtenXlaTensorTest, TestScatterAddInPlace) {
     });
 
     ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-    ExpectCounterChanged("xla::scatter_add_", cpp_test::GetIgnoredCounters());
+    ExpectCounterChanged("xla::scatter_add", cpp_test::GetIgnoredCounters());
   }
 }
 

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -6315,7 +6315,7 @@ TEST_F(AtenXlaTensorTest, TestOneHot) {
   // TODO: PT one_hot impl employs item() which could be eliminated.
   ExpectCounterNotChanged("aten::(?!_local_scalar_dense).*",
                           cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::scatter_out", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::scatter", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestTranspose) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2707,83 +2707,79 @@ at::Tensor XLANativeFunctions::rsub(const at::Tensor& self,
 }
 
 at::Tensor scatter_reduce_helper(const at::Tensor& self, int64_t dim,
-                                      const at::Tensor& index,
-                                      const at::Tensor& src,
-                                      c10::optional<c10::string_view> reduce) {
+                                 const at::Tensor& index, const at::Tensor& src,
+                                 c10::optional<c10::string_view> reduce) {
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   if (!reduce.has_value()) {
-    return bridge::AtenFromXlaTensor(XLATensor::scatter(self_tensor, dim,
-                           bridge::GetXlaTensor(index),
+    return bridge::AtenFromXlaTensor(
+        XLATensor::scatter(self_tensor, dim, bridge::GetXlaTensor(index),
                            bridge::GetXlaTensor(src)));
   } else if (*reduce == "add") {
-    return bridge::AtenFromXlaTensor(XLATensor::scatter_add(self_tensor, dim,
-                               bridge::GetXlaTensor(index),
+    return bridge::AtenFromXlaTensor(
+        XLATensor::scatter_add(self_tensor, dim, bridge::GetXlaTensor(index),
                                bridge::GetXlaTensor(src)));
   } else {
     // TODO: implement scatter_mul
     return at::native::call_fallback_fn<
-        &xla_cpu_fallback, ATEN_OP2(scatter, reduce)>::call(self, dim,
-                                                                index, src,
-                                                                *reduce);
+        &xla_cpu_fallback, ATEN_OP2(scatter, reduce)>::call(self, dim, index,
+                                                            src, *reduce);
   }
 }
 
 at::Tensor scatter_reduce_helper(const at::Tensor& self, int64_t dim,
-                                      const at::Tensor& index,
-                                      const at::Scalar& value,
-                                      c10::optional<c10::string_view> reduce) {
+                                 const at::Tensor& index,
+                                 const at::Scalar& value,
+                                 c10::optional<c10::string_view> reduce) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   if (!reduce.has_value()) {
-    return bridge::AtenFromXlaTensor(XLATensor::scatter(self_tensor, dim,
-                           bridge::GetXlaTensor(index), value));
+    return bridge::AtenFromXlaTensor(XLATensor::scatter(
+        self_tensor, dim, bridge::GetXlaTensor(index), value));
   } else if (*reduce == "add") {
-    return bridge::AtenFromXlaTensor(XLATensor::scatter_add(self_tensor, dim,
-                               bridge::GetXlaTensor(index), value));
+    return bridge::AtenFromXlaTensor(XLATensor::scatter_add(
+        self_tensor, dim, bridge::GetXlaTensor(index), value));
   } else {
     // TODO: implement scatter_mul
     return at::native::call_fallback_fn<
         &xla_cpu_fallback, ATEN_OP2(scatter, value_reduce)>::call(self, dim,
-                                                                      index,
-                                                                      value,
-                                                                      *reduce);
+                                                                  index, value,
+                                                                  *reduce);
   }
 }
 
 at::Tensor XLANativeFunctions::scatter(const at::Tensor& self, int64_t dim,
-                                            const at::Tensor& index,
-                                            const at::Tensor& src) {
+                                       const at::Tensor& index,
+                                       const at::Tensor& src) {
   XLA_FN_COUNTER("xla::");
   return scatter_reduce_helper(self, dim, index, src, c10::nullopt);
 }
 
 at::Tensor XLANativeFunctions::scatter(const at::Tensor& self, int64_t dim,
-                                            const at::Tensor& index,
-                                            const at::Scalar& value) {
+                                       const at::Tensor& index,
+                                       const at::Scalar& value) {
   XLA_FN_COUNTER("xla::");
   return scatter_reduce_helper(self, dim, index, value, c10::nullopt);
 }
 
 at::Tensor XLANativeFunctions::scatter(const at::Tensor& self, int64_t dim,
-                                            const at::Tensor& index,
-                                            const at::Tensor& src,
-                                            c10::string_view reduce) {
+                                       const at::Tensor& index,
+                                       const at::Tensor& src,
+                                       c10::string_view reduce) {
   XLA_FN_COUNTER("xla::");
   return scatter_reduce_helper(self, dim, index, src, reduce);
 }
 
 at::Tensor XLANativeFunctions::scatter(const at::Tensor& self, int64_t dim,
-                                            const at::Tensor& index,
-                                            const at::Scalar& value,
-                                            c10::string_view reduce) {
+                                       const at::Tensor& index,
+                                       const at::Scalar& value,
+                                       c10::string_view reduce) {
   XLA_FN_COUNTER("xla::");
   return scatter_reduce_helper(self, dim, index, value, reduce);
 }
 
-at::Tensor XLANativeFunctions::scatter_add(const at::Tensor& self,
-                                                int64_t dim,
-                                                const at::Tensor& index,
-                                                const at::Tensor& src) {
+at::Tensor XLANativeFunctions::scatter_add(const at::Tensor& self, int64_t dim,
+                                           const at::Tensor& index,
+                                           const at::Tensor& src) {
   XLA_FN_COUNTER("xla::");
   return scatter_reduce_helper(self, dim, index, src, "add");
 }

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2706,110 +2706,86 @@ at::Tensor XLANativeFunctions::rsub(const at::Tensor& self,
       XLATensor::rsub(bridge::GetXlaTensor(self), other, alpha));
 }
 
-at::Tensor& scatter_reduce_out_helper(const at::Tensor& self, int64_t dim,
+at::Tensor scatter_reduce_helper(const at::Tensor& self, int64_t dim,
                                       const at::Tensor& index,
                                       const at::Tensor& src,
-                                      c10::optional<c10::string_view> reduce,
-                                      at::Tensor& out) {
+                                      c10::optional<c10::string_view> reduce) {
   XLATensor self_tensor = bridge::GetXlaTensor(self);
-  XLATensor out_tensor = bridge::GetXlaTensor(out);
   if (!reduce.has_value()) {
-    XLATensor::scatter_out(out_tensor, self_tensor, dim,
+    return bridge::AtenFromXlaTensor(XLATensor::scatter(self_tensor, dim,
                            bridge::GetXlaTensor(index),
-                           bridge::GetXlaTensor(src));
-    return out;
+                           bridge::GetXlaTensor(src)));
   } else if (*reduce == "add") {
-    XLATensor::scatter_add_out(out_tensor, self_tensor, dim,
+    return bridge::AtenFromXlaTensor(XLATensor::scatter_add(self_tensor, dim,
                                bridge::GetXlaTensor(index),
-                               bridge::GetXlaTensor(src));
+                               bridge::GetXlaTensor(src)));
   } else {
     // TODO: implement scatter_mul
     return at::native::call_fallback_fn<
-        &xla_cpu_fallback, ATEN_OP2(scatter, reduce_out)>::call(self, dim,
+        &xla_cpu_fallback, ATEN_OP2(scatter, reduce)>::call(self, dim,
                                                                 index, src,
-                                                                *reduce, out);
+                                                                *reduce);
   }
-  return out;
 }
 
-at::Tensor& scatter_reduce_out_helper(const at::Tensor& self, int64_t dim,
+at::Tensor scatter_reduce_helper(const at::Tensor& self, int64_t dim,
                                       const at::Tensor& index,
                                       const at::Scalar& value,
-                                      c10::optional<c10::string_view> reduce,
-                                      at::Tensor& out) {
+                                      c10::optional<c10::string_view> reduce) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
-  XLATensor out_tensor = bridge::GetXlaTensor(out);
   if (!reduce.has_value()) {
-    XLATensor::scatter_out(out_tensor, self_tensor, dim,
-                           bridge::GetXlaTensor(index), value);
-    return out;
+    return bridge::AtenFromXlaTensor(XLATensor::scatter(self_tensor, dim,
+                           bridge::GetXlaTensor(index), value));
   } else if (*reduce == "add") {
-    XLATensor::scatter_add_out(out_tensor, self_tensor, dim,
-                               bridge::GetXlaTensor(index), value);
+    return bridge::AtenFromXlaTensor(XLATensor::scatter_add(self_tensor, dim,
+                               bridge::GetXlaTensor(index), value));
   } else {
     // TODO: implement scatter_mul
     return at::native::call_fallback_fn<
-        &xla_cpu_fallback, ATEN_OP2(scatter, value_reduce_out)>::call(self, dim,
+        &xla_cpu_fallback, ATEN_OP2(scatter, value_reduce)>::call(self, dim,
                                                                       index,
                                                                       value,
-                                                                      *reduce,
-                                                                      out);
+                                                                      *reduce);
   }
-  return out;
 }
 
-at::Tensor& XLANativeFunctions::scatter_out(const at::Tensor& self, int64_t dim,
+at::Tensor XLANativeFunctions::scatter(const at::Tensor& self, int64_t dim,
+                                            const at::Tensor& index,
+                                            const at::Tensor& src) {
+  XLA_FN_COUNTER("xla::");
+  return scatter_reduce_helper(self, dim, index, src, c10::nullopt);
+}
+
+at::Tensor XLANativeFunctions::scatter(const at::Tensor& self, int64_t dim,
+                                            const at::Tensor& index,
+                                            const at::Scalar& value) {
+  XLA_FN_COUNTER("xla::");
+  return scatter_reduce_helper(self, dim, index, value, c10::nullopt);
+}
+
+at::Tensor XLANativeFunctions::scatter(const at::Tensor& self, int64_t dim,
                                             const at::Tensor& index,
                                             const at::Tensor& src,
-                                            at::Tensor& out) {
+                                            c10::string_view reduce) {
   XLA_FN_COUNTER("xla::");
-  return scatter_reduce_out_helper(self, dim, index, src, c10::nullopt, out);
+  return scatter_reduce_helper(self, dim, index, src, reduce);
 }
 
-at::Tensor& XLANativeFunctions::scatter_out(const at::Tensor& self, int64_t dim,
+at::Tensor XLANativeFunctions::scatter(const at::Tensor& self, int64_t dim,
                                             const at::Tensor& index,
                                             const at::Scalar& value,
-                                            at::Tensor& out) {
+                                            c10::string_view reduce) {
   XLA_FN_COUNTER("xla::");
-  return scatter_reduce_out_helper(self, dim, index, value, c10::nullopt, out);
+  return scatter_reduce_helper(self, dim, index, value, reduce);
 }
 
-at::Tensor& XLANativeFunctions::scatter_out(const at::Tensor& self, int64_t dim,
-                                            const at::Tensor& index,
-                                            const at::Tensor& src,
-                                            c10::string_view reduce,
-                                            at::Tensor& out) {
-  XLA_FN_COUNTER("xla::");
-  return scatter_reduce_out_helper(self, dim, index, src, reduce, out);
-}
-
-at::Tensor& XLANativeFunctions::scatter_out(const at::Tensor& self, int64_t dim,
-                                            const at::Tensor& index,
-                                            const at::Scalar& value,
-                                            c10::string_view reduce,
-                                            at::Tensor& out) {
-  XLA_FN_COUNTER("xla::");
-  return scatter_reduce_out_helper(self, dim, index, value, reduce, out);
-}
-
-at::Tensor& XLANativeFunctions::scatter_add_out(const at::Tensor& self,
+at::Tensor XLANativeFunctions::scatter_add(const at::Tensor& self,
                                                 int64_t dim,
                                                 const at::Tensor& index,
-                                                const at::Tensor& src,
-                                                at::Tensor& out) {
+                                                const at::Tensor& src) {
   XLA_FN_COUNTER("xla::");
-  return scatter_reduce_out_helper(self, dim, index, src, "add", out);
-}
-
-at::Tensor& XLANativeFunctions::scatter_add_(at::Tensor& self, int64_t dim,
-                                             const at::Tensor& index,
-                                             const at::Tensor& src) {
-  XLA_FN_COUNTER("xla::");
-  XLATensor self_tensor = bridge::GetXlaTensor(self);
-  XLATensor::scatter_add_(self_tensor, dim, bridge::GetXlaTensor(index),
-                          bridge::GetXlaTensor(src));
-  return self;
+  return scatter_reduce_helper(self, dim, index, src, "add");
 }
 
 at::Tensor XLANativeFunctions::select(const at::Tensor& self, int64_t dim,

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -934,19 +934,17 @@ class XLATensor {
 
   static void copy_(XLATensor& input, XLATensor& src);
 
-  static void scatter_out(XLATensor& out, const XLATensor& input,
+  static XLATensor scatter(const XLATensor& input,
                           xla::int64 dim, const XLATensor& index,
                           const XLATensor& src);
-  static void scatter_out(XLATensor& out, const XLATensor& input,
+  static XLATensor scatter(const XLATensor& input,
                           xla::int64 dim, const XLATensor& index,
                           const at::Scalar& value);
 
-  static void scatter_add_(XLATensor& input, xla::int64 dim,
-                           const XLATensor& index, const XLATensor& src);
-  static void scatter_add_out(XLATensor& out, const XLATensor& input,
+  static XLATensor scatter_add(const XLATensor& input,
                               xla::int64 dim, const XLATensor& index,
                               const XLATensor& src);
-  static void scatter_add_out(XLATensor& out, const XLATensor& input,
+  static XLATensor scatter_add(const XLATensor& input,
                               xla::int64 dim, const XLATensor& index,
                               const at::Scalar& value);
 

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -934,19 +934,15 @@ class XLATensor {
 
   static void copy_(XLATensor& input, XLATensor& src);
 
-  static XLATensor scatter(const XLATensor& input,
-                          xla::int64 dim, const XLATensor& index,
-                          const XLATensor& src);
-  static XLATensor scatter(const XLATensor& input,
-                          xla::int64 dim, const XLATensor& index,
-                          const at::Scalar& value);
+  static XLATensor scatter(const XLATensor& input, xla::int64 dim,
+                           const XLATensor& index, const XLATensor& src);
+  static XLATensor scatter(const XLATensor& input, xla::int64 dim,
+                           const XLATensor& index, const at::Scalar& value);
 
-  static XLATensor scatter_add(const XLATensor& input,
-                              xla::int64 dim, const XLATensor& index,
-                              const XLATensor& src);
-  static XLATensor scatter_add(const XLATensor& input,
-                              xla::int64 dim, const XLATensor& index,
-                              const at::Scalar& value);
+  static XLATensor scatter_add(const XLATensor& input, xla::int64 dim,
+                               const XLATensor& index, const XLATensor& src);
+  static XLATensor scatter_add(const XLATensor& input, xla::int64 dim,
+                               const XLATensor& index, const at::Scalar& value);
 
   static XLATensor select(const XLATensor& input, xla::int64 dim,
                           xla::int64 index);

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2187,45 +2187,38 @@ void XLATensor::copy_(XLATensor& input, XLATensor& src) {
   }
 }
 
-void XLATensor::scatter_out(XLATensor& out, const XLATensor& input,
+XLATensor XLATensor::scatter(const XLATensor& input,
                             xla::int64 dim, const XLATensor& index,
                             const XLATensor& src) {
-  out.SetIrValue(ir::MakeNode<ir::ops::Scatter>(
+  return input.CreateFrom(ir::MakeNode<ir::ops::Scatter>(
       input.GetIrValue(), index.GetIrValue(), src.GetIrValue(),
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank())));
 }
 
-void XLATensor::scatter_out(XLATensor& out, const XLATensor& input,
+XLATensor XLATensor::scatter(const XLATensor& input,
                             xla::int64 dim, const XLATensor& index,
                             const at::Scalar& value) {
   ir::Value constant =
       GetIrValueForScalar(value, input.shape(), input.GetDevice());
-  out.SetIrValue(ir::MakeNode<ir::ops::Scatter>(
+  return input.CreateFrom(ir::MakeNode<ir::ops::Scatter>(
       input.GetIrValue(), index.GetIrValue(), constant,
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank())));
 }
 
-void XLATensor::scatter_add_(XLATensor& input, xla::int64 dim,
-                             const XLATensor& index, const XLATensor& src) {
-  input.SetIrValue(ir::MakeNode<ir::ops::ScatterAdd>(
-      input.GetIrValue(), index.GetIrValue(), src.GetIrValue(),
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank())));
-}
-
-void XLATensor::scatter_add_out(XLATensor& out, const XLATensor& input,
+XLATensor XLATensor::scatter_add(const XLATensor& input,
                                 xla::int64 dim, const XLATensor& index,
                                 const XLATensor& src) {
-  out.SetIrValue(ir::MakeNode<ir::ops::ScatterAdd>(
+  return input.CreateFrom(ir::MakeNode<ir::ops::ScatterAdd>(
       input.GetIrValue(), index.GetIrValue(), src.GetIrValue(),
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank())));
 }
 
-void XLATensor::scatter_add_out(XLATensor& out, const XLATensor& input,
+XLATensor XLATensor::scatter_add(const XLATensor& input,
                                 xla::int64 dim, const XLATensor& index,
                                 const at::Scalar& value) {
   ir::Value constant =
       GetIrValueForScalar(value, input.shape(), input.GetDevice());
-  out.SetIrValue(ir::MakeNode<ir::ops::ScatterAdd>(
+  return input.CreateFrom(ir::MakeNode<ir::ops::ScatterAdd>(
       input.GetIrValue(), index.GetIrValue(), constant,
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank())));
 }

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2187,17 +2187,15 @@ void XLATensor::copy_(XLATensor& input, XLATensor& src) {
   }
 }
 
-XLATensor XLATensor::scatter(const XLATensor& input,
-                            xla::int64 dim, const XLATensor& index,
-                            const XLATensor& src) {
+XLATensor XLATensor::scatter(const XLATensor& input, xla::int64 dim,
+                             const XLATensor& index, const XLATensor& src) {
   return input.CreateFrom(ir::MakeNode<ir::ops::Scatter>(
       input.GetIrValue(), index.GetIrValue(), src.GetIrValue(),
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank())));
 }
 
-XLATensor XLATensor::scatter(const XLATensor& input,
-                            xla::int64 dim, const XLATensor& index,
-                            const at::Scalar& value) {
+XLATensor XLATensor::scatter(const XLATensor& input, xla::int64 dim,
+                             const XLATensor& index, const at::Scalar& value) {
   ir::Value constant =
       GetIrValueForScalar(value, input.shape(), input.GetDevice());
   return input.CreateFrom(ir::MakeNode<ir::ops::Scatter>(
@@ -2205,17 +2203,16 @@ XLATensor XLATensor::scatter(const XLATensor& input,
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank())));
 }
 
-XLATensor XLATensor::scatter_add(const XLATensor& input,
-                                xla::int64 dim, const XLATensor& index,
-                                const XLATensor& src) {
+XLATensor XLATensor::scatter_add(const XLATensor& input, xla::int64 dim,
+                                 const XLATensor& index, const XLATensor& src) {
   return input.CreateFrom(ir::MakeNode<ir::ops::ScatterAdd>(
       input.GetIrValue(), index.GetIrValue(), src.GetIrValue(),
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank())));
 }
 
-XLATensor XLATensor::scatter_add(const XLATensor& input,
-                                xla::int64 dim, const XLATensor& index,
-                                const at::Scalar& value) {
+XLATensor XLATensor::scatter_add(const XLATensor& input, xla::int64 dim,
+                                 const XLATensor& index,
+                                 const at::Scalar& value) {
   ir::Value constant =
       GetIrValueForScalar(value, input.shape(), input.GetDevice());
   return input.CreateFrom(ir::MakeNode<ir::ops::ScatterAdd>(

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -174,12 +174,11 @@ supported:
   - index_add_
   - index_fill_.int_Scalar
   - index_fill_.int_Tensor
-  - scatter.src_out
-  - scatter.value_out
-  - scatter.reduce_out
-  - scatter.value_reduce_out
-  - scatter_add_
-  - scatter_add.out
+  - scatter.src
+  - scatter.value
+  - scatter.reduce
+  - scatter.value_reduce
+  - scatter_add
   - bitwise_and.Tensor
   - bitwise_and.Scalar
   - bitwise_or.Tensor_out


### PR DESCRIPTION
Small update to the op lowering guide to make it a little more explicit that given the choice between writing a lowering for the `out-of-place` or `out=` variant of an operator (for example, `add.Tensor` vs. `add.out`), it's better to write a lowering for the out-of-place variant, since we'll code-generate an out= lowering for you.

In a lot of cases, you'll actually silently incur a minor perf hit, although I don't expect it to be too impactful - pytorch core code-generates composite kernels for some `out-of-place` operators that create an empty tensor and call into the `out=` operator, so you'll end up going through that code path to hit your `out=` lowering.

There are also a bunch of existing lowerings written for `out=` operators. Historically, that's probably because it was only recently that the codegen started automatically trying to detect when it could codegen `out=` and inplace lowerings for you.

So just as a start, I updated the `scatter` lowerings to lower the out-of-place variant of the op instead. A little curious if we'll see any perf changes after this commit lands in the perf dashboard.