### PR TITLE
Run test_autocast for cpu and gpu on circleCI

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -96,13 +96,14 @@ function run_torch_xla_tests() {
   pushd $XLA_DIR
     echo "Running Python Tests"
     ./test/run_tests.sh
+    # only run test_autocast for cpu and gpu on circleCI.
+    python test/test_autocast.py
 
     # echo "Running MNIST Test"
     # python test/test_train_mp_mnist.py --tidy
-    if [ -x "$(command -v nvidia-smi)" ]; then
-      python test/test_autocast.py
+    # if [ -x "$(command -v nvidia-smi)" ]; then
       # python test/test_train_mp_mnist_amp.py --fake_data
-    fi
+    # fi
 
     pushd test/cpp
     echo "Running C++ Tests"

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -51,8 +51,7 @@ class TestAutocastBase(unittest.TestCase):
 
   def setUp(self):
     super(TestAutocastBase, self).setUp()
-    self.autocast_lists = AutocastTestLists(
-        torch.device(xm.xla_device()))
+    self.autocast_lists = AutocastTestLists(torch.device(xm.xla_device()))
     self.autocast_unsupported_lists = AutocastTestUnsupportedLists()
     self.skip_list = []
 

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -2,7 +2,7 @@ import argparse
 import sys
 
 parser = argparse.ArgumentParser(add_help=False)
-parser.add_argument('--verbosity', type=int, default=0)
+parser.add_argument('--verbosity', type=int, default=2)
 FLAGS, leftovers = parser.parse_known_args()
 sys.argv = [sys.argv[0]] + leftovers
 
@@ -52,7 +52,7 @@ class TestAutocastBase(unittest.TestCase):
   def setUp(self):
     super(TestAutocastBase, self).setUp()
     self.autocast_lists = AutocastTestLists(
-        torch.device(xm.xla_device(devkind="GPU")))
+        torch.device(xm.xla_device()))
     self.autocast_unsupported_lists = AutocastTestUnsupportedLists()
     self.skip_list = []
 


### PR DESCRIPTION
This should increase the test coverage. Running `test_autocast` on CPU CI should help us to catch the breakage from the upstream pytorch. More context in https://github.com/pytorch/xla/issues/3086#issuecomment-901401166