### PR TITLE
match an optional 3rd digit for version number

### DIFF
--- a/docker/common.sh
+++ b/docker/common.sh
@@ -16,7 +16,7 @@ function collect_wheels() {
   release_version=$1
   wheel_version="${release_version}"
   if [ "${release_version}" != "nightly" ]; then
-    wheel_version=$( echo "${release_version}" | grep -oP '\d+.\d+' )
+    wheel_version=$( echo "${release_version}" | grep -oP '\d+.\d+(.\d+)?' )
   fi
 
   mkdir /tmp/staging-wheels


### PR DESCRIPTION
tested:
~$ release_version="1.2.1"
~$ echo "${release_version}" | grep -oP '\d+.\d+(.\d+)?'
1.2.1
~$ release_version="1.2"
~$ echo "${release_version}" | grep -oP '\d+.\d+(.\d+)?'
1.2
~$ release_version="1.10.1"
~$ echo "${release_version}" | grep -oP '\d+.\d+(.\d+)?'
1.10.1
~$ release_version="1.10.11"
~$ echo "${release_version}" | grep -oP '\d+.\d+(.\d+)?'
1.10.11
