### PR TITLE
Updated python env to python3

### DIFF
--- a/scripts/bench_tensor_io.py
+++ b/scripts/bench_tensor_io.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/scripts/cond_patch.py
+++ b/scripts/cond_patch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/scripts/debug_run.py
+++ b/scripts/debug_run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/scripts/dump_stacks.py
+++ b/scripts/dump_stacks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # The following command is needed (as root) in order to enable GDB to attach
 # existing user processes:

--- a/scripts/fixup_binary.py
+++ b/scripts/fixup_binary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/scripts/gcsfs_bench.py
+++ b/scripts/gcsfs_bench.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/scripts/grab_graphs.py
+++ b/scripts/grab_graphs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Parses the output of XLA_SAVE_TENSORS_FILE and produces statistics about graph
 # types and Python frames.
 

--- a/scripts/grab_metrics.py
+++ b/scripts/grab_metrics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Given a log file in which the XLA metrics report has been dumped, extracts the
 # different metrics across multiple points and produces data in a format which
 # can be graphed.

--- a/scripts/metrics_to_tensorboard.py
+++ b/scripts/metrics_to_tensorboard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Add metrics images to tensorboard summary for easy viewing/comparisons
 
 import argparse

--- a/scripts/normalize_graph_text.py
+++ b/scripts/normalize_graph_text.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/scripts/stack_trace_parse.py
+++ b/scripts/stack_trace_parse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/scripts/tf_log_filter.py
+++ b/scripts/tf_log_filter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 


### PR DESCRIPTION
Earlier version of the scripts specified #!/usr/bin/env python for debug_run.py and related scripts.
This led to module not found errors for modules such as matplotlib, PIL etc, even though these modules were already installed on TPU VM.

The PR is to change env reference to python3.
With this change, the debug_run.py script runs without errors.

Also updated for other scripts using env python.