### PR TITLE
Skip AdaptiveMaxPool2D cpp test until tile mismatch bug is fixed on TPU

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -7418,6 +7418,11 @@ TEST_F(AtenXlaTensorTest, TestAvgPool3DNoBatch) {
 }
 
 TEST_F(AtenXlaTensorTest, TestAdaptiveMaxPool2D) {
+  DeviceType hw_type = GetDefaultDevice()->hw_type;
+  // skip this test until the tile mismatch bug is fixed.
+  if (hw_type == DeviceType::TPU) {
+    return;
+  }
   std::vector<torch::Tensor> inputs = {
       torch::rand({2, 10, 10}, torch::TensorOptions(torch::kFloat)),
       torch::rand({2, 2, 10, 10}, torch::TensorOptions(torch::kFloat)),
@@ -7443,6 +7448,11 @@ TEST_F(AtenXlaTensorTest, TestAdaptiveMaxPool2D) {
 }
 
 TEST_F(AtenXlaTensorTest, TestAdaptiveMaxPool2DBackward) {
+  DeviceType hw_type = GetDefaultDevice()->hw_type;
+  // skip this test until the tile mismatch bug is fixed.
+  if (hw_type == DeviceType::TPU) {
+    return;
+  }
   std::vector<torch::Tensor> inputs = {
       torch::rand({2, 10, 10},
                   torch::TensorOptions(torch::kFloat).requires_grad(true)),


### PR DESCRIPTION
test failed on TPU with message
```
  (0) INTERNAL: Expected instruction to have shape equal to (u32[2,2,2]{2,1,0:T(2,128)}), actual shape is (u32[2,2,2]{2,1,0:T(8,128)(4,1)}):
%tuple.1 = (u32[2,2,2]{2,1,0:T(8,128)(4,1)}) tuple(u32[2,2,2]{2,1,0:T(2,128)} %reduce-window.32.clone)
         [[{{node XRTCompile}}]]
         [[XRTCompile_G3]]
```

filed the bug with XLA team, skip the test for now.