### PR TITLE
change master to main

### DIFF
--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -201,7 +201,7 @@ function build_and_install_torch_xla() {
 }
 
 function install_torchvision_from_source() {
-  torchvision_repo_version="master"
+  torchvision_repo_version="main"
   # Cannot install torchvision package with PyTorch installation from source.
   # https://github.com/pytorch/vision/issues/967
   git clone -b "${torchvision_repo_version}" https://github.com/pytorch/vision.git


### PR DESCRIPTION
torch vision changed their "master" branch to "main", causing build failures.