### PR TITLE
Update debug build to also use buster

### DIFF
--- a/docker/debug_cloudbuild.yaml
+++ b/docker/debug_cloudbuild.yaml
@@ -28,7 +28,7 @@ options:
     dynamic_substitutions: true
     substitution_option: 'ALLOW_LOOSE'
 substitutions:
-    _DOCKER_BASE_IMAGE: 'debian:stretch'
+    _DOCKER_BASE_IMAGE: 'debian:buster'
     _CUDA: '0'
     _PYTHON_VERSION: '3.6'
     _RELEASE_VERSION: 'nightly'  # or rX.Y


### PR DESCRIPTION
In https://github.com/pytorch/xla/commit/cb531adae3f414637f8e91b2493d5ec87356a524 we update the wheel build to use debian buster. We need to make the same update to our debug build to make it pass.