### PR TITLE
Provide op lowering for PReLU

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -5669,7 +5669,7 @@ TEST_F(AtenXlaTensorTest, TestPrelu) {
   torch::Tensor input =
       torch::rand({2, channel_size, 4}, torch::TensorOptions(torch::kFloat));
   torch::Tensor weight =
-    torch::rand(channel_size, torch::TensorOptions(torch::kFloat));  
+      torch::rand(channel_size, torch::TensorOptions(torch::kFloat));
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor xla_input = CopyToDevice(input, device);
     torch::Tensor xla_weight = CopyToDevice(weight, device);

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -5665,10 +5665,11 @@ TEST_F(AtenXlaTensorTest, TestReluInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestPrelu) {
+  int channel_size = 3;
   torch::Tensor input =
-      torch::rand(6, torch::TensorOptions(torch::kFloat));
+      torch::rand({2, channel_size, 4}, torch::TensorOptions(torch::kFloat));
   torch::Tensor weight =
-    torch::rand(1, torch::TensorOptions(torch::kFloat));  
+    torch::rand(channel_size, torch::TensorOptions(torch::kFloat));  
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor xla_input = CopyToDevice(input, device);
     torch::Tensor xla_weight = CopyToDevice(weight, device);
@@ -5677,6 +5678,9 @@ TEST_F(AtenXlaTensorTest, TestPrelu) {
     AllClose(output, xla_output);
     AllClose(input, xla_input);
   });
+
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::prelu", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestHardshrink) {

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -926,6 +926,28 @@ TEST_F(AtenXlaTensorTest, TestLogDet) {
   }
 }
 
+TEST_F(AtenXlaTensorTest, TestSLogDet) {
+  static const int dims[] = {4, 7};
+  for (auto m : dims) {
+    torch::Tensor a =
+        torch::rand({3, m, m}, torch::TensorOptions(torch::kFloat));
+    torch::Tensor pd_a = torch::matmul(a, torch::transpose(a, 1, 2)) +
+                         torch::eye(m, torch::TensorOptions(torch::kFloat));
+    auto b = torch::slogdet(pd_a);
+    ForEachDevice([&](const torch::Device& device) {
+      torch::Tensor xla_a = CopyToDevice(pd_a, device);
+      auto xla_b = torch::slogdet(xla_a);
+      AllClose(std::get<0>(b), std::get<0>(xla_b), /*rtol=*/1e-3,
+               /*atol=*/1e-4);
+      AllClose(std::get<1>(b), std::get<1>(xla_b), /*rtol=*/1e-3,
+               /*atol=*/1e-4);
+    });
+  }
+
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::slogdet", cpp_test::GetIgnoredCounters());
+}
+
 TEST_F(AtenXlaTensorTest, TestTriangularSolve) {
   static const int dims[] = {4, 7};
   for (bool batched_a : {true, false}) {

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -5664,6 +5664,21 @@ TEST_F(AtenXlaTensorTest, TestReluInPlace) {
   });
 }
 
+TEST_F(AtenXlaTensorTest, TestPrelu) {
+  torch::Tensor input =
+      torch::rand(6, torch::TensorOptions(torch::kFloat));
+  torch::Tensor weight =
+    torch::rand(1, torch::TensorOptions(torch::kFloat));  
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_input = CopyToDevice(input, device);
+    torch::Tensor xla_weight = CopyToDevice(weight, device);
+    torch::Tensor output = torch::prelu(input, weight);
+    torch::Tensor xla_output = torch::prelu(xla_input, xla_weight);
+    AllClose(output, xla_output);
+    AllClose(input, xla_input);
+  });
+}
+
 TEST_F(AtenXlaTensorTest, TestHardshrink) {
   torch::Tensor input = torch::randn({10}, torch::TensorOptions(torch::kFloat));
   torch::Tensor output = torch::hardshrink(input);

--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -259,6 +259,7 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_softplus_inplace_overlap_xla',  # doesn't raise
         'test_softshrink_inplace_overlap_xla',  # doesn't raise
         'test_Conv2d_backward_depthwise_xla_float64',  # slow compilation
+        'test_leaky_relu_inplace_with_neg_slope_xla', # expecting a specific error message
     },
 
     # test_type_promotion.py

--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -259,7 +259,7 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_softplus_inplace_overlap_xla',  # doesn't raise
         'test_softshrink_inplace_overlap_xla',  # doesn't raise
         'test_Conv2d_backward_depthwise_xla_float64',  # slow compilation
-        'test_leaky_relu_inplace_with_neg_slope_xla', # expecting a specific error message
+        'test_leaky_relu_inplace_with_neg_slope_xla',  # expecting a specific error message
     },
 
     # test_type_promotion.py

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2537,7 +2537,7 @@ at::Tensor XLANativeFunctions::pow(const at::Scalar& self,
 at::Tensor XLANativeFunctions::prelu(const at::Tensor& self,
                                      const at::Tensor& weight) {
   XLA_FN_COUNTER("xla::");
-  
+
   // If multiple weights, check channel size == number of weights.
   int64_t weight_num = weight.numel();
   if (weight.numel() > 1) {
@@ -2550,11 +2550,12 @@ at::Tensor XLANativeFunctions::prelu(const at::Tensor& self,
            "parameter numbers = "
         << weight_num << " and channel size = " << channel_size;
   }
-  
+
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor weight_tensor = bridge::GetXlaTensor(weight);
 
-  return bridge::AtenFromXlaTensor(XLATensor::prelu(self_tensor, weight_tensor));
+  return bridge::AtenFromXlaTensor(
+      XLATensor::prelu(self_tensor, weight_tensor));
 }
 
 at::Tensor XLANativeFunctions::prod(const at::Tensor& self,

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2534,6 +2534,23 @@ at::Tensor XLANativeFunctions::pow(const at::Scalar& self,
       XLATensor::pow(self, bridge::GetXlaTensor(exponent)));
 }
 
+at::Tensor XLANativeFunctions::prelu(const at::Tensor& self, const at::Tensor& weight) {
+  std::cout << "[PReLU, aten_xla_type.cpp] Starting" << std::endl;
+  std::cout << "[PReLU, aten_xla_type.cpp] Self tensor:" << std::endl;
+  std::cout << self << std::endl;;
+  std::cout << "[PReLU, aten_xla_type.cpp] Weight tensor:" << std::endl;
+  std::cout << weight << std::endl;
+
+  XLA_FN_COUNTER("xla::");
+  XLATensor self_tensor = bridge::GetXlaTensor(self);
+  XLATensor weight_tensor = bridge::GetXlaTensor(weight);
+
+  at::Tensor ret = bridge::AtenFromXlaTensor(XLATensor::prelu(self_tensor, weight_tensor));
+
+  std::cout << "[PReLU, aten_xla_type.cpp] Finished" << std::endl;
+  return ret;
+}
+
 at::Tensor XLANativeFunctions::prod(const at::Tensor& self,
                                     c10::optional<at::ScalarType> dtype) {
   XLA_FN_COUNTER("xla::");

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2922,6 +2922,15 @@ at::Tensor XLANativeFunctions::slice(const at::Tensor& self, int64_t dim,
       bridge::GetXlaTensor(self), dim, start_val, end_val, step));
 }
 
+std::tuple<at::Tensor, at::Tensor> XLANativeFunctions::slogdet(
+    const at::Tensor& self) {
+  XLA_FN_COUNTER("xla::");
+  XLATensor self_tensor = bridge::GetXlaTensor(self);
+  auto outputs = XLATensor::slogdet(self_tensor);
+  return std::make_tuple(bridge::AtenFromXlaTensor(std::get<0>(outputs)),
+                         bridge::AtenFromXlaTensor(std::get<1>(outputs)));
+}
+
 at::Tensor XLANativeFunctions::smooth_l1_loss(const at::Tensor& self,
                                               const at::Tensor& target,
                                               int64_t reduction, double beta) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1741,7 +1741,7 @@ at::Tensor XLANativeFunctions::leaky_relu_backward(
     const at::Tensor& grad_output, const at::Tensor& self,
     const at::Scalar& negative_slope, bool self_is_result) {
   XLA_FN_COUNTER("xla::");
-  XLA_CHECK(!self_is_result || negative_slope.to<double>() > 0.0);
+  XLA_CHECK(!self_is_result || negative_slope.to<double>() >= 0.0);
   return bridge::AtenFromXlaTensor(XLATensor::leaky_relu_backward(
       bridge::GetXlaTensor(grad_output), bridge::GetXlaTensor(self),
       negative_slope.to<double>()));

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2536,15 +2536,11 @@ at::Tensor XLANativeFunctions::pow(const at::Scalar& self,
 
 at::Tensor XLANativeFunctions::prelu(const at::Tensor& self,
                                      const at::Tensor& weight) {
-  std::cout << "[PReLU, aten_xla_type.cpp] Starting" << std::endl;
-  std::cout << "[PReLU, aten_xla_type.cpp] Self tensor:" << std::endl;
-  std::cout << self << std::endl;
-  std::cout << "[PReLU, aten_xla_type.cpp] Weight tensor:" << std::endl;
-  std::cout << weight << std::endl;
-
-  // If multiple weights, check if channel size == number of weights.
+  XLA_FN_COUNTER("xla::");
+  
+  // If multiple weights, check channel size == number of weights.
   int64_t weight_num = weight.numel();
-  if (weight_num != 1) {
+  if (weight.numel() > 1) {
     int64_t input_dim = self.dim();
     XLA_CHECK_GT(input_dim, 0) << "Input tensor dimension cannot be 0";
 
@@ -2554,16 +2550,11 @@ at::Tensor XLANativeFunctions::prelu(const at::Tensor& self,
            "parameter numbers = "
         << weight_num << " and channel size = " << channel_size;
   }
-
-  XLA_FN_COUNTER("xla::");
+  
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor weight_tensor = bridge::GetXlaTensor(weight);
 
-  at::Tensor ret =
-      bridge::AtenFromXlaTensor(XLATensor::prelu(self_tensor, weight_tensor));
-
-  std::cout << "[PReLU, aten_xla_type.cpp] Finished" << std::endl;
-  return ret;
+  return bridge::AtenFromXlaTensor(XLATensor::prelu(self_tensor, weight_tensor));
 }
 
 at::Tensor XLANativeFunctions::prod(const at::Tensor& self,

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -185,8 +185,8 @@ xla::XlaOp BuildPrelu(xla::XlaOp input, xla::XlaOp weight) {
   xla::int64_t broadcast_dim = weight_num == 1 ? 0 : 1;
 
   xla::XlaOp zero = xla::Zero(input.builder(), input_shape.element_type());
-  xla::XlaOp broadcasted_weight = xla::BroadcastInDim(weight, 
-        input_shape.dimensions(), {broadcast_dim});
+  xla::XlaOp broadcasted_weight =
+      xla::BroadcastInDim(weight, input_shape.dimensions(), {broadcast_dim});
   xla::XlaOp product = xla::Mul(input, broadcasted_weight);
 
   return xla::Select(xla::Gt(input, zero), input, product);

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -175,6 +175,18 @@ xla::XlaOp BuildLeakyReluBackward(xla::XlaOp grad_output, xla::XlaOp input,
                      negative_slope * grad_output);
 }
 
+xla::XlaOp BuildPrelu(xla::XlaOp input, xla::XlaOp weight) {
+  std::cout << "[PReLU, elementwise.cpp] Starting" << std::endl;
+  const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
+  xla::XlaOp zero = xla::Zero(input.builder(), input_shape.element_type());
+  std::cout << "[PReLU, elementwise.cpp] Middle 1" << std::endl;
+  xla::XlaOp weighted = input * weight;
+  std::cout << "[PReLU, elementwise.cpp] Middle 2" << std::endl;
+  xla::XlaOp ret = xla::Select(xla::Gt(input, zero), input, weighted);
+  std::cout << "[PReLU, elementwise.cpp] Finished" << std::endl;
+  return ret;
+} 
+
 xla::XlaOp BuildSigmoid(xla::XlaOp input) {
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(input);
   xla::XlaOp half = XlaHelpers::ScalarValue<float>(0.5, shape.element_type(),

--- a/torch_xla/csrc/elementwise.h
+++ b/torch_xla/csrc/elementwise.h
@@ -18,6 +18,8 @@ xla::XlaOp BuildThreshold(xla::XlaOp input, xla::XlaOp output,
 // Computes the rectified linear unit (replace negative elements with 0).
 xla::XlaOp BuildRelu(xla::XlaOp input);
 
+xla::XlaOp BuildPrelu(xla::XlaOp input, xla::XlaOp weight);
+
 std::vector<xla::XlaOp> BuildRrelu(xla::XlaOp input, const at::Scalar& lower,
                                    const at::Scalar& upper, bool training,
                                    xla::XlaOp rng_seed);

--- a/torch_xla/csrc/ops/infer_output_shape.cpp
+++ b/torch_xla/csrc/ops/infer_output_shape.cpp
@@ -8,6 +8,7 @@ namespace ops {
 
 xla::Shape InferOutputShape(absl::Span<const xla::Shape> input_shapes,
                             const LowerForShapeFn& core_lowering_fn) {
+  std::cout << "[PReLU, infer_output_shape.cpp] Starting" << std::endl;
   xla::XlaBuilder b("InferOutputShape");
   std::vector<xla::XlaOp> parameters;
   for (size_t parameter_number = 0; parameter_number < input_shapes.size();
@@ -16,7 +17,9 @@ xla::Shape InferOutputShape(absl::Span<const xla::Shape> input_shapes,
                                         input_shapes[parameter_number],
                                         absl::StrCat("p", parameter_number)));
   }
+  std::cout << "[PReLU, infer_output_shape.cpp] Middle 1" << std::endl;
   xla::XlaOp result = core_lowering_fn(parameters);
+  std::cout << "[PReLU, infer_output_shape.cpp] Finished" << std::endl;
   return XlaHelpers::ShapeOfXlaOp(result);
 }
 

--- a/torch_xla/csrc/ops/infer_output_shape.cpp
+++ b/torch_xla/csrc/ops/infer_output_shape.cpp
@@ -8,7 +8,6 @@ namespace ops {
 
 xla::Shape InferOutputShape(absl::Span<const xla::Shape> input_shapes,
                             const LowerForShapeFn& core_lowering_fn) {
-  std::cout << "[PReLU, infer_output_shape.cpp] Starting" << std::endl;
   xla::XlaBuilder b("InferOutputShape");
   std::vector<xla::XlaOp> parameters;
   for (size_t parameter_number = 0; parameter_number < input_shapes.size();
@@ -17,9 +16,7 @@ xla::Shape InferOutputShape(absl::Span<const xla::Shape> input_shapes,
                                         input_shapes[parameter_number],
                                         absl::StrCat("p", parameter_number)));
   }
-  std::cout << "[PReLU, infer_output_shape.cpp] Middle 1" << std::endl;
   xla::XlaOp result = core_lowering_fn(parameters);
-  std::cout << "[PReLU, infer_output_shape.cpp] Finished" << std::endl;
   return XlaHelpers::ShapeOfXlaOp(result);
 }
 

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -168,6 +168,32 @@ NodePtr ReluOp(const Value& input) {
       std::move(lower_fn));
 }
 
+NodePtr Prelu(const Value& input, const Value& weight) {
+  // TODO @wonjoo need dimension checking
+  auto lower_fn = [](const Node& node, LoweringContext* loctx) -> XlaOpVector {
+    std::cout << "[PReLU, ops.cpp] Lowering_fn starting" << std::endl;
+    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
+    xla::XlaOp xla_weight = loctx->GetOutputOp(node.operand(1));
+    xla::XlaOp xla_output = BuildPrelu(xla_input, xla_weight);
+    std::cout << "[PReLU, ops.cpp] Lowering_fn finished" << std::endl;
+    return node.ReturnOp(xla_output, loctx);
+  };
+
+  auto lower_for_shape_fn =
+      [](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
+    // TODO @wonjoo shape check
+    std::cout << "[PReLU, ops.cpp] Lowering_shape_fn starting" << std::endl;
+    xla::XlaOp xla_output = BuildPrelu(operands[0], operands[1]);
+    std::cout << "[PReLU, ops.cpp] Lowering_shape_fn finished" << std::endl;
+    return xla_output;
+  };
+
+  return GenericOp(
+      OpKind(at::aten::prelu), {input, weight},
+      [&]() { return InferOutputShape({input.shape(), weight.shape()}, lower_for_shape_fn); },
+      std::move(lower_fn));
+}
+
 NodePtr HardSigmoid(const Value& input) {
   auto lower_fn = [](const Node& node, LoweringContext* loctx) -> XlaOpVector {
     xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -175,23 +175,29 @@ NodePtr Prelu(const Value& input, const Value& weight) {
     xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
     xla::XlaOp xla_weight = loctx->GetOutputOp(node.operand(1));
     xla::XlaOp xla_output = BuildPrelu(xla_input, xla_weight);
+    std::cout << "[PReLU, ops.cpp] Lowering_fn shape of result: "
+              << XlaHelpers::ShapeOfXlaOp(xla_output) << std::endl;
     std::cout << "[PReLU, ops.cpp] Lowering_fn finished" << std::endl;
     return node.ReturnOp(xla_output, loctx);
   };
 
   auto lower_for_shape_fn =
       [](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
-    // TODO @wonjoo shape check
+    XLA_CHECK_EQ(operands.size(), 2) << "Unexpected number of operands";
     std::cout << "[PReLU, ops.cpp] Lowering_shape_fn starting" << std::endl;
     xla::XlaOp xla_output = BuildPrelu(operands[0], operands[1]);
+    std::cout << "[PReLU, ops.cpp] Lowering_shape_fn shape of result: "
+              << XlaHelpers::ShapeOfXlaOp(xla_output) << std::endl;
     std::cout << "[PReLU, ops.cpp] Lowering_shape_fn finished" << std::endl;
     return xla_output;
   };
 
-  return GenericOp(
-      OpKind(at::aten::prelu), {input, weight},
-      [&]() { return InferOutputShape({input.shape(), weight.shape()}, lower_for_shape_fn); },
-      std::move(lower_fn));
+  return GenericOp(OpKind(at::aten::prelu), {input, weight},
+                   [&]() {
+                     return InferOutputShape({input.shape(), weight.shape()},
+                                             lower_for_shape_fn);
+                   },
+                   std::move(lower_fn));
 }
 
 NodePtr HardSigmoid(const Value& input) {

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -176,8 +176,7 @@ NodePtr Prelu(const Value& input, const Value& weight) {
     return node.ReturnOp(xla_output, loctx);
   };
 
-  return GenericOp(OpKind(at::aten::prelu), {input, weight},
-                   input.shape(),
+  return GenericOp(OpKind(at::aten::prelu), {input, weight}, input.shape(),
                    std::move(lower_fn));
 }
 

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -230,6 +230,8 @@ NodePtr LogicalOr(const Value& input, const Value& other);
 NodePtr NanToNum(const Value& input, const Value& nan, const Value& posinf,
                  const Value& neginf);
 
+NodePtr SLogDet(const Value& input);
+
 }  // namespace ops
 }  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -112,6 +112,8 @@ NodePtr Rsqrt(const Value& input);
 
 NodePtr ReciprocalOp(const Value& input);
 
+NodePtr Prelu(const Value& input, const Value& weight);
+
 NodePtr Pow(const Value& input, const Value& exponent);
 
 NodePtr Fmod(const Value& dividend, const Value& divisor);

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -988,6 +988,8 @@ class XLATensor {
                          xla::int64_t start, xla::int64_t end,
                          xla::int64_t step);
 
+  static std::tuple<XLATensor, XLATensor> slogdet(const XLATensor& input);
+
   // Computes a loss that uses a squared term if the absolute element-wise error
   // falls below 1 and an L1 term otherwise.
   static XLATensor smooth_l1_loss(const XLATensor& input,

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -885,6 +885,8 @@ class XLATensor {
   static XLATensor pow(const XLATensor& input, const XLATensor& exponent);
   static XLATensor pow(const at::Scalar& input, const XLATensor& exponent);
 
+  static XLATensor prelu(const XLATensor& input, const XLATensor& weight);
+
   static XLATensor prod(const XLATensor& input,
                         std::vector<xla::int64_t> dimensions,
                         bool keep_reduced_dimensions,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2081,7 +2081,8 @@ XLATensor XLATensor::pow(const at::Scalar& input, const XLATensor& exponent) {
 
 XLATensor XLATensor::prelu(const XLATensor& input, const XLATensor& weight) {
   std::cout << "[PReLU, tensor_methods.cpp] Starting" << std::endl;
-  XLATensor ret = input.CreateFrom(ir::ops::Prelu(input.GetIrValue(), weight.GetIrValue()));
+  XLATensor ret =
+      input.CreateFrom(ir::ops::Prelu(input.GetIrValue(), weight.GetIrValue()));
   std::cout << "[PReLU, tensor_methods.cpp] Finished" << std::endl;
   return ret;
 }

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2357,6 +2357,12 @@ XLATensor XLATensor::slice(const XLATensor& input, xla::int64_t dim,
   return input.CreateViewTensor(std::move(view_info));
 }
 
+std::tuple<XLATensor, XLATensor> XLATensor::slogdet(const XLATensor& input) {
+  ir::NodePtr node = ir::ops::SLogDet(input.GetIrValue());
+  return std::make_tuple(input.CreateFrom(ir::Value(node, 0)),
+                         input.CreateFrom(ir::Value(node, 1)));
+}
+
 XLATensor XLATensor::smooth_l1_loss(const XLATensor& input,
                                     const XLATensor& target,
                                     xla::int64_t reduction, double beta) {

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2080,7 +2080,8 @@ XLATensor XLATensor::pow(const at::Scalar& input, const XLATensor& exponent) {
 }
 
 XLATensor XLATensor::prelu(const XLATensor& input, const XLATensor& weight) {
-  return input.CreateFrom(ir::ops::Prelu(input.GetIrValue(), weight.GetIrValue()));
+  return input.CreateFrom(
+      ir::ops::Prelu(input.GetIrValue(), weight.GetIrValue()));
 }
 
 XLATensor XLATensor::prod(const XLATensor& input,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2080,11 +2080,7 @@ XLATensor XLATensor::pow(const at::Scalar& input, const XLATensor& exponent) {
 }
 
 XLATensor XLATensor::prelu(const XLATensor& input, const XLATensor& weight) {
-  std::cout << "[PReLU, tensor_methods.cpp] Starting" << std::endl;
-  XLATensor ret =
-      input.CreateFrom(ir::ops::Prelu(input.GetIrValue(), weight.GetIrValue()));
-  std::cout << "[PReLU, tensor_methods.cpp] Finished" << std::endl;
-  return ret;
+  return input.CreateFrom(ir::ops::Prelu(input.GetIrValue(), weight.GetIrValue()));
 }
 
 XLATensor XLATensor::prod(const XLATensor& input,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2079,6 +2079,13 @@ XLATensor XLATensor::pow(const at::Scalar& input, const XLATensor& exponent) {
   return exponent.CreateFrom(ir::ops::Pow(input_node, exponent.GetIrValue()));
 }
 
+XLATensor XLATensor::prelu(const XLATensor& input, const XLATensor& weight) {
+  std::cout << "[PReLU, tensor_methods.cpp] Starting" << std::endl;
+  XLATensor ret = input.CreateFrom(ir::ops::Prelu(input.GetIrValue(), weight.GetIrValue()));
+  std::cout << "[PReLU, tensor_methods.cpp] Finished" << std::endl;
+  return ret;
+}
+
 XLATensor XLATensor::prod(const XLATensor& input,
                           std::vector<xla::int64_t> dimensions,
                           bool keep_reduced_dimensions,

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -224,6 +224,7 @@ supported:
   - pow.Scalar
   - pow.Tensor_Scalar
   - pow.Tensor_Tensor
+  - prelu
   - prod
   - prod.dim_int
   - put_

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -1,296 +1,184 @@
 backend: XLA
 cpp_namespace: torch_xla
 supported:
+  - __ilshift__.Scalar
+  - __ilshift__.Tensor
+  - __irshift__.Scalar
+  - __irshift__.Tensor
+  - __lshift__.Scalar
+  - __lshift__.Tensor
+  - __rshift__.Scalar
+  - __rshift__.Tensor
+  - _adaptive_avg_pool2d
+  - _adaptive_avg_pool2d_backward
+  - _adaptive_avg_pool3d
+  - _adaptive_avg_pool3d_backward
+  - _amp_foreach_non_finite_check_and_unscale_
+  - _amp_update_scale_
+  - _copy_from
+  - _copy_from_and_resize
+  - _index_put_impl_
+  - _local_scalar_dense
+  - _log_softmax
+  - _log_softmax_backward_data
+  - _pack_padded_sequence
+  - _s_where
+  - _softmax
+  - _softmax_backward_data
+  - _to_cpu
+  - _trilinear
+  - _unsafe_view
   - abs
   - acos
-  - add.Tensor
+  - acosh
+  - adaptive_max_pool2d
+  - adaptive_max_pool2d_backward
   - add.Scalar
+  - add.Tensor
+  - addcdiv
+  - addcdiv_
+  - addcmul
+  - addmm
+  - alias
+  - all
   - all.dim
   - amax
   - amin
+  - any
   - any.dim
   - arange.start_out
   - argmax
   - argmin
-  - acosh
-  - asinh
-  - atanh
   - as_strided
   - as_strided_
   - asin
+  - asinh
   - atan
+  - atan2
+  - atanh
+  - avg_pool2d
+  - avg_pool2d_backward
+  - avg_pool3d
+  - avg_pool3d_backward
   - baddbmm
   - bernoulli
-  - bernoulli_.Tensor
   - bernoulli_.float
+  - bernoulli_.Tensor
   - binary_cross_entropy
   - binary_cross_entropy_backward
   - binary_cross_entropy_with_logits
+  - bitwise_and.Scalar
+  - bitwise_and.Tensor
   - bitwise_not.out
+  - bitwise_or.Scalar_out
+  - bitwise_or.Tensor_out
+  - bitwise_xor.Scalar_out
+  - bitwise_xor.Tensor_out
   - bmm
   - cat
   - ceil
+  - cholesky
   - clamp
   - clamp.Tensor
   - clamp_max
   - clamp_max.Tensor_out
   - clamp_min
   - clamp_min.Tensor_out
+  - clone
   - constant_pad_nd
-  - convolution_overrideable
   - convolution_backward_overrideable
-  - _copy_from
-  - _copy_from_and_resize
-  - _to_cpu
+  - convolution_overrideable
   - cos
   - cosh
+  - cross
   - cumprod
   - cumsum
+  - diag
   - diagonal
+  - div.Scalar
   - div.Tensor
   - div.Tensor_mode
-  - div.Scalar
   - dot
+  - elu
+  - elu_
+  - elu_backward
   - embedding
   - embedding_dense_backward
   - empty.memory_format
-  - resize_
   - empty_strided
+  - eq.Scalar
+  - eq.Tensor
   - erf
   - erfc
+  - erfinv
   - exp
-  - expm1
   - expand
-  - eye.out
+  - expm1
+  - exponential_
   - eye.m_out
+  - eye.out
   - fill_.Scalar
   - fill_.Tensor
+  - flip
   - floor
+  - fmod.Scalar
+  - fmod.Tensor
   - frac
+  - gather
+  - ge.Scalar
+  - ge.Tensor
+  - gelu
+  - gelu_backward
+  - ger
+  - gt.Scalar
+  - gt.Tensor
+  - hardshrink
+  - hardshrink_backward
+  - hardsigmoid
+  - hardsigmoid_backward
+  - hardtanh
+  - hardtanh_backward
   - index.Tensor
+  - index_add_
   - index_copy_
+  - index_fill_.int_Scalar
+  - index_fill_.int_Tensor
   - index_put_
-  - _index_put_impl_
+  - index_select
   - inverse
   - isnan
   - kl_div
   - kl_div_backward
   - kthvalue
+  - l1_loss
+  - l1_loss_backward
+  - le.Scalar
+  - le.Tensor
+  - leaky_relu
+  - leaky_relu_backward
+  - lerp.Scalar
+  - lerp.Tensor
   - log
-  - log10
   - log1p
   - log2
+  - log10
+  - log_sigmoid_backward
+  - log_sigmoid_forward
   - logdet
-  - _log_softmax
-  - _log_softmax_backward_data
+  - logical_and
+  - logical_not
+  - logical_or
+  - logical_xor
   - logsumexp
-  - max.dim
-  - max.dim_max
-  - mean
-  - mean.dim
-  - min.dim
-  - min.dim_min
-  - mm
-  - mul.Tensor
-  - mul.Scalar
-  - mv
-  - mv.out
-  - native_batch_norm
-  - native_batch_norm_backward
-  - permute
-  - reciprocal
-  - neg
-  - repeat
-  - round
-  - relu
-  - relu_
-  - gelu
-  - gelu_backward
-  - hardshrink
-  - hardshrink_backward
-  - rsqrt
-  - select.int
-  - silu.out
-  - sigmoid
-  - sin
-  - sinh
-  - slice.Tensor
-  - _softmax
-  - _softmax_backward_data
-  - split.Tensor
-  - split_with_sizes
-  - squeeze
-  - squeeze.dim
-  - squeeze_
-  - squeeze_.dim
-  - stack
-  - sum
-  - sum.dim_IntList
-  - sqrt
-  - std
-  - std.dim
-  - std.correction
-  - std_mean.correction
-  - prod
-  - prod.dim_int
-  - t
-  - t_
-  - tan
-  - tanh
-  - threshold
-  - threshold_backward
-  - transpose.int
-  - transpose_
-  - flip
-  - _trilinear
-  - trunc
-  - _unsafe_view
-  - unsqueeze
-  - unsqueeze_
-  - var
-  - var.dim
-  - var.correction
-  - var_mean.correction
-  - _s_where
-  - norm.ScalarOpt_dtype
-  - norm.Scalar
-  - norm.ScalarOpt_dim_dtype
-  - norm.ScalarOpt_dim
-  - clone
-  - zero_
-  - sub.Tensor
-  - sub.Scalar
-  - rsub.Tensor
-  - rsub.Scalar
-  - addmm
-  - unbind.int
-  - _local_scalar_dense
-  - _pack_padded_sequence
+  - lt.Scalar
+  - lt.Tensor
   - masked_fill_.Scalar
   - masked_fill_.Tensor
   - masked_scatter_
-  - view
-  - put_
-  - index_add_
-  - index_fill_.int_Scalar
-  - index_fill_.int_Tensor
-  - scatter.src
-  - scatter.value
-  - scatter.reduce
-  - scatter.value_reduce
-  - scatter_add
-  - bitwise_and.Tensor
-  - bitwise_and.Scalar
-  - bitwise_or.Tensor_out
-  - bitwise_or.Scalar_out
-  - bitwise_xor.Tensor_out
-  - bitwise_xor.Scalar_out
-  - __lshift__.Scalar
-  - __lshift__.Tensor
-  - __ilshift__.Scalar
-  - __ilshift__.Tensor
-  - __rshift__.Scalar
-  - __rshift__.Tensor
-  - __irshift__.Scalar
-  - __irshift__.Tensor
-  - tril_
-  - triu_
-  - addcdiv_
-  - random_.from
-  - random_.to
-  - random_
-  - uniform_
-  - exponential_
-  - diag
-  - cross
-  - triu
-  - tril
-  - trace
-  - ne.Scalar
-  - ne.Tensor
-  - eq.Scalar
-  - eq.Tensor
-  - ge.Scalar
-  - ge.Tensor
-  - le.Scalar
-  - le.Tensor
-  - gt.Scalar
-  - gt.Tensor
-  - lt.Scalar
-  - lt.Tensor
-  - take
-  - index_select
   - masked_select
-  - nonzero
-  - gather
-  - addcmul
-  - addcdiv
-  - triangular_solve
-  - symeig
-  - svd
-  - cholesky
-  - qr
-  - erfinv
-  - sgn
-  - sign
-  - atan2
-  - fmod.Scalar
-  - fmod.Tensor
-  - remainder.Scalar
-  - remainder.Tensor
-  - min
   - max
-  - maximum
-  - minimum
-  - sort
-  - topk
-  - all
-  - any
-  - pow.Tensor_Tensor
-  - pow.Scalar
-  - pow.Tensor_Scalar
-  - normal_
-  - normal.Tensor_float
-  - normal.float_Tensor
-  - normal.Tensor_Tensor
-  - alias
-  - _amp_foreach_non_finite_check_and_unscale_
-  - _amp_update_scale_
-  - mse_loss
-  - mse_loss_backward
-  - l1_loss
-  - l1_loss_backward
-  - nll_loss_forward
-  - nll_loss_backward
-  - nll_loss2d_forward
-  - nll_loss2d_backward
-  - smooth_l1_loss
-  - smooth_l1_loss_backward
-  - elu
-  - elu_backward
-  - elu_
-  - hardsigmoid
-  - hardsigmoid_backward
-  - hardtanh
-  - hardtanh_backward
-  - leaky_relu
-  - leaky_relu_backward
-  - log_sigmoid_forward
-  - log_sigmoid_backward
-  - rrelu_with_noise
-  - rrelu_with_noise_backward
-  - softplus
-  - softplus_backward
-  - softshrink
-  - softshrink_backward
-  - _adaptive_avg_pool2d
-  - _adaptive_avg_pool2d_backward
-  - _adaptive_avg_pool3d
-  - _adaptive_avg_pool3d_backward
-  - avg_pool2d
-  - avg_pool2d_backward
-  - avg_pool3d
-  - avg_pool3d_backward
+  - max.dim
+  - max.dim_max
   - max_pool2d_with_indices
   - max_pool2d_with_indices_backward
   - max_pool3d_with_indices
@@ -299,30 +187,143 @@ supported:
   - max_unpool2d_backward
   - max_unpool3d
   - max_unpool3d_backward
+  - maximum
+  - mean
+  - mean.dim
+  - min
+  - min.dim
+  - min.dim_min
+  - minimum
+  - mm
+  - mse_loss
+  - mse_loss_backward
+  - mul.Scalar
+  - mul.Tensor
+  - mv
+  - mv.out
+  - nan_to_num
+  - native_batch_norm
+  - native_batch_norm_backward
+  - ne.Scalar
+  - ne.Tensor
+  - neg
+  - nll_loss2d_backward
+  - nll_loss2d_forward
+  - nll_loss_backward
+  - nll_loss_forward
+  - nonzero
+  - norm.Scalar
+  - norm.ScalarOpt_dim
+  - norm.ScalarOpt_dim_dtype
+  - norm.ScalarOpt_dtype
+  - normal.float_Tensor
+  - normal.Tensor_float
+  - normal.Tensor_Tensor
+  - normal_
+  - permute
+  - pow.Scalar
+  - pow.Tensor_Scalar
+  - pow.Tensor_Tensor
+  - prod
+  - prod.dim_int
+  - put_
+  - qr
+  - random_
+  - random_.from
+  - random_.to
+  - reciprocal
   - reflection_pad2d
   - reflection_pad2d_backward
+  - relu
+  - relu_
+  - remainder.Scalar
+  - remainder.Tensor
+  - repeat
   - replication_pad1d
   - replication_pad1d_backward
   - replication_pad2d
   - replication_pad2d_backward
-  - upsample_nearest2d.vec
-  - upsample_nearest2d_backward.vec
+  - resize_
+  - round
+  - rrelu_with_noise
+  - rrelu_with_noise_backward
+  - rsqrt
+  - rsub.Scalar
+  - rsub.Tensor
+  - scatter.reduce
+  - scatter.src
+  - scatter.value
+  - scatter.value_reduce
+  - scatter_add
+  - select.int
+  - sgn
+  - sigmoid
+  - sigmoid_backward
+  - sign
+  - silu.out
+  - sin
+  - sinh
+  - slice.Tensor
+  - slogdet
+  - smooth_l1_loss
+  - smooth_l1_loss_backward
+  - softplus
+  - softplus_backward
+  - softshrink
+  - softshrink_backward
+  - sort
+  - split.Tensor
+  - split_with_sizes
+  - sqrt
+  - squeeze
+  - squeeze.dim
+  - squeeze_
+  - squeeze_.dim
+  - stack
+  - std
+  - std.correction
+  - std.dim
+  - std_mean.correction
+  - sub.Scalar
+  - sub.Tensor
+  - sum
+  - sum.dim_IntList
+  - svd
+  - symeig
+  - t
+  - t_
+  - take
+  - tan
+  - tanh
+  - tanh_backward
+  - threshold
+  - threshold_backward
+  - topk
+  - trace
+  - transpose.int
+  - transpose_
+  - triangular_solve
+  - tril
+  - tril_
+  - triu
+  - triu_
+  - trunc
+  - unbind.int
+  - uniform_
+  - unsqueeze
+  - unsqueeze_
   - upsample_bilinear2d
   - upsample_bilinear2d_backward
   - upsample_nearest2d
+  - upsample_nearest2d.vec
   - upsample_nearest2d_backward
-  - sigmoid_backward
-  - tanh_backward
-  - ger
-  - lerp.Scalar
-  - lerp.Tensor
-  - adaptive_max_pool2d
-  - adaptive_max_pool2d_backward
-  - logical_not
-  - logical_xor
-  - logical_or
-  - logical_and
-  - nan_to_num
+  - upsample_nearest2d_backward.vec
+  - var
+  - var.correction
+  - var.dim
+  - var_mean.correction
+  - view
+  - zero_
 autograd:
   - max_pool2d
   - max_pool3d


### PR DESCRIPTION
PR to provide op lowering for PReLU. 

Some relevant info:
- PyTorch PReLU implementation -- https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/Activation.cpp#L599. 
- xla::BroadCastinDim -- https://www.tensorflow.org/xla/operation_semantics#broadcastindim.

TODOs (all done)
- ~~Add unit tests~~
- ~~Add shape checks~~
- ~~Remove code for debugging~~
