### PR TITLE
update colab torch version

### DIFF
--- a/contrib/colab/DC-GAN.ipynb
+++ b/contrib/colab/DC-GAN.ipynb
@@ -71,7 +71,7 @@
         "colab": {}
       },
       "source": [
-        "!pip install cloud-tpu-client==0.10 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
+        "!pip install cloud-tpu-client==0.10 torch==1.9.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
       ],
       "execution_count": null,
       "outputs": []

--- a/contrib/colab/Distributing_Large_Embedding_tables.ipynb
+++ b/contrib/colab/Distributing_Large_Embedding_tables.ipynb
@@ -63,7 +63,7 @@
         "colab": {}
       },
       "source": [
-        "!pip install cloud-tpu-client==0.10 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
+        "!pip install cloud-tpu-client==0.10 torch==1.9.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
       ],
       "execution_count": null,
       "outputs": []

--- a/contrib/colab/getting-started.ipynb
+++ b/contrib/colab/getting-started.ipynb
@@ -91,7 +91,7 @@
         "colab": {}
       },
       "source": [
-        "!pip install cloud-tpu-client==0.10 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
+        "!pip install cloud-tpu-client==0.10 torch==1.9.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
       ],
       "execution_count": null,
       "outputs": []

--- a/contrib/colab/issue-report.ipynb
+++ b/contrib/colab/issue-report.ipynb
@@ -33,7 +33,7 @@
         "colab": {}
       },
       "source": [
-        "!pip install cloud-tpu-client==0.10 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
+        "!pip install cloud-tpu-client==0.10 torch==1.9.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
       ],
       "execution_count": null,
       "outputs": []

--- a/contrib/colab/mnist-training.ipynb
+++ b/contrib/colab/mnist-training.ipynb
@@ -72,7 +72,7 @@
         "colab": {}
       },
       "source": [
-        "!pip install cloud-tpu-client==0.10 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
+        "!pip install cloud-tpu-client==0.10 torch==1.9.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
       ],
       "execution_count": null,
       "outputs": []

--- a/contrib/colab/multi-core-alexnet-fashion-mnist.ipynb
+++ b/contrib/colab/multi-core-alexnet-fashion-mnist.ipynb
@@ -66,7 +66,7 @@
         "# Installs PyTorch, PyTorch/XLA, and Torchvision\n",
         "# Copy this cell into your own notebooks to use PyTorch on Cloud TPUs \n",
         "# Warning: this may take a couple minutes to run\n",
-        "!pip install cloud-tpu-client==0.10 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
+        "!pip install cloud-tpu-client==0.10 torch==1.9.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
       ],
       "execution_count": null,
       "outputs": []

--- a/contrib/colab/resnet18-training.ipynb
+++ b/contrib/colab/resnet18-training.ipynb
@@ -44,7 +44,7 @@
         "colab": {}
       },
       "source": [
-        "!pip install cloud-tpu-client==0.10 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
+        "!pip install cloud-tpu-client==0.10 torch==1.9.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
       ],
       "execution_count": null,
       "outputs": []

--- a/contrib/colab/resnet50-inference.ipynb
+++ b/contrib/colab/resnet50-inference.ipynb
@@ -71,7 +71,7 @@
         "colab": {}
       },
       "source": [
-        "!pip install cloud-tpu-client==0.10 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
+        "!pip install cloud-tpu-client==0.10 torch==1.9.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
       ],
       "execution_count": null,
       "outputs": []

--- a/contrib/colab/single-core-alexnet-fashion-mnist.ipynb
+++ b/contrib/colab/single-core-alexnet-fashion-mnist.ipynb
@@ -54,7 +54,7 @@
         "colab": {}
       },
       "source": [
-        "!pip install cloud-tpu-client==0.10 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
+        "!pip install cloud-tpu-client==0.10 torch==1.9.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
       ],
       "execution_count": null,
       "outputs": []

--- a/contrib/colab/style_transfer_inference.ipynb
+++ b/contrib/colab/style_transfer_inference.ipynb
@@ -78,7 +78,7 @@
         "colab": {}
       },
       "source": [
-        "!pip install cloud-tpu-client==0.10 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
+        "!pip install cloud-tpu-client==0.10 torch==1.9.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
       ],
       "execution_count": null,
       "outputs": []

--- a/contrib/colab/xla_builder_autograd.ipynb
+++ b/contrib/colab/xla_builder_autograd.ipynb
@@ -50,7 +50,7 @@
         "colab": {}
       },
       "source": [
-        "!pip install cloud-tpu-client==0.10 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
+        "!pip install cloud-tpu-client==0.10 torch==1.9.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
custom wheel for colab is hard to build and colab has set 1.10 as default torch version
so installing 1.9 as default for our colabs.