### PR TITLE
Provide op lowering for prelu

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -5678,6 +5678,21 @@ TEST_F(AtenXlaTensorTest, TestReluInPlace) {
   });
 }
 
+TEST_F(AtenXlaTensorTest, TestPrelu) {
+  torch::Tensor input =
+      torch::rand(6, torch::TensorOptions(torch::kFloat));
+  torch::Tensor weight =
+    torch::rand(1, torch::TensorOptions(torch::kFloat));  
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_input = CopyToDevice(input, device);
+    torch::Tensor xla_weight = CopyToDevice(weight, device);
+    torch::Tensor output = torch::prelu(input, weight);
+    torch::Tensor xla_output = torch::prelu(xla_input, xla_weight);
+    AllClose(output, xla_output);
+    AllClose(input, xla_input);
+  });
+}
+
 TEST_F(AtenXlaTensorTest, TestHardshrink) {
   torch::Tensor input = torch::randn({10}, torch::TensorOptions(torch::kFloat));
   torch::Tensor output = torch::hardshrink(input);

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -5679,10 +5679,11 @@ TEST_F(AtenXlaTensorTest, TestReluInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestPrelu) {
+  int channel_size = 3;
   torch::Tensor input =
-      torch::rand(6, torch::TensorOptions(torch::kFloat));
+      torch::rand({2, channel_size, 4}, torch::TensorOptions(torch::kFloat));
   torch::Tensor weight =
-    torch::rand(1, torch::TensorOptions(torch::kFloat));  
+    torch::rand(channel_size, torch::TensorOptions(torch::kFloat));  
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor xla_input = CopyToDevice(input, device);
     torch::Tensor xla_weight = CopyToDevice(weight, device);
@@ -5691,6 +5692,9 @@ TEST_F(AtenXlaTensorTest, TestPrelu) {
     AllClose(output, xla_output);
     AllClose(input, xla_input);
   });
+
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::prelu", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestHardshrink) {

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -5684,13 +5684,12 @@ TEST_F(AtenXlaTensorTest, TestPrelu) {
       torch::rand({2, channel_size, 4}, torch::TensorOptions(torch::kFloat));
   torch::Tensor weight =
       torch::rand(channel_size, torch::TensorOptions(torch::kFloat));
+  torch::Tensor output = torch::prelu(input, weight);
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor xla_input = CopyToDevice(input, device);
     torch::Tensor xla_weight = CopyToDevice(weight, device);
-    torch::Tensor output = torch::prelu(input, weight);
     torch::Tensor xla_output = torch::prelu(xla_input, xla_weight);
     AllClose(output, xla_output);
-    AllClose(input, xla_input);
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -5683,7 +5683,7 @@ TEST_F(AtenXlaTensorTest, TestPrelu) {
   torch::Tensor input =
       torch::rand({2, channel_size, 4}, torch::TensorOptions(torch::kFloat));
   torch::Tensor weight =
-    torch::rand(channel_size, torch::TensorOptions(torch::kFloat));  
+      torch::rand(channel_size, torch::TensorOptions(torch::kFloat));
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor xla_input = CopyToDevice(input, device);
     torch::Tensor xla_weight = CopyToDevice(weight, device);

--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -262,6 +262,7 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_softplus_inplace_overlap_xla',  # doesn't raise
         'test_softshrink_inplace_overlap_xla',  # doesn't raise
         'test_Conv2d_backward_depthwise_xla_float64',  # slow compilation
+        'test_leaky_relu_inplace_with_neg_slope_xla',  # expecting a specific error message
     },
 
     # test_type_promotion.py

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2549,18 +2549,33 @@ at::Tensor XLANativeFunctions::pow(const at::Scalar& self,
       XLATensor::pow(self, bridge::GetXlaTensor(exponent)));
 }
 
-at::Tensor XLANativeFunctions::prelu(const at::Tensor& self, const at::Tensor& weight) {
+at::Tensor XLANativeFunctions::prelu(const at::Tensor& self,
+                                     const at::Tensor& weight) {
   std::cout << "[PReLU, aten_xla_type.cpp] Starting" << std::endl;
   std::cout << "[PReLU, aten_xla_type.cpp] Self tensor:" << std::endl;
-  std::cout << self << std::endl;;
+  std::cout << self << std::endl;
   std::cout << "[PReLU, aten_xla_type.cpp] Weight tensor:" << std::endl;
   std::cout << weight << std::endl;
+
+  // If multiple weights, check if channel size == number of weights.
+  int64_t weight_num = weight.numel();
+  if (weight_num != 1) {
+    int64_t input_dim = self.dim();
+    XLA_CHECK_GT(input_dim, 0) << "Input tensor dimension cannot be 0";
+
+    int64_t channel_size = input_dim > 1 ? self.size(1) : 1;
+    XLA_CHECK_EQ(channel_size, weight_num)
+        << "Mismatch of parameter numbers and input channel size. Found "
+           "parameter numbers = "
+        << weight_num << " and channel size = " << channel_size;
+  }
 
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor weight_tensor = bridge::GetXlaTensor(weight);
 
-  at::Tensor ret = bridge::AtenFromXlaTensor(XLATensor::prelu(self_tensor, weight_tensor));
+  at::Tensor ret =
+      bridge::AtenFromXlaTensor(XLATensor::prelu(self_tensor, weight_tensor));
 
   std::cout << "[PReLU, aten_xla_type.cpp] Finished" << std::endl;
   return ret;

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1756,7 +1756,7 @@ at::Tensor XLANativeFunctions::leaky_relu_backward(
     const at::Tensor& grad_output, const at::Tensor& self,
     const at::Scalar& negative_slope, bool self_is_result) {
   XLA_FN_COUNTER("xla::");
-  XLA_CHECK(!self_is_result || negative_slope.to<double>() > 0.0);
+  XLA_CHECK(!self_is_result || negative_slope.to<double>() >= 0.0);
   return bridge::AtenFromXlaTensor(XLATensor::leaky_relu_backward(
       bridge::GetXlaTensor(grad_output), bridge::GetXlaTensor(self),
       negative_slope.to<double>()));

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2551,15 +2551,11 @@ at::Tensor XLANativeFunctions::pow(const at::Scalar& self,
 
 at::Tensor XLANativeFunctions::prelu(const at::Tensor& self,
                                      const at::Tensor& weight) {
-  std::cout << "[PReLU, aten_xla_type.cpp] Starting" << std::endl;
-  std::cout << "[PReLU, aten_xla_type.cpp] Self tensor:" << std::endl;
-  std::cout << self << std::endl;
-  std::cout << "[PReLU, aten_xla_type.cpp] Weight tensor:" << std::endl;
-  std::cout << weight << std::endl;
-
-  // If multiple weights, check if channel size == number of weights.
+  XLA_FN_COUNTER("xla::");
+  
+  // If multiple weights, check channel size == number of weights.
   int64_t weight_num = weight.numel();
-  if (weight_num != 1) {
+  if (weight.numel() > 1) {
     int64_t input_dim = self.dim();
     XLA_CHECK_GT(input_dim, 0) << "Input tensor dimension cannot be 0";
 
@@ -2569,16 +2565,11 @@ at::Tensor XLANativeFunctions::prelu(const at::Tensor& self,
            "parameter numbers = "
         << weight_num << " and channel size = " << channel_size;
   }
-
-  XLA_FN_COUNTER("xla::");
+  
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor weight_tensor = bridge::GetXlaTensor(weight);
 
-  at::Tensor ret =
-      bridge::AtenFromXlaTensor(XLATensor::prelu(self_tensor, weight_tensor));
-
-  std::cout << "[PReLU, aten_xla_type.cpp] Finished" << std::endl;
-  return ret;
+  return bridge::AtenFromXlaTensor(XLATensor::prelu(self_tensor, weight_tensor));
 }
 
 at::Tensor XLANativeFunctions::prod(const at::Tensor& self,

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2549,6 +2549,23 @@ at::Tensor XLANativeFunctions::pow(const at::Scalar& self,
       XLATensor::pow(self, bridge::GetXlaTensor(exponent)));
 }
 
+at::Tensor XLANativeFunctions::prelu(const at::Tensor& self, const at::Tensor& weight) {
+  std::cout << "[PReLU, aten_xla_type.cpp] Starting" << std::endl;
+  std::cout << "[PReLU, aten_xla_type.cpp] Self tensor:" << std::endl;
+  std::cout << self << std::endl;;
+  std::cout << "[PReLU, aten_xla_type.cpp] Weight tensor:" << std::endl;
+  std::cout << weight << std::endl;
+
+  XLA_FN_COUNTER("xla::");
+  XLATensor self_tensor = bridge::GetXlaTensor(self);
+  XLATensor weight_tensor = bridge::GetXlaTensor(weight);
+
+  at::Tensor ret = bridge::AtenFromXlaTensor(XLATensor::prelu(self_tensor, weight_tensor));
+
+  std::cout << "[PReLU, aten_xla_type.cpp] Finished" << std::endl;
+  return ret;
+}
+
 at::Tensor XLANativeFunctions::prod(const at::Tensor& self,
                                     c10::optional<at::ScalarType> dtype) {
   XLA_FN_COUNTER("xla::");

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2552,7 +2552,7 @@ at::Tensor XLANativeFunctions::pow(const at::Scalar& self,
 at::Tensor XLANativeFunctions::prelu(const at::Tensor& self,
                                      const at::Tensor& weight) {
   XLA_FN_COUNTER("xla::");
-  
+
   // If multiple weights, check channel size == number of weights.
   int64_t weight_num = weight.numel();
   if (weight.numel() > 1) {
@@ -2565,11 +2565,12 @@ at::Tensor XLANativeFunctions::prelu(const at::Tensor& self,
            "parameter numbers = "
         << weight_num << " and channel size = " << channel_size;
   }
-  
+
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   XLATensor weight_tensor = bridge::GetXlaTensor(weight);
 
-  return bridge::AtenFromXlaTensor(XLATensor::prelu(self_tensor, weight_tensor));
+  return bridge::AtenFromXlaTensor(
+      XLATensor::prelu(self_tensor, weight_tensor));
 }
 
 at::Tensor XLANativeFunctions::prod(const at::Tensor& self,

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -185,8 +185,8 @@ xla::XlaOp BuildPrelu(xla::XlaOp input, xla::XlaOp weight) {
   xla::int64_t broadcast_dim = weight_num == 1 ? 0 : 1;
 
   xla::XlaOp zero = xla::Zero(input.builder(), input_shape.element_type());
-  xla::XlaOp broadcasted_weight = xla::BroadcastInDim(weight, 
-        input_shape.dimensions(), {broadcast_dim});
+  xla::XlaOp broadcasted_weight =
+      xla::BroadcastInDim(weight, input_shape.dimensions(), {broadcast_dim});
   xla::XlaOp product = xla::Mul(input, broadcasted_weight);
 
   return xla::Select(xla::Gt(input, zero), input, product);

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -175,6 +175,18 @@ xla::XlaOp BuildLeakyReluBackward(xla::XlaOp grad_output, xla::XlaOp input,
                      negative_slope * grad_output);
 }
 
+xla::XlaOp BuildPrelu(xla::XlaOp input, xla::XlaOp weight) {
+  std::cout << "[PReLU, elementwise.cpp] Starting" << std::endl;
+  const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
+  xla::XlaOp zero = xla::Zero(input.builder(), input_shape.element_type());
+  std::cout << "[PReLU, elementwise.cpp] Middle 1" << std::endl;
+  xla::XlaOp weighted = input * weight;
+  std::cout << "[PReLU, elementwise.cpp] Middle 2" << std::endl;
+  xla::XlaOp ret = xla::Select(xla::Gt(input, zero), input, weighted);
+  std::cout << "[PReLU, elementwise.cpp] Finished" << std::endl;
+  return ret;
+} 
+
 xla::XlaOp BuildSigmoid(xla::XlaOp input) {
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(input);
   xla::XlaOp half = XlaHelpers::ScalarValue<float>(0.5, shape.element_type(),

--- a/torch_xla/csrc/elementwise.h
+++ b/torch_xla/csrc/elementwise.h
@@ -18,6 +18,8 @@ xla::XlaOp BuildThreshold(xla::XlaOp input, xla::XlaOp output,
 // Computes the rectified linear unit (replace negative elements with 0).
 xla::XlaOp BuildRelu(xla::XlaOp input);
 
+xla::XlaOp BuildPrelu(xla::XlaOp input, xla::XlaOp weight);
+
 std::vector<xla::XlaOp> BuildRrelu(xla::XlaOp input, const at::Scalar& lower,
                                    const at::Scalar& upper, bool training,
                                    xla::XlaOp rng_seed);

--- a/torch_xla/csrc/ops/infer_output_shape.cpp
+++ b/torch_xla/csrc/ops/infer_output_shape.cpp
@@ -8,6 +8,7 @@ namespace ops {
 
 xla::Shape InferOutputShape(absl::Span<const xla::Shape> input_shapes,
                             const LowerForShapeFn& core_lowering_fn) {
+  std::cout << "[PReLU, infer_output_shape.cpp] Starting" << std::endl;
   xla::XlaBuilder b("InferOutputShape");
   std::vector<xla::XlaOp> parameters;
   for (size_t parameter_number = 0; parameter_number < input_shapes.size();
@@ -16,7 +17,9 @@ xla::Shape InferOutputShape(absl::Span<const xla::Shape> input_shapes,
                                         input_shapes[parameter_number],
                                         absl::StrCat("p", parameter_number)));
   }
+  std::cout << "[PReLU, infer_output_shape.cpp] Middle 1" << std::endl;
   xla::XlaOp result = core_lowering_fn(parameters);
+  std::cout << "[PReLU, infer_output_shape.cpp] Finished" << std::endl;
   return XlaHelpers::ShapeOfXlaOp(result);
 }
 

--- a/torch_xla/csrc/ops/infer_output_shape.cpp
+++ b/torch_xla/csrc/ops/infer_output_shape.cpp
@@ -8,7 +8,6 @@ namespace ops {
 
 xla::Shape InferOutputShape(absl::Span<const xla::Shape> input_shapes,
                             const LowerForShapeFn& core_lowering_fn) {
-  std::cout << "[PReLU, infer_output_shape.cpp] Starting" << std::endl;
   xla::XlaBuilder b("InferOutputShape");
   std::vector<xla::XlaOp> parameters;
   for (size_t parameter_number = 0; parameter_number < input_shapes.size();
@@ -17,9 +16,7 @@ xla::Shape InferOutputShape(absl::Span<const xla::Shape> input_shapes,
                                         input_shapes[parameter_number],
                                         absl::StrCat("p", parameter_number)));
   }
-  std::cout << "[PReLU, infer_output_shape.cpp] Middle 1" << std::endl;
   xla::XlaOp result = core_lowering_fn(parameters);
-  std::cout << "[PReLU, infer_output_shape.cpp] Finished" << std::endl;
   return XlaHelpers::ShapeOfXlaOp(result);
 }
 

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -168,6 +168,32 @@ NodePtr ReluOp(const Value& input) {
       std::move(lower_fn));
 }
 
+NodePtr Prelu(const Value& input, const Value& weight) {
+  // TODO @wonjoo need dimension checking
+  auto lower_fn = [](const Node& node, LoweringContext* loctx) -> XlaOpVector {
+    std::cout << "[PReLU, ops.cpp] Lowering_fn starting" << std::endl;
+    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
+    xla::XlaOp xla_weight = loctx->GetOutputOp(node.operand(1));
+    xla::XlaOp xla_output = BuildPrelu(xla_input, xla_weight);
+    std::cout << "[PReLU, ops.cpp] Lowering_fn finished" << std::endl;
+    return node.ReturnOp(xla_output, loctx);
+  };
+
+  auto lower_for_shape_fn =
+      [](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
+    // TODO @wonjoo shape check
+    std::cout << "[PReLU, ops.cpp] Lowering_shape_fn starting" << std::endl;
+    xla::XlaOp xla_output = BuildPrelu(operands[0], operands[1]);
+    std::cout << "[PReLU, ops.cpp] Lowering_shape_fn finished" << std::endl;
+    return xla_output;
+  };
+
+  return GenericOp(
+      OpKind(at::aten::prelu), {input, weight},
+      [&]() { return InferOutputShape({input.shape(), weight.shape()}, lower_for_shape_fn); },
+      std::move(lower_fn));
+}
+
 NodePtr HardSigmoid(const Value& input) {
   auto lower_fn = [](const Node& node, LoweringContext* loctx) -> XlaOpVector {
     xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -175,23 +175,29 @@ NodePtr Prelu(const Value& input, const Value& weight) {
     xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
     xla::XlaOp xla_weight = loctx->GetOutputOp(node.operand(1));
     xla::XlaOp xla_output = BuildPrelu(xla_input, xla_weight);
+    std::cout << "[PReLU, ops.cpp] Lowering_fn shape of result: "
+              << XlaHelpers::ShapeOfXlaOp(xla_output) << std::endl;
     std::cout << "[PReLU, ops.cpp] Lowering_fn finished" << std::endl;
     return node.ReturnOp(xla_output, loctx);
   };
 
   auto lower_for_shape_fn =
       [](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
-    // TODO @wonjoo shape check
+    XLA_CHECK_EQ(operands.size(), 2) << "Unexpected number of operands";
     std::cout << "[PReLU, ops.cpp] Lowering_shape_fn starting" << std::endl;
     xla::XlaOp xla_output = BuildPrelu(operands[0], operands[1]);
+    std::cout << "[PReLU, ops.cpp] Lowering_shape_fn shape of result: "
+              << XlaHelpers::ShapeOfXlaOp(xla_output) << std::endl;
     std::cout << "[PReLU, ops.cpp] Lowering_shape_fn finished" << std::endl;
     return xla_output;
   };
 
-  return GenericOp(
-      OpKind(at::aten::prelu), {input, weight},
-      [&]() { return InferOutputShape({input.shape(), weight.shape()}, lower_for_shape_fn); },
-      std::move(lower_fn));
+  return GenericOp(OpKind(at::aten::prelu), {input, weight},
+                   [&]() {
+                     return InferOutputShape({input.shape(), weight.shape()},
+                                             lower_for_shape_fn);
+                   },
+                   std::move(lower_fn));
 }
 
 NodePtr HardSigmoid(const Value& input) {

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -176,8 +176,7 @@ NodePtr Prelu(const Value& input, const Value& weight) {
     return node.ReturnOp(xla_output, loctx);
   };
 
-  return GenericOp(OpKind(at::aten::prelu), {input, weight},
-                   input.shape(),
+  return GenericOp(OpKind(at::aten::prelu), {input, weight}, input.shape(),
                    std::move(lower_fn));
 }
 

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -112,6 +112,8 @@ NodePtr Rsqrt(const Value& input);
 
 NodePtr ReciprocalOp(const Value& input);
 
+NodePtr Prelu(const Value& input, const Value& weight);
+
 NodePtr Pow(const Value& input, const Value& exponent);
 
 NodePtr Fmod(const Value& dividend, const Value& divisor);

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -885,6 +885,8 @@ class XLATensor {
   static XLATensor pow(const XLATensor& input, const XLATensor& exponent);
   static XLATensor pow(const at::Scalar& input, const XLATensor& exponent);
 
+  static XLATensor prelu(const XLATensor& input, const XLATensor& weight);
+
   static XLATensor prod(const XLATensor& input,
                         std::vector<xla::int64_t> dimensions,
                         bool keep_reduced_dimensions,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2081,7 +2081,8 @@ XLATensor XLATensor::pow(const at::Scalar& input, const XLATensor& exponent) {
 
 XLATensor XLATensor::prelu(const XLATensor& input, const XLATensor& weight) {
   std::cout << "[PReLU, tensor_methods.cpp] Starting" << std::endl;
-  XLATensor ret = input.CreateFrom(ir::ops::Prelu(input.GetIrValue(), weight.GetIrValue()));
+  XLATensor ret =
+      input.CreateFrom(ir::ops::Prelu(input.GetIrValue(), weight.GetIrValue()));
   std::cout << "[PReLU, tensor_methods.cpp] Finished" << std::endl;
   return ret;
 }

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2080,7 +2080,8 @@ XLATensor XLATensor::pow(const at::Scalar& input, const XLATensor& exponent) {
 }
 
 XLATensor XLATensor::prelu(const XLATensor& input, const XLATensor& weight) {
-  return input.CreateFrom(ir::ops::Prelu(input.GetIrValue(), weight.GetIrValue()));
+  return input.CreateFrom(
+      ir::ops::Prelu(input.GetIrValue(), weight.GetIrValue()));
 }
 
 XLATensor XLATensor::prod(const XLATensor& input,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2080,11 +2080,7 @@ XLATensor XLATensor::pow(const at::Scalar& input, const XLATensor& exponent) {
 }
 
 XLATensor XLATensor::prelu(const XLATensor& input, const XLATensor& weight) {
-  std::cout << "[PReLU, tensor_methods.cpp] Starting" << std::endl;
-  XLATensor ret =
-      input.CreateFrom(ir::ops::Prelu(input.GetIrValue(), weight.GetIrValue()));
-  std::cout << "[PReLU, tensor_methods.cpp] Finished" << std::endl;
-  return ret;
+  return input.CreateFrom(ir::ops::Prelu(input.GetIrValue(), weight.GetIrValue()));
 }
 
 XLATensor XLATensor::prod(const XLATensor& input,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2079,6 +2079,13 @@ XLATensor XLATensor::pow(const at::Scalar& input, const XLATensor& exponent) {
   return exponent.CreateFrom(ir::ops::Pow(input_node, exponent.GetIrValue()));
 }
 
+XLATensor XLATensor::prelu(const XLATensor& input, const XLATensor& weight) {
+  std::cout << "[PReLU, tensor_methods.cpp] Starting" << std::endl;
+  XLATensor ret = input.CreateFrom(ir::ops::Prelu(input.GetIrValue(), weight.GetIrValue()));
+  std::cout << "[PReLU, tensor_methods.cpp] Finished" << std::endl;
+  return ret;
+}
+
 XLATensor XLATensor::prod(const XLATensor& input,
                           std::vector<xla::int64_t> dimensions,
                           bool keep_reduced_dimensions,

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -224,6 +224,7 @@ supported:
   - pow.Scalar
   - pow.Tensor_Scalar
   - pow.Tensor_Tensor
+  - prelu
   - prod
   - prod.dim_int
   - put_


### PR DESCRIPTION
Provide op lowering for prelu. Some relevant readings:
- PyTorch PReLU implementation -- https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/Activation.cpp#L599.
- xla::BroadCastinDim -- https://www.tensorflow.org/xla/operation_semantics#broadcastindim.

Also addressed CircleCI failures due to recent updates in PyTorch tests (https://github.com/pytorch/pytorch/blob/master/test/test_nn.py#L18518):
- Allow zero slope for `leaky_relu_backward` in `aten_type_xla.cpp` as expected in the new PyTorch test
- Disabled a PyTorch test `test_leaky_relu_inplace_wistth_neg_slope` due to the new PyTorch test expecting a specific error message

I've included these changes in this same PR since they were one-line changes. I can move these out to a separate PR if necessary. 