### PR TITLE
More missing includes

### DIFF
--- a/torch_xla/csrc/ops/index_ops.h
+++ b/torch_xla/csrc/ops/index_ops.h
@@ -23,8 +23,8 @@
 
 #pragma once
 
-#include <ATen/core/Tensor.h>
 #include <ATen/core/List.h>
+#include <ATen/core/Tensor.h>
 
 #include "torch_xla/csrc/ir.h"
 #include "torch_xla/csrc/tensor.h"

--- a/torch_xla/csrc/ops/index_ops.h
+++ b/torch_xla/csrc/ops/index_ops.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <ATen/core/Tensor.h>
+#include <ATen/core/List.h>
 
 #include "torch_xla/csrc/ir.h"
 #include "torch_xla/csrc/tensor.h"

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -20,6 +20,9 @@
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/layout_manager.h"
 
+#include <ATen/Formatting.h>
+#include <ATen/Functions.h>
+
 namespace torch_xla {
 namespace {
 

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -1,5 +1,8 @@
 #include "torch_xla/csrc/tensor_util.h"
 
+#include <ATen/Formatting.h>
+#include <ATen/Functions.h>
+
 #include <algorithm>
 #include <cstring>
 #include <functional>
@@ -19,9 +22,6 @@
 #include "torch/csrc/lazy/core/hash.h"
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/layout_manager.h"
-
-#include <ATen/Formatting.h>
-#include <ATen/Functions.h>
 
 namespace torch_xla {
 namespace {


### PR DESCRIPTION
pytorch/pytorch#68691 removes `ATen/ATen.h` includes from many `torch` headers and only includes `Tensor.h`. Unfortunately, the XLA build is failing because it depends on these transitive includes. This PR fixes the build for me locally.