### PR TITLE
Fix f64 div(f32, f64) issue

### DIFF
--- a/test/test_data_type.py
+++ b/test/test_data_type.py
@@ -48,6 +48,13 @@ class XlaDataTypeTest(unittest.TestCase):
     else:
       assert 'f64' in device_data_hlo, device_data_hlo
 
+  def test_datatype_f32_div_f64(self):
+    t1 = torch.rand(2, 2, dtype=torch.float, device=xm.xla_device())
+    t2 = t1 / 2.0
+    hlo_text = torch_xla._XLAC._get_xla_tensors_text([t2])
+    assert t2.dtype == torch.float
+    assert 'f64' not in hlo_text
+
 
 if __name__ == '__main__':
   print(f'XLA_USE_BF16: {os.getenv("XLA_USE_BF16")}')

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1245,7 +1245,7 @@ at::Tensor XLANativeFunctions::div(
     c10::optional<c10::string_view> rounding_mode) {
   XLA_FN_COUNTER("xla::");
   at::ScalarType dtype = at::result_type(self, other);
-  auto operands = GetBinaryOperands(self, other);
+  auto operands = GetBinaryOperands(self, UnwrapNumber(other, dtype));
   return bridge::AtenFromXlaTensor(
       XLATensor::div(operands.first, operands.second, rounding_mode, dtype));
 }


### PR DESCRIPTION
This PR fixes the f64 div issue when a f32 tensor is divided by a f64 scalar. This issue significantly slows down some huggingface models on Nvidia T4 GPU which has poor f64 performance.

Minimal code to reproduce this issue:
```python
import torch, torch_xla
import torch_xla.core.xla_model as xm

device = xm.xla_device()

a = torch.rand(10,10, dtype=torch.float32).to(device)
b = a / 2.0
print(torch_xla._XLAC._get_xla_tensors_text([b]))
```
Before this fix:
```llvm
IR {
  %0 = f64[] xla::device_data(), device=GPU:0
  %1 = f32[10,10]{1,0} xla::device_data(), device=GPU:0
  %2 = f64[10,10]{1,0} aten::div(%1, %0)
  %3 = f32[10,10]{1,0} xla::cast(%2), type=f32, ROOT=0
}
```
After this fix:
```llvm
IR {
  %0 = f32[] xla::device_data(), device=GPU:0
  %1 = f32[10,10]{1,0} xla::device_data(), device=GPU:0
  %2 = f32[10,10]{1,0} aten::div(%1, %0), ROOT=0
}
```