### PR TITLE
Update isnan tensor method to cast to xla::PrimitiveType::PRED

### DIFF
--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -290,7 +290,7 @@ ir::Value GetFloatingIrValue(const XLATensor& input,
 }
 
 ir::Value GetBooleanIrValue(ir::Value input_value) {
-  if (input_value.element_type() != xla::PrimitiveType::PRED) {
+  if (input_value.shape().element_type() != xla::PrimitiveType::PRED) {
     input_value =
         ir::MakeNode<ir::ops::Cast>(input_value, xla::PrimitiveType::PRED);
   }
@@ -1454,9 +1454,9 @@ XLATensor XLATensor::inverse(const XLATensor& input) {
 }
 
 XLATensor XLATensor::isnan(const XLATensor& input) {
-  ir::Value isnan_result = ir::ops::IsNan(input.GetIrValue());
-  ir::Value boolean_casted = GetBooleanIrValue(isnan_result);
-  return input.CreateFrom(boolean_casted);
+  ir::Value result = ir::ops::IsNan(input.GetIrValue());
+  ir::Value casted = GetBooleanIrValue(result);
+  return input.CreateFrom(casted, at::ScalarType::Bool);
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::kthvalue(const XLATensor& input,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -289,6 +289,14 @@ ir::Value GetFloatingIrValue(const XLATensor& input,
   return input_value;
 }
 
+ir::Value GetBooleanIrValue(ir::Value input_value) {
+  if (input_value.element_type() != xla::PrimitiveType::PRED) {
+    input_value =
+        ir::MakeNode<ir::ops::Cast>(input_value, xla::PrimitiveType::PRED);
+  }
+  return input_value;
+}
+
 absl::optional<ir::Value> GetOptionalIrValue(const XLATensor& tensor) {
   absl::optional<ir::Value> value;
   if (!tensor.is_null()) {
@@ -1446,8 +1454,9 @@ XLATensor XLATensor::inverse(const XLATensor& input) {
 }
 
 XLATensor XLATensor::isnan(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::IsNan(input.GetIrValue()),
-                          at::ScalarType::Bool);
+  ir::Value isnan_result = ir::ops::IsNan(input.GetIrValue());
+  ir::Value boolean_casted = GetBooleanIrValue(isnan_result);
+  return input.CreateFrom(boolean_casted);
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::kthvalue(const XLATensor& input,


### PR DESCRIPTION
This PR addresses https://github.com/pytorch/xla/issues/3225. 