### PR TITLE
Fix XlA_ERROR build issue

### DIFF
--- a/third_party/xla_client/mesh_service.cc
+++ b/third_party/xla_client/mesh_service.cc
@@ -49,7 +49,19 @@ namespace {
                               status.error_message());
 }
 
-std::ostream& operator<<(std::ostream& ostrm, const ::grpc::Status& status) {
+std::basic_ostringstream<char>& operator<<(std::basic_ostringstream<char> ostrm,
+                                           const ::grpc::Status& status) {
+  if (status.ok()) {
+    ostrm << "OK";
+  } else {
+    ostrm << status.error_message() << " ("
+          << static_cast<int>(status.error_code()) << ")";
+  }
+  return ostrm;
+}
+
+std::basic_ostringstream<char>& operator<<(
+    std::basic_ostringstream<char>& ostrm, const ::grpc::Status& status) {
   if (status.ok()) {
     ostrm << "OK";
   } else {
@@ -96,7 +108,9 @@ class MeshServiceImpl : public grpc::MeshService::Service {
     void Complete(int64_t ordinal, std::string payload,
                   const std::set<int64_t>& replicas);
 
-    const std::map<int64_t, std::string>& Payloads() const { return payloads_; };
+    const std::map<int64_t, std::string>& Payloads() const {
+      return payloads_;
+    };
 
    private:
     size_t count_;
@@ -189,7 +203,7 @@ MeshServiceImpl::MeshServiceImpl(grpc::Config config) {
     ::grpc::ServerContext* context, const grpc::RendezvousRequest* request,
     grpc::RendezvousResponse* response) {
   std::set<int64_t> replicas(request->replicas().begin(),
-                           request->replicas().end());
+                             request->replicas().end());
   auto rendezvous = GetRendezvous(request->tag(), replicas);
   rendezvous->Complete(request->ordinal(), request->payload(), replicas);
   TF_VLOG(3) << "Entering rendezvous: ordinal=" << request->ordinal()

--- a/third_party/xla_client/mesh_service.cc
+++ b/third_party/xla_client/mesh_service.cc
@@ -49,8 +49,7 @@ namespace {
                               status.error_message());
 }
 
-std::basic_ostringstream<char>& operator<<(std::basic_ostringstream<char> ostrm,
-                                           const ::grpc::Status& status) {
+std::ostream& operator<<(std::ostream& ostrm, const ::grpc::Status& status) {
   if (status.ok()) {
     ostrm << "OK";
   } else {
@@ -60,8 +59,8 @@ std::basic_ostringstream<char>& operator<<(std::basic_ostringstream<char> ostrm,
   return ostrm;
 }
 
-std::basic_ostringstream<char>& operator<<(
-    std::basic_ostringstream<char>& ostrm, const ::grpc::Status& status) {
+std::basic_ostringstream<char>& operator<<(std::basic_ostringstream<char> ostrm,
+                                           const ::grpc::Status& status) {
   if (status.ok()) {
     ostrm << "OK";
   } else {

--- a/torch_xla/csrc/ops/scalar.cpp
+++ b/torch_xla/csrc/ops/scalar.cpp
@@ -83,7 +83,9 @@ XlaOpVector Scalar::Lower(LoweringContext* loctx) const {
                                    xla::complex128(value_.toComplexDouble()));
       break;
     default:
-      XLA_ERROR() << "Unable to lower scalar " << value_ << " of shape "
+      std::stringstream ss;
+      ss << value_;
+      XLA_ERROR() << "Unable to lower scalar " << ss.str() << " of shape "
                   << shape();
   }
 


### PR DESCRIPTION
This is to fix the build issue on my build machine

```
tensorflow/compiler/xla/xla_client/mesh_service.cc:390:26: error: invalid operands to binary expression ('xla::internal::ErrorSink' and '::grpc::Status')
                << "): " << status;
                ~~~~~~~~ ^  ~~~~~~
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ostream:245:7: note: candidate function not viable: no known conversion from '::grpc::Status' to 'const void *' for 1st argument; take the address of the argument with &
      operator<<(const void* __p)
      ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/system_error:279:5: note: candidate function template not viable: no known conversion from '::grpc::Status' to 'const std::error_code' for 2nd argument
    operator<<(basic_ostream<_CharT, _Traits>& __os, const error_code& __e)
    ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ostream:511:5: note: candidate function template not viable: no known conversion from '::grpc::Status' to 'char' for 2nd argument
    operator<<(basic_ostream<_CharT, _Traits>& __out, char __c)
    ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ostream:517:5: note: candidate function template not viable: no known conversion from '::grpc::Status' to 'char' for 2nd argument
    operator<<(basic_ostream<char, _Traits>& __out, char __c)
```

fundamental problem is from
```
tensorflow/compiler/xla/xla_client/mesh_service.cc:52:15: note: candidate function not viable: no known conversion from 'xla::internal::ErrorSink' to 'std::ostream &' (aka 'basic_ostream<char> &') for 1st argument
std::ostream& operator<<(std::ostream& ostrm, const ::grpc::Status& status) {
```

since
https://github.com/pytorch/xla/blob/master/third_party/xla_client/tf_logging.h#L51
return a lValue.

the fix is to add a overload to take `basic_ostringstream` as value(instead of reference) . I can't do that for `ostream` since the constructor for `ostream` is protected.