### PR TITLE
Move softplus out of tensor_ops and make it an regular op

### DIFF
--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -253,11 +253,11 @@ xla::XlaOp BuildAbs(xla::XlaOp input) {
   return xla::Abs(input);
 }
 
-xla::XlaOp BuildSoftplus(xla::XlaOp input, xla::XlaOp beta, xla::XlaOp threshold) {
+xla::XlaOp BuildSoftplus(xla::XlaOp input, xla::XlaOp beta,
+                         xla::XlaOp threshold) {
   return xla::Select(
-    xla::Gt(xla::Mul(input, beta), threshold), input,
-    xla::Div(
-        xla::Log1p(xla::Exp(xla::Mul(input, beta))), beta));
+      xla::Gt(xla::Mul(input, beta), threshold), input,
+      xla::Div(xla::Log1p(xla::Exp(xla::Mul(input, beta))), beta));
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -253,4 +253,11 @@ xla::XlaOp BuildAbs(xla::XlaOp input) {
   return xla::Abs(input);
 }
 
+xla::XlaOp BuildSoftplus(xla::XlaOp input, xla::XlaOp beta, xla::XlaOp threshold) {
+  return xla::Select(
+    xla::Gt(xla::Mul(input, beta), threshold), input,
+    xla::Div(
+        xla::Log1p(xla::Exp(xla::Mul(input, beta))), beta));
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/elementwise.h
+++ b/torch_xla/csrc/elementwise.h
@@ -69,4 +69,6 @@ xla::XlaOp BuildSign(xla::XlaOp input);
 // Computes the absolute value of the input.
 xla::XlaOp BuildAbs(xla::XlaOp input);
 
+xla::XlaOp BuildSoftplus(xla::XlaOp input, xla::XlaOp beta, xla::XlaOp threshold);
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/elementwise.h
+++ b/torch_xla/csrc/elementwise.h
@@ -69,6 +69,7 @@ xla::XlaOp BuildSign(xla::XlaOp input);
 // Computes the absolute value of the input.
 xla::XlaOp BuildAbs(xla::XlaOp input);
 
-xla::XlaOp BuildSoftplus(xla::XlaOp input, xla::XlaOp beta, xla::XlaOp threshold);
+xla::XlaOp BuildSoftplus(xla::XlaOp input, xla::XlaOp beta,
+                         xla::XlaOp threshold);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -951,7 +951,8 @@ NodePtr SLogDet(const Value& input) {
       std::move(lower_fn), /*num_outputs=*/2);
 }
 
-NodePtr Softplus(const Value& input, const Value& beta, const Value& threshold) {
+NodePtr Softplus(const Value& input, const Value& beta,
+                 const Value& threshold) {
   auto lower_fn = [](const Node& node, LoweringContext* loctx) -> XlaOpVector {
     xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
     xla::XlaOp xla_beta = loctx->GetOutputOp(node.operand(1));
@@ -960,8 +961,8 @@ NodePtr Softplus(const Value& input, const Value& beta, const Value& threshold) 
     return node.ReturnOp(xla_output, loctx);
   };
 
-  return GenericOp(OpKind(at::aten::softplus), {input, beta, threshold}, input.shape(),
-                   std::move(lower_fn));
+  return GenericOp(OpKind(at::aten::softplus), {input, beta, threshold},
+                   input.shape(), std::move(lower_fn));
 }
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -951,6 +951,19 @@ NodePtr SLogDet(const Value& input) {
       std::move(lower_fn), /*num_outputs=*/2);
 }
 
+NodePtr Softplus(const Value& input, const Value& beta, const Value& threshold) {
+  auto lower_fn = [](const Node& node, LoweringContext* loctx) -> XlaOpVector {
+    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
+    xla::XlaOp xla_beta = loctx->GetOutputOp(node.operand(1));
+    xla::XlaOp xla_threshold = loctx->GetOutputOp(node.operand(2));
+    xla::XlaOp xla_output = BuildSoftplus(xla_input, xla_beta, xla_threshold);
+    return node.ReturnOp(xla_output, loctx);
+  };
+
+  return GenericOp(OpKind(at::aten::softplus), {input, beta, threshold}, input.shape(),
+                   std::move(lower_fn));
+}
+
 }  // namespace ops
 }  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -238,6 +238,8 @@ NodePtr NanToNum(const Value& input, const Value& nan, const Value& posinf,
 
 NodePtr SLogDet(const Value& input);
 
+NodePtr Softplus(const Value& input, const Value& beta, const Value& threshold);
+
 }  // namespace ops
 }  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2450,7 +2450,12 @@ XLATensor XLATensor::softmax_backward(const XLATensor& grad_output,
 
 XLATensor XLATensor::softplus(const XLATensor& input, const at::Scalar& beta,
                               const at::Scalar& threshold) {
-  return tensor_ops::Softplus(input, beta, threshold);
+  ir::Value beta_value = XLATensor::GetIrValueForScalar(
+      beta, input.shape().get().element_type(), input.GetDevice());
+  ir::Value threshold_value = XLATensor::GetIrValueForScalar(
+      threshold, input.shape().get().element_type(), input.GetDevice());
+  return input.CreateFrom(
+      ir::ops::Softplus(input.GetIrValue(), beta_value, threshold_value));
 }
 
 XLATensor XLATensor::softplus_backward(const XLATensor& grad_output,


### PR DESCRIPTION
This PR partly addresses https://github.com/pytorch/xla/issues/3237. 

This PR moves `softplus` out of tensor_ops and makes it an regular op. Following this, we'll do the same for `softplus_backward` and `mish`, which are currently both in tensor_ops. 