### PR TITLE
Pass exponent as constant instead of device_data

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1765,6 +1765,14 @@ class TestAtenXlaTensor(XlaTestCase):
     y = torch.rand(5)
     self.assertEqual(x + y, y + x)
 
+  def test_pow_constant(self):
+    xla_device = xm.xla_device()
+    t1 = torch.pow(torch.tensor([2.0, 3.0], device=xm.xla_device()), 5)
+    hlo_text = torch_xla._XLAC._get_xla_tensors_text([t1])
+    const_hlo = hlo_text.split('\n')[1]
+    assert 'prim::Constant' in const_hlo
+    assert 'xla::device_data' not in const_hlo
+
 
 class MNISTComparator(nn.Module):
 

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -722,6 +722,17 @@ ir::Value XLATensor::GetDeviceDataIrValue(const at::Scalar& value,
   return ir::MakeNode<ir::ops::DeviceData>(std::move(data));
 }
 
+ir::Value XLATensor::GetIrValueForConstant(const at::Scalar& value,
+                                           const xla::Shape& shape) {
+  ir::Value ir_value =
+      ir::ops::ScalarOp(std::move(value), shape.element_type());
+  if (!shape.dimensions().empty()) {
+    ir_value = ir::MakeNode<ir::ops::Expand>(
+        ir_value, xla::util::ToVector<xla::int64_t>(shape.dimensions()));
+  }
+  return ir_value;
+}
+
 ir::Value XLATensor::GetIrValueForScalar(const at::Scalar& value,
                                          xla::PrimitiveType type,
                                          const Device& device) {

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -103,6 +103,10 @@ class XLATensor {
   static ir::Value GetDeviceDataIrValue(const at::Scalar& value,
                                         xla::PrimitiveType type,
                                         const Device& device);
+  // Use with caution, constant will cause more frequent recompilation
+  // compared to the device_data.
+  static ir::Value GetIrValueForConstant(const at::Scalar& value,
+                                         const xla::Shape& shape);
   static ir::Value GetIrValueForScalar(const at::Scalar& value,
                                        xla::PrimitiveType type,
                                        const Device& device);

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2093,8 +2093,9 @@ XLATensor XLATensor::permute(const XLATensor& input,
 }
 
 XLATensor XLATensor::pow(const XLATensor& input, const at::Scalar& exponent) {
-  ir::Value exponent_node =
-      GetIrValueForScalar(exponent, input.shape(), input.GetDevice());
+  // We want to pass exponent_node as a constant to give XLA more room to
+  // optimize
+  ir::Value exponent_node = GetIrValueForConstant(exponent, input.shape());
   return input.CreateFrom(ir::ops::Pow(input.GetIrValue(), exponent_node));
 }
 


### PR DESCRIPTION
This is to implement https://github.com/pytorch/xla/issues/3248.

New HLO for `torch.pow(torch.tensor([2.0, 3.0], device=xm.xla_device()), 5)` looks like
```
IR {
  %0 = f32[] prim::Constant(), location=test_pow_constant@test_operations.py:1770, value=5
  %1 = f32[2]{0} aten::expand(%0), location=test_pow_constant@test_operations.py:1770, size=(2)
  %2 = f32[2]{0} xla::device_data(), location=test_pow_constant@test_operations.py:1770, device=CPU:0
  %3 = f32[2]{0} aten::pow(%2, %1), location=test_pow_constant@test_operations.py:1770, ROOT=0
}
```

Note that `exponent` becomes a `prim::Constant`. This will give XLA compiler more room to optimize and improve the accuracy and speed.