### PR TITLE
Move softplus_backward out of tensor_ops and make it an regular op

### DIFF
--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -260,4 +260,14 @@ xla::XlaOp BuildSoftplus(xla::XlaOp input, xla::XlaOp beta,
       xla::Div(xla::Log1p(xla::Exp(xla::Mul(input, beta))), beta));
 }
 
+xla::XlaOp BuildSoftplusBackward(xla::XlaOp grad_output, xla::XlaOp input,
+                                 xla::XlaOp beta, xla::XlaOp threshold,
+                                 xla::XlaOp output) {
+  xla::XlaOp scaled_input = xla::Mul(input, beta);
+  xla::XlaOp z = xla::Exp(xla::Mul(output, beta));
+  return xla::XlaOp::Select(
+    xla::Gt(scaled_input, threshold), grad_output,
+    xla::Mul(grad_output, xla::Div(xla::Sub(z, 1), z))); 
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -265,9 +265,10 @@ xla::XlaOp BuildSoftplusBackward(xla::XlaOp grad_output, xla::XlaOp input,
                                  xla::XlaOp output) {
   xla::XlaOp scaled_input = xla::Mul(input, beta);
   xla::XlaOp z = xla::Exp(xla::Mul(output, beta));
-  return xla::XlaOp::Select(
+  xla::XlaOp one = xla::One(z.builder(), XlaHelpers::ShapeOfXlaOp(z).element_type());
+  return xla::Select(
     xla::Gt(scaled_input, threshold), grad_output,
-    xla::Mul(grad_output, xla::Div(xla::Sub(z, 1), z))); 
+    xla::Mul(grad_output, xla::Div(xla::Sub(z, one), z))); 
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -265,10 +265,10 @@ xla::XlaOp BuildSoftplusBackward(xla::XlaOp grad_output, xla::XlaOp input,
                                  xla::XlaOp output) {
   xla::XlaOp scaled_input = xla::Mul(input, beta);
   xla::XlaOp z = xla::Exp(xla::Mul(output, beta));
-  xla::XlaOp one = xla::One(z.builder(), XlaHelpers::ShapeOfXlaOp(z).element_type());
-  return xla::Select(
-    xla::Gt(scaled_input, threshold), grad_output,
-    xla::Mul(grad_output, xla::Div(xla::Sub(z, one), z))); 
+  xla::XlaOp one =
+      xla::One(z.builder(), XlaHelpers::ShapeOfXlaOp(z).element_type());
+  return xla::Select(xla::Gt(scaled_input, threshold), grad_output,
+                     xla::Mul(grad_output, xla::Div(xla::Sub(z, one), z)));
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/elementwise.h
+++ b/torch_xla/csrc/elementwise.h
@@ -72,4 +72,8 @@ xla::XlaOp BuildAbs(xla::XlaOp input);
 xla::XlaOp BuildSoftplus(xla::XlaOp input, xla::XlaOp beta,
                          xla::XlaOp threshold);
 
+xla::XlaOp BuildSoftplusBackward(xla::XlaOp grad_output, xla::XlaOp input,
+                                 xla::XlaOp beta, xla::XlaOp threshold,
+                                 xla::XlaOp output);
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -965,6 +965,21 @@ NodePtr Softplus(const Value& input, const Value& beta,
                    input.shape(), std::move(lower_fn));
 }
 
+NodePtr SoftplusBackward(const Value& grad_output, const Value& input,
+                         const Value& beta, const Value& threshold,
+                         const Value& output) {
+  auto lower_fn = [](const Node& node, LoweringContext* loctx) -> XlaOpVector {
+    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
+    xla::XlaOp xla_beta = loctx->GetOutputOp(node.operand(1));
+    xla::XlaOp xla_threshold = loctx->GetOutputOp(node.operand(2));
+    xla::XlaOp xla_output = BuildSoftplus(xla_input, xla_beta, xla_threshold);
+    return node.ReturnOp(xla_output, loctx);
+  };
+
+  return GenericOp(OpKind(at::aten::softplus), {input, beta, threshold},
+                   input.shape(), std::move(lower_fn));
+}
+
 }  // namespace ops
 }  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -240,6 +240,10 @@ NodePtr SLogDet(const Value& input);
 
 NodePtr Softplus(const Value& input, const Value& beta, const Value& threshold);
 
+NodePtr SoftplusBackward(const Value& grad_output, const Value& input,
+                         const Value& beta, const Value& threshold,
+                         const Value& output);
+
 }  // namespace ops
 }  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2461,8 +2461,8 @@ XLATensor XLATensor::softplus_backward(const XLATensor& grad_output,
       beta, input.shape().get().element_type(), input.GetDevice());
   ir::Value threshold_value = XLATensor::GetIrValueForScalar(
       threshold, input.shape().get().element_type(), input.GetDevice());
-  return input.CreateFrom(
-      ir::ops::SoftplusBackward(grad_output.GetIrValue(), input.GetIrValue(), beta_value, threshold_value,
+  return input.CreateFrom(ir::ops::SoftplusBackward(
+      grad_output.GetIrValue(), input.GetIrValue(), beta_value, threshold_value,
       output.GetIrValue()));
 }
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2457,8 +2457,13 @@ XLATensor XLATensor::softplus_backward(const XLATensor& grad_output,
                                        const at::Scalar& beta,
                                        const at::Scalar& threshold,
                                        const XLATensor& output) {
-  return tensor_ops::SoftplusBackward(grad_output, input, beta, threshold,
-                                      output);
+  ir::Value beta_value = XLATensor::GetIrValueForScalar(
+      beta, input.shape().get().element_type(), input.GetDevice());
+  ir::Value threshold_value = XLATensor::GetIrValueForScalar(
+      threshold, input.shape().get().element_type(), input.GetDevice());
+  return input.CreateFrom(
+      ir::ops::SoftplusBackward(grad_output.GetIrValue(), input.GetIrValue(), beta_value, threshold_value,
+      output.GetIrValue()));
 }
 
 XLATensor XLATensor::softshrink(const XLATensor& input,


### PR DESCRIPTION
This PR is a follow-up to https://github.com/pytorch/xla/pull/3250 and partly addresses #3237.

This PR moves softplus_backward out of tensor_ops and makes it an regular op. Previously, we've done this for softplus. Following this, we'll do the same for mish.