### PR TITLE
.circleci: Only unlink if file exists

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -70,7 +70,10 @@ function install_deps_pytorch_xla() {
   # XLA build requires Bazel
   # We use bazelisk to avoid updating Bazel version manually.
   sudo npm install -g @bazel/bazelisk
-  sudo unlink /usr/bin/bazel
+  # Only unlink if file exists
+  if [[ -e /usr/bin/bazel ]]; then
+    sudo unlink /usr/bin/bazel
+  fi
   sudo ln -s "$(command -v bazelisk)" /usr/bin/bazel
 
   # Symnlink the missing cuda headers if exists


### PR DESCRIPTION
/usr/bin/bazel doesn't exist in upstream pytorch/pytorch so
make it so that unlink doesn't run if it doesn't exist

Fixes https://github.com/pytorch/xla/issues/3270 introduced in https://github.com/pytorch/xla/pull/3255

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>