### PR TITLE
Removed deprecated torch.symeig and added torch.linalg.eigh

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -934,29 +934,23 @@ TEST_F(AtenXlaTensorTest, TestQR) {
   }
 }
 
-TEST_F(AtenXlaTensorTest, TestSymEig) {
+TEST_F(AtenXlaTensorTest, TestLinalgEigh) {
   static const int dims[] = {4, 7};
   for (auto m : dims) {
-    for (bool eigenvectors : {true, false}) {
-      for (bool upper : {true, false}) {
-        torch::Tensor a =
-            torch::rand({m, m}, torch::TensorOptions(torch::kFloat));
-        torch::Tensor sym_a = a.mm(a.t());
-        auto b = torch::symeig(sym_a, eigenvectors, upper);
-        ForEachDevice([&](const torch::Device& device) {
-          torch::Tensor xla_a = CopyToDevice(sym_a, device);
-          auto xla_b = torch::symeig(xla_a, eigenvectors, upper);
-          AllClose(std::get<0>(b), std::get<0>(xla_b), /*rtol=*/3e-2,
-                   /*atol=*/1e-2);
-          if (eigenvectors) {
-            AllClose(std::get<1>(b).abs(), std::get<1>(xla_b).abs(),
-                     /*rtol=*/3e-2,
-                     /*atol=*/1e-2);
-          } else {
-            EXPECT_EQ(std::get<1>(b).sizes(), std::get<1>(xla_b).sizes());
-          }
-        });
-      }
+    for (std::string uplo : {"U", "L"}) {
+      torch::Tensor a =
+          torch::rand({m, m}, torch::TensorOptions(torch::kFloat));
+      torch::Tensor sym_a = a.mm(a.t());
+      auto b = torch::linalg_eigh(sym_a, uplo);
+      ForEachDevice([&](const torch::Device& device) {
+        torch::Tensor xla_a = CopyToDevice(sym_a, device);
+        auto xla_b = torch::linalg_eigh(xla_a, uplo);
+        AllClose(std::get<0>(b), std::get<0>(xla_b), /*rtol=*/3e-2,
+                 /*atol=*/1e-2);
+        AllClose(std::get<1>(b).abs(), std::get<1>(xla_b).abs(),
+                 /*rtol=*/3e-2,
+                 /*atol=*/1e-2);
+      });
     }
   }
 }

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2777,11 +2777,10 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> XLANativeFunctions::svd(
                          bridge::AtenFromXlaTensor(std::get<2>(results)));
 }
 
-std::tuple<at::Tensor, at::Tensor> XLANativeFunctions::symeig(
-    const at::Tensor& self, bool eigenvectors, bool upper) {
+std::tuple<at::Tensor, at::Tensor> XLANativeFunctions::linalg_eigh(
+    const at::Tensor& self, c10::string_view uplo) {
   TORCH_LAZY_FN_COUNTER("xla::");
-  auto results =
-      tensor_methods::symeig(bridge::GetXlaTensor(self), eigenvectors, upper);
+  auto results = tensor_methods::linalg_eigh(bridge::GetXlaTensor(self), uplo);
   return std::make_tuple(bridge::AtenFromXlaTensor(std::get<0>(results)),
                          bridge::AtenFromXlaTensor(std::get<1>(results)));
 }

--- a/torch_xla/csrc/ops/symeig.cpp
+++ b/torch_xla/csrc/ops/symeig.cpp
@@ -45,7 +45,7 @@ xla::Shape NodeOutputShape(const torch::lazy::Value& input, bool eigenvectors,
 }  // namespace
 
 SymEig::SymEig(const torch::lazy::Value& input, bool eigenvectors, bool lower)
-    : XlaNode(torch::lazy::OpKind(at::aten::symeig), {input},
+    : XlaNode(torch::lazy::OpKind(at::aten::linalg_eigh), {input},
               [&]() { return NodeOutputShape(input, eigenvectors, lower); },
               /*num_outputs=*/2, torch::lazy::MHash(eigenvectors, lower)),
       eigenvectors_(eigenvectors),

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -449,6 +449,9 @@ XLATensorPtr lerp(const XLATensorPtr& input, const XLATensorPtr& end,
 XLATensorPtr lerp(const XLATensorPtr& input, const XLATensorPtr& end,
                   const at::Scalar& weight);
 
+std::tuple<XLATensorPtr, XLATensorPtr> linalg_eigh(const XLATensorPtr& input,
+                                                   c10::string_view uplo);
+
 XLATensorPtr linspace(const at::Scalar& start, const at::Scalar& end,
                       const int64_t steps, at::ScalarType element_type,
                       const torch::lazy::BackendDevice& device);
@@ -804,9 +807,6 @@ XLATensorPtr sum(const XLATensorPtr& input, std::vector<int64_t> dimensions,
 
 std::tuple<XLATensorPtr, XLATensorPtr, XLATensorPtr> svd(
     const XLATensorPtr& input, bool some, bool compute_uv);
-
-std::tuple<XLATensorPtr, XLATensorPtr> symeig(const XLATensorPtr& input,
-                                              bool eigenvectors, bool upper);
 
 XLATensorPtr take(const XLATensorPtr& input, const XLATensorPtr& index);
 

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -197,6 +197,7 @@ supported:
   - leaky_relu_backward
   - lerp.Scalar
   - lerp.Tensor
+  - linalg_eigh
   - linspace
   - log
   - log1p
@@ -307,7 +308,6 @@ supported:
   - sum
   - sum.dim_IntList
   - svd
-  - symeig
   - t
   - t_
   - tanh_backward


### PR DESCRIPTION
`torch.symeig` was deprecated in 1.9 release and will be removed in the next 1.11 release. This PR removes `symeig` and replaces it with `linalg_eigh`.

https://github.com/pytorch/pytorch/pull/69857 that removes deprecated functions in PyTorch is currently blocked by pytorch/xla (see [this failing CI](https://github.com/pytorch/pytorch/runs/4605268862?check_suite_focus=true)).

