### PR TITLE
Remove output parameter in softplus_backward op

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ calculate_docker_image: &calculate_docker_image
     # Just a quick smoke test to see if we can actually extract the tag
     git -C /tmp/pytorch rev-parse HEAD:.circleci/docker
     DOCKER_TAG=$(git -C /tmp/pytorch rev-parse HEAD:.circleci/docker)
-    echo "declare -x DOCKER_IMAGE=308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-cuda11.5-cudnn8-py3-gcc7:${DOCKER_TAG}" >> "${BASH_ENV}"
+    echo "declare -x DOCKER_IMAGE=308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.1-cudnn8-py3-gcc7:${DOCKER_TAG}" >> "${BASH_ENV}"
 
 run_build: &run_build
   resource_class: xlarge

--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -263,6 +263,7 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_softshrink_inplace_overlap_xla',  # doesn't raise
         'test_Conv2d_backward_depthwise_xla_float64',  # slow compilation
         'test_leaky_relu_inplace_with_neg_slope_xla',  # expecting a specific error message
+        'test_upsamplingBicubic2d_correctness_xla',  # FIXME! Got dtypes torch.float32 and torch.float64
     },
 
     # test_type_promotion.py

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3009,12 +3009,11 @@ at::Tensor XLANativeFunctions::softplus(const at::Tensor& self,
 at::Tensor XLANativeFunctions::softplus_backward(const at::Tensor& grad_output,
                                                  const at::Tensor& self,
                                                  const at::Scalar& beta,
-                                                 const at::Scalar& threshold,
-                                                 const at::Tensor& output) {
+                                                 const at::Scalar& threshold) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::softplus_backward(
       bridge::GetXlaTensor(grad_output), bridge::GetXlaTensor(self), beta,
-      threshold, bridge::GetXlaTensor(output)));
+      threshold));
 }
 
 at::Tensor XLANativeFunctions::softshrink(const at::Tensor& self,

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -1018,11 +1018,11 @@ class XLATensor {
 
   static XLATensor softplus(const XLATensor& input, const at::Scalar& beta,
                             const at::Scalar& threshold);
+                            
   static XLATensor softplus_backward(const XLATensor& grad_output,
                                      const XLATensor& input,
                                      const at::Scalar& beta,
-                                     const at::Scalar& threshold,
-                                     const XLATensor& output);
+                                     const at::Scalar& threshold);
 
   static XLATensor softshrink(const XLATensor& input, const at::Scalar& lambda);
   static XLATensor softshrink_backward(const XLATensor& grad_out,

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -1018,7 +1018,7 @@ class XLATensor {
 
   static XLATensor softplus(const XLATensor& input, const at::Scalar& beta,
                             const at::Scalar& threshold);
-                            
+
   static XLATensor softplus_backward(const XLATensor& grad_output,
                                      const XLATensor& input,
                                      const at::Scalar& beta,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2458,10 +2458,8 @@ XLATensor XLATensor::softplus(const XLATensor& input, const at::Scalar& beta,
 XLATensor XLATensor::softplus_backward(const XLATensor& grad_output,
                                        const XLATensor& input,
                                        const at::Scalar& beta,
-                                       const at::Scalar& threshold,
-                                       const XLATensor& output) {
-  return tensor_ops::SoftplusBackward(grad_output, input, beta, threshold,
-                                      output);
+                                       const at::Scalar& threshold) {
+  return tensor_ops::SoftplusBackward(grad_output, input, beta, threshold);
 }
 
 XLATensor XLATensor::softshrink(const XLATensor& input,

--- a/torch_xla/csrc/tensor_ops.cpp
+++ b/torch_xla/csrc/tensor_ops.cpp
@@ -156,7 +156,8 @@ XLATensor Softplus(const XLATensor& input, const at::Scalar& beta,
 }
 
 XLATensor SoftplusBackward(const XLATensor& grad_output, const XLATensor& input,
-                           const at::Scalar& beta, const at::Scalar& threshold) {
+                           const at::Scalar& beta,
+                           const at::Scalar& threshold) {
   XLATensor scaled_input = XLATensor::mul(input, beta);
   XLATensor z = XLATensor::exp(scaled_input);
   return XLATensor::where(

--- a/torch_xla/csrc/tensor_ops.cpp
+++ b/torch_xla/csrc/tensor_ops.cpp
@@ -164,7 +164,8 @@ XLATensor SoftplusBackward(const XLATensor& grad_output, const XLATensor& input,
 
   return XLATensor::where(
       XLATensor::gt(scaled_input, threshold), grad_output,
-      XLATensor::mul(grad_output, XLATensor::div(z, XLATensor::add(z, one_vec, 1))));
+      XLATensor::mul(grad_output,
+                     XLATensor::div(z, XLATensor::add(z, one_vec, 1))));
 }
 
 XLATensor Select(const XLATensor& input, xla::int64_t dim, xla::int64_t index) {

--- a/torch_xla/csrc/tensor_ops.cpp
+++ b/torch_xla/csrc/tensor_ops.cpp
@@ -156,10 +156,9 @@ XLATensor Softplus(const XLATensor& input, const at::Scalar& beta,
 }
 
 XLATensor SoftplusBackward(const XLATensor& grad_output, const XLATensor& input,
-                           const at::Scalar& beta, const at::Scalar& threshold,
-                           const XLATensor& output) {
+                           const at::Scalar& beta, const at::Scalar& threshold) {
   XLATensor scaled_input = XLATensor::mul(input, beta);
-  XLATensor z = XLATensor::exp(XLATensor::mul(output, beta));
+  XLATensor z = XLATensor::exp(scaled_input);
   return XLATensor::where(
       XLATensor::gt(scaled_input, threshold), grad_output,
       XLATensor::mul(grad_output, XLATensor::div(XLATensor::sub(z, 1, 1), z)));

--- a/torch_xla/csrc/tensor_ops.cpp
+++ b/torch_xla/csrc/tensor_ops.cpp
@@ -160,9 +160,11 @@ XLATensor SoftplusBackward(const XLATensor& grad_output, const XLATensor& input,
                            const at::Scalar& threshold) {
   XLATensor scaled_input = XLATensor::mul(input, beta);
   XLATensor z = XLATensor::exp(scaled_input);
+  XLATensor one_vec = XLATensor::full_like(z, 1, z.GetDevice(), z.dtype());
+
   return XLATensor::where(
       XLATensor::gt(scaled_input, threshold), grad_output,
-      XLATensor::mul(grad_output, XLATensor::div(XLATensor::sub(z, 1, 1), z)));
+      XLATensor::mul(grad_output, XLATensor::div(z, XLATensor::add(z, one_vec, 1))));
 }
 
 XLATensor Select(const XLATensor& input, xla::int64_t dim, xla::int64_t index) {

--- a/torch_xla/csrc/tensor_ops.h
+++ b/torch_xla/csrc/tensor_ops.h
@@ -26,8 +26,7 @@ XLATensor Softplus(const XLATensor& input, const at::Scalar& beta,
                    const at::Scalar& threshold);
 
 XLATensor SoftplusBackward(const XLATensor& grad_output, const XLATensor& input,
-                           const at::Scalar& beta, const at::Scalar& threshold,
-                           const XLATensor& output);
+                           const at::Scalar& beta, const at::Scalar& threshold);
 
 XLATensor Select(const XLATensor& input, xla::int64_t dim, xla::int64_t index);
 


### PR DESCRIPTION
PyTorch recently has pushed a commit last week that changes an op's input parameters (https://github.com/pytorch/pytorch/pull/70296). This breaks our build because we had this op (softplus_backward) already lowered with the original input parameters. This PR addresses this issue. 