### PR TITLE
Install numpy before running test

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -21,6 +21,10 @@ function apply_patches() {
   ./xla/scripts/apply_patches.sh
 }
 
+function install_numpy() {
+  pip install numpy==1.16.3
+}
+
 function rebase_pull_request_on_target_branch() {
   # TODO: directly use ENV_VAR when CircleCi exposes base branch.
   # Try rebasing on top of base (dest) branch first.
@@ -55,9 +59,6 @@ function install_deps_pytorch_xla() {
   # Install libraries required for running some PyTorch test suites
   pip install hypothesis
   pip install cloud-tpu-client
-
-  # Update numpy version
-  pip install numpy==1.16.3
 
   # Using the Ninja generator requires CMake version 3.13 or greater
   pip install cmake>=3.13 --upgrade

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -22,7 +22,7 @@ function apply_patches() {
 }
 
 function install_numpy() {
-  pip install numpy==1.18.5
+  pip install numpy>=1.18.5
 }
 
 function rebase_pull_request_on_target_branch() {

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -22,7 +22,7 @@ function apply_patches() {
 }
 
 function install_numpy() {
-  pip install numpy==1.16.3
+  pip install numpy==1.18.5
 }
 
 function rebase_pull_request_on_target_branch() {

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -10,5 +10,6 @@ XLA_DIR=$PYTORCH_DIR/xla
 
 source "$PYTORCH_DIR/.jenkins/pytorch/common_utils.sh"
 install_torchvision
+install_numpy
 
 run_torch_xla_tests $PYTORCH_DIR $XLA_DIR


### PR DESCRIPTION
Checking the log and saw

```
+ pip install numpy==1.16.3
Collecting numpy==1.16.3
  Downloading numpy-1.16.3-cp37-cp37m-manylinux1_x86_64.whl (17.3 MB)
Installing collected packages: numpy
  Attempting uninstall: numpy
    Found existing installation: numpy 1.18.5
    Uninstalling numpy-1.18.5:
      Successfully uninstalled numpy-1.18.5
Successfully installed numpy-1.16.3
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
scikit-image 0.18.3 requires numpy>=1.16.5, but you have numpy 1.16.3 which is incompatible.
pywavelets 1.2.0 requires numpy>=1.17.3, but you have numpy 1.16.3 which is incompatible.
numba 0.55.0 requires numpy<1.22,>=1.18, but you have numpy 1.16.3 which is incompatible.
matplotlib 3.5.1 requires numpy>=1.17, but you have numpy 1.16.3 which is incompatible.
```

so it seems like we install the numpy when we build pytorch, which is unnecessary since it is already 1.18(and it failed). It seems like we need to install numpy before running the test instead.