### PR TITLE
Revert "Pull latest changes for TensorFlow"

### DIFF
--- a/test/cpp/metrics_snapshot.cpp
+++ b/test/cpp/metrics_snapshot.cpp
@@ -31,7 +31,7 @@ std::vector<MetricsSnapshot::ChangedCounter> MetricsSnapshot::CounterChanged(
     std::smatch match;
     if ((ignore_set == nullptr || ignore_set->count(name_counter.first) == 0) &&
         std::regex_match(name_counter.first, match, cregex)) {
-      int64_t start_value =
+      xla::int64_t start_value =
           xla::util::FindOr(counters_map_, name_counter.first, 0);
       if (name_counter.second != start_value) {
         changed.push_back(
@@ -48,7 +48,7 @@ std::string MetricsSnapshot::DumpDifferences(
   std::stringstream ss;
   for (auto& name_counter : after.counters_map_) {
     if (ignore_set == nullptr || ignore_set->count(name_counter.first) == 0) {
-      int64_t start_value =
+      xla::int64_t start_value =
           xla::util::FindOr(counters_map_, name_counter.first, 0);
       if (name_counter.second != start_value) {
         ss << "Counter '" << name_counter.first << "' changed from "

--- a/test/cpp/metrics_snapshot.h
+++ b/test/cpp/metrics_snapshot.h
@@ -16,8 +16,8 @@ class MetricsSnapshot {
  public:
   struct ChangedCounter {
     std::string name;
-    int64_t before = 0;
-    int64_t after = 0;
+    xla::int64_t before = 0;
+    xla::int64_t after = 0;
   };
 
   MetricsSnapshot();
@@ -43,7 +43,7 @@ class MetricsSnapshot {
                                    std::stringstream* ss);
 
   std::unordered_map<std::string, MetricSamples> metrics_map_;
-  std::unordered_map<std::string, int64_t> counters_map_;
+  std::unordered_map<std::string, xla::int64_t> counters_map_;
 };
 
 }  // namespace cpp_test

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -4187,8 +4187,8 @@ TEST_F(AtenXlaTensorTest, TestRandperm) {
   torch::Tensor shuffle = torch::randperm(
       n, torch::TensorOptions(torch::kLong).device(torch::kXLA));
   torch::Tensor shuffle_cpu = CopyToDevice(shuffle, torch::kCPU);
-  std::vector<int64_t> shuffle_data(shuffle_cpu.data_ptr<int64_t>(),
-                                    shuffle_cpu.data_ptr<int64_t>() + n);
+  std::vector<xla::int64_t> shuffle_data(shuffle_cpu.data_ptr<int64_t>(),
+                                         shuffle_cpu.data_ptr<int64_t>() + n);
   EXPECT_TRUE(shuffle_data.size() == n && xla::IsPermutation(shuffle_data));
   ExpectCounterNotChanged("aten::(?!randperm.generator_out).*",
                           cpp_test::GetIgnoredCounters());
@@ -6602,8 +6602,8 @@ TEST_F(AtenXlaTensorTest, TestUnsafeView) {
 TEST_F(AtenXlaTensorTest, TestNarrow) {
   torch::Tensor a =
       torch::rand({8, 10, 4, 4}, torch::TensorOptions(torch::kFloat));
-  for (int64_t dim : {1, -3}) {
-    for (int64_t start : {2, -8}) {
+  for (xla::int64_t dim : {1, -3}) {
+    for (xla::int64_t start : {2, -8}) {
       torch::Tensor b = a.narrow(dim, start, 6);
       ForEachDevice([&](const torch::Device& device) {
         torch::Tensor xla_a = CopyToDevice(a, device);
@@ -6618,8 +6618,8 @@ TEST_F(AtenXlaTensorTest, TestNarrow) {
 }
 
 TEST_F(AtenXlaTensorTest, TestNarrowUpdate) {
-  for (int64_t dim : {1, -2}) {
-    for (int64_t start : {2, -6}) {
+  for (xla::int64_t dim : {1, -2}) {
+    for (xla::int64_t start : {2, -6}) {
       torch::Tensor a =
           torch::rand({3, 8, 3}, torch::TensorOptions(torch::kFloat));
       torch::Tensor a_copy = a.clone();
@@ -6642,8 +6642,8 @@ TEST_F(AtenXlaTensorTest, TestNarrowUpdate) {
 }
 
 TEST_F(AtenXlaTensorTest, TestNarrowUpdateBaseCheck) {
-  for (int64_t dim : {0, -2}) {
-    for (int64_t start : {2, -6}) {
+  for (xla::int64_t dim : {0, -2}) {
+    for (xla::int64_t start : {2, -6}) {
       torch::Tensor a =
           torch::zeros({8, 3}, torch::TensorOptions(torch::kFloat));
       torch::Tensor a_copy = a.clone();
@@ -6666,9 +6666,9 @@ TEST_F(AtenXlaTensorTest, TestNarrowUpdateBaseCheck) {
 }
 
 TEST_F(AtenXlaTensorTest, TestNarrowUpdateTwoSlices) {
-  for (int64_t dim : {0, -2}) {
-    for (int64_t start0 : {2, -6}) {
-      for (int64_t start1 : {6, -2}) {
+  for (xla::int64_t dim : {0, -2}) {
+    for (xla::int64_t start0 : {2, -6}) {
+      for (xla::int64_t start1 : {6, -2}) {
         torch::Tensor a =
             torch::zeros({8, 3}, torch::TensorOptions(torch::kFloat));
         torch::Tensor a_copy = a.clone();
@@ -6700,8 +6700,8 @@ TEST_F(AtenXlaTensorTest, TestNarrowUpdateTwoSlices) {
 }
 
 TEST_F(AtenXlaTensorTest, TestNarrowUpdateView) {
-  for (int64_t dim : {0, -3}) {
-    for (int64_t start : {2, -6}) {
+  for (xla::int64_t dim : {0, -3}) {
+    for (xla::int64_t start : {2, -6}) {
       torch::Tensor a =
           torch::rand({8, 2, 3}, torch::TensorOptions(torch::kFloat));
       torch::Tensor a_copy = a.clone();
@@ -6726,9 +6726,9 @@ TEST_F(AtenXlaTensorTest, TestNarrowUpdateView) {
 }
 
 TEST_F(AtenXlaTensorTest, TestNarrowInNarrowUpdate) {
-  for (int64_t dim : {1, -2}) {
-    for (int64_t start0 : {1, -7}) {
-      for (int64_t start1 : {1, -5}) {
+  for (xla::int64_t dim : {1, -2}) {
+    for (xla::int64_t start0 : {1, -7}) {
+      for (xla::int64_t start1 : {1, -5}) {
         torch::Tensor a =
             torch::rand({3, 8, 3}, torch::TensorOptions(torch::kFloat));
         torch::Tensor a_copy = a.clone();
@@ -6754,8 +6754,8 @@ TEST_F(AtenXlaTensorTest, TestNarrowInNarrowUpdate) {
 }
 
 TEST_F(AtenXlaTensorTest, TestNarrowCopy) {
-  for (int64_t dim : {1, -3}) {
-    for (int64_t start : {2, -8}) {
+  for (xla::int64_t dim : {1, -3}) {
+    for (xla::int64_t start : {2, -8}) {
       ForEachDevice([&](const torch::Device& device) {
         torch::Tensor input =
             torch::rand({8, 10, 4, 4}, torch::TensorOptions(torch::kFloat));

--- a/test/cpp/test_replication.cpp
+++ b/test/cpp/test_replication.cpp
@@ -31,8 +31,8 @@ void TestSingleReplication(const std::vector<Device>& devices,
                            const std::vector<Device>& all_devices) {
   // Simulates N threads executing the same computation, using separated XRT
   // executions, and issuing CRS operations.
-  std::vector<std::string> device_strings;
-  std::vector<std::string> all_device_strings;
+  std::vector<xla::string> device_strings;
+  std::vector<xla::string> all_device_strings;
   for (auto& device : devices) {
     device_strings.push_back(device.ToString());
   }

--- a/tf_patches/multi_load_libtpu.diff
+++ b/tf_patches/multi_load_libtpu.diff
@@ -1,0 +1,49 @@
+diff --git a/tensorflow/core/tpu/tpu_initializer_helper.cc b/tensorflow/core/tpu/tpu_initializer_helper.cc
+index 050d04e35d0..f44c1baa371 100644
+--- a/tensorflow/core/tpu/tpu_initializer_helper.cc
++++ b/tensorflow/core/tpu/tpu_initializer_helper.cc
+@@ -33,6 +33,22 @@ static std::string GetEnvVar(const char* name) {
+   return absl::StrCat(getenv(name));
+ }
+ 
++bool GetEnvBool(const char* name, bool defval) {
++  const char* env = getenv(name);
++  if (env == nullptr) {
++    return defval;
++  }
++  if (std::strcmp(env, "true") == 0) {
++    return true;
++  }
++  if (std::strcmp(env, "false") == 0) {
++    return false;
++  }
++  int int_env;
++  bool has_int = absl::SimpleAtoi(env, &int_env);
++  return has_int && int_env != 0;
++}
++
+ }  // namespace
+ 
+ bool TryAcquireTpuLock() {
+@@ -59,7 +75,10 @@ bool TryAcquireTpuLock() {
+     // TODO(skyewm): we could make per-chip lock files and look at
+     // TPU_VISIBLE_DEVICES if we wanted to make this really precise.
+     std::string chips_per_host_bounds = GetEnvVar("TPU_CHIPS_PER_HOST_BOUNDS");
+-    if (chips_per_host_bounds.empty() || chips_per_host_bounds == "2,2,1") {
++    bool allow_multiple_libtpu_load =
++        GetEnvBool("ALLOW_MULTIPLE_LIBTPU_LOAD", false);
++    if ((chips_per_host_bounds.empty() || chips_per_host_bounds == "2,2,1") &&
++        !allow_multiple_libtpu_load) {
+       int fd = open("/tmp/libtpu_lockfile", O_CREAT | O_RDWR, 0644);
+ 
+       // This lock is held until the process exits intentionally. The underlying
+@@ -72,7 +91,8 @@ bool TryAcquireTpuLock() {
+         should_load_library = true;
+       }
+     } else {
+-      VLOG(1) << "TPU_HOST_BOUNDS or TPU_VISIBLE_DEVICES is not empty, "
++      VLOG(1) << "TPU_CHIPS_PER_HOST_BOUNDS is not empty or "
++                 "ALLOW_MULTIPLE_LIBTPU_LOAD is set to True, "
+                  "therefore allowing multiple libtpu.so loads.";
+       should_load_library = true;
+     }

--- a/third_party/xla_client/computation_client.cc
+++ b/third_party/xla_client/computation_client.cc
@@ -305,7 +305,7 @@ std::vector<std::string> ComputationClient::GetCompilationDevices(
   return compilation_devices;
 }
 
-void ComputationClient::RunLocalService(uint64_t service_port) {
+void ComputationClient::RunLocalService(xla::uint64 service_port) {
   try {
     XrtLocalService* service = new XrtLocalService(
         "localservice|localhost:" + std::to_string(service_port),

--- a/third_party/xla_client/computation_client.h
+++ b/third_party/xla_client/computation_client.h
@@ -271,7 +271,7 @@ class ComputationClient {
 
   // Run the XRT local service, this will block the caller unitl the server
   // being stopped.
-  static void RunLocalService(uint64_t service_port);
+  static void RunLocalService(xla::uint64 service_port);
 
   // Retrieves the ordinal number out of a device string. This is the number
   // after the last ':' character of the device string.

--- a/third_party/xla_client/metrics.h
+++ b/third_party/xla_client/metrics.h
@@ -64,12 +64,12 @@ class CounterData {
  public:
   CounterData() : value_(0) {}
 
-  void AddValue(int64_t value) { value_ += value; }
+  void AddValue(xla::int64_t value) { value_ += value; }
 
-  int64_t Value() const { return value_; }
+  xla::int64_t Value() const { return value_; }
 
  private:
-  std::atomic<int64_t> value_;
+  std::atomic<xla::int64_t> value_;
 };
 
 class MetricsArena {
@@ -157,9 +157,9 @@ class Counter {
  public:
   explicit Counter(std::string name);
 
-  void AddValue(int64_t value) { GetData()->AddValue(value); }
+  void AddValue(xla::int64_t value) { GetData()->AddValue(value); }
 
-  int64_t Value() const { return GetData()->Value(); }
+  xla::int64_t Value() const { return GetData()->Value(); }
 
  private:
   CounterData* GetData() const;

--- a/third_party/xla_client/metrics_analysis.cc
+++ b/third_party/xla_client/metrics_analysis.cc
@@ -32,7 +32,7 @@ class MetricFrequency : public Analyzer {
       return {Analysis::Symptom::kNormal};
     }
     size_t metric_count = metric->TotalSamples();
-    int64_t step_count = step->Value();
+    xla::int64_t step_count = step->Value();
     if (step_count <= warmup_steps_) {
       return {Analysis::Symptom::kNormal};
     }
@@ -107,7 +107,7 @@ class XrtMetricFrequency : public Analyzer {
     }
 
     std::stringstream ss;
-    int64_t step_count = step->Value();
+    xla::int64_t step_count = step->Value();
     auto xrt_metrics = ComputationClient::Get()->GetMetrics();
     for (auto const& kv : metric_name_thresholds_) {
       auto it = xrt_metrics.find(kv.first);

--- a/third_party/xla_client/metrics_reader.cc
+++ b/third_party/xla_client/metrics_reader.cc
@@ -44,7 +44,7 @@ std::string CreateXrtMetricReport() {
       ss << "  StdDev: " << minfo.repr_fn(percentile.stddev * minfo.scale)
          << std::endl;
 
-      uint64_t delta_time = percentile.end_nstime - percentile.start_nstime;
+      uint64 delta_time = percentile.end_nstime - percentile.start_nstime;
       if (delta_time > 0) {
         double count_sec = 1e6 * (static_cast<double>(percentile.num_samples) /
                                   (delta_time / 1000.0));

--- a/third_party/xla_client/record_reader.cc
+++ b/third_party/xla_client/record_reader.cc
@@ -8,7 +8,7 @@
 namespace xla {
 namespace util {
 
-RecordReader::RecordReader(std::string path, const std::string& compression,
+RecordReader::RecordReader(std::string path, const string& compression,
                            int64_t buffer_size)
     : path_(std::move(path)) {
   tensorflow::Env* env = tensorflow::Env::Default();

--- a/third_party/xla_client/record_reader.h
+++ b/third_party/xla_client/record_reader.h
@@ -25,7 +25,7 @@ class RecordReader {
  private:
   std::string path_;
   std::mutex lock_;
-  uint64_t offset_ = 0;
+  uint64 offset_ = 0;
   std::unique_ptr<tensorflow::RandomAccessFile> file_;
   std::unique_ptr<tensorflow::io::RecordReader> reader_;
 };

--- a/third_party/xla_client/types.h
+++ b/third_party/xla_client/types.h
@@ -24,8 +24,8 @@ struct Percentile {
   };
 
   UnitOfMeaure unit_of_measure = UnitOfMeaure::kNumber;
-  uint64_t start_nstime = 0;
-  uint64_t end_nstime = 0;
+  uint64 start_nstime = 0;
+  uint64 end_nstime = 0;
   double min_value = NAN;
   double max_value = NAN;
   double mean = NAN;

--- a/third_party/xla_client/util.cc
+++ b/third_party/xla_client/util.cc
@@ -6,7 +6,7 @@ namespace xla {
 namespace util {
 namespace {
 
-hash_t LoadHash(const uint8_t** data, const uint8_t* top) {
+hash_t LoadHash(const uint8** data, const uint8* top) {
   std::ptrdiff_t size = top - (*data);
   if (size >= sizeof(hash_t)) {
     hash_t v;
@@ -17,7 +17,7 @@ hash_t LoadHash(const uint8_t** data, const uint8_t* top) {
 
   union {
     hash_t h;
-    uint8_t b[sizeof(hash_t)];
+    uint8 b[sizeof(hash_t)];
   } uval;
   uval.h = 0;
   std::memcpy(uval.b, *data, size);
@@ -31,8 +31,8 @@ hash_t HashBlock(const void* data, size_t n, const hash_t& seed) {
   const hash_t m = 0xc6a4a7935bd1e995;
   const int r = 47;
 
-  const uint8_t* u8_data = reinterpret_cast<const uint8_t*>(data);
-  const uint8_t* top = u8_data + n;
+  const uint8* u8_data = reinterpret_cast<const uint8*>(data);
+  const uint8* top = u8_data + n;
   hash_t h = seed ^ (n * m);
   while (u8_data < top) {
     hash_t k = LoadHash(&u8_data, top);

--- a/third_party/xla_client/xrt_computation_client.cc
+++ b/third_party/xla_client/xrt_computation_client.cc
@@ -68,14 +68,14 @@ class TensorAllocator : public tensorflow::Allocator {
     return allocator;
   }
 
-  std::string Name() override { return "XLA_TensorAllocator"; }
+  string Name() override { return "XLA_TensorAllocator"; }
 
   void* AllocateRaw(size_t alignment, size_t num_bytes) override {
     // We use an alignment-sized area before the memory returned to the caller,
     // to store a pointer to its AllocBlocks.
     alignment = std::max<size_t>(alignment, sizeof(void*));
     // To call aligned_alloc(), num_bytes must be multiple of alignment.
-    num_bytes = tensorflow::MathUtil::CeilOfRatio(num_bytes, alignment) * alignment;
+    num_bytes = RoundUpToNearest(num_bytes, alignment);
 
     AllocKey alloc_key = {alignment, num_bytes};
     void* block = nullptr;
@@ -298,7 +298,7 @@ ComputationClient::DataPtr XrtComputationClient::CreateDataPlaceholder(
 std::vector<size_t> XrtComputationClient::PartitionTransferToServer(
     absl::Span<const TensorSource> tensors) {
   int64_t max_partition_size = GetMaxTensorsPartitionSize();
-  uint64_t current_size = 0;
+  uint64 current_size = 0;
   std::vector<size_t> partitions;
   for (size_t i = 0; i < tensors.size(); ++i) {
     int64_t tensor_size = ShapeUtil::ByteSizeOfElements(tensors[i].shape);
@@ -1375,7 +1375,7 @@ void XrtComputationClient::InitializeDevices(
 
 void XrtComputationClient::SetupGpuRuntime() {
   struct NcclUniqueIdFactory : public tensorflow::NcclUniqueIdFactory {
-    std::string GetUniqueId(absl::Span<const int64_t> replicas) override {
+    std::string GetUniqueId(absl::Span<const xla::int64_t> replicas) override {
       return service::MeshClient::Get()->GetNcclUniqueUid(replicas);
     }
   };

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -129,8 +129,8 @@ std::pair<XLATensor, XLATensor> GetBinaryOperands(const at::Tensor& self,
 }
 
 // The input is in format of {N, C, H, W} and the output will be {H, W}.
-std::vector<int64_t> GetOutputSizeWithScale(
-    absl::Span<const int64_t> input_size,
+std::vector<xla::int64_t> GetOutputSizeWithScale(
+    absl::Span<const xla::int64_t> input_size,
     const c10::optional<at::ArrayRef<double>>& scale_factors,
     const c10::optional<at::IntArrayRef>& output_size) {
   if (!output_size) {
@@ -138,12 +138,12 @@ std::vector<int64_t> GetOutputSizeWithScale(
     XLA_CHECK_EQ(scale_factors->size(), 2);
     // Calculate the output size from input_shape and scale_factors
     XLA_CHECK_EQ(input_size.size(), 4);
-    int64_t output_h = input_size[2] * (*scale_factors)[0];
-    int64_t output_w = input_size[3] * (*scale_factors)[1];
+    xla::int64_t output_h = input_size[2] * (*scale_factors)[0];
+    xla::int64_t output_w = input_size[3] * (*scale_factors)[1];
     return {output_h, output_w};
   }
   XLA_CHECK(!scale_factors);
-  return xla::util::ToVector<int64_t>(*output_size);
+  return xla::util::ToVector<xla::int64_t>(*output_size);
 }
 
 void CheckBinaryOpTypePromotion(const at::Tensor& out, const at::Tensor& self,
@@ -293,9 +293,9 @@ at::Tensor XLANativeFunctions::_adaptive_avg_pool3d_backward(
     const at::Tensor& grad_output, const at::Tensor& self) {
   XLA_FN_COUNTER("xla::");
   int64_t rank = grad_output.dim();
-  std::vector<int64_t> output_size{grad_output.size(rank - 3),
-                                   grad_output.size(rank - 2),
-                                   grad_output.size(rank - 1)};
+  std::vector<xla::int64_t> output_size{grad_output.size(rank - 3),
+                                        grad_output.size(rank - 2),
+                                        grad_output.size(rank - 1)};
   if (!IsSupportedAdaptivePool(XlaHelpers::I64List(self.sizes()), output_size,
                                /*pool_dim=*/3)) {
     return at::native::call_fallback_fn<
@@ -324,8 +324,8 @@ at::Tensor XLANativeFunctions::_adaptive_avg_pool2d_backward(
     const at::Tensor& grad_output, const at::Tensor& self) {
   XLA_FN_COUNTER("xla::");
   int64_t rank = grad_output.dim();
-  std::vector<int64_t> output_size{grad_output.size(rank - 2),
-                                   grad_output.size(rank - 1)};
+  std::vector<xla::int64_t> output_size{grad_output.size(rank - 2),
+                                        grad_output.size(rank - 1)};
   if (!IsSupportedAdaptivePool(XlaHelpers::I64List(self.sizes()), output_size,
                                /*pool_dim=*/2)) {
     return at::native::call_fallback_fn<
@@ -357,8 +357,8 @@ at::Tensor XLANativeFunctions::adaptive_max_pool2d_backward(
     const at::Tensor& indices) {
   XLA_FN_COUNTER("xla::");
   int64_t rank = grad_output.dim();
-  std::vector<int64_t> output_size{grad_output.size(rank - 2),
-                                   grad_output.size(rank - 1)};
+  std::vector<xla::int64_t> output_size{grad_output.size(rank - 2),
+                                        grad_output.size(rank - 1)};
   if (!IsSupportedAdaptivePool(XlaHelpers::I64List(self.sizes()), output_size,
                                /*pool_dim=*/2)) {
     return at::native::call_fallback_fn<
@@ -622,7 +622,8 @@ at::Tensor XLANativeFunctions::all(const at::Tensor& self) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(XLATensor::all(
-      self_tensor, xla::util::Iota<int64_t>(self_tensor.shape().get().rank()),
+      self_tensor,
+      xla::util::Iota<xla::int64_t>(self_tensor.shape().get().rank()),
       /*keep_reduced_dimensions=*/false));
 }
 
@@ -653,7 +654,8 @@ at::Tensor XLANativeFunctions::any(const at::Tensor& self) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(XLATensor::any(
-      self_tensor, xla::util::Iota<int64_t>(self_tensor.shape().get().rank()),
+      self_tensor,
+      xla::util::Iota<xla::int64_t>(self_tensor.shape().get().rank()),
       /*keep_reduced_dimensions=*/false));
 }
 
@@ -1390,7 +1392,7 @@ at::Tensor XLANativeFunctions::expand(const at::Tensor& self,
                                       at::IntArrayRef size, bool implicit) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::expand(
-      bridge::GetXlaTensor(self), xla::util::ToVector<int64_t>(size)));
+      bridge::GetXlaTensor(self), xla::util::ToVector<xla::int64_t>(size)));
 }
 
 at::Tensor XLANativeFunctions::expm1(const at::Tensor& self) {
@@ -1831,7 +1833,7 @@ at::Tensor XLANativeFunctions::logsumexp(const at::Tensor& self,
                                          at::IntArrayRef dim, bool keepdim) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::logsumexp(
-      bridge::GetXlaTensor(self), xla::util::ToVector<int64_t>(dim),
+      bridge::GetXlaTensor(self), xla::util::ToVector<xla::int64_t>(dim),
       /*keep_reduced_dimensions=*/keepdim));
 }
 
@@ -2048,7 +2050,7 @@ at::Tensor XLANativeFunctions::max_unpool2d(const at::Tensor& self,
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::max_unpool(
       bridge::GetXlaTensor(self), bridge::GetXlaTensor(indices),
-      xla::util::ToVector<int64_t>(output_size)));
+      xla::util::ToVector<xla::int64_t>(output_size)));
 }
 
 at::Tensor XLANativeFunctions::max_unpool2d_backward(
@@ -2058,7 +2060,7 @@ at::Tensor XLANativeFunctions::max_unpool2d_backward(
   return bridge::AtenFromXlaTensor(XLATensor::max_unpool_backward(
       bridge::GetXlaTensor(grad_output), bridge::GetXlaTensor(self),
       bridge::GetXlaTensor(indices),
-      xla::util::ToVector<int64_t>(output_size)));
+      xla::util::ToVector<xla::int64_t>(output_size)));
 }
 
 at::Tensor XLANativeFunctions::max_unpool3d(const at::Tensor& self,
@@ -2069,7 +2071,7 @@ at::Tensor XLANativeFunctions::max_unpool3d(const at::Tensor& self,
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::max_unpool(
       bridge::GetXlaTensor(self), bridge::GetXlaTensor(indices),
-      xla::util::ToVector<int64_t>(output_size)));
+      xla::util::ToVector<xla::int64_t>(output_size)));
 }
 
 at::Tensor XLANativeFunctions::max_unpool3d_backward(
@@ -2080,7 +2082,7 @@ at::Tensor XLANativeFunctions::max_unpool3d_backward(
   return bridge::AtenFromXlaTensor(XLATensor::max_unpool_backward(
       bridge::GetXlaTensor(grad_output), bridge::GetXlaTensor(self),
       bridge::GetXlaTensor(indices),
-      xla::util::ToVector<int64_t>(output_size)));
+      xla::util::ToVector<xla::int64_t>(output_size)));
 }
 
 at::Tensor XLANativeFunctions::mean(const at::Tensor& self,
@@ -2088,7 +2090,8 @@ at::Tensor XLANativeFunctions::mean(const at::Tensor& self,
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(XLATensor::mean(
-      self_tensor, xla::util::Iota<int64_t>(self_tensor.shape().get().rank()),
+      self_tensor,
+      xla::util::Iota<xla::int64_t>(self_tensor.shape().get().rank()),
       /*keep_reduced_dimensions=*/false, dtype));
 }
 
@@ -2097,7 +2100,7 @@ at::Tensor XLANativeFunctions::mean(const at::Tensor& self, at::IntArrayRef dim,
                                     c10::optional<at::ScalarType> dtype) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::mean(
-      bridge::GetXlaTensor(self), xla::util::ToVector<int64_t>(dim),
+      bridge::GetXlaTensor(self), xla::util::ToVector<xla::int64_t>(dim),
       /*keep_reduced_dimensions=*/keepdim, dtype));
 }
 
@@ -2587,7 +2590,8 @@ at::Tensor XLANativeFunctions::prod(const at::Tensor& self,
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(XLATensor::prod(
-      self_tensor, xla::util::Iota<int64_t>(self_tensor.shape().get().rank()),
+      self_tensor,
+      xla::util::Iota<xla::int64_t>(self_tensor.shape().get().rank()),
       /*keep_reduced_dimensions=*/false,
       PromoteIntegralType(self.scalar_type(), dtype)));
 }
@@ -2682,7 +2686,7 @@ at::Tensor XLANativeFunctions::reflection_pad2d(const at::Tensor& self,
                                                 at::IntArrayRef padding) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::reflection_pad2d(
-      bridge::GetXlaTensor(self), xla::util::ToVector<int64_t>(padding)));
+      bridge::GetXlaTensor(self), xla::util::ToVector<xla::int64_t>(padding)));
 }
 
 at::Tensor XLANativeFunctions::reflection_pad2d_backward(
@@ -2691,7 +2695,7 @@ at::Tensor XLANativeFunctions::reflection_pad2d_backward(
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::reflection_pad2d_backward(
       bridge::GetXlaTensor(grad_output), bridge::GetXlaTensor(self),
-      xla::util::ToVector<int64_t>(padding)));
+      xla::util::ToVector<xla::int64_t>(padding)));
 }
 
 at::Tensor XLANativeFunctions::relu(const at::Tensor& self) {
@@ -3118,16 +3122,18 @@ at::Tensor XLANativeFunctions::std(const at::Tensor& self, bool unbiased) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(XLATensor::std(
-      self_tensor, xla::util::Iota<int64_t>(self_tensor.shape().get().rank()),
+      self_tensor,
+      xla::util::Iota<xla::int64_t>(self_tensor.shape().get().rank()),
       /*keep_reduced_dimensions=*/false, /*correction=*/unbiased ? 1 : 0));
 }
 
 at::Tensor XLANativeFunctions::std(const at::Tensor& self, at::IntArrayRef dim,
                                    bool unbiased, bool keepdim) {
   XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(XLATensor::std(
-      bridge::GetXlaTensor(self), xla::util::ToVector<int64_t>(dim), keepdim,
-      /*correction=*/unbiased ? 1 : 0));
+  return bridge::AtenFromXlaTensor(
+      XLATensor::std(bridge::GetXlaTensor(self),
+                     xla::util::ToVector<xla::int64_t>(dim), keepdim,
+                     /*correction=*/unbiased ? 1 : 0));
 }
 
 at::Tensor XLANativeFunctions::std(const at::Tensor& self,
@@ -3138,8 +3144,8 @@ at::Tensor XLANativeFunctions::std(const at::Tensor& self,
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(XLATensor::std(
       self_tensor,
-      dim ? xla::util::ToVector<int64_t>(*dim)
-          : xla::util::Iota<int64_t>(self_tensor.shape().get().rank()),
+      dim ? xla::util::ToVector<xla::int64_t>(*dim)
+          : xla::util::Iota<xla::int64_t>(self_tensor.shape().get().rank()),
       keepdim, correction ? *correction : 1));
 }
 
@@ -3150,8 +3156,8 @@ std::tuple<at::Tensor, at::Tensor> XLANativeFunctions::std_mean(
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   auto results = XLATensor::std_mean(
       self_tensor,
-      dim ? xla::util::ToVector<int64_t>(*dim)
-          : xla::util::Iota<int64_t>(self_tensor.shape().get().rank()),
+      dim ? xla::util::ToVector<xla::int64_t>(*dim)
+          : xla::util::Iota<xla::int64_t>(self_tensor.shape().get().rank()),
       correction ? *correction : 1, keepdim);
   return std::make_tuple(bridge::AtenFromXlaTensor(std::get<0>(results)),
                          bridge::AtenFromXlaTensor(std::get<1>(results)));
@@ -3187,7 +3193,8 @@ at::Tensor XLANativeFunctions::sum(const at::Tensor& self,
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(XLATensor::sum(
-      self_tensor, xla::util::Iota<int64_t>(self_tensor.shape().get().rank()),
+      self_tensor,
+      xla::util::Iota<xla::int64_t>(self_tensor.shape().get().rank()),
       /*keep_reduced_dimensions=*/false, dtype));
 }
 
@@ -3197,7 +3204,7 @@ at::Tensor XLANativeFunctions::sum(const at::Tensor& self, at::IntArrayRef dim,
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
       XLATensor::sum(bridge::GetXlaTensor(self),
-                     xla::util::ToVector<int64_t>(dim), keepdim, dtype));
+                     xla::util::ToVector<xla::int64_t>(dim), keepdim, dtype));
 }
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor> XLANativeFunctions::svd(
@@ -3398,7 +3405,8 @@ at::Tensor XLANativeFunctions::upsample_bilinear2d(
                                                                scales_w);
   }
   return bridge::AtenFromXlaTensor(XLATensor::upsample_bilinear2d(
-      self_tensor, xla::util::ToVector<int64_t>(output_size), align_corners));
+      self_tensor, xla::util::ToVector<xla::int64_t>(output_size),
+      align_corners));
 }
 
 at::Tensor XLANativeFunctions::upsample_bilinear2d_backward(
@@ -3418,8 +3426,8 @@ at::Tensor XLANativeFunctions::upsample_bilinear2d_backward(
                                                      scales_h, scales_w);
   }
   return bridge::AtenFromXlaTensor(XLATensor::upsample_bilinear2d_backward(
-      grad_output_tensor, xla::util::ToVector<int64_t>(output_size),
-      xla::util::ToVector<int64_t>(input_size), align_corners));
+      grad_output_tensor, xla::util::ToVector<xla::int64_t>(output_size),
+      xla::util::ToVector<xla::int64_t>(input_size), align_corners));
 }
 
 at::Tensor XLANativeFunctions::upsample_nearest2d(
@@ -3435,7 +3443,7 @@ at::Tensor XLANativeFunctions::upsample_nearest2d(
                                                  vec)>::call(input, output_size,
                                                              scale_factors);
   }
-  absl::Span<const int64_t> input_dims =
+  absl::Span<const xla::int64_t> input_dims =
       input_tensor.shape().get().dimensions();
   return bridge::AtenFromXlaTensor(XLATensor::upsample_nearest2d(
       input_tensor,
@@ -3458,7 +3466,8 @@ at::Tensor XLANativeFunctions::upsample_nearest2d_backward(
                                                              input_size,
                                                              scale_factors);
   }
-  std::vector<int64_t> input_dim = xla::util::ToVector<int64_t>(input_size);
+  std::vector<xla::int64_t> input_dim =
+      xla::util::ToVector<xla::int64_t>(input_size);
   return bridge::AtenFromXlaTensor(XLATensor::upsample_nearest2d_backward(
       grad_output_tensor,
       GetOutputSizeWithScale(input_dim, scale_factors, output_size),
@@ -3480,7 +3489,7 @@ at::Tensor XLANativeFunctions::upsample_nearest2d(
                                                               scales_w);
   }
   return bridge::AtenFromXlaTensor(XLATensor::upsample_nearest2d(
-      self_tensor, xla::util::ToVector<int64_t>(output_size)));
+      self_tensor, xla::util::ToVector<xla::int64_t>(output_size)));
 }
 
 at::Tensor XLANativeFunctions::upsample_nearest2d_backward(
@@ -3500,18 +3509,19 @@ at::Tensor XLANativeFunctions::upsample_nearest2d_backward(
                                                     scales_w);
   }
   return bridge::AtenFromXlaTensor(XLATensor::upsample_nearest2d_backward(
-      grad_output_tensor, xla::util::ToVector<int64_t>(output_size),
-      xla::util::ToVector<int64_t>(input_size)));
+      grad_output_tensor, xla::util::ToVector<xla::int64_t>(output_size),
+      xla::util::ToVector<xla::int64_t>(input_size)));
 }
 
 at::Tensor XLANativeFunctions::var(const at::Tensor& self, bool unbiased) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
-  return bridge::AtenFromXlaTensor(XLATensor::var(
-      bridge::GetXlaTensor(self),
-      xla::util::Iota<int64_t>(bridge::GetXlaTensor(self).shape().get().rank()),
-      /*correction=*/unbiased ? 1 : 0,
-      /*keep_reduced_dimensions=*/false));
+  return bridge::AtenFromXlaTensor(
+      XLATensor::var(bridge::GetXlaTensor(self),
+                     xla::util::Iota<xla::int64_t>(
+                         bridge::GetXlaTensor(self).shape().get().rank()),
+                     /*correction=*/unbiased ? 1 : 0,
+                     /*keep_reduced_dimensions=*/false));
 }
 
 at::Tensor XLANativeFunctions::var(const at::Tensor& self, at::IntArrayRef dim,
@@ -3532,7 +3542,7 @@ at::Tensor XLANativeFunctions::var(const at::Tensor& self,
   return bridge::AtenFromXlaTensor(
       XLATensor::var(self_tensor,
                      dim ? XlaHelpers::I64List(*dim)
-                         : xla::util::Iota<int64_t>(
+                         : xla::util::Iota<xla::int64_t>(
                                bridge::GetXlaTensor(self).shape().get().rank()),
                      correction ? *correction : 1, keepdim));
 }
@@ -3544,8 +3554,8 @@ std::tuple<at::Tensor, at::Tensor> XLANativeFunctions::var_mean(
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   auto results = XLATensor::var_mean(
       self_tensor,
-      dim ? xla::util::ToVector<int64_t>(*dim)
-          : xla::util::Iota<int64_t>(self_tensor.shape().get().rank()),
+      dim ? xla::util::ToVector<xla::int64_t>(*dim)
+          : xla::util::Iota<xla::int64_t>(self_tensor.shape().get().rank()),
       correction ? *correction : 1, keepdim);
   return std::make_tuple(bridge::AtenFromXlaTensor(std::get<0>(results)),
                          bridge::AtenFromXlaTensor(std::get<1>(results)));

--- a/torch_xla/csrc/convert_ops.cpp
+++ b/torch_xla/csrc/convert_ops.cpp
@@ -18,14 +18,14 @@ xla::XlaOp ExplicitBooleanConvert(xla::XlaOp op, xla::PrimitiveType from) {
   return xla::Ne(op, zero);
 }
 
-xla::XlaOp CreateRawMask(xla::XlaOp op, xla::PrimitiveType type, int64_t size,
-                         int64_t narrow_size) {
-  uint64_t mask_value =
-      (static_cast<uint64_t>(1) << narrow_size * CHAR_BIT) - 1;
+xla::XlaOp CreateRawMask(xla::XlaOp op, xla::PrimitiveType type,
+                         xla::int64_t size, xla::int64_t narrow_size) {
+  xla::uint64 mask_value =
+      (static_cast<xla::uint64>(1) << narrow_size * CHAR_BIT) - 1;
   xla::XlaOp mask = XlaHelpers::ScalarValue(mask_value, type, op.builder());
   if (xla::primitive_util::IsSignedIntegralType(type)) {
     // Sign extend the truncation mask.
-    xla::XlaOp shift = XlaHelpers::ScalarValue<int32_t>(
+    xla::XlaOp shift = XlaHelpers::ScalarValue<xla::int32>(
         (size - narrow_size) * CHAR_BIT, op.builder());
     mask = (mask << shift) >> shift;
   }
@@ -38,8 +38,9 @@ xla::XlaOp ConvertData(xla::XlaOp op, xla::PrimitiveType type,
       !xla::primitive_util::IsIntegralType(narrow_type)) {
     return op;
   }
-  int64_t size = xla::ShapeUtil::ByteSizeOfPrimitiveType(type);
-  int64_t narrow_size = xla::ShapeUtil::ByteSizeOfPrimitiveType(narrow_type);
+  xla::int64_t size = xla::ShapeUtil::ByteSizeOfPrimitiveType(type);
+  xla::int64_t narrow_size =
+      xla::ShapeUtil::ByteSizeOfPrimitiveType(narrow_type);
   XLA_CHECK_GE(size, narrow_size);
   if (size == narrow_size) {
     return op;

--- a/torch_xla/csrc/convolution.cpp
+++ b/torch_xla/csrc/convolution.cpp
@@ -101,20 +101,20 @@ namespace {
 
 // Input needs to be NCHW format.
 xla::XlaOp PadInputFromOutputSize(xla::XlaOp input,
-                                  absl::Span<const int64_t> stride,
-                                  absl::Span<const int64_t> output_padding,
+                                  absl::Span<const xla::int64_t> stride,
+                                  absl::Span<const xla::int64_t> output_padding,
                                   bool unpad = false) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
-  int64_t num_spatial = input_shape.rank() - 2;
+  xla::int64_t num_spatial = input_shape.rank() - 2;
   // No padding for batch dimension and features dimension.
-  std::vector<int64_t> expected_input_sizes{input_shape.dimensions(0),
-                                            input_shape.dimensions(1)};
-  for (int64_t spatial_dim = 0; spatial_dim < num_spatial; ++spatial_dim) {
-    int64_t input_size = input_shape.dimensions(2 + spatial_dim);
+  std::vector<xla::int64_t> expected_input_sizes{input_shape.dimensions(0),
+                                                 input_shape.dimensions(1)};
+  for (xla::int64_t spatial_dim = 0; spatial_dim < num_spatial; ++spatial_dim) {
+    xla::int64_t input_size = input_shape.dimensions(2 + spatial_dim);
     // Input_size needs to increase by pad_to_input to generate the output
     // that includes output_padding. The formula is derived from the output size
     // calculation in the BuildTransposedConvolution.
-    int64_t pad_to_input =
+    xla::int64_t pad_to_input =
         ((input_size - 1) * stride[spatial_dim] + output_padding[spatial_dim]) /
             stride[spatial_dim] +
         1 - input_size;
@@ -127,9 +127,9 @@ xla::XlaOp PadInputFromOutputSize(xla::XlaOp input,
 // Create a TF convolution metadata structure out of PyTorch convolution
 // attributes.
 tensorflow::ConvOpAttrs MakeConvOpAttrs(
-    absl::Span<const int64_t> spatial_stride,
-    absl::Span<const int64_t> spatial_padding,
-    absl::Span<const int64_t> spatial_dilation, bool depthwise) {
+    absl::Span<const xla::int64_t> spatial_stride,
+    absl::Span<const xla::int64_t> spatial_padding,
+    absl::Span<const xla::int64_t> spatial_dilation, bool depthwise) {
   int num_spatial_dims = spatial_stride.size();
   XLA_CHECK_EQ(spatial_padding.size(), num_spatial_dims);
   XLA_CHECK_EQ(spatial_dilation.size(), num_spatial_dims);
@@ -159,14 +159,15 @@ tensorflow::ConvOpAttrs MakeConvOpAttrs(
 
 // Transpose filter shape to have [channel, batch] as last two dimensions.
 // 4D case: (N, C, H, W) -> (H, W, C, N)
-const std::vector<int64_t>& FilterTransposePermutation(const int64_t k) {
+const std::vector<xla::int64_t>& FilterTransposePermutation(
+    const xla::int64_t k) {
   if (k == 4) {
-    static std::vector<int64_t>* permutation =
-        new std::vector<int64_t>({2, 3, 1, 0});
+    static std::vector<xla::int64_t>* permutation =
+        new std::vector<xla::int64_t>({2, 3, 1, 0});
     return *permutation;
   } else if (k == 5) {
-    static std::vector<int64_t>* permutation =
-        new std::vector<int64_t>({2, 3, 4, 1, 0});
+    static std::vector<xla::int64_t>* permutation =
+        new std::vector<xla::int64_t>({2, 3, 4, 1, 0});
     return *permutation;
   } else {
     XLA_ERROR() << "Invalid rank: " << k;
@@ -176,14 +177,15 @@ const std::vector<int64_t>& FilterTransposePermutation(const int64_t k) {
 // Bias broadcast based on output shape produces:
 // (N, H, W) + (C,) = (N, H, W, C)
 // This permutation does (N, H, W, C) -> (N, C, H, W)
-const std::vector<int64_t>& BiasTransposePermutation(const int64_t k) {
+const std::vector<xla::int64_t>& BiasTransposePermutation(
+    const xla::int64_t k) {
   if (k == 4) {
-    static std::vector<int64_t>* permutation =
-        new std::vector<int64_t>({0, 3, 1, 2});
+    static std::vector<xla::int64_t>* permutation =
+        new std::vector<xla::int64_t>({0, 3, 1, 2});
     return *permutation;
   } else if (k == 5) {
-    static std::vector<int64_t>* permutation =
-        new std::vector<int64_t>({0, 4, 1, 2, 3});
+    static std::vector<xla::int64_t>* permutation =
+        new std::vector<xla::int64_t>({0, 4, 1, 2, 3});
     return *permutation;
   } else {
     XLA_ERROR() << "Invalid rank: " << k;
@@ -191,23 +193,23 @@ const std::vector<int64_t>& BiasTransposePermutation(const int64_t k) {
 }
 
 // Reduce bias from (N, C, H, W) to (C,)
-const std::vector<int64_t>& BiasReduceDimensions(const int64_t k) {
+const std::vector<xla::int64_t>& BiasReduceDimensions(const xla::int64_t k) {
   if (k == 4) {
-    static std::vector<int64_t>* reduce_dim =
-        new std::vector<int64_t>({0, 2, 3});
+    static std::vector<xla::int64_t>* reduce_dim =
+        new std::vector<xla::int64_t>({0, 2, 3});
     return *reduce_dim;
   } else if (k == 5) {
-    static std::vector<int64_t>* reduce_dim =
-        new std::vector<int64_t>({0, 2, 3, 4});
+    static std::vector<xla::int64_t>* reduce_dim =
+        new std::vector<xla::int64_t>({0, 2, 3, 4});
     return *reduce_dim;
   } else {
     XLA_ERROR() << "Invalid rank: " << k;
   }
 }
 
-std::vector<std::pair<int64_t, int64_t>> MakePadding(
-    absl::Span<const int64_t> padding) {
-  std::vector<std::pair<int64_t, int64_t>> dims_padding;
+std::vector<std::pair<xla::int64_t, xla::int64_t>> MakePadding(
+    absl::Span<const xla::int64_t> padding) {
+  std::vector<std::pair<xla::int64_t, xla::int64_t>> dims_padding;
   for (const auto dim_padding : padding) {
     dims_padding.emplace_back(dim_padding, dim_padding);
   }
@@ -215,12 +217,11 @@ std::vector<std::pair<int64_t, int64_t>> MakePadding(
 }
 
 // Computes the input gradient for a convolution.
-xla::XlaOp BuildConvBackwardInput(xla::XlaOp grad_output, xla::XlaOp kernel,
-                                  const xla::Shape& input_shape,
-                                  absl::Span<const int64_t> spatial_stride,
-                                  absl::Span<const int64_t> spatial_padding,
-                                  absl::Span<const int64_t> spatial_dilation,
-                                  int64_t groups) {
+xla::XlaOp BuildConvBackwardInput(
+    xla::XlaOp grad_output, xla::XlaOp kernel, const xla::Shape& input_shape,
+    absl::Span<const xla::int64_t> spatial_stride,
+    absl::Span<const xla::int64_t> spatial_padding,
+    absl::Span<const xla::int64_t> spatial_dilation, xla::int64_t groups) {
   tensorflow::ConvOpAttrs conv_op_attrs =
       MakeConvOpAttrs(spatial_stride, spatial_padding, spatial_dilation, false);
   xla::XlaOp kernel_transposed =
@@ -233,12 +234,11 @@ xla::XlaOp BuildConvBackwardInput(xla::XlaOp grad_output, xla::XlaOp kernel,
 }
 
 // Computes the kernel gradient for a convolution.
-xla::XlaOp BuildConvBackwardWeight(xla::XlaOp grad_output, xla::XlaOp input,
-                                   const xla::Shape& kernel_shape,
-                                   absl::Span<const int64_t> spatial_stride,
-                                   absl::Span<const int64_t> spatial_padding,
-                                   absl::Span<const int64_t> spatial_dilation,
-                                   int64_t groups) {
+xla::XlaOp BuildConvBackwardWeight(
+    xla::XlaOp grad_output, xla::XlaOp input, const xla::Shape& kernel_shape,
+    absl::Span<const xla::int64_t> spatial_stride,
+    absl::Span<const xla::int64_t> spatial_padding,
+    absl::Span<const xla::int64_t> spatial_dilation, xla::int64_t groups) {
   tensorflow::ConvOpAttrs conv_op_attrs =
       MakeConvOpAttrs(spatial_stride, spatial_padding, spatial_dilation, false);
   auto transpose_permutation = FilterTransposePermutation(kernel_shape.rank());
@@ -270,20 +270,20 @@ xla::XlaOp BuildGradBias(xla::XlaOp grad_output) {
       BiasReduceDimensions(grad_output_shape.rank()));
 }
 
-xla::XlaOp BuildTransposedConvolution(xla::XlaOp input, xla::XlaOp kernel,
-                                      absl::Span<const int64_t> stride,
-                                      absl::Span<const int64_t> padding,
-                                      absl::Span<const int64_t> dilation,
-                                      absl::Span<const int64_t> output_padding,
-                                      int64_t groups) {
+xla::XlaOp BuildTransposedConvolution(
+    xla::XlaOp input, xla::XlaOp kernel, absl::Span<const xla::int64_t> stride,
+    absl::Span<const xla::int64_t> padding,
+    absl::Span<const xla::int64_t> dilation,
+    absl::Span<const xla::int64_t> output_padding, xla::int64_t groups) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   const xla::Shape& kernel_shape = XlaHelpers::ShapeOfXlaOp(kernel);
-  int64_t num_spatial = input_shape.rank() - 2;
+  xla::int64_t num_spatial = input_shape.rank() - 2;
   // We only support 2D or 3D convolution.
   XLA_CHECK(num_spatial == 2 || num_spatial == 3) << num_spatial;
   // Fold group into output_size feature dimension
-  int64_t features_size = kernel_shape.dimensions(1) * groups;
-  std::vector<int64_t> output_size{input_shape.dimensions(0), features_size};
+  xla::int64_t features_size = kernel_shape.dimensions(1) * groups;
+  std::vector<xla::int64_t> output_size{input_shape.dimensions(0),
+                                        features_size};
   for (int spatial_dim = 0; spatial_dim < num_spatial; ++spatial_dim) {
     output_size.push_back(
         (input_shape.dimensions(2 + spatial_dim) - 1) * stride[spatial_dim] -
@@ -302,9 +302,10 @@ xla::XlaOp BuildTransposedConvolution(xla::XlaOp input, xla::XlaOp kernel,
 
 ConvGrads BuildTransposedConvolutionBackward(
     xla::XlaOp grad_output, xla::XlaOp input, xla::XlaOp kernel,
-    absl::Span<const int64_t> stride, absl::Span<const int64_t> padding,
-    absl::Span<const int64_t> dilation,
-    absl::Span<const int64_t> output_padding, int64_t groups) {
+    absl::Span<const xla::int64_t> stride,
+    absl::Span<const xla::int64_t> padding,
+    absl::Span<const xla::int64_t> dilation,
+    absl::Span<const xla::int64_t> output_padding, xla::int64_t groups) {
   // grad_output includes output_padding, hence we need to pad the input and
   // unpad the grad_input.
   xla::XlaOp grad_input =
@@ -324,9 +325,10 @@ ConvGrads BuildTransposedConvolutionBackward(
 }  // namespace
 
 xla::XlaOp BuildConvolutionOverrideable(
-    xla::XlaOp input, xla::XlaOp kernel, absl::Span<const int64_t> stride,
-    absl::Span<const int64_t> padding, absl::Span<const int64_t> dilation,
-    bool transposed, absl::Span<const int64_t> output_padding, int64_t groups) {
+    xla::XlaOp input, xla::XlaOp kernel, absl::Span<const xla::int64_t> stride,
+    absl::Span<const xla::int64_t> padding,
+    absl::Span<const xla::int64_t> dilation, bool transposed,
+    absl::Span<const xla::int64_t> output_padding, xla::int64_t groups) {
   if (transposed) {
     return BuildTransposedConvolution(input, kernel, stride, padding, dilation,
                                       output_padding, groups);
@@ -347,9 +349,10 @@ xla::XlaOp BuildConvolutionOverrideable(
 
 xla::XlaOp BuildConvolutionOverrideableBias(
     xla::XlaOp input, xla::XlaOp kernel, xla::XlaOp bias,
-    absl::Span<const int64_t> stride, absl::Span<const int64_t> padding,
-    absl::Span<const int64_t> dilation, bool transposed,
-    absl::Span<const int64_t> output_padding, int64_t groups) {
+    absl::Span<const xla::int64_t> stride,
+    absl::Span<const xla::int64_t> padding,
+    absl::Span<const xla::int64_t> dilation, bool transposed,
+    absl::Span<const xla::int64_t> output_padding, xla::int64_t groups) {
   xla::XlaOp conv =
       BuildConvolutionOverrideable(input, kernel, stride, padding, dilation,
                                    transposed, output_padding, groups);
@@ -365,9 +368,10 @@ xla::XlaOp BuildConvolutionOverrideableBias(
 
 ConvGrads BuildConvolutionBackwardOverrideable(
     xla::XlaOp grad_output, xla::XlaOp input, xla::XlaOp kernel,
-    absl::Span<const int64_t> stride, absl::Span<const int64_t> padding,
-    absl::Span<const int64_t> dilation, bool transposed,
-    absl::Span<const int64_t> output_padding, int64_t groups) {
+    absl::Span<const xla::int64_t> stride,
+    absl::Span<const xla::int64_t> padding,
+    absl::Span<const xla::int64_t> dilation, bool transposed,
+    absl::Span<const xla::int64_t> output_padding, xla::int64_t groups) {
   if (transposed) {
     return BuildTransposedConvolutionBackward(grad_output, input, kernel,
                                               stride, padding, dilation,

--- a/torch_xla/csrc/convolution.h
+++ b/torch_xla/csrc/convolution.h
@@ -8,16 +8,18 @@ namespace torch_xla {
 // Computes the convolution of the given input and kernel with the given
 // precision, with the given stride and padding.
 xla::XlaOp BuildConvolutionOverrideable(
-    xla::XlaOp input, xla::XlaOp kernel, absl::Span<const int64_t> stride,
-    absl::Span<const int64_t> padding, absl::Span<const int64_t> dilation,
-    bool transposed, absl::Span<const int64_t> output_padding, int64_t groups);
+    xla::XlaOp input, xla::XlaOp kernel, absl::Span<const xla::int64_t> stride,
+    absl::Span<const xla::int64_t> padding,
+    absl::Span<const xla::int64_t> dilation, bool transposed,
+    absl::Span<const xla::int64_t> output_padding, xla::int64_t groups);
 
 // Same as above, then broadcasts the bias and adds it to the result.
 xla::XlaOp BuildConvolutionOverrideableBias(
     xla::XlaOp input, xla::XlaOp kernel, xla::XlaOp bias,
-    absl::Span<const int64_t> stride, absl::Span<const int64_t> padding,
-    absl::Span<const int64_t> dilation, bool transposed,
-    absl::Span<const int64_t> output_padding, int64_t groups);
+    absl::Span<const xla::int64_t> stride,
+    absl::Span<const xla::int64_t> padding,
+    absl::Span<const xla::int64_t> dilation, bool transposed,
+    absl::Span<const xla::int64_t> output_padding, xla::int64_t groups);
 
 struct ConvGrads {
   xla::XlaOp grad_input;
@@ -28,8 +30,9 @@ struct ConvGrads {
 // Computes the gradients for a convolution with the given stride and padding.
 ConvGrads BuildConvolutionBackwardOverrideable(
     xla::XlaOp grad_output, xla::XlaOp input, xla::XlaOp kernel,
-    absl::Span<const int64_t> stride, absl::Span<const int64_t> padding,
-    absl::Span<const int64_t> dilation, bool transposed,
-    absl::Span<const int64_t> output_padding, int64_t groups);
+    absl::Span<const xla::int64_t> stride,
+    absl::Span<const xla::int64_t> padding,
+    absl::Span<const xla::int64_t> dilation, bool transposed,
+    absl::Span<const xla::int64_t> output_padding, xla::int64_t groups);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/cross_replica_reduces.cpp
+++ b/torch_xla/csrc/cross_replica_reduces.cpp
@@ -69,7 +69,7 @@ xla::XlaComputation GetReduceComutation(AllReduceType reduce_type,
 }
 
 std::vector<xla::ReplicaGroup> CreateReduceGroups(
-    const std::vector<std::vector<int64_t>>& groups) {
+    const std::vector<std::vector<xla::int64_t>>& groups) {
   std::vector<xla::ReplicaGroup> reduce_groups;
   for (auto& group : groups) {
     xla::ReplicaGroup rgroup;
@@ -86,7 +86,7 @@ std::vector<xla::ReplicaGroup> CreateReduceGroups(
 std::vector<xla::XlaOp> BuildAllReduce(
     AllReduceType reduce_type, absl::Span<const xla::XlaOp> operands,
     xla::XlaOp token, double scale,
-    const std::vector<std::vector<int64_t>>& groups) {
+    const std::vector<std::vector<xla::int64_t>>& groups) {
   std::vector<xla::ReplicaGroup> reduce_groups = CreateReduceGroups(groups);
   // TODO: We use pseudo-tokens ATM, which are real values. This need to be
   // switched to use the real XLA Token once support has been added to XLA
@@ -124,10 +124,10 @@ std::vector<xla::XlaOp> BuildAllReduce(
   return result;
 }
 
-AllToAllResult BuildAllToAll(xla::XlaOp input, xla::XlaOp token,
-                             int64_t split_dimension, int64_t concat_dimension,
-                             int64_t split_count,
-                             const std::vector<std::vector<int64_t>>& groups) {
+AllToAllResult BuildAllToAll(
+    xla::XlaOp input, xla::XlaOp token, xla::int64_t split_dimension,
+    xla::int64_t concat_dimension, xla::int64_t split_count,
+    const std::vector<std::vector<xla::int64_t>>& groups) {
   std::vector<xla::ReplicaGroup> reduce_groups = CreateReduceGroups(groups);
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   xla::Shape reduce_shape = MakeArrayShapeFromDimensions(
@@ -141,8 +141,9 @@ AllToAllResult BuildAllToAll(xla::XlaOp input, xla::XlaOp token,
 }
 
 AllGatherResult BuildAllGather(
-    xla::XlaOp input, xla::XlaOp token, int64_t dim, int64_t shard_count,
-    const std::vector<std::vector<int64_t>>& groups) {
+    xla::XlaOp input, xla::XlaOp token, xla::int64_t dim,
+    xla::int64_t shard_count,
+    const std::vector<std::vector<xla::int64_t>>& groups) {
   std::vector<xla::ReplicaGroup> reduce_groups = CreateReduceGroups(groups);
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   TokenHandler token_handler(token);
@@ -154,7 +155,8 @@ AllGatherResult BuildAllGather(
 
 CollectivePermuteResult BuildCollectivePermute(
     xla::XlaOp input, xla::XlaOp token,
-    const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs) {
+    const std::vector<std::pair<xla::int64_t, xla::int64_t>>&
+        source_target_pairs) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   TokenHandler token_handler(token);
   // TODO: This is missing layout pinning ATM. If XLA scheduling is not exactly
@@ -167,8 +169,8 @@ CollectivePermuteResult BuildCollectivePermute(
 
 ReduceScatterResult BuildReduceScatter(
     AllReduceType reduce_type, xla::XlaOp input, xla::XlaOp token, double scale,
-    int64_t scatter_dim, int64_t shard_count,
-    const std::vector<std::vector<int64_t>>& groups) {
+    xla::int64_t scatter_dim, xla::int64_t shard_count,
+    const std::vector<std::vector<xla::int64_t>>& groups) {
   std::vector<xla::ReplicaGroup> reduce_groups = CreateReduceGroups(groups);
   TokenHandler token_handler(token);
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);

--- a/torch_xla/csrc/cross_replica_reduces.h
+++ b/torch_xla/csrc/cross_replica_reduces.h
@@ -39,24 +39,26 @@ struct ReduceScatterResult {
 std::vector<xla::XlaOp> BuildAllReduce(
     AllReduceType reduce_type, absl::Span<const xla::XlaOp> operands,
     xla::XlaOp token, double scale,
-    const std::vector<std::vector<int64_t>>& groups);
+    const std::vector<std::vector<xla::int64_t>>& groups);
 
-AllToAllResult BuildAllToAll(xla::XlaOp input, xla::XlaOp token,
-                             int64_t split_dimension, int64_t concat_dimension,
-                             int64_t split_count,
-                             const std::vector<std::vector<int64_t>>& groups);
+AllToAllResult BuildAllToAll(
+    xla::XlaOp input, xla::XlaOp token, xla::int64_t split_dimension,
+    xla::int64_t concat_dimension, xla::int64_t split_count,
+    const std::vector<std::vector<xla::int64_t>>& groups);
 
-AllGatherResult BuildAllGather(xla::XlaOp input, xla::XlaOp token, int64_t dim,
-                               int64_t shard_count,
-                               const std::vector<std::vector<int64_t>>& groups);
+AllGatherResult BuildAllGather(
+    xla::XlaOp input, xla::XlaOp token, xla::int64_t dim,
+    xla::int64_t shard_count,
+    const std::vector<std::vector<xla::int64_t>>& groups);
 
 CollectivePermuteResult BuildCollectivePermute(
     xla::XlaOp input, xla::XlaOp token,
-    const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs);
+    const std::vector<std::pair<xla::int64_t, xla::int64_t>>&
+        source_target_pairs);
 
 ReduceScatterResult BuildReduceScatter(
     AllReduceType reduce_type, xla::XlaOp input, xla::XlaOp token, double scale,
-    int64_t scatter_dim, int64_t shard_count,
-    const std::vector<std::vector<int64_t>>& groups);
+    xla::int64_t scatter_dim, xla::int64_t shard_count,
+    const std::vector<std::vector<xla::int64_t>>& groups);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/data_ops.cpp
+++ b/torch_xla/csrc/data_ops.cpp
@@ -21,28 +21,29 @@ namespace torch_xla {
 namespace {
 
 bool IsSparseGather(const xla::Shape& input_shape,
-                    const xla::Shape& index_shape, int64_t dim) {
+                    const xla::Shape& index_shape, xla::int64_t dim) {
   static int dense_gather_factor =
       xla::sys_util::GetEnvInt("XLA_DENSE_GATHER_FACTOR", 100);
-  int64_t input_elements = xla::ShapeUtil::ElementsIn(input_shape);
-  int64_t index_elements = xla::ShapeUtil::ElementsIn(index_shape);
+  xla::int64_t input_elements = xla::ShapeUtil::ElementsIn(input_shape);
+  xla::int64_t index_elements = xla::ShapeUtil::ElementsIn(index_shape);
   // Simple heuristic. Might need fine tuning.
   return index_elements < input_elements / dense_gather_factor;
 }
 
 }  // namespace
 
-bool IsSparseGather(xla::XlaOp input, xla::XlaOp index, int64_t dim) {
+bool IsSparseGather(xla::XlaOp input, xla::XlaOp index, xla::int64_t dim) {
   return IsSparseGather(XlaHelpers::ShapeOfXlaOp(input),
                         XlaHelpers::ShapeOfXlaOp(index), dim);
 }
 
-std::vector<int64_t> GetCompleteShape(absl::Span<const int64_t> output_sizes,
-                                      absl::Span<const int64_t> input_sizes) {
+std::vector<xla::int64_t> GetCompleteShape(
+    absl::Span<const xla::int64_t> output_sizes,
+    absl::Span<const xla::int64_t> input_sizes) {
   c10::optional<size_t> incomplete_dim;
-  int64_t incomplete_element_count = 1;
+  xla::int64_t incomplete_element_count = 1;
   for (size_t dim = 0; dim < output_sizes.size(); ++dim) {
-    int64_t dim_size = output_sizes[dim];
+    xla::int64_t dim_size = output_sizes[dim];
     if (dim_size < 0) {
       XLA_CHECK(!incomplete_dim)
           << "More than one incomplete dimension found: " << *incomplete_dim
@@ -52,13 +53,14 @@ std::vector<int64_t> GetCompleteShape(absl::Span<const int64_t> output_sizes,
       incomplete_element_count *= dim_size;
     }
   }
-  int64_t total_element_count = xla::util::Multiply<int64_t>(input_sizes);
+  xla::int64_t total_element_count =
+      xla::util::Multiply<xla::int64_t>(input_sizes);
   if (!incomplete_dim) {
     XLA_CHECK_EQ(total_element_count,
-                 xla::util::Multiply<int64_t>(output_sizes))
+                 xla::util::Multiply<xla::int64_t>(output_sizes))
         << "(" << absl::StrJoin(output_sizes, ", ") << ") vs. ("
         << absl::StrJoin(input_sizes, ", ") << ")";
-    return xla::util::ToVector<int64_t>(output_sizes);
+    return xla::util::ToVector<xla::int64_t>(output_sizes);
   }
   XLA_CHECK_GT(incomplete_element_count, 0)
       << "Cannot reshape tensor of 0 elements into shape "
@@ -67,21 +69,22 @@ std::vector<int64_t> GetCompleteShape(absl::Span<const int64_t> output_sizes,
   XLA_CHECK_EQ(total_element_count % incomplete_element_count, 0)
       << "(" << absl::StrJoin(output_sizes, ", ") << ") vs. ("
       << absl::StrJoin(input_sizes, ", ") << ")";
-  std::vector<int64_t> complete_output_sizes =
-      xla::util::ToVector<int64_t>(output_sizes);
+  std::vector<xla::int64_t> complete_output_sizes =
+      xla::util::ToVector<xla::int64_t>(output_sizes);
   complete_output_sizes[*incomplete_dim] =
       total_element_count / incomplete_element_count;
   return complete_output_sizes;
 }
 
-xla::XlaOp BuildView(xla::XlaOp input, absl::Span<const int64_t> output_sizes) {
+xla::XlaOp BuildView(xla::XlaOp input,
+                     absl::Span<const xla::int64_t> output_sizes) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   const auto complete_output_sizes =
       GetCompleteShape(output_sizes, input_shape.dimensions());
   return XlaHelpers::DynamicReshape(input, complete_output_sizes);
 }
 
-xla::XlaOp SqueezeTrivialDimension(xla::XlaOp input, int64_t dim) {
+xla::XlaOp SqueezeTrivialDimension(xla::XlaOp input, xla::int64_t dim) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   XLA_CHECK_LT(dim, input_shape.rank());
   if (input_shape.dimensions(dim) != 1) {
@@ -99,22 +102,23 @@ xla::XlaOp SqueezeAllTrivialDimensions(xla::XlaOp input) {
 }
 
 xla::XlaOp BuildExpand(xla::XlaOp input,
-                       absl::Span<const int64_t> output_sizes) {
+                       absl::Span<const xla::int64_t> output_sizes) {
   auto input_sizes = XlaHelpers::SizesOfXlaOp(input);
   // Adjust the rank of the input to match the rank of the output.
   XLA_CHECK_LE(input_sizes.size(), output_sizes.size());
   input_sizes.insert(input_sizes.begin(),
                      output_sizes.size() - input_sizes.size(), 1);
   xla::XlaOp implicit_reshape = XlaHelpers::DynamicReshape(input, input_sizes);
-  return xla::BroadcastInDim(implicit_reshape, output_sizes,
-                             xla::util::Iota<int64_t>(output_sizes.size()));
+  return xla::BroadcastInDim(
+      implicit_reshape, output_sizes,
+      xla::util::Iota<xla::int64_t>(output_sizes.size()));
 }
 
-std::vector<int64_t> BuildSqueezedDimensions(
-    absl::Span<const int64_t> dimensions, int64_t squeeze_dim) {
-  std::vector<int64_t> output_dimensions;
-  for (int64_t i = 0; i < dimensions.size(); ++i) {
-    int64_t dim = dimensions[i];
+std::vector<xla::int64_t> BuildSqueezedDimensions(
+    absl::Span<const xla::int64_t> dimensions, xla::int64_t squeeze_dim) {
+  std::vector<xla::int64_t> output_dimensions;
+  for (xla::int64_t i = 0; i < dimensions.size(); ++i) {
+    xla::int64_t dim = dimensions[i];
     if (dim != 1 || (i != squeeze_dim && squeeze_dim >= 0)) {
       output_dimensions.push_back(dim);
     }
@@ -122,21 +126,21 @@ std::vector<int64_t> BuildSqueezedDimensions(
   return output_dimensions;
 }
 
-std::vector<int64_t> BuildUnsqueezeDimensions(
-    absl::Span<const int64_t> dimensions, int64_t dim) {
+std::vector<xla::int64_t> BuildUnsqueezeDimensions(
+    absl::Span<const xla::int64_t> dimensions, xla::int64_t dim) {
   XLA_CHECK_LE(dim, dimensions.size());
-  auto unsqueeze_dimensions = xla::util::ToVector<int64_t>(dimensions);
+  auto unsqueeze_dimensions = xla::util::ToVector<xla::int64_t>(dimensions);
   unsqueeze_dimensions.insert(unsqueeze_dimensions.begin() + dim, 1);
   return unsqueeze_dimensions;
 }
 
-xla::XlaOp BuildUnsqueeze(xla::XlaOp input, int64_t dim) {
+xla::XlaOp BuildUnsqueeze(xla::XlaOp input, xla::int64_t dim) {
   auto dimensions =
       BuildUnsqueezeDimensions(XlaHelpers::SizesOfXlaOp(input), dim);
   return XlaHelpers::DynamicReshape(input, dimensions);
 }
 
-xla::XlaOp BuildStack(absl::Span<const xla::XlaOp> inputs, int64_t dim) {
+xla::XlaOp BuildStack(absl::Span<const xla::XlaOp> inputs, xla::int64_t dim) {
   // Reshape inputs along the dim axis.
   XLA_CHECK_GT(inputs.size(), 0);
   std::vector<xla::XlaOp> reshaped_inputs;
@@ -149,12 +153,13 @@ xla::XlaOp BuildStack(absl::Span<const xla::XlaOp> inputs, int64_t dim) {
   return xla::ConcatInDim(inputs[0].builder(), reshaped_inputs, dim);
 }
 
-xla::XlaOp BuildCat(absl::Span<const xla::XlaOp> inputs, int64_t dim) {
+xla::XlaOp BuildCat(absl::Span<const xla::XlaOp> inputs, xla::int64_t dim) {
   XLA_CHECK_GT(inputs.size(), 0);
   return xla::ConcatInDim(inputs[0].builder(), inputs, dim);
 }
 
-xla::XlaOp BuildRepeat(xla::XlaOp input, absl::Span<const int64_t> repeats) {
+xla::XlaOp BuildRepeat(xla::XlaOp input,
+                       absl::Span<const xla::int64_t> repeats) {
   const auto input_sizes = XlaHelpers::SizesOfXlaOp(input);
   XLA_CHECK_GE(repeats.size(), input_sizes.size())
       << "Number of dimensions of repeat dims can not be smaller than number "
@@ -167,15 +172,15 @@ xla::XlaOp BuildRepeat(xla::XlaOp input, absl::Span<const int64_t> repeats) {
     repeated = xla::ConcatInDim(input.builder(), repeated_inputs, dim);
   }
   if (repeats.size() > input_sizes.size()) {
-    std::vector<int64_t> remaining_repeats(repeats.begin(),
-                                           repeats.begin() + broadcast_dims);
+    std::vector<xla::int64_t> remaining_repeats(
+        repeats.begin(), repeats.begin() + broadcast_dims);
     repeated = xla::Broadcast(repeated, remaining_repeats);
   }
   return repeated;
 }
 
-size_t ComputeSplitCount(int64_t dim_size,
-                         absl::Span<const int64_t> split_sizes) {
+size_t ComputeSplitCount(xla::int64_t dim_size,
+                         absl::Span<const xla::int64_t> split_sizes) {
   size_t count = 0;
   for (auto size : split_sizes) {
     if (size > dim_size) {
@@ -188,11 +193,11 @@ size_t ComputeSplitCount(int64_t dim_size,
 }
 
 std::vector<xla::XlaOp> BuildSplit(xla::XlaOp input,
-                                   absl::Span<const int64_t> split_sizes,
-                                   int64_t dim) {
+                                   absl::Span<const xla::int64_t> split_sizes,
+                                   xla::int64_t dim) {
   const auto input_sizes = XlaHelpers::SizesOfXlaOp(input);
-  int64_t dim_size = input_sizes.at(dim);
-  int64_t index = 0;
+  xla::int64_t dim_size = input_sizes.at(dim);
+  xla::int64_t index = 0;
   std::vector<xla::XlaOp> splits;
   for (auto size : split_sizes) {
     if (index + size > dim_size) {
@@ -205,7 +210,7 @@ std::vector<xla::XlaOp> BuildSplit(xla::XlaOp input,
 }
 
 xla::XlaOp BuildUpdateSlice(xla::XlaOp input, xla::XlaOp source,
-                            absl::Span<const int64_t> base_indices) {
+                            absl::Span<const xla::int64_t> base_indices) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   const xla::Shape& source_shape = XlaHelpers::ShapeOfXlaOp(source);
   xla::XlaOp update_source = source;
@@ -218,18 +223,20 @@ xla::XlaOp BuildUpdateSlice(xla::XlaOp input, xla::XlaOp source,
   std::vector<xla::XlaOp> start_indices;
   for (auto index : base_indices) {
     start_indices.push_back(
-        XlaHelpers::ScalarValue<int64_t>(index, input.builder()));
+        XlaHelpers::ScalarValue<xla::int64_t>(index, input.builder()));
   }
   return xla::DynamicUpdateSlice(input, reshaped_source, start_indices);
 }
 
-xla::XlaOp BuildSlice(xla::XlaOp input, absl::Span<const int64_t> base_indices,
-                      absl::Span<const int64_t> sizes) {
+xla::XlaOp BuildSlice(xla::XlaOp input,
+                      absl::Span<const xla::int64_t> base_indices,
+                      absl::Span<const xla::int64_t> sizes) {
   XLA_CHECK_EQ(base_indices.size(), sizes.size());
-  std::vector<int64_t> limit_indices(base_indices.begin(), base_indices.end());
+  std::vector<xla::int64_t> limit_indices(base_indices.begin(),
+                                          base_indices.end());
   std::transform(limit_indices.begin(), limit_indices.end(), sizes.begin(),
-                 limit_indices.begin(), std::plus<int64_t>());
-  std::vector<int64_t> strides(base_indices.size(), 1);
+                 limit_indices.begin(), std::plus<xla::int64_t>());
+  std::vector<xla::int64_t> strides(base_indices.size(), 1);
   return xla::Slice(input, base_indices, limit_indices, strides);
 }
 
@@ -256,11 +263,11 @@ xla::XlaOp BuildTake(xla::XlaOp input, xla::XlaOp index) {
   return XlaHelpers::DynamicReshape(r1_result, index_shape.dimensions());
 }
 
-xla::XlaOp BuildResize(xla::XlaOp input, absl::Span<const int64_t> size) {
+xla::XlaOp BuildResize(xla::XlaOp input, absl::Span<const xla::int64_t> size) {
   xla::Shape input_shape;
   xla::XlaOp r1_input = XlaHelpers::Flatten(input, &input_shape);
-  int64_t num_elements = xla::ShapeUtil::ElementsIn(input_shape);
-  int64_t new_num_elements = xla::util::Multiply<int64_t>(size);
+  xla::int64_t num_elements = xla::ShapeUtil::ElementsIn(input_shape);
+  xla::int64_t new_num_elements = xla::util::Multiply<xla::int64_t>(size);
   xla::XlaOp resized_input = input;
   if (num_elements > new_num_elements) {
     resized_input = xla::SliceInDim(r1_input, 0, new_num_elements, 1, 0);
@@ -276,8 +283,9 @@ xla::XlaOp BuildResize(xla::XlaOp input, absl::Span<const int64_t> size) {
   return XlaHelpers::DynamicReshape(resized_input, size);
 }
 
-xla::XlaOp BuildUnselect(xla::XlaOp target, xla::XlaOp source, int64_t dim,
-                         int64_t start, int64_t end, int64_t stride) {
+xla::XlaOp BuildUnselect(xla::XlaOp target, xla::XlaOp source, xla::int64_t dim,
+                         xla::int64_t start, xla::int64_t end,
+                         xla::int64_t stride) {
   const xla::Shape& target_shape = XlaHelpers::ShapeOfXlaOp(target);
   const xla::Shape& source_shape = XlaHelpers::ShapeOfXlaOp(source);
   if (target_shape.dimensions(dim) == source_shape.dimensions(dim)) {
@@ -295,14 +303,14 @@ xla::XlaOp BuildUnselect(xla::XlaOp target, xla::XlaOp source, int64_t dim,
   xla::XlaOp pred_zero = xla::Zero(target.builder(), pred_type);
   xla::XlaOp zero = xla::Zero(target.builder(), target_shape.element_type());
   xla::PaddingConfig padding_config;
-  for (int64_t i = 0; i < target_shape.rank(); ++i) {
+  for (xla::int64_t i = 0; i < target_shape.rank(); ++i) {
     auto* dims = padding_config.add_dimensions();
     if (i == dim) {
       dims->set_edge_padding_low(start);
       dims->set_interior_padding(stride - 1);
 
-      int64_t size = start + source_shape.dimensions(i) +
-                     (source_shape.dimensions(i) - 1) * (stride - 1);
+      xla::int64_t size = start + source_shape.dimensions(i) +
+                          (source_shape.dimensions(i) - 1) * (stride - 1);
       dims->set_edge_padding_high(target_shape.dimensions(i) - size);
     } else {
       XLA_CHECK_EQ(target_shape.dimensions(i), source_shape.dimensions(i))
@@ -318,16 +326,16 @@ xla::XlaOp BuildUnselect(xla::XlaOp target, xla::XlaOp source, int64_t dim,
 }
 
 xla::XlaOp BuildReflectionPad2d(xla::XlaOp input,
-                                absl::Span<const int64_t> padding) {
+                                absl::Span<const xla::int64_t> padding) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   XLA_CHECK_GE(2 * input_shape.rank(), padding.size());
   XLA_CHECK_EQ(padding.size() % 2, 0) << "Uneven padding: " << padding.size();
   xla::XlaOp result = input;
   for (size_t i = 0; i < padding.size(); i += 2) {
-    int64_t dim = input_shape.rank() - 1 - i / 2;
-    int64_t dim_size = input_shape.dimensions(dim);
-    int64_t lhs_padding = padding[i];
-    int64_t rhs_padding = padding[i + 1];
+    xla::int64_t dim = input_shape.rank() - 1 - i / 2;
+    xla::int64_t dim_size = input_shape.dimensions(dim);
+    xla::int64_t lhs_padding = padding[i];
+    xla::int64_t rhs_padding = padding[i + 1];
 
     XLA_CHECK(lhs_padding >= 0 && lhs_padding <= dim_size - 1);
     XLA_CHECK(rhs_padding >= 0 && rhs_padding <= dim_size - 1);
@@ -342,7 +350,7 @@ xla::XlaOp BuildReflectionPad2d(xla::XlaOp input,
 }
 
 xla::XlaOp BuildReflectionPadBackward(xla::XlaOp grad_output, xla::XlaOp input,
-                                      absl::Span<const int64_t> padding) {
+                                      absl::Span<const xla::int64_t> padding) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   const xla::Shape& grad_output_shape = XlaHelpers::ShapeOfXlaOp(grad_output);
   XLA_CHECK_GE(2 * grad_output_shape.rank(), padding.size());
@@ -350,10 +358,10 @@ xla::XlaOp BuildReflectionPadBackward(xla::XlaOp grad_output, xla::XlaOp input,
 
   xla::XlaOp grad = grad_output;
   for (size_t i = 0; i < padding.size(); i += 2) {
-    int64_t dim = grad_output_shape.rank() - 1 - i / 2;
-    int64_t dim_size = grad_output_shape.dimensions(dim);
-    int64_t lhs_padding = padding[i];
-    int64_t rhs_padding = padding[i + 1];
+    xla::int64_t dim = grad_output_shape.rank() - 1 - i / 2;
+    xla::int64_t dim_size = grad_output_shape.dimensions(dim);
+    xla::int64_t lhs_padding = padding[i];
+    xla::int64_t rhs_padding = padding[i + 1];
 
     XLA_CHECK(lhs_padding >= 0 && lhs_padding <= dim_size - 1);
     XLA_CHECK(rhs_padding >= 0 && rhs_padding <= dim_size - 1);
@@ -381,13 +389,13 @@ xla::XlaOp BuildReflectionPadBackward(xla::XlaOp grad_output, xla::XlaOp input,
 }
 
 xla::XlaOp BuildReplicationPad(xla::XlaOp input,
-                               absl::Span<const int64_t> padding) {
+                               absl::Span<const xla::int64_t> padding) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   XLA_CHECK_GE(2 * input_shape.rank(), padding.size());
   XLA_CHECK_EQ(padding.size() % 2, 0) << "Uneven padding: " << padding.size();
   xla::XlaOp result = input;
   for (size_t i = 0; i < padding.size(); i += 2) {
-    int64_t dim = input_shape.rank() - 1 - i / 2;
+    xla::int64_t dim = input_shape.rank() - 1 - i / 2;
     if ((padding[i] != 0 || padding[i + 1] != 0) &&
         input_shape.dimensions(dim) > 0) {
       std::vector<xla::XlaOp> parts;
@@ -411,7 +419,7 @@ xla::XlaOp BuildReplicationPad(xla::XlaOp input,
 }
 
 xla::XlaOp BuildReplicationPadBackward(xla::XlaOp grad_output, xla::XlaOp input,
-                                       absl::Span<const int64_t> padding) {
+                                       absl::Span<const xla::int64_t> padding) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   const xla::Shape& grad_output_shape = XlaHelpers::ShapeOfXlaOp(grad_output);
   XLA_CHECK_GE(2 * grad_output_shape.rank(), padding.size());
@@ -419,10 +427,10 @@ xla::XlaOp BuildReplicationPadBackward(xla::XlaOp grad_output, xla::XlaOp input,
 
   xla::XlaOp grad = grad_output;
   for (size_t i = 0; i < padding.size(); i += 2) {
-    int64_t dim = grad_output_shape.rank() - 1 - i / 2;
-    int64_t dim_size = grad_output_shape.dimensions(dim);
-    int64_t lhs_padding = padding[i];
-    int64_t rhs_padding = padding[i + 1];
+    xla::int64_t dim = grad_output_shape.rank() - 1 - i / 2;
+    xla::int64_t dim_size = grad_output_shape.dimensions(dim);
+    xla::int64_t lhs_padding = padding[i];
+    xla::int64_t rhs_padding = padding[i + 1];
 
     XLA_CHECK(lhs_padding >= 0 && lhs_padding <= dim_size - 1);
     XLA_CHECK(rhs_padding >= 0 && rhs_padding <= dim_size - 1);
@@ -451,8 +459,8 @@ xla::XlaOp BuildReplicationPadBackward(xla::XlaOp grad_output, xla::XlaOp input,
   return grad;
 }
 
-xla::XlaOp PadInDim(xla::XlaOp input, int64_t dim, int64_t pad_lo,
-                    int64_t pad_hi, const xla::XlaOp* pad_value) {
+xla::XlaOp PadInDim(xla::XlaOp input, xla::int64_t dim, xla::int64_t pad_lo,
+                    xla::int64_t pad_hi, const xla::XlaOp* pad_value) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   xla::XlaOp zero;
   if (pad_value == nullptr) {
@@ -460,7 +468,7 @@ xla::XlaOp PadInDim(xla::XlaOp input, int64_t dim, int64_t pad_lo,
     pad_value = &zero;
   }
   xla::PaddingConfig padding_config;
-  for (int64_t i = 0; i < input_shape.rank(); ++i) {
+  for (xla::int64_t i = 0; i < input_shape.rank(); ++i) {
     auto* dims = padding_config.add_dimensions();
     dims->set_interior_padding(0);
     if (i == dim) {

--- a/torch_xla/csrc/data_ops.h
+++ b/torch_xla/csrc/data_ops.h
@@ -10,22 +10,24 @@
 // data movement and no computation.
 namespace torch_xla {
 
-bool IsSparseGather(xla::XlaOp input, xla::XlaOp index, int64_t dim);
+bool IsSparseGather(xla::XlaOp input, xla::XlaOp index, xla::int64_t dim);
 
 // For input_sizes and a potentially incomplete output_sizes, return a complete
 // output shape. The complete output shape has same total number of elements as
 // input_sizes and matches output_sizes in all dimensions except for at most
 // one, which can be inferred and stored as -1 in output_sizes.
-std::vector<int64_t> GetCompleteShape(absl::Span<const int64_t> output_sizes,
-                                      absl::Span<const int64_t> input_sizes);
+std::vector<xla::int64_t> GetCompleteShape(
+    absl::Span<const xla::int64_t> output_sizes,
+    absl::Span<const xla::int64_t> input_sizes);
 
 // Creates a new tensor with the same data as the input tensor and the specified
 // output size.
-xla::XlaOp BuildView(xla::XlaOp input, absl::Span<const int64_t> output_sizes);
+xla::XlaOp BuildView(xla::XlaOp input,
+                     absl::Span<const xla::int64_t> output_sizes);
 
 // Squeezes the given dimension if trivial (size 1), returns the unchanged input
 // otherwise.
-xla::XlaOp SqueezeTrivialDimension(xla::XlaOp input, int64_t dim);
+xla::XlaOp SqueezeTrivialDimension(xla::XlaOp input, xla::int64_t dim);
 
 // Squeezes out the trivial (size 1) dimensions of the input.
 xla::XlaOp SqueezeAllTrivialDimensions(xla::XlaOp input);
@@ -33,67 +35,70 @@ xla::XlaOp SqueezeAllTrivialDimensions(xla::XlaOp input);
 // Creates a new tensor with the singleton dimensions expanded to the specified
 // output sizes.
 xla::XlaOp BuildExpand(xla::XlaOp input,
-                       absl::Span<const int64_t> output_sizes);
+                       absl::Span<const xla::int64_t> output_sizes);
 
-std::vector<int64_t> BuildSqueezedDimensions(
-    absl::Span<const int64_t> dimensions, int64_t squeeze_dim);
+std::vector<xla::int64_t> BuildSqueezedDimensions(
+    absl::Span<const xla::int64_t> dimensions, xla::int64_t squeeze_dim);
 
-std::vector<int64_t> BuildUnsqueezeDimensions(
-    absl::Span<const int64_t> dimensions, int64_t dim);
+std::vector<xla::int64_t> BuildUnsqueezeDimensions(
+    absl::Span<const xla::int64_t> dimensions, xla::int64_t dim);
 
 // Insert a dimension of size one at the specified position.
-xla::XlaOp BuildUnsqueeze(xla::XlaOp input, int64_t dim);
+xla::XlaOp BuildUnsqueeze(xla::XlaOp input, xla::int64_t dim);
 
 // Concatenates a list of tensors along a new dimension dim.
-xla::XlaOp BuildStack(absl::Span<const xla::XlaOp> inputs, int64_t dim);
+xla::XlaOp BuildStack(absl::Span<const xla::XlaOp> inputs, xla::int64_t dim);
 
 // Concatenates a list of tensors along an existing dimension specified by the
 // dim argument.
-xla::XlaOp BuildCat(absl::Span<const xla::XlaOp> inputs, int64_t dim);
+xla::XlaOp BuildCat(absl::Span<const xla::XlaOp> inputs, xla::int64_t dim);
 
 // Repeats the input tensor along each dimension by the given number of repeats.
-xla::XlaOp BuildRepeat(xla::XlaOp input, absl::Span<const int64_t> repeats);
+xla::XlaOp BuildRepeat(xla::XlaOp input,
+                       absl::Span<const xla::int64_t> repeats);
 
 // Computes the number of splits with a dimension size and the split sizes.
-size_t ComputeSplitCount(int64_t dim_size,
-                         absl::Span<const int64_t> split_sizes);
+size_t ComputeSplitCount(xla::int64_t dim_size,
+                         absl::Span<const xla::int64_t> split_sizes);
 
 // Splits a tensor into parts whose size is passed in split_sizes, along the dim
 // dimension.
 std::vector<xla::XlaOp> BuildSplit(xla::XlaOp input,
-                                   absl::Span<const int64_t> split_sizes,
-                                   int64_t dim);
+                                   absl::Span<const xla::int64_t> split_sizes,
+                                   xla::int64_t dim);
 
 // Creates an updated version of input, where, starting at base_indices, source
 // if overlapped with input.
 xla::XlaOp BuildUpdateSlice(xla::XlaOp input, xla::XlaOp source,
-                            absl::Span<const int64_t> base_indices);
+                            absl::Span<const xla::int64_t> base_indices);
 
-xla::XlaOp BuildSlice(xla::XlaOp input, absl::Span<const int64_t> base_indices,
-                      absl::Span<const int64_t> sizes);
+xla::XlaOp BuildSlice(xla::XlaOp input,
+                      absl::Span<const xla::int64_t> base_indices,
+                      absl::Span<const xla::int64_t> sizes);
 
 xla::XlaOp BoundIndices(xla::XlaOp index, xla::XlaOp max_index);
 
 xla::XlaOp BuildTake(xla::XlaOp input, xla::XlaOp index);
 
-xla::XlaOp BuildResize(xla::XlaOp input, absl::Span<const int64_t> size);
+xla::XlaOp BuildResize(xla::XlaOp input, absl::Span<const xla::int64_t> size);
 
-xla::XlaOp BuildUnselect(xla::XlaOp target, xla::XlaOp source, int64_t dim,
-                         int64_t start, int64_t end, int64_t stride);
+xla::XlaOp BuildUnselect(xla::XlaOp target, xla::XlaOp source, xla::int64_t dim,
+                         xla::int64_t start, xla::int64_t end,
+                         xla::int64_t stride);
 
 xla::XlaOp BuildReflectionPad2d(xla::XlaOp input,
-                                absl::Span<const int64_t> padding);
+                                absl::Span<const xla::int64_t> padding);
 
 xla::XlaOp BuildReflectionPadBackward(xla::XlaOp grad_output, xla::XlaOp input,
-                                      absl::Span<const int64_t> padding);
+                                      absl::Span<const xla::int64_t> padding);
 
 xla::XlaOp BuildReplicationPad(xla::XlaOp input,
-                               absl::Span<const int64_t> padding);
+                               absl::Span<const xla::int64_t> padding);
 
 xla::XlaOp BuildReplicationPadBackward(xla::XlaOp grad_output, xla::XlaOp input,
-                                       absl::Span<const int64_t> padding);
+                                       absl::Span<const xla::int64_t> padding);
 
-xla::XlaOp PadInDim(xla::XlaOp input, int64_t dim, int64_t pad_lo,
-                    int64_t pad_hi, const xla::XlaOp* pad_value = nullptr);
+xla::XlaOp PadInDim(xla::XlaOp input, xla::int64_t dim, xla::int64_t pad_lo,
+                    xla::int64_t pad_hi, const xla::XlaOp* pad_value = nullptr);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -181,8 +181,8 @@ xla::XlaOp BuildPrelu(xla::XlaOp input, xla::XlaOp weight) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   const xla::Shape& weight_shape = XlaHelpers::ShapeOfXlaOp(weight);
 
-  int64_t weight_num = xla::ShapeUtil::ElementsIn(weight_shape);
-  int64_t broadcast_dim = weight_num == 1 ? 0 : 1;
+  xla::int64_t weight_num = xla::ShapeUtil::ElementsIn(weight_shape);
+  xla::int64_t broadcast_dim = weight_num == 1 ? 0 : 1;
 
   xla::XlaOp zero = xla::Zero(input.builder(), input_shape.element_type());
   xla::XlaOp broadcasted_weight =

--- a/torch_xla/csrc/helpers.cpp
+++ b/torch_xla/csrc/helpers.cpp
@@ -51,11 +51,11 @@ xla::PrecisionConfig XlaHelpers::BuildPrecisionConfig(
   return precision_config;
 }
 
-xla::XlaOp XlaHelpers::BroadcastDimensions(xla::XlaOp input,
-                                           absl::Span<const int64_t> dimensions,
-                                           absl::Span<const int64_t> sizes) {
+xla::XlaOp XlaHelpers::BroadcastDimensions(
+    xla::XlaOp input, absl::Span<const xla::int64_t> dimensions,
+    absl::Span<const xla::int64_t> sizes) {
   XLA_CHECK_EQ(dimensions.size(), sizes.size());
-  std::vector<int64_t> bcast_sizes = SizesOfXlaOp(input);
+  std::vector<xla::int64_t> bcast_sizes = SizesOfXlaOp(input);
   for (size_t i = 0; i < dimensions.size(); ++i) {
     bcast_sizes.at(dimensions[i]) = sizes[i];
   }
@@ -74,9 +74,10 @@ xla::XlaOp XlaHelpers::CreateReturnValue(
   }
 }
 
-std::vector<int64_t> XlaHelpers::DropDimensions(
-    absl::Span<const int64_t> sizes, absl::Span<const int64_t> drop_dims) {
-  std::vector<int64_t> new_dims;
+std::vector<xla::int64_t> XlaHelpers::DropDimensions(
+    absl::Span<const xla::int64_t> sizes,
+    absl::Span<const xla::int64_t> drop_dims) {
+  std::vector<xla::int64_t> new_dims;
   size_t drop_index = 0;
   for (size_t i = 0; i < sizes.size(); ++i) {
     if (drop_index < drop_dims.size() && i == drop_dims[drop_index]) {
@@ -89,41 +90,43 @@ std::vector<int64_t> XlaHelpers::DropDimensions(
   return new_dims;
 }
 
-int64_t XlaHelpers::GetCanonicalDimensionIndex(int64_t dim, int64_t rank) {
-  int64_t min_shape_dim = -rank;
-  int64_t max_shape_dim = rank - 1;
+xla::int64_t XlaHelpers::GetCanonicalDimensionIndex(xla::int64_t dim,
+                                                    xla::int64_t rank) {
+  xla::int64_t min_shape_dim = -rank;
+  xla::int64_t max_shape_dim = rank - 1;
   XLA_CHECK(min_shape_dim <= dim && dim <= max_shape_dim)
       << "Value out of range (expected to be in range of [" << min_shape_dim
       << ", " << max_shape_dim << "], but got " << dim << ")";
-  int64_t dim_index = dim < 0 ? rank + dim : dim;
+  xla::int64_t dim_index = dim < 0 ? rank + dim : dim;
   XLA_CHECK_GE(dim_index, 0);
   XLA_CHECK_LT(dim_index, rank);
   return dim_index;
 }
 
-std::vector<int64_t> XlaHelpers::GetCanonicalDimensionIndices(
-    absl::Span<const int64_t> dimensions, int64_t rank) {
-  std::vector<int64_t> canonical_dim_indices;
-  for (int64_t dim : dimensions) {
+std::vector<xla::int64_t> XlaHelpers::GetCanonicalDimensionIndices(
+    absl::Span<const xla::int64_t> dimensions, xla::int64_t rank) {
+  std::vector<xla::int64_t> canonical_dim_indices;
+  for (xla::int64_t dim : dimensions) {
     canonical_dim_indices.push_back(GetCanonicalDimensionIndex(dim, rank));
   }
   return canonical_dim_indices;
 }
 
-int64_t XlaHelpers::GetCanonicalPosition(absl::Span<const int64_t> dimensions,
-                                         int64_t dim, int64_t pos) {
+xla::int64_t XlaHelpers::GetCanonicalPosition(
+    absl::Span<const xla::int64_t> dimensions, xla::int64_t dim,
+    xla::int64_t pos) {
   dim = GetCanonicalDimensionIndex(dim, dimensions.size());
   if (pos < 0) {
     pos = GetCanonicalDimensionIndex(pos, dimensions[dim]);
   } else {
-    pos = std::min<int64_t>(pos, dimensions[dim]);
+    pos = std::min<xla::int64_t>(pos, dimensions[dim]);
   }
   return pos;
 }
 
-int64_t XlaHelpers::GetDynamicDimension(const xla::Shape& shape) {
-  int64_t dynamic_dimension = -1;
-  for (int64_t i = 0; i < shape.rank(); ++i) {
+xla::int64_t XlaHelpers::GetDynamicDimension(const xla::Shape& shape) {
+  xla::int64_t dynamic_dimension = -1;
+  for (xla::int64_t i = 0; i < shape.rank(); ++i) {
     if (shape.is_dynamic_dimension(i)) {
       XLA_CHECK(dynamic_dimension < 0)
           << "Only one dynamic dimension is supported: " << i << " and "
@@ -135,11 +138,12 @@ int64_t XlaHelpers::GetDynamicDimension(const xla::Shape& shape) {
 }
 
 XlaHelpers::DynamicSize XlaHelpers::GetDimensionsSize(
-    absl::Span<const xla::XlaOp> inputs, absl::Span<const int64_t> dimensions) {
+    absl::Span<const xla::XlaOp> inputs,
+    absl::Span<const xla::int64_t> dimensions) {
   XLA_CHECK(!inputs.empty());
   xla::PrimitiveType size_type = GetShapeDimensionType(/*device=*/nullptr);
   xla::XlaOp size;
-  int64_t size_scalar = 1;
+  xla::int64_t size_scalar = 1;
   for (auto& input : inputs) {
     const xla::Shape& shape = ShapeOfXlaOp(input);
     for (auto dim : dimensions) {
@@ -161,7 +165,7 @@ XlaHelpers::DynamicSize XlaHelpers::GetDimensionsSize(
       }
     }
   }
-  absl::optional<int64_t> scalar_size;
+  absl::optional<xla::int64_t> scalar_size;
   if (size_scalar >= 0) {
     scalar_size = size_scalar;
   }
@@ -174,29 +178,29 @@ XlaHelpers::DynamicSize XlaHelpers::GetDimensionsSize(
 XlaHelpers::MinMax XlaHelpers::MinMaxValues(xla::PrimitiveType type) {
   switch (type) {
     case xla::PrimitiveType::S8:
-      return {std::numeric_limits<int8_t>::lowest(),
-              std::numeric_limits<int8_t>::max()};
+      return {std::numeric_limits<xla::int8>::lowest(),
+              std::numeric_limits<xla::int8>::max()};
     case xla::PrimitiveType::U8:
-      return {std::numeric_limits<uint8_t>::lowest(),
-              std::numeric_limits<uint8_t>::max()};
+      return {std::numeric_limits<xla::uint8>::lowest(),
+              std::numeric_limits<xla::uint8>::max()};
     case xla::PrimitiveType::S16:
-      return {std::numeric_limits<int16_t>::lowest(),
-              std::numeric_limits<int16_t>::max()};
+      return {std::numeric_limits<xla::int16>::lowest(),
+              std::numeric_limits<xla::int16>::max()};
     case xla::PrimitiveType::U16:
-      return {std::numeric_limits<uint16_t>::lowest(),
-              std::numeric_limits<uint16_t>::max()};
+      return {std::numeric_limits<xla::uint16>::lowest(),
+              std::numeric_limits<xla::uint16>::max()};
     case xla::PrimitiveType::S32:
-      return {static_cast<int64_t>(std::numeric_limits<int32_t>::lowest()),
-              static_cast<int64_t>(std::numeric_limits<int32_t>::max())};
+      return {static_cast<int64_t>(std::numeric_limits<xla::int32>::lowest()),
+              static_cast<int64_t>(std::numeric_limits<xla::int32>::max())};
     case xla::PrimitiveType::U32:
-      return {static_cast<int64_t>(std::numeric_limits<uint32_t>::lowest()),
-              static_cast<int64_t>(std::numeric_limits<uint32_t>::max())};
+      return {static_cast<int64_t>(std::numeric_limits<xla::uint32>::lowest()),
+              static_cast<int64_t>(std::numeric_limits<xla::uint32>::max())};
     case xla::PrimitiveType::S64:
-      return {static_cast<int64_t>(std::numeric_limits<int64_t>::lowest()),
-              static_cast<int64_t>(std::numeric_limits<int64_t>::max())};
+      return {static_cast<int64_t>(std::numeric_limits<xla::int64_t>::lowest()),
+              static_cast<int64_t>(std::numeric_limits<xla::int64_t>::max())};
     case xla::PrimitiveType::U64:
-      return {static_cast<int64_t>(std::numeric_limits<uint64_t>::lowest()),
-              static_cast<int64_t>(std::numeric_limits<uint64_t>::max())};
+      return {static_cast<int64_t>(std::numeric_limits<xla::uint64>::lowest()),
+              static_cast<int64_t>(std::numeric_limits<xla::uint64>::max())};
     case xla::PrimitiveType::F16:
       return {static_cast<float>(std::numeric_limits<xla::half>::lowest()),
               static_cast<float>(std::numeric_limits<xla::half>::max())};
@@ -215,7 +219,7 @@ XlaHelpers::MinMax XlaHelpers::MinMaxValues(xla::PrimitiveType type) {
 }
 
 xla::PaddingConfig XlaHelpers::MakeXlaPaddingConfigFromNdPadding(
-    absl::Span<const int64_t> padding) {
+    absl::Span<const xla::int64_t> padding) {
   XLA_CHECK_EQ(padding.size() % 2, 0)
       << "Padding specification must have even length";
   XLA_CHECK(!padding.empty()) << "Padding specification cannot be empty";
@@ -272,24 +276,26 @@ const xla::Shape& XlaHelpers::ShapeOfXlaOp(xla::XlaOp op) {
   return *shape;
 }
 
-std::vector<int64_t> XlaHelpers::SizesOfXlaOp(xla::XlaOp op) {
+std::vector<xla::int64_t> XlaHelpers::SizesOfXlaOp(xla::XlaOp op) {
   const xla::Shape& op_shape = ShapeOfXlaOp(op);
-  return std::vector<int64_t>(op_shape.dimensions().begin(),
-                              op_shape.dimensions().end());
+  return std::vector<xla::int64_t>(op_shape.dimensions().begin(),
+                                   op_shape.dimensions().end());
 }
 
 xla::PrimitiveType XlaHelpers::TypeOfXlaOp(xla::XlaOp op) {
   return ShapeOfXlaOp(op).element_type();
 }
 
-xla::XlaOp XlaHelpers::ReshapeToRank(xla::XlaOp input, int64_t expected_rank,
-                                     int64_t offset) {
+xla::XlaOp XlaHelpers::ReshapeToRank(xla::XlaOp input,
+                                     xla::int64_t expected_rank,
+                                     xla::int64_t offset) {
   const xla::Shape& shape = ShapeOfXlaOp(input);
   XLA_CHECK_LE(offset + shape.rank(), expected_rank);
   if (shape.rank() == expected_rank) {
     return input;
   }
-  std::vector<int64_t> dimensions(expected_rank - offset - shape.rank(), 1);
+  std::vector<xla::int64_t> dimensions(expected_rank - offset - shape.rank(),
+                                       1);
   dimensions.insert(dimensions.end(), shape.dimensions().begin(),
                     shape.dimensions().end());
   dimensions.insert(dimensions.end(), offset, 1);
@@ -298,8 +304,8 @@ xla::XlaOp XlaHelpers::ReshapeToRank(xla::XlaOp input, int64_t expected_rank,
 
 absl::optional<XlaHelpers::DynamicReshapeInfo>
 XlaHelpers::GetDynamicReshapeInfo(const xla::Shape& input_shape,
-                                  absl::Span<const int64_t> output_sizes) {
-  int64_t input_dynamic_dimension = GetDynamicDimension(input_shape);
+                                  absl::Span<const xla::int64_t> output_sizes) {
+  xla::int64_t input_dynamic_dimension = GetDynamicDimension(input_shape);
   if (input_dynamic_dimension < 0) {
     return absl::nullopt;
   }
@@ -307,13 +313,13 @@ XlaHelpers::GetDynamicReshapeInfo(const xla::Shape& input_shape,
   info.output_shape =
       xla::ShapeUtil::MakeShape(input_shape.element_type(), output_sizes);
   if (info.output_shape.rank() > 0) {
-    int64_t size_at_dyndim = 1;
-    for (int64_t i = 0; i <= input_dynamic_dimension; ++i) {
+    xla::int64_t size_at_dyndim = 1;
+    for (xla::int64_t i = 0; i <= input_dynamic_dimension; ++i) {
       size_at_dyndim *= input_shape.dimensions(i);
     }
-    int64_t dynamic_dimension = -1;
-    int64_t out_size = 1;
-    for (int64_t i = 0; i < output_sizes.size(); ++i) {
+    xla::int64_t dynamic_dimension = -1;
+    xla::int64_t out_size = 1;
+    for (xla::int64_t i = 0; i < output_sizes.size(); ++i) {
       XLA_CHECK_LE(out_size, size_at_dyndim / input_shape.dimensions(
                                                   input_dynamic_dimension))
           << "Unable to map dynamic dimension of shape " << input_shape
@@ -334,7 +340,8 @@ XlaHelpers::GetDynamicReshapeInfo(const xla::Shape& input_shape,
 }
 
 xla::Shape XlaHelpers::GetDynamicReshape(
-    const xla::Shape& input_shape, absl::Span<const int64_t> output_sizes) {
+    const xla::Shape& input_shape,
+    absl::Span<const xla::int64_t> output_sizes) {
   auto info = GetDynamicReshapeInfo(input_shape, output_sizes);
   if (info) {
     return info->output_shape;
@@ -342,8 +349,8 @@ xla::Shape XlaHelpers::GetDynamicReshape(
   return xla::ShapeUtil::MakeShape(input_shape.element_type(), output_sizes);
 }
 
-xla::XlaOp XlaHelpers::DynamicReshape(xla::XlaOp input,
-                                      absl::Span<const int64_t> output_sizes) {
+xla::XlaOp XlaHelpers::DynamicReshape(
+    xla::XlaOp input, absl::Span<const xla::int64_t> output_sizes) {
   const xla::Shape& input_shape = ShapeOfXlaOp(input);
   if (output_sizes == input_shape.dimensions()) {
     return input;
@@ -359,7 +366,7 @@ xla::XlaOp XlaHelpers::DynamicReshape(xla::XlaOp input,
 xla::XlaOp XlaHelpers::DynamicReshapeAs(xla::XlaOp input,
                                         const xla::Shape& shape) {
   const xla::Shape& input_shape = ShapeOfXlaOp(input);
-  int64_t dynamic_dimension = GetDynamicDimension(shape);
+  xla::int64_t dynamic_dimension = GetDynamicDimension(shape);
   if (dynamic_dimension >= 0) {
     return xla::ReshapeWithInferredDimension(input, shape.dimensions(),
                                              dynamic_dimension);
@@ -381,18 +388,19 @@ xla::XlaOp XlaHelpers::Flatten(xla::XlaOp input, xla::Shape* input_shape) {
   if (input_shape_tmp->rank() == 1) {
     return input;
   }
-  int64_t input_elements = xla::ShapeUtil::ElementsIn(*input_shape_tmp);
+  xla::int64_t input_elements = xla::ShapeUtil::ElementsIn(*input_shape_tmp);
   return DynamicReshape(input, {input_elements});
 }
 
-xla::XlaOp XlaHelpers::FlattenDimRange(xla::XlaOp input, int64_t start,
-                                       int64_t range, xla::Shape* input_shape) {
+xla::XlaOp XlaHelpers::FlattenDimRange(xla::XlaOp input, xla::int64_t start,
+                                       xla::int64_t range,
+                                       xla::Shape* input_shape) {
   xla::util::MaybePtr<xla::Shape> input_shape_tmp(input_shape);
   *input_shape_tmp = ShapeOfXlaOp(input);
 
-  std::vector<int64_t> sizes;
-  int64_t flat_size = -1;
-  for (int64_t dim = 0; dim < input_shape_tmp->rank(); ++dim) {
+  std::vector<xla::int64_t> sizes;
+  xla::int64_t flat_size = -1;
+  for (xla::int64_t dim = 0; dim < input_shape_tmp->rank(); ++dim) {
     if (dim < start || dim >= start + range) {
       if (flat_size >= 0) {
         sizes.push_back(flat_size);
@@ -410,12 +418,11 @@ xla::XlaOp XlaHelpers::FlattenDimRange(xla::XlaOp input, int64_t start,
   return DynamicReshape(input, sizes);
 }
 
-std::vector<int64_t> XlaHelpers::MakeTransposePermutation(int64_t dim0,
-                                                          int64_t dim1,
-                                                          int64_t rank) {
-  int64_t canonical_dim0 = GetCanonicalDimensionIndex(dim0, rank);
-  int64_t canonical_dim1 = GetCanonicalDimensionIndex(dim1, rank);
-  auto permute_dims = xla::util::Iota<int64_t>(rank);
+std::vector<xla::int64_t> XlaHelpers::MakeTransposePermutation(
+    xla::int64_t dim0, xla::int64_t dim1, xla::int64_t rank) {
+  xla::int64_t canonical_dim0 = GetCanonicalDimensionIndex(dim0, rank);
+  xla::int64_t canonical_dim1 = GetCanonicalDimensionIndex(dim1, rank);
+  auto permute_dims = xla::util::Iota<xla::int64_t>(rank);
   std::swap(permute_dims[canonical_dim0], permute_dims[canonical_dim1]);
   return permute_dims;
 }
@@ -434,8 +441,8 @@ xla::PrimitiveType XlaHelpers::PromoteType(xla::PrimitiveType type1,
   if (type1 == type2) {
     return type1;
   }
-  int64_t size1 = xla::ShapeUtil::ByteSizeOfPrimitiveType(type1);
-  int64_t size2 = xla::ShapeUtil::ByteSizeOfPrimitiveType(type2);
+  xla::int64_t size1 = xla::ShapeUtil::ByteSizeOfPrimitiveType(type1);
+  xla::int64_t size2 = xla::ShapeUtil::ByteSizeOfPrimitiveType(type2);
   if (xla::primitive_util::IsComplexType(type1)) {
     return (!xla::primitive_util::IsComplexType(type2) || size1 >= size2)
                ? type1
@@ -519,10 +526,10 @@ std::pair<xla::XlaOp, xla::XlaOp> XlaHelpers::PromoteSecondValue(
                    op1, ConvertTo(op2, type2, type1, /*device=*/nullptr));
 }
 
-std::vector<int64_t> XlaHelpers::GetPromotedShape(
-    absl::Span<const int64_t> shape1_dims,
-    absl::Span<const int64_t> shape2_dims) {
-  std::vector<int64_t> dimensions;
+std::vector<xla::int64_t> XlaHelpers::GetPromotedShape(
+    absl::Span<const xla::int64_t> shape1_dims,
+    absl::Span<const xla::int64_t> shape2_dims) {
+  std::vector<xla::int64_t> dimensions;
   // If the rank of a shape is bigger than then other, fill up the first
   // dimensions with the ones of the bigger.
   // Example:
@@ -540,16 +547,16 @@ std::vector<int64_t> XlaHelpers::GetPromotedShape(
   }
   // For the common dimensions, they must match, or one of them be 1.
   size_t min_size = std::min(shape1_dims.size(), shape2_dims.size());
-  for (int64_t i = 0; i < min_size; ++i) {
-    int64_t dim1 = shape1_dims[shape1_dims.size() - min_size + i];
-    int64_t dim2 = shape2_dims[shape2_dims.size() - min_size + i];
+  for (xla::int64_t i = 0; i < min_size; ++i) {
+    xla::int64_t dim1 = shape1_dims[shape1_dims.size() - min_size + i];
+    xla::int64_t dim2 = shape2_dims[shape2_dims.size() - min_size + i];
     XLA_CHECK(dim1 == dim2 || dim1 == 1 || dim2 == 1)
         << "(" << absl::StrJoin(shape1_dims, ", ") << ") and ("
         << absl::StrJoin(shape1_dims, ", ") << ")";
     if (dim1 == 0 || dim2 == 0) {
       dimensions.push_back(0);
     } else {
-      dimensions.push_back(std::max<int64_t>(dim1, dim2));
+      dimensions.push_back(std::max<xla::int64_t>(dim1, dim2));
     }
   }
   return dimensions;
@@ -605,7 +612,7 @@ xla::XlaOp XlaHelpers::ImplicitBroadcast(xla::XlaOp op,
   const auto& shape_dims = shape.dimensions();
   XLA_CHECK_GE(shape_dims.size(), op_shape_dims.size())
       << shape << " vs " << op_shape;
-  int64_t size_delta = shape_dims.size() - op_shape_dims.size();
+  xla::int64_t size_delta = shape_dims.size() - op_shape_dims.size();
   xla::XlaOp new_op = op;
   if (!std::equal(op_shape_dims.begin(), op_shape_dims.end(),
                   shape_dims.begin() + size_delta)) {
@@ -615,9 +622,9 @@ xla::XlaOp XlaHelpers::ImplicitBroadcast(xla::XlaOp op,
     //   shape    = [6, 8, 3, 4, 5]
     // After this operation we will have:
     //   op_shape =       [3, 4, 5]
-    std::vector<int64_t> common_shape_dims(shape_dims.begin() + size_delta,
-                                           shape_dims.end());
-    std::vector<int64_t> broadcast_dimensions(op_shape_dims.size());
+    std::vector<xla::int64_t> common_shape_dims(shape_dims.begin() + size_delta,
+                                                shape_dims.end());
+    std::vector<xla::int64_t> broadcast_dimensions(op_shape_dims.size());
     std::iota(broadcast_dimensions.begin(), broadcast_dimensions.end(), 0);
     new_op =
         xla::BroadcastInDim(new_op, common_shape_dims, broadcast_dimensions);
@@ -629,8 +636,8 @@ xla::XlaOp XlaHelpers::ImplicitBroadcast(xla::XlaOp op,
     //   shape    = [6, 8, 3, 4, 5]
     // After this operation we will have (added [6, 8]):
     //   op_shape = [6, 8, 3, 4, 5]
-    std::vector<int64_t> broadcast_sizes(shape_dims.begin(),
-                                         shape_dims.begin() + size_delta);
+    std::vector<xla::int64_t> broadcast_sizes(shape_dims.begin(),
+                                              shape_dims.begin() + size_delta);
     new_op = xla::Broadcast(new_op, broadcast_sizes);
   }
   return new_op;

--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -29,12 +29,12 @@ class XlaHelpers {
 
   struct DynamicSize {
     xla::XlaOp size;
-    absl::optional<int64_t> scalar_size;
+    absl::optional<xla::int64_t> scalar_size;
   };
 
   struct DynamicReshapeInfo {
     xla::Shape output_shape;
-    int64_t dynamic_dimension = -1;
+    xla::int64_t dynamic_dimension = -1;
   };
 
   template <class T>
@@ -52,21 +52,21 @@ class XlaHelpers {
         return xla::LiteralUtil::CreateR0<xla::half>(
             static_cast<xla::half>(static_cast<float>(scalar_value)));
       case xla::PrimitiveType::S64:
-        return xla::LiteralUtil::CreateR0<int64_t>(scalar_value);
+        return xla::LiteralUtil::CreateR0<xla::int64_t>(scalar_value);
       case xla::PrimitiveType::U64:
-        return xla::LiteralUtil::CreateR0<uint64_t>(scalar_value);
+        return xla::LiteralUtil::CreateR0<xla::uint64>(scalar_value);
       case xla::PrimitiveType::S32:
-        return xla::LiteralUtil::CreateR0<int32_t>(scalar_value);
+        return xla::LiteralUtil::CreateR0<xla::int32>(scalar_value);
       case xla::PrimitiveType::U32:
-        return xla::LiteralUtil::CreateR0<uint32_t>(scalar_value);
+        return xla::LiteralUtil::CreateR0<xla::uint32>(scalar_value);
       case xla::PrimitiveType::S16:
-        return xla::LiteralUtil::CreateR0<int16_t>(scalar_value);
+        return xla::LiteralUtil::CreateR0<xla::int16>(scalar_value);
       case xla::PrimitiveType::U16:
-        return xla::LiteralUtil::CreateR0<uint16_t>(scalar_value);
+        return xla::LiteralUtil::CreateR0<xla::uint16>(scalar_value);
       case xla::PrimitiveType::S8:
-        return xla::LiteralUtil::CreateR0<int8_t>(scalar_value);
+        return xla::LiteralUtil::CreateR0<xla::int8>(scalar_value);
       case xla::PrimitiveType::U8:
-        return xla::LiteralUtil::CreateR0<uint8_t>(scalar_value);
+        return xla::LiteralUtil::CreateR0<xla::uint8>(scalar_value);
       case xla::PrimitiveType::PRED:
         return xla::LiteralUtil::CreateR0<bool>(scalar_value);
       case xla::PrimitiveType::C64:
@@ -98,7 +98,7 @@ class XlaHelpers {
       return ScalarValue(scalar_value.toDouble(), type, builder);
     }
     XLA_CHECK(scalar_value.isIntegral()) << "Scalar type not supported";
-    return ScalarValue(static_cast<int64_t>(scalar_value.toLong()), type,
+    return ScalarValue(static_cast<xla::int64_t>(scalar_value.toLong()), type,
                        builder);
   }
 
@@ -111,22 +111,22 @@ class XlaHelpers {
   static const xla::Shape& ShapeOfXlaOp(xla::XlaOp op);
 
   // Returns the list of dimension sizes for the given XLA operation.
-  static std::vector<int64_t> SizesOfXlaOp(xla::XlaOp op);
+  static std::vector<xla::int64_t> SizesOfXlaOp(xla::XlaOp op);
 
   // Returns the value type of given XLA operation.
   static xla::PrimitiveType TypeOfXlaOp(xla::XlaOp op);
 
-  static std::vector<int64_t> GetAllDimensions(size_t rank) {
-    return xla::util::Iota<int64_t>(rank);
+  static std::vector<xla::int64_t> GetAllDimensions(size_t rank) {
+    return xla::util::Iota<xla::int64_t>(rank);
   }
 
-  static std::vector<int64_t> GetAllDimensions(const xla::Shape& shape) {
-    return xla::util::Iota<int64_t>(shape.rank());
+  static std::vector<xla::int64_t> GetAllDimensions(const xla::Shape& shape) {
+    return xla::util::Iota<xla::int64_t>(shape.rank());
   }
 
-  static xla::XlaOp BroadcastDimensions(xla::XlaOp input,
-                                        absl::Span<const int64_t> dimensions,
-                                        absl::Span<const int64_t> sizes);
+  static xla::XlaOp BroadcastDimensions(
+      xla::XlaOp input, absl::Span<const xla::int64_t> dimensions,
+      absl::Span<const xla::int64_t> sizes);
 
   static xla::XlaOp CreateReturnValue(xla::XlaBuilder* builder,
                                       const std::vector<xla::XlaOp>& outputs);
@@ -134,7 +134,7 @@ class XlaHelpers {
   // Creates a scalar broadcasted to a given shape.
   template <class T>
   static xla::XlaOp ScalarBroadcast(T scalar_value, xla::PrimitiveType type,
-                                    absl::Span<const int64_t> dimensions,
+                                    absl::Span<const xla::int64_t> dimensions,
                                     xla::XlaBuilder* builder) {
     xla::XlaOp scalar_op = ScalarValue<T>(scalar_value, type, builder);
     return xla::Broadcast(scalar_op, dimensions);
@@ -148,13 +148,15 @@ class XlaHelpers {
   }
 
   static absl::optional<DynamicReshapeInfo> GetDynamicReshapeInfo(
-      const xla::Shape& input_shape, absl::Span<const int64_t> output_sizes);
+      const xla::Shape& input_shape,
+      absl::Span<const xla::int64_t> output_sizes);
 
-  static xla::Shape GetDynamicReshape(const xla::Shape& input_shape,
-                                      absl::Span<const int64_t> output_sizes);
+  static xla::Shape GetDynamicReshape(
+      const xla::Shape& input_shape,
+      absl::Span<const xla::int64_t> output_sizes);
 
   static xla::XlaOp DynamicReshape(xla::XlaOp input,
-                                   absl::Span<const int64_t> output_sizes);
+                                   absl::Span<const xla::int64_t> output_sizes);
 
   static xla::XlaOp DynamicReshapeAs(xla::XlaOp input, const xla::Shape& shape);
 
@@ -166,40 +168,44 @@ class XlaHelpers {
 
   // Converts an iterable container to a vector XLA int64's.
   template <typename S>
-  static std::vector<int64_t> I64List(const S& input) {
-    return xla::util::ToVector<int64_t>(input);
+  static std::vector<xla::int64_t> I64List(const S& input) {
+    return xla::util::ToVector<xla::int64_t>(input);
   }
 
-  static c10::optional<int64_t> I64Optional(c10::optional<int64_t> opt) {
-    return opt ? c10::optional<int64_t>(*opt) : c10::nullopt;
+  static c10::optional<xla::int64_t> I64Optional(c10::optional<int64_t> opt) {
+    return opt ? c10::optional<xla::int64_t>(*opt) : c10::nullopt;
   }
 
   // Creates an XLA padding configuration from a n-dimensional padding list.
   static xla::PaddingConfig MakeXlaPaddingConfigFromNdPadding(
-      absl::Span<const int64_t> padding);
+      absl::Span<const xla::int64_t> padding);
 
   // Creates a set of dimension by dropping the drop_dims ones.
-  static std::vector<int64_t> DropDimensions(
-      absl::Span<const int64_t> sizes, absl::Span<const int64_t> drop_dims);
+  static std::vector<xla::int64_t> DropDimensions(
+      absl::Span<const xla::int64_t> sizes,
+      absl::Span<const xla::int64_t> drop_dims);
 
   // Get the canonical dimension index in the [0, rank) interval. Negative
   // indices are interpreted as follows: -1 is rank-1, -2 is rank-2 etc.
-  static int64_t GetCanonicalDimensionIndex(int64_t dim, int64_t rank);
+  static xla::int64_t GetCanonicalDimensionIndex(xla::int64_t dim,
+                                                 xla::int64_t rank);
 
   // Same as above, for multiple dimensions.
-  static std::vector<int64_t> GetCanonicalDimensionIndices(
-      absl::Span<const int64_t> dimensions, int64_t rank);
+  static std::vector<xla::int64_t> GetCanonicalDimensionIndices(
+      absl::Span<const xla::int64_t> dimensions, xla::int64_t rank);
 
   // Returns the canonical position in the dim dimension, handling negative
   // values for the position.
-  static int64_t GetCanonicalPosition(absl::Span<const int64_t> dimensions,
-                                      int64_t dim, int64_t pos);
+  static xla::int64_t GetCanonicalPosition(
+      absl::Span<const xla::int64_t> dimensions, xla::int64_t dim,
+      xla::int64_t pos);
 
   // Retrieves the dynamic dimension of an input shape, or returns -1 if none.
-  static int64_t GetDynamicDimension(const xla::Shape& shape);
+  static xla::int64_t GetDynamicDimension(const xla::Shape& shape);
 
-  static DynamicSize GetDimensionsSize(absl::Span<const xla::XlaOp> inputs,
-                                       absl::Span<const int64_t> dimensions);
+  static DynamicSize GetDimensionsSize(
+      absl::Span<const xla::XlaOp> inputs,
+      absl::Span<const xla::int64_t> dimensions);
 
   // Retrieves type's minimum and maximum values.
   static MinMax MinMaxValues(xla::PrimitiveType type);
@@ -222,14 +228,14 @@ class XlaHelpers {
   // appending 1s to the major dimension. If offset is greater than zero, 1s
   // will be prepened to the minor dimension as well.
   // Expected condition: rank(input) + offset <= expected_rank
-  static xla::XlaOp ReshapeToRank(xla::XlaOp input, int64_t expected_rank,
-                                  int64_t offset = 0);
+  static xla::XlaOp ReshapeToRank(xla::XlaOp input, xla::int64_t expected_rank,
+                                  xla::int64_t offset = 0);
 
   static xla::XlaOp Flatten(xla::XlaOp input,
                             xla::Shape* input_shape = nullptr);
 
-  static xla::XlaOp FlattenDimRange(xla::XlaOp input, int64_t start,
-                                    int64_t range,
+  static xla::XlaOp FlattenDimRange(xla::XlaOp input, xla::int64_t start,
+                                    xla::int64_t range,
                                     xla::Shape* input_shape = nullptr);
 
   // Gathers the input using the order specified by the permutation. For each i,
@@ -237,7 +243,7 @@ class XlaHelpers {
   // size as the input.
   template <typename Container>
   static std::vector<typename Container::value_type> Permute(
-      absl::Span<const int64_t> permutation, const Container& input) {
+      absl::Span<const xla::int64_t> permutation, const Container& input) {
     using T = typename Container::value_type;
     XLA_CHECK(input.size() == permutation.size() &&
               xla::IsPermutation(permutation))
@@ -250,9 +256,9 @@ class XlaHelpers {
   }
 
   // Creates a transposition from the given input and dimensions.
-  static std::vector<int64_t> MakeTransposePermutation(int64_t dim0,
-                                                       int64_t dim1,
-                                                       int64_t rank);
+  static std::vector<xla::int64_t> MakeTransposePermutation(xla::int64_t dim0,
+                                                            xla::int64_t dim1,
+                                                            xla::int64_t rank);
 
   static xla::PrimitiveType PromoteType(xla::PrimitiveType type1,
                                         xla::PrimitiveType type2);
@@ -294,9 +300,9 @@ class XlaHelpers {
   //   shape1       = [9, 7, 6, 1, 2]
   //   shape2       =       [6, 5, 2]
   //   result_shape = [9, 7, 6, 5, 2]
-  static std::vector<int64_t> GetPromotedShape(
-      absl::Span<const int64_t> shape1_dims,
-      absl::Span<const int64_t> shape2_dims);
+  static std::vector<xla::int64_t> GetPromotedShape(
+      absl::Span<const xla::int64_t> shape1_dims,
+      absl::Span<const xla::int64_t> shape2_dims);
 
   static xla::Shape GetPromotedShape(const xla::Shape& shape1,
                                      const xla::Shape& shape2);

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -151,25 +151,26 @@ AllReduceType GetReduceType(const std::string& reduce_type) {
   XLA_ERROR() << "Unknown AllReduce type: " << reduce_type;
 }
 
-std::vector<std::vector<int64_t>> CreateReduceGroups(const py::list& groups) {
-  std::vector<std::vector<int64_t>> replica_groups;
+std::vector<std::vector<xla::int64_t>> CreateReduceGroups(
+    const py::list& groups) {
+  std::vector<std::vector<xla::int64_t>> replica_groups;
   for (auto& group : groups) {
     replica_groups.emplace_back();
     for (auto& replica_id : group.cast<py::list>()) {
-      replica_groups.back().push_back(replica_id.cast<int64_t>());
+      replica_groups.back().push_back(replica_id.cast<xla::int64_t>());
     }
   }
   return replica_groups;
 }
 
-std::vector<std::pair<int64_t, int64_t>> CreateSourceTargetPairs(
+std::vector<std::pair<xla::int64_t, xla::int64_t>> CreateSourceTargetPairs(
     const py::list& pairs) {
-  std::vector<std::pair<int64_t, int64_t>> source_target_pairs;
+  std::vector<std::pair<xla::int64_t, xla::int64_t>> source_target_pairs;
   for (auto& pair : pairs) {
     const auto& pylist_pair = pair.cast<py::list>();
     XLA_CHECK_EQ(len(pylist_pair), 2);
-    source_target_pairs.push_back(
-        {pylist_pair[0].cast<int64_t>(), pylist_pair[1].cast<int64_t>()});
+    source_target_pairs.push_back({pylist_pair[0].cast<xla::int64_t>(),
+                                   pylist_pair[1].cast<xla::int64_t>()});
   }
   return source_target_pairs;
 }
@@ -177,7 +178,7 @@ std::vector<std::pair<int64_t, int64_t>> CreateSourceTargetPairs(
 std::shared_ptr<ir::Value> AllReduceInPlace(
     const std::string& reduce_type, const std::vector<at::Tensor>& tensors,
     const std::shared_ptr<ir::Value>& token, double scale,
-    const std::vector<std::vector<int64_t>>& replica_groups) {
+    const std::vector<std::vector<xla::int64_t>>& replica_groups) {
   std::vector<XLATensor> xtensors = GetXlaTensors(tensors, /*want_all=*/true);
   return std::make_shared<ir::Value>(XLATensor::all_reduce(
       &xtensors, *token, GetReduceType(reduce_type), scale, replica_groups));
@@ -186,7 +187,7 @@ std::shared_ptr<ir::Value> AllReduceInPlace(
 std::pair<at::Tensor, std::shared_ptr<ir::Value>> AllReduce(
     const std::string& reduce_type, const at::Tensor& input,
     const std::shared_ptr<ir::Value>& token, double scale,
-    const std::vector<std::vector<int64_t>>& replica_groups) {
+    const std::vector<std::vector<xla::int64_t>>& replica_groups) {
   XLATensor result;
   ir::Value new_token;
   std::tie(result, new_token) =
@@ -199,9 +200,9 @@ std::pair<at::Tensor, std::shared_ptr<ir::Value>> AllReduce(
 
 std::pair<at::Tensor, std::shared_ptr<ir::Value>> ReduceScatter(
     const std::string& reduce_type, const at::Tensor& input,
-    const std::shared_ptr<ir::Value>& token, double scale, int64_t scatter_dim,
-    int64_t shard_count,
-    const std::vector<std::vector<int64_t>>& replica_groups) {
+    const std::shared_ptr<ir::Value>& token, double scale,
+    xla::int64_t scatter_dim, xla::int64_t shard_count,
+    const std::vector<std::vector<xla::int64_t>>& replica_groups) {
   XLATensor result;
   ir::Value new_token;
   std::tie(result, new_token) = XLATensor::reduce_scatter(
@@ -214,8 +215,8 @@ std::pair<at::Tensor, std::shared_ptr<ir::Value>> ReduceScatter(
 
 std::pair<at::Tensor, std::shared_ptr<ir::Value>> AllGather(
     const at::Tensor& input, const std::shared_ptr<ir::Value>& token,
-    int64_t dim, int64_t shard_count,
-    const std::vector<std::vector<int64_t>>& replica_groups) {
+    xla::int64_t dim, xla::int64_t shard_count,
+    const std::vector<std::vector<xla::int64_t>>& replica_groups) {
   XLATensor result;
   ir::Value new_token;
   std::tie(result, new_token) = XLATensor::all_gather(
@@ -226,8 +227,9 @@ std::pair<at::Tensor, std::shared_ptr<ir::Value>> AllGather(
 
 std::pair<at::Tensor, std::shared_ptr<ir::Value>> AllToAll(
     const at::Tensor& input, const std::shared_ptr<ir::Value>& token,
-    int64_t split_dimension, int64_t concat_dimension, int64_t split_count,
-    const std::vector<std::vector<int64_t>>& replica_groups) {
+    xla::int64_t split_dimension, xla::int64_t concat_dimension,
+    xla::int64_t split_count,
+    const std::vector<std::vector<xla::int64_t>>& replica_groups) {
   XLATensor result;
   ir::Value new_token;
   std::tie(result, new_token) = XLATensor::all_to_all(
@@ -240,7 +242,8 @@ std::pair<at::Tensor, std::shared_ptr<ir::Value>> AllToAll(
 
 std::pair<at::Tensor, std::shared_ptr<ir::Value>> CollectivePermute(
     const at::Tensor& input, const std::shared_ptr<ir::Value>& token,
-    const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs) {
+    const std::vector<std::pair<xla::int64_t, xla::int64_t>>&
+        source_target_pairs) {
   XLATensor result;
   ir::Value new_token;
   std::tie(result, new_token) = XLATensor::collective_permute(
@@ -286,12 +289,12 @@ void StepMarker(const std::string& device_str,
   }
 }
 
-void SetRngSeed(uint64_t seed, const std::string& device_str) {
+void SetRngSeed(xla::uint64 seed, const std::string& device_str) {
   Device device = GetDeviceOrCurrent(device_str);
   XLATensor::SetRngSeed(device, seed);
 }
 
-uint64_t GetRngSeed(const std::string& device_str) {
+xla::uint64 GetRngSeed(const std::string& device_str) {
   return XLATensor::GetRunningSeed(GetDeviceOrCurrent(device_str));
 }
 
@@ -367,7 +370,8 @@ std::shared_ptr<ir::Value> CreateToken(const std::string& device_str) {
   return std::make_shared<ir::Value>(std::move(ir_value));
 }
 
-at::Tensor GetXlaTensorDimensionSize(const at::Tensor& tensor, int64_t dim) {
+at::Tensor GetXlaTensorDimensionSize(const at::Tensor& tensor,
+                                     xla::int64_t dim) {
   XLATensor xtensor = bridge::GetXlaTensor(tensor);
   return bridge::AtenFromXlaTensor(
       XLATensor::get_dimensions_size(xtensor, {dim}));
@@ -406,7 +410,7 @@ py::object GetRevisions() {
 
 std::vector<py::bytes> Rendezvous(int ordinal, const std::string& tag,
                                   const std::string& payload,
-                                  const std::vector<int64_t>& replicas) {
+                                  const std::vector<xla::int64_t>& replicas) {
   xla::service::MeshClient* mesh_client = xla::service::MeshClient::Get();
   std::vector<py::bytes> payloads;
   if (mesh_client != nullptr) {
@@ -422,7 +426,8 @@ std::vector<py::bytes> Rendezvous(int ordinal, const std::string& tag,
 }
 
 std::shared_ptr<xla::util::RecordReader> CreateRecordReader(
-    std::string path, const std::string& compression, int64_t buffer_size) {
+    std::string path, const std::string& compression,
+    xla::int64_t buffer_size) {
   return std::make_shared<xla::util::RecordReader>(std::move(path), compression,
                                                    buffer_size);
 }
@@ -589,7 +594,7 @@ void RemoveTfFile(const std::string& path) {
 
 py::object XlaNms(const at::Tensor& boxes, const at::Tensor& scores,
                   const at::Tensor& score_threshold,
-                  const at::Tensor& iou_threshold, int64_t output_size) {
+                  const at::Tensor& iou_threshold, xla::int64_t output_size) {
   at::Tensor selected_indices;
   at::Tensor num_valid;
   {
@@ -750,7 +755,8 @@ void InitXlaModuleBindings(py::module m) {
         });
   m.def("_xla_nms", [](const at::Tensor& boxes, const at::Tensor& scores,
                        const at::Tensor& score_threshold,
-                       const at::Tensor& iou_threshold, int64_t output_size) {
+                       const at::Tensor& iou_threshold,
+                       xla::int64_t output_size) {
     return XlaNms(boxes, scores, score_threshold, iou_threshold, output_size);
   });
   m.def("_xla_user_computation",
@@ -846,7 +852,7 @@ void InitXlaModuleBindings(py::module m) {
   });
   m.def("_xla_rendezvous",
         [](int ordinal, const std::string& tag, const std::string& payload,
-           const std::vector<int64_t>& replicas) {
+           const std::vector<xla::int64_t>& replicas) {
           return Rendezvous(ordinal, tag, payload, replicas);
         });
 
@@ -857,7 +863,7 @@ void InitXlaModuleBindings(py::module m) {
                                       const std::vector<at::Tensor>& tensors,
                                       const std::shared_ptr<ir::Value>& token,
                                       double scale, const py::list& groups) {
-    std::vector<std::vector<int64_t>> replica_groups =
+    std::vector<std::vector<xla::int64_t>> replica_groups =
         CreateReduceGroups(groups);
     std::shared_ptr<ir::Value> new_token;
     {
@@ -871,7 +877,7 @@ void InitXlaModuleBindings(py::module m) {
         [](const std::string& reduce_type, const at::Tensor& input,
            const std::shared_ptr<ir::Value>& token, double scale,
            const py::list& groups) {
-          std::vector<std::vector<int64_t>> replica_groups =
+          std::vector<std::vector<xla::int64_t>> replica_groups =
               CreateReduceGroups(groups);
           at::Tensor result;
           std::shared_ptr<ir::Value> new_token;
@@ -888,9 +894,9 @@ void InitXlaModuleBindings(py::module m) {
         });
   m.def("_xla_all_to_all",
         [](const at::Tensor& input, const std::shared_ptr<ir::Value>& token,
-           int64_t split_dimension, int64_t concat_dimension,
-           int64_t split_count, const py::list& groups) {
-          std::vector<std::vector<int64_t>> replica_groups =
+           xla::int64_t split_dimension, xla::int64_t concat_dimension,
+           xla::int64_t split_count, const py::list& groups) {
+          std::vector<std::vector<xla::int64_t>> replica_groups =
               CreateReduceGroups(groups);
           at::Tensor result;
           std::shared_ptr<ir::Value> new_token;
@@ -908,8 +914,8 @@ void InitXlaModuleBindings(py::module m) {
         });
   m.def("_xla_all_gather",
         [](const at::Tensor& input, const std::shared_ptr<ir::Value>& token,
-           int64_t dim, int64_t shard_count, const py::list& groups) {
-          std::vector<std::vector<int64_t>> replica_groups =
+           xla::int64_t dim, xla::int64_t shard_count, const py::list& groups) {
+          std::vector<std::vector<xla::int64_t>> replica_groups =
               CreateReduceGroups(groups);
           at::Tensor result;
           std::shared_ptr<ir::Value> new_token;
@@ -924,29 +930,30 @@ void InitXlaModuleBindings(py::module m) {
           result_tuple[1] = new_token;
           return result_tuple;
         });
-  m.def("_xla_collective_permute",
-        [](const at::Tensor& input, const std::shared_ptr<ir::Value>& token,
-           const py::list& pairs) {
-          std::vector<std::pair<int64_t, int64_t>> source_target_pairs =
-              CreateSourceTargetPairs(pairs);
-          at::Tensor result;
-          std::shared_ptr<ir::Value> new_token;
-          {
-            NoGilSection nogil;
-            std::tie(result, new_token) =
-                CollectivePermute(input, token, source_target_pairs);
-          }
-          auto result_tuple = py::tuple(2);
-          result_tuple[0] = torch::autograd::make_variable(
-              result, /*requires_grad=*/input.requires_grad());
-          result_tuple[1] = new_token;
-          return result_tuple;
-        });
+  m.def("_xla_collective_permute", [](const at::Tensor& input,
+                                      const std::shared_ptr<ir::Value>& token,
+                                      const py::list& pairs) {
+    std::vector<std::pair<xla::int64_t, xla::int64_t>> source_target_pairs =
+        CreateSourceTargetPairs(pairs);
+    at::Tensor result;
+    std::shared_ptr<ir::Value> new_token;
+    {
+      NoGilSection nogil;
+      std::tie(result, new_token) =
+          CollectivePermute(input, token, source_target_pairs);
+    }
+    auto result_tuple = py::tuple(2);
+    result_tuple[0] = torch::autograd::make_variable(
+        result, /*requires_grad=*/input.requires_grad());
+    result_tuple[1] = new_token;
+    return result_tuple;
+  });
   m.def("_xla_reduce_scatter",
         [](const std::string& reduce_type, const at::Tensor& input,
            const std::shared_ptr<ir::Value>& token, double scale,
-           int64_t scatter_dim, int64_t shard_count, const py::list& groups) {
-          std::vector<std::vector<int64_t>> replica_groups =
+           xla::int64_t scatter_dim, xla::int64_t shard_count,
+           const py::list& groups) {
+          std::vector<std::vector<xla::int64_t>> replica_groups =
               CreateReduceGroups(groups);
           at::Tensor result;
           std::shared_ptr<ir::Value> new_token;
@@ -967,7 +974,7 @@ void InitXlaModuleBindings(py::module m) {
   });
   m.def("_xla_get_default_device", []() { return GetCurrentThreadDevice(); });
   m.def("_xla_set_rng_seed",
-        [](uint64_t seed, const std::string& device) {
+        [](xla::uint64 seed, const std::string& device) {
           SetRngSeed(seed, device);
         },
         py::arg("seed") = 101, py::arg("device") = "");
@@ -1034,7 +1041,7 @@ void InitXlaModuleBindings(py::module m) {
       m, "RecordReader");
   m.def("_xla_create_tfrecord_reader",
         [](const std::string& path, const std::string& compression,
-           int64_t buffer_size) {
+           xla::int64_t buffer_size) {
           NoGilSection nogil;
           return CreateRecordReader(path, compression, buffer_size);
         },
@@ -1109,8 +1116,8 @@ void InitXlaModuleBindings(py::module m) {
           xla::Shape tensor_shape = GetTensorShape(tensor, device);
           return op_builder::ShapeToPyShape(tensor_shape);
         });
-  m.def("_xla_op_param", [](op_builder::BuilderPtr builder, int64_t param_no,
-                            py::object py_shape) {
+  m.def("_xla_op_param", [](op_builder::BuilderPtr builder,
+                            xla::int64_t param_no, py::object py_shape) {
     xla::Shape shape = op_builder::PyShapeToShape(py_shape);
     xla::XlaOp param = xla::Parameter(builder.get(), param_no, shape,
                                       absl::StrCat("p", param_no));
@@ -1153,7 +1160,7 @@ void InitXlaModuleBindings(py::module m) {
            const std::vector<op_builder::OpPtr>& operands, py::dict args) {
           return op_builder::CreateOp(builder, opname, operands, args);
         });
-  m.def("_run_xrt_local_service", [](uint64_t service_port) {
+  m.def("_run_xrt_local_service", [](xla::uint64 service_port) {
     xla::ComputationClient::RunLocalService(service_port);
   });
   m.def("_xla_sgd_optimizer_step_",

--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -60,7 +60,7 @@ std::string GetCurrentScope() {
 }
 
 ShapeCache* GetShapeCache() {
-  static int64_t shape_cache_size =
+  static xla::int64_t shape_cache_size =
       xla::sys_util::GetEnvInt("XLA_IR_SHAPE_CACHE_SIZE", 4096);
   static ShapeCache* cache = new ShapeCache(shape_cache_size);
   return cache;

--- a/torch_xla/csrc/layout_manager.cpp
+++ b/torch_xla/csrc/layout_manager.cpp
@@ -25,26 +25,26 @@ class LayoutManager {
     return mgr;
   }
 
-  const std::vector<int64_t>* GetLayout(
-      absl::Span<const int64_t> dimensions) const {
+  const std::vector<xla::int64_t>* GetLayout(
+      absl::Span<const xla::int64_t> dimensions) const {
     auto it = layouts_.find(dimensions);
     return it != layouts_.end() ? &it->second->layout : nullptr;
   }
 
  private:
   struct LayoutEntry {
-    std::vector<int64_t> dimensions;
-    std::vector<int64_t> layout;
+    std::vector<xla::int64_t> dimensions;
+    std::vector<xla::int64_t> layout;
   };
 
   struct DimensionsHasher {
-    size_t operator()(const absl::Span<const int64_t>& dimensions) const {
+    size_t operator()(const absl::Span<const xla::int64_t>& dimensions) const {
       return xla::util::HashReduce(xla::util::MHash(dimensions));
     }
   };
 
   using LayoutMap =
-      std::unordered_map<absl::Span<const int64_t>,
+      std::unordered_map<absl::Span<const xla::int64_t>,
                          std::shared_ptr<LayoutEntry>, DimensionsHasher>;
 
   LayoutManager() {
@@ -78,20 +78,20 @@ class LayoutManager {
     }
   }
 
-  static std::vector<int64_t> ParseIntList(const std::string& list_str) {
+  static std::vector<xla::int64_t> ParseIntList(const std::string& list_str) {
     std::vector<std::string> parts = absl::StrSplit(list_str, ',');
-    std::vector<int64_t> ints;
+    std::vector<xla::int64_t> ints;
     for (const auto& int_str : parts) {
       ints.push_back(std::stol(int_str));
     }
     return ints;
   }
 
-  static std::vector<int64_t> ParseLayout(const std::string& list_str,
-                                          int64_t rank) {
-    std::vector<int64_t> ints = ParseIntList(list_str);
+  static std::vector<xla::int64_t> ParseLayout(const std::string& list_str,
+                                               xla::int64_t rank) {
+    std::vector<xla::int64_t> ints = ParseIntList(list_str);
     XLA_CHECK_EQ(ints.size(), rank) << list_str;
-    std::set<int64_t> unique_ints;
+    std::set<xla::int64_t> unique_ints;
     for (auto dim : ints) {
       XLA_CHECK_GE(dim, 0) << list_str;
       XLA_CHECK_LT(dim, rank) << list_str;
@@ -104,19 +104,19 @@ class LayoutManager {
   LayoutMap layouts_;
 };
 
-double PaddingFactor(int64_t size, int padding) {
+double PaddingFactor(xla::int64_t size, int padding) {
   int rem = static_cast<int>(size % padding);
   return 1.0 + (rem > 0 ? static_cast<double>(padding - rem) /
                               static_cast<double>(size)
                         : 0.0);
 }
 
-xla::Shape MakeShapeWithSortedLayout(absl::Span<const int64_t> dimensions,
+xla::Shape MakeShapeWithSortedLayout(absl::Span<const xla::int64_t> dimensions,
                                      xla::PrimitiveType type) {
   // Place bigger dimensions on most minor layout locations.
-  std::vector<int64_t> layout =
-      xla::util::Iota<int64_t>(dimensions.size(), dimensions.size() - 1, -1);
-  std::sort(layout.begin(), layout.end(), [&](int64_t a, int64_t b) {
+  std::vector<xla::int64_t> layout = xla::util::Iota<xla::int64_t>(
+      dimensions.size(), dimensions.size() - 1, -1);
+  std::sort(layout.begin(), layout.end(), [&](xla::int64_t a, xla::int64_t b) {
     return dimensions[a] > dimensions[b];
   });
   return xla::ShapeUtil::MakeShapeWithLayout(type, dimensions, layout);
@@ -133,7 +133,7 @@ xla::Shape* SetDynamicDimensions(xla::Shape* shape,
   return shape;
 }
 
-xla::Shape MakeTpuShape(absl::Span<const int64_t> dimensions,
+xla::Shape MakeTpuShape(absl::Span<const xla::int64_t> dimensions,
                         absl::Span<const bool> dynamic_dimensions,
                         xla::PrimitiveType type) {
   static double max_padding_factor =
@@ -151,9 +151,9 @@ xla::Shape MakeTpuShape(absl::Span<const int64_t> dimensions,
 }
 
 xla::Shape MakeShapeWithLayout(xla::PrimitiveType type,
-                               absl::Span<const int64_t> dimensions,
+                               absl::Span<const xla::int64_t> dimensions,
                                absl::Span<const bool> dynamic_dimensions,
-                               absl::Span<const int64_t> layout) {
+                               absl::Span<const xla::int64_t> layout) {
   xla::Shape shape =
       xla::ShapeUtil::MakeShapeWithLayout(type, dimensions, layout);
   SetDynamicDimensions(&shape, dynamic_dimensions);
@@ -162,7 +162,7 @@ xla::Shape MakeShapeWithLayout(xla::PrimitiveType type,
 
 }  // namespace
 
-xla::Shape MakeTorchTensorLayout(absl::Span<const int64_t> dimensions,
+xla::Shape MakeTorchTensorLayout(absl::Span<const xla::int64_t> dimensions,
                                  absl::Span<const bool> dynamic_dimensions,
                                  xla::PrimitiveType type) {
   xla::Shape shape =
@@ -172,7 +172,7 @@ xla::Shape MakeTorchTensorLayout(absl::Span<const int64_t> dimensions,
 }
 
 xla::Shape MakeArrayShapeFromDimensions(
-    absl::Span<const int64_t> dimensions,
+    absl::Span<const xla::int64_t> dimensions,
     absl::Span<const bool> dynamic_dimensions, xla::PrimitiveType type,
     DeviceType device_type) {
   auto layout_ptr = LayoutManager::Get()->GetLayout(dimensions);

--- a/torch_xla/csrc/layout_manager.h
+++ b/torch_xla/csrc/layout_manager.h
@@ -9,7 +9,7 @@ namespace torch_xla {
 
 // Creates a minor-to-major layout from given dimensions. The dynamic_dimensions
 // slice should be either empty, or of the same size as dimensions.
-xla::Shape MakeTorchTensorLayout(absl::Span<const int64_t> dimensions,
+xla::Shape MakeTorchTensorLayout(absl::Span<const xla::int64_t> dimensions,
                                  absl::Span<const bool> dynamic_dimensions,
                                  xla::PrimitiveType type);
 
@@ -18,7 +18,7 @@ xla::Shape MakeTorchTensorLayout(absl::Span<const int64_t> dimensions,
 // XLA layout. The dynamic_dimensions slice should be either empty, or of the
 // same size as dimensions.
 xla::Shape MakeArrayShapeFromDimensions(
-    absl::Span<const int64_t> dimensions,
+    absl::Span<const xla::int64_t> dimensions,
     absl::Span<const bool> dynamic_dimensions, xla::PrimitiveType type,
     DeviceType device_type);
 

--- a/torch_xla/csrc/matrix.cpp
+++ b/torch_xla/csrc/matrix.cpp
@@ -18,10 +18,10 @@ struct DiagonalMask {
 
 xla::PaddingConfig CreateDiagonalPaddingConfig(const xla::Shape& target_shape,
                                                const xla::Shape& input_shape,
-                                               int64_t offset) {
-  int64_t rank = target_shape.rank();
+                                               xla::int64_t offset) {
+  xla::int64_t rank = target_shape.rank();
   xla::PaddingConfig padding_config;
-  for (int64_t i = 0; i < rank - 2; ++i) {
+  for (xla::int64_t i = 0; i < rank - 2; ++i) {
     auto* dims = padding_config.add_dimensions();
     dims->set_edge_padding_low(0);
     dims->set_interior_padding(0);
@@ -34,9 +34,9 @@ xla::PaddingConfig CreateDiagonalPaddingConfig(const xla::Shape& target_shape,
   } else {
     dims->set_edge_padding_low(target_shape.dimensions(rank - 1) * (-offset));
   }
-  int64_t num_elements =
+  xla::int64_t num_elements =
       target_shape.dimensions(rank - 2) * target_shape.dimensions(rank - 1);
-  int64_t num_interior_paddings =
+  xla::int64_t num_interior_paddings =
       input_shape.dimensions(input_shape.rank() - 1) - 1;
   dims->set_edge_padding_high(num_elements - dims->edge_padding_low() -
                               num_interior_paddings * dims->interior_padding() -
@@ -46,7 +46,7 @@ xla::PaddingConfig CreateDiagonalPaddingConfig(const xla::Shape& target_shape,
 
 DiagonalMask CreateDiagonalMask(xla::XlaOp input,
                                 const xla::Shape& target_shape,
-                                int64_t offset) {
+                                xla::int64_t offset) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   xla::PaddingConfig padding_config =
       CreateDiagonalPaddingConfig(target_shape, input_shape, offset);
@@ -66,10 +66,11 @@ DiagonalMask CreateDiagonalMask(xla::XlaOp input,
   return {source, mask};
 }
 
-std::vector<int64_t> GetDiagonalPermutation(int64_t rank, int64_t dim1,
-                                            int64_t dim2) {
-  std::vector<int64_t> permutation;
-  for (int64_t dim = 0; dim < rank; ++dim) {
+std::vector<xla::int64_t> GetDiagonalPermutation(xla::int64_t rank,
+                                                 xla::int64_t dim1,
+                                                 xla::int64_t dim2) {
+  std::vector<xla::int64_t> permutation;
+  for (xla::int64_t dim = 0; dim < rank; ++dim) {
     if (dim != dim1 && dim != dim2) {
       permutation.push_back(dim);
     }
@@ -81,18 +82,18 @@ std::vector<int64_t> GetDiagonalPermutation(int64_t rank, int64_t dim1,
 
 }  // namespace
 
-xla::XlaOp BuildTriu(xla::XlaOp input, int64_t diagonal) {
+xla::XlaOp BuildTriu(xla::XlaOp input, xla::int64_t diagonal) {
   return xla::Select(xla::TriangleMask(input, diagonal - 1),
                      xla::ZerosLike(input), input);
 }
 
-xla::XlaOp BuildTril(xla::XlaOp input, int64_t diagonal) {
+xla::XlaOp BuildTril(xla::XlaOp input, xla::int64_t diagonal) {
   return xla::Select(xla::TriangleMask(input, diagonal), input,
                      xla::ZerosLike(input));
 }
 
-xla::XlaOp BuildDiagonal(xla::XlaOp input, int64_t offset, int64_t dim1,
-                         int64_t dim2) {
+xla::XlaOp BuildDiagonal(xla::XlaOp input, xla::int64_t offset,
+                         xla::int64_t dim1, xla::int64_t dim2) {
   xla::XlaOp diag_input = input;
   if (dim1 != 0 || dim2 != 1) {
     const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
@@ -103,7 +104,8 @@ xla::XlaOp BuildDiagonal(xla::XlaOp input, int64_t offset, int64_t dim1,
 }
 
 xla::XlaOp BuildDiagonalViewUpdate(xla::XlaOp target, xla::XlaOp input,
-                                   int64_t offset, int64_t dim1, int64_t dim2) {
+                                   xla::int64_t offset, xla::int64_t dim1,
+                                   xla::int64_t dim2) {
   const xla::Shape* target_shape = &XlaHelpers::ShapeOfXlaOp(target);
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   xla::XlaOp diag_input = input;
@@ -111,7 +113,7 @@ xla::XlaOp BuildDiagonalViewUpdate(xla::XlaOp target, xla::XlaOp input,
     diag_input = ConvertTo(input, input_shape.element_type(),
                            target_shape->element_type(), /*device=*/nullptr);
   }
-  std::vector<int64_t> permutation;
+  std::vector<xla::int64_t> permutation;
   xla::XlaOp diag_target = target;
   if (dim1 != 0 || dim2 != 1) {
     permutation = GetDiagonalPermutation(target_shape->rank(), dim1, dim2);

--- a/torch_xla/csrc/matrix.h
+++ b/torch_xla/csrc/matrix.h
@@ -4,15 +4,16 @@
 
 namespace torch_xla {
 
-xla::XlaOp BuildTriu(xla::XlaOp input, int64_t diagonal);
+xla::XlaOp BuildTriu(xla::XlaOp input, xla::int64_t diagonal);
 
-xla::XlaOp BuildTril(xla::XlaOp input, int64_t diagonal);
+xla::XlaOp BuildTril(xla::XlaOp input, xla::int64_t diagonal);
 
-xla::XlaOp BuildDiagonal(xla::XlaOp input, int64_t offset, int64_t dim1,
-                         int64_t dim2);
+xla::XlaOp BuildDiagonal(xla::XlaOp input, xla::int64_t offset,
+                         xla::int64_t dim1, xla::int64_t dim2);
 
 xla::XlaOp BuildDiagonalViewUpdate(xla::XlaOp target, xla::XlaOp input,
-                                   int64_t offset, int64_t dim1, int64_t dim2);
+                                   xla::int64_t offset, xla::int64_t dim1,
+                                   xla::int64_t dim2);
 
 xla::XlaOp BuildInverse(xla::XlaOp input);
 

--- a/torch_xla/csrc/nll_loss.cpp
+++ b/torch_xla/csrc/nll_loss.cpp
@@ -18,21 +18,21 @@ struct WeightScale {
 // Build a iota tensor populated with values 0 through depth - 1, with the
 // exception of ignore_index which is set to -1 (if between 0 and depth - 1).
 // This allows the ignored index to be ignored by the one-hot conversion.
-xla::XlaOp OneHotIota(xla::XlaBuilder* builder, int64_t depth, int axis,
+xla::XlaOp OneHotIota(xla::XlaBuilder* builder, xla::int64_t depth, int axis,
                       const xla::Shape& indices_shape, int ignore_index) {
   int indices_dims = indices_shape.rank();
-  std::vector<int64_t> linspace_dims(indices_dims + 1, 1);
+  std::vector<xla::int64_t> linspace_dims(indices_dims + 1, 1);
   linspace_dims[axis] = depth;
   xla::Shape linspace_xla_shape =
       xla::ShapeUtil::MakeShape(indices_shape.element_type(), linspace_dims);
   xla::XlaOp iota = xla::Iota(builder, linspace_xla_shape, axis);
   if (ignore_index >= 0 && ignore_index < depth) {
     xla::XlaOp ignore_index_op =
-        xla::Broadcast(XlaHelpers::ScalarValue<int64_t>(
+        xla::Broadcast(XlaHelpers::ScalarValue<xla::int64_t>(
                            ignore_index, indices_shape.element_type(), builder),
                        linspace_dims);
     xla::XlaOp invalid_index =
-        xla::Broadcast(XlaHelpers::ScalarValue<int64_t>(
+        xla::Broadcast(XlaHelpers::ScalarValue<xla::int64_t>(
                            -1, indices_shape.element_type(), builder),
                        linspace_dims);
     iota = xla::Select(xla::Eq(iota, ignore_index_op), invalid_index, iota);
@@ -45,14 +45,14 @@ xla::XlaOp OneHotIota(xla::XlaBuilder* builder, int64_t depth, int axis,
 // "on_value" and "off_value" represent the values to use for the on and off
 // positions, respectively. If "ignore_index" is a valid class, it'll be
 // considered off.
-xla::XlaOp LabelsToOneHot(xla::XlaBuilder* builder, int64_t depth, int axis,
-                          xla::XlaOp indices, xla::XlaOp on_value,
+xla::XlaOp LabelsToOneHot(xla::XlaBuilder* builder, xla::int64_t depth,
+                          int axis, xla::XlaOp indices, xla::XlaOp on_value,
                           xla::XlaOp off_value, int ignore_index) {
   const xla::Shape& indices_shape = XlaHelpers::ShapeOfXlaOp(indices);
 
   // Expand the labels with a depth dimension for the classes.
-  std::vector<int64_t> output_dimensions(indices_shape.dimensions().begin(),
-                                         indices_shape.dimensions().end());
+  std::vector<xla::int64_t> output_dimensions(
+      indices_shape.dimensions().begin(), indices_shape.dimensions().end());
   output_dimensions.insert(output_dimensions.begin() + axis, depth);
 
   xla::XlaOp iota = OneHotIota(/*builder=*/builder, /*depth=*/depth,
@@ -61,7 +61,7 @@ xla::XlaOp LabelsToOneHot(xla::XlaBuilder* builder, int64_t depth, int axis,
 
   // Now compare the labels in index form to the iota tensor to get the one hot
   // format.
-  std::vector<int64_t> broadcast_dims(indices_shape.rank());
+  std::vector<xla::int64_t> broadcast_dims(indices_shape.rank());
   std::iota(broadcast_dims.begin(), broadcast_dims.begin() + axis, 0);
   std::iota(broadcast_dims.begin() + axis, broadcast_dims.end(), axis + 1);
   xla::XlaOp one_hot_bool = xla::Eq(indices, iota, broadcast_dims);
@@ -76,7 +76,7 @@ WeightScale GetMaskedWeight(xla::XlaOp weight, const xla::Shape& logits_shape,
                             int axis, int ignore_index, bool non_zero_scale) {
   const xla::Shape& labels_shape = XlaHelpers::ShapeOfXlaOp(labels);
   xla::XlaOp valid_bitmap = xla::Ne(
-      labels, XlaHelpers::ScalarValue<int64_t>(
+      labels, XlaHelpers::ScalarValue<xla::int64_t>(
                   ignore_index, labels_shape.element_type(), labels.builder()));
   xla::XlaOp xweight;
   if (!weight.IsUninitialized()) {
@@ -87,7 +87,7 @@ WeightScale GetMaskedWeight(xla::XlaOp weight, const xla::Shape& logits_shape,
   }
   xla::XlaOp zeros =
       XlaHelpers::ScalarBroadcast<float>(0.0, logits_shape, labels.builder());
-  std::vector<int64_t> broadcast_dims(labels_shape.rank());
+  std::vector<xla::int64_t> broadcast_dims(labels_shape.rank());
   std::iota(broadcast_dims.begin(), broadcast_dims.begin() + axis, 0);
   std::iota(broadcast_dims.begin() + axis, broadcast_dims.end(), axis + 1);
   xla::XlaOp xvalid_bitmap = xla::BroadcastInDim(

--- a/torch_xla/csrc/nms_op.cpp
+++ b/torch_xla/csrc/nms_op.cpp
@@ -19,22 +19,22 @@ namespace torch_xla {
 namespace {
 
 struct WhileCondFn {
-  WhileCondFn(int64_t num_boxes, int64_t output_size)
+  WhileCondFn(xla::int64_t num_boxes, xla::int64_t output_size)
       : num_boxes(num_boxes), output_size(output_size) {}
 
   xla::StatusOr<xla::XlaOp> operator()(absl::Span<const xla::XlaOp> values,
                                        xla::XlaBuilder* builder) const {
     xla::XlaOp row_idx = values[0];
     xla::XlaOp row_in_bounds =
-        xla::Lt(row_idx, xla::ConstantR0<int32_t>(builder, num_boxes));
+        xla::Lt(row_idx, xla::ConstantR0<xla::int32>(builder, num_boxes));
     xla::XlaOp num_outputs_so_far = values[1];
     xla::XlaOp results_not_full = xla::Lt(
-        num_outputs_so_far, xla::ConstantR0<int32_t>(builder, output_size));
+        num_outputs_so_far, xla::ConstantR0<xla::int32>(builder, output_size));
     return xla::And(row_in_bounds, results_not_full);
   }
 
-  int64_t num_boxes;
-  int64_t output_size;
+  xla::int64_t num_boxes;
+  xla::int64_t output_size;
 };
 
 // Process the boxes one-by-one using the iou matrix mask.
@@ -42,7 +42,7 @@ struct WhileCondFn {
 // to ensure that suppressed boxes cannot themselves suppress other
 // boxes.
 struct SuppressBodyFn {
-  explicit SuppressBodyFn(int64_t num_boxes) : num_boxes(num_boxes) {}
+  explicit SuppressBodyFn(xla::int64_t num_boxes) : num_boxes(num_boxes) {}
 
   xla::StatusOr<std::vector<xla::XlaOp>> operator()(
       absl::Span<const xla::XlaOp> values, xla::XlaBuilder* builder) const {
@@ -82,17 +82,19 @@ struct SuppressBodyFn {
                                    included_iou};
   }
 
-  int64_t num_boxes;
+  xla::int64_t num_boxes;
 };
 
-xla::XlaOp NmsGather(xla::XlaOp input, absl::Span<const int64_t> input_sizes,
+xla::XlaOp NmsGather(xla::XlaOp input,
+                     absl::Span<const xla::int64_t> input_sizes,
                      xla::XlaOp indices,
-                     absl::Span<const int64_t> indices_sizes, int64_t axis) {
+                     absl::Span<const xla::int64_t> indices_sizes,
+                     xla::int64_t axis) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
-  int64_t num_indices = xla::util::Multiply<int64_t>(indices_sizes);
+  xla::int64_t num_indices = xla::util::Multiply<xla::int64_t>(indices_sizes);
   if (num_indices == 0) {
-    std::vector<int64_t> output_sizes =
-        xla::util::ToVector<int64_t>(input_sizes);
+    std::vector<xla::int64_t> output_sizes =
+        xla::util::ToVector<xla::int64_t>(input_sizes);
     output_sizes.erase(std::next(output_sizes.begin(), axis));
     return xla::Broadcast(
         xla::Zero(input.builder(), input_shape.element_type()), output_sizes);
@@ -123,9 +125,9 @@ xla::XlaOp NmsGather(xla::XlaOp input, absl::Span<const int64_t> input_sizes,
   //       index_vector_dim=0,
   //       slice_sizes={1,1,2}
   xla::GatherDimensionNumbers dim_numbers;
-  std::vector<int64_t> slice_sizes;
-  for (int64_t i = 0; i < input_sizes.size(); ++i) {
-    int64_t window_bound;
+  std::vector<xla::int64_t> slice_sizes;
+  for (xla::int64_t i = 0; i < input_sizes.size(); ++i) {
+    xla::int64_t window_bound;
     if (i == axis) {
       dim_numbers.add_collapsed_slice_dims(i);
       window_bound = 1;
@@ -148,17 +150,17 @@ xla::XlaOp NmsGather(xla::XlaOp input, absl::Span<const int64_t> input_sizes,
 
 NmsResult BuildNms(xla::XlaOp boxes, xla::XlaOp scores,
                    xla::XlaOp score_threshold, xla::XlaOp iou_threshold,
-                   int64_t output_size) {
+                   xla::int64_t output_size) {
   const xla::Shape& boxes_shape = XlaHelpers::ShapeOfXlaOp(boxes);
-  int64_t num_boxes = boxes_shape.dimensions(0);
+  xla::int64_t num_boxes = boxes_shape.dimensions(0);
   const xla::Shape& scores_shape = XlaHelpers::ShapeOfXlaOp(scores);
   XLA_CHECK_EQ(boxes_shape.rank(), 2);
   XLA_CHECK_EQ(boxes_shape.dimensions(1), 4);
   XLA_CHECK_EQ(scores_shape.rank(), 1);
   XLA_CHECK_EQ(scores_shape.dimensions(0), num_boxes);
-  XLA_CHECK_LT(num_boxes, std::numeric_limits<int32_t>::max());
+  XLA_CHECK_LT(num_boxes, std::numeric_limits<xla::int32>::max());
   XLA_CHECK_GE(output_size, 0);
-  XLA_CHECK_LT(output_size, std::numeric_limits<int32_t>::max());
+  XLA_CHECK_LT(output_size, std::numeric_limits<xla::int32>::max());
 
   xla::XlaBuilder* builder = boxes.builder();
   // Choose a more convenient layout.
@@ -281,8 +283,8 @@ NmsResult BuildNms(xla::XlaOp boxes, xla::XlaOp scores,
       /*computation=*/
       xla::CreateScalarAddComputation(xla::PrimitiveType::S32, builder),
       /*dimensions_to_reduce=*/{0});
-  xla::XlaOp num_valid =
-      xla::Min(num_valid_total, xla::ConstantR0<int32_t>(builder, output_size));
+  xla::XlaOp num_valid = xla::Min(
+      num_valid_total, xla::ConstantR0<xla::int32>(builder, output_size));
 
   // Re-index into the original scores input tensor, using a Gather.
   // Boxes were suppressed in the sorted domain.

--- a/torch_xla/csrc/nms_op.h
+++ b/torch_xla/csrc/nms_op.h
@@ -11,6 +11,6 @@ struct NmsResult {
 
 NmsResult BuildNms(xla::XlaOp boxes, xla::XlaOp scores,
                    xla::XlaOp score_threshold, xla::XlaOp iou_threshold,
-                   int64_t output_size);
+                   xla::int64_t output_size);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/op_by_op_executor.cpp
+++ b/torch_xla/csrc/op_by_op_executor.cpp
@@ -218,7 +218,7 @@ OpByOpExecutor::AsyncTask OpByOpExecutor::ExecuteAsync(
 }
 
 OpByOpExecutor* OpByOpExecutor::Get() {
-  static const int64_t compile_cache_size =
+  static const xla::int64_t compile_cache_size =
       xla::sys_util::GetEnvInt("SPLIT_EXECUTOR_CACHE_SIZE", 2048);
   static OpByOpExecutor* split_executor =
       new OpByOpExecutor(compile_cache_size);

--- a/torch_xla/csrc/ops/adaptive_avg_pool2d.cpp
+++ b/torch_xla/csrc/ops/adaptive_avg_pool2d.cpp
@@ -11,7 +11,7 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& input,
-                           absl::Span<const int64_t> output_size) {
+                           absl::Span<const xla::int64_t> output_size) {
   auto lower_for_shape_fn =
       [output_size](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     XLA_CHECK_EQ(operands.size(), 1);
@@ -23,7 +23,7 @@ xla::Shape NodeOutputShape(const Value& input,
 }  // namespace
 
 AdaptiveAvgPool2d::AdaptiveAvgPool2d(const Value& input,
-                                     std::vector<int64_t> output_size)
+                                     std::vector<xla::int64_t> output_size)
     : Node(ir::OpKind(at::aten::adaptive_avg_pool2d), {input},
            [&]() { return NodeOutputShape(input, output_size); },
            /*num_outputs=*/1, torch::lazy::MHash(output_size)),

--- a/torch_xla/csrc/ops/adaptive_avg_pool2d.h
+++ b/torch_xla/csrc/ops/adaptive_avg_pool2d.h
@@ -10,7 +10,7 @@ namespace ops {
 
 class AdaptiveAvgPool2d : public Node {
  public:
-  AdaptiveAvgPool2d(const Value& input, std::vector<int64_t> output_size);
+  AdaptiveAvgPool2d(const Value& input, std::vector<xla::int64_t> output_size);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -18,10 +18,10 @@ class AdaptiveAvgPool2d : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& output_size() const { return output_size_; }
+  const std::vector<xla::int64_t>& output_size() const { return output_size_; }
 
  private:
-  std::vector<int64_t> output_size_;
+  std::vector<xla::int64_t> output_size_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/adaptive_avg_pool3d.cpp
+++ b/torch_xla/csrc/ops/adaptive_avg_pool3d.cpp
@@ -11,7 +11,7 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& input,
-                           absl::Span<const int64_t> output_size) {
+                           absl::Span<const xla::int64_t> output_size) {
   auto lower_for_shape_fn =
       [output_size](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     XLA_CHECK_EQ(operands.size(), 1);
@@ -23,7 +23,7 @@ xla::Shape NodeOutputShape(const Value& input,
 }  // namespace
 
 AdaptiveAvgPool3d::AdaptiveAvgPool3d(const Value& input,
-                                     std::vector<int64_t> output_size)
+                                     std::vector<xla::int64_t> output_size)
     : Node(ir::OpKind(at::aten::adaptive_avg_pool3d), {input},
            [&]() { return NodeOutputShape(input, output_size); },
            /*num_outputs=*/1, torch::lazy::MHash(output_size)),

--- a/torch_xla/csrc/ops/adaptive_avg_pool3d.h
+++ b/torch_xla/csrc/ops/adaptive_avg_pool3d.h
@@ -12,7 +12,7 @@ namespace ops {
 
 class AdaptiveAvgPool3d : public Node {
  public:
-  AdaptiveAvgPool3d(const Value& input, std::vector<int64_t> output_size);
+  AdaptiveAvgPool3d(const Value& input, std::vector<xla::int64_t> output_size);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -20,10 +20,10 @@ class AdaptiveAvgPool3d : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& output_size() const { return output_size_; }
+  const std::vector<xla::int64_t>& output_size() const { return output_size_; }
 
  private:
-  std::vector<int64_t> output_size_;
+  std::vector<xla::int64_t> output_size_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/adaptive_max_pool2d.cpp
+++ b/torch_xla/csrc/ops/adaptive_max_pool2d.cpp
@@ -11,7 +11,7 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& input,
-                           absl::Span<const int64_t> output_size) {
+                           absl::Span<const xla::int64_t> output_size) {
   auto lower_for_shape_fn =
       [output_size](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     XLA_CHECK_EQ(operands.size(), 1);
@@ -24,7 +24,7 @@ xla::Shape NodeOutputShape(const Value& input,
 }  // namespace
 
 AdaptiveMaxPool2d::AdaptiveMaxPool2d(const Value& input,
-                                     std::vector<int64_t> output_size)
+                                     std::vector<xla::int64_t> output_size)
     : Node(ir::OpKind(at::aten::adaptive_max_pool2d), {input},
            [&]() { return NodeOutputShape(input, output_size); },
            /*num_outputs=*/2, torch::lazy::MHash(output_size)),

--- a/torch_xla/csrc/ops/adaptive_max_pool2d.h
+++ b/torch_xla/csrc/ops/adaptive_max_pool2d.h
@@ -10,7 +10,7 @@ namespace ops {
 
 class AdaptiveMaxPool2d : public Node {
  public:
-  AdaptiveMaxPool2d(const Value& input, std::vector<int64_t> output_size);
+  AdaptiveMaxPool2d(const Value& input, std::vector<xla::int64_t> output_size);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -18,10 +18,10 @@ class AdaptiveMaxPool2d : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& output_size() const { return output_size_; }
+  const std::vector<xla::int64_t>& output_size() const { return output_size_; }
 
  private:
-  std::vector<int64_t> output_size_;
+  std::vector<xla::int64_t> output_size_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/all.cpp
+++ b/torch_xla/csrc/ops/all.cpp
@@ -13,7 +13,8 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
+xla::Shape NodeOutputShape(const Value& input,
+                           std::vector<xla::int64_t>& dimensions,
                            bool keep_reduced_dimensions) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
@@ -24,7 +25,7 @@ xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
 
 }  // namespace
 
-All::All(const Value& input, std::vector<int64_t> dimensions,
+All::All(const Value& input, std::vector<xla::int64_t> dimensions,
          bool keep_reduced_dimensions)
     : Node(ir::OpKind(at::aten::all), {input},
            NodeOutputShape(input, dimensions, keep_reduced_dimensions),

--- a/torch_xla/csrc/ops/all.h
+++ b/torch_xla/csrc/ops/all.h
@@ -11,7 +11,7 @@ namespace ops {
 
 class All : public Node {
  public:
-  All(const Value& input, std::vector<int64_t> dimensions,
+  All(const Value& input, std::vector<xla::int64_t> dimensions,
       bool keep_reduced_dimensions);
 
   std::string ToString() const override;
@@ -20,12 +20,12 @@ class All : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  const std::vector<int64_t>& dimensions() const { return dimensions_; }
+  const std::vector<xla::int64_t>& dimensions() const { return dimensions_; }
 
   bool keep_reduced_dimensions() const { return keep_reduced_dimensions_; }
 
  private:
-  std::vector<int64_t> dimensions_;
+  std::vector<xla::int64_t> dimensions_;
   bool keep_reduced_dimensions_;
 };
 

--- a/torch_xla/csrc/ops/all_gather.cpp
+++ b/torch_xla/csrc/ops/all_gather.cpp
@@ -12,9 +12,10 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const Value& input, const Value& token, int64_t dim,
-                           int64_t shard_count,
-                           const std::vector<std::vector<int64_t>>& groups) {
+xla::Shape NodeOutputShape(
+    const Value& input, const Value& token, xla::int64_t dim,
+    xla::int64_t shard_count,
+    const std::vector<std::vector<xla::int64_t>>& groups) {
   auto shape_fn = [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     AllGatherResult result =
         BuildAllGather(operands[0], operands[1], dim, shard_count, groups);
@@ -25,9 +26,9 @@ xla::Shape NodeOutputShape(const Value& input, const Value& token, int64_t dim,
 
 }  // namespace
 
-AllGather::AllGather(const Value& input, const Value& token, int64_t dim,
-                     int64_t shard_count,
-                     std::vector<std::vector<int64_t>> groups)
+AllGather::AllGather(const Value& input, const Value& token, xla::int64_t dim,
+                     xla::int64_t shard_count,
+                     std::vector<std::vector<xla::int64_t>> groups)
     : Node(xla_all_gather, {input, token},
            [&]() {
              return NodeOutputShape(input, token, dim, shard_count, groups);

--- a/torch_xla/csrc/ops/all_gather.h
+++ b/torch_xla/csrc/ops/all_gather.h
@@ -9,8 +9,9 @@ namespace ops {
 
 class AllGather : public Node {
  public:
-  AllGather(const Value& input, const Value& token, int64_t dim,
-            int64_t shard_count, std::vector<std::vector<int64_t>> groups);
+  AllGather(const Value& input, const Value& token, xla::int64_t dim,
+            xla::int64_t shard_count,
+            std::vector<std::vector<xla::int64_t>> groups);
 
   std::string ToString() const override;
 
@@ -18,16 +19,18 @@ class AllGather : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  int64_t dim() const { return dim_; }
+  xla::int64_t dim() const { return dim_; }
 
-  int64_t shard_count() const { return shard_count_; }
+  xla::int64_t shard_count() const { return shard_count_; }
 
-  const std::vector<std::vector<int64_t>>& groups() const { return groups_; }
+  const std::vector<std::vector<xla::int64_t>>& groups() const {
+    return groups_;
+  }
 
  private:
-  int64_t dim_;
-  int64_t shard_count_;
-  std::vector<std::vector<int64_t>> groups_;
+  xla::int64_t dim_;
+  xla::int64_t shard_count_;
+  std::vector<std::vector<xla::int64_t>> groups_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/all_reduce.cpp
+++ b/torch_xla/csrc/ops/all_reduce.cpp
@@ -33,7 +33,8 @@ std::vector<Value> GetOperandList(absl::Span<const Value> operands,
 
 AllReduce::AllReduce(AllReduceType reduce_type,
                      absl::Span<const Value> operands, const Value& token,
-                     double scale, std::vector<std::vector<int64_t>> groups)
+                     double scale,
+                     std::vector<std::vector<xla::int64_t>> groups)
     : Node(xla_cross_replica_sum, GetOperandList(operands, token),
            [&]() { return NodeOutputShape(operands, token); },
            /*num_outputs=*/operands.size() + 1,

--- a/torch_xla/csrc/ops/all_reduce.h
+++ b/torch_xla/csrc/ops/all_reduce.h
@@ -11,7 +11,7 @@ class AllReduce : public Node {
  public:
   AllReduce(AllReduceType reduce_type, absl::Span<const Value> operands,
             const Value& token, double scale,
-            std::vector<std::vector<int64_t>> groups);
+            std::vector<std::vector<xla::int64_t>> groups);
 
   std::string ToString() const override;
 
@@ -23,12 +23,14 @@ class AllReduce : public Node {
 
   double scale() const { return scale_; }
 
-  const std::vector<std::vector<int64_t>>& groups() const { return groups_; }
+  const std::vector<std::vector<xla::int64_t>>& groups() const {
+    return groups_;
+  }
 
  private:
   AllReduceType reduce_type_;
   double scale_;
-  std::vector<std::vector<int64_t>> groups_;
+  std::vector<std::vector<xla::int64_t>> groups_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/all_to_all.cpp
+++ b/torch_xla/csrc/ops/all_to_all.cpp
@@ -11,10 +11,10 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const Value& input, const Value& token,
-                           int64_t split_dimension, int64_t concat_dimension,
-                           int64_t split_count,
-                           const std::vector<std::vector<int64_t>>& groups) {
+xla::Shape NodeOutputShape(
+    const Value& input, const Value& token, xla::int64_t split_dimension,
+    xla::int64_t concat_dimension, xla::int64_t split_count,
+    const std::vector<std::vector<xla::int64_t>>& groups) {
   auto shape_fn = [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     AllToAllResult result =
         BuildAllToAll(operands[0], operands[1], split_dimension,
@@ -27,9 +27,9 @@ xla::Shape NodeOutputShape(const Value& input, const Value& token,
 }  // namespace
 
 AllToAll::AllToAll(const Value& input, const Value& token,
-                   int64_t split_dimension, int64_t concat_dimension,
-                   int64_t split_count,
-                   std::vector<std::vector<int64_t>> groups)
+                   xla::int64_t split_dimension, xla::int64_t concat_dimension,
+                   xla::int64_t split_count,
+                   std::vector<std::vector<xla::int64_t>> groups)
     : Node(xla_all_to_all, {input, token},
            [&]() {
              return NodeOutputShape(input, token, split_dimension,

--- a/torch_xla/csrc/ops/all_to_all.h
+++ b/torch_xla/csrc/ops/all_to_all.h
@@ -9,9 +9,9 @@ namespace ops {
 
 class AllToAll : public Node {
  public:
-  AllToAll(const Value& input, const Value& token, int64_t split_dimension,
-           int64_t concat_dimension, int64_t split_count,
-           std::vector<std::vector<int64_t>> groups);
+  AllToAll(const Value& input, const Value& token, xla::int64_t split_dimension,
+           xla::int64_t concat_dimension, xla::int64_t split_count,
+           std::vector<std::vector<xla::int64_t>> groups);
 
   std::string ToString() const override;
 
@@ -19,19 +19,21 @@ class AllToAll : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  int64_t split_dimension() const { return split_dimension_; }
+  xla::int64_t split_dimension() const { return split_dimension_; }
 
-  int64_t concat_dimension() const { return concat_dimension_; }
+  xla::int64_t concat_dimension() const { return concat_dimension_; }
 
-  int64_t split_count() const { return split_count_; }
+  xla::int64_t split_count() const { return split_count_; }
 
-  const std::vector<std::vector<int64_t>>& groups() const { return groups_; }
+  const std::vector<std::vector<xla::int64_t>>& groups() const {
+    return groups_;
+  }
 
  private:
-  int64_t split_dimension_;
-  int64_t concat_dimension_;
-  int64_t split_count_;
-  std::vector<std::vector<int64_t>> groups_;
+  xla::int64_t split_dimension_;
+  xla::int64_t concat_dimension_;
+  xla::int64_t split_count_;
+  std::vector<std::vector<xla::int64_t>> groups_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/amax.cpp
+++ b/torch_xla/csrc/ops/amax.cpp
@@ -9,7 +9,8 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
+xla::Shape NodeOutputShape(const Value& input,
+                           std::vector<xla::int64_t>& dimensions,
                            bool keepdim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
@@ -20,7 +21,8 @@ xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
 
 }  // namespace
 
-Amax::Amax(const Value& input, std::vector<int64_t> dimensions, bool keepdim)
+Amax::Amax(const Value& input, std::vector<xla::int64_t> dimensions,
+           bool keepdim)
     : Node(ir::OpKind(at::aten::amax), {input},
            [&]() { return NodeOutputShape(input, dimensions, keepdim); },
            /*num_outputs=*/1, torch::lazy::MHash(dimensions, keepdim)),

--- a/torch_xla/csrc/ops/amax.h
+++ b/torch_xla/csrc/ops/amax.h
@@ -8,7 +8,7 @@ namespace ops {
 
 class Amax : public Node {
  public:
-  Amax(const Value& input, std::vector<int64_t> dimensions, bool keepdim);
+  Amax(const Value& input, std::vector<xla::int64_t> dimensions, bool keepdim);
 
   std::string ToString() const override;
 
@@ -16,12 +16,12 @@ class Amax : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  std::vector<int64_t> dim() const { return dimensions_; };
+  std::vector<xla::int64_t> dim() const { return dimensions_; };
 
   bool keepdim() const { return keepdim_; }
 
  private:
-  std::vector<int64_t> dimensions_;
+  std::vector<xla::int64_t> dimensions_;
   bool keepdim_;
 };
 

--- a/torch_xla/csrc/ops/amin.cpp
+++ b/torch_xla/csrc/ops/amin.cpp
@@ -9,7 +9,8 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
+xla::Shape NodeOutputShape(const Value& input,
+                           std::vector<xla::int64_t>& dimensions,
                            bool keepdim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
@@ -20,7 +21,8 @@ xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
 
 }  // namespace
 
-Amin::Amin(const Value& input, std::vector<int64_t> dimensions, bool keepdim)
+Amin::Amin(const Value& input, std::vector<xla::int64_t> dimensions,
+           bool keepdim)
     : Node(ir::OpKind(at::aten::amin), {input},
            [&]() { return NodeOutputShape(input, dimensions, keepdim); },
            /*num_outputs=*/1, torch::lazy::MHash(dimensions, keepdim)),

--- a/torch_xla/csrc/ops/amin.h
+++ b/torch_xla/csrc/ops/amin.h
@@ -8,7 +8,7 @@ namespace ops {
 
 class Amin : public Node {
  public:
-  Amin(const Value& input, std::vector<int64_t> dimensions, bool keepdim);
+  Amin(const Value& input, std::vector<xla::int64_t> dimensions, bool keepdim);
 
   std::string ToString() const override;
 
@@ -16,12 +16,12 @@ class Amin : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  std::vector<int64_t> dim() const { return dimensions_; };
+  std::vector<xla::int64_t> dim() const { return dimensions_; };
 
   bool keepdim() const { return keepdim_; }
 
  private:
-  std::vector<int64_t> dimensions_;
+  std::vector<xla::int64_t> dimensions_;
   bool keepdim_;
 };
 

--- a/torch_xla/csrc/ops/any.cpp
+++ b/torch_xla/csrc/ops/any.cpp
@@ -13,7 +13,8 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
+xla::Shape NodeOutputShape(const Value& input,
+                           std::vector<xla::int64_t>& dimensions,
                            bool keep_reduced_dimensions) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
@@ -24,7 +25,7 @@ xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
 
 }  // namespace
 
-Any::Any(const Value& input, std::vector<int64_t> dimensions,
+Any::Any(const Value& input, std::vector<xla::int64_t> dimensions,
          bool keep_reduced_dimensions)
     : Node(ir::OpKind(at::aten::any), {input},
            NodeOutputShape(input, dimensions, keep_reduced_dimensions),

--- a/torch_xla/csrc/ops/any.h
+++ b/torch_xla/csrc/ops/any.h
@@ -11,7 +11,7 @@ namespace ops {
 
 class Any : public Node {
  public:
-  Any(const Value& input, std::vector<int64_t> dimensions,
+  Any(const Value& input, std::vector<xla::int64_t> dimensions,
       bool keep_reduced_dimensions);
 
   std::string ToString() const override;
@@ -20,12 +20,12 @@ class Any : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  const std::vector<int64_t>& dimensions() const { return dimensions_; }
+  const std::vector<xla::int64_t>& dimensions() const { return dimensions_; }
 
   bool keep_reduced_dimensions() const { return keep_reduced_dimensions_; }
 
  private:
-  std::vector<int64_t> dimensions_;
+  std::vector<xla::int64_t> dimensions_;
   bool keep_reduced_dimensions_;
 };
 

--- a/torch_xla/csrc/ops/arg_max.cpp
+++ b/torch_xla/csrc/ops/arg_max.cpp
@@ -9,7 +9,7 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const Value& input, int64_t dim, bool keepdim) {
+xla::Shape NodeOutputShape(const Value& input, xla::int64_t dim, bool keepdim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildArgMax(operands[0], dim, keepdim);
@@ -19,7 +19,7 @@ xla::Shape NodeOutputShape(const Value& input, int64_t dim, bool keepdim) {
 
 }  // namespace
 
-ArgMax::ArgMax(const Value& input, int64_t dim, bool keepdim)
+ArgMax::ArgMax(const Value& input, xla::int64_t dim, bool keepdim)
     : Node(ir::OpKind(at::aten::argmax), {input},
            [&]() { return NodeOutputShape(input, dim, keepdim); },
            /*num_outputs=*/1, torch::lazy::MHash(dim, keepdim)),

--- a/torch_xla/csrc/ops/arg_max.h
+++ b/torch_xla/csrc/ops/arg_max.h
@@ -8,7 +8,7 @@ namespace ops {
 
 class ArgMax : public Node {
  public:
-  ArgMax(const Value& input, int64_t dim, bool keepdim);
+  ArgMax(const Value& input, xla::int64_t dim, bool keepdim);
 
   std::string ToString() const override;
 
@@ -16,12 +16,12 @@ class ArgMax : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  int64_t dim() const { return dim_; };
+  xla::int64_t dim() const { return dim_; };
 
   bool keepdim() const { return keepdim_; }
 
  private:
-  int64_t dim_;
+  xla::int64_t dim_;
   bool keepdim_;
 };
 

--- a/torch_xla/csrc/ops/arg_min.cpp
+++ b/torch_xla/csrc/ops/arg_min.cpp
@@ -9,7 +9,7 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const Value& input, int64_t dim, bool keepdim) {
+xla::Shape NodeOutputShape(const Value& input, xla::int64_t dim, bool keepdim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildArgMin(operands[0], dim, keepdim);
@@ -19,7 +19,7 @@ xla::Shape NodeOutputShape(const Value& input, int64_t dim, bool keepdim) {
 
 }  // namespace
 
-ArgMin::ArgMin(const Value& input, int64_t dim, bool keepdim)
+ArgMin::ArgMin(const Value& input, xla::int64_t dim, bool keepdim)
     : Node(ir::OpKind(at::aten::argmin), {input},
            [&]() { return NodeOutputShape(input, dim, keepdim); },
            /*num_outputs=*/1, torch::lazy::MHash(dim, keepdim)),

--- a/torch_xla/csrc/ops/arg_min.h
+++ b/torch_xla/csrc/ops/arg_min.h
@@ -8,7 +8,7 @@ namespace ops {
 
 class ArgMin : public Node {
  public:
-  ArgMin(const Value& input, int64_t dim, bool keepdim);
+  ArgMin(const Value& input, xla::int64_t dim, bool keepdim);
 
   std::string ToString() const override;
 
@@ -16,12 +16,12 @@ class ArgMin : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  int64_t dim() const { return dim_; };
+  xla::int64_t dim() const { return dim_; };
 
   bool keepdim() const { return keepdim_; }
 
  private:
-  int64_t dim_;
+  xla::int64_t dim_;
   bool keepdim_;
 };
 

--- a/torch_xla/csrc/ops/as_strided.cpp
+++ b/torch_xla/csrc/ops/as_strided.cpp
@@ -16,12 +16,12 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::XlaOp LowerAsStrided(xla::XlaOp input, absl::Span<const int64_t> size,
-                          absl::Span<const int64_t> stride,
-                          int64_t storage_offset) {
+xla::XlaOp LowerAsStrided(xla::XlaOp input, absl::Span<const xla::int64_t> size,
+                          absl::Span<const xla::int64_t> stride,
+                          xla::int64_t storage_offset) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
-  int64_t input_element_count = xla::ShapeUtil::ElementsIn(input_shape);
-  int64_t slice_size = xla::util::Multiply<int64_t>(size);
+  xla::int64_t input_element_count = xla::ShapeUtil::ElementsIn(input_shape);
+  xla::int64_t slice_size = xla::util::Multiply<xla::int64_t>(size);
   XLA_CHECK_LE(storage_offset + slice_size, input_element_count);
 
   xla::XlaOp off_input = input;
@@ -31,9 +31,9 @@ xla::XlaOp LowerAsStrided(xla::XlaOp input, absl::Span<const int64_t> size,
                                 storage_offset + slice_size, 1, 0);
   }
 
-  std::vector<int64_t> permutation = xla::InversePermutation(
+  std::vector<xla::int64_t> permutation = xla::InversePermutation(
       AsStrided::GetArrayStridePermutation(stride, size));
-  std::vector<int64_t> new_sizes = xla::PermuteInverse(size, permutation);
+  std::vector<xla::int64_t> new_sizes = xla::PermuteInverse(size, permutation);
   xla::XlaOp reshaped_input = XlaHelpers::DynamicReshape(off_input, new_sizes);
   return xla::IsIdentityPermutation(permutation)
              ? reshaped_input
@@ -42,8 +42,9 @@ xla::XlaOp LowerAsStrided(xla::XlaOp input, absl::Span<const int64_t> size,
 
 }  // namespace
 
-AsStrided::AsStrided(const Value& input, std::vector<int64_t> size,
-                     std::vector<int64_t> stride, int64_t storage_offset)
+AsStrided::AsStrided(const Value& input, std::vector<xla::int64_t> size,
+                     std::vector<xla::int64_t> stride,
+                     xla::int64_t storage_offset)
     : Node(ir::OpKind(at::aten::as_strided), {input},
            [&]() {
              return xla::ShapeUtil::MakeShape(input.shape().element_type(),
@@ -73,19 +74,22 @@ XlaOpVector AsStrided::Lower(LoweringContext* loctx) const {
 }
 
 bool AsStrided::StrideIsSupported(const xla::Shape& input_shape,
-                                  absl::Span<const int64_t> size,
-                                  absl::Span<const int64_t> stride,
-                                  int64_t storage_offset) {
-  std::vector<int64_t> sorted_stride(stride.begin(), stride.end());
+                                  absl::Span<const xla::int64_t> size,
+                                  absl::Span<const xla::int64_t> stride,
+                                  xla::int64_t storage_offset) {
+  std::vector<xla::int64_t> sorted_stride(stride.begin(), stride.end());
   std::sort(sorted_stride.begin(), sorted_stride.end());
   return stride.empty() || sorted_stride.front() == 1;
 }
 
-std::vector<int64_t> AsStrided::GetArrayStridePermutation(
-    absl::Span<const int64_t> stride, absl::Span<const int64_t> size) {
-  std::vector<int64_t> permutation = xla::util::Iota<int64_t>(stride.size());
-  std::sort(permutation.begin(), permutation.end(),
-            [&](int64_t a, int64_t b) { return stride[a] > stride[b]; });
+std::vector<xla::int64_t> AsStrided::GetArrayStridePermutation(
+    absl::Span<const xla::int64_t> stride,
+    absl::Span<const xla::int64_t> size) {
+  std::vector<xla::int64_t> permutation =
+      xla::util::Iota<xla::int64_t>(stride.size());
+  std::sort(
+      permutation.begin(), permutation.end(),
+      [&](xla::int64_t a, xla::int64_t b) { return stride[a] > stride[b]; });
   return permutation;
 }
 

--- a/torch_xla/csrc/ops/as_strided.h
+++ b/torch_xla/csrc/ops/as_strided.h
@@ -11,8 +11,8 @@ namespace ops {
 
 class AsStrided : public Node {
  public:
-  AsStrided(const Value& input, std::vector<int64_t> size,
-            std::vector<int64_t> stride, int64_t storage_offset);
+  AsStrided(const Value& input, std::vector<xla::int64_t> size,
+            std::vector<xla::int64_t> stride, xla::int64_t storage_offset);
 
   std::string ToString() const override;
 
@@ -20,24 +20,25 @@ class AsStrided : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  const std::vector<int64_t>& size() const { return size_; }
+  const std::vector<xla::int64_t>& size() const { return size_; }
 
-  const std::vector<int64_t>& stride() const { return stride_; }
+  const std::vector<xla::int64_t>& stride() const { return stride_; }
 
-  int64_t storage_offset() const { return storage_offset_; }
+  xla::int64_t storage_offset() const { return storage_offset_; }
 
   static bool StrideIsSupported(const xla::Shape& input_shape,
-                                absl::Span<const int64_t> size,
-                                absl::Span<const int64_t> stride,
-                                int64_t storage_offset);
+                                absl::Span<const xla::int64_t> size,
+                                absl::Span<const xla::int64_t> stride,
+                                xla::int64_t storage_offset);
 
-  static std::vector<int64_t> GetArrayStridePermutation(
-      absl::Span<const int64_t> stride, absl::Span<const int64_t> size);
+  static std::vector<xla::int64_t> GetArrayStridePermutation(
+      absl::Span<const xla::int64_t> stride,
+      absl::Span<const xla::int64_t> size);
 
  private:
-  std::vector<int64_t> size_;
-  std::vector<int64_t> stride_;
-  int64_t storage_offset_;
+  std::vector<xla::int64_t> size_;
+  std::vector<xla::int64_t> stride_;
+  xla::int64_t storage_offset_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/as_strided_view_update.cpp
+++ b/torch_xla/csrc/ops/as_strided_view_update.cpp
@@ -16,15 +16,15 @@ namespace ops {
 namespace {
 
 xla::XlaOp LowerAsStridedViewUpdate(xla::XlaOp target, xla::XlaOp input,
-                                    absl::Span<const int64_t> size,
-                                    absl::Span<const int64_t> stride,
-                                    int64_t storage_offset) {
+                                    absl::Span<const xla::int64_t> size,
+                                    absl::Span<const xla::int64_t> stride,
+                                    xla::int64_t storage_offset) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
-  int64_t input_element_count = xla::ShapeUtil::ElementsIn(input_shape);
-  int64_t slice_size = xla::util::Multiply<int64_t>(size);
+  xla::int64_t input_element_count = xla::ShapeUtil::ElementsIn(input_shape);
+  xla::int64_t slice_size = xla::util::Multiply<xla::int64_t>(size);
   XLA_CHECK_LE(storage_offset + input_element_count, slice_size);
 
-  std::vector<int64_t> permutation =
+  std::vector<xla::int64_t> permutation =
       AsStrided::GetArrayStridePermutation(stride, input_shape.dimensions());
   xla::XlaOp transposed_input = xla::IsIdentityPermutation(permutation)
                                     ? input
@@ -32,9 +32,10 @@ xla::XlaOp LowerAsStridedViewUpdate(xla::XlaOp target, xla::XlaOp input,
   if (storage_offset > 0 || input_element_count < slice_size) {
     xla::XlaOp r1_input = XlaHelpers::Flatten(transposed_input);
     xla::XlaOp r1_target = XlaHelpers::Flatten(target);
-    transposed_input = xla::DynamicUpdateSlice(
-        r1_target, r1_input,
-        {XlaHelpers::ScalarValue<int64_t>(storage_offset, input.builder())});
+    transposed_input =
+        xla::DynamicUpdateSlice(r1_target, r1_input,
+                                {XlaHelpers::ScalarValue<xla::int64_t>(
+                                    storage_offset, input.builder())});
   }
   return XlaHelpers::DynamicReshape(transposed_input, size);
 }
@@ -43,9 +44,9 @@ xla::XlaOp LowerAsStridedViewUpdate(xla::XlaOp target, xla::XlaOp input,
 
 AsStridedViewUpdate::AsStridedViewUpdate(const Value& target,
                                          const Value& input,
-                                         std::vector<int64_t> size,
-                                         std::vector<int64_t> stride,
-                                         int64_t storage_offset)
+                                         std::vector<xla::int64_t> size,
+                                         std::vector<xla::int64_t> stride,
+                                         xla::int64_t storage_offset)
     : Node(xla_as_strided_view_update, {target, input},
            [&]() {
              return xla::ShapeUtil::MakeShape(target.shape().element_type(),

--- a/torch_xla/csrc/ops/as_strided_view_update.h
+++ b/torch_xla/csrc/ops/as_strided_view_update.h
@@ -12,8 +12,9 @@ namespace ops {
 class AsStridedViewUpdate : public Node {
  public:
   AsStridedViewUpdate(const Value& target, const Value& input,
-                      std::vector<int64_t> size, std::vector<int64_t> stride,
-                      int64_t storage_offset);
+                      std::vector<xla::int64_t> size,
+                      std::vector<xla::int64_t> stride,
+                      xla::int64_t storage_offset);
 
   std::string ToString() const override;
 
@@ -21,16 +22,16 @@ class AsStridedViewUpdate : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  const std::vector<int64_t>& size() const { return size_; }
+  const std::vector<xla::int64_t>& size() const { return size_; }
 
-  const std::vector<int64_t>& stride() const { return stride_; }
+  const std::vector<xla::int64_t>& stride() const { return stride_; }
 
-  int64_t storage_offset() const { return storage_offset_; }
+  xla::int64_t storage_offset() const { return storage_offset_; }
 
  private:
-  std::vector<int64_t> size_;
-  std::vector<int64_t> stride_;
-  int64_t storage_offset_;
+  std::vector<xla::int64_t> size_;
+  std::vector<xla::int64_t> stride_;
+  xla::int64_t storage_offset_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/avg_pool_nd.cpp
+++ b/torch_xla/csrc/ops/avg_pool_nd.cpp
@@ -12,11 +12,11 @@ namespace ops {
 namespace {
 
 // Infers the output shape of the max pooling operation.
-xla::Shape NodeOutputShape(const Value& input, int64_t spatial_dim_count,
-                           absl::Span<const int64_t> kernel_size,
-                           absl::Span<const int64_t> stride,
-                           absl::Span<const int64_t> padding, bool ceil_mode,
-                           bool count_include_pad) {
+xla::Shape NodeOutputShape(const Value& input, xla::int64_t spatial_dim_count,
+                           absl::Span<const xla::int64_t> kernel_size,
+                           absl::Span<const xla::int64_t> stride,
+                           absl::Span<const xla::int64_t> padding,
+                           bool ceil_mode, bool count_include_pad) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     XLA_CHECK_EQ(operands.size(), 1)
@@ -27,7 +27,7 @@ xla::Shape NodeOutputShape(const Value& input, int64_t spatial_dim_count,
   return InferOutputShape({input.shape()}, lower_for_shape_fn);
 }
 
-c10::Symbol AvgPoolNdSymbol(int64_t spatial_dim_count) {
+c10::Symbol AvgPoolNdSymbol(xla::int64_t spatial_dim_count) {
   switch (spatial_dim_count) {
     case 1:
       return at::aten::avg_pool1d;
@@ -43,10 +43,11 @@ c10::Symbol AvgPoolNdSymbol(int64_t spatial_dim_count) {
 
 }  // namespace
 
-AvgPoolNd::AvgPoolNd(const Value& input, int64_t spatial_dim_count,
-                     std::vector<int64_t> kernel_size,
-                     std::vector<int64_t> stride, std::vector<int64_t> padding,
-                     bool ceil_mode, bool count_include_pad)
+AvgPoolNd::AvgPoolNd(const Value& input, xla::int64_t spatial_dim_count,
+                     std::vector<xla::int64_t> kernel_size,
+                     std::vector<xla::int64_t> stride,
+                     std::vector<xla::int64_t> padding, bool ceil_mode,
+                     bool count_include_pad)
     : Node(ir::OpKind(AvgPoolNdSymbol(spatial_dim_count)), {input},
            [&]() {
              return NodeOutputShape(input, spatial_dim_count, kernel_size,

--- a/torch_xla/csrc/ops/avg_pool_nd.h
+++ b/torch_xla/csrc/ops/avg_pool_nd.h
@@ -8,10 +8,10 @@ namespace ops {
 
 class AvgPoolNd : public Node {
  public:
-  AvgPoolNd(const Value& input, int64_t spatial_dim_count,
-            std::vector<int64_t> kernel_size, std::vector<int64_t> stride,
-            std::vector<int64_t> padding, bool ceil_mode,
-            bool count_include_pad);
+  AvgPoolNd(const Value& input, xla::int64_t spatial_dim_count,
+            std::vector<xla::int64_t> kernel_size,
+            std::vector<xla::int64_t> stride, std::vector<xla::int64_t> padding,
+            bool ceil_mode, bool count_include_pad);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -19,24 +19,24 @@ class AvgPoolNd : public Node {
 
   std::string ToString() const override;
 
-  int64_t spatial_dim_count() const { return spatial_dim_count_; }
+  xla::int64_t spatial_dim_count() const { return spatial_dim_count_; }
 
-  const std::vector<int64_t>& kernel_size() const { return kernel_size_; }
+  const std::vector<xla::int64_t>& kernel_size() const { return kernel_size_; }
 
-  const std::vector<int64_t>& stride() const { return stride_; }
+  const std::vector<xla::int64_t>& stride() const { return stride_; }
 
-  const std::vector<int64_t>& padding() const { return padding_; }
+  const std::vector<xla::int64_t>& padding() const { return padding_; }
 
   bool ceil_mode() const { return ceil_mode_; }
 
   bool count_include_pad() const { return count_include_pad_; }
 
  private:
-  int64_t spatial_dim_count_;
+  xla::int64_t spatial_dim_count_;
   // The parameters of the pooling.
-  std::vector<int64_t> kernel_size_;
-  std::vector<int64_t> stride_;
-  std::vector<int64_t> padding_;
+  std::vector<xla::int64_t> kernel_size_;
+  std::vector<xla::int64_t> stride_;
+  std::vector<xla::int64_t> padding_;
   bool ceil_mode_;
   // Whether the counts used to compute the average should include the added
   // padding.

--- a/torch_xla/csrc/ops/avg_pool_nd_backward.cpp
+++ b/torch_xla/csrc/ops/avg_pool_nd_backward.cpp
@@ -11,11 +11,11 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& grad_output, const Value& input,
-                           int64_t spatial_dim_count,
-                           absl::Span<const int64_t> kernel_size,
-                           absl::Span<const int64_t> stride,
-                           absl::Span<const int64_t> padding, bool ceil_mode,
-                           bool count_include_pad) {
+                           xla::int64_t spatial_dim_count,
+                           absl::Span<const xla::int64_t> kernel_size,
+                           absl::Span<const xla::int64_t> stride,
+                           absl::Span<const xla::int64_t> padding,
+                           bool ceil_mode, bool count_include_pad) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     XLA_CHECK_EQ(operands.size(), 2)
@@ -29,7 +29,7 @@ xla::Shape NodeOutputShape(const Value& grad_output, const Value& input,
                           lower_for_shape_fn);
 }
 
-c10::Symbol AvgNdBackwardSymbol(int64_t spatial_dim_count) {
+c10::Symbol AvgNdBackwardSymbol(xla::int64_t spatial_dim_count) {
   switch (spatial_dim_count) {
     case 2:
       return at::aten::avg_pool2d_backward;
@@ -43,10 +43,13 @@ c10::Symbol AvgNdBackwardSymbol(int64_t spatial_dim_count) {
 
 }  // namespace
 
-AvgPoolNdBackward::AvgPoolNdBackward(
-    const Value& grad_output, const Value& input, int64_t spatial_dim_count,
-    std::vector<int64_t> kernel_size, std::vector<int64_t> stride,
-    std::vector<int64_t> padding, bool ceil_mode, bool count_include_pad)
+AvgPoolNdBackward::AvgPoolNdBackward(const Value& grad_output,
+                                     const Value& input,
+                                     xla::int64_t spatial_dim_count,
+                                     std::vector<xla::int64_t> kernel_size,
+                                     std::vector<xla::int64_t> stride,
+                                     std::vector<xla::int64_t> padding,
+                                     bool ceil_mode, bool count_include_pad)
     : Node(OpKind(AvgNdBackwardSymbol(spatial_dim_count)), {grad_output, input},
            [&]() {
              return NodeOutputShape(grad_output, input, spatial_dim_count,

--- a/torch_xla/csrc/ops/avg_pool_nd_backward.h
+++ b/torch_xla/csrc/ops/avg_pool_nd_backward.h
@@ -9,9 +9,11 @@ namespace ops {
 class AvgPoolNdBackward : public Node {
  public:
   AvgPoolNdBackward(const Value& grad_output, const Value& input,
-                    int64_t spatial_dim_count, std::vector<int64_t> kernel_size,
-                    std::vector<int64_t> stride, std::vector<int64_t> padding,
-                    bool ceil_mode, bool count_include_pad);
+                    xla::int64_t spatial_dim_count,
+                    std::vector<xla::int64_t> kernel_size,
+                    std::vector<xla::int64_t> stride,
+                    std::vector<xla::int64_t> padding, bool ceil_mode,
+                    bool count_include_pad);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -19,24 +21,24 @@ class AvgPoolNdBackward : public Node {
 
   std::string ToString() const override;
 
-  int64_t spatial_dim_count() const { return spatial_dim_count_; }
+  xla::int64_t spatial_dim_count() const { return spatial_dim_count_; }
 
-  const std::vector<int64_t>& kernel_size() const { return kernel_size_; }
+  const std::vector<xla::int64_t>& kernel_size() const { return kernel_size_; }
 
-  const std::vector<int64_t>& stride() const { return stride_; }
+  const std::vector<xla::int64_t>& stride() const { return stride_; }
 
-  const std::vector<int64_t>& padding() const { return padding_; }
+  const std::vector<xla::int64_t>& padding() const { return padding_; }
 
   bool ceil_mode() const { return ceil_mode_; }
 
   bool count_include_pad() const { return count_include_pad_; }
 
  private:
-  int64_t spatial_dim_count_;
+  xla::int64_t spatial_dim_count_;
   // The parameters of the pooling.
-  std::vector<int64_t> kernel_size_;
-  std::vector<int64_t> stride_;
-  std::vector<int64_t> padding_;
+  std::vector<xla::int64_t> kernel_size_;
+  std::vector<xla::int64_t> stride_;
+  std::vector<xla::int64_t> padding_;
   bool ceil_mode_;
   // Whether the counts used to compute the average should include the added
   // padding.

--- a/torch_xla/csrc/ops/cat.cpp
+++ b/torch_xla/csrc/ops/cat.cpp
@@ -10,7 +10,8 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(absl::Span<const ir::Value> values, int64_t dim) {
+xla::Shape NodeOutputShape(absl::Span<const ir::Value> values,
+                           xla::int64_t dim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildCat(operands, dim);
@@ -25,7 +26,7 @@ xla::Shape NodeOutputShape(absl::Span<const ir::Value> values, int64_t dim) {
 
 }  // namespace
 
-Cat::Cat(absl::Span<const ir::Value> values, int64_t dim)
+Cat::Cat(absl::Span<const ir::Value> values, xla::int64_t dim)
     : Node(ir::OpKind(at::aten::cat), values,
            [&]() { return NodeOutputShape(values, dim); },
            /*num_outputs=*/1, torch::lazy::MHash(dim)),

--- a/torch_xla/csrc/ops/cat.h
+++ b/torch_xla/csrc/ops/cat.h
@@ -9,7 +9,7 @@ namespace ops {
 
 class Cat : public Node {
  public:
-  Cat(absl::Span<const ir::Value> values, int64_t dim);
+  Cat(absl::Span<const ir::Value> values, xla::int64_t dim);
 
   std::string ToString() const override;
 
@@ -17,10 +17,10 @@ class Cat : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  int64_t dim() const { return dim_; };
+  xla::int64_t dim() const { return dim_; };
 
  private:
-  int64_t dim_;
+  xla::int64_t dim_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/collective_permute.cpp
+++ b/torch_xla/csrc/ops/collective_permute.cpp
@@ -13,7 +13,8 @@ namespace {
 
 xla::Shape NodeOutputShape(
     const Value& input, const Value& token,
-    const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs) {
+    const std::vector<std::pair<xla::int64_t, xla::int64_t>>&
+        source_target_pairs) {
   auto shape_fn = [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     CollectivePermuteResult result =
         BuildCollectivePermute(operands[0], operands[1], source_target_pairs);
@@ -26,7 +27,7 @@ xla::Shape NodeOutputShape(
 
 CollectivePermute::CollectivePermute(
     const Value& input, const Value& token,
-    std::vector<std::pair<int64_t, int64_t>> source_target_pairs)
+    std::vector<std::pair<xla::int64_t, xla::int64_t>> source_target_pairs)
     : Node(xla_collective_permute, {input, token},
            [&]() { return NodeOutputShape(input, token, source_target_pairs); },
            /*num_outputs=*/2, torch::lazy::MHash(source_target_pairs)),

--- a/torch_xla/csrc/ops/collective_permute.h
+++ b/torch_xla/csrc/ops/collective_permute.h
@@ -11,7 +11,7 @@ class CollectivePermute : public Node {
  public:
   CollectivePermute(
       const Value& input, const Value& token,
-      std::vector<std::pair<int64_t, int64_t>> source_target_pairs);
+      std::vector<std::pair<xla::int64_t, xla::int64_t>> source_target_pairs);
 
   std::string ToString() const override;
 
@@ -19,12 +19,13 @@ class CollectivePermute : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs() const {
+  const std::vector<std::pair<xla::int64_t, xla::int64_t>>&
+  source_target_pairs() const {
     return source_target_pairs_;
   }
 
  private:
-  std::vector<std::pair<int64_t, int64_t>> source_target_pairs_;
+  std::vector<std::pair<xla::int64_t, xla::int64_t>> source_target_pairs_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/constant_pad_nd.cpp
+++ b/torch_xla/csrc/ops/constant_pad_nd.cpp
@@ -14,7 +14,7 @@ namespace ops {
 namespace {
 
 xla::XlaOp LowerPad(xla::XlaOp input, const at::Scalar& value,
-                    absl::Span<const int64_t> pad) {
+                    absl::Span<const xla::int64_t> pad) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   return xla::Pad(input,
                   XlaHelpers::ScalarValue(value, input_shape.element_type(),
@@ -23,7 +23,7 @@ xla::XlaOp LowerPad(xla::XlaOp input, const at::Scalar& value,
 }
 
 xla::Shape NodeOutputShape(const Value& input, const at::Scalar& value,
-                           absl::Span<const int64_t> pad) {
+                           absl::Span<const xla::int64_t> pad) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return LowerPad(operands[0], value, pad);
@@ -33,7 +33,7 @@ xla::Shape NodeOutputShape(const Value& input, const at::Scalar& value,
 
 }  // namespace
 
-ConstantPadNd::ConstantPadNd(const Value& input, std::vector<int64_t> pad,
+ConstantPadNd::ConstantPadNd(const Value& input, std::vector<xla::int64_t> pad,
                              const at::Scalar& value)
     : Node(ir::OpKind(at::aten::constant_pad_nd), {input},
            [&]() { return NodeOutputShape(input, value, pad); },

--- a/torch_xla/csrc/ops/constant_pad_nd.h
+++ b/torch_xla/csrc/ops/constant_pad_nd.h
@@ -10,7 +10,7 @@ namespace ops {
 
 class ConstantPadNd : public Node {
  public:
-  ConstantPadNd(const Value& input, std::vector<int64_t> pad,
+  ConstantPadNd(const Value& input, std::vector<xla::int64_t> pad,
                 const at::Scalar& value);
 
   std::string ToString() const override;
@@ -21,10 +21,10 @@ class ConstantPadNd : public Node {
 
   const at::Scalar& value() const { return value_; }
 
-  const std::vector<int64_t>& pad() const { return pad_; }
+  const std::vector<xla::int64_t>& pad() const { return pad_; }
 
  private:
-  std::vector<int64_t> pad_;
+  std::vector<xla::int64_t> pad_;
   at::Scalar value_;
 };
 

--- a/torch_xla/csrc/ops/convolution_backward_overrideable.cpp
+++ b/torch_xla/csrc/ops/convolution_backward_overrideable.cpp
@@ -13,11 +13,12 @@ namespace {
 
 xla::Shape NodeOutputShape(const Value& grad_output, const Value& input,
                            const Value& weight,
-                           absl::Span<const int64_t> stride,
-                           absl::Span<const int64_t> padding,
-                           absl::Span<const int64_t> dilation, bool transposed,
-                           absl::Span<const int64_t> output_padding,
-                           int64_t groups) {
+                           absl::Span<const xla::int64_t> stride,
+                           absl::Span<const xla::int64_t> padding,
+                           absl::Span<const xla::int64_t> dilation,
+                           bool transposed,
+                           absl::Span<const xla::int64_t> output_padding,
+                           xla::int64_t groups) {
   auto lower_for_shape_fn =
       [stride, padding, dilation, transposed, output_padding,
        groups](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
@@ -37,9 +38,9 @@ xla::Shape NodeOutputShape(const Value& grad_output, const Value& input,
 
 ConvolutionBackwardOverrideable::ConvolutionBackwardOverrideable(
     const Value& grad_output, const Value& input, const Value& weight,
-    std::vector<int64_t> stride, std::vector<int64_t> padding,
-    std::vector<int64_t> dilation, bool transposed,
-    std::vector<int64_t> output_padding, int64_t groups)
+    std::vector<xla::int64_t> stride, std::vector<xla::int64_t> padding,
+    std::vector<xla::int64_t> dilation, bool transposed,
+    std::vector<xla::int64_t> output_padding, xla::int64_t groups)
     : Node(ir::OpKind(at::aten::convolution_backward_overrideable),
            {grad_output, input, weight},
            [&]() {

--- a/torch_xla/csrc/ops/convolution_backward_overrideable.h
+++ b/torch_xla/csrc/ops/convolution_backward_overrideable.h
@@ -12,9 +12,9 @@ class ConvolutionBackwardOverrideable : public Node {
  public:
   ConvolutionBackwardOverrideable(
       const Value& grad_output, const Value& input, const Value& weight,
-      std::vector<int64_t> stride, std::vector<int64_t> padding,
-      std::vector<int64_t> dilation, bool transposed,
-      std::vector<int64_t> output_padding, int64_t groups);
+      std::vector<xla::int64_t> stride, std::vector<xla::int64_t> padding,
+      std::vector<xla::int64_t> dilation, bool transposed,
+      std::vector<xla::int64_t> output_padding, xla::int64_t groups);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -22,25 +22,27 @@ class ConvolutionBackwardOverrideable : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& stride() const { return stride_; }
+  const std::vector<xla::int64_t>& stride() const { return stride_; }
 
-  const std::vector<int64_t>& padding() const { return padding_; }
+  const std::vector<xla::int64_t>& padding() const { return padding_; }
 
-  const std::vector<int64_t>& dilation() const { return dilation_; }
+  const std::vector<xla::int64_t>& dilation() const { return dilation_; }
 
   bool transposed() const { return transposed_; }
 
-  const std::vector<int64_t>& output_padding() const { return output_padding_; }
+  const std::vector<xla::int64_t>& output_padding() const {
+    return output_padding_;
+  }
 
-  int64_t groups() const { return groups_; }
+  xla::int64_t groups() const { return groups_; }
 
  private:
-  std::vector<int64_t> stride_;
-  std::vector<int64_t> padding_;
-  std::vector<int64_t> dilation_;
-  std::vector<int64_t> output_padding_;
+  std::vector<xla::int64_t> stride_;
+  std::vector<xla::int64_t> padding_;
+  std::vector<xla::int64_t> dilation_;
+  std::vector<xla::int64_t> output_padding_;
   bool transposed_;
-  int64_t groups_;
+  xla::int64_t groups_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/convolution_overrideable.cpp
+++ b/torch_xla/csrc/ops/convolution_overrideable.cpp
@@ -13,11 +13,12 @@ namespace {
 
 // The bias doesn't matter for shape inference.
 xla::Shape NodeOutputShape(const Value& input, const Value& weight,
-                           absl::Span<const int64_t> stride,
-                           absl::Span<const int64_t> padding,
-                           absl::Span<const int64_t> dilation, bool transposed,
-                           absl::Span<const int64_t> output_padding,
-                           int64_t groups) {
+                           absl::Span<const xla::int64_t> stride,
+                           absl::Span<const xla::int64_t> padding,
+                           absl::Span<const xla::int64_t> dilation,
+                           bool transposed,
+                           absl::Span<const xla::int64_t> output_padding,
+                           xla::int64_t groups) {
   auto lower_for_shape_fn =
       [stride, padding, dilation, output_padding, transposed,
        groups](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
@@ -33,9 +34,9 @@ xla::Shape NodeOutputShape(const Value& input, const Value& weight,
 
 ConvolutionOverrideable::ConvolutionOverrideable(
     const Value& input, const Value& weight, const Value& bias,
-    std::vector<int64_t> stride, std::vector<int64_t> padding,
-    std::vector<int64_t> dilation, bool transposed,
-    std::vector<int64_t> output_padding, int64_t groups)
+    std::vector<xla::int64_t> stride, std::vector<xla::int64_t> padding,
+    std::vector<xla::int64_t> dilation, bool transposed,
+    std::vector<xla::int64_t> output_padding, xla::int64_t groups)
     : Node(ir::OpKind(at::aten::convolution_overrideable),
            {input, weight, bias},
            [&]() {
@@ -53,9 +54,10 @@ ConvolutionOverrideable::ConvolutionOverrideable(
       groups_(groups) {}
 
 ConvolutionOverrideable::ConvolutionOverrideable(
-    const Value& input, const Value& weight, std::vector<int64_t> stride,
-    std::vector<int64_t> padding, std::vector<int64_t> dilation,
-    bool transposed, std::vector<int64_t> output_padding, int64_t groups)
+    const Value& input, const Value& weight, std::vector<xla::int64_t> stride,
+    std::vector<xla::int64_t> padding, std::vector<xla::int64_t> dilation,
+    bool transposed, std::vector<xla::int64_t> output_padding,
+    xla::int64_t groups)
     : Node(ir::OpKind(at::aten::convolution_overrideable), {input, weight},
            [&]() {
              return NodeOutputShape(input, weight, stride, padding, dilation,

--- a/torch_xla/csrc/ops/convolution_overrideable.h
+++ b/torch_xla/csrc/ops/convolution_overrideable.h
@@ -12,16 +12,18 @@ namespace ops {
 class ConvolutionOverrideable : public Node {
  public:
   ConvolutionOverrideable(const Value& input, const Value& weight,
-                          const Value& bias, std::vector<int64_t> stride,
-                          std::vector<int64_t> padding,
-                          std::vector<int64_t> dilation, bool transposed,
-                          std::vector<int64_t> output_padding, int64_t groups);
+                          const Value& bias, std::vector<xla::int64_t> stride,
+                          std::vector<xla::int64_t> padding,
+                          std::vector<xla::int64_t> dilation, bool transposed,
+                          std::vector<xla::int64_t> output_padding,
+                          xla::int64_t groups);
 
   ConvolutionOverrideable(const Value& input, const Value& weight,
-                          std::vector<int64_t> stride,
-                          std::vector<int64_t> padding,
-                          std::vector<int64_t> dilation, bool transposed,
-                          std::vector<int64_t> output_padding, int64_t groups);
+                          std::vector<xla::int64_t> stride,
+                          std::vector<xla::int64_t> padding,
+                          std::vector<xla::int64_t> dilation, bool transposed,
+                          std::vector<xla::int64_t> output_padding,
+                          xla::int64_t groups);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -29,25 +31,27 @@ class ConvolutionOverrideable : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& stride() const { return stride_; }
+  const std::vector<xla::int64_t>& stride() const { return stride_; }
 
-  const std::vector<int64_t>& padding() const { return padding_; }
+  const std::vector<xla::int64_t>& padding() const { return padding_; }
 
-  const std::vector<int64_t>& dilation() const { return dilation_; }
+  const std::vector<xla::int64_t>& dilation() const { return dilation_; }
 
   bool transposed() const { return transposed_; }
 
-  const std::vector<int64_t>& output_padding() const { return output_padding_; }
+  const std::vector<xla::int64_t>& output_padding() const {
+    return output_padding_;
+  }
 
-  int64_t groups() const { return groups_; }
+  xla::int64_t groups() const { return groups_; }
 
  private:
-  std::vector<int64_t> stride_;
-  std::vector<int64_t> padding_;
-  std::vector<int64_t> dilation_;
-  std::vector<int64_t> output_padding_;
+  std::vector<xla::int64_t> stride_;
+  std::vector<xla::int64_t> padding_;
+  std::vector<xla::int64_t> dilation_;
+  std::vector<xla::int64_t> output_padding_;
   bool transposed_;
-  int64_t groups_;
+  xla::int64_t groups_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/cumprod.cpp
+++ b/torch_xla/csrc/ops/cumprod.cpp
@@ -14,7 +14,7 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::XlaOp LowerCumProd(xla::XlaOp input, int64_t dim,
+xla::XlaOp LowerCumProd(xla::XlaOp input, xla::int64_t dim,
                         c10::optional<at::ScalarType> dtype) {
   xla::XlaOp casted_input = CastToScalarType(input, dtype);
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(casted_input);
@@ -36,7 +36,7 @@ xla::Shape NodeOutputShape(const Value& input,
 
 }  // namespace
 
-CumProd::CumProd(const Value& input, int64_t dim,
+CumProd::CumProd(const Value& input, xla::int64_t dim,
                  c10::optional<at::ScalarType> dtype)
     : Node(ir::OpKind(at::aten::cumprod), {input},
            [&]() { return NodeOutputShape(input, dtype); },

--- a/torch_xla/csrc/ops/cumprod.h
+++ b/torch_xla/csrc/ops/cumprod.h
@@ -11,7 +11,8 @@ namespace ops {
 
 class CumProd : public Node {
  public:
-  CumProd(const Value& input, int64_t dim, c10::optional<at::ScalarType> dtype);
+  CumProd(const Value& input, xla::int64_t dim,
+          c10::optional<at::ScalarType> dtype);
 
   std::string ToString() const override;
 
@@ -19,12 +20,12 @@ class CumProd : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  int64_t dim() const { return dim_; }
+  xla::int64_t dim() const { return dim_; }
 
   const c10::optional<at::ScalarType>& dtype() const { return dtype_; }
 
  private:
-  int64_t dim_;
+  xla::int64_t dim_;
   c10::optional<at::ScalarType> dtype_;
 };
 

--- a/torch_xla/csrc/ops/cumsum.cpp
+++ b/torch_xla/csrc/ops/cumsum.cpp
@@ -13,7 +13,7 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::XlaOp LowerCumSum(xla::XlaOp input, int64_t dim,
+xla::XlaOp LowerCumSum(xla::XlaOp input, xla::int64_t dim,
                        c10::optional<at::ScalarType> dtype) {
   xla::XlaOp casted_input = CastToScalarType(input, dtype);
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(casted_input);
@@ -35,7 +35,7 @@ xla::Shape NodeOutputShape(const Value& input,
 
 }  // namespace
 
-CumSum::CumSum(const Value& input, int64_t dim,
+CumSum::CumSum(const Value& input, xla::int64_t dim,
                c10::optional<at::ScalarType> dtype)
     : Node(ir::OpKind(at::aten::cumsum), {input},
            [&]() { return NodeOutputShape(input, dtype); },

--- a/torch_xla/csrc/ops/cumsum.h
+++ b/torch_xla/csrc/ops/cumsum.h
@@ -11,7 +11,8 @@ namespace ops {
 
 class CumSum : public Node {
  public:
-  CumSum(const Value& input, int64_t dim, c10::optional<at::ScalarType> dtype);
+  CumSum(const Value& input, xla::int64_t dim,
+         c10::optional<at::ScalarType> dtype);
 
   std::string ToString() const override;
 
@@ -19,12 +20,12 @@ class CumSum : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  int64_t dim() const { return dim_; }
+  xla::int64_t dim() const { return dim_; }
 
   const c10::optional<at::ScalarType>& dtype() const { return dtype_; }
 
  private:
-  int64_t dim_;
+  xla::int64_t dim_;
   c10::optional<at::ScalarType> dtype_;
 };
 

--- a/torch_xla/csrc/ops/diagonal.cpp
+++ b/torch_xla/csrc/ops/diagonal.cpp
@@ -11,8 +11,8 @@ namespace torch_xla {
 namespace ir {
 namespace ops {
 
-Diagonal::Diagonal(const Value& input, int64_t offset, int64_t dim1,
-                   int64_t dim2)
+Diagonal::Diagonal(const Value& input, xla::int64_t offset, xla::int64_t dim1,
+                   xla::int64_t dim2)
     : Node(ir::OpKind(at::aten::diagonal), {input},
            [&]() {
              return MakeDiagonalShape(input.shape(), offset, dim1, dim2);
@@ -39,20 +39,21 @@ std::string Diagonal::ToString() const {
   return ss.str();
 }
 
-xla::Shape Diagonal::MakeDiagonalShape(const xla::Shape& shape, int64_t offset,
-                                       int64_t dim1, int64_t dim2) {
-  std::vector<int64_t> dimensions;
-  for (int64_t dim = 0; dim < shape.rank(); ++dim) {
+xla::Shape Diagonal::MakeDiagonalShape(const xla::Shape& shape,
+                                       xla::int64_t offset, xla::int64_t dim1,
+                                       xla::int64_t dim2) {
+  std::vector<xla::int64_t> dimensions;
+  for (xla::int64_t dim = 0; dim < shape.rank(); ++dim) {
     if (dim != dim1 && dim != dim2) {
       dimensions.push_back(shape.dimensions(dim));
     }
   }
-  int64_t dsize;
+  xla::int64_t dsize;
   if (offset >= 0) {
-    dsize = std::max<int64_t>(
+    dsize = std::max<xla::int64_t>(
         std::min(shape.dimensions(dim1), shape.dimensions(dim2) - offset), 0);
   } else {
-    dsize = std::max<int64_t>(
+    dsize = std::max<xla::int64_t>(
         std::min(shape.dimensions(dim1) + offset, shape.dimensions(dim2)), 0);
   }
   dimensions.push_back(dsize);

--- a/torch_xla/csrc/ops/diagonal.h
+++ b/torch_xla/csrc/ops/diagonal.h
@@ -8,7 +8,8 @@ namespace ops {
 
 class Diagonal : public Node {
  public:
-  Diagonal(const Value& input, int64_t offset, int64_t dim1, int64_t dim2);
+  Diagonal(const Value& input, xla::int64_t offset, xla::int64_t dim1,
+           xla::int64_t dim2);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -16,19 +17,20 @@ class Diagonal : public Node {
 
   std::string ToString() const override;
 
-  int64_t offset() const { return offset_; }
+  xla::int64_t offset() const { return offset_; }
 
-  int64_t dim1() const { return dim1_; }
+  xla::int64_t dim1() const { return dim1_; }
 
-  int64_t dim2() const { return dim2_; }
+  xla::int64_t dim2() const { return dim2_; }
 
-  static xla::Shape MakeDiagonalShape(const xla::Shape& shape, int64_t offset,
-                                      int64_t dim1, int64_t dim2);
+  static xla::Shape MakeDiagonalShape(const xla::Shape& shape,
+                                      xla::int64_t offset, xla::int64_t dim1,
+                                      xla::int64_t dim2);
 
  private:
-  int64_t offset_;
-  int64_t dim1_;
-  int64_t dim2_;
+  xla::int64_t offset_;
+  xla::int64_t dim1_;
+  xla::int64_t dim2_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/diagonal_view_update.cpp
+++ b/torch_xla/csrc/ops/diagonal_view_update.cpp
@@ -9,8 +9,8 @@ namespace ir {
 namespace ops {
 
 DiagonalViewUpdate::DiagonalViewUpdate(const Value& target, const Value& input,
-                                       int64_t offset, int64_t dim1,
-                                       int64_t dim2)
+                                       xla::int64_t offset, xla::int64_t dim1,
+                                       xla::int64_t dim2)
     : Node(xla_diagonal_view_update, {target, input}, target.shape(),
            /*num_outputs=*/1, torch::lazy::MHash(offset, dim1, dim2)),
       offset_(offset),

--- a/torch_xla/csrc/ops/diagonal_view_update.h
+++ b/torch_xla/csrc/ops/diagonal_view_update.h
@@ -8,8 +8,8 @@ namespace ops {
 
 class DiagonalViewUpdate : public Node {
  public:
-  DiagonalViewUpdate(const Value& target, const Value& input, int64_t offset,
-                     int64_t dim1, int64_t dim2);
+  DiagonalViewUpdate(const Value& target, const Value& input,
+                     xla::int64_t offset, xla::int64_t dim1, xla::int64_t dim2);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -17,16 +17,16 @@ class DiagonalViewUpdate : public Node {
 
   std::string ToString() const override;
 
-  int64_t offset() const { return offset_; }
+  xla::int64_t offset() const { return offset_; }
 
-  int64_t dim1() const { return dim1_; }
+  xla::int64_t dim1() const { return dim1_; }
 
-  int64_t dim2() const { return dim2_; }
+  xla::int64_t dim2() const { return dim2_; }
 
  private:
-  int64_t offset_;
-  int64_t dim1_;
-  int64_t dim2_;
+  xla::int64_t offset_;
+  xla::int64_t dim1_;
+  xla::int64_t dim2_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/expand.cpp
+++ b/torch_xla/csrc/ops/expand.cpp
@@ -11,7 +11,7 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& input,
-                           const std::vector<int64_t>& size) {
+                           const std::vector<xla::int64_t>& size) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildExpand(operands[0], size);
@@ -21,7 +21,7 @@ xla::Shape NodeOutputShape(const Value& input,
 
 }  // namespace
 
-Expand::Expand(const Value& input, std::vector<int64_t> size)
+Expand::Expand(const Value& input, std::vector<xla::int64_t> size)
     : Node(ir::OpKind(at::aten::expand), {input},
            [&]() { return NodeOutputShape(input, size); },
            /*num_outputs=*/1, torch::lazy::MHash(size)),

--- a/torch_xla/csrc/ops/expand.h
+++ b/torch_xla/csrc/ops/expand.h
@@ -10,7 +10,7 @@ namespace ops {
 
 class Expand : public Node {
  public:
-  Expand(const Value& input, std::vector<int64_t> size);
+  Expand(const Value& input, std::vector<xla::int64_t> size);
 
   std::string ToString() const override;
 
@@ -18,10 +18,10 @@ class Expand : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  const std::vector<int64_t>& size() const { return size_; };
+  const std::vector<xla::int64_t>& size() const { return size_; };
 
  private:
-  std::vector<int64_t> size_;
+  std::vector<xla::int64_t> size_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/flip.cpp
+++ b/torch_xla/csrc/ops/flip.cpp
@@ -7,7 +7,7 @@ namespace torch_xla {
 namespace ir {
 namespace ops {
 
-Flip::Flip(const Value& input, std::vector<int64_t> dims)
+Flip::Flip(const Value& input, std::vector<xla::int64_t> dims)
     : Node(ir::OpKind(at::aten::flip), {input}, input.shape(),
            /*num_outputs=*/1, torch::lazy::MHash(dims)),
       dims_(std::move(dims)) {}

--- a/torch_xla/csrc/ops/flip.h
+++ b/torch_xla/csrc/ops/flip.h
@@ -9,7 +9,7 @@ namespace ops {
 
 class Flip : public Node {
  public:
-  Flip(const Value& input, std::vector<int64_t> dims);
+  Flip(const Value& input, std::vector<xla::int64_t> dims);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -17,11 +17,11 @@ class Flip : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& dims() const { return dims_; }
+  const std::vector<xla::int64_t>& dims() const { return dims_; }
 
  private:
   // The dimensions which are flipped.
-  std::vector<int64_t> dims_;
+  std::vector<xla::int64_t> dims_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/gather.cpp
+++ b/torch_xla/csrc/ops/gather.cpp
@@ -12,7 +12,7 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& input, const Value& index,
-                           int64_t dim) {
+                           xla::int64_t dim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return xla::TorchGather(operands[0], operands[1], dim,
@@ -23,7 +23,7 @@ xla::Shape NodeOutputShape(const Value& input, const Value& index,
 
 }  // namespace
 
-Gather::Gather(const Value& input, int64_t dim, const Value& index)
+Gather::Gather(const Value& input, xla::int64_t dim, const Value& index)
     : Node(ir::OpKind(at::aten::gather), {input, index},
            [&]() { return NodeOutputShape(input, index, dim); },
            /*num_outputs=*/1, torch::lazy::MHash(dim)),

--- a/torch_xla/csrc/ops/gather.h
+++ b/torch_xla/csrc/ops/gather.h
@@ -8,7 +8,7 @@ namespace ops {
 
 class Gather : public Node {
  public:
-  Gather(const Value& input, int64_t dim, const Value& index);
+  Gather(const Value& input, xla::int64_t dim, const Value& index);
 
   std::string ToString() const override;
 
@@ -16,10 +16,10 @@ class Gather : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  int64_t dim() const { return dim_; };
+  xla::int64_t dim() const { return dim_; };
 
  private:
-  int64_t dim_;
+  xla::int64_t dim_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/generic_slice.cpp
+++ b/torch_xla/csrc/ops/generic_slice.cpp
@@ -13,8 +13,8 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& input,
-                           absl::Span<const int64_t> base_indices,
-                           absl::Span<const int64_t> sizes) {
+                           absl::Span<const xla::int64_t> base_indices,
+                           absl::Span<const xla::int64_t> sizes) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildSlice(operands[0], base_indices, sizes);
@@ -25,8 +25,8 @@ xla::Shape NodeOutputShape(const Value& input,
 }  // namespace
 
 GenericSlice::GenericSlice(const Value& input,
-                           absl::Span<const int64_t> base_indices,
-                           absl::Span<const int64_t> sizes)
+                           absl::Span<const xla::int64_t> base_indices,
+                           absl::Span<const xla::int64_t> sizes)
     : Node(xla_generic_slice, {input},
            [&]() { return NodeOutputShape(input, base_indices, sizes); },
            /*num_outputs=*/1, torch::lazy::MHash(base_indices, sizes)),

--- a/torch_xla/csrc/ops/generic_slice.h
+++ b/torch_xla/csrc/ops/generic_slice.h
@@ -9,8 +9,8 @@ namespace ops {
 
 class GenericSlice : public Node {
  public:
-  GenericSlice(const Value& input, absl::Span<const int64_t> base_indices,
-               absl::Span<const int64_t> sizes);
+  GenericSlice(const Value& input, absl::Span<const xla::int64_t> base_indices,
+               absl::Span<const xla::int64_t> sizes);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -18,13 +18,15 @@ class GenericSlice : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& base_indices() const { return base_indices_; }
+  const std::vector<xla::int64_t>& base_indices() const {
+    return base_indices_;
+  }
 
-  const std::vector<int64_t>& sizes() const { return sizes_; }
+  const std::vector<xla::int64_t>& sizes() const { return sizes_; }
 
  private:
-  std::vector<int64_t> base_indices_;
-  std::vector<int64_t> sizes_;
+  std::vector<xla::int64_t> base_indices_;
+  std::vector<xla::int64_t> sizes_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/get_dimensions_size.cpp
+++ b/torch_xla/csrc/ops/get_dimensions_size.cpp
@@ -12,7 +12,7 @@ namespace ir {
 namespace ops {
 
 GetDimensionsSize::GetDimensionsSize(const Value& input,
-                                     std::vector<int64_t> dimensions)
+                                     std::vector<xla::int64_t> dimensions)
     : Node(xla_get_dimensions_size, {input},
            xla::ShapeUtil::MakeShape(GetShapeDimensionType(/*device=*/nullptr),
                                      {}),

--- a/torch_xla/csrc/ops/get_dimensions_size.h
+++ b/torch_xla/csrc/ops/get_dimensions_size.h
@@ -10,7 +10,7 @@ namespace ops {
 
 class GetDimensionsSize : public Node {
  public:
-  GetDimensionsSize(const Value& input, std::vector<int64_t> dimensions);
+  GetDimensionsSize(const Value& input, std::vector<xla::int64_t> dimensions);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -18,10 +18,10 @@ class GetDimensionsSize : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& dimensions() const { return dimensions_; }
+  const std::vector<xla::int64_t>& dimensions() const { return dimensions_; }
 
  private:
-  std::vector<int64_t> dimensions_;
+  std::vector<xla::int64_t> dimensions_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/index_get.cpp
+++ b/torch_xla/csrc/ops/index_get.cpp
@@ -11,7 +11,7 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& base, const Value& indices,
-                           int64_t start_dim) {
+                           xla::int64_t start_dim) {
   auto lower_for_shape_fn =
       [start_dim](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     XLA_CHECK_EQ(operands.size(), 2);
@@ -23,7 +23,7 @@ xla::Shape NodeOutputShape(const Value& base, const Value& indices,
 }  // namespace
 
 IndexGet::IndexGet(const ir::Value& base, const ir::Value& indices,
-                   int64_t start_dim)
+                   xla::int64_t start_dim)
     : Node(OpKind(at::aten::index), {base, indices},
            [&]() { return NodeOutputShape(base, indices, start_dim); },
            /*num_outputs=*/1, torch::lazy::MHash(start_dim)),

--- a/torch_xla/csrc/ops/index_get.h
+++ b/torch_xla/csrc/ops/index_get.h
@@ -8,7 +8,8 @@ namespace ops {
 
 class IndexGet : public Node {
  public:
-  IndexGet(const ir::Value& base, const ir::Value& indices, int64_t start_dim);
+  IndexGet(const ir::Value& base, const ir::Value& indices,
+           xla::int64_t start_dim);
 
   std::string ToString() const override;
 
@@ -16,11 +17,11 @@ class IndexGet : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  int64_t start_dim() const { return start_dim_; }
+  xla::int64_t start_dim() const { return start_dim_; }
 
  private:
   // The dimension number at which indexing starts.
-  int64_t start_dim_;
+  xla::int64_t start_dim_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/index_ops.cpp
+++ b/torch_xla/csrc/ops/index_ops.cpp
@@ -69,7 +69,7 @@ std::vector<at::Tensor> ExpandByteTensors(
 
 struct IndexAdjacencyInfo {
   bool contiguous_non_null = false;
-  int64_t start_dim = 0;
+  xla::int64_t start_dim = 0;
 };
 
 // Checks whether all the non-null tensors are adjacent, in which case we must
@@ -82,7 +82,7 @@ IndexAdjacencyInfo GetIndexAdjacencyInfo(at::TensorList indices) {
   auto start = std::find_if(indices.begin(), indices.end(), is_defined);
   auto stop = std::find_if(indices.rbegin(), indices.rend(), is_defined);
   auto it = std::find_if(start, stop.base(), is_null);
-  int64_t start_dim = std::distance(indices.begin(), start);
+  xla::int64_t start_dim = std::distance(indices.begin(), start);
   return {it == stop.base(), start_dim};
 }
 
@@ -118,7 +118,7 @@ CanonicalIndexInfo TransposeToFront(at::Tensor base, at::TensorList indices) {
   IndexAdjacencyInfo adjacency_info = GetIndexAdjacencyInfo(indices);
   if (adjacency_info.contiguous_non_null) {
     return {base, std::move(transposed_indices),
-            xla::util::Iota<int64_t>(base_rank), adjacency_info.start_dim};
+            xla::util::Iota<xla::int64_t>(base_rank), adjacency_info.start_dim};
   }
   return {base.permute(dims), std::move(transposed_indices),
           xla::InversePermutation(XlaHelpers::I64List(dims)), 0};
@@ -148,7 +148,7 @@ std::vector<XLATensor> WrapIndicesOnce(const XLATensor& base,
   return canonical_indices;
 }
 
-ir::NodePtr IndexFillOp(const ir::Value& buffer, int64_t dim,
+ir::NodePtr IndexFillOp(const ir::Value& buffer, xla::int64_t dim,
                         const ir::Value& index, const ir::Value& value) {
   auto lower_fn = [dim](const ir::Node& node,
                         ir::LoweringContext* loctx) -> ir::XlaOpVector {
@@ -173,7 +173,7 @@ ir::NodePtr IndexFillOp(const ir::Value& buffer, int64_t dim,
       std::move(lower_fn), /*num_outputs=*/1, torch::lazy::MHash(dim));
 }
 
-ir::NodePtr IndexAddOp(const ir::Value& buffer, int64_t dim,
+ir::NodePtr IndexAddOp(const ir::Value& buffer, xla::int64_t dim,
                        const ir::Value& index, const ir::Value& source) {
   auto lower_fn = [dim](const ir::Node& node,
                         ir::LoweringContext* loctx) -> ir::XlaOpVector {
@@ -198,7 +198,7 @@ ir::NodePtr IndexAddOp(const ir::Value& buffer, int64_t dim,
       std::move(lower_fn));
 }
 
-ir::NodePtr IndexCopyOp(const ir::Value& buffer, int64_t dim,
+ir::NodePtr IndexCopyOp(const ir::Value& buffer, xla::int64_t dim,
                         const ir::Value& index, const ir::Value& source) {
   auto lower_fn = [dim](const ir::Node& node,
                         ir::LoweringContext* loctx) -> ir::XlaOpVector {
@@ -240,19 +240,19 @@ CanonicalIndexInfo GetCanonicalIndexInfo(
 
 ir::Value EnsureRank1(const ir::Value& index) {
   XLA_CHECK_LE(index->shape().rank(), 1);
-  return index->shape().rank() == 0
-             ? ir::MakeNode<ir::ops::Expand>(index, std::vector<int64_t>{1})
-             : index;
+  return index->shape().rank() == 0 ? ir::MakeNode<ir::ops::Expand>(
+                                          index, std::vector<xla::int64_t>{1})
+                                    : index;
 }
 
 XLATensor IndexByTensors(const XLATensor& base,
                          absl::Span<const XLATensor> indices,
-                         int64_t start_dim) {
+                         xla::int64_t start_dim) {
   if (indices.empty()) {
     return base;
   }
   auto canonical_indices = WrapIndicesOnce(base, indices, start_dim);
-  int64_t indices_rank = canonical_indices.front().shape().get().rank();
+  xla::int64_t indices_rank = canonical_indices.front().shape().get().rank();
   // Stack the indices to allow the whole multi-indexing to be dispatched with a
   // single gather.
   XLATensor indices_nd = XLATensor::stack(canonical_indices, indices_rank);
@@ -264,14 +264,14 @@ XLATensor IndexByTensors(const XLATensor& base,
 
 ir::Value IndexPutByTensors(const XLATensor& base,
                             absl::Span<const XLATensor> indices,
-                            int64_t start_dim, const XLATensor& values,
+                            xla::int64_t start_dim, const XLATensor& values,
                             bool accumulate,
-                            absl::Span<const int64_t> result_permutation) {
+                            absl::Span<const xla::int64_t> result_permutation) {
   if (indices.empty()) {
     return base.GetIrValue();
   }
   auto canonical_indices = WrapIndicesOnce(base, indices, start_dim);
-  int64_t indices_rank = canonical_indices.front().shape().get().rank();
+  xla::int64_t indices_rank = canonical_indices.front().shape().get().rank();
   // Stack the indices to allow the whole multi-indexing to be dispatched with a
   // single scatter.
   XLATensor indices_nd = XLATensor::stack(canonical_indices, indices_rank);
@@ -279,10 +279,10 @@ ir::Value IndexPutByTensors(const XLATensor& base,
       ir::MakeNode<ir::ops::IndexPut>(base.GetIrValue(),
                                       indices_nd.GetIrValue(), start_dim,
                                       values.GetIrValue(), accumulate),
-      xla::util::ToVector<int64_t>(result_permutation));
+      xla::util::ToVector<xla::int64_t>(result_permutation));
 }
 
-ir::NodePtr IndexFill(const XLATensor& base, int64_t dim,
+ir::NodePtr IndexFill(const XLATensor& base, xla::int64_t dim,
                       const XLATensor& index, const at::Scalar& value) {
   XLA_CHECK_EQ(index.dtype(), at::ScalarType::Long)
       << "Fill index is expected to be of scalar type Long, but it is "
@@ -295,7 +295,7 @@ ir::NodePtr IndexFill(const XLATensor& base, int64_t dim,
                                      base.GetDevice()));
 }
 
-ir::NodePtr IndexFill(const XLATensor& base, int64_t dim,
+ir::NodePtr IndexFill(const XLATensor& base, xla::int64_t dim,
                       const XLATensor& index, const XLATensor& value) {
   XLA_CHECK_EQ(index.dtype(), at::ScalarType::Long)
       << "Fill index is expected to be of scalar type Long, but it is "
@@ -308,8 +308,8 @@ ir::NodePtr IndexFill(const XLATensor& base, int64_t dim,
                      value.GetIrValue());
 }
 
-ir::Value IndexAdd(const XLATensor& base, int64_t dim, const XLATensor& index,
-                   const XLATensor& source) {
+ir::Value IndexAdd(const XLATensor& base, xla::int64_t dim,
+                   const XLATensor& index, const XLATensor& source) {
   XLA_CHECK(index.dtype() == at::ScalarType::Long ||
             index.dtype() == at::ScalarType::Int)
       << "Add index is expected to be of scalar type Long or scalar type Int, "
@@ -321,8 +321,8 @@ ir::Value IndexAdd(const XLATensor& base, int64_t dim, const XLATensor& index,
                     source.GetIrValue());
 }
 
-ir::Value IndexCopy(const XLATensor& base, int64_t dim, const XLATensor& index,
-                    const XLATensor& source) {
+ir::Value IndexCopy(const XLATensor& base, xla::int64_t dim,
+                    const XLATensor& index, const XLATensor& source) {
   XLA_CHECK_EQ(index.dtype(), at::ScalarType::Long)
       << "Copy index is expected to be of scalar type Long, but it is "
       << index.dtype();

--- a/torch_xla/csrc/ops/index_ops.h
+++ b/torch_xla/csrc/ops/index_ops.h
@@ -37,9 +37,9 @@ struct CanonicalIndexInfo {
   // The permutation to be applied to the result. This is needed for indexed
   // updates, since a permutation is applied to the base to bring non-null
   // indices to front. This is the inverse of that permutation.
-  std::vector<int64_t> result_permutation;
+  std::vector<xla::int64_t> result_permutation;
   // The dimension number at which indexing starts.
-  int64_t start_dim = 0;
+  xla::int64_t start_dim = 0;
 };
 
 // Transform the given base and indices to a form supported by the XLATensor
@@ -57,24 +57,24 @@ ir::Value EnsureRank1(const ir::Value& index);
 // description.
 XLATensor IndexByTensors(const XLATensor& base,
                          absl::Span<const XLATensor> indices,
-                         int64_t start_dim);
+                         xla::int64_t start_dim);
 
 ir::Value IndexPutByTensors(const XLATensor& base,
                             absl::Span<const XLATensor> indices,
-                            int64_t start_dim, const XLATensor& updates,
+                            xla::int64_t start_dim, const XLATensor& updates,
                             bool accumulate,
-                            absl::Span<const int64_t> result_permutation);
+                            absl::Span<const xla::int64_t> result_permutation);
 
-ir::NodePtr IndexFill(const XLATensor& base, int64_t dim,
+ir::NodePtr IndexFill(const XLATensor& base, xla::int64_t dim,
                       const XLATensor& index, const at::Scalar& value);
 
-ir::NodePtr IndexFill(const XLATensor& base, int64_t dim,
+ir::NodePtr IndexFill(const XLATensor& base, xla::int64_t dim,
                       const XLATensor& index, const XLATensor& value);
 
-ir::Value IndexAdd(const XLATensor& base, int64_t dim, const XLATensor& index,
-                   const XLATensor& source);
+ir::Value IndexAdd(const XLATensor& base, xla::int64_t dim,
+                   const XLATensor& index, const XLATensor& source);
 
-ir::Value IndexCopy(const XLATensor& base, int64_t dim, const XLATensor& index,
-                    const XLATensor& source);
+ir::Value IndexCopy(const XLATensor& base, xla::int64_t dim,
+                    const XLATensor& index, const XLATensor& source);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/index_put.cpp
+++ b/torch_xla/csrc/ops/index_put.cpp
@@ -8,7 +8,8 @@ namespace ir {
 namespace ops {
 
 IndexPut::IndexPut(const ir::Value& base, const ir::Value& indices,
-                   int64_t start_dim, const ir::Value& values, bool accumulate)
+                   xla::int64_t start_dim, const ir::Value& values,
+                   bool accumulate)
     : Node(OpKind(at::aten::index_put), {base, indices, values}, base.shape(),
            /*num_outputs=*/1, torch::lazy::MHash(start_dim, accumulate)),
       start_dim_(start_dim),

--- a/torch_xla/csrc/ops/index_put.h
+++ b/torch_xla/csrc/ops/index_put.h
@@ -8,8 +8,8 @@ namespace ops {
 
 class IndexPut : public Node {
  public:
-  IndexPut(const ir::Value& base, const ir::Value& indices, int64_t start_dim,
-           const ir::Value& values, bool accumulate);
+  IndexPut(const ir::Value& base, const ir::Value& indices,
+           xla::int64_t start_dim, const ir::Value& values, bool accumulate);
 
   std::string ToString() const override;
 
@@ -17,13 +17,13 @@ class IndexPut : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  int64_t start_dim() const { return start_dim_; }
+  xla::int64_t start_dim() const { return start_dim_; }
 
   bool accumulate() const { return accumulate_; }
 
  private:
   // The dimension number at which indexing starts.
-  int64_t start_dim_;
+  xla::int64_t start_dim_;
   // Whether to accumulate instead of set.
   bool accumulate_;
 };

--- a/torch_xla/csrc/ops/index_select.cpp
+++ b/torch_xla/csrc/ops/index_select.cpp
@@ -11,7 +11,7 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& input, const Value& index,
-                           int64_t dim) {
+                           xla::int64_t dim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return xla::TorchIndexSelect(operands[0], operands[1], dim);
@@ -21,7 +21,8 @@ xla::Shape NodeOutputShape(const Value& input, const Value& index,
 
 }  // namespace
 
-IndexSelect::IndexSelect(const Value& input, int64_t dim, const Value& index)
+IndexSelect::IndexSelect(const Value& input, xla::int64_t dim,
+                         const Value& index)
     : Node(ir::OpKind(at::aten::index_select), {input, index},
            [&]() { return NodeOutputShape(input, index, dim); },
            /*num_outputs=*/1, torch::lazy::MHash(dim)),

--- a/torch_xla/csrc/ops/index_select.h
+++ b/torch_xla/csrc/ops/index_select.h
@@ -8,7 +8,7 @@ namespace ops {
 
 class IndexSelect : public Node {
  public:
-  IndexSelect(const Value& input, int64_t dim, const Value& index);
+  IndexSelect(const Value& input, xla::int64_t dim, const Value& index);
 
   std::string ToString() const override;
 
@@ -16,10 +16,10 @@ class IndexSelect : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  int64_t dim() const { return dim_; };
+  xla::int64_t dim() const { return dim_; };
 
  private:
-  int64_t dim_;
+  xla::int64_t dim_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/kth_value.cpp
+++ b/torch_xla/csrc/ops/kth_value.cpp
@@ -9,7 +9,7 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const Value& input, int64_t k, int64_t dim,
+xla::Shape NodeOutputShape(const Value& input, xla::int64_t k, xla::int64_t dim,
                            bool keepdim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
@@ -21,7 +21,8 @@ xla::Shape NodeOutputShape(const Value& input, int64_t k, int64_t dim,
 
 }  // namespace
 
-KthValue::KthValue(const Value& input, int64_t k, int64_t dim, bool keepdim)
+KthValue::KthValue(const Value& input, xla::int64_t k, xla::int64_t dim,
+                   bool keepdim)
     : Node(ir::OpKind(at::aten::kthvalue), {input},
            [&]() { return NodeOutputShape(input, k, dim, keepdim); },
            /*num_outputs=*/2, torch::lazy::MHash(k, dim, keepdim)),

--- a/torch_xla/csrc/ops/kth_value.h
+++ b/torch_xla/csrc/ops/kth_value.h
@@ -8,7 +8,7 @@ namespace ops {
 
 class KthValue : public Node {
  public:
-  KthValue(const Value& input, int64_t k, int64_t dim, bool keepdim);
+  KthValue(const Value& input, xla::int64_t k, xla::int64_t dim, bool keepdim);
 
   std::string ToString() const override;
 
@@ -16,15 +16,15 @@ class KthValue : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  int64_t k() const { return k_; };
+  xla::int64_t k() const { return k_; };
 
-  int64_t dim() const { return dim_; };
+  xla::int64_t dim() const { return dim_; };
 
   bool keepdim() const { return keepdim_; }
 
  private:
-  int64_t k_;
-  int64_t dim_;
+  xla::int64_t k_;
+  xla::int64_t dim_;
   bool keepdim_;
 };
 

--- a/torch_xla/csrc/ops/log_softmax.cpp
+++ b/torch_xla/csrc/ops/log_softmax.cpp
@@ -11,7 +11,7 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::XlaOp LowerLogSoftmax(xla::XlaOp input, int64_t dim,
+xla::XlaOp LowerLogSoftmax(xla::XlaOp input, xla::int64_t dim,
                            const c10::optional<at::ScalarType>& dtype) {
   xla::XlaOp result = BuildLogSoftmax(input, dim);
   return CastToScalarType(result, dtype);
@@ -28,7 +28,7 @@ xla::Shape NodeOutputShape(const Value& input,
 
 }  // namespace
 
-LogSoftmax::LogSoftmax(const Value& input, int64_t dim,
+LogSoftmax::LogSoftmax(const Value& input, xla::int64_t dim,
                        c10::optional<at::ScalarType> dtype)
     : Node(ir::OpKind(at::aten::log_softmax), {input},
            [&]() { return NodeOutputShape(input, dtype); },

--- a/torch_xla/csrc/ops/log_softmax.h
+++ b/torch_xla/csrc/ops/log_softmax.h
@@ -12,7 +12,7 @@ namespace ops {
 // IR node for log(softmax) operation.
 class LogSoftmax : public Node {
  public:
-  LogSoftmax(const Value& input, int64_t dim,
+  LogSoftmax(const Value& input, xla::int64_t dim,
              c10::optional<at::ScalarType> dtype);
 
   NodePtr Clone(OpList operands) const override;
@@ -21,13 +21,13 @@ class LogSoftmax : public Node {
 
   std::string ToString() const override;
 
-  int64_t dim() const { return dim_; }
+  xla::int64_t dim() const { return dim_; }
 
   const c10::optional<at::ScalarType>& dtype() const { return dtype_; }
 
  private:
   // The dimension along which the result is computed.
-  int64_t dim_;
+  xla::int64_t dim_;
   c10::optional<at::ScalarType> dtype_;
 };
 

--- a/torch_xla/csrc/ops/log_softmax_backward.cpp
+++ b/torch_xla/csrc/ops/log_softmax_backward.cpp
@@ -10,7 +10,7 @@ namespace ir {
 namespace ops {
 
 LogSoftmaxBackward::LogSoftmaxBackward(const Value& grad_output,
-                                       const Value& output, int64_t dim)
+                                       const Value& output, xla::int64_t dim)
     : Node(ir::OpKind(at::aten::_log_softmax_backward_data),
            {grad_output, output}, grad_output.shape(),
            /*num_outputs=*/1, torch::lazy::MHash(dim)),

--- a/torch_xla/csrc/ops/log_softmax_backward.h
+++ b/torch_xla/csrc/ops/log_softmax_backward.h
@@ -9,7 +9,7 @@ namespace ops {
 class LogSoftmaxBackward : public Node {
  public:
   LogSoftmaxBackward(const Value& grad_output, const Value& output,
-                     int64_t dim);
+                     xla::int64_t dim);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -17,11 +17,11 @@ class LogSoftmaxBackward : public Node {
 
   std::string ToString() const override;
 
-  int64_t dim() const { return dim_; }
+  xla::int64_t dim() const { return dim_; }
 
  private:
   // The dimension along which the result is computed.
-  int64_t dim_;
+  xla::int64_t dim_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/logsumexp.cpp
+++ b/torch_xla/csrc/ops/logsumexp.cpp
@@ -13,7 +13,8 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
+xla::Shape NodeOutputShape(const Value& input,
+                           std::vector<xla::int64_t>& dimensions,
                            bool keep_reduced_dimensions) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
@@ -24,7 +25,7 @@ xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
 
 }  // namespace
 
-Logsumexp::Logsumexp(const Value& input, std::vector<int64_t> dimensions,
+Logsumexp::Logsumexp(const Value& input, std::vector<xla::int64_t> dimensions,
                      bool keep_reduced_dimensions)
     : Node(ir::OpKind(at::aten::logsumexp), {input},
            [&]() {

--- a/torch_xla/csrc/ops/logsumexp.h
+++ b/torch_xla/csrc/ops/logsumexp.h
@@ -12,7 +12,7 @@ namespace ops {
 
 class Logsumexp : public Node {
  public:
-  Logsumexp(const Value& input, std::vector<int64_t> dimensions,
+  Logsumexp(const Value& input, std::vector<xla::int64_t> dimensions,
             bool keep_reduced_dimensions);
 
   std::string ToString() const override;
@@ -21,12 +21,12 @@ class Logsumexp : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  const std::vector<int64_t>& dimensions() const { return dimensions_; }
+  const std::vector<xla::int64_t>& dimensions() const { return dimensions_; }
 
   bool keep_reduced_dimensions() const { return keep_reduced_dimensions_; }
 
  private:
-  std::vector<int64_t> dimensions_;
+  std::vector<xla::int64_t> dimensions_;
   bool keep_reduced_dimensions_;
 };
 

--- a/torch_xla/csrc/ops/masked_select.cpp
+++ b/torch_xla/csrc/ops/masked_select.cpp
@@ -12,7 +12,7 @@ namespace {
 
 xla::Shape NodeOutputShape(const Value& input) {
   const xla::Shape& input_shape = input.shape();
-  int64_t input_elements = xla::ShapeUtil::ElementsIn(input_shape);
+  xla::int64_t input_elements = xla::ShapeUtil::ElementsIn(input_shape);
   xla::PrimitiveType size_type = GetShapeDimensionType(/*device=*/nullptr);
   xla::Shape result_shape =
       xla::ShapeUtil::MakeShape(input_shape.element_type(), {input_elements});

--- a/torch_xla/csrc/ops/max_in_dim.cpp
+++ b/torch_xla/csrc/ops/max_in_dim.cpp
@@ -9,7 +9,7 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const Value& input, int64_t dim, bool keepdim) {
+xla::Shape NodeOutputShape(const Value& input, xla::int64_t dim, bool keepdim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     xla::XlaOp values = BuildMaxInDim(operands[0], dim, keepdim);
@@ -21,7 +21,7 @@ xla::Shape NodeOutputShape(const Value& input, int64_t dim, bool keepdim) {
 
 }  // namespace
 
-MaxInDim::MaxInDim(const Value& input, int64_t dim, bool keepdim)
+MaxInDim::MaxInDim(const Value& input, xla::int64_t dim, bool keepdim)
     : Node(ir::OpKind(at::aten::max), {input},
            [&]() { return NodeOutputShape(input, dim, keepdim); },
            /*num_outputs=*/2, torch::lazy::MHash(dim, keepdim)),

--- a/torch_xla/csrc/ops/max_in_dim.h
+++ b/torch_xla/csrc/ops/max_in_dim.h
@@ -8,7 +8,7 @@ namespace ops {
 
 class MaxInDim : public Node {
  public:
-  MaxInDim(const Value& input, int64_t dim, bool keepdim);
+  MaxInDim(const Value& input, xla::int64_t dim, bool keepdim);
 
   std::string ToString() const override;
 
@@ -16,12 +16,12 @@ class MaxInDim : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  int64_t dim() const { return dim_; };
+  xla::int64_t dim() const { return dim_; };
 
   bool keepdim() const { return keepdim_; }
 
  private:
-  int64_t dim_;
+  xla::int64_t dim_;
   bool keepdim_;
 };
 

--- a/torch_xla/csrc/ops/max_pool_nd.cpp
+++ b/torch_xla/csrc/ops/max_pool_nd.cpp
@@ -10,10 +10,11 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const Value& input, int64_t spatial_dim_count,
-                           absl::Span<const int64_t> kernel_size,
-                           absl::Span<const int64_t> stride,
-                           absl::Span<const int64_t> padding, bool ceil_mode) {
+xla::Shape NodeOutputShape(const Value& input, xla::int64_t spatial_dim_count,
+                           absl::Span<const xla::int64_t> kernel_size,
+                           absl::Span<const xla::int64_t> stride,
+                           absl::Span<const xla::int64_t> padding,
+                           bool ceil_mode) {
   auto shape_fn = [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     MaxPoolResult result =
         BuildMaxPoolNd(operands[0], spatial_dim_count, kernel_size, stride,
@@ -23,7 +24,7 @@ xla::Shape NodeOutputShape(const Value& input, int64_t spatial_dim_count,
   return InferOutputShape({input.shape()}, shape_fn);
 }
 
-c10::Symbol MaxPoolNdSymbol(int64_t spatial_dim_count) {
+c10::Symbol MaxPoolNdSymbol(xla::int64_t spatial_dim_count) {
   switch (spatial_dim_count) {
     case 1:
       return at::aten::max_pool1d;
@@ -39,10 +40,10 @@ c10::Symbol MaxPoolNdSymbol(int64_t spatial_dim_count) {
 
 }  // namespace
 
-MaxPoolNd::MaxPoolNd(const Value& input, int64_t spatial_dim_count,
-                     std::vector<int64_t> kernel_size,
-                     std::vector<int64_t> stride, std::vector<int64_t> padding,
-                     bool ceil_mode)
+MaxPoolNd::MaxPoolNd(const Value& input, xla::int64_t spatial_dim_count,
+                     std::vector<xla::int64_t> kernel_size,
+                     std::vector<xla::int64_t> stride,
+                     std::vector<xla::int64_t> padding, bool ceil_mode)
     : Node(ir::OpKind(MaxPoolNdSymbol(spatial_dim_count)), {input},
            [&]() {
              return NodeOutputShape(input, spatial_dim_count, kernel_size,

--- a/torch_xla/csrc/ops/max_pool_nd.h
+++ b/torch_xla/csrc/ops/max_pool_nd.h
@@ -8,9 +8,10 @@ namespace ops {
 
 class MaxPoolNd : public Node {
  public:
-  MaxPoolNd(const Value& input, int64_t spatial_dim_count,
-            std::vector<int64_t> kernel_size, std::vector<int64_t> stride,
-            std::vector<int64_t> padding, bool ceil_mode);
+  MaxPoolNd(const Value& input, xla::int64_t spatial_dim_count,
+            std::vector<xla::int64_t> kernel_size,
+            std::vector<xla::int64_t> stride, std::vector<xla::int64_t> padding,
+            bool ceil_mode);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -18,23 +19,23 @@ class MaxPoolNd : public Node {
 
   std::string ToString() const override;
 
-  int64_t spatial_dim_count() const { return spatial_dim_count_; }
+  xla::int64_t spatial_dim_count() const { return spatial_dim_count_; }
 
-  const std::vector<int64_t>& kernel_size() const { return kernel_size_; }
+  const std::vector<xla::int64_t>& kernel_size() const { return kernel_size_; }
 
-  const std::vector<int64_t>& stride() const { return stride_; }
+  const std::vector<xla::int64_t>& stride() const { return stride_; }
 
-  const std::vector<int64_t>& padding() const { return padding_; }
+  const std::vector<xla::int64_t>& padding() const { return padding_; }
 
   bool ceil_mode() const { return ceil_mode_; }
 
  private:
-  int64_t spatial_dim_count_;
+  xla::int64_t spatial_dim_count_;
   // The parameters of the pooling. Only support the same kernel size, stride
   // and padding in both dimensions for now.
-  std::vector<int64_t> kernel_size_;
-  std::vector<int64_t> stride_;
-  std::vector<int64_t> padding_;
+  std::vector<xla::int64_t> kernel_size_;
+  std::vector<xla::int64_t> stride_;
+  std::vector<xla::int64_t> padding_;
   bool ceil_mode_;
 };
 

--- a/torch_xla/csrc/ops/max_pool_nd_backward.cpp
+++ b/torch_xla/csrc/ops/max_pool_nd_backward.cpp
@@ -11,10 +11,11 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& grad_output, const Value& input,
-                           int64_t spatial_dim_count,
-                           absl::Span<const int64_t> kernel_size,
-                           absl::Span<const int64_t> stride,
-                           absl::Span<const int64_t> padding, bool ceil_mode) {
+                           xla::int64_t spatial_dim_count,
+                           absl::Span<const xla::int64_t> kernel_size,
+                           absl::Span<const xla::int64_t> stride,
+                           absl::Span<const xla::int64_t> padding,
+                           bool ceil_mode) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     XLA_CHECK_EQ(operands.size(), 2);
@@ -26,7 +27,7 @@ xla::Shape NodeOutputShape(const Value& grad_output, const Value& input,
                           lower_for_shape_fn);
 }
 
-c10::Symbol MaxPoolNdBackwardSymbol(int64_t spatial_dim_count) {
+c10::Symbol MaxPoolNdBackwardSymbol(xla::int64_t spatial_dim_count) {
   switch (spatial_dim_count) {
     case 2:
       return at::aten::max_pool2d_with_indices_backward;
@@ -40,10 +41,13 @@ c10::Symbol MaxPoolNdBackwardSymbol(int64_t spatial_dim_count) {
 
 }  // namespace
 
-MaxPoolNdBackward::MaxPoolNdBackward(
-    const Value& grad_output, const Value& input, int64_t spatial_dim_count,
-    std::vector<int64_t> kernel_size, std::vector<int64_t> stride,
-    std::vector<int64_t> padding, bool ceil_mode)
+MaxPoolNdBackward::MaxPoolNdBackward(const Value& grad_output,
+                                     const Value& input,
+                                     xla::int64_t spatial_dim_count,
+                                     std::vector<xla::int64_t> kernel_size,
+                                     std::vector<xla::int64_t> stride,
+                                     std::vector<xla::int64_t> padding,
+                                     bool ceil_mode)
     : Node(ir::OpKind(MaxPoolNdBackwardSymbol(spatial_dim_count)),
            {grad_output, input},
            [&]() {

--- a/torch_xla/csrc/ops/max_pool_nd_backward.h
+++ b/torch_xla/csrc/ops/max_pool_nd_backward.h
@@ -9,9 +9,10 @@ namespace ops {
 class MaxPoolNdBackward : public Node {
  public:
   MaxPoolNdBackward(const Value& grad_output, const Value& input,
-                    int64_t spatial_dim_count, std::vector<int64_t> kernel_size,
-                    std::vector<int64_t> stride, std::vector<int64_t> padding,
-                    bool ceil_mode);
+                    xla::int64_t spatial_dim_count,
+                    std::vector<xla::int64_t> kernel_size,
+                    std::vector<xla::int64_t> stride,
+                    std::vector<xla::int64_t> padding, bool ceil_mode);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -19,21 +20,21 @@ class MaxPoolNdBackward : public Node {
 
   std::string ToString() const override;
 
-  int64_t spatial_dim_count() const { return spatial_dim_count_; }
+  xla::int64_t spatial_dim_count() const { return spatial_dim_count_; }
 
-  const std::vector<int64_t>& kernel_size() const { return kernel_size_; }
+  const std::vector<xla::int64_t>& kernel_size() const { return kernel_size_; }
 
-  const std::vector<int64_t>& stride() const { return stride_; }
+  const std::vector<xla::int64_t>& stride() const { return stride_; }
 
-  const std::vector<int64_t>& padding() const { return padding_; }
+  const std::vector<xla::int64_t>& padding() const { return padding_; }
 
   bool ceil_mode() const { return ceil_mode_; }
 
  private:
-  int64_t spatial_dim_count_;
-  std::vector<int64_t> kernel_size_;
-  std::vector<int64_t> stride_;
-  std::vector<int64_t> padding_;
+  xla::int64_t spatial_dim_count_;
+  std::vector<xla::int64_t> kernel_size_;
+  std::vector<xla::int64_t> stride_;
+  std::vector<xla::int64_t> padding_;
   bool ceil_mode_;
 };
 

--- a/torch_xla/csrc/ops/max_unpool_nd.cpp
+++ b/torch_xla/csrc/ops/max_unpool_nd.cpp
@@ -11,7 +11,7 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& input, const Value& indices,
-                           absl::Span<const int64_t> output_size) {
+                           absl::Span<const xla::int64_t> output_size) {
   auto shape_fn = [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildMaxUnpoolNd(GetCurrentDevice(), operands[0], operands[1],
                             output_size);
@@ -19,7 +19,7 @@ xla::Shape NodeOutputShape(const Value& input, const Value& indices,
   return InferOutputShape({input.shape(), indices.shape()}, shape_fn);
 }
 
-c10::Symbol MaxUnpoolNdSymbol(int64_t spatial_dim_count) {
+c10::Symbol MaxUnpoolNdSymbol(xla::int64_t spatial_dim_count) {
   switch (spatial_dim_count) {
     case 2:
       return at::aten::max_unpool2d;
@@ -34,7 +34,7 @@ c10::Symbol MaxUnpoolNdSymbol(int64_t spatial_dim_count) {
 }  // namespace
 
 MaxUnpoolNd::MaxUnpoolNd(const Value& input, const Value& indices,
-                         std::vector<int64_t> output_size)
+                         std::vector<xla::int64_t> output_size)
     : Node(ir::OpKind(MaxUnpoolNdSymbol(output_size.size())), {input, indices},
            [&]() { return NodeOutputShape(input, indices, output_size); },
            /*num_outputs=*/1, torch::lazy::MHash(output_size)),

--- a/torch_xla/csrc/ops/max_unpool_nd.h
+++ b/torch_xla/csrc/ops/max_unpool_nd.h
@@ -9,7 +9,7 @@ namespace ops {
 class MaxUnpoolNd : public Node {
  public:
   MaxUnpoolNd(const Value& input, const Value& indices,
-              std::vector<int64_t> output_size);
+              std::vector<xla::int64_t> output_size);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -17,10 +17,10 @@ class MaxUnpoolNd : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& output_size() const { return output_size_; }
+  const std::vector<xla::int64_t>& output_size() const { return output_size_; }
 
  private:
-  std::vector<int64_t> output_size_;
+  std::vector<xla::int64_t> output_size_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/max_unpool_nd_backward.cpp
+++ b/torch_xla/csrc/ops/max_unpool_nd_backward.cpp
@@ -12,7 +12,7 @@ namespace {
 
 xla::Shape NodeOutputShape(const Value& grad_output, const Value& input,
                            const Value& indices,
-                           absl::Span<const int64_t> output_size) {
+                           absl::Span<const xla::int64_t> output_size) {
   auto shape_fn = [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildMaxUnpoolNdBackward(operands[0], operands[1], operands[2],
                                     output_size);
@@ -21,7 +21,7 @@ xla::Shape NodeOutputShape(const Value& grad_output, const Value& input,
                           shape_fn);
 }
 
-c10::Symbol MaxUnpoolNdBackwardSymbol(int64_t spatial_dim_count) {
+c10::Symbol MaxUnpoolNdBackwardSymbol(xla::int64_t spatial_dim_count) {
   switch (spatial_dim_count) {
     case 2:
       return at::aten::max_unpool2d_backward;
@@ -38,7 +38,7 @@ c10::Symbol MaxUnpoolNdBackwardSymbol(int64_t spatial_dim_count) {
 MaxUnpoolNdBackward::MaxUnpoolNdBackward(const Value& grad_output,
                                          const Value& input,
                                          const Value& indices,
-                                         std::vector<int64_t> output_size)
+                                         std::vector<xla::int64_t> output_size)
     : Node(ir::OpKind(MaxUnpoolNdBackwardSymbol(output_size.size())),
            {grad_output, input, indices},
            [&]() {

--- a/torch_xla/csrc/ops/max_unpool_nd_backward.h
+++ b/torch_xla/csrc/ops/max_unpool_nd_backward.h
@@ -9,7 +9,8 @@ namespace ops {
 class MaxUnpoolNdBackward : public Node {
  public:
   MaxUnpoolNdBackward(const Value& grad_output, const Value& input,
-                      const Value& indices, std::vector<int64_t> output_size);
+                      const Value& indices,
+                      std::vector<xla::int64_t> output_size);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -17,10 +18,10 @@ class MaxUnpoolNdBackward : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& output_size() const { return output_size_; }
+  const std::vector<xla::int64_t>& output_size() const { return output_size_; }
 
  private:
-  std::vector<int64_t> output_size_;
+  std::vector<xla::int64_t> output_size_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/mean.cpp
+++ b/torch_xla/csrc/ops/mean.cpp
@@ -13,7 +13,8 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::XlaOp LowerMean(xla::XlaOp input, const std::vector<int64_t>& dimensions,
+xla::XlaOp LowerMean(xla::XlaOp input,
+                     const std::vector<xla::int64_t>& dimensions,
                      bool keep_reduced_dimensions,
                      const c10::optional<at::ScalarType>& dtype) {
   xla::XlaOp result = BuildMean(input, dimensions, keep_reduced_dimensions);
@@ -23,7 +24,7 @@ xla::XlaOp LowerMean(xla::XlaOp input, const std::vector<int64_t>& dimensions,
 }
 
 xla::Shape NodeOutputShape(const Value& input,
-                           const std::vector<int64_t>& dimensions,
+                           const std::vector<xla::int64_t>& dimensions,
                            bool keep_reduced_dimensions,
                            const c10::optional<at::ScalarType>& dtype) {
   auto lower_for_shape_fn =
@@ -35,7 +36,7 @@ xla::Shape NodeOutputShape(const Value& input,
 
 }  // namespace
 
-Mean::Mean(const Value& input, std::vector<int64_t> dimensions,
+Mean::Mean(const Value& input, std::vector<xla::int64_t> dimensions,
            bool keep_reduced_dimensions, c10::optional<at::ScalarType> dtype)
     : Node(ir::OpKind(at::aten::mean), {input},
            [&]() {

--- a/torch_xla/csrc/ops/mean.h
+++ b/torch_xla/csrc/ops/mean.h
@@ -14,7 +14,7 @@ namespace ops {
 
 class Mean : public Node {
  public:
-  Mean(const Value& input, std::vector<int64_t> dimensions,
+  Mean(const Value& input, std::vector<xla::int64_t> dimensions,
        bool keep_reduced_dimensions, c10::optional<at::ScalarType> dtype);
 
   std::string ToString() const override;
@@ -23,14 +23,14 @@ class Mean : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  const std::vector<int64_t>& dimensions() const { return dimensions_; }
+  const std::vector<xla::int64_t>& dimensions() const { return dimensions_; }
 
   bool keep_reduced_dimensions() const { return keep_reduced_dimensions_; }
 
   const c10::optional<at::ScalarType>& dtype() const { return dtype_; }
 
  private:
-  std::vector<int64_t> dimensions_;
+  std::vector<xla::int64_t> dimensions_;
   bool keep_reduced_dimensions_;
   c10::optional<at::ScalarType> dtype_;
 };

--- a/torch_xla/csrc/ops/min_in_dim.cpp
+++ b/torch_xla/csrc/ops/min_in_dim.cpp
@@ -9,7 +9,7 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const Value& input, int64_t dim, bool keepdim) {
+xla::Shape NodeOutputShape(const Value& input, xla::int64_t dim, bool keepdim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     xla::XlaOp values = BuildMinInDim(operands[0], dim, keepdim);
@@ -21,7 +21,7 @@ xla::Shape NodeOutputShape(const Value& input, int64_t dim, bool keepdim) {
 
 }  // namespace
 
-MinInDim::MinInDim(const Value& input, int64_t dim, bool keepdim)
+MinInDim::MinInDim(const Value& input, xla::int64_t dim, bool keepdim)
     : Node(ir::OpKind(at::aten::min), {input},
            [&]() { return NodeOutputShape(input, dim, keepdim); },
            /*num_outputs=*/2, torch::lazy::MHash(dim, keepdim)),

--- a/torch_xla/csrc/ops/min_in_dim.h
+++ b/torch_xla/csrc/ops/min_in_dim.h
@@ -8,7 +8,7 @@ namespace ops {
 
 class MinInDim : public Node {
  public:
-  MinInDim(const Value& input, int64_t dim, bool keepdim);
+  MinInDim(const Value& input, xla::int64_t dim, bool keepdim);
 
   std::string ToString() const override;
 
@@ -16,12 +16,12 @@ class MinInDim : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  int64_t dim() const { return dim_; };
+  xla::int64_t dim() const { return dim_; };
 
   bool keepdim() const { return keepdim_; }
 
  private:
-  int64_t dim_;
+  xla::int64_t dim_;
   bool keepdim_;
 };
 

--- a/torch_xla/csrc/ops/nms.cpp
+++ b/torch_xla/csrc/ops/nms.cpp
@@ -13,7 +13,8 @@ namespace {
 
 xla::Shape NodeOutputShape(const Value& boxes, const Value& scores,
                            const Value& score_threshold,
-                           const Value& iou_threshold, int64_t output_size) {
+                           const Value& iou_threshold,
+                           xla::int64_t output_size) {
   auto shape_fn = [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     NmsResult result = BuildNms(operands[0], operands[1], operands[2],
                                 operands[3], output_size);
@@ -28,7 +29,7 @@ xla::Shape NodeOutputShape(const Value& boxes, const Value& scores,
 }  // namespace
 
 Nms::Nms(const Value& boxes, const Value& scores, const Value& score_threshold,
-         const Value& iou_threshold, int64_t output_size)
+         const Value& iou_threshold, xla::int64_t output_size)
     : Node(xla_nms, {boxes, scores, score_threshold, iou_threshold},
            [&]() {
              return NodeOutputShape(boxes, scores, score_threshold,

--- a/torch_xla/csrc/ops/nms.h
+++ b/torch_xla/csrc/ops/nms.h
@@ -9,7 +9,7 @@ namespace ops {
 class Nms : public Node {
  public:
   Nms(const Value& boxes, const Value& scores, const Value& score_threshold,
-      const Value& iou_threshold, int64_t output_size);
+      const Value& iou_threshold, xla::int64_t output_size);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -17,10 +17,10 @@ class Nms : public Node {
 
   std::string ToString() const override;
 
-  int64_t output_size() const { return output_size_; }
+  xla::int64_t output_size() const { return output_size_; }
 
  private:
-  int64_t output_size_;
+  xla::int64_t output_size_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/nonzero.cpp
+++ b/torch_xla/csrc/ops/nonzero.cpp
@@ -12,7 +12,7 @@ namespace {
 
 xla::Shape NodeOutputShape(const Value& input) {
   const xla::Shape& input_shape = input.shape();
-  int64_t index_elements = xla::ShapeUtil::ElementsIn(input_shape);
+  xla::int64_t index_elements = xla::ShapeUtil::ElementsIn(input_shape);
   xla::PrimitiveType size_type = GetShapeDimensionType(/*device=*/nullptr);
   xla::Shape result_shape = xla::ShapeUtil::MakeShape(
       size_type, {index_elements, input_shape.rank()});

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -264,14 +264,14 @@ NodePtr SigmoidBackward(const Value& grad_output, const Value& output) {
 }
 
 NodePtr LogSoftmaxBackwardOp(const Value& grad_output, const Value& output,
-                             int64_t dim) {
+                             xla::int64_t dim) {
   return MakeNode<LogSoftmaxBackward>(
       grad_output, output,
       XlaHelpers::GetCanonicalDimensionIndex(dim, grad_output.shape().rank()));
 }
 
 NodePtr SoftmaxBackwardOp(const Value& grad_output, const Value& output,
-                          int64_t dim) {
+                          xla::int64_t dim) {
   return MakeNode<SoftmaxBackward>(
       grad_output, output,
       XlaHelpers::GetCanonicalDimensionIndex(dim, grad_output.shape().rank()));
@@ -513,36 +513,36 @@ NodePtr ARange(const at::Scalar& start, const at::Scalar& end,
                                          step.toDouble());
       break;
     case xla::PrimitiveType::U8:
-      values = XlaHelpers::Range<uint8_t>(start.toByte(), end.toByte(),
-                                          step.toByte());
+      values = XlaHelpers::Range<xla::uint8>(start.toByte(), end.toByte(),
+                                             step.toByte());
       break;
     case xla::PrimitiveType::S8:
-      values = XlaHelpers::Range<int8_t>(start.toChar(), end.toChar(),
-                                         step.toChar());
+      values = XlaHelpers::Range<xla::int8>(start.toChar(), end.toChar(),
+                                            step.toChar());
       break;
     case xla::PrimitiveType::S16:
-      values = XlaHelpers::Range<int16_t>(start.toShort(), end.toShort(),
-                                          step.toShort());
+      values = XlaHelpers::Range<xla::int16>(start.toShort(), end.toShort(),
+                                             step.toShort());
       break;
     case xla::PrimitiveType::U16:
-      values =
-          XlaHelpers::Range<uint16_t>(start.toInt(), end.toInt(), step.toInt());
+      values = XlaHelpers::Range<xla::uint16>(start.toInt(), end.toInt(),
+                                              step.toInt());
       break;
     case xla::PrimitiveType::S32:
-      values =
-          XlaHelpers::Range<int32_t>(start.toInt(), end.toInt(), step.toInt());
+      values = XlaHelpers::Range<xla::int32>(start.toInt(), end.toInt(),
+                                             step.toInt());
       break;
     case xla::PrimitiveType::U32:
-      values = XlaHelpers::Range<uint32_t>(start.toLong(), end.toLong(),
-                                           step.toLong());
+      values = XlaHelpers::Range<xla::uint32>(start.toLong(), end.toLong(),
+                                              step.toLong());
       break;
     case xla::PrimitiveType::S64:
-      values = XlaHelpers::Range<int64_t>(start.toLong(), end.toLong(),
-                                          step.toLong());
+      values = XlaHelpers::Range<xla::int64_t>(start.toLong(), end.toLong(),
+                                               step.toLong());
       break;
     case xla::PrimitiveType::U64:
-      values = XlaHelpers::Range<uint64_t>(start.toLong(), end.toLong(),
-                                           step.toLong());
+      values = XlaHelpers::Range<xla::uint64>(start.toLong(), end.toLong(),
+                                              step.toLong());
       break;
     default:
       XLA_ERROR() << "XLA type not supported: " << type;
@@ -575,11 +575,11 @@ NodePtr BroadcastTensors(absl::Span<const Value> tensors) {
 
 NodePtr Norm(const Value& input, const c10::optional<at::Scalar>& p,
              c10::optional<at::ScalarType> dtype,
-             absl::Span<const int64_t> dims, bool keepdim) {
+             absl::Span<const xla::int64_t> dims, bool keepdim) {
   ScopePusher ir_scope(at::aten::norm.toQualString());
-  auto dimensions = xla::util::ToVector<int64_t>(dims);
+  auto dimensions = xla::util::ToVector<xla::int64_t>(dims);
   if (dimensions.empty()) {
-    dimensions = xla::util::Iota<int64_t>(input.shape().rank());
+    dimensions = xla::util::Iota<xla::int64_t>(input.shape().rank());
   }
   if (!p.has_value() || p->toDouble() == 2.0) {
     NodePtr square = input * input;
@@ -610,7 +610,8 @@ NodePtr Norm(const Value& input, const c10::optional<at::Scalar>& p,
   return Pow(result, norm_exp_inv);
 }
 
-NodePtr Identity(int64_t lines, int64_t cols, xla::PrimitiveType element_type) {
+NodePtr Identity(xla::int64_t lines, xla::int64_t cols,
+                 xla::PrimitiveType element_type) {
   auto lower_fn = [=](const Node& node, LoweringContext* loctx) -> XlaOpVector {
     return node.ReturnOp(
         xla::IdentityMatrix(loctx->builder(), element_type, lines, cols),
@@ -704,7 +705,7 @@ NodePtr MaxUnary(const Value& input) {
         XlaHelpers::ScalarValue(min_max.min, element_type, loctx->builder());
     xla::XlaOp result = xla::Reduce(
         xla_input, init_value, XlaHelpers::CreateMaxComputation(element_type),
-        xla::util::Iota<int64_t>(input_shape.rank()));
+        xla::util::Iota<xla::int64_t>(input_shape.rank()));
     return node.ReturnOp(xla::Reshape(result, {}), loctx);
   };
   XLA_CHECK_GT(xla::ShapeUtil::ElementsIn(input.shape()), 0);
@@ -723,7 +724,7 @@ NodePtr MinUnary(const Value& input) {
         XlaHelpers::ScalarValue(min_max.max, element_type, loctx->builder());
     xla::XlaOp result = xla::Reduce(
         xla_input, init_value, XlaHelpers::CreateMinComputation(element_type),
-        xla::util::Iota<int64_t>(input_shape.rank()));
+        xla::util::Iota<xla::int64_t>(input_shape.rank()));
     return node.ReturnOp(xla::Reshape(result, {}), loctx);
   };
   XLA_CHECK_GT(xla::ShapeUtil::ElementsIn(input.shape()), 0);

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -138,10 +138,10 @@ NodePtr SiLUBackward(const Value& grad_output, const Value& input);
 NodePtr SigmoidBackward(const Value& grad_output, const Value& output);
 
 NodePtr LogSoftmaxBackwardOp(const Value& grad_output, const Value& output,
-                             int64_t dim);
+                             xla::int64_t dim);
 
 NodePtr SoftmaxBackwardOp(const Value& grad_output, const Value& output,
-                          int64_t dim);
+                          xla::int64_t dim);
 
 NodePtr Clamp(const Value& input, const Value& min, const Value& max);
 
@@ -180,9 +180,10 @@ NodePtr BroadcastTensors(absl::Span<const Value> tensors);
 
 NodePtr Norm(const Value& input, const c10::optional<at::Scalar>& p,
              c10::optional<at::ScalarType> dtype,
-             absl::Span<const int64_t> dims, bool keepdim);
+             absl::Span<const xla::int64_t> dims, bool keepdim);
 
-NodePtr Identity(int64_t lines, int64_t cols, xla::PrimitiveType element_type);
+NodePtr Identity(xla::int64_t lines, xla::int64_t cols,
+                 xla::PrimitiveType element_type);
 
 NodePtr Elu(const Value& input, const at::Scalar& alpha,
             const at::Scalar& scale, const at::Scalar& input_scale);

--- a/torch_xla/csrc/ops/permute.cpp
+++ b/torch_xla/csrc/ops/permute.cpp
@@ -10,7 +10,8 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const Value& input, absl::Span<const int64_t> dims) {
+xla::Shape NodeOutputShape(const Value& input,
+                           absl::Span<const xla::int64_t> dims) {
   auto lower_for_shape_fn =
       [dims](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     XLA_CHECK_EQ(operands.size(), 1);
@@ -21,7 +22,7 @@ xla::Shape NodeOutputShape(const Value& input, absl::Span<const int64_t> dims) {
 
 }  // namespace
 
-Permute::Permute(const Value& input, std::vector<int64_t> dims)
+Permute::Permute(const Value& input, std::vector<xla::int64_t> dims)
     : Node(ir::OpKind(at::aten::permute), {input},
            [&]() { return NodeOutputShape(input, dims); },
            /*num_outputs=*/1, torch::lazy::MHash(dims)),
@@ -43,8 +44,9 @@ std::string Permute::ToString() const {
   return ss.str();
 }
 
-xla::Shape Permute::MakePermuteShape(const xla::Shape& source_shape,
-                                     absl::Span<const int64_t> permutation) {
+xla::Shape Permute::MakePermuteShape(
+    const xla::Shape& source_shape,
+    absl::Span<const xla::int64_t> permutation) {
   return XlaHelpers::GetDynamicReshape(
       source_shape,
       XlaHelpers::Permute(permutation, source_shape.dimensions()));

--- a/torch_xla/csrc/ops/permute.h
+++ b/torch_xla/csrc/ops/permute.h
@@ -9,7 +9,7 @@ namespace ops {
 
 class Permute : public Node {
  public:
-  Permute(const Value& input, std::vector<int64_t> dims);
+  Permute(const Value& input, std::vector<xla::int64_t> dims);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -17,14 +17,15 @@ class Permute : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& dims() const { return dims_; }
+  const std::vector<xla::int64_t>& dims() const { return dims_; }
 
-  static xla::Shape MakePermuteShape(const xla::Shape& source_shape,
-                                     absl::Span<const int64_t> permutation);
+  static xla::Shape MakePermuteShape(
+      const xla::Shape& source_shape,
+      absl::Span<const xla::int64_t> permutation);
 
  private:
   // The permutation of dimensions.
-  std::vector<int64_t> dims_;
+  std::vector<xla::int64_t> dims_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/prod.cpp
+++ b/torch_xla/csrc/ops/prod.cpp
@@ -14,7 +14,8 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::XlaOp LowerProd(xla::XlaOp input, const std::vector<int64_t>& dimensions,
+xla::XlaOp LowerProd(xla::XlaOp input,
+                     const std::vector<xla::int64_t>& dimensions,
                      bool keep_reduced_dimensions,
                      c10::optional<at::ScalarType> dtype) {
   xla::XlaOp casted_input;
@@ -28,7 +29,8 @@ xla::XlaOp LowerProd(xla::XlaOp input, const std::vector<int64_t>& dimensions,
   return BuildProd(casted_input, dimensions, keep_reduced_dimensions);
 }
 
-xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
+xla::Shape NodeOutputShape(const Value& input,
+                           std::vector<xla::int64_t>& dimensions,
                            bool keep_reduced_dimensions,
                            c10::optional<at::ScalarType> dtype) {
   auto lower_for_shape_fn =
@@ -40,7 +42,7 @@ xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
 
 }  // namespace
 
-Prod::Prod(const Value& input, std::vector<int64_t> dimensions,
+Prod::Prod(const Value& input, std::vector<xla::int64_t> dimensions,
            bool keep_reduced_dimensions, c10::optional<at::ScalarType> dtype)
     : Node(ir::OpKind(at::aten::prod), {input},
            [&]() {

--- a/torch_xla/csrc/ops/prod.h
+++ b/torch_xla/csrc/ops/prod.h
@@ -12,7 +12,7 @@ namespace ops {
 
 class Prod : public Node {
  public:
-  Prod(const Value& input, std::vector<int64_t> dimensions,
+  Prod(const Value& input, std::vector<xla::int64_t> dimensions,
        bool keep_reduced_dimensions, c10::optional<at::ScalarType> dtype);
 
   std::string ToString() const override;
@@ -21,14 +21,14 @@ class Prod : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  const std::vector<int64_t>& dimensions() const { return dimensions_; }
+  const std::vector<xla::int64_t>& dimensions() const { return dimensions_; }
 
   bool keep_reduced_dimensions() const { return keep_reduced_dimensions_; }
 
   const c10::optional<at::ScalarType>& dtype() const { return dtype_; }
 
  private:
-  std::vector<int64_t> dimensions_;
+  std::vector<xla::int64_t> dimensions_;
   bool keep_reduced_dimensions_;
   c10::optional<at::ScalarType> dtype_;
 };

--- a/torch_xla/csrc/ops/qr.cpp
+++ b/torch_xla/csrc/ops/qr.cpp
@@ -22,8 +22,8 @@ xla::Shape NodeOutputShape(const Value& input, bool some) {
   const xla::Shape& input_shape = input.shape();
   XLA_CHECK_GE(input_shape.rank(), 2) << input_shape;
   // The input tensor is ..., M, N
-  int64_t m_dim = input_shape.dimensions(input_shape.rank() - 2);
-  int64_t n_dim = input_shape.dimensions(input_shape.rank() - 1);
+  xla::int64_t m_dim = input_shape.dimensions(input_shape.rank() - 2);
+  xla::int64_t n_dim = input_shape.dimensions(input_shape.rank() - 1);
   xla::Shape qshape(input_shape);
   xla::Shape rshape(input_shape);
   if (!some) {

--- a/torch_xla/csrc/ops/reduce_scatter.cpp
+++ b/torch_xla/csrc/ops/reduce_scatter.cpp
@@ -11,10 +11,10 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(AllReduceType reduce_type, const Value input,
-                           const Value& token, double scale,
-                           int64_t scatter_dim, int64_t shard_count,
-                           const std::vector<std::vector<int64_t>>& groups) {
+xla::Shape NodeOutputShape(
+    AllReduceType reduce_type, const Value input, const Value& token,
+    double scale, xla::int64_t scatter_dim, xla::int64_t shard_count,
+    const std::vector<std::vector<xla::int64_t>>& groups) {
   auto shape_fn = [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     xla::XlaOp inputOp = operands[0];
     xla::XlaOp tokenOp = operands[1];
@@ -29,8 +29,8 @@ xla::Shape NodeOutputShape(AllReduceType reduce_type, const Value input,
 
 ReduceScatter::ReduceScatter(AllReduceType reduce_type, const Value& input,
                              const Value& token, double scale,
-                             int64_t scatter_dim, int64_t shard_count,
-                             std::vector<std::vector<int64_t>> groups)
+                             xla::int64_t scatter_dim, xla::int64_t shard_count,
+                             std::vector<std::vector<xla::int64_t>> groups)
     : Node(xla_reduce_scatter, {input, token},
            [&]() {
              return NodeOutputShape(reduce_type, input, token, scale,

--- a/torch_xla/csrc/ops/reduce_scatter.h
+++ b/torch_xla/csrc/ops/reduce_scatter.h
@@ -10,8 +10,9 @@ namespace ops {
 class ReduceScatter : public Node {
  public:
   ReduceScatter(AllReduceType reduce_type, const Value& input,
-                const Value& token, double scale, int64_t scatter_dim,
-                int64_t shard_count, std::vector<std::vector<int64_t>> groups);
+                const Value& token, double scale, xla::int64_t scatter_dim,
+                xla::int64_t shard_count,
+                std::vector<std::vector<xla::int64_t>> groups);
 
   std::string ToString() const override;
 
@@ -23,14 +24,16 @@ class ReduceScatter : public Node {
 
   double scale() const { return scale_; }
 
-  const std::vector<std::vector<int64_t>>& groups() const { return groups_; }
+  const std::vector<std::vector<xla::int64_t>>& groups() const {
+    return groups_;
+  }
 
  private:
   AllReduceType reduce_type_;
   double scale_;
-  int64_t scatter_dim_;
-  int64_t shard_count_;
-  std::vector<std::vector<int64_t>> groups_;
+  xla::int64_t scatter_dim_;
+  xla::int64_t shard_count_;
+  std::vector<std::vector<xla::int64_t>> groups_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/reflection_pad2d.cpp
+++ b/torch_xla/csrc/ops/reflection_pad2d.cpp
@@ -11,7 +11,7 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& input,
-                           absl::Span<const int64_t> padding) {
+                           absl::Span<const xla::int64_t> padding) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildReflectionPad2d(operands[0], padding);
@@ -22,7 +22,7 @@ xla::Shape NodeOutputShape(const Value& input,
 }  // namespace
 
 ReflectionPad2d::ReflectionPad2d(const Value& input,
-                                 std::vector<int64_t> padding)
+                                 std::vector<xla::int64_t> padding)
     : Node(OpKind(at::aten::reflection_pad2d), {input},
            [&]() { return NodeOutputShape(input, padding); },
            /*num_outputs=*/1, torch::lazy::MHash(padding)),

--- a/torch_xla/csrc/ops/reflection_pad2d.h
+++ b/torch_xla/csrc/ops/reflection_pad2d.h
@@ -10,7 +10,7 @@ namespace ops {
 
 class ReflectionPad2d : public Node {
  public:
-  ReflectionPad2d(const Value& input, std::vector<int64_t> padding);
+  ReflectionPad2d(const Value& input, std::vector<xla::int64_t> padding);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -18,10 +18,10 @@ class ReflectionPad2d : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& padding() const { return padding_; }
+  const std::vector<xla::int64_t>& padding() const { return padding_; }
 
  private:
-  std::vector<int64_t> padding_;
+  std::vector<xla::int64_t> padding_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/reflection_pad2d_backward.cpp
+++ b/torch_xla/csrc/ops/reflection_pad2d_backward.cpp
@@ -11,7 +11,7 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& grad_output, const Value& input,
-                           absl::Span<const int64_t> padding) {
+                           absl::Span<const xla::int64_t> padding) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildReflectionPadBackward(operands[0], operands[1], padding);
@@ -22,9 +22,9 @@ xla::Shape NodeOutputShape(const Value& grad_output, const Value& input,
 
 }  // namespace
 
-ReflectionPad2dBackward::ReflectionPad2dBackward(const Value& grad_output,
-                                                 const Value& input,
-                                                 std::vector<int64_t> padding)
+ReflectionPad2dBackward::ReflectionPad2dBackward(
+    const Value& grad_output, const Value& input,
+    std::vector<xla::int64_t> padding)
     : Node(OpKind(at::aten::reflection_pad2d_backward), {grad_output, input},
            [&]() { return NodeOutputShape(grad_output, input, padding); },
            /*num_outputs=*/1, torch::lazy::MHash(padding)),

--- a/torch_xla/csrc/ops/reflection_pad2d_backward.h
+++ b/torch_xla/csrc/ops/reflection_pad2d_backward.h
@@ -11,7 +11,7 @@ namespace ops {
 class ReflectionPad2dBackward : public Node {
  public:
   ReflectionPad2dBackward(const Value& gard_output, const Value& input,
-                          std::vector<int64_t> padding);
+                          std::vector<xla::int64_t> padding);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -19,10 +19,10 @@ class ReflectionPad2dBackward : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& padding() const { return padding_; }
+  const std::vector<xla::int64_t>& padding() const { return padding_; }
 
  private:
-  std::vector<int64_t> padding_;
+  std::vector<xla::int64_t> padding_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/repeat.cpp
+++ b/torch_xla/csrc/ops/repeat.cpp
@@ -11,7 +11,7 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& input,
-                           absl::Span<const int64_t> repeats) {
+                           absl::Span<const xla::int64_t> repeats) {
   auto lower_for_shape_fn =
       [repeats](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     XLA_CHECK_EQ(operands.size(), 1);
@@ -22,7 +22,7 @@ xla::Shape NodeOutputShape(const Value& input,
 
 }  // namespace
 
-Repeat::Repeat(const Value& input, std::vector<int64_t> repeats)
+Repeat::Repeat(const Value& input, std::vector<xla::int64_t> repeats)
     : Node(ir::OpKind(at::aten::repeat), {input},
            [&]() { return NodeOutputShape(input, repeats); },
            /*num_outputs=*/1, torch::lazy::MHash(repeats)),

--- a/torch_xla/csrc/ops/repeat.h
+++ b/torch_xla/csrc/ops/repeat.h
@@ -9,7 +9,7 @@ namespace ops {
 
 class Repeat : public Node {
  public:
-  Repeat(const Value& input, std::vector<int64_t> repeats);
+  Repeat(const Value& input, std::vector<xla::int64_t> repeats);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -17,11 +17,11 @@ class Repeat : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& repeats() const { return repeats_; }
+  const std::vector<xla::int64_t>& repeats() const { return repeats_; }
 
  private:
   // The number of repeats along each dimension.
-  std::vector<int64_t> repeats_;
+  std::vector<xla::int64_t> repeats_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/replication_pad.cpp
+++ b/torch_xla/csrc/ops/replication_pad.cpp
@@ -12,7 +12,7 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& input,
-                           absl::Span<const int64_t> padding) {
+                           absl::Span<const xla::int64_t> padding) {
   auto shape_fn = [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildReplicationPad(operands[0], padding);
   };
@@ -21,7 +21,8 @@ xla::Shape NodeOutputShape(const Value& input,
 
 }  // namespace
 
-ReplicationPad::ReplicationPad(const Value& input, std::vector<int64_t> padding)
+ReplicationPad::ReplicationPad(const Value& input,
+                               std::vector<xla::int64_t> padding)
     : Node(xla_replication_pad, {input},
            [&]() { return NodeOutputShape(input, padding); },
            /*num_outputs=*/1, torch::lazy::MHash(padding)),

--- a/torch_xla/csrc/ops/replication_pad.h
+++ b/torch_xla/csrc/ops/replication_pad.h
@@ -9,7 +9,7 @@ namespace ops {
 
 class ReplicationPad : public Node {
  public:
-  ReplicationPad(const Value& input, std::vector<int64_t> padding);
+  ReplicationPad(const Value& input, std::vector<xla::int64_t> padding);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -17,10 +17,10 @@ class ReplicationPad : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& padding() const { return padding_; }
+  const std::vector<xla::int64_t>& padding() const { return padding_; }
 
  private:
-  std::vector<int64_t> padding_;
+  std::vector<xla::int64_t> padding_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/replication_pad_backward.cpp
+++ b/torch_xla/csrc/ops/replication_pad_backward.cpp
@@ -12,7 +12,7 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& grad_output, const Value& input,
-                           absl::Span<const int64_t> padding) {
+                           absl::Span<const xla::int64_t> padding) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildReplicationPadBackward(operands[0], operands[1], padding);
@@ -23,9 +23,9 @@ xla::Shape NodeOutputShape(const Value& grad_output, const Value& input,
 
 }  // namespace
 
-ReplicationPadBackward::ReplicationPadBackward(const Value& grad_output,
-                                               const Value& input,
-                                               std::vector<int64_t> padding)
+ReplicationPadBackward::ReplicationPadBackward(
+    const Value& grad_output, const Value& input,
+    std::vector<xla::int64_t> padding)
     : Node(xla_replication_pad_backward, {grad_output, input},
            [&]() { return NodeOutputShape(grad_output, input, padding); },
            /*num_outputs=*/1, torch::lazy::MHash(padding)),

--- a/torch_xla/csrc/ops/replication_pad_backward.h
+++ b/torch_xla/csrc/ops/replication_pad_backward.h
@@ -11,7 +11,7 @@ namespace ops {
 class ReplicationPadBackward : public Node {
  public:
   ReplicationPadBackward(const Value& gard_output, const Value& input,
-                         std::vector<int64_t> padding);
+                         std::vector<xla::int64_t> padding);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -19,10 +19,10 @@ class ReplicationPadBackward : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& padding() const { return padding_; }
+  const std::vector<xla::int64_t>& padding() const { return padding_; }
 
  private:
-  std::vector<int64_t> padding_;
+  std::vector<xla::int64_t> padding_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/resize.cpp
+++ b/torch_xla/csrc/ops/resize.cpp
@@ -10,13 +10,14 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const Value& input, absl::Span<const int64_t> size) {
+xla::Shape NodeOutputShape(const Value& input,
+                           absl::Span<const xla::int64_t> size) {
   return xla::ShapeUtil::MakeShape(input.shape().element_type(), size);
 }
 
 }  // namespace
 
-Resize::Resize(const Value& input, std::vector<int64_t> size)
+Resize::Resize(const Value& input, std::vector<xla::int64_t> size)
     : Node(ir::OpKind(at::aten::resize), {input},
            [&]() { return NodeOutputShape(input, size); },
            /*num_outputs=*/1, torch::lazy::MHash(size)),

--- a/torch_xla/csrc/ops/resize.h
+++ b/torch_xla/csrc/ops/resize.h
@@ -8,7 +8,7 @@ namespace ops {
 
 class Resize : public Node {
  public:
-  Resize(const Value& input, std::vector<int64_t> size);
+  Resize(const Value& input, std::vector<xla::int64_t> size);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -16,10 +16,10 @@ class Resize : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& size() const { return size_; }
+  const std::vector<xla::int64_t>& size() const { return size_; }
 
  private:
-  std::vector<int64_t> size_;
+  std::vector<xla::int64_t> size_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/scalar.cpp
+++ b/torch_xla/csrc/ops/scalar.cpp
@@ -39,28 +39,28 @@ XlaOpVector Scalar::Lower(LoweringContext* loctx) const {
       literal.Set<bool>({}, static_cast<bool>(value_.toInt()));
       break;
     case xla::PrimitiveType::S8:
-      literal.Set<int8_t>({}, static_cast<int8_t>(value_.toChar()));
+      literal.Set<xla::int8>({}, static_cast<xla::int8>(value_.toChar()));
       break;
     case xla::PrimitiveType::U8:
-      literal.Set<uint8_t>({}, static_cast<uint8_t>(value_.toByte()));
+      literal.Set<xla::uint8>({}, static_cast<xla::uint8>(value_.toByte()));
       break;
     case xla::PrimitiveType::S16:
-      literal.Set<int16_t>({}, static_cast<int16_t>(value_.toShort()));
+      literal.Set<xla::int16>({}, static_cast<xla::int16>(value_.toShort()));
       break;
     case xla::PrimitiveType::U16:
-      literal.Set<uint16_t>({}, static_cast<uint16_t>(value_.toShort()));
+      literal.Set<xla::uint16>({}, static_cast<xla::uint16>(value_.toShort()));
       break;
     case xla::PrimitiveType::S32:
-      literal.Set<int32_t>({}, static_cast<int32_t>(value_.toInt()));
+      literal.Set<xla::int32>({}, static_cast<xla::int32>(value_.toInt()));
       break;
     case xla::PrimitiveType::U32:
-      literal.Set<uint32_t>({}, static_cast<uint32_t>(value_.toInt()));
+      literal.Set<xla::uint32>({}, static_cast<xla::uint32>(value_.toInt()));
       break;
     case xla::PrimitiveType::S64:
-      literal.Set<int64_t>({}, static_cast<int64_t>(value_.toLong()));
+      literal.Set<xla::int64_t>({}, static_cast<xla::int64_t>(value_.toLong()));
       break;
     case xla::PrimitiveType::U64:
-      literal.Set<uint64_t>({}, static_cast<uint64_t>(value_.toLong()));
+      literal.Set<xla::uint64>({}, static_cast<xla::uint64>(value_.toLong()));
       break;
     case xla::PrimitiveType::F32:
       literal.Set<float>({}, static_cast<float>(value_.toDouble()));

--- a/torch_xla/csrc/ops/scatter.cpp
+++ b/torch_xla/csrc/ops/scatter.cpp
@@ -8,7 +8,7 @@ namespace ir {
 namespace ops {
 
 Scatter::Scatter(const Value& input, const Value& index, const Value& src,
-                 int64_t dim)
+                 xla::int64_t dim)
     : Node(ir::OpKind(at::aten::scatter), {input, index, src}, input.shape(),
            /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}

--- a/torch_xla/csrc/ops/scatter.h
+++ b/torch_xla/csrc/ops/scatter.h
@@ -9,7 +9,7 @@ namespace ops {
 class Scatter : public Node {
  public:
   Scatter(const Value& input, const Value& index, const Value& src,
-          int64_t dim);
+          xla::int64_t dim);
 
   std::string ToString() const override;
 
@@ -17,10 +17,10 @@ class Scatter : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  int64_t dim() const { return dim_; };
+  xla::int64_t dim() const { return dim_; };
 
  private:
-  int64_t dim_;
+  xla::int64_t dim_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/scatter_add.cpp
+++ b/torch_xla/csrc/ops/scatter_add.cpp
@@ -10,7 +10,7 @@ namespace ir {
 namespace ops {
 
 ScatterAdd::ScatterAdd(const Value& input, const Value& index, const Value& src,
-                       int64_t dim)
+                       xla::int64_t dim)
     : Node(ir::OpKind(at::aten::scatter_add), {input, index, src},
            input.shape(),
            /*num_outputs=*/1, torch::lazy::MHash(dim)),

--- a/torch_xla/csrc/ops/scatter_add.h
+++ b/torch_xla/csrc/ops/scatter_add.h
@@ -9,7 +9,7 @@ namespace ops {
 class ScatterAdd : public Node {
  public:
   ScatterAdd(const Value& input, const Value& index, const Value& src,
-             int64_t dim);
+             xla::int64_t dim);
 
   std::string ToString() const override;
 
@@ -17,10 +17,10 @@ class ScatterAdd : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  int64_t dim() const { return dim_; };
+  xla::int64_t dim() const { return dim_; };
 
  private:
-  int64_t dim_;
+  xla::int64_t dim_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/select.cpp
+++ b/torch_xla/csrc/ops/select.cpp
@@ -8,8 +8,8 @@ namespace torch_xla {
 namespace ir {
 namespace ops {
 
-Select::Select(const Value& input, int64_t dim, int64_t start, int64_t end,
-               int64_t stride)
+Select::Select(const Value& input, xla::int64_t dim, xla::int64_t start,
+               xla::int64_t end, xla::int64_t stride)
     : Node(xla_select, {input},
            [&]() {
              return MakeSelectShape(input.shape(), dim, start, end, stride);
@@ -38,16 +38,18 @@ std::string Select::ToString() const {
   return ss.str();
 }
 
-xla::Shape Select::MakeSelectShape(const xla::Shape& shape, int64_t dim,
-                                   int64_t start, int64_t end, int64_t stride) {
-  int64_t effective_stride = GetStride(start, end, stride);
+xla::Shape Select::MakeSelectShape(const xla::Shape& shape, xla::int64_t dim,
+                                   xla::int64_t start, xla::int64_t end,
+                                   xla::int64_t stride) {
+  xla::int64_t effective_stride = GetStride(start, end, stride);
   xla::Shape select_shape(shape);
   select_shape.set_dimensions(
       dim, (end - start + effective_stride - 1) / effective_stride);
   return select_shape;
 }
 
-int64_t Select::GetStride(int64_t start, int64_t end, int64_t stride) {
+xla::int64_t Select::GetStride(xla::int64_t start, xla::int64_t end,
+                               xla::int64_t stride) {
   if (stride == 0) {
     XLA_CHECK_EQ(start, end);
     stride = 1;

--- a/torch_xla/csrc/ops/select.h
+++ b/torch_xla/csrc/ops/select.h
@@ -8,8 +8,8 @@ namespace ops {
 
 class Select : public Node {
  public:
-  Select(const Value& input, int64_t dim, int64_t start, int64_t end,
-         int64_t stride);
+  Select(const Value& input, xla::int64_t dim, xla::int64_t start,
+         xla::int64_t end, xla::int64_t stride);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -17,24 +17,26 @@ class Select : public Node {
 
   std::string ToString() const override;
 
-  int64_t dim() const { return dim_; }
+  xla::int64_t dim() const { return dim_; }
 
-  int64_t start() const { return start_; }
+  xla::int64_t start() const { return start_; }
 
-  int64_t end() const { return end_; }
+  xla::int64_t end() const { return end_; }
 
-  int64_t stride() const { return stride_; }
+  xla::int64_t stride() const { return stride_; }
 
-  static xla::Shape MakeSelectShape(const xla::Shape& shape, int64_t dim,
-                                    int64_t start, int64_t end, int64_t stride);
+  static xla::Shape MakeSelectShape(const xla::Shape& shape, xla::int64_t dim,
+                                    xla::int64_t start, xla::int64_t end,
+                                    xla::int64_t stride);
 
-  static int64_t GetStride(int64_t start, int64_t end, int64_t stride);
+  static xla::int64_t GetStride(xla::int64_t start, xla::int64_t end,
+                                xla::int64_t stride);
 
  private:
-  int64_t dim_;
-  int64_t start_;
-  int64_t end_;
-  int64_t stride_;
+  xla::int64_t dim_;
+  xla::int64_t start_;
+  xla::int64_t end_;
+  xla::int64_t stride_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/softmax.cpp
+++ b/torch_xla/csrc/ops/softmax.cpp
@@ -11,7 +11,7 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::XlaOp LowerSoftmax(xla::XlaOp input, int64_t dim,
+xla::XlaOp LowerSoftmax(xla::XlaOp input, xla::int64_t dim,
                         const c10::optional<at::ScalarType>& dtype) {
   xla::XlaOp result = BuildSoftmax(input, dim);
   return CastToScalarType(result, dtype);
@@ -28,7 +28,7 @@ xla::Shape NodeOutputShape(const Value& input,
 
 }  // namespace
 
-Softmax::Softmax(const Value& input, int64_t dim,
+Softmax::Softmax(const Value& input, xla::int64_t dim,
                  c10::optional<at::ScalarType> dtype)
     : Node(ir::OpKind(at::aten::softmax), {input},
            [&]() { return NodeOutputShape(input, dtype); },

--- a/torch_xla/csrc/ops/softmax.h
+++ b/torch_xla/csrc/ops/softmax.h
@@ -11,7 +11,8 @@ namespace ops {
 
 class Softmax : public Node {
  public:
-  Softmax(const Value& input, int64_t dim, c10::optional<at::ScalarType> dtype);
+  Softmax(const Value& input, xla::int64_t dim,
+          c10::optional<at::ScalarType> dtype);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -19,12 +20,12 @@ class Softmax : public Node {
 
   std::string ToString() const override;
 
-  int64_t dim() const { return dim_; }
+  xla::int64_t dim() const { return dim_; }
 
   const c10::optional<at::ScalarType>& dtype() const { return dtype_; }
 
  private:
-  int64_t dim_;
+  xla::int64_t dim_;
   c10::optional<at::ScalarType> dtype_;
 };
 

--- a/torch_xla/csrc/ops/softmax_backward.cpp
+++ b/torch_xla/csrc/ops/softmax_backward.cpp
@@ -10,7 +10,7 @@ namespace ir {
 namespace ops {
 
 SoftmaxBackward::SoftmaxBackward(const Value& grad_output, const Value& output,
-                                 int64_t dim)
+                                 xla::int64_t dim)
     : Node(ir::OpKind(at::aten::_softmax_backward_data), {grad_output, output},
            grad_output.shape(),
            /*num_outputs=*/1, torch::lazy::MHash(dim)),

--- a/torch_xla/csrc/ops/softmax_backward.h
+++ b/torch_xla/csrc/ops/softmax_backward.h
@@ -8,7 +8,8 @@ namespace ops {
 
 class SoftmaxBackward : public Node {
  public:
-  SoftmaxBackward(const Value& grad_output, const Value& output, int64_t dim);
+  SoftmaxBackward(const Value& grad_output, const Value& output,
+                  xla::int64_t dim);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -16,11 +17,11 @@ class SoftmaxBackward : public Node {
 
   std::string ToString() const override;
 
-  int64_t dim() const { return dim_; }
+  xla::int64_t dim() const { return dim_; }
 
  private:
   // The dimension along which the result is computed.
-  int64_t dim_;
+  xla::int64_t dim_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/split.cpp
+++ b/torch_xla/csrc/ops/split.cpp
@@ -12,8 +12,8 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& input,
-                           const std::vector<int64_t>& split_sizes,
-                           int64_t dim) {
+                           const std::vector<xla::int64_t>& split_sizes,
+                           xla::int64_t dim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return xla::Tuple(operands[0].builder(),
@@ -24,7 +24,8 @@ xla::Shape NodeOutputShape(const Value& input,
 
 }  // namespace
 
-Split::Split(const Value& input, std::vector<int64_t> split_sizes, int64_t dim)
+Split::Split(const Value& input, std::vector<xla::int64_t> split_sizes,
+             xla::int64_t dim)
     : Node(ir::OpKind(at::aten::split), {input},
            [&]() { return NodeOutputShape(input, split_sizes, dim); },
            ComputeSplitCount(input.shape().dimensions(dim), split_sizes),

--- a/torch_xla/csrc/ops/split.h
+++ b/torch_xla/csrc/ops/split.h
@@ -11,7 +11,8 @@ namespace ops {
 // Split the tensor into chunks along a given dimension.
 class Split : public Node {
  public:
-  Split(const Value& input, std::vector<int64_t> split_sizes, int64_t dim);
+  Split(const Value& input, std::vector<xla::int64_t> split_sizes,
+        xla::int64_t dim);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -19,13 +20,13 @@ class Split : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& split_sizes() const { return split_sizes_; }
+  const std::vector<xla::int64_t>& split_sizes() const { return split_sizes_; }
 
-  int64_t dim() const { return dim_; }
+  xla::int64_t dim() const { return dim_; }
 
  private:
-  std::vector<int64_t> split_sizes_;
-  int64_t dim_;
+  std::vector<xla::int64_t> split_sizes_;
+  xla::int64_t dim_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/stack.cpp
+++ b/torch_xla/csrc/ops/stack.cpp
@@ -10,7 +10,8 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(absl::Span<const ir::Value> values, int64_t dim) {
+xla::Shape NodeOutputShape(absl::Span<const ir::Value> values,
+                           xla::int64_t dim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildStack(operands, dim);
@@ -25,7 +26,7 @@ xla::Shape NodeOutputShape(absl::Span<const ir::Value> values, int64_t dim) {
 
 }  // namespace
 
-Stack::Stack(absl::Span<const ir::Value> values, int64_t dim)
+Stack::Stack(absl::Span<const ir::Value> values, xla::int64_t dim)
     : Node(ir::OpKind(at::aten::stack), values,
            [&]() { return NodeOutputShape(values, dim); },
            /*num_outputs=*/1, torch::lazy::MHash(dim)),

--- a/torch_xla/csrc/ops/stack.h
+++ b/torch_xla/csrc/ops/stack.h
@@ -9,7 +9,7 @@ namespace ops {
 
 class Stack : public Node {
  public:
-  Stack(absl::Span<const ir::Value> values, int64_t dim);
+  Stack(absl::Span<const ir::Value> values, xla::int64_t dim);
 
   std::string ToString() const override;
 
@@ -17,10 +17,10 @@ class Stack : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  int64_t dim() const { return dim_; };
+  xla::int64_t dim() const { return dim_; };
 
  private:
-  int64_t dim_;
+  xla::int64_t dim_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/std.cpp
+++ b/torch_xla/csrc/ops/std.cpp
@@ -10,8 +10,10 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
-                           bool keep_reduced_dimensions, int64_t correction) {
+xla::Shape NodeOutputShape(const Value& input,
+                           std::vector<xla::int64_t>& dimensions,
+                           bool keep_reduced_dimensions,
+                           xla::int64_t correction) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildStdDeviation(operands[0], dimensions, keep_reduced_dimensions,
@@ -22,8 +24,8 @@ xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
 
 }  // namespace
 
-Std::Std(const Value& input, std::vector<int64_t> dimensions,
-         bool keep_reduced_dimensions, int64_t correction)
+Std::Std(const Value& input, std::vector<xla::int64_t> dimensions,
+         bool keep_reduced_dimensions, xla::int64_t correction)
     : Node(ir::OpKind(at::aten::std), {input},
            [&]() {
              return NodeOutputShape(input, dimensions, keep_reduced_dimensions,

--- a/torch_xla/csrc/ops/std.h
+++ b/torch_xla/csrc/ops/std.h
@@ -11,8 +11,8 @@ namespace ops {
 
 class Std : public Node {
  public:
-  Std(const Value& input, std::vector<int64_t> dimensions,
-      bool keep_reduced_dimensions, int64_t correction);
+  Std(const Value& input, std::vector<xla::int64_t> dimensions,
+      bool keep_reduced_dimensions, xla::int64_t correction);
 
   std::string ToString() const override;
 
@@ -20,16 +20,16 @@ class Std : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  const std::vector<int64_t>& dimensions() const { return dimensions_; }
+  const std::vector<xla::int64_t>& dimensions() const { return dimensions_; }
 
   bool keep_reduced_dimensions() const { return keep_reduced_dimensions_; }
 
-  int64_t correction() const { return correction_; }
+  xla::int64_t correction() const { return correction_; }
 
  private:
-  std::vector<int64_t> dimensions_;
+  std::vector<xla::int64_t> dimensions_;
   bool keep_reduced_dimensions_;
-  int64_t correction_;
+  xla::int64_t correction_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/std_mean.cpp
+++ b/torch_xla/csrc/ops/std_mean.cpp
@@ -10,8 +10,10 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
-                           bool keep_reduced_dimensions, int64_t correction) {
+xla::Shape NodeOutputShape(const Value& input,
+                           std::vector<xla::int64_t>& dimensions,
+                           bool keep_reduced_dimensions,
+                           xla::int64_t correction) {
   auto lower_for_shape_fn_std_mean =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     xla::XlaOp std = BuildStdDeviation(operands[0], dimensions,
@@ -25,8 +27,8 @@ xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
 
 }  // namespace
 
-StdMean::StdMean(const Value& input, std::vector<int64_t> dimensions,
-                 int64_t correction, bool keep_reduced_dimensions)
+StdMean::StdMean(const Value& input, std::vector<xla::int64_t> dimensions,
+                 xla::int64_t correction, bool keep_reduced_dimensions)
     : Node(ir::OpKind(at::aten::std_mean), {input},
            [&]() {
              return NodeOutputShape(input, dimensions, keep_reduced_dimensions,

--- a/torch_xla/csrc/ops/std_mean.h
+++ b/torch_xla/csrc/ops/std_mean.h
@@ -11,8 +11,8 @@ namespace ops {
 
 class StdMean : public Node {
  public:
-  StdMean(const Value& input, std::vector<int64_t> dimensions,
-          int64_t correction, bool keep_reduced_dimensions);
+  StdMean(const Value& input, std::vector<xla::int64_t> dimensions,
+          xla::int64_t correction, bool keep_reduced_dimensions);
 
   std::string ToString() const override;
 
@@ -20,15 +20,15 @@ class StdMean : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  const std::vector<int64_t>& dimensions() const { return dimensions_; }
+  const std::vector<xla::int64_t>& dimensions() const { return dimensions_; }
 
-  int64_t correction() const { return correction_; }
+  xla::int64_t correction() const { return correction_; }
 
   bool keep_reduced_dimensions() const { return keep_reduced_dimensions_; }
 
  private:
-  std::vector<int64_t> dimensions_;
-  int64_t correction_;
+  std::vector<xla::int64_t> dimensions_;
+  xla::int64_t correction_;
   bool keep_reduced_dimensions_;
 };
 

--- a/torch_xla/csrc/ops/sum.cpp
+++ b/torch_xla/csrc/ops/sum.cpp
@@ -14,7 +14,7 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::XlaOp LowerSum(xla::XlaOp input, absl::Span<const int64_t> dimensions,
+xla::XlaOp LowerSum(xla::XlaOp input, absl::Span<const xla::int64_t> dimensions,
                     bool keep_reduced_dimensions,
                     c10::optional<at::ScalarType> dtype) {
   return BuildSum(CastToScalarType(input, dtype), dimensions,
@@ -22,7 +22,7 @@ xla::XlaOp LowerSum(xla::XlaOp input, absl::Span<const int64_t> dimensions,
 }
 
 xla::Shape NodeOutputShape(const Value& input,
-                           absl::Span<const int64_t> dimensions,
+                           absl::Span<const xla::int64_t> dimensions,
                            bool keep_reduced_dimensions,
                            c10::optional<at::ScalarType> dtype) {
   auto lower_for_shape_fn =
@@ -34,7 +34,7 @@ xla::Shape NodeOutputShape(const Value& input,
 
 }  // namespace
 
-Sum::Sum(const Value& input, std::vector<int64_t> dimensions,
+Sum::Sum(const Value& input, std::vector<xla::int64_t> dimensions,
          bool keep_reduced_dimensions, c10::optional<at::ScalarType> dtype)
     : Node(ir::OpKind(at::aten::sum), {input},
            [&]() {

--- a/torch_xla/csrc/ops/sum.h
+++ b/torch_xla/csrc/ops/sum.h
@@ -12,7 +12,7 @@ namespace ops {
 
 class Sum : public Node {
  public:
-  Sum(const Value& input, std::vector<int64_t> dimensions,
+  Sum(const Value& input, std::vector<xla::int64_t> dimensions,
       bool keep_reduced_dimensions, c10::optional<at::ScalarType> dtype);
 
   std::string ToString() const override;
@@ -21,14 +21,14 @@ class Sum : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  const std::vector<int64_t>& dimensions() const { return dimensions_; }
+  const std::vector<xla::int64_t>& dimensions() const { return dimensions_; }
 
   bool keep_reduced_dimensions() const { return keep_reduced_dimensions_; }
 
   const c10::optional<at::ScalarType>& dtype() const { return dtype_; }
 
  private:
-  std::vector<int64_t> dimensions_;
+  std::vector<xla::int64_t> dimensions_;
   bool keep_reduced_dimensions_;
   c10::optional<at::ScalarType> dtype_;
 };

--- a/torch_xla/csrc/ops/svd.cpp
+++ b/torch_xla/csrc/ops/svd.cpp
@@ -24,15 +24,15 @@ std::vector<xla::XlaOp> LowerSVD(xla::XlaOp input, bool some, bool compute_uv) {
     u = xla::Zeros(input.builder(), XlaHelpers::ShapeOfXlaOp(u));
     v = xla::Zeros(input.builder(), XlaHelpers::ShapeOfXlaOp(v));
   } else if (some) {
-    int64_t m_dim = input_shape.dimensions(input_shape.rank() - 2);
-    int64_t n_dim = input_shape.dimensions(input_shape.rank() - 1);
-    std::vector<int64_t> base_indices(input_shape.rank(), 0);
+    xla::int64_t m_dim = input_shape.dimensions(input_shape.rank() - 2);
+    xla::int64_t n_dim = input_shape.dimensions(input_shape.rank() - 1);
+    std::vector<xla::int64_t> base_indices(input_shape.rank(), 0);
 
-    auto u_sizes = xla::util::ToVector<int64_t>(input_shape.dimensions());
+    auto u_sizes = xla::util::ToVector<xla::int64_t>(input_shape.dimensions());
     u_sizes[input_shape.rank() - 1] = std::min(m_dim, n_dim);
     u = BuildSlice(u, base_indices, u_sizes);
 
-    auto v_sizes = xla::util::ToVector<int64_t>(input_shape.dimensions());
+    auto v_sizes = xla::util::ToVector<xla::int64_t>(input_shape.dimensions());
     v_sizes[input_shape.rank() - 2] = n_dim;
     v_sizes[input_shape.rank() - 1] = std::min(m_dim, n_dim);
     v = BuildSlice(v, base_indices, v_sizes);
@@ -44,8 +44,8 @@ xla::Shape NodeOutputShape(const Value& input, bool some, bool compute_uv) {
   const xla::Shape& input_shape = input.shape();
   XLA_CHECK_GE(input_shape.rank(), 2) << input_shape;
   // The input tensor is ...,M,N
-  int64_t m_dim = input_shape.dimensions(input_shape.rank() - 2);
-  int64_t n_dim = input_shape.dimensions(input_shape.rank() - 1);
+  xla::int64_t m_dim = input_shape.dimensions(input_shape.rank() - 2);
+  xla::int64_t n_dim = input_shape.dimensions(input_shape.rank() - 1);
   xla::Shape ushape(input_shape);
   if (!compute_uv || !some) {
     ushape.set_dimensions(input_shape.rank() - 1, m_dim);

--- a/torch_xla/csrc/ops/topk.cpp
+++ b/torch_xla/csrc/ops/topk.cpp
@@ -9,7 +9,7 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const Value& input, int64_t k, int64_t dim,
+xla::Shape NodeOutputShape(const Value& input, xla::int64_t k, xla::int64_t dim,
                            bool largest, bool sorted, bool stable) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
@@ -21,7 +21,7 @@ xla::Shape NodeOutputShape(const Value& input, int64_t k, int64_t dim,
 
 }  // namespace
 
-TopK::TopK(const Value& input, int64_t k, int64_t dim, bool largest,
+TopK::TopK(const Value& input, xla::int64_t k, xla::int64_t dim, bool largest,
            bool sorted, bool stable)
     : Node(ir::OpKind(at::aten::topk), {input},
            [&]() {

--- a/torch_xla/csrc/ops/topk.h
+++ b/torch_xla/csrc/ops/topk.h
@@ -8,8 +8,8 @@ namespace ops {
 
 class TopK : public Node {
  public:
-  TopK(const Value& input, int64_t k, int64_t dim, bool largest, bool sorted,
-       bool stable);
+  TopK(const Value& input, xla::int64_t k, xla::int64_t dim, bool largest,
+       bool sorted, bool stable);
 
   std::string ToString() const override;
 
@@ -17,9 +17,9 @@ class TopK : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  int64_t k() const { return k_; };
+  xla::int64_t k() const { return k_; };
 
-  int64_t dim() const { return dim_; };
+  xla::int64_t dim() const { return dim_; };
 
   bool largest() const { return largest_; }
 
@@ -28,8 +28,8 @@ class TopK : public Node {
   bool stable() const { return stable_; }
 
  private:
-  int64_t k_;
-  int64_t dim_;
+  xla::int64_t k_;
+  xla::int64_t dim_;
   bool largest_;
   bool sorted_;
   bool stable_;

--- a/torch_xla/csrc/ops/triangular_solve.cpp
+++ b/torch_xla/csrc/ops/triangular_solve.cpp
@@ -17,8 +17,8 @@ namespace {
 std::pair<xla::Shape, xla::Shape> InferTriangularSolveShape(
     const xla::Shape& rhs_shape, const xla::Shape& lhs_shape) {
   // Obtain the number of right-hand sides, and dimension of the square matrix.
-  int64_t nrhs = rhs_shape.dimensions(rhs_shape.rank() - 1);
-  int64_t n = lhs_shape.dimensions(lhs_shape.rank() - 1);
+  xla::int64_t nrhs = rhs_shape.dimensions(rhs_shape.rank() - 1);
+  xla::int64_t n = lhs_shape.dimensions(lhs_shape.rank() - 1);
   xla::Shape rhs_batch_shape(rhs_shape);
   xla::Shape lhs_batch_shape(lhs_shape);
   rhs_batch_shape.DeleteDimension(rhs_batch_shape.rank() - 1);

--- a/torch_xla/csrc/ops/tril.cpp
+++ b/torch_xla/csrc/ops/tril.cpp
@@ -7,7 +7,7 @@ namespace torch_xla {
 namespace ir {
 namespace ops {
 
-Tril::Tril(const Value& input, int64_t diagonal)
+Tril::Tril(const Value& input, xla::int64_t diagonal)
     : Node(ir::OpKind(at::aten::tril), {input}, input.shape(),
            /*num_outputs=*/1, torch::lazy::MHash(diagonal)),
       diagonal_(diagonal) {}

--- a/torch_xla/csrc/ops/tril.h
+++ b/torch_xla/csrc/ops/tril.h
@@ -10,7 +10,7 @@ namespace ops {
 // matrices input.
 class Tril : public Node {
  public:
-  Tril(const Value& input, int64_t diagonal);
+  Tril(const Value& input, xla::int64_t diagonal);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -18,10 +18,10 @@ class Tril : public Node {
 
   std::string ToString() const override;
 
-  int64_t diagonal() const { return diagonal_; }
+  xla::int64_t diagonal() const { return diagonal_; }
 
  private:
-  int64_t diagonal_;
+  xla::int64_t diagonal_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/triu.cpp
+++ b/torch_xla/csrc/ops/triu.cpp
@@ -7,7 +7,7 @@ namespace torch_xla {
 namespace ir {
 namespace ops {
 
-Triu::Triu(const Value& input, int64_t diagonal)
+Triu::Triu(const Value& input, xla::int64_t diagonal)
     : Node(ir::OpKind(at::aten::triu), {input}, input.shape(),
            /*num_outputs=*/1, torch::lazy::MHash(diagonal)),
       diagonal_(diagonal) {}

--- a/torch_xla/csrc/ops/triu.h
+++ b/torch_xla/csrc/ops/triu.h
@@ -10,7 +10,7 @@ namespace ops {
 // matrices input.
 class Triu : public Node {
  public:
-  Triu(const Value& input, int64_t diagonal);
+  Triu(const Value& input, xla::int64_t diagonal);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -18,10 +18,10 @@ class Triu : public Node {
 
   std::string ToString() const override;
 
-  int64_t diagonal() const { return diagonal_; }
+  xla::int64_t diagonal() const { return diagonal_; }
 
  private:
-  int64_t diagonal_;
+  xla::int64_t diagonal_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/unselect.cpp
+++ b/torch_xla/csrc/ops/unselect.cpp
@@ -11,8 +11,8 @@ namespace torch_xla {
 namespace ir {
 namespace ops {
 
-Unselect::Unselect(const Value& target, const Value& source, int64_t dim,
-                   int64_t start, int64_t end, int64_t stride)
+Unselect::Unselect(const Value& target, const Value& source, xla::int64_t dim,
+                   xla::int64_t start, xla::int64_t end, xla::int64_t stride)
     : Node(xla_unselect, {target, source}, target.shape(),
            /*num_outputs=*/1, torch::lazy::MHash(dim, start, end, stride)),
       dim_(dim),

--- a/torch_xla/csrc/ops/unselect.h
+++ b/torch_xla/csrc/ops/unselect.h
@@ -8,8 +8,8 @@ namespace ops {
 
 class Unselect : public Node {
  public:
-  Unselect(const Value& target, const Value& source, int64_t dim, int64_t start,
-           int64_t end, int64_t stride);
+  Unselect(const Value& target, const Value& source, xla::int64_t dim,
+           xla::int64_t start, xla::int64_t end, xla::int64_t stride);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -17,19 +17,19 @@ class Unselect : public Node {
 
   std::string ToString() const override;
 
-  int64_t dim() const { return dim_; }
+  xla::int64_t dim() const { return dim_; }
 
-  int64_t start() const { return start_; }
+  xla::int64_t start() const { return start_; }
 
-  int64_t end() const { return end_; }
+  xla::int64_t end() const { return end_; }
 
-  int64_t stride() const { return stride_; }
+  xla::int64_t stride() const { return stride_; }
 
  private:
-  int64_t dim_;
-  int64_t start_;
-  int64_t end_;
-  int64_t stride_;
+  xla::int64_t dim_;
+  xla::int64_t start_;
+  xla::int64_t end_;
+  xla::int64_t stride_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/update_slice.cpp
+++ b/torch_xla/csrc/ops/update_slice.cpp
@@ -13,7 +13,7 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& input, const Value& source,
-                           absl::Span<const int64_t> base_indices) {
+                           absl::Span<const xla::int64_t> base_indices) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildUpdateSlice(operands[0], operands[1], base_indices);
@@ -24,7 +24,7 @@ xla::Shape NodeOutputShape(const Value& input, const Value& source,
 }  // namespace
 
 UpdateSlice::UpdateSlice(const Value& input, const Value& source,
-                         absl::Span<const int64_t> base_indices)
+                         absl::Span<const xla::int64_t> base_indices)
     : Node(xla_update_slice, {input, source},
            [&]() { return NodeOutputShape(input, source, base_indices); },
            /*num_outputs=*/1, torch::lazy::Hash(base_indices)),

--- a/torch_xla/csrc/ops/update_slice.h
+++ b/torch_xla/csrc/ops/update_slice.h
@@ -10,7 +10,7 @@ namespace ops {
 class UpdateSlice : public Node {
  public:
   UpdateSlice(const Value& input, const Value& source,
-              absl::Span<const int64_t> base_indices);
+              absl::Span<const xla::int64_t> base_indices);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -18,10 +18,12 @@ class UpdateSlice : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& base_indices() const { return base_indices_; }
+  const std::vector<xla::int64_t>& base_indices() const {
+    return base_indices_;
+  }
 
  private:
-  std::vector<int64_t> base_indices_;
+  std::vector<xla::int64_t> base_indices_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/upsample_bilinear2d.cpp
+++ b/torch_xla/csrc/ops/upsample_bilinear2d.cpp
@@ -10,7 +10,7 @@ namespace ir {
 namespace ops {
 
 UpsampleBilinear::UpsampleBilinear(const Value& input,
-                                   std::vector<int64_t> output_size,
+                                   std::vector<xla::int64_t> output_size,
                                    bool align_corners)
     : Node(ir::OpKind(at::aten::upsample_bilinear2d), {input},
            [&]() {

--- a/torch_xla/csrc/ops/upsample_bilinear2d.h
+++ b/torch_xla/csrc/ops/upsample_bilinear2d.h
@@ -10,7 +10,7 @@ namespace ops {
 
 class UpsampleBilinear : public Node {
  public:
-  UpsampleBilinear(const Value& input, std::vector<int64_t> output_size,
+  UpsampleBilinear(const Value& input, std::vector<xla::int64_t> output_size,
                    bool align_corners);
 
   NodePtr Clone(OpList operands) const override;
@@ -19,12 +19,12 @@ class UpsampleBilinear : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& output_size() const { return output_size_; }
+  const std::vector<xla::int64_t>& output_size() const { return output_size_; }
 
   bool align_corners() const { return align_corners_; }
 
  private:
-  std::vector<int64_t> output_size_;
+  std::vector<xla::int64_t> output_size_;
   bool align_corners_;
 };
 

--- a/torch_xla/csrc/ops/upsample_bilinear2d_backward.cpp
+++ b/torch_xla/csrc/ops/upsample_bilinear2d_backward.cpp
@@ -10,8 +10,8 @@ namespace ir {
 namespace ops {
 
 UpsampleBilinearBackward::UpsampleBilinearBackward(
-    const Value& input, std::vector<int64_t> output_size,
-    std::vector<int64_t> input_size, bool align_corners)
+    const Value& input, std::vector<xla::int64_t> output_size,
+    std::vector<xla::int64_t> input_size, bool align_corners)
     : Node(ir::OpKind(at::aten::upsample_bilinear2d_backward), {input},
            [&]() {
              return resize::GetBackwardOutputShape2d(input.shape(), input_size);

--- a/torch_xla/csrc/ops/upsample_bilinear2d_backward.h
+++ b/torch_xla/csrc/ops/upsample_bilinear2d_backward.h
@@ -10,8 +10,10 @@ namespace ops {
 
 class UpsampleBilinearBackward : public Node {
  public:
-  UpsampleBilinearBackward(const Value& input, std::vector<int64_t> output_size,
-                           std::vector<int64_t> input_size, bool align_corners);
+  UpsampleBilinearBackward(const Value& input,
+                           std::vector<xla::int64_t> output_size,
+                           std::vector<xla::int64_t> input_size,
+                           bool align_corners);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -19,15 +21,15 @@ class UpsampleBilinearBackward : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& output_size() const { return output_size_; }
+  const std::vector<xla::int64_t>& output_size() const { return output_size_; }
 
-  const std::vector<int64_t>& input_size() const { return input_size_; }
+  const std::vector<xla::int64_t>& input_size() const { return input_size_; }
 
   bool align_corners() const { return align_corners_; }
 
  private:
-  std::vector<int64_t> output_size_;
-  std::vector<int64_t> input_size_;
+  std::vector<xla::int64_t> output_size_;
+  std::vector<xla::int64_t> input_size_;
   bool align_corners_;
 };
 

--- a/torch_xla/csrc/ops/upsample_nearest2d.cpp
+++ b/torch_xla/csrc/ops/upsample_nearest2d.cpp
@@ -10,7 +10,7 @@ namespace ir {
 namespace ops {
 
 UpsampleNearest::UpsampleNearest(const Value& input,
-                                 std::vector<int64_t> output_size)
+                                 std::vector<xla::int64_t> output_size)
     : Node(ir::OpKind(at::aten::upsample_nearest2d), {input},
            [&]() {
              return resize::GetForwardOutputShape2d(input.shape(), output_size);

--- a/torch_xla/csrc/ops/upsample_nearest2d.h
+++ b/torch_xla/csrc/ops/upsample_nearest2d.h
@@ -10,7 +10,7 @@ namespace ops {
 
 class UpsampleNearest : public Node {
  public:
-  UpsampleNearest(const Value& input, std::vector<int64_t> output_size);
+  UpsampleNearest(const Value& input, std::vector<xla::int64_t> output_size);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -18,10 +18,10 @@ class UpsampleNearest : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& output_size() const { return output_size_; }
+  const std::vector<xla::int64_t>& output_size() const { return output_size_; }
 
  private:
-  std::vector<int64_t> output_size_;
+  std::vector<xla::int64_t> output_size_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/upsample_nearest2d_backward.cpp
+++ b/torch_xla/csrc/ops/upsample_nearest2d_backward.cpp
@@ -10,8 +10,8 @@ namespace ir {
 namespace ops {
 
 UpsampleNearestBackward::UpsampleNearestBackward(
-    const Value& input, std::vector<int64_t> output_size,
-    std::vector<int64_t> input_size)
+    const Value& input, std::vector<xla::int64_t> output_size,
+    std::vector<xla::int64_t> input_size)
     : Node(ir::OpKind(at::aten::upsample_nearest2d_backward), {input},
            [&]() {
              return resize::GetBackwardOutputShape2d(input.shape(), input_size);

--- a/torch_xla/csrc/ops/upsample_nearest2d_backward.h
+++ b/torch_xla/csrc/ops/upsample_nearest2d_backward.h
@@ -10,8 +10,9 @@ namespace ops {
 
 class UpsampleNearestBackward : public Node {
  public:
-  UpsampleNearestBackward(const Value& input, std::vector<int64_t> output_size,
-                          std::vector<int64_t> input_size);
+  UpsampleNearestBackward(const Value& input,
+                          std::vector<xla::int64_t> output_size,
+                          std::vector<xla::int64_t> input_size);
 
   NodePtr Clone(OpList operands) const override;
 
@@ -19,13 +20,13 @@ class UpsampleNearestBackward : public Node {
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& output_size() const { return output_size_; }
+  const std::vector<xla::int64_t>& output_size() const { return output_size_; }
 
-  const std::vector<int64_t>& input_size() const { return input_size_; }
+  const std::vector<xla::int64_t>& input_size() const { return input_size_; }
 
  private:
-  std::vector<int64_t> output_size_;
-  std::vector<int64_t> input_size_;
+  std::vector<xla::int64_t> output_size_;
+  std::vector<xla::int64_t> input_size_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/user_computation.cpp
+++ b/torch_xla/csrc/ops/user_computation.cpp
@@ -34,7 +34,7 @@ XlaOpVector UserComputation::Lower(LoweringContext* loctx) const {
   XlaOpVector results;
   const xla::Shape& result_shape = computation_->program_shape().result();
   if (result_shape.IsTuple()) {
-    for (int64_t i = 0; i < result_shape.tuple_shapes_size(); ++i) {
+    for (xla::int64_t i = 0; i < result_shape.tuple_shapes_size(); ++i) {
       results.push_back(xla::GetTupleElement(output, i));
     }
   } else {

--- a/torch_xla/csrc/ops/var.cpp
+++ b/torch_xla/csrc/ops/var.cpp
@@ -13,8 +13,10 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
-                           int64_t correction, bool keep_reduced_dimensions) {
+xla::Shape NodeOutputShape(const Value& input,
+                           std::vector<xla::int64_t>& dimensions,
+                           xla::int64_t correction,
+                           bool keep_reduced_dimensions) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildVar(operands[0], dimensions, correction,
@@ -25,8 +27,8 @@ xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
 
 }  // namespace
 
-Var::Var(const Value& input, std::vector<int64_t> dimensions,
-         int64_t correction, bool keep_reduced_dimensions)
+Var::Var(const Value& input, std::vector<xla::int64_t> dimensions,
+         xla::int64_t correction, bool keep_reduced_dimensions)
     : Node(ir::OpKind(at::aten::var), {input},
            NodeOutputShape(input, dimensions, correction,
                            keep_reduced_dimensions),

--- a/torch_xla/csrc/ops/var.h
+++ b/torch_xla/csrc/ops/var.h
@@ -11,8 +11,8 @@ namespace ops {
 
 class Var : public Node {
  public:
-  Var(const Value& input, std::vector<int64_t> dimensions, int64_t correction,
-      bool keep_reduced_dimensions);
+  Var(const Value& input, std::vector<xla::int64_t> dimensions,
+      xla::int64_t correction, bool keep_reduced_dimensions);
 
   std::string ToString() const override;
 
@@ -20,15 +20,15 @@ class Var : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  const std::vector<int64_t>& dimensions() const { return dimensions_; }
+  const std::vector<xla::int64_t>& dimensions() const { return dimensions_; }
 
   bool keep_reduced_dimensions() const { return keep_reduced_dimensions_; }
 
-  int64_t correction() const { return correction_; }
+  xla::int64_t correction() const { return correction_; }
 
  private:
-  std::vector<int64_t> dimensions_;
-  int64_t correction_;
+  std::vector<xla::int64_t> dimensions_;
+  xla::int64_t correction_;
   bool keep_reduced_dimensions_;
 };
 

--- a/torch_xla/csrc/ops/var_mean.cpp
+++ b/torch_xla/csrc/ops/var_mean.cpp
@@ -13,8 +13,10 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
-                           int64_t correction, bool keep_reduced_dimensions) {
+xla::Shape NodeOutputShape(const Value& input,
+                           std::vector<xla::int64_t>& dimensions,
+                           xla::int64_t correction,
+                           bool keep_reduced_dimensions) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     xla::XlaOp var =
@@ -28,8 +30,8 @@ xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
 
 }  // namespace
 
-VarMean::VarMean(const Value& input, std::vector<int64_t> dimensions,
-                 int64_t correction, bool keep_reduced_dimensions)
+VarMean::VarMean(const Value& input, std::vector<xla::int64_t> dimensions,
+                 xla::int64_t correction, bool keep_reduced_dimensions)
     : Node(ir::OpKind(at::aten::var_mean), {input},
            [&]() {
              return NodeOutputShape(input, dimensions, correction,

--- a/torch_xla/csrc/ops/var_mean.h
+++ b/torch_xla/csrc/ops/var_mean.h
@@ -11,8 +11,8 @@ namespace ops {
 
 class VarMean : public Node {
  public:
-  VarMean(const Value& input, std::vector<int64_t> dimensions,
-          int64_t correction, bool keep_reduced_dimensions);
+  VarMean(const Value& input, std::vector<xla::int64_t> dimensions,
+          xla::int64_t correction, bool keep_reduced_dimensions);
 
   std::string ToString() const override;
 
@@ -20,15 +20,15 @@ class VarMean : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  const std::vector<int64_t>& dimensions() const { return dimensions_; }
+  const std::vector<xla::int64_t>& dimensions() const { return dimensions_; }
 
   bool keep_reduced_dimensions() const { return keep_reduced_dimensions_; }
 
-  int64_t correction() const { return correction_; }
+  xla::int64_t correction() const { return correction_; }
 
  private:
-  std::vector<int64_t> dimensions_;
-  int64_t correction_;
+  std::vector<xla::int64_t> dimensions_;
+  xla::int64_t correction_;
   bool keep_reduced_dimensions_;
 };
 

--- a/torch_xla/csrc/ops/view.cpp
+++ b/torch_xla/csrc/ops/view.cpp
@@ -12,7 +12,7 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& input,
-                           absl::Span<const int64_t> output_sizes) {
+                           absl::Span<const xla::int64_t> output_sizes) {
   const xla::Shape& input_shape = input.shape();
   auto info = XlaHelpers::GetDynamicReshapeInfo(input_shape, output_sizes);
   if (info) {
@@ -26,7 +26,7 @@ xla::Shape NodeOutputShape(const Value& input,
 
 }  // namespace
 
-View::View(const Value& input, std::vector<int64_t> output_size)
+View::View(const Value& input, std::vector<xla::int64_t> output_size)
     : Node(ir::OpKind(at::aten::view), {input},
            NodeOutputShape(input, output_size),
            /*num_outputs=*/1, torch::lazy::MHash(output_size)),

--- a/torch_xla/csrc/ops/view.h
+++ b/torch_xla/csrc/ops/view.h
@@ -10,16 +10,16 @@ namespace ops {
 
 class View : public Node {
  public:
-  View(const Value& input, std::vector<int64_t> output_size);
+  View(const Value& input, std::vector<xla::int64_t> output_size);
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
   std::string ToString() const override;
 
-  const std::vector<int64_t>& output_size() const { return output_size_; }
+  const std::vector<xla::int64_t>& output_size() const { return output_size_; }
 
  private:
-  std::vector<int64_t> output_size_;
+  std::vector<xla::int64_t> output_size_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/pooling.cpp
+++ b/torch_xla/csrc/pooling.cpp
@@ -18,8 +18,8 @@ namespace {
 const xla::PrimitiveType kIndicesType = xla::PrimitiveType::U32;
 
 struct PoolingOpAttributes {
-  std::vector<int64_t> kernel_size;
-  std::vector<int64_t> stride;
+  std::vector<xla::int64_t> kernel_size;
+  std::vector<xla::int64_t> stride;
 };
 
 struct PoolSliceIndices {
@@ -46,25 +46,25 @@ xla::XlaComputation CreateGeComputation(xla::PrimitiveType type) {
   return ConsumeValue(reduction_builder.Build());
 }
 
-xla::TensorFormat MakeNCHWFormat(int64_t spatial_dim_count) {
+xla::TensorFormat MakeNCHWFormat(xla::int64_t spatial_dim_count) {
   return {/*batch_dimension=*/0,
           /*feature_dimension=*/1,
           /*spatial_dimensions=*/
-          xla::util::Iota<int64_t>(spatial_dim_count, 2)};
+          xla::util::Iota<xla::int64_t>(spatial_dim_count, 2)};
 }
 
 // Construct the pooling attributes for the given kernel size, stride and
 // padding.
 PoolingOpAttributes MakePoolingOpAttributes(
-    absl::Span<const int64_t> kernel_size_attr,
-    absl::Span<const int64_t> stride_attr) {
+    absl::Span<const xla::int64_t> kernel_size_attr,
+    absl::Span<const xla::int64_t> stride_attr) {
   // Create a NCHW kernel size with 1 for batch size and feature.
-  std::vector<int64_t> kernel_size(2, 1);
+  std::vector<xla::int64_t> kernel_size(2, 1);
   kernel_size.insert(kernel_size.end(), kernel_size_attr.begin(),
                      kernel_size_attr.end());
   // Create a NCHW stride size with 1 for batch size and feature. Same as kernel
   // size if not specified.
-  std::vector<int64_t> stride;
+  std::vector<xla::int64_t> stride;
   if (stride_attr.empty()) {
     stride = kernel_size;
   } else {
@@ -76,12 +76,12 @@ PoolingOpAttributes MakePoolingOpAttributes(
 
 // Compute the  pool kernel size required for the specified output_size
 // from the given input_size, when the stride is the same as the kernel size.
-std::vector<int64_t> AdaptivePoolKernelSize(
-    absl::Span<const int64_t> input_size, absl::Span<const int64_t> output_size,
-    int pool_dim) {
+std::vector<xla::int64_t> AdaptivePoolKernelSize(
+    absl::Span<const xla::int64_t> input_size,
+    absl::Span<const xla::int64_t> output_size, int pool_dim) {
   // Create a NCHW kernel size with 1 for batch size and feature.
-  std::vector<int64_t> kernel_size(2, 1);
-  int64_t spatial_dim_off = input_size.size() - pool_dim;
+  std::vector<xla::int64_t> kernel_size(2, 1);
+  xla::int64_t spatial_dim_off = input_size.size() - pool_dim;
   for (int spatial_dim = 0; spatial_dim < pool_dim; ++spatial_dim) {
     XLA_CHECK_EQ(
         input_size[spatial_dim_off + spatial_dim] % output_size[spatial_dim], 0)
@@ -96,14 +96,14 @@ std::vector<int64_t> AdaptivePoolKernelSize(
 
 struct BatchInput {
   xla::XlaOp batch_input;
-  int64_t original_rank;
+  xla::int64_t original_rank;
 };
 
 // Adds a batch dimension of size 1 if the input tensor doesn't have a batch
 // dimension.
-BatchInput CreateBatchInput(xla::XlaOp input, int64_t spatial_dim_count) {
+BatchInput CreateBatchInput(xla::XlaOp input, xla::int64_t spatial_dim_count) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
-  int64_t rank = input_shape.rank();
+  xla::int64_t rank = input_shape.rank();
   XLA_CHECK(rank == spatial_dim_count + 1 || rank == spatial_dim_count + 2)
       << "Input must be a " << spatial_dim_count + 1 << "-D or "
       << spatial_dim_count + 2 << "-D tensor";
@@ -113,8 +113,8 @@ BatchInput CreateBatchInput(xla::XlaOp input, int64_t spatial_dim_count) {
   return {input, rank};
 }
 
-xla::XlaOp RemoveTrivialBatch(xla::XlaOp batch, int64_t original_rank,
-                              int64_t spatial_dim_count) {
+xla::XlaOp RemoveTrivialBatch(xla::XlaOp batch, xla::int64_t original_rank,
+                              xla::int64_t spatial_dim_count) {
   if (original_rank == spatial_dim_count + 1) {
     return SqueezeTrivialDimension(batch, 0);
   }
@@ -124,20 +124,20 @@ xla::XlaOp RemoveTrivialBatch(xla::XlaOp batch, int64_t original_rank,
 // Creates low and high padding specification for the given padding (which is
 // symmetric) and ceil mode. Additional high padding could be required when ceil
 // mode is set.
-std::vector<std::pair<int64_t, int64_t>> CeilModePadding(
-    absl::Span<const int64_t> padding, const xla::Shape& input_shape,
-    absl::Span<const int64_t> kernel_size, absl::Span<const int64_t> stride,
-    bool ceil_mode) {
-  std::vector<std::pair<int64_t, int64_t>> ceil_mode_padding;
+std::vector<std::pair<xla::int64_t, xla::int64_t>> CeilModePadding(
+    absl::Span<const xla::int64_t> padding, const xla::Shape& input_shape,
+    absl::Span<const xla::int64_t> kernel_size,
+    absl::Span<const xla::int64_t> stride, bool ceil_mode) {
+  std::vector<std::pair<xla::int64_t, xla::int64_t>> ceil_mode_padding;
   for (int i = 0; i < padding.size(); ++i) {
-    int64_t left_padding = padding[i];
-    int64_t input_size = input_shape.dimensions(2 + i);
-    int64_t output_size_rem =
+    xla::int64_t left_padding = padding[i];
+    xla::int64_t input_size = input_shape.dimensions(2 + i);
+    xla::int64_t output_size_rem =
         (input_size + 2 * left_padding - kernel_size[i]) % stride[i];
-    int64_t right_padding = left_padding;
+    xla::int64_t right_padding = left_padding;
     if (ceil_mode && output_size_rem != 0) {
-      int64_t extra_padding = stride[i] - output_size_rem;
-      int64_t new_output_size =
+      xla::int64_t extra_padding = stride[i] - output_size_rem;
+      xla::int64_t new_output_size =
           (input_size + left_padding + right_padding + extra_padding -
            kernel_size[i] + stride[i] - 1) /
               stride[i] +
@@ -153,11 +153,10 @@ std::vector<std::pair<int64_t, int64_t>> CeilModePadding(
 }
 
 // Creates an XLA padding configuration from a padding attribute value.
-xla::PaddingConfig MakeXlaPaddingConfig(absl::Span<const int64_t> padding,
-                                        const xla::Shape& input_shape,
-                                        absl::Span<const int64_t> kernel_size,
-                                        absl::Span<const int64_t> stride,
-                                        bool ceil_mode) {
+xla::PaddingConfig MakeXlaPaddingConfig(
+    absl::Span<const xla::int64_t> padding, const xla::Shape& input_shape,
+    absl::Span<const xla::int64_t> kernel_size,
+    absl::Span<const xla::int64_t> stride, bool ceil_mode) {
   xla::PaddingConfig padding_config;
   for (int i = 0; i < 2; ++i) {
     padding_config.add_dimensions();
@@ -176,8 +175,8 @@ xla::PaddingConfig MakeXlaPaddingConfig(absl::Span<const int64_t> padding,
 
 xla::XlaOp CreatePoolIndicesIota(const xla::Shape& input_shape,
                                  xla::XlaBuilder* builder) {
-  int64_t spatial_input_elements = 1;
-  for (int64_t i = 2; i < input_shape.rank(); ++i) {
+  xla::int64_t spatial_input_elements = 1;
+  for (xla::int64_t i = 2; i < input_shape.rank(); ++i) {
     spatial_input_elements *= input_shape.dimensions(i);
   }
   xla::XlaOp iota = xla::Iota(
@@ -219,11 +218,11 @@ xla::XlaOp ComputeNoOverlapMaxPoolIndices(
                            pooling_op_attributes.stride, xla::Padding::kValid);
 }
 
-PoolSliceIndices ComputeSliceIndices(xla::XlaOp linear_index,
-                                     absl::Span<const int64_t> dimensions,
-                                     absl::Span<const int64_t> window_strides) {
+PoolSliceIndices ComputeSliceIndices(
+    xla::XlaOp linear_index, absl::Span<const xla::int64_t> dimensions,
+    absl::Span<const xla::int64_t> window_strides) {
   xla::PrimitiveType scalar_type = XlaHelpers::TypeOfXlaOp(linear_index);
-  std::vector<int64_t> strides = ComputeArrayStrides(dimensions);
+  std::vector<xla::int64_t> strides = ComputeArrayStrides(dimensions);
   PoolSliceIndices indices;
   xla::XlaOp current_index = linear_index;
   for (size_t i = 0; i < dimensions.size(); ++i) {
@@ -274,7 +273,7 @@ xla::XlaOp ComputeMaxPoolIndices(
                padding_config);
 
   const xla::Shape& pool_result_shape = XlaHelpers::ShapeOfXlaOp(pool_result);
-  int64_t pool_elements = xla::ShapeUtil::ElementsIn(pool_result_shape);
+  xla::int64_t pool_elements = xla::ShapeUtil::ElementsIn(pool_result_shape);
 
   InitValues initial_values;
   size_t counter_id =
@@ -305,7 +304,7 @@ xla::XlaOp ComputeMaxPoolIndices(
     xla::XlaOp iota_slice =
         xla::DynamicSlice(init[iota_id], slice_indices.input_indices,
                           pooling_op_attributes.kernel_size);
-    std::vector<int64_t> result_slice_sizes(
+    std::vector<xla::int64_t> result_slice_sizes(
         pooling_op_attributes.kernel_size.size(), 1);
     xla::XlaOp pool_result_slice = xla::DynamicSlice(
         init[pool_result_id], slice_indices.result_indices, result_slice_sizes);
@@ -349,10 +348,10 @@ xla::XlaOp ComputeMaxPoolIndices(
 
 }  // namespace
 
-bool IsSupportedAdaptivePool(absl::Span<const int64_t> input_size,
-                             absl::Span<const int64_t> output_size,
+bool IsSupportedAdaptivePool(absl::Span<const xla::int64_t> input_size,
+                             absl::Span<const xla::int64_t> output_size,
                              int pool_dim) {
-  int64_t rank = input_size.size();
+  xla::int64_t rank = input_size.size();
   XLA_CHECK_EQ(output_size.size(), pool_dim);
   for (int spatial_dim = 0; spatial_dim < pool_dim; ++spatial_dim) {
     if (input_size[rank - pool_dim + spatial_dim] % output_size[spatial_dim] !=
@@ -364,7 +363,7 @@ bool IsSupportedAdaptivePool(absl::Span<const int64_t> input_size,
 }
 
 MaxPoolResult BuildAdaptiveMaxPoolNd(xla::XlaOp input,
-                                     absl::Span<const int64_t> output_size,
+                                     absl::Span<const xla::int64_t> output_size,
                                      int pool_dim) {
   BatchInput batch_input_info =
       CreateBatchInput(input, /*spatial_dim_count=*/pool_dim);
@@ -401,8 +400,9 @@ xla::XlaOp BuildAdaptiveMaxPoolNdBackward(xla::XlaOp out_backprop,
       XlaHelpers::ShapeOfXlaOp(batch_out_backprop_info.batch_input);
   XLA_CHECK_EQ(out_backprop_shape.rank(), pool_dim + 2)
       << "Invalid rank of gradient output";
-  std::vector<int64_t> output_size(out_backprop_shape.dimensions().begin() + 2,
-                                   out_backprop_shape.dimensions().end());
+  std::vector<xla::int64_t> output_size(
+      out_backprop_shape.dimensions().begin() + 2,
+      out_backprop_shape.dimensions().end());
   xla::XlaBuilder* builder = out_backprop.builder();
   BatchInput batch_input_info = CreateBatchInput(input, pool_dim);
   const xla::Shape& input_shape =
@@ -414,7 +414,8 @@ xla::XlaOp BuildAdaptiveMaxPoolNdBackward(xla::XlaOp out_backprop,
   const auto kernel_size =
       AdaptivePoolKernelSize(input_shape.dimensions(), output_size, pool_dim);
   // AdaptiveMaxPool won't have padding.
-  std::vector<std::pair<int64_t, int64_t>> window_padding(2 + pool_dim, {0, 0});
+  std::vector<std::pair<xla::int64_t, xla::int64_t>> window_padding(
+      2 + pool_dim, {0, 0});
   xla::XlaOp batch_result = xla::SelectAndScatterWithGeneralPadding(
       /*operand=*/batch_input_info.batch_input,
       /*select=*/select,
@@ -429,10 +430,10 @@ xla::XlaOp BuildAdaptiveMaxPoolNdBackward(xla::XlaOp out_backprop,
                             /*spatial_dim_count=*/pool_dim);
 }
 
-MaxPoolResult BuildMaxPoolNd(xla::XlaOp input, int64_t spatial_dim_count,
-                             absl::Span<const int64_t> kernel_size,
-                             absl::Span<const int64_t> stride,
-                             absl::Span<const int64_t> padding,
+MaxPoolResult BuildMaxPoolNd(xla::XlaOp input, xla::int64_t spatial_dim_count,
+                             absl::Span<const xla::int64_t> kernel_size,
+                             absl::Span<const xla::int64_t> stride,
+                             absl::Span<const xla::int64_t> padding,
                              bool ceil_mode) {
   xla::XlaBuilder* builder = input.builder();
   BatchInput batch_input_info = CreateBatchInput(input, spatial_dim_count);
@@ -462,10 +463,10 @@ MaxPoolResult BuildMaxPoolNd(xla::XlaOp input, int64_t spatial_dim_count,
 }
 
 xla::XlaOp BuildMaxPoolNdBackward(xla::XlaOp out_backprop, xla::XlaOp input,
-                                  int64_t spatial_dim_count,
-                                  absl::Span<const int64_t> kernel_size,
-                                  absl::Span<const int64_t> stride,
-                                  absl::Span<const int64_t> padding,
+                                  xla::int64_t spatial_dim_count,
+                                  absl::Span<const xla::int64_t> kernel_size,
+                                  absl::Span<const xla::int64_t> stride,
+                                  absl::Span<const xla::int64_t> padding,
                                   bool ceil_mode) {
   xla::XlaBuilder* builder = out_backprop.builder();
   BatchInput batch_input_info = CreateBatchInput(input, spatial_dim_count);
@@ -478,7 +479,7 @@ xla::XlaOp BuildMaxPoolNdBackward(xla::XlaOp out_backprop, xla::XlaOp input,
   PoolingOpAttributes pooling_op_attributes =
       MakePoolingOpAttributes(/*kernel_size_attr=*/kernel_size,
                               /*stride_attr=*/stride);
-  std::vector<std::pair<int64_t, int64_t>> window_padding;
+  std::vector<std::pair<xla::int64_t, xla::int64_t>> window_padding;
   const auto ceil_mode_padding =
       CeilModePadding(padding, input_shape, kernel_size, stride, ceil_mode);
   window_padding.resize(2);
@@ -502,14 +503,14 @@ xla::XlaOp BuildMaxPoolNdBackward(xla::XlaOp out_backprop, xla::XlaOp input,
 
 xla::XlaOp BuildMaxUnpoolNd(const Device& device, xla::XlaOp input,
                             xla::XlaOp indices,
-                            absl::Span<const int64_t> output_size) {
+                            absl::Span<const xla::int64_t> output_size) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   XLA_CHECK_EQ(input_shape.rank(), 2 + output_size.size());
 
   xla::Shape zeros_shape = xla::ShapeUtil::MakeShape(
       input_shape.element_type(),
       {input_shape.dimensions(0), input_shape.dimensions(1),
-       xla::util::Multiply<int64_t>(output_size)});
+       xla::util::Multiply<xla::int64_t>(output_size)});
   xla::XlaOp zeros = xla::Zeros(input.builder(), zeros_shape);
   xla::XlaOp init_value =
       xla::Broadcast(xla::MinValue(input.builder(), input_shape.element_type()),
@@ -532,16 +533,16 @@ xla::XlaOp BuildMaxUnpoolNd(const Device& device, xla::XlaOp input,
   xla::XlaOp result =
       xla::Select(xla::Ne(scatter_result, init_value), scatter_result, zeros);
 
-  std::vector<int64_t> result_sizes(
+  std::vector<xla::int64_t> result_sizes(
       {input_shape.dimensions(0), input_shape.dimensions(1)});
   result_sizes.insert(result_sizes.end(), output_size.begin(),
                       output_size.end());
   return XlaHelpers::DynamicReshape(result, result_sizes);
 }
 
-xla::XlaOp BuildMaxUnpoolNdBackward(xla::XlaOp grad_output, xla::XlaOp input,
-                                    xla::XlaOp indices,
-                                    absl::Span<const int64_t> output_size) {
+xla::XlaOp BuildMaxUnpoolNdBackward(
+    xla::XlaOp grad_output, xla::XlaOp input, xla::XlaOp indices,
+    absl::Span<const xla::int64_t> output_size) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   xla::XlaOp flat_grad_output =
       XlaHelpers::FlattenDimRange(grad_output, 2, output_size.size());
@@ -554,11 +555,11 @@ xla::XlaOp BuildMaxUnpoolNdBackward(xla::XlaOp grad_output, xla::XlaOp input,
   return XlaHelpers::DynamicReshapeAs(gather_result, input_shape);
 }
 
-xla::XlaOp BuildAvgPoolNd(xla::XlaOp input, int64_t spatial_dim_count,
-                          absl::Span<const int64_t> kernel_size,
-                          absl::Span<const int64_t> stride,
-                          absl::Span<const int64_t> padding, bool ceil_mode,
-                          bool count_include_pad) {
+xla::XlaOp BuildAvgPoolNd(xla::XlaOp input, xla::int64_t spatial_dim_count,
+                          absl::Span<const xla::int64_t> kernel_size,
+                          absl::Span<const xla::int64_t> stride,
+                          absl::Span<const xla::int64_t> padding,
+                          bool ceil_mode, bool count_include_pad) {
   PoolingOpAttributes pooling_op_attributes =
       MakePoolingOpAttributes(/*kernel_size_attr=*/kernel_size,
                               /*stride_attr=*/stride);
@@ -580,10 +581,10 @@ xla::XlaOp BuildAvgPoolNd(xla::XlaOp input, int64_t spatial_dim_count,
 }
 
 xla::XlaOp BuildAvgPoolNdBackward(xla::XlaOp out_backprop, xla::XlaOp input,
-                                  int64_t spatial_dim_count,
-                                  absl::Span<const int64_t> kernel_size,
-                                  absl::Span<const int64_t> stride,
-                                  absl::Span<const int64_t> padding,
+                                  xla::int64_t spatial_dim_count,
+                                  absl::Span<const xla::int64_t> kernel_size,
+                                  absl::Span<const xla::int64_t> stride,
+                                  absl::Span<const xla::int64_t> padding,
                                   bool ceil_mode, bool count_include_pad) {
   PoolingOpAttributes pooling_op_attributes =
       MakePoolingOpAttributes(/*kernel_size_attr=*/kernel_size,
@@ -609,12 +610,12 @@ xla::XlaOp BuildAvgPoolNdBackward(xla::XlaOp out_backprop, xla::XlaOp input,
 }
 
 xla::XlaOp BuildAdaptiveAvgPool(xla::XlaOp input,
-                                absl::Span<const int64_t> output_size,
+                                absl::Span<const xla::int64_t> output_size,
                                 int pool_dim) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   const auto kernel_size =
       AdaptivePoolKernelSize(input_shape.dimensions(), output_size, pool_dim);
-  std::vector<std::pair<int64_t, int64_t>> no_padding(pool_dim);
+  std::vector<std::pair<xla::int64_t, xla::int64_t>> no_padding(pool_dim);
   BatchInput batch_input_info =
       CreateBatchInput(input, /*spatial_dim_count=*/pool_dim);
   xla::XlaOp batch_result = xla::AvgPool(
@@ -630,7 +631,7 @@ xla::XlaOp BuildAdaptiveAvgPool(xla::XlaOp input,
 }
 
 xla::XlaOp BuildAdaptiveAvgPool3d(xla::XlaOp input,
-                                  absl::Span<const int64_t> output_size) {
+                                  absl::Span<const xla::int64_t> output_size) {
   XLA_CHECK_EQ(output_size.size(), 3) << "Invalid output size rank";
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   XLA_CHECK(input_shape.rank() == 4 || input_shape.rank() == 5)
@@ -639,7 +640,7 @@ xla::XlaOp BuildAdaptiveAvgPool3d(xla::XlaOp input,
 }
 
 xla::XlaOp BuildAdaptiveAvgPool2d(xla::XlaOp input,
-                                  absl::Span<const int64_t> output_size) {
+                                  absl::Span<const xla::int64_t> output_size) {
   XLA_CHECK_EQ(output_size.size(), 2) << "Invalid output size rank";
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   XLA_CHECK(input_shape.rank() == 4 || input_shape.rank() == 3)
@@ -655,15 +656,16 @@ xla::XlaOp BuildAdaptiveAvgPoolBackward(xla::XlaOp out_backprop,
       XlaHelpers::ShapeOfXlaOp(batch_out_backprop_info.batch_input);
   XLA_CHECK_EQ(out_backprop_shape.rank(), pool_dim + 2)
       << "Invalid rank of gradient output";
-  std::vector<int64_t> output_size(out_backprop_shape.dimensions().begin() + 2,
-                                   out_backprop_shape.dimensions().end());
+  std::vector<xla::int64_t> output_size(
+      out_backprop_shape.dimensions().begin() + 2,
+      out_backprop_shape.dimensions().end());
   auto gradients_size = XlaHelpers::SizesOfXlaOp(input);
   if (gradients_size.size() == pool_dim + 1) {
     gradients_size.insert(gradients_size.begin(), 1);
   }
   const auto kernel_size =
       AdaptivePoolKernelSize(gradients_size, output_size, pool_dim);
-  std::vector<std::pair<int64_t, int64_t>> no_padding(pool_dim);
+  std::vector<std::pair<xla::int64_t, xla::int64_t>> no_padding(pool_dim);
   xla::XlaOp batch_result = xla::AvgPoolGrad(
       /*out_backprop=*/batch_out_backprop_info.batch_input,
       /*gradients_size=*/gradients_size,

--- a/torch_xla/csrc/pooling.h
+++ b/torch_xla/csrc/pooling.h
@@ -12,45 +12,46 @@ struct MaxPoolResult {
 };
 
 // Computes max pooling for the given input.
-MaxPoolResult BuildMaxPoolNd(xla::XlaOp input, int64_t spatial_dim_count,
-                             absl::Span<const int64_t> kernel_size,
-                             absl::Span<const int64_t> stride,
-                             absl::Span<const int64_t> padding, bool ceil_mode);
+MaxPoolResult BuildMaxPoolNd(xla::XlaOp input, xla::int64_t spatial_dim_count,
+                             absl::Span<const xla::int64_t> kernel_size,
+                             absl::Span<const xla::int64_t> stride,
+                             absl::Span<const xla::int64_t> padding,
+                             bool ceil_mode);
 
 // Computes the gradient for max pooling.
 xla::XlaOp BuildMaxPoolNdBackward(xla::XlaOp out_backprop, xla::XlaOp input,
-                                  int64_t spatial_dim_count,
-                                  absl::Span<const int64_t> kernel_size,
-                                  absl::Span<const int64_t> stride,
-                                  absl::Span<const int64_t> padding,
+                                  xla::int64_t spatial_dim_count,
+                                  absl::Span<const xla::int64_t> kernel_size,
+                                  absl::Span<const xla::int64_t> stride,
+                                  absl::Span<const xla::int64_t> padding,
                                   bool ceil_mode);
 
 // Computes average pooling for the given input.
-xla::XlaOp BuildAvgPoolNd(xla::XlaOp input, int64_t spatial_dim_count,
-                          absl::Span<const int64_t> kernel_size,
-                          absl::Span<const int64_t> stride,
-                          absl::Span<const int64_t> padding, bool ceil_mode,
-                          bool count_include_pad);
+xla::XlaOp BuildAvgPoolNd(xla::XlaOp input, xla::int64_t spatial_dim_count,
+                          absl::Span<const xla::int64_t> kernel_size,
+                          absl::Span<const xla::int64_t> stride,
+                          absl::Span<const xla::int64_t> padding,
+                          bool ceil_mode, bool count_include_pad);
 
 // Computes the gradient for average pooling.
 xla::XlaOp BuildAvgPoolNdBackward(xla::XlaOp out_backprop, xla::XlaOp input,
-                                  int64_t spatial_dim_count,
-                                  absl::Span<const int64_t> kernel_size,
-                                  absl::Span<const int64_t> stride,
-                                  absl::Span<const int64_t> padding,
+                                  xla::int64_t spatial_dim_count,
+                                  absl::Span<const xla::int64_t> kernel_size,
+                                  absl::Span<const xla::int64_t> stride,
+                                  absl::Span<const xla::int64_t> padding,
                                   bool ceil_mode, bool count_include_pad);
 
 xla::XlaOp BuildMaxUnpoolNd(const Device& device, xla::XlaOp input,
                             xla::XlaOp indices,
-                            absl::Span<const int64_t> output_size);
+                            absl::Span<const xla::int64_t> output_size);
 
 xla::XlaOp BuildMaxUnpoolNdBackward(xla::XlaOp grad_output, xla::XlaOp input,
                                     xla::XlaOp indices,
-                                    absl::Span<const int64_t> output_size);
+                                    absl::Span<const xla::int64_t> output_size);
 
 // Computes adaptive max pooling for the given input and output size.
 MaxPoolResult BuildAdaptiveMaxPoolNd(xla::XlaOp input,
-                                     absl::Span<const int64_t> output_size,
+                                     absl::Span<const xla::int64_t> output_size,
                                      int pool_dim);
 
 // Computes the gradient for adaptive max pooling.
@@ -59,7 +60,7 @@ xla::XlaOp BuildAdaptiveMaxPoolNdBackward(xla::XlaOp out_backprop,
 
 // Computes adaptive average pooling for the given input and output size.
 xla::XlaOp BuildAdaptiveAvgPool3d(xla::XlaOp input,
-                                  absl::Span<const int64_t> output_size);
+                                  absl::Span<const xla::int64_t> output_size);
 
 // Computes the gradient for adaptive average pooling.
 xla::XlaOp BuildAdaptiveAvgPool3dBackward(xla::XlaOp out_backprop,
@@ -67,7 +68,7 @@ xla::XlaOp BuildAdaptiveAvgPool3dBackward(xla::XlaOp out_backprop,
 
 // Computes adaptive average pooling for the given input and output size.
 xla::XlaOp BuildAdaptiveAvgPool2d(xla::XlaOp input,
-                                  absl::Span<const int64_t> output_size);
+                                  absl::Span<const xla::int64_t> output_size);
 
 // Computes the gradient for adaptive average pooling.
 xla::XlaOp BuildAdaptiveAvgPool2dBackward(xla::XlaOp out_backprop,
@@ -75,8 +76,8 @@ xla::XlaOp BuildAdaptiveAvgPool2dBackward(xla::XlaOp out_backprop,
 
 // Returns true if XLA lowering is supported for the given input and output size
 // combination.
-bool IsSupportedAdaptivePool(absl::Span<const int64_t> input_size,
-                             absl::Span<const int64_t> output_size,
+bool IsSupportedAdaptivePool(absl::Span<const xla::int64_t> input_size,
+                             absl::Span<const xla::int64_t> output_size,
                              int pool_dim);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/random.cpp
+++ b/torch_xla/csrc/random.cpp
@@ -117,7 +117,7 @@ xla::XlaOp RngUniform(xla::XlaOp seed, const xla::Shape& shape,
           .value;
     case xla::PrimitiveType::C64:
     case xla::PrimitiveType::C128: {
-      xla::XlaOp k_seed = XlaHelpers::ScalarValue<uint64_t>(
+      xla::XlaOp k_seed = XlaHelpers::ScalarValue<xla::uint64>(
           17, XlaHelpers::TypeOfXlaOp(rng_seed), rng_seed.builder());
       xla::XlaOp rng_real = xla::UniformFloatingPointDistribution(
                                 rng_seed, initial_state, GetBitGenerator(),
@@ -173,7 +173,7 @@ xla::XlaOp RngNormal(xla::XlaOp seed, const xla::Shape& shape, xla::XlaOp mean,
     }
     case xla::PrimitiveType::C64:
     case xla::PrimitiveType::C128: {
-      xla::XlaOp k_seed = XlaHelpers::ScalarValue<uint64_t>(
+      xla::XlaOp k_seed = XlaHelpers::ScalarValue<xla::uint64>(
           17, XlaHelpers::TypeOfXlaOp(rng_seed), rng_seed.builder());
       xla::XlaOp rng_real =
           xla::NormalFloatingPointDistribution(rng_seed, initial_state,

--- a/torch_xla/csrc/reduction.cpp
+++ b/torch_xla/csrc/reduction.cpp
@@ -15,7 +15,7 @@ namespace torch_xla {
 namespace {
 
 struct ReductionInfo {
-  std::vector<int64_t> new_dimensions;
+  std::vector<xla::int64_t> new_dimensions;
   XlaHelpers::DynamicSize element_count;
 };
 
@@ -25,12 +25,12 @@ struct SummationResult {
 };
 
 ReductionInfo GetReductionInfo(xla::XlaOp input, const xla::Shape& shape,
-                               absl::Span<const int64_t> dimensions,
+                               absl::Span<const xla::int64_t> dimensions,
                                bool keep_reduced_dimensions) {
   ReductionInfo rinfo;
-  std::unordered_set<int64_t> reduced_dimensions(dimensions.begin(),
-                                                 dimensions.end());
-  for (int64_t i = 0; i < shape.rank(); ++i) {
+  std::unordered_set<xla::int64_t> reduced_dimensions(dimensions.begin(),
+                                                      dimensions.end());
+  for (xla::int64_t i = 0; i < shape.rank(); ++i) {
     if (reduced_dimensions.count(i) > 0) {
       if (keep_reduced_dimensions) {
         rinfo.new_dimensions.push_back(1);
@@ -87,7 +87,7 @@ xla::XlaOp AverageValue(xla::XlaOp input, xla::XlaOp reduced) {
 }
 
 SummationResult CreateSummation(xla::XlaOp input,
-                                absl::Span<const int64_t> dimensions,
+                                absl::Span<const xla::int64_t> dimensions,
                                 bool keep_reduced_dimensions, bool scale) {
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(input);
   xla::XlaOp init_value = xla::Zero(input.builder(), shape.element_type());
@@ -108,7 +108,8 @@ SummationResult CreateSummation(xla::XlaOp input,
   return result;
 }
 
-xla::XlaOp CreateProduct(xla::XlaOp input, absl::Span<const int64_t> dimensions,
+xla::XlaOp CreateProduct(xla::XlaOp input,
+                         absl::Span<const xla::int64_t> dimensions,
                          bool keep_reduced_dimensions) {
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(input);
   xla::XlaOp init_value = xla::One(input.builder(), shape.element_type());
@@ -227,7 +228,7 @@ xla::XlaOp BuildMseLoss(xla::XlaOp input, xla::XlaOp target,
       result, xla::Zero(input.builder(), input_shape.element_type()),
       XlaHelpers::CreateAddComputation(input_shape.element_type()));
   if (reduction == ReductionMode::kMean) {
-    int64_t num_elements = xla::ShapeUtil::ElementsIn(input_shape);
+    xla::int64_t num_elements = xla::ShapeUtil::ElementsIn(input_shape);
     if (num_elements == 0) {
       return xla::NanValue(input.builder(), input_shape.element_type());
     } else {
@@ -251,7 +252,7 @@ xla::XlaOp BuildMseLossBackward(xla::XlaOp grad_output, xla::XlaOp input,
   }
   xla::XlaOp grad_value = grad_output;
   if (reduction == ReductionMode::kMean) {
-    int64_t num_elements = xla::ShapeUtil::ElementsIn(input_shape);
+    xla::int64_t num_elements = xla::ShapeUtil::ElementsIn(input_shape);
     xla::XlaOp scale_value = XlaHelpers::ScalarValue<double>(
         1.0 / static_cast<double>(num_elements), input_shape.element_type(),
         input.builder());
@@ -260,21 +261,23 @@ xla::XlaOp BuildMseLossBackward(xla::XlaOp grad_output, xla::XlaOp input,
   return d_input * grad_value;
 }
 
-xla::XlaOp BuildCumulativeComputation(xla::XlaOp input, int64_t dim,
+xla::XlaOp BuildCumulativeComputation(xla::XlaOp input, xla::int64_t dim,
                                       const xla::XlaComputation& reducer,
                                       xla::XlaOp init) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
-  std::vector<int64_t> window_strides(input_shape.rank(), 1);
-  std::vector<int64_t> window_dims(input_shape.rank(), 1);
+  std::vector<xla::int64_t> window_strides(input_shape.rank(), 1);
+  std::vector<xla::int64_t> window_dims(input_shape.rank(), 1);
   window_dims[dim] = input_shape.dimensions(dim);
-  std::vector<std::pair<int64_t, int64_t>> padding(input_shape.rank());
+  std::vector<std::pair<xla::int64_t, xla::int64_t>> padding(
+      input_shape.rank());
   padding[dim].first = input_shape.dimensions(dim) - 1;
   return xla::ReduceWindowWithGeneralPadding(
       input, init, reducer, window_dims, window_strides,
       /*base_dilations=*/{}, /*window_dilations=*/{}, padding);
 }
 
-xla::XlaOp BuildMean(xla::XlaOp input, absl::Span<const int64_t> dimensions,
+xla::XlaOp BuildMean(xla::XlaOp input,
+                     absl::Span<const xla::int64_t> dimensions,
                      bool keep_reduced_dimensions) {
   return CreateSummation(input, dimensions, keep_reduced_dimensions,
                          /*scale=*/true)
@@ -282,14 +285,15 @@ xla::XlaOp BuildMean(xla::XlaOp input, absl::Span<const int64_t> dimensions,
 }
 
 xla::XlaOp BuildStdDeviation(xla::XlaOp input,
-                             absl::Span<const int64_t> dimensions,
-                             bool keep_reduced_dimensions, int64_t correction) {
+                             absl::Span<const xla::int64_t> dimensions,
+                             bool keep_reduced_dimensions,
+                             xla::int64_t correction) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   xla::XlaOp mean =
       BuildMean(input, dimensions, /*keep_reduced_dimensions*/ true);
   xla::XlaOp bcast_mean =
       xla::BroadcastInDim(mean, input_shape.dimensions(),
-                          xla::util::Iota<int64_t>(input_shape.rank()));
+                          xla::util::Iota<xla::int64_t>(input_shape.rank()));
   xla::XlaOp input_mean_diff = input - bcast_mean;
   xla::XlaOp squared_var = input_mean_diff * input_mean_diff;
   xla::XlaOp squared_result;
@@ -312,25 +316,26 @@ xla::XlaOp BuildStdDeviation(xla::XlaOp input,
   return xla::Sqrt(squared_result);
 }
 
-xla::XlaOp BuildSum(xla::XlaOp input, absl::Span<const int64_t> dimensions,
+xla::XlaOp BuildSum(xla::XlaOp input, absl::Span<const xla::int64_t> dimensions,
                     bool keep_reduced_dimensions) {
   return CreateSummation(input, dimensions, keep_reduced_dimensions,
                          /*scale=*/false)
       .result;
 }
 
-xla::XlaOp BuildProd(xla::XlaOp input, absl::Span<const int64_t> dimensions,
+xla::XlaOp BuildProd(xla::XlaOp input,
+                     absl::Span<const xla::int64_t> dimensions,
                      bool keep_reduced_dimensions) {
   return CreateProduct(input, dimensions, keep_reduced_dimensions);
 }
 
-xla::XlaOp BuildMaxInDim(xla::XlaOp input, int64_t dim,
+xla::XlaOp BuildMaxInDim(xla::XlaOp input, xla::int64_t dim,
                          bool keep_reduced_dimensions) {
   return BuildMaxInDims(input, {dim}, keep_reduced_dimensions);
 }
 
 xla::XlaOp BuildMaxInDims(xla::XlaOp input,
-                          absl::Span<const int64_t> dimensions,
+                          absl::Span<const xla::int64_t> dimensions,
                           bool keep_reduced_dimensions) {
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(input);
   XlaHelpers::MinMax min_max = XlaHelpers::MinMaxValues(shape.element_type());
@@ -351,13 +356,13 @@ xla::XlaOp BuildMaxInDims(xla::XlaOp input,
   return result;
 }
 
-xla::XlaOp BuildMinInDim(xla::XlaOp input, int64_t dim,
+xla::XlaOp BuildMinInDim(xla::XlaOp input, xla::int64_t dim,
                          bool keep_reduced_dimensions) {
   return BuildMinInDims(input, {dim}, keep_reduced_dimensions);
 }
 
 xla::XlaOp BuildMinInDims(xla::XlaOp input,
-                          absl::Span<const int64_t> dimensions,
+                          absl::Span<const xla::int64_t> dimensions,
                           bool keep_reduced_dimensions) {
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(input);
   XlaHelpers::MinMax min_max = XlaHelpers::MinMaxValues(shape.element_type());
@@ -378,7 +383,7 @@ xla::XlaOp BuildMinInDims(xla::XlaOp input,
   return result;
 }
 
-xla::XlaOp BuildArgMax(xla::XlaOp input, int64_t dim, bool keepdim) {
+xla::XlaOp BuildArgMax(xla::XlaOp input, xla::int64_t dim, bool keepdim) {
   const xla::Shape* shape = &XlaHelpers::ShapeOfXlaOp(input);
   xla::XlaOp operand = input;
   if (dim < 0) {
@@ -387,18 +392,19 @@ xla::XlaOp BuildArgMax(xla::XlaOp input, int64_t dim, bool keepdim) {
                                          {xla::ShapeUtil::ElementsIn(*shape)});
     shape = &XlaHelpers::ShapeOfXlaOp(operand);
   }
-  xla::XlaOp result = xla::ArgMax(
+  xla::XlaOp result = xla::ArgMaxTwoPass(
       operand,
-      GetDevicePrimitiveType(xla::PrimitiveType::S64, /*device=*/nullptr), dim);
+      GetDevicePrimitiveType(xla::PrimitiveType::S64, /*device=*/nullptr), dim,
+      /*tie_low=*/true);
   if (keepdim) {
-    auto dimensions = xla::util::ToVector<int64_t>(shape->dimensions());
+    auto dimensions = xla::util::ToVector<xla::int64_t>(shape->dimensions());
     dimensions[dim] = 1;
     result = XlaHelpers::DynamicReshape(result, dimensions);
   }
   return result;
 }
 
-xla::XlaOp BuildArgMin(xla::XlaOp input, int64_t dim, bool keepdim) {
+xla::XlaOp BuildArgMin(xla::XlaOp input, xla::int64_t dim, bool keepdim) {
   const xla::Shape* shape = &XlaHelpers::ShapeOfXlaOp(input);
   xla::XlaOp operand = input;
   if (dim < 0) {
@@ -407,18 +413,19 @@ xla::XlaOp BuildArgMin(xla::XlaOp input, int64_t dim, bool keepdim) {
                                          {xla::ShapeUtil::ElementsIn(*shape)});
     shape = &XlaHelpers::ShapeOfXlaOp(operand);
   }
-  xla::XlaOp result = xla::ArgMin(
+  xla::XlaOp result = xla::ArgMinTwoPass(
       operand,
-      GetDevicePrimitiveType(xla::PrimitiveType::S64, /*device=*/nullptr), dim);
+      GetDevicePrimitiveType(xla::PrimitiveType::S64, /*device=*/nullptr), dim,
+      /*tie_low=*/true);
   if (keepdim) {
-    auto dimensions = xla::util::ToVector<int64_t>(shape->dimensions());
+    auto dimensions = xla::util::ToVector<xla::int64_t>(shape->dimensions());
     dimensions[dim] = 1;
     result = XlaHelpers::DynamicReshape(result, dimensions);
   }
   return result;
 }
 
-xla::XlaOp BuildAll(xla::XlaOp input, absl::Span<const int64_t> dimensions,
+xla::XlaOp BuildAll(xla::XlaOp input, absl::Span<const xla::int64_t> dimensions,
                     bool keep_reduced_dimensions) {
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(input);
   ReductionInfo rinfo =
@@ -440,7 +447,7 @@ xla::XlaOp BuildAll(xla::XlaOp input, absl::Span<const int64_t> dimensions,
   return result;
 }
 
-xla::XlaOp BuildAny(xla::XlaOp input, absl::Span<const int64_t> dimensions,
+xla::XlaOp BuildAny(xla::XlaOp input, absl::Span<const xla::int64_t> dimensions,
                     bool keep_reduced_dimensions) {
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(input);
   ReductionInfo rinfo =
@@ -462,8 +469,8 @@ xla::XlaOp BuildAny(xla::XlaOp input, absl::Span<const int64_t> dimensions,
   return result;
 }
 
-xla::XlaOp BuildVar(xla::XlaOp input, absl::Span<const int64_t> dimensions,
-                    int64_t correction, bool keep_reduced_dimensions) {
+xla::XlaOp BuildVar(xla::XlaOp input, absl::Span<const xla::int64_t> dimensions,
+                    xla::int64_t correction, bool keep_reduced_dimensions) {
   const auto& input_builder = input.builder();
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   const xla::PrimitiveType input_type = input_shape.element_type();
@@ -496,7 +503,7 @@ xla::XlaOp BuildVar(xla::XlaOp input, absl::Span<const int64_t> dimensions,
 }
 
 xla::XlaOp BuildLogsumexp(xla::XlaOp input,
-                          absl::Span<const int64_t> dimensions,
+                          absl::Span<const xla::int64_t> dimensions,
                           bool keep_reduced_dimensions) {
   // Use the log-sum-exp trick to avoid overflow.
   xla::XlaOp max_in_dim =

--- a/torch_xla/csrc/reduction.h
+++ b/torch_xla/csrc/reduction.h
@@ -34,74 +34,77 @@ xla::XlaOp BuildMseLossBackward(xla::XlaOp grad_output, xla::XlaOp input,
 // Builds a mean by reducing all the dimensions listed in dimensions. If
 // keep_reduced_dimensions is true, the reduced dimensions will be retained,
 // with value 1.
-xla::XlaOp BuildMean(xla::XlaOp input, absl::Span<const int64_t> dimensions,
+xla::XlaOp BuildMean(xla::XlaOp input,
+                     absl::Span<const xla::int64_t> dimensions,
                      bool keep_reduced_dimensions);
 
 xla::XlaOp BuildStdDeviation(xla::XlaOp input,
-                             absl::Span<const int64_t> dimensions,
-                             bool keep_reduced_dimensions, int64_t correction);
+                             absl::Span<const xla::int64_t> dimensions,
+                             bool keep_reduced_dimensions,
+                             xla::int64_t correction);
 
 // Builds the sum of all values by reducing all the dimensions listed in
 // dimensions. If keep_reduced_dimensions is true, the reduced dimensions will
 // be retained, with value 1.
-xla::XlaOp BuildSum(xla::XlaOp input, absl::Span<const int64_t> dimensions,
+xla::XlaOp BuildSum(xla::XlaOp input, absl::Span<const xla::int64_t> dimensions,
                     bool keep_reduced_dimensions);
 
 // Builds the max of all values by reducing in the given dimension. If
 // keep_reduced_dimensions is true, the reduced dimension will be retained, with
 // value 1.
-xla::XlaOp BuildMaxInDim(xla::XlaOp input, int64_t dim,
+xla::XlaOp BuildMaxInDim(xla::XlaOp input, xla::int64_t dim,
                          bool keep_reduced_dimensions);
 
 // Builds the max of all values by reducing in the given dimensions. If
 // keep_reduced_dimensions is true, the reduced dimension will be retained, with
 // value 1.
 xla::XlaOp BuildMaxInDims(xla::XlaOp input,
-                          absl::Span<const int64_t> dimensions,
+                          absl::Span<const xla::int64_t> dimensions,
                           bool keep_reduced_dimensions);
 
 // Builds the min of all values by reducing in the given dimension. If
 // keep_reduced_dimensions is true, the reduced dimension will be retained, with
 // value 1.
-xla::XlaOp BuildMinInDim(xla::XlaOp input, int64_t dim,
+xla::XlaOp BuildMinInDim(xla::XlaOp input, xla::int64_t dim,
                          bool keep_reduced_dimensions);
 
 // Builds the min of all values by reducing in the given dimensions. If
 // keep_reduced_dimensions is true, the reduced dimension will be retained, with
 // value 1.
 xla::XlaOp BuildMinInDims(xla::XlaOp input,
-                          absl::Span<const int64_t> dimensions,
+                          absl::Span<const xla::int64_t> dimensions,
                           bool keep_reduced_dimensions);
 
 // Compute the indices of the maximum values of a tensor across a dimension.
-xla::XlaOp BuildArgMax(xla::XlaOp input, int64_t dim, bool keepdim);
+xla::XlaOp BuildArgMax(xla::XlaOp input, xla::int64_t dim, bool keepdim);
 
 // Compute the indices of the minimum values of a tensor across a dimension.
-xla::XlaOp BuildArgMin(xla::XlaOp input, int64_t dim, bool keepdim);
+xla::XlaOp BuildArgMin(xla::XlaOp input, xla::int64_t dim, bool keepdim);
 
 // Builds the product of all values by reducing all the dimensions listed in
 // dimensions. If keep_reduced_dimensions is true, the reduced dimensions will
 // be retained, with value 1.
-xla::XlaOp BuildProd(xla::XlaOp input, absl::Span<const int64_t> dimensions,
+xla::XlaOp BuildProd(xla::XlaOp input,
+                     absl::Span<const xla::int64_t> dimensions,
                      bool keep_reduced_dimensions);
 
 // Compute the cumulative computation specified by "reducer" and "init" in the
 // given dimension "dim".
-xla::XlaOp BuildCumulativeComputation(xla::XlaOp input, int64_t dim,
+xla::XlaOp BuildCumulativeComputation(xla::XlaOp input, xla::int64_t dim,
                                       const xla::XlaComputation& reducer,
                                       xla::XlaOp init);
 
-xla::XlaOp BuildAll(xla::XlaOp input, absl::Span<const int64_t> dimensions,
+xla::XlaOp BuildAll(xla::XlaOp input, absl::Span<const xla::int64_t> dimensions,
                     bool keep_reduced_dimensions);
 
-xla::XlaOp BuildAny(xla::XlaOp input, absl::Span<const int64_t> dimensions,
+xla::XlaOp BuildAny(xla::XlaOp input, absl::Span<const xla::int64_t> dimensions,
                     bool keep_reduced_dimensions);
 
-xla::XlaOp BuildVar(xla::XlaOp input, absl::Span<const int64_t> dimensions,
-                    int64_t correction, bool keep_reduced_dimensions);
+xla::XlaOp BuildVar(xla::XlaOp input, absl::Span<const xla::int64_t> dimensions,
+                    xla::int64_t correction, bool keep_reduced_dimensions);
 
 xla::XlaOp BuildLogsumexp(xla::XlaOp input,
-                          absl::Span<const int64_t> dimensions,
+                          absl::Span<const xla::int64_t> dimensions,
                           bool keep_reduced_dimensions);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/resize_ops.cpp
+++ b/torch_xla/csrc/resize_ops.cpp
@@ -26,7 +26,7 @@ double ResizeFactor(const xla::Shape& input_shape,
 }  // namespace
 
 xla::Shape GetForwardOutputShape2d(const xla::Shape& input_shape,
-                                   absl::Span<const int64_t> output_size) {
+                                   absl::Span<const xla::int64_t> output_size) {
   XLA_CHECK_EQ(output_size.size(), 2);
   return ShapeBuilder(input_shape.element_type())
       .Add(input_shape, 0)
@@ -37,7 +37,7 @@ xla::Shape GetForwardOutputShape2d(const xla::Shape& input_shape,
 }
 
 xla::Shape GetBackwardOutputShape2d(const xla::Shape& input_shape,
-                                    absl::Span<const int64_t> input_size) {
+                                    absl::Span<const xla::int64_t> input_size) {
   return xla::ShapeUtil::MakeShape(input_shape.element_type(), input_size);
 }
 
@@ -54,7 +54,7 @@ xla::XlaOp LowerForward2d(const std::string& target, xla::XlaOp input,
   }
   // XLA wants NHWC while PyTorch comes in as NCHW, so we need to transpose,
   // call the kernel, and transpose back.
-  std::vector<int64_t> transpose_permute({0, 3, 2, 1});
+  std::vector<xla::int64_t> transpose_permute({0, 3, 2, 1});
   auto inv_transpose_permute = xla::InversePermutation(transpose_permute);
   xla::Shape resized_shape =
       xla::ShapeUtil::PermuteDimensions(transpose_permute, output_shape);
@@ -77,7 +77,7 @@ xla::XlaOp LowerBackward2d(const std::string& target, xla::XlaOp input,
   }
   // XLA wants NHWC while PyTorch comes in as NCHW, so we need to transpose,
   // call the kernel, and transpose back.
-  std::vector<int64_t> transpose_permute({0, 3, 2, 1});
+  std::vector<xla::int64_t> transpose_permute({0, 3, 2, 1});
   auto inv_transpose_permute = xla::InversePermutation(transpose_permute);
   xla::Shape resized_shape =
       xla::ShapeUtil::PermuteDimensions(transpose_permute, output_shape);

--- a/torch_xla/csrc/resize_ops.h
+++ b/torch_xla/csrc/resize_ops.h
@@ -9,10 +9,10 @@ namespace torch_xla {
 namespace resize {
 
 xla::Shape GetForwardOutputShape2d(const xla::Shape& input_shape,
-                                   absl::Span<const int64_t> output_size);
+                                   absl::Span<const xla::int64_t> output_size);
 
 xla::Shape GetBackwardOutputShape2d(const xla::Shape& input_shape,
-                                    absl::Span<const int64_t> input_size);
+                                    absl::Span<const xla::int64_t> input_size);
 
 xla::XlaOp LowerForward2d(const std::string& target, xla::XlaOp input,
                           const xla::Shape& output_shape, bool align_corners,

--- a/torch_xla/csrc/shape_builder.cpp
+++ b/torch_xla/csrc/shape_builder.cpp
@@ -4,13 +4,13 @@
 
 namespace torch_xla {
 
-ShapeBuilder& ShapeBuilder::Add(const xla::Shape& shape, int64_t dim) {
+ShapeBuilder& ShapeBuilder::Add(const xla::Shape& shape, xla::int64_t dim) {
   dims_.push_back({&shape, dim});
   return *this;
 }
 
 ShapeBuilder& ShapeBuilder::Add(const xla::Shape& shape,
-                                absl::Span<const int64_t> dimensions) {
+                                absl::Span<const xla::int64_t> dimensions) {
   dims_.reserve(dimensions.size());
   for (auto dim : dimensions) {
     dims_.push_back({&shape, dim});
@@ -18,13 +18,13 @@ ShapeBuilder& ShapeBuilder::Add(const xla::Shape& shape,
   return *this;
 }
 
-ShapeBuilder& ShapeBuilder::Add(int64_t size) {
+ShapeBuilder& ShapeBuilder::Add(xla::int64_t size) {
   dims_.push_back({nullptr, size});
   return *this;
 }
 
 xla::Shape ShapeBuilder::Build() const {
-  std::vector<int64_t> dimensions;
+  std::vector<xla::int64_t> dimensions;
   dimensions.reserve(dims_.size());
   for (auto& sdim : dims_) {
     if (sdim.shape != nullptr) {
@@ -34,7 +34,7 @@ xla::Shape ShapeBuilder::Build() const {
     }
   }
   xla::Shape shape = xla::ShapeUtil::MakeShape(type_, dimensions);
-  for (int64_t i = 0; i < shape.rank(); ++i) {
+  for (xla::int64_t i = 0; i < shape.rank(); ++i) {
     const ShapeDim& sdim = dims_[i];
     if (sdim.shape != nullptr) {
       shape.set_dynamic_dimension(

--- a/torch_xla/csrc/shape_builder.h
+++ b/torch_xla/csrc/shape_builder.h
@@ -12,19 +12,19 @@ class ShapeBuilder {
  public:
   explicit ShapeBuilder(xla::PrimitiveType type) : type_(type) {}
 
-  ShapeBuilder& Add(const xla::Shape& shape, int64_t dim);
+  ShapeBuilder& Add(const xla::Shape& shape, xla::int64_t dim);
 
   ShapeBuilder& Add(const xla::Shape& shape,
-                    absl::Span<const int64_t> dimensions);
+                    absl::Span<const xla::int64_t> dimensions);
 
-  ShapeBuilder& Add(int64_t size);
+  ShapeBuilder& Add(xla::int64_t size);
 
   xla::Shape Build() const;
 
  private:
   struct ShapeDim {
     const xla::Shape* shape = nullptr;
-    int64_t dim_or_size = -1;
+    xla::int64_t dim_or_size = -1;
   };
 
   xla::PrimitiveType type_;

--- a/torch_xla/csrc/softmax_builder.cpp
+++ b/torch_xla/csrc/softmax_builder.cpp
@@ -8,16 +8,17 @@ namespace torch_xla {
 namespace {
 
 struct SoftMaxPartials {
-  std::vector<int64_t> broadcast_dimensions;
+  std::vector<xla::int64_t> broadcast_dimensions;
   xla::XlaOp shifted_logits;
   xla::XlaOp exp_shifted;
   xla::XlaOp reduce;
 };
 
-std::vector<int64_t> BroadcastDimensions(int64_t dims, int64_t reduce_dim) {
-  std::vector<int64_t> result_dims;
+std::vector<xla::int64_t> BroadcastDimensions(xla::int64_t dims,
+                                              xla::int64_t reduce_dim) {
+  std::vector<xla::int64_t> result_dims;
   result_dims.reserve(dims);
-  for (int64_t i = 0; i < dims; ++i) {
+  for (xla::int64_t i = 0; i < dims; ++i) {
     if (reduce_dim != i) {
       result_dims.push_back(i);
     }
@@ -25,9 +26,9 @@ std::vector<int64_t> BroadcastDimensions(int64_t dims, int64_t reduce_dim) {
   return result_dims;
 }
 
-SoftMaxPartials LogSoftmaxPartials(xla::XlaOp logits, int64_t dim) {
+SoftMaxPartials LogSoftmaxPartials(xla::XlaOp logits, xla::int64_t dim) {
   const xla::Shape& logits_shape = XlaHelpers::ShapeOfXlaOp(logits);
-  std::vector<int64_t> broadcast_dimensions =
+  std::vector<xla::int64_t> broadcast_dimensions =
       BroadcastDimensions(logits_shape.rank(), dim);
   xla::XlaComputation max_func =
       XlaHelpers::CreateMaxComputation(logits_shape.element_type());
@@ -46,7 +47,7 @@ SoftMaxPartials LogSoftmaxPartials(xla::XlaOp logits, int64_t dim) {
   return {std::move(broadcast_dimensions), shifted_logits, exp_shifted, reduce};
 }
 
-xla::XlaOp SoftmaxSumOfGrad(xla::XlaOp grad_output, int64_t dim) {
+xla::XlaOp SoftmaxSumOfGrad(xla::XlaOp grad_output, xla::int64_t dim) {
   const xla::Shape& grad_output_shape = XlaHelpers::ShapeOfXlaOp(grad_output);
   auto broadcast_dimensions =
       BroadcastDimensions(grad_output_shape.rank(), dim);
@@ -60,14 +61,14 @@ xla::XlaOp SoftmaxSumOfGrad(xla::XlaOp grad_output, int64_t dim) {
 
 }  // namespace
 
-xla::XlaOp BuildLogSoftmax(xla::XlaOp logits, int64_t dim) {
+xla::XlaOp BuildLogSoftmax(xla::XlaOp logits, xla::int64_t dim) {
   SoftMaxPartials parts = LogSoftmaxPartials(logits, dim);
   return xla::Sub(parts.shifted_logits, xla::Log(parts.reduce),
                   parts.broadcast_dimensions);
 }
 
 xla::XlaOp BuildLogSoftmaxGrad(xla::XlaOp grad_output, xla::XlaOp output,
-                               int64_t dim) {
+                               xla::int64_t dim) {
   // Inspired from tf2xla.
   xla::XlaOp sum = SoftmaxSumOfGrad(grad_output, dim);
   const xla::Shape& grad_output_shape = XlaHelpers::ShapeOfXlaOp(grad_output);
@@ -77,13 +78,13 @@ xla::XlaOp BuildLogSoftmaxGrad(xla::XlaOp grad_output, xla::XlaOp output,
                   xla::Mul(xla::Exp(output), sum, broadcast_dimensions));
 }
 
-xla::XlaOp BuildSoftmax(xla::XlaOp logits, int64_t dim) {
+xla::XlaOp BuildSoftmax(xla::XlaOp logits, xla::int64_t dim) {
   SoftMaxPartials parts = LogSoftmaxPartials(logits, dim);
   return xla::Div(parts.exp_shifted, parts.reduce, parts.broadcast_dimensions);
 }
 
 xla::XlaOp BuildSoftmaxGrad(xla::XlaOp grad_output, xla::XlaOp output,
-                            int64_t dim) {
+                            xla::int64_t dim) {
   xla::XlaOp sum = SoftmaxSumOfGrad(xla::Mul(grad_output, output), dim);
   const xla::Shape& grad_output_shape = XlaHelpers::ShapeOfXlaOp(grad_output);
   auto broadcast_dimensions =

--- a/torch_xla/csrc/softmax_builder.h
+++ b/torch_xla/csrc/softmax_builder.h
@@ -5,15 +5,15 @@
 namespace torch_xla {
 
 // Computes log(softmax(logits)) along the dimension specified by "dim".
-xla::XlaOp BuildLogSoftmax(xla::XlaOp logits, int64_t dim);
+xla::XlaOp BuildLogSoftmax(xla::XlaOp logits, xla::int64_t dim);
 
 // Computes the gradient of the input of the LogSoftmax function.
 xla::XlaOp BuildLogSoftmaxGrad(xla::XlaOp grad_output, xla::XlaOp output,
-                               int64_t dim);
+                               xla::int64_t dim);
 
-xla::XlaOp BuildSoftmax(xla::XlaOp logits, int64_t dim);
+xla::XlaOp BuildSoftmax(xla::XlaOp logits, xla::int64_t dim);
 
 xla::XlaOp BuildSoftmaxGrad(xla::XlaOp grad_output, xla::XlaOp output,
-                            int64_t dim);
+                            xla::int64_t dim);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -266,9 +266,9 @@ bool ShouldSyncIrValue(const ir::Value& ir_value) {
 class XLATensor::DeviceContextArena {
   struct DeviceContext {
     std::mutex lock;
-    std::map<int64_t, std::weak_ptr<Data>> tensors_data;
-    uint64_t seed = 101;
-    uint64_t running_seed = 101;
+    std::map<xla::int64_t, std::weak_ptr<Data>> tensors_data;
+    xla::uint64 seed = 101;
+    xla::uint64 running_seed = 101;
     ir::Value seed_ir_value;
   };
 
@@ -309,8 +309,8 @@ class XLATensor::DeviceContextArena {
 
   ir::Value GetRngSeed(const Device& device) {
     static const at::ScalarType kSeedType = at::ScalarType::Long;
-    static const uint64_t kSeedMul = 214013;
-    static const uint64_t kSeedAdd = 2531011;
+    static const xla::uint64 kSeedMul = 214013;
+    static const xla::uint64 kSeedAdd = 2531011;
     DeviceContext* devctx = GetDeviceContext(device);
     std::lock_guard<std::mutex> lock(devctx->lock);
     if (!devctx->seed_ir_value) {
@@ -330,13 +330,13 @@ class XLATensor::DeviceContextArena {
     return devctx->seed_ir_value;
   }
 
-  uint64_t GetRunningSeed(const Device& device) {
+  xla::uint64 GetRunningSeed(const Device& device) {
     DeviceContext* devctx = GetDeviceContext(device);
     std::lock_guard<std::mutex> lock(devctx->lock);
     return devctx->running_seed;
   }
 
-  void SetRngSeed(const Device& device, uint64_t seed) {
+  void SetRngSeed(const Device& device, xla::uint64 seed) {
     DeviceContext* devctx = GetDeviceContext(device);
     std::lock_guard<std::mutex> lock(devctx->lock);
     devctx->seed = seed;
@@ -388,10 +388,10 @@ class XLATensor::DeviceContextArena {
 };
 
 struct DeviceDataInfo : public xla::ComputationClient::Data::Info {
-  DeviceDataInfo(int64_t tensor_id, bool read_only)
+  DeviceDataInfo(xla::int64_t tensor_id, bool read_only)
       : tensor_id(tensor_id), read_only(read_only) {}
 
-  int64_t tensor_id = 0;
+  xla::int64_t tensor_id = 0;
   bool read_only = false;
 };
 
@@ -490,7 +490,7 @@ XLATensor::Data* XLATensor::data() const {
   return data_.get();
 }
 
-int64_t XLATensor::size(int64_t dim) const {
+xla::int64_t XLATensor::size(xla::int64_t dim) const {
   auto xla_shape = shape();
   int rank = xla_shape.get().rank();
   int dim_index = XlaHelpers::GetCanonicalDimensionIndex(dim, rank);
@@ -533,7 +533,7 @@ xla::Shape XLATensor::shape_with_layout() const {
 
 const Device& XLATensor::GetDevice() const { return data()->device; }
 
-int64_t XLATensor::GetUniqueId() const { return data()->unique_id; }
+xla::int64_t XLATensor::GetUniqueId() const { return data()->unique_id; }
 
 std::ptrdiff_t XLATensor::GetViewAliasId() const {
   return data()->view != nullptr
@@ -728,7 +728,7 @@ ir::Value XLATensor::GetIrValueForConstant(const at::Scalar& value,
       ir::ops::ScalarOp(std::move(value), shape.element_type());
   if (!shape.dimensions().empty()) {
     ir_value = ir::MakeNode<ir::ops::Expand>(
-        ir_value, xla::util::ToVector<int64_t>(shape.dimensions()));
+        ir_value, xla::util::ToVector<xla::int64_t>(shape.dimensions()));
   }
   return ir_value;
 }
@@ -748,14 +748,13 @@ ir::Value XLATensor::GetIrValueForScalar(const at::Scalar& value,
       value, MakeXlaPrimitiveType(GetScalarType(value), &device), device);
 }
 
-ir::Value XLATensor::GetIrValueForScalar(const at::Scalar& value,
-                                         xla::PrimitiveType type,
-                                         absl::Span<const int64_t> dimensions,
-                                         const Device& device) {
+ir::Value XLATensor::GetIrValueForScalar(
+    const at::Scalar& value, xla::PrimitiveType type,
+    absl::Span<const xla::int64_t> dimensions, const Device& device) {
   ir::Value ir_value = GetIrValueForScalar(value, type, device);
   if (!dimensions.empty()) {
     ir_value = ir::MakeNode<ir::ops::Expand>(
-        ir_value, xla::util::ToVector<int64_t>(dimensions));
+        ir_value, xla::util::ToVector<xla::int64_t>(dimensions));
   }
   return ir_value;
 }
@@ -789,8 +788,9 @@ View::IrNode XLATensor::GetViewUpdate(const std::shared_ptr<View>& view) const {
 std::shared_ptr<View> XLATensor::UpdateView(std::shared_ptr<View> view,
                                             ir::Value ir_value) const {
   if (ir_value.shape().dimensions() != view->shape().dimensions()) {
-    XLA_CHECK_EQ(xla::util::Multiply<int64_t>(ir_value.shape().dimensions()),
-                 xla::util::Multiply<int64_t>(view->shape().dimensions()));
+    XLA_CHECK_EQ(
+        xla::util::Multiply<xla::int64_t>(ir_value.shape().dimensions()),
+        xla::util::Multiply<xla::int64_t>(view->shape().dimensions()));
 
     ViewInfo view_info(ViewInfo::Type::kReshape, ir_value.shape(),
                        view->shape());
@@ -928,10 +928,10 @@ std::vector<xla::ComputationClient::DataPtr> XLATensor::GatherTensorsXlaData(
     const std::vector<XLATensor>& tensors, absl::Span<const size_t> indices,
     absl::Span<const xla::ComputationClient::DataPtr> tensors_data) {
   std::vector<xla::ComputationClient::DataPtr> result_tensors_data;
-  std::unordered_map<int64_t, size_t> uid_index_map;
+  std::unordered_map<xla::int64_t, size_t> uid_index_map;
   size_t indices_index = 0;
   for (size_t i = 0; i < tensors.size(); ++i) {
-    int64_t tensor_id = tensors[i].GetUniqueId();
+    xla::int64_t tensor_id = tensors[i].GetUniqueId();
     auto it = uid_index_map.find(tensor_id);
     if (it != uid_index_map.end()) {
       // Current tensor is a duplicate of a previously processed tensor that had
@@ -1147,7 +1147,7 @@ XLATensor::SyncTensorCollection XLATensor::CollectSyncTensors(
   std::vector<at::Tensor> at_tensors;
   std::vector<std::string> devices;
   std::vector<size_t> at_tensor_index;
-  std::unordered_set<int64_t> tensor_ids;
+  std::unordered_set<xla::int64_t> tensor_ids;
   // The force_xla_data controls aliasing compilation, so effectively the same
   // graph with on/off force_xla_data should not match, hash wise.
   coll.hash = torch::lazy::MHash(config.force_xla_data);
@@ -1499,10 +1499,10 @@ XLATensor::OpByOpAsync XLATensor::SyncTensorsGraphOpByOp(
 void XLATensor::BuildInputOutputAliases(const std::vector<XLATensor>& tensors,
                                         absl::Span<const size_t> indices,
                                         ir::LoweringContext* lowering_ctx) {
-  std::unordered_map<int64_t, size_t> output_tensor_id_map;
+  std::unordered_map<xla::int64_t, size_t> output_tensor_id_map;
   for (size_t i = 0; i < indices.size(); ++i) {
     size_t tensor_index = indices[i];
-    int64_t tensor_id = tensors[tensor_index].GetUniqueId();
+    xla::int64_t tensor_id = tensors[tensor_index].GetUniqueId();
     output_tensor_id_map[tensor_id] = i;
   }
   const std::vector<xla::ComputationClient::DataPtr>& parameters_data =
@@ -1520,7 +1520,7 @@ void XLATensor::BuildInputOutputAliases(const std::vector<XLATensor>& tensors,
         if (parameters_data[i]->shape() == root_shape &&
             alias_map[output_index] < 0) {
           lowering_ctx->builder()->SetUpAlias(
-              {static_cast<int64_t>(output_index)}, i, {});
+              {static_cast<xla::int64_t>(output_index)}, i, {});
           alias_map[output_index] = i;
 
           TF_VLOG(6) << "Aliased paramter " << i << " with output "
@@ -1651,8 +1651,9 @@ std::shared_ptr<XLATensor::Async> XLATensor::SyncTensorsGraphInternal(
       compile_result.device.ToString(), std::move(cached_computation));
 }
 
-int64_t XLATensor::GetNextTensorId() {
-  static std::atomic<int64_t>* id_generator = new std::atomic<int64_t>(1);
+xla::int64_t XLATensor::GetNextTensorId() {
+  static std::atomic<xla::int64_t>* id_generator =
+      new std::atomic<xla::int64_t>(1);
   return id_generator->fetch_add(1);
 }
 
@@ -1660,11 +1661,11 @@ ir::Value XLATensor::GetRngSeed(const Device& device) {
   return DeviceContextArena::Get()->GetRngSeed(device);
 }
 
-void XLATensor::SetRngSeed(const Device& device, uint64_t seed) {
+void XLATensor::SetRngSeed(const Device& device, xla::uint64 seed) {
   DeviceContextArena::Get()->SetRngSeed(device, seed);
 }
 
-uint64_t XLATensor::GetRunningSeed(const Device& device) {
+xla::uint64 XLATensor::GetRunningSeed(const Device& device) {
   return DeviceContextArena::Get()->GetRunningSeed(device);
 }
 

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -47,7 +47,7 @@ class XLATensor {
 
   XLATensor alias() const { return XLATensor(data_ptr()); }
 
-  int64_t size(int64_t dim) const;
+  xla::int64_t size(xla::int64_t dim) const;
 
   at::Tensor ToTensor(bool detached);
 
@@ -70,7 +70,7 @@ class XLATensor {
   xla::Shape shape_with_layout() const;
 
   const Device& GetDevice() const;
-  int64_t GetUniqueId() const;
+  xla::int64_t GetUniqueId() const;
 
   // Retrieves an opaque ID of the alias object upon which the tensor's view is
   // rooted, or 0 if this tensor is not a view.
@@ -112,10 +112,9 @@ class XLATensor {
                                        const Device& device);
   static ir::Value GetIrValueForScalar(const at::Scalar& value,
                                        const Device& device);
-  static ir::Value GetIrValueForScalar(const at::Scalar& value,
-                                       xla::PrimitiveType type,
-                                       absl::Span<const int64_t> dimensions,
-                                       const Device& device);
+  static ir::Value GetIrValueForScalar(
+      const at::Scalar& value, xla::PrimitiveType type,
+      absl::Span<const xla::int64_t> dimensions, const Device& device);
   static ir::Value GetIrValueForScalar(const at::Scalar& value,
                                        const xla::Shape& shape,
                                        const Device& device);
@@ -125,9 +124,9 @@ class XLATensor {
 
   static ir::Value GetRngSeed(const Device& device);
 
-  static void SetRngSeed(const Device& device, uint64_t seed);
+  static void SetRngSeed(const Device& device, xla::uint64 seed);
 
-  static uint64_t GetRunningSeed(const Device& device);
+  static xla::uint64 GetRunningSeed(const Device& device);
 
   // Dispatches a comparison operator, setting the logical type of the result
   // appropriately.
@@ -189,37 +188,37 @@ class XLATensor {
   //////////////////////////////////////////////////////////////////////////////
   static std::pair<XLATensor, ir::Value> all_reduce(
       const XLATensor& input, const ir::Value& token, AllReduceType reduce_type,
-      double scale, std::vector<std::vector<int64_t>> groups);
+      double scale, std::vector<std::vector<xla::int64_t>> groups);
 
   static ir::Value all_reduce_(XLATensor& input, const ir::Value& token,
                                AllReduceType reduce_type, double scale,
-                               std::vector<std::vector<int64_t>> groups);
+                               std::vector<std::vector<xla::int64_t>> groups);
 
   static ir::Value all_reduce(std::vector<XLATensor>* inputs,
                               const ir::Value& token, AllReduceType reduce_type,
                               double scale,
-                              std::vector<std::vector<int64_t>> groups);
+                              std::vector<std::vector<xla::int64_t>> groups);
 
   static std::pair<XLATensor, ir::Value> reduce_scatter(
       const XLATensor& input, const ir::Value& token, AllReduceType reduce_type,
-      double scale, int64_t scatter_dim, int64_t shard_count,
-      std::vector<std::vector<int64_t>> groups);
+      double scale, xla::int64_t scatter_dim, xla::int64_t shard_count,
+      std::vector<std::vector<xla::int64_t>> groups);
 
   static std::pair<XLATensor, ir::Value> all_to_all(
-      const XLATensor& input, const ir::Value& token, int64_t split_dimension,
-      int64_t concat_dimension, int64_t split_count,
-      std::vector<std::vector<int64_t>> groups);
+      const XLATensor& input, const ir::Value& token,
+      xla::int64_t split_dimension, xla::int64_t concat_dimension,
+      xla::int64_t split_count, std::vector<std::vector<xla::int64_t>> groups);
 
   static std::pair<XLATensor, ir::Value> all_gather(
-      const XLATensor& input, const ir::Value& token, int64_t dim,
-      int64_t shard_count, std::vector<std::vector<int64_t>> groups);
+      const XLATensor& input, const ir::Value& token, xla::int64_t dim,
+      xla::int64_t shard_count, std::vector<std::vector<xla::int64_t>> groups);
 
   static std::pair<XLATensor, ir::Value> collective_permute(
       const XLATensor& input, const ir::Value& token,
-      std::vector<std::pair<int64_t, int64_t>> source_target_pairs);
+      std::vector<std::pair<xla::int64_t, xla::int64_t>> source_target_pairs);
 
   static XLATensor get_dimensions_size(const XLATensor& input,
-                                       std::vector<int64_t> dimensions);
+                                       std::vector<xla::int64_t> dimensions);
 
   static void sgd_optimizer_step_(XLATensor& step, XLATensor& param,
                                   XLATensor& buf, const XLATensor& found_inf,
@@ -255,19 +254,19 @@ class XLATensor {
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
 
   static std::tuple<XLATensor, XLATensor> adaptive_max_pool2d(
-      const XLATensor& input, std::vector<int64_t> output_size);
+      const XLATensor& input, std::vector<xla::int64_t> output_size);
 
   static XLATensor adaptive_max_pool2d_backward(const XLATensor& grad_output,
                                                 const XLATensor& input);
 
   static XLATensor adaptive_avg_pool3d(const XLATensor& input,
-                                       std::vector<int64_t> output_size);
+                                       std::vector<xla::int64_t> output_size);
 
   static XLATensor adaptive_avg_pool3d_backward(const XLATensor& grad_output,
                                                 const XLATensor& input);
 
   static XLATensor _adaptive_avg_pool2d(const XLATensor& input,
-                                        std::vector<int64_t> output_size);
+                                        std::vector<xla::int64_t> output_size);
 
   static XLATensor _adaptive_avg_pool2d_backward(const XLATensor& grad_output,
                                                  const XLATensor& input);
@@ -307,38 +306,45 @@ class XLATensor {
   static XLATensor addmm(const XLATensor& input, const XLATensor& weight,
                          const XLATensor& bias);
 
-  static XLATensor all(const XLATensor& input, std::vector<int64_t> dimensions,
+  static XLATensor all(const XLATensor& input,
+                       std::vector<xla::int64_t> dimensions,
                        bool keep_reduced_dimensions);
 
-  static XLATensor amax(const XLATensor& input, std::vector<int64_t> dimensions,
+  static XLATensor amax(const XLATensor& input,
+                        std::vector<xla::int64_t> dimensions,
                         bool keep_reduced_dimensions);
 
-  static XLATensor amin(const XLATensor& input, std::vector<int64_t> dimensions,
+  static XLATensor amin(const XLATensor& input,
+                        std::vector<xla::int64_t> dimensions,
                         bool keep_reduced_dimensions);
 
-  static XLATensor any(const XLATensor& input, std::vector<int64_t> dimensions,
+  static XLATensor any(const XLATensor& input,
+                       std::vector<xla::int64_t> dimensions,
                        bool keep_reduced_dimensions);
 
   static void arange_out(XLATensor& out, const at::Scalar& start,
                          const at::Scalar& end, const at::Scalar& step,
                          at::ScalarType scalar_type);
 
-  static XLATensor argmax(const XLATensor& input, int64_t dim, bool keepdim);
+  static XLATensor argmax(const XLATensor& input, xla::int64_t dim,
+                          bool keepdim);
   static XLATensor argmax(const XLATensor& input);
 
-  static XLATensor argmin(const XLATensor& input, int64_t dim, bool keepdim);
+  static XLATensor argmin(const XLATensor& input, xla::int64_t dim,
+                          bool keepdim);
   static XLATensor argmin(const XLATensor& input);
 
   // Takes a slice from the input as R1 at the specified offset and reshapes it
   // into the provided size.
-  static XLATensor as_strided(const XLATensor& input, std::vector<int64_t> size,
-                              std::vector<int64_t> stride,
-                              c10::optional<int64_t> storage_offset);
+  static XLATensor as_strided(const XLATensor& input,
+                              std::vector<xla::int64_t> size,
+                              std::vector<xla::int64_t> stride,
+                              c10::optional<xla::int64_t> storage_offset);
 
   // In-place version of the method above.
-  static void as_strided_(XLATensor& input, std::vector<int64_t> size,
-                          std::vector<int64_t> stride,
-                          c10::optional<int64_t> storage_offset);
+  static void as_strided_(XLATensor& input, std::vector<xla::int64_t> size,
+                          std::vector<xla::int64_t> stride,
+                          c10::optional<xla::int64_t> storage_offset);
 
   static XLATensor asin(const XLATensor& input);
 
@@ -353,18 +359,18 @@ class XLATensor {
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
 
   static XLATensor avg_pool_nd(const XLATensor& input,
-                               int64_t spatial_dim_count,
-                               std::vector<int64_t> kernel_size,
-                               std::vector<int64_t> stride,
-                               std::vector<int64_t> padding, bool ceil_mode,
-                               bool count_include_pad);
+                               xla::int64_t spatial_dim_count,
+                               std::vector<xla::int64_t> kernel_size,
+                               std::vector<xla::int64_t> stride,
+                               std::vector<xla::int64_t> padding,
+                               bool ceil_mode, bool count_include_pad);
 
   static XLATensor avg_pool_nd_backward(const XLATensor& out_backprop,
                                         const XLATensor& input,
-                                        int64_t spatial_dim_count,
-                                        std::vector<int64_t> kernel_size,
-                                        std::vector<int64_t> stride,
-                                        std::vector<int64_t> padding,
+                                        xla::int64_t spatial_dim_count,
+                                        std::vector<xla::int64_t> kernel_size,
+                                        std::vector<xla::int64_t> stride,
+                                        std::vector<xla::int64_t> padding,
                                         bool ceil_mode, bool count_include_pad);
 
   static XLATensor baddbmm(const XLATensor& input, const XLATensor& batch1,
@@ -379,13 +385,13 @@ class XLATensor {
   static XLATensor binary_cross_entropy(const XLATensor& input,
                                         const XLATensor& target,
                                         const XLATensor& weight,
-                                        int64_t reduction);
+                                        xla::int64_t reduction);
 
   static XLATensor binary_cross_entropy_backward(const XLATensor& grad_output,
                                                  const XLATensor& input,
                                                  const XLATensor& target,
                                                  const XLATensor& weight,
-                                                 int64_t reduction);
+                                                 xla::int64_t reduction);
 
   static XLATensor bitwise_and(const XLATensor& input, const at::Scalar& other);
 
@@ -414,7 +420,7 @@ class XLATensor {
   static std::vector<XLATensor> broadcast_tensors(
       absl::Span<const XLATensor> tensors);
 
-  static XLATensor cat(absl::Span<const XLATensor> tensors, int64_t dim);
+  static XLATensor cat(absl::Span<const XLATensor> tensors, xla::int64_t dim);
 
   static XLATensor ceil(const XLATensor& input);
 
@@ -435,27 +441,28 @@ class XLATensor {
   // Pad with the given value and size specified by the given list of low and
   // high paddings.
   static XLATensor constant_pad_nd(const XLATensor& input,
-                                   absl::Span<const int64_t> pad,
+                                   absl::Span<const xla::int64_t> pad,
                                    const at::Scalar& value);
 
   static XLATensor convolution_overrideable(
       const XLATensor& input, const XLATensor& weight, const XLATensor& bias,
-      std::vector<int64_t> stride, std::vector<int64_t> padding,
-      std::vector<int64_t> dilation, bool transposed,
-      std::vector<int64_t> output_padding, int64_t groups);
+      std::vector<xla::int64_t> stride, std::vector<xla::int64_t> padding,
+      std::vector<xla::int64_t> dilation, bool transposed,
+      std::vector<xla::int64_t> output_padding, xla::int64_t groups);
 
   static std::tuple<XLATensor, XLATensor, XLATensor>
   convolution_backward_overrideable(
       const XLATensor& out_backprop, const XLATensor& input,
-      const XLATensor& weight, std::vector<int64_t> stride,
-      std::vector<int64_t> padding, std::vector<int64_t> dilation,
-      bool transposed, std::vector<int64_t> output_padding, int64_t groups);
+      const XLATensor& weight, std::vector<xla::int64_t> stride,
+      std::vector<xla::int64_t> padding, std::vector<xla::int64_t> dilation,
+      bool transposed, std::vector<xla::int64_t> output_padding,
+      xla::int64_t groups);
 
   static XLATensor convolution_overrideable(
       const XLATensor& input, const XLATensor& weight,
-      std::vector<int64_t> stride, std::vector<int64_t> padding,
-      std::vector<int64_t> dilation, bool transposed,
-      std::vector<int64_t> output_padding, int64_t groups);
+      std::vector<xla::int64_t> stride, std::vector<xla::int64_t> padding,
+      std::vector<xla::int64_t> dilation, bool transposed,
+      std::vector<xla::int64_t> output_padding, xla::int64_t groups);
 
   static XLATensor cos(const XLATensor& input);
 
@@ -465,25 +472,25 @@ class XLATensor {
   // If the dimension is not given, it defaults to the first dimension found
   // with the size 3.
   static XLATensor cross(const XLATensor& input, const XLATensor& other,
-                         c10::optional<int64_t> dim);
+                         c10::optional<xla::int64_t> dim);
 
   // Returns the cumulative product of elements of input in the given dimension.
-  static XLATensor cumprod(const XLATensor& input, int64_t dim,
+  static XLATensor cumprod(const XLATensor& input, xla::int64_t dim,
                            c10::optional<at::ScalarType> dtype);
 
   // Returns the cumulative sum of elements of input in the given dimension.
-  static XLATensor cumsum(const XLATensor& input, int64_t dim,
+  static XLATensor cumsum(const XLATensor& input, xla::int64_t dim,
                           c10::optional<at::ScalarType> dtype);
 
   // If the input is a matrix (2-D tensor), returns a 1-D tensor with the
   // diagonal elements of the input. If the input is a vector (1-D tensor),
   // returns a 2-D square tensor with the elements of input as the diagonal.
-  static XLATensor diag(const XLATensor& input, int64_t offset);
+  static XLATensor diag(const XLATensor& input, xla::int64_t offset);
 
   // Returns the diagonal of a matrix (2-D tensor) or batch of matrices. The
   // matrix dimensions are specified by dim1 and dim2, the diagonal by offset.
-  static XLATensor diagonal(const XLATensor& input, int64_t offset,
-                            int64_t dim1, int64_t dim2);
+  static XLATensor diagonal(const XLATensor& input, xla::int64_t offset,
+                            xla::int64_t dim1, xla::int64_t dim2);
 
   static XLATensor div(
       const XLATensor& input, const XLATensor& other,
@@ -508,8 +515,8 @@ class XLATensor {
 
   static XLATensor embedding_dense_backward(const XLATensor& grad_output,
                                             const XLATensor& indices,
-                                            int64_t num_weights,
-                                            int64_t padding_idx,
+                                            xla::int64_t num_weights,
+                                            xla::int64_t padding_idx,
                                             bool scale_grad_by_freq);
 
   static XLATensor eq(const XLATensor& input, const at::Scalar& other);
@@ -524,23 +531,25 @@ class XLATensor {
 
   static XLATensor exp(const XLATensor& input);
 
-  static XLATensor expand(const XLATensor& input, std::vector<int64_t> size);
+  static XLATensor expand(const XLATensor& input,
+                          std::vector<xla::int64_t> size);
 
   static XLATensor expm1(const XLATensor& input);
 
   static void exponential_(XLATensor& input, double lambd);
 
   // Returns a 2-D tensor with ones on the diagonal and zeros elsewhere.
-  static XLATensor eye(int64_t lines, int64_t cols, const Device& device,
-                       at::ScalarType element_type);
+  static XLATensor eye(xla::int64_t lines, xla::int64_t cols,
+                       const Device& device, at::ScalarType element_type);
 
-  static void eye_out(XLATensor& out, int64_t lines, int64_t cols);
+  static void eye_out(XLATensor& out, xla::int64_t lines, xla::int64_t cols);
 
   // Fills the input with the given value.
   static void fill_(XLATensor& input, const at::Scalar& value);
 
   // Flips (reverses) the values in the dimensions of the input tensor.
-  static XLATensor flip(const XLATensor& input, absl::Span<const int64_t> dims);
+  static XLATensor flip(const XLATensor& input,
+                        absl::Span<const xla::int64_t> dims);
 
   static XLATensor floor(const XLATensor& input);
 
@@ -553,14 +562,14 @@ class XLATensor {
 
   static XLATensor frac(const XLATensor& input);
 
-  static XLATensor full(absl::Span<const int64_t> size,
+  static XLATensor full(absl::Span<const xla::int64_t> size,
                         const at::Scalar& fill_value, const Device& device,
                         at::ScalarType scalar_type);
   static XLATensor full_like(const XLATensor& input,
                              const at::Scalar& fill_value, const Device& device,
                              c10::optional<at::ScalarType> scalar_type);
 
-  static XLATensor gather(const XLATensor& input, int64_t dim,
+  static XLATensor gather(const XLATensor& input, xla::int64_t dim,
                           const XLATensor& index);
 
   static XLATensor ge(const XLATensor& input, const at::Scalar& other);
@@ -583,48 +592,49 @@ class XLATensor {
   // d(start_dim+p+1) x ... x dn.
   static XLATensor index(const XLATensor& input,
                          absl::Span<const XLATensor> indices,
-                         int64_t start_dim);
+                         xla::int64_t start_dim);
 
-  static XLATensor index_add(const XLATensor& input, int64_t dim,
+  static XLATensor index_add(const XLATensor& input, xla::int64_t dim,
                              const XLATensor& index, const XLATensor& source,
                              const at::Scalar& alpha);
 
-  static XLATensor index_copy(const XLATensor& input, int64_t dim,
+  static XLATensor index_copy(const XLATensor& input, xla::int64_t dim,
                               const XLATensor& index, const XLATensor& source);
 
-  static void index_copy_(XLATensor& input, int64_t dim, const XLATensor& index,
-                          const XLATensor& source);
+  static void index_copy_(XLATensor& input, xla::int64_t dim,
+                          const XLATensor& index, const XLATensor& source);
 
   // Fills the elements of the base tensor with the given value in the given
   // dimension, at positions given by the index. The index must be a rank-1
   // tensor.
-  static XLATensor index_fill(const XLATensor& input, int64_t dim,
+  static XLATensor index_fill(const XLATensor& input, xla::int64_t dim,
                               const XLATensor& index, const at::Scalar& value);
 
   // Same as above, but the value is wrapped as a rank-0 tensor.
-  static XLATensor index_fill(const XLATensor& input, int64_t dim,
+  static XLATensor index_fill(const XLATensor& input, xla::int64_t dim,
                               const XLATensor& index, const XLATensor& value);
 
-  static void index_fill_(XLATensor& input, int64_t dim, const XLATensor& index,
-                          const XLATensor& value);
+  static void index_fill_(XLATensor& input, xla::int64_t dim,
+                          const XLATensor& index, const XLATensor& value);
 
-  static void index_fill_(XLATensor& input, int64_t dim, const XLATensor& index,
-                          const at::Scalar& value);
+  static void index_fill_(XLATensor& input, xla::int64_t dim,
+                          const XLATensor& index, const at::Scalar& value);
 
   // Puts values into the input tensor using the given indices (a tuple of
   // tensors) and returns the result.
   static XLATensor index_put(const XLATensor& input,
                              absl::Span<const XLATensor> indices,
-                             int64_t start_dim, const XLATensor& values,
+                             xla::int64_t start_dim, const XLATensor& values,
                              bool accumulate,
-                             absl::Span<const int64_t> result_permutation);
+                             absl::Span<const xla::int64_t> result_permutation);
 
   static void index_put_(XLATensor& input, const XLATensor& canonical_base,
-                         absl::Span<const XLATensor> indices, int64_t start_dim,
-                         const XLATensor& values, bool accumulate,
-                         absl::Span<const int64_t> result_permutation);
+                         absl::Span<const XLATensor> indices,
+                         xla::int64_t start_dim, const XLATensor& values,
+                         bool accumulate,
+                         absl::Span<const xla::int64_t> result_permutation);
 
-  static XLATensor index_select(const XLATensor& input, int64_t dim,
+  static XLATensor index_select(const XLATensor& input, xla::int64_t dim,
                                 const XLATensor& index);
 
   static XLATensor inverse(const XLATensor& input);
@@ -633,19 +643,21 @@ class XLATensor {
 
   static XLATensor kl_div_backward(const XLATensor& grad_output,
                                    const XLATensor& input,
-                                   const XLATensor& target, int64_t reduction,
-                                   bool log_target);
+                                   const XLATensor& target,
+                                   xla::int64_t reduction, bool log_target);
 
   static std::tuple<XLATensor, XLATensor> kthvalue(const XLATensor& input,
-                                                   int64_t k, int64_t dim,
+                                                   xla::int64_t k,
+                                                   xla::int64_t dim,
                                                    bool keepdim);
 
   static XLATensor l1_loss(const XLATensor& input, const XLATensor& target,
-                           int64_t reduction);
+                           xla::int64_t reduction);
 
   static XLATensor l1_loss_backward(const XLATensor& grad_output,
                                     const XLATensor& input,
-                                    const XLATensor& target, int64_t reduction);
+                                    const XLATensor& target,
+                                    xla::int64_t reduction);
 
   static XLATensor le(const XLATensor& input, const at::Scalar& other);
 
@@ -687,11 +699,12 @@ class XLATensor {
                                         const XLATensor& input,
                                         const XLATensor& buffer);
 
-  static XLATensor log_softmax(const XLATensor& input, int64_t dim,
+  static XLATensor log_softmax(const XLATensor& input, xla::int64_t dim,
                                c10::optional<at::ScalarType> dtype);
 
   static XLATensor log_softmax_backward(const XLATensor& grad_output,
-                                        const XLATensor& output, int64_t dim);
+                                        const XLATensor& output,
+                                        xla::int64_t dim);
 
   static XLATensor log1p(const XLATensor& input);
   static void log1p_(XLATensor& input);
@@ -707,7 +720,7 @@ class XLATensor {
   static XLATensor logical_or(const XLATensor& input, const XLATensor& other);
 
   static XLATensor logsumexp(const XLATensor& input,
-                             std::vector<int64_t> dimensions,
+                             std::vector<xla::int64_t> dimensions,
                              bool keep_reduced_dimensions);
 
   static XLATensor xlogy(const XLATensor& input, const XLATensor& other);
@@ -734,33 +747,34 @@ class XLATensor {
   static XLATensor max(const XLATensor& input);
 
   static std::tuple<XLATensor, XLATensor> max(const XLATensor& input,
-                                              int64_t dim, bool keepdim);
+                                              xla::int64_t dim, bool keepdim);
 
   static void max_out(XLATensor& max, XLATensor& max_values,
-                      const XLATensor& input, int64_t dim, bool keepdim);
+                      const XLATensor& input, xla::int64_t dim, bool keepdim);
 
   static std::tuple<XLATensor, XLATensor> max_pool_nd(
-      const XLATensor& input, int64_t spatial_dim_count,
-      std::vector<int64_t> kernel_size, std::vector<int64_t> stride,
-      std::vector<int64_t> padding, bool ceil_mode);
+      const XLATensor& input, xla::int64_t spatial_dim_count,
+      std::vector<xla::int64_t> kernel_size, std::vector<xla::int64_t> stride,
+      std::vector<xla::int64_t> padding, bool ceil_mode);
 
   static XLATensor max_pool_nd_backward(const XLATensor& out_backprop,
                                         const XLATensor& input,
-                                        int64_t spatial_dim_count,
-                                        std::vector<int64_t> kernel_size,
-                                        std::vector<int64_t> stride,
-                                        std::vector<int64_t> padding,
+                                        xla::int64_t spatial_dim_count,
+                                        std::vector<xla::int64_t> kernel_size,
+                                        std::vector<xla::int64_t> stride,
+                                        std::vector<xla::int64_t> padding,
                                         bool ceil_mode);
 
   static XLATensor max_unpool(const XLATensor& input, const XLATensor& indices,
-                              std::vector<int64_t> output_size);
+                              std::vector<xla::int64_t> output_size);
 
   static XLATensor max_unpool_backward(const XLATensor& grad_output,
                                        const XLATensor& input,
                                        const XLATensor& indices,
-                                       std::vector<int64_t> output_size);
+                                       std::vector<xla::int64_t> output_size);
 
-  static XLATensor mean(const XLATensor& input, std::vector<int64_t> dimensions,
+  static XLATensor mean(const XLATensor& input,
+                        std::vector<xla::int64_t> dimensions,
                         bool keep_reduced_dimensions,
                         c10::optional<at::ScalarType> dtype);
 
@@ -771,22 +785,22 @@ class XLATensor {
   static XLATensor min(const XLATensor& input);
 
   static std::tuple<XLATensor, XLATensor> min(const XLATensor& input,
-                                              int64_t dim, bool keepdim);
+                                              xla::int64_t dim, bool keepdim);
 
   static void min_out(XLATensor& min, XLATensor& min_indices,
-                      const XLATensor& input, int64_t dim, bool keepdim);
+                      const XLATensor& input, xla::int64_t dim, bool keepdim);
 
   static XLATensor mish(const XLATensor& input);
 
   static XLATensor mm(const XLATensor& input, const XLATensor& weight);
 
   static XLATensor mse_loss(const XLATensor& input, const XLATensor& target,
-                            int64_t reduction);
+                            xla::int64_t reduction);
 
   static XLATensor mse_loss_backward(const XLATensor& grad_output,
                                      const XLATensor& input,
                                      const XLATensor& target,
-                                     int64_t reduction);
+                                     xla::int64_t reduction);
 
   static XLATensor mul(
       const XLATensor& input, const XLATensor& other,
@@ -805,8 +819,8 @@ class XLATensor {
 
   // Returns a new tensor that is a narrowed view of the input in the given
   // dimension.
-  static XLATensor narrow(const XLATensor& input, int64_t dim, int64_t start,
-                          int64_t length);
+  static XLATensor narrow(const XLATensor& input, xla::int64_t dim,
+                          xla::int64_t start, xla::int64_t length);
 
   // Like batch_norm, but returns additional save_mean and save_invstd used by
   // the backward pass.
@@ -828,32 +842,32 @@ class XLATensor {
   static XLATensor neg(const XLATensor& input);
 
   static XLATensor nll_loss(const XLATensor& input, const XLATensor& target,
-                            const XLATensor& weight, int64_t reduction,
+                            const XLATensor& weight, xla::int64_t reduction,
                             int ignore_index);
 
   static XLATensor nll_loss2d(const XLATensor& input, const XLATensor& target,
-                              const XLATensor& weight, int64_t reduction,
+                              const XLATensor& weight, xla::int64_t reduction,
                               int ignore_index);
 
   static XLATensor nll_loss2d_backward(const XLATensor& grad_output,
                                        const XLATensor& input,
                                        const XLATensor& target,
                                        const XLATensor& weight,
-                                       int64_t reduction, int ignore_index,
+                                       xla::int64_t reduction, int ignore_index,
                                        const XLATensor& total_weight);
 
   static XLATensor nll_loss_backward(const XLATensor& grad_output,
                                      const XLATensor& input,
                                      const XLATensor& target,
-                                     const XLATensor& weight, int64_t reduction,
-                                     int ignore_index,
+                                     const XLATensor& weight,
+                                     xla::int64_t reduction, int ignore_index,
                                      const XLATensor& total_weight);
 
   static std::pair<XLATensor, XLATensor> nms(const XLATensor& boxes,
                                              const XLATensor& scores,
                                              const XLATensor& score_threshold,
                                              const XLATensor& iou_threshold,
-                                             int64_t output_size);
+                                             xla::int64_t output_size);
 
   static XLATensor nonzero(const XLATensor& input);
 
@@ -875,7 +889,7 @@ class XLATensor {
 
   // Permute the dimensions of this tensor according to the given permutation.
   static XLATensor permute(const XLATensor& input,
-                           absl::Span<const int64_t> dims);
+                           absl::Span<const xla::int64_t> dims);
 
   static XLATensor pow(const XLATensor& input, const at::Scalar& exponent);
   static XLATensor pow(const XLATensor& input, const XLATensor& exponent);
@@ -883,7 +897,8 @@ class XLATensor {
 
   static XLATensor prelu(const XLATensor& input, const XLATensor& weight);
 
-  static XLATensor prod(const XLATensor& input, std::vector<int64_t> dimensions,
+  static XLATensor prod(const XLATensor& input,
+                        std::vector<xla::int64_t> dimensions,
                         bool keep_reduced_dimensions,
                         c10::optional<at::ScalarType> dtype);
 
@@ -894,17 +909,17 @@ class XLATensor {
 
   static void random_(XLATensor& input, int64_t from, int64_t to);
 
-  static XLATensor randperm(int64_t n, const Device& device,
+  static XLATensor randperm(xla::int64_t n, const Device& device,
                             at::ScalarType scalar_type);
 
   static XLATensor reciprocal(const XLATensor& input);
 
   static XLATensor reflection_pad2d(const XLATensor& input,
-                                    std::vector<int64_t> padding);
+                                    std::vector<xla::int64_t> padding);
 
   static XLATensor reflection_pad2d_backward(const XLATensor& grad_output,
                                              const XLATensor& input,
-                                             std::vector<int64_t> padding);
+                                             std::vector<xla::int64_t> padding);
 
   static XLATensor relu(const XLATensor& input);
   static void relu_(XLATensor& input);
@@ -914,21 +929,22 @@ class XLATensor {
 
   // Repeats the input tensor along each dimension by the given number of
   // repeats.
-  static XLATensor repeat(const XLATensor& input, std::vector<int64_t> repeats);
+  static XLATensor repeat(const XLATensor& input,
+                          std::vector<xla::int64_t> repeats);
 
   static XLATensor replication_pad1d(const XLATensor& input,
-                                     std::vector<int64_t> padding);
-  static XLATensor replication_pad1d_backward(const XLATensor& grad_output,
-                                              const XLATensor& input,
-                                              std::vector<int64_t> padding);
+                                     std::vector<xla::int64_t> padding);
+  static XLATensor replication_pad1d_backward(
+      const XLATensor& grad_output, const XLATensor& input,
+      std::vector<xla::int64_t> padding);
 
   static XLATensor replication_pad2d(const XLATensor& input,
-                                     std::vector<int64_t> padding);
-  static XLATensor replication_pad2d_backward(const XLATensor& grad_output,
-                                              const XLATensor& input,
-                                              std::vector<int64_t> padding);
+                                     std::vector<xla::int64_t> padding);
+  static XLATensor replication_pad2d_backward(
+      const XLATensor& grad_output, const XLATensor& input,
+      std::vector<xla::int64_t> padding);
 
-  static void resize_(XLATensor& input, std::vector<int64_t> size);
+  static void resize_(XLATensor& input, std::vector<xla::int64_t> size);
 
   static XLATensor round(const XLATensor& input);
 
@@ -954,17 +970,18 @@ class XLATensor {
 
   static void copy_(XLATensor& input, XLATensor& src);
 
-  static XLATensor scatter(const XLATensor& input, int64_t dim,
+  static XLATensor scatter(const XLATensor& input, xla::int64_t dim,
                            const XLATensor& index, const XLATensor& src);
-  static XLATensor scatter(const XLATensor& input, int64_t dim,
+  static XLATensor scatter(const XLATensor& input, xla::int64_t dim,
                            const XLATensor& index, const at::Scalar& value);
 
-  static XLATensor scatter_add(const XLATensor& input, int64_t dim,
+  static XLATensor scatter_add(const XLATensor& input, xla::int64_t dim,
                                const XLATensor& index, const XLATensor& src);
-  static XLATensor scatter_add(const XLATensor& input, int64_t dim,
+  static XLATensor scatter_add(const XLATensor& input, xla::int64_t dim,
                                const XLATensor& index, const at::Scalar& value);
 
-  static XLATensor select(const XLATensor& input, int64_t dim, int64_t index);
+  static XLATensor select(const XLATensor& input, xla::int64_t dim,
+                          xla::int64_t index);
 
   static void silu_out(XLATensor& input, XLATensor& out);
   static XLATensor silu_backward(XLATensor& grad_output, XLATensor& input);
@@ -980,27 +997,28 @@ class XLATensor {
 
   static XLATensor sinh(const XLATensor& input);
 
-  static XLATensor slice(const XLATensor& input, int64_t dim, int64_t start,
-                         int64_t end, int64_t step);
+  static XLATensor slice(const XLATensor& input, xla::int64_t dim,
+                         xla::int64_t start, xla::int64_t end,
+                         xla::int64_t step);
 
   static std::tuple<XLATensor, XLATensor> slogdet(const XLATensor& input);
 
   // Computes a loss that uses a squared term if the absolute element-wise error
   // falls below 1 and an L1 term otherwise.
   static XLATensor smooth_l1_loss(const XLATensor& input,
-                                  const XLATensor& target, int64_t reduction,
-                                  double beta);
+                                  const XLATensor& target,
+                                  xla::int64_t reduction, double beta);
 
   // Returns the gradient of the input of a smooth_l1_loss operation.
   static XLATensor smooth_l1_loss_backward(const XLATensor& grad_output,
                                            const XLATensor& input,
                                            const XLATensor& target,
-                                           int64_t reduction, double beta);
+                                           xla::int64_t reduction, double beta);
 
-  static XLATensor softmax(const XLATensor& input, int64_t dim,
+  static XLATensor softmax(const XLATensor& input, xla::int64_t dim,
                            c10::optional<at::ScalarType> dtype);
   static XLATensor softmax_backward(const XLATensor& grad_output,
-                                    const XLATensor& output, int64_t dim);
+                                    const XLATensor& output, xla::int64_t dim);
 
   static XLATensor softplus(const XLATensor& input, const at::Scalar& beta,
                             const at::Scalar& threshold);
@@ -1016,10 +1034,12 @@ class XLATensor {
                                        const at::Scalar& lambda);
 
   static std::vector<XLATensor> split(const XLATensor& input,
-                                      int64_t split_size, int64_t dim);
+                                      xla::int64_t split_size,
+                                      xla::int64_t dim);
 
   static std::vector<XLATensor> split_with_sizes(
-      const XLATensor& input, std::vector<int64_t> split_size, int64_t dim);
+      const XLATensor& input, std::vector<xla::int64_t> split_size,
+      xla::int64_t dim);
 
   static XLATensor sqrt(const XLATensor& input);
 
@@ -1028,20 +1048,21 @@ class XLATensor {
 
   // Squeeze out the specified dimension index, if trivial (size 1). Returns
   // unchanged input otherwise.
-  static XLATensor squeeze(const XLATensor& input, int64_t dim);
+  static XLATensor squeeze(const XLATensor& input, xla::int64_t dim);
 
   // In-place versions of the methods above.
   static void squeeze_(XLATensor& input);
-  static void squeeze_(XLATensor& input, int64_t dim);
+  static void squeeze_(XLATensor& input, xla::int64_t dim);
 
-  static XLATensor stack(absl::Span<const XLATensor> tensors, int64_t dim);
+  static XLATensor stack(absl::Span<const XLATensor> tensors, xla::int64_t dim);
 
-  static XLATensor std(const XLATensor& input, std::vector<int64_t> dimensions,
-                       bool keep_reduced_dimensions, int64_t correction);
+  static XLATensor std(const XLATensor& input,
+                       std::vector<xla::int64_t> dimensions,
+                       bool keep_reduced_dimensions, xla::int64_t correction);
 
   static std::tuple<XLATensor, XLATensor> std_mean(
-      const XLATensor& input, std::vector<int64_t> dimensions,
-      int64_t correction, bool keep_reduced_dimensions);
+      const XLATensor& input, std::vector<xla::int64_t> dimensions,
+      xla::int64_t correction, bool keep_reduced_dimensions);
 
   static XLATensor sub(
       const XLATensor& input, const XLATensor& other, const at::Scalar& alpha,
@@ -1050,7 +1071,8 @@ class XLATensor {
       const XLATensor& input, const at::Scalar& other, const at::Scalar& alpha,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
 
-  static XLATensor sum(const XLATensor& input, std::vector<int64_t> dimensions,
+  static XLATensor sum(const XLATensor& input,
+                       std::vector<xla::int64_t> dimensions,
                        bool keep_reduced_dimensions,
                        c10::optional<at::ScalarType> dtype);
 
@@ -1079,7 +1101,7 @@ class XLATensor {
                       c10::optional<at::ScalarType> scalar_type);
 
   static std::tuple<XLATensor, XLATensor> topk(const XLATensor& input,
-                                               int64_t k, int64_t dim,
+                                               xla::int64_t k, xla::int64_t dim,
                                                bool largest, bool sorted,
                                                bool stable);
 
@@ -1087,11 +1109,12 @@ class XLATensor {
   static XLATensor trace(const XLATensor& input);
 
   // Swap given dimensions of the input.
-  static XLATensor transpose(const XLATensor& input, int64_t dim0,
-                             int64_t dim1);
+  static XLATensor transpose(const XLATensor& input, xla::int64_t dim0,
+                             xla::int64_t dim1);
 
   // In-place version of the method above.
-  static void transpose_(XLATensor& input, int64_t dim0, int64_t dim1);
+  static void transpose_(XLATensor& input, xla::int64_t dim0,
+                         xla::int64_t dim1);
 
   static std::tuple<XLATensor, XLATensor> triangular_solve(
       const XLATensor& rhs, const XLATensor& lhs, bool left_side, bool upper,
@@ -1099,57 +1122,59 @@ class XLATensor {
 
   // Returns the lower triangular part of a matrix (2-D tensor) or batch of
   // matrices input, the other elements of the result tensor out are set to 0.
-  static XLATensor tril(const XLATensor& input, int64_t diagonal);
+  static XLATensor tril(const XLATensor& input, xla::int64_t diagonal);
 
   // In-place version of the method above.
-  static void tril_(XLATensor& input, int64_t diagonal);
+  static void tril_(XLATensor& input, xla::int64_t diagonal);
 
   // Returns the upper triangular part of a matrix (2-D tensor) or batch of
   // matrices input, the other elements of the result tensor out are set to 0.
-  static XLATensor triu(const XLATensor& input, int64_t diagonal);
+  static XLATensor triu(const XLATensor& input, xla::int64_t diagonal);
 
   // In-place version of the method above.
-  static void triu_(XLATensor& input, int64_t diagonal);
+  static void triu_(XLATensor& input, xla::int64_t diagonal);
 
   static XLATensor trunc(const XLATensor& input);
 
   // Returns a tuple of all slices along a given dimension with that dimension
   // removed.
-  static std::vector<XLATensor> unbind(const XLATensor& input, int64_t dim);
+  static std::vector<XLATensor> unbind(const XLATensor& input,
+                                       xla::int64_t dim);
 
   static void uniform_(XLATensor& input, double from, double to);
 
   // Insert a dimension of size one at the specified position.
-  static XLATensor unsqueeze(const XLATensor& input, int64_t dim);
+  static XLATensor unsqueeze(const XLATensor& input, xla::int64_t dim);
 
   // In-place version of the method above.
-  static void unsqueeze_(XLATensor& input, int64_t dim);
+  static void unsqueeze_(XLATensor& input, xla::int64_t dim);
 
   static XLATensor upsample_bilinear2d(const XLATensor& input,
-                                       std::vector<int64_t> output_size,
+                                       std::vector<xla::int64_t> output_size,
                                        bool align_corners);
 
   static XLATensor upsample_bilinear2d_backward(
-      const XLATensor& grad_output, std::vector<int64_t> output_size,
-      std::vector<int64_t> input_size, bool align_corners);
+      const XLATensor& grad_output, std::vector<xla::int64_t> output_size,
+      std::vector<xla::int64_t> input_size, bool align_corners);
 
   static XLATensor upsample_nearest2d(const XLATensor& input,
-                                      std::vector<int64_t> output_size);
+                                      std::vector<xla::int64_t> output_size);
 
-  static XLATensor upsample_nearest2d_backward(const XLATensor& grad_output,
-                                               std::vector<int64_t> output_size,
-                                               std::vector<int64_t> input_size);
+  static XLATensor upsample_nearest2d_backward(
+      const XLATensor& grad_output, std::vector<xla::int64_t> output_size,
+      std::vector<xla::int64_t> input_size);
 
-  static XLATensor var(const XLATensor& input, std::vector<int64_t> dimensions,
-                       int64_t correction, bool keep_reduced_dimensions);
+  static XLATensor var(const XLATensor& input,
+                       std::vector<xla::int64_t> dimensions,
+                       xla::int64_t correction, bool keep_reduced_dimensions);
 
   static std::tuple<XLATensor, XLATensor> var_mean(
-      const XLATensor& input, std::vector<int64_t> dimensions,
-      int64_t correction, bool keep_reduced_dimensions);
+      const XLATensor& input, std::vector<xla::int64_t> dimensions,
+      xla::int64_t correction, bool keep_reduced_dimensions);
 
   // Like reshape, but it returns a view into the original tensor.
   static XLATensor view(const XLATensor& input,
-                        absl::Span<const int64_t> output_size);
+                        absl::Span<const xla::int64_t> output_size);
 
   static void zero_(XLATensor& input);
 
@@ -1255,7 +1280,7 @@ class XLATensor {
     c10::optional<at::ScalarType> logical_element_type;
     c10::optional<at::Tensor> tensor_data;
     const Device device;
-    const int64_t unique_id = 0;
+    const xla::int64_t unique_id = 0;
     size_t generation = 1;
   };
 
@@ -1401,7 +1426,7 @@ class XLATensor {
       std::vector<XLATensor>* tensors, absl::Span<const std::string> devices,
       const SyncTensorsConfig& config);
 
-  static int64_t GetNextTensorId();
+  static xla::int64_t GetNextTensorId();
 
   std::shared_ptr<Data> data_;
 };

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -156,7 +156,7 @@ ir::Value MaybeExpand(const ir::Value& input, const xla::Shape& target_shape) {
     return input;
   }
   return ir::MakeNode<ir::ops::Expand>(
-      input, xla::util::ToVector<int64_t>(target_shape.dimensions()));
+      input, xla::util::ToVector<xla::int64_t>(target_shape.dimensions()));
 }
 
 MinMaxValues GetMinMaxValues(const XLATensor& tensor,
@@ -175,10 +175,10 @@ MinMaxValues GetMinMaxValues(const XLATensor& tensor,
                                          tensor.GetDevice())};
 }
 
-void CheckRank(const XLATensor& t, int64_t expected_rank,
+void CheckRank(const XLATensor& t, xla::int64_t expected_rank,
                const std::string& tag, const std::string& arg_name,
                int arg_number) {
-  int64_t actual_rank = t.shape().get().rank();
+  xla::int64_t actual_rank = t.shape().get().rank();
   XLA_CHECK_EQ(actual_rank, expected_rank)
       << "Expected " << expected_rank << "-dimensional tensor, but got "
       << actual_rank << "-dimensional tensor for "
@@ -188,15 +188,15 @@ void CheckRank(const XLATensor& t, int64_t expected_rank,
 
 template <typename T>
 void CheckShapeDimensions(const T& size) {
-  XLA_CHECK(std::all_of(size.begin(), size.end(), [](int64_t dim) {
+  XLA_CHECK(std::all_of(size.begin(), size.end(), [](xla::int64_t dim) {
     return dim >= 0;
   })) << "Dimensions cannot be negative numbers";
 }
 
-void CheckDimensionSize(const XLATensor& t, int64_t dim, int64_t expected_size,
-                        const std::string& tag, const std::string& arg_name,
-                        int arg_number) {
-  int64_t dim_size = t.size(dim);
+void CheckDimensionSize(const XLATensor& t, xla::int64_t dim,
+                        xla::int64_t expected_size, const std::string& tag,
+                        const std::string& arg_name, int arg_number) {
+  xla::int64_t dim_size = t.size(dim);
   XLA_CHECK_EQ(t.size(dim), expected_size)
       << "Expected tensor to have size " << expected_size << " at dimension "
       << dim << ", but got size " << dim_size << " for "
@@ -215,10 +215,10 @@ void CheckBmmDimension(const std::string& tag, const XLATensor& batch1,
                      "batch2", 2);
 }
 
-std::vector<int64_t> GetExpandDimensions(const xla::Shape& shape,
-                                         std::vector<int64_t> dimensions) {
+std::vector<xla::int64_t> GetExpandDimensions(
+    const xla::Shape& shape, std::vector<xla::int64_t> dimensions) {
   XLA_CHECK_GE(dimensions.size(), shape.rank()) << shape;
-  int64_t base = dimensions.size() - shape.rank();
+  xla::int64_t base = dimensions.size() - shape.rank();
   for (size_t i = 0; i < shape.rank(); ++i) {
     if (dimensions[base + i] == -1) {
       dimensions[base + i] = shape.dimensions(i);
@@ -227,7 +227,7 @@ std::vector<int64_t> GetExpandDimensions(const xla::Shape& shape,
   return dimensions;
 }
 
-ReductionMode GetXlaReductionMode(int64_t reduction) {
+ReductionMode GetXlaReductionMode(xla::int64_t reduction) {
   switch (reduction) {
     case at::Reduction::Mean:
       return ReductionMode::kMean;
@@ -242,14 +242,14 @@ ReductionMode GetXlaReductionMode(int64_t reduction) {
 // Resizes and / or checks whether a list is of the given size. The list is only
 // resized if its size is 1. If it's empty, it's replaced with the provided
 // default first.
-std::vector<int64_t> CheckIntList(absl::Span<const int64_t> list, size_t length,
-                                  const std::string& name,
-                                  std::vector<int64_t> def = {}) {
-  std::vector<int64_t> result;
+std::vector<xla::int64_t> CheckIntList(absl::Span<const xla::int64_t> list,
+                                       size_t length, const std::string& name,
+                                       std::vector<xla::int64_t> def = {}) {
+  std::vector<xla::int64_t> result;
   if (list.empty()) {
     result = std::move(def);
   } else {
-    result = xla::util::ToVector<int64_t>(list);
+    result = xla::util::ToVector<xla::int64_t>(list);
   }
   if (result.size() == 1 && length > 1) {
     result.resize(length, result[0]);
@@ -316,9 +316,9 @@ void CheckIsIntegralOrPred(const xla::Shape& shape,
 }
 
 ViewInfo CreateAsStridedViewInfo(const xla::Shape& input_shape,
-                                 std::vector<int64_t> size,
-                                 std::vector<int64_t> stride,
-                                 c10::optional<int64_t> storage_offset) {
+                                 std::vector<xla::int64_t> size,
+                                 std::vector<xla::int64_t> stride,
+                                 c10::optional<xla::int64_t> storage_offset) {
   xla::Shape result_shape = XlaHelpers::GetDynamicReshape(input_shape, size);
   AsStridedInfo as_strided_info;
   as_strided_info.stride = std::move(stride);
@@ -336,16 +336,16 @@ ViewInfo CreateAsStridedViewInfo(const xla::Shape& input_shape,
 //////////////////////////////////////////////////////////////////////////////
 std::pair<XLATensor, ir::Value> XLATensor::all_reduce(
     const XLATensor& input, const ir::Value& token, AllReduceType reduce_type,
-    double scale, std::vector<std::vector<int64_t>> groups) {
+    double scale, std::vector<std::vector<xla::int64_t>> groups) {
   std::vector<ir::Value> input_values({input.GetIrValue()});
   ir::NodePtr node = ir::MakeNode<ir::ops::AllReduce>(
       reduce_type, input_values, token, scale, std::move(groups));
   return {input.CreateFrom(ir::Value(node, 0)), ir::Value(node, 1)};
 }
 
-ir::Value XLATensor::all_reduce_(XLATensor& input, const ir::Value& token,
-                                 AllReduceType reduce_type, double scale,
-                                 std::vector<std::vector<int64_t>> groups) {
+ir::Value XLATensor::all_reduce_(
+    XLATensor& input, const ir::Value& token, AllReduceType reduce_type,
+    double scale, std::vector<std::vector<xla::int64_t>> groups) {
   std::vector<ir::Value> input_values({input.GetIrValue()});
   ir::NodePtr node = ir::MakeNode<ir::ops::AllReduce>(
       reduce_type, input_values, token, scale, std::move(groups));
@@ -356,7 +356,7 @@ ir::Value XLATensor::all_reduce_(XLATensor& input, const ir::Value& token,
 ir::Value XLATensor::all_reduce(std::vector<XLATensor>* inputs,
                                 const ir::Value& token,
                                 AllReduceType reduce_type, double scale,
-                                std::vector<std::vector<int64_t>> groups) {
+                                std::vector<std::vector<xla::int64_t>> groups) {
   std::vector<ir::Value> input_values;
   input_values.reserve(inputs->size());
   for (auto& input : *inputs) {
@@ -372,8 +372,8 @@ ir::Value XLATensor::all_reduce(std::vector<XLATensor>* inputs,
 
 std::pair<XLATensor, ir::Value> XLATensor::reduce_scatter(
     const XLATensor& input, const ir::Value& token, AllReduceType reduce_type,
-    double scale, int64_t scatter_dim, int64_t shard_count,
-    std::vector<std::vector<int64_t>> groups) {
+    double scale, xla::int64_t scatter_dim, xla::int64_t shard_count,
+    std::vector<std::vector<xla::int64_t>> groups) {
   ir::NodePtr node = ir::MakeNode<ir::ops::ReduceScatter>(
       reduce_type, input.GetIrValue(), token, scale, scatter_dim, shard_count,
       std::move(groups));
@@ -381,9 +381,9 @@ std::pair<XLATensor, ir::Value> XLATensor::reduce_scatter(
 }
 
 std::pair<XLATensor, ir::Value> XLATensor::all_to_all(
-    const XLATensor& input, const ir::Value& token, int64_t split_dimension,
-    int64_t concat_dimension, int64_t split_count,
-    std::vector<std::vector<int64_t>> groups) {
+    const XLATensor& input, const ir::Value& token,
+    xla::int64_t split_dimension, xla::int64_t concat_dimension,
+    xla::int64_t split_count, std::vector<std::vector<xla::int64_t>> groups) {
   ir::NodePtr node = ir::MakeNode<ir::ops::AllToAll>(
       input.GetIrValue(), token, split_dimension, concat_dimension, split_count,
       std::move(groups));
@@ -391,8 +391,8 @@ std::pair<XLATensor, ir::Value> XLATensor::all_to_all(
 }
 
 std::pair<XLATensor, ir::Value> XLATensor::all_gather(
-    const XLATensor& input, const ir::Value& token, int64_t dim,
-    int64_t shard_count, std::vector<std::vector<int64_t>> groups) {
+    const XLATensor& input, const ir::Value& token, xla::int64_t dim,
+    xla::int64_t shard_count, std::vector<std::vector<xla::int64_t>> groups) {
   ir::NodePtr node = ir::MakeNode<ir::ops::AllGather>(
       input.GetIrValue(), token, dim, shard_count, std::move(groups));
   return {input.CreateFrom(ir::Value(node, 0)), ir::Value(node, 1)};
@@ -400,14 +400,14 @@ std::pair<XLATensor, ir::Value> XLATensor::all_gather(
 
 std::pair<XLATensor, ir::Value> XLATensor::collective_permute(
     const XLATensor& input, const ir::Value& token,
-    std::vector<std::pair<int64_t, int64_t>> source_target_pairs) {
+    std::vector<std::pair<xla::int64_t, xla::int64_t>> source_target_pairs) {
   ir::NodePtr node = ir::MakeNode<ir::ops::CollectivePermute>(
       input.GetIrValue(), token, std::move(source_target_pairs));
   return {input.CreateFrom(ir::Value(node, 0)), ir::Value(node, 1)};
 }
 
 XLATensor XLATensor::get_dimensions_size(const XLATensor& input,
-                                         std::vector<int64_t> dimensions) {
+                                         std::vector<xla::int64_t> dimensions) {
   return input.CreateFrom(ir::MakeNode<ir::ops::GetDimensionsSize>(
                               input.GetIrValue(), std::move(dimensions)),
                           at::ScalarType::Int);
@@ -504,7 +504,7 @@ XLATensor XLATensor::__rshift__(
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::adaptive_max_pool2d(
-    const XLATensor& input, std::vector<int64_t> output_size) {
+    const XLATensor& input, std::vector<xla::int64_t> output_size) {
   ir::NodePtr node =
       ir::MakeNode<ir::ops::AdaptiveMaxPool2d>(input.GetIrValue(), output_size);
   XLATensor out = input.CreateFrom(ir::Value(node, 0));
@@ -519,8 +519,8 @@ XLATensor XLATensor::adaptive_max_pool2d_backward(const XLATensor& grad_output,
       grad_output.GetIrValue(), input.GetIrValue()));
 }
 
-XLATensor XLATensor::adaptive_avg_pool3d(const XLATensor& input,
-                                         std::vector<int64_t> output_size) {
+XLATensor XLATensor::adaptive_avg_pool3d(
+    const XLATensor& input, std::vector<xla::int64_t> output_size) {
   return input.CreateFrom(ir::MakeNode<ir::ops::AdaptiveAvgPool3d>(
       input.GetIrValue(), std::move(output_size)));
 }
@@ -531,8 +531,8 @@ XLATensor XLATensor::adaptive_avg_pool3d_backward(const XLATensor& grad_output,
       grad_output.GetIrValue(), input.GetIrValue()));
 }
 
-XLATensor XLATensor::_adaptive_avg_pool2d(const XLATensor& input,
-                                          std::vector<int64_t> output_size) {
+XLATensor XLATensor::_adaptive_avg_pool2d(
+    const XLATensor& input, std::vector<xla::int64_t> output_size) {
   return input.CreateFrom(ir::MakeNode<ir::ops::AdaptiveAvgPool2d>(
       input.GetIrValue(), std::move(output_size)));
 }
@@ -638,7 +638,7 @@ XLATensor XLATensor::addmm(const XLATensor& input, const XLATensor& weight,
 }
 
 XLATensor XLATensor::all(const XLATensor& input,
-                         std::vector<int64_t> dimensions,
+                         std::vector<xla::int64_t> dimensions,
                          bool keep_reduced_dimensions) {
   at::ScalarType result_type = input.dtype() == at::ScalarType::Byte
                                    ? at::ScalarType::Byte
@@ -652,7 +652,7 @@ XLATensor XLATensor::all(const XLATensor& input,
 }
 
 XLATensor XLATensor::amax(const XLATensor& input,
-                          std::vector<int64_t> dimensions,
+                          std::vector<xla::int64_t> dimensions,
                           bool keep_reduced_dimensions) {
   return input.CreateFrom(
       ir::MakeNode<ir::ops::Amax>(input.GetIrValue(),
@@ -662,7 +662,7 @@ XLATensor XLATensor::amax(const XLATensor& input,
 }
 
 XLATensor XLATensor::amin(const XLATensor& input,
-                          std::vector<int64_t> dimensions,
+                          std::vector<xla::int64_t> dimensions,
                           bool keep_reduced_dimensions) {
   return input.CreateFrom(
       ir::MakeNode<ir::ops::Amin>(input.GetIrValue(),
@@ -672,7 +672,7 @@ XLATensor XLATensor::amin(const XLATensor& input,
 }
 
 XLATensor XLATensor::any(const XLATensor& input,
-                         std::vector<int64_t> dimensions,
+                         std::vector<xla::int64_t> dimensions,
                          bool keep_reduced_dimensions) {
   at::ScalarType result_type = input.dtype() == at::ScalarType::Byte
                                    ? at::ScalarType::Byte
@@ -692,8 +692,9 @@ void XLATensor::arange_out(XLATensor& out, const at::Scalar& start,
   out.SetScalarType(scalar_type);
 }
 
-XLATensor XLATensor::argmax(const XLATensor& input, int64_t dim, bool keepdim) {
-  int64_t canonical_dim =
+XLATensor XLATensor::argmax(const XLATensor& input, xla::int64_t dim,
+                            bool keepdim) {
+  xla::int64_t canonical_dim =
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   return input.CreateFrom(
       ir::MakeNode<ir::ops::ArgMax>(input.GetIrValue(), canonical_dim, keepdim),
@@ -706,8 +707,9 @@ XLATensor XLATensor::argmax(const XLATensor& input) {
       at::ScalarType::Long);
 }
 
-XLATensor XLATensor::argmin(const XLATensor& input, int64_t dim, bool keepdim) {
-  int64_t canonical_dim =
+XLATensor XLATensor::argmin(const XLATensor& input, xla::int64_t dim,
+                            bool keepdim) {
+  xla::int64_t canonical_dim =
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   return input.CreateFrom(
       ir::MakeNode<ir::ops::ArgMin>(input.GetIrValue(), canonical_dim, keepdim),
@@ -721,17 +723,17 @@ XLATensor XLATensor::argmin(const XLATensor& input) {
 }
 
 XLATensor XLATensor::as_strided(const XLATensor& input,
-                                std::vector<int64_t> size,
-                                std::vector<int64_t> stride,
-                                c10::optional<int64_t> storage_offset) {
+                                std::vector<xla::int64_t> size,
+                                std::vector<xla::int64_t> stride,
+                                c10::optional<xla::int64_t> storage_offset) {
   auto input_shape = input.shape();
   return input.CreateViewTensor(CreateAsStridedViewInfo(
       input_shape, std::move(size), std::move(stride), storage_offset));
 }
 
-void XLATensor::as_strided_(XLATensor& input, std::vector<int64_t> size,
-                            std::vector<int64_t> stride,
-                            c10::optional<int64_t> storage_offset) {
+void XLATensor::as_strided_(XLATensor& input, std::vector<xla::int64_t> size,
+                            std::vector<xla::int64_t> stride,
+                            c10::optional<xla::int64_t> storage_offset) {
   if (input.data()->view == nullptr) {
     input.SetIrValue(ir::MakeNode<ir::ops::AsStrided>(
         input.GetIrValue(), std::move(size), std::move(stride),
@@ -767,11 +769,11 @@ XLATensor XLATensor::atan2(const XLATensor& input, const XLATensor& other,
 }
 
 XLATensor XLATensor::avg_pool_nd(const XLATensor& input,
-                                 int64_t spatial_dim_count,
-                                 std::vector<int64_t> kernel_size,
-                                 std::vector<int64_t> stride,
-                                 std::vector<int64_t> padding, bool ceil_mode,
-                                 bool count_include_pad) {
+                                 xla::int64_t spatial_dim_count,
+                                 std::vector<xla::int64_t> kernel_size,
+                                 std::vector<xla::int64_t> stride,
+                                 std::vector<xla::int64_t> padding,
+                                 bool ceil_mode, bool count_include_pad) {
   kernel_size = CheckIntList(kernel_size, spatial_dim_count, "kernel_size");
   stride = CheckIntList(stride, spatial_dim_count, "stride", kernel_size);
   padding = CheckIntList(padding, spatial_dim_count, "padding");
@@ -782,9 +784,9 @@ XLATensor XLATensor::avg_pool_nd(const XLATensor& input,
 
 XLATensor XLATensor::avg_pool_nd_backward(
     const XLATensor& out_backprop, const XLATensor& input,
-    int64_t spatial_dim_count, std::vector<int64_t> kernel_size,
-    std::vector<int64_t> stride, std::vector<int64_t> padding, bool ceil_mode,
-    bool count_include_pad) {
+    xla::int64_t spatial_dim_count, std::vector<xla::int64_t> kernel_size,
+    std::vector<xla::int64_t> stride, std::vector<xla::int64_t> padding,
+    bool ceil_mode, bool count_include_pad) {
   kernel_size = CheckIntList(kernel_size, spatial_dim_count, "kernel_size");
   stride = CheckIntList(stride, spatial_dim_count, "stride", kernel_size);
   padding = CheckIntList(padding, spatial_dim_count, "padding");
@@ -835,7 +837,7 @@ void XLATensor::bernoulli_(XLATensor& input, const XLATensor& probability) {
 XLATensor XLATensor::binary_cross_entropy(const XLATensor& input,
                                           const XLATensor& target,
                                           const XLATensor& weight,
-                                          int64_t reduction) {
+                                          xla::int64_t reduction) {
   return input.CreateFrom(ir::MakeNode<ir::ops::BinaryCrossEntropy>(
       input.GetIrValue(), target.GetIrValue(), GetOptionalIrValue(weight),
       GetXlaReductionMode(reduction)));
@@ -845,7 +847,7 @@ XLATensor XLATensor::binary_cross_entropy_backward(const XLATensor& grad_output,
                                                    const XLATensor& input,
                                                    const XLATensor& target,
                                                    const XLATensor& weight,
-                                                   int64_t reduction) {
+                                                   xla::int64_t reduction) {
   return input.CreateFrom(ir::MakeNode<ir::ops::BinaryCrossEntropyBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), target.GetIrValue(),
       GetOptionalIrValue(weight), GetXlaReductionMode(reduction)));
@@ -914,7 +916,8 @@ std::vector<XLATensor> XLATensor::broadcast_tensors(
   return tensors.front().MakeOutputTensors(node);
 }
 
-XLATensor XLATensor::cat(absl::Span<const XLATensor> tensors, int64_t dim) {
+XLATensor XLATensor::cat(absl::Span<const XLATensor> tensors,
+                         xla::int64_t dim) {
   // Shape checks for cat:
   // - If not empty, every tensor shape must be the same.
   // - Empty tensor passes but is simply ignore in implementation,
@@ -998,9 +1001,9 @@ XLATensor XLATensor::clone(const XLATensor& input) {
 }
 
 XLATensor XLATensor::constant_pad_nd(const XLATensor& input,
-                                     absl::Span<const int64_t> pad,
+                                     absl::Span<const xla::int64_t> pad,
                                      const at::Scalar& value) {
-  std::vector<int64_t> complete_pad(pad.begin(), pad.end());
+  std::vector<xla::int64_t> complete_pad(pad.begin(), pad.end());
   complete_pad.resize(2 * input.shape().get().rank());
   return input.CreateFrom(ir::MakeNode<ir::ops::ConstantPadNd>(
       input.GetIrValue(), complete_pad, value));
@@ -1008,9 +1011,9 @@ XLATensor XLATensor::constant_pad_nd(const XLATensor& input,
 
 XLATensor XLATensor::convolution_overrideable(
     const XLATensor& input, const XLATensor& weight, const XLATensor& bias,
-    std::vector<int64_t> stride, std::vector<int64_t> padding,
-    std::vector<int64_t> dilation, bool transposed,
-    std::vector<int64_t> output_padding, int64_t groups) {
+    std::vector<xla::int64_t> stride, std::vector<xla::int64_t> padding,
+    std::vector<xla::int64_t> dilation, bool transposed,
+    std::vector<xla::int64_t> output_padding, xla::int64_t groups) {
   ir::NodePtr ir_value = ir::MakeNode<ir::ops::ConvolutionOverrideable>(
       input.GetIrValue(), weight.GetIrValue(), bias.GetIrValue(),
       std::move(stride), std::move(padding), std::move(dilation), transposed,
@@ -1020,9 +1023,9 @@ XLATensor XLATensor::convolution_overrideable(
 
 XLATensor XLATensor::convolution_overrideable(
     const XLATensor& input, const XLATensor& weight,
-    std::vector<int64_t> stride, std::vector<int64_t> padding,
-    std::vector<int64_t> dilation, bool transposed,
-    std::vector<int64_t> output_padding, int64_t groups) {
+    std::vector<xla::int64_t> stride, std::vector<xla::int64_t> padding,
+    std::vector<xla::int64_t> dilation, bool transposed,
+    std::vector<xla::int64_t> output_padding, xla::int64_t groups) {
   ir::NodePtr ir_value = ir::MakeNode<ir::ops::ConvolutionOverrideable>(
       input.GetIrValue(), weight.GetIrValue(), std::move(stride),
       std::move(padding), std::move(dilation), transposed,
@@ -1033,9 +1036,10 @@ XLATensor XLATensor::convolution_overrideable(
 std::tuple<XLATensor, XLATensor, XLATensor>
 XLATensor::convolution_backward_overrideable(
     const XLATensor& out_backprop, const XLATensor& input,
-    const XLATensor& weight, std::vector<int64_t> stride,
-    std::vector<int64_t> padding, std::vector<int64_t> dilation,
-    bool transposed, std::vector<int64_t> output_padding, int64_t groups) {
+    const XLATensor& weight, std::vector<xla::int64_t> stride,
+    std::vector<xla::int64_t> padding, std::vector<xla::int64_t> dilation,
+    bool transposed, std::vector<xla::int64_t> output_padding,
+    xla::int64_t groups) {
   ir::NodePtr node = ir::MakeNode<ir::ops::ConvolutionBackwardOverrideable>(
       out_backprop.GetIrValue(), input.GetIrValue(), weight.GetIrValue(),
       std::move(stride), std::move(padding), std::move(dilation), transposed,
@@ -1056,13 +1060,13 @@ XLATensor XLATensor::cosh(const XLATensor& input) {
 }
 
 XLATensor XLATensor::cross(const XLATensor& input, const XLATensor& other,
-                           c10::optional<int64_t> dim) {
+                           c10::optional<xla::int64_t> dim) {
   return tensor_ops::Cross(input, other, dim);
 }
 
-XLATensor XLATensor::cumprod(const XLATensor& input, int64_t dim,
+XLATensor XLATensor::cumprod(const XLATensor& input, xla::int64_t dim,
                              c10::optional<at::ScalarType> dtype) {
-  int64_t canonical_dim =
+  xla::int64_t canonical_dim =
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   if (!dtype) {
     dtype = input.dtype_optional();
@@ -1072,9 +1076,9 @@ XLATensor XLATensor::cumprod(const XLATensor& input, int64_t dim,
       dtype);
 }
 
-XLATensor XLATensor::cumsum(const XLATensor& input, int64_t dim,
+XLATensor XLATensor::cumsum(const XLATensor& input, xla::int64_t dim,
                             c10::optional<at::ScalarType> dtype) {
-  int64_t canonical_dim =
+  xla::int64_t canonical_dim =
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   if (!dtype) {
     dtype = input.dtype_optional();
@@ -1084,8 +1088,8 @@ XLATensor XLATensor::cumsum(const XLATensor& input, int64_t dim,
       dtype);
 }
 
-XLATensor XLATensor::diag(const XLATensor& input, int64_t offset) {
-  int64_t rank = input.shape().get().rank();
+XLATensor XLATensor::diag(const XLATensor& input, xla::int64_t offset) {
+  xla::int64_t rank = input.shape().get().rank();
   XLA_CHECK(rank == 1 || rank == 2)
       << "Invalid argument for diag: matrix or a vector expected";
   if (rank == 1) {
@@ -1094,12 +1098,12 @@ XLATensor XLATensor::diag(const XLATensor& input, int64_t offset) {
   return diagonal(input, offset, /*dim1=*/-2, /*dim2=*/-1);
 }
 
-XLATensor XLATensor::diagonal(const XLATensor& input, int64_t offset,
-                              int64_t dim1, int64_t dim2) {
+XLATensor XLATensor::diagonal(const XLATensor& input, xla::int64_t offset,
+                              xla::int64_t dim1, xla::int64_t dim2) {
   auto input_shape = input.shape();
-  int64_t canonical_dim1 =
+  xla::int64_t canonical_dim1 =
       XlaHelpers::GetCanonicalDimensionIndex(dim1, input.shape().get().rank());
-  int64_t canonical_dim2 =
+  xla::int64_t canonical_dim2 =
       XlaHelpers::GetCanonicalDimensionIndex(dim2, input.shape().get().rank());
   DiagonalInfo diagonal_info;
   diagonal_info.offset = offset;
@@ -1203,8 +1207,8 @@ XLATensor XLATensor::elu_backward(const XLATensor& grad_output,
 
 XLATensor XLATensor::embedding_dense_backward(const XLATensor& grad_output,
                                               const XLATensor& indices,
-                                              int64_t num_weights,
-                                              int64_t padding_idx,
+                                              xla::int64_t num_weights,
+                                              xla::int64_t padding_idx,
                                               bool scale_grad_by_freq) {
   return tensor_ops::EmbeddingDenseBackward(grad_output, indices, num_weights,
                                             padding_idx, scale_grad_by_freq);
@@ -1226,7 +1230,8 @@ XLATensor XLATensor::exp(const XLATensor& input) {
   return input.CreateFrom(ir::ops::Exp(input.GetIrValue()));
 }
 
-XLATensor XLATensor::expand(const XLATensor& input, std::vector<int64_t> size) {
+XLATensor XLATensor::expand(const XLATensor& input,
+                            std::vector<xla::int64_t> size) {
   auto input_shape = input.shape();
   return input.CreateFrom(ir::MakeNode<ir::ops::Expand>(
       input.GetIrValue(),
@@ -1245,15 +1250,15 @@ void XLATensor::exponential_(XLATensor& input, double lambd) {
       GetRngSeed(input.GetDevice()), input_shape.get()));
 }
 
-XLATensor XLATensor::eye(int64_t lines, int64_t cols, const Device& device,
-                         at::ScalarType element_type) {
+XLATensor XLATensor::eye(xla::int64_t lines, xla::int64_t cols,
+                         const Device& device, at::ScalarType element_type) {
   return XLATensor::Create(
       ir::ops::Identity(lines, cols,
                         MakeXlaPrimitiveType(element_type, &device)),
       device, element_type);
 }
 
-void XLATensor::eye_out(XLATensor& out, int64_t lines, int64_t cols) {
+void XLATensor::eye_out(XLATensor& out, xla::int64_t lines, xla::int64_t cols) {
   out.SetIrValue(
       ir::ops::Identity(lines, cols >= 0 ? cols : lines,
                         GetDevicePrimitiveType(out.shape().get().element_type(),
@@ -1267,10 +1272,10 @@ void XLATensor::fill_(XLATensor& input, const at::Scalar& value) {
 }
 
 XLATensor XLATensor::flip(const XLATensor& input,
-                          absl::Span<const int64_t> dims) {
+                          absl::Span<const xla::int64_t> dims) {
   auto dimensions = XlaHelpers::GetCanonicalDimensionIndices(
       dims, input.shape().get().rank());
-  std::set<int64_t> unique_dims(dimensions.begin(), dimensions.end());
+  std::set<xla::int64_t> unique_dims(dimensions.begin(), dimensions.end());
   XLA_CHECK_EQ(unique_dims.size(), dimensions.size());
   return input.CreateFrom(
       ir::MakeNode<ir::ops::Flip>(input.GetIrValue(), dimensions));
@@ -1298,7 +1303,7 @@ XLATensor XLATensor::frac(const XLATensor& input) {
   return input.CreateFrom(ir::ops::FracOp(input.GetIrValue()));
 }
 
-XLATensor XLATensor::full(absl::Span<const int64_t> size,
+XLATensor XLATensor::full(absl::Span<const xla::int64_t> size,
                           const at::Scalar& fill_value, const Device& device,
                           at::ScalarType scalar_type) {
   CheckShapeDimensions(size);
@@ -1323,7 +1328,7 @@ XLATensor XLATensor::full_like(const XLATensor& input,
                           device, *scalar_type);
 }
 
-XLATensor XLATensor::gather(const XLATensor& input, int64_t dim,
+XLATensor XLATensor::gather(const XLATensor& input, xla::int64_t dim,
                             const XLATensor& index) {
   return input.CreateFrom(ir::MakeNode<ir::ops::Gather>(
       input.GetIrValue(),
@@ -1363,85 +1368,84 @@ XLATensor XLATensor::gt(const XLATensor& input, const XLATensor& other) {
 
 XLATensor XLATensor::index(const XLATensor& input,
                            absl::Span<const XLATensor> indices,
-                           int64_t start_dim) {
+                           xla::int64_t start_dim) {
   return IndexByTensors(input, indices, start_dim);
 }
 
-XLATensor XLATensor::index_add(const XLATensor& input, int64_t dim,
+XLATensor XLATensor::index_add(const XLATensor& input, xla::int64_t dim,
                                const XLATensor& index, const XLATensor& source,
                                const at::Scalar& alpha) {
   ir::Value constant = GetIrValueForScalar(
       alpha, source.shape().get().element_type(), input.GetDevice());
   auto scaled_source = input.CreateFrom(source.GetIrValue() * constant);
-  int64_t canonical_dim =
+  xla::int64_t canonical_dim =
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   return input.CreateFrom(IndexAdd(input, canonical_dim, index, scaled_source));
 }
 
-XLATensor XLATensor::index_copy(const XLATensor& input, int64_t dim,
+XLATensor XLATensor::index_copy(const XLATensor& input, xla::int64_t dim,
                                 const XLATensor& index,
                                 const XLATensor& source) {
-  int64_t canonical_dim =
+  xla::int64_t canonical_dim =
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   return input.CreateFrom(IndexCopy(input, canonical_dim, index, source));
 }
 
-void XLATensor::index_copy_(XLATensor& input, int64_t dim,
+void XLATensor::index_copy_(XLATensor& input, xla::int64_t dim,
                             const XLATensor& index, const XLATensor& source) {
-  int64_t canonical_dim =
+  xla::int64_t canonical_dim =
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   input.SetIrValue(IndexCopy(input, canonical_dim, index, source));
 }
 
-XLATensor XLATensor::index_fill(const XLATensor& input, int64_t dim,
+XLATensor XLATensor::index_fill(const XLATensor& input, xla::int64_t dim,
                                 const XLATensor& index,
                                 const at::Scalar& value) {
-  int64_t canonical_dim =
+  xla::int64_t canonical_dim =
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   return input.CreateFrom(IndexFill(input, canonical_dim, index, value));
 }
 
-XLATensor XLATensor::index_fill(const XLATensor& input, int64_t dim,
+XLATensor XLATensor::index_fill(const XLATensor& input, xla::int64_t dim,
                                 const XLATensor& index,
                                 const XLATensor& value) {
-  int64_t canonical_dim =
+  xla::int64_t canonical_dim =
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   return input.CreateFrom(IndexFill(input, canonical_dim, index, value));
 }
 
-void XLATensor::index_fill_(XLATensor& input, int64_t dim,
+void XLATensor::index_fill_(XLATensor& input, xla::int64_t dim,
                             const XLATensor& index, const XLATensor& value) {
-  int64_t canonical_dim =
+  xla::int64_t canonical_dim =
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   input.SetIrValue(IndexFill(input, canonical_dim, index, value));
 }
 
-void XLATensor::index_fill_(XLATensor& input, int64_t dim,
+void XLATensor::index_fill_(XLATensor& input, xla::int64_t dim,
                             const XLATensor& index, const at::Scalar& value) {
-  int64_t canonical_dim =
+  xla::int64_t canonical_dim =
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   input.SetIrValue(IndexFill(input, canonical_dim, index, value));
 }
 
-XLATensor XLATensor::index_put(const XLATensor& input,
-                               absl::Span<const XLATensor> indices,
-                               int64_t start_dim, const XLATensor& values,
-                               bool accumulate,
-                               absl::Span<const int64_t> result_permutation) {
+XLATensor XLATensor::index_put(
+    const XLATensor& input, absl::Span<const XLATensor> indices,
+    xla::int64_t start_dim, const XLATensor& values, bool accumulate,
+    absl::Span<const xla::int64_t> result_permutation) {
   return input.CreateFrom(IndexPutByTensors(input, indices, start_dim, values,
                                             accumulate, result_permutation));
 }
 
 void XLATensor::index_put_(XLATensor& input, const XLATensor& canonical_base,
                            absl::Span<const XLATensor> indices,
-                           int64_t start_dim, const XLATensor& values,
+                           xla::int64_t start_dim, const XLATensor& values,
                            bool accumulate,
-                           absl::Span<const int64_t> result_permutation) {
+                           absl::Span<const xla::int64_t> result_permutation) {
   input.SetIrValue(IndexPutByTensors(canonical_base, indices, start_dim, values,
                                      accumulate, result_permutation));
 }
 
-XLATensor XLATensor::index_select(const XLATensor& input, int64_t dim,
+XLATensor XLATensor::index_select(const XLATensor& input, xla::int64_t dim,
                                   const XLATensor& index) {
   ir::Value index_value = EnsureRank1(index.GetIrValue());
   return input.CreateFrom(ir::MakeNode<ir::ops::IndexSelect>(
@@ -1462,14 +1466,15 @@ XLATensor XLATensor::isnan(const XLATensor& input) {
 
 XLATensor XLATensor::kl_div_backward(const XLATensor& grad_output,
                                      const XLATensor& input,
-                                     const XLATensor& target, int64_t reduction,
-                                     bool log_target) {
+                                     const XLATensor& target,
+                                     xla::int64_t reduction, bool log_target) {
   return tensor_ops::KlDivBackward(grad_output, input, target,
                                    GetXlaReductionMode(reduction), log_target);
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::kthvalue(const XLATensor& input,
-                                                     int64_t k, int64_t dim,
+                                                     xla::int64_t k,
+                                                     xla::int64_t dim,
                                                      bool keepdim) {
   ir::NodePtr node = ir::MakeNode<ir::ops::KthValue>(
       input.GetIrValue(), k,
@@ -1481,7 +1486,7 @@ std::tuple<XLATensor, XLATensor> XLATensor::kthvalue(const XLATensor& input,
 }
 
 XLATensor XLATensor::l1_loss(const XLATensor& input, const XLATensor& target,
-                             int64_t reduction) {
+                             xla::int64_t reduction) {
   return input.CreateFrom(ir::MakeNode<ir::ops::L1Loss>(
       input.GetIrValue(), target.GetIrValue(), GetXlaReductionMode(reduction)));
 }
@@ -1489,7 +1494,7 @@ XLATensor XLATensor::l1_loss(const XLATensor& input, const XLATensor& target,
 XLATensor XLATensor::l1_loss_backward(const XLATensor& grad_output,
                                       const XLATensor& input,
                                       const XLATensor& target,
-                                      int64_t reduction) {
+                                      xla::int64_t reduction) {
   return input.CreateFrom(ir::MakeNode<ir::ops::L1LossBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), target.GetIrValue(),
       GetXlaReductionMode(reduction)));
@@ -1601,7 +1606,7 @@ XLATensor XLATensor::log_sigmoid_backward(const XLATensor& grad_output,
       grad_output.GetIrValue(), input.GetIrValue(), buffer.GetIrValue()));
 }
 
-XLATensor XLATensor::log_softmax(const XLATensor& input, int64_t dim,
+XLATensor XLATensor::log_softmax(const XLATensor& input, xla::int64_t dim,
                                  c10::optional<at::ScalarType> dtype) {
   if (!dtype) {
     dtype = input.dtype_optional();
@@ -1616,7 +1621,7 @@ XLATensor XLATensor::log_softmax(const XLATensor& input, int64_t dim,
 
 XLATensor XLATensor::log_softmax_backward(const XLATensor& grad_output,
                                           const XLATensor& output,
-                                          int64_t dim) {
+                                          xla::int64_t dim) {
   return grad_output.CreateFrom(ir::ops::LogSoftmaxBackwardOp(
       grad_output.GetIrValue(), output.GetIrValue(), dim));
 }
@@ -1666,7 +1671,7 @@ XLATensor XLATensor::logical_or(const XLATensor& input,
 }
 
 XLATensor XLATensor::logsumexp(const XLATensor& input,
-                               std::vector<int64_t> dimensions,
+                               std::vector<xla::int64_t> dimensions,
                                bool keep_reduced_dimensions) {
   return input.CreateFrom(ir::MakeNode<ir::ops::Logsumexp>(
       input.GetIrValue(),
@@ -1733,8 +1738,9 @@ XLATensor XLATensor::max(const XLATensor& input) {
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::max(const XLATensor& input,
-                                                int64_t dim, bool keepdim) {
-  int64_t canonical_dim =
+                                                xla::int64_t dim,
+                                                bool keepdim) {
+  xla::int64_t canonical_dim =
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   ir::NodePtr node = ir::MakeNode<ir::ops::MaxInDim>(input.GetIrValue(),
                                                      canonical_dim, keepdim);
@@ -1744,8 +1750,9 @@ std::tuple<XLATensor, XLATensor> XLATensor::max(const XLATensor& input,
 }
 
 void XLATensor::max_out(XLATensor& max, XLATensor& max_values,
-                        const XLATensor& input, int64_t dim, bool keepdim) {
-  int64_t canonical_dim =
+                        const XLATensor& input, xla::int64_t dim,
+                        bool keepdim) {
+  xla::int64_t canonical_dim =
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   ir::NodePtr node = ir::MakeNode<ir::ops::MaxInDim>(input.GetIrValue(),
                                                      canonical_dim, keepdim);
@@ -1754,9 +1761,9 @@ void XLATensor::max_out(XLATensor& max, XLATensor& max_values,
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::max_pool_nd(
-    const XLATensor& input, int64_t spatial_dim_count,
-    std::vector<int64_t> kernel_size, std::vector<int64_t> stride,
-    std::vector<int64_t> padding, bool ceil_mode) {
+    const XLATensor& input, xla::int64_t spatial_dim_count,
+    std::vector<xla::int64_t> kernel_size, std::vector<xla::int64_t> stride,
+    std::vector<xla::int64_t> padding, bool ceil_mode) {
   kernel_size = CheckIntList(kernel_size, spatial_dim_count, "kernel_size");
   stride = CheckIntList(stride, spatial_dim_count, "stride", kernel_size);
   padding = CheckIntList(padding, spatial_dim_count, "padding");
@@ -1768,10 +1775,13 @@ std::tuple<XLATensor, XLATensor> XLATensor::max_pool_nd(
       input.CreateFrom(ir::Value(node, 1), at::ScalarType::Long));
 }
 
-XLATensor XLATensor::max_pool_nd_backward(
-    const XLATensor& out_backprop, const XLATensor& input,
-    int64_t spatial_dim_count, std::vector<int64_t> kernel_size,
-    std::vector<int64_t> stride, std::vector<int64_t> padding, bool ceil_mode) {
+XLATensor XLATensor::max_pool_nd_backward(const XLATensor& out_backprop,
+                                          const XLATensor& input,
+                                          xla::int64_t spatial_dim_count,
+                                          std::vector<xla::int64_t> kernel_size,
+                                          std::vector<xla::int64_t> stride,
+                                          std::vector<xla::int64_t> padding,
+                                          bool ceil_mode) {
   kernel_size = CheckIntList(kernel_size, spatial_dim_count, "kernel_size");
   stride = CheckIntList(stride, spatial_dim_count, "stride", kernel_size);
   padding = CheckIntList(padding, spatial_dim_count, "padding");
@@ -1783,22 +1793,21 @@ XLATensor XLATensor::max_pool_nd_backward(
 
 XLATensor XLATensor::max_unpool(const XLATensor& input,
                                 const XLATensor& indices,
-                                std::vector<int64_t> output_size) {
+                                std::vector<xla::int64_t> output_size) {
   return input.CreateFrom(ir::MakeNode<ir::ops::MaxUnpoolNd>(
       input.GetIrValue(), indices.GetIrValue(), std::move(output_size)));
 }
 
-XLATensor XLATensor::max_unpool_backward(const XLATensor& grad_output,
-                                         const XLATensor& input,
-                                         const XLATensor& indices,
-                                         std::vector<int64_t> output_size) {
+XLATensor XLATensor::max_unpool_backward(
+    const XLATensor& grad_output, const XLATensor& input,
+    const XLATensor& indices, std::vector<xla::int64_t> output_size) {
   return grad_output.CreateFrom(ir::MakeNode<ir::ops::MaxUnpoolNdBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), indices.GetIrValue(),
       std::move(output_size)));
 }
 
 XLATensor XLATensor::mean(const XLATensor& input,
-                          std::vector<int64_t> dimensions,
+                          std::vector<xla::int64_t> dimensions,
                           bool keep_reduced_dimensions,
                           c10::optional<at::ScalarType> dtype) {
   if (!dtype) {
@@ -1823,8 +1832,9 @@ XLATensor XLATensor::min(const XLATensor& input) {
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::min(const XLATensor& input,
-                                                int64_t dim, bool keepdim) {
-  int64_t canonical_dim =
+                                                xla::int64_t dim,
+                                                bool keepdim) {
+  xla::int64_t canonical_dim =
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   ir::NodePtr node = ir::MakeNode<ir::ops::MinInDim>(input.GetIrValue(),
                                                      canonical_dim, keepdim);
@@ -1834,8 +1844,9 @@ std::tuple<XLATensor, XLATensor> XLATensor::min(const XLATensor& input,
 }
 
 void XLATensor::min_out(XLATensor& min, XLATensor& min_indices,
-                        const XLATensor& input, int64_t dim, bool keepdim) {
-  int64_t canonical_dim =
+                        const XLATensor& input, xla::int64_t dim,
+                        bool keepdim) {
+  xla::int64_t canonical_dim =
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   ir::NodePtr node = ir::MakeNode<ir::ops::MinInDim>(input.GetIrValue(),
                                                      canonical_dim, keepdim);
@@ -1855,7 +1866,7 @@ XLATensor XLATensor::mm(const XLATensor& input, const XLATensor& weight) {
 }
 
 XLATensor XLATensor::mse_loss(const XLATensor& input, const XLATensor& target,
-                              int64_t reduction) {
+                              xla::int64_t reduction) {
   return input.CreateFrom(ir::MakeNode<ir::ops::MseLoss>(
       input.GetIrValue(), target.GetIrValue(), GetXlaReductionMode(reduction)));
 }
@@ -1863,7 +1874,7 @@ XLATensor XLATensor::mse_loss(const XLATensor& input, const XLATensor& target,
 XLATensor XLATensor::mse_loss_backward(const XLATensor& grad_output,
                                        const XLATensor& input,
                                        const XLATensor& target,
-                                       int64_t reduction) {
+                                       xla::int64_t reduction) {
   return input.CreateFrom(ir::MakeNode<ir::ops::MseLossBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), target.GetIrValue(),
       GetXlaReductionMode(reduction)));
@@ -1904,8 +1915,8 @@ XLATensor XLATensor::nan_to_num(const XLATensor& input, const at::Scalar& nan,
                                             posinf_value, neginf_value));
 }
 
-XLATensor XLATensor::narrow(const XLATensor& input, int64_t dim, int64_t start,
-                            int64_t length) {
+XLATensor XLATensor::narrow(const XLATensor& input, xla::int64_t dim,
+                            xla::int64_t start, xla::int64_t length) {
   auto input_shape = input.shape();
   dim = XlaHelpers::GetCanonicalDimensionIndex(dim, input_shape.get().rank());
   xla::Shape narrow_shape = input_shape;
@@ -1993,7 +2004,7 @@ XLATensor XLATensor::neg(const XLATensor& input) {
 }
 
 XLATensor XLATensor::nll_loss(const XLATensor& input, const XLATensor& target,
-                              const XLATensor& weight, int64_t reduction,
+                              const XLATensor& weight, xla::int64_t reduction,
                               int ignore_index) {
   return input.CreateFrom(ir::MakeNode<ir::ops::NllLoss>(
       input.GetIrValue(), target.GetIrValue(), GetOptionalIrValue(weight),
@@ -2001,19 +2012,17 @@ XLATensor XLATensor::nll_loss(const XLATensor& input, const XLATensor& target,
 }
 
 XLATensor XLATensor::nll_loss2d(const XLATensor& input, const XLATensor& target,
-                                const XLATensor& weight, int64_t reduction,
+                                const XLATensor& weight, xla::int64_t reduction,
                                 int ignore_index) {
   return input.CreateFrom(ir::MakeNode<ir::ops::NllLoss2d>(
       input.GetIrValue(), target.GetIrValue(), GetOptionalIrValue(weight),
       GetXlaReductionMode(reduction), ignore_index));
 }
 
-XLATensor XLATensor::nll_loss2d_backward(const XLATensor& grad_output,
-                                         const XLATensor& input,
-                                         const XLATensor& target,
-                                         const XLATensor& weight,
-                                         int64_t reduction, int ignore_index,
-                                         const XLATensor& total_weight) {
+XLATensor XLATensor::nll_loss2d_backward(
+    const XLATensor& grad_output, const XLATensor& input,
+    const XLATensor& target, const XLATensor& weight, xla::int64_t reduction,
+    int ignore_index, const XLATensor& total_weight) {
   return input.CreateFrom(ir::MakeNode<ir::ops::NllLoss2dBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), target.GetIrValue(),
       GetOptionalIrValue(weight), GetOptionalIrValue(total_weight),
@@ -2024,7 +2033,7 @@ XLATensor XLATensor::nll_loss_backward(const XLATensor& grad_output,
                                        const XLATensor& input,
                                        const XLATensor& target,
                                        const XLATensor& weight,
-                                       int64_t reduction, int ignore_index,
+                                       xla::int64_t reduction, int ignore_index,
                                        const XLATensor& total_weight) {
   return input.CreateFrom(ir::MakeNode<ir::ops::NllLossBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), target.GetIrValue(),
@@ -2036,7 +2045,7 @@ std::pair<XLATensor, XLATensor> XLATensor::nms(const XLATensor& boxes,
                                                const XLATensor& scores,
                                                const XLATensor& score_threshold,
                                                const XLATensor& iou_threshold,
-                                               int64_t output_size) {
+                                               xla::int64_t output_size) {
   ir::NodePtr node = ir::MakeNode<ir::ops::Nms>(
       boxes.GetIrValue(), scores.GetIrValue(), score_threshold.GetIrValue(),
       iou_threshold.GetIrValue(), output_size);
@@ -2097,7 +2106,7 @@ XLATensor XLATensor::not_supported(std::string description, xla::Shape shape,
 }
 
 XLATensor XLATensor::permute(const XLATensor& input,
-                             absl::Span<const int64_t> dims) {
+                             absl::Span<const xla::int64_t> dims) {
   auto input_shape = input.shape();
   ViewInfo view_info(
       ViewInfo::Type::kPermute, input_shape,
@@ -2129,7 +2138,7 @@ XLATensor XLATensor::prelu(const XLATensor& input, const XLATensor& weight) {
 }
 
 XLATensor XLATensor::prod(const XLATensor& input,
-                          std::vector<int64_t> dimensions,
+                          std::vector<xla::int64_t> dimensions,
                           bool keep_reduced_dimensions,
                           c10::optional<at::ScalarType> dtype) {
   if (!dtype) {
@@ -2170,14 +2179,14 @@ XLATensor XLATensor::reciprocal(const XLATensor& input) {
 }
 
 XLATensor XLATensor::reflection_pad2d(const XLATensor& input,
-                                      std::vector<int64_t> padding) {
+                                      std::vector<xla::int64_t> padding) {
   return input.CreateFrom(ir::MakeNode<ir::ops::ReflectionPad2d>(
       input.GetIrValue(), std::move(padding)));
 }
 
-XLATensor XLATensor::reflection_pad2d_backward(const XLATensor& grad_output,
-                                               const XLATensor& input,
-                                               std::vector<int64_t> padding) {
+XLATensor XLATensor::reflection_pad2d_backward(
+    const XLATensor& grad_output, const XLATensor& input,
+    std::vector<xla::int64_t> padding) {
   return input.CreateFrom(ir::MakeNode<ir::ops::ReflectionPad2dBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), std::move(padding)));
 }
@@ -2203,38 +2212,38 @@ XLATensor XLATensor::remainder(const XLATensor& input,
 }
 
 XLATensor XLATensor::repeat(const XLATensor& input,
-                            std::vector<int64_t> repeats) {
+                            std::vector<xla::int64_t> repeats) {
   return input.CreateFrom(
       ir::MakeNode<ir::ops::Repeat>(input.GetIrValue(), std::move(repeats)));
 }
 
 XLATensor XLATensor::replication_pad1d(const XLATensor& input,
-                                       std::vector<int64_t> padding) {
+                                       std::vector<xla::int64_t> padding) {
   return input.CreateFrom(ir::MakeNode<ir::ops::ReplicationPad>(
       input.GetIrValue(), std::move(padding)));
 }
 
-XLATensor XLATensor::replication_pad1d_backward(const XLATensor& grad_output,
-                                                const XLATensor& input,
-                                                std::vector<int64_t> padding) {
+XLATensor XLATensor::replication_pad1d_backward(
+    const XLATensor& grad_output, const XLATensor& input,
+    std::vector<xla::int64_t> padding) {
   return input.CreateFrom(ir::MakeNode<ir::ops::ReplicationPadBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), std::move(padding)));
 }
 
 XLATensor XLATensor::replication_pad2d(const XLATensor& input,
-                                       std::vector<int64_t> padding) {
+                                       std::vector<xla::int64_t> padding) {
   return input.CreateFrom(ir::MakeNode<ir::ops::ReplicationPad>(
       input.GetIrValue(), std::move(padding)));
 }
 
-XLATensor XLATensor::replication_pad2d_backward(const XLATensor& grad_output,
-                                                const XLATensor& input,
-                                                std::vector<int64_t> padding) {
+XLATensor XLATensor::replication_pad2d_backward(
+    const XLATensor& grad_output, const XLATensor& input,
+    std::vector<xla::int64_t> padding) {
   return input.CreateFrom(ir::MakeNode<ir::ops::ReplicationPadBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), std::move(padding)));
 }
 
-void XLATensor::resize_(XLATensor& input, std::vector<int64_t> size) {
+void XLATensor::resize_(XLATensor& input, std::vector<xla::int64_t> size) {
   if (input.data()->view == nullptr) {
     input.SetIrValue(
         ir::MakeNode<ir::ops::Resize>(input.GetIrValue(), std::move(size)));
@@ -2318,14 +2327,14 @@ void XLATensor::copy_(XLATensor& input, XLATensor& src) {
   }
 }
 
-XLATensor XLATensor::scatter(const XLATensor& input, int64_t dim,
+XLATensor XLATensor::scatter(const XLATensor& input, xla::int64_t dim,
                              const XLATensor& index, const XLATensor& src) {
   return input.CreateFrom(ir::MakeNode<ir::ops::Scatter>(
       input.GetIrValue(), index.GetIrValue(), src.GetIrValue(),
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank())));
 }
 
-XLATensor XLATensor::scatter(const XLATensor& input, int64_t dim,
+XLATensor XLATensor::scatter(const XLATensor& input, xla::int64_t dim,
                              const XLATensor& index, const at::Scalar& value) {
   ir::Value constant =
       GetIrValueForScalar(value, input.shape(), input.GetDevice());
@@ -2334,14 +2343,14 @@ XLATensor XLATensor::scatter(const XLATensor& input, int64_t dim,
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank())));
 }
 
-XLATensor XLATensor::scatter_add(const XLATensor& input, int64_t dim,
+XLATensor XLATensor::scatter_add(const XLATensor& input, xla::int64_t dim,
                                  const XLATensor& index, const XLATensor& src) {
   return input.CreateFrom(ir::MakeNode<ir::ops::ScatterAdd>(
       input.GetIrValue(), index.GetIrValue(), src.GetIrValue(),
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank())));
 }
 
-XLATensor XLATensor::scatter_add(const XLATensor& input, int64_t dim,
+XLATensor XLATensor::scatter_add(const XLATensor& input, xla::int64_t dim,
                                  const XLATensor& index,
                                  const at::Scalar& value) {
   ir::Value constant =
@@ -2351,8 +2360,8 @@ XLATensor XLATensor::scatter_add(const XLATensor& input, int64_t dim,
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank())));
 }
 
-XLATensor XLATensor::select(const XLATensor& input, int64_t dim,
-                            int64_t index) {
+XLATensor XLATensor::select(const XLATensor& input, xla::int64_t dim,
+                            xla::int64_t index) {
   return tensor_ops::Select(input, dim, index);
 }
 
@@ -2391,8 +2400,9 @@ XLATensor XLATensor::sinh(const XLATensor& input) {
   return input.CreateFrom(ir::ops::Sinh(input.GetIrValue()));
 }
 
-XLATensor XLATensor::slice(const XLATensor& input, int64_t dim, int64_t start,
-                           int64_t end, int64_t step) {
+XLATensor XLATensor::slice(const XLATensor& input, xla::int64_t dim,
+                           xla::int64_t start, xla::int64_t end,
+                           xla::int64_t step) {
   auto input_shape = input.shape();
   dim = XlaHelpers::GetCanonicalDimensionIndex(dim, input_shape.get().rank());
   start = XlaHelpers::GetCanonicalPosition(input_shape.get().dimensions(), dim,
@@ -2417,8 +2427,8 @@ std::tuple<XLATensor, XLATensor> XLATensor::slogdet(const XLATensor& input) {
 }
 
 XLATensor XLATensor::smooth_l1_loss(const XLATensor& input,
-                                    const XLATensor& target, int64_t reduction,
-                                    double beta) {
+                                    const XLATensor& target,
+                                    xla::int64_t reduction, double beta) {
   return tensor_ops::SmoothL1Loss(input, target, GetXlaReductionMode(reduction),
                                   beta);
 }
@@ -2426,12 +2436,13 @@ XLATensor XLATensor::smooth_l1_loss(const XLATensor& input,
 XLATensor XLATensor::smooth_l1_loss_backward(const XLATensor& grad_output,
                                              const XLATensor& input,
                                              const XLATensor& target,
-                                             int64_t reduction, double beta) {
+                                             xla::int64_t reduction,
+                                             double beta) {
   return tensor_ops::SmoothL1LossBackward(grad_output, input, target,
                                           GetXlaReductionMode(reduction), beta);
 }
 
-XLATensor XLATensor::softmax(const XLATensor& input, int64_t dim,
+XLATensor XLATensor::softmax(const XLATensor& input, xla::int64_t dim,
                              c10::optional<at::ScalarType> dtype) {
   if (!dtype) {
     dtype = input.dtype_optional();
@@ -2445,7 +2456,8 @@ XLATensor XLATensor::softmax(const XLATensor& input, int64_t dim,
 }
 
 XLATensor XLATensor::softmax_backward(const XLATensor& grad_output,
-                                      const XLATensor& output, int64_t dim) {
+                                      const XLATensor& output,
+                                      xla::int64_t dim) {
   return grad_output.CreateFrom(ir::ops::SoftmaxBackwardOp(
       grad_output.GetIrValue(), output.GetIrValue(), dim));
 }
@@ -2482,11 +2494,12 @@ XLATensor XLATensor::softshrink_backward(const XLATensor& grad_out,
 }
 
 std::vector<XLATensor> XLATensor::split(const XLATensor& input,
-                                        int64_t split_size, int64_t dim) {
+                                        xla::int64_t split_size,
+                                        xla::int64_t dim) {
   auto input_shape = input.shape();
   int split_dim =
       XlaHelpers::GetCanonicalDimensionIndex(dim, input_shape.get().rank());
-  int64_t dim_size = input_shape.get().dimensions(split_dim);
+  xla::int64_t dim_size = input_shape.get().dimensions(split_dim);
   if (dim_size == 0) {
     // Deal with dim_size=0, it's a corner case which only return 1 0-dim tensor
     // no matter what split_size is.
@@ -2494,9 +2507,9 @@ std::vector<XLATensor> XLATensor::split(const XLATensor& input,
     return {
         input.CreateFrom(ir::MakeNode<ir::ops::Constant>(std::move(literal)))};
   }
-  std::vector<int64_t> split_sizes;
+  std::vector<xla::int64_t> split_sizes;
   for (; dim_size > 0; dim_size -= split_size) {
-    split_sizes.push_back(std::min<int64_t>(dim_size, split_size));
+    split_sizes.push_back(std::min<xla::int64_t>(dim_size, split_size));
   }
   ir::NodePtr node = ir::MakeNode<ir::ops::Split>(
       input.GetIrValue(), std::move(split_sizes), split_dim);
@@ -2504,7 +2517,8 @@ std::vector<XLATensor> XLATensor::split(const XLATensor& input,
 }
 
 std::vector<XLATensor> XLATensor::split_with_sizes(
-    const XLATensor& input, std::vector<int64_t> split_size, int64_t dim) {
+    const XLATensor& input, std::vector<xla::int64_t> split_size,
+    xla::int64_t dim) {
   auto input_shape = input.shape();
   int split_dim =
       XlaHelpers::GetCanonicalDimensionIndex(dim, input_shape.get().rank());
@@ -2524,9 +2538,9 @@ XLATensor XLATensor::squeeze(const XLATensor& input) {
   return view(input, output_dimensions);
 }
 
-XLATensor XLATensor::squeeze(const XLATensor& input, int64_t dim) {
+XLATensor XLATensor::squeeze(const XLATensor& input, xla::int64_t dim) {
   auto input_shape = input.shape();
-  int64_t squeeze_dim =
+  xla::int64_t squeeze_dim =
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   auto output_dimensions =
       BuildSqueezedDimensions(input_shape.get().dimensions(), squeeze_dim);
@@ -2537,27 +2551,29 @@ void XLATensor::squeeze_(XLATensor& input) {
   input.SetIrValue(ir::MakeNode<ir::ops::Squeeze>(input.GetIrValue(), -1));
 }
 
-void XLATensor::squeeze_(XLATensor& input, int64_t dim) {
+void XLATensor::squeeze_(XLATensor& input, xla::int64_t dim) {
   input.SetIrValue(ir::MakeNode<ir::ops::Squeeze>(
       input.GetIrValue(),
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank())));
 }
 
-XLATensor XLATensor::stack(absl::Span<const XLATensor> tensors, int64_t dim) {
+XLATensor XLATensor::stack(absl::Span<const XLATensor> tensors,
+                           xla::int64_t dim) {
   XLA_CHECK_GT(tensors.size(), 0);
   std::vector<ir::Value> values;
   for (auto& tensor : tensors) {
     values.push_back(tensor.GetIrValue());
   }
-  int64_t canonical_dim = XlaHelpers::GetCanonicalDimensionIndex(
+  xla::int64_t canonical_dim = XlaHelpers::GetCanonicalDimensionIndex(
       dim, tensors.front().shape().get().rank() + 1);
   return tensors[0].CreateFrom(
       ir::MakeNode<ir::ops::Stack>(values, canonical_dim));
 }
 
 XLATensor XLATensor::std(const XLATensor& input,
-                         std::vector<int64_t> dimensions,
-                         bool keep_reduced_dimensions, int64_t correction) {
+                         std::vector<xla::int64_t> dimensions,
+                         bool keep_reduced_dimensions,
+                         xla::int64_t correction) {
   return input.CreateFrom(
       ir::MakeNode<ir::ops::Std>(input.GetIrValue(),
                                  XlaHelpers::GetCanonicalDimensionIndices(
@@ -2566,8 +2582,8 @@ XLATensor XLATensor::std(const XLATensor& input,
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::std_mean(
-    const XLATensor& input, std::vector<int64_t> dimensions, int64_t correction,
-    bool keep_reduced_dimensions) {
+    const XLATensor& input, std::vector<xla::int64_t> dimensions,
+    xla::int64_t correction, bool keep_reduced_dimensions) {
   ir::NodePtr node = ir::MakeNode<ir::ops::StdMean>(
       input.GetIrValue(),
       XlaHelpers::GetCanonicalDimensionIndices(dimensions,
@@ -2598,7 +2614,7 @@ XLATensor XLATensor::sub(const XLATensor& input, const at::Scalar& other,
 }
 
 XLATensor XLATensor::sum(const XLATensor& input,
-                         std::vector<int64_t> dimensions,
+                         std::vector<xla::int64_t> dimensions,
                          bool keep_reduced_dimensions,
                          c10::optional<at::ScalarType> dtype) {
   if (at::isIntegralType(input.dtype(), /*includeBool=*/true) && !dtype) {
@@ -2686,9 +2702,9 @@ XLATensor XLATensor::to(XLATensor& input, c10::optional<Device> device,
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::topk(const XLATensor& input,
-                                                 int64_t k, int64_t dim,
-                                                 bool largest, bool sorted,
-                                                 bool stable) {
+                                                 xla::int64_t k,
+                                                 xla::int64_t dim, bool largest,
+                                                 bool sorted, bool stable) {
   ir::NodePtr node = ir::MakeNode<ir::ops::TopK>(
       input.GetIrValue(), k,
       XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank()),
@@ -2709,8 +2725,8 @@ XLATensor XLATensor::trace(const XLATensor& input) {
                         false, input.dtype());
 }
 
-XLATensor XLATensor::transpose(const XLATensor& input, int64_t dim0,
-                               int64_t dim1) {
+XLATensor XLATensor::transpose(const XLATensor& input, xla::int64_t dim0,
+                               xla::int64_t dim1) {
   auto input_shape = input.shape();
   auto permute_dims = XlaHelpers::MakeTransposePermutation(
       /*dim0=*/dim0, /*dim1=*/dim1, /*rank=*/input_shape.get().rank());
@@ -2718,7 +2734,8 @@ XLATensor XLATensor::transpose(const XLATensor& input, int64_t dim0,
   return input.CreateViewTensor(std::move(view_info));
 }
 
-void XLATensor::transpose_(XLATensor& input, int64_t dim0, int64_t dim1) {
+void XLATensor::transpose_(XLATensor& input, xla::int64_t dim0,
+                           xla::int64_t dim1) {
   auto input_shape = input.shape();
   auto permute_dims = XlaHelpers::MakeTransposePermutation(
       /*dim0=*/dim0, /*dim1=*/dim1, /*rank=*/input_shape.get().rank());
@@ -2737,21 +2754,21 @@ std::tuple<XLATensor, XLATensor> XLATensor::triangular_solve(
                          rhs.CreateFrom(ir::Value(node, 1)));
 }
 
-XLATensor XLATensor::tril(const XLATensor& input, int64_t diagonal) {
+XLATensor XLATensor::tril(const XLATensor& input, xla::int64_t diagonal) {
   return input.CreateFrom(
       ir::MakeNode<ir::ops::Tril>(input.GetIrValue(), diagonal));
 }
 
-void XLATensor::tril_(XLATensor& input, int64_t diagonal) {
+void XLATensor::tril_(XLATensor& input, xla::int64_t diagonal) {
   input.SetIrValue(ir::MakeNode<ir::ops::Tril>(input.GetIrValue(), diagonal));
 }
 
-XLATensor XLATensor::triu(const XLATensor& input, int64_t diagonal) {
+XLATensor XLATensor::triu(const XLATensor& input, xla::int64_t diagonal) {
   return input.CreateFrom(
       ir::MakeNode<ir::ops::Triu>(input.GetIrValue(), diagonal));
 }
 
-void XLATensor::triu_(XLATensor& input, int64_t diagonal) {
+void XLATensor::triu_(XLATensor& input, xla::int64_t diagonal) {
   input.SetIrValue(ir::MakeNode<ir::ops::Triu>(input.GetIrValue(), diagonal));
 }
 
@@ -2759,12 +2776,13 @@ XLATensor XLATensor::trunc(const XLATensor& input) {
   return input.CreateFrom(ir::ops::Trunc(input.GetIrValue()));
 }
 
-std::vector<XLATensor> XLATensor::unbind(const XLATensor& input, int64_t dim) {
+std::vector<XLATensor> XLATensor::unbind(const XLATensor& input,
+                                         xla::int64_t dim) {
   dim = XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
-  int64_t dim_size = input.size(dim);
+  xla::int64_t dim_size = input.size(dim);
   std::vector<XLATensor> slices;
   slices.reserve(dim_size);
-  for (int64_t index = 0; index < dim_size; ++index) {
+  for (xla::int64_t index = 0; index < dim_size; ++index) {
     slices.push_back(select(input, dim, index));
   }
   return slices;
@@ -2781,16 +2799,16 @@ void XLATensor::uniform_(XLATensor& input, double from, double to) {
       GetRngSeed(input.GetDevice()), input_shape));
 }
 
-XLATensor XLATensor::unsqueeze(const XLATensor& input, int64_t dim) {
+XLATensor XLATensor::unsqueeze(const XLATensor& input, xla::int64_t dim) {
   auto input_shape = input.shape();
-  int64_t squeeze_dim =
+  xla::int64_t squeeze_dim =
       XlaHelpers::GetCanonicalDimensionIndex(dim, input_shape.get().rank() + 1);
   auto dimensions =
       BuildUnsqueezeDimensions(input_shape.get().dimensions(), squeeze_dim);
   return view(input, dimensions);
 }
 
-void XLATensor::unsqueeze_(XLATensor& input, int64_t dim) {
+void XLATensor::unsqueeze_(XLATensor& input, xla::int64_t dim) {
   int squeeze_dim = XlaHelpers::GetCanonicalDimensionIndex(
       dim, input.shape().get().rank() + 1);
   input.SetIrValue(
@@ -2798,37 +2816,37 @@ void XLATensor::unsqueeze_(XLATensor& input, int64_t dim) {
 }
 
 XLATensor XLATensor::upsample_bilinear2d(const XLATensor& input,
-                                         std::vector<int64_t> output_size,
+                                         std::vector<xla::int64_t> output_size,
                                          bool align_corners) {
   return input.CreateFrom(ir::MakeNode<ir::ops::UpsampleBilinear>(
       input.GetIrValue(), std::move(output_size), align_corners));
 }
 
 XLATensor XLATensor::upsample_bilinear2d_backward(
-    const XLATensor& grad_output, std::vector<int64_t> output_size,
-    std::vector<int64_t> input_size, bool align_corners) {
+    const XLATensor& grad_output, std::vector<xla::int64_t> output_size,
+    std::vector<xla::int64_t> input_size, bool align_corners) {
   return grad_output.CreateFrom(ir::MakeNode<ir::ops::UpsampleBilinearBackward>(
       grad_output.GetIrValue(), std::move(output_size), std::move(input_size),
       align_corners));
 }
 
 XLATensor XLATensor::upsample_nearest2d(const XLATensor& input,
-                                        std::vector<int64_t> output_size) {
+                                        std::vector<xla::int64_t> output_size) {
   return input.CreateFrom(ir::MakeNode<ir::ops::UpsampleNearest>(
       input.GetIrValue(), std::move(output_size)));
 }
 
 XLATensor XLATensor::upsample_nearest2d_backward(
-    const XLATensor& grad_output, std::vector<int64_t> output_size,
-    std::vector<int64_t> input_size) {
+    const XLATensor& grad_output, std::vector<xla::int64_t> output_size,
+    std::vector<xla::int64_t> input_size) {
   return grad_output.CreateFrom(ir::MakeNode<ir::ops::UpsampleNearestBackward>(
       grad_output.GetIrValue(), std::move(output_size), std::move(input_size)));
 }
 
 XLATensor XLATensor::view(const XLATensor& input,
-                          absl::Span<const int64_t> output_size) {
+                          absl::Span<const xla::int64_t> output_size) {
   auto input_shape = input.shape();
-  std::vector<int64_t> complete_dimensions =
+  std::vector<xla::int64_t> complete_dimensions =
       GetCompleteShape(output_size, input_shape.get().dimensions());
   xla::Shape shape =
       XlaHelpers::GetDynamicReshape(input_shape, complete_dimensions);
@@ -2837,7 +2855,8 @@ XLATensor XLATensor::view(const XLATensor& input,
 }
 
 XLATensor XLATensor::var(const XLATensor& input,
-                         std::vector<int64_t> dimensions, int64_t correction,
+                         std::vector<xla::int64_t> dimensions,
+                         xla::int64_t correction,
                          bool keep_reduced_dimensions) {
   return input.CreateFrom(
       ir::MakeNode<ir::ops::Var>(input.GetIrValue(),
@@ -2847,8 +2866,8 @@ XLATensor XLATensor::var(const XLATensor& input,
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::var_mean(
-    const XLATensor& input, std::vector<int64_t> dimensions, int64_t correction,
-    bool keep_reduced_dimensions) {
+    const XLATensor& input, std::vector<xla::int64_t> dimensions,
+    xla::int64_t correction, bool keep_reduced_dimensions) {
   ir::NodePtr node = ir::MakeNode<ir::ops::VarMean>(
       input.GetIrValue(),
       XlaHelpers::GetCanonicalDimensionIndices(dimensions,

--- a/torch_xla/csrc/tensor_ops.cpp
+++ b/torch_xla/csrc/tensor_ops.cpp
@@ -12,7 +12,8 @@ namespace {
 // Returns the sub-tensor at the given index in the given dimension. Its rank
 // is one less than the input, in other words the singleton dimension is
 // squeezed out.
-XLATensor IndexAcrossDims(const XLATensor& input, int64_t dim, int64_t index) {
+XLATensor IndexAcrossDims(const XLATensor& input, xla::int64_t dim,
+                          xla::int64_t index) {
   return XLATensor::squeeze(XLATensor::slice(input, dim, index, index + 1, 1),
                             dim);
 }
@@ -20,8 +21,8 @@ XLATensor IndexAcrossDims(const XLATensor& input, int64_t dim, int64_t index) {
 }  // namespace
 
 XLATensor Cross(const XLATensor& input, const XLATensor& other,
-                c10::optional<int64_t> dim) {
-  int64_t canonical_dim;
+                c10::optional<xla::int64_t> dim) {
+  xla::int64_t canonical_dim;
   if (dim) {
     canonical_dim = XlaHelpers::GetCanonicalDimensionIndex(
         *dim, input.shape().get().rank());
@@ -64,7 +65,7 @@ XLATensor KlDivBackward(const XLATensor& grad_output, const XLATensor& input,
   auto input_shape_ref = input.shape();
   XLATensor expanded_grad_output = XLATensor::expand(
       grad_output,
-      xla::util::ToVector<int64_t>(input_shape_ref.get().dimensions()));
+      xla::util::ToVector<xla::int64_t>(input_shape_ref.get().dimensions()));
   XLATensor grad_input;
   if (!log_target) {
     grad_input = XLATensor::where(
@@ -83,13 +84,14 @@ XLATensor KlDivBackward(const XLATensor& grad_output, const XLATensor& input,
   return grad_input;
 }
 
-XLATensor MakeMatrixWithDiagonal(const XLATensor& input, int64_t diagonal) {
-  int64_t size = input.shape().get().dimensions(0);
+XLATensor MakeMatrixWithDiagonal(const XLATensor& input,
+                                 xla::int64_t diagonal) {
+  xla::int64_t size = input.shape().get().dimensions(0);
   XLATensor identity =
       XLATensor::eye(size, size, input.GetDevice(), input.dtype());
   auto padding = diagonal >= 0
-                     ? std::vector<int64_t>{diagonal, 0, 0, diagonal}
-                     : std::vector<int64_t>{0, -diagonal, -diagonal, 0};
+                     ? std::vector<xla::int64_t>{diagonal, 0, 0, diagonal}
+                     : std::vector<xla::int64_t>{0, -diagonal, -diagonal, 0};
   return XLATensor::constant_pad_nd(XLATensor::mul(identity, input), padding,
                                     0);
 }
@@ -113,7 +115,7 @@ XLATensor SmoothL1Loss(const XLATensor& input, const XLATensor& target,
   XLATensor elementwise_loss = XLATensor::where(
       XLATensor::lt(abs_diff, beta_scalar), squared_loss, l1_loss);
   auto all_dimensions =
-      xla::util::Iota<int64_t>((*broadcasted_input.shape()).rank());
+      xla::util::Iota<xla::int64_t>((*broadcasted_input.shape()).rank());
   switch (reduction) {
     case ReductionMode::kNone:
       return elementwise_loss;
@@ -191,7 +193,7 @@ XLATensor SoftplusBackward(const XLATensor& grad_output, const XLATensor& input,
                      XLATensor::div(z, XLATensor::add(z, one_vec, 1))));
 }
 
-XLATensor Select(const XLATensor& input, int64_t dim, int64_t index) {
+XLATensor Select(const XLATensor& input, xla::int64_t dim, xla::int64_t index) {
   auto shape = input.shape();
   dim = XlaHelpers::GetCanonicalDimensionIndex(dim, shape.get().rank());
   XLATensor result = XLATensor::narrow(input, dim, index, 1);
@@ -200,8 +202,10 @@ XLATensor Select(const XLATensor& input, int64_t dim, int64_t index) {
 }
 
 XLATensor EmbeddingDenseBackward(const XLATensor& grad_output,
-                                 const XLATensor& indices, int64_t num_weights,
-                                 int64_t padding_idx, bool scale_grad_by_freq) {
+                                 const XLATensor& indices,
+                                 xla::int64_t num_weights,
+                                 xla::int64_t padding_idx,
+                                 bool scale_grad_by_freq) {
   XLA_CHECK_EQ(indices.dtype(), at::ScalarType::Long)
       << "Embedding indices are expected to be of scalar type Long";
   auto indices_shape_ref = indices.shape();
@@ -209,7 +213,7 @@ XLATensor EmbeddingDenseBackward(const XLATensor& grad_output,
   // more than the indices.
   XLA_CHECK_EQ(grad_output.shape().get().rank(),
                indices_shape_ref.get().rank() + 1);
-  int64_t numel = xla::ShapeUtil::ElementsIn(indices_shape_ref.get());
+  xla::int64_t numel = xla::ShapeUtil::ElementsIn(indices_shape_ref.get());
   XLATensor grad = XLATensor::view(grad_output, {numel, grad_output.size(-1)});
   XLATensor grad_weight =
       XLATensor::full({num_weights, grad_output.size(-1)}, 0,
@@ -234,7 +238,7 @@ XLATensor EmbeddingDenseBackward(const XLATensor& grad_output,
       XLATensor::ne(indices_rank1, static_cast<double>(padding_idx)), 1);
   skip_padding = XLATensor::expand(
       skip_padding,
-      xla::util::ToVector<int64_t>(grad.shape().get().dimensions()));
+      xla::util::ToVector<xla::int64_t>(grad.shape().get().dimensions()));
   XLATensor zero_grad =
       XLATensor::full_like(grad, 0, grad.GetDevice(), grad.dtype());
   return XLATensor::index_put(

--- a/torch_xla/csrc/tensor_ops.h
+++ b/torch_xla/csrc/tensor_ops.h
@@ -11,13 +11,13 @@ namespace torch_xla {
 namespace tensor_ops {
 
 XLATensor Cross(const XLATensor& input, const XLATensor& other,
-                c10::optional<int64_t> dim);
+                c10::optional<xla::int64_t> dim);
 
 XLATensor KlDivBackward(const XLATensor& grad_output, const XLATensor& input,
                         const XLATensor& target, ReductionMode reduction,
                         bool log_target);
 
-XLATensor MakeMatrixWithDiagonal(const XLATensor& input, int64_t diagonal);
+XLATensor MakeMatrixWithDiagonal(const XLATensor& input, xla::int64_t diagonal);
 
 XLATensor SmoothL1Loss(const XLATensor& input, const XLATensor& target,
                        ReductionMode reduction, double beta);
@@ -32,11 +32,13 @@ XLATensor Softplus(const XLATensor& input, const at::Scalar& beta,
 XLATensor SoftplusBackward(const XLATensor& grad_output, const XLATensor& input,
                            const at::Scalar& beta, const at::Scalar& threshold);
 
-XLATensor Select(const XLATensor& input, int64_t dim, int64_t index);
+XLATensor Select(const XLATensor& input, xla::int64_t dim, xla::int64_t index);
 
 XLATensor EmbeddingDenseBackward(const XLATensor& grad_output,
-                                 const XLATensor& indices, int64_t num_weights,
-                                 int64_t padding_idx, bool scale_grad_by_freq);
+                                 const XLATensor& indices,
+                                 xla::int64_t num_weights,
+                                 xla::int64_t padding_idx,
+                                 bool scale_grad_by_freq);
 
 }  // namespace tensor_ops
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -229,8 +229,8 @@ struct Caster<std::complex<double>> {
 // Copies n bytes from source to dest, with different stride values for source
 // and destination.
 template <typename S, typename D>
-void StridedCopy(D* dest, int64_t dest_stride, const S* source,
-                 int64_t source_stride, int64_t n) {
+void StridedCopy(D* dest, xla::int64_t dest_stride, const S* source,
+                 xla::int64_t source_stride, xla::int64_t n) {
   Caster<S> caster;
   const S* source_top = source + n * source_stride;
   for (; source < source_top; dest += dest_stride, source += source_stride) {
@@ -241,9 +241,9 @@ void StridedCopy(D* dest, int64_t dest_stride, const S* source,
 // Computes the offset of the value at a given index, assuming a contiguous/flat
 // tensor data representation.
 template <typename S>
-int64_t GetFlatTensorOffset(const S& strides,
-                            const std::vector<int64_t>& indices) {
-  int64_t base = 0;
+xla::int64_t GetFlatTensorOffset(const S& strides,
+                                 const std::vector<xla::int64_t>& indices) {
+  xla::int64_t base = 0;
   for (size_t i = 0; i < indices.size(); ++i) {
     base += indices[i] * strides[i];
   }
@@ -302,18 +302,18 @@ struct CopyType<true> {
 };
 
 template <typename D, typename S>
-void CheckedMemcpy(D* dest, const S* source, int64_t n) {
+void CheckedMemcpy(D* dest, const S* source, xla::int64_t n) {
   static_assert(sizeof(S) == sizeof(D), "Types size mismatch");
   std::memcpy(dest, source, n * sizeof(S));
 }
 
 template <typename D, typename S>
-void CopyData(D* dest, const S* source, int64_t n, const CopyDirect&) {
+void CopyData(D* dest, const S* source, xla::int64_t n, const CopyDirect&) {
   std::copy(source, source + n, dest);
 }
 
 template <typename D, typename S>
-void CopyData(D* dest, const S* source, int64_t n, const CopyCasted&) {
+void CopyData(D* dest, const S* source, xla::int64_t n, const CopyCasted&) {
   // Use strided copy with step 1 since it has the static_cast<> required to
   // convert from/to bfloat16.
   StridedCopy(dest, 1, source, 1, n);
@@ -321,32 +321,33 @@ void CopyData(D* dest, const S* source, int64_t n, const CopyCasted&) {
 
 template <>
 void CopyData<at::BFloat16, tensorflow::bfloat16>(
-    at::BFloat16* dest, const tensorflow::bfloat16* source, int64_t n,
+    at::BFloat16* dest, const tensorflow::bfloat16* source, xla::int64_t n,
     const CopyCasted&) {
   CheckedMemcpy<at::BFloat16, tensorflow::bfloat16>(dest, source, n);
 }
 template <>
 void CopyData<tensorflow::bfloat16, at::BFloat16>(tensorflow::bfloat16* dest,
                                                   const at::BFloat16* source,
-                                                  int64_t n,
+                                                  xla::int64_t n,
                                                   const CopyCasted&) {
   CheckedMemcpy<tensorflow::bfloat16, at::BFloat16>(dest, source, n);
 }
 
-std::vector<int64_t> GetIterationDimensions(const xla::Shape& shape) {
+std::vector<xla::int64_t> GetIterationDimensions(const xla::Shape& shape) {
   // We want to favor the most minor dimension as core iteration dimension, as
   // this walks one of the two tensors buffers in a cache friendly fashion.
   // Though, if the most minor dimension is too small, we will end up doing more
   // StridedCopy() iterations in CopyTensors().
   // So we select the most minor dimension, unless one of the other dimensions
   // is more than kMinorDimScale times the most minor one.
-  static const int64_t kMinorDimScale = 8;
-  std::vector<int64_t> iter_dims =
-      xla::util::ToVector<int64_t>(shape.layout().minor_to_major());
+  static const xla::int64_t kMinorDimScale = 8;
+  std::vector<xla::int64_t> iter_dims =
+      xla::util::ToVector<xla::int64_t>(shape.layout().minor_to_major());
   size_t index = 0;
-  int64_t scaled_dim_size = kMinorDimScale * shape.dimensions(iter_dims[index]);
+  xla::int64_t scaled_dim_size =
+      kMinorDimScale * shape.dimensions(iter_dims[index]);
   for (size_t i = 1; i < iter_dims.size(); ++i) {
-    int64_t dim = iter_dims[i];
+    xla::int64_t dim = iter_dims[i];
     if (shape.dimensions(dim) > scaled_dim_size) {
       index = i;
       scaled_dim_size = shape.dimensions(dim);
@@ -357,39 +358,40 @@ std::vector<int64_t> GetIterationDimensions(const xla::Shape& shape) {
 }
 
 struct CopyPartition {
-  explicit CopyPartition(absl::Span<const int64_t> dimensions)
+  explicit CopyPartition(absl::Span<const xla::int64_t> dimensions)
       : base(dimensions.size()), limit(dimensions.begin(), dimensions.end()) {}
 
-  std::vector<int64_t> base;
-  std::vector<int64_t> limit;
+  std::vector<xla::int64_t> base;
+  std::vector<xla::int64_t> limit;
 };
 
 std::vector<CopyPartition> CreateCopyPartitions(
-    absl::Span<const int64_t> dimensions, int64_t strided_copy_dimension) {
+    absl::Span<const xla::int64_t> dimensions,
+    xla::int64_t strided_copy_dimension) {
   // The minimum number of elements copy that can be assigned to a thread.
-  static const int64_t kMinThreadElements = 100000;
+  static const xla::int64_t kMinThreadElements = 100000;
   // Use at most 50% of the available cores.
-  int64_t max_parts =
-      std::max<int64_t>(std::thread::hardware_concurrency() / 2, 1);
+  xla::int64_t max_parts =
+      std::max<xla::int64_t>(std::thread::hardware_concurrency() / 2, 1);
   // Find the maximum dimension which is not the strided copy dimension.
-  int64_t max_dim = -1;
-  for (int64_t i = 0; i < dimensions.size(); ++i) {
+  xla::int64_t max_dim = -1;
+  for (xla::int64_t i = 0; i < dimensions.size(); ++i) {
     if (i != strided_copy_dimension &&
         (max_dim < 0 || dimensions[i] > dimensions[max_dim])) {
       max_dim = i;
     }
   }
 
-  int64_t num_elements = xla::util::Multiply<int64_t>(dimensions);
-  int64_t max_dim_unit_elements = num_elements / dimensions[max_dim];
-  int64_t max_dim_size = dimensions[max_dim];
-  int64_t part_size =
-      std::max<int64_t>(std::max<int64_t>(max_dim_size / max_parts, 1),
-                        kMinThreadElements / max_dim_unit_elements);
+  xla::int64_t num_elements = xla::util::Multiply<xla::int64_t>(dimensions);
+  xla::int64_t max_dim_unit_elements = num_elements / dimensions[max_dim];
+  xla::int64_t max_dim_size = dimensions[max_dim];
+  xla::int64_t part_size = std::max<xla::int64_t>(
+      std::max<xla::int64_t>(max_dim_size / max_parts, 1),
+      kMinThreadElements / max_dim_unit_elements);
   std::vector<CopyPartition> parts;
-  int64_t csize = 0;
+  xla::int64_t csize = 0;
   while (csize < max_dim_size) {
-    int64_t n = std::min<int64_t>(part_size, max_dim_size - csize);
+    xla::int64_t n = std::min<xla::int64_t>(part_size, max_dim_size - csize);
     CopyPartition p(dimensions);
     p.base[max_dim] = csize;
     p.limit[max_dim] = csize + n;
@@ -400,22 +402,23 @@ std::vector<CopyPartition> CreateCopyPartitions(
 }
 
 template <typename SType, typename DType>
-void SlicedCopy(absl::Span<const int64_t> dimensions, const SType* src_data,
-                absl::Span<const int64_t> src_strides, DType* dest_data,
-                absl::Span<const int64_t> dest_strides,
-                absl::Span<const int64_t> iter_dims,
+void SlicedCopy(absl::Span<const xla::int64_t> dimensions,
+                const SType* src_data,
+                absl::Span<const xla::int64_t> src_strides, DType* dest_data,
+                absl::Span<const xla::int64_t> dest_strides,
+                absl::Span<const xla::int64_t> iter_dims,
                 const CopyPartition& part) {
-  std::vector<int64_t> indices(part.base);
-  int64_t inner_src_stride = src_strides[iter_dims.front()];
-  int64_t inner_dest_stride = dest_strides[iter_dims.front()];
-  int64_t n = 0;
+  std::vector<xla::int64_t> indices(part.base);
+  xla::int64_t inner_src_stride = src_strides[iter_dims.front()];
+  xla::int64_t inner_dest_stride = dest_strides[iter_dims.front()];
+  xla::int64_t n = 0;
   while (n < indices.size()) {
     StridedCopy(dest_data + GetFlatTensorOffset(dest_strides, indices),
                 inner_dest_stride,
                 src_data + GetFlatTensorOffset(src_strides, indices),
                 inner_src_stride, dimensions[iter_dims.front()]);
     for (n = 1; n < indices.size(); ++n) {
-      int64_t dim = iter_dims[n];
+      xla::int64_t dim = iter_dims[n];
       indices[dim] += 1;
       if (indices[dim] < part.limit[dim]) {
         break;
@@ -432,7 +435,7 @@ void CopyTensors(const void* src_buffer, const xla::Shape& src_shape,
   XLA_CHECK(xla::ShapeUtil::SameDimensions(src_shape, dest_shape))
       << src_shape << " vs. " << dest_shape;
 
-  int64_t total_elements = xla::ShapeUtil::ElementsIn(src_shape);
+  xla::int64_t total_elements = xla::ShapeUtil::ElementsIn(src_shape);
   XLA_CHECK_EQ(dest_buffer_size, total_elements * sizeof(DType));
 
   const SType* src_data = reinterpret_cast<const SType*>(src_buffer);
@@ -446,9 +449,9 @@ void CopyTensors(const void* src_buffer, const xla::Shape& src_shape,
     // We issue a multi-threaded copy by slicing the bigger dimension and
     // assigning its copy to different threads. This code is only valid for
     // ranks >= 2, but the layout check above covers the case.
-    std::vector<int64_t> src_strides = ComputeShapeStrides(src_shape);
-    std::vector<int64_t> dest_strides = ComputeShapeStrides(dest_shape);
-    std::vector<int64_t> iter_dims = GetIterationDimensions(dest_shape);
+    std::vector<xla::int64_t> src_strides = ComputeShapeStrides(src_shape);
+    std::vector<xla::int64_t> dest_strides = ComputeShapeStrides(dest_shape);
+    std::vector<xla::int64_t> iter_dims = GetIterationDimensions(dest_shape);
     std::vector<CopyPartition> parts =
         CreateCopyPartitions(dest_shape.dimensions(), iter_dims.front());
     auto mwait = std::make_shared<xla::util::MultiWait>(parts.size());
@@ -502,36 +505,36 @@ void TensorToBufferSType(const at::Tensor& tensor, const xla::Shape& dest_shape,
                                   dest_buffer_size, device);
       break;
     case xla::PrimitiveType::U8:
-      TensorToBuffer<SType, uint8_t>(tensor, dest_shape, dest_buffer,
-                                     dest_buffer_size, device);
+      TensorToBuffer<SType, xla::uint8>(tensor, dest_shape, dest_buffer,
+                                        dest_buffer_size, device);
       break;
     case xla::PrimitiveType::S8:
-      TensorToBuffer<SType, int8_t>(tensor, dest_shape, dest_buffer,
-                                    dest_buffer_size, device);
+      TensorToBuffer<SType, xla::int8>(tensor, dest_shape, dest_buffer,
+                                       dest_buffer_size, device);
       break;
     case xla::PrimitiveType::S16:
-      TensorToBuffer<SType, int16_t>(tensor, dest_shape, dest_buffer,
-                                     dest_buffer_size, device);
+      TensorToBuffer<SType, xla::int16>(tensor, dest_shape, dest_buffer,
+                                        dest_buffer_size, device);
       break;
     case xla::PrimitiveType::U16:
-      TensorToBuffer<SType, uint16_t>(tensor, dest_shape, dest_buffer,
-                                      dest_buffer_size, device);
+      TensorToBuffer<SType, xla::uint16>(tensor, dest_shape, dest_buffer,
+                                         dest_buffer_size, device);
       break;
     case xla::PrimitiveType::S32:
-      TensorToBuffer<SType, int32_t>(tensor, dest_shape, dest_buffer,
-                                     dest_buffer_size, device);
+      TensorToBuffer<SType, xla::int32>(tensor, dest_shape, dest_buffer,
+                                        dest_buffer_size, device);
       break;
     case xla::PrimitiveType::U32:
-      TensorToBuffer<SType, uint32_t>(tensor, dest_shape, dest_buffer,
-                                      dest_buffer_size, device);
+      TensorToBuffer<SType, xla::uint32>(tensor, dest_shape, dest_buffer,
+                                         dest_buffer_size, device);
       break;
     case xla::PrimitiveType::S64:
-      TensorToBuffer<SType, int64_t>(tensor, dest_shape, dest_buffer,
-                                     dest_buffer_size, device);
+      TensorToBuffer<SType, xla::int64_t>(tensor, dest_shape, dest_buffer,
+                                          dest_buffer_size, device);
       break;
     case xla::PrimitiveType::U64:
-      TensorToBuffer<SType, uint64_t>(tensor, dest_shape, dest_buffer,
-                                      dest_buffer_size, device);
+      TensorToBuffer<SType, xla::uint64>(tensor, dest_shape, dest_buffer,
+                                         dest_buffer_size, device);
       break;
     case xla::PrimitiveType::C64:
       TensorToBuffer<SType, xla::complex64>(tensor, dest_shape, dest_buffer,
@@ -630,7 +633,7 @@ at::Tensor XlaLiteralToTensor(const xla::Literal& literal,
   xla::Shape torch_shape = MakeTorchTensorLayout(
       literal.shape().dimensions(), /*dynamic_dimensions=*/{},
       literal.shape().element_type());
-  int64_t total_elements = xla::ShapeUtil::ElementsIn(torch_shape);
+  xla::int64_t total_elements = xla::ShapeUtil::ElementsIn(torch_shape);
 
   const auto literal_data = literal.data<SType>();
   at::Tensor tensor = at::empty(dimensions, at::TensorOptions(atype));
@@ -678,9 +681,9 @@ at::Tensor XlaLiteralToTensorHelper(const xla::Literal& literal,
 
 }  // namespace
 
-std::vector<int64_t> ComputeShapeStrides(const xla::Shape& shape) {
-  std::vector<int64_t> strides(shape.rank());
-  int64_t stride = 1;
+std::vector<xla::int64_t> ComputeShapeStrides(const xla::Shape& shape) {
+  std::vector<xla::int64_t> strides(shape.rank());
+  xla::int64_t stride = 1;
   for (auto dim : shape.layout().minor_to_major()) {
     strides[dim] = stride;
     stride *= shape.dimensions(dim);
@@ -688,9 +691,10 @@ std::vector<int64_t> ComputeShapeStrides(const xla::Shape& shape) {
   return strides;
 }
 
-std::vector<int64_t> ComputeArrayStrides(absl::Span<const int64_t> sizes) {
-  std::vector<int64_t> strides(sizes.size(), 1);
-  for (int64_t i = sizes.size(); i > 1; --i) {
+std::vector<xla::int64_t> ComputeArrayStrides(
+    absl::Span<const xla::int64_t> sizes) {
+  std::vector<xla::int64_t> strides(sizes.size(), 1);
+  for (xla::int64_t i = sizes.size(); i > 1; --i) {
     strides[i - 2] = strides[i - 1] * sizes[i - 1];
   }
   return strides;
@@ -711,21 +715,21 @@ at::Tensor MakeTensorFromXlaLiteral(const xla::Literal& literal,
     case xla::PrimitiveType::F64:
       return XlaLiteralToTensorHelper<double>(literal, dest_element_type);
     case xla::PrimitiveType::U8:
-      return XlaLiteralToTensorHelper<uint8_t>(literal, dest_element_type);
+      return XlaLiteralToTensorHelper<xla::uint8>(literal, dest_element_type);
     case xla::PrimitiveType::S8:
-      return XlaLiteralToTensorHelper<int8_t>(literal, dest_element_type);
+      return XlaLiteralToTensorHelper<xla::int8>(literal, dest_element_type);
     case xla::PrimitiveType::S16:
-      return XlaLiteralToTensorHelper<int16_t>(literal, dest_element_type);
+      return XlaLiteralToTensorHelper<xla::int16>(literal, dest_element_type);
     case xla::PrimitiveType::U16:
-      return XlaLiteralToTensorHelper<uint16_t>(literal, dest_element_type);
+      return XlaLiteralToTensorHelper<xla::uint16>(literal, dest_element_type);
     case xla::PrimitiveType::S32:
-      return XlaLiteralToTensorHelper<int32_t>(literal, dest_element_type);
+      return XlaLiteralToTensorHelper<xla::int32>(literal, dest_element_type);
     case xla::PrimitiveType::U32:
-      return XlaLiteralToTensorHelper<uint32_t>(literal, dest_element_type);
+      return XlaLiteralToTensorHelper<xla::uint32>(literal, dest_element_type);
     case xla::PrimitiveType::S64:
-      return XlaLiteralToTensorHelper<int64_t>(literal, dest_element_type);
+      return XlaLiteralToTensorHelper<xla::int64_t>(literal, dest_element_type);
     case xla::PrimitiveType::U64:
-      return XlaLiteralToTensorHelper<uint64_t>(literal, dest_element_type);
+      return XlaLiteralToTensorHelper<xla::uint64>(literal, dest_element_type);
     case xla::PrimitiveType::C64:
       return XlaLiteralToTensorHelper<xla::complex64>(literal,
                                                       dest_element_type);

--- a/torch_xla/csrc/tensor_util.h
+++ b/torch_xla/csrc/tensor_util.h
@@ -14,9 +14,10 @@
 
 namespace torch_xla {
 
-std::vector<int64_t> ComputeShapeStrides(const xla::Shape& shape);
+std::vector<xla::int64_t> ComputeShapeStrides(const xla::Shape& shape);
 
-std::vector<int64_t> ComputeArrayStrides(absl::Span<const int64_t> sizes);
+std::vector<xla::int64_t> ComputeArrayStrides(
+    absl::Span<const xla::int64_t> sizes);
 
 // Converts an XLA literal to an at::Tensor of the given element type.
 at::Tensor MakeTensorFromXlaLiteral(const xla::Literal& literal,

--- a/torch_xla/csrc/token_handler.cpp
+++ b/torch_xla/csrc/token_handler.cpp
@@ -10,16 +10,16 @@ namespace {
 
 xla::XlaOp SliceOneToken(xla::XlaOp input) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
-  int64_t input_rank = input_shape.rank();
+  xla::int64_t input_rank = input_shape.rank();
   if (input_rank > 0) {
     xla::GatherDimensionNumbers dim_numbers;
-    for (int64_t i = 0; i < input_rank; ++i) {
+    for (xla::int64_t i = 0; i < input_rank; ++i) {
       dim_numbers.add_collapsed_slice_dims(i);
       dim_numbers.add_start_index_map(i);
     }
     dim_numbers.set_index_vector_dim(0);
 
-    std::vector<int64_t> slice_sizes(input_rank, 1);
+    std::vector<xla::int64_t> slice_sizes(input_rank, 1);
     xla::XlaOp indices = xla::Zeros(
         input.builder(),
         xla::ShapeUtil::MakeShape(xla::PrimitiveType::S32, {input_rank}));

--- a/torch_xla/csrc/view.cpp
+++ b/torch_xla/csrc/view.cpp
@@ -40,13 +40,16 @@ ir::Value ApplyViewInfo(ir::Value ir_value, const ViewInfo& view_info) {
       return ir::MakeNode<ir::ops::Permute>(ir_value, view_info.permutation);
     case ViewInfo::Type::kReshape:
       return ir::MakeNode<ir::ops::View>(
-          ir_value, xla::util::ToVector<int64_t>(view_info.shape.dimensions()));
+          ir_value,
+          xla::util::ToVector<xla::int64_t>(view_info.shape.dimensions()));
     case ViewInfo::Type::kResize:
       return ir::MakeNode<ir::ops::Resize>(
-          ir_value, xla::util::ToVector<int64_t>(view_info.shape.dimensions()));
+          ir_value,
+          xla::util::ToVector<xla::int64_t>(view_info.shape.dimensions()));
     case ViewInfo::Type::kAsStrided:
       return ir::MakeNode<ir::ops::AsStrided>(
-          ir_value, xla::util::ToVector<int64_t>(view_info.shape.dimensions()),
+          ir_value,
+          xla::util::ToVector<xla::int64_t>(view_info.shape.dimensions()),
           view_info.as_strided->stride, view_info.as_strided->offset);
     case ViewInfo::Type::kDiagonal:
       return ir::MakeNode<ir::ops::Diagonal>(
@@ -90,18 +93,19 @@ ir::Value ApplyUpdate(ir::Value ir_value,
         break;
       case ViewInfo::Type::kReshape:
         result = ir::MakeNode<ir::ops::View>(
-            result,
-            xla::util::ToVector<int64_t>(view_info.source_shape.dimensions()));
+            result, xla::util::ToVector<xla::int64_t>(
+                        view_info.source_shape.dimensions()));
         break;
       case ViewInfo::Type::kResize:
         result = ir::MakeNode<ir::ops::Resize>(
-            result,
-            xla::util::ToVector<int64_t>(view_info.source_shape.dimensions()));
+            result, xla::util::ToVector<xla::int64_t>(
+                        view_info.source_shape.dimensions()));
         break;
       case ViewInfo::Type::kAsStrided:
         result = ir::MakeNode<ir::ops::AsStridedViewUpdate>(
             tmp_values[i - 1], result,
-            xla::util::ToVector<int64_t>(view_info.source_shape.dimensions()),
+            xla::util::ToVector<xla::int64_t>(
+                view_info.source_shape.dimensions()),
             view_info.as_strided->stride, view_info.as_strided->offset);
         break;
       case ViewInfo::Type::kDiagonal:
@@ -126,7 +130,7 @@ ViewInfo::ViewInfo(Type view_type, xla::Shape shape, xla::Shape source_shape)
       source_shape(std::move(source_shape)) {}
 
 ViewInfo::ViewInfo(Type view_type, xla::Shape source_shape,
-                   std::vector<int64_t> permutation)
+                   std::vector<xla::int64_t> permutation)
     : view_type(view_type),
       shape(ir::ops::Permute::MakePermuteShape(source_shape, permutation)),
       source_shape(std::move(source_shape)),

--- a/torch_xla/csrc/view.h
+++ b/torch_xla/csrc/view.h
@@ -16,10 +16,10 @@ struct SelectInfo {
            stride == ref.stride;
   }
 
-  int64_t dim = 0;
-  int64_t start = 0;
-  int64_t end = 0;
-  int64_t stride = 0;
+  xla::int64_t dim = 0;
+  xla::int64_t start = 0;
+  xla::int64_t end = 0;
+  xla::int64_t stride = 0;
 };
 
 struct AsStridedInfo {
@@ -27,8 +27,8 @@ struct AsStridedInfo {
     return offset == ref.offset && stride == ref.stride;
   }
 
-  std::vector<int64_t> stride;
-  int64_t offset = 0;
+  std::vector<xla::int64_t> stride;
+  xla::int64_t offset = 0;
 };
 
 struct DiagonalInfo {
@@ -36,9 +36,9 @@ struct DiagonalInfo {
     return offset == ref.offset && dim1 == ref.dim1 && dim2 == ref.dim2;
   }
 
-  int64_t offset = 0;
-  int64_t dim1 = 0;
-  int64_t dim2 = 1;
+  xla::int64_t offset = 0;
+  xla::int64_t dim1 = 0;
+  xla::int64_t dim2 = 1;
 };
 
 struct ViewInfo {
@@ -57,7 +57,7 @@ struct ViewInfo {
   ViewInfo() = default;
   ViewInfo(Type view_type, xla::Shape shape, xla::Shape source_shape);
   ViewInfo(Type view_type, xla::Shape source_shape,
-           std::vector<int64_t> permutation);
+           std::vector<xla::int64_t> permutation);
   ViewInfo(Type view_type, const xla::Shape& source_shape, SelectInfo select);
   ViewInfo(Type view_type, xla::Shape shape, xla::Shape source_shape,
            AsStridedInfo as_strided);
@@ -77,11 +77,11 @@ struct ViewInfo {
   xla::Shape shape;
   // In case of narrowing, the starting indices from where the narrow slice is
   // cut.
-  std::vector<int64_t> indices;
+  std::vector<xla::int64_t> indices;
   // The shape of the source of this view.
   xla::Shape source_shape;
   // The permutation to be used. If empty, this is not a permute operation.
-  std::vector<int64_t> permutation;
+  std::vector<xla::int64_t> permutation;
   // Information used for sliced views.
   absl::optional<SelectInfo> select;
   // Information used for as_strided views.

--- a/torch_xla/csrc/xla_lower_util.cpp
+++ b/torch_xla/csrc/xla_lower_util.cpp
@@ -12,7 +12,6 @@
 #include "tensorflow/compiler/xla/util.h"
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
-#include "tensorflow/stream_executor/dnn.h"
 #include "torch_xla/csrc/convert_ops.h"
 #include "torch_xla/csrc/data_ops.h"
 #include "torch_xla/csrc/helpers.h"
@@ -24,7 +23,7 @@ namespace {
 
 struct ConditionMaskData {
   xla::Shape iota_shape;
-  int64_t flattened_size;
+  xla::int64_t flattened_size;
   xla::XlaOp r1_condition_int;
   xla::PrimitiveType condition_int_type;
   xla::XlaOp length;
@@ -35,7 +34,7 @@ ConditionMaskData CreateConditionMaskData(xla::XlaOp condition) {
   xla::Shape iota_shape = XlaHelpers::ShapeOfXlaOp(condition);
   iota_shape.set_element_type(GetShapeDimensionType(/*device=*/nullptr));
 
-  int64_t flattened_size = xla::ShapeUtil::ElementsIn(iota_shape);
+  xla::int64_t flattened_size = xla::ShapeUtil::ElementsIn(iota_shape);
   xla::XlaOp r1_condition =
       XlaHelpers::DynamicReshape(condition, {flattened_size});
   xla::XlaOp r1_condition_int =
@@ -66,8 +65,8 @@ bool ShouldUseDenseScatter(const Device& device, const xla::Shape& input_shape,
   static int dense_scatter_factor =
       xla::sys_util::GetEnvInt("XLA_DENSE_SCATTER_FACTOR", 100);
   if (device.hw_type == DeviceType::TPU) {
-    int64_t input_elements = xla::ShapeUtil::ElementsIn(input_shape);
-    int64_t index_elements = xla::ShapeUtil::ElementsIn(index_shape);
+    xla::int64_t input_elements = xla::ShapeUtil::ElementsIn(input_shape);
+    xla::int64_t index_elements = xla::ShapeUtil::ElementsIn(index_shape);
     return index_elements * dense_scatter_factor >= input_elements;
   }
   return false;
@@ -75,32 +74,34 @@ bool ShouldUseDenseScatter(const Device& device, const xla::Shape& input_shape,
 
 xla::XlaOp DotExpand(xla::XlaOp op, const xla::Shape& op_shape,
                      const xla::Shape& to_shape) {
-  int64_t rank_delta = to_shape.rank() - op_shape.rank();
+  xla::int64_t rank_delta = to_shape.rank() - op_shape.rank();
   XLA_CHECK_GT(rank_delta, 0) << op_shape << " vs. " << to_shape;
 
-  std::vector<int64_t> reshape_sizes(to_shape.rank(), 1);
+  std::vector<xla::int64_t> reshape_sizes(to_shape.rank(), 1);
   std::copy(op_shape.dimensions().begin(), op_shape.dimensions().end(),
             reshape_sizes.begin() + rank_delta);
   xla::XlaOp result = XlaHelpers::DynamicReshape(op, reshape_sizes);
 
-  std::vector<int64_t> broadcasted_sizes(
+  std::vector<xla::int64_t> broadcasted_sizes(
       to_shape.dimensions().begin(),
       to_shape.dimensions().begin() + rank_delta);
   broadcasted_sizes.insert(broadcasted_sizes.end(),
                            op_shape.dimensions().begin(),
                            op_shape.dimensions().end());
   return xla::BroadcastInDim(result, broadcasted_sizes,
-                             xla::util::Iota<int64_t>(to_shape.rank()));
+                             xla::util::Iota<xla::int64_t>(to_shape.rank()));
 }
 
 std::pair<xla::XlaOp, xla::XlaOp> DotBroadcast(xla::XlaOp lhs,
                                                const xla::Shape& lhs_shape,
                                                xla::XlaOp rhs,
                                                const xla::Shape& rhs_shape) {
-  auto lhs_dimensions = xla::util::ToVector<int64_t>(lhs_shape.dimensions());
-  auto rhs_dimensions = xla::util::ToVector<int64_t>(rhs_shape.dimensions());
+  auto lhs_dimensions =
+      xla::util::ToVector<xla::int64_t>(lhs_shape.dimensions());
+  auto rhs_dimensions =
+      xla::util::ToVector<xla::int64_t>(rhs_shape.dimensions());
   XLA_CHECK_EQ(lhs_dimensions.size(), rhs_dimensions.size());
-  for (int64_t i = 0; i < lhs_dimensions.size() - 2; ++i) {
+  for (xla::int64_t i = 0; i < lhs_dimensions.size() - 2; ++i) {
     if (lhs_dimensions[i] == rhs_dimensions[i]) {
       continue;
     }
@@ -118,11 +119,13 @@ std::pair<xla::XlaOp, xla::XlaOp> DotBroadcast(xla::XlaOp lhs,
   xla::XlaOp broadcasted_rhs = rhs;
   if (lhs_dimensions != lhs_shape.dimensions()) {
     broadcasted_lhs = xla::BroadcastInDim(
-        lhs, lhs_dimensions, xla::util::Iota<int64_t>(lhs_dimensions.size()));
+        lhs, lhs_dimensions,
+        xla::util::Iota<xla::int64_t>(lhs_dimensions.size()));
   }
   if (rhs_dimensions != rhs_shape.dimensions()) {
     broadcasted_rhs = xla::BroadcastInDim(
-        rhs, rhs_dimensions, xla::util::Iota<int64_t>(rhs_dimensions.size()));
+        rhs, rhs_dimensions,
+        xla::util::Iota<xla::int64_t>(rhs_dimensions.size()));
   }
   return std::make_pair(broadcasted_lhs, broadcasted_rhs);
 }
@@ -141,13 +144,14 @@ xla::XlaComputation MakeScatterComputation(
 }
 
 xla::XlaOp CreateIndexAlongDim(
-    xla::XlaOp buffer, int64_t dim, xla::XlaOp index, xla::XlaOp value,
+    xla::XlaOp buffer, xla::int64_t dim, xla::XlaOp index, xla::XlaOp value,
     bool broadcast_value_to_index,
     const std::function<xla::XlaOp(xla::XlaOp, xla::XlaOp)>& combiner) {
   const xla::Shape& buffer_shape = XlaHelpers::ShapeOfXlaOp(buffer);
   xla::ScatterDimensionNumbers dim_numbers;
   dim_numbers.set_index_vector_dim(1);
-  for (int64_t window_dim = 0; window_dim < buffer_shape.rank(); ++window_dim) {
+  for (xla::int64_t window_dim = 0; window_dim < buffer_shape.rank();
+       ++window_dim) {
     if (window_dim != dim) {
       dim_numbers.add_update_window_dims(window_dim);
     } else {
@@ -165,8 +169,8 @@ xla::XlaOp CreateIndexAlongDim(
   }
   if (broadcast_value_to_index) {
     const xla::Shape& index_shape = XlaHelpers::ShapeOfXlaOp(index);
-    std::vector<int64_t> update_dimensions =
-        xla::util::ToVector<int64_t>(buffer_shape.dimensions());
+    std::vector<xla::int64_t> update_dimensions =
+        xla::util::ToVector<xla::int64_t>(buffer_shape.dimensions());
     update_dimensions[dim] = index_shape.dimensions(0);
     updates = xla::Broadcast(updates, update_dimensions);
   }
@@ -178,7 +182,7 @@ xla::XlaOp CreateIndexAlongDim(
 }
 
 bool ScatterRequiresPadding(const xla::Shape& input_shape,
-                            const xla::Shape& index_shape, int64_t dim) {
+                            const xla::Shape& index_shape, xla::int64_t dim) {
   bool requires_padding = false;
   for (size_t i = 0; i < input_shape.rank(); ++i) {
     if (input_shape.dimensions(i) > index_shape.dimensions(i)) {
@@ -191,16 +195,16 @@ bool ScatterRequiresPadding(const xla::Shape& input_shape,
 }
 
 xla::XlaOp XlaDenseScatter(xla::XlaOp input, xla::XlaOp index, xla::XlaOp src,
-                           int64_t dim, const ScatterOptions& options) {
+                           xla::int64_t dim, const ScatterOptions& options) {
   // Contribute back this code to xla::TorchScatterDense() once this has reached
   // a stable implementation.
   xla::XlaBuilder* builder = input.builder();
   return builder->ReportErrorOrReturn([&]() -> xla::StatusOr<xla::XlaOp> {
     const xla::Shape& index_shape = XlaHelpers::ShapeOfXlaOp(index);
     const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
-    std::vector<int64_t> index_broacast_dims;
-    std::vector<int64_t> sizes;
-    for (int64_t i = 0; i < index_shape.rank(); ++i) {
+    std::vector<xla::int64_t> index_broacast_dims;
+    std::vector<xla::int64_t> sizes;
+    for (xla::int64_t i = 0; i < index_shape.rank(); ++i) {
       if (i < dim) {
         index_broacast_dims.push_back(i);
       } else {
@@ -263,7 +267,7 @@ std::vector<xla::XlaOp> BuildConditionIndices(xla::XlaOp condition) {
   ConditionMaskData cmd = CreateConditionMaskData(condition);
   std::vector<xla::XlaOp> to_sort = {cmd.r1_condition_int};
   std::vector<xla::PrimitiveType> types_to_sort = {cmd.condition_int_type};
-  for (int64_t axis = 0; axis < cmd.iota_shape.rank(); ++axis) {
+  for (xla::int64_t axis = 0; axis < cmd.iota_shape.rank(); ++axis) {
     xla::XlaOp iota = xla::Iota(condition.builder(), cmd.iota_shape, axis);
     xla::XlaOp reshaped = xla::Reshape(iota, {cmd.flattened_size});
     to_sort.push_back(reshaped);
@@ -276,7 +280,7 @@ std::vector<xla::XlaOp> BuildConditionIndices(xla::XlaOp condition) {
       /*dimension=*/0,
       /*is_stable=*/true);
   std::vector<xla::XlaOp> to_concat;
-  for (int64_t i = 0; i < cmd.iota_shape.rank(); ++i) {
+  for (xla::int64_t i = 0; i < cmd.iota_shape.rank(); ++i) {
     xla::XlaOp index_single_dim = xla::GetTupleElement(sorted, i + 1);
     to_concat.push_back(
         xla::Reshape(index_single_dim, {cmd.flattened_size, 1}));
@@ -289,7 +293,7 @@ std::vector<xla::XlaOp> BuildConditionIndices(xla::XlaOp condition) {
 
 }  // namespace
 
-xla::XlaOp PadToSize(xla::XlaOp input, absl::Span<const int64_t> size,
+xla::XlaOp PadToSize(xla::XlaOp input, absl::Span<const xla::int64_t> size,
                      absl::optional<xla::XlaOp> pad_value) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   XLA_CHECK_EQ(input_shape.rank(), size.size());
@@ -308,8 +312,8 @@ xla::XlaOp PadToSize(xla::XlaOp input, absl::Span<const int64_t> size,
   return has_padding ? xla::Pad(input, *pad_value, padding_config) : input;
 }
 
-std::vector<xla::XlaOp> CreateKthValue(xla::XlaOp input, int64_t k, int64_t dim,
-                                       bool keepdim) {
+std::vector<xla::XlaOp> CreateKthValue(xla::XlaOp input, xla::int64_t k,
+                                       xla::int64_t dim, bool keepdim) {
   // Here 'k' is 1 based (1...).
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(input);
   XLA_CHECK_LE(k, shape.dimensions(dim));
@@ -322,12 +326,12 @@ std::vector<xla::XlaOp> CreateKthValue(xla::XlaOp input, int64_t k, int64_t dim,
           {shape.element_type(), xla::PrimitiveType::S32}, input.builder()),
       dim);
 
-  std::vector<int64_t> start_indices(shape.rank(), 0);
+  std::vector<xla::int64_t> start_indices(shape.rank(), 0);
   start_indices[dim] = k - 1;
-  std::vector<int64_t> limit_indices(shape.dimensions().begin(),
-                                     shape.dimensions().end());
+  std::vector<xla::int64_t> limit_indices(shape.dimensions().begin(),
+                                          shape.dimensions().end());
   limit_indices[dim] = k;
-  std::vector<int64_t> strides(shape.rank(), 1);
+  std::vector<xla::int64_t> strides(shape.rank(), 1);
 
   xla::XlaOp values = xla::Slice(xla::GetTupleElement(sort_result, 0),
                                  start_indices, limit_indices, strides);
@@ -344,8 +348,9 @@ std::vector<xla::XlaOp> CreateKthValue(xla::XlaOp input, int64_t k, int64_t dim,
                                                       /*device=*/nullptr))};
 }
 
-std::vector<xla::XlaOp> CreateTopK(xla::XlaOp input, int64_t k, int64_t dim,
-                                   bool largest, bool stable) {
+std::vector<xla::XlaOp> CreateTopK(xla::XlaOp input, xla::int64_t k,
+                                   xla::int64_t dim, bool largest,
+                                   bool stable) {
   // Here 'k' is 1 based (1...).
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(input);
   XLA_CHECK_LE(k, shape.dimensions(dim));
@@ -361,11 +366,11 @@ std::vector<xla::XlaOp> CreateTopK(xla::XlaOp input, int64_t k, int64_t dim,
                     input.builder());
   xla::XlaOp sort_result = xla::Sort({input, iota}, comparator, dim, stable);
 
-  std::vector<int64_t> start_indices(shape.rank(), 0);
-  std::vector<int64_t> limit_indices(shape.dimensions().begin(),
-                                     shape.dimensions().end());
+  std::vector<xla::int64_t> start_indices(shape.rank(), 0);
+  std::vector<xla::int64_t> limit_indices(shape.dimensions().begin(),
+                                          shape.dimensions().end());
   limit_indices[dim] = k;
-  std::vector<int64_t> strides(shape.rank(), 1);
+  std::vector<xla::int64_t> strides(shape.rank(), 1);
 
   xla::XlaOp values = xla::Slice(xla::GetTupleElement(sort_result, 0),
                                  start_indices, limit_indices, strides);
@@ -409,7 +414,7 @@ xla::XlaOp CreateMatMul(xla::XlaOp lhs, xla::XlaOp rhs) {
     // At this point lhs and rhs ranks are the same, use left rank in code
     // below.
     xla::DotDimensionNumbers dims;
-    for (int64_t i = 0; i < lhs_shape.rank() - 2; ++i) {
+    for (xla::int64_t i = 0; i < lhs_shape.rank() - 2; ++i) {
       dims.add_lhs_batch_dimensions(i);
       dims.add_rhs_batch_dimensions(i);
     }
@@ -511,21 +516,22 @@ std::vector<xla::XlaOp> CreateBroadcastTensors(
 }
 
 xla::XlaOp CreateIndex(xla::XlaOp input, xla::XlaOp indices,
-                       int64_t start_dim) {
+                       xla::int64_t start_dim) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   const xla::Shape& indices_shape = XlaHelpers::ShapeOfXlaOp(indices);
   XLA_CHECK_GE(indices_shape.rank(), 1);
-  int64_t num_index_dims = indices_shape.dimensions(indices_shape.rank() - 1);
+  xla::int64_t num_index_dims =
+      indices_shape.dimensions(indices_shape.rank() - 1);
   xla::GatherDimensionNumbers dim_numbers;
-  std::vector<int64_t> slice_sizes;
+  std::vector<xla::int64_t> slice_sizes;
   slice_sizes.reserve(input_shape.rank());
-  for (int64_t i = 0; i < input_shape.rank(); ++i) {
+  for (xla::int64_t i = 0; i < input_shape.rank(); ++i) {
     if (i >= start_dim && i < num_index_dims + start_dim) {
       dim_numbers.add_collapsed_slice_dims(i);
       slice_sizes.push_back(1);
     } else {
       slice_sizes.push_back(input_shape.dimensions(i));
-      int64_t indices_rank = indices_shape.rank() - 1;
+      xla::int64_t indices_rank = indices_shape.rank() - 1;
       if (i < start_dim) {
         dim_numbers.add_offset_dims(i);
       } else {
@@ -534,40 +540,42 @@ xla::XlaOp CreateIndex(xla::XlaOp input, xla::XlaOp indices,
     }
   }
   dim_numbers.set_index_vector_dim(indices_shape.rank() - 1);
-  for (int64_t i = 0; i < num_index_dims; i++) {
+  for (xla::int64_t i = 0; i < num_index_dims; i++) {
     dim_numbers.add_start_index_map(i + start_dim);
   }
   return xla::Gather(input, indices, dim_numbers, slice_sizes);
 }
 
 xla::XlaOp CreateIndexUpdate(
-    xla::XlaOp buffer, xla::XlaOp indices, int64_t start_dim, xla::XlaOp values,
+    xla::XlaOp buffer, xla::XlaOp indices, xla::int64_t start_dim,
+    xla::XlaOp values,
     const std::function<xla::XlaOp(xla::XlaOp, xla::XlaOp)>& combiner) {
   const xla::Shape& buffer_shape = XlaHelpers::ShapeOfXlaOp(buffer);
   const xla::Shape& indices_shape = XlaHelpers::ShapeOfXlaOp(indices);
   const xla::Shape& values_shape = XlaHelpers::ShapeOfXlaOp(values);
 
-  absl::Span<const int64_t> indices_dims =
-      stream_executor::dnn::AsInt64Slice(indices_shape.dimensions());
+  absl::Span<const xla::int64_t> indices_dims =
+      xla::AsInt64Slice(indices_shape.dimensions());
   XLA_CHECK(!indices_dims.empty());
   // The minor dimension of indices contains the indices to update.
-  int64_t num_index_dims = indices_dims.back();
+  xla::int64_t num_index_dims = indices_dims.back();
   indices_dims.remove_suffix(1);
   xla::ScatterDimensionNumbers dim_numbers;
   dim_numbers.set_index_vector_dim(indices_shape.rank() - 1);
 
-  int64_t values_rank = values_shape.rank();
-  int64_t buffer_rank = buffer_shape.rank();
-  int64_t num_window_dims_in_values = buffer_rank - num_index_dims;
+  xla::int64_t values_rank = values_shape.rank();
+  xla::int64_t buffer_rank = buffer_shape.rank();
+  xla::int64_t num_window_dims_in_values = buffer_rank - num_index_dims;
 
   // Make the values match the rank expected by scatter.
-  std::vector<int64_t> expected_values_dims;
-  for (int64_t dim = 0; dim < start_dim; ++dim) {
+  std::vector<xla::int64_t> expected_values_dims;
+  for (xla::int64_t dim = 0; dim < start_dim; ++dim) {
     expected_values_dims.push_back(buffer_shape.dimensions(dim));
   }
   expected_values_dims.insert(expected_values_dims.end(), indices_dims.begin(),
                               indices_dims.end());
-  for (int64_t dim = num_index_dims + start_dim; dim < buffer_rank; ++dim) {
+  for (xla::int64_t dim = num_index_dims + start_dim; dim < buffer_rank;
+       ++dim) {
     expected_values_dims.push_back(buffer_shape.dimensions(dim));
   }
   xla::XlaOp new_values = values;
@@ -579,14 +587,14 @@ xla::XlaOp CreateIndexUpdate(
   const xla::Shape& new_values_shape = XlaHelpers::ShapeOfXlaOp(new_values);
   values_rank = new_values_shape.rank();
 
-  for (int64_t dim = 0; dim < start_dim; ++dim) {
+  for (xla::int64_t dim = 0; dim < start_dim; ++dim) {
     dim_numbers.add_update_window_dims(dim);
   }
-  for (int64_t i = values_rank - num_window_dims_in_values + start_dim;
+  for (xla::int64_t i = values_rank - num_window_dims_in_values + start_dim;
        i < values_rank; ++i) {
     dim_numbers.add_update_window_dims(i);
   }
-  for (int64_t i = 0; i < num_index_dims; ++i) {
+  for (xla::int64_t i = 0; i < num_index_dims; ++i) {
     dim_numbers.add_inserted_window_dims(i + start_dim);
     dim_numbers.add_scatter_dims_to_operand_dims(i + start_dim);
   }
@@ -596,7 +604,7 @@ xla::XlaOp CreateIndexUpdate(
                       dim_numbers);
 }
 
-xla::XlaOp CreateIndexAdd(xla::XlaOp buffer, int64_t dim, xla::XlaOp index,
+xla::XlaOp CreateIndexAdd(xla::XlaOp buffer, xla::int64_t dim, xla::XlaOp index,
                           xla::XlaOp value) {
   auto add_scatter_combiner = [](xla::XlaOp x, xla::XlaOp y) -> xla::XlaOp {
     return x + y;
@@ -606,14 +614,14 @@ xla::XlaOp CreateIndexAdd(xla::XlaOp buffer, int64_t dim, xla::XlaOp index,
                              add_scatter_combiner);
 }
 
-xla::XlaOp CreateIndexCopy(xla::XlaOp buffer, int64_t dim, xla::XlaOp index,
-                           xla::XlaOp value) {
+xla::XlaOp CreateIndexCopy(xla::XlaOp buffer, xla::int64_t dim,
+                           xla::XlaOp index, xla::XlaOp value) {
   return CreateIndexAlongDim(buffer, dim, index, value,
                              /*broadcast_value_to_index=*/false, nullptr);
 }
 
-xla::XlaOp CreateIndexFill(xla::XlaOp buffer, int64_t dim, xla::XlaOp index,
-                           xla::XlaOp value) {
+xla::XlaOp CreateIndexFill(xla::XlaOp buffer, xla::int64_t dim,
+                           xla::XlaOp index, xla::XlaOp value) {
   return CreateIndexAlongDim(buffer, dim, index, value,
                              /*broadcast_value_to_index=*/true, nullptr);
 }
@@ -630,7 +638,7 @@ XlaOpCombiner NumericAddCombiner() {
 }
 
 xla::XlaOp CreateScatter(const Device& device, xla::XlaOp input,
-                         xla::XlaOp index, xla::XlaOp source, int64_t dim,
+                         xla::XlaOp index, xla::XlaOp source, xla::int64_t dim,
                          const ScatterOptions& options) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   xla::Shape index_shape = XlaHelpers::ShapeOfXlaOp(index);
@@ -638,7 +646,7 @@ xla::XlaOp CreateScatter(const Device& device, xla::XlaOp input,
   XLA_CHECK_EQ(source_shape.rank(), index_shape.rank());
   xla::XlaOp source_op = source;
   if (source_shape.dimensions() != index_shape.dimensions()) {
-    std::vector<int64_t> base_indices(source_shape.rank(), 0);
+    std::vector<xla::int64_t> base_indices(source_shape.rank(), 0);
     source_op = BuildSlice(source_op, base_indices, index_shape.dimensions());
   }
   if (ShouldUseDenseScatter(device, input_shape, index_shape)) {
@@ -648,7 +656,7 @@ xla::XlaOp CreateScatter(const Device& device, xla::XlaOp input,
   xla::ShapeUtil::AppendMajorDimension(1, &index_shape);
   std::vector<xla::XlaOp> to_concat;
   to_concat.reserve(input_shape.rank());
-  for (int64_t i = 0; i < input_shape.rank(); ++i) {
+  for (xla::int64_t i = 0; i < input_shape.rank(); ++i) {
     if (i == dim) {
       to_concat.push_back(
           XlaHelpers::DynamicReshape(index, index_shape.dimensions()));
@@ -660,7 +668,7 @@ xla::XlaOp CreateScatter(const Device& device, xla::XlaOp input,
       xla::ConcatInDim(input.builder(), to_concat, input_shape.rank());
   xla::ScatterDimensionNumbers scatter_dnums;
   scatter_dnums.set_index_vector_dim(input_shape.rank());
-  for (int64_t i = 0; i < input_shape.rank(); ++i) {
+  for (xla::int64_t i = 0; i < input_shape.rank(); ++i) {
     scatter_dnums.add_inserted_window_dims(i);
     scatter_dnums.add_scatter_dims_to_operand_dims(i);
   }
@@ -726,7 +734,7 @@ xla::XlaOp BuildMaskedScatter(xla::XlaOp input, xla::XlaOp mask,
   xla::XlaOp mask_indices = indices[0];
   xla::XlaOp num_indices = indices[1];
 
-  int64_t input_size = xla::ShapeUtil::ElementsIn(input_shape);
+  xla::int64_t input_size = xla::ShapeUtil::ElementsIn(input_shape);
   if (input_size > xla::ShapeUtil::ElementsIn(source_shape)) {
     r1_source = PadToSize(r1_source, {input_size});
   }
@@ -734,7 +742,7 @@ xla::XlaOp BuildMaskedScatter(xla::XlaOp input, xla::XlaOp mask,
 
   xla::ScatterDimensionNumbers scatter_dnums;
   scatter_dnums.set_index_vector_dim(1);
-  for (int64_t i = 0; i < input_shape.rank(); ++i) {
+  for (xla::int64_t i = 0; i < input_shape.rank(); ++i) {
     scatter_dnums.add_inserted_window_dims(i);
     scatter_dnums.add_scatter_dims_to_operand_dims(i);
   }

--- a/torch_xla/csrc/xla_lower_util.h
+++ b/torch_xla/csrc/xla_lower_util.h
@@ -9,14 +9,14 @@
 
 namespace torch_xla {
 
-xla::XlaOp PadToSize(xla::XlaOp input, absl::Span<const int64_t> size,
+xla::XlaOp PadToSize(xla::XlaOp input, absl::Span<const xla::int64_t> size,
                      absl::optional<xla::XlaOp> pad_value = absl::nullopt);
 
-std::vector<xla::XlaOp> CreateKthValue(xla::XlaOp input, int64_t k, int64_t dim,
-                                       bool keepdim);
+std::vector<xla::XlaOp> CreateKthValue(xla::XlaOp input, xla::int64_t k,
+                                       xla::int64_t dim, bool keepdim);
 
-std::vector<xla::XlaOp> CreateTopK(xla::XlaOp input, int64_t k, int64_t dim,
-                                   bool largest, bool stable);
+std::vector<xla::XlaOp> CreateTopK(xla::XlaOp input, xla::int64_t k,
+                                   xla::int64_t dim, bool largest, bool stable);
 
 xla::XlaOp CreateMatMul(xla::XlaOp lhs, xla::XlaOp rhs);
 
@@ -43,22 +43,23 @@ std::vector<xla::XlaOp> CreateBroadcastTensors(
     absl::Span<const xla::XlaOp> operands);
 
 // Similar to tf.gather_nd, used to implement advanced indexing.
-xla::XlaOp CreateIndex(xla::XlaOp input, xla::XlaOp indices, int64_t start_dim);
+xla::XlaOp CreateIndex(xla::XlaOp input, xla::XlaOp indices,
+                       xla::int64_t start_dim);
 
 // Similar to tf.scatter_nd, used to implement advanced indexing updates.
 xla::XlaOp CreateIndexUpdate(
-    xla::XlaOp buffer, xla::XlaOp indices, int64_t start_dim,
+    xla::XlaOp buffer, xla::XlaOp indices, xla::int64_t start_dim,
     xla::XlaOp updates,
     const std::function<xla::XlaOp(xla::XlaOp, xla::XlaOp)>& combiner);
 
-xla::XlaOp CreateIndexAdd(xla::XlaOp buffer, int64_t dim, xla::XlaOp index,
+xla::XlaOp CreateIndexAdd(xla::XlaOp buffer, xla::int64_t dim, xla::XlaOp index,
                           xla::XlaOp value);
 
-xla::XlaOp CreateIndexCopy(xla::XlaOp buffer, int64_t dim, xla::XlaOp index,
-                           xla::XlaOp value);
+xla::XlaOp CreateIndexCopy(xla::XlaOp buffer, xla::int64_t dim,
+                           xla::XlaOp index, xla::XlaOp value);
 
-xla::XlaOp CreateIndexFill(xla::XlaOp buffer, int64_t dim, xla::XlaOp index,
-                           xla::XlaOp values);
+xla::XlaOp CreateIndexFill(xla::XlaOp buffer, xla::int64_t dim,
+                           xla::XlaOp index, xla::XlaOp values);
 
 using XlaOpCombiner = std::function<xla::XlaOp(xla::XlaOp, xla::XlaOp)>;
 
@@ -74,7 +75,7 @@ struct ScatterOptions {
 };
 
 xla::XlaOp CreateScatter(const Device& device, xla::XlaOp input,
-                         xla::XlaOp index, xla::XlaOp source, int64_t dim,
+                         xla::XlaOp index, xla::XlaOp source, xla::int64_t dim,
                          const ScatterOptions& options);
 
 xla::XlaOp CreatePut(const Device& device, xla::XlaOp input, xla::XlaOp index,

--- a/torch_xla/csrc/xla_op_builder.cpp
+++ b/torch_xla/csrc/xla_op_builder.cpp
@@ -156,15 +156,16 @@ xla::Padding ParsePadding(const std::string& padding_str) {
 
 xla::XlaOp Reshape(const BuilderPtr& builder,
                    const std::vector<OpPtr>& operands, py::dict args) {
-  std::vector<int64_t> sizes = GetTupleVector<int64_t>(args["sizes"]);
+  std::vector<xla::int64_t> sizes = GetTupleVector<xla::int64_t>(args["sizes"]);
   absl::optional<py::tuple> arg_dimensions =
       ArgOptional<py::tuple>(args, "dimensions");
   if (arg_dimensions) {
-    std::vector<int64_t> dimensions = GetTupleVector<int64_t>(*arg_dimensions);
+    std::vector<xla::int64_t> dimensions =
+        GetTupleVector<xla::int64_t>(*arg_dimensions);
     return xla::Reshape(operands.at(0)->op, dimensions, sizes);
   }
-  int64_t inferred_dimension =
-      ArgOrDefault<int64_t>(args, "inferred_dimension", -1);
+  xla::int64_t inferred_dimension =
+      ArgOrDefault<xla::int64_t>(args, "inferred_dimension", -1);
   if (inferred_dimension >= 0) {
     return xla::ReshapeWithInferredDimension(operands.at(0)->op, sizes,
                                              inferred_dimension);
@@ -174,20 +175,21 @@ xla::XlaOp Reshape(const BuilderPtr& builder,
 
 xla::XlaOp DynamicReshape(const BuilderPtr& builder,
                           const std::vector<OpPtr>& operands, py::dict args) {
-  std::vector<int64_t> sizes = GetTupleVector<int64_t>(args["sizes"]);
+  std::vector<xla::int64_t> sizes = GetTupleVector<xla::int64_t>(args["sizes"]);
   return XlaHelpers::DynamicReshape(operands.at(0)->op, sizes);
 }
 
 xla::XlaOp Broadcast(const BuilderPtr& builder,
                      const std::vector<OpPtr>& operands, py::dict args) {
-  std::vector<int64_t> sizes = GetTupleVector<int64_t>(args["sizes"]);
+  std::vector<xla::int64_t> sizes = GetTupleVector<xla::int64_t>(args["sizes"]);
   return xla::Broadcast(operands.at(0)->op, sizes);
 }
 
 xla::XlaOp BroadcastInDim(const BuilderPtr& builder,
                           const std::vector<OpPtr>& operands, py::dict args) {
-  std::vector<int64_t> sizes = GetTupleVector<int64_t>(args["sizes"]);
-  std::vector<int64_t> dimensions = GetTupleVector<int64_t>(args["dimensions"]);
+  std::vector<xla::int64_t> sizes = GetTupleVector<xla::int64_t>(args["sizes"]);
+  std::vector<xla::int64_t> dimensions =
+      GetTupleVector<xla::int64_t>(args["dimensions"]);
   return xla::BroadcastInDim(operands.at(0)->op, sizes, dimensions);
 }
 
@@ -233,9 +235,9 @@ xla::PaddingConfig ParsePaddingConfig(py::tuple cfg) {
     py::tuple dims = dimp.cast<py::tuple>();
     XLA_CHECK_EQ(dims.size(), 3);
     auto dim = pad_config.add_dimensions();
-    dim->set_edge_padding_low(dims[0].cast<int64_t>());
-    dim->set_edge_padding_high(dims[1].cast<int64_t>());
-    dim->set_interior_padding(dims[2].cast<int64_t>());
+    dim->set_edge_padding_low(dims[0].cast<xla::int64_t>());
+    dim->set_edge_padding_high(dims[1].cast<xla::int64_t>());
+    dim->set_interior_padding(dims[2].cast<xla::int64_t>());
   }
   return pad_config;
 }
@@ -259,36 +261,41 @@ xla::XlaOp Pad(const BuilderPtr& builder, const std::vector<OpPtr>& operands,
 
 xla::XlaOp Transpose(const BuilderPtr& builder,
                      const std::vector<OpPtr>& operands, py::dict args) {
-  std::vector<int64_t> permutation =
-      GetTupleVector<int64_t>(args["permutation"]);
+  std::vector<xla::int64_t> permutation =
+      GetTupleVector<xla::int64_t>(args["permutation"]);
   return xla::Transpose(operands.at(0)->op, permutation);
 }
 
 xla::ConvolutionDimensionNumbers ParseConvolutionDimensionNumbers(
     py::dict args) {
   xla::ConvolutionDimensionNumbers dimension_numbers;
-  XLA_PBSET(dimension_numbers, input_batch_dimension, int64_t, args);
-  XLA_PBSET(dimension_numbers, input_feature_dimension, int64_t, args);
-  XLA_PBSET(dimension_numbers, kernel_input_feature_dimension, int64_t, args);
-  XLA_PBSET(dimension_numbers, kernel_output_feature_dimension, int64_t, args);
-  XLA_PBSET(dimension_numbers, output_batch_dimension, int64_t, args);
-  XLA_PBSET(dimension_numbers, output_feature_dimension, int64_t, args);
-  XLA_PBSET_REP(dimension_numbers, input_spatial_dimensions, int64_t, args);
-  XLA_PBSET_REP(dimension_numbers, kernel_spatial_dimensions, int64_t, args);
-  XLA_PBSET_REP(dimension_numbers, output_spatial_dimensions, int64_t, args);
+  XLA_PBSET(dimension_numbers, input_batch_dimension, xla::int64_t, args);
+  XLA_PBSET(dimension_numbers, input_feature_dimension, xla::int64_t, args);
+  XLA_PBSET(dimension_numbers, kernel_input_feature_dimension, xla::int64_t,
+            args);
+  XLA_PBSET(dimension_numbers, kernel_output_feature_dimension, xla::int64_t,
+            args);
+  XLA_PBSET(dimension_numbers, output_batch_dimension, xla::int64_t, args);
+  XLA_PBSET(dimension_numbers, output_feature_dimension, xla::int64_t, args);
+  XLA_PBSET_REP(dimension_numbers, input_spatial_dimensions, xla::int64_t,
+                args);
+  XLA_PBSET_REP(dimension_numbers, kernel_spatial_dimensions, xla::int64_t,
+                args);
+  XLA_PBSET_REP(dimension_numbers, output_spatial_dimensions, xla::int64_t,
+                args);
   return dimension_numbers;
 }
 
 xla::XlaOp ConvWithGeneralPadding(const BuilderPtr& builder,
                                   const std::vector<OpPtr>& operands,
                                   py::dict args) {
-  std::vector<int64_t> window_strides =
-      GetTupleVector<int64_t>(args["window_strides"]);
-  int64_t feature_group_count =
-      ArgOrDefault<int64_t>(args, "feature_group_count", 1);
-  int64_t batch_group_count =
-      ArgOrDefault<int64_t>(args, "batch_group_count", 1);
-  auto padding = ParsePairList<int64_t>(args["padding"]);
+  std::vector<xla::int64_t> window_strides =
+      GetTupleVector<xla::int64_t>(args["window_strides"]);
+  xla::int64_t feature_group_count =
+      ArgOrDefault<xla::int64_t>(args, "feature_group_count", 1);
+  xla::int64_t batch_group_count =
+      ArgOrDefault<xla::int64_t>(args, "batch_group_count", 1);
+  auto padding = ParsePairList<xla::int64_t>(args["padding"]);
   xla::PrecisionConfig precision_config = DotPrecisonConfig(args);
   return xla::ConvWithGeneralPadding(
       operands.at(0)->op, operands.at(1)->op, window_strides, padding,
@@ -298,12 +305,12 @@ xla::XlaOp ConvWithGeneralPadding(const BuilderPtr& builder,
 xla::XlaOp ConvWithGeneralDimensions(const BuilderPtr& builder,
                                      const std::vector<OpPtr>& operands,
                                      py::dict args) {
-  std::vector<int64_t> window_strides =
-      GetTupleVector<int64_t>(args["window_strides"]);
-  int64_t feature_group_count =
-      ArgOrDefault<int64_t>(args, "feature_group_count", 1);
-  int64_t batch_group_count =
-      ArgOrDefault<int64_t>(args, "batch_group_count", 1);
+  std::vector<xla::int64_t> window_strides =
+      GetTupleVector<xla::int64_t>(args["window_strides"]);
+  xla::int64_t feature_group_count =
+      ArgOrDefault<xla::int64_t>(args, "feature_group_count", 1);
+  xla::int64_t batch_group_count =
+      ArgOrDefault<xla::int64_t>(args, "batch_group_count", 1);
   xla::Padding padding = ParsePadding(args["padding"].cast<std::string>());
   xla::ConvolutionDimensionNumbers dimension_numbers =
       ParseConvolutionDimensionNumbers(args);
@@ -316,13 +323,13 @@ xla::XlaOp ConvWithGeneralDimensions(const BuilderPtr& builder,
 
 xla::XlaOp ConvGeneral(const BuilderPtr& builder,
                        const std::vector<OpPtr>& operands, py::dict args) {
-  std::vector<int64_t> window_strides =
-      GetTupleVector<int64_t>(args["window_strides"]);
-  int64_t feature_group_count =
-      ArgOrDefault<int64_t>(args, "feature_group_count", 1);
-  int64_t batch_group_count =
-      ArgOrDefault<int64_t>(args, "batch_group_count", 1);
-  auto padding = ParsePairList<int64_t>(args["padding"]);
+  std::vector<xla::int64_t> window_strides =
+      GetTupleVector<xla::int64_t>(args["window_strides"]);
+  xla::int64_t feature_group_count =
+      ArgOrDefault<xla::int64_t>(args, "feature_group_count", 1);
+  xla::int64_t batch_group_count =
+      ArgOrDefault<xla::int64_t>(args, "batch_group_count", 1);
+  auto padding = ParsePairList<xla::int64_t>(args["padding"]);
   xla::ConvolutionDimensionNumbers dimension_numbers =
       ParseConvolutionDimensionNumbers(args);
   xla::PrecisionConfig precision_config = DotPrecisonConfig(args);
@@ -335,17 +342,17 @@ xla::XlaOp ConvGeneral(const BuilderPtr& builder,
 xla::XlaOp ConvGeneralDilated(const BuilderPtr& builder,
                               const std::vector<OpPtr>& operands,
                               py::dict args) {
-  std::vector<int64_t> window_strides =
-      GetTupleVector<int64_t>(args["window_strides"]);
-  std::vector<int64_t> lhs_dilation =
-      GetTupleVector<int64_t>(args["lhs_dilation"]);
-  std::vector<int64_t> rhs_dilation =
-      GetTupleVector<int64_t>(args["rhs_dilation"]);
-  int64_t feature_group_count =
-      ArgOrDefault<int64_t>(args, "feature_group_count", 1);
-  int64_t batch_group_count =
-      ArgOrDefault<int64_t>(args, "batch_group_count", 1);
-  auto padding = ParsePairList<int64_t>(args["padding"]);
+  std::vector<xla::int64_t> window_strides =
+      GetTupleVector<xla::int64_t>(args["window_strides"]);
+  std::vector<xla::int64_t> lhs_dilation =
+      GetTupleVector<xla::int64_t>(args["lhs_dilation"]);
+  std::vector<xla::int64_t> rhs_dilation =
+      GetTupleVector<xla::int64_t>(args["rhs_dilation"]);
+  xla::int64_t feature_group_count =
+      ArgOrDefault<xla::int64_t>(args, "feature_group_count", 1);
+  xla::int64_t batch_group_count =
+      ArgOrDefault<xla::int64_t>(args, "batch_group_count", 1);
+  auto padding = ParsePairList<xla::int64_t>(args["padding"]);
   xla::ConvolutionDimensionNumbers dimension_numbers =
       ParseConvolutionDimensionNumbers(args);
   xla::PrecisionConfig precision_config = DotPrecisonConfig(args);
@@ -357,12 +364,12 @@ xla::XlaOp ConvGeneralDilated(const BuilderPtr& builder,
 
 xla::XlaOp Conv(const BuilderPtr& builder, const std::vector<OpPtr>& operands,
                 py::dict args) {
-  std::vector<int64_t> window_strides =
-      GetTupleVector<int64_t>(args["window_strides"]);
-  int64_t feature_group_count =
-      ArgOrDefault<int64_t>(args, "feature_group_count", 1);
-  int64_t batch_group_count =
-      ArgOrDefault<int64_t>(args, "batch_group_count", 1);
+  std::vector<xla::int64_t> window_strides =
+      GetTupleVector<xla::int64_t>(args["window_strides"]);
+  xla::int64_t feature_group_count =
+      ArgOrDefault<xla::int64_t>(args, "feature_group_count", 1);
+  xla::int64_t batch_group_count =
+      ArgOrDefault<xla::int64_t>(args, "batch_group_count", 1);
   xla::Padding padding = ParsePadding(args["padding"].cast<std::string>());
   xla::PrecisionConfig precision_config = DotPrecisonConfig(args);
   return xla::Conv(operands.at(0)->op, operands.at(1)->op, window_strides,
@@ -372,28 +379,29 @@ xla::XlaOp Conv(const BuilderPtr& builder, const std::vector<OpPtr>& operands,
 
 xla::XlaOp Slice(const BuilderPtr& builder, const std::vector<OpPtr>& operands,
                  py::dict args) {
-  std::vector<int64_t> start_indices =
-      GetTupleVector<int64_t>(args["start_indices"]);
-  std::vector<int64_t> limit_indices =
-      GetTupleVector<int64_t>(args["limit_indices"]);
-  std::vector<int64_t> strides = GetTupleVector<int64_t>(args["strides"]);
+  std::vector<xla::int64_t> start_indices =
+      GetTupleVector<xla::int64_t>(args["start_indices"]);
+  std::vector<xla::int64_t> limit_indices =
+      GetTupleVector<xla::int64_t>(args["limit_indices"]);
+  std::vector<xla::int64_t> strides =
+      GetTupleVector<xla::int64_t>(args["strides"]);
   return xla::Slice(operands.at(0)->op, start_indices, limit_indices, strides);
 }
 
 xla::XlaOp SliceInDim(const BuilderPtr& builder,
                       const std::vector<OpPtr>& operands, py::dict args) {
-  int64_t start_index = args["start_index"].cast<int64_t>();
-  int64_t limit_index = args["limit_index"].cast<int64_t>();
-  int64_t dimno = args["dimno"].cast<int64_t>();
-  int64_t stride = ArgOrDefault<int64_t>(args, "stride", 1);
+  xla::int64_t start_index = args["start_index"].cast<xla::int64_t>();
+  xla::int64_t limit_index = args["limit_index"].cast<xla::int64_t>();
+  xla::int64_t dimno = args["dimno"].cast<xla::int64_t>();
+  xla::int64_t stride = ArgOrDefault<xla::int64_t>(args, "stride", 1);
   return xla::SliceInDim(operands.at(0)->op, start_index, limit_index, stride,
                          dimno);
 }
 
 xla::XlaOp DynamicSlice(const BuilderPtr& builder,
                         const std::vector<OpPtr>& operands, py::dict args) {
-  std::vector<int64_t> slice_sizes =
-      GetTupleVector<int64_t>(args["slice_sizes"]);
+  std::vector<xla::int64_t> slice_sizes =
+      GetTupleVector<xla::int64_t>(args["slice_sizes"]);
   std::vector<xla::XlaOp> start_indices =
       GetOpVector(args["start_indices"].cast<py::tuple>());
   return xla::DynamicSlice(operands.at(0)->op, start_indices, slice_sizes);
@@ -410,7 +418,8 @@ xla::XlaOp DynamicUpdateSlice(const BuilderPtr& builder,
 
 xla::XlaOp Reduce(const BuilderPtr& builder, const std::vector<OpPtr>& operands,
                   py::dict args) {
-  std::vector<int64_t> dimensions = GetTupleVector<int64_t>(args["dimensions"]);
+  std::vector<xla::int64_t> dimensions =
+      GetTupleVector<xla::int64_t>(args["dimensions"]);
   ComputationPtr computation = args["computation"].cast<ComputationPtr>();
   return xla::Reduce(operands.at(0)->op, operands.at(1)->op,
                      computation->computation(), dimensions);
@@ -425,10 +434,10 @@ xla::XlaOp ReduceAll(const BuilderPtr& builder,
 
 xla::XlaOp ReduceWindow(const BuilderPtr& builder,
                         const std::vector<OpPtr>& operands, py::dict args) {
-  std::vector<int64_t> window_dimensions =
-      GetTupleVector<int64_t>(args["window_dimensions"]);
-  std::vector<int64_t> window_strides =
-      GetTupleVector<int64_t>(args["window_strides"]);
+  std::vector<xla::int64_t> window_dimensions =
+      GetTupleVector<xla::int64_t>(args["window_dimensions"]);
+  std::vector<xla::int64_t> window_strides =
+      GetTupleVector<xla::int64_t>(args["window_strides"]);
   ComputationPtr computation = args["computation"].cast<ComputationPtr>();
   xla::Padding padding = ParsePadding(args["padding"].cast<std::string>());
   return xla::ReduceWindow(operands.at(0)->op, operands.at(1)->op,
@@ -438,7 +447,8 @@ xla::XlaOp ReduceWindow(const BuilderPtr& builder,
 
 xla::XlaOp Map(const BuilderPtr& builder, const std::vector<OpPtr>& operands,
                py::dict args) {
-  std::vector<int64_t> dimensions = GetTupleVector<int64_t>(args["dimensions"]);
+  std::vector<xla::int64_t> dimensions =
+      GetTupleVector<xla::int64_t>(args["dimensions"]);
   ComputationPtr computation = args["computation"].cast<ComputationPtr>();
   std::vector<xla::XlaOp> static_operands =
       GetOpVector(args["static_operands"].cast<py::tuple>());
@@ -497,25 +507,25 @@ xla::GatherDimensionNumbers ParseGatherDimensionNumbers(py::dict args) {
       ArgOptional<py::tuple>(args, "offset_dims");
   if (arg_offset_dims) {
     for (auto& dim : *arg_offset_dims) {
-      dimension_numbers.add_offset_dims(dim.cast<int64_t>());
+      dimension_numbers.add_offset_dims(dim.cast<xla::int64_t>());
     }
   }
   absl::optional<py::tuple> arg_collapsed_slice_dims =
       ArgOptional<py::tuple>(args, "collapsed_slice_dims");
   if (arg_collapsed_slice_dims) {
     for (auto& dim : *arg_collapsed_slice_dims) {
-      dimension_numbers.add_collapsed_slice_dims(dim.cast<int64_t>());
+      dimension_numbers.add_collapsed_slice_dims(dim.cast<xla::int64_t>());
     }
   }
   absl::optional<py::tuple> arg_start_index_map =
       ArgOptional<py::tuple>(args, "start_index_map");
   if (arg_start_index_map) {
     for (auto& dim : *arg_start_index_map) {
-      dimension_numbers.add_start_index_map(dim.cast<int64_t>());
+      dimension_numbers.add_start_index_map(dim.cast<xla::int64_t>());
     }
   }
-  absl::optional<int64_t> arg_index_vector_dim =
-      ArgOptional<int64_t>(args, "index_vector_dim");
+  absl::optional<xla::int64_t> arg_index_vector_dim =
+      ArgOptional<xla::int64_t>(args, "index_vector_dim");
   if (arg_index_vector_dim) {
     dimension_numbers.set_index_vector_dim(*arg_index_vector_dim);
   }
@@ -524,8 +534,8 @@ xla::GatherDimensionNumbers ParseGatherDimensionNumbers(py::dict args) {
 
 xla::XlaOp Gather(const BuilderPtr& builder, const std::vector<OpPtr>& operands,
                   py::dict args) {
-  std::vector<int64_t> slice_sizes =
-      GetTupleVector<int64_t>(args["slice_sizes"]);
+  std::vector<xla::int64_t> slice_sizes =
+      GetTupleVector<xla::int64_t>(args["slice_sizes"]);
   bool indices_are_sorted =
       ArgOrDefault<bool>(args, "indices_are_sorted", false);
   xla::GatherDimensionNumbers dimension_numbers =
@@ -540,25 +550,26 @@ xla::ScatterDimensionNumbers ParseScatterDimensionNumbers(py::dict args) {
       ArgOptional<py::tuple>(args, "update_window_dims");
   if (arg_update_window_dims) {
     for (auto& dim : *arg_update_window_dims) {
-      dimension_numbers.add_update_window_dims(dim.cast<int64_t>());
+      dimension_numbers.add_update_window_dims(dim.cast<xla::int64_t>());
     }
   }
   absl::optional<py::tuple> arg_inserted_window_dims =
       ArgOptional<py::tuple>(args, "inserted_window_dims");
   if (arg_inserted_window_dims) {
     for (auto& dim : *arg_inserted_window_dims) {
-      dimension_numbers.add_inserted_window_dims(dim.cast<int64_t>());
+      dimension_numbers.add_inserted_window_dims(dim.cast<xla::int64_t>());
     }
   }
   absl::optional<py::tuple> arg_scatter_dims_to_operand_dims =
       ArgOptional<py::tuple>(args, "scatter_dims_to_operand_dims");
   if (arg_scatter_dims_to_operand_dims) {
     for (auto& dim : *arg_scatter_dims_to_operand_dims) {
-      dimension_numbers.add_scatter_dims_to_operand_dims(dim.cast<int64_t>());
+      dimension_numbers.add_scatter_dims_to_operand_dims(
+          dim.cast<xla::int64_t>());
     }
   }
-  absl::optional<int64_t> arg_index_vector_dim =
-      ArgOptional<int64_t>(args, "index_vector_dim");
+  absl::optional<xla::int64_t> arg_index_vector_dim =
+      ArgOptional<xla::int64_t>(args, "index_vector_dim");
   if (arg_index_vector_dim) {
     dimension_numbers.set_index_vector_dim(*arg_index_vector_dim);
   }
@@ -584,10 +595,10 @@ xla::XlaOp SelectAndScatter(const BuilderPtr& builder,
       args["select_computation"].cast<ComputationPtr>();
   ComputationPtr scatter_computation =
       args["scatter_computation"].cast<ComputationPtr>();
-  std::vector<int64_t> window_dimensions =
-      GetTupleVector<int64_t>(args["window_dimensions"]);
-  std::vector<int64_t> window_strides =
-      GetTupleVector<int64_t>(args["window_strides"]);
+  std::vector<xla::int64_t> window_dimensions =
+      GetTupleVector<xla::int64_t>(args["window_dimensions"]);
+  std::vector<xla::int64_t> window_strides =
+      GetTupleVector<xla::int64_t>(args["window_strides"]);
   xla::Padding padding = ParsePadding(args["padding"].cast<std::string>());
   return xla::SelectAndScatter(
       operands.at(0)->op, select_computation->computation(), window_dimensions,
@@ -602,11 +613,11 @@ xla::XlaOp SelectAndScatterWithGeneralPadding(
       args["select_computation"].cast<ComputationPtr>();
   ComputationPtr scatter_computation =
       args["scatter_computation"].cast<ComputationPtr>();
-  std::vector<int64_t> window_dimensions =
-      GetTupleVector<int64_t>(args["window_dimensions"]);
-  std::vector<int64_t> window_strides =
-      GetTupleVector<int64_t>(args["window_strides"]);
-  auto padding = ParsePairList<int64_t>(args["padding"]);
+  std::vector<xla::int64_t> window_dimensions =
+      GetTupleVector<xla::int64_t>(args["window_dimensions"]);
+  std::vector<xla::int64_t> window_strides =
+      GetTupleVector<xla::int64_t>(args["window_strides"]);
+  auto padding = ParsePairList<xla::int64_t>(args["padding"]);
   return xla::SelectAndScatterWithGeneralPadding(
       operands.at(0)->op, select_computation->computation(), window_dimensions,
       window_strides, padding, operands.at(1)->op, operands.at(2)->op,
@@ -614,19 +625,21 @@ xla::XlaOp SelectAndScatterWithGeneralPadding(
 }
 
 xla::TensorFormat ParseTensorFormat(py::dict args) {
-  int64_t batch_dimension = args["batch_dimension"].cast<int64_t>();
-  int64_t feature_dimension = args["feature_dimension"].cast<int64_t>();
-  std::vector<int64_t> spatial_dimensions =
-      GetTupleVector<int64_t>(args["spatial_dimensions"]);
+  xla::int64_t batch_dimension = args["batch_dimension"].cast<xla::int64_t>();
+  xla::int64_t feature_dimension =
+      args["feature_dimension"].cast<xla::int64_t>();
+  std::vector<xla::int64_t> spatial_dimensions =
+      GetTupleVector<xla::int64_t>(args["spatial_dimensions"]);
   return xla::TensorFormat(batch_dimension, feature_dimension,
                            spatial_dimensions);
 }
 
 xla::XlaOp MaxPool(const BuilderPtr& builder,
                    const std::vector<OpPtr>& operands, py::dict args) {
-  std::vector<int64_t> kernel_size =
-      GetTupleVector<int64_t>(args["kernel_size"]);
-  std::vector<int64_t> stride = GetTupleVector<int64_t>(args["stride"]);
+  std::vector<xla::int64_t> kernel_size =
+      GetTupleVector<xla::int64_t>(args["kernel_size"]);
+  std::vector<xla::int64_t> stride =
+      GetTupleVector<xla::int64_t>(args["stride"]);
   xla::Padding padding = ParsePadding(args["padding"].cast<std::string>());
   xla::TensorFormat data_format = ParseTensorFormat(args);
   return xla::MaxPool(operands.at(0)->op, kernel_size, stride, padding,
@@ -636,7 +649,7 @@ xla::XlaOp MaxPool(const BuilderPtr& builder,
 xla::XlaOp Sort(const BuilderPtr& builder, const std::vector<OpPtr>& operands,
                 py::dict args) {
   bool is_stable = ArgOrDefault<bool>(args, "is_stable", false);
-  int64_t dimension = ArgOrDefault<int64_t>(args, "dimension", -1);
+  xla::int64_t dimension = ArgOrDefault<xla::int64_t>(args, "dimension", -1);
   ComputationPtr comparator = args["comparator"].cast<ComputationPtr>();
   std::vector<xla::XlaOp> ops = ExtractXlaOps(operands);
   return xla::Sort(ops, comparator->computation(), dimension, is_stable);
@@ -645,7 +658,7 @@ xla::XlaOp Sort(const BuilderPtr& builder, const std::vector<OpPtr>& operands,
 xla::XlaOp Iota(const BuilderPtr& builder, const std::vector<OpPtr>& operands,
                 py::dict args) {
   xla::Shape shape = PyShapeToShape(args["shape"]);
-  int64_t iota_dimension = args["iota_dimension"].cast<int64_t>();
+  xla::int64_t iota_dimension = args["iota_dimension"].cast<xla::int64_t>();
   return xla::Iota(builder.get(), shape, iota_dimension);
 }
 
@@ -656,13 +669,14 @@ xla::XlaOp Clamp(const BuilderPtr& builder, const std::vector<OpPtr>& operands,
 
 xla::XlaOp Rev(const BuilderPtr& builder, const std::vector<OpPtr>& operands,
                py::dict args) {
-  std::vector<int64_t> dimensions = GetTupleVector<int64_t>(args["dimensions"]);
+  std::vector<xla::int64_t> dimensions =
+      GetTupleVector<xla::int64_t>(args["dimensions"]);
   return xla::Rev(operands.at(0)->op, dimensions);
 }
 
 xla::XlaOp ConcatInDim(const BuilderPtr& builder,
                        const std::vector<OpPtr>& operands, py::dict args) {
-  int64_t dimension = args["dimension"].cast<int64_t>();
+  xla::int64_t dimension = args["dimension"].cast<xla::int64_t>();
   std::vector<xla::XlaOp> ops = ExtractXlaOps(operands);
   return xla::ConcatInDim(builder.get(), ops, dimension);
 }
@@ -677,19 +691,19 @@ xla::XlaOp Convert(const BuilderPtr& builder,
 
 xla::XlaOp GetTupleElement(const BuilderPtr& builder,
                            const std::vector<OpPtr>& operands, py::dict args) {
-  int64_t index = args["index"].cast<int64_t>();
+  xla::int64_t index = args["index"].cast<xla::int64_t>();
   return xla::GetTupleElement(operands.at(0)->op, index);
 }
 
 xla::XlaOp GetDimensionSize(const BuilderPtr& builder,
                             const std::vector<OpPtr>& operands, py::dict args) {
-  int64_t dimension = args["dimension"].cast<int64_t>();
+  xla::int64_t dimension = args["dimension"].cast<xla::int64_t>();
   return xla::GetDimensionSize(operands.at(0)->op, dimension);
 }
 
 xla::XlaOp SetDimensionSize(const BuilderPtr& builder,
                             const std::vector<OpPtr>& operands, py::dict args) {
-  int64_t dimension = args["dimension"].cast<int64_t>();
+  xla::int64_t dimension = args["dimension"].cast<xla::int64_t>();
   return xla::SetDimensionSize(operands.at(0)->op, operands.at(1)->op,
                                dimension);
 }
@@ -851,8 +865,8 @@ xla::Shape PyShapeToShape(py::object shape) {
   }
   py::dict py_shape = shape.cast<py::dict>();
   std::string type = py_shape["type"].cast<std::string>();
-  std::vector<int64_t> dimensions =
-      GetTupleVector<int64_t>(py_shape["sizes"].cast<py::tuple>());
+  std::vector<xla::int64_t> dimensions =
+      GetTupleVector<xla::int64_t>(py_shape["sizes"].cast<py::tuple>());
   xla::PrimitiveType xla_type =
       ConsumeValue(xla::primitive_util::StringToPrimitiveType(type));
   if (py_shape.contains("dynamic_dimensions")) {


### PR DESCRIPTION
Reverts pytorch/xla#3298

breaking pytorch/xla test `TestConv3DNonSquare` 
```
2022-01-24T23:18:49.0471924Z [0;32m[ RUN      ] [mTensorTest.TestConv3DNonSquare
2022-01-24T23:21:46.2586262Z ./run_tests.sh: line 65:  1565 Aborted                 (core dumped) ./test_ptxla ${FILTER:+"$FILTER"} 2> $LOGFILE
2022-01-24T23:21:46.2588094Z + cleanup
2022-01-24T23:21:46.2588298Z + retcode=134
2022-01-24T23:21:46.2590754Z + set +x
2022-01-24T23:21:46.2639038Z ##[error]Process completed with exit code 134.
```