### PR TITLE
Output the same dtype for aten::div.Scalar as input if input is float

### DIFF
--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1202,6 +1202,11 @@ XLATensor XLATensor::div(const XLATensor& input, const XLATensor& other,
 XLATensor XLATensor::div(const XLATensor& input, const at::Scalar& other) {
   at::ScalarType scalar_type =
       at::typeMetaToScalarType(c10::get_default_dtype());
+  xla::PrimitiveType input_type = input.shape().get().element_type();
+  bool input_is_float = xla::primitive_util::IsFloatingPointType(input_type);
+  if (input_is_float) {
+    scalar_type = TensorTypeFromXlaType(input_type);
+  }
   ir::Value input_value = GetFloatingIrValue(input, scalar_type);
   ir::Value other_value = GetIrValueForScalar(
       other, input_value.shape().element_type(), input.GetDevice());


### PR DESCRIPTION
So lowering of `div.Scalar` is consistent with `div.Tensor`, which also uses input dtype if it is floating point:

https://github.com/pytorch/xla/blob/master/torch_xla/csrc/tensor_methods.cpp#L1154-L1164