### PR TITLE
Migrate to upstream helper functions

### DIFF
--- a/torch_xla/csrc/helpers.cpp
+++ b/torch_xla/csrc/helpers.cpp
@@ -10,6 +10,7 @@
 #include "tensorflow/compiler/xla/xla_client/sys_util.h"
 #include "tensorflow/compiler/xla/xla_client/tf_logging.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch/csrc/lazy/core/helpers.h"
 #include "torch_xla/csrc/convert_ops.h"
 #include "torch_xla/csrc/tensor_util.h"
 
@@ -72,56 +73,6 @@ xla::XlaOp XlaHelpers::CreateReturnValue(
   } else {
     return xla::Tuple(builder, {});
   }
-}
-
-std::vector<xla::int64_t> XlaHelpers::DropDimensions(
-    absl::Span<const xla::int64_t> sizes,
-    absl::Span<const xla::int64_t> drop_dims) {
-  std::vector<xla::int64_t> new_dims;
-  size_t drop_index = 0;
-  for (size_t i = 0; i < sizes.size(); ++i) {
-    if (drop_index < drop_dims.size() && i == drop_dims[drop_index]) {
-      ++drop_index;
-    } else {
-      new_dims.push_back(sizes[i]);
-    }
-  }
-  XLA_CHECK_EQ(drop_index, drop_dims.size());
-  return new_dims;
-}
-
-xla::int64_t XlaHelpers::GetCanonicalDimensionIndex(xla::int64_t dim,
-                                                    xla::int64_t rank) {
-  xla::int64_t min_shape_dim = -rank;
-  xla::int64_t max_shape_dim = rank - 1;
-  XLA_CHECK(min_shape_dim <= dim && dim <= max_shape_dim)
-      << "Value out of range (expected to be in range of [" << min_shape_dim
-      << ", " << max_shape_dim << "], but got " << dim << ")";
-  xla::int64_t dim_index = dim < 0 ? rank + dim : dim;
-  XLA_CHECK_GE(dim_index, 0);
-  XLA_CHECK_LT(dim_index, rank);
-  return dim_index;
-}
-
-std::vector<xla::int64_t> XlaHelpers::GetCanonicalDimensionIndices(
-    absl::Span<const xla::int64_t> dimensions, xla::int64_t rank) {
-  std::vector<xla::int64_t> canonical_dim_indices;
-  for (xla::int64_t dim : dimensions) {
-    canonical_dim_indices.push_back(GetCanonicalDimensionIndex(dim, rank));
-  }
-  return canonical_dim_indices;
-}
-
-xla::int64_t XlaHelpers::GetCanonicalPosition(
-    absl::Span<const xla::int64_t> dimensions, xla::int64_t dim,
-    xla::int64_t pos) {
-  dim = GetCanonicalDimensionIndex(dim, dimensions.size());
-  if (pos < 0) {
-    pos = GetCanonicalDimensionIndex(pos, dimensions[dim]);
-  } else {
-    pos = std::min<xla::int64_t>(pos, dimensions[dim]);
-  }
-  return pos;
 }
 
 xla::int64_t XlaHelpers::GetDynamicDimension(const xla::Shape& shape) {
@@ -418,15 +369,6 @@ xla::XlaOp XlaHelpers::FlattenDimRange(xla::XlaOp input, xla::int64_t start,
   return DynamicReshape(input, sizes);
 }
 
-std::vector<xla::int64_t> XlaHelpers::MakeTransposePermutation(
-    xla::int64_t dim0, xla::int64_t dim1, xla::int64_t rank) {
-  xla::int64_t canonical_dim0 = GetCanonicalDimensionIndex(dim0, rank);
-  xla::int64_t canonical_dim1 = GetCanonicalDimensionIndex(dim1, rank);
-  auto permute_dims = xla::util::Iota<xla::int64_t>(rank);
-  std::swap(permute_dims[canonical_dim0], permute_dims[canonical_dim1]);
-  return permute_dims;
-}
-
 xla::XlaOp XlaHelpers::LinearInterpolation(xla::XlaOp value0, xla::XlaOp value1,
                                            double alpha) {
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(value0);
@@ -526,54 +468,22 @@ std::pair<xla::XlaOp, xla::XlaOp> XlaHelpers::PromoteSecondValue(
                    op1, ConvertTo(op2, type2, type1, /*device=*/nullptr));
 }
 
-std::vector<xla::int64_t> XlaHelpers::GetPromotedShape(
-    absl::Span<const xla::int64_t> shape1_dims,
-    absl::Span<const xla::int64_t> shape2_dims) {
-  std::vector<xla::int64_t> dimensions;
-  // If the rank of a shape is bigger than then other, fill up the first
-  // dimensions with the ones of the bigger.
-  // Example:
-  //   shape1 = [9, 7, 6, 5, 2]
-  //   shape2 =       [6, 1, 2]
-  // Insert [9, 7] into the dimensions vector.
-  if (shape1_dims.size() > shape2_dims.size()) {
-    dimensions.insert(
-        dimensions.end(), shape1_dims.begin(),
-        shape1_dims.begin() + (shape1_dims.size() - shape2_dims.size()));
-  } else if (shape2_dims.size() > shape1_dims.size()) {
-    dimensions.insert(
-        dimensions.end(), shape2_dims.begin(),
-        shape2_dims.begin() + (shape2_dims.size() - shape1_dims.size()));
-  }
-  // For the common dimensions, they must match, or one of them be 1.
-  size_t min_size = std::min(shape1_dims.size(), shape2_dims.size());
-  for (xla::int64_t i = 0; i < min_size; ++i) {
-    xla::int64_t dim1 = shape1_dims[shape1_dims.size() - min_size + i];
-    xla::int64_t dim2 = shape2_dims[shape2_dims.size() - min_size + i];
-    XLA_CHECK(dim1 == dim2 || dim1 == 1 || dim2 == 1)
-        << "(" << absl::StrJoin(shape1_dims, ", ") << ") and ("
-        << absl::StrJoin(shape1_dims, ", ") << ")";
-    if (dim1 == 0 || dim2 == 0) {
-      dimensions.push_back(0);
-    } else {
-      dimensions.push_back(std::max<xla::int64_t>(dim1, dim2));
-    }
-  }
-  return dimensions;
-}
-
 xla::Shape XlaHelpers::GetPromotedShape(const xla::Shape& shape1,
                                         const xla::Shape& shape2) {
   return xla::ShapeUtil::MakeShape(
       shape1.element_type(),
-      GetPromotedShape(shape1.dimensions(), shape2.dimensions()));
+      torch::lazy::GetPromotedShape(
+          xla::util::ToVector<xla::int64_t>(shape1.dimensions()),
+          xla::util::ToVector<xla::int64_t>(shape2.dimensions())));
 }
 
 xla::Shape XlaHelpers::GetPromotedBinaryOpShape(const xla::Shape& shape1,
                                                 const xla::Shape& shape2) {
   return xla::ShapeUtil::MakeShape(
       PromoteType(shape1.element_type(), shape2.element_type()),
-      GetPromotedShape(shape1.dimensions(), shape2.dimensions()));
+      torch::lazy::GetPromotedShape(
+          xla::util::ToVector<xla::int64_t>(shape1.dimensions()),
+          xla::util::ToVector<xla::int64_t>(shape2.dimensions())));
 }
 
 std::pair<xla::XlaOp, xla::XlaOp> XlaHelpers::PromoteShapes(xla::XlaOp op1,

--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -180,26 +180,6 @@ class XlaHelpers {
   static xla::PaddingConfig MakeXlaPaddingConfigFromNdPadding(
       absl::Span<const xla::int64_t> padding);
 
-  // Creates a set of dimension by dropping the drop_dims ones.
-  static std::vector<xla::int64_t> DropDimensions(
-      absl::Span<const xla::int64_t> sizes,
-      absl::Span<const xla::int64_t> drop_dims);
-
-  // Get the canonical dimension index in the [0, rank) interval. Negative
-  // indices are interpreted as follows: -1 is rank-1, -2 is rank-2 etc.
-  static xla::int64_t GetCanonicalDimensionIndex(xla::int64_t dim,
-                                                 xla::int64_t rank);
-
-  // Same as above, for multiple dimensions.
-  static std::vector<xla::int64_t> GetCanonicalDimensionIndices(
-      absl::Span<const xla::int64_t> dimensions, xla::int64_t rank);
-
-  // Returns the canonical position in the dim dimension, handling negative
-  // values for the position.
-  static xla::int64_t GetCanonicalPosition(
-      absl::Span<const xla::int64_t> dimensions, xla::int64_t dim,
-      xla::int64_t pos);
-
   // Retrieves the dynamic dimension of an input shape, or returns -1 if none.
   static xla::int64_t GetDynamicDimension(const xla::Shape& shape);
 
@@ -255,11 +235,6 @@ class XlaHelpers {
     return output;
   }
 
-  // Creates a transposition from the given input and dimensions.
-  static std::vector<xla::int64_t> MakeTransposePermutation(xla::int64_t dim0,
-                                                            xla::int64_t dim1,
-                                                            xla::int64_t rank);
-
   static xla::PrimitiveType PromoteType(xla::PrimitiveType type1,
                                         xla::PrimitiveType type2);
 
@@ -292,21 +267,10 @@ class XlaHelpers {
   static std::pair<xla::XlaOp, xla::XlaOp> PromoteSecond(xla::XlaOp op1,
                                                          xla::XlaOp op2);
 
-  // Calculates the protomoted shape to which the input shapes should be
-  // broadcasted for an elementwise operation. The size of the common dimensions
-  // (2,3,4 for shape1, and 0,1,2 for shape2) must either match, or either one
-  // of the two be 1.
-  // Example:
-  //   shape1       = [9, 7, 6, 1, 2]
-  //   shape2       =       [6, 5, 2]
-  //   result_shape = [9, 7, 6, 5, 2]
-  static std::vector<xla::int64_t> GetPromotedShape(
-      absl::Span<const xla::int64_t> shape1_dims,
-      absl::Span<const xla::int64_t> shape2_dims);
-
   static xla::Shape GetPromotedShape(const xla::Shape& shape1,
                                      const xla::Shape& shape2);
 
+  // TODO @wonjoo - Migrate to torch::lazy after Shape is migrated
   static xla::Shape GetPromotedBinaryOpShape(const xla::Shape& shape1,
                                              const xla::Shape& shape2);
 

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -8,6 +8,7 @@
 #include "tensorflow/compiler/xla/shape_util.h"
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch/csrc/lazy/core/helpers.h"
 #include "torch_xla/csrc/convert_ops.h"
 #include "torch_xla/csrc/data_ops.h"
 #include "torch_xla/csrc/elementwise.h"
@@ -267,14 +268,14 @@ NodePtr LogSoftmaxBackwardOp(const Value& grad_output, const Value& output,
                              xla::int64_t dim) {
   return MakeNode<LogSoftmaxBackward>(
       grad_output, output,
-      XlaHelpers::GetCanonicalDimensionIndex(dim, grad_output.shape().rank()));
+      torch::lazy::GetCanonicalDimensionIndex(dim, grad_output.shape().rank()));
 }
 
 NodePtr SoftmaxBackwardOp(const Value& grad_output, const Value& output,
                           xla::int64_t dim) {
   return MakeNode<SoftmaxBackward>(
       grad_output, output,
-      XlaHelpers::GetCanonicalDimensionIndex(dim, grad_output.shape().rank()));
+      torch::lazy::GetCanonicalDimensionIndex(dim, grad_output.shape().rank()));
 }
 
 NodePtr Clamp(const Value& input, const Value& min, const Value& max) {

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -26,6 +26,7 @@
 #include "tensorflow/core/profiler/lib/traceme.h"
 #include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/lazy/core/hash.h"
+#include "torch/csrc/lazy/core/helpers.h"
 #include "torch/csrc/lazy/core/tensor_util.h"
 #include "torch_xla/csrc/debug_util.h"
 #include "torch_xla/csrc/helpers.h"
@@ -494,7 +495,7 @@ XLATensor::Data* XLATensor::data() const {
 xla::int64_t XLATensor::size(xla::int64_t dim) const {
   auto xla_shape = shape();
   int rank = xla_shape.get().rank();
-  int dim_index = XlaHelpers::GetCanonicalDimensionIndex(dim, rank);
+  int dim_index = torch::lazy::GetCanonicalDimensionIndex(dim, rank);
   return xla_shape.get().dimensions(dim_index);
 }
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -11,6 +11,7 @@
 #include "tensorflow/compiler/xla/xla_client/util.h"
 #include "tensorflow/compiler/xla/xla_client/xla_util.h"
 #include "torch/csrc/autograd/variable.h"
+#include "torch/csrc/lazy/core/helpers.h"
 #include "torch_xla/csrc/aten_xla_bridge.h"
 #include "torch_xla/csrc/data_ops.h"
 #include "torch_xla/csrc/helpers.h"
@@ -677,32 +678,35 @@ XLATensor XLATensor::all(const XLATensor& input,
   at::ScalarType result_type = input.dtype() == at::ScalarType::Byte
                                    ? at::ScalarType::Byte
                                    : at::ScalarType::Bool;
-  return input.CreateFrom(
-      ir::MakeNode<ir::ops::All>(input.GetIrValue(),
-                                 XlaHelpers::GetCanonicalDimensionIndices(
-                                     dimensions, input.shape().get().rank()),
-                                 keep_reduced_dimensions),
-      result_type);
+  return input.CreateFrom(ir::MakeNode<ir::ops::All>(
+                              input.GetIrValue(),
+                              torch::lazy::GetCanonicalDimensionIndices(
+                                  xla::util::ToVector<xla::int64_t>(dimensions),
+                                  input.shape().get().rank()),
+                              keep_reduced_dimensions),
+                          result_type);
 }
 
 XLATensor XLATensor::amax(const XLATensor& input,
                           std::vector<xla::int64_t> dimensions,
                           bool keep_reduced_dimensions) {
-  return input.CreateFrom(
-      ir::MakeNode<ir::ops::Amax>(input.GetIrValue(),
-                                  XlaHelpers::GetCanonicalDimensionIndices(
-                                      dimensions, input.shape().get().rank()),
-                                  keep_reduced_dimensions));
+  return input.CreateFrom(ir::MakeNode<ir::ops::Amax>(
+      input.GetIrValue(),
+      torch::lazy::GetCanonicalDimensionIndices(
+          xla::util::ToVector<xla::int64_t>(dimensions),
+          input.shape().get().rank()),
+      keep_reduced_dimensions));
 }
 
 XLATensor XLATensor::amin(const XLATensor& input,
                           std::vector<xla::int64_t> dimensions,
                           bool keep_reduced_dimensions) {
-  return input.CreateFrom(
-      ir::MakeNode<ir::ops::Amin>(input.GetIrValue(),
-                                  XlaHelpers::GetCanonicalDimensionIndices(
-                                      dimensions, input.shape().get().rank()),
-                                  keep_reduced_dimensions));
+  return input.CreateFrom(ir::MakeNode<ir::ops::Amin>(
+      input.GetIrValue(),
+      torch::lazy::GetCanonicalDimensionIndices(
+          xla::util::ToVector<xla::int64_t>(dimensions),
+          input.shape().get().rank()),
+      keep_reduced_dimensions));
 }
 
 XLATensor XLATensor::any(const XLATensor& input,
@@ -711,12 +715,13 @@ XLATensor XLATensor::any(const XLATensor& input,
   at::ScalarType result_type = input.dtype() == at::ScalarType::Byte
                                    ? at::ScalarType::Byte
                                    : at::ScalarType::Bool;
-  return input.CreateFrom(
-      ir::MakeNode<ir::ops::Any>(input.GetIrValue(),
-                                 XlaHelpers::GetCanonicalDimensionIndices(
-                                     dimensions, input.shape().get().rank()),
-                                 keep_reduced_dimensions),
-      result_type);
+  return input.CreateFrom(ir::MakeNode<ir::ops::Any>(
+                              input.GetIrValue(),
+                              torch::lazy::GetCanonicalDimensionIndices(
+                                  xla::util::ToVector<xla::int64_t>(dimensions),
+                                  input.shape().get().rank()),
+                              keep_reduced_dimensions),
+                          result_type);
 }
 
 void XLATensor::arange_out(XLATensor& out, const at::Scalar& start,
@@ -729,7 +734,7 @@ void XLATensor::arange_out(XLATensor& out, const at::Scalar& start,
 XLATensor XLATensor::argmax(const XLATensor& input, xla::int64_t dim,
                             bool keepdim) {
   xla::int64_t canonical_dim =
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
+      torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   return input.CreateFrom(
       ir::MakeNode<ir::ops::ArgMax>(input.GetIrValue(), canonical_dim, keepdim),
       at::ScalarType::Long);
@@ -744,7 +749,7 @@ XLATensor XLATensor::argmax(const XLATensor& input) {
 XLATensor XLATensor::argmin(const XLATensor& input, xla::int64_t dim,
                             bool keepdim) {
   xla::int64_t canonical_dim =
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
+      torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   return input.CreateFrom(
       ir::MakeNode<ir::ops::ArgMin>(input.GetIrValue(), canonical_dim, keepdim),
       at::ScalarType::Long);
@@ -967,7 +972,7 @@ XLATensor XLATensor::cat(absl::Span<const XLATensor> tensors,
     if (tensor_shape.rank() == 1 && tensor_shape.dimensions()[0] == 0) {
       continue;
     }
-    dim = XlaHelpers::GetCanonicalDimensionIndex(dim, tensor_shape.rank());
+    dim = torch::lazy::GetCanonicalDimensionIndex(dim, tensor_shape.rank());
     tensor_shape.DeleteDimension(dim);
     if (!shapes.empty()) {
       XLA_CHECK(xla::ShapeUtil::Compatible(shapes.back(), tensor_shape))
@@ -1101,7 +1106,7 @@ XLATensor XLATensor::cross(const XLATensor& input, const XLATensor& other,
 XLATensor XLATensor::cumprod(const XLATensor& input, xla::int64_t dim,
                              c10::optional<at::ScalarType> dtype) {
   xla::int64_t canonical_dim =
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
+      torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   if (!dtype) {
     dtype = input.dtype_optional();
   }
@@ -1113,7 +1118,7 @@ XLATensor XLATensor::cumprod(const XLATensor& input, xla::int64_t dim,
 XLATensor XLATensor::cumsum(const XLATensor& input, xla::int64_t dim,
                             c10::optional<at::ScalarType> dtype) {
   xla::int64_t canonical_dim =
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
+      torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   if (!dtype) {
     dtype = input.dtype_optional();
   }
@@ -1136,9 +1141,9 @@ XLATensor XLATensor::diagonal(const XLATensor& input, xla::int64_t offset,
                               xla::int64_t dim1, xla::int64_t dim2) {
   auto input_shape = input.shape();
   xla::int64_t canonical_dim1 =
-      XlaHelpers::GetCanonicalDimensionIndex(dim1, input.shape().get().rank());
+      torch::lazy::GetCanonicalDimensionIndex(dim1, input.shape().get().rank());
   xla::int64_t canonical_dim2 =
-      XlaHelpers::GetCanonicalDimensionIndex(dim2, input.shape().get().rank());
+      torch::lazy::GetCanonicalDimensionIndex(dim2, input.shape().get().rank());
   DiagonalInfo diagonal_info;
   diagonal_info.offset = offset;
   diagonal_info.dim1 = canonical_dim1;
@@ -1312,8 +1317,8 @@ void XLATensor::fill_(XLATensor& input, const at::Scalar& value) {
 
 XLATensor XLATensor::flip(const XLATensor& input,
                           absl::Span<const xla::int64_t> dims) {
-  auto dimensions = XlaHelpers::GetCanonicalDimensionIndices(
-      dims, input.shape().get().rank());
+  auto dimensions = torch::lazy::GetCanonicalDimensionIndices(
+      xla::util::ToVector<xla::int64_t>(dims), input.shape().get().rank());
   std::set<xla::int64_t> unique_dims(dimensions.begin(), dimensions.end());
   XLA_CHECK_EQ(unique_dims.size(), dimensions.size());
   return input.CreateFrom(
@@ -1371,7 +1376,7 @@ XLATensor XLATensor::gather(const XLATensor& input, xla::int64_t dim,
                             const XLATensor& index) {
   return input.CreateFrom(ir::MakeNode<ir::ops::Gather>(
       input.GetIrValue(),
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank()),
+      torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank()),
       index.GetIrValue()));
 }
 
@@ -1418,7 +1423,7 @@ XLATensor XLATensor::index_add(const XLATensor& input, xla::int64_t dim,
       alpha, source.shape().get().element_type(), input.GetDevice());
   auto scaled_source = input.CreateFrom(source.GetIrValue() * constant);
   xla::int64_t canonical_dim =
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
+      torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   return input.CreateFrom(IndexAdd(input, canonical_dim, index, scaled_source));
 }
 
@@ -1426,14 +1431,14 @@ XLATensor XLATensor::index_copy(const XLATensor& input, xla::int64_t dim,
                                 const XLATensor& index,
                                 const XLATensor& source) {
   xla::int64_t canonical_dim =
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
+      torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   return input.CreateFrom(IndexCopy(input, canonical_dim, index, source));
 }
 
 void XLATensor::index_copy_(XLATensor& input, xla::int64_t dim,
                             const XLATensor& index, const XLATensor& source) {
   xla::int64_t canonical_dim =
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
+      torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   input.SetIrValue(IndexCopy(input, canonical_dim, index, source));
 }
 
@@ -1441,7 +1446,7 @@ XLATensor XLATensor::index_fill(const XLATensor& input, xla::int64_t dim,
                                 const XLATensor& index,
                                 const at::Scalar& value) {
   xla::int64_t canonical_dim =
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
+      torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   return input.CreateFrom(IndexFill(input, canonical_dim, index, value));
 }
 
@@ -1449,21 +1454,21 @@ XLATensor XLATensor::index_fill(const XLATensor& input, xla::int64_t dim,
                                 const XLATensor& index,
                                 const XLATensor& value) {
   xla::int64_t canonical_dim =
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
+      torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   return input.CreateFrom(IndexFill(input, canonical_dim, index, value));
 }
 
 void XLATensor::index_fill_(XLATensor& input, xla::int64_t dim,
                             const XLATensor& index, const XLATensor& value) {
   xla::int64_t canonical_dim =
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
+      torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   input.SetIrValue(IndexFill(input, canonical_dim, index, value));
 }
 
 void XLATensor::index_fill_(XLATensor& input, xla::int64_t dim,
                             const XLATensor& index, const at::Scalar& value) {
   xla::int64_t canonical_dim =
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
+      torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   input.SetIrValue(IndexFill(input, canonical_dim, index, value));
 }
 
@@ -1489,7 +1494,7 @@ XLATensor XLATensor::index_select(const XLATensor& input, xla::int64_t dim,
   ir::Value index_value = EnsureRank1(index.GetIrValue());
   return input.CreateFrom(ir::MakeNode<ir::ops::IndexSelect>(
       input.GetIrValue(),
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank()),
+      torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank()),
       index_value));
 }
 
@@ -1517,7 +1522,7 @@ std::tuple<XLATensor, XLATensor> XLATensor::kthvalue(const XLATensor& input,
                                                      bool keepdim) {
   ir::NodePtr node = ir::MakeNode<ir::ops::KthValue>(
       input.GetIrValue(), k,
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank()),
+      torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank()),
       keepdim);
   return std::make_tuple(
       input.CreateFrom(ir::Value(node, 0)),
@@ -1652,7 +1657,7 @@ XLATensor XLATensor::log_softmax(const XLATensor& input, xla::int64_t dim,
   }
   return input.CreateFrom(
       ir::MakeNode<ir::ops::LogSoftmax>(input.GetIrValue(),
-                                        XlaHelpers::GetCanonicalDimensionIndex(
+                                        torch::lazy::GetCanonicalDimensionIndex(
                                             dim, input.shape().get().rank()),
                                         dtype),
       dtype);
@@ -1714,8 +1719,9 @@ XLATensor XLATensor::logsumexp(const XLATensor& input,
                                bool keep_reduced_dimensions) {
   return input.CreateFrom(ir::MakeNode<ir::ops::Logsumexp>(
       input.GetIrValue(),
-      XlaHelpers::GetCanonicalDimensionIndices(dimensions,
-                                               input.shape().get().rank()),
+      torch::lazy::GetCanonicalDimensionIndices(
+          xla::util::ToVector<xla::int64_t>(dimensions),
+          input.shape().get().rank()),
       keep_reduced_dimensions));
 }
 
@@ -1780,7 +1786,7 @@ std::tuple<XLATensor, XLATensor> XLATensor::max(const XLATensor& input,
                                                 xla::int64_t dim,
                                                 bool keepdim) {
   xla::int64_t canonical_dim =
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
+      torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   ir::NodePtr node = ir::MakeNode<ir::ops::MaxInDim>(input.GetIrValue(),
                                                      canonical_dim, keepdim);
   return std::make_tuple(
@@ -1792,7 +1798,7 @@ void XLATensor::max_out(XLATensor& max, XLATensor& max_values,
                         const XLATensor& input, xla::int64_t dim,
                         bool keepdim) {
   xla::int64_t canonical_dim =
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
+      torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   ir::NodePtr node = ir::MakeNode<ir::ops::MaxInDim>(input.GetIrValue(),
                                                      canonical_dim, keepdim);
   max.SetIrValue(ir::Value(node, 0));
@@ -1852,12 +1858,13 @@ XLATensor XLATensor::mean(const XLATensor& input,
   if (!dtype) {
     dtype = input.dtype_optional();
   }
-  return input.CreateFrom(
-      ir::MakeNode<ir::ops::Mean>(input.GetIrValue(),
-                                  XlaHelpers::GetCanonicalDimensionIndices(
-                                      dimensions, input.shape().get().rank()),
-                                  keep_reduced_dimensions, dtype),
-      dtype);
+  return input.CreateFrom(ir::MakeNode<ir::ops::Mean>(
+                              input.GetIrValue(),
+                              torch::lazy::GetCanonicalDimensionIndices(
+                                  xla::util::ToVector<xla::int64_t>(dimensions),
+                                  input.shape().get().rank()),
+                              keep_reduced_dimensions, dtype),
+                          dtype);
 }
 
 XLATensor XLATensor::min(const XLATensor& input, const XLATensor& other,
@@ -1874,7 +1881,7 @@ std::tuple<XLATensor, XLATensor> XLATensor::min(const XLATensor& input,
                                                 xla::int64_t dim,
                                                 bool keepdim) {
   xla::int64_t canonical_dim =
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
+      torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   ir::NodePtr node = ir::MakeNode<ir::ops::MinInDim>(input.GetIrValue(),
                                                      canonical_dim, keepdim);
   return std::make_tuple(
@@ -1886,7 +1893,7 @@ void XLATensor::min_out(XLATensor& min, XLATensor& min_indices,
                         const XLATensor& input, xla::int64_t dim,
                         bool keepdim) {
   xla::int64_t canonical_dim =
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
+      torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   ir::NodePtr node = ir::MakeNode<ir::ops::MinInDim>(input.GetIrValue(),
                                                      canonical_dim, keepdim);
   min.SetIrValue(ir::Value(node, 0));
@@ -1957,7 +1964,7 @@ XLATensor XLATensor::nan_to_num(const XLATensor& input, const at::Scalar& nan,
 XLATensor XLATensor::narrow(const XLATensor& input, xla::int64_t dim,
                             xla::int64_t start, xla::int64_t length) {
   auto input_shape = input.shape();
-  dim = XlaHelpers::GetCanonicalDimensionIndex(dim, input_shape.get().rank());
+  dim = torch::lazy::GetCanonicalDimensionIndex(dim, input_shape.get().rank());
   xla::Shape narrow_shape = input_shape;
   narrow_shape.set_dimensions(dim, length);
 
@@ -1966,8 +1973,9 @@ XLATensor XLATensor::narrow(const XLATensor& input, xla::int64_t dim,
                                  ? ViewInfo::Type::kReshape
                                  : ViewInfo::Type::kNarrow;
   ViewInfo view_info(view_type, std::move(narrow_shape), input_shape);
-  view_info.indices[dim] = XlaHelpers::GetCanonicalPosition(
-      input_shape.get().dimensions(), dim, start);
+  view_info.indices[dim] = torch::lazy::GetCanonicalPosition(
+      xla::util::ToVector<xla::int64_t>(input_shape.get().dimensions()), dim,
+      start);
   return input.CreateViewTensor(std::move(view_info));
 }
 
@@ -2102,7 +2110,7 @@ XLATensor XLATensor::norm(const XLATensor& input,
                           const c10::optional<at::Scalar>& p,
                           c10::optional<at::ScalarType> dtype,
                           at::IntArrayRef dim, bool keepdim) {
-  auto canonical_dims = XlaHelpers::GetCanonicalDimensionIndices(
+  auto canonical_dims = torch::lazy::GetCanonicalDimensionIndices(
       XlaHelpers::I64List(dim), input.shape().get().rank());
   if (!dtype) {
     dtype = input.dtype_optional();
@@ -2149,7 +2157,8 @@ XLATensor XLATensor::permute(const XLATensor& input,
   auto input_shape = input.shape();
   ViewInfo view_info(
       ViewInfo::Type::kPermute, input_shape,
-      XlaHelpers::GetCanonicalDimensionIndices(dims, input_shape.get().rank()));
+      torch::lazy::GetCanonicalDimensionIndices(
+          xla::util::ToVector<xla::int64_t>(dims), input_shape.get().rank()));
   return input.CreateViewTensor(std::move(view_info));
 }
 
@@ -2183,12 +2192,13 @@ XLATensor XLATensor::prod(const XLATensor& input,
   if (!dtype) {
     dtype = input.dtype_optional();
   }
-  return input.CreateFrom(
-      ir::MakeNode<ir::ops::Prod>(input.GetIrValue(),
-                                  XlaHelpers::GetCanonicalDimensionIndices(
-                                      dimensions, input.shape().get().rank()),
-                                  keep_reduced_dimensions, dtype),
-      dtype);
+  return input.CreateFrom(ir::MakeNode<ir::ops::Prod>(
+                              input.GetIrValue(),
+                              torch::lazy::GetCanonicalDimensionIndices(
+                                  xla::util::ToVector<xla::int64_t>(dimensions),
+                                  input.shape().get().rank()),
+                              keep_reduced_dimensions, dtype),
+                          dtype);
 }
 
 void XLATensor::put_(XLATensor& input, const XLATensor& index,
@@ -2370,7 +2380,8 @@ XLATensor XLATensor::scatter(const XLATensor& input, xla::int64_t dim,
                              const XLATensor& index, const XLATensor& src) {
   return input.CreateFrom(ir::MakeNode<ir::ops::Scatter>(
       input.GetIrValue(), index.GetIrValue(), src.GetIrValue(),
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank())));
+      torch::lazy::GetCanonicalDimensionIndex(dim,
+                                              input.shape().get().rank())));
 }
 
 XLATensor XLATensor::scatter(const XLATensor& input, xla::int64_t dim,
@@ -2379,14 +2390,16 @@ XLATensor XLATensor::scatter(const XLATensor& input, xla::int64_t dim,
       GetIrValueForScalar(value, input.shape(), input.GetDevice());
   return input.CreateFrom(ir::MakeNode<ir::ops::Scatter>(
       input.GetIrValue(), index.GetIrValue(), constant,
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank())));
+      torch::lazy::GetCanonicalDimensionIndex(dim,
+                                              input.shape().get().rank())));
 }
 
 XLATensor XLATensor::scatter_add(const XLATensor& input, xla::int64_t dim,
                                  const XLATensor& index, const XLATensor& src) {
   return input.CreateFrom(ir::MakeNode<ir::ops::ScatterAdd>(
       input.GetIrValue(), index.GetIrValue(), src.GetIrValue(),
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank())));
+      torch::lazy::GetCanonicalDimensionIndex(dim,
+                                              input.shape().get().rank())));
 }
 
 XLATensor XLATensor::scatter_add(const XLATensor& input, xla::int64_t dim,
@@ -2396,7 +2409,8 @@ XLATensor XLATensor::scatter_add(const XLATensor& input, xla::int64_t dim,
       GetIrValueForScalar(value, input.shape(), input.GetDevice());
   return input.CreateFrom(ir::MakeNode<ir::ops::ScatterAdd>(
       input.GetIrValue(), index.GetIrValue(), constant,
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank())));
+      torch::lazy::GetCanonicalDimensionIndex(dim,
+                                              input.shape().get().rank())));
 }
 
 XLATensor XLATensor::select(const XLATensor& input, xla::int64_t dim,
@@ -2443,11 +2457,13 @@ XLATensor XLATensor::slice(const XLATensor& input, xla::int64_t dim,
                            xla::int64_t start, xla::int64_t end,
                            xla::int64_t step) {
   auto input_shape = input.shape();
-  dim = XlaHelpers::GetCanonicalDimensionIndex(dim, input_shape.get().rank());
-  start = XlaHelpers::GetCanonicalPosition(input_shape.get().dimensions(), dim,
-                                           start);
-  end = XlaHelpers::GetCanonicalPosition(input_shape.get().dimensions(), dim,
-                                         end);
+  dim = torch::lazy::GetCanonicalDimensionIndex(dim, input_shape.get().rank());
+  start = torch::lazy::GetCanonicalPosition(
+      xla::util::ToVector<xla::int64_t>(input_shape.get().dimensions()), dim,
+      start);
+  end = torch::lazy::GetCanonicalPosition(
+      xla::util::ToVector<xla::int64_t>(input_shape.get().dimensions()), dim,
+      end);
   // PyTorch allows tensor[-1:0] to return a 0-dim tensor.
   if (start > end) {
     end = start;
@@ -2488,7 +2504,7 @@ XLATensor XLATensor::softmax(const XLATensor& input, xla::int64_t dim,
   }
   return input.CreateFrom(
       ir::MakeNode<ir::ops::Softmax>(input.GetIrValue(),
-                                     XlaHelpers::GetCanonicalDimensionIndex(
+                                     torch::lazy::GetCanonicalDimensionIndex(
                                          dim, input.shape().get().rank()),
                                      dtype),
       dtype);
@@ -2537,7 +2553,7 @@ std::vector<XLATensor> XLATensor::split(const XLATensor& input,
                                         xla::int64_t dim) {
   auto input_shape = input.shape();
   int split_dim =
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input_shape.get().rank());
+      torch::lazy::GetCanonicalDimensionIndex(dim, input_shape.get().rank());
   xla::int64_t dim_size = input_shape.get().dimensions(split_dim);
   if (dim_size == 0) {
     // Deal with dim_size=0, it's a corner case which only return 1 0-dim tensor
@@ -2560,7 +2576,7 @@ std::vector<XLATensor> XLATensor::split_with_sizes(
     xla::int64_t dim) {
   auto input_shape = input.shape();
   int split_dim =
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input_shape.get().rank());
+      torch::lazy::GetCanonicalDimensionIndex(dim, input_shape.get().rank());
   ir::NodePtr node = ir::MakeNode<ir::ops::Split>(
       input.GetIrValue(), std::move(split_size), split_dim);
   return input.MakeOutputTensors(node);
@@ -2580,7 +2596,7 @@ XLATensor XLATensor::squeeze(const XLATensor& input) {
 XLATensor XLATensor::squeeze(const XLATensor& input, xla::int64_t dim) {
   auto input_shape = input.shape();
   xla::int64_t squeeze_dim =
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
+      torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   auto output_dimensions =
       BuildSqueezedDimensions(input_shape.get().dimensions(), squeeze_dim);
   return view(input, output_dimensions);
@@ -2592,8 +2608,8 @@ void XLATensor::squeeze_(XLATensor& input) {
 
 void XLATensor::squeeze_(XLATensor& input, xla::int64_t dim) {
   input.SetIrValue(ir::MakeNode<ir::ops::Squeeze>(
-      input.GetIrValue(),
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank())));
+      input.GetIrValue(), torch::lazy::GetCanonicalDimensionIndex(
+                              dim, input.shape().get().rank())));
 }
 
 XLATensor XLATensor::stack(absl::Span<const XLATensor> tensors,
@@ -2603,7 +2619,7 @@ XLATensor XLATensor::stack(absl::Span<const XLATensor> tensors,
   for (auto& tensor : tensors) {
     values.push_back(tensor.GetIrValue());
   }
-  xla::int64_t canonical_dim = XlaHelpers::GetCanonicalDimensionIndex(
+  xla::int64_t canonical_dim = torch::lazy::GetCanonicalDimensionIndex(
       dim, tensors.front().shape().get().rank() + 1);
   return tensors[0].CreateFrom(
       ir::MakeNode<ir::ops::Stack>(values, canonical_dim));
@@ -2613,11 +2629,12 @@ XLATensor XLATensor::std(const XLATensor& input,
                          std::vector<xla::int64_t> dimensions,
                          bool keep_reduced_dimensions,
                          xla::int64_t correction) {
-  return input.CreateFrom(
-      ir::MakeNode<ir::ops::Std>(input.GetIrValue(),
-                                 XlaHelpers::GetCanonicalDimensionIndices(
-                                     dimensions, input.shape().get().rank()),
-                                 keep_reduced_dimensions, correction));
+  return input.CreateFrom(ir::MakeNode<ir::ops::Std>(
+      input.GetIrValue(),
+      torch::lazy::GetCanonicalDimensionIndices(
+          xla::util::ToVector<xla::int64_t>(dimensions),
+          input.shape().get().rank()),
+      keep_reduced_dimensions, correction));
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::std_mean(
@@ -2625,8 +2642,9 @@ std::tuple<XLATensor, XLATensor> XLATensor::std_mean(
     xla::int64_t correction, bool keep_reduced_dimensions) {
   ir::NodePtr node = ir::MakeNode<ir::ops::StdMean>(
       input.GetIrValue(),
-      XlaHelpers::GetCanonicalDimensionIndices(dimensions,
-                                               input.shape().get().rank()),
+      torch::lazy::GetCanonicalDimensionIndices(
+          xla::util::ToVector<xla::int64_t>(dimensions),
+          input.shape().get().rank()),
       correction, keep_reduced_dimensions);
   return std::make_tuple(input.CreateFrom(ir::Value(node, 0)),
                          input.CreateFrom(ir::Value(node, 1)));
@@ -2661,12 +2679,13 @@ XLATensor XLATensor::sum(const XLATensor& input,
   } else if (!dtype) {
     dtype = input.dtype_optional();
   }
-  return input.CreateFrom(
-      ir::MakeNode<ir::ops::Sum>(input.GetIrValue(),
-                                 XlaHelpers::GetCanonicalDimensionIndices(
-                                     dimensions, input.shape().get().rank()),
-                                 keep_reduced_dimensions, dtype),
-      dtype);
+  return input.CreateFrom(ir::MakeNode<ir::ops::Sum>(
+                              input.GetIrValue(),
+                              torch::lazy::GetCanonicalDimensionIndices(
+                                  xla::util::ToVector<xla::int64_t>(dimensions),
+                                  input.shape().get().rank()),
+                              keep_reduced_dimensions, dtype),
+                          dtype);
 }
 
 std::tuple<XLATensor, XLATensor, XLATensor> XLATensor::svd(
@@ -2746,7 +2765,7 @@ std::tuple<XLATensor, XLATensor> XLATensor::topk(const XLATensor& input,
                                                  bool sorted, bool stable) {
   ir::NodePtr node = ir::MakeNode<ir::ops::TopK>(
       input.GetIrValue(), k,
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank()),
+      torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank()),
       largest, sorted, stable);
   return std::make_tuple(
       input.CreateFrom(ir::Value(node, 0)),
@@ -2767,7 +2786,7 @@ XLATensor XLATensor::trace(const XLATensor& input) {
 XLATensor XLATensor::transpose(const XLATensor& input, xla::int64_t dim0,
                                xla::int64_t dim1) {
   auto input_shape = input.shape();
-  auto permute_dims = XlaHelpers::MakeTransposePermutation(
+  auto permute_dims = torch::lazy::MakeTransposePermutation(
       /*dim0=*/dim0, /*dim1=*/dim1, /*rank=*/input_shape.get().rank());
   ViewInfo view_info(ViewInfo::Type::kPermute, input_shape, permute_dims);
   return input.CreateViewTensor(std::move(view_info));
@@ -2776,7 +2795,7 @@ XLATensor XLATensor::transpose(const XLATensor& input, xla::int64_t dim0,
 void XLATensor::transpose_(XLATensor& input, xla::int64_t dim0,
                            xla::int64_t dim1) {
   auto input_shape = input.shape();
-  auto permute_dims = XlaHelpers::MakeTransposePermutation(
+  auto permute_dims = torch::lazy::MakeTransposePermutation(
       /*dim0=*/dim0, /*dim1=*/dim1, /*rank=*/input_shape.get().rank());
   ViewInfo view_info(ViewInfo::Type::kPermute, input_shape, permute_dims);
   return input.ModifyCurrentView(std::move(view_info));
@@ -2817,7 +2836,8 @@ XLATensor XLATensor::trunc(const XLATensor& input) {
 
 std::vector<XLATensor> XLATensor::unbind(const XLATensor& input,
                                          xla::int64_t dim) {
-  dim = XlaHelpers::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
+  dim =
+      torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   xla::int64_t dim_size = input.size(dim);
   std::vector<XLATensor> slices;
   slices.reserve(dim_size);
@@ -2840,15 +2860,15 @@ void XLATensor::uniform_(XLATensor& input, double from, double to) {
 
 XLATensor XLATensor::unsqueeze(const XLATensor& input, xla::int64_t dim) {
   auto input_shape = input.shape();
-  xla::int64_t squeeze_dim =
-      XlaHelpers::GetCanonicalDimensionIndex(dim, input_shape.get().rank() + 1);
+  xla::int64_t squeeze_dim = torch::lazy::GetCanonicalDimensionIndex(
+      dim, input_shape.get().rank() + 1);
   auto dimensions =
       BuildUnsqueezeDimensions(input_shape.get().dimensions(), squeeze_dim);
   return view(input, dimensions);
 }
 
 void XLATensor::unsqueeze_(XLATensor& input, xla::int64_t dim) {
-  int squeeze_dim = XlaHelpers::GetCanonicalDimensionIndex(
+  int squeeze_dim = torch::lazy::GetCanonicalDimensionIndex(
       dim, input.shape().get().rank() + 1);
   input.SetIrValue(
       ir::MakeNode<ir::ops::Unsqueeze>(input.GetIrValue(), squeeze_dim));
@@ -2897,11 +2917,12 @@ XLATensor XLATensor::var(const XLATensor& input,
                          std::vector<xla::int64_t> dimensions,
                          xla::int64_t correction,
                          bool keep_reduced_dimensions) {
-  return input.CreateFrom(
-      ir::MakeNode<ir::ops::Var>(input.GetIrValue(),
-                                 XlaHelpers::GetCanonicalDimensionIndices(
-                                     dimensions, input.shape().get().rank()),
-                                 correction, keep_reduced_dimensions));
+  return input.CreateFrom(ir::MakeNode<ir::ops::Var>(
+      input.GetIrValue(),
+      torch::lazy::GetCanonicalDimensionIndices(
+          xla::util::ToVector<xla::int64_t>(dimensions),
+          input.shape().get().rank()),
+      correction, keep_reduced_dimensions));
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::var_mean(
@@ -2909,8 +2930,9 @@ std::tuple<XLATensor, XLATensor> XLATensor::var_mean(
     xla::int64_t correction, bool keep_reduced_dimensions) {
   ir::NodePtr node = ir::MakeNode<ir::ops::VarMean>(
       input.GetIrValue(),
-      XlaHelpers::GetCanonicalDimensionIndices(dimensions,
-                                               input.shape().get().rank()),
+      torch::lazy::GetCanonicalDimensionIndices(
+          xla::util::ToVector<xla::int64_t>(dimensions),
+          input.shape().get().rank()),
       correction, keep_reduced_dimensions);
   return std::make_tuple(input.CreateFrom(ir::Value(node, 0)),
                          input.CreateFrom(ir::Value(node, 1)));

--- a/torch_xla/csrc/tensor_ops.cpp
+++ b/torch_xla/csrc/tensor_ops.cpp
@@ -2,6 +2,7 @@
 
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch/csrc/lazy/core/helpers.h"
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/ir.h"
 
@@ -24,7 +25,7 @@ XLATensor Cross(const XLATensor& input, const XLATensor& other,
                 c10::optional<xla::int64_t> dim) {
   xla::int64_t canonical_dim;
   if (dim) {
-    canonical_dim = XlaHelpers::GetCanonicalDimensionIndex(
+    canonical_dim = torch::lazy::GetCanonicalDimensionIndex(
         *dim, input.shape().get().rank());
   } else {
     auto input_shape_ref = input.shape();
@@ -195,9 +196,11 @@ XLATensor SoftplusBackward(const XLATensor& grad_output, const XLATensor& input,
 
 XLATensor Select(const XLATensor& input, xla::int64_t dim, xla::int64_t index) {
   auto shape = input.shape();
-  dim = XlaHelpers::GetCanonicalDimensionIndex(dim, shape.get().rank());
+  dim = torch::lazy::GetCanonicalDimensionIndex(dim, shape.get().rank());
   XLATensor result = XLATensor::narrow(input, dim, index, 1);
-  auto new_dims = XlaHelpers::DropDimensions(shape.get().dimensions(), {dim});
+  auto new_dims = torch::lazy::DropDimensions(
+      xla::util::ToVector<xla::int64_t>(shape.get().dimensions()),
+      std::vector<xla::int64_t>({dim}));
   return XLATensor::view(result, new_dims);
 }
 

--- a/torch_xla/csrc/xla_lower_util.cpp
+++ b/torch_xla/csrc/xla_lower_util.cpp
@@ -12,6 +12,7 @@
 #include "tensorflow/compiler/xla/util.h"
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch/csrc/lazy/core/helpers.h"
 #include "torch_xla/csrc/convert_ops.h"
 #include "torch_xla/csrc/data_ops.h"
 #include "torch_xla/csrc/helpers.h"
@@ -338,7 +339,9 @@ std::vector<xla::XlaOp> CreateKthValue(xla::XlaOp input, xla::int64_t k,
   xla::XlaOp indices = xla::Slice(xla::GetTupleElement(sort_result, 1),
                                   start_indices, limit_indices, strides);
   if (!keepdim) {
-    auto reshape_sizes = XlaHelpers::DropDimensions(shape.dimensions(), {dim});
+    auto reshape_sizes = torch::lazy::DropDimensions(
+        xla::util::ToVector<xla::int64_t>(shape.dimensions()),
+        std::vector<xla::int64_t>({dim}));
     values = XlaHelpers::DynamicReshape(values, reshape_sizes);
     indices = XlaHelpers::DynamicReshape(indices, reshape_sizes);
   }


### PR DESCRIPTION
[LTC, Phase 1] Migrate to upstream torch::lazy::helpers.h functions

Migrated helper functions include:
- DropDimensions
- GetCanonicalDimensionIndex
- GetCanonicalDimensionIndices
- GetCanonicalPosition
- MakeTransposePermutation
- GetCanonicalPosition
- MakeTransposePermutation
- GetPromotedShape