### PR TITLE
Migrate to upstream util functions

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -624,8 +624,7 @@ at::Tensor XLANativeFunctions::all(const at::Tensor& self) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(XLATensor::all(
-      self_tensor,
-      torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
+      self_tensor, torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
       /*keep_reduced_dimensions=*/false));
 }
 
@@ -656,8 +655,7 @@ at::Tensor XLANativeFunctions::any(const at::Tensor& self) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(XLATensor::any(
-      self_tensor,
-      torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
+      self_tensor, torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
       /*keep_reduced_dimensions=*/false));
 }
 
@@ -2117,8 +2115,7 @@ at::Tensor XLANativeFunctions::mean(const at::Tensor& self,
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(XLATensor::mean(
-      self_tensor,
-      torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
+      self_tensor, torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
       /*keep_reduced_dimensions=*/false, dtype));
 }
 
@@ -2617,8 +2614,7 @@ at::Tensor XLANativeFunctions::prod(const at::Tensor& self,
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(XLATensor::prod(
-      self_tensor,
-      torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
+      self_tensor, torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
       /*keep_reduced_dimensions=*/false,
       PromoteIntegralType(self.scalar_type(), dtype)));
 }
@@ -2713,8 +2709,7 @@ at::Tensor XLANativeFunctions::reflection_pad2d(const at::Tensor& self,
                                                 at::IntArrayRef padding) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::reflection_pad2d(
-      bridge::GetXlaTensor(self),
-      torch::lazy::ToVector<int64_t>(padding)));
+      bridge::GetXlaTensor(self), torch::lazy::ToVector<int64_t>(padding)));
 }
 
 at::Tensor XLANativeFunctions::reflection_pad2d_backward(
@@ -3150,18 +3145,16 @@ at::Tensor XLANativeFunctions::std(const at::Tensor& self, bool unbiased) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(XLATensor::std(
-      self_tensor,
-      torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
+      self_tensor, torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
       /*keep_reduced_dimensions=*/false, /*correction=*/unbiased ? 1 : 0));
 }
 
 at::Tensor XLANativeFunctions::std(const at::Tensor& self, at::IntArrayRef dim,
                                    bool unbiased, bool keepdim) {
   XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(
-      XLATensor::std(bridge::GetXlaTensor(self),
-                     torch::lazy::ToVector<int64_t>(dim), keepdim,
-                     /*correction=*/unbiased ? 1 : 0));
+  return bridge::AtenFromXlaTensor(XLATensor::std(
+      bridge::GetXlaTensor(self), torch::lazy::ToVector<int64_t>(dim), keepdim,
+      /*correction=*/unbiased ? 1 : 0));
 }
 
 at::Tensor XLANativeFunctions::std(const at::Tensor& self,
@@ -3221,8 +3214,7 @@ at::Tensor XLANativeFunctions::sum(const at::Tensor& self,
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(XLATensor::sum(
-      self_tensor,
-      torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
+      self_tensor, torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
       /*keep_reduced_dimensions=*/false, dtype));
 }
 
@@ -3433,8 +3425,7 @@ at::Tensor XLANativeFunctions::upsample_bilinear2d(
                                                                scales_w);
   }
   return bridge::AtenFromXlaTensor(XLATensor::upsample_bilinear2d(
-      self_tensor, torch::lazy::ToVector<int64_t>(output_size),
-      align_corners));
+      self_tensor, torch::lazy::ToVector<int64_t>(output_size), align_corners));
 }
 
 at::Tensor XLANativeFunctions::upsample_bilinear2d_backward(
@@ -3494,8 +3485,7 @@ at::Tensor XLANativeFunctions::upsample_nearest2d_backward(
                                                              input_size,
                                                              scale_factors);
   }
-  std::vector<int64_t> input_dim =
-      torch::lazy::ToVector<int64_t>(input_size);
+  std::vector<int64_t> input_dim = torch::lazy::ToVector<int64_t>(input_size);
   return bridge::AtenFromXlaTensor(XLATensor::upsample_nearest2d_backward(
       grad_output_tensor,
       GetOutputSizeWithScale(input_dim, scale_factors, output_size),

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -10,6 +10,7 @@
 #include "tensorflow/compiler/xla/xla_client/sys_util.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
 #include "torch/csrc/lazy/core/tensor_util.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/XLANativeFunctions.h"
 #include "torch_xla/csrc/aten_autograd_ops.h"
 #include "torch_xla/csrc/aten_cpu_fallback.h"
@@ -144,7 +145,7 @@ std::vector<int64_t> GetOutputSizeWithScale(
     return {output_h, output_w};
   }
   XLA_CHECK(!scale_factors);
-  return xla::util::ToVector<int64_t>(*output_size);
+  return torch::lazy::ToVector<int64_t>(*output_size);
 }
 
 void CheckBinaryOpTypePromotion(const at::Tensor& out, const at::Tensor& self,
@@ -623,7 +624,8 @@ at::Tensor XLANativeFunctions::all(const at::Tensor& self) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(XLATensor::all(
-      self_tensor, xla::util::Iota<int64_t>(self_tensor.shape().get().rank()),
+      self_tensor,
+      torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
       /*keep_reduced_dimensions=*/false));
 }
 
@@ -654,7 +656,8 @@ at::Tensor XLANativeFunctions::any(const at::Tensor& self) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(XLATensor::any(
-      self_tensor, xla::util::Iota<int64_t>(self_tensor.shape().get().rank()),
+      self_tensor,
+      torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
       /*keep_reduced_dimensions=*/false));
 }
 
@@ -1391,7 +1394,7 @@ at::Tensor XLANativeFunctions::expand(const at::Tensor& self,
                                       at::IntArrayRef size, bool implicit) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::expand(
-      bridge::GetXlaTensor(self), xla::util::ToVector<int64_t>(size)));
+      bridge::GetXlaTensor(self), torch::lazy::ToVector<int64_t>(size)));
 }
 
 at::Tensor XLANativeFunctions::expm1(const at::Tensor& self) {
@@ -1857,7 +1860,7 @@ at::Tensor XLANativeFunctions::logsumexp(const at::Tensor& self,
                                          at::IntArrayRef dim, bool keepdim) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::logsumexp(
-      bridge::GetXlaTensor(self), xla::util::ToVector<int64_t>(dim),
+      bridge::GetXlaTensor(self), torch::lazy::ToVector<int64_t>(dim),
       /*keep_reduced_dimensions=*/keepdim));
 }
 
@@ -2074,7 +2077,7 @@ at::Tensor XLANativeFunctions::max_unpool2d(const at::Tensor& self,
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::max_unpool(
       bridge::GetXlaTensor(self), bridge::GetXlaTensor(indices),
-      xla::util::ToVector<int64_t>(output_size)));
+      torch::lazy::ToVector<int64_t>(output_size)));
 }
 
 at::Tensor XLANativeFunctions::max_unpool2d_backward(
@@ -2084,7 +2087,7 @@ at::Tensor XLANativeFunctions::max_unpool2d_backward(
   return bridge::AtenFromXlaTensor(XLATensor::max_unpool_backward(
       bridge::GetXlaTensor(grad_output), bridge::GetXlaTensor(self),
       bridge::GetXlaTensor(indices),
-      xla::util::ToVector<int64_t>(output_size)));
+      torch::lazy::ToVector<int64_t>(output_size)));
 }
 
 at::Tensor XLANativeFunctions::max_unpool3d(const at::Tensor& self,
@@ -2095,7 +2098,7 @@ at::Tensor XLANativeFunctions::max_unpool3d(const at::Tensor& self,
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::max_unpool(
       bridge::GetXlaTensor(self), bridge::GetXlaTensor(indices),
-      xla::util::ToVector<int64_t>(output_size)));
+      torch::lazy::ToVector<int64_t>(output_size)));
 }
 
 at::Tensor XLANativeFunctions::max_unpool3d_backward(
@@ -2106,7 +2109,7 @@ at::Tensor XLANativeFunctions::max_unpool3d_backward(
   return bridge::AtenFromXlaTensor(XLATensor::max_unpool_backward(
       bridge::GetXlaTensor(grad_output), bridge::GetXlaTensor(self),
       bridge::GetXlaTensor(indices),
-      xla::util::ToVector<int64_t>(output_size)));
+      torch::lazy::ToVector<int64_t>(output_size)));
 }
 
 at::Tensor XLANativeFunctions::mean(const at::Tensor& self,
@@ -2114,7 +2117,8 @@ at::Tensor XLANativeFunctions::mean(const at::Tensor& self,
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(XLATensor::mean(
-      self_tensor, xla::util::Iota<int64_t>(self_tensor.shape().get().rank()),
+      self_tensor,
+      torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
       /*keep_reduced_dimensions=*/false, dtype));
 }
 
@@ -2123,7 +2127,7 @@ at::Tensor XLANativeFunctions::mean(const at::Tensor& self, at::IntArrayRef dim,
                                     c10::optional<at::ScalarType> dtype) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::mean(
-      bridge::GetXlaTensor(self), xla::util::ToVector<int64_t>(dim),
+      bridge::GetXlaTensor(self), torch::lazy::ToVector<int64_t>(dim),
       /*keep_reduced_dimensions=*/keepdim, dtype));
 }
 
@@ -2613,7 +2617,8 @@ at::Tensor XLANativeFunctions::prod(const at::Tensor& self,
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(XLATensor::prod(
-      self_tensor, xla::util::Iota<int64_t>(self_tensor.shape().get().rank()),
+      self_tensor,
+      torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
       /*keep_reduced_dimensions=*/false,
       PromoteIntegralType(self.scalar_type(), dtype)));
 }
@@ -2708,7 +2713,8 @@ at::Tensor XLANativeFunctions::reflection_pad2d(const at::Tensor& self,
                                                 at::IntArrayRef padding) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::reflection_pad2d(
-      bridge::GetXlaTensor(self), xla::util::ToVector<int64_t>(padding)));
+      bridge::GetXlaTensor(self),
+      torch::lazy::ToVector<int64_t>(padding)));
 }
 
 at::Tensor XLANativeFunctions::reflection_pad2d_backward(
@@ -2717,7 +2723,7 @@ at::Tensor XLANativeFunctions::reflection_pad2d_backward(
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::reflection_pad2d_backward(
       bridge::GetXlaTensor(grad_output), bridge::GetXlaTensor(self),
-      xla::util::ToVector<int64_t>(padding)));
+      torch::lazy::ToVector<int64_t>(padding)));
 }
 
 at::Tensor XLANativeFunctions::relu(const at::Tensor& self) {
@@ -3144,16 +3150,18 @@ at::Tensor XLANativeFunctions::std(const at::Tensor& self, bool unbiased) {
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(XLATensor::std(
-      self_tensor, xla::util::Iota<int64_t>(self_tensor.shape().get().rank()),
+      self_tensor,
+      torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
       /*keep_reduced_dimensions=*/false, /*correction=*/unbiased ? 1 : 0));
 }
 
 at::Tensor XLANativeFunctions::std(const at::Tensor& self, at::IntArrayRef dim,
                                    bool unbiased, bool keepdim) {
   XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(XLATensor::std(
-      bridge::GetXlaTensor(self), xla::util::ToVector<int64_t>(dim), keepdim,
-      /*correction=*/unbiased ? 1 : 0));
+  return bridge::AtenFromXlaTensor(
+      XLATensor::std(bridge::GetXlaTensor(self),
+                     torch::lazy::ToVector<int64_t>(dim), keepdim,
+                     /*correction=*/unbiased ? 1 : 0));
 }
 
 at::Tensor XLANativeFunctions::std(const at::Tensor& self,
@@ -3164,8 +3172,8 @@ at::Tensor XLANativeFunctions::std(const at::Tensor& self,
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(XLATensor::std(
       self_tensor,
-      dim ? xla::util::ToVector<int64_t>(*dim)
-          : xla::util::Iota<int64_t>(self_tensor.shape().get().rank()),
+      dim ? torch::lazy::ToVector<int64_t>(*dim)
+          : torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
       keepdim, correction ? *correction : 1));
 }
 
@@ -3176,8 +3184,8 @@ std::tuple<at::Tensor, at::Tensor> XLANativeFunctions::std_mean(
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   auto results = XLATensor::std_mean(
       self_tensor,
-      dim ? xla::util::ToVector<int64_t>(*dim)
-          : xla::util::Iota<int64_t>(self_tensor.shape().get().rank()),
+      dim ? torch::lazy::ToVector<int64_t>(*dim)
+          : torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
       correction ? *correction : 1, keepdim);
   return std::make_tuple(bridge::AtenFromXlaTensor(std::get<0>(results)),
                          bridge::AtenFromXlaTensor(std::get<1>(results)));
@@ -3213,7 +3221,8 @@ at::Tensor XLANativeFunctions::sum(const at::Tensor& self,
   XLA_FN_COUNTER("xla::");
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(XLATensor::sum(
-      self_tensor, xla::util::Iota<int64_t>(self_tensor.shape().get().rank()),
+      self_tensor,
+      torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
       /*keep_reduced_dimensions=*/false, dtype));
 }
 
@@ -3223,7 +3232,7 @@ at::Tensor XLANativeFunctions::sum(const at::Tensor& self, at::IntArrayRef dim,
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
       XLATensor::sum(bridge::GetXlaTensor(self),
-                     xla::util::ToVector<int64_t>(dim), keepdim, dtype));
+                     torch::lazy::ToVector<int64_t>(dim), keepdim, dtype));
 }
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor> XLANativeFunctions::svd(
@@ -3424,7 +3433,8 @@ at::Tensor XLANativeFunctions::upsample_bilinear2d(
                                                                scales_w);
   }
   return bridge::AtenFromXlaTensor(XLATensor::upsample_bilinear2d(
-      self_tensor, xla::util::ToVector<int64_t>(output_size), align_corners));
+      self_tensor, torch::lazy::ToVector<int64_t>(output_size),
+      align_corners));
 }
 
 at::Tensor XLANativeFunctions::upsample_bilinear2d_backward(
@@ -3444,8 +3454,8 @@ at::Tensor XLANativeFunctions::upsample_bilinear2d_backward(
                                                      scales_h, scales_w);
   }
   return bridge::AtenFromXlaTensor(XLATensor::upsample_bilinear2d_backward(
-      grad_output_tensor, xla::util::ToVector<int64_t>(output_size),
-      xla::util::ToVector<int64_t>(input_size), align_corners));
+      grad_output_tensor, torch::lazy::ToVector<int64_t>(output_size),
+      torch::lazy::ToVector<int64_t>(input_size), align_corners));
 }
 
 at::Tensor XLANativeFunctions::upsample_nearest2d(
@@ -3484,7 +3494,8 @@ at::Tensor XLANativeFunctions::upsample_nearest2d_backward(
                                                              input_size,
                                                              scale_factors);
   }
-  std::vector<int64_t> input_dim = xla::util::ToVector<int64_t>(input_size);
+  std::vector<int64_t> input_dim =
+      torch::lazy::ToVector<int64_t>(input_size);
   return bridge::AtenFromXlaTensor(XLATensor::upsample_nearest2d_backward(
       grad_output_tensor,
       GetOutputSizeWithScale(input_dim, scale_factors, output_size),
@@ -3506,7 +3517,7 @@ at::Tensor XLANativeFunctions::upsample_nearest2d(
                                                               scales_w);
   }
   return bridge::AtenFromXlaTensor(XLATensor::upsample_nearest2d(
-      self_tensor, xla::util::ToVector<int64_t>(output_size)));
+      self_tensor, torch::lazy::ToVector<int64_t>(output_size)));
 }
 
 at::Tensor XLANativeFunctions::upsample_nearest2d_backward(
@@ -3526,8 +3537,28 @@ at::Tensor XLANativeFunctions::upsample_nearest2d_backward(
                                                     scales_w);
   }
   return bridge::AtenFromXlaTensor(XLATensor::upsample_nearest2d_backward(
-      grad_output_tensor, xla::util::ToVector<int64_t>(output_size),
-      xla::util::ToVector<int64_t>(input_size)));
+      grad_output_tensor, torch::lazy::ToVector<int64_t>(output_size),
+      torch::lazy::ToVector<int64_t>(input_size)));
+}
+
+at::Tensor XLANativeFunctions::var(const at::Tensor& self, bool unbiased) {
+  XLA_FN_COUNTER("xla::");
+  XLATensor self_tensor = bridge::GetXlaTensor(self);
+  return bridge::AtenFromXlaTensor(
+      XLATensor::var(bridge::GetXlaTensor(self),
+                     torch::lazy::Iota<int64_t>(
+                         bridge::GetXlaTensor(self).shape().get().rank()),
+                     /*correction=*/unbiased ? 1 : 0,
+                     /*keep_reduced_dimensions=*/false));
+}
+
+at::Tensor XLANativeFunctions::var(const at::Tensor& self, at::IntArrayRef dim,
+                                   bool unbiased, bool keepdim) {
+  XLA_FN_COUNTER("xla::");
+  XLATensor self_tensor = bridge::GetXlaTensor(self);
+  return bridge::AtenFromXlaTensor(
+      XLATensor::var(self_tensor, XlaHelpers::I64List(dim),
+                     /*correction=*/unbiased ? 1 : 0, keepdim));
 }
 
 at::Tensor XLANativeFunctions::var(const at::Tensor& self,
@@ -3539,7 +3570,7 @@ at::Tensor XLANativeFunctions::var(const at::Tensor& self,
   return bridge::AtenFromXlaTensor(
       XLATensor::var(self_tensor,
                      dim ? XlaHelpers::I64List(*dim)
-                         : xla::util::Iota<int64_t>(
+                         : torch::lazy::Iota<int64_t>(
                                bridge::GetXlaTensor(self).shape().get().rank()),
                      correction ? *correction : 1, keepdim));
 }
@@ -3551,8 +3582,8 @@ std::tuple<at::Tensor, at::Tensor> XLANativeFunctions::var_mean(
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   auto results = XLATensor::var_mean(
       self_tensor,
-      dim ? xla::util::ToVector<int64_t>(*dim)
-          : xla::util::Iota<int64_t>(self_tensor.shape().get().rank()),
+      dim ? torch::lazy::ToVector<int64_t>(*dim)
+          : torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
       correction ? *correction : 1, keepdim);
   return std::make_tuple(bridge::AtenFromXlaTensor(std::get<0>(results)),
                          bridge::AtenFromXlaTensor(std::get<1>(results)));

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3531,26 +3531,6 @@ at::Tensor XLANativeFunctions::upsample_nearest2d_backward(
       torch::lazy::ToVector<int64_t>(input_size)));
 }
 
-at::Tensor XLANativeFunctions::var(const at::Tensor& self, bool unbiased) {
-  XLA_FN_COUNTER("xla::");
-  XLATensor self_tensor = bridge::GetXlaTensor(self);
-  return bridge::AtenFromXlaTensor(
-      XLATensor::var(bridge::GetXlaTensor(self),
-                     torch::lazy::Iota<int64_t>(
-                         bridge::GetXlaTensor(self).shape().get().rank()),
-                     /*correction=*/unbiased ? 1 : 0,
-                     /*keep_reduced_dimensions=*/false));
-}
-
-at::Tensor XLANativeFunctions::var(const at::Tensor& self, at::IntArrayRef dim,
-                                   bool unbiased, bool keepdim) {
-  XLA_FN_COUNTER("xla::");
-  XLATensor self_tensor = bridge::GetXlaTensor(self);
-  return bridge::AtenFromXlaTensor(
-      XLATensor::var(self_tensor, XlaHelpers::I64List(dim),
-                     /*correction=*/unbiased ? 1 : 0, keepdim));
-}
-
 at::Tensor XLANativeFunctions::var(const at::Tensor& self,
                                    c10::optional<at::IntArrayRef> dim,
                                    c10::optional<int64_t> correction,

--- a/torch_xla/csrc/cross_replica_reduces.cpp
+++ b/torch_xla/csrc/cross_replica_reduces.cpp
@@ -5,6 +5,7 @@
 #include "tensorflow/compiler/xla/shape_util.h"
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/convert_ops.h"
 #include "torch_xla/csrc/device.h"
 #include "torch_xla/csrc/helpers.h"
@@ -65,7 +66,7 @@ xla::XlaComputation GetReduceComutation(AllReduceType reduce_type,
       return XlaHelpers::CreateMaxComputation(type);
   }
   XLA_ERROR() << "Invalid reduce type: "
-              << xla::util::GetEnumValue(reduce_type);
+              << torch::lazy::GetEnumValue(reduce_type);
 }
 
 std::vector<xla::ReplicaGroup> CreateReduceGroups(

--- a/torch_xla/csrc/data_ops.cpp
+++ b/torch_xla/csrc/data_ops.cpp
@@ -108,9 +108,8 @@ xla::XlaOp BuildExpand(xla::XlaOp input,
   input_sizes.insert(input_sizes.begin(),
                      output_sizes.size() - input_sizes.size(), 1);
   xla::XlaOp implicit_reshape = XlaHelpers::DynamicReshape(input, input_sizes);
-  return xla::BroadcastInDim(
-      implicit_reshape, output_sizes,
-      torch::lazy::Iota<int64_t>(output_sizes.size()));
+  return xla::BroadcastInDim(implicit_reshape, output_sizes,
+                             torch::lazy::Iota<int64_t>(output_sizes.size()));
 }
 
 std::vector<int64_t> BuildSqueezedDimensions(

--- a/torch_xla/csrc/device.h
+++ b/torch_xla/csrc/device.h
@@ -5,6 +5,7 @@
 
 #include "tensorflow/compiler/xla/xla_client/util.h"
 #include "torch/csrc/lazy/core/hash.h"
+#include "torch/csrc/lazy/core/util.h"
 
 namespace torch_xla {
 
@@ -37,7 +38,7 @@ struct Device {
   }
 
   size_t hash() const {
-    return torch::lazy::StdHashCombine(xla::util::GetEnumValue(hw_type),
+    return torch::lazy::StdHashCombine(torch::lazy::GetEnumValue(hw_type),
                                        ordinal + 1);
   }
 

--- a/torch_xla/csrc/helpers.cpp
+++ b/torch_xla/csrc/helpers.cpp
@@ -11,6 +11,7 @@
 #include "tensorflow/compiler/xla/xla_client/tf_logging.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
 #include "torch/csrc/lazy/core/helpers.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/convert_ops.h"
 #include "torch_xla/csrc/tensor_util.h"
 

--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -16,6 +16,7 @@
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
 #include "tensorflow/core/lib/bfloat16/bfloat16.h"
+#include "torch/csrc/lazy/core/util.h"
 
 namespace torch_xla {
 
@@ -117,11 +118,11 @@ class XlaHelpers {
   static xla::PrimitiveType TypeOfXlaOp(xla::XlaOp op);
 
   static std::vector<int64_t> GetAllDimensions(size_t rank) {
-    return xla::util::Iota<int64_t>(rank);
+    return torch::lazy::Iota<int64_t>(rank);
   }
 
   static std::vector<int64_t> GetAllDimensions(const xla::Shape& shape) {
-    return xla::util::Iota<int64_t>(shape.rank());
+    return torch::lazy::Iota<int64_t>(shape.rank());
   }
 
   static xla::XlaOp BroadcastDimensions(xla::XlaOp input,
@@ -167,7 +168,7 @@ class XlaHelpers {
   // Converts an iterable container to a vector XLA int64's.
   template <typename S>
   static std::vector<int64_t> I64List(const S& input) {
-    return xla::util::ToVector<int64_t>(input);
+    return torch::lazy::ToVector<int64_t>(input);
   }
 
   static c10::optional<int64_t> I64Optional(c10::optional<int64_t> opt) {

--- a/torch_xla/csrc/layout_manager.cpp
+++ b/torch_xla/csrc/layout_manager.cpp
@@ -115,8 +115,8 @@ double PaddingFactor(int64_t size, int padding) {
 xla::Shape MakeShapeWithSortedLayout(absl::Span<const int64_t> dimensions,
                                      xla::PrimitiveType type) {
   // Place bigger dimensions on most minor layout locations.
-  std::vector<int64_t> layout = torch::lazy::Iota<int64_t>(
-      dimensions.size(), dimensions.size() - 1, -1);
+  std::vector<int64_t> layout =
+      torch::lazy::Iota<int64_t>(dimensions.size(), dimensions.size() - 1, -1);
   std::sort(layout.begin(), layout.end(), [&](int64_t a, int64_t b) {
     return dimensions[a] > dimensions[b];
   });

--- a/torch_xla/csrc/layout_manager.cpp
+++ b/torch_xla/csrc/layout_manager.cpp
@@ -14,6 +14,7 @@
 #include "tensorflow/compiler/xla/xla_client/sys_util.h"
 #include "tensorflow/compiler/xla/xla_client/tf_logging.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch/csrc/lazy/core/util.h"
 
 namespace torch_xla {
 namespace {
@@ -114,8 +115,8 @@ double PaddingFactor(int64_t size, int padding) {
 xla::Shape MakeShapeWithSortedLayout(absl::Span<const int64_t> dimensions,
                                      xla::PrimitiveType type) {
   // Place bigger dimensions on most minor layout locations.
-  std::vector<int64_t> layout =
-      xla::util::Iota<int64_t>(dimensions.size(), dimensions.size() - 1, -1);
+  std::vector<int64_t> layout = torch::lazy::Iota<int64_t>(
+      dimensions.size(), dimensions.size() - 1, -1);
   std::sort(layout.begin(), layout.end(), [&](int64_t a, int64_t b) {
     return dimensions[a] > dimensions[b];
   });

--- a/torch_xla/csrc/nms_op.cpp
+++ b/torch_xla/csrc/nms_op.cpp
@@ -10,6 +10,7 @@
 #include "tensorflow/compiler/xla/util.h"
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/helpers.h"
 
 // Code extracted from:
@@ -92,7 +93,7 @@ xla::XlaOp NmsGather(xla::XlaOp input, absl::Span<const int64_t> input_sizes,
   int64_t num_indices = xla::util::Multiply<int64_t>(indices_sizes);
   if (num_indices == 0) {
     std::vector<int64_t> output_sizes =
-        xla::util::ToVector<int64_t>(input_sizes);
+        torch::lazy::ToVector<int64_t>(input_sizes);
     output_sizes.erase(std::next(output_sizes.begin(), axis));
     return xla::Broadcast(
         xla::Zero(input.builder(), input_shape.element_type()), output_sizes);

--- a/torch_xla/csrc/ops/all_reduce.cpp
+++ b/torch_xla/csrc/ops/all_reduce.cpp
@@ -3,6 +3,7 @@
 #include "absl/strings/str_join.h"
 #include "tensorflow/compiler/xla/shape_util.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/ops/xla_ops.h"
 
@@ -37,7 +38,7 @@ AllReduce::AllReduce(AllReduceType reduce_type,
     : Node(xla_cross_replica_sum, GetOperandList(operands, token),
            [&]() { return NodeOutputShape(operands, token); },
            /*num_outputs=*/operands.size() + 1,
-           torch::lazy::MHash(xla::util::GetEnumValue(reduce_type), scale,
+           torch::lazy::MHash(torch::lazy::GetEnumValue(reduce_type), scale,
                               groups)),
       reduce_type_(reduce_type),
       scale_(scale),
@@ -64,7 +65,7 @@ XlaOpVector AllReduce::Lower(LoweringContext* loctx) const {
 std::string AllReduce::ToString() const {
   std::stringstream ss;
   ss << Node::ToString()
-     << ", reduce_type=" << xla::util::GetEnumValue(reduce_type_)
+     << ", reduce_type=" << torch::lazy::GetEnumValue(reduce_type_)
      << ", scale=" << scale_ << ", groups=(";
   for (size_t i = 0; i < groups_.size(); ++i) {
     ss << (i == 0 ? "(" : ",(");

--- a/torch_xla/csrc/ops/as_strided.cpp
+++ b/torch_xla/csrc/ops/as_strided.cpp
@@ -83,13 +83,10 @@ bool AsStrided::StrideIsSupported(const xla::Shape& input_shape,
 }
 
 std::vector<int64_t> AsStrided::GetArrayStridePermutation(
-    absl::Span<const int64_t> stride,
-    absl::Span<const int64_t> size) {
-  std::vector<int64_t> permutation =
-      torch::lazy::Iota<int64_t>(stride.size());
-  std::sort(
-      permutation.begin(), permutation.end(),
-      [&](int64_t a, int64_t b) { return stride[a] > stride[b]; });
+    absl::Span<const int64_t> stride, absl::Span<const int64_t> size) {
+  std::vector<int64_t> permutation = torch::lazy::Iota<int64_t>(stride.size());
+  std::sort(permutation.begin(), permutation.end(),
+            [&](int64_t a, int64_t b) { return stride[a] > stride[b]; });
   return permutation;
 }
 

--- a/torch_xla/csrc/ops/as_strided.cpp
+++ b/torch_xla/csrc/ops/as_strided.cpp
@@ -5,6 +5,7 @@
 #include "tensorflow/compiler/xla/shape_util.h"
 #include "tensorflow/compiler/xla/util.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/data_ops.h"
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/lowering_context.h"
@@ -82,10 +83,13 @@ bool AsStrided::StrideIsSupported(const xla::Shape& input_shape,
 }
 
 std::vector<int64_t> AsStrided::GetArrayStridePermutation(
-    absl::Span<const int64_t> stride, absl::Span<const int64_t> size) {
-  std::vector<int64_t> permutation = xla::util::Iota<int64_t>(stride.size());
-  std::sort(permutation.begin(), permutation.end(),
-            [&](int64_t a, int64_t b) { return stride[a] > stride[b]; });
+    absl::Span<const int64_t> stride,
+    absl::Span<const int64_t> size) {
+  std::vector<int64_t> permutation =
+      torch::lazy::Iota<int64_t>(stride.size());
+  std::sort(
+      permutation.begin(), permutation.end(),
+      [&](int64_t a, int64_t b) { return stride[a] > stride[b]; });
   return permutation;
 }
 

--- a/torch_xla/csrc/ops/binary_cross_entropy.cpp
+++ b/torch_xla/csrc/ops/binary_cross_entropy.cpp
@@ -2,6 +2,7 @@
 
 #include "absl/types/span.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
@@ -38,7 +39,7 @@ BinaryCrossEntropy::BinaryCrossEntropy(const Value& logits, const Value& labels,
            xla::util::GetValuesVector<Value>({logits, labels}, {&weight}),
            [&]() { return NodeOutputShape(logits, labels, weight, reduction); },
            /*num_outputs=*/1,
-           torch::lazy::MHash(xla::util::GetEnumValue(reduction))),
+           torch::lazy::MHash(torch::lazy::GetEnumValue(reduction))),
       reduction_(reduction) {}
 
 NodePtr BinaryCrossEntropy::Clone(OpList operands) const {
@@ -64,7 +65,7 @@ XlaOpVector BinaryCrossEntropy::Lower(LoweringContext* loctx) const {
 std::string BinaryCrossEntropy::ToString() const {
   std::stringstream ss;
   ss << Node::ToString()
-     << ", reduction=" << xla::util::GetEnumValue(reduction_);
+     << ", reduction=" << torch::lazy::GetEnumValue(reduction_);
   return ss.str();
 }
 

--- a/torch_xla/csrc/ops/binary_cross_entropy_backward.cpp
+++ b/torch_xla/csrc/ops/binary_cross_entropy_backward.cpp
@@ -2,6 +2,7 @@
 
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
@@ -44,7 +45,7 @@ BinaryCrossEntropyBackward::BinaryCrossEntropyBackward(
                                     reduction);
            },
            /*num_outputs=*/1,
-           torch::lazy::MHash(xla::util::GetEnumValue(reduction))),
+           torch::lazy::MHash(torch::lazy::GetEnumValue(reduction))),
       reduction_(reduction) {}
 
 NodePtr BinaryCrossEntropyBackward::Clone(OpList operands) const {
@@ -72,7 +73,7 @@ XlaOpVector BinaryCrossEntropyBackward::Lower(LoweringContext* loctx) const {
 std::string BinaryCrossEntropyBackward::ToString() const {
   std::stringstream ss;
   ss << Node::ToString()
-     << ", reduction=" << xla::util::GetEnumValue(reduction_);
+     << ", reduction=" << torch::lazy::GetEnumValue(reduction_);
   return ss.str();
 }
 

--- a/torch_xla/csrc/ops/index_ops.cpp
+++ b/torch_xla/csrc/ops/index_ops.cpp
@@ -119,8 +119,7 @@ CanonicalIndexInfo TransposeToFront(at::Tensor base, at::TensorList indices) {
   IndexAdjacencyInfo adjacency_info = GetIndexAdjacencyInfo(indices);
   if (adjacency_info.contiguous_non_null) {
     return {base, std::move(transposed_indices),
-            torch::lazy::Iota<int64_t>(base_rank),
-            adjacency_info.start_dim};
+            torch::lazy::Iota<int64_t>(base_rank), adjacency_info.start_dim};
   }
   return {base.permute(dims), std::move(transposed_indices),
           xla::InversePermutation(XlaHelpers::I64List(dims)), 0};

--- a/torch_xla/csrc/ops/index_ops.cpp
+++ b/torch_xla/csrc/ops/index_ops.cpp
@@ -6,6 +6,7 @@
 #include "tensorflow/compiler/xla/permutation_util.h"
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/aten_xla_bridge.h"
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/lowering_context.h"
@@ -118,7 +119,8 @@ CanonicalIndexInfo TransposeToFront(at::Tensor base, at::TensorList indices) {
   IndexAdjacencyInfo adjacency_info = GetIndexAdjacencyInfo(indices);
   if (adjacency_info.contiguous_non_null) {
     return {base, std::move(transposed_indices),
-            xla::util::Iota<int64_t>(base_rank), adjacency_info.start_dim};
+            torch::lazy::Iota<int64_t>(base_rank),
+            adjacency_info.start_dim};
   }
   return {base.permute(dims), std::move(transposed_indices),
           xla::InversePermutation(XlaHelpers::I64List(dims)), 0};
@@ -279,7 +281,7 @@ ir::Value IndexPutByTensors(const XLATensor& base,
       ir::MakeNode<ir::ops::IndexPut>(base.GetIrValue(),
                                       indices_nd.GetIrValue(), start_dim,
                                       values.GetIrValue(), accumulate),
-      xla::util::ToVector<int64_t>(result_permutation));
+      torch::lazy::ToVector<int64_t>(result_permutation));
 }
 
 ir::NodePtr IndexFill(const XLATensor& base, int64_t dim,

--- a/torch_xla/csrc/ops/l1_loss.cpp
+++ b/torch_xla/csrc/ops/l1_loss.cpp
@@ -2,6 +2,7 @@
 
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
@@ -25,7 +26,7 @@ L1Loss::L1Loss(const Value& input, const Value& target, ReductionMode reduction)
     : Node(ir::OpKind(at::aten::l1_loss), {input, target},
            [&]() { return NodeOutputShape(input, target, reduction); },
            /*num_outputs=*/1,
-           torch::lazy::MHash(xla::util::GetEnumValue(reduction))),
+           torch::lazy::MHash(torch::lazy::GetEnumValue(reduction))),
       reduction_(reduction) {}
 
 NodePtr L1Loss::Clone(OpList operands) const {
@@ -41,7 +42,7 @@ XlaOpVector L1Loss::Lower(LoweringContext* loctx) const {
 std::string L1Loss::ToString() const {
   std::stringstream ss;
   ss << Node::ToString()
-     << ", reduction=" << xla::util::GetEnumValue(reduction_);
+     << ", reduction=" << torch::lazy::GetEnumValue(reduction_);
   return ss.str();
 }
 

--- a/torch_xla/csrc/ops/l1_loss_backward.cpp
+++ b/torch_xla/csrc/ops/l1_loss_backward.cpp
@@ -1,6 +1,7 @@
 #include "torch_xla/csrc/ops/l1_loss_backward.h"
 
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
@@ -29,7 +30,7 @@ L1LossBackward::L1LossBackward(const Value& grad_output, const Value& input,
              return NodeOutputShape(grad_output, input, target, reduction);
            },
            /*num_outputs=*/1,
-           torch::lazy::MHash(xla::util::GetEnumValue(reduction))),
+           torch::lazy::MHash(torch::lazy::GetEnumValue(reduction))),
       reduction_(reduction) {}
 
 NodePtr L1LossBackward::Clone(OpList operands) const {
@@ -48,7 +49,7 @@ XlaOpVector L1LossBackward::Lower(LoweringContext* loctx) const {
 std::string L1LossBackward::ToString() const {
   std::stringstream ss;
   ss << Node::ToString()
-     << ", reduction=" << xla::util::GetEnumValue(reduction_);
+     << ", reduction=" << torch::lazy::GetEnumValue(reduction_);
   return ss.str();
 }
 

--- a/torch_xla/csrc/ops/mse_loss.cpp
+++ b/torch_xla/csrc/ops/mse_loss.cpp
@@ -4,6 +4,7 @@
 
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
@@ -28,7 +29,7 @@ MseLoss::MseLoss(const Value& input, const Value& target,
     : Node(ir::OpKind(at::aten::mse_loss), {input, target},
            [&]() { return NodeOutputShape(input, target, reduction); },
            /*num_outputs=*/1,
-           torch::lazy::MHash(xla::util::GetEnumValue(reduction))),
+           torch::lazy::MHash(torch::lazy::GetEnumValue(reduction))),
       reduction_(reduction) {}
 
 NodePtr MseLoss::Clone(OpList operands) const {
@@ -44,7 +45,7 @@ XlaOpVector MseLoss::Lower(LoweringContext* loctx) const {
 std::string MseLoss::ToString() const {
   std::stringstream ss;
   ss << Node::ToString()
-     << ", reduction=" << xla::util::GetEnumValue(reduction_);
+     << ", reduction=" << torch::lazy::GetEnumValue(reduction_);
   return ss.str();
 }
 

--- a/torch_xla/csrc/ops/mse_loss_backward.cpp
+++ b/torch_xla/csrc/ops/mse_loss_backward.cpp
@@ -1,6 +1,7 @@
 #include "torch_xla/csrc/ops/mse_loss_backward.h"
 
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 #include "torch_xla/csrc/ops/mse_loss.h"
@@ -32,7 +33,7 @@ MseLossBackward::MseLossBackward(const Value& grad_output, const Value& input,
              return NodeOutputShape(grad_output, input, target, reduction);
            },
            /*num_outputs=*/1,
-           torch::lazy::MHash(xla::util::GetEnumValue(reduction))),
+           torch::lazy::MHash(torch::lazy::GetEnumValue(reduction))),
       reduction_(reduction) {}
 
 NodePtr MseLossBackward::Clone(OpList operands) const {
@@ -51,7 +52,7 @@ XlaOpVector MseLossBackward::Lower(LoweringContext* loctx) const {
 std::string MseLossBackward::ToString() const {
   std::stringstream ss;
   ss << Node::ToString()
-     << ", reduction=" << xla::util::GetEnumValue(reduction_);
+     << ", reduction=" << torch::lazy::GetEnumValue(reduction_);
   return ss.str();
 }
 

--- a/torch_xla/csrc/ops/nll_loss.cpp
+++ b/torch_xla/csrc/ops/nll_loss.cpp
@@ -2,6 +2,7 @@
 
 #include "absl/types/span.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/nll_loss.h"
 #include "torch_xla/csrc/ops/infer_output_shape.h"
@@ -36,15 +37,15 @@ xla::Shape NodeOutputShape(const Value& logits, const Value& labels,
 NllLoss::NllLoss(const Value& logits, const Value& labels,
                  const absl::optional<Value>& weight, ReductionMode reduction,
                  int ignore_index)
-    : Node(
-          ir::OpKind(at::aten::nll_loss),
-          xla::util::GetValuesVector<Value>({logits, labels}, {&weight}),
-          [&]() {
-            return NodeOutputShape(logits, labels, weight, reduction,
-                                   ignore_index);
-          },
-          /*num_outputs=*/1,
-          torch::lazy::MHash(xla::util::GetEnumValue(reduction), ignore_index)),
+    : Node(ir::OpKind(at::aten::nll_loss),
+           xla::util::GetValuesVector<Value>({logits, labels}, {&weight}),
+           [&]() {
+             return NodeOutputShape(logits, labels, weight, reduction,
+                                    ignore_index);
+           },
+           /*num_outputs=*/1,
+           torch::lazy::MHash(torch::lazy::GetEnumValue(reduction),
+                              ignore_index)),
       reduction_(reduction),
       ignore_index_(ignore_index) {}
 
@@ -71,7 +72,7 @@ XlaOpVector NllLoss::Lower(LoweringContext* loctx) const {
 std::string NllLoss::ToString() const {
   std::stringstream ss;
   ss << Node::ToString()
-     << ", reduction=" << xla::util::GetEnumValue(reduction_)
+     << ", reduction=" << torch::lazy::GetEnumValue(reduction_)
      << ", ignore_index=" << ignore_index_;
   return ss.str();
 }

--- a/torch_xla/csrc/ops/nll_loss2d.cpp
+++ b/torch_xla/csrc/ops/nll_loss2d.cpp
@@ -2,6 +2,7 @@
 
 #include "absl/types/span.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/nll_loss.h"
 #include "torch_xla/csrc/ops/infer_output_shape.h"
@@ -36,15 +37,15 @@ xla::Shape NodeOutputShape(const Value& logits, const Value& labels,
 NllLoss2d::NllLoss2d(const Value& logits, const Value& labels,
                      const absl::optional<Value>& weight,
                      ReductionMode reduction, int ignore_index)
-    : Node(
-          ir::OpKind(at::aten::nll_loss2d),
-          xla::util::GetValuesVector<Value>({logits, labels}, {&weight}),
-          [&]() {
-            return NodeOutputShape(logits, labels, weight, reduction,
-                                   ignore_index);
-          },
-          /*num_outputs=*/1,
-          torch::lazy::MHash(xla::util::GetEnumValue(reduction), ignore_index)),
+    : Node(ir::OpKind(at::aten::nll_loss2d),
+           xla::util::GetValuesVector<Value>({logits, labels}, {&weight}),
+           [&]() {
+             return NodeOutputShape(logits, labels, weight, reduction,
+                                    ignore_index);
+           },
+           /*num_outputs=*/1,
+           torch::lazy::MHash(torch::lazy::GetEnumValue(reduction),
+                              ignore_index)),
       reduction_(reduction),
       ignore_index_(ignore_index) {}
 
@@ -71,7 +72,7 @@ XlaOpVector NllLoss2d::Lower(LoweringContext* loctx) const {
 std::string NllLoss2d::ToString() const {
   std::stringstream ss;
   ss << Node::ToString()
-     << ", reduction=" << xla::util::GetEnumValue(reduction_)
+     << ", reduction=" << torch::lazy::GetEnumValue(reduction_)
      << ", ignore_index=" << ignore_index_;
   return ss.str();
 }

--- a/torch_xla/csrc/ops/nll_loss2d_backward.cpp
+++ b/torch_xla/csrc/ops/nll_loss2d_backward.cpp
@@ -2,6 +2,7 @@
 
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/nll_loss.h"
 #include "torch_xla/csrc/ops/infer_output_shape.h"
@@ -44,16 +45,16 @@ NllLoss2dBackward::NllLoss2dBackward(const Value& grad_output,
                                      const absl::optional<Value>& weight,
                                      const absl::optional<Value>& total_weight,
                                      ReductionMode reduction, int ignore_index)
-    : Node(
-          ir::OpKind(at::aten::nll_loss2d_backward),
-          xla::util::GetValuesVector<Value>({grad_output, logits, labels},
-                                            {&weight, &total_weight}),
-          [&]() {
-            return NodeOutputShape(grad_output, logits, labels, weight,
-                                   total_weight, reduction, ignore_index);
-          },
-          /*num_outputs=*/1,
-          torch::lazy::MHash(xla::util::GetEnumValue(reduction), ignore_index)),
+    : Node(ir::OpKind(at::aten::nll_loss2d_backward),
+           xla::util::GetValuesVector<Value>({grad_output, logits, labels},
+                                             {&weight, &total_weight}),
+           [&]() {
+             return NodeOutputShape(grad_output, logits, labels, weight,
+                                    total_weight, reduction, ignore_index);
+           },
+           /*num_outputs=*/1,
+           torch::lazy::MHash(torch::lazy::GetEnumValue(reduction),
+                              ignore_index)),
       reduction_(reduction),
       ignore_index_(ignore_index) {}
 
@@ -87,7 +88,7 @@ XlaOpVector NllLoss2dBackward::Lower(LoweringContext* loctx) const {
 std::string NllLoss2dBackward::ToString() const {
   std::stringstream ss;
   ss << Node::ToString()
-     << ", reduction=" << xla::util::GetEnumValue(reduction_)
+     << ", reduction=" << torch::lazy::GetEnumValue(reduction_)
      << ", ignore_index=" << ignore_index_;
   return ss.str();
 }

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -9,6 +9,7 @@
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
 #include "torch/csrc/lazy/core/helpers.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/convert_ops.h"
 #include "torch_xla/csrc/data_ops.h"
 #include "torch_xla/csrc/elementwise.h"
@@ -578,9 +579,9 @@ NodePtr Norm(const Value& input, const c10::optional<at::Scalar>& p,
              c10::optional<at::ScalarType> dtype,
              absl::Span<const int64_t> dims, bool keepdim) {
   ScopePusher ir_scope(at::aten::norm.toQualString());
-  auto dimensions = xla::util::ToVector<int64_t>(dims);
+  auto dimensions = torch::lazy::ToVector<int64_t>(dims);
   if (dimensions.empty()) {
-    dimensions = xla::util::Iota<int64_t>(input.shape().rank());
+    dimensions = torch::lazy::Iota<int64_t>(input.shape().rank());
   }
   if (!p.has_value() || p->toDouble() == 2.0) {
     NodePtr square = input * input;
@@ -705,7 +706,7 @@ NodePtr MaxUnary(const Value& input) {
         XlaHelpers::ScalarValue(min_max.min, element_type, loctx->builder());
     xla::XlaOp result = xla::Reduce(
         xla_input, init_value, XlaHelpers::CreateMaxComputation(element_type),
-        xla::util::Iota<int64_t>(input_shape.rank()));
+        torch::lazy::Iota<int64_t>(input_shape.rank()));
     return node.ReturnOp(xla::Reshape(result, {}), loctx);
   };
   XLA_CHECK_GT(xla::ShapeUtil::ElementsIn(input.shape()), 0);
@@ -724,7 +725,7 @@ NodePtr MinUnary(const Value& input) {
         XlaHelpers::ScalarValue(min_max.max, element_type, loctx->builder());
     xla::XlaOp result = xla::Reduce(
         xla_input, init_value, XlaHelpers::CreateMinComputation(element_type),
-        xla::util::Iota<int64_t>(input_shape.rank()));
+        torch::lazy::Iota<int64_t>(input_shape.rank()));
     return node.ReturnOp(xla::Reshape(result, {}), loctx);
   };
   XLA_CHECK_GT(xla::ShapeUtil::ElementsIn(input.shape()), 0);

--- a/torch_xla/csrc/ops/reduce_scatter.cpp
+++ b/torch_xla/csrc/ops/reduce_scatter.cpp
@@ -2,6 +2,7 @@
 
 #include "absl/strings/str_join.h"
 #include "tensorflow/compiler/xla/shape_util.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 #include "torch_xla/csrc/ops/xla_ops.h"
@@ -37,7 +38,7 @@ ReduceScatter::ReduceScatter(AllReduceType reduce_type, const Value& input,
                                     scatter_dim, shard_count, groups);
            },
            /*num_outputs=*/2,
-           torch::lazy::MHash(xla::util::GetEnumValue(reduce_type), scale,
+           torch::lazy::MHash(torch::lazy::GetEnumValue(reduce_type), scale,
                               scatter_dim, shard_count, groups)),
       reduce_type_(reduce_type),
       scale_(scale),
@@ -61,7 +62,7 @@ XlaOpVector ReduceScatter::Lower(LoweringContext* loctx) const {
 std::string ReduceScatter::ToString() const {
   std::stringstream ss;
   ss << Node::ToString()
-     << ", reduce_type=" << xla::util::GetEnumValue(reduce_type_)
+     << ", reduce_type=" << torch::lazy::GetEnumValue(reduce_type_)
      << ", scale=" << scale_ << ", scatter_dim=" << scatter_dim_
      << ", shard_count=" << shard_count_ << ", groups=(";
   for (size_t i = 0; i < groups_.size(); ++i) {

--- a/torch_xla/csrc/ops/svd.cpp
+++ b/torch_xla/csrc/ops/svd.cpp
@@ -4,6 +4,7 @@
 #include "tensorflow/compiler/xla/client/lib/matrix.h"
 #include "tensorflow/compiler/xla/client/lib/svd.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/data_ops.h"
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/lowering_context.h"
@@ -28,11 +29,13 @@ std::vector<xla::XlaOp> LowerSVD(xla::XlaOp input, bool some, bool compute_uv) {
     int64_t n_dim = input_shape.dimensions(input_shape.rank() - 1);
     std::vector<int64_t> base_indices(input_shape.rank(), 0);
 
-    auto u_sizes = xla::util::ToVector<int64_t>(input_shape.dimensions());
+    auto u_sizes =
+        torch::lazy::ToVector<int64_t>(input_shape.dimensions());
     u_sizes[input_shape.rank() - 1] = std::min(m_dim, n_dim);
     u = BuildSlice(u, base_indices, u_sizes);
 
-    auto v_sizes = xla::util::ToVector<int64_t>(input_shape.dimensions());
+    auto v_sizes =
+        torch::lazy::ToVector<int64_t>(input_shape.dimensions());
     v_sizes[input_shape.rank() - 2] = n_dim;
     v_sizes[input_shape.rank() - 1] = std::min(m_dim, n_dim);
     v = BuildSlice(v, base_indices, v_sizes);

--- a/torch_xla/csrc/ops/svd.cpp
+++ b/torch_xla/csrc/ops/svd.cpp
@@ -29,13 +29,11 @@ std::vector<xla::XlaOp> LowerSVD(xla::XlaOp input, bool some, bool compute_uv) {
     int64_t n_dim = input_shape.dimensions(input_shape.rank() - 1);
     std::vector<int64_t> base_indices(input_shape.rank(), 0);
 
-    auto u_sizes =
-        torch::lazy::ToVector<int64_t>(input_shape.dimensions());
+    auto u_sizes = torch::lazy::ToVector<int64_t>(input_shape.dimensions());
     u_sizes[input_shape.rank() - 1] = std::min(m_dim, n_dim);
     u = BuildSlice(u, base_indices, u_sizes);
 
-    auto v_sizes =
-        torch::lazy::ToVector<int64_t>(input_shape.dimensions());
+    auto v_sizes = torch::lazy::ToVector<int64_t>(input_shape.dimensions());
     v_sizes[input_shape.rank() - 2] = n_dim;
     v_sizes[input_shape.rank() - 1] = std::min(m_dim, n_dim);
     v = BuildSlice(v, base_indices, v_sizes);

--- a/torch_xla/csrc/pooling.cpp
+++ b/torch_xla/csrc/pooling.cpp
@@ -8,6 +8,7 @@
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
 #include "torch/csrc/lazy/core/tensor_util.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/data_ops.h"
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/tensor_util.h"
@@ -51,7 +52,7 @@ xla::TensorFormat MakeNCHWFormat(int64_t spatial_dim_count) {
   return {/*batch_dimension=*/0,
           /*feature_dimension=*/1,
           /*spatial_dimensions=*/
-          xla::util::Iota<int64_t>(spatial_dim_count, 2)};
+          torch::lazy::Iota<int64_t>(spatial_dim_count, 2)};
 }
 
 // Construct the pooling attributes for the given kernel size, stride and
@@ -225,7 +226,7 @@ PoolSliceIndices ComputeSliceIndices(xla::XlaOp linear_index,
                                      absl::Span<const int64_t> window_strides) {
   xla::PrimitiveType scalar_type = XlaHelpers::TypeOfXlaOp(linear_index);
   std::vector<int64_t> strides = torch::lazy::ComputeArrayStrides(
-      xla::util::ToVector<int64_t>(dimensions));
+      torch::lazy::ToVector<int64_t>(dimensions));
   PoolSliceIndices indices;
   xla::XlaOp current_index = linear_index;
   for (size_t i = 0; i < dimensions.size(); ++i) {

--- a/torch_xla/csrc/reduction.cpp
+++ b/torch_xla/csrc/reduction.cpp
@@ -7,6 +7,7 @@
 #include "tensorflow/compiler/xla/client/lib/constants.h"
 #include "tensorflow/compiler/xla/literal_util.h"
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/convert_ops.h"
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/tensor_util.h"
@@ -289,7 +290,7 @@ xla::XlaOp BuildStdDeviation(xla::XlaOp input,
       BuildMean(input, dimensions, /*keep_reduced_dimensions*/ true);
   xla::XlaOp bcast_mean =
       xla::BroadcastInDim(mean, input_shape.dimensions(),
-                          xla::util::Iota<int64_t>(input_shape.rank()));
+                          torch::lazy::Iota<int64_t>(input_shape.rank()));
   xla::XlaOp input_mean_diff = input - bcast_mean;
   xla::XlaOp squared_var = input_mean_diff * input_mean_diff;
   xla::XlaOp squared_result;
@@ -391,7 +392,7 @@ xla::XlaOp BuildArgMax(xla::XlaOp input, int64_t dim, bool keepdim) {
       operand,
       GetDevicePrimitiveType(xla::PrimitiveType::S64, /*device=*/nullptr), dim);
   if (keepdim) {
-    auto dimensions = xla::util::ToVector<int64_t>(shape->dimensions());
+    auto dimensions = torch::lazy::ToVector<int64_t>(shape->dimensions());
     dimensions[dim] = 1;
     result = XlaHelpers::DynamicReshape(result, dimensions);
   }
@@ -411,7 +412,7 @@ xla::XlaOp BuildArgMin(xla::XlaOp input, int64_t dim, bool keepdim) {
       operand,
       GetDevicePrimitiveType(xla::PrimitiveType::S64, /*device=*/nullptr), dim);
   if (keepdim) {
-    auto dimensions = xla::util::ToVector<int64_t>(shape->dimensions());
+    auto dimensions = torch::lazy::ToVector<int64_t>(shape->dimensions());
     dimensions[dim] = 1;
     result = XlaHelpers::DynamicReshape(result, dimensions);
   }

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -28,6 +28,7 @@
 #include "torch/csrc/lazy/core/hash.h"
 #include "torch/csrc/lazy/core/helpers.h"
 #include "torch/csrc/lazy/core/tensor_util.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/debug_util.h"
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/ir_dump_util.h"
@@ -168,7 +169,7 @@ class XlaDataCacheArena {
   struct TensorHasher {
     size_t operator()(const at::Tensor& tensor) const {
       return torch::lazy::HashReduce(torch::lazy::HashCombine(
-          xla::util::GetEnumValue(tensor.scalar_type()), TensorHash(tensor)));
+          torch::lazy::GetEnumValue(tensor.scalar_type()), TensorHash(tensor)));
     };
   };
   struct TensorComparer {
@@ -738,7 +739,7 @@ ir::Value XLATensor::GetIrValueForConstant(const at::Scalar& value,
       ir::ops::ScalarOp(std::move(value), shape.element_type());
   if (!shape.dimensions().empty()) {
     ir_value = ir::MakeNode<ir::ops::Expand>(
-        ir_value, xla::util::ToVector<int64_t>(shape.dimensions()));
+        ir_value, torch::lazy::ToVector<int64_t>(shape.dimensions()));
   }
   return ir_value;
 }
@@ -765,7 +766,7 @@ ir::Value XLATensor::GetIrValueForScalar(const at::Scalar& value,
   ir::Value ir_value = GetIrValueForScalar(value, type, device);
   if (!dimensions.empty()) {
     ir_value = ir::MakeNode<ir::ops::Expand>(
-        ir_value, xla::util::ToVector<int64_t>(dimensions));
+        ir_value, torch::lazy::ToVector<int64_t>(dimensions));
   }
   return ir_value;
 }

--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -7,6 +7,7 @@
 #include "tensorflow/compiler/xla/xla_client/computation_client.h"
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "torch/csrc/lazy/core/tensor_util.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/aten_xla_bridge.h"
 #include "torch_xla/csrc/device.h"
 #include "torch_xla/csrc/layout_manager.h"
@@ -141,7 +142,7 @@ void XLATensorImpl::SetupSizeProperties() {
     }
     sizes_and_strides_.set_sizes(updated_sizes);
     auto updated_strides = torch::lazy::ComputeArrayStrides(
-        xla::util::ToVector<int64_t>(shape.get().dimensions()));
+        torch::lazy::ToVector<int64_t>(shape.get().dimensions()));
     for (int i = 0; i < updated_strides.size(); i++) {
       sizes_and_strides_.stride_at_unchecked(i) = updated_strides[i];
     }

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -12,6 +12,7 @@
 #include "tensorflow/compiler/xla/xla_client/xla_util.h"
 #include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/lazy/core/helpers.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/aten_xla_bridge.h"
 #include "torch_xla/csrc/data_ops.h"
 #include "torch_xla/csrc/helpers.h"
@@ -159,7 +160,7 @@ ir::Value MaybeExpand(const ir::Value& input, const xla::Shape& target_shape) {
     return input;
   }
   return ir::MakeNode<ir::ops::Expand>(
-      input, xla::util::ToVector<int64_t>(target_shape.dimensions()));
+      input, torch::lazy::ToVector<int64_t>(target_shape.dimensions()));
 }
 
 MinMaxValues GetMinMaxValues(const XLATensor& tensor,
@@ -252,7 +253,7 @@ std::vector<int64_t> CheckIntList(absl::Span<const int64_t> list, size_t length,
   if (list.empty()) {
     result = std::move(def);
   } else {
-    result = xla::util::ToVector<int64_t>(list);
+    result = torch::lazy::ToVector<int64_t>(list);
   }
   if (result.size() == 1 && length > 1) {
     result.resize(length, result[0]);
@@ -2398,7 +2399,7 @@ void XLATensor::copy_(XLATensor& input, XLATensor& src) {
     at::Tensor src_tensor = src.ToTensor(/*detached=*/true);
     if (!xla::util::Equal(src_tensor.sizes(), input_shape.get().dimensions())) {
       src_tensor = src_tensor.expand(
-          xla::util::ToVector<int64_t>(input_shape.get().dimensions()));
+          torch::lazy::ToVector<int64_t>(input_shape.get().dimensions()));
     }
     input.UpdateFromTensor(std::move(src_tensor), /*sync=*/false);
   }

--- a/torch_xla/csrc/tensor_ops.cpp
+++ b/torch_xla/csrc/tensor_ops.cpp
@@ -3,6 +3,7 @@
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
 #include "torch/csrc/lazy/core/helpers.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/ir.h"
 
@@ -65,7 +66,7 @@ XLATensor KlDivBackward(const XLATensor& grad_output, const XLATensor& input,
   auto input_shape_ref = input.shape();
   XLATensor expanded_grad_output = XLATensor::expand(
       grad_output,
-      xla::util::ToVector<int64_t>(input_shape_ref.get().dimensions()));
+      torch::lazy::ToVector<int64_t>(input_shape_ref.get().dimensions()));
   XLATensor grad_input;
   if (!log_target) {
     grad_input = XLATensor::where(
@@ -114,7 +115,7 @@ XLATensor SmoothL1Loss(const XLATensor& input, const XLATensor& target,
   XLATensor elementwise_loss = XLATensor::where(
       XLATensor::lt(abs_diff, beta_scalar), squared_loss, l1_loss);
   auto all_dimensions =
-      xla::util::Iota<int64_t>((*broadcasted_input.shape()).rank());
+      torch::lazy::Iota<int64_t>((*broadcasted_input.shape()).rank());
   switch (reduction) {
     case ReductionMode::kNone:
       return elementwise_loss;
@@ -126,7 +127,7 @@ XLATensor SmoothL1Loss(const XLATensor& input, const XLATensor& target,
                             broadcasted_input.dtype());
     default:
       XLA_ERROR() << "Invalid reduction type: "
-                  << xla::util::GetEnumValue(reduction);
+                  << torch::lazy::GetEnumValue(reduction);
   }
 }
 
@@ -167,7 +168,7 @@ XLATensor SmoothL1LossBackward(const XLATensor& grad_output,
     }
     default:
       XLA_ERROR() << "Invalid reduction type: "
-                  << xla::util::GetEnumValue(reduction);
+                  << torch::lazy::GetEnumValue(reduction);
   }
 }
 
@@ -237,7 +238,7 @@ XLATensor EmbeddingDenseBackward(const XLATensor& grad_output,
       XLATensor::ne(indices_rank1, static_cast<double>(padding_idx)), 1);
   skip_padding = XLATensor::expand(
       skip_padding,
-      xla::util::ToVector<int64_t>(grad.shape().get().dimensions()));
+      torch::lazy::ToVector<int64_t>(grad.shape().get().dimensions()));
   XLATensor zero_grad =
       XLATensor::full_like(grad, 0, grad.GetDevice(), grad.dtype());
   return XLATensor::index_put(

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -20,6 +20,7 @@
 #include "tensorflow/compiler/xla/xla_client/util.h"
 #include "tensorflow/core/lib/bfloat16/bfloat16.h"
 #include "torch/csrc/lazy/core/hash.h"
+#include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/layout_manager.h"
 
@@ -342,7 +343,7 @@ std::vector<int64_t> GetIterationDimensions(const xla::Shape& shape) {
   // is more than kMinorDimScale times the most minor one.
   static const int64_t kMinorDimScale = 8;
   std::vector<int64_t> iter_dims =
-      xla::util::ToVector<int64_t>(shape.layout().minor_to_major());
+      torch::lazy::ToVector<int64_t>(shape.layout().minor_to_major());
   size_t index = 0;
   int64_t scaled_dim_size = kMinorDimScale * shape.dimensions(iter_dims[index]);
   for (size_t i = 1; i < iter_dims.size(); ++i) {
@@ -626,7 +627,7 @@ template <typename SType, typename DType>
 at::Tensor XlaLiteralToTensor(const xla::Literal& literal,
                               at::ScalarType atype) {
   std::vector<int64_t> dimensions =
-      xla::util::ToVector<int64_t>(literal.shape().dimensions());
+      torch::lazy::ToVector<int64_t>(literal.shape().dimensions());
   xla::Shape torch_shape = MakeTorchTensorLayout(
       literal.shape().dimensions(), /*dynamic_dimensions=*/{},
       literal.shape().element_type());

--- a/torch_xla/csrc/view.cpp
+++ b/torch_xla/csrc/view.cpp
@@ -105,8 +105,7 @@ ir::Value ApplyUpdate(ir::Value ir_value,
       case ViewInfo::Type::kAsStrided:
         result = ir::MakeNode<ir::ops::AsStridedViewUpdate>(
             tmp_values[i - 1], result,
-            torch::lazy::ToVector<int64_t>(
-                view_info.source_shape.dimensions()),
+            torch::lazy::ToVector<int64_t>(view_info.source_shape.dimensions()),
             view_info.as_strided->stride, view_info.as_strided->offset);
         break;
       case ViewInfo::Type::kDiagonal:

--- a/torch_xla/csrc/xla_lower_util.cpp
+++ b/torch_xla/csrc/xla_lower_util.cpp
@@ -99,10 +99,8 @@ std::pair<xla::XlaOp, xla::XlaOp> DotBroadcast(xla::XlaOp lhs,
                                                const xla::Shape& lhs_shape,
                                                xla::XlaOp rhs,
                                                const xla::Shape& rhs_shape) {
-  auto lhs_dimensions =
-      torch::lazy::ToVector<int64_t>(lhs_shape.dimensions());
-  auto rhs_dimensions =
-      torch::lazy::ToVector<int64_t>(rhs_shape.dimensions());
+  auto lhs_dimensions = torch::lazy::ToVector<int64_t>(lhs_shape.dimensions());
+  auto rhs_dimensions = torch::lazy::ToVector<int64_t>(rhs_shape.dimensions());
   XLA_CHECK_EQ(lhs_dimensions.size(), rhs_dimensions.size());
   for (int64_t i = 0; i < lhs_dimensions.size() - 2; ++i) {
     if (lhs_dimensions[i] == rhs_dimensions[i]) {
@@ -122,13 +120,11 @@ std::pair<xla::XlaOp, xla::XlaOp> DotBroadcast(xla::XlaOp lhs,
   xla::XlaOp broadcasted_rhs = rhs;
   if (lhs_dimensions != lhs_shape.dimensions()) {
     broadcasted_lhs = xla::BroadcastInDim(
-        lhs, lhs_dimensions,
-        torch::lazy::Iota<int64_t>(lhs_dimensions.size()));
+        lhs, lhs_dimensions, torch::lazy::Iota<int64_t>(lhs_dimensions.size()));
   }
   if (rhs_dimensions != rhs_shape.dimensions()) {
     broadcasted_rhs = xla::BroadcastInDim(
-        rhs, rhs_dimensions,
-        torch::lazy::Iota<int64_t>(rhs_dimensions.size()));
+        rhs, rhs_dimensions, torch::lazy::Iota<int64_t>(rhs_dimensions.size()));
   }
   return std::make_pair(broadcasted_lhs, broadcasted_rhs);
 }


### PR DESCRIPTION
[LTC, Phase 1] Migrate to upstream torch::lazy::util.h

Migrated util functions include:
- torch::lazy::Iota
- torch::lazy::ToVector
- torch::lazy::GetEnumValue

In PTXLA, we were using `xla::util` versions of these util functions, so we don't have anything to remove on our end. But to stay consistent, we've migrated to PyTorch's versions of these functions. 