### PR TITLE
Disable failing tests on TPU

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -360,6 +360,18 @@ DISABLED_TORCH_TESTS_TPU_ONLY = {
         'test_EmbeddingBag_per_sample_weights_and_offsets_xla',  # server side crash
         'test_upsamplingBilinear2d_xla',  # precision
         'test_upsamplingNearest2d_xla',  # precision
+        'test_GRU_grad_and_gradgrad_xla_float64',  # grad check failure
+        'test_LSTM_grad_and_gradgrad_xla_float64',  # grad check failure
+        'test_conv3d_valid_padding_backward_xla',  # grad check failure
+        'test_ctc_loss_xla',  # runtime overflow error
+        'test_upsamplingBicubic2d_antialias_False_align_corners_False_xla',  # grad check failure
+        'test_upsamplingBicubic2d_antialias_False_align_corners_True_xla',  # grad check failure
+        'test_upsamplingBicubic2d_antialias_True_align_corners_False_xla',  # grad check failure
+        'test_upsamplingBicubic2d_antialias_True_align_corners_True_xla',  # grad check failure
+        'test_upsamplingNearest1d_xla',  # grad check failure
+        'test_upsamplingNearest3d_xla',  # grad check failure
+        'test_cross_entropy_label_smoothing_consistent_index_target_and_probs_xla',  # precision
+        'test_cross_entropy_loss_prob_target_all_reductions_xla',  # precision
     },
 
     # test_type_promotion.py

--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -340,6 +340,9 @@ DISABLED_TORCH_TESTS_TPU_ONLY = {
         'test_softplus_low_threshold_xla',  # server side crash
         'test_put_xla',  # slow on TPU (~20 min each)
         'test_cov_xla',  # precision (9.53674e-07 vs 0)
+        'test_diff_xla_float32',  # expected instruction to have shape equal
+        'test_diff_xla_float64',  # expected instruction to have shape equal
+        'test_nullary_op_mem_overlap_xla'  # core dumped
     },
 
     # test_indexing.py


### PR DESCRIPTION
We've had op tests failing for a while in TPU. Since our tests are always failing, it's hard to distinguish new potential bugs coming in. This PR attempts to make our op tests in TPU green again by disabling currently failing tests.

With these disabled tests, I can confirm that these tests are correctly getting skipped while testing on TPU. 

Issue tracking the disabled tests: https://github.com/pytorch/xla/issues/3333.

Pending: run all tests via `test/run_tests.sh`. 