### PR TITLE
Remove unused var dispatches in favor of var.correction

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3514,26 +3514,6 @@ at::Tensor XLANativeFunctions::upsample_nearest2d_backward(
       xla::util::ToVector<xla::int64_t>(input_size)));
 }
 
-at::Tensor XLANativeFunctions::var(const at::Tensor& self, bool unbiased) {
-  XLA_FN_COUNTER("xla::");
-  XLATensor self_tensor = bridge::GetXlaTensor(self);
-  return bridge::AtenFromXlaTensor(
-      XLATensor::var(bridge::GetXlaTensor(self),
-                     xla::util::Iota<xla::int64_t>(
-                         bridge::GetXlaTensor(self).shape().get().rank()),
-                     /*correction=*/unbiased ? 1 : 0,
-                     /*keep_reduced_dimensions=*/false));
-}
-
-at::Tensor XLANativeFunctions::var(const at::Tensor& self, at::IntArrayRef dim,
-                                   bool unbiased, bool keepdim) {
-  XLA_FN_COUNTER("xla::");
-  XLATensor self_tensor = bridge::GetXlaTensor(self);
-  return bridge::AtenFromXlaTensor(
-      XLATensor::var(self_tensor, XlaHelpers::I64List(dim),
-                     /*correction=*/unbiased ? 1 : 0, keepdim));
-}
-
 at::Tensor XLANativeFunctions::var(const at::Tensor& self,
                                    c10::optional<at::IntArrayRef> dim,
                                    c10::optional<int64_t> correction,

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -322,9 +322,7 @@ supported:
   - upsample_nearest2d.vec
   - upsample_nearest2d_backward
   - upsample_nearest2d_backward.vec
-  - var
   - var.correction
-  - var.dim
   - var_mean.correction
   - view
   - xlogy.Tensor


### PR DESCRIPTION
Partially addresisng the issue raised in #3247 to fix `var` autograd issue.