### PR TITLE
Revert "TF version bump to resolve v2-nightly, libtpu-nightly runtime issues"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ import torch
 base_dir = os.path.dirname(os.path.abspath(__file__))
 third_party_path = os.path.join(base_dir, 'third_party')
 
-_libtpu_version = '0.1.dev20220128'
+_libtpu_version = '0.1.dev20211015'
 _litbpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
 
 

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -12,7 +12,6 @@
 #include <utility>
 #include <vector>
 
-#include "absl/hash/hash.h"
 #include "absl/types/span.h"
 #include "tensorflow/compiler/xla/client/xla_builder.h"
 #include "tensorflow/compiler/xla/xla_client/types.h"

--- a/torch_xla/csrc/ops/constant.cpp
+++ b/torch_xla/csrc/ops/constant.cpp
@@ -11,7 +11,7 @@ namespace ops {
 
 Constant::Constant(xla::Literal value)
     : Node(OpKind(at::prim::Constant), value.shape(), /*num_outputs=*/1,
-           absl::Hash<xla::LiteralBase>{}(value)),
+           value.Hash()),
       value_(std::move(value)) {}
 
 std::string Constant::ToString() const {


### PR DESCRIPTION
Reverts pytorch/xla#3345 as it seemingly broke PyTorch OSS CI, see https://github.com/pytorch/pytorch/actions/runs/1809292357 , which is the test run on a completely unrelated PR. All subsequent tests seem to crash runner so no logs can be collected