### PR TITLE
Lower `torch._linalg_svd`

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -847,7 +847,7 @@ TEST_F(AtenXlaTensorTest, TestSVD) {
 }
 
 TEST_F(AtenXlaTensorTest, TestLinalgSVD) {
-  static const int dims[] = {4, 7};
+  static const int dims[] = {0, 4, 7};
   for (auto m : dims) {
     for (auto n : dims) {
       torch::Tensor a =

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -852,10 +852,12 @@ TEST_F(AtenXlaTensorTest, TestLinalgSVD) {
     for (auto n : dims) {
       torch::Tensor a =
           torch::rand({m, n}, torch::TensorOptions(torch::kFloat));
-      auto b = torch::_linalg_svd(a, /*full_matrices=*/false, /*compute_uv=*/true);
+      auto b =
+          torch::_linalg_svd(a, /*full_matrices=*/false, /*compute_uv=*/true);
       ForEachDevice([&](const torch::Device& device) {
         torch::Tensor xla_a = CopyToDevice(a, device);
-        auto xla_b = torch::_linalg_svd(xla_a, /*full_matrices=*/false, /*compute_uv=*/true);
+        auto xla_b = torch::_linalg_svd(xla_a, /*full_matrices=*/false,
+                                        /*compute_uv=*/true);
         // The U and V matrices might have different sign for column vectors, so
         // cannot be compared if not by absolute value.
         AllClose(std::get<0>(b).abs(), std::get<0>(xla_b).abs(), /*rtol=*/1e-3,

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -462,17 +462,19 @@ at::Tensor& XLANativeFunctions::_index_put_impl_(
                                                    accumulate);
 }
 
-std::tuple<at::Tensor,at::Tensor,at::Tensor> XLANativeFunctions::_linalg_svd(const at::Tensor& A, bool full_matrices, bool compute_uv) {
+std::tuple<at::Tensor, at::Tensor, at::Tensor> XLANativeFunctions::_linalg_svd(
+    const at::Tensor& A, bool full_matrices, bool compute_uv) {
   XLA_FN_COUNTER("xla::");
   // Should return conjugate transpose of V, but conjugate is not yet lowered.
   // Fall back to CPU for complex types until conjugate is lowered.
   if (A.is_complex()) {
-    return at::native::call_fallback_fn<&xla_cpu_fallback,
-                                        ATEN_OP(_linalg_svd)>::call(
-                                          A, full_matrices, compute_uv);
+    return at::native::call_fallback_fn<
+        &xla_cpu_fallback, ATEN_OP(_linalg_svd)>::call(A, full_matrices,
+                                                       compute_uv);
   }
 
-  auto results = XLATensor::_linalg_svd(bridge::GetXlaTensor(A), full_matrices, compute_uv);
+  auto results = XLATensor::_linalg_svd(bridge::GetXlaTensor(A), full_matrices,
+                                        compute_uv);
   return std::make_tuple(bridge::AtenFromXlaTensor(std::get<0>(results)),
                          bridge::AtenFromXlaTensor(std::get<1>(results)),
                          bridge::AtenFromXlaTensor(std::get<2>(results)));

--- a/torch_xla/csrc/ops/svd.cpp
+++ b/torch_xla/csrc/ops/svd.cpp
@@ -14,7 +14,8 @@ namespace ir {
 namespace ops {
 namespace {
 
-std::vector<xla::XlaOp> LowerSVD(xla::XlaOp input, bool full_matrices, bool compute_uv, bool deprecated_svd) {
+std::vector<xla::XlaOp> LowerSVD(xla::XlaOp input, bool full_matrices,
+                                 bool compute_uv, bool deprecated_svd) {
   xla::SVDResult svd_result =
       xla::SVD(input, /*max_iter=*/100, /*epsilon=*/1e-6,
                XlaHelpers::mat_mul_precision());
@@ -22,8 +23,12 @@ std::vector<xla::XlaOp> LowerSVD(xla::XlaOp input, bool full_matrices, bool comp
   xla::XlaOp u = svd_result.u;
   xla::XlaOp v = svd_result.v;
   if (!compute_uv) {
-    xla::Shape u_shape = deprecated_svd ? XlaHelpers::ShapeOfXlaOp(u) : xla::ShapeUtil::MakeShape(input_shape.element_type(), {0});
-    xla::Shape v_shape = deprecated_svd ? XlaHelpers::ShapeOfXlaOp(v) :  xla::ShapeUtil::MakeShape(input_shape.element_type(), {0});
+    xla::Shape u_shape = deprecated_svd ? XlaHelpers::ShapeOfXlaOp(u)
+                                        : xla::ShapeUtil::MakeShape(
+                                              input_shape.element_type(), {0});
+    xla::Shape v_shape = deprecated_svd ? XlaHelpers::ShapeOfXlaOp(v)
+                                        : xla::ShapeUtil::MakeShape(
+                                              input_shape.element_type(), {0});
     u = xla::Zeros(input.builder(), u_shape);
     v = xla::Zeros(input.builder(), v_shape);
   } else if (!full_matrices) {
@@ -56,7 +61,8 @@ std::vector<xla::XlaOp> LowerSVD(xla::XlaOp input, bool full_matrices, bool comp
   return {u, svd_result.d, v};
 }
 
-xla::Shape NodeOutputShape(const Value& input, bool full_matrices, bool compute_uv, bool deprecated_svd) {
+xla::Shape NodeOutputShape(const Value& input, bool full_matrices,
+                           bool compute_uv, bool deprecated_svd) {
   const xla::Shape& input_shape = input.shape();
   XLA_CHECK_GE(input_shape.rank(), 2) << input_shape;
   // The input tensor is ...,M,N
@@ -96,27 +102,35 @@ xla::Shape NodeOutputShape(const Value& input, bool full_matrices, bool compute_
 
 }  // namespace
 
-SVD::SVD(const Value& input, bool full_matrices, bool compute_uv, bool deprecated_svd)
+SVD::SVD(const Value& input, bool full_matrices, bool compute_uv,
+         bool deprecated_svd)
     : Node(torch::lazy::OpKind(at::aten::svd), {input},
-           [&]() { return NodeOutputShape(input, full_matrices, compute_uv, deprecated_svd); },
-           /*num_outputs=*/3, torch::lazy::MHash(full_matrices, compute_uv, deprecated_svd)),
+           [&]() {
+             return NodeOutputShape(input, full_matrices, compute_uv,
+                                    deprecated_svd);
+           },
+           /*num_outputs=*/3,
+           torch::lazy::MHash(full_matrices, compute_uv, deprecated_svd)),
       full_matrices_(full_matrices),
       compute_uv_(compute_uv),
       deprecated_svd_(deprecated_svd) {}
 
 NodePtr SVD::Clone(OpList operands) const {
-  return MakeNode<SVD>(operands.at(0), full_matrices_, compute_uv_, deprecated_svd_);
+  return MakeNode<SVD>(operands.at(0), full_matrices_, compute_uv_,
+                       deprecated_svd_);
 }
 
 XlaOpVector SVD::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
-  return ReturnOps(LowerSVD(input, full_matrices_, compute_uv_, deprecated_svd_), loctx);
+  return ReturnOps(
+      LowerSVD(input, full_matrices_, compute_uv_, deprecated_svd_), loctx);
 }
 
 std::string SVD::ToString() const {
   std::stringstream ss;
   ss << Node::ToString() << ", full_matrices=" << full_matrices_
-     << ", compute_uv=" << compute_uv_ << ", deprecated_svd=" << deprecated_svd_;
+     << ", compute_uv=" << compute_uv_
+     << ", deprecated_svd=" << deprecated_svd_;
   return ss.str();
 }
 

--- a/torch_xla/csrc/ops/svd.cpp
+++ b/torch_xla/csrc/ops/svd.cpp
@@ -14,7 +14,7 @@ namespace ir {
 namespace ops {
 namespace {
 
-std::vector<xla::XlaOp> LowerSVD(xla::XlaOp input, bool some, bool compute_uv) {
+std::vector<xla::XlaOp> LowerSVD(xla::XlaOp input, bool full_matrices, bool compute_uv, bool deprecated_svd) {
   xla::SVDResult svd_result =
       xla::SVD(input, /*max_iter=*/100, /*epsilon=*/1e-6,
                XlaHelpers::mat_mul_precision());
@@ -22,9 +22,11 @@ std::vector<xla::XlaOp> LowerSVD(xla::XlaOp input, bool some, bool compute_uv) {
   xla::XlaOp u = svd_result.u;
   xla::XlaOp v = svd_result.v;
   if (!compute_uv) {
-    u = xla::Zeros(input.builder(), XlaHelpers::ShapeOfXlaOp(u));
-    v = xla::Zeros(input.builder(), XlaHelpers::ShapeOfXlaOp(v));
-  } else if (some) {
+    xla::Shape u_shape = deprecated_svd ? XlaHelpers::ShapeOfXlaOp(u) : xla::ShapeUtil::MakeShape(input_shape.element_type(), {0});
+    xla::Shape v_shape = deprecated_svd ? XlaHelpers::ShapeOfXlaOp(v) :  xla::ShapeUtil::MakeShape(input_shape.element_type(), {0});
+    u = xla::Zeros(input.builder(), u_shape);
+    v = xla::Zeros(input.builder(), v_shape);
+  } else if (!full_matrices) {
     int64_t m_dim = input_shape.dimensions(input_shape.rank() - 2);
     int64_t n_dim = input_shape.dimensions(input_shape.rank() - 1);
     std::vector<int64_t> base_indices(input_shape.rank(), 0);
@@ -38,17 +40,33 @@ std::vector<xla::XlaOp> LowerSVD(xla::XlaOp input, bool some, bool compute_uv) {
     v_sizes[input_shape.rank() - 1] = std::min(m_dim, n_dim);
     v = BuildSlice(v, base_indices, v_sizes);
   }
+
+  // Return Vh (conjugate transpose) for torch.linalg.svd. Conjugate not lowered
+  // yet so just transpose.
+  if (compute_uv && !deprecated_svd) {
+    int64_t v_rank = XlaHelpers::ShapeOfXlaOp(v).rank();
+    auto dims = std::vector<int64_t>(v_rank);
+    std::iota(dims.begin(), dims.end(), 0);
+
+    dims[v_rank - 2] = v_rank - 1;
+    dims[v_rank - 1] = v_rank - 2;
+    v = xla::Transpose(v, dims);
+  }
+
   return {u, svd_result.d, v};
 }
 
-xla::Shape NodeOutputShape(const Value& input, bool some, bool compute_uv) {
+xla::Shape NodeOutputShape(const Value& input, bool full_matrices, bool compute_uv, bool deprecated_svd) {
   const xla::Shape& input_shape = input.shape();
   XLA_CHECK_GE(input_shape.rank(), 2) << input_shape;
   // The input tensor is ...,M,N
   int64_t m_dim = input_shape.dimensions(input_shape.rank() - 2);
   int64_t n_dim = input_shape.dimensions(input_shape.rank() - 1);
   xla::Shape ushape(input_shape);
-  if (!compute_uv || !some) {
+
+  if (!compute_uv && !deprecated_svd) {
+    ushape = xla::ShapeUtil::MakeShape(input_shape.element_type(), {0});
+  } else if (!compute_uv || full_matrices) {
     ushape.set_dimensions(input_shape.rank() - 1, m_dim);
   } else {
     ushape.set_dimensions(input_shape.rank() - 1, std::min(m_dim, n_dim));
@@ -58,35 +76,47 @@ xla::Shape NodeOutputShape(const Value& input, bool some, bool compute_uv) {
                                                 {std::min(m_dim, n_dim)});
   // V is NxN
   xla::Shape vshape(input_shape);
-  vshape.set_dimensions(input_shape.rank() - 2, n_dim);
-  if (some) {
-    vshape.set_dimensions(input_shape.rank() - 1, std::min(m_dim, n_dim));
+  if (!deprecated_svd) {
+    if (compute_uv) {
+      vshape.set_dimensions(input_shape.rank() - 1, n_dim);
+      vshape.set_dimensions(input_shape.rank() - 2,
+                            full_matrices ? m_dim : std::min(m_dim, n_dim));
+    } else {
+      vshape = xla::ShapeUtil::MakeShape(input_shape.element_type(), {0});
+    }
+  } else {
+    vshape.set_dimensions(input_shape.rank() - 2, n_dim);
+    if (!full_matrices) {
+      vshape.set_dimensions(input_shape.rank() - 1, std::min(m_dim, n_dim));
+    }
   }
+
   return xla::ShapeUtil::MakeTupleShape({ushape, dshape, vshape});
 }
 
 }  // namespace
 
-SVD::SVD(const Value& input, bool some, bool compute_uv)
+SVD::SVD(const Value& input, bool full_matrices, bool compute_uv, bool deprecated_svd)
     : Node(torch::lazy::OpKind(at::aten::svd), {input},
-           [&]() { return NodeOutputShape(input, some, compute_uv); },
-           /*num_outputs=*/3, torch::lazy::MHash(some, compute_uv)),
-      some_(some),
-      compute_uv_(compute_uv) {}
+           [&]() { return NodeOutputShape(input, full_matrices, compute_uv, deprecated_svd); },
+           /*num_outputs=*/3, torch::lazy::MHash(full_matrices, compute_uv, deprecated_svd)),
+      full_matrices_(full_matrices),
+      compute_uv_(compute_uv),
+      deprecated_svd_(deprecated_svd) {}
 
 NodePtr SVD::Clone(OpList operands) const {
-  return MakeNode<SVD>(operands.at(0), some_, compute_uv_);
+  return MakeNode<SVD>(operands.at(0), full_matrices_, compute_uv_, deprecated_svd_);
 }
 
 XlaOpVector SVD::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
-  return ReturnOps(LowerSVD(input, some_, compute_uv_), loctx);
+  return ReturnOps(LowerSVD(input, full_matrices_, compute_uv_, deprecated_svd_), loctx);
 }
 
 std::string SVD::ToString() const {
   std::stringstream ss;
-  ss << Node::ToString() << ", some=" << some_
-     << ", compute_uv=" << compute_uv_;
+  ss << Node::ToString() << ", full_matrices=" << full_matrices_
+     << ", compute_uv=" << compute_uv_ << ", deprecated_svd=" << deprecated_svd_;
   return ss.str();
 }
 

--- a/torch_xla/csrc/ops/svd.h
+++ b/torch_xla/csrc/ops/svd.h
@@ -8,7 +8,8 @@ namespace ops {
 
 class SVD : public Node {
  public:
-  SVD(const Value& input, bool full_matrices, bool compute_uv, bool deprecated_svd);
+  SVD(const Value& input, bool full_matrices, bool compute_uv,
+      bool deprecated_svd);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/svd.h
+++ b/torch_xla/csrc/ops/svd.h
@@ -8,7 +8,7 @@ namespace ops {
 
 class SVD : public Node {
  public:
-  SVD(const Value& input, bool some, bool compute_uv);
+  SVD(const Value& input, bool full_matrices, bool compute_uv, bool deprecated_svd);
 
   std::string ToString() const override;
 
@@ -16,13 +16,14 @@ class SVD : public Node {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  bool some() const { return some_; }
+  bool full_matrices() const { return full_matrices_; }
 
   bool compute_uv() const { return compute_uv_; }
 
  private:
-  bool some_;
+  bool full_matrices_;
   bool compute_uv_;
+  bool deprecated_svd_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -322,7 +322,8 @@ class XLATensor {
                                  double scale_backoff_factor,
                                  int growth_interval);
 
-  static std::tuple<XLATensor, XLATensor, XLATensor> _linalg_svd(const XLATensor& A, bool full_matrices, bool compute_uv);
+  static std::tuple<XLATensor, XLATensor, XLATensor> _linalg_svd(
+      const XLATensor& A, bool full_matrices, bool compute_uv);
 
   static XLATensor abs(const XLATensor& input);
 

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -322,6 +322,8 @@ class XLATensor {
                                  double scale_backoff_factor,
                                  int growth_interval);
 
+  static std::tuple<XLATensor, XLATensor, XLATensor> _linalg_svd(const XLATensor& A, bool full_matrices, bool compute_uv);
+
   static XLATensor abs(const XLATensor& input);
 
   static XLATensor acos(const XLATensor& input);

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -631,6 +631,14 @@ void XLATensor::_amp_update_scale_(XLATensor& current_scale,
   current_scale.SetInPlaceIrValue(ir::Value(node, 0));
 }
 
+std::tuple<XLATensor, XLATensor, XLATensor> XLATensor::_linalg_svd(const XLATensor& input, bool full_matrices, bool compute_uv) {
+  ir::NodePtr node =
+    ir::MakeNode<ir::ops::SVD>(input.GetIrValue(), full_matrices, compute_uv, /*deprecated_svd=*/false);
+  return std::make_tuple(input.CreateFrom(ir::Value(node, 0)),
+                         input.CreateFrom(ir::Value(node, 1)),
+                         input.CreateFrom(ir::Value(node, 2)));
+}
+
 XLATensor XLATensor::abs(const XLATensor& input) {
   return input.CreateFrom(ir::ops::Abs(input.GetIrValue()));
 }
@@ -2709,7 +2717,7 @@ XLATensor XLATensor::sum(const XLATensor& input,
 std::tuple<XLATensor, XLATensor, XLATensor> XLATensor::svd(
     const XLATensor& input, bool some, bool compute_uv) {
   ir::NodePtr node =
-      ir::MakeNode<ir::ops::SVD>(input.GetIrValue(), some, compute_uv);
+      ir::MakeNode<ir::ops::SVD>(input.GetIrValue(), /*full_matrices=*/!some, compute_uv, /*deprecated_svd=*/true);
   return std::make_tuple(input.CreateFrom(ir::Value(node, 0)),
                          input.CreateFrom(ir::Value(node, 1)),
                          input.CreateFrom(ir::Value(node, 2)));

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -631,9 +631,10 @@ void XLATensor::_amp_update_scale_(XLATensor& current_scale,
   current_scale.SetInPlaceIrValue(ir::Value(node, 0));
 }
 
-std::tuple<XLATensor, XLATensor, XLATensor> XLATensor::_linalg_svd(const XLATensor& input, bool full_matrices, bool compute_uv) {
-  ir::NodePtr node =
-    ir::MakeNode<ir::ops::SVD>(input.GetIrValue(), full_matrices, compute_uv, /*deprecated_svd=*/false);
+std::tuple<XLATensor, XLATensor, XLATensor> XLATensor::_linalg_svd(
+    const XLATensor& input, bool full_matrices, bool compute_uv) {
+  ir::NodePtr node = ir::MakeNode<ir::ops::SVD>(
+      input.GetIrValue(), full_matrices, compute_uv, /*deprecated_svd=*/false);
   return std::make_tuple(input.CreateFrom(ir::Value(node, 0)),
                          input.CreateFrom(ir::Value(node, 1)),
                          input.CreateFrom(ir::Value(node, 2)));
@@ -2717,7 +2718,8 @@ XLATensor XLATensor::sum(const XLATensor& input,
 std::tuple<XLATensor, XLATensor, XLATensor> XLATensor::svd(
     const XLATensor& input, bool some, bool compute_uv) {
   ir::NodePtr node =
-      ir::MakeNode<ir::ops::SVD>(input.GetIrValue(), /*full_matrices=*/!some, compute_uv, /*deprecated_svd=*/true);
+      ir::MakeNode<ir::ops::SVD>(input.GetIrValue(), /*full_matrices=*/!some,
+                                 compute_uv, /*deprecated_svd=*/true);
   return std::make_tuple(input.CreateFrom(ir::Value(node, 0)),
                          input.CreateFrom(ir::Value(node, 1)),
                          input.CreateFrom(ir::Value(node, 2)));

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -18,6 +18,7 @@ supported:
   - _copy_from
   - _copy_from_and_resize
   - _index_put_impl_
+  - _linalg_svd
   - _local_scalar_dense
   - _log_softmax
   - _log_softmax_backward_data


### PR DESCRIPTION
@JackCaoG FYI

- Update `some` to `full_matrices` in `svd.cpp/h` to be consistent with `torch.linalg.svd*`
- Add `deprecated_svd` flag to `SVD` to determine output shape. See the [PyTorch docs](https://pytorch.org/docs/stable/generated/torch.svd.html) for an explanation of the differences between `torch.svd` (deprecated) and `torch.linalg.svd`.
- Fall back to CPU for complex numbers, since we need to return the conjugate transpose of `V` (i.e. `Vh`), but conjugate is not yet lowered.
- Re-enable `TestNuclearNorm`