### PR TITLE
Update circleci base image with TF version bump

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,16 +15,16 @@ launch_docker_and_build: &launch_docker_and_build
   name: Launch Docker Container and Build
   no_output_timeout: "1h"
   command: |
-    set -e
+    set -ex
     eval $(aws ecr get-login --region us-east-1 --no-include-email)
-    time docker pull ${GCR_DOCKER_IMAGE} >/dev/null
+    docker pull ${GCR_DOCKER_IMAGE} >/dev/null
     # This is to stage PyTorch/XLA base image for use in the upstream. Right now,
     # we are using PyTorch base image in the upstream test -- but, in case
     # we also want the upstream workflow to use PyTorch/XLA build image, we
     # need to have them in the ECR. This is not expensive, and only pushes it
     # if image layers are not present in the repo.
-    time docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:latest >/dev/null
-    time docker push ${ECR_DOCKER_IMAGE_BASE}:latest >/dev/null
+    docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:latest >/dev/null
+    docker push ${ECR_DOCKER_IMAGE_BASE}:latest >/dev/null
     sudo pkill -SIGHUP dockerd
     # To enable remote caching, use SCCACHE_BUCKET=${SCCACHE_BUCKET}
     echo "declare -x SCCACHE_BUCKET=${LOCAL_BUCKET}" >> /home/circleci/project/env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,9 @@ launch_docker_and_build: &launch_docker_and_build
     # need to have them in the ECR. This is not expensive, and only pushes it
     # if image layers are not present in the repo.
     docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:latest >/dev/null
-    docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:v0.1 >/dev/null
+    docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:v0.2 >/dev/null
     docker push ${ECR_DOCKER_IMAGE_BASE}:latest >/dev/null
-    docker push ${ECR_DOCKER_IMAGE_BASE}:v0.1 >/dev/null
+    docker push ${ECR_DOCKER_IMAGE_BASE}:v0.2 >/dev/null
     sudo pkill -SIGHUP dockerd
     # To enable remote caching, use SCCACHE_BUCKET=${SCCACHE_BUCKET}
     echo "declare -x SCCACHE_BUCKET=${LOCAL_BUCKET}" >> /home/circleci/project/env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ launch_docker_and_build: &launch_docker_and_build
     # need to have them in the ECR. This is not expensive, and only pushes it
     # if image layers are not present in the repo.
     time docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:latest >/dev/null
-    time docker push ${ECR_DOCKER_IMAGE} >/dev/null
+    time docker push ${ECR_DOCKER_IMAGE_BASE}:latest >/dev/null
     sudo pkill -SIGHUP dockerd
     # To enable remote caching, use SCCACHE_BUCKET=${SCCACHE_BUCKET}
     echo "declare -x SCCACHE_BUCKET=${LOCAL_BUCKET}" >> /home/circleci/project/env
@@ -82,7 +82,7 @@ calculate_docker_image: &calculate_docker_image
     git clone --quiet https://github.com/pytorch/pytorch.git "/tmp/pytorch"
     git -C /tmp/pytorch rev-parse HEAD:.circleci/docker
     DOCKER_TAG=$(git -C /tmp/pytorch rev-parse HEAD:.circleci/docker)
-    echo "declare -x DOCKER_TAG=${DOCKER_TAG]" >> "${BASH_ENV}"
+    echo "declare -x DOCKER_TAG=${DOCKER_TAG}" >> "${BASH_ENV}"
     # For staging our build image in ECR for upstream testing
     echo "declare -x ECR_DOCKER_IMAGE_BASE=308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/xla_base" >> "${BASH_ENV}"
     # For PyTorch/XLA CI workflow, we only pull & push to gcr.io

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,9 @@ launch_docker_and_build: &launch_docker_and_build
     # need to have them in the ECR. This is not expensive, and only pushes it
     # if image layers are not present in the repo.
     docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:latest >/dev/null
+    docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:v0.1 >/dev/null
     docker push ${ECR_DOCKER_IMAGE_BASE}:latest >/dev/null
+    docker push ${ECR_DOCKER_IMAGE_BASE}:v0.1 >/dev/null
     sudo pkill -SIGHUP dockerd
     # To enable remote caching, use SCCACHE_BUCKET=${SCCACHE_BUCKET}
     echo "declare -x SCCACHE_BUCKET=${LOCAL_BUCKET}" >> /home/circleci/project/env
@@ -87,7 +89,7 @@ calculate_docker_image: &calculate_docker_image
     echo "declare -x ECR_DOCKER_IMAGE_BASE=308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/xla_base" >> "${BASH_ENV}"
     # For PyTorch/XLA CI workflow, we only pull & push to gcr.io
     BASE_IMAGE_TAG="3.7-11.2.0-cudnn8-devel-ubuntu18.04-mini"
-    echo "declare -x GCR_DOCKER_IMAGE=gcr.io/tpu-pytorch/xla_base:${BASE_IMAGE_TAG}" >> "${BASH_ENV}"
+    echo "declare -x GCR_DOCKER_IMAGE=gcr.io/tpu-pytorch/xla_base:latest" >> "${BASH_ENV}"
 
 run_build: &run_build
   resource_class: 2xlarge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ launch_docker_and_build: &launch_docker_and_build
     # we also want the upstream workflow to use PyTorch/XLA build image, we
     # need to have them in the ECR. This is not expensive, and only pushes it
     # if image layers are not present in the repo.
-    time docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE} >/dev/null
+    time docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:latest >/dev/null
     time docker push ${ECR_DOCKER_IMAGE} >/dev/null
     sudo pkill -SIGHUP dockerd
     # To enable remote caching, use SCCACHE_BUCKET=${SCCACHE_BUCKET}
@@ -82,8 +82,9 @@ calculate_docker_image: &calculate_docker_image
     git clone --quiet https://github.com/pytorch/pytorch.git "/tmp/pytorch"
     git -C /tmp/pytorch rev-parse HEAD:.circleci/docker
     DOCKER_TAG=$(git -C /tmp/pytorch rev-parse HEAD:.circleci/docker)
+    echo "declare -x DOCKER_TAG=${DOCKER_TAG]" >> "${BASH_ENV}"
     # For staging our build image in ECR for upstream testing
-    echo "declare -x ECR_DOCKER_IMAGE=308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/xla_base:${DOCKER_TAG}" >> "${BASH_ENV}"
+    echo "declare -x ECR_DOCKER_IMAGE_BASE=308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/xla_base" >> "${BASH_ENV}"
     # For PyTorch/XLA CI workflow, we only pull & push to gcr.io
     BASE_IMAGE_TAG="3.7-11.2.0-cudnn8-devel-ubuntu18.04-mini"
     echo "declare -x GCR_DOCKER_IMAGE=gcr.io/tpu-pytorch/xla_base:${BASE_IMAGE_TAG}" >> "${BASH_ENV}"

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -87,7 +87,7 @@ ADD ./install_conda.sh install_conda.sh
 RUN sudo chown jenkins ./install_conda.sh
 RUN bash ./install_conda.sh "${python_version}" /opt/conda
 
-RUN echo "conda activate pytorch" >> ~/.bashrc
+RUN echo "conda activate base" >> ~/.bashrc
 RUN echo "export TF_CPP_LOG_THREAD_ID=1" >> ~/.bashrc
 ENV PATH /opt/conda/bin:$PATH
 

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -50,6 +50,10 @@ RUN apt-get install -y python-pip python3-pip git curl libopenblas-dev vim \
 ADD ./install_llvm_clang.sh install_llvm_clang.sh
 RUN bash ./install_llvm_clang.sh
 
+# Install valgrind
+ADD ./install_valgrind.sh install_valgrind.sh
+RUN bash ./install_valgrind.sh
+
 # Sets up jenkins user.
 RUN useradd jenkins && \
     mkdir /home/jenkins && \

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -44,7 +44,7 @@ ENV TPUVM_MODE "${tpuvm}"
 # Install base system packages
 RUN apt-get update
 RUN apt-get install -y python-pip python3-pip git curl libopenblas-dev vim \
-  apt-transport-https ca-certificates wget procps openssl libssl-dev sudo
+  apt-transport-https ca-certificates wget procps openssl libssl-dev sudo libc6-dbg
 
 # Install clang & llvm
 ADD ./install_llvm_clang.sh install_llvm_clang.sh

--- a/.circleci/docker/install_conda.sh
+++ b/.circleci/docker/install_conda.sh
@@ -30,12 +30,11 @@ function install_and_setup_conda() {
   conda update -y -n base conda
   conda install -y python=$PYTHON_VERSION
 
-  conda install -y numpy pyyaml mkl-include setuptools cmake cffi typing \
+  conda install -y numpy=1.18.5 pyyaml mkl-include setuptools cmake cffi typing \
     tqdm coverage hypothesis dataclasses cython
   /usr/bin/yes | pip install typing_extensions==3.10.0.2  # Required for Python<=3.7
   /usr/bin/yes | pip install --upgrade oauth2client
   /usr/bin/yes | pip install lark-parser
-  /usr/bin/yes | pip install --upgrade numpy>=1.14
   /usr/bin/yes | pip install --upgrade numba
   /usr/bin/yes | pip install cloud-tpu-client
   /usr/bin/yes | pip install expecttest==0.1.3

--- a/.circleci/docker/install_conda.sh
+++ b/.circleci/docker/install_conda.sh
@@ -21,19 +21,17 @@ function install_and_setup_conda() {
 
   echo ". ${CONDA_PREFIX}/etc/profile.d/conda.sh" >> ~/.bashrc
   source "${CONDA_PREFIX}/etc/profile.d/conda.sh"
-  ENVNAME="pytorch"
-  if conda env list | awk '{print $1}' | grep "^$ENVNAME$"; then
-    conda remove --name "$ENVNAME" --all
-  fi
+
   if [ -z "$PYTHON_VERSION" ]; then
     PYTHON_VERSION=$DEFAULT_PYTHON_VERSION
   fi
-  conda create -y --name "$ENVNAME" python=${PYTHON_VERSION} anaconda
-  conda activate "$ENVNAME"
   export CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 
+  conda update -y -n base conda
+  conda install -y python=$PYTHON_VERSION
+
   conda install -y numpy pyyaml mkl-include setuptools cmake cffi typing \
-    tqdm coverage hypothesis dataclasses scipy cython
+    tqdm coverage hypothesis dataclasses scipy cython scikit-image
   /usr/bin/yes | pip install typing_extensions==3.10.0.2  # Required for Python<=3.7
   /usr/bin/yes | pip install --upgrade oauth2client
   /usr/bin/yes | pip install lark-parser
@@ -48,6 +46,7 @@ function install_and_setup_conda() {
   /usr/bin/yes | pip install boto3
   /usr/bin/yes | pip install mypy
   /usr/bin/yes | pip install psutil
+  /usr/bin/yes | pip install unittest-xml-reporting
 
 }
 

--- a/.circleci/docker/install_conda.sh
+++ b/.circleci/docker/install_conda.sh
@@ -44,6 +44,10 @@ function install_and_setup_conda() {
   /usr/bin/yes | pip install ninja  # Install ninja to speedup the build
   /usr/bin/yes | pip install cmake>=3.13 --upgrade  # Using Ninja requires CMake>=3.13
   /usr/bin/yes | pip install absl-py
+  # Additional PyTorch requirements
+  /usr/bin/yes | pip install boto3
+  /usr/bin/yes | pip install mypy
+  /usr/bin/yes | pip install psutil
 
 }
 

--- a/.circleci/docker/install_conda.sh
+++ b/.circleci/docker/install_conda.sh
@@ -31,7 +31,7 @@ function install_and_setup_conda() {
   conda install -y python=$PYTHON_VERSION
 
   conda install -y numpy pyyaml mkl-include setuptools cmake cffi typing \
-    tqdm coverage hypothesis dataclasses scipy cython scikit-image
+    tqdm coverage hypothesis dataclasses cython
   /usr/bin/yes | pip install typing_extensions==3.10.0.2  # Required for Python<=3.7
   /usr/bin/yes | pip install --upgrade oauth2client
   /usr/bin/yes | pip install lark-parser
@@ -43,10 +43,12 @@ function install_and_setup_conda() {
   /usr/bin/yes | pip install cmake>=3.13 --upgrade  # Using Ninja requires CMake>=3.13
   /usr/bin/yes | pip install absl-py
   # Additional PyTorch requirements
-  /usr/bin/yes | pip install boto3
-  /usr/bin/yes | pip install mypy
+  /usr/bin/yes | pip install scikit-image scipy==1.1.0  # >1.1.0 breaks PyTorch tests
+  /usr/bin/yes | pip install boto3==1.16.34
+  /usr/bin/yes | pip install mypy==0.812
   /usr/bin/yes | pip install psutil
   /usr/bin/yes | pip install unittest-xml-reporting
+  /usr/bin/yes | pip install pytest
 
 }
 

--- a/.circleci/docker/install_valgrind.sh
+++ b/.circleci/docker/install_valgrind.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -ex
+
+mkdir valgrind_build && cd valgrind_build
+VALGRIND_VERSION=3.16.1
+wget https://ossci-linux.s3.amazonaws.com/valgrind-${VALGRIND_VERSION}.tar.bz2
+tar -xjf valgrind-${VALGRIND_VERSION}.tar.bz2
+cd valgrind-${VALGRIND_VERSION}
+./configure --prefix=/usr/local
+make -j6
+sudo make install
+cd ../../
+rm -rf valgrind_build
+alias valgrind="/usr/local/bin/valgrind"

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ import torch
 base_dir = os.path.dirname(os.path.abspath(__file__))
 third_party_path = os.path.join(base_dir, 'third_party')
 
-_libtpu_version = '0.1.dev20220118'
+_libtpu_version = '0.1.dev20220128'
 _litbpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
 
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ import torch
 base_dir = os.path.dirname(os.path.abspath(__file__))
 third_party_path = os.path.join(base_dir, 'third_party')
 
-_libtpu_version = '0.1.dev20211015'
+_libtpu_version = '0.1.dev20220118'
 _litbpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
 
 

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/hash/hash.h"
 #include "absl/types/span.h"
 #include "tensorflow/compiler/xla/client/xla_builder.h"
 #include "tensorflow/compiler/xla/xla_client/types.h"

--- a/torch_xla/csrc/ops/constant.cpp
+++ b/torch_xla/csrc/ops/constant.cpp
@@ -11,7 +11,7 @@ namespace ops {
 
 Constant::Constant(xla::Literal value)
     : Node(OpKind(at::prim::Constant), value.shape(), /*num_outputs=*/1,
-           value.Hash()),
+          absl::Hash<xla::LiteralBase>{}(value)),
       value_(std::move(value)) {}
 
 std::string Constant::ToString() const {

--- a/torch_xla/csrc/ops/constant.cpp
+++ b/torch_xla/csrc/ops/constant.cpp
@@ -11,7 +11,7 @@ namespace ops {
 
 Constant::Constant(xla::Literal value)
     : Node(OpKind(at::prim::Constant), value.shape(), /*num_outputs=*/1,
-          absl::Hash<xla::LiteralBase>{}(value)),
+           absl::Hash<xla::LiteralBase>{}(value)),
       value_(std::move(value)) {}
 
 std::string Constant::ToString() const {


### PR DESCRIPTION
This is to expand the previous work #3345 (reverted), so that it doesn't break the upstream. This PR must be included in the upcoming release `1.11`.

DO_NOT_MERGE_YET, til we merge / resolve pytorch/pytorch#72496