### PR TITLE
Revert "Use `update-alternatives` to link clang++ -> clang++-8"

### DIFF
--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -126,7 +126,6 @@ function install_llvm_clang() {
   sudo apt-get install -y clang-8 clang++-8
   maybe_append 'export CC=clang-8 CXX=clang++-8' ~/.bashrc
   export CC=clang-8 CXX=clang++-8
-  sudo update-alternatives --install /usr/bin/clang++ clang++ $(which clang++-8) 70
 }
 
 function install_req_packages() {


### PR DESCRIPTION
Reverts pytorch/xla#3363