### PR TITLE
ci: Migrate off of legacy GPU executor (#3278)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,7 +296,7 @@ workflows:
                 - /release\/.*/
       - pytorch_xla_run_test:
           name: pytorch_xla_run_GPU_test
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small.multi
           use_cuda_docker_runtime: "1"
           requires:
             - pytorch_xla_run_build


### PR DESCRIPTION
Cherry pick https://github.com/pytorch/xla/commit/bd7e3f6bcd5b4f53b39a01c02ead4c40ee29aad3 to release 1.11 since gpu change already merged to pytorch 1.11