### PR TITLE
Migrate to upstream torch::lazy::BackendDevice

### DIFF
--- a/test/cpp/test_replication.cpp
+++ b/test/cpp/test_replication.cpp
@@ -86,7 +86,7 @@ void TestSingleReplication(const std::vector<Device>& devices,
 class ReplicationTest : public AtenXlaTensorTestBase {};
 
 TEST_F(ReplicationTest, TestNSingleReplication) {
-  WithAllDevices({DeviceType::TPU, DeviceType::GPU},
+  WithAllDevices({TorchXLADeviceType::TPU, TorchXLADeviceType::GPU},
                  [&](const std::vector<Device>& devices,
                      const std::vector<Device>& all_devices) {
                    TestSingleReplication(devices, all_devices);

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -377,8 +377,8 @@ void XLANativeFunctions::_amp_foreach_non_finite_check_and_unscale_(
     at::TensorList self, at::Tensor& found_inf, const at::Tensor& inv_scale) {
   XLA_FN_COUNTER("xla::");
   XLATensor found_inf_tensor = bridge::GetXlaTensor(found_inf);
-  DeviceType hw_type = found_inf_tensor.GetDevice().hw_type;
-  XLA_CHECK(hw_type == DeviceType::GPU || hw_type == DeviceType::CPU)
+  TorchXLADeviceType hw_type = found_inf_tensor.GetDevice().device_type.hw_type;
+  XLA_CHECK(hw_type == TorchXLADeviceType::GPU || hw_type == TorchXLADeviceType::CPU)
       << "AMP should be used with XLA:GPU";
   XLATensor::_amp_foreach_non_finite_check_and_unscale_(
       bridge::GetXlaTensors(self), found_inf_tensor,
@@ -394,8 +394,8 @@ at::Tensor& XLANativeFunctions::_amp_update_scale_(at::Tensor& current_scale,
   XLA_FN_COUNTER("xla::");
   XLATensor growth_tracker_tensor = bridge::GetXlaTensor(growth_tracker);
   XLATensor current_scale_tensor = bridge::GetXlaTensor(current_scale);
-  DeviceType hw_type = growth_tracker_tensor.GetDevice().hw_type;
-  XLA_CHECK(hw_type == DeviceType::GPU || hw_type == DeviceType::CPU)
+  TorchXLADeviceType hw_type = growth_tracker_tensor.GetDevice().device_type.hw_type;
+  XLA_CHECK(hw_type == TorchXLADeviceType::GPU || hw_type == TorchXLADeviceType::CPU)
       << "AMP should be used with XLA:GPU";
   XLATensor::_amp_update_scale_(growth_tracker_tensor, current_scale_tensor,
                                 bridge::GetXlaTensor(found_inf),
@@ -3407,7 +3407,7 @@ at::Tensor XLANativeFunctions::upsample_bilinear2d(
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   // Only the XLA TPU backend for now implements the CustomCall required by
   // our XLA lowering.
-  if (self_tensor.GetDevice().hw_type != DeviceType::TPU ||
+  if (self_tensor.GetDevice().device_type.hw_type != TorchXLADeviceType::TPU ||
       (scales_h && *scales_h != 1.0) || (scales_w && *scales_w != 1.0)) {
     return at::native::call_fallback_fn<
         &xla_cpu_fallback, ATEN_OP(upsample_bilinear2d)>::call(self,
@@ -3428,7 +3428,7 @@ at::Tensor XLANativeFunctions::upsample_bilinear2d_backward(
   XLATensor grad_output_tensor = bridge::GetXlaTensor(grad_output);
   // Only the XLA TPU backend for now implements the CustomCall required by
   // our XLA lowering.
-  if (grad_output_tensor.GetDevice().hw_type != DeviceType::TPU ||
+  if (grad_output_tensor.GetDevice().device_type.hw_type != TorchXLADeviceType::TPU ||
       (scales_h && *scales_h != 1.0) || (scales_w && *scales_w != 1.0)) {
     return at::native::call_fallback_fn<
         &xla_cpu_fallback,
@@ -3448,7 +3448,7 @@ at::Tensor XLANativeFunctions::upsample_nearest2d(
   XLATensor input_tensor = bridge::GetXlaTensor(input);
   // Only the XLA TPU backend for now implements the CustomCall required by our
   // XLA lowering.
-  if (input_tensor.GetDevice().hw_type != DeviceType::TPU) {
+  if (input_tensor.GetDevice().device_type.hw_type != TorchXLADeviceType::TPU) {
     return at::native::call_fallback_fn<&xla_cpu_fallback,
                                         ATEN_OP2(upsample_nearest2d,
                                                  vec)>::call(input, output_size,
@@ -3469,7 +3469,7 @@ at::Tensor XLANativeFunctions::upsample_nearest2d_backward(
   XLATensor grad_output_tensor = bridge::GetXlaTensor(grad_output);
   // Only the XLA TPU backend for now implements the CustomCall required by our
   // XLA lowering.
-  if (grad_output_tensor.GetDevice().hw_type != DeviceType::TPU) {
+  if (grad_output_tensor.GetDevice().device_type.hw_type != TorchXLADeviceType::TPU) {
     return at::native::call_fallback_fn<&xla_cpu_fallback,
                                         ATEN_OP2(upsample_nearest2d_backward,
                                                  vec)>::call(grad_output,
@@ -3491,7 +3491,7 @@ at::Tensor XLANativeFunctions::upsample_nearest2d(
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   // Only the XLA TPU backend for now implements the CustomCall required by
   // our XLA lowering.
-  if (self_tensor.GetDevice().hw_type != DeviceType::TPU ||
+  if (self_tensor.GetDevice().device_type.hw_type != TorchXLADeviceType::TPU ||
       (scales_h && *scales_h != 1.0) || (scales_w && *scales_w != 1.0)) {
     return at::native::call_fallback_fn<
         &xla_cpu_fallback, ATEN_OP(upsample_nearest2d)>::call(self, output_size,
@@ -3510,7 +3510,7 @@ at::Tensor XLANativeFunctions::upsample_nearest2d_backward(
   XLATensor grad_output_tensor = bridge::GetXlaTensor(grad_output);
   // Only the XLA TPU backend for now implements the CustomCall required by
   // our XLA lowering.
-  if (grad_output_tensor.GetDevice().hw_type != DeviceType::TPU ||
+  if (grad_output_tensor.GetDevice().device_type.hw_type != TorchXLADeviceType::TPU ||
       (scales_h && *scales_h != 1.0) || (scales_w && *scales_w != 1.0)) {
     return at::native::call_fallback_fn<
         &xla_cpu_fallback,

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -378,7 +378,8 @@ void XLANativeFunctions::_amp_foreach_non_finite_check_and_unscale_(
   XLA_FN_COUNTER("xla::");
   XLATensor found_inf_tensor = bridge::GetXlaTensor(found_inf);
   TorchXLADeviceType hw_type = found_inf_tensor.GetDevice().device_type.hw_type;
-  XLA_CHECK(hw_type == TorchXLADeviceType::GPU || hw_type == TorchXLADeviceType::CPU)
+  XLA_CHECK(hw_type == TorchXLADeviceType::GPU ||
+            hw_type == TorchXLADeviceType::CPU)
       << "AMP should be used with XLA:GPU";
   XLATensor::_amp_foreach_non_finite_check_and_unscale_(
       bridge::GetXlaTensors(self), found_inf_tensor,
@@ -394,8 +395,10 @@ at::Tensor& XLANativeFunctions::_amp_update_scale_(at::Tensor& current_scale,
   XLA_FN_COUNTER("xla::");
   XLATensor growth_tracker_tensor = bridge::GetXlaTensor(growth_tracker);
   XLATensor current_scale_tensor = bridge::GetXlaTensor(current_scale);
-  TorchXLADeviceType hw_type = growth_tracker_tensor.GetDevice().device_type.hw_type;
-  XLA_CHECK(hw_type == TorchXLADeviceType::GPU || hw_type == TorchXLADeviceType::CPU)
+  TorchXLADeviceType hw_type =
+      growth_tracker_tensor.GetDevice().device_type.hw_type;
+  XLA_CHECK(hw_type == TorchXLADeviceType::GPU ||
+            hw_type == TorchXLADeviceType::CPU)
       << "AMP should be used with XLA:GPU";
   XLATensor::_amp_update_scale_(growth_tracker_tensor, current_scale_tensor,
                                 bridge::GetXlaTensor(found_inf),
@@ -3428,7 +3431,8 @@ at::Tensor XLANativeFunctions::upsample_bilinear2d_backward(
   XLATensor grad_output_tensor = bridge::GetXlaTensor(grad_output);
   // Only the XLA TPU backend for now implements the CustomCall required by
   // our XLA lowering.
-  if (grad_output_tensor.GetDevice().device_type.hw_type != TorchXLADeviceType::TPU ||
+  if (grad_output_tensor.GetDevice().device_type.hw_type !=
+          TorchXLADeviceType::TPU ||
       (scales_h && *scales_h != 1.0) || (scales_w && *scales_w != 1.0)) {
     return at::native::call_fallback_fn<
         &xla_cpu_fallback,
@@ -3469,7 +3473,8 @@ at::Tensor XLANativeFunctions::upsample_nearest2d_backward(
   XLATensor grad_output_tensor = bridge::GetXlaTensor(grad_output);
   // Only the XLA TPU backend for now implements the CustomCall required by our
   // XLA lowering.
-  if (grad_output_tensor.GetDevice().device_type.hw_type != TorchXLADeviceType::TPU) {
+  if (grad_output_tensor.GetDevice().device_type.hw_type !=
+      TorchXLADeviceType::TPU) {
     return at::native::call_fallback_fn<&xla_cpu_fallback,
                                         ATEN_OP2(upsample_nearest2d_backward,
                                                  vec)>::call(grad_output,
@@ -3510,7 +3515,8 @@ at::Tensor XLANativeFunctions::upsample_nearest2d_backward(
   XLATensor grad_output_tensor = bridge::GetXlaTensor(grad_output);
   // Only the XLA TPU backend for now implements the CustomCall required by
   // our XLA lowering.
-  if (grad_output_tensor.GetDevice().device_type.hw_type != TorchXLADeviceType::TPU ||
+  if (grad_output_tensor.GetDevice().device_type.hw_type !=
+          TorchXLADeviceType::TPU ||
       (scales_h && *scales_h != 1.0) || (scales_w && *scales_w != 1.0)) {
     return at::native::call_fallback_fn<
         &xla_cpu_fallback,

--- a/torch_xla/csrc/convert_ops.cpp
+++ b/torch_xla/csrc/convert_ops.cpp
@@ -55,7 +55,8 @@ xla::XlaOp ConvertTo(xla::XlaOp op, xla::PrimitiveType from,
   if (from == to) {
     return op;
   }
-  if (GetDeviceOrCurrent(device).device_type.hw_type != TorchXLADeviceType::TPU) {
+  if (GetDeviceOrCurrent(device).device_type.hw_type !=
+      TorchXLADeviceType::TPU) {
     return xla::ConvertElementType(op, to);
   }
   switch (from) {

--- a/torch_xla/csrc/convert_ops.cpp
+++ b/torch_xla/csrc/convert_ops.cpp
@@ -55,7 +55,7 @@ xla::XlaOp ConvertTo(xla::XlaOp op, xla::PrimitiveType from,
   if (from == to) {
     return op;
   }
-  if (GetDeviceOrCurrent(device).hw_type != DeviceType::TPU) {
+  if (GetDeviceOrCurrent(device).device_type.hw_type != TorchXLADeviceType::TPU) {
     return xla::ConvertElementType(op, to);
   }
   switch (from) {

--- a/torch_xla/csrc/cross_replica_reduces.cpp
+++ b/torch_xla/csrc/cross_replica_reduces.cpp
@@ -32,7 +32,7 @@ xla::Shape MakeReduceShape(absl::Span<const xla::Shape> operand_shapes) {
   for (auto& shape : operand_shapes) {
     shapes_and_layouts.push_back(MakeArrayShapeFromDimensions(
         shape.dimensions(), shape.dynamic_dimensions(), shape.element_type(),
-        xla_device.hw_type));
+        xla_device.device_type.hw_type));
   }
   return xla::ShapeUtil::MakeTupleShape(shapes_and_layouts);
 }
@@ -133,7 +133,7 @@ AllToAllResult BuildAllToAll(xla::XlaOp input, xla::XlaOp token,
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   xla::Shape reduce_shape = MakeArrayShapeFromDimensions(
       input_shape.dimensions(), input_shape.dynamic_dimensions(),
-      input_shape.element_type(), GetCurrentDevice().hw_type);
+      input_shape.element_type(), GetCurrentDevice().device_type.hw_type);
   TokenHandler token_handler(token);
   xla::XlaOp reduce_result = xla::AllToAll(
       token_handler.GetInput(input, &input_shape), split_dimension,
@@ -175,7 +175,7 @@ ReduceScatterResult BuildReduceScatter(
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   xla::Shape reduce_shape = MakeArrayShapeFromDimensions(
       input_shape.dimensions(), input_shape.dynamic_dimensions(),
-      input_shape.element_type(), GetCurrentDevice().hw_type);
+      input_shape.element_type(), GetCurrentDevice().device_type.hw_type);
 
   xla::XlaOp reduce_result = xla::ReduceScatter(
       token_handler.GetInput(input, &input_shape),

--- a/torch_xla/csrc/device.cpp
+++ b/torch_xla/csrc/device.cpp
@@ -11,13 +11,13 @@ namespace {
 
 thread_local absl::optional<Device> g_current_device;
 
-std::string DeviceTypeToString(DeviceType hw_type) {
-  switch (hw_type) {
-    case DeviceType::CPU:
+std::string DeviceTypeToString(DeviceType device_type) {
+  switch (device_type.hw_type) {
+    case TorchXLADeviceType::CPU:
       return "CPU";
-    case DeviceType::GPU:
+    case TorchXLADeviceType::GPU:
       return "GPU";
-    case DeviceType::TPU:
+    case TorchXLADeviceType::TPU:
       return "TPU";
   }
   XLA_ERROR() << "Invalid device type";
@@ -44,11 +44,11 @@ void ParseDevice(const std::string& device_spec, Device* device) {
 
   device->ordinal = std::stoi(device_spec_parts[1]);
   if (device_spec_parts[0] == "TPU") {
-    device->hw_type = DeviceType::TPU;
+    device->device_type.hw_type = TorchXLADeviceType::TPU;
   } else if (device_spec_parts[0] == "CPU") {
-    device->hw_type = DeviceType::CPU;
+    device->device_type.hw_type = TorchXLADeviceType::CPU;
   } else if (device_spec_parts[0] == "GPU") {
-    device->hw_type = DeviceType::GPU;
+    device->device_type.hw_type = TorchXLADeviceType::GPU;
   } else {
     XLA_ERROR() << "Invalid device specification: " << device_spec;
   }
@@ -61,7 +61,7 @@ Device::Device(const std::string& device_spec) {
 }
 
 std::string Device::ToString() const {
-  return absl::StrCat(DeviceTypeToString(hw_type), ":", ordinal);
+  return absl::StrCat(DeviceTypeToString(device_type.hw_type), ":", ordinal);
 }
 
 const Device* GetDefaultDevice() {

--- a/torch_xla/csrc/device.cpp
+++ b/torch_xla/csrc/device.cpp
@@ -44,11 +44,11 @@ void ParseDevice(const std::string& device_spec, Device* device) {
 
   device->ordinal = std::stoi(device_spec_parts[1]);
   if (device_spec_parts[0] == "TPU") {
-    device->device_type.hw_type = TorchXLADeviceType::TPU;
+    device->device_type = DeviceType(TorchXLADeviceType::TPU);
   } else if (device_spec_parts[0] == "CPU") {
-    device->device_type.hw_type = TorchXLADeviceType::CPU;
+    device->device_type = DeviceType(TorchXLADeviceType::CPU);
   } else if (device_spec_parts[0] == "GPU") {
-    device->device_type.hw_type = TorchXLADeviceType::GPU;
+    device->device_type = DeviceType(TorchXLADeviceType::GPU);
   } else {
     XLA_ERROR() << "Invalid device specification: " << device_spec;
   }

--- a/torch_xla/csrc/device.h
+++ b/torch_xla/csrc/device.h
@@ -31,6 +31,8 @@ struct Device : public torch::lazy::BackendDevice {
         device_type(device_type),
         ordinal(ordinal) {}
 
+  bool operator==(const Device& other) const { return compare(other) == 0; }
+
   bool operator!=(const Device& other) const { return compare(other) != 0; }
 
   bool operator<(const Device& rhs) const { return compare(rhs) < 0; }

--- a/torch_xla/csrc/device.h
+++ b/torch_xla/csrc/device.h
@@ -19,6 +19,7 @@ struct DeviceType : public torch::lazy::BackendDeviceType {
     hw_type = torch_xla_device_type;
     type = static_cast<int>(hw_type);
   }
+  
 };
 
 struct Device : public torch::lazy::BackendDevice {
@@ -30,6 +31,17 @@ struct Device : public torch::lazy::BackendDevice {
             ordinal),
         device_type(device_type),
         ordinal(ordinal) {}
+
+  bool operator!=(const Device& other) const { return compare(other) != 0; }
+
+  bool operator<(const Device& rhs) const { return compare(rhs) < 0; }
+
+  int compare(const Device& rhs) const {
+    if (device_type.hw_type != rhs.device_type.hw_type) {
+      return device_type.hw_type < rhs.device_type.hw_type ? -1 : +1;
+    }
+    return ordinal < rhs.ordinal ? -1 : (ordinal > rhs.ordinal ? +1 : 0);
+  }
 
   std::string ToString() const;
 

--- a/torch_xla/csrc/device.h
+++ b/torch_xla/csrc/device.h
@@ -25,14 +25,17 @@ struct Device : public torch::lazy::BackendDevice {
   Device() = default;
   explicit Device(const std::string& device_spec);
   Device(DeviceType device_type, int ordinal)
-        : torch::lazy::BackendDevice(std::make_shared<torch::lazy::BackendDeviceType>(device_type), ordinal),
-        device_type(device_type), ordinal(ordinal) {}
+      : torch::lazy::BackendDevice(
+            std::make_shared<torch::lazy::BackendDeviceType>(device_type),
+            ordinal),
+        device_type(device_type),
+        ordinal(ordinal) {}
 
   std::string ToString() const;
 
   size_t hash() const {
-    return torch::lazy::StdHashCombine(torch::lazy::GetEnumValue(device_type.hw_type),
-                                       ordinal + 1);
+    return torch::lazy::StdHashCombine(
+        torch::lazy::GetEnumValue(device_type.hw_type), ordinal + 1);
   }
 
   DeviceType device_type = DeviceType(TorchXLADeviceType::CPU);

--- a/torch_xla/csrc/device.h
+++ b/torch_xla/csrc/device.h
@@ -19,7 +19,6 @@ struct DeviceType : public torch::lazy::BackendDeviceType {
     hw_type = torch_xla_device_type;
     type = static_cast<int>(hw_type);
   }
-  
 };
 
 struct Device : public torch::lazy::BackendDevice {

--- a/torch_xla/csrc/layout_manager.cpp
+++ b/torch_xla/csrc/layout_manager.cpp
@@ -181,7 +181,7 @@ xla::Shape MakeArrayShapeFromDimensions(
     return MakeShapeWithLayout(type, dimensions, dynamic_dimensions,
                                *layout_ptr);
   }
-  if (dimensions.size() > 1 && device_type == DeviceType::TPU) {
+  if (dimensions.size() > 1 && device_type.hw_type == TorchXLADeviceType::TPU) {
     return MakeTpuShape(dimensions, dynamic_dimensions, type);
   }
   return MakeTorchTensorLayout(dimensions, dynamic_dimensions, type);

--- a/torch_xla/csrc/op_by_op_executor.cpp
+++ b/torch_xla/csrc/op_by_op_executor.cpp
@@ -155,7 +155,7 @@ std::vector<xla::ComputationClient::ExecuteChainedOp> OpByOpExecutor::BuildOps(
           xla::ProgramShape program_shape =
               ConsumeValue(computation.GetProgramShape());
           compile_shapes.push_back(MakeShapeWithDeviceLayout(
-              program_shape.result(), exec_device.hw_type));
+              program_shape.result(), exec_device.device_type.hw_type));
           compile_instances.push_back({std::move(computation), device,
                                        compilation_devices,
                                        &compile_shapes.back()});

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1328,8 +1328,8 @@ std::vector<xla::ComputationClient::DataPtr> XLATensor::FetchTensorData(
     xla::ComputationClient::DataPtr xla_data = tensor.CurrentXlaData();
     if (xla_data == nullptr && config.force_xla_data) {
       const Device& tensor_device = tensor.GetDevice();
-      xla::Shape shape =
-          MakeShapeWithDeviceLayout(tensor.shape(), tensor_device.device_type.hw_type);
+      xla::Shape shape = MakeShapeWithDeviceLayout(
+          tensor.shape(), tensor_device.device_type.hw_type);
       xla_data = xla::ComputationClient::Get()->CreateDataPlaceholder(
           tensor_device.ToString(), std::move(shape));
       tensor.SetXlaData(xla_data, config.sync_xla_data);
@@ -1606,8 +1606,8 @@ XLATensor::CompilationResult XLATensor::Compile(
 
   xla::XlaComputation computation = ConsumeValue(lowering_ctx.Build());
   xla::ProgramShape program_shape = ConsumeValue(computation.GetProgramShape());
-  xla::Shape shape =
-      MakeShapeWithDeviceLayout(program_shape.result(), coll.device.device_type.hw_type);
+  xla::Shape shape = MakeShapeWithDeviceLayout(program_shape.result(),
+                                               coll.device.device_type.hw_type);
 
   std::vector<xla::ComputationClient::CompileInstance> instances;
   instances.push_back({std::move(computation), coll.device.ToString(),

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -538,7 +538,7 @@ xla::Shape XLATensor::shape_with_layout() const {
   auto xla_shape = shape();
   return MakeArrayShapeFromDimensions(
       xla_shape.get().dimensions(), xla_shape.get().dynamic_dimensions(),
-      xla_shape.get().element_type(), GetDevice().hw_type);
+      xla_shape.get().element_type(), GetDevice().device_type.hw_type);
 }
 
 const Device& XLATensor::GetDevice() const { return data()->device; }
@@ -1329,7 +1329,7 @@ std::vector<xla::ComputationClient::DataPtr> XLATensor::FetchTensorData(
     if (xla_data == nullptr && config.force_xla_data) {
       const Device& tensor_device = tensor.GetDevice();
       xla::Shape shape =
-          MakeShapeWithDeviceLayout(tensor.shape(), tensor_device.hw_type);
+          MakeShapeWithDeviceLayout(tensor.shape(), tensor_device.device_type.hw_type);
       xla_data = xla::ComputationClient::Get()->CreateDataPlaceholder(
           tensor_device.ToString(), std::move(shape));
       tensor.SetXlaData(xla_data, config.sync_xla_data);
@@ -1607,7 +1607,7 @@ XLATensor::CompilationResult XLATensor::Compile(
   xla::XlaComputation computation = ConsumeValue(lowering_ctx.Build());
   xla::ProgramShape program_shape = ConsumeValue(computation.GetProgramShape());
   xla::Shape shape =
-      MakeShapeWithDeviceLayout(program_shape.result(), coll.device.hw_type);
+      MakeShapeWithDeviceLayout(program_shape.result(), coll.device.device_type.hw_type);
 
   std::vector<xla::ComputationClient::CompileInstance> instances;
   instances.push_back({std::move(computation), coll.device.ToString(),

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1369,7 +1369,7 @@ XLATensor XLATensor::full(absl::Span<const int64_t> size,
   CheckShapeDimensions(size);
   xla::Shape shape = MakeArrayShapeFromDimensions(
       size, /*dynamic_dimensions=*/{},
-      MakeXlaPrimitiveType(scalar_type, &device), device.hw_type);
+      MakeXlaPrimitiveType(scalar_type, &device), device.device_type.hw_type);
   return Create(GetIrValueForScalar(fill_value, shape, device), device,
                 scalar_type);
 }

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -139,8 +139,9 @@ xla::PrimitiveType XlaTypeFromTensorType(at::ScalarType scalar_type,
                                          const Device& device) {
   switch (scalar_type) {
     case at::ScalarType::Double:
-      return device.device_type.hw_type != TorchXLADeviceType::TPU ? xla::PrimitiveType::F64
-                                               : xla::PrimitiveType::F32;
+      return device.device_type.hw_type != TorchXLADeviceType::TPU
+                 ? xla::PrimitiveType::F64
+                 : xla::PrimitiveType::F32;
     case at::ScalarType::Float:
       return xla::PrimitiveType::F32;
     case at::ScalarType::BFloat16:
@@ -1052,8 +1053,9 @@ xla::PrimitiveType GetDevicePrimitiveType(xla::PrimitiveType type,
       if (DowncastBF16() || DowncastF16()) {
         return xla::PrimitiveType::F32;
       }
-      return xla_device.device_type.hw_type != TorchXLADeviceType::TPU ? xla::PrimitiveType::F64
-                                                   : xla::PrimitiveType::F32;
+      return xla_device.device_type.hw_type != TorchXLADeviceType::TPU
+                 ? xla::PrimitiveType::F64
+                 : xla::PrimitiveType::F32;
     case xla::PrimitiveType::F32:
       if (UseF16() || DowncastF16()) {
         return xla::PrimitiveType::F16;
@@ -1061,18 +1063,21 @@ xla::PrimitiveType GetDevicePrimitiveType(xla::PrimitiveType type,
       return UseBF16() || DowncastBF16() ? xla::PrimitiveType::BF16
                                          : xla::PrimitiveType::F32;
     case xla::PrimitiveType::U16:
-      return xla_device.device_type.hw_type != TorchXLADeviceType::TPU ? xla::PrimitiveType::U16
-                                                   : xla::PrimitiveType::U32;
+      return xla_device.device_type.hw_type != TorchXLADeviceType::TPU
+                 ? xla::PrimitiveType::U16
+                 : xla::PrimitiveType::U32;
     case xla::PrimitiveType::S16:
-      return xla_device.device_type.hw_type != TorchXLADeviceType::TPU ? xla::PrimitiveType::S16
-                                                   : xla::PrimitiveType::S32;
+      return xla_device.device_type.hw_type != TorchXLADeviceType::TPU
+                 ? xla::PrimitiveType::S16
+                 : xla::PrimitiveType::S32;
     case xla::PrimitiveType::S64:
       return Use32BitLong() ? xla::PrimitiveType::S32 : xla::PrimitiveType::S64;
     case xla::PrimitiveType::U64:
       return Use32BitLong() ? xla::PrimitiveType::U32 : xla::PrimitiveType::U64;
     case xla::PrimitiveType::C128:
-      return xla_device.device_type.hw_type != TorchXLADeviceType::TPU ? xla::PrimitiveType::C128
-                                                   : xla::PrimitiveType::C64;
+      return xla_device.device_type.hw_type != TorchXLADeviceType::TPU
+                 ? xla::PrimitiveType::C128
+                 : xla::PrimitiveType::C64;
     default:
       return type;
   }
@@ -1124,8 +1129,9 @@ bool RequiresRawTypeCasting(at::ScalarType scalar_type, const Device* device) {
 
 xla::PrimitiveType GetShapeDimensionType(const Device* device) {
   Device xla_device = GetDeviceOrCurrent(device);
-  return xla_device.device_type.hw_type == TorchXLADeviceType::CPU ? xla::PrimitiveType::S64
-                                               : xla::PrimitiveType::S32;
+  return xla_device.device_type.hw_type == TorchXLADeviceType::CPU
+             ? xla::PrimitiveType::S64
+             : xla::PrimitiveType::S32;
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -139,7 +139,7 @@ xla::PrimitiveType XlaTypeFromTensorType(at::ScalarType scalar_type,
                                          const Device& device) {
   switch (scalar_type) {
     case at::ScalarType::Double:
-      return device.hw_type != DeviceType::TPU ? xla::PrimitiveType::F64
+      return device.device_type.hw_type != TorchXLADeviceType::TPU ? xla::PrimitiveType::F64
                                                : xla::PrimitiveType::F32;
     case at::ScalarType::Float:
       return xla::PrimitiveType::F32;
@@ -967,7 +967,7 @@ xla::Shape CreateComputationShapeFromTensor(const at::Tensor& tensor,
       XlaHelpers::I64List(tensor.sizes()),
       /*dynamic_dimensions=*/{},
       MakeXlaPrimitiveType(tensor.type().scalarType(), &xla_device),
-      xla_device.hw_type);
+      xla_device.device_type.hw_type);
 }
 
 at::ScalarType TensorTypeFromXlaType(xla::PrimitiveType xla_type) {
@@ -1052,7 +1052,7 @@ xla::PrimitiveType GetDevicePrimitiveType(xla::PrimitiveType type,
       if (DowncastBF16() || DowncastF16()) {
         return xla::PrimitiveType::F32;
       }
-      return xla_device.hw_type != DeviceType::TPU ? xla::PrimitiveType::F64
+      return xla_device.device_type.hw_type != TorchXLADeviceType::TPU ? xla::PrimitiveType::F64
                                                    : xla::PrimitiveType::F32;
     case xla::PrimitiveType::F32:
       if (UseF16() || DowncastF16()) {
@@ -1061,17 +1061,17 @@ xla::PrimitiveType GetDevicePrimitiveType(xla::PrimitiveType type,
       return UseBF16() || DowncastBF16() ? xla::PrimitiveType::BF16
                                          : xla::PrimitiveType::F32;
     case xla::PrimitiveType::U16:
-      return xla_device.hw_type != DeviceType::TPU ? xla::PrimitiveType::U16
+      return xla_device.device_type.hw_type != TorchXLADeviceType::TPU ? xla::PrimitiveType::U16
                                                    : xla::PrimitiveType::U32;
     case xla::PrimitiveType::S16:
-      return xla_device.hw_type != DeviceType::TPU ? xla::PrimitiveType::S16
+      return xla_device.device_type.hw_type != TorchXLADeviceType::TPU ? xla::PrimitiveType::S16
                                                    : xla::PrimitiveType::S32;
     case xla::PrimitiveType::S64:
       return Use32BitLong() ? xla::PrimitiveType::S32 : xla::PrimitiveType::S64;
     case xla::PrimitiveType::U64:
       return Use32BitLong() ? xla::PrimitiveType::U32 : xla::PrimitiveType::U64;
     case xla::PrimitiveType::C128:
-      return xla_device.hw_type != DeviceType::TPU ? xla::PrimitiveType::C128
+      return xla_device.device_type.hw_type != TorchXLADeviceType::TPU ? xla::PrimitiveType::C128
                                                    : xla::PrimitiveType::C64;
     default:
       return type;
@@ -1124,7 +1124,7 @@ bool RequiresRawTypeCasting(at::ScalarType scalar_type, const Device* device) {
 
 xla::PrimitiveType GetShapeDimensionType(const Device* device) {
   Device xla_device = GetDeviceOrCurrent(device);
-  return xla_device.hw_type == DeviceType::CPU ? xla::PrimitiveType::S64
+  return xla_device.device_type.hw_type == TorchXLADeviceType::CPU ? xla::PrimitiveType::S64
                                                : xla::PrimitiveType::S32;
 }
 

--- a/torch_xla/csrc/xla_lower_util.cpp
+++ b/torch_xla/csrc/xla_lower_util.cpp
@@ -67,7 +67,7 @@ bool ShouldUseDenseScatter(const Device& device, const xla::Shape& input_shape,
                            const xla::Shape& index_shape) {
   static int dense_scatter_factor =
       xla::sys_util::GetEnvInt("XLA_DENSE_SCATTER_FACTOR", 100);
-  if (device.hw_type == DeviceType::TPU) {
+  if (device.device_type.hw_type == TorchXLADeviceType::TPU) {
     int64_t input_elements = xla::ShapeUtil::ElementsIn(input_shape);
     int64_t index_elements = xla::ShapeUtil::ElementsIn(index_shape);
     return index_elements * dense_scatter_factor >= input_elements;


### PR DESCRIPTION
Migrate to upstream torch::lazy::BackendDevice.

As part of this, we need to extend two classes from upstream:
1. `torch::lazy::BackendDeviceType`
2. `torch::lazy::BackendDevice`

We define a new class `DeviceType` that extends `torch::lazy::BackendDeviceType`. The purpose of this class is to define the types of device that our backend supports. As a part of this migration, we rename the existing `DeviceType` enum to `TorchXLADeviceType`. 