### PR TITLE
Disable XLA continuation by default for 1.11 release

### DIFF
--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -55,6 +55,8 @@ def _setup_default_env():
   _set_missing_env('TPU_HOST_BOUNDS', '1,1,1')
   _set_missing_env('GRPC_VERBOSITY', 'ERROR')
   _set_missing_env('ALLOW_MULTIPLE_LIBTPU_LOAD', '1')
+  # Disable continuation by default (TODO re-enable when the feature is ready)
+  _set_missing_env('LIBTPU_INIT_ARGS', '--notpu_use_continuations')
   if server_is_alive():
     _set_missing_env('XRT_START_LOCAL_SERVER', '0')
 


### PR DESCRIPTION
Backport https://github.com/pytorch/xla/pull/3381 to 1.11 release branch.