### PR TITLE
Use Cloud Build private pool

### DIFF
--- a/build_torch_xla_libs.sh
+++ b/build_torch_xla_libs.sh
@@ -40,8 +40,8 @@ if [[ "$TPUVM_MODE" == "1" ]]; then
 fi
 
 MAX_JOBS=
-if [[ "$XLA_CUDA" == "1" ]] && [[ "$CLOUD_BUILD" == "true" ]]; then
-  MAX_JOBS="--jobs=16"
+if [[ ! -z "$BAZEL_JOBS" ]]; then
+  MAX_JOBS="--jobs=$BAZEL_JOBS"
 fi
 
 OPTS+=(--cxxopt="-std=c++14")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,8 @@ ARG cuda="0"
 ARG cuda_compute="7.0,7.5"
 ARG cxx_abi="0"
 ARG tpuvm=""
+ARG bazel_jobs=""
+ARG git_clone="false"
 
 RUN apt-get update
 RUN apt-get install -y git sudo python-pip python3-pip
@@ -38,7 +40,7 @@ ENV BAZEL_JOBS "${bazel_jobs}"
 # cloud build. Otherwise, just use local.
 # https://github.com/GoogleCloudPlatform/cloud-builders/issues/435
 COPY . /pytorch/xla
-RUN if [ "${git_clone}" = true ]; then github_branch="${release_version}" && \
+RUN if [ "${git_clone}" = "true" ]; then github_branch="${release_version}" && \
   if [ "${release_version}" = "nightly" ]; then github_branch="master"; fi && \
   cd /pytorch && \
   rm -rf xla && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,7 +46,9 @@ RUN if [ "${cloud_build}" = true ]; then github_branch="${release_version}" && \
   cd / && \
   git clone -b "${github_branch}" --recursive https://github.com/pytorch-tpu/examples tpu-examples; fi
 
+ENV CLOUD_BUILD false
 RUN cd /pytorch && bash xla/scripts/build_torch_wheels.sh ${python_version} ${release_version}
+ENV CLOUD_BUILD "${cloud_build}"
 
 # Use conda environment on startup or when running scripts.
 RUN echo "conda activate pytorch" >> ~/.bashrc

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,6 @@ ARG base_image="debian:buster"
 FROM "${base_image}"
 
 ARG python_version="3.6"
-ARG cloud_build="false"
 ARG release_version="nightly"
 ARG cuda="0"
 ARG cuda_compute="7.0,7.5"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,9 +23,6 @@ ENV USE_CUDA "0"
 ENV XLA_CUDA "${cuda}"
 ENV TF_CUDA_COMPUTE_CAPABILITIES "${cuda_compute}"
 
-# Whether the build is running on GCB
-ENV CLOUD_BUILD "${cloud_build}"
-
 # Whether to build torch and torch_xla libraries with CXX ABI
 ENV CXX_ABI "${cxx_abi}"
 ENV _GLIBCXX_USE_CXX11_ABI "${cxx_abi}"
@@ -33,12 +30,15 @@ ENV _GLIBCXX_USE_CXX11_ABI "${cxx_abi}"
 # Whether to build for TPUVM mode
 ENV TPUVM_MODE "${tpuvm}"
 
+# Maximum number of jobs to use for bazel build
+ENV BAZEL_JOBS "${bazel_jobs}"
+
 # To get around issue of Cloud Build with recursive submodule update
 # clone recursively from pytorch/xla if building docker image with
 # cloud build. Otherwise, just use local.
 # https://github.com/GoogleCloudPlatform/cloud-builders/issues/435
 COPY . /pytorch/xla
-RUN if [ "${cloud_build}" = true ]; then github_branch="${release_version}" && \
+RUN if [ "${git_clone}" = true ]; then github_branch="${release_version}" && \
   if [ "${release_version}" = "nightly" ]; then github_branch="master"; fi && \
   cd /pytorch && \
   rm -rf xla && \
@@ -46,9 +46,7 @@ RUN if [ "${cloud_build}" = true ]; then github_branch="${release_version}" && \
   cd / && \
   git clone -b "${github_branch}" --recursive https://github.com/pytorch-tpu/examples tpu-examples; fi
 
-ENV CLOUD_BUILD false
 RUN cd /pytorch && bash xla/scripts/build_torch_wheels.sh ${python_version} ${release_version}
-ENV CLOUD_BUILD "${cloud_build}"
 
 # Use conda environment on startup or when running scripts.
 RUN echo "conda activate pytorch" >> ~/.bashrc

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -10,8 +10,8 @@ steps:
           '--build-arg', 'python_version=${_PYTHON_VERSION}',
           '--build-arg', 'release_version=${_RELEASE_VERSION}',
           '--build-arg', 'tpuvm=${_TPU_VM}',
-          '--build-arg', 'bazel_jobs=${_BAZEL_JOBS}'
-          '--build-arg', 'git_clone=${_GIT_CLONE}'
+          '--build-arg', 'bazel_jobs=${_BAZEL_JOBS}',
+          '--build-arg', 'git_clone=${_GIT_CLONE}',
           '-t', 'gcr.io/tpu-pytorch/xla:${_IMAGE_NAME}',
           '-f', 'docker/Dockerfile', '.'
         ]
@@ -40,7 +40,8 @@ substitutions:
     _BAZEL_JOBS: ''
     _GIT_CLONE: 'true'
 options:
-    machineType: 'N1_HIGHCPU_32'
+    pool:
+      name: 'projects/tpu-pytorch/locations/us-central1/workerPools/wheel_build'
     dynamic_substitutions: true
     substitution_option: 'ALLOW_LOOSE'
 timeout: 18000s

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -6,11 +6,12 @@ steps:
   args: [
           'build',
           '--build-arg', 'base_image=${_DOCKER_BASE_IMAGE}',
-          '--build-arg', 'cloud_build=true',
           '--build-arg', 'cuda=${_CUDA}',
           '--build-arg', 'python_version=${_PYTHON_VERSION}',
           '--build-arg', 'release_version=${_RELEASE_VERSION}',
           '--build-arg', 'tpuvm=${_TPU_VM}',
+          '--build-arg', 'bazel_jobs=${_BAZEL_JOBS}'
+          '--build-arg', 'git_clone=${_GIT_CLONE}'
           '-t', 'gcr.io/tpu-pytorch/xla:${_IMAGE_NAME}',
           '-f', 'docker/Dockerfile', '.'
         ]
@@ -36,8 +37,10 @@ substitutions:
     _IMAGE_NAME: '${_RELEASE_VERSION}_${_PYTHON_VERSION}'
     _UPLOAD_SUBDIR: ''
     _TPU_VM: ''
+    _BAZEL_JOBS: ''
+    _GIT_CLONE: 'true'
 options:
-#    machineType: 'N1_HIGHCPU_32'
+    machineType: 'N1_HIGHCPU_32'
     dynamic_substitutions: true
     substitution_option: 'ALLOW_LOOSE'
 timeout: 18000s

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -37,7 +37,7 @@ substitutions:
     _UPLOAD_SUBDIR: ''
     _TPU_VM: ''
 options:
-    machineType: 'N1_HIGHCPU_32'
+#    machineType: 'N1_HIGHCPU_32'
     dynamic_substitutions: true
     substitution_option: 'ALLOW_LOOSE'
 timeout: 18000s

--- a/docker/gcb_pool.yaml
+++ b/docker/gcb_pool.yaml
@@ -1,0 +1,4 @@
+privatePoolV1Config:
+  workerConfig:
+    diskSizeGb: '500'
+    machineType: e2-standard-32


### PR DESCRIPTION
Fixes timeout in CUDA build by using larger machine with more build jobs.

I will update the triggers in our project after I submit.

Private pool docs: https://cloud.google.com/build/docs/private-pools/run-builds-in-private-pool

[Successful test build link](https://console.cloud.google.com/cloud-build/builds;region=us-central1/8f00200a-c1a9-4ea6-90dd-13ec30070e72?project=tpu-pytorch)