### PR TITLE
Bind torch and torch_xla build option, USE_CXX11_ABI, to _GLIBCXX_USE…

### DIFF
--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -30,13 +30,13 @@ ENV TORCH_CUDA_ARCH_LIST Maxwell
 ENV TORCH_NVCC_FLAGS "-Xfatbin -compress-all"
 ENV CUDA_PATH /usr/local/cuda
 
-# Whether to build torch and torch_xla libraries with CXX ABI
+# Set C/C++ compilers
 ENV CC "${cc}"
 ENV CXX "${cxx}"
-ENV CXX_ABI "${cxx_abi}"
+
+# Whether to build torch and torch_xla libraries with CXX ABI
 ENV _GLIBCXX_USE_CXX11_ABI "${cxx_abi}"
-ENV CFLAGS "${CFLAGS} -D_GLIBCXX_USE_CXX11_ABI=${CXX_ABI}"
-ENV CXXFLAGS="${CXXFLAGS} -D_GLIBCXX_USE_CXX11_ABI=${CXX_ABI}"
+ENV CXXFLAGS "${CXXFLAGS} -D_GLIBCXX_USE_CXX11_ABI=${cxx_abi}"
 
 # Whether to build for TPUVM mode
 ENV TPUVM_MODE "${tpuvm}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,8 +27,8 @@ ENV TF_CUDA_COMPUTE_CAPABILITIES "${cuda_compute}"
 ENV CLOUD_BUILD "${cloud_build}"
 
 # Whether to build torch and torch_xla libraries with CXX ABI
-ENV CXX_ABI "${cxx_abi}"
 ENV _GLIBCXX_USE_CXX11_ABI "${cxx_abi}"
+ENV CXXFLAGS "${CXXFLAGS} -D_GLIBCXX_USE_CXX11_ABI=${cxx_abi}"
 
 # Whether to build for TPUVM mode
 ENV TPUVM_MODE "${tpuvm}"

--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -30,11 +30,6 @@ function setup_system {
   maybe_append 'APT::Acquire::Retries "10";' /etc/apt/apt.conf.d/80-failparams
   maybe_append 'APT::Acquire::http::Timeout "180";' /etc/apt/apt.conf.d/80-failparams
   maybe_append 'APT::Acquire::ftp::Timeout "180";' /etc/apt/apt.conf.d/80-failparams
-
-  if [ "$CXX_ABI" == "0" ]; then
-    export CFLAGS="${CFLAGS} -D_GLIBCXX_USE_CXX11_ABI=0"
-    export CXXFLAGS="${CXXFLAGS} -D_GLIBCXX_USE_CXX11_ABI=0"
-  fi
 }
 
 function install_cudnn {


### PR DESCRIPTION
Resolve #3390 . This change will simplify and make sure that torch and torch-xla use the same GLIBCXX_USE_ABI flag.