### PR TITLE
Re-enable continuation for tpuvm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ import torch
 base_dir = os.path.dirname(os.path.abspath(__file__))
 third_party_path = os.path.join(base_dir, 'third_party')
 
-_libtpu_version = '0.1.dev20220128'
+_libtpu_version = '0.1.dev20220303'
 _litbpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
 
 

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -55,8 +55,6 @@ def _setup_default_env():
   _set_missing_env('TPU_HOST_BOUNDS', '1,1,1')
   _set_missing_env('GRPC_VERBOSITY', 'ERROR')
   _set_missing_env('ALLOW_MULTIPLE_LIBTPU_LOAD', '1')
-  # Disable continuation by default
-  _set_missing_env('LIBTPU_INIT_ARGS', '--notpu_use_continuations')
   if server_is_alive():
     _set_missing_env('XRT_START_LOCAL_SERVER', '0')
 


### PR DESCRIPTION
Re-enable the XLA continuation feature for TPUVM, that was disabled in #3381 . I will cherry-pick this to `release/1.11` after we secure a working `libtpu-nightly`.