### PR TITLE
Update circleci ubuntu image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,8 @@ run_build: &run_build
   - run:
       name: "Setup custom environment variables"
       command: |
-        pyenv global 3.6.5
+        pyenv install 3.7.0
+        pyenv global 3.7.0
         echo "export CLOUDSDK_PYTHON=$(which python3)" >> $BASH_ENV
   - run:
       <<: *update_submodule
@@ -119,7 +120,8 @@ run_test: &run_test
   - run:
       name: "Setup custom environment variables"
       command: |
-        pyenv global 3.6.5
+        pyenv install 3.7.0
+        pyenv global 3.7.0
         echo "export CLOUDSDK_PYTHON=$(which python3)" >> $BASH_ENV
   - run:
       <<: *update_submodule
@@ -143,7 +145,8 @@ run_test_and_push_doc: &run_test_and_push_doc
   - run:
       name: "Setup custom environment variables"
       command: |
-        pyenv global 3.6.5
+        pyenv install 3.7.0
+        pyenv global 3.7.0
         echo "export CLOUDSDK_PYTHON=$(which python3)" >> $BASH_ENV
   - run:
       <<: *update_submodule
@@ -168,8 +171,6 @@ run_test_and_push_doc: &run_test_and_push_doc
 run_clang_format: &run_clang_format
   name: Run clang-format
   command: |
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-    sudo add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main'
     sudo apt-get update
     sudo apt install -y clang-format-7
     git_status=$(git status --porcelain)
@@ -192,6 +193,7 @@ run_clang_format: &run_clang_format
 run_yapf: &run_yapf
   name: Run yapf
   command: |
+    pyenv install 3.7.0
     pyenv global 3.7.0
     pip install --upgrade pip
     pip install yapf==0.30.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ calculate_docker_image: &calculate_docker_image
 run_build: &run_build
   resource_class: 2xlarge
   machine:
-    image: ubuntu-1604:201903-01
+    image: ubuntu-2004:202111-02
   steps:
   - checkout
   - run:
@@ -113,7 +113,7 @@ run_build: &run_build
 
 run_test: &run_test
   machine:
-    image: ubuntu-1604:201903-01
+    image: ubuntu-2004:202111-02
   steps:
   - checkout
   - run:
@@ -137,7 +137,7 @@ run_test: &run_test
 
 run_test_and_push_doc: &run_test_and_push_doc
   machine:
-    image: ubuntu-1604:201903-01
+    image: ubuntu-2004:202111-02
   steps:
   - checkout
   - run:
@@ -239,7 +239,7 @@ ci_params: &ci_params
 jobs:
   linter_check:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202111-02
     steps:
     - checkout
     - run:
@@ -249,7 +249,7 @@ jobs:
 
   linter_check_no_torch_pin:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202111-02
     steps:
     - checkout
     - run:

--- a/.circleci/setup_ci_environment.sh
+++ b/.circleci/setup_ci_environment.sh
@@ -19,11 +19,18 @@ sudo apt-get update && sudo apt-get -y install google-cloud-sdk
 echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
 /usr/bin/yes | gcloud auth configure-docker
 
+# Set up Docker repo
+sudo apt-get install lsb-release
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
 # Set up NVIDIA docker repo
 curl -s -L --retry 3 https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
-echo "deb https://nvidia.github.io/libnvidia-container/ubuntu16.04/amd64 /" | sudo tee -a /etc/apt/sources.list.d/nvidia-docker.list
-echo "deb https://nvidia.github.io/nvidia-container-runtime/ubuntu16.04/amd64 /" | sudo tee -a /etc/apt/sources.list.d/nvidia-docker.list
-echo "deb https://nvidia.github.io/nvidia-docker/ubuntu16.04/amd64 /" | sudo tee -a /etc/apt/sources.list.d/nvidia-docker.list
+echo "deb https://nvidia.github.io/nvidia-container-runtime/ubuntu20.04/amd64 /" | sudo tee -a /etc/apt/sources.list.d/nvidia-docker.list
+echo "deb https://nvidia.github.io/libnvidia-container/ubuntu20.04/amd64 /" | sudo tee -a /etc/apt/sources.list.d/nvidia-docker.list
+echo "deb https://nvidia.github.io/nvidia-docker/ubuntu20.04/amd64 /" | sudo tee -a /etc/apt/sources.list.d/nvidia-docker.list
 
 # Remove unnecessary sources
 sudo rm -f /etc/apt/sources.list.d/google-chrome.list
@@ -62,9 +69,9 @@ retry sudo apt-get -y install \
   linux-headers-$(uname -r) \
   linux-image-generic \
   moreutils \
-  docker-ce=5:18.09.4~3-0~ubuntu-xenial \
-  nvidia-container-runtime=2.0.0+docker18.09.4-1 \
-  nvidia-docker2=2.0.3+docker18.09.4-1 \
+  docker-ce=5:20.10.13~3-0~ubuntu-focal \
+  nvidia-container-runtime=3.8.1-1 \
+  nvidia-docker2=2.9.1-1 \
   expect-dev
 
 sudo pkill -SIGHUP dockerd


### PR DESCRIPTION
Our Circle CI machines use Ubuntu 16.04 as base OS version, and it's being deprecated: 
```
This job is either using an Ubuntu 14.04 image, an Ubuntu 16.04 image, or the default Ubuntu 14.04-based image by specifying machine:true in config. These images (including the default image) will be deprecated May 31, 2022. Upgrade your image from Ubuntu 14.04 or 16.04 to 20.04.
```

This shouldn't affect the actual build & test workloads, as we run our customer docker image inside the host machine; but we will need to update the host machine OS and make sure nvidia-smi docker-nvidia run for GPU testing.