### PR TITLE
Colab env-setup.py script update: install 1.11 & nightly from colab whls

### DIFF
--- a/contrib/scripts/env-setup.py
+++ b/contrib/scripts/env-setup.py
@@ -25,7 +25,7 @@ TORCHVISION_WHEEL_TMPL = 'torchvision-{whl_version}-cp{py_version}-cp{py_version
 VERSION_REGEX = re.compile(r'^(\d+\.)+\d+$')
 
 def is_gpu_runtime():
-  return os.environ.get('COLAB_GPU', 0) == 1
+  return int(os.environ.get('COLAB_GPU', 0)) == 1
 
 
 def is_tpu_runtime():


### PR DESCRIPTION
The current 2vm wheels are not compatible with colab, and the colab `env-setup.py` script is outdated to redirect user request to the proper colab wheels.