### PR TITLE
Doc publish script requirements error fix

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@ mistune==0.8.4
 sphinx==2.4.4
 docutils==0.16
 m2r
--e git+git://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
+-e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme


### PR DESCRIPTION
Circleci doc publish job is failing due to
```
ERROR: Could not find a version that satisfies the requirement pytorch-sphinx-theme (unavailable) (from versions: 0.0.18, 0.0.19)
ERROR: No matching distribution found for pytorch-sphinx-theme (unavailable)
./docs_build.sh: line 3: sphinx-build: command not found
```

This PR resolves the issue, when tested locally
```
Successfully installed pytorch-sphinx-theme-0.0.24
Running Sphinx v2.4.4
```