### PR TITLE
Allow boolean scalar value

### DIFF
--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -98,6 +98,9 @@ class XlaHelpers {
     if (scalar_value.isFloatingPoint()) {
       return ScalarValue(scalar_value.toDouble(), type, builder);
     }
+    if (scalar_value.isBoolean()) {
+      return ScalarValue(scalar_value.toBool(), type, builder);
+    }
     XLA_CHECK(scalar_value.isIntegral()) << "Scalar type not supported";
     return ScalarValue(static_cast<int64_t>(scalar_value.toLong()), type,
                        builder);


### PR DESCRIPTION
This should fix our w2v2 turorial, which currently failed at
```
Exception in device=TPU:2: /home/jackcao/pytorch/xla/torch_xla/csrc/helpers.h:105 : Check failed: scalar_value.isIntegral() 
```