### PR TITLE
Update colab wheel URL for colab tutorials.

### DIFF
--- a/contrib/colab/DC-GAN.ipynb
+++ b/contrib/colab/DC-GAN.ipynb
@@ -1,30 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "accelerator": "TPU",
-    "colab": {
-      "name": "DC-GAN.ipynb",
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.6.10"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -41,17 +15,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "nxtjkPBWQhxF",
-        "colab": {}
+        "id": "nxtjkPBWQhxF"
       },
+      "outputs": [],
       "source": [
         "import os\n",
         "assert os.environ['COLAB_TPU_ADDR'], 'Make sure to select TPU from Edit > Notebook settings > Hardware accelerator'"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -65,34 +39,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "OApBOAe1fpH_"
       },
+      "outputs": [],
       "source": [
-        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
-      ],
-      "execution_count": null,
-      "outputs": []
+        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
-      ],
       "metadata": {
         "id": "nfSCdVlA8jFg"
-      }
+      },
+      "source": [
+        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "J1Vfg-rH8bF4"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
+      ]
     },
     {
       "cell_type": "markdown",
@@ -105,9 +79,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "vJZrkoejQhxK"
       },
+      "outputs": [],
       "source": [
         "# VERSION = \"1.11\"  #@param [\"1.11\", \"nightly\", \"20220315\"]  # or YYYYMMDD format\n",
         "# !curl https://raw.githubusercontent.com/pytorch/xla/master/contrib/scripts/env-setup.py -o pytorch-xla-env-setup.py\n",
@@ -122,9 +98,7 @@
         "\n",
         "# !ldconfig\n",
         "# !ldd /usr/local/lib/python3.7/dist-packages/torch/lib/libtorch.so"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -174,11 +148,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "o6r3OlA_QhxP",
-        "colab": {}
+        "id": "o6r3OlA_QhxP"
       },
+      "outputs": [],
       "source": [
         "import torch\n",
         "from torch import nn, optim\n",
@@ -192,9 +168,7 @@
         "import torch_xla.distributed.parallel_loader as pl\n",
         "import torch_xla.distributed.xla_multiprocessing as xmp\n",
         "import torch_xla.utils.utils as xu"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -210,11 +184,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "fDStxFFGQhxR",
-        "colab": {}
+        "id": "fDStxFFGQhxR"
       },
+      "outputs": [],
       "source": [
         "# Define Parameters\n",
         "FLAGS = {}\n",
@@ -225,17 +201,17 @@
         "FLAGS['disc_learning_rate'] = 0.001\n",
         "FLAGS['num_epochs'] = 21\n",
         "FLAGS['num_cores'] = 8  "
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "R40fkk90QhxT",
-        "colab": {}
+        "id": "R40fkk90QhxT"
       },
+      "outputs": [],
       "source": [
         "from matplotlib.pyplot import imshow\n",
         "from matplotlib import pyplot as plt\n",
@@ -264,33 +240,33 @@
         "def display_results():\n",
         "    img = cv2.imread(RESULT_IMG_PATH, cv2.IMREAD_UNCHANGED)\n",
         "    cv2_imshow(img)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "QH6HiMRaQhxW",
-        "colab": {}
+        "id": "QH6HiMRaQhxW"
       },
+      "outputs": [],
       "source": [
         "def mnist_data():\n",
         "    compose = transforms.Compose([transforms.ToTensor(), transforms.Normalize([0.5], [0.5])])\n",
         "    out_dir = '{}/dataset'.format(FLAGS['datadir'])\n",
         "    return datasets.MNIST(root=out_dir, train=True, transform=compose, download=True)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "Pjtbtac9QhxY",
-        "colab": {}
+        "id": "Pjtbtac9QhxY"
       },
+      "outputs": [],
       "source": [
         "class DiscriminativeNet(torch.nn.Module):\n",
         "    \n",
@@ -311,17 +287,17 @@
         "        x = F.leaky_relu(self.fc1(x), 0.01)\n",
         "        return torch.sigmoid(x)            \n",
         "        "
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "rATu6mC2Qhxa",
-        "colab": {}
+        "id": "rATu6mC2Qhxa"
       },
+      "outputs": [],
       "source": [
         "class GenerativeNet(torch.nn.Module):\n",
         "    \n",
@@ -369,33 +345,33 @@
         "        x = self.conv2(x)\n",
         "        x = torch.tanh(x)\n",
         "        return x"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "3oBrhFUEQhxc",
-        "colab": {}
+        "id": "3oBrhFUEQhxc"
       },
+      "outputs": [],
       "source": [
         "def init_weights(m):\n",
         "    classname = m.__class__.__name__\n",
         "    if classname.find('Conv') != -1 or classname.find('BatchNorm') != -1:\n",
         "        m.weight.data.normal_(0.00, 0.02)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "EZ45r5UvQhxe",
-        "colab": {}
+        "id": "EZ45r5UvQhxe"
       },
+      "outputs": [],
       "source": [
         "def real_data_target(size, device):\n",
         "    '''\n",
@@ -410,9 +386,7 @@
         "    '''\n",
         "    data = torch.zeros(size, 1)\n",
         "    return data.to(device)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -434,11 +408,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "OFzyeN_GQhxk",
-        "colab": {}
+        "id": "OFzyeN_GQhxk"
       },
+      "outputs": [],
       "source": [
         "SERIAL_EXEC = xmp.MpSerialExecutor()\n",
         "# Only instantiate model weights once in memory.\n",
@@ -548,17 +524,17 @@
         "    num_test_samples = 24\n",
         "    test_noise = generator.generate_noise(num_test_samples).to(device)\n",
         "    xm.do_on_ordinals(plot_results, generator(test_noise).detach(), (0,))"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "svXHYwFv6Nf_",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "svXHYwFv6Nf_"
       },
+      "outputs": [],
       "source": [
         "# Start training processes\n",
         "def _mp_fn(rank, flags):\n",
@@ -569,22 +545,20 @@
         "\n",
         "xmp.spawn(_mp_fn, args=(FLAGS,), nprocs=FLAGS['num_cores'],\n",
         "          start_method='fork')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "T641nJpEdh4i",
-        "colab": {}
+        "id": "T641nJpEdh4i"
       },
+      "outputs": [],
       "source": [
         "display_results()"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -598,5 +572,31 @@
         "[CS231n] (http://cs231n.stanford.edu/slides/2017/cs231n_2017_lecture13.pdf)"
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "TPU",
+    "colab": {
+      "name": "DC-GAN.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.6.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/contrib/colab/Distributing_Large_Embedding_tables.ipynb
+++ b/contrib/colab/Distributing_Large_Embedding_tables.ipynb
@@ -1,24 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "Example: Distributing Large Embedding tables over TPU cores",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "accelerator": "TPU"
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "4SM2yBfGVJCk",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "4SM2yBfGVJCk"
       },
       "source": [
         "# Distributing Large Embedding tables over TPU cores\n",
@@ -33,23 +19,23 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "2skQNymdVCRB",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "2skQNymdVCRB"
       },
+      "outputs": [],
       "source": [
         "import os\n",
         "assert os.environ['COLAB_TPU_ADDR'], 'Make sure to select TPU from Edit > Notebook settings > Hardware accelerator'"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "iGsiv-BNWVBM",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "iGsiv-BNWVBM"
       },
       "source": [
         "## [RUNME] Install Colab TPU compatible PyTorch/TPU wheels and dependencies"
@@ -57,34 +43,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "OApBOAe1fpH_"
       },
+      "outputs": [],
       "source": [
-        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
-      ],
-      "execution_count": null,
-      "outputs": []
+        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
-      ],
       "metadata": {
         "id": "nfSCdVlA8jFg"
-      }
+      },
+      "source": [
+        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "J1Vfg-rH8bF4"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
+      ]
     },
     {
       "cell_type": "markdown",
@@ -97,9 +83,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "vJZrkoejQhxK"
       },
+      "outputs": [],
       "source": [
         "# VERSION = \"1.11\"  #@param [\"1.11\", \"nightly\", \"20220315\"]  # or YYYYMMDD format\n",
         "# !curl https://raw.githubusercontent.com/pytorch/xla/master/contrib/scripts/env-setup.py -o pytorch-xla-env-setup.py\n",
@@ -114,15 +102,13 @@
         "\n",
         "# !ldconfig\n",
         "# !ldd /usr/local/lib/python3.7/dist-packages/torch/lib/libtorch.so"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "XO-lZMnnYm7P",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "XO-lZMnnYm7P"
       },
       "source": [
         "## Description and Objective\n",
@@ -153,11 +139,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "mrwgZmZVgk6D",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "mrwgZmZVgk6D"
       },
+      "outputs": [],
       "source": [
         "fairseq_path = '/tmp/fairseq'\n",
         "!git clone https://github.com/pytorch-tpu/fairseq.git -b tpu {fairseq_path}\n",
@@ -167,15 +155,13 @@
         "\n",
         "import sys\n",
         "sys.path.append(fairseq_path)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "qxIRT7xRglJ5",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "qxIRT7xRglJ5"
       },
       "source": [
         "Now let's define `DistributedEmbedding` and the wrapper around the `fairseq_model` that will use it. We override the original model's embedding table, add the forward and backward methods described above, and add a couple of other methods to be used later."
@@ -183,11 +169,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "xVKXBwl5eqlN",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "xVKXBwl5eqlN"
       },
+      "outputs": [],
       "source": [
         "import torch\n",
         "import torch.nn as nn\n",
@@ -282,15 +270,13 @@
         "    for i, _ in enumerate(self.parameters()):\n",
         "      if i != last_index:\n",
         "        yield _"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "5wahSapg6YAE",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "5wahSapg6YAE"
       },
       "source": [
         "Let's now create the `Namespace`, which `fairseq` uses to define the task, dataset, model and more."
@@ -298,11 +284,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "HCcPvjX36i_7",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "HCcPvjX36i_7"
       },
+      "outputs": [],
       "source": [
         "from fairseq import options\n",
         "\n",
@@ -348,15 +336,13 @@
         "args = options.parse_args_and_arch(parser, input_args=args)\n",
         "args.input_shapes = INPUT_SHAPES\n",
         "args.use_gpu = False"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "A7A1IMTFjw9f",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "A7A1IMTFjw9f"
       },
       "source": [
         "Now let's create the models. We're still at global scope, doing this will save host memory. Let's also define the training:"
@@ -364,11 +350,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "G8ekUtnqe90X",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "G8ekUtnqe90X"
       },
+      "outputs": [],
       "source": [
         "import math\n",
         "import torch_xla.distributed.xla_multiprocessing as xmp\n",
@@ -455,15 +443,13 @@
         "    update = 'Step {}, loss {:.4f}'.format(step, running_loss / step)\n",
         "    xm.add_step_closure(lambda s: xm.master_print(s, flush=True), args=(update,))\n",
         "  xm.master_print(met.metrics_report())"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "_VS5EGD1fmYB",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "_VS5EGD1fmYB"
       },
       "source": [
         "Now let's fire up the training, and observe that it doesn't crash w/ an HBM OOM! Note that the first few steps take long because of initial compilations."
@@ -471,16 +457,30 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "6OzYnmCKfpdm",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "6OzYnmCKfpdm"
       },
+      "outputs": [],
       "source": [
         "xmp.spawn(train, args=(), nprocs=NUM_DEVICES, start_method='fork')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "TPU",
+    "colab": {
+      "collapsed_sections": [],
+      "name": "Example: Distributing Large Embedding tables over TPU cores",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/contrib/colab/Exploring_LazyTensor_with_Debug_Metrics.ipynb
+++ b/contrib/colab/Exploring_LazyTensor_with_Debug_Metrics.ipynb
@@ -1,7 +1,433 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 5,
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "06e73109",
+      "metadata": {
+        "id": "06e73109"
+      },
+      "source": [
+        "# Setup PyTorch/XLA Environment"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "89f6b658",
+      "metadata": {
+        "id": "89f6b658"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "# Environment variable for profiling / debug\n",
+        "os.environ['PT_XLA_DEBUG'] = '1'"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "WJ5qowFp1yJP",
+      "metadata": {
+        "id": "WJ5qowFp1yJP"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "5VDH-vKP1q9u",
+      "metadata": {
+        "id": "5VDH-vKP1q9u"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "assert os.environ['COLAB_TPU_ADDR'], 'Make sure to select TPU from Edit > Notebook settings > Hardware accelerator'"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "8aa70226",
+      "metadata": {
+        "id": "8aa70226"
+      },
+      "outputs": [],
+      "source": [
+        "import torch\n",
+        "import torch_xla\n",
+        "import torch_xla.core.xla_model as xm\n",
+        "import torch_xla.debug.metrics as met\n",
+        "\n",
+        "import torch.nn as nn"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "e55acb83",
+      "metadata": {
+        "id": "e55acb83"
+      },
+      "source": [
+        "## Create XLA Tensor \n",
+        "\n",
+        "For illustration, perform operations with XLA tensor(s), and view HLO Graph:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "20d93911",
+      "metadata": {
+        "id": "20d93911"
+      },
+      "outputs": [],
+      "source": [
+        "dev = xm.xla_device()\n",
+        "\n",
+        "x1 = torch.rand((3, 3)).to(dev)\n",
+        "x2 = torch.rand((3, 8)).to(dev)\n",
+        "\n",
+        "y1 = torch.einsum('bs,st->bt', x1, x2)\n",
+        "y1 = y1 + x2\n",
+        "print(torch_xla._XLAC._get_xla_tensors_text([y1]))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "RdNpPCL_eYUp",
+      "metadata": {
+        "id": "RdNpPCL_eYUp"
+      },
+      "source": [
+        "Notice that XLA Tensors are \"Lazy\", i.e. The operations have been recorded but no computation/execution actually is done until required.\n",
+        "\n",
+        "The execution is done when a LazyTensor Barrier is inserted.\n",
+        "The easiest way to insert a barrier is mark_step() call:"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "6b85ebc0",
+      "metadata": {
+        "id": "6b85ebc0"
+      },
+      "source": [
+        "## Exploring LazyTensor with Debug Metrics\n",
+        "Report the metrics and counters, and notice that no compilation has been performed yet, nor the graph has been executed."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "7e09e1ff",
+      "metadata": {
+        "id": "7e09e1ff"
+      },
+      "outputs": [],
+      "source": [
+        "# Print all available metrics \n",
+        "print(f\"Available metrics:\\n {met.metric_names()}\")\n",
+        "# Print all available counters\n",
+        "print(f\"Available counters:\\n {met.counter_names()}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "c137c446",
+      "metadata": {
+        "id": "c137c446"
+      },
+      "source": [
+        "## Graph Execution Scenarios - 1\n",
+        "\n",
+        "The simplest where LazyTensor barrier is inserted triggers execution of graph(s) recorded so far is to call the mark_step API explicitly:\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ee9a743c",
+      "metadata": {
+        "id": "ee9a743c"
+      },
+      "outputs": [],
+      "source": [
+        "xm.mark_step()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "kOohNpTYoOrR",
+      "metadata": {
+        "id": "kOohNpTYoOrR"
+      },
+      "source": [
+        "Let's review the available metrics after the mark step call:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "f043601d",
+      "metadata": {
+        "id": "f043601d"
+      },
+      "outputs": [],
+      "source": [
+        "# Print all available metrics \n",
+        "print(f\"Available metrics:\\n {met.metric_names()}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "qjRW_OKjoasv",
+      "metadata": {
+        "id": "qjRW_OKjoasv"
+      },
+      "source": [
+        "Note that we see the CompileTime metric available now. This metrics can provide the details of Compilation Times distribution for all the graph compilations executed so far. However, here we are only interested in the number of times the compilations happens, we can report it as:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ce416d37",
+      "metadata": {
+        "id": "ce416d37"
+      },
+      "outputs": [],
+      "source": [
+        "met.metric_data('CompileTime')[:1]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "4d45d908",
+      "metadata": {
+        "id": "4d45d908"
+      },
+      "source": [
+        "## Execution Scenario - 2\n",
+        "Another scenario, where the LazyTensor Barrier is inserted is when PyTorch/XLA encounters an OP with no XLA lowering. Let's examine this scenario:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "86050e62",
+      "metadata": {
+        "id": "86050e62"
+      },
+      "outputs": [],
+      "source": [
+        "y1 = y1.view(3, 1, 2, 4)\n",
+        "# Example op with no XLA lowering\n",
+        "unfold = nn.Unfold(kernel_size=(2, 3))\n",
+        "y2 =  unfold(y1)\n",
+        "y4 = y2 * 2"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "1ee2c95d",
+      "metadata": {
+        "id": "1ee2c95d"
+      },
+      "source": [
+        "Notice that an additional compilation is triggered."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "c546dcb3",
+      "metadata": {
+        "id": "c546dcb3"
+      },
+      "outputs": [],
+      "source": [
+        "met.metric_data('CompileTime')[:1]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "JEjG0VU6pi3Z",
+      "metadata": {
+        "id": "JEjG0VU6pi3Z"
+      },
+      "source": [
+        "Notice also the counters:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "nwRyaPm3pha5",
+      "metadata": {
+        "id": "nwRyaPm3pha5"
+      },
+      "outputs": [],
+      "source": [
+        "print(f\"Available counters:\\n {met.counter_names()}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "8e2bfa93",
+      "metadata": {
+        "id": "8e2bfa93"
+      },
+      "source": [
+        "## PyTorch/XLA Profiler\n",
+        "In the remainder of this notebook we will explore how PyTorch/XLA profiler can help surface these metrics insights without writing any additional line of code.\n",
+        "\n",
+        "Note: We alter the lower level variables to display the debug info which will by default be printed on your terminal (can be captured in the logfile). It is intended for educational purposes and is not the recommended way to use the profiler."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "276316b9",
+      "metadata": {
+        "id": "276316b9"
+      },
+      "outputs": [],
+      "source": [
+        "from torch_xla.debug.frame_parser_util import process_frames"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "8c985a52",
+      "metadata": {
+        "id": "8c985a52"
+      },
+      "source": [
+        "Example stack trace:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "223f64c3",
+      "metadata": {
+        "id": "223f64c3"
+      },
+      "outputs": [],
+      "source": [
+        "debug_file = torch_xla._tmp_fname\n",
+        "process_frames(debug_file)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "5905ace9",
+      "metadata": {
+        "id": "5905ace9"
+      },
+      "outputs": [],
+      "source": [
+        "y4 = y4.reshape(-1,1)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "9ec76730",
+      "metadata": {
+        "id": "9ec76730"
+      },
+      "source": [
+        "## Device to host transfer\n",
+        "Now let's create a device to host transfer scenario:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "d70c301d",
+      "metadata": {
+        "id": "d70c301d"
+      },
+      "outputs": [],
+      "source": [
+        "print(y4[0].item())"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "7ba90288",
+      "metadata": {
+        "id": "7ba90288"
+      },
+      "outputs": [],
+      "source": [
+        "# Print all available counters\n",
+        "print(f\"Available counters:\\n {met.counter_names()}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "5145c93f",
+      "metadata": {
+        "id": "5145c93f"
+      },
+      "outputs": [],
+      "source": [
+        "print(met.counter_value('aten::_local_scalar_dense'))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "53b620cd",
+      "metadata": {
+        "id": "53b620cd"
+      },
+      "outputs": [],
+      "source": [
+        "process_frames(debug_file)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "F_S_eXK1qfAd",
+      "metadata": {
+        "id": "F_S_eXK1qfAd"
+      },
+      "source": [
+        "Notice that device to host transfer are reported in terms of _local_scalar_dense op. In the usual seting PyTorch/XLA profiler would provide you the full stack-trace leading to lines in your code which are causing device to host transfers."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "6An3HV34q0La",
+      "metadata": {
+        "id": "6An3HV34q0La"
+      },
+      "source": [
+        "# Summary\n",
+        "In this notebook we have explored the LazyTensor behavior with some basic metrics and briefly also experiemented with some of the functionalities of PyTorch/XLA profiler. To explore other features of Pytorch/XLA profiler please review:\n",
+        "- [Blog Posts](https://cloud.google.com/blog/topics/developers-practitioners/pytorchxla-performance-debugging-tpu-vm-part-1)\n",
+        "- [Contrib Notebooks](https://github.com/pytorch/xla.git)"
+      ]
+    }
+  ],
   "metadata": {
+    "accelerator": "TPU",
+    "colab": {
+      "collapsed_sections": [],
+      "name": "Exploring LazyTensor-with-Debug-Metrics.ipynb",
+      "provenance": []
+    },
     "kernelspec": {
       "display_name": "Python 3 (ipykernel)",
       "language": "python",
@@ -18,434 +444,8 @@
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
       "version": "3.8.10"
-    },
-    "colab": {
-      "name": "Exploring LazyTensor-with-Debug-Metrics.ipynb",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "accelerator": "TPU"
-  },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "06e73109"
-      },
-      "source": [
-        "# Setup PyTorch/XLA Environment"
-      ],
-      "id": "06e73109"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "89f6b658"
-      },
-      "source": [
-        "import os\n",
-        "\n",
-        "# Environment variable for profiling / debug\n",
-        "os.environ['PT_XLA_DEBUG'] = '1'"
-      ],
-      "id": "89f6b658",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "WJ5qowFp1yJP"
-      },
-      "source": [
-        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
-      ],
-      "id": "WJ5qowFp1yJP",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "5VDH-vKP1q9u"
-      },
-      "source": [
-        "import os\n",
-        "assert os.environ['COLAB_TPU_ADDR'], 'Make sure to select TPU from Edit > Notebook settings > Hardware accelerator'"
-      ],
-      "id": "5VDH-vKP1q9u",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "8aa70226"
-      },
-      "source": [
-        "import torch\n",
-        "import torch_xla\n",
-        "import torch_xla.core.xla_model as xm\n",
-        "import torch_xla.debug.metrics as met\n",
-        "\n",
-        "import torch.nn as nn"
-      ],
-      "id": "8aa70226",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "e55acb83"
-      },
-      "source": [
-        "## Create XLA Tensor \n",
-        "\n",
-        "For illustration, perform operations with XLA tensor(s), and view HLO Graph:"
-      ],
-      "id": "e55acb83"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "20d93911"
-      },
-      "source": [
-        "dev = xm.xla_device()\n",
-        "\n",
-        "x1 = torch.rand((3, 3)).to(dev)\n",
-        "x2 = torch.rand((3, 8)).to(dev)\n",
-        "\n",
-        "y1 = torch.einsum('bs,st->bt', x1, x2)\n",
-        "y1 = y1 + x2\n",
-        "print(torch_xla._XLAC._get_xla_tensors_text([y1]))"
-      ],
-      "id": "20d93911",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Notice that XLA Tensors are \"Lazy\", i.e. The operations have been recorded but no computation/execution actually is done until required.\n",
-        "\n",
-        "The execution is done when a LazyTensor Barrier is inserted.\n",
-        "The easiest way to insert a barrier is mark_step() call:"
-      ],
-      "metadata": {
-        "id": "RdNpPCL_eYUp"
-      },
-      "id": "RdNpPCL_eYUp"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "6b85ebc0"
-      },
-      "source": [
-        "## Exploring LazyTensor with Debug Metrics\n",
-        "Report the metrics and counters, and notice that no compilation has been performed yet, nor the graph has been executed."
-      ],
-      "id": "6b85ebc0"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "7e09e1ff"
-      },
-      "source": [
-        "# Print all available metrics \n",
-        "print(f\"Available metrics:\\n {met.metric_names()}\")\n",
-        "# Print all available counters\n",
-        "print(f\"Available counters:\\n {met.counter_names()}\")"
-      ],
-      "id": "7e09e1ff",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "c137c446"
-      },
-      "source": [
-        "## Graph Execution Scenarios - 1\n",
-        "\n",
-        "The simplest where LazyTensor barrier is inserted triggers execution of graph(s) recorded so far is to call the mark_step API explicitly:\n"
-      ],
-      "id": "c137c446"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "ee9a743c"
-      },
-      "source": [
-        "xm.mark_step()"
-      ],
-      "id": "ee9a743c",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Let's review the available metrics after the mark step call:"
-      ],
-      "metadata": {
-        "id": "kOohNpTYoOrR"
-      },
-      "id": "kOohNpTYoOrR"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "f043601d"
-      },
-      "source": [
-        "# Print all available metrics \n",
-        "print(f\"Available metrics:\\n {met.metric_names()}\")"
-      ],
-      "id": "f043601d",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Note that we see the CompileTime metric available now. This metrics can provide the details of Compilation Times distribution for all the graph compilations executed so far. However, here we are only interested in the number of times the compilations happens, we can report it as:"
-      ],
-      "metadata": {
-        "id": "qjRW_OKjoasv"
-      },
-      "id": "qjRW_OKjoasv"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "ce416d37"
-      },
-      "source": [
-        "met.metric_data('CompileTime')[:1]"
-      ],
-      "id": "ce416d37",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "4d45d908"
-      },
-      "source": [
-        "## Execution Scenario - 2\n",
-        "Another scenario, where the LazyTensor Barrier is inserted is when PyTorch/XLA encounters an OP with no XLA lowering. Let's examine this scenario:"
-      ],
-      "id": "4d45d908"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "86050e62"
-      },
-      "source": [
-        "y1 = y1.view(3, 1, 2, 4)\n",
-        "# Example op with no XLA lowering\n",
-        "unfold = nn.Unfold(kernel_size=(2, 3))\n",
-        "y2 =  unfold(y1)\n",
-        "y4 = y2 * 2"
-      ],
-      "id": "86050e62",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "1ee2c95d"
-      },
-      "source": [
-        "Notice that an additional compilation is triggered."
-      ],
-      "id": "1ee2c95d"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "c546dcb3"
-      },
-      "source": [
-        "met.metric_data('CompileTime')[:1]"
-      ],
-      "id": "c546dcb3",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Notice also the counters:"
-      ],
-      "metadata": {
-        "id": "JEjG0VU6pi3Z"
-      },
-      "id": "JEjG0VU6pi3Z"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "print(f\"Available counters:\\n {met.counter_names()}\")"
-      ],
-      "metadata": {
-        "id": "nwRyaPm3pha5"
-      },
-      "id": "nwRyaPm3pha5",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "8e2bfa93"
-      },
-      "source": [
-        "## PyTorch/XLA Profiler\n",
-        "In the remainder of this notebook we will explore how PyTorch/XLA profiler can help surface these metrics insights without writing any additional line of code.\n",
-        "\n",
-        "Note: We alter the lower level variables to display the debug info which will by default be printed on your terminal (can be captured in the logfile). It is intended for educational purposes and is not the recommended way to use the profiler."
-      ],
-      "id": "8e2bfa93"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "276316b9"
-      },
-      "source": [
-        "from torch_xla.debug.frame_parser_util import process_frames"
-      ],
-      "id": "276316b9",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "8c985a52"
-      },
-      "source": [
-        "Example stack trace:"
-      ],
-      "id": "8c985a52"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "223f64c3"
-      },
-      "source": [
-        "debug_file = torch_xla._tmp_fname\n",
-        "process_frames(debug_file)"
-      ],
-      "id": "223f64c3",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "5905ace9"
-      },
-      "source": [
-        "y4 = y4.reshape(-1,1)"
-      ],
-      "id": "5905ace9",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "9ec76730"
-      },
-      "source": [
-        "## Device to host transfer\n",
-        "Now let's create a device to host transfer scenario:"
-      ],
-      "id": "9ec76730"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "d70c301d"
-      },
-      "source": [
-        "print(y4[0].item())"
-      ],
-      "id": "d70c301d",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "7ba90288"
-      },
-      "source": [
-        "# Print all available counters\n",
-        "print(f\"Available counters:\\n {met.counter_names()}\")"
-      ],
-      "id": "7ba90288",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "5145c93f"
-      },
-      "source": [
-        "print(met.counter_value('aten::_local_scalar_dense'))"
-      ],
-      "id": "5145c93f",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "53b620cd"
-      },
-      "source": [
-        "process_frames(debug_file)"
-      ],
-      "id": "53b620cd",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Notice that device to host transfer are reported in terms of _local_scalar_dense op. In the usual seting PyTorch/XLA profiler would provide you the full stack-trace leading to lines in your code which are causing device to host transfers."
-      ],
-      "metadata": {
-        "id": "F_S_eXK1qfAd"
-      },
-      "id": "F_S_eXK1qfAd"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Summary\n",
-        "In this notebook we have explored the LazyTensor behavior with some basic metrics and briefly also experiemented with some of the functionalities of PyTorch/XLA profiler. To explore other features of Pytorch/XLA profiler please review:\n",
-        "- [Blog Posts](https://cloud.google.com/blog/topics/developers-practitioners/pytorchxla-performance-debugging-tpu-vm-part-1)\n",
-        "- [Contrib Notebooks](https://github.com/pytorch/xla.git)"
-      ],
-      "metadata": {
-        "id": "6An3HV34q0La"
-      },
-      "id": "6An3HV34q0La"
     }
-  ]
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/contrib/colab/LazyTensor_Basics.ipynb
+++ b/contrib/colab/LazyTensor_Basics.ipynb
@@ -1,7 +1,219 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 5,
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "06e73109",
+      "metadata": {
+        "id": "06e73109"
+      },
+      "source": [
+        "# Setup PyTorch/XLA Environment"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "WJ5qowFp1yJP",
+      "metadata": {
+        "id": "WJ5qowFp1yJP"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "5VDH-vKP1q9u",
+      "metadata": {
+        "id": "5VDH-vKP1q9u"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "assert os.environ['COLAB_TPU_ADDR'], 'Make sure to select TPU from Edit > Notebook settings > Hardware accelerator'"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "8aa70226",
+      "metadata": {
+        "id": "8aa70226"
+      },
+      "outputs": [],
+      "source": [
+        "import torch\n",
+        "import torch_xla\n",
+        "import torch_xla.core.xla_model as xm\n",
+        "import torch_xla.debug.metrics as met\n",
+        "\n",
+        "import torch.nn as nn"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "e55acb83",
+      "metadata": {
+        "id": "e55acb83"
+      },
+      "source": [
+        "## LazyTensor Basics \n",
+        "\n",
+        "This colab is a companion to the blog post titled \"Understanding Lazy Tensor System Performance\".\n",
+        "\n",
+        "For illustration of lazy tensor behavior, let's perform some operations with XLA tensor(s), and examine the resulting HLO Graph:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "20d93911",
+      "metadata": {
+        "id": "20d93911"
+      },
+      "outputs": [],
+      "source": [
+        "dev = xm.xla_device()\n",
+        "\n",
+        "x1 = torch.rand((3, 3)).to(dev)\n",
+        "x2 = torch.rand((3, 8)).to(dev)\n",
+        "\n",
+        "y1 = torch.einsum('bs,st->bt', x1, x2)\n",
+        "y1 = y1 + x2\n",
+        "print(torch_xla._XLAC._get_xla_tensors_text([y1]))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "RdNpPCL_eYUp",
+      "metadata": {
+        "id": "RdNpPCL_eYUp"
+      },
+      "source": [
+        "Notice that XLA Tensors are \"Lazy\", i.e. The operations have been recorded but no computation/execution actually is done until required.\n",
+        "\n",
+        "The execution is done when a LazyTensor Barrier is inserted.\n",
+        "The easiest way to insert a barrier is mark_step() call:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "Pc_GPV7zgV2b",
+      "metadata": {
+        "id": "Pc_GPV7zgV2b"
+      },
+      "outputs": [],
+      "source": [
+        "xm.mark_step()\n",
+        "print(torch_xla._XLAC._get_xla_tensors_text([x1]))\n",
+        "print(y1.device)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "jBthtD2MzSyD",
+      "metadata": {
+        "id": "jBthtD2MzSyD"
+      },
+      "source": [
+        "# Dynamic Graph\n",
+        "Now let's create a method which executes operations on xla tensors followed by a mark_step call. Optionally we also introduce a dynamic structure with these tensors. We then execute this method with and without the dynamic structure and measure the run time."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "tWcwhuglRYAG",
+      "metadata": {
+        "id": "tWcwhuglRYAG"
+      },
+      "outputs": [],
+      "source": [
+        "def dummy_step(x, y, loss, acc=False):\n",
+        "  z = torch.einsum('bs,st->bt', y, x)\n",
+        "  step_loss = z.sum().view(1,)\n",
+        "  if acc: \n",
+        "    loss = torch.cat((loss, step_loss))\n",
+        "  else:\n",
+        "    loss = step_loss\n",
+        "  xm.mark_step()\n",
+        "  return loss"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "YGAf-6c0ZxoK",
+      "metadata": {
+        "id": "YGAf-6c0ZxoK"
+      },
+      "outputs": [],
+      "source": [
+        "import time\n",
+        "def measure_time(acc=False):\n",
+        "  exec_times = []\n",
+        "  iter_count = 100\n",
+        "  x = torch.rand((512, 8)).to(dev)\n",
+        "  y = torch.rand((512, 512)).to(dev)\n",
+        "  loss = torch.zeros(1).to(dev)\n",
+        "  for i in range(iter_count):\n",
+        "    tic = time.time()\n",
+        "    loss = dummy_step(x, y, loss, acc=acc)\n",
+        "    toc = time.time()\n",
+        "    exec_times.append(toc - tic)\n",
+        "  return exec_times"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "I5UFoYwDndpU",
+      "metadata": {
+        "id": "I5UFoYwDndpU"
+      },
+      "outputs": [],
+      "source": [
+        "dyn = measure_time(acc=True) # acc= True Results in dynamic graph\n",
+        "st = measure_time(acc=False) # Static graph, computation shape, inputs and output shapes don't change"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "4cnVF11ykWxG",
+      "metadata": {
+        "id": "4cnVF11ykWxG"
+      },
+      "outputs": [],
+      "source": [
+        "import matplotlib.pyplot as plt\n",
+        "plt.plot(st, label = 'static graph')\n",
+        "plt.plot(dyn, label = 'dynamic graph')\n",
+        "plt.legend()\n",
+        "plt.title('Execution time in seconds')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "1bkkZ5vN0f8u",
+      "metadata": {
+        "id": "1bkkZ5vN0f8u"
+      },
+      "source": [
+        "Notice that dynamic graph execution times are consistently higher for same computation because of the compilation cost incurred in every iteration. Static graph curve benefits from compilation cache and quickly stablizes to a faster execution time."
+      ]
+    }
+  ],
   "metadata": {
+    "accelerator": "TPU",
+    "colab": {
+      "collapsed_sections": [],
+      "name": "LazyTensor-Basics.ipynb",
+      "provenance": []
+    },
     "kernelspec": {
       "display_name": "Python 3 (ipykernel)",
       "language": "python",
@@ -18,220 +230,8 @@
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
       "version": "3.8.10"
-    },
-    "colab": {
-      "name": "LazyTensor-Basics.ipynb",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "accelerator": "TPU"
-  },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "06e73109"
-      },
-      "source": [
-        "# Setup PyTorch/XLA Environment"
-      ],
-      "id": "06e73109"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "WJ5qowFp1yJP"
-      },
-      "source": [
-        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
-      ],
-      "id": "WJ5qowFp1yJP",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "5VDH-vKP1q9u"
-      },
-      "source": [
-        "import os\n",
-        "assert os.environ['COLAB_TPU_ADDR'], 'Make sure to select TPU from Edit > Notebook settings > Hardware accelerator'"
-      ],
-      "id": "5VDH-vKP1q9u",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "8aa70226"
-      },
-      "source": [
-        "import torch\n",
-        "import torch_xla\n",
-        "import torch_xla.core.xla_model as xm\n",
-        "import torch_xla.debug.metrics as met\n",
-        "\n",
-        "import torch.nn as nn"
-      ],
-      "id": "8aa70226",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "e55acb83"
-      },
-      "source": [
-        "## LazyTensor Basics \n",
-        "\n",
-        "This colab is a companion to the blog post titled \"Understanding Lazy Tensor System Performance\".\n",
-        "\n",
-        "For illustration of lazy tensor behavior, let's perform some operations with XLA tensor(s), and examine the resulting HLO Graph:"
-      ],
-      "id": "e55acb83"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "20d93911"
-      },
-      "source": [
-        "dev = xm.xla_device()\n",
-        "\n",
-        "x1 = torch.rand((3, 3)).to(dev)\n",
-        "x2 = torch.rand((3, 8)).to(dev)\n",
-        "\n",
-        "y1 = torch.einsum('bs,st->bt', x1, x2)\n",
-        "y1 = y1 + x2\n",
-        "print(torch_xla._XLAC._get_xla_tensors_text([y1]))"
-      ],
-      "id": "20d93911",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Notice that XLA Tensors are \"Lazy\", i.e. The operations have been recorded but no computation/execution actually is done until required.\n",
-        "\n",
-        "The execution is done when a LazyTensor Barrier is inserted.\n",
-        "The easiest way to insert a barrier is mark_step() call:"
-      ],
-      "metadata": {
-        "id": "RdNpPCL_eYUp"
-      },
-      "id": "RdNpPCL_eYUp"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "xm.mark_step()\n",
-        "print(torch_xla._XLAC._get_xla_tensors_text([x1]))\n",
-        "print(y1.device)"
-      ],
-      "metadata": {
-        "id": "Pc_GPV7zgV2b"
-      },
-      "id": "Pc_GPV7zgV2b",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Dynamic Graph\n",
-        "Now let's create a method which executes operations on xla tensors followed by a mark_step call. Optionally we also introduce a dynamic structure with these tensors. We then execute this method with and without the dynamic structure and measure the run time."
-      ],
-      "metadata": {
-        "id": "jBthtD2MzSyD"
-      },
-      "id": "jBthtD2MzSyD"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "def dummy_step(x, y, loss, acc=False):\n",
-        "  z = torch.einsum('bs,st->bt', y, x)\n",
-        "  step_loss = z.sum().view(1,)\n",
-        "  if acc: \n",
-        "    loss = torch.cat((loss, step_loss))\n",
-        "  else:\n",
-        "    loss = step_loss\n",
-        "  xm.mark_step()\n",
-        "  return loss"
-      ],
-      "metadata": {
-        "id": "tWcwhuglRYAG"
-      },
-      "id": "tWcwhuglRYAG",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import time\n",
-        "def measure_time(acc=False):\n",
-        "  exec_times = []\n",
-        "  iter_count = 100\n",
-        "  x = torch.rand((512, 8)).to(dev)\n",
-        "  y = torch.rand((512, 512)).to(dev)\n",
-        "  loss = torch.zeros(1).to(dev)\n",
-        "  for i in range(iter_count):\n",
-        "    tic = time.time()\n",
-        "    loss = dummy_step(x, y, loss, acc=acc)\n",
-        "    toc = time.time()\n",
-        "    exec_times.append(toc - tic)\n",
-        "  return exec_times"
-      ],
-      "metadata": {
-        "id": "YGAf-6c0ZxoK"
-      },
-      "id": "YGAf-6c0ZxoK",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "dyn = measure_time(acc=True) # acc= True Results in dynamic graph\n",
-        "st = measure_time(acc=False) # Static graph, computation shape, inputs and output shapes don't change"
-      ],
-      "metadata": {
-        "id": "I5UFoYwDndpU"
-      },
-      "id": "I5UFoYwDndpU",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import matplotlib.pyplot as plt\n",
-        "plt.plot(st, label = 'static graph')\n",
-        "plt.plot(dyn, label = 'dynamic graph')\n",
-        "plt.legend()\n",
-        "plt.title('Execution time in seconds')"
-      ],
-      "metadata": {
-        "id": "4cnVF11ykWxG"
-      },
-      "id": "4cnVF11ykWxG",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Notice that dynamic graph execution times are consistently higher for same computation because of the compilation cost incurred in every iteration. Static graph curve benefits from compilation cache and quickly stablizes to a faster execution time."
-      ],
-      "metadata": {
-        "id": "1bkkZ5vN0f8u"
-      },
-      "id": "1bkkZ5vN0f8u"
     }
-  ]
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/contrib/colab/getting-started.ipynb
+++ b/contrib/colab/getting-started.ipynb
@@ -1,25 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "Getting Started with PyTorch on Cloud TPUs",
-      "provenance": [],
-      "collapsed_sections": [],
-      "machine_shape": "hm"
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "accelerator": "TPU"
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "RKLajLqUni6H",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "RKLajLqUni6H"
       },
       "source": [
         "## Getting Started with PyTorch on Cloud TPUs\n",
@@ -45,8 +30,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "b3rCVMRazoeB",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "b3rCVMRazoeB"
       },
       "source": [
         "<h3>  &nbsp;&nbsp;Use Colab Cloud TPU&nbsp;&nbsp; <a href=\"https://cloud.google.com/tpu/\"><img valign=\"middle\" src=\"https://raw.githubusercontent.com/GoogleCloudPlatform/tensorflow-without-a-phd/master/tensorflow-rl-pong/images/tpu-hexagon.png\" width=\"50\"></a></h3>\n",
@@ -57,23 +42,23 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "3P6b3uqfzpDI",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "3P6b3uqfzpDI"
       },
+      "outputs": [],
       "source": [
         "import os\n",
         "assert os.environ['COLAB_TPU_ADDR'], 'Make sure to select TPU from Edit > Notebook settings > Hardware accelerator'"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "CHzziBW5AoZH",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "CHzziBW5AoZH"
       },
       "source": [
         "## Installing PyTorch/XLA\n",
@@ -85,34 +70,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "OApBOAe1fpH_"
       },
+      "outputs": [],
       "source": [
-        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
-      ],
-      "execution_count": null,
-      "outputs": []
+        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
-      ],
       "metadata": {
         "id": "nfSCdVlA8jFg"
-      }
+      },
+      "source": [
+        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "J1Vfg-rH8bF4"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
+      ]
     },
     {
       "cell_type": "markdown",
@@ -125,9 +110,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "vJZrkoejQhxK"
       },
+      "outputs": [],
       "source": [
         "# VERSION = \"1.11\"  #@param [\"1.11\", \"nightly\", \"20220315\"]  # or YYYYMMDD format\n",
         "# !curl https://raw.githubusercontent.com/pytorch/xla/master/contrib/scripts/env-setup.py -o pytorch-xla-env-setup.py\n",
@@ -142,15 +129,13 @@
         "\n",
         "# !ldconfig\n",
         "# !ldd /usr/local/lib/python3.7/dist-packages/torch/lib/libtorch.so"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "ls3j-EWI2D2v",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "ls3j-EWI2D2v"
       },
       "source": [
         "## Creating and Manipulating Tensors on TPUs\n",
@@ -162,11 +147,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "42avAvSg17by",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "42avAvSg17by"
       },
+      "outputs": [],
       "source": [
         "# imports pytorch\n",
         "import torch\n",
@@ -174,15 +161,13 @@
         "# imports the torch_xla package\n",
         "import torch_xla\n",
         "import torch_xla.core.xla_model as xm"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "4b8RfPPk4VIX",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "4b8RfPPk4VIX"
       },
       "source": [
         "As mentioned above, the PyTorch/XLA package (torch_xla) lets PyTorch use TPU devices. The `xla_device()` function returns the TPU's \"default\" core as a device. This lets PyTorch creates tensors on TPUs:"
@@ -190,25 +175,25 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "H9KYz-Vk4fMa",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "H9KYz-Vk4fMa"
       },
+      "outputs": [],
       "source": [
         "# Creates a random tensor on xla:1 (a Cloud TPU core)\n",
         "dev = xm.xla_device()\n",
         "t1 = torch.ones(3, 3, device = dev)\n",
         "print(t1)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "yHwOC-xr4_LX",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "yHwOC-xr4_LX"
       },
       "source": [
         "See the documentation at http://pytorch.org/xla/ for a description of all public PyTorch/XLA functions. Here `xm.xla_device()` acquired the first Cloud TPU core ('xla:1'). Other cores can be directly acquired, too:"
@@ -216,25 +201,25 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "2ef7flq95OxD",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "2ef7flq95OxD"
       },
+      "outputs": [],
       "source": [
         "# Creating a tensor on the second Cloud TPU core\n",
         "second_dev = xm.xla_device(n=2, devkind='TPU')\n",
         "t2 = torch.zeros(3, 3, device = second_dev)\n",
         "print(t2)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "ANcDKzGG5_ua",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "ANcDKzGG5_ua"
       },
       "source": [
         "It is recommended that you use functions like `xm.xla_device()` over directly specifying TPU cores. A future Colab tutorial will show how to easily train a network using multiple cores (or you can look at [an example](https://colab.research.google.com/github/pytorch/xla/blob/master/contrib/colab/mnist-training.ipynb#scrollTo=Afwo4H7kSd8Phttps://)).\n"
@@ -243,8 +228,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "QiKmkAkoO06x",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "QiKmkAkoO06x"
       },
       "source": [
         "Tensors on TPUs can be manipulated like any other PyTorch tensor. The following cell adds, multiplies, and matrix multiplies two tensors on a TPU core:"
@@ -252,26 +237,26 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "l50-R2kwFY7Z",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "l50-R2kwFY7Z"
       },
+      "outputs": [],
       "source": [
         "a = torch.randn(2, 2, device = dev)\n",
         "b = torch.randn(2, 2, device = dev)\n",
         "print(a + b)\n",
         "print(b * 2)\n",
         "print(torch.matmul(a, b))"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "cfDBbDtuisdu",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "cfDBbDtuisdu"
       },
       "source": [
         "This next cell runs a 1D convolution on a TPU core:"
@@ -279,25 +264,25 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "aryiLyezisEg",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "aryiLyezisEg"
       },
+      "outputs": [],
       "source": [
         "# Creates random filters and inputs to a 1D convolution\n",
         "filters = torch.randn(33, 16, 3, device = dev)\n",
         "inputs = torch.randn(20, 16, 50, device = dev)\n",
         "torch.nn.functional.conv1d(inputs, filters)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "D5b4AmYDgbKd",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "D5b4AmYDgbKd"
       },
       "source": [
         "And tensors can be transferred between CPU and TPU. In the following cell, a tensor on the CPU is copied to a TPU core, and then copied back to the CPU again. Note that PyTorch makes copies of tensors when transferring them across devices, so `t_cpu` and `t_cpu_again` are different tensors.\n",
@@ -306,11 +291,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "8WTsdQ3yO-8G",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "8WTsdQ3yO-8G"
       },
+      "outputs": [],
       "source": [
         "# Creates a tensor on the CPU (device='cpu' is unnecessary and only added for clarity)\n",
         "t_cpu = torch.randn(2, 2, device='cpu')\n",
@@ -321,15 +308,13 @@
         "\n",
         "t_cpu_again = t_tpu.to('cpu')\n",
         "print(t_cpu_again)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "DWtOgDLxN_BV",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "DWtOgDLxN_BV"
       },
       "source": [
         "## Running PyTorch modules and autograd on TPUs\n",
@@ -341,11 +326,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "P-WT-r8sRERM",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "P-WT-r8sRERM"
       },
+      "outputs": [],
       "source": [
         "# Creates a linear module\n",
         "fc = torch.nn.Linear(5, 2, bias=True)\n",
@@ -359,15 +346,13 @@
         "# Runs and prints the module\n",
         "output = fc(features)\n",
         "print(output)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "23Epn0HHR_Nq",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "23Epn0HHR_Nq"
       },
       "source": [
         "Autograd is the system PyTorch uses to populate the gradients of weights in a neural network. See [here](https://pytorch.org/tutorials/beginner/blitz/autograd_tutorial.html#sphx-glr-beginner-blitz-autograd-tutorial-py) for details about PyTorch's autograd. When a module is run on a TPU core, its gradients are also populated on the same TPU core by autograd. The following cell demonstrates this:"
@@ -375,23 +360,23 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "Qs-2q5AMRixo",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "Qs-2q5AMRixo"
       },
+      "outputs": [],
       "source": [
         "output.backward(torch.ones_like(output))\n",
         "print(fc.weight.grad)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "u0g3o1wHmF38",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "u0g3o1wHmF38"
       },
       "source": [
         "## Running PyTorch networks on TPUs\n",
@@ -401,11 +386,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "ZLtM_M1imkFQ",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "ZLtM_M1imkFQ"
       },
+      "outputs": [],
       "source": [
         "import torch.nn as nn\n",
         "import torch.nn.functional as F\n",
@@ -453,15 +440,13 @@
         "# Runs network\n",
         "out = net(input)\n",
         "print(out)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "zmySVJYIm88W",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "zmySVJYIm88W"
       },
       "source": [
         "As in the previous snippets, running PyTorch on a TPU just requires specifying a TPU core as a device."
@@ -470,8 +455,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "e9y2QGhl8SyE",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "e9y2QGhl8SyE"
       },
       "source": [
         "## More PyTorch on TPUs!\n",
@@ -496,5 +481,20 @@
         "\n"
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "TPU",
+    "colab": {
+      "collapsed_sections": [],
+      "machine_shape": "hm",
+      "name": "Getting Started with PyTorch on Cloud TPUs",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/contrib/colab/issue-report.ipynb
+++ b/contrib/colab/issue-report.ipynb
@@ -1,25 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "PyTorch_XLA_Debug",
-      "provenance": [],
-      "collapsed_sections": [],
-      "machine_shape": "hm"
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "accelerator": "TPU"
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "-5-xIyOwIk45",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "-5-xIyOwIk45"
       },
       "source": [
         "Install PyTorch Nightly packages and set up the backend version."
@@ -27,34 +12,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "OApBOAe1fpH_"
       },
+      "outputs": [],
       "source": [
-        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
-      ],
-      "execution_count": null,
-      "outputs": []
+        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
-      ],
       "metadata": {
         "id": "nfSCdVlA8jFg"
-      }
+      },
+      "source": [
+        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "J1Vfg-rH8bF4"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
+      ]
     },
     {
       "cell_type": "markdown",
@@ -67,9 +52,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "vJZrkoejQhxK"
       },
+      "outputs": [],
       "source": [
         "# VERSION = \"1.11\"  #@param [\"1.11\", \"nightly\", \"20220315\"]  # or YYYYMMDD format\n",
         "# !curl https://raw.githubusercontent.com/pytorch/xla/master/contrib/scripts/env-setup.py -o pytorch-xla-env-setup.py\n",
@@ -84,15 +71,13 @@
         "\n",
         "# !ldconfig\n",
         "# !ldd /usr/local/lib/python3.7/dist-packages/torch/lib/libtorch.so"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "AxoPg3MPIz6d",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "AxoPg3MPIz6d"
       },
       "source": [
         "Install the other publicly available dependencies (PIP, APT, ...)."
@@ -100,22 +85,22 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "cb8MzLOAKKXS",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "cb8MzLOAKKXS"
       },
+      "outputs": [],
       "source": [
         "# !pip install transformers"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "cAZS4UD_I89G",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "cAZS4UD_I89G"
       },
       "source": [
         "Clone the repo containing the model to be tested.\n",
@@ -125,23 +110,23 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "gyrcRaWFJrBf",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "gyrcRaWFJrBf"
       },
+      "outputs": [],
       "source": [
         "!rm -rf pytorch-xla-transformer-language-model/\n",
         "!git clone https://github.com/dlibenzi/pytorch-xla-transformer-language-model.git"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "bxdfcIREJF97",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "bxdfcIREJF97"
       },
       "source": [
         "Setup the environment."
@@ -149,11 +134,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "2hXaIwi3Kr_1",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "2hXaIwi3Kr_1"
       },
+      "outputs": [],
       "source": [
         "import os\n",
         "# os.environ['XLA_IR_DEBUG'] = '1'\n",
@@ -163,15 +150,13 @@
         "# os.environ['XLA_SAVE_TENSORS_FILE'] = 'tensors.log'\n",
         "# os.environ['XLA_SAVE_TENSORS_FMT'] = 'text'\n",
         "# os.environ['XLA_TRIM_GRAPH_SIZE'] = '1000000'"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "BUVjzXMjJN5Q",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "BUVjzXMjJN5Q"
       },
       "source": [
         "Override the files which needs editing/tweaking during the debug session.\n",
@@ -185,11 +170,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "zQ2_OcQxMEI8",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "zQ2_OcQxMEI8"
       },
+      "outputs": [],
       "source": [
         "%%writefile pytorch-xla-transformer-language-model/train.py\n",
         "# Copyright (c) 2019, Bryan McCann\n",
@@ -293,15 +280,13 @@
         "if __name__ == '__main__':\n",
         "  # Set nprocs=1 for debugging (using one core).\n",
         "  xmp.spawn(main, args=(), nprocs=1)\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "lcSHTc_uJYuM",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "lcSHTc_uJYuM"
       },
       "source": [
         "Cleanup (optional) the products of previous runs, as some operations might append to existing content (like tensors logging)."
@@ -309,23 +294,23 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "46T_FzvTU1KE",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "46T_FzvTU1KE"
       },
+      "outputs": [],
       "source": [
         "!rm -f tensors.log\n",
         "!rm -rf /tmp/debug_run*"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "snzW8KikJlvK",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "snzW8KikJlvK"
       },
       "source": [
         "Run the model's script with proper command line."
@@ -333,22 +318,22 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "_aceXPFHJ1Zq",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "_aceXPFHJ1Zq"
       },
+      "outputs": [],
       "source": [
         "!python pytorch-xla-transformer-language-model/train.py"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "TC-f3okfGQHX",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "TC-f3okfGQHX"
       },
       "source": [
         "For debugging it is also useful to run the *debug_run.py* script to collect a set of debug information packaged in a TAR file.\n",
@@ -358,35 +343,35 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "xq-prSeCGH0J",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "xq-prSeCGH0J"
       },
+      "outputs": [],
       "source": [
         "!git clone https://github.com/pytorch/xla.git"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "SFpZLS98HBIq",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "SFpZLS98HBIq"
       },
+      "outputs": [],
       "source": [
         "!./xla/scripts/debug_run.py --outfile debug_run.tar.gz --hlo -- python -u pytorch-xla-transformer-language-model/train.py"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "jHiJZTTIJq5y",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "jHiJZTTIJq5y"
       },
       "source": [
         "Download generated debug files or logs."
@@ -394,18 +379,33 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "VCowkX_-Ofkn",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "VCowkX_-Ofkn"
       },
+      "outputs": [],
       "source": [
         "from google.colab import files\n",
         "# files.download('tensors.log')\n",
         "# files.download('debug_run.tar.gz')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "TPU",
+    "colab": {
+      "collapsed_sections": [],
+      "machine_shape": "hm",
+      "name": "PyTorch_XLA_Debug",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/contrib/colab/mnist-training.ipynb
+++ b/contrib/colab/mnist-training.ipynb
@@ -1,25 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "PyTorch/TPU MNIST Training",
-      "provenance": [],
-      "collapsed_sections": [],
-      "machine_shape": "hm"
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "accelerator": "TPU"
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "0WzFpOKDmURO",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "0WzFpOKDmURO"
       },
       "source": [
         "## PyTorch/TPU MNIST Demo\n",
@@ -30,8 +15,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "xOp9jBEumdvC",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "xOp9jBEumdvC"
       },
       "source": [
         "<h3>  &nbsp;&nbsp;Use Colab Cloud TPU&nbsp;&nbsp; <a href=\"https://cloud.google.com/tpu/\"><img valign=\"middle\" src=\"https://raw.githubusercontent.com/GoogleCloudPlatform/tensorflow-without-a-phd/master/tensorflow-rl-pong/images/tpu-hexagon.png\" width=\"50\"></a></h3>\n",
@@ -42,23 +27,23 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "Hx4YVNHametU",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "Hx4YVNHametU"
       },
+      "outputs": [],
       "source": [
         "import os\n",
         "assert os.environ['COLAB_TPU_ADDR'], 'Make sure to select TPU from Edit > Notebook settings > Hardware accelerator'"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "YofXQrnxmf5r",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "YofXQrnxmf5r"
       },
       "source": [
         "### [RUNME] Install Colab TPU compatible PyTorch/TPU wheels and dependencies"
@@ -66,34 +51,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "OApBOAe1fpH_"
       },
+      "outputs": [],
       "source": [
-        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
-      ],
-      "execution_count": null,
-      "outputs": []
+        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
-      ],
       "metadata": {
         "id": "nfSCdVlA8jFg"
-      }
+      },
+      "source": [
+        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "J1Vfg-rH8bF4"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
+      ]
     },
     {
       "cell_type": "markdown",
@@ -106,9 +91,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "vJZrkoejQhxK"
       },
+      "outputs": [],
       "source": [
         "# VERSION = \"1.11\"  #@param [\"1.11\", \"nightly\", \"20220315\"]  # or YYYYMMDD format\n",
         "# !curl https://raw.githubusercontent.com/pytorch/xla/master/contrib/scripts/env-setup.py -o pytorch-xla-env-setup.py\n",
@@ -123,9 +110,7 @@
         "\n",
         "# !ldconfig\n",
         "# !ldd /usr/local/lib/python3.7/dist-packages/torch/lib/libtorch.so"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -139,11 +124,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "LNLegt4jLkRD",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "LNLegt4jLkRD"
       },
+      "outputs": [],
       "source": [
         "# Result Visualization Helper\n",
         "import math\n",
@@ -175,17 +162,17 @@
         "          'X {}/{}'.format(label, prediction), color='red')\n",
         "    ax.imshow(img)\n",
         "  plt.savefig(RESULT_IMG_PATH, transparent=True)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "kNh-oEmHmorI",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "kNh-oEmHmorI"
       },
+      "outputs": [],
       "source": [
         "# Define Parameters\n",
         "FLAGS = {}\n",
@@ -198,17 +185,17 @@
         "FLAGS['num_cores'] = 8\n",
         "FLAGS['log_steps'] = 20\n",
         "FLAGS['metrics_debug'] = False"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "pTmxZL5ymp8P",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "pTmxZL5ymp8P"
       },
+      "outputs": [],
       "source": [
         "import numpy as np\n",
         "import os\n",
@@ -348,17 +335,17 @@
         "      xm.master_print(met.metrics_report(), flush=True)\n",
         "\n",
         "  return accuracy, data, pred, target"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "Afwo4H7kSd8P",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "Afwo4H7kSd8P"
       },
+      "outputs": [],
       "source": [
         "# Start training processes\n",
         "def _mp_fn(rank, flags):\n",
@@ -372,15 +359,13 @@
         "\n",
         "xmp.spawn(_mp_fn, args=(FLAGS,), nprocs=FLAGS['num_cores'],\n",
         "          start_method='fork')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "MznTE72_mthI",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "MznTE72_mthI"
       },
       "source": [
         "## Visualize Predictions"
@@ -388,19 +373,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "X9VAwyUnI7Sb",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "X9VAwyUnI7Sb"
       },
+      "outputs": [],
       "source": [
         "from google.colab.patches import cv2_imshow\n",
         "import cv2\n",
         "img = cv2.imread(RESULT_IMG_PATH, cv2.IMREAD_UNCHANGED)\n",
         "cv2_imshow(img)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "TPU",
+    "colab": {
+      "collapsed_sections": [],
+      "machine_shape": "hm",
+      "name": "PyTorch/TPU MNIST Training",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/contrib/colab/multi-core-alexnet-fashion-mnist.ipynb
+++ b/contrib/colab/multi-core-alexnet-fashion-mnist.ipynb
@@ -1,25 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "PyTorch on Cloud TPUs: MultiCore Training AlexNet on Fashion MNIST",
-      "provenance": [],
-      "collapsed_sections": [],
-      "machine_shape": "hm"
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "accelerator": "TPU"
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "foxdQ7m3RsOk",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "foxdQ7m3RsOk"
       },
       "source": [
         "##PyTorch on Cloud TPUs: MultiCore Training AlexNet on Fashion MNIST \n",
@@ -31,23 +16,23 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "SAzIwJg2vweI",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "SAzIwJg2vweI"
       },
+      "outputs": [],
       "source": [
         "import os\n",
         "assert os.environ['COLAB_TPU_ADDR'], 'Make sure to select TPU from Edit > Notebook settings > Hardware accelerator'"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "_UYwdM3qRjhS",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "_UYwdM3qRjhS"
       },
       "source": [
         "### Installing PyTorch/XLA\n",
@@ -57,37 +42,37 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "OApBOAe1fpH_"
       },
+      "outputs": [],
       "source": [
-	"# Installs PyTorch, PyTorch/XLA, and Torchvision\n",
+        "# Installs PyTorch, PyTorch/XLA, and Torchvision\n",
         "# Copy this cell into your own notebooks to use PyTorch on Cloud TPUs \n",
         "# Warning: this may take a couple minutes to run\n",
-        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
-      ],
-      "execution_count": null,
-      "outputs": []
+        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
-      ],
       "metadata": {
         "id": "nfSCdVlA8jFg"
-      }
+      },
+      "source": [
+        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "J1Vfg-rH8bF4"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
+      ]
     },
     {
       "cell_type": "markdown",
@@ -100,9 +85,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "vJZrkoejQhxK"
       },
+      "outputs": [],
       "source": [
         "# VERSION = \"1.11\"  #@param [\"1.11\", \"nightly\", \"20220315\"]  # or YYYYMMDD format\n",
         "# !curl https://raw.githubusercontent.com/pytorch/xla/master/contrib/scripts/env-setup.py -o pytorch-xla-env-setup.py\n",
@@ -117,15 +104,13 @@
         "\n",
         "# !ldconfig\n",
         "# !ldd /usr/local/lib/python3.7/dist-packages/torch/lib/libtorch.so"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "kLe_HkWzUCHP",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "kLe_HkWzUCHP"
       },
       "source": [
         "### Dataset & Network\n",
@@ -138,8 +123,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "hzXONhL6Wa-_",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "hzXONhL6Wa-_"
       },
       "source": [
         "### Using Multiple Cloud TPU Cores\n",
@@ -151,11 +136,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "eSiwkKVLW9zO",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "eSiwkKVLW9zO"
       },
+      "outputs": [],
       "source": [
         "import torch\n",
         "import torch_xla\n",
@@ -184,15 +171,13 @@
         "flags = {}\n",
         "# Note: Colab only supports start_method='fork'\n",
         "xmp.spawn(simple_map_fn, args=(flags,), nprocs=8, start_method='fork')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "iq8D9sGwu_MT",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "iq8D9sGwu_MT"
       },
       "source": [
         "Let's start looking at the above cell with the call to `spawn(),` which is documented [here](http://pytorch.org/xla/#torch_xla.distributed.xla_multiprocessing.spawn). `spawn()` takes a function (the \"map function\"), a tuple of arguments (the placeholder `flags` dict), the number of processes to create, and whether to create these new processes by \"forking\" or \"spawning.\" While spawning new processes is generally recommended, Colab only supports forking.\n",
@@ -207,8 +192,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "_Zi_7MF4-nBs",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "_Zi_7MF4-nBs"
       },
       "source": [
         "### An Aside on Context\n",
@@ -222,11 +207,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "ej0qnTFC-p6m",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "ej0qnTFC-p6m"
       },
+      "outputs": [],
       "source": [
         "# Don't mix these!\n",
         "# Only one type of context per Colab!\n",
@@ -235,15 +222,13 @@
         "#device = xm.xla_device()  # Requires a single process context\n",
         "\n",
         "#xmp.spawn(simple_map_fn, args=(flags,), nprocs=8, start_method='fork')  # Requires a multiprocess context"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "MtXxG6whFR90",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "MtXxG6whFR90"
       },
       "source": [
         "The second warning is: each process should perform the same Cloud TPU computations!"
@@ -251,11 +236,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "HveR4CZtFaOW",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "HveR4CZtFaOW"
       },
+      "outputs": [],
       "source": [
         "# Don't perform different computations on different processes!\n",
         "# Warning: uncommenting the below and running this cell will likely hang your Colab!\n",
@@ -268,15 +255,13 @@
         "\n",
         "\n",
         "# xmp.spawn(simple_map_fn, args=(flags,), nprocs=8, start_method='fork')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "alwue4JCF3Le",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "alwue4JCF3Le"
       },
       "source": [
         "Performing the same Cloud TPU computations lets the context coordinate the processes correctly. Again, we'll see this better below.\n",
@@ -286,11 +271,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "RHS6iAUzGWwt",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "RHS6iAUzGWwt"
       },
+      "outputs": [],
       "source": [
         "# Common Cloud TPU computation but different CPU computation is OK\n",
         "def simple_map_fn(index, flags):\n",
@@ -308,15 +295,13 @@
         "\n",
         "\n",
         "xmp.spawn(simple_map_fn, args=(flags,), nprocs=8, start_method='fork')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "21WNWICABAo1",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "21WNWICABAo1"
       },
       "source": [
         "### Multicore Training\n",
@@ -333,11 +318,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "pqx-VgEizPiF",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "pqx-VgEizPiF"
       },
+      "outputs": [],
       "source": [
         "import torchvision\n",
         "from torchvision import datasets\n",
@@ -487,17 +474,17 @@
         "  elapsed_eval_time = time.time() - eval_start\n",
         "  print(\"Process\", index, \"finished evaluation. Evaluation time was:\", elapsed_eval_time)\n",
         "  print(\"Process\", index, \"guessed\", num_correct, \"of\", total_guesses, \"correctly for\", num_correct/total_guesses * 100, \"% accuracy.\")"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "8rDe9KaS1mzz",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "8rDe9KaS1mzz"
       },
+      "outputs": [],
       "source": [
         "# Configures training (and evaluation) parameters\n",
         "flags['batch_size'] = 32\n",
@@ -506,15 +493,13 @@
         "flags['seed'] = 1234\n",
         "\n",
         "xmp.spawn(map_fn, args=(flags,), nprocs=8, start_method='fork')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "gkhC6gt1N1c8",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "gkhC6gt1N1c8"
       },
       "source": [
         "The network should take about 30 seconds to train and about 10 seconds to evaluate on each process. Using an entire Cloud TPU is, as expected, dramatically faster than training and evaluating on a single Cloud TPU core.\n"
@@ -523,8 +508,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "WSp0EOq8Pg2b",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "WSp0EOq8Pg2b"
       },
       "source": [
         "##What's Next?\n",
@@ -542,5 +527,20 @@
         "Additional notebooks demonstrating how to run PyTorch on Cloud TPUs can be found [here](https://github.com/pytorch/xla). While Colab provides a free Cloud TPU, training is even faster on [Google Cloud Platform](https://github.com/pytorch/xla#Cloud), especially when using multiple Cloud TPUs in a Cloud TPU pod. Scaling from a single Cloud TPU, like in this notebook, to many Cloud TPUs in a pod is easy, too. You use the same code as this notebook and just spawn more processes."
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "TPU",
+    "colab": {
+      "collapsed_sections": [],
+      "machine_shape": "hm",
+      "name": "PyTorch on Cloud TPUs: MultiCore Training AlexNet on Fashion MNIST",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/contrib/colab/pytorch-xla-profiling-colab.ipynb
+++ b/contrib/colab/pytorch-xla-profiling-colab.ipynb
@@ -1,19 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "PyTorch/XLA Profling Colab Tutorial",
-      "provenance": [],
-      "collapsed_sections": [],
-      "machine_shape": "hm"
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "accelerator": "TPU"
-  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -38,14 +23,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "O53lrJMDn9Rd"
       },
+      "outputs": [],
       "source": [
-        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl tensorboard-plugin-profile"
-      ],
-      "execution_count": null,
-      "outputs": []
+        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl tensorboard-plugin-profile"
+      ]
     },
     {
       "cell_type": "markdown",
@@ -59,9 +44,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "iMdPRFXIn_jH"
       },
+      "outputs": [],
       "source": [
         "# Define Parameters\n",
         "import os\n",
@@ -75,27 +62,27 @@
         "FLAGS['num_cores'] = 8 if os.environ.get('TPU_NAME', None) else 1\n",
         "FLAGS['log_steps'] = 20\n",
         "FLAGS['metrics_debug'] = False"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "EP5H63aViwJe"
       },
+      "outputs": [],
       "source": [
         "# Setup profiler env var\n",
         "os.environ['XLA_HLO_DEBUG'] = '1'"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "Micd3xZvoA-c"
       },
+      "outputs": [],
       "source": [
         "import multiprocessing\n",
         "import numpy as np\n",
@@ -183,9 +170,7 @@
         "\n",
         "def ResNet18():\n",
         "  return ResNet(BasicBlock, [2, 2, 2, 2])"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -198,9 +183,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "8vMl96KLoCq8"
       },
+      "outputs": [],
       "source": [
         "SERIAL_EXEC = xmp.MpSerialExecutor()\n",
         "# Only instantiate model weights once in memory.\n",
@@ -285,15 +272,15 @@
         "\n",
         "  return accuracy, data, pred, target\n",
         "  "
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "_2nL4HmloEyl"
       },
+      "outputs": [],
       "source": [
         "# Start training processes\n",
         "def _mp_fn(rank, flags, training_started):\n",
@@ -314,9 +301,7 @@
         "training_started = multiprocessing.Event()\n",
         "p = multiprocessing.Process(target=target_fn, args=(training_started,))\n",
         "p.start()"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -329,9 +314,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "zppUkQI3fv2p"
       },
+      "outputs": [],
       "source": [
         "training_started.wait(120)\n",
         "\n",
@@ -340,22 +327,35 @@
         "             os.environ.get('TPU_NAME')).group(1)\n",
         "xp.trace('localhost:9012', '/tmp/tensorboard')  # client side profiling\n",
         "xp.trace(f'{tpu_ip}:8466', '/tmp/tensorboard')  # need GCS bucket for all traces to be written"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "Efdo1gx4bYRY"
       },
+      "outputs": [],
       "source": [
         "%load_ext tensorboard\n",
         "%tensorboard --logdir /tmp/tensorboard --load_fast=false\n",
         "# Click on \"INACTIVE\" dropdown and select \"PROFILE\""
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "TPU",
+    "colab": {
+      "collapsed_sections": [],
+      "machine_shape": "hm",
+      "name": "PyTorch/XLA Profling Colab Tutorial",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/contrib/colab/resnet18-training.ipynb
+++ b/contrib/colab/resnet18-training.ipynb
@@ -1,25 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "PyTorch/XLA ResNet18/CIFAR10 Training",
-      "provenance": [],
-      "collapsed_sections": [],
-      "machine_shape": "hm"
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "accelerator": "TPU"
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "YX1hxqUQn47M",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "YX1hxqUQn47M"
       },
       "source": [
         "## PyTorch/XLA ResNet18/CIFAR10 (GPU or TPU)"
@@ -28,8 +13,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "pLQPoJ6Fn8wF",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "pLQPoJ6Fn8wF"
       },
       "source": [
         "### [RUNME] Install Colab compatible PyTorch/XLA wheels and dependencies\n",
@@ -38,34 +23,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "OApBOAe1fpH_"
       },
+      "outputs": [],
       "source": [
-        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
-      ],
-      "execution_count": null,
-      "outputs": []
+        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
-      ],
       "metadata": {
         "id": "nfSCdVlA8jFg"
-      }
+      },
+      "source": [
+        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "J1Vfg-rH8bF4"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
+      ]
     },
     {
       "cell_type": "markdown",
@@ -78,9 +63,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "vJZrkoejQhxK"
       },
+      "outputs": [],
       "source": [
         "# VERSION = \"1.11\"  #@param [\"1.11\", \"nightly\", \"20220315\"]  # or YYYYMMDD format\n",
         "# !curl https://raw.githubusercontent.com/pytorch/xla/master/contrib/scripts/env-setup.py -o pytorch-xla-env-setup.py\n",
@@ -95,32 +82,30 @@
         "\n",
         "# !ldconfig\n",
         "# !ldd /usr/local/lib/python3.7/dist-packages/torch/lib/libtorch.so"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "xiFzLg5gy7l6",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "xiFzLg5gy7l6"
       },
+      "outputs": [],
       "source": [
         "# PyTorch/XLA GPU Setup (only if GPU runtime)\n",
         "import os\n",
         "if os.environ.get('COLAB_GPU', '0') == '1':\n",
         "  os.environ['GPU_NUM_DEVICES'] = '1'\n",
         "  os.environ['XLA_FLAGS'] = '--xla_gpu_cuda_data_dir=/usr/local/cuda/'"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "rroH9yiAn-XE",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "rroH9yiAn-XE"
       },
       "source": [
         "### Define Parameters\n",
@@ -129,11 +114,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "cMojPWZUqr2s",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "cMojPWZUqr2s"
       },
+      "outputs": [],
       "source": [
         "# Result Visualization Helper\n",
         "from matplotlib import pyplot as plt\n",
@@ -169,17 +156,17 @@
         "                          CIFAR10_LABELS[prediction]), color='red')\n",
         "    ax.imshow(img)\n",
         "  plt.savefig(RESULT_IMG_PATH, transparent=True)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "iMdPRFXIn_jH",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "iMdPRFXIn_jH"
       },
+      "outputs": [],
       "source": [
         "# Define Parameters\n",
         "FLAGS = {}\n",
@@ -192,17 +179,17 @@
         "FLAGS['num_cores'] = 8 if os.environ.get('TPU_NAME', None) else 1\n",
         "FLAGS['log_steps'] = 20\n",
         "FLAGS['metrics_debug'] = False"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "Micd3xZvoA-c",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "Micd3xZvoA-c"
       },
+      "outputs": [],
       "source": [
         "import numpy as np\n",
         "import os\n",
@@ -287,17 +274,17 @@
         "\n",
         "def ResNet18():\n",
         "  return ResNet(BasicBlock, [2, 2, 2, 2])"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "8vMl96KLoCq8",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "8vMl96KLoCq8"
       },
+      "outputs": [],
       "source": [
         "SERIAL_EXEC = xmp.MpSerialExecutor()\n",
         "# Only instantiate model weights once in memory.\n",
@@ -410,17 +397,17 @@
         "\n",
         "  return accuracy, data, pred, target\n",
         "  "
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "_2nL4HmloEyl",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "_2nL4HmloEyl"
       },
+      "outputs": [],
       "source": [
         "# Start training processes\n",
         "def _mp_fn(rank, flags):\n",
@@ -434,15 +421,13 @@
         "\n",
         "xmp.spawn(_mp_fn, args=(FLAGS,), nprocs=FLAGS['num_cores'],\n",
         "          start_method='fork')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "_wt7wEVJoFmf",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "_wt7wEVJoFmf"
       },
       "source": [
         "## Visualize Predictions"
@@ -450,19 +435,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "mSdVUMPjoGhy",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "mSdVUMPjoGhy"
       },
+      "outputs": [],
       "source": [
         "from google.colab.patches import cv2_imshow\n",
         "import cv2\n",
         "img = cv2.imread(RESULT_IMG_PATH, cv2.IMREAD_UNCHANGED)\n",
         "cv2_imshow(img)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "TPU",
+    "colab": {
+      "collapsed_sections": [],
+      "machine_shape": "hm",
+      "name": "PyTorch/XLA ResNet18/CIFAR10 Training",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/contrib/colab/resnet50-inference.ipynb
+++ b/contrib/colab/resnet50-inference.ipynb
@@ -1,25 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "PyTorch/TPU ResNet50 Inference",
-      "provenance": [],
-      "collapsed_sections": [],
-      "machine_shape": "hm"
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "accelerator": "TPU"
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "UHKEkDHRpKcN",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "UHKEkDHRpKcN"
       },
       "source": [
         "## PyTorch/TPU ResNet50 Inference Demo"
@@ -28,8 +13,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "tWj3au5upQh1",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "tWj3au5upQh1"
       },
       "source": [
         "<h3>  &nbsp;&nbsp;Use Colab Cloud TPU&nbsp;&nbsp; <a href=\"https://cloud.google.com/tpu/\"><img valign=\"middle\" src=\"https://raw.githubusercontent.com/GoogleCloudPlatform/tensorflow-without-a-phd/master/tensorflow-rl-pong/images/tpu-hexagon.png\" width=\"50\"></a></h3>\n",
@@ -40,23 +25,23 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "n0ycw8UJpSSc",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "n0ycw8UJpSSc"
       },
+      "outputs": [],
       "source": [
         "import os\n",
         "assert os.environ['COLAB_TPU_ADDR'], 'Make sure to select TPU from Edit > Notebook settings > Hardware accelerator'"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "XOBxO6smpTjx",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "XOBxO6smpTjx"
       },
       "source": [
         "### [RUNME] Install Colab TPU compatible PyTorch/TPU wheels and dependencies\n",
@@ -65,34 +50,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "OApBOAe1fpH_"
       },
+      "outputs": [],
       "source": [
-        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
-      ],
-      "execution_count": null,
-      "outputs": []
+        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
-      ],
       "metadata": {
         "id": "nfSCdVlA8jFg"
-      }
+      },
+      "source": [
+        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "J1Vfg-rH8bF4"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
+      ]
     },
     {
       "cell_type": "markdown",
@@ -105,9 +90,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "vJZrkoejQhxK"
       },
+      "outputs": [],
       "source": [
         "# VERSION = \"1.11\"  #@param [\"1.11\", \"nightly\", \"20220315\"]  # or YYYYMMDD format\n",
         "# !curl https://raw.githubusercontent.com/pytorch/xla/master/contrib/scripts/env-setup.py -o pytorch-xla-env-setup.py\n",
@@ -122,15 +109,13 @@
         "\n",
         "# !ldconfig\n",
         "# !ldd /usr/local/lib/python3.7/dist-packages/torch/lib/libtorch.so"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "ZZv23uP1pWrG",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "ZZv23uP1pWrG"
       },
       "source": [
         "### Download image to do inference with"
@@ -138,11 +123,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "GXD87Wk7pYWc",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "GXD87Wk7pYWc"
       },
+      "outputs": [],
       "source": [
         "%matplotlib inline\n",
         "# From OpenImages V5 Dataset\n",
@@ -154,17 +141,17 @@
         "\n",
         "img = Image.open('corgi.jpg');\n",
         "plt.imshow(img);"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "kDgDdSOQpaOr",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "kDgDdSOQpaOr"
       },
+      "outputs": [],
       "source": [
         "import torch\n",
         "import torch_xla.core.xla_model as xm\n",
@@ -177,17 +164,17 @@
         "DEVICE = xm.xla_device()\n",
         "model = model.to(DEVICE)\n",
         "model"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "SyuBVxzdpb1-",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "SyuBVxzdpb1-"
       },
+      "outputs": [],
       "source": [
         "# Preprocess and display image\n",
         "from torchvision import transforms\n",
@@ -216,15 +203,13 @@
         "ax[1].imshow(inv_norm_tensor);\n",
         "ax[1].axis('off');\n",
         "ax[1].set_title('inv_norm(preprocessed image)');"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "mqhGuZfipeOZ",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "mqhGuZfipeOZ"
       },
       "source": [
         "### [RUNME] Imagenet Class Labels "
@@ -232,11 +217,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "AqSzhj7OpjG-",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "AqSzhj7OpjG-"
       },
+      "outputs": [],
       "source": [
         "IMAGENET_LABELS = {0: 'tench, Tinca tinca',\n",
         " 1: 'goldfish, Carassius auratus',\n",
@@ -1238,15 +1225,13 @@
         " 997: 'bolete',\n",
         " 998: 'ear, spike, capitulum',\n",
         " 999: 'toilet tissue, toilet paper, bathroom tissue'}"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "y8uYEgkLpo7K",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "y8uYEgkLpo7K"
       },
       "source": [
         "### Run Single Prediction\n",
@@ -1256,26 +1241,26 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "xjBwB6Z-poFk",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "xjBwB6Z-poFk"
       },
+      "outputs": [],
       "source": [
         "# Single prediction call\n",
         "outputs = model(input_tensor)\n",
         "print('outputs.device == {}'.format(outputs.device))\n",
         "prediction = outputs.max(dim=1).indices.item()\n",
         "print('ResNet50 prediction: {}'.format(IMAGENET_LABELS[prediction]))"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "SDmMjCkDprEh",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "SDmMjCkDprEh"
       },
       "source": [
         "### [TPU] Performance Benchmarking Inference on single core\n",
@@ -1295,11 +1280,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "eYA6z44Hpsl_",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "eYA6z44Hpsl_"
       },
+      "outputs": [],
       "source": [
         "import numpy as np\n",
         "import time\n",
@@ -1318,15 +1305,13 @@
         "print('Inference times: p50={:.2f}ms p90={:.2f}ms p95={:.2f}ms'.format(\n",
         "    np.percentile(times, 50), np.percentile(times, 90),\n",
         "    np.percentile(times, 95)))"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "GZqlNzuopvWN",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "GZqlNzuopvWN"
       },
       "source": [
         "### [GPU] Benchmarking\n",
@@ -1339,26 +1324,28 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "zt7h51tFpwMI",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "zt7h51tFpwMI"
       },
+      "outputs": [],
       "source": [
         "# Need newer torch version: https://github.com/pytorch/pytorch/issues/26608\n",
         "!pip uninstall -y torch\n",
         "!pip install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cu100/torch_nightly.html"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "hEU5YcB_px9U",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "hEU5YcB_px9U"
       },
+      "outputs": [],
       "source": [
         "import torch\n",
         "\n",
@@ -1368,34 +1355,34 @@
         "gpu_model = torch.hub.load('pytorch/vision', 'resnet50', pretrained=True)\n",
         "gpu_model.eval()\n",
         "gpu_model = gpu_model.to('cuda')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "h_UmAqRfpzAP",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "h_UmAqRfpzAP"
       },
+      "outputs": [],
       "source": [
         "!wget -O corgi.jpg \\\n",
         "  https://farm4.staticflickr.com/1301/4694470234_6f27a4f602_o.jpg\n",
         "\n",
         "from PIL import Image\n",
         "img = Image.open('corgi.jpg')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "LA4X1f-tp2U5",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "LA4X1f-tp2U5"
       },
+      "outputs": [],
       "source": [
         "batch_size = 32\n",
         "\n",
@@ -1415,17 +1402,17 @@
         "\n",
         "gpu_input_tensor = image_tensor.unsqueeze(0)\n",
         "gpu_input_batch = gpu_input_tensor.repeat(batch_size, 1, 1, 1).to('cuda')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "3j2LHsSmp3o2",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "3j2LHsSmp3o2"
       },
+      "outputs": [],
       "source": [
         "import numpy as np\n",
         "import time\n",
@@ -1439,9 +1426,22 @@
         "print('GPU Inference times: p50={:.2f}ms p90={:.2f}ms p95={:.2f}ms'.format(\n",
         "    np.percentile(times, 50), np.percentile(times, 90),\n",
         "    np.percentile(times, 95)))"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "TPU",
+    "colab": {
+      "collapsed_sections": [],
+      "machine_shape": "hm",
+      "name": "PyTorch/TPU ResNet50 Inference",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/contrib/colab/single-core-alexnet-fashion-mnist.ipynb
+++ b/contrib/colab/single-core-alexnet-fashion-mnist.ipynb
@@ -1,25 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "PyTorch on Cloud TPUs: Single Core Training AlexNet on Fashion MNIST",
-      "provenance": [],
-      "collapsed_sections": [],
-      "machine_shape": "hm"
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "accelerator": "TPU"
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "IZgybIMXbpCl",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "IZgybIMXbpCl"
       },
       "source": [
         "##PyTorch on Cloud TPUs: Single Core Training AlexNet on Fashion MNIST \n",
@@ -37,8 +22,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "qxSMwPAIb5zI",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "qxSMwPAIb5zI"
       },
       "source": [
         "### Installing PyTorch/XLA\n",
@@ -48,34 +33,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "OApBOAe1fpH_"
       },
+      "outputs": [],
       "source": [
-        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
-      ],
-      "execution_count": null,
-      "outputs": []
+        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
-      ],
       "metadata": {
         "id": "nfSCdVlA8jFg"
-      }
+      },
+      "source": [
+        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "J1Vfg-rH8bF4"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
+      ]
     },
     {
       "cell_type": "markdown",
@@ -88,9 +73,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "vJZrkoejQhxK"
       },
+      "outputs": [],
       "source": [
         "# VERSION = \"1.11\"  #@param [\"1.11\", \"nightly\", \"20220315\"]  # or YYYYMMDD format\n",
         "# !curl https://raw.githubusercontent.com/pytorch/xla/master/contrib/scripts/env-setup.py -o pytorch-xla-env-setup.py\n",
@@ -105,15 +92,13 @@
         "\n",
         "# !ldconfig\n",
         "# !ldd /usr/local/lib/python3.7/dist-packages/torch/lib/libtorch.so"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "u_izjOUccDg4",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "u_izjOUccDg4"
       },
       "source": [
         "### Dataset & Network\n",
@@ -130,11 +115,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "-FkLA4MSlcNf",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "-FkLA4MSlcNf"
       },
+      "outputs": [],
       "source": [
         "# Downloads the Fashion MNIST dataset using Torchvision\n",
         "# Note: This may take a minute.\n",
@@ -162,15 +149,13 @@
         "  os.path.join(\"/tmp/fashionmnist\"),\n",
         "  train=True,\n",
         "  download=True)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "zRyIvDK6Z_xM",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "zRyIvDK6Z_xM"
       },
       "source": [
         "Now that we have the dataset, we can look at elements of it directly. Each element of raw_dataset is a tuple. The first element is a single channel greyscale 28x28 Python Image Library (PIL) image, and the second element is the example's class index. You can change the `img_index` in the following cell to visualize different examples."
@@ -178,25 +163,25 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "40bWSY2_ZrO9",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "40bWSY2_ZrO9"
       },
+      "outputs": [],
       "source": [
         "img_index = 0\n",
         "tup = raw_dataset[img_index]\n",
         "display(tup[0].resize((224, 224)))\n",
         "print(class_map[tup[1]])"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "4BzG5t8HbaMf",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "4BzG5t8HbaMf"
       },
       "source": [
         "Now we'll create our AlexNet model and put it on a Cloud TPU core.\n",
@@ -206,11 +191,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "xMMZxHoIk9n7",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "xMMZxHoIk9n7"
       },
+      "outputs": [],
       "source": [
         "import torch_xla\n",
         "import torch_xla.core.xla_model as xm\n",
@@ -222,15 +209,13 @@
         "# Acquires the default Cloud TPU core and moves the model to it\n",
         "device = xm.xla_device()\n",
         "net = net.to(device)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "RYB7dKkqfsiI",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "RYB7dKkqfsiI"
       },
       "source": [
         "### Dataloaders\n",
@@ -240,11 +225,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "AoTe3v5W881g",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "AoTe3v5W881g"
       },
+      "outputs": [],
       "source": [
         "import torchvision.transforms as transforms\n",
         "\n",
@@ -257,15 +244,13 @@
         "to_rgb = transforms.Lambda(lambda image: image.convert('RGB'))\n",
         "resize = transforms.Resize((224, 224))\n",
         "my_transform = transforms.Compose([resize, to_rgb, transforms.ToTensor(), normalize])"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "tFTMqbNMgwWI",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "tFTMqbNMgwWI"
       },
       "source": [
         "Now we can download train and test datasets using TorchVision and apply this transform to them."
@@ -273,11 +258,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "gsXFl-CFgtG9",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "gsXFl-CFgtG9"
       },
+      "outputs": [],
       "source": [
         "train_dataset = datasets.FashionMNIST(\n",
         "  os.path.join(\"/tmp/fashionmnist\"),\n",
@@ -290,15 +277,13 @@
         "  train=False,\n",
         "  download=True,\n",
         "  transform=my_transform)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "YV9nMJRSh_ld",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "YV9nMJRSh_ld"
       },
       "source": [
         "PyTorch provides a variety of \"Samplers\" to acquire elements of datasets in different orders. The [Random Sampler](https://pytorch.org/docs/stable/data.html#torch.utils.data.RandomSampler), which we'll use, samples elements randomly without replacement."
@@ -306,23 +291,23 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "khRAFXTe-KfX",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "khRAFXTe-KfX"
       },
+      "outputs": [],
       "source": [
         "train_sampler = torch.utils.data.RandomSampler(train_dataset)\n",
         "test_sampler = torch.utils.data.RandomSampler(test_dataset)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "Dy1Eq2O_iagC",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "Dy1Eq2O_iagC"
       },
       "source": [
         "Finally, we create DataLoaders that load batches of examples from our Dataset according to our Sampler's policy. "
@@ -330,11 +315,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "TV5yqz2W9PzX",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "TV5yqz2W9PzX"
       },
+      "outputs": [],
       "source": [
         "batch_size = 8\n",
         "\n",
@@ -347,15 +334,13 @@
         "  test_dataset,\n",
         "  batch_size=batch_size,\n",
         "  sampler=test_sampler)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "kHQbrK5ijXGS",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "kHQbrK5ijXGS"
       },
       "source": [
         "### Evaluating the Network\n",
@@ -365,11 +350,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "UlSLfLaW_A3G",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "UlSLfLaW_A3G"
       },
+      "outputs": [],
       "source": [
         "import time\n",
         "from google.colab import widgets\n",
@@ -429,29 +416,27 @@
         "          col = 0\n",
         "        else:\n",
         "          col += 1"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "EyXjocsog0We",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "EyXjocsog0We"
       },
+      "outputs": [],
       "source": [
         "# Percentage of guesses that are correct (expected to be 0.1)\n",
         "eval_network(net, test_loader)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "qencz3bJpaNU",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "qencz3bJpaNU"
       },
       "source": [
         "You should see the untrained network guess about 10% of the dataset correctly, since it's randomly guessing and there are 10 classes."
@@ -460,8 +445,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "oJFsnpfxf0j2",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "oJFsnpfxf0j2"
       },
       "source": [
         "### Training the Network\n",
@@ -483,11 +468,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "RSl2WMQMGutS",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "RSl2WMQMGutS"
       },
+      "outputs": [],
       "source": [
         "# Note: this will take 5-10 minutes to run.\n",
         "num_epochs = 1\n",
@@ -517,15 +504,13 @@
         "\n",
         "elapsed_time = time.time() - start_time\n",
         "print (\"Spent \", elapsed_time, \" seconds training for \", num_epochs, \" epoch(s) on a single core.\")"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "id8KQMotr3DA",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "id8KQMotr3DA"
       },
       "source": [
         "\n",
@@ -539,22 +524,22 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "KA_74FcEZ5cq",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "KA_74FcEZ5cq"
       },
+      "outputs": [],
       "source": [
         "eval_network(net, test_loader)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "YHSM9PGcsdfd",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "YHSM9PGcsdfd"
       },
       "source": [
         "You should see the network dramatically improve (it should guess 60%+)."
@@ -563,8 +548,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "Tl8iYcWxgJUv",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "Tl8iYcWxgJUv"
       },
       "source": [
         "### What's Next\n",
@@ -574,5 +559,20 @@
         "Additional information about PyTorch on Cloud TPUs, including more sample Colabs, is available on the PyTorch/XLA package's [Github](https://github.com/pytorch/xla). You're encouraged to try PyTorch on Cloud TPUs on both Colab and Google Cloud Platform, too! For Colab, just copy the first code cell in this notebook to start your own. If you have ideas/suggestions/comments the best way to contact the team is with an [issue on our Github](https://github.com/pytorch/xla/issues). "
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "TPU",
+    "colab": {
+      "collapsed_sections": [],
+      "machine_shape": "hm",
+      "name": "PyTorch on Cloud TPUs: Single Core Training AlexNet on Fashion MNIST",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/contrib/colab/style_transfer_inference.ipynb
+++ b/contrib/colab/style_transfer_inference.ipynb
@@ -1,25 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "PyTorch on TPUs: Fast Neural Style Transfer",
-      "provenance": [],
-      "collapsed_sections": [],
-      "machine_shape": "hm"
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "accelerator": "TPU"
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "dbOTXWKBnBiP",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "dbOTXWKBnBiP"
       },
       "source": [
         "![alt text](https://i.imgur.com/ipYa6Q8.png)"
@@ -28,8 +13,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "h1mYGqkc1kqv",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "h1mYGqkc1kqv"
       },
       "source": [
         "## PyTorch on TPUs: Fast Neural Style Transfer\n",
@@ -46,8 +31,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "YofXQrnxmf5r",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "YofXQrnxmf5r"
       },
       "source": [
         "### Installs PyTorch & Loads the Networks\n",
@@ -58,48 +43,48 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "sg7i8Wk6Iblu",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "sg7i8Wk6Iblu"
       },
+      "outputs": [],
       "source": [
         "import os\n",
         "assert os.environ['COLAB_TPU_ADDR'], 'Make sure to select TPU from Edit > Notebook settings > Hardware accelerator'"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "OApBOAe1fpH_"
       },
+      "outputs": [],
       "source": [
-        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
-      ],
-      "execution_count": null,
-      "outputs": []
+        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
-      ],
       "metadata": {
         "id": "nfSCdVlA8jFg"
-      }
+      },
+      "source": [
+        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "J1Vfg-rH8bF4"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
+      ]
     },
     {
       "cell_type": "markdown",
@@ -112,9 +97,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "vJZrkoejQhxK"
       },
+      "outputs": [],
       "source": [
         "# VERSION = \"1.11\"  #@param [\"1.11\", \"nightly\", \"20220315\"]  # or YYYYMMDD format\n",
         "# !curl https://raw.githubusercontent.com/pytorch/xla/master/contrib/scripts/env-setup.py -o pytorch-xla-env-setup.py\n",
@@ -129,17 +116,17 @@
         "\n",
         "# !ldconfig\n",
         "# !ldd /usr/local/lib/python3.7/dist-packages/torch/lib/libtorch.so"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "sPJVqAKyml5W",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "sPJVqAKyml5W"
       },
+      "outputs": [],
       "source": [
         "from google.colab.patches import cv2_imshow\n",
         "import cv2\n",
@@ -208,15 +195,13 @@
         "candy = load_style(candy_path)\n",
         "mosaic = load_style(mosaic_path)\n",
         "udnie = load_style(udnie_path)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "j1w1G4AcWw9f",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "j1w1G4AcWw9f"
       },
       "source": [
         "## Try it out!\n",
@@ -228,12 +213,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "EozMXwIV9iOJ",
-        "colab_type": "code",
         "cellView": "both",
-        "colab": {}
+        "colab": {},
+        "colab_type": "code",
+        "id": "EozMXwIV9iOJ"
       },
+      "outputs": [],
       "source": [
         "#@markdown ### Image URL (right click -> copy image address):\n",
         "content_image_url = 'https://cdn.pixabay.com/photo/2019/06/11/15/42/corgi-face-4267312__480.jpg' #@param {type:\"string\"}\n",
@@ -252,15 +239,13 @@
         "content_image = content_image.unsqueeze(0).to(device)\n",
         "\n",
         "cv2_imshow(img)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "e0vHw-aHoG-s",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "e0vHw-aHoG-s"
       },
       "source": [
         "To style your image simply uncomment the style you wish to apply below and run the cell!"
@@ -268,11 +253,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "Z0j9i4EWctbU",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "Z0j9i4EWctbU"
       },
+      "outputs": [],
       "source": [
         "with torch.no_grad():\n",
         "  output = rain_princess(content_image)\n",
@@ -284,9 +271,22 @@
         "utils.save_image(RESULT_IMAGE, output[0].cpu())\n",
         "img = cv2.imread(RESULT_IMAGE, cv2.IMREAD_UNCHANGED)\n",
         "cv2_imshow(img)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "TPU",
+    "colab": {
+      "collapsed_sections": [],
+      "machine_shape": "hm",
+      "name": "PyTorch on TPUs: Fast Neural Style Transfer",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/contrib/colab/xla_builder_autograd.ipynb
+++ b/contrib/colab/xla_builder_autograd.ipynb
@@ -1,25 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "Beyond Pytorch Native APIs",
-      "provenance": [],
-      "collapsed_sections": [],
-      "machine_shape": "hm"
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "accelerator": "TPU"
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "GxDkdWhYSiLi",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "GxDkdWhYSiLi"
       },
       "source": [
         "# Beyond Pytorch Native APIs"
@@ -28,8 +13,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "Ded3RflTZnZ8",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "Ded3RflTZnZ8"
       },
       "source": [
         "The XLA backend of PyTorch allows an end user to create functions whose implementation is totally controlled by the user's Python code itself, in terms of the lower level XLA HLO operation generated.\n",
@@ -44,34 +29,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "OApBOAe1fpH_"
       },
+      "outputs": [],
       "source": [
-        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
-      ],
-      "execution_count": null,
-      "outputs": []
+        "!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
-      ],
       "metadata": {
         "id": "nfSCdVlA8jFg"
-      }
+      },
+      "source": [
+        "### If you're using GPU with this colab notebook, run the below commented code to install GPU compatible PyTorch wheel and dependencies"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "J1Vfg-rH8bF4"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "#!pip install cloud-tpu-client==0.10 torch==1.11.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl --force-reinstall "
+      ]
     },
     {
       "cell_type": "markdown",
@@ -84,9 +69,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "vJZrkoejQhxK"
       },
+      "outputs": [],
       "source": [
         "# VERSION = \"1.11\"  #@param [\"1.11\", \"nightly\", \"20220315\"]  # or YYYYMMDD format\n",
         "# !curl https://raw.githubusercontent.com/pytorch/xla/master/contrib/scripts/env-setup.py -o pytorch-xla-env-setup.py\n",
@@ -101,17 +88,17 @@
         "\n",
         "# !ldconfig\n",
         "# !ldd /usr/local/lib/python3.7/dist-packages/torch/lib/libtorch.so"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "zQ2_OcQxMEI8",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "zQ2_OcQxMEI8"
       },
+      "outputs": [],
       "source": [
         "import torch\n",
         "import torch_xla\n",
@@ -197,9 +184,22 @@
         "loss = out.pow(2).sum()\n",
         "loss.backward()\n",
         "print(x.grad.cpu())"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "TPU",
+    "colab": {
+      "collapsed_sections": [],
+      "machine_shape": "hm",
+      "name": "Beyond Pytorch Native APIs",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
Use the colab 1.11 wheel for tutorials, since 2vm wheels are not compatible.