### PR TITLE
Patch view change into 1.10

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,7 @@ RUN if [ "${cloud_build}" = true ]; then github_branch="${release_version}" && \
   if [ "${release_version}" = "nightly" ]; then github_branch="master"; fi && \
   cd /pytorch && \
   rm -rf xla && \
-  git clone -b "${github_branch}" --recursive https://github.com/pytorch/xla && \
+  git clone -b patch_view_1_10 --recursive https://github.com/pytorch/xla && \
   cd / && \
   git clone -b "${github_branch}" --recursive https://github.com/pytorch-tpu/examples tpu-examples; fi
 

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -1281,7 +1281,7 @@ class XLATensor {
 
   void SetXlaData(xla::ComputationClient::DataPtr xla_data, bool sync);
 
-  void SetIrValue(ir::Value ir_value);
+  void SetIrValue(ir::Value ir_value, bool inplace = true);
   void SetInPlaceIrValue(ir::Value ir_value);
 
   void AssignIrValue(ir::Value ir_value) const;


### PR DESCRIPTION
This is to backport https://github.com/pytorch/xla/pull/3411 into 1.10, the goal is to unblock researcher from keep using 1.10 given 1.11 currently has some speed regression.