### PR TITLE
Rephrase `all_reduce` docstring to clarify the condition for in-place op

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -527,7 +527,7 @@ def _host_all_reduce(reduce_type, inputs, cctx, scale=None):
 
 
 def all_reduce(reduce_type, inputs, scale=1.0, groups=None, cctx=None):
-  """Performs an inplace reduce operation on the input tensor(s).
+  """Performs an all-reduce operation on the input tensor(s).
 
   Args:
     reduce_type (string): One of ``xm.REDUCE_SUM``, ``xm.REDUCE_MUL``,
@@ -544,10 +544,10 @@ def all_reduce(reduce_type, inputs, scale=1.0, groups=None, cctx=None):
         all the replicas in it.
 
   Returns:
-    If a single `torch.Tensor` is passed, the return value is a `torch.Tensor`
-    holding the reduced value (across the replicas). If a list/tuple is passed,
-    this function performs an inplace all-reduce op on the input tensors, and
-    returns the list/tuple itself.
+    If a list/tuple is passed, this function performs an inplace all-reduce op 
+    (across the replicas) on the input tensors, and returns the list/tuple itself.
+    If a single `torch.Tensor` is passed, the all-reduce op is NOT inplace and
+    the reduced value (across the replicas) is returned as a single `torch.Tensor`.
   """
   # In a sea-of-devices case we use two level of reductions. One using the fast
   # device interconnect, and then using the torch.distributed reduction API to


### PR DESCRIPTION
Currently, the docstring for `torch_xla.core.xla_model.all_reduce` might be a bit misleading. In particular, it does not make it clear that the all-reduce op is NOT in-place when `inputs` is a single tensor.

For PyTorch users who have been using [`torch.distributed.all_reduce`](https://github.com/pytorch/pytorch/blob/d583f9c9d2bd0cc5fb5d369cd498bd62b62c43fe/torch/distributed/distributed_c10d.py#L1253) in the past, this could be especially confusing because `torch.distributed.all_reduce` always operates in-place, which leads to programmer bugs such as b/226225366.

This PR rephrases the docstring for `all_reduce` to make it explicit that the all-reduce op is NOT inplace when a single `torch.Tensor` is passed.