### PR TITLE
Pin Jinja2 for doc push

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 mistune==0.8.4
 sphinx==2.4.4
 docutils==0.16
+Jinja2<3.1
 m2r
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme


### PR DESCRIPTION
This is to fix https://github.com/pytorch/xla/issues/3448.

Verified that it is updated locally
```
Successfully installed Jinja2-3.0.3 pytorch-sphinx-theme
```