### PR TITLE
Fix aten::gather

### DIFF
--- a/torch_xla/csrc/ops/gather.cpp
+++ b/torch_xla/csrc/ops/gather.cpp
@@ -9,24 +9,11 @@
 namespace torch_xla {
 namespace ir {
 namespace ops {
-namespace {
-
-xla::Shape NodeOutputShape(const Value& input, const Value& index,
-                           int64_t dim) {
-  auto lower_for_shape_fn =
-      [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
-    return xla::TorchGather(operands[0], operands[1], dim,
-                            IsSparseGather(operands[0], operands[1], dim));
-  };
-  return InferOutputShape({input.xla_shape(), index.xla_shape()},
-                          lower_for_shape_fn);
-}
-
-}  // namespace
 
 Gather::Gather(const Value& input, int64_t dim, const Value& index)
     : Node(torch::lazy::OpKind(at::aten::gather), {input, index},
-           [&]() { return NodeOutputShape(input, index, dim); },
+           xla::ShapeUtil::MakeShape(input.xla_shape().element_type(),
+                                     index.xla_shape().dimensions()),
            /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}
 
@@ -37,9 +24,7 @@ NodePtr Gather::Clone(OpList operands) const {
 XlaOpVector Gather::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
   xla::XlaOp index = loctx->GetOutputOp(operand(1));
-  return ReturnOp(
-      xla::TorchGather(input, index, dim_, IsSparseGather(input, index, dim_)),
-      loctx);
+  return ReturnOp(xla::TorchGather(input, index, dim_, /*sparse=*/true), loctx);
 }
 
 std::string Gather::ToString() const {


### PR DESCRIPTION
This PR fixed a bug in the lowering of aten::gather that caused the deberta model to be 6.8x slower than PyTorch.

It looks like the [non sparse implementation](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/client/lib/slicing.cc#L171-L202) of xla::TorchGather is very inefficient. For a typical deberta workload `input=f32[10,10,512,512]` and `index=u32[10,10,512,512]`, this algorithm will first broadcast `index` to `u32[10,10,512,512,512]` followed by a reduction to `f32[10,10,512,512]`.

I tested the performance of gather with  `input f32[10,10,N,N]` and `index u32[10,10,N,N]` for `N=64,128,256,512` on GPU. In all cases, the original sparse implementation is orders of magnitude better than the non-sparse implementation. So maybe the default sparse implementation should always be used, though it's possible the non-sparse version is better on TPU.

| N          | sparse (us) | non-sparse (us) |
| ------  | ------ | ------  |
| 512      | 251     | 29664 |
| 256     | 81        | 5360   |
| 128      | 27       | 830     |
| 64       | 12        | 252     |

Below shows the performance of `microsoft/deberta-base` model with a batch_size of 10 on Nvidia V100.
|   Test   |  Throughput (it/s) |
| ---- | ------ |
| torch | 3.22 |
| torch_xla |  0.47 |
| torch_xla + this PR | 4.84 |