### PR TITLE
Migrate to upstream torch::lazy::Value

### DIFF
--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -101,9 +101,9 @@ std::string Use::ToString() const {
   return ss.str();
 }
 
-const xla::Shape& Value::shape() const { return node->xla_shape(index); }
+const xla::Shape& Value::xla_shape() const { return node->xla_shape(index); }
 
-const xla::Shape& Value::node_shape() const { return node->xla_shape(); }
+const xla::Shape& Value::xla_node_shape() const { return node->xla_shape(); }
 
 torch::lazy::hash_t Value::hash() const {
   return torch::lazy::HashCombine(node->hash(), index);

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -62,7 +62,7 @@ using OutputMap =
 // Represents an input/operand for a Node object.
 struct Value : public torch::lazy::Value {
   Value() = default;
-  Value(NodePtr node, size_t index = 0) : node(std::move(node)), index(index) {}
+  Value(NodePtr node, size_t index = 0) : torch::lazy::Value(std::dynamic_pointer_cast<torch::lazy::Node>(node), index), node(std::move(node)), index(index) {}
 
   // Retrieves the shape of this value. If the IR Node generating the value is a
   // multi-output node, the shape returned by this API will not be the full

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -60,7 +60,7 @@ using OutputMap =
     std::unordered_map<torch::lazy::Output, T, torch::lazy::Output::Hasher>;
 
 // Represents an input/operand for a Node object.
-struct Value {
+struct Value : public torch::lazy::Value {
   Value() = default;
   Value(NodePtr node, size_t index = 0) : node(std::move(node)), index(index) {}
 

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -68,8 +68,8 @@ struct Value : public torch::lazy::Value {
   // multi-output node, the shape returned by this API will not be the full
   // tuple shape, but only the shape at index referred by this value.
   // To retrieve the full tuple shape in that case, use the node_shape() API.
-  const xla::Shape& shape() const;
-  const xla::Shape& node_shape() const;
+  const xla::Shape& xla_shape() const;
+  const xla::Shape& xla_node_shape() const;
 
   torch::lazy::hash_t hash() const;
 

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -62,7 +62,11 @@ using OutputMap =
 // Represents an input/operand for a Node object.
 struct Value : public torch::lazy::Value {
   Value() = default;
-  Value(NodePtr node, size_t index = 0) : torch::lazy::Value(std::dynamic_pointer_cast<torch::lazy::Node>(node), index), node(std::move(node)), index(index) {}
+  Value(NodePtr node, size_t index = 0)
+      : torch::lazy::Value(std::dynamic_pointer_cast<torch::lazy::Node>(node),
+                           index),
+        node(std::move(node)),
+        index(index) {}
 
   // Retrieves the shape of this value. If the IR Node generating the value is a
   // multi-output node, the shape returned by this API will not be the full

--- a/torch_xla/csrc/ops/adam_optimizer_step.cpp
+++ b/torch_xla/csrc/ops/adam_optimizer_step.cpp
@@ -11,9 +11,9 @@ namespace {
 
 xla::Shape NodeOutputShape(const Value& step, const Value& param) {
   return xla::ShapeUtil::MakeTupleShape(
-      {/*step=*/step.shape(), /*param=*/param.shape(),
-       /*exp_avg=*/param.shape(), /*exp_avg_sq=*/param.shape(),
-       /*max_exp_avg_sq=*/param.shape()});
+      {/*step=*/step.xla_shape(), /*param=*/param.xla_shape(),
+       /*exp_avg=*/param.xla_shape(), /*exp_avg_sq=*/param.xla_shape(),
+       /*max_exp_avg_sq=*/param.xla_shape()});
 }
 
 }  // namespace
@@ -35,7 +35,7 @@ AdamOptimizerStep::AdamOptimizerStep(
       use_adamw_(use_adamw) {}
 
 NodePtr AdamOptimizerStep::Clone(OpList operands) const {
-  return MakeNode<AdamOptimizerStep>(
+  return ir::MakeNode<AdamOptimizerStep>(
       operands.at(0), operands.at(1), operands.at(2), operands.at(3),
       operands.at(4), operands.at(5), operands.at(6), operands.at(7),
       operands.at(8), operands.at(9), operands.at(10), operands.at(11),

--- a/torch_xla/csrc/ops/adaptive_avg_pool2d.cpp
+++ b/torch_xla/csrc/ops/adaptive_avg_pool2d.cpp
@@ -17,7 +17,7 @@ xla::Shape NodeOutputShape(const Value& input,
     XLA_CHECK_EQ(operands.size(), 1);
     return BuildAdaptiveAvgPool2d(operands[0], output_size);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -30,7 +30,7 @@ AdaptiveAvgPool2d::AdaptiveAvgPool2d(const Value& input,
       output_size_(std::move(output_size)) {}
 
 NodePtr AdaptiveAvgPool2d::Clone(OpList operands) const {
-  return MakeNode<AdaptiveAvgPool2d>(operands.at(0), output_size_);
+  return ir::MakeNode<AdaptiveAvgPool2d>(operands.at(0), output_size_);
 }
 
 XlaOpVector AdaptiveAvgPool2d::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/adaptive_avg_pool3d.cpp
+++ b/torch_xla/csrc/ops/adaptive_avg_pool3d.cpp
@@ -17,7 +17,7 @@ xla::Shape NodeOutputShape(const Value& input,
     XLA_CHECK_EQ(operands.size(), 1);
     return BuildAdaptiveAvgPool3d(operands[0], output_size);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -30,7 +30,7 @@ AdaptiveAvgPool3d::AdaptiveAvgPool3d(const Value& input,
       output_size_(std::move(output_size)) {}
 
 NodePtr AdaptiveAvgPool3d::Clone(OpList operands) const {
-  return MakeNode<AdaptiveAvgPool3d>(operands.at(0), output_size_);
+  return ir::MakeNode<AdaptiveAvgPool3d>(operands.at(0), output_size_);
 }
 
 XlaOpVector AdaptiveAvgPool3d::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/adaptive_max_pool2d.cpp
+++ b/torch_xla/csrc/ops/adaptive_max_pool2d.cpp
@@ -18,7 +18,7 @@ xla::Shape NodeOutputShape(const Value& input,
     MaxPoolResult result = BuildAdaptiveMaxPoolNd(operands[0], output_size, 2);
     return xla::Tuple(operands[0].builder(), {result.result, result.indices});
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -31,7 +31,7 @@ AdaptiveMaxPool2d::AdaptiveMaxPool2d(const Value& input,
       output_size_(std::move(output_size)) {}
 
 NodePtr AdaptiveMaxPool2d::Clone(OpList operands) const {
-  return MakeNode<AdaptiveMaxPool2d>(operands.at(0), output_size_);
+  return ir::MakeNode<AdaptiveMaxPool2d>(operands.at(0), output_size_);
 }
 
 XlaOpVector AdaptiveMaxPool2d::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/all.cpp
+++ b/torch_xla/csrc/ops/all.cpp
@@ -19,7 +19,7 @@ xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildAll(operands[0], dimensions, keep_reduced_dimensions);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -34,7 +34,8 @@ All::All(const Value& input, std::vector<int64_t> dimensions,
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
 NodePtr All::Clone(OpList operands) const {
-  return MakeNode<All>(operands.at(0), dimensions_, keep_reduced_dimensions_);
+  return ir::MakeNode<All>(operands.at(0), dimensions_,
+                           keep_reduced_dimensions_);
 }
 
 XlaOpVector All::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/all_gather.cpp
+++ b/torch_xla/csrc/ops/all_gather.cpp
@@ -20,7 +20,7 @@ xla::Shape NodeOutputShape(const Value& input, const Value& token, int64_t dim,
         BuildAllGather(operands[0], operands[1], dim, shard_count, groups);
     return xla::Tuple(operands[0].builder(), {result.result, result.token});
   };
-  return InferOutputShape({input.shape(), token.shape()}, shape_fn);
+  return InferOutputShape({input.xla_shape(), token.xla_shape()}, shape_fn);
 }
 
 }  // namespace
@@ -38,8 +38,8 @@ AllGather::AllGather(const Value& input, const Value& token, int64_t dim,
       groups_(std::move(groups)) {}
 
 NodePtr AllGather::Clone(OpList operands) const {
-  return MakeNode<AllGather>(operands.at(0), operands.at(1), dim_, shard_count_,
-                             groups_);
+  return ir::MakeNode<AllGather>(operands.at(0), operands.at(1), dim_,
+                                 shard_count_, groups_);
 }
 
 XlaOpVector AllGather::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/all_reduce.cpp
+++ b/torch_xla/csrc/ops/all_reduce.cpp
@@ -17,9 +17,9 @@ xla::Shape NodeOutputShape(absl::Span<const Value> operands,
   std::vector<xla::Shape> tuple_shapes;
   tuple_shapes.reserve(operands.size() + 1);
   for (auto& operand : operands) {
-    tuple_shapes.push_back(operand.shape());
+    tuple_shapes.push_back(operand.xla_shape());
   }
-  tuple_shapes.push_back(token.shape());
+  tuple_shapes.push_back(token.xla_shape());
   return xla::ShapeUtil::MakeTupleShape(tuple_shapes);
 }
 
@@ -46,8 +46,8 @@ AllReduce::AllReduce(AllReduceType reduce_type,
 
 NodePtr AllReduce::Clone(OpList operands) const {
   std::vector<Value> operand_list(operands.begin(), operands.end() - 1);
-  return MakeNode<AllReduce>(reduce_type_, operand_list, operands.back(),
-                             scale_, groups_);
+  return ir::MakeNode<AllReduce>(reduce_type_, operand_list, operands.back(),
+                                 scale_, groups_);
 }
 
 XlaOpVector AllReduce::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/all_to_all.cpp
+++ b/torch_xla/csrc/ops/all_to_all.cpp
@@ -21,7 +21,7 @@ xla::Shape NodeOutputShape(const Value& input, const Value& token,
                       concat_dimension, split_count, groups);
     return xla::Tuple(operands[0].builder(), {result.result, result.token});
   };
-  return InferOutputShape({input.shape(), token.shape()}, shape_fn);
+  return InferOutputShape({input.xla_shape(), token.xla_shape()}, shape_fn);
 }
 
 }  // namespace
@@ -44,8 +44,9 @@ AllToAll::AllToAll(const Value& input, const Value& token,
       groups_(std::move(groups)) {}
 
 NodePtr AllToAll::Clone(OpList operands) const {
-  return MakeNode<AllToAll>(operands.at(0), operands.at(1), split_dimension_,
-                            concat_dimension_, split_count_, groups_);
+  return ir::MakeNode<AllToAll>(operands.at(0), operands.at(1),
+                                split_dimension_, concat_dimension_,
+                                split_count_, groups_);
 }
 
 XlaOpVector AllToAll::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/amax.cpp
+++ b/torch_xla/csrc/ops/amax.cpp
@@ -15,7 +15,7 @@ xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildMaxInDims(operands[0], dimensions, keepdim);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -28,7 +28,7 @@ Amax::Amax(const Value& input, std::vector<int64_t> dimensions, bool keepdim)
       keepdim_(keepdim) {}
 
 NodePtr Amax::Clone(OpList operands) const {
-  return MakeNode<Amax>(operands.at(0), dimensions_, keepdim_);
+  return ir::MakeNode<Amax>(operands.at(0), dimensions_, keepdim_);
 }
 
 XlaOpVector Amax::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/amin.cpp
+++ b/torch_xla/csrc/ops/amin.cpp
@@ -15,7 +15,7 @@ xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildMinInDims(operands[0], dimensions, keepdim);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -28,7 +28,7 @@ Amin::Amin(const Value& input, std::vector<int64_t> dimensions, bool keepdim)
       keepdim_(keepdim) {}
 
 NodePtr Amin::Clone(OpList operands) const {
-  return MakeNode<Amin>(operands.at(0), dimensions_, keepdim_);
+  return ir::MakeNode<Amin>(operands.at(0), dimensions_, keepdim_);
 }
 
 XlaOpVector Amin::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/amp_foreach_non_finite_check_and_unscale.cpp
+++ b/torch_xla/csrc/ops/amp_foreach_non_finite_check_and_unscale.cpp
@@ -15,10 +15,10 @@ xla::Shape NodeOutputShape(const OpList& inputs, const Value& found_inf) {
   std::vector<xla::Shape> output_shapes;
   output_shapes.reserve(inputs.size() + 1);
   for (size_t i = 0; i < inputs.size(); ++i) {
-    const xla::Shape& input_shape = inputs[i].shape();
+    const xla::Shape& input_shape = inputs[i].xla_shape();
     output_shapes.push_back(input_shape);
   }
-  output_shapes.push_back(found_inf.shape());
+  output_shapes.push_back(found_inf.xla_shape());
   return xla::ShapeUtil::MakeTupleShape(output_shapes);
 }
 
@@ -44,8 +44,8 @@ AmpForachNonFiniteCheckAndUnscale::AmpForachNonFiniteCheckAndUnscale(
 NodePtr AmpForachNonFiniteCheckAndUnscale::Clone(OpList operands) const {
   std::vector<Value> operand_list(operands.begin(), operands.end() - 2);
   size_t sz = operand_list.size();
-  return MakeNode<AmpForachNonFiniteCheckAndUnscale>(operand_list, operands[sz],
-                                                     operands[sz + 1]);
+  return ir::MakeNode<AmpForachNonFiniteCheckAndUnscale>(
+      operand_list, operands[sz], operands[sz + 1]);
 }
 
 XlaOpVector AmpForachNonFiniteCheckAndUnscale::Lower(

--- a/torch_xla/csrc/ops/amp_update_scale.cpp
+++ b/torch_xla/csrc/ops/amp_update_scale.cpp
@@ -14,7 +14,7 @@ namespace {
 xla::Shape NodeOutputShape(const Value& growth_tracker,
                            const Value& current_scale) {
   return xla::ShapeUtil::MakeTupleShape(
-      {growth_tracker.shape(), current_scale.shape()});
+      {growth_tracker.xla_shape(), current_scale.xla_shape()});
 }
 
 }  // namespace
@@ -33,9 +33,9 @@ AmpUpdateScale::AmpUpdateScale(const Value& current_scale,
       growth_interval_(growth_interval) {}
 
 NodePtr AmpUpdateScale::Clone(OpList operands) const {
-  return MakeNode<AmpUpdateScale>(operands[0], operands[1], operands[2],
-                                  scale_growth_factor_, scale_backoff_factor_,
-                                  growth_interval_);
+  return ir::MakeNode<AmpUpdateScale>(operands[0], operands[1], operands[2],
+                                      scale_growth_factor_,
+                                      scale_backoff_factor_, growth_interval_);
 }
 
 XlaOpVector AmpUpdateScale::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/any.cpp
+++ b/torch_xla/csrc/ops/any.cpp
@@ -19,7 +19,7 @@ xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildAny(operands[0], dimensions, keep_reduced_dimensions);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -34,7 +34,8 @@ Any::Any(const Value& input, std::vector<int64_t> dimensions,
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
 NodePtr Any::Clone(OpList operands) const {
-  return MakeNode<Any>(operands.at(0), dimensions_, keep_reduced_dimensions_);
+  return ir::MakeNode<Any>(operands.at(0), dimensions_,
+                           keep_reduced_dimensions_);
 }
 
 XlaOpVector Any::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/arg_max.cpp
+++ b/torch_xla/csrc/ops/arg_max.cpp
@@ -14,7 +14,7 @@ xla::Shape NodeOutputShape(const Value& input, int64_t dim, bool keepdim) {
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildArgMax(operands[0], dim, keepdim);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -27,7 +27,7 @@ ArgMax::ArgMax(const Value& input, int64_t dim, bool keepdim)
       keepdim_(keepdim) {}
 
 NodePtr ArgMax::Clone(OpList operands) const {
-  return MakeNode<ArgMax>(operands.at(0), dim_, keepdim_);
+  return ir::MakeNode<ArgMax>(operands.at(0), dim_, keepdim_);
 }
 
 XlaOpVector ArgMax::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/arg_min.cpp
+++ b/torch_xla/csrc/ops/arg_min.cpp
@@ -14,7 +14,7 @@ xla::Shape NodeOutputShape(const Value& input, int64_t dim, bool keepdim) {
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildArgMin(operands[0], dim, keepdim);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -27,7 +27,7 @@ ArgMin::ArgMin(const Value& input, int64_t dim, bool keepdim)
       keepdim_(keepdim) {}
 
 NodePtr ArgMin::Clone(OpList operands) const {
-  return MakeNode<ArgMin>(operands.at(0), dim_, keepdim_);
+  return ir::MakeNode<ArgMin>(operands.at(0), dim_, keepdim_);
 }
 
 XlaOpVector ArgMin::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/arithmetic_ir_ops.cpp
+++ b/torch_xla/csrc/ops/arithmetic_ir_ops.cpp
@@ -15,10 +15,10 @@ NodePtr operator+(const Value& node1, const Value& node2) {
     xla::XlaOp op1 = loctx->GetOutputOp(node.operand(1));
     return node.ReturnOp(XlaHelpers::PromotedAdd(op0, op1), loctx);
   };
-  return ops::GenericOp(
-      torch::lazy::OpKind(at::aten::add), {node1, node2},
-      XlaHelpers::GetPromotedBinaryOpShape(node1.shape(), node2.shape()),
-      std::move(lower_fn));
+  return ops::GenericOp(torch::lazy::OpKind(at::aten::add), {node1, node2},
+                        XlaHelpers::GetPromotedBinaryOpShape(node1.xla_shape(),
+                                                             node2.xla_shape()),
+                        std::move(lower_fn));
 }
 
 NodePtr operator-(const Value& node1, const Value& node2) {
@@ -27,10 +27,10 @@ NodePtr operator-(const Value& node1, const Value& node2) {
     xla::XlaOp op1 = loctx->GetOutputOp(node.operand(1));
     return node.ReturnOp(XlaHelpers::PromotedSub(op0, op1), loctx);
   };
-  return ops::GenericOp(
-      torch::lazy::OpKind(at::aten::sub), {node1, node2},
-      XlaHelpers::GetPromotedBinaryOpShape(node1.shape(), node2.shape()),
-      std::move(lower_fn));
+  return ops::GenericOp(torch::lazy::OpKind(at::aten::sub), {node1, node2},
+                        XlaHelpers::GetPromotedBinaryOpShape(node1.xla_shape(),
+                                                             node2.xla_shape()),
+                        std::move(lower_fn));
 }
 
 NodePtr operator*(const Value& node1, const Value& node2) {
@@ -39,10 +39,10 @@ NodePtr operator*(const Value& node1, const Value& node2) {
     xla::XlaOp op1 = loctx->GetOutputOp(node.operand(1));
     return node.ReturnOp(XlaHelpers::PromotedMul(op0, op1), loctx);
   };
-  return ops::GenericOp(
-      torch::lazy::OpKind(at::aten::mul), {node1, node2},
-      XlaHelpers::GetPromotedBinaryOpShape(node1.shape(), node2.shape()),
-      std::move(lower_fn));
+  return ops::GenericOp(torch::lazy::OpKind(at::aten::mul), {node1, node2},
+                        XlaHelpers::GetPromotedBinaryOpShape(node1.xla_shape(),
+                                                             node2.xla_shape()),
+                        std::move(lower_fn));
 }
 
 NodePtr operator/(const Value& node1, const Value& node2) {
@@ -51,10 +51,10 @@ NodePtr operator/(const Value& node1, const Value& node2) {
     xla::XlaOp op1 = loctx->GetOutputOp(node.operand(1));
     return node.ReturnOp(XlaHelpers::PromotedDiv(op0, op1), loctx);
   };
-  return ops::GenericOp(
-      torch::lazy::OpKind(at::aten::div), {node1, node2},
-      XlaHelpers::GetPromotedBinaryOpShape(node1.shape(), node2.shape()),
-      std::move(lower_fn));
+  return ops::GenericOp(torch::lazy::OpKind(at::aten::div), {node1, node2},
+                        XlaHelpers::GetPromotedBinaryOpShape(node1.xla_shape(),
+                                                             node2.xla_shape()),
+                        std::move(lower_fn));
 }
 
 }  // namespace ir

--- a/torch_xla/csrc/ops/as_strided.cpp
+++ b/torch_xla/csrc/ops/as_strided.cpp
@@ -47,7 +47,7 @@ AsStrided::AsStrided(const Value& input, std::vector<int64_t> size,
                      std::vector<int64_t> stride, int64_t storage_offset)
     : Node(torch::lazy::OpKind(at::aten::as_strided), {input},
            [&]() {
-             return xla::ShapeUtil::MakeShape(input.shape().element_type(),
+             return xla::ShapeUtil::MakeShape(input.xla_shape().element_type(),
                                               size);
            },
            /*num_outputs=*/1, torch::lazy::MHash(size, stride, storage_offset)),
@@ -64,7 +64,8 @@ std::string AsStrided::ToString() const {
 }
 
 NodePtr AsStrided::Clone(OpList operands) const {
-  return MakeNode<AsStrided>(operands.at(0), size_, stride_, storage_offset_);
+  return ir::MakeNode<AsStrided>(operands.at(0), size_, stride_,
+                                 storage_offset_);
 }
 
 XlaOpVector AsStrided::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/as_strided_view_update.cpp
+++ b/torch_xla/csrc/ops/as_strided_view_update.cpp
@@ -48,7 +48,7 @@ AsStridedViewUpdate::AsStridedViewUpdate(const Value& target,
                                          int64_t storage_offset)
     : Node(xla_as_strided_view_update, {target, input},
            [&]() {
-             return xla::ShapeUtil::MakeShape(target.shape().element_type(),
+             return xla::ShapeUtil::MakeShape(target.xla_shape().element_type(),
                                               size);
            },
            /*num_outputs=*/1, torch::lazy::MHash(size, stride, storage_offset)),
@@ -65,8 +65,8 @@ std::string AsStridedViewUpdate::ToString() const {
 }
 
 NodePtr AsStridedViewUpdate::Clone(OpList operands) const {
-  return MakeNode<AsStridedViewUpdate>(operands.at(0), operands.at(1), size_,
-                                       stride_, storage_offset_);
+  return ir::MakeNode<AsStridedViewUpdate>(operands.at(0), operands.at(1),
+                                           size_, stride_, storage_offset_);
 }
 
 XlaOpVector AsStridedViewUpdate::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/avg_pool_nd.cpp
+++ b/torch_xla/csrc/ops/avg_pool_nd.cpp
@@ -24,7 +24,7 @@ xla::Shape NodeOutputShape(const Value& input, int64_t spatial_dim_count,
     return BuildAvgPoolNd(operands[0], spatial_dim_count, kernel_size, stride,
                           padding, ceil_mode, count_include_pad);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 c10::Symbol AvgPoolNdSymbol(int64_t spatial_dim_count) {
@@ -64,8 +64,9 @@ AvgPoolNd::AvgPoolNd(const Value& input, int64_t spatial_dim_count,
       count_include_pad_(count_include_pad) {}
 
 NodePtr AvgPoolNd::Clone(OpList operands) const {
-  return MakeNode<AvgPoolNd>(operands.at(0), spatial_dim_count_, kernel_size_,
-                             stride_, padding_, ceil_mode_, count_include_pad_);
+  return ir::MakeNode<AvgPoolNd>(operands.at(0), spatial_dim_count_,
+                                 kernel_size_, stride_, padding_, ceil_mode_,
+                                 count_include_pad_);
 }
 
 XlaOpVector AvgPoolNd::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/avg_pool_nd_backward.cpp
+++ b/torch_xla/csrc/ops/avg_pool_nd_backward.cpp
@@ -25,7 +25,7 @@ xla::Shape NodeOutputShape(const Value& grad_output, const Value& input,
                                   kernel_size, stride, padding, ceil_mode,
                                   count_include_pad);
   };
-  return InferOutputShape({grad_output.shape(), input.shape()},
+  return InferOutputShape({grad_output.xla_shape(), input.xla_shape()},
                           lower_for_shape_fn);
 }
 
@@ -65,9 +65,9 @@ AvgPoolNdBackward::AvgPoolNdBackward(
       count_include_pad_(count_include_pad) {}
 
 NodePtr AvgPoolNdBackward::Clone(OpList operands) const {
-  return MakeNode<AvgPoolNdBackward>(operands.at(0), operands.at(1),
-                                     spatial_dim_count_, kernel_size_, stride_,
-                                     padding_, ceil_mode_, count_include_pad_);
+  return ir::MakeNode<AvgPoolNdBackward>(
+      operands.at(0), operands.at(1), spatial_dim_count_, kernel_size_, stride_,
+      padding_, ceil_mode_, count_include_pad_);
 }
 
 XlaOpVector AvgPoolNdBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/binary_cross_entropy.cpp
+++ b/torch_xla/csrc/ops/binary_cross_entropy.cpp
@@ -25,7 +25,7 @@ xla::Shape NodeOutputShape(const Value& logits, const Value& labels,
   std::vector<xla::Shape> shapes;
   for (auto& input :
        xla::util::GetValuesVector<Value>({logits, labels}, {&weight})) {
-    shapes.push_back(input.shape());
+    shapes.push_back(input.xla_shape());
   }
   return InferOutputShape(shapes, lower_for_shape_fn);
 }
@@ -47,8 +47,8 @@ NodePtr BinaryCrossEntropy::Clone(OpList operands) const {
   if (operands.size() > 2) {
     weight = operands.at(2);
   }
-  return MakeNode<BinaryCrossEntropy>(operands.at(0), operands.at(1), weight,
-                                      reduction_);
+  return ir::MakeNode<BinaryCrossEntropy>(operands.at(0), operands.at(1),
+                                          weight, reduction_);
 }
 
 XlaOpVector BinaryCrossEntropy::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/binary_cross_entropy_backward.cpp
+++ b/torch_xla/csrc/ops/binary_cross_entropy_backward.cpp
@@ -27,7 +27,7 @@ xla::Shape NodeOutputShape(const Value& grad_output, const Value& logits,
   std::vector<xla::Shape> shapes;
   for (auto& input : xla::util::GetValuesVector<Value>(
            {grad_output, logits, labels}, {&weight})) {
-    shapes.push_back(input.shape());
+    shapes.push_back(input.xla_shape());
   }
   return InferOutputShape(shapes, lower_for_shape_fn);
 }
@@ -53,7 +53,7 @@ NodePtr BinaryCrossEntropyBackward::Clone(OpList operands) const {
   if (operands.size() > 3) {
     weight = operands.at(3);
   }
-  return MakeNode<BinaryCrossEntropyBackward>(
+  return ir::MakeNode<BinaryCrossEntropyBackward>(
       operands.at(0), operands.at(1), operands.at(2), weight, reduction_);
 }
 

--- a/torch_xla/csrc/ops/bitwise_ir_ops.cpp
+++ b/torch_xla/csrc/ops/bitwise_ir_ops.cpp
@@ -22,12 +22,12 @@ Value BitwiseAnd(const Value& node1, const Value& node2) {
         operands[0], operands[1],
         [](xla::XlaOp lhs, xla::XlaOp rhs) { return lhs & rhs; });
   };
-  return GenericOp(
-      torch::lazy::OpKind(at::aten::__and__), {node1, node2},
-      [&]() {
-        return InferOutputShape({node1.shape(), node2.shape()}, shape_fn);
-      },
-      std::move(lower_fn));
+  return GenericOp(torch::lazy::OpKind(at::aten::__and__), {node1, node2},
+                   [&]() {
+                     return InferOutputShape(
+                         {node1.xla_shape(), node2.xla_shape()}, shape_fn);
+                   },
+                   std::move(lower_fn));
 }
 
 Value BitwiseOr(const Value& node1, const Value& node2) {
@@ -43,12 +43,12 @@ Value BitwiseOr(const Value& node1, const Value& node2) {
         operands[0], operands[1],
         [](xla::XlaOp lhs, xla::XlaOp rhs) { return lhs | rhs; });
   };
-  return GenericOp(
-      torch::lazy::OpKind(at::aten::__or__), {node1, node2},
-      [&]() {
-        return InferOutputShape({node1.shape(), node2.shape()}, shape_fn);
-      },
-      std::move(lower_fn));
+  return GenericOp(torch::lazy::OpKind(at::aten::__or__), {node1, node2},
+                   [&]() {
+                     return InferOutputShape(
+                         {node1.xla_shape(), node2.xla_shape()}, shape_fn);
+                   },
+                   std::move(lower_fn));
 }
 
 Value BitwiseXor(const Value& node1, const Value& node2) {
@@ -64,12 +64,12 @@ Value BitwiseXor(const Value& node1, const Value& node2) {
         operands[0], operands[1],
         [](xla::XlaOp lhs, xla::XlaOp rhs) { return lhs ^ rhs; });
   };
-  return GenericOp(
-      torch::lazy::OpKind(at::aten::__xor__), {node1, node2},
-      [&]() {
-        return InferOutputShape({node1.shape(), node2.shape()}, shape_fn);
-      },
-      std::move(lower_fn));
+  return GenericOp(torch::lazy::OpKind(at::aten::__xor__), {node1, node2},
+                   [&]() {
+                     return InferOutputShape(
+                         {node1.xla_shape(), node2.xla_shape()}, shape_fn);
+                   },
+                   std::move(lower_fn));
 }
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/cast.cpp
+++ b/torch_xla/csrc/ops/cast.cpp
@@ -17,7 +17,7 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& input, xla::PrimitiveType type) {
-  xla::Shape shape = input.shape();
+  xla::Shape shape = input.xla_shape();
   shape.set_element_type(type);
   return shape;
 }
@@ -42,8 +42,8 @@ Cast::Cast(const Value& input, at::ScalarType dtype,
       stype_(stype) {}
 
 NodePtr Cast::Clone(OpList operands) const {
-  return dtype_ ? MakeNode<Cast>(operands.at(0), *dtype_, stype_)
-                : MakeNode<Cast>(operands.at(0), type_);
+  return dtype_ ? ir::MakeNode<Cast>(operands.at(0), *dtype_, stype_)
+                : ir::MakeNode<Cast>(operands.at(0), type_);
 }
 
 XlaOpVector Cast::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/cat.cpp
+++ b/torch_xla/csrc/ops/cat.cpp
@@ -18,7 +18,7 @@ xla::Shape NodeOutputShape(absl::Span<const ir::Value> values, int64_t dim) {
   std::vector<xla::Shape> shapes;
   shapes.reserve(values.size());
   for (auto& value : values) {
-    shapes.push_back(value.shape());
+    shapes.push_back(value.xla_shape());
   }
   return InferOutputShape(shapes, lower_for_shape_fn);
 }
@@ -32,7 +32,7 @@ Cat::Cat(absl::Span<const ir::Value> values, int64_t dim)
       dim_(dim) {}
 
 NodePtr Cat::Clone(OpList operands) const {
-  return MakeNode<Cat>(operands, dim_);
+  return ir::MakeNode<Cat>(operands, dim_);
 }
 
 XlaOpVector Cat::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/cholesky.cpp
+++ b/torch_xla/csrc/ops/cholesky.cpp
@@ -9,12 +9,12 @@ namespace ir {
 namespace ops {
 
 Cholesky::Cholesky(const Value& input, bool lower)
-    : Node(torch::lazy::OpKind(at::aten::cholesky), {input}, input.shape(),
+    : Node(torch::lazy::OpKind(at::aten::cholesky), {input}, input.xla_shape(),
            /*num_outputs=*/1, torch::lazy::MHash(lower)),
       lower_(lower) {}
 
 NodePtr Cholesky::Clone(OpList operands) const {
-  return MakeNode<Cholesky>(operands.at(0), lower_);
+  return ir::MakeNode<Cholesky>(operands.at(0), lower_);
 }
 
 XlaOpVector Cholesky::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/collective_permute.cpp
+++ b/torch_xla/csrc/ops/collective_permute.cpp
@@ -19,7 +19,7 @@ xla::Shape NodeOutputShape(
         BuildCollectivePermute(operands[0], operands[1], source_target_pairs);
     return xla::Tuple(operands[0].builder(), {result.result, result.token});
   };
-  return InferOutputShape({input.shape(), token.shape()}, shape_fn);
+  return InferOutputShape({input.xla_shape(), token.xla_shape()}, shape_fn);
 }
 
 }  // namespace
@@ -33,8 +33,8 @@ CollectivePermute::CollectivePermute(
       source_target_pairs_(std::move(source_target_pairs)) {}
 
 NodePtr CollectivePermute::Clone(OpList operands) const {
-  return MakeNode<CollectivePermute>(operands.at(0), operands.at(1),
-                                     source_target_pairs_);
+  return ir::MakeNode<CollectivePermute>(operands.at(0), operands.at(1),
+                                         source_target_pairs_);
 }
 
 XlaOpVector CollectivePermute::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/constant.cpp
+++ b/torch_xla/csrc/ops/constant.cpp
@@ -25,7 +25,7 @@ std::string Constant::ToString() const {
 }
 
 NodePtr Constant::Clone(OpList operands) const {
-  return MakeNode<Constant>(value_.Clone());
+  return ir::MakeNode<Constant>(value_.Clone());
 }
 
 XlaOpVector Constant::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/constant_pad_nd.cpp
+++ b/torch_xla/csrc/ops/constant_pad_nd.cpp
@@ -28,7 +28,7 @@ xla::Shape NodeOutputShape(const Value& input, const at::Scalar& value,
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return LowerPad(operands[0], value, pad);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -42,7 +42,7 @@ ConstantPadNd::ConstantPadNd(const Value& input, std::vector<int64_t> pad,
       value_(value) {}
 
 NodePtr ConstantPadNd::Clone(OpList operands) const {
-  return MakeNode<ConstantPadNd>(operands.at(0), pad_, value_);
+  return ir::MakeNode<ConstantPadNd>(operands.at(0), pad_, value_);
 }
 
 XlaOpVector ConstantPadNd::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/convolution_backward_overrideable.cpp
+++ b/torch_xla/csrc/ops/convolution_backward_overrideable.cpp
@@ -29,8 +29,9 @@ xla::Shape NodeOutputShape(const Value& grad_output, const Value& input,
     return xla::Tuple(operands[0].builder(),
                       {grads.grad_input, grads.grad_weight, grads.grad_bias});
   };
-  return InferOutputShape({grad_output.shape(), input.shape(), weight.shape()},
-                          lower_for_shape_fn);
+  return InferOutputShape(
+      {grad_output.xla_shape(), input.xla_shape(), weight.xla_shape()},
+      lower_for_shape_fn);
 }
 
 }  // namespace
@@ -58,7 +59,7 @@ ConvolutionBackwardOverrideable::ConvolutionBackwardOverrideable(
       groups_(groups) {}
 
 NodePtr ConvolutionBackwardOverrideable::Clone(OpList operands) const {
-  return MakeNode<ConvolutionBackwardOverrideable>(
+  return ir::MakeNode<ConvolutionBackwardOverrideable>(
       operands.at(0), operands.at(1), operands.at(2), stride_, padding_,
       dilation_, transposed_, output_padding_, groups_);
 }

--- a/torch_xla/csrc/ops/convolution_overrideable.cpp
+++ b/torch_xla/csrc/ops/convolution_overrideable.cpp
@@ -26,7 +26,8 @@ xla::Shape NodeOutputShape(const Value& input, const Value& weight,
                                         padding, dilation, transposed,
                                         output_padding, groups);
   };
-  return InferOutputShape({input.shape(), weight.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape(), weight.xla_shape()},
+                          lower_for_shape_fn);
 }
 
 }  // namespace
@@ -74,10 +75,10 @@ ConvolutionOverrideable::ConvolutionOverrideable(
 
 NodePtr ConvolutionOverrideable::Clone(OpList operands) const {
   return operands.size() == 3
-             ? MakeNode<ConvolutionOverrideable>(
+             ? ir::MakeNode<ConvolutionOverrideable>(
                    operands.at(0), operands.at(1), operands.at(2), stride_,
                    padding_, dilation_, transposed_, output_padding_, groups_)
-             : MakeNode<ConvolutionOverrideable>(
+             : ir::MakeNode<ConvolutionOverrideable>(
                    operands.at(0), operands.at(1), stride_, padding_, dilation_,
                    transposed_, output_padding_, groups_);
 }

--- a/torch_xla/csrc/ops/cumprod.cpp
+++ b/torch_xla/csrc/ops/cumprod.cpp
@@ -30,9 +30,9 @@ xla::Shape NodeOutputShape(const Value& input,
                            c10::optional<at::ScalarType> dtype) {
   if (dtype) {
     return xla::ShapeUtil::ChangeElementType(
-        input.shape(), MakeXlaPrimitiveType(*dtype, /*device=*/nullptr));
+        input.xla_shape(), MakeXlaPrimitiveType(*dtype, /*device=*/nullptr));
   }
-  return input.shape();
+  return input.xla_shape();
 }
 
 }  // namespace
@@ -47,7 +47,7 @@ CumProd::CumProd(const Value& input, int64_t dim,
       dtype_(dtype) {}
 
 NodePtr CumProd::Clone(OpList operands) const {
-  return MakeNode<CumProd>(operands.at(0), dim_, dtype_);
+  return ir::MakeNode<CumProd>(operands.at(0), dim_, dtype_);
 }
 
 XlaOpVector CumProd::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/cumsum.cpp
+++ b/torch_xla/csrc/ops/cumsum.cpp
@@ -29,9 +29,9 @@ xla::Shape NodeOutputShape(const Value& input,
                            c10::optional<at::ScalarType> dtype) {
   if (dtype) {
     return xla::ShapeUtil::ChangeElementType(
-        input.shape(), MakeXlaPrimitiveType(*dtype, /*device=*/nullptr));
+        input.xla_shape(), MakeXlaPrimitiveType(*dtype, /*device=*/nullptr));
   }
-  return input.shape();
+  return input.xla_shape();
 }
 
 }  // namespace
@@ -46,7 +46,7 @@ CumSum::CumSum(const Value& input, int64_t dim,
       dtype_(dtype) {}
 
 NodePtr CumSum::Clone(OpList operands) const {
-  return MakeNode<CumSum>(operands.at(0), dim_, dtype_);
+  return ir::MakeNode<CumSum>(operands.at(0), dim_, dtype_);
 }
 
 XlaOpVector CumSum::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/device_data.cpp
+++ b/torch_xla/csrc/ops/device_data.cpp
@@ -21,7 +21,7 @@ std::string DeviceData::ToString() const {
 }
 
 NodePtr DeviceData::Clone(OpList operands) const {
-  return MakeNode<DeviceData>(data_);
+  return ir::MakeNode<DeviceData>(data_);
 }
 
 XlaOpVector DeviceData::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/diagonal.cpp
+++ b/torch_xla/csrc/ops/diagonal.cpp
@@ -15,7 +15,7 @@ Diagonal::Diagonal(const Value& input, int64_t offset, int64_t dim1,
                    int64_t dim2)
     : Node(torch::lazy::OpKind(at::aten::diagonal), {input},
            [&]() {
-             return MakeDiagonalShape(input.shape(), offset, dim1, dim2);
+             return MakeDiagonalShape(input.xla_shape(), offset, dim1, dim2);
            },
            /*num_outputs=*/1, torch::lazy::MHash(offset, dim1, dim2)),
       offset_(offset),
@@ -23,7 +23,7 @@ Diagonal::Diagonal(const Value& input, int64_t offset, int64_t dim1,
       dim2_(dim2) {}
 
 NodePtr Diagonal::Clone(OpList operands) const {
-  return MakeNode<Diagonal>(operands.at(0), offset_, dim1_, dim2_);
+  return ir::MakeNode<Diagonal>(operands.at(0), offset_, dim1_, dim2_);
 }
 
 XlaOpVector Diagonal::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/diagonal_view_update.cpp
+++ b/torch_xla/csrc/ops/diagonal_view_update.cpp
@@ -11,15 +11,15 @@ namespace ops {
 DiagonalViewUpdate::DiagonalViewUpdate(const Value& target, const Value& input,
                                        int64_t offset, int64_t dim1,
                                        int64_t dim2)
-    : Node(xla_diagonal_view_update, {target, input}, target.shape(),
+    : Node(xla_diagonal_view_update, {target, input}, target.xla_shape(),
            /*num_outputs=*/1, torch::lazy::MHash(offset, dim1, dim2)),
       offset_(offset),
       dim1_(dim1),
       dim2_(dim2) {}
 
 NodePtr DiagonalViewUpdate::Clone(OpList operands) const {
-  return MakeNode<DiagonalViewUpdate>(operands.at(0), operands.at(1), offset_,
-                                      dim1_, dim2_);
+  return ir::MakeNode<DiagonalViewUpdate>(operands.at(0), operands.at(1),
+                                          offset_, dim1_, dim2_);
 }
 
 XlaOpVector DiagonalViewUpdate::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/expand.cpp
+++ b/torch_xla/csrc/ops/expand.cpp
@@ -16,7 +16,7 @@ xla::Shape NodeOutputShape(const Value& input,
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildExpand(operands[0], size);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -28,7 +28,7 @@ Expand::Expand(const Value& input, std::vector<int64_t> size)
       size_(std::move(size)) {}
 
 NodePtr Expand::Clone(OpList operands) const {
-  return MakeNode<Expand>(operands.at(0), size_);
+  return ir::MakeNode<Expand>(operands.at(0), size_);
 }
 
 XlaOpVector Expand::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/flip.cpp
+++ b/torch_xla/csrc/ops/flip.cpp
@@ -8,12 +8,12 @@ namespace ir {
 namespace ops {
 
 Flip::Flip(const Value& input, std::vector<int64_t> dims)
-    : Node(torch::lazy::OpKind(at::aten::flip), {input}, input.shape(),
+    : Node(torch::lazy::OpKind(at::aten::flip), {input}, input.xla_shape(),
            /*num_outputs=*/1, torch::lazy::MHash(dims)),
       dims_(std::move(dims)) {}
 
 NodePtr Flip::Clone(OpList operands) const {
-  return MakeNode<Flip>(operands.at(0), dims_);
+  return ir::MakeNode<Flip>(operands.at(0), dims_);
 }
 
 XlaOpVector Flip::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/gather.cpp
+++ b/torch_xla/csrc/ops/gather.cpp
@@ -18,7 +18,8 @@ xla::Shape NodeOutputShape(const Value& input, const Value& index,
     return xla::TorchGather(operands[0], operands[1], dim,
                             IsSparseGather(operands[0], operands[1], dim));
   };
-  return InferOutputShape({input.shape(), index.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape(), index.xla_shape()},
+                          lower_for_shape_fn);
 }
 
 }  // namespace
@@ -30,7 +31,7 @@ Gather::Gather(const Value& input, int64_t dim, const Value& index)
       dim_(dim) {}
 
 NodePtr Gather::Clone(OpList operands) const {
-  return MakeNode<Gather>(operands.at(0), dim_, operands.at(1));
+  return ir::MakeNode<Gather>(operands.at(0), dim_, operands.at(1));
 }
 
 XlaOpVector Gather::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/generic_slice.cpp
+++ b/torch_xla/csrc/ops/generic_slice.cpp
@@ -19,7 +19,7 @@ xla::Shape NodeOutputShape(const Value& input,
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildSlice(operands[0], base_indices, sizes);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -34,7 +34,7 @@ GenericSlice::GenericSlice(const Value& input,
       sizes_(sizes.begin(), sizes.end()) {}
 
 NodePtr GenericSlice::Clone(OpList operands) const {
-  return MakeNode<GenericSlice>(operands.at(0), base_indices_, sizes_);
+  return ir::MakeNode<GenericSlice>(operands.at(0), base_indices_, sizes_);
 }
 
 XlaOpVector GenericSlice::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/get_dimensions_size.cpp
+++ b/torch_xla/csrc/ops/get_dimensions_size.cpp
@@ -20,7 +20,7 @@ GetDimensionsSize::GetDimensionsSize(const Value& input,
       dimensions_(std::move(dimensions)) {}
 
 NodePtr GetDimensionsSize::Clone(OpList operands) const {
-  return MakeNode<GetDimensionsSize>(operands.at(0), dimensions_);
+  return ir::MakeNode<GetDimensionsSize>(operands.at(0), dimensions_);
 }
 
 XlaOpVector GetDimensionsSize::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/hardshrink.cpp
+++ b/torch_xla/csrc/ops/hardshrink.cpp
@@ -10,7 +10,8 @@ namespace ir {
 namespace ops {
 
 Hardshrink::Hardshrink(const Value& input, const at::Scalar& lambda)
-    : Node(torch::lazy::OpKind(at::aten::hardshrink), {input}, input.shape(),
+    : Node(torch::lazy::OpKind(at::aten::hardshrink), {input},
+           input.xla_shape(),
            /*num_outputs=*/1, ScalarHash(lambda)),
       lambda_(std::move(lambda)) {}
 
@@ -21,7 +22,7 @@ std::string Hardshrink::ToString() const {
 }
 
 NodePtr Hardshrink::Clone(OpList operands) const {
-  return MakeNode<Hardshrink>(operands.at(0), lambda_);
+  return ir::MakeNode<Hardshrink>(operands.at(0), lambda_);
 }
 
 XlaOpVector Hardshrink::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/hardtanh_backward.cpp
+++ b/torch_xla/csrc/ops/hardtanh_backward.cpp
@@ -12,7 +12,7 @@ HardtanhBackward::HardtanhBackward(const Value& grad_output, const Value& input,
                                    const at::Scalar& min_val,
                                    const at::Scalar& max_val)
     : Node(torch::lazy::OpKind(at::aten::hardtanh_backward),
-           {grad_output, input}, grad_output.shape(), /*num_outputs=*/1,
+           {grad_output, input}, grad_output.xla_shape(), /*num_outputs=*/1,
            torch::lazy::MHash(ScalarHash(min_val), ScalarHash(max_val))),
       min_val_(min_val),
       max_val_(max_val) {}
@@ -25,8 +25,8 @@ std::string HardtanhBackward::ToString() const {
 }
 
 NodePtr HardtanhBackward::Clone(OpList operands) const {
-  return MakeNode<HardtanhBackward>(operands.at(0), operands.at(1), min_val_,
-                                    max_val_);
+  return ir::MakeNode<HardtanhBackward>(operands.at(0), operands.at(1),
+                                        min_val_, max_val_);
 }
 
 XlaOpVector HardtanhBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/index_get.cpp
+++ b/torch_xla/csrc/ops/index_get.cpp
@@ -17,7 +17,8 @@ xla::Shape NodeOutputShape(const Value& base, const Value& indices,
     XLA_CHECK_EQ(operands.size(), 2);
     return CreateIndex(operands[0], operands[1], start_dim);
   };
-  return InferOutputShape({base.shape(), indices.shape()}, lower_for_shape_fn);
+  return InferOutputShape({base.xla_shape(), indices.xla_shape()},
+                          lower_for_shape_fn);
 }
 
 }  // namespace
@@ -36,7 +37,7 @@ std::string IndexGet::ToString() const {
 }
 
 NodePtr IndexGet::Clone(OpList operands) const {
-  return MakeNode<IndexGet>(operands.at(0), operands.at(1), start_dim_);
+  return ir::MakeNode<IndexGet>(operands.at(0), operands.at(1), start_dim_);
 }
 
 XlaOpVector IndexGet::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/index_ops.cpp
+++ b/torch_xla/csrc/ops/index_ops.cpp
@@ -168,7 +168,7 @@ ir::NodePtr IndexFillOp(const ir::Value& buffer, int64_t dim,
       torch::lazy::OpKind(at::aten::index_fill), {buffer, index_rank1, value},
       [&]() {
         return ir::ops::InferOutputShape(
-            {buffer.shape(), index_rank1.shape(), value.shape()},
+            {buffer.xla_shape(), index_rank1.xla_shape(), value.xla_shape()},
             lower_for_shape_fn);
       },
       std::move(lower_fn), /*num_outputs=*/1, torch::lazy::MHash(dim));
@@ -193,7 +193,7 @@ ir::NodePtr IndexAddOp(const ir::Value& buffer, int64_t dim,
       torch::lazy::OpKind(at::aten::index_add), {buffer, index_rank1, source},
       [&]() {
         return ir::ops::InferOutputShape(
-            {buffer.shape(), index_rank1.shape(), source.shape()},
+            {buffer.xla_shape(), index_rank1.xla_shape(), source.xla_shape()},
             lower_for_shape_fn);
       },
       std::move(lower_fn));
@@ -218,7 +218,7 @@ ir::NodePtr IndexCopyOp(const ir::Value& buffer, int64_t dim,
       torch::lazy::OpKind(at::aten::index_copy), {buffer, index_rank1, source},
       [&]() {
         return ir::ops::InferOutputShape(
-            {buffer.shape(), index_rank1.shape(), source.shape()},
+            {buffer.xla_shape(), index_rank1.xla_shape(), source.xla_shape()},
             lower_for_shape_fn);
       },
       std::move(lower_fn));

--- a/torch_xla/csrc/ops/index_put.cpp
+++ b/torch_xla/csrc/ops/index_put.cpp
@@ -10,7 +10,7 @@ namespace ops {
 IndexPut::IndexPut(const ir::Value& base, const ir::Value& indices,
                    int64_t start_dim, const ir::Value& values, bool accumulate)
     : Node(torch::lazy::OpKind(at::aten::index_put), {base, indices, values},
-           base.shape(),
+           base.xla_shape(),
            /*num_outputs=*/1, torch::lazy::MHash(start_dim, accumulate)),
       start_dim_(start_dim),
       accumulate_(accumulate) {}
@@ -23,8 +23,8 @@ std::string IndexPut::ToString() const {
 }
 
 NodePtr IndexPut::Clone(OpList operands) const {
-  return MakeNode<IndexPut>(operands.at(0), operands.at(1), start_dim_,
-                            operands.at(2), accumulate_);
+  return ir::MakeNode<IndexPut>(operands.at(0), operands.at(1), start_dim_,
+                                operands.at(2), accumulate_);
 }
 
 XlaOpVector IndexPut::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/index_select.cpp
+++ b/torch_xla/csrc/ops/index_select.cpp
@@ -16,7 +16,8 @@ xla::Shape NodeOutputShape(const Value& input, const Value& index,
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return xla::TorchIndexSelect(operands[0], operands[1], dim);
   };
-  return InferOutputShape({input.shape(), index.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape(), index.xla_shape()},
+                          lower_for_shape_fn);
 }
 
 }  // namespace
@@ -28,7 +29,7 @@ IndexSelect::IndexSelect(const Value& input, int64_t dim, const Value& index)
       dim_(dim) {}
 
 NodePtr IndexSelect::Clone(OpList operands) const {
-  return MakeNode<IndexSelect>(operands.at(0), dim_, operands.at(1));
+  return ir::MakeNode<IndexSelect>(operands.at(0), dim_, operands.at(1));
 }
 
 XlaOpVector IndexSelect::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/kth_value.cpp
+++ b/torch_xla/csrc/ops/kth_value.cpp
@@ -16,7 +16,7 @@ xla::Shape NodeOutputShape(const Value& input, int64_t k, int64_t dim,
     return xla::Tuple(operands[0].builder(),
                       CreateKthValue(operands[0], k, dim, keepdim));
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -30,7 +30,7 @@ KthValue::KthValue(const Value& input, int64_t k, int64_t dim, bool keepdim)
       keepdim_(keepdim) {}
 
 NodePtr KthValue::Clone(OpList operands) const {
-  return MakeNode<KthValue>(operands.at(0), k_, dim_, keepdim_);
+  return ir::MakeNode<KthValue>(operands.at(0), k_, dim_, keepdim_);
 }
 
 XlaOpVector KthValue::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/l1_loss.cpp
+++ b/torch_xla/csrc/ops/l1_loss.cpp
@@ -17,7 +17,8 @@ xla::Shape NodeOutputShape(const Value& input, const Value& target,
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildL1Loss(operands[0], operands[1], reduction);
   };
-  return InferOutputShape({input.shape(), target.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape(), target.xla_shape()},
+                          lower_for_shape_fn);
 }
 
 }  // namespace
@@ -30,7 +31,7 @@ L1Loss::L1Loss(const Value& input, const Value& target, ReductionMode reduction)
       reduction_(reduction) {}
 
 NodePtr L1Loss::Clone(OpList operands) const {
-  return MakeNode<L1Loss>(operands.at(0), operands.at(1), reduction_);
+  return ir::MakeNode<L1Loss>(operands.at(0), operands.at(1), reduction_);
 }
 
 XlaOpVector L1Loss::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/l1_loss_backward.cpp
+++ b/torch_xla/csrc/ops/l1_loss_backward.cpp
@@ -17,8 +17,9 @@ xla::Shape NodeOutputShape(const Value& grad_output, const Value& input,
     return BuildL1LossBackward(operands[0], operands[1], operands[2],
                                reduction);
   };
-  return InferOutputShape({grad_output.shape(), input.shape(), target.shape()},
-                          lower_for_shape_fn);
+  return InferOutputShape(
+      {grad_output.xla_shape(), input.xla_shape(), target.xla_shape()},
+      lower_for_shape_fn);
 }
 
 }  // namespace
@@ -35,8 +36,8 @@ L1LossBackward::L1LossBackward(const Value& grad_output, const Value& input,
       reduction_(reduction) {}
 
 NodePtr L1LossBackward::Clone(OpList operands) const {
-  return MakeNode<L1LossBackward>(operands.at(0), operands.at(1),
-                                  operands.at(2), reduction_);
+  return ir::MakeNode<L1LossBackward>(operands.at(0), operands.at(1),
+                                      operands.at(2), reduction_);
 }
 
 XlaOpVector L1LossBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/leaky_relu.cpp
+++ b/torch_xla/csrc/ops/leaky_relu.cpp
@@ -8,12 +8,13 @@ namespace ir {
 namespace ops {
 
 LeakyRelu::LeakyRelu(const Value& input, double negative_slope)
-    : Node(torch::lazy::OpKind(at::aten::leaky_relu), {input}, input.shape(),
+    : Node(torch::lazy::OpKind(at::aten::leaky_relu), {input},
+           input.xla_shape(),
            /*num_outputs=*/1, torch::lazy::MHash(negative_slope)),
       negative_slope_(negative_slope) {}
 
 NodePtr LeakyRelu::Clone(OpList operands) const {
-  return MakeNode<LeakyRelu>(operands.at(0), negative_slope_);
+  return ir::MakeNode<LeakyRelu>(operands.at(0), negative_slope_);
 }
 
 XlaOpVector LeakyRelu::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/leaky_relu_backward.cpp
+++ b/torch_xla/csrc/ops/leaky_relu_backward.cpp
@@ -10,13 +10,13 @@ namespace ops {
 LeakyReluBackward::LeakyReluBackward(const Value& grad_output,
                                      const Value& input, double negative_slope)
     : Node(torch::lazy::OpKind(at::aten::leaky_relu_backward),
-           {grad_output, input}, input.shape(),
+           {grad_output, input}, input.xla_shape(),
            /*num_outputs=*/1, torch::lazy::MHash(negative_slope)),
       negative_slope_(negative_slope) {}
 
 NodePtr LeakyReluBackward::Clone(OpList operands) const {
-  return MakeNode<LeakyReluBackward>(operands.at(0), operands.at(1),
-                                     negative_slope_);
+  return ir::MakeNode<LeakyReluBackward>(operands.at(0), operands.at(1),
+                                         negative_slope_);
 }
 
 XlaOpVector LeakyReluBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/linear_interpolation.cpp
+++ b/torch_xla/csrc/ops/linear_interpolation.cpp
@@ -10,12 +10,13 @@ namespace ops {
 
 LinearInterpolation::LinearInterpolation(const Value& value,
                                          const Value& new_value, double alpha)
-    : Node(xla_moving_average, {value, new_value}, value.shape(),
+    : Node(xla_moving_average, {value, new_value}, value.xla_shape(),
            /*num_outputs=*/1, torch::lazy::MHash(alpha)),
       alpha_(alpha) {}
 
 NodePtr LinearInterpolation::Clone(OpList operands) const {
-  return MakeNode<LinearInterpolation>(operands.at(0), operands.at(1), alpha_);
+  return ir::MakeNode<LinearInterpolation>(operands.at(0), operands.at(1),
+                                           alpha_);
 }
 
 XlaOpVector LinearInterpolation::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/linspace.cpp
+++ b/torch_xla/csrc/ops/linspace.cpp
@@ -11,15 +11,16 @@ namespace ops {
 Linspace::Linspace(const Value& start, const Value& end, int64_t steps)
     : Node(torch::lazy::OpKind(at::aten::linspace), {start, end},
            [&]() {
-             xla::PrimitiveType dtype = XlaHelpers::PromoteType(
-                 start.shape().element_type(), end.shape().element_type());
+             xla::PrimitiveType dtype =
+                 XlaHelpers::PromoteType(start.xla_shape().element_type(),
+                                         end.xla_shape().element_type());
              return xla::ShapeUtil::MakeShape(dtype, {steps});
            },
            /*num_outputs=*/1, torch::lazy::MHash(steps)),
       steps_(steps) {}
 
 NodePtr Linspace::Clone(OpList operands) const {
-  return MakeNode<Linspace>(operands.at(0), operands.at(1), steps_);
+  return ir::MakeNode<Linspace>(operands.at(0), operands.at(1), steps_);
 }
 
 XlaOpVector Linspace::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/log_softmax.cpp
+++ b/torch_xla/csrc/ops/log_softmax.cpp
@@ -22,9 +22,9 @@ xla::Shape NodeOutputShape(const Value& input,
                            const c10::optional<at::ScalarType>& dtype) {
   if (dtype) {
     return xla::ShapeUtil::ChangeElementType(
-        input.shape(), MakeXlaPrimitiveType(*dtype, /*device=*/nullptr));
+        input.xla_shape(), MakeXlaPrimitiveType(*dtype, /*device=*/nullptr));
   }
-  return input.shape();
+  return input.xla_shape();
 }
 
 }  // namespace
@@ -39,7 +39,7 @@ LogSoftmax::LogSoftmax(const Value& input, int64_t dim,
       dtype_(dtype) {}
 
 NodePtr LogSoftmax::Clone(OpList operands) const {
-  return MakeNode<LogSoftmax>(operands.at(0), dim_, dtype_);
+  return ir::MakeNode<LogSoftmax>(operands.at(0), dim_, dtype_);
 }
 
 XlaOpVector LogSoftmax::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/log_softmax_backward.cpp
+++ b/torch_xla/csrc/ops/log_softmax_backward.cpp
@@ -12,12 +12,12 @@ namespace ops {
 LogSoftmaxBackward::LogSoftmaxBackward(const Value& grad_output,
                                        const Value& output, int64_t dim)
     : Node(torch::lazy::OpKind(at::aten::_log_softmax_backward_data),
-           {grad_output, output}, grad_output.shape(),
+           {grad_output, output}, grad_output.xla_shape(),
            /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}
 
 NodePtr LogSoftmaxBackward::Clone(OpList operands) const {
-  return MakeNode<LogSoftmaxBackward>(operands.at(0), operands.at(1), dim_);
+  return ir::MakeNode<LogSoftmaxBackward>(operands.at(0), operands.at(1), dim_);
 }
 
 XlaOpVector LogSoftmaxBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/logsumexp.cpp
+++ b/torch_xla/csrc/ops/logsumexp.cpp
@@ -19,7 +19,7 @@ xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildLogsumexp(operands[0], dimensions, keep_reduced_dimensions);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -36,8 +36,8 @@ Logsumexp::Logsumexp(const Value& input, std::vector<int64_t> dimensions,
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
 NodePtr Logsumexp::Clone(OpList operands) const {
-  return MakeNode<Logsumexp>(operands.at(0), dimensions_,
-                             keep_reduced_dimensions_);
+  return ir::MakeNode<Logsumexp>(operands.at(0), dimensions_,
+                                 keep_reduced_dimensions_);
 }
 
 XlaOpVector Logsumexp::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/masked_fill.cpp
+++ b/torch_xla/csrc/ops/masked_fill.cpp
@@ -12,12 +12,12 @@ namespace ops {
 MaskedFill::MaskedFill(const Value& input, const Value& mask,
                        const at::Scalar& value)
     : Node(torch::lazy::OpKind(at::aten::masked_fill), {input, mask},
-           input.shape(),
+           input.xla_shape(),
            /*num_outputs=*/1, ScalarHash(value)),
       value_(std::move(value)) {}
 
 NodePtr MaskedFill::Clone(OpList operands) const {
-  return MakeNode<MaskedFill>(operands.at(0), operands.at(1), value_);
+  return ir::MakeNode<MaskedFill>(operands.at(0), operands.at(1), value_);
 }
 
 XlaOpVector MaskedFill::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/masked_scatter.cpp
+++ b/torch_xla/csrc/ops/masked_scatter.cpp
@@ -10,12 +10,12 @@ namespace ops {
 MaskedScatter::MaskedScatter(const Value& input, const Value& mask,
                              const Value& source)
     : Node(torch::lazy::OpKind(at::aten::masked_scatter), {input, mask, source},
-           input.shape(),
+           input.xla_shape(),
            /*num_outputs=*/1) {}
 
 NodePtr MaskedScatter::Clone(OpList operands) const {
-  return MakeNode<MaskedScatter>(operands.at(0), operands.at(1),
-                                 operands.at(2));
+  return ir::MakeNode<MaskedScatter>(operands.at(0), operands.at(1),
+                                     operands.at(2));
 }
 
 XlaOpVector MaskedScatter::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/masked_select.cpp
+++ b/torch_xla/csrc/ops/masked_select.cpp
@@ -11,7 +11,7 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& input) {
-  const xla::Shape& input_shape = input.shape();
+  const xla::Shape& input_shape = input.xla_shape();
   int64_t input_elements = xla::ShapeUtil::ElementsIn(input_shape);
   xla::PrimitiveType size_type = GetShapeDimensionType(/*device=*/nullptr);
   xla::Shape result_shape =
@@ -29,7 +29,7 @@ MaskedSelect::MaskedSelect(const Value& input, const Value& mask)
            /*num_outputs=*/2) {}
 
 NodePtr MaskedSelect::Clone(OpList operands) const {
-  return MakeNode<MaskedSelect>(operands.at(0), operands.at(1));
+  return ir::MakeNode<MaskedSelect>(operands.at(0), operands.at(1));
 }
 
 XlaOpVector MaskedSelect::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/max_in_dim.cpp
+++ b/torch_xla/csrc/ops/max_in_dim.cpp
@@ -16,7 +16,7 @@ xla::Shape NodeOutputShape(const Value& input, int64_t dim, bool keepdim) {
     xla::XlaOp indices = BuildArgMax(operands[0], dim, keepdim);
     return xla::Tuple(values.builder(), {values, indices});
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -29,7 +29,7 @@ MaxInDim::MaxInDim(const Value& input, int64_t dim, bool keepdim)
       keepdim_(keepdim) {}
 
 NodePtr MaxInDim::Clone(OpList operands) const {
-  return MakeNode<MaxInDim>(operands.at(0), dim_, keepdim_);
+  return ir::MakeNode<MaxInDim>(operands.at(0), dim_, keepdim_);
 }
 
 XlaOpVector MaxInDim::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/max_pool_nd.cpp
+++ b/torch_xla/csrc/ops/max_pool_nd.cpp
@@ -20,7 +20,7 @@ xla::Shape NodeOutputShape(const Value& input, int64_t spatial_dim_count,
                        padding, ceil_mode);
     return xla::Tuple(operands[0].builder(), {result.result, result.indices});
   };
-  return InferOutputShape({input.shape()}, shape_fn);
+  return InferOutputShape({input.xla_shape()}, shape_fn);
 }
 
 c10::Symbol MaxPoolNdSymbol(int64_t spatial_dim_count) {
@@ -58,8 +58,8 @@ MaxPoolNd::MaxPoolNd(const Value& input, int64_t spatial_dim_count,
       ceil_mode_(ceil_mode) {}
 
 NodePtr MaxPoolNd::Clone(OpList operands) const {
-  return MakeNode<MaxPoolNd>(operands.at(0), spatial_dim_count_, kernel_size_,
-                             stride_, padding_, ceil_mode_);
+  return ir::MakeNode<MaxPoolNd>(operands.at(0), spatial_dim_count_,
+                                 kernel_size_, stride_, padding_, ceil_mode_);
 }
 
 XlaOpVector MaxPoolNd::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/max_pool_nd_backward.cpp
+++ b/torch_xla/csrc/ops/max_pool_nd_backward.cpp
@@ -22,7 +22,7 @@ xla::Shape NodeOutputShape(const Value& grad_output, const Value& input,
                                   /*input=*/operands[1], spatial_dim_count,
                                   kernel_size, stride, padding, ceil_mode);
   };
-  return InferOutputShape({grad_output.shape(), input.shape()},
+  return InferOutputShape({grad_output.xla_shape(), input.xla_shape()},
                           lower_for_shape_fn);
 }
 
@@ -60,9 +60,9 @@ MaxPoolNdBackward::MaxPoolNdBackward(
       ceil_mode_(ceil_mode) {}
 
 NodePtr MaxPoolNdBackward::Clone(OpList operands) const {
-  return MakeNode<MaxPoolNdBackward>(operands.at(0), operands.at(1),
-                                     spatial_dim_count_, kernel_size_, stride_,
-                                     padding_, ceil_mode_);
+  return ir::MakeNode<MaxPoolNdBackward>(operands.at(0), operands.at(1),
+                                         spatial_dim_count_, kernel_size_,
+                                         stride_, padding_, ceil_mode_);
 }
 
 XlaOpVector MaxPoolNdBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/max_unpool_nd.cpp
+++ b/torch_xla/csrc/ops/max_unpool_nd.cpp
@@ -16,7 +16,7 @@ xla::Shape NodeOutputShape(const Value& input, const Value& indices,
     return BuildMaxUnpoolNd(GetCurrentDevice(), operands[0], operands[1],
                             output_size);
   };
-  return InferOutputShape({input.shape(), indices.shape()}, shape_fn);
+  return InferOutputShape({input.xla_shape(), indices.xla_shape()}, shape_fn);
 }
 
 c10::Symbol MaxUnpoolNdSymbol(int64_t spatial_dim_count) {
@@ -42,7 +42,8 @@ MaxUnpoolNd::MaxUnpoolNd(const Value& input, const Value& indices,
       output_size_(std::move(output_size)) {}
 
 NodePtr MaxUnpoolNd::Clone(OpList operands) const {
-  return MakeNode<MaxUnpoolNd>(operands.at(0), operands.at(1), output_size_);
+  return ir::MakeNode<MaxUnpoolNd>(operands.at(0), operands.at(1),
+                                   output_size_);
 }
 
 XlaOpVector MaxUnpoolNd::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/max_unpool_nd_backward.cpp
+++ b/torch_xla/csrc/ops/max_unpool_nd_backward.cpp
@@ -17,8 +17,9 @@ xla::Shape NodeOutputShape(const Value& grad_output, const Value& input,
     return BuildMaxUnpoolNdBackward(operands[0], operands[1], operands[2],
                                     output_size);
   };
-  return InferOutputShape({grad_output.shape(), input.shape(), indices.shape()},
-                          shape_fn);
+  return InferOutputShape(
+      {grad_output.xla_shape(), input.xla_shape(), indices.xla_shape()},
+      shape_fn);
 }
 
 c10::Symbol MaxUnpoolNdBackwardSymbol(int64_t spatial_dim_count) {
@@ -48,8 +49,8 @@ MaxUnpoolNdBackward::MaxUnpoolNdBackward(const Value& grad_output,
       output_size_(std::move(output_size)) {}
 
 NodePtr MaxUnpoolNdBackward::Clone(OpList operands) const {
-  return MakeNode<MaxUnpoolNdBackward>(operands.at(0), operands.at(1),
-                                       operands.at(2), output_size_);
+  return ir::MakeNode<MaxUnpoolNdBackward>(operands.at(0), operands.at(1),
+                                           operands.at(2), output_size_);
 }
 
 XlaOpVector MaxUnpoolNdBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/mean.cpp
+++ b/torch_xla/csrc/ops/mean.cpp
@@ -31,7 +31,7 @@ xla::Shape NodeOutputShape(const Value& input,
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return LowerMean(operands[0], dimensions, keep_reduced_dimensions, dtype);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -51,8 +51,8 @@ Mean::Mean(const Value& input, std::vector<int64_t> dimensions,
       dtype_(dtype) {}
 
 NodePtr Mean::Clone(OpList operands) const {
-  return MakeNode<Mean>(operands.at(0), dimensions_, keep_reduced_dimensions_,
-                        dtype_);
+  return ir::MakeNode<Mean>(operands.at(0), dimensions_,
+                            keep_reduced_dimensions_, dtype_);
 }
 
 XlaOpVector Mean::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/min_in_dim.cpp
+++ b/torch_xla/csrc/ops/min_in_dim.cpp
@@ -16,7 +16,7 @@ xla::Shape NodeOutputShape(const Value& input, int64_t dim, bool keepdim) {
     xla::XlaOp indices = BuildArgMin(operands[0], dim, keepdim);
     return xla::Tuple(values.builder(), {values, indices});
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -29,7 +29,7 @@ MinInDim::MinInDim(const Value& input, int64_t dim, bool keepdim)
       keepdim_(keepdim) {}
 
 NodePtr MinInDim::Clone(OpList operands) const {
-  return MakeNode<MinInDim>(operands.at(0), dim_, keepdim_);
+  return ir::MakeNode<MinInDim>(operands.at(0), dim_, keepdim_);
 }
 
 XlaOpVector MinInDim::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/mse_loss.cpp
+++ b/torch_xla/csrc/ops/mse_loss.cpp
@@ -19,7 +19,8 @@ xla::Shape NodeOutputShape(const Value& input, const Value& target,
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildMseLoss(operands[0], operands[1], reduction);
   };
-  return InferOutputShape({input.shape(), target.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape(), target.xla_shape()},
+                          lower_for_shape_fn);
 }
 
 }  // namespace
@@ -33,7 +34,7 @@ MseLoss::MseLoss(const Value& input, const Value& target,
       reduction_(reduction) {}
 
 NodePtr MseLoss::Clone(OpList operands) const {
-  return MakeNode<MseLoss>(operands.at(0), operands.at(1), reduction_);
+  return ir::MakeNode<MseLoss>(operands.at(0), operands.at(1), reduction_);
 }
 
 XlaOpVector MseLoss::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/mse_loss_backward.cpp
+++ b/torch_xla/csrc/ops/mse_loss_backward.cpp
@@ -19,8 +19,9 @@ xla::Shape NodeOutputShape(const Value& grad_output, const Value& input,
     return BuildMseLossBackward(operands[0], operands[1], operands[2],
                                 reduction);
   };
-  return InferOutputShape({grad_output.shape(), input.shape(), target.shape()},
-                          lower_for_shape_fn);
+  return InferOutputShape(
+      {grad_output.xla_shape(), input.xla_shape(), target.xla_shape()},
+      lower_for_shape_fn);
 }
 
 }  // namespace
@@ -37,8 +38,8 @@ MseLossBackward::MseLossBackward(const Value& grad_output, const Value& input,
       reduction_(reduction) {}
 
 NodePtr MseLossBackward::Clone(OpList operands) const {
-  return MakeNode<MseLossBackward>(operands.at(0), operands.at(1),
-                                   operands.at(2), reduction_);
+  return ir::MakeNode<MseLossBackward>(operands.at(0), operands.at(1),
+                                       operands.at(2), reduction_);
 }
 
 XlaOpVector MseLossBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/native_batch_norm_backward.cpp
+++ b/torch_xla/csrc/ops/native_batch_norm_backward.cpp
@@ -22,9 +22,10 @@ xla::Shape NodeOutputShape(const Value& grad_out, const Value& input,
                       {xla_outputs.grad_input, xla_outputs.grad_weight,
                        xla_outputs.grad_bias});
   };
-  return InferOutputShape({grad_out.shape(), input.shape(), weight.shape(),
-                           save_mean.shape(), save_invstd.shape()},
-                          lower_for_shape_fn);
+  return InferOutputShape(
+      {grad_out.xla_shape(), input.xla_shape(), weight.xla_shape(),
+       save_mean.xla_shape(), save_invstd.xla_shape()},
+      lower_for_shape_fn);
 }
 
 }  // namespace
@@ -43,9 +44,9 @@ NativeBatchNormBackward::NativeBatchNormBackward(
       eps_(eps) {}
 
 NodePtr NativeBatchNormBackward::Clone(OpList operands) const {
-  return MakeNode<NativeBatchNormBackward>(operands.at(0), operands.at(1),
-                                           operands.at(2), operands.at(3),
-                                           operands.at(4), training_, eps_);
+  return ir::MakeNode<NativeBatchNormBackward>(operands.at(0), operands.at(1),
+                                               operands.at(2), operands.at(3),
+                                               operands.at(4), training_, eps_);
 }
 
 XlaOpVector NativeBatchNormBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/native_batch_norm_forward.cpp
+++ b/torch_xla/csrc/ops/native_batch_norm_forward.cpp
@@ -43,9 +43,10 @@ xla::Shape NodeOutputShape(const Value& input, const Value& weight,
                        operands[4], training, 0.5);
     return xla::Tuple(operands[0].builder(), values);
   };
-  return InferOutputShape({input.shape(), weight.shape(), bias.shape(),
-                           running_mean.shape(), running_var.shape()},
-                          lower_for_shape_fn);
+  return InferOutputShape(
+      {input.xla_shape(), weight.xla_shape(), bias.xla_shape(),
+       running_mean.xla_shape(), running_var.xla_shape()},
+      lower_for_shape_fn);
 }
 
 }  // namespace
@@ -67,9 +68,9 @@ NativeBatchNormForward::NativeBatchNormForward(const Value& input,
       eps_(eps) {}
 
 NodePtr NativeBatchNormForward::Clone(OpList operands) const {
-  return MakeNode<NativeBatchNormForward>(operands.at(0), operands.at(1),
-                                          operands.at(2), operands.at(3),
-                                          operands.at(4), training_, eps_);
+  return ir::MakeNode<NativeBatchNormForward>(operands.at(0), operands.at(1),
+                                              operands.at(2), operands.at(3),
+                                              operands.at(4), training_, eps_);
 }
 
 XlaOpVector NativeBatchNormForward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/nll_loss.cpp
+++ b/torch_xla/csrc/ops/nll_loss.cpp
@@ -27,7 +27,7 @@ xla::Shape NodeOutputShape(const Value& logits, const Value& labels,
   std::vector<xla::Shape> shapes;
   for (auto& input :
        xla::util::GetValuesVector<Value>({logits, labels}, {&weight})) {
-    shapes.push_back(input.shape());
+    shapes.push_back(input.xla_shape());
   }
   return InferOutputShape(shapes, lower_for_shape_fn);
 }
@@ -54,8 +54,8 @@ NodePtr NllLoss::Clone(OpList operands) const {
   if (operands.size() > 2) {
     weight = operands.at(2);
   }
-  return MakeNode<NllLoss>(operands.at(0), operands.at(1), weight, reduction_,
-                           ignore_index_);
+  return ir::MakeNode<NllLoss>(operands.at(0), operands.at(1), weight,
+                               reduction_, ignore_index_);
 }
 
 XlaOpVector NllLoss::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/nll_loss2d.cpp
+++ b/torch_xla/csrc/ops/nll_loss2d.cpp
@@ -27,7 +27,7 @@ xla::Shape NodeOutputShape(const Value& logits, const Value& labels,
   std::vector<xla::Shape> shapes;
   for (auto& input :
        xla::util::GetValuesVector<Value>({logits, labels}, {&weight})) {
-    shapes.push_back(input.shape());
+    shapes.push_back(input.xla_shape());
   }
   return InferOutputShape(shapes, lower_for_shape_fn);
 }
@@ -54,8 +54,8 @@ NodePtr NllLoss2d::Clone(OpList operands) const {
   if (operands.size() > 2) {
     weight = operands.at(2);
   }
-  return MakeNode<NllLoss2d>(operands.at(0), operands.at(1), weight, reduction_,
-                             ignore_index_);
+  return ir::MakeNode<NllLoss2d>(operands.at(0), operands.at(1), weight,
+                                 reduction_, ignore_index_);
 }
 
 XlaOpVector NllLoss2d::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/nll_loss2d_backward.cpp
+++ b/torch_xla/csrc/ops/nll_loss2d_backward.cpp
@@ -33,7 +33,7 @@ xla::Shape NodeOutputShape(const Value& grad_output, const Value& logits,
   std::vector<xla::Shape> shapes;
   for (auto& input : xla::util::GetValuesVector<Value>(
            {grad_output, logits, labels}, {&weight, &total_weight})) {
-    shapes.push_back(input.shape());
+    shapes.push_back(input.xla_shape());
   }
   return InferOutputShape(shapes, lower_for_shape_fn);
 }
@@ -65,9 +65,9 @@ NodePtr NllLoss2dBackward::Clone(OpList operands) const {
     weight = operands.at(3);
     total_weight = operands.at(4);
   }
-  return MakeNode<NllLoss2dBackward>(operands.at(0), operands.at(1),
-                                     operands.at(2), weight, total_weight,
-                                     reduction_, ignore_index_);
+  return ir::MakeNode<NllLoss2dBackward>(operands.at(0), operands.at(1),
+                                         operands.at(2), weight, total_weight,
+                                         reduction_, ignore_index_);
 }
 
 XlaOpVector NllLoss2dBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/nll_loss_backward.cpp
+++ b/torch_xla/csrc/ops/nll_loss_backward.cpp
@@ -33,7 +33,7 @@ xla::Shape NodeOutputShape(const Value& grad_output, const Value& logits,
   std::vector<xla::Shape> shapes;
   for (auto& input : xla::util::GetValuesVector<Value>(
            {grad_output, logits, labels}, {&weight, &total_weight})) {
-    shapes.push_back(input.shape());
+    shapes.push_back(input.xla_shape());
   }
   return InferOutputShape(shapes, lower_for_shape_fn);
 }
@@ -65,9 +65,9 @@ NodePtr NllLossBackward::Clone(OpList operands) const {
     weight = operands.at(3);
     total_weight = operands.at(4);
   }
-  return MakeNode<NllLossBackward>(operands.at(0), operands.at(1),
-                                   operands.at(2), weight, total_weight,
-                                   reduction_, ignore_index_);
+  return ir::MakeNode<NllLossBackward>(operands.at(0), operands.at(1),
+                                       operands.at(2), weight, total_weight,
+                                       reduction_, ignore_index_);
 }
 
 XlaOpVector NllLossBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/nms.cpp
+++ b/torch_xla/csrc/ops/nms.cpp
@@ -20,9 +20,10 @@ xla::Shape NodeOutputShape(const Value& boxes, const Value& scores,
     return xla::Tuple(result.selected_indices.builder(),
                       {result.selected_indices, result.num_valid});
   };
-  return InferOutputShape({boxes.shape(), scores.shape(),
-                           score_threshold.shape(), iou_threshold.shape()},
-                          shape_fn);
+  return InferOutputShape(
+      {boxes.xla_shape(), scores.xla_shape(), score_threshold.xla_shape(),
+       iou_threshold.xla_shape()},
+      shape_fn);
 }
 
 }  // namespace
@@ -38,8 +39,8 @@ Nms::Nms(const Value& boxes, const Value& scores, const Value& score_threshold,
       output_size_(output_size) {}
 
 NodePtr Nms::Clone(OpList operands) const {
-  return MakeNode<Nms>(operands.at(0), operands.at(1), operands.at(2),
-                       operands.at(3), output_size_);
+  return ir::MakeNode<Nms>(operands.at(0), operands.at(1), operands.at(2),
+                           operands.at(3), output_size_);
 }
 
 XlaOpVector Nms::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/nonzero.cpp
+++ b/torch_xla/csrc/ops/nonzero.cpp
@@ -11,7 +11,7 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& input) {
-  const xla::Shape& input_shape = input.shape();
+  const xla::Shape& input_shape = input.xla_shape();
   int64_t index_elements = xla::ShapeUtil::ElementsIn(input_shape);
   xla::PrimitiveType size_type = GetShapeDimensionType(/*device=*/nullptr);
   xla::Shape result_shape = xla::ShapeUtil::MakeShape(
@@ -29,7 +29,7 @@ NonZero::NonZero(const Value& input)
            /*num_outputs=*/2) {}
 
 NodePtr NonZero::Clone(OpList operands) const {
-  return MakeNode<NonZero>(operands.at(0));
+  return ir::MakeNode<NonZero>(operands.at(0));
 }
 
 XlaOpVector NonZero::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/normal.cpp
+++ b/torch_xla/csrc/ops/normal.cpp
@@ -10,10 +10,10 @@ namespace ops {
 
 Normal::Normal(const Value& mean, const Value& std, const Value& seed)
     : Node(torch::lazy::OpKind(at::aten::normal), {mean, std, seed},
-           mean.shape()) {}
+           mean.xla_shape()) {}
 
 NodePtr Normal::Clone(OpList operands) const {
-  return MakeNode<Normal>(operands.at(0), operands.at(1), operands.at(2));
+  return ir::MakeNode<Normal>(operands.at(0), operands.at(1), operands.at(2));
 }
 
 XlaOpVector Normal::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -15,14 +15,14 @@ namespace ir {
 namespace ops {
 
 inline NodePtr ScalarOp(const at::Scalar& value, xla::Shape shape) {
-  return MakeNode<Scalar>(value, std::move(shape));
+  return ir::MakeNode<Scalar>(value, std::move(shape));
 }
 inline NodePtr ScalarOp(const at::Scalar& value, xla::PrimitiveType type) {
-  return MakeNode<Scalar>(value, type);
+  return ir::MakeNode<Scalar>(value, type);
 }
 
 inline NodePtr ConstantOp(xla::Literal value) {
-  return MakeNode<Constant>(std::move(value));
+  return ir::MakeNode<Constant>(std::move(value));
 }
 
 inline NodePtr GenericOp(

--- a/torch_xla/csrc/ops/permute.cpp
+++ b/torch_xla/csrc/ops/permute.cpp
@@ -16,7 +16,7 @@ xla::Shape NodeOutputShape(const Value& input, absl::Span<const int64_t> dims) {
     XLA_CHECK_EQ(operands.size(), 1);
     return xla::Transpose(operands[0], dims);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -28,7 +28,7 @@ Permute::Permute(const Value& input, std::vector<int64_t> dims)
       dims_(std::move(dims)) {}
 
 NodePtr Permute::Clone(OpList operands) const {
-  return MakeNode<Permute>(operands.at(0), dims_);
+  return ir::MakeNode<Permute>(operands.at(0), dims_);
 }
 
 XlaOpVector Permute::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/prod.cpp
+++ b/torch_xla/csrc/ops/prod.cpp
@@ -36,7 +36,7 @@ xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return LowerProd(operands[0], dimensions, keep_reduced_dimensions, dtype);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -56,8 +56,8 @@ Prod::Prod(const Value& input, std::vector<int64_t> dimensions,
       dtype_(dtype) {}
 
 NodePtr Prod::Clone(OpList operands) const {
-  return MakeNode<Prod>(operands.at(0), dimensions_, keep_reduced_dimensions_,
-                        dtype_);
+  return ir::MakeNode<Prod>(operands.at(0), dimensions_,
+                            keep_reduced_dimensions_, dtype_);
 }
 
 XlaOpVector Prod::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/put.cpp
+++ b/torch_xla/csrc/ops/put.cpp
@@ -10,13 +10,13 @@ namespace ops {
 Put::Put(const Value& input, const Value& index, const Value& source,
          bool accumulate)
     : Node(torch::lazy::OpKind(at::aten::put), {input, index, source},
-           input.shape(),
+           input.xla_shape(),
            /*num_outputs=*/1, torch::lazy::MHash(accumulate)),
       accumulate_(accumulate) {}
 
 NodePtr Put::Clone(OpList operands) const {
-  return MakeNode<Put>(operands.at(0), operands.at(1), operands.at(2),
-                       accumulate_);
+  return ir::MakeNode<Put>(operands.at(0), operands.at(1), operands.at(2),
+                           accumulate_);
 }
 
 XlaOpVector Put::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/qr.cpp
+++ b/torch_xla/csrc/ops/qr.cpp
@@ -19,7 +19,7 @@ std::vector<xla::XlaOp> LowerQR(xla::XlaOp input, bool some) {
 }
 
 xla::Shape NodeOutputShape(const Value& input, bool some) {
-  const xla::Shape& input_shape = input.shape();
+  const xla::Shape& input_shape = input.xla_shape();
   XLA_CHECK_GE(input_shape.rank(), 2) << input_shape;
   // The input tensor is ..., M, N
   int64_t m_dim = input_shape.dimensions(input_shape.rank() - 2);
@@ -48,7 +48,7 @@ QR::QR(const Value& input, bool some)
       some_(some) {}
 
 NodePtr QR::Clone(OpList operands) const {
-  return MakeNode<QR>(operands.at(0), some_);
+  return ir::MakeNode<QR>(operands.at(0), some_);
 }
 
 XlaOpVector QR::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/reduce_scatter.cpp
+++ b/torch_xla/csrc/ops/reduce_scatter.cpp
@@ -23,7 +23,7 @@ xla::Shape NodeOutputShape(AllReduceType reduce_type, const Value input,
         reduce_type, inputOp, tokenOp, scale, scatter_dim, shard_count, groups);
     return xla::Tuple(operands[0].builder(), {result.result, result.token});
   };
-  return InferOutputShape({input.shape(), token.shape()}, shape_fn);
+  return InferOutputShape({input.xla_shape(), token.xla_shape()}, shape_fn);
 }
 
 }  // namespace
@@ -47,8 +47,9 @@ ReduceScatter::ReduceScatter(AllReduceType reduce_type, const Value& input,
       groups_(std::move(groups)) {}
 
 NodePtr ReduceScatter::Clone(OpList operands) const {
-  return MakeNode<ReduceScatter>(reduce_type_, operands.at(0), operands.at(1),
-                                 scale_, scatter_dim_, shard_count_, groups_);
+  return ir::MakeNode<ReduceScatter>(reduce_type_, operands.at(0),
+                                     operands.at(1), scale_, scatter_dim_,
+                                     shard_count_, groups_);
 }
 
 XlaOpVector ReduceScatter::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/reflection_pad2d.cpp
+++ b/torch_xla/csrc/ops/reflection_pad2d.cpp
@@ -16,7 +16,7 @@ xla::Shape NodeOutputShape(const Value& input,
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildReflectionPad2d(operands[0], padding);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -29,7 +29,7 @@ ReflectionPad2d::ReflectionPad2d(const Value& input,
       padding_(std::move(padding)) {}
 
 NodePtr ReflectionPad2d::Clone(OpList operands) const {
-  return MakeNode<ReflectionPad2d>(operands.at(0), padding_);
+  return ir::MakeNode<ReflectionPad2d>(operands.at(0), padding_);
 }
 
 XlaOpVector ReflectionPad2d::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/reflection_pad2d_backward.cpp
+++ b/torch_xla/csrc/ops/reflection_pad2d_backward.cpp
@@ -16,7 +16,7 @@ xla::Shape NodeOutputShape(const Value& grad_output, const Value& input,
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildReflectionPadBackward(operands[0], operands[1], padding);
   };
-  return InferOutputShape({grad_output.shape(), input.shape()},
+  return InferOutputShape({grad_output.xla_shape(), input.xla_shape()},
                           lower_for_shape_fn);
 }
 
@@ -32,8 +32,8 @@ ReflectionPad2dBackward::ReflectionPad2dBackward(const Value& grad_output,
       padding_(std::move(padding)) {}
 
 NodePtr ReflectionPad2dBackward::Clone(OpList operands) const {
-  return MakeNode<ReflectionPad2dBackward>(operands.at(0), operands.at(1),
-                                           padding_);
+  return ir::MakeNode<ReflectionPad2dBackward>(operands.at(0), operands.at(1),
+                                               padding_);
 }
 
 XlaOpVector ReflectionPad2dBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/repeat.cpp
+++ b/torch_xla/csrc/ops/repeat.cpp
@@ -17,7 +17,7 @@ xla::Shape NodeOutputShape(const Value& input,
     XLA_CHECK_EQ(operands.size(), 1);
     return BuildRepeat(operands[0], repeats);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -29,7 +29,7 @@ Repeat::Repeat(const Value& input, std::vector<int64_t> repeats)
       repeats_(std::move(repeats)) {}
 
 NodePtr Repeat::Clone(OpList operands) const {
-  return MakeNode<Repeat>(operands.at(0), repeats_);
+  return ir::MakeNode<Repeat>(operands.at(0), repeats_);
 }
 
 XlaOpVector Repeat::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/replication_pad.cpp
+++ b/torch_xla/csrc/ops/replication_pad.cpp
@@ -16,7 +16,7 @@ xla::Shape NodeOutputShape(const Value& input,
   auto shape_fn = [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildReplicationPad(operands[0], padding);
   };
-  return InferOutputShape({input.shape()}, shape_fn);
+  return InferOutputShape({input.xla_shape()}, shape_fn);
 }
 
 }  // namespace
@@ -28,7 +28,7 @@ ReplicationPad::ReplicationPad(const Value& input, std::vector<int64_t> padding)
       padding_(std::move(padding)) {}
 
 NodePtr ReplicationPad::Clone(OpList operands) const {
-  return MakeNode<ReplicationPad>(operands.at(0), padding_);
+  return ir::MakeNode<ReplicationPad>(operands.at(0), padding_);
 }
 
 XlaOpVector ReplicationPad::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/replication_pad_backward.cpp
+++ b/torch_xla/csrc/ops/replication_pad_backward.cpp
@@ -17,7 +17,7 @@ xla::Shape NodeOutputShape(const Value& grad_output, const Value& input,
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildReplicationPadBackward(operands[0], operands[1], padding);
   };
-  return InferOutputShape({grad_output.shape(), input.shape()},
+  return InferOutputShape({grad_output.xla_shape(), input.xla_shape()},
                           lower_for_shape_fn);
 }
 
@@ -32,8 +32,8 @@ ReplicationPadBackward::ReplicationPadBackward(const Value& grad_output,
       padding_(std::move(padding)) {}
 
 NodePtr ReplicationPadBackward::Clone(OpList operands) const {
-  return MakeNode<ReplicationPadBackward>(operands.at(0), operands.at(1),
-                                          padding_);
+  return ir::MakeNode<ReplicationPadBackward>(operands.at(0), operands.at(1),
+                                              padding_);
 }
 
 XlaOpVector ReplicationPadBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/resize.cpp
+++ b/torch_xla/csrc/ops/resize.cpp
@@ -11,7 +11,7 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& input, absl::Span<const int64_t> size) {
-  return xla::ShapeUtil::MakeShape(input.shape().element_type(), size);
+  return xla::ShapeUtil::MakeShape(input.xla_shape().element_type(), size);
 }
 
 }  // namespace
@@ -23,7 +23,7 @@ Resize::Resize(const Value& input, std::vector<int64_t> size)
       size_(std::move(size)) {}
 
 NodePtr Resize::Clone(OpList operands) const {
-  return MakeNode<Resize>(operands.at(0), size_);
+  return ir::MakeNode<Resize>(operands.at(0), size_);
 }
 
 XlaOpVector Resize::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/rrelu_with_noise.cpp
+++ b/torch_xla/csrc/ops/rrelu_with_noise.cpp
@@ -13,7 +13,8 @@ RreluWithNoise::RreluWithNoise(const Value& input, const Value& seed,
                                const at::Scalar& lower, const at::Scalar& upper,
                                bool training)
     : Node(torch::lazy::OpKind(at::aten::rrelu_with_noise), {input, seed},
-           xla::ShapeUtil::MakeTupleShape({input.shape(), input.shape()}),
+           xla::ShapeUtil::MakeTupleShape(
+               {input.xla_shape(), input.xla_shape()}),
            /*num_outputs=*/2,
            torch::lazy::MHash(ScalarHash(lower), ScalarHash(upper), training)),
       lower_(std::move(lower)),
@@ -21,8 +22,8 @@ RreluWithNoise::RreluWithNoise(const Value& input, const Value& seed,
       training_(training) {}
 
 NodePtr RreluWithNoise::Clone(OpList operands) const {
-  return MakeNode<RreluWithNoise>(operands.at(0), operands.at(1), lower_,
-                                  upper_, training_);
+  return ir::MakeNode<RreluWithNoise>(operands.at(0), operands.at(1), lower_,
+                                      upper_, training_);
 }
 
 XlaOpVector RreluWithNoise::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/rrelu_with_noise_backward.cpp
+++ b/torch_xla/csrc/ops/rrelu_with_noise_backward.cpp
@@ -12,7 +12,7 @@ RreluWithNoiseBackward::RreluWithNoiseBackward(
     const Value& grad_output, const Value& input, const Value& noise,
     const at::Scalar& lower, const at::Scalar& upper, bool training)
     : Node(torch::lazy::OpKind(at::aten::rrelu_with_noise_backward),
-           {grad_output, input, noise}, input.shape(),
+           {grad_output, input, noise}, input.xla_shape(),
            /*num_outputs=*/1,
            torch::lazy::MHash(ScalarHash(lower), ScalarHash(upper), training)),
       lower_(std::move(lower)),
@@ -20,9 +20,9 @@ RreluWithNoiseBackward::RreluWithNoiseBackward(
       training_(training) {}
 
 NodePtr RreluWithNoiseBackward::Clone(OpList operands) const {
-  return MakeNode<RreluWithNoiseBackward>(operands.at(0), operands.at(1),
-                                          operands.at(2), lower_, upper_,
-                                          training_);
+  return ir::MakeNode<RreluWithNoiseBackward>(operands.at(0), operands.at(1),
+                                              operands.at(2), lower_, upper_,
+                                              training_);
 }
 
 XlaOpVector RreluWithNoiseBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/scatter.cpp
+++ b/torch_xla/csrc/ops/scatter.cpp
@@ -10,13 +10,13 @@ namespace ops {
 Scatter::Scatter(const Value& input, const Value& index, const Value& src,
                  int64_t dim)
     : Node(torch::lazy::OpKind(at::aten::scatter), {input, index, src},
-           input.shape(),
+           input.xla_shape(),
            /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}
 
 NodePtr Scatter::Clone(OpList operands) const {
-  return MakeNode<Scatter>(operands.at(0), operands.at(1), operands.at(2),
-                           dim_);
+  return ir::MakeNode<Scatter>(operands.at(0), operands.at(1), operands.at(2),
+                               dim_);
 }
 
 XlaOpVector Scatter::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/scatter_add.cpp
+++ b/torch_xla/csrc/ops/scatter_add.cpp
@@ -12,13 +12,13 @@ namespace ops {
 ScatterAdd::ScatterAdd(const Value& input, const Value& index, const Value& src,
                        int64_t dim)
     : Node(torch::lazy::OpKind(at::aten::scatter_add), {input, index, src},
-           input.shape(),
+           input.xla_shape(),
            /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}
 
 NodePtr ScatterAdd::Clone(OpList operands) const {
-  return MakeNode<ScatterAdd>(operands.at(0), operands.at(1), operands.at(2),
-                              dim_);
+  return ir::MakeNode<ScatterAdd>(operands.at(0), operands.at(1),
+                                  operands.at(2), dim_);
 }
 
 XlaOpVector ScatterAdd::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/select.cpp
+++ b/torch_xla/csrc/ops/select.cpp
@@ -12,7 +12,7 @@ Select::Select(const Value& input, int64_t dim, int64_t start, int64_t end,
                int64_t stride)
     : Node(xla_select, {input},
            [&]() {
-             return MakeSelectShape(input.shape(), dim, start, end, stride);
+             return MakeSelectShape(input.xla_shape(), dim, start, end, stride);
            },
            /*num_outputs=*/1, torch::lazy::MHash(dim, start, end, stride)),
       dim_(dim),
@@ -21,7 +21,7 @@ Select::Select(const Value& input, int64_t dim, int64_t start, int64_t end,
       stride_(stride) {}
 
 NodePtr Select::Clone(OpList operands) const {
-  return MakeNode<Select>(operands.at(0), dim_, start_, end_, stride_);
+  return ir::MakeNode<Select>(operands.at(0), dim_, start_, end_, stride_);
 }
 
 XlaOpVector Select::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/sgd_optimizer_step.cpp
+++ b/torch_xla/csrc/ops/sgd_optimizer_step.cpp
@@ -10,8 +10,9 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& step, const Value& param) {
-  return xla::ShapeUtil::MakeTupleShape(
-      {/*step=*/step.shape(), /*param=*/param.shape(), /*buf=*/param.shape()});
+  return xla::ShapeUtil::MakeTupleShape({/*step=*/step.xla_shape(),
+                                         /*param=*/param.xla_shape(),
+                                         /*buf=*/param.xla_shape()});
 }
 
 }  // namespace
@@ -34,7 +35,7 @@ SgdOptimizerStep::SgdOptimizerStep(const Value& found_inf, const Value& step,
       use_nesterov_(use_nesterov) {}
 
 NodePtr SgdOptimizerStep::Clone(OpList operands) const {
-  return MakeNode<SgdOptimizerStep>(
+  return ir::MakeNode<SgdOptimizerStep>(
       operands.at(0), operands.at(1), operands.at(2), operands.at(3),
       operands.at(4), operands.at(5), operands.at(6), operands.at(7),
       operands.at(8), use_weight_decay_, use_momentum_, use_nesterov_);

--- a/torch_xla/csrc/ops/shrink_backward.cpp
+++ b/torch_xla/csrc/ops/shrink_backward.cpp
@@ -12,7 +12,7 @@ namespace ops {
 ShrinkBackward::ShrinkBackward(torch::lazy::OpKind kind,
                                const Value& grad_output, const Value& input,
                                const at::Scalar& lambda)
-    : Node(kind, {grad_output, input}, input.shape(), /*num_outputs=*/1,
+    : Node(kind, {grad_output, input}, input.xla_shape(), /*num_outputs=*/1,
            ScalarHash(lambda)),
       lambda_(std::move(lambda)) {}
 

--- a/torch_xla/csrc/ops/softmax.cpp
+++ b/torch_xla/csrc/ops/softmax.cpp
@@ -22,9 +22,9 @@ xla::Shape NodeOutputShape(const Value& input,
                            const c10::optional<at::ScalarType>& dtype) {
   if (dtype) {
     return xla::ShapeUtil::ChangeElementType(
-        input.shape(), MakeXlaPrimitiveType(*dtype, /*device=*/nullptr));
+        input.xla_shape(), MakeXlaPrimitiveType(*dtype, /*device=*/nullptr));
   }
-  return input.shape();
+  return input.xla_shape();
 }
 
 }  // namespace
@@ -39,7 +39,7 @@ Softmax::Softmax(const Value& input, int64_t dim,
       dtype_(dtype) {}
 
 NodePtr Softmax::Clone(OpList operands) const {
-  return MakeNode<Softmax>(operands.at(0), dim_, dtype_);
+  return ir::MakeNode<Softmax>(operands.at(0), dim_, dtype_);
 }
 
 XlaOpVector Softmax::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/softmax_backward.cpp
+++ b/torch_xla/csrc/ops/softmax_backward.cpp
@@ -12,12 +12,12 @@ namespace ops {
 SoftmaxBackward::SoftmaxBackward(const Value& grad_output, const Value& output,
                                  int64_t dim)
     : Node(torch::lazy::OpKind(at::aten::_softmax_backward_data),
-           {grad_output, output}, grad_output.shape(),
+           {grad_output, output}, grad_output.xla_shape(),
            /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}
 
 NodePtr SoftmaxBackward::Clone(OpList operands) const {
-  return MakeNode<SoftmaxBackward>(operands.at(0), operands.at(1), dim_);
+  return ir::MakeNode<SoftmaxBackward>(operands.at(0), operands.at(1), dim_);
 }
 
 XlaOpVector SoftmaxBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/softshrink.cpp
+++ b/torch_xla/csrc/ops/softshrink.cpp
@@ -10,7 +10,8 @@ namespace ir {
 namespace ops {
 
 Softshrink::Softshrink(const Value& input, const at::Scalar& lambda)
-    : Node(torch::lazy::OpKind(at::aten::softshrink), {input}, input.shape(),
+    : Node(torch::lazy::OpKind(at::aten::softshrink), {input},
+           input.xla_shape(),
            /*num_outputs=*/1, ScalarHash(lambda)),
       lambda_(std::move(lambda)) {}
 
@@ -21,7 +22,7 @@ std::string Softshrink::ToString() const {
 }
 
 NodePtr Softshrink::Clone(OpList operands) const {
-  return MakeNode<Softshrink>(operands.at(0), lambda_);
+  return ir::MakeNode<Softshrink>(operands.at(0), lambda_);
 }
 
 XlaOpVector Softshrink::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/split.cpp
+++ b/torch_xla/csrc/ops/split.cpp
@@ -19,7 +19,7 @@ xla::Shape NodeOutputShape(const Value& input,
     return xla::Tuple(operands[0].builder(),
                       BuildSplit(operands[0], split_sizes, dim));
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -27,13 +27,13 @@ xla::Shape NodeOutputShape(const Value& input,
 Split::Split(const Value& input, std::vector<int64_t> split_sizes, int64_t dim)
     : Node(torch::lazy::OpKind(at::aten::split), {input},
            [&]() { return NodeOutputShape(input, split_sizes, dim); },
-           ComputeSplitCount(input.shape().dimensions(dim), split_sizes),
+           ComputeSplitCount(input.xla_shape().dimensions(dim), split_sizes),
            torch::lazy::MHash(split_sizes, dim)),
       split_sizes_(std::move(split_sizes)),
       dim_(dim) {}
 
 NodePtr Split::Clone(OpList operands) const {
-  return MakeNode<Split>(operands.at(0), split_sizes_, dim_);
+  return ir::MakeNode<Split>(operands.at(0), split_sizes_, dim_);
 }
 
 XlaOpVector Split::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/squeeze.cpp
+++ b/torch_xla/csrc/ops/squeeze.cpp
@@ -24,7 +24,7 @@ xla::Shape NodeOutputShape(const Value& input, int dim) {
     XLA_CHECK_EQ(operands.size(), 1);
     return LowerSqueeze(operands[0], dim);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -36,7 +36,7 @@ Squeeze::Squeeze(const Value& input, int dim)
       dim_(dim) {}
 
 NodePtr Squeeze::Clone(OpList operands) const {
-  return MakeNode<Squeeze>(operands.at(0), dim_);
+  return ir::MakeNode<Squeeze>(operands.at(0), dim_);
 }
 
 XlaOpVector Squeeze::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/stack.cpp
+++ b/torch_xla/csrc/ops/stack.cpp
@@ -18,7 +18,7 @@ xla::Shape NodeOutputShape(absl::Span<const ir::Value> values, int64_t dim) {
   std::vector<xla::Shape> shapes;
   shapes.reserve(values.size());
   for (auto& value : values) {
-    shapes.push_back(value.shape());
+    shapes.push_back(value.xla_shape());
   }
   return InferOutputShape(shapes, lower_for_shape_fn);
 }
@@ -32,7 +32,7 @@ Stack::Stack(absl::Span<const ir::Value> values, int64_t dim)
       dim_(dim) {}
 
 NodePtr Stack::Clone(OpList operands) const {
-  return MakeNode<Stack>(operands, dim_);
+  return ir::MakeNode<Stack>(operands, dim_);
 }
 
 XlaOpVector Stack::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/std.cpp
+++ b/torch_xla/csrc/ops/std.cpp
@@ -17,7 +17,7 @@ xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
     return BuildStdDeviation(operands[0], dimensions, keep_reduced_dimensions,
                              correction);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -36,8 +36,8 @@ Std::Std(const Value& input, std::vector<int64_t> dimensions,
       correction_(correction) {}
 
 NodePtr Std::Clone(OpList operands) const {
-  return MakeNode<Std>(operands.at(0), dimensions_, keep_reduced_dimensions_,
-                       correction_);
+  return ir::MakeNode<Std>(operands.at(0), dimensions_,
+                           keep_reduced_dimensions_, correction_);
 }
 
 XlaOpVector Std::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/std_mean.cpp
+++ b/torch_xla/csrc/ops/std_mean.cpp
@@ -20,7 +20,7 @@ xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
         BuildMean(operands[0], dimensions, keep_reduced_dimensions);
     return xla::Tuple(operands[0].builder(), {std, mean});
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn_std_mean);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn_std_mean);
 }
 
 }  // namespace
@@ -39,8 +39,8 @@ StdMean::StdMean(const Value& input, std::vector<int64_t> dimensions,
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
 NodePtr StdMean::Clone(OpList operands) const {
-  return MakeNode<StdMean>(operands.at(0), dimensions_, correction_,
-                           keep_reduced_dimensions_);
+  return ir::MakeNode<StdMean>(operands.at(0), dimensions_, correction_,
+                               keep_reduced_dimensions_);
 }
 
 XlaOpVector StdMean::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/sum.cpp
+++ b/torch_xla/csrc/ops/sum.cpp
@@ -30,7 +30,7 @@ xla::Shape NodeOutputShape(const Value& input,
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return LowerSum(operands[0], dimensions, keep_reduced_dimensions, dtype);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -50,8 +50,8 @@ Sum::Sum(const Value& input, std::vector<int64_t> dimensions,
       dtype_(dtype) {}
 
 NodePtr Sum::Clone(OpList operands) const {
-  return MakeNode<Sum>(operands.at(0), dimensions_, keep_reduced_dimensions_,
-                       dtype_);
+  return ir::MakeNode<Sum>(operands.at(0), dimensions_,
+                           keep_reduced_dimensions_, dtype_);
 }
 
 XlaOpVector Sum::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/svd.cpp
+++ b/torch_xla/csrc/ops/svd.cpp
@@ -42,7 +42,7 @@ std::vector<xla::XlaOp> LowerSVD(xla::XlaOp input, bool some, bool compute_uv) {
 }
 
 xla::Shape NodeOutputShape(const Value& input, bool some, bool compute_uv) {
-  const xla::Shape& input_shape = input.shape();
+  const xla::Shape& input_shape = input.xla_shape();
   XLA_CHECK_GE(input_shape.rank(), 2) << input_shape;
   // The input tensor is ...,M,N
   int64_t m_dim = input_shape.dimensions(input_shape.rank() - 2);
@@ -75,7 +75,7 @@ SVD::SVD(const Value& input, bool some, bool compute_uv)
       compute_uv_(compute_uv) {}
 
 NodePtr SVD::Clone(OpList operands) const {
-  return MakeNode<SVD>(operands.at(0), some_, compute_uv_);
+  return ir::MakeNode<SVD>(operands.at(0), some_, compute_uv_);
 }
 
 XlaOpVector SVD::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/symeig.cpp
+++ b/torch_xla/csrc/ops/symeig.cpp
@@ -27,7 +27,7 @@ std::vector<xla::XlaOp> LowerSymEig(xla::XlaOp input, bool eigenvectors,
 }
 
 xla::Shape NodeOutputShape(const Value& input, bool eigenvectors, bool lower) {
-  const xla::Shape& input_shape = input.shape();
+  const xla::Shape& input_shape = input.xla_shape();
   XLA_CHECK_GE(input_shape.rank(), 2) << input_shape;
   // W is ..., M
   xla::Shape wshape(input_shape);
@@ -53,7 +53,7 @@ SymEig::SymEig(const Value& input, bool eigenvectors, bool lower)
       lower_(lower) {}
 
 NodePtr SymEig::Clone(OpList operands) const {
-  return MakeNode<SymEig>(operands.at(0), eigenvectors_, lower_);
+  return ir::MakeNode<SymEig>(operands.at(0), eigenvectors_, lower_);
 }
 
 XlaOpVector SymEig::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/threshold.cpp
+++ b/torch_xla/csrc/ops/threshold.cpp
@@ -8,13 +8,13 @@ namespace ir {
 namespace ops {
 
 Threshold::Threshold(const Value& input, float threshold, float value)
-    : Node(torch::lazy::OpKind(at::aten::threshold), {input}, input.shape(),
+    : Node(torch::lazy::OpKind(at::aten::threshold), {input}, input.xla_shape(),
            /*num_outputs=*/1, torch::lazy::MHash(threshold, value)),
       threshold_(threshold),
       value_(value) {}
 
 NodePtr Threshold::Clone(OpList operands) const {
-  return MakeNode<Threshold>(operands.at(0), threshold_, value_);
+  return ir::MakeNode<Threshold>(operands.at(0), threshold_, value_);
 }
 
 XlaOpVector Threshold::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/threshold_backward.cpp
+++ b/torch_xla/csrc/ops/threshold_backward.cpp
@@ -10,13 +10,13 @@ namespace ops {
 ThresholdBackward::ThresholdBackward(const Value& grad_output,
                                      const Value& input, float threshold)
     : Node(torch::lazy::OpKind(at::aten::threshold_backward),
-           {grad_output, input}, input.shape(), /*num_outputs=*/1,
+           {grad_output, input}, input.xla_shape(), /*num_outputs=*/1,
            torch::lazy::MHash(threshold)),
       threshold_(threshold) {}
 
 NodePtr ThresholdBackward::Clone(OpList operands) const {
-  return MakeNode<ThresholdBackward>(operands.at(0), operands.at(1),
-                                     threshold_);
+  return ir::MakeNode<ThresholdBackward>(operands.at(0), operands.at(1),
+                                         threshold_);
 }
 
 XlaOpVector ThresholdBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/topk.cpp
+++ b/torch_xla/csrc/ops/topk.cpp
@@ -16,7 +16,7 @@ xla::Shape NodeOutputShape(const Value& input, int64_t k, int64_t dim,
     return xla::Tuple(operands[0].builder(),
                       CreateTopK(operands[0], k, dim, largest, stable));
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -36,7 +36,8 @@ TopK::TopK(const Value& input, int64_t k, int64_t dim, bool largest,
       stable_(stable) {}
 
 NodePtr TopK::Clone(OpList operands) const {
-  return MakeNode<TopK>(operands.at(0), k_, dim_, largest_, sorted_, stable_);
+  return ir::MakeNode<TopK>(operands.at(0), k_, dim_, largest_, sorted_,
+                            stable_);
 }
 
 XlaOpVector TopK::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/triangular_solve.cpp
+++ b/torch_xla/csrc/ops/triangular_solve.cpp
@@ -66,7 +66,7 @@ std::vector<xla::XlaOp> LowerTriangularSolve(xla::XlaOp rhs, xla::XlaOp lhs,
 
 xla::Shape NodeOutputShape(const Value& rhs, const Value& lhs) {
   std::pair<xla::Shape, xla::Shape> broadcasted_shapes =
-      InferTriangularSolveShape(rhs.shape(), lhs.shape());
+      InferTriangularSolveShape(rhs.xla_shape(), lhs.xla_shape());
   return xla::ShapeUtil::MakeTupleShape(
       {broadcasted_shapes.first, broadcasted_shapes.second});
 }
@@ -86,8 +86,9 @@ TriangularSolve::TriangularSolve(const Value& rhs, const Value& lhs,
       unit_diagonal_(unit_diagonal) {}
 
 NodePtr TriangularSolve::Clone(OpList operands) const {
-  return MakeNode<TriangularSolve>(operands.at(0), operands.at(1), left_side_,
-                                   lower_, transpose_, unit_diagonal_);
+  return ir::MakeNode<TriangularSolve>(operands.at(0), operands.at(1),
+                                       left_side_, lower_, transpose_,
+                                       unit_diagonal_);
 }
 
 XlaOpVector TriangularSolve::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/tril.cpp
+++ b/torch_xla/csrc/ops/tril.cpp
@@ -8,12 +8,12 @@ namespace ir {
 namespace ops {
 
 Tril::Tril(const Value& input, int64_t diagonal)
-    : Node(torch::lazy::OpKind(at::aten::tril), {input}, input.shape(),
+    : Node(torch::lazy::OpKind(at::aten::tril), {input}, input.xla_shape(),
            /*num_outputs=*/1, torch::lazy::MHash(diagonal)),
       diagonal_(diagonal) {}
 
 NodePtr Tril::Clone(OpList operands) const {
-  return MakeNode<Tril>(operands.at(0), diagonal_);
+  return ir::MakeNode<Tril>(operands.at(0), diagonal_);
 }
 
 XlaOpVector Tril::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/triu.cpp
+++ b/torch_xla/csrc/ops/triu.cpp
@@ -8,12 +8,12 @@ namespace ir {
 namespace ops {
 
 Triu::Triu(const Value& input, int64_t diagonal)
-    : Node(torch::lazy::OpKind(at::aten::triu), {input}, input.shape(),
+    : Node(torch::lazy::OpKind(at::aten::triu), {input}, input.xla_shape(),
            /*num_outputs=*/1, torch::lazy::MHash(diagonal)),
       diagonal_(diagonal) {}
 
 NodePtr Triu::Clone(OpList operands) const {
-  return MakeNode<Triu>(operands.at(0), diagonal_);
+  return ir::MakeNode<Triu>(operands.at(0), diagonal_);
 }
 
 XlaOpVector Triu::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/unselect.cpp
+++ b/torch_xla/csrc/ops/unselect.cpp
@@ -13,7 +13,7 @@ namespace ops {
 
 Unselect::Unselect(const Value& target, const Value& source, int64_t dim,
                    int64_t start, int64_t end, int64_t stride)
-    : Node(xla_unselect, {target, source}, target.shape(),
+    : Node(xla_unselect, {target, source}, target.xla_shape(),
            /*num_outputs=*/1, torch::lazy::MHash(dim, start, end, stride)),
       dim_(dim),
       start_(start),
@@ -21,8 +21,8 @@ Unselect::Unselect(const Value& target, const Value& source, int64_t dim,
       stride_(stride) {}
 
 NodePtr Unselect::Clone(OpList operands) const {
-  return MakeNode<Unselect>(operands.at(0), operands.at(1), dim_, start_, end_,
-                            stride_);
+  return ir::MakeNode<Unselect>(operands.at(0), operands.at(1), dim_, start_,
+                                end_, stride_);
 }
 
 XlaOpVector Unselect::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/unsqueeze.cpp
+++ b/torch_xla/csrc/ops/unsqueeze.cpp
@@ -9,7 +9,7 @@ namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const Value& input, int dim) {
-  const xla::Shape& shape = input.shape();
+  const xla::Shape& shape = input.xla_shape();
   auto dimensions = BuildUnsqueezeDimensions(shape.dimensions(), dim);
   return xla::ShapeUtil::MakeShape(shape.element_type(), dimensions);
 }
@@ -23,7 +23,7 @@ Unsqueeze::Unsqueeze(const Value& input, int dim)
       dim_(dim) {}
 
 NodePtr Unsqueeze::Clone(OpList operands) const {
-  return MakeNode<Unsqueeze>(operands.at(0), dim_);
+  return ir::MakeNode<Unsqueeze>(operands.at(0), dim_);
 }
 
 XlaOpVector Unsqueeze::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/update_slice.cpp
+++ b/torch_xla/csrc/ops/update_slice.cpp
@@ -18,7 +18,8 @@ xla::Shape NodeOutputShape(const Value& input, const Value& source,
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildUpdateSlice(operands[0], operands[1], base_indices);
   };
-  return InferOutputShape({input.shape(), source.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape(), source.xla_shape()},
+                          lower_for_shape_fn);
 }
 
 }  // namespace
@@ -31,7 +32,8 @@ UpdateSlice::UpdateSlice(const Value& input, const Value& source,
       base_indices_(base_indices.begin(), base_indices.end()) {}
 
 NodePtr UpdateSlice::Clone(OpList operands) const {
-  return MakeNode<UpdateSlice>(operands.at(0), operands.at(1), base_indices_);
+  return ir::MakeNode<UpdateSlice>(operands.at(0), operands.at(1),
+                                   base_indices_);
 }
 
 XlaOpVector UpdateSlice::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/upsample_bilinear2d.cpp
+++ b/torch_xla/csrc/ops/upsample_bilinear2d.cpp
@@ -14,15 +14,16 @@ UpsampleBilinear::UpsampleBilinear(const Value& input,
                                    bool align_corners)
     : Node(torch::lazy::OpKind(at::aten::upsample_bilinear2d), {input},
            [&]() {
-             return resize::GetForwardOutputShape2d(input.shape(), output_size);
+             return resize::GetForwardOutputShape2d(input.xla_shape(),
+                                                    output_size);
            },
            /*num_outputs=*/1, torch::lazy::MHash(output_size, align_corners)),
       output_size_(std::move(output_size)),
       align_corners_(align_corners) {}
 
 NodePtr UpsampleBilinear::Clone(OpList operands) const {
-  return MakeNode<UpsampleBilinear>(operands.at(0), output_size_,
-                                    align_corners_);
+  return ir::MakeNode<UpsampleBilinear>(operands.at(0), output_size_,
+                                        align_corners_);
 }
 
 XlaOpVector UpsampleBilinear::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/upsample_bilinear2d_backward.cpp
+++ b/torch_xla/csrc/ops/upsample_bilinear2d_backward.cpp
@@ -14,7 +14,8 @@ UpsampleBilinearBackward::UpsampleBilinearBackward(
     std::vector<int64_t> input_size, bool align_corners)
     : Node(torch::lazy::OpKind(at::aten::upsample_bilinear2d_backward), {input},
            [&]() {
-             return resize::GetBackwardOutputShape2d(input.shape(), input_size);
+             return resize::GetBackwardOutputShape2d(input.xla_shape(),
+                                                     input_size);
            },
            /*num_outputs=*/1,
            torch::lazy::MHash(output_size, input_size, align_corners)),
@@ -23,8 +24,8 @@ UpsampleBilinearBackward::UpsampleBilinearBackward(
       align_corners_(align_corners) {}
 
 NodePtr UpsampleBilinearBackward::Clone(OpList operands) const {
-  return MakeNode<UpsampleBilinearBackward>(operands.at(0), output_size_,
-                                            input_size_, align_corners_);
+  return ir::MakeNode<UpsampleBilinearBackward>(operands.at(0), output_size_,
+                                                input_size_, align_corners_);
 }
 
 XlaOpVector UpsampleBilinearBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/upsample_nearest2d.cpp
+++ b/torch_xla/csrc/ops/upsample_nearest2d.cpp
@@ -13,13 +13,14 @@ UpsampleNearest::UpsampleNearest(const Value& input,
                                  std::vector<int64_t> output_size)
     : Node(torch::lazy::OpKind(at::aten::upsample_nearest2d), {input},
            [&]() {
-             return resize::GetForwardOutputShape2d(input.shape(), output_size);
+             return resize::GetForwardOutputShape2d(input.xla_shape(),
+                                                    output_size);
            },
            /*num_outputs=*/1, torch::lazy::MHash(output_size)),
       output_size_(std::move(output_size)) {}
 
 NodePtr UpsampleNearest::Clone(OpList operands) const {
-  return MakeNode<UpsampleNearest>(operands.at(0), output_size_);
+  return ir::MakeNode<UpsampleNearest>(operands.at(0), output_size_);
 }
 
 XlaOpVector UpsampleNearest::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/upsample_nearest2d_backward.cpp
+++ b/torch_xla/csrc/ops/upsample_nearest2d_backward.cpp
@@ -14,15 +14,16 @@ UpsampleNearestBackward::UpsampleNearestBackward(
     std::vector<int64_t> input_size)
     : Node(torch::lazy::OpKind(at::aten::upsample_nearest2d_backward), {input},
            [&]() {
-             return resize::GetBackwardOutputShape2d(input.shape(), input_size);
+             return resize::GetBackwardOutputShape2d(input.xla_shape(),
+                                                     input_size);
            },
            /*num_outputs=*/1, torch::lazy::MHash(output_size, input_size)),
       output_size_(std::move(output_size)),
       input_size_(std::move(input_size)) {}
 
 NodePtr UpsampleNearestBackward::Clone(OpList operands) const {
-  return MakeNode<UpsampleNearestBackward>(operands.at(0), output_size_,
-                                           input_size_);
+  return ir::MakeNode<UpsampleNearestBackward>(operands.at(0), output_size_,
+                                               input_size_);
 }
 
 XlaOpVector UpsampleNearestBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/var.cpp
+++ b/torch_xla/csrc/ops/var.cpp
@@ -20,7 +20,7 @@ xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
     return BuildVar(operands[0], dimensions, correction,
                     keep_reduced_dimensions);
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -37,8 +37,8 @@ Var::Var(const Value& input, std::vector<int64_t> dimensions,
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
 NodePtr Var::Clone(OpList operands) const {
-  return MakeNode<Var>(operands.at(0), dimensions_, correction_,
-                       keep_reduced_dimensions_);
+  return ir::MakeNode<Var>(operands.at(0), dimensions_, correction_,
+                           keep_reduced_dimensions_);
 }
 
 XlaOpVector Var::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/var_mean.cpp
+++ b/torch_xla/csrc/ops/var_mean.cpp
@@ -23,7 +23,7 @@ xla::Shape NodeOutputShape(const Value& input, std::vector<int64_t>& dimensions,
         BuildMean(operands[0], dimensions, keep_reduced_dimensions);
     return xla::Tuple(operands[0].builder(), {var, mean});
   };
-  return InferOutputShape({input.shape()}, lower_for_shape_fn);
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace
@@ -42,8 +42,8 @@ VarMean::VarMean(const Value& input, std::vector<int64_t> dimensions,
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
 NodePtr VarMean::Clone(OpList operands) const {
-  return MakeNode<VarMean>(operands.at(0), dimensions_, correction_,
-                           keep_reduced_dimensions_);
+  return ir::MakeNode<VarMean>(operands.at(0), dimensions_, correction_,
+                               keep_reduced_dimensions_);
 }
 
 XlaOpVector VarMean::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/view.cpp
+++ b/torch_xla/csrc/ops/view.cpp
@@ -13,7 +13,7 @@ namespace {
 
 xla::Shape NodeOutputShape(const Value& input,
                            absl::Span<const int64_t> output_sizes) {
-  const xla::Shape& input_shape = input.shape();
+  const xla::Shape& input_shape = input.xla_shape();
   auto info = XlaHelpers::GetDynamicReshapeInfo(input_shape, output_sizes);
   if (info) {
     return std::move(info->output_shape);

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -156,7 +156,7 @@ struct MinMaxValues {
 };
 
 ir::Value MaybeExpand(const ir::Value& input, const xla::Shape& target_shape) {
-  if (input.shape().dimensions() == target_shape.dimensions()) {
+  if (input.xla_shape().dimensions() == target_shape.dimensions()) {
     return input;
   }
   return ir::MakeNode<ir::ops::Expand>(
@@ -288,14 +288,15 @@ ir::Value GetIrValueOrDefault(const XLATensor& input,
 ir::Value GetFloatingIrValue(const XLATensor& input,
                              at::ScalarType float_type) {
   ir::Value input_value = input.GetIrValue();
-  if (xla::primitive_util::IsIntegralType(input_value.shape().element_type())) {
+  if (xla::primitive_util::IsIntegralType(
+          input_value.xla_shape().element_type())) {
     input_value = ir::MakeNode<ir::ops::Cast>(input_value, float_type);
   }
   return input_value;
 }
 
 ir::Value GetBooleanIrValue(ir::Value input_value) {
-  if (input_value.shape().element_type() != xla::PrimitiveType::PRED) {
+  if (input_value.xla_shape().element_type() != xla::PrimitiveType::PRED) {
     input_value =
         ir::MakeNode<ir::ops::Cast>(input_value, xla::PrimitiveType::PRED);
   }
@@ -1209,7 +1210,7 @@ XLATensor XLATensor::div(const XLATensor& input, const XLATensor& other,
     if (logical_element_type.has_value()) {
       xla::PrimitiveType res_intended_type =
           MakeXlaPrimitiveType(*logical_element_type, &input.GetDevice());
-      if (res.shape().element_type() != res_intended_type) {
+      if (res.xla_shape().element_type() != res_intended_type) {
         res = ir::MakeNode<ir::ops::Cast>(res, res_intended_type);
       }
     }
@@ -1231,7 +1232,7 @@ XLATensor XLATensor::div(const XLATensor& input, const at::Scalar& other) {
   }
   ir::Value input_value = GetFloatingIrValue(input, scalar_type);
   ir::Value other_value = GetIrValueForScalar(
-      other, input_value.shape().element_type(), input.GetDevice());
+      other, input_value.xla_shape().element_type(), input.GetDevice());
   return input.CreateFrom(input_value / other_value, scalar_type);
 }
 


### PR DESCRIPTION
Migrate to upstream torch::lazy::Value. 

The only difference from the upstream `torch::lazy::Value` is that we have `xla::Shape`. Since we still need this, we've renamed the existing `shape()` functions to `xla_shape()` (similar to https://github.com/pytorch/xla/pull/3402). 