### PR TITLE
Move device lock before the execution instead of tensor gathering

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -81,14 +81,14 @@ function run_async_rng {
 }
 
 function run_all_tests {
-  #run_dynamic python3 "$CDIR/../../test/test_view_ops.py" "$@" -v TestViewOpsXLA
-  #run_test python3 "$CDIR/../../test/test_torch.py" "$@" -v TestTorchDeviceTypeXLA
-  #run_dynamic python3 "$CDIR/../../test/test_torch.py" "$@" -v TestDevicePrecisionXLA
-  #run_test python3 "$CDIR/../../test/test_torch.py" "$@" -v TestTensorDeviceOpsXLA
-  #run_test python3 "$CDIR/../../test/test_indexing.py" "$@" -v TestIndexingXLA
-  #run_test python3 "$CDIR/../../test/test_indexing.py" "$@" -v NumpyTestsXLA
-  #run_dynamic python3 "$CDIR/../../test/test_nn.py" "$@" -v TestNNDeviceTypeXLA
-  #run_dynamic python3 "$CDIR/../../test/test_type_promotion.py" "$@" -v TestTypePromotionXLA
+  run_dynamic python3 "$CDIR/../../test/test_view_ops.py" "$@" -v TestViewOpsXLA
+  run_test python3 "$CDIR/../../test/test_torch.py" "$@" -v TestTorchDeviceTypeXLA
+  run_dynamic python3 "$CDIR/../../test/test_torch.py" "$@" -v TestDevicePrecisionXLA
+  run_test python3 "$CDIR/../../test/test_torch.py" "$@" -v TestTensorDeviceOpsXLA
+  run_test python3 "$CDIR/../../test/test_indexing.py" "$@" -v TestIndexingXLA
+  run_test python3 "$CDIR/../../test/test_indexing.py" "$@" -v NumpyTestsXLA
+  run_dynamic python3 "$CDIR/../../test/test_nn.py" "$@" -v TestNNDeviceTypeXLA
+  run_dynamic python3 "$CDIR/../../test/test_type_promotion.py" "$@" -v TestTypePromotionXLA
   run_dynamic python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_opbyop python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_eager_debug python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -81,14 +81,14 @@ function run_async_rng {
 }
 
 function run_all_tests {
-  run_dynamic python3 "$CDIR/../../test/test_view_ops.py" "$@" -v TestViewOpsXLA
-  run_test python3 "$CDIR/../../test/test_torch.py" "$@" -v TestTorchDeviceTypeXLA
-  run_dynamic python3 "$CDIR/../../test/test_torch.py" "$@" -v TestDevicePrecisionXLA
-  run_test python3 "$CDIR/../../test/test_torch.py" "$@" -v TestTensorDeviceOpsXLA
-  run_test python3 "$CDIR/../../test/test_indexing.py" "$@" -v TestIndexingXLA
-  run_test python3 "$CDIR/../../test/test_indexing.py" "$@" -v NumpyTestsXLA
-  run_dynamic python3 "$CDIR/../../test/test_nn.py" "$@" -v TestNNDeviceTypeXLA
-  run_dynamic python3 "$CDIR/../../test/test_type_promotion.py" "$@" -v TestTypePromotionXLA
+  #run_dynamic python3 "$CDIR/../../test/test_view_ops.py" "$@" -v TestViewOpsXLA
+  #run_test python3 "$CDIR/../../test/test_torch.py" "$@" -v TestTorchDeviceTypeXLA
+  #run_dynamic python3 "$CDIR/../../test/test_torch.py" "$@" -v TestDevicePrecisionXLA
+  #run_test python3 "$CDIR/../../test/test_torch.py" "$@" -v TestTensorDeviceOpsXLA
+  #run_test python3 "$CDIR/../../test/test_indexing.py" "$@" -v TestIndexingXLA
+  #run_test python3 "$CDIR/../../test/test_indexing.py" "$@" -v NumpyTestsXLA
+  #run_dynamic python3 "$CDIR/../../test/test_nn.py" "$@" -v TestNNDeviceTypeXLA
+  #run_dynamic python3 "$CDIR/../../test/test_type_promotion.py" "$@" -v TestTypePromotionXLA
   run_dynamic python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_opbyop python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_eager_debug python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY

--- a/third_party/xla_client/xrt_computation_client.h
+++ b/third_party/xla_client/xrt_computation_client.h
@@ -146,7 +146,8 @@ class XrtComputationClient : public ComputationClient {
 
   struct XrtData : public Data {
     XrtData(std::string device, Shape device_shape)
-        : Data(std::move(device), std::move(device_shape)) {}
+        : Data(std::move(device), std::move(device_shape)),
+          handle_ptr(nullptr) {}
     XrtData(XrtComputationClient* self, std::string device, Shape device_shape,
             int64_t handle)
         : Data(std::move(device), std::move(device_shape)),

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1316,7 +1316,7 @@ XLATensor::PostOrderData XLATensor::RunPostOrder(
   for (auto node : po_data.post_order) {
     const ir::ops::DeviceData* device_data = ir::ops::DeviceData::Cast(node);
     if (device_data != nullptr) {
-      if (device_data->data()->HasValue() == 0) {
+      if (!device_data->data()->HasValue()) {
         TensorCollectionBarrier(coll);
       }
       xla::ComputationClient::Data::OpaqueHandle handle =

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -996,7 +996,8 @@ std::vector<xla::ComputationClient::DataPtr> XLATensor::GatherTensorsXlaData(
 void XLATensor::TensorCollectionBarrier(SyncTensorCollection* coll) {
   std::string invalid_device(
       "Unknown0"); /* Temp solution to idetify unassigned devices */
-  if (coll->device.ToString().compare(invalid_device) == 0 || coll->unlocker.size() > 0) {
+  if (coll->device.ToString().compare(invalid_device) == 0 ||
+      coll->unlocker.size() > 0) {
     return;
   }
   TF_VLOG(4) << "Waiting on device barrier for device " << coll->device

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1302,7 +1302,7 @@ XLATensor::ComputationCache* XLATensor::GetComputationCache() {
 XLATensor::PostOrderData XLATensor::RunPostOrder(
     const std::vector<XLATensor>& tensors, SyncTensorCollection* coll) {
   absl::Span<const size_t> indices = coll->indices;
-  std::vector<const ir::Node*> roots;
+  std::vector<const torch::lazy::Node*> roots;
   roots.reserve(indices.size());
   for (auto index : indices) {
     ir::XlaValue ir_value = tensors.at(index).CurrentIrValue();

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -996,19 +996,17 @@ std::vector<xla::ComputationClient::DataPtr> XLATensor::GatherTensorsXlaData(
 void XLATensor::TensorCollectionBarrier(SyncTensorCollection* coll) {
   std::string invalid_device(
       "Unknown0"); /* Temp solution to idetify unassigned devices */
-  if (coll->device.ToString().compare(invalid_device) == 0) {
+  if (coll->device.ToString().compare(invalid_device) == 0 || coll->unlocker.size() > 0) {
     return;
   }
-  if (coll->unlocker.size() == 0) {
-    TF_VLOG(4) << "Waiting on device barrier for device " << coll->device
-               << " ...";
-    {
-      XLA_TIMED("DeviceLockWait");
-      coll->unlocker = LockDevices({coll->device});
-    }
-    TF_VLOG(4) << "Waiting on device barrier for device " << coll->device
-               << " done!";
+  TF_VLOG(4) << "Waiting on device barrier for device " << coll->device
+             << " ...";
+  {
+    XLA_TIMED("DeviceLockWait");
+    coll->unlocker = LockDevices({coll->device});
   }
+  TF_VLOG(4) << "Waiting on device barrier for device " << coll->device
+             << " done!";
 }
 
 std::vector<at::Tensor> XLATensor::GetTensorsOpByOp(

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -996,7 +996,7 @@ std::vector<xla::ComputationClient::DataPtr> XLATensor::GatherTensorsXlaData(
 void XLATensor::TensorCollectionBarrier(SyncTensorCollection* coll) {
   static const std::string invalid_device(
       "Unknown0"); /* Temp solution to idetify unassigned devices */
-  if (coll->device.ToString().compare(invalid_device) == 0 ||
+  if (coll->device.toString().compare(invalid_device) == 0 ||
       coll->unlocker.size() > 0) {
     return;
   }

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1287,6 +1287,7 @@ std::shared_ptr<XLATensor::Async> XLATensor::TryRunCachedSync(
   XLA_VALUE_METRIC("TensorsGraphSize", po_data->post_order.size());
   TF_VLOG(5) << "TensorsGraphSize=" << po_data->post_order.size();
 
+  TensorCollectionBarrier(&coll); /* Temp location. Will eventually move inside ScheduleSyncTensorsGraph() */
   return ScheduleSyncTensorsGraph(
       tensors, coll, std::move(po_data->parameters_data),
       coll->device.toString(), std::move(cached_computation));
@@ -1711,7 +1712,6 @@ std::shared_ptr<XLATensor::Async> XLATensor::SyncTensorsGraphInternal(
              << torch::lazy::HashToString(coll.hash);
   std::shared_ptr<Async> async = TryRunCachedSync(tensors, &coll, &po_data);
   if (async != nullptr) {
-    TensorCollectionBarrier(&coll);
     return async;
   }
 

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -994,9 +994,6 @@ std::vector<xla::ComputationClient::DataPtr> XLATensor::GatherTensorsXlaData(
 }
 
 void XLATensor::TensorCollectionBarrier(SyncTensorCollection* coll) {
-  if (coll->indices.empty()) {
-    return;
-  }
   TF_VLOG(4) << "Waiting on device barrier for device " << coll->device
              << " ...";
   {
@@ -1300,8 +1297,9 @@ XLATensor::ComputationCache* XLATensor::GetComputationCache() {
 }
 
 XLATensor::PostOrderData XLATensor::RunPostOrder(
-    const std::vector<XLATensor>& tensors, absl::Span<const size_t> indices) {
-  std::vector<const torch::lazy::Node*> roots;
+    const std::vector<XLATensor>& tensors, SyncTensorCollection* coll) {
+  absl::Span<const size_t> indices = coll->indices;
+  std::vector<const ir::Node*> roots;
   roots.reserve(indices.size());
   for (auto index : indices) {
     ir::XlaValue ir_value = tensors.at(index).CurrentIrValue();
@@ -1311,6 +1309,7 @@ XLATensor::PostOrderData XLATensor::RunPostOrder(
   po_data.post_order = ir::Util::ComputePostOrder(roots, &po_data.emission_map);
   std::unordered_map<xla::ComputationClient::Data::OpaqueHandle, size_t>
       data_handles;
+  TensorCollectionBarrier(coll);
   for (auto node : po_data.post_order) {
     const ir::ops::DeviceData* device_data = ir::ops::DeviceData::Cast(node);
     if (device_data != nullptr) {
@@ -1376,7 +1375,6 @@ std::shared_ptr<XLATensor::Async> XLATensor::ScheduleSyncTensorsGraph(
     ComputationCache::TypePtr cached_computation) {
   tensorflow::profiler::TraceMe activity(
       "ScheduleSyncTensorsGraph", tensorflow::profiler::TraceMeLevel::kInfo);
-  TensorCollectionBarrier(coll);
   std::shared_ptr<Async> async = std::make_shared<Async>(
       coll, std::move(parameters_data), std::move(tensors_data),
       std::move(cached_computation));
@@ -1677,12 +1675,13 @@ std::shared_ptr<XLATensor::Async> XLATensor::SyncTensorsGraphInternal(
       "SyncTensorsGraphInternal", tensorflow::profiler::TraceMeLevel::kInfo);
   SyncTensorCollection coll = CollectSyncTensors(*tensors, config);
   if (coll.indices.empty()) {
+    TensorCollectionBarrier(&coll);
     return nullptr;
   }
+  PostOrderData po_data = RunPostOrder(*tensors, &coll);
   DebugUtil::SaveTensorsGraphInfo("ScheduleSyncTensorsGraph", *tensors,
                                   &coll.indices);
 
-  PostOrderData po_data = RunPostOrder(*tensors, coll.indices);
   coll.hash = torch::lazy::HashCombine(
       coll.hash, torch::lazy::Hash(po_data.parameter_sequence));
   TF_VLOG(4) << "Parameter sequence graph hash "

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -994,6 +994,10 @@ std::vector<xla::ComputationClient::DataPtr> XLATensor::GatherTensorsXlaData(
 }
 
 void XLATensor::TensorCollectionBarrier(SyncTensorCollection* coll) {
+  std::string str1 ("Unknown0"); /* Temp solution to idetify unassigned devices */
+  if (coll->device.ToString().compare(str1) == 0) {
+    return;
+  }
   if (coll->barrier_applied == false) {
     TF_VLOG(4) << "Waiting on device barrier for device " << coll->device
                << " ...";

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -994,18 +994,17 @@ std::vector<xla::ComputationClient::DataPtr> XLATensor::GatherTensorsXlaData(
 }
 
 void XLATensor::TensorCollectionBarrier(SyncTensorCollection* coll) {
-  std::string str1(
+  std::string invalid_device(
       "Unknown0"); /* Temp solution to idetify unassigned devices */
-  if (coll->device.ToString().compare(str1) == 0) {
+  if (coll->device.ToString().compare(invalid_device) == 0) {
     return;
   }
-  if (coll->barrier_applied == false) {
+  if (coll->unlocker.size() == 0) {
     TF_VLOG(4) << "Waiting on device barrier for device " << coll->device
                << " ...";
     {
       XLA_TIMED("DeviceLockWait");
       coll->unlocker = LockDevices({coll->device});
-      coll->barrier_applied = true;
     }
     TF_VLOG(4) << "Waiting on device barrier for device " << coll->device
                << " done!";

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -994,7 +994,8 @@ std::vector<xla::ComputationClient::DataPtr> XLATensor::GatherTensorsXlaData(
 }
 
 void XLATensor::TensorCollectionBarrier(SyncTensorCollection* coll) {
-  std::string str1 ("Unknown0"); /* Temp solution to idetify unassigned devices */
+  std::string str1(
+      "Unknown0"); /* Temp solution to idetify unassigned devices */
   if (coll->device.ToString().compare(str1) == 0) {
     return;
   }

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -1237,11 +1237,12 @@ class XLATensor {
   };
 
   struct SyncTensorCollection {
-    SyncTensorCollection() : hash(0) {}
+    SyncTensorCollection() : hash(0), barrier_applied(false) {}
 
     SyncTensorsConfig config;
     std::vector<size_t> indices;
     torch::lazy::hash_t hash;
+    bool barrier_applied;
     std::vector<xla::util::ExceptionCleanup> unlocker;
     torch::lazy::BackendDevice device;
   };

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -1408,6 +1408,9 @@ class XLATensor {
   static SyncTensorCollection CollectSyncTensors(
       const std::vector<XLATensor>& tensors, const SyncTensorsConfig& config);
 
+  // Waits for this SyncTensorCollection's device barrier and acuire the lock.
+  static void TensorCollectionBarrier(SyncTensorCollection* coll);
+
   // Implementation of the GetTensors() API using the op-by-op executor.
   static std::vector<at::Tensor> GetTensorsOpByOp(
       std::vector<XLATensor>* tensors);

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -1456,7 +1456,7 @@ class XLATensor {
       std::string device, ComputationCache::TypePtr cached_computation);
 
   static PostOrderData RunPostOrder(const std::vector<XLATensor>& tensors,
-                                    absl::Span<const size_t> indices);
+                                    SyncTensorCollection* coll);
 
   static ComputationCache::TypePtr LookupCachedCompile(
       const std::vector<XLATensor>& tensors, const torch::lazy::hash_t& hash);

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -1237,12 +1237,11 @@ class XLATensor {
   };
 
   struct SyncTensorCollection {
-    SyncTensorCollection() : hash(0), barrier_applied(false) {}
+    SyncTensorCollection() : hash(0) {}
 
     SyncTensorsConfig config;
     std::vector<size_t> indices;
     torch::lazy::hash_t hash;
-    bool barrier_applied;
     std::vector<xla::util::ExceptionCleanup> unlocker;
     torch::lazy::BackendDevice device;
   };


### PR DESCRIPTION
This pr ports https://github.com/pytorch/pytorch/pull/74864 to pytorch/xla and should help https://github.com/pytorch/xla/issues/3434. This will need some more testing but the concept seem right to me.


I think this optimization is based on the assumption that even if previous execution does not finish, we still truncate the pending IR of the Tensor to become a BackendData with the correct shape. The actual handle assignment to the BackendData wont' happen until the previous execution finish but that would be OK since we only need true data handle in next execution.

There is a catch that PlaceHolder and Ir truncating only happened when `force_xla_data` is true. AFAICT GetTensor will have `force_xla_data == false` and Synctensor will have `force_xla_data == true`. I think this is fine. If we consider a case of

```
a = torch.tensor(1)
b = torch.tensor(1)
c = a + b
print (c) ---> GetTensor, won't truncate c's IR
d = c + a
xm.mark_step() --> Synctensor, will truncate IR
```

we expect print not changing the IR of c anyway so there is no need to wait for that execution to finish before we finalize our second graph.
