### PR TITLE
Add function in ir.cpp to update upstream env vars

### DIFF
--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -107,6 +107,10 @@ def _prepare_to_exit():
   if int(os.environ.get('PT_XLA_DEBUG', '0')):
     _summarize_fn_tracker()
 
+def _map_xla_env_vars_to_lazy():
+  _XLAC._map_xla_env_vars_to_lazy()
+
 
 atexit.register(_prepare_to_exit)
 _apply_patches()
+_map_xla_env_vars_to_lazy()

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -107,6 +107,7 @@ def _prepare_to_exit():
   if int(os.environ.get('PT_XLA_DEBUG', '0')):
     _summarize_fn_tracker()
 
+
 def _map_xla_env_vars_to_lazy():
   _XLAC._map_xla_env_vars_to_lazy()
 

--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -83,11 +83,6 @@ torch::lazy::hash_t GetOperandHashes(const OpList& operands,
   return hash;
 }
 
-void SetXlaEnvVars() {
-  static bool wants_frames = xla::sys_util::GetEnvBool("XLA_IR_DEBUG", false);
-  FLAGS_torch_lazy_ir_debug = wants_frames;
-}
-
 }  // namespace
 
 bool Use::operator<(const Use& rhs) const {
@@ -129,7 +124,6 @@ Node::Node(torch::lazy::OpKind op, OpList operands, xla::Shape shape,
   for (auto& operand : operands) {
     AddOperand(operand.node, operand.index);
   }
-  SetXlaEnvVars();
 }
 
 Node::Node(torch::lazy::OpKind op, OpList operands,
@@ -147,9 +141,7 @@ Node::Node(torch::lazy::OpKind op, xla::Shape shape, size_t num_outputs,
                         [&](bool /*bakeInSizes*/) -> torch::lazy::hash_t {
                           return GetOpHash(op, shape, hash_seed);
                         }),
-      xla_shape_(std::move(shape)) {
-  SetXlaEnvVars();
-}
+      xla_shape_(std::move(shape)) {}
 
 Node::~Node() {
   for (size_t i = 0; i < operands_as_outputs_.size(); ++i) {

--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -7,6 +7,7 @@
 #include "tensorflow/compiler/xla/xla_client/cache.h"
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/sys_util.h"
+#include "torch/csrc/lazy/core/config.h"
 #include "torch/csrc/lazy/core/hash.h"
 #include "torch/csrc/lazy/core/ir_metadata.h"
 #include "torch/csrc/lazy/python/python_util.h"
@@ -80,6 +81,11 @@ torch::lazy::hash_t GetOperandHashes(const OpList& operands,
     hash = torch::lazy::HashCombine(hash, operand.hash());
   }
   return hash;
+}
+
+void setXlaEnvVars() {
+  static bool wants_frames = xla::sys_util::GetEnvBool("XLA_IR_DEBUG", false);
+  FLAGS_torch_lazy_ir_debug = wants_frames;
 }
 
 }  // namespace
@@ -259,3 +265,11 @@ void ScopePusher::ResetScopes() { ResetScopeContext(); }
 
 }  // namespace ir
 }  // namespace torch_xla
+
+void setXlaEnvVars() {
+  std::cout << "WONJOO: before, FLAGS_torch_lazy_ir_debug=" << FLAGS_torch_lazy_ir_debug << std::endl;
+  static bool wants_frames = xla::sys_util::GetEnvBool("XLA_IR_DEBUG", false);
+  std::cout << "WONJOO: wants_frames=" << wants_frames << std::endl;
+  FLAGS_torch_lazy_ir_debug = wants_frames;
+  std::cout << "WONJOO: after, FLAGS_torch_lazy_ir_debug=" << FLAGS_torch_lazy_ir_debug << std::endl;
+}

--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -83,7 +83,7 @@ torch::lazy::hash_t GetOperandHashes(const OpList& operands,
   return hash;
 }
 
-void setXlaEnvVars() {
+void SetXlaEnvVars() {
   static bool wants_frames = xla::sys_util::GetEnvBool("XLA_IR_DEBUG", false);
   FLAGS_torch_lazy_ir_debug = wants_frames;
 }
@@ -129,6 +129,7 @@ Node::Node(torch::lazy::OpKind op, OpList operands, xla::Shape shape,
   for (auto& operand : operands) {
     AddOperand(operand.node, operand.index);
   }
+  SetXlaEnvVars();
 }
 
 Node::Node(torch::lazy::OpKind op, OpList operands,
@@ -146,7 +147,9 @@ Node::Node(torch::lazy::OpKind op, xla::Shape shape, size_t num_outputs,
                         [&](bool /*bakeInSizes*/) -> torch::lazy::hash_t {
                           return GetOpHash(op, shape, hash_seed);
                         }),
-      xla_shape_(std::move(shape)) {}
+      xla_shape_(std::move(shape)) {
+  SetXlaEnvVars();
+}
 
 Node::~Node() {
   for (size_t i = 0; i < operands_as_outputs_.size(); ++i) {
@@ -265,11 +268,3 @@ void ScopePusher::ResetScopes() { ResetScopeContext(); }
 
 }  // namespace ir
 }  // namespace torch_xla
-
-void setXlaEnvVars() {
-  std::cout << "WONJOO: before, FLAGS_torch_lazy_ir_debug=" << FLAGS_torch_lazy_ir_debug << std::endl;
-  static bool wants_frames = xla::sys_util::GetEnvBool("XLA_IR_DEBUG", false);
-  std::cout << "WONJOO: wants_frames=" << wants_frames << std::endl;
-  FLAGS_torch_lazy_ir_debug = wants_frames;
-  std::cout << "WONJOO: after, FLAGS_torch_lazy_ir_debug=" << FLAGS_torch_lazy_ir_debug << std::endl;
-}


### PR DESCRIPTION
Fixes regression introduced by https://github.com/pytorch/xla/pull/3402 with python frames when `XLA_IR_DEBUG` flag is set. 

With this change, can confirm that python frame is added to the IR:
```
Python 3.8.10 (default, Mar 15 2022, 12:22:08) 
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torch
>>> import torch_xla
>>> a = torch.tensor([1, 2], device="xla:0")
>>> print(torch_xla._XLAC._get_xla_tensors_text([a]))
IR {
  %0 = s64[2]{0} xla::device_data(), location=<module>@<stdin>:1, device=CPU:0, ROOT=0
}
```
