### PR TITLE
Add test_env_var_mapper.py test

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -51,8 +51,8 @@ function run_downcast_bf16 {
   XLA_DOWNCAST_BF16=1 run_test "$@"
 }
 
-function run_xla_ir_debug_enabled {
-  echo "Running with XLA_IR_DEBUG enabled: $@"
+function run_xla_ir_debug {
+  echo "Running with XLA_IR_DEBUG: $@"
   XLA_IR_DEBUG=1 run_test "$@"
 }
 
@@ -114,7 +114,7 @@ function run_all_tests {
   run_xla_backend_mp python3 "$CDIR/test_torch_distributed_all_reduce_xla_backend.py"
   run_xla_backend_mp python3 "$CDIR/test_torch_distributed_multi_all_reduce_xla_backend.py"
   run_xla_backend_mp python3 "$CDIR/test_torch_distributed_reduce_scatter_xla_backend.py"
-  run_xla_ir_debug_enabled python3 "$CDIR/test_env_var_mapper.py"
+  run_xla_ir_debug python3 "$CDIR/test_env_var_mapper.py"
 }
 
 if [ "$LOGFILE" != "" ]; then

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -51,6 +51,11 @@ function run_downcast_bf16 {
   XLA_DOWNCAST_BF16=1 run_test "$@"
 }
 
+function run_xla_ir_debug_enabled {
+  echo "Running with XLA_IR_DEBUG enabled: $@"
+  XLA_IR_DEBUG=1 run_test "$@"
+}
+
 function run_dynamic {
   if [[ "$TPUVM_MODE" == "1" ]]; then
     run_test "$@"
@@ -76,39 +81,40 @@ function run_async_rng {
 }
 
 function run_all_tests {
-  run_dynamic python3 "$CDIR/../../test/test_view_ops.py" "$@" -v TestViewOpsXLA
-  run_test python3 "$CDIR/../../test/test_torch.py" "$@" -v TestTorchDeviceTypeXLA
-  run_dynamic python3 "$CDIR/../../test/test_torch.py" "$@" -v TestDevicePrecisionXLA
-  run_test python3 "$CDIR/../../test/test_torch.py" "$@" -v TestTensorDeviceOpsXLA
-  run_test python3 "$CDIR/../../test/test_indexing.py" "$@" -v TestIndexingXLA
-  run_test python3 "$CDIR/../../test/test_indexing.py" "$@" -v NumpyTestsXLA
-  run_dynamic python3 "$CDIR/../../test/test_nn.py" "$@" -v TestNNDeviceTypeXLA
-  run_dynamic python3 "$CDIR/../../test/test_type_promotion.py" "$@" -v TestTypePromotionXLA
-  run_dynamic python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
-  run_opbyop python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
-  run_eager_debug python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
-  run_async_rng python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
-  run_test python3 "$CDIR/test_mp_replication.py"
-  run_test python3 "$CDIR/test_mp_all_to_all.py"
-  run_test python3 "$CDIR/test_mp_collective_permute.py"
-  run_test python3 "$CDIR/test_mp_all_gather.py"
-  run_test python3 "$CDIR/test_mp_reduce_scatter.py"
-  run_test python3 "$CDIR/test_mp_distributed_mm.py"
-  run_test python3 "$CDIR/test_mp_rendezvous.py"
-  run_test python3 "$CDIR/test_mp_save.py"
-  run_test python3 "$CDIR/test_mp_mesh_reduce.py"
-  run_test python3 "$CDIR/test_mp_sync_batch_norm.py"
-  run_test python3 "$CDIR/test_async_closures.py"
-  run_test python3 "$CDIR/test_xla_dist.py"
-  run_test python3 "$CDIR/test_profiler.py"
-  run_test python3 "$CDIR/test_ops.py"
-  run_downcast_bf16 python3 "$CDIR/test_data_type.py"
-  run_use_bf16 python3 "$CDIR/test_data_type.py"
-  run_test python3 "$CDIR/test_torch_distributed_xla_backend.py"
-  run_xla_backend_mp python3 "$CDIR/test_torch_distributed_all_gather_xla_backend.py"
-  run_xla_backend_mp python3 "$CDIR/test_torch_distributed_all_reduce_xla_backend.py"
-  run_xla_backend_mp python3 "$CDIR/test_torch_distributed_multi_all_reduce_xla_backend.py"
-  run_xla_backend_mp python3 "$CDIR/test_torch_distributed_reduce_scatter_xla_backend.py"
+  # run_dynamic python3 "$CDIR/../../test/test_view_ops.py" "$@" -v TestViewOpsXLA
+  # run_test python3 "$CDIR/../../test/test_torch.py" "$@" -v TestTorchDeviceTypeXLA
+  # run_dynamic python3 "$CDIR/../../test/test_torch.py" "$@" -v TestDevicePrecisionXLA
+  # run_test python3 "$CDIR/../../test/test_torch.py" "$@" -v TestTensorDeviceOpsXLA
+  # run_test python3 "$CDIR/../../test/test_indexing.py" "$@" -v TestIndexingXLA
+  # run_test python3 "$CDIR/../../test/test_indexing.py" "$@" -v NumpyTestsXLA
+  # run_dynamic python3 "$CDIR/../../test/test_nn.py" "$@" -v TestNNDeviceTypeXLA
+  # run_dynamic python3 "$CDIR/../../test/test_type_promotion.py" "$@" -v TestTypePromotionXLA
+  # run_dynamic python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  # run_opbyop python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  # run_eager_debug python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  # run_async_rng python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  # run_test python3 "$CDIR/test_mp_replication.py"
+  # run_test python3 "$CDIR/test_mp_all_to_all.py"
+  # run_test python3 "$CDIR/test_mp_collective_permute.py"
+  # run_test python3 "$CDIR/test_mp_all_gather.py"
+  # run_test python3 "$CDIR/test_mp_reduce_scatter.py"
+  # run_test python3 "$CDIR/test_mp_distributed_mm.py"
+  # run_test python3 "$CDIR/test_mp_rendezvous.py"
+  # run_test python3 "$CDIR/test_mp_save.py"
+  # run_test python3 "$CDIR/test_mp_mesh_reduce.py"
+  # run_test python3 "$CDIR/test_mp_sync_batch_norm.py"
+  # run_test python3 "$CDIR/test_async_closures.py"
+  # run_test python3 "$CDIR/test_xla_dist.py"
+  # run_test python3 "$CDIR/test_profiler.py"
+  # run_test python3 "$CDIR/test_ops.py"
+  # run_downcast_bf16 python3 "$CDIR/test_data_type.py"
+  # run_use_bf16 python3 "$CDIR/test_data_type.py"
+  # run_test python3 "$CDIR/test_torch_distributed_xla_backend.py"
+  # run_xla_backend_mp python3 "$CDIR/test_torch_distributed_all_gather_xla_backend.py"
+  # run_xla_backend_mp python3 "$CDIR/test_torch_distributed_all_reduce_xla_backend.py"
+  # run_xla_backend_mp python3 "$CDIR/test_torch_distributed_multi_all_reduce_xla_backend.py"
+  # run_xla_backend_mp python3 "$CDIR/test_torch_distributed_reduce_scatter_xla_backend.py"
+  run_xla_ir_debug_enabled python3 "$CDIR/test_env_var_mapper.py"
 }
 
 if [ "$LOGFILE" != "" ]; then

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -81,39 +81,39 @@ function run_async_rng {
 }
 
 function run_all_tests {
-  # run_dynamic python3 "$CDIR/../../test/test_view_ops.py" "$@" -v TestViewOpsXLA
-  # run_test python3 "$CDIR/../../test/test_torch.py" "$@" -v TestTorchDeviceTypeXLA
-  # run_dynamic python3 "$CDIR/../../test/test_torch.py" "$@" -v TestDevicePrecisionXLA
-  # run_test python3 "$CDIR/../../test/test_torch.py" "$@" -v TestTensorDeviceOpsXLA
-  # run_test python3 "$CDIR/../../test/test_indexing.py" "$@" -v TestIndexingXLA
-  # run_test python3 "$CDIR/../../test/test_indexing.py" "$@" -v NumpyTestsXLA
-  # run_dynamic python3 "$CDIR/../../test/test_nn.py" "$@" -v TestNNDeviceTypeXLA
-  # run_dynamic python3 "$CDIR/../../test/test_type_promotion.py" "$@" -v TestTypePromotionXLA
-  # run_dynamic python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
-  # run_opbyop python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
-  # run_eager_debug python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
-  # run_async_rng python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
-  # run_test python3 "$CDIR/test_mp_replication.py"
-  # run_test python3 "$CDIR/test_mp_all_to_all.py"
-  # run_test python3 "$CDIR/test_mp_collective_permute.py"
-  # run_test python3 "$CDIR/test_mp_all_gather.py"
-  # run_test python3 "$CDIR/test_mp_reduce_scatter.py"
-  # run_test python3 "$CDIR/test_mp_distributed_mm.py"
-  # run_test python3 "$CDIR/test_mp_rendezvous.py"
-  # run_test python3 "$CDIR/test_mp_save.py"
-  # run_test python3 "$CDIR/test_mp_mesh_reduce.py"
-  # run_test python3 "$CDIR/test_mp_sync_batch_norm.py"
-  # run_test python3 "$CDIR/test_async_closures.py"
-  # run_test python3 "$CDIR/test_xla_dist.py"
-  # run_test python3 "$CDIR/test_profiler.py"
-  # run_test python3 "$CDIR/test_ops.py"
-  # run_downcast_bf16 python3 "$CDIR/test_data_type.py"
-  # run_use_bf16 python3 "$CDIR/test_data_type.py"
-  # run_test python3 "$CDIR/test_torch_distributed_xla_backend.py"
-  # run_xla_backend_mp python3 "$CDIR/test_torch_distributed_all_gather_xla_backend.py"
-  # run_xla_backend_mp python3 "$CDIR/test_torch_distributed_all_reduce_xla_backend.py"
-  # run_xla_backend_mp python3 "$CDIR/test_torch_distributed_multi_all_reduce_xla_backend.py"
-  # run_xla_backend_mp python3 "$CDIR/test_torch_distributed_reduce_scatter_xla_backend.py"
+  run_dynamic python3 "$CDIR/../../test/test_view_ops.py" "$@" -v TestViewOpsXLA
+  run_test python3 "$CDIR/../../test/test_torch.py" "$@" -v TestTorchDeviceTypeXLA
+  run_dynamic python3 "$CDIR/../../test/test_torch.py" "$@" -v TestDevicePrecisionXLA
+  run_test python3 "$CDIR/../../test/test_torch.py" "$@" -v TestTensorDeviceOpsXLA
+  run_test python3 "$CDIR/../../test/test_indexing.py" "$@" -v TestIndexingXLA
+  run_test python3 "$CDIR/../../test/test_indexing.py" "$@" -v NumpyTestsXLA
+  run_dynamic python3 "$CDIR/../../test/test_nn.py" "$@" -v TestNNDeviceTypeXLA
+  run_dynamic python3 "$CDIR/../../test/test_type_promotion.py" "$@" -v TestTypePromotionXLA
+  run_dynamic python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  run_opbyop python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  run_eager_debug python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  run_async_rng python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  run_test python3 "$CDIR/test_mp_replication.py"
+  run_test python3 "$CDIR/test_mp_all_to_all.py"
+  run_test python3 "$CDIR/test_mp_collective_permute.py"
+  run_test python3 "$CDIR/test_mp_all_gather.py"
+  run_test python3 "$CDIR/test_mp_reduce_scatter.py"
+  run_test python3 "$CDIR/test_mp_distributed_mm.py"
+  run_test python3 "$CDIR/test_mp_rendezvous.py"
+  run_test python3 "$CDIR/test_mp_save.py"
+  run_test python3 "$CDIR/test_mp_mesh_reduce.py"
+  run_test python3 "$CDIR/test_mp_sync_batch_norm.py"
+  run_test python3 "$CDIR/test_async_closures.py"
+  run_test python3 "$CDIR/test_xla_dist.py"
+  run_test python3 "$CDIR/test_profiler.py"
+  run_test python3 "$CDIR/test_ops.py"
+  run_downcast_bf16 python3 "$CDIR/test_data_type.py"
+  run_use_bf16 python3 "$CDIR/test_data_type.py"
+  run_test python3 "$CDIR/test_torch_distributed_xla_backend.py"
+  run_xla_backend_mp python3 "$CDIR/test_torch_distributed_all_gather_xla_backend.py"
+  run_xla_backend_mp python3 "$CDIR/test_torch_distributed_all_reduce_xla_backend.py"
+  run_xla_backend_mp python3 "$CDIR/test_torch_distributed_multi_all_reduce_xla_backend.py"
+  run_xla_backend_mp python3 "$CDIR/test_torch_distributed_reduce_scatter_xla_backend.py"
   run_xla_ir_debug_enabled python3 "$CDIR/test_env_var_mapper.py"
 }
 

--- a/test/test_env_var_mapper.py
+++ b/test/test_env_var_mapper.py
@@ -14,19 +14,16 @@ def check_env_flag(name, default=''):
 class EnvVarMapperTest(unittest.TestCase):
     
     def test_xla_ir_debug(self):
-      print("WONJOO starting")
       xla_device = xm.xla_device()
       t = torch.tensor([2.0, 3.0], dtype=torch.float, device=xla_device)
       xla_tensors_report = torch_xla._XLAC._xla_tensors_report(0, str(xla_device))
-      print("WONJOO:")
-      print(xla_tensors_report)
       if check_env_flag('XLA_IR_DEBUG'):
-        print("WONJOO: XLA_IR_DEBUG enabled")
+        assert 'Frames' in xla_tensors_report
       else:
-        print("WONJOO: XLA_IR_DEBUG disabled")
-      print("WONJOO completed")
+        assert 'Frames' not in xla_tensors_report
 
 
 if __name__ == '__main__':
   test = unittest.main()
   sys.exit(0 if test.result.wasSuccessful() else 1)
+

--- a/test/test_env_var_mapper.py
+++ b/test/test_env_var_mapper.py
@@ -12,18 +12,17 @@ def check_env_flag(name, default=''):
 
 
 class EnvVarMapperTest(unittest.TestCase):
-    
-    def test_xla_ir_debug(self):
-      xla_device = xm.xla_device()
-      t = torch.tensor([2.0, 3.0], dtype=torch.float, device=xla_device)
-      xla_tensors_report = torch_xla._XLAC._xla_tensors_report(0, str(xla_device))
-      if check_env_flag('XLA_IR_DEBUG'):
-        assert 'Frames' in xla_tensors_report
-      else:
-        assert 'Frames' not in xla_tensors_report
+
+  def test_xla_ir_debug(self):
+    xla_device = xm.xla_device()
+    t = torch.tensor([2.0, 3.0], dtype=torch.float, device=xla_device)
+    xla_tensors_report = torch_xla._XLAC._xla_tensors_report(0, str(xla_device))
+    if check_env_flag('XLA_IR_DEBUG'):
+      assert 'Frames' in xla_tensors_report
+    else:
+      assert 'Frames' not in xla_tensors_report
 
 
 if __name__ == '__main__':
   test = unittest.main()
   sys.exit(0 if test.result.wasSuccessful() else 1)
-

--- a/test/test_env_var_mapper.py
+++ b/test/test_env_var_mapper.py
@@ -1,0 +1,32 @@
+import os
+
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.utils.utils as xu
+import unittest
+
+
+def check_env_flag(name, default=''):
+  return os.getenv(name, default).upper() in ['ON', '1', 'YES', 'TRUE', 'Y']
+
+
+class EnvVarMapperTest(unittest.TestCase):
+    
+    def test_xla_ir_debug(self):
+      print("WONJOO starting")
+      xla_device = xm.xla_device()
+      t = torch.tensor([2.0, 3.0], dtype=torch.float, device=xla_device)
+      xla_tensors_report = torch_xla._XLAC._xla_tensors_report(0, str(xla_device))
+      print("WONJOO:")
+      print(xla_tensors_report)
+      if check_env_flag('XLA_IR_DEBUG'):
+        print("WONJOO: XLA_IR_DEBUG enabled")
+      else:
+        print("WONJOO: XLA_IR_DEBUG disabled")
+      print("WONJOO completed")
+
+
+if __name__ == '__main__':
+  test = unittest.main()
+  sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -343,6 +343,7 @@ std::string GetLiveTensorsReport(size_t nodes_threshold,
            << ", device=" << tensor.GetDevice()
            << ", ir_nodes=" << post_order.size() << "\n";
         for (size_t i = post_order.size(); i > 0; --i) {
+          std::cout << "WONJOO: frame_info.empty()=" << (post_order[i - 1]->metadata().frame_info.empty()) << std::endl;
           if (!post_order[i - 1]->metadata().frame_info.empty()) {
             ss << post_order[i - 1]->metadata().frame_info;
             break;

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -343,7 +343,6 @@ std::string GetLiveTensorsReport(size_t nodes_threshold,
            << ", device=" << tensor.GetDevice()
            << ", ir_nodes=" << post_order.size() << "\n";
         for (size_t i = post_order.size(); i > 0; --i) {
-          std::cout << "WONJOO: frame_info.empty()=" << (post_order[i - 1]->metadata().frame_info.empty()) << std::endl;
           if (!post_order[i - 1]->metadata().frame_info.empty()) {
             ss << post_order[i - 1]->metadata().frame_info;
             break;


### PR DESCRIPTION
As a follow-up to https://github.com/pytorch/xla/pull/3469, this PR adds a test to verify frame info when the `XLA_IR_DEBUG` env var is set. 

Created a new test `test/test_env_var_mapper.py` that uses `xla_tensors_report = torch_xla._XLAC._xla_tensors_report(0, str(xla_device))` to determine if frame info is attached to the IR when `XLA_IR_DEBUG` is set. For now, we only test the case when `XLA_IR_DEBUG` is enabled (we don't test when disabled, but this can be added as well if needed). This python test `test/test_env_var_mapper.py` will be extended as we map more XLA env vars to upstream. 

The `frame_info` is included in the `torch_xla._XLAC._xla_tensors_report` only if it's not empty, as defined in https://github.com/pytorch/xla/blob/master/torch_xla/csrc/init_python_bindings.cpp#L346. And the keyword `Frame` is attached to the `cout` by the upstream `torch::lazy` frames, as defined in https://github.com/pytorch/pytorch/blob/master/torch/csrc/lazy/core/ir_metadata.cpp#L28. So if the keyward `Frame` is included in the `xla_tensors_report`, we can verify that `XLA_IR_DEBUG` env var has correctly been mapped to the upstream torch `FLAGS_torch_lazy_ir_debug` and that the frame info has been attached correctly. 

Here is what the `torch_xla._XLAC._xla_tensors_report` output looks like `frame_info` is not empty:
```
Tensor: id=1, shape=f32[2]{0}, device=Unknown0, ir_nodes=1
Frames:
  test_xla_ir_debug (/home/wonjoo/pytorch/xla/test/test_env_var_mapper.py:18)
  _callTestMethod (/usr/lib/python3.8/unittest/case.py:633)
  run (/usr/lib/python3.8/unittest/case.py:676)
  __call__ (/usr/lib/python3.8/unittest/case.py:736)
  run (/usr/lib/python3.8/unittest/suite.py:122)
  __call__ (/usr/lib/python3.8/unittest/suite.py:84)
  run (/usr/lib/python3.8/unittest/suite.py:122)
  __call__ (/usr/lib/python3.8/unittest/suite.py:84)
  run (/usr/lib/python3.8/unittest/runner.py:176)
  runTests (/usr/lib/python3.8/unittest/main.py:271)
  __init__ (/usr/lib/python3.8/unittest/main.py:101)
  <module> (/home/wonjoo/pytorch/xla/test/test_env_var_mapper.py:28)
IR {
  %0 = f32[2]{0} xla::device_data(), location=test_xla_ir_debug@test_env_var_mapper.py:19, device=TPU:0, ROOT=0
}
```

Test output:
```
----------------------------------------------------------------------
Ran 1 test in 32.852s

OK

```
