### PR TITLE
Removing Duplicate Ostream Definitions for at::Scalar

### DIFF
--- a/torch_xla/csrc/ops/scalar.cpp
+++ b/torch_xla/csrc/ops/scalar.cpp
@@ -101,10 +101,6 @@ torch::lazy::hash_t ScalarHash(const at::Scalar& s) {
                              : torch::lazy::Hash(s.toLong());
 }
 
-std::ostream& operator<<(std::ostream& ostrm, at::Scalar s) {
-  return ostrm << (s.isFloatingPoint() ? s.toDouble() : s.toLong());
-}
-
 }  // namespace ops
 }  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/scalar.h
+++ b/torch_xla/csrc/ops/scalar.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ATen/core/Formatting.h>
 #include <c10/core/Scalar.h>
 
 #include <iostream>
@@ -33,8 +34,6 @@ class Scalar : public Node {
 };
 
 torch::lazy::hash_t ScalarHash(const at::Scalar& s);
-
-std::ostream& operator<<(std::ostream& ostrm, at::Scalar s);
 
 }  // namespace ops
 }  // namespace ir


### PR DESCRIPTION
The duplicate definition of the the Ostream function in <ATen/core/Formatting.h> and in XLA was causing errors in the PR
https://github.com/pytorch/pytorch/pull/75050

