### PR TITLE
Remove shape and operand related code in Node

### DIFF
--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -200,20 +200,6 @@ XlaOpVector Node::ReturnOps(absl::Span<const xla::XlaOp> ops,
   return result;
 }
 
-std::string Node::ToString() const {
-  std::stringstream ss;
-  ss << xla_shape() << " " << op();
-  if (num_outputs() > 1) {
-    ss << ", num_outputs=" << num_outputs();
-  }
-  torch::lazy::MetaData metadata = torch::lazy::GetMetaDataIfDebugging();
-  if (!metadata.scope.empty()) {
-    ss << ", scope=" << metadata.scope;
-  }
-  torch::lazy::EmitShortFrameInfo(ss, metadata.frame_info);
-  return ss.str();
-}
-
 NodePtr Node::Clone(OpList operands) const {
   XLA_ERROR() << "Cloning not implemented for node: " << *this;
 }

--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -157,10 +157,6 @@ const xla::Shape& Node::xla_shape(size_t output_index) const {
   return xla_shape_;
 }
 
-const torch::lazy::Shape& Node::shape(size_t output_index) const {
-  return shapes_.at(output_index);
-}
-
 void Node::AddOperand(NodePtr node, size_t index) {
   XLA_CHECK_LT(index, node->num_outputs());
   operands_.push_back(std::move(node));

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -122,12 +122,6 @@ class Node : public torch::lazy::Node {
   // multi-output node, output_index must be zero.
   const xla::Shape& xla_shape(size_t output_index) const;
 
-  // Retrieves the full shape of the IR Node.
-  c10::ArrayRef<torch::lazy::Shape> shapes() const override { return shapes_; }
-
-  // Retrieves the shape of the output at a given index.
-  const torch::lazy::Shape& shape(size_t output_index = 0) const override;
-
   const std::vector<torch::lazy::Output>& operands() const override {
     return operands_as_outputs_;
   }
@@ -170,7 +164,6 @@ class Node : public torch::lazy::Node {
   static std::vector<torch::lazy::SourceLocation> GetFrameInfo();
 
   xla::Shape xla_shape_;
-  std::vector<torch::lazy::Shape> shapes_;
   // A node holds a real reference to its operands.
   std::vector<NodePtr> operands_;
   // Outputs do not hold references on the nodes, and neither do the uses, since

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -122,14 +122,6 @@ class Node : public torch::lazy::Node {
   // multi-output node, output_index must be zero.
   const xla::Shape& xla_shape(size_t output_index) const;
 
-  const std::vector<torch::lazy::Output>& operands() const override {
-    return operands_as_outputs_;
-  }
-
-  const torch::lazy::Output& operand(size_t i) const override {
-    return operands_as_outputs_.at(i);
-  }
-
   const std::set<Use>& uses() const { return uses_; }
 
   void ReplaceOperand(size_t operand_no, NodePtr node, size_t index = 0);
@@ -166,9 +158,6 @@ class Node : public torch::lazy::Node {
   xla::Shape xla_shape_;
   // A node holds a real reference to its operands.
   std::vector<NodePtr> operands_;
-  // Outputs do not hold references on the nodes, and neither do the uses, since
-  // otherwise we get into circular reference counting.
-  std::vector<torch::lazy::Output> operands_as_outputs_;
   // We use a set for uses, as we want deterministic use sequencing.
   std::set<Use> uses_;
 };

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -128,8 +128,6 @@ class Node : public torch::lazy::Node {
 
   void ReplaceAllUsesWith(NodePtr node, size_t index = 0);
 
-  virtual std::string ToString() const override;
-
   virtual NodePtr Clone(OpList operands) const;
 
   virtual XlaOpVector Lower(LoweringContext* loctx) const;


### PR DESCRIPTION
As a follow-up to https://github.com/pytorch/pytorch/commit/e1b4117e30deb84ed61040bd601437ffea27b411, we are also removing the following functions and variables from `torch_xla::ir::Node` since upstream `torch::lazy::Node` now as them:
- `shapes_` and `shapes()`
- `operands_as_outputs_ ` and `operands()`

~~TBD: re-defining `NodePtr` to use upstream `torch::lazy::Node`.~~ I'll separate this PR from the `NodePtr` migration PR as the `NodePtr` is taking a bit to debug the test failures -- https://github.com/pytorch/xla/pull/3481. 
 