### PR TITLE
Only include `test/cpp/build/test_ptxla` when `BUILD_CPP_TESTS=1`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -347,9 +347,10 @@ setup(
         ],
     },
     data_files=[
-        'test/cpp/build/test_ptxla',
         'scripts/fixup_binary.py',
-    ],
+    ] + [
+        'test/cpp/build/test_ptxla'
+    ] if _check_env_flag('BUILD_CPP_TESTS', default='1') else [],
     cmdclass={
         'build_ext': Build,
         'clean': Clean,


### PR DESCRIPTION
Otherwise you get this error:

```
warning: install_data: setup script did not provide a directory for 'test/cpp/build/test_ptxla' -- installing right in 'build/bdist.linux-x86_64/egg'

error: can't copy 'test/cpp/build/test_ptxla': doesn't exist or not a regular file
```