### PR TITLE
Use upstream torch::lazy::Node in xla NodePtr

### DIFF
--- a/test/cpp/test_ir.cpp
+++ b/test/cpp/test_ir.cpp
@@ -20,36 +20,46 @@ TEST(IrTest, TestScalarCreate) {
 TEST(IrTest, TestReplace) {
   ir::NodePtr scalar1 = ir::ops::ScalarOp(1.0, xla::F32);
   ir::NodePtr scalar2 = ir::ops::ScalarOp(2.0, xla::F32);
-  ir::Value add = scalar1 + scalar2;
-  EXPECT_EQ(scalar1->uses().size(), 1);
-  EXPECT_EQ(scalar2->uses().size(), 1);
+  ir::Value value1 = ir::Value(scalar1, 0);
+  ir::Value value2 = ir::Value(scalar2, 0);
+  ir::NodePtr add = value1 + value2;
+
+  EXPECT_EQ(dynamic_cast<ir::Node*>(scalar1.get())->uses().size(), 1);
+  EXPECT_EQ(dynamic_cast<ir::Node*>(scalar2.get())->uses().size(), 1);
 
   ir::NodePtr scalar3 = ir::ops::ScalarOp(3.0, xla::F32);
-  scalar1->ReplaceAllUsesWith(scalar3);
-  EXPECT_EQ(scalar1->uses().size(), 0);
-  EXPECT_EQ(scalar3->uses().size(), 1);
+  dynamic_cast<ir::Node*>(scalar1.get())->ReplaceAllUsesWith(scalar3);
 
-  add->ReplaceOperand(0, scalar1);
-  EXPECT_EQ(scalar1->uses().size(), 1);
+  EXPECT_EQ(dynamic_cast<ir::Node*>(scalar1.get())->uses().size(), 0);
+  EXPECT_EQ(dynamic_cast<ir::Node*>(scalar3.get())->uses().size(), 1);
+
+  dynamic_cast<ir::Node*>(add.get())->ReplaceOperand(0, scalar1);
+  EXPECT_EQ(dynamic_cast<ir::Node*>(scalar1.get())->uses().size(), 1);
 }
 
 TEST(IrTest, TestHash) {
   ir::NodePtr scalar1 = ir::ops::ScalarOp(1.0, xla::F32);
   ir::NodePtr scalar2 = ir::ops::ScalarOp(2.0, xla::F32);
-  ir::Value add1 = scalar1 + scalar2;
+  ir::Value value1 = ir::Value(scalar1, 0);
+  ir::Value value2 = ir::Value(scalar2, 0);
+  ir::Value add1 = value1 + value2;
 
   ir::NodePtr scalar3 = ir::ops::ScalarOp(1.0, xla::F32);
   ir::NodePtr scalar4 = ir::ops::ScalarOp(2.0, xla::F32);
-  ir::Value add2 = scalar1 + scalar2;
+  ir::Value value3 = ir::Value(scalar3, 0);
+  ir::Value value4 = ir::Value(scalar4, 0);
+  ir::Value add2 = value3 + value4;
 
   ir::NodePtr scalar5 = ir::ops::ScalarOp(11.0, xla::F32);
   ir::NodePtr scalar6 = ir::ops::ScalarOp(22.0, xla::F32);
-  ir::Value add3 = scalar5 + scalar6;
+  ir::Value value5 = ir::Value(scalar5, 0);
+  ir::Value value6 = ir::Value(scalar6, 0);
+  ir::Value add3 = value5 + value6;
 
   EXPECT_EQ(add1->hash(), add2->hash());
   EXPECT_NE(add1->hash(), add3->hash());
 
-  ir::Value sub = scalar1 - scalar2;
+  ir::Value sub = value1 - value2;
 
   EXPECT_NE(add1->hash(), sub->hash());
 }

--- a/test/cpp/test_ir.cpp
+++ b/test/cpp/test_ir.cpp
@@ -51,7 +51,7 @@ TEST(IrTest, TestHash) {
   EXPECT_EQ(add1->hash(), add2->hash());
   EXPECT_NE(add1->hash(), add3->hash());
 
-  ir::Value sub = ir::Value(scalar1, 0) + ir::Value(scalar2, 0);
+  ir::Value sub = ir::Value(scalar1, 0) - ir::Value(scalar2, 0);
 
   EXPECT_NE(add1->hash(), sub->hash());
 }

--- a/test/cpp/test_ir.cpp
+++ b/test/cpp/test_ir.cpp
@@ -20,9 +20,7 @@ TEST(IrTest, TestScalarCreate) {
 TEST(IrTest, TestReplace) {
   ir::NodePtr scalar1 = ir::ops::ScalarOp(1.0, xla::F32);
   ir::NodePtr scalar2 = ir::ops::ScalarOp(2.0, xla::F32);
-  ir::Value value1 = ir::Value(scalar1, 0);
-  ir::Value value2 = ir::Value(scalar2, 0);
-  ir::NodePtr add = value1 + value2;
+  ir::NodePtr add = ir::Value(scalar1, 0) + ir::Value(scalar2, 0);
 
   EXPECT_EQ(dynamic_cast<ir::Node*>(scalar1.get())->uses().size(), 1);
   EXPECT_EQ(dynamic_cast<ir::Node*>(scalar2.get())->uses().size(), 1);
@@ -40,26 +38,20 @@ TEST(IrTest, TestReplace) {
 TEST(IrTest, TestHash) {
   ir::NodePtr scalar1 = ir::ops::ScalarOp(1.0, xla::F32);
   ir::NodePtr scalar2 = ir::ops::ScalarOp(2.0, xla::F32);
-  ir::Value value1 = ir::Value(scalar1, 0);
-  ir::Value value2 = ir::Value(scalar2, 0);
-  ir::Value add1 = value1 + value2;
+  ir::Value add1 = ir::Value(scalar1, 0) + ir::Value(scalar2, 0);
 
   ir::NodePtr scalar3 = ir::ops::ScalarOp(1.0, xla::F32);
   ir::NodePtr scalar4 = ir::ops::ScalarOp(2.0, xla::F32);
-  ir::Value value3 = ir::Value(scalar3, 0);
-  ir::Value value4 = ir::Value(scalar4, 0);
-  ir::Value add2 = value3 + value4;
+  ir::Value add2 = ir::Value(scalar3, 0) + ir::Value(scalar4, 0);
 
   ir::NodePtr scalar5 = ir::ops::ScalarOp(11.0, xla::F32);
   ir::NodePtr scalar6 = ir::ops::ScalarOp(22.0, xla::F32);
-  ir::Value value5 = ir::Value(scalar5, 0);
-  ir::Value value6 = ir::Value(scalar6, 0);
-  ir::Value add3 = value5 + value6;
+  ir::Value add3 = ir::Value(scalar5, 0) + ir::Value(scalar6, 0);
 
   EXPECT_EQ(add1->hash(), add2->hash());
   EXPECT_NE(add1->hash(), add3->hash());
 
-  ir::Value sub = value1 - value2;
+  ir::Value sub = ir::Value(scalar1, 0) + ir::Value(scalar2, 0);
 
   EXPECT_NE(add1->hash(), sub->hash());
 }

--- a/test/cpp/test_ir.cpp
+++ b/test/cpp/test_ir.cpp
@@ -13,19 +13,19 @@ namespace torch_xla {
 namespace cpp_test {
 
 TEST(IrTest, TestScalarCreate) {
-  ir::NodePtr scalar = ir::ops::ScalarOp(1.0, xla::F32);
+  torch::lazy::NodePtr scalar = ir::ops::ScalarOp(1.0, xla::F32);
   ASSERT_TRUE(scalar != nullptr);
 }
 
 TEST(IrTest, TestReplace) {
-  ir::NodePtr scalar1 = ir::ops::ScalarOp(1.0, xla::F32);
-  ir::NodePtr scalar2 = ir::ops::ScalarOp(2.0, xla::F32);
-  ir::NodePtr add = ir::Value(scalar1, 0) + ir::Value(scalar2, 0);
+  torch::lazy::NodePtr scalar1 = ir::ops::ScalarOp(1.0, xla::F32);
+  torch::lazy::NodePtr scalar2 = ir::ops::ScalarOp(2.0, xla::F32);
+  torch::lazy::NodePtr add = ir::Value(scalar1, 0) + ir::Value(scalar2, 0);
 
   EXPECT_EQ(dynamic_cast<ir::Node*>(scalar1.get())->uses().size(), 1);
   EXPECT_EQ(dynamic_cast<ir::Node*>(scalar2.get())->uses().size(), 1);
 
-  ir::NodePtr scalar3 = ir::ops::ScalarOp(3.0, xla::F32);
+  torch::lazy::NodePtr scalar3 = ir::ops::ScalarOp(3.0, xla::F32);
   dynamic_cast<ir::Node*>(scalar1.get())->ReplaceAllUsesWith(scalar3);
 
   EXPECT_EQ(dynamic_cast<ir::Node*>(scalar1.get())->uses().size(), 0);
@@ -36,16 +36,16 @@ TEST(IrTest, TestReplace) {
 }
 
 TEST(IrTest, TestHash) {
-  ir::NodePtr scalar1 = ir::ops::ScalarOp(1.0, xla::F32);
-  ir::NodePtr scalar2 = ir::ops::ScalarOp(2.0, xla::F32);
+  torch::lazy::NodePtr scalar1 = ir::ops::ScalarOp(1.0, xla::F32);
+  torch::lazy::NodePtr scalar2 = ir::ops::ScalarOp(2.0, xla::F32);
   ir::Value add1 = ir::Value(scalar1, 0) + ir::Value(scalar2, 0);
 
-  ir::NodePtr scalar3 = ir::ops::ScalarOp(1.0, xla::F32);
-  ir::NodePtr scalar4 = ir::ops::ScalarOp(2.0, xla::F32);
+  torch::lazy::NodePtr scalar3 = ir::ops::ScalarOp(1.0, xla::F32);
+  torch::lazy::NodePtr scalar4 = ir::ops::ScalarOp(2.0, xla::F32);
   ir::Value add2 = ir::Value(scalar3, 0) + ir::Value(scalar4, 0);
 
-  ir::NodePtr scalar5 = ir::ops::ScalarOp(11.0, xla::F32);
-  ir::NodePtr scalar6 = ir::ops::ScalarOp(22.0, xla::F32);
+  torch::lazy::NodePtr scalar5 = ir::ops::ScalarOp(11.0, xla::F32);
+  torch::lazy::NodePtr scalar6 = ir::ops::ScalarOp(22.0, xla::F32);
   ir::Value add3 = ir::Value(scalar5, 0) + ir::Value(scalar6, 0);
 
   EXPECT_EQ(add1->hash(), add2->hash());

--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -162,7 +162,7 @@ const xla::Shape& Node::xla_shape(size_t output_index) const {
   return xla_shape_;
 }
 
-void Node::AddOperand(NodePtr node, size_t index) {
+void Node::AddOperand(torch::lazy::NodePtr node, size_t index) {
   XLA_CHECK_LT(index, node->num_outputs());
   operands_.push_back(std::move(node));
   operands_as_outputs_.push_back(
@@ -171,7 +171,8 @@ void Node::AddOperand(NodePtr node, size_t index) {
   casted->AddUse(Use(this, operands_.size() - 1, index));
 }
 
-void Node::ReplaceOperand(size_t operand_no, NodePtr node, size_t index) {
+void Node::ReplaceOperand(size_t operand_no, torch::lazy::NodePtr node,
+                          size_t index) {
   XLA_CHECK_LT(index, node->num_outputs());
   Node* casted = dynamic_cast<Node*>(node.get());
   torch::lazy::Output* output = &operands_as_outputs_.at(operand_no);
@@ -182,7 +183,7 @@ void Node::ReplaceOperand(size_t operand_no, NodePtr node, size_t index) {
   operands_[operand_no] = std::move(node);
 }
 
-void Node::ReplaceAllUsesWith(NodePtr node, size_t index) {
+void Node::ReplaceAllUsesWith(torch::lazy::NodePtr node, size_t index) {
   // A call to ReplaceOperand() will end up calling RemoveUse() into the
   // current node, so snapshot the current uses and iterate over them.
   std::vector<Use> current_uses(uses_.begin(), uses_.end());
@@ -208,7 +209,7 @@ XlaOpVector Node::ReturnOps(absl::Span<const xla::XlaOp> ops,
   return result;
 }
 
-NodePtr Node::Clone(OpList operands) const {
+torch::lazy::NodePtr Node::Clone(OpList operands) const {
   XLA_ERROR() << "Cloning not implemented for node: " << *this;
 }
 

--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -112,10 +112,6 @@ const xla::Shape& Value::xla_node_shape() const {
   return casted->xla_shape();
 }
 
-torch::lazy::hash_t Value::hash() const {
-  return torch::lazy::HashCombine(node->hash(), index);
-}
-
 Node* Value::operator->() const { return dynamic_cast<Node*>(node.get()); }
 
 Node::Node(torch::lazy::OpKind op, OpList operands, xla::Shape shape,

--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -112,8 +112,6 @@ const xla::Shape& Value::xla_node_shape() const {
   return casted->xla_shape();
 }
 
-Node* Value::operator->() const { return dynamic_cast<Node*>(node.get()); }
-
 Node::Node(torch::lazy::OpKind op, OpList operands, xla::Shape shape,
            size_t num_outputs, torch::lazy::hash_t hash_seed)
     : torch::lazy::Node(

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -26,8 +26,6 @@ namespace ir {
 class Node;
 class LoweringContext;
 
-using NodePtr = std::shared_ptr<torch::lazy::Node>;
-
 using XlaOpVector = tensorflow::gtl::InlinedVector<xla::XlaOp, 1>;
 
 // Represents a use of the output of a given node.
@@ -62,7 +60,7 @@ using OutputMap =
 // Represents an input/operand for a Node object.
 struct Value : public torch::lazy::Value {
   Value() = default;
-  Value(NodePtr node, size_t index = 0)
+  Value(torch::lazy::NodePtr node, size_t index = 0)
       : torch::lazy::Value(std::dynamic_pointer_cast<torch::lazy::Node>(node),
                            index) {}
 
@@ -115,11 +113,12 @@ class Node : public torch::lazy::Node {
 
   const std::set<Use>& uses() const { return uses_; }
 
-  void ReplaceOperand(size_t operand_no, NodePtr node, size_t index = 0);
+  void ReplaceOperand(size_t operand_no, torch::lazy::NodePtr node,
+                      size_t index = 0);
 
-  void ReplaceAllUsesWith(NodePtr node, size_t index = 0);
+  void ReplaceAllUsesWith(torch::lazy::NodePtr node, size_t index = 0);
 
-  virtual NodePtr Clone(OpList operands) const;
+  virtual torch::lazy::NodePtr Clone(OpList operands) const;
 
   virtual XlaOpVector Lower(LoweringContext* loctx) const;
 
@@ -130,7 +129,7 @@ class Node : public torch::lazy::Node {
 
  private:
   // Adds node's index output number as operand.
-  void AddOperand(NodePtr node, size_t index = 0);
+  void AddOperand(torch::lazy::NodePtr node, size_t index = 0);
 
   void AddUse(Use use) { uses_.insert(std::move(use)); }
 
@@ -165,7 +164,7 @@ inline std::ostream& operator<<(std::ostream& stream, const Node& node) {
 }
 
 template <typename T, typename... Args>
-NodePtr MakeNode(Args&&... args) {
+torch::lazy::NodePtr MakeNode(Args&&... args) {
   return std::make_shared<T>(std::forward<Args>(args)...);
 }
 

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -26,7 +26,7 @@ namespace ir {
 class Node;
 class LoweringContext;
 
-using NodePtr = std::shared_ptr<Node>;
+using NodePtr = std::shared_ptr<torch::lazy::Node>;
 
 using XlaOpVector = tensorflow::gtl::InlinedVector<xla::XlaOp, 1>;
 
@@ -79,7 +79,7 @@ struct Value : public torch::lazy::Value {
 
   operator bool() const { return node != nullptr; }
 
-  Node* operator->() const { return node.get(); }
+  Node* operator->() const;
 
   NodePtr node;
   size_t index = 0;

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -70,8 +70,6 @@ struct Value : public torch::lazy::Value {
   // To retrieve the full tuple shape in that case, use the node_shape() API.
   const xla::Shape& xla_shape() const;
   const xla::Shape& xla_node_shape() const;
-
-  Node* operator->() const;
 };
 
 using OpList = absl::Span<const Value>;

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -145,8 +145,6 @@ class Node : public torch::lazy::Node {
   static std::vector<torch::lazy::SourceLocation> GetFrameInfo();
 
   xla::Shape xla_shape_;
-  // A node holds a real reference to its operands.
-  // std::vector<NodePtr> operands_;
   // We use a set for uses, as we want deterministic use sequencing.
   std::set<Use> uses_;
 };

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -64,9 +64,7 @@ struct Value : public torch::lazy::Value {
   Value() = default;
   Value(NodePtr node, size_t index = 0)
       : torch::lazy::Value(std::dynamic_pointer_cast<torch::lazy::Node>(node),
-                           index),
-        node(std::move(node)),
-        index(index) {}
+                           index) {}
 
   // Retrieves the shape of this value. If the IR Node generating the value is a
   // multi-output node, the shape returned by this API will not be the full
@@ -75,14 +73,7 @@ struct Value : public torch::lazy::Value {
   const xla::Shape& xla_shape() const;
   const xla::Shape& xla_node_shape() const;
 
-  torch::lazy::hash_t hash() const;
-
-  operator bool() const { return node != nullptr; }
-
   Node* operator->() const;
-
-  NodePtr node;
-  size_t index = 0;
 };
 
 using OpList = absl::Span<const Value>;
@@ -155,7 +146,7 @@ class Node : public torch::lazy::Node {
 
   xla::Shape xla_shape_;
   // A node holds a real reference to its operands.
-  std::vector<NodePtr> operands_;
+  // std::vector<NodePtr> operands_;
   // We use a set for uses, as we want deterministic use sequencing.
   std::set<Use> uses_;
 };

--- a/torch_xla/csrc/ir_util.cpp
+++ b/torch_xla/csrc/ir_util.cpp
@@ -62,7 +62,7 @@ std::vector<const torch::lazy::Node*> Util::ComputePostOrder(
 std::vector<Value> Util::Clone(
     absl::Span<const Value> values,
     absl::Span<const torch::lazy::Node* const> post_order) {
-  std::unordered_map<const torch::lazy::Node*, NodePtr> clone_map;
+  std::unordered_map<const torch::lazy::Node*, torch::lazy::NodePtr> clone_map;
   for (auto node : post_order) {
     if (clone_map.count(node) > 0) {
       continue;

--- a/torch_xla/csrc/ops/adam_optimizer_step.cpp
+++ b/torch_xla/csrc/ops/adam_optimizer_step.cpp
@@ -34,7 +34,7 @@ AdamOptimizerStep::AdamOptimizerStep(
       use_amsgrad_(use_amsgrad),
       use_adamw_(use_adamw) {}
 
-NodePtr AdamOptimizerStep::Clone(OpList operands) const {
+torch::lazy::NodePtr AdamOptimizerStep::Clone(OpList operands) const {
   return ir::MakeNode<AdamOptimizerStep>(
       operands.at(0), operands.at(1), operands.at(2), operands.at(3),
       operands.at(4), operands.at(5), operands.at(6), operands.at(7),

--- a/torch_xla/csrc/ops/adam_optimizer_step.h
+++ b/torch_xla/csrc/ops/adam_optimizer_step.h
@@ -15,7 +15,7 @@ class AdamOptimizerStep : public Node {
                     const Value& weight_decay, const Value& eps,
                     bool use_weight_decay, bool use_amsgrad, bool use_adamw);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/adaptive_avg_pool2d.cpp
+++ b/torch_xla/csrc/ops/adaptive_avg_pool2d.cpp
@@ -29,7 +29,7 @@ AdaptiveAvgPool2d::AdaptiveAvgPool2d(const Value& input,
            /*num_outputs=*/1, torch::lazy::MHash(output_size)),
       output_size_(std::move(output_size)) {}
 
-NodePtr AdaptiveAvgPool2d::Clone(OpList operands) const {
+torch::lazy::NodePtr AdaptiveAvgPool2d::Clone(OpList operands) const {
   return ir::MakeNode<AdaptiveAvgPool2d>(operands.at(0), output_size_);
 }
 

--- a/torch_xla/csrc/ops/adaptive_avg_pool2d.h
+++ b/torch_xla/csrc/ops/adaptive_avg_pool2d.h
@@ -12,7 +12,7 @@ class AdaptiveAvgPool2d : public Node {
  public:
   AdaptiveAvgPool2d(const Value& input, std::vector<int64_t> output_size);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/adaptive_avg_pool3d.cpp
+++ b/torch_xla/csrc/ops/adaptive_avg_pool3d.cpp
@@ -29,7 +29,7 @@ AdaptiveAvgPool3d::AdaptiveAvgPool3d(const Value& input,
            /*num_outputs=*/1, torch::lazy::MHash(output_size)),
       output_size_(std::move(output_size)) {}
 
-NodePtr AdaptiveAvgPool3d::Clone(OpList operands) const {
+torch::lazy::NodePtr AdaptiveAvgPool3d::Clone(OpList operands) const {
   return ir::MakeNode<AdaptiveAvgPool3d>(operands.at(0), output_size_);
 }
 

--- a/torch_xla/csrc/ops/adaptive_avg_pool3d.h
+++ b/torch_xla/csrc/ops/adaptive_avg_pool3d.h
@@ -14,7 +14,7 @@ class AdaptiveAvgPool3d : public Node {
  public:
   AdaptiveAvgPool3d(const Value& input, std::vector<int64_t> output_size);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/adaptive_max_pool2d.cpp
+++ b/torch_xla/csrc/ops/adaptive_max_pool2d.cpp
@@ -30,7 +30,7 @@ AdaptiveMaxPool2d::AdaptiveMaxPool2d(const Value& input,
            /*num_outputs=*/2, torch::lazy::MHash(output_size)),
       output_size_(std::move(output_size)) {}
 
-NodePtr AdaptiveMaxPool2d::Clone(OpList operands) const {
+torch::lazy::NodePtr AdaptiveMaxPool2d::Clone(OpList operands) const {
   return ir::MakeNode<AdaptiveMaxPool2d>(operands.at(0), output_size_);
 }
 

--- a/torch_xla/csrc/ops/adaptive_max_pool2d.h
+++ b/torch_xla/csrc/ops/adaptive_max_pool2d.h
@@ -12,7 +12,7 @@ class AdaptiveMaxPool2d : public Node {
  public:
   AdaptiveMaxPool2d(const Value& input, std::vector<int64_t> output_size);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/all.cpp
+++ b/torch_xla/csrc/ops/all.cpp
@@ -33,7 +33,7 @@ All::All(const Value& input, std::vector<int64_t> dimensions,
       dimensions_(std::move(dimensions)),
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
-NodePtr All::Clone(OpList operands) const {
+torch::lazy::NodePtr All::Clone(OpList operands) const {
   return ir::MakeNode<All>(operands.at(0), dimensions_,
                            keep_reduced_dimensions_);
 }

--- a/torch_xla/csrc/ops/all.h
+++ b/torch_xla/csrc/ops/all.h
@@ -16,7 +16,7 @@ class All : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/all_gather.cpp
+++ b/torch_xla/csrc/ops/all_gather.cpp
@@ -37,7 +37,7 @@ AllGather::AllGather(const Value& input, const Value& token, int64_t dim,
       shard_count_(shard_count),
       groups_(std::move(groups)) {}
 
-NodePtr AllGather::Clone(OpList operands) const {
+torch::lazy::NodePtr AllGather::Clone(OpList operands) const {
   return ir::MakeNode<AllGather>(operands.at(0), operands.at(1), dim_,
                                  shard_count_, groups_);
 }

--- a/torch_xla/csrc/ops/all_gather.h
+++ b/torch_xla/csrc/ops/all_gather.h
@@ -14,7 +14,7 @@ class AllGather : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/all_reduce.cpp
+++ b/torch_xla/csrc/ops/all_reduce.cpp
@@ -44,7 +44,7 @@ AllReduce::AllReduce(AllReduceType reduce_type,
       scale_(scale),
       groups_(std::move(groups)) {}
 
-NodePtr AllReduce::Clone(OpList operands) const {
+torch::lazy::NodePtr AllReduce::Clone(OpList operands) const {
   std::vector<Value> operand_list(operands.begin(), operands.end() - 1);
   return ir::MakeNode<AllReduce>(reduce_type_, operand_list, operands.back(),
                                  scale_, groups_);

--- a/torch_xla/csrc/ops/all_reduce.h
+++ b/torch_xla/csrc/ops/all_reduce.h
@@ -15,7 +15,7 @@ class AllReduce : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/all_to_all.cpp
+++ b/torch_xla/csrc/ops/all_to_all.cpp
@@ -43,7 +43,7 @@ AllToAll::AllToAll(const Value& input, const Value& token,
       split_count_(split_count),
       groups_(std::move(groups)) {}
 
-NodePtr AllToAll::Clone(OpList operands) const {
+torch::lazy::NodePtr AllToAll::Clone(OpList operands) const {
   return ir::MakeNode<AllToAll>(operands.at(0), operands.at(1),
                                 split_dimension_, concat_dimension_,
                                 split_count_, groups_);

--- a/torch_xla/csrc/ops/all_to_all.h
+++ b/torch_xla/csrc/ops/all_to_all.h
@@ -15,7 +15,7 @@ class AllToAll : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/amax.cpp
+++ b/torch_xla/csrc/ops/amax.cpp
@@ -27,7 +27,7 @@ Amax::Amax(const Value& input, std::vector<int64_t> dimensions, bool keepdim)
       dimensions_(std::move(dimensions)),
       keepdim_(keepdim) {}
 
-NodePtr Amax::Clone(OpList operands) const {
+torch::lazy::NodePtr Amax::Clone(OpList operands) const {
   return ir::MakeNode<Amax>(operands.at(0), dimensions_, keepdim_);
 }
 

--- a/torch_xla/csrc/ops/amax.h
+++ b/torch_xla/csrc/ops/amax.h
@@ -12,7 +12,7 @@ class Amax : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/amin.cpp
+++ b/torch_xla/csrc/ops/amin.cpp
@@ -27,7 +27,7 @@ Amin::Amin(const Value& input, std::vector<int64_t> dimensions, bool keepdim)
       dimensions_(std::move(dimensions)),
       keepdim_(keepdim) {}
 
-NodePtr Amin::Clone(OpList operands) const {
+torch::lazy::NodePtr Amin::Clone(OpList operands) const {
   return ir::MakeNode<Amin>(operands.at(0), dimensions_, keepdim_);
 }
 

--- a/torch_xla/csrc/ops/amin.h
+++ b/torch_xla/csrc/ops/amin.h
@@ -12,7 +12,7 @@ class Amin : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/amp_foreach_non_finite_check_and_unscale.cpp
+++ b/torch_xla/csrc/ops/amp_foreach_non_finite_check_and_unscale.cpp
@@ -41,7 +41,8 @@ AmpForachNonFiniteCheckAndUnscale::AmpForachNonFiniteCheckAndUnscale(
            NodeOutputShape(inputs, found_inf),
            /*num_outputs=*/inputs.size() + 1) {}
 
-NodePtr AmpForachNonFiniteCheckAndUnscale::Clone(OpList operands) const {
+torch::lazy::NodePtr AmpForachNonFiniteCheckAndUnscale::Clone(
+    OpList operands) const {
   std::vector<Value> operand_list(operands.begin(), operands.end() - 2);
   size_t sz = operand_list.size();
   return ir::MakeNode<AmpForachNonFiniteCheckAndUnscale>(

--- a/torch_xla/csrc/ops/amp_foreach_non_finite_check_and_unscale.h
+++ b/torch_xla/csrc/ops/amp_foreach_non_finite_check_and_unscale.h
@@ -12,7 +12,7 @@ class AmpForachNonFiniteCheckAndUnscale : public Node {
                                     const Value& found_inf,
                                     const Value& inv_scale);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 };

--- a/torch_xla/csrc/ops/amp_update_scale.cpp
+++ b/torch_xla/csrc/ops/amp_update_scale.cpp
@@ -32,7 +32,7 @@ AmpUpdateScale::AmpUpdateScale(const Value& current_scale,
       scale_backoff_factor_(scale_backoff_factor),
       growth_interval_(growth_interval) {}
 
-NodePtr AmpUpdateScale::Clone(OpList operands) const {
+torch::lazy::NodePtr AmpUpdateScale::Clone(OpList operands) const {
   return ir::MakeNode<AmpUpdateScale>(operands[0], operands[1], operands[2],
                                       scale_growth_factor_,
                                       scale_backoff_factor_, growth_interval_);

--- a/torch_xla/csrc/ops/amp_update_scale.h
+++ b/torch_xla/csrc/ops/amp_update_scale.h
@@ -12,7 +12,7 @@ class AmpUpdateScale : public Node {
                  const Value& found_inf, double scale_growth_factor,
                  double scale_backoff_factor, int growth_interval);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/any.cpp
+++ b/torch_xla/csrc/ops/any.cpp
@@ -33,7 +33,7 @@ Any::Any(const Value& input, std::vector<int64_t> dimensions,
       dimensions_(std::move(dimensions)),
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
-NodePtr Any::Clone(OpList operands) const {
+torch::lazy::NodePtr Any::Clone(OpList operands) const {
   return ir::MakeNode<Any>(operands.at(0), dimensions_,
                            keep_reduced_dimensions_);
 }

--- a/torch_xla/csrc/ops/any.h
+++ b/torch_xla/csrc/ops/any.h
@@ -16,7 +16,7 @@ class Any : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/arg_max.cpp
+++ b/torch_xla/csrc/ops/arg_max.cpp
@@ -26,7 +26,7 @@ ArgMax::ArgMax(const Value& input, int64_t dim, bool keepdim)
       dim_(dim),
       keepdim_(keepdim) {}
 
-NodePtr ArgMax::Clone(OpList operands) const {
+torch::lazy::NodePtr ArgMax::Clone(OpList operands) const {
   return ir::MakeNode<ArgMax>(operands.at(0), dim_, keepdim_);
 }
 

--- a/torch_xla/csrc/ops/arg_max.h
+++ b/torch_xla/csrc/ops/arg_max.h
@@ -12,7 +12,7 @@ class ArgMax : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/arg_min.cpp
+++ b/torch_xla/csrc/ops/arg_min.cpp
@@ -26,7 +26,7 @@ ArgMin::ArgMin(const Value& input, int64_t dim, bool keepdim)
       dim_(dim),
       keepdim_(keepdim) {}
 
-NodePtr ArgMin::Clone(OpList operands) const {
+torch::lazy::NodePtr ArgMin::Clone(OpList operands) const {
   return ir::MakeNode<ArgMin>(operands.at(0), dim_, keepdim_);
 }
 

--- a/torch_xla/csrc/ops/arg_min.h
+++ b/torch_xla/csrc/ops/arg_min.h
@@ -12,7 +12,7 @@ class ArgMin : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/arithmetic_ir_ops.cpp
+++ b/torch_xla/csrc/ops/arithmetic_ir_ops.cpp
@@ -9,7 +9,7 @@
 namespace torch_xla {
 namespace ir {
 
-NodePtr operator+(const Value& node1, const Value& node2) {
+torch::lazy::NodePtr operator+(const Value& node1, const Value& node2) {
   auto lower_fn = [](const Node& node, LoweringContext* loctx) -> XlaOpVector {
     xla::XlaOp op0 = loctx->GetOutputOp(node.operand(0));
     xla::XlaOp op1 = loctx->GetOutputOp(node.operand(1));
@@ -21,7 +21,7 @@ NodePtr operator+(const Value& node1, const Value& node2) {
                         std::move(lower_fn));
 }
 
-NodePtr operator-(const Value& node1, const Value& node2) {
+torch::lazy::NodePtr operator-(const Value& node1, const Value& node2) {
   auto lower_fn = [](const Node& node, LoweringContext* loctx) -> XlaOpVector {
     xla::XlaOp op0 = loctx->GetOutputOp(node.operand(0));
     xla::XlaOp op1 = loctx->GetOutputOp(node.operand(1));
@@ -33,7 +33,7 @@ NodePtr operator-(const Value& node1, const Value& node2) {
                         std::move(lower_fn));
 }
 
-NodePtr operator*(const Value& node1, const Value& node2) {
+torch::lazy::NodePtr operator*(const Value& node1, const Value& node2) {
   auto lower_fn = [](const Node& node, LoweringContext* loctx) -> XlaOpVector {
     xla::XlaOp op0 = loctx->GetOutputOp(node.operand(0));
     xla::XlaOp op1 = loctx->GetOutputOp(node.operand(1));
@@ -45,7 +45,7 @@ NodePtr operator*(const Value& node1, const Value& node2) {
                         std::move(lower_fn));
 }
 
-NodePtr operator/(const Value& node1, const Value& node2) {
+torch::lazy::NodePtr operator/(const Value& node1, const Value& node2) {
   auto lower_fn = [](const Node& node, LoweringContext* loctx) -> XlaOpVector {
     xla::XlaOp op0 = loctx->GetOutputOp(node.operand(0));
     xla::XlaOp op1 = loctx->GetOutputOp(node.operand(1));

--- a/torch_xla/csrc/ops/arithmetic_ir_ops.h
+++ b/torch_xla/csrc/ops/arithmetic_ir_ops.h
@@ -5,10 +5,10 @@
 namespace torch_xla {
 namespace ir {
 
-NodePtr operator+(const Value& node1, const Value& node2);
-NodePtr operator-(const Value& node1, const Value& node2);
-NodePtr operator*(const Value& node1, const Value& node2);
-NodePtr operator/(const Value& node1, const Value& node2);
+torch::lazy::NodePtr operator+(const Value& node1, const Value& node2);
+torch::lazy::NodePtr operator-(const Value& node1, const Value& node2);
+torch::lazy::NodePtr operator*(const Value& node1, const Value& node2);
+torch::lazy::NodePtr operator/(const Value& node1, const Value& node2);
 
 }  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/as_strided.cpp
+++ b/torch_xla/csrc/ops/as_strided.cpp
@@ -63,7 +63,7 @@ std::string AsStrided::ToString() const {
   return ss.str();
 }
 
-NodePtr AsStrided::Clone(OpList operands) const {
+torch::lazy::NodePtr AsStrided::Clone(OpList operands) const {
   return ir::MakeNode<AsStrided>(operands.at(0), size_, stride_,
                                  storage_offset_);
 }

--- a/torch_xla/csrc/ops/as_strided.h
+++ b/torch_xla/csrc/ops/as_strided.h
@@ -16,7 +16,7 @@ class AsStrided : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/as_strided_view_update.cpp
+++ b/torch_xla/csrc/ops/as_strided_view_update.cpp
@@ -64,7 +64,7 @@ std::string AsStridedViewUpdate::ToString() const {
   return ss.str();
 }
 
-NodePtr AsStridedViewUpdate::Clone(OpList operands) const {
+torch::lazy::NodePtr AsStridedViewUpdate::Clone(OpList operands) const {
   return ir::MakeNode<AsStridedViewUpdate>(operands.at(0), operands.at(1),
                                            size_, stride_, storage_offset_);
 }

--- a/torch_xla/csrc/ops/as_strided_view_update.h
+++ b/torch_xla/csrc/ops/as_strided_view_update.h
@@ -17,7 +17,7 @@ class AsStridedViewUpdate : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/avg_pool_nd.cpp
+++ b/torch_xla/csrc/ops/avg_pool_nd.cpp
@@ -63,7 +63,7 @@ AvgPoolNd::AvgPoolNd(const Value& input, int64_t spatial_dim_count,
       ceil_mode_(ceil_mode),
       count_include_pad_(count_include_pad) {}
 
-NodePtr AvgPoolNd::Clone(OpList operands) const {
+torch::lazy::NodePtr AvgPoolNd::Clone(OpList operands) const {
   return ir::MakeNode<AvgPoolNd>(operands.at(0), spatial_dim_count_,
                                  kernel_size_, stride_, padding_, ceil_mode_,
                                  count_include_pad_);

--- a/torch_xla/csrc/ops/avg_pool_nd.h
+++ b/torch_xla/csrc/ops/avg_pool_nd.h
@@ -13,7 +13,7 @@ class AvgPoolNd : public Node {
             std::vector<int64_t> padding, bool ceil_mode,
             bool count_include_pad);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/avg_pool_nd_backward.cpp
+++ b/torch_xla/csrc/ops/avg_pool_nd_backward.cpp
@@ -64,7 +64,7 @@ AvgPoolNdBackward::AvgPoolNdBackward(
       ceil_mode_(ceil_mode),
       count_include_pad_(count_include_pad) {}
 
-NodePtr AvgPoolNdBackward::Clone(OpList operands) const {
+torch::lazy::NodePtr AvgPoolNdBackward::Clone(OpList operands) const {
   return ir::MakeNode<AvgPoolNdBackward>(
       operands.at(0), operands.at(1), spatial_dim_count_, kernel_size_, stride_,
       padding_, ceil_mode_, count_include_pad_);

--- a/torch_xla/csrc/ops/avg_pool_nd_backward.h
+++ b/torch_xla/csrc/ops/avg_pool_nd_backward.h
@@ -13,7 +13,7 @@ class AvgPoolNdBackward : public Node {
                     std::vector<int64_t> stride, std::vector<int64_t> padding,
                     bool ceil_mode, bool count_include_pad);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/bernoulli.cpp
+++ b/torch_xla/csrc/ops/bernoulli.cpp
@@ -13,7 +13,7 @@ Bernoulli::Bernoulli(const Value& probability, const Value& seed,
     : Node(torch::lazy::OpKind(at::aten::bernoulli), {probability, seed},
            std::move(shape)) {}
 
-NodePtr Bernoulli::Clone(OpList operands) const {
+torch::lazy::NodePtr Bernoulli::Clone(OpList operands) const {
   return ir::MakeNode<Bernoulli>(operands.at(0), operands.at(1), xla_shape());
 }
 

--- a/torch_xla/csrc/ops/bernoulli.h
+++ b/torch_xla/csrc/ops/bernoulli.h
@@ -10,7 +10,7 @@ class Bernoulli : public Node {
  public:
   Bernoulli(const Value& probability, const Value& seed, xla::Shape shape);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 };

--- a/torch_xla/csrc/ops/binary_cross_entropy.cpp
+++ b/torch_xla/csrc/ops/binary_cross_entropy.cpp
@@ -42,7 +42,7 @@ BinaryCrossEntropy::BinaryCrossEntropy(const Value& logits, const Value& labels,
            torch::lazy::MHash(torch::lazy::GetEnumValue(reduction))),
       reduction_(reduction) {}
 
-NodePtr BinaryCrossEntropy::Clone(OpList operands) const {
+torch::lazy::NodePtr BinaryCrossEntropy::Clone(OpList operands) const {
   absl::optional<Value> weight;
   if (operands.size() > 2) {
     weight = operands.at(2);

--- a/torch_xla/csrc/ops/binary_cross_entropy.h
+++ b/torch_xla/csrc/ops/binary_cross_entropy.h
@@ -16,7 +16,7 @@ class BinaryCrossEntropy : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/binary_cross_entropy_backward.cpp
+++ b/torch_xla/csrc/ops/binary_cross_entropy_backward.cpp
@@ -48,7 +48,7 @@ BinaryCrossEntropyBackward::BinaryCrossEntropyBackward(
            torch::lazy::MHash(torch::lazy::GetEnumValue(reduction))),
       reduction_(reduction) {}
 
-NodePtr BinaryCrossEntropyBackward::Clone(OpList operands) const {
+torch::lazy::NodePtr BinaryCrossEntropyBackward::Clone(OpList operands) const {
   absl::optional<Value> weight;
   if (operands.size() > 3) {
     weight = operands.at(3);

--- a/torch_xla/csrc/ops/binary_cross_entropy_backward.h
+++ b/torch_xla/csrc/ops/binary_cross_entropy_backward.h
@@ -17,7 +17,7 @@ class BinaryCrossEntropyBackward : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/cast.cpp
+++ b/torch_xla/csrc/ops/cast.cpp
@@ -41,7 +41,7 @@ Cast::Cast(const Value& input, at::ScalarType dtype,
       dtype_(dtype),
       stype_(stype) {}
 
-NodePtr Cast::Clone(OpList operands) const {
+torch::lazy::NodePtr Cast::Clone(OpList operands) const {
   return dtype_ ? ir::MakeNode<Cast>(operands.at(0), *dtype_, stype_)
                 : ir::MakeNode<Cast>(operands.at(0), type_);
 }

--- a/torch_xla/csrc/ops/cast.h
+++ b/torch_xla/csrc/ops/cast.h
@@ -17,7 +17,7 @@ class Cast : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/cat.cpp
+++ b/torch_xla/csrc/ops/cat.cpp
@@ -31,7 +31,7 @@ Cat::Cat(absl::Span<const ir::Value> values, int64_t dim)
            /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}
 
-NodePtr Cat::Clone(OpList operands) const {
+torch::lazy::NodePtr Cat::Clone(OpList operands) const {
   return ir::MakeNode<Cat>(operands, dim_);
 }
 

--- a/torch_xla/csrc/ops/cat.h
+++ b/torch_xla/csrc/ops/cat.h
@@ -13,7 +13,7 @@ class Cat : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/cholesky.cpp
+++ b/torch_xla/csrc/ops/cholesky.cpp
@@ -13,7 +13,7 @@ Cholesky::Cholesky(const Value& input, bool lower)
            /*num_outputs=*/1, torch::lazy::MHash(lower)),
       lower_(lower) {}
 
-NodePtr Cholesky::Clone(OpList operands) const {
+torch::lazy::NodePtr Cholesky::Clone(OpList operands) const {
   return ir::MakeNode<Cholesky>(operands.at(0), lower_);
 }
 

--- a/torch_xla/csrc/ops/cholesky.h
+++ b/torch_xla/csrc/ops/cholesky.h
@@ -12,7 +12,7 @@ class Cholesky : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/collective_permute.cpp
+++ b/torch_xla/csrc/ops/collective_permute.cpp
@@ -32,7 +32,7 @@ CollectivePermute::CollectivePermute(
            /*num_outputs=*/2, torch::lazy::MHash(source_target_pairs)),
       source_target_pairs_(std::move(source_target_pairs)) {}
 
-NodePtr CollectivePermute::Clone(OpList operands) const {
+torch::lazy::NodePtr CollectivePermute::Clone(OpList operands) const {
   return ir::MakeNode<CollectivePermute>(operands.at(0), operands.at(1),
                                          source_target_pairs_);
 }

--- a/torch_xla/csrc/ops/collective_permute.h
+++ b/torch_xla/csrc/ops/collective_permute.h
@@ -15,7 +15,7 @@ class CollectivePermute : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/constant.cpp
+++ b/torch_xla/csrc/ops/constant.cpp
@@ -24,7 +24,7 @@ std::string Constant::ToString() const {
   return ss.str();
 }
 
-NodePtr Constant::Clone(OpList operands) const {
+torch::lazy::NodePtr Constant::Clone(OpList operands) const {
   return ir::MakeNode<Constant>(value_.Clone());
 }
 

--- a/torch_xla/csrc/ops/constant.h
+++ b/torch_xla/csrc/ops/constant.h
@@ -12,7 +12,7 @@ class Constant : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/constant_pad_nd.cpp
+++ b/torch_xla/csrc/ops/constant_pad_nd.cpp
@@ -41,7 +41,7 @@ ConstantPadNd::ConstantPadNd(const Value& input, std::vector<int64_t> pad,
       pad_(std::move(pad)),
       value_(value) {}
 
-NodePtr ConstantPadNd::Clone(OpList operands) const {
+torch::lazy::NodePtr ConstantPadNd::Clone(OpList operands) const {
   return ir::MakeNode<ConstantPadNd>(operands.at(0), pad_, value_);
 }
 

--- a/torch_xla/csrc/ops/constant_pad_nd.h
+++ b/torch_xla/csrc/ops/constant_pad_nd.h
@@ -15,7 +15,7 @@ class ConstantPadNd : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/convolution_backward_overrideable.cpp
+++ b/torch_xla/csrc/ops/convolution_backward_overrideable.cpp
@@ -58,7 +58,8 @@ ConvolutionBackwardOverrideable::ConvolutionBackwardOverrideable(
       transposed_(transposed),
       groups_(groups) {}
 
-NodePtr ConvolutionBackwardOverrideable::Clone(OpList operands) const {
+torch::lazy::NodePtr ConvolutionBackwardOverrideable::Clone(
+    OpList operands) const {
   return ir::MakeNode<ConvolutionBackwardOverrideable>(
       operands.at(0), operands.at(1), operands.at(2), stride_, padding_,
       dilation_, transposed_, output_padding_, groups_);

--- a/torch_xla/csrc/ops/convolution_backward_overrideable.h
+++ b/torch_xla/csrc/ops/convolution_backward_overrideable.h
@@ -16,7 +16,7 @@ class ConvolutionBackwardOverrideable : public Node {
       std::vector<int64_t> dilation, bool transposed,
       std::vector<int64_t> output_padding, int64_t groups);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/convolution_overrideable.cpp
+++ b/torch_xla/csrc/ops/convolution_overrideable.cpp
@@ -73,7 +73,7 @@ ConvolutionOverrideable::ConvolutionOverrideable(
       transposed_(transposed),
       groups_(groups) {}
 
-NodePtr ConvolutionOverrideable::Clone(OpList operands) const {
+torch::lazy::NodePtr ConvolutionOverrideable::Clone(OpList operands) const {
   return operands.size() == 3
              ? ir::MakeNode<ConvolutionOverrideable>(
                    operands.at(0), operands.at(1), operands.at(2), stride_,

--- a/torch_xla/csrc/ops/convolution_overrideable.h
+++ b/torch_xla/csrc/ops/convolution_overrideable.h
@@ -23,7 +23,7 @@ class ConvolutionOverrideable : public Node {
                           std::vector<int64_t> dilation, bool transposed,
                           std::vector<int64_t> output_padding, int64_t groups);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/cumprod.cpp
+++ b/torch_xla/csrc/ops/cumprod.cpp
@@ -46,7 +46,7 @@ CumProd::CumProd(const Value& input, int64_t dim,
       dim_(dim),
       dtype_(dtype) {}
 
-NodePtr CumProd::Clone(OpList operands) const {
+torch::lazy::NodePtr CumProd::Clone(OpList operands) const {
   return ir::MakeNode<CumProd>(operands.at(0), dim_, dtype_);
 }
 

--- a/torch_xla/csrc/ops/cumprod.h
+++ b/torch_xla/csrc/ops/cumprod.h
@@ -15,7 +15,7 @@ class CumProd : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/cumsum.cpp
+++ b/torch_xla/csrc/ops/cumsum.cpp
@@ -45,7 +45,7 @@ CumSum::CumSum(const Value& input, int64_t dim,
       dim_(dim),
       dtype_(dtype) {}
 
-NodePtr CumSum::Clone(OpList operands) const {
+torch::lazy::NodePtr CumSum::Clone(OpList operands) const {
   return ir::MakeNode<CumSum>(operands.at(0), dim_, dtype_);
 }
 

--- a/torch_xla/csrc/ops/cumsum.h
+++ b/torch_xla/csrc/ops/cumsum.h
@@ -15,7 +15,7 @@ class CumSum : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/device_data.cpp
+++ b/torch_xla/csrc/ops/device_data.cpp
@@ -20,7 +20,7 @@ std::string DeviceData::ToString() const {
   return ss.str();
 }
 
-NodePtr DeviceData::Clone(OpList operands) const {
+torch::lazy::NodePtr DeviceData::Clone(OpList operands) const {
   return ir::MakeNode<DeviceData>(data_);
 }
 

--- a/torch_xla/csrc/ops/device_data.h
+++ b/torch_xla/csrc/ops/device_data.h
@@ -13,7 +13,7 @@ class DeviceData : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/diagonal.cpp
+++ b/torch_xla/csrc/ops/diagonal.cpp
@@ -22,7 +22,7 @@ Diagonal::Diagonal(const Value& input, int64_t offset, int64_t dim1,
       dim1_(dim1),
       dim2_(dim2) {}
 
-NodePtr Diagonal::Clone(OpList operands) const {
+torch::lazy::NodePtr Diagonal::Clone(OpList operands) const {
   return ir::MakeNode<Diagonal>(operands.at(0), offset_, dim1_, dim2_);
 }
 

--- a/torch_xla/csrc/ops/diagonal.h
+++ b/torch_xla/csrc/ops/diagonal.h
@@ -10,7 +10,7 @@ class Diagonal : public Node {
  public:
   Diagonal(const Value& input, int64_t offset, int64_t dim1, int64_t dim2);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/diagonal_view_update.cpp
+++ b/torch_xla/csrc/ops/diagonal_view_update.cpp
@@ -17,7 +17,7 @@ DiagonalViewUpdate::DiagonalViewUpdate(const Value& target, const Value& input,
       dim1_(dim1),
       dim2_(dim2) {}
 
-NodePtr DiagonalViewUpdate::Clone(OpList operands) const {
+torch::lazy::NodePtr DiagonalViewUpdate::Clone(OpList operands) const {
   return ir::MakeNode<DiagonalViewUpdate>(operands.at(0), operands.at(1),
                                           offset_, dim1_, dim2_);
 }

--- a/torch_xla/csrc/ops/diagonal_view_update.h
+++ b/torch_xla/csrc/ops/diagonal_view_update.h
@@ -11,7 +11,7 @@ class DiagonalViewUpdate : public Node {
   DiagonalViewUpdate(const Value& target, const Value& input, int64_t offset,
                      int64_t dim1, int64_t dim2);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/discrete_uniform.cpp
+++ b/torch_xla/csrc/ops/discrete_uniform.cpp
@@ -15,7 +15,7 @@ DiscreteUniform::DiscreteUniform(const Value& from, const Value& to,
     : Node(torch::lazy::OpKind(at::aten::random), {from, to, seed}, rng_shape,
            /*num_outputs=*/1, torch::lazy::Hash(rng_shape)) {}
 
-NodePtr DiscreteUniform::Clone(OpList operands) const {
+torch::lazy::NodePtr DiscreteUniform::Clone(OpList operands) const {
   return ir::MakeNode<DiscreteUniform>(operands.at(0), operands.at(1),
                                        operands.at(2), xla_shape());
 }

--- a/torch_xla/csrc/ops/discrete_uniform.h
+++ b/torch_xla/csrc/ops/discrete_uniform.h
@@ -11,7 +11,7 @@ class DiscreteUniform : public Node {
   DiscreteUniform(const Value& from, const Value& to, const Value& seed,
                   const xla::Shape& rng_shape);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 };

--- a/torch_xla/csrc/ops/expand.cpp
+++ b/torch_xla/csrc/ops/expand.cpp
@@ -27,7 +27,7 @@ Expand::Expand(const Value& input, std::vector<int64_t> size)
            /*num_outputs=*/1, torch::lazy::MHash(size)),
       size_(std::move(size)) {}
 
-NodePtr Expand::Clone(OpList operands) const {
+torch::lazy::NodePtr Expand::Clone(OpList operands) const {
   return ir::MakeNode<Expand>(operands.at(0), size_);
 }
 

--- a/torch_xla/csrc/ops/expand.h
+++ b/torch_xla/csrc/ops/expand.h
@@ -14,7 +14,7 @@ class Expand : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/exponential.cpp
+++ b/torch_xla/csrc/ops/exponential.cpp
@@ -13,7 +13,7 @@ Exponential::Exponential(const Value& lambda, const Value& seed,
     : Node(torch::lazy::OpKind(at::aten::exponential), {lambda, seed},
            std::move(shape)) {}
 
-NodePtr Exponential::Clone(OpList operands) const {
+torch::lazy::NodePtr Exponential::Clone(OpList operands) const {
   return ir::MakeNode<Exponential>(operands.at(0), operands.at(1), xla_shape());
 }
 

--- a/torch_xla/csrc/ops/exponential.h
+++ b/torch_xla/csrc/ops/exponential.h
@@ -10,7 +10,7 @@ class Exponential : public Node {
  public:
   Exponential(const Value& lambda, const Value& seed, xla::Shape shape);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 };

--- a/torch_xla/csrc/ops/flip.cpp
+++ b/torch_xla/csrc/ops/flip.cpp
@@ -12,7 +12,7 @@ Flip::Flip(const Value& input, std::vector<int64_t> dims)
            /*num_outputs=*/1, torch::lazy::MHash(dims)),
       dims_(std::move(dims)) {}
 
-NodePtr Flip::Clone(OpList operands) const {
+torch::lazy::NodePtr Flip::Clone(OpList operands) const {
   return ir::MakeNode<Flip>(operands.at(0), dims_);
 }
 

--- a/torch_xla/csrc/ops/flip.h
+++ b/torch_xla/csrc/ops/flip.h
@@ -11,7 +11,7 @@ class Flip : public Node {
  public:
   Flip(const Value& input, std::vector<int64_t> dims);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/gather.cpp
+++ b/torch_xla/csrc/ops/gather.cpp
@@ -30,7 +30,7 @@ Gather::Gather(const Value& input, int64_t dim, const Value& index)
            /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}
 
-NodePtr Gather::Clone(OpList operands) const {
+torch::lazy::NodePtr Gather::Clone(OpList operands) const {
   return ir::MakeNode<Gather>(operands.at(0), dim_, operands.at(1));
 }
 

--- a/torch_xla/csrc/ops/gather.h
+++ b/torch_xla/csrc/ops/gather.h
@@ -12,7 +12,7 @@ class Gather : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/generic.cpp
+++ b/torch_xla/csrc/ops/generic.cpp
@@ -26,7 +26,7 @@ Generic::Generic(torch::lazy::OpKind op, xla::Shape shape, LowerFn lower_fn,
       lower_fn_(std::move(lower_fn)),
       hash_seed_(hash_seed) {}
 
-NodePtr Generic::Clone(OpList operands) const {
+torch::lazy::NodePtr Generic::Clone(OpList operands) const {
   return ir::MakeNode<Generic>(op(), operands, xla_shape(), lower_fn_,
                                num_outputs(), hash_seed_);
 }

--- a/torch_xla/csrc/ops/generic.h
+++ b/torch_xla/csrc/ops/generic.h
@@ -27,7 +27,7 @@ class Generic : public Node {
   Generic(torch::lazy::OpKind op, xla::Shape shape, LowerFn lower_fn,
           size_t num_outputs, torch::lazy::hash_t hash_seed);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/generic_slice.cpp
+++ b/torch_xla/csrc/ops/generic_slice.cpp
@@ -33,7 +33,7 @@ GenericSlice::GenericSlice(const Value& input,
       base_indices_(base_indices.begin(), base_indices.end()),
       sizes_(sizes.begin(), sizes.end()) {}
 
-NodePtr GenericSlice::Clone(OpList operands) const {
+torch::lazy::NodePtr GenericSlice::Clone(OpList operands) const {
   return ir::MakeNode<GenericSlice>(operands.at(0), base_indices_, sizes_);
 }
 

--- a/torch_xla/csrc/ops/generic_slice.h
+++ b/torch_xla/csrc/ops/generic_slice.h
@@ -12,7 +12,7 @@ class GenericSlice : public Node {
   GenericSlice(const Value& input, absl::Span<const int64_t> base_indices,
                absl::Span<const int64_t> sizes);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/get_dimensions_size.cpp
+++ b/torch_xla/csrc/ops/get_dimensions_size.cpp
@@ -19,7 +19,7 @@ GetDimensionsSize::GetDimensionsSize(const Value& input,
            /*num_outputs=*/1, torch::lazy::MHash(dimensions)),
       dimensions_(std::move(dimensions)) {}
 
-NodePtr GetDimensionsSize::Clone(OpList operands) const {
+torch::lazy::NodePtr GetDimensionsSize::Clone(OpList operands) const {
   return ir::MakeNode<GetDimensionsSize>(operands.at(0), dimensions_);
 }
 

--- a/torch_xla/csrc/ops/get_dimensions_size.h
+++ b/torch_xla/csrc/ops/get_dimensions_size.h
@@ -12,7 +12,7 @@ class GetDimensionsSize : public Node {
  public:
   GetDimensionsSize(const Value& input, std::vector<int64_t> dimensions);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/hardshrink.cpp
+++ b/torch_xla/csrc/ops/hardshrink.cpp
@@ -21,7 +21,7 @@ std::string Hardshrink::ToString() const {
   return ss.str();
 }
 
-NodePtr Hardshrink::Clone(OpList operands) const {
+torch::lazy::NodePtr Hardshrink::Clone(OpList operands) const {
   return ir::MakeNode<Hardshrink>(operands.at(0), lambda_);
 }
 

--- a/torch_xla/csrc/ops/hardshrink.h
+++ b/torch_xla/csrc/ops/hardshrink.h
@@ -14,7 +14,7 @@ class Hardshrink : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/hardtanh_backward.cpp
+++ b/torch_xla/csrc/ops/hardtanh_backward.cpp
@@ -24,7 +24,7 @@ std::string HardtanhBackward::ToString() const {
   return ss.str();
 }
 
-NodePtr HardtanhBackward::Clone(OpList operands) const {
+torch::lazy::NodePtr HardtanhBackward::Clone(OpList operands) const {
   return ir::MakeNode<HardtanhBackward>(operands.at(0), operands.at(1),
                                         min_val_, max_val_);
 }

--- a/torch_xla/csrc/ops/hardtanh_backward.h
+++ b/torch_xla/csrc/ops/hardtanh_backward.h
@@ -15,7 +15,7 @@ class HardtanhBackward : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/index_get.cpp
+++ b/torch_xla/csrc/ops/index_get.cpp
@@ -36,7 +36,7 @@ std::string IndexGet::ToString() const {
   return ss.str();
 }
 
-NodePtr IndexGet::Clone(OpList operands) const {
+torch::lazy::NodePtr IndexGet::Clone(OpList operands) const {
   return ir::MakeNode<IndexGet>(operands.at(0), operands.at(1), start_dim_);
 }
 

--- a/torch_xla/csrc/ops/index_get.h
+++ b/torch_xla/csrc/ops/index_get.h
@@ -12,7 +12,7 @@ class IndexGet : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/index_ops.cpp
+++ b/torch_xla/csrc/ops/index_ops.cpp
@@ -149,8 +149,9 @@ std::vector<XLATensor> WrapIndicesOnce(const XLATensor& base,
   return canonical_indices;
 }
 
-ir::NodePtr IndexFillOp(const ir::Value& buffer, int64_t dim,
-                        const ir::Value& index, const ir::Value& value) {
+torch::lazy::NodePtr IndexFillOp(const ir::Value& buffer, int64_t dim,
+                                 const ir::Value& index,
+                                 const ir::Value& value) {
   auto lower_fn = [dim](const ir::Node& node,
                         ir::LoweringContext* loctx) -> ir::XlaOpVector {
     xla::XlaOp xla_base = loctx->GetOutputOp(node.operand(0));
@@ -174,8 +175,9 @@ ir::NodePtr IndexFillOp(const ir::Value& buffer, int64_t dim,
       std::move(lower_fn), /*num_outputs=*/1, torch::lazy::MHash(dim));
 }
 
-ir::NodePtr IndexAddOp(const ir::Value& buffer, int64_t dim,
-                       const ir::Value& index, const ir::Value& source) {
+torch::lazy::NodePtr IndexAddOp(const ir::Value& buffer, int64_t dim,
+                                const ir::Value& index,
+                                const ir::Value& source) {
   auto lower_fn = [dim](const ir::Node& node,
                         ir::LoweringContext* loctx) -> ir::XlaOpVector {
     xla::XlaOp xla_base = loctx->GetOutputOp(node.operand(0));
@@ -199,8 +201,9 @@ ir::NodePtr IndexAddOp(const ir::Value& buffer, int64_t dim,
       std::move(lower_fn));
 }
 
-ir::NodePtr IndexCopyOp(const ir::Value& buffer, int64_t dim,
-                        const ir::Value& index, const ir::Value& source) {
+torch::lazy::NodePtr IndexCopyOp(const ir::Value& buffer, int64_t dim,
+                                 const ir::Value& index,
+                                 const ir::Value& source) {
   auto lower_fn = [dim](const ir::Node& node,
                         ir::LoweringContext* loctx) -> ir::XlaOpVector {
     xla::XlaOp xla_base = loctx->GetOutputOp(node.operand(0));
@@ -283,8 +286,9 @@ ir::Value IndexPutByTensors(const XLATensor& base,
       torch::lazy::ToVector<int64_t>(result_permutation));
 }
 
-ir::NodePtr IndexFill(const XLATensor& base, int64_t dim,
-                      const XLATensor& index, const at::Scalar& value) {
+torch::lazy::NodePtr IndexFill(const XLATensor& base, int64_t dim,
+                               const XLATensor& index,
+                               const at::Scalar& value) {
   XLA_CHECK_EQ(index.dtype(), at::ScalarType::Long)
       << "Fill index is expected to be of scalar type Long, but it is "
       << index.dtype();
@@ -296,8 +300,8 @@ ir::NodePtr IndexFill(const XLATensor& base, int64_t dim,
                                      base.GetDevice()));
 }
 
-ir::NodePtr IndexFill(const XLATensor& base, int64_t dim,
-                      const XLATensor& index, const XLATensor& value) {
+torch::lazy::NodePtr IndexFill(const XLATensor& base, int64_t dim,
+                               const XLATensor& index, const XLATensor& value) {
   XLA_CHECK_EQ(index.dtype(), at::ScalarType::Long)
       << "Fill index is expected to be of scalar type Long, but it is "
       << index.dtype();

--- a/torch_xla/csrc/ops/index_ops.cpp
+++ b/torch_xla/csrc/ops/index_ops.cpp
@@ -243,8 +243,9 @@ CanonicalIndexInfo GetCanonicalIndexInfo(
 }
 
 ir::Value EnsureRank1(const ir::Value& index) {
-  XLA_CHECK_LE(index->xla_shape().rank(), 1);
-  return index->xla_shape().rank() == 0
+  const ir::Node* casted = dynamic_cast<const ir::Node*>(index.node.get());
+  XLA_CHECK_LE(casted->xla_shape().rank(), 1);
+  return casted->xla_shape().rank() == 0
              ? ir::MakeNode<ir::ops::Expand>(index, std::vector<int64_t>{1})
              : index;
 }

--- a/torch_xla/csrc/ops/index_ops.h
+++ b/torch_xla/csrc/ops/index_ops.h
@@ -65,11 +65,11 @@ ir::Value IndexPutByTensors(const XLATensor& base,
                             bool accumulate,
                             absl::Span<const int64_t> result_permutation);
 
-ir::NodePtr IndexFill(const XLATensor& base, int64_t dim,
-                      const XLATensor& index, const at::Scalar& value);
+torch::lazy::NodePtr IndexFill(const XLATensor& base, int64_t dim,
+                               const XLATensor& index, const at::Scalar& value);
 
-ir::NodePtr IndexFill(const XLATensor& base, int64_t dim,
-                      const XLATensor& index, const XLATensor& value);
+torch::lazy::NodePtr IndexFill(const XLATensor& base, int64_t dim,
+                               const XLATensor& index, const XLATensor& value);
 
 ir::Value IndexAdd(const XLATensor& base, int64_t dim, const XLATensor& index,
                    const XLATensor& source);

--- a/torch_xla/csrc/ops/index_put.cpp
+++ b/torch_xla/csrc/ops/index_put.cpp
@@ -22,7 +22,7 @@ std::string IndexPut::ToString() const {
   return ss.str();
 }
 
-NodePtr IndexPut::Clone(OpList operands) const {
+torch::lazy::NodePtr IndexPut::Clone(OpList operands) const {
   return ir::MakeNode<IndexPut>(operands.at(0), operands.at(1), start_dim_,
                                 operands.at(2), accumulate_);
 }

--- a/torch_xla/csrc/ops/index_put.h
+++ b/torch_xla/csrc/ops/index_put.h
@@ -13,7 +13,7 @@ class IndexPut : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/index_select.cpp
+++ b/torch_xla/csrc/ops/index_select.cpp
@@ -28,7 +28,7 @@ IndexSelect::IndexSelect(const Value& input, int64_t dim, const Value& index)
            /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}
 
-NodePtr IndexSelect::Clone(OpList operands) const {
+torch::lazy::NodePtr IndexSelect::Clone(OpList operands) const {
   return ir::MakeNode<IndexSelect>(operands.at(0), dim_, operands.at(1));
 }
 

--- a/torch_xla/csrc/ops/index_select.h
+++ b/torch_xla/csrc/ops/index_select.h
@@ -12,7 +12,7 @@ class IndexSelect : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/kth_value.cpp
+++ b/torch_xla/csrc/ops/kth_value.cpp
@@ -29,7 +29,7 @@ KthValue::KthValue(const Value& input, int64_t k, int64_t dim, bool keepdim)
       dim_(dim),
       keepdim_(keepdim) {}
 
-NodePtr KthValue::Clone(OpList operands) const {
+torch::lazy::NodePtr KthValue::Clone(OpList operands) const {
   return ir::MakeNode<KthValue>(operands.at(0), k_, dim_, keepdim_);
 }
 

--- a/torch_xla/csrc/ops/kth_value.h
+++ b/torch_xla/csrc/ops/kth_value.h
@@ -12,7 +12,7 @@ class KthValue : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/l1_loss.cpp
+++ b/torch_xla/csrc/ops/l1_loss.cpp
@@ -30,7 +30,7 @@ L1Loss::L1Loss(const Value& input, const Value& target, ReductionMode reduction)
            torch::lazy::MHash(torch::lazy::GetEnumValue(reduction))),
       reduction_(reduction) {}
 
-NodePtr L1Loss::Clone(OpList operands) const {
+torch::lazy::NodePtr L1Loss::Clone(OpList operands) const {
   return ir::MakeNode<L1Loss>(operands.at(0), operands.at(1), reduction_);
 }
 

--- a/torch_xla/csrc/ops/l1_loss.h
+++ b/torch_xla/csrc/ops/l1_loss.h
@@ -14,7 +14,7 @@ class L1Loss : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/l1_loss_backward.cpp
+++ b/torch_xla/csrc/ops/l1_loss_backward.cpp
@@ -35,7 +35,7 @@ L1LossBackward::L1LossBackward(const Value& grad_output, const Value& input,
            torch::lazy::MHash(torch::lazy::GetEnumValue(reduction))),
       reduction_(reduction) {}
 
-NodePtr L1LossBackward::Clone(OpList operands) const {
+torch::lazy::NodePtr L1LossBackward::Clone(OpList operands) const {
   return ir::MakeNode<L1LossBackward>(operands.at(0), operands.at(1),
                                       operands.at(2), reduction_);
 }

--- a/torch_xla/csrc/ops/l1_loss_backward.h
+++ b/torch_xla/csrc/ops/l1_loss_backward.h
@@ -15,7 +15,7 @@ class L1LossBackward : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/leaky_relu.cpp
+++ b/torch_xla/csrc/ops/leaky_relu.cpp
@@ -13,7 +13,7 @@ LeakyRelu::LeakyRelu(const Value& input, double negative_slope)
            /*num_outputs=*/1, torch::lazy::MHash(negative_slope)),
       negative_slope_(negative_slope) {}
 
-NodePtr LeakyRelu::Clone(OpList operands) const {
+torch::lazy::NodePtr LeakyRelu::Clone(OpList operands) const {
   return ir::MakeNode<LeakyRelu>(operands.at(0), negative_slope_);
 }
 

--- a/torch_xla/csrc/ops/leaky_relu.h
+++ b/torch_xla/csrc/ops/leaky_relu.h
@@ -12,7 +12,7 @@ class LeakyRelu : public Node {
  public:
   LeakyRelu(const Value& input, double negative_slope);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/leaky_relu_backward.cpp
+++ b/torch_xla/csrc/ops/leaky_relu_backward.cpp
@@ -14,7 +14,7 @@ LeakyReluBackward::LeakyReluBackward(const Value& grad_output,
            /*num_outputs=*/1, torch::lazy::MHash(negative_slope)),
       negative_slope_(negative_slope) {}
 
-NodePtr LeakyReluBackward::Clone(OpList operands) const {
+torch::lazy::NodePtr LeakyReluBackward::Clone(OpList operands) const {
   return ir::MakeNode<LeakyReluBackward>(operands.at(0), operands.at(1),
                                          negative_slope_);
 }

--- a/torch_xla/csrc/ops/leaky_relu_backward.h
+++ b/torch_xla/csrc/ops/leaky_relu_backward.h
@@ -13,7 +13,7 @@ class LeakyReluBackward : public Node {
   LeakyReluBackward(const Value& grad_output, const Value& input,
                     double negative_slope);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/linear_interpolation.cpp
+++ b/torch_xla/csrc/ops/linear_interpolation.cpp
@@ -14,7 +14,7 @@ LinearInterpolation::LinearInterpolation(const Value& value,
            /*num_outputs=*/1, torch::lazy::MHash(alpha)),
       alpha_(alpha) {}
 
-NodePtr LinearInterpolation::Clone(OpList operands) const {
+torch::lazy::NodePtr LinearInterpolation::Clone(OpList operands) const {
   return ir::MakeNode<LinearInterpolation>(operands.at(0), operands.at(1),
                                            alpha_);
 }

--- a/torch_xla/csrc/ops/linear_interpolation.h
+++ b/torch_xla/csrc/ops/linear_interpolation.h
@@ -12,7 +12,7 @@ class LinearInterpolation : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/linspace.cpp
+++ b/torch_xla/csrc/ops/linspace.cpp
@@ -19,7 +19,7 @@ Linspace::Linspace(const Value& start, const Value& end, int64_t steps)
            /*num_outputs=*/1, torch::lazy::MHash(steps)),
       steps_(steps) {}
 
-NodePtr Linspace::Clone(OpList operands) const {
+torch::lazy::NodePtr Linspace::Clone(OpList operands) const {
   return ir::MakeNode<Linspace>(operands.at(0), operands.at(1), steps_);
 }
 

--- a/torch_xla/csrc/ops/linspace.h
+++ b/torch_xla/csrc/ops/linspace.h
@@ -12,7 +12,7 @@ class Linspace : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/log_softmax.cpp
+++ b/torch_xla/csrc/ops/log_softmax.cpp
@@ -38,7 +38,7 @@ LogSoftmax::LogSoftmax(const Value& input, int64_t dim,
       dim_(dim),
       dtype_(dtype) {}
 
-NodePtr LogSoftmax::Clone(OpList operands) const {
+torch::lazy::NodePtr LogSoftmax::Clone(OpList operands) const {
   return ir::MakeNode<LogSoftmax>(operands.at(0), dim_, dtype_);
 }
 

--- a/torch_xla/csrc/ops/log_softmax.h
+++ b/torch_xla/csrc/ops/log_softmax.h
@@ -15,7 +15,7 @@ class LogSoftmax : public Node {
   LogSoftmax(const Value& input, int64_t dim,
              c10::optional<at::ScalarType> dtype);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/log_softmax_backward.cpp
+++ b/torch_xla/csrc/ops/log_softmax_backward.cpp
@@ -16,7 +16,7 @@ LogSoftmaxBackward::LogSoftmaxBackward(const Value& grad_output,
            /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}
 
-NodePtr LogSoftmaxBackward::Clone(OpList operands) const {
+torch::lazy::NodePtr LogSoftmaxBackward::Clone(OpList operands) const {
   return ir::MakeNode<LogSoftmaxBackward>(operands.at(0), operands.at(1), dim_);
 }
 

--- a/torch_xla/csrc/ops/log_softmax_backward.h
+++ b/torch_xla/csrc/ops/log_softmax_backward.h
@@ -11,7 +11,7 @@ class LogSoftmaxBackward : public Node {
   LogSoftmaxBackward(const Value& grad_output, const Value& output,
                      int64_t dim);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/logsumexp.cpp
+++ b/torch_xla/csrc/ops/logsumexp.cpp
@@ -35,7 +35,7 @@ Logsumexp::Logsumexp(const Value& input, std::vector<int64_t> dimensions,
       dimensions_(std::move(dimensions)),
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
-NodePtr Logsumexp::Clone(OpList operands) const {
+torch::lazy::NodePtr Logsumexp::Clone(OpList operands) const {
   return ir::MakeNode<Logsumexp>(operands.at(0), dimensions_,
                                  keep_reduced_dimensions_);
 }

--- a/torch_xla/csrc/ops/logsumexp.h
+++ b/torch_xla/csrc/ops/logsumexp.h
@@ -17,7 +17,7 @@ class Logsumexp : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/masked_fill.cpp
+++ b/torch_xla/csrc/ops/masked_fill.cpp
@@ -16,7 +16,7 @@ MaskedFill::MaskedFill(const Value& input, const Value& mask,
            /*num_outputs=*/1, ScalarHash(value)),
       value_(std::move(value)) {}
 
-NodePtr MaskedFill::Clone(OpList operands) const {
+torch::lazy::NodePtr MaskedFill::Clone(OpList operands) const {
   return ir::MakeNode<MaskedFill>(operands.at(0), operands.at(1), value_);
 }
 

--- a/torch_xla/csrc/ops/masked_fill.h
+++ b/torch_xla/csrc/ops/masked_fill.h
@@ -14,7 +14,7 @@ class MaskedFill : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/masked_scatter.cpp
+++ b/torch_xla/csrc/ops/masked_scatter.cpp
@@ -13,7 +13,7 @@ MaskedScatter::MaskedScatter(const Value& input, const Value& mask,
            input.xla_shape(),
            /*num_outputs=*/1) {}
 
-NodePtr MaskedScatter::Clone(OpList operands) const {
+torch::lazy::NodePtr MaskedScatter::Clone(OpList operands) const {
   return ir::MakeNode<MaskedScatter>(operands.at(0), operands.at(1),
                                      operands.at(2));
 }

--- a/torch_xla/csrc/ops/masked_scatter.h
+++ b/torch_xla/csrc/ops/masked_scatter.h
@@ -13,7 +13,7 @@ class MaskedScatter : public Node {
  public:
   MaskedScatter(const Value& input, const Value& mask, const Value& source);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 };

--- a/torch_xla/csrc/ops/masked_select.cpp
+++ b/torch_xla/csrc/ops/masked_select.cpp
@@ -28,7 +28,7 @@ MaskedSelect::MaskedSelect(const Value& input, const Value& mask)
            NodeOutputShape(input),
            /*num_outputs=*/2) {}
 
-NodePtr MaskedSelect::Clone(OpList operands) const {
+torch::lazy::NodePtr MaskedSelect::Clone(OpList operands) const {
   return ir::MakeNode<MaskedSelect>(operands.at(0), operands.at(1));
 }
 

--- a/torch_xla/csrc/ops/masked_select.h
+++ b/torch_xla/csrc/ops/masked_select.h
@@ -13,7 +13,7 @@ class MaskedSelect : public Node {
  public:
   MaskedSelect(const Value& input, const Value& mask);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 };

--- a/torch_xla/csrc/ops/max_in_dim.cpp
+++ b/torch_xla/csrc/ops/max_in_dim.cpp
@@ -28,7 +28,7 @@ MaxInDim::MaxInDim(const Value& input, int64_t dim, bool keepdim)
       dim_(dim),
       keepdim_(keepdim) {}
 
-NodePtr MaxInDim::Clone(OpList operands) const {
+torch::lazy::NodePtr MaxInDim::Clone(OpList operands) const {
   return ir::MakeNode<MaxInDim>(operands.at(0), dim_, keepdim_);
 }
 

--- a/torch_xla/csrc/ops/max_in_dim.h
+++ b/torch_xla/csrc/ops/max_in_dim.h
@@ -12,7 +12,7 @@ class MaxInDim : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/max_pool_nd.cpp
+++ b/torch_xla/csrc/ops/max_pool_nd.cpp
@@ -57,7 +57,7 @@ MaxPoolNd::MaxPoolNd(const Value& input, int64_t spatial_dim_count,
       padding_(std::move(padding)),
       ceil_mode_(ceil_mode) {}
 
-NodePtr MaxPoolNd::Clone(OpList operands) const {
+torch::lazy::NodePtr MaxPoolNd::Clone(OpList operands) const {
   return ir::MakeNode<MaxPoolNd>(operands.at(0), spatial_dim_count_,
                                  kernel_size_, stride_, padding_, ceil_mode_);
 }

--- a/torch_xla/csrc/ops/max_pool_nd.h
+++ b/torch_xla/csrc/ops/max_pool_nd.h
@@ -12,7 +12,7 @@ class MaxPoolNd : public Node {
             std::vector<int64_t> kernel_size, std::vector<int64_t> stride,
             std::vector<int64_t> padding, bool ceil_mode);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/max_pool_nd_backward.cpp
+++ b/torch_xla/csrc/ops/max_pool_nd_backward.cpp
@@ -59,7 +59,7 @@ MaxPoolNdBackward::MaxPoolNdBackward(
       padding_(std::move(padding)),
       ceil_mode_(ceil_mode) {}
 
-NodePtr MaxPoolNdBackward::Clone(OpList operands) const {
+torch::lazy::NodePtr MaxPoolNdBackward::Clone(OpList operands) const {
   return ir::MakeNode<MaxPoolNdBackward>(operands.at(0), operands.at(1),
                                          spatial_dim_count_, kernel_size_,
                                          stride_, padding_, ceil_mode_);

--- a/torch_xla/csrc/ops/max_pool_nd_backward.h
+++ b/torch_xla/csrc/ops/max_pool_nd_backward.h
@@ -13,7 +13,7 @@ class MaxPoolNdBackward : public Node {
                     std::vector<int64_t> stride, std::vector<int64_t> padding,
                     bool ceil_mode);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/max_unpool_nd.cpp
+++ b/torch_xla/csrc/ops/max_unpool_nd.cpp
@@ -41,7 +41,7 @@ MaxUnpoolNd::MaxUnpoolNd(const Value& input, const Value& indices,
            /*num_outputs=*/1, torch::lazy::MHash(output_size)),
       output_size_(std::move(output_size)) {}
 
-NodePtr MaxUnpoolNd::Clone(OpList operands) const {
+torch::lazy::NodePtr MaxUnpoolNd::Clone(OpList operands) const {
   return ir::MakeNode<MaxUnpoolNd>(operands.at(0), operands.at(1),
                                    output_size_);
 }

--- a/torch_xla/csrc/ops/max_unpool_nd.h
+++ b/torch_xla/csrc/ops/max_unpool_nd.h
@@ -11,7 +11,7 @@ class MaxUnpoolNd : public Node {
   MaxUnpoolNd(const Value& input, const Value& indices,
               std::vector<int64_t> output_size);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/max_unpool_nd_backward.cpp
+++ b/torch_xla/csrc/ops/max_unpool_nd_backward.cpp
@@ -48,7 +48,7 @@ MaxUnpoolNdBackward::MaxUnpoolNdBackward(const Value& grad_output,
            /*num_outputs=*/1, torch::lazy::MHash(output_size)),
       output_size_(std::move(output_size)) {}
 
-NodePtr MaxUnpoolNdBackward::Clone(OpList operands) const {
+torch::lazy::NodePtr MaxUnpoolNdBackward::Clone(OpList operands) const {
   return ir::MakeNode<MaxUnpoolNdBackward>(operands.at(0), operands.at(1),
                                            operands.at(2), output_size_);
 }

--- a/torch_xla/csrc/ops/max_unpool_nd_backward.h
+++ b/torch_xla/csrc/ops/max_unpool_nd_backward.h
@@ -11,7 +11,7 @@ class MaxUnpoolNdBackward : public Node {
   MaxUnpoolNdBackward(const Value& grad_output, const Value& input,
                       const Value& indices, std::vector<int64_t> output_size);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/mean.cpp
+++ b/torch_xla/csrc/ops/mean.cpp
@@ -50,7 +50,7 @@ Mean::Mean(const Value& input, std::vector<int64_t> dimensions,
       keep_reduced_dimensions_(keep_reduced_dimensions),
       dtype_(dtype) {}
 
-NodePtr Mean::Clone(OpList operands) const {
+torch::lazy::NodePtr Mean::Clone(OpList operands) const {
   return ir::MakeNode<Mean>(operands.at(0), dimensions_,
                             keep_reduced_dimensions_, dtype_);
 }

--- a/torch_xla/csrc/ops/mean.h
+++ b/torch_xla/csrc/ops/mean.h
@@ -19,7 +19,7 @@ class Mean : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/min_in_dim.cpp
+++ b/torch_xla/csrc/ops/min_in_dim.cpp
@@ -28,7 +28,7 @@ MinInDim::MinInDim(const Value& input, int64_t dim, bool keepdim)
       dim_(dim),
       keepdim_(keepdim) {}
 
-NodePtr MinInDim::Clone(OpList operands) const {
+torch::lazy::NodePtr MinInDim::Clone(OpList operands) const {
   return ir::MakeNode<MinInDim>(operands.at(0), dim_, keepdim_);
 }
 

--- a/torch_xla/csrc/ops/min_in_dim.h
+++ b/torch_xla/csrc/ops/min_in_dim.h
@@ -12,7 +12,7 @@ class MinInDim : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/mse_loss.cpp
+++ b/torch_xla/csrc/ops/mse_loss.cpp
@@ -33,7 +33,7 @@ MseLoss::MseLoss(const Value& input, const Value& target,
            torch::lazy::MHash(torch::lazy::GetEnumValue(reduction))),
       reduction_(reduction) {}
 
-NodePtr MseLoss::Clone(OpList operands) const {
+torch::lazy::NodePtr MseLoss::Clone(OpList operands) const {
   return ir::MakeNode<MseLoss>(operands.at(0), operands.at(1), reduction_);
 }
 

--- a/torch_xla/csrc/ops/mse_loss.h
+++ b/torch_xla/csrc/ops/mse_loss.h
@@ -14,7 +14,7 @@ class MseLoss : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/mse_loss_backward.cpp
+++ b/torch_xla/csrc/ops/mse_loss_backward.cpp
@@ -37,7 +37,7 @@ MseLossBackward::MseLossBackward(const Value& grad_output, const Value& input,
            torch::lazy::MHash(torch::lazy::GetEnumValue(reduction))),
       reduction_(reduction) {}
 
-NodePtr MseLossBackward::Clone(OpList operands) const {
+torch::lazy::NodePtr MseLossBackward::Clone(OpList operands) const {
   return ir::MakeNode<MseLossBackward>(operands.at(0), operands.at(1),
                                        operands.at(2), reduction_);
 }

--- a/torch_xla/csrc/ops/mse_loss_backward.h
+++ b/torch_xla/csrc/ops/mse_loss_backward.h
@@ -15,7 +15,7 @@ class MseLossBackward : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/native_batch_norm_backward.cpp
+++ b/torch_xla/csrc/ops/native_batch_norm_backward.cpp
@@ -43,7 +43,7 @@ NativeBatchNormBackward::NativeBatchNormBackward(
       training_(training),
       eps_(eps) {}
 
-NodePtr NativeBatchNormBackward::Clone(OpList operands) const {
+torch::lazy::NodePtr NativeBatchNormBackward::Clone(OpList operands) const {
   return ir::MakeNode<NativeBatchNormBackward>(operands.at(0), operands.at(1),
                                                operands.at(2), operands.at(3),
                                                operands.at(4), training_, eps_);

--- a/torch_xla/csrc/ops/native_batch_norm_backward.h
+++ b/torch_xla/csrc/ops/native_batch_norm_backward.h
@@ -13,7 +13,7 @@ class NativeBatchNormBackward : public Node {
                           const Value& weight, const Value& save_mean,
                           const Value& save_invstd, bool training, double eps);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/native_batch_norm_forward.cpp
+++ b/torch_xla/csrc/ops/native_batch_norm_forward.cpp
@@ -67,7 +67,7 @@ NativeBatchNormForward::NativeBatchNormForward(const Value& input,
       training_(training),
       eps_(eps) {}
 
-NodePtr NativeBatchNormForward::Clone(OpList operands) const {
+torch::lazy::NodePtr NativeBatchNormForward::Clone(OpList operands) const {
   return ir::MakeNode<NativeBatchNormForward>(operands.at(0), operands.at(1),
                                               operands.at(2), operands.at(3),
                                               operands.at(4), training_, eps_);

--- a/torch_xla/csrc/ops/native_batch_norm_forward.h
+++ b/torch_xla/csrc/ops/native_batch_norm_forward.h
@@ -12,7 +12,7 @@ class NativeBatchNormForward : public Node {
                          const Value& bias, const Value& running_mean,
                          const Value& running_var, bool training, double eps);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/nll_loss.cpp
+++ b/torch_xla/csrc/ops/nll_loss.cpp
@@ -49,7 +49,7 @@ NllLoss::NllLoss(const Value& logits, const Value& labels,
       reduction_(reduction),
       ignore_index_(ignore_index) {}
 
-NodePtr NllLoss::Clone(OpList operands) const {
+torch::lazy::NodePtr NllLoss::Clone(OpList operands) const {
   absl::optional<Value> weight;
   if (operands.size() > 2) {
     weight = operands.at(2);

--- a/torch_xla/csrc/ops/nll_loss.h
+++ b/torch_xla/csrc/ops/nll_loss.h
@@ -16,7 +16,7 @@ class NllLoss : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/nll_loss2d.cpp
+++ b/torch_xla/csrc/ops/nll_loss2d.cpp
@@ -49,7 +49,7 @@ NllLoss2d::NllLoss2d(const Value& logits, const Value& labels,
       reduction_(reduction),
       ignore_index_(ignore_index) {}
 
-NodePtr NllLoss2d::Clone(OpList operands) const {
+torch::lazy::NodePtr NllLoss2d::Clone(OpList operands) const {
   absl::optional<Value> weight;
   if (operands.size() > 2) {
     weight = operands.at(2);

--- a/torch_xla/csrc/ops/nll_loss2d.h
+++ b/torch_xla/csrc/ops/nll_loss2d.h
@@ -16,7 +16,7 @@ class NllLoss2d : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/nll_loss2d_backward.cpp
+++ b/torch_xla/csrc/ops/nll_loss2d_backward.cpp
@@ -58,7 +58,7 @@ NllLoss2dBackward::NllLoss2dBackward(const Value& grad_output,
       reduction_(reduction),
       ignore_index_(ignore_index) {}
 
-NodePtr NllLoss2dBackward::Clone(OpList operands) const {
+torch::lazy::NodePtr NllLoss2dBackward::Clone(OpList operands) const {
   absl::optional<Value> weight;
   absl::optional<Value> total_weight;
   if (operands.size() > 3) {

--- a/torch_xla/csrc/ops/nll_loss2d_backward.h
+++ b/torch_xla/csrc/ops/nll_loss2d_backward.h
@@ -17,7 +17,7 @@ class NllLoss2dBackward : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/nll_loss_backward.cpp
+++ b/torch_xla/csrc/ops/nll_loss_backward.cpp
@@ -58,7 +58,7 @@ NllLossBackward::NllLossBackward(const Value& grad_output, const Value& logits,
       reduction_(reduction),
       ignore_index_(ignore_index) {}
 
-NodePtr NllLossBackward::Clone(OpList operands) const {
+torch::lazy::NodePtr NllLossBackward::Clone(OpList operands) const {
   absl::optional<Value> weight;
   absl::optional<Value> total_weight;
   if (operands.size() > 3) {

--- a/torch_xla/csrc/ops/nll_loss_backward.h
+++ b/torch_xla/csrc/ops/nll_loss_backward.h
@@ -17,7 +17,7 @@ class NllLossBackward : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/nms.cpp
+++ b/torch_xla/csrc/ops/nms.cpp
@@ -38,7 +38,7 @@ Nms::Nms(const Value& boxes, const Value& scores, const Value& score_threshold,
            /*num_outputs=*/2, torch::lazy::MHash(output_size)),
       output_size_(output_size) {}
 
-NodePtr Nms::Clone(OpList operands) const {
+torch::lazy::NodePtr Nms::Clone(OpList operands) const {
   return ir::MakeNode<Nms>(operands.at(0), operands.at(1), operands.at(2),
                            operands.at(3), output_size_);
 }

--- a/torch_xla/csrc/ops/nms.h
+++ b/torch_xla/csrc/ops/nms.h
@@ -11,7 +11,7 @@ class Nms : public Node {
   Nms(const Value& boxes, const Value& scores, const Value& score_threshold,
       const Value& iou_threshold, int64_t output_size);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/nonzero.cpp
+++ b/torch_xla/csrc/ops/nonzero.cpp
@@ -28,7 +28,7 @@ NonZero::NonZero(const Value& input)
            NodeOutputShape(input),
            /*num_outputs=*/2) {}
 
-NodePtr NonZero::Clone(OpList operands) const {
+torch::lazy::NodePtr NonZero::Clone(OpList operands) const {
   return ir::MakeNode<NonZero>(operands.at(0));
 }
 

--- a/torch_xla/csrc/ops/nonzero.h
+++ b/torch_xla/csrc/ops/nonzero.h
@@ -13,7 +13,7 @@ class NonZero : public Node {
  public:
   NonZero(const Value& input);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 };

--- a/torch_xla/csrc/ops/normal.cpp
+++ b/torch_xla/csrc/ops/normal.cpp
@@ -12,7 +12,7 @@ Normal::Normal(const Value& mean, const Value& std, const Value& seed)
     : Node(torch::lazy::OpKind(at::aten::normal), {mean, std, seed},
            mean.xla_shape()) {}
 
-NodePtr Normal::Clone(OpList operands) const {
+torch::lazy::NodePtr Normal::Clone(OpList operands) const {
   return ir::MakeNode<Normal>(operands.at(0), operands.at(1), operands.at(2));
 }
 

--- a/torch_xla/csrc/ops/normal.h
+++ b/torch_xla/csrc/ops/normal.h
@@ -10,7 +10,7 @@ class Normal : public Node {
  public:
   Normal(const Value& mean, const Value& std, const Value& seed);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 };

--- a/torch_xla/csrc/ops/not_supported.cpp
+++ b/torch_xla/csrc/ops/not_supported.cpp
@@ -13,7 +13,7 @@ NotSupported::NotSupported(std::string description, xla::Shape shape)
            torch::lazy::MHash(description)),
       description_(std::move(description)) {}
 
-NodePtr NotSupported::Clone(OpList operands) const {
+torch::lazy::NodePtr NotSupported::Clone(OpList operands) const {
   return ir::MakeNode<NotSupported>(description_, xla_shape());
 }
 

--- a/torch_xla/csrc/ops/not_supported.h
+++ b/torch_xla/csrc/ops/not_supported.h
@@ -14,7 +14,7 @@ class NotSupported : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -14,18 +14,20 @@ namespace torch_xla {
 namespace ir {
 namespace ops {
 
-inline NodePtr ScalarOp(const at::Scalar& value, xla::Shape shape) {
+inline torch::lazy::NodePtr ScalarOp(const at::Scalar& value,
+                                     xla::Shape shape) {
   return ir::MakeNode<Scalar>(value, std::move(shape));
 }
-inline NodePtr ScalarOp(const at::Scalar& value, xla::PrimitiveType type) {
+inline torch::lazy::NodePtr ScalarOp(const at::Scalar& value,
+                                     xla::PrimitiveType type) {
   return ir::MakeNode<Scalar>(value, type);
 }
 
-inline NodePtr ConstantOp(xla::Literal value) {
+inline torch::lazy::NodePtr ConstantOp(xla::Literal value) {
   return ir::MakeNode<Constant>(std::move(value));
 }
 
-inline NodePtr GenericOp(
+inline torch::lazy::NodePtr GenericOp(
     torch::lazy::OpKind op, absl::Span<const Value> operands, xla::Shape shape,
     Generic::LowerFn lower_fn, size_t num_outputs = 1,
     // cast to uint32_t to avoid ambiguous constructor of uint128
@@ -35,7 +37,7 @@ inline NodePtr GenericOp(
                                           num_outputs, hash_seed);
 }
 
-inline NodePtr GenericOp(
+inline torch::lazy::NodePtr GenericOp(
     torch::lazy::OpKind op, absl::Span<const Value> operands,
     const std::function<xla::Shape()>& shape_fn, Generic::LowerFn lower_fn,
     size_t num_outputs = 1,
@@ -46,208 +48,228 @@ inline NodePtr GenericOp(
                                           hash_seed);
 }
 
-inline NodePtr GenericOp(torch::lazy::OpKind op, xla::Shape shape,
-                         Generic::LowerFn lower_fn, size_t num_outputs,
-                         torch::lazy::hash_t hash_seed) {
+inline torch::lazy::NodePtr GenericOp(torch::lazy::OpKind op, xla::Shape shape,
+                                      Generic::LowerFn lower_fn,
+                                      size_t num_outputs,
+                                      torch::lazy::hash_t hash_seed) {
   return torch_xla::ir::MakeNode<Generic>(std::move(op), std::move(shape),
                                           std::move(lower_fn), num_outputs,
                                           hash_seed);
 }
 
-NodePtr Acos(const Value& input);
+torch::lazy::NodePtr Acos(const Value& input);
 
-NodePtr Acosh(const Value& input);
+torch::lazy::NodePtr Acosh(const Value& input);
 
-NodePtr Cos(const Value& input);
+torch::lazy::NodePtr Cos(const Value& input);
 
-NodePtr Cosh(const Value& input);
+torch::lazy::NodePtr Cosh(const Value& input);
 
-NodePtr Asin(const Value& input);
+torch::lazy::NodePtr Asin(const Value& input);
 
-NodePtr Asinh(const Value& input);
+torch::lazy::NodePtr Asinh(const Value& input);
 
-NodePtr Sin(const Value& input);
+torch::lazy::NodePtr Sin(const Value& input);
 
-NodePtr Sinh(const Value& input);
+torch::lazy::NodePtr Sinh(const Value& input);
 
-NodePtr Atan(const Value& input);
+torch::lazy::NodePtr Atan(const Value& input);
 
-NodePtr Atanh(const Value& input);
+torch::lazy::NodePtr Atanh(const Value& input);
 
-NodePtr Atan2(const Value& input, const Value& other);
+torch::lazy::NodePtr Atan2(const Value& input, const Value& other);
 
-NodePtr Tan(const Value& input);
+torch::lazy::NodePtr Tan(const Value& input);
 
-NodePtr Tanh(const Value& input);
+torch::lazy::NodePtr Tanh(const Value& input);
 
-NodePtr Neg(const Value& input);
+torch::lazy::NodePtr Neg(const Value& input);
 
-NodePtr SgnOp(const Value& input);
+torch::lazy::NodePtr SgnOp(const Value& input);
 
-NodePtr SignOp(const Value& input);
+torch::lazy::NodePtr SignOp(const Value& input);
 
-NodePtr Abs(const Value& input);
+torch::lazy::NodePtr Abs(const Value& input);
 
-NodePtr ReluOp(const Value& input);
+torch::lazy::NodePtr ReluOp(const Value& input);
 
-NodePtr Min(const Value& input, const Value& other);
+torch::lazy::NodePtr Min(const Value& input, const Value& other);
 
-NodePtr Max(const Value& input, const Value& other);
+torch::lazy::NodePtr Max(const Value& input, const Value& other);
 
-NodePtr Exp(const Value& input);
+torch::lazy::NodePtr Exp(const Value& input);
 
-NodePtr Expm1(const Value& input);
+torch::lazy::NodePtr Expm1(const Value& input);
 
-NodePtr Erf(const Value& input);
+torch::lazy::NodePtr Erf(const Value& input);
 
-NodePtr Erfc(const Value& input);
+torch::lazy::NodePtr Erfc(const Value& input);
 
-NodePtr Erfinv(const Value& input);
+torch::lazy::NodePtr Erfinv(const Value& input);
 
-NodePtr Log(const Value& input);
+torch::lazy::NodePtr Log(const Value& input);
 
-NodePtr LogBase(const Value& input, torch::lazy::OpKind op, double base);
+torch::lazy::NodePtr LogBase(const Value& input, torch::lazy::OpKind op,
+                             double base);
 
-NodePtr Log1p(const Value& input);
+torch::lazy::NodePtr Log1p(const Value& input);
 
-NodePtr Sqrt(const Value& input);
+torch::lazy::NodePtr Sqrt(const Value& input);
 
-NodePtr Rsqrt(const Value& input);
+torch::lazy::NodePtr Rsqrt(const Value& input);
 
-NodePtr ReciprocalOp(const Value& input);
+torch::lazy::NodePtr ReciprocalOp(const Value& input);
 
-NodePtr Prelu(const Value& input, const Value& weight);
+torch::lazy::NodePtr Prelu(const Value& input, const Value& weight);
 
-NodePtr Pow(const Value& input, const Value& exponent);
+torch::lazy::NodePtr Pow(const Value& input, const Value& exponent);
 
-NodePtr Fmod(const Value& dividend, const Value& divisor);
+torch::lazy::NodePtr Fmod(const Value& dividend, const Value& divisor);
 
-NodePtr Not(const Value& input);
+torch::lazy::NodePtr Not(const Value& input);
 
-NodePtr HardSigmoid(const Value& input);
+torch::lazy::NodePtr HardSigmoid(const Value& input);
 
-NodePtr HardSigmoidBackward(const Value& grad_output, const Value& input);
+torch::lazy::NodePtr HardSigmoidBackward(const Value& grad_output,
+                                         const Value& input);
 
-std::tuple<NodePtr, NodePtr> LogSigmoid(const Value& input);
+std::tuple<torch::lazy::NodePtr, torch::lazy::NodePtr> LogSigmoid(
+    const Value& input);
 
-NodePtr LogSigmoidBackward(const Value& grad_output, const Value& input,
-                           const Value& buffer);
+torch::lazy::NodePtr LogSigmoidBackward(const Value& grad_output,
+                                        const Value& input,
+                                        const Value& buffer);
 
-NodePtr Sigmoid(const Value& input);
+torch::lazy::NodePtr Sigmoid(const Value& input);
 
-NodePtr SiLU(const Value& input);
+torch::lazy::NodePtr SiLU(const Value& input);
 
-NodePtr SiLUBackward(const Value& grad_output, const Value& input);
+torch::lazy::NodePtr SiLUBackward(const Value& grad_output, const Value& input);
 
-NodePtr SigmoidBackward(const Value& grad_output, const Value& output);
+torch::lazy::NodePtr SigmoidBackward(const Value& grad_output,
+                                     const Value& output);
 
-NodePtr LogSoftmaxBackwardOp(const Value& grad_output, const Value& output,
-                             int64_t dim);
+torch::lazy::NodePtr LogSoftmaxBackwardOp(const Value& grad_output,
+                                          const Value& output, int64_t dim);
 
-NodePtr SoftmaxBackwardOp(const Value& grad_output, const Value& output,
-                          int64_t dim);
+torch::lazy::NodePtr SoftmaxBackwardOp(const Value& grad_output,
+                                       const Value& output, int64_t dim);
 
-NodePtr Clamp(const Value& input, const Value& min, const Value& max);
+torch::lazy::NodePtr Clamp(const Value& input, const Value& min,
+                           const Value& max);
 
-NodePtr Ceil(const Value& input);
+torch::lazy::NodePtr Ceil(const Value& input);
 
-NodePtr Floor(const Value& input);
+torch::lazy::NodePtr Floor(const Value& input);
 
-NodePtr Round(const Value& input);
+torch::lazy::NodePtr Round(const Value& input);
 
-NodePtr Trunc(const Value& input);
+torch::lazy::NodePtr Trunc(const Value& input);
 
-NodePtr FracOp(const Value& input);
+torch::lazy::NodePtr FracOp(const Value& input);
 
-NodePtr Ger(const Value& input, const Value& other);
+torch::lazy::NodePtr Ger(const Value& input, const Value& other);
 
-NodePtr AddMatMulOp(const Value& input, const Value& weight, const Value& bias);
+torch::lazy::NodePtr AddMatMulOp(const Value& input, const Value& weight,
+                                 const Value& bias);
 
-NodePtr Dot(const Value& input, const Value& weight);
+torch::lazy::NodePtr Dot(const Value& input, const Value& weight);
 
-NodePtr MatMul(const Value& lhs, const Value& rhs);
+torch::lazy::NodePtr MatMul(const Value& lhs, const Value& rhs);
 
-NodePtr AdaptiveMaxPool2dBackward(const Value& grad_output, const Value& input);
+torch::lazy::NodePtr AdaptiveMaxPool2dBackward(const Value& grad_output,
+                                               const Value& input);
 
-NodePtr AdaptiveAvgPool2dBackward(const Value& grad_output, const Value& input);
+torch::lazy::NodePtr AdaptiveAvgPool2dBackward(const Value& grad_output,
+                                               const Value& input);
 
-NodePtr AdaptiveAvgPool3dBackward(const Value& grad_output, const Value& input);
+torch::lazy::NodePtr AdaptiveAvgPool3dBackward(const Value& grad_output,
+                                               const Value& input);
 
-NodePtr ComparisonOp(c10::Symbol kind, const Value& input, const Value& other);
+torch::lazy::NodePtr ComparisonOp(c10::Symbol kind, const Value& input,
+                                  const Value& other);
 
-NodePtr Where(const Value& condition, const Value& input, const Value& other);
+torch::lazy::NodePtr Where(const Value& condition, const Value& input,
+                           const Value& other);
 
-NodePtr ARange(const at::Scalar& start, const at::Scalar& end,
-               const at::Scalar& step, at::ScalarType scalar_type);
+torch::lazy::NodePtr ARange(const at::Scalar& start, const at::Scalar& end,
+                            const at::Scalar& step, at::ScalarType scalar_type);
 
-NodePtr BroadcastTensors(absl::Span<const Value> tensors);
+torch::lazy::NodePtr BroadcastTensors(absl::Span<const Value> tensors);
 
-NodePtr Norm(const Value& input, const c10::optional<at::Scalar>& p,
-             c10::optional<at::ScalarType> dtype,
-             absl::Span<const int64_t> dims, bool keepdim);
+torch::lazy::NodePtr Norm(const Value& input,
+                          const c10::optional<at::Scalar>& p,
+                          c10::optional<at::ScalarType> dtype,
+                          absl::Span<const int64_t> dims, bool keepdim);
 
-NodePtr Identity(int64_t lines, int64_t cols, xla::PrimitiveType element_type);
+torch::lazy::NodePtr Identity(int64_t lines, int64_t cols,
+                              xla::PrimitiveType element_type);
 
-NodePtr Elu(const Value& input, const at::Scalar& alpha,
-            const at::Scalar& scale, const at::Scalar& input_scale);
+torch::lazy::NodePtr Elu(const Value& input, const at::Scalar& alpha,
+                         const at::Scalar& scale,
+                         const at::Scalar& input_scale);
 
-NodePtr EluBackward(const Value& grad_output, const Value& output,
-                    const at::Scalar& alpha, const at::Scalar& scale,
-                    const at::Scalar& input_scale);
+torch::lazy::NodePtr EluBackward(const Value& grad_output, const Value& output,
+                                 const at::Scalar& alpha,
+                                 const at::Scalar& scale,
+                                 const at::Scalar& input_scale);
 
-NodePtr Gelu(const Value& input);
+torch::lazy::NodePtr Gelu(const Value& input);
 
-NodePtr GeluBackward(const Value& grad, const Value& input);
+torch::lazy::NodePtr GeluBackward(const Value& grad, const Value& input);
 
-NodePtr Lshift(const Value& input, const at::Scalar& other);
+torch::lazy::NodePtr Lshift(const Value& input, const at::Scalar& other);
 
-NodePtr Lshift(const Value& input, const Value& other);
+torch::lazy::NodePtr Lshift(const Value& input, const Value& other);
 
-NodePtr Rshift(const Value& input, const at::Scalar& other);
+torch::lazy::NodePtr Rshift(const Value& input, const at::Scalar& other);
 
-NodePtr Rshift(const Value& input, const Value& other);
+torch::lazy::NodePtr Rshift(const Value& input, const Value& other);
 
-NodePtr Remainder(const Value& input, const Value& divisor);
+torch::lazy::NodePtr Remainder(const Value& input, const Value& divisor);
 
-NodePtr MaxUnary(const Value& input);
+torch::lazy::NodePtr MaxUnary(const Value& input);
 
-NodePtr MinUnary(const Value& input);
+torch::lazy::NodePtr MinUnary(const Value& input);
 
-NodePtr Take(const Value& input, const Value& index);
+torch::lazy::NodePtr Take(const Value& input, const Value& index);
 
-NodePtr TanhGelu(const Value& input);
+torch::lazy::NodePtr TanhGelu(const Value& input);
 
-NodePtr TanhGeluBackward(const Value& grad, const Value& input);
+torch::lazy::NodePtr TanhGeluBackward(const Value& grad, const Value& input);
 
-NodePtr LogDet(const Value& input);
+torch::lazy::NodePtr LogDet(const Value& input);
 
-NodePtr Inverse(const Value& input);
+torch::lazy::NodePtr Inverse(const Value& input);
 
-NodePtr IsNan(const Value& input);
+torch::lazy::NodePtr IsNan(const Value& input);
 
-NodePtr BaddBmm(const Value& lhs, const Value& rhs, const Value& bias,
-                const Value& product_multiplier, const Value& bias_multiplier);
+torch::lazy::NodePtr BaddBmm(const Value& lhs, const Value& rhs,
+                             const Value& bias, const Value& product_multiplier,
+                             const Value& bias_multiplier);
 
-NodePtr Lerp(const Value& start, const Value& end, const Value& weight);
+torch::lazy::NodePtr Lerp(const Value& start, const Value& end,
+                          const Value& weight);
 
-NodePtr LogicalNot(const Value& input);
+torch::lazy::NodePtr LogicalNot(const Value& input);
 
-NodePtr LogicalXor(const Value& input, const Value& other);
+torch::lazy::NodePtr LogicalXor(const Value& input, const Value& other);
 
-NodePtr LogicalAnd(const Value& input, const Value& other);
+torch::lazy::NodePtr LogicalAnd(const Value& input, const Value& other);
 
-NodePtr LogicalOr(const Value& input, const Value& other);
+torch::lazy::NodePtr LogicalOr(const Value& input, const Value& other);
 
-NodePtr XLogY(const Value& input, const Value& other);
+torch::lazy::NodePtr XLogY(const Value& input, const Value& other);
 
-NodePtr NanToNum(const Value& input, const Value& nan, const Value& posinf,
-                 const Value& neginf);
+torch::lazy::NodePtr NanToNum(const Value& input, const Value& nan,
+                              const Value& posinf, const Value& neginf);
 
-NodePtr SLogDet(const Value& input);
+torch::lazy::NodePtr SLogDet(const Value& input);
 
-NodePtr Softplus(const Value& input, const Value& beta, const Value& threshold);
+torch::lazy::NodePtr Softplus(const Value& input, const Value& beta,
+                              const Value& threshold);
 
-NodePtr OptimizationBarrier(const Value& input);
+torch::lazy::NodePtr OptimizationBarrier(const Value& input);
 
 }  // namespace ops
 }  // namespace ir

--- a/torch_xla/csrc/ops/permute.cpp
+++ b/torch_xla/csrc/ops/permute.cpp
@@ -27,7 +27,7 @@ Permute::Permute(const Value& input, std::vector<int64_t> dims)
            /*num_outputs=*/1, torch::lazy::MHash(dims)),
       dims_(std::move(dims)) {}
 
-NodePtr Permute::Clone(OpList operands) const {
+torch::lazy::NodePtr Permute::Clone(OpList operands) const {
   return ir::MakeNode<Permute>(operands.at(0), dims_);
 }
 

--- a/torch_xla/csrc/ops/permute.h
+++ b/torch_xla/csrc/ops/permute.h
@@ -11,7 +11,7 @@ class Permute : public Node {
  public:
   Permute(const Value& input, std::vector<int64_t> dims);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/prod.cpp
+++ b/torch_xla/csrc/ops/prod.cpp
@@ -55,7 +55,7 @@ Prod::Prod(const Value& input, std::vector<int64_t> dimensions,
       keep_reduced_dimensions_(keep_reduced_dimensions),
       dtype_(dtype) {}
 
-NodePtr Prod::Clone(OpList operands) const {
+torch::lazy::NodePtr Prod::Clone(OpList operands) const {
   return ir::MakeNode<Prod>(operands.at(0), dimensions_,
                             keep_reduced_dimensions_, dtype_);
 }

--- a/torch_xla/csrc/ops/prod.h
+++ b/torch_xla/csrc/ops/prod.h
@@ -17,7 +17,7 @@ class Prod : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/put.cpp
+++ b/torch_xla/csrc/ops/put.cpp
@@ -14,7 +14,7 @@ Put::Put(const Value& input, const Value& index, const Value& source,
            /*num_outputs=*/1, torch::lazy::MHash(accumulate)),
       accumulate_(accumulate) {}
 
-NodePtr Put::Clone(OpList operands) const {
+torch::lazy::NodePtr Put::Clone(OpList operands) const {
   return ir::MakeNode<Put>(operands.at(0), operands.at(1), operands.at(2),
                            accumulate_);
 }

--- a/torch_xla/csrc/ops/put.h
+++ b/torch_xla/csrc/ops/put.h
@@ -13,7 +13,7 @@ class Put : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/qr.cpp
+++ b/torch_xla/csrc/ops/qr.cpp
@@ -47,7 +47,7 @@ QR::QR(const Value& input, bool some)
            /*num_outputs=*/2, torch::lazy::MHash(some)),
       some_(some) {}
 
-NodePtr QR::Clone(OpList operands) const {
+torch::lazy::NodePtr QR::Clone(OpList operands) const {
   return ir::MakeNode<QR>(operands.at(0), some_);
 }
 

--- a/torch_xla/csrc/ops/qr.h
+++ b/torch_xla/csrc/ops/qr.h
@@ -12,7 +12,7 @@ class QR : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/reduce_scatter.cpp
+++ b/torch_xla/csrc/ops/reduce_scatter.cpp
@@ -46,7 +46,7 @@ ReduceScatter::ReduceScatter(AllReduceType reduce_type, const Value& input,
       shard_count_(shard_count),
       groups_(std::move(groups)) {}
 
-NodePtr ReduceScatter::Clone(OpList operands) const {
+torch::lazy::NodePtr ReduceScatter::Clone(OpList operands) const {
   return ir::MakeNode<ReduceScatter>(reduce_type_, operands.at(0),
                                      operands.at(1), scale_, scatter_dim_,
                                      shard_count_, groups_);

--- a/torch_xla/csrc/ops/reduce_scatter.h
+++ b/torch_xla/csrc/ops/reduce_scatter.h
@@ -15,7 +15,7 @@ class ReduceScatter : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/reflection_pad2d.cpp
+++ b/torch_xla/csrc/ops/reflection_pad2d.cpp
@@ -28,7 +28,7 @@ ReflectionPad2d::ReflectionPad2d(const Value& input,
            /*num_outputs=*/1, torch::lazy::MHash(padding)),
       padding_(std::move(padding)) {}
 
-NodePtr ReflectionPad2d::Clone(OpList operands) const {
+torch::lazy::NodePtr ReflectionPad2d::Clone(OpList operands) const {
   return ir::MakeNode<ReflectionPad2d>(operands.at(0), padding_);
 }
 

--- a/torch_xla/csrc/ops/reflection_pad2d.h
+++ b/torch_xla/csrc/ops/reflection_pad2d.h
@@ -12,7 +12,7 @@ class ReflectionPad2d : public Node {
  public:
   ReflectionPad2d(const Value& input, std::vector<int64_t> padding);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/reflection_pad2d_backward.cpp
+++ b/torch_xla/csrc/ops/reflection_pad2d_backward.cpp
@@ -31,7 +31,7 @@ ReflectionPad2dBackward::ReflectionPad2dBackward(const Value& grad_output,
            /*num_outputs=*/1, torch::lazy::MHash(padding)),
       padding_(std::move(padding)) {}
 
-NodePtr ReflectionPad2dBackward::Clone(OpList operands) const {
+torch::lazy::NodePtr ReflectionPad2dBackward::Clone(OpList operands) const {
   return ir::MakeNode<ReflectionPad2dBackward>(operands.at(0), operands.at(1),
                                                padding_);
 }

--- a/torch_xla/csrc/ops/reflection_pad2d_backward.h
+++ b/torch_xla/csrc/ops/reflection_pad2d_backward.h
@@ -13,7 +13,7 @@ class ReflectionPad2dBackward : public Node {
   ReflectionPad2dBackward(const Value& gard_output, const Value& input,
                           std::vector<int64_t> padding);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/repeat.cpp
+++ b/torch_xla/csrc/ops/repeat.cpp
@@ -28,7 +28,7 @@ Repeat::Repeat(const Value& input, std::vector<int64_t> repeats)
            /*num_outputs=*/1, torch::lazy::MHash(repeats)),
       repeats_(std::move(repeats)) {}
 
-NodePtr Repeat::Clone(OpList operands) const {
+torch::lazy::NodePtr Repeat::Clone(OpList operands) const {
   return ir::MakeNode<Repeat>(operands.at(0), repeats_);
 }
 

--- a/torch_xla/csrc/ops/repeat.h
+++ b/torch_xla/csrc/ops/repeat.h
@@ -11,7 +11,7 @@ class Repeat : public Node {
  public:
   Repeat(const Value& input, std::vector<int64_t> repeats);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/replication_pad.cpp
+++ b/torch_xla/csrc/ops/replication_pad.cpp
@@ -27,7 +27,7 @@ ReplicationPad::ReplicationPad(const Value& input, std::vector<int64_t> padding)
            /*num_outputs=*/1, torch::lazy::MHash(padding)),
       padding_(std::move(padding)) {}
 
-NodePtr ReplicationPad::Clone(OpList operands) const {
+torch::lazy::NodePtr ReplicationPad::Clone(OpList operands) const {
   return ir::MakeNode<ReplicationPad>(operands.at(0), padding_);
 }
 

--- a/torch_xla/csrc/ops/replication_pad.h
+++ b/torch_xla/csrc/ops/replication_pad.h
@@ -11,7 +11,7 @@ class ReplicationPad : public Node {
  public:
   ReplicationPad(const Value& input, std::vector<int64_t> padding);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/replication_pad_backward.cpp
+++ b/torch_xla/csrc/ops/replication_pad_backward.cpp
@@ -31,7 +31,7 @@ ReplicationPadBackward::ReplicationPadBackward(const Value& grad_output,
            /*num_outputs=*/1, torch::lazy::MHash(padding)),
       padding_(std::move(padding)) {}
 
-NodePtr ReplicationPadBackward::Clone(OpList operands) const {
+torch::lazy::NodePtr ReplicationPadBackward::Clone(OpList operands) const {
   return ir::MakeNode<ReplicationPadBackward>(operands.at(0), operands.at(1),
                                               padding_);
 }

--- a/torch_xla/csrc/ops/replication_pad_backward.h
+++ b/torch_xla/csrc/ops/replication_pad_backward.h
@@ -13,7 +13,7 @@ class ReplicationPadBackward : public Node {
   ReplicationPadBackward(const Value& gard_output, const Value& input,
                          std::vector<int64_t> padding);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/resize.cpp
+++ b/torch_xla/csrc/ops/resize.cpp
@@ -22,7 +22,7 @@ Resize::Resize(const Value& input, std::vector<int64_t> size)
            /*num_outputs=*/1, torch::lazy::MHash(size)),
       size_(std::move(size)) {}
 
-NodePtr Resize::Clone(OpList operands) const {
+torch::lazy::NodePtr Resize::Clone(OpList operands) const {
   return ir::MakeNode<Resize>(operands.at(0), size_);
 }
 

--- a/torch_xla/csrc/ops/resize.h
+++ b/torch_xla/csrc/ops/resize.h
@@ -10,7 +10,7 @@ class Resize : public Node {
  public:
   Resize(const Value& input, std::vector<int64_t> size);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/rrelu_with_noise.cpp
+++ b/torch_xla/csrc/ops/rrelu_with_noise.cpp
@@ -21,7 +21,7 @@ RreluWithNoise::RreluWithNoise(const Value& input, const Value& seed,
       upper_(std::move(upper)),
       training_(training) {}
 
-NodePtr RreluWithNoise::Clone(OpList operands) const {
+torch::lazy::NodePtr RreluWithNoise::Clone(OpList operands) const {
   return ir::MakeNode<RreluWithNoise>(operands.at(0), operands.at(1), lower_,
                                       upper_, training_);
 }

--- a/torch_xla/csrc/ops/rrelu_with_noise.h
+++ b/torch_xla/csrc/ops/rrelu_with_noise.h
@@ -16,7 +16,7 @@ class RreluWithNoise : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/rrelu_with_noise_backward.cpp
+++ b/torch_xla/csrc/ops/rrelu_with_noise_backward.cpp
@@ -19,7 +19,7 @@ RreluWithNoiseBackward::RreluWithNoiseBackward(
       upper_(std::move(upper)),
       training_(training) {}
 
-NodePtr RreluWithNoiseBackward::Clone(OpList operands) const {
+torch::lazy::NodePtr RreluWithNoiseBackward::Clone(OpList operands) const {
   return ir::MakeNode<RreluWithNoiseBackward>(operands.at(0), operands.at(1),
                                               operands.at(2), lower_, upper_,
                                               training_);

--- a/torch_xla/csrc/ops/rrelu_with_noise_backward.h
+++ b/torch_xla/csrc/ops/rrelu_with_noise_backward.h
@@ -16,7 +16,7 @@ class RreluWithNoiseBackward : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/scalar.cpp
+++ b/torch_xla/csrc/ops/scalar.cpp
@@ -29,7 +29,7 @@ std::string Scalar::ToString() const {
   return ss.str();
 }
 
-NodePtr Scalar::Clone(OpList operands) const {
+torch::lazy::NodePtr Scalar::Clone(OpList operands) const {
   return ir::MakeNode<Scalar>(value_, xla_shape());
 }
 

--- a/torch_xla/csrc/ops/scalar.h
+++ b/torch_xla/csrc/ops/scalar.h
@@ -23,7 +23,7 @@ class Scalar : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/scatter.cpp
+++ b/torch_xla/csrc/ops/scatter.cpp
@@ -14,7 +14,7 @@ Scatter::Scatter(const Value& input, const Value& index, const Value& src,
            /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}
 
-NodePtr Scatter::Clone(OpList operands) const {
+torch::lazy::NodePtr Scatter::Clone(OpList operands) const {
   return ir::MakeNode<Scatter>(operands.at(0), operands.at(1), operands.at(2),
                                dim_);
 }

--- a/torch_xla/csrc/ops/scatter.h
+++ b/torch_xla/csrc/ops/scatter.h
@@ -13,7 +13,7 @@ class Scatter : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/scatter_add.cpp
+++ b/torch_xla/csrc/ops/scatter_add.cpp
@@ -16,7 +16,7 @@ ScatterAdd::ScatterAdd(const Value& input, const Value& index, const Value& src,
            /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}
 
-NodePtr ScatterAdd::Clone(OpList operands) const {
+torch::lazy::NodePtr ScatterAdd::Clone(OpList operands) const {
   return ir::MakeNode<ScatterAdd>(operands.at(0), operands.at(1),
                                   operands.at(2), dim_);
 }

--- a/torch_xla/csrc/ops/scatter_add.h
+++ b/torch_xla/csrc/ops/scatter_add.h
@@ -13,7 +13,7 @@ class ScatterAdd : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/select.cpp
+++ b/torch_xla/csrc/ops/select.cpp
@@ -20,7 +20,7 @@ Select::Select(const Value& input, int64_t dim, int64_t start, int64_t end,
       end_(end),
       stride_(stride) {}
 
-NodePtr Select::Clone(OpList operands) const {
+torch::lazy::NodePtr Select::Clone(OpList operands) const {
   return ir::MakeNode<Select>(operands.at(0), dim_, start_, end_, stride_);
 }
 

--- a/torch_xla/csrc/ops/select.h
+++ b/torch_xla/csrc/ops/select.h
@@ -11,7 +11,7 @@ class Select : public Node {
   Select(const Value& input, int64_t dim, int64_t start, int64_t end,
          int64_t stride);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/sgd_optimizer_step.cpp
+++ b/torch_xla/csrc/ops/sgd_optimizer_step.cpp
@@ -34,7 +34,7 @@ SgdOptimizerStep::SgdOptimizerStep(const Value& found_inf, const Value& step,
       use_momentum_(use_momentum),
       use_nesterov_(use_nesterov) {}
 
-NodePtr SgdOptimizerStep::Clone(OpList operands) const {
+torch::lazy::NodePtr SgdOptimizerStep::Clone(OpList operands) const {
   return ir::MakeNode<SgdOptimizerStep>(
       operands.at(0), operands.at(1), operands.at(2), operands.at(3),
       operands.at(4), operands.at(5), operands.at(6), operands.at(7),

--- a/torch_xla/csrc/ops/sgd_optimizer_step.h
+++ b/torch_xla/csrc/ops/sgd_optimizer_step.h
@@ -14,7 +14,7 @@ class SgdOptimizerStep : public Node {
                    const Value& lr, const Value& dampening,
                    bool use_weight_decay, bool use_momentum, bool use_nesterov);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/shrink_backward.cpp
+++ b/torch_xla/csrc/ops/shrink_backward.cpp
@@ -22,7 +22,7 @@ std::string ShrinkBackward::ToString() const {
   return ss.str();
 }
 
-NodePtr ShrinkBackward::Clone(OpList operands) const {
+torch::lazy::NodePtr ShrinkBackward::Clone(OpList operands) const {
   return ir::MakeNode<ShrinkBackward>(op(), operands.at(0), operands.at(1),
                                       lambda_);
 }

--- a/torch_xla/csrc/ops/shrink_backward.h
+++ b/torch_xla/csrc/ops/shrink_backward.h
@@ -15,7 +15,7 @@ class ShrinkBackward : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/softmax.cpp
+++ b/torch_xla/csrc/ops/softmax.cpp
@@ -38,7 +38,7 @@ Softmax::Softmax(const Value& input, int64_t dim,
       dim_(dim),
       dtype_(dtype) {}
 
-NodePtr Softmax::Clone(OpList operands) const {
+torch::lazy::NodePtr Softmax::Clone(OpList operands) const {
   return ir::MakeNode<Softmax>(operands.at(0), dim_, dtype_);
 }
 

--- a/torch_xla/csrc/ops/softmax.h
+++ b/torch_xla/csrc/ops/softmax.h
@@ -13,7 +13,7 @@ class Softmax : public Node {
  public:
   Softmax(const Value& input, int64_t dim, c10::optional<at::ScalarType> dtype);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/softmax_backward.cpp
+++ b/torch_xla/csrc/ops/softmax_backward.cpp
@@ -16,7 +16,7 @@ SoftmaxBackward::SoftmaxBackward(const Value& grad_output, const Value& output,
            /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}
 
-NodePtr SoftmaxBackward::Clone(OpList operands) const {
+torch::lazy::NodePtr SoftmaxBackward::Clone(OpList operands) const {
   return ir::MakeNode<SoftmaxBackward>(operands.at(0), operands.at(1), dim_);
 }
 

--- a/torch_xla/csrc/ops/softmax_backward.h
+++ b/torch_xla/csrc/ops/softmax_backward.h
@@ -10,7 +10,7 @@ class SoftmaxBackward : public Node {
  public:
   SoftmaxBackward(const Value& grad_output, const Value& output, int64_t dim);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/softshrink.cpp
+++ b/torch_xla/csrc/ops/softshrink.cpp
@@ -21,7 +21,7 @@ std::string Softshrink::ToString() const {
   return ss.str();
 }
 
-NodePtr Softshrink::Clone(OpList operands) const {
+torch::lazy::NodePtr Softshrink::Clone(OpList operands) const {
   return ir::MakeNode<Softshrink>(operands.at(0), lambda_);
 }
 

--- a/torch_xla/csrc/ops/softshrink.h
+++ b/torch_xla/csrc/ops/softshrink.h
@@ -14,7 +14,7 @@ class Softshrink : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/split.cpp
+++ b/torch_xla/csrc/ops/split.cpp
@@ -32,7 +32,7 @@ Split::Split(const Value& input, std::vector<int64_t> split_sizes, int64_t dim)
       split_sizes_(std::move(split_sizes)),
       dim_(dim) {}
 
-NodePtr Split::Clone(OpList operands) const {
+torch::lazy::NodePtr Split::Clone(OpList operands) const {
   return ir::MakeNode<Split>(operands.at(0), split_sizes_, dim_);
 }
 

--- a/torch_xla/csrc/ops/split.h
+++ b/torch_xla/csrc/ops/split.h
@@ -13,7 +13,7 @@ class Split : public Node {
  public:
   Split(const Value& input, std::vector<int64_t> split_sizes, int64_t dim);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/squeeze.cpp
+++ b/torch_xla/csrc/ops/squeeze.cpp
@@ -35,7 +35,7 @@ Squeeze::Squeeze(const Value& input, int dim)
            /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}
 
-NodePtr Squeeze::Clone(OpList operands) const {
+torch::lazy::NodePtr Squeeze::Clone(OpList operands) const {
   return ir::MakeNode<Squeeze>(operands.at(0), dim_);
 }
 

--- a/torch_xla/csrc/ops/squeeze.h
+++ b/torch_xla/csrc/ops/squeeze.h
@@ -11,7 +11,7 @@ class Squeeze : public Node {
   // Squeeze out the specified dimension index, -1 for all trivial dimensions.
   Squeeze(const Value& input, int dim);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/stack.cpp
+++ b/torch_xla/csrc/ops/stack.cpp
@@ -31,7 +31,7 @@ Stack::Stack(absl::Span<const ir::Value> values, int64_t dim)
            /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}
 
-NodePtr Stack::Clone(OpList operands) const {
+torch::lazy::NodePtr Stack::Clone(OpList operands) const {
   return ir::MakeNode<Stack>(operands, dim_);
 }
 

--- a/torch_xla/csrc/ops/stack.h
+++ b/torch_xla/csrc/ops/stack.h
@@ -13,7 +13,7 @@ class Stack : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/std.cpp
+++ b/torch_xla/csrc/ops/std.cpp
@@ -35,7 +35,7 @@ Std::Std(const Value& input, std::vector<int64_t> dimensions,
       keep_reduced_dimensions_(keep_reduced_dimensions),
       correction_(correction) {}
 
-NodePtr Std::Clone(OpList operands) const {
+torch::lazy::NodePtr Std::Clone(OpList operands) const {
   return ir::MakeNode<Std>(operands.at(0), dimensions_,
                            keep_reduced_dimensions_, correction_);
 }

--- a/torch_xla/csrc/ops/std.h
+++ b/torch_xla/csrc/ops/std.h
@@ -16,7 +16,7 @@ class Std : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/std_mean.cpp
+++ b/torch_xla/csrc/ops/std_mean.cpp
@@ -38,7 +38,7 @@ StdMean::StdMean(const Value& input, std::vector<int64_t> dimensions,
       correction_(correction),
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
-NodePtr StdMean::Clone(OpList operands) const {
+torch::lazy::NodePtr StdMean::Clone(OpList operands) const {
   return ir::MakeNode<StdMean>(operands.at(0), dimensions_, correction_,
                                keep_reduced_dimensions_);
 }

--- a/torch_xla/csrc/ops/std_mean.h
+++ b/torch_xla/csrc/ops/std_mean.h
@@ -16,7 +16,7 @@ class StdMean : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/sum.cpp
+++ b/torch_xla/csrc/ops/sum.cpp
@@ -49,7 +49,7 @@ Sum::Sum(const Value& input, std::vector<int64_t> dimensions,
       keep_reduced_dimensions_(keep_reduced_dimensions),
       dtype_(dtype) {}
 
-NodePtr Sum::Clone(OpList operands) const {
+torch::lazy::NodePtr Sum::Clone(OpList operands) const {
   return ir::MakeNode<Sum>(operands.at(0), dimensions_,
                            keep_reduced_dimensions_, dtype_);
 }

--- a/torch_xla/csrc/ops/sum.h
+++ b/torch_xla/csrc/ops/sum.h
@@ -17,7 +17,7 @@ class Sum : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/svd.cpp
+++ b/torch_xla/csrc/ops/svd.cpp
@@ -74,7 +74,7 @@ SVD::SVD(const Value& input, bool some, bool compute_uv)
       some_(some),
       compute_uv_(compute_uv) {}
 
-NodePtr SVD::Clone(OpList operands) const {
+torch::lazy::NodePtr SVD::Clone(OpList operands) const {
   return ir::MakeNode<SVD>(operands.at(0), some_, compute_uv_);
 }
 

--- a/torch_xla/csrc/ops/svd.h
+++ b/torch_xla/csrc/ops/svd.h
@@ -12,7 +12,7 @@ class SVD : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/symeig.cpp
+++ b/torch_xla/csrc/ops/symeig.cpp
@@ -52,7 +52,7 @@ SymEig::SymEig(const Value& input, bool eigenvectors, bool lower)
       eigenvectors_(eigenvectors),
       lower_(lower) {}
 
-NodePtr SymEig::Clone(OpList operands) const {
+torch::lazy::NodePtr SymEig::Clone(OpList operands) const {
   return ir::MakeNode<SymEig>(operands.at(0), eigenvectors_, lower_);
 }
 

--- a/torch_xla/csrc/ops/symeig.h
+++ b/torch_xla/csrc/ops/symeig.h
@@ -12,7 +12,7 @@ class SymEig : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/threshold.cpp
+++ b/torch_xla/csrc/ops/threshold.cpp
@@ -13,7 +13,7 @@ Threshold::Threshold(const Value& input, float threshold, float value)
       threshold_(threshold),
       value_(value) {}
 
-NodePtr Threshold::Clone(OpList operands) const {
+torch::lazy::NodePtr Threshold::Clone(OpList operands) const {
   return ir::MakeNode<Threshold>(operands.at(0), threshold_, value_);
 }
 

--- a/torch_xla/csrc/ops/threshold.h
+++ b/torch_xla/csrc/ops/threshold.h
@@ -11,7 +11,7 @@ class Threshold : public Node {
  public:
   Threshold(const Value& input, float threshold, float value);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/threshold_backward.cpp
+++ b/torch_xla/csrc/ops/threshold_backward.cpp
@@ -14,7 +14,7 @@ ThresholdBackward::ThresholdBackward(const Value& grad_output,
            torch::lazy::MHash(threshold)),
       threshold_(threshold) {}
 
-NodePtr ThresholdBackward::Clone(OpList operands) const {
+torch::lazy::NodePtr ThresholdBackward::Clone(OpList operands) const {
   return ir::MakeNode<ThresholdBackward>(operands.at(0), operands.at(1),
                                          threshold_);
 }

--- a/torch_xla/csrc/ops/threshold_backward.h
+++ b/torch_xla/csrc/ops/threshold_backward.h
@@ -11,7 +11,7 @@ class ThresholdBackward : public Node {
   ThresholdBackward(const Value& grad_output, const Value& input,
                     float threshold);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/topk.cpp
+++ b/torch_xla/csrc/ops/topk.cpp
@@ -35,7 +35,7 @@ TopK::TopK(const Value& input, int64_t k, int64_t dim, bool largest,
       sorted_(sorted),
       stable_(stable) {}
 
-NodePtr TopK::Clone(OpList operands) const {
+torch::lazy::NodePtr TopK::Clone(OpList operands) const {
   return ir::MakeNode<TopK>(operands.at(0), k_, dim_, largest_, sorted_,
                             stable_);
 }

--- a/torch_xla/csrc/ops/topk.h
+++ b/torch_xla/csrc/ops/topk.h
@@ -13,7 +13,7 @@ class TopK : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/triangular_solve.cpp
+++ b/torch_xla/csrc/ops/triangular_solve.cpp
@@ -85,7 +85,7 @@ TriangularSolve::TriangularSolve(const Value& rhs, const Value& lhs,
       transpose_(transpose),
       unit_diagonal_(unit_diagonal) {}
 
-NodePtr TriangularSolve::Clone(OpList operands) const {
+torch::lazy::NodePtr TriangularSolve::Clone(OpList operands) const {
   return ir::MakeNode<TriangularSolve>(operands.at(0), operands.at(1),
                                        left_side_, lower_, transpose_,
                                        unit_diagonal_);

--- a/torch_xla/csrc/ops/triangular_solve.h
+++ b/torch_xla/csrc/ops/triangular_solve.h
@@ -13,7 +13,7 @@ class TriangularSolve : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/tril.cpp
+++ b/torch_xla/csrc/ops/tril.cpp
@@ -12,7 +12,7 @@ Tril::Tril(const Value& input, int64_t diagonal)
            /*num_outputs=*/1, torch::lazy::MHash(diagonal)),
       diagonal_(diagonal) {}
 
-NodePtr Tril::Clone(OpList operands) const {
+torch::lazy::NodePtr Tril::Clone(OpList operands) const {
   return ir::MakeNode<Tril>(operands.at(0), diagonal_);
 }
 

--- a/torch_xla/csrc/ops/tril.h
+++ b/torch_xla/csrc/ops/tril.h
@@ -12,7 +12,7 @@ class Tril : public Node {
  public:
   Tril(const Value& input, int64_t diagonal);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/triu.cpp
+++ b/torch_xla/csrc/ops/triu.cpp
@@ -12,7 +12,7 @@ Triu::Triu(const Value& input, int64_t diagonal)
            /*num_outputs=*/1, torch::lazy::MHash(diagonal)),
       diagonal_(diagonal) {}
 
-NodePtr Triu::Clone(OpList operands) const {
+torch::lazy::NodePtr Triu::Clone(OpList operands) const {
   return ir::MakeNode<Triu>(operands.at(0), diagonal_);
 }
 

--- a/torch_xla/csrc/ops/triu.h
+++ b/torch_xla/csrc/ops/triu.h
@@ -12,7 +12,7 @@ class Triu : public Node {
  public:
   Triu(const Value& input, int64_t diagonal);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/uniform.cpp
+++ b/torch_xla/csrc/ops/uniform.cpp
@@ -15,7 +15,7 @@ Uniform::Uniform(const Value& from, const Value& to, const Value& seed,
     : Node(torch::lazy::OpKind(at::aten::uniform), {from, to, seed}, rng_shape,
            /*num_outputs=*/1, torch::lazy::Hash(rng_shape)) {}
 
-NodePtr Uniform::Clone(OpList operands) const {
+torch::lazy::NodePtr Uniform::Clone(OpList operands) const {
   return ir::MakeNode<Uniform>(operands.at(0), operands.at(1), operands.at(2),
                                xla_shape());
 }

--- a/torch_xla/csrc/ops/uniform.h
+++ b/torch_xla/csrc/ops/uniform.h
@@ -11,7 +11,7 @@ class Uniform : public Node {
   Uniform(const Value& from, const Value& to, const Value& seed,
           const xla::Shape& rng_shape);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 };

--- a/torch_xla/csrc/ops/unselect.cpp
+++ b/torch_xla/csrc/ops/unselect.cpp
@@ -20,7 +20,7 @@ Unselect::Unselect(const Value& target, const Value& source, int64_t dim,
       end_(end),
       stride_(stride) {}
 
-NodePtr Unselect::Clone(OpList operands) const {
+torch::lazy::NodePtr Unselect::Clone(OpList operands) const {
   return ir::MakeNode<Unselect>(operands.at(0), operands.at(1), dim_, start_,
                                 end_, stride_);
 }

--- a/torch_xla/csrc/ops/unselect.h
+++ b/torch_xla/csrc/ops/unselect.h
@@ -11,7 +11,7 @@ class Unselect : public Node {
   Unselect(const Value& target, const Value& source, int64_t dim, int64_t start,
            int64_t end, int64_t stride);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/unsqueeze.cpp
+++ b/torch_xla/csrc/ops/unsqueeze.cpp
@@ -22,7 +22,7 @@ Unsqueeze::Unsqueeze(const Value& input, int dim)
            /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}
 
-NodePtr Unsqueeze::Clone(OpList operands) const {
+torch::lazy::NodePtr Unsqueeze::Clone(OpList operands) const {
   return ir::MakeNode<Unsqueeze>(operands.at(0), dim_);
 }
 

--- a/torch_xla/csrc/ops/unsqueeze.h
+++ b/torch_xla/csrc/ops/unsqueeze.h
@@ -11,7 +11,7 @@ class Unsqueeze : public Node {
   // Insert a dimension of size one at the specified position.
   Unsqueeze(const Value& input, int dim);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/update_slice.cpp
+++ b/torch_xla/csrc/ops/update_slice.cpp
@@ -31,7 +31,7 @@ UpdateSlice::UpdateSlice(const Value& input, const Value& source,
            /*num_outputs=*/1, torch::lazy::Hash(base_indices)),
       base_indices_(base_indices.begin(), base_indices.end()) {}
 
-NodePtr UpdateSlice::Clone(OpList operands) const {
+torch::lazy::NodePtr UpdateSlice::Clone(OpList operands) const {
   return ir::MakeNode<UpdateSlice>(operands.at(0), operands.at(1),
                                    base_indices_);
 }

--- a/torch_xla/csrc/ops/update_slice.h
+++ b/torch_xla/csrc/ops/update_slice.h
@@ -12,7 +12,7 @@ class UpdateSlice : public Node {
   UpdateSlice(const Value& input, const Value& source,
               absl::Span<const int64_t> base_indices);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/upsample_bilinear2d.cpp
+++ b/torch_xla/csrc/ops/upsample_bilinear2d.cpp
@@ -21,7 +21,7 @@ UpsampleBilinear::UpsampleBilinear(const Value& input,
       output_size_(std::move(output_size)),
       align_corners_(align_corners) {}
 
-NodePtr UpsampleBilinear::Clone(OpList operands) const {
+torch::lazy::NodePtr UpsampleBilinear::Clone(OpList operands) const {
   return ir::MakeNode<UpsampleBilinear>(operands.at(0), output_size_,
                                         align_corners_);
 }

--- a/torch_xla/csrc/ops/upsample_bilinear2d.h
+++ b/torch_xla/csrc/ops/upsample_bilinear2d.h
@@ -13,7 +13,7 @@ class UpsampleBilinear : public Node {
   UpsampleBilinear(const Value& input, std::vector<int64_t> output_size,
                    bool align_corners);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/upsample_bilinear2d_backward.cpp
+++ b/torch_xla/csrc/ops/upsample_bilinear2d_backward.cpp
@@ -23,7 +23,7 @@ UpsampleBilinearBackward::UpsampleBilinearBackward(
       input_size_(std::move(input_size)),
       align_corners_(align_corners) {}
 
-NodePtr UpsampleBilinearBackward::Clone(OpList operands) const {
+torch::lazy::NodePtr UpsampleBilinearBackward::Clone(OpList operands) const {
   return ir::MakeNode<UpsampleBilinearBackward>(operands.at(0), output_size_,
                                                 input_size_, align_corners_);
 }

--- a/torch_xla/csrc/ops/upsample_bilinear2d_backward.h
+++ b/torch_xla/csrc/ops/upsample_bilinear2d_backward.h
@@ -13,7 +13,7 @@ class UpsampleBilinearBackward : public Node {
   UpsampleBilinearBackward(const Value& input, std::vector<int64_t> output_size,
                            std::vector<int64_t> input_size, bool align_corners);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/upsample_nearest2d.cpp
+++ b/torch_xla/csrc/ops/upsample_nearest2d.cpp
@@ -19,7 +19,7 @@ UpsampleNearest::UpsampleNearest(const Value& input,
            /*num_outputs=*/1, torch::lazy::MHash(output_size)),
       output_size_(std::move(output_size)) {}
 
-NodePtr UpsampleNearest::Clone(OpList operands) const {
+torch::lazy::NodePtr UpsampleNearest::Clone(OpList operands) const {
   return ir::MakeNode<UpsampleNearest>(operands.at(0), output_size_);
 }
 

--- a/torch_xla/csrc/ops/upsample_nearest2d.h
+++ b/torch_xla/csrc/ops/upsample_nearest2d.h
@@ -12,7 +12,7 @@ class UpsampleNearest : public Node {
  public:
   UpsampleNearest(const Value& input, std::vector<int64_t> output_size);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/upsample_nearest2d_backward.cpp
+++ b/torch_xla/csrc/ops/upsample_nearest2d_backward.cpp
@@ -21,7 +21,7 @@ UpsampleNearestBackward::UpsampleNearestBackward(
       output_size_(std::move(output_size)),
       input_size_(std::move(input_size)) {}
 
-NodePtr UpsampleNearestBackward::Clone(OpList operands) const {
+torch::lazy::NodePtr UpsampleNearestBackward::Clone(OpList operands) const {
   return ir::MakeNode<UpsampleNearestBackward>(operands.at(0), output_size_,
                                                input_size_);
 }

--- a/torch_xla/csrc/ops/upsample_nearest2d_backward.h
+++ b/torch_xla/csrc/ops/upsample_nearest2d_backward.h
@@ -13,7 +13,7 @@ class UpsampleNearestBackward : public Node {
   UpsampleNearestBackward(const Value& input, std::vector<int64_t> output_size,
                           std::vector<int64_t> input_size);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/user_computation.cpp
+++ b/torch_xla/csrc/ops/user_computation.cpp
@@ -20,7 +20,7 @@ UserComputation::UserComputation(torch::lazy::OpKind op, OpList operands,
            computation->hash()),
       computation_(std::move(computation)) {}
 
-NodePtr UserComputation::Clone(OpList operands) const {
+torch::lazy::NodePtr UserComputation::Clone(OpList operands) const {
   return ir::MakeNode<UserComputation>(op(), operands, computation_);
 }
 

--- a/torch_xla/csrc/ops/user_computation.h
+++ b/torch_xla/csrc/ops/user_computation.h
@@ -12,7 +12,7 @@ class UserComputation : public Node {
   UserComputation(torch::lazy::OpKind op, OpList operands,
                   ComputationPtr computation);
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/var.cpp
+++ b/torch_xla/csrc/ops/var.cpp
@@ -36,7 +36,7 @@ Var::Var(const Value& input, std::vector<int64_t> dimensions,
       correction_(correction),
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
-NodePtr Var::Clone(OpList operands) const {
+torch::lazy::NodePtr Var::Clone(OpList operands) const {
   return ir::MakeNode<Var>(operands.at(0), dimensions_, correction_,
                            keep_reduced_dimensions_);
 }

--- a/torch_xla/csrc/ops/var.h
+++ b/torch_xla/csrc/ops/var.h
@@ -16,7 +16,7 @@ class Var : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/var_mean.cpp
+++ b/torch_xla/csrc/ops/var_mean.cpp
@@ -41,7 +41,7 @@ VarMean::VarMean(const Value& input, std::vector<int64_t> dimensions,
       correction_(correction),
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
-NodePtr VarMean::Clone(OpList operands) const {
+torch::lazy::NodePtr VarMean::Clone(OpList operands) const {
   return ir::MakeNode<VarMean>(operands.at(0), dimensions_, correction_,
                                keep_reduced_dimensions_);
 }

--- a/torch_xla/csrc/ops/var_mean.h
+++ b/torch_xla/csrc/ops/var_mean.h
@@ -16,7 +16,7 @@ class VarMean : public Node {
 
   std::string ToString() const override;
 
-  NodePtr Clone(OpList operands) const override;
+  torch::lazy::NodePtr Clone(OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1076,7 +1076,7 @@ ir::Value XLATensor::CreateTensorNode(xla::ComputationClient::DataPtr data,
 }
 
 std::vector<XLATensor> XLATensor::MakeOutputTensors(
-    ir::NodePtr node, bool inherit_logical_type) const {
+    torch::lazy::NodePtr node, bool inherit_logical_type) const {
   std::vector<XLATensor> tensors;
   tensors.reserve(node->num_outputs());
   for (size_t i = 0; i < node->num_outputs(); ++i) {

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -1371,7 +1371,7 @@ class XLATensor {
   void TryLimitGraphSize();
 
   std::vector<XLATensor> MakeOutputTensors(
-      ir::NodePtr node, bool inherit_logical_type = true) const;
+      torch::lazy::NodePtr node, bool inherit_logical_type = true) const;
 
   ir::Value GetIrValueForTensor(const at::Tensor& tensor,
                                 const Device& device) const;

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -343,7 +343,7 @@ std::pair<XLATensor, ir::Value> XLATensor::all_reduce(
     const XLATensor& input, const ir::Value& token, AllReduceType reduce_type,
     double scale, std::vector<std::vector<int64_t>> groups) {
   std::vector<ir::Value> input_values({input.GetIrValue()});
-  ir::NodePtr node = ir::MakeNode<ir::ops::AllReduce>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::AllReduce>(
       reduce_type, input_values, token, scale, std::move(groups));
   return {input.CreateFrom(ir::Value(node, 0)), ir::Value(node, 1)};
 }
@@ -352,7 +352,7 @@ ir::Value XLATensor::all_reduce_(XLATensor& input, const ir::Value& token,
                                  AllReduceType reduce_type, double scale,
                                  std::vector<std::vector<int64_t>> groups) {
   std::vector<ir::Value> input_values({input.GetIrValue()});
-  ir::NodePtr node = ir::MakeNode<ir::ops::AllReduce>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::AllReduce>(
       reduce_type, input_values, token, scale, std::move(groups));
   input.SetInPlaceIrValue(ir::Value(node, 0));
   return ir::Value(node, 1);
@@ -367,7 +367,7 @@ ir::Value XLATensor::all_reduce(std::vector<XLATensor>* inputs,
   for (auto& input : *inputs) {
     input_values.push_back(input.GetIrValue());
   }
-  ir::NodePtr node = ir::MakeNode<ir::ops::AllReduce>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::AllReduce>(
       reduce_type, input_values, token, scale, std::move(groups));
   for (size_t i = 0; i < inputs->size(); ++i) {
     (*inputs)[i].SetInPlaceIrValue(ir::Value(node, i));
@@ -379,7 +379,7 @@ std::pair<XLATensor, ir::Value> XLATensor::reduce_scatter(
     const XLATensor& input, const ir::Value& token, AllReduceType reduce_type,
     double scale, int64_t scatter_dim, int64_t shard_count,
     std::vector<std::vector<int64_t>> groups) {
-  ir::NodePtr node = ir::MakeNode<ir::ops::ReduceScatter>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::ReduceScatter>(
       reduce_type, input.GetIrValue(), token, scale, scatter_dim, shard_count,
       std::move(groups));
   return {input.CreateFrom(ir::Value(node, 0)), ir::Value(node, 1)};
@@ -389,7 +389,7 @@ ir::Value XLATensor::reduce_scatter_out(
     XLATensor& output, const XLATensor& input, const ir::Value& token,
     AllReduceType reduce_type, double scale, int64_t scatter_dim,
     int64_t shard_count, std::vector<std::vector<int64_t>> groups) {
-  ir::NodePtr node = ir::MakeNode<ir::ops::ReduceScatter>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::ReduceScatter>(
       reduce_type, input.GetIrValue(), token, scale, scatter_dim, shard_count,
       std::move(groups));
   output.SetIrValue(ir::Value(node, 0));
@@ -400,7 +400,7 @@ std::pair<XLATensor, ir::Value> XLATensor::all_to_all(
     const XLATensor& input, const ir::Value& token, int64_t split_dimension,
     int64_t concat_dimension, int64_t split_count,
     std::vector<std::vector<int64_t>> groups) {
-  ir::NodePtr node = ir::MakeNode<ir::ops::AllToAll>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::AllToAll>(
       input.GetIrValue(), token, split_dimension, concat_dimension, split_count,
       std::move(groups));
   return {input.CreateFrom(ir::Value(node, 0)), ir::Value(node, 1)};
@@ -409,7 +409,7 @@ std::pair<XLATensor, ir::Value> XLATensor::all_to_all(
 std::pair<XLATensor, ir::Value> XLATensor::all_gather(
     const XLATensor& input, const ir::Value& token, int64_t dim,
     int64_t shard_count, std::vector<std::vector<int64_t>> groups) {
-  ir::NodePtr node = ir::MakeNode<ir::ops::AllGather>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::AllGather>(
       input.GetIrValue(), token, dim, shard_count, std::move(groups));
   return {input.CreateFrom(ir::Value(node, 0)), ir::Value(node, 1)};
 }
@@ -418,7 +418,7 @@ ir::Value XLATensor::all_gather_out(XLATensor& output, const XLATensor& input,
                                     const ir::Value& token, int64_t dim,
                                     int64_t shard_count,
                                     std::vector<std::vector<int64_t>> groups) {
-  ir::NodePtr node = ir::MakeNode<ir::ops::AllGather>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::AllGather>(
       input.GetIrValue(), token, dim, shard_count, std::move(groups));
   output.SetIrValue(ir::Value(node, 0));
   return ir::Value(node, 1);
@@ -427,7 +427,7 @@ ir::Value XLATensor::all_gather_out(XLATensor& output, const XLATensor& input,
 std::pair<XLATensor, ir::Value> XLATensor::collective_permute(
     const XLATensor& input, const ir::Value& token,
     std::vector<std::pair<int64_t, int64_t>> source_target_pairs) {
-  ir::NodePtr node = ir::MakeNode<ir::ops::CollectivePermute>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::CollectivePermute>(
       input.GetIrValue(), token, std::move(source_target_pairs));
   return {input.CreateFrom(ir::Value(node, 0)), ir::Value(node, 1)};
 }
@@ -453,7 +453,7 @@ void XLATensor::sgd_optimizer_step_(const XLATensor& found_inf, XLATensor& step,
                                            param.GetDevice());
   ir::Value dampening_value =
       GetIrValueForScalar(dampening, param.shape(), param.GetDevice());
-  ir::NodePtr node = ir::MakeNode<ir::ops::SgdOptimizerStep>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::SgdOptimizerStep>(
       found_inf.GetIrValue(), step.GetIrValue(), param.GetIrValue(),
       buf.GetIrValue(), d_p.GetIrValue(), weight_decay_value, momentum_value,
       lr_value, dampening_value,
@@ -482,7 +482,7 @@ void XLATensor::adam_optimizer_step_(
       GetIrValueForScalar(weight_decay, param.shape(), param.GetDevice());
   ir::Value eps_value =
       GetIrValueForScalar(eps, param.shape(), param.GetDevice());
-  ir::NodePtr node = ir::MakeNode<ir::ops::AdamOptimizerStep>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::AdamOptimizerStep>(
       found_inf.GetIrValue(), step.GetIrValue(), param.GetIrValue(), grad_value,
       exp_avg.GetIrValue(), exp_avg_sq.GetIrValue(),
       max_exp_avg_sq.GetIrValue(), beta1_value, beta2_value, lr_value,
@@ -504,7 +504,7 @@ std::vector<XLATensor> XLATensor::user_computation(
   for (auto& input : inputs) {
     input_values.push_back(input.GetIrValue());
   }
-  ir::NodePtr node = ir::MakeNode<ir::ops::UserComputation>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::UserComputation>(
       torch::lazy::OpKind::Get(opname), input_values, std::move(computation));
   // Cast can be one of the user computation and we don't want to inherit the
   // logical_element_type in this case
@@ -564,7 +564,7 @@ XLATensor XLATensor::__rshift__(
 
 std::tuple<XLATensor, XLATensor> XLATensor::adaptive_max_pool2d(
     const XLATensor& input, std::vector<int64_t> output_size) {
-  ir::NodePtr node =
+  torch::lazy::NodePtr node =
       ir::MakeNode<ir::ops::AdaptiveMaxPool2d>(input.GetIrValue(), output_size);
   XLATensor out = input.CreateFrom(ir::Value(node, 0));
   XLATensor indices =
@@ -610,8 +610,9 @@ void XLATensor::_amp_foreach_non_finite_check_and_unscale_(
   for (const auto& x : self) {
     inputs.push_back(x.GetIrValue());
   }
-  ir::NodePtr node = ir::MakeNode<ir::ops::AmpForachNonFiniteCheckAndUnscale>(
-      inputs, found_inf.GetIrValue(), new_inv_scale.GetIrValue());
+  torch::lazy::NodePtr node =
+      ir::MakeNode<ir::ops::AmpForachNonFiniteCheckAndUnscale>(
+          inputs, found_inf.GetIrValue(), new_inv_scale.GetIrValue());
   for (size_t i = 0; i < self.size(); ++i) {
     self[i].SetInPlaceIrValue(ir::Value(node, i));
   }
@@ -624,7 +625,7 @@ void XLATensor::_amp_update_scale_(XLATensor& current_scale,
                                    double scale_growth_factor,
                                    double scale_backoff_factor,
                                    int growth_interval) {
-  ir::NodePtr node = ir::MakeNode<ir::ops::AmpUpdateScale>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::AmpUpdateScale>(
       growth_tracker.GetIrValue(), current_scale.GetIrValue(),
       found_inf.GetIrValue(), scale_growth_factor, scale_backoff_factor,
       growth_interval);
@@ -971,7 +972,7 @@ std::vector<XLATensor> XLATensor::broadcast_tensors(
   for (const auto& tensor : tensors) {
     tensor_ir_values.push_back(tensor.GetIrValue());
   }
-  ir::NodePtr node = ir::ops::BroadcastTensors(tensor_ir_values);
+  torch::lazy::NodePtr node = ir::ops::BroadcastTensors(tensor_ir_values);
   return tensors.front().MakeOutputTensors(node);
 }
 
@@ -1072,10 +1073,11 @@ XLATensor XLATensor::convolution_overrideable(
     std::vector<int64_t> stride, std::vector<int64_t> padding,
     std::vector<int64_t> dilation, bool transposed,
     std::vector<int64_t> output_padding, int64_t groups) {
-  ir::NodePtr ir_value = ir::MakeNode<ir::ops::ConvolutionOverrideable>(
-      input.GetIrValue(), weight.GetIrValue(), bias.GetIrValue(),
-      std::move(stride), std::move(padding), std::move(dilation), transposed,
-      std::move(output_padding), groups);
+  torch::lazy::NodePtr ir_value =
+      ir::MakeNode<ir::ops::ConvolutionOverrideable>(
+          input.GetIrValue(), weight.GetIrValue(), bias.GetIrValue(),
+          std::move(stride), std::move(padding), std::move(dilation),
+          transposed, std::move(output_padding), groups);
   return input.CreateFrom(ir_value);
 }
 
@@ -1084,10 +1086,11 @@ XLATensor XLATensor::convolution_overrideable(
     std::vector<int64_t> stride, std::vector<int64_t> padding,
     std::vector<int64_t> dilation, bool transposed,
     std::vector<int64_t> output_padding, int64_t groups) {
-  ir::NodePtr ir_value = ir::MakeNode<ir::ops::ConvolutionOverrideable>(
-      input.GetIrValue(), weight.GetIrValue(), std::move(stride),
-      std::move(padding), std::move(dilation), transposed,
-      std::move(output_padding), groups);
+  torch::lazy::NodePtr ir_value =
+      ir::MakeNode<ir::ops::ConvolutionOverrideable>(
+          input.GetIrValue(), weight.GetIrValue(), std::move(stride),
+          std::move(padding), std::move(dilation), transposed,
+          std::move(output_padding), groups);
   return input.CreateFrom(ir_value);
 }
 
@@ -1097,10 +1100,11 @@ XLATensor::convolution_backward_overrideable(
     const XLATensor& weight, std::vector<int64_t> stride,
     std::vector<int64_t> padding, std::vector<int64_t> dilation,
     bool transposed, std::vector<int64_t> output_padding, int64_t groups) {
-  ir::NodePtr node = ir::MakeNode<ir::ops::ConvolutionBackwardOverrideable>(
-      out_backprop.GetIrValue(), input.GetIrValue(), weight.GetIrValue(),
-      std::move(stride), std::move(padding), std::move(dilation), transposed,
-      std::move(output_padding), groups);
+  torch::lazy::NodePtr node =
+      ir::MakeNode<ir::ops::ConvolutionBackwardOverrideable>(
+          out_backprop.GetIrValue(), input.GetIrValue(), weight.GetIrValue(),
+          std::move(stride), std::move(padding), std::move(dilation),
+          transposed, std::move(output_padding), groups);
   XLATensor grad_input = out_backprop.CreateFrom(ir::Value(node, 0));
   XLATensor grad_weight = out_backprop.CreateFrom(ir::Value(node, 1));
   XLATensor grad_bias = out_backprop.CreateFrom(ir::Value(node, 2));
@@ -1545,7 +1549,7 @@ XLATensor XLATensor::kl_div_backward(const XLATensor& grad_output,
 std::tuple<XLATensor, XLATensor> XLATensor::kthvalue(const XLATensor& input,
                                                      int64_t k, int64_t dim,
                                                      bool keepdim) {
-  ir::NodePtr node = ir::MakeNode<ir::ops::KthValue>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::KthValue>(
       input.GetIrValue(), k,
       torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank()),
       keepdim);
@@ -1797,8 +1801,8 @@ void XLATensor::masked_scatter_(XLATensor& input, const XLATensor& mask,
 
 XLATensor XLATensor::masked_select(const XLATensor& input,
                                    const XLATensor& mask) {
-  ir::NodePtr node = ir::MakeNode<ir::ops::MaskedSelect>(input.GetIrValue(),
-                                                         mask.GetIrValue());
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::MaskedSelect>(
+      input.GetIrValue(), mask.GetIrValue());
   return input.CreateFrom(ir::Value(node, 0));
 }
 
@@ -1821,8 +1825,8 @@ std::tuple<XLATensor, XLATensor> XLATensor::max(const XLATensor& input,
                                                 int64_t dim, bool keepdim) {
   int64_t canonical_dim =
       torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
-  ir::NodePtr node = ir::MakeNode<ir::ops::MaxInDim>(input.GetIrValue(),
-                                                     canonical_dim, keepdim);
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::MaxInDim>(
+      input.GetIrValue(), canonical_dim, keepdim);
   return std::make_tuple(
       input.CreateFrom(ir::Value(node, 0)),
       input.CreateFrom(ir::Value(node, 1), at::ScalarType::Long));
@@ -1832,8 +1836,8 @@ void XLATensor::max_out(XLATensor& max, XLATensor& max_values,
                         const XLATensor& input, int64_t dim, bool keepdim) {
   int64_t canonical_dim =
       torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
-  ir::NodePtr node = ir::MakeNode<ir::ops::MaxInDim>(input.GetIrValue(),
-                                                     canonical_dim, keepdim);
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::MaxInDim>(
+      input.GetIrValue(), canonical_dim, keepdim);
   max.SetIrValue(ir::Value(node, 0));
   max_values.SetIrValue(ir::Value(node, 1));
 }
@@ -1845,7 +1849,7 @@ std::tuple<XLATensor, XLATensor> XLATensor::max_pool_nd(
   kernel_size = CheckIntList(kernel_size, spatial_dim_count, "kernel_size");
   stride = CheckIntList(stride, spatial_dim_count, "stride", kernel_size);
   padding = CheckIntList(padding, spatial_dim_count, "padding");
-  ir::NodePtr node = ir::MakeNode<ir::ops::MaxPoolNd>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::MaxPoolNd>(
       input.GetIrValue(), spatial_dim_count, std::move(kernel_size),
       std::move(stride), std::move(padding), ceil_mode);
   return std::make_tuple(
@@ -1912,8 +1916,8 @@ std::tuple<XLATensor, XLATensor> XLATensor::min(const XLATensor& input,
                                                 int64_t dim, bool keepdim) {
   int64_t canonical_dim =
       torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
-  ir::NodePtr node = ir::MakeNode<ir::ops::MinInDim>(input.GetIrValue(),
-                                                     canonical_dim, keepdim);
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::MinInDim>(
+      input.GetIrValue(), canonical_dim, keepdim);
   return std::make_tuple(
       input.CreateFrom(ir::Value(node, 0)),
       input.CreateFrom(ir::Value(node, 1), at::ScalarType::Long));
@@ -1923,8 +1927,8 @@ void XLATensor::min_out(XLATensor& min, XLATensor& min_indices,
                         const XLATensor& input, int64_t dim, bool keepdim) {
   int64_t canonical_dim =
       torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
-  ir::NodePtr node = ir::MakeNode<ir::ops::MinInDim>(input.GetIrValue(),
-                                                     canonical_dim, keepdim);
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::MinInDim>(
+      input.GetIrValue(), canonical_dim, keepdim);
   min.SetIrValue(ir::Value(node, 0));
   min_indices.SetIrValue(ir::Value(node, 1));
 }
@@ -2020,7 +2024,7 @@ std::tuple<XLATensor, XLATensor, XLATensor> XLATensor::native_batch_norm(
       GetIrValueOrDefault(running_mean, 0, features_shape, input.GetDevice());
   ir::Value running_var_value =
       GetIrValueOrDefault(running_var, 0, features_shape, input.GetDevice());
-  ir::NodePtr node = ir::MakeNode<ir::ops::NativeBatchNormForward>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::NativeBatchNormForward>(
       input.GetIrValue(), weight_value, bias_value, running_mean_value,
       running_var_value, training, eps);
   XLATensor output = input.CreateFrom(ir::Value(node, 0));
@@ -2056,7 +2060,7 @@ XLATensor::native_batch_norm_backward(const XLATensor& grad_out,
   xla::Shape features_shape = BatchNormFeaturesShape(input);
   ir::Value weight_value =
       GetIrValueOrDefault(weight, 1, features_shape, input.GetDevice());
-  ir::NodePtr node = ir::MakeNode<ir::ops::NativeBatchNormBackward>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::NativeBatchNormBackward>(
       grad_out.GetIrValue(), input.GetIrValue(), weight_value,
       save_mean.GetIrValue(), save_invstd.GetIrValue(), training, eps);
   XLATensor grad_input = input.CreateFrom(ir::Value(node, 0));
@@ -2123,7 +2127,7 @@ std::pair<XLATensor, XLATensor> XLATensor::nms(const XLATensor& boxes,
                                                const XLATensor& score_threshold,
                                                const XLATensor& iou_threshold,
                                                int64_t output_size) {
-  ir::NodePtr node = ir::MakeNode<ir::ops::Nms>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::Nms>(
       boxes.GetIrValue(), scores.GetIrValue(), score_threshold.GetIrValue(),
       iou_threshold.GetIrValue(), output_size);
   return std::pair<XLATensor, XLATensor>(
@@ -2132,7 +2136,8 @@ std::pair<XLATensor, XLATensor> XLATensor::nms(const XLATensor& boxes,
 }
 
 XLATensor XLATensor::nonzero(const XLATensor& input) {
-  ir::NodePtr node = ir::MakeNode<ir::ops::NonZero>(input.GetIrValue());
+  torch::lazy::NodePtr node =
+      ir::MakeNode<ir::ops::NonZero>(input.GetIrValue());
   return input.CreateFrom(ir::Value(node, 0), at::ScalarType::Long);
 }
 
@@ -2243,7 +2248,8 @@ void XLATensor::put_(XLATensor& input, const XLATensor& index,
 
 std::tuple<XLATensor, XLATensor> XLATensor::qr(const XLATensor& input,
                                                bool some) {
-  ir::NodePtr node = ir::MakeNode<ir::ops::QR>(input.GetIrValue(), some);
+  torch::lazy::NodePtr node =
+      ir::MakeNode<ir::ops::QR>(input.GetIrValue(), some);
   return std::make_tuple(input.CreateFrom(ir::Value(node, 0)),
                          input.CreateFrom(ir::Value(node, 1)));
 }
@@ -2347,7 +2353,7 @@ XLATensor XLATensor::round(const XLATensor& input) {
 XLATensor XLATensor::rrelu_with_noise(const XLATensor& input, XLATensor& noise,
                                       const at::Scalar& lower,
                                       const at::Scalar& upper, bool training) {
-  ir::NodePtr output_node = ir::MakeNode<ir::ops::RreluWithNoise>(
+  torch::lazy::NodePtr output_node = ir::MakeNode<ir::ops::RreluWithNoise>(
       input.GetIrValue(), GetRngSeed(input.GetDevice()), lower, upper,
       training);
   noise.SetIrValue(ir::Value(output_node, 1));
@@ -2507,7 +2513,7 @@ XLATensor XLATensor::slice(const XLATensor& input, int64_t dim, int64_t start,
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::slogdet(const XLATensor& input) {
-  ir::NodePtr node = ir::ops::SLogDet(input.GetIrValue());
+  torch::lazy::NodePtr node = ir::ops::SLogDet(input.GetIrValue());
   return std::make_tuple(input.CreateFrom(ir::Value(node, 0)),
                          input.CreateFrom(ir::Value(node, 1)));
 }
@@ -2594,7 +2600,7 @@ std::vector<XLATensor> XLATensor::split(const XLATensor& input,
   for (; dim_size > 0; dim_size -= split_size) {
     split_sizes.push_back(std::min<int64_t>(dim_size, split_size));
   }
-  ir::NodePtr node = ir::MakeNode<ir::ops::Split>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::Split>(
       input.GetIrValue(), std::move(split_sizes), split_dim);
   return input.MakeOutputTensors(node);
 }
@@ -2604,7 +2610,7 @@ std::vector<XLATensor> XLATensor::split_with_sizes(
   auto input_shape = input.shape();
   int split_dim =
       torch::lazy::GetCanonicalDimensionIndex(dim, input_shape.get().rank());
-  ir::NodePtr node = ir::MakeNode<ir::ops::Split>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::Split>(
       input.GetIrValue(), std::move(split_size), split_dim);
   return input.MakeOutputTensors(node);
 }
@@ -2664,7 +2670,7 @@ XLATensor XLATensor::std(const XLATensor& input,
 std::tuple<XLATensor, XLATensor> XLATensor::std_mean(
     const XLATensor& input, std::vector<int64_t> dimensions, int64_t correction,
     bool keep_reduced_dimensions) {
-  ir::NodePtr node = ir::MakeNode<ir::ops::StdMean>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::StdMean>(
       input.GetIrValue(),
       torch::lazy::GetCanonicalDimensionIndices(
           xla::util::ToVector<int64_t>(dimensions), input.shape().get().rank()),
@@ -2713,7 +2719,7 @@ XLATensor XLATensor::sum(const XLATensor& input,
 
 std::tuple<XLATensor, XLATensor, XLATensor> XLATensor::svd(
     const XLATensor& input, bool some, bool compute_uv) {
-  ir::NodePtr node =
+  torch::lazy::NodePtr node =
       ir::MakeNode<ir::ops::SVD>(input.GetIrValue(), some, compute_uv);
   return std::make_tuple(input.CreateFrom(ir::Value(node, 0)),
                          input.CreateFrom(ir::Value(node, 1)),
@@ -2724,7 +2730,7 @@ std::tuple<XLATensor, XLATensor> XLATensor::symeig(const XLATensor& input,
                                                    bool eigenvectors,
                                                    bool upper) {
   // SymEig takes lower instead of upper, hence the negation.
-  ir::NodePtr node =
+  torch::lazy::NodePtr node =
       ir::MakeNode<ir::ops::SymEig>(input.GetIrValue(), eigenvectors, !upper);
   return std::make_tuple(input.CreateFrom(ir::Value(node, 0)),
                          input.CreateFrom(ir::Value(node, 1)));
@@ -2786,7 +2792,7 @@ std::tuple<XLATensor, XLATensor> XLATensor::topk(const XLATensor& input,
                                                  int64_t k, int64_t dim,
                                                  bool largest, bool sorted,
                                                  bool stable) {
-  ir::NodePtr node = ir::MakeNode<ir::ops::TopK>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::TopK>(
       input.GetIrValue(), k,
       torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank()),
       largest, sorted, stable);
@@ -2799,9 +2805,9 @@ XLATensor XLATensor::trace(const XLATensor& input) {
   auto input_shape_ref = input.shape();
   XLA_CHECK_EQ((*input_shape_ref).rank(), 2)
       << "invalid argument for trace: expected a matrix";
-  ir::NodePtr eye = ir::ops::Identity((*input_shape_ref).dimensions(0),
-                                      (*input_shape_ref).dimensions(1),
-                                      (*input_shape_ref).element_type());
+  torch::lazy::NodePtr eye = ir::ops::Identity(
+      (*input_shape_ref).dimensions(0), (*input_shape_ref).dimensions(1),
+      (*input_shape_ref).element_type());
   return XLATensor::sum(input.CreateFrom(eye * input.GetIrValue()), {0, 1},
                         false, input.dtype());
 }
@@ -2827,7 +2833,7 @@ std::tuple<XLATensor, XLATensor> XLATensor::triangular_solve(
     const XLATensor& rhs, const XLATensor& lhs, bool left_side, bool upper,
     bool transpose, bool unitriangular) {
   // TriangularSolve takes lower instead of upper, hence the negation.
-  ir::NodePtr node = ir::MakeNode<ir::ops::TriangularSolve>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::TriangularSolve>(
       rhs.GetIrValue(), lhs.GetIrValue(), left_side, !upper, transpose,
       unitriangular);
   return std::make_tuple(rhs.CreateFrom(ir::Value(node, 0)),
@@ -2947,7 +2953,7 @@ XLATensor XLATensor::var(const XLATensor& input,
 std::tuple<XLATensor, XLATensor> XLATensor::var_mean(
     const XLATensor& input, std::vector<int64_t> dimensions, int64_t correction,
     bool keep_reduced_dimensions) {
-  ir::NodePtr node = ir::MakeNode<ir::ops::VarMean>(
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::VarMean>(
       input.GetIrValue(),
       torch::lazy::GetCanonicalDimensionIndices(
           xla::util::ToVector<int64_t>(dimensions), input.shape().get().rank()),
@@ -2971,7 +2977,7 @@ XLATensor XLATensor::where(const XLATensor& condition, const XLATensor& input,
 XLATensor XLATensor::DispatchComparisonOp(c10::Symbol kind,
                                           const XLATensor& input,
                                           const at::Scalar& other) {
-  ir::NodePtr node = ir::ops::ComparisonOp(
+  torch::lazy::NodePtr node = ir::ops::ComparisonOp(
       kind, input.GetIrValue(), GetIrValueForScalar(other, input.GetDevice()));
   return Create(node, input.GetDevice(), at::ScalarType::Bool);
 }
@@ -2979,7 +2985,7 @@ XLATensor XLATensor::DispatchComparisonOp(c10::Symbol kind,
 XLATensor XLATensor::DispatchComparisonOp(c10::Symbol kind,
                                           const XLATensor& input,
                                           const XLATensor& other) {
-  ir::NodePtr node =
+  torch::lazy::NodePtr node =
       ir::ops::ComparisonOp(kind, input.GetIrValue(), other.GetIrValue());
   return Create(node, input.GetDevice(), at::ScalarType::Bool);
 }


### PR DESCRIPTION
Use `torch::lazy::Node` in `NodePtr` instead of the existing `torch_xla::ir::Node`. 