### PR TITLE
Add optimization barrier to enable the gradient checkpointing

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -748,6 +748,19 @@ class TestDynamicShape(XlaTestCase):
     self.assertEqual(x_dim0_shape.item(), 3)
 
 
+class TestOptimizationBarrier(XlaTestCase):
+
+  def test_optimization_barrier_correctness(self):
+    device = xm.xla_device()
+    # only test optimization_barrier on TPU
+    if xm.xla_device_hw(device) != 'TPU':
+      return
+    x = torch.randn(5, 5, device=device)
+    y = torch.randn(5, 5, device=device)
+    (x1, y1) = xm.optimization_barrier([x, y])
+    self.assertEqual(x + y, x1 + y1)
+
+
 class TestDataType(XlaTestCase):
 
   def test_mixed_dtype_tuple(self):

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -1032,6 +1032,6 @@ def optimization_barrier(tensors):
   the gradient checkpointing.
 
   Args:
-    tensors (torch.Tensor): `torch.Tensor`s to add barrier to.
+    tensors (List[torch.Tensor]): List of `torch.Tensor` to add barrier to.
   """
   return torch_xla._XLAC._xla_optimization_barrier(tensors)

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -1024,3 +1024,14 @@ def get_memory_info(device):
     memory in KB) keys.
   """
   return torch_xla._XLAC._xla_memory_info(str(device))
+
+
+def optimization_barrier(tensors):
+  """Blocks xla compiler from moving computations across this barrier. The common
+  use case would be blocking xla common-subexpression elimination pass from undoing
+  the gradient checkpointing.
+
+  Args:
+    tensors (torch.Tensor): `torch.Tensor`s to add barrier to.
+  """
+  return torch_xla._XLAC._xla_optimization_barrier(tensors)

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -276,6 +276,13 @@ std::pair<at::Tensor, std::shared_ptr<ir::Value>> CollectivePermute(
       std::make_shared<ir::Value>(new_token));
 }
 
+at::Tensor OptimizationBarrier(const at::Tensor& input) {
+  at::Tensor result = bridge::AtenFromXlaTensor(
+      XLATensor::optimization_barrier(bridge::GetXlaTensor(input)));
+  return torch::autograd::make_variable(
+      result, /*requires_grad=*/input.requires_grad());
+}
+
 void SyncTensors(const std::vector<at::Tensor>& tensors,
                  const std::vector<std::string>& devices, bool wait,
                  bool sync_xla_data) {
@@ -1028,6 +1035,8 @@ void InitXlaModuleBindings(py::module m) {
           }
           return new_token;
         });
+  m.def("_xla_optimization_barrier",
+        [](const at::Tensor& input) { return OptimizationBarrier(input); });
   m.def("_xla_set_default_device", [](const std::string& device) {
     return SetCurrentThreadDevice(device);
   });

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -247,6 +247,8 @@ NodePtr SLogDet(const Value& input);
 
 NodePtr Softplus(const Value& input, const Value& beta, const Value& threshold);
 
+NodePtr OptimizationBarrier(const Value& input);
+
 }  // namespace ops
 }  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/xla_ops.cpp
+++ b/torch_xla/csrc/ops/xla_ops.cpp
@@ -18,6 +18,7 @@ const OpKindWrapper xla_get_dimensions_size("xla::xla_get_dimensions_size");
 const OpKindWrapper xla_moving_average("xla::moving_average");
 const OpKindWrapper xla_nms("xla::nms");
 const OpKindWrapper xla_not_supported("xla::not_supported");
+const OpKindWrapper xla_optimization_barrier("xla::optimization_barrier");
 const OpKindWrapper xla_reduce_scatter("xla::reduce_scatter");
 const OpKindWrapper xla_replication_pad("xla::replication_pad");
 const OpKindWrapper xla_replication_pad_backward(

--- a/torch_xla/csrc/ops/xla_ops.h
+++ b/torch_xla/csrc/ops/xla_ops.h
@@ -43,6 +43,7 @@ extern const OpKindWrapper xla_get_dimensions_size;
 extern const OpKindWrapper xla_moving_average;
 extern const OpKindWrapper xla_nms;
 extern const OpKindWrapper xla_not_supported;
+extern const OpKindWrapper xla_optimization_barrier;
 extern const OpKindWrapper xla_reduce_scatter;
 extern const OpKindWrapper xla_replication_pad;
 extern const OpKindWrapper xla_replication_pad_backward;

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -918,6 +918,8 @@ class XLATensor {
   static XLATensor not_supported(std::string description, xla::Shape shape,
                                  const Device& device);
 
+  static XLATensor optimization_barrier(const XLATensor& input);
+
   // Permute the dimensions of this tensor according to the given permutation.
   static XLATensor permute(const XLATensor& input,
                            absl::Span<const int64_t> dims);

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2182,6 +2182,10 @@ XLATensor XLATensor::not_supported(std::string description, xla::Shape shape,
                 device);
 }
 
+XLATensor XLATensor::optimization_barrier(const XLATensor& input) {
+  return input.CreateFrom(ir::ops::OptimizationBarrier(input.GetIrValue()));
+}
+
 XLATensor XLATensor::permute(const XLATensor& input,
                              absl::Span<const int64_t> dims) {
   auto input_shape = input.shape();


### PR DESCRIPTION
This is to fix https://github.com/pytorch/xla/issues/3455. 

This pr introduced a new api `xm.optimization_barrier`, the usage is pretty straightforward, you call this api on the output of the forward pass. For example

```
        dummy_data = torch.zeros(64, 1024, 14, 14, device=device)
        optimizer.zero_grad()
        x = dummy_data
        for n_l, layer in enumerate(model):
            if n_l > 0 and grad_checkpoint:
                x = torch.utils.checkpoint.checkpoint(layer, x)
            else:
                x = layer(x)

        (x,) = xm.optimization_barrier([x])

        dummy_loss = x.sum()
        dummy_loss.backward()
        optimizer.step()
```

this ensures that all of its inputs(in this case the result of the forward pass) are evaluated before any operators that depend on the `optimization_barrier`'s outputs, and XLA is forbidden from eliding or moving non-trivial computations across `optimization_barrier` operators.

running a mini repo on my end, without `optimization_barrier`, I see
```
step 198, free memory after forward = 11514304
step 198, free memory = 11514304
step 199, free memory after forward = 11514304
step 199, free memory = 11514304
Metric: ExecuteTime
  TotalSamples: 200
  Accumulator: 41s329ms857.374us
  ValueRate: 590ms547.571us / second
  Rate: 2.85296 / second
  Percentiles: 1%=204ms379.962us; 5%=205ms526.820us; 10%=205ms608.515us; 20%=205ms785.190us; 50%=205ms188.236us; 80%=206ms065.475us; 90%=207ms667.218us; 95%=218ms647.765us; 99%=259ms730.178us
```

with `optimization barrier` I saw
```
step 198, free memory after forward = 15487456
step 198, free memory = 15487456
step 199, free memory after forward = 15487456
step 199, free memory = 15487456
Metric: ExecuteTime
  TotalSamples: 200
  Accumulator: 12s261ms783.098us
  ValueRate: 763ms711.836us / second
  Rate: 12.4415 / second
  Percentiles: 1%=061ms649.505us; 5%=061ms756.333us; 10%=061ms832.865us; 20%=061ms923.435us; 50%=061ms077.979us; 80%=061ms220.387us; 90%=061ms284.215us; 95%=061ms348.149us; 99%=081ms290.276us
```

What is a bit puzzling is that execute time improved. I would expect execute time to increase since cse was not able to collapse the two forward pass computation. It is a nice surprise so I will take it.

fyi @ronghanghu