### PR TITLE
Update disabled test name for test_upsamplingBicubic2d_xla

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -365,10 +365,7 @@ DISABLED_TORCH_TESTS_TPU_ONLY = {
         'test_LSTM_grad_and_gradgrad_xla_float64',  # grad check failure
         'test_conv3d_valid_padding_backward_xla',  # grad check failure
         'test_ctc_loss_xla',  # runtime overflow error
-        'test_upsamplingBicubic2d_antialias_False_align_corners_False_xla',  # grad check failure
-        'test_upsamplingBicubic2d_antialias_False_align_corners_True_xla',  # grad check failure
-        'test_upsamplingBicubic2d_antialias_True_align_corners_False_xla',  # grad check failure
-        'test_upsamplingBicubic2d_antialias_True_align_corners_True_xla',  # grad check failure
+        'test_upsamplingBicubic2d_xla',  # grad check failure
         'test_upsamplingNearest1d_xla',  # grad check failure
         'test_upsamplingNearest3d_xla',  # grad check failure
         'test_cross_entropy_label_smoothing_consistent_index_target_and_probs_xla',  # precision


### PR DESCRIPTION
Tests `test_upsamplingBicubic2d_xla` have been part of our skip list but was incorrectly named previously. These tests were causing timeouts in the `python-ops` nightly tests. 