### PR TITLE
Make Optimization Barrier in place

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -757,8 +757,9 @@ class TestOptimizationBarrier(XlaTestCase):
       return
     x = torch.randn(5, 5, device=device)
     y = torch.randn(5, 5, device=device)
-    (x1, y1) = xm.optimization_barrier([x, y])
-    self.assertEqual(x + y, x1 + y1)
+    z = x + y
+    xm.optimization_barrier_([x, y])
+    self.assertEqual(z, x + y)
 
 
 class TestDataType(XlaTestCase):

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -1026,7 +1026,7 @@ def get_memory_info(device):
   return torch_xla._XLAC._xla_memory_info(str(device))
 
 
-def optimization_barrier(tensors):
+def optimization_barrier_(tensors):
   """Blocks xla compiler from moving computations across this barrier. The common
   use case would be blocking xla common-subexpression elimination pass from undoing
   the gradient checkpointing.
@@ -1034,4 +1034,4 @@ def optimization_barrier(tensors):
   Args:
     tensors (List[torch.Tensor]): List of `torch.Tensor` to add barrier to.
   """
-  return torch_xla._XLAC._xla_optimization_barrier(tensors)
+  torch_xla._XLAC._xla_optimization_barrier_(tensors)

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -276,17 +276,11 @@ std::pair<at::Tensor, std::shared_ptr<ir::Value>> CollectivePermute(
       std::make_shared<ir::Value>(new_token));
 }
 
-std::vector<at::Tensor> OptimizationBarrier(
-    const std::vector<at::Tensor>& tensors) {
-  std::vector<at::Tensor> result;
-  result.reserve(tensors.size());
+void OptimizationBarrier_(std::vector<at::Tensor>& tensors) {
   for (auto& tensor : tensors) {
-    result.push_back(torch::autograd::make_variable(
-        bridge::AtenFromXlaTensor(
-            XLATensor::optimization_barrier(bridge::GetXlaTensor(tensor))),
-        /*requires_grad=*/tensor.requires_grad()));
+    XLATensor xtensor = bridge::GetXlaTensor(tensor);
+    XLATensor::optimization_barrier_(xtensor);
   }
-  return result;
 }
 
 void SyncTensors(const std::vector<at::Tensor>& tensors,
@@ -1041,8 +1035,8 @@ void InitXlaModuleBindings(py::module m) {
           }
           return new_token;
         });
-  m.def("_xla_optimization_barrier", [](const std::vector<at::Tensor>& inputs) {
-    return OptimizationBarrier(inputs);
+  m.def("_xla_optimization_barrier_", [](std::vector<at::Tensor>& inputs) {
+    OptimizationBarrier_(inputs);
   });
   m.def("_xla_set_default_device", [](const std::string& device) {
     return SetCurrentThreadDevice(device);

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -277,10 +277,8 @@ std::pair<at::Tensor, std::shared_ptr<ir::Value>> CollectivePermute(
 }
 
 void OptimizationBarrier_(std::vector<at::Tensor>& tensors) {
-  for (auto& tensor : tensors) {
-    XLATensor xtensor = bridge::GetXlaTensor(tensor);
-    XLATensor::optimization_barrier_(xtensor);
-  }
+  std::vector<XLATensor> xtensors = GetXlaTensors(tensors, /*want_all=*/false);
+  XLATensor::optimization_barrier_(xtensors);
 }
 
 void SyncTensors(const std::vector<at::Tensor>& tensors,
@@ -1035,9 +1033,8 @@ void InitXlaModuleBindings(py::module m) {
           }
           return new_token;
         });
-  m.def("_xla_optimization_barrier_", [](std::vector<at::Tensor>& inputs) {
-    OptimizationBarrier_(inputs);
-  });
+  m.def("_xla_optimization_barrier_",
+        [](std::vector<at::Tensor>& inputs) { OptimizationBarrier_(inputs); });
   m.def("_xla_set_default_device", [](const std::string& device) {
     return SetCurrentThreadDevice(device);
   });

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -1057,17 +1057,6 @@ torch::lazy::NodePtr Softplus(const Value& input, const Value& beta,
                    std::move(lower_fn));
 }
 
-torch::lazy::NodePtr OptimizationBarrier(const Value& input) {
-  auto lower_fn = [](const Node& node, LoweringContext* loctx) -> XlaOpVector {
-    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
-    xla::XlaOp xla_output = xla::OptimizationBarrier(xla_input);
-    return node.ReturnOp(xla_output, loctx);
-  };
-
-  return GenericOp(xla_optimization_barrier, {input}, input.xla_shape(),
-                   std::move(lower_fn));
-}
-
 }  // namespace ops
 }  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -269,8 +269,6 @@ torch::lazy::NodePtr SLogDet(const Value& input);
 torch::lazy::NodePtr Softplus(const Value& input, const Value& beta,
                               const Value& threshold);
 
-torch::lazy::NodePtr OptimizationBarrier(const Value& input);
-
 }  // namespace ops
 }  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/optimization_barrier.cpp
+++ b/torch_xla/csrc/ops/optimization_barrier.cpp
@@ -1,0 +1,50 @@
+#include "torch_xla/csrc/ops/optimization_barrier.h"
+
+#include "tensorflow/compiler/xla/shape_util.h"
+#include "torch_xla/csrc/lowering_context.h"
+#include "torch_xla/csrc/ops/xla_ops.h"
+#include "torch_xla/csrc/tensor_util.h"
+#include "torch_xla/csrc/xla_lower_util.h"
+
+namespace torch_xla {
+namespace ir {
+namespace ops {
+namespace {
+
+xla::Shape NodeOutputShape(const OpList& inputs) {
+  std::vector<xla::Shape> output_shapes;
+  output_shapes.reserve(inputs.size());
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    output_shapes.push_back(inputs[i].xla_shape());
+  }
+  return xla::ShapeUtil::MakeTupleShape(output_shapes);
+}
+
+}  // namespace
+
+OptimizationBarrier::OptimizationBarrier(const OpList& inputs)
+    : Node(xla_optimization_barrier, inputs, NodeOutputShape(inputs),
+           /*num_outputs=*/inputs.size()) {}
+
+torch::lazy::NodePtr OptimizationBarrier::Clone(OpList operands) const {
+  return ir::MakeNode<OptimizationBarrier>(operands);
+}
+
+XlaOpVector OptimizationBarrier::Lower(LoweringContext* loctx) const {
+  std::vector<xla::XlaOp> inputs;
+  for (size_t i = 0; i < operands().size(); ++i) {
+    inputs.push_back(loctx->GetOutputOp(operand(i)));
+  }
+  xla::XlaOp tuple_input = xla::Tuple(inputs[0].builder(), inputs);
+  xla::XlaOp tuple_output = xla::OptimizationBarrier(tuple_input);
+  std::vector<xla::XlaOp> outputs;
+  outputs.reserve(inputs.size());
+  for (int i = 0; i < inputs.size(); ++i) {
+    outputs.push_back(xla::GetTupleElement(tuple_output, i));
+  }
+  return ReturnOps({outputs}, loctx);
+}
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/optimization_barrier.h
+++ b/torch_xla/csrc/ops/optimization_barrier.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "torch_xla/csrc/ir.h"
+
+namespace torch_xla {
+namespace ir {
+namespace ops {
+
+class OptimizationBarrier : public Node {
+ public:
+  OptimizationBarrier(const OpList& inputs);
+
+  torch::lazy::NodePtr Clone(OpList operands) const override;
+
+  XlaOpVector Lower(LoweringContext* loctx) const override;
+};
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -918,7 +918,7 @@ class XLATensor {
   static XLATensor not_supported(std::string description, xla::Shape shape,
                                  const Device& device);
 
-  static XLATensor optimization_barrier(const XLATensor& input);
+  static void optimization_barrier_(XLATensor& input);
 
   // Permute the dimensions of this tensor according to the given permutation.
   static XLATensor permute(const XLATensor& input,

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -918,7 +918,7 @@ class XLATensor {
   static XLATensor not_supported(std::string description, xla::Shape shape,
                                  const Device& device);
 
-  static void optimization_barrier_(XLATensor& input);
+  static void optimization_barrier_(std::vector<XLATensor>& tensors);
 
   // Permute the dimensions of this tensor according to the given permutation.
   static XLATensor permute(const XLATensor& input,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2195,8 +2195,8 @@ XLATensor XLATensor::not_supported(std::string description, xla::Shape shape,
                 device);
 }
 
-XLATensor XLATensor::optimization_barrier(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::OptimizationBarrier(input.GetIrValue()));
+void XLATensor::optimization_barrier_(XLATensor& input) {
+  return input.SetInPlaceIrValue(ir::ops::OptimizationBarrier(input.GetIrValue()));
 }
 
 XLATensor XLATensor::permute(const XLATensor& input,


### PR DESCRIPTION
This will make `optimization barrier` less awkward. However I tested this implementation and see that it does not help the memory saving. 

Looking at the HLO graph. I think the issue is that
```
 %opt-barrier.9085 = f32[64,1024,14,14]{3,2,1,0} opt-barrier(f32[64,1024,14,14]{3,2,1,0} %maximum.9084)                                                                                                                                        
  %constant.9086 = f32[] constant(0)                                                                                                                                                                                                            
  %reduce.9092 = f32[] reduce(f32[64,1024,14,14]{3,2,1,0} %opt-barrier.9085, f32[] %constant.9086), dimensions={0,1,2,3}, to_apply=%AddComputation.9088 
```

optimization barrier HLO happened at the very end. It should be between forward and backward which will prevent xla compiler to merge forward and backward graph. I need to dig a bit more into this..

fyi @ronghanghu