### PR TITLE
Add performance profiling tool to enable programmatic/interactive/automatic PT-XLA profile capturing

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ With PyTorch/XLA we provide a set of performance profiling tooling and auto-metr
 * [Official tutorial](https://cloud.google.com/tpu/docs/pytorch-xla-performance-profiling-tpu-vm)
 * [Colab notebook](https://colab.research.google.com/github/pytorch/xla/blob/master/contrib/colab/pytorch-xla-profiling-colab.ipynb)
 * [Sample MNIST training script with profiling](https://github.com/pytorch/xla/blob/master/test/test_profile_mp_mnist.py)
+* [Utility script for capturing performance profiles](https://github.com/pytorch/xla/blob/master/scripts/capture_profile.py)
 
 ## <a name="Troubleshooting"></a> Troubleshooting
 

--- a/scripts/capture_profile.py
+++ b/scripts/capture_profile.py
@@ -1,0 +1,137 @@
+import argparse
+import sys
+from time import sleep
+
+import torch_xla.debug.profiler as xp
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Performs an on-demand profiling session on provided profiler servers."
+    )
+
+    parser.add_argument(
+        "--service_addr",
+        dest="service_addr",
+        type=str,
+        required=True,
+        help='comma delimited string of addresses of the profiling servers to profile. ex. "10.0.0.2:8466" or "localhost:9012".',
+    )
+    parser.add_argument(
+        "--logdir",
+        dest="logdir",
+        type=str,
+        required=True,
+        help='the path to write profiling output to. Both the profiler client and server must have access. ex. "gs://bucket/file/path".',
+    )
+    parser.add_argument(
+        "--duration_ms",
+        dest="duration_ms",
+        type=int,
+        default=10000,
+        help="duration in milliseconds for tracing the server.",
+    )
+    parser.add_argument(
+        "--start_time",
+        dest="start_time",
+        type=float,
+        default=None,
+        help=(
+            "the number of seconds to sleep before starting the first profiling. "
+            "This could be a floating point number for subsecond precision. "
+            "Defaults to None, which skips sleeping."
+        ),
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--interactive",
+        dest="interactive",
+        type=str,
+        choices=[None, "once", "loop"],
+        default=None,
+        help=(
+            "run in interactive mode.\n"
+            'If set to "once", the profiler client asks for user confirmation before starting profiling.\n'
+            'If set to "loop", the profiler client repeatedly runs profiling, asking for user confirmation on each run.\n'
+            "Defaults to None, which disables interactive mode."
+        ),
+    )
+
+    def required_length(length):
+        class RequiredLength(argparse.Action):
+            def __call__(self, parser, args, values, option_string=None):
+                if len(values) != length:
+                    msg = f"Argument {self.dest} requires {length} arguments"
+                    raise argparse.ArgumentTypeError(msg)
+                setattr(args, self.dest, values)
+
+        return RequiredLength
+
+    group.add_argument(
+        "--automatic",
+        dest="automatic",
+        type=int,
+        nargs="+",
+        default=None,
+        action=required_length(2),
+        help=(
+            "run in automatic mode.\n"
+            "Requires 2 int type arguments.\n"
+            "The 1st argument specifies the number of profiles to capture.\n"
+            "The 2nd argument specifies the time gap (in seconds) between the profiles, "
+            "i.e. the next profiling will start X seconds after the previous profiling ends.\n"
+            'ex. "--automatic 100 60" captures 100 profiles every 60 seconds.\n'
+            "Defaults to None, which disables automatic mode."
+        ),
+    )
+
+    return parser.parse_args()
+
+
+def request_user_confirmation():
+    usr_input = input('Press "Enter" to start profiling / Press "q" to exit profiling:')
+    usr_input = usr_input.strip().lower()
+    if usr_input == "q" or usr_input == "quit":
+        print("Exiting gracefully...")
+        sys.exit()
+    elif usr_input:
+        raise ValueError(f"Unknown user input: {usr_input}")
+
+
+def main():
+    args = parse_args()
+
+    def trace():
+        xp.trace(
+            service_addr=args.service_addr,
+            logdir=args.logdir,
+            duration_ms=args.duration_ms,
+        )
+        print(f"Saved profiling output to {args.logdir}")
+
+    # optionally sleep for X seconds before starting the profiling
+    if args.start_time:
+        print(f"Profiling will start after {args.start_time} seconds...")
+        sleep(args.start_time)
+
+    # Run performance profiling
+    if args.interactive == "once":
+        request_user_confirmation()
+        trace()
+    elif args.interactive == "loop":
+        while True:
+            request_user_confirmation()
+            trace()
+    elif args.automatic:
+        num_profiles, time_gap = args.automatic
+        for i in range(num_profiles):
+            trace()
+            if i < num_profiles - 1:
+                print(f"The next profiling will start after {time_gap} seconds...")
+                sleep(time_gap)
+    else:
+        trace()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/capture_profile.py
+++ b/scripts/capture_profile.py
@@ -1,3 +1,11 @@
+#!/usr/bin/env python
+"""A utility script for capturing PyTorch/XLA performance profiles interactively and/or automatically
+
+Example run commands:
+    $ python3 capture_profile.py --service_addr "localhost:9001" --logdir "gs://path/to/logdir" --duration_ms 20000 --interactive loop
+    $ python3 capture_profile.py --service_addr "10.0.0.2:9001" --logdir "gs://path/to/logdir" --duration_ms 30000 --automatic 100 60
+"""
+
 import argparse
 import sys
 from time import sleep

--- a/scripts/capture_profile.py
+++ b/scripts/capture_profile.py
@@ -4,6 +4,14 @@
 Example run commands:
     $ python3 capture_profile.py --service_addr "localhost:9001" --logdir "gs://path/to/logdir" --duration_ms 20000 --interactive loop
     $ python3 capture_profile.py --service_addr "10.0.0.2:9001" --logdir "gs://path/to/logdir" --duration_ms 30000 --automatic 100 60
+
+Once you have captured & saved the performance profiles, you can view them using Tensorboard.
+
+Example commands to launch the Tensorboard server:
+    $ (vm) tensorboard --logdir "gs://path/to/logdir --port 8001"
+    $ tensorboard --logdir "/local/path/to/logdir --port 8001"
+
+After that, visit http://localhost:8001/#profile on your machine to view the performance profile in Tensorboard.
 """
 
 import argparse

--- a/scripts/capture_profile.py
+++ b/scripts/capture_profile.py
@@ -22,132 +22,132 @@ import torch_xla.debug.profiler as xp
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(
-        description="Performs an on-demand profiling session on provided profiler servers."
-    )
+  parser = argparse.ArgumentParser(
+      description="Performs an on-demand profiling session on provided profiler servers."
+  )
 
-    parser.add_argument(
-        "--service_addr",
-        dest="service_addr",
-        type=str,
-        required=True,
-        help='comma delimited string of addresses of the profiling servers to profile. ex. "10.0.0.2:8466" or "localhost:9012".',
-    )
-    parser.add_argument(
-        "--logdir",
-        dest="logdir",
-        type=str,
-        required=True,
-        help='the path to write profiling output to. Both the profiler client and server must have access. ex. "gs://bucket/file/path".',
-    )
-    parser.add_argument(
-        "--duration_ms",
-        dest="duration_ms",
-        type=int,
-        default=10000,
-        help="duration in milliseconds for tracing the server.",
-    )
-    parser.add_argument(
-        "--start_time",
-        dest="start_time",
-        type=float,
-        default=None,
-        help=(
-            "the number of seconds to sleep before starting the first profiling. "
-            "This could be a floating point number for subsecond precision. "
-            "Defaults to None, which skips sleeping."
-        ),
-    )
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument(
-        "--interactive",
-        dest="interactive",
-        type=str,
-        choices=[None, "once", "loop"],
-        default=None,
-        help=(
-            "run in interactive mode.\n"
-            'If set to "once", the profiler client asks for user confirmation before starting profiling.\n'
-            'If set to "loop", the profiler client repeatedly runs profiling, asking for user confirmation on each run.\n'
-            "Defaults to None, which disables interactive mode."
-        ),
-    )
+  parser.add_argument(
+      "--service_addr",
+      dest="service_addr",
+      type=str,
+      required=True,
+      help='comma delimited string of addresses of the profiling servers to profile. ex. "10.0.0.2:8466" or "localhost:9012".',
+  )
+  parser.add_argument(
+      "--logdir",
+      dest="logdir",
+      type=str,
+      required=True,
+      help='the path to write profiling output to. Both the profiler client and server must have access. ex. "gs://bucket/file/path".',
+  )
+  parser.add_argument(
+      "--duration_ms",
+      dest="duration_ms",
+      type=int,
+      default=10000,
+      help="duration in milliseconds for tracing the server.",
+  )
+  parser.add_argument(
+      "--start_time",
+      dest="start_time",
+      type=float,
+      default=None,
+      help=(
+          "the number of seconds to sleep before starting the first profiling. "
+          "This could be a floating point number for subsecond precision. "
+          "Defaults to None, which skips sleeping."),
+  )
+  group = parser.add_mutually_exclusive_group()
+  group.add_argument(
+      "--interactive",
+      dest="interactive",
+      type=str,
+      choices=[None, "once", "loop"],
+      default=None,
+      help=(
+          "run in interactive mode.\n"
+          'If set to "once", the profiler client asks for user confirmation before starting profiling.\n'
+          'If set to "loop", the profiler client repeatedly runs profiling, asking for user confirmation on each run.\n'
+          "Defaults to None, which disables interactive mode."),
+  )
 
-    def required_length(length):
-        class RequiredLength(argparse.Action):
-            def __call__(self, parser, args, values, option_string=None):
-                if len(values) != length:
-                    msg = f"Argument {self.dest} requires {length} arguments"
-                    raise argparse.ArgumentTypeError(msg)
-                setattr(args, self.dest, values)
+  def required_length(length):
 
-        return RequiredLength
+    class RequiredLength(argparse.Action):
 
-    group.add_argument(
-        "--automatic",
-        dest="automatic",
-        type=int,
-        nargs="+",
-        default=None,
-        action=required_length(2),
-        help=(
-            "run in automatic mode.\n"
-            "Requires 2 int type arguments.\n"
-            "The 1st argument specifies the number of profiles to capture.\n"
-            "The 2nd argument specifies the time gap (in seconds) between the profiles, "
-            "i.e. the next profiling will start X seconds after the previous profiling ends.\n"
-            'ex. "--automatic 100 60" captures 100 profiles every 60 seconds.\n'
-            "Defaults to None, which disables automatic mode."
-        ),
-    )
+      def __call__(self, parser, args, values, option_string=None):
+        if len(values) != length:
+          msg = f"Argument {self.dest} requires {length} arguments"
+          raise argparse.ArgumentTypeError(msg)
+        setattr(args, self.dest, values)
 
-    return parser.parse_args()
+    return RequiredLength
+
+  group.add_argument(
+      "--automatic",
+      dest="automatic",
+      type=int,
+      nargs="+",
+      default=None,
+      action=required_length(2),
+      help=(
+          "run in automatic mode.\n"
+          "Requires 2 int type arguments.\n"
+          "The 1st argument specifies the number of profiles to capture.\n"
+          "The 2nd argument specifies the time gap (in seconds) between the profiles, "
+          "i.e. the next profiling will start X seconds after the previous profiling ends.\n"
+          'ex. "--automatic 100 60" captures 100 profiles every 60 seconds.\n'
+          "Defaults to None, which disables automatic mode."),
+  )
+
+  return parser.parse_args()
 
 
 def request_user_confirmation():
-    usr_input = input('Press "Enter" to start profiling / Press "q" to exit profiling:')
-    usr_input = usr_input.strip().lower()
-    if usr_input == "q" or usr_input == "quit":
-        print("Exiting gracefully...")
-        sys.exit()
-    elif usr_input:
-        raise ValueError(f"Unknown user input: {usr_input}")
+  usr_input = input(
+      'Press "Enter" to start profiling / Press "q" to exit profiling:')
+  usr_input = usr_input.strip().lower()
+  if usr_input == "q" or usr_input == "quit":
+    print("Exiting gracefully...")
+    sys.exit()
+  elif usr_input:
+    raise ValueError(f"Unknown user input: {usr_input}")
 
 
 def main():
-    args = parse_args()
+  args = parse_args()
 
-    def trace():
-        xp.trace(
-            service_addr=args.service_addr,
-            logdir=args.logdir,
-            duration_ms=args.duration_ms,
-        )
-        print(f"Saved profiling output to {args.logdir}")
+  def trace():
+    xp.trace(
+        service_addr=args.service_addr,
+        logdir=args.logdir,
+        duration_ms=args.duration_ms,
+    )
+    print(f"Saved profiling output to {args.logdir}")
 
-    # optionally sleep for X seconds before starting the profiling
-    if args.start_time:
-        print(f"Profiling will start after {args.start_time} seconds...")
-        sleep(args.start_time)
+  # optionally sleep for X seconds before starting the profiling
+  if args.start_time:
+    print(f"Profiling will start after {args.start_time} seconds...")
+    sleep(args.start_time)
 
-    # Run performance profiling
-    if args.interactive == "once":
-        request_user_confirmation()
-        trace()
-    elif args.interactive == "loop":
-        while True:
-            request_user_confirmation()
-            trace()
-    elif args.automatic:
-        num_profiles, time_gap = args.automatic
-        for i in range(num_profiles):
-            trace()
-            if i < num_profiles - 1:
-                print(f"The next profiling will start after {time_gap} seconds...")
-                sleep(time_gap)
-    else:
-        trace()
+  # Run performance profiling
+  if args.interactive == "once":
+    request_user_confirmation()
+    trace()
+  elif args.interactive == "loop":
+    while True:
+      request_user_confirmation()
+      trace()
+  elif args.automatic:
+    num_profiles, time_gap = args.automatic
+    for i in range(num_profiles):
+      trace()
+      if i < num_profiles - 1:
+        print(f"The next profiling will start after {time_gap} seconds...")
+        sleep(time_gap)
+  else:
+    trace()
 
 
 if __name__ == "__main__":
-    main()
+  main()


### PR DESCRIPTION
Resolves #3471 

## Pull Request Summary

This PR adds a performance profiling utility script (`capture_profile.py`) that enables interactive and/or automatic PT-XLA profile capturing from the command line. The motivation behind `capture_profile.py` is to provide PT-XLA users with an easy and simple way to re-use `torch_xla.debug.profiler.trace` for tracing their training jobs.

## How to Run

Instructions on how to run `capture_profile.py` are already clearly documented in the script itself.

Here are some example run commands
```bash
python3 capture_profile.py --service_addr "localhost:9001" --logdir "gs://path/to/logdir" --duration_ms 20000 --interactive loop
```
```bash
python3 capture_profile.py --service_addr "10.0.0.2:9001" --logdir "gs://path/to/logdir" --duration_ms 30000 --automatic 100 60
```

## For Googlers

See b/226973507 for more details.