### PR TITLE
Lower `aten::randperm.generator_out`

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -92,8 +92,8 @@ function install_deps_pytorch_xla() {
     exit 1
   fi
   bazels3cache --bucket=${XLA_CLANG_CACHE_S3_BUCKET_NAME} --maxEntrySizeBytes=0 --logging.level=verbose
-  # Use cloud cache to build when available.
-  sed -i '/bazel build/ a --remote_http_cache=http://localhost:7777 \\' $XLA_DIR/build_torch_xla_libs.sh
+  # Uncomment to use cloud cache to build when available.
+  # sed -i '/bazel build/ a --remote_http_cache=http://localhost:7777 \\' $XLA_DIR/build_torch_xla_libs.sh
 
 }
 

--- a/build_torch_xla_libs.sh
+++ b/build_torch_xla_libs.sh
@@ -62,7 +62,7 @@ else
   cp -r -u -p $THIRD_PARTY_DIR/xla_client $THIRD_PARTY_DIR/tensorflow/tensorflow/compiler/xla/
 
   pushd $THIRD_PARTY_DIR/tensorflow
-  bazel build $MAX_JOBS $VERBOSE $TPUVM_FLAG --define framework_shared_object=false -c "$MODE" "${OPTS[@]}" \
+  bazel build $MAX_JOBS $VERBOSE $TPUVM_FLAG --spawn_strategy=sandboxed --define framework_shared_object=false -c "$MODE" "${OPTS[@]}" \
     $XLA_CUDA_CFG //tensorflow/compiler/xla/xla_client:libxla_computation_client.so
 
   popd

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ import torch
 base_dir = os.path.dirname(os.path.abspath(__file__))
 third_party_path = os.path.join(base_dir, 'third_party')
 
-_libtpu_version = '0.1.dev20220303'
+_libtpu_version = '0.1.dev20220413'
 _litbpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
 
 

--- a/test/cpp/cpp_test_util.cpp
+++ b/test/cpp/cpp_test_util.cpp
@@ -237,29 +237,29 @@ void WithAllDevices(
 
 std::string GetTensorTextGraph(at::Tensor tensor) {
   XLATensor xtensor = bridge::GetXlaTensor(tensor);
-  return ir::DumpUtil::ToText({xtensor.GetIrValue().node.get()});
+  return DumpUtil::ToText({xtensor.GetIrValue().node.get()});
 }
 
 std::string GetTensorDotGraph(at::Tensor tensor) {
   XLATensor xtensor = bridge::GetXlaTensor(tensor);
-  return ir::DumpUtil::ToDot({xtensor.GetIrValue().node.get()});
+  return DumpUtil::ToDot({xtensor.GetIrValue().node.get()});
 }
 
 std::string GetTensorHloGraph(at::Tensor tensor) {
   XLATensor xtensor = bridge::GetXlaTensor(tensor);
-  return ir::DumpUtil::ToHlo({xtensor.GetIrValue()}, xtensor.GetDevice());
+  return DumpUtil::ToHlo({xtensor.GetIrValue()}, xtensor.GetDevice());
 }
 
-ir::XlaValue GetTensorIrValue(const at::Tensor& tensor,
-                              const torch::lazy::BackendDevice& device) {
+XlaValue GetTensorIrValue(const at::Tensor& tensor,
+                          const torch::lazy::BackendDevice& device) {
   xla::ComputationClient::DataPtr data = TensorToXlaData(tensor, device);
-  return ir::MakeNode<ir::ops::DeviceData>(std::move(data));
+  return torch::lazy::MakeNode<DeviceData>(std::move(data));
 }
 
 std::vector<xla::ComputationClient::DataPtr> Execute(
-    absl::Span<const ir::XlaValue> roots,
+    absl::Span<const XlaValue> roots,
     const torch::lazy::BackendDevice& device) {
-  ir::LoweringContext lowering_ctx("Execute", device);
+  LoweringContext lowering_ctx("Execute", device);
   for (auto node : roots) {
     xla::XlaOp root = lowering_ctx.GetOutputOp(
         torch::lazy::Output(node.node.get(), node.index));
@@ -300,7 +300,7 @@ std::vector<at::Tensor> Fetch(
 }
 
 std::vector<at::Tensor> ExecuteAndFetch(
-    absl::Span<const ir::XlaValue> roots,
+    absl::Span<const XlaValue> roots,
     const torch::lazy::BackendDevice& device) {
   auto results = Execute(roots, device);
   return Fetch(results);

--- a/test/cpp/cpp_test_util.h
+++ b/test/cpp/cpp_test_util.h
@@ -85,19 +85,17 @@ std::string GetTensorDotGraph(at::Tensor tensor);
 
 std::string GetTensorHloGraph(at::Tensor tensor);
 
-ir::XlaValue GetTensorIrValue(const at::Tensor& tensor,
-                              const torch::lazy::BackendDevice& device);
+XlaValue GetTensorIrValue(const at::Tensor& tensor,
+                          const torch::lazy::BackendDevice& device);
 
 std::vector<xla::ComputationClient::DataPtr> Execute(
-    absl::Span<const ir::XlaValue> roots,
-    const torch::lazy::BackendDevice& device);
+    absl::Span<const XlaValue> roots, const torch::lazy::BackendDevice& device);
 
 std::vector<at::Tensor> Fetch(
     absl::Span<const xla::ComputationClient::DataPtr> device_data);
 
 std::vector<at::Tensor> ExecuteAndFetch(
-    absl::Span<const ir::XlaValue> roots,
-    const torch::lazy::BackendDevice& device);
+    absl::Span<const XlaValue> roots, const torch::lazy::BackendDevice& device);
 
 void AssertBackward(const torch::Tensor& xla_output,
                     const std::vector<torch::Tensor>& xla_inputs,

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -11100,6 +11100,7 @@ TEST_F(AtenXlaTensorTest, TestRoll) {
   }
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
   ExpectCounterChanged("xla::roll", cpp_test::GetIgnoredCounters());
+}
 
 }  // namespace cpp_test
 }  // namespace torch_xla

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -11100,7 +11100,6 @@ TEST_F(AtenXlaTensorTest, TestRoll) {
   }
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
   ExpectCounterChanged("xla::roll", cpp_test::GetIgnoredCounters());
-}
 
 }  // namespace cpp_test
 }  // namespace torch_xla

--- a/test/cpp/test_ir.cpp
+++ b/test/cpp/test_ir.cpp
@@ -13,27 +13,27 @@ namespace torch_xla {
 namespace cpp_test {
 
 TEST(IrTest, TestScalarCreate) {
-  torch::lazy::NodePtr scalar = ir::ops::ScalarOp(1.0, xla::F32);
+  torch::lazy::NodePtr scalar = ScalarOp(1.0, xla::F32);
   ASSERT_TRUE(scalar != nullptr);
 }
 
 TEST(IrTest, TestHash) {
-  torch::lazy::NodePtr scalar1 = ir::ops::ScalarOp(1.0, xla::F32);
-  torch::lazy::NodePtr scalar2 = ir::ops::ScalarOp(2.0, xla::F32);
-  ir::XlaValue add1 = ir::XlaValue(scalar1, 0) + ir::XlaValue(scalar2, 0);
+  torch::lazy::NodePtr scalar1 = ScalarOp(1.0, xla::F32);
+  torch::lazy::NodePtr scalar2 = ScalarOp(2.0, xla::F32);
+  XlaValue add1 = XlaValue(scalar1, 0) + XlaValue(scalar2, 0);
 
-  torch::lazy::NodePtr scalar3 = ir::ops::ScalarOp(1.0, xla::F32);
-  torch::lazy::NodePtr scalar4 = ir::ops::ScalarOp(2.0, xla::F32);
-  ir::XlaValue add2 = ir::XlaValue(scalar3, 0) + ir::XlaValue(scalar4, 0);
+  torch::lazy::NodePtr scalar3 = ScalarOp(1.0, xla::F32);
+  torch::lazy::NodePtr scalar4 = ScalarOp(2.0, xla::F32);
+  XlaValue add2 = XlaValue(scalar3, 0) + XlaValue(scalar4, 0);
 
-  torch::lazy::NodePtr scalar5 = ir::ops::ScalarOp(11.0, xla::F32);
-  torch::lazy::NodePtr scalar6 = ir::ops::ScalarOp(22.0, xla::F32);
-  ir::XlaValue add3 = ir::XlaValue(scalar5, 0) + ir::XlaValue(scalar6, 0);
+  torch::lazy::NodePtr scalar5 = ScalarOp(11.0, xla::F32);
+  torch::lazy::NodePtr scalar6 = ScalarOp(22.0, xla::F32);
+  XlaValue add3 = XlaValue(scalar5, 0) + XlaValue(scalar6, 0);
 
   EXPECT_EQ(add1->hash(), add2->hash());
   EXPECT_NE(add1->hash(), add3->hash());
 
-  ir::XlaValue sub = ir::XlaValue(scalar1, 0) - ir::XlaValue(scalar2, 0);
+  XlaValue sub = XlaValue(scalar1, 0) - XlaValue(scalar2, 0);
 
   EXPECT_NE(add1->hash(), sub->hash());
 }
@@ -43,10 +43,9 @@ TEST(IrTest, TestSelectUnselect) {
     at::Tensor a =
         at::rand({4, 16, 3}, at::TensorOptions(at::kFloat)).abs() + 1.0;
 
-    ir::XlaValue v_a = GetTensorIrValue(a, device);
-    ir::XlaValue v_s =
-        ir::MakeNode<ir::ops::Select>(v_a, /*dim=*/1, /*start=*/3,
-                                      /*end=*/14, /*stride=*/3);
+    XlaValue v_a = GetTensorIrValue(a, device);
+    XlaValue v_s = torch::lazy::MakeNode<Select>(v_a, /*dim=*/1, /*start=*/3,
+                                                 /*end=*/14, /*stride=*/3);
 
     auto results = ExecuteAndFetch({v_s}, device);
     at::Tensor b =
@@ -55,9 +54,9 @@ TEST(IrTest, TestSelectUnselect) {
 
     // Paste zeros back into the selected view.
     at::Tensor z = at::zeros_like(b);
-    ir::XlaValue v_z = GetTensorIrValue(z, device);
-    ir::XlaValue v_u =
-        ir::MakeNode<ir::ops::Unselect>(v_a, v_z, /*dim=*/1, /*start=*/3,
+    XlaValue v_z = GetTensorIrValue(z, device);
+    XlaValue v_u =
+        torch::lazy::MakeNode<Unselect>(v_a, v_z, /*dim=*/1, /*start=*/3,
                                         /*end=*/14, /*stride=*/3);
     results = ExecuteAndFetch({v_u}, device);
     // Fetch back the zeros.

--- a/test/cpp/test_op_by_op_executor.cpp
+++ b/test/cpp/test_op_by_op_executor.cpp
@@ -17,9 +17,9 @@ TEST(OpByOpExecutorTest, TestSimpleAdd) {
     at::Tensor b = at::rand({4, 16, 3}, at::TensorOptions(at::kFloat));
     at::Tensor c = a + b;
 
-    ir::XlaValue v_a = GetTensorIrValue(a, device);
-    ir::XlaValue v_b = GetTensorIrValue(b, device);
-    ir::XlaValue v_c = v_a + v_b;
+    XlaValue v_a = GetTensorIrValue(a, device);
+    XlaValue v_b = GetTensorIrValue(b, device);
+    XlaValue v_c = v_a + v_b;
 
     auto results_data =
         OpByOpExecutor::Get()->Execute({v_c}, device.toString(), {});
@@ -35,10 +35,10 @@ TEST(OpByOpExecutorTest, TestStack) {
     at::Tensor b = at::rand({4, 8, 3}, at::TensorOptions(at::kFloat));
     at::Tensor c = at::stack({a, b}, 1);
 
-    ir::XlaValue v_a = GetTensorIrValue(a, device);
-    ir::XlaValue v_b = GetTensorIrValue(b, device);
-    ir::XlaValue v_c =
-        ir::MakeNode<ir::ops::Stack>(std::vector<ir::XlaValue>({v_a, v_b}), 1);
+    XlaValue v_a = GetTensorIrValue(a, device);
+    XlaValue v_b = GetTensorIrValue(b, device);
+    XlaValue v_c =
+        torch::lazy::MakeNode<Stack>(std::vector<XlaValue>({v_a, v_b}), 1);
 
     auto results_data =
         OpByOpExecutor::Get()->Execute({v_c}, device.toString(), {});
@@ -54,10 +54,10 @@ TEST(OpByOpExecutorTest, TestAsyncStack) {
     at::Tensor b = at::rand({4, 8, 3}, at::TensorOptions(at::kFloat));
     at::Tensor c = at::stack({a, b}, 1);
 
-    ir::XlaValue v_a = GetTensorIrValue(a, device);
-    ir::XlaValue v_b = GetTensorIrValue(b, device);
-    ir::XlaValue v_c =
-        ir::MakeNode<ir::ops::Stack>(std::vector<ir::XlaValue>({v_a, v_b}), 1);
+    XlaValue v_a = GetTensorIrValue(a, device);
+    XlaValue v_b = GetTensorIrValue(b, device);
+    XlaValue v_c =
+        torch::lazy::MakeNode<Stack>(std::vector<XlaValue>({v_a, v_b}), 1);
 
     auto async =
         OpByOpExecutor::Get()->ExecuteAsync({v_c}, device.toString(), {});

--- a/third_party/xla_client/xrt_computation_client.cc
+++ b/third_party/xla_client/xrt_computation_client.cc
@@ -25,7 +25,7 @@
 #include "tensorflow/compiler/xrt/xrt_util.h"
 #include "tensorflow/core/framework/allocator.h"
 #include "tensorflow/core/profiler/lib/traceme.h"
-#include "tensorflow/core/tpu/tpu_api_dlsym_initializer.h"
+#include "tensorflow/core/tpu/tpu_initializer_helper.h"
 #include "tensorflow/core/util/device_name_utils.h"
 
 namespace xla {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2709,8 +2709,9 @@ at::Tensor& XLANativeFunctions::randperm_out(
     int64_t n, c10::optional<at::Generator> generator, at::Tensor& out) {
   XLA_FN_COUNTER("xla::");
   if (generator.has_value() && generator->defined()) {
-    return at::native::call_fallback_fn<&xla_cpu_fallback,
-                                        ATEN_OP(randperm_out)>::call(n, out);
+    return at::native::call_fallback_fn<
+        &xla_cpu_fallback, ATEN_OP(randperm_generator_out)>::call(n, generator,
+                                                                  out);
   }
   XLATensor out_tensor = bridge::GetXlaTensor(out);
   XLATensor::randperm_out(n, out_tensor);

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2705,6 +2705,18 @@ at::Tensor& XLANativeFunctions::random_(
   return self;
 }
 
+at::Tensor& XLANativeFunctions::randperm_out(
+    int64_t n, c10::optional<at::Generator> generator, at::Tensor& out) {
+  XLA_FN_COUNTER("xla::");
+  if (generator.has_value() && generator->defined()) {
+    return at::native::call_fallback_fn<&xla_cpu_fallback,
+                                        ATEN_OP(randperm_out)>::call(n, out);
+  }
+  XLATensor out_tensor = bridge::GetXlaTensor(out);
+  XLATensor::randperm_out(n, out_tensor);
+  return out;
+}
+
 at::Tensor XLANativeFunctions::reciprocal(const at::Tensor& self) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -696,8 +696,8 @@ at::Tensor XLANativeFunctions::as_strided(
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   auto xsize = XlaHelpers::I64List(size);
   auto xstride = XlaHelpers::I64List(stride);
-  if (!ir::ops::AsStrided::StrideIsSupported(
-          self_tensor.shape(), xsize, xstride, storage_offset.value_or(0))) {
+  if (!AsStrided::StrideIsSupported(self_tensor.shape(), xsize, xstride,
+                                    storage_offset.value_or(0))) {
     return at::native::call_fallback_fn<
         &xla_cpu_fallback, ATEN_OP(as_strided)>::call(self, size, stride,
                                                       storage_offset);
@@ -714,8 +714,8 @@ const at::Tensor& XLANativeFunctions::as_strided_(
   XLATensor self_tensor = bridge::GetXlaTensor(self);
   auto xsize = XlaHelpers::I64List(size);
   auto xstride = XlaHelpers::I64List(stride);
-  if (!ir::ops::AsStrided::StrideIsSupported(
-          self_tensor.shape(), xsize, xstride, storage_offset.value_or(0))) {
+  if (!AsStrided::StrideIsSupported(self_tensor.shape(), xsize, xstride,
+                                    storage_offset.value_or(0))) {
     return at::native::call_fallback_fn<
         &xla_cpu_fallback, ATEN_OP(as_strided_)>::call(self, size, stride,
                                                        storage_offset);

--- a/torch_xla/csrc/debug_util.cpp
+++ b/torch_xla/csrc/debug_util.cpp
@@ -55,13 +55,13 @@ std::string DebugUtil::GetTensorsGraphInfo(absl::Span<const XLATensor> tensors,
                                            const std::vector<size_t>* indices,
                                            GraphFormat format) {
   std::vector<const torch::lazy::Node*> root_nodes;
-  std::vector<ir::XlaValue> root_values;
+  std::vector<XlaValue> root_values;
   std::vector<torch::lazy::hash_t> root_hashes;
   xla::util::Unique<torch::lazy::BackendDevice> unique_device;
   if (indices != nullptr) {
     for (auto index : *indices) {
       const XLATensor& tensor = tensors[index];
-      ir::XlaValue ir_value = tensor.CurrentIrValue();
+      XlaValue ir_value = tensor.CurrentIrValue();
       if (ir_value) {
         root_nodes.push_back(ir_value.node.get());
         root_hashes.push_back(ir_value.hash());
@@ -71,7 +71,7 @@ std::string DebugUtil::GetTensorsGraphInfo(absl::Span<const XLATensor> tensors,
     }
   } else {
     for (auto& tensor : tensors) {
-      ir::XlaValue ir_value = tensor.CurrentIrValue();
+      XlaValue ir_value = tensor.CurrentIrValue();
       if (ir_value) {
         root_nodes.push_back(ir_value.node.get());
         root_hashes.push_back(ir_value.hash());
@@ -99,11 +99,11 @@ std::string DebugUtil::GetTensorsGraphInfo(absl::Span<const XLATensor> tensors,
 
   std::string graph_str;
   if (format == GraphFormat::kText) {
-    graph_str = ir::DumpUtil::ToText(root_nodes);
+    graph_str = DumpUtil::ToText(root_nodes);
   } else if (format == GraphFormat::kDot) {
-    graph_str = ir::DumpUtil::ToDot(root_nodes);
+    graph_str = DumpUtil::ToDot(root_nodes);
   } else if (format == GraphFormat::kHlo) {
-    graph_str = ir::DumpUtil::ToHlo(
+    graph_str = DumpUtil::ToHlo(
         root_values, unique_device ? *unique_device : GetCurrentDevice());
   } else {
     XLA_ERROR() << "Invalid graph format: " << format;

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -86,7 +86,7 @@ std::string GetTensorsDump(
     const std::function<
         std::string(absl::Span<const torch::lazy::Node* const>)>& coverter) {
   std::vector<const torch::lazy::Node*> nodes;
-  std::vector<ir::XlaValue> values;
+  std::vector<XlaValue> values;
   for (auto& tensor : tensors) {
     XLATensor xtensor = bridge::GetXlaTensor(tensor);
     values.push_back(xtensor.GetIrValue());
@@ -177,108 +177,107 @@ std::vector<std::pair<int64_t, int64_t>> CreateSourceTargetPairs(
   return source_target_pairs;
 }
 
-std::shared_ptr<ir::XlaValue> AllReduceInPlace(
+std::shared_ptr<XlaValue> AllReduceInPlace(
     const std::string& reduce_type, const std::vector<at::Tensor>& tensors,
-    const std::shared_ptr<ir::XlaValue>& token, double scale,
+    const std::shared_ptr<XlaValue>& token, double scale,
     const std::vector<std::vector<int64_t>>& replica_groups, bool pin_layout) {
   std::vector<XLATensor> xtensors = GetXlaTensors(tensors, /*want_all=*/true);
-  return std::make_shared<ir::XlaValue>(
+  return std::make_shared<XlaValue>(
       XLATensor::all_reduce(&xtensors, *token, GetReduceType(reduce_type),
                             scale, replica_groups, pin_layout));
 }
 
-std::pair<at::Tensor, std::shared_ptr<ir::XlaValue>> AllReduce(
+std::pair<at::Tensor, std::shared_ptr<XlaValue>> AllReduce(
     const std::string& reduce_type, const at::Tensor& input,
-    const std::shared_ptr<ir::XlaValue>& token, double scale,
+    const std::shared_ptr<XlaValue>& token, double scale,
     const std::vector<std::vector<int64_t>>& replica_groups, bool pin_layout) {
   XLATensor result;
-  ir::XlaValue new_token;
+  XlaValue new_token;
   std::tie(result, new_token) = XLATensor::all_reduce(
       bridge::GetXlaTensor(input), *token, GetReduceType(reduce_type), scale,
       replica_groups, pin_layout);
-  return std::pair<at::Tensor, std::shared_ptr<ir::XlaValue>>(
+  return std::pair<at::Tensor, std::shared_ptr<XlaValue>>(
       bridge::AtenFromXlaTensor(std::move(result)),
-      std::make_shared<ir::XlaValue>(new_token));
+      std::make_shared<XlaValue>(new_token));
 }
 
-std::pair<at::Tensor, std::shared_ptr<ir::XlaValue>> ReduceScatter(
+std::pair<at::Tensor, std::shared_ptr<XlaValue>> ReduceScatter(
     const std::string& reduce_type, const at::Tensor& input,
-    const std::shared_ptr<ir::XlaValue>& token, double scale,
-    int64_t scatter_dim, int64_t shard_count,
+    const std::shared_ptr<XlaValue>& token, double scale, int64_t scatter_dim,
+    int64_t shard_count,
     const std::vector<std::vector<int64_t>>& replica_groups, bool pin_layout) {
   XLATensor result;
-  ir::XlaValue new_token;
+  XlaValue new_token;
   std::tie(result, new_token) = XLATensor::reduce_scatter(
       bridge::GetXlaTensor(input), *token, GetReduceType(reduce_type), scale,
       scatter_dim, shard_count, replica_groups, pin_layout);
-  return std::pair<at::Tensor, std::shared_ptr<ir::XlaValue>>(
+  return std::pair<at::Tensor, std::shared_ptr<XlaValue>>(
       bridge::AtenFromXlaTensor(std::move(result)),
-      std::make_shared<ir::XlaValue>(new_token));
+      std::make_shared<XlaValue>(new_token));
 }
 
-std::shared_ptr<ir::XlaValue> ReduceScatterOut(
+std::shared_ptr<XlaValue> ReduceScatterOut(
     const std::string& reduce_type, at::Tensor& output, const at::Tensor& input,
-    const std::shared_ptr<ir::XlaValue>& token, double scale,
-    int64_t scatter_dim, int64_t shard_count,
+    const std::shared_ptr<XlaValue>& token, double scale, int64_t scatter_dim,
+    int64_t shard_count,
     const std::vector<std::vector<int64_t>>& replica_groups, bool pin_layout) {
   XLATensor out = bridge::GetXlaTensor(output);
-  ir::XlaValue new_token;
+  XlaValue new_token;
   new_token = XLATensor::reduce_scatter_out(
       out, bridge::GetXlaTensor(input), *token, GetReduceType(reduce_type),
       scale, scatter_dim, shard_count, replica_groups, pin_layout);
-  return std::make_shared<ir::XlaValue>(new_token);
+  return std::make_shared<XlaValue>(new_token);
 }
 
-std::pair<at::Tensor, std::shared_ptr<ir::XlaValue>> AllGather(
-    const at::Tensor& input, const std::shared_ptr<ir::XlaValue>& token,
+std::pair<at::Tensor, std::shared_ptr<XlaValue>> AllGather(
+    const at::Tensor& input, const std::shared_ptr<XlaValue>& token,
     int64_t dim, int64_t shard_count,
     const std::vector<std::vector<int64_t>>& replica_groups, bool pin_layout) {
   XLATensor result;
-  ir::XlaValue new_token;
+  XlaValue new_token;
   std::tie(result, new_token) =
       XLATensor::all_gather(bridge::GetXlaTensor(input), *token, dim,
                             shard_count, replica_groups, pin_layout);
   return {bridge::AtenFromXlaTensor(std::move(result)),
-          std::make_shared<ir::XlaValue>(new_token)};
+          std::make_shared<XlaValue>(new_token)};
 }
 
-std::shared_ptr<ir::XlaValue> AllGatherOut(
+std::shared_ptr<XlaValue> AllGatherOut(
     at::Tensor& output, const at::Tensor& input,
-    const std::shared_ptr<ir::XlaValue>& token, int64_t dim,
-    int64_t shard_count,
+    const std::shared_ptr<XlaValue>& token, int64_t dim, int64_t shard_count,
     const std::vector<std::vector<int64_t>>& replica_groups, bool pin_layout) {
   XLATensor out = bridge::GetXlaTensor(output);
-  ir::XlaValue new_token;
+  XlaValue new_token;
   new_token =
       XLATensor::all_gather_out(out, bridge::GetXlaTensor(input), *token, dim,
                                 shard_count, replica_groups, pin_layout);
-  return std::make_shared<ir::XlaValue>(new_token);
+  return std::make_shared<XlaValue>(new_token);
 }
 
-std::pair<at::Tensor, std::shared_ptr<ir::XlaValue>> AllToAll(
-    const at::Tensor& input, const std::shared_ptr<ir::XlaValue>& token,
+std::pair<at::Tensor, std::shared_ptr<XlaValue>> AllToAll(
+    const at::Tensor& input, const std::shared_ptr<XlaValue>& token,
     int64_t split_dimension, int64_t concat_dimension, int64_t split_count,
     const std::vector<std::vector<int64_t>>& replica_groups, bool pin_layout) {
   XLATensor result;
-  ir::XlaValue new_token;
+  XlaValue new_token;
   std::tie(result, new_token) = XLATensor::all_to_all(
       bridge::GetXlaTensor(input), *token, split_dimension, concat_dimension,
       split_count, replica_groups, pin_layout);
-  return std::pair<at::Tensor, std::shared_ptr<ir::XlaValue>>(
+  return std::pair<at::Tensor, std::shared_ptr<XlaValue>>(
       bridge::AtenFromXlaTensor(std::move(result)),
-      std::make_shared<ir::XlaValue>(new_token));
+      std::make_shared<XlaValue>(new_token));
 }
 
-std::pair<at::Tensor, std::shared_ptr<ir::XlaValue>> CollectivePermute(
-    const at::Tensor& input, const std::shared_ptr<ir::XlaValue>& token,
+std::pair<at::Tensor, std::shared_ptr<XlaValue>> CollectivePermute(
+    const at::Tensor& input, const std::shared_ptr<XlaValue>& token,
     const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs) {
   XLATensor result;
-  ir::XlaValue new_token;
+  XlaValue new_token;
   std::tie(result, new_token) = XLATensor::collective_permute(
       bridge::GetXlaTensor(input), *token, source_target_pairs);
-  return std::pair<at::Tensor, std::shared_ptr<ir::XlaValue>>(
+  return std::pair<at::Tensor, std::shared_ptr<XlaValue>>(
       bridge::AtenFromXlaTensor(std::move(result)),
-      std::make_shared<ir::XlaValue>(new_token));
+      std::make_shared<XlaValue>(new_token));
 }
 
 void OptimizationBarrier_(std::vector<at::Tensor>& tensors) {
@@ -343,10 +342,10 @@ std::string GetLiveTensorsReport(size_t nodes_threshold,
       XLATensor::GetLiveTensors(opt_device ? &opt_device.value() : nullptr);
   std::stringstream ss;
   for (auto& tensor : tensors) {
-    ir::XlaValue ir_value = tensor.CurrentIrValue();
+    XlaValue ir_value = tensor.CurrentIrValue();
     if (ir_value) {
       std::vector<const torch::lazy::Node*> roots({ir_value.node.get()});
-      auto post_order = ir::Util::ComputePostOrder(roots);
+      auto post_order = Util::ComputePostOrder(roots);
       if (post_order.size() > nodes_threshold) {
         ss << "Tensor: id=" << tensor.GetUniqueId()
            << ", shape=" << tensor.shape().get()
@@ -358,7 +357,7 @@ std::string GetLiveTensorsReport(size_t nodes_threshold,
             break;
           }
         }
-        ss << ir::DumpUtil::PostOrderToText(post_order, roots);
+        ss << DumpUtil::PostOrderToText(post_order, roots);
         ss << "\n\n";
       }
     }
@@ -390,7 +389,7 @@ std::vector<at::Tensor> GetXlaTensorsFromAten(
   return xla_tensors;
 }
 
-std::shared_ptr<ir::XlaValue> CreateToken(const std::string& device_str) {
+std::shared_ptr<XlaValue> CreateToken(const std::string& device_str) {
   // This should be using xla::CreateToken() once we have added Token support to
   // XLA AllReduce(). Meanwhile we use a constant as token, and we handle it
   // accordingly in cross_replica_reduces.cpp.
@@ -398,9 +397,9 @@ std::shared_ptr<ir::XlaValue> CreateToken(const std::string& device_str) {
   // as otherwise the XLA compiler passes will remove it, vanishing its
   // sequencing effects.
   torch::lazy::BackendDevice device = GetDeviceOrCurrent(device_str);
-  ir::XlaValue ir_value =
+  XlaValue ir_value =
       XLATensor::GetDeviceDataIrValue(0.0, xla::PrimitiveType::F32, device);
-  return std::make_shared<ir::XlaValue>(std::move(ir_value));
+  return std::make_shared<XlaValue>(std::move(ir_value));
 }
 
 at::Tensor GetXlaTensorDimensionSize(const at::Tensor& tensor, int64_t dim) {
@@ -776,11 +775,11 @@ void BuildProfilerSubmodule(py::module* m) {
       .def_static("is_enabled",
                   &tensorflow::profiler::TraceMeWrapper::IsEnabled);
 
-  py::class_<ir::ScopePusher, std::unique_ptr<ir::ScopePusher>>
-      scope_pusher_class(profiler, "ScopePusher");
+  py::class_<ScopePusher, std::unique_ptr<ScopePusher>> scope_pusher_class(
+      profiler, "ScopePusher");
   profiler.def("scope_pusher",
-               [](const std::string& name) -> std::unique_ptr<ir::ScopePusher> {
-                 return absl::make_unique<ir::ScopePusher>(name);
+               [](const std::string& name) -> std::unique_ptr<ScopePusher> {
+                 return absl::make_unique<ScopePusher>(name);
                });
 }
 
@@ -810,14 +809,14 @@ void InitXlaModuleBindings(py::module m) {
   m.def("_get_xla_tensors_dot",
         [](const std::vector<at::Tensor>& tensors) -> std::string {
           auto coverter = [](absl::Span<const torch::lazy::Node* const> nodes) {
-            return ir::DumpUtil::ToDot(nodes);
+            return DumpUtil::ToDot(nodes);
           };
           return GetTensorsDump(tensors, coverter);
         });
   m.def("_get_xla_tensors_text",
         [](const std::vector<at::Tensor>& tensors) -> std::string {
           auto coverter = [](absl::Span<const torch::lazy::Node* const> nodes) {
-            return ir::DumpUtil::ToText(nodes);
+            return DumpUtil::ToText(nodes);
           };
           return GetTensorsDump(tensors, coverter);
         });
@@ -894,17 +893,17 @@ void InitXlaModuleBindings(py::module m) {
           return Rendezvous(ordinal, tag, payload, replicas);
         });
 
-  py::class_<ir::XlaValue, std::shared_ptr<ir::XlaValue>>(m, "IrValue");
+  py::class_<XlaValue, std::shared_ptr<XlaValue>>(m, "IrValue");
   m.def("_xla_create_token",
         [](const std::string& device) { return CreateToken(device); });
   m.def(
       "_xla_all_reduce_inplace",
       [](const std::string& reduce_type, const std::vector<at::Tensor>& tensors,
-         const std::shared_ptr<ir::XlaValue>& token, double scale,
+         const std::shared_ptr<XlaValue>& token, double scale,
          const py::list& groups, bool pin_layout) {
         std::vector<std::vector<int64_t>> replica_groups =
             CreateReduceGroups(groups);
-        std::shared_ptr<ir::XlaValue> new_token;
+        std::shared_ptr<XlaValue> new_token;
         {
           NoGilSection nogil;
           new_token = AllReduceInPlace(reduce_type, tensors, token, scale,
@@ -914,12 +913,12 @@ void InitXlaModuleBindings(py::module m) {
       });
   m.def("_xla_all_reduce",
         [](const std::string& reduce_type, const at::Tensor& input,
-           const std::shared_ptr<ir::XlaValue>& token, double scale,
+           const std::shared_ptr<XlaValue>& token, double scale,
            const py::list& groups, bool pin_layout) {
           std::vector<std::vector<int64_t>> replica_groups =
               CreateReduceGroups(groups);
           at::Tensor result;
-          std::shared_ptr<ir::XlaValue> new_token;
+          std::shared_ptr<XlaValue> new_token;
           {
             NoGilSection nogil;
             std::tie(result, new_token) = AllReduce(
@@ -932,13 +931,13 @@ void InitXlaModuleBindings(py::module m) {
           return result_tuple;
         });
   m.def("_xla_all_to_all",
-        [](const at::Tensor& input, const std::shared_ptr<ir::XlaValue>& token,
+        [](const at::Tensor& input, const std::shared_ptr<XlaValue>& token,
            int64_t split_dimension, int64_t concat_dimension,
            int64_t split_count, const py::list& groups, bool pin_layout) {
           std::vector<std::vector<int64_t>> replica_groups =
               CreateReduceGroups(groups);
           at::Tensor result;
-          std::shared_ptr<ir::XlaValue> new_token;
+          std::shared_ptr<XlaValue> new_token;
           {
             NoGilSection nogil;
             std::tie(result, new_token) =
@@ -952,13 +951,13 @@ void InitXlaModuleBindings(py::module m) {
           return result_tuple;
         });
   m.def("_xla_all_gather", [](const at::Tensor& input,
-                              const std::shared_ptr<ir::XlaValue>& token,
+                              const std::shared_ptr<XlaValue>& token,
                               int64_t dim, int64_t shard_count,
                               const py::list& groups, bool pin_layout) {
     std::vector<std::vector<int64_t>> replica_groups =
         CreateReduceGroups(groups);
     at::Tensor result;
-    std::shared_ptr<ir::XlaValue> new_token;
+    std::shared_ptr<XlaValue> new_token;
     {
       NoGilSection nogil;
       std::tie(result, new_token) =
@@ -972,12 +971,12 @@ void InitXlaModuleBindings(py::module m) {
   });
   m.def("_xla_all_gather_out",
         [](at::Tensor& output, const at::Tensor& input,
-           const std::shared_ptr<ir::XlaValue>& token, int64_t dim,
+           const std::shared_ptr<XlaValue>& token, int64_t dim,
            int64_t shard_count, const py::list& groups, bool pin_layout) {
           std::vector<std::vector<int64_t>> replica_groups =
               CreateReduceGroups(groups);
           at::Tensor result;
-          std::shared_ptr<ir::XlaValue> new_token;
+          std::shared_ptr<XlaValue> new_token;
           {
             NoGilSection nogil;
             new_token = AllGatherOut(output, input, token, dim, shard_count,
@@ -986,12 +985,12 @@ void InitXlaModuleBindings(py::module m) {
           return new_token;
         });
   m.def("_xla_collective_permute",
-        [](const at::Tensor& input, const std::shared_ptr<ir::XlaValue>& token,
+        [](const at::Tensor& input, const std::shared_ptr<XlaValue>& token,
            const py::list& pairs) {
           std::vector<std::pair<int64_t, int64_t>> source_target_pairs =
               CreateSourceTargetPairs(pairs);
           at::Tensor result;
-          std::shared_ptr<ir::XlaValue> new_token;
+          std::shared_ptr<XlaValue> new_token;
           {
             NoGilSection nogil;
             std::tie(result, new_token) =
@@ -1005,13 +1004,13 @@ void InitXlaModuleBindings(py::module m) {
         });
   m.def("_xla_reduce_scatter",
         [](const std::string& reduce_type, const at::Tensor& input,
-           const std::shared_ptr<ir::XlaValue>& token, double scale,
+           const std::shared_ptr<XlaValue>& token, double scale,
            int64_t scatter_dim, int64_t shard_count, const py::list& groups,
            bool pin_layout) {
           std::vector<std::vector<int64_t>> replica_groups =
               CreateReduceGroups(groups);
           at::Tensor result;
-          std::shared_ptr<ir::XlaValue> new_token;
+          std::shared_ptr<XlaValue> new_token;
           {
             NoGilSection nogil;
             std::tie(result, new_token) =
@@ -1026,13 +1025,13 @@ void InitXlaModuleBindings(py::module m) {
         });
   m.def("_xla_reduce_scatter_out",
         [](const std::string& reduce_type, at::Tensor& output,
-           const at::Tensor& input, const std::shared_ptr<ir::XlaValue>& token,
+           const at::Tensor& input, const std::shared_ptr<XlaValue>& token,
            double scale, int64_t scatter_dim, int64_t shard_count,
            const py::list& groups, bool pin_layout) {
           std::vector<std::vector<int64_t>> replica_groups =
               CreateReduceGroups(groups);
           at::Tensor result;
-          std::shared_ptr<ir::XlaValue> new_token;
+          std::shared_ptr<XlaValue> new_token;
           {
             NoGilSection nogil;
             new_token = ReduceScatterOut(reduce_type, output, input, token,

--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -14,7 +14,6 @@
 #include "torch_xla/csrc/lowering_context.h"
 
 namespace torch_xla {
-namespace ir {
 namespace {
 
 using ShapeCache =
@@ -219,5 +218,4 @@ ScopePusher::~ScopePusher() { PopScope(); }
 
 void ScopePusher::ResetScopes() { ResetScopeContext(); }
 
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -21,7 +21,6 @@
 #include "torch/csrc/lazy/core/ir.h"
 
 namespace torch_xla {
-namespace ir {
 
 static const uint32_t default_hash_seed = (uint32_t)0x5a2d296e9;
 
@@ -153,11 +152,6 @@ inline std::ostream& operator<<(std::ostream& stream, const XlaNode& node) {
   return stream;
 }
 
-template <typename T, typename... Args>
-torch::lazy::NodePtr MakeNode(Args&&... args) {
-  return std::make_shared<T>(std::forward<Args>(args)...);
-}
-
 template <typename T>
 T* NodeCast(const torch::lazy::Node* node, torch::lazy::OpKind op) {
   if (op != node->op()) {
@@ -172,5 +166,4 @@ T* NodeCast(const torch::lazy::Node* node, torch::lazy::OpKind op) {
   return const_cast<T*>(casted);
 }
 
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ir_dump_util.cpp
+++ b/torch_xla/csrc/ir_dump_util.cpp
@@ -12,7 +12,6 @@
 #include "torch_xla/csrc/lowering_context.h"
 
 namespace torch_xla {
-namespace ir {
 namespace {
 
 using NodeIdMap = std::unordered_map<const torch::lazy::Node*, size_t>;
@@ -247,7 +246,7 @@ std::string DumpUtil::PostOrderToText(
 
 std::string DumpUtil::ToHlo(absl::Span<const XlaValue> values,
                             const torch::lazy::BackendDevice& device) {
-  ir::LoweringContext lowering_ctx("IrToHlo", device);
+  LoweringContext lowering_ctx("IrToHlo", device);
   for (auto& ir_value : values) {
     xla::XlaOp root = lowering_ctx.GetOutputOp(
         torch::lazy::Output(ir_value.node.get(), ir_value.index));
@@ -257,5 +256,4 @@ std::string DumpUtil::ToHlo(absl::Span<const XlaValue> values,
   return ConsumeValue(xla::util::GetComputationHloText(computation));
 }
 
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ir_dump_util.h
+++ b/torch_xla/csrc/ir_dump_util.h
@@ -7,7 +7,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
 
 class DumpUtil {
  public:
@@ -27,5 +26,4 @@ class DumpUtil {
                            const torch::lazy::BackendDevice& device);
 };
 
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ir_util.cpp
+++ b/torch_xla/csrc/ir_util.cpp
@@ -3,7 +3,6 @@
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 
 namespace torch_xla {
-namespace ir {
 
 std::vector<const torch::lazy::Node*> Util::ComputePostOrder(
     const torch::lazy::Node* node, EmissionMap* emap) {
@@ -101,5 +100,4 @@ size_t Util::GetGraphSize(absl::Span<const torch::lazy::Node* const> nodes) {
   return post_order.size();
 }
 
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ir_util.h
+++ b/torch_xla/csrc/ir_util.h
@@ -8,7 +8,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
 
 class Util {
  public:
@@ -44,5 +43,4 @@ class Util {
   static size_t GetGraphSize(absl::Span<const torch::lazy::Node* const> nodes);
 };
 
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/lowering_context.cpp
+++ b/torch_xla/csrc/lowering_context.cpp
@@ -12,7 +12,6 @@
 #include "torch/csrc/lazy/core/ir_metadata.h"
 
 namespace torch_xla {
-namespace ir {
 namespace {
 
 class HloMetadataSetter {
@@ -195,5 +194,4 @@ void LoweringContext::ReportBuilderError(const torch::lazy::Node* node,
   throw std::runtime_error(ss.str());
 }
 
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/lowering_context.h
+++ b/torch_xla/csrc/lowering_context.h
@@ -17,7 +17,6 @@
 #include "torch_xla/csrc/ir_util.h"
 
 namespace torch_xla {
-namespace ir {
 
 class LoweringContext {
  public:
@@ -98,5 +97,4 @@ class LoweringContext {
   torch::lazy::Util::EmissionMap emit_status_;
 };
 
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/op_by_op_executor.h
+++ b/torch_xla/csrc/op_by_op_executor.h
@@ -25,14 +25,14 @@ class OpByOpExecutor {
   static OpByOpExecutor* Get();
 
   std::vector<xla::ComputationClient::ExecuteChainedOp> BuildOps(
-      absl::Span<const ir::XlaValue> roots, const std::string& device,
+      absl::Span<const XlaValue> roots, const std::string& device,
       absl::Span<const std::string> devices);
 
   std::vector<xla::ComputationClient::DataPtr> Execute(
-      absl::Span<const ir::XlaValue> roots, const std::string& device,
+      absl::Span<const XlaValue> roots, const std::string& device,
       absl::Span<const std::string> devices);
 
-  AsyncTask ExecuteAsync(absl::Span<const ir::XlaValue> roots,
+  AsyncTask ExecuteAsync(absl::Span<const XlaValue> roots,
                          const std::string& device,
                          absl::Span<const std::string> devices);
 

--- a/torch_xla/csrc/ops/adam_optimizer_step.cpp
+++ b/torch_xla/csrc/ops/adam_optimizer_step.cpp
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& step, const XlaValue& param) {
@@ -36,7 +34,7 @@ AdamOptimizerStep::AdamOptimizerStep(
       use_adamw_(use_adamw) {}
 
 torch::lazy::NodePtr AdamOptimizerStep::Clone(OpList operands) const {
-  return ir::MakeNode<AdamOptimizerStep>(
+  return torch::lazy::MakeNode<AdamOptimizerStep>(
       operands.at(0), operands.at(1), operands.at(2), operands.at(3),
       operands.at(4), operands.at(5), operands.at(6), operands.at(7),
       operands.at(8), operands.at(9), operands.at(10), operands.at(11),
@@ -63,6 +61,4 @@ XlaOpVector AdamOptimizerStep::Lower(LoweringContext* loctx) const {
       loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/adam_optimizer_step.h
+++ b/torch_xla/csrc/ops/adam_optimizer_step.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class AdamOptimizerStep : public XlaNode {
  public:
@@ -26,6 +24,4 @@ class AdamOptimizerStep : public XlaNode {
   bool use_adamw_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/adaptive_avg_pool2d.cpp
+++ b/torch_xla/csrc/ops/adaptive_avg_pool2d.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/pooling.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input,
@@ -30,7 +28,7 @@ AdaptiveAvgPool2d::AdaptiveAvgPool2d(const XlaValue& input,
       output_size_(std::move(output_size)) {}
 
 torch::lazy::NodePtr AdaptiveAvgPool2d::Clone(OpList operands) const {
-  return ir::MakeNode<AdaptiveAvgPool2d>(operands.at(0), output_size_);
+  return torch::lazy::MakeNode<AdaptiveAvgPool2d>(operands.at(0), output_size_);
 }
 
 XlaOpVector AdaptiveAvgPool2d::Lower(LoweringContext* loctx) const {
@@ -46,6 +44,4 @@ std::string AdaptiveAvgPool2d::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/adaptive_avg_pool2d.h
+++ b/torch_xla/csrc/ops/adaptive_avg_pool2d.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class AdaptiveAvgPool2d : public XlaNode {
  public:
@@ -24,6 +22,4 @@ class AdaptiveAvgPool2d : public XlaNode {
   std::vector<int64_t> output_size_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/adaptive_avg_pool3d.cpp
+++ b/torch_xla/csrc/ops/adaptive_avg_pool3d.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/pooling.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input,
@@ -30,7 +28,7 @@ AdaptiveAvgPool3d::AdaptiveAvgPool3d(const XlaValue& input,
       output_size_(std::move(output_size)) {}
 
 torch::lazy::NodePtr AdaptiveAvgPool3d::Clone(OpList operands) const {
-  return ir::MakeNode<AdaptiveAvgPool3d>(operands.at(0), output_size_);
+  return torch::lazy::MakeNode<AdaptiveAvgPool3d>(operands.at(0), output_size_);
 }
 
 XlaOpVector AdaptiveAvgPool3d::Lower(LoweringContext* loctx) const {
@@ -46,6 +44,4 @@ std::string AdaptiveAvgPool3d::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/adaptive_avg_pool3d.h
+++ b/torch_xla/csrc/ops/adaptive_avg_pool3d.h
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class AdaptiveAvgPool3d : public XlaNode {
  public:
@@ -26,6 +24,4 @@ class AdaptiveAvgPool3d : public XlaNode {
   std::vector<int64_t> output_size_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/adaptive_max_pool2d.cpp
+++ b/torch_xla/csrc/ops/adaptive_max_pool2d.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/pooling.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input,
@@ -31,7 +29,7 @@ AdaptiveMaxPool2d::AdaptiveMaxPool2d(const XlaValue& input,
       output_size_(std::move(output_size)) {}
 
 torch::lazy::NodePtr AdaptiveMaxPool2d::Clone(OpList operands) const {
-  return ir::MakeNode<AdaptiveMaxPool2d>(operands.at(0), output_size_);
+  return torch::lazy::MakeNode<AdaptiveMaxPool2d>(operands.at(0), output_size_);
 }
 
 XlaOpVector AdaptiveMaxPool2d::Lower(LoweringContext* loctx) const {
@@ -47,6 +45,4 @@ std::string AdaptiveMaxPool2d::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/adaptive_max_pool2d.h
+++ b/torch_xla/csrc/ops/adaptive_max_pool2d.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class AdaptiveMaxPool2d : public XlaNode {
  public:
@@ -24,6 +22,4 @@ class AdaptiveMaxPool2d : public XlaNode {
   std::vector<int64_t> output_size_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/all.cpp
+++ b/torch_xla/csrc/ops/all.cpp
@@ -9,8 +9,6 @@
 #include "torch_xla/csrc/torch_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input,
@@ -35,8 +33,8 @@ All::All(const XlaValue& input, std::vector<int64_t> dimensions,
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
 torch::lazy::NodePtr All::Clone(OpList operands) const {
-  return ir::MakeNode<All>(operands.at(0), dimensions_,
-                           keep_reduced_dimensions_);
+  return torch::lazy::MakeNode<All>(operands.at(0), dimensions_,
+                                    keep_reduced_dimensions_);
 }
 
 XlaOpVector All::Lower(LoweringContext* loctx) const {
@@ -53,6 +51,4 @@ std::string All::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/all.h
+++ b/torch_xla/csrc/ops/all.h
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class All : public XlaNode {
  public:
@@ -29,6 +27,4 @@ class All : public XlaNode {
   bool keep_reduced_dimensions_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/all_gather.cpp
+++ b/torch_xla/csrc/ops/all_gather.cpp
@@ -8,8 +8,6 @@
 #include "torch_xla/csrc/ops/xla_ops.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& token,
@@ -42,8 +40,8 @@ AllGather::AllGather(const XlaValue& input, const XlaValue& token, int64_t dim,
       pin_layout_(pin_layout) {}
 
 torch::lazy::NodePtr AllGather::Clone(OpList operands) const {
-  return ir::MakeNode<AllGather>(operands.at(0), operands.at(1), dim_,
-                                 shard_count_, groups_, pin_layout_);
+  return torch::lazy::MakeNode<AllGather>(operands.at(0), operands.at(1), dim_,
+                                          shard_count_, groups_, pin_layout_);
 }
 
 XlaOpVector AllGather::Lower(LoweringContext* loctx) const {
@@ -67,6 +65,4 @@ std::string AllGather::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/all_gather.h
+++ b/torch_xla/csrc/ops/all_gather.h
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class AllGather : public XlaNode {
  public:
@@ -34,6 +32,4 @@ class AllGather : public XlaNode {
   bool pin_layout_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/all_reduce.cpp
+++ b/torch_xla/csrc/ops/all_reduce.cpp
@@ -8,8 +8,6 @@
 #include "torch_xla/csrc/ops/xla_ops.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(absl::Span<const XlaValue> operands,
@@ -48,8 +46,9 @@ AllReduce::AllReduce(AllReduceType reduce_type,
 
 torch::lazy::NodePtr AllReduce::Clone(OpList operands) const {
   std::vector<XlaValue> operand_list(operands.begin(), operands.end() - 1);
-  return ir::MakeNode<AllReduce>(reduce_type_, operand_list, operands.back(),
-                                 scale_, groups_, pin_layout_);
+  return torch::lazy::MakeNode<AllReduce>(reduce_type_, operand_list,
+                                          operands.back(), scale_, groups_,
+                                          pin_layout_);
 }
 
 XlaOpVector AllReduce::Lower(LoweringContext* loctx) const {
@@ -78,6 +77,4 @@ std::string AllReduce::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/all_reduce.h
+++ b/torch_xla/csrc/ops/all_reduce.h
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class AllReduce : public XlaNode {
  public:
@@ -34,6 +32,4 @@ class AllReduce : public XlaNode {
   bool pin_layout_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/all_to_all.cpp
+++ b/torch_xla/csrc/ops/all_to_all.cpp
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/ops/xla_ops.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& token,
@@ -47,9 +45,9 @@ AllToAll::AllToAll(const XlaValue& input, const XlaValue& token,
       pin_layout_(pin_layout) {}
 
 torch::lazy::NodePtr AllToAll::Clone(OpList operands) const {
-  return ir::MakeNode<AllToAll>(operands.at(0), operands.at(1),
-                                split_dimension_, concat_dimension_,
-                                split_count_, groups_, pin_layout_);
+  return torch::lazy::MakeNode<AllToAll>(operands.at(0), operands.at(1),
+                                         split_dimension_, concat_dimension_,
+                                         split_count_, groups_, pin_layout_);
 }
 
 XlaOpVector AllToAll::Lower(LoweringContext* loctx) const {
@@ -75,6 +73,4 @@ std::string AllToAll::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/all_to_all.h
+++ b/torch_xla/csrc/ops/all_to_all.h
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class AllToAll : public XlaNode {
  public:
@@ -38,6 +36,4 @@ class AllToAll : public XlaNode {
   bool pin_layout_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/amax.cpp
+++ b/torch_xla/csrc/ops/amax.cpp
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/reduction.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input,
@@ -28,7 +26,7 @@ Amax::Amax(const XlaValue& input, std::vector<int64_t> dimensions, bool keepdim)
       keepdim_(keepdim) {}
 
 torch::lazy::NodePtr Amax::Clone(OpList operands) const {
-  return ir::MakeNode<Amax>(operands.at(0), dimensions_, keepdim_);
+  return torch::lazy::MakeNode<Amax>(operands.at(0), dimensions_, keepdim_);
 }
 
 XlaOpVector Amax::Lower(LoweringContext* loctx) const {
@@ -44,6 +42,4 @@ std::string Amax::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/amax.h
+++ b/torch_xla/csrc/ops/amax.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Amax : public XlaNode {
  public:
@@ -25,6 +23,4 @@ class Amax : public XlaNode {
   bool keepdim_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/amin.cpp
+++ b/torch_xla/csrc/ops/amin.cpp
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/reduction.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input,
@@ -28,7 +26,7 @@ Amin::Amin(const XlaValue& input, std::vector<int64_t> dimensions, bool keepdim)
       keepdim_(keepdim) {}
 
 torch::lazy::NodePtr Amin::Clone(OpList operands) const {
-  return ir::MakeNode<Amin>(operands.at(0), dimensions_, keepdim_);
+  return torch::lazy::MakeNode<Amin>(operands.at(0), dimensions_, keepdim_);
 }
 
 XlaOpVector Amin::Lower(LoweringContext* loctx) const {
@@ -44,6 +42,4 @@ std::string Amin::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/amin.h
+++ b/torch_xla/csrc/ops/amin.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Amin : public XlaNode {
  public:
@@ -25,6 +23,4 @@ class Amin : public XlaNode {
   bool keepdim_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/amp_foreach_non_finite_check_and_unscale.cpp
+++ b/torch_xla/csrc/ops/amp_foreach_non_finite_check_and_unscale.cpp
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const OpList& inputs, const XlaValue& found_inf) {
@@ -45,7 +43,7 @@ torch::lazy::NodePtr AmpForachNonFiniteCheckAndUnscale::Clone(
     OpList operands) const {
   std::vector<XlaValue> operand_list(operands.begin(), operands.end() - 2);
   size_t sz = operand_list.size();
-  return ir::MakeNode<AmpForachNonFiniteCheckAndUnscale>(
+  return torch::lazy::MakeNode<AmpForachNonFiniteCheckAndUnscale>(
       operand_list, operands[sz], operands[sz + 1]);
 }
 
@@ -62,6 +60,4 @@ XlaOpVector AmpForachNonFiniteCheckAndUnscale::Lower(
       loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/amp_foreach_non_finite_check_and_unscale.h
+++ b/torch_xla/csrc/ops/amp_foreach_non_finite_check_and_unscale.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class AmpForachNonFiniteCheckAndUnscale : public XlaNode {
  public:
@@ -17,6 +15,4 @@ class AmpForachNonFiniteCheckAndUnscale : public XlaNode {
   XlaOpVector Lower(LoweringContext* loctx) const override;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/amp_update_scale.cpp
+++ b/torch_xla/csrc/ops/amp_update_scale.cpp
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& growth_tracker,
@@ -33,9 +31,9 @@ AmpUpdateScale::AmpUpdateScale(const XlaValue& current_scale,
       growth_interval_(growth_interval) {}
 
 torch::lazy::NodePtr AmpUpdateScale::Clone(OpList operands) const {
-  return ir::MakeNode<AmpUpdateScale>(operands[0], operands[1], operands[2],
-                                      scale_growth_factor_,
-                                      scale_backoff_factor_, growth_interval_);
+  return torch::lazy::MakeNode<AmpUpdateScale>(
+      operands[0], operands[1], operands[2], scale_growth_factor_,
+      scale_backoff_factor_, growth_interval_);
 }
 
 XlaOpVector AmpUpdateScale::Lower(LoweringContext* loctx) const {
@@ -47,6 +45,4 @@ XlaOpVector AmpUpdateScale::Lower(LoweringContext* loctx) const {
       loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/amp_update_scale.h
+++ b/torch_xla/csrc/ops/amp_update_scale.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class AmpUpdateScale : public XlaNode {
  public:
@@ -22,6 +20,4 @@ class AmpUpdateScale : public XlaNode {
   int growth_interval_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/any.cpp
+++ b/torch_xla/csrc/ops/any.cpp
@@ -9,8 +9,6 @@
 #include "torch_xla/csrc/torch_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input,
@@ -35,8 +33,8 @@ Any::Any(const XlaValue& input, std::vector<int64_t> dimensions,
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
 torch::lazy::NodePtr Any::Clone(OpList operands) const {
-  return ir::MakeNode<Any>(operands.at(0), dimensions_,
-                           keep_reduced_dimensions_);
+  return torch::lazy::MakeNode<Any>(operands.at(0), dimensions_,
+                                    keep_reduced_dimensions_);
 }
 
 XlaOpVector Any::Lower(LoweringContext* loctx) const {
@@ -53,6 +51,4 @@ std::string Any::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/any.h
+++ b/torch_xla/csrc/ops/any.h
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Any : public XlaNode {
  public:
@@ -29,6 +27,4 @@ class Any : public XlaNode {
   bool keep_reduced_dimensions_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/arg_max.cpp
+++ b/torch_xla/csrc/ops/arg_max.cpp
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/reduction.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input, int64_t dim, bool keepdim) {
@@ -27,7 +25,7 @@ ArgMax::ArgMax(const XlaValue& input, int64_t dim, bool keepdim)
       keepdim_(keepdim) {}
 
 torch::lazy::NodePtr ArgMax::Clone(OpList operands) const {
-  return ir::MakeNode<ArgMax>(operands.at(0), dim_, keepdim_);
+  return torch::lazy::MakeNode<ArgMax>(operands.at(0), dim_, keepdim_);
 }
 
 XlaOpVector ArgMax::Lower(LoweringContext* loctx) const {
@@ -41,6 +39,4 @@ std::string ArgMax::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/arg_max.h
+++ b/torch_xla/csrc/ops/arg_max.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class ArgMax : public XlaNode {
  public:
@@ -25,6 +23,4 @@ class ArgMax : public XlaNode {
   bool keepdim_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/arg_min.cpp
+++ b/torch_xla/csrc/ops/arg_min.cpp
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/reduction.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input, int64_t dim, bool keepdim) {
@@ -27,7 +25,7 @@ ArgMin::ArgMin(const XlaValue& input, int64_t dim, bool keepdim)
       keepdim_(keepdim) {}
 
 torch::lazy::NodePtr ArgMin::Clone(OpList operands) const {
-  return ir::MakeNode<ArgMin>(operands.at(0), dim_, keepdim_);
+  return torch::lazy::MakeNode<ArgMin>(operands.at(0), dim_, keepdim_);
 }
 
 XlaOpVector ArgMin::Lower(LoweringContext* loctx) const {
@@ -41,6 +39,4 @@ std::string ArgMin::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/arg_min.h
+++ b/torch_xla/csrc/ops/arg_min.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class ArgMin : public XlaNode {
  public:
@@ -25,6 +23,4 @@ class ArgMin : public XlaNode {
   bool keepdim_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/arithmetic_ir_ops.cpp
+++ b/torch_xla/csrc/ops/arithmetic_ir_ops.cpp
@@ -7,7 +7,6 @@
 #include "torch_xla/csrc/ops/ops.h"
 
 namespace torch_xla {
-namespace ir {
 
 torch::lazy::NodePtr operator+(const XlaValue& node1, const XlaValue& node2) {
   auto lower_fn = [](const XlaNode& node,
@@ -16,10 +15,10 @@ torch::lazy::NodePtr operator+(const XlaValue& node1, const XlaValue& node2) {
     xla::XlaOp op1 = loctx->GetOutputOp(node.operand(1));
     return node.ReturnOp(XlaHelpers::PromotedAdd(op0, op1), loctx);
   };
-  return ops::GenericOp(torch::lazy::OpKind(at::aten::add), {node1, node2},
-                        XlaHelpers::GetPromotedBinaryOpShape(node1.xla_shape(),
-                                                             node2.xla_shape()),
-                        std::move(lower_fn));
+  return GenericOp(torch::lazy::OpKind(at::aten::add), {node1, node2},
+                   XlaHelpers::GetPromotedBinaryOpShape(node1.xla_shape(),
+                                                        node2.xla_shape()),
+                   std::move(lower_fn));
 }
 
 torch::lazy::NodePtr operator-(const XlaValue& node1, const XlaValue& node2) {
@@ -29,10 +28,10 @@ torch::lazy::NodePtr operator-(const XlaValue& node1, const XlaValue& node2) {
     xla::XlaOp op1 = loctx->GetOutputOp(node.operand(1));
     return node.ReturnOp(XlaHelpers::PromotedSub(op0, op1), loctx);
   };
-  return ops::GenericOp(torch::lazy::OpKind(at::aten::sub), {node1, node2},
-                        XlaHelpers::GetPromotedBinaryOpShape(node1.xla_shape(),
-                                                             node2.xla_shape()),
-                        std::move(lower_fn));
+  return GenericOp(torch::lazy::OpKind(at::aten::sub), {node1, node2},
+                   XlaHelpers::GetPromotedBinaryOpShape(node1.xla_shape(),
+                                                        node2.xla_shape()),
+                   std::move(lower_fn));
 }
 
 torch::lazy::NodePtr operator*(const XlaValue& node1, const XlaValue& node2) {
@@ -42,10 +41,10 @@ torch::lazy::NodePtr operator*(const XlaValue& node1, const XlaValue& node2) {
     xla::XlaOp op1 = loctx->GetOutputOp(node.operand(1));
     return node.ReturnOp(XlaHelpers::PromotedMul(op0, op1), loctx);
   };
-  return ops::GenericOp(torch::lazy::OpKind(at::aten::mul), {node1, node2},
-                        XlaHelpers::GetPromotedBinaryOpShape(node1.xla_shape(),
-                                                             node2.xla_shape()),
-                        std::move(lower_fn));
+  return GenericOp(torch::lazy::OpKind(at::aten::mul), {node1, node2},
+                   XlaHelpers::GetPromotedBinaryOpShape(node1.xla_shape(),
+                                                        node2.xla_shape()),
+                   std::move(lower_fn));
 }
 
 torch::lazy::NodePtr operator/(const XlaValue& node1, const XlaValue& node2) {
@@ -55,11 +54,10 @@ torch::lazy::NodePtr operator/(const XlaValue& node1, const XlaValue& node2) {
     xla::XlaOp op1 = loctx->GetOutputOp(node.operand(1));
     return node.ReturnOp(XlaHelpers::PromotedDiv(op0, op1), loctx);
   };
-  return ops::GenericOp(torch::lazy::OpKind(at::aten::div), {node1, node2},
-                        XlaHelpers::GetPromotedBinaryOpShape(node1.xla_shape(),
-                                                             node2.xla_shape()),
-                        std::move(lower_fn));
+  return GenericOp(torch::lazy::OpKind(at::aten::div), {node1, node2},
+                   XlaHelpers::GetPromotedBinaryOpShape(node1.xla_shape(),
+                                                        node2.xla_shape()),
+                   std::move(lower_fn));
 }
 
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/arithmetic_ir_ops.h
+++ b/torch_xla/csrc/ops/arithmetic_ir_ops.h
@@ -3,12 +3,10 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
 
 torch::lazy::NodePtr operator+(const XlaValue& node1, const XlaValue& node2);
 torch::lazy::NodePtr operator-(const XlaValue& node1, const XlaValue& node2);
 torch::lazy::NodePtr operator*(const XlaValue& node1, const XlaValue& node2);
 torch::lazy::NodePtr operator/(const XlaValue& node1, const XlaValue& node2);
 
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/as_strided.cpp
+++ b/torch_xla/csrc/ops/as_strided.cpp
@@ -13,8 +13,6 @@
 #include "torch_xla/csrc/torch_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::XlaOp LowerAsStrided(xla::XlaOp input, absl::Span<const int64_t> size,
@@ -65,8 +63,8 @@ std::string AsStrided::ToString() const {
 }
 
 torch::lazy::NodePtr AsStrided::Clone(OpList operands) const {
-  return ir::MakeNode<AsStrided>(operands.at(0), size_, stride_,
-                                 storage_offset_);
+  return torch::lazy::MakeNode<AsStrided>(operands.at(0), size_, stride_,
+                                          storage_offset_);
 }
 
 XlaOpVector AsStrided::Lower(LoweringContext* loctx) const {
@@ -92,6 +90,4 @@ std::vector<int64_t> AsStrided::GetArrayStridePermutation(
   return permutation;
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/as_strided.h
+++ b/torch_xla/csrc/ops/as_strided.h
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class AsStrided : public XlaNode {
  public:
@@ -40,6 +38,4 @@ class AsStrided : public XlaNode {
   int64_t storage_offset_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/as_strided_view_update.cpp
+++ b/torch_xla/csrc/ops/as_strided_view_update.cpp
@@ -11,8 +11,6 @@
 #include "torch_xla/csrc/torch_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::XlaOp LowerAsStridedViewUpdate(xla::XlaOp target, xla::XlaOp input,
@@ -66,8 +64,8 @@ std::string AsStridedViewUpdate::ToString() const {
 }
 
 torch::lazy::NodePtr AsStridedViewUpdate::Clone(OpList operands) const {
-  return ir::MakeNode<AsStridedViewUpdate>(operands.at(0), operands.at(1),
-                                           size_, stride_, storage_offset_);
+  return torch::lazy::MakeNode<AsStridedViewUpdate>(
+      operands.at(0), operands.at(1), size_, stride_, storage_offset_);
 }
 
 XlaOpVector AsStridedViewUpdate::Lower(LoweringContext* loctx) const {
@@ -78,6 +76,4 @@ XlaOpVector AsStridedViewUpdate::Lower(LoweringContext* loctx) const {
       loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/as_strided_view_update.h
+++ b/torch_xla/csrc/ops/as_strided_view_update.h
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class AsStridedViewUpdate : public XlaNode {
  public:
@@ -33,6 +31,4 @@ class AsStridedViewUpdate : public XlaNode {
   int64_t storage_offset_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/avg_pool_nd.cpp
+++ b/torch_xla/csrc/ops/avg_pool_nd.cpp
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/pooling.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 // Infers the output shape of the max pooling operation.
@@ -64,9 +62,9 @@ AvgPoolNd::AvgPoolNd(const XlaValue& input, int64_t spatial_dim_count,
       count_include_pad_(count_include_pad) {}
 
 torch::lazy::NodePtr AvgPoolNd::Clone(OpList operands) const {
-  return ir::MakeNode<AvgPoolNd>(operands.at(0), spatial_dim_count_,
-                                 kernel_size_, stride_, padding_, ceil_mode_,
-                                 count_include_pad_);
+  return torch::lazy::MakeNode<AvgPoolNd>(operands.at(0), spatial_dim_count_,
+                                          kernel_size_, stride_, padding_,
+                                          ceil_mode_, count_include_pad_);
 }
 
 XlaOpVector AvgPoolNd::Lower(LoweringContext* loctx) const {
@@ -87,6 +85,4 @@ std::string AvgPoolNd::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/avg_pool_nd.h
+++ b/torch_xla/csrc/ops/avg_pool_nd.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class AvgPoolNd : public XlaNode {
  public:
@@ -43,6 +41,4 @@ class AvgPoolNd : public XlaNode {
   bool count_include_pad_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/avg_pool_nd_backward.cpp
+++ b/torch_xla/csrc/ops/avg_pool_nd_backward.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/pooling.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& input,
@@ -68,7 +66,7 @@ AvgPoolNdBackward::AvgPoolNdBackward(const XlaValue& grad_output,
       count_include_pad_(count_include_pad) {}
 
 torch::lazy::NodePtr AvgPoolNdBackward::Clone(OpList operands) const {
-  return ir::MakeNode<AvgPoolNdBackward>(
+  return torch::lazy::MakeNode<AvgPoolNdBackward>(
       operands.at(0), operands.at(1), spatial_dim_count_, kernel_size_, stride_,
       padding_, ceil_mode_, count_include_pad_);
 }
@@ -92,6 +90,4 @@ std::string AvgPoolNdBackward::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/avg_pool_nd_backward.h
+++ b/torch_xla/csrc/ops/avg_pool_nd_backward.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class AvgPoolNdBackward : public XlaNode {
  public:
@@ -43,6 +41,4 @@ class AvgPoolNdBackward : public XlaNode {
   bool count_include_pad_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/bernoulli.cpp
+++ b/torch_xla/csrc/ops/bernoulli.cpp
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Bernoulli::Bernoulli(const XlaValue& probability, const XlaValue& seed,
                      xla::Shape shape)
@@ -14,7 +12,8 @@ Bernoulli::Bernoulli(const XlaValue& probability, const XlaValue& seed,
               std::move(shape)) {}
 
 torch::lazy::NodePtr Bernoulli::Clone(OpList operands) const {
-  return ir::MakeNode<Bernoulli>(operands.at(0), operands.at(1), xla_shape());
+  return torch::lazy::MakeNode<Bernoulli>(operands.at(0), operands.at(1),
+                                          xla_shape());
 }
 
 XlaOpVector Bernoulli::Lower(LoweringContext* loctx) const {
@@ -30,6 +29,4 @@ XlaOpVector Bernoulli::Lower(LoweringContext* loctx) const {
       loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/bernoulli.h
+++ b/torch_xla/csrc/ops/bernoulli.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Bernoulli : public XlaNode {
  public:
@@ -16,6 +14,4 @@ class Bernoulli : public XlaNode {
   XlaOpVector Lower(LoweringContext* loctx) const override;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/binary_cross_entropy.cpp
+++ b/torch_xla/csrc/ops/binary_cross_entropy.cpp
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& logits, const XlaValue& labels,
@@ -49,8 +47,8 @@ torch::lazy::NodePtr BinaryCrossEntropy::Clone(OpList operands) const {
   if (operands.size() > 2) {
     weight = operands.at(2);
   }
-  return ir::MakeNode<BinaryCrossEntropy>(operands.at(0), operands.at(1),
-                                          weight, reduction_);
+  return torch::lazy::MakeNode<BinaryCrossEntropy>(
+      operands.at(0), operands.at(1), weight, reduction_);
 }
 
 XlaOpVector BinaryCrossEntropy::Lower(LoweringContext* loctx) const {
@@ -71,6 +69,4 @@ std::string BinaryCrossEntropy::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/binary_cross_entropy.h
+++ b/torch_xla/csrc/ops/binary_cross_entropy.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/reduction.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class BinaryCrossEntropy : public XlaNode {
  public:
@@ -26,6 +24,4 @@ class BinaryCrossEntropy : public XlaNode {
   ReductionMode reduction_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/binary_cross_entropy_backward.cpp
+++ b/torch_xla/csrc/ops/binary_cross_entropy_backward.cpp
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& logits,
@@ -53,7 +51,7 @@ torch::lazy::NodePtr BinaryCrossEntropyBackward::Clone(OpList operands) const {
   if (operands.size() > 3) {
     weight = operands.at(3);
   }
-  return ir::MakeNode<BinaryCrossEntropyBackward>(
+  return torch::lazy::MakeNode<BinaryCrossEntropyBackward>(
       operands.at(0), operands.at(1), operands.at(2), weight, reduction_);
 }
 
@@ -77,6 +75,4 @@ std::string BinaryCrossEntropyBackward::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/binary_cross_entropy_backward.h
+++ b/torch_xla/csrc/ops/binary_cross_entropy_backward.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/reduction.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class BinaryCrossEntropyBackward : public XlaNode {
  public:
@@ -27,6 +25,4 @@ class BinaryCrossEntropyBackward : public XlaNode {
   ReductionMode reduction_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/bitwise_ir_ops.cpp
+++ b/torch_xla/csrc/ops/bitwise_ir_ops.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ops/ops.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 XlaValue BitwiseAnd(const XlaValue& node1, const XlaValue& node2) {
   auto lower_fn = [](const XlaNode& node,
@@ -75,6 +73,4 @@ XlaValue BitwiseXor(const XlaValue& node1, const XlaValue& node2) {
                    std::move(lower_fn));
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/bitwise_ir_ops.h
+++ b/torch_xla/csrc/ops/bitwise_ir_ops.h
@@ -3,14 +3,10 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 // XlaValue has implicit cast to bool, operator overloads would be confusing.
 XlaValue BitwiseAnd(const XlaValue& node1, const XlaValue& node2);
 XlaValue BitwiseOr(const XlaValue& node1, const XlaValue& node2);
 XlaValue BitwiseXor(const XlaValue& node1, const XlaValue& node2);
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/cast.cpp
+++ b/torch_xla/csrc/ops/cast.cpp
@@ -12,8 +12,6 @@
 #include "torch_xla/csrc/torch_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input, xla::PrimitiveType type) {
@@ -42,8 +40,8 @@ Cast::Cast(const XlaValue& input, at::ScalarType dtype,
       stype_(stype) {}
 
 torch::lazy::NodePtr Cast::Clone(OpList operands) const {
-  return dtype_ ? ir::MakeNode<Cast>(operands.at(0), *dtype_, stype_)
-                : ir::MakeNode<Cast>(operands.at(0), type_);
+  return dtype_ ? torch::lazy::MakeNode<Cast>(operands.at(0), *dtype_, stype_)
+                : torch::lazy::MakeNode<Cast>(operands.at(0), type_);
 }
 
 XlaOpVector Cast::Lower(LoweringContext* loctx) const {
@@ -71,6 +69,4 @@ std::string Cast::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/cast.h
+++ b/torch_xla/csrc/ops/cast.h
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Cast : public XlaNode {
  public:
@@ -33,6 +31,4 @@ class Cast : public XlaNode {
   c10::optional<at::ScalarType> stype_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/cat.cpp
+++ b/torch_xla/csrc/ops/cat.cpp
@@ -6,11 +6,9 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(absl::Span<const ir::XlaValue> values, int64_t dim) {
+xla::Shape NodeOutputShape(absl::Span<const XlaValue> values, int64_t dim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildCat(operands, dim);
@@ -25,14 +23,14 @@ xla::Shape NodeOutputShape(absl::Span<const ir::XlaValue> values, int64_t dim) {
 
 }  // namespace
 
-Cat::Cat(absl::Span<const ir::XlaValue> values, int64_t dim)
+Cat::Cat(absl::Span<const XlaValue> values, int64_t dim)
     : XlaNode(torch::lazy::OpKind(at::aten::cat), values,
               [&]() { return NodeOutputShape(values, dim); },
               /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}
 
 torch::lazy::NodePtr Cat::Clone(OpList operands) const {
-  return ir::MakeNode<Cat>(operands, dim_);
+  return torch::lazy::MakeNode<Cat>(operands, dim_);
 }
 
 XlaOpVector Cat::Lower(LoweringContext* loctx) const {
@@ -49,6 +47,4 @@ std::string Cat::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/cat.h
+++ b/torch_xla/csrc/ops/cat.h
@@ -4,12 +4,10 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Cat : public XlaNode {
  public:
-  Cat(absl::Span<const ir::XlaValue> values, int64_t dim);
+  Cat(absl::Span<const XlaValue> values, int64_t dim);
 
   std::string ToString() const override;
 
@@ -23,6 +21,4 @@ class Cat : public XlaNode {
   int64_t dim_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/cholesky.cpp
+++ b/torch_xla/csrc/ops/cholesky.cpp
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/lowering_context.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Cholesky::Cholesky(const XlaValue& input, bool lower)
     : XlaNode(torch::lazy::OpKind(at::aten::cholesky), {input},
@@ -15,7 +13,7 @@ Cholesky::Cholesky(const XlaValue& input, bool lower)
       lower_(lower) {}
 
 torch::lazy::NodePtr Cholesky::Clone(OpList operands) const {
-  return ir::MakeNode<Cholesky>(operands.at(0), lower_);
+  return torch::lazy::MakeNode<Cholesky>(operands.at(0), lower_);
 }
 
 XlaOpVector Cholesky::Lower(LoweringContext* loctx) const {
@@ -31,6 +29,4 @@ std::string Cholesky::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/cholesky.h
+++ b/torch_xla/csrc/ops/cholesky.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Cholesky : public XlaNode {
  public:
@@ -22,6 +20,4 @@ class Cholesky : public XlaNode {
   bool lower_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/collective_permute.cpp
+++ b/torch_xla/csrc/ops/collective_permute.cpp
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/ops/xla_ops.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(
@@ -34,8 +32,8 @@ CollectivePermute::CollectivePermute(
       source_target_pairs_(std::move(source_target_pairs)) {}
 
 torch::lazy::NodePtr CollectivePermute::Clone(OpList operands) const {
-  return ir::MakeNode<CollectivePermute>(operands.at(0), operands.at(1),
-                                         source_target_pairs_);
+  return torch::lazy::MakeNode<CollectivePermute>(
+      operands.at(0), operands.at(1), source_target_pairs_);
 }
 
 XlaOpVector CollectivePermute::Lower(LoweringContext* loctx) const {
@@ -58,6 +56,4 @@ std::string CollectivePermute::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/collective_permute.h
+++ b/torch_xla/csrc/ops/collective_permute.h
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class CollectivePermute : public XlaNode {
  public:
@@ -27,6 +25,4 @@ class CollectivePermute : public XlaNode {
   std::vector<std::pair<int64_t, int64_t>> source_target_pairs_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/constant.cpp
+++ b/torch_xla/csrc/ops/constant.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/lowering_context.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Constant::Constant(xla::Literal value)
     : XlaNode(torch::lazy::OpKind(at::prim::Constant), value.shape(),
@@ -25,13 +23,11 @@ std::string Constant::ToString() const {
 }
 
 torch::lazy::NodePtr Constant::Clone(OpList operands) const {
-  return ir::MakeNode<Constant>(value_.Clone());
+  return torch::lazy::MakeNode<Constant>(value_.Clone());
 }
 
 XlaOpVector Constant::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::ConstantLiteral(loctx->builder(), value_), loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/constant.h
+++ b/torch_xla/csrc/ops/constant.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Constant : public XlaNode {
  public:
@@ -22,6 +20,4 @@ class Constant : public XlaNode {
   xla::Literal value_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/constant_pad_nd.cpp
+++ b/torch_xla/csrc/ops/constant_pad_nd.cpp
@@ -9,8 +9,6 @@
 #include "torch_xla/csrc/ops/scalar.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::XlaOp LowerPad(xla::XlaOp input, const at::Scalar& value,
@@ -42,7 +40,7 @@ ConstantPadNd::ConstantPadNd(const XlaValue& input, std::vector<int64_t> pad,
       value_(value) {}
 
 torch::lazy::NodePtr ConstantPadNd::Clone(OpList operands) const {
-  return ir::MakeNode<ConstantPadNd>(operands.at(0), pad_, value_);
+  return torch::lazy::MakeNode<ConstantPadNd>(operands.at(0), pad_, value_);
 }
 
 XlaOpVector ConstantPadNd::Lower(LoweringContext* loctx) const {
@@ -58,6 +56,4 @@ std::string ConstantPadNd::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/constant_pad_nd.h
+++ b/torch_xla/csrc/ops/constant_pad_nd.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class ConstantPadNd : public XlaNode {
  public:
@@ -28,6 +26,4 @@ class ConstantPadNd : public XlaNode {
   at::Scalar value_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/convolution_backward_overrideable.cpp
+++ b/torch_xla/csrc/ops/convolution_backward_overrideable.cpp
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& input,
@@ -60,7 +58,7 @@ ConvolutionBackwardOverrideable::ConvolutionBackwardOverrideable(
 
 torch::lazy::NodePtr ConvolutionBackwardOverrideable::Clone(
     OpList operands) const {
-  return ir::MakeNode<ConvolutionBackwardOverrideable>(
+  return torch::lazy::MakeNode<ConvolutionBackwardOverrideable>(
       operands.at(0), operands.at(1), operands.at(2), stride_, padding_,
       dilation_, transposed_, output_padding_, groups_);
 }
@@ -88,6 +86,4 @@ std::string ConvolutionBackwardOverrideable::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/convolution_backward_overrideable.h
+++ b/torch_xla/csrc/ops/convolution_backward_overrideable.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class ConvolutionBackwardOverrideable : public XlaNode {
  public:
@@ -43,6 +41,4 @@ class ConvolutionBackwardOverrideable : public XlaNode {
   int64_t groups_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/convolution_overrideable.cpp
+++ b/torch_xla/csrc/ops/convolution_overrideable.cpp
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 // The bias doesn't matter for shape inference.
@@ -75,10 +73,10 @@ ConvolutionOverrideable::ConvolutionOverrideable(
 
 torch::lazy::NodePtr ConvolutionOverrideable::Clone(OpList operands) const {
   return operands.size() == 3
-             ? ir::MakeNode<ConvolutionOverrideable>(
+             ? torch::lazy::MakeNode<ConvolutionOverrideable>(
                    operands.at(0), operands.at(1), operands.at(2), stride_,
                    padding_, dilation_, transposed_, output_padding_, groups_)
-             : ir::MakeNode<ConvolutionOverrideable>(
+             : torch::lazy::MakeNode<ConvolutionOverrideable>(
                    operands.at(0), operands.at(1), stride_, padding_, dilation_,
                    transposed_, output_padding_, groups_);
 }
@@ -111,6 +109,4 @@ std::string ConvolutionOverrideable::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/convolution_overrideable.h
+++ b/torch_xla/csrc/ops/convolution_overrideable.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 // IR node for 2D & 3D convolutions with or without bias.
 class ConvolutionOverrideable : public XlaNode {
@@ -50,6 +48,4 @@ class ConvolutionOverrideable : public XlaNode {
   int64_t groups_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/cumprod.cpp
+++ b/torch_xla/csrc/ops/cumprod.cpp
@@ -11,8 +11,6 @@
 #include "torch_xla/csrc/torch_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::XlaOp LowerCumProd(xla::XlaOp input, int64_t dim,
@@ -47,7 +45,7 @@ CumProd::CumProd(const XlaValue& input, int64_t dim,
       dtype_(dtype) {}
 
 torch::lazy::NodePtr CumProd::Clone(OpList operands) const {
-  return ir::MakeNode<CumProd>(operands.at(0), dim_, dtype_);
+  return torch::lazy::MakeNode<CumProd>(operands.at(0), dim_, dtype_);
 }
 
 XlaOpVector CumProd::Lower(LoweringContext* loctx) const {
@@ -64,6 +62,4 @@ std::string CumProd::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/cumprod.h
+++ b/torch_xla/csrc/ops/cumprod.h
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class CumProd : public XlaNode {
  public:
@@ -29,6 +27,4 @@ class CumProd : public XlaNode {
   c10::optional<at::ScalarType> dtype_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/cumsum.cpp
+++ b/torch_xla/csrc/ops/cumsum.cpp
@@ -10,8 +10,6 @@
 #include "torch_xla/csrc/torch_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::XlaOp LowerCumSum(xla::XlaOp input, int64_t dim,
@@ -46,7 +44,7 @@ CumSum::CumSum(const XlaValue& input, int64_t dim,
       dtype_(dtype) {}
 
 torch::lazy::NodePtr CumSum::Clone(OpList operands) const {
-  return ir::MakeNode<CumSum>(operands.at(0), dim_, dtype_);
+  return torch::lazy::MakeNode<CumSum>(operands.at(0), dim_, dtype_);
 }
 
 XlaOpVector CumSum::Lower(LoweringContext* loctx) const {
@@ -63,6 +61,4 @@ std::string CumSum::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/cumsum.h
+++ b/torch_xla/csrc/ops/cumsum.h
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class CumSum : public XlaNode {
  public:
@@ -29,6 +27,4 @@ class CumSum : public XlaNode {
   c10::optional<at::ScalarType> dtype_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/device_data.cpp
+++ b/torch_xla/csrc/ops/device_data.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ops/xla_ops.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 DeviceData::DeviceData(std::shared_ptr<xla::ComputationClient::Data> data)
     : XlaNode(xla_device_data, data->shape(), /*num_outputs=*/1,
@@ -21,7 +19,7 @@ std::string DeviceData::ToString() const {
 }
 
 torch::lazy::NodePtr DeviceData::Clone(OpList operands) const {
-  return ir::MakeNode<DeviceData>(data_);
+  return torch::lazy::MakeNode<DeviceData>(data_);
 }
 
 XlaOpVector DeviceData::Lower(LoweringContext* loctx) const {
@@ -29,9 +27,7 @@ XlaOpVector DeviceData::Lower(LoweringContext* loctx) const {
 }
 
 DeviceData* DeviceData::Cast(const torch::lazy::Node* node) {
-  return ir::NodeCast<DeviceData>(node, xla_device_data);
+  return torch_xla::NodeCast<DeviceData>(node, xla_device_data);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/device_data.h
+++ b/torch_xla/csrc/ops/device_data.h
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class DeviceData : public XlaNode {
  public:
@@ -27,6 +25,4 @@ class DeviceData : public XlaNode {
   std::shared_ptr<xla::ComputationClient::Data> data_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/diagonal.cpp
+++ b/torch_xla/csrc/ops/diagonal.cpp
@@ -8,8 +8,6 @@
 #include "torch_xla/csrc/matrix.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Diagonal::Diagonal(const XlaValue& input, int64_t offset, int64_t dim1,
                    int64_t dim2)
@@ -23,7 +21,7 @@ Diagonal::Diagonal(const XlaValue& input, int64_t offset, int64_t dim1,
       dim2_(dim2) {}
 
 torch::lazy::NodePtr Diagonal::Clone(OpList operands) const {
-  return ir::MakeNode<Diagonal>(operands.at(0), offset_, dim1_, dim2_);
+  return torch::lazy::MakeNode<Diagonal>(operands.at(0), offset_, dim1_, dim2_);
 }
 
 XlaOpVector Diagonal::Lower(LoweringContext* loctx) const {
@@ -59,6 +57,4 @@ xla::Shape Diagonal::MakeDiagonalShape(const xla::Shape& shape, int64_t offset,
   return xla::ShapeUtil::MakeShape(shape.element_type(), dimensions);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/diagonal.h
+++ b/torch_xla/csrc/ops/diagonal.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Diagonal : public XlaNode {
  public:
@@ -31,6 +29,4 @@ class Diagonal : public XlaNode {
   int64_t dim2_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/diagonal_view_update.cpp
+++ b/torch_xla/csrc/ops/diagonal_view_update.cpp
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ops/xla_ops.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 DiagonalViewUpdate::DiagonalViewUpdate(const XlaValue& target,
                                        const XlaValue& input, int64_t offset,
@@ -18,8 +16,8 @@ DiagonalViewUpdate::DiagonalViewUpdate(const XlaValue& target,
       dim2_(dim2) {}
 
 torch::lazy::NodePtr DiagonalViewUpdate::Clone(OpList operands) const {
-  return ir::MakeNode<DiagonalViewUpdate>(operands.at(0), operands.at(1),
-                                          offset_, dim1_, dim2_);
+  return torch::lazy::MakeNode<DiagonalViewUpdate>(
+      operands.at(0), operands.at(1), offset_, dim1_, dim2_);
 }
 
 XlaOpVector DiagonalViewUpdate::Lower(LoweringContext* loctx) const {
@@ -37,6 +35,4 @@ std::string DiagonalViewUpdate::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/diagonal_view_update.h
+++ b/torch_xla/csrc/ops/diagonal_view_update.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class DiagonalViewUpdate : public XlaNode {
  public:
@@ -29,6 +27,4 @@ class DiagonalViewUpdate : public XlaNode {
   int64_t dim2_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/discrete_uniform.cpp
+++ b/torch_xla/csrc/ops/discrete_uniform.cpp
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/torch_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 DiscreteUniform::DiscreteUniform(const XlaValue& from, const XlaValue& to,
                                  const XlaValue& seed,
@@ -18,8 +16,8 @@ DiscreteUniform::DiscreteUniform(const XlaValue& from, const XlaValue& to,
               /*num_outputs=*/1, torch::lazy::Hash(rng_shape)) {}
 
 torch::lazy::NodePtr DiscreteUniform::Clone(OpList operands) const {
-  return ir::MakeNode<DiscreteUniform>(operands.at(0), operands.at(1),
-                                       operands.at(2), xla_shape());
+  return torch::lazy::MakeNode<DiscreteUniform>(operands.at(0), operands.at(1),
+                                                operands.at(2), xla_shape());
 }
 
 XlaOpVector DiscreteUniform::Lower(LoweringContext* loctx) const {
@@ -29,6 +27,4 @@ XlaOpVector DiscreteUniform::Lower(LoweringContext* loctx) const {
   return ReturnOp(RngDiscreteUniform(rng_seed, xla_shape(), from, to), loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/discrete_uniform.h
+++ b/torch_xla/csrc/ops/discrete_uniform.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class DiscreteUniform : public XlaNode {
  public:
@@ -16,6 +14,4 @@ class DiscreteUniform : public XlaNode {
   XlaOpVector Lower(LoweringContext* loctx) const override;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/expand.cpp
+++ b/torch_xla/csrc/ops/expand.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input,
@@ -28,7 +26,7 @@ Expand::Expand(const XlaValue& input, std::vector<int64_t> size)
       size_(std::move(size)) {}
 
 torch::lazy::NodePtr Expand::Clone(OpList operands) const {
-  return ir::MakeNode<Expand>(operands.at(0), size_);
+  return torch::lazy::MakeNode<Expand>(operands.at(0), size_);
 }
 
 XlaOpVector Expand::Lower(LoweringContext* loctx) const {
@@ -42,6 +40,4 @@ std::string Expand::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/expand.h
+++ b/torch_xla/csrc/ops/expand.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Expand : public XlaNode {
  public:
@@ -24,6 +22,4 @@ class Expand : public XlaNode {
   std::vector<int64_t> size_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/exponential.cpp
+++ b/torch_xla/csrc/ops/exponential.cpp
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Exponential::Exponential(const XlaValue& lambda, const XlaValue& seed,
                          xla::Shape shape)
@@ -14,7 +12,8 @@ Exponential::Exponential(const XlaValue& lambda, const XlaValue& seed,
               std::move(shape)) {}
 
 torch::lazy::NodePtr Exponential::Clone(OpList operands) const {
-  return ir::MakeNode<Exponential>(operands.at(0), operands.at(1), xla_shape());
+  return torch::lazy::MakeNode<Exponential>(operands.at(0), operands.at(1),
+                                            xla_shape());
 }
 
 XlaOpVector Exponential::Lower(LoweringContext* loctx) const {
@@ -30,6 +29,4 @@ XlaOpVector Exponential::Lower(LoweringContext* loctx) const {
       loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/exponential.h
+++ b/torch_xla/csrc/ops/exponential.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Exponential : public XlaNode {
  public:
@@ -15,6 +13,4 @@ class Exponential : public XlaNode {
   XlaOpVector Lower(LoweringContext* loctx) const override;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/flip.cpp
+++ b/torch_xla/csrc/ops/flip.cpp
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/lowering_context.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Flip::Flip(const XlaValue& input, std::vector<int64_t> dims)
     : XlaNode(torch::lazy::OpKind(at::aten::flip), {input}, input.xla_shape(),
@@ -13,7 +11,7 @@ Flip::Flip(const XlaValue& input, std::vector<int64_t> dims)
       dims_(std::move(dims)) {}
 
 torch::lazy::NodePtr Flip::Clone(OpList operands) const {
-  return ir::MakeNode<Flip>(operands.at(0), dims_);
+  return torch::lazy::MakeNode<Flip>(operands.at(0), dims_);
 }
 
 XlaOpVector Flip::Lower(LoweringContext* loctx) const {
@@ -28,6 +26,4 @@ std::string Flip::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/flip.h
+++ b/torch_xla/csrc/ops/flip.h
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Flip : public XlaNode {
  public:
@@ -24,6 +22,4 @@ class Flip : public XlaNode {
   std::vector<int64_t> dims_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/gather.cpp
+++ b/torch_xla/csrc/ops/gather.cpp
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Gather::Gather(const XlaValue& input, int64_t dim, const XlaValue& index)
     : XlaNode(torch::lazy::OpKind(at::aten::gather), {input, index},
@@ -18,7 +16,7 @@ Gather::Gather(const XlaValue& input, int64_t dim, const XlaValue& index)
       dim_(dim) {}
 
 torch::lazy::NodePtr Gather::Clone(OpList operands) const {
-  return ir::MakeNode<Gather>(operands.at(0), dim_, operands.at(1));
+  return torch::lazy::MakeNode<Gather>(operands.at(0), dim_, operands.at(1));
 }
 
 XlaOpVector Gather::Lower(LoweringContext* loctx) const {
@@ -33,6 +31,4 @@ std::string Gather::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/gather.h
+++ b/torch_xla/csrc/ops/gather.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Gather : public XlaNode {
  public:
@@ -22,6 +20,4 @@ class Gather : public XlaNode {
   int64_t dim_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/generic.cpp
+++ b/torch_xla/csrc/ops/generic.cpp
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/lowering_context.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Generic::Generic(torch::lazy::OpKind op, absl::Span<const XlaValue> operands,
                  xla::Shape shape, LowerFn lower_fn, size_t num_outputs,
@@ -28,14 +26,12 @@ Generic::Generic(torch::lazy::OpKind op, xla::Shape shape, LowerFn lower_fn,
       hash_seed_(hash_seed) {}
 
 torch::lazy::NodePtr Generic::Clone(OpList operands) const {
-  return ir::MakeNode<Generic>(op(), operands, xla_shape(), lower_fn_,
-                               num_outputs(), hash_seed_);
+  return torch::lazy::MakeNode<Generic>(op(), operands, xla_shape(), lower_fn_,
+                                        num_outputs(), hash_seed_);
 }
 
 XlaOpVector Generic::Lower(LoweringContext* loctx) const {
   return lower_fn_(*this, loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/generic.h
+++ b/torch_xla/csrc/ops/generic.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 // Generic IR XlaNode implementation for nodes which can simply be described by
 // a specific OpKind and a lowering function. IR nodes carrying metadata should
@@ -36,6 +34,4 @@ class Generic : public XlaNode {
   torch::lazy::hash_t hash_seed_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/generic_slice.cpp
+++ b/torch_xla/csrc/ops/generic_slice.cpp
@@ -8,8 +8,6 @@
 #include "torch_xla/csrc/torch_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input,
@@ -34,7 +32,8 @@ GenericSlice::GenericSlice(const XlaValue& input,
       sizes_(sizes.begin(), sizes.end()) {}
 
 torch::lazy::NodePtr GenericSlice::Clone(OpList operands) const {
-  return ir::MakeNode<GenericSlice>(operands.at(0), base_indices_, sizes_);
+  return torch::lazy::MakeNode<GenericSlice>(operands.at(0), base_indices_,
+                                             sizes_);
 }
 
 XlaOpVector GenericSlice::Lower(LoweringContext* loctx) const {
@@ -51,6 +50,4 @@ std::string GenericSlice::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/generic_slice.h
+++ b/torch_xla/csrc/ops/generic_slice.h
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class GenericSlice : public XlaNode {
  public:
@@ -27,6 +25,4 @@ class GenericSlice : public XlaNode {
   std::vector<int64_t> sizes_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/get_dimensions_size.cpp
+++ b/torch_xla/csrc/ops/get_dimensions_size.cpp
@@ -8,8 +8,6 @@
 #include "torch_xla/csrc/tensor_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 GetDimensionsSize::GetDimensionsSize(const XlaValue& input,
                                      std::vector<int64_t> dimensions)
@@ -20,7 +18,7 @@ GetDimensionsSize::GetDimensionsSize(const XlaValue& input,
       dimensions_(std::move(dimensions)) {}
 
 torch::lazy::NodePtr GetDimensionsSize::Clone(OpList operands) const {
-  return ir::MakeNode<GetDimensionsSize>(operands.at(0), dimensions_);
+  return torch::lazy::MakeNode<GetDimensionsSize>(operands.at(0), dimensions_);
 }
 
 XlaOpVector GetDimensionsSize::Lower(LoweringContext* loctx) const {
@@ -36,6 +34,4 @@ std::string GetDimensionsSize::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/get_dimensions_size.h
+++ b/torch_xla/csrc/ops/get_dimensions_size.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class GetDimensionsSize : public XlaNode {
  public:
@@ -24,6 +22,4 @@ class GetDimensionsSize : public XlaNode {
   std::vector<int64_t> dimensions_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/hardshrink.cpp
+++ b/torch_xla/csrc/ops/hardshrink.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ops/scalar.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Hardshrink::Hardshrink(const XlaValue& input, const at::Scalar& lambda)
     : XlaNode(torch::lazy::OpKind(at::aten::hardshrink), {input},
@@ -22,7 +20,7 @@ std::string Hardshrink::ToString() const {
 }
 
 torch::lazy::NodePtr Hardshrink::Clone(OpList operands) const {
-  return ir::MakeNode<Hardshrink>(operands.at(0), lambda_);
+  return torch::lazy::MakeNode<Hardshrink>(operands.at(0), lambda_);
 }
 
 XlaOpVector Hardshrink::Lower(LoweringContext* loctx) const {
@@ -30,6 +28,4 @@ XlaOpVector Hardshrink::Lower(LoweringContext* loctx) const {
   return ReturnOp(BuildHardshrink(input, lambda_), loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/hardshrink.h
+++ b/torch_xla/csrc/ops/hardshrink.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Hardshrink : public XlaNode {
  public:
@@ -24,6 +22,4 @@ class Hardshrink : public XlaNode {
   at::Scalar lambda_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/hardtanh_backward.cpp
+++ b/torch_xla/csrc/ops/hardtanh_backward.cpp
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ops/scalar.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 HardtanhBackward::HardtanhBackward(const XlaValue& grad_output,
                                    const XlaValue& input,
@@ -26,8 +24,8 @@ std::string HardtanhBackward::ToString() const {
 }
 
 torch::lazy::NodePtr HardtanhBackward::Clone(OpList operands) const {
-  return ir::MakeNode<HardtanhBackward>(operands.at(0), operands.at(1),
-                                        min_val_, max_val_);
+  return torch::lazy::MakeNode<HardtanhBackward>(operands.at(0), operands.at(1),
+                                                 min_val_, max_val_);
 }
 
 XlaOpVector HardtanhBackward::Lower(LoweringContext* loctx) const {
@@ -38,6 +36,4 @@ XlaOpVector HardtanhBackward::Lower(LoweringContext* loctx) const {
   return ReturnOp(output, loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/hardtanh_backward.h
+++ b/torch_xla/csrc/ops/hardtanh_backward.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class HardtanhBackward : public XlaNode {
  public:
@@ -28,6 +26,4 @@ class HardtanhBackward : public XlaNode {
   at::Scalar max_val_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/index_get.cpp
+++ b/torch_xla/csrc/ops/index_get.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& base, const XlaValue& indices,
@@ -23,7 +21,7 @@ xla::Shape NodeOutputShape(const XlaValue& base, const XlaValue& indices,
 
 }  // namespace
 
-IndexGet::IndexGet(const ir::XlaValue& base, const ir::XlaValue& indices,
+IndexGet::IndexGet(const XlaValue& base, const XlaValue& indices,
                    int64_t start_dim)
     : XlaNode(torch::lazy::OpKind(at::aten::index), {base, indices},
               [&]() { return NodeOutputShape(base, indices, start_dim); },
@@ -37,7 +35,8 @@ std::string IndexGet::ToString() const {
 }
 
 torch::lazy::NodePtr IndexGet::Clone(OpList operands) const {
-  return ir::MakeNode<IndexGet>(operands.at(0), operands.at(1), start_dim_);
+  return torch::lazy::MakeNode<IndexGet>(operands.at(0), operands.at(1),
+                                         start_dim_);
 }
 
 XlaOpVector IndexGet::Lower(LoweringContext* loctx) const {
@@ -47,6 +46,4 @@ XlaOpVector IndexGet::Lower(LoweringContext* loctx) const {
   return ReturnOp(output, loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/index_get.h
+++ b/torch_xla/csrc/ops/index_get.h
@@ -3,13 +3,10 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class IndexGet : public XlaNode {
  public:
-  IndexGet(const ir::XlaValue& base, const ir::XlaValue& indices,
-           int64_t start_dim);
+  IndexGet(const XlaValue& base, const XlaValue& indices, int64_t start_dim);
 
   std::string ToString() const override;
 
@@ -24,6 +21,4 @@ class IndexGet : public XlaNode {
   int64_t start_dim_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/index_ops.h
+++ b/torch_xla/csrc/ops/index_ops.h
@@ -51,7 +51,7 @@ CanonicalIndexInfo GetCanonicalIndexInfo(
     const c10::List<c10::optional<at::Tensor>>& orig_indices);
 
 // Expands a rank <= 1 tensor to rank 1, if necessary.
-ir::XlaValue EnsureRank1(const ir::XlaValue& index);
+XlaValue EnsureRank1(const XlaValue& index);
 
 // Implements indexing by tensors of long according to the top-level
 // description.
@@ -59,11 +59,11 @@ XLATensor IndexByTensors(const XLATensor& base,
                          absl::Span<const XLATensor> indices,
                          int64_t start_dim);
 
-ir::XlaValue IndexPutByTensors(const XLATensor& base,
-                               absl::Span<const XLATensor> indices,
-                               int64_t start_dim, const XLATensor& updates,
-                               bool accumulate,
-                               absl::Span<const int64_t> result_permutation);
+XlaValue IndexPutByTensors(const XLATensor& base,
+                           absl::Span<const XLATensor> indices,
+                           int64_t start_dim, const XLATensor& updates,
+                           bool accumulate,
+                           absl::Span<const int64_t> result_permutation);
 
 torch::lazy::NodePtr IndexFill(const XLATensor& base, int64_t dim,
                                const XLATensor& index, const at::Scalar& value);
@@ -71,10 +71,10 @@ torch::lazy::NodePtr IndexFill(const XLATensor& base, int64_t dim,
 torch::lazy::NodePtr IndexFill(const XLATensor& base, int64_t dim,
                                const XLATensor& index, const XLATensor& value);
 
-ir::XlaValue IndexAdd(const XLATensor& base, int64_t dim,
-                      const XLATensor& index, const XLATensor& source);
+XlaValue IndexAdd(const XLATensor& base, int64_t dim, const XLATensor& index,
+                  const XLATensor& source);
 
-ir::XlaValue IndexCopy(const XLATensor& base, int64_t dim,
-                       const XLATensor& index, const XLATensor& source);
+XlaValue IndexCopy(const XLATensor& base, int64_t dim, const XLATensor& index,
+                   const XLATensor& source);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/index_put.cpp
+++ b/torch_xla/csrc/ops/index_put.cpp
@@ -4,12 +4,9 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
-IndexPut::IndexPut(const ir::XlaValue& base, const ir::XlaValue& indices,
-                   int64_t start_dim, const ir::XlaValue& values,
-                   bool accumulate)
+IndexPut::IndexPut(const XlaValue& base, const XlaValue& indices,
+                   int64_t start_dim, const XlaValue& values, bool accumulate)
     : XlaNode(torch::lazy::OpKind(at::aten::index_put), {base, indices, values},
               base.xla_shape(),
               /*num_outputs=*/1, torch::lazy::MHash(start_dim, accumulate)),
@@ -24,8 +21,8 @@ std::string IndexPut::ToString() const {
 }
 
 torch::lazy::NodePtr IndexPut::Clone(OpList operands) const {
-  return ir::MakeNode<IndexPut>(operands.at(0), operands.at(1), start_dim_,
-                                operands.at(2), accumulate_);
+  return torch::lazy::MakeNode<IndexPut>(
+      operands.at(0), operands.at(1), start_dim_, operands.at(2), accumulate_);
 }
 
 XlaOpVector IndexPut::Lower(LoweringContext* loctx) const {
@@ -41,6 +38,4 @@ XlaOpVector IndexPut::Lower(LoweringContext* loctx) const {
   return ReturnOp(output, loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/index_put.h
+++ b/torch_xla/csrc/ops/index_put.h
@@ -3,13 +3,11 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class IndexPut : public XlaNode {
  public:
-  IndexPut(const ir::XlaValue& base, const ir::XlaValue& indices,
-           int64_t start_dim, const ir::XlaValue& values, bool accumulate);
+  IndexPut(const XlaValue& base, const XlaValue& indices, int64_t start_dim,
+           const XlaValue& values, bool accumulate);
 
   std::string ToString() const override;
 
@@ -28,6 +26,4 @@ class IndexPut : public XlaNode {
   bool accumulate_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/index_select.cpp
+++ b/torch_xla/csrc/ops/index_select.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& index,
@@ -30,7 +28,8 @@ IndexSelect::IndexSelect(const XlaValue& input, int64_t dim,
       dim_(dim) {}
 
 torch::lazy::NodePtr IndexSelect::Clone(OpList operands) const {
-  return ir::MakeNode<IndexSelect>(operands.at(0), dim_, operands.at(1));
+  return torch::lazy::MakeNode<IndexSelect>(operands.at(0), dim_,
+                                            operands.at(1));
 }
 
 XlaOpVector IndexSelect::Lower(LoweringContext* loctx) const {
@@ -45,6 +44,4 @@ std::string IndexSelect::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/index_select.h
+++ b/torch_xla/csrc/ops/index_select.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class IndexSelect : public XlaNode {
  public:
@@ -22,6 +20,4 @@ class IndexSelect : public XlaNode {
   int64_t dim_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/infer_output_shape.cpp
+++ b/torch_xla/csrc/ops/infer_output_shape.cpp
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/helpers.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 xla::Shape InferOutputShape(absl::Span<const xla::Shape> input_shapes,
                             const LowerForShapeFn& core_lowering_fn) {
@@ -20,6 +18,4 @@ xla::Shape InferOutputShape(absl::Span<const xla::Shape> input_shapes,
   return XlaHelpers::ShapeOfXlaOp(result);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/infer_output_shape.h
+++ b/torch_xla/csrc/ops/infer_output_shape.h
@@ -4,8 +4,6 @@
 #include "tensorflow/compiler/xla/client/xla_builder.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 using LowerForShapeFn =
     std::function<xla::XlaOp(absl::Span<const xla::XlaOp> operands)>;
@@ -14,6 +12,4 @@ using LowerForShapeFn =
 xla::Shape InferOutputShape(absl::Span<const xla::Shape> input_shapes,
                             const LowerForShapeFn& core_lowering_fn);
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/kth_value.cpp
+++ b/torch_xla/csrc/ops/kth_value.cpp
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input, int64_t k, int64_t dim,
@@ -30,7 +28,7 @@ KthValue::KthValue(const XlaValue& input, int64_t k, int64_t dim, bool keepdim)
       keepdim_(keepdim) {}
 
 torch::lazy::NodePtr KthValue::Clone(OpList operands) const {
-  return ir::MakeNode<KthValue>(operands.at(0), k_, dim_, keepdim_);
+  return torch::lazy::MakeNode<KthValue>(operands.at(0), k_, dim_, keepdim_);
 }
 
 XlaOpVector KthValue::Lower(LoweringContext* loctx) const {
@@ -45,6 +43,4 @@ std::string KthValue::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/kth_value.h
+++ b/torch_xla/csrc/ops/kth_value.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class KthValue : public XlaNode {
  public:
@@ -28,6 +26,4 @@ class KthValue : public XlaNode {
   bool keepdim_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/l1_loss.cpp
+++ b/torch_xla/csrc/ops/l1_loss.cpp
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& target,
@@ -32,7 +30,8 @@ L1Loss::L1Loss(const XlaValue& input, const XlaValue& target,
       reduction_(reduction) {}
 
 torch::lazy::NodePtr L1Loss::Clone(OpList operands) const {
-  return ir::MakeNode<L1Loss>(operands.at(0), operands.at(1), reduction_);
+  return torch::lazy::MakeNode<L1Loss>(operands.at(0), operands.at(1),
+                                       reduction_);
 }
 
 XlaOpVector L1Loss::Lower(LoweringContext* loctx) const {
@@ -48,6 +47,4 @@ std::string L1Loss::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/l1_loss.h
+++ b/torch_xla/csrc/ops/l1_loss.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/reduction.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class L1Loss : public XlaNode {
  public:
@@ -25,6 +23,4 @@ class L1Loss : public XlaNode {
   ReductionMode reduction_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/l1_loss_backward.cpp
+++ b/torch_xla/csrc/ops/l1_loss_backward.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& input,
@@ -37,8 +35,8 @@ L1LossBackward::L1LossBackward(const XlaValue& grad_output,
       reduction_(reduction) {}
 
 torch::lazy::NodePtr L1LossBackward::Clone(OpList operands) const {
-  return ir::MakeNode<L1LossBackward>(operands.at(0), operands.at(1),
-                                      operands.at(2), reduction_);
+  return torch::lazy::MakeNode<L1LossBackward>(operands.at(0), operands.at(1),
+                                               operands.at(2), reduction_);
 }
 
 XlaOpVector L1LossBackward::Lower(LoweringContext* loctx) const {
@@ -56,6 +54,4 @@ std::string L1LossBackward::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/l1_loss_backward.h
+++ b/torch_xla/csrc/ops/l1_loss_backward.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/reduction.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class L1LossBackward : public XlaNode {
  public:
@@ -25,6 +23,4 @@ class L1LossBackward : public XlaNode {
   ReductionMode reduction_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/leaky_relu.cpp
+++ b/torch_xla/csrc/ops/leaky_relu.cpp
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/lowering_context.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 LeakyRelu::LeakyRelu(const XlaValue& input, double negative_slope)
     : XlaNode(torch::lazy::OpKind(at::aten::leaky_relu), {input},
@@ -14,7 +12,7 @@ LeakyRelu::LeakyRelu(const XlaValue& input, double negative_slope)
       negative_slope_(negative_slope) {}
 
 torch::lazy::NodePtr LeakyRelu::Clone(OpList operands) const {
-  return ir::MakeNode<LeakyRelu>(operands.at(0), negative_slope_);
+  return torch::lazy::MakeNode<LeakyRelu>(operands.at(0), negative_slope_);
 }
 
 XlaOpVector LeakyRelu::Lower(LoweringContext* loctx) const {
@@ -29,6 +27,4 @@ std::string LeakyRelu::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/leaky_relu.h
+++ b/torch_xla/csrc/ops/leaky_relu.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class LeakyRelu : public XlaNode {
  public:
@@ -24,6 +22,4 @@ class LeakyRelu : public XlaNode {
   double negative_slope_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/leaky_relu_backward.cpp
+++ b/torch_xla/csrc/ops/leaky_relu_backward.cpp
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/lowering_context.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 LeakyReluBackward::LeakyReluBackward(const XlaValue& grad_output,
                                      const XlaValue& input,
@@ -16,8 +14,8 @@ LeakyReluBackward::LeakyReluBackward(const XlaValue& grad_output,
       negative_slope_(negative_slope) {}
 
 torch::lazy::NodePtr LeakyReluBackward::Clone(OpList operands) const {
-  return ir::MakeNode<LeakyReluBackward>(operands.at(0), operands.at(1),
-                                         negative_slope_);
+  return torch::lazy::MakeNode<LeakyReluBackward>(
+      operands.at(0), operands.at(1), negative_slope_);
 }
 
 XlaOpVector LeakyReluBackward::Lower(LoweringContext* loctx) const {
@@ -34,6 +32,4 @@ std::string LeakyReluBackward::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/leaky_relu_backward.h
+++ b/torch_xla/csrc/ops/leaky_relu_backward.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class LeakyReluBackward : public XlaNode {
  public:
@@ -25,6 +23,4 @@ class LeakyReluBackward : public XlaNode {
   double negative_slope_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/linear_interpolation.cpp
+++ b/torch_xla/csrc/ops/linear_interpolation.cpp
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ops/xla_ops.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 LinearInterpolation::LinearInterpolation(const XlaValue& value,
                                          const XlaValue& new_value,
@@ -16,8 +14,8 @@ LinearInterpolation::LinearInterpolation(const XlaValue& value,
       alpha_(alpha) {}
 
 torch::lazy::NodePtr LinearInterpolation::Clone(OpList operands) const {
-  return ir::MakeNode<LinearInterpolation>(operands.at(0), operands.at(1),
-                                           alpha_);
+  return torch::lazy::MakeNode<LinearInterpolation>(operands.at(0),
+                                                    operands.at(1), alpha_);
 }
 
 XlaOpVector LinearInterpolation::Lower(LoweringContext* loctx) const {
@@ -33,6 +31,4 @@ std::string LinearInterpolation::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/linear_interpolation.h
+++ b/torch_xla/csrc/ops/linear_interpolation.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class LinearInterpolation : public XlaNode {
  public:
@@ -23,6 +21,4 @@ class LinearInterpolation : public XlaNode {
   double alpha_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/linspace.cpp
+++ b/torch_xla/csrc/ops/linspace.cpp
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Linspace::Linspace(const XlaValue& start, const XlaValue& end, int64_t steps)
     : XlaNode(torch::lazy::OpKind(at::aten::linspace), {start, end},
@@ -20,7 +18,8 @@ Linspace::Linspace(const XlaValue& start, const XlaValue& end, int64_t steps)
       steps_(steps) {}
 
 torch::lazy::NodePtr Linspace::Clone(OpList operands) const {
-  return ir::MakeNode<Linspace>(operands.at(0), operands.at(1), steps_);
+  return torch::lazy::MakeNode<Linspace>(operands.at(0), operands.at(1),
+                                         steps_);
 }
 
 XlaOpVector Linspace::Lower(LoweringContext* loctx) const {
@@ -35,6 +34,4 @@ std::string Linspace::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/linspace.h
+++ b/torch_xla/csrc/ops/linspace.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Linspace : public XlaNode {
  public:
@@ -22,6 +20,4 @@ class Linspace : public XlaNode {
   int64_t steps_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/log_softmax.cpp
+++ b/torch_xla/csrc/ops/log_softmax.cpp
@@ -8,8 +8,6 @@
 #include "torch_xla/csrc/torch_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::XlaOp LowerLogSoftmax(xla::XlaOp input, int64_t dim,
@@ -39,7 +37,7 @@ LogSoftmax::LogSoftmax(const XlaValue& input, int64_t dim,
       dtype_(dtype) {}
 
 torch::lazy::NodePtr LogSoftmax::Clone(OpList operands) const {
-  return ir::MakeNode<LogSoftmax>(operands.at(0), dim_, dtype_);
+  return torch::lazy::MakeNode<LogSoftmax>(operands.at(0), dim_, dtype_);
 }
 
 XlaOpVector LogSoftmax::Lower(LoweringContext* loctx) const {
@@ -54,6 +52,4 @@ std::string LogSoftmax::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/log_softmax.h
+++ b/torch_xla/csrc/ops/log_softmax.h
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 // IR node for log(softmax) operation.
 class LogSoftmax : public XlaNode {
@@ -31,6 +29,4 @@ class LogSoftmax : public XlaNode {
   c10::optional<at::ScalarType> dtype_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/log_softmax_backward.cpp
+++ b/torch_xla/csrc/ops/log_softmax_backward.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/softmax_builder.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 LogSoftmaxBackward::LogSoftmaxBackward(const XlaValue& grad_output,
                                        const XlaValue& output, int64_t dim)
@@ -17,7 +15,8 @@ LogSoftmaxBackward::LogSoftmaxBackward(const XlaValue& grad_output,
       dim_(dim) {}
 
 torch::lazy::NodePtr LogSoftmaxBackward::Clone(OpList operands) const {
-  return ir::MakeNode<LogSoftmaxBackward>(operands.at(0), operands.at(1), dim_);
+  return torch::lazy::MakeNode<LogSoftmaxBackward>(operands.at(0),
+                                                   operands.at(1), dim_);
 }
 
 XlaOpVector LogSoftmaxBackward::Lower(LoweringContext* loctx) const {
@@ -34,6 +33,4 @@ std::string LogSoftmaxBackward::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/log_softmax_backward.h
+++ b/torch_xla/csrc/ops/log_softmax_backward.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class LogSoftmaxBackward : public XlaNode {
  public:
@@ -24,6 +22,4 @@ class LogSoftmaxBackward : public XlaNode {
   int64_t dim_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/logsumexp.cpp
+++ b/torch_xla/csrc/ops/logsumexp.cpp
@@ -9,8 +9,6 @@
 #include "torch_xla/csrc/torch_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input,
@@ -38,8 +36,8 @@ Logsumexp::Logsumexp(const XlaValue& input, std::vector<int64_t> dimensions,
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
 torch::lazy::NodePtr Logsumexp::Clone(OpList operands) const {
-  return ir::MakeNode<Logsumexp>(operands.at(0), dimensions_,
-                                 keep_reduced_dimensions_);
+  return torch::lazy::MakeNode<Logsumexp>(operands.at(0), dimensions_,
+                                          keep_reduced_dimensions_);
 }
 
 XlaOpVector Logsumexp::Lower(LoweringContext* loctx) const {
@@ -56,6 +54,4 @@ std::string Logsumexp::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/logsumexp.h
+++ b/torch_xla/csrc/ops/logsumexp.h
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Logsumexp : public XlaNode {
  public:
@@ -30,6 +28,4 @@ class Logsumexp : public XlaNode {
   bool keep_reduced_dimensions_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/masked_fill.cpp
+++ b/torch_xla/csrc/ops/masked_fill.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ops/scalar.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 MaskedFill::MaskedFill(const XlaValue& input, const XlaValue& mask,
                        const at::Scalar& value)
@@ -17,7 +15,8 @@ MaskedFill::MaskedFill(const XlaValue& input, const XlaValue& mask,
       value_(std::move(value)) {}
 
 torch::lazy::NodePtr MaskedFill::Clone(OpList operands) const {
-  return ir::MakeNode<MaskedFill>(operands.at(0), operands.at(1), value_);
+  return torch::lazy::MakeNode<MaskedFill>(operands.at(0), operands.at(1),
+                                           value_);
 }
 
 XlaOpVector MaskedFill::Lower(LoweringContext* loctx) const {
@@ -40,6 +39,4 @@ std::string MaskedFill::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/masked_fill.h
+++ b/torch_xla/csrc/ops/masked_fill.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class MaskedFill : public XlaNode {
  public:
@@ -25,6 +23,4 @@ class MaskedFill : public XlaNode {
   at::Scalar value_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/masked_scatter.cpp
+++ b/torch_xla/csrc/ops/masked_scatter.cpp
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 MaskedScatter::MaskedScatter(const XlaValue& input, const XlaValue& mask,
                              const XlaValue& source)
@@ -14,8 +12,8 @@ MaskedScatter::MaskedScatter(const XlaValue& input, const XlaValue& mask,
               /*num_outputs=*/1) {}
 
 torch::lazy::NodePtr MaskedScatter::Clone(OpList operands) const {
-  return ir::MakeNode<MaskedScatter>(operands.at(0), operands.at(1),
-                                     operands.at(2));
+  return torch::lazy::MakeNode<MaskedScatter>(operands.at(0), operands.at(1),
+                                              operands.at(2));
 }
 
 XlaOpVector MaskedScatter::Lower(LoweringContext* loctx) const {
@@ -25,6 +23,4 @@ XlaOpVector MaskedScatter::Lower(LoweringContext* loctx) const {
   return ReturnOp(BuildMaskedScatter(input, mask, source), loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/masked_scatter.h
+++ b/torch_xla/csrc/ops/masked_scatter.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 // This node has no metadata, so it could have been implemented as generic-op in
 // ops.cpp, but since this might require special handling from upper IR layers,
@@ -19,6 +17,4 @@ class MaskedScatter : public XlaNode {
   XlaOpVector Lower(LoweringContext* loctx) const override;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/masked_select.cpp
+++ b/torch_xla/csrc/ops/masked_select.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input) {
@@ -29,7 +27,7 @@ MaskedSelect::MaskedSelect(const XlaValue& input, const XlaValue& mask)
               /*num_outputs=*/2) {}
 
 torch::lazy::NodePtr MaskedSelect::Clone(OpList operands) const {
-  return ir::MakeNode<MaskedSelect>(operands.at(0), operands.at(1));
+  return torch::lazy::MakeNode<MaskedSelect>(operands.at(0), operands.at(1));
 }
 
 XlaOpVector MaskedSelect::Lower(LoweringContext* loctx) const {
@@ -38,6 +36,4 @@ XlaOpVector MaskedSelect::Lower(LoweringContext* loctx) const {
   return ReturnOps(BuildMaskedSelect(input, mask), loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/masked_select.h
+++ b/torch_xla/csrc/ops/masked_select.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 // This node has no metadata, so it could have been implemented as generic-op in
 // ops.cpp, but since this might require special handling from upper IR layers,
@@ -18,6 +16,4 @@ class MaskedSelect : public XlaNode {
   XlaOpVector Lower(LoweringContext* loctx) const override;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/max_in_dim.cpp
+++ b/torch_xla/csrc/ops/max_in_dim.cpp
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/reduction.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input, int64_t dim, bool keepdim) {
@@ -29,7 +27,7 @@ MaxInDim::MaxInDim(const XlaValue& input, int64_t dim, bool keepdim)
       keepdim_(keepdim) {}
 
 torch::lazy::NodePtr MaxInDim::Clone(OpList operands) const {
-  return ir::MakeNode<MaxInDim>(operands.at(0), dim_, keepdim_);
+  return torch::lazy::MakeNode<MaxInDim>(operands.at(0), dim_, keepdim_);
 }
 
 XlaOpVector MaxInDim::Lower(LoweringContext* loctx) const {
@@ -45,6 +43,4 @@ std::string MaxInDim::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/max_in_dim.h
+++ b/torch_xla/csrc/ops/max_in_dim.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class MaxInDim : public XlaNode {
  public:
@@ -25,6 +23,4 @@ class MaxInDim : public XlaNode {
   bool keepdim_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/max_pool_nd.cpp
+++ b/torch_xla/csrc/ops/max_pool_nd.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/pooling.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input, int64_t spatial_dim_count,
@@ -58,8 +56,9 @@ MaxPoolNd::MaxPoolNd(const XlaValue& input, int64_t spatial_dim_count,
       ceil_mode_(ceil_mode) {}
 
 torch::lazy::NodePtr MaxPoolNd::Clone(OpList operands) const {
-  return ir::MakeNode<MaxPoolNd>(operands.at(0), spatial_dim_count_,
-                                 kernel_size_, stride_, padding_, ceil_mode_);
+  return torch::lazy::MakeNode<MaxPoolNd>(operands.at(0), spatial_dim_count_,
+                                          kernel_size_, stride_, padding_,
+                                          ceil_mode_);
 }
 
 XlaOpVector MaxPoolNd::Lower(LoweringContext* loctx) const {
@@ -78,6 +77,4 @@ std::string MaxPoolNd::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/max_pool_nd.h
+++ b/torch_xla/csrc/ops/max_pool_nd.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class MaxPoolNd : public XlaNode {
  public:
@@ -38,6 +36,4 @@ class MaxPoolNd : public XlaNode {
   bool ceil_mode_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/max_pool_nd_backward.cpp
+++ b/torch_xla/csrc/ops/max_pool_nd_backward.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/pooling.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& input,
@@ -60,9 +58,9 @@ MaxPoolNdBackward::MaxPoolNdBackward(
       ceil_mode_(ceil_mode) {}
 
 torch::lazy::NodePtr MaxPoolNdBackward::Clone(OpList operands) const {
-  return ir::MakeNode<MaxPoolNdBackward>(operands.at(0), operands.at(1),
-                                         spatial_dim_count_, kernel_size_,
-                                         stride_, padding_, ceil_mode_);
+  return torch::lazy::MakeNode<MaxPoolNdBackward>(
+      operands.at(0), operands.at(1), spatial_dim_count_, kernel_size_, stride_,
+      padding_, ceil_mode_);
 }
 
 XlaOpVector MaxPoolNdBackward::Lower(LoweringContext* loctx) const {
@@ -83,6 +81,4 @@ std::string MaxPoolNdBackward::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/max_pool_nd_backward.h
+++ b/torch_xla/csrc/ops/max_pool_nd_backward.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class MaxPoolNdBackward : public XlaNode {
  public:
@@ -37,6 +35,4 @@ class MaxPoolNdBackward : public XlaNode {
   bool ceil_mode_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/max_unpool_nd.cpp
+++ b/torch_xla/csrc/ops/max_unpool_nd.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/pooling.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& indices,
@@ -42,8 +40,8 @@ MaxUnpoolNd::MaxUnpoolNd(const XlaValue& input, const XlaValue& indices,
       output_size_(std::move(output_size)) {}
 
 torch::lazy::NodePtr MaxUnpoolNd::Clone(OpList operands) const {
-  return ir::MakeNode<MaxUnpoolNd>(operands.at(0), operands.at(1),
-                                   output_size_);
+  return torch::lazy::MakeNode<MaxUnpoolNd>(operands.at(0), operands.at(1),
+                                            output_size_);
 }
 
 XlaOpVector MaxUnpoolNd::Lower(LoweringContext* loctx) const {
@@ -61,6 +59,4 @@ std::string MaxUnpoolNd::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/max_unpool_nd.h
+++ b/torch_xla/csrc/ops/max_unpool_nd.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class MaxUnpoolNd : public XlaNode {
  public:
@@ -23,6 +21,4 @@ class MaxUnpoolNd : public XlaNode {
   std::vector<int64_t> output_size_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/max_unpool_nd_backward.cpp
+++ b/torch_xla/csrc/ops/max_unpool_nd_backward.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/pooling.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& input,
@@ -50,8 +48,8 @@ MaxUnpoolNdBackward::MaxUnpoolNdBackward(const XlaValue& grad_output,
       output_size_(std::move(output_size)) {}
 
 torch::lazy::NodePtr MaxUnpoolNdBackward::Clone(OpList operands) const {
-  return ir::MakeNode<MaxUnpoolNdBackward>(operands.at(0), operands.at(1),
-                                           operands.at(2), output_size_);
+  return torch::lazy::MakeNode<MaxUnpoolNdBackward>(
+      operands.at(0), operands.at(1), operands.at(2), output_size_);
 }
 
 XlaOpVector MaxUnpoolNdBackward::Lower(LoweringContext* loctx) const {
@@ -70,6 +68,4 @@ std::string MaxUnpoolNdBackward::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/max_unpool_nd_backward.h
+++ b/torch_xla/csrc/ops/max_unpool_nd_backward.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class MaxUnpoolNdBackward : public XlaNode {
  public:
@@ -24,6 +22,4 @@ class MaxUnpoolNdBackward : public XlaNode {
   std::vector<int64_t> output_size_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/mean.cpp
+++ b/torch_xla/csrc/ops/mean.cpp
@@ -10,8 +10,6 @@
 #include "torch_xla/csrc/torch_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::XlaOp LowerMean(xla::XlaOp input, const std::vector<int64_t>& dimensions,
@@ -51,8 +49,8 @@ Mean::Mean(const XlaValue& input, std::vector<int64_t> dimensions,
       dtype_(dtype) {}
 
 torch::lazy::NodePtr Mean::Clone(OpList operands) const {
-  return ir::MakeNode<Mean>(operands.at(0), dimensions_,
-                            keep_reduced_dimensions_, dtype_);
+  return torch::lazy::MakeNode<Mean>(operands.at(0), dimensions_,
+                                     keep_reduced_dimensions_, dtype_);
 }
 
 XlaOpVector Mean::Lower(LoweringContext* loctx) const {
@@ -70,6 +68,4 @@ std::string Mean::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/mean.h
+++ b/torch_xla/csrc/ops/mean.h
@@ -9,8 +9,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Mean : public XlaNode {
  public:
@@ -35,6 +33,4 @@ class Mean : public XlaNode {
   c10::optional<at::ScalarType> dtype_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/min_in_dim.cpp
+++ b/torch_xla/csrc/ops/min_in_dim.cpp
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/reduction.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input, int64_t dim, bool keepdim) {
@@ -29,7 +27,7 @@ MinInDim::MinInDim(const XlaValue& input, int64_t dim, bool keepdim)
       keepdim_(keepdim) {}
 
 torch::lazy::NodePtr MinInDim::Clone(OpList operands) const {
-  return ir::MakeNode<MinInDim>(operands.at(0), dim_, keepdim_);
+  return torch::lazy::MakeNode<MinInDim>(operands.at(0), dim_, keepdim_);
 }
 
 XlaOpVector MinInDim::Lower(LoweringContext* loctx) const {
@@ -45,6 +43,4 @@ std::string MinInDim::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/min_in_dim.h
+++ b/torch_xla/csrc/ops/min_in_dim.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class MinInDim : public XlaNode {
  public:
@@ -25,6 +23,4 @@ class MinInDim : public XlaNode {
   bool keepdim_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/mse_loss.cpp
+++ b/torch_xla/csrc/ops/mse_loss.cpp
@@ -9,8 +9,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& target,
@@ -34,7 +32,8 @@ MseLoss::MseLoss(const XlaValue& input, const XlaValue& target,
       reduction_(reduction) {}
 
 torch::lazy::NodePtr MseLoss::Clone(OpList operands) const {
-  return ir::MakeNode<MseLoss>(operands.at(0), operands.at(1), reduction_);
+  return torch::lazy::MakeNode<MseLoss>(operands.at(0), operands.at(1),
+                                        reduction_);
 }
 
 XlaOpVector MseLoss::Lower(LoweringContext* loctx) const {
@@ -50,6 +49,4 @@ std::string MseLoss::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/mse_loss.h
+++ b/torch_xla/csrc/ops/mse_loss.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/reduction.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class MseLoss : public XlaNode {
  public:
@@ -25,6 +23,4 @@ class MseLoss : public XlaNode {
   ReductionMode reduction_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/mse_loss_backward.cpp
+++ b/torch_xla/csrc/ops/mse_loss_backward.cpp
@@ -8,8 +8,6 @@
 #include "torch_xla/csrc/reduction.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& input,
@@ -39,8 +37,8 @@ MseLossBackward::MseLossBackward(const XlaValue& grad_output,
       reduction_(reduction) {}
 
 torch::lazy::NodePtr MseLossBackward::Clone(OpList operands) const {
-  return ir::MakeNode<MseLossBackward>(operands.at(0), operands.at(1),
-                                       operands.at(2), reduction_);
+  return torch::lazy::MakeNode<MseLossBackward>(operands.at(0), operands.at(1),
+                                                operands.at(2), reduction_);
 }
 
 XlaOpVector MseLossBackward::Lower(LoweringContext* loctx) const {
@@ -58,6 +56,4 @@ std::string MseLossBackward::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/mse_loss_backward.h
+++ b/torch_xla/csrc/ops/mse_loss_backward.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/reduction.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class MseLossBackward : public XlaNode {
  public:
@@ -25,6 +23,4 @@ class MseLossBackward : public XlaNode {
   ReductionMode reduction_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/native_batch_norm_backward.cpp
+++ b/torch_xla/csrc/ops/native_batch_norm_backward.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& grad_out, const XlaValue& input,
@@ -47,9 +45,9 @@ NativeBatchNormBackward::NativeBatchNormBackward(const XlaValue& grad_out,
       eps_(eps) {}
 
 torch::lazy::NodePtr NativeBatchNormBackward::Clone(OpList operands) const {
-  return ir::MakeNode<NativeBatchNormBackward>(operands.at(0), operands.at(1),
-                                               operands.at(2), operands.at(3),
-                                               operands.at(4), training_, eps_);
+  return torch::lazy::MakeNode<NativeBatchNormBackward>(
+      operands.at(0), operands.at(1), operands.at(2), operands.at(3),
+      operands.at(4), training_, eps_);
 }
 
 XlaOpVector NativeBatchNormBackward::Lower(LoweringContext* loctx) const {
@@ -71,6 +69,4 @@ std::string NativeBatchNormBackward::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/native_batch_norm_backward.h
+++ b/torch_xla/csrc/ops/native_batch_norm_backward.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 // XlaNode for the backward batch norm operator.
 class NativeBatchNormBackward : public XlaNode {
@@ -29,6 +27,4 @@ class NativeBatchNormBackward : public XlaNode {
   double eps_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/native_batch_norm_forward.cpp
+++ b/torch_xla/csrc/ops/native_batch_norm_forward.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 std::vector<xla::XlaOp> LowerBatchNorm(xla::XlaOp input, xla::XlaOp weight,
@@ -68,9 +66,9 @@ NativeBatchNormForward::NativeBatchNormForward(const XlaValue& input,
       eps_(eps) {}
 
 torch::lazy::NodePtr NativeBatchNormForward::Clone(OpList operands) const {
-  return ir::MakeNode<NativeBatchNormForward>(operands.at(0), operands.at(1),
-                                              operands.at(2), operands.at(3),
-                                              operands.at(4), training_, eps_);
+  return torch::lazy::MakeNode<NativeBatchNormForward>(
+      operands.at(0), operands.at(1), operands.at(2), operands.at(3),
+      operands.at(4), training_, eps_);
 }
 
 XlaOpVector NativeBatchNormForward::Lower(LoweringContext* loctx) const {
@@ -91,6 +89,4 @@ std::string NativeBatchNormForward::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/native_batch_norm_forward.h
+++ b/torch_xla/csrc/ops/native_batch_norm_forward.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class NativeBatchNormForward : public XlaNode {
  public:
@@ -28,6 +26,4 @@ class NativeBatchNormForward : public XlaNode {
   double eps_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/nll_loss.cpp
+++ b/torch_xla/csrc/ops/nll_loss.cpp
@@ -8,8 +8,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& logits, const XlaValue& labels,
@@ -54,8 +52,8 @@ torch::lazy::NodePtr NllLoss::Clone(OpList operands) const {
   if (operands.size() > 2) {
     weight = operands.at(2);
   }
-  return ir::MakeNode<NllLoss>(operands.at(0), operands.at(1), weight,
-                               reduction_, ignore_index_);
+  return torch::lazy::MakeNode<NllLoss>(operands.at(0), operands.at(1), weight,
+                                        reduction_, ignore_index_);
 }
 
 XlaOpVector NllLoss::Lower(LoweringContext* loctx) const {
@@ -77,6 +75,4 @@ std::string NllLoss::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/nll_loss.h
+++ b/torch_xla/csrc/ops/nll_loss.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/reduction.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class NllLoss : public XlaNode {
  public:
@@ -29,6 +27,4 @@ class NllLoss : public XlaNode {
   int ignore_index_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/nll_loss2d.cpp
+++ b/torch_xla/csrc/ops/nll_loss2d.cpp
@@ -8,8 +8,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& logits, const XlaValue& labels,
@@ -54,8 +52,8 @@ torch::lazy::NodePtr NllLoss2d::Clone(OpList operands) const {
   if (operands.size() > 2) {
     weight = operands.at(2);
   }
-  return ir::MakeNode<NllLoss2d>(operands.at(0), operands.at(1), weight,
-                                 reduction_, ignore_index_);
+  return torch::lazy::MakeNode<NllLoss2d>(operands.at(0), operands.at(1),
+                                          weight, reduction_, ignore_index_);
 }
 
 XlaOpVector NllLoss2d::Lower(LoweringContext* loctx) const {
@@ -77,6 +75,4 @@ std::string NllLoss2d::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/nll_loss2d.h
+++ b/torch_xla/csrc/ops/nll_loss2d.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/reduction.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class NllLoss2d : public XlaNode {
  public:
@@ -29,6 +27,4 @@ class NllLoss2d : public XlaNode {
   int ignore_index_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/nll_loss2d_backward.cpp
+++ b/torch_xla/csrc/ops/nll_loss2d_backward.cpp
@@ -8,8 +8,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& logits,
@@ -65,9 +63,9 @@ torch::lazy::NodePtr NllLoss2dBackward::Clone(OpList operands) const {
     weight = operands.at(3);
     total_weight = operands.at(4);
   }
-  return ir::MakeNode<NllLoss2dBackward>(operands.at(0), operands.at(1),
-                                         operands.at(2), weight, total_weight,
-                                         reduction_, ignore_index_);
+  return torch::lazy::MakeNode<NllLoss2dBackward>(
+      operands.at(0), operands.at(1), operands.at(2), weight, total_weight,
+      reduction_, ignore_index_);
 }
 
 XlaOpVector NllLoss2dBackward::Lower(LoweringContext* loctx) const {
@@ -93,6 +91,4 @@ std::string NllLoss2dBackward::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/nll_loss2d_backward.h
+++ b/torch_xla/csrc/ops/nll_loss2d_backward.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/reduction.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class NllLoss2dBackward : public XlaNode {
  public:
@@ -31,6 +29,4 @@ class NllLoss2dBackward : public XlaNode {
   int ignore_index_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/nll_loss_backward.cpp
+++ b/torch_xla/csrc/ops/nll_loss_backward.cpp
@@ -8,8 +8,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& logits,
@@ -65,9 +63,9 @@ torch::lazy::NodePtr NllLossBackward::Clone(OpList operands) const {
     weight = operands.at(3);
     total_weight = operands.at(4);
   }
-  return ir::MakeNode<NllLossBackward>(operands.at(0), operands.at(1),
-                                       operands.at(2), weight, total_weight,
-                                       reduction_, ignore_index_);
+  return torch::lazy::MakeNode<NllLossBackward>(
+      operands.at(0), operands.at(1), operands.at(2), weight, total_weight,
+      reduction_, ignore_index_);
 }
 
 XlaOpVector NllLossBackward::Lower(LoweringContext* loctx) const {
@@ -93,6 +91,4 @@ std::string NllLossBackward::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/nll_loss_backward.h
+++ b/torch_xla/csrc/ops/nll_loss_backward.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/reduction.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class NllLossBackward : public XlaNode {
  public:
@@ -31,6 +29,4 @@ class NllLossBackward : public XlaNode {
   int ignore_index_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/nms.cpp
+++ b/torch_xla/csrc/ops/nms.cpp
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/ops/xla_ops.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& boxes, const XlaValue& scores,
@@ -40,8 +38,9 @@ Nms::Nms(const XlaValue& boxes, const XlaValue& scores,
       output_size_(output_size) {}
 
 torch::lazy::NodePtr Nms::Clone(OpList operands) const {
-  return ir::MakeNode<Nms>(operands.at(0), operands.at(1), operands.at(2),
-                           operands.at(3), output_size_);
+  return torch::lazy::MakeNode<Nms>(operands.at(0), operands.at(1),
+                                    operands.at(2), operands.at(3),
+                                    output_size_);
 }
 
 XlaOpVector Nms::Lower(LoweringContext* loctx) const {
@@ -60,6 +59,4 @@ std::string Nms::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/nms.h
+++ b/torch_xla/csrc/ops/nms.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Nms : public XlaNode {
  public:
@@ -24,6 +22,4 @@ class Nms : public XlaNode {
   int64_t output_size_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/nonzero.cpp
+++ b/torch_xla/csrc/ops/nonzero.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input) {
@@ -29,7 +27,7 @@ NonZero::NonZero(const XlaValue& input)
               /*num_outputs=*/2) {}
 
 torch::lazy::NodePtr NonZero::Clone(OpList operands) const {
-  return ir::MakeNode<NonZero>(operands.at(0));
+  return torch::lazy::MakeNode<NonZero>(operands.at(0));
 }
 
 XlaOpVector NonZero::Lower(LoweringContext* loctx) const {
@@ -37,6 +35,4 @@ XlaOpVector NonZero::Lower(LoweringContext* loctx) const {
   return ReturnOps(BuildNonZero(input), loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/nonzero.h
+++ b/torch_xla/csrc/ops/nonzero.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 // This node has no metadata, so it could have been implemented as generic-op in
 // ops.cpp, but since this might require special handling from upper IR layers,
@@ -18,6 +16,4 @@ class NonZero : public XlaNode {
   XlaOpVector Lower(LoweringContext* loctx) const override;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/normal.cpp
+++ b/torch_xla/csrc/ops/normal.cpp
@@ -5,15 +5,14 @@
 #include "torch_xla/csrc/random.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Normal::Normal(const XlaValue& mean, const XlaValue& std, const XlaValue& seed)
     : XlaNode(torch::lazy::OpKind(at::aten::normal), {mean, std, seed},
               mean.xla_shape()) {}
 
 torch::lazy::NodePtr Normal::Clone(OpList operands) const {
-  return ir::MakeNode<Normal>(operands.at(0), operands.at(1), operands.at(2));
+  return torch::lazy::MakeNode<Normal>(operands.at(0), operands.at(1),
+                                       operands.at(2));
 }
 
 XlaOpVector Normal::Lower(LoweringContext* loctx) const {
@@ -24,6 +23,4 @@ XlaOpVector Normal::Lower(LoweringContext* loctx) const {
       RngNormal(rng_seed, XlaHelpers::ShapeOfXlaOp(mean), mean, std), loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/normal.h
+++ b/torch_xla/csrc/ops/normal.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Normal : public XlaNode {
  public:
@@ -15,6 +13,4 @@ class Normal : public XlaNode {
   XlaOpVector Lower(LoweringContext* loctx) const override;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/not_supported.cpp
+++ b/torch_xla/csrc/ops/not_supported.cpp
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ops/xla_ops.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 NotSupported::NotSupported(std::string description, xla::Shape shape)
     : XlaNode(xla_not_supported, std::move(shape), /*num_outputs=*/1,
@@ -14,7 +12,7 @@ NotSupported::NotSupported(std::string description, xla::Shape shape)
       description_(std::move(description)) {}
 
 torch::lazy::NodePtr NotSupported::Clone(OpList operands) const {
-  return ir::MakeNode<NotSupported>(description_, xla_shape());
+  return torch::lazy::MakeNode<NotSupported>(description_, xla_shape());
 }
 
 XlaOpVector NotSupported::Lower(LoweringContext* /* loctx */) const {
@@ -27,6 +25,4 @@ std::string NotSupported::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/not_supported.h
+++ b/torch_xla/csrc/ops/not_supported.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class NotSupported : public XlaNode {
  public:
@@ -24,6 +22,4 @@ class NotSupported : public XlaNode {
   std::string description_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -32,8 +32,6 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 #define PTXLA_UNARY_OP(name, sym, xla_fn)                                  \
   torch::lazy::NodePtr name(const XlaValue& input) {                       \
@@ -320,7 +318,7 @@ torch::lazy::NodePtr SigmoidBackward(const XlaValue& grad_output,
 
 torch::lazy::NodePtr LogSoftmaxBackwardOp(const XlaValue& grad_output,
                                           const XlaValue& output, int64_t dim) {
-  return ir::MakeNode<LogSoftmaxBackward>(
+  return torch::lazy::MakeNode<LogSoftmaxBackward>(
       grad_output, output,
       torch::lazy::GetCanonicalDimensionIndex(dim,
                                               grad_output.xla_shape().rank()));
@@ -328,7 +326,7 @@ torch::lazy::NodePtr LogSoftmaxBackwardOp(const XlaValue& grad_output,
 
 torch::lazy::NodePtr SoftmaxBackwardOp(const XlaValue& grad_output,
                                        const XlaValue& output, int64_t dim) {
-  return ir::MakeNode<SoftmaxBackward>(
+  return torch::lazy::MakeNode<SoftmaxBackward>(
       grad_output, output,
       torch::lazy::GetCanonicalDimensionIndex(dim,
                                               grad_output.xla_shape().rank()));
@@ -625,7 +623,7 @@ torch::lazy::NodePtr ARange(const at::Scalar& start, const at::Scalar& end,
     default:
       XLA_ERROR() << "XLA type not supported: " << type;
   }
-  return ir::MakeNode<Constant>(std::move(values));
+  return torch::lazy::MakeNode<Constant>(std::move(values));
 }
 
 torch::lazy::NodePtr BroadcastTensors(absl::Span<const XlaValue> tensors) {
@@ -664,7 +662,7 @@ torch::lazy::NodePtr Norm(const XlaValue& input,
   if (!p.has_value() || p->toDouble() == 2.0) {
     torch::lazy::NodePtr square = input * input;
     torch::lazy::NodePtr result =
-        ir::MakeNode<Sum>(square, dimensions, keepdim, dtype);
+        torch::lazy::MakeNode<Sum>(square, dimensions, keepdim, dtype);
     return Sqrt(result);
   }
   double norm_value = p->toDouble();
@@ -680,7 +678,7 @@ torch::lazy::NodePtr Norm(const XlaValue& input,
     //   tensor(3.1235)
     //   >>> print(x.abs().sum())
     //   tensor(11.9437)
-    return ir::MakeNode<Sum>(Abs(input), dimensions, keepdim, dtype);
+    return torch::lazy::MakeNode<Sum>(Abs(input), dimensions, keepdim, dtype);
   }
   // Generic sum(x^p)^(1/p) norms.
   torch::lazy::NodePtr norm_exp =
@@ -689,7 +687,7 @@ torch::lazy::NodePtr Norm(const XlaValue& input,
       ScalarOp(1.0 / norm_value, input.xla_shape().element_type());
   torch::lazy::NodePtr exp = Pow(Abs(input), norm_exp);
   torch::lazy::NodePtr result =
-      ir::MakeNode<Sum>(exp, dimensions, keepdim, dtype);
+      torch::lazy::MakeNode<Sum>(exp, dimensions, keepdim, dtype);
   return Pow(result, norm_exp_inv);
 }
 
@@ -1127,6 +1125,4 @@ torch::lazy::NodePtr Softplus(const XlaValue& input, const XlaValue& beta,
                    std::move(lower_fn));
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -11,20 +11,18 @@
 #include "torch_xla/csrc/ops/scalar.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 inline torch::lazy::NodePtr ScalarOp(const at::Scalar& value,
                                      xla::Shape shape) {
-  return ir::MakeNode<Scalar>(value, std::move(shape));
+  return torch::lazy::MakeNode<Scalar>(value, std::move(shape));
 }
 inline torch::lazy::NodePtr ScalarOp(const at::Scalar& value,
                                      xla::PrimitiveType type) {
-  return ir::MakeNode<Scalar>(value, type);
+  return torch::lazy::MakeNode<Scalar>(value, type);
 }
 
 inline torch::lazy::NodePtr ConstantOp(xla::Literal value) {
-  return ir::MakeNode<Constant>(std::move(value));
+  return torch::lazy::MakeNode<Constant>(std::move(value));
 }
 
 inline torch::lazy::NodePtr GenericOp(
@@ -32,9 +30,9 @@ inline torch::lazy::NodePtr GenericOp(
     xla::Shape shape, Generic::LowerFn lower_fn, size_t num_outputs = 1,
     // cast to uint32_t to avoid ambiguous constructor of uint128
     torch::lazy::hash_t hash_seed = (uint32_t)0x5a2d296e9) {
-  return torch_xla::ir::MakeNode<Generic>(std::move(op), operands,
-                                          std::move(shape), std::move(lower_fn),
-                                          num_outputs, hash_seed);
+  return torch::lazy::MakeNode<Generic>(std::move(op), operands,
+                                        std::move(shape), std::move(lower_fn),
+                                        num_outputs, hash_seed);
 }
 
 inline torch::lazy::NodePtr GenericOp(
@@ -43,18 +41,18 @@ inline torch::lazy::NodePtr GenericOp(
     size_t num_outputs = 1,
     // cast to uint32_t to avoid ambiguous constructor of uint128
     torch::lazy::hash_t hash_seed = (uint32_t)0x5a2d296e9) {
-  return torch_xla::ir::MakeNode<Generic>(std::move(op), operands, shape_fn,
-                                          std::move(lower_fn), num_outputs,
-                                          hash_seed);
+  return torch::lazy::MakeNode<Generic>(std::move(op), operands, shape_fn,
+                                        std::move(lower_fn), num_outputs,
+                                        hash_seed);
 }
 
 inline torch::lazy::NodePtr GenericOp(torch::lazy::OpKind op, xla::Shape shape,
                                       Generic::LowerFn lower_fn,
                                       size_t num_outputs,
                                       torch::lazy::hash_t hash_seed) {
-  return torch_xla::ir::MakeNode<Generic>(std::move(op), std::move(shape),
-                                          std::move(lower_fn), num_outputs,
-                                          hash_seed);
+  return torch::lazy::MakeNode<Generic>(std::move(op), std::move(shape),
+                                        std::move(lower_fn), num_outputs,
+                                        hash_seed);
 }
 
 torch::lazy::NodePtr Acos(const XlaValue& input);
@@ -278,6 +276,4 @@ torch::lazy::NodePtr SLogDet(const XlaValue& input);
 torch::lazy::NodePtr Softplus(const XlaValue& input, const XlaValue& beta,
                               const XlaValue& threshold);
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/optimization_barrier.cpp
+++ b/torch_xla/csrc/ops/optimization_barrier.cpp
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const OpList& inputs) {
@@ -27,7 +25,7 @@ OptimizationBarrier::OptimizationBarrier(const OpList& inputs)
               /*num_outputs=*/inputs.size()) {}
 
 torch::lazy::NodePtr OptimizationBarrier::Clone(OpList operands) const {
-  return ir::MakeNode<OptimizationBarrier>(operands);
+  return torch::lazy::MakeNode<OptimizationBarrier>(operands);
 }
 
 XlaOpVector OptimizationBarrier::Lower(LoweringContext* loctx) const {
@@ -45,6 +43,4 @@ XlaOpVector OptimizationBarrier::Lower(LoweringContext* loctx) const {
   return ReturnOps({outputs}, loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/optimization_barrier.h
+++ b/torch_xla/csrc/ops/optimization_barrier.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class OptimizationBarrier : public XlaNode {
  public:
@@ -15,6 +13,4 @@ class OptimizationBarrier : public XlaNode {
   XlaOpVector Lower(LoweringContext* loctx) const override;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/permute.cpp
+++ b/torch_xla/csrc/ops/permute.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input,
@@ -29,7 +27,7 @@ Permute::Permute(const XlaValue& input, std::vector<int64_t> dims)
       dims_(std::move(dims)) {}
 
 torch::lazy::NodePtr Permute::Clone(OpList operands) const {
-  return ir::MakeNode<Permute>(operands.at(0), dims_);
+  return torch::lazy::MakeNode<Permute>(operands.at(0), dims_);
 }
 
 XlaOpVector Permute::Lower(LoweringContext* loctx) const {
@@ -51,6 +49,4 @@ xla::Shape Permute::MakePermuteShape(const xla::Shape& source_shape,
       XlaHelpers::Permute(permutation, source_shape.dimensions()));
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/permute.h
+++ b/torch_xla/csrc/ops/permute.h
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Permute : public XlaNode {
  public:
@@ -27,6 +25,4 @@ class Permute : public XlaNode {
   std::vector<int64_t> dims_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/prod.cpp
+++ b/torch_xla/csrc/ops/prod.cpp
@@ -11,8 +11,6 @@
 #include "torch_xla/csrc/torch_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::XlaOp LowerProd(xla::XlaOp input, const std::vector<int64_t>& dimensions,
@@ -57,8 +55,8 @@ Prod::Prod(const XlaValue& input, std::vector<int64_t> dimensions,
       dtype_(dtype) {}
 
 torch::lazy::NodePtr Prod::Clone(OpList operands) const {
-  return ir::MakeNode<Prod>(operands.at(0), dimensions_,
-                            keep_reduced_dimensions_, dtype_);
+  return torch::lazy::MakeNode<Prod>(operands.at(0), dimensions_,
+                                     keep_reduced_dimensions_, dtype_);
 }
 
 XlaOpVector Prod::Lower(LoweringContext* loctx) const {
@@ -76,6 +74,4 @@ std::string Prod::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/prod.h
+++ b/torch_xla/csrc/ops/prod.h
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Prod : public XlaNode {
  public:
@@ -33,6 +31,4 @@ class Prod : public XlaNode {
   c10::optional<at::ScalarType> dtype_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/put.cpp
+++ b/torch_xla/csrc/ops/put.cpp
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Put::Put(const XlaValue& input, const XlaValue& index, const XlaValue& source,
          bool accumulate)
@@ -15,8 +13,8 @@ Put::Put(const XlaValue& input, const XlaValue& index, const XlaValue& source,
       accumulate_(accumulate) {}
 
 torch::lazy::NodePtr Put::Clone(OpList operands) const {
-  return ir::MakeNode<Put>(operands.at(0), operands.at(1), operands.at(2),
-                           accumulate_);
+  return torch::lazy::MakeNode<Put>(operands.at(0), operands.at(1),
+                                    operands.at(2), accumulate_);
 }
 
 XlaOpVector Put::Lower(LoweringContext* loctx) const {
@@ -33,6 +31,4 @@ std::string Put::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/put.h
+++ b/torch_xla/csrc/ops/put.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Put : public XlaNode {
  public:
@@ -23,6 +21,4 @@ class Put : public XlaNode {
   bool accumulate_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/qr.cpp
+++ b/torch_xla/csrc/ops/qr.cpp
@@ -8,8 +8,6 @@
 #include "torch_xla/csrc/lowering_context.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 std::vector<xla::XlaOp> LowerQR(xla::XlaOp input, bool some) {
@@ -48,7 +46,7 @@ QR::QR(const XlaValue& input, bool some)
       some_(some) {}
 
 torch::lazy::NodePtr QR::Clone(OpList operands) const {
-  return ir::MakeNode<QR>(operands.at(0), some_);
+  return torch::lazy::MakeNode<QR>(operands.at(0), some_);
 }
 
 XlaOpVector QR::Lower(LoweringContext* loctx) const {
@@ -62,6 +60,4 @@ std::string QR::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/qr.h
+++ b/torch_xla/csrc/ops/qr.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class QR : public XlaNode {
  public:
@@ -22,6 +20,4 @@ class QR : public XlaNode {
   bool some_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/randperm_out.cpp
+++ b/torch_xla/csrc/ops/randperm_out.cpp
@@ -1,0 +1,47 @@
+#include "torch_xla/csrc/ops/randperm_out.h"
+
+#include "torch_xla/csrc/lowering_context.h"
+#include "torch_xla/csrc/ops/infer_output_shape.h"
+#include "torch_xla/csrc/reduction.h"
+
+namespace torch_xla {
+namespace ir {
+namespace ops {
+namespace {
+
+xla::Shape NodeOutputShape(int64_t n) {
+  auto lower_for_shape_fn_randperm_out =
+      [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
+    return BuildRandpermOut(n);
+  };
+  return InferOutputShape({}, lower_for_shape_fn_randperm_out);
+}
+
+}  // namespace
+
+RandpermOut::RandpermOut(int64_t n)
+    : Node(
+          torch::lazy::OpKind(at::aten::randperm), {},
+          [&]() { return NodeOutputShape(n); },
+          /*num_outputs=*/1, torch::lazy::MHash(n)),
+      n_(n) {}
+
+torch::lazy::NodePtr RandpermOut::Clone(OpList operands) const {
+  return MakeNode<RandpermOut>(n_);
+}
+
+XlaOpVector RandpermOut::Lower(LoweringContext* loctx) const {
+  // xla::XlaOp out = loctx->GetOutputOp(operand(0));
+  xla::XlaOp op_randperm_out = BuildRandpermOut(n_);
+  return ReturnOp(op_randperm_out, loctx);
+}
+
+std::string RandpermOut::ToString() const {
+  std::stringstream ss;
+  ss << Node::ToString() << ", n=" << n_;
+  return ss.str();
+}
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/randperm_out.cpp
+++ b/torch_xla/csrc/ops/randperm_out.cpp
@@ -1,4 +1,4 @@
-torch_xla/csrc/ops/randperm_out.cpp#include "torch_xla/csrc/ops/randperm_out.h"
+#include "torch_xla/csrc/ops/randperm_out.h"
 
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/ops/infer_output_shape.h"

--- a/torch_xla/csrc/ops/randperm_out.cpp
+++ b/torch_xla/csrc/ops/randperm_out.cpp
@@ -9,13 +9,13 @@ namespace ir {
 namespace ops {
 
 RandpermOut::RandpermOut(int64_t n)
-    : Node(torch::lazy::OpKind(at::aten::randperm), {},
-           xla::ShapeUtil::MakeShape(xla::U64, {n}),
-           /*num_outputs=*/1, torch::lazy::MHash(n)),
+    : XlaNode(torch::lazy::OpKind(at::aten::randperm), OpList(),
+              xla::ShapeUtil::MakeShape(xla::U64, {n}),
+              /*num_outputs=*/1, torch::lazy::MHash(n)),
       n_(n) {}
 
 torch::lazy::NodePtr RandpermOut::Clone(OpList operands) const {
-  return MakeNode<RandpermOut>(n_);
+  return torch::lazy::MakeNode<RandpermOut>(n_);
 }
 
 XlaOpVector RandpermOut::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/randperm_out.cpp
+++ b/torch_xla/csrc/ops/randperm_out.cpp
@@ -1,4 +1,4 @@
-#include "torch_xla/csrc/ops/randperm_out.h"
+torch_xla/csrc/ops/randperm_out.cpp#include "torch_xla/csrc/ops/randperm_out.h"
 
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/ops/infer_output_shape.h"

--- a/torch_xla/csrc/ops/randperm_out.h
+++ b/torch_xla/csrc/ops/randperm_out.h
@@ -7,7 +7,7 @@ namespace torch_xla {
 namespace ir {
 namespace ops {
 
-class RandpermOut : public Node {
+class RandpermOut : public XlaNode {
  public:
   RandpermOut(int64_t n);
 

--- a/torch_xla/csrc/ops/randperm_out.h
+++ b/torch_xla/csrc/ops/randperm_out.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "tensorflow/compiler/xla/types.h"
+#include "torch_xla/csrc/ir.h"
+
+namespace torch_xla {
+namespace ir {
+namespace ops {
+
+class RandpermOut : public Node {
+ public:
+  RandpermOut(int64_t n);
+
+  std::string ToString() const override;
+
+  torch::lazy::NodePtr Clone(OpList operands) const override;
+
+  XlaOpVector Lower(LoweringContext* loctx) const override;
+
+ private:
+  int64_t n_;
+};
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/reduce_scatter.cpp
+++ b/torch_xla/csrc/ops/reduce_scatter.cpp
@@ -8,8 +8,6 @@
 #include "torch_xla/csrc/ops/xla_ops.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(AllReduceType reduce_type, const XlaValue input,
@@ -52,9 +50,9 @@ ReduceScatter::ReduceScatter(AllReduceType reduce_type, const XlaValue& input,
       pin_layout_(pin_layout) {}
 
 torch::lazy::NodePtr ReduceScatter::Clone(OpList operands) const {
-  return ir::MakeNode<ReduceScatter>(reduce_type_, operands.at(0),
-                                     operands.at(1), scale_, scatter_dim_,
-                                     shard_count_, groups_, pin_layout_);
+  return torch::lazy::MakeNode<ReduceScatter>(
+      reduce_type_, operands.at(0), operands.at(1), scale_, scatter_dim_,
+      shard_count_, groups_, pin_layout_);
 }
 
 XlaOpVector ReduceScatter::Lower(LoweringContext* loctx) const {
@@ -81,6 +79,4 @@ std::string ReduceScatter::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/reduce_scatter.h
+++ b/torch_xla/csrc/ops/reduce_scatter.h
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class ReduceScatter : public XlaNode {
  public:
@@ -37,6 +35,4 @@ class ReduceScatter : public XlaNode {
   bool pin_layout_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/reflection_pad2d.cpp
+++ b/torch_xla/csrc/ops/reflection_pad2d.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input,
@@ -29,7 +27,7 @@ ReflectionPad2d::ReflectionPad2d(const XlaValue& input,
       padding_(std::move(padding)) {}
 
 torch::lazy::NodePtr ReflectionPad2d::Clone(OpList operands) const {
-  return ir::MakeNode<ReflectionPad2d>(operands.at(0), padding_);
+  return torch::lazy::MakeNode<ReflectionPad2d>(operands.at(0), padding_);
 }
 
 XlaOpVector ReflectionPad2d::Lower(LoweringContext* loctx) const {
@@ -45,6 +43,4 @@ std::string ReflectionPad2d::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/reflection_pad2d.h
+++ b/torch_xla/csrc/ops/reflection_pad2d.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class ReflectionPad2d : public XlaNode {
  public:
@@ -24,6 +22,4 @@ class ReflectionPad2d : public XlaNode {
   std::vector<int64_t> padding_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/reflection_pad2d_backward.cpp
+++ b/torch_xla/csrc/ops/reflection_pad2d_backward.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& input,
@@ -32,8 +30,8 @@ ReflectionPad2dBackward::ReflectionPad2dBackward(const XlaValue& grad_output,
       padding_(std::move(padding)) {}
 
 torch::lazy::NodePtr ReflectionPad2dBackward::Clone(OpList operands) const {
-  return ir::MakeNode<ReflectionPad2dBackward>(operands.at(0), operands.at(1),
-                                               padding_);
+  return torch::lazy::MakeNode<ReflectionPad2dBackward>(
+      operands.at(0), operands.at(1), padding_);
 }
 
 XlaOpVector ReflectionPad2dBackward::Lower(LoweringContext* loctx) const {
@@ -50,6 +48,4 @@ std::string ReflectionPad2dBackward::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/reflection_pad2d_backward.h
+++ b/torch_xla/csrc/ops/reflection_pad2d_backward.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class ReflectionPad2dBackward : public XlaNode {
  public:
@@ -25,6 +23,4 @@ class ReflectionPad2dBackward : public XlaNode {
   std::vector<int64_t> padding_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/repeat.cpp
+++ b/torch_xla/csrc/ops/repeat.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input,
@@ -29,7 +27,7 @@ Repeat::Repeat(const XlaValue& input, std::vector<int64_t> repeats)
       repeats_(std::move(repeats)) {}
 
 torch::lazy::NodePtr Repeat::Clone(OpList operands) const {
-  return ir::MakeNode<Repeat>(operands.at(0), repeats_);
+  return torch::lazy::MakeNode<Repeat>(operands.at(0), repeats_);
 }
 
 XlaOpVector Repeat::Lower(LoweringContext* loctx) const {
@@ -45,6 +43,4 @@ std::string Repeat::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/repeat.h
+++ b/torch_xla/csrc/ops/repeat.h
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Repeat : public XlaNode {
  public:
@@ -24,6 +22,4 @@ class Repeat : public XlaNode {
   std::vector<int64_t> repeats_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/replication_pad.cpp
+++ b/torch_xla/csrc/ops/replication_pad.cpp
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/ops/xla_ops.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input,
@@ -29,7 +27,7 @@ ReplicationPad::ReplicationPad(const XlaValue& input,
       padding_(std::move(padding)) {}
 
 torch::lazy::NodePtr ReplicationPad::Clone(OpList operands) const {
-  return ir::MakeNode<ReplicationPad>(operands.at(0), padding_);
+  return torch::lazy::MakeNode<ReplicationPad>(operands.at(0), padding_);
 }
 
 XlaOpVector ReplicationPad::Lower(LoweringContext* loctx) const {
@@ -45,6 +43,4 @@ std::string ReplicationPad::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/replication_pad.h
+++ b/torch_xla/csrc/ops/replication_pad.h
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class ReplicationPad : public XlaNode {
  public:
@@ -23,6 +21,4 @@ class ReplicationPad : public XlaNode {
   std::vector<int64_t> padding_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/replication_pad_backward.cpp
+++ b/torch_xla/csrc/ops/replication_pad_backward.cpp
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/ops/xla_ops.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& input,
@@ -32,8 +30,8 @@ ReplicationPadBackward::ReplicationPadBackward(const XlaValue& grad_output,
       padding_(std::move(padding)) {}
 
 torch::lazy::NodePtr ReplicationPadBackward::Clone(OpList operands) const {
-  return ir::MakeNode<ReplicationPadBackward>(operands.at(0), operands.at(1),
-                                              padding_);
+  return torch::lazy::MakeNode<ReplicationPadBackward>(
+      operands.at(0), operands.at(1), padding_);
 }
 
 XlaOpVector ReplicationPadBackward::Lower(LoweringContext* loctx) const {
@@ -50,6 +48,4 @@ std::string ReplicationPadBackward::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/replication_pad_backward.h
+++ b/torch_xla/csrc/ops/replication_pad_backward.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class ReplicationPadBackward : public XlaNode {
  public:
@@ -25,6 +23,4 @@ class ReplicationPadBackward : public XlaNode {
   std::vector<int64_t> padding_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/resize.cpp
+++ b/torch_xla/csrc/ops/resize.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/lowering_context.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input,
@@ -24,7 +22,7 @@ Resize::Resize(const XlaValue& input, std::vector<int64_t> size)
       size_(std::move(size)) {}
 
 torch::lazy::NodePtr Resize::Clone(OpList operands) const {
-  return ir::MakeNode<Resize>(operands.at(0), size_);
+  return torch::lazy::MakeNode<Resize>(operands.at(0), size_);
 }
 
 XlaOpVector Resize::Lower(LoweringContext* loctx) const {
@@ -39,6 +37,4 @@ std::string Resize::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/resize.h
+++ b/torch_xla/csrc/ops/resize.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Resize : public XlaNode {
  public:
@@ -22,6 +20,4 @@ class Resize : public XlaNode {
   std::vector<int64_t> size_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/roll.cpp
+++ b/torch_xla/csrc/ops/roll.cpp
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/xla_lower_util.h"
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Roll::Roll(const XlaValue& input, std::vector<int64_t> shifts,
            std::vector<int64_t> dims)
@@ -14,7 +12,7 @@ Roll::Roll(const XlaValue& input, std::vector<int64_t> shifts,
       dims_(std::move(dims)) {}
 
 torch::lazy::NodePtr Roll::Clone(OpList operands) const {
-  return ir::MakeNode<Roll>(operands.at(0), shifts_, dims_);
+  return torch::lazy::MakeNode<Roll>(operands.at(0), shifts_, dims_);
 }
 
 XlaOpVector Roll::Lower(LoweringContext* loctx) const {
@@ -30,6 +28,4 @@ std::string Roll::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/roll.h
+++ b/torch_xla/csrc/ops/roll.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Roll : public XlaNode {
  public:
@@ -26,6 +24,4 @@ class Roll : public XlaNode {
   std::vector<int64_t> dims_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/rrelu_with_noise.cpp
+++ b/torch_xla/csrc/ops/rrelu_with_noise.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ops/scalar.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 RreluWithNoise::RreluWithNoise(const XlaValue& input, const XlaValue& seed,
                                const at::Scalar& lower, const at::Scalar& upper,
@@ -23,8 +21,8 @@ RreluWithNoise::RreluWithNoise(const XlaValue& input, const XlaValue& seed,
       training_(training) {}
 
 torch::lazy::NodePtr RreluWithNoise::Clone(OpList operands) const {
-  return ir::MakeNode<RreluWithNoise>(operands.at(0), operands.at(1), lower_,
-                                      upper_, training_);
+  return torch::lazy::MakeNode<RreluWithNoise>(operands.at(0), operands.at(1),
+                                               lower_, upper_, training_);
 }
 
 XlaOpVector RreluWithNoise::Lower(LoweringContext* loctx) const {
@@ -41,6 +39,4 @@ std::string RreluWithNoise::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/rrelu_with_noise.h
+++ b/torch_xla/csrc/ops/rrelu_with_noise.h
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class RreluWithNoise : public XlaNode {
  public:
@@ -33,6 +31,4 @@ class RreluWithNoise : public XlaNode {
   bool training_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/rrelu_with_noise_backward.cpp
+++ b/torch_xla/csrc/ops/rrelu_with_noise_backward.cpp
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ops/scalar.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 RreluWithNoiseBackward::RreluWithNoiseBackward(
     const XlaValue& grad_output, const XlaValue& input, const XlaValue& noise,
@@ -21,9 +19,9 @@ RreluWithNoiseBackward::RreluWithNoiseBackward(
       training_(training) {}
 
 torch::lazy::NodePtr RreluWithNoiseBackward::Clone(OpList operands) const {
-  return ir::MakeNode<RreluWithNoiseBackward>(operands.at(0), operands.at(1),
-                                              operands.at(2), lower_, upper_,
-                                              training_);
+  return torch::lazy::MakeNode<RreluWithNoiseBackward>(
+      operands.at(0), operands.at(1), operands.at(2), lower_, upper_,
+      training_);
 }
 
 XlaOpVector RreluWithNoiseBackward::Lower(LoweringContext* loctx) const {
@@ -42,6 +40,4 @@ std::string RreluWithNoiseBackward::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/rrelu_with_noise_backward.h
+++ b/torch_xla/csrc/ops/rrelu_with_noise_backward.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class RreluWithNoiseBackward : public XlaNode {
  public:
@@ -32,6 +30,4 @@ class RreluWithNoiseBackward : public XlaNode {
   bool training_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/scalar.cpp
+++ b/torch_xla/csrc/ops/scalar.cpp
@@ -9,8 +9,6 @@
 #include "torch_xla/csrc/lowering_context.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Scalar::Scalar(const at::Scalar& value, xla::Shape shape)
     : XlaNode(torch::lazy::OpKind(at::prim::Constant), std::move(shape),
@@ -30,7 +28,7 @@ std::string Scalar::ToString() const {
 }
 
 torch::lazy::NodePtr Scalar::Clone(OpList operands) const {
-  return ir::MakeNode<Scalar>(value_, xla_shape());
+  return torch::lazy::MakeNode<Scalar>(value_, xla_shape());
 }
 
 XlaOpVector Scalar::Lower(LoweringContext* loctx) const {
@@ -101,6 +99,4 @@ torch::lazy::hash_t ScalarHash(const at::Scalar& s) {
                              : torch::lazy::Hash(s.toLong());
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/scalar.h
+++ b/torch_xla/csrc/ops/scalar.h
@@ -9,8 +9,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 // Differently from Constant, this is a scalar value broadcasted to a shape.
 // Even though a Constant could have been used, for simple scalars broadcasted
@@ -35,6 +33,4 @@ class Scalar : public XlaNode {
 
 torch::lazy::hash_t ScalarHash(const at::Scalar& s);
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/scatter.cpp
+++ b/torch_xla/csrc/ops/scatter.cpp
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Scatter::Scatter(const XlaValue& input, const XlaValue& index,
                  const XlaValue& src, int64_t dim)
@@ -15,8 +13,8 @@ Scatter::Scatter(const XlaValue& input, const XlaValue& index,
       dim_(dim) {}
 
 torch::lazy::NodePtr Scatter::Clone(OpList operands) const {
-  return ir::MakeNode<Scatter>(operands.at(0), operands.at(1), operands.at(2),
-                               dim_);
+  return torch::lazy::MakeNode<Scatter>(operands.at(0), operands.at(1),
+                                        operands.at(2), dim_);
 }
 
 XlaOpVector Scatter::Lower(LoweringContext* loctx) const {
@@ -35,6 +33,4 @@ std::string Scatter::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/scatter.h
+++ b/torch_xla/csrc/ops/scatter.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Scatter : public XlaNode {
  public:
@@ -23,6 +21,4 @@ class Scatter : public XlaNode {
   int64_t dim_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/scatter_add.cpp
+++ b/torch_xla/csrc/ops/scatter_add.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 ScatterAdd::ScatterAdd(const XlaValue& input, const XlaValue& index,
                        const XlaValue& src, int64_t dim)
@@ -17,8 +15,8 @@ ScatterAdd::ScatterAdd(const XlaValue& input, const XlaValue& index,
       dim_(dim) {}
 
 torch::lazy::NodePtr ScatterAdd::Clone(OpList operands) const {
-  return ir::MakeNode<ScatterAdd>(operands.at(0), operands.at(1),
-                                  operands.at(2), dim_);
+  return torch::lazy::MakeNode<ScatterAdd>(operands.at(0), operands.at(1),
+                                           operands.at(2), dim_);
 }
 
 XlaOpVector ScatterAdd::Lower(LoweringContext* loctx) const {
@@ -36,6 +34,4 @@ std::string ScatterAdd::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/scatter_add.h
+++ b/torch_xla/csrc/ops/scatter_add.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class ScatterAdd : public XlaNode {
  public:
@@ -23,6 +21,4 @@ class ScatterAdd : public XlaNode {
   int64_t dim_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/select.cpp
+++ b/torch_xla/csrc/ops/select.cpp
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ops/xla_ops.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Select::Select(const XlaValue& input, int64_t dim, int64_t start, int64_t end,
                int64_t stride)
@@ -22,7 +20,8 @@ Select::Select(const XlaValue& input, int64_t dim, int64_t start, int64_t end,
       stride_(stride) {}
 
 torch::lazy::NodePtr Select::Clone(OpList operands) const {
-  return ir::MakeNode<Select>(operands.at(0), dim_, start_, end_, stride_);
+  return torch::lazy::MakeNode<Select>(operands.at(0), dim_, start_, end_,
+                                       stride_);
 }
 
 XlaOpVector Select::Lower(LoweringContext* loctx) const {
@@ -56,6 +55,4 @@ int64_t Select::GetStride(int64_t start, int64_t end, int64_t stride) {
   return stride;
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/select.h
+++ b/torch_xla/csrc/ops/select.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Select : public XlaNode {
  public:
@@ -37,6 +35,4 @@ class Select : public XlaNode {
   int64_t stride_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/sgd_optimizer_step.cpp
+++ b/torch_xla/csrc/ops/sgd_optimizer_step.cpp
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& step, const XlaValue& param) {
@@ -33,7 +31,7 @@ SgdOptimizerStep::SgdOptimizerStep(
       use_nesterov_(use_nesterov) {}
 
 torch::lazy::NodePtr SgdOptimizerStep::Clone(OpList operands) const {
-  return ir::MakeNode<SgdOptimizerStep>(
+  return torch::lazy::MakeNode<SgdOptimizerStep>(
       operands.at(0), operands.at(1), operands.at(2), operands.at(3),
       operands.at(4), operands.at(5), operands.at(6), operands.at(7),
       operands.at(8), use_weight_decay_, use_momentum_, use_nesterov_);
@@ -56,6 +54,4 @@ XlaOpVector SgdOptimizerStep::Lower(LoweringContext* loctx) const {
       loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/sgd_optimizer_step.h
+++ b/torch_xla/csrc/ops/sgd_optimizer_step.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class SgdOptimizerStep : public XlaNode {
  public:
@@ -25,6 +23,4 @@ class SgdOptimizerStep : public XlaNode {
   bool use_nesterov_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/shrink_backward.cpp
+++ b/torch_xla/csrc/ops/shrink_backward.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ops/scalar.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 ShrinkBackward::ShrinkBackward(torch::lazy::OpKind kind,
                                const XlaValue& grad_output,
@@ -23,8 +21,8 @@ std::string ShrinkBackward::ToString() const {
 }
 
 torch::lazy::NodePtr ShrinkBackward::Clone(OpList operands) const {
-  return ir::MakeNode<ShrinkBackward>(op(), operands.at(0), operands.at(1),
-                                      lambda_);
+  return torch::lazy::MakeNode<ShrinkBackward>(op(), operands.at(0),
+                                               operands.at(1), lambda_);
 }
 
 XlaOpVector ShrinkBackward::Lower(LoweringContext* loctx) const {
@@ -33,6 +31,4 @@ XlaOpVector ShrinkBackward::Lower(LoweringContext* loctx) const {
   return ReturnOp(BuildShrinkBackward(grad_output, input, lambda_), loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/shrink_backward.h
+++ b/torch_xla/csrc/ops/shrink_backward.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class ShrinkBackward : public XlaNode {
  public:
@@ -25,6 +23,4 @@ class ShrinkBackward : public XlaNode {
   at::Scalar lambda_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/softmax.cpp
+++ b/torch_xla/csrc/ops/softmax.cpp
@@ -8,8 +8,6 @@
 #include "torch_xla/csrc/torch_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::XlaOp LowerSoftmax(xla::XlaOp input, int64_t dim,
@@ -39,7 +37,7 @@ Softmax::Softmax(const XlaValue& input, int64_t dim,
       dtype_(dtype) {}
 
 torch::lazy::NodePtr Softmax::Clone(OpList operands) const {
-  return ir::MakeNode<Softmax>(operands.at(0), dim_, dtype_);
+  return torch::lazy::MakeNode<Softmax>(operands.at(0), dim_, dtype_);
 }
 
 XlaOpVector Softmax::Lower(LoweringContext* loctx) const {
@@ -54,6 +52,4 @@ std::string Softmax::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/softmax.h
+++ b/torch_xla/csrc/ops/softmax.h
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Softmax : public XlaNode {
  public:
@@ -29,6 +27,4 @@ class Softmax : public XlaNode {
   c10::optional<at::ScalarType> dtype_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/softmax_backward.cpp
+++ b/torch_xla/csrc/ops/softmax_backward.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/softmax_builder.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 SoftmaxBackward::SoftmaxBackward(const XlaValue& grad_output,
                                  const XlaValue& output, int64_t dim)
@@ -17,7 +15,8 @@ SoftmaxBackward::SoftmaxBackward(const XlaValue& grad_output,
       dim_(dim) {}
 
 torch::lazy::NodePtr SoftmaxBackward::Clone(OpList operands) const {
-  return ir::MakeNode<SoftmaxBackward>(operands.at(0), operands.at(1), dim_);
+  return torch::lazy::MakeNode<SoftmaxBackward>(operands.at(0), operands.at(1),
+                                                dim_);
 }
 
 XlaOpVector SoftmaxBackward::Lower(LoweringContext* loctx) const {
@@ -34,6 +33,4 @@ std::string SoftmaxBackward::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/softmax_backward.h
+++ b/torch_xla/csrc/ops/softmax_backward.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class SoftmaxBackward : public XlaNode {
  public:
@@ -24,6 +22,4 @@ class SoftmaxBackward : public XlaNode {
   int64_t dim_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/softshrink.cpp
+++ b/torch_xla/csrc/ops/softshrink.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ops/scalar.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Softshrink::Softshrink(const XlaValue& input, const at::Scalar& lambda)
     : XlaNode(torch::lazy::OpKind(at::aten::softshrink), {input},
@@ -22,7 +20,7 @@ std::string Softshrink::ToString() const {
 }
 
 torch::lazy::NodePtr Softshrink::Clone(OpList operands) const {
-  return ir::MakeNode<Softshrink>(operands.at(0), lambda_);
+  return torch::lazy::MakeNode<Softshrink>(operands.at(0), lambda_);
 }
 
 XlaOpVector Softshrink::Lower(LoweringContext* loctx) const {
@@ -30,6 +28,4 @@ XlaOpVector Softshrink::Lower(LoweringContext* loctx) const {
   return ReturnOp(BuildSoftshrink(input, lambda_), loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/softshrink.h
+++ b/torch_xla/csrc/ops/softshrink.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Softshrink : public XlaNode {
  public:
@@ -24,6 +22,4 @@ class Softshrink : public XlaNode {
   at::Scalar lambda_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/split.cpp
+++ b/torch_xla/csrc/ops/split.cpp
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input,
@@ -34,7 +32,7 @@ Split::Split(const XlaValue& input, std::vector<int64_t> split_sizes,
       dim_(dim) {}
 
 torch::lazy::NodePtr Split::Clone(OpList operands) const {
-  return ir::MakeNode<Split>(operands.at(0), split_sizes_, dim_);
+  return torch::lazy::MakeNode<Split>(operands.at(0), split_sizes_, dim_);
 }
 
 XlaOpVector Split::Lower(LoweringContext* loctx) const {
@@ -50,6 +48,4 @@ std::string Split::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/split.h
+++ b/torch_xla/csrc/ops/split.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 // Split the tensor into chunks along a given dimension.
 class Split : public XlaNode {
@@ -28,6 +26,4 @@ class Split : public XlaNode {
   int64_t dim_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/squeeze.cpp
+++ b/torch_xla/csrc/ops/squeeze.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::XlaOp LowerSqueeze(xla::XlaOp input, int dim) {
@@ -36,7 +34,7 @@ Squeeze::Squeeze(const XlaValue& input, int dim)
       dim_(dim) {}
 
 torch::lazy::NodePtr Squeeze::Clone(OpList operands) const {
-  return ir::MakeNode<Squeeze>(operands.at(0), dim_);
+  return torch::lazy::MakeNode<Squeeze>(operands.at(0), dim_);
 }
 
 XlaOpVector Squeeze::Lower(LoweringContext* loctx) const {
@@ -51,6 +49,4 @@ std::string Squeeze::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/squeeze.h
+++ b/torch_xla/csrc/ops/squeeze.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Squeeze : public XlaNode {
  public:
@@ -23,6 +21,4 @@ class Squeeze : public XlaNode {
   int dim_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/stack.cpp
+++ b/torch_xla/csrc/ops/stack.cpp
@@ -6,11 +6,9 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(absl::Span<const ir::XlaValue> values, int64_t dim) {
+xla::Shape NodeOutputShape(absl::Span<const XlaValue> values, int64_t dim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildStack(operands, dim);
@@ -25,14 +23,14 @@ xla::Shape NodeOutputShape(absl::Span<const ir::XlaValue> values, int64_t dim) {
 
 }  // namespace
 
-Stack::Stack(absl::Span<const ir::XlaValue> values, int64_t dim)
+Stack::Stack(absl::Span<const XlaValue> values, int64_t dim)
     : XlaNode(torch::lazy::OpKind(at::aten::stack), values,
               [&]() { return NodeOutputShape(values, dim); },
               /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}
 
 torch::lazy::NodePtr Stack::Clone(OpList operands) const {
-  return ir::MakeNode<Stack>(operands, dim_);
+  return torch::lazy::MakeNode<Stack>(operands, dim_);
 }
 
 XlaOpVector Stack::Lower(LoweringContext* loctx) const {
@@ -49,6 +47,4 @@ std::string Stack::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/stack.h
+++ b/torch_xla/csrc/ops/stack.h
@@ -4,12 +4,10 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Stack : public XlaNode {
  public:
-  Stack(absl::Span<const ir::XlaValue> values, int64_t dim);
+  Stack(absl::Span<const XlaValue> values, int64_t dim);
 
   std::string ToString() const override;
 
@@ -23,6 +21,4 @@ class Stack : public XlaNode {
   int64_t dim_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/std.cpp
+++ b/torch_xla/csrc/ops/std.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/reduction.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input,
@@ -38,8 +36,8 @@ Std::Std(const XlaValue& input, std::vector<int64_t> dimensions,
       correction_(correction) {}
 
 torch::lazy::NodePtr Std::Clone(OpList operands) const {
-  return ir::MakeNode<Std>(operands.at(0), dimensions_,
-                           keep_reduced_dimensions_, correction_);
+  return torch::lazy::MakeNode<Std>(operands.at(0), dimensions_,
+                                    keep_reduced_dimensions_, correction_);
 }
 
 XlaOpVector Std::Lower(LoweringContext* loctx) const {
@@ -58,6 +56,4 @@ std::string Std::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/std.h
+++ b/torch_xla/csrc/ops/std.h
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Std : public XlaNode {
  public:
@@ -32,6 +30,4 @@ class Std : public XlaNode {
   int64_t correction_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/std_mean.cpp
+++ b/torch_xla/csrc/ops/std_mean.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/reduction.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input,
@@ -41,8 +39,8 @@ StdMean::StdMean(const XlaValue& input, std::vector<int64_t> dimensions,
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
 torch::lazy::NodePtr StdMean::Clone(OpList operands) const {
-  return ir::MakeNode<StdMean>(operands.at(0), dimensions_, correction_,
-                               keep_reduced_dimensions_);
+  return torch::lazy::MakeNode<StdMean>(operands.at(0), dimensions_,
+                                        correction_, keep_reduced_dimensions_);
 }
 
 XlaOpVector StdMean::Lower(LoweringContext* loctx) const {
@@ -62,6 +60,4 @@ std::string StdMean::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/std_mean.h
+++ b/torch_xla/csrc/ops/std_mean.h
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class StdMean : public XlaNode {
  public:
@@ -32,6 +30,4 @@ class StdMean : public XlaNode {
   bool keep_reduced_dimensions_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/sum.cpp
+++ b/torch_xla/csrc/ops/sum.cpp
@@ -11,8 +11,6 @@
 #include "torch_xla/csrc/torch_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::XlaOp LowerSum(xla::XlaOp input, absl::Span<const int64_t> dimensions,
@@ -50,8 +48,8 @@ Sum::Sum(const XlaValue& input, std::vector<int64_t> dimensions,
       dtype_(dtype) {}
 
 torch::lazy::NodePtr Sum::Clone(OpList operands) const {
-  return ir::MakeNode<Sum>(operands.at(0), dimensions_,
-                           keep_reduced_dimensions_, dtype_);
+  return torch::lazy::MakeNode<Sum>(operands.at(0), dimensions_,
+                                    keep_reduced_dimensions_, dtype_);
 }
 
 XlaOpVector Sum::Lower(LoweringContext* loctx) const {
@@ -69,6 +67,4 @@ std::string Sum::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/sum.h
+++ b/torch_xla/csrc/ops/sum.h
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Sum : public XlaNode {
  public:
@@ -33,6 +31,4 @@ class Sum : public XlaNode {
   c10::optional<at::ScalarType> dtype_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/svd.cpp
+++ b/torch_xla/csrc/ops/svd.cpp
@@ -10,8 +10,6 @@
 #include "torch_xla/csrc/lowering_context.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 std::vector<xla::XlaOp> LowerSVD(xla::XlaOp input, bool some, bool compute_uv) {
@@ -75,7 +73,7 @@ SVD::SVD(const XlaValue& input, bool some, bool compute_uv)
       compute_uv_(compute_uv) {}
 
 torch::lazy::NodePtr SVD::Clone(OpList operands) const {
-  return ir::MakeNode<SVD>(operands.at(0), some_, compute_uv_);
+  return torch::lazy::MakeNode<SVD>(operands.at(0), some_, compute_uv_);
 }
 
 XlaOpVector SVD::Lower(LoweringContext* loctx) const {
@@ -90,6 +88,4 @@ std::string SVD::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/svd.h
+++ b/torch_xla/csrc/ops/svd.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class SVD : public XlaNode {
  public:
@@ -25,6 +23,4 @@ class SVD : public XlaNode {
   bool compute_uv_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/symeig.cpp
+++ b/torch_xla/csrc/ops/symeig.cpp
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/lowering_context.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 std::vector<xla::XlaOp> LowerSymEig(xla::XlaOp input, bool eigenvectors,
@@ -54,7 +52,7 @@ SymEig::SymEig(const XlaValue& input, bool eigenvectors, bool lower)
       lower_(lower) {}
 
 torch::lazy::NodePtr SymEig::Clone(OpList operands) const {
-  return ir::MakeNode<SymEig>(operands.at(0), eigenvectors_, lower_);
+  return torch::lazy::MakeNode<SymEig>(operands.at(0), eigenvectors_, lower_);
 }
 
 XlaOpVector SymEig::Lower(LoweringContext* loctx) const {
@@ -69,6 +67,4 @@ std::string SymEig::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/symeig.h
+++ b/torch_xla/csrc/ops/symeig.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class SymEig : public XlaNode {
  public:
@@ -25,6 +23,4 @@ class SymEig : public XlaNode {
   bool lower_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/threshold.cpp
+++ b/torch_xla/csrc/ops/threshold.cpp
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/lowering_context.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Threshold::Threshold(const XlaValue& input, float threshold, float value)
     : XlaNode(torch::lazy::OpKind(at::aten::threshold), {input},
@@ -15,7 +13,7 @@ Threshold::Threshold(const XlaValue& input, float threshold, float value)
       value_(value) {}
 
 torch::lazy::NodePtr Threshold::Clone(OpList operands) const {
-  return ir::MakeNode<Threshold>(operands.at(0), threshold_, value_);
+  return torch::lazy::MakeNode<Threshold>(operands.at(0), threshold_, value_);
 }
 
 XlaOpVector Threshold::Lower(LoweringContext* loctx) const {
@@ -31,6 +29,4 @@ std::string Threshold::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/threshold.h
+++ b/torch_xla/csrc/ops/threshold.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 // IR node for the threshold operation.
 class Threshold : public XlaNode {
@@ -26,6 +24,4 @@ class Threshold : public XlaNode {
   float value_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/threshold_backward.cpp
+++ b/torch_xla/csrc/ops/threshold_backward.cpp
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/lowering_context.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 ThresholdBackward::ThresholdBackward(const XlaValue& grad_output,
                                      const XlaValue& input, float threshold)
@@ -15,8 +13,8 @@ ThresholdBackward::ThresholdBackward(const XlaValue& grad_output,
       threshold_(threshold) {}
 
 torch::lazy::NodePtr ThresholdBackward::Clone(OpList operands) const {
-  return ir::MakeNode<ThresholdBackward>(operands.at(0), operands.at(1),
-                                         threshold_);
+  return torch::lazy::MakeNode<ThresholdBackward>(operands.at(0),
+                                                  operands.at(1), threshold_);
 }
 
 XlaOpVector ThresholdBackward::Lower(LoweringContext* loctx) const {
@@ -32,6 +30,4 @@ std::string ThresholdBackward::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/threshold_backward.h
+++ b/torch_xla/csrc/ops/threshold_backward.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class ThresholdBackward : public XlaNode {
  public:
@@ -23,6 +21,4 @@ class ThresholdBackward : public XlaNode {
   float threshold_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/topk.cpp
+++ b/torch_xla/csrc/ops/topk.cpp
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input, int64_t k, int64_t dim,
@@ -36,8 +34,8 @@ TopK::TopK(const XlaValue& input, int64_t k, int64_t dim, bool largest,
       stable_(stable) {}
 
 torch::lazy::NodePtr TopK::Clone(OpList operands) const {
-  return ir::MakeNode<TopK>(operands.at(0), k_, dim_, largest_, sorted_,
-                            stable_);
+  return torch::lazy::MakeNode<TopK>(operands.at(0), k_, dim_, largest_,
+                                     sorted_, stable_);
 }
 
 XlaOpVector TopK::Lower(LoweringContext* loctx) const {
@@ -53,6 +51,4 @@ std::string TopK::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/topk.h
+++ b/torch_xla/csrc/ops/topk.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class TopK : public XlaNode {
  public:
@@ -35,6 +33,4 @@ class TopK : public XlaNode {
   bool stable_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/triangular_solve.cpp
+++ b/torch_xla/csrc/ops/triangular_solve.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/lowering_context.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 // This function plays two roles:
@@ -86,9 +84,9 @@ TriangularSolve::TriangularSolve(const XlaValue& rhs, const XlaValue& lhs,
       unit_diagonal_(unit_diagonal) {}
 
 torch::lazy::NodePtr TriangularSolve::Clone(OpList operands) const {
-  return ir::MakeNode<TriangularSolve>(operands.at(0), operands.at(1),
-                                       left_side_, lower_, transpose_,
-                                       unit_diagonal_);
+  return torch::lazy::MakeNode<TriangularSolve>(operands.at(0), operands.at(1),
+                                                left_side_, lower_, transpose_,
+                                                unit_diagonal_);
 }
 
 XlaOpVector TriangularSolve::Lower(LoweringContext* loctx) const {
@@ -107,6 +105,4 @@ std::string TriangularSolve::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/triangular_solve.h
+++ b/torch_xla/csrc/ops/triangular_solve.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class TriangularSolve : public XlaNode {
  public:
@@ -32,6 +30,4 @@ class TriangularSolve : public XlaNode {
   bool unit_diagonal_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/tril.cpp
+++ b/torch_xla/csrc/ops/tril.cpp
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/matrix.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Tril::Tril(const XlaValue& input, int64_t diagonal)
     : XlaNode(torch::lazy::OpKind(at::aten::tril), {input}, input.xla_shape(),
@@ -13,7 +11,7 @@ Tril::Tril(const XlaValue& input, int64_t diagonal)
       diagonal_(diagonal) {}
 
 torch::lazy::NodePtr Tril::Clone(OpList operands) const {
-  return ir::MakeNode<Tril>(operands.at(0), diagonal_);
+  return torch::lazy::MakeNode<Tril>(operands.at(0), diagonal_);
 }
 
 XlaOpVector Tril::Lower(LoweringContext* loctx) const {
@@ -28,6 +26,4 @@ std::string Tril::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/tril.h
+++ b/torch_xla/csrc/ops/tril.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 // XlaNode for the lower triangular part of a matrix (2-D tensor) or batch of
 // matrices input.
@@ -24,6 +22,4 @@ class Tril : public XlaNode {
   int64_t diagonal_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/triu.cpp
+++ b/torch_xla/csrc/ops/triu.cpp
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/matrix.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Triu::Triu(const XlaValue& input, int64_t diagonal)
     : XlaNode(torch::lazy::OpKind(at::aten::triu), {input}, input.xla_shape(),
@@ -13,7 +11,7 @@ Triu::Triu(const XlaValue& input, int64_t diagonal)
       diagonal_(diagonal) {}
 
 torch::lazy::NodePtr Triu::Clone(OpList operands) const {
-  return ir::MakeNode<Triu>(operands.at(0), diagonal_);
+  return torch::lazy::MakeNode<Triu>(operands.at(0), diagonal_);
 }
 
 XlaOpVector Triu::Lower(LoweringContext* loctx) const {
@@ -28,6 +26,4 @@ std::string Triu::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/triu.h
+++ b/torch_xla/csrc/ops/triu.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 // XlaNode for the upper triangular part of a matrix (2-D tensor) or batch of
 // matrices input.
@@ -24,6 +22,4 @@ class Triu : public XlaNode {
   int64_t diagonal_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/uniform.cpp
+++ b/torch_xla/csrc/ops/uniform.cpp
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/torch_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Uniform::Uniform(const XlaValue& from, const XlaValue& to, const XlaValue& seed,
                  const xla::Shape& rng_shape)
@@ -17,8 +15,8 @@ Uniform::Uniform(const XlaValue& from, const XlaValue& to, const XlaValue& seed,
               /*num_outputs=*/1, torch::lazy::Hash(rng_shape)) {}
 
 torch::lazy::NodePtr Uniform::Clone(OpList operands) const {
-  return ir::MakeNode<Uniform>(operands.at(0), operands.at(1), operands.at(2),
-                               xla_shape());
+  return torch::lazy::MakeNode<Uniform>(operands.at(0), operands.at(1),
+                                        operands.at(2), xla_shape());
 }
 
 XlaOpVector Uniform::Lower(LoweringContext* loctx) const {
@@ -28,6 +26,4 @@ XlaOpVector Uniform::Lower(LoweringContext* loctx) const {
   return ReturnOp(RngUniform(rng_seed, xla_shape(), from, to), loctx);
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/uniform.h
+++ b/torch_xla/csrc/ops/uniform.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Uniform : public XlaNode {
  public:
@@ -16,6 +14,4 @@ class Uniform : public XlaNode {
   XlaOpVector Lower(LoweringContext* loctx) const override;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/unselect.cpp
+++ b/torch_xla/csrc/ops/unselect.cpp
@@ -8,8 +8,6 @@
 #include "torch_xla/csrc/tensor_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 Unselect::Unselect(const XlaValue& target, const XlaValue& source, int64_t dim,
                    int64_t start, int64_t end, int64_t stride)
@@ -21,8 +19,8 @@ Unselect::Unselect(const XlaValue& target, const XlaValue& source, int64_t dim,
       stride_(stride) {}
 
 torch::lazy::NodePtr Unselect::Clone(OpList operands) const {
-  return ir::MakeNode<Unselect>(operands.at(0), operands.at(1), dim_, start_,
-                                end_, stride_);
+  return torch::lazy::MakeNode<Unselect>(operands.at(0), operands.at(1), dim_,
+                                         start_, end_, stride_);
 }
 
 XlaOpVector Unselect::Lower(LoweringContext* loctx) const {
@@ -40,6 +38,4 @@ std::string Unselect::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/unselect.h
+++ b/torch_xla/csrc/ops/unselect.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Unselect : public XlaNode {
  public:
@@ -32,6 +30,4 @@ class Unselect : public XlaNode {
   int64_t stride_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/unsqueeze.cpp
+++ b/torch_xla/csrc/ops/unsqueeze.cpp
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/lowering_context.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input, int dim) {
@@ -23,7 +21,7 @@ Unsqueeze::Unsqueeze(const XlaValue& input, int dim)
       dim_(dim) {}
 
 torch::lazy::NodePtr Unsqueeze::Clone(OpList operands) const {
-  return ir::MakeNode<Unsqueeze>(operands.at(0), dim_);
+  return torch::lazy::MakeNode<Unsqueeze>(operands.at(0), dim_);
 }
 
 XlaOpVector Unsqueeze::Lower(LoweringContext* loctx) const {
@@ -38,6 +36,4 @@ std::string Unsqueeze::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/unsqueeze.h
+++ b/torch_xla/csrc/ops/unsqueeze.h
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Unsqueeze : public XlaNode {
  public:
@@ -24,6 +22,4 @@ class Unsqueeze : public XlaNode {
   int dim_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/update_slice.cpp
+++ b/torch_xla/csrc/ops/update_slice.cpp
@@ -8,8 +8,6 @@
 #include "torch_xla/csrc/torch_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& source,
@@ -32,8 +30,8 @@ UpdateSlice::UpdateSlice(const XlaValue& input, const XlaValue& source,
       base_indices_(base_indices.begin(), base_indices.end()) {}
 
 torch::lazy::NodePtr UpdateSlice::Clone(OpList operands) const {
-  return ir::MakeNode<UpdateSlice>(operands.at(0), operands.at(1),
-                                   base_indices_);
+  return torch::lazy::MakeNode<UpdateSlice>(operands.at(0), operands.at(1),
+                                            base_indices_);
 }
 
 XlaOpVector UpdateSlice::Lower(LoweringContext* loctx) const {
@@ -50,6 +48,4 @@ std::string UpdateSlice::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/update_slice.h
+++ b/torch_xla/csrc/ops/update_slice.h
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class UpdateSlice : public XlaNode {
  public:
@@ -24,6 +22,4 @@ class UpdateSlice : public XlaNode {
   std::vector<int64_t> base_indices_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/upsample_bilinear2d.cpp
+++ b/torch_xla/csrc/ops/upsample_bilinear2d.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/resize_ops.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 UpsampleBilinear::UpsampleBilinear(const XlaValue& input,
                                    std::vector<int64_t> output_size,
@@ -23,8 +21,8 @@ UpsampleBilinear::UpsampleBilinear(const XlaValue& input,
       align_corners_(align_corners) {}
 
 torch::lazy::NodePtr UpsampleBilinear::Clone(OpList operands) const {
-  return ir::MakeNode<UpsampleBilinear>(operands.at(0), output_size_,
-                                        align_corners_);
+  return torch::lazy::MakeNode<UpsampleBilinear>(operands.at(0), output_size_,
+                                                 align_corners_);
 }
 
 XlaOpVector UpsampleBilinear::Lower(LoweringContext* loctx) const {
@@ -43,6 +41,4 @@ std::string UpsampleBilinear::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/upsample_bilinear2d.h
+++ b/torch_xla/csrc/ops/upsample_bilinear2d.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class UpsampleBilinear : public XlaNode {
  public:
@@ -28,6 +26,4 @@ class UpsampleBilinear : public XlaNode {
   bool align_corners_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/upsample_bilinear2d_backward.cpp
+++ b/torch_xla/csrc/ops/upsample_bilinear2d_backward.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/resize_ops.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 UpsampleBilinearBackward::UpsampleBilinearBackward(
     const XlaValue& input, std::vector<int64_t> output_size,
@@ -25,8 +23,8 @@ UpsampleBilinearBackward::UpsampleBilinearBackward(
       align_corners_(align_corners) {}
 
 torch::lazy::NodePtr UpsampleBilinearBackward::Clone(OpList operands) const {
-  return ir::MakeNode<UpsampleBilinearBackward>(operands.at(0), output_size_,
-                                                input_size_, align_corners_);
+  return torch::lazy::MakeNode<UpsampleBilinearBackward>(
+      operands.at(0), output_size_, input_size_, align_corners_);
 }
 
 XlaOpVector UpsampleBilinearBackward::Lower(LoweringContext* loctx) const {
@@ -46,6 +44,4 @@ std::string UpsampleBilinearBackward::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/upsample_bilinear2d_backward.h
+++ b/torch_xla/csrc/ops/upsample_bilinear2d_backward.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class UpsampleBilinearBackward : public XlaNode {
  public:
@@ -32,6 +30,4 @@ class UpsampleBilinearBackward : public XlaNode {
   bool align_corners_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/upsample_nearest2d.cpp
+++ b/torch_xla/csrc/ops/upsample_nearest2d.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/resize_ops.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 UpsampleNearest::UpsampleNearest(const XlaValue& input,
                                  std::vector<int64_t> output_size)
@@ -20,7 +18,7 @@ UpsampleNearest::UpsampleNearest(const XlaValue& input,
       output_size_(std::move(output_size)) {}
 
 torch::lazy::NodePtr UpsampleNearest::Clone(OpList operands) const {
-  return ir::MakeNode<UpsampleNearest>(operands.at(0), output_size_);
+  return torch::lazy::MakeNode<UpsampleNearest>(operands.at(0), output_size_);
 }
 
 XlaOpVector UpsampleNearest::Lower(LoweringContext* loctx) const {
@@ -39,6 +37,4 @@ std::string UpsampleNearest::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/upsample_nearest2d.h
+++ b/torch_xla/csrc/ops/upsample_nearest2d.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class UpsampleNearest : public XlaNode {
  public:
@@ -24,6 +22,4 @@ class UpsampleNearest : public XlaNode {
   std::vector<int64_t> output_size_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/upsample_nearest2d_backward.cpp
+++ b/torch_xla/csrc/ops/upsample_nearest2d_backward.cpp
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/resize_ops.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 UpsampleNearestBackward::UpsampleNearestBackward(
     const XlaValue& input, std::vector<int64_t> output_size,
@@ -23,8 +21,8 @@ UpsampleNearestBackward::UpsampleNearestBackward(
       input_size_(std::move(input_size)) {}
 
 torch::lazy::NodePtr UpsampleNearestBackward::Clone(OpList operands) const {
-  return ir::MakeNode<UpsampleNearestBackward>(operands.at(0), output_size_,
-                                               input_size_);
+  return torch::lazy::MakeNode<UpsampleNearestBackward>(
+      operands.at(0), output_size_, input_size_);
 }
 
 XlaOpVector UpsampleNearestBackward::Lower(LoweringContext* loctx) const {
@@ -43,6 +41,4 @@ std::string UpsampleNearestBackward::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/upsample_nearest2d_backward.h
+++ b/torch_xla/csrc/ops/upsample_nearest2d_backward.h
@@ -5,8 +5,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class UpsampleNearestBackward : public XlaNode {
  public:
@@ -29,6 +27,4 @@ class UpsampleNearestBackward : public XlaNode {
   std::vector<int64_t> input_size_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/user_computation.cpp
+++ b/torch_xla/csrc/ops/user_computation.cpp
@@ -3,8 +3,6 @@
 #include "torch_xla/csrc/lowering_context.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 size_t GetNumOutputs(const xla::Shape& shape) {
@@ -21,7 +19,7 @@ UserComputation::UserComputation(torch::lazy::OpKind op, OpList operands,
       computation_(std::move(computation)) {}
 
 torch::lazy::NodePtr UserComputation::Clone(OpList operands) const {
-  return ir::MakeNode<UserComputation>(op(), operands, computation_);
+  return torch::lazy::MakeNode<UserComputation>(op(), operands, computation_);
 }
 
 XlaOpVector UserComputation::Lower(LoweringContext* loctx) const {
@@ -49,6 +47,4 @@ std::string UserComputation::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/user_computation.h
+++ b/torch_xla/csrc/ops/user_computation.h
@@ -4,8 +4,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class UserComputation : public XlaNode {
  public:
@@ -24,6 +22,4 @@ class UserComputation : public XlaNode {
   ComputationPtr computation_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/var.cpp
+++ b/torch_xla/csrc/ops/var.cpp
@@ -9,8 +9,6 @@
 #include "torch_xla/csrc/torch_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input,
@@ -39,8 +37,8 @@ Var::Var(const XlaValue& input, std::vector<int64_t> dimensions,
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
 torch::lazy::NodePtr Var::Clone(OpList operands) const {
-  return ir::MakeNode<Var>(operands.at(0), dimensions_, correction_,
-                           keep_reduced_dimensions_);
+  return torch::lazy::MakeNode<Var>(operands.at(0), dimensions_, correction_,
+                                    keep_reduced_dimensions_);
 }
 
 XlaOpVector Var::Lower(LoweringContext* loctx) const {
@@ -58,6 +56,4 @@ std::string Var::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/var.h
+++ b/torch_xla/csrc/ops/var.h
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class Var : public XlaNode {
  public:
@@ -32,6 +30,4 @@ class Var : public XlaNode {
   bool keep_reduced_dimensions_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/var_mean.cpp
+++ b/torch_xla/csrc/ops/var_mean.cpp
@@ -9,8 +9,6 @@
 #include "torch_xla/csrc/torch_util.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input,
@@ -44,8 +42,8 @@ VarMean::VarMean(const XlaValue& input, std::vector<int64_t> dimensions,
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
 torch::lazy::NodePtr VarMean::Clone(OpList operands) const {
-  return ir::MakeNode<VarMean>(operands.at(0), dimensions_, correction_,
-                               keep_reduced_dimensions_);
+  return torch::lazy::MakeNode<VarMean>(operands.at(0), dimensions_,
+                                        correction_, keep_reduced_dimensions_);
 }
 
 XlaOpVector VarMean::Lower(LoweringContext* loctx) const {
@@ -65,6 +63,4 @@ std::string VarMean::ToString() const {
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/var_mean.h
+++ b/torch_xla/csrc/ops/var_mean.h
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class VarMean : public XlaNode {
  public:
@@ -32,6 +30,4 @@ class VarMean : public XlaNode {
   bool keep_reduced_dimensions_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/view.cpp
+++ b/torch_xla/csrc/ops/view.cpp
@@ -7,8 +7,6 @@
 #include "torch_xla/csrc/lowering_context.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 namespace {
 
 xla::Shape NodeOutputShape(const XlaValue& input,
@@ -26,25 +24,23 @@ xla::Shape NodeOutputShape(const XlaValue& input,
 
 }  // namespace
 
-View::View(const XlaValue& input, std::vector<int64_t> output_size)
+ViewOp::ViewOp(const XlaValue& input, std::vector<int64_t> output_size)
     : XlaNode(torch::lazy::OpKind(at::aten::view), {input},
               NodeOutputShape(input, output_size),
               /*num_outputs=*/1, torch::lazy::MHash(output_size)),
       output_size_(std::move(output_size)) {}
 
-XlaOpVector View::Lower(LoweringContext* loctx) const {
+XlaOpVector ViewOp::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
   xla::XlaOp output = BuildView(input, output_size_);
   return ReturnOp(output, loctx);
 }
 
-std::string View::ToString() const {
+std::string ViewOp::ToString() const {
   std::stringstream ss;
   ss << XlaNode::ToString() << ", output_size=("
      << absl::StrJoin(output_size_, ", ") << ")";
   return ss.str();
 }
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/view.h
+++ b/torch_xla/csrc/ops/view.h
@@ -5,12 +5,10 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
-class View : public XlaNode {
+class ViewOp : public XlaNode {
  public:
-  View(const XlaValue& input, std::vector<int64_t> output_size);
+  ViewOp(const XlaValue& input, std::vector<int64_t> output_size);
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
@@ -22,6 +20,4 @@ class View : public XlaNode {
   std::vector<int64_t> output_size_;
 };
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/xla_ops.cpp
+++ b/torch_xla/csrc/ops/xla_ops.cpp
@@ -1,8 +1,6 @@
 #include "torch_xla/csrc/ops/xla_ops.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 const OpKindWrapper xla_adam_optimizer_step("xla::adam_optimizer_step");
 const OpKindWrapper xla_all_gather("xla::all_gather");
@@ -29,6 +27,4 @@ const OpKindWrapper xla_tensor_data("xla::tensor_data");
 const OpKindWrapper xla_unselect("xla::unselect");
 const OpKindWrapper xla_update_slice("xla::update_slice");
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/xla_ops.h
+++ b/torch_xla/csrc/ops/xla_ops.h
@@ -6,8 +6,6 @@
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
-namespace ir {
-namespace ops {
 
 class OpKindWrapper {
  public:
@@ -53,6 +51,4 @@ extern const OpKindWrapper xla_tensor_data;
 extern const OpKindWrapper xla_unselect;
 extern const OpKindWrapper xla_update_slice;
 
-}  // namespace ops
-}  // namespace ir
 }  // namespace torch_xla

--- a/torch_xla/csrc/reduction.cpp
+++ b/torch_xla/csrc/reduction.cpp
@@ -1,4 +1,3 @@
-torch_xla/csrc/reduction.cpp
 #include "torch_xla/csrc/reduction.h"
 
 #include <stdlib.h>
@@ -551,12 +550,13 @@ xla::XlaOp BuildLogsumexp(xla::XlaOp input,
  * resolve this pitfall, i.e. ensuring that the permutations are truly
  * randomly uniformly distributed.
  * Link to PyTorch CUDA implementation of this post-processing:
- * https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cuda/Randperm.cu
+ *
+ https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cuda/Randperm.cu
  */
 xla::XlaOp BuildRandpermOut(int64_t n, xla::XlaBuilder* builder) {
   // Create an arange tensor of size n
   xla::PrimitiveType element_type = xla::U64;
-  xla::XlaOp input = xla::Iota(builder, element_type, n);26
+  xla::XlaOp input = xla::Iota(builder, element_type, n);
 
   // Ensure that the key space is greater than or equal to the cube of the
   // number of values to manage the number of collisions. Inspired by

--- a/torch_xla/csrc/reduction.cpp
+++ b/torch_xla/csrc/reduction.cpp
@@ -1,3 +1,4 @@
+torch_xla/csrc/reduction.cpp
 #include "torch_xla/csrc/reduction.h"
 
 #include <stdlib.h>
@@ -555,7 +556,7 @@ xla::XlaOp BuildLogsumexp(xla::XlaOp input,
 xla::XlaOp BuildRandpermOut(int64_t n, xla::XlaBuilder* builder) {
   // Create an arange tensor of size n
   xla::PrimitiveType element_type = xla::U64;
-  xla::XlaOp input = xla::Iota(builder, element_type, n);
+  xla::XlaOp input = xla::Iota(builder, element_type, n);26
 
   // Ensure that the key space is greater than or equal to the cube of the
   // number of values to manage the number of collisions. Inspired by

--- a/torch_xla/csrc/reduction.cpp
+++ b/torch_xla/csrc/reduction.cpp
@@ -525,7 +525,7 @@ xla::XlaOp BuildLogsumexp(xla::XlaOp input,
 
 /**
  * @brief Returns a random permutation of integers from 0 to n - 1
- *
+
  * [Algorithm of randperm]: randperm is implemented by sorting an
  * arange tensor of size n with randomly generated keys. When random
  * keys are different from each other, all different permutations have

--- a/torch_xla/csrc/reduction.cpp
+++ b/torch_xla/csrc/reduction.cpp
@@ -555,7 +555,7 @@ xla::XlaOp BuildLogsumexp(xla::XlaOp input,
 xla::XlaOp BuildRandpermOut(int64_t n, xla::XlaBuilder* builder) {
   // Create an arange tensor of size n
   xla::PrimitiveType element_type = xla::U64;
-  xla::XlaOp input = xla::Iota(&builder, element_type, n);
+  xla::XlaOp input = xla::Iota(builder, element_type, n);
 
   // Ensure that the key space is greater than or equal to the cube of the
   // number of values to manage the number of collisions. Inspired by
@@ -567,9 +567,9 @@ xla::XlaOp BuildRandpermOut(int64_t n, xla::XlaBuilder* builder) {
 
   // Define shapes and constants
   const xla::Shape key_shape = xla::ShapeUtil::MakeShape(xla::U32, {n});
-  xla::XlaOp zero = XlaHelpers::ScalarValue(0U, &builder);
+  xla::XlaOp zero = XlaHelpers::ScalarValue(0U, builder);
   xla::XlaOp max_value =
-      XlaHelpers::ScalarValue(tensorflow::kuint32max, &builder);
+      XlaHelpers::ScalarValue(tensorflow::kuint32max, builder);
 
   // To address the pitfall, sort the permutation with random keys for multiple
   // rounds
@@ -578,7 +578,7 @@ xla::XlaOp BuildRandpermOut(int64_t n, xla::XlaBuilder* builder) {
     xla::XlaOp keys = xla::RngUniform(zero, max_value, key_shape);
     xla::XlaOp sorted = xla::Sort(
         {keys, curr},
-        xla::CreateScalarLtComputation({xla::U32, element_type}, &builder));
+        xla::CreateScalarLtComputation({xla::U32, element_type}, builder));
     curr = xla::GetTupleElement(sorted, 1);
   }
 

--- a/torch_xla/csrc/reduction.h
+++ b/torch_xla/csrc/reduction.h
@@ -104,4 +104,6 @@ xla::XlaOp BuildLogsumexp(xla::XlaOp input,
                           absl::Span<const int64_t> dimensions,
                           bool keep_reduced_dimensions);
 
+xla::XlaOp BuildRandpermOut(int64_t n);
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/reduction.h
+++ b/torch_xla/csrc/reduction.h
@@ -104,6 +104,6 @@ xla::XlaOp BuildLogsumexp(xla::XlaOp input,
                           absl::Span<const int64_t> dimensions,
                           bool keep_reduced_dimensions);
 
-xla::XlaOp BuildRandpermOut(int64_t n);
+xla::XlaOp BuildRandpermOut(int64_t n, xla::XlaBuilder* builder);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -215,14 +215,13 @@ XlaDataCacheArena::XlaDataCache* GetXlaDataCache(
   return arena->Get(device);
 }
 
-ir::XlaValue IrValueFromScalar(const at::Scalar& value,
-                               at::ScalarType scalar_type,
-                               const torch::lazy::BackendDevice& device,
-                               bool transfer_async) {
+XlaValue IrValueFromScalar(const at::Scalar& value, at::ScalarType scalar_type,
+                           const torch::lazy::BackendDevice& device,
+                           bool transfer_async) {
   at::Tensor tensor = at::scalar_tensor(value, at::TensorOptions(scalar_type));
   xla::ComputationClient::DataPtr device_data =
       TensorToXlaData(tensor, device, transfer_async);
-  return ir::MakeNode<ir::ops::DeviceData>(std::move(device_data));
+  return torch::lazy::MakeNode<DeviceData>(std::move(device_data));
 }
 
 xla::ComputationClient::DataPtr GetDeviceData(
@@ -264,8 +263,8 @@ bool IsSpecialScalar(const at::Scalar& value) {
   return false;
 }
 
-bool ShouldSyncIrValue(const ir::XlaValue& ir_value) {
-  return ir_value->op() != ir::ops::xla_not_supported;
+bool ShouldSyncIrValue(const XlaValue& ir_value) {
+  return ir_value->op() != xla_not_supported;
 }
 
 }  // namespace
@@ -281,7 +280,7 @@ class XLATensor::DeviceContextArena {
     std::map<int64_t, std::weak_ptr<Data>> tensors_data;
     uint64_t seed = 101;
     uint64_t running_seed = 101;
-    ir::XlaValue seed_ir_value;
+    XlaValue seed_ir_value;
   };
 
  public:
@@ -320,7 +319,7 @@ class XLATensor::DeviceContextArena {
     return tensors;
   }
 
-  ir::XlaValue GetRngSeed(const torch::lazy::BackendDevice& device) {
+  XlaValue GetRngSeed(const torch::lazy::BackendDevice& device) {
     static const at::ScalarType kSeedType = at::ScalarType::Long;
     static const uint64_t kSeedMul = 214013;
     static const uint64_t kSeedAdd = 2531011;
@@ -337,10 +336,10 @@ class XLATensor::DeviceContextArena {
     devctx->running_seed = kSeedAdd + kSeedMul * devctx->running_seed;
     // Compose new seeds from the root seed, to avoid creating too many XLA
     // computation parameters which might overflow the TPU capacity.
-    ir::XlaValue k = ir::ops::ScalarOp(
-        MakeIntScalar(kSeedMul), MakeXlaPrimitiveType(kSeedType, &device));
-    ir::XlaValue b = ir::ops::ScalarOp(
-        MakeIntScalar(kSeedAdd), MakeXlaPrimitiveType(kSeedType, &device));
+    XlaValue k = ScalarOp(MakeIntScalar(kSeedMul),
+                          MakeXlaPrimitiveType(kSeedType, &device));
+    XlaValue b = ScalarOp(MakeIntScalar(kSeedAdd),
+                          MakeXlaPrimitiveType(kSeedType, &device));
     devctx->seed_ir_value = b + k * devctx->seed_ir_value;
     return devctx->seed_ir_value;
   }
@@ -356,7 +355,7 @@ class XLATensor::DeviceContextArena {
     std::lock_guard<std::mutex> lock(devctx->lock);
     devctx->seed = seed;
     devctx->running_seed = devctx->seed;
-    devctx->seed_ir_value = ir::XlaValue();
+    devctx->seed_ir_value = XlaValue();
   }
 
   void MarkStep(const torch::lazy::BackendDevice& device) {
@@ -364,7 +363,7 @@ class XLATensor::DeviceContextArena {
     std::lock_guard<std::mutex> lock(devctx->lock);
     devctx->seed = 1012031 + devctx->seed * 7012063;
     devctx->running_seed = devctx->seed;
-    devctx->seed_ir_value = ir::XlaValue();
+    devctx->seed_ir_value = XlaValue();
   }
 
  private:
@@ -464,7 +463,7 @@ XLATensor XLATensor::Create(
 }
 
 XLATensor XLATensor::Create(
-    ir::XlaValue ir_value, const torch::lazy::BackendDevice& device,
+    XlaValue ir_value, const torch::lazy::BackendDevice& device,
     c10::optional<at::ScalarType> logical_element_type) {
   XLATensor xtensor(std::move(ir_value), device, logical_element_type);
   DeviceContextArena::Get()->RegisterTensor(xtensor.data_ptr());
@@ -493,7 +492,7 @@ XLATensor::XLATensor(xla::ComputationClient::DataPtr xla_data,
                                    ParseDeviceString(xla_data->device()),
                                    logical_element_type)) {}
 
-XLATensor::XLATensor(ir::XlaValue ir_value,
+XLATensor::XLATensor(XlaValue ir_value,
                      const torch::lazy::BackendDevice& device,
                      c10::optional<at::ScalarType> logical_element_type)
     : data_(std::make_shared<Data>(std::move(ir_value), device,
@@ -572,7 +571,7 @@ xla::ComputationClient::DataPtr XLATensor::GetXlaData() {
   // XLA data can coexist with a view, but we need to check that the view did
   // not receive any updates before calling the current XLA valid.
   bool up_to_date = true;
-  ir::XlaValue ir_value;
+  XlaValue ir_value;
   if (data()->view != nullptr) {
     View::IrNode ir_value_updated = GetViewUpdate(data()->view);
     up_to_date = !ir_value_updated.updated;
@@ -609,14 +608,14 @@ xla::ComputationClient::DataPtr XLATensor::CurrentXlaData() const {
 
 std::string XLATensor::DumpHloComputation(
     const std::vector<XLATensor>& tensors) {
-  std::vector<ir::XlaValue> ir_values;
+  std::vector<XlaValue> ir_values;
   for (auto& tensor : tensors) {
-    ir::XlaValue ir_value = tensor.CurrentIrValue();
+    XlaValue ir_value = tensor.CurrentIrValue();
     if (ir_value) {
       ir_values.push_back(std::move(ir_value));
     }
   }
-  return !ir_values.empty() ? ir::DumpUtil::ToHlo(ir_values, GetCurrentDevice())
+  return !ir_values.empty() ? DumpUtil::ToHlo(ir_values, GetCurrentDevice())
                             : std::string();
 }
 
@@ -629,14 +628,14 @@ void XLATensor::SetXlaData(xla::ComputationClient::DataPtr xla_data,
   data()->xla_data = std::move(xla_data);
   // Assigning a device data should always clear the IR node, to allow graph
   // trimming. A view cannot be reset though, unless we are at a step-end sync.
-  AssignIrValue(ir::XlaValue());
+  AssignIrValue(XlaValue());
   if (sync) {
     data()->view = nullptr;
     data()->tensor_data = c10::nullopt;
   }
 }
 
-void XLATensor::SetIrValue(ir::XlaValue ir_value, bool inplace) {
+void XLATensor::SetIrValue(XlaValue ir_value, bool inplace) {
   data()->xla_data = nullptr;
   data()->tensor_data = c10::nullopt;
   if (data()->view != nullptr && inplace) {
@@ -658,16 +657,16 @@ void XLATensor::SetIrValue(ir::XlaValue ir_value, bool inplace) {
   }
 }
 
-void XLATensor::SetInPlaceIrValue(ir::XlaValue ir_value) {
+void XLATensor::SetInPlaceIrValue(XlaValue ir_value) {
   auto xla_shape = shape();
   if (xla_shape.get().element_type() != ir_value.xla_shape().element_type()) {
     ir_value =
-        ir::MakeNode<ir::ops::Cast>(ir_value, xla_shape.get().element_type());
+        torch::lazy::MakeNode<Cast>(ir_value, xla_shape.get().element_type());
   }
   SetIrValue(std::move(ir_value), /*inplace=*/true);
 }
 
-void XLATensor::AssignIrValue(ir::XlaValue ir_value) const {
+void XLATensor::AssignIrValue(XlaValue ir_value) const {
   data()->ir_value = std::move(ir_value);
   data()->generation += 1;
 }
@@ -687,8 +686,8 @@ void XLATensor::TryLimitGraphSize() {
   }
 }
 
-ir::XlaValue XLATensor::GetIrValue() const {
-  ir::XlaValue ir_value = CurrentIrValue();
+XlaValue XLATensor::GetIrValue() const {
+  XlaValue ir_value = CurrentIrValue();
   if (ir_value) {
     return ir_value;
   }
@@ -709,7 +708,7 @@ ir::XlaValue XLATensor::GetIrValue() const {
   return data()->ir_value;
 }
 
-ir::XlaValue XLATensor::CurrentIrValue() const {
+XlaValue XLATensor::CurrentIrValue() const {
   if (data()->view != nullptr) {
     return GetViewUpdate(data()->view).ir_value;
   }
@@ -727,16 +726,15 @@ c10::optional<at::Tensor> XLATensor::CurrentTensorData() const {
   return data()->tensor_data;
 }
 
-ir::XlaValue XLATensor::GetIrValueForTensor(
+XlaValue XLATensor::GetIrValueForTensor(
     const at::Tensor& tensor, const torch::lazy::BackendDevice& device) const {
   xla::ComputationClient::DataPtr data;
   bool read_only = false;
   if (tensor.dim() == 0 && tensor.numel() == 1) {
     at::Scalar value = tensor.item();
     if (IsSpecialScalar(value)) {
-      return ir::ops::ScalarOp(
-          std::move(value),
-          MakeXlaPrimitiveType(tensor.scalar_type(), &device));
+      return ScalarOp(std::move(value),
+                      MakeXlaPrimitiveType(tensor.scalar_type(), &device));
     }
     data = GetDeviceData(tensor, device);
     read_only = true;
@@ -747,62 +745,61 @@ ir::XlaValue XLATensor::GetIrValueForTensor(
   return CreateTensorNode(std::move(data), read_only);
 }
 
-ir::XlaValue XLATensor::GetDeviceDataIrValue(
+XlaValue XLATensor::GetDeviceDataIrValue(
     const at::Scalar& value, xla::PrimitiveType type,
     const torch::lazy::BackendDevice& device) {
   xla::ComputationClient::DataPtr data =
       GetDeviceData(value, TensorTypeFromXlaType(type), device);
   data->SetInfo(
       std::make_shared<DeviceDataInfo>(/*tensor_id=*/-1, /*read_only=*/true));
-  return ir::MakeNode<ir::ops::DeviceData>(std::move(data));
+  return torch::lazy::MakeNode<DeviceData>(std::move(data));
 }
 
-ir::XlaValue XLATensor::GetIrValueForConstant(const at::Scalar& value,
-                                              const xla::Shape& shape) {
-  ir::XlaValue ir_value =
-      ir::ops::ScalarOp(std::move(value), shape.element_type());
+XlaValue XLATensor::GetIrValueForConstant(const at::Scalar& value,
+                                          const xla::Shape& shape) {
+  XlaValue ir_value = ScalarOp(std::move(value), shape.element_type());
   if (!shape.dimensions().empty()) {
-    ir_value = ir::MakeNode<ir::ops::Expand>(
+    ir_value = torch::lazy::MakeNode<Expand>(
         ir_value, torch::lazy::ToVector<int64_t>(shape.dimensions()));
   }
   return ir_value;
 }
 
-ir::XlaValue XLATensor::GetIrValueForScalar(
+XlaValue XLATensor::GetIrValueForScalar(
     const at::Scalar& value, xla::PrimitiveType type,
     const torch::lazy::BackendDevice& device) {
   if (IsSpecialScalar(value)) {
-    return ir::ops::ScalarOp(std::move(value), type);
+    return ScalarOp(std::move(value), type);
   }
   return GetDeviceDataIrValue(value, type, device);
 }
 
-ir::XlaValue XLATensor::GetIrValueForScalar(
+XlaValue XLATensor::GetIrValueForScalar(
     const at::Scalar& value, const torch::lazy::BackendDevice& device) {
   return GetIrValueForScalar(
       value, MakeXlaPrimitiveType(GetScalarType(value), &device), device);
 }
 
-ir::XlaValue XLATensor::GetIrValueForScalar(
+XlaValue XLATensor::GetIrValueForScalar(
     const at::Scalar& value, xla::PrimitiveType type,
     absl::Span<const int64_t> dimensions,
     const torch::lazy::BackendDevice& device) {
-  ir::XlaValue ir_value = GetIrValueForScalar(value, type, device);
+  XlaValue ir_value = GetIrValueForScalar(value, type, device);
   if (!dimensions.empty()) {
-    ir_value = ir::MakeNode<ir::ops::Expand>(
+    ir_value = torch::lazy::MakeNode<Expand>(
         ir_value, torch::lazy::ToVector<int64_t>(dimensions));
   }
   return ir_value;
 }
 
-ir::XlaValue XLATensor::GetIrValueForScalar(
+XlaValue XLATensor::GetIrValueForScalar(
     const at::Scalar& value, const xla::Shape& shape,
     const torch::lazy::BackendDevice& device) {
   return GetIrValueForScalar(value, shape.element_type(), shape.dimensions(),
                              device);
 }
 
-ir::XlaValue XLATensor::GetIrValueForScalar(
+XlaValue XLATensor::GetIrValueForScalar(
     const at::Scalar& value, const xla::Shape& shape,
     c10::optional<at::ScalarType> logical_element_type,
     const torch::lazy::BackendDevice& device) {
@@ -823,7 +820,7 @@ View::IrNode XLATensor::GetViewUpdate(const std::shared_ptr<View>& view) const {
 }
 
 std::shared_ptr<View> XLATensor::UpdateView(std::shared_ptr<View> view,
-                                            ir::XlaValue ir_value) const {
+                                            XlaValue ir_value) const {
   if (ir_value.xla_shape().dimensions() != view->shape().dimensions()) {
     XLA_CHECK_EQ(
         xla::util::Multiply<int64_t>(ir_value.xla_shape().dimensions()),
@@ -849,11 +846,11 @@ void XLATensor::ModifyCurrentView(ViewInfo view_info) const {
   }
   // This node is not a view. Since this function is meant to modify a view
   // in place, we need to turn this existing tensor into a view.
-  ir::XlaValue ir_value = GetIrValue();
+  XlaValue ir_value = GetIrValue();
   std::shared_ptr<Alias> alias = std::make_shared<Alias>(ir_value);
   data()->view =
       std::make_shared<View>(view_info.shape, alias, std::move(view_info));
-  AssignIrValue(ir::XlaValue());
+  AssignIrValue(XlaValue());
 }
 
 std::shared_ptr<View> XLATensor::CreateView(ViewInfo view_info) const {
@@ -863,13 +860,13 @@ std::shared_ptr<View> XLATensor::CreateView(ViewInfo view_info) const {
   // This node is not a view, and creating a view forks the current node into
   // becoming one itself. This means creating an alias with the current IR
   // XlaNode, and using the same alias for the created IR XlaNode.
-  ir::XlaValue ir_value = GetIrValue();
+  XlaValue ir_value = GetIrValue();
   std::shared_ptr<Alias> alias = std::make_shared<Alias>(ir_value);
   ViewInfo this_view_info(ViewInfo::Type::kNoOp, ir_value.xla_shape(),
                           ir_value.xla_shape());
   data()->view = std::make_shared<View>(ir_value.xla_shape(), alias,
                                         std::move(this_view_info));
-  AssignIrValue(ir::XlaValue());
+  AssignIrValue(XlaValue());
   return std::make_shared<View>(view_info.shape, alias, view_info);
 }
 
@@ -921,7 +918,7 @@ void XLATensor::SetTensor(at::Tensor tensor) {
   SetTensorData(tensor);
   data()->view = nullptr;
   data()->xla_data = nullptr;
-  AssignIrValue(ir::XlaValue());
+  AssignIrValue(XlaValue());
 }
 
 void XLATensor::UpdateFromTensor(at::Tensor tensor, bool sync) {
@@ -934,9 +931,9 @@ void XLATensor::UpdateFromTensor(at::Tensor tensor, bool sync) {
     at::Tensor coyped_tensor = torch::lazy::CopyTensor(tensor, dtype());
     SetTensorData(coyped_tensor);
     data()->xla_data = nullptr;
-    AssignIrValue(ir::XlaValue());
+    AssignIrValue(XlaValue());
     if (data()->view != nullptr) {
-      ir::XlaValue ir_value = GetIrValueForTensor(coyped_tensor, GetDevice());
+      XlaValue ir_value = GetIrValueForTensor(coyped_tensor, GetDevice());
       data()->view = UpdateView(data()->view, std::move(ir_value));
     }
   }
@@ -1020,7 +1017,7 @@ std::vector<at::Tensor> XLATensor::GetTensorsOpByOp(
     DebugUtil::SaveTensorsGraphInfo("GetTensorsOpByOp", *tensors,
                                     &coll.indices);
 
-    std::vector<ir::XlaValue> roots = CollectRoots(*tensors, coll.indices);
+    std::vector<XlaValue> roots = CollectRoots(*tensors, coll.indices);
     TensorCollectionBarrier(&coll);
     async_tensors_data =
         OpByOpExecutor::Get()->Execute(roots, coll.device.toString(), {});
@@ -1105,10 +1102,10 @@ std::vector<XLATensor> XLATensor::CreateTensors(
   return xla_tensors;
 }
 
-ir::XlaValue XLATensor::CreateTensorNode(xla::ComputationClient::DataPtr data,
-                                         bool read_only) const {
+XlaValue XLATensor::CreateTensorNode(xla::ComputationClient::DataPtr data,
+                                     bool read_only) const {
   data->SetInfo(std::make_shared<DeviceDataInfo>(GetUniqueId(), read_only));
-  return ir::MakeNode<ir::ops::DeviceData>(std::move(data));
+  return torch::lazy::MakeNode<DeviceData>(std::move(data));
 }
 
 std::vector<XLATensor> XLATensor::MakeOutputTensors(
@@ -1117,9 +1114,9 @@ std::vector<XLATensor> XLATensor::MakeOutputTensors(
   tensors.reserve(node->num_outputs());
   for (size_t i = 0; i < node->num_outputs(); ++i) {
     if (inherit_logical_type) {
-      tensors.push_back(CreateFrom(ir::XlaValue(node, i)));
+      tensors.push_back(CreateFrom(XlaValue(node, i)));
     } else {
-      tensors.push_back(CreateFrom(ir::XlaValue(node, i),
+      tensors.push_back(CreateFrom(XlaValue(node, i),
                                    /*logical_element_type=*/c10::nullopt));
     }
   }
@@ -1132,33 +1129,33 @@ XLATensor XLATensor::CopyTensorToDevice(
   return Create(ToTensor(/*detached=*/true), device);
 }
 
-ir::XlaValue XLATensor::MaybeCastIrValue(
-    ir::XlaValue ir_value, const torch::lazy::BackendDevice& device,
+XlaValue XLATensor::MaybeCastIrValue(
+    XlaValue ir_value, const torch::lazy::BackendDevice& device,
     c10::optional<at::ScalarType> logical_element_type) const {
   if (!logical_element_type) {
     logical_element_type = dtype_optional();
   }
   if (logical_element_type &&
       RequiresRawTypeCasting(*logical_element_type, &device)) {
-    ir_value = ir::MakeNode<ir::ops::Cast>(ir_value, *logical_element_type);
+    ir_value = torch::lazy::MakeNode<Cast>(ir_value, *logical_element_type);
   }
   return ir_value;
 }
 
-XLATensor XLATensor::CreateFrom(ir::XlaValue ir_value) const {
+XLATensor XLATensor::CreateFrom(XlaValue ir_value) const {
   ir_value = MaybeCastIrValue(std::move(ir_value), GetDevice(),
                               /*logical_element_type=*/c10::nullopt);
   return Create(std::move(ir_value), GetDevice(), dtype_optional());
 }
 
 XLATensor XLATensor::CreateFrom(
-    ir::XlaValue ir_value, const torch::lazy::BackendDevice& device) const {
+    XlaValue ir_value, const torch::lazy::BackendDevice& device) const {
   ir_value = MaybeCastIrValue(std::move(ir_value), device,
                               /*logical_element_type=*/c10::nullopt);
   return Create(std::move(ir_value), device, dtype_optional());
 }
 
-XLATensor XLATensor::CreateFrom(ir::XlaValue ir_value,
+XLATensor XLATensor::CreateFrom(XlaValue ir_value,
                                 at::ScalarType logical_element_type) const {
   ir_value =
       MaybeCastIrValue(std::move(ir_value), GetDevice(), logical_element_type);
@@ -1166,14 +1163,14 @@ XLATensor XLATensor::CreateFrom(ir::XlaValue ir_value,
 }
 
 XLATensor XLATensor::CreateFrom(
-    ir::XlaValue ir_value,
+    XlaValue ir_value,
     c10::optional<at::ScalarType> logical_element_type_opt) const {
   ir_value = MaybeCastIrValue(std::move(ir_value), GetDevice(),
                               logical_element_type_opt);
   return Create(std::move(ir_value), GetDevice(), logical_element_type_opt);
 }
 
-XLATensor XLATensor::CreateFrom(ir::XlaValue ir_value,
+XLATensor XLATensor::CreateFrom(XlaValue ir_value,
                                 const torch::lazy::BackendDevice& device,
                                 at::ScalarType logical_element_type) const {
   ir_value =
@@ -1221,7 +1218,7 @@ XLATensor::SyncTensorCollection XLATensor::CollectSyncTensors(
   for (size_t i = 0; i < tensors.size(); ++i) {
     if (tensor_ids.insert(tensors[i].GetUniqueId()).second &&
         tensors[i].CurrentXlaData() == nullptr) {
-      ir::XlaValue ir_value = tensors[i].CurrentIrValue();
+      XlaValue ir_value = tensors[i].CurrentIrValue();
       if (ir_value) {
         if (ShouldSyncIrValue(ir_value)) {
           // Add only tensors which need to be synced.
@@ -1310,16 +1307,16 @@ XLATensor::PostOrderData XLATensor::RunPostOrder(
   std::vector<const torch::lazy::Node*> roots;
   roots.reserve(indices.size());
   for (auto index : indices) {
-    ir::XlaValue ir_value = tensors.at(index).CurrentIrValue();
+    XlaValue ir_value = tensors.at(index).CurrentIrValue();
     roots.push_back(ir_value.node.get());
   }
   PostOrderData po_data;
-  po_data.post_order = ir::Util::ComputePostOrder(roots, &po_data.emission_map);
+  po_data.post_order = Util::ComputePostOrder(roots, &po_data.emission_map);
   std::unordered_map<xla::ComputationClient::Data::OpaqueHandle, size_t>
       data_handles;
 
   for (auto node : po_data.post_order) {
-    const ir::ops::DeviceData* device_data = ir::ops::DeviceData::Cast(node);
+    const DeviceData* device_data = DeviceData::Cast(node);
     if (device_data != nullptr) {
       /* Acceptable race condition: HasValue may return false. This is OK
        * since the conditional barrier is a performance optimization. */
@@ -1341,9 +1338,9 @@ XLATensor::PostOrderData XLATensor::RunPostOrder(
   return po_data;
 }
 
-std::vector<ir::XlaValue> XLATensor::CollectRoots(
+std::vector<XlaValue> XLATensor::CollectRoots(
     const std::vector<XLATensor>& tensors, absl::Span<const size_t> indices) {
-  std::vector<ir::XlaValue> roots;
+  std::vector<XlaValue> roots;
   roots.reserve(indices.size());
   for (auto index : indices) {
     roots.push_back(tensors.at(index).CurrentIrValue());
@@ -1483,7 +1480,7 @@ void XLATensor::SyncLiveTensorsGraph(const torch::lazy::BackendDevice* device,
 void XLATensor::MarkStep(const torch::lazy::BackendDevice& device) {
   XLA_COUNTER("MarkStep", 1);
   DeviceContextArena::Get()->MarkStep(device);
-  ir::ScopePusher::ResetScopes();
+  ScopePusher::ResetScopes();
   g_tls_data.Reset();
 }
 
@@ -1510,7 +1507,7 @@ XLATensor::OpByOpAsync XLATensor::SyncTensorsGraphOpByOp(
   struct Async {
     explicit Async(SyncTensorCollection coll,
                    std::vector<xla::ComputationClient::DataPtr> tensors_data,
-                   std::vector<ir::XlaValue> roots,
+                   std::vector<XlaValue> roots,
                    absl::Span<const std::string> devices)
         : coll(std::move(coll)),
           tensors_data(std::move(tensors_data)),
@@ -1519,7 +1516,7 @@ XLATensor::OpByOpAsync XLATensor::SyncTensorsGraphOpByOp(
 
     SyncTensorCollection coll;
     std::vector<xla::ComputationClient::DataPtr> tensors_data;
-    std::vector<ir::XlaValue> roots;
+    std::vector<XlaValue> roots;
     std::vector<std::string> devices;
   };
 
@@ -1527,7 +1524,7 @@ XLATensor::OpByOpAsync XLATensor::SyncTensorsGraphOpByOp(
   DebugUtil::SaveTensorsGraphInfo("SyncTensorsGraphOpByOp", *tensors,
                                   &coll.indices);
 
-  std::vector<ir::XlaValue> roots = CollectRoots(*tensors, coll.indices);
+  std::vector<XlaValue> roots = CollectRoots(*tensors, coll.indices);
   auto tensors_data = FetchTensorData(tensors, coll.config, coll.indices);
   TensorCollectionBarrier(&coll);
   auto async = std::make_shared<Async>(std::move(coll), std::move(tensors_data),
@@ -1564,7 +1561,7 @@ XLATensor::OpByOpAsync XLATensor::SyncTensorsGraphOpByOp(
 
 void XLATensor::BuildInputOutputAliases(const std::vector<XLATensor>& tensors,
                                         absl::Span<const size_t> indices,
-                                        ir::LoweringContext* lowering_ctx) {
+                                        LoweringContext* lowering_ctx) {
   std::unordered_map<int64_t, size_t> output_tensor_id_map;
   for (size_t i = 0; i < indices.size(); ++i) {
     size_t tensor_index = indices[i];
@@ -1611,11 +1608,11 @@ XLATensor::CompilationResult XLATensor::Compile(
       tensorflow::profiler::TraceMeLevel::kInfo);
   static const bool enable_aliasing =
       xla::sys_util::GetEnvBool("XLA_ENABLE_PARAM_ALIASING", true);
-  ir::LoweringContext lowering_ctx("SyncTensorsGraph", coll.device,
-                                   po_data->post_order,
-                                   std::move(po_data->emission_map));
+  LoweringContext lowering_ctx("SyncTensorsGraph", coll.device,
+                               po_data->post_order,
+                               std::move(po_data->emission_map));
   for (auto index : coll.indices) {
-    ir::XlaValue ir_value = tensors[index].CurrentIrValue();
+    XlaValue ir_value = tensors[index].CurrentIrValue();
     xla::XlaOp root = lowering_ctx.GetOutputOp(
         torch::lazy::Output(ir_value.node.get(), ir_value.index));
     lowering_ctx.AddResult(root);
@@ -1726,7 +1723,7 @@ int64_t XLATensor::GetNextTensorId() {
   return id_generator->fetch_add(1);
 }
 
-ir::XlaValue XLATensor::GetRngSeed(const torch::lazy::BackendDevice& device) {
+XlaValue XLATensor::GetRngSeed(const torch::lazy::BackendDevice& device) {
   return DeviceContextArena::Get()->GetRngSeed(device);
 }
 
@@ -1749,7 +1746,7 @@ bool XLATensor::ShouldSyncIrNode() {
   if (!this->data()->ir_value) {
     return false;
   }
-  return this->data()->ir_value->op() != ir::ops::xla_device_data;
+  return this->data()->ir_value->op() != xla_device_data;
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -962,6 +962,8 @@ class XLATensor {
   static XLATensor randperm(int64_t n, const torch::lazy::BackendDevice& device,
                             at::ScalarType scalar_type);
 
+  static void randperm_out(int64_t n, XLATensor& out);
+
   static XLATensor reciprocal(const XLATensor& input);
 
   static XLATensor reflection_pad2d(const XLATensor& input,

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -37,7 +37,7 @@ class XLATensor {
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
 
   static XLATensor Create(
-      ir::XlaValue ir_value, const torch::lazy::BackendDevice& device,
+      XlaValue ir_value, const torch::lazy::BackendDevice& device,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
 
   // Creates an empty/null tensor.
@@ -90,12 +90,12 @@ class XLATensor {
 
   // Retrieves the current IR XlaNode, or nullptr in case no active IR XlaNode
   // is available.
-  ir::XlaValue CurrentIrValue() const;
+  XlaValue CurrentIrValue() const;
 
   // Retrieves the IR XlaNode representing this XLATensor. One will be created
   // if missing. Note that although this is a const API, it actually changes the
   // internal state ofthe object.
-  ir::XlaValue GetIrValue() const;
+  XlaValue GetIrValue() const;
 
   c10::optional<at::Tensor> CurrentTensorData() const;
 
@@ -122,31 +122,31 @@ class XLATensor {
   // that is affected by the view tensor.
   static void ApplyEagerSync(std::vector<XLATensor>& tensors);
 
-  static ir::XlaValue GetDeviceDataIrValue(
+  static XlaValue GetDeviceDataIrValue(
       const at::Scalar& value, xla::PrimitiveType type,
       const torch::lazy::BackendDevice& device);
   // Use with caution, constant will cause more frequent recompilation
   // compared to the device_data.
-  static ir::XlaValue GetIrValueForConstant(const at::Scalar& value,
-                                            const xla::Shape& shape);
-  static ir::XlaValue GetIrValueForScalar(
-      const at::Scalar& value, xla::PrimitiveType type,
-      const torch::lazy::BackendDevice& device);
-  static ir::XlaValue GetIrValueForScalar(
-      const at::Scalar& value, const torch::lazy::BackendDevice& device);
-  static ir::XlaValue GetIrValueForScalar(
-      const at::Scalar& value, xla::PrimitiveType type,
-      absl::Span<const int64_t> dimensions,
-      const torch::lazy::BackendDevice& device);
-  static ir::XlaValue GetIrValueForScalar(
-      const at::Scalar& value, const xla::Shape& shape,
-      const torch::lazy::BackendDevice& device);
-  static ir::XlaValue GetIrValueForScalar(
+  static XlaValue GetIrValueForConstant(const at::Scalar& value,
+                                        const xla::Shape& shape);
+  static XlaValue GetIrValueForScalar(const at::Scalar& value,
+                                      xla::PrimitiveType type,
+                                      const torch::lazy::BackendDevice& device);
+  static XlaValue GetIrValueForScalar(const at::Scalar& value,
+                                      const torch::lazy::BackendDevice& device);
+  static XlaValue GetIrValueForScalar(const at::Scalar& value,
+                                      xla::PrimitiveType type,
+                                      absl::Span<const int64_t> dimensions,
+                                      const torch::lazy::BackendDevice& device);
+  static XlaValue GetIrValueForScalar(const at::Scalar& value,
+                                      const xla::Shape& shape,
+                                      const torch::lazy::BackendDevice& device);
+  static XlaValue GetIrValueForScalar(
       const at::Scalar& value, const xla::Shape& shape,
       c10::optional<at::ScalarType> logical_element_type,
       const torch::lazy::BackendDevice& device);
 
-  static ir::XlaValue GetRngSeed(const torch::lazy::BackendDevice& device);
+  static XlaValue GetRngSeed(const torch::lazy::BackendDevice& device);
 
   static void SetRngSeed(const torch::lazy::BackendDevice& device,
                          uint64_t seed);
@@ -212,52 +212,51 @@ class XLATensor {
   //////////////////////////////////////////////////////////////////////////////
   // XLA dedicated operators follows here, listed in alphabetical order.
   //////////////////////////////////////////////////////////////////////////////
-  static std::pair<XLATensor, ir::XlaValue> all_reduce(
-      const XLATensor& input, const ir::XlaValue& token,
-      AllReduceType reduce_type, double scale,
+  static std::pair<XLATensor, XlaValue> all_reduce(
+      const XLATensor& input, const XlaValue& token, AllReduceType reduce_type,
+      double scale, std::vector<std::vector<int64_t>> groups, bool pin_layout);
+
+  static XlaValue all_reduce_(XLATensor& input, const XlaValue& token,
+                              AllReduceType reduce_type, double scale,
+                              std::vector<std::vector<int64_t>> groups,
+                              bool pin_layout);
+
+  static XlaValue all_reduce(std::vector<XLATensor>* inputs,
+                             const XlaValue& token, AllReduceType reduce_type,
+                             double scale,
+                             std::vector<std::vector<int64_t>> groups,
+                             bool pin_layout);
+
+  static std::pair<XLATensor, XlaValue> reduce_scatter(
+      const XLATensor& input, const XlaValue& token, AllReduceType reduce_type,
+      double scale, int64_t scatter_dim, int64_t shard_count,
       std::vector<std::vector<int64_t>> groups, bool pin_layout);
 
-  static ir::XlaValue all_reduce_(XLATensor& input, const ir::XlaValue& token,
-                                  AllReduceType reduce_type, double scale,
-                                  std::vector<std::vector<int64_t>> groups,
-                                  bool pin_layout);
-
-  static ir::XlaValue all_reduce(std::vector<XLATensor>* inputs,
-                                 const ir::XlaValue& token,
-                                 AllReduceType reduce_type, double scale,
-                                 std::vector<std::vector<int64_t>> groups,
-                                 bool pin_layout);
-
-  static std::pair<XLATensor, ir::XlaValue> reduce_scatter(
-      const XLATensor& input, const ir::XlaValue& token,
-      AllReduceType reduce_type, double scale, int64_t scatter_dim,
-      int64_t shard_count, std::vector<std::vector<int64_t>> groups,
-      bool pin_layout);
-
-  static ir::XlaValue reduce_scatter_out(
-      XLATensor& output, const XLATensor& input, const ir::XlaValue& token,
-      AllReduceType reduce_type, double scale, int64_t scatter_dim,
-      int64_t shard_count, std::vector<std::vector<int64_t>> groups,
-      bool pin_layout);
-
-  static std::pair<XLATensor, ir::XlaValue> all_to_all(
-      const XLATensor& input, const ir::XlaValue& token,
-      int64_t split_dimension, int64_t concat_dimension, int64_t split_count,
-      std::vector<std::vector<int64_t>> groups, bool pin_layout);
-
-  static std::pair<XLATensor, ir::XlaValue> all_gather(
-      const XLATensor& input, const ir::XlaValue& token, int64_t dim,
-      int64_t shard_count, std::vector<std::vector<int64_t>> groups,
-      bool pin_layout);
-
-  static ir::XlaValue all_gather_out(XLATensor& output, const XLATensor& input,
-                                     const ir::XlaValue& token, int64_t dim,
-                                     int64_t shard_count,
+  static XlaValue reduce_scatter_out(XLATensor& output, const XLATensor& input,
+                                     const XlaValue& token,
+                                     AllReduceType reduce_type, double scale,
+                                     int64_t scatter_dim, int64_t shard_count,
                                      std::vector<std::vector<int64_t>> groups,
                                      bool pin_layout);
 
-  static std::pair<XLATensor, ir::XlaValue> collective_permute(
-      const XLATensor& input, const ir::XlaValue& token,
+  static std::pair<XLATensor, XlaValue> all_to_all(
+      const XLATensor& input, const XlaValue& token, int64_t split_dimension,
+      int64_t concat_dimension, int64_t split_count,
+      std::vector<std::vector<int64_t>> groups, bool pin_layout);
+
+  static std::pair<XLATensor, XlaValue> all_gather(
+      const XLATensor& input, const XlaValue& token, int64_t dim,
+      int64_t shard_count, std::vector<std::vector<int64_t>> groups,
+      bool pin_layout);
+
+  static XlaValue all_gather_out(XLATensor& output, const XLATensor& input,
+                                 const XlaValue& token, int64_t dim,
+                                 int64_t shard_count,
+                                 std::vector<std::vector<int64_t>> groups,
+                                 bool pin_layout);
+
+  static std::pair<XLATensor, XlaValue> collective_permute(
+      const XLATensor& input, const XlaValue& token,
       std::vector<std::pair<int64_t, int64_t>> source_target_pairs);
 
   static XLATensor get_dimensions_size(const XLATensor& input,
@@ -1302,7 +1301,7 @@ class XLATensor {
           logical_element_type(logical_element_type),
           device(device),
           unique_id(GetNextTensorId()) {}
-    Data(ir::XlaValue ir_value, const torch::lazy::BackendDevice& device,
+    Data(XlaValue ir_value, const torch::lazy::BackendDevice& device,
          c10::optional<at::ScalarType> logical_element_type)
         : ir_value(std::move(ir_value)),
           logical_element_type(logical_element_type),
@@ -1323,7 +1322,7 @@ class XLATensor {
     ~Data();
 
     xla::ComputationClient::DataPtr xla_data;
-    ir::XlaValue ir_value;
+    XlaValue ir_value;
     std::shared_ptr<View> view;
     c10::optional<at::ScalarType> logical_element_type;
     c10::optional<at::Tensor> tensor_data;
@@ -1335,7 +1334,7 @@ class XLATensor {
   XLATensor(const at::Tensor& tensor, const torch::lazy::BackendDevice& device);
   XLATensor(xla::ComputationClient::DataPtr xla_data,
             c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
-  XLATensor(ir::XlaValue ir_value, const torch::lazy::BackendDevice& device,
+  XLATensor(XlaValue ir_value, const torch::lazy::BackendDevice& device,
             c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
   XLATensor(std::shared_ptr<View> view,
             const torch::lazy::BackendDevice& device,
@@ -1352,20 +1351,20 @@ class XLATensor {
 
   void SetXlaData(xla::ComputationClient::DataPtr xla_data, bool sync);
 
-  void SetIrValue(ir::XlaValue ir_value, bool inplace = true);
-  void SetInPlaceIrValue(ir::XlaValue ir_value);
+  void SetIrValue(XlaValue ir_value, bool inplace = true);
+  void SetInPlaceIrValue(XlaValue ir_value);
 
-  void AssignIrValue(ir::XlaValue ir_value) const;
+  void AssignIrValue(XlaValue ir_value) const;
 
   void SetTensorData(at::Tensor tensor_data);
 
-  ir::XlaValue CreateTensorNode(xla::ComputationClient::DataPtr data,
-                                bool read_only) const;
+  XlaValue CreateTensorNode(xla::ComputationClient::DataPtr data,
+                            bool read_only) const;
 
   View::IrNode GetViewUpdate(const std::shared_ptr<View>& view) const;
 
   std::shared_ptr<View> UpdateView(std::shared_ptr<View> view,
-                                   ir::XlaValue ir_value) const;
+                                   XlaValue ir_value) const;
 
   void SetSubView(ViewInfo view_info) const;
   void ModifyCurrentView(ViewInfo view_info) const;
@@ -1374,21 +1373,21 @@ class XLATensor {
 
   XLATensor CopyTensorToDevice(const torch::lazy::BackendDevice& device);
 
-  ir::XlaValue MaybeCastIrValue(
-      ir::XlaValue ir_value, const torch::lazy::BackendDevice& device,
+  XlaValue MaybeCastIrValue(
+      XlaValue ir_value, const torch::lazy::BackendDevice& device,
       c10::optional<at::ScalarType> logical_element_type) const;
 
   // Create a new XLA tensor with the same metadata of the input tensor (with
   // possible overrides), and the new IR value.
-  XLATensor CreateFrom(ir::XlaValue ir_value) const;
-  XLATensor CreateFrom(ir::XlaValue ir_value,
+  XLATensor CreateFrom(XlaValue ir_value) const;
+  XLATensor CreateFrom(XlaValue ir_value,
                        const torch::lazy::BackendDevice& device) const;
-  XLATensor CreateFrom(ir::XlaValue ir_value,
+  XLATensor CreateFrom(XlaValue ir_value,
                        at::ScalarType logical_element_type) const;
   XLATensor CreateFrom(
-      ir::XlaValue ir_value,
+      XlaValue ir_value,
       c10::optional<at::ScalarType> logical_element_type_opt) const;
-  XLATensor CreateFrom(ir::XlaValue ir_value,
+  XLATensor CreateFrom(XlaValue ir_value,
                        const torch::lazy::BackendDevice& device,
                        at::ScalarType logical_element_type) const;
 
@@ -1402,8 +1401,8 @@ class XLATensor {
   std::vector<XLATensor> MakeOutputTensors(
       torch::lazy::NodePtr node, bool inherit_logical_type = true) const;
 
-  ir::XlaValue GetIrValueForTensor(
-      const at::Tensor& tensor, const torch::lazy::BackendDevice& device) const;
+  XlaValue GetIrValueForTensor(const at::Tensor& tensor,
+                               const torch::lazy::BackendDevice& device) const;
 
   static ComputationCache* GetComputationCache();
 
@@ -1432,7 +1431,7 @@ class XLATensor {
       const std::vector<XLATensor>& tensors, absl::Span<const size_t> indices,
       absl::Span<const xla::ComputationClient::DataPtr> tensors_data);
 
-  static std::vector<ir::XlaValue> CollectRoots(
+  static std::vector<XlaValue> CollectRoots(
       const std::vector<XLATensor>& tensors, absl::Span<const size_t> indices);
 
   static std::vector<xla::ComputationClient::DataPtr> FetchTensorData(
@@ -1469,7 +1468,7 @@ class XLATensor {
 
   static void BuildInputOutputAliases(const std::vector<XLATensor>& tensors,
                                       absl::Span<const size_t> indices,
-                                      ir::LoweringContext* lowering_ctx);
+                                      LoweringContext* lowering_ctx);
 
   static CompilationResult Compile(const std::vector<XLATensor>& tensors,
                                    absl::Span<const std::string> devices,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2282,8 +2282,8 @@ void XLATensor::random_(XLATensor& input, int64_t from, int64_t to) {
 }
 
 void XLATensor::randperm_out(int64_t n, XLATensor& out) {
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::RandpermOut>(n);
-  out.SetInPlaceIrValue(ir::Value(node));
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<ir::ops::RandpermOut>(n);
+  out.SetInPlaceIrValue(XlaValue(node));
 }
 
 XLATensor XLATensor::reciprocal(const XLATensor& input) {

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -103,6 +103,7 @@
 #include "torch_xla/csrc/ops/prod.h"
 #include "torch_xla/csrc/ops/put.h"
 #include "torch_xla/csrc/ops/qr.h"
+#include "torch_xla/csrc/ops/randperm_out.h"
 #include "torch_xla/csrc/ops/reduce_scatter.h"
 #include "torch_xla/csrc/ops/reflection_pad2d.h"
 #include "torch_xla/csrc/ops/reflection_pad2d_backward.h"
@@ -2304,6 +2305,11 @@ void XLATensor::random_(XLATensor& input, int64_t from, int64_t to) {
       GetIrValueForScalar(from, xla::PrimitiveType::S64, input.GetDevice()),
       GetIrValueForScalar(to, xla::PrimitiveType::S64, input.GetDevice()),
       GetRngSeed(input.GetDevice()), input_shape));
+}
+
+void XLATensor::randperm_out(int64_t n, XLATensor& out) {
+  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::RandpermOut>(n);
+  out.SetInPlaceIrValue(ir::Value(node));
 }
 
 XLATensor XLATensor::reciprocal(const XLATensor& input) {

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -154,16 +154,15 @@ namespace torch_xla {
 namespace {
 
 struct MinMaxValues {
-  ir::XlaValue min;
-  ir::XlaValue max;
+  XlaValue min;
+  XlaValue max;
 };
 
-ir::XlaValue MaybeExpand(const ir::XlaValue& input,
-                         const xla::Shape& target_shape) {
+XlaValue MaybeExpand(const XlaValue& input, const xla::Shape& target_shape) {
   if (input.xla_shape().dimensions() == target_shape.dimensions()) {
     return input;
   }
-  return ir::MakeNode<ir::ops::Expand>(
+  return torch::lazy::MakeNode<Expand>(
       input, torch::lazy::ToVector<int64_t>(target_shape.dimensions()));
 }
 
@@ -278,10 +277,10 @@ xla::Shape BatchNormFeaturesShape(const XLATensor& input) {
 
 // Returns the IR for the given input or the provided default value broadcasted
 // to the default shape, if the input is undefined.
-ir::XlaValue GetIrValueOrDefault(const XLATensor& input,
-                                 const at::Scalar& default_value,
-                                 const xla::Shape& default_shape,
-                                 const torch::lazy::BackendDevice& device) {
+XlaValue GetIrValueOrDefault(const XLATensor& input,
+                             const at::Scalar& default_value,
+                             const xla::Shape& default_shape,
+                             const torch::lazy::BackendDevice& device) {
   return input.is_null() ? XLATensor::GetIrValueForScalar(default_value,
                                                           default_shape, device)
                          : input.GetIrValue();
@@ -289,26 +288,25 @@ ir::XlaValue GetIrValueOrDefault(const XLATensor& input,
 
 // Returns the IR for the given input. If the IR is not a floating point value,
 // cast it to the float_type.
-ir::XlaValue GetFloatingIrValue(const XLATensor& input,
-                                at::ScalarType float_type) {
-  ir::XlaValue input_value = input.GetIrValue();
+XlaValue GetFloatingIrValue(const XLATensor& input, at::ScalarType float_type) {
+  XlaValue input_value = input.GetIrValue();
   if (xla::primitive_util::IsIntegralType(
           input_value.xla_shape().element_type())) {
-    input_value = ir::MakeNode<ir::ops::Cast>(input_value, float_type);
+    input_value = torch::lazy::MakeNode<Cast>(input_value, float_type);
   }
   return input_value;
 }
 
-ir::XlaValue GetBooleanIrValue(ir::XlaValue input_value) {
+XlaValue GetBooleanIrValue(XlaValue input_value) {
   if (input_value.xla_shape().element_type() != xla::PrimitiveType::PRED) {
     input_value =
-        ir::MakeNode<ir::ops::Cast>(input_value, xla::PrimitiveType::PRED);
+        torch::lazy::MakeNode<Cast>(input_value, xla::PrimitiveType::PRED);
   }
   return input_value;
 }
 
-absl::optional<ir::XlaValue> GetOptionalIrValue(const XLATensor& tensor) {
-  absl::optional<ir::XlaValue> value;
+absl::optional<XlaValue> GetOptionalIrValue(const XLATensor& tensor) {
+  absl::optional<XlaValue> value;
   if (!tensor.is_null()) {
     value = tensor.GetIrValue();
   }
@@ -343,112 +341,111 @@ ViewInfo CreateAsStridedViewInfo(const xla::Shape& input_shape,
 //////////////////////////////////////////////////////////////////////////////
 // XLA dedicated operators follows here, listed in alphabetical order.
 //////////////////////////////////////////////////////////////////////////////
-std::pair<XLATensor, ir::XlaValue> XLATensor::all_reduce(
-    const XLATensor& input, const ir::XlaValue& token,
-    AllReduceType reduce_type, double scale,
-    std::vector<std::vector<int64_t>> groups, bool pin_layout) {
-  std::vector<ir::XlaValue> input_values({input.GetIrValue()});
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::AllReduce>(
+std::pair<XLATensor, XlaValue> XLATensor::all_reduce(
+    const XLATensor& input, const XlaValue& token, AllReduceType reduce_type,
+    double scale, std::vector<std::vector<int64_t>> groups, bool pin_layout) {
+  std::vector<XlaValue> input_values({input.GetIrValue()});
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<AllReduce>(
       reduce_type, input_values, token, scale, std::move(groups), pin_layout);
-  return {input.CreateFrom(ir::XlaValue(node, 0)), ir::XlaValue(node, 1)};
+  return {input.CreateFrom(XlaValue(node, 0)), XlaValue(node, 1)};
 }
 
-ir::XlaValue XLATensor::all_reduce_(XLATensor& input, const ir::XlaValue& token,
-                                    AllReduceType reduce_type, double scale,
-                                    std::vector<std::vector<int64_t>> groups,
-                                    bool pin_layout) {
-  std::vector<ir::XlaValue> input_values({input.GetIrValue()});
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::AllReduce>(
+XlaValue XLATensor::all_reduce_(XLATensor& input, const XlaValue& token,
+                                AllReduceType reduce_type, double scale,
+                                std::vector<std::vector<int64_t>> groups,
+                                bool pin_layout) {
+  std::vector<XlaValue> input_values({input.GetIrValue()});
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<AllReduce>(
       reduce_type, input_values, token, scale, std::move(groups), pin_layout);
-  input.SetInPlaceIrValue(ir::XlaValue(node, 0));
-  return ir::XlaValue(node, 1);
+  input.SetInPlaceIrValue(XlaValue(node, 0));
+  return XlaValue(node, 1);
 }
 
-ir::XlaValue XLATensor::all_reduce(std::vector<XLATensor>* inputs,
-                                   const ir::XlaValue& token,
-                                   AllReduceType reduce_type, double scale,
-                                   std::vector<std::vector<int64_t>> groups,
-                                   bool pin_layout) {
-  std::vector<ir::XlaValue> input_values;
+XlaValue XLATensor::all_reduce(std::vector<XLATensor>* inputs,
+                               const XlaValue& token, AllReduceType reduce_type,
+                               double scale,
+                               std::vector<std::vector<int64_t>> groups,
+                               bool pin_layout) {
+  std::vector<XlaValue> input_values;
   input_values.reserve(inputs->size());
   for (auto& input : *inputs) {
     input_values.push_back(input.GetIrValue());
   }
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::AllReduce>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<AllReduce>(
       reduce_type, input_values, token, scale, std::move(groups), pin_layout);
   for (size_t i = 0; i < inputs->size(); ++i) {
-    (*inputs)[i].SetInPlaceIrValue(ir::XlaValue(node, i));
+    (*inputs)[i].SetInPlaceIrValue(XlaValue(node, i));
   }
-  return ir::XlaValue(node, inputs->size());
+  return XlaValue(node, inputs->size());
 }
 
-std::pair<XLATensor, ir::XlaValue> XLATensor::reduce_scatter(
-    const XLATensor& input, const ir::XlaValue& token,
-    AllReduceType reduce_type, double scale, int64_t scatter_dim,
-    int64_t shard_count, std::vector<std::vector<int64_t>> groups,
-    bool pin_layout) {
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::ReduceScatter>(
-      reduce_type, input.GetIrValue(), token, scale, scatter_dim, shard_count,
-      std::move(groups), pin_layout);
-  return {input.CreateFrom(ir::XlaValue(node, 0)), ir::XlaValue(node, 1)};
-}
-
-ir::XlaValue XLATensor::reduce_scatter_out(
-    XLATensor& output, const XLATensor& input, const ir::XlaValue& token,
-    AllReduceType reduce_type, double scale, int64_t scatter_dim,
-    int64_t shard_count, std::vector<std::vector<int64_t>> groups,
-    bool pin_layout) {
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::ReduceScatter>(
-      reduce_type, input.GetIrValue(), token, scale, scatter_dim, shard_count,
-      std::move(groups), pin_layout);
-  output.SetIrValue(ir::XlaValue(node, 0));
-  return ir::XlaValue(node, 1);
-}
-
-std::pair<XLATensor, ir::XlaValue> XLATensor::all_to_all(
-    const XLATensor& input, const ir::XlaValue& token, int64_t split_dimension,
-    int64_t concat_dimension, int64_t split_count,
+std::pair<XLATensor, XlaValue> XLATensor::reduce_scatter(
+    const XLATensor& input, const XlaValue& token, AllReduceType reduce_type,
+    double scale, int64_t scatter_dim, int64_t shard_count,
     std::vector<std::vector<int64_t>> groups, bool pin_layout) {
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::AllToAll>(
-      input.GetIrValue(), token, split_dimension, concat_dimension, split_count,
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<ReduceScatter>(
+      reduce_type, input.GetIrValue(), token, scale, scatter_dim, shard_count,
       std::move(groups), pin_layout);
-  return {input.CreateFrom(ir::XlaValue(node, 0)), ir::XlaValue(node, 1)};
+  return {input.CreateFrom(XlaValue(node, 0)), XlaValue(node, 1)};
 }
 
-std::pair<XLATensor, ir::XlaValue> XLATensor::all_gather(
-    const XLATensor& input, const ir::XlaValue& token, int64_t dim,
-    int64_t shard_count, std::vector<std::vector<int64_t>> groups,
-    bool pin_layout) {
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::AllGather>(
-      input.GetIrValue(), token, dim, shard_count, std::move(groups),
-      pin_layout);
-  return {input.CreateFrom(ir::XlaValue(node, 0)), ir::XlaValue(node, 1)};
-}
-
-ir::XlaValue XLATensor::all_gather_out(XLATensor& output,
+XlaValue XLATensor::reduce_scatter_out(XLATensor& output,
                                        const XLATensor& input,
-                                       const ir::XlaValue& token, int64_t dim,
-                                       int64_t shard_count,
+                                       const XlaValue& token,
+                                       AllReduceType reduce_type, double scale,
+                                       int64_t scatter_dim, int64_t shard_count,
                                        std::vector<std::vector<int64_t>> groups,
                                        bool pin_layout) {
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::AllGather>(
-      input.GetIrValue(), token, dim, shard_count, std::move(groups),
-      pin_layout);
-  output.SetIrValue(ir::XlaValue(node, 0));
-  return ir::XlaValue(node, 1);
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<ReduceScatter>(
+      reduce_type, input.GetIrValue(), token, scale, scatter_dim, shard_count,
+      std::move(groups), pin_layout);
+  output.SetIrValue(XlaValue(node, 0));
+  return XlaValue(node, 1);
 }
 
-std::pair<XLATensor, ir::XlaValue> XLATensor::collective_permute(
-    const XLATensor& input, const ir::XlaValue& token,
+std::pair<XLATensor, XlaValue> XLATensor::all_to_all(
+    const XLATensor& input, const XlaValue& token, int64_t split_dimension,
+    int64_t concat_dimension, int64_t split_count,
+    std::vector<std::vector<int64_t>> groups, bool pin_layout) {
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<AllToAll>(
+      input.GetIrValue(), token, split_dimension, concat_dimension, split_count,
+      std::move(groups), pin_layout);
+  return {input.CreateFrom(XlaValue(node, 0)), XlaValue(node, 1)};
+}
+
+std::pair<XLATensor, XlaValue> XLATensor::all_gather(
+    const XLATensor& input, const XlaValue& token, int64_t dim,
+    int64_t shard_count, std::vector<std::vector<int64_t>> groups,
+    bool pin_layout) {
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<AllGather>(
+      input.GetIrValue(), token, dim, shard_count, std::move(groups),
+      pin_layout);
+  return {input.CreateFrom(XlaValue(node, 0)), XlaValue(node, 1)};
+}
+
+XlaValue XLATensor::all_gather_out(XLATensor& output, const XLATensor& input,
+                                   const XlaValue& token, int64_t dim,
+                                   int64_t shard_count,
+                                   std::vector<std::vector<int64_t>> groups,
+                                   bool pin_layout) {
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<AllGather>(
+      input.GetIrValue(), token, dim, shard_count, std::move(groups),
+      pin_layout);
+  output.SetIrValue(XlaValue(node, 0));
+  return XlaValue(node, 1);
+}
+
+std::pair<XLATensor, XlaValue> XLATensor::collective_permute(
+    const XLATensor& input, const XlaValue& token,
     std::vector<std::pair<int64_t, int64_t>> source_target_pairs) {
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::CollectivePermute>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<CollectivePermute>(
       input.GetIrValue(), token, std::move(source_target_pairs));
-  return {input.CreateFrom(ir::XlaValue(node, 0)), ir::XlaValue(node, 1)};
+  return {input.CreateFrom(XlaValue(node, 0)), XlaValue(node, 1)};
 }
 
 XLATensor XLATensor::get_dimensions_size(const XLATensor& input,
                                          std::vector<int64_t> dimensions) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::GetDimensionsSize>(
+  return input.CreateFrom(torch::lazy::MakeNode<GetDimensionsSize>(
                               input.GetIrValue(), std::move(dimensions)),
                           at::ScalarType::Int);
 }
@@ -459,23 +456,23 @@ void XLATensor::sgd_optimizer_step_(const XLATensor& found_inf, XLATensor& step,
                                     double momentum, double lr,
                                     double dampening, bool nesterov,
                                     bool maximize) {
-  ir::XlaValue weight_decay_value =
+  XlaValue weight_decay_value =
       GetIrValueForScalar(weight_decay, param.shape(), param.GetDevice());
-  ir::XlaValue momentum_value =
+  XlaValue momentum_value =
       GetIrValueForScalar(momentum, param.shape(), param.GetDevice());
-  ir::XlaValue lr_value = GetIrValueForScalar(maximize ? -lr : lr,
-                                              param.shape(), param.GetDevice());
-  ir::XlaValue dampening_value =
+  XlaValue lr_value = GetIrValueForScalar(maximize ? -lr : lr, param.shape(),
+                                          param.GetDevice());
+  XlaValue dampening_value =
       GetIrValueForScalar(dampening, param.shape(), param.GetDevice());
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::SgdOptimizerStep>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<SgdOptimizerStep>(
       found_inf.GetIrValue(), step.GetIrValue(), param.GetIrValue(),
       buf.GetIrValue(), d_p.GetIrValue(), weight_decay_value, momentum_value,
       lr_value, dampening_value,
       /*use_weight_decay=*/weight_decay != 0,
       /*use_momentum=*/momentum != 0, /*use_nesterov=*/nesterov);
-  step.SetInPlaceIrValue(ir::XlaValue(node, 0));
-  param.SetInPlaceIrValue(ir::XlaValue(node, 1));
-  buf.SetInPlaceIrValue(ir::XlaValue(node, 2));
+  step.SetInPlaceIrValue(XlaValue(node, 0));
+  param.SetInPlaceIrValue(XlaValue(node, 1));
+  buf.SetInPlaceIrValue(XlaValue(node, 2));
 }
 
 void XLATensor::adam_optimizer_step_(
@@ -484,41 +481,41 @@ void XLATensor::adam_optimizer_step_(
     XLATensor& max_exp_avg_sq, double beta1, double beta2, double lr,
     double weight_decay, double eps, bool amsgrad, bool maximize,
     bool use_adamw) {
-  ir::XlaValue grad_value =
+  XlaValue grad_value =
       maximize ? XLATensor::mul(grad, -1).GetIrValue() : grad.GetIrValue();
-  ir::XlaValue beta1_value =
+  XlaValue beta1_value =
       GetIrValueForScalar(beta1, found_inf.shape(), found_inf.GetDevice());
-  ir::XlaValue beta2_value =
+  XlaValue beta2_value =
       GetIrValueForScalar(beta2, found_inf.shape(), found_inf.GetDevice());
-  ir::XlaValue lr_value =
+  XlaValue lr_value =
       GetIrValueForScalar(lr, found_inf.shape(), found_inf.GetDevice());
-  ir::XlaValue weight_decay_value =
+  XlaValue weight_decay_value =
       GetIrValueForScalar(weight_decay, param.shape(), param.GetDevice());
-  ir::XlaValue eps_value =
+  XlaValue eps_value =
       GetIrValueForScalar(eps, param.shape(), param.GetDevice());
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::AdamOptimizerStep>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<AdamOptimizerStep>(
       found_inf.GetIrValue(), step.GetIrValue(), param.GetIrValue(), grad_value,
       exp_avg.GetIrValue(), exp_avg_sq.GetIrValue(),
       max_exp_avg_sq.GetIrValue(), beta1_value, beta2_value, lr_value,
       weight_decay_value, eps_value,
       /*use_weight_decay=*/weight_decay != 0,
       /*use_amsgrad=*/amsgrad, /*use_adamw=*/use_adamw);
-  step.SetInPlaceIrValue(ir::XlaValue(node, 0));
-  param.SetInPlaceIrValue(ir::XlaValue(node, 1));
-  exp_avg.SetInPlaceIrValue(ir::XlaValue(node, 2));
-  exp_avg_sq.SetInPlaceIrValue(ir::XlaValue(node, 3));
-  max_exp_avg_sq.SetInPlaceIrValue(ir::XlaValue(node, 4));
+  step.SetInPlaceIrValue(XlaValue(node, 0));
+  param.SetInPlaceIrValue(XlaValue(node, 1));
+  exp_avg.SetInPlaceIrValue(XlaValue(node, 2));
+  exp_avg_sq.SetInPlaceIrValue(XlaValue(node, 3));
+  max_exp_avg_sq.SetInPlaceIrValue(XlaValue(node, 4));
 }
 
 std::vector<XLATensor> XLATensor::user_computation(
     const std::string& opname, absl::Span<const XLATensor> inputs,
     ComputationPtr computation) {
   XLA_CHECK(!inputs.empty());
-  std::vector<ir::XlaValue> input_values;
+  std::vector<XlaValue> input_values;
   for (auto& input : inputs) {
     input_values.push_back(input.GetIrValue());
   }
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::UserComputation>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<UserComputation>(
       torch::lazy::OpKind::Get(opname), input_values, std::move(computation));
   // Cast can be one of the user computation and we don't want to inherit the
   // logical_element_type in this case
@@ -529,108 +526,103 @@ std::vector<XLATensor> XLATensor::user_computation(
 // ATEN operators follows here, listed in alphabetical order.
 //////////////////////////////////////////////////////////////////////////////
 void XLATensor::__ilshift__(XLATensor& input, const at::Scalar& other) {
-  input.SetInPlaceIrValue(ir::ops::Lshift(input.GetIrValue(), other));
+  input.SetInPlaceIrValue(Lshift(input.GetIrValue(), other));
 }
 
 void XLATensor::__ilshift__(XLATensor& input, const XLATensor& other) {
-  input.SetInPlaceIrValue(
-      ir::ops::Lshift(input.GetIrValue(), other.GetIrValue()));
+  input.SetInPlaceIrValue(Lshift(input.GetIrValue(), other.GetIrValue()));
 }
 
 void XLATensor::__irshift__(XLATensor& input, const at::Scalar& other) {
-  input.SetInPlaceIrValue(ir::ops::Rshift(input.GetIrValue(), other));
+  input.SetInPlaceIrValue(Rshift(input.GetIrValue(), other));
 }
 
 void XLATensor::__irshift__(XLATensor& input, const XLATensor& other) {
-  input.SetInPlaceIrValue(
-      ir::ops::Rshift(input.GetIrValue(), other.GetIrValue()));
+  input.SetInPlaceIrValue(Rshift(input.GetIrValue(), other.GetIrValue()));
 }
 
 XLATensor XLATensor::__lshift__(
     const XLATensor& input, const at::Scalar& other,
     c10::optional<at::ScalarType> logical_element_type) {
-  return input.CreateFrom(ir::ops::Lshift(input.GetIrValue(), other),
+  return input.CreateFrom(Lshift(input.GetIrValue(), other),
                           logical_element_type);
 }
 
 XLATensor XLATensor::__lshift__(
     const XLATensor& input, const XLATensor& other,
     c10::optional<at::ScalarType> logical_element_type) {
-  return input.CreateFrom(
-      ir::ops::Lshift(input.GetIrValue(), other.GetIrValue()),
-      logical_element_type);
+  return input.CreateFrom(Lshift(input.GetIrValue(), other.GetIrValue()),
+                          logical_element_type);
 }
 
 XLATensor XLATensor::__rshift__(
     const XLATensor& input, const at::Scalar& other,
     c10::optional<at::ScalarType> logical_element_type) {
-  return input.CreateFrom(ir::ops::Rshift(input.GetIrValue(), other),
+  return input.CreateFrom(Rshift(input.GetIrValue(), other),
                           logical_element_type);
 }
 
 XLATensor XLATensor::__rshift__(
     const XLATensor& input, const XLATensor& other,
     c10::optional<at::ScalarType> logical_element_type) {
-  return input.CreateFrom(
-      ir::ops::Rshift(input.GetIrValue(), other.GetIrValue()),
-      logical_element_type);
+  return input.CreateFrom(Rshift(input.GetIrValue(), other.GetIrValue()),
+                          logical_element_type);
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::adaptive_max_pool2d(
     const XLATensor& input, std::vector<int64_t> output_size) {
   torch::lazy::NodePtr node =
-      ir::MakeNode<ir::ops::AdaptiveMaxPool2d>(input.GetIrValue(), output_size);
-  XLATensor out = input.CreateFrom(ir::XlaValue(node, 0));
-  XLATensor indices =
-      input.CreateFrom(ir::XlaValue(node, 1), at::ScalarType::Long);
+      torch::lazy::MakeNode<AdaptiveMaxPool2d>(input.GetIrValue(), output_size);
+  XLATensor out = input.CreateFrom(XlaValue(node, 0));
+  XLATensor indices = input.CreateFrom(XlaValue(node, 1), at::ScalarType::Long);
   return std::make_tuple(std::move(out), std::move(indices));
 }
 
 XLATensor XLATensor::adaptive_max_pool2d_backward(const XLATensor& grad_output,
                                                   const XLATensor& input) {
-  return input.CreateFrom(ir::ops::AdaptiveMaxPool2dBackward(
-      grad_output.GetIrValue(), input.GetIrValue()));
+  return input.CreateFrom(
+      AdaptiveMaxPool2dBackward(grad_output.GetIrValue(), input.GetIrValue()));
 }
 
 XLATensor XLATensor::adaptive_avg_pool3d(const XLATensor& input,
                                          std::vector<int64_t> output_size) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::AdaptiveAvgPool3d>(
+  return input.CreateFrom(torch::lazy::MakeNode<AdaptiveAvgPool3d>(
       input.GetIrValue(), std::move(output_size)));
 }
 
 XLATensor XLATensor::adaptive_avg_pool3d_backward(const XLATensor& grad_output,
                                                   const XLATensor& input) {
-  return input.CreateFrom(ir::ops::AdaptiveAvgPool3dBackward(
-      grad_output.GetIrValue(), input.GetIrValue()));
+  return input.CreateFrom(
+      AdaptiveAvgPool3dBackward(grad_output.GetIrValue(), input.GetIrValue()));
 }
 
 XLATensor XLATensor::_adaptive_avg_pool2d(const XLATensor& input,
                                           std::vector<int64_t> output_size) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::AdaptiveAvgPool2d>(
+  return input.CreateFrom(torch::lazy::MakeNode<AdaptiveAvgPool2d>(
       input.GetIrValue(), std::move(output_size)));
 }
 
 XLATensor XLATensor::_adaptive_avg_pool2d_backward(const XLATensor& grad_output,
                                                    const XLATensor& input) {
-  return input.CreateFrom(ir::ops::AdaptiveAvgPool2dBackward(
-      grad_output.GetIrValue(), input.GetIrValue()));
+  return input.CreateFrom(
+      AdaptiveAvgPool2dBackward(grad_output.GetIrValue(), input.GetIrValue()));
 }
 
 void XLATensor::_amp_foreach_non_finite_check_and_unscale_(
     std::vector<XLATensor> self, XLATensor& found_inf,
     const XLATensor& inv_scale) {
-  std::vector<ir::XlaValue> inputs;
+  std::vector<XlaValue> inputs;
   XLATensor new_inv_scale = XLATensor::max(inv_scale);
   for (const auto& x : self) {
     inputs.push_back(x.GetIrValue());
   }
   torch::lazy::NodePtr node =
-      ir::MakeNode<ir::ops::AmpForachNonFiniteCheckAndUnscale>(
+      torch::lazy::MakeNode<AmpForachNonFiniteCheckAndUnscale>(
           inputs, found_inf.GetIrValue(), new_inv_scale.GetIrValue());
   for (size_t i = 0; i < self.size(); ++i) {
-    self[i].SetInPlaceIrValue(ir::XlaValue(node, i));
+    self[i].SetInPlaceIrValue(XlaValue(node, i));
   }
-  found_inf.SetInPlaceIrValue(ir::XlaValue(node, self.size()));
+  found_inf.SetInPlaceIrValue(XlaValue(node, self.size()));
 }
 
 void XLATensor::_amp_update_scale_(XLATensor& current_scale,
@@ -639,30 +631,30 @@ void XLATensor::_amp_update_scale_(XLATensor& current_scale,
                                    double scale_growth_factor,
                                    double scale_backoff_factor,
                                    int growth_interval) {
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::AmpUpdateScale>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<AmpUpdateScale>(
       growth_tracker.GetIrValue(), current_scale.GetIrValue(),
       found_inf.GetIrValue(), scale_growth_factor, scale_backoff_factor,
       growth_interval);
-  growth_tracker.SetInPlaceIrValue(ir::XlaValue(node, 1));
-  current_scale.SetInPlaceIrValue(ir::XlaValue(node, 0));
+  growth_tracker.SetInPlaceIrValue(XlaValue(node, 1));
+  current_scale.SetInPlaceIrValue(XlaValue(node, 0));
 }
 
 XLATensor XLATensor::abs(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Abs(input.GetIrValue()));
+  return input.CreateFrom(Abs(input.GetIrValue()));
 }
 
 XLATensor XLATensor::acos(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Acos(input.GetIrValue()));
+  return input.CreateFrom(Acos(input.GetIrValue()));
 }
 
 XLATensor XLATensor::acosh(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Acosh(input.GetIrValue()));
+  return input.CreateFrom(Acosh(input.GetIrValue()));
 }
 
 XLATensor XLATensor::add(const XLATensor& input, const XLATensor& other,
                          const at::Scalar& alpha,
                          c10::optional<at::ScalarType> logical_element_type) {
-  ir::XlaValue constant = GetIrValueForScalar(
+  XlaValue constant = GetIrValueForScalar(
       alpha, other.shape(), logical_element_type, input.GetDevice());
   return input.CreateFrom(input.GetIrValue() + other.GetIrValue() * constant,
                           logical_element_type);
@@ -671,9 +663,9 @@ XLATensor XLATensor::add(const XLATensor& input, const XLATensor& other,
 XLATensor XLATensor::add(const XLATensor& input, const at::Scalar& other,
                          const at::Scalar& alpha,
                          c10::optional<at::ScalarType> logical_element_type) {
-  ir::XlaValue other_constant = GetIrValueForScalar(
+  XlaValue other_constant = GetIrValueForScalar(
       other, input.shape(), logical_element_type, input.GetDevice());
-  ir::XlaValue alpha_constant = GetIrValueForScalar(
+  XlaValue alpha_constant = GetIrValueForScalar(
       alpha, input.shape(), logical_element_type, input.GetDevice());
   return input.CreateFrom(input.GetIrValue() + other_constant * alpha_constant,
                           logical_element_type);
@@ -682,33 +674,33 @@ XLATensor XLATensor::add(const XLATensor& input, const at::Scalar& other,
 XLATensor XLATensor::addcdiv(const XLATensor& input, const at::Scalar& value,
                              const XLATensor& tensor1,
                              const XLATensor& tensor2) {
-  ir::XlaValue constant = GetIrValueForScalar(
+  XlaValue constant = GetIrValueForScalar(
       value, tensor1.shape().get().element_type(), input.GetDevice());
-  ir::XlaValue div = tensor1.GetIrValue() / tensor2.GetIrValue();
+  XlaValue div = tensor1.GetIrValue() / tensor2.GetIrValue();
   return input.CreateFrom(input.GetIrValue() + div * constant);
 }
 
 void XLATensor::addcdiv_(XLATensor& input, const at::Scalar& value,
                          const XLATensor& tensor1, const XLATensor& tensor2) {
-  ir::XlaValue constant = GetIrValueForScalar(
+  XlaValue constant = GetIrValueForScalar(
       value, tensor1.shape().get().element_type(), input.GetDevice());
-  ir::XlaValue div = tensor1.GetIrValue() / tensor2.GetIrValue();
+  XlaValue div = tensor1.GetIrValue() / tensor2.GetIrValue();
   input.SetInPlaceIrValue(input.GetIrValue() + div * constant);
 }
 
 XLATensor XLATensor::addcmul(const XLATensor& input, const at::Scalar& value,
                              const XLATensor& tensor1,
                              const XLATensor& tensor2) {
-  ir::XlaValue constant = GetIrValueForScalar(
+  XlaValue constant = GetIrValueForScalar(
       value, tensor1.shape().get().element_type(), input.GetDevice());
-  ir::XlaValue mul = tensor1.GetIrValue() * tensor2.GetIrValue();
+  XlaValue mul = tensor1.GetIrValue() * tensor2.GetIrValue();
   return input.CreateFrom(input.GetIrValue() + mul * constant);
 }
 
 XLATensor XLATensor::addmm(const XLATensor& input, const XLATensor& weight,
                            const XLATensor& bias) {
-  return input.CreateFrom(ir::ops::AddMatMulOp(
-      input.GetIrValue(), weight.GetIrValue(), bias.GetIrValue()));
+  return input.CreateFrom(
+      AddMatMulOp(input.GetIrValue(), weight.GetIrValue(), bias.GetIrValue()));
 }
 
 XLATensor XLATensor::all(const XLATensor& input,
@@ -718,7 +710,7 @@ XLATensor XLATensor::all(const XLATensor& input,
                                    ? at::ScalarType::Byte
                                    : at::ScalarType::Bool;
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::All>(input.GetIrValue(),
+      torch::lazy::MakeNode<All>(input.GetIrValue(),
                                  torch::lazy::GetCanonicalDimensionIndices(
                                      xla::util::ToVector<int64_t>(dimensions),
                                      input.shape().get().rank()),
@@ -729,7 +721,7 @@ XLATensor XLATensor::all(const XLATensor& input,
 XLATensor XLATensor::amax(const XLATensor& input,
                           std::vector<int64_t> dimensions,
                           bool keep_reduced_dimensions) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::Amax>(
+  return input.CreateFrom(torch::lazy::MakeNode<Amax>(
       input.GetIrValue(),
       torch::lazy::GetCanonicalDimensionIndices(
           xla::util::ToVector<int64_t>(dimensions), input.shape().get().rank()),
@@ -739,7 +731,7 @@ XLATensor XLATensor::amax(const XLATensor& input,
 XLATensor XLATensor::amin(const XLATensor& input,
                           std::vector<int64_t> dimensions,
                           bool keep_reduced_dimensions) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::Amin>(
+  return input.CreateFrom(torch::lazy::MakeNode<Amin>(
       input.GetIrValue(),
       torch::lazy::GetCanonicalDimensionIndices(
           xla::util::ToVector<int64_t>(dimensions), input.shape().get().rank()),
@@ -753,7 +745,7 @@ XLATensor XLATensor::any(const XLATensor& input,
                                    ? at::ScalarType::Byte
                                    : at::ScalarType::Bool;
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::Any>(input.GetIrValue(),
+      torch::lazy::MakeNode<Any>(input.GetIrValue(),
                                  torch::lazy::GetCanonicalDimensionIndices(
                                      xla::util::ToVector<int64_t>(dimensions),
                                      input.shape().get().rank()),
@@ -764,7 +756,7 @@ XLATensor XLATensor::any(const XLATensor& input,
 void XLATensor::arange_out(XLATensor& out, const at::Scalar& start,
                            const at::Scalar& end, const at::Scalar& step,
                            at::ScalarType scalar_type) {
-  out.SetIrValue(ir::ops::ARange(start, end, step, scalar_type));
+  out.SetIrValue(ARange(start, end, step, scalar_type));
   out.SetScalarType(scalar_type);
 }
 
@@ -772,13 +764,13 @@ XLATensor XLATensor::argmax(const XLATensor& input, int64_t dim, bool keepdim) {
   int64_t canonical_dim =
       torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::ArgMax>(input.GetIrValue(), canonical_dim, keepdim),
+      torch::lazy::MakeNode<ArgMax>(input.GetIrValue(), canonical_dim, keepdim),
       at::ScalarType::Long);
 }
 
 XLATensor XLATensor::argmax(const XLATensor& input) {
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::ArgMax>(input.GetIrValue(), -1, false),
+      torch::lazy::MakeNode<ArgMax>(input.GetIrValue(), -1, false),
       at::ScalarType::Long);
 }
 
@@ -786,13 +778,13 @@ XLATensor XLATensor::argmin(const XLATensor& input, int64_t dim, bool keepdim) {
   int64_t canonical_dim =
       torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::ArgMin>(input.GetIrValue(), canonical_dim, keepdim),
+      torch::lazy::MakeNode<ArgMin>(input.GetIrValue(), canonical_dim, keepdim),
       at::ScalarType::Long);
 }
 
 XLATensor XLATensor::argmin(const XLATensor& input) {
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::ArgMin>(input.GetIrValue(), -1, false),
+      torch::lazy::MakeNode<ArgMin>(input.GetIrValue(), -1, false),
       at::ScalarType::Long);
 }
 
@@ -809,7 +801,7 @@ void XLATensor::as_strided_(XLATensor& input, std::vector<int64_t> size,
                             std::vector<int64_t> stride,
                             c10::optional<int64_t> storage_offset) {
   if (input.data()->view == nullptr) {
-    input.SetIrValue(ir::MakeNode<ir::ops::AsStrided>(
+    input.SetIrValue(torch::lazy::MakeNode<AsStrided>(
         input.GetIrValue(), std::move(size), std::move(stride),
         storage_offset.value_or(0)));
   } else {
@@ -820,26 +812,25 @@ void XLATensor::as_strided_(XLATensor& input, std::vector<int64_t> size,
 }
 
 XLATensor XLATensor::asin(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Asin(input.GetIrValue()));
+  return input.CreateFrom(Asin(input.GetIrValue()));
 }
 
 XLATensor XLATensor::asinh(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Asinh(input.GetIrValue()));
+  return input.CreateFrom(Asinh(input.GetIrValue()));
 }
 
 XLATensor XLATensor::atan(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Atan(input.GetIrValue()));
+  return input.CreateFrom(Atan(input.GetIrValue()));
 }
 
 XLATensor XLATensor::atanh(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Atanh(input.GetIrValue()));
+  return input.CreateFrom(Atanh(input.GetIrValue()));
 }
 
 XLATensor XLATensor::atan2(const XLATensor& input, const XLATensor& other,
                            c10::optional<at::ScalarType> logical_element_type) {
-  return input.CreateFrom(
-      ir::ops::Atan2(input.GetIrValue(), other.GetIrValue()),
-      logical_element_type);
+  return input.CreateFrom(Atan2(input.GetIrValue(), other.GetIrValue()),
+                          logical_element_type);
 }
 
 XLATensor XLATensor::avg_pool_nd(const XLATensor& input,
@@ -851,7 +842,7 @@ XLATensor XLATensor::avg_pool_nd(const XLATensor& input,
   kernel_size = CheckIntList(kernel_size, spatial_dim_count, "kernel_size");
   stride = CheckIntList(stride, spatial_dim_count, "stride", kernel_size);
   padding = CheckIntList(padding, spatial_dim_count, "padding");
-  return input.CreateFrom(ir::MakeNode<ir::ops::AvgPoolNd>(
+  return input.CreateFrom(torch::lazy::MakeNode<AvgPoolNd>(
       input.GetIrValue(), spatial_dim_count, std::move(kernel_size),
       std::move(stride), std::move(padding), ceil_mode, count_include_pad));
 }
@@ -864,7 +855,7 @@ XLATensor XLATensor::avg_pool_nd_backward(
   kernel_size = CheckIntList(kernel_size, spatial_dim_count, "kernel_size");
   stride = CheckIntList(stride, spatial_dim_count, "stride", kernel_size);
   padding = CheckIntList(padding, spatial_dim_count, "padding");
-  return out_backprop.CreateFrom(ir::MakeNode<ir::ops::AvgPoolNdBackward>(
+  return out_backprop.CreateFrom(torch::lazy::MakeNode<AvgPoolNdBackward>(
       out_backprop.GetIrValue(), input.GetIrValue(), spatial_dim_count,
       std::move(kernel_size), std::move(stride), std::move(padding), ceil_mode,
       count_include_pad));
@@ -874,36 +865,36 @@ XLATensor XLATensor::baddbmm(const XLATensor& input, const XLATensor& batch1,
                              const XLATensor& batch2, const at::Scalar& beta,
                              const at::Scalar& alpha) {
   CheckBmmDimension(/*tag=*/"baddbmm", batch1, batch2);
-  ir::XlaValue product_multiplier = XLATensor::GetIrValueForScalar(
+  XlaValue product_multiplier = XLATensor::GetIrValueForScalar(
       alpha, batch1.shape().get().element_type(), batch1.GetDevice());
-  ir::XlaValue bias_multiplier = XLATensor::GetIrValueForScalar(
+  XlaValue bias_multiplier = XLATensor::GetIrValueForScalar(
       beta, input.shape().get().element_type(), input.GetDevice());
-  return input.CreateFrom(ir::ops::BaddBmm(
-      batch1.GetIrValue(), batch2.GetIrValue(), input.GetIrValue(),
-      product_multiplier, bias_multiplier));
+  return input.CreateFrom(BaddBmm(batch1.GetIrValue(), batch2.GetIrValue(),
+                                  input.GetIrValue(), product_multiplier,
+                                  bias_multiplier));
 }
 
 XLATensor XLATensor::bernoulli(const XLATensor& input, double probability) {
   auto input_shape = input.shape();
-  return input.CreateFrom(ir::MakeNode<ir::ops::Bernoulli>(
+  return input.CreateFrom(torch::lazy::MakeNode<Bernoulli>(
       GetIrValueForScalar(probability, input_shape, input.GetDevice()),
       GetRngSeed(input.GetDevice()), input_shape.get()));
 }
 
 XLATensor XLATensor::bernoulli(const XLATensor& input) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::Bernoulli>(
+  return input.CreateFrom(torch::lazy::MakeNode<Bernoulli>(
       input.GetIrValue(), GetRngSeed(input.GetDevice()), input.shape().get()));
 }
 
 void XLATensor::bernoulli_(XLATensor& input, double probability) {
   auto input_shape = input.shape();
-  input.SetInPlaceIrValue(ir::MakeNode<ir::ops::Bernoulli>(
+  input.SetInPlaceIrValue(torch::lazy::MakeNode<Bernoulli>(
       GetIrValueForScalar(probability, input_shape, input.GetDevice()),
       GetRngSeed(input.GetDevice()), input_shape.get()));
 }
 
 void XLATensor::bernoulli_(XLATensor& input, const XLATensor& probability) {
-  input.SetInPlaceIrValue(ir::MakeNode<ir::ops::Bernoulli>(
+  input.SetInPlaceIrValue(torch::lazy::MakeNode<Bernoulli>(
       probability.GetIrValue(), GetRngSeed(input.GetDevice()),
       input.shape().get()));
 }
@@ -912,7 +903,7 @@ XLATensor XLATensor::binary_cross_entropy(const XLATensor& input,
                                           const XLATensor& target,
                                           const XLATensor& weight,
                                           int64_t reduction) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::BinaryCrossEntropy>(
+  return input.CreateFrom(torch::lazy::MakeNode<BinaryCrossEntropy>(
       input.GetIrValue(), target.GetIrValue(), GetOptionalIrValue(weight),
       GetXlaReductionMode(reduction)));
 }
@@ -922,7 +913,7 @@ XLATensor XLATensor::binary_cross_entropy_backward(const XLATensor& grad_output,
                                                    const XLATensor& target,
                                                    const XLATensor& weight,
                                                    int64_t reduction) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::BinaryCrossEntropyBackward>(
+  return input.CreateFrom(torch::lazy::MakeNode<BinaryCrossEntropyBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), target.GetIrValue(),
       GetOptionalIrValue(weight), GetXlaReductionMode(reduction)));
 }
@@ -930,48 +921,47 @@ XLATensor XLATensor::binary_cross_entropy_backward(const XLATensor& grad_output,
 XLATensor XLATensor::bitwise_and(const XLATensor& input,
                                  const at::Scalar& other) {
   CheckIsIntegralOrPred(input.shape(), "__and__");
-  ir::XlaValue constant =
+  XlaValue constant =
       GetIrValueForScalar(other, input.shape(), input.GetDevice());
-  return input.CreateFrom(ir::ops::BitwiseAnd(input.GetIrValue(), constant));
+  return input.CreateFrom(BitwiseAnd(input.GetIrValue(), constant));
 }
 
 XLATensor XLATensor::bitwise_and(const XLATensor& input,
                                  const XLATensor& other) {
   CheckIsIntegralOrPred(input.shape(), "__and__");
-  return input.CreateFrom(
-      ir::ops::BitwiseAnd(input.GetIrValue(), other.GetIrValue()));
+  return input.CreateFrom(BitwiseAnd(input.GetIrValue(), other.GetIrValue()));
 }
 
 void XLATensor::bitwise_not_out(XLATensor& out, const XLATensor& input) {
-  out.SetIrValue(ir::ops::Not(input.GetIrValue()));
+  out.SetIrValue(Not(input.GetIrValue()));
 }
 
 void XLATensor::bitwise_or_out(XLATensor& out, const XLATensor& input,
                                const at::Scalar& other) {
   CheckIsIntegralOrPred(input.shape(), "__or__");
-  ir::XlaValue constant =
+  XlaValue constant =
       GetIrValueForScalar(other, input.shape(), input.GetDevice());
-  out.SetIrValue(ir::ops::BitwiseOr(input.GetIrValue(), constant));
+  out.SetIrValue(BitwiseOr(input.GetIrValue(), constant));
 }
 
 void XLATensor::bitwise_or_out(XLATensor& out, const XLATensor& input,
                                const XLATensor& other) {
   CheckIsIntegralOrPred(input.shape(), "__or__");
-  out.SetIrValue(ir::ops::BitwiseOr(input.GetIrValue(), other.GetIrValue()));
+  out.SetIrValue(BitwiseOr(input.GetIrValue(), other.GetIrValue()));
 }
 
 void XLATensor::bitwise_xor_out(XLATensor& out, const XLATensor& input,
                                 const at::Scalar& other) {
   CheckIsIntegralOrPred(input.shape(), "__xor__");
-  ir::XlaValue constant =
+  XlaValue constant =
       GetIrValueForScalar(other, input.shape(), input.GetDevice());
-  out.SetIrValue(ir::ops::BitwiseXor(input.GetIrValue(), constant));
+  out.SetIrValue(BitwiseXor(input.GetIrValue(), constant));
 }
 
 void XLATensor::bitwise_xor_out(XLATensor& out, const XLATensor& input,
                                 const XLATensor& other) {
   CheckIsIntegralOrPred(input.shape(), "__xor__");
-  out.SetIrValue(ir::ops::BitwiseXor(input.GetIrValue(), other.GetIrValue()));
+  out.SetIrValue(BitwiseXor(input.GetIrValue(), other.GetIrValue()));
 }
 
 XLATensor XLATensor::bmm(const XLATensor& batch1, const XLATensor& batch2) {
@@ -982,11 +972,11 @@ XLATensor XLATensor::bmm(const XLATensor& batch1, const XLATensor& batch2) {
 std::vector<XLATensor> XLATensor::broadcast_tensors(
     absl::Span<const XLATensor> tensors) {
   XLA_CHECK(!tensors.empty()) << "broadcast_tensors cannot take an empty list";
-  std::vector<ir::XlaValue> tensor_ir_values;
+  std::vector<XlaValue> tensor_ir_values;
   for (const auto& tensor : tensors) {
     tensor_ir_values.push_back(tensor.GetIrValue());
   }
-  torch::lazy::NodePtr node = ir::ops::BroadcastTensors(tensor_ir_values);
+  torch::lazy::NodePtr node = BroadcastTensors(tensor_ir_values);
   return tensors.front().MakeOutputTensors(node);
 }
 
@@ -999,7 +989,7 @@ XLATensor XLATensor::cat(absl::Span<const XLATensor> tensors, int64_t dim) {
   //   e.g. ([4, 0, 32, 32], [4, 2, 32, 32], dim=1) passes.
   //   ([4, 0, 32, 32], [4, 2, 31, 32], dim=1) throws.
   XLA_CHECK_GT(tensors.size(), 0);
-  std::vector<ir::XlaValue> values;
+  std::vector<XlaValue> values;
   std::vector<xla::Shape> shapes;
   for (size_t i = 0; i < tensors.size(); ++i) {
     xla::Shape tensor_shape = tensors[i].shape();
@@ -1018,25 +1008,24 @@ XLATensor XLATensor::cat(absl::Span<const XLATensor> tensors, int64_t dim) {
   if (values.empty()) {
     return tensors[0];
   }
-  return tensors[0].CreateFrom(ir::MakeNode<ir::ops::Cat>(values, dim));
+  return tensors[0].CreateFrom(torch::lazy::MakeNode<Cat>(values, dim));
 }
 
 XLATensor XLATensor::ceil(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Ceil(input.GetIrValue()));
+  return input.CreateFrom(Ceil(input.GetIrValue()));
 }
 
 XLATensor XLATensor::cholesky(const XLATensor& input, bool upper) {
   // Cholesky takes lower instead of upper, hence the negation.
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::Cholesky>(input.GetIrValue(), !upper));
+      torch::lazy::MakeNode<Cholesky>(input.GetIrValue(), !upper));
 }
 
 XLATensor XLATensor::clamp(const XLATensor& input,
                            const c10::optional<at::Scalar>& min,
                            const c10::optional<at::Scalar>& max) {
   MinMaxValues min_max = GetMinMaxValues(input, min, max);
-  return input.CreateFrom(
-      ir::ops::Clamp(input.GetIrValue(), min_max.min, min_max.max));
+  return input.CreateFrom(Clamp(input.GetIrValue(), min_max.min, min_max.max));
 }
 
 XLATensor XLATensor::clamp(const XLATensor& input,
@@ -1044,12 +1033,12 @@ XLATensor XLATensor::clamp(const XLATensor& input,
                            const c10::optional<at::Tensor>& max) {
   XLA_CHECK(min || max)
       << "At least one of \'min\' or \'max\' must not be None";
-  ir::XlaValue res = input.GetIrValue();
+  XlaValue res = input.GetIrValue();
   if (min) {
-    res = ir::ops::Max(res, bridge::GetXlaTensor(*min).GetIrValue());
+    res = Max(res, bridge::GetXlaTensor(*min).GetIrValue());
   }
   if (max) {
-    res = ir::ops::Min(res, bridge::GetXlaTensor(*max).GetIrValue());
+    res = Min(res, bridge::GetXlaTensor(*max).GetIrValue());
   }
   return input.CreateFrom(res);
 }
@@ -1059,12 +1048,12 @@ void XLATensor::clamp_out(XLATensor& out, const XLATensor& input,
                           const c10::optional<at::Tensor>& max) {
   XLA_CHECK(min || max)
       << "At least one of \'min\' or \'max\' must not be None";
-  ir::XlaValue res = input.GetIrValue();
+  XlaValue res = input.GetIrValue();
   if (min) {
-    res = ir::ops::Max(res, bridge::GetXlaTensor(*min).GetIrValue());
+    res = Max(res, bridge::GetXlaTensor(*min).GetIrValue());
   }
   if (max) {
-    res = ir::ops::Min(res, bridge::GetXlaTensor(*max).GetIrValue());
+    res = Min(res, bridge::GetXlaTensor(*max).GetIrValue());
   }
   out.SetInPlaceIrValue(res);
 }
@@ -1078,7 +1067,7 @@ XLATensor XLATensor::constant_pad_nd(const XLATensor& input,
                                      const at::Scalar& value) {
   std::vector<int64_t> complete_pad(pad.begin(), pad.end());
   complete_pad.resize(2 * input.shape().get().rank());
-  return input.CreateFrom(ir::MakeNode<ir::ops::ConstantPadNd>(
+  return input.CreateFrom(torch::lazy::MakeNode<ConstantPadNd>(
       input.GetIrValue(), complete_pad, value));
 }
 
@@ -1088,7 +1077,7 @@ XLATensor XLATensor::convolution_overrideable(
     std::vector<int64_t> dilation, bool transposed,
     std::vector<int64_t> output_padding, int64_t groups) {
   torch::lazy::NodePtr ir_value =
-      ir::MakeNode<ir::ops::ConvolutionOverrideable>(
+      torch::lazy::MakeNode<ConvolutionOverrideable>(
           input.GetIrValue(), weight.GetIrValue(), bias.GetIrValue(),
           std::move(stride), std::move(padding), std::move(dilation),
           transposed, std::move(output_padding), groups);
@@ -1101,7 +1090,7 @@ XLATensor XLATensor::convolution_overrideable(
     std::vector<int64_t> dilation, bool transposed,
     std::vector<int64_t> output_padding, int64_t groups) {
   torch::lazy::NodePtr ir_value =
-      ir::MakeNode<ir::ops::ConvolutionOverrideable>(
+      torch::lazy::MakeNode<ConvolutionOverrideable>(
           input.GetIrValue(), weight.GetIrValue(), std::move(stride),
           std::move(padding), std::move(dilation), transposed,
           std::move(output_padding), groups);
@@ -1115,23 +1104,23 @@ XLATensor::convolution_backward_overrideable(
     std::vector<int64_t> padding, std::vector<int64_t> dilation,
     bool transposed, std::vector<int64_t> output_padding, int64_t groups) {
   torch::lazy::NodePtr node =
-      ir::MakeNode<ir::ops::ConvolutionBackwardOverrideable>(
+      torch::lazy::MakeNode<ConvolutionBackwardOverrideable>(
           out_backprop.GetIrValue(), input.GetIrValue(), weight.GetIrValue(),
           std::move(stride), std::move(padding), std::move(dilation),
           transposed, std::move(output_padding), groups);
-  XLATensor grad_input = out_backprop.CreateFrom(ir::XlaValue(node, 0));
-  XLATensor grad_weight = out_backprop.CreateFrom(ir::XlaValue(node, 1));
-  XLATensor grad_bias = out_backprop.CreateFrom(ir::XlaValue(node, 2));
+  XLATensor grad_input = out_backprop.CreateFrom(XlaValue(node, 0));
+  XLATensor grad_weight = out_backprop.CreateFrom(XlaValue(node, 1));
+  XLATensor grad_bias = out_backprop.CreateFrom(XlaValue(node, 2));
   return std::make_tuple(std::move(grad_input), std::move(grad_weight),
                          std::move(grad_bias));
 }
 
 XLATensor XLATensor::cos(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Cos(input.GetIrValue()));
+  return input.CreateFrom(Cos(input.GetIrValue()));
 }
 
 XLATensor XLATensor::cosh(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Cosh(input.GetIrValue()));
+  return input.CreateFrom(Cosh(input.GetIrValue()));
 }
 
 XLATensor XLATensor::cross(const XLATensor& input, const XLATensor& other,
@@ -1147,7 +1136,7 @@ XLATensor XLATensor::cumprod(const XLATensor& input, int64_t dim,
     dtype = input.dtype_optional();
   }
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::CumProd>(input.GetIrValue(), canonical_dim, dtype),
+      torch::lazy::MakeNode<CumProd>(input.GetIrValue(), canonical_dim, dtype),
       dtype);
 }
 
@@ -1159,7 +1148,7 @@ XLATensor XLATensor::cumsum(const XLATensor& input, int64_t dim,
     dtype = input.dtype_optional();
   }
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::CumSum>(input.GetIrValue(), canonical_dim, dtype),
+      torch::lazy::MakeNode<CumSum>(input.GetIrValue(), canonical_dim, dtype),
       dtype);
 }
 
@@ -1205,15 +1194,15 @@ XLATensor XLATensor::div(const XLATensor& input, const XLATensor& other,
   }
   // We need to cast both input and other to float to perform true divide, floor
   // divide and trunc divide.
-  ir::XlaValue input_value = GetFloatingIrValue(input, scalar_type);
-  ir::XlaValue other_value = GetFloatingIrValue(other, scalar_type);
-  ir::XlaValue res = input_value / other_value;
+  XlaValue input_value = GetFloatingIrValue(input, scalar_type);
+  XlaValue other_value = GetFloatingIrValue(other, scalar_type);
+  XlaValue res = input_value / other_value;
 
   if (rounding_mode.has_value()) {
     if (*rounding_mode == "trunc") {
-      res = ir::ops::Trunc(res);
+      res = Trunc(res);
     } else if (*rounding_mode == "floor") {
-      res = ir::ops::Floor(res);
+      res = Floor(res);
     } else {
       XLA_CHECK(false)
           << "rounding_mode must be one of None, 'trunc', or 'floor'";
@@ -1229,7 +1218,7 @@ XLATensor XLATensor::div(const XLATensor& input, const XLATensor& other,
       xla::PrimitiveType res_intended_type =
           MakeXlaPrimitiveType(*logical_element_type, &input.GetDevice());
       if (res.xla_shape().element_type() != res_intended_type) {
-        res = ir::MakeNode<ir::ops::Cast>(res, res_intended_type);
+        res = torch::lazy::MakeNode<Cast>(res, res_intended_type);
       }
     }
     return input.CreateFrom(res, logical_element_type);
@@ -1248,8 +1237,8 @@ XLATensor XLATensor::div(const XLATensor& input, const at::Scalar& other) {
   if (input_is_float) {
     scalar_type = TensorTypeFromXlaType(input_type);
   }
-  ir::XlaValue input_value = GetFloatingIrValue(input, scalar_type);
-  ir::XlaValue other_value = GetIrValueForScalar(
+  XlaValue input_value = GetFloatingIrValue(input, scalar_type);
+  XlaValue other_value = GetIrValueForScalar(
       other, input_value.xla_shape().element_type(), input.GetDevice());
   return input.CreateFrom(input_value / other_value, scalar_type);
 }
@@ -1265,14 +1254,12 @@ XLATensor XLATensor::eq(const XLATensor& input, const XLATensor& other) {
 XLATensor XLATensor::elu(const XLATensor& input, const at::Scalar& alpha,
                          const at::Scalar& scale,
                          const at::Scalar& input_scale) {
-  return input.CreateFrom(
-      ir::ops::Elu(input.GetIrValue(), alpha, scale, input_scale));
+  return input.CreateFrom(Elu(input.GetIrValue(), alpha, scale, input_scale));
 }
 
 void XLATensor::elu_(XLATensor& input, const at::Scalar& alpha,
                      const at::Scalar& scale, const at::Scalar& input_scale) {
-  input.SetInPlaceIrValue(
-      ir::ops::Elu(input.GetIrValue(), alpha, scale, input_scale));
+  input.SetInPlaceIrValue(Elu(input.GetIrValue(), alpha, scale, input_scale));
 }
 
 XLATensor XLATensor::elu_backward(const XLATensor& grad_output,
@@ -1280,9 +1267,9 @@ XLATensor XLATensor::elu_backward(const XLATensor& grad_output,
                                   const at::Scalar& scale,
                                   const at::Scalar& input_scale,
                                   const XLATensor& output) {
-  return grad_output.CreateFrom(ir::ops::EluBackward(grad_output.GetIrValue(),
-                                                     output.GetIrValue(), alpha,
-                                                     scale, input_scale));
+  return grad_output.CreateFrom(EluBackward(grad_output.GetIrValue(),
+                                            output.GetIrValue(), alpha, scale,
+                                            input_scale));
 }
 
 XLATensor XLATensor::embedding_dense_backward(const XLATensor& grad_output,
@@ -1295,35 +1282,35 @@ XLATensor XLATensor::embedding_dense_backward(const XLATensor& grad_output,
 }
 
 XLATensor XLATensor::erf(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Erf(input.GetIrValue()));
+  return input.CreateFrom(Erf(input.GetIrValue()));
 }
 
 XLATensor XLATensor::erfc(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Erfc(input.GetIrValue()));
+  return input.CreateFrom(Erfc(input.GetIrValue()));
 }
 
 XLATensor XLATensor::erfinv(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Erfinv(input.GetIrValue()));
+  return input.CreateFrom(Erfinv(input.GetIrValue()));
 }
 
 XLATensor XLATensor::exp(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Exp(input.GetIrValue()));
+  return input.CreateFrom(Exp(input.GetIrValue()));
 }
 
 XLATensor XLATensor::expand(const XLATensor& input, std::vector<int64_t> size) {
   auto input_shape = input.shape();
-  return input.CreateFrom(ir::MakeNode<ir::ops::Expand>(
+  return input.CreateFrom(torch::lazy::MakeNode<Expand>(
       input.GetIrValue(),
       GetExpandDimensions(input_shape.get(), std::move(size))));
 }
 
 XLATensor XLATensor::expm1(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Expm1(input.GetIrValue()));
+  return input.CreateFrom(Expm1(input.GetIrValue()));
 }
 
 void XLATensor::exponential_(XLATensor& input, double lambd) {
   auto input_shape = input.shape();
-  input.SetInPlaceIrValue(ir::MakeNode<ir::ops::Exponential>(
+  input.SetInPlaceIrValue(torch::lazy::MakeNode<Exponential>(
       GetIrValueForScalar(lambd, input_shape.get().element_type(),
                           input.GetDevice()),
       GetRngSeed(input.GetDevice()), input_shape.get()));
@@ -1333,20 +1320,19 @@ XLATensor XLATensor::eye(int64_t lines, int64_t cols,
                          const torch::lazy::BackendDevice& device,
                          at::ScalarType element_type) {
   return XLATensor::Create(
-      ir::ops::Identity(lines, cols,
-                        MakeXlaPrimitiveType(element_type, &device)),
+      Identity(lines, cols, MakeXlaPrimitiveType(element_type, &device)),
       device, element_type);
 }
 
 void XLATensor::eye_out(XLATensor& out, int64_t lines, int64_t cols) {
   out.SetIrValue(
-      ir::ops::Identity(lines, cols >= 0 ? cols : lines,
-                        GetDevicePrimitiveType(out.shape().get().element_type(),
-                                               &out.GetDevice())));
+      Identity(lines, cols >= 0 ? cols : lines,
+               GetDevicePrimitiveType(out.shape().get().element_type(),
+                                      &out.GetDevice())));
 }
 
 void XLATensor::fill_(XLATensor& input, const at::Scalar& value) {
-  ir::XlaValue constant =
+  XlaValue constant =
       GetIrValueForScalar(value, input.shape(), input.GetDevice());
   input.SetInPlaceIrValue(std::move(constant));
 }
@@ -1358,29 +1344,29 @@ XLATensor XLATensor::flip(const XLATensor& input,
   std::set<int64_t> unique_dims(dimensions.begin(), dimensions.end());
   XLA_CHECK_EQ(unique_dims.size(), dimensions.size());
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::Flip>(input.GetIrValue(), dimensions));
+      torch::lazy::MakeNode<Flip>(input.GetIrValue(), dimensions));
 }
 
 XLATensor XLATensor::floor(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Floor(input.GetIrValue()));
+  return input.CreateFrom(Floor(input.GetIrValue()));
 }
 
 XLATensor XLATensor::fmod(const XLATensor& input, const XLATensor& other,
                           c10::optional<at::ScalarType> logical_element_type) {
-  return input.CreateFrom(ir::ops::Fmod(input.GetIrValue(), other.GetIrValue()),
+  return input.CreateFrom(Fmod(input.GetIrValue(), other.GetIrValue()),
                           logical_element_type);
 }
 
 XLATensor XLATensor::fmod(const XLATensor& input, const at::Scalar& other,
                           c10::optional<at::ScalarType> logical_element_type) {
-  ir::XlaValue constant = GetIrValueForScalar(
+  XlaValue constant = GetIrValueForScalar(
       other, input.shape(), logical_element_type, input.GetDevice());
-  return input.CreateFrom(ir::ops::Fmod(input.GetIrValue(), constant),
+  return input.CreateFrom(Fmod(input.GetIrValue(), constant),
                           logical_element_type);
 }
 
 XLATensor XLATensor::frac(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::FracOp(input.GetIrValue()));
+  return input.CreateFrom(FracOp(input.GetIrValue()));
 }
 
 XLATensor XLATensor::full(absl::Span<const int64_t> size,
@@ -1422,7 +1408,7 @@ XLATensor XLATensor::gather(const XLATensor& input, int64_t dim,
       XLA_CHECK_LE(index.size(dim), input.size(dim));
     }
   }
-  return input.CreateFrom(ir::MakeNode<ir::ops::Gather>(
+  return input.CreateFrom(torch::lazy::MakeNode<Gather>(
       input.GetIrValue(), canonical_dim, index.GetIrValue()));
 }
 
@@ -1437,9 +1423,9 @@ XLATensor XLATensor::ge(const XLATensor& input, const XLATensor& other) {
 XLATensor XLATensor::gelu(const XLATensor& input,
                           const c10::string_view approximate) {
   if (approximate == "none") {
-    return input.CreateFrom(ir::ops::Gelu(input.GetIrValue()));
+    return input.CreateFrom(Gelu(input.GetIrValue()));
   } else if (approximate == "tanh") {
-    return input.CreateFrom(ir::ops::TanhGelu(input.GetIrValue()));
+    return input.CreateFrom(TanhGelu(input.GetIrValue()));
   } else {
     XLA_ERROR() << "Unknown gelu type: " << approximate;
   }
@@ -1450,17 +1436,17 @@ XLATensor XLATensor::gelu_backward(const XLATensor& grad,
                                    const c10::string_view approximate) {
   if (approximate == "none") {
     return input.CreateFrom(
-        ir::ops::GeluBackward(grad.GetIrValue(), input.GetIrValue()));
+        GeluBackward(grad.GetIrValue(), input.GetIrValue()));
   } else if (approximate == "tanh") {
     return input.CreateFrom(
-        ir::ops::TanhGeluBackward(grad.GetIrValue(), input.GetIrValue()));
+        TanhGeluBackward(grad.GetIrValue(), input.GetIrValue()));
   } else {
     XLA_ERROR() << "Unknown gelu type: " << approximate;
   }
 }
 
 XLATensor XLATensor::ger(const XLATensor& input, const XLATensor& vec2) {
-  return input.CreateFrom(ir::ops::Ger(input.GetIrValue(), vec2.GetIrValue()));
+  return input.CreateFrom(Ger(input.GetIrValue(), vec2.GetIrValue()));
 }
 
 XLATensor XLATensor::gt(const XLATensor& input, const at::Scalar& other) {
@@ -1480,7 +1466,7 @@ XLATensor XLATensor::index(const XLATensor& input,
 XLATensor XLATensor::index_add(const XLATensor& input, int64_t dim,
                                const XLATensor& index, const XLATensor& source,
                                const at::Scalar& alpha) {
-  ir::XlaValue constant = GetIrValueForScalar(
+  XlaValue constant = GetIrValueForScalar(
       alpha, source.shape().get().element_type(), input.GetDevice());
   auto scaled_source = input.CreateFrom(source.GetIrValue() * constant);
   int64_t canonical_dim =
@@ -1546,20 +1532,20 @@ void XLATensor::index_put_(XLATensor& input, const XLATensor& canonical_base,
 
 XLATensor XLATensor::index_select(const XLATensor& input, int64_t dim,
                                   const XLATensor& index) {
-  ir::XlaValue index_value = EnsureRank1(index.GetIrValue());
-  return input.CreateFrom(ir::MakeNode<ir::ops::IndexSelect>(
+  XlaValue index_value = EnsureRank1(index.GetIrValue());
+  return input.CreateFrom(torch::lazy::MakeNode<IndexSelect>(
       input.GetIrValue(),
       torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank()),
       index_value));
 }
 
 XLATensor XLATensor::inverse(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Inverse(input.GetIrValue()));
+  return input.CreateFrom(Inverse(input.GetIrValue()));
 }
 
 XLATensor XLATensor::isnan(const XLATensor& input) {
-  ir::XlaValue result = ir::ops::IsNan(input.GetIrValue());
-  ir::XlaValue casted = GetBooleanIrValue(result);
+  XlaValue result = IsNan(input.GetIrValue());
+  XlaValue casted = GetBooleanIrValue(result);
   return input.CreateFrom(casted, at::ScalarType::Bool);
 }
 
@@ -1574,18 +1560,18 @@ XLATensor XLATensor::kl_div_backward(const XLATensor& grad_output,
 std::tuple<XLATensor, XLATensor> XLATensor::kthvalue(const XLATensor& input,
                                                      int64_t k, int64_t dim,
                                                      bool keepdim) {
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::KthValue>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<KthValue>(
       input.GetIrValue(), k,
       torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank()),
       keepdim);
   return std::make_tuple(
-      input.CreateFrom(ir::XlaValue(node, 0)),
-      input.CreateFrom(ir::XlaValue(node, 1), at::ScalarType::Long));
+      input.CreateFrom(XlaValue(node, 0)),
+      input.CreateFrom(XlaValue(node, 1), at::ScalarType::Long));
 }
 
 XLATensor XLATensor::l1_loss(const XLATensor& input, const XLATensor& target,
                              int64_t reduction) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::L1Loss>(
+  return input.CreateFrom(torch::lazy::MakeNode<L1Loss>(
       input.GetIrValue(), target.GetIrValue(), GetXlaReductionMode(reduction)));
 }
 
@@ -1593,7 +1579,7 @@ XLATensor XLATensor::l1_loss_backward(const XLATensor& grad_output,
                                       const XLATensor& input,
                                       const XLATensor& target,
                                       int64_t reduction) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::L1LossBackward>(
+  return input.CreateFrom(torch::lazy::MakeNode<L1LossBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), target.GetIrValue(),
       GetXlaReductionMode(reduction)));
 }
@@ -1609,80 +1595,79 @@ XLATensor XLATensor::le(const XLATensor& input, const XLATensor& other) {
 XLATensor XLATensor::hardshrink(const XLATensor& input,
                                 const at::Scalar& lambda) {
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::Hardshrink>(input.GetIrValue(), lambda));
+      torch::lazy::MakeNode<Hardshrink>(input.GetIrValue(), lambda));
 }
 
 XLATensor XLATensor::hardshrink_backward(const XLATensor& grad_out,
                                          const XLATensor& input,
                                          const at::Scalar& lambda) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::ShrinkBackward>(
+  return input.CreateFrom(torch::lazy::MakeNode<ShrinkBackward>(
       torch::lazy::OpKind(at::aten::hardshrink_backward), grad_out.GetIrValue(),
       input.GetIrValue(), lambda));
 }
 
 XLATensor XLATensor::hardsigmoid(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::HardSigmoid(input.GetIrValue()));
+  return input.CreateFrom(HardSigmoid(input.GetIrValue()));
 }
 
 XLATensor XLATensor::hardsigmoid_backward(const XLATensor& grad_output,
                                           const XLATensor& input) {
-  return input.CreateFrom(ir::ops::HardSigmoidBackward(grad_output.GetIrValue(),
-                                                       input.GetIrValue()));
+  return input.CreateFrom(
+      HardSigmoidBackward(grad_output.GetIrValue(), input.GetIrValue()));
 }
 
 XLATensor XLATensor::hardswish(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::HardSwish(input.GetIrValue()));
+  return input.CreateFrom(HardSwish(input.GetIrValue()));
 }
 
 XLATensor XLATensor::hardswish_backward(const XLATensor& grad_output,
                                         const XLATensor& input) {
   return input.CreateFrom(
-      ir::ops::HardSwishBackward(grad_output.GetIrValue(), input.GetIrValue()));
+      HardSwishBackward(grad_output.GetIrValue(), input.GetIrValue()));
 }
 
 XLATensor XLATensor::hardtanh_backward(const XLATensor& grad_output,
                                        const XLATensor& input,
                                        const at::Scalar& min_val,
                                        const at::Scalar& max_val) {
-  return grad_output.CreateFrom(ir::MakeNode<ir::ops::HardtanhBackward>(
+  return grad_output.CreateFrom(torch::lazy::MakeNode<HardtanhBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), min_val, max_val));
 }
 
 XLATensor XLATensor::leaky_relu(const XLATensor& input, double negative_slope) {
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::LeakyRelu>(input.GetIrValue(), negative_slope));
+      torch::lazy::MakeNode<LeakyRelu>(input.GetIrValue(), negative_slope));
 }
 
 XLATensor XLATensor::leaky_relu_backward(const XLATensor& grad_output,
                                          const XLATensor& input,
                                          double negative_slope) {
-  return grad_output.CreateFrom(ir::MakeNode<ir::ops::LeakyReluBackward>(
+  return grad_output.CreateFrom(torch::lazy::MakeNode<LeakyReluBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), negative_slope));
 }
 
 XLATensor XLATensor::lerp(const XLATensor& input, const XLATensor& end,
                           const XLATensor& weight) {
   return input.CreateFrom(
-      ir::ops::Lerp(input.GetIrValue(), end.GetIrValue(), weight.GetIrValue()));
+      Lerp(input.GetIrValue(), end.GetIrValue(), weight.GetIrValue()));
 }
 
 XLATensor XLATensor::lerp(const XLATensor& input, const XLATensor& end,
                           const at::Scalar& weight) {
-  ir::XlaValue weight_val = GetIrValueForScalar(
+  XlaValue weight_val = GetIrValueForScalar(
       weight, input.shape().get().element_type(), input.GetDevice());
   return input.CreateFrom(
-      ir::ops::Lerp(input.GetIrValue(), end.GetIrValue(), weight_val));
+      Lerp(input.GetIrValue(), end.GetIrValue(), weight_val));
 }
 
 XLATensor XLATensor::linspace(const at::Scalar& start, const at::Scalar& end,
                               const int64_t steps, at::ScalarType element_type,
                               const torch::lazy::BackendDevice& device) {
-  ir::XlaValue start_val =
+  XlaValue start_val =
       GetIrValueForScalar(start, xla::PrimitiveType::F32, device);
-  ir::XlaValue end_val =
-      GetIrValueForScalar(end, xla::PrimitiveType::F32, device);
+  XlaValue end_val = GetIrValueForScalar(end, xla::PrimitiveType::F32, device);
   return XLATensor::Create(
-      ir::MakeNode<ir::ops::Linspace>(start_val, end_val, steps), device,
+      torch::lazy::MakeNode<Linspace>(start_val, end_val, steps), device,
       element_type);
 }
 
@@ -1691,9 +1676,8 @@ XLATensor XLATensor::log(const XLATensor& input) {
   // otherwise result will inherit the input's logical_element_type. In the
   // case of log(int) -> float, we want to derive the dtype from IR value
   // instead of input's logical_element_type.
-  return input.CreateFrom(
-      ir::ops::Log(GetFloatingIrValue(input, at::ScalarType::Float)),
-      c10::nullopt);
+  return input.CreateFrom(Log(GetFloatingIrValue(input, at::ScalarType::Float)),
+                          c10::nullopt);
 }
 
 XLATensor XLATensor::log_base(const XLATensor& input, torch::lazy::OpKind op,
@@ -1703,18 +1687,17 @@ XLATensor XLATensor::log_base(const XLATensor& input, torch::lazy::OpKind op,
   // case of logbase(int) -> float, we want to derive the dtype from IR value
   // instead of input's logical_element_type.
   return input.CreateFrom(
-      ir::ops::LogBase(GetFloatingIrValue(input, at::ScalarType::Float), op,
-                       base),
+      LogBase(GetFloatingIrValue(input, at::ScalarType::Float), op, base),
       c10::nullopt);
 }
 
 XLATensor XLATensor::log_sigmoid(const XLATensor& input) {
-  return input.CreateFrom(std::get<0>(ir::ops::LogSigmoid(input.GetIrValue())));
+  return input.CreateFrom(std::get<0>(LogSigmoid(input.GetIrValue())));
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::log_sigmoid_forward(
     const XLATensor& input) {
-  auto output_and_buffer = ir::ops::LogSigmoid(input.GetIrValue());
+  auto output_and_buffer = LogSigmoid(input.GetIrValue());
   return std::make_tuple(input.CreateFrom(std::get<0>(output_and_buffer)),
                          input.CreateFrom(std::get<1>(output_and_buffer)));
 }
@@ -1722,7 +1705,7 @@ std::tuple<XLATensor, XLATensor> XLATensor::log_sigmoid_forward(
 XLATensor XLATensor::log_sigmoid_backward(const XLATensor& grad_output,
                                           const XLATensor& input,
                                           const XLATensor& buffer) {
-  return grad_output.CreateFrom(ir::ops::LogSigmoidBackward(
+  return grad_output.CreateFrom(LogSigmoidBackward(
       grad_output.GetIrValue(), input.GetIrValue(), buffer.GetIrValue()));
 }
 
@@ -1732,7 +1715,7 @@ XLATensor XLATensor::log_softmax(const XLATensor& input, int64_t dim,
     dtype = input.dtype_optional();
   }
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::LogSoftmax>(input.GetIrValue(),
+      torch::lazy::MakeNode<LogSoftmax>(input.GetIrValue(),
                                         torch::lazy::GetCanonicalDimensionIndex(
                                             dim, input.shape().get().rank()),
                                         dtype),
@@ -1742,8 +1725,8 @@ XLATensor XLATensor::log_softmax(const XLATensor& input, int64_t dim,
 XLATensor XLATensor::log_softmax_backward(const XLATensor& grad_output,
                                           const XLATensor& output,
                                           int64_t dim) {
-  return grad_output.CreateFrom(ir::ops::LogSoftmaxBackwardOp(
-      grad_output.GetIrValue(), output.GetIrValue(), dim));
+  return grad_output.CreateFrom(
+      LogSoftmaxBackwardOp(grad_output.GetIrValue(), output.GetIrValue(), dim));
 }
 
 XLATensor XLATensor::log1p(const XLATensor& input) {
@@ -1752,48 +1735,43 @@ XLATensor XLATensor::log1p(const XLATensor& input) {
   // case of log1p(int) -> float, we want to derive the dtype from IR value
   // instead of input's logical_element_type.
   return input.CreateFrom(
-      ir::ops::Log1p(GetFloatingIrValue(input, at::ScalarType::Float)),
-      c10::nullopt);
+      Log1p(GetFloatingIrValue(input, at::ScalarType::Float)), c10::nullopt);
 }
 
 void XLATensor::log1p_(XLATensor& input) {
-  input.SetInPlaceIrValue(ir::ops::Log1p(input.GetIrValue()));
+  input.SetInPlaceIrValue(Log1p(input.GetIrValue()));
 }
 
 XLATensor XLATensor::logdet(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::LogDet(input.GetIrValue()));
+  return input.CreateFrom(LogDet(input.GetIrValue()));
 }
 
 XLATensor XLATensor::logical_not(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::LogicalNot(input.GetIrValue()),
-                          at::ScalarType::Bool);
+  return input.CreateFrom(LogicalNot(input.GetIrValue()), at::ScalarType::Bool);
 }
 
 XLATensor XLATensor::logical_xor(const XLATensor& input,
                                  const XLATensor& other) {
-  return input.CreateFrom(
-      ir::ops::LogicalXor(input.GetIrValue(), other.GetIrValue()),
-      at::ScalarType::Bool);
+  return input.CreateFrom(LogicalXor(input.GetIrValue(), other.GetIrValue()),
+                          at::ScalarType::Bool);
 }
 
 XLATensor XLATensor::logical_and(const XLATensor& input,
                                  const XLATensor& other) {
-  return input.CreateFrom(
-      ir::ops::LogicalAnd(input.GetIrValue(), other.GetIrValue()),
-      at::ScalarType::Bool);
+  return input.CreateFrom(LogicalAnd(input.GetIrValue(), other.GetIrValue()),
+                          at::ScalarType::Bool);
 }
 
 XLATensor XLATensor::logical_or(const XLATensor& input,
                                 const XLATensor& other) {
-  return input.CreateFrom(
-      ir::ops::LogicalOr(input.GetIrValue(), other.GetIrValue()),
-      at::ScalarType::Bool);
+  return input.CreateFrom(LogicalOr(input.GetIrValue(), other.GetIrValue()),
+                          at::ScalarType::Bool);
 }
 
 XLATensor XLATensor::logsumexp(const XLATensor& input,
                                std::vector<int64_t> dimensions,
                                bool keep_reduced_dimensions) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::Logsumexp>(
+  return input.CreateFrom(torch::lazy::MakeNode<Logsumexp>(
       input.GetIrValue(),
       torch::lazy::GetCanonicalDimensionIndices(
           xla::util::ToVector<int64_t>(dimensions), input.shape().get().rank()),
@@ -1806,8 +1784,8 @@ XLATensor XLATensor::xlogy(const XLATensor& input, const XLATensor& other) {
   // case of xlogy(int,int) -> float, we want to derive the dtype from IR value
   // instead of input's logical_element_type.
   return input.CreateFrom(
-      ir::ops::XLogY(input.GetIrValue(),
-                     GetFloatingIrValue(other, at::ScalarType::Float)),
+      XLogY(input.GetIrValue(),
+            GetFloatingIrValue(other, at::ScalarType::Float)),
       c10::nullopt);
 }
 
@@ -1821,61 +1799,60 @@ XLATensor XLATensor::lt(const XLATensor& input, const XLATensor& other) {
 
 void XLATensor::masked_fill_(XLATensor& input, const XLATensor& mask,
                              const at::Scalar& value) {
-  ir::ScopePusher ir_scope(at::aten::masked_fill.toQualString());
-  input.SetIrValue(ir::MakeNode<ir::ops::MaskedFill>(
+  ScopePusher ir_scope(at::aten::masked_fill.toQualString());
+  input.SetIrValue(torch::lazy::MakeNode<MaskedFill>(
       input.GetIrValue(), MaybeExpand(mask.GetIrValue(), input.shape()),
       value));
 }
 
 void XLATensor::masked_scatter_(XLATensor& input, const XLATensor& mask,
                                 const XLATensor& source) {
-  ir::ScopePusher ir_scope(at::aten::masked_scatter.toQualString());
-  input.SetIrValue(ir::MakeNode<ir::ops::MaskedScatter>(
+  ScopePusher ir_scope(at::aten::masked_scatter.toQualString());
+  input.SetIrValue(torch::lazy::MakeNode<MaskedScatter>(
       input.GetIrValue(), MaybeExpand(mask.GetIrValue(), input.shape()),
       source.GetIrValue()));
 }
 
 XLATensor XLATensor::masked_select(const XLATensor& input,
                                    const XLATensor& mask) {
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::MaskedSelect>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<MaskedSelect>(
       input.GetIrValue(), mask.GetIrValue());
-  return input.CreateFrom(ir::XlaValue(node, 0));
+  return input.CreateFrom(XlaValue(node, 0));
 }
 
 XLATensor XLATensor::matmul(const XLATensor& input, const XLATensor& other) {
-  return input.CreateFrom(
-      ir::ops::MatMul(input.GetIrValue(), other.GetIrValue()));
+  return input.CreateFrom(MatMul(input.GetIrValue(), other.GetIrValue()));
 }
 
 XLATensor XLATensor::max(const XLATensor& input, const XLATensor& other,
                          c10::optional<at::ScalarType> logical_element_type) {
-  return input.CreateFrom(ir::ops::Max(input.GetIrValue(), other.GetIrValue()),
+  return input.CreateFrom(Max(input.GetIrValue(), other.GetIrValue()),
                           logical_element_type);
 }
 
 XLATensor XLATensor::max(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::MaxUnary(input.GetIrValue()), input.dtype());
+  return input.CreateFrom(MaxUnary(input.GetIrValue()), input.dtype());
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::max(const XLATensor& input,
                                                 int64_t dim, bool keepdim) {
   int64_t canonical_dim =
       torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::MaxInDim>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<MaxInDim>(
       input.GetIrValue(), canonical_dim, keepdim);
   return std::make_tuple(
-      input.CreateFrom(ir::XlaValue(node, 0)),
-      input.CreateFrom(ir::XlaValue(node, 1), at::ScalarType::Long));
+      input.CreateFrom(XlaValue(node, 0)),
+      input.CreateFrom(XlaValue(node, 1), at::ScalarType::Long));
 }
 
 void XLATensor::max_out(XLATensor& max, XLATensor& max_values,
                         const XLATensor& input, int64_t dim, bool keepdim) {
   int64_t canonical_dim =
       torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::MaxInDim>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<MaxInDim>(
       input.GetIrValue(), canonical_dim, keepdim);
-  max.SetIrValue(ir::XlaValue(node, 0));
-  max_values.SetIrValue(ir::XlaValue(node, 1));
+  max.SetIrValue(XlaValue(node, 0));
+  max_values.SetIrValue(XlaValue(node, 1));
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::max_pool_nd(
@@ -1885,12 +1862,12 @@ std::tuple<XLATensor, XLATensor> XLATensor::max_pool_nd(
   kernel_size = CheckIntList(kernel_size, spatial_dim_count, "kernel_size");
   stride = CheckIntList(stride, spatial_dim_count, "stride", kernel_size);
   padding = CheckIntList(padding, spatial_dim_count, "padding");
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::MaxPoolNd>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<MaxPoolNd>(
       input.GetIrValue(), spatial_dim_count, std::move(kernel_size),
       std::move(stride), std::move(padding), ceil_mode);
   return std::make_tuple(
-      input.CreateFrom(ir::XlaValue(node, 0)),
-      input.CreateFrom(ir::XlaValue(node, 1), at::ScalarType::Long));
+      input.CreateFrom(XlaValue(node, 0)),
+      input.CreateFrom(XlaValue(node, 1), at::ScalarType::Long));
 }
 
 XLATensor XLATensor::max_pool_nd_backward(
@@ -1900,7 +1877,7 @@ XLATensor XLATensor::max_pool_nd_backward(
   kernel_size = CheckIntList(kernel_size, spatial_dim_count, "kernel_size");
   stride = CheckIntList(stride, spatial_dim_count, "stride", kernel_size);
   padding = CheckIntList(padding, spatial_dim_count, "padding");
-  return out_backprop.CreateFrom(ir::MakeNode<ir::ops::MaxPoolNdBackward>(
+  return out_backprop.CreateFrom(torch::lazy::MakeNode<MaxPoolNdBackward>(
       out_backprop.GetIrValue(), input.GetIrValue(), spatial_dim_count,
       std::move(kernel_size), std::move(stride), std::move(padding),
       ceil_mode));
@@ -1909,7 +1886,7 @@ XLATensor XLATensor::max_pool_nd_backward(
 XLATensor XLATensor::max_unpool(const XLATensor& input,
                                 const XLATensor& indices,
                                 std::vector<int64_t> output_size) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::MaxUnpoolNd>(
+  return input.CreateFrom(torch::lazy::MakeNode<MaxUnpoolNd>(
       input.GetIrValue(), indices.GetIrValue(), std::move(output_size)));
 }
 
@@ -1917,7 +1894,7 @@ XLATensor XLATensor::max_unpool_backward(const XLATensor& grad_output,
                                          const XLATensor& input,
                                          const XLATensor& indices,
                                          std::vector<int64_t> output_size) {
-  return grad_output.CreateFrom(ir::MakeNode<ir::ops::MaxUnpoolNdBackward>(
+  return grad_output.CreateFrom(torch::lazy::MakeNode<MaxUnpoolNdBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), indices.GetIrValue(),
       std::move(output_size)));
 }
@@ -1930,7 +1907,7 @@ XLATensor XLATensor::mean(const XLATensor& input,
     dtype = input.dtype_optional();
   }
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::Mean>(input.GetIrValue(),
+      torch::lazy::MakeNode<Mean>(input.GetIrValue(),
                                   torch::lazy::GetCanonicalDimensionIndices(
                                       xla::util::ToVector<int64_t>(dimensions),
                                       input.shape().get().rank()),
@@ -1940,49 +1917,48 @@ XLATensor XLATensor::mean(const XLATensor& input,
 
 XLATensor XLATensor::min(const XLATensor& input, const XLATensor& other,
                          c10::optional<at::ScalarType> logical_element_type) {
-  return input.CreateFrom(ir::ops::Min(input.GetIrValue(), other.GetIrValue()),
+  return input.CreateFrom(Min(input.GetIrValue(), other.GetIrValue()),
                           logical_element_type);
 }
 
 XLATensor XLATensor::min(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::MinUnary(input.GetIrValue()), input.dtype());
+  return input.CreateFrom(MinUnary(input.GetIrValue()), input.dtype());
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::min(const XLATensor& input,
                                                 int64_t dim, bool keepdim) {
   int64_t canonical_dim =
       torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::MinInDim>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<MinInDim>(
       input.GetIrValue(), canonical_dim, keepdim);
   return std::make_tuple(
-      input.CreateFrom(ir::XlaValue(node, 0)),
-      input.CreateFrom(ir::XlaValue(node, 1), at::ScalarType::Long));
+      input.CreateFrom(XlaValue(node, 0)),
+      input.CreateFrom(XlaValue(node, 1), at::ScalarType::Long));
 }
 
 void XLATensor::min_out(XLATensor& min, XLATensor& min_indices,
                         const XLATensor& input, int64_t dim, bool keepdim) {
   int64_t canonical_dim =
       torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank());
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::MinInDim>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<MinInDim>(
       input.GetIrValue(), canonical_dim, keepdim);
-  min.SetIrValue(ir::XlaValue(node, 0));
-  min_indices.SetIrValue(ir::XlaValue(node, 1));
+  min.SetIrValue(XlaValue(node, 0));
+  min_indices.SetIrValue(XlaValue(node, 1));
 }
 
 XLATensor XLATensor::mish(const XLATensor& input) {
   return input.CreateFrom(
       input.GetIrValue() *
-      ir::ops::Tanh(tensor_ops::Softplus(input, 1, 20).GetIrValue()));
+      Tanh(tensor_ops::Softplus(input, 1, 20).GetIrValue()));
 }
 
 XLATensor XLATensor::mm(const XLATensor& input, const XLATensor& weight) {
-  return input.CreateFrom(
-      ir::ops::Dot(input.GetIrValue(), weight.GetIrValue()));
+  return input.CreateFrom(Dot(input.GetIrValue(), weight.GetIrValue()));
 }
 
 XLATensor XLATensor::mse_loss(const XLATensor& input, const XLATensor& target,
                               int64_t reduction) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::MseLoss>(
+  return input.CreateFrom(torch::lazy::MakeNode<MseLoss>(
       input.GetIrValue(), target.GetIrValue(), GetXlaReductionMode(reduction)));
 }
 
@@ -1990,7 +1966,7 @@ XLATensor XLATensor::mse_loss_backward(const XLATensor& grad_output,
                                        const XLATensor& input,
                                        const XLATensor& target,
                                        int64_t reduction) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::MseLossBackward>(
+  return input.CreateFrom(torch::lazy::MakeNode<MseLossBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), target.GetIrValue(),
       GetXlaReductionMode(reduction)));
 }
@@ -2003,31 +1979,31 @@ XLATensor XLATensor::mul(const XLATensor& input, const XLATensor& other,
 
 XLATensor XLATensor::mul(const XLATensor& input, const at::Scalar& other,
                          c10::optional<at::ScalarType> logical_element_type) {
-  ir::XlaValue constant = GetIrValueForScalar(
+  XlaValue constant = GetIrValueForScalar(
       other, input.shape(), logical_element_type, input.GetDevice());
   return input.CreateFrom(input.GetIrValue() * constant, logical_element_type);
 }
 
 XLATensor XLATensor::mv(const XLATensor& input, const XLATensor& vec) {
-  return input.CreateFrom(ir::ops::Dot(input.GetIrValue(), vec.GetIrValue()));
+  return input.CreateFrom(Dot(input.GetIrValue(), vec.GetIrValue()));
 }
 
 void XLATensor::mv_out(XLATensor& out, const XLATensor& input,
                        const XLATensor& vec) {
-  out.SetIrValue(ir::ops::Dot(input.GetIrValue(), vec.GetIrValue()));
+  out.SetIrValue(Dot(input.GetIrValue(), vec.GetIrValue()));
 }
 
 XLATensor XLATensor::nan_to_num(const XLATensor& input, const at::Scalar& nan,
                                 const at::Scalar& posinf,
                                 const at::Scalar& neginf) {
-  ir::XlaValue nan_value =
+  XlaValue nan_value =
       GetIrValueForScalar(nan, input.shape(), input.GetDevice());
-  ir::XlaValue posinf_value =
+  XlaValue posinf_value =
       GetIrValueForScalar(posinf, input.shape(), input.GetDevice());
-  ir::XlaValue neginf_value =
+  XlaValue neginf_value =
       GetIrValueForScalar(neginf, input.shape(), input.GetDevice());
-  return input.CreateFrom(ir::ops::NanToNum(input.GetIrValue(), nan_value,
-                                            posinf_value, neginf_value));
+  return input.CreateFrom(
+      NanToNum(input.GetIrValue(), nan_value, posinf_value, neginf_value));
 }
 
 XLATensor XLATensor::narrow(const XLATensor& input, int64_t dim, int64_t start,
@@ -2052,30 +2028,30 @@ std::tuple<XLATensor, XLATensor, XLATensor> XLATensor::native_batch_norm(
     XLATensor& running_mean, XLATensor& running_var, bool training,
     double momentum, double eps) {
   xla::Shape features_shape = BatchNormFeaturesShape(input);
-  ir::XlaValue weight_value =
+  XlaValue weight_value =
       GetIrValueOrDefault(weight, 1, features_shape, input.GetDevice());
-  ir::XlaValue bias_value =
+  XlaValue bias_value =
       GetIrValueOrDefault(bias, 0, features_shape, input.GetDevice());
-  ir::XlaValue running_mean_value =
+  XlaValue running_mean_value =
       GetIrValueOrDefault(running_mean, 0, features_shape, input.GetDevice());
-  ir::XlaValue running_var_value =
+  XlaValue running_var_value =
       GetIrValueOrDefault(running_var, 0, features_shape, input.GetDevice());
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::NativeBatchNormForward>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<NativeBatchNormForward>(
       input.GetIrValue(), weight_value, bias_value, running_mean_value,
       running_var_value, training, eps);
-  XLATensor output = input.CreateFrom(ir::XlaValue(node, 0));
+  XLATensor output = input.CreateFrom(XlaValue(node, 0));
   XLATensor mean;
   XLATensor variance_inverse;
   if (training) {
-    mean = input.CreateFrom(ir::XlaValue(node, 1));
-    variance_inverse = input.CreateFrom(ir::XlaValue(node, 3));
+    mean = input.CreateFrom(XlaValue(node, 1));
+    variance_inverse = input.CreateFrom(XlaValue(node, 3));
     if (!running_mean.is_null()) {
-      running_mean.SetIrValue(ir::MakeNode<ir::ops::LinearInterpolation>(
+      running_mean.SetIrValue(torch::lazy::MakeNode<LinearInterpolation>(
           mean.GetIrValue(), running_mean.GetIrValue(), momentum));
     }
     if (!running_var.is_null()) {
-      running_var.SetIrValue(ir::MakeNode<ir::ops::LinearInterpolation>(
-          ir::XlaValue(node, 2), running_var.GetIrValue(), momentum));
+      running_var.SetIrValue(torch::lazy::MakeNode<LinearInterpolation>(
+          XlaValue(node, 2), running_var.GetIrValue(), momentum));
     }
   } else {
     at::Tensor at_input = bridge::AtenFromXlaTensor(input);
@@ -2094,14 +2070,14 @@ XLATensor::native_batch_norm_backward(const XLATensor& grad_out,
                                       const XLATensor& save_invstd,
                                       bool training, double eps) {
   xla::Shape features_shape = BatchNormFeaturesShape(input);
-  ir::XlaValue weight_value =
+  XlaValue weight_value =
       GetIrValueOrDefault(weight, 1, features_shape, input.GetDevice());
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::NativeBatchNormBackward>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<NativeBatchNormBackward>(
       grad_out.GetIrValue(), input.GetIrValue(), weight_value,
       save_mean.GetIrValue(), save_invstd.GetIrValue(), training, eps);
-  XLATensor grad_input = input.CreateFrom(ir::XlaValue(node, 0));
-  XLATensor grad_weight = input.CreateFrom(ir::XlaValue(node, 1));
-  XLATensor grad_bias = input.CreateFrom(ir::XlaValue(node, 2));
+  XLATensor grad_input = input.CreateFrom(XlaValue(node, 0));
+  XLATensor grad_weight = input.CreateFrom(XlaValue(node, 1));
+  XLATensor grad_bias = input.CreateFrom(XlaValue(node, 2));
   return std::make_tuple(std::move(grad_input), std::move(grad_weight),
                          std::move(grad_bias));
 }
@@ -2115,13 +2091,13 @@ XLATensor XLATensor::ne(const XLATensor& input, const XLATensor& other) {
 }
 
 XLATensor XLATensor::neg(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Neg(input.GetIrValue()));
+  return input.CreateFrom(Neg(input.GetIrValue()));
 }
 
 XLATensor XLATensor::nll_loss(const XLATensor& input, const XLATensor& target,
                               const XLATensor& weight, int64_t reduction,
                               int ignore_index) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::NllLoss>(
+  return input.CreateFrom(torch::lazy::MakeNode<NllLoss>(
       input.GetIrValue(), target.GetIrValue(), GetOptionalIrValue(weight),
       GetXlaReductionMode(reduction), ignore_index));
 }
@@ -2129,7 +2105,7 @@ XLATensor XLATensor::nll_loss(const XLATensor& input, const XLATensor& target,
 XLATensor XLATensor::nll_loss2d(const XLATensor& input, const XLATensor& target,
                                 const XLATensor& weight, int64_t reduction,
                                 int ignore_index) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::NllLoss2d>(
+  return input.CreateFrom(torch::lazy::MakeNode<NllLoss2d>(
       input.GetIrValue(), target.GetIrValue(), GetOptionalIrValue(weight),
       GetXlaReductionMode(reduction), ignore_index));
 }
@@ -2140,7 +2116,7 @@ XLATensor XLATensor::nll_loss2d_backward(const XLATensor& grad_output,
                                          const XLATensor& weight,
                                          int64_t reduction, int ignore_index,
                                          const XLATensor& total_weight) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::NllLoss2dBackward>(
+  return input.CreateFrom(torch::lazy::MakeNode<NllLoss2dBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), target.GetIrValue(),
       GetOptionalIrValue(weight), GetOptionalIrValue(total_weight),
       GetXlaReductionMode(reduction), ignore_index));
@@ -2152,7 +2128,7 @@ XLATensor XLATensor::nll_loss_backward(const XLATensor& grad_output,
                                        const XLATensor& weight,
                                        int64_t reduction, int ignore_index,
                                        const XLATensor& total_weight) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::NllLossBackward>(
+  return input.CreateFrom(torch::lazy::MakeNode<NllLossBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), target.GetIrValue(),
       GetOptionalIrValue(weight), GetOptionalIrValue(total_weight),
       GetXlaReductionMode(reduction), ignore_index));
@@ -2163,18 +2139,18 @@ std::pair<XLATensor, XLATensor> XLATensor::nms(const XLATensor& boxes,
                                                const XLATensor& score_threshold,
                                                const XLATensor& iou_threshold,
                                                int64_t output_size) {
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::Nms>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<Nms>(
       boxes.GetIrValue(), scores.GetIrValue(), score_threshold.GetIrValue(),
       iou_threshold.GetIrValue(), output_size);
   return std::pair<XLATensor, XLATensor>(
-      Create(ir::XlaValue(node, 0), boxes.GetDevice(), at::ScalarType::Int),
-      Create(ir::XlaValue(node, 1), boxes.GetDevice(), at::ScalarType::Int));
+      Create(XlaValue(node, 0), boxes.GetDevice(), at::ScalarType::Int),
+      Create(XlaValue(node, 1), boxes.GetDevice(), at::ScalarType::Int));
 }
 
 XLATensor XLATensor::nonzero(const XLATensor& input) {
   torch::lazy::NodePtr node =
-      ir::MakeNode<ir::ops::NonZero>(input.GetIrValue());
-  return input.CreateFrom(ir::XlaValue(node, 0), at::ScalarType::Long);
+      torch::lazy::MakeNode<NonZero>(input.GetIrValue());
+  return input.CreateFrom(XlaValue(node, 0), at::ScalarType::Long);
 }
 
 XLATensor XLATensor::norm(const XLATensor& input,
@@ -2187,30 +2163,30 @@ XLATensor XLATensor::norm(const XLATensor& input,
     dtype = input.dtype_optional();
   }
   return input.CreateFrom(
-      ir::ops::Norm(input.GetIrValue(), p, dtype, canonical_dims, keepdim));
+      Norm(input.GetIrValue(), p, dtype, canonical_dims, keepdim));
 }
 
 XLATensor XLATensor::normal(double mean, const XLATensor& std) {
-  return std.CreateFrom(ir::MakeNode<ir::ops::Normal>(
+  return std.CreateFrom(torch::lazy::MakeNode<Normal>(
       GetIrValueForScalar(mean, std.shape(), std.GetDevice()), std.GetIrValue(),
       GetRngSeed(std.GetDevice())));
 }
 
 XLATensor XLATensor::normal(const XLATensor& mean, double std) {
-  return mean.CreateFrom(ir::MakeNode<ir::ops::Normal>(
+  return mean.CreateFrom(torch::lazy::MakeNode<Normal>(
       mean.GetIrValue(),
       GetIrValueForScalar(std, mean.shape(), mean.GetDevice()),
       GetRngSeed(mean.GetDevice())));
 }
 
 XLATensor XLATensor::normal(const XLATensor& mean, const XLATensor& std) {
-  return mean.CreateFrom(ir::MakeNode<ir::ops::Normal>(
+  return mean.CreateFrom(torch::lazy::MakeNode<Normal>(
       mean.GetIrValue(), MaybeExpand(std.GetIrValue(), mean.shape()),
       GetRngSeed(mean.GetDevice())));
 }
 
 void XLATensor::normal_(XLATensor& input, double mean, double std) {
-  input.SetInPlaceIrValue(ir::MakeNode<ir::ops::Normal>(
+  input.SetInPlaceIrValue(torch::lazy::MakeNode<Normal>(
       GetIrValueForScalar(mean, input.shape(), input.GetDevice()),
       GetIrValueForScalar(std, input.shape(), input.GetDevice()),
       GetRngSeed(input.GetDevice())));
@@ -2218,20 +2194,20 @@ void XLATensor::normal_(XLATensor& input, double mean, double std) {
 
 XLATensor XLATensor::not_supported(std::string description, xla::Shape shape,
                                    const torch::lazy::BackendDevice& device) {
-  return Create(ir::MakeNode<ir::ops::NotSupported>(std::move(description),
+  return Create(torch::lazy::MakeNode<NotSupported>(std::move(description),
                                                     std::move(shape)),
                 device);
 }
 
 void XLATensor::optimization_barrier_(std::vector<XLATensor>& tensors) {
-  std::vector<ir::XlaValue> irs;
+  std::vector<XlaValue> irs;
   irs.reserve(tensors.size());
   for (XLATensor& tensor : tensors) {
     irs.push_back(tensor.GetIrValue());
   }
-  torch::lazy::NodePtr result = ir::MakeNode<ir::ops::OptimizationBarrier>(irs);
+  torch::lazy::NodePtr result = torch::lazy::MakeNode<OptimizationBarrier>(irs);
   for (int i = 0; i < tensors.size(); i++) {
-    tensors[i].SetInPlaceIrValue(ir::XlaValue(result, i));
+    tensors[i].SetInPlaceIrValue(XlaValue(result, i));
   }
 }
 
@@ -2248,24 +2224,22 @@ XLATensor XLATensor::permute(const XLATensor& input,
 XLATensor XLATensor::pow(const XLATensor& input, const at::Scalar& exponent) {
   // We want to pass exponent_node as a constant to give XLA more room to
   // optimize
-  ir::XlaValue exponent_node = GetIrValueForConstant(exponent, input.shape());
-  return input.CreateFrom(ir::ops::Pow(input.GetIrValue(), exponent_node));
+  XlaValue exponent_node = GetIrValueForConstant(exponent, input.shape());
+  return input.CreateFrom(Pow(input.GetIrValue(), exponent_node));
 }
 
 XLATensor XLATensor::pow(const XLATensor& input, const XLATensor& exponent) {
-  return input.CreateFrom(
-      ir::ops::Pow(input.GetIrValue(), exponent.GetIrValue()));
+  return input.CreateFrom(Pow(input.GetIrValue(), exponent.GetIrValue()));
 }
 
 XLATensor XLATensor::pow(const at::Scalar& input, const XLATensor& exponent) {
-  ir::XlaValue input_node =
+  XlaValue input_node =
       GetIrValueForScalar(input, exponent.shape(), exponent.GetDevice());
-  return exponent.CreateFrom(ir::ops::Pow(input_node, exponent.GetIrValue()));
+  return exponent.CreateFrom(Pow(input_node, exponent.GetIrValue()));
 }
 
 XLATensor XLATensor::prelu(const XLATensor& input, const XLATensor& weight) {
-  return input.CreateFrom(
-      ir::ops::Prelu(input.GetIrValue(), weight.GetIrValue()));
+  return input.CreateFrom(Prelu(input.GetIrValue(), weight.GetIrValue()));
 }
 
 XLATensor XLATensor::prod(const XLATensor& input,
@@ -2276,7 +2250,7 @@ XLATensor XLATensor::prod(const XLATensor& input,
     dtype = input.dtype_optional();
   }
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::Prod>(input.GetIrValue(),
+      torch::lazy::MakeNode<Prod>(input.GetIrValue(),
                                   torch::lazy::GetCanonicalDimensionIndices(
                                       xla::util::ToVector<int64_t>(dimensions),
                                       input.shape().get().rank()),
@@ -2286,22 +2260,22 @@ XLATensor XLATensor::prod(const XLATensor& input,
 
 void XLATensor::put_(XLATensor& input, const XLATensor& index,
                      const XLATensor& source, bool accumulate) {
-  input.SetInPlaceIrValue(ir::MakeNode<ir::ops::Put>(
+  input.SetInPlaceIrValue(torch::lazy::MakeNode<Put>(
       input.GetIrValue(), index.GetIrValue(), source.GetIrValue(), accumulate));
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::qr(const XLATensor& input,
                                                bool some) {
   torch::lazy::NodePtr node =
-      ir::MakeNode<ir::ops::QR>(input.GetIrValue(), some);
-  return std::make_tuple(input.CreateFrom(ir::XlaValue(node, 0)),
-                         input.CreateFrom(ir::XlaValue(node, 1)));
+      torch::lazy::MakeNode<QR>(input.GetIrValue(), some);
+  return std::make_tuple(input.CreateFrom(XlaValue(node, 0)),
+                         input.CreateFrom(XlaValue(node, 1)));
 }
 
 void XLATensor::random_(XLATensor& input, int64_t from, int64_t to) {
   XLA_CHECK_LE(from, to);
   auto input_shape = input.shape();
-  input.SetInPlaceIrValue(ir::MakeNode<ir::ops::DiscreteUniform>(
+  input.SetInPlaceIrValue(torch::lazy::MakeNode<DiscreteUniform>(
       GetIrValueForScalar(from, xla::PrimitiveType::S64, input.GetDevice()),
       GetIrValueForScalar(to, xla::PrimitiveType::S64, input.GetDevice()),
       GetRngSeed(input.GetDevice()), input_shape));
@@ -2313,78 +2287,77 @@ void XLATensor::randperm_out(int64_t n, XLATensor& out) {
 }
 
 XLATensor XLATensor::reciprocal(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::ReciprocalOp(input.GetIrValue()));
+  return input.CreateFrom(ReciprocalOp(input.GetIrValue()));
 }
 
 XLATensor XLATensor::reflection_pad2d(const XLATensor& input,
                                       std::vector<int64_t> padding) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::ReflectionPad2d>(
+  return input.CreateFrom(torch::lazy::MakeNode<ReflectionPad2d>(
       input.GetIrValue(), std::move(padding)));
 }
 
 XLATensor XLATensor::reflection_pad2d_backward(const XLATensor& grad_output,
                                                const XLATensor& input,
                                                std::vector<int64_t> padding) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::ReflectionPad2dBackward>(
+  return input.CreateFrom(torch::lazy::MakeNode<ReflectionPad2dBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), std::move(padding)));
 }
 
 XLATensor XLATensor::relu(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::ReluOp(input.GetIrValue()));
+  return input.CreateFrom(ReluOp(input.GetIrValue()));
 }
 
 void XLATensor::relu_(XLATensor& input) {
-  input.SetInPlaceIrValue(ir::ops::ReluOp(input.GetIrValue()));
+  input.SetInPlaceIrValue(ReluOp(input.GetIrValue()));
 }
 
 XLATensor XLATensor::remainder(const XLATensor& input, const XLATensor& other) {
-  return input.CreateFrom(
-      ir::ops::Remainder(input.GetIrValue(), other.GetIrValue()));
+  return input.CreateFrom(Remainder(input.GetIrValue(), other.GetIrValue()));
 }
 
 XLATensor XLATensor::remainder(const XLATensor& input,
                                const at::Scalar& other) {
-  ir::XlaValue constant =
+  XlaValue constant =
       GetIrValueForScalar(other, input.shape(), input.GetDevice());
-  return input.CreateFrom(ir::ops::Remainder(input.GetIrValue(), constant));
+  return input.CreateFrom(Remainder(input.GetIrValue(), constant));
 }
 
 XLATensor XLATensor::repeat(const XLATensor& input,
                             std::vector<int64_t> repeats) {
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::Repeat>(input.GetIrValue(), std::move(repeats)));
+      torch::lazy::MakeNode<Repeat>(input.GetIrValue(), std::move(repeats)));
 }
 
 XLATensor XLATensor::replication_pad1d(const XLATensor& input,
                                        std::vector<int64_t> padding) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::ReplicationPad>(
+  return input.CreateFrom(torch::lazy::MakeNode<ReplicationPad>(
       input.GetIrValue(), std::move(padding)));
 }
 
 XLATensor XLATensor::replication_pad1d_backward(const XLATensor& grad_output,
                                                 const XLATensor& input,
                                                 std::vector<int64_t> padding) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::ReplicationPadBackward>(
+  return input.CreateFrom(torch::lazy::MakeNode<ReplicationPadBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), std::move(padding)));
 }
 
 XLATensor XLATensor::replication_pad2d(const XLATensor& input,
                                        std::vector<int64_t> padding) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::ReplicationPad>(
+  return input.CreateFrom(torch::lazy::MakeNode<ReplicationPad>(
       input.GetIrValue(), std::move(padding)));
 }
 
 XLATensor XLATensor::replication_pad2d_backward(const XLATensor& grad_output,
                                                 const XLATensor& input,
                                                 std::vector<int64_t> padding) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::ReplicationPadBackward>(
+  return input.CreateFrom(torch::lazy::MakeNode<ReplicationPadBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), std::move(padding)));
 }
 
 void XLATensor::resize_(XLATensor& input, std::vector<int64_t> size) {
   if (input.data()->view == nullptr) {
     input.SetIrValue(
-        ir::MakeNode<ir::ops::Resize>(input.GetIrValue(), std::move(size)));
+        torch::lazy::MakeNode<Resize>(input.GetIrValue(), std::move(size)));
   } else {
     auto input_shape = input.shape();
     xla::Shape resize_shape =
@@ -2406,23 +2379,23 @@ XLATensor XLATensor::roll(const XLATensor& input,
   }
   auto canonical_dims = torch::lazy::GetCanonicalDimensionIndices(
       torch::lazy::ToVector<int64_t>(dims), input.shape().get().rank());
-  return input.CreateFrom(ir::MakeNode<ir::ops::Roll>(
+  return input.CreateFrom(torch::lazy::MakeNode<Roll>(
       input.GetIrValue(), torch::lazy::ToVector<int64_t>(shifts),
       canonical_dims));
 }
 
 XLATensor XLATensor::round(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Round(input.GetIrValue()));
+  return input.CreateFrom(Round(input.GetIrValue()));
 }
 
 XLATensor XLATensor::rrelu_with_noise(const XLATensor& input, XLATensor& noise,
                                       const at::Scalar& lower,
                                       const at::Scalar& upper, bool training) {
-  torch::lazy::NodePtr output_node = ir::MakeNode<ir::ops::RreluWithNoise>(
+  torch::lazy::NodePtr output_node = torch::lazy::MakeNode<RreluWithNoise>(
       input.GetIrValue(), GetRngSeed(input.GetDevice()), lower, upper,
       training);
-  noise.SetIrValue(ir::XlaValue(output_node, 1));
-  return input.CreateFrom(ir::XlaValue(output_node, 0));
+  noise.SetIrValue(XlaValue(output_node, 1));
+  return input.CreateFrom(XlaValue(output_node, 0));
 }
 
 XLATensor XLATensor::rrelu_with_noise_backward(const XLATensor& grad_output,
@@ -2431,19 +2404,19 @@ XLATensor XLATensor::rrelu_with_noise_backward(const XLATensor& grad_output,
                                                const at::Scalar& lower,
                                                const at::Scalar& upper,
                                                bool training) {
-  return grad_output.CreateFrom(ir::MakeNode<ir::ops::RreluWithNoiseBackward>(
+  return grad_output.CreateFrom(torch::lazy::MakeNode<RreluWithNoiseBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), noise.GetIrValue(), lower,
       upper, training));
 }
 
 XLATensor XLATensor::rsqrt(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Rsqrt(input.GetIrValue()));
+  return input.CreateFrom(Rsqrt(input.GetIrValue()));
 }
 
 XLATensor XLATensor::rsub(const XLATensor& input, const XLATensor& other,
                           const at::Scalar& alpha,
                           c10::optional<at::ScalarType> logical_element_type) {
-  ir::XlaValue alpha_xla = GetIrValueForScalar(
+  XlaValue alpha_xla = GetIrValueForScalar(
       alpha, other.shape(), logical_element_type, other.GetDevice());
   return input.CreateFrom(other.GetIrValue() - alpha_xla * input.GetIrValue(),
                           logical_element_type);
@@ -2452,9 +2425,9 @@ XLATensor XLATensor::rsub(const XLATensor& input, const XLATensor& other,
 XLATensor XLATensor::rsub(const XLATensor& input, const at::Scalar& other,
                           const at::Scalar& alpha,
                           c10::optional<at::ScalarType> logical_element_type) {
-  ir::XlaValue alpha_xla = GetIrValueForScalar(
+  XlaValue alpha_xla = GetIrValueForScalar(
       alpha, input.shape(), logical_element_type, input.GetDevice());
-  ir::XlaValue other_xla = GetIrValueForScalar(
+  XlaValue other_xla = GetIrValueForScalar(
       other, input.shape(), logical_element_type, input.GetDevice());
   return input.CreateFrom(other_xla - alpha_xla * input.GetIrValue(),
                           logical_element_type);
@@ -2462,11 +2435,11 @@ XLATensor XLATensor::rsub(const XLATensor& input, const at::Scalar& other,
 
 void XLATensor::copy_(XLATensor& input, XLATensor& src) {
   if (input.GetDevice() == src.GetDevice()) {
-    ir::XlaValue copy_value;
+    XlaValue copy_value;
     if (input.dtype() == src.dtype()) {
       copy_value = src.GetIrValue();
     } else {
-      copy_value = ir::MakeNode<ir::ops::Cast>(src.GetIrValue(), input.dtype(),
+      copy_value = torch::lazy::MakeNode<Cast>(src.GetIrValue(), input.dtype(),
                                                src.dtype());
     }
     input.SetIrValue(MaybeExpand(copy_value, input.shape()));
@@ -2483,7 +2456,7 @@ void XLATensor::copy_(XLATensor& input, XLATensor& src) {
 
 XLATensor XLATensor::scatter(const XLATensor& input, int64_t dim,
                              const XLATensor& index, const XLATensor& src) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::Scatter>(
+  return input.CreateFrom(torch::lazy::MakeNode<Scatter>(
       input.GetIrValue(), index.GetIrValue(), src.GetIrValue(),
       torch::lazy::GetCanonicalDimensionIndex(dim,
                                               input.shape().get().rank())));
@@ -2491,9 +2464,9 @@ XLATensor XLATensor::scatter(const XLATensor& input, int64_t dim,
 
 XLATensor XLATensor::scatter(const XLATensor& input, int64_t dim,
                              const XLATensor& index, const at::Scalar& value) {
-  ir::XlaValue constant =
+  XlaValue constant =
       GetIrValueForScalar(value, input.shape(), input.GetDevice());
-  return input.CreateFrom(ir::MakeNode<ir::ops::Scatter>(
+  return input.CreateFrom(torch::lazy::MakeNode<Scatter>(
       input.GetIrValue(), index.GetIrValue(), constant,
       torch::lazy::GetCanonicalDimensionIndex(dim,
                                               input.shape().get().rank())));
@@ -2501,7 +2474,7 @@ XLATensor XLATensor::scatter(const XLATensor& input, int64_t dim,
 
 XLATensor XLATensor::scatter_add(const XLATensor& input, int64_t dim,
                                  const XLATensor& index, const XLATensor& src) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::ScatterAdd>(
+  return input.CreateFrom(torch::lazy::MakeNode<ScatterAdd>(
       input.GetIrValue(), index.GetIrValue(), src.GetIrValue(),
       torch::lazy::GetCanonicalDimensionIndex(dim,
                                               input.shape().get().rank())));
@@ -2510,9 +2483,9 @@ XLATensor XLATensor::scatter_add(const XLATensor& input, int64_t dim,
 XLATensor XLATensor::scatter_add(const XLATensor& input, int64_t dim,
                                  const XLATensor& index,
                                  const at::Scalar& value) {
-  ir::XlaValue constant =
+  XlaValue constant =
       GetIrValueForScalar(value, input.shape(), input.GetDevice());
-  return input.CreateFrom(ir::MakeNode<ir::ops::ScatterAdd>(
+  return input.CreateFrom(torch::lazy::MakeNode<ScatterAdd>(
       input.GetIrValue(), index.GetIrValue(), constant,
       torch::lazy::GetCanonicalDimensionIndex(dim,
                                               input.shape().get().rank())));
@@ -2524,38 +2497,38 @@ XLATensor XLATensor::select(const XLATensor& input, int64_t dim,
 }
 
 void XLATensor::silu_out(XLATensor& input, XLATensor& out) {
-  out.SetInPlaceIrValue(ir::ops::SiLU(input.GetIrValue()));
+  out.SetInPlaceIrValue(SiLU(input.GetIrValue()));
 }
 
 XLATensor XLATensor::silu_backward(XLATensor& grad_output, XLATensor& input) {
   return input.CreateFrom(
-      ir::ops::SiLUBackward(grad_output.GetIrValue(), input.GetIrValue()));
+      SiLUBackward(grad_output.GetIrValue(), input.GetIrValue()));
 }
 
 XLATensor XLATensor::sigmoid(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Sigmoid(input.GetIrValue()));
+  return input.CreateFrom(Sigmoid(input.GetIrValue()));
 }
 
 XLATensor XLATensor::sigmoid_backward(const XLATensor& grad_output,
                                       const XLATensor& output) {
   return grad_output.CreateFrom(
-      ir::ops::SigmoidBackward(grad_output.GetIrValue(), output.GetIrValue()));
+      SigmoidBackward(grad_output.GetIrValue(), output.GetIrValue()));
 }
 
 XLATensor XLATensor::sgn(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::SgnOp(input.GetIrValue()));
+  return input.CreateFrom(SgnOp(input.GetIrValue()));
 }
 
 XLATensor XLATensor::sign(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::SignOp(input.GetIrValue()));
+  return input.CreateFrom(SignOp(input.GetIrValue()));
 }
 
 XLATensor XLATensor::sin(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Sin(input.GetIrValue()));
+  return input.CreateFrom(Sin(input.GetIrValue()));
 }
 
 XLATensor XLATensor::sinh(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Sinh(input.GetIrValue()));
+  return input.CreateFrom(Sinh(input.GetIrValue()));
 }
 
 XLATensor XLATensor::slice(const XLATensor& input, int64_t dim, int64_t start,
@@ -2578,9 +2551,9 @@ XLATensor XLATensor::slice(const XLATensor& input, int64_t dim, int64_t start,
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::slogdet(const XLATensor& input) {
-  torch::lazy::NodePtr node = ir::ops::SLogDet(input.GetIrValue());
-  return std::make_tuple(input.CreateFrom(ir::XlaValue(node, 0)),
-                         input.CreateFrom(ir::XlaValue(node, 1)));
+  torch::lazy::NodePtr node = SLogDet(input.GetIrValue());
+  return std::make_tuple(input.CreateFrom(XlaValue(node, 0)),
+                         input.CreateFrom(XlaValue(node, 1)));
 }
 
 XLATensor XLATensor::smooth_l1_loss(const XLATensor& input,
@@ -2604,7 +2577,7 @@ XLATensor XLATensor::softmax(const XLATensor& input, int64_t dim,
     dtype = input.dtype_optional();
   }
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::Softmax>(input.GetIrValue(),
+      torch::lazy::MakeNode<Softmax>(input.GetIrValue(),
                                      torch::lazy::GetCanonicalDimensionIndex(
                                          dim, input.shape().get().rank()),
                                      dtype),
@@ -2613,18 +2586,18 @@ XLATensor XLATensor::softmax(const XLATensor& input, int64_t dim,
 
 XLATensor XLATensor::softmax_backward(const XLATensor& grad_output,
                                       const XLATensor& output, int64_t dim) {
-  return grad_output.CreateFrom(ir::ops::SoftmaxBackwardOp(
-      grad_output.GetIrValue(), output.GetIrValue(), dim));
+  return grad_output.CreateFrom(
+      SoftmaxBackwardOp(grad_output.GetIrValue(), output.GetIrValue(), dim));
 }
 
 XLATensor XLATensor::softplus(const XLATensor& input, const at::Scalar& beta,
                               const at::Scalar& threshold) {
-  ir::XlaValue beta_value = XLATensor::GetIrValueForScalar(
+  XlaValue beta_value = XLATensor::GetIrValueForScalar(
       beta, input.shape().get().element_type(), input.GetDevice());
-  ir::XlaValue threshold_value = XLATensor::GetIrValueForScalar(
+  XlaValue threshold_value = XLATensor::GetIrValueForScalar(
       threshold, input.shape().get().element_type(), input.GetDevice());
   return input.CreateFrom(
-      ir::ops::Softplus(input.GetIrValue(), beta_value, threshold_value));
+      Softplus(input.GetIrValue(), beta_value, threshold_value));
 }
 
 XLATensor XLATensor::softplus_backward(const XLATensor& grad_output,
@@ -2637,13 +2610,13 @@ XLATensor XLATensor::softplus_backward(const XLATensor& grad_output,
 XLATensor XLATensor::softshrink(const XLATensor& input,
                                 const at::Scalar& lambda) {
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::Softshrink>(input.GetIrValue(), lambda));
+      torch::lazy::MakeNode<Softshrink>(input.GetIrValue(), lambda));
 }
 
 XLATensor XLATensor::softshrink_backward(const XLATensor& grad_out,
                                          const XLATensor& input,
                                          const at::Scalar& lambda) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::ShrinkBackward>(
+  return input.CreateFrom(torch::lazy::MakeNode<ShrinkBackward>(
       torch::lazy::OpKind(at::aten::softshrink_backward), grad_out.GetIrValue(),
       input.GetIrValue(), lambda));
 }
@@ -2659,13 +2632,13 @@ std::vector<XLATensor> XLATensor::split(const XLATensor& input,
     // no matter what split_size is.
     xla::Literal literal(input_shape.get());
     return {
-        input.CreateFrom(ir::MakeNode<ir::ops::Constant>(std::move(literal)))};
+        input.CreateFrom(torch::lazy::MakeNode<Constant>(std::move(literal)))};
   }
   std::vector<int64_t> split_sizes;
   for (; dim_size > 0; dim_size -= split_size) {
     split_sizes.push_back(std::min<int64_t>(dim_size, split_size));
   }
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::Split>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<Split>(
       input.GetIrValue(), std::move(split_sizes), split_dim);
   return input.MakeOutputTensors(node);
 }
@@ -2675,13 +2648,13 @@ std::vector<XLATensor> XLATensor::split_with_sizes(
   auto input_shape = input.shape();
   int split_dim =
       torch::lazy::GetCanonicalDimensionIndex(dim, input_shape.get().rank());
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::Split>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<Split>(
       input.GetIrValue(), std::move(split_size), split_dim);
   return input.MakeOutputTensors(node);
 }
 
 XLATensor XLATensor::sqrt(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Sqrt(input.GetIrValue()));
+  return input.CreateFrom(Sqrt(input.GetIrValue()));
 }
 
 XLATensor XLATensor::squeeze(const XLATensor& input) {
@@ -2701,31 +2674,31 @@ XLATensor XLATensor::squeeze(const XLATensor& input, int64_t dim) {
 }
 
 void XLATensor::squeeze_(XLATensor& input) {
-  input.SetIrValue(ir::MakeNode<ir::ops::Squeeze>(input.GetIrValue(), -1));
+  input.SetIrValue(torch::lazy::MakeNode<Squeeze>(input.GetIrValue(), -1));
 }
 
 void XLATensor::squeeze_(XLATensor& input, int64_t dim) {
-  input.SetIrValue(ir::MakeNode<ir::ops::Squeeze>(
+  input.SetIrValue(torch::lazy::MakeNode<Squeeze>(
       input.GetIrValue(), torch::lazy::GetCanonicalDimensionIndex(
                               dim, input.shape().get().rank())));
 }
 
 XLATensor XLATensor::stack(absl::Span<const XLATensor> tensors, int64_t dim) {
   XLA_CHECK_GT(tensors.size(), 0);
-  std::vector<ir::XlaValue> values;
+  std::vector<XlaValue> values;
   for (auto& tensor : tensors) {
     values.push_back(tensor.GetIrValue());
   }
   int64_t canonical_dim = torch::lazy::GetCanonicalDimensionIndex(
       dim, tensors.front().shape().get().rank() + 1);
   return tensors[0].CreateFrom(
-      ir::MakeNode<ir::ops::Stack>(values, canonical_dim));
+      torch::lazy::MakeNode<Stack>(values, canonical_dim));
 }
 
 XLATensor XLATensor::std(const XLATensor& input,
                          std::vector<int64_t> dimensions,
                          bool keep_reduced_dimensions, int64_t correction) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::Std>(
+  return input.CreateFrom(torch::lazy::MakeNode<Std>(
       input.GetIrValue(),
       torch::lazy::GetCanonicalDimensionIndices(
           xla::util::ToVector<int64_t>(dimensions), input.shape().get().rank()),
@@ -2735,19 +2708,19 @@ XLATensor XLATensor::std(const XLATensor& input,
 std::tuple<XLATensor, XLATensor> XLATensor::std_mean(
     const XLATensor& input, std::vector<int64_t> dimensions, int64_t correction,
     bool keep_reduced_dimensions) {
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::StdMean>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<StdMean>(
       input.GetIrValue(),
       torch::lazy::GetCanonicalDimensionIndices(
           xla::util::ToVector<int64_t>(dimensions), input.shape().get().rank()),
       correction, keep_reduced_dimensions);
-  return std::make_tuple(input.CreateFrom(ir::XlaValue(node, 0)),
-                         input.CreateFrom(ir::XlaValue(node, 1)));
+  return std::make_tuple(input.CreateFrom(XlaValue(node, 0)),
+                         input.CreateFrom(XlaValue(node, 1)));
 }
 
 XLATensor XLATensor::sub(const XLATensor& input, const XLATensor& other,
                          const at::Scalar& alpha,
                          c10::optional<at::ScalarType> logical_element_type) {
-  ir::XlaValue constant = GetIrValueForScalar(
+  XlaValue constant = GetIrValueForScalar(
       alpha, other.shape(), logical_element_type, other.GetDevice());
   return input.CreateFrom(input.GetIrValue() - other.GetIrValue() * constant,
                           logical_element_type);
@@ -2756,9 +2729,9 @@ XLATensor XLATensor::sub(const XLATensor& input, const XLATensor& other,
 XLATensor XLATensor::sub(const XLATensor& input, const at::Scalar& other,
                          const at::Scalar& alpha,
                          c10::optional<at::ScalarType> logical_element_type) {
-  ir::XlaValue other_constant = GetIrValueForScalar(
+  XlaValue other_constant = GetIrValueForScalar(
       other, input.shape(), logical_element_type, input.GetDevice());
-  ir::XlaValue alpha_constant = GetIrValueForScalar(
+  XlaValue alpha_constant = GetIrValueForScalar(
       alpha, input.shape(), logical_element_type, input.GetDevice());
   return input.CreateFrom(input.GetIrValue() - other_constant * alpha_constant,
                           logical_element_type);
@@ -2774,7 +2747,7 @@ XLATensor XLATensor::sum(const XLATensor& input,
     dtype = input.dtype_optional();
   }
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::Sum>(input.GetIrValue(),
+      torch::lazy::MakeNode<Sum>(input.GetIrValue(),
                                  torch::lazy::GetCanonicalDimensionIndices(
                                      xla::util::ToVector<int64_t>(dimensions),
                                      input.shape().get().rank()),
@@ -2785,10 +2758,10 @@ XLATensor XLATensor::sum(const XLATensor& input,
 std::tuple<XLATensor, XLATensor, XLATensor> XLATensor::svd(
     const XLATensor& input, bool some, bool compute_uv) {
   torch::lazy::NodePtr node =
-      ir::MakeNode<ir::ops::SVD>(input.GetIrValue(), some, compute_uv);
-  return std::make_tuple(input.CreateFrom(ir::XlaValue(node, 0)),
-                         input.CreateFrom(ir::XlaValue(node, 1)),
-                         input.CreateFrom(ir::XlaValue(node, 2)));
+      torch::lazy::MakeNode<SVD>(input.GetIrValue(), some, compute_uv);
+  return std::make_tuple(input.CreateFrom(XlaValue(node, 0)),
+                         input.CreateFrom(XlaValue(node, 1)),
+                         input.CreateFrom(XlaValue(node, 2)));
 }
 
 std::tuple<XLATensor, XLATensor> XLATensor::symeig(const XLATensor& input,
@@ -2796,22 +2769,21 @@ std::tuple<XLATensor, XLATensor> XLATensor::symeig(const XLATensor& input,
                                                    bool upper) {
   // SymEig takes lower instead of upper, hence the negation.
   torch::lazy::NodePtr node =
-      ir::MakeNode<ir::ops::SymEig>(input.GetIrValue(), eigenvectors, !upper);
-  return std::make_tuple(input.CreateFrom(ir::XlaValue(node, 0)),
-                         input.CreateFrom(ir::XlaValue(node, 1)));
+      torch::lazy::MakeNode<SymEig>(input.GetIrValue(), eigenvectors, !upper);
+  return std::make_tuple(input.CreateFrom(XlaValue(node, 0)),
+                         input.CreateFrom(XlaValue(node, 1)));
 }
 
 XLATensor XLATensor::take(const XLATensor& input, const XLATensor& index) {
-  return input.CreateFrom(
-      ir::ops::Take(input.GetIrValue(), index.GetIrValue()));
+  return input.CreateFrom(Take(input.GetIrValue(), index.GetIrValue()));
 }
 
 XLATensor XLATensor::tan(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Tan(input.GetIrValue()));
+  return input.CreateFrom(Tan(input.GetIrValue()));
 }
 
 XLATensor XLATensor::tanh(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Tanh(input.GetIrValue()));
+  return input.CreateFrom(Tanh(input.GetIrValue()));
 }
 
 XLATensor XLATensor::tanh_backward(const XLATensor& grad_output,
@@ -2823,13 +2795,13 @@ XLATensor XLATensor::tanh_backward(const XLATensor& grad_output,
 XLATensor XLATensor::threshold(const XLATensor& input, float threshold,
                                float value) {
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::Threshold>(input.GetIrValue(), threshold, value));
+      torch::lazy::MakeNode<Threshold>(input.GetIrValue(), threshold, value));
 }
 
 XLATensor XLATensor::threshold_backward(const XLATensor& grad_output,
                                         const XLATensor& input,
                                         float threshold) {
-  return grad_output.CreateFrom(ir::MakeNode<ir::ops::ThresholdBackward>(
+  return grad_output.CreateFrom(torch::lazy::MakeNode<ThresholdBackward>(
       grad_output.GetIrValue(), input.GetIrValue(), threshold));
 }
 
@@ -2858,22 +2830,22 @@ std::tuple<XLATensor, XLATensor> XLATensor::topk(const XLATensor& input,
                                                  int64_t k, int64_t dim,
                                                  bool largest, bool sorted,
                                                  bool stable) {
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::TopK>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<TopK>(
       input.GetIrValue(), k,
       torch::lazy::GetCanonicalDimensionIndex(dim, input.shape().get().rank()),
       largest, sorted, stable);
   return std::make_tuple(
-      input.CreateFrom(ir::XlaValue(node, 0)),
-      input.CreateFrom(ir::XlaValue(node, 1), at::ScalarType::Long));
+      input.CreateFrom(XlaValue(node, 0)),
+      input.CreateFrom(XlaValue(node, 1), at::ScalarType::Long));
 }
 
 XLATensor XLATensor::trace(const XLATensor& input) {
   auto input_shape_ref = input.shape();
   XLA_CHECK_EQ((*input_shape_ref).rank(), 2)
       << "invalid argument for trace: expected a matrix";
-  torch::lazy::NodePtr eye = ir::ops::Identity(
-      (*input_shape_ref).dimensions(0), (*input_shape_ref).dimensions(1),
-      (*input_shape_ref).element_type());
+  torch::lazy::NodePtr eye = Identity((*input_shape_ref).dimensions(0),
+                                      (*input_shape_ref).dimensions(1),
+                                      (*input_shape_ref).element_type());
   return XLATensor::sum(input.CreateFrom(eye * input.GetIrValue()), {0, 1},
                         false, input.dtype());
 }
@@ -2899,33 +2871,33 @@ std::tuple<XLATensor, XLATensor> XLATensor::triangular_solve(
     const XLATensor& rhs, const XLATensor& lhs, bool left_side, bool upper,
     bool transpose, bool unitriangular) {
   // TriangularSolve takes lower instead of upper, hence the negation.
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::TriangularSolve>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<TriangularSolve>(
       rhs.GetIrValue(), lhs.GetIrValue(), left_side, !upper, transpose,
       unitriangular);
-  return std::make_tuple(rhs.CreateFrom(ir::XlaValue(node, 0)),
-                         rhs.CreateFrom(ir::XlaValue(node, 1)));
+  return std::make_tuple(rhs.CreateFrom(XlaValue(node, 0)),
+                         rhs.CreateFrom(XlaValue(node, 1)));
 }
 
 XLATensor XLATensor::tril(const XLATensor& input, int64_t diagonal) {
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::Tril>(input.GetIrValue(), diagonal));
+      torch::lazy::MakeNode<Tril>(input.GetIrValue(), diagonal));
 }
 
 void XLATensor::tril_(XLATensor& input, int64_t diagonal) {
-  input.SetIrValue(ir::MakeNode<ir::ops::Tril>(input.GetIrValue(), diagonal));
+  input.SetIrValue(torch::lazy::MakeNode<Tril>(input.GetIrValue(), diagonal));
 }
 
 XLATensor XLATensor::triu(const XLATensor& input, int64_t diagonal) {
   return input.CreateFrom(
-      ir::MakeNode<ir::ops::Triu>(input.GetIrValue(), diagonal));
+      torch::lazy::MakeNode<Triu>(input.GetIrValue(), diagonal));
 }
 
 void XLATensor::triu_(XLATensor& input, int64_t diagonal) {
-  input.SetIrValue(ir::MakeNode<ir::ops::Triu>(input.GetIrValue(), diagonal));
+  input.SetIrValue(torch::lazy::MakeNode<Triu>(input.GetIrValue(), diagonal));
 }
 
 XLATensor XLATensor::trunc(const XLATensor& input) {
-  return input.CreateFrom(ir::ops::Trunc(input.GetIrValue()));
+  return input.CreateFrom(Trunc(input.GetIrValue()));
 }
 
 std::vector<XLATensor> XLATensor::unbind(const XLATensor& input, int64_t dim) {
@@ -2943,7 +2915,7 @@ std::vector<XLATensor> XLATensor::unbind(const XLATensor& input, int64_t dim) {
 void XLATensor::uniform_(XLATensor& input, double from, double to) {
   XLA_CHECK_LE(from, to);
   auto input_shape = input.shape();
-  input.SetInPlaceIrValue(ir::MakeNode<ir::ops::Uniform>(
+  input.SetInPlaceIrValue(torch::lazy::MakeNode<Uniform>(
       GetIrValueForScalar(from, input_shape.get().element_type(),
                           input.GetDevice()),
       GetIrValueForScalar(to, input_shape.get().element_type(),
@@ -2964,34 +2936,34 @@ void XLATensor::unsqueeze_(XLATensor& input, int64_t dim) {
   int squeeze_dim = torch::lazy::GetCanonicalDimensionIndex(
       dim, input.shape().get().rank() + 1);
   input.SetIrValue(
-      ir::MakeNode<ir::ops::Unsqueeze>(input.GetIrValue(), squeeze_dim));
+      torch::lazy::MakeNode<Unsqueeze>(input.GetIrValue(), squeeze_dim));
 }
 
 XLATensor XLATensor::upsample_bilinear2d(const XLATensor& input,
                                          std::vector<int64_t> output_size,
                                          bool align_corners) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::UpsampleBilinear>(
+  return input.CreateFrom(torch::lazy::MakeNode<UpsampleBilinear>(
       input.GetIrValue(), std::move(output_size), align_corners));
 }
 
 XLATensor XLATensor::upsample_bilinear2d_backward(
     const XLATensor& grad_output, std::vector<int64_t> output_size,
     std::vector<int64_t> input_size, bool align_corners) {
-  return grad_output.CreateFrom(ir::MakeNode<ir::ops::UpsampleBilinearBackward>(
+  return grad_output.CreateFrom(torch::lazy::MakeNode<UpsampleBilinearBackward>(
       grad_output.GetIrValue(), std::move(output_size), std::move(input_size),
       align_corners));
 }
 
 XLATensor XLATensor::upsample_nearest2d(const XLATensor& input,
                                         std::vector<int64_t> output_size) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::UpsampleNearest>(
+  return input.CreateFrom(torch::lazy::MakeNode<UpsampleNearest>(
       input.GetIrValue(), std::move(output_size)));
 }
 
 XLATensor XLATensor::upsample_nearest2d_backward(
     const XLATensor& grad_output, std::vector<int64_t> output_size,
     std::vector<int64_t> input_size) {
-  return grad_output.CreateFrom(ir::MakeNode<ir::ops::UpsampleNearestBackward>(
+  return grad_output.CreateFrom(torch::lazy::MakeNode<UpsampleNearestBackward>(
       grad_output.GetIrValue(), std::move(output_size), std::move(input_size)));
 }
 
@@ -3009,7 +2981,7 @@ XLATensor XLATensor::view(const XLATensor& input,
 XLATensor XLATensor::var(const XLATensor& input,
                          std::vector<int64_t> dimensions, int64_t correction,
                          bool keep_reduced_dimensions) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::Var>(
+  return input.CreateFrom(torch::lazy::MakeNode<Var>(
       input.GetIrValue(),
       torch::lazy::GetCanonicalDimensionIndices(
           xla::util::ToVector<int64_t>(dimensions), input.shape().get().rank()),
@@ -3019,31 +2991,31 @@ XLATensor XLATensor::var(const XLATensor& input,
 std::tuple<XLATensor, XLATensor> XLATensor::var_mean(
     const XLATensor& input, std::vector<int64_t> dimensions, int64_t correction,
     bool keep_reduced_dimensions) {
-  torch::lazy::NodePtr node = ir::MakeNode<ir::ops::VarMean>(
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<VarMean>(
       input.GetIrValue(),
       torch::lazy::GetCanonicalDimensionIndices(
           xla::util::ToVector<int64_t>(dimensions), input.shape().get().rank()),
       correction, keep_reduced_dimensions);
-  return std::make_tuple(input.CreateFrom(ir::XlaValue(node, 0)),
-                         input.CreateFrom(ir::XlaValue(node, 1)));
+  return std::make_tuple(input.CreateFrom(XlaValue(node, 0)),
+                         input.CreateFrom(XlaValue(node, 1)));
 }
 
 void XLATensor::zero_(XLATensor& input) {
-  ir::XlaValue constant =
+  XlaValue constant =
       GetIrValueForScalar(0.0, input.shape(), input.GetDevice());
   input.SetInPlaceIrValue(std::move(constant));
 }
 
 XLATensor XLATensor::where(const XLATensor& condition, const XLATensor& input,
                            const XLATensor& other) {
-  return input.CreateFrom(ir::ops::Where(
-      condition.GetIrValue(), input.GetIrValue(), other.GetIrValue()));
+  return input.CreateFrom(
+      Where(condition.GetIrValue(), input.GetIrValue(), other.GetIrValue()));
 }
 
 XLATensor XLATensor::DispatchComparisonOp(c10::Symbol kind,
                                           const XLATensor& input,
                                           const at::Scalar& other) {
-  torch::lazy::NodePtr node = ir::ops::ComparisonOp(
+  torch::lazy::NodePtr node = ComparisonOp(
       kind, input.GetIrValue(), GetIrValueForScalar(other, input.GetDevice()));
   return Create(node, input.GetDevice(), at::ScalarType::Bool);
 }
@@ -3052,7 +3024,7 @@ XLATensor XLATensor::DispatchComparisonOp(c10::Symbol kind,
                                           const XLATensor& input,
                                           const XLATensor& other) {
   torch::lazy::NodePtr node =
-      ir::ops::ComparisonOp(kind, input.GetIrValue(), other.GetIrValue());
+      ComparisonOp(kind, input.GetIrValue(), other.GetIrValue());
   return Create(node, input.GetDevice(), at::ScalarType::Bool);
 }
 

--- a/torch_xla/csrc/tensor_ops.cpp
+++ b/torch_xla/csrc/tensor_ops.cpp
@@ -98,7 +98,7 @@ XLATensor MakeMatrixWithDiagonal(const XLATensor& input, int64_t diagonal) {
 
 XLATensor SmoothL1Loss(const XLATensor& input, const XLATensor& target,
                        ReductionMode reduction, double beta) {
-  torch_xla::ir::ScopePusher ir_scope(at::aten::smooth_l1_loss.toQualString());
+  torch_xla::ScopePusher ir_scope(at::aten::smooth_l1_loss.toQualString());
   auto broadcasted_inputs = XLATensor::broadcast_tensors({input, target});
   XLA_CHECK_EQ(broadcasted_inputs.size(), 2);
   const XLATensor& broadcasted_input = broadcasted_inputs[0];
@@ -134,7 +134,7 @@ XLATensor SmoothL1Loss(const XLATensor& input, const XLATensor& target,
 XLATensor SmoothL1LossBackward(const XLATensor& grad_output,
                                const XLATensor& input, const XLATensor& target,
                                ReductionMode reduction, double beta) {
-  torch_xla::ir::ScopePusher ir_scope(
+  torch_xla::ScopePusher ir_scope(
       at::aten::smooth_l1_loss_backward.toQualString());
   auto broadcasted_inputs = XLATensor::broadcast_tensors({input, target});
   XLA_CHECK_EQ(broadcasted_inputs.size(), 2);

--- a/torch_xla/csrc/view.h
+++ b/torch_xla/csrc/view.h
@@ -95,13 +95,13 @@ struct ViewInfo {
 class Alias {
  public:
   struct UpdateData {
-    ir::XlaValue ir_value;
+    XlaValue ir_value;
     std::vector<ViewInfo> view_infos;
   };
 
-  explicit Alias(ir::XlaValue ir_value) : ir_value_(std::move(ir_value)) {}
+  explicit Alias(XlaValue ir_value) : ir_value_(std::move(ir_value)) {}
 
-  const ir::XlaValue& ir_value() const { return ir_value_; }
+  const XlaValue& ir_value() const { return ir_value_; }
 
   const std::vector<UpdateData>& updates() const { return updates_; }
 
@@ -110,13 +110,13 @@ class Alias {
   // Appends an update to the IR value stored within the alias. The ir_value is
   // the value to be written, and view_infos represents the forward path from
   // the alias's ir_value to the update ir_value.
-  void Update(ir::XlaValue ir_value, std::vector<ViewInfo> view_infos);
+  void Update(XlaValue ir_value, std::vector<ViewInfo> view_infos);
 
-  ir::XlaValue SyncUpdateOperations();
+  XlaValue SyncUpdateOperations();
 
  private:
   // The IR value which is the root at which the view was created.
-  ir::XlaValue ir_value_;
+  XlaValue ir_value_;
   // The stacked updates on the view. Orders matter, as most recent updates
   // might overwrite older ones.
   std::vector<UpdateData> updates_;
@@ -128,7 +128,7 @@ class Alias {
 class View {
  public:
   struct IrNode {
-    ir::XlaValue ir_value;
+    XlaValue ir_value;
     bool updated;
   };
 
@@ -136,7 +136,7 @@ class View {
   View(xla::Shape shape, std::shared_ptr<Alias> alias,
        std::vector<ViewInfo> view_infos);
 
-  void Update(ir::XlaValue ir_value);
+  void Update(XlaValue ir_value);
 
   const xla::Shape& shape() const { return shape_; }
 
@@ -157,7 +157,7 @@ class View {
   std::vector<ViewInfo> view_infos_;
   xla::Shape shape_;
   std::shared_ptr<Alias> alias_;
-  ir::XlaValue ir_value_;
+  XlaValue ir_value_;
   size_t generation_ = 0;
 };
 

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -235,6 +235,7 @@ supported:
   - random_
   - random_.from
   - random_.to
+  - randperm.generator_out
   - reciprocal
   - reflection_pad2d
   - reflection_pad2d_backward


### PR DESCRIPTION
Resolves #3369 

## Pull Request Summary

This PR implements lowering for `randperm.generator_out`.
Link to its signiture in `native_functions.yaml`: https://github.com/pytorch/pytorch/blob/cc1902a5ed64e5e3b956c5cc6fcbdcd45630f7b8/aten/src/ATen/native/native_functions.yaml#L3567-L3570

## Notes
- Lowering for `randperm_out` has already been implemented in the past, but it got deleted in Feb 2020 for some reason. Link to the commit that deleted the lowering for `randperm_out`: https://github.com/pytorch/xla/commit/237d32629f0f7d9d385c7289b1e2c746c8dfb26d.