### PR TITLE
Make layout pining optional for cross core communication

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -526,7 +526,12 @@ def _host_all_reduce(reduce_type, inputs, cctx, scale=None):
         REDUCE_SUM, inputs, token, 1.0, [])
 
 
-def all_reduce(reduce_type, inputs, scale=1.0, groups=None, cctx=None):
+def all_reduce(reduce_type,
+               inputs,
+               scale=1.0,
+               groups=None,
+               cctx=None,
+               pin_layout=True):
   """Performs an inplace reduce operation on the input tensor(s).
 
   Args:
@@ -542,6 +547,11 @@ def all_reduce(reduce_type, inputs, scale=1.0, groups=None, cctx=None):
         defines two groups, one with the `[0, 1, 2, 3]` replicas and one with
         the `[4, 5, 6, 7]` replicas. If `None` there will be only one group with
         all the replicas in it.
+    pin_layout (bool, optional): whether to pin the layout for this communication op.
+      Layout pining can prevent potential data corruption when each process that
+      participate in the communication has slightly different program, but it might
+      cause some xla compiation to fail. Unpin the layout when you see error message
+      like "HloModule has a mix of layout constrained".
 
   Returns:
     If a single `torch.Tensor` is passed, the return value is a `torch.Tensor`
@@ -562,12 +572,13 @@ def all_reduce(reduce_type, inputs, scale=1.0, groups=None, cctx=None):
     token, devctx = _get_all_reduce_token()
     if isinstance(inputs, torch.Tensor):
       result = torch_xla._XLAC._xla_all_reduce(reduce_type, inputs, token,
-                                               scale, cctx.intercore_group)
+                                               scale, cctx.intercore_group,
+                                               pin_layout)
       devctx.all_reduce_token = result[1]
       results = [result[0]]
     else:
       devctx.all_reduce_token = torch_xla._XLAC._xla_all_reduce_inplace(
-          reduce_type, inputs, token, scale, cctx.intercore_group)
+          reduce_type, inputs, token, scale, cctx.intercore_group, pin_layout)
       results = inputs
   else:
     if isinstance(inputs, torch.Tensor):
@@ -582,7 +593,7 @@ def all_reduce(reduce_type, inputs, scale=1.0, groups=None, cctx=None):
   return results[0] if isinstance(inputs, torch.Tensor) else results
 
 
-def all_gather(value, dim=0, groups=None, output=None):
+def all_gather(value, dim=0, groups=None, output=None, pin_layout=True):
   """Performs an all-gather operation along a given dimension.
 
   Args:
@@ -595,6 +606,11 @@ def all_gather(value, dim=0, groups=None, output=None):
         the `[4, 5, 6, 7]` replicas. If `None` there will be only one group with
         all the replicas in it.
     output (torch.Tensor): Optional output tensor.
+    pin_layout (bool, optional): whether to pin the layout for this communication op.
+      Layout pining can prevent potential data corruption when each process that
+      participate in the communication has slightly different program, but it might
+      cause some xla compiation to fail. Unpin the layout when you see error message
+      like "HloModule has a mix of layout constrained".
 
   Returns:
     A tensor which has, in the ``dim`` dimension, all the values from the
@@ -613,12 +629,13 @@ def all_gather(value, dim=0, groups=None, output=None):
   if output != None:
     # Call the out of place version of the all_gather
     new_token = torch_xla._XLAC._xla_all_gather_out(output, value, token, dim,
-                                                    shard_count, groups or [])
+                                                    shard_count, groups or [],
+                                                    pin_layout)
     devctx.all_reduce_token = new_token
     return output
 
   result = torch_xla._XLAC._xla_all_gather(value, token, dim, shard_count,
-                                           groups or [])
+                                           groups or [], pin_layout)
   devctx.all_reduce_token = result[1]
   return result[0]
 
@@ -627,7 +644,8 @@ def all_to_all(value,
                split_dimension,
                concat_dimension,
                split_count,
-               groups=None):
+               groups=None,
+               pin_layout=True):
   """Performs an XLA `AllToAll()` operation on the input tensor.
 
   See: https://www.tensorflow.org/xla/operation_semantics#alltoall
@@ -642,6 +660,11 @@ def all_to_all(value,
         defines two groups, one with the `[0, 1, 2, 3]` replicas and one with
         the `[4, 5, 6, 7]` replicas. If `None` there will be only one group with
         all the replicas in it.
+    pin_layout (bool, optional): whether to pin the layout for this communication op.
+      Layout pining can prevent potential data corruption when each process that
+      participate in the communication has slightly different program, but it might
+      cause some xla compiation to fail. Unpin the layout when you see error message
+      like "HloModule has a mix of layout constrained".
 
   Returns:
     The result `torch.Tensor` of the `all_to_all()` operation.
@@ -649,7 +672,7 @@ def all_to_all(value,
   token, devctx = _get_all_reduce_token()
   result = torch_xla._XLAC._xla_all_to_all(value, token, split_dimension,
                                            concat_dimension, split_count,
-                                           groups or [])
+                                           groups or [], pin_layout)
   devctx.all_reduce_token = result[1]
   return result[0]
 
@@ -685,7 +708,8 @@ def reduce_scatter(reduce_type,
                    scatter_dim,
                    shard_count,
                    groups=None,
-                   output=None):
+                   output=None,
+                   pin_layout=True):
   """Performs a XLA `ReduceScatter()` operation on the input tensor.
 
   See: https://www.tensorflow.org/xla/operation_semantics#reducescatter
@@ -704,6 +728,11 @@ def reduce_scatter(reduce_type,
         the `[4, 5, 6, 7]` replicas. If `None` there will be only one group with
         all the replicas in it.
     output: Optional output tensor
+    pin_layout (bool, optional): whether to pin the layout for this communication op.
+      Layout pining can prevent potential data corruption when each process that
+      participate in the communication has slightly different program, but it might
+      cause some xla compiation to fail. Unpin the layout when you see error message
+      like "HloModule has a mix of layout constrained".
 
   Returns:
     A `torch.Tensor` with all the values reduced accross replicas. Each process
@@ -717,13 +746,13 @@ def reduce_scatter(reduce_type,
                                                         input, token, scale,
                                                         scatter_dim,
                                                         shard_count, groups or
-                                                        [])
+                                                        [], pin_layout)
     devctx.all_reduce_token = new_token
     return output
 
   result = torch_xla._XLAC._xla_reduce_scatter(reduce_type, input, token, scale,
                                                scatter_dim, shard_count,
-                                               groups or [])
+                                               groups or [], pin_layout)
   devctx.all_reduce_token = result[1]
   return result[0]
 

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -593,7 +593,7 @@ def all_reduce(reduce_type,
   return results[0] if isinstance(inputs, torch.Tensor) else results
 
 
-def all_gather(value, dim=0, groups=None, output=None, pin_layout=True):
+def all_gather(value, dim=0, groups=None, output=None, pin_layout=False):
   """Performs an all-gather operation along a given dimension.
 
   Args:
@@ -645,7 +645,7 @@ def all_to_all(value,
                concat_dimension,
                split_count,
                groups=None,
-               pin_layout=True):
+               pin_layout=False):
   """Performs an XLA `AllToAll()` operation on the input tensor.
 
   See: https://www.tensorflow.org/xla/operation_semantics#alltoall
@@ -709,7 +709,7 @@ def reduce_scatter(reduce_type,
                    shard_count,
                    groups=None,
                    output=None,
-                   pin_layout=True):
+                   pin_layout=False):
   """Performs a XLA `ReduceScatter()` operation on the input tensor.
 
   See: https://www.tensorflow.org/xla/operation_semantics#reducescatter

--- a/torch_xla/csrc/cross_replica_reduces.cpp
+++ b/torch_xla/csrc/cross_replica_reduces.cpp
@@ -87,7 +87,7 @@ std::vector<xla::ReplicaGroup> CreateReduceGroups(
 std::vector<xla::XlaOp> BuildAllReduce(
     AllReduceType reduce_type, absl::Span<const xla::XlaOp> operands,
     xla::XlaOp token, double scale,
-    const std::vector<std::vector<int64_t>>& groups) {
+    const std::vector<std::vector<int64_t>>& groups, bool pin_layout) {
   std::vector<xla::ReplicaGroup> reduce_groups = CreateReduceGroups(groups);
   // TODO: We use pseudo-tokens ATM, which are real values. This need to be
   // switched to use the real XLA Token once support has been added to XLA
@@ -101,11 +101,19 @@ std::vector<xla::XlaOp> BuildAllReduce(
     type_ctx.second.operand_shapes.push_back(
         XlaHelpers::ShapeOfXlaOp(token_op));
 
-    xla::XlaOp reduce = xla::AllReduce(
-        xla::Tuple(operands[0].builder(), type_ctx.second.ops),
-        GetReduceComutation(reduce_type, type_ctx.first), reduce_groups,
-        /*channel_id=*/absl::nullopt,
-        MakeReduceShape(type_ctx.second.operand_shapes));
+    xla::XlaOp reduce;
+    if (pin_layout) {
+      reduce = xla::AllReduce(
+          xla::Tuple(operands[0].builder(), type_ctx.second.ops),
+          GetReduceComutation(reduce_type, type_ctx.first), reduce_groups,
+          /*channel_id=*/absl::nullopt,
+          /*shape_with_layout=*/
+          MakeReduceShape(type_ctx.second.operand_shapes));
+    } else {
+      reduce = xla::AllReduce(
+          xla::Tuple(operands[0].builder(), type_ctx.second.ops),
+          GetReduceComutation(reduce_type, type_ctx.first), reduce_groups);
+    }
     for (size_t i = 0; i < type_ctx.second.indices.size(); ++i) {
       size_t op_idx = type_ctx.second.indices[i];
       xla::XlaOp gte = xla::GetTupleElement(reduce, i);
@@ -128,28 +136,49 @@ std::vector<xla::XlaOp> BuildAllReduce(
 AllToAllResult BuildAllToAll(xla::XlaOp input, xla::XlaOp token,
                              int64_t split_dimension, int64_t concat_dimension,
                              int64_t split_count,
-                             const std::vector<std::vector<int64_t>>& groups) {
+                             const std::vector<std::vector<int64_t>>& groups,
+                             bool pin_layout) {
   std::vector<xla::ReplicaGroup> reduce_groups = CreateReduceGroups(groups);
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
-  xla::Shape reduce_shape = MakeArrayShapeFromDimensions(
-      input_shape.dimensions(), input_shape.dynamic_dimensions(),
-      input_shape.element_type(), GetCurrentDevice().device_type.hw_type);
   TokenHandler token_handler(token);
-  xla::XlaOp reduce_result = xla::AllToAll(
-      token_handler.GetInput(input, &input_shape), split_dimension,
-      concat_dimension, split_count, reduce_groups, reduce_shape.layout());
+  xla::XlaOp reduce_result;
+  if (pin_layout) {
+    xla::Shape reduce_shape = MakeArrayShapeFromDimensions(
+        input_shape.dimensions(), input_shape.dynamic_dimensions(),
+        input_shape.element_type(), GetCurrentDevice().device_type.hw_type);
+    reduce_result = xla::AllToAll(token_handler.GetInput(input, &input_shape),
+                                  split_dimension, concat_dimension,
+                                  split_count, reduce_groups,
+                                  /*layout=*/reduce_shape.layout());
+  } else {
+    reduce_result = xla::AllToAll(token_handler.GetInput(input, &input_shape),
+                                  split_dimension, concat_dimension,
+                                  split_count, reduce_groups);
+  }
   return {reduce_result, token_handler.GetNewToken(reduce_result)};
 }
 
-AllGatherResult BuildAllGather(
-    xla::XlaOp input, xla::XlaOp token, int64_t dim, int64_t shard_count,
-    const std::vector<std::vector<int64_t>>& groups) {
+AllGatherResult BuildAllGather(xla::XlaOp input, xla::XlaOp token, int64_t dim,
+                               int64_t shard_count,
+                               const std::vector<std::vector<int64_t>>& groups,
+                               bool pin_layout) {
   std::vector<xla::ReplicaGroup> reduce_groups = CreateReduceGroups(groups);
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   TokenHandler token_handler(token);
-  xla::XlaOp all_gather_result =
-      xla::AllGather(token_handler.GetInput(input, &input_shape), dim,
-                     shard_count, reduce_groups);
+  xla::XlaOp all_gather_result;
+  if (pin_layout) {
+    xla::Shape reduce_shape = MakeArrayShapeFromDimensions(
+        input_shape.dimensions(), input_shape.dynamic_dimensions(),
+        input_shape.element_type(), GetCurrentDevice().device_type.hw_type);
+    all_gather_result =
+        xla::AllGather(token_handler.GetInput(input, &input_shape), dim,
+                       shard_count, reduce_groups, /*channel_id=*/absl::nullopt,
+                       /*layout=*/reduce_shape.layout());
+  } else {
+    all_gather_result =
+        xla::AllGather(token_handler.GetInput(input, &input_shape), dim,
+                       shard_count, reduce_groups);
+  }
   return {all_gather_result, token_handler.GetNewToken(all_gather_result)};
 }
 
@@ -169,15 +198,26 @@ CollectivePermuteResult BuildCollectivePermute(
 ReduceScatterResult BuildReduceScatter(
     AllReduceType reduce_type, xla::XlaOp input, xla::XlaOp token, double scale,
     int64_t scatter_dim, int64_t shard_count,
-    const std::vector<std::vector<int64_t>>& groups) {
+    const std::vector<std::vector<int64_t>>& groups, bool pin_layout) {
   std::vector<xla::ReplicaGroup> reduce_groups = CreateReduceGroups(groups);
   TokenHandler token_handler(token);
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
-
-  xla::XlaOp reduce_result = xla::ReduceScatter(
-      token_handler.GetInput(input, &input_shape),
-      GetReduceComutation(reduce_type, input_shape.element_type()), scatter_dim,
-      shard_count, reduce_groups);
+  xla::XlaOp reduce_result;
+  if (pin_layout) {
+    xla::Shape reduce_shape = MakeArrayShapeFromDimensions(
+        input_shape.dimensions(), input_shape.dynamic_dimensions(),
+        input_shape.element_type(), GetCurrentDevice().device_type.hw_type);
+    reduce_result = xla::ReduceScatter(
+        token_handler.GetInput(input, &input_shape),
+        GetReduceComutation(reduce_type, input_shape.element_type()),
+        scatter_dim, shard_count, reduce_groups, /*channel_id=*/absl::nullopt,
+        /*layout=*/reduce_shape.layout());
+  } else {
+    reduce_result = xla::ReduceScatter(
+        token_handler.GetInput(input, &input_shape),
+        GetReduceComutation(reduce_type, input_shape.element_type()),
+        scatter_dim, shard_count, reduce_groups);
+  }
 
   if (scale != 1.0) {
     xla::XlaOp scaling_value = XlaHelpers::ScalarValue<float>(

--- a/torch_xla/csrc/cross_replica_reduces.h
+++ b/torch_xla/csrc/cross_replica_reduces.h
@@ -39,16 +39,18 @@ struct ReduceScatterResult {
 std::vector<xla::XlaOp> BuildAllReduce(
     AllReduceType reduce_type, absl::Span<const xla::XlaOp> operands,
     xla::XlaOp token, double scale,
-    const std::vector<std::vector<int64_t>>& groups);
+    const std::vector<std::vector<int64_t>>& groups, bool pin_layout);
 
 AllToAllResult BuildAllToAll(xla::XlaOp input, xla::XlaOp token,
                              int64_t split_dimension, int64_t concat_dimension,
                              int64_t split_count,
-                             const std::vector<std::vector<int64_t>>& groups);
+                             const std::vector<std::vector<int64_t>>& groups,
+                             bool pin_layout);
 
 AllGatherResult BuildAllGather(xla::XlaOp input, xla::XlaOp token, int64_t dim,
                                int64_t shard_count,
-                               const std::vector<std::vector<int64_t>>& groups);
+                               const std::vector<std::vector<int64_t>>& groups,
+                               bool pin_layout);
 
 CollectivePermuteResult BuildCollectivePermute(
     xla::XlaOp input, xla::XlaOp token,
@@ -57,6 +59,6 @@ CollectivePermuteResult BuildCollectivePermute(
 ReduceScatterResult BuildReduceScatter(
     AllReduceType reduce_type, xla::XlaOp input, xla::XlaOp token, double scale,
     int64_t scatter_dim, int64_t shard_count,
-    const std::vector<std::vector<int64_t>>& groups);
+    const std::vector<std::vector<int64_t>>& groups, bool pin_layout);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/all_gather.cpp
+++ b/torch_xla/csrc/ops/all_gather.cpp
@@ -14,10 +14,11 @@ namespace {
 
 xla::Shape NodeOutputShape(const Value& input, const Value& token, int64_t dim,
                            int64_t shard_count,
-                           const std::vector<std::vector<int64_t>>& groups) {
+                           const std::vector<std::vector<int64_t>>& groups,
+                           bool pin_layout) {
   auto shape_fn = [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
-    AllGatherResult result =
-        BuildAllGather(operands[0], operands[1], dim, shard_count, groups);
+    AllGatherResult result = BuildAllGather(operands[0], operands[1], dim,
+                                            shard_count, groups, pin_layout);
     return xla::Tuple(operands[0].builder(), {result.result, result.token});
   };
   return InferOutputShape({input.xla_shape(), token.xla_shape()}, shape_fn);
@@ -27,33 +28,36 @@ xla::Shape NodeOutputShape(const Value& input, const Value& token, int64_t dim,
 
 AllGather::AllGather(const Value& input, const Value& token, int64_t dim,
                      int64_t shard_count,
-                     std::vector<std::vector<int64_t>> groups)
+                     std::vector<std::vector<int64_t>> groups, bool pin_layout)
     : Node(xla_all_gather, {input, token},
            [&]() {
-             return NodeOutputShape(input, token, dim, shard_count, groups);
+             return NodeOutputShape(input, token, dim, shard_count, groups,
+                                    pin_layout);
            },
-           /*num_outputs=*/2, torch::lazy::MHash(dim, shard_count, groups)),
+           /*num_outputs=*/2,
+           torch::lazy::MHash(dim, shard_count, groups, pin_layout)),
       dim_(dim),
       shard_count_(shard_count),
-      groups_(std::move(groups)) {}
+      groups_(std::move(groups)),
+      pin_layout_(pin_layout) {}
 
 torch::lazy::NodePtr AllGather::Clone(OpList operands) const {
   return ir::MakeNode<AllGather>(operands.at(0), operands.at(1), dim_,
-                                 shard_count_, groups_);
+                                 shard_count_, groups_, pin_layout_);
 }
 
 XlaOpVector AllGather::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
   xla::XlaOp token = loctx->GetOutputOp(operand(1));
   AllGatherResult result =
-      BuildAllGather(input, token, dim_, shard_count_, groups_);
+      BuildAllGather(input, token, dim_, shard_count_, groups_, pin_layout_);
   return ReturnOps({result.result, result.token}, loctx);
 }
 
 std::string AllGather::ToString() const {
   std::stringstream ss;
   ss << Node::ToString() << ", dim=" << dim_ << ", shard_count=" << shard_count_
-     << ", groups=(";
+     << ", pin_layout=" << pin_layout_ << ", groups=(";
   for (size_t i = 0; i < groups_.size(); ++i) {
     ss << (i == 0 ? "(" : ",(");
     ss << absl::StrJoin(groups_[i], ", ") << ")";

--- a/torch_xla/csrc/ops/all_gather.h
+++ b/torch_xla/csrc/ops/all_gather.h
@@ -10,7 +10,8 @@ namespace ops {
 class AllGather : public Node {
  public:
   AllGather(const Value& input, const Value& token, int64_t dim,
-            int64_t shard_count, std::vector<std::vector<int64_t>> groups);
+            int64_t shard_count, std::vector<std::vector<int64_t>> groups,
+            bool pin_layout);
 
   std::string ToString() const override;
 
@@ -24,10 +25,13 @@ class AllGather : public Node {
 
   const std::vector<std::vector<int64_t>>& groups() const { return groups_; }
 
+  bool pin_layout() const { return pin_layout_; }
+
  private:
   int64_t dim_;
   int64_t shard_count_;
   std::vector<std::vector<int64_t>> groups_;
+  bool pin_layout_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/all_reduce.h
+++ b/torch_xla/csrc/ops/all_reduce.h
@@ -11,7 +11,7 @@ class AllReduce : public Node {
  public:
   AllReduce(AllReduceType reduce_type, absl::Span<const Value> operands,
             const Value& token, double scale,
-            std::vector<std::vector<int64_t>> groups);
+            std::vector<std::vector<int64_t>> groups, bool pin_layout);
 
   std::string ToString() const override;
 
@@ -25,10 +25,13 @@ class AllReduce : public Node {
 
   const std::vector<std::vector<int64_t>>& groups() const { return groups_; }
 
+  bool pin_layout() const { return pin_layout_; }
+
  private:
   AllReduceType reduce_type_;
   double scale_;
   std::vector<std::vector<int64_t>> groups_;
+  bool pin_layout_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/all_to_all.cpp
+++ b/torch_xla/csrc/ops/all_to_all.cpp
@@ -14,11 +14,12 @@ namespace {
 xla::Shape NodeOutputShape(const Value& input, const Value& token,
                            int64_t split_dimension, int64_t concat_dimension,
                            int64_t split_count,
-                           const std::vector<std::vector<int64_t>>& groups) {
+                           const std::vector<std::vector<int64_t>>& groups,
+                           bool pin_layout) {
   auto shape_fn = [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     AllToAllResult result =
         BuildAllToAll(operands[0], operands[1], split_dimension,
-                      concat_dimension, split_count, groups);
+                      concat_dimension, split_count, groups, pin_layout);
     return xla::Tuple(operands[0].builder(), {result.result, result.token});
   };
   return InferOutputShape({input.xla_shape(), token.xla_shape()}, shape_fn);
@@ -29,31 +30,34 @@ xla::Shape NodeOutputShape(const Value& input, const Value& token,
 AllToAll::AllToAll(const Value& input, const Value& token,
                    int64_t split_dimension, int64_t concat_dimension,
                    int64_t split_count,
-                   std::vector<std::vector<int64_t>> groups)
+                   std::vector<std::vector<int64_t>> groups, bool pin_layout)
     : Node(xla_all_to_all, {input, token},
            [&]() {
              return NodeOutputShape(input, token, split_dimension,
-                                    concat_dimension, split_count, groups);
+                                    concat_dimension, split_count, groups,
+                                    pin_layout);
            },
            /*num_outputs=*/2,
            torch::lazy::MHash(split_dimension, concat_dimension, split_count,
-                              groups)),
+                              groups, pin_layout)),
       split_dimension_(split_dimension),
       concat_dimension_(concat_dimension),
       split_count_(split_count),
-      groups_(std::move(groups)) {}
+      groups_(std::move(groups)),
+      pin_layout_(pin_layout) {}
 
 torch::lazy::NodePtr AllToAll::Clone(OpList operands) const {
   return ir::MakeNode<AllToAll>(operands.at(0), operands.at(1),
                                 split_dimension_, concat_dimension_,
-                                split_count_, groups_);
+                                split_count_, groups_, pin_layout_);
 }
 
 XlaOpVector AllToAll::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
   xla::XlaOp token = loctx->GetOutputOp(operand(1));
-  AllToAllResult result = BuildAllToAll(
-      input, token, split_dimension_, concat_dimension_, split_count_, groups_);
+  AllToAllResult result =
+      BuildAllToAll(input, token, split_dimension_, concat_dimension_,
+                    split_count_, groups_, pin_layout_);
   return ReturnOps({result.result, result.token}, loctx);
 }
 
@@ -61,7 +65,8 @@ std::string AllToAll::ToString() const {
   std::stringstream ss;
   ss << Node::ToString() << ", split_dimension=" << split_dimension_
      << ", concat_dimension=" << concat_dimension_
-     << ", split_count=" << split_count_ << ", groups=(";
+     << ", split_count=" << split_count_ << ", pin_layout=" << pin_layout_
+     << ", groups=(";
   for (size_t i = 0; i < groups_.size(); ++i) {
     ss << (i == 0 ? "(" : ",(");
     ss << absl::StrJoin(groups_[i], ", ") << ")";

--- a/torch_xla/csrc/ops/all_to_all.h
+++ b/torch_xla/csrc/ops/all_to_all.h
@@ -11,7 +11,7 @@ class AllToAll : public Node {
  public:
   AllToAll(const Value& input, const Value& token, int64_t split_dimension,
            int64_t concat_dimension, int64_t split_count,
-           std::vector<std::vector<int64_t>> groups);
+           std::vector<std::vector<int64_t>> groups, bool pin_layout);
 
   std::string ToString() const override;
 
@@ -27,11 +27,14 @@ class AllToAll : public Node {
 
   const std::vector<std::vector<int64_t>>& groups() const { return groups_; }
 
+  bool pin_layout() const { return pin_layout_; }
+
  private:
   int64_t split_dimension_;
   int64_t concat_dimension_;
   int64_t split_count_;
   std::vector<std::vector<int64_t>> groups_;
+  bool pin_layout_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/ops/reduce_scatter.cpp
+++ b/torch_xla/csrc/ops/reduce_scatter.cpp
@@ -15,12 +15,14 @@ namespace {
 xla::Shape NodeOutputShape(AllReduceType reduce_type, const Value input,
                            const Value& token, double scale,
                            int64_t scatter_dim, int64_t shard_count,
-                           const std::vector<std::vector<int64_t>>& groups) {
+                           const std::vector<std::vector<int64_t>>& groups,
+                           bool pin_layout) {
   auto shape_fn = [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     xla::XlaOp inputOp = operands[0];
     xla::XlaOp tokenOp = operands[1];
-    ReduceScatterResult result = BuildReduceScatter(
-        reduce_type, inputOp, tokenOp, scale, scatter_dim, shard_count, groups);
+    ReduceScatterResult result =
+        BuildReduceScatter(reduce_type, inputOp, tokenOp, scale, scatter_dim,
+                           shard_count, groups, pin_layout);
     return xla::Tuple(operands[0].builder(), {result.result, result.token});
   };
   return InferOutputShape({input.xla_shape(), token.xla_shape()}, shape_fn);
@@ -31,32 +33,36 @@ xla::Shape NodeOutputShape(AllReduceType reduce_type, const Value input,
 ReduceScatter::ReduceScatter(AllReduceType reduce_type, const Value& input,
                              const Value& token, double scale,
                              int64_t scatter_dim, int64_t shard_count,
-                             std::vector<std::vector<int64_t>> groups)
+                             std::vector<std::vector<int64_t>> groups,
+                             bool pin_layout)
     : Node(xla_reduce_scatter, {input, token},
            [&]() {
              return NodeOutputShape(reduce_type, input, token, scale,
-                                    scatter_dim, shard_count, groups);
+                                    scatter_dim, shard_count, groups,
+                                    pin_layout);
            },
            /*num_outputs=*/2,
            torch::lazy::MHash(torch::lazy::GetEnumValue(reduce_type), scale,
-                              scatter_dim, shard_count, groups)),
+                              scatter_dim, shard_count, groups, pin_layout)),
       reduce_type_(reduce_type),
       scale_(scale),
       scatter_dim_(scatter_dim),
       shard_count_(shard_count),
-      groups_(std::move(groups)) {}
+      groups_(std::move(groups)),
+      pin_layout_(pin_layout) {}
 
 torch::lazy::NodePtr ReduceScatter::Clone(OpList operands) const {
   return ir::MakeNode<ReduceScatter>(reduce_type_, operands.at(0),
                                      operands.at(1), scale_, scatter_dim_,
-                                     shard_count_, groups_);
+                                     shard_count_, groups_, pin_layout_);
 }
 
 XlaOpVector ReduceScatter::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
   xla::XlaOp token = loctx->GetOutputOp(operand(1));
-  ReduceScatterResult result = BuildReduceScatter(
-      reduce_type_, input, token, scale_, scatter_dim_, shard_count_, groups_);
+  ReduceScatterResult result =
+      BuildReduceScatter(reduce_type_, input, token, scale_, scatter_dim_,
+                         shard_count_, groups_, pin_layout_);
   return ReturnOps({result.result, result.token}, loctx);
 }
 
@@ -65,7 +71,8 @@ std::string ReduceScatter::ToString() const {
   ss << Node::ToString()
      << ", reduce_type=" << torch::lazy::GetEnumValue(reduce_type_)
      << ", scale=" << scale_ << ", scatter_dim=" << scatter_dim_
-     << ", shard_count=" << shard_count_ << ", groups=(";
+     << ", shard_count=" << shard_count_ << ", pin_layout=" << pin_layout_
+     << ", groups=(";
   for (size_t i = 0; i < groups_.size(); ++i) {
     ss << (i == 0 ? "(" : ",(");
     ss << absl::StrJoin(groups_[i], ", ") << ")";

--- a/torch_xla/csrc/ops/reduce_scatter.h
+++ b/torch_xla/csrc/ops/reduce_scatter.h
@@ -11,7 +11,8 @@ class ReduceScatter : public Node {
  public:
   ReduceScatter(AllReduceType reduce_type, const Value& input,
                 const Value& token, double scale, int64_t scatter_dim,
-                int64_t shard_count, std::vector<std::vector<int64_t>> groups);
+                int64_t shard_count, std::vector<std::vector<int64_t>> groups,
+                bool pin_layout);
 
   std::string ToString() const override;
 
@@ -25,12 +26,15 @@ class ReduceScatter : public Node {
 
   const std::vector<std::vector<int64_t>>& groups() const { return groups_; }
 
+  bool pin_layout() const { return pin_layout_; }
+
  private:
   AllReduceType reduce_type_;
   double scale_;
   int64_t scatter_dim_;
   int64_t shard_count_;
   std::vector<std::vector<int64_t>> groups_;
+  bool pin_layout_;
 };
 
 }  // namespace ops

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -210,41 +210,46 @@ class XLATensor {
   //////////////////////////////////////////////////////////////////////////////
   static std::pair<XLATensor, ir::Value> all_reduce(
       const XLATensor& input, const ir::Value& token, AllReduceType reduce_type,
-      double scale, std::vector<std::vector<int64_t>> groups);
+      double scale, std::vector<std::vector<int64_t>> groups, bool pin_layout);
 
   static ir::Value all_reduce_(XLATensor& input, const ir::Value& token,
                                AllReduceType reduce_type, double scale,
-                               std::vector<std::vector<int64_t>> groups);
+                               std::vector<std::vector<int64_t>> groups,
+                               bool pin_layout);
 
   static ir::Value all_reduce(std::vector<XLATensor>* inputs,
                               const ir::Value& token, AllReduceType reduce_type,
                               double scale,
-                              std::vector<std::vector<int64_t>> groups);
+                              std::vector<std::vector<int64_t>> groups,
+                              bool pin_layout);
 
   static std::pair<XLATensor, ir::Value> reduce_scatter(
       const XLATensor& input, const ir::Value& token, AllReduceType reduce_type,
       double scale, int64_t scatter_dim, int64_t shard_count,
-      std::vector<std::vector<int64_t>> groups);
+      std::vector<std::vector<int64_t>> groups, bool pin_layout);
 
   static ir::Value reduce_scatter_out(XLATensor& output, const XLATensor& input,
                                       const ir::Value& token,
                                       AllReduceType reduce_type, double scale,
                                       int64_t scatter_dim, int64_t shard_count,
-                                      std::vector<std::vector<int64_t>> groups);
+                                      std::vector<std::vector<int64_t>> groups,
+                                      bool pin_layout);
 
   static std::pair<XLATensor, ir::Value> all_to_all(
       const XLATensor& input, const ir::Value& token, int64_t split_dimension,
       int64_t concat_dimension, int64_t split_count,
-      std::vector<std::vector<int64_t>> groups);
+      std::vector<std::vector<int64_t>> groups, bool pin_layout);
 
   static std::pair<XLATensor, ir::Value> all_gather(
       const XLATensor& input, const ir::Value& token, int64_t dim,
-      int64_t shard_count, std::vector<std::vector<int64_t>> groups);
+      int64_t shard_count, std::vector<std::vector<int64_t>> groups,
+      bool pin_layout);
 
   static ir::Value all_gather_out(XLATensor& output, const XLATensor& input,
                                   const ir::Value& token, int64_t dim,
                                   int64_t shard_count,
-                                  std::vector<std::vector<int64_t>> groups);
+                                  std::vector<std::vector<int64_t>> groups,
+                                  bool pin_layout);
 
   static std::pair<XLATensor, ir::Value> collective_permute(
       const XLATensor& input, const ir::Value& token,


### PR DESCRIPTION
This is to fix https://github.com/pytorch/xla/issues/3506. I verified that with all `pin_layout=True`(default) or all `pin_layout=False`, test will passed.

PyTorch/xla currently compile graph separately for each TPU core(or GPU core). It is possible that graph being generated in each core is slightly different due to 
1. slightly different input shape
2. different embedding table size
3. ...

XLA compiler generate can tolerate small different among different cores but this will be a problem for communication ops. If the input shape difference ended up resulting in a layout difference among tensors that user want to call communication op, there can be a data corruption.

To overcome this problem we introduce the layout pining, which guarantee that all cores that participate in communication has the same layout for input tensor. However in some corner cases, pinging all layout will not work. For example `all_gather(pin)` + `reduce_scatter(pin)` might fail in some case. 

This pr aim to provide a workaround when such failure happened. PyTorch/XLA will pin all communcation op layout by defualt, but if there is a compilation error with message `HloModule has a mix of layout constrained` user can choose to unpin all layout.

FYI @ronghanghu @hjm-aws 