### PR TITLE
Start XRT server in a separate process in CircleCI CPU test

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -118,7 +118,7 @@ function run_torch_xla_tests() {
     export XRT_DEVICE_MAP="CPU:0;/job:localservice/replica:0/task:0/device:XLA_CPU:0"
     XLA_PORT=$(shuf -i 40701-40999 -n 1)
     export XRT_WORKERS="localservice:0;grpc://localhost:$XLA_PORT"
-    python -m torch_xla.core.xrt_run_server --port $XLA_PORT --restart
+    python torch_xla/core/xrt_run_server.py --port $XLA_PORT --restart
   fi
   export PYTORCH_TESTING_DEVICE_ONLY_FOR="xla"
 
@@ -148,8 +148,10 @@ function run_torch_xla_tests() {
     fi
 
     # clear the XRT server before cpp test since CPP test won't run torch_xla's
-    # __init__.py hence will force a in process server.
-    clean_xrt_server
+    # __init__.py hence will force a in process server. Note that we can not use
+    # -m here since we are in the XLA dir. Trying to run the torch_xla module
+    # from this dir will result in a `version.py` missing error.
+    python torch_xla/core/xrt_run_server.py --stop
     pushd test/cpp
     echo "Running C++ Tests"
     ./run_tests.sh

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -21,11 +21,6 @@ function apply_patches() {
   ./xla/scripts/apply_patches.sh
 }
 
-function clean_xrt_server() {
-  echo "Cleanning up XRT server"
-  python -m torch_xla.core.xrt_run_server --stop
-}
-
 function rebase_pull_request_on_target_branch() {
   # TODO: directly use ENV_VAR when CircleCi exposes base branch.
   # Try rebasing on top of base (dest) branch first.

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -12,3 +12,5 @@ source "$PYTORCH_DIR/.jenkins/pytorch/common_utils.sh"
 install_torchvision
 
 run_torch_xla_tests $PYTORCH_DIR $XLA_DIR
+
+trap clean_xrt_server ERR EXIT

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -12,5 +12,3 @@ source "$PYTORCH_DIR/.jenkins/pytorch/common_utils.sh"
 install_torchvision
 
 run_torch_xla_tests $PYTORCH_DIR $XLA_DIR
-
-trap clean_xrt_server ERR EXIT


### PR DESCRIPTION
This is to fix https://github.com/pytorch/xla/issues/3513, keep shutting down and restarting xrt server might result in some flakiness. 