### PR TITLE
LTC phase 2 clean up

### DIFF
--- a/test/cpp/test_ir.cpp
+++ b/test/cpp/test_ir.cpp
@@ -17,24 +17,6 @@ TEST(IrTest, TestScalarCreate) {
   ASSERT_TRUE(scalar != nullptr);
 }
 
-TEST(IrTest, TestReplace) {
-  torch::lazy::NodePtr scalar1 = ir::ops::ScalarOp(1.0, xla::F32);
-  torch::lazy::NodePtr scalar2 = ir::ops::ScalarOp(2.0, xla::F32);
-  torch::lazy::NodePtr add = ir::Value(scalar1, 0) + ir::Value(scalar2, 0);
-
-  EXPECT_EQ(dynamic_cast<ir::Node*>(scalar1.get())->uses().size(), 1);
-  EXPECT_EQ(dynamic_cast<ir::Node*>(scalar2.get())->uses().size(), 1);
-
-  torch::lazy::NodePtr scalar3 = ir::ops::ScalarOp(3.0, xla::F32);
-  dynamic_cast<ir::Node*>(scalar1.get())->ReplaceAllUsesWith(scalar3);
-
-  EXPECT_EQ(dynamic_cast<ir::Node*>(scalar1.get())->uses().size(), 0);
-  EXPECT_EQ(dynamic_cast<ir::Node*>(scalar3.get())->uses().size(), 1);
-
-  dynamic_cast<ir::Node*>(add.get())->ReplaceOperand(0, scalar1);
-  EXPECT_EQ(dynamic_cast<ir::Node*>(scalar1.get())->uses().size(), 1);
-}
-
 TEST(IrTest, TestHash) {
   torch::lazy::NodePtr scalar1 = ir::ops::ScalarOp(1.0, xla::F32);
   torch::lazy::NodePtr scalar2 = ir::ops::ScalarOp(2.0, xla::F32);

--- a/torch_xla/csrc/XLANativeFunctions_include.h
+++ b/torch_xla/csrc/XLANativeFunctions_include.h
@@ -1,5 +1,4 @@
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/metrics.h"
-
 #include "torch_xla/csrc/aten_cpu_fallback.h"
 #include "torch_xla/csrc/aten_xla_bridge.h"

--- a/torch_xla/csrc/XLANativeFunctions_include.h
+++ b/torch_xla/csrc/XLANativeFunctions_include.h
@@ -1,0 +1,5 @@
+#include "tensorflow/compiler/xla/xla_client/debug_macros.h"
+#include "tensorflow/compiler/xla/xla_client/metrics.h"
+
+#include "torch_xla/csrc/aten_cpu_fallback.h"
+#include "torch_xla/csrc/aten_xla_bridge.h"

--- a/torch_xla/csrc/aten_xla_bridge.cpp
+++ b/torch_xla/csrc/aten_xla_bridge.cpp
@@ -109,8 +109,8 @@ XLATensor GetXlaTensorOrCreateForWrappedNumber(const at::Tensor& tensor,
                                                const Device& device) {
   return (tensor.unsafeGetTensorImpl()->is_wrapped_number() ||
           (tensor.dim() == 0 && tensor.numel() == 1))
-      ? GetOrCreateXlaTensor(tensor, device)
-      : GetXlaTensor(tensor);
+             ? GetOrCreateXlaTensor(tensor, device)
+             : GetXlaTensor(tensor);
 }
 
 std::vector<XLATensor> GetOrCreateXlaTensors(

--- a/torch_xla/csrc/aten_xla_bridge.cpp
+++ b/torch_xla/csrc/aten_xla_bridge.cpp
@@ -105,6 +105,14 @@ XLATensor GetOrCreateXlaTensor(const c10::optional<at::Tensor>& tensor,
   return xtensor ? *xtensor : XLATensor::Create(*tensor, device);
 }
 
+XLATensor GetXlaTensorOrCreateForWrappedNumber(const at::Tensor& tensor,
+                                               const Device& device) {
+  return (tensor.unsafeGetTensorImpl()->is_wrapped_number() ||
+          (tensor.dim() == 0 && tensor.numel() == 1))
+      ? GetOrCreateXlaTensor(tensor, device)
+      : GetXlaTensor(tensor);
+}
+
 std::vector<XLATensor> GetOrCreateXlaTensors(
     absl::Span<const at::Tensor> tensors, const Device& device) {
   std::vector<XLATensor> xla_tensors;

--- a/torch_xla/csrc/aten_xla_bridge.h
+++ b/torch_xla/csrc/aten_xla_bridge.h
@@ -34,6 +34,9 @@ XLATensor GetOrCreateXlaTensor(const at::Tensor& tensor, const Device& device);
 
 XLATensor GetOrCreateXlaTensor(const c10::optional<at::Tensor>& tensor,
                                const Device& device);
+// TODO: change to upstream BackendDevice
+XLATensor GetXlaTensorOrCreateForWrappedNumber(const at::Tensor& tensor,
+                                               const Device& device);
 
 std::vector<XLATensor> GetOrCreateXlaTensors(
     absl::Span<const at::Tensor> tensors, const Device& device);

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1,4 +1,3 @@
-#include <ATen/Context.h>
 #include <ATen/ExpandUtils.h>
 #include <ATen/Operators.h>
 #include <ATen/native/BinaryOps.h>
@@ -25,7 +24,6 @@
 #include "torch_xla/csrc/tensor_impl.h"
 #include "torch_xla/csrc/tensor_util.h"
 #include "torch_xla/csrc/torch_util.h"
-#include "torch_xla/csrc/version.h"
 
 // [Implementation Guidelines]
 // - If you want to call a at::func which doesn't have a kernel registered


### PR DESCRIPTION
This pr does a few things
1. Clean up `Use`, 
2. add a `torch_xla/csrc/XLANativeFunctions_include.h` which will use for generated `XLANativeFunction.cpp`
3. add a `GetXlaTensorOrCreateForWrappedNumber` which will used for generated `XLANativeFunction.cpp`


TODO(maybe separate pr): remove `addOperand` from our end
TODO(maybe separate pr): update to use `BackendDevice` after @wonjoolee95 's device pr merged.

FYI @wconstab 