### PR TITLE
Revert "Update tf submodule to 04/07/2022"

### DIFF
--- a/third_party/xla_client/xrt_computation_client.cc
+++ b/third_party/xla_client/xrt_computation_client.cc
@@ -25,7 +25,7 @@
 #include "tensorflow/compiler/xrt/xrt_util.h"
 #include "tensorflow/core/framework/allocator.h"
 #include "tensorflow/core/profiler/lib/traceme.h"
-#include "tensorflow/core/tpu/tpu_initializer_helper.h"
+#include "tensorflow/core/tpu/tpu_api_dlsym_initializer.h"
 #include "tensorflow/core/util/device_name_utils.h"
 
 namespace xla {


### PR DESCRIPTION
Reverts pytorch/xla#3507

upstream build is failing due to it is using remote cache. Revert it for now. FYI @ronghanghu