### PR TITLE
Remove TPU_HOST_BOUNDS setting for TPU single host

### DIFF
--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -52,7 +52,6 @@ def _set_missing_env(name, value):
 
 def _setup_default_env():
   _set_missing_env('TF_CPP_MIN_LOG_LEVEL', '1')
-  _set_missing_env('TPU_HOST_BOUNDS', '1,1,1')
   _set_missing_env('GRPC_VERBOSITY', 'ERROR')
   _set_missing_env('ALLOW_MULTIPLE_LIBTPU_LOAD', '1')
   if server_is_alive():


### PR DESCRIPTION
This was a workaround introduced earlier, it is no longer needed. Tested on the new v3-8 and it runs fine. 

For pod, it is being set in 
https://github.com/pytorch/xla/blob/cc0495356857a72df7ac4d2e75dc4b535308c3e1/torch_xla/distributed/xla_dist.py#L332