### PR TITLE
Lower Gelu and GeluBackward

### DIFF
--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -289,13 +289,13 @@ xla::XlaOp BuildSoftplus(xla::XlaOp input, xla::XlaOp beta,
 xla::XlaOp BuildGelu(xla::XlaOp input) {
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(input);
   xla::XlaOp half = XlaHelpers::ScalarValue<float>(0.5, shape.element_type(),
-                                                    input.builder());
+                                                   input.builder());
   xla::XlaOp one = XlaHelpers::ScalarValue<float>(1.0, shape.element_type(),
-                                                    input.builder());
-  xla::XlaOp m_sqrt2 = XlaHelpers::ScalarValue<float>(M_SQRT2, shape.element_type(),
-                                                    input.builder());
-  xla::XlaOp m_sqrt1_2 = XlaHelpers::ScalarValue<float>(M_SQRT1_2, shape.element_type(),
-                                                    input.builder());
+                                                  input.builder());
+  xla::XlaOp m_sqrt2 = XlaHelpers::ScalarValue<float>(
+      M_SQRT2, shape.element_type(), input.builder());
+  xla::XlaOp m_sqrt1_2 = XlaHelpers::ScalarValue<float>(
+      M_SQRT1_2, shape.element_type(), input.builder());
 
   return input * half * (xla::Erf(input * m_sqrt1_2) + one);
 }
@@ -303,13 +303,13 @@ xla::XlaOp BuildGelu(xla::XlaOp input) {
 xla::XlaOp BuildGeluBackward(xla::XlaOp grad_output, xla::XlaOp input) {
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(input);
   xla::XlaOp half = XlaHelpers::ScalarValue<float>(0.5, shape.element_type(),
-                                                    input.builder());
+                                                   input.builder());
   xla::XlaOp one = XlaHelpers::ScalarValue<float>(1.0, shape.element_type(),
-                                                    input.builder());
-  xla::XlaOp m_2_sqrtpi = XlaHelpers::ScalarValue<float>(M_2_SQRTPI, shape.element_type(),
-                                                    input.builder());
-  xla::XlaOp m_sqrt1_2 = XlaHelpers::ScalarValue<float>(M_SQRT1_2, shape.element_type(),
-                                                    input.builder());
+                                                  input.builder());
+  xla::XlaOp m_2_sqrtpi = XlaHelpers::ScalarValue<float>(
+      M_2_SQRTPI, shape.element_type(), input.builder());
+  xla::XlaOp m_sqrt1_2 = XlaHelpers::ScalarValue<float>(
+      M_SQRT1_2, shape.element_type(), input.builder());
 
   xla::XlaOp kAlpha = m_2_sqrtpi * m_sqrt1_2 * half;
   xla::XlaOp scratch = xla::Erf(input * m_sqrt1_2);

--- a/torch_xla/csrc/elementwise.h
+++ b/torch_xla/csrc/elementwise.h
@@ -74,4 +74,11 @@ xla::XlaOp BuildAbs(xla::XlaOp input);
 xla::XlaOp BuildSoftplus(xla::XlaOp input, xla::XlaOp beta,
                          xla::XlaOp threshold);
 
+// Computes the GELU function of input.
+// GELU(x) = x * 0.5 * (1.0 + torch.erf(x / math.sqrt(2.0)))
+xla::XlaOp BuildGelu(xla::XlaOp input);
+
+// Computes the backward of GELU. 
+xla::XlaOp BuildGeluBackward(xla::XlaOp grad_output, xla::XlaOp input);
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/elementwise.h
+++ b/torch_xla/csrc/elementwise.h
@@ -78,7 +78,7 @@ xla::XlaOp BuildSoftplus(xla::XlaOp input, xla::XlaOp beta,
 // GELU(x) = x * 0.5 * (1.0 + torch.erf(x / math.sqrt(2.0)))
 xla::XlaOp BuildGelu(xla::XlaOp input);
 
-// Computes the backward of GELU. 
+// Computes the backward of GELU.
 xla::XlaOp BuildGeluBackward(xla::XlaOp grad_output, xla::XlaOp input);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -738,20 +738,22 @@ torch::lazy::NodePtr EluBackward(const XlaValue& grad_output,
 }
 
 torch::lazy::NodePtr Gelu(const XlaValue& input) {
-  auto lower_fn = [](const XlaNode& node, LoweringContext* loctx) -> XlaOpVector {
+  auto lower_fn = [](const XlaNode& node,
+                     LoweringContext* loctx) -> XlaOpVector {
     xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
     return node.ReturnOp(BuildGelu(xla_input), loctx);
   };
-  return GenericOp(torch::lazy::OpKind(at::aten::gelu),
-                   {input}, input.xla_shape(), std::move(lower_fn));
+  return GenericOp(torch::lazy::OpKind(at::aten::gelu), {input},
+                   input.xla_shape(), std::move(lower_fn));
 }
 
-torch::lazy::NodePtr GeluBackward(const XlaValue& grad_output, const XlaValue& input) {
-  auto lower_fn = [](const XlaNode& node, LoweringContext* loctx) -> XlaOpVector {
+torch::lazy::NodePtr GeluBackward(const XlaValue& grad_output,
+                                  const XlaValue& input) {
+  auto lower_fn = [](const XlaNode& node,
+                     LoweringContext* loctx) -> XlaOpVector {
     xla::XlaOp xla_grad_output = loctx->GetOutputOp(node.operand(0));
     xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(1));
-    return node.ReturnOp(BuildGeluBackward(xla_grad_output, xla_input),
-                         loctx);
+    return node.ReturnOp(BuildGeluBackward(xla_grad_output, xla_input), loctx);
   };
   return GenericOp(torch::lazy::OpKind(at::aten::gelu_backward),
                    {grad_output, input}, input.xla_shape(),


### PR DESCRIPTION
As part of https://github.com/pytorch/xla/issues/3527, we'll lower our existing ops that rely on IR level computation.

Testing Gelu and GeluBackward unit tests succeeded locally. 