### PR TITLE
Move GetXlaTensorOrCreateForWrappedNumber to `torch::lazy` namespace

### DIFF
--- a/torch_xla/csrc/aten_xla_bridge.cpp
+++ b/torch_xla/csrc/aten_xla_bridge.cpp
@@ -106,14 +106,6 @@ XLATensor GetOrCreateXlaTensor(const c10::optional<at::Tensor>& tensor,
   return xtensor ? *xtensor : XLATensor::Create(*tensor, device);
 }
 
-XLATensor GetXlaTensorOrCreateForWrappedNumber(
-    const at::Tensor& tensor, const torch::lazy::BackendDevice& device) {
-  return (tensor.unsafeGetTensorImpl()->is_wrapped_number() ||
-          (tensor.dim() == 0 && tensor.numel() == 1))
-             ? GetOrCreateXlaTensor(tensor, device)
-             : GetXlaTensor(tensor);
-}
-
 std::vector<XLATensor> GetOrCreateXlaTensors(
     absl::Span<const at::Tensor> tensors,
     const torch::lazy::BackendDevice& device) {
@@ -341,3 +333,17 @@ std::vector<at::Tensor> CreateXlaTensors(
 
 }  // namespace bridge
 }  // namespace torch_xla
+
+namespace torch {
+namespace lazy {
+
+torch_xla::XLATensor GetXlaTensorOrCreateForWrappedNumber(
+    const at::Tensor& tensor, const torch::lazy::BackendDevice& device) {
+  return (tensor.unsafeGetTensorImpl()->is_wrapped_number() ||
+          (tensor.dim() == 0 && tensor.numel() == 1))
+             ? torch_xla::bridge::GetOrCreateXlaTensor(tensor, device)
+             : torch_xla::bridge::GetXlaTensor(tensor);
+}
+
+}  // namespace lazy
+}  // namespace torch

--- a/torch_xla/csrc/aten_xla_bridge.h
+++ b/torch_xla/csrc/aten_xla_bridge.h
@@ -36,9 +36,6 @@ XLATensor GetOrCreateXlaTensor(const at::Tensor& tensor,
 XLATensor GetOrCreateXlaTensor(const c10::optional<at::Tensor>& tensor,
                                const torch::lazy::BackendDevice& device);
 
-XLATensor GetXlaTensorOrCreateForWrappedNumber(
-    const at::Tensor& tensor, const torch::lazy::BackendDevice& device);
-
 std::vector<XLATensor> GetOrCreateXlaTensors(
     absl::Span<const at::Tensor> tensors,
     const torch::lazy::BackendDevice& device);
@@ -111,3 +108,12 @@ std::vector<at::Tensor> CreateXlaTensors(
 
 }  // namespace bridge
 }  // namespace torch_xla
+
+namespace torch {
+namespace lazy {
+
+torch_xla::XLATensor GetXlaTensorOrCreateForWrappedNumber(
+    const at::Tensor& tensor, const torch::lazy::BackendDevice& device);
+
+}  // namespace lazy
+}  // namespace torch

--- a/torch_xla/csrc/generated_file_include.h
+++ b/torch_xla/csrc/generated_file_include.h
@@ -2,3 +2,4 @@
 #include "tensorflow/compiler/xla/xla_client/metrics.h"
 #include "torch_xla/csrc/aten_cpu_fallback.h"
 #include "torch_xla/csrc/aten_xla_bridge.h"
+#include "torch_xla/csrc/ir.h"


### PR DESCRIPTION
This is for ltc migration phase 2