### PR TITLE
Revert "Start XRT server in a separate process in CircleCI CPU test"

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -113,7 +113,6 @@ function run_torch_xla_tests() {
     export XRT_DEVICE_MAP="CPU:0;/job:localservice/replica:0/task:0/device:XLA_CPU:0"
     XLA_PORT=$(shuf -i 40701-40999 -n 1)
     export XRT_WORKERS="localservice:0;grpc://localhost:$XLA_PORT"
-    python torch_xla/core/xrt_run_server.py --port $XLA_PORT --restart
   fi
   export PYTORCH_TESTING_DEVICE_ONLY_FOR="xla"
 
@@ -142,11 +141,6 @@ function run_torch_xla_tests() {
       fi
     fi
 
-    # clear the XRT server before cpp test since CPP test won't run torch_xla's
-    # __init__.py hence will force a in process server. Note that we can not use
-    # -m here since we are in the XLA dir. Trying to run the torch_xla module
-    # from this dir will result in a `version.py` missing error.
-    python torch_xla/core/xrt_run_server.py --stop
     pushd test/cpp
     echo "Running C++ Tests"
     ./run_tests.sh


### PR DESCRIPTION
Reverts pytorch/xla#3519