### PR TITLE
Fix view with no-op view_info

### DIFF
--- a/torch_xla/csrc/view.cpp
+++ b/torch_xla/csrc/view.cpp
@@ -187,13 +187,27 @@ ir::XlaValue Alias::SyncUpdateOperations() {
 View::View(xla::Shape shape, std::shared_ptr<Alias> alias, ViewInfo view_info)
     : shape_(std::move(shape)), alias_(std::move(alias)) {
   view_infos_.push_back(std::move(view_info));
+  if (view_info.view_type == ViewInfo::Type::kNoOp) {
+    ir_value_ = alias_->ir_value();
+  }
 }
 
 View::View(xla::Shape shape, std::shared_ptr<Alias> alias,
            std::vector<ViewInfo> view_infos)
     : view_infos_(std::move(view_infos)),
       shape_(std::move(shape)),
-      alias_(std::move(alias)) {}
+      alias_(std::move(alias)) {
+  bool all_view_info_no_op = true;
+  for (const ViewInfo& view_info : view_infos_) {
+    if (view_info.view_type != ViewInfo::Type::kNoOp) {
+      all_view_info_no_op = false;
+      break;
+    }
+  }
+  if (all_view_info_no_op) {
+    ir_value_ = alias_->ir_value();
+  }
+}
 
 void View::Update(ir::XlaValue ir_value) {
   alias_->Update(std::move(ir_value), view_infos_);


### PR DESCRIPTION
This is to fix https://github.com/pytorch/xla/issues/3488

The issue here is when we are creating a view, we change the base tensor from an `IR` to `View`(with no-op viewInfo)

https://github.com/pytorch/xla/blob/f684fd43897534a2c522982a6892f00c811835df/torch_xla/csrc/tensor.cpp#L870-L872

However currently our View constructor does not init its' `ir_value_` hence 
https://github.com/pytorch/xla/blob/f684fd43897534a2c522982a6892f00c811835df/torch_xla/csrc/view.h#L152-L154

will always return false and clear the `xla_data`
https://github.com/pytorch/xla/blob/f684fd43897534a2c522982a6892f00c811835df/torch_xla/csrc/tensor.cpp#L818-L821


When we have a tensor that has `xla_data` (already materialized), and  being used as a input to an operand, it will create a `device_data` `IRNode`
https://github.com/pytorch/xla/blob/f684fd43897534a2c522982a6892f00c811835df/torch_xla/csrc/tensor.cpp#L696-L704

and when this tensor got used as in an view op, this bug will clear the `xla_data` which will cause inconsistent graph being generated(tensor with `xla_data` will not be considered as the output of the graph but the tensor with `ir_value` and no `xla_data` will). 

@bdhirsh I don't know how will this looks like after functionization pass. It is hard to write a test for this one but we should probably make sure this bug do not bite us when we do the migration.