### PR TITLE
[xla][cpu] Add Arm Compute Library (ACL) build option for torch-xla

### DIFF
--- a/build_torch_xla_libs.sh
+++ b/build_torch_xla_libs.sh
@@ -65,6 +65,10 @@ if [[ "$XLA_CUDA" == "1" ]]; then
   OPTS+=(--config=cuda)
 fi
 
+if [[ "$XLA_CPU_USE_ACL" == "1" ]]; then
+  OPTS+=("--define=build_with_acl=true")
+fi
+
 if [ "$CMD" == "clean" ]; then
   pushd $THIRD_PARTY_DIR/tensorflow
   bazel clean


### PR DESCRIPTION
ACL build support has been added under the build flag: XLA_CPU_USE_ACL

This will enable the acl runtime for xla once the below tensorflow/xla PR is merged.
https://github.com/tensorflow/tensorflow/pull/55534/commits
