### PR TITLE
remove the new line in XLA_EMIT_STEPLOG print

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -810,7 +810,11 @@ def _run_step_closures():
 
 def mark_step():
   if xu.getenv_as('XLA_EMIT_STEPLOG', bool, False):
-    print('torch_xla.core.xla_model::mark_step', file=sys.stderr, flush=True)
+    print(
+        'torch_xla.core.xla_model::mark_step\n',
+        end='',
+        file=sys.stderr,
+        flush=True)
   torch_xla._XLAC._xla_step_marker(
       torch_xla._XLAC._xla_get_default_device(), [],
       wait=xu.getenv_as('XLA_SYNC_WAIT', bool, False))


### PR DESCRIPTION
This PR removes the new line via `end=''` at the end of `'torch_xla.core.xla_model::mark_step'` print (changing it to `'torch_xla.core.xla_model::mark_step\n'` with an explicit `\n` as part of the string) after each mark_step call when running on a TPU pod with xla_dist.py.

Otherwise, because `print` in Python is not an atomic op, two processes simultaneously running `print("ABCD")` can print either `ABCD\nABCD\n` or `ABCDABCD\n\n`, even with `flush=True`.

The later case (printing `torch_xla.core.xla_model::mark_steptorch_xla.core.xla_model::mark_step\n\n`) causes empty lines to show up each step when running on TPU pods (as in the screenshot below) due to splitting new lines in `stream.readline` in https://github.com/pytorch/xla/blob/9df591d7aaad97b0ead3b1548b5dd808261e1afa/torch_xla/distributed/xla_dist.py#L145-L147

Screenshot to show the problem before this PR (a lot of empty lines printed each step):
<img width="920" alt="Screen Shot 2022-04-30 at 1 54 53 PM" src="https://user-images.githubusercontent.com/6997335/166122916-6812d940-1c21-4f84-a1b5-cb29fca3e729.png">

