### PR TITLE
Lower celu, celu_, selu, and selu_

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -6350,7 +6350,7 @@ TEST_F(AtenXlaTensorTest, TestSelu) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::elu", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::selu", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestSeluInPlace) {
@@ -6365,7 +6365,7 @@ TEST_F(AtenXlaTensorTest, TestSeluInPlace) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::elu_", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::selu_", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestCelu) {
@@ -6380,7 +6380,7 @@ TEST_F(AtenXlaTensorTest, TestCelu) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::elu", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::celu", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestCeluInPlace) {
@@ -6396,7 +6396,7 @@ TEST_F(AtenXlaTensorTest, TestCeluInPlace) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::elu_", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::celu_", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestGelu) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1049,6 +1049,21 @@ at::Tensor XLANativeFunctions::ceil(const at::Tensor& self) {
   return bridge::AtenFromXlaTensor(XLATensor::ceil(bridge::GetXlaTensor(self)));
 }
 
+at::Tensor XLANativeFunctions::celu(const at::Tensor& self,
+                                    const at::Scalar& alpha) {
+  XLA_FN_COUNTER("xla::");
+  return bridge::AtenFromXlaTensor(
+      XLATensor::celu(bridge::GetXlaTensor(self), alpha));
+}
+
+at::Tensor& XLANativeFunctions::celu_(at::Tensor& self,
+                                      const at::Scalar& alpha) {
+  XLA_FN_COUNTER("xla::");
+  XLATensor self_tensor = bridge::GetXlaTensor(self);
+  XLATensor::celu_(self_tensor, alpha);
+  return self;
+}
+
 at::Tensor XLANativeFunctions::cholesky(const at::Tensor& self, bool upper) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
@@ -2957,6 +2972,18 @@ at::Tensor XLANativeFunctions::select(const at::Tensor& self, int64_t dim,
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
       XLATensor::select(bridge::GetXlaTensor(self), dim, index));
+}
+
+at::Tensor XLANativeFunctions::selu(const at::Tensor& self) {
+  XLA_FN_COUNTER("xla::");
+  return bridge::AtenFromXlaTensor(XLATensor::selu(bridge::GetXlaTensor(self)));
+}
+
+at::Tensor& XLANativeFunctions::selu_(at::Tensor& self) {
+  XLA_FN_COUNTER("xla::");
+  XLATensor self_tensor = bridge::GetXlaTensor(self);
+  XLATensor::selu_(self_tensor);
+  return self;
 }
 
 at::Tensor& XLANativeFunctions::silu_out(const at::Tensor& self,

--- a/torch_xla/csrc/elementwise.h
+++ b/torch_xla/csrc/elementwise.h
@@ -81,4 +81,12 @@ xla::XlaOp BuildGelu(xla::XlaOp input);
 // Computes the backward of GELU.
 xla::XlaOp BuildGeluBackward(xla::XlaOp grad_output, xla::XlaOp input);
 
+// Computes the CELU function of input.
+// CELU(x)=max(0,x)+min(0,a*(exp(x/a)−1))
+xla::XlaOp BuildCelu(xla::XlaOp input, const at::Scalar& alpha);
+
+// Computes the SELU function of input.
+// SELU(x)=scale*(max(0,x)+min(0,a*(exp(x)−1)))
+xla::XlaOp BuildSelu(xla::XlaOp input);
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -350,6 +350,16 @@ torch::lazy::NodePtr Clamp(const XlaValue& input, const XlaValue& min,
                    input.xla_shape(), std::move(lower_fn));
 }
 
+torch::lazy::NodePtr Celu(const XlaValue& input, const at::Scalar& alpha) {
+  auto lower_fn = [=](const XlaNode& node,
+                      LoweringContext* loctx) -> XlaOpVector {
+    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
+    return node.ReturnOp(BuildCelu(xla_input, alpha), loctx);
+  };
+  return GenericOp(torch::lazy::OpKind(at::aten::celu), {input},
+                   input.xla_shape(), std::move(lower_fn));
+}
+
 torch::lazy::NodePtr Ger(const XlaValue& input, const XlaValue& other) {
   auto lower_fn = [](const XlaNode& node,
                      LoweringContext* loctx) -> XlaOpVector {
@@ -1123,6 +1133,16 @@ torch::lazy::NodePtr Softplus(const XlaValue& input, const XlaValue& beta,
   return GenericOp(torch::lazy::OpKind(at::aten::softplus),
                    {input, beta, threshold}, input.xla_shape(),
                    std::move(lower_fn));
+}
+
+torch::lazy::NodePtr Selu(const XlaValue& input) {
+  auto lower_fn = [](const XlaNode& node,
+                     LoweringContext* loctx) -> XlaOpVector {
+    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
+    return node.ReturnOp(BuildSelu(xla_input), loctx);
+  };
+  return GenericOp(torch::lazy::OpKind(at::aten::selu), {input},
+                   input.xla_shape(), std::move(lower_fn));
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -164,6 +164,8 @@ torch::lazy::NodePtr Clamp(const XlaValue& input, const XlaValue& min,
 
 torch::lazy::NodePtr Ceil(const XlaValue& input);
 
+torch::lazy::NodePtr Celu(const XlaValue& input, const at::Scalar& alpha);
+
 torch::lazy::NodePtr Floor(const XlaValue& input);
 
 torch::lazy::NodePtr Round(const XlaValue& input);
@@ -275,5 +277,7 @@ torch::lazy::NodePtr SLogDet(const XlaValue& input);
 
 torch::lazy::NodePtr Softplus(const XlaValue& input, const XlaValue& beta,
                               const XlaValue& threshold);
+
+torch::lazy::NodePtr Selu(const XlaValue& input);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -467,6 +467,9 @@ class XLATensor {
 
   static XLATensor ceil(const XLATensor& input);
 
+  static XLATensor celu(const XLATensor& input, const at::Scalar& alpha);
+  static void celu_(XLATensor& input, const at::Scalar& alpha);
+
   static XLATensor cholesky(const XLATensor& input, bool upper);
 
   static XLATensor clamp(const XLATensor& input,
@@ -1033,6 +1036,9 @@ class XLATensor {
                                const XLATensor& index, const at::Scalar& value);
 
   static XLATensor select(const XLATensor& input, int64_t dim, int64_t index);
+
+  static XLATensor selu(const XLATensor& input);
+  static void selu_(XLATensor& input);
 
   static void silu_out(XLATensor& input, XLATensor& out);
   static XLATensor silu_backward(XLATensor& grad_output, XLATensor& input);

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1014,6 +1014,14 @@ XLATensor XLATensor::ceil(const XLATensor& input) {
   return input.CreateFrom(Ceil(input.GetIrValue()));
 }
 
+XLATensor XLATensor::celu(const XLATensor& input, const at::Scalar& alpha) {
+  return input.CreateFrom(Celu(input.GetIrValue(), alpha));
+}
+
+void XLATensor::celu_(XLATensor& input, const at::Scalar& alpha) {
+  input.SetInPlaceIrValue(Celu(input.GetIrValue(), alpha));
+}
+
 XLATensor XLATensor::cholesky(const XLATensor& input, bool upper) {
   // Cholesky takes lower instead of upper, hence the negation.
   return input.CreateFrom(
@@ -2488,6 +2496,14 @@ XLATensor XLATensor::scatter_add(const XLATensor& input, int64_t dim,
 XLATensor XLATensor::select(const XLATensor& input, int64_t dim,
                             int64_t index) {
   return tensor_ops::Select(input, dim, index);
+}
+
+XLATensor XLATensor::selu(const XLATensor& input) {
+  return input.CreateFrom(Selu(input.GetIrValue()));
+}
+
+void XLATensor::selu_(XLATensor& input) {
+  input.SetInPlaceIrValue(Selu(input.GetIrValue()));
 }
 
 void XLATensor::silu_out(XLATensor& input, XLATensor& out) {

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -76,6 +76,8 @@ supported:
   - bmm
   - cat
   - ceil
+  - celu
+  - celu_
   - cholesky
   - clamp
   - clamp.Tensor
@@ -261,6 +263,8 @@ supported:
   - scatter.value_reduce
   - scatter_add
   - select.int
+  - selu
+  - selu_
   - sgn
   - sigmoid
   - sigmoid_backward


### PR DESCRIPTION
Lower celu, celu_, selu, and selu_.

Trying to fix the newly introduced test failures due to https://github.com/pytorch/xla/pull/3539. This PR lowers `celu`, `celu_`, `selu`, and `selu_` into separate lowerings. 

Once this PR merges, I'll rebase the above PR and fix its tests.