### PR TITLE
Experimental support for single-host TPU in PjRt

### DIFF
--- a/third_party/xla_client/BUILD
+++ b/third_party/xla_client/BUILD
@@ -148,6 +148,7 @@ cc_library(
         "//tensorflow/compiler/xla/client:global_data",
         "//tensorflow/compiler/xla/client:xla_computation",
         "//tensorflow/compiler/xla/pjrt:cpu_device",
+        "//tensorflow/compiler/xla/pjrt:tpu_client",
         "//tensorflow/compiler/xla/pjrt:pjrt_client",
         "//tensorflow/compiler/xla/rpc:grpc_stub",
         "//tensorflow/compiler/xla/service:cpu_plugin",

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 
+#include "absl/strings/ascii.h"
 #include "absl/types/span.h"
 #include "tensorflow/compiler/xla/client/xla_computation.h"
 #include "tensorflow/compiler/xla/layout_util.h"
@@ -20,8 +21,8 @@ namespace xla {
 namespace {
 
 std::string PjRtDeviceToString(PjRtDevice* const device) {
-  std::string platform(device->client()->platform_name());
-  std::transform(platform.begin(), platform.end(), platform.begin(), ::toupper);
+  std::string platform =
+      absl::AsciiStrToUpper(device->client()->platform_name());
   std::string str = absl::StrFormat("%s:%d", platform, device->id());
   return str;
 }

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -116,7 +116,7 @@ std::vector<ComputationClient::ComputationPtr> PjRtComputationClient::Compile(
   std::vector<ComputationClient::ComputationPtr> computations;
 
   for (auto& instance : instances) {
-    auto pjrt_device = StringToPjRtDevice(instance.devices[0]);
+    PjRtDevice* pjrt_device = StringToPjRtDevice(instance.compilation_device);
     xla::ProgramShape program_shape =
         instance.computation.GetProgramShape().ValueOrDie();
     xla::CompileOptions compile_options;

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -55,7 +55,7 @@ PjRtComputationClient::PjRtComputationClient() {
 
   XLA_CHECK(client_.get() != nullptr);
 
-  for (auto* device : client_->addressable_devices()) {
+  for (auto* device : client_->devices()) {
     std::string device_str = PjRtDeviceToString(device);
     string_to_device_.emplace(device_str, device);
   }

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -120,7 +120,8 @@ std::vector<ComputationClient::ComputationPtr> PjRtComputationClient::Compile(
     xla::ProgramShape program_shape =
         instance.computation.GetProgramShape().ValueOrDie();
     xla::CompileOptions compile_options;
-    compile_options.compile_portable_executable = true;
+    compile_options.executable_build_options.set_num_replicas(client->addressable_device_count());
+    compile_options.executable_build_options.set_device_ordinal(pjrt_device->id());
     std::unique_ptr<xla::PjRtExecutable> executable =
         client_->Compile(instance.computation, compile_options).ValueOrDie();
     std::shared_ptr<PjRtComputation> pjrt_computation =
@@ -158,7 +159,7 @@ PjRtComputationClient::ExecuteComputation(
   xla::ExecuteOptions execute_options;
   execute_options.untuple_result = options.explode_tuple;
   std::vector<std::unique_ptr<xla::PjRtBuffer>> results =
-      pjrt_computation.executable->ExecutePortable(buffers, pjrt_device, execute_options)
+      pjrt_computation.executable->ExecuteSharded(buffers, pjrt_device, execute_options)
           .ValueOrDie();
 
   std::vector<DataPtr> datas;

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -57,7 +57,7 @@ PjRtComputationClient::PjRtComputationClient() {
 
   for (auto* device : client_->addressable_devices()) {
     std::string device_str = PjRtDeviceToString(device);
-    string_to_device.emplace(device_str, device);
+    string_to_device_.emplace(device_str, device);
   }
 }
 
@@ -211,9 +211,9 @@ PjRtComputationClient::GetReplicationDevices() {
 
 xla::PjRtDevice* PjRtComputationClient::StringToPjRtDevice(
     const std::string& device) {
-  XLA_CHECK(string_to_device.find(device) != string_to_device.end())
+  XLA_CHECK(string_to_device_.find(device) != string_to_device_.end())
       << "Unknown device " << device;
-  xla::PjRtDevice* pjrt_device = string_to_device[device];
+  xla::PjRtDevice* pjrt_device = string_to_device_[device];
   return pjrt_device;
 }
 

--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -144,7 +144,7 @@ class PjRtComputationClient : public ComputationClient {
 
  private:
   std::shared_ptr<PjRtClient> client_;
-  std::unordered_map<std::string, xla::PjRtDevice* const> string_to_device;
+  std::unordered_map<std::string, xla::PjRtDevice* const> string_to_device_;
   std::shared_ptr<std::vector<std::string>> replication_devices_;
 
   xla::PjRtDevice* StringToPjRtDevice(const std::string& device);

--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -32,7 +32,9 @@ class PjRtComputationClient : public ComputationClient {
       return reinterpret_cast<std::uintptr_t>(get_handle());
     };
     void Assign(const Data& data) override;
-    bool HasValue() const override { return get_handle() != nullptr; };
+    bool HasValue() const override {
+      return buffer != nullptr && !buffer->IsDeleted();
+    };
 
     std::shared_ptr<PjRtBuffer> buffer;
   };

--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -75,6 +75,9 @@ class PjRtComputationClient : public ComputationClient {
 
   std::vector<std::string> GetAllDevices() const override;
 
+  void SetReplicationDevices(
+      std::shared_ptr<std::vector<std::string>> devices) override;
+
   std::shared_ptr<std::vector<std::string>> GetReplicationDevices() override;
 
   void PrepareToExit() override { return; };
@@ -127,12 +130,6 @@ class PjRtComputationClient : public ComputationClient {
     return "getresourcedomainplaceholder";
   };
 
-  void SetReplicationDevices(
-      std::shared_ptr<std::vector<std::string>> devices) override {
-    // TODO(wcromar): use replication devices
-    TF_VLOG(2) << __FUNCTION__ << " not implemented";
-  };
-
   void SetRngSeed(size_t seed) override {
     XLA_ERROR() << __FUNCTION__ << " not implemented";
   };
@@ -146,7 +143,11 @@ class PjRtComputationClient : public ComputationClient {
   };
 
  private:
-  std::unique_ptr<PjRtClient> client_;
+  std::shared_ptr<PjRtClient> client_;
+  std::unordered_map<std::string, xla::PjRtDevice* const> string_to_device;
+  std::shared_ptr<std::vector<std::string>> replication_devices_;
+
+  xla::PjRtDevice* StringToPjRtDevice(const std::string& device);
 };
 
 }  // namespace xla


### PR DESCRIPTION
This PR adds experimental support for execution on a single TPU host. To use PjRt instead of XRT, set `PJRT_DEVICE=TPU`. This will not work with `xla_multiprocessing`, as only one process can open the TPU device at a time. I will look into workarounds and solutions in a future PR.

Also clean up some rough edges from #3463:

- Execute computation on specified device, rather than executing on all addressable devices and returning the first result
- Propagate `explode_tuple` execute option to PjRt
- Construct device string from platform name and device id instead of using debug string (e.g. "TPU:5", "CPU:0")
- Give incoming tensors the default layout before transferring them to device
- Implement `ComputationClient::SetReplicationDevices`