### PR TITLE
[WIP] Use XlaBackendData in PyTorch/XLA

### DIFF
--- a/test/cpp/cpp_test_util.cpp
+++ b/test/cpp/cpp_test_util.cpp
@@ -252,7 +252,7 @@ std::string GetTensorHloGraph(at::Tensor tensor) {
 
 torch::lazy::Value GetTensorIrValue(const at::Tensor& tensor,
                                     const torch::lazy::BackendDevice& device) {
-  xla::ComputationClient::DataPtr data = TensorToXlaData(tensor, device);
+  torch::lazy::BackendDataPtr data = TensorToXlaData(tensor, device);
   return torch::lazy::MakeNode<DeviceData>(std::move(data));
 }
 
@@ -283,7 +283,7 @@ std::vector<xla::ComputationClient::DataPtr> Execute(
 
   xla::ComputationClient::ExecuteComputationOptions options;
   return xla::ComputationClient::Get()->ExecuteComputation(
-      *computations.front(), lowering_ctx.GetParametersData(),
+      *computations.front(), UnwrapXlaData(lowering_ctx.GetParametersData()),
       device.toString(), options);
 }
 

--- a/test/cpp/test_op_by_op_executor.cpp
+++ b/test/cpp/test_op_by_op_executor.cpp
@@ -7,6 +7,7 @@
 #include "torch_xla/csrc/ops/ops.h"
 #include "torch_xla/csrc/ops/scalar.h"
 #include "torch_xla/csrc/ops/stack.h"
+#include "torch_xla/csrc/tensor_util.h"
 
 namespace torch_xla {
 namespace cpp_test {
@@ -23,7 +24,7 @@ TEST(OpByOpExecutorTest, TestSimpleAdd) {
 
     auto results_data =
         OpByOpExecutor::Get()->Execute({v_c}, device.toString(), {});
-    auto results = Fetch(results_data);
+    auto results = Fetch(UnwrapXlaData(results_data));
 
     AllClose(results.front(), c);
   });
@@ -42,7 +43,7 @@ TEST(OpByOpExecutorTest, TestStack) {
 
     auto results_data =
         OpByOpExecutor::Get()->Execute({v_c}, device.toString(), {});
-    auto results = Fetch(results_data);
+    auto results = Fetch(UnwrapXlaData(results_data));
 
     AllClose(results.front(), c);
   });
@@ -62,7 +63,7 @@ TEST(OpByOpExecutorTest, TestAsyncStack) {
     auto async =
         OpByOpExecutor::Get()->ExecuteAsync({v_c}, device.toString(), {});
     async.Wait();
-    auto results = Fetch(async.ConsumeValue());
+    auto results = Fetch(UnwrapXlaData(async.ConsumeValue()));
 
     AllClose(results.front(), c);
   });

--- a/test/cpp/test_replication.cpp
+++ b/test/cpp/test_replication.cpp
@@ -62,8 +62,8 @@ void TestSingleReplication(
   for (size_t i = 0; i < device_strings.size(); ++i) {
     auto executor = [&, i]() {
       results[i] = xla::ComputationClient::Get()->ExecuteComputation(
-          *compiled_computations[i], {tensors_data[i]}, device_strings[i],
-          exec_options);
+          *compiled_computations[i], {UnwrapXlaData(tensors_data[i])},
+          device_strings[i], exec_options);
     };
     xla::env::ScheduleIoClosure(mwait.Completer(std::move(executor)));
   }

--- a/torch_xla/csrc/lowering_context.h
+++ b/torch_xla/csrc/lowering_context.h
@@ -11,6 +11,7 @@
 #include "tensorflow/compiler/xla/types.h"
 #include "tensorflow/compiler/xla/xla_client/computation_client.h"
 #include "tensorflow/core/platform/macros.h"
+#include "torch/csrc/lazy/backend/backend_data.h"
 #include "torch/csrc/lazy/core/ir_util.h"
 #include "torch_xla/csrc/device.h"
 #include "torch_xla/csrc/ir.h"
@@ -34,11 +35,11 @@ class LoweringContext {
   // returned. Otherwise a new one will be created, associated with the tensor
   // held in data.
   xla::XlaOp GetParameter(
-      const std::shared_ptr<xla::ComputationClient::Data>& data);
+      const std::shared_ptr<torch::lazy::BackendData>& data);
 
   // Retrieves the vector holding all the tensors associated with the parameter
   // instructions which have been created.
-  const std::vector<xla::ComputationClient::DataPtr>& GetParametersData() const;
+  const std::vector<torch::lazy::BackendDataPtr>& GetParametersData() const;
 
   const std::vector<size_t>& GetParameterSequence() const;
 
@@ -88,8 +89,8 @@ class LoweringContext {
 
   xla::XlaBuilder builder_;
   torch::lazy::BackendDevice device_;
-  std::vector<xla::ComputationClient::DataPtr> parameters_;
-  std::unordered_map<xla::ComputationClient::Data::OpaqueHandle, Parameter>
+  std::vector<torch::lazy::BackendDataPtr> parameters_;
+  std::unordered_map<torch::lazy::BackendData::Handle, Parameter>
       parameters_map_;
   std::vector<size_t> parameter_sequence_;
   std::vector<xla::XlaOp> root_tuple_;

--- a/torch_xla/csrc/op_by_op_executor.h
+++ b/torch_xla/csrc/op_by_op_executor.h
@@ -19,7 +19,7 @@ namespace torch_xla {
 // lowered and executed independently.
 class OpByOpExecutor {
  public:
-  using AsyncResult = std::vector<xla::ComputationClient::DataPtr>;
+  using AsyncResult = std::vector<torch::lazy::BackendDataPtr>;
   using AsyncTask = xla::util::AsyncTask<AsyncResult>;
 
   static OpByOpExecutor* Get();
@@ -28,7 +28,7 @@ class OpByOpExecutor {
       c10::ArrayRef<torch::lazy::Value> roots, const std::string& device,
       absl::Span<const std::string> devices);
 
-  std::vector<xla::ComputationClient::DataPtr> Execute(
+  std::vector<torch::lazy::BackendDataPtr> Execute(
       c10::ArrayRef<torch::lazy::Value> roots, const std::string& device,
       absl::Span<const std::string> devices);
 

--- a/torch_xla/csrc/ops/device_data.cpp
+++ b/torch_xla/csrc/ops/device_data.cpp
@@ -4,11 +4,12 @@
 
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/ops/xla_ops.h"
+#include "torch_xla/csrc/tensor_util.h"
 
 namespace torch_xla {
 
-DeviceData::DeviceData(std::shared_ptr<xla::ComputationClient::Data> data)
-    : XlaNode(xla_device_data, data->shape(), /*num_outputs=*/1,
+DeviceData::DeviceData(std::shared_ptr<torch::lazy::BackendData> data)
+    : XlaNode(xla_device_data, UnwrapXlaData(data)->shape(), /*num_outputs=*/1,
               /*hash_seed=*/(uint32_t)101),
       data_(std::move(data)) {}
 

--- a/torch_xla/csrc/ops/device_data.h
+++ b/torch_xla/csrc/ops/device_data.h
@@ -1,13 +1,14 @@
 #pragma once
 
 #include "tensorflow/compiler/xla/xla_client/computation_client.h"
+#include "torch/csrc/lazy/backend/backend_data.h"
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
 
 class DeviceData : public XlaNode {
  public:
-  DeviceData(std::shared_ptr<xla::ComputationClient::Data> data);
+  DeviceData(std::shared_ptr<torch::lazy::BackendData> data);
 
   std::string ToString() const override;
 
@@ -15,14 +16,14 @@ class DeviceData : public XlaNode {
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  const std::shared_ptr<xla::ComputationClient::Data>& data() const {
+  const std::shared_ptr<torch::lazy::BackendData>& data() const {
     return data_;
   }
 
   static DeviceData* Cast(const torch::lazy::Node* node);
 
  private:
-  std::shared_ptr<xla::ComputationClient::Data> data_;
+  std::shared_ptr<torch::lazy::BackendData> data_;
 };
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -33,7 +33,7 @@ class XLATensor : public c10::intrusive_ptr_target {
   static XLATensor Create(const at::Tensor& tensor,
                           const torch::lazy::BackendDevice& device);
   static XLATensor Create(
-      xla::ComputationClient::DataPtr xla_data,
+      torch::lazy::BackendDataPtr xla_data,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
 
   static XLATensor Create(
@@ -80,13 +80,13 @@ class XLATensor : public c10::intrusive_ptr_target {
 
   // Fetches the XLA data behind the tensor. If the tensor has a graph defining
   // its current value, executes the graph and fetches the XLA data result.
-  xla::ComputationClient::DataPtr GetXlaData();
+  torch::lazy::BackendDataPtr GetXlaData();
 
   // Fetches the current value of the XLA data, which can be missing (nullptr)
   // in case the tensor has a graph defining its current value,
-  xla::ComputationClient::DataPtr CurrentXlaData() const;
+  torch::lazy::BackendDataPtr CurrentXlaData() const;
 
-  void SetXlaData(xla::ComputationClient::DataPtr xla_data);
+  void SetXlaData(torch::lazy::BackendDataPtr xla_data);
 
   // Retrieves the current IR XlaNode, or nullptr in case no active IR XlaNode
   // is available.
@@ -1233,7 +1233,7 @@ class XLATensor : public c10::intrusive_ptr_target {
   struct PostOrderData {
     std::vector<const torch::lazy::Node*> post_order;
     torch::lazy::Util::EmissionMap emission_map;
-    std::vector<xla::ComputationClient::DataPtr> parameters_data;
+    std::vector<torch::lazy::BackendDataPtr> parameters_data;
     std::vector<size_t> parameter_sequence;
   };
 
@@ -1241,7 +1241,7 @@ class XLATensor : public c10::intrusive_ptr_target {
     torch::lazy::BackendDevice device;
     size_t emitted_nodes = 0;
     std::shared_ptr<xla::ComputationClient::Computation> computation;
-    std::vector<xla::ComputationClient::DataPtr> parameters_data;
+    std::vector<torch::lazy::BackendDataPtr> parameters_data;
   };
 
   struct CachedComputation {
@@ -1258,8 +1258,8 @@ class XLATensor : public c10::intrusive_ptr_target {
 
   struct Async {
     Async(SyncTensorCollection* coll,
-          std::vector<xla::ComputationClient::DataPtr> parameters_data,
-          std::vector<xla::ComputationClient::DataPtr> tensors_data,
+          std::vector<torch::lazy::BackendDataPtr> parameters_data,
+          std::vector<torch::lazy::BackendDataPtr> tensors_data,
           ComputationCache::TypePtr cached_computation);
 
     void Wait();
@@ -1267,17 +1267,17 @@ class XLATensor : public c10::intrusive_ptr_target {
     xla::util::MultiWait mwait;
     std::vector<size_t> indices;
     std::vector<xla::util::ExceptionCleanup> unlocker;
-    std::vector<xla::ComputationClient::DataPtr> parameters_data;
+    std::vector<torch::lazy::BackendDataPtr> parameters_data;
     std::string device;
     ComputationCache::TypePtr cached_computation;
-    std::vector<xla::ComputationClient::DataPtr> tensors_data;
+    std::vector<torch::lazy::BackendDataPtr> tensors_data;
   };
 
   // This is the core XLA tensor data structure where all the tensor data is
   // held. The XLA tensor is nothing more than a shared pointer to a Data
   // object.
   struct Data {
-    Data(xla::ComputationClient::DataPtr xla_data,
+    Data(torch::lazy::BackendDataPtr xla_data,
          const torch::lazy::BackendDevice& device,
          c10::optional<at::ScalarType> logical_element_type)
         : xla_data(std::move(xla_data)),
@@ -1304,7 +1304,7 @@ class XLATensor : public c10::intrusive_ptr_target {
 
     ~Data();
 
-    xla::ComputationClient::DataPtr xla_data;
+    torch::lazy::BackendDataPtr xla_data;
     torch::lazy::Value ir_value;
     std::shared_ptr<View> view;
     // TODO: remove this in favor of torch::lazy::Shape within ir_value.
@@ -1316,7 +1316,7 @@ class XLATensor : public c10::intrusive_ptr_target {
   };
 
   XLATensor(const at::Tensor& tensor, const torch::lazy::BackendDevice& device);
-  XLATensor(xla::ComputationClient::DataPtr xla_data,
+  XLATensor(torch::lazy::BackendDataPtr xla_data,
             c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
   XLATensor(torch::lazy::Value ir_value,
             const torch::lazy::BackendDevice& device,
@@ -1334,7 +1334,7 @@ class XLATensor : public c10::intrusive_ptr_target {
 
   std::shared_ptr<Data> data_ptr() const { return data_; }
 
-  void SetXlaData(xla::ComputationClient::DataPtr xla_data, bool sync);
+  void SetXlaData(torch::lazy::BackendDataPtr xla_data, bool sync);
 
   void SetIrValue(torch::lazy::Value ir_value, bool inplace = true);
   void SetInPlaceIrValue(torch::lazy::Value ir_value);
@@ -1343,7 +1343,7 @@ class XLATensor : public c10::intrusive_ptr_target {
 
   void SetTensorData(at::Tensor tensor_data);
 
-  torch::lazy::Value CreateTensorNode(xla::ComputationClient::DataPtr data,
+  torch::lazy::Value CreateTensorNode(torch::lazy::BackendDataPtr data,
                                       bool read_only) const;
 
   View::IrNode GetViewUpdate(const std::shared_ptr<View>& view) const;
@@ -1412,14 +1412,14 @@ class XLATensor : public c10::intrusive_ptr_target {
 
   // Gathers the XLA device data for all the input tensors, after an
   // asynchronous operation.
-  static std::vector<xla::ComputationClient::DataPtr> GatherTensorsXlaData(
+  static std::vector<torch::lazy::BackendDataPtr> GatherTensorsXlaData(
       const std::vector<XLATensor>& tensors, absl::Span<const size_t> indices,
-      absl::Span<const xla::ComputationClient::DataPtr> tensors_data);
+      absl::Span<const torch::lazy::BackendDataPtr> tensors_data);
 
   static std::vector<torch::lazy::Value> CollectRoots(
       const std::vector<XLATensor>& tensors, absl::Span<const size_t> indices);
 
-  static std::vector<xla::ComputationClient::DataPtr> FetchTensorData(
+  static std::vector<torch::lazy::BackendDataPtr> FetchTensorData(
       std::vector<XLATensor>* tensors, const SyncTensorsConfig& config,
       absl::Span<const size_t> indices);
 
@@ -1432,13 +1432,13 @@ class XLATensor : public c10::intrusive_ptr_target {
   // present within the coll structure.
   static std::shared_ptr<XLATensor::Async> ScheduleSyncTensorsGraph(
       SyncTensorCollection* coll,
-      std::vector<xla::ComputationClient::DataPtr> parameters_data,
-      std::vector<xla::ComputationClient::DataPtr> tensors_data,
+      std::vector<torch::lazy::BackendDataPtr> parameters_data,
+      std::vector<torch::lazy::BackendDataPtr> tensors_data,
       ComputationCache::TypePtr cached_computation);
 
   static std::shared_ptr<Async> ScheduleSyncTensorsGraph(
       std::vector<XLATensor>* tensors, SyncTensorCollection* coll,
-      std::vector<xla::ComputationClient::DataPtr> parameters_data,
+      std::vector<torch::lazy::BackendDataPtr> parameters_data,
       std::string device, ComputationCache::TypePtr cached_computation);
 
   static PostOrderData RunPostOrder(const std::vector<XLATensor>& tensors,

--- a/torch_xla/csrc/tensor_util.h
+++ b/torch_xla/csrc/tensor_util.h
@@ -11,8 +11,21 @@
 #include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/lazy/core/hash.h"
 #include "torch_xla/csrc/device.h"
+#include "torch_xla/csrc/xla_backend_impl.h"
 
 namespace torch_xla {
+
+xla::ComputationClient::DataPtr UnwrapXlaData(
+    const torch::lazy::BackendDataPtr& data);
+
+std::vector<xla::ComputationClient::DataPtr> UnwrapXlaData(
+    absl::Span<const torch::lazy::BackendDataPtr> datas);
+
+torch::lazy::BackendDataPtr WrapXlaData(
+    const xla::ComputationClient::DataPtr& xla_data);
+
+std::vector<torch::lazy::BackendDataPtr> WrapXlaData(
+    absl::Span<const xla::ComputationClient::DataPtr> xla_datas);
 
 std::vector<int64_t> ComputeShapeStrides(const xla::Shape& shape);
 
@@ -22,7 +35,7 @@ at::Tensor MakeTensorFromXlaLiteral(const xla::Literal& literal,
 
 // TODO LTC @wonjoo - Migrate to upstream after Device -> BackendDevice
 std::vector<at::Tensor> XlaDataToTensors(
-    absl::Span<const xla::ComputationClient::DataPtr> xla_data,
+    absl::Span<const torch::lazy::BackendDataPtr> xla_data,
     at::ScalarType dest_element_type);
 
 bool TensorCompare(const at::Tensor& t1, const at::Tensor& t2);
@@ -30,7 +43,7 @@ bool TensorCompare(const at::Tensor& t1, const at::Tensor& t2);
 // Uploads an ATEN tensor data to the device and fetches the corresponding
 // device data handle.
 // TODO LTC @wonjoo - Migrate to upstream after Device -> BackendDevice
-xla::ComputationClient::DataPtr TensorToXlaData(
+torch::lazy::BackendDataPtr TensorToXlaData(
     const at::Tensor& tensor, const torch::lazy::BackendDevice& device,
     bool transfer_async = false);
 
@@ -39,7 +52,7 @@ torch::lazy::hash_t TensorHash(const at::Tensor& tensor);
 // Retrieves the device data handles by parallel uploading data onto the
 // corresponding devices.
 // TODO LTC @wonjoo - Migrate to upstream after Device -> BackendDevice
-std::vector<xla::ComputationClient::DataPtr> CreateTensorsData(
+std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
     const std::vector<at::Tensor>& tensors,
     const std::vector<std::string>& devices, bool transfer_async = false);
 

--- a/torch_xla/csrc/xla_backend_impl.h
+++ b/torch_xla/csrc/xla_backend_impl.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <iostream>
+#include <string>
+
+#include "tensorflow/compiler/xla/xla_client/computation_client.h"
+#include "torch/csrc/lazy/backend/backend_interface.h"
+#include "torch_xla/csrc/device.h"
+
+namespace torch_xla {
+class XLAData : public torch::lazy::BackendData {
+ public:
+  XLAData(const torch::lazy::Shape& shape,
+          const torch::lazy::BackendDevice& device,
+          xla::ComputationClient::DataPtr xla_data)
+      : torch::lazy::BackendData(device, shape), xla_data_(xla_data) {}
+
+  // TODO set Device and torch::lazy_shape correctly
+  XLAData(xla::ComputationClient::DataPtr xla_data)
+      : torch::lazy::BackendData(ParseDeviceString(xla_data->device()),
+                                 torch::lazy::Shape()),
+        xla_data_(xla_data) {}
+
+  Handle GetHandle() override { return xla_data_->GetOpaqueHandle(); }
+
+  void Assign(const torch::lazy::BackendData& data) override {
+    // Assign should only be called to update the handle, no need
+    // to update device and shape.
+    XLAData new_xla_data = static_cast<const XLAData&>(data).xla_data_;
+    xla_data_->Assign(*(new_xla_data.xla_data().get()));
+  }
+
+  bool HasValue() const override { return xla_data_->HasValue(); }
+
+  xla::ComputationClient::DataPtr xla_data() { return xla_data_; }
+
+ private:
+  // TODO: Do we really need a Share_Ptr here?
+  xla::ComputationClient::DataPtr xla_data_;
+};
+
+}  // namespace torch_xla


### PR DESCRIPTION
In PyTorch/XLA we use `xla::ComputationClient::DataPtr` to represent a Data on the device. This is defined in `third_party/xla_client/computation_client.h`. The real implementation resides in `third_party/xla_client/xrt_computation_client.h` (and `pjrt_computation_client`). In order to migrate to Upstream LTC, we have to use `torch::lazy::BackendDataPtr`. The issue here is that there is no way to get PyTorch to take dependency on `xla_client`(since it is being build with tf) and vice versa. 

My solution is to wrap the `xla::ComputationClient::DataPtr` within the `XLAData` which inherits from `torch::lazy::BackendData`. Whenever we need to do the real data transfer, we pass the underlying `xla::ComputationClient::DataPtr` to the runtime. This wrapping and unwrapping will have some overhead (measure below) hence I am not planning to merge this pr to the 1.12 release branch.


TODO: 
- [x] Clean up the code
- [x] Verify correctness
- [x] Benchmark the `Wrap` and `Unwrap` on TPU 