### PR TITLE
Revert PR#3450 and use sparse_gather in gather

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -71,9 +71,10 @@ void CheckSubOperandTypes(at::ScalarType type1, at::ScalarType type2) {
 
 c10::optional<at::ScalarType> PromoteIntegralType(
     at::ScalarType src_dtype, const c10::optional<at::ScalarType>& opt_dtype) {
-  return opt_dtype.has_value() ? opt_dtype.value()
-         : at::isIntegralType(src_dtype, /*includeBool=*/true) ? at::kLong
-                                                               : opt_dtype;
+  return opt_dtype.has_value()
+             ? opt_dtype.value()
+             : at::isIntegralType(src_dtype, /*includeBool=*/true) ? at::kLong
+                                                                   : opt_dtype;
 }
 
 bool IsTypeWithLargerRangeThanLong(torch::ScalarType dtype) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -71,10 +71,9 @@ void CheckSubOperandTypes(at::ScalarType type1, at::ScalarType type2) {
 
 c10::optional<at::ScalarType> PromoteIntegralType(
     at::ScalarType src_dtype, const c10::optional<at::ScalarType>& opt_dtype) {
-  return opt_dtype.has_value()
-             ? opt_dtype.value()
-             : at::isIntegralType(src_dtype, /*includeBool=*/true) ? at::kLong
-                                                                   : opt_dtype;
+  return opt_dtype.has_value() ? opt_dtype.value()
+         : at::isIntegralType(src_dtype, /*includeBool=*/true) ? at::kLong
+                                                               : opt_dtype;
 }
 
 bool IsTypeWithLargerRangeThanLong(torch::ScalarType dtype) {
@@ -1495,10 +1494,11 @@ at::Tensor XLANativeFunctions::frac(const at::Tensor& self) {
 
 at::Tensor XLANativeFunctions::gather(const at::Tensor& self, int64_t dim,
                                       const at::Tensor& index,
-                                      bool /* sparse_grad */) {
+                                      bool sparse_grad) {
   XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(XLATensor::gather(
-      bridge::GetXlaTensor(self), dim, bridge::GetXlaTensor(index)));
+  return bridge::AtenFromXlaTensor(
+      XLATensor::gather(bridge::GetXlaTensor(self), dim,
+                        bridge::GetXlaTensor(index), sparse_grad));
 }
 
 at::Tensor XLANativeFunctions::ge(const at::Tensor& self,

--- a/torch_xla/csrc/ops/gather.cpp
+++ b/torch_xla/csrc/ops/gather.cpp
@@ -22,7 +22,9 @@ torch::lazy::NodePtr Gather::Clone(OpList operands) const {
 XlaOpVector Gather::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
   xla::XlaOp index = loctx->GetOutputOp(operand(1));
-  return ReturnOp(xla::TorchGather(input, index, dim_, /*sparse=*/true), loctx);
+  return ReturnOp(
+      xla::TorchGather(input, index, dim_, IsSparseGather(input, index, dim_)),
+      loctx);
 }
 
 std::string Gather::ToString() const {

--- a/torch_xla/csrc/ops/gather.cpp
+++ b/torch_xla/csrc/ops/gather.cpp
@@ -8,28 +8,30 @@
 
 namespace torch_xla {
 
-Gather::Gather(const XlaValue& input, int64_t dim, const XlaValue& index)
+Gather::Gather(const XlaValue& input, int64_t dim, const XlaValue& index,
+               bool sparse_grad)
     : XlaNode(torch::lazy::OpKind(at::aten::gather), {input, index},
               xla::ShapeUtil::MakeShape(input.xla_shape().element_type(),
                                         index.xla_shape().dimensions()),
               /*num_outputs=*/1, torch::lazy::MHash(dim)),
-      dim_(dim) {}
+      dim_(dim),
+      sparse_grad_(sparse_grad) {}
 
 torch::lazy::NodePtr Gather::Clone(OpList operands) const {
-  return torch::lazy::MakeNode<Gather>(operands.at(0), dim_, operands.at(1));
+  return torch::lazy::MakeNode<Gather>(operands.at(0), dim_, operands.at(1),
+                                       sparse_grad_);
 }
 
 XlaOpVector Gather::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
   xla::XlaOp index = loctx->GetOutputOp(operand(1));
-  return ReturnOp(
-      xla::TorchGather(input, index, dim_, IsSparseGather(input, index, dim_)),
-      loctx);
+  return ReturnOp(xla::TorchGather(input, index, dim_, sparse_grad_), loctx);
 }
 
 std::string Gather::ToString() const {
   std::stringstream ss;
-  ss << XlaNode::ToString() << ", dim=" << dim_;
+  ss << XlaNode::ToString() << ", dim=" << dim_
+     << ", sparse_grad=" << sparse_grad_;
   return ss.str();
 }
 

--- a/torch_xla/csrc/ops/gather.h
+++ b/torch_xla/csrc/ops/gather.h
@@ -6,7 +6,8 @@ namespace torch_xla {
 
 class Gather : public XlaNode {
  public:
-  Gather(const XlaValue& input, int64_t dim, const XlaValue& index);
+  Gather(const XlaValue& input, int64_t dim, const XlaValue& index,
+         bool sparse_grad);
 
   std::string ToString() const override;
 
@@ -18,6 +19,7 @@ class Gather : public XlaNode {
 
  private:
   int64_t dim_;
+  bool sparse_grad_;
 };
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -616,7 +616,7 @@ class XLATensor {
                              c10::optional<at::ScalarType> scalar_type);
 
   static XLATensor gather(const XLATensor& input, int64_t dim,
-                          const XLATensor& index);
+                          const XLATensor& index, bool sparse_grad);
 
   static XLATensor ge(const XLATensor& input, const at::Scalar& other);
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1403,7 +1403,7 @@ XLATensor XLATensor::full_like(const XLATensor& input,
 }
 
 XLATensor XLATensor::gather(const XLATensor& input, int64_t dim,
-                            const XLATensor& index) {
+                            const XLATensor& index, bool sparse_grad) {
   xla::Shape input_shape = input.shape();
   xla::Shape index_shape = index.shape();
   XLA_CHECK_EQ(input_shape.rank(), index_shape.rank());

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1415,7 +1415,7 @@ XLATensor XLATensor::gather(const XLATensor& input, int64_t dim,
     }
   }
   return input.CreateFrom(torch::lazy::MakeNode<Gather>(
-      input.GetIrValue(), canonical_dim, index.GetIrValue()));
+      input.GetIrValue(), canonical_dim, index.GetIrValue(), sparse_grad));
 }
 
 XLATensor XLATensor::ge(const XLATensor& input, const at::Scalar& other) {


### PR DESCRIPTION
Previously, we've internally overridden the `sparse_grad` option in [`torch.gather`](https://pytorch.org/docs/stable/generated/torch.gather.html) (see #3450 ). However, forcing `sparse_grad=true` always can have a serious performance implications, like #3441 . This PR addresses the issue and honors the `sparse_grad` option as passed with the original `torch.gather` calls.

cc hi @ymwangg, with this change you would need to pass `sparse_grad=true` explicitly to `torch.gather` as described in  [`torch.gather`](https://pytorch.org/docs/stable/generated/torch.gather.html). Let us know if you run into any issues after we revert #3450 
cc @ronghanghu FYI

