### PR TITLE
Full codegen addcmul

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -561,16 +561,6 @@ at::Tensor& XLANativeFunctions::addcdiv_(at::Tensor& self,
   return self;
 }
 
-at::Tensor XLANativeFunctions::addcmul(const at::Tensor& self,
-                                       const at::Tensor& tensor1,
-                                       const at::Tensor& tensor2,
-                                       const at::Scalar& value) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(XLATensor::addcmul(
-      bridge::GetXlaTensor(self), value, bridge::GetXlaTensor(tensor1),
-      bridge::GetXlaTensor(tensor2)));
-}
-
 at::Tensor XLANativeFunctions::addmm(const at::Tensor& self,
                                      const at::Tensor& mat1,
                                      const at::Tensor& mat2,

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -21,6 +21,15 @@ torch_xla::XlaOpVector Acosh::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::Acosh(xla_input), loctx);
 }
 
+torch_xla::XlaOpVector Addcmul::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  xla::XlaOp xla_tensor_1 = loctx->GetOutputOp(operand(1));
+  xla::XlaOp xla_tensor_2 = loctx->GetOutputOp(operand(2));
+  xla::XlaOp xla_constant = loctx->GetOutputOp(operand(3));
+  xla::XlaOp mul = xla_tensor_1 * xla_tensor_2;
+  return ReturnOp(xla_input + mul * xla_constant, loctx);
+}
+
 torch_xla::XlaOpVector Asin::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   return ReturnOp(xla::Asin(xla_input), loctx);

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -16,8 +16,12 @@ xla::Shape AcoshOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
-
-xla::Shape AddcmulOutputShape(const torch::lazy::Value& input, const torch::lazy::Value& tensor1, const torch::lazy::Value& tensor2, const torch::lazy::Value& value) { return GetXlaShape(input); }
+xla::Shape AddcmulOutputShape(const torch::lazy::Value& input,
+                              const torch::lazy::Value& tensor1,
+                              const torch::lazy::Value& tensor2,
+                              const torch::lazy::Value& value) {
+  return GetXlaShape(input);
+}
 
 xla::Shape AsinOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -16,6 +16,9 @@ xla::Shape AcoshOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
+
+xla::Shape AddcmulOutputShape(const torch::lazy::Value& input, const torch::lazy::Value& tensor1, const torch::lazy::Value& tensor2, const torch::lazy::Value& value) { return GetXlaShape(input); }
+
 xla::Shape AsinOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -9,7 +9,10 @@ xla::Shape AcosOutputShape(const torch::lazy::Value& input);
 
 xla::Shape AcoshOutputShape(const torch::lazy::Value& input);
 
-xla::Shape AddcmulOutputShape(const torch::lazy::Value& input, const torch::lazy::Value& tensor1, const torch::lazy::Value& tensor2, const torch::lazy::Value& value);
+xla::Shape AddcmulOutputShape(const torch::lazy::Value& input,
+                              const torch::lazy::Value& tensor1,
+                              const torch::lazy::Value& tensor2,
+                              const torch::lazy::Value& value);
 
 xla::Shape AsinOutputShape(const torch::lazy::Value& input);
 

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -9,6 +9,8 @@ xla::Shape AcosOutputShape(const torch::lazy::Value& input);
 
 xla::Shape AcoshOutputShape(const torch::lazy::Value& input);
 
+xla::Shape AddcmulOutputShape(const torch::lazy::Value& input, const torch::lazy::Value& tensor1, const torch::lazy::Value& tensor2, const torch::lazy::Value& value);
+
 xla::Shape AsinOutputShape(const torch::lazy::Value& input);
 
 xla::Shape AsinhOutputShape(const torch::lazy::Value& input);

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -354,9 +354,6 @@ class XLATensor : public c10::intrusive_ptr_target {
   static void addcdiv_(XLATensor& input, const at::Scalar& value,
                        const XLATensor& tensor1, const XLATensor& tensor2);
 
-  static XLATensor addcmul(const XLATensor& input, const at::Scalar& value,
-                           const XLATensor& tensor1, const XLATensor& tensor2);
-
   static XLATensor addmm(const XLATensor& input, const XLATensor& weight,
                          const XLATensor& bias);
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -705,15 +705,6 @@ void XLATensor::addcdiv_(XLATensor& input, const at::Scalar& value,
   input.SetInPlaceIrValue(input.GetIrValue() + div * constant);
 }
 
-XLATensor XLATensor::addcmul(const XLATensor& input, const at::Scalar& value,
-                             const XLATensor& tensor1,
-                             const XLATensor& tensor2) {
-  torch::lazy::Value constant = GetIrValueForScalar(
-      value, tensor1.shape().get().element_type(), input.GetDevice());
-  torch::lazy::Value mul = tensor1.GetIrValue() * tensor2.GetIrValue();
-  return input.CreateFrom(input.GetIrValue() + mul * constant);
-}
-
 XLATensor XLATensor::addmm(const XLATensor& input, const XLATensor& weight,
                            const XLATensor& bias) {
   return input.CreateFrom(

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -1,9 +1,10 @@
 backend: XLA
 cpp_namespace: torch_xla
 full_codegen:
+  - abs
   - acos
   - acosh
-  - abs
+  - addcmul
   - asin
   - asinh
   - atan
@@ -46,7 +47,6 @@ supported:
   - add.Tensor
   - addcdiv
   - addcdiv_
-  - addcmul
   - addmm
   - alias
   - all


### PR DESCRIPTION
We're seeing some issues when we're trying to full codgen ops that has `at::Scalar` as part of their inputs like `addcmul` op. The generated `class Addcmul` in `LazyIr.h` looks like:
```
Addcmul(const torch_xla::XlaValue& self, const torch_xla::XlaValue& tensor1, 
  const torch_xla::XlaValue& tensor2, const torch_xla::XlaValue& value, 
  std::vector<torch::lazy::Shape>&& shapes)
```
However, the generated `MakeNode<Addcmul>` call in `XlaNativeFunctions.cpp` file looks like:
```
auto node = torch::lazy::MakeNode<Addcmul>(lazy_self->GetIrValue(),
                      lazy_tensor1->GetIrValue(),
                      lazy_tensor2->GetIrValue(),
                      torch::lazy::LazyGraphExecutor::Get()->GetIrValueForScalarFromCodegen(value),
                      std::move(shapes));
```
And since the `GetIrValueForScalarFromCodegen(value)` call in `XlaNativeFunctions.cpp` returns a `torch::lazy::Value` while `class Addcmul` in `LazyIr.h` expects a `torch_xla::Value`, the build fails with error:
```
/workspace/pytorch/xla/torch_xla/csrc/generated/XLANativeFunctions.cpp:111:34: note: in instantiation of function template specialization 'torch::lazy::MakeNode<torch_xla::Addcmul, torch_xla::XlaValue, torch_xla::XlaValue, torch_xla::XlaValue, torch::lazy::Value, std::vector<torch::lazy::Shape, std::allocator<torch::lazy::Shape> > >' requested here
        auto node = torch::lazy::MakeNode<Addcmul>(lazy_self->GetIrValue(),
                                 ^
/workspace/pytorch/xla/torch_xla/csrc/generated/LazyIr.h:128:3: note: candidate constructor not viable: no known conversion from 'torch::lazy::Value' to 'const torch_xla::XlaValue' for 4th argument
  Addcmul(const torch_xla::XlaValue& self, const torch_xla::XlaValue& tensor1, const torch_xla::XlaValue& tensor2, const torch_xla::XlaValue& value, std::vector<torch::lazy::Shape>&& shapes)
  ^
/workspace/pytorch/xla/torch_xla/csrc/generated/LazyIr.h:122:7: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 5 were provided
class Addcmul : public XlaNode {
      ^
/workspace/pytorch/xla/torch_xla/csrc/generated/LazyIr.h:122:7: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 5 were provided
```

The upstream codegen for `GetIrValueForScalarFromCodegen(value)` calls seems to happen here at https://github.com/pytorch/pytorch/blob/master/torchgen/dest/lazy_ir.py#L313. @JackCaoG, should we override the upstream `GenLazyNativeFuncDefinition` (https://github.com/pytorch/pytorch/blob/master/torchgen/dest/lazy_ir.py#L281) to override this function?

---

Generated `LazyIr.h` file:
```
class Addcmul : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::addcmul);
  }

  Addcmul(const torch_xla::XlaValue& self, const torch_xla::XlaValue& tensor1, const torch_xla::XlaValue& tensor2, const torch_xla::XlaValue& value, std::vector<torch::lazy::Shape>&& shapes)

      : XlaNode(torch::lazy::OpKind(at::aten::addcmul),
              {self, tensor1, tensor2, value}, std::move(shapes),
              [&]() { return AddcmulOutputShape(self, tensor1, tensor2, value); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
        

  {
    
  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();
    
    return ss.str();
  }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;

  
  

};
```

---

Generated `XLANativeFunctions.cpp`:
```
    at::Tensor XLANativeFunctions::addcmul(const at::Tensor & self, const at::Tensor & tensor1, const at::Tensor & tensor2, const at::Scalar & value) {
        
        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self, tensor1, tensor2);
        TORCH_INTERNAL_ASSERT(common_device);
        
        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        torch_xla::XLATensorPtr lazy_tensor1 = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(tensor1, *common_device);
        torch_xla::XLATensorPtr lazy_tensor2 = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(tensor2, *common_device);
        auto out_meta = at::meta::addcmul(self, tensor1, tensor2, value);
        std::vector<torch::lazy::Shape> shapes{
        torch::lazy::Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
        TORCH_INTERNAL_ASSERT(shapes.size() == 1);
        if(torch::lazy::symbolicShapeEnabled()){
            std::vector<torch::jit::IValue> inputs = { self, tensor1, tensor2, value };
            char* schema_str = "aten::addcmul(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor";
            applySymbolicShapesOnLT(schema_str, inputs, shapes);
        }
        
        auto node = torch::lazy::MakeNode<Addcmul>(lazy_self->GetIrValue(),
                              lazy_tensor1->GetIrValue(),
                              lazy_tensor2->GetIrValue(),
                              torch::lazy::LazyGraphExecutor::Get()->GetIrValueForScalarFromCodegen(value),
                                                                                      std::move(shapes));
        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };
```