### PR TITLE
Bazel build issue patch

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -93,7 +93,7 @@ function install_deps_pytorch_xla() {
   fi
   bazels3cache --bucket=${XLA_CLANG_CACHE_S3_BUCKET_NAME} --maxEntrySizeBytes=0 --logging.level=verbose
   # Uncomment to use cloud cache to build when available.
-  # sed -i '/bazel build/ a --remote_http_cache=http://localhost:7777 \\' $XLA_DIR/build_torch_xla_libs.sh
+  sed -i '/bazel build/ a --remote_http_cache=http://localhost:7777 \\' $XLA_DIR/build_torch_xla_libs.sh
 
 }
 

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -93,7 +93,7 @@ function install_deps_pytorch_xla() {
   fi
   bazels3cache --bucket=${XLA_CLANG_CACHE_S3_BUCKET_NAME} --maxEntrySizeBytes=0 --logging.level=verbose
   # Uncomment to use cloud cache to build when available.
-  sed -i '/bazel build/ a --remote_http_cache=http://localhost:7777 \\' $XLA_DIR/build_torch_xla_libs.sh
+  #sed -i '/bazel build/ a --remote_http_cache=http://localhost:7777 \\' $XLA_DIR/build_torch_xla_libs.sh
 
 }
 

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -49,6 +49,7 @@ function checkout_torch_pin_if_available() {
 
 function install_deps_pytorch_xla() {
   XLA_DIR=$1
+  USE_CACHE="${2:-1}"
 
   # Install ninja to speedup the build
   pip install ninja
@@ -92,9 +93,10 @@ function install_deps_pytorch_xla() {
     exit 1
   fi
   bazels3cache --bucket=${XLA_CLANG_CACHE_S3_BUCKET_NAME} --maxEntrySizeBytes=0 --logging.level=verbose
-  # Uncomment to use cloud cache to build when available.
-  #sed -i '/bazel build/ a --remote_http_cache=http://localhost:7777 \\' $XLA_DIR/build_torch_xla_libs.sh
-
+  # Use cloud cache to build when available.
+  if [[ "$USE_CACHE" == 1 ]]; then
+    sed -i '/bazel build/ a --remote_http_cache=http://localhost:7777 \\' $XLA_DIR/build_torch_xla_libs.sh
+  fi
 }
 
 function build_torch_xla() {

--- a/build_torch_xla_libs.sh
+++ b/build_torch_xla_libs.sh
@@ -34,7 +34,15 @@ if [[ "$XLA_BAZEL_VERBOSE" == "1" ]]; then
   VERBOSE="-s"
 fi
 
-BUILD_STRATEGY="local"
+BUILD_STRATEGY="standalone"
+if [[ "$XLA_SANDBOX_BUILD" == "0" ]]; then
+  # Temporary patch until tensorflow update bazel requirement to 5.2.0
+  echo "6e54699884cfad49d4e8f6dd59a4050bc95c4edf" > third_party/tensorflow/.bazelversion
+  # We can remove this after https://github.com/bazelbuild/bazel/issues/15359 is resolved
+  unset CC
+  unset CXX
+  BUILD_STRATEGY="local"
+fi
 if [[ "$XLA_SANDBOX_BUILD" == "1" ]]; then
   BUILD_STRATEGY="sandboxed --sandbox_tmpfs_path=/tmp"
 fi
@@ -64,12 +72,6 @@ if [ "$CMD" == "clean" ]; then
   bazel clean
   popd
 else
-  # Temporary patch until tensorflow update bazel requirement to 5.2.0
-  echo "6e54699884cfad49d4e8f6dd59a4050bc95c4edf" > third_party/tensorflow/.bazelversion
-  # We can remove this after https://github.com/bazelbuild/bazel/issues/15359 is resolved
-  unset CC
-  unset CXX
-
   cp -r -u -p $THIRD_PARTY_DIR/xla_client $THIRD_PARTY_DIR/tensorflow/tensorflow/compiler/xla/
 
   pushd $THIRD_PARTY_DIR/tensorflow

--- a/build_torch_xla_libs.sh
+++ b/build_torch_xla_libs.sh
@@ -73,7 +73,8 @@ else
   cp -r -u -p $THIRD_PARTY_DIR/xla_client $THIRD_PARTY_DIR/tensorflow/tensorflow/compiler/xla/
 
   pushd $THIRD_PARTY_DIR/tensorflow
-  bazel build $MAX_JOBS $VERBOSE $TPUVM_FLAG --spawn_strategy=$BUILD_STRATEGY --define framework_shared_object=false -c "$MODE" "${OPTS[@]}" \
+  bazel build $MAX_JOBS $VERBOSE $TPUVM_FLAG --spawn_strategy=$BUILD_STRATEGY --show_progress_rate_limit=5 \
+    --define framework_shared_object=false -c "$MODE" "${OPTS[@]}" \
     $XLA_CUDA_CFG //tensorflow/compiler/xla/xla_client:libxla_computation_client.so
 
   popd

--- a/build_torch_xla_libs.sh
+++ b/build_torch_xla_libs.sh
@@ -61,6 +61,10 @@ if [ "$CMD" == "clean" ]; then
 else
   # Temporary patch until tensorflow update bazel requirement to 5.2.0
   echo "6e54699884cfad49d4e8f6dd59a4050bc95c4edf" > third_party/tensorflow/.bazelversion
+  # We can remove this after https://github.com/bazelbuild/bazel/issues/15359 is resolved
+  unset CC
+  unset CXX
+
   cp -r -u -p $THIRD_PARTY_DIR/xla_client $THIRD_PARTY_DIR/tensorflow/tensorflow/compiler/xla/
 
   pushd $THIRD_PARTY_DIR/tensorflow

--- a/build_torch_xla_libs.sh
+++ b/build_torch_xla_libs.sh
@@ -34,6 +34,11 @@ if [[ "$XLA_BAZEL_VERBOSE" == "1" ]]; then
   VERBOSE="-s"
 fi
 
+BUILD_STRATEGY="local"
+if [[ "$XLA_SANDBOX_BUILD" == "1" ]]; then
+  BUILD_STRATEGY="sandboxed"
+fi
+
 TPUVM_FLAG=
 if [[ "$TPUVM_MODE" == "1" ]]; then
   TPUVM_FLAG="--define=with_tpu_support=true"
@@ -68,7 +73,7 @@ else
   cp -r -u -p $THIRD_PARTY_DIR/xla_client $THIRD_PARTY_DIR/tensorflow/tensorflow/compiler/xla/
 
   pushd $THIRD_PARTY_DIR/tensorflow
-  bazel build $MAX_JOBS $VERBOSE $TPUVM_FLAG --spawn_strategy=local --define framework_shared_object=false -c "$MODE" "${OPTS[@]}" \
+  bazel build $MAX_JOBS $VERBOSE $TPUVM_FLAG --spawn_strategy=$BUILD_STRATEGY --define framework_shared_object=false -c "$MODE" "${OPTS[@]}" \
     $XLA_CUDA_CFG //tensorflow/compiler/xla/xla_client:libxla_computation_client.so
 
   popd

--- a/build_torch_xla_libs.sh
+++ b/build_torch_xla_libs.sh
@@ -36,7 +36,7 @@ fi
 
 BUILD_STRATEGY="local"
 if [[ "$XLA_SANDBOX_BUILD" == "1" ]]; then
-  BUILD_STRATEGY="sandboxed"
+  BUILD_STRATEGY="sandboxed --sandbox_tmpfs_path=/tmp"
 fi
 
 TPUVM_FLAG=
@@ -73,7 +73,7 @@ else
   cp -r -u -p $THIRD_PARTY_DIR/xla_client $THIRD_PARTY_DIR/tensorflow/tensorflow/compiler/xla/
 
   pushd $THIRD_PARTY_DIR/tensorflow
-  bazel build $MAX_JOBS $VERBOSE $TPUVM_FLAG --spawn_strategy=$BUILD_STRATEGY --show_progress_rate_limit=5 \
+  bazel build $MAX_JOBS $VERBOSE $TPUVM_FLAG --spawn_strategy=$BUILD_STRATEGY --show_progress_rate_limit=20 \
     --define framework_shared_object=false -c "$MODE" "${OPTS[@]}" \
     $XLA_CUDA_CFG //tensorflow/compiler/xla/xla_client:libxla_computation_client.so
 

--- a/build_torch_xla_libs.sh
+++ b/build_torch_xla_libs.sh
@@ -59,10 +59,12 @@ if [ "$CMD" == "clean" ]; then
   bazel clean
   popd
 else
+  # Temporary patch until tensorflow update bazel requirement to 5.2.0
+  echo "6e54699884cfad49d4e8f6dd59a4050bc95c4edf" > third_party/tensorflow/.bazelversion
   cp -r -u -p $THIRD_PARTY_DIR/xla_client $THIRD_PARTY_DIR/tensorflow/tensorflow/compiler/xla/
 
   pushd $THIRD_PARTY_DIR/tensorflow
-  bazel build $MAX_JOBS $VERBOSE $TPUVM_FLAG --spawn_strategy=sandboxed --define framework_shared_object=false -c "$MODE" "${OPTS[@]}" \
+  bazel build $MAX_JOBS $VERBOSE $TPUVM_FLAG --spawn_strategy=local --define framework_shared_object=false -c "$MODE" "${OPTS[@]}" \
     $XLA_CUDA_CFG //tensorflow/compiler/xla/xla_client:libxla_computation_client.so
 
   popd


### PR DESCRIPTION
Address #3569 , `bazel==5.1.1` introduced this error where bazel build corrupts build cache (both local and remote) during external builds (e.g., llvm). The issue seems to be confined to only `clang` `clang++` uses [issue](https://github.com/bazelbuild/bazel/issues/15359), but I was able to resolve with the (pre-release) `bazel==5.2.0`. Until `tensorflow` bumps up the bazel requirement, this patch should serve us to avoid build speed regression. 

Also, I had to unset `CC` and `CXX` for tensorflow build. This is still related to the bazel's `clang` `clang++` issue.

Bazel 5.2.0 will release after 5/23/22.