### PR TITLE
Replace XlaValue with upstream lazy::Value

### DIFF
--- a/scripts/gen_lazy_tensor.py
+++ b/scripts/gen_lazy_tensor.py
@@ -79,6 +79,5 @@ if __name__ == '__main__':
       create_tensor="XLATensor::Create",
       create_aten_from_ltc_tensor="torch_xla::bridge::AtenFromXlaTensor",
       tuple_aten_from_ltc_tensors="torch::lazy::TupleAtenFromLtcTensors",
-      lazy_value_class="torch_xla::XlaValue",
       lazy_tensor_ptr="torch_xla::XLATensorPtr",
       get_device_fn="torch_xla::bridge::GetXlaDevice")

--- a/test/cpp/cpp_test_util.cpp
+++ b/test/cpp/cpp_test_util.cpp
@@ -250,14 +250,14 @@ std::string GetTensorHloGraph(at::Tensor tensor) {
   return DumpUtil::ToHlo({xtensor.GetIrValue()}, xtensor.GetDevice());
 }
 
-XlaValue GetTensorIrValue(const at::Tensor& tensor,
-                          const torch::lazy::BackendDevice& device) {
+torch::lazy::Value GetTensorIrValue(const at::Tensor& tensor,
+                                    const torch::lazy::BackendDevice& device) {
   xla::ComputationClient::DataPtr data = TensorToXlaData(tensor, device);
   return torch::lazy::MakeNode<DeviceData>(std::move(data));
 }
 
 std::vector<xla::ComputationClient::DataPtr> Execute(
-    absl::Span<const XlaValue> roots,
+    absl::Span<const torch::lazy::Value> roots,
     const torch::lazy::BackendDevice& device) {
   LoweringContext lowering_ctx("Execute", device);
   for (auto node : roots) {
@@ -300,7 +300,7 @@ std::vector<at::Tensor> Fetch(
 }
 
 std::vector<at::Tensor> ExecuteAndFetch(
-    absl::Span<const XlaValue> roots,
+    absl::Span<const torch::lazy::Value> roots,
     const torch::lazy::BackendDevice& device) {
   auto results = Execute(roots, device);
   return Fetch(results);

--- a/test/cpp/cpp_test_util.h
+++ b/test/cpp/cpp_test_util.h
@@ -85,17 +85,19 @@ std::string GetTensorDotGraph(at::Tensor tensor);
 
 std::string GetTensorHloGraph(at::Tensor tensor);
 
-XlaValue GetTensorIrValue(const at::Tensor& tensor,
-                          const torch::lazy::BackendDevice& device);
+torch::lazy::Value GetTensorIrValue(const at::Tensor& tensor,
+                                    const torch::lazy::BackendDevice& device);
 
 std::vector<xla::ComputationClient::DataPtr> Execute(
-    absl::Span<const XlaValue> roots, const torch::lazy::BackendDevice& device);
+    absl::Span<const torch::lazy::Value> roots,
+    const torch::lazy::BackendDevice& device);
 
 std::vector<at::Tensor> Fetch(
     absl::Span<const xla::ComputationClient::DataPtr> device_data);
 
 std::vector<at::Tensor> ExecuteAndFetch(
-    absl::Span<const XlaValue> roots, const torch::lazy::BackendDevice& device);
+    absl::Span<const torch::lazy::Value> roots,
+    const torch::lazy::BackendDevice& device);
 
 void AssertBackward(const torch::Tensor& xla_output,
                     const std::vector<torch::Tensor>& xla_inputs,

--- a/test/cpp/test_ir.cpp
+++ b/test/cpp/test_ir.cpp
@@ -20,20 +20,24 @@ TEST(IrTest, TestScalarCreate) {
 TEST(IrTest, TestHash) {
   torch::lazy::NodePtr scalar1 = ScalarOp(1.0, xla::F32);
   torch::lazy::NodePtr scalar2 = ScalarOp(2.0, xla::F32);
-  XlaValue add1 = XlaValue(scalar1, 0) + XlaValue(scalar2, 0);
+  torch::lazy::Value add1 =
+      torch::lazy::Value(scalar1, 0) + torch::lazy::Value(scalar2, 0);
 
   torch::lazy::NodePtr scalar3 = ScalarOp(1.0, xla::F32);
   torch::lazy::NodePtr scalar4 = ScalarOp(2.0, xla::F32);
-  XlaValue add2 = XlaValue(scalar3, 0) + XlaValue(scalar4, 0);
+  torch::lazy::Value add2 =
+      torch::lazy::Value(scalar3, 0) + torch::lazy::Value(scalar4, 0);
 
   torch::lazy::NodePtr scalar5 = ScalarOp(11.0, xla::F32);
   torch::lazy::NodePtr scalar6 = ScalarOp(22.0, xla::F32);
-  XlaValue add3 = XlaValue(scalar5, 0) + XlaValue(scalar6, 0);
+  torch::lazy::Value add3 =
+      torch::lazy::Value(scalar5, 0) + torch::lazy::Value(scalar6, 0);
 
   EXPECT_EQ(add1->hash(), add2->hash());
   EXPECT_NE(add1->hash(), add3->hash());
 
-  XlaValue sub = XlaValue(scalar1, 0) - XlaValue(scalar2, 0);
+  torch::lazy::Value sub =
+      torch::lazy::Value(scalar1, 0) - torch::lazy::Value(scalar2, 0);
 
   EXPECT_NE(add1->hash(), sub->hash());
 }
@@ -43,9 +47,10 @@ TEST(IrTest, TestSelectUnselect) {
     at::Tensor a =
         at::rand({4, 16, 3}, at::TensorOptions(at::kFloat)).abs() + 1.0;
 
-    XlaValue v_a = GetTensorIrValue(a, device);
-    XlaValue v_s = torch::lazy::MakeNode<Select>(v_a, /*dim=*/1, /*start=*/3,
-                                                 /*end=*/14, /*stride=*/3);
+    torch::lazy::Value v_a = GetTensorIrValue(a, device);
+    torch::lazy::Value v_s =
+        torch::lazy::MakeNode<Select>(v_a, /*dim=*/1, /*start=*/3,
+                                      /*end=*/14, /*stride=*/3);
 
     auto results = ExecuteAndFetch({v_s}, device);
     at::Tensor b =
@@ -54,8 +59,8 @@ TEST(IrTest, TestSelectUnselect) {
 
     // Paste zeros back into the selected view.
     at::Tensor z = at::zeros_like(b);
-    XlaValue v_z = GetTensorIrValue(z, device);
-    XlaValue v_u =
+    torch::lazy::Value v_z = GetTensorIrValue(z, device);
+    torch::lazy::Value v_u =
         torch::lazy::MakeNode<Unselect>(v_a, v_z, /*dim=*/1, /*start=*/3,
                                         /*end=*/14, /*stride=*/3);
     results = ExecuteAndFetch({v_u}, device);

--- a/test/cpp/test_op_by_op_executor.cpp
+++ b/test/cpp/test_op_by_op_executor.cpp
@@ -17,9 +17,9 @@ TEST(OpByOpExecutorTest, TestSimpleAdd) {
     at::Tensor b = at::rand({4, 16, 3}, at::TensorOptions(at::kFloat));
     at::Tensor c = a + b;
 
-    XlaValue v_a = GetTensorIrValue(a, device);
-    XlaValue v_b = GetTensorIrValue(b, device);
-    XlaValue v_c = v_a + v_b;
+    torch::lazy::Value v_a = GetTensorIrValue(a, device);
+    torch::lazy::Value v_b = GetTensorIrValue(b, device);
+    torch::lazy::Value v_c = v_a + v_b;
 
     auto results_data =
         OpByOpExecutor::Get()->Execute({v_c}, device.toString(), {});
@@ -35,10 +35,10 @@ TEST(OpByOpExecutorTest, TestStack) {
     at::Tensor b = at::rand({4, 8, 3}, at::TensorOptions(at::kFloat));
     at::Tensor c = at::stack({a, b}, 1);
 
-    XlaValue v_a = GetTensorIrValue(a, device);
-    XlaValue v_b = GetTensorIrValue(b, device);
-    XlaValue v_c =
-        torch::lazy::MakeNode<Stack>(std::vector<XlaValue>({v_a, v_b}), 1);
+    torch::lazy::Value v_a = GetTensorIrValue(a, device);
+    torch::lazy::Value v_b = GetTensorIrValue(b, device);
+    torch::lazy::Value v_c = torch::lazy::MakeNode<Stack>(
+        std::vector<torch::lazy::Value>({v_a, v_b}), 1);
 
     auto results_data =
         OpByOpExecutor::Get()->Execute({v_c}, device.toString(), {});
@@ -54,10 +54,10 @@ TEST(OpByOpExecutorTest, TestAsyncStack) {
     at::Tensor b = at::rand({4, 8, 3}, at::TensorOptions(at::kFloat));
     at::Tensor c = at::stack({a, b}, 1);
 
-    XlaValue v_a = GetTensorIrValue(a, device);
-    XlaValue v_b = GetTensorIrValue(b, device);
-    XlaValue v_c =
-        torch::lazy::MakeNode<Stack>(std::vector<XlaValue>({v_a, v_b}), 1);
+    torch::lazy::Value v_a = GetTensorIrValue(a, device);
+    torch::lazy::Value v_b = GetTensorIrValue(b, device);
+    torch::lazy::Value v_c = torch::lazy::MakeNode<Stack>(
+        std::vector<torch::lazy::Value>({v_a, v_b}), 1);
 
     auto async =
         OpByOpExecutor::Get()->ExecuteAsync({v_c}, device.toString(), {});

--- a/torch_xla/csrc/debug_util.cpp
+++ b/torch_xla/csrc/debug_util.cpp
@@ -55,13 +55,13 @@ std::string DebugUtil::GetTensorsGraphInfo(absl::Span<const XLATensor> tensors,
                                            const std::vector<size_t>* indices,
                                            GraphFormat format) {
   std::vector<const torch::lazy::Node*> root_nodes;
-  std::vector<XlaValue> root_values;
+  std::vector<torch::lazy::Value> root_values;
   std::vector<torch::lazy::hash_t> root_hashes;
   xla::util::Unique<torch::lazy::BackendDevice> unique_device;
   if (indices != nullptr) {
     for (auto index : *indices) {
       const XLATensor& tensor = tensors[index];
-      XlaValue ir_value = tensor.CurrentIrValue();
+      torch::lazy::Value ir_value = tensor.CurrentIrValue();
       if (ir_value) {
         root_nodes.push_back(ir_value.node.get());
         root_hashes.push_back(ir_value.hash());
@@ -71,7 +71,7 @@ std::string DebugUtil::GetTensorsGraphInfo(absl::Span<const XLATensor> tensors,
     }
   } else {
     for (auto& tensor : tensors) {
-      XlaValue ir_value = tensor.CurrentIrValue();
+      torch::lazy::Value ir_value = tensor.CurrentIrValue();
       if (ir_value) {
         root_nodes.push_back(ir_value.node.get());
         root_hashes.push_back(ir_value.hash());

--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -84,16 +84,6 @@ torch::lazy::hash_t GetOperandHashes(const OpList& operands,
 
 }  // namespace
 
-// const xla::Shape& XlaValue::xla_shape() const {
-//   XlaNode* casted = dynamic_cast<XlaNode*>(node.get());
-//   return casted->xla_shape(index);
-// }
-
-// const xla::Shape& XlaValue::xla_node_shape() const {
-//   XlaNode* casted = dynamic_cast<XlaNode*>(node.get());
-//   return casted->xla_shape();
-// }
-
 XlaNode::XlaNode(torch::lazy::OpKind op, OpList operands,
                  std::vector<torch::lazy::Shape>&& shapes, xla::Shape xla_shape,
                  size_t num_outputs, torch::lazy::hash_t hash_seed)

--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -225,7 +225,7 @@ void ScopePusher::ResetScopes() { ResetScopeContext(); }
 
 const xla::Shape& GetXlaShape(const torch::lazy::Value& value) {
   XlaNode* casted = dynamic_cast<XlaNode*>(value.node.get());
-  return casted->xla_shape();
+  return casted->xla_shape(value.index);
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -84,15 +84,15 @@ torch::lazy::hash_t GetOperandHashes(const OpList& operands,
 
 }  // namespace
 
-const xla::Shape& XlaValue::xla_shape() const {
-  XlaNode* casted = dynamic_cast<XlaNode*>(node.get());
-  return casted->xla_shape(index);
-}
+// const xla::Shape& XlaValue::xla_shape() const {
+//   XlaNode* casted = dynamic_cast<XlaNode*>(node.get());
+//   return casted->xla_shape(index);
+// }
 
-const xla::Shape& XlaValue::xla_node_shape() const {
-  XlaNode* casted = dynamic_cast<XlaNode*>(node.get());
-  return casted->xla_shape();
-}
+// const xla::Shape& XlaValue::xla_node_shape() const {
+//   XlaNode* casted = dynamic_cast<XlaNode*>(node.get());
+//   return casted->xla_shape();
+// }
 
 XlaNode::XlaNode(torch::lazy::OpKind op, OpList operands,
                  std::vector<torch::lazy::Shape>&& shapes, xla::Shape xla_shape,
@@ -102,7 +102,7 @@ XlaNode::XlaNode(torch::lazy::OpKind op, OpList operands,
       node_hash_(torch::lazy::HashCombine(op.hash(), hash_seed)),
       dag_hash_(GetOperandHashes(operands, node_hash_)) {
   // We have to call AddOperand here since upstream OpList is
-  // an array of torch::lazy::Value while we uses XlaValue.
+  // an array of torch::lazy::Value while we uses torch::lazy::Value.
   for (auto& operand : operands) {
     AddOperand(operand.node, operand.index);
   }
@@ -116,7 +116,7 @@ XlaNode::XlaNode(torch::lazy::OpKind op, OpList operands,
       node_hash_(torch::lazy::HashCombine(op.hash(), hash_seed)),
       dag_hash_(GetOperandHashes(operands, node_hash_)) {
   // We have to call AddOperand here since upstream OpList is
-  // an array of torch::lazy::Value while we uses XlaValue.
+  // an array of torch::lazy::Value while we uses torch::lazy::Value.
   for (auto& operand : operands) {
     AddOperand(operand.node, operand.index);
   }
@@ -131,7 +131,7 @@ XlaNode::XlaNode(torch::lazy::OpKind op, OpList operands,
       node_hash_(torch::lazy::HashCombine(op.hash(), hash_seed)),
       dag_hash_(GetOperandHashes(operands, node_hash_)) {
   // We have to call AddOperand here since upstream OpList is
-  // an array of torch::lazy::Value while we uses XlaValue.
+  // an array of torch::lazy::Value while we uses torch::lazy::Value.
   for (auto& operand : operands) {
     AddOperand(operand.node, operand.index);
   }
@@ -232,5 +232,10 @@ ScopePusher::ScopePusher(const std::string& name) { PushScope(name); }
 ScopePusher::~ScopePusher() { PopScope(); }
 
 void ScopePusher::ResetScopes() { ResetScopeContext(); }
+
+const xla::Shape& GetXlaShape(const torch::lazy::Value& value) {
+  XlaNode* casted = dynamic_cast<XlaNode*>(value.node.get());
+  return casted->xla_shape();
+}
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -35,21 +35,24 @@ using OutputMap =
     std::unordered_map<torch::lazy::Output, T, torch::lazy::Output::Hasher>;
 
 // Represents an input/operand for a XlaNode object.
-struct XlaValue : public torch::lazy::Value {
-  XlaValue() = default;
-  XlaValue(torch::lazy::NodePtr node, size_t index = 0)
-      : torch::lazy::Value(std::dynamic_pointer_cast<torch::lazy::Node>(node),
-                           index) {}
+// struct XlaValue : public torch::lazy::Value {
+//   torch::lazy::Value() = default;
+//   torch::lazy::Value(torch::lazy::NodePtr node, size_t index = 0)
+//       :
+//       torch::lazy::Value(std::dynamic_pointer_cast<torch::lazy::Node>(node),
+//                            index) {}
 
-  // Retrieves the shape of this value. If the IR XlaNode generating the value
-  // is a multi-output node, the shape returned by this API will not be the full
-  // tuple shape, but only the shape at index referred by this value.
-  // To retrieve the full tuple shape in that case, use the node_shape() API.
-  const xla::Shape& xla_shape() const;
-  const xla::Shape& xla_node_shape() const;
-};
+//   // Retrieves the shape of this value. If the IR XlaNode generating the
+//   value
+//   // is a multi-output node, the shape returned by this API will not be the
+//   full
+//   // tuple shape, but only the shape at index referred by this value.
+//   // To retrieve the full tuple shape in that case, use the node_shape() API.
+//   // const xla::Shape& xla_shape() const;
+//   // const xla::Shape& xla_node_shape() const;
+// };
 
-using OpList = absl::Span<const XlaValue>;
+using OpList = absl::Span<const torch::lazy::Value>;
 
 // A node in the graph. Nodes for operations which requires extra data to be
 // stored for lowering, should inherit from this class and add operation
@@ -158,6 +161,8 @@ inline std::ostream& operator<<(std::ostream& stream, const XlaNode& node) {
   stream << node.ToString();
   return stream;
 }
+
+const xla::Shape& GetXlaShape(const torch::lazy::Value& value);
 
 template <typename T>
 T* NodeCast(const torch::lazy::Node* node, torch::lazy::OpKind op) {

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -34,24 +34,6 @@ template <typename T>
 using OutputMap =
     std::unordered_map<torch::lazy::Output, T, torch::lazy::Output::Hasher>;
 
-// Represents an input/operand for a XlaNode object.
-// struct XlaValue : public torch::lazy::Value {
-//   torch::lazy::Value() = default;
-//   torch::lazy::Value(torch::lazy::NodePtr node, size_t index = 0)
-//       :
-//       torch::lazy::Value(std::dynamic_pointer_cast<torch::lazy::Node>(node),
-//                            index) {}
-
-//   // Retrieves the shape of this value. If the IR XlaNode generating the
-//   value
-//   // is a multi-output node, the shape returned by this API will not be the
-//   full
-//   // tuple shape, but only the shape at index referred by this value.
-//   // To retrieve the full tuple shape in that case, use the node_shape() API.
-//   // const xla::Shape& xla_shape() const;
-//   // const xla::Shape& xla_node_shape() const;
-// };
-
 using OpList = absl::Span<const torch::lazy::Value>;
 
 // A node in the graph. Nodes for operations which requires extra data to be

--- a/torch_xla/csrc/ir_dump_util.cpp
+++ b/torch_xla/csrc/ir_dump_util.cpp
@@ -244,7 +244,7 @@ std::string DumpUtil::PostOrderToText(
   return ss.str();
 }
 
-std::string DumpUtil::ToHlo(absl::Span<const XlaValue> values,
+std::string DumpUtil::ToHlo(absl::Span<const torch::lazy::Value> values,
                             const torch::lazy::BackendDevice& device) {
   LoweringContext lowering_ctx("IrToHlo", device);
   for (auto& ir_value : values) {

--- a/torch_xla/csrc/ir_dump_util.h
+++ b/torch_xla/csrc/ir_dump_util.h
@@ -22,7 +22,7 @@ class DumpUtil {
       absl::Span<const torch::lazy::Node* const> post_order,
       absl::Span<const torch::lazy::Node* const> roots);
 
-  static std::string ToHlo(absl::Span<const XlaValue> values,
+  static std::string ToHlo(absl::Span<const torch::lazy::Value> values,
                            const torch::lazy::BackendDevice& device);
 };
 

--- a/torch_xla/csrc/ir_util.cpp
+++ b/torch_xla/csrc/ir_util.cpp
@@ -58,15 +58,15 @@ std::vector<const torch::lazy::Node*> Util::ComputePostOrder(
   return ComputePostOrder(nodes, &emap);
 }
 
-std::vector<XlaValue> Util::Clone(
-    absl::Span<const XlaValue> values,
+std::vector<torch::lazy::Value> Util::Clone(
+    absl::Span<const torch::lazy::Value> values,
     absl::Span<const torch::lazy::Node* const> post_order) {
   std::unordered_map<const torch::lazy::Node*, torch::lazy::NodePtr> clone_map;
   for (auto node : post_order) {
     if (clone_map.count(node) > 0) {
       continue;
     }
-    std::vector<XlaValue> inputs;
+    std::vector<torch::lazy::Value> inputs;
     for (auto& output : node->operands()) {
       auto it = clone_map.find(output.node);
       XLA_CHECK(it != clone_map.end())
@@ -77,7 +77,7 @@ std::vector<XlaValue> Util::Clone(
     clone_map[node] = casted->Clone(inputs);
   }
 
-  std::vector<XlaValue> cloned;
+  std::vector<torch::lazy::Value> cloned;
   for (auto& value : values) {
     auto it = clone_map.find(value.node.get());
     XLA_CHECK(it != clone_map.end()) << "Bad post-order: " << value->ToString();
@@ -86,7 +86,8 @@ std::vector<XlaValue> Util::Clone(
   return cloned;
 }
 
-std::vector<XlaValue> Util::Clone(absl::Span<const XlaValue> values) {
+std::vector<torch::lazy::Value> Util::Clone(
+    absl::Span<const torch::lazy::Value> values) {
   std::vector<const torch::lazy::Node*> nodes;
   for (auto& value : values) {
     nodes.push_back(value.node.get());

--- a/torch_xla/csrc/ir_util.h
+++ b/torch_xla/csrc/ir_util.h
@@ -31,11 +31,12 @@ class Util {
       absl::Span<const torch::lazy::Node* const> nodes);
 
   // Clones the IR graph whose roots are passed in the values parameter.
-  static std::vector<XlaValue> Clone(absl::Span<const XlaValue> values);
+  static std::vector<torch::lazy::Value> Clone(
+      absl::Span<const torch::lazy::Value> values);
 
   // Same as the above, but the post-order is passed as parameter.
-  static std::vector<XlaValue> Clone(
-      absl::Span<const XlaValue> values,
+  static std::vector<torch::lazy::Value> Clone(
+      absl::Span<const torch::lazy::Value> values,
       absl::Span<const torch::lazy::Node* const> post_order);
 
   // Retrieves the number of nodes within the graph whose sink are passed in the

--- a/torch_xla/csrc/nms_op.cpp
+++ b/torch_xla/csrc/nms_op.cpp
@@ -275,7 +275,7 @@ NmsResult BuildNms(xla::XlaOp boxes, xla::XlaOp scores,
   xla::XlaOp ones_included =
       xla::Select(included, xla::Broadcast(one_s32, {num_boxes}),
                   xla::Broadcast(zero_s32, {num_boxes}));
-  // num_valid is scalar. XlaValue should be bound by output_size.
+  // num_valid is scalar. torch::lazy::Value should be bound by output_size.
   xla::XlaOp num_valid_total = xla::Reduce(
       ones_included,
       /*init_value=*/zero_s32,

--- a/torch_xla/csrc/op_by_op_executor.cpp
+++ b/torch_xla/csrc/op_by_op_executor.cpp
@@ -86,7 +86,7 @@ OpByOpExecutor::OpByOpExecutor(size_t compile_cache_size)
     : compile_cache_(compile_cache_size) {}
 
 std::vector<xla::ComputationClient::ExecuteChainedOp> OpByOpExecutor::BuildOps(
-    absl::Span<const XlaValue> roots, const std::string& device,
+    absl::Span<const torch::lazy::Value> roots, const std::string& device,
     absl::Span<const std::string> devices) {
   std::vector<const torch::lazy::Node*> root_nodes;
   root_nodes.reserve(roots.size());
@@ -200,7 +200,7 @@ std::vector<xla::ComputationClient::ExecuteChainedOp> OpByOpExecutor::BuildOps(
 }
 
 std::vector<xla::ComputationClient::DataPtr> OpByOpExecutor::Execute(
-    absl::Span<const XlaValue> roots, const std::string& device,
+    absl::Span<const torch::lazy::Value> roots, const std::string& device,
     absl::Span<const std::string> devices) {
   auto chained_exec_ops = BuildOps(roots, device, devices);
   return xla::ComputationClient::Get()->ExecuteChained(chained_exec_ops,
@@ -208,9 +208,9 @@ std::vector<xla::ComputationClient::DataPtr> OpByOpExecutor::Execute(
 }
 
 OpByOpExecutor::AsyncTask OpByOpExecutor::ExecuteAsync(
-    absl::Span<const XlaValue> roots, const std::string& device,
+    absl::Span<const torch::lazy::Value> roots, const std::string& device,
     absl::Span<const std::string> devices) {
-  std::vector<XlaValue> roots_vector(roots.begin(), roots.end());
+  std::vector<torch::lazy::Value> roots_vector(roots.begin(), roots.end());
   std::vector<std::string> devices_vector(devices.begin(), devices.end());
   auto taskfn = [this, roots = std::move(roots_vector),
                  devices = std::move(devices_vector), device]() -> AsyncResult {

--- a/torch_xla/csrc/op_by_op_executor.h
+++ b/torch_xla/csrc/op_by_op_executor.h
@@ -25,14 +25,14 @@ class OpByOpExecutor {
   static OpByOpExecutor* Get();
 
   std::vector<xla::ComputationClient::ExecuteChainedOp> BuildOps(
-      absl::Span<const XlaValue> roots, const std::string& device,
+      absl::Span<const torch::lazy::Value> roots, const std::string& device,
       absl::Span<const std::string> devices);
 
   std::vector<xla::ComputationClient::DataPtr> Execute(
-      absl::Span<const XlaValue> roots, const std::string& device,
+      absl::Span<const torch::lazy::Value> roots, const std::string& device,
       absl::Span<const std::string> devices);
 
-  AsyncTask ExecuteAsync(absl::Span<const XlaValue> roots,
+  AsyncTask ExecuteAsync(absl::Span<const torch::lazy::Value> roots,
                          const std::string& device,
                          absl::Span<const std::string> devices);
 

--- a/torch_xla/csrc/ops/adam_optimizer_step.cpp
+++ b/torch_xla/csrc/ops/adam_optimizer_step.cpp
@@ -7,22 +7,24 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& step, const XlaValue& param) {
+xla::Shape NodeOutputShape(const torch::lazy::Value& step,
+                           const torch::lazy::Value& param) {
   return xla::ShapeUtil::MakeTupleShape(
-      {/*step=*/step.xla_shape(), /*param=*/param.xla_shape(),
-       /*exp_avg=*/param.xla_shape(), /*exp_avg_sq=*/param.xla_shape(),
-       /*max_exp_avg_sq=*/param.xla_shape()});
+      {/*step=*/GetXlaShape(step), /*param=*/GetXlaShape(param),
+       /*exp_avg=*/GetXlaShape(param), /*exp_avg_sq=*/GetXlaShape(param),
+       /*max_exp_avg_sq=*/GetXlaShape(param)});
 }
 
 }  // namespace
 
 AdamOptimizerStep::AdamOptimizerStep(
-    const XlaValue& found_inf, const XlaValue& step, const XlaValue& param,
-    const XlaValue& grad, const XlaValue& exp_avg, const XlaValue& exp_avg_sq,
-    const XlaValue& max_exp_avg_sq, const XlaValue& beta1,
-    const XlaValue& beta2, const XlaValue& lr, const XlaValue& weight_decay,
-    const XlaValue& eps, bool use_weight_decay, bool use_amsgrad,
-    bool use_adamw)
+    const torch::lazy::Value& found_inf, const torch::lazy::Value& step,
+    const torch::lazy::Value& param, const torch::lazy::Value& grad,
+    const torch::lazy::Value& exp_avg, const torch::lazy::Value& exp_avg_sq,
+    const torch::lazy::Value& max_exp_avg_sq, const torch::lazy::Value& beta1,
+    const torch::lazy::Value& beta2, const torch::lazy::Value& lr,
+    const torch::lazy::Value& weight_decay, const torch::lazy::Value& eps,
+    bool use_weight_decay, bool use_amsgrad, bool use_adamw)
     : XlaNode(xla_adam_optimizer_step,
               {found_inf, step, param, grad, exp_avg, exp_avg_sq,
                max_exp_avg_sq, beta1, beta2, lr, weight_decay, eps},

--- a/torch_xla/csrc/ops/adam_optimizer_step.h
+++ b/torch_xla/csrc/ops/adam_optimizer_step.h
@@ -6,13 +6,14 @@ namespace torch_xla {
 
 class AdamOptimizerStep : public XlaNode {
  public:
-  AdamOptimizerStep(const XlaValue& found_inf, const XlaValue& step,
-                    const XlaValue& param, const XlaValue& grad,
-                    const XlaValue& exp_avg, const XlaValue& exp_avg_sq,
-                    const XlaValue& max_exp_avg_sq, const XlaValue& beta1,
-                    const XlaValue& beta2, const XlaValue& lr,
-                    const XlaValue& weight_decay, const XlaValue& eps,
-                    bool use_weight_decay, bool use_amsgrad, bool use_adamw);
+  AdamOptimizerStep(
+      const torch::lazy::Value& found_inf, const torch::lazy::Value& step,
+      const torch::lazy::Value& param, const torch::lazy::Value& grad,
+      const torch::lazy::Value& exp_avg, const torch::lazy::Value& exp_avg_sq,
+      const torch::lazy::Value& max_exp_avg_sq, const torch::lazy::Value& beta1,
+      const torch::lazy::Value& beta2, const torch::lazy::Value& lr,
+      const torch::lazy::Value& weight_decay, const torch::lazy::Value& eps,
+      bool use_weight_decay, bool use_amsgrad, bool use_adamw);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/adaptive_avg_pool2d.cpp
+++ b/torch_xla/csrc/ops/adaptive_avg_pool2d.cpp
@@ -8,19 +8,19 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            absl::Span<const int64_t> output_size) {
   auto lower_for_shape_fn =
       [output_size](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     XLA_CHECK_EQ(operands.size(), 1);
     return BuildAdaptiveAvgPool2d(operands[0], output_size);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-AdaptiveAvgPool2d::AdaptiveAvgPool2d(const XlaValue& input,
+AdaptiveAvgPool2d::AdaptiveAvgPool2d(const torch::lazy::Value& input,
                                      std::vector<int64_t> output_size)
     : XlaNode(torch::lazy::OpKind(at::aten::adaptive_avg_pool2d), {input},
               [&]() { return NodeOutputShape(input, output_size); },

--- a/torch_xla/csrc/ops/adaptive_avg_pool2d.h
+++ b/torch_xla/csrc/ops/adaptive_avg_pool2d.h
@@ -8,7 +8,8 @@ namespace torch_xla {
 
 class AdaptiveAvgPool2d : public XlaNode {
  public:
-  AdaptiveAvgPool2d(const XlaValue& input, std::vector<int64_t> output_size);
+  AdaptiveAvgPool2d(const torch::lazy::Value& input,
+                    std::vector<int64_t> output_size);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/adaptive_avg_pool3d.cpp
+++ b/torch_xla/csrc/ops/adaptive_avg_pool3d.cpp
@@ -8,19 +8,19 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            absl::Span<const int64_t> output_size) {
   auto lower_for_shape_fn =
       [output_size](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     XLA_CHECK_EQ(operands.size(), 1);
     return BuildAdaptiveAvgPool3d(operands[0], output_size);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-AdaptiveAvgPool3d::AdaptiveAvgPool3d(const XlaValue& input,
+AdaptiveAvgPool3d::AdaptiveAvgPool3d(const torch::lazy::Value& input,
                                      std::vector<int64_t> output_size)
     : XlaNode(torch::lazy::OpKind(at::aten::adaptive_avg_pool3d), {input},
               [&]() { return NodeOutputShape(input, output_size); },

--- a/torch_xla/csrc/ops/adaptive_avg_pool3d.h
+++ b/torch_xla/csrc/ops/adaptive_avg_pool3d.h
@@ -10,7 +10,8 @@ namespace torch_xla {
 
 class AdaptiveAvgPool3d : public XlaNode {
  public:
-  AdaptiveAvgPool3d(const XlaValue& input, std::vector<int64_t> output_size);
+  AdaptiveAvgPool3d(const torch::lazy::Value& input,
+                    std::vector<int64_t> output_size);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/adaptive_max_pool2d.cpp
+++ b/torch_xla/csrc/ops/adaptive_max_pool2d.cpp
@@ -8,7 +8,7 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            absl::Span<const int64_t> output_size) {
   auto lower_for_shape_fn =
       [output_size](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
@@ -16,12 +16,12 @@ xla::Shape NodeOutputShape(const XlaValue& input,
     MaxPoolResult result = BuildAdaptiveMaxPoolNd(operands[0], output_size, 2);
     return xla::Tuple(operands[0].builder(), {result.result, result.indices});
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-AdaptiveMaxPool2d::AdaptiveMaxPool2d(const XlaValue& input,
+AdaptiveMaxPool2d::AdaptiveMaxPool2d(const torch::lazy::Value& input,
                                      std::vector<int64_t> output_size)
     : XlaNode(torch::lazy::OpKind(at::aten::adaptive_max_pool2d), {input},
               [&]() { return NodeOutputShape(input, output_size); },

--- a/torch_xla/csrc/ops/adaptive_max_pool2d.h
+++ b/torch_xla/csrc/ops/adaptive_max_pool2d.h
@@ -8,7 +8,8 @@ namespace torch_xla {
 
 class AdaptiveMaxPool2d : public XlaNode {
  public:
-  AdaptiveMaxPool2d(const XlaValue& input, std::vector<int64_t> output_size);
+  AdaptiveMaxPool2d(const torch::lazy::Value& input,
+                    std::vector<int64_t> output_size);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/all.cpp
+++ b/torch_xla/csrc/ops/all.cpp
@@ -11,19 +11,19 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            std::vector<int64_t>& dimensions,
                            bool keep_reduced_dimensions) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildAll(operands[0], dimensions, keep_reduced_dimensions);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-All::All(const XlaValue& input, std::vector<int64_t> dimensions,
+All::All(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
          bool keep_reduced_dimensions)
     : XlaNode(torch::lazy::OpKind(at::aten::all), {input},
               NodeOutputShape(input, dimensions, keep_reduced_dimensions),

--- a/torch_xla/csrc/ops/all.h
+++ b/torch_xla/csrc/ops/all.h
@@ -9,7 +9,7 @@ namespace torch_xla {
 
 class All : public XlaNode {
  public:
-  All(const XlaValue& input, std::vector<int64_t> dimensions,
+  All(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
       bool keep_reduced_dimensions);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/all_gather.cpp
+++ b/torch_xla/csrc/ops/all_gather.cpp
@@ -10,8 +10,9 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& token,
-                           int64_t dim, int64_t shard_count,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
+                           const torch::lazy::Value& token, int64_t dim,
+                           int64_t shard_count,
                            const std::vector<std::vector<int64_t>>& groups,
                            bool pin_layout) {
   auto shape_fn = [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
@@ -19,12 +20,13 @@ xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& token,
                                             shard_count, groups, pin_layout);
     return xla::Tuple(operands[0].builder(), {result.result, result.token});
   };
-  return InferOutputShape({input.xla_shape(), token.xla_shape()}, shape_fn);
+  return InferOutputShape({GetXlaShape(input), GetXlaShape(token)}, shape_fn);
 }
 
 }  // namespace
 
-AllGather::AllGather(const XlaValue& input, const XlaValue& token, int64_t dim,
+AllGather::AllGather(const torch::lazy::Value& input,
+                     const torch::lazy::Value& token, int64_t dim,
                      int64_t shard_count,
                      std::vector<std::vector<int64_t>> groups, bool pin_layout)
     : XlaNode(xla_all_gather, {input, token},

--- a/torch_xla/csrc/ops/all_gather.h
+++ b/torch_xla/csrc/ops/all_gather.h
@@ -7,9 +7,9 @@ namespace torch_xla {
 
 class AllGather : public XlaNode {
  public:
-  AllGather(const XlaValue& input, const XlaValue& token, int64_t dim,
-            int64_t shard_count, std::vector<std::vector<int64_t>> groups,
-            bool pin_layout);
+  AllGather(const torch::lazy::Value& input, const torch::lazy::Value& token,
+            int64_t dim, int64_t shard_count,
+            std::vector<std::vector<int64_t>> groups, bool pin_layout);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/all_reduce.h
+++ b/torch_xla/csrc/ops/all_reduce.h
@@ -7,8 +7,9 @@ namespace torch_xla {
 
 class AllReduce : public XlaNode {
  public:
-  AllReduce(AllReduceType reduce_type, absl::Span<const XlaValue> operands,
-            const XlaValue& token, double scale,
+  AllReduce(AllReduceType reduce_type,
+            absl::Span<const torch::lazy::Value> operands,
+            const torch::lazy::Value& token, double scale,
             std::vector<std::vector<int64_t>> groups, bool pin_layout);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/all_to_all.cpp
+++ b/torch_xla/csrc/ops/all_to_all.cpp
@@ -9,7 +9,8 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& token,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
+                           const torch::lazy::Value& token,
                            int64_t split_dimension, int64_t concat_dimension,
                            int64_t split_count,
                            const std::vector<std::vector<int64_t>>& groups,
@@ -20,14 +21,14 @@ xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& token,
                       concat_dimension, split_count, groups, pin_layout);
     return xla::Tuple(operands[0].builder(), {result.result, result.token});
   };
-  return InferOutputShape({input.xla_shape(), token.xla_shape()}, shape_fn);
+  return InferOutputShape({GetXlaShape(input), GetXlaShape(token)}, shape_fn);
 }
 
 }  // namespace
 
-AllToAll::AllToAll(const XlaValue& input, const XlaValue& token,
-                   int64_t split_dimension, int64_t concat_dimension,
-                   int64_t split_count,
+AllToAll::AllToAll(const torch::lazy::Value& input,
+                   const torch::lazy::Value& token, int64_t split_dimension,
+                   int64_t concat_dimension, int64_t split_count,
                    std::vector<std::vector<int64_t>> groups, bool pin_layout)
     : XlaNode(xla_all_to_all, {input, token},
               [&]() {

--- a/torch_xla/csrc/ops/all_to_all.h
+++ b/torch_xla/csrc/ops/all_to_all.h
@@ -7,7 +7,7 @@ namespace torch_xla {
 
 class AllToAll : public XlaNode {
  public:
-  AllToAll(const XlaValue& input, const XlaValue& token,
+  AllToAll(const torch::lazy::Value& input, const torch::lazy::Value& token,
            int64_t split_dimension, int64_t concat_dimension,
            int64_t split_count, std::vector<std::vector<int64_t>> groups,
            bool pin_layout);

--- a/torch_xla/csrc/ops/amax.cpp
+++ b/torch_xla/csrc/ops/amax.cpp
@@ -7,18 +7,19 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            std::vector<int64_t>& dimensions, bool keepdim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildMaxInDims(operands[0], dimensions, keepdim);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-Amax::Amax(const XlaValue& input, std::vector<int64_t> dimensions, bool keepdim)
+Amax::Amax(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
+           bool keepdim)
     : XlaNode(torch::lazy::OpKind(at::aten::amax), {input},
               [&]() { return NodeOutputShape(input, dimensions, keepdim); },
               /*num_outputs=*/1, torch::lazy::MHash(dimensions, keepdim)),

--- a/torch_xla/csrc/ops/amax.h
+++ b/torch_xla/csrc/ops/amax.h
@@ -6,7 +6,8 @@ namespace torch_xla {
 
 class Amax : public XlaNode {
  public:
-  Amax(const XlaValue& input, std::vector<int64_t> dimensions, bool keepdim);
+  Amax(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
+       bool keepdim);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/amin.cpp
+++ b/torch_xla/csrc/ops/amin.cpp
@@ -7,18 +7,19 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            std::vector<int64_t>& dimensions, bool keepdim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildMinInDims(operands[0], dimensions, keepdim);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-Amin::Amin(const XlaValue& input, std::vector<int64_t> dimensions, bool keepdim)
+Amin::Amin(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
+           bool keepdim)
     : XlaNode(torch::lazy::OpKind(at::aten::amin), {input},
               [&]() { return NodeOutputShape(input, dimensions, keepdim); },
               /*num_outputs=*/1, torch::lazy::MHash(dimensions, keepdim)),

--- a/torch_xla/csrc/ops/amin.h
+++ b/torch_xla/csrc/ops/amin.h
@@ -6,7 +6,8 @@ namespace torch_xla {
 
 class Amin : public XlaNode {
  public:
-  Amin(const XlaValue& input, std::vector<int64_t> dimensions, bool keepdim);
+  Amin(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
+       bool keepdim);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/amp_foreach_non_finite_check_and_unscale.h
+++ b/torch_xla/csrc/ops/amp_foreach_non_finite_check_and_unscale.h
@@ -7,8 +7,8 @@ namespace torch_xla {
 class AmpForachNonFiniteCheckAndUnscale : public XlaNode {
  public:
   AmpForachNonFiniteCheckAndUnscale(const OpList& inputs,
-                                    const XlaValue& found_inf,
-                                    const XlaValue& inv_scale);
+                                    const torch::lazy::Value& found_inf,
+                                    const torch::lazy::Value& inv_scale);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/amp_update_scale.cpp
+++ b/torch_xla/csrc/ops/amp_update_scale.cpp
@@ -9,17 +9,17 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& growth_tracker,
-                           const XlaValue& current_scale) {
+xla::Shape NodeOutputShape(const torch::lazy::Value& growth_tracker,
+                           const torch::lazy::Value& current_scale) {
   return xla::ShapeUtil::MakeTupleShape(
-      {growth_tracker.xla_shape(), current_scale.xla_shape()});
+      {GetXlaShape(growth_tracker), GetXlaShape(current_scale)});
 }
 
 }  // namespace
 
-AmpUpdateScale::AmpUpdateScale(const XlaValue& current_scale,
-                               const XlaValue& growth_tracker,
-                               const XlaValue& found_inf,
+AmpUpdateScale::AmpUpdateScale(const torch::lazy::Value& current_scale,
+                               const torch::lazy::Value& growth_tracker,
+                               const torch::lazy::Value& found_inf,
                                double scale_growth_factor,
                                double scale_backoff_factor, int growth_interval)
     : XlaNode(torch::lazy::OpKind(at::aten::_amp_update_scale_),

--- a/torch_xla/csrc/ops/amp_update_scale.h
+++ b/torch_xla/csrc/ops/amp_update_scale.h
@@ -6,9 +6,11 @@ namespace torch_xla {
 
 class AmpUpdateScale : public XlaNode {
  public:
-  AmpUpdateScale(const XlaValue& current_scale, const XlaValue& growth_tracker,
-                 const XlaValue& found_inf, double scale_growth_factor,
-                 double scale_backoff_factor, int growth_interval);
+  AmpUpdateScale(const torch::lazy::Value& current_scale,
+                 const torch::lazy::Value& growth_tracker,
+                 const torch::lazy::Value& found_inf,
+                 double scale_growth_factor, double scale_backoff_factor,
+                 int growth_interval);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/any.cpp
+++ b/torch_xla/csrc/ops/any.cpp
@@ -11,19 +11,19 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            std::vector<int64_t>& dimensions,
                            bool keep_reduced_dimensions) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildAny(operands[0], dimensions, keep_reduced_dimensions);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-Any::Any(const XlaValue& input, std::vector<int64_t> dimensions,
+Any::Any(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
          bool keep_reduced_dimensions)
     : XlaNode(torch::lazy::OpKind(at::aten::any), {input},
               NodeOutputShape(input, dimensions, keep_reduced_dimensions),

--- a/torch_xla/csrc/ops/any.h
+++ b/torch_xla/csrc/ops/any.h
@@ -9,7 +9,7 @@ namespace torch_xla {
 
 class Any : public XlaNode {
  public:
-  Any(const XlaValue& input, std::vector<int64_t> dimensions,
+  Any(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
       bool keep_reduced_dimensions);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/arg_max.cpp
+++ b/torch_xla/csrc/ops/arg_max.cpp
@@ -7,17 +7,18 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input, int64_t dim, bool keepdim) {
+xla::Shape NodeOutputShape(const torch::lazy::Value& input, int64_t dim,
+                           bool keepdim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildArgMax(operands[0], dim, keepdim);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-ArgMax::ArgMax(const XlaValue& input, int64_t dim, bool keepdim)
+ArgMax::ArgMax(const torch::lazy::Value& input, int64_t dim, bool keepdim)
     : XlaNode(torch::lazy::OpKind(at::aten::argmax), {input},
               [&]() { return NodeOutputShape(input, dim, keepdim); },
               /*num_outputs=*/1, torch::lazy::MHash(dim, keepdim)),

--- a/torch_xla/csrc/ops/arg_max.h
+++ b/torch_xla/csrc/ops/arg_max.h
@@ -6,7 +6,7 @@ namespace torch_xla {
 
 class ArgMax : public XlaNode {
  public:
-  ArgMax(const XlaValue& input, int64_t dim, bool keepdim);
+  ArgMax(const torch::lazy::Value& input, int64_t dim, bool keepdim);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/arg_min.cpp
+++ b/torch_xla/csrc/ops/arg_min.cpp
@@ -7,17 +7,18 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input, int64_t dim, bool keepdim) {
+xla::Shape NodeOutputShape(const torch::lazy::Value& input, int64_t dim,
+                           bool keepdim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildArgMin(operands[0], dim, keepdim);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-ArgMin::ArgMin(const XlaValue& input, int64_t dim, bool keepdim)
+ArgMin::ArgMin(const torch::lazy::Value& input, int64_t dim, bool keepdim)
     : XlaNode(torch::lazy::OpKind(at::aten::argmin), {input},
               [&]() { return NodeOutputShape(input, dim, keepdim); },
               /*num_outputs=*/1, torch::lazy::MHash(dim, keepdim)),

--- a/torch_xla/csrc/ops/arg_min.h
+++ b/torch_xla/csrc/ops/arg_min.h
@@ -6,7 +6,7 @@ namespace torch_xla {
 
 class ArgMin : public XlaNode {
  public:
-  ArgMin(const XlaValue& input, int64_t dim, bool keepdim);
+  ArgMin(const torch::lazy::Value& input, int64_t dim, bool keepdim);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/arithmetic_ir_ops.cpp
+++ b/torch_xla/csrc/ops/arithmetic_ir_ops.cpp
@@ -8,7 +8,8 @@
 
 namespace torch_xla {
 
-torch::lazy::NodePtr operator+(const XlaValue& node1, const XlaValue& node2) {
+torch::lazy::NodePtr operator+(const torch::lazy::Value& node1,
+                               const torch::lazy::Value& node2) {
   auto lower_fn = [](const XlaNode& node,
                      LoweringContext* loctx) -> XlaOpVector {
     xla::XlaOp op0 = loctx->GetOutputOp(node.operand(0));
@@ -16,12 +17,13 @@ torch::lazy::NodePtr operator+(const XlaValue& node1, const XlaValue& node2) {
     return node.ReturnOp(XlaHelpers::PromotedAdd(op0, op1), loctx);
   };
   return GenericOp(torch::lazy::OpKind(at::aten::add), {node1, node2},
-                   XlaHelpers::GetPromotedBinaryOpShape(node1.xla_shape(),
-                                                        node2.xla_shape()),
+                   XlaHelpers::GetPromotedBinaryOpShape(GetXlaShape(node1),
+                                                        GetXlaShape(node2)),
                    std::move(lower_fn));
 }
 
-torch::lazy::NodePtr operator-(const XlaValue& node1, const XlaValue& node2) {
+torch::lazy::NodePtr operator-(const torch::lazy::Value& node1,
+                               const torch::lazy::Value& node2) {
   auto lower_fn = [](const XlaNode& node,
                      LoweringContext* loctx) -> XlaOpVector {
     xla::XlaOp op0 = loctx->GetOutputOp(node.operand(0));
@@ -29,12 +31,13 @@ torch::lazy::NodePtr operator-(const XlaValue& node1, const XlaValue& node2) {
     return node.ReturnOp(XlaHelpers::PromotedSub(op0, op1), loctx);
   };
   return GenericOp(torch::lazy::OpKind(at::aten::sub), {node1, node2},
-                   XlaHelpers::GetPromotedBinaryOpShape(node1.xla_shape(),
-                                                        node2.xla_shape()),
+                   XlaHelpers::GetPromotedBinaryOpShape(GetXlaShape(node1),
+                                                        GetXlaShape(node2)),
                    std::move(lower_fn));
 }
 
-torch::lazy::NodePtr operator*(const XlaValue& node1, const XlaValue& node2) {
+torch::lazy::NodePtr operator*(const torch::lazy::Value& node1,
+                               const torch::lazy::Value& node2) {
   auto lower_fn = [](const XlaNode& node,
                      LoweringContext* loctx) -> XlaOpVector {
     xla::XlaOp op0 = loctx->GetOutputOp(node.operand(0));
@@ -42,12 +45,13 @@ torch::lazy::NodePtr operator*(const XlaValue& node1, const XlaValue& node2) {
     return node.ReturnOp(XlaHelpers::PromotedMul(op0, op1), loctx);
   };
   return GenericOp(torch::lazy::OpKind(at::aten::mul), {node1, node2},
-                   XlaHelpers::GetPromotedBinaryOpShape(node1.xla_shape(),
-                                                        node2.xla_shape()),
+                   XlaHelpers::GetPromotedBinaryOpShape(GetXlaShape(node1),
+                                                        GetXlaShape(node2)),
                    std::move(lower_fn));
 }
 
-torch::lazy::NodePtr operator/(const XlaValue& node1, const XlaValue& node2) {
+torch::lazy::NodePtr operator/(const torch::lazy::Value& node1,
+                               const torch::lazy::Value& node2) {
   auto lower_fn = [](const XlaNode& node,
                      LoweringContext* loctx) -> XlaOpVector {
     xla::XlaOp op0 = loctx->GetOutputOp(node.operand(0));
@@ -55,8 +59,8 @@ torch::lazy::NodePtr operator/(const XlaValue& node1, const XlaValue& node2) {
     return node.ReturnOp(XlaHelpers::PromotedDiv(op0, op1), loctx);
   };
   return GenericOp(torch::lazy::OpKind(at::aten::div), {node1, node2},
-                   XlaHelpers::GetPromotedBinaryOpShape(node1.xla_shape(),
-                                                        node2.xla_shape()),
+                   XlaHelpers::GetPromotedBinaryOpShape(GetXlaShape(node1),
+                                                        GetXlaShape(node2)),
                    std::move(lower_fn));
 }
 

--- a/torch_xla/csrc/ops/arithmetic_ir_ops.h
+++ b/torch_xla/csrc/ops/arithmetic_ir_ops.h
@@ -4,9 +4,13 @@
 
 namespace torch_xla {
 
-torch::lazy::NodePtr operator+(const XlaValue& node1, const XlaValue& node2);
-torch::lazy::NodePtr operator-(const XlaValue& node1, const XlaValue& node2);
-torch::lazy::NodePtr operator*(const XlaValue& node1, const XlaValue& node2);
-torch::lazy::NodePtr operator/(const XlaValue& node1, const XlaValue& node2);
+torch::lazy::NodePtr operator+(const torch::lazy::Value& node1,
+                               const torch::lazy::Value& node2);
+torch::lazy::NodePtr operator-(const torch::lazy::Value& node1,
+                               const torch::lazy::Value& node2);
+torch::lazy::NodePtr operator*(const torch::lazy::Value& node1,
+                               const torch::lazy::Value& node2);
+torch::lazy::NodePtr operator/(const torch::lazy::Value& node1,
+                               const torch::lazy::Value& node2);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/as_strided.cpp
+++ b/torch_xla/csrc/ops/as_strided.cpp
@@ -41,12 +41,12 @@ xla::XlaOp LowerAsStrided(xla::XlaOp input, absl::Span<const int64_t> size,
 
 }  // namespace
 
-AsStrided::AsStrided(const XlaValue& input, std::vector<int64_t> size,
+AsStrided::AsStrided(const torch::lazy::Value& input, std::vector<int64_t> size,
                      std::vector<int64_t> stride, int64_t storage_offset)
     : XlaNode(torch::lazy::OpKind(at::aten::as_strided), {input},
               [&]() {
                 return xla::ShapeUtil::MakeShape(
-                    input.xla_shape().element_type(), size);
+                    GetXlaShape(input).element_type(), size);
               },
               /*num_outputs=*/1,
               torch::lazy::MHash(size, stride, storage_offset)),

--- a/torch_xla/csrc/ops/as_strided.h
+++ b/torch_xla/csrc/ops/as_strided.h
@@ -9,7 +9,7 @@ namespace torch_xla {
 
 class AsStrided : public XlaNode {
  public:
-  AsStrided(const XlaValue& input, std::vector<int64_t> size,
+  AsStrided(const torch::lazy::Value& input, std::vector<int64_t> size,
             std::vector<int64_t> stride, int64_t storage_offset);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/as_strided_view_update.cpp
+++ b/torch_xla/csrc/ops/as_strided_view_update.cpp
@@ -39,15 +39,15 @@ xla::XlaOp LowerAsStridedViewUpdate(xla::XlaOp target, xla::XlaOp input,
 
 }  // namespace
 
-AsStridedViewUpdate::AsStridedViewUpdate(const XlaValue& target,
-                                         const XlaValue& input,
+AsStridedViewUpdate::AsStridedViewUpdate(const torch::lazy::Value& target,
+                                         const torch::lazy::Value& input,
                                          std::vector<int64_t> size,
                                          std::vector<int64_t> stride,
                                          int64_t storage_offset)
     : XlaNode(xla_as_strided_view_update, {target, input},
               [&]() {
                 return xla::ShapeUtil::MakeShape(
-                    target.xla_shape().element_type(), size);
+                    GetXlaShape(target).element_type(), size);
               },
               /*num_outputs=*/1,
               torch::lazy::MHash(size, stride, storage_offset)),

--- a/torch_xla/csrc/ops/as_strided_view_update.h
+++ b/torch_xla/csrc/ops/as_strided_view_update.h
@@ -9,7 +9,8 @@ namespace torch_xla {
 
 class AsStridedViewUpdate : public XlaNode {
  public:
-  AsStridedViewUpdate(const XlaValue& target, const XlaValue& input,
+  AsStridedViewUpdate(const torch::lazy::Value& target,
+                      const torch::lazy::Value& input,
                       std::vector<int64_t> size, std::vector<int64_t> stride,
                       int64_t storage_offset);
 

--- a/torch_xla/csrc/ops/avg_pool_nd.cpp
+++ b/torch_xla/csrc/ops/avg_pool_nd.cpp
@@ -10,7 +10,8 @@ namespace torch_xla {
 namespace {
 
 // Infers the output shape of the max pooling operation.
-xla::Shape NodeOutputShape(const XlaValue& input, int64_t spatial_dim_count,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
+                           int64_t spatial_dim_count,
                            absl::Span<const int64_t> kernel_size,
                            absl::Span<const int64_t> stride,
                            absl::Span<const int64_t> padding, bool ceil_mode,
@@ -22,7 +23,7 @@ xla::Shape NodeOutputShape(const XlaValue& input, int64_t spatial_dim_count,
     return BuildAvgPoolNd(operands[0], spatial_dim_count, kernel_size, stride,
                           padding, ceil_mode, count_include_pad);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 c10::Symbol AvgPoolNdSymbol(int64_t spatial_dim_count) {
@@ -41,7 +42,7 @@ c10::Symbol AvgPoolNdSymbol(int64_t spatial_dim_count) {
 
 }  // namespace
 
-AvgPoolNd::AvgPoolNd(const XlaValue& input, int64_t spatial_dim_count,
+AvgPoolNd::AvgPoolNd(const torch::lazy::Value& input, int64_t spatial_dim_count,
                      std::vector<int64_t> kernel_size,
                      std::vector<int64_t> stride, std::vector<int64_t> padding,
                      bool ceil_mode, bool count_include_pad)

--- a/torch_xla/csrc/ops/avg_pool_nd.h
+++ b/torch_xla/csrc/ops/avg_pool_nd.h
@@ -6,7 +6,7 @@ namespace torch_xla {
 
 class AvgPoolNd : public XlaNode {
  public:
-  AvgPoolNd(const XlaValue& input, int64_t spatial_dim_count,
+  AvgPoolNd(const torch::lazy::Value& input, int64_t spatial_dim_count,
             std::vector<int64_t> kernel_size, std::vector<int64_t> stride,
             std::vector<int64_t> padding, bool ceil_mode,
             bool count_include_pad);

--- a/torch_xla/csrc/ops/avg_pool_nd_backward.cpp
+++ b/torch_xla/csrc/ops/avg_pool_nd_backward.cpp
@@ -8,7 +8,8 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& grad_output,
+                           const torch::lazy::Value& input,
                            int64_t spatial_dim_count,
                            absl::Span<const int64_t> kernel_size,
                            absl::Span<const int64_t> stride,
@@ -23,7 +24,7 @@ xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& input,
                                   kernel_size, stride, padding, ceil_mode,
                                   count_include_pad);
   };
-  return InferOutputShape({grad_output.xla_shape(), input.xla_shape()},
+  return InferOutputShape({GetXlaShape(grad_output), GetXlaShape(input)},
                           lower_for_shape_fn);
 }
 
@@ -41,8 +42,8 @@ c10::Symbol AvgNdBackwardSymbol(int64_t spatial_dim_count) {
 
 }  // namespace
 
-AvgPoolNdBackward::AvgPoolNdBackward(const XlaValue& grad_output,
-                                     const XlaValue& input,
+AvgPoolNdBackward::AvgPoolNdBackward(const torch::lazy::Value& grad_output,
+                                     const torch::lazy::Value& input,
                                      int64_t spatial_dim_count,
                                      std::vector<int64_t> kernel_size,
                                      std::vector<int64_t> stride,

--- a/torch_xla/csrc/ops/avg_pool_nd_backward.h
+++ b/torch_xla/csrc/ops/avg_pool_nd_backward.h
@@ -6,8 +6,9 @@ namespace torch_xla {
 
 class AvgPoolNdBackward : public XlaNode {
  public:
-  AvgPoolNdBackward(const XlaValue& grad_output, const XlaValue& input,
-                    int64_t spatial_dim_count, std::vector<int64_t> kernel_size,
+  AvgPoolNdBackward(const torch::lazy::Value& grad_output,
+                    const torch::lazy::Value& input, int64_t spatial_dim_count,
+                    std::vector<int64_t> kernel_size,
                     std::vector<int64_t> stride, std::vector<int64_t> padding,
                     bool ceil_mode, bool count_include_pad);
 

--- a/torch_xla/csrc/ops/bernoulli.cpp
+++ b/torch_xla/csrc/ops/bernoulli.cpp
@@ -6,8 +6,8 @@
 
 namespace torch_xla {
 
-Bernoulli::Bernoulli(const XlaValue& probability, const XlaValue& seed,
-                     xla::Shape shape)
+Bernoulli::Bernoulli(const torch::lazy::Value& probability,
+                     const torch::lazy::Value& seed, xla::Shape shape)
     : XlaNode(torch::lazy::OpKind(at::aten::bernoulli), {probability, seed},
               std::move(shape)) {}
 

--- a/torch_xla/csrc/ops/bernoulli.h
+++ b/torch_xla/csrc/ops/bernoulli.h
@@ -6,8 +6,8 @@ namespace torch_xla {
 
 class Bernoulli : public XlaNode {
  public:
-  Bernoulli(const XlaValue& probability, const XlaValue& seed,
-            xla::Shape shape);
+  Bernoulli(const torch::lazy::Value& probability,
+            const torch::lazy::Value& seed, xla::Shape shape);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/binary_cross_entropy.h
+++ b/torch_xla/csrc/ops/binary_cross_entropy.h
@@ -8,8 +8,9 @@ namespace torch_xla {
 
 class BinaryCrossEntropy : public XlaNode {
  public:
-  BinaryCrossEntropy(const XlaValue& logits, const XlaValue& labels,
-                     const absl::optional<XlaValue>& weight,
+  BinaryCrossEntropy(const torch::lazy::Value& logits,
+                     const torch::lazy::Value& labels,
+                     const absl::optional<torch::lazy::Value>& weight,
                      ReductionMode reduction);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/binary_cross_entropy_backward.h
+++ b/torch_xla/csrc/ops/binary_cross_entropy_backward.h
@@ -8,9 +8,10 @@ namespace torch_xla {
 
 class BinaryCrossEntropyBackward : public XlaNode {
  public:
-  BinaryCrossEntropyBackward(const XlaValue& grad_output,
-                             const XlaValue& logits, const XlaValue& labels,
-                             const absl::optional<XlaValue>& weight,
+  BinaryCrossEntropyBackward(const torch::lazy::Value& grad_output,
+                             const torch::lazy::Value& logits,
+                             const torch::lazy::Value& labels,
+                             const absl::optional<torch::lazy::Value>& weight,
                              ReductionMode reduction);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/bitwise_ir_ops.cpp
+++ b/torch_xla/csrc/ops/bitwise_ir_ops.cpp
@@ -7,7 +7,8 @@
 
 namespace torch_xla {
 
-XlaValue BitwiseAnd(const XlaValue& node1, const XlaValue& node2) {
+torch::lazy::Value BitwiseAnd(const torch::lazy::Value& node1,
+                              const torch::lazy::Value& node2) {
   auto lower_fn = [](const XlaNode& node,
                      LoweringContext* loctx) -> XlaOpVector {
     xla::XlaOp op0 = loctx->GetOutputOp(node.operand(0));
@@ -24,12 +25,13 @@ XlaValue BitwiseAnd(const XlaValue& node1, const XlaValue& node2) {
   return GenericOp(torch::lazy::OpKind(at::aten::__and__), {node1, node2},
                    [&]() {
                      return InferOutputShape(
-                         {node1.xla_shape(), node2.xla_shape()}, shape_fn);
+                         {GetXlaShape(node1), GetXlaShape(node2)}, shape_fn);
                    },
                    std::move(lower_fn));
 }
 
-XlaValue BitwiseOr(const XlaValue& node1, const XlaValue& node2) {
+torch::lazy::Value BitwiseOr(const torch::lazy::Value& node1,
+                             const torch::lazy::Value& node2) {
   auto lower_fn = [](const XlaNode& node,
                      LoweringContext* loctx) -> XlaOpVector {
     xla::XlaOp op0 = loctx->GetOutputOp(node.operand(0));
@@ -46,12 +48,13 @@ XlaValue BitwiseOr(const XlaValue& node1, const XlaValue& node2) {
   return GenericOp(torch::lazy::OpKind(at::aten::__or__), {node1, node2},
                    [&]() {
                      return InferOutputShape(
-                         {node1.xla_shape(), node2.xla_shape()}, shape_fn);
+                         {GetXlaShape(node1), GetXlaShape(node2)}, shape_fn);
                    },
                    std::move(lower_fn));
 }
 
-XlaValue BitwiseXor(const XlaValue& node1, const XlaValue& node2) {
+torch::lazy::Value BitwiseXor(const torch::lazy::Value& node1,
+                              const torch::lazy::Value& node2) {
   auto lower_fn = [](const XlaNode& node,
                      LoweringContext* loctx) -> XlaOpVector {
     xla::XlaOp op0 = loctx->GetOutputOp(node.operand(0));
@@ -68,7 +71,7 @@ XlaValue BitwiseXor(const XlaValue& node1, const XlaValue& node2) {
   return GenericOp(torch::lazy::OpKind(at::aten::__xor__), {node1, node2},
                    [&]() {
                      return InferOutputShape(
-                         {node1.xla_shape(), node2.xla_shape()}, shape_fn);
+                         {GetXlaShape(node1), GetXlaShape(node2)}, shape_fn);
                    },
                    std::move(lower_fn));
 }

--- a/torch_xla/csrc/ops/bitwise_ir_ops.h
+++ b/torch_xla/csrc/ops/bitwise_ir_ops.h
@@ -4,9 +4,13 @@
 
 namespace torch_xla {
 
-// XlaValue has implicit cast to bool, operator overloads would be confusing.
-XlaValue BitwiseAnd(const XlaValue& node1, const XlaValue& node2);
-XlaValue BitwiseOr(const XlaValue& node1, const XlaValue& node2);
-XlaValue BitwiseXor(const XlaValue& node1, const XlaValue& node2);
+// torch::lazy::Value has implicit cast to bool, operator overloads would be
+// confusing.
+torch::lazy::Value BitwiseAnd(const torch::lazy::Value& node1,
+                              const torch::lazy::Value& node2);
+torch::lazy::Value BitwiseOr(const torch::lazy::Value& node1,
+                             const torch::lazy::Value& node2);
+torch::lazy::Value BitwiseXor(const torch::lazy::Value& node1,
+                              const torch::lazy::Value& node2);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/cast.cpp
+++ b/torch_xla/csrc/ops/cast.cpp
@@ -14,20 +14,21 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input, xla::PrimitiveType type) {
-  xla::Shape shape = input.xla_shape();
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
+                           xla::PrimitiveType type) {
+  xla::Shape shape = GetXlaShape(input);
   shape.set_element_type(type);
   return shape;
 }
 
 }  // namespace
 
-Cast::Cast(const XlaValue& input, xla::PrimitiveType type)
+Cast::Cast(const torch::lazy::Value& input, xla::PrimitiveType type)
     : XlaNode(xla_cast, {input}, NodeOutputShape(input, type),
               /*num_outputs=*/1, torch::lazy::MHash(static_cast<int>(type))),
       type_(type) {}
 
-Cast::Cast(const XlaValue& input, at::ScalarType dtype,
+Cast::Cast(const torch::lazy::Value& input, at::ScalarType dtype,
            c10::optional<at::ScalarType> stype)
     : XlaNode(xla_cast, {input},
               NodeOutputShape(input,

--- a/torch_xla/csrc/ops/cast.h
+++ b/torch_xla/csrc/ops/cast.h
@@ -9,8 +9,8 @@ namespace torch_xla {
 
 class Cast : public XlaNode {
  public:
-  Cast(const XlaValue& input, xla::PrimitiveType type);
-  Cast(const XlaValue& input, at::ScalarType dtype,
+  Cast(const torch::lazy::Value& input, xla::PrimitiveType type);
+  Cast(const torch::lazy::Value& input, at::ScalarType dtype,
        c10::optional<at::ScalarType> stype = c10::nullopt);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/cat.cpp
+++ b/torch_xla/csrc/ops/cat.cpp
@@ -8,7 +8,8 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(absl::Span<const XlaValue> values, int64_t dim) {
+xla::Shape NodeOutputShape(absl::Span<const torch::lazy::Value> values,
+                           int64_t dim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildCat(operands, dim);
@@ -16,14 +17,14 @@ xla::Shape NodeOutputShape(absl::Span<const XlaValue> values, int64_t dim) {
   std::vector<xla::Shape> shapes;
   shapes.reserve(values.size());
   for (auto& value : values) {
-    shapes.push_back(value.xla_shape());
+    shapes.push_back(GetXlaShape(value));
   }
   return InferOutputShape(shapes, lower_for_shape_fn);
 }
 
 }  // namespace
 
-Cat::Cat(absl::Span<const XlaValue> values, int64_t dim)
+Cat::Cat(absl::Span<const torch::lazy::Value> values, int64_t dim)
     : XlaNode(torch::lazy::OpKind(at::aten::cat), values,
               [&]() { return NodeOutputShape(values, dim); },
               /*num_outputs=*/1, torch::lazy::MHash(dim)),

--- a/torch_xla/csrc/ops/cat.h
+++ b/torch_xla/csrc/ops/cat.h
@@ -7,7 +7,7 @@ namespace torch_xla {
 
 class Cat : public XlaNode {
  public:
-  Cat(absl::Span<const XlaValue> values, int64_t dim);
+  Cat(absl::Span<const torch::lazy::Value> values, int64_t dim);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/cholesky.cpp
+++ b/torch_xla/csrc/ops/cholesky.cpp
@@ -6,9 +6,9 @@
 
 namespace torch_xla {
 
-Cholesky::Cholesky(const XlaValue& input, bool lower)
+Cholesky::Cholesky(const torch::lazy::Value& input, bool lower)
     : XlaNode(torch::lazy::OpKind(at::aten::cholesky), {input},
-              input.xla_shape(),
+              GetXlaShape(input),
               /*num_outputs=*/1, torch::lazy::MHash(lower)),
       lower_(lower) {}
 

--- a/torch_xla/csrc/ops/cholesky.h
+++ b/torch_xla/csrc/ops/cholesky.h
@@ -6,7 +6,7 @@ namespace torch_xla {
 
 class Cholesky : public XlaNode {
  public:
-  Cholesky(const XlaValue& input, bool lower);
+  Cholesky(const torch::lazy::Value& input, bool lower);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/collective_permute.cpp
+++ b/torch_xla/csrc/ops/collective_permute.cpp
@@ -10,20 +10,20 @@ namespace torch_xla {
 namespace {
 
 xla::Shape NodeOutputShape(
-    const XlaValue& input, const XlaValue& token,
+    const torch::lazy::Value& input, const torch::lazy::Value& token,
     const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs) {
   auto shape_fn = [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     CollectivePermuteResult result =
         BuildCollectivePermute(operands[0], operands[1], source_target_pairs);
     return xla::Tuple(operands[0].builder(), {result.result, result.token});
   };
-  return InferOutputShape({input.xla_shape(), token.xla_shape()}, shape_fn);
+  return InferOutputShape({GetXlaShape(input), GetXlaShape(token)}, shape_fn);
 }
 
 }  // namespace
 
 CollectivePermute::CollectivePermute(
-    const XlaValue& input, const XlaValue& token,
+    const torch::lazy::Value& input, const torch::lazy::Value& token,
     std::vector<std::pair<int64_t, int64_t>> source_target_pairs)
     : XlaNode(
           xla_collective_permute, {input, token},

--- a/torch_xla/csrc/ops/collective_permute.h
+++ b/torch_xla/csrc/ops/collective_permute.h
@@ -8,7 +8,7 @@ namespace torch_xla {
 class CollectivePermute : public XlaNode {
  public:
   CollectivePermute(
-      const XlaValue& input, const XlaValue& token,
+      const torch::lazy::Value& input, const torch::lazy::Value& token,
       std::vector<std::pair<int64_t, int64_t>> source_target_pairs);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/constant_pad_nd.cpp
+++ b/torch_xla/csrc/ops/constant_pad_nd.cpp
@@ -20,19 +20,20 @@ xla::XlaOp LowerPad(xla::XlaOp input, const at::Scalar& value,
                   XlaHelpers::MakeXlaPaddingConfigFromNdPadding(pad));
 }
 
-xla::Shape NodeOutputShape(const XlaValue& input, const at::Scalar& value,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
+                           const at::Scalar& value,
                            absl::Span<const int64_t> pad) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return LowerPad(operands[0], value, pad);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-ConstantPadNd::ConstantPadNd(const XlaValue& input, std::vector<int64_t> pad,
-                             const at::Scalar& value)
+ConstantPadNd::ConstantPadNd(const torch::lazy::Value& input,
+                             std::vector<int64_t> pad, const at::Scalar& value)
     : XlaNode(torch::lazy::OpKind(at::aten::constant_pad_nd), {input},
               [&]() { return NodeOutputShape(input, value, pad); },
               /*num_outputs=*/1, torch::lazy::MHash(pad, ScalarHash(value))),

--- a/torch_xla/csrc/ops/constant_pad_nd.h
+++ b/torch_xla/csrc/ops/constant_pad_nd.h
@@ -8,7 +8,7 @@ namespace torch_xla {
 
 class ConstantPadNd : public XlaNode {
  public:
-  ConstantPadNd(const XlaValue& input, std::vector<int64_t> pad,
+  ConstantPadNd(const torch::lazy::Value& input, std::vector<int64_t> pad,
                 const at::Scalar& value);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/convolution_backward_overrideable.cpp
+++ b/torch_xla/csrc/ops/convolution_backward_overrideable.cpp
@@ -9,13 +9,11 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& input,
-                           const XlaValue& weight,
-                           absl::Span<const int64_t> stride,
-                           absl::Span<const int64_t> padding,
-                           absl::Span<const int64_t> dilation, bool transposed,
-                           absl::Span<const int64_t> output_padding,
-                           int64_t groups) {
+xla::Shape NodeOutputShape(
+    const torch::lazy::Value& grad_output, const torch::lazy::Value& input,
+    const torch::lazy::Value& weight, absl::Span<const int64_t> stride,
+    absl::Span<const int64_t> padding, absl::Span<const int64_t> dilation,
+    bool transposed, absl::Span<const int64_t> output_padding, int64_t groups) {
   auto lower_for_shape_fn =
       [stride, padding, dilation, transposed, output_padding,
        groups](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
@@ -28,17 +26,17 @@ xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& input,
                       {grads.grad_input, grads.grad_weight, grads.grad_bias});
   };
   return InferOutputShape(
-      {grad_output.xla_shape(), input.xla_shape(), weight.xla_shape()},
+      {GetXlaShape(grad_output), GetXlaShape(input), GetXlaShape(weight)},
       lower_for_shape_fn);
 }
 
 }  // namespace
 
 ConvolutionBackwardOverrideable::ConvolutionBackwardOverrideable(
-    const XlaValue& grad_output, const XlaValue& input, const XlaValue& weight,
-    std::vector<int64_t> stride, std::vector<int64_t> padding,
-    std::vector<int64_t> dilation, bool transposed,
-    std::vector<int64_t> output_padding, int64_t groups)
+    const torch::lazy::Value& grad_output, const torch::lazy::Value& input,
+    const torch::lazy::Value& weight, std::vector<int64_t> stride,
+    std::vector<int64_t> padding, std::vector<int64_t> dilation,
+    bool transposed, std::vector<int64_t> output_padding, int64_t groups)
     : XlaNode(torch::lazy::OpKind(at::aten::convolution_backward_overrideable),
               {grad_output, input, weight},
               [&]() {

--- a/torch_xla/csrc/ops/convolution_backward_overrideable.h
+++ b/torch_xla/csrc/ops/convolution_backward_overrideable.h
@@ -9,8 +9,8 @@ namespace torch_xla {
 class ConvolutionBackwardOverrideable : public XlaNode {
  public:
   ConvolutionBackwardOverrideable(
-      const XlaValue& grad_output, const XlaValue& input,
-      const XlaValue& weight, std::vector<int64_t> stride,
+      const torch::lazy::Value& grad_output, const torch::lazy::Value& input,
+      const torch::lazy::Value& weight, std::vector<int64_t> stride,
       std::vector<int64_t> padding, std::vector<int64_t> dilation,
       bool transposed, std::vector<int64_t> output_padding, int64_t groups);
 

--- a/torch_xla/csrc/ops/convolution_overrideable.cpp
+++ b/torch_xla/csrc/ops/convolution_overrideable.cpp
@@ -10,7 +10,8 @@ namespace torch_xla {
 namespace {
 
 // The bias doesn't matter for shape inference.
-xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& weight,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
+                           const torch::lazy::Value& weight,
                            absl::Span<const int64_t> stride,
                            absl::Span<const int64_t> padding,
                            absl::Span<const int64_t> dilation, bool transposed,
@@ -24,17 +25,17 @@ xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& weight,
                                         padding, dilation, transposed,
                                         output_padding, groups);
   };
-  return InferOutputShape({input.xla_shape(), weight.xla_shape()},
+  return InferOutputShape({GetXlaShape(input), GetXlaShape(weight)},
                           lower_for_shape_fn);
 }
 
 }  // namespace
 
 ConvolutionOverrideable::ConvolutionOverrideable(
-    const XlaValue& input, const XlaValue& weight, const XlaValue& bias,
-    std::vector<int64_t> stride, std::vector<int64_t> padding,
-    std::vector<int64_t> dilation, bool transposed,
-    std::vector<int64_t> output_padding, int64_t groups)
+    const torch::lazy::Value& input, const torch::lazy::Value& weight,
+    const torch::lazy::Value& bias, std::vector<int64_t> stride,
+    std::vector<int64_t> padding, std::vector<int64_t> dilation,
+    bool transposed, std::vector<int64_t> output_padding, int64_t groups)
     : XlaNode(torch::lazy::OpKind(at::aten::convolution_overrideable),
               {input, weight, bias},
               [&]() {
@@ -52,9 +53,10 @@ ConvolutionOverrideable::ConvolutionOverrideable(
       groups_(groups) {}
 
 ConvolutionOverrideable::ConvolutionOverrideable(
-    const XlaValue& input, const XlaValue& weight, std::vector<int64_t> stride,
-    std::vector<int64_t> padding, std::vector<int64_t> dilation,
-    bool transposed, std::vector<int64_t> output_padding, int64_t groups)
+    const torch::lazy::Value& input, const torch::lazy::Value& weight,
+    std::vector<int64_t> stride, std::vector<int64_t> padding,
+    std::vector<int64_t> dilation, bool transposed,
+    std::vector<int64_t> output_padding, int64_t groups)
     : XlaNode(torch::lazy::OpKind(at::aten::convolution_overrideable),
               {input, weight},
               [&]() {

--- a/torch_xla/csrc/ops/convolution_overrideable.h
+++ b/torch_xla/csrc/ops/convolution_overrideable.h
@@ -9,13 +9,16 @@ namespace torch_xla {
 // IR node for 2D & 3D convolutions with or without bias.
 class ConvolutionOverrideable : public XlaNode {
  public:
-  ConvolutionOverrideable(const XlaValue& input, const XlaValue& weight,
-                          const XlaValue& bias, std::vector<int64_t> stride,
+  ConvolutionOverrideable(const torch::lazy::Value& input,
+                          const torch::lazy::Value& weight,
+                          const torch::lazy::Value& bias,
+                          std::vector<int64_t> stride,
                           std::vector<int64_t> padding,
                           std::vector<int64_t> dilation, bool transposed,
                           std::vector<int64_t> output_padding, int64_t groups);
 
-  ConvolutionOverrideable(const XlaValue& input, const XlaValue& weight,
+  ConvolutionOverrideable(const torch::lazy::Value& input,
+                          const torch::lazy::Value& weight,
                           std::vector<int64_t> stride,
                           std::vector<int64_t> padding,
                           std::vector<int64_t> dilation, bool transposed,

--- a/torch_xla/csrc/ops/cumprod.cpp
+++ b/torch_xla/csrc/ops/cumprod.cpp
@@ -24,18 +24,18 @@ xla::XlaOp LowerCumProd(xla::XlaOp input, int64_t dim,
   return BuildCumulativeComputation(casted_input, dim, reducer, init);
 }
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            c10::optional<at::ScalarType> dtype) {
   if (dtype) {
     return xla::ShapeUtil::ChangeElementType(
-        input.xla_shape(), MakeXlaPrimitiveType(*dtype, /*device=*/nullptr));
+        GetXlaShape(input), MakeXlaPrimitiveType(*dtype, /*device=*/nullptr));
   }
-  return input.xla_shape();
+  return GetXlaShape(input);
 }
 
 }  // namespace
 
-CumProd::CumProd(const XlaValue& input, int64_t dim,
+CumProd::CumProd(const torch::lazy::Value& input, int64_t dim,
                  c10::optional<at::ScalarType> dtype)
     : XlaNode(torch::lazy::OpKind(at::aten::cumprod), {input},
               [&]() { return NodeOutputShape(input, dtype); },

--- a/torch_xla/csrc/ops/cumprod.h
+++ b/torch_xla/csrc/ops/cumprod.h
@@ -9,7 +9,7 @@ namespace torch_xla {
 
 class CumProd : public XlaNode {
  public:
-  CumProd(const XlaValue& input, int64_t dim,
+  CumProd(const torch::lazy::Value& input, int64_t dim,
           c10::optional<at::ScalarType> dtype);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/cumsum.cpp
+++ b/torch_xla/csrc/ops/cumsum.cpp
@@ -23,18 +23,18 @@ xla::XlaOp LowerCumSum(xla::XlaOp input, int64_t dim,
   return BuildCumulativeComputation(casted_input, dim, reducer, init);
 }
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            c10::optional<at::ScalarType> dtype) {
   if (dtype) {
     return xla::ShapeUtil::ChangeElementType(
-        input.xla_shape(), MakeXlaPrimitiveType(*dtype, /*device=*/nullptr));
+        GetXlaShape(input), MakeXlaPrimitiveType(*dtype, /*device=*/nullptr));
   }
-  return input.xla_shape();
+  return GetXlaShape(input);
 }
 
 }  // namespace
 
-CumSum::CumSum(const XlaValue& input, int64_t dim,
+CumSum::CumSum(const torch::lazy::Value& input, int64_t dim,
                c10::optional<at::ScalarType> dtype)
     : XlaNode(torch::lazy::OpKind(at::aten::cumsum), {input},
               [&]() { return NodeOutputShape(input, dtype); },

--- a/torch_xla/csrc/ops/cumsum.h
+++ b/torch_xla/csrc/ops/cumsum.h
@@ -9,7 +9,7 @@ namespace torch_xla {
 
 class CumSum : public XlaNode {
  public:
-  CumSum(const XlaValue& input, int64_t dim,
+  CumSum(const torch::lazy::Value& input, int64_t dim,
          c10::optional<at::ScalarType> dtype);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/diagonal.cpp
+++ b/torch_xla/csrc/ops/diagonal.cpp
@@ -9,11 +9,12 @@
 
 namespace torch_xla {
 
-Diagonal::Diagonal(const XlaValue& input, int64_t offset, int64_t dim1,
-                   int64_t dim2)
+Diagonal::Diagonal(const torch::lazy::Value& input, int64_t offset,
+                   int64_t dim1, int64_t dim2)
     : XlaNode(torch::lazy::OpKind(at::aten::diagonal), {input},
               [&]() {
-                return MakeDiagonalShape(input.xla_shape(), offset, dim1, dim2);
+                return MakeDiagonalShape(GetXlaShape(input), offset, dim1,
+                                         dim2);
               },
               /*num_outputs=*/1, torch::lazy::MHash(offset, dim1, dim2)),
       offset_(offset),

--- a/torch_xla/csrc/ops/diagonal.h
+++ b/torch_xla/csrc/ops/diagonal.h
@@ -6,7 +6,8 @@ namespace torch_xla {
 
 class Diagonal : public XlaNode {
  public:
-  Diagonal(const XlaValue& input, int64_t offset, int64_t dim1, int64_t dim2);
+  Diagonal(const torch::lazy::Value& input, int64_t offset, int64_t dim1,
+           int64_t dim2);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/diagonal_view_update.cpp
+++ b/torch_xla/csrc/ops/diagonal_view_update.cpp
@@ -6,10 +6,11 @@
 
 namespace torch_xla {
 
-DiagonalViewUpdate::DiagonalViewUpdate(const XlaValue& target,
-                                       const XlaValue& input, int64_t offset,
-                                       int64_t dim1, int64_t dim2)
-    : XlaNode(xla_diagonal_view_update, {target, input}, target.xla_shape(),
+DiagonalViewUpdate::DiagonalViewUpdate(const torch::lazy::Value& target,
+                                       const torch::lazy::Value& input,
+                                       int64_t offset, int64_t dim1,
+                                       int64_t dim2)
+    : XlaNode(xla_diagonal_view_update, {target, input}, GetXlaShape(target),
               /*num_outputs=*/1, torch::lazy::MHash(offset, dim1, dim2)),
       offset_(offset),
       dim1_(dim1),

--- a/torch_xla/csrc/ops/diagonal_view_update.h
+++ b/torch_xla/csrc/ops/diagonal_view_update.h
@@ -6,8 +6,9 @@ namespace torch_xla {
 
 class DiagonalViewUpdate : public XlaNode {
  public:
-  DiagonalViewUpdate(const XlaValue& target, const XlaValue& input,
-                     int64_t offset, int64_t dim1, int64_t dim2);
+  DiagonalViewUpdate(const torch::lazy::Value& target,
+                     const torch::lazy::Value& input, int64_t offset,
+                     int64_t dim1, int64_t dim2);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/discrete_uniform.cpp
+++ b/torch_xla/csrc/ops/discrete_uniform.cpp
@@ -8,8 +8,9 @@
 
 namespace torch_xla {
 
-DiscreteUniform::DiscreteUniform(const XlaValue& from, const XlaValue& to,
-                                 const XlaValue& seed,
+DiscreteUniform::DiscreteUniform(const torch::lazy::Value& from,
+                                 const torch::lazy::Value& to,
+                                 const torch::lazy::Value& seed,
                                  const xla::Shape& rng_shape)
     : XlaNode(torch::lazy::OpKind(at::aten::random), {from, to, seed},
               rng_shape,

--- a/torch_xla/csrc/ops/discrete_uniform.h
+++ b/torch_xla/csrc/ops/discrete_uniform.h
@@ -6,8 +6,8 @@ namespace torch_xla {
 
 class DiscreteUniform : public XlaNode {
  public:
-  DiscreteUniform(const XlaValue& from, const XlaValue& to,
-                  const XlaValue& seed, const xla::Shape& rng_shape);
+  DiscreteUniform(const torch::lazy::Value& from, const torch::lazy::Value& to,
+                  const torch::lazy::Value& seed, const xla::Shape& rng_shape);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/expand.cpp
+++ b/torch_xla/csrc/ops/expand.cpp
@@ -8,18 +8,18 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            const std::vector<int64_t>& size) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildExpand(operands[0], size);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-Expand::Expand(const XlaValue& input, std::vector<int64_t> size)
+Expand::Expand(const torch::lazy::Value& input, std::vector<int64_t> size)
     : XlaNode(torch::lazy::OpKind(at::aten::expand), {input},
               [&]() { return NodeOutputShape(input, size); },
               /*num_outputs=*/1, torch::lazy::MHash(size)),

--- a/torch_xla/csrc/ops/expand.h
+++ b/torch_xla/csrc/ops/expand.h
@@ -8,7 +8,7 @@ namespace torch_xla {
 
 class Expand : public XlaNode {
  public:
-  Expand(const XlaValue& input, std::vector<int64_t> size);
+  Expand(const torch::lazy::Value& input, std::vector<int64_t> size);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/exponential.cpp
+++ b/torch_xla/csrc/ops/exponential.cpp
@@ -6,8 +6,8 @@
 
 namespace torch_xla {
 
-Exponential::Exponential(const XlaValue& lambda, const XlaValue& seed,
-                         xla::Shape shape)
+Exponential::Exponential(const torch::lazy::Value& lambda,
+                         const torch::lazy::Value& seed, xla::Shape shape)
     : XlaNode(torch::lazy::OpKind(at::aten::exponential), {lambda, seed},
               std::move(shape)) {}
 

--- a/torch_xla/csrc/ops/exponential.h
+++ b/torch_xla/csrc/ops/exponential.h
@@ -6,7 +6,8 @@ namespace torch_xla {
 
 class Exponential : public XlaNode {
  public:
-  Exponential(const XlaValue& lambda, const XlaValue& seed, xla::Shape shape);
+  Exponential(const torch::lazy::Value& lambda, const torch::lazy::Value& seed,
+              xla::Shape shape);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/flip.cpp
+++ b/torch_xla/csrc/ops/flip.cpp
@@ -5,8 +5,8 @@
 
 namespace torch_xla {
 
-Flip::Flip(const XlaValue& input, std::vector<int64_t> dims)
-    : XlaNode(torch::lazy::OpKind(at::aten::flip), {input}, input.xla_shape(),
+Flip::Flip(const torch::lazy::Value& input, std::vector<int64_t> dims)
+    : XlaNode(torch::lazy::OpKind(at::aten::flip), {input}, GetXlaShape(input),
               /*num_outputs=*/1, torch::lazy::MHash(dims)),
       dims_(std::move(dims)) {}
 

--- a/torch_xla/csrc/ops/flip.h
+++ b/torch_xla/csrc/ops/flip.h
@@ -7,7 +7,7 @@ namespace torch_xla {
 
 class Flip : public XlaNode {
  public:
-  Flip(const XlaValue& input, std::vector<int64_t> dims);
+  Flip(const torch::lazy::Value& input, std::vector<int64_t> dims);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/gather.cpp
+++ b/torch_xla/csrc/ops/gather.cpp
@@ -8,11 +8,11 @@
 
 namespace torch_xla {
 
-Gather::Gather(const XlaValue& input, int64_t dim, const XlaValue& index,
-               bool sparse_grad)
+Gather::Gather(const torch::lazy::Value& input, int64_t dim,
+               const torch::lazy::Value& index, bool sparse_grad)
     : XlaNode(torch::lazy::OpKind(at::aten::gather), {input, index},
-              xla::ShapeUtil::MakeShape(input.xla_shape().element_type(),
-                                        index.xla_shape().dimensions()),
+              xla::ShapeUtil::MakeShape(GetXlaShape(input).element_type(),
+                                        GetXlaShape(index).dimensions()),
               /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim),
       sparse_grad_(sparse_grad) {}

--- a/torch_xla/csrc/ops/gather.h
+++ b/torch_xla/csrc/ops/gather.h
@@ -6,8 +6,8 @@ namespace torch_xla {
 
 class Gather : public XlaNode {
  public:
-  Gather(const XlaValue& input, int64_t dim, const XlaValue& index,
-         bool sparse_grad);
+  Gather(const torch::lazy::Value& input, int64_t dim,
+         const torch::lazy::Value& index, bool sparse_grad);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/generic.cpp
+++ b/torch_xla/csrc/ops/generic.cpp
@@ -4,7 +4,8 @@
 
 namespace torch_xla {
 
-Generic::Generic(torch::lazy::OpKind op, absl::Span<const XlaValue> operands,
+Generic::Generic(torch::lazy::OpKind op,
+                 absl::Span<const torch::lazy::Value> operands,
                  xla::Shape shape, LowerFn lower_fn, size_t num_outputs,
                  torch::lazy::hash_t hash_seed)
     : XlaNode(std::move(op), operands, std::move(shape), num_outputs,
@@ -12,7 +13,8 @@ Generic::Generic(torch::lazy::OpKind op, absl::Span<const XlaValue> operands,
       lower_fn_(std::move(lower_fn)),
       hash_seed_(hash_seed) {}
 
-Generic::Generic(torch::lazy::OpKind op, absl::Span<const XlaValue> operands,
+Generic::Generic(torch::lazy::OpKind op,
+                 absl::Span<const torch::lazy::Value> operands,
                  const std::function<xla::Shape()>& shape_fn, LowerFn lower_fn,
                  size_t num_outputs, torch::lazy::hash_t hash_seed)
     : XlaNode(std::move(op), operands, shape_fn, num_outputs, hash_seed),

--- a/torch_xla/csrc/ops/generic.h
+++ b/torch_xla/csrc/ops/generic.h
@@ -13,11 +13,11 @@ class Generic : public XlaNode {
  public:
   using LowerFn = std::function<XlaOpVector(const XlaNode&, LoweringContext*)>;
 
-  Generic(torch::lazy::OpKind op, absl::Span<const XlaValue> operands,
+  Generic(torch::lazy::OpKind op, absl::Span<const torch::lazy::Value> operands,
           xla::Shape shape, LowerFn lower_fn, size_t num_outputs = 1,
           torch::lazy::hash_t hash_seed = (uint32_t)0x5a2d296e9);
 
-  Generic(torch::lazy::OpKind op, absl::Span<const XlaValue> operands,
+  Generic(torch::lazy::OpKind op, absl::Span<const torch::lazy::Value> operands,
           const std::function<xla::Shape()>& shape_fn, LowerFn lower_fn,
           size_t num_outputs = 1,
           torch::lazy::hash_t hash_seed = (uint32_t)0x5a2d296e9);

--- a/torch_xla/csrc/ops/generic_slice.cpp
+++ b/torch_xla/csrc/ops/generic_slice.cpp
@@ -10,19 +10,19 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            absl::Span<const int64_t> base_indices,
                            absl::Span<const int64_t> sizes) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildSlice(operands[0], base_indices, sizes);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-GenericSlice::GenericSlice(const XlaValue& input,
+GenericSlice::GenericSlice(const torch::lazy::Value& input,
                            absl::Span<const int64_t> base_indices,
                            absl::Span<const int64_t> sizes)
     : XlaNode(xla_generic_slice, {input},

--- a/torch_xla/csrc/ops/generic_slice.h
+++ b/torch_xla/csrc/ops/generic_slice.h
@@ -7,7 +7,8 @@ namespace torch_xla {
 
 class GenericSlice : public XlaNode {
  public:
-  GenericSlice(const XlaValue& input, absl::Span<const int64_t> base_indices,
+  GenericSlice(const torch::lazy::Value& input,
+               absl::Span<const int64_t> base_indices,
                absl::Span<const int64_t> sizes);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;

--- a/torch_xla/csrc/ops/get_dimensions_size.cpp
+++ b/torch_xla/csrc/ops/get_dimensions_size.cpp
@@ -9,7 +9,7 @@
 
 namespace torch_xla {
 
-GetDimensionsSize::GetDimensionsSize(const XlaValue& input,
+GetDimensionsSize::GetDimensionsSize(const torch::lazy::Value& input,
                                      std::vector<int64_t> dimensions)
     : XlaNode(xla_get_dimensions_size, {input},
               xla::ShapeUtil::MakeShape(

--- a/torch_xla/csrc/ops/get_dimensions_size.h
+++ b/torch_xla/csrc/ops/get_dimensions_size.h
@@ -8,7 +8,8 @@ namespace torch_xla {
 
 class GetDimensionsSize : public XlaNode {
  public:
-  GetDimensionsSize(const XlaValue& input, std::vector<int64_t> dimensions);
+  GetDimensionsSize(const torch::lazy::Value& input,
+                    std::vector<int64_t> dimensions);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/hardshrink.cpp
+++ b/torch_xla/csrc/ops/hardshrink.cpp
@@ -7,9 +7,10 @@
 
 namespace torch_xla {
 
-Hardshrink::Hardshrink(const XlaValue& input, const at::Scalar& lambda)
+Hardshrink::Hardshrink(const torch::lazy::Value& input,
+                       const at::Scalar& lambda)
     : XlaNode(torch::lazy::OpKind(at::aten::hardshrink), {input},
-              input.xla_shape(),
+              GetXlaShape(input),
               /*num_outputs=*/1, ScalarHash(lambda)),
       lambda_(std::move(lambda)) {}
 

--- a/torch_xla/csrc/ops/hardshrink.h
+++ b/torch_xla/csrc/ops/hardshrink.h
@@ -8,7 +8,7 @@ namespace torch_xla {
 
 class Hardshrink : public XlaNode {
  public:
-  Hardshrink(const XlaValue& input, const at::Scalar& lambda);
+  Hardshrink(const torch::lazy::Value& input, const at::Scalar& lambda);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/hardtanh_backward.cpp
+++ b/torch_xla/csrc/ops/hardtanh_backward.cpp
@@ -6,12 +6,12 @@
 
 namespace torch_xla {
 
-HardtanhBackward::HardtanhBackward(const XlaValue& grad_output,
-                                   const XlaValue& input,
+HardtanhBackward::HardtanhBackward(const torch::lazy::Value& grad_output,
+                                   const torch::lazy::Value& input,
                                    const at::Scalar& min_val,
                                    const at::Scalar& max_val)
     : XlaNode(torch::lazy::OpKind(at::aten::hardtanh_backward),
-              {grad_output, input}, grad_output.xla_shape(), /*num_outputs=*/1,
+              {grad_output, input}, GetXlaShape(grad_output), /*num_outputs=*/1,
               torch::lazy::MHash(ScalarHash(min_val), ScalarHash(max_val))),
       min_val_(min_val),
       max_val_(max_val) {}

--- a/torch_xla/csrc/ops/hardtanh_backward.h
+++ b/torch_xla/csrc/ops/hardtanh_backward.h
@@ -8,8 +8,9 @@ namespace torch_xla {
 
 class HardtanhBackward : public XlaNode {
  public:
-  HardtanhBackward(const XlaValue& grad_output, const XlaValue& input,
-                   const at::Scalar& min_val, const at::Scalar& max_val);
+  HardtanhBackward(const torch::lazy::Value& grad_output,
+                   const torch::lazy::Value& input, const at::Scalar& min_val,
+                   const at::Scalar& max_val);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/index_get.cpp
+++ b/torch_xla/csrc/ops/index_get.cpp
@@ -8,21 +8,22 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& base, const XlaValue& indices,
+xla::Shape NodeOutputShape(const torch::lazy::Value& base,
+                           const torch::lazy::Value& indices,
                            int64_t start_dim) {
   auto lower_for_shape_fn =
       [start_dim](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     XLA_CHECK_EQ(operands.size(), 2);
     return CreateIndex(operands[0], operands[1], start_dim);
   };
-  return InferOutputShape({base.xla_shape(), indices.xla_shape()},
+  return InferOutputShape({GetXlaShape(base), GetXlaShape(indices)},
                           lower_for_shape_fn);
 }
 
 }  // namespace
 
-IndexGet::IndexGet(const XlaValue& base, const XlaValue& indices,
-                   int64_t start_dim)
+IndexGet::IndexGet(const torch::lazy::Value& base,
+                   const torch::lazy::Value& indices, int64_t start_dim)
     : XlaNode(torch::lazy::OpKind(at::aten::index), {base, indices},
               [&]() { return NodeOutputShape(base, indices, start_dim); },
               /*num_outputs=*/1, torch::lazy::MHash(start_dim)),

--- a/torch_xla/csrc/ops/index_get.h
+++ b/torch_xla/csrc/ops/index_get.h
@@ -6,7 +6,8 @@ namespace torch_xla {
 
 class IndexGet : public XlaNode {
  public:
-  IndexGet(const XlaValue& base, const XlaValue& indices, int64_t start_dim);
+  IndexGet(const torch::lazy::Value& base, const torch::lazy::Value& indices,
+           int64_t start_dim);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/index_ops.h
+++ b/torch_xla/csrc/ops/index_ops.h
@@ -51,7 +51,7 @@ CanonicalIndexInfo GetCanonicalIndexInfo(
     const c10::List<c10::optional<at::Tensor>>& orig_indices);
 
 // Expands a rank <= 1 tensor to rank 1, if necessary.
-XlaValue EnsureRank1(const XlaValue& index);
+torch::lazy::Value EnsureRank1(const torch::lazy::Value& index);
 
 // Implements indexing by tensors of long according to the top-level
 // description.
@@ -59,11 +59,10 @@ XLATensor IndexByTensors(const XLATensor& base,
                          absl::Span<const XLATensor> indices,
                          int64_t start_dim);
 
-XlaValue IndexPutByTensors(const XLATensor& base,
-                           absl::Span<const XLATensor> indices,
-                           int64_t start_dim, const XLATensor& updates,
-                           bool accumulate,
-                           absl::Span<const int64_t> result_permutation);
+torch::lazy::Value IndexPutByTensors(
+    const XLATensor& base, absl::Span<const XLATensor> indices,
+    int64_t start_dim, const XLATensor& updates, bool accumulate,
+    absl::Span<const int64_t> result_permutation);
 
 torch::lazy::NodePtr IndexFill(const XLATensor& base, int64_t dim,
                                const XLATensor& index, const at::Scalar& value);
@@ -71,10 +70,10 @@ torch::lazy::NodePtr IndexFill(const XLATensor& base, int64_t dim,
 torch::lazy::NodePtr IndexFill(const XLATensor& base, int64_t dim,
                                const XLATensor& index, const XLATensor& value);
 
-XlaValue IndexAdd(const XLATensor& base, int64_t dim, const XLATensor& index,
-                  const XLATensor& source);
+torch::lazy::Value IndexAdd(const XLATensor& base, int64_t dim,
+                            const XLATensor& index, const XLATensor& source);
 
-XlaValue IndexCopy(const XLATensor& base, int64_t dim, const XLATensor& index,
-                   const XLATensor& source);
+torch::lazy::Value IndexCopy(const XLATensor& base, int64_t dim,
+                             const XLATensor& index, const XLATensor& source);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/index_put.cpp
+++ b/torch_xla/csrc/ops/index_put.cpp
@@ -5,10 +5,11 @@
 
 namespace torch_xla {
 
-IndexPut::IndexPut(const XlaValue& base, const XlaValue& indices,
-                   int64_t start_dim, const XlaValue& values, bool accumulate)
+IndexPut::IndexPut(const torch::lazy::Value& base,
+                   const torch::lazy::Value& indices, int64_t start_dim,
+                   const torch::lazy::Value& values, bool accumulate)
     : XlaNode(torch::lazy::OpKind(at::aten::index_put), {base, indices, values},
-              base.xla_shape(),
+              GetXlaShape(base),
               /*num_outputs=*/1, torch::lazy::MHash(start_dim, accumulate)),
       start_dim_(start_dim),
       accumulate_(accumulate) {}

--- a/torch_xla/csrc/ops/index_put.h
+++ b/torch_xla/csrc/ops/index_put.h
@@ -6,8 +6,9 @@ namespace torch_xla {
 
 class IndexPut : public XlaNode {
  public:
-  IndexPut(const XlaValue& base, const XlaValue& indices, int64_t start_dim,
-           const XlaValue& values, bool accumulate);
+  IndexPut(const torch::lazy::Value& base, const torch::lazy::Value& indices,
+           int64_t start_dim, const torch::lazy::Value& values,
+           bool accumulate);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/index_select.cpp
+++ b/torch_xla/csrc/ops/index_select.cpp
@@ -8,20 +8,20 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& index,
-                           int64_t dim) {
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
+                           const torch::lazy::Value& index, int64_t dim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return xla::TorchIndexSelect(operands[0], operands[1], dim);
   };
-  return InferOutputShape({input.xla_shape(), index.xla_shape()},
+  return InferOutputShape({GetXlaShape(input), GetXlaShape(index)},
                           lower_for_shape_fn);
 }
 
 }  // namespace
 
-IndexSelect::IndexSelect(const XlaValue& input, int64_t dim,
-                         const XlaValue& index)
+IndexSelect::IndexSelect(const torch::lazy::Value& input, int64_t dim,
+                         const torch::lazy::Value& index)
     : XlaNode(torch::lazy::OpKind(at::aten::index_select), {input, index},
               [&]() { return NodeOutputShape(input, index, dim); },
               /*num_outputs=*/1, torch::lazy::MHash(dim)),

--- a/torch_xla/csrc/ops/index_select.h
+++ b/torch_xla/csrc/ops/index_select.h
@@ -6,7 +6,8 @@ namespace torch_xla {
 
 class IndexSelect : public XlaNode {
  public:
-  IndexSelect(const XlaValue& input, int64_t dim, const XlaValue& index);
+  IndexSelect(const torch::lazy::Value& input, int64_t dim,
+              const torch::lazy::Value& index);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/kth_value.cpp
+++ b/torch_xla/csrc/ops/kth_value.cpp
@@ -7,19 +7,20 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input, int64_t k, int64_t dim,
-                           bool keepdim) {
+xla::Shape NodeOutputShape(const torch::lazy::Value& input, int64_t k,
+                           int64_t dim, bool keepdim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return xla::Tuple(operands[0].builder(),
                       CreateKthValue(operands[0], k, dim, keepdim));
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-KthValue::KthValue(const XlaValue& input, int64_t k, int64_t dim, bool keepdim)
+KthValue::KthValue(const torch::lazy::Value& input, int64_t k, int64_t dim,
+                   bool keepdim)
     : XlaNode(torch::lazy::OpKind(at::aten::kthvalue), {input},
               [&]() { return NodeOutputShape(input, k, dim, keepdim); },
               /*num_outputs=*/2, torch::lazy::MHash(k, dim, keepdim)),

--- a/torch_xla/csrc/ops/kth_value.h
+++ b/torch_xla/csrc/ops/kth_value.h
@@ -6,7 +6,8 @@ namespace torch_xla {
 
 class KthValue : public XlaNode {
  public:
-  KthValue(const XlaValue& input, int64_t k, int64_t dim, bool keepdim);
+  KthValue(const torch::lazy::Value& input, int64_t k, int64_t dim,
+           bool keepdim);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/l1_loss.cpp
+++ b/torch_xla/csrc/ops/l1_loss.cpp
@@ -9,20 +9,21 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& target,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
+                           const torch::lazy::Value& target,
                            ReductionMode reduction) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildL1Loss(operands[0], operands[1], reduction);
   };
-  return InferOutputShape({input.xla_shape(), target.xla_shape()},
+  return InferOutputShape({GetXlaShape(input), GetXlaShape(target)},
                           lower_for_shape_fn);
 }
 
 }  // namespace
 
-L1Loss::L1Loss(const XlaValue& input, const XlaValue& target,
-               ReductionMode reduction)
+L1Loss::L1Loss(const torch::lazy::Value& input,
+               const torch::lazy::Value& target, ReductionMode reduction)
     : XlaNode(torch::lazy::OpKind(at::aten::l1_loss), {input, target},
               [&]() { return NodeOutputShape(input, target, reduction); },
               /*num_outputs=*/1,

--- a/torch_xla/csrc/ops/l1_loss.h
+++ b/torch_xla/csrc/ops/l1_loss.h
@@ -8,7 +8,7 @@ namespace torch_xla {
 
 class L1Loss : public XlaNode {
  public:
-  L1Loss(const XlaValue& input, const XlaValue& target,
+  L1Loss(const torch::lazy::Value& input, const torch::lazy::Value& target,
          ReductionMode reduction);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/l1_loss_backward.cpp
+++ b/torch_xla/csrc/ops/l1_loss_backward.cpp
@@ -8,22 +8,25 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& input,
-                           const XlaValue& target, ReductionMode reduction) {
+xla::Shape NodeOutputShape(const torch::lazy::Value& grad_output,
+                           const torch::lazy::Value& input,
+                           const torch::lazy::Value& target,
+                           ReductionMode reduction) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildL1LossBackward(operands[0], operands[1], operands[2],
                                reduction);
   };
   return InferOutputShape(
-      {grad_output.xla_shape(), input.xla_shape(), target.xla_shape()},
+      {GetXlaShape(grad_output), GetXlaShape(input), GetXlaShape(target)},
       lower_for_shape_fn);
 }
 
 }  // namespace
 
-L1LossBackward::L1LossBackward(const XlaValue& grad_output,
-                               const XlaValue& input, const XlaValue& target,
+L1LossBackward::L1LossBackward(const torch::lazy::Value& grad_output,
+                               const torch::lazy::Value& input,
+                               const torch::lazy::Value& target,
                                ReductionMode reduction)
     : XlaNode(torch::lazy::OpKind(at::aten::l1_loss_backward),
               {grad_output, input, target},

--- a/torch_xla/csrc/ops/l1_loss_backward.h
+++ b/torch_xla/csrc/ops/l1_loss_backward.h
@@ -8,8 +8,9 @@ namespace torch_xla {
 
 class L1LossBackward : public XlaNode {
  public:
-  L1LossBackward(const XlaValue& grad_output, const XlaValue& input,
-                 const XlaValue& target, ReductionMode reduction);
+  L1LossBackward(const torch::lazy::Value& grad_output,
+                 const torch::lazy::Value& input,
+                 const torch::lazy::Value& target, ReductionMode reduction);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/leaky_relu.cpp
+++ b/torch_xla/csrc/ops/leaky_relu.cpp
@@ -5,9 +5,9 @@
 
 namespace torch_xla {
 
-LeakyRelu::LeakyRelu(const XlaValue& input, double negative_slope)
+LeakyRelu::LeakyRelu(const torch::lazy::Value& input, double negative_slope)
     : XlaNode(torch::lazy::OpKind(at::aten::leaky_relu), {input},
-              input.xla_shape(),
+              GetXlaShape(input),
               /*num_outputs=*/1, torch::lazy::MHash(negative_slope)),
       negative_slope_(negative_slope) {}
 

--- a/torch_xla/csrc/ops/leaky_relu.h
+++ b/torch_xla/csrc/ops/leaky_relu.h
@@ -8,7 +8,7 @@ namespace torch_xla {
 
 class LeakyRelu : public XlaNode {
  public:
-  LeakyRelu(const XlaValue& input, double negative_slope);
+  LeakyRelu(const torch::lazy::Value& input, double negative_slope);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/leaky_relu_backward.cpp
+++ b/torch_xla/csrc/ops/leaky_relu_backward.cpp
@@ -5,11 +5,11 @@
 
 namespace torch_xla {
 
-LeakyReluBackward::LeakyReluBackward(const XlaValue& grad_output,
-                                     const XlaValue& input,
+LeakyReluBackward::LeakyReluBackward(const torch::lazy::Value& grad_output,
+                                     const torch::lazy::Value& input,
                                      double negative_slope)
     : XlaNode(torch::lazy::OpKind(at::aten::leaky_relu_backward),
-              {grad_output, input}, input.xla_shape(),
+              {grad_output, input}, GetXlaShape(input),
               /*num_outputs=*/1, torch::lazy::MHash(negative_slope)),
       negative_slope_(negative_slope) {}
 

--- a/torch_xla/csrc/ops/leaky_relu_backward.h
+++ b/torch_xla/csrc/ops/leaky_relu_backward.h
@@ -8,8 +8,8 @@ namespace torch_xla {
 
 class LeakyReluBackward : public XlaNode {
  public:
-  LeakyReluBackward(const XlaValue& grad_output, const XlaValue& input,
-                    double negative_slope);
+  LeakyReluBackward(const torch::lazy::Value& grad_output,
+                    const torch::lazy::Value& input, double negative_slope);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/linear_interpolation.cpp
+++ b/torch_xla/csrc/ops/linear_interpolation.cpp
@@ -6,10 +6,10 @@
 
 namespace torch_xla {
 
-LinearInterpolation::LinearInterpolation(const XlaValue& value,
-                                         const XlaValue& new_value,
+LinearInterpolation::LinearInterpolation(const torch::lazy::Value& value,
+                                         const torch::lazy::Value& new_value,
                                          double alpha)
-    : XlaNode(xla_moving_average, {value, new_value}, value.xla_shape(),
+    : XlaNode(xla_moving_average, {value, new_value}, GetXlaShape(value),
               /*num_outputs=*/1, torch::lazy::MHash(alpha)),
       alpha_(alpha) {}
 

--- a/torch_xla/csrc/ops/linear_interpolation.h
+++ b/torch_xla/csrc/ops/linear_interpolation.h
@@ -6,8 +6,8 @@ namespace torch_xla {
 
 class LinearInterpolation : public XlaNode {
  public:
-  LinearInterpolation(const XlaValue& value, const XlaValue& new_value,
-                      double alpha);
+  LinearInterpolation(const torch::lazy::Value& value,
+                      const torch::lazy::Value& new_value, double alpha);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/linspace.cpp
+++ b/torch_xla/csrc/ops/linspace.cpp
@@ -6,12 +6,13 @@
 
 namespace torch_xla {
 
-Linspace::Linspace(const XlaValue& start, const XlaValue& end, int64_t steps)
+Linspace::Linspace(const torch::lazy::Value& start,
+                   const torch::lazy::Value& end, int64_t steps)
     : XlaNode(torch::lazy::OpKind(at::aten::linspace), {start, end},
               [&]() {
                 xla::PrimitiveType dtype =
-                    XlaHelpers::PromoteType(start.xla_shape().element_type(),
-                                            end.xla_shape().element_type());
+                    XlaHelpers::PromoteType(GetXlaShape(start).element_type(),
+                                            GetXlaShape(end).element_type());
                 return xla::ShapeUtil::MakeShape(dtype, {steps});
               },
               /*num_outputs=*/1, torch::lazy::MHash(steps)),

--- a/torch_xla/csrc/ops/linspace.h
+++ b/torch_xla/csrc/ops/linspace.h
@@ -6,7 +6,8 @@ namespace torch_xla {
 
 class Linspace : public XlaNode {
  public:
-  Linspace(const XlaValue& start, const XlaValue& end, const int64_t steps);
+  Linspace(const torch::lazy::Value& start, const torch::lazy::Value& end,
+           const int64_t steps);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/log_softmax.cpp
+++ b/torch_xla/csrc/ops/log_softmax.cpp
@@ -16,18 +16,18 @@ xla::XlaOp LowerLogSoftmax(xla::XlaOp input, int64_t dim,
   return CastToScalarType(result, dtype);
 }
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            const c10::optional<at::ScalarType>& dtype) {
   if (dtype) {
     return xla::ShapeUtil::ChangeElementType(
-        input.xla_shape(), MakeXlaPrimitiveType(*dtype, /*device=*/nullptr));
+        GetXlaShape(input), MakeXlaPrimitiveType(*dtype, /*device=*/nullptr));
   }
-  return input.xla_shape();
+  return GetXlaShape(input);
 }
 
 }  // namespace
 
-LogSoftmax::LogSoftmax(const XlaValue& input, int64_t dim,
+LogSoftmax::LogSoftmax(const torch::lazy::Value& input, int64_t dim,
                        c10::optional<at::ScalarType> dtype)
     : XlaNode(torch::lazy::OpKind(at::aten::log_softmax), {input},
               [&]() { return NodeOutputShape(input, dtype); },

--- a/torch_xla/csrc/ops/log_softmax.h
+++ b/torch_xla/csrc/ops/log_softmax.h
@@ -10,7 +10,7 @@ namespace torch_xla {
 // IR node for log(softmax) operation.
 class LogSoftmax : public XlaNode {
  public:
-  LogSoftmax(const XlaValue& input, int64_t dim,
+  LogSoftmax(const torch::lazy::Value& input, int64_t dim,
              c10::optional<at::ScalarType> dtype);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;

--- a/torch_xla/csrc/ops/log_softmax_backward.cpp
+++ b/torch_xla/csrc/ops/log_softmax_backward.cpp
@@ -7,10 +7,11 @@
 
 namespace torch_xla {
 
-LogSoftmaxBackward::LogSoftmaxBackward(const XlaValue& grad_output,
-                                       const XlaValue& output, int64_t dim)
+LogSoftmaxBackward::LogSoftmaxBackward(const torch::lazy::Value& grad_output,
+                                       const torch::lazy::Value& output,
+                                       int64_t dim)
     : XlaNode(torch::lazy::OpKind(at::aten::_log_softmax_backward_data),
-              {grad_output, output}, grad_output.xla_shape(),
+              {grad_output, output}, GetXlaShape(grad_output),
               /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}
 

--- a/torch_xla/csrc/ops/log_softmax_backward.h
+++ b/torch_xla/csrc/ops/log_softmax_backward.h
@@ -6,8 +6,8 @@ namespace torch_xla {
 
 class LogSoftmaxBackward : public XlaNode {
  public:
-  LogSoftmaxBackward(const XlaValue& grad_output, const XlaValue& output,
-                     int64_t dim);
+  LogSoftmaxBackward(const torch::lazy::Value& grad_output,
+                     const torch::lazy::Value& output, int64_t dim);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/logsumexp.cpp
+++ b/torch_xla/csrc/ops/logsumexp.cpp
@@ -11,19 +11,20 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            std::vector<int64_t>& dimensions,
                            bool keep_reduced_dimensions) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildLogsumexp(operands[0], dimensions, keep_reduced_dimensions);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-Logsumexp::Logsumexp(const XlaValue& input, std::vector<int64_t> dimensions,
+Logsumexp::Logsumexp(const torch::lazy::Value& input,
+                     std::vector<int64_t> dimensions,
                      bool keep_reduced_dimensions)
     : XlaNode(torch::lazy::OpKind(at::aten::logsumexp), {input},
               [&]() {

--- a/torch_xla/csrc/ops/logsumexp.h
+++ b/torch_xla/csrc/ops/logsumexp.h
@@ -10,7 +10,7 @@ namespace torch_xla {
 
 class Logsumexp : public XlaNode {
  public:
-  Logsumexp(const XlaValue& input, std::vector<int64_t> dimensions,
+  Logsumexp(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
             bool keep_reduced_dimensions);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/masked_fill.cpp
+++ b/torch_xla/csrc/ops/masked_fill.cpp
@@ -7,10 +7,10 @@
 
 namespace torch_xla {
 
-MaskedFill::MaskedFill(const XlaValue& input, const XlaValue& mask,
-                       const at::Scalar& value)
+MaskedFill::MaskedFill(const torch::lazy::Value& input,
+                       const torch::lazy::Value& mask, const at::Scalar& value)
     : XlaNode(torch::lazy::OpKind(at::aten::masked_fill), {input, mask},
-              input.xla_shape(),
+              GetXlaShape(input),
               /*num_outputs=*/1, ScalarHash(value)),
       value_(std::move(value)) {}
 

--- a/torch_xla/csrc/ops/masked_fill.h
+++ b/torch_xla/csrc/ops/masked_fill.h
@@ -8,7 +8,7 @@ namespace torch_xla {
 
 class MaskedFill : public XlaNode {
  public:
-  MaskedFill(const XlaValue& input, const XlaValue& mask,
+  MaskedFill(const torch::lazy::Value& input, const torch::lazy::Value& mask,
              const at::Scalar& value);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/masked_scatter.cpp
+++ b/torch_xla/csrc/ops/masked_scatter.cpp
@@ -5,10 +5,11 @@
 
 namespace torch_xla {
 
-MaskedScatter::MaskedScatter(const XlaValue& input, const XlaValue& mask,
-                             const XlaValue& source)
+MaskedScatter::MaskedScatter(const torch::lazy::Value& input,
+                             const torch::lazy::Value& mask,
+                             const torch::lazy::Value& source)
     : XlaNode(torch::lazy::OpKind(at::aten::masked_scatter),
-              {input, mask, source}, input.xla_shape(),
+              {input, mask, source}, GetXlaShape(input),
               /*num_outputs=*/1) {}
 
 torch::lazy::NodePtr MaskedScatter::Clone(OpList operands) const {

--- a/torch_xla/csrc/ops/masked_scatter.h
+++ b/torch_xla/csrc/ops/masked_scatter.h
@@ -9,8 +9,8 @@ namespace torch_xla {
 // it gets its own IR node class.
 class MaskedScatter : public XlaNode {
  public:
-  MaskedScatter(const XlaValue& input, const XlaValue& mask,
-                const XlaValue& source);
+  MaskedScatter(const torch::lazy::Value& input, const torch::lazy::Value& mask,
+                const torch::lazy::Value& source);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/masked_select.cpp
+++ b/torch_xla/csrc/ops/masked_select.cpp
@@ -8,8 +8,8 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input) {
-  const xla::Shape& input_shape = input.xla_shape();
+xla::Shape NodeOutputShape(const torch::lazy::Value& input) {
+  const xla::Shape& input_shape = GetXlaShape(input);
   int64_t input_elements = xla::ShapeUtil::ElementsIn(input_shape);
   xla::PrimitiveType size_type = GetShapeDimensionType(/*device=*/nullptr);
   xla::Shape result_shape =
@@ -21,7 +21,8 @@ xla::Shape NodeOutputShape(const XlaValue& input) {
 
 }  // namespace
 
-MaskedSelect::MaskedSelect(const XlaValue& input, const XlaValue& mask)
+MaskedSelect::MaskedSelect(const torch::lazy::Value& input,
+                           const torch::lazy::Value& mask)
     : XlaNode(torch::lazy::OpKind(at::aten::masked_select), {input, mask},
               NodeOutputShape(input),
               /*num_outputs=*/2) {}

--- a/torch_xla/csrc/ops/masked_select.h
+++ b/torch_xla/csrc/ops/masked_select.h
@@ -9,7 +9,7 @@ namespace torch_xla {
 // it gets its own IR node class.
 class MaskedSelect : public XlaNode {
  public:
-  MaskedSelect(const XlaValue& input, const XlaValue& mask);
+  MaskedSelect(const torch::lazy::Value& input, const torch::lazy::Value& mask);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/max_in_dim.h
+++ b/torch_xla/csrc/ops/max_in_dim.h
@@ -6,7 +6,7 @@ namespace torch_xla {
 
 class MaxInDim : public XlaNode {
  public:
-  MaxInDim(const XlaValue& input, int64_t dim, bool keepdim);
+  MaxInDim(const torch::lazy::Value& input, int64_t dim, bool keepdim);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/max_pool_nd.cpp
+++ b/torch_xla/csrc/ops/max_pool_nd.cpp
@@ -8,7 +8,8 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input, int64_t spatial_dim_count,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
+                           int64_t spatial_dim_count,
                            absl::Span<const int64_t> kernel_size,
                            absl::Span<const int64_t> stride,
                            absl::Span<const int64_t> padding, bool ceil_mode) {
@@ -18,7 +19,7 @@ xla::Shape NodeOutputShape(const XlaValue& input, int64_t spatial_dim_count,
                        padding, ceil_mode);
     return xla::Tuple(operands[0].builder(), {result.result, result.indices});
   };
-  return InferOutputShape({input.xla_shape()}, shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, shape_fn);
 }
 
 c10::Symbol MaxPoolNdSymbol(int64_t spatial_dim_count) {
@@ -37,7 +38,7 @@ c10::Symbol MaxPoolNdSymbol(int64_t spatial_dim_count) {
 
 }  // namespace
 
-MaxPoolNd::MaxPoolNd(const XlaValue& input, int64_t spatial_dim_count,
+MaxPoolNd::MaxPoolNd(const torch::lazy::Value& input, int64_t spatial_dim_count,
                      std::vector<int64_t> kernel_size,
                      std::vector<int64_t> stride, std::vector<int64_t> padding,
                      bool ceil_mode)

--- a/torch_xla/csrc/ops/max_pool_nd.h
+++ b/torch_xla/csrc/ops/max_pool_nd.h
@@ -6,7 +6,7 @@ namespace torch_xla {
 
 class MaxPoolNd : public XlaNode {
  public:
-  MaxPoolNd(const XlaValue& input, int64_t spatial_dim_count,
+  MaxPoolNd(const torch::lazy::Value& input, int64_t spatial_dim_count,
             std::vector<int64_t> kernel_size, std::vector<int64_t> stride,
             std::vector<int64_t> padding, bool ceil_mode);
 

--- a/torch_xla/csrc/ops/max_pool_nd_backward.cpp
+++ b/torch_xla/csrc/ops/max_pool_nd_backward.cpp
@@ -8,7 +8,8 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& grad_output,
+                           const torch::lazy::Value& input,
                            int64_t spatial_dim_count,
                            absl::Span<const int64_t> kernel_size,
                            absl::Span<const int64_t> stride,
@@ -20,7 +21,7 @@ xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& input,
                                   /*input=*/operands[1], spatial_dim_count,
                                   kernel_size, stride, padding, ceil_mode);
   };
-  return InferOutputShape({grad_output.xla_shape(), input.xla_shape()},
+  return InferOutputShape({GetXlaShape(grad_output), GetXlaShape(input)},
                           lower_for_shape_fn);
 }
 
@@ -39,7 +40,7 @@ c10::Symbol MaxPoolNdBackwardSymbol(int64_t spatial_dim_count) {
 }  // namespace
 
 MaxPoolNdBackward::MaxPoolNdBackward(
-    const XlaValue& grad_output, const XlaValue& input,
+    const torch::lazy::Value& grad_output, const torch::lazy::Value& input,
     int64_t spatial_dim_count, std::vector<int64_t> kernel_size,
     std::vector<int64_t> stride, std::vector<int64_t> padding, bool ceil_mode)
     : XlaNode(torch::lazy::OpKind(MaxPoolNdBackwardSymbol(spatial_dim_count)),

--- a/torch_xla/csrc/ops/max_pool_nd_backward.h
+++ b/torch_xla/csrc/ops/max_pool_nd_backward.h
@@ -6,8 +6,9 @@ namespace torch_xla {
 
 class MaxPoolNdBackward : public XlaNode {
  public:
-  MaxPoolNdBackward(const XlaValue& grad_output, const XlaValue& input,
-                    int64_t spatial_dim_count, std::vector<int64_t> kernel_size,
+  MaxPoolNdBackward(const torch::lazy::Value& grad_output,
+                    const torch::lazy::Value& input, int64_t spatial_dim_count,
+                    std::vector<int64_t> kernel_size,
                     std::vector<int64_t> stride, std::vector<int64_t> padding,
                     bool ceil_mode);
 

--- a/torch_xla/csrc/ops/max_unpool_nd.cpp
+++ b/torch_xla/csrc/ops/max_unpool_nd.cpp
@@ -8,13 +8,14 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& indices,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
+                           const torch::lazy::Value& indices,
                            absl::Span<const int64_t> output_size) {
   auto shape_fn = [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildMaxUnpoolNd(GetCurrentDevice(), operands[0], operands[1],
                             output_size);
   };
-  return InferOutputShape({input.xla_shape(), indices.xla_shape()}, shape_fn);
+  return InferOutputShape({GetXlaShape(input), GetXlaShape(indices)}, shape_fn);
 }
 
 c10::Symbol MaxUnpoolNdSymbol(int64_t spatial_dim_count) {
@@ -31,7 +32,8 @@ c10::Symbol MaxUnpoolNdSymbol(int64_t spatial_dim_count) {
 
 }  // namespace
 
-MaxUnpoolNd::MaxUnpoolNd(const XlaValue& input, const XlaValue& indices,
+MaxUnpoolNd::MaxUnpoolNd(const torch::lazy::Value& input,
+                         const torch::lazy::Value& indices,
                          std::vector<int64_t> output_size)
     : XlaNode(torch::lazy::OpKind(MaxUnpoolNdSymbol(output_size.size())),
               {input, indices},

--- a/torch_xla/csrc/ops/max_unpool_nd.h
+++ b/torch_xla/csrc/ops/max_unpool_nd.h
@@ -6,7 +6,8 @@ namespace torch_xla {
 
 class MaxUnpoolNd : public XlaNode {
  public:
-  MaxUnpoolNd(const XlaValue& input, const XlaValue& indices,
+  MaxUnpoolNd(const torch::lazy::Value& input,
+              const torch::lazy::Value& indices,
               std::vector<int64_t> output_size);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;

--- a/torch_xla/csrc/ops/mean.cpp
+++ b/torch_xla/csrc/ops/mean.cpp
@@ -21,7 +21,7 @@ xla::XlaOp LowerMean(xla::XlaOp input, const std::vector<int64_t>& dimensions,
                : result;
 }
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            const std::vector<int64_t>& dimensions,
                            bool keep_reduced_dimensions,
                            const c10::optional<at::ScalarType>& dtype) {
@@ -29,12 +29,12 @@ xla::Shape NodeOutputShape(const XlaValue& input,
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return LowerMean(operands[0], dimensions, keep_reduced_dimensions, dtype);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-Mean::Mean(const XlaValue& input, std::vector<int64_t> dimensions,
+Mean::Mean(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
            bool keep_reduced_dimensions, c10::optional<at::ScalarType> dtype)
     : XlaNode(torch::lazy::OpKind(at::aten::mean), {input},
               [&]() {

--- a/torch_xla/csrc/ops/mean.h
+++ b/torch_xla/csrc/ops/mean.h
@@ -12,7 +12,7 @@ namespace torch_xla {
 
 class Mean : public XlaNode {
  public:
-  Mean(const XlaValue& input, std::vector<int64_t> dimensions,
+  Mean(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
        bool keep_reduced_dimensions, c10::optional<at::ScalarType> dtype);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/min_in_dim.cpp
+++ b/torch_xla/csrc/ops/min_in_dim.cpp
@@ -7,19 +7,20 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input, int64_t dim, bool keepdim) {
+xla::Shape NodeOutputShape(const torch::lazy::Value& input, int64_t dim,
+                           bool keepdim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     xla::XlaOp values = BuildMinInDim(operands[0], dim, keepdim);
     xla::XlaOp indices = BuildArgMin(operands[0], dim, keepdim);
     return xla::Tuple(values.builder(), {values, indices});
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-MinInDim::MinInDim(const XlaValue& input, int64_t dim, bool keepdim)
+MinInDim::MinInDim(const torch::lazy::Value& input, int64_t dim, bool keepdim)
     : XlaNode(torch::lazy::OpKind(at::aten::min), {input},
               [&]() { return NodeOutputShape(input, dim, keepdim); },
               /*num_outputs=*/2, torch::lazy::MHash(dim, keepdim)),

--- a/torch_xla/csrc/ops/min_in_dim.h
+++ b/torch_xla/csrc/ops/min_in_dim.h
@@ -6,7 +6,7 @@ namespace torch_xla {
 
 class MinInDim : public XlaNode {
  public:
-  MinInDim(const XlaValue& input, int64_t dim, bool keepdim);
+  MinInDim(const torch::lazy::Value& input, int64_t dim, bool keepdim);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/mse_loss.cpp
+++ b/torch_xla/csrc/ops/mse_loss.cpp
@@ -11,20 +11,21 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& target,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
+                           const torch::lazy::Value& target,
                            ReductionMode reduction) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildMseLoss(operands[0], operands[1], reduction);
   };
-  return InferOutputShape({input.xla_shape(), target.xla_shape()},
+  return InferOutputShape({GetXlaShape(input), GetXlaShape(target)},
                           lower_for_shape_fn);
 }
 
 }  // namespace
 
-MseLoss::MseLoss(const XlaValue& input, const XlaValue& target,
-                 ReductionMode reduction)
+MseLoss::MseLoss(const torch::lazy::Value& input,
+                 const torch::lazy::Value& target, ReductionMode reduction)
     : XlaNode(torch::lazy::OpKind(at::aten::mse_loss), {input, target},
               [&]() { return NodeOutputShape(input, target, reduction); },
               /*num_outputs=*/1,

--- a/torch_xla/csrc/ops/mse_loss.h
+++ b/torch_xla/csrc/ops/mse_loss.h
@@ -8,7 +8,7 @@ namespace torch_xla {
 
 class MseLoss : public XlaNode {
  public:
-  MseLoss(const XlaValue& input, const XlaValue& target,
+  MseLoss(const torch::lazy::Value& input, const torch::lazy::Value& target,
           ReductionMode reduction);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/mse_loss_backward.cpp
+++ b/torch_xla/csrc/ops/mse_loss_backward.cpp
@@ -10,22 +10,25 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& input,
-                           const XlaValue& target, ReductionMode reduction) {
+xla::Shape NodeOutputShape(const torch::lazy::Value& grad_output,
+                           const torch::lazy::Value& input,
+                           const torch::lazy::Value& target,
+                           ReductionMode reduction) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildMseLossBackward(operands[0], operands[1], operands[2],
                                 reduction);
   };
   return InferOutputShape(
-      {grad_output.xla_shape(), input.xla_shape(), target.xla_shape()},
+      {GetXlaShape(grad_output), GetXlaShape(input), GetXlaShape(target)},
       lower_for_shape_fn);
 }
 
 }  // namespace
 
-MseLossBackward::MseLossBackward(const XlaValue& grad_output,
-                                 const XlaValue& input, const XlaValue& target,
+MseLossBackward::MseLossBackward(const torch::lazy::Value& grad_output,
+                                 const torch::lazy::Value& input,
+                                 const torch::lazy::Value& target,
                                  ReductionMode reduction)
     : XlaNode(torch::lazy::OpKind(at::aten::mse_loss_backward),
               {grad_output, input, target},

--- a/torch_xla/csrc/ops/mse_loss_backward.h
+++ b/torch_xla/csrc/ops/mse_loss_backward.h
@@ -8,8 +8,9 @@ namespace torch_xla {
 
 class MseLossBackward : public XlaNode {
  public:
-  MseLossBackward(const XlaValue& grad_output, const XlaValue& input,
-                  const XlaValue& target, ReductionMode reduction);
+  MseLossBackward(const torch::lazy::Value& grad_output,
+                  const torch::lazy::Value& input,
+                  const torch::lazy::Value& target, ReductionMode reduction);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/native_batch_norm_backward.cpp
+++ b/torch_xla/csrc/ops/native_batch_norm_backward.cpp
@@ -8,9 +8,12 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& grad_out, const XlaValue& input,
-                           const XlaValue& weight, const XlaValue& save_mean,
-                           const XlaValue& save_invstd, bool training) {
+xla::Shape NodeOutputShape(const torch::lazy::Value& grad_out,
+                           const torch::lazy::Value& input,
+                           const torch::lazy::Value& weight,
+                           const torch::lazy::Value& save_mean,
+                           const torch::lazy::Value& save_invstd,
+                           bool training) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     BatchNormGrads xla_outputs =
@@ -21,19 +24,17 @@ xla::Shape NodeOutputShape(const XlaValue& grad_out, const XlaValue& input,
                        xla_outputs.grad_bias});
   };
   return InferOutputShape(
-      {grad_out.xla_shape(), input.xla_shape(), weight.xla_shape(),
-       save_mean.xla_shape(), save_invstd.xla_shape()},
+      {GetXlaShape(grad_out), GetXlaShape(input), GetXlaShape(weight),
+       GetXlaShape(save_mean), GetXlaShape(save_invstd)},
       lower_for_shape_fn);
 }
 
 }  // namespace
 
-NativeBatchNormBackward::NativeBatchNormBackward(const XlaValue& grad_out,
-                                                 const XlaValue& input,
-                                                 const XlaValue& weight,
-                                                 const XlaValue& save_mean,
-                                                 const XlaValue& save_invstd,
-                                                 bool training, double eps)
+NativeBatchNormBackward::NativeBatchNormBackward(
+    const torch::lazy::Value& grad_out, const torch::lazy::Value& input,
+    const torch::lazy::Value& weight, const torch::lazy::Value& save_mean,
+    const torch::lazy::Value& save_invstd, bool training, double eps)
     : XlaNode(torch::lazy::OpKind(at::aten::native_batch_norm_backward),
               {grad_out, input, weight, save_mean, save_invstd},
               [&]() {

--- a/torch_xla/csrc/ops/native_batch_norm_backward.h
+++ b/torch_xla/csrc/ops/native_batch_norm_backward.h
@@ -7,9 +7,11 @@ namespace torch_xla {
 // XlaNode for the backward batch norm operator.
 class NativeBatchNormBackward : public XlaNode {
  public:
-  NativeBatchNormBackward(const XlaValue& grad_out, const XlaValue& input,
-                          const XlaValue& weight, const XlaValue& save_mean,
-                          const XlaValue& save_invstd, bool training,
+  NativeBatchNormBackward(const torch::lazy::Value& grad_out,
+                          const torch::lazy::Value& input,
+                          const torch::lazy::Value& weight,
+                          const torch::lazy::Value& save_mean,
+                          const torch::lazy::Value& save_invstd, bool training,
                           double eps);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;

--- a/torch_xla/csrc/ops/native_batch_norm_forward.cpp
+++ b/torch_xla/csrc/ops/native_batch_norm_forward.cpp
@@ -31,9 +31,12 @@ std::vector<xla::XlaOp> LowerBatchNorm(xla::XlaOp input, xla::XlaOp weight,
   return values;
 }
 
-xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& weight,
-                           const XlaValue& bias, const XlaValue& running_mean,
-                           const XlaValue& running_var, bool training) {
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
+                           const torch::lazy::Value& weight,
+                           const torch::lazy::Value& bias,
+                           const torch::lazy::Value& running_mean,
+                           const torch::lazy::Value& running_var,
+                           bool training) {
   auto lower_for_shape_fn =
       [training](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     std::vector<xla::XlaOp> values =
@@ -42,19 +45,17 @@ xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& weight,
     return xla::Tuple(operands[0].builder(), values);
   };
   return InferOutputShape(
-      {input.xla_shape(), weight.xla_shape(), bias.xla_shape(),
-       running_mean.xla_shape(), running_var.xla_shape()},
+      {GetXlaShape(input), GetXlaShape(weight), GetXlaShape(bias),
+       GetXlaShape(running_mean), GetXlaShape(running_var)},
       lower_for_shape_fn);
 }
 
 }  // namespace
 
-NativeBatchNormForward::NativeBatchNormForward(const XlaValue& input,
-                                               const XlaValue& weight,
-                                               const XlaValue& bias,
-                                               const XlaValue& running_mean,
-                                               const XlaValue& running_var,
-                                               bool training, double eps)
+NativeBatchNormForward::NativeBatchNormForward(
+    const torch::lazy::Value& input, const torch::lazy::Value& weight,
+    const torch::lazy::Value& bias, const torch::lazy::Value& running_mean,
+    const torch::lazy::Value& running_var, bool training, double eps)
     : XlaNode(torch::lazy::OpKind(at::aten::native_batch_norm),
               {input, weight, bias, running_mean, running_var},
               [&]() {

--- a/torch_xla/csrc/ops/native_batch_norm_forward.h
+++ b/torch_xla/csrc/ops/native_batch_norm_forward.h
@@ -6,9 +6,11 @@ namespace torch_xla {
 
 class NativeBatchNormForward : public XlaNode {
  public:
-  NativeBatchNormForward(const XlaValue& input, const XlaValue& weight,
-                         const XlaValue& bias, const XlaValue& running_mean,
-                         const XlaValue& running_var, bool training,
+  NativeBatchNormForward(const torch::lazy::Value& input,
+                         const torch::lazy::Value& weight,
+                         const torch::lazy::Value& bias,
+                         const torch::lazy::Value& running_mean,
+                         const torch::lazy::Value& running_var, bool training,
                          double eps);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;

--- a/torch_xla/csrc/ops/nll_loss.h
+++ b/torch_xla/csrc/ops/nll_loss.h
@@ -8,9 +8,9 @@ namespace torch_xla {
 
 class NllLoss : public XlaNode {
  public:
-  NllLoss(const XlaValue& logits, const XlaValue& labels,
-          const absl::optional<XlaValue>& weight, ReductionMode reduction,
-          int ignore_index);
+  NllLoss(const torch::lazy::Value& logits, const torch::lazy::Value& labels,
+          const absl::optional<torch::lazy::Value>& weight,
+          ReductionMode reduction, int ignore_index);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/nll_loss2d.cpp
+++ b/torch_xla/csrc/ops/nll_loss2d.cpp
@@ -10,8 +10,9 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& logits, const XlaValue& labels,
-                           const absl::optional<XlaValue>& weight,
+xla::Shape NodeOutputShape(const torch::lazy::Value& logits,
+                           const torch::lazy::Value& labels,
+                           const absl::optional<torch::lazy::Value>& weight,
                            ReductionMode reduction, int ignore_index) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
@@ -23,20 +24,22 @@ xla::Shape NodeOutputShape(const XlaValue& logits, const XlaValue& labels,
                         reduction);
   };
   std::vector<xla::Shape> shapes;
-  for (auto& input :
-       xla::util::GetValuesVector<XlaValue>({logits, labels}, {&weight})) {
-    shapes.push_back(input.xla_shape());
+  for (auto& input : xla::util::GetValuesVector<torch::lazy::Value>(
+           {logits, labels}, {&weight})) {
+    shapes.push_back(GetXlaShape(input));
   }
   return InferOutputShape(shapes, lower_for_shape_fn);
 }
 
 }  // namespace
 
-NllLoss2d::NllLoss2d(const XlaValue& logits, const XlaValue& labels,
-                     const absl::optional<XlaValue>& weight,
+NllLoss2d::NllLoss2d(const torch::lazy::Value& logits,
+                     const torch::lazy::Value& labels,
+                     const absl::optional<torch::lazy::Value>& weight,
                      ReductionMode reduction, int ignore_index)
     : XlaNode(torch::lazy::OpKind(at::aten::nll_loss2d),
-              xla::util::GetValuesVector<XlaValue>({logits, labels}, {&weight}),
+              xla::util::GetValuesVector<torch::lazy::Value>({logits, labels},
+                                                             {&weight}),
               [&]() {
                 return NodeOutputShape(logits, labels, weight, reduction,
                                        ignore_index);
@@ -48,7 +51,7 @@ NllLoss2d::NllLoss2d(const XlaValue& logits, const XlaValue& labels,
       ignore_index_(ignore_index) {}
 
 torch::lazy::NodePtr NllLoss2d::Clone(OpList operands) const {
-  absl::optional<XlaValue> weight;
+  absl::optional<torch::lazy::Value> weight;
   if (operands.size() > 2) {
     weight = operands.at(2);
   }

--- a/torch_xla/csrc/ops/nll_loss2d.h
+++ b/torch_xla/csrc/ops/nll_loss2d.h
@@ -8,9 +8,9 @@ namespace torch_xla {
 
 class NllLoss2d : public XlaNode {
  public:
-  NllLoss2d(const XlaValue& logits, const XlaValue& labels,
-            const absl::optional<XlaValue>& weight, ReductionMode reduction,
-            int ignore_index);
+  NllLoss2d(const torch::lazy::Value& logits, const torch::lazy::Value& labels,
+            const absl::optional<torch::lazy::Value>& weight,
+            ReductionMode reduction, int ignore_index);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/nll_loss2d_backward.cpp
+++ b/torch_xla/csrc/ops/nll_loss2d_backward.cpp
@@ -10,11 +10,12 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& logits,
-                           const XlaValue& labels,
-                           const absl::optional<XlaValue>& weight,
-                           const absl::optional<XlaValue>& total_weight,
-                           ReductionMode reduction, int ignore_index) {
+xla::Shape NodeOutputShape(
+    const torch::lazy::Value& grad_output, const torch::lazy::Value& logits,
+    const torch::lazy::Value& labels,
+    const absl::optional<torch::lazy::Value>& weight,
+    const absl::optional<torch::lazy::Value>& total_weight,
+    ReductionMode reduction, int ignore_index) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     xla::XlaOp weight;
@@ -29,9 +30,9 @@ xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& logits,
                                 total_weight, ignore_index, reduction);
   };
   std::vector<xla::Shape> shapes;
-  for (auto& input : xla::util::GetValuesVector<XlaValue>(
+  for (auto& input : xla::util::GetValuesVector<torch::lazy::Value>(
            {grad_output, logits, labels}, {&weight, &total_weight})) {
-    shapes.push_back(input.xla_shape());
+    shapes.push_back(GetXlaShape(input));
   }
   return InferOutputShape(shapes, lower_for_shape_fn);
 }
@@ -39,12 +40,13 @@ xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& logits,
 }  // namespace
 
 NllLoss2dBackward::NllLoss2dBackward(
-    const XlaValue& grad_output, const XlaValue& logits, const XlaValue& labels,
-    const absl::optional<XlaValue>& weight,
-    const absl::optional<XlaValue>& total_weight, ReductionMode reduction,
-    int ignore_index)
+    const torch::lazy::Value& grad_output, const torch::lazy::Value& logits,
+    const torch::lazy::Value& labels,
+    const absl::optional<torch::lazy::Value>& weight,
+    const absl::optional<torch::lazy::Value>& total_weight,
+    ReductionMode reduction, int ignore_index)
     : XlaNode(torch::lazy::OpKind(at::aten::nll_loss2d_backward),
-              xla::util::GetValuesVector<XlaValue>(
+              xla::util::GetValuesVector<torch::lazy::Value>(
                   {grad_output, logits, labels}, {&weight, &total_weight}),
               [&]() {
                 return NodeOutputShape(grad_output, logits, labels, weight,
@@ -57,8 +59,8 @@ NllLoss2dBackward::NllLoss2dBackward(
       ignore_index_(ignore_index) {}
 
 torch::lazy::NodePtr NllLoss2dBackward::Clone(OpList operands) const {
-  absl::optional<XlaValue> weight;
-  absl::optional<XlaValue> total_weight;
+  absl::optional<torch::lazy::Value> weight;
+  absl::optional<torch::lazy::Value> total_weight;
   if (operands.size() > 3) {
     weight = operands.at(3);
     total_weight = operands.at(4);

--- a/torch_xla/csrc/ops/nll_loss2d_backward.h
+++ b/torch_xla/csrc/ops/nll_loss2d_backward.h
@@ -8,10 +8,11 @@ namespace torch_xla {
 
 class NllLoss2dBackward : public XlaNode {
  public:
-  NllLoss2dBackward(const XlaValue& grad_output, const XlaValue& logits,
-                    const XlaValue& labels,
-                    const absl::optional<XlaValue>& weight,
-                    const absl::optional<XlaValue>& total_weight,
+  NllLoss2dBackward(const torch::lazy::Value& grad_output,
+                    const torch::lazy::Value& logits,
+                    const torch::lazy::Value& labels,
+                    const absl::optional<torch::lazy::Value>& weight,
+                    const absl::optional<torch::lazy::Value>& total_weight,
                     ReductionMode reduction, int ignore_index);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/nll_loss_backward.h
+++ b/torch_xla/csrc/ops/nll_loss_backward.h
@@ -8,10 +8,11 @@ namespace torch_xla {
 
 class NllLossBackward : public XlaNode {
  public:
-  NllLossBackward(const XlaValue& grad_output, const XlaValue& logits,
-                  const XlaValue& labels,
-                  const absl::optional<XlaValue>& weight,
-                  const absl::optional<XlaValue>& total_weight,
+  NllLossBackward(const torch::lazy::Value& grad_output,
+                  const torch::lazy::Value& logits,
+                  const torch::lazy::Value& labels,
+                  const absl::optional<torch::lazy::Value>& weight,
+                  const absl::optional<torch::lazy::Value>& total_weight,
                   ReductionMode reduction, int ignore_index);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/nms.cpp
+++ b/torch_xla/csrc/ops/nms.cpp
@@ -9,9 +9,11 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& boxes, const XlaValue& scores,
-                           const XlaValue& score_threshold,
-                           const XlaValue& iou_threshold, int64_t output_size) {
+xla::Shape NodeOutputShape(const torch::lazy::Value& boxes,
+                           const torch::lazy::Value& scores,
+                           const torch::lazy::Value& score_threshold,
+                           const torch::lazy::Value& iou_threshold,
+                           int64_t output_size) {
   auto shape_fn = [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     NmsResult result = BuildNms(operands[0], operands[1], operands[2],
                                 operands[3], output_size);
@@ -19,16 +21,16 @@ xla::Shape NodeOutputShape(const XlaValue& boxes, const XlaValue& scores,
                       {result.selected_indices, result.num_valid});
   };
   return InferOutputShape(
-      {boxes.xla_shape(), scores.xla_shape(), score_threshold.xla_shape(),
-       iou_threshold.xla_shape()},
+      {GetXlaShape(boxes), GetXlaShape(scores), GetXlaShape(score_threshold),
+       GetXlaShape(iou_threshold)},
       shape_fn);
 }
 
 }  // namespace
 
-Nms::Nms(const XlaValue& boxes, const XlaValue& scores,
-         const XlaValue& score_threshold, const XlaValue& iou_threshold,
-         int64_t output_size)
+Nms::Nms(const torch::lazy::Value& boxes, const torch::lazy::Value& scores,
+         const torch::lazy::Value& score_threshold,
+         const torch::lazy::Value& iou_threshold, int64_t output_size)
     : XlaNode(xla_nms, {boxes, scores, score_threshold, iou_threshold},
               [&]() {
                 return NodeOutputShape(boxes, scores, score_threshold,

--- a/torch_xla/csrc/ops/nms.h
+++ b/torch_xla/csrc/ops/nms.h
@@ -6,9 +6,9 @@ namespace torch_xla {
 
 class Nms : public XlaNode {
  public:
-  Nms(const XlaValue& boxes, const XlaValue& scores,
-      const XlaValue& score_threshold, const XlaValue& iou_threshold,
-      int64_t output_size);
+  Nms(const torch::lazy::Value& boxes, const torch::lazy::Value& scores,
+      const torch::lazy::Value& score_threshold,
+      const torch::lazy::Value& iou_threshold, int64_t output_size);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/nonzero.cpp
+++ b/torch_xla/csrc/ops/nonzero.cpp
@@ -8,8 +8,8 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input) {
-  const xla::Shape& input_shape = input.xla_shape();
+xla::Shape NodeOutputShape(const torch::lazy::Value& input) {
+  const xla::Shape& input_shape = GetXlaShape(input);
   int64_t index_elements = xla::ShapeUtil::ElementsIn(input_shape);
   xla::PrimitiveType size_type = GetShapeDimensionType(/*device=*/nullptr);
   xla::Shape result_shape = xla::ShapeUtil::MakeShape(
@@ -21,7 +21,7 @@ xla::Shape NodeOutputShape(const XlaValue& input) {
 
 }  // namespace
 
-NonZero::NonZero(const XlaValue& input)
+NonZero::NonZero(const torch::lazy::Value& input)
     : XlaNode(torch::lazy::OpKind(at::aten::nonzero), {input},
               NodeOutputShape(input),
               /*num_outputs=*/2) {}

--- a/torch_xla/csrc/ops/nonzero.h
+++ b/torch_xla/csrc/ops/nonzero.h
@@ -9,7 +9,7 @@ namespace torch_xla {
 // it gets its own IR node class.
 class NonZero : public XlaNode {
  public:
-  NonZero(const XlaValue& input);
+  NonZero(const torch::lazy::Value& input);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/normal.cpp
+++ b/torch_xla/csrc/ops/normal.cpp
@@ -6,9 +6,10 @@
 
 namespace torch_xla {
 
-Normal::Normal(const XlaValue& mean, const XlaValue& std, const XlaValue& seed)
+Normal::Normal(const torch::lazy::Value& mean, const torch::lazy::Value& std,
+               const torch::lazy::Value& seed)
     : XlaNode(torch::lazy::OpKind(at::aten::normal), {mean, std, seed},
-              mean.xla_shape()) {}
+              GetXlaShape(mean)) {}
 
 torch::lazy::NodePtr Normal::Clone(OpList operands) const {
   return torch::lazy::MakeNode<Normal>(operands.at(0), operands.at(1),

--- a/torch_xla/csrc/ops/normal.h
+++ b/torch_xla/csrc/ops/normal.h
@@ -6,7 +6,8 @@ namespace torch_xla {
 
 class Normal : public XlaNode {
  public:
-  Normal(const XlaValue& mean, const XlaValue& std, const XlaValue& seed);
+  Normal(const torch::lazy::Value& mean, const torch::lazy::Value& std,
+         const torch::lazy::Value& seed);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -26,7 +26,7 @@ inline torch::lazy::NodePtr ConstantOp(xla::Literal value) {
 }
 
 inline torch::lazy::NodePtr GenericOp(
-    torch::lazy::OpKind op, absl::Span<const XlaValue> operands,
+    torch::lazy::OpKind op, absl::Span<const torch::lazy::Value> operands,
     xla::Shape shape, Generic::LowerFn lower_fn, size_t num_outputs = 1,
     // cast to uint32_t to avoid ambiguous constructor of uint128
     torch::lazy::hash_t hash_seed = (uint32_t)0x5a2d296e9) {
@@ -36,7 +36,7 @@ inline torch::lazy::NodePtr GenericOp(
 }
 
 inline torch::lazy::NodePtr GenericOp(
-    torch::lazy::OpKind op, absl::Span<const XlaValue> operands,
+    torch::lazy::OpKind op, absl::Span<const torch::lazy::Value> operands,
     const std::function<xla::Shape()>& shape_fn, Generic::LowerFn lower_fn,
     size_t num_outputs = 1,
     // cast to uint32_t to avoid ambiguous constructor of uint128
@@ -55,130 +55,154 @@ inline torch::lazy::NodePtr GenericOp(torch::lazy::OpKind op, xla::Shape shape,
                                         hash_seed);
 }
 
-torch::lazy::NodePtr Sin(const XlaValue& input);
+torch::lazy::NodePtr Cos(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Sinh(const XlaValue& input);
+torch::lazy::NodePtr Cosh(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Atan2(const XlaValue& input, const XlaValue& other);
+torch::lazy::NodePtr Sin(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Tan(const XlaValue& input);
+torch::lazy::NodePtr Sinh(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Tanh(const XlaValue& input);
+torch::lazy::NodePtr Atan2(const torch::lazy::Value& input,
+                           const torch::lazy::Value& other);
 
-torch::lazy::NodePtr Neg(const XlaValue& input);
+torch::lazy::NodePtr Tan(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr ReluOp(const XlaValue& input);
+torch::lazy::NodePtr Tanh(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Min(const XlaValue& input, const XlaValue& other);
+torch::lazy::NodePtr Neg(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Exp(const XlaValue& input);
+torch::lazy::NodePtr SgnOp(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Expm1(const XlaValue& input);
+torch::lazy::NodePtr SignOp(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Erf(const XlaValue& input);
+torch::lazy::NodePtr ReluOp(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Erfc(const XlaValue& input);
+torch::lazy::NodePtr Min(const torch::lazy::Value& input,
+                         const torch::lazy::Value& other);
 
-torch::lazy::NodePtr Erfinv(const XlaValue& input);
+torch::lazy::NodePtr Exp(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Log(const XlaValue& input);
+torch::lazy::NodePtr Expm1(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr LogBase(const XlaValue& input, torch::lazy::OpKind op,
-                             double base);
+torch::lazy::NodePtr Erf(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Log1p(const XlaValue& input);
+torch::lazy::NodePtr Erfc(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Sqrt(const XlaValue& input);
+torch::lazy::NodePtr Erfinv(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Rsqrt(const XlaValue& input);
+torch::lazy::NodePtr Log(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr ReciprocalOp(const XlaValue& input);
+torch::lazy::NodePtr LogBase(const torch::lazy::Value& input,
+                             torch::lazy::OpKind op, double base);
 
-torch::lazy::NodePtr Prelu(const XlaValue& input, const XlaValue& weight);
+torch::lazy::NodePtr Log1p(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Pow(const XlaValue& input, const XlaValue& exponent);
+torch::lazy::NodePtr Sqrt(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Fmod(const XlaValue& dividend, const XlaValue& divisor);
+torch::lazy::NodePtr Rsqrt(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Not(const XlaValue& input);
+torch::lazy::NodePtr ReciprocalOp(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr HardSigmoid(const XlaValue& input);
+torch::lazy::NodePtr Prelu(const torch::lazy::Value& input,
+                           const torch::lazy::Value& weight);
 
-torch::lazy::NodePtr HardSigmoidBackward(const XlaValue& grad_output,
-                                         const XlaValue& input);
+torch::lazy::NodePtr Pow(const torch::lazy::Value& input,
+                         const torch::lazy::Value& exponent);
 
-torch::lazy::NodePtr HardSwish(const XlaValue& input);
+torch::lazy::NodePtr Fmod(const torch::lazy::Value& dividend,
+                          const torch::lazy::Value& divisor);
 
-torch::lazy::NodePtr HardSwishBackward(const XlaValue& grad_output,
-                                       const XlaValue& input);
+torch::lazy::NodePtr Not(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr LogSigmoid(const XlaValue& input);
+torch::lazy::NodePtr HardSigmoid(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr LogSigmoidBackward(const XlaValue& grad_output,
-                                        const XlaValue& input,
-                                        const XlaValue& buffer);
+torch::lazy::NodePtr HardSigmoidBackward(const torch::lazy::Value& grad_output,
+                                         const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Sigmoid(const XlaValue& input);
+torch::lazy::NodePtr HardSwish(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr SiLU(const XlaValue& input);
+torch::lazy::NodePtr HardSwishBackward(const torch::lazy::Value& grad_output,
+                                       const torch::lazy::Value& input);
 
-torch::lazy::NodePtr SiLUBackward(const XlaValue& grad_output,
-                                  const XlaValue& input);
+torch::lazy::NodePtr LogSigmoid(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr SigmoidBackward(const XlaValue& grad_output,
-                                     const XlaValue& output);
+torch::lazy::NodePtr LogSigmoidBackward(const torch::lazy::Value& grad_output,
+                                        const torch::lazy::Value& input,
+                                        const torch::lazy::Value& buffer);
 
-torch::lazy::NodePtr LogSoftmaxBackwardOp(const XlaValue& grad_output,
-                                          const XlaValue& output, int64_t dim);
+torch::lazy::NodePtr Sigmoid(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr SoftmaxBackwardOp(const XlaValue& grad_output,
-                                       const XlaValue& output, int64_t dim);
+torch::lazy::NodePtr SiLU(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Clamp(const XlaValue& input, const XlaValue& min,
-                           const XlaValue& max);
+torch::lazy::NodePtr SiLUBackward(const torch::lazy::Value& grad_output,
+                                  const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Ceil(const XlaValue& input);
+torch::lazy::NodePtr SigmoidBackward(const torch::lazy::Value& grad_output,
+                                     const torch::lazy::Value& output);
 
-torch::lazy::NodePtr Celu(const XlaValue& input, const at::Scalar& alpha);
+torch::lazy::NodePtr LogSoftmaxBackwardOp(const torch::lazy::Value& grad_output,
+                                          const torch::lazy::Value& output,
+                                          int64_t dim);
 
-torch::lazy::NodePtr Floor(const XlaValue& input);
+torch::lazy::NodePtr SoftmaxBackwardOp(const torch::lazy::Value& grad_output,
+                                       const torch::lazy::Value& output,
+                                       int64_t dim);
 
-torch::lazy::NodePtr Round(const XlaValue& input);
+torch::lazy::NodePtr Clamp(const torch::lazy::Value& input,
+                           const torch::lazy::Value& min,
+                           const torch::lazy::Value& max);
 
-torch::lazy::NodePtr Trunc(const XlaValue& input);
+torch::lazy::NodePtr Ceil(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr FracOp(const XlaValue& input);
+torch::lazy::NodePtr Celu(const torch::lazy::Value& input,
+                          const at::Scalar& alpha);
 
-torch::lazy::NodePtr Ger(const XlaValue& input, const XlaValue& other);
+torch::lazy::NodePtr Floor(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr AddMatMulOp(const XlaValue& input, const XlaValue& weight,
-                                 const XlaValue& bias);
+torch::lazy::NodePtr Round(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Dot(const XlaValue& input, const XlaValue& weight);
+torch::lazy::NodePtr Trunc(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr MatMul(const XlaValue& lhs, const XlaValue& rhs);
+torch::lazy::NodePtr FracOp(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr AdaptiveMaxPool2dBackward(const XlaValue& grad_output,
-                                               const XlaValue& input);
+torch::lazy::NodePtr Ger(const torch::lazy::Value& input,
+                         const torch::lazy::Value& other);
 
-torch::lazy::NodePtr AdaptiveAvgPool2dBackward(const XlaValue& grad_output,
-                                               const XlaValue& input);
+torch::lazy::NodePtr AddMatMulOp(const torch::lazy::Value& input,
+                                 const torch::lazy::Value& weight,
+                                 const torch::lazy::Value& bias);
 
-torch::lazy::NodePtr AdaptiveAvgPool3dBackward(const XlaValue& grad_output,
-                                               const XlaValue& input);
+torch::lazy::NodePtr Dot(const torch::lazy::Value& input,
+                         const torch::lazy::Value& weight);
 
-torch::lazy::NodePtr ComparisonOp(c10::Symbol kind, const XlaValue& input,
-                                  const XlaValue& other);
+torch::lazy::NodePtr MatMul(const torch::lazy::Value& lhs,
+                            const torch::lazy::Value& rhs);
 
-torch::lazy::NodePtr Where(const XlaValue& condition, const XlaValue& input,
-                           const XlaValue& other);
+torch::lazy::NodePtr AdaptiveMaxPool2dBackward(
+    const torch::lazy::Value& grad_output, const torch::lazy::Value& input);
+
+torch::lazy::NodePtr AdaptiveAvgPool2dBackward(
+    const torch::lazy::Value& grad_output, const torch::lazy::Value& input);
+
+torch::lazy::NodePtr AdaptiveAvgPool3dBackward(
+    const torch::lazy::Value& grad_output, const torch::lazy::Value& input);
+
+torch::lazy::NodePtr ComparisonOp(c10::Symbol kind,
+                                  const torch::lazy::Value& input,
+                                  const torch::lazy::Value& other);
+
+torch::lazy::NodePtr Where(const torch::lazy::Value& condition,
+                           const torch::lazy::Value& input,
+                           const torch::lazy::Value& other);
 
 torch::lazy::NodePtr ARange(const at::Scalar& start, const at::Scalar& end,
                             const at::Scalar& step, at::ScalarType scalar_type);
 
-torch::lazy::NodePtr BroadcastTensors(absl::Span<const XlaValue> tensors);
+torch::lazy::NodePtr BroadcastTensors(
+    absl::Span<const torch::lazy::Value> tensors);
 
-torch::lazy::NodePtr Norm(const XlaValue& input,
+torch::lazy::NodePtr Norm(const torch::lazy::Value& input,
                           const c10::optional<at::Scalar>& p,
                           c10::optional<at::ScalarType> dtype,
                           absl::Span<const int64_t> dims, bool keepdim);
@@ -186,73 +210,89 @@ torch::lazy::NodePtr Norm(const XlaValue& input,
 torch::lazy::NodePtr Identity(int64_t lines, int64_t cols,
                               xla::PrimitiveType element_type);
 
-torch::lazy::NodePtr Elu(const XlaValue& input, const at::Scalar& alpha,
-                         const at::Scalar& scale,
+torch::lazy::NodePtr Elu(const torch::lazy::Value& input,
+                         const at::Scalar& alpha, const at::Scalar& scale,
                          const at::Scalar& input_scale);
 
-torch::lazy::NodePtr EluBackward(const XlaValue& grad_output,
-                                 const XlaValue& output,
+torch::lazy::NodePtr EluBackward(const torch::lazy::Value& grad_output,
+                                 const torch::lazy::Value& output,
                                  const at::Scalar& alpha,
                                  const at::Scalar& scale,
                                  const at::Scalar& input_scale);
 
-torch::lazy::NodePtr Gelu(const XlaValue& input);
+torch::lazy::NodePtr Gelu(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr GeluBackward(const XlaValue& grad, const XlaValue& input);
+torch::lazy::NodePtr GeluBackward(const torch::lazy::Value& grad,
+                                  const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Lshift(const XlaValue& input, const at::Scalar& other);
+torch::lazy::NodePtr Lshift(const torch::lazy::Value& input,
+                            const at::Scalar& other);
 
-torch::lazy::NodePtr Lshift(const XlaValue& input, const XlaValue& other);
+torch::lazy::NodePtr Lshift(const torch::lazy::Value& input,
+                            const torch::lazy::Value& other);
 
-torch::lazy::NodePtr Rshift(const XlaValue& input, const at::Scalar& other);
+torch::lazy::NodePtr Rshift(const torch::lazy::Value& input,
+                            const at::Scalar& other);
 
-torch::lazy::NodePtr Rshift(const XlaValue& input, const XlaValue& other);
+torch::lazy::NodePtr Rshift(const torch::lazy::Value& input,
+                            const torch::lazy::Value& other);
 
-torch::lazy::NodePtr Remainder(const XlaValue& input, const XlaValue& divisor);
+torch::lazy::NodePtr Remainder(const torch::lazy::Value& input,
+                               const torch::lazy::Value& divisor);
 
-torch::lazy::NodePtr MaxUnary(const XlaValue& input);
+torch::lazy::NodePtr MaxUnary(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr MinUnary(const XlaValue& input);
+torch::lazy::NodePtr MinUnary(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Take(const XlaValue& input, const XlaValue& index);
+torch::lazy::NodePtr Take(const torch::lazy::Value& input,
+                          const torch::lazy::Value& index);
 
-torch::lazy::NodePtr TanhGelu(const XlaValue& input);
+torch::lazy::NodePtr TanhGelu(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr TanhGeluBackward(const XlaValue& grad,
-                                      const XlaValue& input);
+torch::lazy::NodePtr TanhGeluBackward(const torch::lazy::Value& grad,
+                                      const torch::lazy::Value& input);
 
-torch::lazy::NodePtr LogDet(const XlaValue& input);
+torch::lazy::NodePtr LogDet(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Inverse(const XlaValue& input);
+torch::lazy::NodePtr Inverse(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr IsNan(const XlaValue& input);
+torch::lazy::NodePtr IsNan(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr BaddBmm(const XlaValue& lhs, const XlaValue& rhs,
-                             const XlaValue& bias,
-                             const XlaValue& product_multiplier,
-                             const XlaValue& bias_multiplier);
+torch::lazy::NodePtr BaddBmm(const torch::lazy::Value& lhs,
+                             const torch::lazy::Value& rhs,
+                             const torch::lazy::Value& bias,
+                             const torch::lazy::Value& product_multiplier,
+                             const torch::lazy::Value& bias_multiplier);
 
-torch::lazy::NodePtr Lerp(const XlaValue& start, const XlaValue& end,
-                          const XlaValue& weight);
+torch::lazy::NodePtr Lerp(const torch::lazy::Value& start,
+                          const torch::lazy::Value& end,
+                          const torch::lazy::Value& weight);
 
-torch::lazy::NodePtr LogicalNot(const XlaValue& input);
+torch::lazy::NodePtr LogicalNot(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr LogicalXor(const XlaValue& input, const XlaValue& other);
+torch::lazy::NodePtr LogicalXor(const torch::lazy::Value& input,
+                                const torch::lazy::Value& other);
 
-torch::lazy::NodePtr LogicalAnd(const XlaValue& input, const XlaValue& other);
+torch::lazy::NodePtr LogicalAnd(const torch::lazy::Value& input,
+                                const torch::lazy::Value& other);
 
-torch::lazy::NodePtr LogicalOr(const XlaValue& input, const XlaValue& other);
+torch::lazy::NodePtr LogicalOr(const torch::lazy::Value& input,
+                               const torch::lazy::Value& other);
 
-torch::lazy::NodePtr XLogY(const XlaValue& input, const XlaValue& other);
+torch::lazy::NodePtr XLogY(const torch::lazy::Value& input,
+                           const torch::lazy::Value& other);
 
-torch::lazy::NodePtr NanToNum(const XlaValue& input, const XlaValue& nan,
-                              const XlaValue& posinf, const XlaValue& neginf);
+torch::lazy::NodePtr NanToNum(const torch::lazy::Value& input,
+                              const torch::lazy::Value& nan,
+                              const torch::lazy::Value& posinf,
+                              const torch::lazy::Value& neginf);
 
-torch::lazy::NodePtr SLogDet(const XlaValue& input);
+torch::lazy::NodePtr SLogDet(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Softplus(const XlaValue& input, const XlaValue& beta,
-                              const XlaValue& threshold);
+torch::lazy::NodePtr Softplus(const torch::lazy::Value& input,
+                              const torch::lazy::Value& beta,
+                              const torch::lazy::Value& threshold);
 
-torch::lazy::NodePtr Selu(const XlaValue& input);
+torch::lazy::NodePtr Selu(const torch::lazy::Value& input);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -4,36 +4,59 @@
 
 namespace torch_xla {
 
-xla::Shape AbsOutputShape(const XlaValue& input) { return input.xla_shape(); }
+xla::Shape AbsOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
+}
 
-xla::Shape AcosOutputShape(const XlaValue& input) { return input.xla_shape(); }
+xla::Shape AcosOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
+}
 
-xla::Shape AcoshOutputShape(const XlaValue& input) { return input.xla_shape(); }
+xla::Shape AcoshOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
+}
 
-xla::Shape AsinOutputShape(const XlaValue& input) { return input.xla_shape(); }
+xla::Shape AsinOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
+}
 
-xla::Shape AsinhOutputShape(const XlaValue& input) { return input.xla_shape(); }
+xla::Shape AsinhOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
+}
 
-xla::Shape AtanOutputShape(const XlaValue& input) { return input.xla_shape(); }
+xla::Shape AtanOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
+}
 
-xla::Shape AtanhOutputShape(const XlaValue& input) { return input.xla_shape(); }
+xla::Shape AtanhOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
+}
 
-xla::Shape CosOutputShape(const XlaValue& input) { return input.xla_shape(); }
+xla::Shape CosOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
+}
 
-xla::Shape CoshOutputShape(const XlaValue& input) { return input.xla_shape(); }
+xla::Shape CoshOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
+}
 
-xla::Shape MaximumOutputShape(const XlaValue& input, const XlaValue& other) {
+xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
+                              const torch::lazy::Value& other) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     auto promoted = XlaHelpers::Promote(operands[0], operands[1]);
     return xla::Max(promoted.first, promoted.second);
   };
-  return InferOutputShape({input.xla_shape(), other.xla_shape()},
+  return InferOutputShape({GetXlaShape(input), GetXlaShape(other)},
                           lower_for_shape_fn);
 }
 
-xla::Shape SgnOutputShape(const XlaValue& input) { return input.xla_shape(); }
+xla::Shape SgnOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
+}
 
-xla::Shape SignOutputShape(const XlaValue& input) { return input.xla_shape(); }
+xla::Shape SignOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
+}
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -3,28 +3,29 @@
 
 namespace torch_xla {
 
-xla::Shape AbsOutputShape(const XlaValue& input);
+xla::Shape AbsOutputShape(const torch::lazy::Value& input);
 
-xla::Shape AcosOutputShape(const XlaValue& input);
+xla::Shape AcosOutputShape(const torch::lazy::Value& input);
 
-xla::Shape AcoshOutputShape(const XlaValue& input);
+xla::Shape AcoshOutputShape(const torch::lazy::Value& input);
 
-xla::Shape AsinOutputShape(const XlaValue& input);
+xla::Shape AsinOutputShape(const torch::lazy::Value& input);
 
-xla::Shape AsinhOutputShape(const XlaValue& input);
+xla::Shape AsinhOutputShape(const torch::lazy::Value& input);
 
-xla::Shape AtanOutputShape(const XlaValue& input);
+xla::Shape AtanOutputShape(const torch::lazy::Value& input);
 
-xla::Shape AtanhOutputShape(const XlaValue& input);
+xla::Shape AtanhOutputShape(const torch::lazy::Value& input);
 
-xla::Shape CosOutputShape(const XlaValue& input);
+xla::Shape CosOutputShape(const torch::lazy::Value& input);
 
-xla::Shape CoshOutputShape(const XlaValue& input);
+xla::Shape CoshOutputShape(const torch::lazy::Value& input);
 
-xla::Shape MaximumOutputShape(const XlaValue& input, const XlaValue& other);
+xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
+                              const torch::lazy::Value& other);
 
-xla::Shape SgnOutputShape(const XlaValue& input);
+xla::Shape SgnOutputShape(const torch::lazy::Value& input);
 
-xla::Shape SignOutputShape(const XlaValue& input);
+xla::Shape SignOutputShape(const torch::lazy::Value& input);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/optimization_barrier.cpp
+++ b/torch_xla/csrc/ops/optimization_barrier.cpp
@@ -13,7 +13,7 @@ xla::Shape NodeOutputShape(const OpList& inputs) {
   std::vector<xla::Shape> output_shapes;
   output_shapes.reserve(inputs.size());
   for (size_t i = 0; i < inputs.size(); ++i) {
-    output_shapes.push_back(inputs[i].xla_shape());
+    output_shapes.push_back(GetXlaShape(inputs[i]));
   }
   return xla::ShapeUtil::MakeTupleShape(output_shapes);
 }

--- a/torch_xla/csrc/ops/permute.cpp
+++ b/torch_xla/csrc/ops/permute.cpp
@@ -8,19 +8,19 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            absl::Span<const int64_t> dims) {
   auto lower_for_shape_fn =
       [dims](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     XLA_CHECK_EQ(operands.size(), 1);
     return xla::Transpose(operands[0], dims);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-Permute::Permute(const XlaValue& input, std::vector<int64_t> dims)
+Permute::Permute(const torch::lazy::Value& input, std::vector<int64_t> dims)
     : XlaNode(torch::lazy::OpKind(at::aten::permute), {input},
               [&]() { return NodeOutputShape(input, dims); },
               /*num_outputs=*/1, torch::lazy::MHash(dims)),

--- a/torch_xla/csrc/ops/permute.h
+++ b/torch_xla/csrc/ops/permute.h
@@ -7,7 +7,7 @@ namespace torch_xla {
 
 class Permute : public XlaNode {
  public:
-  Permute(const XlaValue& input, std::vector<int64_t> dims);
+  Permute(const torch::lazy::Value& input, std::vector<int64_t> dims);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/prod.cpp
+++ b/torch_xla/csrc/ops/prod.cpp
@@ -27,7 +27,7 @@ xla::XlaOp LowerProd(xla::XlaOp input, const std::vector<int64_t>& dimensions,
   return BuildProd(casted_input, dimensions, keep_reduced_dimensions);
 }
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            std::vector<int64_t>& dimensions,
                            bool keep_reduced_dimensions,
                            c10::optional<at::ScalarType> dtype) {
@@ -35,12 +35,12 @@ xla::Shape NodeOutputShape(const XlaValue& input,
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return LowerProd(operands[0], dimensions, keep_reduced_dimensions, dtype);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-Prod::Prod(const XlaValue& input, std::vector<int64_t> dimensions,
+Prod::Prod(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
            bool keep_reduced_dimensions, c10::optional<at::ScalarType> dtype)
     : XlaNode(torch::lazy::OpKind(at::aten::prod), {input},
               [&]() {

--- a/torch_xla/csrc/ops/prod.h
+++ b/torch_xla/csrc/ops/prod.h
@@ -10,7 +10,7 @@ namespace torch_xla {
 
 class Prod : public XlaNode {
  public:
-  Prod(const XlaValue& input, std::vector<int64_t> dimensions,
+  Prod(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
        bool keep_reduced_dimensions, c10::optional<at::ScalarType> dtype);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/put.cpp
+++ b/torch_xla/csrc/ops/put.cpp
@@ -5,10 +5,10 @@
 
 namespace torch_xla {
 
-Put::Put(const XlaValue& input, const XlaValue& index, const XlaValue& source,
-         bool accumulate)
+Put::Put(const torch::lazy::Value& input, const torch::lazy::Value& index,
+         const torch::lazy::Value& source, bool accumulate)
     : XlaNode(torch::lazy::OpKind(at::aten::put), {input, index, source},
-              input.xla_shape(),
+              GetXlaShape(input),
               /*num_outputs=*/1, torch::lazy::MHash(accumulate)),
       accumulate_(accumulate) {}
 

--- a/torch_xla/csrc/ops/put.h
+++ b/torch_xla/csrc/ops/put.h
@@ -6,8 +6,8 @@ namespace torch_xla {
 
 class Put : public XlaNode {
  public:
-  Put(const XlaValue& input, const XlaValue& index, const XlaValue& source,
-      bool accumulate);
+  Put(const torch::lazy::Value& input, const torch::lazy::Value& index,
+      const torch::lazy::Value& source, bool accumulate);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/qr.cpp
+++ b/torch_xla/csrc/ops/qr.cpp
@@ -16,8 +16,8 @@ std::vector<xla::XlaOp> LowerQR(xla::XlaOp input, bool some) {
   return {q, r};
 }
 
-xla::Shape NodeOutputShape(const XlaValue& input, bool some) {
-  const xla::Shape& input_shape = input.xla_shape();
+xla::Shape NodeOutputShape(const torch::lazy::Value& input, bool some) {
+  const xla::Shape& input_shape = GetXlaShape(input);
   XLA_CHECK_GE(input_shape.rank(), 2) << input_shape;
   // The input tensor is ..., M, N
   int64_t m_dim = input_shape.dimensions(input_shape.rank() - 2);
@@ -39,7 +39,7 @@ xla::Shape NodeOutputShape(const XlaValue& input, bool some) {
 
 }  // namespace
 
-QR::QR(const XlaValue& input, bool some)
+QR::QR(const torch::lazy::Value& input, bool some)
     : XlaNode(torch::lazy::OpKind(at::aten::qr), {input},
               [&]() { return NodeOutputShape(input, some); },
               /*num_outputs=*/2, torch::lazy::MHash(some)),

--- a/torch_xla/csrc/ops/qr.h
+++ b/torch_xla/csrc/ops/qr.h
@@ -6,7 +6,7 @@ namespace torch_xla {
 
 class QR : public XlaNode {
  public:
-  QR(const XlaValue& input, bool some);
+  QR(const torch::lazy::Value& input, bool some);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/recv.cpp
+++ b/torch_xla/csrc/ops/recv.cpp
@@ -10,19 +10,19 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& token, const xla::Shape& recv_shape,
-                           int64_t channel_id) {
+xla::Shape NodeOutputShape(const torch::lazy::Value& token,
+                           const xla::Shape& recv_shape, int64_t channel_id) {
   auto shape_fn = [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     xla::XlaOp tokenOp = operands[0];
     RecvResult result = BuildRecvWithToken(tokenOp, recv_shape, channel_id);
     return xla::Tuple(tokenOp.builder(), {result.result, result.token});
   };
-  return InferOutputShape({recv_shape, token.xla_shape()}, shape_fn);
+  return InferOutputShape({recv_shape, GetXlaShape(token)}, shape_fn);
 }
 
 }  // namespace
 
-Recv::Recv(const XlaValue& token, const xla::Shape& recv_shape,
+Recv::Recv(const torch::lazy::Value& token, const xla::Shape& recv_shape,
            int64_t channel_id)
     : XlaNode(xla_recv, {token},
               [&]() { return NodeOutputShape(token, recv_shape, channel_id); },

--- a/torch_xla/csrc/ops/recv.h
+++ b/torch_xla/csrc/ops/recv.h
@@ -9,7 +9,8 @@ namespace ops {
 
 class Recv : public XlaNode {
  public:
-  Recv(const XlaValue& token, const xla::Shape& recv_shape, int64_t channel_id);
+  Recv(const torch::lazy::Value& token, const xla::Shape& recv_shape,
+       int64_t channel_id);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/reduce_scatter.cpp
+++ b/torch_xla/csrc/ops/reduce_scatter.cpp
@@ -10,8 +10,9 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(AllReduceType reduce_type, const XlaValue input,
-                           const XlaValue& token, double scale,
+xla::Shape NodeOutputShape(AllReduceType reduce_type,
+                           const torch::lazy::Value input,
+                           const torch::lazy::Value& token, double scale,
                            int64_t scatter_dim, int64_t shard_count,
                            const std::vector<std::vector<int64_t>>& groups,
                            bool pin_layout) {
@@ -23,13 +24,14 @@ xla::Shape NodeOutputShape(AllReduceType reduce_type, const XlaValue input,
                            shard_count, groups, pin_layout);
     return xla::Tuple(operands[0].builder(), {result.result, result.token});
   };
-  return InferOutputShape({input.xla_shape(), token.xla_shape()}, shape_fn);
+  return InferOutputShape({GetXlaShape(input), GetXlaShape(token)}, shape_fn);
 }
 
 }  // namespace
 
-ReduceScatter::ReduceScatter(AllReduceType reduce_type, const XlaValue& input,
-                             const XlaValue& token, double scale,
+ReduceScatter::ReduceScatter(AllReduceType reduce_type,
+                             const torch::lazy::Value& input,
+                             const torch::lazy::Value& token, double scale,
                              int64_t scatter_dim, int64_t shard_count,
                              std::vector<std::vector<int64_t>> groups,
                              bool pin_layout)

--- a/torch_xla/csrc/ops/reduce_scatter.h
+++ b/torch_xla/csrc/ops/reduce_scatter.h
@@ -7,10 +7,10 @@ namespace torch_xla {
 
 class ReduceScatter : public XlaNode {
  public:
-  ReduceScatter(AllReduceType reduce_type, const XlaValue& input,
-                const XlaValue& token, double scale, int64_t scatter_dim,
-                int64_t shard_count, std::vector<std::vector<int64_t>> groups,
-                bool pin_layout);
+  ReduceScatter(AllReduceType reduce_type, const torch::lazy::Value& input,
+                const torch::lazy::Value& token, double scale,
+                int64_t scatter_dim, int64_t shard_count,
+                std::vector<std::vector<int64_t>> groups, bool pin_layout);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/reflection_pad2d.cpp
+++ b/torch_xla/csrc/ops/reflection_pad2d.cpp
@@ -8,18 +8,18 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            absl::Span<const int64_t> padding) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildReflectionPad2d(operands[0], padding);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-ReflectionPad2d::ReflectionPad2d(const XlaValue& input,
+ReflectionPad2d::ReflectionPad2d(const torch::lazy::Value& input,
                                  std::vector<int64_t> padding)
     : XlaNode(torch::lazy::OpKind(at::aten::reflection_pad2d), {input},
               [&]() { return NodeOutputShape(input, padding); },

--- a/torch_xla/csrc/ops/reflection_pad2d.h
+++ b/torch_xla/csrc/ops/reflection_pad2d.h
@@ -8,7 +8,8 @@ namespace torch_xla {
 
 class ReflectionPad2d : public XlaNode {
  public:
-  ReflectionPad2d(const XlaValue& input, std::vector<int64_t> padding);
+  ReflectionPad2d(const torch::lazy::Value& input,
+                  std::vector<int64_t> padding);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/reflection_pad2d_backward.cpp
+++ b/torch_xla/csrc/ops/reflection_pad2d_backward.cpp
@@ -8,21 +8,22 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& grad_output,
+                           const torch::lazy::Value& input,
                            absl::Span<const int64_t> padding) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildReflectionPadBackward(operands[0], operands[1], padding);
   };
-  return InferOutputShape({grad_output.xla_shape(), input.xla_shape()},
+  return InferOutputShape({GetXlaShape(grad_output), GetXlaShape(input)},
                           lower_for_shape_fn);
 }
 
 }  // namespace
 
-ReflectionPad2dBackward::ReflectionPad2dBackward(const XlaValue& grad_output,
-                                                 const XlaValue& input,
-                                                 std::vector<int64_t> padding)
+ReflectionPad2dBackward::ReflectionPad2dBackward(
+    const torch::lazy::Value& grad_output, const torch::lazy::Value& input,
+    std::vector<int64_t> padding)
     : XlaNode(torch::lazy::OpKind(at::aten::reflection_pad2d_backward),
               {grad_output, input},
               [&]() { return NodeOutputShape(grad_output, input, padding); },

--- a/torch_xla/csrc/ops/reflection_pad2d_backward.h
+++ b/torch_xla/csrc/ops/reflection_pad2d_backward.h
@@ -8,7 +8,8 @@ namespace torch_xla {
 
 class ReflectionPad2dBackward : public XlaNode {
  public:
-  ReflectionPad2dBackward(const XlaValue& gard_output, const XlaValue& input,
+  ReflectionPad2dBackward(const torch::lazy::Value& gard_output,
+                          const torch::lazy::Value& input,
                           std::vector<int64_t> padding);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;

--- a/torch_xla/csrc/ops/repeat.cpp
+++ b/torch_xla/csrc/ops/repeat.cpp
@@ -8,19 +8,19 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            absl::Span<const int64_t> repeats) {
   auto lower_for_shape_fn =
       [repeats](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     XLA_CHECK_EQ(operands.size(), 1);
     return BuildRepeat(operands[0], repeats);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-Repeat::Repeat(const XlaValue& input, std::vector<int64_t> repeats)
+Repeat::Repeat(const torch::lazy::Value& input, std::vector<int64_t> repeats)
     : XlaNode(torch::lazy::OpKind(at::aten::repeat), {input},
               [&]() { return NodeOutputShape(input, repeats); },
               /*num_outputs=*/1, torch::lazy::MHash(repeats)),

--- a/torch_xla/csrc/ops/repeat.h
+++ b/torch_xla/csrc/ops/repeat.h
@@ -7,7 +7,7 @@ namespace torch_xla {
 
 class Repeat : public XlaNode {
  public:
-  Repeat(const XlaValue& input, std::vector<int64_t> repeats);
+  Repeat(const torch::lazy::Value& input, std::vector<int64_t> repeats);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/replication_pad.cpp
+++ b/torch_xla/csrc/ops/replication_pad.cpp
@@ -9,17 +9,17 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            absl::Span<const int64_t> padding) {
   auto shape_fn = [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildReplicationPad(operands[0], padding);
   };
-  return InferOutputShape({input.xla_shape()}, shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, shape_fn);
 }
 
 }  // namespace
 
-ReplicationPad::ReplicationPad(const XlaValue& input,
+ReplicationPad::ReplicationPad(const torch::lazy::Value& input,
                                std::vector<int64_t> padding)
     : XlaNode(xla_replication_pad, {input},
               [&]() { return NodeOutputShape(input, padding); },

--- a/torch_xla/csrc/ops/replication_pad.h
+++ b/torch_xla/csrc/ops/replication_pad.h
@@ -7,7 +7,7 @@ namespace torch_xla {
 
 class ReplicationPad : public XlaNode {
  public:
-  ReplicationPad(const XlaValue& input, std::vector<int64_t> padding);
+  ReplicationPad(const torch::lazy::Value& input, std::vector<int64_t> padding);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/replication_pad_backward.cpp
+++ b/torch_xla/csrc/ops/replication_pad_backward.cpp
@@ -9,21 +9,22 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& grad_output, const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& grad_output,
+                           const torch::lazy::Value& input,
                            absl::Span<const int64_t> padding) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildReplicationPadBackward(operands[0], operands[1], padding);
   };
-  return InferOutputShape({grad_output.xla_shape(), input.xla_shape()},
+  return InferOutputShape({GetXlaShape(grad_output), GetXlaShape(input)},
                           lower_for_shape_fn);
 }
 
 }  // namespace
 
-ReplicationPadBackward::ReplicationPadBackward(const XlaValue& grad_output,
-                                               const XlaValue& input,
-                                               std::vector<int64_t> padding)
+ReplicationPadBackward::ReplicationPadBackward(
+    const torch::lazy::Value& grad_output, const torch::lazy::Value& input,
+    std::vector<int64_t> padding)
     : XlaNode(xla_replication_pad_backward, {grad_output, input},
               [&]() { return NodeOutputShape(grad_output, input, padding); },
               /*num_outputs=*/1, torch::lazy::MHash(padding)),

--- a/torch_xla/csrc/ops/replication_pad_backward.h
+++ b/torch_xla/csrc/ops/replication_pad_backward.h
@@ -8,7 +8,8 @@ namespace torch_xla {
 
 class ReplicationPadBackward : public XlaNode {
  public:
-  ReplicationPadBackward(const XlaValue& gard_output, const XlaValue& input,
+  ReplicationPadBackward(const torch::lazy::Value& gard_output,
+                         const torch::lazy::Value& input,
                          std::vector<int64_t> padding);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;

--- a/torch_xla/csrc/ops/resize.cpp
+++ b/torch_xla/csrc/ops/resize.cpp
@@ -8,14 +8,14 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            absl::Span<const int64_t> size) {
-  return xla::ShapeUtil::MakeShape(input.xla_shape().element_type(), size);
+  return xla::ShapeUtil::MakeShape(GetXlaShape(input).element_type(), size);
 }
 
 }  // namespace
 
-Resize::Resize(const XlaValue& input, std::vector<int64_t> size)
+Resize::Resize(const torch::lazy::Value& input, std::vector<int64_t> size)
     : XlaNode(torch::lazy::OpKind(at::aten::resize), {input},
               [&]() { return NodeOutputShape(input, size); },
               /*num_outputs=*/1, torch::lazy::MHash(size)),

--- a/torch_xla/csrc/ops/resize.h
+++ b/torch_xla/csrc/ops/resize.h
@@ -6,7 +6,7 @@ namespace torch_xla {
 
 class Resize : public XlaNode {
  public:
-  Resize(const XlaValue& input, std::vector<int64_t> size);
+  Resize(const torch::lazy::Value& input, std::vector<int64_t> size);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/roll.cpp
+++ b/torch_xla/csrc/ops/roll.cpp
@@ -4,9 +4,9 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 namespace torch_xla {
 
-Roll::Roll(const XlaValue& input, std::vector<int64_t> shifts,
+Roll::Roll(const torch::lazy::Value& input, std::vector<int64_t> shifts,
            std::vector<int64_t> dims)
-    : XlaNode(torch::lazy::OpKind(at::aten::roll), {input}, input.xla_shape(),
+    : XlaNode(torch::lazy::OpKind(at::aten::roll), {input}, GetXlaShape(input),
               /*num_outputs=*/1, torch::lazy::MHash(shifts, dims)),
       shifts_(std::move(shifts)),
       dims_(std::move(dims)) {}

--- a/torch_xla/csrc/ops/roll.h
+++ b/torch_xla/csrc/ops/roll.h
@@ -6,7 +6,7 @@ namespace torch_xla {
 
 class Roll : public XlaNode {
  public:
-  Roll(const XlaValue& input, std::vector<int64_t> shifts,
+  Roll(const torch::lazy::Value& input, std::vector<int64_t> shifts,
        std::vector<int64_t> dims);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;

--- a/torch_xla/csrc/ops/rrelu_with_noise.cpp
+++ b/torch_xla/csrc/ops/rrelu_with_noise.cpp
@@ -7,13 +7,14 @@
 
 namespace torch_xla {
 
-RreluWithNoise::RreluWithNoise(const XlaValue& input, const XlaValue& seed,
+RreluWithNoise::RreluWithNoise(const torch::lazy::Value& input,
+                               const torch::lazy::Value& seed,
                                const at::Scalar& lower, const at::Scalar& upper,
                                bool training)
     : XlaNode(
           torch::lazy::OpKind(at::aten::rrelu_with_noise), {input, seed},
           xla::ShapeUtil::MakeTupleShape(
-              {input.xla_shape(), input.xla_shape()}),
+              {GetXlaShape(input), GetXlaShape(input)}),
           /*num_outputs=*/2,
           torch::lazy::MHash(ScalarHash(lower), ScalarHash(upper), training)),
       lower_(std::move(lower)),

--- a/torch_xla/csrc/ops/rrelu_with_noise.h
+++ b/torch_xla/csrc/ops/rrelu_with_noise.h
@@ -9,9 +9,9 @@ namespace torch_xla {
 
 class RreluWithNoise : public XlaNode {
  public:
-  RreluWithNoise(const XlaValue& input, const XlaValue& seed,
-                 const at::Scalar& lower, const at::Scalar& upper,
-                 bool training);
+  RreluWithNoise(const torch::lazy::Value& input,
+                 const torch::lazy::Value& seed, const at::Scalar& lower,
+                 const at::Scalar& upper, bool training);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/rrelu_with_noise_backward.cpp
+++ b/torch_xla/csrc/ops/rrelu_with_noise_backward.cpp
@@ -7,11 +7,12 @@
 namespace torch_xla {
 
 RreluWithNoiseBackward::RreluWithNoiseBackward(
-    const XlaValue& grad_output, const XlaValue& input, const XlaValue& noise,
-    const at::Scalar& lower, const at::Scalar& upper, bool training)
+    const torch::lazy::Value& grad_output, const torch::lazy::Value& input,
+    const torch::lazy::Value& noise, const at::Scalar& lower,
+    const at::Scalar& upper, bool training)
     : XlaNode(
           torch::lazy::OpKind(at::aten::rrelu_with_noise_backward),
-          {grad_output, input, noise}, input.xla_shape(),
+          {grad_output, input, noise}, GetXlaShape(input),
           /*num_outputs=*/1,
           torch::lazy::MHash(ScalarHash(lower), ScalarHash(upper), training)),
       lower_(std::move(lower)),

--- a/torch_xla/csrc/ops/rrelu_with_noise_backward.h
+++ b/torch_xla/csrc/ops/rrelu_with_noise_backward.h
@@ -8,9 +8,11 @@ namespace torch_xla {
 
 class RreluWithNoiseBackward : public XlaNode {
  public:
-  RreluWithNoiseBackward(const XlaValue& grad_output, const XlaValue& input,
-                         const XlaValue& noise, const at::Scalar& lower,
-                         const at::Scalar& upper, bool training);
+  RreluWithNoiseBackward(const torch::lazy::Value& grad_output,
+                         const torch::lazy::Value& input,
+                         const torch::lazy::Value& noise,
+                         const at::Scalar& lower, const at::Scalar& upper,
+                         bool training);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/scatter.cpp
+++ b/torch_xla/csrc/ops/scatter.cpp
@@ -5,10 +5,11 @@
 
 namespace torch_xla {
 
-Scatter::Scatter(const XlaValue& input, const XlaValue& index,
-                 const XlaValue& src, int64_t dim)
+Scatter::Scatter(const torch::lazy::Value& input,
+                 const torch::lazy::Value& index, const torch::lazy::Value& src,
+                 int64_t dim)
     : XlaNode(torch::lazy::OpKind(at::aten::scatter), {input, index, src},
-              input.xla_shape(),
+              GetXlaShape(input),
               /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}
 

--- a/torch_xla/csrc/ops/scatter.h
+++ b/torch_xla/csrc/ops/scatter.h
@@ -6,8 +6,8 @@ namespace torch_xla {
 
 class Scatter : public XlaNode {
  public:
-  Scatter(const XlaValue& input, const XlaValue& index, const XlaValue& src,
-          int64_t dim);
+  Scatter(const torch::lazy::Value& input, const torch::lazy::Value& index,
+          const torch::lazy::Value& src, int64_t dim);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/scatter_add.cpp
+++ b/torch_xla/csrc/ops/scatter_add.cpp
@@ -7,10 +7,11 @@
 
 namespace torch_xla {
 
-ScatterAdd::ScatterAdd(const XlaValue& input, const XlaValue& index,
-                       const XlaValue& src, int64_t dim)
+ScatterAdd::ScatterAdd(const torch::lazy::Value& input,
+                       const torch::lazy::Value& index,
+                       const torch::lazy::Value& src, int64_t dim)
     : XlaNode(torch::lazy::OpKind(at::aten::scatter_add), {input, index, src},
-              input.xla_shape(),
+              GetXlaShape(input),
               /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}
 

--- a/torch_xla/csrc/ops/scatter_add.h
+++ b/torch_xla/csrc/ops/scatter_add.h
@@ -6,8 +6,8 @@ namespace torch_xla {
 
 class ScatterAdd : public XlaNode {
  public:
-  ScatterAdd(const XlaValue& input, const XlaValue& index, const XlaValue& src,
-             int64_t dim);
+  ScatterAdd(const torch::lazy::Value& input, const torch::lazy::Value& index,
+             const torch::lazy::Value& src, int64_t dim);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/select.cpp
+++ b/torch_xla/csrc/ops/select.cpp
@@ -6,11 +6,11 @@
 
 namespace torch_xla {
 
-Select::Select(const XlaValue& input, int64_t dim, int64_t start, int64_t end,
-               int64_t stride)
+Select::Select(const torch::lazy::Value& input, int64_t dim, int64_t start,
+               int64_t end, int64_t stride)
     : XlaNode(xla_select, {input},
               [&]() {
-                return MakeSelectShape(input.xla_shape(), dim, start, end,
+                return MakeSelectShape(GetXlaShape(input), dim, start, end,
                                        stride);
               },
               /*num_outputs=*/1, torch::lazy::MHash(dim, start, end, stride)),

--- a/torch_xla/csrc/ops/select.h
+++ b/torch_xla/csrc/ops/select.h
@@ -6,8 +6,8 @@ namespace torch_xla {
 
 class Select : public XlaNode {
  public:
-  Select(const XlaValue& input, int64_t dim, int64_t start, int64_t end,
-         int64_t stride);
+  Select(const torch::lazy::Value& input, int64_t dim, int64_t start,
+         int64_t end, int64_t stride);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/send.cpp
+++ b/torch_xla/csrc/ops/send.cpp
@@ -10,7 +10,8 @@ namespace ir {
 namespace ops {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& token,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
+                           const torch::lazy::Value& token,
                            int64_t channel_id) {
   auto shape_fn =
       [channel_id](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
@@ -20,12 +21,13 @@ xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& token,
     return xla::Tuple(tokenOp.builder(),
                       {result.input_as_result, result.token});
   };
-  return InferOutputShape({input.xla_shape(), token.xla_shape()}, shape_fn);
+  return InferOutputShape({GetXlaShape(input), GetXlaShape(token)}, shape_fn);
 }
 
 }  // namespace
 
-Send::Send(const XlaValue& input, const XlaValue& token, int64_t channel_id)
+Send::Send(const torch::lazy::Value& input, const torch::lazy::Value& token,
+           int64_t channel_id)
     : XlaNode(xla_send, {input, token},
               [&]() { return NodeOutputShape(input, token, channel_id); },
               /*num_outputs=*/2, torch::lazy::MHash(channel_id)),

--- a/torch_xla/csrc/ops/send.h
+++ b/torch_xla/csrc/ops/send.h
@@ -9,7 +9,8 @@ namespace ops {
 
 class Send : public XlaNode {
  public:
-  Send(const XlaValue& input, const XlaValue& token, int64_t channel_id);
+  Send(const torch::lazy::Value& input, const torch::lazy::Value& token,
+       int64_t channel_id);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/sgd_optimizer_step.cpp
+++ b/torch_xla/csrc/ops/sgd_optimizer_step.cpp
@@ -7,19 +7,22 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& step, const XlaValue& param) {
-  return xla::ShapeUtil::MakeTupleShape({/*step=*/step.xla_shape(),
-                                         /*param=*/param.xla_shape(),
-                                         /*buf=*/param.xla_shape()});
+xla::Shape NodeOutputShape(const torch::lazy::Value& step,
+                           const torch::lazy::Value& param) {
+  return xla::ShapeUtil::MakeTupleShape({/*step=*/GetXlaShape(step),
+                                         /*param=*/GetXlaShape(param),
+                                         /*buf=*/GetXlaShape(param)});
 }
 
 }  // namespace
 
 SgdOptimizerStep::SgdOptimizerStep(
-    const XlaValue& found_inf, const XlaValue& step, const XlaValue& param,
-    const XlaValue& buf, const XlaValue& d_p, const XlaValue& weight_decay,
-    const XlaValue& momentum, const XlaValue& lr, const XlaValue& dampening,
-    bool use_weight_decay, bool use_momentum, bool use_nesterov)
+    const torch::lazy::Value& found_inf, const torch::lazy::Value& step,
+    const torch::lazy::Value& param, const torch::lazy::Value& buf,
+    const torch::lazy::Value& d_p, const torch::lazy::Value& weight_decay,
+    const torch::lazy::Value& momentum, const torch::lazy::Value& lr,
+    const torch::lazy::Value& dampening, bool use_weight_decay,
+    bool use_momentum, bool use_nesterov)
     : XlaNode(xla_sgd_optimizer_step,
               {found_inf, step, param, buf, d_p, weight_decay, momentum, lr,
                dampening},

--- a/torch_xla/csrc/ops/sgd_optimizer_step.h
+++ b/torch_xla/csrc/ops/sgd_optimizer_step.h
@@ -6,11 +6,14 @@ namespace torch_xla {
 
 class SgdOptimizerStep : public XlaNode {
  public:
-  SgdOptimizerStep(const XlaValue& found_inf, const XlaValue& step,
-                   const XlaValue& param, const XlaValue& buf,
-                   const XlaValue& d_p, const XlaValue& weight_decay,
-                   const XlaValue& momentum, const XlaValue& lr,
-                   const XlaValue& dampening, bool use_weight_decay,
+  SgdOptimizerStep(const torch::lazy::Value& found_inf,
+                   const torch::lazy::Value& step,
+                   const torch::lazy::Value& param,
+                   const torch::lazy::Value& buf, const torch::lazy::Value& d_p,
+                   const torch::lazy::Value& weight_decay,
+                   const torch::lazy::Value& momentum,
+                   const torch::lazy::Value& lr,
+                   const torch::lazy::Value& dampening, bool use_weight_decay,
                    bool use_momentum, bool use_nesterov);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;

--- a/torch_xla/csrc/ops/shrink_backward.cpp
+++ b/torch_xla/csrc/ops/shrink_backward.cpp
@@ -8,9 +8,10 @@
 namespace torch_xla {
 
 ShrinkBackward::ShrinkBackward(torch::lazy::OpKind kind,
-                               const XlaValue& grad_output,
-                               const XlaValue& input, const at::Scalar& lambda)
-    : XlaNode(kind, {grad_output, input}, input.xla_shape(), /*num_outputs=*/1,
+                               const torch::lazy::Value& grad_output,
+                               const torch::lazy::Value& input,
+                               const at::Scalar& lambda)
+    : XlaNode(kind, {grad_output, input}, GetXlaShape(input), /*num_outputs=*/1,
               ScalarHash(lambda)),
       lambda_(std::move(lambda)) {}
 

--- a/torch_xla/csrc/ops/shrink_backward.h
+++ b/torch_xla/csrc/ops/shrink_backward.h
@@ -8,8 +8,9 @@ namespace torch_xla {
 
 class ShrinkBackward : public XlaNode {
  public:
-  ShrinkBackward(torch::lazy::OpKind kind, const XlaValue& grad_output,
-                 const XlaValue& input, const at::Scalar& lambda);
+  ShrinkBackward(torch::lazy::OpKind kind,
+                 const torch::lazy::Value& grad_output,
+                 const torch::lazy::Value& input, const at::Scalar& lambda);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/softmax.cpp
+++ b/torch_xla/csrc/ops/softmax.cpp
@@ -16,18 +16,18 @@ xla::XlaOp LowerSoftmax(xla::XlaOp input, int64_t dim,
   return CastToScalarType(result, dtype);
 }
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            const c10::optional<at::ScalarType>& dtype) {
   if (dtype) {
     return xla::ShapeUtil::ChangeElementType(
-        input.xla_shape(), MakeXlaPrimitiveType(*dtype, /*device=*/nullptr));
+        GetXlaShape(input), MakeXlaPrimitiveType(*dtype, /*device=*/nullptr));
   }
-  return input.xla_shape();
+  return GetXlaShape(input);
 }
 
 }  // namespace
 
-Softmax::Softmax(const XlaValue& input, int64_t dim,
+Softmax::Softmax(const torch::lazy::Value& input, int64_t dim,
                  c10::optional<at::ScalarType> dtype)
     : XlaNode(torch::lazy::OpKind(at::aten::softmax), {input},
               [&]() { return NodeOutputShape(input, dtype); },

--- a/torch_xla/csrc/ops/softmax.h
+++ b/torch_xla/csrc/ops/softmax.h
@@ -9,7 +9,7 @@ namespace torch_xla {
 
 class Softmax : public XlaNode {
  public:
-  Softmax(const XlaValue& input, int64_t dim,
+  Softmax(const torch::lazy::Value& input, int64_t dim,
           c10::optional<at::ScalarType> dtype);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;

--- a/torch_xla/csrc/ops/softmax_backward.cpp
+++ b/torch_xla/csrc/ops/softmax_backward.cpp
@@ -7,10 +7,10 @@
 
 namespace torch_xla {
 
-SoftmaxBackward::SoftmaxBackward(const XlaValue& grad_output,
-                                 const XlaValue& output, int64_t dim)
+SoftmaxBackward::SoftmaxBackward(const torch::lazy::Value& grad_output,
+                                 const torch::lazy::Value& output, int64_t dim)
     : XlaNode(torch::lazy::OpKind(at::aten::_softmax_backward_data),
-              {grad_output, output}, grad_output.xla_shape(),
+              {grad_output, output}, GetXlaShape(grad_output),
               /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim) {}
 

--- a/torch_xla/csrc/ops/softmax_backward.h
+++ b/torch_xla/csrc/ops/softmax_backward.h
@@ -6,8 +6,8 @@ namespace torch_xla {
 
 class SoftmaxBackward : public XlaNode {
  public:
-  SoftmaxBackward(const XlaValue& grad_output, const XlaValue& output,
-                  int64_t dim);
+  SoftmaxBackward(const torch::lazy::Value& grad_output,
+                  const torch::lazy::Value& output, int64_t dim);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/softshrink.cpp
+++ b/torch_xla/csrc/ops/softshrink.cpp
@@ -7,9 +7,10 @@
 
 namespace torch_xla {
 
-Softshrink::Softshrink(const XlaValue& input, const at::Scalar& lambda)
+Softshrink::Softshrink(const torch::lazy::Value& input,
+                       const at::Scalar& lambda)
     : XlaNode(torch::lazy::OpKind(at::aten::softshrink), {input},
-              input.xla_shape(),
+              GetXlaShape(input),
               /*num_outputs=*/1, ScalarHash(lambda)),
       lambda_(std::move(lambda)) {}
 

--- a/torch_xla/csrc/ops/softshrink.h
+++ b/torch_xla/csrc/ops/softshrink.h
@@ -8,7 +8,7 @@ namespace torch_xla {
 
 class Softshrink : public XlaNode {
  public:
-  Softshrink(const XlaValue& input, const at::Scalar& lambda);
+  Softshrink(const torch::lazy::Value& input, const at::Scalar& lambda);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/split.h
+++ b/torch_xla/csrc/ops/split.h
@@ -9,7 +9,8 @@ namespace torch_xla {
 // Split the tensor into chunks along a given dimension.
 class Split : public XlaNode {
  public:
-  Split(const XlaValue& input, std::vector<int64_t> split_sizes, int64_t dim);
+  Split(const torch::lazy::Value& input, std::vector<int64_t> split_sizes,
+        int64_t dim);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/squeeze.cpp
+++ b/torch_xla/csrc/ops/squeeze.cpp
@@ -16,18 +16,18 @@ xla::XlaOp LowerSqueeze(xla::XlaOp input, int dim) {
   return SqueezeTrivialDimension(input, dim);
 }
 
-xla::Shape NodeOutputShape(const XlaValue& input, int dim) {
+xla::Shape NodeOutputShape(const torch::lazy::Value& input, int dim) {
   auto lower_for_shape_fn =
       [dim](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     XLA_CHECK_EQ(operands.size(), 1);
     return LowerSqueeze(operands[0], dim);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-Squeeze::Squeeze(const XlaValue& input, int dim)
+Squeeze::Squeeze(const torch::lazy::Value& input, int dim)
     : XlaNode(torch::lazy::OpKind(at::aten::squeeze), {input},
               [&]() { return NodeOutputShape(input, dim); },
               /*num_outputs=*/1, torch::lazy::MHash(dim)),

--- a/torch_xla/csrc/ops/squeeze.h
+++ b/torch_xla/csrc/ops/squeeze.h
@@ -7,7 +7,7 @@ namespace torch_xla {
 class Squeeze : public XlaNode {
  public:
   // Squeeze out the specified dimension index, -1 for all trivial dimensions.
-  Squeeze(const XlaValue& input, int dim);
+  Squeeze(const torch::lazy::Value& input, int dim);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/stack.cpp
+++ b/torch_xla/csrc/ops/stack.cpp
@@ -8,7 +8,8 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(absl::Span<const XlaValue> values, int64_t dim) {
+xla::Shape NodeOutputShape(absl::Span<const torch::lazy::Value> values,
+                           int64_t dim) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildStack(operands, dim);
@@ -16,14 +17,14 @@ xla::Shape NodeOutputShape(absl::Span<const XlaValue> values, int64_t dim) {
   std::vector<xla::Shape> shapes;
   shapes.reserve(values.size());
   for (auto& value : values) {
-    shapes.push_back(value.xla_shape());
+    shapes.push_back(GetXlaShape(value));
   }
   return InferOutputShape(shapes, lower_for_shape_fn);
 }
 
 }  // namespace
 
-Stack::Stack(absl::Span<const XlaValue> values, int64_t dim)
+Stack::Stack(absl::Span<const torch::lazy::Value> values, int64_t dim)
     : XlaNode(torch::lazy::OpKind(at::aten::stack), values,
               [&]() { return NodeOutputShape(values, dim); },
               /*num_outputs=*/1, torch::lazy::MHash(dim)),

--- a/torch_xla/csrc/ops/stack.h
+++ b/torch_xla/csrc/ops/stack.h
@@ -7,7 +7,7 @@ namespace torch_xla {
 
 class Stack : public XlaNode {
  public:
-  Stack(absl::Span<const XlaValue> values, int64_t dim);
+  Stack(absl::Span<const torch::lazy::Value> values, int64_t dim);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/std.cpp
+++ b/torch_xla/csrc/ops/std.cpp
@@ -8,7 +8,7 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            std::vector<int64_t>& dimensions,
                            bool keep_reduced_dimensions, int64_t correction) {
   auto lower_for_shape_fn =
@@ -16,12 +16,12 @@ xla::Shape NodeOutputShape(const XlaValue& input,
     return BuildStdDeviation(operands[0], dimensions, keep_reduced_dimensions,
                              correction);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-Std::Std(const XlaValue& input, std::vector<int64_t> dimensions,
+Std::Std(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
          bool keep_reduced_dimensions, int64_t correction)
     : XlaNode(
           torch::lazy::OpKind(at::aten::std), {input},

--- a/torch_xla/csrc/ops/std.h
+++ b/torch_xla/csrc/ops/std.h
@@ -9,7 +9,7 @@ namespace torch_xla {
 
 class Std : public XlaNode {
  public:
-  Std(const XlaValue& input, std::vector<int64_t> dimensions,
+  Std(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
       bool keep_reduced_dimensions, int64_t correction);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/std_mean.cpp
+++ b/torch_xla/csrc/ops/std_mean.cpp
@@ -8,7 +8,7 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            std::vector<int64_t>& dimensions,
                            bool keep_reduced_dimensions, int64_t correction) {
   auto lower_for_shape_fn_std_mean =
@@ -19,13 +19,14 @@ xla::Shape NodeOutputShape(const XlaValue& input,
         BuildMean(operands[0], dimensions, keep_reduced_dimensions);
     return xla::Tuple(operands[0].builder(), {std, mean});
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn_std_mean);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn_std_mean);
 }
 
 }  // namespace
 
-StdMean::StdMean(const XlaValue& input, std::vector<int64_t> dimensions,
-                 int64_t correction, bool keep_reduced_dimensions)
+StdMean::StdMean(const torch::lazy::Value& input,
+                 std::vector<int64_t> dimensions, int64_t correction,
+                 bool keep_reduced_dimensions)
     : XlaNode(
           torch::lazy::OpKind(at::aten::std_mean), {input},
           [&]() {

--- a/torch_xla/csrc/ops/std_mean.h
+++ b/torch_xla/csrc/ops/std_mean.h
@@ -9,7 +9,7 @@ namespace torch_xla {
 
 class StdMean : public XlaNode {
  public:
-  StdMean(const XlaValue& input, std::vector<int64_t> dimensions,
+  StdMean(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
           int64_t correction, bool keep_reduced_dimensions);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/sum.cpp
+++ b/torch_xla/csrc/ops/sum.cpp
@@ -20,7 +20,7 @@ xla::XlaOp LowerSum(xla::XlaOp input, absl::Span<const int64_t> dimensions,
                   keep_reduced_dimensions);
 }
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            absl::Span<const int64_t> dimensions,
                            bool keep_reduced_dimensions,
                            c10::optional<at::ScalarType> dtype) {
@@ -28,12 +28,12 @@ xla::Shape NodeOutputShape(const XlaValue& input,
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return LowerSum(operands[0], dimensions, keep_reduced_dimensions, dtype);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-Sum::Sum(const XlaValue& input, std::vector<int64_t> dimensions,
+Sum::Sum(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
          bool keep_reduced_dimensions, c10::optional<at::ScalarType> dtype)
     : XlaNode(torch::lazy::OpKind(at::aten::sum), {input},
               [&]() {

--- a/torch_xla/csrc/ops/sum.h
+++ b/torch_xla/csrc/ops/sum.h
@@ -10,7 +10,7 @@ namespace torch_xla {
 
 class Sum : public XlaNode {
  public:
-  Sum(const XlaValue& input, std::vector<int64_t> dimensions,
+  Sum(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
       bool keep_reduced_dimensions, c10::optional<at::ScalarType> dtype);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/svd.cpp
+++ b/torch_xla/csrc/ops/svd.cpp
@@ -39,8 +39,9 @@ std::vector<xla::XlaOp> LowerSVD(xla::XlaOp input, bool some, bool compute_uv) {
   return {u, svd_result.d, v};
 }
 
-xla::Shape NodeOutputShape(const XlaValue& input, bool some, bool compute_uv) {
-  const xla::Shape& input_shape = input.xla_shape();
+xla::Shape NodeOutputShape(const torch::lazy::Value& input, bool some,
+                           bool compute_uv) {
+  const xla::Shape& input_shape = GetXlaShape(input);
   XLA_CHECK_GE(input_shape.rank(), 2) << input_shape;
   // The input tensor is ...,M,N
   int64_t m_dim = input_shape.dimensions(input_shape.rank() - 2);
@@ -65,7 +66,7 @@ xla::Shape NodeOutputShape(const XlaValue& input, bool some, bool compute_uv) {
 
 }  // namespace
 
-SVD::SVD(const XlaValue& input, bool some, bool compute_uv)
+SVD::SVD(const torch::lazy::Value& input, bool some, bool compute_uv)
     : XlaNode(torch::lazy::OpKind(at::aten::svd), {input},
               [&]() { return NodeOutputShape(input, some, compute_uv); },
               /*num_outputs=*/3, torch::lazy::MHash(some, compute_uv)),

--- a/torch_xla/csrc/ops/svd.h
+++ b/torch_xla/csrc/ops/svd.h
@@ -6,7 +6,7 @@ namespace torch_xla {
 
 class SVD : public XlaNode {
  public:
-  SVD(const XlaValue& input, bool some, bool compute_uv);
+  SVD(const torch::lazy::Value& input, bool some, bool compute_uv);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/symeig.cpp
+++ b/torch_xla/csrc/ops/symeig.cpp
@@ -24,9 +24,9 @@ std::vector<xla::XlaOp> LowerSymEig(xla::XlaOp input, bool eigenvectors,
   return {w, v};
 }
 
-xla::Shape NodeOutputShape(const XlaValue& input, bool eigenvectors,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input, bool eigenvectors,
                            bool lower) {
-  const xla::Shape& input_shape = input.xla_shape();
+  const xla::Shape& input_shape = GetXlaShape(input);
   XLA_CHECK_GE(input_shape.rank(), 2) << input_shape;
   // W is ..., M
   xla::Shape wshape(input_shape);
@@ -44,7 +44,7 @@ xla::Shape NodeOutputShape(const XlaValue& input, bool eigenvectors,
 
 }  // namespace
 
-SymEig::SymEig(const XlaValue& input, bool eigenvectors, bool lower)
+SymEig::SymEig(const torch::lazy::Value& input, bool eigenvectors, bool lower)
     : XlaNode(torch::lazy::OpKind(at::aten::symeig), {input},
               [&]() { return NodeOutputShape(input, eigenvectors, lower); },
               /*num_outputs=*/2, torch::lazy::MHash(eigenvectors, lower)),

--- a/torch_xla/csrc/ops/symeig.h
+++ b/torch_xla/csrc/ops/symeig.h
@@ -6,7 +6,7 @@ namespace torch_xla {
 
 class SymEig : public XlaNode {
  public:
-  SymEig(const XlaValue& input, bool eigenvectors, bool lower);
+  SymEig(const torch::lazy::Value& input, bool eigenvectors, bool lower);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/threshold.cpp
+++ b/torch_xla/csrc/ops/threshold.cpp
@@ -5,9 +5,10 @@
 
 namespace torch_xla {
 
-Threshold::Threshold(const XlaValue& input, float threshold, float value)
+Threshold::Threshold(const torch::lazy::Value& input, float threshold,
+                     float value)
     : XlaNode(torch::lazy::OpKind(at::aten::threshold), {input},
-              input.xla_shape(),
+              GetXlaShape(input),
               /*num_outputs=*/1, torch::lazy::MHash(threshold, value)),
       threshold_(threshold),
       value_(value) {}

--- a/torch_xla/csrc/ops/threshold.h
+++ b/torch_xla/csrc/ops/threshold.h
@@ -7,7 +7,7 @@ namespace torch_xla {
 // IR node for the threshold operation.
 class Threshold : public XlaNode {
  public:
-  Threshold(const XlaValue& input, float threshold, float value);
+  Threshold(const torch::lazy::Value& input, float threshold, float value);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/threshold_backward.cpp
+++ b/torch_xla/csrc/ops/threshold_backward.cpp
@@ -5,10 +5,11 @@
 
 namespace torch_xla {
 
-ThresholdBackward::ThresholdBackward(const XlaValue& grad_output,
-                                     const XlaValue& input, float threshold)
+ThresholdBackward::ThresholdBackward(const torch::lazy::Value& grad_output,
+                                     const torch::lazy::Value& input,
+                                     float threshold)
     : XlaNode(torch::lazy::OpKind(at::aten::threshold_backward),
-              {grad_output, input}, input.xla_shape(), /*num_outputs=*/1,
+              {grad_output, input}, GetXlaShape(input), /*num_outputs=*/1,
               torch::lazy::MHash(threshold)),
       threshold_(threshold) {}
 

--- a/torch_xla/csrc/ops/threshold_backward.h
+++ b/torch_xla/csrc/ops/threshold_backward.h
@@ -6,8 +6,8 @@ namespace torch_xla {
 
 class ThresholdBackward : public XlaNode {
  public:
-  ThresholdBackward(const XlaValue& grad_output, const XlaValue& input,
-                    float threshold);
+  ThresholdBackward(const torch::lazy::Value& grad_output,
+                    const torch::lazy::Value& input, float threshold);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/topk.cpp
+++ b/torch_xla/csrc/ops/topk.cpp
@@ -7,20 +7,21 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input, int64_t k, int64_t dim,
-                           bool largest, bool sorted, bool stable) {
+xla::Shape NodeOutputShape(const torch::lazy::Value& input, int64_t k,
+                           int64_t dim, bool largest, bool sorted,
+                           bool stable) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return xla::Tuple(operands[0].builder(),
                       CreateTopK(operands[0], k, dim, largest, stable));
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-TopK::TopK(const XlaValue& input, int64_t k, int64_t dim, bool largest,
-           bool sorted, bool stable)
+TopK::TopK(const torch::lazy::Value& input, int64_t k, int64_t dim,
+           bool largest, bool sorted, bool stable)
     : XlaNode(torch::lazy::OpKind(at::aten::topk), {input},
               [&]() {
                 return NodeOutputShape(input, k, dim, largest, sorted, stable);

--- a/torch_xla/csrc/ops/topk.h
+++ b/torch_xla/csrc/ops/topk.h
@@ -6,8 +6,8 @@ namespace torch_xla {
 
 class TopK : public XlaNode {
  public:
-  TopK(const XlaValue& input, int64_t k, int64_t dim, bool largest, bool sorted,
-       bool stable);
+  TopK(const torch::lazy::Value& input, int64_t k, int64_t dim, bool largest,
+       bool sorted, bool stable);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/triangular_solve.cpp
+++ b/torch_xla/csrc/ops/triangular_solve.cpp
@@ -62,18 +62,19 @@ std::vector<xla::XlaOp> LowerTriangularSolve(xla::XlaOp rhs, xla::XlaOp lhs,
   return {solution, lhs_broadcasted};
 }
 
-xla::Shape NodeOutputShape(const XlaValue& rhs, const XlaValue& lhs) {
+xla::Shape NodeOutputShape(const torch::lazy::Value& rhs,
+                           const torch::lazy::Value& lhs) {
   std::pair<xla::Shape, xla::Shape> broadcasted_shapes =
-      InferTriangularSolveShape(rhs.xla_shape(), lhs.xla_shape());
+      InferTriangularSolveShape(GetXlaShape(rhs), GetXlaShape(lhs));
   return xla::ShapeUtil::MakeTupleShape(
       {broadcasted_shapes.first, broadcasted_shapes.second});
 }
 
 }  // namespace
 
-TriangularSolve::TriangularSolve(const XlaValue& rhs, const XlaValue& lhs,
-                                 bool left_side, bool lower, bool transpose,
-                                 bool unit_diagonal)
+TriangularSolve::TriangularSolve(const torch::lazy::Value& rhs,
+                                 const torch::lazy::Value& lhs, bool left_side,
+                                 bool lower, bool transpose, bool unit_diagonal)
     : XlaNode(torch::lazy::OpKind(at::aten::triangular_solve), {rhs, lhs},
               [&]() { return NodeOutputShape(rhs, lhs); },
               /*num_outputs=*/2,

--- a/torch_xla/csrc/ops/triangular_solve.h
+++ b/torch_xla/csrc/ops/triangular_solve.h
@@ -6,8 +6,9 @@ namespace torch_xla {
 
 class TriangularSolve : public XlaNode {
  public:
-  TriangularSolve(const XlaValue& rhs, const XlaValue& lhs, bool left_side,
-                  bool lower, bool transpose, bool unit_diagonal);
+  TriangularSolve(const torch::lazy::Value& rhs, const torch::lazy::Value& lhs,
+                  bool left_side, bool lower, bool transpose,
+                  bool unit_diagonal);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/tril.cpp
+++ b/torch_xla/csrc/ops/tril.cpp
@@ -5,8 +5,8 @@
 
 namespace torch_xla {
 
-Tril::Tril(const XlaValue& input, int64_t diagonal)
-    : XlaNode(torch::lazy::OpKind(at::aten::tril), {input}, input.xla_shape(),
+Tril::Tril(const torch::lazy::Value& input, int64_t diagonal)
+    : XlaNode(torch::lazy::OpKind(at::aten::tril), {input}, GetXlaShape(input),
               /*num_outputs=*/1, torch::lazy::MHash(diagonal)),
       diagonal_(diagonal) {}
 

--- a/torch_xla/csrc/ops/tril.h
+++ b/torch_xla/csrc/ops/tril.h
@@ -8,7 +8,7 @@ namespace torch_xla {
 // matrices input.
 class Tril : public XlaNode {
  public:
-  Tril(const XlaValue& input, int64_t diagonal);
+  Tril(const torch::lazy::Value& input, int64_t diagonal);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/triu.cpp
+++ b/torch_xla/csrc/ops/triu.cpp
@@ -5,8 +5,8 @@
 
 namespace torch_xla {
 
-Triu::Triu(const XlaValue& input, int64_t diagonal)
-    : XlaNode(torch::lazy::OpKind(at::aten::triu), {input}, input.xla_shape(),
+Triu::Triu(const torch::lazy::Value& input, int64_t diagonal)
+    : XlaNode(torch::lazy::OpKind(at::aten::triu), {input}, GetXlaShape(input),
               /*num_outputs=*/1, torch::lazy::MHash(diagonal)),
       diagonal_(diagonal) {}
 

--- a/torch_xla/csrc/ops/triu.h
+++ b/torch_xla/csrc/ops/triu.h
@@ -8,7 +8,7 @@ namespace torch_xla {
 // matrices input.
 class Triu : public XlaNode {
  public:
-  Triu(const XlaValue& input, int64_t diagonal);
+  Triu(const torch::lazy::Value& input, int64_t diagonal);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/uniform.cpp
+++ b/torch_xla/csrc/ops/uniform.cpp
@@ -8,8 +8,8 @@
 
 namespace torch_xla {
 
-Uniform::Uniform(const XlaValue& from, const XlaValue& to, const XlaValue& seed,
-                 const xla::Shape& rng_shape)
+Uniform::Uniform(const torch::lazy::Value& from, const torch::lazy::Value& to,
+                 const torch::lazy::Value& seed, const xla::Shape& rng_shape)
     : XlaNode(torch::lazy::OpKind(at::aten::uniform), {from, to, seed},
               rng_shape,
               /*num_outputs=*/1, torch::lazy::Hash(rng_shape)) {}

--- a/torch_xla/csrc/ops/uniform.h
+++ b/torch_xla/csrc/ops/uniform.h
@@ -6,8 +6,8 @@ namespace torch_xla {
 
 class Uniform : public XlaNode {
  public:
-  Uniform(const XlaValue& from, const XlaValue& to, const XlaValue& seed,
-          const xla::Shape& rng_shape);
+  Uniform(const torch::lazy::Value& from, const torch::lazy::Value& to,
+          const torch::lazy::Value& seed, const xla::Shape& rng_shape);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/unselect.cpp
+++ b/torch_xla/csrc/ops/unselect.cpp
@@ -9,9 +9,10 @@
 
 namespace torch_xla {
 
-Unselect::Unselect(const XlaValue& target, const XlaValue& source, int64_t dim,
-                   int64_t start, int64_t end, int64_t stride)
-    : XlaNode(xla_unselect, {target, source}, target.xla_shape(),
+Unselect::Unselect(const torch::lazy::Value& target,
+                   const torch::lazy::Value& source, int64_t dim, int64_t start,
+                   int64_t end, int64_t stride)
+    : XlaNode(xla_unselect, {target, source}, GetXlaShape(target),
               /*num_outputs=*/1, torch::lazy::MHash(dim, start, end, stride)),
       dim_(dim),
       start_(start),

--- a/torch_xla/csrc/ops/unselect.h
+++ b/torch_xla/csrc/ops/unselect.h
@@ -6,8 +6,8 @@ namespace torch_xla {
 
 class Unselect : public XlaNode {
  public:
-  Unselect(const XlaValue& target, const XlaValue& source, int64_t dim,
-           int64_t start, int64_t end, int64_t stride);
+  Unselect(const torch::lazy::Value& target, const torch::lazy::Value& source,
+           int64_t dim, int64_t start, int64_t end, int64_t stride);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/unsqueeze.cpp
+++ b/torch_xla/csrc/ops/unsqueeze.cpp
@@ -6,15 +6,15 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input, int dim) {
-  const xla::Shape& shape = input.xla_shape();
+xla::Shape NodeOutputShape(const torch::lazy::Value& input, int dim) {
+  const xla::Shape& shape = GetXlaShape(input);
   auto dimensions = BuildUnsqueezeDimensions(shape.dimensions(), dim);
   return xla::ShapeUtil::MakeShape(shape.element_type(), dimensions);
 }
 
 }  // namespace
 
-Unsqueeze::Unsqueeze(const XlaValue& input, int dim)
+Unsqueeze::Unsqueeze(const torch::lazy::Value& input, int dim)
     : XlaNode(torch::lazy::OpKind(at::aten::unsqueeze), {input},
               [&]() { return NodeOutputShape(input, dim); },
               /*num_outputs=*/1, torch::lazy::MHash(dim)),

--- a/torch_xla/csrc/ops/unsqueeze.h
+++ b/torch_xla/csrc/ops/unsqueeze.h
@@ -7,7 +7,7 @@ namespace torch_xla {
 class Unsqueeze : public XlaNode {
  public:
   // Insert a dimension of size one at the specified position.
-  Unsqueeze(const XlaValue& input, int dim);
+  Unsqueeze(const torch::lazy::Value& input, int dim);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/update_slice.cpp
+++ b/torch_xla/csrc/ops/update_slice.cpp
@@ -10,19 +10,21 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input, const XlaValue& source,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
+                           const torch::lazy::Value& source,
                            absl::Span<const int64_t> base_indices) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     return BuildUpdateSlice(operands[0], operands[1], base_indices);
   };
-  return InferOutputShape({input.xla_shape(), source.xla_shape()},
+  return InferOutputShape({GetXlaShape(input), GetXlaShape(source)},
                           lower_for_shape_fn);
 }
 
 }  // namespace
 
-UpdateSlice::UpdateSlice(const XlaValue& input, const XlaValue& source,
+UpdateSlice::UpdateSlice(const torch::lazy::Value& input,
+                         const torch::lazy::Value& source,
                          absl::Span<const int64_t> base_indices)
     : XlaNode(xla_update_slice, {input, source},
               [&]() { return NodeOutputShape(input, source, base_indices); },

--- a/torch_xla/csrc/ops/update_slice.h
+++ b/torch_xla/csrc/ops/update_slice.h
@@ -7,7 +7,7 @@ namespace torch_xla {
 
 class UpdateSlice : public XlaNode {
  public:
-  UpdateSlice(const XlaValue& input, const XlaValue& source,
+  UpdateSlice(const torch::lazy::Value& input, const torch::lazy::Value& source,
               absl::Span<const int64_t> base_indices);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;

--- a/torch_xla/csrc/ops/upsample_bilinear2d.cpp
+++ b/torch_xla/csrc/ops/upsample_bilinear2d.cpp
@@ -7,12 +7,12 @@
 
 namespace torch_xla {
 
-UpsampleBilinear::UpsampleBilinear(const XlaValue& input,
+UpsampleBilinear::UpsampleBilinear(const torch::lazy::Value& input,
                                    std::vector<int64_t> output_size,
                                    bool align_corners)
     : XlaNode(torch::lazy::OpKind(at::aten::upsample_bilinear2d), {input},
               [&]() {
-                return resize::GetForwardOutputShape2d(input.xla_shape(),
+                return resize::GetForwardOutputShape2d(GetXlaShape(input),
                                                        output_size);
               },
               /*num_outputs=*/1,

--- a/torch_xla/csrc/ops/upsample_bilinear2d.h
+++ b/torch_xla/csrc/ops/upsample_bilinear2d.h
@@ -8,8 +8,8 @@ namespace torch_xla {
 
 class UpsampleBilinear : public XlaNode {
  public:
-  UpsampleBilinear(const XlaValue& input, std::vector<int64_t> output_size,
-                   bool align_corners);
+  UpsampleBilinear(const torch::lazy::Value& input,
+                   std::vector<int64_t> output_size, bool align_corners);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/upsample_bilinear2d_backward.cpp
+++ b/torch_xla/csrc/ops/upsample_bilinear2d_backward.cpp
@@ -8,12 +8,12 @@
 namespace torch_xla {
 
 UpsampleBilinearBackward::UpsampleBilinearBackward(
-    const XlaValue& input, std::vector<int64_t> output_size,
+    const torch::lazy::Value& input, std::vector<int64_t> output_size,
     std::vector<int64_t> input_size, bool align_corners)
     : XlaNode(torch::lazy::OpKind(at::aten::upsample_bilinear2d_backward),
               {input},
               [&]() {
-                return resize::GetBackwardOutputShape2d(input.xla_shape(),
+                return resize::GetBackwardOutputShape2d(GetXlaShape(input),
                                                         input_size);
               },
               /*num_outputs=*/1,

--- a/torch_xla/csrc/ops/upsample_bilinear2d_backward.h
+++ b/torch_xla/csrc/ops/upsample_bilinear2d_backward.h
@@ -8,7 +8,7 @@ namespace torch_xla {
 
 class UpsampleBilinearBackward : public XlaNode {
  public:
-  UpsampleBilinearBackward(const XlaValue& input,
+  UpsampleBilinearBackward(const torch::lazy::Value& input,
                            std::vector<int64_t> output_size,
                            std::vector<int64_t> input_size, bool align_corners);
 

--- a/torch_xla/csrc/ops/upsample_nearest2d.cpp
+++ b/torch_xla/csrc/ops/upsample_nearest2d.cpp
@@ -7,11 +7,11 @@
 
 namespace torch_xla {
 
-UpsampleNearest::UpsampleNearest(const XlaValue& input,
+UpsampleNearest::UpsampleNearest(const torch::lazy::Value& input,
                                  std::vector<int64_t> output_size)
     : XlaNode(torch::lazy::OpKind(at::aten::upsample_nearest2d), {input},
               [&]() {
-                return resize::GetForwardOutputShape2d(input.xla_shape(),
+                return resize::GetForwardOutputShape2d(GetXlaShape(input),
                                                        output_size);
               },
               /*num_outputs=*/1, torch::lazy::MHash(output_size)),

--- a/torch_xla/csrc/ops/upsample_nearest2d.h
+++ b/torch_xla/csrc/ops/upsample_nearest2d.h
@@ -8,7 +8,8 @@ namespace torch_xla {
 
 class UpsampleNearest : public XlaNode {
  public:
-  UpsampleNearest(const XlaValue& input, std::vector<int64_t> output_size);
+  UpsampleNearest(const torch::lazy::Value& input,
+                  std::vector<int64_t> output_size);
 
   torch::lazy::NodePtr Clone(OpList operands) const override;
 

--- a/torch_xla/csrc/ops/upsample_nearest2d_backward.cpp
+++ b/torch_xla/csrc/ops/upsample_nearest2d_backward.cpp
@@ -8,12 +8,12 @@
 namespace torch_xla {
 
 UpsampleNearestBackward::UpsampleNearestBackward(
-    const XlaValue& input, std::vector<int64_t> output_size,
+    const torch::lazy::Value& input, std::vector<int64_t> output_size,
     std::vector<int64_t> input_size)
     : XlaNode(torch::lazy::OpKind(at::aten::upsample_nearest2d_backward),
               {input},
               [&]() {
-                return resize::GetBackwardOutputShape2d(input.xla_shape(),
+                return resize::GetBackwardOutputShape2d(GetXlaShape(input),
                                                         input_size);
               },
               /*num_outputs=*/1, torch::lazy::MHash(output_size, input_size)),

--- a/torch_xla/csrc/ops/upsample_nearest2d_backward.h
+++ b/torch_xla/csrc/ops/upsample_nearest2d_backward.h
@@ -8,7 +8,7 @@ namespace torch_xla {
 
 class UpsampleNearestBackward : public XlaNode {
  public:
-  UpsampleNearestBackward(const XlaValue& input,
+  UpsampleNearestBackward(const torch::lazy::Value& input,
                           std::vector<int64_t> output_size,
                           std::vector<int64_t> input_size);
 

--- a/torch_xla/csrc/ops/var.cpp
+++ b/torch_xla/csrc/ops/var.cpp
@@ -11,7 +11,7 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            std::vector<int64_t>& dimensions, int64_t correction,
                            bool keep_reduced_dimensions) {
   auto lower_for_shape_fn =
@@ -19,12 +19,12 @@ xla::Shape NodeOutputShape(const XlaValue& input,
     return BuildVar(operands[0], dimensions, correction,
                     keep_reduced_dimensions);
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-Var::Var(const XlaValue& input, std::vector<int64_t> dimensions,
+Var::Var(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
          int64_t correction, bool keep_reduced_dimensions)
     : XlaNode(
           torch::lazy::OpKind(at::aten::var), {input},

--- a/torch_xla/csrc/ops/var.h
+++ b/torch_xla/csrc/ops/var.h
@@ -9,7 +9,7 @@ namespace torch_xla {
 
 class Var : public XlaNode {
  public:
-  Var(const XlaValue& input, std::vector<int64_t> dimensions,
+  Var(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
       int64_t correction, bool keep_reduced_dimensions);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/var_mean.cpp
+++ b/torch_xla/csrc/ops/var_mean.cpp
@@ -11,7 +11,7 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            std::vector<int64_t>& dimensions, int64_t correction,
                            bool keep_reduced_dimensions) {
   auto lower_for_shape_fn =
@@ -22,13 +22,14 @@ xla::Shape NodeOutputShape(const XlaValue& input,
         BuildMean(operands[0], dimensions, keep_reduced_dimensions);
     return xla::Tuple(operands[0].builder(), {var, mean});
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
 }
 
 }  // namespace
 
-VarMean::VarMean(const XlaValue& input, std::vector<int64_t> dimensions,
-                 int64_t correction, bool keep_reduced_dimensions)
+VarMean::VarMean(const torch::lazy::Value& input,
+                 std::vector<int64_t> dimensions, int64_t correction,
+                 bool keep_reduced_dimensions)
     : XlaNode(
           torch::lazy::OpKind(at::aten::var_mean), {input},
           [&]() {

--- a/torch_xla/csrc/ops/var_mean.h
+++ b/torch_xla/csrc/ops/var_mean.h
@@ -9,7 +9,7 @@ namespace torch_xla {
 
 class VarMean : public XlaNode {
  public:
-  VarMean(const XlaValue& input, std::vector<int64_t> dimensions,
+  VarMean(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
           int64_t correction, bool keep_reduced_dimensions);
 
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/view.cpp
+++ b/torch_xla/csrc/ops/view.cpp
@@ -9,9 +9,9 @@
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const XlaValue& input,
+xla::Shape NodeOutputShape(const torch::lazy::Value& input,
                            absl::Span<const int64_t> output_sizes) {
-  const xla::Shape& input_shape = input.xla_shape();
+  const xla::Shape& input_shape = GetXlaShape(input);
   auto info = XlaHelpers::GetDynamicReshapeInfo(input_shape, output_sizes);
   if (info) {
     return std::move(info->output_shape);
@@ -24,7 +24,8 @@ xla::Shape NodeOutputShape(const XlaValue& input,
 
 }  // namespace
 
-ViewOp::ViewOp(const XlaValue& input, std::vector<int64_t> output_size)
+ViewOp::ViewOp(const torch::lazy::Value& input,
+               std::vector<int64_t> output_size)
     : XlaNode(torch::lazy::OpKind(at::aten::view), {input},
               NodeOutputShape(input, output_size),
               /*num_outputs=*/1, torch::lazy::MHash(output_size)),

--- a/torch_xla/csrc/ops/view.h
+++ b/torch_xla/csrc/ops/view.h
@@ -8,7 +8,7 @@ namespace torch_xla {
 
 class ViewOp : public XlaNode {
  public:
-  ViewOp(const XlaValue& input, std::vector<int64_t> output_size);
+  ViewOp(const torch::lazy::Value& input, std::vector<int64_t> output_size);
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -37,7 +37,7 @@ class XLATensor : public c10::intrusive_ptr_target {
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
 
   static XLATensor Create(
-      XlaValue ir_value, const torch::lazy::BackendDevice& device,
+      torch::lazy::Value ir_value, const torch::lazy::BackendDevice& device,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
 
   // Creates an empty/null tensor.
@@ -90,12 +90,12 @@ class XLATensor : public c10::intrusive_ptr_target {
 
   // Retrieves the current IR XlaNode, or nullptr in case no active IR XlaNode
   // is available.
-  XlaValue CurrentIrValue() const;
+  torch::lazy::Value CurrentIrValue() const;
 
   // Retrieves the IR XlaNode representing this XLATensor. One will be created
   // if missing. Note that although this is a const API, it actually changes the
   // internal state ofthe object.
-  XlaValue GetIrValue() const;
+  torch::lazy::Value GetIrValue() const;
 
   c10::optional<at::Tensor> CurrentTensorData() const;
 
@@ -122,31 +122,32 @@ class XLATensor : public c10::intrusive_ptr_target {
   // that is affected by the view tensor.
   static void ApplyEagerSync(std::vector<XLATensor>& tensors);
 
-  static XlaValue GetDeviceDataIrValue(
+  static torch::lazy::Value GetDeviceDataIrValue(
       const at::Scalar& value, xla::PrimitiveType type,
       const torch::lazy::BackendDevice& device);
   // Use with caution, constant will cause more frequent recompilation
   // compared to the device_data.
-  static XlaValue GetIrValueForConstant(const at::Scalar& value,
-                                        const xla::Shape& shape);
-  static XlaValue GetIrValueForScalar(const at::Scalar& value,
-                                      xla::PrimitiveType type,
-                                      const torch::lazy::BackendDevice& device);
-  static XlaValue GetIrValueForScalar(const at::Scalar& value,
-                                      const torch::lazy::BackendDevice& device);
-  static XlaValue GetIrValueForScalar(const at::Scalar& value,
-                                      xla::PrimitiveType type,
-                                      absl::Span<const int64_t> dimensions,
-                                      const torch::lazy::BackendDevice& device);
-  static XlaValue GetIrValueForScalar(const at::Scalar& value,
-                                      const xla::Shape& shape,
-                                      const torch::lazy::BackendDevice& device);
-  static XlaValue GetIrValueForScalar(
+  static torch::lazy::Value GetIrValueForConstant(const at::Scalar& value,
+                                                  const xla::Shape& shape);
+  static torch::lazy::Value GetIrValueForScalar(
+      const at::Scalar& value, xla::PrimitiveType type,
+      const torch::lazy::BackendDevice& device);
+  static torch::lazy::Value GetIrValueForScalar(
+      const at::Scalar& value, const torch::lazy::BackendDevice& device);
+  static torch::lazy::Value GetIrValueForScalar(
+      const at::Scalar& value, xla::PrimitiveType type,
+      absl::Span<const int64_t> dimensions,
+      const torch::lazy::BackendDevice& device);
+  static torch::lazy::Value GetIrValueForScalar(
+      const at::Scalar& value, const xla::Shape& shape,
+      const torch::lazy::BackendDevice& device);
+  static torch::lazy::Value GetIrValueForScalar(
       const at::Scalar& value, const xla::Shape& shape,
       c10::optional<at::ScalarType> logical_element_type,
       const torch::lazy::BackendDevice& device);
 
-  static XlaValue GetRngSeed(const torch::lazy::BackendDevice& device);
+  static torch::lazy::Value GetRngSeed(
+      const torch::lazy::BackendDevice& device);
 
   static void SetRngSeed(const torch::lazy::BackendDevice& device,
                          uint64_t seed);
@@ -212,63 +213,62 @@ class XLATensor : public c10::intrusive_ptr_target {
   //////////////////////////////////////////////////////////////////////////////
   // XLA dedicated operators follows here, listed in alphabetical order.
   //////////////////////////////////////////////////////////////////////////////
-  static std::pair<XLATensor, XlaValue> all_reduce(
-      const XLATensor& input, const XlaValue& token, AllReduceType reduce_type,
-      double scale, std::vector<std::vector<int64_t>> groups, bool pin_layout);
-
-  static XlaValue all_reduce_(XLATensor& input, const XlaValue& token,
-                              AllReduceType reduce_type, double scale,
-                              std::vector<std::vector<int64_t>> groups,
-                              bool pin_layout);
-
-  static XlaValue all_reduce(std::vector<XLATensor>* inputs,
-                             const XlaValue& token, AllReduceType reduce_type,
-                             double scale,
-                             std::vector<std::vector<int64_t>> groups,
-                             bool pin_layout);
-
-  static std::pair<XLATensor, XlaValue> reduce_scatter(
-      const XLATensor& input, const XlaValue& token, AllReduceType reduce_type,
-      double scale, int64_t scatter_dim, int64_t shard_count,
+  static std::pair<XLATensor, torch::lazy::Value> all_reduce(
+      const XLATensor& input, const torch::lazy::Value& token,
+      AllReduceType reduce_type, double scale,
       std::vector<std::vector<int64_t>> groups, bool pin_layout);
 
-  static XlaValue reduce_scatter_out(XLATensor& output, const XLATensor& input,
-                                     const XlaValue& token,
-                                     AllReduceType reduce_type, double scale,
-                                     int64_t scatter_dim, int64_t shard_count,
-                                     std::vector<std::vector<int64_t>> groups,
-                                     bool pin_layout);
-
-  static std::pair<XLATensor, XlaValue> all_to_all(
-      const XLATensor& input, const XlaValue& token, int64_t split_dimension,
-      int64_t concat_dimension, int64_t split_count,
+  static torch::lazy::Value all_reduce_(
+      XLATensor& input, const torch::lazy::Value& token,
+      AllReduceType reduce_type, double scale,
       std::vector<std::vector<int64_t>> groups, bool pin_layout);
 
-  static std::pair<XLATensor, XlaValue> all_gather(
-      const XLATensor& input, const XlaValue& token, int64_t dim,
+  static torch::lazy::Value all_reduce(std::vector<XLATensor>* inputs,
+                                       const torch::lazy::Value& token,
+                                       AllReduceType reduce_type, double scale,
+                                       std::vector<std::vector<int64_t>> groups,
+                                       bool pin_layout);
+
+  static std::pair<XLATensor, torch::lazy::Value> reduce_scatter(
+      const XLATensor& input, const torch::lazy::Value& token,
+      AllReduceType reduce_type, double scale, int64_t scatter_dim,
       int64_t shard_count, std::vector<std::vector<int64_t>> groups,
       bool pin_layout);
 
-  static XlaValue all_gather_out(XLATensor& output, const XLATensor& input,
-                                 const XlaValue& token, int64_t dim,
-                                 int64_t shard_count,
-                                 std::vector<std::vector<int64_t>> groups,
-                                 bool pin_layout);
+  static torch::lazy::Value reduce_scatter_out(
+      XLATensor& output, const XLATensor& input,
+      const torch::lazy::Value& token, AllReduceType reduce_type, double scale,
+      int64_t scatter_dim, int64_t shard_count,
+      std::vector<std::vector<int64_t>> groups, bool pin_layout);
 
-  static std::pair<XLATensor, XlaValue> collective_permute(
-      const XLATensor& input, const XlaValue& token,
+  static std::pair<XLATensor, torch::lazy::Value> all_to_all(
+      const XLATensor& input, const torch::lazy::Value& token,
+      int64_t split_dimension, int64_t concat_dimension, int64_t split_count,
+      std::vector<std::vector<int64_t>> groups, bool pin_layout);
+
+  static std::pair<XLATensor, torch::lazy::Value> all_gather(
+      const XLATensor& input, const torch::lazy::Value& token, int64_t dim,
+      int64_t shard_count, std::vector<std::vector<int64_t>> groups,
+      bool pin_layout);
+
+  static torch::lazy::Value all_gather_out(
+      XLATensor& output, const XLATensor& input,
+      const torch::lazy::Value& token, int64_t dim, int64_t shard_count,
+      std::vector<std::vector<int64_t>> groups, bool pin_layout);
+
+  static std::pair<XLATensor, torch::lazy::Value> collective_permute(
+      const XLATensor& input, const torch::lazy::Value& token,
       std::vector<std::pair<int64_t, int64_t>> source_target_pairs);
 
   static XLATensor get_dimensions_size(const XLATensor& input,
                                        std::vector<int64_t> dimensions);
 
-  static std::pair<XLATensor, XlaValue> recv(XLATensor& output,
-                                             const XlaValue& token,
-                                             int64_t channel_id);
+  static std::pair<XLATensor, torch::lazy::Value> recv(
+      XLATensor& output, const torch::lazy::Value& token, int64_t channel_id);
 
-  static std::pair<XLATensor, XlaValue> send(const XLATensor& input,
-                                             const XlaValue& token,
-                                             int64_t channel_id);
+  static std::pair<XLATensor, torch::lazy::Value> send(
+      const XLATensor& input, const torch::lazy::Value& token,
+      int64_t channel_id);
 
   static void sgd_optimizer_step_(const XLATensor& found_inf, XLATensor& step,
                                   XLATensor& param, XLATensor& buf,
@@ -1284,7 +1284,7 @@ class XLATensor : public c10::intrusive_ptr_target {
           logical_element_type(logical_element_type),
           device(device),
           unique_id(GetNextTensorId()) {}
-    Data(XlaValue ir_value, const torch::lazy::BackendDevice& device,
+    Data(torch::lazy::Value ir_value, const torch::lazy::BackendDevice& device,
          c10::optional<at::ScalarType> logical_element_type)
         : ir_value(std::move(ir_value)),
           logical_element_type(logical_element_type),
@@ -1305,7 +1305,7 @@ class XLATensor : public c10::intrusive_ptr_target {
     ~Data();
 
     xla::ComputationClient::DataPtr xla_data;
-    XlaValue ir_value;
+    torch::lazy::Value ir_value;
     std::shared_ptr<View> view;
     // TODO: remove this in favor of torch::lazy::Shape within ir_value.
     c10::optional<at::ScalarType> logical_element_type;
@@ -1318,7 +1318,8 @@ class XLATensor : public c10::intrusive_ptr_target {
   XLATensor(const at::Tensor& tensor, const torch::lazy::BackendDevice& device);
   XLATensor(xla::ComputationClient::DataPtr xla_data,
             c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
-  XLATensor(XlaValue ir_value, const torch::lazy::BackendDevice& device,
+  XLATensor(torch::lazy::Value ir_value,
+            const torch::lazy::BackendDevice& device,
             c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
   XLATensor(std::shared_ptr<View> view,
             const torch::lazy::BackendDevice& device,
@@ -1335,20 +1336,20 @@ class XLATensor : public c10::intrusive_ptr_target {
 
   void SetXlaData(xla::ComputationClient::DataPtr xla_data, bool sync);
 
-  void SetIrValue(XlaValue ir_value, bool inplace = true);
-  void SetInPlaceIrValue(XlaValue ir_value);
+  void SetIrValue(torch::lazy::Value ir_value, bool inplace = true);
+  void SetInPlaceIrValue(torch::lazy::Value ir_value);
 
-  void AssignIrValue(XlaValue ir_value) const;
+  void AssignIrValue(torch::lazy::Value ir_value) const;
 
   void SetTensorData(at::Tensor tensor_data);
 
-  XlaValue CreateTensorNode(xla::ComputationClient::DataPtr data,
-                            bool read_only) const;
+  torch::lazy::Value CreateTensorNode(xla::ComputationClient::DataPtr data,
+                                      bool read_only) const;
 
   View::IrNode GetViewUpdate(const std::shared_ptr<View>& view) const;
 
   std::shared_ptr<View> UpdateView(std::shared_ptr<View> view,
-                                   XlaValue ir_value) const;
+                                   torch::lazy::Value ir_value) const;
 
   void SetSubView(ViewInfo view_info) const;
   void ModifyCurrentView(ViewInfo view_info) const;
@@ -1357,21 +1358,21 @@ class XLATensor : public c10::intrusive_ptr_target {
 
   XLATensor CopyTensorToDevice(const torch::lazy::BackendDevice& device);
 
-  XlaValue MaybeCastIrValue(
-      XlaValue ir_value, const torch::lazy::BackendDevice& device,
+  torch::lazy::Value MaybeCastIrValue(
+      torch::lazy::Value ir_value, const torch::lazy::BackendDevice& device,
       c10::optional<at::ScalarType> logical_element_type) const;
 
   // Create a new XLA tensor with the same metadata of the input tensor (with
   // possible overrides), and the new IR value.
-  XLATensor CreateFrom(XlaValue ir_value) const;
-  XLATensor CreateFrom(XlaValue ir_value,
+  XLATensor CreateFrom(torch::lazy::Value ir_value) const;
+  XLATensor CreateFrom(torch::lazy::Value ir_value,
                        const torch::lazy::BackendDevice& device) const;
-  XLATensor CreateFrom(XlaValue ir_value,
+  XLATensor CreateFrom(torch::lazy::Value ir_value,
                        at::ScalarType logical_element_type) const;
   XLATensor CreateFrom(
-      XlaValue ir_value,
+      torch::lazy::Value ir_value,
       c10::optional<at::ScalarType> logical_element_type_opt) const;
-  XLATensor CreateFrom(XlaValue ir_value,
+  XLATensor CreateFrom(torch::lazy::Value ir_value,
                        const torch::lazy::BackendDevice& device,
                        at::ScalarType logical_element_type) const;
 
@@ -1385,8 +1386,8 @@ class XLATensor : public c10::intrusive_ptr_target {
   std::vector<XLATensor> MakeOutputTensors(
       torch::lazy::NodePtr node, bool inherit_logical_type = true) const;
 
-  XlaValue GetIrValueForTensor(const at::Tensor& tensor,
-                               const torch::lazy::BackendDevice& device) const;
+  torch::lazy::Value GetIrValueForTensor(
+      const at::Tensor& tensor, const torch::lazy::BackendDevice& device) const;
 
   static ComputationCache* GetComputationCache();
 
@@ -1415,7 +1416,7 @@ class XLATensor : public c10::intrusive_ptr_target {
       const std::vector<XLATensor>& tensors, absl::Span<const size_t> indices,
       absl::Span<const xla::ComputationClient::DataPtr> tensors_data);
 
-  static std::vector<XlaValue> CollectRoots(
+  static std::vector<torch::lazy::Value> CollectRoots(
       const std::vector<XLATensor>& tensors, absl::Span<const size_t> indices);
 
   static std::vector<xla::ComputationClient::DataPtr> FetchTensorData(

--- a/torch_xla/csrc/view.h
+++ b/torch_xla/csrc/view.h
@@ -95,13 +95,14 @@ struct ViewInfo {
 class Alias {
  public:
   struct UpdateData {
-    XlaValue ir_value;
+    torch::lazy::Value ir_value;
     std::vector<ViewInfo> view_infos;
   };
 
-  explicit Alias(XlaValue ir_value) : ir_value_(std::move(ir_value)) {}
+  explicit Alias(torch::lazy::Value ir_value)
+      : ir_value_(std::move(ir_value)) {}
 
-  const XlaValue& ir_value() const { return ir_value_; }
+  const torch::lazy::Value& ir_value() const { return ir_value_; }
 
   const std::vector<UpdateData>& updates() const { return updates_; }
 
@@ -110,13 +111,13 @@ class Alias {
   // Appends an update to the IR value stored within the alias. The ir_value is
   // the value to be written, and view_infos represents the forward path from
   // the alias's ir_value to the update ir_value.
-  void Update(XlaValue ir_value, std::vector<ViewInfo> view_infos);
+  void Update(torch::lazy::Value ir_value, std::vector<ViewInfo> view_infos);
 
-  XlaValue SyncUpdateOperations();
+  torch::lazy::Value SyncUpdateOperations();
 
  private:
   // The IR value which is the root at which the view was created.
-  XlaValue ir_value_;
+  torch::lazy::Value ir_value_;
   // The stacked updates on the view. Orders matter, as most recent updates
   // might overwrite older ones.
   std::vector<UpdateData> updates_;
@@ -128,7 +129,7 @@ class Alias {
 class View {
  public:
   struct IrNode {
-    XlaValue ir_value;
+    torch::lazy::Value ir_value;
     bool updated;
   };
 
@@ -136,7 +137,7 @@ class View {
   View(xla::Shape shape, std::shared_ptr<Alias> alias,
        std::vector<ViewInfo> view_infos);
 
-  void Update(XlaValue ir_value);
+  void Update(torch::lazy::Value ir_value);
 
   const xla::Shape& shape() const { return shape_; }
 
@@ -157,7 +158,7 @@ class View {
   std::vector<ViewInfo> view_infos_;
   xla::Shape shape_;
   std::shared_ptr<Alias> alias_;
-  XlaValue ir_value_;
+  torch::lazy::Value ir_value_;
   size_t generation_ = 0;
 };
 


### PR DESCRIPTION
Replace XlaValue with upstream lazy::Value

Following up on https://github.com/pytorch/xla/pull/3567, we see that keeping our own `torch_xla::XlaValue` causes issues for LTC codegen and will make things unnecessarily more complicated. This removes our `torch_xla::XlaValue` completely and uses the upstream `lazy::Value`. 

This PR adds a function `GetXlaShape(lazy::Value)` in `ir.h` that retrieves the xla shape given a `lazy::Value`, which eliminates the need to keep our own `XlaValue`. 