### PR TITLE
Full codegen for `log`, `log2`, and `log10`

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1787,22 +1787,10 @@ at::Tensor XLANativeFunctions::linspace(const at::Scalar& start,
                           GetXlaDeviceOrCurrent(device)));
 }
 
-at::Tensor XLANativeFunctions::log10(const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(XLATensor::log_base(
-      bridge::GetXlaTensor(self), torch::lazy::OpKind(at::aten::log10), 10.0));
-}
-
 at::Tensor XLANativeFunctions::log1p(const at::Tensor& self) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
       XLATensor::log1p(bridge::GetXlaTensor(self)));
-}
-
-at::Tensor XLANativeFunctions::log2(const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(XLATensor::log_base(
-      bridge::GetXlaTensor(self), torch::lazy::OpKind(at::aten::log2), 2.0));
 }
 
 at::Tensor XLANativeFunctions::log_sigmoid_backward(

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1787,11 +1787,6 @@ at::Tensor XLANativeFunctions::linspace(const at::Scalar& start,
                           GetXlaDeviceOrCurrent(device)));
 }
 
-at::Tensor XLANativeFunctions::log(const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(XLATensor::log(bridge::GetXlaTensor(self)));
-}
-
 at::Tensor XLANativeFunctions::log10(const at::Tensor& self) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(XLATensor::log_base(

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -206,8 +206,7 @@ xla::XlaOp BuildLeakyReluBackward(xla::XlaOp grad_output, xla::XlaOp input,
 xla::XlaOp BuildLogBase(xla::XlaOp input, double base) {
   xla::XlaOp result = xla::Log(input);
   xla::XlaOp ln_base = XlaHelpers::ScalarValue<float>(
-      1.0 / std::log(base), XlaHelpers::TypeOfXlaOp(input),
-      input.builder());
+      1.0 / std::log(base), XlaHelpers::TypeOfXlaOp(input), input.builder());
   return (result * ln_base);
 }
 

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -203,6 +203,14 @@ xla::XlaOp BuildLeakyReluBackward(xla::XlaOp grad_output, xla::XlaOp input,
                      negative_slope * grad_output);
 }
 
+xla::XlaOp BuildLogBase(xla::XlaOp input, double base) {
+  xla::XlaOp result = xla::Log(input);
+  xla::XlaOp ln_base = XlaHelpers::ScalarValue<float>(
+      1.0 / std::log(base), XlaHelpers::TypeOfXlaOp(input),
+      input.builder());
+  return (result * ln_base);
+}
+
 xla::XlaOp BuildPrelu(xla::XlaOp input, xla::XlaOp weight) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   const xla::Shape& weight_shape = XlaHelpers::ShapeOfXlaOp(weight);

--- a/torch_xla/csrc/elementwise.h
+++ b/torch_xla/csrc/elementwise.h
@@ -48,6 +48,9 @@ xla::XlaOp BuildLeakyRelu(xla::XlaOp input, double negative_slope);
 xla::XlaOp BuildLeakyReluBackward(xla::XlaOp grad_output, xla::XlaOp input,
                                   double negative_slope_value);
 
+// Computes log of base on input
+xla::XlaOp BuildLogBase(xla::XlaOp input, double base);
+
 // Computes the sigmoid function using Tanh
 // Sigmoid(x) = (tanh(x ∗ 0.5) + 1) ∗ 0.5
 xla::XlaOp BuildSigmoid(xla::XlaOp input);

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -74,7 +74,6 @@ PTXLA_UNARY_OP(Tanh, at::aten::tanh, xla::Tanh);
 PTXLA_UNARY_OP(Neg, at::aten::neg, xla::Neg);
 PTXLA_UNARY_OP(Exp, at::aten::exp, xla::Exp);
 PTXLA_UNARY_OP(Expm1, at::aten::expm1, xla::Expm1);
-PTXLA_UNARY_OP(Log, at::aten::log, xla::Log);
 PTXLA_UNARY_OP(Log1p, at::aten::log1p, xla::Log1p);
 PTXLA_UNARY_OP(Erf, at::aten::erf, xla::Erf);
 PTXLA_UNARY_OP(Erfc, at::aten::erfc, xla::Erfc);

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -101,21 +101,6 @@ torch::lazy::NodePtr FracOp(const XlaValue& input) {
   return input - Trunc(input);
 }
 
-torch::lazy::NodePtr LogBase(const XlaValue& input, torch::lazy::OpKind op,
-                             double base) {
-  auto lower_fn = [base](const XlaNode& node,
-                         LoweringContext* loctx) -> XlaOpVector {
-    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
-    xla::XlaOp result = xla::Log(xla_input);
-    xla::XlaOp ln_base = XlaHelpers::ScalarValue<float>(
-        1.0 / std::log(base), node.xla_shape().element_type(),
-        xla_input.builder());
-    return node.ReturnOp(result * ln_base, loctx);
-  };
-  return GenericOp(op, {input}, input.xla_shape(), std::move(lower_fn),
-                   /*num_outputs=*/1, torch::lazy::MHash(base));
-}
-
 torch::lazy::NodePtr ReciprocalOp(const XlaValue& input) {
   auto lower_fn = [](const XlaNode& node,
                      LoweringContext* loctx) -> XlaOpVector {

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -81,9 +81,6 @@ torch::lazy::NodePtr Erfc(const XlaValue& input);
 
 torch::lazy::NodePtr Erfinv(const XlaValue& input);
 
-torch::lazy::NodePtr LogBase(const XlaValue& input, torch::lazy::OpKind op,
-                             double base);
-
 torch::lazy::NodePtr Log1p(const XlaValue& input);
 
 torch::lazy::NodePtr Sqrt(const XlaValue& input);

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -81,8 +81,6 @@ torch::lazy::NodePtr Erfc(const XlaValue& input);
 
 torch::lazy::NodePtr Erfinv(const XlaValue& input);
 
-torch::lazy::NodePtr Log(const XlaValue& input);
-
 torch::lazy::NodePtr LogBase(const XlaValue& input, torch::lazy::OpKind op,
                              double base);
 

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -50,6 +50,15 @@ torch_xla::XlaOpVector Cosh::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   return ReturnOp(xla::Cosh(xla_input), loctx);
 }
+torch_xla::XlaOpVector Log::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  return ReturnOp(xla::Log(xla_input), loctx);
+}
+
+// torch_xla::XlaOpVector Log1p::Lower(LoweringContext* loctx) const {
+//   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+//   return ReturnOp(xla::Log1p(xla_input), loctx);
+// }
 
 torch_xla::XlaOpVector Maximum::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -73,14 +73,14 @@ torch_xla::XlaOpVector Log::Lower(LoweringContext* loctx) const {
 }
 
 torch_xla::XlaOpVector Log2::Lower(LoweringContext* loctx) const {
-  double base = 2.0;
+  static const double base = 2.0;
   xla::XlaOp xla_input =
       GetFloatingOp(loctx->GetOutputOp(operand(0)), xla::PrimitiveType::F32);
   return ReturnOp(BuildLogBase(xla_input, base), loctx);
 }
 
 torch_xla::XlaOpVector Log10::Lower(LoweringContext* loctx) const {
-  double base = 10.0;
+  static const double base = 10.0;
   xla::XlaOp xla_input =
       GetFloatingOp(loctx->GetOutputOp(operand(0)), xla::PrimitiveType::F32);
   return ReturnOp(BuildLogBase(xla_input, base), loctx);

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -55,10 +55,17 @@ torch_xla::XlaOpVector Log::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::Log(xla_input), loctx);
 }
 
-// torch_xla::XlaOpVector Log1p::Lower(LoweringContext* loctx) const {
-//   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
-//   return ReturnOp(xla::Log1p(xla_input), loctx);
-// }
+torch_xla::XlaOpVector Log2::Lower(LoweringContext* loctx) const {
+  double base = 2.0;
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  return ReturnOp(BuildLogBase(xla_input, base), loctx);
+}
+
+torch_xla::XlaOpVector Log10::Lower(LoweringContext* loctx) const {
+  double base = 10.0;
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  return ReturnOp(BuildLogBase(xla_input, base), loctx);
+}
 
 torch_xla::XlaOpVector Maximum::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -9,18 +9,19 @@ namespace torch_xla {
 namespace {
 
 // If the XlaOp is not a floating point, cast it to float_type.
-xla::XlaOp GetFloatingOp(const xla::XlaOp& input, xla::PrimitiveType float_type) {
+xla::XlaOp GetFloatingOp(const xla::XlaOp& input,
+                         xla::PrimitiveType float_type) {
   if (xla::primitive_util::IsIntegralType(XlaHelpers::TypeOfXlaOp(input))) {
     const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
     xla::PrimitiveType raw_from = input_shape.element_type();
     xla::PrimitiveType raw_to = float_type;
-    xla::XlaOp input =
-        ConvertToRaw(input, raw_from, raw_from, raw_to, raw_to, /*device=*/nullptr);
+    xla::XlaOp input = ConvertToRaw(input, raw_from, raw_from, raw_to, raw_to,
+                                    /*device=*/nullptr);
   }
   return input;
 }
 
-} // namespace
+}  // namespace
 
 torch_xla::XlaOpVector Abs::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
@@ -73,13 +74,15 @@ torch_xla::XlaOpVector Log::Lower(LoweringContext* loctx) const {
 
 torch_xla::XlaOpVector Log2::Lower(LoweringContext* loctx) const {
   double base = 2.0;
-  xla::XlaOp xla_input = GetFloatingOp(loctx->GetOutputOp(operand(0)), xla::PrimitiveType::F32);
+  xla::XlaOp xla_input =
+      GetFloatingOp(loctx->GetOutputOp(operand(0)), xla::PrimitiveType::F32);
   return ReturnOp(BuildLogBase(xla_input, base), loctx);
 }
 
 torch_xla::XlaOpVector Log10::Lower(LoweringContext* loctx) const {
   double base = 10.0;
-  xla::XlaOp xla_input = GetFloatingOp(loctx->GetOutputOp(operand(0)), xla::PrimitiveType::F32);
+  xla::XlaOp xla_input =
+      GetFloatingOp(loctx->GetOutputOp(operand(0)), xla::PrimitiveType::F32);
   return ReturnOp(BuildLogBase(xla_input, base), loctx);
 }
 

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -1,10 +1,26 @@
 #include <torch_xla/csrc/generated/LazyIr.h>
 
 #include "tensorflow/compiler/xla/client/lib/math.h"
+#include "torch_xla/csrc/convert_ops.h"
 #include "torch_xla/csrc/elementwise.h"
 #include "torch_xla/csrc/helpers.h"
 
 namespace torch_xla {
+namespace {
+
+// If the XlaOp is not a floating point, cast it to float_type.
+xla::XlaOp GetFloatingOp(const xla::XlaOp& input, xla::PrimitiveType float_type) {
+  if (xla::primitive_util::IsIntegralType(XlaHelpers::TypeOfXlaOp(input))) {
+    const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
+    xla::PrimitiveType raw_from = input_shape.element_type();
+    xla::PrimitiveType raw_to = float_type;
+    xla::XlaOp input =
+        ConvertToRaw(input, raw_from, raw_from, raw_to, raw_to, /*device=*/nullptr);
+  }
+  return input;
+}
+
+} // namespace
 
 torch_xla::XlaOpVector Abs::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
@@ -57,13 +73,13 @@ torch_xla::XlaOpVector Log::Lower(LoweringContext* loctx) const {
 
 torch_xla::XlaOpVector Log2::Lower(LoweringContext* loctx) const {
   double base = 2.0;
-  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  xla::XlaOp xla_input = GetFloatingOp(loctx->GetOutputOp(operand(0)), xla::PrimitiveType::F32);
   return ReturnOp(BuildLogBase(xla_input, base), loctx);
 }
 
 torch_xla::XlaOpVector Log10::Lower(LoweringContext* loctx) const {
   double base = 10.0;
-  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  xla::XlaOp xla_input = GetFloatingOp(loctx->GetOutputOp(operand(0)), xla::PrimitiveType::F32);
   return ReturnOp(BuildLogBase(xla_input, base), loctx);
 }
 

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -15,8 +15,8 @@ xla::XlaOp GetFloatingOp(const xla::XlaOp& input,
     const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
     xla::PrimitiveType raw_from = input_shape.element_type();
     xla::PrimitiveType raw_to = float_type;
-    xla::XlaOp input = ConvertToRaw(input, raw_from, raw_from, raw_to, raw_to,
-                                    /*device=*/nullptr);
+    return ConvertToRaw(input, raw_from, raw_from, raw_to, raw_to,
+                        /*device=*/nullptr);
   }
   return input;
 }

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -21,6 +21,7 @@ xla::Shape AtanhOutputShape(const XlaValue& input) { return input.xla_shape(); }
 xla::Shape CosOutputShape(const XlaValue& input) { return input.xla_shape(); }
 
 xla::Shape CoshOutputShape(const XlaValue& input) { return input.xla_shape(); }
+
 xla::Shape LogOutputShape(const XlaValue& input) { return input.xla_shape(); }
 
 xla::Shape Log2OutputShape(const XlaValue& input) { return input.xla_shape(); }

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -23,7 +23,9 @@ xla::Shape CosOutputShape(const XlaValue& input) { return input.xla_shape(); }
 xla::Shape CoshOutputShape(const XlaValue& input) { return input.xla_shape(); }
 xla::Shape LogOutputShape(const XlaValue& input) { return input.xla_shape(); }
 
-// xla::Shape Log1pOutputShape(const XlaValue& input) { return input.xla_shape(); }
+xla::Shape Log2OutputShape(const XlaValue& input) { return input.xla_shape(); }
+
+xla::Shape Log10OutputShape(const XlaValue& input) { return input.xla_shape(); }
 
 xla::Shape MaximumOutputShape(const XlaValue& input, const XlaValue& other) {
   auto lower_for_shape_fn =

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -21,6 +21,9 @@ xla::Shape AtanhOutputShape(const XlaValue& input) { return input.xla_shape(); }
 xla::Shape CosOutputShape(const XlaValue& input) { return input.xla_shape(); }
 
 xla::Shape CoshOutputShape(const XlaValue& input) { return input.xla_shape(); }
+xla::Shape LogOutputShape(const XlaValue& input) { return input.xla_shape(); }
+
+// xla::Shape Log1pOutputShape(const XlaValue& input) { return input.xla_shape(); }
 
 xla::Shape MaximumOutputShape(const XlaValue& input, const XlaValue& other) {
   auto lower_for_shape_fn =

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -20,6 +20,9 @@ xla::Shape AtanhOutputShape(const XlaValue& input);
 xla::Shape CosOutputShape(const XlaValue& input);
 
 xla::Shape CoshOutputShape(const XlaValue& input);
+xla::Shape LogOutputShape(const XlaValue& input);
+
+// xla::Shape Log1pOutputShape(const XlaValue& input);
 
 xla::Shape MaximumOutputShape(const XlaValue& input, const XlaValue& other);
 

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -20,6 +20,7 @@ xla::Shape AtanhOutputShape(const XlaValue& input);
 xla::Shape CosOutputShape(const XlaValue& input);
 
 xla::Shape CoshOutputShape(const XlaValue& input);
+
 xla::Shape LogOutputShape(const XlaValue& input);
 
 xla::Shape Log2OutputShape(const XlaValue& input);

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -22,7 +22,9 @@ xla::Shape CosOutputShape(const XlaValue& input);
 xla::Shape CoshOutputShape(const XlaValue& input);
 xla::Shape LogOutputShape(const XlaValue& input);
 
-// xla::Shape Log1pOutputShape(const XlaValue& input);
+xla::Shape Log2OutputShape(const XlaValue& input);
+
+xla::Shape Log10OutputShape(const XlaValue& input);
 
 xla::Shape MaximumOutputShape(const XlaValue& input, const XlaValue& other);
 

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -732,9 +732,6 @@ class XLATensor : public c10::intrusive_ptr_target {
                             const int64_t steps, at::ScalarType element_type,
                             const torch::lazy::BackendDevice& device);
 
-  static XLATensor log_base(const XLATensor& input, torch::lazy::OpKind op,
-                            double base);
-
   static XLATensor log_sigmoid(const XLATensor& input);
   static std::tuple<XLATensor, XLATensor> log_sigmoid_forward(
       const XLATensor& input);

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -732,8 +732,6 @@ class XLATensor : public c10::intrusive_ptr_target {
                             const int64_t steps, at::ScalarType element_type,
                             const torch::lazy::BackendDevice& device);
 
-  static XLATensor log(const XLATensor& input);
-
   static XLATensor log_base(const XLATensor& input, torch::lazy::OpKind op,
                             double base);
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1670,17 +1670,6 @@ XLATensor XLATensor::linspace(const at::Scalar& start, const at::Scalar& end,
       element_type);
 }
 
-XLATensor XLATensor::log_base(const XLATensor& input, torch::lazy::OpKind op,
-                              double base) {
-  // Here we explictly pass c10::nullopt as logical_element_type because
-  // otherwise result will inherit the input's logical_element_type. In the
-  // case of logbase(int) -> float, we want to derive the dtype from IR value
-  // instead of input's logical_element_type.
-  return input.CreateFrom(
-      LogBase(GetFloatingIrValue(input, at::ScalarType::Float), op, base),
-      c10::nullopt);
-}
-
 XLATensor XLATensor::log_sigmoid(const XLATensor& input) {
   torch::lazy::NodePtr node = LogSigmoid(input.GetIrValue());
   return input.CreateFrom(XlaValue(node, 0));

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1670,15 +1670,6 @@ XLATensor XLATensor::linspace(const at::Scalar& start, const at::Scalar& end,
       element_type);
 }
 
-XLATensor XLATensor::log(const XLATensor& input) {
-  // Here we explictly pass c10::nullopt as logical_element_type because
-  // otherwise result will inherit the input's logical_element_type. In the
-  // case of log(int) -> float, we want to derive the dtype from IR value
-  // instead of input's logical_element_type.
-  return input.CreateFrom(Log(GetFloatingIrValue(input, at::ScalarType::Float)),
-                          c10::nullopt);
-}
-
 XLATensor XLATensor::log_base(const XLATensor& input, torch::lazy::OpKind op,
                               double base) {
   // Here we explictly pass c10::nullopt as logical_element_type because

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -11,6 +11,8 @@ full_codegen:
   - cos
   - cosh
   - log
+  - log2
+  - log10
   - maximum
   - sgn
   - sign
@@ -168,8 +170,6 @@ supported:
   - lerp.Tensor
   - linspace
   - log1p
-  - log2
-  - log10
   - log_sigmoid_backward
   - log_sigmoid_forward
   - logdet

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -10,6 +10,7 @@ full_codegen:
   - atanh
   - cos
   - cosh
+  - log
   - maximum
   - sgn
   - sign
@@ -166,7 +167,6 @@ supported:
   - lerp.Scalar
   - lerp.Tensor
   - linspace
-  - log
   - log1p
   - log2
   - log10


### PR DESCRIPTION
Full codegen for `log`, `log2`, and `log10`

---

Generated `LazyIr.h`

```
class Log : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::log);
  }
  Log(const torch_xla::XlaValue& self, std::vector<torch::lazy::Shape>&& shapes)

      : XlaNode(torch::lazy::OpKind(at::aten::log),
              {self}, std::move(shapes),
              [&]() { return LogOutputShape(self); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
  {  }
  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();
    return ss.str();
  }
  bool CanBeReused(const torch_xla::XlaValue& self) const {
    return false;
    }
  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;
};

class Log10 : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::log10);
  }

  Log10(const torch_xla::XlaValue& self, std::vector<torch::lazy::Shape>&& shapes)

      : XlaNode(torch::lazy::OpKind(at::aten::log10),
              {self}, std::move(shapes),
              [&]() { return Log10OutputShape(self); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
  {  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();
    return ss.str();
  }
  bool CanBeReused(const torch_xla::XlaValue& self) const {
    return false;
    }
  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;
};

class Log2 : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::log2);
  }

  Log2(const torch_xla::XlaValue& self, std::vector<torch::lazy::Shape>&& shapes)

      : XlaNode(torch::lazy::OpKind(at::aten::log2),
              {self}, std::move(shapes),
              [&]() { return Log2OutputShape(self); },
              /* num_outputs */ 1,
              torch::lazy::MHash()
  {  }
  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();

    return ss.str();
  }
  bool CanBeReused(const torch_xla::XlaValue& self) const {
    return false;
    }
  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;
};
```
---

Generate `XLANativeFunctions.cpp`


```
    at::Tensor XLANativeFunctions::log(const at::Tensor & self) {
        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self);
        TORCH_INTERNAL_ASSERT(common_device);
        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        torch::lazy::NodePtr node = torch::lazy::ReuseNode<Log>(lazy_self->GetIrValue());
        if (!node) {
            auto out_meta = at::meta::log(self);
            std::vector<torch::lazy::Shape> shapes{
        torch::lazy::Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
            TORCH_INTERNAL_ASSERT(shapes.size() == 1);
            if(torch::lazy::symbolicShapeEnabled()){
                std::vector<torch::jit::IValue> inputs = { self };
                char* schema_str = "aten::log(Tensor self) -> Tensor";
                applySymbolicShapesOnLT(schema_str, inputs, shapes);
            }
            node = torch::lazy::MakeNode<Log>(lazy_self->GetIrValue(), std::move(shapes));
            CacheNode(node);
        }
        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };


    at::Tensor XLANativeFunctions::log10(const at::Tensor & self) {
        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self);
        TORCH_INTERNAL_ASSERT(common_device);
        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        torch::lazy::NodePtr node = torch::lazy::ReuseNode<Log10>(lazy_self->GetIrValue());
        if (!node) {
            auto out_meta = at::meta::log10(self);
            std::vector<torch::lazy::Shape> shapes{
        torch::lazy::Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
            TORCH_INTERNAL_ASSERT(shapes.size() == 1);
            if(torch::lazy::symbolicShapeEnabled()){
                std::vector<torch::jit::IValue> inputs = { self };
                char* schema_str = "aten::log10(Tensor self) -> Tensor";
                applySymbolicShapesOnLT(schema_str, inputs, shapes);
            }

            node = torch::lazy::MakeNode<Log10>(lazy_self->GetIrValue(), std::move(shapes));
            CacheNode(node);
        }
        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };


    at::Tensor XLANativeFunctions::log2(const at::Tensor & self) {
        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self);
        TORCH_INTERNAL_ASSERT(common_device);
        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        torch::lazy::NodePtr node = torch::lazy::ReuseNode<Log2>(lazy_self->GetIrValue());
        if (!node) {
            auto out_meta = at::meta::log2(self);
            std::vector<torch::lazy::Shape> shapes{
        torch::lazy::Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
            TORCH_INTERNAL_ASSERT(shapes.size() == 1);
            if(torch::lazy::symbolicShapeEnabled()){
                std::vector<torch::jit::IValue> inputs = { self };
                char* schema_str = "aten::log2(Tensor self) -> Tensor";
                applySymbolicShapesOnLT(schema_str, inputs, shapes);
            }

            node = torch::lazy::MakeNode<Log2>(lazy_self->GetIrValue(), std::move(shapes));
            CacheNode(node);
        }

        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };
```