### PR TITLE
Full codegen for `cos` and `cosh`

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1142,16 +1142,6 @@ XLANativeFunctions::convolution_backward_overrideable(
                      : at::Tensor());
 }
 
-at::Tensor XLANativeFunctions::cos(const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(XLATensor::cos(bridge::GetXlaTensor(self)));
-}
-
-at::Tensor XLANativeFunctions::cosh(const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(XLATensor::cosh(bridge::GetXlaTensor(self)));
-}
-
 at::Tensor XLANativeFunctions::cross(const at::Tensor& self,
                                      const at::Tensor& other,
                                      c10::optional<int64_t> dim) {

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -67,8 +67,6 @@ namespace torch_xla {
                      std::move(lower_fn));                                     \
   }
 
-PTXLA_UNARY_OP(Cos, at::aten::cos, xla::Cos);
-PTXLA_UNARY_OP(Cosh, at::aten::cosh, xla::Cosh);
 PTXLA_UNARY_OP(Sin, at::aten::sin, xla::Sin);
 PTXLA_UNARY_OP(Sinh, at::aten::sinh, xla::Sinh);
 PTXLA_UNARY_OP(Tan, at::aten::tan, xla::Tan);

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -55,10 +55,6 @@ inline torch::lazy::NodePtr GenericOp(torch::lazy::OpKind op, xla::Shape shape,
                                         hash_seed);
 }
 
-torch::lazy::NodePtr Cos(const XlaValue& input);
-
-torch::lazy::NodePtr Cosh(const XlaValue& input);
-
 torch::lazy::NodePtr Sin(const XlaValue& input);
 
 torch::lazy::NodePtr Sinh(const XlaValue& input);

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -41,6 +41,16 @@ torch_xla::XlaOpVector Atanh::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::Atanh(xla_input), loctx);
 }
 
+torch_xla::XlaOpVector Cos::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  return ReturnOp(xla::Cos(xla_input), loctx);
+}
+
+torch_xla::XlaOpVector Cosh::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  return ReturnOp(xla::Cosh(xla_input), loctx);
+}
+
 torch_xla::XlaOpVector Maximum::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   xla::XlaOp xla_other = loctx->GetOutputOp(operand(1));

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -18,6 +18,10 @@ xla::Shape AtanOutputShape(const XlaValue& input) { return input.xla_shape(); }
 
 xla::Shape AtanhOutputShape(const XlaValue& input) { return input.xla_shape(); }
 
+xla::Shape CosOutputShape(const XlaValue& input) { return input.xla_shape(); }
+
+xla::Shape CoshOutputShape(const XlaValue& input) { return input.xla_shape(); }
+
 xla::Shape MaximumOutputShape(const XlaValue& input, const XlaValue& other) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -17,6 +17,10 @@ xla::Shape AtanOutputShape(const XlaValue& input);
 
 xla::Shape AtanhOutputShape(const XlaValue& input);
 
+xla::Shape CosOutputShape(const XlaValue& input);
+
+xla::Shape CoshOutputShape(const XlaValue& input);
+
 xla::Shape MaximumOutputShape(const XlaValue& input, const XlaValue& other);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -505,10 +505,6 @@ class XLATensor : public c10::intrusive_ptr_target {
       std::vector<int64_t> dilation, bool transposed,
       std::vector<int64_t> output_padding, int64_t groups);
 
-  static XLATensor cos(const XLATensor& input);
-
-  static XLATensor cosh(const XLATensor& input);
-
   // Returns the cross product of the two input tensors in the given dimension.
   // If the dimension is not given, it defaults to the first dimension found
   // with the size 3.

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1122,14 +1122,6 @@ XLATensor::convolution_backward_overrideable(
                          std::move(grad_bias));
 }
 
-XLATensor XLATensor::cos(const XLATensor& input) {
-  return input.CreateFrom(Cos(input.GetIrValue()));
-}
-
-XLATensor XLATensor::cosh(const XLATensor& input) {
-  return input.CreateFrom(Cosh(input.GetIrValue()));
-}
-
 XLATensor XLATensor::cross(const XLATensor& input, const XLATensor& other,
                            c10::optional<int64_t> dim) {
   return tensor_ops::Cross(input, other, dim);

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -8,6 +8,8 @@ full_codegen:
   - asinh
   - atan
   - atanh
+  - cos
+  - cosh
   - maximum
 supported:
   - __ilshift__.Scalar
@@ -91,8 +93,6 @@ supported:
   - constant_pad_nd
   - convolution_backward_overrideable
   - convolution_overrideable
-  - cos
-  - cosh
   - cross
   - cumprod
   - cumsum


### PR DESCRIPTION
Full codegen for `cos` and `cosh`

---
Generated in `LazyIr.h`
```
  Cos(const torch_xla::XlaValue& self, std::vector<torch::lazy::Shape>&& shapes)
      : XlaNode(torch::lazy::OpKind(at::aten::cos),
              {self}, std::move(shapes),
              [&]() { return CosOutputShape(self); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
  {  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();

    return ss.str();
  }

  bool CanBeReused(const torch_xla::XlaValue& self) const {
    return false;
    }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;
};

class Cosh : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::cosh);
  }

  Cosh(const torch_xla::XlaValue& self, std::vector<torch::lazy::Shape>&& shapes)

      : XlaNode(torch::lazy::OpKind(at::aten::cosh),
              {self}, std::move(shapes),
              [&]() { return CoshOutputShape(self); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
  {  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();

    return ss.str();
  }
  bool CanBeReused(const torch_xla::XlaValue& self) const {
    return false;
    }
  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;
};
```

---
Generated in `XLANativeFunctions.cpp`

```
    at::Tensor XLANativeFunctions::cos(const at::Tensor & self) {

        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self);
        TORCH_INTERNAL_ASSERT(common_device);

        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        torch::lazy::NodePtr node = torch::lazy::ReuseNode<Cos>(lazy_self->GetIrValue());
        if (!node) {
            auto out_meta = at::meta::cos(self);
            std::vector<torch::lazy::Shape> shapes{
        torch::lazy::Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
            TORCH_INTERNAL_ASSERT(shapes.size() == 1);
            if(torch::lazy::symbolicShapeEnabled()){
                std::vector<torch::jit::IValue> inputs = { self };
                char* schema_str = "aten::cos(Tensor self) -> Tensor";
                applySymbolicShapesOnLT(schema_str, inputs, shapes);
            }

            node = torch::lazy::MakeNode<Cos>(lazy_self->GetIrValue(), std::move(shapes));
            CacheNode(node);
        }

        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };


    at::Tensor XLANativeFunctions::cosh(const at::Tensor & self) {

        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self);
        TORCH_INTERNAL_ASSERT(common_device);

        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        torch::lazy::NodePtr node = torch::lazy::ReuseNode<Cosh>(lazy_self->GetIrValue());
        if (!node) {
            auto out_meta = at::meta::cosh(self);
            std::vector<torch::lazy::Shape> shapes{
        torch::lazy::Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
            TORCH_INTERNAL_ASSERT(shapes.size() == 1);
            if(torch::lazy::symbolicShapeEnabled()){
                std::vector<torch::jit::IValue> inputs = { self };
                char* schema_str = "aten::cosh(Tensor self) -> Tensor";
                applySymbolicShapesOnLT(schema_str, inputs, shapes);
            }

            node = torch::lazy::MakeNode<Cosh>(lazy_self->GetIrValue(), std::move(shapes));
            CacheNode(node);
        }

        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };
```