### PR TITLE
Full codegen for `Inverse`

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1656,11 +1656,11 @@ at::Tensor XLANativeFunctions::index_select(const at::Tensor& self, int64_t dim,
       bridge::GetXlaTensor(self), dim, bridge::GetXlaTensor(index)));
 }
 
-at::Tensor XLANativeFunctions::inverse(const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(
-      XLATensor::inverse(bridge::GetXlaTensor(self)));
-}
+// at::Tensor XLANativeFunctions::inverse(const at::Tensor& self) {
+//   XLA_FN_COUNTER("xla::");
+//   return bridge::AtenFromXlaTensor(
+//       XLATensor::inverse(bridge::GetXlaTensor(self)));
+// }
 
 at::Tensor XLANativeFunctions::isnan(const at::Tensor& self) {
   XLA_FN_COUNTER("xla::");

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1656,12 +1656,6 @@ at::Tensor XLANativeFunctions::index_select(const at::Tensor& self, int64_t dim,
       bridge::GetXlaTensor(self), dim, bridge::GetXlaTensor(index)));
 }
 
-// at::Tensor XLANativeFunctions::inverse(const at::Tensor& self) {
-//   XLA_FN_COUNTER("xla::");
-//   return bridge::AtenFromXlaTensor(
-//       XLATensor::inverse(bridge::GetXlaTensor(self)));
-// }
-
 at::Tensor XLANativeFunctions::isnan(const at::Tensor& self) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -925,17 +925,6 @@ torch::lazy::NodePtr LogDet(const torch::lazy::Value& input) {
                    std::move(lower_fn));
 }
 
-// torch::lazy::NodePtr Inverse(const XlaValue& input) {
-//   auto lower_fn = [](const XlaNode& node,
-//                      LoweringContext* loctx) -> XlaOpVector {
-//     xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
-//     xla::XlaOp result = BuildInverse(xla_input);
-//     return node.ReturnOp(result, loctx);
-//   };
-//   return GenericOp(torch::lazy::OpKind(at::aten::inverse), {input},
-//                    input.xla_shape(), std::move(lower_fn));
-// }
-
 torch::lazy::NodePtr BaddBmm(const torch::lazy::Value& lhs,
                              const torch::lazy::Value& rhs,
                              const torch::lazy::Value& bias,

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -925,16 +925,16 @@ torch::lazy::NodePtr LogDet(const torch::lazy::Value& input) {
                    std::move(lower_fn));
 }
 
-torch::lazy::NodePtr Inverse(const torch::lazy::Value& input) {
-  auto lower_fn = [](const XlaNode& node,
-                     LoweringContext* loctx) -> XlaOpVector {
-    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
-    xla::XlaOp result = BuildInverse(xla_input);
-    return node.ReturnOp(result, loctx);
-  };
-  return GenericOp(torch::lazy::OpKind(at::aten::inverse), {input},
-                   GetXlaShape(input), std::move(lower_fn));
-}
+// torch::lazy::NodePtr Inverse(const XlaValue& input) {
+//   auto lower_fn = [](const XlaNode& node,
+//                      LoweringContext* loctx) -> XlaOpVector {
+//     xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
+//     xla::XlaOp result = BuildInverse(xla_input);
+//     return node.ReturnOp(result, loctx);
+//   };
+//   return GenericOp(torch::lazy::OpKind(at::aten::inverse), {input},
+//                    input.xla_shape(), std::move(lower_fn));
+// }
 
 torch::lazy::NodePtr BaddBmm(const torch::lazy::Value& lhs,
                              const torch::lazy::Value& rhs,

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -254,7 +254,7 @@ torch::lazy::NodePtr TanhGeluBackward(const torch::lazy::Value& grad,
 
 torch::lazy::NodePtr LogDet(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr IsNan(const XlaValue& input);
+torch::lazy::NodePtr IsNan(const torch::lazy::Value& input);
 
 torch::lazy::NodePtr BaddBmm(const torch::lazy::Value& lhs,
                              const torch::lazy::Value& rhs,

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -254,7 +254,7 @@ torch::lazy::NodePtr TanhGeluBackward(const torch::lazy::Value& grad,
 
 torch::lazy::NodePtr LogDet(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Inverse(const torch::lazy::Value& input);
+// torch::lazy::NodePtr Inverse(const XlaValue& input);
 
 torch::lazy::NodePtr IsNan(const torch::lazy::Value& input);
 

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -254,9 +254,7 @@ torch::lazy::NodePtr TanhGeluBackward(const torch::lazy::Value& grad,
 
 torch::lazy::NodePtr LogDet(const torch::lazy::Value& input);
 
-// torch::lazy::NodePtr Inverse(const XlaValue& input);
-
-torch::lazy::NodePtr IsNan(const torch::lazy::Value& input);
+torch::lazy::NodePtr IsNan(const XlaValue& input);
 
 torch::lazy::NodePtr BaddBmm(const torch::lazy::Value& lhs,
                              const torch::lazy::Value& rhs,

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -50,6 +50,8 @@ torch_xla::XlaOpVector Cos::Lower(LoweringContext* loctx) const {
 torch_xla::XlaOpVector Cosh::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   return ReturnOp(xla::Cosh(xla_input), loctx);
+}
+
 torch_xla::XlaOpVector Inverse::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   return ReturnOp(BuildInverse(xla_input), loctx);

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -52,7 +52,7 @@ torch_xla::XlaOpVector Cosh::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::Cosh(xla_input), loctx);
 torch_xla::XlaOpVector Inverse::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
-  return node.ReturnOp(BuildInverse(xla_input), loctx);
+  return ReturnOp(BuildInverse(xla_input), loctx);
 }
 
 torch_xla::XlaOpVector Maximum::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -3,6 +3,7 @@
 #include "tensorflow/compiler/xla/client/lib/math.h"
 #include "torch_xla/csrc/elementwise.h"
 #include "torch_xla/csrc/helpers.h"
+#include "torch_xla/csrc/matrix.h"
 
 namespace torch_xla {
 
@@ -49,6 +50,9 @@ torch_xla::XlaOpVector Cos::Lower(LoweringContext* loctx) const {
 torch_xla::XlaOpVector Cosh::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   return ReturnOp(xla::Cosh(xla_input), loctx);
+torch_xla::XlaOpVector Inverse::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  return node.ReturnOp(BuildInverse(xla_input), loctx);
 }
 
 torch_xla::XlaOpVector Maximum::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -42,6 +42,9 @@ xla::Shape CoshOutputShape(const torch::lazy::Value& input) {
 
 xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
                               const torch::lazy::Value& other) {
+xla::Shape InverseOutputShape(const XlaValue& input) { return input.xla_shape(); }
+
+xla::Shape MaximumOutputShape(const XlaValue& input, const XlaValue& other) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     auto promoted = XlaHelpers::Promote(operands[0], operands[1]);

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -40,7 +40,9 @@ xla::Shape CoshOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
-xla::Shape InverseOutputShape(const torch::lazy::Value& input) { return GetXlaShape(input); }
+xla::Shape InverseOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
+}
 
 xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
                               const torch::lazy::Value& other) {

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -40,7 +40,7 @@ xla::Shape CoshOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
-xla::Shape InverseOutputShape(const XlaValue& input) { return input.xla_shape(); }
+xla::Shape InverseOutputShape(const torch::lazy::Value& input) { return GetXlaShape(input); }
 
 xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
                               const torch::lazy::Value& other) {

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -40,11 +40,10 @@ xla::Shape CoshOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
-xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
-                              const torch::lazy::Value& other) {
 xla::Shape InverseOutputShape(const XlaValue& input) { return input.xla_shape(); }
 
-xla::Shape MaximumOutputShape(const XlaValue& input, const XlaValue& other) {
+xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
+                              const torch::lazy::Value& other) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     auto promoted = XlaHelpers::Promote(operands[0], operands[1]);

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -21,6 +21,8 @@ xla::Shape CosOutputShape(const torch::lazy::Value& input);
 
 xla::Shape CoshOutputShape(const torch::lazy::Value& input);
 
+xla::Shape InverseOutputShape(const XlaValue& input);
+
 xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
                               const torch::lazy::Value& other);
 
@@ -33,8 +35,5 @@ xla::Shape SinOutputShape(const torch::lazy::Value& input);
 xla::Shape SinhOutputShape(const torch::lazy::Value& input);
 
 xla::Shape TanOutputShape(const torch::lazy::Value& input);
-xla::Shape InverseOutputShape(const XlaValue& input);
-
-xla::Shape MaximumOutputShape(const XlaValue& input, const XlaValue& other);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -33,5 +33,8 @@ xla::Shape SinOutputShape(const torch::lazy::Value& input);
 xla::Shape SinhOutputShape(const torch::lazy::Value& input);
 
 xla::Shape TanOutputShape(const torch::lazy::Value& input);
+xla::Shape InverseOutputShape(const XlaValue& input);
+
+xla::Shape MaximumOutputShape(const XlaValue& input, const XlaValue& other);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -21,7 +21,7 @@ xla::Shape CosOutputShape(const torch::lazy::Value& input);
 
 xla::Shape CoshOutputShape(const torch::lazy::Value& input);
 
-xla::Shape InverseOutputShape(const XlaValue& input);
+xla::Shape InverseOutputShape(const torch::lazy::Value& input);
 
 xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
                               const torch::lazy::Value& other);

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -674,7 +674,7 @@ class XLATensor : public c10::intrusive_ptr_target {
   static XLATensor index_select(const XLATensor& input, int64_t dim,
                                 const XLATensor& index);
 
-  static XLATensor inverse(const XLATensor& input);
+//   static XLATensor inverse(const XLATensor& input);
 
   static XLATensor isnan(const XLATensor& input);
 

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -674,8 +674,6 @@ class XLATensor : public c10::intrusive_ptr_target {
   static XLATensor index_select(const XLATensor& input, int64_t dim,
                                 const XLATensor& index);
 
-//   static XLATensor inverse(const XLATensor& input);
-
   static XLATensor isnan(const XLATensor& input);
 
   static XLATensor kl_div_backward(const XLATensor& grad_output,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1544,9 +1544,9 @@ XLATensor XLATensor::index_select(const XLATensor& input, int64_t dim,
       index_value));
 }
 
-XLATensor XLATensor::inverse(const XLATensor& input) {
-  return input.CreateFrom(Inverse(input.GetIrValue()));
-}
+// XLATensor XLATensor::inverse(const XLATensor& input) {
+//   return input.CreateFrom(Inverse(input.GetIrValue()));
+// }
 
 XLATensor XLATensor::isnan(const XLATensor& input) {
   torch::lazy::Value result = IsNan(input.GetIrValue());

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1544,10 +1544,6 @@ XLATensor XLATensor::index_select(const XLATensor& input, int64_t dim,
       index_value));
 }
 
-// XLATensor XLATensor::inverse(const XLATensor& input) {
-//   return input.CreateFrom(Inverse(input.GetIrValue()));
-// }
-
 XLATensor XLATensor::isnan(const XLATensor& input) {
   torch::lazy::Value result = IsNan(input.GetIrValue());
   torch::lazy::Value casted = GetBooleanIrValue(result);

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -10,6 +10,7 @@ full_codegen:
   - atanh
   - cos
   - cosh
+  - inverse
   - maximum
   - sgn
   - sign
@@ -155,7 +156,6 @@ supported:
   - index_fill_.int_Tensor
   - index_put_
   - index_select
-  - inverse
   - isnan
   - kl_div
   - kl_div_backward


### PR DESCRIPTION
Full codegen for `Inverse`

- [x] Compilation is blocked on PyTorch shape inference landing in `torch/csrc/lazy/core/shape_inference.h`
 -  PR: https://github.com/pytorch/pytorch/pull/77888

---
Generate `LazyIr.h`

```
class Inverse : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::inverse);
  }

  Inverse(const torch::lazy::Value& self, std::vector<torch::lazy::Shape>&& shapes)

      : XlaNode(torch::lazy::OpKind(at::aten::inverse),
              {self}, std::move(shapes),
              [&]() { return InverseOutputShape(self); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
  {

  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();

    return ss.str();
  }

  bool CanBeReused(const torch::lazy::Value& self) const {
    return false;
    }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;
};
```

---
Generated `XLANativeFunctions.cpp `:

```
    at::Tensor XLANativeFunctions::inverse(const at::Tensor & self) {

        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self);
        TORCH_INTERNAL_ASSERT(common_device);

        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        torch::lazy::NodePtr node = torch::lazy::ReuseNode<Inverse>(lazy_self->GetIrValue());
        if (!node) {

            auto shapes = torch::lazy::compute_shape_inverse(self);
            TORCH_INTERNAL_ASSERT(shapes.size() == 1);
            if(torch::lazy::symbolicShapeEnabled()){
                std::vector<torch::jit::IValue> inputs = { self };
                char* schema_str = "aten::inverse(Tensor self) -> Tensor";
                applySymbolicShapesOnLT(schema_str, inputs, shapes);
            }

            node = torch::lazy::MakeNode<Inverse>(lazy_self->GetIrValue(), std::move(shapes));
            CacheNode(node);
        }

        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };
```