### PR TITLE
Full codegen for `logdet`

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1835,12 +1835,6 @@ at::Tensor XLANativeFunctions::logsumexp(const at::Tensor& self,
       /*keep_reduced_dimensions=*/keepdim));
 }
 
-at::Tensor XLANativeFunctions::logdet(const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(
-      XLATensor::logdet(bridge::GetXlaTensor(self)));
-}
-
 at::Tensor XLANativeFunctions::xlogy(const at::Tensor& self,
                                      const at::Tensor& other) {
   XLA_FN_COUNTER("xla::");
@@ -2946,15 +2940,6 @@ at::Tensor XLANativeFunctions::slice(const at::Tensor& self, int64_t dim,
   int64_t end_val = end.has_value() ? end.value() : INT64_MAX;
   return bridge::AtenFromXlaTensor(XLATensor::slice(
       bridge::GetXlaTensor(self), dim, start_val, end_val, step));
-}
-
-std::tuple<at::Tensor, at::Tensor> XLANativeFunctions::slogdet(
-    const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  XLATensor self_tensor = bridge::GetXlaTensor(self);
-  auto outputs = XLATensor::slogdet(self_tensor);
-  return std::make_tuple(bridge::AtenFromXlaTensor(std::get<0>(outputs)),
-                         bridge::AtenFromXlaTensor(std::get<1>(outputs)));
 }
 
 at::Tensor XLANativeFunctions::smooth_l1_loss(const at::Tensor& self,

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1835,15 +1835,6 @@ at::Tensor XLANativeFunctions::logsumexp(const at::Tensor& self,
       /*keep_reduced_dimensions=*/keepdim));
 }
 
-std::tuple<at::Tensor, at::Tensor> XLANativeFunctions::slogdet(
-    const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  XLATensor self_tensor = bridge::GetXlaTensor(self);
-  auto outputs = XLATensor::slogdet(self_tensor);
-  return std::make_tuple(bridge::AtenFromXlaTensor(std::get<0>(outputs)),
-                         bridge::AtenFromXlaTensor(std::get<1>(outputs)));
-}
-
 at::Tensor XLANativeFunctions::xlogy(const at::Tensor& self,
                                      const at::Tensor& other) {
   XLA_FN_COUNTER("xla::");
@@ -2949,6 +2940,15 @@ at::Tensor XLANativeFunctions::slice(const at::Tensor& self, int64_t dim,
   int64_t end_val = end.has_value() ? end.value() : INT64_MAX;
   return bridge::AtenFromXlaTensor(XLATensor::slice(
       bridge::GetXlaTensor(self), dim, start_val, end_val, step));
+}
+
+std::tuple<at::Tensor, at::Tensor> XLANativeFunctions::slogdet(
+    const at::Tensor& self) {
+  XLA_FN_COUNTER("xla::");
+  XLATensor self_tensor = bridge::GetXlaTensor(self);
+  auto outputs = XLATensor::slogdet(self_tensor);
+  return std::make_tuple(bridge::AtenFromXlaTensor(std::get<0>(outputs)),
+                         bridge::AtenFromXlaTensor(std::get<1>(outputs)));
 }
 
 at::Tensor XLANativeFunctions::smooth_l1_loss(const at::Tensor& self,

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1835,13 +1835,6 @@ at::Tensor XLANativeFunctions::logsumexp(const at::Tensor& self,
       /*keep_reduced_dimensions=*/keepdim));
 }
 
-at::Tensor XLANativeFunctions::xlogy(const at::Tensor& self,
-                                     const at::Tensor& other) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(XLATensor::xlogy(
-      bridge::GetXlaTensor(self), bridge::GetXlaTensor(other)));
-}
-
 std::tuple<at::Tensor, at::Tensor> XLANativeFunctions::slogdet(
     const at::Tensor& self) {
   XLA_FN_COUNTER("xla::");
@@ -1849,6 +1842,13 @@ std::tuple<at::Tensor, at::Tensor> XLANativeFunctions::slogdet(
   auto outputs = XLATensor::slogdet(self_tensor);
   return std::make_tuple(bridge::AtenFromXlaTensor(std::get<0>(outputs)),
                          bridge::AtenFromXlaTensor(std::get<1>(outputs)));
+}
+
+at::Tensor XLANativeFunctions::xlogy(const at::Tensor& self,
+                                     const at::Tensor& other) {
+  XLA_FN_COUNTER("xla::");
+  return bridge::AtenFromXlaTensor(XLATensor::xlogy(
+      bridge::GetXlaTensor(self), bridge::GetXlaTensor(other)));
 }
 
 at::Tensor XLANativeFunctions::lt(const at::Tensor& self,

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1842,6 +1842,15 @@ at::Tensor XLANativeFunctions::xlogy(const at::Tensor& self,
       bridge::GetXlaTensor(self), bridge::GetXlaTensor(other)));
 }
 
+std::tuple<at::Tensor, at::Tensor> XLANativeFunctions::slogdet(
+    const at::Tensor& self) {
+  XLA_FN_COUNTER("xla::");
+  XLATensor self_tensor = bridge::GetXlaTensor(self);
+  auto outputs = XLATensor::slogdet(self_tensor);
+  return std::make_tuple(bridge::AtenFromXlaTensor(std::get<0>(outputs)),
+                         bridge::AtenFromXlaTensor(std::get<1>(outputs)));
+}
+
 at::Tensor XLANativeFunctions::lt(const at::Tensor& self,
                                   const at::Scalar& other) {
   XLA_FN_COUNTER("xla::");

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -1113,13 +1113,6 @@ torch::lazy::NodePtr SLogDet(const torch::lazy::Value& input) {
 
 torch::lazy::NodePtr Softplus(const torch::lazy::Value& input,
                               const torch::lazy::Value& beta,
-=======
-torch::lazy::NodePtr Softplus(const torch::lazy::Value& input, const torch::lazy::Value& beta,
->>>>>>> 15e41af4 (merge conflict resolution)
-=======
-torch::lazy::NodePtr Softplus(const torch::lazy::Value& input,
-                              const torch::lazy::Value& beta,
->>>>>>> 7260a694 (linter)
                               const torch::lazy::Value& threshold) {
   auto lower_fn = [](const XlaNode& node,
                      LoweringContext* loctx) -> XlaOpVector {

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 
+#include "tensorflow/compiler/xla/client/lib/logdet.h"
 #include "tensorflow/compiler/xla/client/lib/math.h"
 #include "tensorflow/compiler/xla/client/lib/matrix.h"
 #include "tensorflow/compiler/xla/shape_util.h"
@@ -1105,8 +1106,6 @@ torch::lazy::NodePtr NanToNum(const torch::lazy::Value& input,
                    std::move(lower_fn));
 }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 torch::lazy::NodePtr SLogDet(const torch::lazy::Value& input) {
   auto lower_fn = [](const XlaNode& node,
                      LoweringContext* loctx) -> XlaOpVector {

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -908,23 +908,6 @@ torch::lazy::NodePtr TanhGeluBackward(const torch::lazy::Value& grad,
   return grad * (left_derivative + right_derivative);
 }
 
-torch::lazy::NodePtr LogDet(const torch::lazy::Value& input) {
-  auto lower_fn = [](const XlaNode& node,
-                     LoweringContext* loctx) -> XlaOpVector {
-    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
-    xla::XlaOp result = xla::LogDet(xla_input);
-    return node.ReturnOp(result, loctx);
-  };
-  const xla::Shape& input_shape = GetXlaShape(input);
-  XLA_CHECK_GE(input_shape.rank(), 2) << input_shape;
-  // The input tensor is ...,N,N
-  xla::Shape logdet_shape(input_shape);
-  logdet_shape.DeleteDimension(input_shape.rank() - 1);
-  logdet_shape.DeleteDimension(input_shape.rank() - 2);
-  return GenericOp(torch::lazy::OpKind(at::aten::logdet), {input}, logdet_shape,
-                   std::move(lower_fn));
-}
-
 torch::lazy::NodePtr BaddBmm(const torch::lazy::Value& lhs,
                              const torch::lazy::Value& rhs,
                              const torch::lazy::Value& bias,

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -1105,6 +1105,7 @@ torch::lazy::NodePtr NanToNum(const torch::lazy::Value& input,
                    std::move(lower_fn));
 }
 
+<<<<<<< HEAD
 torch::lazy::NodePtr SLogDet(const torch::lazy::Value& input) {
   auto lower_fn = [](const XlaNode& node,
                      LoweringContext* loctx) -> XlaOpVector {
@@ -1129,6 +1130,9 @@ torch::lazy::NodePtr SLogDet(const torch::lazy::Value& input) {
 
 torch::lazy::NodePtr Softplus(const torch::lazy::Value& input,
                               const torch::lazy::Value& beta,
+=======
+torch::lazy::NodePtr Softplus(const torch::lazy::Value& input, const torch::lazy::Value& beta,
+>>>>>>> 15e41af4 (merge conflict resolution)
                               const torch::lazy::Value& threshold) {
   auto lower_fn = [](const XlaNode& node,
                      LoweringContext* loctx) -> XlaOpVector {

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -2,7 +2,6 @@
 
 #include <cmath>
 
-#include "tensorflow/compiler/xla/client/lib/logdet.h"
 #include "tensorflow/compiler/xla/client/lib/math.h"
 #include "tensorflow/compiler/xla/client/lib/matrix.h"
 #include "tensorflow/compiler/xla/shape_util.h"

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -1106,6 +1106,7 @@ torch::lazy::NodePtr NanToNum(const torch::lazy::Value& input,
 }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 torch::lazy::NodePtr SLogDet(const torch::lazy::Value& input) {
   auto lower_fn = [](const XlaNode& node,
                      LoweringContext* loctx) -> XlaOpVector {
@@ -1133,6 +1134,10 @@ torch::lazy::NodePtr Softplus(const torch::lazy::Value& input,
 =======
 torch::lazy::NodePtr Softplus(const torch::lazy::Value& input, const torch::lazy::Value& beta,
 >>>>>>> 15e41af4 (merge conflict resolution)
+=======
+torch::lazy::NodePtr Softplus(const torch::lazy::Value& input,
+                              const torch::lazy::Value& beta,
+>>>>>>> 7260a694 (linter)
                               const torch::lazy::Value& threshold) {
   auto lower_fn = [](const XlaNode& node,
                      LoweringContext* loctx) -> XlaOpVector {

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -285,7 +285,8 @@ torch::lazy::NodePtr NanToNum(const torch::lazy::Value& input,
                               const torch::lazy::Value& posinf,
                               const torch::lazy::Value& neginf);
 
-torch::lazy::NodePtr Softplus(const torch::lazy::Value& input, const torch::lazy::Value& beta,
+torch::lazy::NodePtr Softplus(const torch::lazy::Value& input,
+                              const torch::lazy::Value& beta,
                               const torch::lazy::Value& threshold);
 
 torch::lazy::NodePtr Selu(const torch::lazy::Value& input);

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -285,11 +285,8 @@ torch::lazy::NodePtr NanToNum(const torch::lazy::Value& input,
                               const torch::lazy::Value& posinf,
                               const torch::lazy::Value& neginf);
 
-torch::lazy::NodePtr SLogDet(const torch::lazy::Value& input);
-
-torch::lazy::NodePtr Softplus(const torch::lazy::Value& input,
-                              const torch::lazy::Value& beta,
-                              const torch::lazy::Value& threshold);
+torch::lazy::NodePtr Softplus(const XlaValue& input, const XlaValue& beta,
+                              const XlaValue& threshold);
 
 torch::lazy::NodePtr Selu(const torch::lazy::Value& input);
 

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -252,8 +252,6 @@ torch::lazy::NodePtr TanhGelu(const torch::lazy::Value& input);
 torch::lazy::NodePtr TanhGeluBackward(const torch::lazy::Value& grad,
                                       const torch::lazy::Value& input);
 
-torch::lazy::NodePtr LogDet(const torch::lazy::Value& input);
-
 torch::lazy::NodePtr IsNan(const torch::lazy::Value& input);
 
 torch::lazy::NodePtr BaddBmm(const torch::lazy::Value& lhs,

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -285,6 +285,8 @@ torch::lazy::NodePtr NanToNum(const torch::lazy::Value& input,
                               const torch::lazy::Value& posinf,
                               const torch::lazy::Value& neginf);
 
+torch::lazy::NodePtr SLogDet(const torch::lazy::Value& input);
+
 torch::lazy::NodePtr Softplus(const torch::lazy::Value& input,
                               const torch::lazy::Value& beta,
                               const torch::lazy::Value& threshold);

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -285,8 +285,8 @@ torch::lazy::NodePtr NanToNum(const torch::lazy::Value& input,
                               const torch::lazy::Value& posinf,
                               const torch::lazy::Value& neginf);
 
-torch::lazy::NodePtr Softplus(const XlaValue& input, const XlaValue& beta,
-                              const XlaValue& threshold);
+torch::lazy::NodePtr Softplus(const torch::lazy::Value& input, const torch::lazy::Value& beta,
+                              const torch::lazy::Value& threshold);
 
 torch::lazy::NodePtr Selu(const torch::lazy::Value& input);
 

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -93,7 +93,7 @@ torch_xla::XlaOpVector Tan::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::Tan(xla_input), loctx);
 torch_xla::XlaOpVector Slogdet::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
-    xla::SignAndLogDet result = xla::SLogDet(xla_input);
+  xla::SignAndLogDet result = xla::SLogDet(xla_input);
   return ReturnOps({result.sign, result.logdet}, loctx);
 }
 

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -88,13 +88,15 @@ torch_xla::XlaOpVector Sinh::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::Sinh(xla_input), loctx);
 }
 
-torch_xla::XlaOpVector Tan::Lower(LoweringContext* loctx) const {
-  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
-  return ReturnOp(xla::Tan(xla_input), loctx);
 torch_xla::XlaOpVector Slogdet::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   xla::SignAndLogDet result = xla::SLogDet(xla_input);
   return ReturnOps({result.sign, result.logdet}, loctx);
+}
+
+torch_xla::XlaOpVector Tan::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  return ReturnOp(xla::Tan(xla_input), loctx);
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -1,5 +1,6 @@
 #include <torch_xla/csrc/generated/LazyIr.h>
 
+#include "tensorflow/compiler/xla/client/lib/logdet.h"
 #include "tensorflow/compiler/xla/client/lib/math.h"
 #include "torch_xla/csrc/elementwise.h"
 #include "torch_xla/csrc/helpers.h"
@@ -50,6 +51,9 @@ torch_xla::XlaOpVector Cos::Lower(LoweringContext* loctx) const {
 torch_xla::XlaOpVector Cosh::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   return ReturnOp(xla::Cosh(xla_input), loctx);
+torch_xla::XlaOpVector Logdet::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  return ReturnOp(xla::LogDet(xla_input), loctx);
 }
 
 torch_xla::XlaOpVector Inverse::Lower(LoweringContext* loctx) const {
@@ -87,6 +91,10 @@ torch_xla::XlaOpVector Sinh::Lower(LoweringContext* loctx) const {
 torch_xla::XlaOpVector Tan::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   return ReturnOp(xla::Tan(xla_input), loctx);
+torch_xla::XlaOpVector Slogdet::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+    xla::SignAndLogDet result = xla::SLogDet(xla_input);
+  return ReturnOps({result.sign, result.logdet}, loctx);
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -51,6 +51,8 @@ torch_xla::XlaOpVector Cos::Lower(LoweringContext* loctx) const {
 torch_xla::XlaOpVector Cosh::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   return ReturnOp(xla::Cosh(xla_input), loctx);
+}
+
 torch_xla::XlaOpVector Logdet::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   return ReturnOp(xla::LogDet(xla_input), loctx);

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -90,11 +90,12 @@ torch_xla::XlaOpVector Sinh::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::Sinh(xla_input), loctx);
 }
 
-torch_xla::XlaOpVector Slogdet::Lower(LoweringContext* loctx) const {
-  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
-  xla::SignAndLogDet result = xla::SLogDet(xla_input);
-  return ReturnOps({result.sign, result.logdet}, loctx);
-}
+/* Blocked on https://github.com/pytorch/xla/issues/3596 */
+// torch_xla::XlaOpVector Slogdet::Lower(LoweringContext* loctx) const {
+//   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+//   xla::SignAndLogDet result = xla::SLogDet(xla_input);
+//   return ReturnOps({result.sign, result.logdet}, loctx);
+// }
 
 torch_xla::XlaOpVector Tan::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -56,7 +56,8 @@ xla::Shape LogdetOutputShape(const torch::lazy::Value& input) {
   return logdet_shape;
 }
 
-xla::Shape MaximumOutputShape(const torch::lazy::Value& input, const torch::lazy::Value& other) {
+xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
+                              const torch::lazy::Value& other) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     auto promoted = XlaHelpers::Promote(operands[0], operands[1]);
@@ -82,7 +83,7 @@ xla::Shape SinhOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
-xla::Shape SlogdetOutputShape(const torch::lazy::Value& input) { 
+xla::Shape SlogdetOutputShape(const torch::lazy::Value& input) {
   auto lower_for_shape_fn =
       [](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     xla::SignAndLogDet result = xla::SLogDet(operands[0]);

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -45,9 +45,7 @@ xla::Shape InverseOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
-xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
-                              const torch::lazy::Value& other) {
-xla::Shape LogdetOutputShape(const torch::lazy::Value& input) { 
+xla::Shape LogdetOutputShape(const torch::lazy::Value& input) {
   const xla::Shape& input_shape = GetXlaShape(input);
   XLA_CHECK_GE(input_shape.rank(), 2) << input_shape;
   // The input tensor is ...,N,N

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -1,5 +1,6 @@
 #include "torch_xla/csrc/ops/ops_xla_shape_fn.h"
 
+#include "tensorflow/compiler/xla/client/lib/logdet.h"
 #include "torch_xla/csrc/helpers.h"
 
 namespace torch_xla {
@@ -83,14 +84,15 @@ xla::Shape SinhOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
-xla::Shape SlogdetOutputShape(const torch::lazy::Value& input) {
-  auto lower_for_shape_fn =
-      [](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
-    xla::SignAndLogDet result = xla::SLogDet(operands[0]);
-    return xla::Tuple(operands[0].builder(), {result.sign, result.logdet});
-  };
-  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
-}
+/* Blocked on https://github.com/pytorch/xla/issues/3596 */
+// xla::Shape SlogdetOutputShape(const torch::lazy::Value& input) {
+//   auto lower_for_shape_fn =
+//       [](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
+//     xla::SignAndLogDet result = xla::SLogDet(operands[0]);
+//     return xla::Tuple(operands[0].builder(), {result.sign, result.logdet});
+//   };
+//   return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
+// }
 
 xla::Shape TanOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -46,6 +46,17 @@ xla::Shape InverseOutputShape(const torch::lazy::Value& input) {
 
 xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
                               const torch::lazy::Value& other) {
+xla::Shape LogdetOutputShape(const XlaValue& input) { 
+  const xla::Shape& input_shape = input.xla_shape();
+  XLA_CHECK_GE(input_shape.rank(), 2) << input_shape;
+  // The input tensor is ...,N,N
+  xla::Shape logdet_shape(input_shape);
+  logdet_shape.DeleteDimension(input_shape.rank() - 1);
+  logdet_shape.DeleteDimension(input_shape.rank() - 2);
+  return logdet_shape; 
+}
+
+xla::Shape MaximumOutputShape(const XlaValue& input, const XlaValue& other) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     auto promoted = XlaHelpers::Promote(operands[0], operands[1]);
@@ -73,6 +84,13 @@ xla::Shape SinhOutputShape(const torch::lazy::Value& input) {
 
 xla::Shape TanOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
+xla::Shape SlogdetOutputShape(const XlaValue& input) { 
+  auto lower_for_shape_fn =
+      [](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
+    xla::SignAndLogDet result = xla::SLogDet(operands[0]);
+    return xla::Tuple(operands[0].builder(), {result.sign, result.logdet});
+  };
+  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -46,8 +46,8 @@ xla::Shape InverseOutputShape(const torch::lazy::Value& input) {
 
 xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
                               const torch::lazy::Value& other) {
-xla::Shape LogdetOutputShape(const XlaValue& input) { 
-  const xla::Shape& input_shape = input.xla_shape();
+xla::Shape LogdetOutputShape(const torch::lazy::Value& input) { 
+  const xla::Shape& input_shape = GetXlaShape(input);
   XLA_CHECK_GE(input_shape.rank(), 2) << input_shape;
   // The input tensor is ...,N,N
   xla::Shape logdet_shape(input_shape);
@@ -56,7 +56,7 @@ xla::Shape LogdetOutputShape(const XlaValue& input) {
   return logdet_shape;
 }
 
-xla::Shape MaximumOutputShape(const XlaValue& input, const XlaValue& other) {
+xla::Shape MaximumOutputShape(const torch::lazy::Value& input, const torch::lazy::Value& other) {
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     auto promoted = XlaHelpers::Promote(operands[0], operands[1]);
@@ -82,15 +82,17 @@ xla::Shape SinhOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
-xla::Shape TanOutputShape(const torch::lazy::Value& input) {
-  return GetXlaShape(input);
-xla::Shape SlogdetOutputShape(const XlaValue& input) { 
+xla::Shape SlogdetOutputShape(const torch::lazy::Value& input) { 
   auto lower_for_shape_fn =
       [](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     xla::SignAndLogDet result = xla::SLogDet(operands[0]);
     return xla::Tuple(operands[0].builder(), {result.sign, result.logdet});
   };
-  return InferOutputShape({input.xla_shape()}, lower_for_shape_fn);
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
+}
+
+xla::Shape TanOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -53,7 +53,7 @@ xla::Shape LogdetOutputShape(const XlaValue& input) {
   xla::Shape logdet_shape(input_shape);
   logdet_shape.DeleteDimension(input_shape.rank() - 1);
   logdet_shape.DeleteDimension(input_shape.rank() - 2);
-  return logdet_shape; 
+  return logdet_shape;
 }
 
 xla::Shape MaximumOutputShape(const XlaValue& input, const XlaValue& other) {

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -35,5 +35,10 @@ xla::Shape SinOutputShape(const torch::lazy::Value& input);
 xla::Shape SinhOutputShape(const torch::lazy::Value& input);
 
 xla::Shape TanOutputShape(const torch::lazy::Value& input);
+xla::Shape LogdetOutputShape(const XlaValue& input);
+
+xla::Shape MaximumOutputShape(const XlaValue& input, const XlaValue& other);
+
+xla::Shape SlogdetOutputShape(const XlaValue& input);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -27,7 +27,8 @@ xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
                               const torch::lazy::Value& other);
 xla::Shape LogdetOutputShape(const torch::lazy::Value& input);
 
-xla::Shape MaximumOutputShape(const torch::lazy::Value& input, const torch::lazy::Value& other);
+xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
+                              const torch::lazy::Value& other);
 
 xla::Shape SgnOutputShape(const torch::lazy::Value& input);
 

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -38,7 +38,8 @@ xla::Shape SinOutputShape(const torch::lazy::Value& input);
 
 xla::Shape SinhOutputShape(const torch::lazy::Value& input);
 
-xla::Shape SlogdetOutputShape(const torch::lazy::Value& input);
+/* Blocked on https://github.com/pytorch/xla/issues/3596 */
+// xla::Shape SlogdetOutputShape(const torch::lazy::Value& input);
 
 xla::Shape TanOutputShape(const torch::lazy::Value& input);
 

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -25,6 +25,9 @@ xla::Shape InverseOutputShape(const torch::lazy::Value& input);
 
 xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
                               const torch::lazy::Value& other);
+xla::Shape LogdetOutputShape(const torch::lazy::Value& input);
+
+xla::Shape MaximumOutputShape(const torch::lazy::Value& input, const torch::lazy::Value& other);
 
 xla::Shape SgnOutputShape(const torch::lazy::Value& input);
 
@@ -34,11 +37,8 @@ xla::Shape SinOutputShape(const torch::lazy::Value& input);
 
 xla::Shape SinhOutputShape(const torch::lazy::Value& input);
 
+xla::Shape SlogdetOutputShape(const torch::lazy::Value& input);
+
 xla::Shape TanOutputShape(const torch::lazy::Value& input);
-xla::Shape LogdetOutputShape(const XlaValue& input);
-
-xla::Shape MaximumOutputShape(const XlaValue& input, const XlaValue& other);
-
-xla::Shape SlogdetOutputShape(const XlaValue& input);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -23,8 +23,6 @@ xla::Shape CoshOutputShape(const torch::lazy::Value& input);
 
 xla::Shape InverseOutputShape(const torch::lazy::Value& input);
 
-xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
-                              const torch::lazy::Value& other);
 xla::Shape LogdetOutputShape(const torch::lazy::Value& input);
 
 xla::Shape MaximumOutputShape(const torch::lazy::Value& input,

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -1028,6 +1028,8 @@ class XLATensor : public c10::intrusive_ptr_target {
   static XLATensor slice(const XLATensor& input, int64_t dim, int64_t start,
                          int64_t end, int64_t step);
 
+  static std::tuple<XLATensor, XLATensor> slogdet(const XLATensor& input);
+
   // Computes a loss that uses a squared term if the absolute element-wise error
   // falls below 1 and an L1 term otherwise.
   static XLATensor smooth_l1_loss(const XLATensor& input,

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -751,8 +751,6 @@ class XLATensor : public c10::intrusive_ptr_target {
   static XLATensor log1p(const XLATensor& input);
   static void log1p_(XLATensor& input);
 
-  static XLATensor logdet(const XLATensor& input);
-
   static XLATensor logical_not(const XLATensor& input);
 
   static XLATensor logical_xor(const XLATensor& input, const XLATensor& other);
@@ -1029,8 +1027,6 @@ class XLATensor : public c10::intrusive_ptr_target {
 
   static XLATensor slice(const XLATensor& input, int64_t dim, int64_t start,
                          int64_t end, int64_t step);
-
-  static std::tuple<XLATensor, XLATensor> slogdet(const XLATensor& input);
 
   // Computes a loss that uses a squared term if the absolute element-wise error
   // falls below 1 and an L1 term otherwise.

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2524,6 +2524,12 @@ XLATensor XLATensor::slice(const XLATensor& input, int64_t dim, int64_t start,
   return input.CreateViewTensor(std::move(view_info));
 }
 
+std::tuple<XLATensor, XLATensor> XLATensor::slogdet(const XLATensor& input) {
+  torch::lazy::NodePtr node = SLogDet(input.GetIrValue());
+  return std::make_tuple(input.CreateFrom(torch::lazy::Value(node, 0)),
+                         input.CreateFrom(torch::lazy::Value(node, 1)));
+}
+
 XLATensor XLATensor::smooth_l1_loss(const XLATensor& input,
                                     const XLATensor& target, int64_t reduction,
                                     double beta) {

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1745,10 +1745,6 @@ void XLATensor::log1p_(XLATensor& input) {
   input.SetInPlaceIrValue(Log1p(input.GetIrValue()));
 }
 
-XLATensor XLATensor::logdet(const XLATensor& input) {
-  return input.CreateFrom(LogDet(input.GetIrValue()));
-}
-
 XLATensor XLATensor::logical_not(const XLATensor& input) {
   return input.CreateFrom(LogicalNot(input.GetIrValue()), at::ScalarType::Bool);
 }
@@ -2526,12 +2522,6 @@ XLATensor XLATensor::slice(const XLATensor& input, int64_t dim, int64_t start,
   SelectInfo select = {dim, start, end, step};
   ViewInfo view_info(ViewInfo::Type::kSelect, input_shape, std::move(select));
   return input.CreateViewTensor(std::move(view_info));
-}
-
-std::tuple<XLATensor, XLATensor> XLATensor::slogdet(const XLATensor& input) {
-  torch::lazy::NodePtr node = SLogDet(input.GetIrValue());
-  return std::make_tuple(input.CreateFrom(torch::lazy::Value(node, 0)),
-                         input.CreateFrom(torch::lazy::Value(node, 1)));
 }
 
 XLATensor XLATensor::smooth_l1_loss(const XLATensor& input,

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -17,6 +17,9 @@ full_codegen:
   - sin
   - sinh
   - tan
+  - logdet
+  - maximum
+  - slogdet
 supported:
   - __ilshift__.Scalar
   - __ilshift__.Tensor
@@ -175,7 +178,6 @@ supported:
   - log10
   - log_sigmoid_backward
   - log_sigmoid_forward
-  - logdet
   - logical_and
   - logical_not
   - logical_or
@@ -274,7 +276,6 @@ supported:
   - silu.out
   - silu_backward
   - slice.Tensor
-  - slogdet
   - smooth_l1_loss
   - smooth_l1_loss_backward
   - softplus

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -11,15 +11,13 @@ full_codegen:
   - cos
   - cosh
   - inverse
+  - logdet
   - maximum
   - sgn
   - sign
   - sin
   - sinh
   - tan
-  - logdet
-  - maximum
-  - slogdet
 supported:
   - __ilshift__.Scalar
   - __ilshift__.Tensor
@@ -276,6 +274,7 @@ supported:
   - silu.out
   - silu_backward
   - slice.Tensor
+  - slogdet
   - smooth_l1_loss
   - smooth_l1_loss_backward
   - softplus


### PR DESCRIPTION
Full codegen for `logdet`, `slogdet`

- [x] `SLogDet` compilation is blocked on PyTorch shape inference landing in torch/csrc/lazy/core/shape_inference.h
  - https://github.com/pytorch/pytorch/pull/77904
- [ ] `SLogDet` compilation is blocked on upstream codegen issues
  - https://github.com/pytorch/xla/issues/3596

---
Generate `LazyIr.h`

```
class Logdet : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::logdet);
  }

  Logdet(const torch_xla::XlaValue& self, std::vector<torch::lazy::Shape>&& shapes)

      : XlaNode(torch::lazy::OpKind(at::aten::logdet),
              {self}, std::move(shapes),
              [&]() { return LogdetOutputShape(self); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
  {  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();

    return ss.str();
  }

  bool CanBeReused(const torch_xla::XlaValue& self) const {
    return false;
    }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;
};
```

---
Generated `XLANativeFunctions.cpp `:

```
    at::Tensor XLANativeFunctions::logdet(const at::Tensor & self) {

        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self);
        TORCH_INTERNAL_ASSERT(common_device);

        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        torch::lazy::NodePtr node = torch::lazy::ReuseNode<Logdet>(lazy_self->GetIrValue());
        if (!node) {

            auto shapes = torch::lazy::compute_shape_logdet(self);
            TORCH_INTERNAL_ASSERT(shapes.size() == 1);
            if(torch::lazy::symbolicShapeEnabled()){
                std::vector<torch::jit::IValue> inputs = { self };
                char* schema_str = "aten::logdet(Tensor self) -> Tensor";
                applySymbolicShapesOnLT(schema_str, inputs, shapes);
            }

            node = torch::lazy::MakeNode<Logdet>(lazy_self->GetIrValue(), std::move(shapes));
            CacheNode(node);
        }

        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };
```