### PR TITLE
Address review comments from #3550

### DIFF
--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -120,10 +120,9 @@ std::vector<ComputationClient::ComputationPtr> PjRtComputationClient::Compile(
         instance.computation.GetProgramShape().ValueOrDie();
     xla::CompileOptions compile_options;
     // TODO(wcromar): set compile_options.argument_layouts, enable strict shapes
+    compile_options.executable_build_options.set_num_partitions(1);
     compile_options.executable_build_options.set_num_replicas(
         client_->device_count());
-    compile_options.executable_build_options.set_device_ordinal(
-        pjrt_device->local_hardware_id());
     std::unique_ptr<xla::PjRtExecutable> executable =
         client_->Compile(instance.computation, compile_options).ValueOrDie();
     std::shared_ptr<PjRtComputation> pjrt_computation =

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -121,9 +121,9 @@ std::vector<ComputationClient::ComputationPtr> PjRtComputationClient::Compile(
     xla::CompileOptions compile_options;
     // TODO(wcromar): set compile_options.argument_layouts, enable strict shapes
     compile_options.executable_build_options.set_num_replicas(
-        client_->addressable_device_count());
+        client_->device_count());
     compile_options.executable_build_options.set_device_ordinal(
-        pjrt_device->id());
+        pjrt_device->local_hardware_id());
     std::unique_ptr<xla::PjRtExecutable> executable =
         client_->Compile(instance.computation, compile_options).ValueOrDie();
     std::shared_ptr<PjRtComputation> pjrt_computation =

--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -15,41 +15,6 @@
 namespace xla {
 
 class PjRtComputationClient : public ComputationClient {
-  struct PjRtData : public Data {
-    PjRtData(std::string device, Shape device_shape)
-        : Data(std::move(device), std::move(device_shape)) {}
-
-    PjRtData(std::string device, Shape device_shape,
-             std::shared_ptr<PjRtBuffer> buffer)
-        : Data(std::move(device), std::move(device_shape)), buffer(buffer) {}
-
-    void* get_handle() const {
-      return buffer->AcquireExternalReference()
-          .ValueOrDie()
-          ->OpaqueDeviceMemoryDataPointer();
-    };
-    OpaqueHandle GetOpaqueHandle() override {
-      return reinterpret_cast<std::uintptr_t>(get_handle());
-    };
-    void Assign(const Data& data) override;
-    bool HasValue() const override {
-      return buffer != nullptr && !buffer->IsDeleted();
-    };
-
-    std::shared_ptr<PjRtBuffer> buffer;
-  };
-
-  struct PjRtComputation : public Computation {
-    PjRtComputation(XlaComputation computation, ProgramShape program_shape,
-                    std::vector<std::string> devices,
-                    std::unique_ptr<xla::PjRtExecutable> executable)
-        : Computation(std::move(computation), std::move(program_shape),
-                      std::move(devices)),
-          executable(std::move(executable)) {}
-
-    std::unique_ptr<xla::PjRtExecutable> executable;
-  };
-
  public:
   PjRtComputationClient();
 
@@ -150,6 +115,41 @@ class PjRtComputationClient : public ComputationClient {
   std::shared_ptr<std::vector<std::string>> replication_devices_;
 
   xla::PjRtDevice* StringToPjRtDevice(const std::string& device);
+
+  struct PjRtData : public Data {
+    PjRtData(std::string device, Shape device_shape)
+        : Data(std::move(device), std::move(device_shape)) {}
+
+    PjRtData(std::string device, Shape device_shape,
+             std::shared_ptr<PjRtBuffer> buffer)
+        : Data(std::move(device), std::move(device_shape)), buffer(buffer) {}
+
+    void* get_handle() const {
+      return buffer->AcquireExternalReference()
+          .ValueOrDie()
+          ->OpaqueDeviceMemoryDataPointer();
+    };
+    OpaqueHandle GetOpaqueHandle() override {
+      return reinterpret_cast<std::uintptr_t>(get_handle());
+    };
+    void Assign(const Data& data) override;
+    bool HasValue() const override {
+      return buffer != nullptr && !buffer->IsDeleted();
+    };
+
+    std::shared_ptr<PjRtBuffer> buffer;
+  };
+
+  struct PjRtComputation : public Computation {
+    PjRtComputation(XlaComputation computation, ProgramShape program_shape,
+                    std::vector<std::string> devices,
+                    std::unique_ptr<xla::PjRtExecutable> executable)
+        : Computation(std::move(computation), std::move(program_shape),
+                      std::move(devices)),
+          executable(std::move(executable)) {}
+
+    std::unique_ptr<xla::PjRtExecutable> executable;
+  };
 };
 
 }  // namespace xla


### PR DESCRIPTION
- Make PjRtData and PjRtComputation private
- Explicitly set num_partitions = 1
- Remove device_ordinal setting because it was computed incorrectly for multiprocess workloads and seems to be inferred automatically