### PR TITLE
Full codegen sin, sinh, and tan

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1553,6 +1553,11 @@ at::Tensor XLANativeFunctions::hardtanh(const at::Tensor& self,
       XLATensor::clamp(bridge::GetXlaTensor(self), min_val, max_val));
 }
 
+at::Tensor XLANativeFunctions::tanh(const at::Tensor& self) {
+  XLA_FN_COUNTER("xla::");
+  return bridge::AtenFromXlaTensor(XLATensor::tanh(bridge::GetXlaTensor(self)));
+}
+
 at::Tensor XLANativeFunctions::hardtanh_backward(const at::Tensor& grad_output,
                                                  const at::Tensor& self,
                                                  const at::Scalar& min_val,
@@ -2939,16 +2944,6 @@ at::Tensor XLANativeFunctions::sigmoid_backward(const at::Tensor& grad_output,
       bridge::GetXlaTensor(grad_output), bridge::GetXlaTensor(output)));
 }
 
-at::Tensor XLANativeFunctions::sin(const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(XLATensor::sin(bridge::GetXlaTensor(self)));
-}
-
-at::Tensor XLANativeFunctions::sinh(const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(XLATensor::sinh(bridge::GetXlaTensor(self)));
-}
-
 at::Tensor XLANativeFunctions::slice(const at::Tensor& self, int64_t dim,
                                      c10::optional<int64_t> start,
                                      c10::optional<int64_t> end, int64_t step) {
@@ -3217,16 +3212,6 @@ at::Tensor XLANativeFunctions::take(const at::Tensor& self,
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
       XLATensor::take(bridge::GetXlaTensor(self), bridge::GetXlaTensor(index)));
-}
-
-at::Tensor XLANativeFunctions::tan(const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(XLATensor::tan(bridge::GetXlaTensor(self)));
-}
-
-at::Tensor XLANativeFunctions::tanh(const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(XLATensor::tanh(bridge::GetXlaTensor(self)));
 }
 
 at::Tensor XLANativeFunctions::tanh_backward(const at::Tensor& grad_output,

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -68,9 +68,6 @@ namespace torch_xla {
                      std::move(lower_fn));                                     \
   }
 
-PTXLA_UNARY_OP(Sin, at::aten::sin, xla::Sin);
-PTXLA_UNARY_OP(Sinh, at::aten::sinh, xla::Sinh);
-PTXLA_UNARY_OP(Tan, at::aten::tan, xla::Tan);
 PTXLA_UNARY_OP(Tanh, at::aten::tanh, xla::Tanh);
 PTXLA_UNARY_OP(Neg, at::aten::neg, xla::Neg);
 PTXLA_UNARY_OP(Exp, at::aten::exp, xla::Exp);

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -68,4 +68,19 @@ torch_xla::XlaOpVector Sign::Lower(LoweringContext* loctx) const {
   return ReturnOp(BuildSign(xla_input), loctx);
 }
 
+torch_xla::XlaOpVector Sin::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  return ReturnOp(xla::Sin(xla_input), loctx);
+}
+
+torch_xla::XlaOpVector Sinh::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  return ReturnOp(xla::Sinh(xla_input), loctx);
+}
+
+torch_xla::XlaOpVector Tan::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  return ReturnOp(xla::Tan(xla_input), loctx);
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -59,4 +59,16 @@ xla::Shape SignOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
+xla::Shape SinOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
+}
+
+xla::Shape SinhOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
+}
+
+xla::Shape TanOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -28,4 +28,10 @@ xla::Shape SgnOutputShape(const torch::lazy::Value& input);
 
 xla::Shape SignOutputShape(const torch::lazy::Value& input);
 
+xla::Shape SinOutputShape(const torch::lazy::Value& input);
+
+xla::Shape SinhOutputShape(const torch::lazy::Value& input);
+
+xla::Shape TanOutputShape(const torch::lazy::Value& input);
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -1029,10 +1029,6 @@ class XLATensor : public c10::intrusive_ptr_target {
   static XLATensor sigmoid_backward(const XLATensor& grad_output,
                                     const XLATensor& output);
 
-  static XLATensor sin(const XLATensor& input);
-
-  static XLATensor sinh(const XLATensor& input);
-
   static XLATensor slice(const XLATensor& input, int64_t dim, int64_t start,
                          int64_t end, int64_t step);
 
@@ -1116,9 +1112,8 @@ class XLATensor : public c10::intrusive_ptr_target {
 
   static XLATensor take(const XLATensor& input, const XLATensor& index);
 
-  static XLATensor tan(const XLATensor& input);
-
   static XLATensor tanh(const XLATensor& input);
+
   static XLATensor tanh_backward(const XLATensor& grad_output,
                                  const XLATensor& output);
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2513,14 +2513,6 @@ XLATensor XLATensor::sigmoid_backward(const XLATensor& grad_output,
       SigmoidBackward(grad_output.GetIrValue(), output.GetIrValue()));
 }
 
-XLATensor XLATensor::sin(const XLATensor& input) {
-  return input.CreateFrom(Sin(input.GetIrValue()));
-}
-
-XLATensor XLATensor::sinh(const XLATensor& input) {
-  return input.CreateFrom(Sinh(input.GetIrValue()));
-}
-
 XLATensor XLATensor::slice(const XLATensor& input, int64_t dim, int64_t start,
                            int64_t end, int64_t step) {
   auto input_shape = input.shape();
@@ -2766,10 +2758,6 @@ std::tuple<XLATensor, XLATensor> XLATensor::symeig(const XLATensor& input,
 
 XLATensor XLATensor::take(const XLATensor& input, const XLATensor& index) {
   return input.CreateFrom(Take(input.GetIrValue(), index.GetIrValue()));
-}
-
-XLATensor XLATensor::tan(const XLATensor& input) {
-  return input.CreateFrom(Tan(input.GetIrValue()));
 }
 
 XLATensor XLATensor::tanh(const XLATensor& input) {

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -13,6 +13,9 @@ full_codegen:
   - maximum
   - sgn
   - sign
+  - sin
+  - sinh
+  - tan
 supported:
   - __ilshift__.Scalar
   - __ilshift__.Tensor
@@ -270,8 +273,6 @@ supported:
   - sigmoid_backward
   - silu.out
   - silu_backward
-  - sin
-  - sinh
   - slice.Tensor
   - slogdet
   - smooth_l1_loss
@@ -303,7 +304,6 @@ supported:
   - t
   - t_
   - take
-  - tan
   - tanh
   - tanh_backward
   - threshold


### PR DESCRIPTION
Full codegen sin, sinh, and tan

---

Generated `LazyIr.h`:
```
class Sin : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::sin);
  }

  Sin(const torch_xla::XlaValue& self, std::vector<torch::lazy::Shape>&& shapes)

      : XlaNode(torch::lazy::OpKind(at::aten::sin),
              {self}, std::move(shapes),
              [&]() { return SinOutputShape(self); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
        

  {
    
  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();
    
    return ss.str();
  }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;

  
  

};

class Sinh : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::sinh);
  }

  Sinh(const torch_xla::XlaValue& self, std::vector<torch::lazy::Shape>&& shapes)

      : XlaNode(torch::lazy::OpKind(at::aten::sinh),
              {self}, std::move(shapes),
              [&]() { return SinhOutputShape(self); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
        

  {
    
  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();
    
    return ss.str();
  }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;

  
  

};

class Tan : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::tan);
  }

  Tan(const torch_xla::XlaValue& self, std::vector<torch::lazy::Shape>&& shapes)

      : XlaNode(torch::lazy::OpKind(at::aten::tan),
              {self}, std::move(shapes),
              [&]() { return TanOutputShape(self); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
        

  {
    
  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();
    
    return ss.str();
  }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;

  
  

};

```

---

Generated `XLANativeFunctions.cpp`:
```
    at::Tensor XLANativeFunctions::sin(const at::Tensor & self) {
        
        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self);
        TORCH_INTERNAL_ASSERT(common_device);
        
        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        auto out_meta = at::meta::sin(self);
        std::vector<torch::lazy::Shape> shapes{
        torch::lazy::Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
        TORCH_INTERNAL_ASSERT(shapes.size() == 1);
        if(torch::lazy::symbolicShapeEnabled()){
            std::vector<torch::jit::IValue> inputs = { self };
            char* schema_str = "aten::sin(Tensor self) -> Tensor";
            applySymbolicShapesOnLT(schema_str, inputs, shapes);
        }
        
        auto node = torch::lazy::MakeNode<Sin>(lazy_self->GetIrValue(),
                                                                                      std::move(shapes));
        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };

    
    at::Tensor XLANativeFunctions::sinh(const at::Tensor & self) {
        
        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self);
        TORCH_INTERNAL_ASSERT(common_device);
        
        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        auto out_meta = at::meta::sinh(self);
        std::vector<torch::lazy::Shape> shapes{
        torch::lazy::Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
        TORCH_INTERNAL_ASSERT(shapes.size() == 1);
        if(torch::lazy::symbolicShapeEnabled()){
            std::vector<torch::jit::IValue> inputs = { self };
            char* schema_str = "aten::sinh(Tensor self) -> Tensor";
            applySymbolicShapesOnLT(schema_str, inputs, shapes);
        }
        
        auto node = torch::lazy::MakeNode<Sinh>(lazy_self->GetIrValue(),
                                                                                      std::move(shapes));
        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };

    
    at::Tensor XLANativeFunctions::tan(const at::Tensor & self) {
        
        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self);
        TORCH_INTERNAL_ASSERT(common_device);
        
        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        auto out_meta = at::meta::tan(self);
        std::vector<torch::lazy::Shape> shapes{
        torch::lazy::Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
        TORCH_INTERNAL_ASSERT(shapes.size() == 1);
        if(torch::lazy::symbolicShapeEnabled()){
            std::vector<torch::jit::IValue> inputs = { self };
            char* schema_str = "aten::tan(Tensor self) -> Tensor";
            applySymbolicShapesOnLT(schema_str, inputs, shapes);
        }
        
        auto node = torch::lazy::MakeNode<Tan>(lazy_self->GetIrValue(),
                                                                                      std::move(shapes));
        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };

    

```