### PR TITLE
Inherit from torch::lazy::LoweringContext

### DIFF
--- a/test/cpp/cpp_test_util.cpp
+++ b/test/cpp/cpp_test_util.cpp
@@ -266,7 +266,7 @@ std::vector<xla::ComputationClient::DataPtr> Execute(
     lowering_ctx.AddResult(root);
   }
 
-  xla::XlaComputation computation = ConsumeValue(lowering_ctx.Build());
+  xla::XlaComputation computation = ConsumeValue(lowering_ctx.BuildXla());
   xla::ProgramShape program_shape = ConsumeValue(computation.GetProgramShape());
   xla::Shape shape = MakeShapeWithDeviceLayout(
       program_shape.result(), static_cast<XlaDeviceType>(device.type()));

--- a/torch_xla/csrc/ir_dump_util.cpp
+++ b/torch_xla/csrc/ir_dump_util.cpp
@@ -248,11 +248,10 @@ std::string DumpUtil::ToHlo(c10::ArrayRef<torch::lazy::Value> values,
                             const torch::lazy::BackendDevice& device) {
   LoweringContext lowering_ctx("IrToHlo", device);
   for (auto& ir_value : values) {
-    xla::XlaOp root = lowering_ctx.GetOutputOp(
+    lowering_ctx.AddResult(
         torch::lazy::Output(ir_value.node.get(), ir_value.index));
-    lowering_ctx.AddResult(root);
   }
-  xla::XlaComputation computation = ConsumeValue(lowering_ctx.Build());
+  xla::XlaComputation computation = ConsumeValue(lowering_ctx.BuildXla());
   return ConsumeValue(xla::util::GetComputationHloText(computation));
 }
 

--- a/torch_xla/csrc/op_by_op_executor.cpp
+++ b/torch_xla/csrc/op_by_op_executor.cpp
@@ -72,7 +72,7 @@ xla::XlaComputation BuildNodeComputation(
   for (auto& xla_op : loctx.LowerNode(node)) {
     loctx.AddResult(xla_op);
   }
-  return ConsumeValue(loctx.Build());
+  return ConsumeValue(loctx.BuildXla());
 }
 
 torch::lazy::hash_t GetNodesKeySeed(const std::string& device,

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1656,7 +1656,7 @@ XLATensor::CompilationResult XLATensor::Compile(
     BuildInputOutputAliases(tensors, coll.indices, &lowering_ctx);
   }
 
-  xla::XlaComputation computation = ConsumeValue(lowering_ctx.Build());
+  xla::XlaComputation computation = ConsumeValue(lowering_ctx.BuildXla());
   xla::ProgramShape program_shape = ConsumeValue(computation.GetProgramShape());
   xla::Shape shape = MakeShapeWithDeviceLayout(
       program_shape.result(), static_cast<XlaDeviceType>(coll.device.type()));


### PR DESCRIPTION
This pr make `LoweringContext` to inherit from `torch::lazy::LoweringContext`. I need the `xla_backend_data` pr for this pr so can not merge it right now.

TODO: `LoweringContext` -> `XLALoweringContext` in a separate pr.