### PR TITLE
Check if XLA_SANDBOX_BUIDL is unset before applying the bazel patch

### DIFF
--- a/build_torch_xla_libs.sh
+++ b/build_torch_xla_libs.sh
@@ -35,16 +35,15 @@ if [[ "$XLA_BAZEL_VERBOSE" == "1" ]]; then
 fi
 
 BUILD_STRATEGY="standalone"
-if [[ -z "$XLA_SANDBOX_BUILD" ]] || [[ "$XLA_SANDBOX_BUILD" == "0" ]]; then
+if [[ "$XLA_SANDBOX_BUILD" == "1" ]]; then
+  BUILD_STRATEGY="sandboxed --sandbox_tmpfs_path=/tmp"
+else
   # Temporary patch until tensorflow update bazel requirement to 5.2.0
   echo "6e54699884cfad49d4e8f6dd59a4050bc95c4edf" > third_party/tensorflow/.bazelversion
   # We can remove this after https://github.com/bazelbuild/bazel/issues/15359 is resolved
   unset CC
   unset CXX
   BUILD_STRATEGY="local"
-fi
-if [[ "$XLA_SANDBOX_BUILD" == "1" ]]; then
-  BUILD_STRATEGY="sandboxed --sandbox_tmpfs_path=/tmp"
 fi
 
 TPUVM_FLAG=

--- a/build_torch_xla_libs.sh
+++ b/build_torch_xla_libs.sh
@@ -35,7 +35,7 @@ if [[ "$XLA_BAZEL_VERBOSE" == "1" ]]; then
 fi
 
 BUILD_STRATEGY="standalone"
-if [[ "$XLA_SANDBOX_BUILD" == "0" ]]; then
+if [[ -z "$XLA_SANDBOX_BUILD" ]] || [[ "$XLA_SANDBOX_BUILD" == "0" ]]; then
   # Temporary patch until tensorflow update bazel requirement to 5.2.0
   echo "6e54699884cfad49d4e8f6dd59a4050bc95c4edf" > third_party/tensorflow/.bazelversion
   # We can remove this after https://github.com/bazelbuild/bazel/issues/15359 is resolved


### PR DESCRIPTION
The original checks worked for CI workflows, but had a bug with a local build. `XLA_SANDBOX_BUILD` may not be set in case of local build -- and it should be treated as a non-sandboxed build, and thus we apply the patch.