### PR TITLE
Update `googletest` dependency to its stable version `1.11.0` pin

### DIFF
--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -32,7 +32,7 @@ set_directory_properties(PROPERTIES EP_PREFIX "${GTEST_DIR}")
 ExternalProject_Add(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG 6f5fd0d7199b9a19faa
+  GIT_TAG e2239ee6043f73722e7aa812a459f54a28552929
   SOURCE_DIR "${GTEST_DIR}/src/googletest-src"
   BINARY_DIR "${GTEST_DIR}/src/googletest-build"
   # Disable install step


### PR DESCRIPTION
**Issue: https://github.com/pytorch/xla/issues/3589**