### PR TITLE
[WIP] Full codegen logical boolean ops

### DIFF
--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -11,6 +11,10 @@ full_codegen:
   - cos
   - cosh
   - maximum
+  - logical_and
+  - logical_not
+  - logical_or
+  - logical_xor
   - sgn
   - sign
   - sin
@@ -176,10 +180,6 @@ supported:
   - log_sigmoid_backward
   - log_sigmoid_forward
   - logdet
-  - logical_and
-  - logical_not
-  - logical_or
-  - logical_xor
   - logsumexp
   - lt.Scalar
   - lt.Tensor


### PR DESCRIPTION
Full codegen logical boolean ops
- logical_and
- logical_not
- logical_or
- logical_xor

Currently blocked by upstream shape inference PR -- https://github.com/pytorch/pytorch/pull/78004 