### PR TITLE
Full codegen floor and reciprocal

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1414,12 +1414,6 @@ at::Tensor XLANativeFunctions::flip(const at::Tensor& self,
       XLATensor::flip(bridge::GetXlaTensor(self), XlaHelpers::I64List(dims)));
 }
 
-at::Tensor XLANativeFunctions::floor(const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(
-      XLATensor::floor(bridge::GetXlaTensor(self)));
-}
-
 at::Tensor XLANativeFunctions::fmod(const at::Tensor& self,
                                     const at::Tensor& other) {
   XLA_FN_COUNTER("xla::");
@@ -2623,12 +2617,6 @@ at::Tensor& XLANativeFunctions::random_(
   int64_t inc = (dtype == at::ScalarType::Long) ? 0 : 1;
   XLATensor::random_(self_tensor, 0, GetIntegerUpperLimitForType(dtype) + inc);
   return self;
-}
-
-at::Tensor XLANativeFunctions::reciprocal(const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(
-      XLATensor::reciprocal(bridge::GetXlaTensor(self)));
 }
 
 at::Tensor XLANativeFunctions::reflection_pad2d(const at::Tensor& self,

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -102,8 +102,6 @@ torch::lazy::NodePtr Sqrt(const torch::lazy::Value& input);
 
 torch::lazy::NodePtr Rsqrt(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr ReciprocalOp(const torch::lazy::Value& input);
-
 torch::lazy::NodePtr Prelu(const torch::lazy::Value& input,
                            const torch::lazy::Value& weight);
 
@@ -157,8 +155,6 @@ torch::lazy::NodePtr Ceil(const torch::lazy::Value& input);
 
 torch::lazy::NodePtr Celu(const torch::lazy::Value& input,
                           const at::Scalar& alpha);
-
-torch::lazy::NodePtr Floor(const torch::lazy::Value& input);
 
 torch::lazy::NodePtr Round(const torch::lazy::Value& input);
 

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -53,14 +53,19 @@ torch_xla::XlaOpVector Cosh::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::Cosh(xla_input), loctx);
 }
 
-torch_xla::XlaOpVector Logdet::Lower(LoweringContext* loctx) const {
+torch_xla::XlaOpVector Floor::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
-  return ReturnOp(xla::LogDet(xla_input), loctx);
+  return ReturnOp(xla::Floor(xla_input), loctx);
 }
 
 torch_xla::XlaOpVector Inverse::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   return ReturnOp(BuildInverse(xla_input), loctx);
+}
+
+torch_xla::XlaOpVector Logdet::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  return ReturnOp(xla::LogDet(xla_input), loctx);
 }
 
 torch_xla::XlaOpVector Maximum::Lower(LoweringContext* loctx) const {
@@ -75,6 +80,11 @@ torch_xla::XlaOpVector Minimum::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_other = loctx->GetOutputOp(operand(1));
   auto promoted = XlaHelpers::Promote(xla_input, xla_other);
   return ReturnOp(xla::Min(promoted.first, promoted.second), loctx);
+}
+
+torch_xla::XlaOpVector Reciprocal::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  return ReturnOp(BuildReciprocal(xla_input), loctx);
 }
 
 torch_xla::XlaOpVector Sgn::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -41,6 +41,10 @@ xla::Shape CoshOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
+xla::Shape FloorOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
+}
+
 xla::Shape InverseOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
@@ -75,6 +79,10 @@ xla::Shape MinimumOutputShape(const torch::lazy::Value& input,
   };
   return InferOutputShape({GetXlaShape(input), GetXlaShape(other)},
                           lower_for_shape_fn);
+}
+
+xla::Shape ReciprocalOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
 }
 
 xla::Shape SgnOutputShape(const torch::lazy::Value& input) {

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -21,6 +21,8 @@ xla::Shape CosOutputShape(const torch::lazy::Value& input);
 
 xla::Shape CoshOutputShape(const torch::lazy::Value& input);
 
+xla::Shape FloorOutputShape(const torch::lazy::Value& input);
+
 xla::Shape InverseOutputShape(const torch::lazy::Value& input);
 
 xla::Shape LogdetOutputShape(const torch::lazy::Value& input);
@@ -30,6 +32,8 @@ xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
 
 xla::Shape MinimumOutputShape(const torch::lazy::Value& input,
                               const torch::lazy::Value& other);
+                              
+xla::Shape ReciprocalOutputShape(const torch::lazy::Value& input);
 
 xla::Shape SgnOutputShape(const torch::lazy::Value& input);
 

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -32,7 +32,7 @@ xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
 
 xla::Shape MinimumOutputShape(const torch::lazy::Value& input,
                               const torch::lazy::Value& other);
-                              
+
 xla::Shape ReciprocalOutputShape(const torch::lazy::Value& input);
 
 xla::Shape SgnOutputShape(const torch::lazy::Value& input);

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -587,8 +587,6 @@ class XLATensor : public c10::intrusive_ptr_target {
   // Flips (reverses) the values in the dimensions of the input tensor.
   static XLATensor flip(const XLATensor& input, absl::Span<const int64_t> dims);
 
-  static XLATensor floor(const XLATensor& input);
-
   static XLATensor fmod(
       const XLATensor& input, const XLATensor& other,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
@@ -942,8 +940,6 @@ class XLATensor : public c10::intrusive_ptr_target {
 
   static XLATensor randperm(int64_t n, const torch::lazy::BackendDevice& device,
                             at::ScalarType scalar_type);
-
-  static XLATensor reciprocal(const XLATensor& input);
 
   static XLATensor reflection_pad2d(const XLATensor& input,
                                     std::vector<int64_t> padding);

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1207,7 +1207,8 @@ XLATensor XLATensor::div(const XLATensor& input, const XLATensor& other,
     if (*rounding_mode == "trunc") {
       res = Trunc(res);
     } else if (*rounding_mode == "floor") {
-      res = Floor(res);
+      res =
+          torch::lazy::MakeNode<Floor>(res, std::vector<torch::lazy::Shape>());
     } else {
       XLA_CHECK(false)
           << "rounding_mode must be one of None, 'trunc', or 'floor'";
@@ -1350,10 +1351,6 @@ XLATensor XLATensor::flip(const XLATensor& input,
   XLA_CHECK_EQ(unique_dims.size(), dimensions.size());
   return input.CreateFrom(
       torch::lazy::MakeNode<Flip>(input.GetIrValue(), dimensions));
-}
-
-XLATensor XLATensor::floor(const XLATensor& input) {
-  return input.CreateFrom(Floor(input.GetIrValue()));
 }
 
 XLATensor XLATensor::fmod(const XLATensor& input, const XLATensor& other,
@@ -2266,10 +2263,6 @@ void XLATensor::random_(XLATensor& input, int64_t from, int64_t to) {
       GetIrValueForScalar(from, xla::PrimitiveType::S64, input.GetDevice()),
       GetIrValueForScalar(to, xla::PrimitiveType::S64, input.GetDevice()),
       GetRngSeed(input.GetDevice()), input_shape));
-}
-
-XLATensor XLATensor::reciprocal(const XLATensor& input) {
-  return input.CreateFrom(ReciprocalOp(input.GetIrValue()));
 }
 
 XLATensor XLATensor::reflection_pad2d(const XLATensor& input,

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -10,10 +10,12 @@ full_codegen:
   - atanh
   - cos
   - cosh
+  - floor
   - inverse
   - logdet
   - maximum
   - minimum
+  - reciprocal
   - sgn
   - sign
   - sin
@@ -131,7 +133,6 @@ supported:
   - fill_.Scalar
   - fill_.Tensor
   - flip
-  - floor
   - fmod.Scalar
   - fmod.Tensor
   - frac
@@ -241,7 +242,6 @@ supported:
   - random_
   - random_.from
   - random_.to
-  - reciprocal
   - reflection_pad2d
   - reflection_pad2d_backward
   - relu


### PR DESCRIPTION
Full codegen floor and reciprocal

---
Generated `LazyIr.h`:
```
class Floor : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::floor);
  }

  Floor(const torch::lazy::Value& self, std::vector<torch::lazy::Shape>&& shapes)

      : XlaNode(torch::lazy::OpKind(at::aten::floor),
              {self}, std::move(shapes),
              [&]() { return FloorOutputShape(self); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
        

  {
    
  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();
    
    return ss.str();
  }

  bool CanBeReused(const torch::lazy::Value& self) const {
    return false;
    }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;

  
  

};

class Reciprocal : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::reciprocal);
  }

  Reciprocal(const torch::lazy::Value& self, std::vector<torch::lazy::Shape>&& shapes)

      : XlaNode(torch::lazy::OpKind(at::aten::reciprocal),
              {self}, std::move(shapes),
              [&]() { return ReciprocalOutputShape(self); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
        

  {
    
  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();
    
    return ss.str();
  }

  bool CanBeReused(const torch::lazy::Value& self) const {
    return false;
    }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;

  
  

};
```
---
Generated `XLANativeFunctions.cpp`:
```
    at::Tensor XLANativeFunctions::floor(const at::Tensor & self) {
        
        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self);
        TORCH_INTERNAL_ASSERT(common_device);
        
        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        torch::lazy::NodePtr node = torch::lazy::ReuseNode<Floor>(lazy_self->GetIrValue());
        if (!node) {
            auto out_meta = at::meta::floor(self);
            std::vector<torch::lazy::Shape> shapes{
        torch::lazy::Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
            TORCH_INTERNAL_ASSERT(shapes.size() == 1);
            if(torch::lazy::symbolicShapeEnabled()){
                std::vector<torch::jit::IValue> inputs = { self };
                char* schema_str = "aten::floor(Tensor self) -> Tensor";
                applySymbolicShapesOnLT(schema_str, inputs, shapes);
            }
        
            node = torch::lazy::MakeNode<Floor>(lazy_self->GetIrValue(), std::move(shapes));
            CacheNode(node);
        }
        
        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };

at::Tensor XLANativeFunctions::reciprocal(const at::Tensor & self) {
        
        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self);
        TORCH_INTERNAL_ASSERT(common_device);
        
        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        torch::lazy::NodePtr node = torch::lazy::ReuseNode<Reciprocal>(lazy_self->GetIrValue());
        if (!node) {
            auto out_meta = at::meta::reciprocal(self);
            std::vector<torch::lazy::Shape> shapes{
        torch::lazy::Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
            TORCH_INTERNAL_ASSERT(shapes.size() == 1);
            if(torch::lazy::symbolicShapeEnabled()){
                std::vector<torch::jit::IValue> inputs = { self };
                char* schema_str = "aten::reciprocal(Tensor self) -> Tensor";
                applySymbolicShapesOnLT(schema_str, inputs, shapes);
            }
        
            node = torch::lazy::MakeNode<Reciprocal>(lazy_self->GetIrValue(), std::move(shapes));
            CacheNode(node);
        }
        
        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };
```