### PR TITLE
Revert "Revert "Full codegen for `logdet` (#3576)" (#3601)"

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1835,12 +1835,6 @@ at::Tensor XLANativeFunctions::logsumexp(const at::Tensor& self,
       /*keep_reduced_dimensions=*/keepdim));
 }
 
-at::Tensor XLANativeFunctions::logdet(const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(
-      XLATensor::logdet(bridge::GetXlaTensor(self)));
-}
-
 at::Tensor XLANativeFunctions::xlogy(const at::Tensor& self,
                                      const at::Tensor& other) {
   XLA_FN_COUNTER("xla::");

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -908,23 +908,6 @@ torch::lazy::NodePtr TanhGeluBackward(const torch::lazy::Value& grad,
   return grad * (left_derivative + right_derivative);
 }
 
-torch::lazy::NodePtr LogDet(const torch::lazy::Value& input) {
-  auto lower_fn = [](const XlaNode& node,
-                     LoweringContext* loctx) -> XlaOpVector {
-    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
-    xla::XlaOp result = xla::LogDet(xla_input);
-    return node.ReturnOp(result, loctx);
-  };
-  const xla::Shape& input_shape = GetXlaShape(input);
-  XLA_CHECK_GE(input_shape.rank(), 2) << input_shape;
-  // The input tensor is ...,N,N
-  xla::Shape logdet_shape(input_shape);
-  logdet_shape.DeleteDimension(input_shape.rank() - 1);
-  logdet_shape.DeleteDimension(input_shape.rank() - 2);
-  return GenericOp(torch::lazy::OpKind(at::aten::logdet), {input}, logdet_shape,
-                   std::move(lower_fn));
-}
-
 torch::lazy::NodePtr BaddBmm(const torch::lazy::Value& lhs,
                              const torch::lazy::Value& rhs,
                              const torch::lazy::Value& bias,

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -252,8 +252,6 @@ torch::lazy::NodePtr TanhGelu(const torch::lazy::Value& input);
 torch::lazy::NodePtr TanhGeluBackward(const torch::lazy::Value& grad,
                                       const torch::lazy::Value& input);
 
-torch::lazy::NodePtr LogDet(const torch::lazy::Value& input);
-
 torch::lazy::NodePtr IsNan(const torch::lazy::Value& input);
 
 torch::lazy::NodePtr BaddBmm(const torch::lazy::Value& lhs,

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -1,5 +1,6 @@
 #include <torch_xla/csrc/generated/LazyIr.h>
 
+#include "tensorflow/compiler/xla/client/lib/logdet.h"
 #include "tensorflow/compiler/xla/client/lib/math.h"
 #include "torch_xla/csrc/elementwise.h"
 #include "torch_xla/csrc/helpers.h"
@@ -52,6 +53,11 @@ torch_xla::XlaOpVector Cosh::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::Cosh(xla_input), loctx);
 }
 
+torch_xla::XlaOpVector Logdet::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  return ReturnOp(xla::LogDet(xla_input), loctx);
+}
+
 torch_xla::XlaOpVector Inverse::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   return ReturnOp(BuildInverse(xla_input), loctx);
@@ -83,6 +89,13 @@ torch_xla::XlaOpVector Sinh::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   return ReturnOp(xla::Sinh(xla_input), loctx);
 }
+
+/* Blocked on https://github.com/pytorch/xla/issues/3596 */
+// torch_xla::XlaOpVector Slogdet::Lower(LoweringContext* loctx) const {
+//   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+//   xla::SignAndLogDet result = xla::SLogDet(xla_input);
+//   return ReturnOps({result.sign, result.logdet}, loctx);
+// }
 
 torch_xla::XlaOpVector Tan::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -1,5 +1,6 @@
 #include "torch_xla/csrc/ops/ops_xla_shape_fn.h"
 
+#include "tensorflow/compiler/xla/client/lib/logdet.h"
 #include "torch_xla/csrc/helpers.h"
 
 namespace torch_xla {
@@ -44,6 +45,16 @@ xla::Shape InverseOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
+xla::Shape LogdetOutputShape(const torch::lazy::Value& input) {
+  const xla::Shape& input_shape = GetXlaShape(input);
+  XLA_CHECK_GE(input_shape.rank(), 2) << input_shape;
+  // The input tensor is ...,N,N
+  xla::Shape logdet_shape(input_shape);
+  logdet_shape.DeleteDimension(input_shape.rank() - 1);
+  logdet_shape.DeleteDimension(input_shape.rank() - 2);
+  return logdet_shape;
+}
+
 xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
                               const torch::lazy::Value& other) {
   auto lower_for_shape_fn =
@@ -70,6 +81,16 @@ xla::Shape SinOutputShape(const torch::lazy::Value& input) {
 xla::Shape SinhOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
+
+/* Blocked on https://github.com/pytorch/xla/issues/3596 */
+// xla::Shape SlogdetOutputShape(const torch::lazy::Value& input) {
+//   auto lower_for_shape_fn =
+//       [](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
+//     xla::SignAndLogDet result = xla::SLogDet(operands[0]);
+//     return xla::Tuple(operands[0].builder(), {result.sign, result.logdet});
+//   };
+//   return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
+// }
 
 xla::Shape TanOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -23,6 +23,8 @@ xla::Shape CoshOutputShape(const torch::lazy::Value& input);
 
 xla::Shape InverseOutputShape(const torch::lazy::Value& input);
 
+xla::Shape LogdetOutputShape(const torch::lazy::Value& input);
+
 xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
                               const torch::lazy::Value& other);
 
@@ -33,6 +35,9 @@ xla::Shape SignOutputShape(const torch::lazy::Value& input);
 xla::Shape SinOutputShape(const torch::lazy::Value& input);
 
 xla::Shape SinhOutputShape(const torch::lazy::Value& input);
+
+/* Blocked on https://github.com/pytorch/xla/issues/3596 */
+// xla::Shape SlogdetOutputShape(const torch::lazy::Value& input);
 
 xla::Shape TanOutputShape(const torch::lazy::Value& input);
 

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -751,8 +751,6 @@ class XLATensor : public c10::intrusive_ptr_target {
   static XLATensor log1p(const XLATensor& input);
   static void log1p_(XLATensor& input);
 
-  static XLATensor logdet(const XLATensor& input);
-
   static XLATensor logical_not(const XLATensor& input);
 
   static XLATensor logical_xor(const XLATensor& input, const XLATensor& other);

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1745,10 +1745,6 @@ void XLATensor::log1p_(XLATensor& input) {
   input.SetInPlaceIrValue(Log1p(input.GetIrValue()));
 }
 
-XLATensor XLATensor::logdet(const XLATensor& input) {
-  return input.CreateFrom(LogDet(input.GetIrValue()));
-}
-
 XLATensor XLATensor::logical_not(const XLATensor& input) {
   return input.CreateFrom(LogicalNot(input.GetIrValue()), at::ScalarType::Bool);
 }

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -11,6 +11,7 @@ full_codegen:
   - cos
   - cosh
   - inverse
+  - logdet
   - maximum
   - sgn
   - sign
@@ -175,7 +176,6 @@ supported:
   - log10
   - log_sigmoid_backward
   - log_sigmoid_forward
-  - logdet
   - logical_and
   - logical_not
   - logical_or


### PR DESCRIPTION
This reverts commit 67e4efbc9f3dd63f63ead416d050e08043e1f0c8.

Re-landing https://github.com/pytorch/xla/pull/3576, after we have re-updated the TF pin to the correct one. 