### PR TITLE
Make MP_OP_TEST optional

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -85,7 +85,7 @@ function run_pjrt {
   PJRT_DEVICE=CPU run_test "$@"
 }
 
-function run_all_tests {
+function run_op_tests {
   run_dynamic python3 "$CDIR/../../test/test_view_ops.py" "$@" -v TestViewOpsXLA
   run_test python3 "$CDIR/../../test/test_torch.py" "$@" -v TestTorchDeviceTypeXLA
   run_dynamic python3 "$CDIR/../../test/test_torch.py" "$@" -v TestDevicePrecisionXLA
@@ -102,16 +102,6 @@ function run_all_tests {
   # work on CPU.
   # run_test python3 "$CDIR/test_checkpoint.py"
   run_pjrt python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
-  run_test python3 "$CDIR/test_mp_replication.py"
-  run_test python3 "$CDIR/test_mp_all_to_all.py"
-  run_test python3 "$CDIR/test_mp_collective_permute.py"
-  run_test python3 "$CDIR/test_mp_all_gather.py"
-  run_test python3 "$CDIR/test_mp_reduce_scatter.py"
-  run_test python3 "$CDIR/test_mp_distributed_mm.py"
-  run_test python3 "$CDIR/test_mp_rendezvous.py"
-  run_test python3 "$CDIR/test_mp_save.py"
-  run_test python3 "$CDIR/test_mp_mesh_reduce.py"
-  run_test python3 "$CDIR/test_mp_sync_batch_norm.py"
   run_test python3 "$CDIR/test_async_closures.py"
   run_test python3 "$CDIR/test_xla_dist.py"
   run_test python3 "$CDIR/test_profiler.py"
@@ -126,8 +116,28 @@ function run_all_tests {
   run_xla_ir_debug python3 "$CDIR/test_env_var_mapper.py"
 }
 
+function run_mp_op_tests {
+  run_test python3 "$CDIR/test_mp_replication.py"
+  run_test python3 "$CDIR/test_mp_all_to_all.py"
+  run_test python3 "$CDIR/test_mp_collective_permute.py"
+  run_test python3 "$CDIR/test_mp_all_gather.py"
+  run_test python3 "$CDIR/test_mp_reduce_scatter.py"
+  run_test python3 "$CDIR/test_mp_distributed_mm.py"
+  run_test python3 "$CDIR/test_mp_rendezvous.py"
+  run_test python3 "$CDIR/test_mp_save.py"
+  run_test python3 "$CDIR/test_mp_mesh_reduce.py"
+  run_test python3 "$CDIR/test_mp_sync_batch_norm.py"
+}
+
+function run_tests {
+  run_op_tests
+  if [[ "$XLA_SKIP_MP_OP_TESTS" != "1" ]]; then
+    run_mp_op_tests
+  fi
+}
+
 if [ "$LOGFILE" != "" ]; then
-  run_all_tests 2>&1 | tee $LOGFILE
+  run_tests 2>&1 | tee $LOGFILE
 else
-  run_all_tests
+  run_tests
 fi


### PR DESCRIPTION
This is the xla prt of pr to fix https://github.com/pytorch/xla/issues/3513

we have ~8 cc op tests, on CPU CI each of them will start 4 grpc server(since we config test to use 4 cpu) with random port. Every time we have a port conflict test will fail. This pr is to provide an option to limit these cc ops tests on cpu to only be run on pytorch/xla CI. It is very unlikely upstream will break pt/xla cc op. Most of the cc op test is not supported on CPU so it will bring up the xrt server and then directly quit which only creates churn.

I will set the env var on upstream to disable these cc op tests on CPU CI.