### PR TITLE
Support type promotion in torch.cat

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2,6 +2,7 @@
 #include <ATen/Operators.h>
 #include <ATen/native/BinaryOps.h>
 #include <ATen/native/CPUFallback.h>
+#include <ATen/native/TypeProperties.h>
 
 #include <mutex>
 
@@ -1002,8 +1003,8 @@ at::Tensor XLANativeFunctions::bmm(const at::Tensor& self,
 
 at::Tensor XLANativeFunctions::cat(at::TensorList tensors, int64_t dim) {
   XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(
-      XLATensor::cat(bridge::GetXlaTensors(tensors), dim));
+  return bridge::AtenFromXlaTensor(XLATensor::cat(
+      bridge::GetXlaTensors(tensors), dim, at::native::result_type(tensors)));
 }
 
 at::Tensor XLANativeFunctions::ceil(const at::Tensor& self) {

--- a/torch_xla/csrc/data_ops.cpp
+++ b/torch_xla/csrc/data_ops.cpp
@@ -151,9 +151,14 @@ xla::XlaOp BuildStack(absl::Span<const xla::XlaOp> inputs, int64_t dim) {
   return xla::ConcatInDim(inputs[0].builder(), reshaped_inputs, dim);
 }
 
-xla::XlaOp BuildCat(absl::Span<const xla::XlaOp> inputs, int64_t dim) {
+xla::XlaOp BuildCat(absl::Span<const xla::XlaOp> inputs, int64_t dim,
+                    at::ScalarType dtype) {
   XLA_CHECK_GT(inputs.size(), 0);
-  return xla::ConcatInDim(inputs[0].builder(), inputs, dim);
+  std::vector<xla::XlaOp> casted_inputs;
+  for (const auto& op : inputs) {
+    casted_inputs.push_back(CastToScalarType(op, dtype));
+  }
+  return xla::ConcatInDim(inputs[0].builder(), casted_inputs, dim);
 }
 
 xla::XlaOp BuildRepeat(xla::XlaOp input, absl::Span<const int64_t> repeats) {

--- a/torch_xla/csrc/data_ops.h
+++ b/torch_xla/csrc/data_ops.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <c10/core/ScalarType.h>
+
 #include <vector>
 
 #include "absl/types/optional.h"
@@ -49,7 +51,8 @@ xla::XlaOp BuildStack(absl::Span<const xla::XlaOp> inputs, int64_t dim);
 
 // Concatenates a list of tensors along an existing dimension specified by the
 // dim argument.
-xla::XlaOp BuildCat(absl::Span<const xla::XlaOp> inputs, int64_t dim);
+xla::XlaOp BuildCat(absl::Span<const xla::XlaOp> inputs, int64_t dim,
+                    at::ScalarType dtype);
 
 // Repeats the input tensor along each dimension by the given number of repeats.
 xla::XlaOp BuildRepeat(xla::XlaOp input, absl::Span<const int64_t> repeats);

--- a/torch_xla/csrc/ops/cat.cpp
+++ b/torch_xla/csrc/ops/cat.cpp
@@ -26,10 +26,9 @@ xla::Shape NodeOutputShape(c10::ArrayRef<torch::lazy::Value> values,
 
 Cat::Cat(c10::ArrayRef<torch::lazy::Value> values, int64_t dim,
          at::ScalarType dtype)
-    : XlaNode(
-          torch::lazy::OpKind(at::aten::cat), values,
-          [&]() { return NodeOutputShape(values, dim, dtype); },
-          /*num_outputs=*/1, torch::lazy::MHash(dim)),
+    : XlaNode(torch::lazy::OpKind(at::aten::cat), values,
+              [&]() { return NodeOutputShape(values, dim, dtype); },
+              /*num_outputs=*/1, torch::lazy::MHash(dim)),
       dim_(dim),
       dtype_(dtype) {}
 

--- a/torch_xla/csrc/ops/cat.h
+++ b/torch_xla/csrc/ops/cat.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <c10/core/ScalarType.h>
+
 #include "absl/types/span.h"
 #include "torch_xla/csrc/ir.h"
 
@@ -7,7 +9,8 @@ namespace torch_xla {
 
 class Cat : public XlaNode {
  public:
-  Cat(c10::ArrayRef<torch::lazy::Value> values, int64_t dim);
+  Cat(c10::ArrayRef<torch::lazy::Value> values, int64_t dim,
+      at::ScalarType dtype);
 
   std::string ToString() const override;
 
@@ -17,8 +20,11 @@ class Cat : public XlaNode {
 
   int64_t dim() const { return dim_; };
 
+  at::ScalarType dtype() const { return dtype_; };
+
  private:
   int64_t dim_;
+  at::ScalarType dtype_;
 };
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -459,7 +459,8 @@ class XLATensor : public c10::intrusive_ptr_target {
   static std::vector<XLATensor> broadcast_tensors(
       absl::Span<const XLATensor> tensors);
 
-  static XLATensor cat(absl::Span<const XLATensor> tensors, int64_t dim, at::ScalarType dtype);
+  static XLATensor cat(absl::Span<const XLATensor> tensors, int64_t dim,
+                       at::ScalarType dtype);
 
   static XLATensor ceil(const XLATensor& input);
 

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -459,7 +459,7 @@ class XLATensor : public c10::intrusive_ptr_target {
   static std::vector<XLATensor> broadcast_tensors(
       absl::Span<const XLATensor> tensors);
 
-  static XLATensor cat(absl::Span<const XLATensor> tensors, int64_t dim);
+  static XLATensor cat(absl::Span<const XLATensor> tensors, int64_t dim, at::ScalarType dtype);
 
   static XLATensor ceil(const XLATensor& input);
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -981,7 +981,8 @@ std::vector<XLATensor> XLATensor::broadcast_tensors(
   return tensors.front().MakeOutputTensors(node);
 }
 
-XLATensor XLATensor::cat(absl::Span<const XLATensor> tensors, int64_t dim, at::ScalarType dtype) {
+XLATensor XLATensor::cat(absl::Span<const XLATensor> tensors, int64_t dim,
+                         at::ScalarType dtype) {
   // Shape checks for cat:
   // - If not empty, every tensor shape must be the same.
   // - Empty tensor passes but is simply ignore in implementation,
@@ -1000,7 +1001,8 @@ XLATensor XLATensor::cat(absl::Span<const XLATensor> tensors, int64_t dim, at::S
     dim = torch::lazy::GetCanonicalDimensionIndex(dim, tensor_shape.rank());
     tensor_shape.DeleteDimension(dim);
     if (!shapes.empty()) {
-      XLA_CHECK(xla::ShapeUtil::CompatibleIgnoringElementType(shapes.back(), tensor_shape))
+      XLA_CHECK(xla::ShapeUtil::CompatibleIgnoringElementType(shapes.back(),
+                                                              tensor_shape))
           << shapes.back() << " vs. " << tensor_shape;
     }
     shapes.push_back(tensor_shape);
@@ -1009,7 +1011,8 @@ XLATensor XLATensor::cat(absl::Span<const XLATensor> tensors, int64_t dim, at::S
   if (values.empty()) {
     return tensors[0];
   }
-  return tensors[0].CreateFrom(torch::lazy::MakeNode<Cat>(values, dim, dtype), dtype);
+  return tensors[0].CreateFrom(torch::lazy::MakeNode<Cat>(values, dim, dtype),
+                               dtype);
 }
 
 XLATensor XLATensor::ceil(const XLATensor& input) {

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -981,7 +981,7 @@ std::vector<XLATensor> XLATensor::broadcast_tensors(
   return tensors.front().MakeOutputTensors(node);
 }
 
-XLATensor XLATensor::cat(absl::Span<const XLATensor> tensors, int64_t dim) {
+XLATensor XLATensor::cat(absl::Span<const XLATensor> tensors, int64_t dim, at::ScalarType dtype) {
   // Shape checks for cat:
   // - If not empty, every tensor shape must be the same.
   // - Empty tensor passes but is simply ignore in implementation,
@@ -1000,7 +1000,7 @@ XLATensor XLATensor::cat(absl::Span<const XLATensor> tensors, int64_t dim) {
     dim = torch::lazy::GetCanonicalDimensionIndex(dim, tensor_shape.rank());
     tensor_shape.DeleteDimension(dim);
     if (!shapes.empty()) {
-      XLA_CHECK(xla::ShapeUtil::Compatible(shapes.back(), tensor_shape))
+      XLA_CHECK(xla::ShapeUtil::CompatibleIgnoringElementType(shapes.back(), tensor_shape))
           << shapes.back() << " vs. " << tensor_shape;
     }
     shapes.push_back(tensor_shape);
@@ -1009,7 +1009,7 @@ XLATensor XLATensor::cat(absl::Span<const XLATensor> tensors, int64_t dim) {
   if (values.empty()) {
     return tensors[0];
   }
-  return tensors[0].CreateFrom(torch::lazy::MakeNode<Cat>(values, dim));
+  return tensors[0].CreateFrom(torch::lazy::MakeNode<Cat>(values, dim, dtype), dtype);
 }
 
 XLATensor XLATensor::ceil(const XLATensor& input) {


### PR DESCRIPTION
I noticed torch_xla does not support type promotion in `torch.cat` when running the Huggingface `microsoft/layoutlmv2-base-uncased` model. This PR fixes this issue.
Minimal code to reproduce the bug:
```py
import torch
import torch_xla.core.xla_model as xm

device = xm.xla_device()
#device = torch.device("cpu:0")

x = torch.ones((14,512),device=device,dtype=torch.int64)
y = torch.ones((14,49),device=device,dtype=torch.float32)
z = torch.cat([x,y],dim=1)
print(z.dtype)
```