### PR TITLE
Wrap ComputationClient::Computation inside of torch_xla::Computation

### DIFF
--- a/torch_xla/csrc/computation.cpp
+++ b/torch_xla/csrc/computation.cpp
@@ -5,9 +5,30 @@
 namespace torch_xla {
 
 Computation::Computation(std::string name, xla::XlaComputation computation)
-    : name_(std::move(name)), computation_(std::move(computation)) {
-  program_shape_ = ConsumeValue(computation_.GetProgramShape());
-  hash_ = torch::lazy::MHash(name_, computation_.proto().SerializeAsString());
+    : name_(std::move(name)),
+      xla_client_computation_(
+          std::make_shared<xla::ComputationClient::Computation>(
+              std::move(computation))) {
+  hash_ = torch::lazy::MHash(
+      name_,
+      xla_client_computation_->computation().proto().SerializeAsString());
+}
+
+Computation::Computation(
+    std::shared_ptr<xla::ComputationClient::Computation> xla_client_computation)
+    : name_(""), hash_(0) {
+  xla_client_computation_ = xla_client_computation;
+}
+
+std::vector<torch::lazy::ComputationPtr> WrapClientComputation(
+    std::vector<std::shared_ptr<xla::ComputationClient::Computation>>
+        computations) {
+  std::vector<torch::lazy::ComputationPtr> res;
+  res.reserve(computations.size());
+  for (auto client_computation : computations) {
+    res.push_back(std::make_shared<Computation>(client_computation));
+  }
+  return res;
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/xla_backend_impl.cpp
+++ b/torch_xla/csrc/xla_backend_impl.cpp
@@ -118,11 +118,9 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
           {current_device.toString()}, &shape));
     }
     std::vector<std::shared_ptr<xla::ComputationClient::Computation>>
-        computations = xla::ComputationClient::Get()->Compile(
+        client_computations = xla::ComputationClient::Get()->Compile(
             std::move(compile_instances));
-    // TODO(JackCaoG): wrap the `xla::ComputationClient::Computation` inside
-    // `torch_xla::Computation` which inherited from `torch::lazy::Computation`
-    return {};
+    return WrapClientComputation(client_computations);
   }
 
   std::vector<torch::lazy::BackendDataPtr> ExecuteComputation(


### PR DESCRIPTION
Refactor  `torch_xla::Computation` to unify it with the `ComputationClient::Computation`. The goal of this exercise is that
1. LTC upstream needs a way to represent a computation
2. runtime needs a way to represent a computation
3. Pytorch and TF(where our runtime resides) can not take dependency with each other

so we have to wrap a runtime Computation inside a `torch_xla::Computation` which inherits from `torch::lazy::Computation`.

another thing LTC does is to replace `CompileInstance` in https://github.com/pytorch/xla/blob/73aa5c5ef583291938f3251e899adc25498c68d9/third_party/xla_client/computation_client.h#L105
with `torch::lazy::Computation` too. Compare https://github.com/pytorch/pytorch/blob/master/torch/csrc/lazy/core/lazy_graph_executor.cpp#L818 with https://github.com/pytorch/xla/blob/master/torch_xla/csrc/tensor.cpp#L1675

FYI @will-cromar since `Computation` is used by pjrt as well.