### PR TITLE
Move more test under XLA_SKIP_MP_OP_TESTS flag

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -107,10 +107,6 @@ function run_op_tests {
   run_downcast_bf16 python3 "$CDIR/test_data_type.py"
   run_use_bf16 python3 "$CDIR/test_data_type.py"
   run_test python3 "$CDIR/test_torch_distributed_xla_backend.py"
-  run_xla_backend_mp python3 "$CDIR/test_torch_distributed_all_gather_xla_backend.py"
-  run_xla_backend_mp python3 "$CDIR/test_torch_distributed_all_reduce_xla_backend.py"
-  run_xla_backend_mp python3 "$CDIR/test_torch_distributed_multi_all_reduce_xla_backend.py"
-  run_xla_backend_mp python3 "$CDIR/test_torch_distributed_reduce_scatter_xla_backend.py"
   run_xla_ir_debug python3 "$CDIR/test_env_var_mapper.py"
 }
 
@@ -125,6 +121,10 @@ function run_mp_op_tests {
   run_test python3 "$CDIR/test_mp_save.py"
   run_test python3 "$CDIR/test_mp_mesh_reduce.py"
   run_test python3 "$CDIR/test_mp_sync_batch_norm.py"
+  run_xla_backend_mp python3 "$CDIR/test_torch_distributed_all_gather_xla_backend.py"
+  run_xla_backend_mp python3 "$CDIR/test_torch_distributed_all_reduce_xla_backend.py"
+  run_xla_backend_mp python3 "$CDIR/test_torch_distributed_multi_all_reduce_xla_backend.py"
+  run_xla_backend_mp python3 "$CDIR/test_torch_distributed_reduce_scatter_xla_backend.py"
 }
 
 function run_tests {


### PR DESCRIPTION
These test won't be run on CPU anyway. Disable them from pytorch upstream CI.