### PR TITLE
Load libtpu when ComputationClient is created.

### DIFF
--- a/third_party/xla_client/BUILD
+++ b/third_party/xla_client/BUILD
@@ -167,7 +167,6 @@ cc_library(
         "//tensorflow/core/profiler/rpc:profiler_server_impl",
         "//tensorflow/core/profiler/rpc/client:profiler_client",
         "//tensorflow/core/protobuf/tpu:topology_proto_cc",
-        "//tensorflow/core/tpu:tpu_api_dlsym_initializer",
         "//tensorflow/stream_executor:stream_executor_impl",
         "@com_google_absl//absl/numeric:int128",
         "@com_google_absl//absl/strings",

--- a/third_party/xla_client/xrt_computation_client.cc
+++ b/third_party/xla_client/xrt_computation_client.cc
@@ -283,7 +283,7 @@ XrtComputationClient::XrtComputationClient(
                << "/replica:0/task:" << worker_target.first.task_no;
   }
 
-  TF_VLOG(1) << "libtpu status: " << tensorflow::tpu::FindAndLoadTpuLibrary();
+  TF_LOG(INFO) << "libtpu status: " << tensorflow::tpu::FindAndLoadTpuLibrary();
 
   TF_VLOG(1) << "XRT default device: " << options_.default_device;
   if (ShouldStartLocalService(options_.devices)) {

--- a/third_party/xla_client/xrt_computation_client.cc
+++ b/third_party/xla_client/xrt_computation_client.cc
@@ -282,6 +282,9 @@ XrtComputationClient::XrtComputationClient(
                << " for /job:" << worker_target.first.name
                << "/replica:0/task:" << worker_target.first.task_no;
   }
+
+  TF_VLOG(1) << "libtpu status: " << tensorflow::tpu::FindAndLoadTpuLibrary();
+
   TF_VLOG(1) << "XRT default device: " << options_.default_device;
   if (ShouldStartLocalService(options_.devices)) {
     MaybeCreateLocalService(options_);

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -106,6 +106,7 @@ from .version import __version__
 logger.info(
     'Letting libtpu.so load fail during _XLAC import. libtpu.so will be loaded '
     'from `libtpu` Python package when the ComputationClient is created.')
+# _tpu_vm_init() will update TPU_LIBRARY_PATH to Python package, if available
 os.environ['TPU_LIBRARY_PATH'] = '/dev/null'
 import _XLAC
 

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -91,8 +91,6 @@ _setup_xla_flags()
 if int(os.environ.get('PT_XLA_DEBUG', '0')):
   _fd, _tmp_fname = _setup_debug_env()
 
-# Setup libtpu library for TPU VM.
-_tpu_vm_init()
 
 import atexit
 import torch
@@ -100,6 +98,9 @@ from ._patched_functions import _apply_patches
 from .version import __version__
 import _XLAC
 
+# Set path for libtpu.so. Let static initializer fail during _XLAC import.
+# libtpu should be loaded when the ComputationClient is created.
+_tpu_vm_init()
 
 def _prepare_to_exit():
   _XLAC._prepare_to_exit()

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -91,7 +91,6 @@ _setup_xla_flags()
 if int(os.environ.get('PT_XLA_DEBUG', '0')):
   _fd, _tmp_fname = _setup_debug_env()
 
-
 import atexit
 import torch
 from ._patched_functions import _apply_patches
@@ -101,6 +100,7 @@ import _XLAC
 # Set path for libtpu.so. Let static initializer fail during _XLAC import.
 # libtpu should be loaded when the ComputationClient is created.
 _tpu_vm_init()
+
 
 def _prepare_to_exit():
   _XLAC._prepare_to_exit()


### PR DESCRIPTION
This lets us set topology env vars between after importing `torch_xla` and before creating the computation client. Example of restricting a process to one chip:

```
root@845104b51fc1:/root# PJRT_DEVICE=TPU python
Python 3.8.13 (default, Apr 20 2022, 18:59:55) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torch_xla.core.xla_model as xm
2022-05-27 16:34:42.423356: I tensorflow/core/tpu/tpu_initializer_helper.cc:253] Libtpu path is: libtpu.so # libtpu load fails here
>>> import os
>>> os.environ["TPU_CHIPS_PER_PROCESS_BOUNDS"] = "1,1,1"
>>> os.environ["TPU_PROCESS_BOUNDS"] = "1,1,1"
>>> os.environ["TPU_VISIBLE_DEVICES"] = "0"
>>> xm.xla_device()
2022-05-27 16:35:53.310894: I tensorflow/compiler/xla/xla_client/pjrt_computation_client.cc:50] Initializing PjRt TPU client...
2022-05-27 16:35:53.310960: I tensorflow/core/tpu/tpu_initializer_helper.cc:253] Libtpu path is: /home/ptxla/.local/lib/python3.8/site-packages/libtpu/libtpu.so # actual libtpu path
2022-05-27 16:35:54.823864: I tensorflow/compiler/xla/service/service.cc:174] XLA service 0x559faa3f5d30 initialized for platform TPU (this does not guarantee that XLA will be used). Devices:
2022-05-27 16:35:54.823921: I tensorflow/compiler/xla/service/service.cc:182]   StreamExecutor device (0): TPU, 2a886c8
2022-05-27 16:35:54.823930: I tensorflow/compiler/xla/service/service.cc:182]   StreamExecutor device (1): TPU, 2a886c8
device(type='xla', index=0)
>>>
```

Previously, libtpu was loaded by [`tpu_api_dlsym_initializer`](https://github.com/tensorflow/tensorflow/blob/8c78a5a5f6d6e510f5bbc327b2efaeeaea4f3796/tensorflow/core/tpu/tpu_api_dlsym_initializer.cc#L25) in TensorFlow.

- Remove our direct dependency on `tpu_api_dlsym_initializer`
- Implement dynamic loading for `XrtComputationClient`
- Dynamic loading [already implemented](https://github.com/tensorflow/tensorflow/blob/55243ab31de4c067cb065b0a4c6fc948d4727c2f/tensorflow/compiler/xla/pjrt/tpu_client.cc#L251) for PjRt

We still have a transitive dependency on `tpu_api_dlsym_initializer` via `//tensorflow/core/distributed_runtime/rpc:grpc_runtime` -> `//tensorflow/core/tpu:tpu_runtime` when we build with `with_tpu_support`. We can't remove remove the dependency from `//tensorflow/core/tpu:tpu_runtime` without actually changing how TF initializes libtpu. Thus, I moved the path setup for libtpu _after_ the import of `_XLAC`, which forces the static initializer to fail. We then dynamically initialize libtpu when we create the `ComputationClient`.

(Edge case: if libtpu is present in the default path at `./libtpu.so`, then libtpu will load during `import torch_xla`)

<details>
<summary>Bazel query</summary>

```
$ bazel query 'allpaths(//tensorflow/compiler/xla/xla_client:libxla_computation_client.so,//tensorflow/core/tpu:tpu_api_dlsym_initializer)' --output=graph
2022/05/27 16:56:51 Using unreleased version at commit 6e54699884cfad49d4e8f6dd59a4050bc95c4edf
digraph mygraph {
  node [shape=box];
  "//tensorflow/compiler/xla/xla_client:libxla_computation_client.so"
  "//tensorflow/compiler/xla/xla_client:libxla_computation_client.so" -> "//tensorflow/compiler/xla/xla_client:computation_client_impl"
  "//tensorflow/compiler/xla/xla_client:computation_client_impl"
  "//tensorflow/compiler/xla/xla_client:computation_client_impl" -> "//tensorflow/core/distributed_runtime/rpc:grpc_runtime"
  "//tensorflow/core/distributed_runtime/rpc:grpc_runtime"
  "//tensorflow/core/distributed_runtime/rpc:grpc_runtime" -> "//tensorflow/core/distributed_runtime/rpc:grpc_server_lib"
  "//tensorflow/core/distributed_runtime/rpc:grpc_runtime" -> "//tensorflow/core/distributed_runtime/rpc:grpc_session"
  "//tensorflow/core/distributed_runtime/rpc:grpc_server_lib"
  "//tensorflow/core/distributed_runtime/rpc:grpc_server_lib" -> "//tensorflow/core/distributed_runtime/rpc:grpc_master_service"
  "//tensorflow/core/distributed_runtime/rpc:grpc_server_lib" -> "//tensorflow/core/distributed_runtime:local_master"
  "//tensorflow/core/distributed_runtime/rpc:grpc_server_lib" -> "//tensorflow/core/distributed_runtime:master"
  "//tensorflow/core/distributed_runtime/rpc:grpc_server_lib" -> "//tensorflow/core/distributed_runtime:master_session"
  "//tensorflow/core/distributed_runtime/rpc:grpc_session"
  "//tensorflow/core/distributed_runtime/rpc:grpc_session" -> "//tensorflow/core/distributed_runtime:local_master"
  "//tensorflow/core/distributed_runtime:local_master"
  "//tensorflow/core/distributed_runtime:local_master" -> "//tensorflow/core/distributed_runtime:master"
  "//tensorflow/core/distributed_runtime/rpc:grpc_master_service"
  "//tensorflow/core/distributed_runtime/rpc:grpc_master_service" -> "//tensorflow/core/distributed_runtime:master"
  "//tensorflow/core/distributed_runtime:master"
  "//tensorflow/core/distributed_runtime:master" -> "//tensorflow/core/distributed_runtime:master_session"
  "//tensorflow/core/distributed_runtime:master_session"
  "//tensorflow/core/distributed_runtime:master_session" -> "//tensorflow/core/distributed_runtime:scheduler"
  "//tensorflow/core/distributed_runtime:scheduler"
  "//tensorflow/core/distributed_runtime:scheduler" -> "//tensorflow/core:tensorflow_opensource"
  "//tensorflow/core:tensorflow_opensource"
  "//tensorflow/core:tensorflow_opensource" -> "//tensorflow/core:core"
  "//tensorflow/core:core"
  "//tensorflow/core:core" -> "//tensorflow/core/common_runtime:core"
  "//tensorflow/core/common_runtime:core"
  "//tensorflow/core/common_runtime:core" -> "//tensorflow/core/tpu:tpu_runtime"
  [label="//tensorflow:with_tpu_support"];
  "//tensorflow/core/tpu:tpu_runtime"
  "//tensorflow/core/tpu:tpu_runtime" -> "//tensorflow/core/tpu:tpu_api_dlsym_initializer"
  "//tensorflow/core/tpu:tpu_api_dlsym_initializer"
}
```
</details>

Tested manually that libtpu still loads successfully for both XRT and PjRt