### PR TITLE
code for async scalar transfer

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -85,6 +85,11 @@ function run_pjrt {
   PJRT_DEVICE=CPU run_test "$@"
 }
 
+function run_async_scalar {
+  echo "Running in Async Scalar Upload mode: $@"
+  XLA_TRANSFER_SCALAR_ASYNC=1 run_test "$@"
+}
+
 function run_op_tests {
   run_dynamic python3 "$CDIR/../../test/test_view_ops.py" "$@" -v TestViewOpsXLA
   run_test python3 "$CDIR/../../test/test_torch.py" "$@" -v TestTorchDeviceTypeXLA
@@ -98,6 +103,7 @@ function run_op_tests {
   run_opbyop python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_eager_debug python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_async_rng python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  run_async_scalar python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_test python3 "$CDIR/test_grad_checkpoint.py"
   run_pjrt python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_test python3 "$CDIR/test_async_closures.py"

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -75,11 +75,6 @@ function run_xla_backend_mp {
   MASTER_ADDR=localhost MASTER_PORT=6000 run_test "$@"
 }
 
-function run_async_rng {
-  echo "Running in Async RNG Upload mode: $@"
-  XLA_TRANSFER_SEED_ASYNC=1 run_test "$@"
-}
-
 function run_pjrt {
   echo "Running in PjRt runtime: $@"
   PJRT_DEVICE=CPU run_test "$@"
@@ -102,7 +97,6 @@ function run_op_tests {
   run_dynamic python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_opbyop python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_eager_debug python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
-  run_async_rng python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_async_scalar python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_test python3 "$CDIR/test_grad_checkpoint.py"
   run_pjrt python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1876,11 +1876,13 @@ class TestModelComparator(XlaTestCase):
     self.assertEqual(len(report), 0)
 
 
-class TestAsyncRNG(XlaTestCase):
+class TestAsyncRNGOrScalar(XlaTestCase):
 
   def test(self):
     xla_device = xm.xla_device()
-    async_rng_mode = xu.getenv_as('XLA_TRANSFER_SEED_ASYNC', bool, defval=False)
+    async_mode = xu.getenv_as(
+        'XLA_TRANSFER_SEED_ASYNC', bool, defval=False) or xu.getenv_as(
+            'XLA_TRANSFER_SCALAR_ASYNC', bool, defval=False)
     # mark_step to clear the rng seed
     xm.mark_step()
 
@@ -1889,7 +1891,7 @@ class TestAsyncRNG(XlaTestCase):
         0]
     t1 = torch.randn(3, 3, device=xla_device)
     xm.mark_step()
-    if async_rng_mode:
+    if async_mode:
       assert met.metric_data(
           "TransferToServerAsync")[0] == async_transfer_count + 1
     else:

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1876,13 +1876,11 @@ class TestModelComparator(XlaTestCase):
     self.assertEqual(len(report), 0)
 
 
-class TestAsyncRNGOrScalar(XlaTestCase):
+class TestAsyncScalar(XlaTestCase):
 
-  def test(self):
+  def test_rng_seed_transfer(self):
     xla_device = xm.xla_device()
-    async_mode = xu.getenv_as(
-        'XLA_TRANSFER_SEED_ASYNC', bool, defval=False) or xu.getenv_as(
-            'XLA_TRANSFER_SCALAR_ASYNC', bool, defval=False)
+    async_mode = xu.getenv_as('XLA_TRANSFER_SCALAR_ASYNC', bool, defval=False)
     # mark_step to clear the rng seed
     xm.mark_step()
 
@@ -1891,6 +1889,22 @@ class TestAsyncRNGOrScalar(XlaTestCase):
         0]
     t1 = torch.randn(3, 3, device=xla_device)
     xm.mark_step()
+    if async_mode:
+      assert met.metric_data(
+          "TransferToServerAsync")[0] == async_transfer_count + 1
+    else:
+      assert met.metric_data("TransferToServerAsync") == None
+
+  def test_scalar_transfer(self):
+    xla_device = xm.xla_device()
+    async_mode = xu.getenv_as('XLA_TRANSFER_SCALAR_ASYNC', bool, defval=False)
+
+    transfer_to_server_async_metric = met.metric_data("TransferToServerAsync")
+    async_transfer_count = 0 if transfer_to_server_async_metric == None else transfer_to_server_async_metric[
+        0]
+    t1 = torch.randn(3, 3).to(xla_device)
+    t2 = t1 / 0.5
+    t3 = t2.cpu()
     if async_mode:
       assert met.metric_data(
           "TransferToServerAsync")[0] == async_transfer_count + 1

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -125,7 +125,7 @@ class XLATensor : public c10::intrusive_ptr_target {
 
   static torch::lazy::Value GetDeviceDataIrValue(
       const at::Scalar& value, xla::PrimitiveType type,
-      const torch::lazy::BackendDevice& device);
+      const torch::lazy::BackendDevice& device, bool transfer_async = false);
   // Use with caution, constant will cause more frequent recompilation
   // compared to the device_data.
   static torch::lazy::Value GetIrValueForConstant(const at::Scalar& value,

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -125,7 +125,7 @@ class XLATensor : public c10::intrusive_ptr_target {
 
   static torch::lazy::Value GetDeviceDataIrValue(
       const at::Scalar& value, xla::PrimitiveType type,
-      const torch::lazy::BackendDevice& device, bool transfer_async = false);
+      const torch::lazy::BackendDevice& device);
   // Use with caution, constant will cause more frequent recompilation
   // compared to the device_data.
   static torch::lazy::Value GetIrValueForConstant(const at::Scalar& value,

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -655,7 +655,7 @@ torch::lazy::BackendDataPtr TensorToXlaData(
   XLA_TIMED("TensorToData");
   static const bool transfer_async =
       xla::sys_util::GetEnvBool("XLA_TRANSFER_SCALAR_ASYNC", false);
-  if (tensor.dim() == 0 && tensor.numel() == 1 && transfer_async) {
+  if (transfer_async && tensor.dim() == 0 && tensor.numel() == 1) {
     std::shared_ptr<DataAsync> async = std::make_shared<DataAsync>();
     auto populate_mwait =
         std::make_shared<xla::util::MultiWait>(/*num_wait=*/1);

--- a/torch_xla/csrc/tensor_util.h
+++ b/torch_xla/csrc/tensor_util.h
@@ -44,8 +44,7 @@ bool TensorCompare(const at::Tensor& t1, const at::Tensor& t2);
 // device data handle.
 // TODO LTC @wonjoo - Migrate to upstream after Device -> BackendDevice
 torch::lazy::BackendDataPtr TensorToXlaData(
-    const at::Tensor& tensor, const torch::lazy::BackendDevice& device,
-    bool transfer_async = false);
+    const at::Tensor& tensor, const torch::lazy::BackendDevice& device);
 
 torch::lazy::hash_t TensorHash(const at::Tensor& tensor);
 

--- a/torch_xla/csrc/xla_backend_impl.cpp
+++ b/torch_xla/csrc/xla_backend_impl.cpp
@@ -27,14 +27,14 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
   torch::lazy::BackendDataPtr MakeComputationDataFromTensor(
       const at::Tensor& tensor, const torch::lazy::Shape& shape,
       const torch::lazy::BackendDevice& device) const override {
-    return TensorToXlaData(tensor, device, /*transfer_async=*/false);
+    return TensorToXlaData(tensor, device);
   }
 
   torch::lazy::BackendDataPtr MakeComputationDataFromScalar(
       const at::Scalar& scalar,
       const torch::lazy::BackendDevice& device) const override {
     at::Tensor t = at::scalar_tensor(scalar);
-    return TensorToXlaData(t, device, /*transfer_async=*/false);
+    return TensorToXlaData(t, device);
   }
 
   torch::lazy::BackendDataPtr CreateDataPlaceholder(


### PR DESCRIPTION
This PR is built on top of #3292 . Here we transfer the scalars to device in async mode. 
Consider the example in this comment: https://github.com/pytorch/xla/issues/3352#issuecomment-1042077820
```
denom = (exp_avg_sq.sqrt() / math.sqrt(bias_correction2)).add_(eps)
```
This step occurs in the adam optimizer (might be in other places too). In this case, the `bias_correction2` is a scalar that needs to be transferred to the device. Since this transfer happens synchronously, if a previous execution is running, this transfer would be blocked. This would block the model tracing and hence the model_tracing of the current step does not overlap with the execution of the previous step.
Here is what the profile looks like for a 2-layer bert on CPU with the transfer blocked.
<img width="814" alt="Screen Shot 2022-05-29 at 10 09 43 PM" src="https://user-images.githubusercontent.com/73188662/170921313-3986d2c4-c85b-4060-bdf8-e0ec897e29b4.png">

The optim_loop block is just xp.Trace over the optimizer step. It is blocked by transfer. 

By tracing the scalars asynchronously, the model tracing is no longer blocked and the execute computations are overlapping with the model tracing (this can be seen by reduced gap between the two executes and optim_loop not been stretched.

<img width="768" alt="Screen Shot 2022-05-29 at 10 10 40 PM" src="https://user-images.githubusercontent.com/73188662/170921828-c810302b-4cb5-45ff-b159-254f9f407046.png">


