### PR TITLE
replace out= lowerings with functional lowerings

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -2884,7 +2884,7 @@ TEST_F(AtenXlaTensorTest, TestClampMinTensorExplicit) {
     AllClose(b, xla_b);
   });
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::clamp_min_out", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::clamp_min", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestClampMaxExplicit) {
@@ -2912,7 +2912,7 @@ TEST_F(AtenXlaTensorTest, TestClampMaxTensorExplicit) {
     AllClose(b, xla_b);
   });
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::clamp_max_out", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::clamp_max", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestClampMinExplicitInPlace) {
@@ -3460,7 +3460,7 @@ TEST_F(AtenXlaTensorTest, TestSiLU) {
     AllClose(b, xla_b, /*rtol=*/1e-3, /*atol=*/1e-5);
   });
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::silu_out", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::silu", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestSiLUBackward) {
@@ -9029,7 +9029,7 @@ TEST_F(AtenXlaTensorTest, TestBitwiseOr) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::bitwise_or_out", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::bitwise_or", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestBitwiseOrInPlace) {
@@ -9047,7 +9047,7 @@ TEST_F(AtenXlaTensorTest, TestBitwiseOrInPlace) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::bitwise_or_out", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::bitwise_or", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestBitwiseOrScalar) {
@@ -9062,7 +9062,7 @@ TEST_F(AtenXlaTensorTest, TestBitwiseOrScalar) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::bitwise_or_out", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::bitwise_or", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestBitwiseOrScalarInPlace) {
@@ -9078,7 +9078,7 @@ TEST_F(AtenXlaTensorTest, TestBitwiseOrScalarInPlace) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::bitwise_or_out", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::bitwise_or", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestBitwiseXor) {
@@ -9095,7 +9095,7 @@ TEST_F(AtenXlaTensorTest, TestBitwiseXor) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::bitwise_xor_out", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::bitwise_xor", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestBitwiseXorInPlace) {
@@ -9113,7 +9113,7 @@ TEST_F(AtenXlaTensorTest, TestBitwiseXorInPlace) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::bitwise_xor_out", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::bitwise_xor", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestBitwiseXorScalar) {
@@ -9128,7 +9128,7 @@ TEST_F(AtenXlaTensorTest, TestBitwiseXorScalar) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::bitwise_xor_out", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::bitwise_xor", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestBitwiseXorScalarInPlace) {
@@ -9144,7 +9144,7 @@ TEST_F(AtenXlaTensorTest, TestBitwiseXorScalarInPlace) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::bitwise_xor_out", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::bitwise_xor", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestLshift) {

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -437,19 +437,15 @@ class XLATensor : public c10::intrusive_ptr_target {
 
   static XLATensor bitwise_and(const XLATensor& input, const XLATensor& other);
 
-  static void bitwise_not_out(XLATensor& out, const XLATensor& input);
+  static XLATensor bitwise_not(const XLATensor& input);
 
-  static void bitwise_or_out(XLATensor& out, const XLATensor& input,
-                             const at::Scalar& other);
+  static XLATensor bitwise_or(const XLATensor& input, const at::Scalar& other);
 
-  static void bitwise_or_out(XLATensor& out, const XLATensor& input,
-                             const XLATensor& other);
+  static XLATensor bitwise_or(const XLATensor& input, const XLATensor& other);
 
-  static void bitwise_xor_out(XLATensor& out, const XLATensor& input,
-                              const at::Scalar& other);
+  static XLATensor bitwise_xor(const XLATensor& input, const at::Scalar& other);
 
-  static void bitwise_xor_out(XLATensor& out, const XLATensor& input,
-                              const XLATensor& other);
+  static XLATensor bitwise_xor(const XLATensor& input, const XLATensor& other);
 
   // Batch matrix multiplication. Both tensors must be 3D, the batch size must
   // match and the remaining two dimensions must be compatible for matrix
@@ -476,9 +472,6 @@ class XLATensor : public c10::intrusive_ptr_target {
   static XLATensor clamp(const XLATensor& input,
                          const c10::optional<at::Tensor>& min,
                          const c10::optional<at::Tensor>& max);
-  static void clamp_out(XLATensor& out, const XLATensor& input,
-                        const c10::optional<at::Tensor>& min,
-                        const c10::optional<at::Tensor>& max);
 
   static XLATensor clone(const XLATensor& input);
 
@@ -1022,7 +1015,7 @@ class XLATensor : public c10::intrusive_ptr_target {
   static XLATensor selu(const XLATensor& input);
   static void selu_(XLATensor& input);
 
-  static void silu_out(XLATensor& input, XLATensor& out);
+  static XLATensor silu(const XLATensor& input);
   static XLATensor silu_backward(XLATensor& grad_output, XLATensor& input);
   static XLATensor sigmoid(const XLATensor& input);
   static XLATensor sigmoid_backward(const XLATensor& grad_output,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -933,36 +933,36 @@ XLATensor XLATensor::bitwise_and(const XLATensor& input,
   return input.CreateFrom(BitwiseAnd(input.GetIrValue(), other.GetIrValue()));
 }
 
-void XLATensor::bitwise_not_out(XLATensor& out, const XLATensor& input) {
-  out.SetIrValue(Not(input.GetIrValue()));
+XLATensor XLATensor::bitwise_not(const XLATensor& input) {
+  return input.CreateFrom(Not(input.GetIrValue()));
 }
 
-void XLATensor::bitwise_or_out(XLATensor& out, const XLATensor& input,
-                               const at::Scalar& other) {
-  CheckIsIntegralOrPred(input.shape(), "__or__");
-  torch::lazy::Value constant =
-      GetIrValueForScalar(other, input.shape(), input.GetDevice());
-  out.SetIrValue(BitwiseOr(input.GetIrValue(), constant));
-}
-
-void XLATensor::bitwise_or_out(XLATensor& out, const XLATensor& input,
-                               const XLATensor& other) {
-  CheckIsIntegralOrPred(input.shape(), "__or__");
-  out.SetIrValue(BitwiseOr(input.GetIrValue(), other.GetIrValue()));
-}
-
-void XLATensor::bitwise_xor_out(XLATensor& out, const XLATensor& input,
+XLATensor XLATensor::bitwise_or(const XLATensor& input,
                                 const at::Scalar& other) {
+  CheckIsIntegralOrPred(input.shape(), "__or__");
+  torch::lazy::Value constant =
+      GetIrValueForScalar(other, input.shape(), input.GetDevice());
+  return input.CreateFrom(BitwiseOr(input.GetIrValue(), constant));
+}
+
+XLATensor XLATensor::bitwise_or(const XLATensor& input,
+                                const XLATensor& other) {
+  CheckIsIntegralOrPred(input.shape(), "__or__");
+  return input.CreateFrom(BitwiseOr(input.GetIrValue(), other.GetIrValue()));
+}
+
+XLATensor XLATensor::bitwise_xor(const XLATensor& input,
+                                 const at::Scalar& other) {
   CheckIsIntegralOrPred(input.shape(), "__xor__");
   torch::lazy::Value constant =
       GetIrValueForScalar(other, input.shape(), input.GetDevice());
-  out.SetIrValue(BitwiseXor(input.GetIrValue(), constant));
+  return input.CreateFrom(BitwiseXor(input.GetIrValue(), constant));
 }
 
-void XLATensor::bitwise_xor_out(XLATensor& out, const XLATensor& input,
-                                const XLATensor& other) {
+XLATensor XLATensor::bitwise_xor(const XLATensor& input,
+                                 const XLATensor& other) {
   CheckIsIntegralOrPred(input.shape(), "__xor__");
-  out.SetIrValue(BitwiseXor(input.GetIrValue(), other.GetIrValue()));
+  return input.CreateFrom(BitwiseXor(input.GetIrValue(), other.GetIrValue()));
 }
 
 XLATensor XLATensor::bmm(const XLATensor& batch1, const XLATensor& batch2) {
@@ -1055,23 +1055,6 @@ XLATensor XLATensor::clamp(const XLATensor& input,
     res = Min(res, bridge::GetXlaTensor(*max).GetIrValue());
   }
   return input.CreateFrom(res);
-}
-
-void XLATensor::clamp_out(XLATensor& out, const XLATensor& input,
-                          const c10::optional<at::Tensor>& min,
-                          const c10::optional<at::Tensor>& max) {
-  XLA_CHECK(min || max)
-      << "At least one of \'min\' or \'max\' must not be None";
-  torch::lazy::Value res = input.GetIrValue();
-  if (min) {
-    res = torch::lazy::MakeNode<Maximum>(
-        res, bridge::GetXlaTensor(*min).GetIrValue(),
-        std::vector<torch::lazy::Shape>());
-  }
-  if (max) {
-    res = Min(res, bridge::GetXlaTensor(*max).GetIrValue());
-  }
-  out.SetInPlaceIrValue(res);
 }
 
 XLATensor XLATensor::clone(const XLATensor& input) {
@@ -2482,8 +2465,8 @@ void XLATensor::selu_(XLATensor& input) {
   input.SetInPlaceIrValue(Selu(input.GetIrValue()));
 }
 
-void XLATensor::silu_out(XLATensor& input, XLATensor& out) {
-  out.SetInPlaceIrValue(SiLU(input.GetIrValue()));
+XLATensor XLATensor::silu(const XLATensor& input) {
+  return input.CreateFrom(SiLU(input.GetIrValue()));
 }
 
 XLATensor XLATensor::silu_backward(XLATensor& grad_output, XLATensor& input) {

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -82,11 +82,11 @@ supported:
   - binary_cross_entropy_with_logits
   - bitwise_and.Scalar
   - bitwise_and.Tensor
-  - bitwise_not.out
-  - bitwise_or.Scalar_out
-  - bitwise_or.Tensor_out
-  - bitwise_xor.Scalar_out
-  - bitwise_xor.Tensor_out
+  - bitwise_not
+  - bitwise_or.Scalar
+  - bitwise_or.Tensor
+  - bitwise_xor.Scalar
+  - bitwise_xor.Tensor
   - bmm
   - cat
   - ceil
@@ -96,9 +96,9 @@ supported:
   - clamp
   - clamp.Tensor
   - clamp_max
-  - clamp_max.Tensor_out
+  - clamp_max.Tensor
   - clamp_min
-  - clamp_min.Tensor_out
+  - clamp_min.Tensor
   - clone
   - constant_pad_nd
   - convolution_backward_overrideable
@@ -271,7 +271,7 @@ supported:
   - selu_
   - sigmoid
   - sigmoid_backward
-  - silu.out
+  - silu
   - silu_backward
   - slice.Tensor
   - slogdet


### PR DESCRIPTION
Now that we have functional variants most aten ops, the external backend codegen that XLA uses will be able to generate inplace + out= kernels automatically, and XLA only needs to write a lowering for the functional op. There are a handful of lowerings that this applies to today in `xla_native_functions.yaml`, which I fixed.

Part of the reason I want this is actually because functionalization - once XLA is using functionalization, it should (almost) never even see an out= op. So really, we want it to be in the business of lowering functional ops when possible.