### PR TITLE
delegate sym_sizes to sizes since Pytorch is now using sym_sizes

### DIFF
--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -109,7 +109,8 @@ at::IntArrayRef XLATensorImpl::sizes_custom() const {
 }
 
 c10::SymIntArrayRef XLATensorImpl::sym_sizes_custom() const {
-  return sizes_custom();
+  auto sizes = sizes_custom();
+  return c10::SymIntArrayRef(sizes.data(), sizes.size());
 }
 
 at::IntArrayRef XLATensorImpl::strides_custom() const {

--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -110,7 +110,8 @@ at::IntArrayRef XLATensorImpl::sizes_custom() const {
 
 c10::SymIntArrayRef XLATensorImpl::sym_sizes_custom() const {
   auto sizes = sizes_custom();
-  return c10::SymIntArrayRef(reinterpret_cast<const c10::SymInt*>(sizes.data()), sizes.size());
+  return c10::SymIntArrayRef(reinterpret_cast<const c10::SymInt*>(sizes.data()),
+                             sizes.size());
 }
 
 at::IntArrayRef XLATensorImpl::strides_custom() const {

--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -108,6 +108,10 @@ at::IntArrayRef XLATensorImpl::sizes_custom() const {
   return sizes_default();
 }
 
+c10::SymIntArrayRef XLATensorImpl::sym_sizes_custom() const {
+  return sizes_custom();
+}
+
 at::IntArrayRef XLATensorImpl::strides_custom() const {
   const_cast<XLATensorImpl*>(this)->SetupSizeProperties();
   return strides_default();

--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -110,7 +110,7 @@ at::IntArrayRef XLATensorImpl::sizes_custom() const {
 
 c10::SymIntArrayRef XLATensorImpl::sym_sizes_custom() const {
   auto sizes = sizes_custom();
-  return c10::SymIntArrayRef(sizes.data(), sizes.size());
+  return c10::SymIntArrayRef(reinterpret_cast<const c10::SymInt*>(sizes.data()), sizes.size());
 }
 
 at::IntArrayRef XLATensorImpl::strides_custom() const {

--- a/torch_xla/csrc/tensor_impl.h
+++ b/torch_xla/csrc/tensor_impl.h
@@ -31,6 +31,7 @@ class XLATensorImpl : public c10::TensorImpl {
   void shallow_copy_from(const c10::intrusive_ptr<TensorImpl>& impl) override;
 
   at::IntArrayRef sizes_custom() const override;
+  c10::SymIntArrayRef sym_sizes_custom() const override;
   at::IntArrayRef strides_custom() const override;
 
   int64_t dim_custom() const override;


### PR DESCRIPTION
@JackCaoG  We are switching `THPVariable_size` to use `sym_sizes` here https://github.com/pytorch/pytorch/blob/b8382eb3c1d25c8d6aafd4bea0351db07c045f12/tools/autograd/templates/python_variable_methods.cpp#L98 in https://github.com/pytorch/pytorch/pull/78135 . I think to make XLA tests pass we need to implement `sym_sizes_custom`