### PR TITLE
Fix ScopePusher regression issue

### DIFF
--- a/test/cpp/test_ir.cpp
+++ b/test/cpp/test_ir.cpp
@@ -89,7 +89,7 @@ TEST(IrTest, TestScopePusherWithDebugging) {
   torch::lazy::ScopePusher scope("TestScope");
   torch::lazy::NodePtr nodeptr = ScalarOp(1.0, xla::F32);
   auto metaWithScope = nodeptr->metadata();
-  EXPECT_EQ(metaWithScope.scope, "TestScope.1");
+  ASSERT_TRUE(metaWithScope.scope.find("TestScope") != std::string::npos);
   EXPECT_EQ(metaWithScope.frame_info.size(), 1);
   FLAGS_torch_lazy_ir_debug = restore_FLAGS_torch_lazy_ir_debug;
 }

--- a/test/cpp/test_ir.cpp
+++ b/test/cpp/test_ir.cpp
@@ -72,12 +72,26 @@ TEST(IrTest, TestSelectUnselect) {
   });
 }
 
-TEST(IrTest, TestScopePusher) {
+TEST(IrTest, TestScopePusherWithoutDebugging) {
+  bool restore_FLAGS_torch_lazy_ir_debug = FLAGS_torch_lazy_ir_debug;
+  FLAGS_torch_lazy_ir_debug = false;
+  torch::lazy::ScopePusher scope("TestScope");
+  torch::lazy::NodePtr nodeptr = ScalarOp(1.0, xla::F32);
+  auto metaWithScope = nodeptr->metadata();
+  EXPECT_EQ(metaWithScope.scope, "");
+  EXPECT_EQ(metaWithScope.frame_info.size(), 0);
+  FLAGS_torch_lazy_ir_debug = restore_FLAGS_torch_lazy_ir_debug;
+}
+
+TEST(IrTest, TestScopePusherWithDebugging) {
+  bool restore_FLAGS_torch_lazy_ir_debug = FLAGS_torch_lazy_ir_debug;
+  FLAGS_torch_lazy_ir_debug = true;
   torch::lazy::ScopePusher scope("TestScope");
   torch::lazy::NodePtr nodeptr = ScalarOp(1.0, xla::F32);
   auto metaWithScope = nodeptr->metadata();
   EXPECT_EQ(metaWithScope.scope, "TestScope.1");
   EXPECT_EQ(metaWithScope.frame_info.size(), 1);
+  FLAGS_torch_lazy_ir_debug = restore_FLAGS_torch_lazy_ir_debug;
 }
 
 }  // namespace cpp_test

--- a/test/cpp/test_ir.cpp
+++ b/test/cpp/test_ir.cpp
@@ -72,5 +72,13 @@ TEST(IrTest, TestSelectUnselect) {
   });
 }
 
+TEST(IrTest, TestScopePusher) {
+  torch::lazy::ScopePusher scope("TestScope");
+  torch::lazy::NodePtr nodeptr = ScalarOp(1.0, xla::F32);
+  auto metaWithScope = nodeptr->metadata();
+  EXPECT_EQ(metaWithScope.scope, "TestScope.1");
+  EXPECT_EQ(metaWithScope.frame_info.size(), 1);
+}
+
 }  // namespace cpp_test
 }  // namespace torch_xla

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -808,11 +808,11 @@ void BuildProfilerSubmodule(py::module* m) {
       .def_static("is_enabled",
                   &tensorflow::profiler::TraceMeWrapper::IsEnabled);
 
-  py::class_<ScopePusher, std::unique_ptr<ScopePusher>> scope_pusher_class(
+  py::class_<torch::lazy::ScopePusher, std::unique_ptr<torch::lazy::ScopePusher>> scope_pusher_class(
       profiler, "ScopePusher");
   profiler.def("scope_pusher",
-               [](const std::string& name) -> std::unique_ptr<ScopePusher> {
-                 return absl::make_unique<ScopePusher>(name);
+               [](const std::string& name) -> std::unique_ptr<torch::lazy::ScopePusher> {
+                 return absl::make_unique<torch::lazy::ScopePusher>(name);
                });
 }
 

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -808,12 +808,14 @@ void BuildProfilerSubmodule(py::module* m) {
       .def_static("is_enabled",
                   &tensorflow::profiler::TraceMeWrapper::IsEnabled);
 
-  py::class_<torch::lazy::ScopePusher, std::unique_ptr<torch::lazy::ScopePusher>> scope_pusher_class(
-      profiler, "ScopePusher");
-  profiler.def("scope_pusher",
-               [](const std::string& name) -> std::unique_ptr<torch::lazy::ScopePusher> {
-                 return absl::make_unique<torch::lazy::ScopePusher>(name);
-               });
+  py::class_<torch::lazy::ScopePusher,
+             std::unique_ptr<torch::lazy::ScopePusher>>
+      scope_pusher_class(profiler, "ScopePusher");
+  profiler.def(
+      "scope_pusher",
+      [](const std::string& name) -> std::unique_ptr<torch::lazy::ScopePusher> {
+        return absl::make_unique<torch::lazy::ScopePusher>(name);
+      });
 }
 
 void InitXlaModuleBindings(py::module m) {

--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -19,48 +19,6 @@ namespace {
 using ShapeCache =
     xla::util::Cache<torch::lazy::hash_t, xla::Shape, torch::lazy::HashReducer>;
 
-struct ScopeEntry {
-  std::string name;
-  size_t saved_next_id = 1;
-};
-
-struct ScopeContext {
-  std::vector<ScopeEntry> scopes;
-  size_t next_id = 1;
-};
-
-thread_local ScopeContext g_scope_context;
-
-void PushScope(const std::string& name) {
-  size_t id = g_scope_context.next_id;
-  g_scope_context.scopes.push_back(
-      {absl::StrCat(name, ".", id), g_scope_context.next_id + 1});
-  g_scope_context.next_id = 1;
-}
-
-void PopScope() {
-  XLA_CHECK(!g_scope_context.scopes.empty());
-  g_scope_context.next_id = g_scope_context.scopes.back().saved_next_id;
-  g_scope_context.scopes.pop_back();
-}
-
-void ResetScopeContext() {
-  XLA_CHECK_EQ(g_scope_context.scopes.size(), 0);
-  g_scope_context.next_id = 1;
-}
-
-std::string GetCurrentScope() {
-  std::string scope;
-  for (auto& scope_entry : g_scope_context.scopes) {
-    if (scope.empty()) {
-      absl::StrAppend(&scope, scope_entry.name);
-    } else {
-      absl::StrAppend(&scope, "/", scope_entry.name);
-    }
-  }
-  return scope;
-}
-
 ShapeCache* GetShapeCache() {
   static int64_t shape_cache_size =
       xla::sys_util::GetEnvInt("XLA_IR_SHAPE_CACHE_SIZE", 4096);
@@ -201,12 +159,6 @@ xla::Shape XlaNode::GetOpShape(
   }
   return *shape;
 }
-
-ScopePusher::ScopePusher(const std::string& name) { PushScope(name); }
-
-ScopePusher::~ScopePusher() { PopScope(); }
-
-void ScopePusher::ResetScopes() { ResetScopeContext(); }
 
 const xla::Shape& GetXlaShape(const torch::lazy::Value& value) {
   XlaNode* casted = dynamic_cast<XlaNode*>(value.node.get());

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -139,16 +139,6 @@ class XlaNode : public torch::lazy::Node {
   const xla::OpSharding* output_sharding_ = nullptr;
 };
 
-// RAII data structure to be used a stack variable to enter a new IR scope. IR
-// scope names will appear in the IR and will help identifying the source of the
-// single IR nodes.
-struct ScopePusher {
-  explicit ScopePusher(const std::string& name);
-  ~ScopePusher();
-
-  static void ResetScopes();
-};
-
 inline std::ostream& operator<<(std::ostream& stream, const XlaNode& node) {
   stream << node.ToString();
   return stream;

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -650,7 +650,7 @@ torch::lazy::NodePtr Norm(const torch::lazy::Value& input,
                           const c10::optional<at::Scalar>& p,
                           c10::optional<at::ScalarType> dtype,
                           absl::Span<const int64_t> dims, bool keepdim) {
-  ScopePusher ir_scope(at::aten::norm.toQualString());
+  torch::lazy::ScopePusher ir_scope(at::aten::norm.toQualString());
   auto dimensions = torch::lazy::ToVector<int64_t>(dims);
   if (dimensions.empty()) {
     dimensions = torch::lazy::Iota<int64_t>(GetXlaShape(input).rank());
@@ -760,31 +760,31 @@ torch::lazy::NodePtr GeluBackward(const torch::lazy::Value& grad_output,
 
 torch::lazy::NodePtr Lshift(const torch::lazy::Value& input,
                             const at::Scalar& other) {
-  ScopePusher ir_scope(at::aten::__lshift__.toQualString());
+  torch::lazy::ScopePusher ir_scope(at::aten::__lshift__.toQualString());
   return input * ScalarOp(pow(2, other.to<double>()), GetXlaShape(input));
 }
 
 torch::lazy::NodePtr Lshift(const torch::lazy::Value& input,
                             const torch::lazy::Value& other) {
-  ScopePusher ir_scope(at::aten::__lshift__.toQualString());
+  torch::lazy::ScopePusher ir_scope(at::aten::__lshift__.toQualString());
   return input * Pow(ScalarOp(2, GetXlaShape(input)), other);
 }
 
 torch::lazy::NodePtr Rshift(const torch::lazy::Value& input,
                             const at::Scalar& other) {
-  ScopePusher ir_scope(at::aten::__rshift__.toQualString());
+  torch::lazy::ScopePusher ir_scope(at::aten::__rshift__.toQualString());
   return input / ScalarOp(pow(2, other.to<double>()), GetXlaShape(input));
 }
 
 torch::lazy::NodePtr Rshift(const torch::lazy::Value& input,
                             const torch::lazy::Value& other) {
-  ScopePusher ir_scope(at::aten::__rshift__.toQualString());
+  torch::lazy::ScopePusher ir_scope(at::aten::__rshift__.toQualString());
   return input / Pow(ScalarOp(2, GetXlaShape(input)), other);
 }
 
 torch::lazy::NodePtr Remainder(const torch::lazy::Value& input,
                                const torch::lazy::Value& divisor) {
-  ScopePusher ir_scope(at::aten::remainder.toQualString());
+  torch::lazy::ScopePusher ir_scope(at::aten::remainder.toQualString());
   torch::lazy::NodePtr f = Fmod(
       input,
       torch::lazy::MakeNode<Abs>(divisor, std::vector<torch::lazy::Shape>()));
@@ -856,7 +856,7 @@ torch::lazy::NodePtr Take(const torch::lazy::Value& input,
 
 torch::lazy::NodePtr TanhGelu(const torch::lazy::Value& input) {
   // TODO: add proper lowering function
-  ScopePusher ir_scope("aten::tanh_gelu");
+  torch::lazy::ScopePusher ir_scope("aten::tanh_gelu");
   const xla::Shape& shape = GetXlaShape(input);
   // inner = math.sqrt(2 / math.pi) * (x + 0.044715 * torch.pow(input, 3))
   // input * 0.5 * (1.0 + torch.tanh(inner))
@@ -873,7 +873,7 @@ torch::lazy::NodePtr TanhGelu(const torch::lazy::Value& input) {
 torch::lazy::NodePtr TanhGeluBackward(const torch::lazy::Value& grad,
                                       const torch::lazy::Value& input) {
   // TODO: add proper lowering function
-  ScopePusher ir_scope("aten::tanh_gelu_backward");
+  torch::lazy::ScopePusher ir_scope("aten::tanh_gelu_backward");
   const xla::Shape& shape = GetXlaShape(input);
   constexpr float kBeta = M_SQRT2 * M_2_SQRTPI * 0.5;
   torch::lazy::NodePtr beta = ScalarOp(kBeta, shape);
@@ -938,7 +938,7 @@ torch::lazy::NodePtr BaddBmm(const torch::lazy::Value& lhs,
 torch::lazy::NodePtr Lerp(const torch::lazy::Value& start,
                           const torch::lazy::Value& end,
                           const torch::lazy::Value& weight) {
-  ScopePusher ir_scope(at::aten::lerp.toQualString());
+  torch::lazy::ScopePusher ir_scope(at::aten::lerp.toQualString());
   return start + weight * (end - start);
 }
 

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1518,7 +1518,7 @@ void XLATensor::SyncLiveTensorsGraph(const torch::lazy::BackendDevice* device,
 void XLATensor::MarkStep(const torch::lazy::BackendDevice& device) {
   XLA_COUNTER("MarkStep", 1);
   DeviceContextArena::Get()->MarkStep(device);
-  ScopePusher::ResetScopes();
+  torch::lazy::ScopePusher::ResetScopes();
   g_tls_data.Reset();
 }
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1781,7 +1781,7 @@ XLATensor XLATensor::lt(const XLATensor& input, const XLATensor& other) {
 
 void XLATensor::masked_fill_(XLATensor& input, const XLATensor& mask,
                              const at::Scalar& value) {
-  ScopePusher ir_scope(at::aten::masked_fill.toQualString());
+  torch::lazy::ScopePusher ir_scope(at::aten::masked_fill.toQualString());
   input.SetIrValue(torch::lazy::MakeNode<MaskedFill>(
       input.GetIrValue(), MaybeExpand(mask.GetIrValue(), input.shape()),
       value));
@@ -1789,7 +1789,7 @@ void XLATensor::masked_fill_(XLATensor& input, const XLATensor& mask,
 
 void XLATensor::masked_scatter_(XLATensor& input, const XLATensor& mask,
                                 const XLATensor& source) {
-  ScopePusher ir_scope(at::aten::masked_scatter.toQualString());
+  torch::lazy::ScopePusher ir_scope(at::aten::masked_scatter.toQualString());
   input.SetIrValue(torch::lazy::MakeNode<MaskedScatter>(
       input.GetIrValue(), MaybeExpand(mask.GetIrValue(), input.shape()),
       source.GetIrValue()));

--- a/torch_xla/csrc/tensor_ops.cpp
+++ b/torch_xla/csrc/tensor_ops.cpp
@@ -98,7 +98,7 @@ XLATensor MakeMatrixWithDiagonal(const XLATensor& input, int64_t diagonal) {
 
 XLATensor SmoothL1Loss(const XLATensor& input, const XLATensor& target,
                        ReductionMode reduction, double beta) {
-  torch_xla::ScopePusher ir_scope(at::aten::smooth_l1_loss.toQualString());
+  torch::lazy::ScopePusher ir_scope(at::aten::smooth_l1_loss.toQualString());
   auto broadcasted_inputs = XLATensor::broadcast_tensors({input, target});
   XLA_CHECK_EQ(broadcasted_inputs.size(), 2);
   const XLATensor& broadcasted_input = broadcasted_inputs[0];
@@ -134,7 +134,7 @@ XLATensor SmoothL1Loss(const XLATensor& input, const XLATensor& target,
 XLATensor SmoothL1LossBackward(const XLATensor& grad_output,
                                const XLATensor& input, const XLATensor& target,
                                ReductionMode reduction, double beta) {
-  torch_xla::ScopePusher ir_scope(
+  torch::lazy::ScopePusher ir_scope(
       at::aten::smooth_l1_loss_backward.toQualString());
   auto broadcasted_inputs = XLATensor::broadcast_tensors({input, target});
   XLA_CHECK_EQ(broadcasted_inputs.size(), 2);


### PR DESCRIPTION
Fix ScopePusher regression issue,  as noted in https://github.com/pytorch/xla/issues/3631. 

Testing locally, I can see that scope is now getting added correctly:
```
>>> import torch; import torch_xla
>>> 
>>> scope = torch_xla._XLAC.profiler.scope_pusher('custom scope name')
>>> a = torch.tensor([1, 2], device="xla:0")
>>> 
>>> a
tensor([1, 2], device='xla:0')
>>> print(torch_xla._XLAC._get_xla_tensors_text([a]))
IR {
  %0 = s64[2]{0} xla::device_data(), scope=custom scope name.1, location=<module>@<stdin>:1, device=CPU:0, ROOT=0
}
```

Also added unit tests to test this, but unfortunately I currently cannot build cpp unit tests locally so I'll wait for the CI to verify. 