### PR TITLE
fix torchvision pinning

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -7,7 +7,6 @@ source .circleci/common.sh
 PYTORCH_DIR=/tmp/pytorch
 XLA_DIR=$PYTORCH_DIR/xla
 clone_pytorch $PYTORCH_DIR $XLA_DIR
-source "$PYTORCH_DIR/.jenkins/pytorch/common_utils.sh"
 
 SCCACHE="$(which sccache)"
 if [ -z "${SCCACHE}" ]; then

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -8,7 +8,20 @@ source .circleci/common.sh
 PYTORCH_DIR=/tmp/pytorch
 XLA_DIR=$PYTORCH_DIR/xla
 
-source "$PYTORCH_DIR/.jenkins/pytorch/common_utils.sh"
+# Needs to be kept in sync with .jenkins/pytorch/common_utils.sh in pytorch/pytorch.
+TORCHVISION_COMMIT="$(cat $PYTORCH_DIR/.github/ci_commit_pins/vision.txt)"
+
+function pip_install() {
+  # retry 3 times
+  # old versions of pip don't have the "--progress-bar" flag
+  pip install --progress-bar off "$@" || pip install --progress-bar off "$@" || pip install --progress-bar off "$@" ||\
+  pip install "$@" || pip install "$@" || pip install "$@"
+}
+
+function install_torchvision() {
+  pip_install --user "git+https://github.com/pytorch/vision.git@$TORCHVISION_COMMIT"
+}
+
 install_torchvision
 
 run_torch_xla_tests $PYTORCH_DIR $XLA_DIR


### PR DESCRIPTION
This should hopefully fix the torch vision pinning issue from https://github.com/pytorch/pytorch/pull/79151. We probably don't wanna be running `source .jenkins/pytorch/common_utils.sh`, because:

(1) that file makes assumptions about relative paths now that are a pain to fix
(2) It looks like the CI scripts only actually use it to figure out how to install torch vision, and duplicating it doesn't seem any less of a hassle

Will confirm with CI