### PR TITLE
Load libtpu in XRT local service

### DIFF
--- a/third_party/xla_client/xrt_computation_client.cc
+++ b/third_party/xla_client/xrt_computation_client.cc
@@ -25,7 +25,6 @@
 #include "tensorflow/compiler/xrt/xrt_util.h"
 #include "tensorflow/core/framework/allocator.h"
 #include "tensorflow/core/profiler/lib/traceme.h"
-#include "tensorflow/core/tpu/tpu_initializer_helper.h"
 #include "tensorflow/core/util/device_name_utils.h"
 
 namespace xla {
@@ -283,8 +282,6 @@ XrtComputationClient::XrtComputationClient(
                << " for /job:" << worker_target.first.name
                << "/replica:0/task:" << worker_target.first.task_no;
   }
-
-  TF_LOG(INFO) << "libtpu status: " << tensorflow::tpu::FindAndLoadTpuLibrary();
 
   TF_VLOG(1) << "XRT default device: " << options_.default_device;
   if (ShouldStartLocalService(options_.devices)) {

--- a/third_party/xla_client/xrt_local_service.cc
+++ b/third_party/xla_client/xrt_local_service.cc
@@ -9,6 +9,7 @@
 #include "tensorflow/core/protobuf/cluster.pb.h"
 #include "tensorflow/core/protobuf/tensorflow_server.pb.h"
 #include "tensorflow/core/public/session_options.h"
+#include "tensorflow/core/tpu/tpu_initializer_helper.h"
 
 namespace xla {
 namespace {
@@ -51,6 +52,7 @@ void FillServerDef(const std::string& cluster_spec, const std::string& job_name,
 
 XrtLocalService::XrtLocalService(const std::string& cluster_spec,
                                  const std::string& job_name, int task_index) {
+  TF_LOG(INFO) << "libtpu status: " << tensorflow::tpu::FindAndLoadTpuLibrary();
   tensorflow::ServerDef server_def;
   FillServerDef(cluster_spec, job_name, task_index, &server_def);
   TF_CHECK_OK(tensorflow::NewServer(server_def, &server_));


### PR DESCRIPTION
Fixes libtpu load with in `xrt_run_server`, which does not create a ComputationClient. Tested manually on v2-8