### PR TITLE
Create MatMul op to build MatMul with bias op

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -74,9 +74,10 @@ void CheckSubOperandTypes(at::ScalarType type1, at::ScalarType type2) {
 
 c10::optional<at::ScalarType> PromoteIntegralType(
     at::ScalarType src_dtype, const c10::optional<at::ScalarType>& opt_dtype) {
-  return opt_dtype.has_value() ? opt_dtype.value()
-         : at::isIntegralType(src_dtype, /*includeBool=*/true) ? at::kLong
-                                                               : opt_dtype;
+  return opt_dtype.has_value()
+             ? opt_dtype.value()
+             : at::isIntegralType(src_dtype, /*includeBool=*/true) ? at::kLong
+                                                                   : opt_dtype;
 }
 
 bool IsTypeWithLargerRangeThanLong(torch::ScalarType dtype) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -74,10 +74,9 @@ void CheckSubOperandTypes(at::ScalarType type1, at::ScalarType type2) {
 
 c10::optional<at::ScalarType> PromoteIntegralType(
     at::ScalarType src_dtype, const c10::optional<at::ScalarType>& opt_dtype) {
-  return opt_dtype.has_value()
-             ? opt_dtype.value()
-             : at::isIntegralType(src_dtype, /*includeBool=*/true) ? at::kLong
-                                                                   : opt_dtype;
+  return opt_dtype.has_value() ? opt_dtype.value()
+         : at::isIntegralType(src_dtype, /*includeBool=*/true) ? at::kLong
+                                                               : opt_dtype;
 }
 
 bool IsTypeWithLargerRangeThanLong(torch::ScalarType dtype) {
@@ -3116,11 +3115,11 @@ at::Tensor XLANativeFunctions::sum(const at::Tensor& self,
                                    at::OptionalIntArrayRef dim, bool keepdim,
                                    c10::optional<at::ScalarType> dtype) {
   XLA_FN_COUNTER("xla::");
-  XLATensor self_tensor = bridge::GetXlaTensor(self);
+  XLATensorPtr self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(XLATensor::sum(
       self_tensor,
       dim ? torch::lazy::ToVector<int64_t>(*dim)
-          : torch::lazy::Iota<int64_t>(self_tensor.shape().get().rank()),
+          : torch::lazy::Iota<int64_t>(self_tensor->shape().get().rank()),
       keepdim, dtype));
 }
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -722,8 +722,8 @@ XLATensorPtr XLATensor::addcmul(const XLATensorPtr& input,
 XLATensorPtr XLATensor::addmm(const XLATensorPtr& input,
                               const XLATensorPtr& weight,
                               const XLATensorPtr& bias) {
-  return input->CreateFrom(AddMatMulOp(
-      input->GetIrValue(), weight->GetIrValue(), bias->GetIrValue()));
+  return input->CreateFrom(XLATensor::matmul(input, weight)->GetIrValue() +
+                           bias->GetIrValue());
 }
 
 XLATensorPtr XLATensor::all(const XLATensorPtr& input,

--- a/torch_xla/csrc/xla_lower_util.cpp
+++ b/torch_xla/csrc/xla_lower_util.cpp
@@ -440,9 +440,9 @@ xla::XlaOp BuildMatMul(xla::XlaOp lhs, xla::XlaOp rhs, xla::XlaOp bias) {
   xla::XlaOp dot = CreateMatMul(lhs, rhs);
   const xla::Shape& dot_shape = XlaHelpers::ShapeOfXlaOp(dot);
   const xla::Shape& bias_shape = XlaHelpers::ShapeOfXlaOp(bias);
-  //if (bias_shape.dimensions() != dot_shape.dimensions()) {
-  //  bias = BuildExpand(bias, dot_shape.dimensions());
-  //}
+  if (bias_shape.dimensions() != dot_shape.dimensions()) {
+    bias = BuildExpand(bias, dot_shape.dimensions());
+  }
   return dot + bias;
 }
 

--- a/torch_xla/csrc/xla_lower_util.cpp
+++ b/torch_xla/csrc/xla_lower_util.cpp
@@ -437,12 +437,12 @@ xla::XlaOp BuildGer(xla::XlaOp lhs, xla::XlaOp rhs) {
 }
 
 xla::XlaOp BuildMatMul(xla::XlaOp lhs, xla::XlaOp rhs, xla::XlaOp bias) {
-  xla::XlaOp dot = BuildDot(lhs, rhs);
+  xla::XlaOp dot = CreateMatMul(lhs, rhs);
   const xla::Shape& dot_shape = XlaHelpers::ShapeOfXlaOp(dot);
   const xla::Shape& bias_shape = XlaHelpers::ShapeOfXlaOp(bias);
-  if (bias_shape.dimensions() != dot_shape.dimensions()) {
-    bias = BuildExpand(bias, dot_shape.dimensions());
-  }
+  //if (bias_shape.dimensions() != dot_shape.dimensions()) {
+  //  bias = BuildExpand(bias, dot_shape.dimensions());
+  //}
   return dot + bias;
 }
 


### PR DESCRIPTION
This helps improve matmul with bias computation and partially addresses the performance regression with ViT model. This replaces `Dot` with`CreateMatMul` op, which actually calls `Dot` internally if it's simpler multiplications and calls `DotGeneral` otherwise. 