### PR TITLE
Disable ECR image update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,10 +23,10 @@ launch_docker_and_build: &launch_docker_and_build
     # we also want the upstream workflow to use PyTorch/XLA build image, we
     # need to have them in the ECR. This is not expensive, and only pushes it
     # if image layers are not present in the repo.
-    docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:latest >/dev/null
-    docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:v0.2 >/dev/null
-    docker push ${ECR_DOCKER_IMAGE_BASE}:latest >/dev/null
-    docker push ${ECR_DOCKER_IMAGE_BASE}:v0.2 >/dev/null
+    #docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:latest >/dev/null
+    #docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:v0.2 >/dev/null
+    #docker push ${ECR_DOCKER_IMAGE_BASE}:latest >/dev/null
+    #docker push ${ECR_DOCKER_IMAGE_BASE}:v0.2 >/dev/null
     sudo pkill -SIGHUP dockerd
     # To enable remote caching, use SCCACHE_BUCKET=${SCCACHE_BUCKET}
     echo "declare -x SCCACHE_BUCKET=${LOCAL_BUCKET}" >> /home/circleci/project/env


### PR DESCRIPTION
This is to temporarily disable ECR image update until we stabilize the upstream build [issue](https://github.com/pytorch/pytorch/issues/80034)