### PR TITLE
Move ldpreload setting for tpuvm docker to the end

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,9 +32,6 @@ ENV CXXFLAGS "${CXXFLAGS} -D_GLIBCXX_USE_CXX11_ABI=${cxx_abi}"
 # Whether to build for TPUVM mode
 ENV TPUVM_MODE "${tpuvm}"
 
-# Set LD_PRELOAD to use tcmalloc if for tpuvm mode.
-ENV LD_PRELOAD=${tpuvm:+"/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4"}
-
 # Maximum number of jobs to use for bazel build
 ENV BAZEL_JOBS "${bazel_jobs}"
 
@@ -52,6 +49,9 @@ RUN if [ "${git_clone}" = "true" ]; then github_branch="${release_version}" && \
   git clone -b "${github_branch}" --recursive https://github.com/pytorch-tpu/examples tpu-examples; fi
 
 RUN cd /pytorch && bash xla/scripts/build_torch_wheels.sh ${python_version} ${release_version}
+
+# Set LD_PRELOAD to use tcmalloc if for tpuvm mode.
+ENV LD_PRELOAD=${tpuvm:+"/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4"}
 
 # Use conda environment on startup or when running scripts.
 RUN echo "conda activate pytorch" >> ~/.bashrc


### PR DESCRIPTION
This will solve the TPUVM docker build failure. The issue is that we set the LD_PRELOAD in the begging but tc_malloc won't be installed until the pytorch/xla build. This invalid LD_PRELOAD will cause all sorts of issues like 
```
Step #0: ERROR: ld.so: object '/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
Step #0: ERROR: ld.so: object '/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
```