### PR TITLE
Fix typo: `idetify` -> `identify`

### DIFF
--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1022,7 +1022,7 @@ std::vector<torch::lazy::BackendDataPtr> XLATensor::GatherTensorsXlaData(
 
 void XLATensor::TensorCollectionBarrier(SyncTensorCollection* coll) {
   static const std::string invalid_device(
-      "Unknown0"); /* Temp solution to idetify unassigned devices */
+      "Unknown0"); /* Temp solution to identify unassigned devices */
   if (coll->device.toString().compare(invalid_device) == 0 ||
       coll->unlocker.size() > 0) {
     return;


### PR DESCRIPTION
Patches a grammatical error introduced in https://github.com/pytorch/xla/pull/3457/commits/a2cec8cb2ff5fc081d27253e517857c43c16b7fa.