### PR TITLE
Fix typo `partecipating` -> `participating`

### DIFF
--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -180,7 +180,7 @@ class XLATensor : public c10::intrusive_ptr_target {
   // Applies all the pending IR operations queued over the input tensors. All
   // the tensors must be on the same device. If wait is true, the sync operation
   // will be run synchronously. The devices argument, if not empty, tells the
-  // devices which should be partecipating into the replicated computation.
+  // devices which should be participating into the replicated computation.
   static void SyncTensorsGraph(std::vector<XLATensor>* tensors,
                                absl::Span<const std::string> devices, bool wait,
                                bool sync_xla_data);
@@ -188,7 +188,7 @@ class XLATensor : public c10::intrusive_ptr_target {
   // Makes sure that any outstanding IR operation accumulated over live tensors,
   // gets turned into device data. If wait is true, the sync operation will be
   // run synchronously. The devices argument, if not empty, tells the devices
-  // which should be partecipating into the replicated computation.
+  // which should be participating into the replicated computation.
   static void SyncLiveTensorsGraph(const torch::lazy::BackendDevice* device,
                                    absl::Span<const std::string> devices,
                                    bool wait);


### PR DESCRIPTION
Synchronizing the code base with S4TF: https://github.com/philipturner/s4tf/commit/2c4d12e60682f879fdce8ad3c333b34e98a35b17. This commit is to a branch involved with https://github.com/s4tf/s4tf/pull/17; philipturner/s4tf is not the head repository of Swift for TensorFlow.

Quick question: when do you plan on upgrading from TF 2.8 to TF 2.9? I have done that already.