### PR TITLE
[WIP] make sym_sizes non virtual

### DIFF
--- a/torch_xla/csrc/tensor_impl.h
+++ b/torch_xla/csrc/tensor_impl.h
@@ -31,7 +31,7 @@ class XLATensorImpl : public c10::TensorImpl {
   void shallow_copy_from(const c10::intrusive_ptr<TensorImpl>& impl) override;
 
   at::IntArrayRef sizes_custom() const override;
-  c10::SymIntArrayRef sym_sizes() const override;
+  c10::SymIntArrayRef sym_sizes() const;
   c10::SymIntArrayRef sym_sizes_custom() const override;
   at::IntArrayRef strides_custom() const override;
 


### PR DESCRIPTION
We will be making `sym_sizes` non virtual in PyTorch, so this PR will probably need a pin.