### PR TITLE
Update TestCatTypePromotion test to remove tests for torch::kFloat and torch::kDouble

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -4271,11 +4271,11 @@ TEST_F(AtenXlaTensorTest, TestCat) {
 
 TEST_F(AtenXlaTensorTest, TestCatTypePromotion) {
   for (torch::ScalarType scalar_type_1 :
-       {torch::kHalf, torch::kFloat, torch::kDouble, torch::kShort, torch::kInt,
+       {torch::kFloat, torch::kDouble, torch::kShort, torch::kInt,
         torch::kLong}) {
     for (torch::ScalarType scalar_type_2 :
-         {torch::kHalf, torch::kFloat, torch::kDouble, torch::kShort,
-          torch::kInt, torch::kLong}) {
+         {torch::kFloat, torch::kDouble, torch::kShort, torch::kInt,
+          torch::kLong}) {
       torch::Tensor a =
           torch::ones({2, 1, 3}, torch::TensorOptions(scalar_type_1));
       torch::Tensor b =


### PR DESCRIPTION
Update TestCatTypePromotion test to remove test case for torch::kHalf

---

Related to the recent PR to https://github.com/pytorch/xla/pull/3608, which adds type promotion for cat op. Since TPU does not support f16, remove test case for torch::kHalf.