### PR TITLE
Install jq to docker and push to ECR repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,10 +23,8 @@ launch_docker_and_build: &launch_docker_and_build
     # To allow the upstream workflow to access PyTorch/XLA build images, we
     # need to have them in the ECR. This is not expensive, and only pushes it
     # if image layers are not present in the repo.
-    #docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:latest >/dev/null
-    #docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:v0.2 >/dev/null
-    #docker push ${ECR_DOCKER_IMAGE_BASE}:latest >/dev/null
-    #docker push ${ECR_DOCKER_IMAGE_BASE}:v0.2 >/dev/null
+    docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:v0.4 >/dev/null
+    docker push ${ECR_DOCKER_IMAGE_BASE}:v0.4 >/dev/null
     sudo pkill -SIGHUP dockerd
     # To enable remote caching, use SCCACHE_BUCKET=${SCCACHE_BUCKET}
     echo "declare -x SCCACHE_BUCKET=${LOCAL_BUCKET}" >> /home/circleci/project/env

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -51,8 +51,9 @@ RUN rm /etc/apt/sources.list.d/nvidia-ml.list
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
 
 # Install base system packages
-RUN apt-get update --fix-missing
-RUN apt-get install -y python-pip python3-pip git curl libopenblas-dev vim \
+RUN apt-get clean && apt-get update
+RUN apt-get upgrade -y
+RUN apt-get install --fix-missing -y python-pip python3-pip git curl libopenblas-dev vim jq \
   apt-transport-https ca-certificates procps openssl sudo wget libssl-dev libc6-dbg
 
 # Install clang & llvm


### PR DESCRIPTION
The upstream workflow seems to require jq in the base image.