### PR TITLE
Install vision without pep517

### DIFF
--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -19,7 +19,7 @@ function pip_install() {
 }
 
 function install_torchvision() {
-  pip_install --user "git+https://github.com/pytorch/vision.git@$TORCHVISION_COMMIT"
+  pip_install --user --no-use-pep517 "git+https://github.com/pytorch/vision.git@$TORCHVISION_COMMIT"
 }
 
 install_torchvision


### PR DESCRIPTION
This is related to https://github.com/pytorch/pytorch/pull/81074, which should fix the vision build hence enable the GPU CI again.