### PR TITLE
Update CUDA linux repo key

### DIFF
--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -48,7 +48,7 @@ RUN rm /etc/apt/sources.list.d/nvidia-ml.list
 
 # Rotate nvidia repo public key (last updated: 04/27/2022)
 # Unfortunately, nvidia/cuda image is shipped with invalid public key
-RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
 
 # Install base system packages
 RUN apt-get clean && apt-get update

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -44,7 +44,7 @@ ENV TPUVM_MODE "${tpuvm}"
 
 # Remove deprecated deb repo:
 # https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64
-RUN rm /etc/apt/sources.list.d/nvidia-ml.list
+RUN rm /etc/apt/sources.list.d/nvidia-ml.list && apt-get clean && apt-get update
 
 # Rotate nvidia repo public key (last updated: 04/27/2022)
 # Unfortunately, nvidia/cuda image is shipped with invalid public key


### PR DESCRIPTION
Following https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772 and https://github.com/pytorch/xla/commit/f684fd43897534a2c522982a6892f00c811835df to update the key. I took a look at https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ and found this new public key file.. hope it is the right one. Currently master CI failed with 
```
E: Failed to fetch https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/Packages.gz  File has unexpected size (815853 != 814314). Mirror sync in progress? [IP: 152.195.19.142 443]
   Hashes of expected file:
    - Filesize:814314 [weak]
    - SHA256:257071ac3a46f8e8ba340c2bd6b88466ff26e4cb0c4b60afacfb267b251dc2d9
    - SHA1:4b2ecd5529c611f17784b07ed4cb2b13d5d4bd25 [weak]
    - MD5Sum:0355ef69bc6b6afaf8493d82295c3633 [weak]
   Release file created at: Mon, 11 Jul 2022 19:02:21 +0000
E: Some index files failed to download. They have been ignored, or old ones used instead.
```