### PR TITLE
LLVM build cache consistency

### DIFF
--- a/.circleci/download_llvm_raw.sh
+++ b/.circleci/download_llvm_raw.sh
@@ -12,7 +12,7 @@ function download_llvm_raw_archive() {
     | grep "LLVM_COMMIT =" | awk '{print $3}' | sed 's/"//g')
 
   if [ "$(gsutil -q stat gs://tpu-pytorch/llvm-raw/${LLVM_COMMIT}.tar.gz; echo $?)" -eq "1" ]; then
-    http_code="$(curl --fail -w '%{http_code}\n' \
+    http_code="$(curl --fail -L -w '%{http_code}\n' \
       https://storage.googleapis.com/mirror.tensorflow.org/github.com/llvm/llvm-project/archive/${LLVM_COMMIT}.tar.gz \
       --output ${LLVM_COMMIT}.tar.gz)"
     if [ "${http_code}" -eq "404" ]; then

--- a/build_torch_xla_libs.sh
+++ b/build_torch_xla_libs.sh
@@ -38,8 +38,6 @@ BUILD_STRATEGY="standalone"
 if [[ "$XLA_SANDBOX_BUILD" == "1" ]]; then
   BUILD_STRATEGY="sandboxed --sandbox_tmpfs_path=/tmp"
 else
-  # Temporary patch until tensorflow update bazel requirement to 5.2.0
-  echo "6e54699884cfad49d4e8f6dd59a4050bc95c4edf" > third_party/tensorflow/.bazelversion
   # We can remove this after https://github.com/bazelbuild/bazel/issues/15359 is resolved
   unset CC
   unset CXX


### PR DESCRIPTION
This addresses pytorch/pytorch#80034
- The URL redirection on the tensorflow mirror might have caused the script to download a wrong file
- remove bazel pin afeter 5.2.0 [release](https://docs.bazel.build/versions/5.2.0/bazel-overview.html), it should retry before giving up on the secondary cache.