### PR TITLE
npm install failure hotfix

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -69,6 +69,9 @@ function install_deps_pytorch_xla() {
 
   sudo apt-get -qq install npm nodejs
 
+  # Upgrade npm to the latest
+  sudo npm install -g npm
+
   # XLA build requires Bazel
   # We use bazelisk to avoid updating Bazel version manually.
   sudo npm install -g @bazel/bazelisk


### PR DESCRIPTION
`npm install` command is failing due to CI VM instance os changes: `WARN engine aws-sdk@2.1174.0: wanted: {"node":">= 10.0.0"} (current: {"node":"8.10.0","npm":"3.5.2"})`

As a hotfix, we are disabling the cloud cache (which is already not being used in the upstream CI).