### PR TITLE
Add test_index_reduce_xla to ignored tests on TPUs

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -345,6 +345,7 @@ DISABLED_TORCH_TESTS_TPU_ONLY = {
         'test_diff_xla_float32',  # expected instruction to have shape equal
         'test_diff_xla_float64',  # expected instruction to have shape equal
         'test_nullary_op_mem_overlap_xla'  # core dumped
+        'test_index_reduce_xla',  # takes too long
     },
 
     # test_indexing.py


### PR DESCRIPTION
Add test_index_reduce_xla to ignored tests on TPUs

---

Multiple `index_reduce` tests seem to take ~30 minutes each and eventually cause the `python-ops` tests to time out.

Seeing the test grid history, python-op tests continuously times out starting 07/01, mostly during `index_reduce` tests. PyTorch test `test_index_reduce` seems to have been updated as of 07/01 -- https://github.com/pytorch/pytorch/pull/80464/files#diff-8aa1a200ec63d23db422aa31b6dca1e6cb372887c43b064ef435210b1b0dec0aR2937, adding more `dtypes` into the tests. Previously, it was only `floating_types_and(torch.half, torch.bfloat16)` which is: 
```
(torch.float32, torch.float64, torch.half, torch.bfloat16)
```
Now, it is updated to `all_types_and(torch.half, torch.bfloat16))` which is: 
```
(torch.float32, torch.float64, torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64, torch.half, torch.bfloat16)
```

Updating the tests to ignore the `test_index_reduce_xla` for now. 

