### PR TITLE
Add shape fn to adaptive_average_pool2d/backward +log_softmax

### DIFF
--- a/test/cpp/test_tensor.cpp
+++ b/test/cpp/test_tensor.cpp
@@ -263,19 +263,6 @@ TEST_F(TensorTest, TestViewOfViewMod) {
   });
 }
 
-TEST_F(TensorTest, TestLogSoftmax) {
-  at::Tensor input = at::rand({5, 3, 4, 2}, at::TensorOptions(at::kFloat));
-  ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-    XLATensorPtr dev_input = XLATensor::Create(input, device);
-    for (int dim = 0; dim < input.dim(); ++dim) {
-      at::Tensor output = input.log_softmax(dim);
-      XLATensorPtr dev_output =
-          XLATensor::log_softmax(dev_input, dim, c10::nullopt);
-      AllClose(output, dev_output, /*rtol=*/1e-3);
-    }
-  });
-}
-
 TEST_F(TensorTest, TestMaxPool2D) {
   at::Tensor input = at::rand({1, 64, 112, 112}, at::TensorOptions(at::kFloat));
   int kernel_size = 3;

--- a/torch_xla/csrc/ops/adaptive_avg_pool2d.cpp
+++ b/torch_xla/csrc/ops/adaptive_avg_pool2d.cpp
@@ -21,16 +21,13 @@ xla::Shape NodeOutputShape(const torch::lazy::Value& input,
 }  // namespace
 
 AdaptiveAvgPool2d::AdaptiveAvgPool2d(const torch::lazy::Value& input,
-                                     std::vector<int64_t> output_size)
+                                     std::vector<int64_t> output_size,
+                                     std::vector<torch::lazy::Shape>&& shapes)
     : XlaNode(torch::lazy::OpKind(at::aten::adaptive_avg_pool2d), {input},
+              std::move(shapes),
               [&]() { return NodeOutputShape(input, output_size); },
               /*num_outputs=*/1, torch::lazy::MHash(output_size)),
       output_size_(std::move(output_size)) {}
-
-torch::lazy::NodePtr AdaptiveAvgPool2d::Clone(
-    torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<AdaptiveAvgPool2d>(operands.at(0), output_size_);
-}
 
 XlaOpVector AdaptiveAvgPool2d::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));

--- a/torch_xla/csrc/ops/adaptive_avg_pool2d.h
+++ b/torch_xla/csrc/ops/adaptive_avg_pool2d.h
@@ -9,9 +9,8 @@ namespace torch_xla {
 class AdaptiveAvgPool2d : public XlaNode {
  public:
   AdaptiveAvgPool2d(const torch::lazy::Value& input,
-                    std::vector<int64_t> output_size);
-
-  torch::lazy::NodePtr Clone(torch::lazy::OpList operands) const override;
+                    std::vector<int64_t> output_size,
+                    std::vector<torch::lazy::Shape>&& shapes);
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/generic.cpp
+++ b/torch_xla/csrc/ops/generic.cpp
@@ -21,6 +21,16 @@ Generic::Generic(torch::lazy::OpKind op,
       lower_fn_(std::move(lower_fn)),
       hash_seed_(hash_seed) {}
 
+Generic::Generic(torch::lazy::OpKind op,
+                 c10::ArrayRef<torch::lazy::Value> operands,
+                 std::vector<torch::lazy::Shape>&& shapes,
+                 const std::function<xla::Shape()>& shape_fn, LowerFn lower_fn,
+                 size_t num_outputs, torch::lazy::hash_t hash_seed)
+    : XlaNode(std::move(op), operands, std::move(shapes), shape_fn, num_outputs,
+              hash_seed),
+      lower_fn_(std::move(lower_fn)),
+      hash_seed_(hash_seed) {}
+
 Generic::Generic(torch::lazy::OpKind op, xla::Shape shape, LowerFn lower_fn,
                  size_t num_outputs, torch::lazy::hash_t hash_seed)
     : XlaNode(std::move(op), std::move(shape), num_outputs, hash_seed),

--- a/torch_xla/csrc/ops/generic.h
+++ b/torch_xla/csrc/ops/generic.h
@@ -22,6 +22,12 @@ class Generic : public XlaNode {
           size_t num_outputs = 1,
           torch::lazy::hash_t hash_seed = (uint32_t)0x5a2d296e9);
 
+  Generic(torch::lazy::OpKind op, c10::ArrayRef<torch::lazy::Value> operands,
+          std::vector<torch::lazy::Shape>&& shapes,
+          const std::function<xla::Shape()>& shape_fn, LowerFn lower_fn,
+          size_t num_outputs = 1,
+          torch::lazy::hash_t hash_seed = (uint32_t)0x5a2d296e9);
+
   Generic(torch::lazy::OpKind op, xla::Shape shape, LowerFn lower_fn,
           size_t num_outputs, torch::lazy::hash_t hash_seed);
 

--- a/torch_xla/csrc/ops/log_softmax.cpp
+++ b/torch_xla/csrc/ops/log_softmax.cpp
@@ -28,17 +28,15 @@ xla::Shape NodeOutputShape(const torch::lazy::Value& input,
 }  // namespace
 
 LogSoftmax::LogSoftmax(const torch::lazy::Value& input, int64_t dim,
-                       c10::optional<at::ScalarType> dtype)
+                       c10::optional<at::ScalarType> dtype,
+                       std::vector<torch::lazy::Shape>&& shapes)
     : XlaNode(torch::lazy::OpKind(at::aten::log_softmax), {input},
+              std::move(shapes),
               [&]() { return NodeOutputShape(input, dtype); },
               /*num_outputs=*/1,
               torch::lazy::MHash(dim, torch::lazy::OptionalOr<int>(dtype, -1))),
       dim_(dim),
       dtype_(dtype) {}
-
-torch::lazy::NodePtr LogSoftmax::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<LogSoftmax>(operands.at(0), dim_, dtype_);
-}
 
 XlaOpVector LogSoftmax::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));

--- a/torch_xla/csrc/ops/log_softmax.h
+++ b/torch_xla/csrc/ops/log_softmax.h
@@ -11,9 +11,8 @@ namespace torch_xla {
 class LogSoftmax : public XlaNode {
  public:
   LogSoftmax(const torch::lazy::Value& input, int64_t dim,
-             c10::optional<at::ScalarType> dtype);
-
-  torch::lazy::NodePtr Clone(torch::lazy::OpList operands) const override;
+             c10::optional<at::ScalarType> dtype,
+             std::vector<torch::lazy::Shape>&& shapes);
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -481,7 +481,8 @@ torch::lazy::NodePtr AdaptiveAvgPool3dBackward(
 }
 
 torch::lazy::NodePtr AdaptiveAvgPool2dBackward(
-    const torch::lazy::Value& grad_output, const torch::lazy::Value& input) {
+    const torch::lazy::Value& grad_output, const torch::lazy::Value& input,
+    std::vector<torch::lazy::Shape>&& shapes) {
   auto lower_fn = [](const XlaNode& node,
                      LoweringContext* loctx) -> XlaOpVector {
     xla::XlaOp grad_output = loctx->GetOutputOp(node.operand(0));
@@ -497,7 +498,7 @@ torch::lazy::NodePtr AdaptiveAvgPool2dBackward(
                                           /*input=*/operands[1]);
   };
   return GenericOp(torch::lazy::OpKind(at::aten::adaptive_avg_pool2d_backward),
-                   {grad_output, input},
+                   {grad_output, input}, std::move(shapes),
                    [&]() {
                      return InferOutputShape(
                          {GetXlaShape(grad_output), GetXlaShape(input)},

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -37,6 +37,18 @@ inline torch::lazy::NodePtr GenericOp(
 
 inline torch::lazy::NodePtr GenericOp(
     torch::lazy::OpKind op, c10::ArrayRef<torch::lazy::Value> operands,
+    std::vector<torch::lazy::Shape>&& shapes,
+    const std::function<xla::Shape()>& shape_fn, Generic::LowerFn lower_fn,
+    size_t num_outputs = 1,
+    // cast to uint32_t to avoid ambiguous constructor of uint128
+    torch::lazy::hash_t hash_seed = (uint32_t)0x5a2d296e9) {
+  return torch::lazy::MakeNode<Generic>(
+      std::move(op), operands, std::move(shapes), shape_fn, std::move(lower_fn),
+      num_outputs, hash_seed);
+}
+
+inline torch::lazy::NodePtr GenericOp(
+    torch::lazy::OpKind op, c10::ArrayRef<torch::lazy::Value> operands,
     const std::function<xla::Shape()>& shape_fn, Generic::LowerFn lower_fn,
     size_t num_outputs = 1,
     // cast to uint32_t to avoid ambiguous constructor of uint128
@@ -177,7 +189,8 @@ torch::lazy::NodePtr AdaptiveMaxPool2dBackward(
     const torch::lazy::Value& grad_output, const torch::lazy::Value& input);
 
 torch::lazy::NodePtr AdaptiveAvgPool2dBackward(
-    const torch::lazy::Value& grad_output, const torch::lazy::Value& input);
+    const torch::lazy::Value& grad_output, const torch::lazy::Value& input,
+    std::vector<torch::lazy::Shape>&& shapes);
 
 torch::lazy::NodePtr AdaptiveAvgPool3dBackward(
     const torch::lazy::Value& grad_output, const torch::lazy::Value& input);

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -334,11 +334,13 @@ class XLATensor : public c10::intrusive_ptr_target {
   static XLATensorPtr adaptive_avg_pool3d_backward(
       const XLATensorPtr& grad_output, const XLATensorPtr& input);
 
-  static XLATensorPtr _adaptive_avg_pool2d(const XLATensorPtr& input,
-                                           std::vector<int64_t> output_size);
+  static XLATensorPtr _adaptive_avg_pool2d(
+      const XLATensorPtr& input, std::vector<int64_t> output_size,
+      std::vector<torch::lazy::Shape>&& shapes);
 
   static XLATensorPtr _adaptive_avg_pool2d_backward(
-      const XLATensorPtr& grad_output, const XLATensorPtr& input);
+      const XLATensorPtr& grad_output, const XLATensorPtr& input,
+      std::vector<torch::lazy::Shape>&& shapes);
 
   static void _amp_foreach_non_finite_check_and_unscale_(
       std::vector<XLATensorPtr> self, XLATensorPtr& found_inf,
@@ -760,7 +762,8 @@ class XLATensor : public c10::intrusive_ptr_target {
                                            const XLATensorPtr& buffer);
 
   static XLATensorPtr log_softmax(const XLATensorPtr& input, int64_t dim,
-                                  c10::optional<at::ScalarType> dtype);
+                                  c10::optional<at::ScalarType> dtype,
+                                  std::vector<torch::lazy::Shape>&& shapes);
 
   static XLATensorPtr log_softmax_backward(const XLATensorPtr& grad_output,
                                            const XLATensorPtr& output,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -620,16 +620,18 @@ XLATensorPtr XLATensor::adaptive_avg_pool3d_backward(
                                                      input->GetIrValue()));
 }
 
-XLATensorPtr XLATensor::_adaptive_avg_pool2d(const XLATensorPtr& input,
-                                             std::vector<int64_t> output_size) {
+XLATensorPtr XLATensor::_adaptive_avg_pool2d(
+    const XLATensorPtr& input, std::vector<int64_t> output_size,
+    std::vector<torch::lazy::Shape>&& shapes) {
   return input->CreateFrom(torch::lazy::MakeNode<AdaptiveAvgPool2d>(
-      input->GetIrValue(), std::move(output_size)));
+      input->GetIrValue(), std::move(output_size), std::move(shapes)));
 }
 
 XLATensorPtr XLATensor::_adaptive_avg_pool2d_backward(
-    const XLATensorPtr& grad_output, const XLATensorPtr& input) {
-  return input->CreateFrom(AdaptiveAvgPool2dBackward(grad_output->GetIrValue(),
-                                                     input->GetIrValue()));
+    const XLATensorPtr& grad_output, const XLATensorPtr& input,
+    std::vector<torch::lazy::Shape>&& shapes) {
+  return input->CreateFrom(AdaptiveAvgPool2dBackward(
+      grad_output->GetIrValue(), input->GetIrValue(), std::move(shapes)));
 }
 
 void XLATensor::_amp_foreach_non_finite_check_and_unscale_(
@@ -1698,7 +1700,8 @@ XLATensorPtr XLATensor::log_sigmoid_backward(const XLATensorPtr& grad_output,
 }
 
 XLATensorPtr XLATensor::log_softmax(const XLATensorPtr& input, int64_t dim,
-                                    c10::optional<at::ScalarType> dtype) {
+                                    c10::optional<at::ScalarType> dtype,
+                                    std::vector<torch::lazy::Shape>&& shapes) {
   if (!dtype) {
     dtype = input->dtype_optional();
   }
@@ -1706,7 +1709,7 @@ XLATensorPtr XLATensor::log_softmax(const XLATensorPtr& input, int64_t dim,
       torch::lazy::MakeNode<LogSoftmax>(input->GetIrValue(),
                                         torch::lazy::GetCanonicalDimensionIndex(
                                             dim, input->shape().get().rank()),
-                                        dtype),
+                                        dtype, std::move(shapes)),
       dtype);
 }
 


### PR DESCRIPTION
This is an experiment for https://github.com/pytorch/xla/issues/3725. It turned out that adding shape_fn manully is not a trival as I thought. Going forward I think I will focus on ops that is hard to codegen and manually add shap_fn there.