### PR TITLE
Add `dynamic_ir`

### DIFF
--- a/torch_xla/csrc/ops/dynamic_ir.cpp
+++ b/torch_xla/csrc/ops/dynamic_ir.cpp
@@ -23,12 +23,11 @@ XlaOpVector SizeNode::Lower(LoweringContext* loctx) const {
 }
 
 int64_t SizeNode::getStaticValue() const {
-  return dynamic_cast<const XlaNode*>(operand(0).node)->shape(0).size(dim_);
+  return operand(0).node->shape(0).size(dim_);
 }
 
 bool SizeNode::isDynamic() const {
-  auto symbolic_vec =
-      dynamic_cast<const XlaNode*>(operand(0).node)->shape(0).is_symbolic();
+  auto symbolic_vec = operand(0).node->shape(0).is_symbolic();
   if (!symbolic_vec.has_value()) {
     return true;
   }

--- a/torch_xla/csrc/ops/dynamic_ir.cpp
+++ b/torch_xla/csrc/ops/dynamic_ir.cpp
@@ -1,0 +1,135 @@
+#include "torch_xla/csrc/ops/dynamic_ir.h"
+
+#include "absl/strings/str_join.h"
+#include "tensorflow/compiler/xla/xla_client/debug_macros.h"
+#include "torch_xla/csrc/lowering_context.h"
+#include "torch_xla/csrc/ops/infer_output_shape.h"
+
+static const torch::lazy::DimensionNode* DimCast(torch::lazy::Output output) {
+  return dynamic_cast<const torch::lazy::DimensionNode*>(output.node);
+}
+
+namespace torch_xla {
+
+SizeNode::SizeNode(torch::lazy::Value input, size_t dim)
+    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::size")},
+              {input}, [&]() {  if (input.node->shapes().size() > 0) {
+                                  torch::lazy::Shape sh_ = input.node->shape(0);
+                                  torch::lazy::Shape sh__ = sh_.with_symbolic_dims(sh_.is_symbolic());
+                                  std::cout << "sh_ vs. sh__" << sh_.is_symbolic().value()[0] << " " << sh__.is_symbolic().value()[0] << std::endl;
+                                  std::cout << "sh_ vs. sh__" << sh_.is_symbolic().value()[1] << " " << sh__.is_symbolic().value()[1] << std::endl;
+                                  return sh__;
+                                } else {
+                                  return torch::lazy::Shape();
+                                }
+                             },
+                  [&]() { return xla::ShapeUtil::MakeShape(xla::S32, {}); }, 1,
+              torch::lazy::MHash(dim)),
+      dim_(dim){
+        if (input.node->shapes().size() > 0) {
+          for (int i = 0; i < operands().size(); i++) {
+            std::cout << "operands i (is_symbolic): "  << operands()[0].node->shape(0).is_symbolic().value()[i] << std::endl;
+            // std::cout << "" << << std::endl;
+          }
+        }
+      };
+
+XlaOpVector SizeNode::Lower(LoweringContext* loctx) const {
+  auto input = loctx->GetOutputOp(operand(0));
+  return ReturnOp(xla::GetDimensionSize(input, this->dim_), loctx);
+}
+
+int64_t SizeNode::getStaticValue() const {
+  return dynamic_cast<const XlaNode*>(operand(0).node)->shape(0).size(dim_);
+}
+
+bool SizeNode::isDynamic() const {
+  auto symbolic_vec =
+      dynamic_cast<const XlaNode*>(operand(0).node)->shape(0).is_symbolic();
+  if (!symbolic_vec.has_value()) {
+    return true;
+  }
+  return symbolic_vec->at(dim_);
+}
+
+std::string SizeNode::ToString() const { return "SizeNode"; }
+
+SizeAdd::SizeAdd(torch::lazy::Value a, torch::lazy::Value b)
+    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::add")},
+              {a, b}, xla::ShapeUtil::MakeShape(xla::S32, {}), 1){};
+
+int64_t SizeAdd::getStaticValue() const {
+  return dynamic_cast<const torch::lazy::DimensionNode*>(operand(0).node)
+             ->getStaticValue() +
+         dynamic_cast<const torch::lazy::DimensionNode*>(operand(1).node)
+             ->getStaticValue();
+}
+
+bool SizeAdd::isDynamic() const {
+  return DimCast(operand(0))->isDynamic() || DimCast(operand(1))->isDynamic();
+}
+
+std::string SizeAdd::ToString() const { return "SizeAdd"; }
+
+XlaOpVector SizeAdd::Lower(LoweringContext* loctx) const {
+  auto input1 = loctx->GetOutputOp(operand(0));
+  auto input2 = loctx->GetOutputOp(operand(1));
+  return ReturnOp(
+      (xla::GetDimensionSize(input1, 0) + xla::GetDimensionSize(input2, 0)),
+      loctx);
+}
+
+SizeMul::SizeMul(torch::lazy::Value a, torch::lazy::Value b)
+    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::mul")},
+              {a, b}, xla::ShapeUtil::MakeShape(xla::S32, {}), 1){};
+
+int64_t SizeMul::getStaticValue() const {
+  return dynamic_cast<const torch::lazy::DimensionNode*>(operand(0).node)
+             ->getStaticValue() *
+         dynamic_cast<const torch::lazy::DimensionNode*>(operand(1).node)
+             ->getStaticValue();
+}
+
+bool SizeMul::isDynamic() const {
+  return DimCast(operand(0))->isDynamic() || DimCast(operand(1))->isDynamic();
+}
+
+std::string SizeMul::ToString() const { return "SizeMul"; }
+
+XlaOpVector SizeMul::Lower(LoweringContext* loctx) const {
+  auto input1 = loctx->GetOutputOp(operand(0));
+  auto input2 = loctx->GetOutputOp(operand(1));
+  return ReturnOp(xla::Mul(xla::GetDimensionSize(input1, 0),
+                           xla::GetDimensionSize(input2, 0)),
+                  loctx);
+}
+
+SizeDiv::SizeDiv(torch::lazy::Value a, torch::lazy::Value b)
+    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::div")},
+              {a, b}, xla::ShapeUtil::MakeShape(xla::S32, {}), 1){};
+
+int64_t SizeDiv::getStaticValue() const {
+  XLA_CHECK(dynamic_cast<const torch::lazy::DimensionNode*>(operand(1).node)
+                ->getStaticValue() != 0)
+      << "Can't divide a dimension by zero";
+  return dynamic_cast<const torch::lazy::DimensionNode*>(operand(0).node)
+             ->getStaticValue() /
+         dynamic_cast<const torch::lazy::DimensionNode*>(operand(1).node)
+             ->getStaticValue();
+}
+
+bool SizeDiv::isDynamic() const {
+  return DimCast(operand(0))->isDynamic() || DimCast(operand(1))->isDynamic();
+}
+
+std::string SizeDiv::ToString() const { return "SizeDiv"; }
+
+XlaOpVector SizeDiv::Lower(LoweringContext* loctx) const {
+  auto input1 = loctx->GetOutputOp(operand(0));
+  auto input2 = loctx->GetOutputOp(operand(1));
+  return ReturnOp(xla::Div(xla::GetDimensionSize(input1, 0),
+                           xla::GetDimensionSize(input2, 0)),
+                  loctx);
+}
+
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/dynamic_ir.cpp
+++ b/torch_xla/csrc/ops/dynamic_ir.cpp
@@ -13,26 +13,18 @@ namespace torch_xla {
 
 SizeNode::SizeNode(torch::lazy::Value input, size_t dim)
     : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::size")},
-              {input}, [&]() {  if (input.node->shapes().size() > 0) {
-                                  torch::lazy::Shape sh_ = input.node->shape(0);
-                                  torch::lazy::Shape sh__ = sh_.with_symbolic_dims(sh_.is_symbolic());
-                                  std::cout << "sh_ vs. sh__" << sh_.is_symbolic().value()[0] << " " << sh__.is_symbolic().value()[0] << std::endl;
-                                  std::cout << "sh_ vs. sh__" << sh_.is_symbolic().value()[1] << " " << sh__.is_symbolic().value()[1] << std::endl;
-                                  return sh__;
-                                } else {
-                                  return torch::lazy::Shape();
-                                }
-                             },
-                  [&]() { return xla::ShapeUtil::MakeShape(xla::S32, {}); }, 1,
+              {input}, xla::ShapeUtil::MakeShape(xla::S32, {}), 1,
               torch::lazy::MHash(dim)),
-      dim_(dim){
-        if (input.node->shapes().size() > 0) {
-          for (int i = 0; i < operands().size(); i++) {
-            std::cout << "operands i (is_symbolic): "  << operands()[0].node->shape(0).is_symbolic().value()[i] << std::endl;
-            // std::cout << "" << << std::endl;
-          }
-        }
-      };
+      dim_(dim) {
+  if (input.node->shapes().size() > 0) {
+    for (int i = 0; i < operands().size(); i++) {
+      std::cout << "operands i (is_symbolic): "
+                << operands()[0].node->shape(0).is_symbolic().value()[i]
+                << std::endl;
+      // std::cout << "" << << std::endl;
+    }
+  }
+};
 
 XlaOpVector SizeNode::Lower(LoweringContext* loctx) const {
   auto input = loctx->GetOutputOp(operand(0));

--- a/torch_xla/csrc/ops/dynamic_ir.cpp
+++ b/torch_xla/csrc/ops/dynamic_ir.cpp
@@ -15,16 +15,7 @@ SizeNode::SizeNode(torch::lazy::Value input, size_t dim)
     : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::size")},
               {input}, xla::ShapeUtil::MakeShape(xla::S32, {}), 1,
               torch::lazy::MHash(dim)),
-      dim_(dim) {
-  if (input.node->shapes().size() > 0) {
-    for (int i = 0; i < operands().size(); i++) {
-      std::cout << "operands i (is_symbolic): "
-                << operands()[0].node->shape(0).is_symbolic().value()[i]
-                << std::endl;
-      // std::cout << "" << << std::endl;
-    }
-  }
-};
+      dim_(dim) {};
 
 XlaOpVector SizeNode::Lower(LoweringContext* loctx) const {
   auto input = loctx->GetOutputOp(operand(0));

--- a/torch_xla/csrc/ops/dynamic_ir.cpp
+++ b/torch_xla/csrc/ops/dynamic_ir.cpp
@@ -15,7 +15,7 @@ SizeNode::SizeNode(torch::lazy::Value input, size_t dim)
     : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::size")},
               {input}, xla::ShapeUtil::MakeShape(xla::S32, {}), 1,
               torch::lazy::MHash(dim)),
-      dim_(dim) {};
+      dim_(dim){};
 
 XlaOpVector SizeNode::Lower(LoweringContext* loctx) const {
   auto input = loctx->GetOutputOp(operand(0));

--- a/torch_xla/csrc/ops/dynamic_ir.h
+++ b/torch_xla/csrc/ops/dynamic_ir.h
@@ -1,0 +1,76 @@
+#pragma once
+
+// #include <torch/ATen/core/symbol.h>
+#include <functional>
+#include <memory>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "torch/csrc/lazy/core/dynamic_ir.h"
+#include "torch_xla/csrc/ir.h"
+
+namespace torch_xla {
+
+/**
+ * The goal of "dynamic" Nodes is to patch a hole in our tracing.
+ * Previously, if a user called `sizes` on a Tensor, it would leak out
+ * of our tracing system, as `sizes` returns a torch.Size or an int. To
+ * prevent this from happening, we introduce torch::lazy::DimensionNode, a new
+ * type of XlaNode that abstracts the operation of getting the dimensions of a
+ * Tensor.
+ *
+ * Consider the following example:
+ * ```
+ * numel = x.shape()[0] * x.shape()[1]
+ * ```
+ *
+ * Here, `x.shape()[i]` will be a SizeNode (subclass of DimensionNode),
+ * and the multiplication of the two SizeNodes will be represented by
+ * a SizeMul (also a subclass of DimensionNode). Through this, we can
+ * prevent `numel` from being represented as a Python int and thus
+ * burned into the Graph.
+ */
+
+// Represents the result of calling `size` on a Tensor
+class SizeNode : public XlaNode, public torch::lazy::DimensionNode {
+ public:
+  SizeNode(torch::lazy::Value input, size_t dim);
+  int64_t getStaticValue() const override;
+  bool isDynamic() const override;
+  std::string ToString() const override;
+  size_t dim_ = 0;
+  virtual XlaOpVector Lower(LoweringContext* loctx) const override;
+};
+
+class SizeAdd : public XlaNode, public torch::lazy::DimensionNode {
+ public:
+  SizeAdd(torch::lazy::Value a, torch::lazy::Value b);
+  int64_t getStaticValue() const override;
+  bool isDynamic() const override;
+  std::string ToString() const override;
+  virtual XlaOpVector Lower(LoweringContext* loctx) const override;
+};
+
+class SizeMul : public XlaNode, public torch::lazy::DimensionNode {
+ public:
+  SizeMul(torch::lazy::Value a, torch::lazy::Value b);
+  int64_t getStaticValue() const override;
+  bool isDynamic() const override;
+  std::string ToString() const override;
+  virtual XlaOpVector Lower(LoweringContext* loctx) const override;
+};
+
+class SizeDiv : public XlaNode, public torch::lazy::DimensionNode {
+ public:
+  SizeDiv(torch::lazy::Value a, torch::lazy::Value b);
+  int64_t getStaticValue() const override;
+  bool isDynamic() const override;
+  std::string ToString() const override;
+  virtual XlaOpVector Lower(LoweringContext* loctx) const override;
+};
+
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/dynamic_ir.h
+++ b/torch_xla/csrc/ops/dynamic_ir.h
@@ -1,6 +1,5 @@
 #pragma once
 
-// #include <torch/ATen/core/symbol.h>
 #include <functional>
 #include <memory>
 #include <set>

--- a/torch_xla/csrc/ops/dynamic_ir.h
+++ b/torch_xla/csrc/ops/dynamic_ir.h
@@ -42,6 +42,7 @@ class SizeNode : public XlaNode, public torch::lazy::DimensionNode {
   bool isDynamic() const override;
   std::string ToString() const override;
   virtual XlaOpVector Lower(LoweringContext* loctx) const override;
+
  private:
   size_t dim_ = 0;
 };

--- a/torch_xla/csrc/ops/dynamic_ir.h
+++ b/torch_xla/csrc/ops/dynamic_ir.h
@@ -41,8 +41,9 @@ class SizeNode : public XlaNode, public torch::lazy::DimensionNode {
   int64_t getStaticValue() const override;
   bool isDynamic() const override;
   std::string ToString() const override;
-  size_t dim_ = 0;
   virtual XlaOpVector Lower(LoweringContext* loctx) const override;
+ private:
+  size_t dim_ = 0;
 };
 
 class SizeAdd : public XlaNode, public torch::lazy::DimensionNode {


### PR DESCRIPTION
A key building block for supporting dynamic ops is `dynamic_ir`. This module inherits from LTC core lazy dimensions to create IR nodes for tensor `size` dimensions.