### PR TITLE
Codegen log_sigmoid_forward/backward

### DIFF
--- a/scripts/gen_lazy_tensor.py
+++ b/scripts/gen_lazy_tensor.py
@@ -78,6 +78,6 @@ if __name__ == '__main__':
       metrics_counter='XLA_FN_COUNTER("xla::")',
       create_tensor="XLATensor::Create",
       create_aten_from_ltc_tensor="torch_xla::bridge::AtenFromXlaTensor",
-      tuple_aten_from_ltc_tensors="torch::lazy::TupleAtenFromLtcTensors",
+      tuple_aten_from_ltc_tensors="torch_xla::bridge::TupleAtenFromXlaTensors",
       lazy_tensor_ptr="torch_xla::XLATensorPtr",
       get_device_fn="torch_xla::bridge::GetXlaDevice")

--- a/torch_xla/csrc/aten_xla_bridge.h
+++ b/torch_xla/csrc/aten_xla_bridge.h
@@ -124,5 +124,16 @@ c10::optional<torch::lazy::BackendDevice> GetXlaDevice(
   return GetXlaDevice(forward_tensors...);
 }
 
+template <size_t... Indices>
+auto TupleAtenFromXlaTensorsImpl(const std::vector<XLATensorPtr>& tensors,
+                                 std::index_sequence<Indices...>) {
+  return std::make_tuple(AtenFromXlaTensor(tensors[Indices])...);
+}
+
+template <size_t N>
+auto TupleAtenFromXlaTensors(const std::vector<XLATensorPtr>& tensors) {
+  return TupleAtenFromXlaTensorsImpl(tensors, std::make_index_sequence<N>{});
+}
+
 }  // namespace bridge
 }  // namespace torch_xla

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1739,24 +1739,6 @@ at::Tensor XLANativeFunctions::log2(const at::Tensor& self) {
       bridge::GetXlaTensor(self), torch::lazy::OpKind(at::aten::log2), 2.0));
 }
 
-at::Tensor XLANativeFunctions::log_sigmoid_backward(
-    const at::Tensor& grad_output, const at::Tensor& self,
-    const at::Tensor& buffer) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(XLATensor::log_sigmoid_backward(
-      bridge::GetXlaTensor(grad_output), bridge::GetXlaTensor(self),
-      bridge::GetXlaTensor(buffer)));
-}
-
-std::tuple<at::Tensor, at::Tensor> XLANativeFunctions::log_sigmoid_forward(
-    const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  auto result_tuple =
-      XLATensor::log_sigmoid_forward(bridge::GetXlaTensor(self));
-  return std::make_tuple(bridge::AtenFromXlaTensor(std::get<0>(result_tuple)),
-                         bridge::AtenFromXlaTensor(std::get<1>(result_tuple)));
-}
-
 at::Tensor XLANativeFunctions::logsumexp(const at::Tensor& self,
                                          at::IntArrayRef dim, bool keepdim) {
   XLA_FN_COUNTER("xla::");

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -226,22 +226,6 @@ torch::lazy::NodePtr LogSigmoid(const torch::lazy::Value& input) {
                    GetXlaShape(input), std::move(lower_fn), /*num_outputs=*/2);
 }
 
-torch::lazy::NodePtr LogSigmoidBackward(const torch::lazy::Value& grad_output,
-                                        const torch::lazy::Value& input,
-                                        const torch::lazy::Value& buffer) {
-  auto lower_fn = [](const XlaNode& node,
-                     LoweringContext* loctx) -> XlaOpVector {
-    xla::XlaOp xla_grad_output = loctx->GetOutputOp(node.operand(0));
-    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(1));
-    xla::XlaOp xla_buffer = loctx->GetOutputOp(node.operand(2));
-    return node.ReturnOp(
-        BuildLogSigmoidBackward(xla_grad_output, xla_input, xla_buffer), loctx);
-  };
-  return GenericOp(torch::lazy::OpKind(at::aten::log_sigmoid_backward),
-                   {grad_output, input, buffer}, GetXlaShape(input),
-                   std::move(lower_fn));
-}
-
 torch::lazy::NodePtr SiLU(const torch::lazy::Value& input) {
   auto lower_fn = [](const XlaNode& node,
                      LoweringContext* loctx) -> XlaOpVector {

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -121,10 +121,6 @@ torch::lazy::NodePtr HardSwishBackward(const torch::lazy::Value& grad_output,
 
 torch::lazy::NodePtr LogSigmoid(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr LogSigmoidBackward(const torch::lazy::Value& grad_output,
-                                        const torch::lazy::Value& input,
-                                        const torch::lazy::Value& buffer);
-
 torch::lazy::NodePtr Sigmoid(const torch::lazy::Value& input);
 
 torch::lazy::NodePtr SiLU(const torch::lazy::Value& input);

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -126,6 +126,19 @@ torch_xla::XlaOpVector LogicalXor::Lower(LoweringContext* loctx) const {
       loctx);
 }
 
+torch_xla::XlaOpVector LogSigmoidForward::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  return ReturnOps(BuildLogSigmoid(xla_input), loctx);
+}
+
+torch_xla::XlaOpVector LogSigmoidBackward::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_grad_output = loctx->GetOutputOp(operand(0));
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(1));
+  xla::XlaOp xla_buffer = loctx->GetOutputOp(operand(2));
+  return ReturnOp(
+      BuildLogSigmoidBackward(xla_grad_output, xla_input, xla_buffer), loctx);
+}
+
 torch_xla::XlaOpVector Maximum::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   xla::XlaOp xla_other = loctx->GetOutputOp(operand(1));

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -1,6 +1,7 @@
 #include "torch_xla/csrc/ops/ops_xla_shape_fn.h"
 
 #include "tensorflow/compiler/xla/client/lib/logdet.h"
+#include "tensorflow/compiler/xla/shape_util.h"
 #include "torch_xla/csrc/helpers.h"
 
 namespace torch_xla {
@@ -111,6 +112,17 @@ xla::Shape LogicalXorOutputShape(const torch::lazy::Value& input,
         [](xla::XlaOp lhs, xla::XlaOp rhs) { return xla::Xor(lhs, rhs); });
   };
   return InferOutputShape({GetXlaShape(input), GetXlaShape(other)}, shape_fn);
+}
+
+xla::Shape LogSigmoidForwardOutputShape(const torch::lazy::Value& input) {
+  return xla::ShapeUtil::MakeTupleShape(
+      {GetXlaShape(input), GetXlaShape(input)});
+}
+
+xla::Shape LogSigmoidBackwardOutputShape(const torch::lazy::Value& grad_output,
+                                         const torch::lazy::Value& input,
+                                         const torch::lazy::Value& buffer) {
+  return GetXlaShape(grad_output);
 }
 
 xla::Shape MaximumOutputShape(const torch::lazy::Value& input,

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -46,6 +46,12 @@ xla::Shape LogicalOrOutputShape(const torch::lazy::Value& input,
 xla::Shape LogicalXorOutputShape(const torch::lazy::Value& input,
                                  const torch::lazy::Value& other);
 
+xla::Shape LogSigmoidForwardOutputShape(const torch::lazy::Value& input);
+
+xla::Shape LogSigmoidBackwardOutputShape(const torch::lazy::Value& grad_output,
+                                         const torch::lazy::Value& input,
+                                         const torch::lazy::Value& buffer);
+
 xla::Shape MaximumOutputShape(const torch::lazy::Value& input,
                               const torch::lazy::Value& other);
 

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -753,11 +753,6 @@ class XLATensor : public c10::intrusive_ptr_target {
                                torch::lazy::OpKind op, double base);
 
   static XLATensorPtr log_sigmoid(const XLATensorPtr& input);
-  static std::tuple<XLATensorPtr, XLATensorPtr> log_sigmoid_forward(
-      const XLATensorPtr& input);
-  static XLATensorPtr log_sigmoid_backward(const XLATensorPtr& grad_output,
-                                           const XLATensorPtr& input,
-                                           const XLATensorPtr& buffer);
 
   static XLATensorPtr log_softmax(const XLATensorPtr& input, int64_t dim,
                                   c10::optional<at::ScalarType> dtype);

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1681,20 +1681,6 @@ XLATensorPtr XLATensor::log_sigmoid(const XLATensorPtr& input) {
   return input->CreateFrom(torch::lazy::Value(node, 0));
 }
 
-std::tuple<XLATensorPtr, XLATensorPtr> XLATensor::log_sigmoid_forward(
-    const XLATensorPtr& input) {
-  torch::lazy::NodePtr node = LogSigmoid(input->GetIrValue());
-  return std::make_tuple(input->CreateFrom(torch::lazy::Value(node, 0)),
-                         input->CreateFrom(torch::lazy::Value(node, 1)));
-}
-
-XLATensorPtr XLATensor::log_sigmoid_backward(const XLATensorPtr& grad_output,
-                                             const XLATensorPtr& input,
-                                             const XLATensorPtr& buffer) {
-  return grad_output->CreateFrom(LogSigmoidBackward(
-      grad_output->GetIrValue(), input->GetIrValue(), buffer->GetIrValue()));
-}
-
 XLATensorPtr XLATensor::log_softmax(const XLATensorPtr& input, int64_t dim,
                                     c10::optional<at::ScalarType> dtype) {
   if (!dtype) {

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -21,6 +21,8 @@ full_codegen:
   - logical_not
   - logical_or
   - logical_xor
+  - log_sigmoid_backward
+  - log_sigmoid_forward
   - maximum
   - minimum
   - reciprocal
@@ -182,8 +184,6 @@ supported:
   - log1p
   - log2
   - log10
-  - log_sigmoid_backward
-  - log_sigmoid_forward
   - logsumexp
   - lt.Scalar
   - lt.Tensor


### PR DESCRIPTION
This pr enables codegen ops that has `std::tuple<at::Tensor, at::Tensor>` as output.

fixes https://github.com/pytorch/xla/issues/3737 and https://github.com/pytorch/xla/issues/3736

LazyIr.h
```
class LogSigmoidBackward : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::log_sigmoid_backward);
  }

  LogSigmoidBackward(const torch::lazy::Value& grad_output,
                     const torch::lazy::Value& self,
                     const torch::lazy::Value& buffer,
                     std::vector<torch::lazy::Shape>&& shapes)
      : XlaNode(torch::lazy::OpKind(at::aten::log_sigmoid_backward),
                {grad_output, self, buffer}, std::move(shapes),
                [&]() {
                  return LogSigmoidBackwardOutputShape(grad_output, self,
                                                       buffer);
                },
                /* num_outputs */ 1, torch::lazy::MHash()) {}

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();

    return ss.str();
  }

  bool CanBeReused(const torch::lazy::Value& grad_output,
                   const torch::lazy::Value& self,
                   const torch::lazy::Value& buffer) const {
    return false;
  }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;
};

class LogSigmoidForward : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::log_sigmoid_forward);
  }

  LogSigmoidForward(const torch::lazy::Value& self,
                    std::vector<torch::lazy::Shape>&& shapes)
      : XlaNode(torch::lazy::OpKind(at::aten::log_sigmoid_forward), {self},
                std::move(shapes),
                [&]() { return LogSigmoidForwardOutputShape(self); },
                /* num_outputs */ 2, torch::lazy::MHash()) {}

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();

    return ss.str();
  }

  bool CanBeReused(const torch::lazy::Value& self) const { return false; }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;
};
```


NativeFunction
```
at::Tensor XLANativeFunctions::log_sigmoid_backward(
    const at::Tensor& grad_output, const at::Tensor& self,
    const at::Tensor& buffer) {
  XLA_FN_COUNTER("xla::");
  auto common_device =
      torch_xla::bridge::GetXlaDevice(grad_output, self, buffer);
  TORCH_INTERNAL_ASSERT(common_device);

  torch_xla::XLATensorPtr lazy_grad_output =
      torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(grad_output,
                                                              *common_device);
  torch_xla::XLATensorPtr lazy_self =
      torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self,
                                                              *common_device);
  torch_xla::XLATensorPtr lazy_buffer =
      torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(buffer,
                                                              *common_device);
  torch::lazy::NodePtr node = torch::lazy::ReuseNode<LogSigmoidBackward>(
      lazy_grad_output->GetIrValue(), lazy_self->GetIrValue(),
      lazy_buffer->GetIrValue());
  if (!node) {
    auto shapes = torch::lazy::compute_shape_log_sigmoid_backward(grad_output,
                                                                  self, buffer);
    TORCH_INTERNAL_ASSERT(shapes.size() == 1);
    if (torch::lazy::symbolicShapeEnabled()) {
      std::vector<torch::jit::IValue> inputs = {grad_output, self, buffer};
      const char* schema_str =
          "aten::log_sigmoid_backward(Tensor grad_output, Tensor self, Tensor "
          "buffer) -> Tensor";
      applySymbolicShapesOnLT(schema_str, inputs, shapes);
    }

    node = torch::lazy::MakeNode<LogSigmoidBackward>(
        lazy_grad_output->GetIrValue(), lazy_self->GetIrValue(),
        lazy_buffer->GetIrValue(), std::move(shapes));
    CacheNode(node);
  }

  auto result = torch_xla::bridge::AtenFromXlaTensor(
      torch_xla::XLATensor::Create(std::move(node), *common_device));
  return result;
};

::std::tuple<at::Tensor, at::Tensor> XLANativeFunctions::log_sigmoid_forward(
    const at::Tensor& self) {
  XLA_FN_COUNTER("xla::");
  auto common_device = torch_xla::bridge::GetXlaDevice(self);
  TORCH_INTERNAL_ASSERT(common_device);

  torch_xla::XLATensorPtr lazy_self =
      torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self,
                                                              *common_device);
  torch::lazy::NodePtr node =
      torch::lazy::ReuseNode<LogSigmoidForward>(lazy_self->GetIrValue());
  if (!node) {
    auto shapes = torch::lazy::compute_shape_log_sigmoid_forward(self);
    TORCH_INTERNAL_ASSERT(shapes.size() == 2);
    if (torch::lazy::symbolicShapeEnabled()) {
      std::vector<torch::jit::IValue> inputs = {self};
      const char* schema_str =
          "aten::log_sigmoid_forward(Tensor self) -> (Tensor output, Tensor "
          "buffer)";
      applySymbolicShapesOnLT(schema_str, inputs, shapes);
    }

    node = torch::lazy::MakeNode<LogSigmoidForward>(lazy_self->GetIrValue(),
                                                    std::move(shapes));
    CacheNode(node);
  }

  std::vector<torch_xla::XLATensorPtr> lazy_tensors;
  for (int i = 0; i < 2; i++) {
    lazy_tensors.push_back(torch_xla::XLATensor::Create(
        torch::lazy::Value(node, i), *common_device));
  }
  auto result = torch::lazy::TupleAtenFromLtcTensors<2>(lazy_tensors);
  return result;
};
```