### PR TITLE
Codegen for Ceil 

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1010,11 +1010,6 @@ at::Tensor XLANativeFunctions::cat(at::TensorList tensors, int64_t dim) {
       bridge::GetXlaTensors(tensors), dim, at::native::result_type(tensors)));
 }
 
-at::Tensor XLANativeFunctions::ceil(const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(XLATensor::ceil(bridge::GetXlaTensor(self)));
-}
-
 at::Tensor XLANativeFunctions::celu(const at::Tensor& self,
                                     const at::Scalar& alpha) {
   XLA_FN_COUNTER("xla::");

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -77,7 +77,6 @@ PTXLA_UNARY_OP(Erf, at::aten::erf, xla::Erf);
 PTXLA_UNARY_OP(Erfc, at::aten::erfc, xla::Erfc);
 PTXLA_UNARY_OP(Erfinv, at::aten::erfinv, xla::ErfInv);
 PTXLA_UNARY_OP(Sqrt, at::aten::sqrt, xla::Sqrt);
-PTXLA_UNARY_OP(Ceil, at::aten::ceil, xla::Ceil);
 PTXLA_UNARY_OP(Round, at::aten::round, xla::RoundToEven);
 PTXLA_UNARY_OP(Not, at::aten::bitwise_not, xla::Not);
 PTXLA_UNARY_OP(IsNan, at::aten::isnan, xla::IsNan);

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -147,8 +147,6 @@ torch::lazy::NodePtr Clamp(const torch::lazy::Value& input,
                            const torch::lazy::Value& min,
                            const torch::lazy::Value& max);
 
-torch::lazy::NodePtr Ceil(const torch::lazy::Value& input);
-
 torch::lazy::NodePtr Celu(const torch::lazy::Value& input,
                           const at::Scalar& alpha);
 

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -43,6 +43,11 @@ torch_xla::XlaOpVector Atanh::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::Atanh(xla_input), loctx);
 }
 
+torch_xla::XlaOpVector Ceil::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  return ReturnOp(xla::Ceil(xla_input), loctx);
+}
+
 torch_xla::XlaOpVector Cos::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   return ReturnOp(xla::Cos(xla_input), loctx);

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -33,6 +33,10 @@ xla::Shape AtanhOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
+xla::Shape CeilOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
+}
+
 xla::Shape CosOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -17,6 +17,8 @@ xla::Shape AtanOutputShape(const torch::lazy::Value& input);
 
 xla::Shape AtanhOutputShape(const torch::lazy::Value& input);
 
+xla::Shape CeilOutputShape(const torch::lazy::Value& input);
+
 xla::Shape CosOutputShape(const torch::lazy::Value& input);
 
 xla::Shape CoshOutputShape(const torch::lazy::Value& input);

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -489,8 +489,6 @@ class XLATensor : public c10::intrusive_ptr_target {
   static XLATensorPtr cat(absl::Span<const XLATensorPtr> tensors, int64_t dim,
                           at::ScalarType dtype);
 
-  static XLATensorPtr ceil(const XLATensorPtr& input);
-
   static XLATensorPtr celu(const XLATensorPtr& input, const at::Scalar& alpha);
   static void celu_(XLATensorPtr& input, const at::Scalar& alpha);
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1032,10 +1032,6 @@ XLATensorPtr XLATensor::cat(absl::Span<const XLATensorPtr> tensors, int64_t dim,
                                 dtype);
 }
 
-XLATensorPtr XLATensor::ceil(const XLATensorPtr& input) {
-  return input->CreateFrom(Ceil(input->GetIrValue()));
-}
-
 XLATensorPtr XLATensor::celu(const XLATensorPtr& input,
                              const at::Scalar& alpha) {
   return input->CreateFrom(Celu(input->GetIrValue(), alpha));

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -8,6 +8,7 @@ full_codegen:
   - asinh
   - atan
   - atanh
+  - ceil
   - cos
   - cosh
   - erf
@@ -95,7 +96,6 @@ supported:
   - bitwise_xor.Tensor
   - bmm
   - cat
-  - ceil
   - celu
   - celu_
   - cholesky


### PR DESCRIPTION
Full codegen for `Ceil`. 

Generated `LazyIr.h`:

```
class Ceil : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::ceil);
  }

  Ceil(const torch::lazy::Value& self, std::vector<torch::lazy::Shape>&& shapes)
      : XlaNode(torch::lazy::OpKind(at::aten::ceil),
              {self}, std::move(shapes),
              [&]() { return CeilOutputShape(self); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
  {
    
  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();
    
    return ss.str();
  }

  

  bool CanBeReused(const torch::lazy::Value& self) const {
    return false;
    }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;

  
  

};
```

Generated `XLANativeFunctions.cpp`:

```
at::Tensor XLANativeFunctions::ceil(const at::Tensor & self) {
        
        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self);
        TORCH_INTERNAL_ASSERT(common_device);
        
        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        torch::lazy::NodePtr node = torch::lazy::ReuseNode<Ceil>(lazy_self->GetIrValue());
        if (!node) {
                    auto self_meta = to_meta(self);
        auto out_meta = at::meta::ceil(self_meta);
        
std::vector<torch::lazy::Shape> shapes{torch::lazy::Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
            TORCH_INTERNAL_ASSERT(shapes.size() == 1);
            if(torch::lazy::symbolicShapeEnabled()){
                std::vector<torch::jit::IValue> inputs = { self };
                const char* schema_str = "aten::ceil(Tensor self) -> Tensor";
                applySymbolicShapesOnLT(schema_str, inputs, shapes);
            }
        
            node = torch::lazy::MakeNode<Ceil>(lazy_self->GetIrValue(), std::move(shapes));
            CacheNode(node);
        }
        
        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };
```