### PR TITLE
Add `SetDimensionSizes` API to enable lowering Dynamic Shape in PyTorch/XLA

### DIFF
--- a/torch_xla/csrc/data_ops.cpp
+++ b/torch_xla/csrc/data_ops.cpp
@@ -94,6 +94,7 @@ xla::XlaOp BuildView(xla::XlaOp input, absl::Span<const int64_t> output_sizes) {
 
 xla::XlaOp SetDimensionSizes(xla::XlaOp input,
                              absl::Span<const xla::XlaOp> output_sizes) {
+  XLA_CHECK_EQ(output_sizes.size(), XlaHelpers::ShapeOfXlaOp(input).rank());
   for (int i = 0; i < output_sizes.size(); i++) {
     xla::Shape dim_shape = XlaHelpers::ShapeOfXlaOp(output_sizes[i]);
     if (dim_shape.is_dynamic()) {

--- a/torch_xla/csrc/data_ops.cpp
+++ b/torch_xla/csrc/data_ops.cpp
@@ -92,6 +92,17 @@ xla::XlaOp BuildView(xla::XlaOp input, absl::Span<const int64_t> output_sizes) {
   return XlaHelpers::DynamicReshape(input, complete_output_sizes);
 }
 
+xla::XlaOp SetDimensionSizes(xla::XlaOp input,
+                             absl::Span<const xla::XlaOp> output_sizes) {
+  for (int i = 0; i < output_sizes.size(); i++) {
+    xla::Shape dim_shape = XlaHelpers::ShapeOfXlaOp(output_sizes[i]);
+    if (dim_shape.is_dynamic()) {
+      input = xla::SetDimensionSize(input, output_sizes[i], i);
+    }
+  }
+  return input;
+}
+
 xla::XlaOp SqueezeTrivialDimension(xla::XlaOp input, int64_t dim) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   XLA_CHECK_LT(dim, input_shape.rank());

--- a/torch_xla/csrc/data_ops.h
+++ b/torch_xla/csrc/data_ops.h
@@ -25,6 +25,10 @@ std::vector<int64_t> GetCompleteShape(absl::Span<const int64_t> output_sizes,
 // output size.
 xla::XlaOp BuildView(xla::XlaOp input, absl::Span<const int64_t> output_sizes);
 
+// Update Output Dynamic Dimensions based on input size()
+xla::XlaOp SetDimensionSizes(xla::XlaOp input,
+                             absl::Span<const xla::XlaOp> output_sizes);
+
 // Squeezes the given dimension if trivial (size 1), returns the unchanged input
 // otherwise.
 xla::XlaOp SqueezeTrivialDimension(xla::XlaOp input, int64_t dim);


### PR DESCRIPTION
Add `SetDimensionSizes` API to enable lowering Dynamic Shape in PyTorch/XLA