### PR TITLE
Full codegen for isnan

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1622,12 +1622,6 @@ at::Tensor XLANativeFunctions::index_select(const at::Tensor& self, int64_t dim,
       bridge::GetXlaTensor(self), dim, bridge::GetXlaTensor(index)));
 }
 
-at::Tensor XLANativeFunctions::isnan(const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(
-      XLATensor::isnan(bridge::GetXlaTensor(self)));
-}
-
 at::Tensor XLANativeFunctions::kl_div(const at::Tensor& self,
                                       const at::Tensor& target,
                                       int64_t reduction, bool log_target) {

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -74,7 +74,6 @@ PTXLA_UNARY_OP(Log, at::aten::log, xla::Log);
 PTXLA_UNARY_OP(Log1p, at::aten::log1p, xla::Log1p);
 PTXLA_UNARY_OP(Sqrt, at::aten::sqrt, xla::Sqrt);
 PTXLA_UNARY_OP(Not, at::aten::bitwise_not, xla::Not);
-PTXLA_UNARY_OP(IsNan, at::aten::isnan, xla::IsNan);
 
 PTXLA_BINARY_OP(Min, at::aten::min, xla::Min);
 PTXLA_BINARY_OP(Pow, at::aten::pow, xla::Pow);

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -227,8 +227,6 @@ torch::lazy::NodePtr TanhGelu(const torch::lazy::Value& input);
 torch::lazy::NodePtr TanhGeluBackward(const torch::lazy::Value& grad,
                                       const torch::lazy::Value& input);
 
-torch::lazy::NodePtr IsNan(const torch::lazy::Value& input);
-
 torch::lazy::NodePtr BaddBmm(const torch::lazy::Value& lhs,
                              const torch::lazy::Value& rhs,
                              const torch::lazy::Value& bias,

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -131,6 +131,11 @@ torch_xla::XlaOpVector Inverse::Lower(LoweringContext* loctx) const {
   return ReturnOp(BuildInverse(xla_input), loctx);
 }
 
+torch_xla::XlaOpVector Isnan::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  return ReturnOp(xla::IsNan(xla_input), loctx);
+}
+
 torch_xla::XlaOpVector Logdet::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   return ReturnOp(xla::LogDet(xla_input), loctx);

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -115,6 +115,12 @@ xla::Shape InverseOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
+xla::Shape IsnanOutputShape(const torch::lazy::Value& input) {
+  xla::Shape isnan_shape(GetXlaShape(input));
+  isnan_shape.set_element_type(xla::PRED);
+  return isnan_shape;
+}
+
 xla::Shape LogdetOutputShape(const torch::lazy::Value& input) {
   const xla::Shape& input_shape = GetXlaShape(input);
   XLA_CHECK_GE(input_shape.rank(), 2) << input_shape;

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -53,6 +53,8 @@ xla::Shape HardswishBackwardOutputShape(const torch::lazy::Value& grad_output,
 
 xla::Shape InverseOutputShape(const torch::lazy::Value& input);
 
+xla::Shape IsnanOutputShape(const torch::lazy::Value& input);
+
 xla::Shape LogdetOutputShape(const torch::lazy::Value& input);
 
 xla::Shape LogicalAndOutputShape(const torch::lazy::Value& input,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1542,7 +1542,8 @@ XLATensorPtr XLATensor::index_select(const XLATensorPtr& input, int64_t dim,
 }
 
 XLATensorPtr XLATensor::isnan(const XLATensorPtr& input) {
-  torch::lazy::Value result = IsNan(input->GetIrValue());
+  torch::lazy::Value result = torch::lazy::MakeNode<Isnan>(
+      input->GetIrValue(), std::vector<torch::lazy::Shape>());
   torch::lazy::Value casted = GetBooleanIrValue(result);
   return input->CreateFrom(casted, at::ScalarType::Bool);
 }

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -17,11 +17,12 @@ full_codegen:
   - exp
   - expm1
   - floor
-  - inverse
   - hardsigmoid
   - hardsigmoid_backward
   - hardswish
   - hardswish_backward
+  - inverse
+  - isnan
   - logdet
   - logical_and
   - logical_not
@@ -174,7 +175,6 @@ supported:
   - index_fill_.int_Tensor
   - index_put_
   - index_select
-  - isnan
   - kl_div
   - kthvalue
   - le.Scalar


### PR DESCRIPTION
## PyTorch PR

https://github.com/pytorch/pytorch/pull/82162

## LazyIr.h
```
class Isnan : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::isnan);
  }

  Isnan(const torch::lazy::Value& self, std::vector<torch::lazy::Shape>&& shapes)
      : XlaNode(torch::lazy::OpKind(at::aten::isnan),
              {self}, std::move(shapes),
              [&]() { return IsnanOutputShape(self); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
  {
    
  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();
    
    return ss.str();
  }

  

  bool CanBeReused(const torch::lazy::Value& self) const {
    return false;
    }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;

  
  

};
```

## XLANativeFunctions.cpp

```
    at::Tensor XLANativeFunctions::isnan(const at::Tensor & self) {
        
        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self);
        TORCH_INTERNAL_ASSERT(common_device);
        
        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        torch::lazy::NodePtr node = torch::lazy::ReuseNode<Isnan>(lazy_self->GetIrValue());
        if (!node) {
            
            auto shapes = torch::lazy::compute_shape_isnan(self);
            TORCH_INTERNAL_ASSERT(shapes.size() == 1);
            if(torch::lazy::symbolicShapeEnabled()){
                std::vector<torch::jit::IValue> inputs = { self };
                const char* schema_str = "aten::isnan(Tensor self) -> Tensor";
                applySymbolicShapesOnLT(schema_str, inputs, shapes);
            }
        
            node = torch::lazy::MakeNode<Isnan>(lazy_self->GetIrValue(), std::move(shapes));
            CacheNode(node);
        }
        
        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };

```

## Testing
Built with `BUILD_CPP_TESTS=0 python setup.py install` in docker container on cloud top.

In python shell, ran:
```
>>> t = torch.randn(2, 2, device=xm.xla_device())
>>> torch.isnan(t)
tensor([[False, False],
        [False, False]], device='xla:0')
```
