### PR TITLE
Enable sccache & remote caching

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -8,6 +8,9 @@ PYTORCH_DIR=/tmp/pytorch
 XLA_DIR=$PYTORCH_DIR/xla
 clone_pytorch $PYTORCH_DIR $XLA_DIR
 
+# Use bazel cache
+USE_CACHE=1
+
 SCCACHE="$(which sccache)"
 if [ -z "${SCCACHE}" ]; then
   echo "Unable to find sccache..."
@@ -30,7 +33,7 @@ pushd $PYTORCH_DIR
 
 checkout_torch_pin_if_available
 
-install_deps_pytorch_xla $XLA_DIR
+install_deps_pytorch_xla $XLA_DIR $USE_CACHE
 
 apply_patches
 

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -64,7 +64,6 @@ function install_deps_pytorch_xla() {
   # Using the Ninja generator requires CMake version 3.13 or greater
   pip install cmake>=3.13 --upgrade
 
-  # Bazel doesn't work with sccache gcc. https://github.com/bazelbuild/bazel/issues/3642
   sudo apt-get -qq update
 
   sudo apt-get -qq install npm nodejs
@@ -88,16 +87,15 @@ function install_deps_pytorch_xla() {
   # Use cloud cache to build when available.
   if [[ "$USE_CACHE" == 1 ]]; then
     # Install bazels3cache for cloud cache
-    # TODO(yeounoh) npm install -g bazels3cache on Linux 5.11.0-1022-aws
-    # USE_CACHE is disabled for now. Upgrade npm to the latest could work:
-    #  sudo npm install -g npm
+    sudo npm install -g n
+    sudo n lts
     sudo npm install -g bazels3cache
-    BAZELS3CACHE="$(which bazels3cache)"
+    BAZELS3CACHE="$(which /usr/local/bin/bazels3cache)"
     if [ -z "${BAZELS3CACHE}" ]; then
       echo "Unable to find bazels3cache..."
       exit 1
     fi
-    bazels3cache --bucket=${XLA_CLANG_CACHE_S3_BUCKET_NAME} --maxEntrySizeBytes=0 --logging.level=verbose
+    /usr/local/bin/bazels3cache --bucket=${XLA_CLANG_CACHE_S3_BUCKET_NAME} --maxEntrySizeBytes=0 --logging.level=verbose
     sed -i '/bazel build/ a --remote_http_cache=http://localhost:7777 \\' $XLA_DIR/build_torch_xla_libs.sh
   fi
 }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,8 @@ launch_docker_and_build: &launch_docker_and_build
     docker push ${ECR_DOCKER_IMAGE_BASE}:v0.4 >/dev/null
     sudo pkill -SIGHUP dockerd
     # To enable remote caching, use SCCACHE_BUCKET=${SCCACHE_BUCKET}
-    echo "declare -x SCCACHE_BUCKET=${LOCAL_BUCKET}" >> /home/circleci/project/env
+    # To disable remote caching, use SCCACHE_BUCKET=${LOCAL_BUCKET}
+    echo "declare -x SCCACHE_BUCKET=${SCCACHE_BUCKET}" >> /home/circleci/project/env
     echo "declare -x SCCACHE_CACHE_SIZE=${SCCACHE_CACHE_SIZE}" >> /home/circleci/project/env
     echo "declare -x AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_SCCACHE_AND_XLA_BAZEL_S3_BUCKET_V1}" >> /home/circleci/project/env
     echo "declare -x AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_SCCACHE_AND_XLA_BAZEL_S3_BUCKET_V1}" >> /home/circleci/project/env


### PR DESCRIPTION
Enable remote build caching after:
- Updated bazel to 5.2.0 #3705 
- [bazel#3642](https://github.com/bazelbuild/bazel/issues/3642) is resolved

this addresses https://github.com/pytorch/pytorch/issues/78182