### PR TITLE
Revert "Disable torch audio wheel build for now"

### DIFF
--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -232,7 +232,7 @@ function main() {
   build_and_install_torch_xla
   popd
   install_torchvision_from_source
-  # install_torchaudio_from_source
+  install_torchaudio_from_source
   install_gcloud
 }
 


### PR DESCRIPTION
Reverts pytorch/xla#3778, as https://github.com/pytorch/audio/pull/2582 should fix the torchaudio build.