### PR TITLE
Rename `SymbolicIntNode` to `SymIntNodeImpl`

### DIFF
--- a/torch_xla/csrc/torch_util.cpp
+++ b/torch_xla/csrc/torch_util.cpp
@@ -12,8 +12,7 @@ void SymIntElements::SetSymIntNodeElements(c10::SymInt& size) {
     std::shared_ptr<c10::SymIntNodeImpl> symbolicIntNode =
         size.toSymIntNodeImpl();
     auto lazySymIntNode =
-        std::dynamic_pointer_cast<torch::lazy::SymIntNodeImpl>(
-            symbolicIntNode);
+        std::dynamic_pointer_cast<torch::lazy::SymIntNodeImpl>(symbolicIntNode);
     auto size_node = lazySymIntNode->node_;
     size_nodes_.push_back(size_node);
     upper_bounds_.push_back(

--- a/torch_xla/csrc/torch_util.cpp
+++ b/torch_xla/csrc/torch_util.cpp
@@ -9,10 +9,10 @@ namespace torch_xla {
 
 void SymIntElements::SetSymIntNodeElements(c10::SymInt& size) {
   if (size.is_symbolic()) {
-    std::shared_ptr<c10::SymbolicIntNode> symbolicIntNode =
-        size.toSymbolicIntNode();
+    std::shared_ptr<c10::SymIntNodeImpl> symbolicIntNode =
+        size.toSymIntNodeImpl();
     auto lazySymIntNode =
-        std::dynamic_pointer_cast<torch::lazy::SymbolicIntNode>(
+        std::dynamic_pointer_cast<torch::lazy::SymIntNodeImpl>(
             symbolicIntNode);
     auto size_node = lazySymIntNode->node_;
     size_nodes_.push_back(size_node);


### PR DESCRIPTION
Rename `SymbolicIntNode` to `SymIntNodeImpl`. 

This change unblocks PyTorch/XLA HEAD that broke due to upstream changes this morning https://github.com/pytorch/pytorch/pull/82350 