### PR TITLE
Codegen relu and relu_

### DIFF
--- a/test/cpp/test_tensor.cpp
+++ b/test/cpp/test_tensor.cpp
@@ -119,16 +119,6 @@ TEST_F(TensorTest, TestSize) {
   });
 }
 
-TEST_F(TensorTest, TestRelu) {
-  at::Tensor input = at::rand({2, 1, 4, 6}, at::TensorOptions(at::kFloat));
-  at::Tensor output = input.relu();
-  ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-    XLATensorPtr dev_input = XLATensor::Create(input, device);
-    XLATensorPtr dev_output = XLATensor::relu(dev_input);
-    AllClose(output, dev_output);
-  });
-}
-
 TEST_F(TensorTest, TestRrelu) {
   at::Tensor input = at::rand({2, 1, 4, 6}, at::TensorOptions(at::kFloat));
   float lower = 0.125;

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2559,18 +2559,6 @@ at::Tensor XLANativeFunctions::reflection_pad2d_backward(
       torch::lazy::ToVector<int64_t>(padding)));
 }
 
-at::Tensor XLANativeFunctions::relu(const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(XLATensor::relu(bridge::GetXlaTensor(self)));
-}
-
-at::Tensor& XLANativeFunctions::relu_(at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  XLATensorPtr self_tensor = bridge::GetXlaTensor(self);
-  XLATensor::relu_(self_tensor);
-  return self;
-}
-
 at::Tensor XLANativeFunctions::remainder(const at::Tensor& self,
                                          const at::Tensor& other) {
   XLA_FN_COUNTER("xla::");

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -127,26 +127,6 @@ torch::lazy::NodePtr SignOp(const torch::lazy::Value& input) {
                    GetXlaShape(input), std::move(lower_fn));
 }
 
-torch::lazy::NodePtr ReluOp(const torch::lazy::Value& input) {
-  auto lower_fn = [](const XlaNode& node,
-                     LoweringContext* loctx) -> XlaOpVector {
-    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
-    xla::XlaOp xla_output = BuildRelu(xla_input);
-    return node.ReturnOp(xla_output, loctx);
-  };
-  auto lower_for_shape_fn =
-      [](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
-    XLA_CHECK_EQ(operands.size(), 1) << "Unexpected number of operands";
-    return BuildRelu(operands[0]);
-  };
-  return GenericOp(torch::lazy::OpKind(at::aten::relu), {input},
-                   [&]() {
-                     return InferOutputShape({GetXlaShape(input)},
-                                             lower_for_shape_fn);
-                   },
-                   std::move(lower_fn));
-}
-
 torch::lazy::NodePtr Prelu(const torch::lazy::Value& input,
                            const torch::lazy::Value& weight) {
   auto lower_fn = [](const XlaNode& node,

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -86,8 +86,6 @@ torch::lazy::NodePtr SgnOp(const torch::lazy::Value& input);
 
 torch::lazy::NodePtr SignOp(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr ReluOp(const torch::lazy::Value& input);
-
 torch::lazy::NodePtr Min(const torch::lazy::Value& input,
                          const torch::lazy::Value& other);
 

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -212,9 +212,9 @@ torch_xla::XlaOpVector Reciprocal::Lower(LoweringContext* loctx) const {
 }
 
 torch_xla::XlaOpVector Relu::Lower(LoweringContext* loctx) const {
-    xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
-    xla::XlaOp xla_output = BuildRelu(xla_input);
-    return ReturnOp(xla_output, loctx);
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  xla::XlaOp xla_output = BuildRelu(xla_input);
+  return ReturnOp(xla_output, loctx);
 }
 
 torch_xla::XlaOpVector Round::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -211,6 +211,12 @@ torch_xla::XlaOpVector Reciprocal::Lower(LoweringContext* loctx) const {
   return ReturnOp(BuildReciprocal(xla_input), loctx);
 }
 
+torch_xla::XlaOpVector Relu::Lower(LoweringContext* loctx) const {
+    xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+    xla::XlaOp xla_output = BuildRelu(xla_input);
+    return ReturnOp(xla_output, loctx);
+}
+
 torch_xla::XlaOpVector Round::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   return ReturnOp(xla::RoundToEven(xla_input), loctx);

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -207,6 +207,15 @@ xla::Shape ReciprocalOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
+xla::Shape ReluOutputShape(const torch::lazy::Value& input) {
+  auto lower_for_shape_fn =
+      [](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
+    XLA_CHECK_EQ(operands.size(), 1) << "Unexpected number of operands";
+    return BuildRelu(operands[0]);
+  };
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
+}
+
 xla::Shape RoundOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -82,6 +82,8 @@ xla::Shape MinimumOutputShape(const torch::lazy::Value& input,
 
 xla::Shape ReciprocalOutputShape(const torch::lazy::Value& input);
 
+xla::Shape ReluOutputShape(const torch::lazy::Value& input);
+
 xla::Shape RoundOutputShape(const torch::lazy::Value& input);
 
 xla::Shape RsqrtOutputShape(const torch::lazy::Value& input);

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -966,9 +966,6 @@ class XLATensor : public c10::intrusive_ptr_target {
                                                 const XLATensorPtr& input,
                                                 std::vector<int64_t> padding);
 
-  static XLATensorPtr relu(const XLATensorPtr& input);
-  static void relu_(XLATensorPtr& input);
-
   static XLATensorPtr remainder(const XLATensorPtr& input,
                                 const XLATensorPtr& other);
   static XLATensorPtr remainder(const XLATensorPtr& input,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2230,14 +2230,6 @@ XLATensorPtr XLATensor::reflection_pad2d_backward(
       grad_output->GetIrValue(), input->GetIrValue(), std::move(padding)));
 }
 
-XLATensorPtr XLATensor::relu(const XLATensorPtr& input) {
-  return input->CreateFrom(ReluOp(input->GetIrValue()));
-}
-
-void XLATensor::relu_(XLATensorPtr& input) {
-  input->SetInPlaceIrValue(ReluOp(input->GetIrValue()));
-}
-
 XLATensorPtr XLATensor::remainder(const XLATensorPtr& input,
                                   const XLATensorPtr& other) {
   return input->CreateFrom(Remainder(input->GetIrValue(), other->GetIrValue()));

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -33,6 +33,7 @@ full_codegen:
   - maximum
   - minimum
   - reciprocal
+  - relu
   - round
   - rsqrt
   - selu
@@ -253,8 +254,6 @@ supported:
   - random_.to
   - reflection_pad2d
   - reflection_pad2d_backward
-  - relu
-  - relu_
   - remainder.Scalar
   - remainder.Tensor
   - repeat


### PR DESCRIPTION
Codegen relu and relu_ https://github.com/pytorch/xla/issues/3797

---
LazyIr.h:
```
class Relu : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::relu);
  }

  Relu(const torch::lazy::Value& self, std::vector<torch::lazy::Shape>&& shapes)
      : XlaNode(torch::lazy::OpKind(at::aten::relu),
              {self}, std::move(shapes),
              [&]() { return ReluOutputShape(self); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
  {
    
  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();
    
    return ss.str();
  }

  

  bool CanBeReused(const torch::lazy::Value& self) const {
    return false;
    }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;

  
  

};
```
---
XLANativeFunctions.cpp:
```
at::Tensor XLANativeFunctions::relu(const at::Tensor & self) {
        
        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self);
        TORCH_INTERNAL_ASSERT(common_device);
        
        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        torch::lazy::NodePtr node = torch::lazy::ReuseNode<Relu>(lazy_self->GetIrValue());
        if (!node) {
            
            auto shapes = torch::lazy::compute_shape_relu(self);
            TORCH_INTERNAL_ASSERT(shapes.size() == 1);
            if(torch::lazy::symbolicShapeEnabled()){
                std::vector<torch::jit::IValue> inputs = { self };
                const char* schema_str = "aten::relu(Tensor self) -> Tensor";
                applySymbolicShapesOnLT(schema_str, inputs, shapes);
            }
        
            node = torch::lazy::MakeNode<Relu>(lazy_self->GetIrValue(), std::move(shapes));
            CacheNode(node);
        }
        
        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };
```