### PR TITLE
Repair `SymIntNodeImpl` to unblock `master` HEAD

### DIFF
--- a/torch_xla/csrc/torch_util.cpp
+++ b/torch_xla/csrc/torch_util.cpp
@@ -10,7 +10,8 @@ namespace torch_xla {
 void SymIntElements::SetSymIntNodeElements(c10::SymInt& size) {
   if (size.is_symbolic()) {
     c10::SymIntNode symbolicIntNode = size.toSymIntNodeImpl();
-    auto* lazySymIntNode = dynamic_cast<torch::lazy::SymIntNodeImpl*>(symbolicIntNode.get());
+    auto* lazySymIntNode =
+        dynamic_cast<torch::lazy::SymIntNodeImpl*>(symbolicIntNode.get());
     auto size_node = lazySymIntNode->node_;
     size_nodes_.push_back(size_node);
     upper_bounds_.push_back(

--- a/torch_xla/csrc/torch_util.cpp
+++ b/torch_xla/csrc/torch_util.cpp
@@ -9,10 +9,8 @@ namespace torch_xla {
 
 void SymIntElements::SetSymIntNodeElements(c10::SymInt& size) {
   if (size.is_symbolic()) {
-    std::shared_ptr<c10::SymIntNodeImpl> symbolicIntNode =
-        size.toSymIntNodeImpl();
-    auto lazySymIntNode =
-        std::dynamic_pointer_cast<torch::lazy::SymIntNodeImpl>(symbolicIntNode);
+    c10::SymIntNode symbolicIntNode = size.toSymIntNodeImpl();
+    auto* lazySymIntNode = dynamic_cast<torch::lazy::SymIntNodeImpl*>(symbolicIntNode.get());
     auto size_node = lazySymIntNode->node_;
     size_nodes_.push_back(size_node);
     upper_bounds_.push_back(


### PR DESCRIPTION
Repair `SymIntNodeImpl` to unblock `master` `HEAD`.

This fix is related to https://github.com/pytorch/pytorch/commit/7be44f8158a817c64de7e2732eba42fc060209f4