### PR TITLE
Codegen trunc

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3142,12 +3142,6 @@ std::tuple<at::Tensor, at::Tensor> XLANativeFunctions::triangular_solve(
                          bridge::AtenFromXlaTensor(std::get<1>(results)));
 }
 
-at::Tensor XLANativeFunctions::trunc(const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(
-      XLATensor::trunc(bridge::GetXlaTensor(self)));
-}
-
 std::vector<at::Tensor> XLANativeFunctions::unbind(const at::Tensor& self,
                                                    int64_t dim) {
   XLA_FN_COUNTER("xla::");

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -80,16 +80,9 @@ PTXLA_BINARY_OP(Pow, at::aten::pow, xla::Pow);
 PTXLA_BINARY_OP(Fmod, at::aten::fmod, xla::Rem);
 PTXLA_BINARY_OP(Atan2, at::aten::atan2, xla::Atan2);
 
-torch::lazy::NodePtr Trunc(const torch::lazy::Value& input) {
-  std::vector<torch::lazy::Shape> shapes;
-  return torch::lazy::MakeNode<Floor>(
-             torch::lazy::MakeNode<Abs>(input, std::move(shapes)),
-             std::vector<torch::lazy::Shape>()) *
-         torch::lazy::MakeNode<Sign>(input, std::vector<torch::lazy::Shape>());
-}
-
 torch::lazy::NodePtr FracOp(const torch::lazy::Value& input) {
-  return input - Trunc(input);
+  return input -
+         torch::lazy::MakeNode<Trunc>(input, std::vector<torch::lazy::Shape>());
 }
 
 torch::lazy::NodePtr LogBase(const torch::lazy::Value& input,

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -140,8 +140,6 @@ torch::lazy::NodePtr Clamp(const torch::lazy::Value& input,
 torch::lazy::NodePtr Celu(const torch::lazy::Value& input,
                           const at::Scalar& alpha);
 
-torch::lazy::NodePtr Trunc(const torch::lazy::Value& input);
-
 torch::lazy::NodePtr FracOp(const torch::lazy::Value& input);
 
 torch::lazy::NodePtr Ger(const torch::lazy::Value& input,

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -284,4 +284,9 @@ torch_xla::XlaOpVector Triu::Lower(LoweringContext* loctx) const {
   return ReturnOp(BuildTriu(xla_input, diagonal), loctx);
 }
 
+torch_xla::XlaOpVector Trunc::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  return ReturnOp(xla::Floor(BuildAbs(xla_input)) * BuildSgn(xla_input), loctx);
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -275,4 +275,8 @@ xla::Shape TriuOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
+xla::Shape TruncOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -112,4 +112,6 @@ xla::Shape TrilOutputShape(const torch::lazy::Value& input);
 
 xla::Shape TriuOutputShape(const torch::lazy::Value& input);
 
+xla::Shape TruncOutputShape(const torch::lazy::Value& input);
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -1170,8 +1170,6 @@ class XLATensor : public c10::intrusive_ptr_target {
       const XLATensorPtr& rhs, const XLATensorPtr& lhs, bool left_side,
       bool upper, bool transpose, bool unitriangular);
 
-  static XLATensorPtr trunc(const XLATensorPtr& input);
-
   // Returns a tuple of all slices along a given dimension with that dimension
   // removed.
   static std::vector<XLATensorPtr> unbind(const XLATensorPtr& input,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1210,7 +1210,8 @@ XLATensorPtr XLATensor::div(
 
   if (rounding_mode.has_value()) {
     if (*rounding_mode == "trunc") {
-      res = Trunc(res);
+      res =
+          torch::lazy::MakeNode<Trunc>(res, std::vector<torch::lazy::Shape>());
     } else if (*rounding_mode == "floor") {
       res =
           torch::lazy::MakeNode<Floor>(res, std::vector<torch::lazy::Shape>());
@@ -2780,10 +2781,6 @@ std::tuple<XLATensorPtr, XLATensorPtr> XLATensor::triangular_solve(
       unitriangular);
   return std::make_tuple(rhs->CreateFrom(torch::lazy::Value(node, 0)),
                          rhs->CreateFrom(torch::lazy::Value(node, 1)));
-}
-
-XLATensorPtr XLATensor::trunc(const XLATensorPtr& input) {
-  return input->CreateFrom(Trunc(input->GetIrValue()));
 }
 
 std::vector<XLATensorPtr> XLATensor::unbind(const XLATensorPtr& input,

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -46,6 +46,7 @@ full_codegen:
   - tanh
   - tril
   - triu
+  - trunc
 ir_gen:
   - _adaptive_avg_pool2d
   - _adaptive_avg_pool2d_backward
@@ -316,7 +317,6 @@ supported:
   - transpose.int
   - transpose_
   - triangular_solve
-  - trunc
   - unbind.int
   - uniform_
   - unsqueeze


### PR DESCRIPTION
Codegen trunc

---
LazyIr.h:
```
class Trunc : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::trunc);
  }

  Trunc(const torch::lazy::Value& self, std::vector<torch::lazy::Shape>&& shapes)
      : XlaNode(torch::lazy::OpKind(at::aten::trunc),
              {self}, std::move(shapes),
              [&]() { return TruncOutputShape(self); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
  {
    
  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();
    
    return ss.str();
  }

  

  bool CanBeReused(const torch::lazy::Value& self) const {
    return false;
    }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;

  
  

};
```
---
XLANativeFunctions.cpp:
```
    at::Tensor XLANativeFunctions::trunc(const at::Tensor & self) {
        
        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self);
        TORCH_INTERNAL_ASSERT(common_device);
        
        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        torch::lazy::NodePtr node = torch::lazy::ReuseNode<Trunc>(lazy_self->GetIrValue());
        if (!node) {
                    auto self_meta = to_meta(self);
        auto out_meta = at::meta::trunc(self_meta);
        
std::vector<torch::lazy::Shape> shapes{torch::lazy::Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
            TORCH_INTERNAL_ASSERT(shapes.size() == 1);
            if(torch::lazy::symbolicShapeEnabled()){
                std::vector<torch::jit::IValue> inputs = { self };
                const char* schema_str = "aten::trunc(Tensor self) -> Tensor";
                applySymbolicShapesOnLT(schema_str, inputs, shapes);
            }
        
            node = torch::lazy::MakeNode<Trunc>(lazy_self->GetIrValue(), std::move(shapes));
            CacheNode(node);
        }
        
        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };

```