### PR TITLE
TPU Pod support with PjRt

### DIFF
--- a/test/pjrt/test_experimental_pjrt_tpu.py
+++ b/test/pjrt/test_experimental_pjrt_tpu.py
@@ -1,0 +1,151 @@
+import concurrent.futures
+import functools
+import itertools
+import os
+import time
+import requests
+
+import torch
+import torch_xla
+from absl.testing import absltest, parameterized
+import torch_xla.core.xla_env_vars as xenv
+import torch_xla.core.xla_model as xm
+from torch_xla.experimental import pjrt
+from torch_xla.experimental import tpu
+
+
+def _get_real_devices():
+  """Wraps `_xla_get_devices` to make it pickle-able"""
+  return torch_xla._XLAC._xla_get_devices()
+
+def _get_all_real_devices():
+  """Wraps `_xla_get_all_devices` to make it pickle-able"""
+  return torch_xla._XLAC._xla_get_all_devices()
+
+class TestExperimentalPjrtTpu(parameterized.TestCase):
+  def setUp(self):
+    time.sleep(1)
+    pjrt.set_device_type('TPU')
+
+    os.environ.pop(xenv.TPU_VISIBLE_DEVICES, None)
+    os.environ.pop(xenv.TPU_PROCESS_BOUNDS, None)
+
+    try:
+      tpu_env = tpu.get_tpu_env()
+      self.accelerator_type = tpu_env['ACCELERATOR_TYPE']
+    except requests.HTTPError as e:
+      raise EnvironmentError('Failed to get TPU metadata. Are you running on a TPU?') from e
+
+    # TODO: assert ComputationClient is not initialized
+    # The main process must not initialize the ComputationClient, otherwise
+    # sub-processes will not be able to initialize the client witht the correct
+    # settings.
+
+  def test_xla_devices_multiprocess(self):
+    accelerator_devices = {
+      'v3-8': {
+        0: {
+          0: torch.device('xla:0'),
+          1: torch.device('xla:1'),
+        },
+        1: {
+          0: torch.device('xla:0'),
+          1: torch.device('xla:1'),
+        },
+        2: {
+          0: torch.device('xla:0'),
+          1: torch.device('xla:1'),
+        },
+        3: {
+          0: torch.device('xla:0'),
+          1: torch.device('xla:1'),
+        },
+      },
+      'v4-8': {
+        0: {0: torch.device('xla:0')},
+        1: {0: torch.device('xla:0')},
+        2: {0: torch.device('xla:0')},
+        3: {0: torch.device('xla:0')},
+      },
+    }
+
+    if self.accelerator_type not in accelerator_devices:
+      raise NotImplementedError('Test not implemented for {}'.format(self.accelerator_type))
+    expected = accelerator_devices[self.accelerator_type]
+
+    devices_per_process = pjrt.run_multiprocess(xm.xla_device)
+    self.assertDictEqual(devices_per_process, expected)
+
+  def test_real_devices_multiprocess(self):
+    accelerator_devices = {
+      'v3-8': {
+        0: {
+          0: ['TPU:0', 'TPU:1'],
+          1: ['TPU:0', 'TPU:1'],
+        },
+        1: {
+          0: ['TPU:2', 'TPU:3'],
+          1: ['TPU:2', 'TPU:3'],
+        },
+        2: {
+          0: ['TPU:4', 'TPU:5'],
+          1: ['TPU:4', 'TPU:5'],
+        },
+        3: {
+          0: ['TPU:6', 'TPU:7'],
+          1: ['TPU:6', 'TPU:7'],
+        },
+      },
+      'v4-8': {
+        0: {0: ['TPU:0']},
+        1: {0: ['TPU:2']},
+        2: {0: ['TPU:3']},
+        3: {0: ['TPU:1']},
+      },
+    }
+
+    if self.accelerator_type not in accelerator_devices:
+      raise NotImplementedError('Test not implemented for {}'.format(self.accelerator_type))
+    expected = accelerator_devices[self.accelerator_type]
+
+
+    devices_per_process = pjrt.run_multiprocess(_get_real_devices)
+    self.assertDictEqual(devices_per_process, expected)
+
+    all_devices = sorted(itertools.chain.from_iterable(process_devices[0] for process_devices in expected.values()))
+    expected_all_devices = {
+      rank: {thread: all_devices for thread in expected[0].keys()} for rank in expected.keys()
+    }
+
+    all_devices_per_process = pjrt.run_multiprocess(_get_all_real_devices)
+    self.assertDictEqual(all_devices_per_process, expected_all_devices)
+
+  def test_single_process_all_chips(self):
+    pass
+
+  def test_single_process_one_chip(self):
+    accelerator_devices = {
+      'v3-8': {
+        0: {
+          0: torch.device('xla:0'),
+          1: torch.device('xla:1'),
+        },
+      },
+      'v4-8': {
+        0: {0: torch.device('xla:0')},
+      },
+    }
+
+    if self.accelerator_type not in accelerator_devices:
+      raise NotImplementedError('Test not implemented for {}'.format(self.accelerator_type))
+    expected = accelerator_devices[self.accelerator_type]
+
+    os.environ[xenv.TPU_VISIBLE_DEVICES] = '0'
+    os.environ[xenv.TPU_PROCESS_BOUNDS] = '1,1,1'
+
+    devices = pjrt.run_multiprocess(xm.xla_device)
+    self.assertDictEqual(devices, expected)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/test/pjrt/test_experimental_pjrt_tpu.py
+++ b/test/pjrt/test_experimental_pjrt_tpu.py
@@ -1,8 +1,6 @@
 import concurrent.futures
-import functools
 import itertools
 import os
-import time
 import requests
 
 import torch

--- a/test/pjrt/test_experimental_pjrt_tpu.py
+++ b/test/pjrt/test_experimental_pjrt_tpu.py
@@ -87,6 +87,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
     self.assertDictEqual(devices_per_process, expected)
 
   def test_real_devices_multiprocess(self):
+    # Real devices unfortunately don't correspond to indices in TPU_VISIBLE_DEVICES
     accelerator_devices = {
         'v3-8': {
             0: {
@@ -94,12 +95,12 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
                 1: ['TPU:0', 'TPU:1'],
             },
             1: {
-                0: ['TPU:2', 'TPU:3'],
-                1: ['TPU:2', 'TPU:3'],
+                0: ['TPU:4', 'TPU:5'],
+                1: ['TPU:4', 'TPU:5']
             },
             2: {
-                0: ['TPU:4', 'TPU:5'],
-                1: ['TPU:4', 'TPU:5'],
+                0: ['TPU:2', 'TPU:3'],
+                1: ['TPU:2', 'TPU:3']
             },
             3: {
                 0: ['TPU:6', 'TPU:7'],

--- a/test/pjrt/test_experimental_pjrt_tpu.py
+++ b/test/pjrt/test_experimental_pjrt_tpu.py
@@ -86,62 +86,6 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
     devices_per_process = pjrt.run_multiprocess(xm.xla_device)
     self.assertDictEqual(devices_per_process, expected)
 
-  def test_real_devices_multiprocess(self):
-    # Real devices unfortunately don't correspond to indices in TPU_VISIBLE_DEVICES
-    accelerator_devices = {
-        'v3-8': {
-            0: {
-                0: ['TPU:0', 'TPU:1'],
-                1: ['TPU:0', 'TPU:1'],
-            },
-            1: {
-                0: ['TPU:4', 'TPU:5'],
-                1: ['TPU:4', 'TPU:5']
-            },
-            2: {
-                0: ['TPU:2', 'TPU:3'],
-                1: ['TPU:2', 'TPU:3']
-            },
-            3: {
-                0: ['TPU:6', 'TPU:7'],
-                1: ['TPU:6', 'TPU:7'],
-            },
-        },
-        'v4-8': {
-            0: {
-                0: ['TPU:0']
-            },
-            1: {
-                0: ['TPU:2']
-            },
-            2: {
-                0: ['TPU:3']
-            },
-            3: {
-                0: ['TPU:1']
-            },
-        },
-    }
-
-    if self.accelerator_type not in accelerator_devices:
-      raise NotImplementedError('Test not implemented for {}'.format(
-          self.accelerator_type))
-    expected = accelerator_devices[self.accelerator_type]
-
-    devices_per_process = pjrt.run_multiprocess(_get_real_devices)
-    self.assertDictEqual(devices_per_process, expected)
-
-    all_devices = sorted(
-        itertools.chain.from_iterable(
-            process_devices[0] for process_devices in expected.values()))
-    expected_all_devices = {
-        rank: {thread: all_devices for thread in expected[0].keys()
-              } for rank in expected.keys()
-    }
-
-    all_devices_per_process = pjrt.run_multiprocess(_get_all_real_devices)
-    self.assertDictEqual(all_devices_per_process, expected_all_devices)
-
   def test_xla_devices_single_process_all_chips(self):
     accelerator_devices = {
         'v3-8': {

--- a/test/pjrt/test_experimental_tpu.py
+++ b/test/pjrt/test_experimental_tpu.py
@@ -164,11 +164,11 @@ class TestExperimentalTpu(parameterized.TestCase):
                                   local_world_size, expected):
     with mock.patch.object(tpu, 'get_tpu_env', return_value=tpu_env), \
         mock.patch.object(tpu, 'get_worker_ips', return_value=worker_ips), \
-        mock.patch.dict(os.environ, clear=True) as mock_env:
+        mock.patch.dict(os.environ, clear=True):
 
       tpu.configure_topology(local_rank, local_world_size)
 
-      self.assertDictContainsSubset(expected, mock_env)
+      self.assertDictContainsSubset(expected, os.environ)
 
 
 if __name__ == '__main__':

--- a/test/pjrt/test_experimental_tpu.py
+++ b/test/pjrt/test_experimental_tpu.py
@@ -17,10 +17,10 @@ class TestExperimentalTpu(parameterized.TestCase):
       ('multi_process_v4-16', '2,2,2', 8),
       ('multi_process_v4-32', '2,2,4', 16),
   )
-  def test_num_processes(self, process_bounds, expected):
+  def test_process_bounds_size(self, process_bounds, expected):
     envs = {xenv.TPU_PROCESS_BOUNDS: process_bounds} if process_bounds else {}
     with mock.patch.dict(os.environ, envs, clear=True):
-      n = tpu.num_processes()
+      n = tpu.process_bounds_size()
 
     self.assertEqual(n, expected)
 

--- a/test/pjrt/test_experimental_tpu.py
+++ b/test/pjrt/test_experimental_tpu.py
@@ -1,4 +1,3 @@
-from cmath import exp
 import os
 import textwrap
 
@@ -9,7 +8,7 @@ from torch_xla.experimental import tpu
 from unittest import mock
 
 
-class TestExperimentalPjrtTpu(parameterized.TestCase):
+class TestExperimentalTpu(parameterized.TestCase):
 
   @parameterized.named_parameters(
       ('default_one_host', None, 4),
@@ -87,6 +86,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
 
   @parameterized.named_parameters(
       ('v4-8_process_0', {
+          'ACCELERATOR_TYPE': 'v4-8',
           xenv.TPU_PROCESS_BOUNDS: '1,1,1',
           xenv.TPU_CHIPS_PER_PROCESS_BOUNDS: '2,2,1',
           'WORKER_ID': '0'
@@ -105,6 +105,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
               '0',
       }),
       ('v4-8_process_3', {
+          'ACCELERATOR_TYPE': 'v4-8',
           xenv.TPU_PROCESS_BOUNDS: '1,1,1',
           xenv.TPU_CHIPS_PER_PROCESS_BOUNDS: '2,2,1',
           'WORKER_ID': '0'
@@ -123,6 +124,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
               '3',
       }),
       ('v4-16_worker_1_process_0', {
+          'ACCELERATOR_TYPE': 'v4-16',
           xenv.TPU_PROCESS_BOUNDS: '1,1,2',
           xenv.TPU_CHIPS_PER_PROCESS_BOUNDS: '2,2,1',
           'WORKER_ID': '1'
@@ -140,7 +142,24 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
           xenv.TPU_VISIBLE_DEVICES:
               '0',
       }),
-  )
+      # TODO: remove this case when process bounds are added to metadata
+      ('v3-8_process_0', {
+          'ACCELERATOR_TYPE': 'v3-8',
+          'WORKER_ID': '0'
+      }, ['localhost'], 0, 4, {
+          xenv.TPU_CHIPS_PER_PROCESS_BOUNDS:
+              '1,1,1',
+          xenv.TPU_PROCESS_BOUNDS:
+              '2,2,1',
+          xenv.CLOUD_TPU_TASK_ID:
+              '0',
+          xenv.TPU_PROCESS_PORT:
+              '8476',
+          xenv.TPU_PROCESS_ADDRESSES:
+              'localhost:8476,localhost:8477,localhost:8478,localhost:8479',
+          xenv.TPU_VISIBLE_DEVICES:
+              '0',
+      }))
   def test_configure_tpu_topology(self, tpu_env, worker_ips, local_rank,
                                   local_world_size, expected):
     with mock.patch.object(tpu, 'get_tpu_env', return_value=tpu_env), \

--- a/test/pjrt/test_experimental_tpu.py
+++ b/test/pjrt/test_experimental_tpu.py
@@ -1,0 +1,160 @@
+from cmath import exp
+import os
+import textwrap
+
+from absl.testing import absltest, parameterized
+import torch_xla.core.xla_env_vars as xenv
+from torch_xla.experimental import tpu
+
+from unittest import mock
+
+class TestExperimentalPjrtTpu(parameterized.TestCase):
+  @parameterized.named_parameters(
+    ('default_one_host', None, 4),
+    ('one_process_one_host', '1,1,1', 1),
+    ('multi_process_one_host', '2,2,1', 4),
+    ('multi_process_v4-16', '2,2,2', 8),
+    ('multi_process_v4-32', '2,2,4', 16),
+  )
+  def test_num_processes(self, process_bounds, expected):
+    envs = {xenv.TPU_PROCESS_BOUNDS: process_bounds} if process_bounds else {}
+    with mock.patch.dict(os.environ, envs, clear=True):
+      n = tpu.num_processes()
+
+    self.assertEqual(n, expected)
+
+  @parameterized.named_parameters(
+    ('default_one_host', None, 4),
+    ('one_process_one_host', '1,1,1', 1),
+    ('multi_process_one_host', '2,2,1', 4),
+    ('multi_process_v4-16', '2,2,2', 4),
+    ('multi_process_v4-32', '2,2,4', 4),
+  )
+  def test_num_local_processes(self, process_bounds, expected):
+    envs = {xenv.TPU_PROCESS_BOUNDS: process_bounds} if process_bounds else {}
+    with mock.patch.dict(os.environ, envs, clear=True):
+      n = tpu.num_local_processes()
+
+    self.assertEqual(n, expected)
+
+
+  @parameterized.parameters(
+    (None, None),
+    ('0', 0),
+    ('1', 1),
+    ('15', 15)
+  )
+  def test_task_id(self, task_id, expected):
+    envs = {xenv.CLOUD_TPU_TASK_ID: task_id} if task_id else {}
+    with mock.patch.dict(os.environ, envs, clear=True):
+      i = tpu.task_id()
+
+    self.assertEqual(i, expected)
+
+  def test_tpu_env(self):
+    tpu_env_yaml = textwrap.dedent("""
+      ACCELERATOR_TYPE: 'v4-16'
+      CHIPS_PER_HOST_BOUNDS: '2,2,1'
+      HOST_BOUNDS: '1,1,2'
+      TPU_CHIPS_PER_PROCESS_BOUNDS: '2,2,1'
+      TPU_PROCESS_BOUNDS: '1,1,2'
+      ZONE: 'us-central2-b'
+    """)
+
+    with mock.patch.object(tpu, '_get_metadata', return_value=tpu_env_yaml):
+      tpu_env = tpu.get_tpu_env()
+
+    self.assertDictEqual(tpu_env, {
+      'ACCELERATOR_TYPE': 'v4-16',
+      'CHIPS_PER_HOST_BOUNDS': '2,2,1',
+      'HOST_BOUNDS': '1,1,2',
+      'TPU_CHIPS_PER_PROCESS_BOUNDS': '2,2,1',
+      'TPU_PROCESS_BOUNDS': '1,1,2',
+      'ZONE': 'us-central2-b',
+    })
+
+  @parameterized.named_parameters(
+    ('one_host', 't1v-n-ea9d3291-w-0:12345:10.130.0.31', ['localhost']),
+    (
+      'four_hosts',
+      't1v-n-0f996b37-w-0:12345:10.130.0.26,t1v-n-0f996b37-w-1:12346:10.130.0.27,t1v-n-0f996b37-w-2:12347:10.130.0.25,t1v-n-0f996b37-w-3:12348:10.130.0.28',
+      ['10.130.0.26', '10.130.0.27', '10.130.0.25', '10.130.0.28'],
+    ),
+  )
+  def test_get_worker_ips(self, worker_network_endpoints, expected):
+    with mock.patch.object(tpu, '_get_metadata', return_value=worker_network_endpoints):
+      worker_ips = tpu.get_worker_ips()
+
+    self.assertListEqual(worker_ips, expected)
+
+  @parameterized.named_parameters(
+    (
+      'v4-8_process_0',
+      {
+        xenv.TPU_PROCESS_BOUNDS: '1,1,1',
+        xenv.TPU_CHIPS_PER_PROCESS_BOUNDS: '2,2,1',
+        'WORKER_ID': '0'
+      },
+      ['localhost'],
+      0,
+      4,
+      {
+        xenv.TPU_CHIPS_PER_PROCESS_BOUNDS: '1,1,1',
+        xenv.TPU_PROCESS_BOUNDS: '2,2,1',
+        xenv.CLOUD_TPU_TASK_ID: '0',
+        xenv.TPU_PROCESS_PORT: '8476',
+        xenv.TPU_PROCESS_ADDRESSES: 'localhost:8476,localhost:8477,localhost:8478,localhost:8479',
+        xenv.TPU_VISIBLE_DEVICES: '0',
+      }
+    ),
+    (
+      'v4-8_process_3',
+      {
+        xenv.TPU_PROCESS_BOUNDS: '1,1,1',
+        xenv.TPU_CHIPS_PER_PROCESS_BOUNDS: '2,2,1',
+        'WORKER_ID': '0'
+      },
+      ['localhost'],
+      3,
+      4,
+      {
+        xenv.TPU_CHIPS_PER_PROCESS_BOUNDS: '1,1,1',
+        xenv.TPU_PROCESS_BOUNDS: '2,2,1',
+        xenv.CLOUD_TPU_TASK_ID: '3',
+        xenv.TPU_PROCESS_PORT: '8479',
+        xenv.TPU_PROCESS_ADDRESSES: 'localhost:8476,localhost:8477,localhost:8478,localhost:8479',
+        xenv.TPU_VISIBLE_DEVICES: '3',
+      }
+    ),
+    (
+      'v4-16_worker_1_process_0',
+      {
+        xenv.TPU_PROCESS_BOUNDS: '1,1,2',
+        xenv.TPU_CHIPS_PER_PROCESS_BOUNDS: '2,2,1',
+        'WORKER_ID': '1'
+      },
+      ['10.130.0.31', '10.130.0.30'],
+      0,
+      4,
+      {
+        xenv.TPU_CHIPS_PER_PROCESS_BOUNDS: '1,1,1',
+        xenv.TPU_PROCESS_BOUNDS: '2,2,2',
+        xenv.CLOUD_TPU_TASK_ID: '4',
+        xenv.TPU_PROCESS_PORT: '8476',
+        xenv.TPU_PROCESS_ADDRESSES: '10.130.0.31:8476,10.130.0.31:8477,10.130.0.31:8478,10.130.0.31:8479,10.130.0.30:8476,10.130.0.30:8477,10.130.0.30:8478,10.130.0.30:8479',
+        xenv.TPU_VISIBLE_DEVICES: '0',
+      }
+    ),
+  )
+  def test_configure_tpu_topology(self, tpu_env, worker_ips, local_rank, local_world_size, expected):
+    with mock.patch.object(tpu, 'get_tpu_env', return_value=tpu_env), \
+        mock.patch.object(tpu, 'get_worker_ips', return_value=worker_ips), \
+        mock.patch.dict(os.environ, clear=True) as mock_env:
+
+      tpu.configure_topology(local_rank, local_world_size)
+
+      self.assertDictContainsSubset(expected, mock_env)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/test/pjrt/test_experimental_tpu.py
+++ b/test/pjrt/test_experimental_tpu.py
@@ -11,7 +11,7 @@ from unittest import mock
 class TestExperimentalTpu(parameterized.TestCase):
 
   @parameterized.named_parameters(
-      ('default_one_host', None, 4),
+      ('default_one_host', None, 1),
       ('one_process_one_host', '1,1,1', 1),
       ('multi_process_one_host', '2,2,1', 4),
       ('multi_process_v4-16', '2,2,2', 8),

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -109,6 +109,7 @@ function run_op_tests {
   run_test python3 "$CDIR/test_torch_distributed_xla_backend.py"
   run_xla_ir_debug python3 "$CDIR/test_env_var_mapper.py"
   run_pjrt python3 "$CDIR/pjrt/test_experimental_pjrt.py"
+  run_pjrt python3 "$CDIR/pjrt/test_experimental_tpu.py"
 }
 
 function run_mp_op_tests {

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -11,6 +11,7 @@ import torch_xla
 import torch_xla.core.xla_env_vars as xenv
 import torch_xla.core.xla_model as xm
 import torch_xla.utils.utils as xu
+from torch_xla.experimental import tpu
 
 _PJRT_ORDINALS = threading.local()
 
@@ -44,19 +45,6 @@ def num_visible_tpu_chips(default: int = 4) -> int:
   visible_devices = xu.getenv_as(xenv.TPU_VISIBLE_DEVICES, str)
 
   return len(visible_devices.split(',')) if visible_devices else default
-
-
-def configure_tpu_topology(rank: int, processes: int, base_port=8476) -> None:
-  """Sets default TPU topology environment variables for a single TPU host."""
-  ports = list(range(base_port, base_port + processes))
-  os.environ.setdefault(xenv.TPU_CHIPS_PER_PROCESS_BOUNDS, '1,1,1')
-  os.environ.setdefault(xenv.TPU_PROCESS_BOUNDS, '2,2,1')
-  os.environ.setdefault(xenv.TPU_PROCESS_ADDRESSES,
-                        ','.join(f'localhost:{port}' for port in ports))
-
-  os.environ.setdefault(xenv.TPU_VISIBLE_DEVICES, str(rank))
-  os.environ.setdefault(xenv.TPU_PROCESS_PORT, str(ports[rank]))
-  os.environ.setdefault(xenv.CLOUD_TPU_TASK_ID, str(rank))
 
 
 def requires_pjrt(fn: FN) -> FN:
@@ -141,13 +129,13 @@ def addressable_device_count() -> int:
 
 
 @requires_pjrt
-def run_thread_per_device(rank: int, processes: int,
+def run_thread_per_device(process: int, local_processes: int,
                           fn: Callable[..., R]) -> Dict[int, R]:
   """Runs `fn` in a separate thread on each visible device.
 
   Args:
-    rank: rank of current process
-    processes: number of processes on this host
+    process: rank of current process
+    local_processes: number of processes on this host
     fn: Function to run on all devices
 
   Returns:
@@ -155,7 +143,7 @@ def run_thread_per_device(rank: int, processes: int,
     result of calling `fn`.
   """
   if device_type() == 'TPU':
-    configure_tpu_topology(rank, processes)
+    tpu.configure_topology(process, local_processes)
 
   xm.set_replication(xm.xla_device(), xm.get_xla_supported_devices())
   threads = len(xm.get_xla_supported_devices())
@@ -165,8 +153,8 @@ def run_thread_per_device(rank: int, processes: int,
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
       # Assumes same number of threads per process
-      set_global_ordinal(rank * threads + device_index)
-      set_local_ordinal(rank * threads + device_index)
+      set_global_ordinal(tpu.task_id() * threads + device_index)
+      set_local_ordinal(process * threads + device_index)
 
       return fn(*args, **kwargs)
 

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -127,7 +127,7 @@ def run_thread_per_device(local_rank: int, local_world_size: int,
   """Runs `fn` in a separate thread on each visible device.
 
   Args:
-    local_process: rank of current process within this host
+    local_rank: rank of current process within this host
     local_world_size: number of processes on this host
     fn: Function to run on all devices
 

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -40,13 +40,6 @@ def using_pjrt() -> bool:
   return device_type() is not None
 
 
-def num_visible_tpu_chips(default: int = 4) -> int:
-  """Returns number of TPU chips visible to current process."""
-  visible_devices = xu.getenv_as(xenv.TPU_VISIBLE_DEVICES, str)
-
-  return len(visible_devices.split(',')) if visible_devices else default
-
-
 def requires_pjrt(fn: FN) -> FN:
   """Wraps `fn` and checks if this process is using PjRt.
 
@@ -187,7 +180,7 @@ def run_multiprocess(fn: Callable[..., R], *args,
     return_value is the result of calling `fn`.
   """
   if device_type() == 'TPU':
-    processes = num_visible_tpu_chips()
+    processes = tpu.num_local_processes()
   else:
     processes = 1
 

--- a/torch_xla/experimental/tpu.py
+++ b/torch_xla/experimental/tpu.py
@@ -1,0 +1,66 @@
+import cloud_tpu_client
+import os
+from typing import Optional, Iterable, Tuple
+import numpy as np
+import numpy.typing as npt
+import requests
+import yaml
+
+import torch_xla.utils.utils as xu
+import torch_xla.core.xla_env_vars as xenv
+
+_GCE_METADATA_ROOT_URL = 'http://metadata.google.internal/computeMetadata/v1'
+
+MeshShape = Tuple[int, int, int]
+
+def _parse_mesh_shape(mesh: str) -> MeshShape:
+  dims = tuple(int(d) for d in mesh.split(','))
+  if len(dims) != 3:
+    raise ValueError("Mesh shape '{}' should be length 3".format(mesh))
+
+  return dims
+
+def _multiple_mesh_shapes(mesh1: MeshShape, mesh2: MeshShape) -> MeshShape:
+  return tuple(d1 * d2 for d1, d2 in zip(mesh1, mesh2))
+
+def _get_metadata(key: str) -> str:
+  path = os.path.join(_GCE_METADATA_ROOT_URL, 'instance/attributes', key)
+  resp = requests.get(path, headers={'Metadata-Flavor': 'Google'})
+  resp.raise_for_status()
+
+  return resp.text
+
+def task_id() -> Optional[int]:
+  return xu.getenv_as(xenv.CLOUD_TPU_TASK_ID, int)
+
+def get_tpu_env():
+  metadata = _get_metadata('tpu-env')
+
+  return yaml.load(metadata, yaml.Loader)
+
+def configure_topology(local_rank: int, local_world_size: int, base_port: int = 8476):
+  tpu_env = get_tpu_env()
+
+  # Process bounds with 4 chips per process
+  default_process_bounds = _parse_mesh_shape(tpu_env[xenv.TPU_PROCESS_BOUNDS])
+  chips_per_process = _parse_mesh_shape(tpu_env[xenv.TPU_CHIPS_PER_PROCESS_BOUNDS])
+
+  # Process bounds with 1 chip per process
+  process_bounds = _multiple_mesh_shapes(default_process_bounds, chips_per_process)
+
+  os.environ.setdefault(xenv.TPU_CHIPS_PER_PROCESS_BOUNDS, '1,1,1')
+  os.environ.setdefault(xenv.TPU_PROCESS_BOUNDS, ','.join(str(dim) for dim in process_bounds))
+
+  # Assume each TPU has the same number of local processes with the same ports
+  worker_id = int(tpu_env['WORKER_ID'])
+  os.environ.setdefault(xenv.CLOUD_TPU_TASK_ID, str(worker_id * local_world_size + local_rank))
+
+  client = cloud_tpu_client.Client(tpu=tpu_env['NODE_ID'])
+  host_ips = [e['ipAddress'] for e in client.network_endpoints()]
+
+  ports = list(range(base_port, base_port + local_world_size))
+  process_endpoints = [','.join(f'{ip}:{port}' for port in ports) for ip in host_ips]
+  os.environ.setdefault(xenv.TPU_PROCESS_ADDRESSES, ','.join(process_endpoints))
+
+  os.environ.setdefault(xenv.TPU_VISIBLE_DEVICES, str(local_rank))
+  os.environ.setdefault(xenv.TPU_PROCESS_PORT, str(ports[local_rank]))

--- a/torch_xla/experimental/tpu.py
+++ b/torch_xla/experimental/tpu.py
@@ -25,6 +25,7 @@ _ACCELERATOR_TYPE_TO_HOST_BOUNDS = {
     'v3-512': '8,8,1',
     'v3-1024': '8,16,1',
     'v3-2048': '16,16,1',
+    # Get v4 host bounds from TPU metadata
 }
 
 

--- a/torch_xla/experimental/tpu.py
+++ b/torch_xla/experimental/tpu.py
@@ -54,7 +54,7 @@ def _get_metadata(key: str) -> str:
   return resp.text
 
 
-def num_processes(default: int = 4) -> Optional[int]:
+def num_processes(default: int = 1) -> int:
   """Returns number of processes across all TPU hosts."""
   process_bounds = xu.getenv_as(xenv.TPU_PROCESS_BOUNDS, str)
 
@@ -62,10 +62,10 @@ def num_processes(default: int = 4) -> Optional[int]:
       _parse_mesh_shape(process_bounds)) if process_bounds else default
 
 
-def num_local_processes() -> Optional[int]:
+def num_local_processes(local_chips: int = 4) -> int:
   """Returns number of processes to create on this host."""
-  # Don't create more processes than local chips (4)
-  return min(4, num_processes())
+  # Don't create more processes than local chips
+  return min(local_chips, num_processes(default=local_chips))
 
 
 def task_id() -> Optional[int]:

--- a/torch_xla/experimental/tpu.py
+++ b/torch_xla/experimental/tpu.py
@@ -1,10 +1,7 @@
 import functools
-
-
-import functools
 import operator
 import os
-from typing import Optional, List, Tuple
+from typing import Dict, Optional, List, Tuple
 import requests
 import yaml
 
@@ -41,12 +38,13 @@ def num_processes(default: int = 4) -> Optional[int]:
   return _mesh_size(_parse_mesh_shape(process_bounds)) if process_bounds else default
 
 def num_local_processes() -> Optional[int]:
+  # Don't create more processes than local chips (4)
   return min(4, num_processes())
 
 def task_id() -> Optional[int]:
   return xu.getenv_as(xenv.CLOUD_TPU_TASK_ID, int)
 
-def get_tpu_env():
+def get_tpu_env() -> Dict[str, str]:
   metadata = _get_metadata('tpu-env')
 
   return yaml.load(metadata, yaml.Loader)

--- a/torch_xla/experimental/tpu.py
+++ b/torch_xla/experimental/tpu.py
@@ -58,7 +58,7 @@ def _get_metadata(key: str) -> str:
   return resp.text
 
 
-def num_processes(default: int = 1) -> int:
+def process_bounds_size(default: int = 1) -> int:
   """Returns number of processes across all TPU hosts."""
   process_bounds = xu.getenv_as(xenv.TPU_PROCESS_BOUNDS, str)
 
@@ -69,7 +69,7 @@ def num_processes(default: int = 1) -> int:
 def num_local_processes(local_chips: int = 4) -> int:
   """Returns number of processes to create on this host."""
   # Don't create more processes than local chips
-  return min(local_chips, num_processes(default=local_chips))
+  return min(local_chips, process_bounds_size(default=local_chips))
 
 
 def task_id() -> Optional[int]:

--- a/torch_xla/experimental/tpu.py
+++ b/torch_xla/experimental/tpu.py
@@ -1,8 +1,5 @@
-import cloud_tpu_client
 import os
-from typing import Optional, Iterable, Tuple
-import numpy as np
-import numpy.typing as npt
+from typing import Optional, List, Tuple
 import requests
 import yaml
 
@@ -20,7 +17,7 @@ def _parse_mesh_shape(mesh: str) -> MeshShape:
 
   return dims
 
-def _multiple_mesh_shapes(mesh1: MeshShape, mesh2: MeshShape) -> MeshShape:
+def _multiply_mesh_shapes(mesh1: MeshShape, mesh2: MeshShape) -> MeshShape:
   return tuple(d1 * d2 for d1, d2 in zip(mesh1, mesh2))
 
 def _get_metadata(key: str) -> str:
@@ -38,6 +35,15 @@ def get_tpu_env():
 
   return yaml.load(metadata, yaml.Loader)
 
+def get_worker_ips() -> List[str]:
+  metadata = _get_metadata('worker-network-endpoints')
+
+  # Workers have format 'hostname:uid:ip,hostname:uid:ip,...'
+  workers = metadata.split(',')
+  ips = [worker.split(':')[2] for worker in workers]
+
+  return ips if len(ips) > 1 else ['localhost']
+
 def configure_topology(local_rank: int, local_world_size: int, base_port: int = 8476):
   tpu_env = get_tpu_env()
 
@@ -46,7 +52,7 @@ def configure_topology(local_rank: int, local_world_size: int, base_port: int = 
   chips_per_process = _parse_mesh_shape(tpu_env[xenv.TPU_CHIPS_PER_PROCESS_BOUNDS])
 
   # Process bounds with 1 chip per process
-  process_bounds = _multiple_mesh_shapes(default_process_bounds, chips_per_process)
+  process_bounds = _multiply_mesh_shapes(default_process_bounds, chips_per_process)
 
   os.environ.setdefault(xenv.TPU_CHIPS_PER_PROCESS_BOUNDS, '1,1,1')
   os.environ.setdefault(xenv.TPU_PROCESS_BOUNDS, ','.join(str(dim) for dim in process_bounds))
@@ -55,11 +61,10 @@ def configure_topology(local_rank: int, local_world_size: int, base_port: int = 
   worker_id = int(tpu_env['WORKER_ID'])
   os.environ.setdefault(xenv.CLOUD_TPU_TASK_ID, str(worker_id * local_world_size + local_rank))
 
-  client = cloud_tpu_client.Client(tpu=tpu_env['NODE_ID'])
-  host_ips = [e['ipAddress'] for e in client.network_endpoints()]
+  worker_ips = get_worker_ips()
 
   ports = list(range(base_port, base_port + local_world_size))
-  process_endpoints = [','.join(f'{ip}:{port}' for port in ports) for ip in host_ips]
+  process_endpoints = [','.join(f'{ip}:{port}' for port in ports) for ip in worker_ips]
   os.environ.setdefault(xenv.TPU_PROCESS_ADDRESSES, ','.join(process_endpoints))
 
   os.environ.setdefault(xenv.TPU_VISIBLE_DEVICES, str(local_rank))

--- a/torch_xla/experimental/tpu.py
+++ b/torch_xla/experimental/tpu.py
@@ -12,6 +12,7 @@ _GCE_METADATA_ROOT_URL = 'http://metadata.google.internal/computeMetadata/v1'
 
 MeshShape = Tuple[int, int, int]
 
+
 def _parse_mesh_shape(mesh: str) -> MeshShape:
   dims = tuple(int(d) for d in mesh.split(','))
   if len(dims) != 3:
@@ -19,11 +20,14 @@ def _parse_mesh_shape(mesh: str) -> MeshShape:
 
   return dims
 
+
 def _multiply_mesh_shapes(mesh1: MeshShape, mesh2: MeshShape) -> MeshShape:
   return tuple(d1 * d2 for d1, d2 in zip(mesh1, mesh2))
 
+
 def _mesh_size(mesh: MeshShape) -> int:
   return functools.reduce(operator.mul, mesh)
+
 
 def _get_metadata(key: str) -> str:
   path = os.path.join(_GCE_METADATA_ROOT_URL, 'instance/attributes', key)
@@ -32,22 +36,28 @@ def _get_metadata(key: str) -> str:
 
   return resp.text
 
+
 def num_processes(default: int = 4) -> Optional[int]:
   process_bounds = xu.getenv_as(xenv.TPU_PROCESS_BOUNDS, str)
 
-  return _mesh_size(_parse_mesh_shape(process_bounds)) if process_bounds else default
+  return _mesh_size(
+      _parse_mesh_shape(process_bounds)) if process_bounds else default
+
 
 def num_local_processes() -> Optional[int]:
   # Don't create more processes than local chips (4)
   return min(4, num_processes())
 
+
 def task_id() -> Optional[int]:
   return xu.getenv_as(xenv.CLOUD_TPU_TASK_ID, int)
+
 
 def get_tpu_env() -> Dict[str, str]:
   metadata = _get_metadata('tpu-env')
 
   return yaml.load(metadata, yaml.Loader)
+
 
 def get_worker_ips() -> List[str]:
   metadata = _get_metadata('worker-network-endpoints')
@@ -58,27 +68,36 @@ def get_worker_ips() -> List[str]:
 
   return ips if len(ips) > 1 else ['localhost']
 
-def configure_topology(local_rank: int, local_world_size: int, base_port: int = 8476):
+
+def configure_topology(local_rank: int,
+                       local_world_size: int,
+                       base_port: int = 8476):
   tpu_env = get_tpu_env()
 
   # Process bounds with 4 chips per process
   default_process_bounds = _parse_mesh_shape(tpu_env[xenv.TPU_PROCESS_BOUNDS])
-  chips_per_process = _parse_mesh_shape(tpu_env[xenv.TPU_CHIPS_PER_PROCESS_BOUNDS])
+  chips_per_process = _parse_mesh_shape(
+      tpu_env[xenv.TPU_CHIPS_PER_PROCESS_BOUNDS])
 
   # Process bounds with 1 chip per process
-  process_bounds = _multiply_mesh_shapes(default_process_bounds, chips_per_process)
+  process_bounds = _multiply_mesh_shapes(default_process_bounds,
+                                         chips_per_process)
 
   os.environ.setdefault(xenv.TPU_CHIPS_PER_PROCESS_BOUNDS, '1,1,1')
-  os.environ.setdefault(xenv.TPU_PROCESS_BOUNDS, ','.join(str(dim) for dim in process_bounds))
+  os.environ.setdefault(xenv.TPU_PROCESS_BOUNDS,
+                        ','.join(str(dim) for dim in process_bounds))
 
   # Assume each TPU has the same number of local processes with the same ports
   worker_id = int(tpu_env['WORKER_ID'])
-  os.environ.setdefault(xenv.CLOUD_TPU_TASK_ID, str(worker_id * local_world_size + local_rank))
+  os.environ.setdefault(xenv.CLOUD_TPU_TASK_ID,
+                        str(worker_id * local_world_size + local_rank))
 
   worker_ips = get_worker_ips()
 
   ports = list(range(base_port, base_port + local_world_size))
-  process_endpoints = [','.join(f'{ip}:{port}' for port in ports) for ip in worker_ips]
+  process_endpoints = [
+      ','.join(f'{ip}:{port}' for port in ports) for ip in worker_ips
+  ]
   os.environ.setdefault(xenv.TPU_PROCESS_ADDRESSES, ','.join(process_endpoints))
 
   os.environ.setdefault(xenv.TPU_VISIBLE_DEVICES, str(local_rank))


### PR DESCRIPTION
- Move TPU-specific logic from `pjrt.py` to `tpu.py`. All of this logic is broadly applicable to all TPU VMs and isn't strictly related to PjRt.
- Update `configure_topology` to support multiple hosts.
- Create unit tests for `tpu.py` (`test_experimental_tpu.py`). Everything that requires a TPU is mocked out, so this can run on CPU.
- Create short integration test for TPU (`test_experimental_pjrt_tpu.py`). This one initializes the TPU runtime in each test, so this must run on a TPU. Added configs for v3-8 and v4-8. Tested manually on both.

I know the naming of these two new tests is confusing. Let me know if you have alternate suggestions.

PJRT doesn't make a distinction between processes on different hosts, and we already support multiple processes on one host, so no low-level changes were necessary. This PR mainly deals with automatically configuring the TPU topology variables based on the environment.