### PR TITLE
Revert "Bump mistune from 0.8.4 to 2.0.3 in /docs"

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-mistune==2.0.3
+mistune==0.8.4
 sphinx==2.4.4
 docutils==0.16
 Jinja2<3.1


### PR DESCRIPTION
Reverts pytorch/xla#3807

Looks like this PR breaks `master` HEAD with the following error:

```
Exception occurred:
  File "/opt/conda/lib/python3.7/site-packages/m2r.py", line 59, in <module>
    class RestBlockGrammar(mistune.BlockGrammar):
AttributeError: module 'mistune' has no attribute 'BlockGrammar'
```