### PR TITLE
Lower randperm.generator_out

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2543,6 +2543,19 @@ at::Tensor& XLANativeFunctions::random_(
   return self;
 }
 
+at::Tensor& XLANativeFunctions::randperm_out(int64_t n, c10::optional<at::Generator> generator, at::Tensor & out) {
+  XLA_FN_COUNTER("xla::");
+  if (generator.has_value() && generator->defined()) {
+    return at::native::call_fallback_fn<&xla_cpu_fallback,
+                                        ATEN_OP(randperm_generator_out)>::call( // xw32: how can find the thing inside `ATEN_OP`.
+                                                                n, generator, out);
+  }
+
+  XLATensorPtr out_tensor = bridge::GetXlaTensor(out);
+  XLATensor::randperm_out(out_tensor, n);
+  return out;
+}
+
 at::Tensor XLANativeFunctions::reflection_pad2d(const at::Tensor& self,
                                                 at::IntArrayRef padding) {
   XLA_FN_COUNTER("xla::");

--- a/torch_xla/csrc/ops/randperm_out.cpp
+++ b/torch_xla/csrc/ops/randperm_out.cpp
@@ -1,0 +1,31 @@
+#include "torch_xla/csrc/ops/randperm_out.h"
+
+#include "torch_xla/csrc/lowering_context.h"
+#include "tensorflow/compiler/xla/xla_client/xla_util.h"
+#include "torch_xla/csrc/helpers.h"
+#include "torch_xla/csrc/lowering_context.h"
+#include "torch_xla/csrc/torch_util.h"
+
+namespace torch_xla {
+
+// xw32: should I include a xla::Shape param in the constructor?
+// xw32: what opkind should I use?
+// xw32: what does the shape param in the constructor mean?
+RandpermOut::RandpermOut(const torch::lazy::Value& n, const xla::Shape& shape)
+    : XlaNode(torch::lazy::OpKind(at::aten::randperm), {n},
+              shape,
+              /*num_outputs=*/1, torch::lazy::Hash(shape)) {}
+
+torch::lazy::NodePtr RandpermOut::Clone(
+    torch::lazy::OpList operands) const {
+        return torch::lazy::MakeNode<RandpermOut>(operands.at(0), xla_shape());
+}
+
+XlaOpVector RandpermOut::Lower(LoweringContext* loctx) const {
+    xla::XlaOp n = loctx->GetOutputOp(operand(0));
+    xla::XlaOp op_randperm_out = BuildRandpermOut(n, loctx->builder());
+    return ReturnOp(op_randperm_out, loctx);
+}
+
+
+} // namespace torch_xla

--- a/torch_xla/csrc/ops/randperm_out.cpp
+++ b/torch_xla/csrc/ops/randperm_out.cpp
@@ -4,6 +4,7 @@
 #include "tensorflow/compiler/xla/xla_client/xla_util.h"
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/lowering_context.h"
+#include "torch_xla/csrc/random.h"
 #include "torch_xla/csrc/torch_util.h"
 
 namespace torch_xla {
@@ -11,21 +12,26 @@ namespace torch_xla {
 // xw32: should I include a xla::Shape param in the constructor?
 // xw32: what opkind should I use?
 // xw32: what does the shape param in the constructor mean?
-RandpermOut::RandpermOut(const torch::lazy::Value& n, const xla::Shape& shape)
-    : XlaNode(torch::lazy::OpKind(at::aten::randperm), {n},
-              shape,
-              /*num_outputs=*/1, torch::lazy::Hash(shape)) {}
+RandpermOut::RandpermOut(int64_t n, const xla::Shape& shape)
+    : XlaNode(torch::lazy::OpKind(at::aten::randperm), torch::lazy::OpList(),
+              xla::ShapeUtil::MakeShape(xla::U64, {n}),
+              /*num_outputs=*/1, torch::lazy::MHash(n)),
+              n_(n) {}
 
 torch::lazy::NodePtr RandpermOut::Clone(
     torch::lazy::OpList operands) const {
-        return torch::lazy::MakeNode<RandpermOut>(operands.at(0), xla_shape());
+        return torch::lazy::MakeNode<RandpermOut>(n_, xla_shape());
 }
 
 XlaOpVector RandpermOut::Lower(LoweringContext* loctx) const {
-    xla::XlaOp n = loctx->GetOutputOp(operand(0));
-    xla::XlaOp op_randperm_out = BuildRandpermOut(n, loctx->builder());
+    xla::XlaOp op_randperm_out = BuildRandpermOut(n_, loctx->builder());
     return ReturnOp(op_randperm_out, loctx);
 }
 
+std::string RandpermOut::ToString() const {
+  std::stringstream ss;
+  ss << XlaNode::ToString() << ", n=(" << n_ << ")";
+  return ss.str();
+}
 
 } // namespace torch_xla

--- a/torch_xla/csrc/ops/randperm_out.h
+++ b/torch_xla/csrc/ops/randperm_out.h
@@ -7,11 +7,16 @@ namespace torch_xla {
 class RandpermOut : public XlaNode {
   public:
   // xw32: what does the shape mean here?
-  RandpermOut(const torch::lazy::Value& n, const xla::Shape& shape);
+  RandpermOut(int64_t n, const xla::Shape& shape);
 
   torch::lazy::NodePtr Clone(torch::lazy::OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
+
+  std::string ToString() const override;
+
+  private:
+   int64_t n_;
 };
 
 } // namespace torch_xla

--- a/torch_xla/csrc/ops/randperm_out.h
+++ b/torch_xla/csrc/ops/randperm_out.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "torch_xla/csrc/ir.h"
+
+namespace torch_xla {
+
+class RandpermOut : public XlaNode {
+  public:
+  // xw32: what does the shape mean here?
+  RandpermOut(const torch::lazy::Value& n, const xla::Shape& shape);
+
+  torch::lazy::NodePtr Clone(torch::lazy::OpList operands) const override;
+
+  XlaOpVector Lower(LoweringContext* loctx) const override;
+};
+
+} // namespace torch_xla

--- a/torch_xla/csrc/random.h
+++ b/torch_xla/csrc/random.h
@@ -13,4 +13,6 @@ xla::XlaOp RngDiscreteUniform(xla::XlaOp seed, const xla::Shape& shape,
 xla::XlaOp RngNormal(xla::XlaOp seed, const xla::Shape& shape, xla::XlaOp mean,
                      xla::XlaOp std);
 
+xla::XlaOp BuildRandpermOut(int64_t n, xla::XlaBuilder* builder);
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -959,6 +959,8 @@ class XLATensor : public c10::intrusive_ptr_target {
                                const torch::lazy::BackendDevice& device,
                                at::ScalarType scalar_type);
 
+  static void randperm_out(XLATensorPtr& input, int64_t n);
+
   static XLATensorPtr reflection_pad2d(const XLATensorPtr& input,
                                        std::vector<int64_t> padding);
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2220,8 +2220,7 @@ void XLATensor::random_(XLATensorPtr& input, int64_t from, int64_t to) {
 
 void XLATensor::randperm_out(XLATensorPtr& input, int64_t n) {
   auto input_shape = input->shape();
-  input->SetInPlaceIrValue(torch::lazy::MakeNode<RandpermOut>(
-    GetIrValueForScalar(n, xla::PrimitiveType::S64, input->GetDevice()), input_shape));
+  input->SetInPlaceIrValue(torch::lazy::MakeNode<RandpermOut>(n, input_shape));
 }
 
 XLATensorPtr XLATensor::reflection_pad2d(const XLATensorPtr& input,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -100,6 +100,7 @@
 #include "torch_xla/csrc/ops/prod.h"
 #include "torch_xla/csrc/ops/put.h"
 #include "torch_xla/csrc/ops/qr.h"
+#include "torch_xla/csrc/ops/randperm_out.h"
 #include "torch_xla/csrc/ops/recv.h"
 #include "torch_xla/csrc/ops/reduce_scatter.h"
 #include "torch_xla/csrc/ops/reflection_pad2d.h"
@@ -2215,6 +2216,12 @@ void XLATensor::random_(XLATensorPtr& input, int64_t from, int64_t to) {
       GetIrValueForScalar(from, xla::PrimitiveType::S64, input->GetDevice()),
       GetIrValueForScalar(to, xla::PrimitiveType::S64, input->GetDevice()),
       GetRngSeed(input->GetDevice()), input_shape));
+}
+
+void XLATensor::randperm_out(XLATensorPtr& input, int64_t n) {
+  auto input_shape = input->shape();
+  input->SetInPlaceIrValue(torch::lazy::MakeNode<RandpermOut>(
+    GetIrValueForScalar(n, xla::PrimitiveType::S64, input->GetDevice()), input_shape));
 }
 
 XLATensorPtr XLATensor::reflection_pad2d(const XLATensorPtr& input,

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -251,6 +251,7 @@ supported:
   - random_
   - random_.from
   - random_.to
+  - randperm.generator_out
   - reflection_pad2d
   - reflection_pad2d_backward
   - relu


### PR DESCRIPTION
Per this Github issue https://github.com/pytorch/xla/issues/3369, this PR intends to lower `randperm.generator_out`.