### PR TITLE
use XLA patched linear in FSDP (fix #3811 and #3718) and expose options on param sharding dim and pinning memory

### DIFF
--- a/test/test_train_mp_imagenet_fsdp.py
+++ b/test/test_train_mp_imagenet_fsdp.py
@@ -51,6 +51,10 @@ MODEL_OPTS = {
     '--fp32_reduce_scatter': {
         'action': 'store_true',
     },
+    '--no_padding_in_all_gather': {
+        'dest': 'use_padding_in_all_gather',
+        'action': 'store_false',
+    },
 }
 
 FLAGS = args_parse.parse_common_options(
@@ -219,7 +223,8 @@ def train_imagenet():
       m.to(device),
       compute_dtype=getattr(torch, FLAGS.compute_dtype),
       fp32_reduce_scatter=FLAGS.fp32_reduce_scatter,
-      flatten_parameters=FLAGS.flatten_parameters)
+      flatten_parameters=FLAGS.flatten_parameters,
+      use_padding_in_all_gather=FLAGS.use_padding_in_all_gather)
   # Apply gradient checkpointing to sub-modules if specified
   grad_ckpt_wrap = checkpoint_module if FLAGS.use_gradient_checkpointing else (
       lambda x: x)

--- a/test/test_train_mp_imagenet_fsdp.py
+++ b/test/test_train_mp_imagenet_fsdp.py
@@ -51,9 +51,11 @@ MODEL_OPTS = {
     '--fp32_reduce_scatter': {
         'action': 'store_true',
     },
-    '--no_padding_in_all_gather': {
-        'dest': 'use_padding_in_all_gather',
-        'action': 'store_false',
+    '--shard_param_on_dim_0': {
+        'action': 'store_true',
+    },
+    '--pin_layout_in_collective_ops': {
+        'action': 'store_true',
     },
 }
 
@@ -224,7 +226,8 @@ def train_imagenet():
       compute_dtype=getattr(torch, FLAGS.compute_dtype),
       fp32_reduce_scatter=FLAGS.fp32_reduce_scatter,
       flatten_parameters=FLAGS.flatten_parameters,
-      use_padding_in_all_gather=FLAGS.use_padding_in_all_gather)
+      shard_param_on_dim_0=FLAGS.shard_param_on_dim_0,
+      pin_layout_in_collective_ops=FLAGS.pin_layout_in_collective_ops)
   # Apply gradient checkpointing to sub-modules if specified
   grad_ckpt_wrap = checkpoint_module if FLAGS.use_gradient_checkpointing else (
       lambda x: x)

--- a/test/test_train_mp_mnist_fsdp_with_ckpt.py
+++ b/test/test_train_mp_mnist_fsdp_with_ckpt.py
@@ -25,9 +25,11 @@ MODEL_OPTS = {
     '--fp32_reduce_scatter': {
         'action': 'store_true',
     },
-    '--no_padding_in_all_gather': {
-        'dest': 'use_padding_in_all_gather',
-        'action': 'store_false',
+    '--shard_param_on_dim_0': {
+        'action': 'store_true',
+    },
+    '--pin_layout_in_collective_ops': {
+        'action': 'store_true',
     },
 }
 
@@ -157,7 +159,8 @@ def train_mnist(flags, **kwargs):
       compute_dtype=getattr(torch, flags.compute_dtype),
       fp32_reduce_scatter=flags.fp32_reduce_scatter,
       flatten_parameters=flags.flatten_parameters,
-      use_padding_in_all_gather=flags.use_padding_in_all_gather)
+      shard_param_on_dim_0=flags.shard_param_on_dim_0,
+      pin_layout_in_collective_ops=flags.pin_layout_in_collective_ops)
   # Apply gradient checkpointing to sub-modules if specified
   grad_ckpt_wrap = checkpoint_module if flags.use_gradient_checkpointing else (
       lambda x: x)

--- a/test/test_train_mp_mnist_fsdp_with_ckpt.py
+++ b/test/test_train_mp_mnist_fsdp_with_ckpt.py
@@ -25,6 +25,10 @@ MODEL_OPTS = {
     '--fp32_reduce_scatter': {
         'action': 'store_true',
     },
+    '--no_padding_in_all_gather': {
+        'dest': 'use_padding_in_all_gather',
+        'action': 'store_false',
+    },
 }
 
 FLAGS = args_parse.parse_common_options(
@@ -152,7 +156,8 @@ def train_mnist(flags, **kwargs):
       m.to(device),
       compute_dtype=getattr(torch, flags.compute_dtype),
       fp32_reduce_scatter=flags.fp32_reduce_scatter,
-      flatten_parameters=flags.flatten_parameters)
+      flatten_parameters=flags.flatten_parameters,
+      use_padding_in_all_gather=flags.use_padding_in_all_gather)
   # Apply gradient checkpointing to sub-modules if specified
   grad_ckpt_wrap = checkpoint_module if flags.use_gradient_checkpointing else (
       lambda x: x)

--- a/torch_xla/distributed/fsdp/state_dict_utils.py
+++ b/torch_xla/distributed/fsdp/state_dict_utils.py
@@ -22,9 +22,10 @@ def _consolidate_param(state_dict_list, shard_metadata, name, prefix, suffix):
     orig_size = p_info["_orig_size"]
 
   full_param = torch.cat(p_shard_list, dim=0)
-  try:
+  if full_param.dim() == 1:
+    # it's a flattened tensor as in the (usual) case with `shard_param_on_dim_0=False`
     full_param = full_param[:_numel(orig_size)].view(*orig_size)
-  except RuntimeError:
+  else:
     # handle those FSDP models trained with `shard_param_on_dim_0=True`
     full_param = full_param[:orig_size[0]]
 

--- a/torch_xla/distributed/fsdp/state_dict_utils.py
+++ b/torch_xla/distributed/fsdp/state_dict_utils.py
@@ -22,7 +22,11 @@ def _consolidate_param(state_dict_list, shard_metadata, name, prefix, suffix):
     orig_size = p_info["_orig_size"]
 
   full_param = torch.cat(p_shard_list, dim=0)
-  full_param = full_param[:_numel(orig_size)].view(*orig_size)
+  try:
+    full_param = full_param[:_numel(orig_size)].view(*orig_size)
+  except RuntimeError:
+    # handle those FSDP models trained with `shard_param_on_dim_0=True`
+    full_param = full_param[:orig_size[0]]
 
   full_name = orig_name
   if prefix != "":


### PR DESCRIPTION
This PR applies a patch to `nn.Linear` (`torch.nn.functional.linear`) in XLA FSDP so that the `nn.Linear`'s backward pass will use its weight parameter rather than an intermediate result. This resolves the issue in https://github.com/pytorch/xla/issues/3811 and https://github.com/pytorch/xla/issues/3718.

It is accomplished via ~a context manager `xla_patched_linear` around the forward pass~ a patch to the nn.Linear submodules's forward method in an FSDP-wrapped model (to be thread-safe in PJRT) that explicitly defines the backward behavior of `torch.nn.functional.linear` via `XLAPatchedLinear`.

Besides, it also has the following (backward-compatible) minor changes:
* ~expose `use_padding_in_all_gather` in FSDP `__init__` to allow turning off the padding to a multiple of 128 (for https://github.com/pytorch/xla/issues/3510#issuecomment-1101739677) since this sometimes does not work on a few compilers;~ expose `shard_param_on_dim_0` (default `False`). When `shard_param_on_dim_0` is set ``True``, then shard the parameter tensors only along their first dimension (dim 0) *without* flattening them. This can be a workaround for those compilers that may have trouble handling flattened parameters. This option has no effect if ``flatten_parameters`` is ``True``.
* expose `pin_layout_in_collective_ops` in FSDP `__init__` so that one can specify whether to pin layout in all_reduce, all_gather, and reduce_scatter in the FSDP class.
* remove the rendezvous in init that could be undesirable in some situations.

---

The MNIST and ImageNet examples are updated with the new optional flag `--shard_param_on_dim_0` and `--pin_layout_in_collective_ops`, which were tested on v3-8 TPU VM and working well.

The following two tests on MNIST and ImageNet are added to the FSDP test cases in https://github.com/pytorch/xla/pull/3431#issuecomment-1119737644

- [x] Test MNIST nested FSDP w/o padding in all-gather on v3-8
- [x] Test ImageNet ResNet-50 nested FSDP w/o padding in all-gather
- [x] Test ViT 10-billion model on v3-128 w/o gradient checkpointing

#### [OK] Test MNIST nested FSDP w/o padding in all-gather on v3-8

```bash
python3 -u ~/xla_fsdp_dev/test/test_train_mp_mnist_fsdp_with_ckpt.py \
  --batch_size 16 --drop_last --num_epochs 2 \
  --use_nested_fsdp --shard_param_on_dim_0 --pin_layout_in_collective_ops
```
**Results**: matching expected accuracy for 2 training epochs
```
found 8 checkpoint files in /tmp/mnist-fsdp/final_ckpt_rank-*-of-*.pth
saved consolidated model to /tmp/mnist-fsdp/final_ckpt_consolidated.pth
Checkpoint consolidated, Accuracy=98.92 (note: it can be slightly different from the final training accuracy due to non-sync BatchNorm2d in the model)
Max Accuracy: 98.88%
```

#### [pending] Test ImageNet ResNet-50 nested FSDP w/o padding in all-gather

```bash
python3 -u ~/xla_fsdp_dev/test/test_train_mp_imagenet_fsdp.py \
  --datadir /datasets/imagenet-1k --drop_last \
  --model resnet50 --test_set_batch_size 64 --eval_interval 10 \
  --lr 0.4 --batch_size 128 --num_warmup_epochs 5 --lr_scheduler_divide_every_n_epochs 30 --lr_scheduler_divisor 10 --num_epochs 100 \
  --use_nested_fsdp --shard_param_on_dim_0 --pin_layout_in_collective_ops
```

**Results**: matching expected accuracy for batch size 128
```
Max Accuracy: 75.97%
```

cc: @hjm-aws