### PR TITLE
Refactor PjRt device transfers to use `BufferFromHostBuffer`

### DIFF
--- a/third_party/xla_client/env_vars.cc
+++ b/third_party/xla_client/env_vars.cc
@@ -18,6 +18,8 @@ const char* const kEnvShardOrdinal = "XRT_SHARD_ORDINAL";
 const char* const kEnvStartService = "XRT_START_LOCAL_SERVER";
 const char* const kEnvTpuvmMode = "TPUVM_MODE";
 const char* const kEnvPjRtDevice = "PJRT_DEVICE";
+const char* const kEnvPjRtTpuMaxInflightComputations =
+    "PJRT_TPU_MAX_INFLIGHT_COMPUTATIONS";
 
 }  // namespace env
 }  // namespace xla

--- a/third_party/xla_client/env_vars.h
+++ b/third_party/xla_client/env_vars.h
@@ -19,6 +19,7 @@ extern const char* const kEnvShardOrdinal;
 extern const char* const kEnvStartService;
 extern const char* const kEnvTpuvmMode;
 extern const char* const kEnvPjRtDevice;
+extern const char* const kEnvPjRtTpuMaxInflightComputations;
 
 }  // namespace env
 }  // namespace xla

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -96,7 +96,8 @@ std::vector<ComputationClient::DataPtr> PjRtComputationClient::TransferToServer(
                 literal_pointer->untyped_data(),
                 literal_pointer->shape().element_type(),
                 literal_pointer->shape().dimensions(), byte_strides,
-                PjRtClient::HostBufferSemantics::kZeroCopy,
+                PjRtClient::HostBufferSemantics::
+                    kImmutableUntilTransferCompletes,
                 [literal{std::move(literal)}]() { /* frees literal */ },
                 pjrt_device)
             .ValueOrDie());

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -48,7 +48,9 @@ PjRtComputationClient::PjRtComputationClient() {
     client_ = std::move(xla::GetCpuClient(/*asynchronous=*/false).ValueOrDie());
   } else if (device_type == "TPU") {
     TF_VLOG(1) << "Initializing PjRt TPU client...";
-    client_ = xla::GetTpuClient(/*max_inflight_computations=*/1).ValueOrDie();
+    int64_t max_inflight_computations = sys_util::GetEnvInt(
+        env::kEnvPjRtTpuMaxInflightComputations, /*defval=*/32);
+    client_ = xla::GetTpuClient(max_inflight_computations).ValueOrDie();
   } else {
     XLA_ERROR() << absl::StrFormat("Unknown %s '%s'", env::kEnvPjRtDevice,
                                    device_type);
@@ -79,13 +81,26 @@ std::vector<ComputationClient::DataPtr> PjRtComputationClient::TransferToServer(
   std::vector<ComputationClient::DataPtr> datas;
   datas.reserve(tensors.size());
   for (auto& tensor : tensors) {
-    xla::Literal literal(tensor.shape);
-    tensor.populate_fn(tensor, literal.untyped_data(), literal.size_bytes());
-
     PjRtDevice* pjrt_device = StringToPjRtDevice(tensor.device);
-    std::shared_ptr<xla::PjRtBuffer> buffer =
-        client_->BufferFromHostLiteral(literal, pjrt_device).ValueOrDie();
-    buffer->GetReadyFuture().Await();
+
+    auto literal = std::make_shared<xla::Literal>(tensor.shape);
+    tensor.populate_fn(tensor, literal->untyped_data(), literal->size_bytes());
+    absl::InlinedVector<int64_t, 4> byte_strides(
+        literal->shape().dimensions_size());
+    ShapeUtil::ByteStrides(literal->shape(), absl::MakeSpan(byte_strides));
+
+    // Avoid use-after-free on `literal` due to unsequenced move and use.
+    xla::Literal* literal_pointer = literal.get();
+    std::shared_ptr<xla::PjRtBuffer> buffer = std::move(
+        client_
+            ->BufferFromHostBuffer(
+                literal_pointer->untyped_data(),
+                literal_pointer->shape().element_type(),
+                literal_pointer->shape().dimensions(), byte_strides,
+                PjRtClient::HostBufferSemantics::kZeroCopy,
+                [literal{std::move(literal)}]() { /* frees literal */ },
+                pjrt_device)
+            .ValueOrDie());
     ComputationClient::DataPtr data =
         std::make_shared<PjRtData>(tensor.device, tensor.shape, buffer);
     datas.push_back(data);

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -85,8 +85,7 @@ std::vector<ComputationClient::DataPtr> PjRtComputationClient::TransferToServer(
 
     auto literal = std::make_shared<xla::Literal>(tensor.shape);
     tensor.populate_fn(tensor, literal->untyped_data(), literal->size_bytes());
-    absl::InlinedVector<int64_t, 4> byte_strides(
-        literal->shape().dimensions_size());
+    std::vector<int64_t> byte_strides(literal->shape().dimensions_size());
     ShapeUtil::ByteStrides(literal->shape(), absl::MakeSpan(byte_strides));
 
     // Avoid use-after-free on `literal` due to unsequenced move and use.
@@ -101,6 +100,7 @@ std::vector<ComputationClient::DataPtr> PjRtComputationClient::TransferToServer(
                 [literal{std::move(literal)}]() { /* frees literal */ },
                 pjrt_device)
             .ValueOrDie());
+
     ComputationClient::DataPtr data =
         std::make_shared<PjRtData>(tensor.device, tensor.shape, buffer);
     datas.push_back(data);


### PR DESCRIPTION
- Remove call to `Await()` while still keeping `literal` alive for the duration of the transfer.
- Bump `max_inflight_computations` to the [same default value as JAX](https://github.com/tensorflow/tensorflow/blob/44e84cebef5a89a0840f8d401819c25af41ec3db/tensorflow/compiler/xla/python/xla_client.py#L101). Otherwise, performance drops slightly on v4-8 based on my testing.

Based on [`CopyToDevice` implementation in PjRt itself](https://github.com/tensorflow/tensorflow/blob/a37ac96c6eefe809003f29a815b915bfed5ad36b/tensorflow/compiler/xla/pjrt/pjrt_stream_executor_client.cc#L1491-L1501).

Tested with ResNet50+fake data on v4-8 and got comparable (if not slightly better) performance.
