### PR TITLE
Codegen  `all` op and rename existing `all` op to all_dim

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -669,20 +669,11 @@ at::Tensor XLANativeFunctions::alias(const at::Tensor& self) {
   return self;
 }
 
-at::Tensor XLANativeFunctions::all(const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  XLATensorPtr self_tensor = bridge::GetXlaTensor(self);
-  return bridge::AtenFromXlaTensor(XLATensor::all(
-      self_tensor,
-      torch::lazy::Iota<int64_t>(self_tensor->shape().get().rank()),
-      /*keep_reduced_dimensions=*/false));
-}
-
 at::Tensor XLANativeFunctions::all(const at::Tensor& self, int64_t dim,
                                    bool keepdim) {
   XLA_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(
-      XLATensor::all(bridge::GetXlaTensor(self), {dim}, keepdim));
+      XLATensor::all_dim(bridge::GetXlaTensor(self), {dim}, keepdim));
 }
 
 at::Tensor XLANativeFunctions::amax(const at::Tensor& self, at::IntArrayRef dim,

--- a/torch_xla/csrc/ops/all_dim.cpp
+++ b/torch_xla/csrc/ops/all_dim.cpp
@@ -1,4 +1,4 @@
-#include "torch_xla/csrc/ops/all.h"
+#include "torch_xla/csrc/ops/all_dim.h"
 
 #include "absl/strings/str_join.h"
 #include "torch_xla/csrc/helpers.h"
@@ -23,8 +23,8 @@ xla::Shape NodeOutputShape(const torch::lazy::Value& input,
 
 }  // namespace
 
-All::All(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
-         bool keep_reduced_dimensions)
+AllDim::AllDim(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
+               bool keep_reduced_dimensions)
     : XlaNode(torch::lazy::OpKind(at::aten::all), {input},
               NodeOutputShape(input, dimensions, keep_reduced_dimensions),
               /*num_outputs=*/1,
@@ -32,18 +32,18 @@ All::All(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
       dimensions_(std::move(dimensions)),
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
-torch::lazy::NodePtr All::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<All>(operands.at(0), dimensions_,
-                                    keep_reduced_dimensions_);
+torch::lazy::NodePtr AllDim::Clone(torch::lazy::OpList operands) const {
+  return torch::lazy::MakeNode<AllDim>(operands.at(0), dimensions_,
+                                       keep_reduced_dimensions_);
 }
 
-XlaOpVector All::Lower(LoweringContext* loctx) const {
+XlaOpVector AllDim::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
   return ReturnOp(BuildAll(input, dimensions_, keep_reduced_dimensions_),
                   loctx);
 }
 
-std::string All::ToString() const {
+std::string AllDim::ToString() const {
   std::stringstream ss;
   ss << XlaNode::ToString() << ", dimensions=("
      << absl::StrJoin(dimensions_, ", ")

--- a/torch_xla/csrc/ops/all_dim.h
+++ b/torch_xla/csrc/ops/all_dim.h
@@ -7,10 +7,10 @@
 
 namespace torch_xla {
 
-class All : public XlaNode {
+class AllDim : public XlaNode {
  public:
-  All(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
-      bool keep_reduced_dimensions);
+  AllDim(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
+         bool keep_reduced_dimensions);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -53,6 +53,13 @@ torch_xla::XlaOpVector AdaptiveAvgPool3dBackward::Lower(
   return ReturnOp(xla_output, loctx);
 }
 
+torch_xla::XlaOpVector All::Lower(LoweringContext* loctx) const {
+  xla::XlaOp input = loctx->GetOutputOp(operand(0));
+  std::vector<int64_t> dimensions =
+      torch::lazy::Iota<int64_t>(XlaHelpers::ShapeOfXlaOp(input).rank());
+  return ReturnOp(BuildAll(input, dimensions, false), loctx);
+}
+
 torch_xla::XlaOpVector Asin::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   return ReturnOp(xla::Asin(xla_input), loctx);

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -80,6 +80,17 @@ xla::Shape AdaptiveAvgPool3dBackwardOutputShape(
                           lower_for_shape_fn);
 }
 
+xla::Shape AllOutputShape(const torch::lazy::Value& input) {
+  std::vector<int64_t> dimensions =
+      torch::lazy::Iota<int64_t>(GetXlaShape(input).rank());
+  auto lower_for_shape_fn =
+      [dimensions](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
+    return BuildAll(operands[0], dimensions, false);
+  };
+
+  return InferOutputShape({GetXlaShape(input)}, lower_for_shape_fn);
+}
+
 xla::Shape AsinOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -21,6 +21,8 @@ xla::Shape AdaptiveAvgPool3dOutputShape(const torch::lazy::Value& input,
 xla::Shape AdaptiveAvgPool3dBackwardOutputShape(
     const torch::lazy::Value& grad_output, const torch::lazy::Value& input);
 
+xla::Shape AllOutputShape(const torch::lazy::Value& input);
+
 xla::Shape AsinOutputShape(const torch::lazy::Value& input);
 
 xla::Shape AsinhOutputShape(const torch::lazy::Value& input);

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -375,9 +375,9 @@ class XLATensor : public c10::intrusive_ptr_target {
                             const XLATensorPtr& weight,
                             const XLATensorPtr& bias);
 
-  static XLATensorPtr all(const XLATensorPtr& input,
-                          std::vector<int64_t> dimensions,
-                          bool keep_reduced_dimensions);
+  static XLATensorPtr all_dim(const XLATensorPtr& input,
+                              std::vector<int64_t> dimensions,
+                              bool keep_reduced_dimensions);
 
   static XLATensorPtr amax(const XLATensorPtr& input,
                            std::vector<int64_t> dimensions,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -22,7 +22,7 @@
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/ops/adam_optimizer_step.h"
 #include "torch_xla/csrc/ops/adaptive_max_pool2d.h"
-#include "torch_xla/csrc/ops/all.h"
+#include "torch_xla/csrc/ops/all_dim.h"
 #include "torch_xla/csrc/ops/all_gather.h"
 #include "torch_xla/csrc/ops/all_reduce.h"
 #include "torch_xla/csrc/ops/all_to_all.h"
@@ -698,19 +698,19 @@ XLATensorPtr XLATensor::addmm(const XLATensorPtr& input,
       input->GetIrValue(), weight->GetIrValue(), bias->GetIrValue()));
 }
 
-XLATensorPtr XLATensor::all(const XLATensorPtr& input,
-                            std::vector<int64_t> dimensions,
-                            bool keep_reduced_dimensions) {
+XLATensorPtr XLATensor::all_dim(const XLATensorPtr& input,
+                                std::vector<int64_t> dimensions,
+                                bool keep_reduced_dimensions) {
   at::ScalarType result_type = input->dtype() == at::ScalarType::Byte
                                    ? at::ScalarType::Byte
                                    : at::ScalarType::Bool;
-  return input->CreateFrom(
-      torch::lazy::MakeNode<All>(input->GetIrValue(),
-                                 torch::lazy::GetCanonicalDimensionIndices(
-                                     xla::util::ToVector<int64_t>(dimensions),
-                                     input->shape().get().rank()),
-                                 keep_reduced_dimensions),
-      result_type);
+  return input->CreateFrom(torch::lazy::MakeNode<AllDim>(
+                               input->GetIrValue(),
+                               torch::lazy::GetCanonicalDimensionIndices(
+                                   xla::util::ToVector<int64_t>(dimensions),
+                                   input->shape().get().rank()),
+                               keep_reduced_dimensions),
+                           result_type);
 }
 
 XLATensorPtr XLATensor::amax(const XLATensorPtr& input,

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -4,6 +4,7 @@ full_codegen:
   - acos
   - acosh
   - abs
+  - all
   - asin
   - asinh
   - atan
@@ -91,7 +92,6 @@ supported:
   - addcmul
   - addmm
   - alias
-  - all
   - all.dim
   - amax
   - amin


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/3859

---

1. Codegen  `all` op 
2. Rename existing  `all` op to `all_dim`

---
LazyIr.h:
```
class All : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::all);
  }

  All(const torch::lazy::Value& self, std::vector<torch::lazy::Shape>&& shapes)
      : XlaNode(torch::lazy::OpKind(at::aten::all),
              {self}, std::move(shapes),
              [&]() { return AllOutputShape(self); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
  {
    
  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();
    
    return ss.str();
  }

  

  bool CanBeReused(const torch::lazy::Value& self) const {
    return false;
    }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;

  
  

};
```
---
XLANativeFunctions.cpp:
```
    at::Tensor XLANativeFunctions::all(const at::Tensor & self) {
        
        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self);
        TORCH_INTERNAL_ASSERT(common_device);
        
        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        torch::lazy::NodePtr node = torch::lazy::ReuseNode<All>(lazy_self->GetIrValue());
        if (!node) {
                    auto self_meta = to_meta(self);
        auto out_meta = at::meta::all(self_meta);
        
std::vector<torch::lazy::Shape> shapes{torch::lazy::Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
            TORCH_INTERNAL_ASSERT(shapes.size() == 1);
            if(torch::lazy::symbolicShapeEnabled()){
                std::vector<torch::jit::IValue> inputs = { self };
                const char* schema_str = "aten::all(Tensor self) -> Tensor";
                applySymbolicShapesOnLT(schema_str, inputs, shapes);
            }
        
            node = torch::lazy::MakeNode<All>(lazy_self->GetIrValue(), std::move(shapes));
            CacheNode(node);
        }
        
        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };
```