### PR TITLE
Add profiler traces to `PjRtComputationClient`

### DIFF
--- a/test/pjrt/test_profiler.py
+++ b/test/pjrt/test_profiler.py
@@ -24,7 +24,10 @@ def _profile(logdir: str, port: int = 9012):
 class TestPjRtProfiler(absltest.TestCase):
 
   def setUp(self):
-    pjrt.set_device_type('CPU')
+    assert pjrt.using_pjrt()
+
+    # HACK: ensure libtpu is loaded if using TPU
+    xm.xla_device()
 
   def test_profiler_output(self):
     tempdir = self.create_tempdir().full_path

--- a/test/pjrt/test_profiler.py
+++ b/test/pjrt/test_profiler.py
@@ -27,6 +27,7 @@ def _profile(logdir: str, port: int = 9012):
 
   del server
 
+
 class TestPjRtProfiler(absltest.TestCase):
 
   def setUp(self):

--- a/test/pjrt/test_profiler.py
+++ b/test/pjrt/test_profiler.py
@@ -1,0 +1,56 @@
+import codecs
+import contextlib
+import glob
+import os
+import threading
+
+from absl.testing import absltest
+import torch
+import torch_xla.core.xla_model as xm
+import torch_xla.experimental.pjrt as pjrt
+import torch_xla.debug.profiler as xp
+
+
+@contextlib.contextmanager
+def _profile(logdir: str, port: int = 9012):
+  server = xp.start_server(port)
+
+  tracer = threading.Thread(target=xp.trace, args=(f'localhost:{port}', logdir))
+  tracer.setDaemon(True)
+  tracer.start()
+  yield
+
+
+class TestPjRtProfiler(absltest.TestCase):
+
+  def setUp(self):
+    pjrt.set_device_type('CPU')
+
+  def test_profiler_output(self):
+    tempdir = self.create_tempdir().full_path
+
+    with _profile(tempdir):
+      device = xm.xla_device()
+      ones = torch.ones([5])
+
+      xones = ones.to(device)
+      xtwos = xones + xones
+      xm.mark_step()
+
+    profiles = glob.glob(os.path.join(tempdir, "plugins/profile/*/*.xplane.pb"))
+    self.assertLen(profiles, 1, "one .xplane.pb file expected")
+
+    profile = profiles[0]
+    with open(profile, 'rb') as file:
+      # Profile is a binary protobuf. Throw away non-ASCII content so we can
+      # search for trace names
+      content = file.read()
+      ascii_content = codecs.decode(content, 'ascii', errors='ignore')
+
+      expected_methods = ('TransferToServer', 'Compile', 'ExecuteComputation')
+      for method in (f'PjRtComputationClient::{m}' for m in expected_methods):
+        self.assertIn(method, ascii_content)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -109,7 +109,6 @@ function run_op_tests {
   run_test python3 "$CDIR/test_torch_distributed_xla_backend.py"
   run_xla_ir_debug python3 "$CDIR/test_env_var_mapper.py"
   run_pjrt python3 "$CDIR/pjrt/test_experimental_pjrt.py"
-  run_pjrt python3 "$CDIR/pjrt/test_profiler.py"
 }
 
 function run_mp_op_tests {

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -109,6 +109,7 @@ function run_op_tests {
   run_test python3 "$CDIR/test_torch_distributed_xla_backend.py"
   run_xla_ir_debug python3 "$CDIR/test_env_var_mapper.py"
   run_pjrt python3 "$CDIR/pjrt/test_experimental_pjrt.py"
+  run_pjrt python3 "$CDIR/pjrt/test_profiler.py"
 }
 
 function run_mp_op_tests {

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -15,6 +15,7 @@
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/env_vars.h"
 #include "tensorflow/compiler/xla/xla_client/tf_logging.h"
+#include "tensorflow/core/profiler/lib/traceme.h"
 
 namespace xla {
 
@@ -78,6 +79,8 @@ ComputationClient::DataPtr PjRtComputationClient::CreateDataPlaceholder(
 
 std::vector<ComputationClient::DataPtr> PjRtComputationClient::TransferToServer(
     absl::Span<const TensorSource> tensors) {
+  tensorflow::profiler::TraceMe activity(
+    "PjRtComputationClient::TransferToServer", tensorflow::profiler::TraceMeLevel::kInfo);
   std::vector<ComputationClient::DataPtr> datas;
   datas.reserve(tensors.size());
   for (auto& tensor : tensors) {
@@ -112,6 +115,8 @@ std::vector<ComputationClient::DataPtr> PjRtComputationClient::TransferToServer(
 
 std::vector<xla::Literal> PjRtComputationClient::TransferFromServer(
     absl::Span<const DataPtr> handles) {
+  tensorflow::profiler::TraceMe activity(
+    "PjRtComputationClient::TransferFromServer", tensorflow::profiler::TraceMeLevel::kInfo);
   std::vector<xla::Literal> literals;
   literals.reserve(handles.size());
 
@@ -128,6 +133,8 @@ std::vector<xla::Literal> PjRtComputationClient::TransferFromServer(
 
 std::vector<ComputationClient::ComputationPtr> PjRtComputationClient::Compile(
     std::vector<ComputationClient::CompileInstance> instances) {
+  tensorflow::profiler::TraceMe activity(
+    "PjRtComputationClient::Compile", tensorflow::profiler::TraceMeLevel::kInfo);
   std::vector<ComputationClient::ComputationPtr> computations;
 
   for (auto& instance : instances) {
@@ -157,6 +164,8 @@ PjRtComputationClient::ExecuteComputation(
     const ComputationClient::Computation& computation,
     absl::Span<const ComputationClient::DataPtr> arguments,
     const std::string& device, const ExecuteComputationOptions& options) {
+  tensorflow::profiler::TraceMe activity(
+    "PjRtComputationClient::ExecuteComputation", tensorflow::profiler::TraceMeLevel::kInfo);
   TF_VLOG(1) << "Executing PjRt computation on " << device;
   const PjRtComputation& pjrt_computation =
       dynamic_cast<const PjRtComputation&>(computation);


### PR DESCRIPTION
The existing profiler works out of the box because the traces work the same way. Tested manually with TensorBoard:

![image](https://user-images.githubusercontent.com/15197278/184006131-e6cba40d-6ca8-45c3-a4b7-91477a8f84a2.png)
