### PR TITLE
Codegen clamp_min.Tensor and clamp_max.Tensor

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1060,13 +1060,6 @@ at::Tensor XLANativeFunctions::clamp_min(const at::Tensor& self,
       XLATensor::clamp(bridge::GetXlaTensor(self), min, c10::nullopt));
 }
 
-at::Tensor XLANativeFunctions::clamp_min(const at::Tensor& self,
-                                         const at::Tensor& min) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(
-      XLATensor::clamp(bridge::GetXlaTensor(self), min, c10::nullopt));
-}
-
 at::Tensor XLANativeFunctions::clone(
     const at::Tensor& self,
     c10::optional<at::MemoryFormat> /* memory_format */) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1053,13 +1053,6 @@ at::Tensor XLANativeFunctions::clamp_max(const at::Tensor& self,
       XLATensor::clamp(bridge::GetXlaTensor(self), c10::nullopt, max));
 }
 
-at::Tensor XLANativeFunctions::clamp_max(const at::Tensor& self,
-                                         const at::Tensor& max) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(
-      XLATensor::clamp(bridge::GetXlaTensor(self), c10::nullopt, max));
-}
-
 at::Tensor XLANativeFunctions::clamp_min(const at::Tensor& self,
                                          const at::Scalar& min) {
   XLA_FN_COUNTER("xla::");

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -118,6 +118,12 @@ torch_xla::XlaOpVector ClampMaxTensor::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::Min(xla_input, xla_other), loctx);
 }
 
+torch_xla::XlaOpVector ClampMinTensor::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  xla::XlaOp xla_other = loctx->GetOutputOp(operand(1));
+  return ReturnOp(xla::Max(xla_input, xla_other), loctx);
+}
+
 torch_xla::XlaOpVector Cos::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   return ReturnOp(xla::Cos(xla_input), loctx);

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -112,6 +112,12 @@ torch_xla::XlaOpVector Ceil::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::Ceil(xla_input), loctx);
 }
 
+torch_xla::XlaOpVector ClampMaxTensor::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  xla::XlaOp xla_other = loctx->GetOutputOp(operand(1));
+  return ReturnOp(xla::Min(xla_input, xla_other), loctx);
+}
+
 torch_xla::XlaOpVector Cos::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   return ReturnOp(xla::Cos(xla_input), loctx);

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -153,6 +153,15 @@ xla::Shape CeilOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
+xla::Shape ClampMaxTensorOutputShape(const torch::lazy::Value& input, const torch::lazy::Value& other) {
+  auto lower_for_shape_fn =
+      [](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
+    return xla::Min(operands[0], operands[1]);    
+  };
+  return InferOutputShape({GetXlaShape(input), GetXlaShape(other)},
+                          lower_for_shape_fn);
+}
+
 xla::Shape CosOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -153,19 +153,21 @@ xla::Shape CeilOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
-xla::Shape ClampMaxTensorOutputShape(const torch::lazy::Value& input, const torch::lazy::Value& other) {
+xla::Shape ClampMaxTensorOutputShape(const torch::lazy::Value& input,
+                                     const torch::lazy::Value& other) {
   auto lower_for_shape_fn =
       [](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
-    return xla::Min(operands[0], operands[1]);    
+    return xla::Min(operands[0], operands[1]);
   };
   return InferOutputShape({GetXlaShape(input), GetXlaShape(other)},
                           lower_for_shape_fn);
 }
 
-xla::Shape ClampMinTensorOutputShape(const torch::lazy::Value& input, const torch::lazy::Value& other) {
+xla::Shape ClampMinTensorOutputShape(const torch::lazy::Value& input,
+                                     const torch::lazy::Value& other) {
   auto lower_for_shape_fn =
       [](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
-    return xla::Max(operands[0], operands[1]);    
+    return xla::Max(operands[0], operands[1]);
   };
   return InferOutputShape({GetXlaShape(input), GetXlaShape(other)},
                           lower_for_shape_fn);

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -162,6 +162,15 @@ xla::Shape ClampMaxTensorOutputShape(const torch::lazy::Value& input, const torc
                           lower_for_shape_fn);
 }
 
+xla::Shape ClampMinTensorOutputShape(const torch::lazy::Value& input, const torch::lazy::Value& other) {
+  auto lower_for_shape_fn =
+      [](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
+    return xla::Max(operands[0], operands[1]);    
+  };
+  return InferOutputShape({GetXlaShape(input), GetXlaShape(other)},
+                          lower_for_shape_fn);
+}
+
 xla::Shape CosOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -44,6 +44,8 @@ xla::Shape CeilOutputShape(const torch::lazy::Value& input);
 
 xla::Shape ClampMaxTensorOutputShape(const torch::lazy::Value& input, const torch::lazy::Value& target);
 
+xla::Shape ClampMinTensorOutputShape(const torch::lazy::Value& input, const torch::lazy::Value& target);
+
 xla::Shape CosOutputShape(const torch::lazy::Value& input);
 
 xla::Shape CoshOutputShape(const torch::lazy::Value& input);

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -42,6 +42,8 @@ xla::Shape BinaryCrossEntropyBackwardOutputShape(
 
 xla::Shape CeilOutputShape(const torch::lazy::Value& input);
 
+xla::Shape ClampMaxTensorOutputShape(const torch::lazy::Value& input, const torch::lazy::Value& target);
+
 xla::Shape CosOutputShape(const torch::lazy::Value& input);
 
 xla::Shape CoshOutputShape(const torch::lazy::Value& input);

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -42,9 +42,11 @@ xla::Shape BinaryCrossEntropyBackwardOutputShape(
 
 xla::Shape CeilOutputShape(const torch::lazy::Value& input);
 
-xla::Shape ClampMaxTensorOutputShape(const torch::lazy::Value& input, const torch::lazy::Value& target);
+xla::Shape ClampMaxTensorOutputShape(const torch::lazy::Value& input,
+                                     const torch::lazy::Value& target);
 
-xla::Shape ClampMinTensorOutputShape(const torch::lazy::Value& input, const torch::lazy::Value& target);
+xla::Shape ClampMinTensorOutputShape(const torch::lazy::Value& input,
+                                     const torch::lazy::Value& target);
 
 xla::Shape CosOutputShape(const torch::lazy::Value& input);
 

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -13,6 +13,7 @@ full_codegen:
   - binary_cross_entropy_backward
   - ceil
   - clamp_max.Tensor
+  - clamp_min.Tensor
   - cos
   - cosh
   - erf
@@ -129,7 +130,6 @@ supported:
   - clamp.Tensor
   - clamp_max
   - clamp_min
-  - clamp_min.Tensor
   - clone
   - constant_pad_nd
   - convolution_backward_overrideable

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -12,6 +12,7 @@ full_codegen:
   - binary_cross_entropy
   - binary_cross_entropy_backward
   - ceil
+  - clamp_max.Tensor
   - cos
   - cosh
   - erf
@@ -127,7 +128,6 @@ supported:
   - clamp
   - clamp.Tensor
   - clamp_max
-  - clamp_max.Tensor
   - clamp_min
   - clamp_min.Tensor
   - clone


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/3862 and https://github.com/pytorch/xla/issues/3863

---
Codegen `clamp_min.Tensor` and `clamp_max.Tensor`

---
Lazy.ir:
```
class ClampMaxTensor : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::clamp_max);
  }

  ClampMaxTensor(const torch::lazy::Value& self, const torch::lazy::Value& max, std::vector<torch::lazy::Shape>&& shapes)
      : XlaNode(torch::lazy::OpKind(at::aten::clamp_max),
              {self, max}, std::move(shapes),
              [&]() { return ClampMaxTensorOutputShape(self, max); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
  {
    
  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();
    
    return ss.str();
  }

  

  bool CanBeReused(const torch::lazy::Value& self, const torch::lazy::Value& max) const {
    return false;
    }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;

  
  

};

class ClampMinTensor : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::clamp_min);
  }

  ClampMinTensor(const torch::lazy::Value& self, const torch::lazy::Value& min, std::vector<torch::lazy::Shape>&& shapes)
      : XlaNode(torch::lazy::OpKind(at::aten::clamp_min),
              {self, min}, std::move(shapes),
              [&]() { return ClampMinTensorOutputShape(self, min); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
  {
    
  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();
    
    return ss.str();
  }

  

  bool CanBeReused(const torch::lazy::Value& self, const torch::lazy::Value& min) const {
    return false;
    }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;

  
  

};
```
---
XLANativeFunctions.cpp:
```
    at::Tensor XLANativeFunctions::clamp_max(const at::Tensor & self, const at::Tensor & max) {
        
        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self, max);
        TORCH_INTERNAL_ASSERT(common_device);
        
        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        torch_xla::XLATensorPtr lazy_max = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(max, *common_device);
        torch::lazy::NodePtr node = torch::lazy::ReuseNode<ClampMaxTensor>(lazy_self->GetIrValue(), lazy_max->GetIrValue());
        if (!node) {
                    auto self_meta = to_meta(self);
        auto max_meta = to_meta(max);
        auto out_meta = at::meta::clamp_max(self_meta, max_meta);
        
std::vector<torch::lazy::Shape> shapes{torch::lazy::Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
            TORCH_INTERNAL_ASSERT(shapes.size() == 1);
            if(torch::lazy::symbolicShapeEnabled()){
                std::vector<torch::jit::IValue> inputs = { self, max };
                const char* schema_str = "aten::clamp_max.Tensor(Tensor self, Tensor max) -> Tensor";
                applySymbolicShapesOnLT(schema_str, inputs, shapes);
            }
        
            node = torch::lazy::MakeNode<ClampMaxTensor>(lazy_self->GetIrValue(), lazy_max->GetIrValue(), std::move(shapes));
            CacheNode(node);
        }
        
        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };

    
    at::Tensor XLANativeFunctions::clamp_min(const at::Tensor & self, const at::Tensor & min) {
        
        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self, min);
        TORCH_INTERNAL_ASSERT(common_device);
        
        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        torch_xla::XLATensorPtr lazy_min = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(min, *common_device);
        torch::lazy::NodePtr node = torch::lazy::ReuseNode<ClampMinTensor>(lazy_self->GetIrValue(), lazy_min->GetIrValue());
        if (!node) {
                    auto self_meta = to_meta(self);
        auto min_meta = to_meta(min);
        auto out_meta = at::meta::clamp_min(self_meta, min_meta);
        
std::vector<torch::lazy::Shape> shapes{torch::lazy::Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
            TORCH_INTERNAL_ASSERT(shapes.size() == 1);
            if(torch::lazy::symbolicShapeEnabled()){
                std::vector<torch::jit::IValue> inputs = { self, min };
                const char* schema_str = "aten::clamp_min.Tensor(Tensor self, Tensor min) -> Tensor";
                applySymbolicShapesOnLT(schema_str, inputs, shapes);
            }
        
            node = torch::lazy::MakeNode<ClampMinTensor>(lazy_self->GetIrValue(), lazy_min->GetIrValue(), std::move(shapes));
            CacheNode(node);
        }
        
        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };
```