### PR TITLE
Codegen clamp.Tensor

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1038,14 +1038,6 @@ at::Tensor XLANativeFunctions::clamp(const at::Tensor& self,
       XLATensor::clamp(bridge::GetXlaTensor(self), min, max));
 }
 
-at::Tensor XLANativeFunctions::clamp(const at::Tensor& self,
-                                     const c10::optional<at::Tensor>& min,
-                                     const c10::optional<at::Tensor>& max) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(
-      XLATensor::clamp(bridge::GetXlaTensor(self), min, max));
-}
-
 at::Tensor XLANativeFunctions::clamp_max(const at::Tensor& self,
                                          const at::Scalar& max) {
   XLA_FN_COUNTER("xla::");

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -116,6 +116,10 @@ torch_xla::XlaOpVector ClampTensor::Lower(LoweringContext* loctx) const {
   XLA_CHECK(has_min || has_max)
       << "At least one of \'min\' or \'max\' must not be None";
 
+  // This is little bit ugly due to min and max tensors being optional,
+  // and operand[1] can be either min or max:
+  // if !has_min and has_max -> operand[1] is max
+  // if has_min and !has_max -> operand[1] is min
   xla::XlaOp res = loctx->GetOutputOp(operand(0));
   if (has_min && has_max) {
     auto promoted_min =

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -112,6 +112,17 @@ torch_xla::XlaOpVector Ceil::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::Ceil(xla_input), loctx);
 }
 
+torch_xla::XlaOpVector ClampTensor::Lower(LoweringContext* loctx) const {
+  xla::XlaOp res = loctx->GetOutputOp(operand(0));
+  if (has_min) {
+    res = xla::Max(res, loctx->GetOutputOp(operand(1)));
+  }
+  if (has_max) {
+    res = xla::Min(res, loctx->GetOutputOp(operand(2)));
+  }
+  return ReturnOp(res, loctx);
+}
+
 torch_xla::XlaOpVector ClampMaxTensor::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   xla::XlaOp xla_other = loctx->GetOutputOp(operand(1));

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -157,12 +157,18 @@ xla::Shape ClampTensorOutputShape(
     const torch::lazy::Value& input,
     const c10::optional<torch::lazy::Value>& min,
     const c10::optional<torch::lazy::Value>& max) {
+  // This shape function works in a bit of an odd/hacky way. 
+  // If operands.size() > 1, operands[1] can be either min or 
+  // max since they are both optional values. But in this code, 
+  // we are always assuming operands[1] to be min if 
+  // operands.size() > 1. This code works because xla::Min and 
+  // xla::Max produce the same output shapes.
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     xla::XlaOp res = operands[0];
     if (operands.size() > 1) {
       auto promoted = XlaHelpers::Promote(res, operands[1]);
-      res = xla::Max(promoted.first, promoted.second);
+      res = xla::Max(promoted.first, promoted.second);  
     }
     if (operands.size() > 2) {
       auto promoted = XlaHelpers::Promote(res, operands[2]);

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -157,18 +157,18 @@ xla::Shape ClampTensorOutputShape(
     const torch::lazy::Value& input,
     const c10::optional<torch::lazy::Value>& min,
     const c10::optional<torch::lazy::Value>& max) {
-  // This shape function works in a bit of an odd/hacky way. 
-  // If operands.size() > 1, operands[1] can be either min or 
-  // max since they are both optional values. But in this code, 
-  // we are always assuming operands[1] to be min if 
-  // operands.size() > 1. This code works because xla::Min and 
+  // This shape function works in a bit of an odd/hacky way.
+  // If operands.size() > 1, operands[1] can be either min or
+  // max since they are both optional values. But in this code,
+  // we are always assuming operands[1] to be min if
+  // operands.size() > 1. This code works because xla::Min and
   // xla::Max produce the same output shapes.
   auto lower_for_shape_fn =
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     xla::XlaOp res = operands[0];
     if (operands.size() > 1) {
       auto promoted = XlaHelpers::Promote(res, operands[1]);
-      res = xla::Max(promoted.first, promoted.second);  
+      res = xla::Max(promoted.first, promoted.second);
     }
     if (operands.size() > 2) {
       auto promoted = XlaHelpers::Promote(res, operands[2]);

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -161,10 +161,12 @@ xla::Shape ClampTensorOutputShape(
       [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
     xla::XlaOp res = operands[0];
     if (operands.size() > 1) {
-      res = xla::Max(res, operands[1]);
+      auto promoted = XlaHelpers::Promote(res, operands[1]);
+      res = xla::Max(promoted.first, promoted.second);
     }
     if (operands.size() > 2) {
-      res = xla::Min(res, operands[2]);
+      auto promoted = XlaHelpers::Promote(res, operands[2]);
+      res = xla::Min(promoted.first, promoted.second);
     }
     return res;
   };

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -42,6 +42,10 @@ xla::Shape BinaryCrossEntropyBackwardOutputShape(
 
 xla::Shape CeilOutputShape(const torch::lazy::Value& input);
 
+xla::Shape ClampTensorOutputShape(const torch::lazy::Value& input,
+                                  const c10::optional<torch::lazy::Value>& min,
+                                  const c10::optional<torch::lazy::Value>& max);
+
 xla::Shape ClampMaxTensorOutputShape(const torch::lazy::Value& input,
                                      const torch::lazy::Value& target);
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1010,23 +1010,6 @@ XLATensorPtr XLATensor::clamp(const XLATensorPtr& input,
       Clamp(input->GetIrValue(), min_max.min, min_max.max));
 }
 
-XLATensorPtr XLATensor::clamp(const XLATensorPtr& input,
-                              const c10::optional<at::Tensor>& min,
-                              const c10::optional<at::Tensor>& max) {
-  XLA_CHECK(min || max)
-      << "At least one of \'min\' or \'max\' must not be None";
-  torch::lazy::Value res = input->GetIrValue();
-  if (min) {
-    res = torch::lazy::MakeNode<Maximum>(
-        res, bridge::GetXlaTensor(*min)->GetIrValue(),
-        std::vector<torch::lazy::Shape>());
-  }
-  if (max) {
-    res = Min(res, bridge::GetXlaTensor(*max)->GetIrValue());
-  }
-  return input->CreateFrom(res);
-}
-
 XLATensorPtr XLATensor::clone(const XLATensorPtr& input) {
   return input->CreateFrom(input->GetIrValue());
 }

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -12,6 +12,7 @@ full_codegen:
   - binary_cross_entropy
   - binary_cross_entropy_backward
   - ceil
+  - clamp.Tensor
   - clamp_max.Tensor
   - clamp_min.Tensor
   - cos
@@ -131,7 +132,6 @@ supported:
   - celu_
   - cholesky
   - clamp
-  - clamp.Tensor
   - clamp_max
   - clamp_min
   - clone


### PR DESCRIPTION
FIxes https://github.com/pytorch/xla/issues/3861

Codegen clamp.Tensor

---
LazyIr.h:
```
class ClampTensor : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::clamp);
  }

  ClampTensor(const torch::lazy::Value& self, const c10::optional<torch::lazy::Value>& min, const c10::optional<torch::lazy::Value>& max, std::vector<torch::lazy::Shape>&& shapes)
      : XlaNode(torch::lazy::OpKind(at::aten::clamp),
              {self, min.value_or(kNullValue), max.value_or(kNullValue)}, std::move(shapes),
              [&]() { return ClampTensorOutputShape(self, min, max); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
  {
    has_min = !!min;
    has_max = !!max;
  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();
    
    return ss.str();
  }

  

  bool CanBeReused(const torch::lazy::Value& self, const c10::optional<torch::lazy::Value>& min, const c10::optional<torch::lazy::Value>& max) const {
    return false;
    }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;

  
  bool has_min: 1;
  bool has_max: 1;

};
```

---
XLANativeFunctions.cpp:
```
    at::Tensor XLANativeFunctions::clamp_max(const at::Tensor & self, const at::Tensor & max) {
        
        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self, max);
        TORCH_INTERNAL_ASSERT(common_device);
        
        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        torch_xla::XLATensorPtr lazy_max = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(max, *common_device);
        torch::lazy::NodePtr node = torch::lazy::ReuseNode<ClampMaxTensor>(lazy_self->GetIrValue(), lazy_max->GetIrValue());
        if (!node) {
                    auto self_meta = to_meta(self);
        auto max_meta = to_meta(max);
        auto out_meta = at::meta::clamp_max(self_meta, max_meta);
        
std::vector<torch::lazy::Shape> shapes{torch::lazy::Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
            TORCH_INTERNAL_ASSERT(shapes.size() == 1);
            if(torch::lazy::symbolicShapeEnabled()){
                std::vector<torch::jit::IValue> inputs = { self, max };
                const char* schema_str = "aten::clamp_max.Tensor(Tensor self, Tensor max) -> Tensor";
                applySymbolicShapesOnLT(schema_str, inputs, shapes);
            }
        
            node = torch::lazy::MakeNode<ClampMaxTensor>(lazy_self->GetIrValue(), lazy_max->GetIrValue(), std::move(shapes));
            CacheNode(node);
        }
        
        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };
```