### PR TITLE
Codegen elu and elu_

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1157,24 +1157,6 @@ at::Tensor XLANativeFunctions::dot(const at::Tensor& self,
       bridge::GetXlaTensor(self), bridge::GetXlaTensor(tensor)));
 }
 
-at::Tensor XLANativeFunctions::elu(const at::Tensor& self,
-                                   const at::Scalar& alpha,
-                                   const at::Scalar& scale,
-                                   const at::Scalar& input_scale) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(
-      XLATensor::elu(bridge::GetXlaTensor(self), alpha, scale, input_scale));
-}
-
-at::Tensor& XLANativeFunctions::elu_(at::Tensor& self, const at::Scalar& alpha,
-                                     const at::Scalar& scale,
-                                     const at::Scalar& input_scale) {
-  XLA_FN_COUNTER("xla::");
-  XLATensorPtr self_tensor = bridge::GetXlaTensor(self);
-  XLATensor::elu_(self_tensor, alpha, scale, input_scale);
-  return self;
-}
-
 at::Tensor XLANativeFunctions::elu_backward(const at::Tensor& grad_output,
                                             const at::Scalar& alpha,
                                             const at::Scalar& scale,

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -373,6 +373,9 @@ xla::XlaOp BuildLogSigmoidBackward(xla::XlaOp grad_output, xla::XlaOp input,
 xla::XlaOp BuildElu(xla::XlaOp input, xla::XlaOp alpha, xla::XlaOp scale,
                     xla::XlaOp input_scale) {
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(input);
+  alpha = MaybeConvertTo(alpha, shape.element_type());
+  scale = MaybeConvertTo(scale, shape.element_type());
+  input_scale = MaybeConvertTo(input_scale, shape.element_type());
   xla::XlaOp scaled_input = input * input_scale;
   xla::XlaOp zero = xla::Zero(input.builder(), shape.element_type());
   xla::XlaOp one = XlaHelpers::ScalarValue<float>(1.0, shape.element_type(),

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -370,22 +370,16 @@ xla::XlaOp BuildLogSigmoidBackward(xla::XlaOp grad_output, xla::XlaOp input,
   return grad_output * (xla::Neg(max_deriv) - sign * (buffer - one) / buffer);
 }
 
-xla::XlaOp BuildElu(xla::XlaOp input, const at::Scalar& alpha,
-                    const at::Scalar& scale, const at::Scalar& input_scale) {
+xla::XlaOp BuildElu(xla::XlaOp input, xla::XlaOp alpha, xla::XlaOp scale,
+                    xla::XlaOp input_scale) {
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(input);
-  xla::XlaOp scaled_input =
-      input * XlaHelpers::ScalarValue(input_scale, shape.element_type(),
-                                      input.builder());
+  xla::XlaOp scaled_input = input * input_scale;
   xla::XlaOp zero = xla::Zero(input.builder(), shape.element_type());
   xla::XlaOp one = XlaHelpers::ScalarValue<float>(1.0, shape.element_type(),
                                                   input.builder());
-  xla::XlaOp alpha_scalar =
-      XlaHelpers::ScalarValue(alpha, shape.element_type(), input.builder());
-  xla::XlaOp scale_scalar =
-      XlaHelpers::ScalarValue(scale, shape.element_type(), input.builder());
   return xla::Select(xla::Le(input, zero),
-                     alpha_scalar * (xla::Exp(scaled_input) - one), input) *
-         scale_scalar;
+                     alpha * (xla::Exp(scaled_input) - one), input) *
+         scale;
 }
 
 xla::XlaOp BuildEluBackward(xla::XlaOp grad_output, xla::XlaOp output,

--- a/torch_xla/csrc/elementwise.h
+++ b/torch_xla/csrc/elementwise.h
@@ -97,8 +97,8 @@ xla::XlaOp BuildLogSigmoidBackward(xla::XlaOp grad_output, xla::XlaOp input,
                                    xla::XlaOp buffer);
 
 // Computes the Elu function of input.
-xla::XlaOp BuildElu(xla::XlaOp input, const at::Scalar& alpha,
-                    const at::Scalar& scale, const at::Scalar& input_scale);
+xla::XlaOp BuildElu(xla::XlaOp input, xla::XlaOp alpha, xla::XlaOp scale,
+                    xla::XlaOp input_scale);
 
 // Computes the backward of Elu.
 xla::XlaOp BuildEluBackward(xla::XlaOp grad_output, xla::XlaOp output,

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -532,18 +532,6 @@ torch::lazy::NodePtr Identity(int64_t lines, int64_t cols,
                    torch::lazy::MHash(lines, cols));
 }
 
-torch::lazy::NodePtr Elu(const torch::lazy::Value& input,
-                         const at::Scalar& alpha, const at::Scalar& scale,
-                         const at::Scalar& input_scale) {
-  auto lower_fn = [=](const XlaNode& node,
-                      LoweringContext* loctx) -> XlaOpVector {
-    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
-    return node.ReturnOp(BuildElu(xla_input, alpha, scale, input_scale), loctx);
-  };
-  return GenericOp(torch::lazy::OpKind(at::aten::elu), {input},
-                   GetXlaShape(input), std::move(lower_fn));
-}
-
 torch::lazy::NodePtr EluBackward(const torch::lazy::Value& grad_output,
                                  const torch::lazy::Value& output,
                                  const at::Scalar& alpha,

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -175,10 +175,6 @@ torch::lazy::NodePtr Norm(const torch::lazy::Value& input,
 torch::lazy::NodePtr Identity(int64_t lines, int64_t cols,
                               xla::PrimitiveType element_type);
 
-torch::lazy::NodePtr Elu(const torch::lazy::Value& input,
-                         const at::Scalar& alpha, const at::Scalar& scale,
-                         const at::Scalar& input_scale);
-
 torch::lazy::NodePtr EluBackward(const torch::lazy::Value& grad_output,
                                  const torch::lazy::Value& output,
                                  const at::Scalar& alpha,

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -189,6 +189,15 @@ torch_xla::XlaOpVector Cosh::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::Cosh(xla_input), loctx);
 }
 
+torch_xla::XlaOpVector Elu::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  xla::XlaOp xla_alpha = loctx->GetOutputOp(operand(1));
+  xla::XlaOp xla_scale = loctx->GetOutputOp(operand(2));
+  xla::XlaOp xla_input_scale = loctx->GetOutputOp(operand(3));
+  return ReturnOp(BuildElu(xla_input, xla_alpha, xla_scale, xla_input_scale),
+                  loctx);
+}
+
 torch_xla::XlaOpVector Erf::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   return ReturnOp(xla::Erf(xla_input), loctx);

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -256,6 +256,13 @@ xla::Shape CoshOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
+xla::Shape EluOutputShape(const torch::lazy::Value& input,
+                          const torch::lazy::Value& alpha,
+                          const torch::lazy::Value& scale,
+                          const torch::lazy::Value& input_scale) {
+  return GetXlaShape(input);
+}
+
 xla::Shape ErfOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -72,6 +72,11 @@ xla::Shape CosOutputShape(const torch::lazy::Value& input);
 
 xla::Shape CoshOutputShape(const torch::lazy::Value& input);
 
+xla::Shape EluOutputShape(const torch::lazy::Value& input,
+                          const torch::lazy::Value& alpha,
+                          const torch::lazy::Value& scale,
+                          const torch::lazy::Value& input_scale);
+
 xla::Shape ErfOutputShape(const torch::lazy::Value& input);
 
 xla::Shape ErfcOutputShape(const torch::lazy::Value& input);

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -550,11 +550,6 @@ class XLATensor : public c10::intrusive_ptr_target {
   static XLATensorPtr einsum(const std::string& equation,
                              absl::Span<const XLATensorPtr> tensors);
 
-  static XLATensorPtr elu(const XLATensorPtr& input, const at::Scalar& alpha,
-                          const at::Scalar& scale,
-                          const at::Scalar& input_scale);
-  static void elu_(XLATensorPtr& input, const at::Scalar& alpha,
-                   const at::Scalar& scale, const at::Scalar& input_scale);
   static XLATensorPtr elu_backward(const XLATensorPtr& grad_output,
                                    const at::Scalar& alpha,
                                    const at::Scalar& scale,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1151,17 +1151,6 @@ XLATensorPtr XLATensor::eq(const XLATensorPtr& input,
   return DispatchComparisonOp(at::aten::eq, input, other);
 }
 
-XLATensorPtr XLATensor::elu(const XLATensorPtr& input, const at::Scalar& alpha,
-                            const at::Scalar& scale,
-                            const at::Scalar& input_scale) {
-  return input->CreateFrom(Elu(input->GetIrValue(), alpha, scale, input_scale));
-}
-
-void XLATensor::elu_(XLATensorPtr& input, const at::Scalar& alpha,
-                     const at::Scalar& scale, const at::Scalar& input_scale) {
-  input->SetInPlaceIrValue(Elu(input->GetIrValue(), alpha, scale, input_scale));
-}
-
 XLATensorPtr XLATensor::elu_backward(const XLATensorPtr& grad_output,
                                      const at::Scalar& alpha,
                                      const at::Scalar& scale,

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -21,6 +21,7 @@ full_codegen:
   - clamp_min.Tensor
   - cos
   - cosh
+  - elu
   - erf
   - erfc
   - erfinv
@@ -150,8 +151,6 @@ supported:
   - div.Tensor
   - div.Tensor_mode
   - dot
-  - elu
-  - elu_
   - elu_backward
   - embedding
   - embedding_dense_backward


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/3894

---
Codegen elu and elu_ 

---
LazyIr.h:
```
class Elu : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::elu);
  }

  Elu(const torch::lazy::Value& self, const torch::lazy::Value& alpha, const torch::lazy::Value& scale, const torch::lazy::Value& input_scale, std::vector<torch::lazy::Shape>&& shapes)
      : XlaNode(torch::lazy::OpKind(at::aten::elu),
              {self, alpha, scale, input_scale}, std::move(shapes),
              [&]() { return EluOutputShape(self, alpha, scale, input_scale); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
  {
    
  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();
    
    return ss.str();
  }

  

  bool CanBeReused(const torch::lazy::Value& self, const torch::lazy::Value& alpha, const torch::lazy::Value& scale, const torch::lazy::Value& input_scale) const {
    return false;
    }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;

  
  

};
```

---
XLANativeFunctions.cpp:
```
    at::Tensor XLANativeFunctions::elu(const at::Tensor & self, const at::Scalar & alpha, const at::Scalar & scale, const at::Scalar & input_scale) {
        
        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self);
        TORCH_INTERNAL_ASSERT(common_device);
        
        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        auto node_alpha = torch::lazy::LazyGraphExecutor::Get()->
                            GetIrValueForScalarFromCodegen(alpha, *common_device);
        auto node_scale = torch::lazy::LazyGraphExecutor::Get()->
                            GetIrValueForScalarFromCodegen(scale, *common_device);
        auto node_input_scale = torch::lazy::LazyGraphExecutor::Get()->
                            GetIrValueForScalarFromCodegen(input_scale, *common_device);
        torch::lazy::NodePtr node = torch::lazy::ReuseNode<Elu>(lazy_self->GetIrValue(), node_alpha, node_scale, node_input_scale);
        if (!node) {
                    auto self_meta = to_meta(self);
        auto out_meta = at::meta::elu(self_meta, alpha, scale, input_scale);
        
std::vector<torch::lazy::Shape> shapes{torch::lazy::Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
            TORCH_INTERNAL_ASSERT(shapes.size() == 1);
            if(torch::lazy::symbolicShapeEnabled()){
                std::vector<torch::jit::IValue> inputs = { self, alpha, scale, input_scale };
                const char* schema_str = "aten::elu(Tensor self, Scalar alpha=1, Scalar scale=1, Scalar input_scale=1) -> Tensor";
                applySymbolicShapesOnLT(schema_str, inputs, shapes);
            }
        
            node = torch::lazy::MakeNode<Elu>(lazy_self->GetIrValue(), node_alpha, node_scale, node_input_scale, std::move(shapes));
            CacheNode(node);
        }
        
        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    };
```