### PR TITLE
Fix shallowCopy logical_element type issue

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1824,6 +1824,14 @@ class TestAtenXlaTensor(XlaTestCase):
     assert 'prim::Constant' in const_hlo
     assert 'xla::device_data' not in const_hlo
 
+  def test_emb_bf16(self):
+    xla_device = xm.xla_device()
+    index = torch.ones(1, dtype=torch.long, device=xla_device)
+    emb = torch.nn.Embedding(1024, 128, device=xla_device)
+    emb = emb.to(torch.bfloat16)
+    emb_out = emb(index)
+    assert emb_out.dtype == torch.bfloat16
+
 
 class MNISTComparator(nn.Module):
 

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -940,6 +940,7 @@ at::Tensor XLATensor::ToTensor(bool detached) {
 }
 
 void XLATensor::ShallowCopyTo(XLATensorPtr dest) const {
+  dest->SetScalarType(data()->logical_element_type);
   dest->SetIrValue(GetIrValue(), /*inplace=*/false);
 }
 


### PR DESCRIPTION
This is to fix https://github.com/pytorch/xla/issues/3886