### PR TITLE
[WIP] Reproduce `nan` loss with DDP and XLA backend

### DIFF
--- a/test/pjrt/test_ddp.py
+++ b/test/pjrt/test_ddp.py
@@ -1,0 +1,126 @@
+from absl.testing import absltest, parameterized
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.optim as optim
+from torch.nn.parallel import DistributedDataParallel as DDP
+import torch_xla.core.xla_model as xm
+import torch_xla.distributed.xla_backend
+from torch_xla.experimental import pjrt
+
+class ToyModel(nn.Module):
+    def __init__(self):
+        super(ToyModel, self).__init__()
+        self.net1 = nn.Linear(10, 10)
+        self.relu = nn.ReLU()
+        self.net2 = nn.Linear(10, 5)
+
+    def forward(self, x):
+        return self.net2(self.relu(self.net1(x)))
+
+def _init_xla_backend(init_file: str):
+  # TODO: fix these
+  rank = xm.get_ordinal()
+  world_size = xm.xrt_world_size()
+
+  dist.init_process_group(
+    "xla",
+    init_method=f"file://{init_file}",
+    rank=rank,
+    world_size=world_size)
+
+class TestPjRtDistributedDataParallel(parameterized.TestCase):
+
+  @staticmethod
+  def _ddp_step(init_file: str):
+    _init_xla_backend(init_file)
+
+    device = xm.xla_device()
+    model = ToyModel().to(device)
+    ddp_model = DDP(model)
+
+    loss_fn = nn.MSELoss()
+    optimizer = optim.SGD(ddp_model.parameters(), lr=0.001)
+
+    optimizer.zero_grad()
+    outputs = ddp_model(torch.randn(20, 10, device=device))
+
+    labels = torch.randn(20, 5).to(device)
+    loss_fn(outputs, labels).backward()
+    optimizer.step()
+
+  def test_ddp_step(self):
+    pjrt.run_multiprocess(
+      self._ddp_step,
+      self.create_tempfile().full_path)
+
+  @staticmethod
+  def _ddp_loss(init_file: str, barrier: bool):
+    _init_xla_backend(init_file)
+
+    device = xm.xla_device()
+
+    model = nn.Linear(10, 10).to(device)
+    model = DDP(model)
+
+    optimizer = optim.SGD(model.parameters(), lr=1e-100)
+    loss_fn = nn.MSELoss()
+
+    for step in range(100):
+      x = torch.ones(20, 10, device=device)
+      labels = torch.zeros(20, 10, device=device)
+      if barrier:
+        xm.mark_step()
+
+      optimizer.zero_grad()
+      outputs = model(x)
+      loss = loss_fn(outputs, labels)
+      loss.backward()
+
+      optimizer.step()
+
+      if not loss.isfinite():
+        raise ValueError('infinite loss ({}) on step {}'.format(loss, step))
+
+  @parameterized.named_parameters(("barrier", True), ("nobarrier", False))
+  def test_ddp_loss(self, barrier):
+    pjrt.run_multiprocess(
+      self._ddp_loss,
+      self.create_tempfile().full_path,
+      barrier)
+
+  @staticmethod
+  def _ddp_loss_nosync(init_file: str):
+    _init_xla_backend(init_file)
+
+    device = xm.xla_device()
+
+    model = nn.Linear(10, 10).to(device)
+    model = DDP(model)
+
+    optimizer = optim.SGD(model.parameters(), lr=1e-100)
+    loss_fn = nn.MSELoss()
+
+    for step in range(100):
+      x = torch.ones(20, 10, device=device)
+      labels = torch.zeros(20, 10, device=device)
+      xm.mark_step()
+
+      with model.no_sync():
+        outputs = model(x)
+        loss = loss_fn(outputs, labels)
+        loss.backward()
+
+      xm.optimizer_step(optimizer, pin_layout=False)
+
+      if not loss.isfinite():
+        raise ValueError('infinite loss ({}) on step {}'.format(loss, step))
+
+  def test_ddp_loss_nosync(self):
+    pjrt.run_multiprocess(
+      self._ddp_loss_nosync,
+      self.create_tempfile().full_path)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/torch_patches/X10-xla-tensor-storage.diff
+++ b/torch_patches/X10-xla-tensor-storage.diff
@@ -1,0 +1,13 @@
+diff --git a/aten/src/ATen/core/TensorBase.h b/aten/src/ATen/core/TensorBase.h
+index e6dd7365..c80b7dc0 100644
+--- a/aten/src/ATen/core/TensorBase.h
++++ b/aten/src/ATen/core/TensorBase.h
+@@ -326,7 +326,7 @@ class TORCH_API TensorBase {
+     return impl_->storage();
+   }
+   bool is_alias_of(const at::TensorBase& other) const{
+-    return impl_->storage().is_alias_of(other.storage());
++    return is_xla() ? false : impl_->storage().is_alias_of(other.storage());
+   }
+ 
+   inline bool _is_zerotensor() const {

--- a/torch_xla/distributed/xla_backend.py
+++ b/torch_xla/distributed/xla_backend.py
@@ -70,7 +70,7 @@ class ProcessGroupXla(ProcessGroup):
     xm.all_reduce(reduce_type, tensors, groups=self._mesh, pin_layout=False)
     return _ret_work(tensors)
 
-  def allgather(self, output_tensors_list, input_tensors):
+  def allgather(self, output_tensors_list, input_tensors, opts=None):
     for input_tensor, output_tensors in zip(input_tensors, output_tensors_list):
       result = xm.all_gather(input_tensor, groups=self._mesh, pin_layout=False)
       for i, slice in enumerate(torch.split(result, input_tensor.shape[0])):
@@ -82,10 +82,8 @@ class ProcessGroupXla(ProcessGroup):
   # https://github.com/pytorch/pytorch/blob/release/1.10/torch/distributed/distributed_c10d.py#L1129
   def broadcast(self, tensors, opts):
     root_tensor = tensors[opts.rootTensor]
-    root_rank = opts.rootRank
-    if root_rank != self.rank():
-      with torch.no_grad():
-        root_tensor.zero_()
+    scale = 1 if opts.rootRank != self.rank() else 0
+    root_tensor = root_tensor * scale
     xm.all_reduce(
         xm.REDUCE_SUM, [root_tensor], groups=self._mesh, pin_layout=False)
 


### PR DESCRIPTION
See #3625

- Add [`opts` argument](https://github.com/pytorch/pytorch/blob/a85d1f0bcdd02cf18d3b0517337458cb51a18cdb/torch/_C/_distributed_c10d.pyi#L212-L217) to `allgather` to fix `TypeError: allgather() takes 3 positional arguments but 4 were given` during initialization
- Refactor `broadcast` to produce the same graph on all replicas to avoid hanging on `REDUCE_SUM`.
- Add patch for PyTorch to avoid `RuntimeError: .../tensor_impl.cpp:181 : XLA tensors do not have storage` when it calls `is_alias_of`

Although I can get a model to initialize with DDP, the loss consistently goes to `nan`. I found that the gradient increased a little more than 4x after each iteration on a v4-8 (4 devices), suggesting that the gradient is not getting reset after each iteration and is just accumulating infinitely. Once the parameters become unstable, the loss becomes `nan`. It is unclear if this is related to the hack I'm using to fix the crash in `is_alias_of`.

@JackCaoG performed some experiments and found that the IR changed after the first steps:

<details>

<summary>IR for the first 4 steps and comments by @JackCaoG</summary>

```
IR {
  %0 = f32[] xla::device_data(), device=TPU:0
  %1 = s64[1]{0} xla::device_data(), device=TPU:0
  %2 = (s64[4]{0}, f32[]) xla::all_gather(%1, %0), num_outputs=2, dim=0, shard_count=4, pin_layout=0, groups=()
  %3 = s64[] prim::Constant(), value=1
  %4 = s64[6]{0} xla::device_data(), device=TPU:0
  %5 = s64[6]{0} aten::mul(%4, %3)
  %6 = (s64[6]{0}, f32[]) xla::cross_replica_sum(%5, %2.1), num_outputs=2, reduce_type=0, scale=1, pin_layout=0, groups=()
  %7 = f32[] prim::Constant(), value=1
  %8 = f32[10]{0} xla::device_data(), device=TPU:0
  %9 = f32[10]{0} aten::view(%8), output_size=(10)
  %10 = f32[10,10]{1,0} xla::device_data(), device=TPU:0
  %11 = f32[100]{0} aten::view(%10), output_size=(100)
  %12 = f32[110]{0} aten::cat(%11, %9), dim=0, dtype=Float
  %13 = f32[110]{0} aten::mul(%12, %7)
  %14 = (f32[110]{0}, f32[]) xla::cross_replica_sum(%13, %6.1), num_outputs=2, reduce_type=0, scale=1, pin_layout=0, groups=()
  %15 = f32[] xla::device_data(), device=TPU:0
  %16 = f32[] prim::Constant(), value=0
  %17 = f32[20,10]{1,0} aten::expand(%16), size=(20, 10)
  %18 = f32[10]{0} xla::select(%12), dim=0, start=100, end=110, stride=1
  %19 = f32[10]{0} aten::view(%18), output_size=(10)
  %20 = f32[100]{0} xla::select(%12), dim=0, start=0, end=100, stride=1
  %21 = f32[10,10]{1,0} aten::view(%20), output_size=(10, 10)
  %22 = f32[10,10]{0,1} aten::permute(%21), dims=(1, 0)
  %23 = f32[] prim::Constant(), value=1
  %24 = f32[20,10]{1,0} aten::expand(%23), size=(20, 10)
  %25 = f32[20,10]{1,0} aten::addmm(%24, %22, %19)
  %26 = f32[] prim::Constant(), value=1
  %27 = f32[20,10]{1,0} aten::mse_loss_backward(%26, %25, %17), reduction=1
  %28 = f32[10,20]{0,1} aten::permute(%24), dims=(1, 0)
  %29 = f32[10,10]{1,0} aten::mm(%28, %27)
  %30 = f32[10,10]{0,1} aten::permute(%29), dims=(1, 0)
  %31 = f32[10,10]{1,0} aten::mul(%30, %15)
  %32 = f32[100]{0} aten::view(%31), output_size=(100)
  %33 = f32[] xla::device_data(), device=TPU:0
  %34 = f32[1,10]{1,0} aten::sum(%27), dimensions=(0), keep_reduced_dimensions=1, dtype=6
  %35 = f32[10]{0} aten::view(%34), output_size=(10)
  %36 = f32[10]{0} aten::mul(%35, %33)
  %37 = f32[10]{0} aten::view(%36), output_size=(10)
  %38 = f32[] prim::Constant(), value=0
  %39 = f32[110]{0} aten::expand(%38), size=(110)
  %40 = f32[110]{0} xla::unselect(%39, %37), dim=0, start=100, end=110, stride=1
  %41 = f32[110]{0} xla::unselect(%40, %32), dim=0, start=0, end=100, stride=1
  %42 = (f32[110]{0}, f32[]) xla::cross_replica_sum(%41, %14.1), num_outputs=2, reduce_type=0, scale=1, pin_layout=0, groups=()
  %43 = f32[100]{0} xla::select(%42.0), dim=0, start=0, end=100, stride=1
  %44 = f32[10,10]{1,0} aten::view(%43), output_size=(10, 10)
  %45 = f32[10,10]{0,1} aten::permute(%44), dims=(1, 0)
  %46 = f32[10,10]{1,0} aten::permute(%45), dims=(1, 0)
  %47 = f32[] aten::mean(%46), dimensions=(0, 1), keep_reduced_dimensions=0, dtype=6, ROOT=0
  %48 = f32[10]{0} xla::select(%42.0), dim=0, start=100, end=110, stride=1
  %49 = f32[10]{0} aten::view(%48), output_size=(10)
  %50 = f32[1,10]{1,0} aten::view(%49), output_size=(1, 10)
  %51 = f32[10]{0} aten::view(%50), output_size=(10)
  %52 = f32[] aten::mean(%51), dimensions=(0), keep_reduced_dimensions=0, dtype=6, ROOT=1
}

grad after [0.010833740234375, 0.010817745700478554]
loss 0 tensor(0.4371, device='xla:0', grad_fn=<MseLossBackward0>)
[W logger.cpp:322] Warning: Time stats are currently only collected for CPU and CUDA devices. Please refer to CpuTimer or CudaTimer for how to register timer for other device type. (function operator())
[W logger.cpp:322] Warning: Time stats are currently only collected for CPU and CUDA devices. Please refer to CpuTimer or CudaTimer for how to register timer for other device type. (function operator())
[W logger.cpp:322] Warning: Time stats are currently only collected for CPU and CUDA devices. Please refer to CpuTimer or CudaTimer for how to register timer for other device type. (function operator())
[W logger.cpp:322] Warning: Time stats are currently only collected for CPU and CUDA devices. Please refer to CpuTimer or CudaTimer for how to register timer for other device type. (function operator())
IR {
  %0 = f32[] xla::device_data(), device=TPU:0
  %1 = s32[] prim::Constant(), value=1
  %2 = s32[3]{0} xla::device_data(), device=TPU:0
  %3 = s32[3]{0} aten::mul(%2, %1)
  %4 = (s32[3]{0}, f32[]) xla::cross_replica_sum(%3, %0), num_outputs=2, reduce_type=0, scale=1, pin_layout=0, groups=()
  %5 = s32[] prim::Constant(), value=1
  %6 = s32[1]{0} xla::device_data(), device=TPU:0
  %7 = s32[1]{0} aten::mul(%6, %5)
  %8 = (s32[1]{0}, f32[]) xla::cross_replica_sum(%7, %4.1), num_outputs=2, reduce_type=0, scale=1, pin_layout=0, groups=()
  %9 = f32[] xla::device_data(), device=TPU:0
  %10 = f32[] prim::Constant(), value=1
  %11 = f32[10,10]{1,0} aten::expand(%10), size=(10, 10)
  %12 = f32[] prim::Constant(), value=0
  %13 = f32[20,10]{1,0} aten::expand(%12), size=(20, 10)
  %14 = f32[10]{0} xla::device_data(), device=TPU:0
  %15 = f32[10,10]{1,0} xla::device_data(), device=TPU:0
  %16 = f32[10,10]{0,1} aten::permute(%15), dims=(1, 0)
  %17 = f32[] prim::Constant(), value=1
  %18 = f32[20,10]{1,0} aten::expand(%17), size=(20, 10)
  %19 = f32[20,10]{1,0} aten::addmm(%18, %16, %14)
  %20 = f32[] prim::Constant(), value=1
  %21 = f32[20,10]{1,0} aten::mse_loss_backward(%20, %19, %13), reduction=1
  %22 = f32[10,20]{0,1} aten::permute(%18), dims=(1, 0)
  %23 = f32[10,10]{1,0} aten::mm(%22, %21)
  %24 = f32[10,10]{0,1} aten::permute(%23), dims=(1, 0)
  %25 = f32[10,10]{1,0} aten::mul(%24, %11)
  %26 = f32[] prim::Constant(), value=0
  %27 = f32[10,10]{1,0} aten::expand(%26), size=(10, 10)
  %28 = f32[10,10]{1,0} aten::add(%27, %25)
  %29 = f32[10,10]{1,0} aten::mul(%28, %9)
  %30 = f32[100]{0} aten::view(%29), output_size=(100)
  %31 = f32[] xla::device_data(), device=TPU:0
  %32 = f32[] prim::Constant(), value=1
  %33 = f32[10]{0} aten::expand(%32), size=(10)
  %34 = f32[1,10]{1,0} aten::sum(%21), dimensions=(0), keep_reduced_dimensions=1, dtype=6
  %35 = f32[10]{0} aten::view(%34), output_size=(10)
  %36 = f32[10]{0} aten::mul(%35, %33)
  %37 = f32[] prim::Constant(), value=0
  %38 = f32[10]{0} aten::expand(%37), size=(10)
  %39 = f32[10]{0} aten::add(%38, %36)
  %40 = f32[10]{0} aten::mul(%39, %31)
  %41 = f32[10]{0} aten::view(%40), output_size=(10)
  %42 = f32[] prim::Constant(), value=0
  %43 = f32[110]{0} aten::expand(%42), size=(110)
  %44 = f32[110]{0} xla::unselect(%43, %41), dim=0, start=0, end=10, stride=1
  %45 = f32[110]{0} xla::unselect(%44, %30), dim=0, start=10, end=110, stride=1
  %46 = (f32[110]{0}, f32[]) xla::cross_replica_sum(%45, %8.1), num_outputs=2, reduce_type=0, scale=1, pin_layout=0, groups=()
  %47 = f32[100]{0} xla::select(%46.0), dim=0, start=10, end=110, stride=1
  %48 = f32[10,10]{1,0} aten::view(%47), output_size=(10, 10)
  %49 = f32[] aten::mean(%48), dimensions=(0, 1), keep_reduced_dimensions=0, dtype=6, ROOT=0
  %50 = f32[10]{0} xla::select(%46.0), dim=0, start=0, end=10, stride=1
  %51 = f32[10]{0} aten::view(%50), output_size=(10)
  %52 = f32[] aten::mean(%51), dimensions=(0), keep_reduced_dimensions=0, dtype=6, ROOT=1
}

grad after [0.010833740234375, 0.010817745700478554]
loss 1 tensor(0.4371, device='xla:0', grad_fn=<MseLossBackward0>)
IR {
  %0 = f32[] xla::device_data(), device=TPU:0
  %1 = f32[110]{0} xla::device_data(), device=TPU:0
  %2 = (f32[110]{0}, f32[]) xla::cross_replica_sum(%1, %0), num_outputs=2, reduce_type=0, scale=1, pin_layout=0, groups=()
  %3 = f32[100]{0} xla::select(%2.0), dim=0, start=10, end=110, stride=1
  %4 = f32[10,10]{1,0} aten::view(%3), output_size=(10, 10)
  %5 = f32[] aten::mean(%4), dimensions=(0, 1), keep_reduced_dimensions=0, dtype=6, ROOT=0
  %6 = f32[10]{0} xla::select(%2.0), dim=0, start=0, end=10, stride=1
  %7 = f32[10]{0} aten::view(%6), output_size=(10)
  %8 = f32[] aten::mean(%7), dimensions=(0), keep_reduced_dimensions=0, dtype=6, ROOT=1
}

grad after [0.0433349609375, 0.043270982801914215]
loss 2 tensor(0.4371, device='xla:0', grad_fn=<MseLossBackward0>)
IR {
  %0 = f32[] xla::device_data(), device=TPU:0
  %1 = f32[110]{0} xla::device_data(), device=TPU:0
  %2 = (f32[110]{0}, f32[]) xla::cross_replica_sum(%1, %0), num_outputs=2, reduce_type=0, scale=1, pin_layout=0, groups=()
  %3 = f32[100]{0} xla::select(%2.0), dim=0, start=10, end=110, stride=1
  %4 = f32[10,10]{1,0} aten::view(%3), output_size=(10, 10)
  %5 = f32[] aten::mean(%4), dimensions=(0, 1), keep_reduced_dimensions=0, dtype=6, ROOT=0
  %6 = f32[10]{0} xla::select(%2.0), dim=0, start=0, end=10, stride=1
  %7 = f32[10]{0} aten::view(%6), output_size=(10)
  %8 = f32[] aten::mean(%7), dimensions=(0), keep_reduced_dimensions=0, dtype=6, ROOT=1
}

grad after [0.17333984375, 0.17308393120765686]
loss 3 tensor(0.4371, device='xla:0', grad_fn=<MseLossBackward0>)
IR {
  %0 = f32[] xla::device_data(), device=TPU:0
  %1 = f32[110]{0} xla::device_data(), device=TPU:0
  %2 = (f32[110]{0}, f32[]) xla::cross_replica_sum(%1, %0), num_outputs=2, reduce_type=0, scale=1, pin_layout=0, groups=()
  %3 = f32[100]{0} xla::select(%2.0), dim=0, start=10, end=110, stride=1
  %4 = f32[10,10]{1,0} aten::view(%3), output_size=(10, 10)
  %5 = f32[] aten::mean(%4), dimensions=(0, 1), keep_reduced_dimensions=0, dtype=6, ROOT=0
  %6 = f32[10]{0} xla::select(%2.0), dim=0, start=0, end=10, stride=1
  %7 = f32[10]{0} aten::view(%6), output_size=(10)
  %8 = f32[] aten::mean(%7), dimensions=(0), keep_reduced_dimensions=0, dtype=6, ROOT=1
}

grad after [0.693359375, 0.6923357248306274]
loss 4 tensor(0.4371, device='xla:0', grad_fn=<MseLossBackward0>)
```

> first 2 ir graph is the same, last 3 are the same. For the last 3 graph, we started to see the grad accumulated.

> The 4x increased of grad seems to be coming from

```
%2 = (f32[110]{0}, f32[]) xla::cross_replica_sum(%1, %0), num_outputs=2, reduce_type=0, scale=1, pin_layout=0, groups=()
```

> which is just a reduce sum on 4 process with scale=1.. This is expected to 4x the grad. The question is why last 3 step grad is different, it doesn't seem like it is actually running the backward pass, it is just save the grad and fo 4x

> Took a closer look at the first 2 correct IR

```
  %21 = f32[20,10]{1,0} aten::mse_loss_backward(%20, %19, %13), reduction=1
```

> is the result of backward, which after a couple transformation become

```
  %45 = f32[110]{0} xla::unselect(%44, %30), dim=0, start=10, end=110, stride=1
```

> and got all_reduce with other replica

```
  %46 = (f32[110]{0}, f32[]) xla::cross_replica_sum(%45, %8.1), num_outputs=2, reduce_type=0, scale=1, pin_layout=0, groups=()
```

> Last 3 step's grad and parameter seems to be detached from the real computation.

---

</details>

I tested the following instructions on a v4-8 TPU with PyTorch checked out at `9c9f42481761c7f42f47c296a9dbee60f3407b90`.

To confirm that the patches are applied correctly (this test should pass):

```
PJRT_DEVICE=TPU python pytorch/xla/test/pjrt/test_ddp.py TestPjRtDistributedDataParallel.test_ddp_step
```

To reproduce the `nan` loss issue (this test should fail):

```
PJRT_DEVICE=TPU python pytorch/xla/test/pjrt/test_ddp.py TestPjRtDistributedDataParallel.test_ddp_loss_barrier
```

This test adds an `xm.mark_step()` after creating the input to [mimic `MpDeviceLoader`](https://github.com/pytorch/xla/blob/9b9b39cb7f81be9f64f2e8cb6aad687992bd1c5d/torch_xla/distributed/parallel_loader.py#L44-L46). This test gives the correct results without `xm.mark_step` (although it's very slow), and it also works as expected when we use `no_sync()` and accumulate the gradients with `xm.optimizer_step()`. These two tests are `TestPjRtDistributedDataParallel.test_ddp_loss_nobarrier` and `TestPjRtDistributedDataParallel.test_ddp_loss_nosync`, respectively.

CC @hjm-aws 