### PR TITLE
Helper function to wrap entry HLO

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1800,6 +1800,16 @@ class TestAtenXlaTensor(XlaTestCase):
 
     self.runAtenTest([torch.randint(1, 4, (7, 7), dtype=torch.uint8)], test_fn)
 
+  def test_too_many_parameter(self):
+
+    def test_fn(t):
+      # TPU can handle ~3500 parameters on v3 without parameter tupling.
+      for i in range(4000):
+        t += torch.tensor(i, dtype=torch.float, device=t.device)
+      return t
+
+    self.runAtenTest([torch.tensor(20.0)], test_fn)
+
   def test_view_and_copy_(self):
     xla_device = xm.xla_device()
     x = torch.tensor([1.5, 2.5, 3.5, 4.5, 5.5, 6.5], device='cpu')

--- a/third_party/xla_client/computation_client.h
+++ b/third_party/xla_client/computation_client.h
@@ -134,16 +134,19 @@ class ComputationClient {
   struct CompileInstance {
     CompileInstance() = default;
     CompileInstance(XlaComputation computation, std::string compilation_device,
-                    std::vector<std::string> devices, const Shape* output_shape)
+                    std::vector<std::string> devices, const Shape* output_shape,
+                    bool parameter_is_tupled_arguments = false)
         : computation(std::move(computation)),
           compilation_device(std::move(compilation_device)),
           devices(std::move(devices)),
-          output_shape(output_shape) {}
+          output_shape(output_shape),
+          parameter_is_tupled_arguments(parameter_is_tupled_arguments) {}
 
     XlaComputation computation;
     std::string compilation_device;
     std::vector<std::string> devices;
     const Shape* output_shape = nullptr;
+    bool parameter_is_tupled_arguments;
   };
 
   struct ExecuteOptions {

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -153,6 +153,7 @@ std::vector<ComputationClient::ComputationPtr> PjRtComputationClient::Compile(
     compile_options.executable_build_options.set_num_partitions(1);
     compile_options.executable_build_options.set_num_replicas(
         client_->device_count());
+    compile_options.parameter_is_tupled_arguments = true;
     std::unique_ptr<xla::PjRtExecutable> executable =
         client_->Compile(instance.computation, compile_options).ValueOrDie();
     std::shared_ptr<PjRtComputation> pjrt_computation =

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -9,8 +9,8 @@
 #include "tensorflow/compiler/xla/literal.h"
 #include "tensorflow/compiler/xla/pjrt/cpu_device.h"
 #include "tensorflow/compiler/xla/pjrt/pjrt_client.h"
-#include "tensorflow/compiler/xla/pjrt/tpu_client.h"
 #include "tensorflow/compiler/xla/pjrt/tfrt_cpu_pjrt_client.h"
+#include "tensorflow/compiler/xla/pjrt/tpu_client.h"
 #include "tensorflow/compiler/xla/shape.h"
 #include "tensorflow/compiler/xla/xla_client/computation_client.h"
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
@@ -49,7 +49,8 @@ PjRtComputationClient::PjRtComputationClient() {
     TF_VLOG(1) << "Initializing PjRt CPU client...";
     bool async = sys_util::GetEnvBool(env::kEnvPjrtAsyncCpuClient, true);
     int cpu_device_count = sys_util::GetEnvInt(env::kEnvNumCpu, 1);
-    client_ = std::move(xla::GetTfrtCpuClient(async, cpu_device_count).ValueOrDie());
+    client_ =
+        std::move(xla::GetTfrtCpuClient(async, cpu_device_count).ValueOrDie());
   } else if (device_type == "TPU") {
     TF_VLOG(1) << "Initializing PjRt TPU client...";
     int64_t max_inflight_computations = sys_util::GetEnvInt(
@@ -83,7 +84,8 @@ ComputationClient::DataPtr PjRtComputationClient::CreateDataPlaceholder(
 std::vector<ComputationClient::DataPtr> PjRtComputationClient::TransferToServer(
     absl::Span<const TensorSource> tensors) {
   tensorflow::profiler::TraceMe activity(
-    "PjRtComputationClient::TransferToServer", tensorflow::profiler::TraceMeLevel::kInfo);
+      "PjRtComputationClient::TransferToServer",
+      tensorflow::profiler::TraceMeLevel::kInfo);
   std::vector<ComputationClient::DataPtr> datas;
   datas.reserve(tensors.size());
   for (auto& tensor : tensors) {
@@ -119,7 +121,8 @@ std::vector<ComputationClient::DataPtr> PjRtComputationClient::TransferToServer(
 std::vector<xla::Literal> PjRtComputationClient::TransferFromServer(
     absl::Span<const DataPtr> handles) {
   tensorflow::profiler::TraceMe activity(
-    "PjRtComputationClient::TransferFromServer", tensorflow::profiler::TraceMeLevel::kInfo);
+      "PjRtComputationClient::TransferFromServer",
+      tensorflow::profiler::TraceMeLevel::kInfo);
   std::vector<xla::Literal> literals;
   literals.reserve(handles.size());
 
@@ -137,7 +140,8 @@ std::vector<xla::Literal> PjRtComputationClient::TransferFromServer(
 std::vector<ComputationClient::ComputationPtr> PjRtComputationClient::Compile(
     std::vector<ComputationClient::CompileInstance> instances) {
   tensorflow::profiler::TraceMe activity(
-    "PjRtComputationClient::Compile", tensorflow::profiler::TraceMeLevel::kInfo);
+      "PjRtComputationClient::Compile",
+      tensorflow::profiler::TraceMeLevel::kInfo);
   std::vector<ComputationClient::ComputationPtr> computations;
 
   for (auto& instance : instances) {
@@ -153,7 +157,8 @@ std::vector<ComputationClient::ComputationPtr> PjRtComputationClient::Compile(
     compile_options.executable_build_options.set_num_partitions(1);
     compile_options.executable_build_options.set_num_replicas(
         client_->device_count());
-    compile_options.parameter_is_tupled_arguments = true;
+    compile_options.parameter_is_tupled_arguments =
+        instance.parameter_is_tupled_arguments;
     std::unique_ptr<xla::PjRtExecutable> executable =
         client_->Compile(instance.computation, compile_options).ValueOrDie();
     std::shared_ptr<PjRtComputation> pjrt_computation =
@@ -173,7 +178,8 @@ PjRtComputationClient::ExecuteComputation(
     absl::Span<const ComputationClient::DataPtr> arguments,
     const std::string& device, const ExecuteComputationOptions& options) {
   tensorflow::profiler::TraceMe activity(
-    "PjRtComputationClient::ExecuteComputation", tensorflow::profiler::TraceMeLevel::kInfo);
+      "PjRtComputationClient::ExecuteComputation",
+      tensorflow::profiler::TraceMeLevel::kInfo);
   TF_VLOG(1) << "Executing PjRt computation on " << device;
   const PjRtComputation& pjrt_computation =
       dynamic_cast<const PjRtComputation&>(computation);

--- a/torch_xla/csrc/helpers.cpp
+++ b/torch_xla/csrc/helpers.cpp
@@ -609,13 +609,7 @@ xla::StatusOr<xla::XlaComputation> XlaHelpers::WrapXlaComputation(
   xla::XlaOp orig_result;
   orig_result = xla::Call(&builder, computation, inner_params);
 
-  // Construct a single tuple result.
-  const std::vector<xla::XlaOp> results = [&orig_result]() {
-    std::vector<xla::XlaOp> results;
-    results.push_back(orig_result);
-    return results;
-  }();
-
+  // Rebuild aliasing.
   for (const auto& [input_index, output_index] : input_output_alias_pair) {
     // Both input and output will be a tuple so parameter_number will always be
     // 0

--- a/torch_xla/csrc/helpers.cpp
+++ b/torch_xla/csrc/helpers.cpp
@@ -616,9 +616,6 @@ xla::StatusOr<xla::XlaComputation> XlaHelpers::WrapXlaComputation(
     return results;
   }();
 
-  xla::XlaOp result_tuple;
-  { result_tuple = xla::Tuple(&builder, results); }
-
   for (const auto& [input_index, output_index] : input_output_alias_pair) {
     // Both input and output will be a tuple so parameter_number will always be
     // 0

--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -330,6 +330,11 @@ class XlaHelpers {
     s_mat_mul_precision = precision;
   }
 
+  static xla::StatusOr<xla::XlaComputation> WrapXlaComputation(
+      const xla::XlaComputation& computation,
+      const std::vector<xla::Shape>& parameter_shapes,
+      std::vector<std::pair<int64_t, int64_t>> input_output_alias_pair);
+
  private:
   static xla::PrecisionConfig::Precision s_mat_mul_precision;
 };

--- a/torch_xla/csrc/lowering_context.cpp
+++ b/torch_xla/csrc/lowering_context.cpp
@@ -1,6 +1,5 @@
 #include "torch_xla/csrc/lowering_context.h"
 
-#include <iostream>
 #include <sstream>
 #include <stdexcept>
 
@@ -14,7 +13,6 @@
 #include "torch_xla/csrc/computation.h"
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/tensor_util.h"
-using std::cerr;
 
 namespace torch_xla {
 namespace {

--- a/torch_xla/csrc/lowering_context.cpp
+++ b/torch_xla/csrc/lowering_context.cpp
@@ -14,6 +14,9 @@
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/tensor_util.h"
 
+#include <iostream>
+using std::cerr;
+
 namespace torch_xla {
 namespace {
 

--- a/torch_xla/csrc/lowering_context.cpp
+++ b/torch_xla/csrc/lowering_context.cpp
@@ -1,5 +1,6 @@
 #include "torch_xla/csrc/lowering_context.h"
 
+#include <iostream>
 #include <sstream>
 #include <stdexcept>
 
@@ -13,8 +14,6 @@
 #include "torch_xla/csrc/computation.h"
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/tensor_util.h"
-
-#include <iostream>
 using std::cerr;
 
 namespace torch_xla {

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -6,10 +6,12 @@
 #include <condition_variable>
 #include <exception>
 #include <functional>
+#include <iostream>
 #include <mutex>
 #include <set>
 #include <stdexcept>
 #include <unordered_set>
+using std::cerr;
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/memory/memory.h"
@@ -1639,6 +1641,63 @@ void XLATensor::BuildInputOutputAliases(
   XLA_VALUE_METRIC("InputOutputAliasCount", alias_map.size());
 }
 
+xla::StatusOr<xla::XlaComputation> WrapComputation(
+    const xla::XlaComputation& computation,
+    const std::vector<xla::Shape>& parameter_shapes) {
+  xla::XlaBuilder builder(computation.proto().name());
+
+  // Construct a single tuple parameter.
+  const xla::XlaOp input_tuple = [&builder, &parameter_shapes]() {
+    xla::Shape input_tuple;
+    input_tuple.set_element_type(xla::PrimitiveType::TUPLE);
+    input_tuple.mutable_tuple_shapes()->reserve(parameter_shapes.size());
+    for (int i = 0; i < parameter_shapes.size(); ++i) {
+      *input_tuple.add_tuple_shapes() = parameter_shapes[i];
+    }
+    return xla::Parameter(&builder, 0, input_tuple, "in");
+  }();
+
+  // Handle the results of the original computation.
+  const std::vector<xla::XlaOp> inner_params = [&input_tuple,
+                                                &parameter_shapes]() {
+    std::vector<xla::XlaOp> parameters;
+    parameters.reserve(parameter_shapes.size());
+    for (int i = 0; i < parameter_shapes.size(); ++i) {
+      parameters.push_back(xla::GetTupleElement(input_tuple, i));
+    }
+    return parameters;
+  }();
+
+  // Call the original computation.
+  xla::XlaOp orig_result;
+  orig_result = xla::Call(&builder, computation, inner_params);
+
+  // Construct a single tuple result.
+  const std::vector<xla::XlaOp> results = [&orig_result]() {
+    std::vector<xla::XlaOp> results;
+    results.push_back(orig_result);
+    return results;
+  }();
+
+  xla::XlaOp result_tuple;
+  { result_tuple = xla::Tuple(&builder, results); }
+
+  // // Preserve aliases.
+  // if (io_info.use_dummy_input()) {
+  //   for (const auto& [input_index, output_index] : io_info.io_aliases) {
+  //     Skip the dummy input at index 0.
+  //     builder.SetUpAlias(xla::ShapeIndex({output_index}), 0,
+  //                        xla::ShapeIndex({input_index + 1}));
+  //   }
+  // } else {
+  //   for (const auto& [input_index, output_index] : io_info.io_aliases) {
+  //     builder.SetUpAlias(xla::ShapeIndex({output_index}), 0,
+  //                        xla::ShapeIndex({input_index}));
+  //   }
+  // }
+  return builder.Build(result_tuple);
+}
+
 XLATensor::CompilationResult XLATensor::Compile(
     const std::vector<XLATensorPtr>& tensors,
     absl::Span<const std::string> devices, const SyncTensorCollection& coll,
@@ -1693,7 +1752,13 @@ XLATensor::CompilationResult XLATensor::Compile(
   }
 
   xla::XlaComputation computation = ConsumeValue(lowering_ctx.BuildXla());
+  cerr << "hlo built = \n"
+       << ConsumeValue(xla::util::GetComputationHloText(computation)) << "\n";
   xla::ProgramShape program_shape = ConsumeValue(computation.GetProgramShape());
+  xla::XlaComputation wrapped_computation =
+      ConsumeValue(WrapComputation(computation, program_shape.parameters()));
+  cerr << "wrapped hlo built = \n"
+       << ConsumeValue(xla::util::GetComputationHloText(wrapped_computation)) << "\n";
   xla::Shape shape = MakeShapeWithDeviceLayout(
       program_shape.result(), static_cast<XlaDeviceType>(coll.device.type()));
 

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -6,12 +6,10 @@
 #include <condition_variable>
 #include <exception>
 #include <functional>
-#include <iostream>
 #include <mutex>
 #include <set>
 #include <stdexcept>
 #include <unordered_set>
-using std::cerr;
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/memory/memory.h"
@@ -1762,12 +1760,6 @@ XLATensor::CompilationResult XLATensor::Compile(
   xla::Shape shape =
       MakeShapeWithDeviceLayout(wrapped_program_shape.result(),
                                 static_cast<XlaDeviceType>(coll.device.type()));
-
-  cerr << "hlo built = \n"
-       << ConsumeValue(xla::util::GetComputationHloText(computation)) << "\n";
-  cerr << "wrapped hlo built = \n"
-       << ConsumeValue(xla::util::GetComputationHloText(wrapped_computation))
-       << "\n";
 
   std::vector<xla::ComputationClient::CompileInstance> instances;
   instances.push_back({std::move(wrapped_computation), coll.device.toString(),

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1644,59 +1644,6 @@ std::vector<std::pair<int64_t, int64_t>> XLATensor::BuildInputOutputAliases(
   return input_output_alias_pair;
 }
 
-xla::StatusOr<xla::XlaComputation> WrapComputation(
-    const xla::XlaComputation& computation,
-    const std::vector<xla::Shape>& parameter_shapes,
-    std::vector<std::pair<int64_t, int64_t>> input_output_alias_pair) {
-  xla::XlaBuilder builder(computation.proto().name());
-
-  // Construct a single tuple parameter.
-  const xla::XlaOp input_tuple = [&builder, &parameter_shapes]() {
-    xla::Shape input_tuple;
-    input_tuple.set_element_type(xla::PrimitiveType::TUPLE);
-    input_tuple.mutable_tuple_shapes()->reserve(parameter_shapes.size());
-    for (int i = 0; i < parameter_shapes.size(); ++i) {
-      *input_tuple.add_tuple_shapes() = parameter_shapes[i];
-    }
-    return xla::Parameter(&builder, 0, input_tuple, "in");
-  }();
-
-  // Handle the results of the original computation.
-  const std::vector<xla::XlaOp> inner_params = [&input_tuple,
-                                                &parameter_shapes]() {
-    std::vector<xla::XlaOp> parameters;
-    parameters.reserve(parameter_shapes.size());
-    for (int i = 0; i < parameter_shapes.size(); ++i) {
-      parameters.push_back(xla::GetTupleElement(input_tuple, i));
-    }
-    return parameters;
-  }();
-
-  // Call the original computation.
-  xla::XlaOp orig_result;
-  orig_result = xla::Call(&builder, computation, inner_params);
-
-  // Construct a single tuple result.
-  const std::vector<xla::XlaOp> results = [&orig_result]() {
-    std::vector<xla::XlaOp> results;
-    results.push_back(orig_result);
-    return results;
-  }();
-
-  xla::XlaOp result_tuple;
-  { result_tuple = xla::Tuple(&builder, results); }
-
-  for (const auto& [input_index, output_index] : input_output_alias_pair) {
-    // Both input and output will be a tuple so parameter_number will always be
-    // 0
-    builder.SetUpAlias(/*output_index=*/xla::ShapeIndex({output_index}),
-                       /*param_number=*/0,
-                       /*param_index=*/xla::ShapeIndex({input_index}));
-  }
-
-  return builder.Build(orig_result);
-}
-
 XLATensor::CompilationResult XLATensor::Compile(
     const std::vector<XLATensorPtr>& tensors,
     absl::Span<const std::string> devices, const SyncTensorCollection& coll,
@@ -1763,7 +1710,7 @@ XLATensor::CompilationResult XLATensor::Compile(
       (program_shape.parameters_size() >= parameter_wrapping_threadshold) &&
       using_pjrt;
   if (should_wrap_parameter) {
-    computation = ConsumeValue(WrapComputation(
+    computation = ConsumeValue(XlaHelpers::WrapXlaComputation(
         computation, program_shape.parameters(), input_output_alias_pair));
     program_shape = ConsumeValue(computation.GetProgramShape());
   }

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1710,6 +1710,9 @@ XLATensor::CompilationResult XLATensor::Compile(
       (program_shape.parameters_size() >= parameter_wrapping_threadshold) &&
       using_pjrt;
   if (should_wrap_parameter) {
+    TF_VLOG(3) << "Wrapping graph with " << program_shape.parameters_size()
+               << " parameters. Threadshold = "
+               << parameter_wrapping_threadshold;
     computation = ConsumeValue(XlaHelpers::WrapXlaComputation(
         computation, program_shape.parameters(), input_output_alias_pair));
     program_shape = ConsumeValue(computation.GetProgramShape());

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1695,7 +1695,9 @@ xla::StatusOr<xla::XlaComputation> WrapComputation(
   //                        xla::ShapeIndex({input_index}));
   //   }
   // }
-  return builder.Build(result_tuple);
+
+  // return builder.Build(result_tuple);
+  return builder.Build(orig_result);
 }
 
 XLATensor::CompilationResult XLATensor::Compile(
@@ -1755,14 +1757,17 @@ XLATensor::CompilationResult XLATensor::Compile(
   xla::ProgramShape program_shape = ConsumeValue(computation.GetProgramShape());
   xla::XlaComputation wrapped_computation =
       ConsumeValue(WrapComputation(computation, program_shape.parameters()));
-  xla::ProgramShape wrapped_program_shape = ConsumeValue(wrapped_computation.GetProgramShape());
-  xla::Shape shape = MakeShapeWithDeviceLayout(
-      wrapped_program_shape.result(), static_cast<XlaDeviceType>(coll.device.type()));
+  xla::ProgramShape wrapped_program_shape =
+      ConsumeValue(wrapped_computation.GetProgramShape());
+  xla::Shape shape =
+      MakeShapeWithDeviceLayout(wrapped_program_shape.result(),
+                                static_cast<XlaDeviceType>(coll.device.type()));
 
   cerr << "hlo built = \n"
        << ConsumeValue(xla::util::GetComputationHloText(computation)) << "\n";
   cerr << "wrapped hlo built = \n"
-       << ConsumeValue(xla::util::GetComputationHloText(wrapped_computation)) << "\n";
+       << ConsumeValue(xla::util::GetComputationHloText(wrapped_computation))
+       << "\n";
 
   std::vector<xla::ComputationClient::CompileInstance> instances;
   instances.push_back({std::move(wrapped_computation), coll.device.toString(),

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -1445,9 +1445,9 @@ class XLATensor : public c10::intrusive_ptr_target {
       std::vector<XLATensorPtr>* tensors, SyncTensorCollection* coll,
       PostOrderData* po_data);
 
-  static void BuildInputOutputAliases(const std::vector<XLATensorPtr>& tensors,
-                                      absl::Span<const size_t> indices,
-                                      LoweringContext* lowering_ctx);
+  static std::vector<std::pair<int64_t, int64_t>> BuildInputOutputAliases(
+      const std::vector<XLATensorPtr>& tensors,
+      absl::Span<const size_t> indices, LoweringContext* lowering_ctx);
 
   static CompilationResult Compile(const std::vector<XLATensorPtr>& tensors,
                                    absl::Span<const std::string> devices,


### PR DESCRIPTION
**_This feature is for PJRT only._**

This pr fix the `Computation requires more parameters (3348) than supported (limit 3302)` error on TPU.

TPU has a number of parameter limit that is irrelevant to the actual parameter size. On TPUv3 this limit is 3302. XLA's definition of "parameter" is `data that needs to be moved from cpu to the device`. To workaround this issue we can wrap the parameter into a single tuple which reduce the number of parameter to 1. For example a HLO like

```
ENTRY %SyncTensorsGraph.23 (p0.2: f32[], p1.5: f32[], p2.8: f32[], p3.16: f32[]) -> (f32[]) {
  %p3.16 = f32[] parameter(3), metadata={op_type="xla__device_data" op_name="xla__device_data" source_file="<module>@test_para.py" source_line=9}
  %constant.14 = f32[] constant(0), metadata={op_type="prim__Constant" op_name="prim__Constant" source_file="<module>@test_para.py" source_line=11}
  %constant.13 = f32[] constant(1), metadata={op_type="prim__Constant" op_name="prim__Constant" source_file="<module>@test_para.py" source_line=11}
  %multiply.15 = f32[] multiply(f32[] %constant.14, f32[] %constant.13), metadata={op_type="aten__mul" op_name="aten__mul" source_file="<module>@test_para.py" source_line=11}
  %add.17 = f32[] add(f32[] %p3.16, f32[] %multiply.15), metadata={op_type="aten__add" op_name="aten__add" source_file="<module>@test_para.py" source_line=11}
  %constant.11 = f32[] constant(1), metadata={op_type="prim__Constant" op_name="prim__Constant" source_file="<module>@test_para.py" source_line=11}
  %constant.10 = f32[] constant(1), metadata={op_type="prim__Constant" op_name="prim__Constant" source_file="<module>@test_para.py" source_line=11}
  %multiply.12 = f32[] multiply(f32[] %constant.11, f32[] %constant.10), metadata={op_type="aten__mul" op_name="aten__mul" source_file="<module>@test_para.py" source_line=11}
  %add.18 = f32[] add(f32[] %add.17, f32[] %multiply.12), metadata={op_type="aten__add" op_name="aten__add" source_file="<module>@test_para.py" source_line=11}
  %p2.8 = f32[] parameter(2), metadata={op_type="xla__device_data" op_name="xla__device_data" source_file="<module>@test_para.py" source_line=11}
  %constant.7 = f32[] constant(1), metadata={op_type="prim__Constant" op_name="prim__Constant" source_file="<module>@test_para.py" source_line=11}
  %multiply.9 = f32[] multiply(f32[] %p2.8, f32[] %constant.7), metadata={op_type="aten__mul" op_name="aten__mul" source_file="<module>@test_para.py" source_line=11}
  %add.19 = f32[] add(f32[] %add.18, f32[] %multiply.9), metadata={op_type="aten__add" op_name="aten__add" source_file="<module>@test_para.py" source_line=11}
  %p1.5 = f32[] parameter(1), metadata={op_type="xla__device_data" op_name="xla__device_data" source_file="<module>@test_para.py" source_line=11}
  %constant.4 = f32[] constant(1), metadata={op_type="prim__Constant" op_name="prim__Constant" source_file="<module>@test_para.py" source_line=11}
  %multiply.6 = f32[] multiply(f32[] %p1.5, f32[] %constant.4), metadata={op_type="aten__mul" op_name="aten__mul" source_file="<module>@test_para.py" source_line=11}
  %add.20 = f32[] add(f32[] %add.19, f32[] %multiply.6), metadata={op_type="aten__add" op_name="aten__add" source_file="<module>@test_para.py" source_line=11}
  %p0.2 = f32[] parameter(0), metadata={op_type="xla__device_data" op_name="xla__device_data" source_file="<module>@test_para.py" source_line=11}
  %constant.1 = f32[] constant(1), metadata={op_type="prim__Constant" op_name="prim__Constant" source_file="<module>@test_para.py" source_line=11}
  %multiply.3 = f32[] multiply(f32[] %p0.2, f32[] %constant.1), metadata={op_type="aten__mul" op_name="aten__mul" source_file="<module>@test_para.py" source_line=11}
  %add.21 = f32[] add(f32[] %add.20, f32[] %multiply.3), metadata={op_type="aten__add" op_name="aten__add" source_file="<module>@test_para.py" source_line=11}
  ROOT %tuple.22 = (f32[]) tuple(f32[] %add.21)
}
```

to

```
HloModule SyncTensorsGraph.23.31, entry_computation_layout={((f32[], f32[], f32[], f32[]))->(f32[])}

%SyncTensorsGraph.6 (p0.8: f32[], p1.11: f32[], p2.14: f32[], p3.22: f32[]) -> (f32[]) {
  %p3.22 = f32[] parameter(3), metadata={op_type="xla__device_data" op_name="xla__device_data" source_file="<module>@test_para.py" source_line=9}
  %constant.20 = f32[] constant(0), metadata={op_type="prim__Constant" op_name="prim__Constant" source_file="<module>@test_para.py" source_line=11}
  %constant.19 = f32[] constant(1), metadata={op_type="prim__Constant" op_name="prim__Constant" source_file="<module>@test_para.py" source_line=11}
  %multiply.21 = f32[] multiply(f32[] %constant.20, f32[] %constant.19), metadata={op_type="aten__mul" op_name="aten__mul" source_file="<module>@test_para.py" source_line=11}
  %add.23 = f32[] add(f32[] %p3.22, f32[] %multiply.21), metadata={op_type="aten__add" op_name="aten__add" source_file="<module>@test_para.py" source_line=11}
  %constant.17 = f32[] constant(1), metadata={op_type="prim__Constant" op_name="prim__Constant" source_file="<module>@test_para.py" source_line=11}
  %constant.16 = f32[] constant(1), metadata={op_type="prim__Constant" op_name="prim__Constant" source_file="<module>@test_para.py" source_line=11}
  %multiply.18 = f32[] multiply(f32[] %constant.17, f32[] %constant.16), metadata={op_type="aten__mul" op_name="aten__mul" source_file="<module>@test_para.py" source_line=11}
  %add.24 = f32[] add(f32[] %add.23, f32[] %multiply.18), metadata={op_type="aten__add" op_name="aten__add" source_file="<module>@test_para.py" source_line=11}
  %p2.14 = f32[] parameter(2), metadata={op_type="xla__device_data" op_name="xla__device_data" source_file="<module>@test_para.py" source_line=11}
  %constant.13 = f32[] constant(1), metadata={op_type="prim__Constant" op_name="prim__Constant" source_file="<module>@test_para.py" source_line=11}
  %multiply.15 = f32[] multiply(f32[] %p2.14, f32[] %constant.13), metadata={op_type="aten__mul" op_name="aten__mul" source_file="<module>@test_para.py" source_line=11}
  %add.25 = f32[] add(f32[] %add.24, f32[] %multiply.15), metadata={op_type="aten__add" op_name="aten__add" source_file="<module>@test_para.py" source_line=11}
  %p1.11 = f32[] parameter(1), metadata={op_type="xla__device_data" op_name="xla__device_data" source_file="<module>@test_para.py" source_line=11}
  %constant.10 = f32[] constant(1), metadata={op_type="prim__Constant" op_name="prim__Constant" source_file="<module>@test_para.py" source_line=11}
  %multiply.12 = f32[] multiply(f32[] %p1.11, f32[] %constant.10), metadata={op_type="aten__mul" op_name="aten__mul" source_file="<module>@test_para.py" source_line=11}
  %add.26 = f32[] add(f32[] %add.25, f32[] %multiply.12), metadata={op_type="aten__add" op_name="aten__add" source_file="<module>@test_para.py" source_line=11}
  %p0.8 = f32[] parameter(0), metadata={op_type="xla__device_data" op_name="xla__device_data" source_file="<module>@test_para.py" source_line=11}
  %constant.7 = f32[] constant(1), metadata={op_type="prim__Constant" op_name="prim__Constant" source_file="<module>@test_para.py" source_line=11}
  %multiply.9 = f32[] multiply(f32[] %p0.8, f32[] %constant.7), metadata={op_type="aten__mul" op_name="aten__mul" source_file="<module>@test_para.py" source_line=11}
  %add.27 = f32[] add(f32[] %add.26, f32[] %multiply.9), metadata={op_type="aten__add" op_name="aten__add" source_file="<module>@test_para.py" source_line=11}
  ROOT %tuple.28 = (f32[]) tuple(f32[] %add.27)
}

ENTRY %SyncTensorsGraph.23.31 (in.1: (f32[], f32[], f32[], f32[])) -> (f32[]) {
  %in.1 = (f32[], f32[], f32[], f32[]) parameter(0)
  %get-tuple-element.2 = f32[] get-tuple-element((f32[], f32[], f32[], f32[]) %in.1), index=0
  %get-tuple-element.3 = f32[] get-tuple-element((f32[], f32[], f32[], f32[]) %in.1), index=1
  %get-tuple-element.4 = f32[] get-tuple-element((f32[], f32[], f32[], f32[]) %in.1), index=2
  %get-tuple-element.5 = f32[] get-tuple-element((f32[], f32[], f32[], f32[]) %in.1), index=3
  ROOT %call.29 = (f32[]) call(f32[] %get-tuple-element.2, f32[] %get-tuple-element.3, f32[] %get-tuple-element.4, f32[] %get-tuple-element.5), to_apply=%SyncTensorsGraph.6
}
```

We added another function as entry to forward the parameter to real function. I verified this unblock the issue we saw when scaling up.


PJRT handles tupling input buffers, caller only need to handle wrapping the input for hlo text.

TODO:
~~- [ ] add `XLA_PARAMETER_WRAPPING_THREADSHOLD` value to the graph hash otherwise we might have hash collision(tuple input version and non-tuple version)~~

on a second thought, given tupling doesn't affect speed too much(if at all), this should not be an issue. Even if someone manually modify `XLA_PARAMETER_WRAPPING_THREADSHOLD` and incorrectly hit the cache (expect non-tupling but see tupling) the program will still run correctly because from caller perspective we still pass all parameter as vector. 
On top of this, we currently do not support long lasting cache for PJRT, so this is actually impossible to happen.