### PR TITLE
Codegen frac op

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1230,11 +1230,6 @@ at::Tensor XLANativeFunctions::fmod(const at::Tensor& self,
                     });
 }
 
-at::Tensor XLANativeFunctions::frac(const at::Tensor& self) {
-  XLA_FN_COUNTER("xla::");
-  return bridge::AtenFromXlaTensor(XLATensor::frac(bridge::GetXlaTensor(self)));
-}
-
 at::Tensor XLANativeFunctions::gather(const at::Tensor& self, int64_t dim,
                                       const at::Tensor& index,
                                       bool /* sparse_grad */) {

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -79,11 +79,6 @@ PTXLA_BINARY_OP(Pow, at::aten::pow, xla::Pow);
 PTXLA_BINARY_OP(Fmod, at::aten::fmod, xla::Rem);
 PTXLA_BINARY_OP(Atan2, at::aten::atan2, xla::Atan2);
 
-torch::lazy::NodePtr FracOp(const torch::lazy::Value& input) {
-  return input -
-         torch::lazy::MakeNode<Trunc>(input, std::vector<torch::lazy::Shape>());
-}
-
 torch::lazy::NodePtr LogBase(const torch::lazy::Value& input,
                              torch::lazy::OpKind op, double base) {
   auto lower_fn = [base](const XlaNode& node,

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -136,8 +136,6 @@ torch::lazy::NodePtr Clamp(const torch::lazy::Value& input,
 torch::lazy::NodePtr Celu(const torch::lazy::Value& input,
                           const at::Scalar& alpha);
 
-torch::lazy::NodePtr FracOp(const torch::lazy::Value& input);
-
 torch::lazy::NodePtr AddMatMulOp(const torch::lazy::Value& input,
                                  const torch::lazy::Value& weight,
                                  const torch::lazy::Value& bias);

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -287,6 +287,13 @@ torch_xla::XlaOpVector Floor::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::Floor(xla_input), loctx);
 }
 
+torch_xla::XlaOpVector Frac::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  xla::XlaOp result =
+      xla_input - xla::Floor(BuildAbs(xla_input)) * BuildSgn(xla_input);
+  return ReturnOp(result, loctx);
+}
+
 torch_xla::XlaOpVector GeScalar::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   xla::XlaOp xla_other = loctx->GetOutputOp(operand(1));

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -356,6 +356,10 @@ xla::Shape FloorOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
+xla::Shape FracOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
+}
+
 xla::Shape GeScalarOutputShape(const torch::lazy::Value& self,
                                const torch::lazy::Value& other) {
   auto lower_for_shape_fn =

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -112,6 +112,8 @@ xla::Shape Expm1OutputShape(const torch::lazy::Value& input);
 
 xla::Shape FloorOutputShape(const torch::lazy::Value& input);
 
+xla::Shape FracOutputShape(const torch::lazy::Value& input);
+
 xla::Shape GeScalarOutputShape(const torch::lazy::Value& self,
                                const torch::lazy::Value& other);
 

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -588,8 +588,6 @@ class XLATensor : public c10::intrusive_ptr_target {
       const XLATensorPtr& input, const at::Scalar& other,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
 
-  static XLATensorPtr frac(const XLATensorPtr& input);
-
   static XLATensorPtr full(absl::Span<const int64_t> size,
                            const at::Scalar& fill_value,
                            const torch::lazy::BackendDevice& device,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1163,10 +1163,6 @@ XLATensorPtr XLATensor::fmod(
                            logical_element_type);
 }
 
-XLATensorPtr XLATensor::frac(const XLATensorPtr& input) {
-  return input->CreateFrom(FracOp(input->GetIrValue()));
-}
-
 XLATensorPtr XLATensor::full(absl::Span<const int64_t> size,
                              const at::Scalar& fill_value,
                              const torch::lazy::BackendDevice& device,

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -36,6 +36,7 @@ full_codegen:
   - exp
   - expm1
   - floor
+  - frac
   - ge.Scalar
   - ge.Tensor
   - gt.Scalar
@@ -167,7 +168,6 @@ supported:
   - flip
   - fmod.Scalar
   - fmod.Tensor
-  - frac
   - gather
   - gelu
   - gelu_backward


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/3925

---
Codegen frac op

---
LazyIr.h:
```
class Frac : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::frac);
  }

  Frac(const torch::lazy::Value& self, std::vector<torch::lazy::Shape>&& shapes)
      : XlaNode(torch::lazy::OpKind(at::aten::frac),
              {self}, std::move(shapes),
              [&]() { return FracOutputShape(self); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
  {
    
  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();
    
    return ss.str();
  }

  

  bool CanBeReused(const torch::lazy::Value& self) const {
    return false;
    }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;

  
  

};
```

---
XLANativeFunctions.cpp:
```
    at::Tensor XLANativeFunctions::frac(const at::Tensor & self) {
        
        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self);
        TORCH_INTERNAL_ASSERT(common_device);
        
        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        torch::lazy::NodePtr node = torch::lazy::ReuseNode<Frac>(lazy_self->GetIrValue());
        if (!node) {
                    auto self_meta = to_meta(self);
        auto out_meta = at::meta::frac(self_meta);
        
std::vector<torch::lazy::Shape> shapes{torch::lazy::Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
            TORCH_INTERNAL_ASSERT(shapes.size() == 1);
            if(torch::lazy::symbolicShapeEnabled()){
                std::vector<torch::jit::IValue> inputs = { self };
                const char* schema_str = "aten::frac(Tensor self) -> Tensor";
                applySymbolicShapesOnLT(schema_str, inputs, shapes);
            }
        
            node = torch::lazy::MakeNode<Frac>(lazy_self->GetIrValue(), std::move(shapes));
            CacheNode(node);
        }
        
        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    }
```