### PR TITLE
Clean up SymIntElements

### DIFF
--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -61,6 +61,7 @@ set(TORCH_XLA_TEST_SOURCES
   test_xla_util_cache.cpp
   torch_xla_test.cpp
   test_xla_backend_intf.cpp
+  test_symint.cpp
 )
 
 add_executable(test_ptxla ${TORCH_XLA_TEST_SOURCES})

--- a/test/cpp/test_symint.cpp
+++ b/test/cpp/test_symint.cpp
@@ -25,10 +25,11 @@ TEST(SymintTest, TestSaticSymint) {
   EXPECT_EQ(dynamic_dims.size(), 1);
   EXPECT_EQ(dynamic_dims[0], false);
 
-  std::unordered_map<size_t, torch::lazy::NodePtr> size_node_map =
-      si_element.GetNodeMap();
+  std::vector<torch::lazy::NodePtr> size_nodes = si_element.GetSizeNodes();
   // Static SymIntElements should not have size_node
-  EXPECT_EQ(size_node_map.size(), 0);
+  EXPECT_EQ(size_nodes.size(), 1);
+  EXPECT_EQ(size_nodes[0], nullptr);
+  EXPECT_EQ(si_element.GetSizeNode(0), nullptr);
 }
 
 TEST(SymintTest, TestSaticSymints) {
@@ -47,10 +48,12 @@ TEST(SymintTest, TestSaticSymints) {
   EXPECT_EQ(dynamic_dims.size(), 3);
   EXPECT_EQ(dynamic_dims, std::vector<bool>({false, false, false}));
 
-  std::unordered_map<size_t, torch::lazy::NodePtr> size_node_map =
-      si_element.GetNodeMap();
+  std::vector<torch::lazy::NodePtr> size_nodes = si_element.GetSizeNodes();
   // Static SymIntElements should not have size_node
-  EXPECT_EQ(size_node_map.size(), 0);
+  EXPECT_EQ(size_nodes.size(), 3);
+  EXPECT_EQ(size_nodes,
+            std::vector<torch::lazy::NodePtr>({nullptr, nullptr, nullptr}));
+  EXPECT_EQ(si_element.GetSizeNode(0), nullptr);
 }
 
 TEST(SymintTest, TestDynamicSymint) {
@@ -82,11 +85,9 @@ TEST(SymintTest, TestDynamicSymint) {
   EXPECT_EQ(dynamic_dims.size(), 1);
   EXPECT_EQ(dynamic_dims[0], true);
 
-  std::unordered_map<size_t, torch::lazy::NodePtr> size_node_map =
-      si_element.GetNodeMap();
-  EXPECT_EQ(size_node_map.size(), 1);
-  // look up the SizeNode for dimension 0
-  EXPECT_TRUE(si_element.GetNode(0) != nullptr);
+  std::vector<torch::lazy::NodePtr> size_nodes = si_element.GetSizeNodes();
+  EXPECT_EQ(size_nodes.size(), 1);
+  EXPECT_TRUE(si_element.GetSizeNode(0) != nullptr);
 }
 
 TEST(SymintTest, TestDynamicSymints) {
@@ -121,13 +122,12 @@ TEST(SymintTest, TestDynamicSymints) {
   EXPECT_EQ(dynamic_dims.size(), 3);
   EXPECT_EQ(dynamic_dims, std::vector<bool>({true, true, true}));
 
-  std::unordered_map<size_t, torch::lazy::NodePtr> size_node_map =
-      si_element.GetNodeMap();
-  EXPECT_EQ(size_node_map.size(), 3);
+  std::vector<torch::lazy::NodePtr> size_nodes = si_element.GetSizeNodes();
+  EXPECT_EQ(size_nodes.size(), 3);
   // look up the SizeNode for dimension 0
-  EXPECT_TRUE(si_element.GetNode(0) != nullptr);
-  EXPECT_TRUE(si_element.GetNode(1) != nullptr);
-  EXPECT_TRUE(si_element.GetNode(2) != nullptr);
+  EXPECT_TRUE(si_element.GetSizeNode(0) != nullptr);
+  EXPECT_TRUE(si_element.GetSizeNode(1) != nullptr);
+  EXPECT_TRUE(si_element.GetSizeNode(2) != nullptr);
 }
 
 }  // namespace cpp_test

--- a/test/cpp/test_symint.cpp
+++ b/test/cpp/test_symint.cpp
@@ -1,0 +1,93 @@
+#include <gtest/gtest.h>
+
+#include <iostream>
+
+#include "cpp_test_util.h"
+#include "torch_xla/csrc/generated/LazyIr.h"
+#include "torch_xla/csrc/ir.h"
+#include "torch_xla/csrc/ops/dynamic_ir.h"
+#include "torch_xla/csrc/ops/ops.h"
+#include "torch_xla/csrc/torch_util.h"
+using std::cerr;
+
+namespace torch_xla {
+namespace cpp_test {
+
+TEST(SymintTest, TestSaticSymint) {
+  c10::SymInt static_symint(5);
+  SymIntElements si_element(static_symint);
+
+  std::vector<int64_t> upper_bound = si_element.GetUpperBounds();
+  EXPECT_EQ(upper_bound.size(), 1);
+  EXPECT_EQ(upper_bound[0], 5);
+
+  std::vector<bool> dynamic_dims = si_element.GetDynamicDims();
+  EXPECT_EQ(dynamic_dims.size(), 1);
+  EXPECT_EQ(dynamic_dims[0], false);
+
+  std::unordered_map<size_t, torch::lazy::NodePtr> size_node_map =
+      si_element.GetNodeMap();
+  // Static SymIntElements should not have size_node
+  EXPECT_EQ(size_node_map.size(), 0);
+}
+
+TEST(SymintTest, TestSaticSymints) {
+  // We have to init a std::vector<int64_t> here. Passing a temp variable to
+  // fromIntArrayRef will result in unexpected behavior.
+  std::vector<int64_t> sizes = {6, 19, 10};
+  c10::SymIntArrayRef static_symints =
+      c10::SymIntArrayRef::fromIntArrayRef(sizes);
+  SymIntElements si_element(static_symints);
+
+  std::vector<int64_t> upper_bound = si_element.GetUpperBounds();
+  EXPECT_EQ(upper_bound.size(), 3);
+  EXPECT_EQ(upper_bound, std::vector<int64_t>({6, 19, 10}));
+
+  std::vector<bool> dynamic_dims = si_element.GetDynamicDims();
+  EXPECT_EQ(dynamic_dims.size(), 3);
+  EXPECT_EQ(dynamic_dims, std::vector<bool>({false, false, false}));
+
+  std::unordered_map<size_t, torch::lazy::NodePtr> size_node_map =
+      si_element.GetNodeMap();
+  // Static SymIntElements should not have size_node
+  EXPECT_EQ(size_node_map.size(), 0);
+}
+
+TEST(SymintTest, TestDynamicSymint) {
+  torch::lazy::Value scalar_value =
+      torch::lazy::Value(ScalarOp(1.0, xla::F32), 0);
+  // Manully assign the torch::lazy::shape to avoid calling shape fn in this
+  // test. Note that we have to use one of those codegen ops so they take
+  // lazy::shape in constructor.
+  std::vector<torch::lazy::Shape> abs_lazy_shapes = {
+      torch::lazy::Shape(torch::kFloat, {1})};
+  torch::lazy::NodePtr abs_node =
+      torch::lazy::MakeNode<Abs>(scalar_value, std::move(abs_lazy_shapes));
+  torch::lazy::Value abs_value = torch::lazy::Value(abs_node, 0);
+  torch::lazy::NodePtr size_node =
+      torch::lazy::MakeNode<SizeNode>(abs_value, /*dim=*/0);
+  auto symint_node =
+      c10::make_intrusive<torch::lazy::SymIntNodeImpl>(size_node);
+  // This is not really a dynamic size per say but it is a symint that wraps
+  // around a SizeNode instead of a scalar.
+  c10::SymInt dynamic_symint = symint_node->toSymInt();
+
+  SymIntElements si_element(dynamic_symint);
+
+  std::vector<int64_t> upper_bound = si_element.GetUpperBounds();
+  EXPECT_EQ(upper_bound.size(), 1);
+  EXPECT_EQ(upper_bound[0], 1);
+
+  std::vector<bool> dynamic_dims = si_element.GetDynamicDims();
+  EXPECT_EQ(dynamic_dims.size(), 1);
+  EXPECT_EQ(dynamic_dims[0], true);
+
+  std::unordered_map<size_t, torch::lazy::NodePtr> size_node_map =
+      si_element.GetNodeMap();
+  EXPECT_EQ(size_node_map.size(), 1);
+  // look up the SizeNode for dimension 0
+  EXPECT_TRUE(si_element.GetNode(0) != nullptr);
+}
+
+}  // namespace cpp_test
+}  // namespace torch_xla

--- a/torch_xla/csrc/torch_util.cpp
+++ b/torch_xla/csrc/torch_util.cpp
@@ -7,7 +7,7 @@
 
 namespace torch_xla {
 
-void SymIntElements::SetSymIntNodeElements(c10::SymInt& size) {
+void SymIntElements::AddSymIntNodeElements(c10::SymInt& size) {
   if (size.is_symbolic()) {
     size_t current_index = upper_bounds_.size();
     // c10::SymInt --(convert)--> c10::SymIntNode --(cast)-->
@@ -28,9 +28,10 @@ void SymIntElements::SetSymIntNodeElements(c10::SymInt& size) {
   }
 }
 
-torch::lazy::NodePtr SymIntElements::GetNode(size_t index) {
-  if (size_node_map_.find(index) != size_node_map_.end()) {
-    return size_node_map_[index];
+torch::lazy::NodePtr SymIntElements::GetNode(size_t index) const {
+  auto iter = size_node_map_.find(index);
+  if (iter != size_node_map_.end()) {
+    return iter->second;
   }
   return nullptr;
 }

--- a/torch_xla/csrc/torch_util.h
+++ b/torch_xla/csrc/torch_util.h
@@ -16,26 +16,26 @@ namespace torch_xla {
 // Unpack SymInt objects into their building blocks
 struct SymIntElements {
  public:
-  SymIntElements(c10::SymInt& size) { SetSymIntNodeElements(size); }
+  SymIntElements(c10::SymInt& size) { AddSymIntNodeElements(size); }
   SymIntElements(c10::SymIntArrayRef& size) {
     std::vector<c10::SymInt> _sizes = torch::lazy::ToVector<c10::SymInt>(size);
     for (auto& _size : _sizes) {
-      SetSymIntNodeElements(_size);
+      AddSymIntNodeElements(_size);
     }
   }
-  std::unordered_map<size_t, torch::lazy::NodePtr> GetNodeMap() {
+  std::unordered_map<size_t, torch::lazy::NodePtr> GetNodeMap() const {
     return size_node_map_;
   }
-  std::vector<int64_t> GetUpperBounds() { return upper_bounds_; }
-  std::vector<bool> GetDynamicDims() { return dynamic_dims_; }
-  torch::lazy::NodePtr GetNode(size_t index);
+  std::vector<int64_t> GetUpperBounds() const { return upper_bounds_; }
+  std::vector<bool> GetDynamicDims() const { return dynamic_dims_; }
+  torch::lazy::NodePtr GetNode(size_t index) const;
   void SetUpperBound(int64_t index, int64_t upper_bound) {
     XLA_CHECK_GT(upper_bounds_.size(), index);
     upper_bounds_[index] = upper_bound;
   }
 
  private:
-  void SetSymIntNodeElements(c10::SymInt& size);
+  void AddSymIntNodeElements(c10::SymInt& size);
   std::unordered_map<size_t, torch::lazy::NodePtr> size_node_map_;
   std::vector<int64_t> upper_bounds_;
   std::vector<bool> dynamic_dims_;

--- a/torch_xla/csrc/torch_util.h
+++ b/torch_xla/csrc/torch_util.h
@@ -23,9 +23,12 @@ struct SymIntElements {
       SetSymIntNodeElements(_size);
     }
   }
-  std::vector<torch::lazy::NodePtr> GetNodes() { return size_nodes_; }
+  std::unordered_map<size_t, torch::lazy::NodePtr> GetNodeMap() {
+    return size_node_map_;
+  }
   std::vector<int64_t> GetUpperBounds() { return upper_bounds_; }
   std::vector<bool> GetDynamicDims() { return dynamic_dims_; }
+  torch::lazy::NodePtr GetNode(size_t index);
   void SetUpperBound(int64_t index, int64_t upper_bound) {
     XLA_CHECK_GT(upper_bounds_.size(), index);
     upper_bounds_[index] = upper_bound;
@@ -33,7 +36,7 @@ struct SymIntElements {
 
  private:
   void SetSymIntNodeElements(c10::SymInt& size);
-  std::vector<torch::lazy::NodePtr> size_nodes_;
+  std::unordered_map<size_t, torch::lazy::NodePtr> size_node_map_;
   std::vector<int64_t> upper_bounds_;
   std::vector<bool> dynamic_dims_;
 };

--- a/torch_xla/csrc/torch_util.h
+++ b/torch_xla/csrc/torch_util.h
@@ -23,12 +23,12 @@ struct SymIntElements {
       AddSymIntNodeElements(_size);
     }
   }
-  std::unordered_map<size_t, torch::lazy::NodePtr> GetNodeMap() const {
-    return size_node_map_;
-  }
+  std::vector<torch::lazy::NodePtr> GetSizeNodes() const { return size_nodes_; }
   std::vector<int64_t> GetUpperBounds() const { return upper_bounds_; }
   std::vector<bool> GetDynamicDims() const { return dynamic_dims_; }
-  torch::lazy::NodePtr GetNode(size_t index) const;
+  torch::lazy::NodePtr GetSizeNode(size_t index) const {
+    return size_nodes_[index];
+  }
   void SetUpperBound(int64_t index, int64_t upper_bound) {
     XLA_CHECK_GT(upper_bounds_.size(), index);
     upper_bounds_[index] = upper_bound;
@@ -36,7 +36,9 @@ struct SymIntElements {
 
  private:
   void AddSymIntNodeElements(c10::SymInt& size);
-  std::unordered_map<size_t, torch::lazy::NodePtr> size_node_map_;
+  // Only the symbolic symint will have a size_nodes, static symint
+  // will have a nullptr in this vector.
+  std::vector<torch::lazy::NodePtr> size_nodes_;
   std::vector<int64_t> upper_bounds_;
   std::vector<bool> dynamic_dims_;
 };


### PR DESCRIPTION
We don't need to create constant `size_node` for static dimensions. I don't think we ever want to call `SetDimensionSize` with a static dimension.

TODO
- [x] add cpp test 