### PR TITLE
Fix DDP initialization with XLA backend

### DIFF
--- a/test/pjrt/test_ddp.py
+++ b/test/pjrt/test_ddp.py
@@ -1,0 +1,37 @@
+from absl.testing import absltest, parameterized
+import torch.distributed as dist
+import torch.nn as nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+import torch_xla.core.xla_model as xm
+import torch_xla.distributed.xla_backend
+from torch_xla.experimental import pjrt
+
+
+def _init_xla_backend(init_file: str):
+  rank = xm.get_ordinal()
+  world_size = xm.xrt_world_size()
+
+  dist.init_process_group(
+    "xla",
+    init_method=f"file://{init_file}",
+    rank=rank,
+    world_size=world_size)
+
+class TestPjRtDistributedDataParallel(parameterized.TestCase):
+
+  @staticmethod
+  def _ddp_init(init_file: str):
+    _init_xla_backend(init_file)
+
+    device = xm.xla_device()
+    model = nn.Linear(10, 10).to(device)
+    ddp_model = DDP(model)
+
+  def test_ddp_init(self):
+    pjrt.run_multiprocess(
+      self._ddp_step,
+      self.create_tempfile().full_path)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/test/pjrt/test_ddp.py
+++ b/test/pjrt/test_ddp.py
@@ -12,10 +12,11 @@ def _init_xla_backend(init_file: str):
   world_size = xm.xrt_world_size()
 
   dist.init_process_group(
-    "xla",
-    init_method=f"file://{init_file}",
-    rank=rank,
-    world_size=world_size)
+      "xla",
+      init_method=f"file://{init_file}",
+      rank=rank,
+      world_size=world_size)
+
 
 class TestPjRtDistributedDataParallel(parameterized.TestCase):
 
@@ -28,9 +29,7 @@ class TestPjRtDistributedDataParallel(parameterized.TestCase):
     ddp_model = DDP(model)
 
   def test_ddp_init(self):
-    pjrt.run_multiprocess(
-      self._ddp_step,
-      self.create_tempfile().full_path)
+    pjrt.run_multiprocess(self._ddp_init, self.create_tempfile().full_path)
 
 
 if __name__ == "__main__":

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -111,6 +111,7 @@ function run_op_tests {
   run_xla_ir_debug python3 "$CDIR/test_env_var_mapper.py"
   run_pjrt python3 "$CDIR/pjrt/test_experimental_pjrt.py"
   run_pjrt python3 "$CDIR/pjrt/test_experimental_tpu.py"
+  run_pjrt python3 "$CDIR/pjrt/test_ddp.py"
   run_test python3 "$CDIR/test_operations_hlo.py" "$@" --verbosity=$VERBOSITY
 }
 

--- a/test/test_torch_distributed_xla_backend.py
+++ b/test/test_torch_distributed_xla_backend.py
@@ -155,12 +155,19 @@ class XlaBackendTest(unittest.TestCase):
     opts = dist.BroadcastOptions()
     opts.rootRank = 0
     opts.rootTensor = 0
+
+    # Sync value of `tensor` to remove constants 1 and 0 from graph
+    xm.mark_step()
+
     # xla doesn't have broadcast. We use all_reduce to implement broadcast.
     all_reduce_pattern = r'%all\-reduce\.\d+ = .+ all\-reduce\('
     with xm_cc_op_intercepted('all_reduce'):
       pg_xla.broadcast([tensor], opts)
     hlo = torch_xla._XLAC._get_xla_tensors_hlo([tensor])
     hlo_matches(hlo, all_reduce_pattern)
+
+    assert 'constant' not in hlo, hlo
+
     # purge all computations attached the device.
     xm.mark_step()
 

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -7,6 +7,7 @@ import os
 import re
 import threading
 import time
+from typing import List, Optional
 import torch
 import torch.nn.functional as F
 import torch_xla
@@ -760,6 +761,38 @@ def collective_permute(value, pairs):
   result = torch_xla._XLAC._xla_collective_permute(value, token, pairs)
   devctx.all_reduce_token = result[1]
   return result[0]
+
+
+def collective_broadcast(tensors: List[torch.Tensor],
+                         root_ordinal: int = 0,
+                         groups: Optional[List[int]] = None,
+                         pin_layout: bool = True) -> None:
+  """Broadcast values of `tensors` from root replica to other replicas in-place.
+
+  Args:
+    tensors (list): List of `torch.Tensor`s to broadcast.
+    root_ordinal (int): Ordinal of replica with values to broadcast.
+    groups (list, optional): A list of list, representing the replica groups for
+      the `all_reduce()` operation. Example: `[[0, 1, 2, 3], [4, 5, 6, 7]]`
+        defines two groups, one with the `[0, 1, 2, 3]` replicas and one with
+        the `[4, 5, 6, 7]` replicas. If `None` there will be only one group with
+        all the replicas in it.
+    pin_layout (bool, optional): whether to pin the layout for this communication op.
+      Layout pining can prevent potential data corruption when each process that
+      participate in the communication has slightly different program, but it might
+      cause some xla compiation to fail. Unpin the layout when you see error message
+      like "HloModule has a mix of layout constrained".
+  """
+  for tensor in tensors:
+    with torch.no_grad():
+      scale = torch.tensor(
+          1 if get_ordinal() == root_ordinal else 0, dtype=tensor.dtype)
+      # Transfer scale tensor as device data instead of constant 1 or 0 to
+      # prevent differences between replicas' graphs
+      xscale = send_cpu_data_to_device(scale, tensor.device)
+      tensor.mul_(xscale)
+
+  all_reduce(REDUCE_SUM, tensors, groups=groups, pin_layout=pin_layout)
 
 
 def send(value, channel_id):

--- a/torch_xla/distributed/xla_backend.py
+++ b/torch_xla/distributed/xla_backend.py
@@ -82,12 +82,10 @@ class ProcessGroupXla(ProcessGroup):
   # https://github.com/pytorch/pytorch/blob/release/1.10/torch/distributed/distributed_c10d.py#L1129
   def broadcast(self, tensors, opts):
     root_tensor = tensors[opts.rootTensor]
-    with torch.no_grad():
-      scale = 1 if opts.rootRank != self.rank() else 0
-      root_tensor = root_tensor * scale
-
-    xm.all_reduce(
-        xm.REDUCE_SUM, [root_tensor], groups=self._mesh, pin_layout=False)
+    xm.collective_broadcast([root_tensor],
+                            opts.rootRank,
+                            groups=self._mesh,
+                            pin_layout=False)
 
     return _ret_work([root_tensor])
 

--- a/torch_xla/distributed/xla_backend.py
+++ b/torch_xla/distributed/xla_backend.py
@@ -70,7 +70,7 @@ class ProcessGroupXla(ProcessGroup):
     xm.all_reduce(reduce_type, tensors, groups=self._mesh, pin_layout=False)
     return _ret_work(tensors)
 
-  def allgather(self, output_tensors_list, input_tensors):
+  def allgather(self, output_tensors_list, input_tensors, opts=None):
     for input_tensor, output_tensors in zip(input_tensors, output_tensors_list):
       result = xm.all_gather(input_tensor, groups=self._mesh, pin_layout=False)
       for i, slice in enumerate(torch.split(result, input_tensor.shape[0])):
@@ -82,10 +82,8 @@ class ProcessGroupXla(ProcessGroup):
   # https://github.com/pytorch/pytorch/blob/release/1.10/torch/distributed/distributed_c10d.py#L1129
   def broadcast(self, tensors, opts):
     root_tensor = tensors[opts.rootTensor]
-    root_rank = opts.rootRank
-    if root_rank != self.rank():
-      with torch.no_grad():
-        root_tensor.zero_()
+    scale = 1 if opts.rootRank != self.rank() else 0
+    root_tensor = root_tensor * scale
     xm.all_reduce(
         xm.REDUCE_SUM, [root_tensor], groups=self._mesh, pin_layout=False)
 

--- a/torch_xla/distributed/xla_backend.py
+++ b/torch_xla/distributed/xla_backend.py
@@ -82,8 +82,10 @@ class ProcessGroupXla(ProcessGroup):
   # https://github.com/pytorch/pytorch/blob/release/1.10/torch/distributed/distributed_c10d.py#L1129
   def broadcast(self, tensors, opts):
     root_tensor = tensors[opts.rootTensor]
-    scale = 1 if opts.rootRank != self.rank() else 0
-    root_tensor = root_tensor * scale
+    with torch.no_grad():
+      scale = 1 if opts.rootRank != self.rank() else 0
+      root_tensor = root_tensor * scale
+
     xm.all_reduce(
         xm.REDUCE_SUM, [root_tensor], groups=self._mesh, pin_layout=False)
 

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -216,16 +216,8 @@ def broadcast_master_param(model: nn.Module) -> None:
   """
   Broadcast the model parameters from master process to other processes
   """
-  parameters_and_buffers = []
-  is_master = xm.is_master_ordinal(local=False)
-  for p in chain(model.parameters(), model.buffers()):
-    # Set all params in non-master devices to zero so that all_reduce is
-    # equivalent to broadcasting parameters from master to other devices.
-    scale = torch.tensor(1 if is_master else 0, dtype=p.data.dtype)
-    scale = scale.to(p.data.device)
-    p.data.mul_(scale)
-    parameters_and_buffers.append(p.data)
-  xm.all_reduce(xm.REDUCE_SUM, parameters_and_buffers)
+  parameters_and_buffers = list(chain(model.parameters(), model.buffers()))
+  xm.collective_broadcast(parameters_and_buffers)
   xm.mark_step()
 
 


### PR DESCRIPTION
Merging parts from #3915 that work.

- Add [`opts` argument](https://github.com/pytorch/pytorch/blob/a85d1f0bcdd02cf18d3b0517337458cb51a18cdb/torch/_C/_distributed_c10d.pyi#L212-L217) to `allgather` to fix `TypeError: allgather() takes 3 positional arguments but 4 were given during initialization`
- Refactor `broadcast` to produce the same graph on all replicas to avoid hanging on `REDUCE_SUM`.
- Add CI test to confirm initialization works on CPU

Manually tested on TPU v4.