### PR TITLE
Make SizeNode to use XlaShape and add test

### DIFF
--- a/test/cpp/test_ir.cpp
+++ b/test/cpp/test_ir.cpp
@@ -109,8 +109,6 @@ TEST(IrTest, TestSizeNode) {
 
   EXPECT_EQ(dim_node_0->getStaticValue(), 3);
   EXPECT_EQ(dim_node_1->getStaticValue(), 4);
-  EXPECT_FALSE(dim_node_0->isSymbolic());
-  EXPECT_FALSE(dim_node_1->isSymbolic());
 
   ForEachDevice([&](const torch::lazy::BackendDevice& device) {
     // Lower the SizeNode and execute the GetDimensionSize.
@@ -133,7 +131,6 @@ TEST(IrTest, TestSizeAddNode) {
       std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node_add);
 
   EXPECT_EQ(dim_node_add->getStaticValue(), 7);
-  EXPECT_FALSE(dim_node_add->isSymbolic());
 
   ForEachDevice([&](const torch::lazy::BackendDevice& device) {
     // Lower the SizeAddNode and execute the GetDimensionSize.
@@ -155,7 +152,6 @@ TEST(IrTest, TestSizeMulNode) {
       std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node_mul);
 
   EXPECT_EQ(dim_node_mul->getStaticValue(), 12);
-  EXPECT_FALSE(dim_node_mul->isSymbolic());
 
   ForEachDevice([&](const torch::lazy::BackendDevice& device) {
     // Lower the SizeAddNode and execute the GetDimensionSize.
@@ -177,7 +173,6 @@ TEST(IrTest, TestSizeDivNode) {
       std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node_div);
 
   EXPECT_EQ(dim_node_div->getStaticValue(), 2);
-  EXPECT_FALSE(dim_node_div->isSymbolic());
 
   ForEachDevice([&](const torch::lazy::BackendDevice& device) {
     // Lower the SizeAddNode and execute the GetDimensionSize.

--- a/test/cpp/test_ir.cpp
+++ b/test/cpp/test_ir.cpp
@@ -120,27 +120,27 @@ TEST(IrTest, TestSizeNode) {
   });
 }
 
-// TEST(IrTest, TestSizeAddNode) {
-//   torch::lazy::NodePtr scalar_node =
-//       ScalarOp(1.0, xla::ShapeUtil::MakeShape(xla::F32, {3, 4}));
-//   torch::lazy::NodePtr size_node_0 =
-//       torch::lazy::MakeNode<SizeNode>(scalar_node, 0);
-//   torch::lazy::NodePtr size_node_1 =
-//       torch::lazy::MakeNode<SizeNode>(scalar_node, 1);
-//   torch::lazy::NodePtr size_node_add =
-//       torch::lazy::MakeNode<SizeAdd>(size_node_0, size_node_1);
-//   std::shared_ptr<torch::lazy::DimensionNode> dim_node_add =
-//       std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node_add);
+TEST(IrTest, TestSizeAddNode) {
+  torch::lazy::NodePtr scalar_node =
+      ScalarOp(1.0, xla::ShapeUtil::MakeShape(xla::F32, {3, 4}));
+  torch::lazy::NodePtr size_node_0 =
+      torch::lazy::MakeNode<SizeNode>(scalar_node, 0);
+  torch::lazy::NodePtr size_node_1 =
+      torch::lazy::MakeNode<SizeNode>(scalar_node, 1);
+  torch::lazy::NodePtr size_node_add =
+      torch::lazy::MakeNode<SizeAdd>(size_node_0, size_node_1);
+  std::shared_ptr<torch::lazy::DimensionNode> dim_node_add =
+      std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node_add);
 
-//   EXPECT_EQ(dim_node_add->getStaticValue(), 7);
-//   EXPECT_FALSE(dim_node_add->isSymbolic());
+  EXPECT_EQ(dim_node_add->getStaticValue(), 7);
+  EXPECT_FALSE(dim_node_add->isSymbolic());
 
-//   ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-//     // Lower the SizeNode and execute the GetDimensionSize.
-//     auto results = ExecuteAndFetch({size_node_add}, device);
-//     EXPECT_EQ(results[0].sum().item().toInt(), 7);
-//   });
-// }
+  ForEachDevice([&](const torch::lazy::BackendDevice& device) {
+    // Lower the SizeAddNode and execute the GetDimensionSize.
+    auto results = ExecuteAndFetch({size_node_add}, device);
+    EXPECT_EQ(results[0].sum().item().toInt(), 7);
+  });
+}
 
 }  // namespace cpp_test
 }  // namespace torch_xla

--- a/test/cpp/test_ir.cpp
+++ b/test/cpp/test_ir.cpp
@@ -106,6 +106,7 @@ TEST(IrTest, TestSizeNode) {
       std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node_0);
   std::shared_ptr<torch::lazy::DimensionNode> dim_node_1 =
       std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node_1);
+
   EXPECT_EQ(dim_node_0->getStaticValue(), 3);
   EXPECT_EQ(dim_node_1->getStaticValue(), 4);
   EXPECT_FALSE(dim_node_0->isSymbolic());
@@ -118,6 +119,28 @@ TEST(IrTest, TestSizeNode) {
     EXPECT_EQ(results[1].sum().item().toInt(), 4);
   });
 }
+
+// TEST(IrTest, TestSizeAddNode) {
+//   torch::lazy::NodePtr scalar_node =
+//       ScalarOp(1.0, xla::ShapeUtil::MakeShape(xla::F32, {3, 4}));
+//   torch::lazy::NodePtr size_node_0 =
+//       torch::lazy::MakeNode<SizeNode>(scalar_node, 0);
+//   torch::lazy::NodePtr size_node_1 =
+//       torch::lazy::MakeNode<SizeNode>(scalar_node, 1);
+//   torch::lazy::NodePtr size_node_add =
+//       torch::lazy::MakeNode<SizeAdd>(size_node_0, size_node_1);
+//   std::shared_ptr<torch::lazy::DimensionNode> dim_node_add =
+//       std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node_add);
+
+//   EXPECT_EQ(dim_node_add->getStaticValue(), 7);
+//   EXPECT_FALSE(dim_node_add->isSymbolic());
+
+//   ForEachDevice([&](const torch::lazy::BackendDevice& device) {
+//     // Lower the SizeNode and execute the GetDimensionSize.
+//     auto results = ExecuteAndFetch({size_node_add}, device);
+//     EXPECT_EQ(results[0].sum().item().toInt(), 7);
+//   });
+// }
 
 }  // namespace cpp_test
 }  // namespace torch_xla

--- a/test/cpp/test_ir.cpp
+++ b/test/cpp/test_ir.cpp
@@ -4,6 +4,7 @@
 #include "torch_xla/csrc/ir.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/ops/arithmetic_ir_ops.h"
+#include "torch_xla/csrc/ops/dynamic_ir.h"
 #include "torch_xla/csrc/ops/ops.h"
 #include "torch_xla/csrc/ops/scalar.h"
 #include "torch_xla/csrc/ops/select.h"
@@ -92,6 +93,30 @@ TEST(IrTest, TestScopePusherWithDebugging) {
   ASSERT_TRUE(metaWithScope.scope.find("TestScope") != std::string::npos);
   EXPECT_EQ(metaWithScope.frame_info.size(), 1);
   FLAGS_torch_lazy_ir_debug = restore_FLAGS_torch_lazy_ir_debug;
+}
+
+TEST(IrTest, TestSizeNode) {
+  torch::lazy::NodePtr scalar_node =
+      ScalarOp(1.0, xla::ShapeUtil::MakeShape(xla::F32, {3, 4}));
+  torch::lazy::NodePtr size_node_0 =
+      torch::lazy::MakeNode<SizeNode>(scalar_node, 0);
+  torch::lazy::NodePtr size_node_1 =
+      torch::lazy::MakeNode<SizeNode>(scalar_node, 1);
+  std::shared_ptr<torch::lazy::DimensionNode> dim_node_0 =
+      std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node_0);
+  std::shared_ptr<torch::lazy::DimensionNode> dim_node_1 =
+      std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node_1);
+  EXPECT_EQ(dim_node_0->getStaticValue(), 3);
+  EXPECT_EQ(dim_node_1->getStaticValue(), 4);
+  EXPECT_FALSE(dim_node_0->isSymbolic());
+  EXPECT_FALSE(dim_node_1->isSymbolic());
+
+  ForEachDevice([&](const torch::lazy::BackendDevice& device) {
+    // Lower the SizeNode and execute the GetDimensionSize.
+    auto results = ExecuteAndFetch({size_node_0, size_node_1}, device);
+    EXPECT_EQ(results[0].sum().item().toInt(), 3);
+    EXPECT_EQ(results[1].sum().item().toInt(), 4);
+  });
 }
 
 }  // namespace cpp_test

--- a/test/cpp/test_symint.cpp
+++ b/test/cpp/test_symint.cpp
@@ -82,7 +82,7 @@ TEST(SymintTest, TestDynamicSymint) {
 
   std::vector<torch::lazy::NodePtr> size_nodes = si_element.GetSizeNodes();
   EXPECT_EQ(size_nodes.size(), 1);
-  EXPECT_TRUE(si_element.GetSizeNode(0) != nullptr);
+  EXPECT_EQ(si_element.GetSizeNode(0), size_node);
 }
 
 TEST(SymintTest, TestDynamicSymints) {
@@ -93,9 +93,11 @@ TEST(SymintTest, TestDynamicSymints) {
       torch::lazy::MakeNode<Expand>(scalar_value, target_size);
   torch::lazy::Value expand_value = torch::lazy::Value(expand_node, 0);
   std::vector<c10::SymInt> dynamic_symints;
+  std::vector<torch::lazy::NodePtr> size_nodes;
   for (int i = 0; i < 3; i++) {
     torch::lazy::NodePtr size_node =
         torch::lazy::MakeNode<SizeNode>(expand_value, /*dim=*/i);
+    size_nodes.push_back(size_node);
     auto symint_node =
         c10::make_intrusive<torch::lazy::SymIntNodeImpl>(size_node);
     // This is not a dynamic size from xla perspective but it is a symint that
@@ -114,12 +116,10 @@ TEST(SymintTest, TestDynamicSymints) {
   EXPECT_EQ(dynamic_dims.size(), 3);
   EXPECT_EQ(dynamic_dims, std::vector<bool>({true, true, true}));
 
-  std::vector<torch::lazy::NodePtr> size_nodes = si_element.GetSizeNodes();
-  EXPECT_EQ(size_nodes.size(), 3);
-  // look up the SizeNode for dimension 0
-  EXPECT_TRUE(si_element.GetSizeNode(0) != nullptr);
-  EXPECT_TRUE(si_element.GetSizeNode(1) != nullptr);
-  EXPECT_TRUE(si_element.GetSizeNode(2) != nullptr);
+  std::vector<torch::lazy::NodePtr> si_element_size_nodes =
+      si_element.GetSizeNodes();
+  EXPECT_EQ(si_element_size_nodes.size(), 3);
+  EXPECT_EQ(si_element_size_nodes, size_nodes);
 }
 
 }  // namespace cpp_test

--- a/torch_xla/csrc/ops/dynamic_ir.cpp
+++ b/torch_xla/csrc/ops/dynamic_ir.cpp
@@ -13,7 +13,7 @@ namespace torch_xla {
 
 SizeNode::SizeNode(torch::lazy::Value input, size_t dim)
     : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::size")},
-              {input}, xla::ShapeUtil::MakeShape(xla::S32, {}), 1,
+              {input}, xla::ShapeUtil::MakeShape(xla::S64, {}), 1,
               torch::lazy::MHash(dim)),
       dim_(dim){};
 
@@ -34,7 +34,7 @@ std::string SizeNode::ToString() const { return "SizeNode"; }
 
 SizeAdd::SizeAdd(torch::lazy::Value a, torch::lazy::Value b)
     : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::add")},
-              {a, b}, xla::ShapeUtil::MakeShape(xla::S32, {}), 1) {
+              {a, b}, xla::ShapeUtil::MakeShape(xla::S64, {}), 1) {
   // SizeAdd can only be perfomed between two DimensionNode
   XLA_CHECK(DimCast(operand(0)));
   XLA_CHECK(DimCast(operand(1)));
@@ -55,7 +55,7 @@ XlaOpVector SizeAdd::Lower(LoweringContext* loctx) const {
 
 SizeMul::SizeMul(torch::lazy::Value a, torch::lazy::Value b)
     : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::mul")},
-              {a, b}, xla::ShapeUtil::MakeShape(xla::S32, {}), 1) {
+              {a, b}, xla::ShapeUtil::MakeShape(xla::S64, {}), 1) {
   // SizeMul can only be perfomed between two DimensionNode
   XLA_CHECK(DimCast(operand(0)));
   XLA_CHECK(DimCast(operand(1)));
@@ -76,7 +76,7 @@ XlaOpVector SizeMul::Lower(LoweringContext* loctx) const {
 
 SizeDiv::SizeDiv(torch::lazy::Value a, torch::lazy::Value b)
     : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::div")},
-              {a, b}, xla::ShapeUtil::MakeShape(xla::S32, {}), 1) {
+              {a, b}, xla::ShapeUtil::MakeShape(xla::S64, {}), 1) {
   // SizeDiv can only be perfomed between two DimensionNode
   XLA_CHECK(DimCast(operand(0)));
   XLA_CHECK(DimCast(operand(1)));

--- a/torch_xla/csrc/ops/dynamic_ir.cpp
+++ b/torch_xla/csrc/ops/dynamic_ir.cpp
@@ -30,14 +30,6 @@ int64_t SizeNode::getStaticValue() const {
       .dimensions(dim_);
 }
 
-bool SizeNode::isSymbolic() const {
-  // Not all IR has torch::lazy::shape now, use xla::shape to unblock
-  // the development.
-  return dynamic_cast<const XlaNode*>(operand(0).node)
-      ->xla_shape(operand(0).index)
-      .is_dynamic_dimension(dim_);
-}
-
 std::string SizeNode::ToString() const { return "SizeNode"; }
 
 SizeAdd::SizeAdd(torch::lazy::Value a, torch::lazy::Value b)
@@ -51,10 +43,6 @@ SizeAdd::SizeAdd(torch::lazy::Value a, torch::lazy::Value b)
 int64_t SizeAdd::getStaticValue() const {
   return DimCast(operand(0))->getStaticValue() +
          DimCast(operand(1))->getStaticValue();
-}
-
-bool SizeAdd::isSymbolic() const {
-  return DimCast(operand(0))->isSymbolic() || DimCast(operand(1))->isSymbolic();
 }
 
 std::string SizeAdd::ToString() const { return "SizeAdd"; }
@@ -78,10 +66,6 @@ int64_t SizeMul::getStaticValue() const {
          DimCast(operand(1))->getStaticValue();
 }
 
-bool SizeMul::isSymbolic() const {
-  return DimCast(operand(0))->isSymbolic() || DimCast(operand(1))->isSymbolic();
-}
-
 std::string SizeMul::ToString() const { return "SizeMul"; }
 
 XlaOpVector SizeMul::Lower(LoweringContext* loctx) const {
@@ -103,10 +87,6 @@ int64_t SizeDiv::getStaticValue() const {
       << "Can't divide a dimension by zero";
   return DimCast(operand(0))->getStaticValue() /
          DimCast(operand(1))->getStaticValue();
-}
-
-bool SizeDiv::isSymbolic() const {
-  return DimCast(operand(0))->isSymbolic() || DimCast(operand(1))->isSymbolic();
 }
 
 std::string SizeDiv::ToString() const { return "SizeDiv"; }

--- a/torch_xla/csrc/ops/dynamic_ir.cpp
+++ b/torch_xla/csrc/ops/dynamic_ir.cpp
@@ -23,15 +23,19 @@ XlaOpVector SizeNode::Lower(LoweringContext* loctx) const {
 }
 
 int64_t SizeNode::getStaticValue() const {
-  return operand(0).node->shape(0).size(dim_);
+  // Not all IR has torch::lazy::shape now, use xla::shape to unblock
+  // the development.
+  return dynamic_cast<const XlaNode*>(operand(0).node)
+      ->xla_shape(operand(0).index)
+      .dimensions(dim_);
 }
 
 bool SizeNode::isSymbolic() const {
-  auto symbolic_vec = operand(0).node->shape(0).is_symbolic();
-  if (!symbolic_vec.has_value()) {
-    return true;
-  }
-  return symbolic_vec->at(dim_);
+  // Not all IR has torch::lazy::shape now, use xla::shape to unblock
+  // the development.
+  return dynamic_cast<const XlaNode*>(operand(0).node)
+      ->xla_shape(operand(0).index)
+      .is_dynamic_dimension(dim_);
 }
 
 std::string SizeNode::ToString() const { return "SizeNode"; }

--- a/torch_xla/csrc/ops/dynamic_ir.h
+++ b/torch_xla/csrc/ops/dynamic_ir.h
@@ -39,7 +39,7 @@ class SizeNode : public XlaNode, public torch::lazy::DimensionNode {
  public:
   SizeNode(torch::lazy::Value input, size_t dim);
   int64_t getStaticValue() const override;
-  bool isSymbolic() const override;
+  bool isSymbolic() const override { return true; }
   std::string ToString() const override;
   virtual XlaOpVector Lower(LoweringContext* loctx) const override;
 
@@ -51,7 +51,7 @@ class SizeAdd : public XlaNode, public torch::lazy::DimensionNode {
  public:
   SizeAdd(torch::lazy::Value a, torch::lazy::Value b);
   int64_t getStaticValue() const override;
-  bool isSymbolic() const override;
+  bool isSymbolic() const override { return true; }
   std::string ToString() const override;
   virtual XlaOpVector Lower(LoweringContext* loctx) const override;
 };
@@ -60,7 +60,7 @@ class SizeMul : public XlaNode, public torch::lazy::DimensionNode {
  public:
   SizeMul(torch::lazy::Value a, torch::lazy::Value b);
   int64_t getStaticValue() const override;
-  bool isSymbolic() const override;
+  bool isSymbolic() const override { return true; }
   std::string ToString() const override;
   virtual XlaOpVector Lower(LoweringContext* loctx) const override;
 };
@@ -69,7 +69,7 @@ class SizeDiv : public XlaNode, public torch::lazy::DimensionNode {
  public:
   SizeDiv(torch::lazy::Value a, torch::lazy::Value b);
   int64_t getStaticValue() const override;
-  bool isSymbolic() const override;
+  bool isSymbolic() const override { return true; }
   std::string ToString() const override;
   virtual XlaOpVector Lower(LoweringContext* loctx) const override;
 };


### PR DESCRIPTION
Not all of the Ops has `torch::lazy::shape`, fallback to use `xla_shape` to check for upperbound and is_dynamic. 

TODO:
- [x] add test for other SizeNodes