### PR TITLE
Make expand to support is_alias_of

### DIFF
--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1087,9 +1087,11 @@ XLATensorPtr XLATensor::exp(const XLATensorPtr& input) {
 XLATensorPtr XLATensor::expand(const XLATensorPtr& input,
                                std::vector<int64_t> size) {
   auto input_shape = input->shape();
-  return input->CreateFrom(torch::lazy::MakeNode<Expand>(
+  auto output = input->CreateFrom(torch::lazy::MakeNode<Expand>(
       input->GetIrValue(),
       GetExpandDimensions(input_shape.get(), std::move(size))));
+  output->storage_ = input->Storage();
+  return output;
 }
 
 void XLATensor::exponential_(XLATensorPtr& input, double lambd) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3961
* #3960
* #3959

Summary:
Expand is diffcult to express by using view tensors, and therefore the
storage bit or is_alias_of bit will not be correctly set. Set that manually.

Test Plan:
./test/cpp/build/test_ptxla --gtest_filter=AtenXlaTensorTest.TestExpand