### PR TITLE
Fix the location of libxla_computation_client.so

### DIFF
--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -128,7 +128,7 @@ target_link_libraries(
   -Wl,--unresolved-symbols=ignore-in-shared-libs
   "${TORCH_LIBRARIES}"
   "${PTXLA_LIB}"
-  "${PTXLA_LIBDIR}/torch_xla/lib/libxla_computation_client.so"
+  "${PTXLA_DIR}/torch_xla/lib/libxla_computation_client.so"
   "${PTPY_LIB}"
   "${BINARY_DIR}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}gtest.a"
   "${PYTHON_LIBRARY}"


### PR DESCRIPTION
Summary:
Update the location of libxla_computation_client.so to the correct place
while building the cpp test binary.

Test Plan:
CI for builiding the cpp test binary.