### PR TITLE
Support Tensor.is_alias_of

### DIFF
--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -1195,6 +1195,8 @@ class XLATensor : public c10::intrusive_ptr_target {
                        bool manual);
   void ClearShardingSpec();
 
+  const c10::Storage& Storage() const { return storage_; }
+
  private:
   struct SyncTensorsConfig {
     // Whether we want to force XLA data on the target tensors (hence trimming
@@ -1465,6 +1467,12 @@ class XLATensor : public c10::intrusive_ptr_target {
   bool ShouldSyncIrNode();
 
   std::shared_ptr<Data> data_;
+  // Temporarily used to suport Tensor.is_alias_of().
+  // This is a fake storage that doesn't store anything.
+  // Instead it serves as a marker to mark LazyTensors that
+  // points to the same storage, and thus alias of each other.
+  // FIXME(alanwaketan): Remove this once we have functionalization (bdhirsh).
+  c10::Storage storage_;
 };
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -186,10 +186,8 @@ void XLATensorImpl::AtenInitialize() {
   // ATEN specific initialization calls placed below.
 }
 
-const at::Storage& XLATensorImpl::storage() const {
-  XLA_ERROR() << "XLA tensors do not have storage";
-}
+const at::Storage& XLATensorImpl::storage() const { return tensor_->Storage(); }
 
-bool XLATensorImpl::has_storage() const { return false; }
+bool XLATensorImpl::has_storage() const { return tensor_->Storage(); }
 
 }  // namespace torch_xla


### PR DESCRIPTION
Summary:
Tensor.is_alias_of relies on Storage to perform. However, XLATensorImpl was
not implemented with that in mind. This commit adds a fake storage to XLATensor
as a marker to mark XLATensor that point to the same storage. The reason
why it's not done at XLATensorImpl is that XLATensor maintains the view ops/alias
logic in XLATensor class instead of relying on XLATensorImpl to do the check.

Test Plan:
./test/cpp/build/test_ptxla --gtest_filter=AtenXlaTensorTest.TestViewIsAliasOf