### PR TITLE
Make expand to support is_alias_of

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -11232,5 +11232,17 @@ TEST_F(AtenXlaTensorTest, TestViewIsAliasOf) {
   });
 }
 
+TEST_F(AtenXlaTensorTest, TestExpandIsAliasOf) {
+  torch::Tensor a = torch::empty(4, torch::TensorOptions(torch::kFloat));
+  torch::Tensor b = a.expand(4, 3);
+  EXPECT_TRUE(a.is_alias_of(b));
+
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_a = CopyToDevice(a, device);
+    torch::Tensor xla_b = xla_a.expand(4, 3);
+    EXPECT_EQ(a.is_alias_of(b), xla_a.is_alias_of(xla_b));
+  });
+}
+
 }  // namespace cpp_test
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1087,9 +1087,11 @@ XLATensorPtr XLATensor::exp(const XLATensorPtr& input) {
 XLATensorPtr XLATensor::expand(const XLATensorPtr& input,
                                std::vector<int64_t> size) {
   auto input_shape = input->shape();
-  return input->CreateFrom(torch::lazy::MakeNode<Expand>(
+  auto output = input->CreateFrom(torch::lazy::MakeNode<Expand>(
       input->GetIrValue(),
       GetExpandDimensions(input_shape.get(), std::move(size))));
+  output->storage_ = input->Storage();
+  return output;
 }
 
 void XLATensor::exponential_(XLATensorPtr& input, double lambd) {


### PR DESCRIPTION
Summary:
Expand is diffcult to express by using view tensors, and therefore the
storage bit or is_alias_of bit will not be correctly set. Set that manually.

Test Plan:
./test/cpp/build/test_ptxla --gtest_filter=AtenXlaTensorTest.TestExpand