### PR TITLE
Revert "Add libtpu configuration to cpp test script"

### DIFF
--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -47,11 +47,6 @@ if [[ "$TPUVM_MODE" != "1" ]]; then
   export XLA_EXPERIMENTAL
 fi
 
-# We need to configure the libtpu path to test on TPUVM
-if python -c "import libtpu" &> /dev/null; then
-  export TPU_LIBRARY_PATH=$(dirname $(python -c "import libtpu; print(libtpu.__file__)"))/libtpu.so
-fi
-
 rm -rf "$BUILDDIR"
 mkdir "$BUILDDIR" 2>/dev/null
 pushd "$BUILDDIR"


### PR DESCRIPTION
Reverts pytorch/xla#3957

I am going to revert this change to unblock TPUVM wheel build. This pr itself fixed the CPP test issue on libtpu. However due to an known issue in libtpu, the build will fail with
```
Step #2: Failed to get worker list with error: Failed to fetch URL (http status: 404) No errorF0904 10:21:33.187127      33 enforce_kernel_ipv6_support.cc:72] Check failed: loopback6_ok || !loopback4_ok This machine (fc0bad92a47e) does not have an IPv6 loopback (::1) interface.  This configuration is obsolete.  You may temporarily set --enforce_kernel_ipv6_support=false to bypass this check, but code elsewhere in g3      may fail as result.  See gl_________________30/topics/localhost for details.
Step #2: *** Check failure stack trace: ***
Step #2:     @     0x7fadb4b71164  (unknown)
```

For some reason our wheel build will trigger the cpp test(with the xla:CPU I believe). With this change, the TPUVM build will try to load the libtpu and hence fail the whole build. I think we should check both `XRT_TPU_CONFIG` or `PJRT_DEVICE == TPU` before loading libtpu in cpp test. Running a cpp test using xla:CPU sounds weird when publishing a tpu wheel, we should use XLA:TPU.
