### PR TITLE
[PJRT] Remove thread-local replica ordinals

### DIFF
--- a/test/pjrt/test_experimental_pjrt_multi_cpu.py
+++ b/test/pjrt/test_experimental_pjrt_multi_cpu.py
@@ -1,8 +1,9 @@
+import itertools
 import os
-import collections
-import torch
-import torch_xla
+
 from absl.testing import absltest, parameterized
+
+import torch
 import torch_xla.core.xla_model as xm
 import torch_xla.core.xla_env_vars as xenv
 from torch_xla.experimental import pjrt
@@ -13,10 +14,15 @@ class TestExperimentalPjrtMultiCpu(parameterized.TestCase):
   def setUp(self):
     pjrt.set_device_type('CPU')
 
+    os.environ.update({
+        xenv.PJRT_CPU_ASYNC_CLIENT: 'true',
+        xenv.CPU_NUM_DEVICES: '4',
+    })
+
+  def test_default_cpu_device(self):
     os.environ.pop(xenv.CPU_NUM_DEVICES, None)
     os.environ.pop(xenv.PJRT_CPU_ASYNC_CLIENT, None)
 
-  def test_default_cpu_device(self):
     expected = {0: {0: torch.device('xla:0'),}}
     devices_per_process = pjrt.run_multiprocess(xm.xla_device)
     self.assertDictEqual(devices_per_process, expected)
@@ -30,12 +36,67 @@ class TestExperimentalPjrtMultiCpu(parameterized.TestCase):
             3: torch.device('xla:3')
         }
     }
+
+    devices_per_process = pjrt.run_multiprocess(xm.xla_device)
+    self.assertDictEqual(devices_per_process, expected)
+
+
+  @parameterized.named_parameters(('xla_model', xm.get_ordinal),
+                                  ('pjrt', pjrt.global_ordinal))
+  def test_global_ordinal(self, ordinal_func):
+    results = pjrt.run_multiprocess(ordinal_func)
+    values = list(
+        itertools.chain.from_iterable(row.values() for row in results.values()))
+    self.assertListEqual(sorted(values), [0, 1, 2, 3])
+
+
+  @parameterized.named_parameters(('xla_model', xm.get_local_ordinal),
+                                  ('pjrt', pjrt.local_ordinal))
+  def test_local_ordinal(self, ordinal_func):
+    # TODO(wcromar): add multiprocess tests
+    results = pjrt.run_multiprocess(ordinal_func)
+    values = list(
+        itertools.chain.from_iterable(row.values() for row in results.values()))
+    self.assertListEqual(sorted(values), [0, 1, 2, 3])
+
+
+  @staticmethod
+  def _multi_cpu_backwards():
+    results = {}
+
+    class _CustomBackwards(torch.autograd.Function):
+      @staticmethod
+      def forward(ctx, x):
+        rank = xm.get_ordinal()
+        ctx.forward_rank = rank
+        return x
+
+      @staticmethod
+      def backward(ctx, grad_output):
+        results['forward_ordinal'] = ctx.forward_rank
+        results['backward_ordinal'] = xm.get_ordinal()
+        results['device'] = str(xm.xla_device())
+        return grad_output
+
+    x = torch.ones(1, requires_grad=True, device=xm.xla_device())
+    y = _CustomBackwards.apply(x)
+    y.backward()
+    xm.mark_step()
+
+    return results
+
+  def test_multi_cpu_backwards(self):
     os.environ.update({
         xenv.PJRT_CPU_ASYNC_CLIENT: 'true',
         xenv.CPU_NUM_DEVICES: '4',
     })
-    devices_per_process = pjrt.run_multiprocess(xm.xla_device)
-    self.assertDictEqual(devices_per_process, expected)
+
+    expected = {
+      0: {i: {'forward_ordinal': i, 'backward_ordinal': i, 'device': f'xla:{i}'} for i in range(4)}
+    }
+    results = pjrt.run_multiprocess(self._multi_cpu_backwards)
+
+    self.assertDictEqual(results, expected)
 
 
 if __name__ == '__main__':

--- a/test/pjrt/test_experimental_pjrt_multi_cpu.py
+++ b/test/pjrt/test_experimental_pjrt_multi_cpu.py
@@ -40,7 +40,6 @@ class TestExperimentalPjrtMultiCpu(parameterized.TestCase):
     devices_per_process = pjrt.run_multiprocess(xm.xla_device)
     self.assertDictEqual(devices_per_process, expected)
 
-
   @parameterized.named_parameters(('xla_model', xm.get_ordinal),
                                   ('pjrt', pjrt.global_ordinal))
   def test_global_ordinal(self, ordinal_func):
@@ -48,7 +47,6 @@ class TestExperimentalPjrtMultiCpu(parameterized.TestCase):
     values = list(
         itertools.chain.from_iterable(row.values() for row in results.values()))
     self.assertListEqual(sorted(values), [0, 1, 2, 3])
-
 
   @parameterized.named_parameters(('xla_model', xm.get_local_ordinal),
                                   ('pjrt', pjrt.local_ordinal))
@@ -59,12 +57,12 @@ class TestExperimentalPjrtMultiCpu(parameterized.TestCase):
         itertools.chain.from_iterable(row.values() for row in results.values()))
     self.assertListEqual(sorted(values), [0, 1, 2, 3])
 
-
   @staticmethod
   def _multi_cpu_backwards():
     results = {}
 
     class _CustomBackwards(torch.autograd.Function):
+
       @staticmethod
       def forward(ctx, x):
         rank = xm.get_ordinal()
@@ -92,7 +90,13 @@ class TestExperimentalPjrtMultiCpu(parameterized.TestCase):
     })
 
     expected = {
-      0: {i: {'forward_ordinal': i, 'backward_ordinal': i, 'device': f'xla:{i}'} for i in range(4)}
+        0: {
+            i: {
+                'forward_ordinal': i,
+                'backward_ordinal': i,
+                'device': f'xla:{i}'
+            } for i in range(4)
+        }
     }
     results = pjrt.run_multiprocess(self._multi_cpu_backwards)
 

--- a/test/pjrt/test_experimental_pjrt_multi_cpu.py
+++ b/test/pjrt/test_experimental_pjrt_multi_cpu.py
@@ -65,13 +65,13 @@ class TestExperimentalPjrtMultiCpu(parameterized.TestCase):
 
       @staticmethod
       def forward(ctx, x):
-        rank = xm.get_ordinal()
-        ctx.forward_rank = rank
+        ordinal = xm.get_ordinal()
+        ctx.forward_ordinal = ordinal
         return x
 
       @staticmethod
       def backward(ctx, grad_output):
-        results['forward_ordinal'] = ctx.forward_rank
+        results['forward_ordinal'] = ctx.forward_ordinal
         results['backward_ordinal'] = xm.get_ordinal()
         results['device'] = str(xm.xla_device())
         return grad_output

--- a/test/pjrt/test_experimental_pjrt_tpu.py
+++ b/test/pjrt/test_experimental_pjrt_tpu.py
@@ -144,7 +144,6 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
         devices,
         [torch.device(f'xla:{i}') for i in range(expected_num_devices)])
 
-
   @parameterized.named_parameters(('xla_model', xm.get_ordinal),
                                   ('pjrt', pjrt.global_ordinal))
   def test_global_ordinal(self, ordinal_func):
@@ -163,7 +162,6 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
         itertools.chain.from_iterable(row.values() for row in results.values()))
     self.assertListEqual(sorted(values), list(range(expected_num_devices)))
 
-
   @parameterized.named_parameters(('xla_model', xm.get_local_ordinal),
                                   ('pjrt', pjrt.local_ordinal))
   def test_local_ordinal(self, ordinal_func):
@@ -181,7 +179,6 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
     values = list(
         itertools.chain.from_iterable(row.values() for row in results.values()))
     self.assertListEqual(sorted(values), list(range(expected_num_devices)))
-
 
   @staticmethod
   def _broadcast(sync):

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -170,14 +170,14 @@ def get_ordinal(defval=0):
 
   Args:
     defval (int, optional): The default value to be returned in case there is no
-      replication information available.
+      replication information available. Ignored for PjRt.
       Default: 0
 
   Returns:
     The replication ordinal of the current thread.
   """
   if pjrt.using_pjrt():
-    return pjrt.global_ordinal(defval)
+    return pjrt.global_ordinal()
 
   return xu.getenv_as(xenv.ORDINAL, int, defval=defval)
 
@@ -189,14 +189,14 @@ def get_local_ordinal(defval=0):
 
   Args:
     defval (int, optional): The default value to be returned in case there is no
-      replication information available.
+      replication information available. Ignored for PjRt.
       Default: 0
 
   Returns:
     The replication local ordinal of the current thread.
   """
   if pjrt.using_pjrt():
-    return pjrt.local_ordinal(defval)
+    return pjrt.local_ordinal()
 
   ordinal = xu.getenv_as(xenv.LOCAL_ORDINAL, int, defval=-1)
   if ordinal >= 0:

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1122,6 +1122,11 @@ void InitXlaModuleBindings(py::module m) {
     return SetCurrentThreadDevice(device);
   });
   m.def("_xla_get_default_device", []() { return GetCurrentThreadDevice(); });
+  m.def("_xla_get_default_device_ordinal", []() {
+    std::string device_str = GetCurrentThreadDevice();
+    torch::lazy::BackendDevice device = bridge::AtenDeviceToXlaDevice(device_str);
+    return device.ordinal();
+  });
   m.def("_xla_set_rng_seed",
         [](uint64_t seed, const std::string& device) {
           SetRngSeed(seed, device);

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1124,7 +1124,8 @@ void InitXlaModuleBindings(py::module m) {
   m.def("_xla_get_default_device", []() { return GetCurrentThreadDevice(); });
   m.def("_xla_get_default_device_ordinal", []() {
     std::string device_str = GetCurrentThreadDevice();
-    torch::lazy::BackendDevice device = bridge::AtenDeviceToXlaDevice(device_str);
+    torch::lazy::BackendDevice device =
+        bridge::AtenDeviceToXlaDevice(device_str);
     return device.ordinal();
   });
   m.def("_xla_set_rng_seed",

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -15,7 +15,6 @@ import torch_xla.core.xla_model as xm
 import torch_xla.utils.utils as xu
 from torch_xla.experimental import tpu
 
-
 R = TypeVar('R')
 FN = TypeVar('FN')
 


### PR DESCRIPTION
See #3949 for context

- Replace thread-local ordinals with the default `BackendDevice`'s ordinal.
- Save local world size (i.e. the number of processes on a host) in the `LOCAL_WORLD_SIZE` environment variable. This should be consistent with [`torchrun`](https://pytorch.org/docs/stable/elastic/run.html#environment-variables), although I haven't tested it.

Ran `xla/test/pjrt/test_experimental_pjrt_tpu.py` manually on v3-8 and v4-8