### PR TITLE
Companion fix to process group creation after pytorch PR73164

### DIFF
--- a/test/test_torch_distributed_xla_backend.py
+++ b/test/test_torch_distributed_xla_backend.py
@@ -21,7 +21,7 @@ os.environ[xenv.ORDINAL] = '0'
 
 
 def get_process_group_xla(rank, size):
-  pg_xla_creator = dist.Backend._plugins[dist.Backend.XLA]
+  pg_xla_creator = dist.Backend._plugins[dist.Backend.XLA].creator_fn
   pg_xla = pg_xla_creator(
       prefix_store=None, rank=rank, size=size, timeout=timedelta(minutes=1))
   return pg_xla


### PR DESCRIPTION
PyTorch PR https://github.com/pytorch/pytorch/pull/73164 adds changes to extend the 3rd party distributed backend registration.  As part of this the internal data structure is changed to a named tuple of {creator_fn, bool}. This causes some of the tests in xla to fail as it expects a callable being returned for a particular backend name. 

This PR fixes this issue by calling the creator_fn of the namedtuple instead of the namedtuple itself.