### PR TITLE
Making sure XLA_HLO_DEBUG populate the scope metadata

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -56,6 +56,11 @@ function run_xla_ir_debug {
   XLA_IR_DEBUG=1 run_test "$@"
 }
 
+function run_xla_hlo_debug {
+  echo "Running with XLA_IR_DEBUG: $@"
+  XLA_HLO_DEBUG=1 run_test "$@"
+}
+
 function run_dynamic {
   if [[ "$TPUVM_MODE" == "1" ]]; then
     run_test "$@"
@@ -111,6 +116,7 @@ function run_op_tests {
   run_use_bf16 python3 "$CDIR/test_data_type.py"
   run_test python3 "$CDIR/test_torch_distributed_xla_backend.py"
   run_xla_ir_debug python3 "$CDIR/test_env_var_mapper.py"
+  run_xla_hlo_debug python3 "$CDIR/test_env_var_mapper.py"
   run_pjrt python3 "$CDIR/pjrt/test_experimental_pjrt.py"
   run_pjrt python3 "$CDIR/pjrt/test_experimental_tpu.py"
   run_pjrt python3 "$CDIR/pjrt/test_ddp.py"

--- a/test/test_env_var_mapper.py
+++ b/test/test_env_var_mapper.py
@@ -4,6 +4,7 @@ import torch
 import torch_xla
 import torch_xla.core.xla_model as xm
 import torch_xla.utils.utils as xu
+import torch_xla.debug.profiler as xp
 import unittest
 
 
@@ -13,14 +14,20 @@ def check_env_flag(name, default=''):
 
 class EnvVarMapperTest(unittest.TestCase):
 
-  def test_xla_ir_debug(self):
+  def test_xla_ir_debug_(self):
     xla_device = xm.xla_device()
-    t = torch.tensor([2.0, 3.0], dtype=torch.float, device=xla_device)
+
+    with xp.Trace('test_xla_ir_debug'):
+      t = torch.tensor([2.0, 3.0], dtype=torch.float, device=xla_device)
     xla_tensors_report = torch_xla._XLAC._xla_tensors_report(0, str(xla_device))
-    if check_env_flag('XLA_IR_DEBUG'):
+    expected_scope = "scope=test_xla_ir_debug.1"
+    # XLA_HLO_DEBUG will additionally populate HLO scope for profiler's use
+    if check_env_flag('XLA_IR_DEBUG') or check_env_flag('XLA_HLO_DEBUG'):
       assert 'Frames' in xla_tensors_report
+      assert expected_scope in xla_tensors_report
     else:
       assert 'Frames' not in xla_tensors_report
+      assert expected_scope not in xla_tensors_report
 
 
 if __name__ == '__main__':

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -744,7 +744,8 @@ absl::flat_hash_map<std::string, absl::variant<int>> ConvertDictToMap(
 // Maps PT/XLA env vars to upstream torch::lazy env vars.
 // Upstream lazy env vars defined in torch/csrc/lazy/core/config.h.
 void MapXlaEnvVarsToLazy() {
-  static bool wants_frames = xla::sys_util::GetEnvBool("XLA_IR_DEBUG", false);
+  static bool wants_frames = xla::sys_util::GetEnvBool("XLA_IR_DEBUG", false) |
+                             xla::sys_util::GetEnvBool("XLA_HLO_DEBUG", false);
   FLAGS_torch_lazy_ir_debug = wants_frames;
 }
 


### PR DESCRIPTION
Fix the issue mentioned in https://github.com/pytorch/xla/issues/3965#issuecomment-1241384829, this is not the full fix.

We used to always populate the scope information in IR metadata but now it is defualt off. I think it is OK but we need to make sure `XLA_HLO_DEBUG` also populate scope metadata in IR.