### PR TITLE
allow FSDP wrapping and sharding over modules on CPU devices

### DIFF
--- a/test/test_train_mp_imagenet_fsdp.py
+++ b/test/test_train_mp_imagenet_fsdp.py
@@ -222,7 +222,7 @@ def train_imagenet():
   # - you may wrap sub-modules at different granularity (e.g. at each resnet
   #   stage or each residual block or each conv layer).
   fsdp_wrap = lambda m: FSDP(
-      m.to(device),
+      m,
       compute_dtype=getattr(torch, FLAGS.compute_dtype),
       fp32_reduce_scatter=FLAGS.fp32_reduce_scatter,
       flatten_parameters=FLAGS.flatten_parameters,

--- a/test/test_train_mp_mnist_fsdp_with_ckpt.py
+++ b/test/test_train_mp_mnist_fsdp_with_ckpt.py
@@ -155,7 +155,7 @@ def train_mnist(flags, **kwargs):
   model = MNIST()
   # Wrap the model with FSDP
   fsdp_wrap = lambda m: FSDP(
-      m.to(device),
+      m,
       compute_dtype=getattr(torch, flags.compute_dtype),
       fp32_reduce_scatter=flags.fp32_reduce_scatter,
       flatten_parameters=flags.flatten_parameters,

--- a/torch_xla/distributed/fsdp/README.md
+++ b/torch_xla/distributed/fsdp/README.md
@@ -8,9 +8,7 @@ import torch
 import torch_xla.core.xla_model as xm
 from torch_xla.distributed.fsdp import XlaFullyShardedDataParallel as FSDP
 
-model = model.to(xm.xla_device())
 model = FSDP(my_module)
-
 optim = torch.optim.Adam(model.parameters(), lr=0.0001)
 output = model(x, y)
 loss = output.sum()
@@ -44,7 +42,7 @@ python3 -m torch_xla.distributed.fsdp.consolidate_sharded_ckpts \
   --ckpt_suffix "_rank-*-of-*.pth"
 ```
 
-The implementation of this class is largely inspired by and mostly follows the structure of `fairscale.nn.FullyShardedDataParallel` in https://fairscale.readthedocs.io/en/stable/api/nn/fsdp.html. One of the biggest difference from `fairscale.nn.FullyShardedDataParallel` is that in XLA we don't have explicit parameter storage, so here we resort to a different approach to free full parameters for ZeRO-3.
+The implementation of this class is largely inspired by and mostly follows the structure of `fairscale.nn.FullyShardedDataParallel` in https://fairscale.readthedocs.io/en/stable/api/nn/fsdp.html. One of the biggest differences from `fairscale.nn.FullyShardedDataParallel` is that in XLA we don't have explicit parameter storage, so here we resort to a different approach to free full parameters for ZeRO-3.
 
 ---
 
@@ -54,7 +52,7 @@ The implementation of this class is largely inspired by and mostly follows the s
 * ImageNet: [`test/test_train_mp_imagenet_fsdp.py`](https://github.com/pytorch/xla/blob/master/test/test_train_mp_imagenet_fsdp.py)
 
 #### Installation
-FSDP is availiabe on PyTorch/XLA 1.12 release and newer nightly. Please refer to https://github.com/pytorch/xla#-available-images-and-wheels for installtion guide.
+FSDP is available on PyTorch/XLA 1.12 release and newer nightly. Please refer to https://github.com/pytorch/xla#-available-images-and-wheels for installation guide.
 
 #### Clone PyTorch/XLA repo
 ```bash


### PR DESCRIPTION
Following an offline discussion with @JackCaoG, this PR allows wrapping an `nn.Module` instance with FSDP **without requiring it to be cast to the XLA device first**.

* This allows directly sharding (slicing) the model parameters on the CPU host device and casting the *sharded* parameters to XLA devices, as opposed to the current approach of first casting the entire parameter to XLA and then performing the sharding (slicing) as an XLA HLO graph. The latter often results in TPU runtime not releasing the casted full tensor in time and leading to host-side CPU OOM when running very large models (e.g. 120B parameters), which we aim to resolve in this PR.

* If the input modules have parameters on CPU (or any parameters whose device are not `xm.xla_device()`), those parameters will be cast to `xm.xla_device()` during FSDP initialization.

* It also handles the case of flattened parameters, allowing the `FlatParameter` class to be cast to XLA and changing `self.flat_params` to a list generated on the fly so that instances of the `XlaFlattenParamsWrapper` class can also be directly cast to XLA via `module.to(...)`.

* After this change, one can still use the old approach of first casting the module to XLA devices and then wrapping it with the FSDP class, so existing code wouldn't be broken after this PR.

The MNIST and ImageNet examples are updated to reflect this new feature (directly feeding the module and submodules on CPU devices without first casting them).

---

The outputs from MNIST examples confirm that it works well with both plain and nested FSDP, with or without flattening parameters.

Test 1. MNIST plain FSDP w/o flattened parameters
```
python3 -u ~/xla_fsdp_dev/test/test_train_mp_mnist_fsdp_with_ckpt.py \
  --batch_size 16 --drop_last --num_epochs 2
```
gives
```
Checkpoint consolidated, Accuracy=99.01 (note: it can be slightly different from the final training accuracy due to non-sync BatchNorm2d in the model)
Max Accuracy: 99.03%
```
Test 2. MNIST nested FSDP w/o flattened parameters
```
python3 -u ~/xla_fsdp_dev/test/test_train_mp_mnist_fsdp_with_ckpt.py \
  --batch_size 16 --drop_last --num_epochs 2 \
  --use_nested_fsdp
```
gives
```
Checkpoint consolidated, Accuracy=98.92 (note: it can be slightly different from the final training accuracy due to non-sync BatchNorm2d in the model)
Max Accuracy: 98.88%
```
Test 3. MNIST plain FSDP w/ flattened parameters
```
python3 -u ~/xla_fsdp_dev/test/test_train_mp_mnist_fsdp_with_ckpt.py \
  --batch_size 16 --drop_last --num_epochs 2 \
  --flatten_parameters
```
gives
```
Checkpoint consolidated, Accuracy=99.01 (note: it can be slightly different from the final training accuracy due to non-sync BatchNorm2d in the model)
Max Accuracy: 98.99%
```
Test 4. MNIST nested FSDP w/ flattened parameters
```
python3 -u ~/xla_fsdp_dev/test/test_train_mp_mnist_fsdp_with_ckpt.py \
  --batch_size 16 --drop_last --num_epochs 2 \
  --use_nested_fsdp --flatten_parameters
```
gives
```
Checkpoint consolidated, Accuracy=98.90 (note: it can be slightly different from the final training accuracy due to non-sync BatchNorm2d in the model)
Max Accuracy: 98.93%
```

Test 5. The ImageNet example (plain FSDP w/o flattened parameters) also works well
```
python3 -u ~/xla_fsdp_dev/test/test_train_mp_imagenet_fsdp.py \
  --datadir /datasets02/imagenet-1k --drop_last \
  --model resnet50 --test_set_batch_size 64 --eval_interval 10 \
  --lr 0.4 --batch_size 128 --num_warmup_epochs 5 --lr_scheduler_divide_every_n_epochs 30 --lr_scheduler_divisor 10 --num_epochs 100
```
gives
```
Max Accuracy: 75.86%
```
as expected.

I'm running more test cases, including large model cases, to see if this PR resolves the previous issue of host-side OOM when casting full parameters to XLA and sharing them as part of the XLA computation.

cc: @hjm-aws 