### PR TITLE
Remove "apply PyTorch source patches"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,12 +43,6 @@ To build from source:
 
 ### Build From Source
 
-* Apply PyTorch patches:
-
-  ```Shell
-  xla/scripts/apply_patches.sh
-  ```
-
 * Install the Lark parser used for automatic code generation:
 
   ```Shell


### PR DESCRIPTION
These days, there are really never any source patches.