### PR TITLE
[PJRT] Flatten output of `pjrt.run_multiprocess`

### DIFF
--- a/test/pjrt/test_experimental_pjrt.py
+++ b/test/pjrt/test_experimental_pjrt.py
@@ -44,18 +44,9 @@ class TestExperimentalPjrt(parameterized.TestCase):
   def test_world_size(self):
     self.assertEqual(xm.xrt_world_size(), pjrt.global_device_count())
 
-  # TODO(will-cromar): add a multi-device version of this test.
-  def test_xla_device_default(self):
-    device = xm.xla_device()
-    self.assertEqual(device, torch.device('xla:0'))
-
   def test_xla_device_error(self):
     with self.assertRaises(IndexError):
       xm.xla_device(10)
-
-  def test_run_multiprocess_one_device(self):
-    results = pjrt.run_multiprocess(xm.xla_device)
-    self.assertDictEqual(results, {0: {0: torch.device('xla:0')}})
 
 
 if __name__ == '__main__':

--- a/test/pjrt/test_experimental_pjrt_multi_cpu.py
+++ b/test/pjrt/test_experimental_pjrt_multi_cpu.py
@@ -23,18 +23,16 @@ class TestExperimentalPjrtMultiCpu(parameterized.TestCase):
     os.environ.pop(xenv.CPU_NUM_DEVICES, None)
     os.environ.pop(xenv.PJRT_CPU_ASYNC_CLIENT, None)
 
-    expected = {0: {0: torch.device('xla:0'),}}
+    expected = {0: torch.device('xla:0')}
     devices_per_process = pjrt.run_multiprocess(xm.xla_device)
     self.assertDictEqual(devices_per_process, expected)
 
   def test_multi_cpu_devices(self):
     expected = {
-        0: {
-            0: torch.device('xla:0'),
-            1: torch.device('xla:1'),
-            2: torch.device('xla:2'),
-            3: torch.device('xla:3')
-        }
+        0: torch.device('xla:0'),
+        1: torch.device('xla:1'),
+        2: torch.device('xla:2'),
+        3: torch.device('xla:3'),
     }
 
     devices_per_process = pjrt.run_multiprocess(xm.xla_device)
@@ -44,18 +42,14 @@ class TestExperimentalPjrtMultiCpu(parameterized.TestCase):
                                   ('pjrt', pjrt.global_ordinal))
   def test_global_ordinal(self, ordinal_func):
     results = pjrt.run_multiprocess(ordinal_func)
-    values = list(
-        itertools.chain.from_iterable(row.values() for row in results.values()))
-    self.assertListEqual(sorted(values), [0, 1, 2, 3])
+    self.assertListEqual(sorted(results.values()), [0, 1, 2, 3])
 
   @parameterized.named_parameters(('xla_model', xm.get_local_ordinal),
                                   ('pjrt', pjrt.local_ordinal))
   def test_local_ordinal(self, ordinal_func):
     # TODO(wcromar): add multiprocess tests
     results = pjrt.run_multiprocess(ordinal_func)
-    values = list(
-        itertools.chain.from_iterable(row.values() for row in results.values()))
-    self.assertListEqual(sorted(values), [0, 1, 2, 3])
+    self.assertListEqual(sorted(results.values()), [0, 1, 2, 3])
 
   @staticmethod
   def _multi_cpu_backwards():
@@ -90,13 +84,11 @@ class TestExperimentalPjrtMultiCpu(parameterized.TestCase):
     })
 
     expected = {
-        0: {
-            i: {
-                'forward_ordinal': i,
-                'backward_ordinal': i,
-                'device': f'xla:{i}'
-            } for i in range(4)
-        }
+        i: {
+            'forward_ordinal': i,
+            'backward_ordinal': i,
+            'device': f'xla:{i}'
+        } for i in range(4)
     }
     results = pjrt.run_multiprocess(self._multi_cpu_backwards)
 

--- a/test/pjrt/test_experimental_pjrt_tpu.py
+++ b/test/pjrt/test_experimental_pjrt_tpu.py
@@ -64,12 +64,8 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
 
   def test_xla_devices_single_process_all_chips(self):
     accelerator_devices = {
-        'v3-8': {
-            i: torch.device(f'xla:{i}') for i in range(8)
-        },
-        'v4-8': {
-            i: torch.device(f'xla:{i}') for i in range(4)
-        },
+        'v3-8': {i: torch.device(f'xla:{i}') for i in range(8)},
+        'v4-8': {i: torch.device(f'xla:{i}') for i in range(4)},
     }
 
     if self.accelerator_type not in accelerator_devices:

--- a/test/pjrt/test_experimental_pjrt_tpu.py
+++ b/test/pjrt/test_experimental_pjrt_tpu.py
@@ -37,36 +37,20 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
   def test_xla_devices_multiprocess(self):
     accelerator_devices = {
         'v3-8': {
-            0: {
-                0: torch.device('xla:0'),
-                1: torch.device('xla:1'),
-            },
-            1: {
-                0: torch.device('xla:0'),
-                1: torch.device('xla:1'),
-            },
-            2: {
-                0: torch.device('xla:0'),
-                1: torch.device('xla:1'),
-            },
-            3: {
-                0: torch.device('xla:0'),
-                1: torch.device('xla:1'),
-            },
+            0: torch.device('xla:0'),
+            1: torch.device('xla:1'),
+            3: torch.device('xla:0'),
+            4: torch.device('xla:1'),
+            5: torch.device('xla:0'),
+            6: torch.device('xla:1'),
+            7: torch.device('xla:0'),
+            8: torch.device('xla:1'),
         },
         'v4-8': {
-            0: {
-                0: torch.device('xla:0')
-            },
-            1: {
-                0: torch.device('xla:0')
-            },
-            2: {
-                0: torch.device('xla:0')
-            },
-            3: {
-                0: torch.device('xla:0')
-            },
+            0: torch.device('xla:0'),
+            1: torch.device('xla:0'),
+            2: torch.device('xla:0'),
+            3: torch.device('xla:0'),
         },
     }
 
@@ -81,10 +65,10 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
   def test_xla_devices_single_process_all_chips(self):
     accelerator_devices = {
         'v3-8': {
-            0: {i: torch.device(f'xla:{i}') for i in range(8)},
+            i: torch.device(f'xla:{i}') for i in range(8)
         },
         'v4-8': {
-            0: {i: torch.device(f'xla:{i}') for i in range(4)},
+            i: torch.device(f'xla:{i}') for i in range(4)
         },
     }
 
@@ -102,15 +86,11 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
   def test_xla_devices_single_process_one_chip(self):
     accelerator_devices = {
         'v3-8': {
-            0: {
-                0: torch.device('xla:0'),
-                1: torch.device('xla:1'),
-            },
+            0: torch.device('xla:0'),
+            1: torch.device('xla:1'),
         },
         'v4-8': {
-            0: {
-                0: torch.device('xla:0')
-            },
+            0: torch.device('xla:0')
         },
     }
 
@@ -158,8 +138,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
     expected_num_devices = accelerator_num_devices[self.accelerator_type]
 
     results = pjrt.run_multiprocess(ordinal_func)
-    values = list(
-        itertools.chain.from_iterable(row.values() for row in results.values()))
+    values = list(results.values())
     self.assertListEqual(sorted(values), list(range(expected_num_devices)))
 
   @parameterized.named_parameters(('xla_model', xm.get_local_ordinal),
@@ -176,8 +155,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
     expected_num_devices = accelerator_num_devices[self.accelerator_type]
 
     results = pjrt.run_multiprocess(ordinal_func)
-    values = list(
-        itertools.chain.from_iterable(row.values() for row in results.values()))
+    values = list(results.values())
     self.assertListEqual(sorted(values), list(range(expected_num_devices)))
 
   @staticmethod
@@ -194,14 +172,12 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
   @parameterized.named_parameters(('synchronized_parameters', True),
                                   ('unsynchronized_parameters', False))
   def test_broadcast_master_param(self, sync):
-    torch.set_default_tensor_type('torch.FloatTensor')
     results = pjrt.run_multiprocess(TestExperimentalPjrtTpu._broadcast, sync)
-    master_params = results[0][0]
-    for process_key in results:
-      worker_params = results[process_key][0]
+    master_params = results[0]
+    for ordinal, worker_params in results.items():
       if sync:
         np.testing.assert_array_equal(master_params, worker_params)
-      elif process_key != 0:
+      elif ordinal != 0:
         np.testing.assert_raises(AssertionError, np.testing.assert_array_equal,
                                  master_params, worker_params)
 
@@ -218,11 +194,9 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
   def test_all_gather(self, pin_layout):
     results = pjrt.run_multiprocess(TestExperimentalPjrtTpu._all_gather,
                                     pin_layout)
-    values = list(
-        itertools.chain.from_iterable(row.values() for row in results.values()))
 
-    expected = list(range(len(values)))
-    for v in values:
+    expected = list(range(len(results)))
+    for v in results.values():
       np.testing.assert_array_equal(v, expected)
 
   @staticmethod
@@ -241,16 +215,14 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
     )
     xm.mark_step()
 
-    return xm.get_ordinal(), out.cpu().numpy()
+    return out.cpu().numpy()
 
   @parameterized.named_parameters(('pinned', True), ('unpinned', False))
   def test_reduce_scatter(self, pin_layout):
     results = pjrt.run_multiprocess(TestExperimentalPjrtTpu._reduce_scatter,
                                     pin_layout)
-    values = list(
-        itertools.chain.from_iterable(row.values() for row in results.values()))
 
-    for ordinal, value in values:
+    for ordinal, value in results.items():
       np.testing.assert_array_equal(value, [-ordinal])
 
   @staticmethod
@@ -275,18 +247,16 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
         pin_layout=pin_layout,
     )
 
-    return xm.get_ordinal(), out.cpu().numpy()
+    return out.cpu().numpy()
 
   @parameterized.named_parameters(('pinned', True), ('unpinned', False))
   def test_all_to_all(self, pin_layout):
     results = pjrt.run_multiprocess(TestExperimentalPjrtTpu._all_to_all,
                                     pin_layout)
-    values = list(
-        itertools.chain.from_iterable(row.values() for row in results.values()))
 
-    for ordinal, value in values:
-      np.testing.assert_array_equal(value, [[[-ordinal] * len(values),
-                                             list(range(len(values)))]])
+    for ordinal, value in results.items():
+      np.testing.assert_array_equal(value, [[[-ordinal] * len(results),
+                                             list(range(len(results)))]])
 
 
 if __name__ == '__main__':

--- a/test/pjrt/test_mesh_service.py
+++ b/test/pjrt/test_mesh_service.py
@@ -16,7 +16,7 @@ class PjRtMeshServiceTest(parameterized.TestCase):
       os.environ['XRT_MESH_SERVICE_ADDRESS'] = xrt_mesh_addr
 
     payload = b'message %d' % xm.get_ordinal()
-    return xm.get_ordinal(), xm.rendezvous("test rendezvous", payload, replicas)
+    return xm.rendezvous("test rendezvous", payload, replicas)
 
   @parameterized.named_parameters(
       ('defaults', None, []), ('xrt_address', 'localhost:9477', []),
@@ -24,11 +24,9 @@ class PjRtMeshServiceTest(parameterized.TestCase):
   def test_rendezvous(self, xrt_mesh_addr, replicas):
     results = pjrt.run_multiprocess(self._rendezvous_default, xrt_mesh_addr,
                                     replicas)
-    values = list(
-        itertools.chain.from_iterable(row.values() for row in results.values()))
-    replicas = replicas or list(range(len(values)))
+    replicas = replicas or list(range(len(results)))
 
-    for ordinal, value in values:
+    for ordinal, value in results.items():
       if ordinal in replicas or not replicas:
         self.assertEqual(value, [b'message %d' % r for r in replicas])
 
@@ -38,8 +36,7 @@ class PjRtMeshServiceTest(parameterized.TestCase):
 
   def test_mesh_reduce(self):
     results = pjrt.run_multiprocess(self._mesh_reduce)
-    values = list(
-        itertools.chain.from_iterable(row.values() for row in results.values()))
+    values = list(results.values())
 
     expected = sum(range(len(values)))
     for v in values:

--- a/test/pjrt/test_train_pjrt_imagenet.py
+++ b/test/pjrt/test_train_pjrt_imagenet.py
@@ -114,25 +114,25 @@ def _train_update(device, step, loss, tracker, epoch, writer):
       summary_writer=writer)
 
 
-def train_imagenet():
+def train_imagenet(flags):
   print('==> Preparing data..')
   img_dim = get_model_property('img_dim')
-  if FLAGS.fake_data:
+  if flags.fake_data:
     train_dataset_len = 1200000  # Roughly the size of Imagenet dataset.
     train_loader = xu.SampleGenerator(
-        data=(torch.zeros(FLAGS.batch_size, 3, img_dim, img_dim),
-              torch.zeros(FLAGS.batch_size, dtype=torch.int64)),
-        sample_count=train_dataset_len // FLAGS.batch_size //
+        data=(torch.zeros(flags.batch_size, 3, img_dim, img_dim),
+              torch.zeros(flags.batch_size, dtype=torch.int64)),
+        sample_count=train_dataset_len // flags.batch_size //
         xm.xrt_world_size())
     test_loader = xu.SampleGenerator(
-        data=(torch.zeros(FLAGS.test_set_batch_size, 3, img_dim, img_dim),
-              torch.zeros(FLAGS.test_set_batch_size, dtype=torch.int64)),
-        sample_count=50000 // FLAGS.batch_size // xm.xrt_world_size())
+        data=(torch.zeros(flags.test_set_batch_size, 3, img_dim, img_dim),
+              torch.zeros(flags.test_set_batch_size, dtype=torch.int64)),
+        sample_count=50000 // flags.batch_size // xm.xrt_world_size())
   else:
     normalize = transforms.Normalize(
         mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
     train_dataset = torchvision.datasets.ImageFolder(
-        os.path.join(FLAGS.datadir, 'train'),
+        os.path.join(flags.datadir, 'train'),
         transforms.Compose([
             transforms.RandomResizedCrop(img_dim),
             transforms.RandomHorizontalFlip(),
@@ -142,7 +142,7 @@ def train_imagenet():
     train_dataset_len = len(train_dataset.imgs)
     resize_dim = max(img_dim, 256)
     test_dataset = torchvision.datasets.ImageFolder(
-        os.path.join(FLAGS.datadir, 'val'),
+        os.path.join(flags.datadir, 'val'),
         # Matches Torchvision's eval transforms except Torchvision uses size
         # 256 resize for all models both here and in the train loader. Their
         # version crashes during training on 299x299 images, e.g. inception.
@@ -167,18 +167,18 @@ def train_imagenet():
           shuffle=False)
     train_loader = torch.utils.data.DataLoader(
         train_dataset,
-        batch_size=FLAGS.batch_size,
+        batch_size=flags.batch_size,
         sampler=train_sampler,
-        drop_last=FLAGS.drop_last,
+        drop_last=flags.drop_last,
         shuffle=False if train_sampler else True,
-        num_workers=FLAGS.num_workers)
+        num_workers=flags.num_workers)
     test_loader = torch.utils.data.DataLoader(
         test_dataset,
-        batch_size=FLAGS.test_set_batch_size,
+        batch_size=flags.test_set_batch_size,
         sampler=test_sampler,
-        drop_last=FLAGS.drop_last,
+        drop_last=flags.drop_last,
         shuffle=False,
-        num_workers=FLAGS.num_workers)
+        num_workers=flags.num_workers)
 
   device = xm.xla_device()
   model = get_model_property('model_fn')()
@@ -186,20 +186,20 @@ def train_imagenet():
   pjrt.broadcast_master_param(model)
   writer = None
   if xm.is_master_ordinal():
-    writer = test_utils.get_summary_writer(FLAGS.logdir)
+    writer = test_utils.get_summary_writer(flags.logdir)
   optimizer = optim.SGD(
       model.parameters(),
-      lr=FLAGS.lr,
-      momentum=FLAGS.momentum,
+      lr=flags.lr,
+      momentum=flags.momentum,
       weight_decay=1e-4)
   num_training_steps_per_epoch = train_dataset_len // (
-      FLAGS.batch_size * xm.xrt_world_size())
+      flags.batch_size * xm.xrt_world_size())
   lr_scheduler = schedulers.wrap_optimizer_with_scheduler(
       optimizer,
-      scheduler_type=getattr(FLAGS, 'lr_scheduler_type', None),
-      scheduler_divisor=getattr(FLAGS, 'lr_scheduler_divisor', None),
+      scheduler_type=getattr(flags, 'lr_scheduler_type', None),
+      scheduler_divisor=getattr(flags, 'lr_scheduler_divisor', None),
       scheduler_divide_every_n_epochs=getattr(
-          FLAGS, 'lr_scheduler_divide_every_n_epochs', None),
+          flags, 'lr_scheduler_divide_every_n_epochs', None),
       num_steps_per_epoch=num_training_steps_per_epoch,
       summary_writer=writer)
   loss_fn = nn.CrossEntropyLoss()
@@ -213,10 +213,10 @@ def train_imagenet():
       loss = loss_fn(output, target)
       loss.backward()
       xm.optimizer_step(optimizer)
-      tracker.add(FLAGS.batch_size)
+      tracker.add(flags.batch_size)
       if lr_scheduler:
         lr_scheduler.step()
-      if step % FLAGS.log_steps == 0:
+      if step % flags.log_steps == 0:
         xm.add_step_closure(
             _train_update, args=(device, step, loss, tracker, epoch, writer))
 
@@ -228,7 +228,7 @@ def train_imagenet():
       pred = output.max(1, keepdim=True)[1]
       correct += pred.eq(target.view_as(pred)).sum()
       total_samples += data.size()[0]
-      if step % FLAGS.log_steps == 0:
+      if step % flags.log_steps == 0:
         xm.add_step_closure(
             test_utils.print_test_update, args=(device, None, epoch, step))
     accuracy = 100.0 * correct.item() / total_samples
@@ -238,11 +238,11 @@ def train_imagenet():
   train_device_loader = pl.MpDeviceLoader(train_loader, device)
   test_device_loader = pl.MpDeviceLoader(test_loader, device)
   accuracy, max_accuracy = 0.0, 0.0
-  for epoch in range(1, FLAGS.num_epochs + 1):
+  for epoch in range(1, flags.num_epochs + 1):
     xm.master_print('Epoch {} train begin {}'.format(epoch, test_utils.now()))
     train_loop_fn(train_device_loader, epoch)
     xm.master_print('Epoch {} train end {}'.format(epoch, test_utils.now()))
-    if not FLAGS.test_only_at_end or epoch == FLAGS.num_epochs:
+    if not flags.test_only_at_end or epoch == flags.num_epochs:
       accuracy = test_loop_fn(test_device_loader, epoch)
       xm.master_print('Epoch {} test end {}, Accuracy={:.2f}'.format(
           epoch, test_utils.now(), accuracy))
@@ -252,7 +252,7 @@ def train_imagenet():
           epoch,
           dict_to_write={'Accuracy/test': accuracy},
           write_xla_metrics=True)
-    if FLAGS.metrics_debug:
+    if flags.metrics_debug:
       xm.master_print(met.metrics_report())
 
   test_utils.close_summary_writer(writer)
@@ -263,11 +263,10 @@ def train_imagenet():
 if __name__ == '__main__':
   torch.set_default_tensor_type('torch.FloatTensor')
 
-  results = pjrt.run_multiprocess(train_imagenet)
+  results = pjrt.run_multiprocess(train_imagenet, FLAGS)
   print('Replica max_accuracy:', pprint.pformat(results))
   accuracy = np.mean([
-      np.mean(list(thread_results.values()))
-      for thread_results in results.values()
+      np.mean(list(results.values()))
   ])
   print('Average max_accuracy:', accuracy)
 

--- a/test/pjrt/test_train_pjrt_imagenet.py
+++ b/test/pjrt/test_train_pjrt_imagenet.py
@@ -265,9 +265,7 @@ if __name__ == '__main__':
 
   results = pjrt.run_multiprocess(train_imagenet, FLAGS)
   print('Replica max_accuracy:', pprint.pformat(results))
-  accuracy = np.mean([
-      np.mean(list(results.values()))
-  ])
+  accuracy = np.mean([np.mean(list(results.values()))])
   print('Average max_accuracy:', accuracy)
 
   if accuracy < FLAGS.target_accuracy:

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1132,6 +1132,9 @@ void InitXlaModuleBindings(py::module m) {
         bridge::AtenDeviceToXlaDevice(device_str);
     return device.ordinal();
   });
+  m.def("_xla_get_device_ordinal", [](const std::string& device_str) {
+    return bridge::AtenDeviceToXlaDevice(device_str).ordinal();
+  });
   m.def("_xla_set_rng_seed",
         [](uint64_t seed, const std::string& device) {
           SetRngSeed(seed, device);

--- a/torch_xla/distributed/xla_multiprocessing.py
+++ b/torch_xla/distributed/xla_multiprocessing.py
@@ -10,6 +10,7 @@ import torch.multiprocessing
 import torch_xla
 import torch_xla.core.xla_env_vars as xenv
 import torch_xla.core.xla_model as xm
+from torch_xla.experimental import pjrt
 import torch_xla.utils.utils as xu
 import traceback
 
@@ -378,6 +379,9 @@ def spawn(fn,
     `nprocs` is 1 the `fn` function will be called directly, and the API will
     not return.
   """
+  if pjrt.using_pjrt():
+    return pjrt.spawn(fn, args)
+
   if not _is_xla_config():
     # If this is not an XLA setup, jump to normal multi-processing.
     return _run_direct(fn, args, nprocs, join, daemon, start_method)

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -10,9 +10,9 @@ from typing import Callable, Dict, Generic, List, Optional, Tuple, TypeVar
 
 import sys
 if sys.version_info < (3, 10):
-    from typing_extensions import ParamSpec, Concatenate
+  from typing_extensions import ParamSpec, Concatenate
 else:
-    from typing import ParamSpec, Concatenate
+  from typing import ParamSpec, Concatenate
 
 import torch
 import torch.distributed as dist
@@ -135,7 +135,8 @@ def local_ordinal() -> int:
   return global_ordinal() % local_device_count()
 
 
-def _merge_replica_results(replica_results: List[Tuple[int, R]]) -> Dict[int, R]:
+def _merge_replica_results(
+    replica_results: List[Tuple[int, R]]) -> Dict[int, R]:
   """Merges list of results from multiple replicas
 
   Args:
@@ -147,7 +148,8 @@ def _merge_replica_results(replica_results: List[Tuple[int, R]]) -> Dict[int, R]
   Raises:
     AssertionError: if there are duplicate results for the same replica.
   """
-  replica_counts = collections.Counter(ordinal for ordinal, _ in replica_results)
+  replica_counts = collections.Counter(
+      ordinal for ordinal, _ in replica_results)
   replica, num_results = replica_counts.most_common(1)[0]
   assert num_results == 1, f'{num_results} results for replica {replica}'
 
@@ -186,14 +188,19 @@ def run_thread_per_device(local_rank: int, local_world_size: int,
   with concurrent.futures.ThreadPoolExecutor(
       max_workers=num_threads) as executor:
     # TODO: clean up this statement
-    device_ordinals = [int(torch_xla._XLAC._xla_real_devices([d])[0].split(':')[1]) for d in devices]
-    replica_results = list(zip(device_ordinals, executor.map(_thread_fn, devices)))
+    device_ordinals = [
+        int(torch_xla._XLAC._xla_real_devices([d])[0].split(':')[1])
+        for d in devices
+    ]
+    replica_results = list(
+        zip(device_ordinals, executor.map(_thread_fn, devices)))
 
   return _merge_replica_results(replica_results)
 
 
 @requires_pjrt
-def run_multiprocess(fn: Callable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> Dict[int, R]:
+def run_multiprocess(fn: Callable[P, R], /, *args: P.args,
+                     **kwargs: P.kwargs) -> Dict[int, R]:
   """Runs `fn` on all devices available to PjRt.
 
   Spawns one process per physical device (e.g. TPU chip).
@@ -222,8 +229,8 @@ def run_multiprocess(fn: Callable[P, R], /, *args: P.args, **kwargs: P.kwargs) -
         fn=functools.partial(fn, *args, **kwargs))
     process_results = executor.map(mp_fn, range(num_processes))
     replica_results = list(
-      itertools.chain.from_iterable(result.items() for result in process_results)
-    )
+        itertools.chain.from_iterable(
+            result.items() for result in process_results))
 
   return _merge_replica_results(replica_results)
 
@@ -231,7 +238,8 @@ def run_multiprocess(fn: Callable[P, R], /, *args: P.args, **kwargs: P.kwargs) -
 class _SpawnFn:
   """Pickle-able wrapper around `fn` that passes the ordinal before `args`"""
 
-  def __init__(self, fn: Callable[Concatenate[int, P], R], *args: P.args, **kwargs: P.kwargs):
+  def __init__(self, fn: Callable[Concatenate[int, P], R], *args: P.args,
+               **kwargs: P.kwargs):
     self.fn = fn
     self.args = args
     self.kwargs = kwargs

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -189,7 +189,7 @@ def run_thread_per_device(local_rank: int, local_world_size: int,
       max_workers=num_threads) as executor:
     # TODO: clean up this statement
     device_ordinals = [
-        int(torch_xla._XLAC._xla_real_devices([d])[0].split(':')[1])
+        torch_xla._XLAC._xla_get_device_ordinal(d)
         for d in devices
     ]
     replica_results = list(

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -199,7 +199,7 @@ def run_thread_per_device(local_rank: int, local_world_size: int,
 
 
 @requires_pjrt
-def run_multiprocess(fn: Callable[P, R], /, *args: P.args,
+def run_multiprocess(fn: Callable[P, R], *args: P.args,
                      **kwargs: P.kwargs) -> Dict[int, R]:
   """Runs `fn` on all devices available to PjRt.
 

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -240,15 +240,14 @@ class _SpawnFn:
     self.fn(global_ordinal(), *self.args, **self.kwargs)
 
 
-def spawn(fn: Callable, args: Tuple = ()):
+def spawn(fn: Callable, args: Tuple = ()) -> None:
   """Run functions compatible with xmp.spawn.
 
   Args:
     fn: Callable that takes the process index as the first argument.
     args: args to pass to `fn`
-    nprocs: number of processes to spawn
   """
-  spawn_fn = _SpawnFn(fn, args)
+  spawn_fn = _SpawnFn(fn, *args)
   run_multiprocess(spawn_fn)
 
 

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -189,8 +189,7 @@ def run_thread_per_device(local_rank: int, local_world_size: int,
       max_workers=num_threads) as executor:
     # TODO: clean up this statement
     device_ordinals = [
-        torch_xla._XLAC._xla_get_device_ordinal(d)
-        for d in devices
+        torch_xla._XLAC._xla_get_device_ordinal(d) for d in devices
     ]
     replica_results = list(
         zip(device_ordinals, executor.map(_thread_fn, devices)))


### PR DESCRIPTION
Previously, the output of `pjrt.run_multiprocess` was a dict like `{process_rank: {thread_rank: result}}`. PR #3902 removed the connection between the result of `xm.get_ordinal()` and the process or thread rank, so this output structure is no longer useful. Instead, return a dict like `{replica_ordinal: result}`.

- Update tests to use new output structure.
- Integrate with `xmp.spawn`. I was able to run the XRT MNIST example on v4-8 successfully without any changes.
   - Use the `torch.multiprocessing` context to match `xmp.spawn`.
- Improve type annotations in `pjrt.py`