### PR TITLE
Fix `time` statements in `common.sh`

### DIFF
--- a/docker/common.sh
+++ b/docker/common.sh
@@ -6,8 +6,8 @@ function run_deployment_tests() {
   export CC=clang-8 CXX=clang++-8
 
   # We don't need to load libtpu since test is being done on CPU.
-  TPU_LOAD_LIBRARY=0 time python /pytorch/xla/test/test_train_mp_mnist.py --fake_data
-  TPU_LOAD_LIBRARY=0 time bash /pytorch/xla/test/run_tests.sh
+  time TPU_LOAD_LIBRARY=0 python /pytorch/xla/test/test_train_mp_mnist.py --fake_data
+  time TPU_LOAD_LIBRARY=0 bash /pytorch/xla/test/run_tests.sh
   # TODO(JackCaoG): reenable after fixing the cpp test build
   # time bash /pytorch/xla/test/cpp/run_tests.sh
 }


### PR DESCRIPTION
`time` is a keyword and not a command: https://superuser.com/a/466832