### PR TITLE
Make alias return a fresh TensorImpl.

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -635,7 +635,8 @@ at::Tensor XLANativeFunctions::addmm(const at::Tensor& self,
 
 at::Tensor XLANativeFunctions::alias(const at::Tensor& self) {
   XLA_FN_COUNTER("xla::");
-  return self;
+  return bridge::AtenFromXlaTensor(
+      XLATensor::alias(bridge::GetXlaTensor(self)));
 }
 
 at::Tensor& XLANativeFunctions::arange_out(const at::Scalar& start,

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -375,6 +375,8 @@ class XLATensor : public c10::intrusive_ptr_target {
                             const XLATensorPtr& weight,
                             const XLATensorPtr& bias);
 
+  static XLATensorPtr alias(const XLATensorPtr& input);
+
   static XLATensorPtr amax(const XLATensorPtr& input,
                            std::vector<int64_t> dimensions,
                            bool keep_reduced_dimensions);

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2620,6 +2620,12 @@ XLATensorPtr XLATensor::upsample_nearest2d_backward(
       std::move(input_size)));
 }
 
+XLATensorPtr XLATensor::alias(const XLATensorPtr& input) {
+  torch::lazy::Value ir_value = input->GetIrValue();
+  ViewInfo view_info(ViewInfo::Type::kNoOp, GetXlaShape(ir_value), GetXlaShape(ir_value));
+  return input->CreateViewTensor(std::move(view_info));
+}
+
 XLATensorPtr XLATensor::view(const XLATensorPtr& input,
                              absl::Span<const int64_t> output_size) {
   auto input_shape = input->shape();

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2622,7 +2622,8 @@ XLATensorPtr XLATensor::upsample_nearest2d_backward(
 
 XLATensorPtr XLATensor::alias(const XLATensorPtr& input) {
   torch::lazy::Value ir_value = input->GetIrValue();
-  ViewInfo view_info(ViewInfo::Type::kNoOp, GetXlaShape(ir_value), GetXlaShape(ir_value));
+  ViewInfo view_info(ViewInfo::Type::kNoOp, GetXlaShape(ir_value),
+                     GetXlaShape(ir_value));
   return input->CreateViewTensor(std::move(view_info));
 }
 


### PR DESCRIPTION
This is needed to appease https://github.com/pytorch/pytorch/pull/84893
where we need to actually return fresh TensorImpl in the kernel
implementation; the AD machinery won't do this for you.