### PR TITLE
switch everything to XLASymIntNodeImpl

### DIFF
--- a/test/cpp/test_symint.cpp
+++ b/test/cpp/test_symint.cpp
@@ -65,8 +65,7 @@ TEST(SymintTest, TestDynamicSymint) {
   torch::lazy::Value expand_value = torch::lazy::Value(expand_node, 0);
   torch::lazy::NodePtr size_node =
       torch::lazy::MakeNode<SizeNode>(expand_value, /*dim=*/0);
-  auto symint_node =
-      c10::make_intrusive<torch::lazy::SymIntNodeImpl>(size_node);
+  auto symint_node = c10::make_intrusive<XLASymIntNodeImpl>(size_node);
   // This is not a dynamic size from xla perspective but it is a symint that
   // wraps around a SizeNode instead of a scalar.
   c10::SymInt dynamic_symint = symint_node->toSymInt();
@@ -98,8 +97,7 @@ TEST(SymintTest, TestDynamicSymints) {
     torch::lazy::NodePtr size_node =
         torch::lazy::MakeNode<SizeNode>(expand_value, /*dim=*/i);
     size_nodes.push_back(size_node);
-    auto symint_node =
-        c10::make_intrusive<torch::lazy::SymIntNodeImpl>(size_node);
+    auto symint_node = c10::make_intrusive<XLASymIntNodeImpl>(size_node);
     // This is not a dynamic size from xla perspective but it is a symint that
     // wraps around a SizeNode instead of a scalar.
     dynamic_symints.push_back(symint_node->toSymInt());

--- a/torch_xla/csrc/torch_util.cpp
+++ b/torch_xla/csrc/torch_util.cpp
@@ -14,7 +14,7 @@ void SymIntElements::AddSymIntNodeElements(c10::SymInt& size) {
     // --(get)--> lazy::NodePtr --(cast)--> lazy::DimensionNode
     c10::SymIntNode symbolicIntNode = size.toSymIntNodeImpl();
     auto* lazySymIntNode =
-        dynamic_cast<torch::lazy::SymIntNodeImpl*>(symbolicIntNode.get());
+        dynamic_cast<XLASymIntNodeImpl*>(symbolicIntNode.get());
     torch::lazy::NodePtr size_node = lazySymIntNode->node_;
     std::shared_ptr<torch::lazy::DimensionNode> dimension_node =
         std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node);

--- a/torch_xla/csrc/torch_util.cpp
+++ b/torch_xla/csrc/torch_util.cpp
@@ -4,6 +4,7 @@
 #include "tensorflow/compiler/xla/xla_client/xla_util.h"
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/ops/constant.h"
+#include "torch_xla/csrc/tensor.h"
 
 namespace torch_xla {
 
@@ -15,7 +16,7 @@ void SymIntElements::AddSymIntNodeElements(c10::SymInt& size) {
     c10::SymIntNode symbolicIntNode = size.toSymIntNodeImpl();
     auto* lazySymIntNode =
         dynamic_cast<XLASymIntNodeImpl*>(symbolicIntNode.get());
-    torch::lazy::NodePtr size_node = lazySymIntNode->node_;
+    torch::lazy::NodePtr size_node = lazySymIntNode->node();
     std::shared_ptr<torch::lazy::DimensionNode> dimension_node =
         std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node);
     size_nodes_.push_back(size_node);


### PR DESCRIPTION
We should be using XLASymIntNodeImpl since it's constructing XLANode rather than torch::lazy::Nodes.