### PR TITLE
Update test name for index_reduce tests

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -355,8 +355,8 @@ DISABLED_TORCH_TESTS_TPU_ONLY = {
         'test_cov_xla',  # precision (9.53674e-07 vs 0)
         'test_diff_xla_float32',  # expected instruction to have shape equal
         'test_diff_xla_float64',  # expected instruction to have shape equal
-        'test_nullary_op_mem_overlap_xla'  # core dumped
-        'test_index_reduce_xla',  # takes too long
+        'test_nullary_op_mem_overlap_xla',  # core dumped
+        'test_index_reduce',  # takes too long
     },
 
     # test_indexing.py


### PR DESCRIPTION
Update test name for index_reduce tests

The `test_index_reduce` tests take too long on TPUVM and have been causing our `python-ops` tests to time out for a while now. Disabling these for now. 

---
Can confirm on TPUVM that `test_index_reduce` tests are not being ran:
```
wonjoo@t1v-n-0dd7892e-w-0:~/pytorch$ python test/test_torch.py TestTorchDeviceTypeXLA.test_index_reduce_reduce_mean_xla_bfloat16
E
======================================================================
ERROR: test_index_reduce_reduce_mean_xla_bfloat16 (unittest.loader._FailedTest)
----------------------------------------------------------------------
AttributeError: type object 'TestTorchDeviceTypeXLA' has no attribute 'test_index_reduce_reduce_mean_xla_bfloat16'

----------------------------------------------------------------------
Ran 1 test in 0.001s

FAILED (errors=1)
wonjoo@t1v-n-0dd7892e-w-0:~/pytorch$ 
```