### PR TITLE
Fix gcc-9 build error: duplicate ‘const’

### DIFF
--- a/torch_xla/csrc/aten_autograd_ops.cpp
+++ b/torch_xla/csrc/aten_autograd_ops.cpp
@@ -25,7 +25,7 @@ torch::Tensor EinsumAutogradFunction::forward(
   ctx->saved_data["equation"] = eq_str;
 
   torch::autograd::variable_list vars;
-  for (const torch::Tensor const& tensor : tensors) {
+  for (const torch::Tensor& tensor : tensors) {
     vars.push_back(tensor);
   }
   ctx->save_for_backward(vars);


### PR DESCRIPTION
```
/home/byronyi/pytorch/xla/torch_xla/csrc/aten_autograd_ops.cpp: In static member function ‘static at::Tensor torch_xla::aten_autograd_ops::EinsumAutogradFunction::forward(torch::autograd::AutogradContext*, c10::string_view, at::TensorList)’:
/home/byronyi/pytorch/xla/torch_xla/csrc/aten_autograd_ops.cpp:28:28: error: duplicate ‘const’
   28 |   for (const torch::Tensor const& tensor : tensors) {
      |                            ^~~~~
      |                            -----
```