### PR TITLE
[PJRT] Rename `pjrt.run_multiprocess` to `pjrt._run_multiprocess`.

### DIFF
--- a/test/pjrt/test_ddp.py
+++ b/test/pjrt/test_ddp.py
@@ -52,7 +52,7 @@ class TestPjRtDistributedDataParallel(parameterized.TestCase):
     ddp_model = DDP(model)
 
   def test_ddp_init(self):
-    pjrt.run_multiprocess(self._ddp_init, self.create_tempfile().full_path)
+    pjrt._run_multiprocess(self._ddp_init, self.create_tempfile().full_path)
 
   @staticmethod
   def _ddp_correctness(init_file: str):
@@ -101,8 +101,8 @@ class TestPjRtDistributedDataParallel(parameterized.TestCase):
           step, cpu_loss, ddp_loss)
 
   def test_ddp_correctness(self):
-    pjrt.run_multiprocess(self._ddp_correctness,
-                          self.create_tempfile().full_path)
+    pjrt._run_multiprocess(self._ddp_correctness,
+                           self.create_tempfile().full_path)
 
 
 if __name__ == "__main__":

--- a/test/pjrt/test_experimental_pjrt_multi_cpu.py
+++ b/test/pjrt/test_experimental_pjrt_multi_cpu.py
@@ -25,7 +25,7 @@ class TestExperimentalPjrtMultiCpu(parameterized.TestCase):
     os.environ.pop(xenv.PJRT_CPU_ASYNC_CLIENT, None)
 
     expected = {0: torch.device('xla:0')}
-    devices_per_process = pjrt.run_multiprocess(xm.xla_device)
+    devices_per_process = pjrt._run_multiprocess(xm.xla_device)
     self.assertDictEqual(devices_per_process, expected)
 
   def test_multi_cpu_devices(self):
@@ -36,20 +36,20 @@ class TestExperimentalPjrtMultiCpu(parameterized.TestCase):
         3: torch.device('xla:3'),
     }
 
-    devices_per_process = pjrt.run_multiprocess(xm.xla_device)
+    devices_per_process = pjrt._run_multiprocess(xm.xla_device)
     self.assertDictEqual(devices_per_process, expected)
 
   @parameterized.named_parameters(('xla_model', xm.get_ordinal),
                                   ('pjrt', pjrt.global_ordinal))
   def test_global_ordinal(self, ordinal_func):
-    results = pjrt.run_multiprocess(ordinal_func)
+    results = pjrt._run_multiprocess(ordinal_func)
     self.assertListEqual(sorted(results.values()), [0, 1, 2, 3])
 
   @parameterized.named_parameters(('xla_model', xm.get_local_ordinal),
                                   ('pjrt', pjrt.local_ordinal))
   def test_local_ordinal(self, ordinal_func):
     # TODO(wcromar): add multiprocess tests
-    results = pjrt.run_multiprocess(ordinal_func)
+    results = pjrt._run_multiprocess(ordinal_func)
     self.assertListEqual(sorted(results.values()), [0, 1, 2, 3])
 
   @staticmethod
@@ -91,7 +91,7 @@ class TestExperimentalPjrtMultiCpu(parameterized.TestCase):
             'device': f'xla:{i}'
         } for i in range(4)
     }
-    results = pjrt.run_multiprocess(self._multi_cpu_backwards)
+    results = pjrt._run_multiprocess(self._multi_cpu_backwards)
 
     self.assertDictEqual(results, expected)
 

--- a/test/pjrt/test_experimental_pjrt_tpu.py
+++ b/test/pjrt/test_experimental_pjrt_tpu.py
@@ -59,7 +59,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
           self.accelerator_type))
     expected = accelerator_devices[self.accelerator_type]
 
-    devices_per_process = pjrt.run_multiprocess(xm.xla_device)
+    devices_per_process = pjrt._run_multiprocess(xm.xla_device)
     self.assertDictEqual(devices_per_process, expected)
 
   def test_xla_devices_single_process_all_chips(self):
@@ -76,7 +76,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
     os.environ[xenv.TPU_VISIBLE_CHIPS] = '0,1,2,3'
     os.environ[xenv.TPU_PROCESS_BOUNDS] = '1,1,1'
 
-    devices = pjrt.run_multiprocess(xm.xla_device)
+    devices = pjrt._run_multiprocess(xm.xla_device)
     self.assertDictEqual(devices, expected)
 
   def test_xla_devices_single_process_one_chip(self):
@@ -98,7 +98,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
     os.environ[xenv.TPU_VISIBLE_CHIPS] = '0'
     os.environ[xenv.TPU_PROCESS_BOUNDS] = '1,1,1'
 
-    devices = pjrt.run_multiprocess(xm.xla_device)
+    devices = pjrt._run_multiprocess(xm.xla_device)
     self.assertDictEqual(devices, expected)
 
   def test_default_xla_devices(self):
@@ -133,7 +133,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
           self.accelerator_type))
     expected_num_devices = accelerator_num_devices[self.accelerator_type]
 
-    results = pjrt.run_multiprocess(ordinal_func)
+    results = pjrt._run_multiprocess(ordinal_func)
     values = list(results.values())
     self.assertListEqual(sorted(values), list(range(expected_num_devices)))
 
@@ -150,7 +150,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
           self.accelerator_type))
     expected_num_devices = accelerator_num_devices[self.accelerator_type]
 
-    results = pjrt.run_multiprocess(ordinal_func)
+    results = pjrt._run_multiprocess(ordinal_func)
     values = list(results.values())
     self.assertListEqual(sorted(values), list(range(expected_num_devices)))
 
@@ -168,7 +168,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
   @parameterized.named_parameters(('synchronized_parameters', True),
                                   ('unsynchronized_parameters', False))
   def test_broadcast_master_param(self, sync):
-    results = pjrt.run_multiprocess(TestExperimentalPjrtTpu._broadcast, sync)
+    results = pjrt._run_multiprocess(self._broadcast, sync)
     master_params = results[0]
     for ordinal, worker_params in results.items():
       if sync:
@@ -188,8 +188,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
 
   @parameterized.named_parameters(('pinned', True), ('unpinned', False))
   def test_all_gather(self, pin_layout):
-    results = pjrt.run_multiprocess(TestExperimentalPjrtTpu._all_gather,
-                                    pin_layout)
+    results = pjrt._run_multiprocess(self._all_gather, pin_layout)
 
     expected = list(range(len(results)))
     for v in results.values():
@@ -215,8 +214,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
 
   @parameterized.named_parameters(('pinned', True), ('unpinned', False))
   def test_reduce_scatter(self, pin_layout):
-    results = pjrt.run_multiprocess(TestExperimentalPjrtTpu._reduce_scatter,
-                                    pin_layout)
+    results = pjrt._run_multiprocess(self._reduce_scatter, pin_layout)
 
     for ordinal, value in results.items():
       np.testing.assert_array_equal(value, [-ordinal])
@@ -247,8 +245,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
 
   @parameterized.named_parameters(('pinned', True), ('unpinned', False))
   def test_all_to_all(self, pin_layout):
-    results = pjrt.run_multiprocess(TestExperimentalPjrtTpu._all_to_all,
-                                    pin_layout)
+    results = pjrt._run_multiprocess(self._all_to_all, pin_layout)
 
     for ordinal, value in results.items():
       np.testing.assert_array_equal(value, [[[-ordinal] * len(results),

--- a/test/pjrt/test_mesh_service.py
+++ b/test/pjrt/test_mesh_service.py
@@ -22,8 +22,8 @@ class PjRtMeshServiceTest(parameterized.TestCase):
       ('defaults', None, []), ('xrt_address', 'localhost:9477', []),
       ('four_replicas', None, [0, 1, 2, 3]), ('two_replicas', None, [0, 1]))
   def test_rendezvous(self, xrt_mesh_addr, replicas):
-    results = pjrt.run_multiprocess(self._rendezvous_default, xrt_mesh_addr,
-                                    replicas)
+    results = pjrt._run_multiprocess(self._rendezvous_default, xrt_mesh_addr,
+                                     replicas)
     replicas = replicas or list(range(len(results)))
 
     for ordinal, value in results.items():
@@ -35,7 +35,7 @@ class PjRtMeshServiceTest(parameterized.TestCase):
     return xm.mesh_reduce('test mesh reduce', xm.get_ordinal(), sum)
 
   def test_mesh_reduce(self):
-    results = pjrt.run_multiprocess(self._mesh_reduce)
+    results = pjrt._run_multiprocess(self._mesh_reduce)
     values = list(results.values())
 
     expected = sum(range(len(values)))

--- a/test/pjrt/test_train_pjrt_imagenet.py
+++ b/test/pjrt/test_train_pjrt_imagenet.py
@@ -263,9 +263,9 @@ def train_imagenet(flags):
 if __name__ == '__main__':
   torch.set_default_tensor_type('torch.FloatTensor')
 
-  results = pjrt.run_multiprocess(train_imagenet, FLAGS)
+  results = pjrt._run_multiprocess(train_imagenet, FLAGS)
   print('Replica max_accuracy:', pprint.pformat(results))
-  accuracy = np.mean([np.mean(list(results.values()))])
+  accuracy = np.mean(list(results.values()))
   print('Average max_accuracy:', accuracy)
 
   if accuracy < FLAGS.target_accuracy:

--- a/test/pjrt/test_train_pjrt_mnist.py
+++ b/test/pjrt/test_train_pjrt_mnist.py
@@ -178,12 +178,9 @@ def train_mnist(flags):
 if __name__ == '__main__':
   torch.set_default_tensor_type('torch.FloatTensor')
 
-  results = pjrt.run_multiprocess(train_mnist, FLAGS)
+  results = pjrt._run_multiprocess(train_mnist, FLAGS)
   print('Replica max_accuracy:', pprint.pformat(results))
-  accuracy = np.mean([
-      np.mean(list(thread_results.values()))
-      for thread_results in results.values()
-  ])
+  accuracy = np.mean(list(results.values()))
   print('Average max_accuracy:', accuracy)
 
   if FLAGS.tidy and os.path.isdir(FLAGS.datadir):

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -157,8 +157,8 @@ def _merge_replica_results(
 
 
 @requires_pjrt
-def run_thread_per_device(local_rank: int, local_world_size: int,
-                          fn: Callable[[], R]) -> Dict[int, R]:
+def _run_thread_per_device(local_rank: int, local_world_size: int,
+                           fn: Callable[[], R]) -> Dict[int, R]:
   """Runs `fn` in a separate thread on each visible device.
 
   Args:
@@ -198,8 +198,8 @@ def run_thread_per_device(local_rank: int, local_world_size: int,
 
 
 @requires_pjrt
-def run_multiprocess(fn: Callable[P, R], *args: P.args,
-                     **kwargs: P.kwargs) -> Dict[int, R]:
+def _run_multiprocess(fn: Callable[P, R], *args: P.args,
+                      **kwargs: P.kwargs) -> Dict[int, R]:
   """Runs `fn` on all devices available to PjRt.
 
   Spawns one process per physical device (e.g. TPU chip).
@@ -223,7 +223,7 @@ def run_multiprocess(fn: Callable[P, R], *args: P.args,
       mp_context=torch.multiprocessing.get_context('spawn')) as executor:
 
     mp_fn = functools.partial(
-        run_thread_per_device,
+        _run_thread_per_device,
         local_world_size=num_processes,
         fn=functools.partial(fn, *args, **kwargs))
     process_results = executor.map(mp_fn, range(num_processes))
@@ -255,7 +255,7 @@ def spawn(fn: Callable, args: Tuple = ()) -> None:
     args: args to pass to `fn`
   """
   spawn_fn = _SpawnFn(fn, *args)
-  run_multiprocess(spawn_fn)
+  _run_multiprocess(spawn_fn)
 
 
 def broadcast_master_param(model: nn.Module) -> None:


### PR DESCRIPTION
Marking `run_multiprocess` as private since it's mainly useful for testing. Users should prefer `spawn` instead.