### PR TITLE
Allow einsum to take optional parameter to align with torch

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1056,7 +1056,8 @@ at::Tensor XLANativeFunctions::dot(const at::Tensor& self,
 }
 
 at::Tensor XLANativeFunctions::einsum(c10::string_view equation,
-                                      at::TensorList tensors) {
+                                      at::TensorList tensors,
+                                      at:OptionalIntArrayRef path) {
   std::string cleansed_equation = std::string(equation);
 
   cleansed_equation.erase(
@@ -1070,7 +1071,7 @@ at::Tensor XLANativeFunctions::einsum(c10::string_view equation,
   if (tensors.size() > 2 ||
       !EinsumUtilities::EquationIsValid(cleansed_equation)) {
     XLA_COUNTER("EinsumFallback", 1);
-    return at::native::einsum(equation, tensors);
+    return at::native::einsum(equation, tensors, path);
   }
   return aten_autograd_ops::EinsumAutogradFunction::apply(cleansed_equation,
                                                           tensors);


### PR DESCRIPTION
This is to allow https://github.com/pytorch/pytorch/pull/84890 to allow an einsum optimization, which currently breaks, see https://github.com/pytorch/pytorch/actions/runs/3114441739/jobs/5050779137.