### PR TITLE
Make lint err messaging clearer with `git diff`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,9 @@ run_clang_format: &run_clang_format
     find -name '*.cpp' -o -name '*.h' | xargs clang-format-7 -i -style=file
     git_status=$(git status --porcelain)
     if [[ $git_status ]]; then
-      echo "clang-format-7 is not happy, please run \"clang-format-7 -i -style /PATH/TO/foo.cpp\" to the following files"
+      git diff
+      echo "clang-format-7 recommends the changes above, please manually apply them OR automatically apply the changes "
+      echo "by running \"clang-format-7 -i -style /PATH/TO/foo.cpp\" to the following files"
       echo "${git_status}"
       exit 1
     else
@@ -207,7 +209,9 @@ run_yapf: &run_yapf
     yapf -i -r *.py test/ scripts/ torch_xla/
     git_status=$(git status --porcelain)
     if [[ $git_status ]]; then
-      echo "yapf is not happy, please run `yapf -i /PATH/TO/foo.py` to the following files"
+      git diff
+      echo "yapf recommends the changes above, please manually apply them OR automatically apply the changes "
+      echo "by running `yapf -i /PATH/TO/foo.py` to the following files"
       echo "${git_status}"
       exit 1
     else


### PR DESCRIPTION
This would help those not working on Linux to see the error messages better. I used git diff to see what I should change manually since my change was so small, and it would look like:
<img width="953" alt="image" src="https://user-images.githubusercontent.com/31798555/192048125-7846b7a4-2005-48b2-ac0a-a673d9579e81.png">

I modified the error message a bit in this commit so it makes more sense, though I'd also understand not wanting super verbose logs potentially.
