### PR TITLE
Significantly reduce Docker image size

### DIFF
--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -6,11 +6,12 @@ ARG cuda_version=11.2
 ARG cudnn_version=8.1.1.33
 # Debian repo doesn't have libcudnn
 ARG cuda_repo=ubuntu1804
-ARG tf_cuda_compute_capabilities="7.0,8.0"
+ARG tf_cuda_compute_capabilities="7.0"
 
 ARG tpuvm=1
 ARG build_cpp_tests=0
 
+# Contains all build dependencies for PT/XLA
 FROM python:${python_version}-${debian_version} AS builder
 
 RUN apt-get update
@@ -56,12 +57,14 @@ RUN chmod +x /usr/local/bin/bazel
 RUN mkdir xla
 WORKDIR /pytorch/xla/
 
-COPY tf_patches/
-COPY third_party/ third_party/
-WORKDIR /pytorch/xla/tensorflow
-RUN git apply /pytorch/xla/tf_patches/patch.diff
+# Contains actual build artifacts
+FROM builder AS build
 
-WORKDIR /pytorch/xla
+COPY tf_patches/ tf_patches/
+COPY third_party/ third_party/
+
+RUN patch -d third_party/tensorflow -N -p1 < /pytorch/xla/tf_patches/patch.diff
+
 COPY build_torch_xla_libs.sh .
 
 ARG tpuvm
@@ -69,15 +72,17 @@ ARG tf_cuda_compute_capabilities
 RUN TPUVM_MODE=${tpuvm} XLA_CUDA=${cuda} TF_CUDA_COMPUTE_CAPABILITIES=${tf_cuda_compute_capabilities} bash build_torch_xla_libs.sh -O -D_GLIBCXX_USE_CXX11_ABI=1
 
 COPY torch_xla/ torch_xla/
-COPY scripts/ scripts/
 COPY setup.py .
 COPY xla_native_functions.yaml .
+
+COPY scripts/ scripts/
 
 ARG build_cpp_tests
 RUN BUILD_CPP_TESTS=${build_cpp_tests} TPUVM_MODE=${tpuvm} XLA_CUDA=${cuda} TF_CUDA_COMPUTE_CAPABILITIES=${tf_cuda_compute_capabilities} python setup.py bdist_wheel
 
 RUN pip install dist/*.whl
 
+# Contains only release artifacts
 FROM python:${python_version}-slim-${debian_version} AS release
 
 RUN apt-get update
@@ -102,7 +107,7 @@ RUN apt-get update
 RUN apt-get -y install google-cloud-cli
 
 COPY --from=builder /pytorch/dist/*.whl .
-COPY --from=builder /pytorch/xla/dist/*.whl .
+COPY --from=build /pytorch/xla/dist/*.whl .
 
 RUN pip install *.whl
 RUN rm *.whl

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -6,7 +6,7 @@ ARG cuda_version=11.2
 ARG cudnn_version=8.1.1.33
 # Debian repo doesn't have libcudnn
 ARG cuda_repo=ubuntu1804
-ARG tf_cuda_compute_capabilities="7.0"
+ARG tf_cuda_compute_capabilities="7.0,7.5,8.0"
 
 ARG tpuvm=1
 ARG build_cpp_tests=0
@@ -120,3 +120,8 @@ RUN pip install --no-deps torchvision pillow
 
 RUN mkdir -p /pytorch/xla
 COPY . /pytorch/xla
+
+WORKDIR /pytorch/xla
+RUN python setup.py clean
+
+WORKDIR /

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -55,7 +55,13 @@ RUN chmod +x /usr/local/bin/bazel
 
 RUN mkdir xla
 WORKDIR /pytorch/xla/
+
+COPY tf_patches/
 COPY third_party/ third_party/
+WORKDIR /pytorch/xla/tensorflow
+RUN git apply /pytorch/xla/tf_patches/patch.diff
+
+WORKDIR /pytorch/xla
 COPY build_torch_xla_libs.sh .
 
 ARG tpuvm
@@ -75,7 +81,7 @@ RUN pip install dist/*.whl
 FROM python:${python_version}-slim-${debian_version} AS release
 
 RUN apt-get update
-RUN apt-get install -y libopenblas-base curl gnupg libomp5
+RUN apt-get install -y libopenblas-base curl gnupg libomp5 git
 
 RUN pip install numpy pyyaml
 
@@ -101,7 +107,11 @@ COPY --from=builder /pytorch/xla/dist/*.whl .
 RUN pip install *.whl
 RUN rm *.whl
 
-
 ARG tpuvm
 RUN if [ "${tpuvm}" = "1" ]; then pip install torch_xla[tpuvm]; fi
 
+# TODO: make this version selectable
+RUN pip install --no-deps torchvision pillow
+
+RUN mkdir -p /pytorch/xla
+COPY . /pytorch/xla

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -1,31 +1,32 @@
 ARG python_version=3.8
 ARG debian_version=buster
-FROM python:${python_version}-${debian_version} AS common
+
+ARG cuda=0
+ARG cuda_version=11.2
+ARG cudnn_version=8.1.1.33
+# Debian repo doesn't have libcudnn
+ARG cuda_repo=ubuntu1804
+ARG tf_cuda_compute_capabilities="7.0,8.0"
+
+ARG tpuvm=1
+ARG build_cpp_tests=0
+
+FROM python:${python_version}-${debian_version} AS builder
 
 RUN apt-get update
-RUN apt-get install -y curl gnupg libomp5
+RUN apt-get install -y curl gnupg libomp5 libopenblas-dev
 RUN pip install numpy pyyaml
 
-ARG debian_number=ubuntu1804
+ARG cuda
+ARG cuda_version
+ARG cudnn_version
+ARG cuda_repo
+COPY docker/experimental/maybe_install_cuda.sh .
+RUN CUDA=${cuda} CUDA_REPO=${cuda_repo} CUDA_VERSION=${cuda_version} CUDNN_VERSION=${cudnn_version} ./maybe_install_cuda.sh build
+RUN rm maybe_install_cuda.sh
+ENV LD_LIBRARY_PATH=${cuda:+"${LD_LIBRARY_PATH}:/usr/local/cuda-${cuda_version}/targets/x86_64-linux/lib:/usr/local/nvidia/lib64"}
 
-RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/${debian_number}/x86_64/3bf863cc.pub
-RUN echo "deb https://developer.download.nvidia.com/compute/cuda/repos/${debian_number}/x86_64/ /" >> /etc/apt/sources.list
-RUN apt-get update
-
-ARG cudnn_version="8.1.1.33"
-ARG cuda_version="11.2"
-
-RUN apt-get install -y libcudnn8=8.1.1.33-1+cuda11.2
-
-FROM common AS builder
-
-ARG debian_version=buster
-ARG cudnn_version="8.1.1.33"
-ARG cuda_version="11.2"
-
-RUN apt-get install -y libopenblas-dev
-RUN apt-get install -y libcudnn8-dev=${cudnn_version}-1+cuda${cuda_version}
-
+ARG debian_version
 RUN echo "deb http://apt.llvm.org/${debian_version}/ llvm-toolchain-${debian_version}-8 main" >> /etc/apt/sources.list
 RUN echo "deb-src http://apt.llvm.org/${debian_version}/ llvm-toolchain-${debian_version}-8 main" >> /etc/apt/sources.list
 RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
@@ -37,10 +38,12 @@ RUN update-alternatives --install /usr/bin/clang++ clang++ $(which clang++-8) 70
 ENV CC=clang-8
 ENV CXX=clang++-8
 
+RUN pip install mkl mkl-include setuptools typing_extensions cmake
+
 RUN git clone --recursive --depth=1 https://github.com/pytorch/pytorch.git
 WORKDIR /pytorch
-
-RUN pip install mkl mkl-include setuptools typing_extensions cmake
+COPY torch_patches/ torch_patches/
+RUN bash -c "torch_pin=$(cat torch_patches/.torch_pin &); git fetch origin ${torch_pin:-master}; git checkout origin/${torch_pin:-master}"
 
 RUN USE_CUDA=0 python setup.py bdist_wheel
 
@@ -51,23 +54,40 @@ RUN mv bazelisk-linux-amd64 /usr/local/bin/bazel
 RUN chmod +x /usr/local/bin/bazel
 
 RUN mkdir xla
-COPY third_party xla/third_party
-COPY build_torch_xla_libs.sh xla/
 WORKDIR /pytorch/xla/
+COPY third_party/ third_party/
+COPY build_torch_xla_libs.sh .
 
-RUN apt-get install -y cuda-toolkit-11-2
-RUN XLA_CUDA=1 bash build_torch_xla_libs.sh -O -D_GLIBCXX_USE_CXX11_ABI=1
+ARG tpuvm
+ARG tf_cuda_compute_capabilities
+RUN TPUVM_MODE=${tpuvm} XLA_CUDA=${cuda} TF_CUDA_COMPUTE_CAPABILITIES=${tf_cuda_compute_capabilities} bash build_torch_xla_libs.sh -O -D_GLIBCXX_USE_CXX11_ABI=1
 
-COPY torch_xla torch_xla
-COPY scripts scripts
+COPY torch_xla/ torch_xla/
+COPY scripts/ scripts/
 COPY setup.py .
 COPY xla_native_functions.yaml .
 
-RUN BUILD_CPP_TESTS=0 XLA_CUDA=1 python setup.py bdist_wheel
+ARG build_cpp_tests
+RUN BUILD_CPP_TESTS=${build_cpp_tests} TPUVM_MODE=${tpuvm} XLA_CUDA=${cuda} TF_CUDA_COMPUTE_CAPABILITIES=${tf_cuda_compute_capabilities} python setup.py bdist_wheel
 
 RUN pip install dist/*.whl
 
-FROM common AS release
+FROM python:${python_version}-slim-${debian_version} AS release
+
+RUN apt-get update
+RUN apt-get install -y libopenblas-base curl gnupg libomp5
+
+RUN pip install numpy pyyaml
+
+ARG cuda
+ARG cudnn_version
+ARG cuda_version
+ARG cuda_repo
+
+COPY docker/experimental/maybe_install_cuda.sh .
+RUN CUDA=${cuda} CUDA_REPO=${cuda_repo} CUDA_VERSION=${cuda_version} CUDNN_VERSION=${cudnn_version} ./maybe_install_cuda.sh common
+RUN rm maybe_install_cuda.sh
+ENV LD_LIBRARY_PATH=${cuda:+"${LD_LIBRARY_PATH}:/usr/local/cuda-${cuda_version}/targets/x86_64-linux/lib:/usr/local/nvidia/lib64"}
 
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" >> /etc/apt/sources.list.d/google-cloud-sdk.list
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
@@ -79,5 +99,9 @@ COPY --from=builder /pytorch/dist/*.whl .
 COPY --from=builder /pytorch/xla/dist/*.whl .
 
 RUN pip install *.whl
-RUN pip install torch_xla[tpuvm]
 RUN rm *.whl
+
+
+ARG tpuvm
+RUN if [ "${tpuvm}" = "1" ]; then pip install torch_xla[tpuvm]; fi
+

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -1,0 +1,68 @@
+ARG python_version=3.8
+ARG debian_version=buster
+FROM python:${python_version}-${debian_version} AS common
+
+RUN apt-get update
+RUN apt-get install -y curl gnupg libomp5
+RUN pip install numpy pyyaml
+
+FROM common AS builder
+
+ARG debian_version=buster
+
+RUN apt-get install -y libopenblas-dev
+
+RUN echo "deb http://apt.llvm.org/${debian_version}/ llvm-toolchain-${debian_version}-8 main" >> /etc/apt/sources.list
+RUN echo "deb-src http://apt.llvm.org/${debian_version}/ llvm-toolchain-${debian_version}-8 main" >> /etc/apt/sources.list
+RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+
+RUN apt-get update
+RUN apt-get -y install clang-8 clang++-8
+RUN update-alternatives --install /usr/bin/clang++ clang++ $(which clang++-8) 70
+
+ENV CC=clang-8
+ENV CXX=clang++-8
+
+RUN git clone --recursive --depth=1 https://github.com/pytorch/pytorch.git
+WORKDIR /pytorch
+
+RUN pip install mkl mkl-include setuptools typing_extensions cmake
+
+RUN USE_CUDA=0 python setup.py bdist_wheel
+
+RUN pip install dist/*.whl
+
+RUN curl -LO https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64
+RUN mv bazelisk-linux-amd64 /usr/local/bin/bazel
+RUN chmod +x /usr/local/bin/bazel
+
+RUN mkdir xla
+COPY third_party xla/third_party
+COPY build_torch_xla_libs.sh xla/
+WORKDIR /pytorch/xla/
+
+RUN TPUVM_MODE=1 bash build_torch_xla_libs.sh -O -D_GLIBCXX_USE_CXX11_ABI=1
+
+COPY torch_xla torch_xla
+COPY scripts scripts
+COPY setup.py .
+COPY xla_native_functions.yaml .
+
+RUN TPUVM_MODE=1 BUILD_CPP_TESTS=0 python setup.py bdist_wheel
+
+RUN pip install dist/*.whl
+
+FROM common AS release
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" >> /etc/apt/sources.list.d/google-cloud-sdk.list
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+
+RUN apt-get update
+RUN apt-get -y install google-cloud-cli
+
+COPY --from=builder /pytorch/dist/*.whl .
+COPY --from=builder /pytorch/xla/dist/*.whl .
+
+RUN pip install *.whl
+RUN pip install torch_xla[tpuvm]
+RUN rm *.whl

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -6,11 +6,25 @@ RUN apt-get update
 RUN apt-get install -y curl gnupg libomp5
 RUN pip install numpy pyyaml
 
+ARG debian_number=ubuntu1804
+
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/${debian_number}/x86_64/3bf863cc.pub
+RUN echo "deb https://developer.download.nvidia.com/compute/cuda/repos/${debian_number}/x86_64/ /" >> /etc/apt/sources.list
+RUN apt-get update
+
+ARG cudnn_version="8.1.1.33"
+ARG cuda_version="11.2"
+
+RUN apt-get install -y libcudnn8=8.1.1.33-1+cuda11.2
+
 FROM common AS builder
 
 ARG debian_version=buster
+ARG cudnn_version="8.1.1.33"
+ARG cuda_version="11.2"
 
 RUN apt-get install -y libopenblas-dev
+RUN apt-get install -y libcudnn8-dev=${cudnn_version}-1+cuda${cuda_version}
 
 RUN echo "deb http://apt.llvm.org/${debian_version}/ llvm-toolchain-${debian_version}-8 main" >> /etc/apt/sources.list
 RUN echo "deb-src http://apt.llvm.org/${debian_version}/ llvm-toolchain-${debian_version}-8 main" >> /etc/apt/sources.list
@@ -41,14 +55,15 @@ COPY third_party xla/third_party
 COPY build_torch_xla_libs.sh xla/
 WORKDIR /pytorch/xla/
 
-RUN TPUVM_MODE=1 bash build_torch_xla_libs.sh -O -D_GLIBCXX_USE_CXX11_ABI=1
+RUN apt-get install -y cuda-toolkit-11-2
+RUN XLA_CUDA=1 bash build_torch_xla_libs.sh -O -D_GLIBCXX_USE_CXX11_ABI=1
 
 COPY torch_xla torch_xla
 COPY scripts scripts
 COPY setup.py .
 COPY xla_native_functions.yaml .
 
-RUN TPUVM_MODE=1 BUILD_CPP_TESTS=0 python setup.py bdist_wheel
+RUN BUILD_CPP_TESTS=0 XLA_CUDA=1 python setup.py bdist_wheel
 
 RUN pip install dist/*.whl
 

--- a/docker/experimental/maybe_install_cuda.sh
+++ b/docker/experimental/maybe_install_cuda.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -x
+set -e
+
+cuda_version_hyphenated=${CUDA_VERSION//./-}
+cudnn_major_version=${CUDNN_VERSION%%.*}
+
+function common() {
+  apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/${CUDA_REPO}/x86_64/3bf863cc.pub
+  echo "deb https://developer.download.nvidia.com/compute/cuda/repos/${CUDA_REPO}/x86_64/ /" >> /etc/apt/sources.list
+  apt-get update
+
+  apt-get install -y cuda-libraries-${cuda_version_hyphenated} cuda-minimal-build-${cuda_version_hyphenated} libcudnn${cudnn_major_version}=${CUDNN_VERSION}-1+cuda${CUDA_VERSION}
+}
+
+function build() {
+  common
+
+  apt-get install -y libcudnn${cudnn_major_version}-dev=${CUDNN_VERSION}-1+cuda${CUDA_VERSION} cuda-toolkit-${cuda_version_hyphenated}
+}
+
+if [ "$CUDA" ==  "1" ]; then
+  set -u
+  ${@:1}
+else
+  echo "Skipping CUDA installation (\$CUDA=$CUDA)"
+fi


### PR DESCRIPTION
This PR brings the size of the GPU image down to `6.24 GB` from `17.2 GB`

- Use local `xla` directory instead of cloning from github. This allows building an image from a local working copy
- Separate build image from release image so we don't release build artifacts
- Break build steps up to take better advantage of caching to make debugging less painful. In particular, build TF in its own step because it takes forever
- Remove unnecessary dependencies
- Use smaller `python:X.Y-slim` base images

Needs follow-up:

- Create new Google Cloud Build config for this image
- Collect wheels and upload to GCS
- Start using in e2e tests
- Example of using `builder` image for development

This image still ended up being messier than I wanted, although there are still advantages compared to the old build that make it more reasonable to use for CI and development. We should merge this to unblock #4018 and keep working on it as part of our broader build refactoring work.

Tested manually on TPU VM and GPU