### PR TITLE
Fix `ExpectCounterNotChanged` to correctly account for `_symint`

### DIFF
--- a/test/cpp/torch_xla_test.cpp
+++ b/test/cpp/torch_xla_test.cpp
@@ -61,8 +61,8 @@ void XlaTest::ExpectCounterNotChanged(
   // using the old names. We modify `ExpectCounterNotChanged` to also check
   // `opName_symint` counters. When we finish migrating the ops to symints, we
   // would remove this logic and fix all the tests
-  auto changed_symint =
-      start_msnap_->CounterChanged(counter_regex, *end_msnap_, ignore_set);
+  auto changed_symint = start_msnap_->CounterChanged(counter_regex + "_symint",
+                                                     *end_msnap_, ignore_set);
 
   ExpectCounterNotChanged_(changed_symint);
 }


### PR DESCRIPTION
Fixing the test issue I discussed in https://github.com/pytorch/xla/pull/3978