### PR TITLE
[PJRT] Enable PJRT C API option

### DIFF
--- a/tf_patches/patch.diff
+++ b/tf_patches/patch.diff
@@ -3,9 +3,9 @@ index 9fe020d5937..32774c2f3c0 100644
 --- a/tensorflow/compiler/xla/service/cpu/runtime_fp16.h
 +++ b/tensorflow/compiler/xla/service/cpu/runtime_fp16.h
 @@ -18,12 +18,7 @@ limitations under the License.
- 
+
  #include <stdint.h>
- 
+
 -// _Float16 always gets us the correct ABI type, so use that if available.
 -// AArch64 GCC defines __FLT16_MANT_DIG__ even when _Float16 is not available.
 -#if defined(__FLT16_MANT_DIG__) && \
@@ -32,3 +32,15 @@ index b70ea8af5df..b54a895e306 100644
    } else if (tool_name == "tool_names") {
      return GetAvailableToolNames(session_snapshot);
    } else {
+diff --git a/tensorflow/compiler/xla/pjrt/pjrt_c_api_client.cc b/tensorflow/compiler/xla/pjrt/pjrt_c_api_client.cc
+index e6fda37012b..5d10dc157e2 100644
+--- a/tensorflow/compiler/xla/pjrt/pjrt_c_api_client.cc
++++ b/tensorflow/compiler/xla/pjrt/pjrt_c_api_client.cc
+@@ -787,7 +787,6 @@ PjRtCApiExecutable::ExecuteSharded(
+
+   args.execute_device =
+       tensorflow::down_cast<PjRtCApiDevice*>(device)->c_device();
+-  args.execute_device->device = device;
+
+   RETURN_STATUS_IF_ERROR(pjrt_c_api()->PJRT_Executable_Execute(&args),
+                          pjrt_c_api());

--- a/tf_patches/patch.diff
+++ b/tf_patches/patch.diff
@@ -3,9 +3,9 @@ index 9fe020d5937..32774c2f3c0 100644
 --- a/tensorflow/compiler/xla/service/cpu/runtime_fp16.h
 +++ b/tensorflow/compiler/xla/service/cpu/runtime_fp16.h
 @@ -18,12 +18,7 @@ limitations under the License.
-
+ 
  #include <stdint.h>
-
+ 
 -// _Float16 always gets us the correct ABI type, so use that if available.
 -// AArch64 GCC defines __FLT16_MANT_DIG__ even when _Float16 is not available.
 -#if defined(__FLT16_MANT_DIG__) && \

--- a/third_party/xla_client/BUILD
+++ b/third_party/xla_client/BUILD
@@ -151,6 +151,7 @@ cc_library(
         "//tensorflow/compiler/xla/pjrt:tpu_client",
         "//tensorflow/compiler/xla/pjrt:pjrt_client",
         "//tensorflow/compiler/xla/pjrt:tfrt_cpu_pjrt_client",
+        "//tensorflow/compiler/xla/pjrt:pjrt_c_api_client",
         "//tensorflow/compiler/xla/rpc:grpc_stub",
         "//tensorflow/compiler/xla/service:cpu_plugin",
         "//tensorflow/compiler/xla/service:platform_util",

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -298,8 +298,13 @@ PjRtComputationClient::ExecuteComputation(
     std::unique_ptr<xla::PjRtBuffer> buffer = std::move(result);
 
     std::shared_ptr<PjRtData> data = std::make_shared<PjRtData>(
-        // TODO(wcromar): do we need `logical_on_device_shape` here?
-        device, buffer->on_device_shape(), std::move(buffer));
+        device,
+        // TODO(wcromar): just use `logical_on_device_shape` when it's supported
+        // in C API
+        client_->runtime_type() == xla::PjRtRuntimeType::kTfrt
+            ? buffer->on_device_shape()
+            : buffer->logical_on_device_shape().ValueOrDie(),
+        std::move(buffer));
 
     datas.push_back(data);
   }

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -8,8 +8,9 @@
 #include "tensorflow/compiler/xla/layout_util.h"
 #include "tensorflow/compiler/xla/literal.h"
 #include "tensorflow/compiler/xla/pjrt/cpu_device.h"
-#include "tensorflow/compiler/xla/pjrt/pjrt_executable.h"
+#include "tensorflow/compiler/xla/pjrt/pjrt_c_api_client.h"
 #include "tensorflow/compiler/xla/pjrt/pjrt_client.h"
+#include "tensorflow/compiler/xla/pjrt/pjrt_executable.h"
 #include "tensorflow/compiler/xla/pjrt/tfrt_cpu_pjrt_client.h"
 #include "tensorflow/compiler/xla/pjrt/tpu_client.h"
 #include "tensorflow/compiler/xla/shape.h"
@@ -57,6 +58,12 @@ PjRtComputationClient::PjRtComputationClient() {
     int64_t max_inflight_computations = sys_util::GetEnvInt(
         env::kEnvPjRtTpuMaxInflightComputations, /*defval=*/32);
     client_ = xla::GetTpuClient(max_inflight_computations).ValueOrDie();
+  } else if (device_type == "TPU_C_API") {
+    TF_VLOG(1) << "Initializing PjRt C API client...";
+    client_ = std::move(xla::GetCApiClient().ValueOrDie());
+    // TODO(wcromar): remove this when C API supports
+    // kImmutableUntilTransferCompletes
+    host_buffer_semantics_ = xla::PjRtClient::HostBufferSemantics::kZeroCopy;
   } else {
     XLA_ERROR() << absl::StrFormat("Unknown %s '%s'", env::kEnvPjRtDevice,
                                    device_type);
@@ -112,7 +119,8 @@ std::vector<ComputationClient::DataPtr> PjRtComputationClient::TransferToServer(
     auto literal = std::make_shared<xla::Literal>(tensor.shape);
     tensor.populate_fn(tensor, literal->untyped_data(), literal->size_bytes());
     std::vector<int64_t> byte_strides(literal->shape().dimensions_size());
-    XLA_CHECK_OK(ShapeUtil::ByteStrides(literal->shape(), absl::MakeSpan(byte_strides)));
+    XLA_CHECK_OK(
+        ShapeUtil::ByteStrides(literal->shape(), absl::MakeSpan(byte_strides)));
     total_size += literal->size_bytes();
 
     // Avoid use-after-free on `literal` due to unsequenced move and use.
@@ -123,8 +131,7 @@ std::vector<ComputationClient::DataPtr> PjRtComputationClient::TransferToServer(
                 literal_pointer->untyped_data(),
                 literal_pointer->shape().element_type(),
                 literal_pointer->shape().dimensions(), byte_strides,
-                PjRtClient::HostBufferSemantics::
-                    kImmutableUntilTransferCompletes,
+                host_buffer_semantics_,
                 [literal{std::move(literal)}]() { /* frees literal */ },
                 pjrt_device)
             .ValueOrDie());
@@ -220,17 +227,30 @@ std::vector<ComputationClient::ComputationPtr> PjRtComputationClient::Compile(
     std::unique_ptr<xla::PjRtLoadedExecutable> executable =
         ConsumeValue(client_->Compile(instance.computation, compile_options));
 
-    const auto& hlo_modules = ConsumeValue(executable->GetHloModules());
-    HloComputation* hlo_computation = hlo_modules[0]->entry_computation();
-    xla::ProgramShape program_shape =
-        xla::ProgramShape(hlo_computation->ToProto().program_shape());
+    if (instance.is_sharded) {
+      const auto& hlo_modules = ConsumeValue(executable->GetHloModules());
+      HloComputation* hlo_computation = hlo_modules[0]->entry_computation();
+      xla::ProgramShape program_shape =
+          xla::ProgramShape(hlo_computation->ToProto().program_shape());
 
-    std::shared_ptr<PjRtComputation> pjrt_computation =
-        std::make_shared<PjRtComputation>(
-            std::move(xla::XlaComputation(hlo_modules[0]->ToProto())),
-            program_shape, instance.devices, std::move(executable));
+      std::shared_ptr<PjRtComputation> pjrt_computation =
+          std::make_shared<PjRtComputation>(
+              std::move(xla::XlaComputation(hlo_modules[0]->ToProto())),
+              program_shape, instance.devices, std::move(executable));
 
-    computations.push_back(pjrt_computation);
+      computations.push_back(pjrt_computation);
+    } else {
+      // TODO(wcromar): Remove this case when C API supports GetHloModule
+      xla::ProgramShape program_shape =
+          instance.computation.GetProgramShape().ValueOrDie();
+      std::shared_ptr<PjRtComputation> pjrt_computation =
+          std::make_shared<PjRtComputation>(std::move(instance.computation),
+                                            program_shape, instance.devices,
+                                            std::move(executable));
+
+      computations.push_back(pjrt_computation);
+    }
+
     CreateCompileHandlesCounter()->AddValue(1);
   }
 
@@ -278,8 +298,8 @@ PjRtComputationClient::ExecuteComputation(
     std::unique_ptr<xla::PjRtBuffer> buffer = std::move(result);
 
     std::shared_ptr<PjRtData> data = std::make_shared<PjRtData>(
-        device, buffer->logical_on_device_shape().ValueOrDie(),
-        std::move(buffer));
+        // TODO(wcromar): do we need `logical_on_device_shape` here?
+        device, buffer->on_device_shape(), std::move(buffer));
 
     datas.push_back(data);
   }

--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -115,6 +115,10 @@ class PjRtComputationClient : public ComputationClient {
   std::shared_ptr<PjRtClient> client_;
   std::unordered_map<std::string, xla::PjRtDevice* const> string_to_device_;
   std::shared_ptr<std::vector<std::string>> replication_devices_;
+  // TODO(wcromar): remove this when C API supports
+  // kImmutableUntilTransferCompletes
+  xla::PjRtClient::HostBufferSemantics host_buffer_semantics_ =
+      xla::PjRtClient::HostBufferSemantics::kImmutableUntilTransferCompletes;
 
   xla::PjRtDevice* StringToPjRtDevice(const std::string& device);
 
@@ -126,13 +130,8 @@ class PjRtComputationClient : public ComputationClient {
              std::shared_ptr<PjRtBuffer> buffer)
         : Data(std::move(device), std::move(device_shape)), buffer(buffer) {}
 
-    void* get_handle() const {
-      return buffer->AcquireExternalReference()
-          .ValueOrDie()
-          ->OpaqueDeviceMemoryDataPointer();
-    };
     OpaqueHandle GetOpaqueHandle() override {
-      return reinterpret_cast<std::uintptr_t>(get_handle());
+      return reinterpret_cast<std::uintptr_t>(buffer.get());
     };
     void Assign(const Data& data) override;
     bool HasValue() const override {

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -109,7 +109,6 @@ from .version import __version__
 logger.info(
     'Letting libtpu.so load fail during _XLAC import. libtpu.so will be loaded '
     'from `libtpu` Python package when the ComputationClient is created.')
-# _tpu_vm_init() will update TPU_LIBRARY_PATH to Python package, if available
 os.environ['TPU_LOAD_LIBRARY'] = '0'
 import _XLAC
 del os.environ['TPU_LOAD_LIBRARY']

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -110,9 +110,9 @@ logger.info(
     'Letting libtpu.so load fail during _XLAC import. libtpu.so will be loaded '
     'from `libtpu` Python package when the ComputationClient is created.')
 # _tpu_vm_init() will update TPU_LIBRARY_PATH to Python package, if available
-os.environ['TPU_LIBRARY_PATH'] = '/dev/null'
+os.environ['TPU_LOAD_LIBRARY'] = '0'
 import _XLAC
-del os.environ['TPU_LIBRARY_PATH']
+del os.environ['TPU_LOAD_LIBRARY']
 
 _tpu_vm_init()
 

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -34,7 +34,8 @@ def set_device_type(pjrt_device: str) -> None:
 
 def device_type() -> Optional[str]:
   """Returns the currrent PjRt device type."""
-  return xu.getenv_as(xenv.PJRT_DEVICE, str)
+  pjrt_device = xu.getenv_as(xenv.PJRT_DEVICE, str)
+  return 'TPU' if pjrt_device.startswith('TPU') else pjrt_device
 
 
 def using_pjrt() -> bool:

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -35,7 +35,7 @@ def set_device_type(pjrt_device: str) -> None:
 def device_type() -> Optional[str]:
   """Returns the currrent PjRt device type."""
   pjrt_device = xu.getenv_as(xenv.PJRT_DEVICE, str)
-  return 'TPU' if pjrt_device.startswith('TPU') else pjrt_device
+  return 'TPU' if pjrt_device and pjrt_device.startswith('TPU') else pjrt_device
 
 
 def using_pjrt() -> bool:


### PR DESCRIPTION
[`PjRtCApiClient` in upstream TensorFlow](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/pjrt/pjrt_c_api_client.h)

The new PjRt C API will be used to enable the new TPU runtime that we will support long-term. Note: The `PjRtCApiClient` currently requires a Google-internal build of libtpu. The `TPU_C_API` option will _not_ work with the public `libtpu-nightly` builds at the time of writing.

- Create a `PjRtCApiClient` when `PJRT_DEVICE=TPU_C_API`
  - Still return `"TPU"` from `pjrt.device_type()` because this should be interchangeable with `PjRtTpuClient`.
- Avoid calling `executable->GetHloModules()` except for SPMD-sharded executables because it's not yet supported in the C API. This also means we won't be able to test SPMD with the C API until `GetHloModules` is supported upstream.
- Use `xla::PjRtClient::HostBufferSemantics::kZeroCopy` with C API because it does not yet support `kImmutableUntilTransferCompletes`. 
- Avoid calling `AcquireExternalReference` to get an `OpaqueHandle`. [`AcquireExternalReference`](https://github.com/tensorflow/tensorflow/blob/3899ff4b6e6018a5333e2cf000b826a11411c2b3/tensorflow/compiler/xla/pjrt/pjrt_client.h#L762-L779) is for sharing memory with an external framework and is not necessary in this case. We only need a unique int to represent the underlying buffer (analogous to a "handle" in XRT) to use in [`RunPostOrder`](https://github.com/pytorch/xla/blob/e515d31d199215409277981f7474a6cce1df77b6/torch_xla/csrc/tensor.cpp#L1369-L1370). Use the buffer address directly instead because it's not trivial to get aliased `PjRtBuffer`s and PjRt doesn't have the same notion of a "handle" or a unique buffer ID. The C API does not support `AcquireExternalReference`, but we didn't actually need it anyway.
- Don't modify `TPU_LIBRARY_PATH` in `__init__.py`, since that needs to be set to the custom internal `libtpu` build for testing this PR. Instead, use `TPU_LOAD_LIBRARY=0` to prevent the TF TPU runtime from initializing the TPU when we're not using XRT. This expresses our intent (i.e. don't load libtpu yet) more clearly anyway.
- Patch https://github.com/tensorflow/tensorflow/commit/9a4502ab470177c259865b5b58598be690bdd86e until we update our TF pin past the fix.

Tested manually with ResNet50 on a v4-8. Performance was within ~2% of the `PjRtTpuClient` baseline.

CC @yeounoh @skye

