### PR TITLE
Add ConvertXlaShapeToLazy helper function

### DIFF
--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -63,6 +63,7 @@ set(TORCH_XLA_TEST_SOURCES
   test_xla_backend_intf.cpp
   test_symint.cpp
   test_xla_sharding.cpp
+  test_lazy.cpp
 )
 
 add_executable(test_ptxla ${TORCH_XLA_TEST_SOURCES})

--- a/test/cpp/test_lazy.cpp
+++ b/test/cpp/test_lazy.cpp
@@ -11,32 +11,15 @@ namespace cpp_test {
 class LazyTest : public TorchXlaTest {};
 
 TEST_F(LazyTest, TestXlaShapeToLazy) {
-/*
-  Shape(PrimitiveType element_type, absl::Span<const int64_t> dimensions,
-        absl::Span<const bool> dynamic_dimensions,
-        std::vector<Shape> tuple_shapes)
-*/    
     int64_t dimensions[] = {1, 2};
     bool dynamic_dimensions[] = {false, false};
     absl::Span<const int64_t> xla_dimensions = absl::Span<const int64_t>(dimensions);
     absl::Span<const bool> xla_dynamic_dimensions = absl::Span<const bool>(dynamic_dimensions);
     std::vector<xla::Shape> xla_tuple_shapes = std::vector<xla::Shape>();
-
-    // std::cout << "WONJOO cpptest: dimensions.size()=" << dimensions.size() << std::endl;
-    std::cout << "WONJOO cpptest: xla_dimensions.size()=" << xla_dimensions.size() << std::endl;
-    for (const auto& elem : xla_dimensions) {
-      std::cout << "WONJOO cpptest: xla_dimensions[i]=" << elem << std::endl;;
-    } 
-
     xla::Shape xla_shape = xla::Shape(xla::PrimitiveType::F32, xla_dimensions, xla_dynamic_dimensions, xla_tuple_shapes);
 
     torch::lazy::Shape lazy_shape = XlaHelpers::ConvertXlaShapeToLazy(xla_shape);
-
-    std::cout << "WONJOO cpptest: xla::Shape=" << xla_shape << std::endl;
-    std::cout << "WONJOO cpptest: torch::lazy::Shape=" << lazy_shape << std::endl;
-
     std::vector<int64_t> lazy_dimensions = xla::util::ToVector<int64_t>(lazy_shape.sizes());
-    std::cout << "WONJOO cpptest: lazy_dimensions=" << lazy_dimensions << std::endl;
     const c10::optional<std::vector<bool>>& lazy_dynamic_dimensions = lazy_shape.is_symbolic();
     EXPECT_EQ(lazy_shape.scalar_type(), at::ScalarType::Float);
     EXPECT_EQ(lazy_shape.dim(), 2);
@@ -45,32 +28,15 @@ TEST_F(LazyTest, TestXlaShapeToLazy) {
 }
 
 TEST_F(LazyTest, TestXlaShapeToLazyWithDynamicDimensions) {
-/*
-  Shape(PrimitiveType element_type, absl::Span<const int64_t> dimensions,
-        absl::Span<const bool> dynamic_dimensions,
-        std::vector<Shape> tuple_shapes)
-*/    
     int64_t dimensions[] = {1, 2};
     bool dynamic_dimensions[] = {true, false};
     absl::Span<const int64_t> xla_dimensions = absl::Span<const int64_t>(dimensions);
     absl::Span<const bool> xla_dynamic_dimensions = absl::Span<const bool>(dynamic_dimensions);
     std::vector<xla::Shape> xla_tuple_shapes = std::vector<xla::Shape>();
-
-    // std::cout << "WONJOO cpptest: dimensions.size()=" << dimensions.size() << std::endl;
-    std::cout << "WONJOO cpptest: xla_dimensions.size()=" << xla_dimensions.size() << std::endl;
-    for (const auto& elem : xla_dimensions) {
-      std::cout << "WONJOO cpptest: xla_dimensions[i]=" << elem << std::endl;;
-    } 
-
     xla::Shape xla_shape = xla::Shape(xla::PrimitiveType::F32, xla_dimensions, xla_dynamic_dimensions, xla_tuple_shapes);
 
     torch::lazy::Shape lazy_shape = XlaHelpers::ConvertXlaShapeToLazy(xla_shape);
-
-    std::cout << "WONJOO cpptest: xla::Shape=" << xla_shape << std::endl;
-    std::cout << "WONJOO cpptest: torch::lazy::Shape=" << lazy_shape << std::endl;
-
     std::vector<int64_t> lazy_dimensions = xla::util::ToVector<int64_t>(lazy_shape.sizes());
-    std::cout << "WONJOO cpptest: lazy_dimensions=" << lazy_dimensions << std::endl;
     const c10::optional<std::vector<bool>>& lazy_dynamic_dimensions = lazy_shape.is_symbolic();
     EXPECT_EQ(lazy_shape.scalar_type(), at::ScalarType::Float);
     EXPECT_EQ(lazy_shape.dim(), 2);

--- a/test/cpp/test_lazy.cpp
+++ b/test/cpp/test_lazy.cpp
@@ -129,7 +129,8 @@ TEST_F(LazyTest, TestXlaShapeToLazyWithUnsupportedPrimitiveType) {
   xla::Shape xla_shape = xla::Shape(xla::PrimitiveType::TUPLE, xla_dimensions,
                                     xla_dynamic_dimensions, xla_tuple_shapes);
 
-  EXPECT_THROW(XlaHelpers::ConvertXlaShapeToLazy(xla_shape), std::runtime_error);
+  EXPECT_THROW(XlaHelpers::ConvertXlaShapeToLazy(xla_shape),
+               std::runtime_error);
 }
 
 }  // namespace cpp_test

--- a/test/cpp/test_lazy.cpp
+++ b/test/cpp/test_lazy.cpp
@@ -1,0 +1,83 @@
+#include <gtest/gtest.h>
+
+#include "tensorflow/compiler/xla/shape.h"
+#include "torch/csrc/lazy/core/shape.h"
+#include "torch_xla/csrc/helpers.h"
+#include "torch_xla_test.h"
+
+namespace torch_xla {
+namespace cpp_test {
+
+class LazyTest : public TorchXlaTest {};
+
+TEST_F(LazyTest, TestXlaShapeToLazy) {
+/*
+  Shape(PrimitiveType element_type, absl::Span<const int64_t> dimensions,
+        absl::Span<const bool> dynamic_dimensions,
+        std::vector<Shape> tuple_shapes)
+*/    
+    int64_t dimensions[] = {1, 2};
+    bool dynamic_dimensions[] = {false, false};
+    absl::Span<const int64_t> xla_dimensions = absl::Span<const int64_t>(dimensions);
+    absl::Span<const bool> xla_dynamic_dimensions = absl::Span<const bool>(dynamic_dimensions);
+    std::vector<xla::Shape> xla_tuple_shapes = std::vector<xla::Shape>();
+
+    // std::cout << "WONJOO cpptest: dimensions.size()=" << dimensions.size() << std::endl;
+    std::cout << "WONJOO cpptest: xla_dimensions.size()=" << xla_dimensions.size() << std::endl;
+    for (const auto& elem : xla_dimensions) {
+      std::cout << "WONJOO cpptest: xla_dimensions[i]=" << elem << std::endl;;
+    } 
+
+    xla::Shape xla_shape = xla::Shape(xla::PrimitiveType::F32, xla_dimensions, xla_dynamic_dimensions, xla_tuple_shapes);
+
+    torch::lazy::Shape lazy_shape = XlaHelpers::ConvertXlaShapeToLazy(xla_shape);
+
+    std::cout << "WONJOO cpptest: xla::Shape=" << xla_shape << std::endl;
+    std::cout << "WONJOO cpptest: torch::lazy::Shape=" << lazy_shape << std::endl;
+
+    std::vector<int64_t> lazy_dimensions = xla::util::ToVector<int64_t>(lazy_shape.sizes());
+    std::cout << "WONJOO cpptest: lazy_dimensions=" << lazy_dimensions << std::endl;
+    const c10::optional<std::vector<bool>>& lazy_dynamic_dimensions = lazy_shape.is_symbolic();
+    EXPECT_EQ(lazy_shape.scalar_type(), at::ScalarType::Float);
+    EXPECT_EQ(lazy_shape.dim(), 2);
+    EXPECT_EQ(lazy_dimensions, xla::util::ToVector<int64_t>(xla_dimensions));
+    EXPECT_EQ(lazy_dynamic_dimensions.has_value(), false);
+}
+
+TEST_F(LazyTest, TestXlaShapeToLazyWithDynamicDimensions) {
+/*
+  Shape(PrimitiveType element_type, absl::Span<const int64_t> dimensions,
+        absl::Span<const bool> dynamic_dimensions,
+        std::vector<Shape> tuple_shapes)
+*/    
+    int64_t dimensions[] = {1, 2};
+    bool dynamic_dimensions[] = {true, false};
+    absl::Span<const int64_t> xla_dimensions = absl::Span<const int64_t>(dimensions);
+    absl::Span<const bool> xla_dynamic_dimensions = absl::Span<const bool>(dynamic_dimensions);
+    std::vector<xla::Shape> xla_tuple_shapes = std::vector<xla::Shape>();
+
+    // std::cout << "WONJOO cpptest: dimensions.size()=" << dimensions.size() << std::endl;
+    std::cout << "WONJOO cpptest: xla_dimensions.size()=" << xla_dimensions.size() << std::endl;
+    for (const auto& elem : xla_dimensions) {
+      std::cout << "WONJOO cpptest: xla_dimensions[i]=" << elem << std::endl;;
+    } 
+
+    xla::Shape xla_shape = xla::Shape(xla::PrimitiveType::F32, xla_dimensions, xla_dynamic_dimensions, xla_tuple_shapes);
+
+    torch::lazy::Shape lazy_shape = XlaHelpers::ConvertXlaShapeToLazy(xla_shape);
+
+    std::cout << "WONJOO cpptest: xla::Shape=" << xla_shape << std::endl;
+    std::cout << "WONJOO cpptest: torch::lazy::Shape=" << lazy_shape << std::endl;
+
+    std::vector<int64_t> lazy_dimensions = xla::util::ToVector<int64_t>(lazy_shape.sizes());
+    std::cout << "WONJOO cpptest: lazy_dimensions=" << lazy_dimensions << std::endl;
+    const c10::optional<std::vector<bool>>& lazy_dynamic_dimensions = lazy_shape.is_symbolic();
+    EXPECT_EQ(lazy_shape.scalar_type(), at::ScalarType::Float);
+    EXPECT_EQ(lazy_shape.dim(), 2);
+    EXPECT_EQ(lazy_dimensions, xla::util::ToVector<int64_t>(xla_dimensions));
+    EXPECT_EQ(lazy_dynamic_dimensions.has_value(), true);
+    EXPECT_EQ(lazy_dynamic_dimensions.value(), std::vector<bool>(std::begin(dynamic_dimensions), std::end(dynamic_dimensions)));
+}
+
+}  // namespace cpp_test
+}  // namespace torch_xla

--- a/test/cpp/test_lazy.cpp
+++ b/test/cpp/test_lazy.cpp
@@ -12,7 +12,7 @@ class LazyTest : public TorchXlaTest {};
 
 TEST_F(LazyTest, TestXlaShapeToLazyWithF64) {
   int64_t dimensions[] = {1};
-  bool dynamic_dimensions[] = {false, false};
+  bool dynamic_dimensions[] = {false};
   absl::Span<const int64_t> xla_dimensions =
       absl::Span<const int64_t>(dimensions);
   absl::Span<const bool> xla_dynamic_dimensions =
@@ -33,7 +33,7 @@ TEST_F(LazyTest, TestXlaShapeToLazyWithF64) {
 
 TEST_F(LazyTest, TestXlaShapeToLazyWithPred) {
   int64_t dimensions[] = {1};
-  bool dynamic_dimensions[] = {false, false};
+  bool dynamic_dimensions[] = {false};
   absl::Span<const int64_t> xla_dimensions =
       absl::Span<const int64_t>(dimensions);
   absl::Span<const bool> xla_dynamic_dimensions =
@@ -54,7 +54,7 @@ TEST_F(LazyTest, TestXlaShapeToLazyWithPred) {
 
 TEST_F(LazyTest, TestXlaShapeToLazyWithU64) {
   int64_t dimensions[] = {1};
-  bool dynamic_dimensions[] = {false, false};
+  bool dynamic_dimensions[] = {false};
   absl::Span<const int64_t> xla_dimensions =
       absl::Span<const int64_t>(dimensions);
   absl::Span<const bool> xla_dynamic_dimensions =
@@ -75,7 +75,7 @@ TEST_F(LazyTest, TestXlaShapeToLazyWithU64) {
 
 TEST_F(LazyTest, TestXlaShapeToLazyWithMultipleDimensions) {
   int64_t dimensions[] = {2, 1, 3};
-  bool dynamic_dimensions[] = {false, false};
+  bool dynamic_dimensions[] = {false, false, false};
   absl::Span<const int64_t> xla_dimensions =
       absl::Span<const int64_t>(dimensions);
   absl::Span<const bool> xla_dynamic_dimensions =
@@ -96,7 +96,7 @@ TEST_F(LazyTest, TestXlaShapeToLazyWithMultipleDimensions) {
 
 TEST_F(LazyTest, TestXlaShapeToLazyWithDynamicDimensions) {
   int64_t dimensions[] = {2, 1, 3};
-  bool dynamic_dimensions[] = {true, false};
+  bool dynamic_dimensions[] = {true, false, true};
   absl::Span<const int64_t> xla_dimensions =
       absl::Span<const int64_t>(dimensions);
   absl::Span<const bool> xla_dynamic_dimensions =
@@ -116,6 +116,20 @@ TEST_F(LazyTest, TestXlaShapeToLazyWithDynamicDimensions) {
   EXPECT_EQ(lazy_dynamic_dimensions.value(),
             std::vector<bool>(std::begin(dynamic_dimensions),
                               std::end(dynamic_dimensions)));
+}
+
+TEST_F(LazyTest, TestXlaShapeToLazyWithUnsupportedPrimitiveType) {
+  int64_t dimensions[] = {1};
+  bool dynamic_dimensions[] = {false};
+  absl::Span<const int64_t> xla_dimensions =
+      absl::Span<const int64_t>(dimensions);
+  absl::Span<const bool> xla_dynamic_dimensions =
+      absl::Span<const bool>(dynamic_dimensions);
+  std::vector<xla::Shape> xla_tuple_shapes = std::vector<xla::Shape>();
+  xla::Shape xla_shape = xla::Shape(xla::PrimitiveType::TUPLE, xla_dimensions,
+                                    xla_dynamic_dimensions, xla_tuple_shapes);
+
+  EXPECT_THROW(XlaHelpers::ConvertXlaShapeToLazy(xla_shape), std::runtime_error);
 }
 
 }  // namespace cpp_test

--- a/test/cpp/test_lazy.cpp
+++ b/test/cpp/test_lazy.cpp
@@ -11,38 +11,50 @@ namespace cpp_test {
 class LazyTest : public TorchXlaTest {};
 
 TEST_F(LazyTest, TestXlaShapeToLazy) {
-    int64_t dimensions[] = {1, 2};
-    bool dynamic_dimensions[] = {false, false};
-    absl::Span<const int64_t> xla_dimensions = absl::Span<const int64_t>(dimensions);
-    absl::Span<const bool> xla_dynamic_dimensions = absl::Span<const bool>(dynamic_dimensions);
-    std::vector<xla::Shape> xla_tuple_shapes = std::vector<xla::Shape>();
-    xla::Shape xla_shape = xla::Shape(xla::PrimitiveType::F32, xla_dimensions, xla_dynamic_dimensions, xla_tuple_shapes);
+  int64_t dimensions[] = {1, 2};
+  bool dynamic_dimensions[] = {false, false};
+  absl::Span<const int64_t> xla_dimensions =
+      absl::Span<const int64_t>(dimensions);
+  absl::Span<const bool> xla_dynamic_dimensions =
+      absl::Span<const bool>(dynamic_dimensions);
+  std::vector<xla::Shape> xla_tuple_shapes = std::vector<xla::Shape>();
+  xla::Shape xla_shape = xla::Shape(xla::PrimitiveType::F32, xla_dimensions,
+                                    xla_dynamic_dimensions, xla_tuple_shapes);
 
-    torch::lazy::Shape lazy_shape = XlaHelpers::ConvertXlaShapeToLazy(xla_shape);
-    std::vector<int64_t> lazy_dimensions = xla::util::ToVector<int64_t>(lazy_shape.sizes());
-    const c10::optional<std::vector<bool>>& lazy_dynamic_dimensions = lazy_shape.is_symbolic();
-    EXPECT_EQ(lazy_shape.scalar_type(), at::ScalarType::Float);
-    EXPECT_EQ(lazy_shape.dim(), 2);
-    EXPECT_EQ(lazy_dimensions, xla::util::ToVector<int64_t>(xla_dimensions));
-    EXPECT_EQ(lazy_dynamic_dimensions.has_value(), false);
+  torch::lazy::Shape lazy_shape = XlaHelpers::ConvertXlaShapeToLazy(xla_shape);
+  std::vector<int64_t> lazy_dimensions =
+      xla::util::ToVector<int64_t>(lazy_shape.sizes());
+  const c10::optional<std::vector<bool>>& lazy_dynamic_dimensions =
+      lazy_shape.is_symbolic();
+  EXPECT_EQ(lazy_shape.scalar_type(), at::ScalarType::Float);
+  EXPECT_EQ(lazy_shape.dim(), 2);
+  EXPECT_EQ(lazy_dimensions, xla::util::ToVector<int64_t>(xla_dimensions));
+  EXPECT_EQ(lazy_dynamic_dimensions.has_value(), false);
 }
 
 TEST_F(LazyTest, TestXlaShapeToLazyWithDynamicDimensions) {
-    int64_t dimensions[] = {1, 2};
-    bool dynamic_dimensions[] = {true, false};
-    absl::Span<const int64_t> xla_dimensions = absl::Span<const int64_t>(dimensions);
-    absl::Span<const bool> xla_dynamic_dimensions = absl::Span<const bool>(dynamic_dimensions);
-    std::vector<xla::Shape> xla_tuple_shapes = std::vector<xla::Shape>();
-    xla::Shape xla_shape = xla::Shape(xla::PrimitiveType::F32, xla_dimensions, xla_dynamic_dimensions, xla_tuple_shapes);
+  int64_t dimensions[] = {1, 2};
+  bool dynamic_dimensions[] = {true, false};
+  absl::Span<const int64_t> xla_dimensions =
+      absl::Span<const int64_t>(dimensions);
+  absl::Span<const bool> xla_dynamic_dimensions =
+      absl::Span<const bool>(dynamic_dimensions);
+  std::vector<xla::Shape> xla_tuple_shapes = std::vector<xla::Shape>();
+  xla::Shape xla_shape = xla::Shape(xla::PrimitiveType::F32, xla_dimensions,
+                                    xla_dynamic_dimensions, xla_tuple_shapes);
 
-    torch::lazy::Shape lazy_shape = XlaHelpers::ConvertXlaShapeToLazy(xla_shape);
-    std::vector<int64_t> lazy_dimensions = xla::util::ToVector<int64_t>(lazy_shape.sizes());
-    const c10::optional<std::vector<bool>>& lazy_dynamic_dimensions = lazy_shape.is_symbolic();
-    EXPECT_EQ(lazy_shape.scalar_type(), at::ScalarType::Float);
-    EXPECT_EQ(lazy_shape.dim(), 2);
-    EXPECT_EQ(lazy_dimensions, xla::util::ToVector<int64_t>(xla_dimensions));
-    EXPECT_EQ(lazy_dynamic_dimensions.has_value(), true);
-    EXPECT_EQ(lazy_dynamic_dimensions.value(), std::vector<bool>(std::begin(dynamic_dimensions), std::end(dynamic_dimensions)));
+  torch::lazy::Shape lazy_shape = XlaHelpers::ConvertXlaShapeToLazy(xla_shape);
+  std::vector<int64_t> lazy_dimensions =
+      xla::util::ToVector<int64_t>(lazy_shape.sizes());
+  const c10::optional<std::vector<bool>>& lazy_dynamic_dimensions =
+      lazy_shape.is_symbolic();
+  EXPECT_EQ(lazy_shape.scalar_type(), at::ScalarType::Float);
+  EXPECT_EQ(lazy_shape.dim(), 2);
+  EXPECT_EQ(lazy_dimensions, xla::util::ToVector<int64_t>(xla_dimensions));
+  EXPECT_EQ(lazy_dynamic_dimensions.has_value(), true);
+  EXPECT_EQ(lazy_dynamic_dimensions.value(),
+            std::vector<bool>(std::begin(dynamic_dimensions),
+                              std::end(dynamic_dimensions)));
 }
 
 }  // namespace cpp_test

--- a/test/cpp/test_lazy.cpp
+++ b/test/cpp/test_lazy.cpp
@@ -10,15 +10,15 @@ namespace cpp_test {
 
 class LazyTest : public TorchXlaTest {};
 
-TEST_F(LazyTest, TestXlaShapeToLazy) {
-  int64_t dimensions[] = {1, 2};
+TEST_F(LazyTest, TestXlaShapeToLazyWithF64) {
+  int64_t dimensions[] = {1};
   bool dynamic_dimensions[] = {false, false};
   absl::Span<const int64_t> xla_dimensions =
       absl::Span<const int64_t>(dimensions);
   absl::Span<const bool> xla_dynamic_dimensions =
       absl::Span<const bool>(dynamic_dimensions);
   std::vector<xla::Shape> xla_tuple_shapes = std::vector<xla::Shape>();
-  xla::Shape xla_shape = xla::Shape(xla::PrimitiveType::F32, xla_dimensions,
+  xla::Shape xla_shape = xla::Shape(xla::PrimitiveType::F64, xla_dimensions,
                                     xla_dynamic_dimensions, xla_tuple_shapes);
 
   torch::lazy::Shape lazy_shape = XlaHelpers::ConvertXlaShapeToLazy(xla_shape);
@@ -26,21 +26,83 @@ TEST_F(LazyTest, TestXlaShapeToLazy) {
       xla::util::ToVector<int64_t>(lazy_shape.sizes());
   const c10::optional<std::vector<bool>>& lazy_dynamic_dimensions =
       lazy_shape.is_symbolic();
-  EXPECT_EQ(lazy_shape.scalar_type(), at::ScalarType::Float);
-  EXPECT_EQ(lazy_shape.dim(), 2);
+  EXPECT_EQ(lazy_shape.scalar_type(), at::ScalarType::Double);
+  EXPECT_EQ(lazy_dimensions, xla::util::ToVector<int64_t>(xla_dimensions));
+  EXPECT_EQ(lazy_dynamic_dimensions.has_value(), false);
+}
+
+TEST_F(LazyTest, TestXlaShapeToLazyWithPred) {
+  int64_t dimensions[] = {1};
+  bool dynamic_dimensions[] = {false, false};
+  absl::Span<const int64_t> xla_dimensions =
+      absl::Span<const int64_t>(dimensions);
+  absl::Span<const bool> xla_dynamic_dimensions =
+      absl::Span<const bool>(dynamic_dimensions);
+  std::vector<xla::Shape> xla_tuple_shapes = std::vector<xla::Shape>();
+  xla::Shape xla_shape = xla::Shape(xla::PrimitiveType::PRED, xla_dimensions,
+                                    xla_dynamic_dimensions, xla_tuple_shapes);
+
+  torch::lazy::Shape lazy_shape = XlaHelpers::ConvertXlaShapeToLazy(xla_shape);
+  std::vector<int64_t> lazy_dimensions =
+      xla::util::ToVector<int64_t>(lazy_shape.sizes());
+  const c10::optional<std::vector<bool>>& lazy_dynamic_dimensions =
+      lazy_shape.is_symbolic();
+  EXPECT_EQ(lazy_shape.scalar_type(), at::ScalarType::Bool);
+  EXPECT_EQ(lazy_dimensions, xla::util::ToVector<int64_t>(xla_dimensions));
+  EXPECT_EQ(lazy_dynamic_dimensions.has_value(), false);
+}
+
+TEST_F(LazyTest, TestXlaShapeToLazyWithU64) {
+  int64_t dimensions[] = {1};
+  bool dynamic_dimensions[] = {false, false};
+  absl::Span<const int64_t> xla_dimensions =
+      absl::Span<const int64_t>(dimensions);
+  absl::Span<const bool> xla_dynamic_dimensions =
+      absl::Span<const bool>(dynamic_dimensions);
+  std::vector<xla::Shape> xla_tuple_shapes = std::vector<xla::Shape>();
+  xla::Shape xla_shape = xla::Shape(xla::PrimitiveType::U64, xla_dimensions,
+                                    xla_dynamic_dimensions, xla_tuple_shapes);
+
+  torch::lazy::Shape lazy_shape = XlaHelpers::ConvertXlaShapeToLazy(xla_shape);
+  std::vector<int64_t> lazy_dimensions =
+      xla::util::ToVector<int64_t>(lazy_shape.sizes());
+  const c10::optional<std::vector<bool>>& lazy_dynamic_dimensions =
+      lazy_shape.is_symbolic();
+  EXPECT_EQ(lazy_shape.scalar_type(), at::ScalarType::Long);
+  EXPECT_EQ(lazy_dimensions, xla::util::ToVector<int64_t>(xla_dimensions));
+  EXPECT_EQ(lazy_dynamic_dimensions.has_value(), false);
+}
+
+TEST_F(LazyTest, TestXlaShapeToLazyWithMultipleDimensions) {
+  int64_t dimensions[] = {2, 1, 3};
+  bool dynamic_dimensions[] = {false, false};
+  absl::Span<const int64_t> xla_dimensions =
+      absl::Span<const int64_t>(dimensions);
+  absl::Span<const bool> xla_dynamic_dimensions =
+      absl::Span<const bool>(dynamic_dimensions);
+  std::vector<xla::Shape> xla_tuple_shapes = std::vector<xla::Shape>();
+  xla::Shape xla_shape = xla::Shape(xla::PrimitiveType::F64, xla_dimensions,
+                                    xla_dynamic_dimensions, xla_tuple_shapes);
+
+  torch::lazy::Shape lazy_shape = XlaHelpers::ConvertXlaShapeToLazy(xla_shape);
+  std::vector<int64_t> lazy_dimensions =
+      xla::util::ToVector<int64_t>(lazy_shape.sizes());
+  const c10::optional<std::vector<bool>>& lazy_dynamic_dimensions =
+      lazy_shape.is_symbolic();
+  EXPECT_EQ(lazy_shape.scalar_type(), at::ScalarType::Double);
   EXPECT_EQ(lazy_dimensions, xla::util::ToVector<int64_t>(xla_dimensions));
   EXPECT_EQ(lazy_dynamic_dimensions.has_value(), false);
 }
 
 TEST_F(LazyTest, TestXlaShapeToLazyWithDynamicDimensions) {
-  int64_t dimensions[] = {1, 2};
+  int64_t dimensions[] = {2, 1, 3};
   bool dynamic_dimensions[] = {true, false};
   absl::Span<const int64_t> xla_dimensions =
       absl::Span<const int64_t>(dimensions);
   absl::Span<const bool> xla_dynamic_dimensions =
       absl::Span<const bool>(dynamic_dimensions);
   std::vector<xla::Shape> xla_tuple_shapes = std::vector<xla::Shape>();
-  xla::Shape xla_shape = xla::Shape(xla::PrimitiveType::F32, xla_dimensions,
+  xla::Shape xla_shape = xla::Shape(xla::PrimitiveType::F64, xla_dimensions,
                                     xla_dynamic_dimensions, xla_tuple_shapes);
 
   torch::lazy::Shape lazy_shape = XlaHelpers::ConvertXlaShapeToLazy(xla_shape);
@@ -48,8 +110,7 @@ TEST_F(LazyTest, TestXlaShapeToLazyWithDynamicDimensions) {
       xla::util::ToVector<int64_t>(lazy_shape.sizes());
   const c10::optional<std::vector<bool>>& lazy_dynamic_dimensions =
       lazy_shape.is_symbolic();
-  EXPECT_EQ(lazy_shape.scalar_type(), at::ScalarType::Float);
-  EXPECT_EQ(lazy_shape.dim(), 2);
+  EXPECT_EQ(lazy_shape.scalar_type(), at::ScalarType::Double);
   EXPECT_EQ(lazy_dimensions, xla::util::ToVector<int64_t>(xla_dimensions));
   EXPECT_EQ(lazy_dynamic_dimensions.has_value(), true);
   EXPECT_EQ(lazy_dynamic_dimensions.value(),

--- a/torch_xla/csrc/helpers.cpp
+++ b/torch_xla/csrc/helpers.cpp
@@ -667,15 +667,14 @@ torch::lazy::Shape XlaHelpers::ConvertXlaShapeToLazy(const xla::Shape& shape) {
 
   c10::optional<std::vector<bool>> is_symbolic = c10::nullopt;
   if (shape.is_dynamic()) {
-    std::vector<bool> xla_dynamic_dimensions = xla::util::ToVector<bool>(shape.dynamic_dimensions());
+    std::vector<bool> xla_dynamic_dimensions =
+        xla::util::ToVector<bool>(shape.dynamic_dimensions());
     is_symbolic = c10::make_optional(xla_dynamic_dimensions);
   }
-  
-  return torch::lazy::Shape(
-    scalar_type,
-    xla::util::ToVector<int64_t>(shape.dimensions()),
-    is_symbolic
-  );
+
+  return torch::lazy::Shape(scalar_type,
+                            xla::util::ToVector<int64_t>(shape.dimensions()),
+                            is_symbolic);
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/helpers.cpp
+++ b/torch_xla/csrc/helpers.cpp
@@ -620,51 +620,7 @@ xla::StatusOr<xla::XlaComputation> XlaHelpers::WrapXlaComputation(
 }
 
 torch::lazy::Shape XlaHelpers::ConvertXlaShapeToLazy(const xla::Shape& shape) {
-  at::ScalarType scalar_type;
-  switch (shape.element_type()) {
-    case xla::PrimitiveType::S16:
-      scalar_type = at::ScalarType::Short;
-      break;
-    case xla::PrimitiveType::S32:
-      scalar_type = at::ScalarType::Long;
-      break;
-    case xla::PrimitiveType::S64:
-      // S64 missing from at::ScalarType
-      break;
-    case xla::PrimitiveType::U8:
-      scalar_type = at::ScalarType::Byte;
-      break;
-    case xla::PrimitiveType::U16:
-      // U16 missing from at::ScalarType
-      break;
-    case xla::PrimitiveType::U32:
-      // U32 missing from at::ScalarType
-      break;
-    case xla::PrimitiveType::U64:
-      // U64 missing from at::ScalarType
-      break;
-    case xla::PrimitiveType::F16:
-      // F16 missing from at::ScalarType
-      break;
-    case xla::PrimitiveType::BF16:
-      scalar_type = at::ScalarType::BFloat16;
-      break;
-    case xla::PrimitiveType::F32:
-      scalar_type = at::ScalarType::Float;
-      break;
-    case xla::PrimitiveType::F64:
-      scalar_type = at::ScalarType::Double;
-      break;
-    case xla::PrimitiveType::C64:
-      // C64 missing from at::ScalarType
-      break;
-    case xla::PrimitiveType::C128:
-      // C128 missing from at::ScalarType
-      break;
-    default:
-      scalar_type = at::ScalarType::Undefined;
-  }
-
+  at::ScalarType scalar_type = TensorTypeToRawXlaType(shape.element_type());
   c10::optional<std::vector<bool>> is_symbolic = c10::nullopt;
   if (shape.is_dynamic()) {
     std::vector<bool> xla_dynamic_dimensions =

--- a/torch_xla/csrc/helpers.cpp
+++ b/torch_xla/csrc/helpers.cpp
@@ -664,18 +664,13 @@ torch::lazy::Shape XlaHelpers::ConvertXlaShapeToLazy(const xla::Shape& shape) {
     default:
       scalar_type = at::ScalarType::Undefined;
   }
-  for (const auto& elem : shape.dimensions()) {
-    std::cout << "WONJOO: shape.dimensions()[i]=" << elem << std::endl;;
-  } 
-  // c10::ArrayRef<int64_t> sizes = xla::util::ToVector<int64_t>(shape.dimensions());
-  // std::cout << "WONJOO: shape.dimensions().size()=" << shape.dimensions().size() << std::endl;
-  // std::cout << "WONJOO: sizes.size()=" << sizes.size() << std::endl;
-  // std::cout << "WONJOO: sizes=" << sizes << std::endl;
+
   c10::optional<std::vector<bool>> is_symbolic = c10::nullopt;
   if (shape.is_dynamic()) {
     std::vector<bool> xla_dynamic_dimensions = xla::util::ToVector<bool>(shape.dynamic_dimensions());
     is_symbolic = c10::make_optional(xla_dynamic_dimensions);
   }
+  
   return torch::lazy::Shape(
     scalar_type,
     xla::util::ToVector<int64_t>(shape.dimensions()),

--- a/torch_xla/csrc/helpers.cpp
+++ b/torch_xla/csrc/helpers.cpp
@@ -664,7 +664,13 @@ torch::lazy::Shape XlaHelpers::ConvertXlaShapeToLazy(const xla::Shape& shape) {
     default:
       scalar_type = at::ScalarType::Undefined;
   }
-  c10::ArrayRef<int64_t> sizes = xla::util::ToVector<int64_t>(shape.dimensions());
+  for (const auto& elem : shape.dimensions()) {
+    std::cout << "WONJOO: shape.dimensions()[i]=" << elem << std::endl;;
+  } 
+  // c10::ArrayRef<int64_t> sizes = xla::util::ToVector<int64_t>(shape.dimensions());
+  // std::cout << "WONJOO: shape.dimensions().size()=" << shape.dimensions().size() << std::endl;
+  // std::cout << "WONJOO: sizes.size()=" << sizes.size() << std::endl;
+  // std::cout << "WONJOO: sizes=" << sizes << std::endl;
   c10::optional<std::vector<bool>> is_symbolic = c10::nullopt;
   if (shape.is_dynamic()) {
     std::vector<bool> xla_dynamic_dimensions = xla::util::ToVector<bool>(shape.dynamic_dimensions());
@@ -672,7 +678,7 @@ torch::lazy::Shape XlaHelpers::ConvertXlaShapeToLazy(const xla::Shape& shape) {
   }
   return torch::lazy::Shape(
     scalar_type,
-    sizes,
+    xla::util::ToVector<int64_t>(shape.dimensions()),
     is_symbolic
   );
 }

--- a/torch_xla/csrc/helpers.cpp
+++ b/torch_xla/csrc/helpers.cpp
@@ -620,7 +620,7 @@ xla::StatusOr<xla::XlaComputation> XlaHelpers::WrapXlaComputation(
 }
 
 torch::lazy::Shape XlaHelpers::ConvertXlaShapeToLazy(const xla::Shape& shape) {
-  at::ScalarType scalar_type = TensorTypeToRawXlaType(shape.element_type());
+  at::ScalarType scalar_type = TensorTypeFromXlaType(shape.element_type());
   c10::optional<std::vector<bool>> is_symbolic = c10::nullopt;
   if (shape.is_dynamic()) {
     std::vector<bool> xla_dynamic_dimensions =
@@ -630,7 +630,7 @@ torch::lazy::Shape XlaHelpers::ConvertXlaShapeToLazy(const xla::Shape& shape) {
 
   return torch::lazy::Shape(scalar_type,
                             xla::util::ToVector<int64_t>(shape.dimensions()),
-                            is_symbolic);
+                            std::move(is_symbolic));
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/helpers.cpp
+++ b/torch_xla/csrc/helpers.cpp
@@ -619,4 +619,61 @@ xla::StatusOr<xla::XlaComputation> XlaHelpers::WrapXlaComputation(
   return builder.Build(orig_result);
 }
 
+torch::lazy::Shape XlaHelpers::ConvertXlaShapeToLazy(const xla::Shape& shape) {
+  at::ScalarType scalar_type;
+  switch (shape.element_type()) {
+    case xla::PrimitiveType::S16:
+      scalar_type = at::ScalarType::Short;
+      break;
+    case xla::PrimitiveType::S32:
+      scalar_type = at::ScalarType::Long;
+      break;
+    case xla::PrimitiveType::S64:
+      // S64 missing from at::ScalarType
+      break;
+    case xla::PrimitiveType::U8:
+      scalar_type = at::ScalarType::Byte;
+      break;
+    case xla::PrimitiveType::U16:
+      // U16 missing from at::ScalarType
+      break;
+    case xla::PrimitiveType::U32:
+      // U32 missing from at::ScalarType
+      break;
+    case xla::PrimitiveType::U64:
+      // U64 missing from at::ScalarType
+      break;
+    case xla::PrimitiveType::F16:
+      // F16 missing from at::ScalarType
+      break;
+    case xla::PrimitiveType::BF16:
+      scalar_type = at::ScalarType::BFloat16;
+      break;
+    case xla::PrimitiveType::F32:
+      scalar_type = at::ScalarType::Float;
+      break;
+    case xla::PrimitiveType::F64:
+      scalar_type = at::ScalarType::Double;
+      break;
+    case xla::PrimitiveType::C64:
+      // C64 missing from at::ScalarType
+      break;
+    case xla::PrimitiveType::C128:
+      // C128 missing from at::ScalarType
+      break;
+    default:
+      // TODO
+  }
+  c10::ArrayRef<int64_t> sizes = shape.dimensions();
+  c10::optional<std::vector<bool>> is_symbolic = c10::nullopt;
+  if (shape.is_dynamic()) {
+    is_symbolic = shape.dynamic_dimensions();
+  }
+  return torch::lazy::Shape(
+    scalar_type,
+    sizes,
+    is_symbolic
+  );
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/helpers.cpp
+++ b/torch_xla/csrc/helpers.cpp
@@ -662,12 +662,13 @@ torch::lazy::Shape XlaHelpers::ConvertXlaShapeToLazy(const xla::Shape& shape) {
       // C128 missing from at::ScalarType
       break;
     default:
-      // TODO
+      scalar_type = at::ScalarType::Undefined;
   }
-  c10::ArrayRef<int64_t> sizes = shape.dimensions();
+  c10::ArrayRef<int64_t> sizes = xla::util::ToVector<int64_t>(shape.dimensions());
   c10::optional<std::vector<bool>> is_symbolic = c10::nullopt;
   if (shape.is_dynamic()) {
-    is_symbolic = shape.dynamic_dimensions();
+    std::vector<bool> xla_dynamic_dimensions = xla::util::ToVector<bool>(shape.dynamic_dimensions());
+    is_symbolic = c10::make_optional(xla_dynamic_dimensions);
   }
   return torch::lazy::Shape(
     scalar_type,

--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -339,6 +339,8 @@ class XlaHelpers {
       const std::vector<xla::Shape>& parameter_shapes,
       std::vector<std::pair<int64_t, int64_t>> input_output_alias_pair);
 
+  static torch::lazy::Shape ConvertXlaShapeToLazy(const xla::Shape& shape);
+
  private:
   static xla::PrecisionConfig::Precision s_mat_mul_precision;
 };

--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -16,8 +16,8 @@
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
 #include "tensorflow/compiler/xla/xla_client/util.h"
 #include "tensorflow/core/lib/bfloat16/bfloat16.h"
-#include "torch/csrc/lazy/core/util.h"
 #include "torch/csrc/lazy/core/shape.h"
+#include "torch/csrc/lazy/core/util.h"
 
 namespace torch_xla {
 

--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -17,6 +17,7 @@
 #include "tensorflow/compiler/xla/xla_client/util.h"
 #include "tensorflow/core/lib/bfloat16/bfloat16.h"
 #include "torch/csrc/lazy/core/util.h"
+#include "torch/csrc/lazy/core/shape.h"
 
 namespace torch_xla {
 


### PR DESCRIPTION
Add ConvertXlaShapeToLazy helper function that converts `xla::Shape` to `torch::lazy::Shape`. Also add unit tests for `lazy` related functions. 

PyTorch's `at::ScalarType` is defined at https://github.com/pytorch/pytorch/blob/041edeeecb75f3c110605d7311fa46abe1c62ea9/c10/core/ScalarType.h#L28. 

XLA's `xla::PrimitiveType` is defined at https://github.com/tensorflow/tensorflow/blob/b751126f998f5f5ef023f7817511a01c42efe99a/tensorflow/compiler/xla/xla_data.proto#L27. 

---
TODO
- Decide what to do with incompatible types
- ~Unit tests~