### PR TITLE
Make sure XrtData is not empty before accessing handle

### DIFF
--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -127,7 +127,6 @@ class PjRtComputationClient : public ComputationClient {
         : Data(std::move(device), std::move(device_shape)), buffer(buffer) {}
 
     void* get_handle() const {
-      XLA_CHECK(HasValue());
       return buffer->AcquireExternalReference()
           .ValueOrDie()
           ->OpaqueDeviceMemoryDataPointer();

--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -127,6 +127,7 @@ class PjRtComputationClient : public ComputationClient {
         : Data(std::move(device), std::move(device_shape)), buffer(buffer) {}
 
     void* get_handle() const {
+      XLA_CHECK(HasValue());
       return buffer->AcquireExternalReference()
           .ValueOrDie()
           ->OpaqueDeviceMemoryDataPointer();

--- a/third_party/xla_client/xrt_computation_client.h
+++ b/third_party/xla_client/xrt_computation_client.h
@@ -161,7 +161,10 @@ class XrtComputationClient : public ComputationClient {
         : Data(std::move(device), std::move(device_shape)),
           handle_ptr(handle) {}
 
-    int64_t get_handle() const { return handle_ptr->handle(); }
+    int64_t get_handle() const {
+      XLA_CHECK(HasValue());
+      return handle_ptr->handle();
+    }
 
     OpaqueHandle GetOpaqueHandle() override { return get_handle(); }
 


### PR DESCRIPTION
Before the graph execution, we might create empty data_place_holder in 
https://github.com/pytorch/xla/blob/79c433a066f3757a39693869c19f22d2366ace7f/torch_xla/csrc/tensor.cpp#L1416-L1418

In this case `XrtData` is empty and will have empty handlePtr. We want to guard this to avoid weird segfault.