### PR TITLE
Make sure `PjRtData` is not empty in `GetOpaqueHandle`

### DIFF
--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -131,6 +131,7 @@ class PjRtComputationClient : public ComputationClient {
         : Data(std::move(device), std::move(device_shape)), buffer(buffer) {}
 
     OpaqueHandle GetOpaqueHandle() override {
+      XLA_CHECK(HasValue());
       return reinterpret_cast<std::uintptr_t>(buffer.get());
     };
     void Assign(const Data& data) override;


### PR DESCRIPTION
Same as #4090, but for PJRT