### PR TITLE
Revert "Rename to fromIntArrayRefSlow (#4071)"

### DIFF
--- a/test/cpp/test_symint.cpp
+++ b/test/cpp/test_symint.cpp
@@ -37,7 +37,7 @@ TEST(SymintTest, TestSaticSymints) {
   // We have to init a std::vector<int64_t> here. Passing a temp variable to
   // fromIntArrayRef will result in unexpected behavior.
   std::vector<int64_t> sizes = {6, 19, 10};
-  c10::SymIntArrayRef static_symints = c10::fromIntArrayRefSlow(sizes);
+  c10::SymIntArrayRef static_symints = c10::fromIntArrayRef(sizes);
   SymIntElements si_element(static_symints);
 
   std::vector<int64_t> upper_bound = si_element.GetUpperBounds();

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -581,7 +581,7 @@ at::Tensor XLANativeFunctions::_trilinear(
 at::Tensor XLANativeFunctions::_unsafe_view(const at::Tensor& self,
                                             at::IntArrayRef size) {
   XLA_FN_COUNTER("xla::");
-  return view_symint(self, c10::fromIntArrayRefSlow(size));
+  return view_symint(self, c10::fromIntArrayRef(size));
 }
 
 at::Tensor XLANativeFunctions::add(const at::Tensor& self,


### PR DESCRIPTION
This reverts commit 8332ac9072832c67b2680509bb1ef1abc5813c6a in order to fix the pt/xla build failure in r1.13 branch.

The said commit (https://github.com/pytorch/xla/pull/4071) in included in pt/xla r1.13 release but the companion PR https://github.com/pytorch/pytorch/pull/86235 is not included in pytorch's 1.13 release (https://github.com/pytorch/pytorch/commits/release/1.13).