### PR TITLE
Set default xla_gpu_force_compilation_parallelism

### DIFF
--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -48,6 +48,8 @@ def _setup_xla_flags():
   flags = _set_missing_flags(flags, (('xla_cpu_enable_fast_math', 'false'),))
   flags = _set_missing_flags(
       flags, (('xla_gpu_simplify_all_fp_conversions', 'false'),))
+  flags = _set_missing_flags(flags,
+                             (('xla_gpu_force_compilation_parallelism', '8'),))
   os.environ['XLA_FLAGS'] = ' '.join(flags)
 
 


### PR DESCRIPTION
This PR sets `XLA_FLAGS: --xla_gpu_force_compilation_parallelism=8` by default. We choose this number because most GPU instances have `num_cpus >= 8*num_gpus`  and the marginal benefit of using more than 8 threads is small.

Below is the compilation time benchmark of a few models tested on p3dn.24xlarge instance.
| Model | 1 thread | 8 threads | 16 threads|
| --- | ----------- | ----------| -----------|
| bert-base-uncased | 67s | 31s| 27s|
| bert-large-uncased | 217s | 80s| 72s|
| resnet-50 | 17s | 11s | 9s|