### PR TITLE
Add an api to clear counter and metrics

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -117,6 +117,7 @@ function run_op_tests {
   run_test python3 "$CDIR/test_xla_dist.py"
   run_test python3 "$CDIR/test_profiler.py"
   run_test python3 "$CDIR/test_ops.py"
+  run_test python3 "$CDIR/test_metrics.py"
   run_downcast_bf16 python3 "$CDIR/test_data_type.py"
   run_use_bf16 python3 "$CDIR/test_data_type.py"
   run_test python3 "$CDIR/test_torch_distributed_xla_backend.py"

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -1,0 +1,29 @@
+import os
+
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.debug.metrics as met
+import unittest
+
+
+class MetricsTest(unittest.TestCase):
+
+  def test_clear_counters(self):
+    xla_device = xm.xla_device()
+    t1 = torch.tensor(100, device=xla_device)
+    assert (len(met.counter_names()) > 0)
+    met.clear_counters()
+    assert (len(met.counter_names()) == 0)
+
+  def test_clear_metrics(self):
+    xla_device = xm.xla_device()
+    t1 = torch.tensor(100, device=xla_device)
+    assert (len(met.metric_names()) > 0)
+    met.clear_metrics()
+    assert (len(met.metric_names()) == 0)
+
+
+if __name__ == '__main__':
+  test = unittest.main()
+  sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2077,6 +2077,24 @@ class XpTraceTest(XlaTestCase):
         xm.mark_step()
 
 
+class MetricsTest(XlaTestCase):
+
+  def test_clear_counters(self):
+    xla_device = xm.xla_device()
+    t1 = torch.tensor(100, device=xla_device)
+    assert (len(met.counter_names()) > 0)
+    met.clear_counters()
+    assert (len(met.counter_names()) == 0)
+
+  def test_clear_metrics(self):
+    xla_device = xm.xla_device()
+    t1 = torch.tensor(100, device=xla_device)
+    assert (len(met.metric_names()) > 0)
+    met.clear_metrics()
+    print(met.metrics_report())
+    assert (len(met.metric_names()) == 0)
+
+
 class TestGeneric(XlaTestCase):
 
   def test_zeros_like_patch(self):

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2077,24 +2077,6 @@ class XpTraceTest(XlaTestCase):
         xm.mark_step()
 
 
-class MetricsTest(XlaTestCase):
-
-  def test_clear_counters(self):
-    xla_device = xm.xla_device()
-    t1 = torch.tensor(100, device=xla_device)
-    assert (len(met.counter_names()) > 0)
-    met.clear_counters()
-    assert (len(met.counter_names()) == 0)
-
-  def test_clear_metrics(self):
-    xla_device = xm.xla_device()
-    t1 = torch.tensor(100, device=xla_device)
-    assert (len(met.metric_names()) > 0)
-    met.clear_metrics()
-    print(met.metrics_report())
-    assert (len(met.metric_names()) == 0)
-
-
 class TestGeneric(XlaTestCase):
 
   def test_zeros_like_patch(self):

--- a/third_party/xla_client/metrics.cc
+++ b/third_party/xla_client/metrics.cc
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <sstream>
 
+
 #include "absl/memory/memory.h"
 #include "absl/strings/str_split.h"
 #include "tensorflow/compiler/xla/xla_client/debug_macros.h"
@@ -152,6 +153,14 @@ CounterData* MetricsArena::GetCounter(const std::string& name) {
   std::lock_guard<std::mutex> lock(lock_);
   auto it = counters_.find(name);
   return it != counters_.end() ? it->second.get() : nullptr;
+}
+
+void MetricsArena::ClearCounters() {
+  counters_.clear();
+}
+
+void MetricsArena::ClearMetrics() {
+  metrics_.clear();
 }
 
 MetricData::MetricData(MetricReprFn repr_fn, size_t max_samples)
@@ -330,6 +339,10 @@ std::vector<std::string> GetCounterNames() {
 CounterData* GetCounter(const std::string& name) {
   return MetricsArena::Get()->GetCounter(name);
 }
+
+void ClearCounters() { MetricsArena::Get()->ClearCounters(); }
+
+void ClearMetrics() { MetricsArena::Get()->ClearMetrics(); }
 
 }  // namespace metrics
 }  // namespace xla

--- a/third_party/xla_client/metrics.h
+++ b/third_party/xla_client/metrics.h
@@ -97,6 +97,10 @@ class MetricsArena {
 
   CounterData* GetCounter(const std::string& name);
 
+  void ClearCounters();
+
+  void ClearMetrics();
+
  private:
   std::mutex lock_;
   std::map<std::string, std::shared_ptr<MetricData>> metrics_;
@@ -205,6 +209,10 @@ std::vector<std::string> GetCounterNames();
 // Retrieves the counter data of a given counter, or nullptr if such counter
 // does not exist.
 CounterData* GetCounter(const std::string& name);
+
+void ClearCounters();
+
+void ClearMetrics();
 
 // Scope based utility class to measure the time the code takes within a given
 // C++ scope.

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1189,6 +1189,8 @@ void InitXlaModuleBindings(py::module m) {
   });
   m.def("_xla_metrics_report",
         []() { return xla::metrics_reader::CreateMetricReport(); });
+  m.def("_clear_xla_counters", []() { xla::metrics::ClearCounters(); });
+  m.def("_clear_xla_metrics", []() { xla::metrics::ClearMetrics(); });
   m.def("_xla_tensors_report",
         [](size_t nodes_threshold, const std::string& device) {
           return GetLiveTensorsReport(nodes_threshold, device);

--- a/torch_xla/debug/metrics.py
+++ b/torch_xla/debug/metrics.py
@@ -20,6 +20,12 @@ def counter_value(name):
   return torch_xla._XLAC._xla_counter_value(name)
 
 
+def clear_counters():
+  """Clear the value of all counters.
+  """
+  return torch_xla._XLAC._clear_xla_counters()
+
+
 def metric_names():
   """Retrieves all the currently active metric names."""
   return torch_xla._XLAC._xla_metric_names()
@@ -40,6 +46,12 @@ def metric_data(name):
     The `SAMPLES` is a list of (TIME, VALUE) tuples.
   """
   return torch_xla._XLAC._xla_metric_data(name)
+
+
+def clear_metrics():
+  """Clear the value of all metrics.
+  """
+  return torch_xla._XLAC._clear_xla_metrics()
 
 
 def metrics_report():


### PR DESCRIPTION
Upstream version at https://github.com/pytorch/pytorch/blob/d9ff56ccc03cd5c2f95112ef3ec2316557f5699c/torch/csrc/lazy/core/metrics.h#L92 actually reset the counter instead of clearing it. 

However I found it is more intuitive to clear the counters and there is no way to resert metrics(metrics can not be empty). I think I will submit a pr to update upstream later.