### PR TITLE
Disable cloud cache since it is failing on upstream CI

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -9,7 +9,7 @@ XLA_DIR=$PYTORCH_DIR/xla
 clone_pytorch $PYTORCH_DIR $XLA_DIR
 
 # Use bazel cache
-USE_CACHE=1
+USE_CACHE=0
 
 SCCACHE="$(which sccache)"
 if [ -z "${SCCACHE}" ]; then


### PR DESCRIPTION
Upstream CI failed with
```
+ sudo npm install -g bazels3cache
node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by node)
https://github.com/pytorch/pytorch/actions/runs/3324545518/jobs/5496432160
```