### PR TITLE
node.js v18 gets installed by default since 10/25/2022 due to new lts version available. Lock the version to v16 on bionic

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -66,7 +66,7 @@ function install_deps_pytorch_xla() {
 
   sudo apt-get -qq update
 
-  sudo apt-get -qq install npm nodejs
+  sudo apt-get -qq install npm nodejs=16.18
 
   # XLA build requires Bazel
   # We use bazelisk to avoid updating Bazel version manually.

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -66,7 +66,7 @@ function install_deps_pytorch_xla() {
 
   sudo apt-get -qq update
 
-  sudo apt-get -qq install npm nodejs=16.18
+  sudo apt-get -qq install npm nodejs
 
   # XLA build requires Bazel
   # We use bazelisk to avoid updating Bazel version manually.
@@ -88,7 +88,7 @@ function install_deps_pytorch_xla() {
   if [[ "$USE_CACHE" == 1 ]]; then
     # Install bazels3cache for cloud cache
     sudo npm install -g n
-    sudo n lts
+    sudo n 16.18.0
     sudo npm install -g bazels3cache
     BAZELS3CACHE="$(which /usr/local/bin/bazels3cache)"
     if [ -z "${BAZELS3CACHE}" ]; then


### PR DESCRIPTION
Node.js v18 requires glibc 2.28 per release notes here (https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#toolchain-and-compiler-upgrades). (Bionic does not have glibc 2.28 support by default). May be able to avoid https://github.com/pytorch/pytorch/pull/87737