### PR TITLE
node.js v18 gets installed by default since 10/25/2022 due to new lts…

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -88,7 +88,7 @@ function install_deps_pytorch_xla() {
   if [[ "$USE_CACHE" == 1 ]]; then
     # Install bazels3cache for cloud cache
     sudo npm install -g n
-    sudo n lts
+    sudo n 16.18.0
     sudo npm install -g bazels3cache
     BAZELS3CACHE="$(which /usr/local/bin/bazels3cache)"
     if [ -z "${BAZELS3CACHE}" ]; then


### PR DESCRIPTION
… version available. Lock the version to v16 on bionic (#4125)

* node.js v18 gets installed by default. Lock the version to v16 on bionic (ubuntu 18) as node.js v18 requires glibc 2.28 per release notes. (Bionic does not have glibc 2.28 support by default). May be able to avoid https://github.com/pytorch/pytorch/pull/87737

* supply v16.18.0 at the correct location