### PR TITLE
[PJRT] Use on_device_shape for PJRT return values

### DIFF
--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -311,13 +311,7 @@ PjRtComputationClient::ExecuteComputation(
     std::unique_ptr<xla::PjRtBuffer> buffer = std::move(result);
 
     std::shared_ptr<PjRtData> data = std::make_shared<PjRtData>(
-        device,
-        // TODO(wcromar): just use `logical_on_device_shape` when it's supported
-        // in C API
-        client_->runtime_type() == xla::PjRtRuntimeType::kTfrt
-            ? buffer->on_device_shape()
-            : buffer->logical_on_device_shape().value(),
-        std::move(buffer));
+        device, buffer->on_device_shape(), std::move(buffer));
 
     datas.push_back(data);
   }
@@ -373,7 +367,7 @@ PjRtComputationClient::ExecuteReplicated(
       std::unique_ptr<xla::PjRtBuffer> buffer = std::move(result[i]);
 
       std::shared_ptr<PjRtData> data = std::make_shared<PjRtData>(
-          devices[i], buffer->logical_on_device_shape().value(),
+          devices[i], buffer->on_device_shape(),
           std::move(buffer));
 
       datas.push_back(data);


### PR DESCRIPTION
The difference [according to PJRT](https://github.com/tensorflow/tensorflow/blob/a5dc19fff5b5d6be0a1a3cad89992defee78d202/tensorflow/compiler/xla/pjrt/pjrt_client.h#L759-L768):

```
  virtual const Shape& on_device_shape() const = 0;

  // Same as on_device_shape when the shape is static. When the shape is
  // dynamic, it gathers the metadata from the device and returns a static shape
  // representing the logical shape of the data. This approach is identical to
  // how tensorflow and xrt setup the output buffer in the graph.
  //
  // Since this method actually acquires locks and communicate with the device,
  // it does not have the const qualifier, similar to what ToLiteral does.
  virtual StatusOr<Shape> logical_on_device_shape() = 0;
```

The behavior is the same for static shapes. @yeounoh confirmed that SPMD programs should always give static-shaped buffers. After discussing the change with @JackCaoG, we believe that the correct shape to give the output `DataPtr` is the dynamic shape (given by `on_device_shape`) and not the logical static shape (given by `logical_on_device_shape`).