### PR TITLE
[PERF] Adds DDP mode to imagenet and mnist tests

### DIFF
--- a/test/test_train_mp_imagenet.py
+++ b/test/test_train_mp_imagenet.py
@@ -27,6 +27,9 @@ MODEL_OPTS = {
     '--test_only_at_end': {
         'action': 'store_true',
     },
+    '--ddp': {
+        'action': 'store_true',
+    },
 }
 
 FLAGS = args_parse.parse_common_options(
@@ -56,6 +59,10 @@ import torch_xla.utils.utils as xu
 import torch_xla.core.xla_model as xm
 import torch_xla.distributed.xla_multiprocessing as xmp
 import torch_xla.test.test_utils as test_utils
+
+import torch.distributed as dist
+from torch.nn.parallel import DistributedDataParallel as DDP
+import torch_xla.distributed.xla_backend
 
 DEFAULT_KWARGS = dict(
     batch_size=128,
@@ -112,6 +119,9 @@ def _train_update(device, step, loss, tracker, epoch, writer):
 
 
 def train_imagenet():
+  if FLAGS.ddp:
+    dist.init_process_group('xla', world_size=xm.xrt_world_size(), rank=xm.get_ordinal())
+
   print('==> Preparing data..')
   img_dim = get_model_property('img_dim')
   if FLAGS.fake_data:
@@ -181,6 +191,9 @@ def train_imagenet():
 
   device = xm.xla_device()
   model = get_model_property('model_fn')().to(device)
+  if FLAGS.ddp:
+    model = DDP(model, gradient_as_bucket_view=True)
+
   writer = None
   if xm.is_master_ordinal():
     writer = test_utils.get_summary_writer(FLAGS.logdir)
@@ -209,7 +222,10 @@ def train_imagenet():
       output = model(data)
       loss = loss_fn(output, target)
       loss.backward()
-      xm.optimizer_step(optimizer)
+      if FLAGS.ddp:
+        optimizer.step()
+      else:
+        xm.optimizer_step(optimizer)
       tracker.add(FLAGS.batch_size)
       if lr_scheduler:
         lr_scheduler.step()

--- a/test/test_train_mp_imagenet.py
+++ b/test/test_train_mp_imagenet.py
@@ -120,7 +120,8 @@ def _train_update(device, step, loss, tracker, epoch, writer):
 
 def train_imagenet():
   if FLAGS.ddp:
-    dist.init_process_group('xla', world_size=xm.xrt_world_size(), rank=xm.get_ordinal())
+    dist.init_process_group(
+        'xla', world_size=xm.xrt_world_size(), rank=xm.get_ordinal())
 
   print('==> Preparing data..')
   img_dim = get_model_property('img_dim')

--- a/test/test_train_mp_mnist.py
+++ b/test/test_train_mp_mnist.py
@@ -33,10 +33,10 @@ import torch_xla.core.xla_model as xm
 import torch_xla.distributed.xla_multiprocessing as xmp
 import torch_xla.test.test_utils as test_utils
 
-
 import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP
 import torch_xla.distributed.xla_backend
+
 
 class MNIST(nn.Module):
 
@@ -73,7 +73,8 @@ def _train_update(device, step, loss, tracker, epoch, writer):
 
 def train_mnist(flags, **kwargs):
   if flags.ddp:
-    dist.init_process_group('xla', world_size=xm.xrt_world_size(), rank=xm.get_ordinal())
+    dist.init_process_group(
+        'xla', world_size=xm.xrt_world_size(), rank=xm.get_ordinal())
 
   torch.manual_seed(1)
 


### PR DESCRIPTION
Summary:
This pull requests enhance test_train_mp_imagenet.py and test_train_mp_mnist.py with the ability to use torch.nn.parallel.DistributedDataParallel. So it's easier for us to benchmark it and compare with our native approach.

Test Plan:
MASTER_ADDR=localhost MASTER_PORT=6000 python test/test_train_mp_imagenet.py --ddp --fake_data MASTER_ADDR=localhost MASTER_PORT=6000 python test/test_train_mp_mnist.py --ddp --fake_data