### PR TITLE
Added pytorch patch file to revert https://github.com/pytorch/pytorch…

### DIFF
--- a/torch_patches/81058.diff
+++ b/torch_patches/81058.diff
@@ -1,11 +1,11 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4e556fc878..f78eacf487 100644
+index c2c6fb2496..5cbd50a159 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -44,10 +44,6 @@ if(DEFINED GLIBCXX_USE_CXX11_ABI)
    if(${GLIBCXX_USE_CXX11_ABI} EQUAL 1)
      set(CXX_STANDARD_REQUIRED ON)
-     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=1")
+     string(APPEND CMAKE_CXX_FLAGS " -D_GLIBCXX_USE_CXX11_ABI=1")
 -  else()
 -    # Please note this is required in order to ensure compatibility between gcc 9 and gcc 7
 -    # This could be removed when all Linux PyTorch binary builds are compiled by the same toolchain again

--- a/torch_patches/81058.diff
+++ b/torch_patches/81058.diff
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4e556fc878..f78eacf487 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -44,10 +44,6 @@ if(DEFINED GLIBCXX_USE_CXX11_ABI)
+   if(${GLIBCXX_USE_CXX11_ABI} EQUAL 1)
+     set(CXX_STANDARD_REQUIRED ON)
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=1")
+-  else()
+-    # Please note this is required in order to ensure compatibility between gcc 9 and gcc 7
+-    # This could be removed when all Linux PyTorch binary builds are compiled by the same toolchain again
+-    string(APPEND CMAKE_CXX_FLAGS " -fabi-version=11")
+   endif()
+ endif()
+


### PR DESCRIPTION
Added pytorch patch file to revert https://github.com/pytorch/pytorch/pull/81058

The patch file is obtained by 
```
(pytorch) root@t1v-n-2a2b95ef-w-0:/pytorch# git log --after="2022-07-12 00:00" --before="2022-07-12 23:59"
...
commit b256ff6a8f90441931006958fac223835526f1c3
Author: Sahan Paliskara <sahanp@fb.com>
Date:   Tue Jul 12 18:10:22 2022 +0000

    Allow torch._C to be recognized a module in torch.package (#80917)

commit d552ba3b4f53da9b6a5f6e0463111e43b367ef8a
Author: atalman <atalman@fb.com>
Date:   Tue Jul 12 17:56:33 2022 +0000

     Use fabi-version=11 to ensure compatibility between gcc7 and gcc9 binaries (#81058)

    Fixes: #80489

commit d5bda292074d20cb1164020c4bf3b83a3156bd22
Author: Nikita Shulga <nshulga@fb.com>
Date:   Tue Jul 12 17:35:30 2022 +0000

    [JIT] Tweak annotation extraction for py3.10 (#81334)

    The way Python-3.10+ deals with annotations has changed, see
    https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-10-
and-newer
...

(pytorch) root@t1v-n-2a2b95ef-w-0:/pytorch# git diff d552ba3b4f53da9b6a5f6e0463111e43b367ef8a..d5bda292074d20cb1164020c4bf3b83a3156bd22 -- CMakeLists.txt > revert.patch
```
