### PR TITLE
[SPMD] Use on_device_shape in ExecuteReplicated

### DIFF
--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -365,15 +365,16 @@ PjRtComputationClient::ExecuteReplicated(
       pjrt_computation.executable->Execute(argument_handles, execute_options)
           .value();
 
-  std::vector<std::vector<ComputationClient::DataPtr>> data_handles(
-      results.size());
+  std::vector<std::vector<ComputationClient::DataPtr>> data_handles;
+  data_handles.reserve(results.size());
   for (auto& result : results) {
-    std::vector<ComputationClient::DataPtr> datas(result.size());
+    std::vector<ComputationClient::DataPtr> datas;
+    datas.reserve(result.size());
     for (int32_t i = 0; i < result.size(); ++i) {
       std::unique_ptr<xla::PjRtBuffer> buffer = std::move(result[i]);
 
       std::shared_ptr<PjRtData> data = std::make_shared<PjRtData>(
-          devices[i], buffer->logical_on_device_shape().value(),
+          devices[i], buffer->on_device_shape(),
           std::move(buffer));
 
       datas.push_back(data);

--- a/torch_xla/experimental/xla_sharding.py
+++ b/torch_xla/experimental/xla_sharding.py
@@ -72,6 +72,6 @@ def mark_sharding(t: Union[torch.Tensor,
   return XLAShardedTensor(t)
 
 
-def clear_sharding(t: Union[torch.Tensor, XLAShardedTensor]) -> torch.Tensdor:
+def clear_sharding(t: Union[torch.Tensor, XLAShardedTensor]) -> torch.Tensor:
   """Clear sharding annotation from the input tensor and return a `cpu` casted tensor."""
   return NotImplemented


### PR DESCRIPTION
Use `buffer->on_device_shape` to support tfrt in ExecuteReplicated mode. Also fixes some minor bugs introduced during the latest SPMD refactoring.