### PR TITLE
Fix clear counter

### DIFF
--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -36,6 +36,7 @@ class MetricsTest(unittest.TestCase):
     assert ("TensorToData" in met.metrics_report())
     assert (len(met.metric_names()) > 0)
 
+
 if __name__ == '__main__':
   test = unittest.main()
   sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -33,8 +33,8 @@ class MetricsTest(unittest.TestCase):
     assert (len(met.metric_names()) == 0)
     # perform the same computation and check if metrics increases again
     t2 = torch.tensor(200, device=xla_device)
-    #import pdb; pdb.set_trace()
-
+    assert ("TensorToData" in met.metrics_report())
+    assert (len(met.metric_names()) > 0)
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -12,16 +12,28 @@ class MetricsTest(unittest.TestCase):
   def test_clear_counters(self):
     xla_device = xm.xla_device()
     t1 = torch.tensor(100, device=xla_device)
+    t1 += 2
+    assert ("xla::add" in met.metrics_report())
     assert (len(met.counter_names()) > 0)
     met.clear_counters()
+    assert ("xla::add" not in met.metrics_report())
     assert (len(met.counter_names()) == 0)
+    # perform the same computation and check if counter increases again
+    t1 += 2
+    assert ("xla::add" in met.metrics_report())
+    assert (len(met.counter_names()) > 0)
 
   def test_clear_metrics(self):
     xla_device = xm.xla_device()
     t1 = torch.tensor(100, device=xla_device)
+    assert ("TensorToData" in met.metrics_report())
     assert (len(met.metric_names()) > 0)
     met.clear_metrics()
+    assert ("TensorToData" not in met.metrics_report())
     assert (len(met.metric_names()) == 0)
+    # perform the same computation and check if metrics increases again
+    t2 = torch.tensor(200, device=xla_device)
+    #import pdb; pdb.set_trace()
 
 
 if __name__ == '__main__':

--- a/third_party/xla_client/metrics.h
+++ b/third_party/xla_client/metrics.h
@@ -50,6 +50,8 @@ class MetricData {
 
   std::string Repr(double value) const { return repr_fn_(value); }
 
+  void Clear();
+
  private:
   mutable std::mutex lock_;
   MetricReprFn repr_fn_;

--- a/third_party/xla_client/metrics.h
+++ b/third_party/xla_client/metrics.h
@@ -68,6 +68,8 @@ class CounterData {
 
   int64_t Value() const { return value_; }
 
+  void Clear() { value_ = 0; }
+
  private:
   std::atomic<int64_t> value_;
 };


### PR DESCRIPTION
My previous implementation clear the `vector<CounterData>` and `vector<MetricsData>` directly, but this is incorrect. Counters and Metrics and declared as static variable in different places of code, and won't get recreated if being deleted. What we can do is to reset the value of those counters and make sure they don't show up in report if value is zero. Added additional test to account for this case.