### PR TITLE
[SPMD] Test sharding_spec with clear_sharding, deepcopy

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -127,7 +127,7 @@ function run_op_tests {
   run_pjrt python3 "$CDIR/pjrt/test_experimental_pjrt.py"
   run_pjrt python3 "$CDIR/pjrt/test_experimental_tpu.py"
   run_pjrt python3 "$CDIR/pjrt/test_ddp.py"
-  #run_pjrt python3 "$CDIR/test_xla_sharding.py"  # TODO(yeounoh) debug
+  run_pjrt python3 "$CDIR/test_xla_sharding.py"
   run_test python3 "$CDIR/test_operations_hlo.py" "$@" --verbosity=$VERBOSITY
 }
 

--- a/third_party/xla_client/computation_client.h
+++ b/third_party/xla_client/computation_client.h
@@ -216,17 +216,17 @@ class ComputationClient {
   // wrapped inside a vector.
   virtual std::vector<DataPtr> GetDataShards(DataPtr data) = 0;
 
-  // Transfers local tensor values to the TPU servers and fetches the handles.
+  // Transfers local tensor values to the TPU devices and fetches the handles.
   virtual std::vector<DataPtr> TransferToServer(
       absl::Span<const TensorSource> tensors) = 0;
 
-  // Transfers local tensor values to the TPU servers and fetches the handles.
+  // Transfers local tensor values to the TPU devices and fetches the handles.
   // Update the handles associated with DataPtrs passed instead of creating new
   // datas.
   virtual void TransferToServer(absl::Span<const TensorSource> tensors,
                                 absl::Span<const DataPtr> datas) = 0;
 
-  // Transfers local sharded tensor values to the TPU servers and returns a
+  // Transfers local sharded tensor values to the TPU devices and returns a
   // `PjRtShardedData`.
   virtual DataPtr TransferShardsToServer(
       absl::Span<const TensorSource> tensor_shards, std::string device,

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -115,11 +115,8 @@ class XlaNode : public torch::lazy::Node {
   torch::lazy::hash_t shapeHash() const override { return dag_hash_; }
   // The node's outputs get assigned the same HLO sharding
   // TODO: test multi-output example.
-  const xla::OpSharding* GetSharding() const {
-    if (output_sharding_ == nullptr) {
-      return nullptr;
-    }
-    return output_sharding_.get();
+  const std::shared_ptr<xla::OpSharding> GetSharding() const {
+    return output_sharding_;
   }
   void SetSharding(const xla::OpSharding& sharding) {
     output_sharding_ = std::make_shared<xla::OpSharding>(sharding);

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -630,7 +630,7 @@ XLATensor::ShardingSpecPtr XLATensor::sharding_spec() const {
   torch::lazy::Value ir_value = CurrentIrValue();
   if (ir_value) {
     XLA_CHECK(ir_value.node != nullptr) << "Tyring to access a null cursor";
-    auto* sharding = dynamic_cast<XlaNode*>(ir_value.node.get())->GetSharding();
+    auto sharding = dynamic_cast<XlaNode*>(ir_value.node.get())->GetSharding();
     if (sharding == nullptr) {
       return nullptr;
     }
@@ -701,11 +701,9 @@ void XLATensor::SetInPlaceIrValue(torch::lazy::Value ir_value) {
 }
 
 void XLATensor::AssignIrValue(torch::lazy::Value ir_value) const {
-  // Sharding annotation it not null, if xla_data() is sharded.
-  // TODO(yeounoh): Sharding annotation must be removed by explicit call to
-  // ClearSharding.
+  // Sharding annotation is not null, if xla_data() is sharded.
   ShardingSpecPtr sharding = sharding_spec();
-  if (sharding != nullptr) {
+  if (ir_value && sharding != nullptr) {
     dynamic_cast<XlaNode*>(ir_value.node.get())
         ->SetSharding(sharding->sharding);
   }

--- a/torch_xla/experimental/xla_sharded_tensor.py
+++ b/torch_xla/experimental/xla_sharded_tensor.py
@@ -82,9 +82,7 @@ class XLAShardedTensor(torch.Tensor):
 
   @property
   def sharding_spec(self):
-    # TODO(yeounoh) `torch_xla._XLAC._get_xla_sharding_spec(self.global_tensor)`
-    # is broken after ltc migration, needs a further investigation.
-    return NotImplemented
+    return torch_xla._XLAC._get_xla_sharding_spec(self.global_tensor)
 
   @property
   def shards(self):

--- a/torch_xla/experimental/xla_sharding.py
+++ b/torch_xla/experimental/xla_sharding.py
@@ -74,4 +74,7 @@ def mark_sharding(t: Union[torch.Tensor,
 
 def clear_sharding(t: Union[torch.Tensor, XLAShardedTensor]) -> torch.Tensor:
   """Clear sharding annotation from the input tensor and return a `cpu` casted tensor."""
-  return NotImplemented
+  torch_xla._XLAC._xla_clear_sharding(t)
+  if isinstance(t, XLAShardedTensor):
+    return t.global_tensor
+  return t


### PR DESCRIPTION
This addresses the follwoing:
- Implement `xla_sharding.clear_sharding` API to reset sharding annotation.
- Test/verify `deepcopy` preserves sharding annotation #4095 
- Refactoring based on the comments from #3684 