### PR TITLE
Add short_metrics

### DIFF
--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -36,6 +36,43 @@ class MetricsTest(unittest.TestCase):
     assert ("TensorToData" in met.metrics_report())
     assert (len(met.metric_names()) > 0)
 
+  def test_short_metrics_report_default_list(self):
+    xla_device = xm.xla_device()
+    t1 = torch.tensor(100, device=xla_device)
+    t2 = t1 * 2
+    xm.mark_step()
+    t2_cpu = t2.cpu()
+    short_report = met.short_metrics_report()
+    assert ("TensorToData" not in short_report)
+    assert ("CompileTime" in short_report)
+    assert ("ExecuteTime" in short_report)
+    assert ("TransferToServerTime" in short_report)
+    assert ("TransferFromServerTime" in short_report)
+    assert ("MarkStep" in short_report)
+    # repeat the same computation and expect to see the CachedCompile counter
+    t3 = t1 * 2
+    xm.mark_step()
+    t4 = t1 * 2
+    xm.mark_step()
+    assert ("CachedCompile" in short_report)
+
+  def test_short_metrics_report_custom_list(self):
+    xla_device = xm.xla_device()
+    t1 = torch.tensor(100, device=xla_device)
+    t2 = t1 * 2
+    xm.mark_step()
+    t2_cpu = t2.cpu()
+    short_report = met.short_metrics_report(
+        counter_names=['CreateCompileHandles'])
+    assert ('CreateCompileHandles' in short_report)
+    assert ('MarkStep' not in short_report)
+    # using the default metrics list in this case
+    assert ('CompileTime' in short_report)
+    short_report = met.short_metrics_report(
+        counter_names=['CreateCompileHandles'], metric_names=['InboundData'])
+    assert ('CompileTime' not in short_report)
+    assert ('InboundData' in short_report)
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -73,6 +73,17 @@ class MetricsTest(unittest.TestCase):
     assert ('CompileTime' not in short_report)
     assert ('InboundData' in short_report)
 
+  def test_short_metrics_fallback_counter(self):
+    xla_device = xm.xla_device()
+    t1 = torch.tensor(100, device=xla_device)
+    t2 = t1 * 2
+    # this will trigger a aten::_local_scalar_dense which is the same
+    if t2:
+      t2 += 1
+    assert ('aten::_local_scalar_dense' in met.short_metrics_report())
+    assert ('aten::_local_scalar_dense' in met.short_metrics_report(
+        counter_names=['CreateCompileHandles'], metric_names=['InboundData']))
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -13,48 +13,48 @@ class MetricsTest(unittest.TestCase):
     xla_device = xm.xla_device()
     t1 = torch.tensor(100, device=xla_device)
     t1 += 2
-    assert ("xla::add" in met.metrics_report())
+    self.assertIn("xla::add", met.metrics_report())
     assert (len(met.counter_names()) > 0)
     met.clear_counters()
-    assert ("xla::add" not in met.metrics_report())
+    self.assertNotIn("xla::add", met.metrics_report())
     assert (len(met.counter_names()) == 0)
     # perform the same computation and check if counter increases again
     t1 += 2
-    assert ("xla::add" in met.metrics_report())
+    self.assertIn("xla::add", met.metrics_report())
     assert (len(met.counter_names()) > 0)
 
   def test_clear_metrics(self):
     xla_device = xm.xla_device()
-    t1 = torch.tensor(100, device=xla_device)
-    assert ("TensorToData" in met.metrics_report())
+    t1 = torch.tensor(156, device=xla_device)
+    self.assertIn("TensorToData", met.metrics_report())
     assert (len(met.metric_names()) > 0)
     met.clear_metrics()
-    assert ("TensorToData" not in met.metrics_report())
+    self.assertNotIn("TensorToData", met.metrics_report())
     assert (len(met.metric_names()) == 0)
     # perform the same computation and check if metrics increases again
     t2 = torch.tensor(200, device=xla_device)
-    assert ("TensorToData" in met.metrics_report())
+    self.assertIn("TensorToData", met.metrics_report())
     assert (len(met.metric_names()) > 0)
 
   def test_short_metrics_report_default_list(self):
     xla_device = xm.xla_device()
-    t1 = torch.tensor(100, device=xla_device)
+    t1 = torch.tensor(1456, device=xla_device)
     t2 = t1 * 2
     xm.mark_step()
     t2_cpu = t2.cpu()
     short_report = met.short_metrics_report()
-    assert ("TensorToData" not in short_report)
-    assert ("CompileTime" in short_report)
-    assert ("ExecuteTime" in short_report)
-    assert ("TransferToServerTime" in short_report)
-    assert ("TransferFromServerTime" in short_report)
-    assert ("MarkStep" in short_report)
+    self.assertNotIn("TensorToData", short_report)
+    self.assertIn("CompileTime", short_report)
+    self.assertIn("ExecuteTime", short_report)
+    self.assertIn("TransferToServerTime", short_report)
+    self.assertIn("TransferFromServerTime", short_report)
+    self.assertIn("MarkStep", short_report)
     # repeat the same computation and expect to see the CachedCompile counter
     t3 = t1 * 2
     xm.mark_step()
     t4 = t1 * 2
     xm.mark_step()
-    assert ("CachedCompile" in short_report)
+    self.assertIn("CachedCompile", short_report)
 
   def test_short_metrics_report_custom_list(self):
     xla_device = xm.xla_device()
@@ -64,14 +64,14 @@ class MetricsTest(unittest.TestCase):
     t2_cpu = t2.cpu()
     short_report = met.short_metrics_report(
         counter_names=['CreateCompileHandles'])
-    assert ('CreateCompileHandles' in short_report)
-    assert ('MarkStep' not in short_report)
+    self.assertIn('CreateCompileHandles', short_report)
+    self.assertNotIn('MarkStep', short_report)
     # using the default metrics list in this case
-    assert ('CompileTime' in short_report)
+    self.assertIn('CompileTime', short_report)
     short_report = met.short_metrics_report(
         counter_names=['CreateCompileHandles'], metric_names=['InboundData'])
-    assert ('CompileTime' not in short_report)
-    assert ('InboundData' in short_report)
+    self.assertNotIn('CompileTime', short_report)
+    self.assertIn('InboundData', short_report)
 
   def test_short_metrics_fallback_counter(self):
     xla_device = xm.xla_device()
@@ -80,9 +80,12 @@ class MetricsTest(unittest.TestCase):
     # this will trigger a aten::_local_scalar_dense which is the same as fallback counter
     if t2:
       t2 += 1
-    assert ('aten::_local_scalar_dense' in met.short_metrics_report())
-    assert ('aten::_local_scalar_dense' in met.short_metrics_report(
-        counter_names=['CreateCompileHandles'], metric_names=['InboundData']))
+    self.assertIn('aten::_local_scalar_dense', met.short_metrics_report())
+    self.assertIn(
+        'aten::_local_scalar_dense',
+        met.short_metrics_report(
+            counter_names=['CreateCompileHandles'],
+            metric_names=['InboundData']))
 
 
 if __name__ == '__main__':

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -77,7 +77,7 @@ class MetricsTest(unittest.TestCase):
     xla_device = xm.xla_device()
     t1 = torch.tensor(100, device=xla_device)
     t2 = t1 * 2
-    # this will trigger a aten::_local_scalar_dense which is the same
+    # this will trigger a aten::_local_scalar_dense which is the same as fallback counter
     if t2:
       t2 += 1
     assert ('aten::_local_scalar_dense' in met.short_metrics_report())

--- a/third_party/xla_client/metrics.cc
+++ b/third_party/xla_client/metrics.cc
@@ -364,7 +364,7 @@ std::string CreateMetricReport(const std::vector<std::string>& counter_names,
   static std::string fall_back_counter_prefix = "aten::";
   arena->ForEachCounter([&ss](const std::string& name, CounterData* data) {
     if (name.rfind(fall_back_counter_prefix, 0) == 0 && data->Value() > 0) {
-      // it might omit duplicated counter if user also specified exact aten
+      // it might emit duplicated counter if user also specified exact aten
       // counter in the `counter_names` but it should be very rare.
       EmitCounterInfo(name, data, &ss);
     }

--- a/third_party/xla_client/metrics.cc
+++ b/third_party/xla_client/metrics.cc
@@ -345,6 +345,26 @@ std::string CreateMetricReport() {
   return ss.str();
 }
 
+std::string CreateMetricReport(const std::vector<std::string>& counter_names,
+                               const std::vector<std::string>& metric_names) {
+  MetricsArena* arena = MetricsArena::Get();
+  std::stringstream ss;
+  for (const std::string& metric_name : metric_names) {
+    MetricData* data = arena->GetMetric(metric_name);
+    if (data && data->TotalSamples() > 0) {
+      EmitMetricInfo(metric_name, data, &ss);
+    }
+  }
+  for (const std::string& counter_name : counter_names) {
+    CounterData* data = arena->GetCounter(counter_name);
+    if (data && data->Value() > 0) {
+      EmitCounterInfo(counter_name, data, &ss);
+    }
+  }
+  // TODO: always emit aten counter for fallback
+  return ss.str();
+}
+
 std::vector<std::string> GetMetricNames() {
   return MetricsArena::Get()->GetMetricNames();
 }

--- a/third_party/xla_client/metrics.cc
+++ b/third_party/xla_client/metrics.cc
@@ -361,7 +361,14 @@ std::string CreateMetricReport(const std::vector<std::string>& counter_names,
       EmitCounterInfo(counter_name, data, &ss);
     }
   }
-  // TODO: always emit aten counter for fallback
+  static std::string fall_back_counter_prefix = "aten::";
+  arena->ForEachCounter([&ss](const std::string& name, CounterData* data) {
+    if (name.rfind(fall_back_counter_prefix, 0) == 0 && data->Value() > 0) {
+      // it might omit duplicated counter if user also specified exact aten
+      // counter in the `counter_names` but it should be very rare.
+      EmitCounterInfo(name, data, &ss);
+    }
+  });
   return ss.str();
 }
 

--- a/third_party/xla_client/metrics.h
+++ b/third_party/xla_client/metrics.h
@@ -196,6 +196,10 @@ class Counter {
 // Creates a report with the current metrics statistics.
 std::string CreateMetricReport();
 
+// Creates a report with the selected metrics statistics.
+std::string CreateMetricReport(const std::vector<std::string>& counter_names,
+                               const std::vector<std::string>& metric_names);
+
 // Returns the currently registered metric names. Note that the list can grow
 // since metrics are usualy function intialized (they are static function
 // variables).

--- a/third_party/xla_client/metrics_reader.cc
+++ b/third_party/xla_client/metrics_reader.cc
@@ -74,5 +74,10 @@ std::string CreateMetricReport() {
   return metrics::CreateMetricReport() + CreateXrtMetricReport();
 }
 
+std::string CreateMetricReport(const std::vector<std::string>& counter_names,
+                               const std::vector<std::string>& metric_names) {
+  return metrics::CreateMetricReport(counter_names, metric_names);
+}
+
 }  // namespace metrics_reader
 }  // namespace xla

--- a/third_party/xla_client/metrics_reader.h
+++ b/third_party/xla_client/metrics_reader.h
@@ -2,12 +2,17 @@
 #define XLA_CLIENT_METRICS_READER_H_
 
 #include <string>
+#include <vector>
 
 namespace xla {
 namespace metrics_reader {
 
 // Creates a report with the current metrics statistics.
 std::string CreateMetricReport();
+
+// Creates a report with the selected metrics statistics.
+std::string CreateMetricReport(const std::vector<std::string>& counter_names,
+                               const std::vector<std::string>& metric_names);
 
 }  // namespace metrics_reader
 }  // namespace xla

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1190,6 +1190,19 @@ void InitXlaModuleBindings(py::module m) {
   });
   m.def("_xla_metrics_report",
         []() { return xla::metrics_reader::CreateMetricReport(); });
+  m.def("_short_xla_metrics_report",
+        [](const py::list& counter_names, const py::list& metric_names) {
+          std::vector<std::string> counter_name_vec;
+          std::vector<std::string> metric_name_vec;
+          for (auto& counter : counter_names) {
+            counter_name_vec.push_back(counter.cast<std::string>());
+          }
+          for (auto& metric : metric_names) {
+            metric_name_vec.push_back(metric.cast<std::string>());
+          }
+          return xla::metrics_reader::CreateMetricReport(counter_name_vec,
+                                                         metric_name_vec);
+        });
   m.def("_clear_xla_counters", []() { xla::metrics::ClearCounters(); });
   m.def("_clear_xla_metrics", []() { xla::metrics::ClearMetrics(); });
   m.def("_xla_tensors_report",

--- a/torch_xla/debug/metrics.py
+++ b/torch_xla/debug/metrics.py
@@ -57,3 +57,16 @@ def clear_metrics():
 def metrics_report():
   """Retrieves a string containing the full metrics and counters report."""
   return torch_xla._XLAC._xla_metrics_report()
+
+def metrics_report(counter_names=None, metric_names=None):
+  """Retrieves a string containing the full metrics and counters report.
+
+  Args:
+    counter_names (list): The list of counter names whose data needs to be printed.
+    metric_names (list): The list of metric names whose data needs to be printed.
+  """
+  if counter_names == None:
+    counter_names = ['CachedCompile', 'MarkStep']
+  if metric_names == None:
+    metric_names = ['CompileTime', 'ExecuteTime', 'TransferToServerTime', 'TransferFromServerTime']
+  return torch_xla._XLAC._short_xla_metrics_report(counter_names, metric_names)

--- a/torch_xla/debug/metrics.py
+++ b/torch_xla/debug/metrics.py
@@ -58,7 +58,8 @@ def metrics_report():
   """Retrieves a string containing the full metrics and counters report."""
   return torch_xla._XLAC._xla_metrics_report()
 
-def metrics_report(counter_names=None, metric_names=None):
+
+def short_metrics_report(counter_names=None, metric_names=None):
   """Retrieves a string containing the full metrics and counters report.
 
   Args:
@@ -68,5 +69,8 @@ def metrics_report(counter_names=None, metric_names=None):
   if counter_names == None:
     counter_names = ['CachedCompile', 'MarkStep']
   if metric_names == None:
-    metric_names = ['CompileTime', 'ExecuteTime', 'TransferToServerTime', 'TransferFromServerTime']
+    metric_names = [
+        'CompileTime', 'ExecuteTime', 'TransferToServerTime',
+        'TransferFromServerTime'
+    ]
   return torch_xla._XLAC._short_xla_metrics_report(counter_names, metric_names)

--- a/torch_xla/debug/metrics.py
+++ b/torch_xla/debug/metrics.py
@@ -59,16 +59,16 @@ def metrics_report():
   return torch_xla._XLAC._xla_metrics_report()
 
 
-def short_metrics_report(counter_names=None, metric_names=None):
+def short_metrics_report(counter_names: list = None, metric_names: list = None):
   """Retrieves a string containing the full metrics and counters report.
 
   Args:
     counter_names (list): The list of counter names whose data needs to be printed.
     metric_names (list): The list of metric names whose data needs to be printed.
   """
-  if counter_names == None:
+  if not counter_names:
     counter_names = ['CachedCompile', 'MarkStep']
-  if metric_names == None:
+  if not metric_names:
     metric_names = [
         'CompileTime', 'ExecuteTime', 'TransferToServerTime',
         'TransferFromServerTime'


### PR DESCRIPTION
This pr added an api `short_metrics_report` which by defualt will emit a very short list of relevant metrics. User can also customize which metrics they want to see. IMO full metrics is way too detail in most time.

We will always print out the `aten::` counters since they indicate fallback and are important to users.

example output:
```
Metric: CompileTime
  TotalSamples: 2
  Accumulator: 059ms522.421us
  ValueRate: 01s330ms003.908us / second
  Rate: 45.4528 / second
  Percentiles: 1%=026ms399.367us; 5%=026ms399.367us; 10%=026ms399.367us; 20%=026ms399.367us; 50%=032ms123.054us; 80%=032ms123.054us; 90%=032ms123.054us; 95%=032ms123.054us; 99%=032ms123.054us
Metric: ExecuteTime
  TotalSamples: 3
  Accumulator: 017ms966.371us
  ValueRate: 322ms039.563us / second
  Rate: 56.9432 / second
  Percentiles: 1%=001ms307.637us; 5%=001ms307.637us; 10%=001ms307.637us; 20%=001ms307.637us; 50%=008ms736.607us; 80%=008ms922.127us; 90%=008ms922.127us; 95%=008ms922.127us; 99%=008ms922.127us
Metric: TransferToServerTime
  TotalSamples: 1
  Accumulator: 002ms847.252us
  Percentiles: 1%=002ms847.252us; 5%=002ms847.252us; 10%=002ms847.252us; 20%=002ms847.252us; 50%=002ms847.252us; 80%=002ms847.252us; 90%=002ms847.252us; 95%=002ms847.252us; 99%=002ms847.252us
Metric: TransferFromServerTime
  TotalSamples: 3
  Accumulator: 013ms067.510us
  ValueRate: 279ms381.785us / second
  Rate: 64.1396 / second
  Percentiles: 1%=850.899us; 5%=850.899us; 10%=850.899us; 20%=850.899us; 50%=005ms494.984us; 80%=007ms721.627us; 90%=007ms721.627us; 95%=007ms721.627us; 99%=007ms721.627us
Counter: CachedCompile
  Value: 1
Counter: MarkStep
  Value: 2
Counter: aten::_local_scalar_dense
  Value: 1
```