### PR TITLE
Enable `padded` option for even tensor sharding

### DIFF
--- a/test/cpp/test_xla_sharding.cpp
+++ b/test/cpp/test_xla_sharding.cpp
@@ -39,7 +39,8 @@ TEST_F(XLAShardingTest, ShardTensor) {
           CreateComputationShapeFromTensor(tensor, GetDefaultDevice()),
           devices.size())
           .ToProto();
-  auto shards = ShardingUtil::ShardTensor(tensor, sharding, devices);
+  auto shards =
+      ShardingUtil::ShardTensor(tensor, sharding, devices, /*padded=*/false);
   EXPECT_EQ(shards.size(), 8);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({1}));
   EXPECT_EQ(shards[1].sizes(), c10::ArrayRef<long>({1}));
@@ -52,7 +53,8 @@ TEST_F(XLAShardingTest, ShardTensor) {
       {4, 5, 6, 7},
   });
   sharding = xla::HloSharding::Tile(mesh).ToProto();
-  shards = ShardingUtil::ShardTensor(tensor, sharding, devices);
+  shards =
+      ShardingUtil::ShardTensor(tensor, sharding, devices, /*padded=*/false);
   EXPECT_EQ(shards.size(), 8);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({4, 2, 4}));
   EXPECT_EQ(shards[7].sizes(), c10::ArrayRef<long>({4, 1, 4}));
@@ -61,14 +63,16 @@ TEST_F(XLAShardingTest, ShardTensor) {
   // size should be smaller in dim=1 because it's not evenly divisible.
   xla::Array3D<int64_t> cube({{{0, 1}, {2, 3}, {4, 5}, {6, 7}}});
   sharding = xla::HloSharding::Tile(cube).ToProto();
-  shards = ShardingUtil::ShardTensor(tensor, sharding, devices);
+  shards =
+      ShardingUtil::ShardTensor(tensor, sharding, devices, /*padded=*/false);
   EXPECT_EQ(shards.size(), 8);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({8, 2, 2}));
   EXPECT_EQ(shards[7].sizes(), c10::ArrayRef<long>({8, 1, 2}));
 
   // Replicated, all shards should be identical.
   sharding = xla::HloSharding::Replicate().ToProto();
-  shards = ShardingUtil::ShardTensor(tensor, sharding, devices);
+  shards =
+      ShardingUtil::ShardTensor(tensor, sharding, devices, /*padded=*/false);
   EXPECT_EQ(shards.size(), 8);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({8, 7, 4}));
   EXPECT_EQ(shards[7].sizes(), c10::ArrayRef<long>({8, 7, 4}));
@@ -79,10 +83,18 @@ TEST_F(XLAShardingTest, ShardTensor) {
   tensor = at::ones({1, 8, 7, 4}, at::TensorOptions(at::kFloat));
   xla::Array4D<int64_t> tesseract({{{{0, 1}, {2, 3}, {4, 5}, {6, 7}}}});
   sharding = xla::HloSharding::Tile(tesseract).ToProto();
-  shards = ShardingUtil::ShardTensor(tensor, sharding, devices);
+  shards =
+      ShardingUtil::ShardTensor(tensor, sharding, devices, /*padded=*/false);
   EXPECT_EQ(shards.size(), 8);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({1, 8, 2, 2}));
   EXPECT_EQ(shards[7].sizes(), c10::ArrayRef<long>({1, 8, 1, 2}));
+
+  // 4D tiled and padded, all shard sizes should be idential.
+  shards =
+      ShardingUtil::ShardTensor(tensor, sharding, devices, /*padded=*/true);
+  EXPECT_EQ(shards.size(), 8);
+  EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({1, 8, 2, 2}));
+  EXPECT_EQ(shards[7].sizes(), c10::ArrayRef<long>({1, 8, 2, 2}));
 }
 
 TEST_F(XLAShardingTest, CreateTensorsData) {

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -229,39 +229,39 @@ ShardingUtil::InputHandler(
 
 std::vector<at::Tensor> ShardingUtil::ShardTensor(
     const at::Tensor& tensor, const xla::OpSharding sharding,
-    const std::vector<std::string>& devices) {
+    const std::vector<std::string>& devices, bool padded) {
   TF_LOG(INFO) << "ShardTensor with sharding type(" << sharding.type() << ")..."
                << std::endl;
   std::vector<at::Tensor> shards(devices.size());
   if (sharding.type() == xla::OpSharding::REPLICATED) {
     std::fill_n(shards.begin(), shards.size(), tensor);
   } else if (sharding.type() == xla::OpSharding::OTHER) {
-    CHECK_EQ(devices.size(), sharding.tile_assignment_devices().size())
+    XLA_CHECK_EQ(devices.size(), sharding.tile_assignment_devices().size())
         << "Invalid sharding tile_assignment_devices.size(): expected "
         << devices.size() << ", actual "
         << sharding.tile_assignment_devices().size();
-    CHECK(sharding.tile_shape().dimensions_size() <= 2);
-    CHECK(tensor.sizes().size() >= sharding.tile_shape().dimensions_size());
+    XLA_CHECK(sharding.tile_shape().dimensions_size() <= 2);
+    XLA_CHECK(tensor.sizes().size() >= sharding.tile_shape().dimensions_size());
 
     auto tile_shape = sharding.tile_assignment_dimensions();
-    for (int64_t core : sharding.tile_assignment_devices()) {
+    for (size_t i = 0; i < shards.size(); ++i) {
       at::Tensor shard;
       if (tile_shape.size() == 1) {
         int64_t x_partition = tensor.sizes()[0] / tile_shape[0] +
                               (tensor.sizes()[0] % tile_shape[0] != 0);
         shard = tensor.index(
-            {at::indexing::Slice((core % tile_shape[0]) * x_partition,
-                                 (core % tile_shape[0] + 1) * x_partition)});
+            {at::indexing::Slice((i % tile_shape[0]) * x_partition,
+                                 (i % tile_shape[0] + 1) * x_partition)});
       } else if (tile_shape.size() == 2) {
         int64_t x_partition = tensor.sizes()[0] / tile_shape[0] +
                               (tensor.sizes()[0] % tile_shape[0] != 0);
         int64_t y_partition = tensor.sizes()[1] / tile_shape[1] +
                               (tensor.sizes()[1] % tile_shape[1] != 0);
         shard = tensor.index(
-            {at::indexing::Slice((core / tile_shape[1]) * x_partition,
-                                 (core / tile_shape[1] + 1) * x_partition),
-             at::indexing::Slice((core % tile_shape[1]) * y_partition,
-                                 (core % tile_shape[1] + 1) * y_partition)});
+            {at::indexing::Slice((i / tile_shape[1]) * x_partition,
+                                 (i / tile_shape[1] + 1) * x_partition),
+             at::indexing::Slice((i % tile_shape[1]) * y_partition,
+                                 (i % tile_shape[1] + 1) * y_partition)});
       } else if (tile_shape.size() == 3) {
         int64_t x_partition = tensor.sizes()[0] / tile_shape[0] +
                               (tensor.sizes()[0] % tile_shape[0] != 0);
@@ -271,12 +271,12 @@ std::vector<at::Tensor> ShardingUtil::ShardTensor(
                               (tensor.sizes()[2] % tile_shape[2] != 0);
         shard = tensor.index(
             {at::indexing::Slice(
-                 (core / tile_shape[1] / tile_shape[2]) * x_partition,
-                 (core / tile_shape[1] / tile_shape[2] + 1) * x_partition),
-             at::indexing::Slice((core / tile_shape[2]) * y_partition,
-                                 (core / tile_shape[2] + 1) * y_partition),
-             at::indexing::Slice((core % tile_shape[2]) * z_partition,
-                                 (core % tile_shape[2] + 1) * z_partition)});
+                 (i / tile_shape[1] / tile_shape[2]) * x_partition,
+                 (i / tile_shape[1] / tile_shape[2] + 1) * x_partition),
+             at::indexing::Slice((i / tile_shape[2]) * y_partition,
+                                 (i / tile_shape[2] + 1) * y_partition),
+             at::indexing::Slice((i % tile_shape[2]) * z_partition,
+                                 (i % tile_shape[2] + 1) * z_partition)});
       } else if (tile_shape.size() == 4) {
         int64_t x_partition = tensor.sizes()[0] / tile_shape[0] +
                               (tensor.sizes()[0] % tile_shape[0] != 0);
@@ -288,17 +288,17 @@ std::vector<at::Tensor> ShardingUtil::ShardTensor(
                               (tensor.sizes()[3] % tile_shape[3] != 0);
         shard = tensor.index(
             {at::indexing::Slice(
-                 (core / tile_shape[1] / tile_shape[2] / tile_shape[3]) *
+                 (i / tile_shape[1] / tile_shape[2] / tile_shape[3]) *
                      x_partition,
-                 (core / tile_shape[1] / tile_shape[2] / tile_shape[3] + 1) *
+                 (i / tile_shape[1] / tile_shape[2] / tile_shape[3] + 1) *
                      x_partition),
              at::indexing::Slice(
-                 (core / tile_shape[2] / tile_shape[3]) * y_partition,
-                 (core / tile_shape[2] / tile_shape[3] + 1) * y_partition),
-             at::indexing::Slice((core / tile_shape[3]) * z_partition,
-                                 (core / tile_shape[3] + 1) * z_partition),
-             at::indexing::Slice((core % tile_shape[3]) * w_partition,
-                                 (core % tile_shape[3] + 1) * w_partition)});
+                 (i / tile_shape[2] / tile_shape[3]) * y_partition,
+                 (i / tile_shape[2] / tile_shape[3] + 1) * y_partition),
+             at::indexing::Slice((i / tile_shape[3]) * z_partition,
+                                 (i / tile_shape[3] + 1) * z_partition),
+             at::indexing::Slice((i % tile_shape[3]) * w_partition,
+                                 (i % tile_shape[3] + 1) * w_partition)});
       } else if (tile_shape.size() == 5) {
         int64_t x_partition = tensor.sizes()[0] / tile_shape[0] +
                               (tensor.sizes()[0] % tile_shape[0] != 0);
@@ -311,31 +311,48 @@ std::vector<at::Tensor> ShardingUtil::ShardTensor(
         int64_t v_partition = tensor.sizes()[4] / tile_shape[4] +
                               (tensor.sizes()[4] % tile_shape[4] != 0);
         shard = tensor.index(
-            {at::indexing::Slice((core / tile_shape[1] / tile_shape[2] /
+            {at::indexing::Slice((i / tile_shape[1] / tile_shape[2] /
                                   tile_shape[3] / tile_shape[4]) *
                                      x_partition,
-                                 (core / tile_shape[1] / tile_shape[2] /
+                                 (i / tile_shape[1] / tile_shape[2] /
                                       tile_shape[3] / tile_shape[4] +
                                   1) *
                                      x_partition),
              at::indexing::Slice(
-                 (core / tile_shape[2] / tile_shape[3] / tile_shape[4]) *
+                 (i / tile_shape[2] / tile_shape[3] / tile_shape[4]) *
                      y_partition,
-                 (core / tile_shape[2] / tile_shape[3] / tile_shape[4] + 1) *
+                 (i / tile_shape[2] / tile_shape[3] / tile_shape[4] + 1) *
                      y_partition),
              at::indexing::Slice(
-                 (core / tile_shape[3] / tile_shape[4]) * z_partition,
-                 (core / tile_shape[3] / tile_shape[4] + 1) * z_partition),
-             at::indexing::Slice((core / tile_shape[4]) * w_partition,
-                                 (core / tile_shape[4] + 1) * w_partition),
-             at::indexing::Slice((core % tile_shape[4]) * v_partition,
-                                 (core % tile_shape[4] + 1) * v_partition)});
+                 (i / tile_shape[3] / tile_shape[4]) * z_partition,
+                 (i / tile_shape[3] / tile_shape[4] + 1) * z_partition),
+             at::indexing::Slice((i / tile_shape[4]) * w_partition,
+                                 (i / tile_shape[4] + 1) * w_partition),
+             at::indexing::Slice((i % tile_shape[4]) * v_partition,
+                                 (i % tile_shape[4] + 1) * v_partition)});
       }
+      int64_t core = sharding.tile_assignment_devices()[i];
       shards[core] = shard.contiguous(at::MemoryFormat::Contiguous);
     }
   } else if ((sharding.type() == xla::OpSharding::MANUAL) ||
              (sharding.type() == xla::OpSharding::TUPLE)) {
     TF_LOG(ERROR) << "Unsupported OpSharidng type " << sharding.type();
+  }
+
+  // Zero-pad to the right to ensure the sizes are even
+  if (shards.size() > 0 && padded) {
+    for (size_t i = 1; i < shards.size(); ++i) {
+      std::vector<long> pads;
+      for (size_t j = 0; j < shards[i].sizes().size(); ++j) {
+        XLA_CHECK_GE(shards[0].sizes().at(j), shards[i].sizes().at(j));
+        pads.push_back(shards[0].sizes().at(j) - shards[i].sizes().at(j));
+        pads.push_back(0);  // no padding on lhs
+      }
+      // Padding starts from the last dimension
+      std::reverse(pads.begin(), pads.end());
+      shards[i] = at::constant_pad_nd(
+          shards[i], c10::IntArrayRef(pads.data(), pads.size()), 0);
+    }
   }
   return shards;
 }

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -46,10 +46,10 @@ class ShardingUtil {
   // sharded across devices along the same dimension in the `tile_assignment`;
   // the returned tensor shards vector is indexed by the device IDs. There is no
   // data duplication. Shards are not padded in case the input tensor is not
-  // evenly partitionable.
+  // evenly partitionable, unless `padded` is set.
   static std::vector<at::Tensor> ShardTensor(
       const at::Tensor& tensor, const xla::OpSharding sharding,
-      const std::vector<std::string>& devices);
+      const std::vector<std::string>& devices, bool padded = true);
 };
 
 }  // namespace torch_xla

--- a/torch_xla/experimental/xla_sharded_tensor.py
+++ b/torch_xla/experimental/xla_sharded_tensor.py
@@ -58,7 +58,7 @@ class XLAShardedTensor(torch.Tensor):
   # 4-way row-wise, and replicate column-wise.
   # >> input = torch.randn(8, 10)
   # >> mesh_shape = (4, 2)
-  # >> assert np.prod(mesh_shape) == xm.xrt_world_size()
+  # >> assert np.prod(mesh_shape) == len(xm.get_xla_supported_devices())
   # >> partition_spec = (0, None)
   # >> assert len(input.shape) == len(partition_spec)
   partition_spec: Tuple[int, None]

--- a/torch_xla/experimental/xla_sharding.py
+++ b/torch_xla/experimental/xla_sharding.py
@@ -39,7 +39,8 @@ def mark_sharding(t: Union[torch.Tensor,
     # full replication
     output = xs.mark_sharding(output, device_mesh, (None, None))
   """
-  num_devices = xm.xrt_world_size()
+  num_devices = len(xm.get_xla_supported_devices())
+  assert num_devices > 0, "This requires XLA supported device(s)."
   assert np.prod(mesh_shape) == num_devices, \
     f"{mesh_shape} is not mappable over {num_devices} devices."
   assert all((d >= 0 and d < len(mesh_shape)) for d in partition_spec if d), \


### PR DESCRIPTION
This fixes the inconsistent shard size issue I faced while testing convolution layer sharding. This has been the issue, but wasn't surfaced during simple linear testing. Also fixed a minor bug, where `xrt_world_size()` returns all the devices, not just `xla` devices.