### PR TITLE
[LTC] Use upstream DeviceDataInfo

### DIFF
--- a/third_party/xla_client/computation_client.h
+++ b/third_party/xla_client/computation_client.h
@@ -24,10 +24,6 @@ class ComputationClient {
  public:
   class Data {
    public:
-    struct Info {
-      virtual ~Info() {}
-    };
-
     using OpaqueHandle = int64_t;
 
     Data(std::string device, Shape shape)
@@ -39,13 +35,6 @@ class ComputationClient {
 
     const Shape& shape() const { return shape_; }
 
-    Info* info() const { return info_.get(); }
-
-    std::shared_ptr<Info> SetInfo(std::shared_ptr<Info> info) {
-      std::swap(info, info_);
-      return info;
-    }
-
     virtual OpaqueHandle GetOpaqueHandle() = 0;
 
     virtual void Assign(const Data& data) = 0;
@@ -55,7 +44,6 @@ class ComputationClient {
    private:
     std::string device_;
     Shape shape_;
-    std::shared_ptr<Info> info_;
   };
 
   using DataPtr = std::shared_ptr<Data>;

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -37,6 +37,7 @@
 #include "torch/csrc/jit/python/pybind.h"
 #include "torch/csrc/lazy/core/config.h"
 #include "torch/csrc/lazy/core/ir_util.h"
+#include "torch/csrc/lazy/core/lazy_graph_executor.h"
 #include "torch_xla/csrc/aten_xla_bridge.h"
 #include "torch_xla/csrc/computation.h"
 #include "torch_xla/csrc/device.h"
@@ -1498,12 +1499,9 @@ void InitXlaModuleBindings(py::module m) {
             if (!device_data) {
               continue;
             }
-            const auto backend_data = device_data->data();
-            xla::ComputationClient::DataPtr dataptr =
-                ((torch_xla::XLAData*)backend_data.get())->xla_data();
-            XLA_CHECK(dataptr);
-            torch_xla::DeviceDataInfo* infoptr =
-                (torch_xla::DeviceDataInfo*)dataptr->info();
+            const auto& backend_data = device_data->data();
+            auto* infoptr =
+                static_cast<torch::lazy::LazyGraphExecutor::DeviceDataInfo*>(backend_data->info());
             XLA_CHECK(infoptr);
 
             // Dedup by handle

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1501,7 +1501,8 @@ void InitXlaModuleBindings(py::module m) {
             }
             const auto& backend_data = device_data->data();
             auto* infoptr =
-                static_cast<torch::lazy::LazyGraphExecutor::DeviceDataInfo*>(backend_data->info());
+                static_cast<torch::lazy::LazyGraphExecutor::DeviceDataInfo*>(
+                    backend_data->info());
             XLA_CHECK(infoptr);
 
             // Dedup by handle

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -785,7 +785,7 @@ torch::lazy::Value XLATensor::GetDeviceDataIrValue(
   torch::lazy::BackendDataPtr data =
       GetDeviceData(value, TensorTypeFromXlaType(type), device);
   // TODO: consider using upstream info class if possible
-  UnwrapXlaData(data)->SetInfo(
+  data->SetInfo(
       std::make_shared<DeviceDataInfo>(/*tensor_id=*/-1, /*read_only=*/true));
   return torch::lazy::MakeNode<DeviceData>(std::move(data));
 }
@@ -1147,7 +1147,7 @@ std::vector<XLATensorPtr> XLATensor::CreateTensors(
 
 torch::lazy::Value XLATensor::CreateTensorNode(torch::lazy::BackendDataPtr data,
                                                bool read_only) const {
-  UnwrapXlaData(data)->SetInfo(
+  data->SetInfo(
       std::make_shared<DeviceDataInfo>(GetUniqueId(), read_only));
   return torch::lazy::MakeNode<DeviceData>(std::move(data));
 }

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1147,8 +1147,7 @@ std::vector<XLATensorPtr> XLATensor::CreateTensors(
 
 torch::lazy::Value XLATensor::CreateTensorNode(torch::lazy::BackendDataPtr data,
                                                bool read_only) const {
-  data->SetInfo(
-      std::make_shared<DeviceDataInfo>(GetUniqueId(), read_only));
+  data->SetInfo(std::make_shared<DeviceDataInfo>(GetUniqueId(), read_only));
   return torch::lazy::MakeNode<DeviceData>(std::move(data));
 }
 

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -787,7 +787,8 @@ torch::lazy::Value XLATensor::GetDeviceDataIrValue(
       GetDeviceData(value, TensorTypeFromXlaType(type), device);
   // TODO: consider using upstream info class if possible
   data->SetInfo(
-      std::make_shared<torch::lazy::LazyGraphExecutor::DeviceDataInfo>(/*tensor_id=*/-1, /*read_only=*/true));
+      std::make_shared<torch::lazy::LazyGraphExecutor::DeviceDataInfo>(
+          /*tensor_id=*/-1, /*read_only=*/true));
   return torch::lazy::MakeNode<DeviceData>(std::move(data));
 }
 
@@ -1148,7 +1149,9 @@ std::vector<XLATensorPtr> XLATensor::CreateTensors(
 
 torch::lazy::Value XLATensor::CreateTensorNode(torch::lazy::BackendDataPtr data,
                                                bool read_only) const {
-  data->SetInfo(std::make_shared<torch::lazy::LazyGraphExecutor::DeviceDataInfo>(GetUniqueId(), read_only));
+  data->SetInfo(
+      std::make_shared<torch::lazy::LazyGraphExecutor::DeviceDataInfo>(
+          GetUniqueId(), read_only));
   return torch::lazy::MakeNode<DeviceData>(std::move(data));
 }
 
@@ -1685,7 +1688,8 @@ std::vector<std::pair<int64_t, int64_t>> XLATensor::BuildInputOutputAliases(
   std::vector<ssize_t> alias_map(indices.size(), -1);
   for (size_t i = 0; i < parameters_data.size(); ++i) {
     auto* data_info =
-        static_cast<torch::lazy::LazyGraphExecutor::DeviceDataInfo*>(parameters_data[i]->info());
+        static_cast<torch::lazy::LazyGraphExecutor::DeviceDataInfo*>(
+            parameters_data[i]->info());
     if (data_info != nullptr && !data_info->read_only) {
       auto it = output_tensor_id_map.find(data_info->tensor_id);
       if (it != output_tensor_id_map.end()) {
@@ -1693,8 +1697,7 @@ std::vector<std::pair<int64_t, int64_t>> XLATensor::BuildInputOutputAliases(
         xla::XlaOp root = lowering_ctx->GetResult(output_index);
         const xla::Shape& root_shape = XlaHelpers::ShapeOfXlaOp(root);
         auto parameter_data_shape = UnwrapXlaData(parameters_data[i])->shape();
-        if (parameter_data_shape == root_shape &&
-            alias_map[output_index] < 0) {
+        if (parameter_data_shape == root_shape && alias_map[output_index] < 0) {
           // parameter is not a tuple so param_index will always be {}
           lowering_ctx->builder()->SetUpAlias(
               {/*output_index=*/static_cast<int64_t>(output_index)},

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -30,6 +30,7 @@
 #include "torch/csrc/lazy/core/hash.h"
 #include "torch/csrc/lazy/core/helpers.h"
 #include "torch/csrc/lazy/core/ir_util.h"
+#include "torch/csrc/lazy/core/lazy_graph_executor.h"
 #include "torch/csrc/lazy/core/tensor_util.h"
 #include "torch/csrc/lazy/core/util.h"
 #include "torch_xla/csrc/computation.h"
@@ -786,7 +787,7 @@ torch::lazy::Value XLATensor::GetDeviceDataIrValue(
       GetDeviceData(value, TensorTypeFromXlaType(type), device);
   // TODO: consider using upstream info class if possible
   data->SetInfo(
-      std::make_shared<DeviceDataInfo>(/*tensor_id=*/-1, /*read_only=*/true));
+      std::make_shared<torch::lazy::LazyGraphExecutor::DeviceDataInfo>(/*tensor_id=*/-1, /*read_only=*/true));
   return torch::lazy::MakeNode<DeviceData>(std::move(data));
 }
 
@@ -1147,7 +1148,7 @@ std::vector<XLATensorPtr> XLATensor::CreateTensors(
 
 torch::lazy::Value XLATensor::CreateTensorNode(torch::lazy::BackendDataPtr data,
                                                bool read_only) const {
-  data->SetInfo(std::make_shared<DeviceDataInfo>(GetUniqueId(), read_only));
+  data->SetInfo(std::make_shared<torch::lazy::LazyGraphExecutor::DeviceDataInfo>(GetUniqueId(), read_only));
   return torch::lazy::MakeNode<DeviceData>(std::move(data));
 }
 
@@ -1680,19 +1681,19 @@ std::vector<std::pair<int64_t, int64_t>> XLATensor::BuildInputOutputAliases(
     output_tensor_id_map[tensor_id] = i;
   }
   // TODO we need xla_shape here.
-  const std::vector<xla::ComputationClient::DataPtr>& parameters_data =
-      UnwrapXlaData(lowering_ctx->GetParametersData());
+  const auto& parameters_data = lowering_ctx->GetParametersData();
   std::vector<ssize_t> alias_map(indices.size(), -1);
   for (size_t i = 0; i < parameters_data.size(); ++i) {
-    DeviceDataInfo* data_info =
-        dynamic_cast<DeviceDataInfo*>(parameters_data[i]->info());
+    auto* data_info =
+        static_cast<torch::lazy::LazyGraphExecutor::DeviceDataInfo*>(parameters_data[i]->info());
     if (data_info != nullptr && !data_info->read_only) {
       auto it = output_tensor_id_map.find(data_info->tensor_id);
       if (it != output_tensor_id_map.end()) {
         size_t output_index = it->second;
         xla::XlaOp root = lowering_ctx->GetResult(output_index);
         const xla::Shape& root_shape = XlaHelpers::ShapeOfXlaOp(root);
-        if (parameters_data[i]->shape() == root_shape &&
+        auto parameter_data_shape = UnwrapXlaData(parameters_data[i])->shape();
+        if (parameter_data_shape == root_shape &&
             alias_map[output_index] < 0) {
           // parameter is not a tuple so param_index will always be {}
           lowering_ctx->builder()->SetUpAlias(
@@ -1702,7 +1703,7 @@ std::vector<std::pair<int64_t, int64_t>> XLATensor::BuildInputOutputAliases(
           input_output_alias_pair.push_back(std::make_pair(i, output_index));
 
           TF_VLOG(6) << "Aliased paramter " << i << " with output "
-                     << output_index << ": " << parameters_data[i]->shape();
+                     << output_index << ": " << parameter_data_shape;
         }
       }
     }

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -50,13 +50,13 @@ class TORCH_API XLASymNodeImpl : public c10::SymNodeImpl {
 class XLATensor;
 using XLATensorPtr = c10::intrusive_ptr<XLATensor>;
 
-struct DeviceDataInfo : public torch::lazy::BackendData::Info {
-  DeviceDataInfo(int64_t tensor_id, bool read_only)
-      : tensor_id(tensor_id), read_only(read_only) {}
+// struct DeviceDataInfo : public torch::lazy::BackendData::Info {
+//   DeviceDataInfo(int64_t tensor_id, bool read_only)
+//       : tensor_id(tensor_id), read_only(read_only) {}
 
-  int64_t tensor_id = 0;
-  bool read_only = false;
-};
+//   int64_t tensor_id = 0;
+//   bool read_only = false;
+// };
 
 class XLATensor : public c10::intrusive_ptr_target {
   class DeviceContextArena;

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -50,14 +50,6 @@ class TORCH_API XLASymNodeImpl : public c10::SymNodeImpl {
 class XLATensor;
 using XLATensorPtr = c10::intrusive_ptr<XLATensor>;
 
-// struct DeviceDataInfo : public torch::lazy::BackendData::Info {
-//   DeviceDataInfo(int64_t tensor_id, bool read_only)
-//       : tensor_id(tensor_id), read_only(read_only) {}
-
-//   int64_t tensor_id = 0;
-//   bool read_only = false;
-// };
-
 class XLATensor : public c10::intrusive_ptr_target {
   class DeviceContextArena;
   struct Data;

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -50,7 +50,7 @@ class TORCH_API XLASymNodeImpl : public c10::SymNodeImpl {
 class XLATensor;
 using XLATensorPtr = c10::intrusive_ptr<XLATensor>;
 
-struct DeviceDataInfo : public xla::ComputationClient::Data::Info {
+struct DeviceDataInfo : public torch::lazy::BackendData::Info {
   DeviceDataInfo(int64_t tensor_id, bool read_only)
       : tensor_id(tensor_id), read_only(read_only) {}
 

--- a/torch_xla/csrc/xla_backend_impl.h
+++ b/torch_xla/csrc/xla_backend_impl.h
@@ -8,6 +8,11 @@
 #include "torch_xla/csrc/device.h"
 
 namespace torch_xla {
+
+// To be noted, the most appropriate way to adopt BackendData
+// should actually be letting ComputationClient::Data inherit it.
+// Since ComputationClient is within TensorFlow, and TF cannot
+// depend on PyTorch. Therefore, we have this intermediate wrapper.
 class XLAData : public torch::lazy::BackendData {
  public:
   XLAData(const torch::lazy::Shape& shape,


### PR DESCRIPTION
Summary:
This pull request switches to use torch::lazy::LazyGraphExecutor::DeviceDataInfo and deletes our own DeviceDataInfo. In addition, it also deletes ComputationClient::Data::Info as the Info is now stored in torch::lazy::BackendData.

Test Plan:
CI.