### PR TITLE
Make ExecuteComputationOptions as default

### DIFF
--- a/third_party/xla_client/computation_client.h
+++ b/third_party/xla_client/computation_client.h
@@ -22,9 +22,10 @@ namespace xla {
 
 // Somehow the compiler doesn't allow type that has default member being
 // used as a default parameter in a method defined in the same scope.
-// Therefore, ClientExecuteOptions is defined here instead of within ComputationClient.
+// Therefore, ClientExecuteOptions is defined here instead of within
+// ComputationClient.
 struct ClientExecuteOptions {
-  bool explode_tuple {true};
+  bool explode_tuple{true};
 };
 
 class ComputationClient {
@@ -238,7 +239,9 @@ class ComputationClient {
   // its single elements.
   virtual std::vector<DataPtr> ExecuteComputation(
       const Computation& computation, absl::Span<const DataPtr> arguments,
-      const std::string& device, const ExecuteComputationOptions& options = ExecuteComputationOptions{}) = 0;
+      const std::string& device,
+      const ExecuteComputationOptions& options =
+          ExecuteComputationOptions{}) = 0;
 
   // Executes the computation in replicated mode.
   // The size of the arguments vector is the number of replicas to execute,

--- a/third_party/xla_client/computation_client.h
+++ b/third_party/xla_client/computation_client.h
@@ -20,6 +20,13 @@
 
 namespace xla {
 
+// Somehow the compiler doesn't allow type that has default member being
+// used as a default parameter in a method defined in the same scope.
+// Therefore, ClientExecuteOptions is defined here instead of within ComputationClient.
+struct ClientExecuteOptions {
+  bool explode_tuple {true};
+};
+
 class ComputationClient {
  public:
   class Data {
@@ -140,15 +147,11 @@ class ComputationClient {
     bool is_sharded;
   };
 
-  struct ExecuteOptions {
-    bool explode_tuple = true;
-  };
+  struct ExecuteComputationOptions : public ClientExecuteOptions {};
 
-  struct ExecuteComputationOptions : public ExecuteOptions {};
+  struct ExecuteReplicatedOptions : public ClientExecuteOptions {};
 
-  struct ExecuteReplicatedOptions : public ExecuteOptions {};
-
-  struct ExecuteParallelOptions : public ExecuteOptions {};
+  struct ExecuteParallelOptions : public ClientExecuteOptions {};
 
   // Describes an operation to be fed to the ExecuteChained() API.
   // If the device_data member is not nullptr, this operation is a device data
@@ -235,7 +238,7 @@ class ComputationClient {
   // its single elements.
   virtual std::vector<DataPtr> ExecuteComputation(
       const Computation& computation, absl::Span<const DataPtr> arguments,
-      const std::string& device, const ExecuteComputationOptions& options) = 0;
+      const std::string& device, const ExecuteComputationOptions& options = ExecuteComputationOptions{}) = 0;
 
   // Executes the computation in replicated mode.
   // The size of the arguments vector is the number of replicas to execute,

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1607,11 +1607,10 @@ void InitXlaModuleBindings(py::module m) {
           }
 
           std::string deviceStr = device.toString();
-          xla::ComputationClient::ExecuteComputationOptions options;
           std::vector<std::shared_ptr<xla::ComputationClient::Data>> results =
               xla::ComputationClient::Get()->ExecuteComputation(
                   *cachedComputation->computation->client_computation(),
-                  parameters_data, deviceStr, options);
+                  parameters_data, deviceStr);
           std::vector<at::Tensor> retlist;
           {
             XLA_TIMED("RunCachedGraphOutputData");

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1478,7 +1478,6 @@ std::shared_ptr<XLATensor::Async> XLATensor::ScheduleSyncTensorsGraph(
       std::move(cached_computation));
 
   auto syncfn = [async, hash = coll->hash]() {
-    xla::ComputationClient::ExecuteComputationOptions options;
     try {
       std::vector<xla::ComputationClient::DataPtr> results;
       // Execute replicated if the compiled computation is partitioned.
@@ -1489,7 +1488,6 @@ std::shared_ptr<XLATensor::Async> XLATensor::ScheduleSyncTensorsGraph(
             device_arguments = torch_xla::ShardingUtil::InputHandler(
                 UnwrapXlaData(async->parameters_data), devices);
         xla::ComputationClient::ExecuteReplicatedOptions execute_options;
-        execute_options.explode_tuple = options.explode_tuple;
 
         TF_VLOG(3) << "Executing IR graph hash "
                    << torch::lazy::HashToString(hash) << " on all devices.";
@@ -1506,7 +1504,7 @@ std::shared_ptr<XLATensor::Async> XLATensor::ScheduleSyncTensorsGraph(
                    << async->device << " ...";
         results = xla::ComputationClient::Get()->ExecuteComputation(
             *async->cached_computation->computation->client_computation(),
-            UnwrapXlaData(async->parameters_data), async->device, options);
+            UnwrapXlaData(async->parameters_data), async->device);
         TF_VLOG(3) << "Executing IR graph hash "
                    << torch::lazy::HashToString(hash) << " on device "
                    << async->device << " done!";

--- a/torch_xla/csrc/xla_backend_impl.cpp
+++ b/torch_xla/csrc/xla_backend_impl.cpp
@@ -166,11 +166,10 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
       torch::lazy::ComputationPtr computation,
       c10::ArrayRef<torch::lazy::BackendDataPtr> arguments,
       const torch::lazy::BackendDevice& device) const override {
-    xla::ComputationClient::ExecuteComputationOptions options;
     std::vector<xla::ComputationClient::DataPtr> results =
         xla::ComputationClient::Get()->ExecuteComputation(
             *(UnwrapClientComputation(computation).get()),
-            UnwrapXlaData(arguments), device.toString(), options);
+            UnwrapXlaData(arguments), device.toString());
     return WrapXlaData(results);
   }
 


### PR DESCRIPTION
Summary:
ExecuteComputationOptions has always been used to pass the default members. Therefore, let's make it as a default parameter of ComputationClient::ExecuteComputation().

Test Plan:
CI.