### PR TITLE
[WIP] part codegen atan2

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -163,20 +163,16 @@ std::pair<XLATensorPtr, XLATensorPtr> GetBinaryOperands(
 
 // The input is in format of {N, C, H, W} and the output will be {H, W}.
 std::vector<int64_t> GetOutputSizeWithScale(
-    absl::Span<const int64_t> input_size,
-    const c10::optional<at::ArrayRef<double>>& scale_factors,
-    const at::OptionalIntArrayRef& output_size) {
-  if (!output_size) {
-    XLA_CHECK(scale_factors);
-    XLA_CHECK_EQ(scale_factors->size(), 2);
-    // Calculate the output size from input_shape and scale_factors
-    XLA_CHECK_EQ(input_size.size(), 4);
-    int64_t output_h = input_size[2] * (*scale_factors)[0];
-    int64_t output_w = input_size[3] * (*scale_factors)[1];
-    return {output_h, output_w};
-  }
-  XLA_CHECK(!scale_factors);
-  return torch::lazy::ToVector<int64_t>(*output_size);
+    absl::Span<const int64_t> input_size, const c10::optional<double> scales_h,
+    const c10::optional<double> scales_w,
+    const std::vector<int64_t>& output_size) {
+  XLA_CHECK(scales_h);
+  XLA_CHECK(scales_w);
+  // Calculate the output size from input_shape and scale_factors
+  XLA_CHECK_EQ(input_size.size(), 4);
+  int64_t output_h = input_size[2] * (*scales_h);
+  int64_t output_w = input_size[3] * (*scales_w);
+  return {output_h, output_w};
 }
 
 void CheckBinaryOpTypePromotion(const at::Tensor& out, const at::Tensor& self,
@@ -2886,55 +2882,20 @@ at::Tensor XLANativeFunctions::upsample_bilinear2d_backward(
 }
 
 at::Tensor XLANativeFunctions::upsample_nearest2d(
-    const at::Tensor& input, at::OptionalIntArrayRef output_size,
-    c10::optional<at::ArrayRef<double>> scale_factors) {
-  XLA_FN_COUNTER("xla::");
-  XLATensorPtr input_tensor = bridge::GetXlaTensor(input);
-  absl::Span<const int64_t> input_dims =
-      input_tensor->shape().get().dimensions();
-  return bridge::AtenFromXlaTensor(XLATensor::upsample_nearest2d(
-      input_tensor,
-      GetOutputSizeWithScale(input_dims, scale_factors, output_size)));
-}
-
-at::Tensor XLANativeFunctions::upsample_nearest2d_backward(
-    const at::Tensor& grad_output, at::OptionalIntArrayRef output_size,
-    at::IntArrayRef input_size,
-    c10::optional<at::ArrayRef<double>> scale_factors) {
-  XLA_FN_COUNTER("xla::");
-  XLATensorPtr grad_output_tensor = bridge::GetXlaTensor(grad_output);
-  // Only the XLA TPU backend for now implements the CustomCall required by our
-  // XLA lowering.
-  XlaDeviceType hw_type =
-      static_cast<XlaDeviceType>(grad_output_tensor->GetDevice().type());
-  if (hw_type != XlaDeviceType::TPU) {
-    return at::native::call_fallback_fn<&xla_cpu_fallback,
-                                        ATEN_OP2(upsample_nearest2d_backward,
-                                                 vec)>::call(grad_output,
-                                                             output_size,
-                                                             input_size,
-                                                             scale_factors);
-  }
-  std::vector<int64_t> input_dim = torch::lazy::ToVector<int64_t>(input_size);
-  return bridge::AtenFromXlaTensor(XLATensor::upsample_nearest2d_backward(
-      grad_output_tensor,
-      GetOutputSizeWithScale(input_dim, scale_factors, output_size),
-      input_dim));
-}
-
-at::Tensor XLANativeFunctions::upsample_nearest2d(
     const at::Tensor& self, at::IntArrayRef output_size,
     c10::optional<double> scales_h, c10::optional<double> scales_w) {
   XLA_FN_COUNTER("xla::");
   XLATensorPtr self_tensor = bridge::GetXlaTensor(self);
+  absl::Span<const int64_t> input_dims =
+      self_tensor->shape().get().dimensions();
+  std::vector<int64_t> scaled_output_size =
+      torch::lazy::ToVector<int64_t>(output_size);
   if ((scales_h && *scales_h != 1.0) || (scales_w && *scales_w != 1.0)) {
-    return at::native::call_fallback_fn<
-        &xla_cpu_fallback, ATEN_OP(upsample_nearest2d)>::call(self, output_size,
-                                                              scales_h,
-                                                              scales_w);
+    scaled_output_size = GetOutputSizeWithScale(input_dims, scales_h, scales_w,
+                                                scaled_output_size);
   }
-  return bridge::AtenFromXlaTensor(XLATensor::upsample_nearest2d(
-      self_tensor, torch::lazy::ToVector<int64_t>(output_size)));
+  return bridge::AtenFromXlaTensor(
+      XLATensor::upsample_nearest2d(self_tensor, scaled_output_size));
 }
 
 at::Tensor XLANativeFunctions::upsample_nearest2d_backward(

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -688,11 +688,16 @@ at::Tensor XLANativeFunctions::atan2(const at::Tensor& self,
     return at::native::call_fallback_fn<&xla_cpu_fallback,
                                         ATEN_OP(atan2)>::call(self, other);
   }
-  return DoBinaryOp(self, other,
-                    [&](const XLATensorPtr& xself, const XLATensorPtr& xother,
-                        at::ScalarType dtype) {
-                      return XLATensor::atan2(xself, xother, dtype);
-                    });
+
+  auto common_device = torch_xla::bridge::GetXlaDevice(self, other);
+  XLA_CHECK(common_device);
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<Atan2>(
+      bridge::GetXlaTensor(self)->GetIrValue(),
+      bridge::GetXlaTensor(other)->GetIrValue(),
+      bridge::GetXlaTensor(at::result_type(self, other))->GetIrValue());
+
+  return torch_xla::bridge::AtenFromXlaTensor(
+      torch_xla::XLATensor::Create(std::move(node), *common_device));
 }
 
 at::Tensor XLANativeFunctions::avg_pool2d(

--- a/torch_xla/csrc/computation.cpp
+++ b/torch_xla/csrc/computation.cpp
@@ -26,7 +26,7 @@ Computation::Computation(std::string name, xla::XlaComputation computation,
 Computation::Computation(
     std::shared_ptr<xla::ComputationClient::Computation> xla_client_computation)
     : name_(""), hash_(0) {
-  xla_client_computation_ = xla_client_computation;
+  xla_client_computation_ = std::move(xla_client_computation);
 }
 
 std::vector<torch::lazy::ComputationPtr> WrapClientComputation(

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1610,8 +1610,8 @@ void InitXlaModuleBindings(py::module m) {
           xla::ComputationClient::ExecuteComputationOptions options;
           std::vector<std::shared_ptr<xla::ComputationClient::Data>> results =
               xla::ComputationClient::Get()->ExecuteComputation(
-                  *cachedComputation->computation, parameters_data, deviceStr,
-                  options);
+                  *cachedComputation->computation->client_computation(),
+                  parameters_data, deviceStr, options);
           std::vector<at::Tensor> retlist;
           {
             XLA_TIMED("RunCachedGraphOutputData");

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -77,7 +77,6 @@ PTXLA_UNARY_OP(Sqrt, at::aten::sqrt, xla::Sqrt);
 PTXLA_BINARY_OP(Min, at::aten::min, xla::Min);
 PTXLA_BINARY_OP(Pow, at::aten::pow, xla::Pow);
 PTXLA_BINARY_OP(Fmod, at::aten::fmod, xla::Rem);
-PTXLA_BINARY_OP(Atan2, at::aten::atan2, xla::Atan2);
 
 torch::lazy::NodePtr LogBase(const torch::lazy::Value& input,
                              torch::lazy::OpKind op, double base) {

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -75,9 +75,6 @@ torch::lazy::NodePtr Sin(const torch::lazy::Value& input);
 
 torch::lazy::NodePtr Sinh(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr Atan2(const torch::lazy::Value& input,
-                           const torch::lazy::Value& other);
-
 torch::lazy::NodePtr Tan(const torch::lazy::Value& input);
 
 torch::lazy::NodePtr Neg(const torch::lazy::Value& input);

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -120,6 +120,13 @@ torch_xla::XlaOpVector Atan::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::Atan(xla_input), loctx);
 }
 
+torch_xla::XlaOpVector Atan2::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  xla::XlaOp xla_other = loctx->GetOutputOp(operand(1));
+  auto promoted = XlaHelpers::Promote(xla_input, xla_other);
+  return ReturnOp(xla::Atan2(promoted.first, promoted.second), loctx);
+}
+
 torch_xla::XlaOpVector Atanh::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   return ReturnOp(xla::Atanh(xla_input), loctx);

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -193,6 +193,17 @@ xla::Shape AtanOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
+xla::Shape Atan2OutputShape(const torch::lazy::Value& input,
+                            const torch::lazy::Value& other) {
+  auto lower_for_shape_fn =
+      [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
+    auto promoted = XlaHelpers::Promote(operands[0], operands[1]);
+    return xla::Atan2(promoted.first, promoted.second);
+  };
+  return InferOutputShape({GetXlaShape(input), GetXlaShape(other)},
+                          lower_for_shape_fn);
+}
+
 xla::Shape AtanhOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -55,6 +55,9 @@ xla::Shape AtanOutputShape(const torch::lazy::Value& input);
 
 xla::Shape AtanhOutputShape(const torch::lazy::Value& input);
 
+xla::Shape Atan2OutputShape(const torch::lazy::Value& input,
+                            const torch::lazy::Value& other);
+
 xla::Shape BinaryCrossEntropyOutputShape(
     const torch::lazy::Value& input, const torch::lazy::Value& target,
     const c10::optional<torch::lazy::Value>& weight, int64_t reduction);

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1494,7 +1494,8 @@ std::shared_ptr<XLATensor::Async> XLATensor::ScheduleSyncTensorsGraph(
         TF_VLOG(3) << "Executing IR graph hash "
                    << torch::lazy::HashToString(hash) << " on all devices.";
         results = xla::ComputationClient::Get()->ExecuteReplicated(
-            *async->cached_computation->computation, device_arguments, devices,
+            *async->cached_computation->computation->client_computation(),
+            device_arguments, devices,
             execute_options)[0];  // TODO(yeounoh) assumes replicated outputs
         TF_VLOG(3) << "Executing IR graph hash "
                    << torch::lazy::HashToString(hash)
@@ -1504,7 +1505,7 @@ std::shared_ptr<XLATensor::Async> XLATensor::ScheduleSyncTensorsGraph(
                    << torch::lazy::HashToString(hash) << " on device "
                    << async->device << " ...";
         results = xla::ComputationClient::Get()->ExecuteComputation(
-            *async->cached_computation->computation,
+            *async->cached_computation->computation->client_computation(),
             UnwrapXlaData(async->parameters_data), async->device, options);
         TF_VLOG(3) << "Executing IR graph hash "
                    << torch::lazy::HashToString(hash) << " on device "
@@ -1824,7 +1825,8 @@ XLATensor::CompilationResult XLATensor::Compile(
 
   return {/*device=*/coll.device,
           /*emitted_nodes=*/lowering_ctx.GetEmittedNodeCount(),
-          /*computation=*/std::move(computations.front()),
+          /*computation=*/
+          std::make_shared<Computation>(std::move(computations.front())),
           /*parameters_data=*/std::move(po_data->parameters_data),
           /*is_sharded=*/is_sharded};
 }

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -428,10 +428,6 @@ class XLATensor : public c10::intrusive_ptr_target {
                           std::vector<int64_t> stride,
                           c10::optional<int64_t> storage_offset);
 
-  static XLATensorPtr atan2(
-      const XLATensorPtr& input, const XLATensorPtr& other,
-      c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
-
   static XLATensorPtr avg_pool_nd(const XLATensorPtr& input,
                                   int64_t spatial_dim_count,
                                   std::vector<int64_t> kernel_size,

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -1230,12 +1230,10 @@ class XLATensor : public c10::intrusive_ptr_target {
   const c10::Storage& Storage() const { return storage_; }
 
   struct CachedComputation {
-    CachedComputation(
-        std::shared_ptr<xla::ComputationClient::Computation> computation,
-        bool is_sharded = false)
+    CachedComputation(ComputationPtr computation, bool is_sharded = false)
         : computation(std::move(computation)), is_sharded(is_sharded) {}
 
-    std::shared_ptr<xla::ComputationClient::Computation> computation;
+    ComputationPtr computation;
     bool is_sharded;
   };
 
@@ -1277,7 +1275,7 @@ class XLATensor : public c10::intrusive_ptr_target {
   struct CompilationResult {
     torch::lazy::BackendDevice device;
     size_t emitted_nodes = 0;
-    std::shared_ptr<xla::ComputationClient::Computation> computation;
+    ComputationPtr computation;
     std::vector<torch::lazy::BackendDataPtr> parameters_data;
     bool is_sharded = false;
   };

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -711,13 +711,6 @@ void XLATensor::as_strided_(XLATensorPtr& input, std::vector<int64_t> size,
   }
 }
 
-XLATensorPtr XLATensor::atan2(
-    const XLATensorPtr& input, const XLATensorPtr& other,
-    c10::optional<at::ScalarType> logical_element_type) {
-  return input->CreateFrom(Atan2(input->GetIrValue(), other->GetIrValue()),
-                           logical_element_type);
-}
-
 XLATensorPtr XLATensor::avg_pool_nd(const XLATensorPtr& input,
                                     int64_t spatial_dim_count,
                                     std::vector<int64_t> kernel_size,

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -87,6 +87,7 @@ ir_gen:
   - _adaptive_avg_pool2d_backward
   - _adaptive_avg_pool3d
   - _adaptive_avg_pool3d_backward
+  - atan2
   - bitwise_and.Tensor
   - bitwise_or.Tensor
   - bitwise_xor.Tensor
@@ -128,7 +129,6 @@ supported:
   - argmin
   - as_strided
   - as_strided_
-  - atan2
   - avg_pool2d
   - avg_pool2d_backward
   - avg_pool3d

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -322,9 +322,7 @@ supported:
   - upsample_bilinear2d
   - upsample_bilinear2d_backward
   - upsample_nearest2d
-  - upsample_nearest2d.vec
   - upsample_nearest2d_backward
-  - upsample_nearest2d_backward.vec
   - var.correction
   - var_mean.correction
   - view

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -129,6 +129,7 @@ supported:
   - argmin
   - as_strided
   - as_strided_
+  - atan2
   - avg_pool2d
   - avg_pool2d_backward
   - avg_pool3d


### PR DESCRIPTION
partially codegen atan2

---

Generated `LazyIr.h`:

```
class Atan2 : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::atan2);
  }

  Atan2(const torch::lazy::Value& self, const torch::lazy::Value& other)
      : XlaNode(torch::lazy::OpKind(at::aten::atan2),
              {self, other},
              [&]() { return Atan2OutputShape(self, other); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
  {
    
  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();
    
    return ss.str();
  }

  

  bool CanBeReused(const torch::lazy::Value& self, const torch::lazy::Value& other) const {
    return false;
    }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;

  
  

};
```