### PR TITLE
Implement `xm.rendezvous` with XLA collective communication

### DIFF
--- a/test/pjrt/test_mesh_service.py
+++ b/test/pjrt/test_mesh_service.py
@@ -11,24 +11,37 @@ from torch_xla.experimental import pjrt
 class PjRtMeshServiceTest(parameterized.TestCase):
 
   @staticmethod
-  def _rendezvous_default(xrt_mesh_addr: Optional[str], replicas: List[int]):
-    if xrt_mesh_addr:
-      os.environ['XRT_MESH_SERVICE_ADDRESS'] = xrt_mesh_addr
-
+  def _rendezvous_static_size():
     payload = b'message %d' % xm.get_ordinal()
-    return xm.rendezvous("test rendezvous", payload, replicas)
+    return xm.rendezvous("test rendezvous", payload)
 
-  @parameterized.named_parameters(
-      ('defaults', None, []), ('xrt_address', 'localhost:9477', []),
-      ('four_replicas', None, [0, 1, 2, 3]), ('two_replicas', None, [0, 1]))
-  def test_rendezvous(self, xrt_mesh_addr, replicas):
-    results = pjrt._run_multiprocess(self._rendezvous_default, xrt_mesh_addr,
-                                     replicas)
-    replicas = replicas or list(range(len(results)))
+  def test_rendezvous_static_size(self):
+    results = pjrt._run_multiprocess(self._rendezvous_static_size)
 
-    for ordinal, value in results.items():
-      if ordinal in replicas or not replicas:
-        self.assertEqual(value, [b'message %d' % r for r in replicas])
+    expected = sorted([b'message %d' % r for r in results])
+    self.assertDictEqual(results, {r: expected for r in results})
+
+  @staticmethod
+  def _rendezvous_dynamic_size():
+    payload = b'message' * xm.get_ordinal()
+    return xm.rendezvous("test rendezvous", payload)
+
+  def test_rendezvous_dynamic_size(self):
+    results = pjrt._run_multiprocess(self._rendezvous_dynamic_size)
+
+    expected = sorted([b'message' * r for r in results])
+    self.assertDictEqual(results, {r: expected for r in results})
+
+  @staticmethod
+  def _rendezvous_replica_groups():
+    replicas = list(range(pjrt.global_device_count()))
+    return xm.rendezvous("test rendezvous", b'message', replicas)
+
+  def test_rendezvous_replica_groups(self):
+    results = pjrt._run_multiprocess(self._rendezvous_replica_groups)
+
+    expected = [b'message'] * len(results)
+    self.assertDictEqual(results, {r: expected for r in results})
 
   @staticmethod
   def _mesh_reduce():

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -129,6 +129,7 @@ function run_op_tests {
   run_pjrt python3 "$CDIR/pjrt/test_experimental_pjrt.py"
   run_pjrt python3 "$CDIR/pjrt/test_experimental_tpu.py"
   run_pjrt python3 "$CDIR/pjrt/test_ddp.py"
+  run_pjrt python3 "$CDIR/pjrt/test_mesh_service.py"
   run_pjrt python3 "$CDIR/test_xla_sharding.py"
   run_test python3 "$CDIR/test_operations_hlo.py" "$@" --verbosity=$VERBOSITY
 }

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -264,7 +264,7 @@ def rendezvous(tag: str, payload: bytes,
   """Share `payload` with all replicas in `ordinals`.
 
   All of PjRt is experimental right now, but consider `rendezvous` to be _very_
-  experimental. Only tested on TPU v4.
+  experimental.
 
   `tag` is ignored except for logging.
 
@@ -296,7 +296,8 @@ def rendezvous(tag: str, payload: bytes,
   sizes = xm.all_gather(size)
 
   # Pad data to at least length 1, otherwise we can't split the result
-  max_size = torch.max(torch.tensor(1, device=device, dtype=torch.int), torch.max(sizes))
+  max_size = torch.max(
+      torch.tensor(1, device=device, dtype=torch.int), torch.max(sizes))
   xm.mark_step()
 
   padded_data = torch.nn.functional.pad(data, (


### PR DESCRIPTION
We have found that `gloo` doesn't scale effectively to large pod sizes, and it's not easily possible to use `torch.distributed` in a multithreaded context such as TPU v3.

- `xm.rendezvous` will now call `xm.mark_step` to sync results from XLA.
- Support multithreaded contexts like TPU v2/v3.
- Don't initialize an XLA process group in `xm.rendezvous`. Also remove initialization based on `XRT_MESH_SERVICE_ADDRESS` since host 0 is not predictable anyway.
- Require that user calls `xm.rendezvous` from _all_ replicas per [XLA requirements](https://www.tensorflow.org/xla/operation_semantics#allreduce): `Computing the result of AllReduce requires having one input from each replica, so if one replica executes a AllReduce node more times than another, then the former replica will wait forever.` This covers the vast majority of the usage of `rendezvous` in our experience.

Tested manually on a TPU v4-8 with 1 process and 4 threads to simulate a v3.