### PR TITLE
Fix check_tensor_need_materialization

### DIFF
--- a/test/dynamo/test_dynamo_integrations_util.py
+++ b/test/dynamo/test_dynamo_integrations_util.py
@@ -47,7 +47,8 @@ class PybindTest(unittest.TestCase):
     assert (torch_xla._XLAC._check_tensor_need_materialization([t1]) == [False])
     t1 = t1.to(xla_device)
     assert (torch_xla._XLAC._check_tensor_need_materialization([t1]) == [False])
-    # call mark_step to clear pending irs on t1. This should
+    # call mark_step to clear pending irs on t1. This should test the case where
+    # XLATensor has a `XLAData` instead of a `DeviceData` IR.
     xm.mark_step()
     assert (torch_xla._XLAC._check_tensor_need_materialization([t1]) == [False])
     t2 = t1 * 2

--- a/test/dynamo/test_dynamo_integrations_util.py
+++ b/test/dynamo/test_dynamo_integrations_util.py
@@ -47,6 +47,9 @@ class PybindTest(unittest.TestCase):
     assert (torch_xla._XLAC._check_tensor_need_materialization([t1]) == [False])
     t1 = t1.to(xla_device)
     assert (torch_xla._XLAC._check_tensor_need_materialization([t1]) == [False])
+    # call mark_step to clear pending irs on t1. This should
+    xm.mark_step()
+    assert (torch_xla._XLAC._check_tensor_need_materialization([t1]) == [False])
     t2 = t1 * 2
     assert (torch_xla._XLAC._check_tensor_need_materialization([t1]) == [False])
     assert (torch_xla._XLAC._check_tensor_need_materialization([t2]) == [True])

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1534,7 +1534,7 @@ void InitXlaModuleBindings(py::module m) {
             need_materialization.push_back(false);
           } else if (xtensor->CurrentXlaData() != nullptr) {
             // input tensor has xla_data which means it is already on device
-            need_materialization.push_back(true);
+            need_materialization.push_back(false);
           } else if (xtensor->CurrentIrValue().node != nullptr) {
             torch::lazy::NodePtr node = xtensor->CurrentIrValue().node;
             if (torch_xla::DeviceData::Cast(


### PR DESCRIPTION
Fix https://github.com/pytorch/xla/issues/4183,

a tensor that already has `xla_data` does not need to be materialized.

FYI @shunting314 