### PR TITLE
[LTC] Use getBackend()->ExecuteComputation()

### DIFF
--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1579,26 +1579,20 @@ void InitXlaModuleBindings(py::module m) {
                                        << torch::lazy::HashToString(hash)
                                        << ". Maybe the entry get "
                                           "kicked out of the LRU cache";
-          std::vector<xla::ComputationClient::DataPtr> parameters_data;
+          std::vector<torch::lazy::BackendDataPtr> parameters_data;
           torch::lazy::BackendDevice device = torch_xla::GetCurrentDevice();
           {
             XLA_TIMED("RunCachedGraphInputData");
             // setup the parameters_data
             int idx = 0;
             for (auto& ivalue : graph_inputs) {
-              at::Tensor tensor = ivalue.toTensor();
-              XLATensorPtr xla_tensor_ptr = bridge::TryGetXlaTensor(tensor);
-              xla::ComputationClient::DataPtr dataptr;
-              if (xla_tensor_ptr) {
-                torch::lazy::BackendDataPtr backend_data_ptr =
-                    xla_tensor_ptr->GetXlaData();
+              torch::lazy::BackendDataPtr dataptr;
+              if (auto xla_tensor_ptr = bridge::TryGetXlaTensor(ivalue.toTensor())) {
                 dataptr =
-                    dynamic_cast<torch_xla::XLAData*>(backend_data_ptr.get())
-                        ->xla_data();
+                    xla_tensor_ptr->GetXlaData();
               } else {
-                torch::lazy::BackendDataPtr backend_data =
+                dataptr =
                     torch_xla::TensorToXlaData(ivalue.toTensor(), device);
-                dataptr = ((torch_xla::XLAData*)backend_data.get())->xla_data();
               }
 
               ++idx;
@@ -1606,11 +1600,10 @@ void InitXlaModuleBindings(py::module m) {
             }
           }
 
-          std::string deviceStr = device.toString();
-          std::vector<std::shared_ptr<xla::ComputationClient::Data>> results =
-              xla::ComputationClient::Get()->ExecuteComputation(
-                  *cachedComputation->computation->client_computation(),
-                  parameters_data, deviceStr);
+          auto results =
+              torch::lazy::getBackend()->ExecuteComputation(
+                  cachedComputation->computation,
+                  parameters_data, device);
           std::vector<at::Tensor> retlist;
           {
             XLA_TIMED("RunCachedGraphOutputData");
@@ -1618,7 +1611,7 @@ void InitXlaModuleBindings(py::module m) {
             int i = 0;
             for (auto& data : results) {
               XLATensorPtr xla_tensor =
-                  torch_xla::XLATensor::Create(torch_xla::WrapXlaData(data));
+                  torch_xla::XLATensor::Create(data);
               retlist.push_back(bridge::AtenFromXlaTensor(xla_tensor));
               ++i;
             }

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1587,12 +1587,11 @@ void InitXlaModuleBindings(py::module m) {
             int idx = 0;
             for (auto& ivalue : graph_inputs) {
               torch::lazy::BackendDataPtr dataptr;
-              if (auto xla_tensor_ptr = bridge::TryGetXlaTensor(ivalue.toTensor())) {
-                dataptr =
-                    xla_tensor_ptr->GetXlaData();
+              if (auto xla_tensor_ptr =
+                      bridge::TryGetXlaTensor(ivalue.toTensor())) {
+                dataptr = xla_tensor_ptr->GetXlaData();
               } else {
-                dataptr =
-                    torch_xla::TensorToXlaData(ivalue.toTensor(), device);
+                dataptr = torch_xla::TensorToXlaData(ivalue.toTensor(), device);
               }
 
               ++idx;
@@ -1600,18 +1599,15 @@ void InitXlaModuleBindings(py::module m) {
             }
           }
 
-          auto results =
-              torch::lazy::getBackend()->ExecuteComputation(
-                  cachedComputation->computation,
-                  parameters_data, device);
+          auto results = torch::lazy::getBackend()->ExecuteComputation(
+              cachedComputation->computation, parameters_data, device);
           std::vector<at::Tensor> retlist;
           {
             XLA_TIMED("RunCachedGraphOutputData");
             // Convert result back to at::tensor
             int i = 0;
             for (auto& data : results) {
-              XLATensorPtr xla_tensor =
-                  torch_xla::XLATensor::Create(data);
+              XLATensorPtr xla_tensor = torch_xla::XLATensor::Create(data);
               retlist.push_back(bridge::AtenFromXlaTensor(xla_tensor));
               ++i;
             }

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1504,15 +1504,15 @@ std::shared_ptr<XLATensor::Async> XLATensor::ScheduleSyncTensorsGraph(
                    << torch::lazy::HashToString(hash) << " on device "
                    << async->device << " ...";
         results = torch::lazy::getBackend()->ExecuteComputation(
-            async->cached_computation->computation,
-            async->parameters_data, ParseDeviceString(async->device));
+            async->cached_computation->computation, async->parameters_data,
+            ParseDeviceString(async->device));
         TF_VLOG(3) << "Executing IR graph hash "
                    << torch::lazy::HashToString(hash) << " on device "
                    << async->device << " done!";
       }
       for (size_t i = 0; i < results.size(); ++i) {
         if (async->tensors_data[i] != nullptr) {
-         async->tensors_data[i]->Assign(*results[i]);
+          async->tensors_data[i]->Assign(*results[i]);
         } else {
           async->tensors_data[i] = std::move(results[i]);
         }

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1479,7 +1479,7 @@ std::shared_ptr<XLATensor::Async> XLATensor::ScheduleSyncTensorsGraph(
 
   auto syncfn = [async, hash = coll->hash]() {
     try {
-      std::vector<xla::ComputationClient::DataPtr> results;
+      std::vector<torch::lazy::BackendDataPtr> results;
       // Execute replicated if the compiled computation is partitioned.
       if (async->cached_computation->is_sharded) {
         std::vector<std::string> devices =
@@ -1491,10 +1491,11 @@ std::shared_ptr<XLATensor::Async> XLATensor::ScheduleSyncTensorsGraph(
 
         TF_VLOG(3) << "Executing IR graph hash "
                    << torch::lazy::HashToString(hash) << " on all devices.";
-        results = xla::ComputationClient::Get()->ExecuteReplicated(
+        // TODO(jwtan): Remove the WrapXlaData when inherits LazyGraphExecutor.
+        results = WrapXlaData(xla::ComputationClient::Get()->ExecuteReplicated(
             *async->cached_computation->computation->client_computation(),
             device_arguments, devices,
-            execute_options)[0];  // TODO(yeounoh) assumes replicated outputs
+            execute_options)[0]);  // TODO(yeounoh) assumes replicated outputs
         TF_VLOG(3) << "Executing IR graph hash "
                    << torch::lazy::HashToString(hash)
                    << " on all devices, done!";
@@ -1502,18 +1503,18 @@ std::shared_ptr<XLATensor::Async> XLATensor::ScheduleSyncTensorsGraph(
         TF_VLOG(3) << "Executing IR graph hash "
                    << torch::lazy::HashToString(hash) << " on device "
                    << async->device << " ...";
-        results = xla::ComputationClient::Get()->ExecuteComputation(
-            *async->cached_computation->computation->client_computation(),
-            UnwrapXlaData(async->parameters_data), async->device);
+        results = torch::lazy::getBackend()->ExecuteComputation(
+            async->cached_computation->computation,
+            async->parameters_data, ParseDeviceString(async->device));
         TF_VLOG(3) << "Executing IR graph hash "
                    << torch::lazy::HashToString(hash) << " on device "
                    << async->device << " done!";
       }
       for (size_t i = 0; i < results.size(); ++i) {
         if (async->tensors_data[i] != nullptr) {
-          UnwrapXlaData(async->tensors_data[i])->Assign(*results[i]);
+         async->tensors_data[i]->Assign(*results[i]);
         } else {
-          async->tensors_data[i] = WrapXlaData(std::move(results[i]));
+          async->tensors_data[i] = std::move(results[i]);
         }
       }
     } catch (...) {


### PR DESCRIPTION
Summary:
This patch replaces all uses of xla::ComputationClient::Get()->ExecuteComputation() with torch::lazy::getBackend()->ExecuteComputation() such that it's consistent with upstream.

Test Plan:
CI