### PR TITLE
[LTC] Adopt getBackend()->GetComputationDataFromNode()

### DIFF
--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1493,7 +1493,8 @@ void InitXlaModuleBindings(py::module m) {
               data_handles;
 
           for (const torch::lazy::Node* nodeptr : post_order) {
-            const auto backend_data = torch::lazy::getBackend()->GetComputationDataFromNode(nodeptr);
+            const auto backend_data =
+                torch::lazy::getBackend()->GetComputationDataFromNode(nodeptr);
             auto* infoptr =
                 static_cast<torch::lazy::LazyGraphExecutor::DeviceDataInfo*>(
                     backend_data->info());

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1493,12 +1493,7 @@ void InitXlaModuleBindings(py::module m) {
               data_handles;
 
           for (const torch::lazy::Node* nodeptr : post_order) {
-            const torch_xla::DeviceData* device_data =
-                torch_xla::DeviceData::Cast(nodeptr);
-            if (!device_data) {
-              continue;
-            }
-            const auto& backend_data = device_data->data();
+            const auto backend_data = torch::lazy::getBackend()->GetComputationDataFromNode(nodeptr);
             auto* infoptr =
                 static_cast<torch::lazy::LazyGraphExecutor::DeviceDataInfo*>(
                     backend_data->info());

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1495,6 +1495,9 @@ void InitXlaModuleBindings(py::module m) {
           for (const torch::lazy::Node* nodeptr : post_order) {
             const auto backend_data =
                 torch::lazy::getBackend()->GetComputationDataFromNode(nodeptr);
+            if (!backend_data) {
+              continue;
+            }
             auto* infoptr =
                 static_cast<torch::lazy::LazyGraphExecutor::DeviceDataInfo*>(
                     backend_data->info());

--- a/torch_xla/csrc/op_by_op_executor.cpp
+++ b/torch_xla/csrc/op_by_op_executor.cpp
@@ -123,7 +123,8 @@ std::vector<xla::ComputationClient::ExecuteChainedOp> OpByOpExecutor::BuildOps(
   for (size_t i = 0; i < post_order.size(); ++i) {
     const torch::lazy::Node* node = post_order[i];
     xla::ComputationClient::ExecuteChainedOp& cxop = chained_exec_ops[i];
-    const auto backend_data = torch::lazy::getBackend()->GetComputationDataFromNode(node);
+    const auto backend_data =
+        torch::lazy::getBackend()->GetComputationDataFromNode(node);
     if (backend_data != nullptr) {
       cxop.device_data = UnwrapXlaData(backend_data);
       ops_shapes[i] = &cxop.device_data->shape();

--- a/torch_xla/csrc/op_by_op_executor.cpp
+++ b/torch_xla/csrc/op_by_op_executor.cpp
@@ -123,9 +123,9 @@ std::vector<xla::ComputationClient::ExecuteChainedOp> OpByOpExecutor::BuildOps(
   for (size_t i = 0; i < post_order.size(); ++i) {
     const torch::lazy::Node* node = post_order[i];
     xla::ComputationClient::ExecuteChainedOp& cxop = chained_exec_ops[i];
-    const DeviceData* device_data = DeviceData::Cast(node);
-    if (device_data != nullptr) {
-      cxop.device_data = UnwrapXlaData(device_data->data());
+    const auto backend_data = torch::lazy::getBackend()->GetComputationDataFromNode(node);
+    if (backend_data != nullptr) {
+      cxop.device_data = UnwrapXlaData(backend_data);
       ops_shapes[i] = &cxop.device_data->shape();
       device_data_ops[i] = true;
     } else {

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1372,22 +1372,22 @@ XLATensor::PostOrderData XLATensor::RunPostOrder(
       data_handles;
 
   for (auto node : po_data.post_order) {
-    const DeviceData* device_data = DeviceData::Cast(node);
-    if (device_data != nullptr) {
+    const auto backend_data = torch::lazy::getBackend()->GetComputationDataFromNode(node);
+    if (backend_data != nullptr) {
       /* Acceptable race condition: HasValue may return false. This is OK
        * since the conditional barrier is a performance optimization. */
-      if (!device_data->data()->HasValue()) {
+      if (!backend_data->HasValue()) {
         TensorCollectionBarrier(coll);
       }
       xla::ComputationClient::Data::OpaqueHandle handle =
-          device_data->data()->GetHandle();
+          backend_data->GetHandle();
       auto it = data_handles.find(handle);
       if (it != data_handles.end()) {
         po_data.parameter_sequence.push_back(it->second);
       } else {
         po_data.parameter_sequence.push_back(po_data.parameters_data.size());
         data_handles[handle] = po_data.parameters_data.size();
-        po_data.parameters_data.push_back(device_data->data());
+        po_data.parameters_data.push_back(backend_data);
       }
     }
   }
@@ -1981,10 +1981,9 @@ int64_t XLATensor::GetOpaqueHandle() const {
   if (xla_data != nullptr) {
     return UnwrapXlaData(xla_data)->GetOpaqueHandle();
   }
-  const torch_xla::DeviceData* device_data =
-      torch_xla::DeviceData::Cast(GetIrValue().node.get());
-  if (device_data) {
-    return device_data->data()->GetHandle();
+  const auto backend_data = torch::lazy::getBackend()->GetComputationDataFromNode(GetIrValue().node.get());
+  if (backend_data) {
+    return backend_data->GetHandle();
   } else {
     XLA_CHECK(false) << "XlaTensor does not have data handle";
   }

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -785,7 +785,6 @@ torch::lazy::Value XLATensor::GetDeviceDataIrValue(
     const torch::lazy::BackendDevice& device) {
   torch::lazy::BackendDataPtr data =
       GetDeviceData(value, TensorTypeFromXlaType(type), device);
-  // TODO: consider using upstream info class if possible
   data->SetInfo(
       std::make_shared<torch::lazy::LazyGraphExecutor::DeviceDataInfo>(
           /*tensor_id=*/-1, /*read_only=*/true));

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1372,7 +1372,8 @@ XLATensor::PostOrderData XLATensor::RunPostOrder(
       data_handles;
 
   for (auto node : po_data.post_order) {
-    const auto backend_data = torch::lazy::getBackend()->GetComputationDataFromNode(node);
+    const auto backend_data =
+        torch::lazy::getBackend()->GetComputationDataFromNode(node);
     if (backend_data != nullptr) {
       /* Acceptable race condition: HasValue may return false. This is OK
        * since the conditional barrier is a performance optimization. */
@@ -1981,7 +1982,9 @@ int64_t XLATensor::GetOpaqueHandle() const {
   if (xla_data != nullptr) {
     return UnwrapXlaData(xla_data)->GetOpaqueHandle();
   }
-  const auto backend_data = torch::lazy::getBackend()->GetComputationDataFromNode(GetIrValue().node.get());
+  const auto backend_data =
+      torch::lazy::getBackend()->GetComputationDataFromNode(
+          GetIrValue().node.get());
   if (backend_data) {
     return backend_data->GetHandle();
   } else {


### PR DESCRIPTION
Summary:
This patch tries replace DeviceData::Cast() with getBackend()->GetComputationDataFromNode() where it can simplify the code.

Test Plan:
CI