### PR TITLE
Experimental TPU implementation of DistributedDataParallel

### DIFF
--- a/test/distributed_util.py
+++ b/test/distributed_util.py
@@ -68,10 +68,7 @@ def init_xla_backend():
   rank = xm.get_ordinal()
   world_size = xm.xrt_world_size()
 
-  dist.init_process_group(
-      "xla",
-      rank=rank,
-      world_size=world_size)
+  dist.init_process_group("xla", rank=rank, world_size=world_size)
   return rank, world_size
 
 

--- a/test/pjrt/test_ddp.py
+++ b/test/pjrt/test_ddp.py
@@ -1,8 +1,11 @@
 from absl.testing import absltest, parameterized
 import os
 import sys
+import torch.distributed as dist
 import torch.nn as nn
-from torch.nn.parallel import DistributedDataParallel as DDP
+# TODO: fix this
+# from torch.nn.parallel import DistributedDataParallel as DDP
+from torch_xla.experimental.pjrt import DistributedDataParallel as DDP
 import torch_xla.core.xla_model as xm
 from torch_xla.experimental import pjrt
 
@@ -20,7 +23,8 @@ class TestPjRtDistributedDataParallel(parameterized.TestCase):
 
   @staticmethod
   def _ddp_init(init_file: str):
-    util.init_xla_backend(init_file)
+    if not dist.is_initialized():
+      util.init_xla_backend(init_file)
 
     device = xm.xla_device()
     model = nn.Linear(10, 10).to(device)

--- a/test/pjrt/test_ddp.py
+++ b/test/pjrt/test_ddp.py
@@ -19,7 +19,7 @@ import distributed_util as util
 FLAGS = args_parse.parse_common_options()
 
 ddp_parameters = [('torch_xla', pjrt.DistributedDataParallel)]
-if tpu.version() >= 4:
+if pjrt.device_type() == 'TPU' and tpu.version() >= 4:
   ddp_parameters.append(('torch', torch.nn.parallel.DistributedDataParallel))
 
 

--- a/test/pjrt/test_ddp.py
+++ b/test/pjrt/test_ddp.py
@@ -26,32 +26,26 @@ class TestPjRtDistributedDataParallel(parameterized.TestCase):
     ddp_model = ddp(model)
 
   @parameterized.named_parameters(
-    ('torch', torch.nn.parallel.DistributedDataParallel),
-    ('torch_xla', pjrt.DistributedDataParallel),
+      ('torch', torch.nn.parallel.DistributedDataParallel),
+      ('torch_xla', pjrt.DistributedDataParallel),
   )
   def test_ddp_init(self, ddp: type):
     pjrt._run_multiprocess(self._ddp_init, ddp)
 
   @parameterized.named_parameters(
-    ('torch', torch.nn.parallel.DistributedDataParallel),
-    ('torch_xla', pjrt.DistributedDataParallel),
+      ('torch', torch.nn.parallel.DistributedDataParallel),
+      ('torch_xla', pjrt.DistributedDataParallel),
   )
   def test_ddp_correctness(self, ddp: type):
-    pjrt._run_multiprocess(
-        util.ddp_correctness,
-        ddp=ddp,
-        debug=FLAGS.debug)
+    pjrt._run_multiprocess(util.ddp_correctness, ddp=ddp, debug=FLAGS.debug)
 
   @parameterized.named_parameters(
-    ('torch', torch.nn.parallel.DistributedDataParallel),
-    ('torch_xla', pjrt.DistributedDataParallel),
+      ('torch', torch.nn.parallel.DistributedDataParallel),
+      ('torch_xla', pjrt.DistributedDataParallel),
   )
   def test_ddp_correctness_large_net(self, ddp: type):
     pjrt._run_multiprocess(
-        util.ddp_correctness,
-        ddp=ddp,
-        use_large_net=True,
-        debug=FLAGS.debug)
+        util.ddp_correctness, ddp=ddp, use_large_net=True, debug=FLAGS.debug)
 
 
 if __name__ == "__main__":

--- a/test/pjrt/test_ddp.py
+++ b/test/pjrt/test_ddp.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from absl.testing import absltest, parameterized
 import os
 import sys
@@ -6,6 +7,7 @@ import torch.nn as nn
 import torch.nn.parallel
 import torch_xla.core.xla_model as xm
 from torch_xla.experimental import pjrt
+from torch_xla.experimental import tpu
 
 # Setup import folders.
 xla_test_folder = os.path.dirname(os.path.dirname(os.path.abspath(sys.argv[0])))
@@ -16,8 +18,15 @@ import distributed_util as util
 
 FLAGS = args_parse.parse_common_options()
 
+ddp_parameters = [('torch_xla', pjrt.DistributedDataParallel)]
+if tpu.version() >= 4:
+  ddp_parameters.append(('torch', torch.nn.parallel.DistributedDataParallel))
+
 
 class TestPjRtDistributedDataParallel(parameterized.TestCase):
+
+  def setUp(self):
+    os.environ['PJRT_INIT_TORCH_DISTRIBUTED'] = '1'
 
   @staticmethod
   def _ddp_init(ddp):
@@ -25,24 +34,20 @@ class TestPjRtDistributedDataParallel(parameterized.TestCase):
     model = nn.Linear(10, 10).to(device)
     ddp_model = ddp(model)
 
-  @parameterized.named_parameters(
-      ('torch', torch.nn.parallel.DistributedDataParallel),
-      ('torch_xla', pjrt.DistributedDataParallel),
-  )
+  @parameterized.named_parameters(*ddp_parameters)
   def test_ddp_init(self, ddp: type):
     pjrt._run_multiprocess(self._ddp_init, ddp)
 
-  @parameterized.named_parameters(
-      ('torch', torch.nn.parallel.DistributedDataParallel),
-      ('torch_xla', pjrt.DistributedDataParallel),
-  )
+  def test_ddp_init_no_distributed(self):
+    with self.assertRaises(RuntimeError):
+      with mock.patch.dict(os.environ, {'PJRT_INIT_TORCH_DISTRIBUTED': '0'}):
+        pjrt._run_multiprocess(self._ddp_init, pjrt.DistributedDataParallel)
+
+  @parameterized.named_parameters(*ddp_parameters)
   def test_ddp_correctness(self, ddp: type):
     pjrt._run_multiprocess(util.ddp_correctness, ddp=ddp, debug=FLAGS.debug)
 
-  @parameterized.named_parameters(
-      ('torch', torch.nn.parallel.DistributedDataParallel),
-      ('torch_xla', pjrt.DistributedDataParallel),
-  )
+  @parameterized.named_parameters(*ddp_parameters)
   def test_ddp_correctness_large_net(self, ddp: type):
     pjrt._run_multiprocess(
         util.ddp_correctness, ddp=ddp, use_large_net=True, debug=FLAGS.debug)

--- a/test/test_ddp.py
+++ b/test/test_ddp.py
@@ -22,7 +22,7 @@ class TestXrtDistributedDataParallel(parameterized.TestCase):
           'Default device {} is not a TPU device'.format(device),
           file=sys.stderr)
       return
-    util.ddp_correctness(None, use_large_net=use_large_net, debug=debug)
+    util.ddp_correctness(use_large_net=use_large_net, debug=debug)
 
   def test_ddp_correctness(self):
     xmp.spawn(self._ddp_correctness, args=(False, FLAGS.debug))

--- a/third_party/xla_client/computation_client.h
+++ b/third_party/xla_client/computation_client.h
@@ -298,6 +298,10 @@ class ComputationClient {
 
   virtual std::vector<std::string> GetAllDevices() const = 0;
 
+  virtual int GetProcessIndex() const = 0;
+
+  virtual int GetNumProcesses() const = 0;
+
   virtual void SetReplicationDevices(
       std::shared_ptr<std::vector<std::string>> devices) = 0;
 

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -402,6 +402,15 @@ std::vector<std::string> PjRtComputationClient::GetAllDevices() const {
   return PjRtDevicesToString(client_->devices());
 }
 
+int PjRtComputationClient::GetNumProcesses() const {
+  int max_process_index = client_->process_index();
+  for (auto* device : client_->devices()) {
+    max_process_index = std::max(max_process_index, device->process_index());
+  }
+
+  return max_process_index + 1;
+};
+
 void PjRtComputationClient::SetReplicationDevices(
     std::shared_ptr<std::vector<std::string>> devices) {
   replication_devices_ = std::move(devices);

--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -54,6 +54,10 @@ class PjRtComputationClient : public ComputationClient {
 
   std::vector<std::string> GetAllDevices() const override;
 
+  int GetProcessIndex() const override { return client_->process_index(); };
+
+  int GetNumProcesses() const override;
+
   void SetReplicationDevices(
       std::shared_ptr<std::vector<std::string>> devices) override;
 

--- a/third_party/xla_client/xrt_computation_client.h
+++ b/third_party/xla_client/xrt_computation_client.h
@@ -303,6 +303,14 @@ class XrtComputationClient : public ComputationClient {
 
   std::vector<std::string> GetAllDevices() const override;
 
+  int GetProcessIndex() const override {
+    XLA_ERROR() << __FUNCTION__ << " not implemented";
+  }
+
+  int GetNumProcesses() const override {
+    XLA_ERROR() << __FUNCTION__ << " not implemented";
+  }
+
   void SetReplicationDevices(
       std::shared_ptr<std::vector<std::string>> devices) override;
 

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1149,6 +1149,12 @@ void InitXlaModuleBindings(py::module m) {
         bridge::AtenDeviceToXlaDevice(device_str);
     return device.ordinal();
   });
+  m.def("_xla_get_process_index", []() {
+    return xla::ComputationClient::Get()->GetProcessIndex();
+  });
+  m.def("_xla_get_num_processes", []() {
+    return xla::ComputationClient::Get()->GetNumProcesses();
+  });
   m.def("_xla_get_device_ordinal", [](const std::string& device_str) {
     return bridge::AtenDeviceToXlaDevice(device_str).ordinal();
   });

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1149,12 +1149,10 @@ void InitXlaModuleBindings(py::module m) {
         bridge::AtenDeviceToXlaDevice(device_str);
     return device.ordinal();
   });
-  m.def("_xla_get_process_index", []() {
-    return xla::ComputationClient::Get()->GetProcessIndex();
-  });
-  m.def("_xla_get_num_processes", []() {
-    return xla::ComputationClient::Get()->GetNumProcesses();
-  });
+  m.def("_xla_get_process_index",
+        []() { return xla::ComputationClient::Get()->GetProcessIndex(); });
+  m.def("_xla_get_num_processes",
+        []() { return xla::ComputationClient::Get()->GetNumProcesses(); });
   m.def("_xla_get_device_ordinal", [](const std::string& device_str) {
     return bridge::AtenDeviceToXlaDevice(device_str).ordinal();
   });

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -374,7 +374,11 @@ class DistributedDataParallel(nn.Module):
     """Average gradients across replicas."""
     return xm.all_reduce(xm.REDUCE_SUM, grad, scale=1. / global_device_count())
 
-  def __init__(self, module: nn.Module, *, broadcast_buffers: bool=True, **kwargs):
+  def __init__(self,
+               module: nn.Module,
+               *,
+               broadcast_buffers: bool = True,
+               **kwargs):
     super().__init__()
 
     if kwargs:

--- a/torch_xla/experimental/tpu.py
+++ b/torch_xla/experimental/tpu.py
@@ -1,6 +1,7 @@
 import functools
 import operator
 import os
+import re
 from typing import Dict, NamedTuple, Optional, List, Tuple
 import requests
 import yaml
@@ -85,6 +86,16 @@ def get_tpu_env() -> Dict[str, str]:
   metadata = _get_metadata('tpu-env')
 
   return yaml.load(metadata, yaml.Loader)
+
+
+def version() -> int:
+  try:
+    env = get_tpu_env()
+  except requests.HTTPError as e:
+    raise EnvironmentError('Failed to get TPU metadata') from e
+
+  match = re.match(r'^v(\d)-(\d+)$', env['ACCELERATOR_TYPE'])
+  return int(match.groups()[0])
 
 
 def get_worker_ips() -> List[str]:


### PR DESCRIPTION
- Adds experimental implementation of DDP that works on TPU v3 and gives moderately better performance on TPU v4 (1805 ex/sec/replica vs 1710 ex/sec/replica in my experiments).
- Add C++ methods to get PJRT process index and process count (similar to JAX)
- Initialize `torch.distributed` in `pjrt.spawn`, since the master address and process ranks are not predictable on TPU.
- Tweak learning rate and `atol` in DDP tests. The LR was so small that the parameter comparison always passed, even when I had errors in my code.
- Don't broadcast buffers in ResNet50 example to match native XLA distributed implementation.
- Test PJRT with both upstream and experimental DDP.

Tested with PJRT and XRT:

```
XRT_TPU_CONFIG="localservice;0;localhost:51011" TPU_NUM_DEVICES=4 MASTER_ADDR=localhost MASTER_PORT=12355 python pytorch/xla/test/test_ddp.py
PJRT_DEVICE=TPU python pytorch/xla/test/pjrt/test_ddp.py
```