### PR TITLE
Run cached graph api should grab device lock first

### DIFF
--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1598,7 +1598,7 @@ void InitXlaModuleBindings(py::module m) {
             }
           }
 
-          auto results = torch::lazy::getBackend()->ExecuteComputation(
+          auto results = XLATensor::ExecuteComputationWithBarrier(
               cachedComputation->computation, parameters_data, device);
           std::vector<at::Tensor> retlist;
           {

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -148,8 +148,14 @@ class DeviceLockerArena {
 
 xla::util::ExceptionCleanup LockDevice(
     const torch::lazy::BackendDevice& device) {
-  auto locker = DeviceLockerArena::Get()->GetLocker(device);
-  locker->Lock();
+  TF_VLOG(4) << "Waiting on device barrier for device " << device << " ...";
+  std::shared_ptr<DeviceLocker> locker;
+  {
+    XLA_TIMED("DeviceLockWait");
+    locker = DeviceLockerArena::Get()->GetLocker(device);
+    locker->Lock();
+  }
+  TF_VLOG(4) << "Waiting on device barrier for device " << device << " done!";
   return xla::util::ExceptionCleanup(
       [locker =
            std::move(locker)](xla::util::ExceptionCleanup::StatusType status) {
@@ -1039,15 +1045,19 @@ void XLATensor::TensorCollectionBarrier(SyncTensorCollection* coll) {
       coll->unlocker.size() > 0) {
     return;
   }
-  TF_VLOG(4) << "Waiting on device barrier for device " << coll->device
-             << " ...";
-  {
-    // TODO(yeounoh) lock SPMD device
-    XLA_TIMED("DeviceLockWait");
-    coll->unlocker = LockDevices({coll->device});
-  }
-  TF_VLOG(4) << "Waiting on device barrier for device " << coll->device
-             << " done!";
+  // TODO(yeounoh) lock SPMD device
+  coll->unlocker = LockDevices({coll->device});
+}
+
+std::vector<torch::lazy::BackendDataPtr>
+XLATensor::ExecuteComputationWithBarrier(
+    torch::lazy::ComputationPtr computation,
+    c10::ArrayRef<torch::lazy::BackendDataPtr> arguments,
+    const torch::lazy::BackendDevice& device) {
+  std::vector<xla::util::ExceptionCleanup> unlocker;
+  unlocker = LockDevices({device});
+  return torch::lazy::getBackend()->ExecuteComputation(computation, arguments,
+                                                       device);
 }
 
 std::vector<at::Tensor> XLATensor::GetTensorsOpByOp(

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -1241,6 +1241,11 @@ class XLATensor : public c10::intrusive_ptr_target {
 
   int64_t GetOpaqueHandle() const;
 
+  static std::vector<torch::lazy::BackendDataPtr> ExecuteComputationWithBarrier(
+      torch::lazy::ComputationPtr computation,
+      c10::ArrayRef<torch::lazy::BackendDataPtr> arguments,
+      const torch::lazy::BackendDevice& device);
+
  private:
   struct SyncTensorsConfig {
     // Whether we want to force XLA data on the target tensors (hence trimming


### PR DESCRIPTION
We need to grab the device lock before execute the computation in `_run_cached_graph`. This is to prevent more than 1 graph being executed in the same time.

Current implementation we can only grab lock within `tensor.cpp` hence this change.

FYI @shunting314 @wconstab 