### PR TITLE
Add a api to reset and extract RNG Seed

### DIFF
--- a/test/dynamo/test_dynamo_integrations_util.py
+++ b/test/dynamo/test_dynamo_integrations_util.py
@@ -41,6 +41,11 @@ class PybindTest(unittest.TestCase):
     ])
     assert (expected_tensor_ids == sorted(res_pair[0]))
 
+  def test_reset_and_get_rng_seed(self):
+    device = xm.xla_device()
+    current_seed = xm.get_rng_state(device)
+    new_seed_tensor = torch_xla._XLAC._reset_and_get_rng_seed()
+
   def test_check_tensor_need_materialization(self):
     xla_device = xm.xla_device()
     t1 = torch.randn(20, 5)

--- a/test/dynamo/test_dynamo_integrations_util.py
+++ b/test/dynamo/test_dynamo_integrations_util.py
@@ -41,10 +41,19 @@ class PybindTest(unittest.TestCase):
     ])
     assert (expected_tensor_ids == sorted(res_pair[0]))
 
-  def test_reset_and_get_rng_seed(self):
+  def test_get_rng_seed_as_tensor(self):
     device = xm.xla_device()
     current_seed = xm.get_rng_state(device)
-    new_seed_tensor = torch_xla._XLAC._reset_and_get_rng_seed()
+    new_seed_tensor = torch_xla._XLAC._get_rng_seed_as_tensor(str(device), True)
+    self.assertNotEqual(current_seed, new_seed_tensor.item())
+    current_seed = xm.get_rng_state(device)
+    self.assertEqual(current_seed, new_seed_tensor.item())
+    new_seed_tensor_2 = torch_xla._XLAC._get_rng_seed_as_tensor(
+        str(device), False)
+    self.assertEqual(current_seed, new_seed_tensor_2.item())
+
+  def test_get_seed_info_id(self):
+    self.assertEqual(torch_xla._XLAC._get_seed_info_id(), -127389)
 
   def test_check_tensor_need_materialization(self):
     xla_device = xm.xla_device()

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1513,6 +1513,7 @@ void InitXlaModuleBindings(py::module m) {
             if (infoptr) {
               tensor_ids.push_back(infoptr->tensor_id);
             } else {
+              // TODO(JackCaoG): Make sure this device data is actually seed.
               tensor_ids.push_back(seed_info_id);
             }
             at::Tensor tensor = bridge::AtenFromXlaTensor(

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1527,12 +1527,12 @@ void InitXlaModuleBindings(py::module m) {
 
   m.def("_get_seed_info_id", []() -> int64_t { return seed_info_id; });
 
-  m.def("_reset_and_get_rng_seed",
-        [](const std::string& device_str) -> at::IValue {
+  m.def("_get_rng_seed_as_tensor",
+        [](const std::string& device_str, bool reset) -> at::IValue {
           torch::lazy::BackendDevice device =
               bridge::AtenDeviceToXlaDevice(c10::Device(device_str));
           return bridge::AtenFromXlaTensor(torch_xla::XLATensor::Create(
-              XLATensor::ResetAndGetRngSeedData(device)));
+              XLATensor::GetRngSeedData(device, reset)));
         });
 
   // Return true if value of the tensor requires a computation.

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -367,19 +367,25 @@ class XLATensor::DeviceContextArena {
     devctx->seed_ir_value = torch::lazy::Value();
   }
 
-  torch::lazy::BackendDataPtr ResetAndGetRngSeedData(
-      const torch::lazy::BackendDevice& device) {
+  torch::lazy::BackendDataPtr GetRngSeedData(
+      const torch::lazy::BackendDevice& device, bool reset) {
     static const at::ScalarType kSeedType = at::ScalarType::Long;
     DeviceContext* devctx = GetDeviceContext(device);
     std::lock_guard<std::mutex> lock(devctx->lock);
-    devctx->seed = 1012031 + devctx->seed * 7012063;
-    devctx->running_seed = devctx->seed;
-    at::Tensor tensor = at::scalar_tensor(MakeIntScalar(devctx->seed),
-                                          at::TensorOptions(kSeedType));
-    torch::lazy::BackendDataPtr device_data = TensorToXlaData(tensor, device);
-    devctx->seed_ir_value =
-        torch::lazy::MakeNode<DeviceData>(std::move(device_data));
-    return device_data;
+    if (reset) {
+      devctx->seed = 1012031 + devctx->seed * 7012063;
+      devctx->running_seed = devctx->seed;
+      at::Tensor tensor = at::scalar_tensor(MakeIntScalar(devctx->seed),
+                                            at::TensorOptions(kSeedType));
+      torch::lazy::BackendDataPtr device_data = TensorToXlaData(tensor, device);
+      devctx->seed_ir_value = torch::lazy::MakeNode<DeviceData>(device_data);
+    } else if (!devctx->seed_ir_value) {
+      devctx->seed_ir_value =
+          IrValueFromScalar(MakeIntScalar(devctx->seed), kSeedType, device);
+    }
+
+    return torch_xla::DeviceData::Cast(devctx->seed_ir_value.node.get())
+        ->data();
   }
 
   void MarkStep(const torch::lazy::BackendDevice& device) {
@@ -1921,9 +1927,9 @@ uint64_t XLATensor::GetRunningSeed(const torch::lazy::BackendDevice& device) {
   return DeviceContextArena::Get()->GetRunningSeed(device);
 }
 
-torch::lazy::BackendDataPtr XLATensor::ResetAndGetRngSeedData(
-    const torch::lazy::BackendDevice& device) {
-  return DeviceContextArena::Get()->ResetAndGetRngSeedData(device);
+torch::lazy::BackendDataPtr XLATensor::GetRngSeedData(
+    const torch::lazy::BackendDevice& device, bool reset) {
+  return DeviceContextArena::Get()->GetRngSeedData(device, reset);
 }
 
 bool XLATensor::UseEagerDebugMode() {

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -184,8 +184,8 @@ class XLATensor : public c10::intrusive_ptr_target {
 
   static uint64_t GetRunningSeed(const torch::lazy::BackendDevice& device);
 
-  static torch::lazy::BackendDataPtr ResetAndGetRngSeedData(
-      const torch::lazy::BackendDevice& device);
+  static torch::lazy::BackendDataPtr GetRngSeedData(
+      const torch::lazy::BackendDevice& device, bool reset);
 
   // Dispatches a comparison operator, setting the logical type of the result
   // appropriately.

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -184,6 +184,9 @@ class XLATensor : public c10::intrusive_ptr_target {
 
   static uint64_t GetRunningSeed(const torch::lazy::BackendDevice& device);
 
+  static torch::lazy::BackendDataPtr ResetAndGetRngSeedData(
+      const torch::lazy::BackendDevice& device);
+
   // Dispatches a comparison operator, setting the logical type of the result
   // appropriately.
   static XLATensorPtr DispatchComparisonOp(c10::Symbol kind,


### PR DESCRIPTION
This pr is the pytorch/xla side of fix for https://github.com/pytorch/xla/issues/4169.

In this pr we provided a way to check whether a device_data is a IR seed and add an api to get the `device_data` corresponding to the random seed. Remaining part is to add a check in graphInputMatcher https://github.com/pytorch/pytorch/blob/e4a8661ab84022c1bff622c6d2f6e679180b1df5/torch/_dynamo/optimizations/torchxla_integration.py#L36

something similar to 
```
if tensor_id == seed_info_id:
  inp = torch_xla._XLAC._get_rng_seed_as_tensor(str(traced_ivalue.device), True)
```

Whether to `Reset` the IR seed depends on if we do a `mark_step` across different dynamo runs. (mark_step will increment base seed and we want different base seed for every step).

FYI @shunting314 @wconstab 