### PR TITLE
Optionally bundle libtpu into TPU VM wheel

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,15 @@ and for Colab:
 
 You can also add `+yyyymmdd` after `torch_xla-nightly` to get the nightly wheel of a specified date. To get the companion pytorch nightly wheel, replace the `torch_xla` with `torch` on above wheel links.
 
-Note that for Cloud TPU VM, you can update the libtpu after the torch_xla wheel by 
+### Installing libtpu
+
+For PyTorch/XLA release r1.13 and older and when developing PyTorch/XLA, install the `libtpu` pip package with the following command:
 
 ```
 pip3 install torch_xla[tpuvm]
 ```
+
+This is only required on Cloud TPU VMs.
 
 ## <a name="API"></a> API & Best Practices
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,7 @@ ENV CXXFLAGS "${CXXFLAGS} -D_GLIBCXX_USE_CXX11_ABI=${cxx_abi}"
 
 # Whether to build for TPUVM mode
 ENV TPUVM_MODE "${tpuvm}"
+ENV BUNDLE_LIBTPU "${tpuvm}"
 
 # Maximum number of jobs to use for bazel build
 ENV BAZEL_JOBS "${bazel_jobs}"

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -86,7 +86,7 @@ COPY scripts/ scripts/
 
 ARG build_cpp_tests
 ARG package_version
-RUN TORCH_XLA_VERSION=${package_version} BUILD_CPP_TESTS=${build_cpp_tests} TPUVM_MODE=${tpuvm} XLA_CUDA=${cuda} TF_CUDA_COMPUTE_CAPABILITIES=${tf_cuda_compute_capabilities} python setup.py bdist_wheel
+RUN TORCH_XLA_VERSION=${package_version} BUILD_CPP_TESTS=${build_cpp_tests} TPUVM_MODE=${tpuvm} BUNDLE_LIBTPU=${tpuvm} XLA_CUDA=${cuda} TF_CUDA_COMPUTE_CAPABILITIES=${tf_cuda_compute_capabilities} python setup.py bdist_wheel
 
 RUN pip install dist/*.whl
 

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,9 @@
 #   XLA_CUDA=0
 #     build the xla/xrt client with CUDA enabled
 #
+#   BUNDLE_LIBTPU=1
+#     include libtpu in final wheel
+#
 
 from __future__ import print_function
 
@@ -45,10 +48,13 @@ import multiprocessing.pool
 import os
 import platform
 import re
+import requests
 import shutil
 import subprocess
 import sys
+import tempfile
 import torch
+import zipfile
 
 base_dir = os.path.dirname(os.path.abspath(__file__))
 third_party_path = os.path.join(base_dir, 'third_party')
@@ -137,6 +143,32 @@ def build_extra_libraries(base_dir, build_mode=None):
         'Failed to build external libraries: {}'.format(build_libs_cmd),
         file=sys.stderr)
     sys.exit(1)
+
+
+def maybe_bundle_libtpu(base_dir):
+  libtpu_path = os.path.join(base_dir, 'torch_xla', 'lib', 'libtpu.so')
+  os.remove(libtpu_path)
+  if not _check_env_flag('BUNDLE_LIBTPU', '0'):
+    return
+
+  try:
+    import libtpu
+    module_path = os.path.dirname(libtpu.__file__)
+    print('Found pre-installed libtpu at ', module_path)
+    shutil.copyfile(os.path.join(module_path, 'libtpu.so'), libtpu_path)
+  except ModuleNotFoundError:
+    print('No installed libtpu found. Downloading...')
+
+    with tempfile.NamedTemporaryFile('wb') as whl:
+      resp = requests.get(_libtpu_storage_path)
+      resp.raise_for_status()
+
+      whl.write(resp.content)
+      whl.flush()
+
+      with open(libtpu_path, 'wb') as libtpu_so:
+        z = zipfile.ZipFile(whl.name)
+        libtpu_so.write(z.read('libtpu/libtpu.so'))
 
 
 def generate_protos(base_dir, third_party_path):
@@ -250,6 +282,9 @@ if build_mode not in ['clean']:
 
   # Build the support libraries (ie, TF).
   build_extra_libraries(base_dir, build_mode=build_mode)
+
+  # Copy libtpu.so into torch_xla/lib
+  maybe_bundle_libtpu(base_dir)
 
   # Generate the proto C++/python files only after third_party has built.
   generate_protos(base_dir, third_party_path)

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ from __future__ import print_function
 
 from setuptools import setup, find_packages, distutils
 from torch.utils.cpp_extension import BuildExtension, CppExtension
+import contextlib
 import distutils.ccompiler
 import distutils.command.clean
 import glob
@@ -147,7 +148,9 @@ def build_extra_libraries(base_dir, build_mode=None):
 
 def maybe_bundle_libtpu(base_dir):
   libtpu_path = os.path.join(base_dir, 'torch_xla', 'lib', 'libtpu.so')
-  os.remove(libtpu_path)
+  with contextlib.suppress(FileNotFoundError):
+    os.remove(libtpu_path)
+
   if not _check_env_flag('BUNDLE_LIBTPU', '0'):
     return
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@
 #   XLA_CUDA=0
 #     build the xla/xrt client with CUDA enabled
 #
-#   BUNDLE_LIBTPU=1
+#   BUNDLE_LIBTPU=0
 #     include libtpu in final wheel
 #
 

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import shutil
 import tempfile
 import subprocess
 
@@ -86,11 +87,18 @@ def _summarize_fn_tracker():
 
 
 def _tpu_vm_init():
+  module_path = os.path.dirname(__file__)
+  bundled_libtpu_path = os.path.join(module_path, 'lib/libtpu.so')
+  if os.path.isfile(bundled_libtpu_path) and not os.getenv('TPU_LIBRARY_PATH'):
+    logger.info('Using bundled libtpu.so (%s)', bundled_libtpu_path)
+    os.environ['TPU_LIBRARY_PATH'] = bundled_libtpu_path
+    return
+
   try:
     import libtpu
     libtpu.configure_library_path()
   except ImportError:
-    return
+    pass
 
 
 # These needs to be called before the _XLAC module is loaded.


### PR DESCRIPTION
Add build flag `BUNDLE_LIBTPU` to optionally copy `libtpu.so` into the final wheel. If `BUNDLE_LIBTPU=1`, first try to copy the locally installed `libtpu.so`. If `libtpu` is not installed, extract it from the pinned libtpu wheel. 

At run time, we will use the following precedence order:

- `TPU_LIBRARY_PATH` for custom libtpu builds
- Bundled `libtpu.so`
- `libtpu` pip package

This lets us install `torch_xla` side by side with JAX. Note that you cannot use the TPU from both simultaneously. From the same machine:

```
wcromar@t1v-n-bf2f726f-w-0:~$ PJRT_DEVICE=TPU TF_CPP_MIN_LOG_LEVEL=0 python3 -c 'import torch_xla.core.xla_model as xm; print(xm.xla_device())'
INFO:torch_xla:Letting libtpu.so load fail during _XLAC import. libtpu.so will be loaded from `libtpu` Python package when the ComputationClient is created.
2022-11-15 19:15:24.408415: I tensorflow/core/tpu/tpu_initializer_helper.cc:275] Libtpu path is: libtpu.so
INFO:torch_xla:Using bundled libtpu.so (/home/wcromar/.local/lib/python3.8/site-packages/torch_xla/lib/libtpu.so)
2022-11-15 19:15:24.509817: I tensorflow/core/tpu/tpu_initializer_helper.cc:275] Libtpu path is: /home/wcromar/.local/lib/python3.8/site-packages/torch_xla/lib/libtpu.so
[...]
xla:0
wcromar@t1v-n-bf2f726f-w-0:~$ TF_CPP_MIN_LOG_LEVEL=0 python3 -c "import jax; print(jax.local_devices())"
2022-11-15 19:23:55.104045: I external/org_tensorflow/tensorflow/compiler/xla/stream_executor/tpu/tpu_initializer_helper.cc:275] Libtpu path is: /home/wcromar/.local/lib/python3.8/site-packages/libtpu/libtpu.so
[...]
[TpuDevice(id=0, process_index=0, coords=(0,0,0), core_on_chip=0), TpuDevice(id=1, process_index=0, coords=(1,0,0), core_on_chip=0), TpuDevice(id=2, process_index=0, coords=(0,1,0), core_on_chip=0), TpuDevice(id=3, process_index=0, coords=(1,1,0), core_on_chip=0)]
[...]
```
