### PR TITLE
full codegen baddbmm

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -773,18 +773,6 @@ at::Tensor XLANativeFunctions::avg_pool3d_backward(
       count_include_pad));
 }
 
-at::Tensor XLANativeFunctions::baddbmm(const at::Tensor& self,
-                                       const at::Tensor& batch1,
-                                       const at::Tensor& batch2,
-                                       const at::Scalar& beta,
-                                       const at::Scalar& alpha) {
-  XLA_FN_COUNTER("xla::");
-
-  return bridge::AtenFromXlaTensor(XLATensor::baddbmm(
-      bridge::GetXlaTensor(self), bridge::GetXlaTensor(batch1),
-      bridge::GetXlaTensor(batch2), beta, alpha));
-}
-
 at::Tensor XLANativeFunctions::bernoulli(
     const at::Tensor& self, c10::optional<at::Generator> generator) {
   XLA_FN_COUNTER("xla::");

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -203,12 +203,6 @@ torch::lazy::NodePtr TanhGelu(const torch::lazy::Value& input);
 torch::lazy::NodePtr TanhGeluBackward(const torch::lazy::Value& grad,
                                       const torch::lazy::Value& input);
 
-torch::lazy::NodePtr BaddBmm(const torch::lazy::Value& lhs,
-                             const torch::lazy::Value& rhs,
-                             const torch::lazy::Value& bias,
-                             const torch::lazy::Value& product_multiplier,
-                             const torch::lazy::Value& bias_multiplier);
-
 torch::lazy::NodePtr Lerp(const torch::lazy::Value& start,
                           const torch::lazy::Value& end,
                           const torch::lazy::Value& weight);

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -132,6 +132,20 @@ torch_xla::XlaOpVector Atanh::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::Atanh(xla_input), loctx);
 }
 
+torch_xla::XlaOpVector Baddbmm::Lower(LoweringContext* loctx) const {
+  xla::XlaOp xla_self = loctx->GetOutputOp(operand(0));
+  xla::XlaOp xla_batch1 = loctx->GetOutputOp(operand(1));
+  xla::XlaOp xla_batch2 = loctx->GetOutputOp(operand(2));
+  xla::XlaOp xla_beta = loctx->GetOutputOp(operand(3));
+  xla::XlaOp xla_alpha = loctx->GetOutputOp(operand(4));
+  std::tie(xla_batch1, xla_batch2) =
+      XlaHelpers::PromoteValues(xla_batch1, xla_batch2);
+
+  return ReturnOp(BuildMatMulWithMultiplier(xla_batch1, xla_batch2, xla_self,
+                                            xla_alpha, xla_beta),
+                  loctx);
+}
+
 torch_xla::XlaOpVector BinaryCrossEntropy::Lower(LoweringContext* loctx) const {
   xla::XlaOp logits = loctx->GetOutputOp(operand(0));
   xla::XlaOp labels = loctx->GetOutputOp(operand(1));

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -208,6 +208,23 @@ xla::Shape AtanhOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }
 
+xla::Shape BaddbmmOutputShape(const torch::lazy::Value& self,
+                              const torch::lazy::Value& batch1,
+                              const torch::lazy::Value& batch2,
+                              const torch::lazy::Value& beta,
+                              const torch::lazy::Value& alpha) {
+  auto lower_for_shape_fn =
+      [](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
+    return BuildMatMulWithMultiplier(operands[0], operands[1], operands[2],
+                                     operands[3], operands[4]);
+  };
+
+  return InferOutputShape(
+      {GetXlaShape(batch1), GetXlaShape(batch2), GetXlaShape(self),
+       GetXlaShape(alpha), GetXlaShape(beta)},
+      lower_for_shape_fn);
+}
+
 xla::Shape BinaryCrossEntropyOutputShape(
     const torch::lazy::Value& input, const torch::lazy::Value& target,
     const c10::optional<torch::lazy::Value>& weight, int64_t reduction) {

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -58,6 +58,12 @@ xla::Shape Atan2OutputShape(const torch::lazy::Value& input,
 
 xla::Shape AtanhOutputShape(const torch::lazy::Value& input);
 
+xla::Shape BaddbmmOutputShape(const torch::lazy::Value& self,
+                              const torch::lazy::Value& batch1,
+                              const torch::lazy::Value& batch2,
+                              const torch::lazy::Value& beta,
+                              const torch::lazy::Value& alpha);
+
 xla::Shape BinaryCrossEntropyOutputShape(
     const torch::lazy::Value& input, const torch::lazy::Value& target,
     const c10::optional<torch::lazy::Value>& weight, int64_t reduction);

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -444,11 +444,6 @@ class XLATensor : public c10::intrusive_ptr_target {
       std::vector<int64_t> stride, std::vector<int64_t> padding, bool ceil_mode,
       bool count_include_pad);
 
-  static XLATensorPtr baddbmm(const XLATensorPtr& input,
-                              const XLATensorPtr& batch1,
-                              const XLATensorPtr& batch2,
-                              const at::Scalar& beta, const at::Scalar& alpha);
-
   static XLATensorPtr bernoulli(const XLATensorPtr& input, double probability);
   static XLATensorPtr bernoulli(const XLATensorPtr& input);
   static void bernoulli_(XLATensorPtr& input, const XLATensorPtr& probability);

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -739,21 +739,6 @@ XLATensorPtr XLATensor::avg_pool_nd_backward(
       count_include_pad));
 }
 
-XLATensorPtr XLATensor::baddbmm(const XLATensorPtr& input,
-                                const XLATensorPtr& batch1,
-                                const XLATensorPtr& batch2,
-                                const at::Scalar& beta,
-                                const at::Scalar& alpha) {
-  CheckBmmDimension(/*tag=*/"baddbmm", batch1, batch2);
-  torch::lazy::Value product_multiplier = XLATensor::GetIrValueForScalar(
-      alpha, batch1->shape().get().element_type(), batch1->GetDevice());
-  torch::lazy::Value bias_multiplier = XLATensor::GetIrValueForScalar(
-      beta, input->shape().get().element_type(), input->GetDevice());
-  return input->CreateFrom(BaddBmm(batch1->GetIrValue(), batch2->GetIrValue(),
-                                   input->GetIrValue(), product_multiplier,
-                                   bias_multiplier));
-}
-
 XLATensorPtr XLATensor::bernoulli(const XLATensorPtr& input,
                                   double probability) {
   auto input_shape = input->shape();

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -16,6 +16,7 @@ full_codegen:
   - asinh
   - atan
   - atanh
+  - baddbmm
   - binary_cross_entropy
   - binary_cross_entropy_backward
   - bitwise_not
@@ -134,7 +135,6 @@ supported:
   - avg_pool2d_backward
   - avg_pool3d
   - avg_pool3d_backward
-  - baddbmm
   - bernoulli
   - bernoulli.p
   - bernoulli_.Tensor


### PR DESCRIPTION
full codegen baddbmm

generated XLANativeFunctions.cpp:
```
    at::Tensor XLANativeFunctions::baddbmm(const at::Tensor & self, const at::Tensor & batch1, const at::Tensor & batch2, const at::Scalar & beta, const at::Scalar & alpha) {
        
        XLA_FN_COUNTER("xla::");
        auto common_device = torch_xla::bridge::GetXlaDevice(self, batch1, batch2);
        TORCH_INTERNAL_ASSERT(common_device);
        
        torch_xla::XLATensorPtr lazy_self = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(self, *common_device);
        torch_xla::XLATensorPtr lazy_batch1 = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(batch1, *common_device);
        torch_xla::XLATensorPtr lazy_batch2 = torch_xla::bridge::GetXlaTensorOrCreateForWrappedNumber(batch2, *common_device);
        auto node_beta = torch::lazy::LazyGraphExecutor::Get()->
                            GetIrValueForScalarFromCodegen(beta, *common_device);
        auto node_alpha = torch::lazy::LazyGraphExecutor::Get()->
                            GetIrValueForScalarFromCodegen(alpha, *common_device);
        torch::lazy::NodePtr node = torch::lazy::ReuseNode<Baddbmm>(lazy_self->GetIrValue(), lazy_batch1->GetIrValue(), lazy_batch2->GetIrValue(), node_beta, node_alpha);
      if (!node) {
          
          node = torch::lazy::MakeNode<Baddbmm>(lazy_self->GetIrValue(), lazy_batch1->GetIrValue(), lazy_batch2->GetIrValue(), node_beta, node_alpha);
          CacheNode(node);
      }
      
        auto result = torch_xla::bridge::AtenFromXlaTensor(
                torch_xla::XLATensor::Create(std::move(node), *common_device));
        return result;
    }
```

generated LazyIr.h:
```
class Baddbmm : public XlaNode {
 public:
  static torch::lazy::OpKind ClassOpKind() {
    return torch::lazy::OpKind(at::aten::baddbmm);
  }

  Baddbmm(const torch::lazy::Value& self, const torch::lazy::Value& batch1, const torch::lazy::Value& batch2, const torch::lazy::Value& beta, const torch::lazy::Value& alpha)
      : XlaNode(torch::lazy::OpKind(at::aten::baddbmm),
              {self, batch1, batch2, beta, alpha},
              [&]() { return BaddbmmOutputShape(self, batch1, batch2, beta, alpha); },
              /* num_outputs */ 1,
              torch::lazy::MHash())
  {
    
  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << XlaNode::ToString();
    
    return ss.str();
  }

  

  bool CanBeReused(const torch::lazy::Value& self, const torch::lazy::Value& batch1, const torch::lazy::Value& batch2, const torch::lazy::Value& beta, const torch::lazy::Value& alpha) const {
    return false;
    }

  torch_xla::XlaOpVector Lower(LoweringContext* loctx) const override;

  
  

};
```