### PR TITLE
Add unsharded computation test for virtual device

### DIFF
--- a/test/test_xla_sharding.py
+++ b/test/test_xla_sharding.py
@@ -175,6 +175,17 @@ class VirtualDeviceTest(XlaShardingTest):
     self.assertIn("VirtualDeviceUsage", met.counter_names())
     self.assertNotEqual(met.counter_value("VirtualDeviceUsage"), 0)
 
+  def test_no_sharding(self):
+    t1 = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]],
+                      dtype=torch.float,
+                      device=xm.xla_device())
+    t2 = torch.tensor([[8, 7, 6, 5, 4, 3, 2, 1]],
+                      dtype=torch.float,
+                      device=xm.xla_device())
+    t3 = t1 + t2
+    t3_expected = [9.0, 9.0, 9.0, 9.0, 9.0, 9.0, 9.0, 9.0]
+    self.assertEqual(t3.tolist()[0], t3_expected)
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -302,8 +302,6 @@ PjRtComputationClient::ExecuteComputation(
   const PjRtComputation& pjrt_computation =
       dynamic_cast<const PjRtComputation&>(computation);
 
-  TF_VLOG(1) << "Executing PjRt computation on " << device;
-
   xla::PjRtDevice* pjrt_device = StringToPjRtDevice(device);
   XLA_CHECK(pjrt_device->IsAddressable()) << pjrt_device->DebugString();
 


### PR DESCRIPTION
Without sharding, we expect tensors defined on the virtual device to be transferred to the default xla device (e.g. `TPU:0`) for computation execution. When there is sharding involved, the tensors may be sharded explicitly, or implicitly replicated across devices.