### PR TITLE
Handle sparse PjRtDevice IDs

### DIFF
--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -136,6 +136,9 @@ class PjRtComputationClient : public ComputationClient {
 
  private:
   std::shared_ptr<PjRtClient> client_;
+  // global_ordinals_ tracks a map from PjRtDeviceId to the device's
+  // dense global ordinal.
+  std::unordered_map<int, int> global_ordinals_;
   std::unordered_map<std::string, xla::PjRtDevice* const> string_to_device_;
   std::shared_ptr<std::vector<std::string>> replication_devices_;
   std::unordered_map<std::string, std::unique_ptr<std::shared_mutex>>
@@ -147,6 +150,10 @@ class PjRtComputationClient : public ComputationClient {
   std::shared_lock<std::shared_mutex> lock_device_shared(
       const std::string& device);
   std::unique_lock<std::shared_mutex> lock_device(const std::string& device);
+
+  std::string PjRtDeviceToString(PjRtDevice* const device) const;
+  std::vector<std::string> PjRtDevicesToString(
+      absl::Span<PjRtDevice* const> devices) const;
 
   struct PjRtData : public Data {
     PjRtData(std::string device, Shape device_shape)


### PR DESCRIPTION
This change handles sparse PjRtDeviceIds by maintaining a map from the device ID to a dense global ordinal.