### PR TITLE
Prevent multi register Lazy key

### DIFF
--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -129,4 +129,5 @@ def _init_xla_lazy_backend():
 
 atexit.register(_prepare_to_exit)
 _apply_patches()
-_init_xla_lazy_backend()
+if os.environ.get('INIT_LAZY_BACKEND', '1') != '0':
+  _init_xla_lazy_backend()

--- a/torch_xla/core/xrt_run_server.py
+++ b/torch_xla/core/xrt_run_server.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 
 from pathlib import Path
+os.environ['INIT_LAZY_BACKEND'] = '0'
 from torch_xla.__init__ import server_is_alive, XRT_RUN_SERVER_PROCESS, XRT_SERVER_REGEX
 
 


### PR DESCRIPTION
Doing a quick fix for 1.13 since it is less intrsuive. I will do a proper fix using `std::call_once` in master