### PR TITLE
Workaround the crash in TF

### DIFF
--- a/tf_patches/repalce_crash.diff
+++ b/tf_patches/repalce_crash.diff
@@ -1,0 +1,16 @@
+diff --git a/tensorflow/core/distributed_runtime/master.cc b/tensorflow/core/distributed_runtime/master.cc
+index a54b1c0d660..0801160227e 100644
+--- a/tensorflow/core/distributed_runtime/master.cc
++++ b/tensorflow/core/distributed_runtime/master.cc
+@@ -382,7 +382,10 @@ void Master::CreateSession(const CreateSessionRequest* req,
+       worker_cache_factory_options.cluster_def = &cluster_def;
+       // If the target starts with gRPC protocol prefix, remove the prefix
+       string normalized_string(req->target());
+-      RE2::Replace(&normalized_string, kGrpcPrefixRegex, "");
++      static string grpc_prefxi = "grpc://";
++      if (normalized_string.rfind(grpc_prefxi, 0) == 0) {
++       normalized_string = normalized_string.substr(grpc_prefxi.size());
++      }
+ 
+       // Set the server_def's job_name and task_index fields.
+       for (auto&& job : cluster_def.job()) {


### PR DESCRIPTION
trigger of the crash is
```
      string normalized_string(req->target());
      RE2::Replace(&normalized_string, kGrpcPrefixRegex, "");
```

with some debug build, I am able to see
```
2022-11-19 00:10:14.315887: I tensorflow/core/distributed_runtime/master.cc:388] normalized_string grpc://10.130.0.84:51011, kGrpcPrefixRegex ^grpc.*://

terminate called after throwing an instance of 'std::out_of_range'
  what():  basic_string::replace: __pos (which is 18446744073686787136) > this->size() (which is 24)
```

I think it is just trying to get rid of the `grpc://` prefix.. not sure why would it crashed. I have no idea why RE2::Replace will crash, the input seems legit, but RE2 are not part of the tf, it is from third_party. There isn't an easy way for me to debug RE2::Replace