### PR TITLE
XLA Op Key Registration should only happen once.

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2082,6 +2082,14 @@ class XpTraceTest(XlaTestCase):
         xm.mark_step()
 
 
+class RegisterXLAKeyTest(XlaTestCase):
+
+  def test_multi_init_xla_backend(self):
+    torch_xla._XLAC._init_xla_lazy_backend()
+    torch_xla._XLAC._init_xla_lazy_backend()
+    self.assertEqual(met.counter_value("RegisterXLAFunctions"), 1)
+
+
 class TestGeneric(XlaTestCase):
 
   def test_zeros_like_patch(self):


### PR DESCRIPTION
This is a more robust fix compared to 1.13 quick fix in https://github.com/pytorch/xla/pull/4223