### PR TITLE
Add const override flag to getstaticValue

### DIFF
--- a/torch_xla/csrc/ops/dynamic_ir.h
+++ b/torch_xla/csrc/ops/dynamic_ir.h
@@ -57,7 +57,7 @@ class SizeEq : public XlaNode, public torch::lazy::DimensionNode {
  public:
   SizeEq(torch::lazy::Value a, torch::lazy::Value b);
   int64_t getDynamicValue() const override;
-  int64_t getStaticValue() {
+  int64_t getStaticValue() const override {
     TORCH_CHECK(false, "Comparison operators should be using getDynamicValue");
   }
   bool isSymbolic() const override { return true; }


### PR DESCRIPTION
This is to get rid of build time warning messages
```
In file included from /pytorch/xla/torch_xla/csrc/xla_backend_impl.cpp:9:
In file included from /pytorch/xla/torch_xla/csrc/ir_builder.h:9:
/pytorch/xla/torch_xla/csrc/ops/dynamic_ir.h:60:11: warning: 'torch_xla::SizeEq::getStaticValue' hides overloaded virtual function [-Woverloaded-virtual]
  int64_t getStaticValue() {
          ^
/pytorch/torch/csrc/lazy/core/dynamic_ir.h:52:19: note: hidden overloaded virtual function 'torch::lazy::DimensionNode::getStaticValue' declared here: different qualifiers ('const' vs unqualified)
  virtual int64_t getStaticValue() const {
                  ^

```