### PR TITLE
Remove tensor.storage_

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -11588,26 +11588,6 @@ TEST_F(AtenXlaTensorTest, TestRoll) {
   ExpectCounterChanged("xla::roll", cpp_test::GetIgnoredCounters());
 }
 
-TEST_F(AtenXlaTensorTest, TestViewIsAliasOf) {
-  torch::Tensor a = torch::empty(4, torch::TensorOptions(torch::kFloat));
-  torch::Tensor b = torch::empty(4, torch::TensorOptions(torch::kFloat));
-
-  ForEachDevice([&](const torch::Device& device) {
-    torch::Tensor xla_a = CopyToDevice(a, device);
-    torch::Tensor xla_b = CopyToDevice(b, device);
-    EXPECT_EQ(!a.is_alias_of(b), !xla_a.is_alias_of(xla_b));
-
-    torch::Tensor c = a.view({2, 2});
-    torch::Tensor xla_c = xla_a.view({2, 2});
-    EXPECT_EQ(a.is_alias_of(c), xla_a.is_alias_of(xla_c));
-
-    torch::Tensor d = c.view({1, 4});
-    torch::Tensor lazy_d = xla_c.view({1, 4});
-    EXPECT_EQ(d.is_alias_of(c), lazy_d.is_alias_of(xla_c));
-    EXPECT_EQ(d.is_alias_of(a), lazy_d.is_alias_of(xla_a));
-  });
-}
-
 TEST_F(AtenXlaTensorTest, TestExpandIsAliasOf) {
   torch::Tensor a = torch::empty(4, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = a.expand(4, 3);

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -531,11 +531,7 @@ XLATensor::XLATensor(std::shared_ptr<View> view,
     : XLATensor(std::make_shared<Data>(std::move(view), device,
                                        logical_element_type)) {}
 
-XLATensor::XLATensor(std::shared_ptr<Data> data)
-    : data_(std::move(data)),
-      storage_(c10::Storage(
-          {}, 0,
-          c10::DataPtr(nullptr, backendDeviceToAtenDevice(data_->device)))) {}
+XLATensor::XLATensor(std::shared_ptr<Data> data) : data_(std::move(data)) {}
 
 XLATensor::Data* XLATensor::data() const {
   XLA_CHECK(data_ != nullptr) << "Trying to access a null cursor";
@@ -935,10 +931,8 @@ std::shared_ptr<View> XLATensor::CreateView(ViewInfo view_info) const {
 }
 
 XLATensorPtr XLATensor::CreateViewTensor(ViewInfo view_info) const {
-  auto new_tensor =
-      Create(CreateView(std::move(view_info)), GetDevice(), dtype_optional());
-  new_tensor->storage_ = Storage();
-  return new_tensor;
+  return Create(CreateView(std::move(view_info)), GetDevice(),
+                dtype_optional());
 }
 
 at::Tensor XLATensor::ToTensor(bool detached) {

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -1227,8 +1227,6 @@ class XLATensor : public c10::intrusive_ptr_target {
   void ClearShardingSpec();
   ShardingSpecPtr sharding_spec() const;
 
-  const c10::Storage& Storage() const { return storage_; }
-
   struct CachedComputation {
     CachedComputation(ComputationPtr computation, bool is_sharded = false)
         : computation(std::move(computation)), is_sharded(is_sharded) {}
@@ -1513,12 +1511,6 @@ class XLATensor : public c10::intrusive_ptr_target {
   bool ShouldSyncIrNode();
 
   std::shared_ptr<Data> data_;
-  // Temporarily used to suport Tensor.is_alias_of().
-  // This is a fake storage that doesn't store anything.
-  // Instead it serves as a marker to mark LazyTensors that
-  // points to the same storage, and thus alias of each other.
-  // FIXME(alanwaketan): Remove this once we have functionalization (bdhirsh).
-  c10::Storage storage_;
 };
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -205,8 +205,4 @@ void XLATensorImpl::AtenInitialize() {
   // ATEN specific initialization calls placed below.
 }
 
-const at::Storage& XLATensorImpl::storage() const { return tensor_->Storage(); }
-
-bool XLATensorImpl::has_storage() const { return tensor_->Storage(); }
-
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor_impl.h
+++ b/torch_xla/csrc/tensor_impl.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <ATen/Tensor.h>
-#include <c10/core/Storage.h>
 #include <c10/core/TensorImpl.h>
 
 #include "torch_xla/csrc/tensor.h"
@@ -42,10 +41,6 @@ class XLATensorImpl : public c10::TensorImpl {
   int64_t numel_custom() const override;
 
   bool is_contiguous_custom(at::MemoryFormat memory_format) const override;
-
-  const at::Storage& storage() const override;
-
-  bool has_storage() const override;
 
   static void AtenInitialize();
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1110,20 +1110,16 @@ XLATensorPtr XLATensor::exp(const XLATensorPtr& input) {
 XLATensorPtr XLATensor::expand(const XLATensorPtr& input,
                                std::vector<int64_t> size) {
   auto input_shape = input->shape();
-  auto output = input->CreateFrom(torch::lazy::MakeNode<Expand>(
+  return input->CreateFrom(torch::lazy::MakeNode<Expand>(
       input->GetIrValue(),
       GetExpandDimensions(input_shape.get(), std::move(size))));
-  output->storage_ = input->Storage();
-  return output;
 }
 
 XLATensorPtr XLATensor::expand_symint(const XLATensorPtr& input,
                                       c10::SymIntArrayRef sym_size) {
   SymIntElements size_elements = SymIntElements(sym_size);
-  XLATensorPtr output = input->CreateFrom(
+  return input->CreateFrom(
       torch::lazy::MakeNode<ExpandSymInt>(input->GetIrValue(), size_elements));
-  output->storage_ = input->Storage();
-  return output;
 }
 
 void XLATensor::exponential_(XLATensorPtr& input, double lambd) {


### PR DESCRIPTION
This PR is dependent on https://github.com/pytorch/xla/pull/4158. 

---
As we enable functionazliation, `tensor.strage_` is no longer needed. 