### PR TITLE
Disable failing take python op tests on TPU

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -366,6 +366,8 @@ DISABLED_TORCH_TESTS_TPU_ONLY = {
         'test_diff_xla_float64',  # expected instruction to have shape equal
         'test_nullary_op_mem_overlap_xla',  # core dumped
         'test_index_reduce',  # takes too long
+        'test_take_xla_float64',  # 'dtype' do not match: torch.float32 != torch.float64
+        'test_take_xla_int16',  # 'dtype' do not match: torch.int32 != torch.int16
     },
 
     # test_indexing.py


### PR DESCRIPTION
Python op tests `test_take_xla_int16` and `test_take_xla_float64` have been failing on TPUs, disabling them for now. 

---
These tests fail due to `dtype` mismatch, `'dtype' do not match: torch.int32 != torch.int16` for the `int16` test and `'dtype' do not match: torch.float32 != torch.float64` for the `float64` test. 

For example, for the `int16` test with gdb triggered at the `ops_xla_shape_fn.cpp`, I can see that the `shape` of `input` at `TakeOutputShape` (at `ops_xla_shape_fn.cpp`) is wrongly set to `s32` (it should be `s16` since `test_torch.py` sets `dtype=torch.int16`). The outcome tensors' values are equal, but just their `dtype`s mismatch. The error only happens on TPU. 

@JackCaoG, let me know if you think disabling these would be fine for now. 

---
With these changes, the failing `take` tests get skipped:
```
wonjoo@t1v-n-0dd7892e-w-0:~/pytorch$ python test/test_torch.py TestTorchDeviceTypeXLA.test_take_xla_int16
s
----------------------------------------------------------------------
Ran 1 test in 0.003s

OK (skipped=1)

wonjoo@t1v-n-0dd7892e-w-0:~/pytorch$ python test/test_torch.py TestTorchDeviceTypeXLA.test_take_xla_float64
s
----------------------------------------------------------------------
Ran 1 test in 0.003s

OK (skipped=1)
wonjoo@t1v-n-0dd7892e-w-0:~/pytorch$ 
```