### PR TITLE
[SPMD] fixes bugs with AssignIrValue & ExecuteReplicated

### DIFF
--- a/test/test_xla_sharding.py
+++ b/test/test_xla_sharding.py
@@ -102,6 +102,15 @@ class XlaShardingTest(unittest.TestCase):
         torch_xla._XLAC._get_xla_sharding_spec(xt),
         torch_xla._XLAC._get_xla_sharding_spec(xt2))
 
+  def test_mark_step(self):
+    xt = torch.randn(2, 4, 8, 16).to(xm.xla_device())
+    xs.mark_sharding(xt, self._get_mesh((1, 1, 1, self.n_devices)),
+                     (0, 1, 2, 3))
+    sharding_spec = torch_xla._XLAC._get_xla_sharding_spec(xt)
+    xm.mark_step()  # resets IR value
+    self.assertEqual(sharding_spec, torch_xla._XLAC._get_xla_sharding_spec(xt))
+
+
 
 class VirtualDeviceTest(XlaShardingTest):
 

--- a/test/test_xla_sharding.py
+++ b/test/test_xla_sharding.py
@@ -111,7 +111,6 @@ class XlaShardingTest(unittest.TestCase):
     self.assertEqual(sharding_spec, torch_xla._XLAC._get_xla_sharding_spec(xt))
 
 
-
 class VirtualDeviceTest(XlaShardingTest):
 
   @classmethod

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -369,15 +369,16 @@ PjRtComputationClient::ExecuteReplicated(
   data_handles.reserve(results.size());
   for (int32_t i = 0; i < results.size(); ++i) {
     xla::PjRtDevice* pjrt_device = StringToPjRtDevice(devices[i]);
-    XLA_CHECK(pjrt_device->IsAddressable()) << pjrt_device->DebugString();
+    XLA_CHECK(pjrt_device->IsAddressable())
+        << pjrt_device->DebugString() << " is not addressable.";
 
     std::vector<ComputationClient::DataPtr> datas;
     datas.reserve(results[i].size());
     for (int32_t j = 0; j < results[i].size(); ++j) {
       std::unique_ptr<xla::PjRtBuffer> buffer = std::move(results[i][j]);
       XLA_CHECK(pjrt_device == buffer->device())
-          << pjrt_device->DebugString() << " vs "
-          << buffer->device()->DebugString();
+          << "Exepcted device: " << pjrt_device->DebugString()
+          << " vs. actual device: " << buffer->device()->DebugString();
 
       std::shared_ptr<PjRtData> data = std::make_shared<PjRtData>(
           devices[i], buffer->on_device_shape(), std::move(buffer));

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -367,16 +367,20 @@ PjRtComputationClient::ExecuteReplicated(
 
   std::vector<std::vector<ComputationClient::DataPtr>> data_handles;
   data_handles.reserve(results.size());
-  for (auto& result : results) {
+  for (int32_t i = 0; i < results.size(); ++i) {
+    xla::PjRtDevice* pjrt_device = StringToPjRtDevice(devices[i]);
+    XLA_CHECK(pjrt_device->IsAddressable()) << pjrt_device->DebugString();
+
     std::vector<ComputationClient::DataPtr> datas;
-    datas.reserve(result.size());
-    for (int32_t i = 0; i < result.size(); ++i) {
-      std::unique_ptr<xla::PjRtBuffer> buffer = std::move(result[i]);
+    datas.reserve(results[i].size());
+    for (int32_t j = 0; j < results[i].size(); ++j) {
+      std::unique_ptr<xla::PjRtBuffer> buffer = std::move(results[i][j]);
+      XLA_CHECK(pjrt_device == buffer->device())
+          << pjrt_device->DebugString() << " vs "
+          << buffer->device()->DebugString();
 
       std::shared_ptr<PjRtData> data = std::make_shared<PjRtData>(
-          devices[i], buffer->on_device_shape(),
-          std::move(buffer));
-
+          devices[i], buffer->on_device_shape(), std::move(buffer));
       datas.push_back(data);
     }
     data_handles.push_back(datas);


### PR DESCRIPTION
This fixes a couple of bugs in `AssignIrValue` and `ExecuteReplicated` for sharding, to enable `mark_step()` with SPMD. Note that this doesn't address sharding propagation through views, which will be handled later.