### PR TITLE
inplace operation within no_grad context for all_gather

### DIFF
--- a/torch_xla/distributed/xla_backend.py
+++ b/torch_xla/distributed/xla_backend.py
@@ -74,7 +74,8 @@ class ProcessGroupXla(ProcessGroup):
     for input_tensor, output_tensors in zip(input_tensors, output_tensors_list):
       result = xm.all_gather(input_tensor, groups=self._mesh, pin_layout=False)
       for i, slice in enumerate(torch.split(result, input_tensor.shape[0])):
-        output_tensors[i].copy_(slice)
+        with torch.no_grad():
+          output_tensors[i].copy_(slice)
 
     return _ret_work([t for sublist in output_tensors_list for t in sublist])
 


### PR DESCRIPTION
Currently the allgather performs inplace copy which results in errors that look like this: https://discuss.pytorch.org/t/leaf-variable-was-used-in-an-inplace-operation/308

Hence performing the inplace copy within `no_grad` context.