### PR TITLE
Fix 1d transpose

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1864,8 +1864,14 @@ class TestAtenXlaTensor(XlaTestCase):
   def test_transpose_1d(self):
 
     def test_fn(t1):
-      t1.t_()
       return t1.t()
+
+    self.runAtenTest([torch.arange(15, dtype=torch.int32)], test_fn)
+
+  def test_transpose_1d_inplace(self):
+
+    def test_fn(t1):
+      return t1.t_()
 
     self.runAtenTest([torch.arange(15, dtype=torch.int32)], test_fn)
 

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1861,6 +1861,14 @@ class TestAtenXlaTensor(XlaTestCase):
     emb_out = emb(index)
     assert emb_out.dtype == torch.bfloat16
 
+  def test_transpose_1d(self):
+
+    def test_fn(t1):
+      t1.t_()
+      return t1.t()
+
+    self.runAtenTest([torch.arange(15, dtype=torch.int32)], test_fn)
+
 
 class MNISTComparator(nn.Module):
 


### PR DESCRIPTION
This is to fix https://github.com/pytorch/xla/issues/4234.

@wonjoolee95 let's remove the view part in transpose after functionization, you can just do
```
return input->CreateFrom(ir_value);
```
instead.

FYI @pscollins  @Liyang90 