### PR TITLE
CI requires cmake>=3.18 to install PyTorch

### DIFF
--- a/.circleci/docker/install_conda.sh
+++ b/.circleci/docker/install_conda.sh
@@ -39,7 +39,8 @@ function install_and_setup_conda() {
   /usr/bin/yes | pip install cloud-tpu-client
   /usr/bin/yes | pip install expecttest==0.1.3
   /usr/bin/yes | pip install ninja  # Install ninja to speedup the build
-  /usr/bin/yes | pip install "cmake>=3.13" --upgrade  # Using Ninja requires CMake>=3.13
+  # Using Ninja requires CMake>=3.13, PyTorch requires CMake>=3.18
+  /usr/bin/yes | pip install "cmake>=3.18" --upgrade
   /usr/bin/yes | pip install absl-py
   # Additional PyTorch requirements
   /usr/bin/yes | pip install scikit-image scipy==1.1.0  # >1.1.0 breaks PyTorch tests


### PR DESCRIPTION
PyTorch just updated their `cmake` requirement.