### PR TITLE
[LTC] Replace XLA_TIMED with TORCH_LAZY_TIMED

### DIFF
--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -148,7 +148,6 @@ class MetricsTest(unittest.TestCase):
     self.assertIn("DeviceLockWait", metric_names)
     self.assertNotEqual(met.metric_data("DeviceLockWait"), None)
 
-
     met.clear_metrics()
     self.assertNotIn("InputOutputAliasCount", met.metric_names())
     self.assertEqual(met.metric_data("InputOutputAliasCount"), None)

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -134,15 +134,26 @@ class MetricsTest(unittest.TestCase):
     self.assertIn("InputOutputAliasCount", metric_names)
     self.assertNotEqual(met.metric_data("InputOutputAliasCount"), None)
 
-    met.clear_metrics()
-    self.assertNotIn("InputOutputAliasCount", met.metric_names())
-    self.assertEqual(met.metric_data("InputOutputAliasCount"), None)
-
     # timed metrics
     self.assertIn("TensorToData", report)
     self.assertIn("UnwrapXlaData", report)
     self.assertIn("WrapXlaData", report)
     self.assertIn("DeviceLockWait", report)
+    self.assertIn("TensorToData", metric_names)
+    self.assertNotEqual(met.metric_data("TensorToData"), None)
+    self.assertIn("UnwrapXlaData", metric_names)
+    self.assertNotEqual(met.metric_data("UnwrapXlaData"), None)
+    self.assertIn("WrapXlaData", metric_names)
+    self.assertNotEqual(met.metric_data("WrapXlaData"), None)
+    self.assertIn("DeviceLockWait", metric_names)
+    self.assertNotEqual(met.metric_data("DeviceLockWait"), None)
+
+
+    met.clear_metrics()
+    self.assertNotIn("InputOutputAliasCount", met.metric_names())
+    self.assertEqual(met.metric_data("InputOutputAliasCount"), None)
+    self.assertNotIn("TensorToData", met.metric_names())
+    self.assertEqual(met.metric_data("TensorToData"), None)
 
     # repeat the same computation and expect to see the CachedCompile counter
     t3 = t1 * 2

--- a/third_party/xla_client/metrics.h
+++ b/third_party/xla_client/metrics.h
@@ -246,6 +246,9 @@ class TimedSection {
   int64_t start_;
 };
 
+// XLA_TIMED should only be used within xla_client. Please use
+// TORCH_LAZY_TIMED in pytorch/xla. For more information, see
+// NOTE: [TORCH_LAZY_COUNTER v.s. XLA_COUNTER].
 #define XLA_TIMED(name)                                           \
   static xla::metrics::Metric* timed_metric =                     \
       new xla::metrics::Metric(name, xla::metrics::MetricFnTime); \

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1667,7 +1667,7 @@ void InitXlaModuleBindings(py::module m) {
           std::vector<torch::lazy::BackendDataPtr> parameters_data;
           torch::lazy::BackendDevice device = torch_xla::GetCurrentDevice();
           {
-            XLA_TIMED("RunCachedGraphInputData");
+            TORCH_LAZY_TIMED("RunCachedGraphInputData");
             // setup the parameters_data
             int idx = 0;
             for (auto& ivalue : graph_inputs) {
@@ -1688,7 +1688,7 @@ void InitXlaModuleBindings(py::module m) {
               cachedComputation->computation, parameters_data, device);
           std::vector<at::Tensor> retlist;
           {
-            XLA_TIMED("RunCachedGraphOutputData");
+            TORCH_LAZY_TIMED("RunCachedGraphOutputData");
             // Convert result back to at::tensor
             int i = 0;
             for (auto& data : results) {

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -151,7 +151,7 @@ xla::util::ExceptionCleanup LockDevice(
   TF_VLOG(4) << "Waiting on device barrier for device " << device << " ...";
   std::shared_ptr<DeviceLocker> locker;
   {
-    XLA_TIMED("DeviceLockWait");
+    TORCH_LAZY_TIMED("DeviceLockWait");
     locker = DeviceLockerArena::Get()->GetLocker(device);
     locker->Lock();
   }
@@ -806,7 +806,7 @@ torch::lazy::Value XLATensor::GetIrValueForTensor(
     data = GetDeviceData(tensor, device);
     read_only = true;
   } else {
-    XLA_TIMED("IrValueTensorToXlaData");
+    TORCH_LAZY_TIMED("IrValueTensorToXlaData");
     data = TensorToXlaData(tensor, device);
   }
   return CreateTensorNode(std::move(data), read_only);

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -37,7 +37,7 @@ struct DataAsync {
 
 void TransferToServerAsync(std::shared_ptr<DataAsync> async,
                            const std::vector<std::string>& devices) {
-  XLA_TIMED("TransferToServerAsync");
+  TORCH_LAZY_TIMED("TransferToServerAsync");
 
   std::vector<xla::ComputationClient::DataPtr> async_xla_datas =
       xla::ComputationClient::Get()->CreateAsyncDatas(async->source_tensors);
@@ -652,7 +652,7 @@ void PopulateTensorBuffer(const at::Tensor& tensor,
 torch::lazy::BackendDataPtr TensorToXlaData(
     const at::Tensor& tensor, const xla::Shape& shape,
     const torch::lazy::BackendDevice& device) {
-  XLA_TIMED("TensorToData");
+  TORCH_LAZY_TIMED("TensorToData");
   if (device.type() == (int8_t)XlaDeviceType::SPMD) {
     // When SPMD is enabled, we want to delay the data transfer for XLA
     // tensors until the data is sharded. So, we skip the data transfer
@@ -763,13 +763,13 @@ at::Tensor XlaLiteralToTensorHelper(const xla::Literal& literal,
 
 xla::ComputationClient::DataPtr UnwrapXlaData(
     const torch::lazy::BackendDataPtr& data) {
-  XLA_TIMED("UnwrapXlaData");
+  TORCH_LAZY_TIMED("UnwrapXlaData");
   return dynamic_cast<XLAData*>(data.get())->xla_data();
 }
 
 std::vector<xla::ComputationClient::DataPtr> UnwrapXlaData(
     absl::Span<const torch::lazy::BackendDataPtr> datas) {
-  XLA_TIMED("UnwrapXlaData");
+  TORCH_LAZY_TIMED("UnwrapXlaData");
   std::vector<xla::ComputationClient::DataPtr> xla_datas;
   xla_datas.reserve(datas.size());
   for (const auto& data : datas) {
@@ -780,13 +780,13 @@ std::vector<xla::ComputationClient::DataPtr> UnwrapXlaData(
 
 torch::lazy::BackendDataPtr WrapXlaData(
     const xla::ComputationClient::DataPtr& xla_data) {
-  XLA_TIMED("WrapXlaData");
+  TORCH_LAZY_TIMED("WrapXlaData");
   return std::make_shared<XLAData>(xla_data);
 }
 
 std::vector<torch::lazy::BackendDataPtr> WrapXlaData(
     absl::Span<const xla::ComputationClient::DataPtr> xla_datas) {
-  XLA_TIMED("WrapXlaData");
+  TORCH_LAZY_TIMED("WrapXlaData");
   std::vector<torch::lazy::BackendDataPtr> datas;
   datas.reserve(xla_datas.size());
   for (const auto& xla_data : xla_datas) {
@@ -868,7 +868,7 @@ torch::lazy::BackendDataPtr TensorToXlaData(
 std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
     const std::vector<at::Tensor>& tensors,
     const std::vector<std::string>& devices, bool transfer_async) {
-  XLA_TIMED("TensorToData");
+  TORCH_LAZY_TIMED("TensorToData");
   XLA_CHECK_EQ(tensors.size(), devices.size());
   if (transfer_async) {
     std::shared_ptr<DataAsync> async = std::make_shared<DataAsync>();
@@ -918,7 +918,7 @@ std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
     const std::vector<at::Tensor>& tensors,
     const std::vector<XLATensor::ShardingSpecPtr>& shardings,
     const std::vector<std::string>& devices) {
-  XLA_TIMED("TensorToData");
+  TORCH_LAZY_TIMED("TensorToData");
   XLA_CHECK_EQ(tensors.size(), shardings.size());
   XLA_CHECK_EQ(tensors.size(), devices.size());
 


### PR DESCRIPTION
Summary:
This patch just simply replaces XLA_TIMED with TORCH_LAZY_TIMED. TORCH_LAZY_TIMED means timed metrics. Most of the work has been done by #4245.

Test Plan:
PJRT_DEVICE=CPU python test/test_metrics.py