### PR TITLE
Clean up some XLATensor unused interfaces

### DIFF
--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1186,19 +1186,6 @@ std::vector<at::Tensor> XLATensor::FetchTensors(
   return results;
 }
 
-std::vector<XLATensorPtr> XLATensor::CreateTensors(
-    const std::vector<at::Tensor>& tensors,
-    const std::vector<std::string>& devices) {
-  std::vector<torch::lazy::BackendDataPtr> handles =
-      CreateTensorsData(tensors, devices);
-  std::vector<XLATensorPtr> xla_tensors;
-  for (size_t i = 0; i < handles.size(); ++i) {
-    xla_tensors.push_back(
-        Create(std::move(handles[i]), tensors[i].scalar_type()));
-  }
-  return xla_tensors;
-}
-
 torch::lazy::Value XLATensor::CreateTensorNode(torch::lazy::BackendDataPtr data,
                                                bool read_only) const {
   data->SetInfo(

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1242,40 +1242,13 @@ torch::lazy::Value XLATensor::MaybeCastIrValue(
 }
 
 XLATensorPtr XLATensor::CreateFrom(torch::lazy::Value ir_value) const {
-  ir_value = MaybeCastIrValue(std::move(ir_value), GetDevice(),
-                              /*logical_element_type=*/c10::nullopt);
   return Create(std::move(ir_value), GetDevice(), dtype_optional());
 }
 
 XLATensorPtr XLATensor::CreateFrom(
     torch::lazy::Value ir_value,
-    const torch::lazy::BackendDevice& device) const {
-  ir_value = MaybeCastIrValue(std::move(ir_value), device,
-                              /*logical_element_type=*/c10::nullopt);
-  return Create(std::move(ir_value), device, dtype_optional());
-}
-
-XLATensorPtr XLATensor::CreateFrom(torch::lazy::Value ir_value,
-                                   at::ScalarType logical_element_type) const {
-  ir_value =
-      MaybeCastIrValue(std::move(ir_value), GetDevice(), logical_element_type);
-  return Create(std::move(ir_value), GetDevice(), logical_element_type);
-}
-
-XLATensorPtr XLATensor::CreateFrom(
-    torch::lazy::Value ir_value,
     c10::optional<at::ScalarType> logical_element_type_opt) const {
-  ir_value = MaybeCastIrValue(std::move(ir_value), GetDevice(),
-                              logical_element_type_opt);
   return Create(std::move(ir_value), GetDevice(), logical_element_type_opt);
-}
-
-XLATensorPtr XLATensor::CreateFrom(torch::lazy::Value ir_value,
-                                   const torch::lazy::BackendDevice& device,
-                                   at::ScalarType logical_element_type) const {
-  ir_value =
-      MaybeCastIrValue(std::move(ir_value), device, logical_element_type);
-  return Create(std::move(ir_value), device, logical_element_type);
 }
 
 void XLATensor::ApplyPendingGraph() {

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -576,14 +576,6 @@ xla::util::MaybeRef<xla::Shape> XLATensor::shape() const {
       XlaHelpers::I64List(data()->tensor_data->sizes()));
 }
 
-xla::Shape XLATensor::shape_with_layout() const {
-  auto xla_shape = shape();
-  return MakeArrayShapeFromDimensions(
-      xla_shape.get().dimensions(), xla_shape.get().dynamic_dimensions(),
-      xla_shape.get().element_type(),
-      static_cast<XlaDeviceType>(GetDevice().type()));
-}
-
 const torch::lazy::BackendDevice& XLATensor::GetDevice() const {
   return data()->device;
 }

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1229,13 +1229,25 @@ torch::lazy::Value XLATensor::MaybeCastIrValue(
 }
 
 XLATensorPtr XLATensor::CreateFrom(torch::lazy::Value ir_value) const {
+  ir_value = MaybeCastIrValue(std::move(ir_value), GetDevice(),
+                              /*logical_element_type=*/c10::nullopt);
   return Create(std::move(ir_value), GetDevice(), dtype_optional());
 }
 
 XLATensorPtr XLATensor::CreateFrom(
     torch::lazy::Value ir_value,
     c10::optional<at::ScalarType> logical_element_type_opt) const {
+  ir_value = MaybeCastIrValue(std::move(ir_value), GetDevice(),
+                              logical_element_type_opt);
   return Create(std::move(ir_value), GetDevice(), logical_element_type_opt);
+}
+
+XLATensorPtr XLATensor::CreateFrom(torch::lazy::Value ir_value,
+                                   const torch::lazy::BackendDevice& device,
+                                   at::ScalarType logical_element_type) const {
+  ir_value =
+      MaybeCastIrValue(std::move(ir_value), device, logical_element_type);
+  return Create(std::move(ir_value), device, logical_element_type);
 }
 
 void XLATensor::ApplyPendingGraph() {

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -1396,16 +1396,9 @@ class XLATensor : public c10::intrusive_ptr_target {
   // Create a new XLA tensor with the same metadata of the input tensor (with
   // possible overrides), and the new IR value.
   XLATensorPtr CreateFrom(torch::lazy::Value ir_value) const;
-  XLATensorPtr CreateFrom(torch::lazy::Value ir_value,
-                          const torch::lazy::BackendDevice& device) const;
-  XLATensorPtr CreateFrom(torch::lazy::Value ir_value,
-                          at::ScalarType logical_element_type) const;
   XLATensorPtr CreateFrom(
       torch::lazy::Value ir_value,
       c10::optional<at::ScalarType> logical_element_type_opt) const;
-  XLATensorPtr CreateFrom(torch::lazy::Value ir_value,
-                          const torch::lazy::BackendDevice& device,
-                          at::ScalarType logical_element_type) const;
 
   // We build an XLA graph accumulating XLA operations, but at a given point we
   // need to force a rendering, otherwise the graph can grow without control.

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -100,7 +100,6 @@ class XLATensor : public c10::intrusive_ptr_target {
   void SetScalarType(c10::optional<at::ScalarType> logical_element_type);
 
   xla::util::MaybeRef<xla::Shape> shape() const;
-  xla::Shape shape_with_layout() const;
 
   const torch::lazy::BackendDevice& GetDevice() const;
   int64_t GetUniqueId() const;

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -238,12 +238,6 @@ class XLATensor : public c10::intrusive_ptr_target {
   // All the tensors must be on the same device.
   static std::vector<at::Tensor> GetTensors(std::vector<XLATensorPtr>* tensors);
 
-  // Operation which creates XLA tensors out of PyTorch CPU tensors by batching
-  // the requests to the computation servers.
-  static std::vector<XLATensorPtr> CreateTensors(
-      const std::vector<at::Tensor>& tensors,
-      const std::vector<std::string>& devices);
-
   //////////////////////////////////////////////////////////////////////////////
   // XLA dedicated operators follows here, listed in alphabetical order.
   //////////////////////////////////////////////////////////////////////////////

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -1393,6 +1393,10 @@ class XLATensor : public c10::intrusive_ptr_target {
   XLATensorPtr CreateFrom(
       torch::lazy::Value ir_value,
       c10::optional<at::ScalarType> logical_element_type_opt) const;
+  // TODO: We should remove this one once MaybeCastIrValue is no longer needed.
+  XLATensorPtr CreateFrom(torch::lazy::Value ir_value,
+                          const torch::lazy::BackendDevice& device,
+                          at::ScalarType logical_element_type) const;
 
   // We build an XLA graph accumulating XLA operations, but at a given point we
   // need to force a rendering, otherwise the graph can grow without control.

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1204,7 +1204,7 @@ XLATensorPtr XLATensor::full_like(const XLATensorPtr& input,
   } else {
     scalar_type = input->dtype();
   }
-  return input->CreateFrom(
+  return XLATensor::Create(
       GetIrValueForScalar(fill_value, tensor_shape, device), device,
       *scalar_type);
 }

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1204,7 +1204,7 @@ XLATensorPtr XLATensor::full_like(const XLATensorPtr& input,
   } else {
     scalar_type = input->dtype();
   }
-  return XLATensor::Create(
+  return input->CreateFrom(
       GetIrValueForScalar(fill_value, tensor_shape, device), device,
       *scalar_type);
 }


### PR DESCRIPTION
Summary:
This pull request removes `XLATensor::shape_with_layout`, `XLATensor::CreateTensors` and some `XLATensor::CreateFrom`. In addition, it also removes `MaybeCastIrValue` in `XLATensor::CreateFrom` which should no longer be needed.

Test Plan:
CI.