### PR TITLE
Add aten::_cdist_forward

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -11620,5 +11620,24 @@ TEST_F(AtenXlaTensorTest, TestExpandIsAliasOf) {
   });
 }
 
+TEST_F(AtenXlaTensorTest, TestCdistForward) {
+  torch::Tensor a =
+      torch::rand({2, 20, 5}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor b =
+      torch::rand({2, 10, 5}, torch::TensorOptions(torch::kFloat));
+  std::vector<double> p_list = {0.0, 1.0, 2.0, 5.0,
+                                std::numeric_limits<double>::infinity()};
+  for (const auto& p : p_list) {
+    torch::Tensor c = torch::cdist(a, b, p);
+    ForEachDevice([&](const torch::Device& device) {
+      torch::Tensor xla_a = CopyToDevice(a, device);
+      torch::Tensor xla_b = CopyToDevice(b, device);
+      torch::Tensor xla_c = torch::cdist(xla_a, xla_b, p);
+      AllClose(c, xla_c);
+    });
+  }
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+}
+
 }  // namespace cpp_test
 }  // namespace torch_xla

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -11637,6 +11637,7 @@ TEST_F(AtenXlaTensorTest, TestCdistForward) {
     });
   }
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::_cdist_forward", cpp_test::GetIgnoredCounters());
 }
 
 }  // namespace cpp_test

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3094,8 +3094,9 @@ at::Tensor XLANativeFunctions::_cdist_forward(
   // compute_mode is ignored because the use_mm_for_euclid_dist lowering
   // (compute_mode is 0 or 1) is achieved through composite ops from
   // native pytorch.
+  TORCH_LAZY_FN_COUNTER("xla::");
   XLA_CHECK(p >= 0) << "p value for the p-norm distance must be >= 0";
-  return bridge::AtenFromXlaTensor(tensor_methods::_cdist_forward(
+  return bridge::AtenFromXlaTensor(tensor_methods::cdist_forward(
       bridge::GetXlaTensor(x1), bridge::GetXlaTensor(x2), p));
 }
 

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3088,4 +3088,15 @@ at::Tensor XLANativeFunctions::slice_backward(const at::Tensor& grad_output,
                                     step);
 }
 
+at::Tensor XLANativeFunctions::_cdist_forward(
+    const at::Tensor& x1, const at::Tensor& x2, double p,
+    c10::optional<int64_t> compute_mode) {
+  // compute_mode is ignored because the use_mm_for_euclid_dist lowering
+  // (compute_mode is 0 or 1) is achieved through composite ops from
+  // native pytorch.
+  XLA_CHECK(p >= 0) << "p value for the p-norm distance must be >= 0";
+  return bridge::AtenFromXlaTensor(tensor_methods::_cdist_forward(
+      bridge::GetXlaTensor(x1), bridge::GetXlaTensor(x2), p));
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/cdist.cpp
+++ b/torch_xla/csrc/ops/cdist.cpp
@@ -1,0 +1,58 @@
+#include "torch_xla/csrc/ops/cdist.h"
+
+#include "torch_xla/csrc/lowering_context.h"
+#include "torch_xla/csrc/ops/infer_output_shape.h"
+#include "torch_xla/csrc/xla_lower_util.h"
+
+namespace torch_xla {
+namespace {
+
+xla::Shape NodeOutputShape(const torch::lazy::Value& x1,
+                           const torch::lazy::Value& x2,
+                           const torch::lazy::Value& p, bool use_hamming,
+                           bool use_chebyshev) {
+  auto lower_for_shape_fn =
+      [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
+    return BuildCdistForward(operands[0], operands[1], operands[2], use_hamming,
+                             use_chebyshev);
+  };
+  return InferOutputShape({GetXlaShape(x1), GetXlaShape(x2), GetXlaShape(p)},
+                          lower_for_shape_fn);
+}
+
+}  // namespace
+
+CdistForward::CdistForward(const torch::lazy::Value& x1,
+                           const torch::lazy::Value& x2,
+                           const torch::lazy::Value& p, bool use_hamming,
+                           bool use_chebyshev)
+    : XlaNode(torch::lazy::OpKind(at::aten::_cdist_forward), {x1, x2, p},
+              [&]() {
+                return NodeOutputShape(x1, x2, p, use_hamming, use_chebyshev);
+              },
+              /*num_outputs=*/1,
+              torch::lazy::MHash(use_hamming, use_chebyshev)),
+      use_hamming_(use_hamming),
+      use_chebyshev_(use_chebyshev) {}
+
+torch::lazy::NodePtr CdistForward::Clone(torch::lazy::OpList operands) const {
+  return torch::lazy::MakeNode<CdistForward>(operands.at(0), operands.at(1),
+                                             operands.at(2), use_hamming_,
+                                             use_chebyshev_);
+}
+
+XlaOpVector CdistForward::Lower(LoweringContext* loctx) const {
+  xla::XlaOp x1 = loctx->GetOutputOp(operand(0));
+  xla::XlaOp x2 = loctx->GetOutputOp(operand(1));
+  xla::XlaOp p = loctx->GetOutputOp(operand(2));
+  return ReturnOp(BuildCdistForward(x1, x2, p, use_hamming_, use_chebyshev_),
+                  loctx);
+}
+
+std::string CdistForward::ToString() const {
+  std::stringstream ss;
+  ss << XlaNode::ToString();
+  return ss.str();
+}
+
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/cdist.cpp
+++ b/torch_xla/csrc/ops/cdist.cpp
@@ -51,7 +51,8 @@ XlaOpVector CdistForward::Lower(LoweringContext* loctx) const {
 
 std::string CdistForward::ToString() const {
   std::stringstream ss;
-  ss << XlaNode::ToString();
+  ss << XlaNode::ToString() << ", use_hamming=" << use_hamming_
+     << ", use_chebyshev=" << use_chebyshev_;
   return ss.str();
 }
 

--- a/torch_xla/csrc/ops/cdist.h
+++ b/torch_xla/csrc/ops/cdist.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "torch_xla/csrc/ir.h"
+
+namespace torch_xla {
+
+class CdistForward : public XlaNode {
+ public:
+  CdistForward(const torch::lazy::Value& x1, const torch::lazy::Value& x2,
+               const torch::lazy::Value& p, bool use_hamming,
+               bool use_chebyshev);
+
+  std::string ToString() const override;
+
+  torch::lazy::NodePtr Clone(torch::lazy::OpList operands) const override;
+
+  XlaOpVector Lower(LoweringContext* loctx) const override;
+
+ private:
+  bool use_hamming_;    // handle p == 0
+  bool use_chebyshev_;  // handle p == +inf
+};
+
+}  // namespace torch_xla

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -856,7 +856,7 @@ XLATensorPtr cat(absl::Span<const XLATensorPtr> tensors, int64_t dim,
                                 dtype);
 }
 
-XLATensorPtr _cdist_forward(const XLATensorPtr& x1, const XLATensorPtr& x2,
+XLATensorPtr cdist_forward(const XLATensorPtr& x1, const XLATensorPtr& x2,
                             double p) {
   torch::lazy::Value exponent_node =
       XLATensor::GetIrValueForScalar(p, x1->GetDevice());

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -857,7 +857,7 @@ XLATensorPtr cat(absl::Span<const XLATensorPtr> tensors, int64_t dim,
 }
 
 XLATensorPtr cdist_forward(const XLATensorPtr& x1, const XLATensorPtr& x2,
-                            double p) {
+                           double p) {
   torch::lazy::Value exponent_node =
       XLATensor::GetIrValueForScalar(p, x1->GetDevice());
   torch::lazy::NodePtr node = torch::lazy::MakeNode<CdistForward>(

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -231,7 +231,7 @@ std::vector<XLATensorPtr> broadcast_tensors(
 XLATensorPtr cat(absl::Span<const XLATensorPtr> tensors, int64_t dim,
                  at::ScalarType dtype);
 
-XLATensorPtr _cdist_forward(const XLATensorPtr& x1, const XLATensorPtr& x2,
+XLATensorPtr cdist_forward(const XLATensorPtr& x1, const XLATensorPtr& x2,
                             double p);
 
 XLATensorPtr celu(const XLATensorPtr& input, const at::Scalar& alpha);

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -231,6 +231,9 @@ std::vector<XLATensorPtr> broadcast_tensors(
 XLATensorPtr cat(absl::Span<const XLATensorPtr> tensors, int64_t dim,
                  at::ScalarType dtype);
 
+XLATensorPtr _cdist_forward(const XLATensorPtr& x1, const XLATensorPtr& x2,
+                            double p);
+
 XLATensorPtr celu(const XLATensorPtr& input, const at::Scalar& alpha);
 void celu_(XLATensorPtr& input, const at::Scalar& alpha);
 

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -232,7 +232,7 @@ XLATensorPtr cat(absl::Span<const XLATensorPtr> tensors, int64_t dim,
                  at::ScalarType dtype);
 
 XLATensorPtr cdist_forward(const XLATensorPtr& x1, const XLATensorPtr& x2,
-                            double p);
+                           double p);
 
 XLATensorPtr celu(const XLATensorPtr& input, const at::Scalar& alpha);
 void celu_(XLATensorPtr& input, const at::Scalar& alpha);

--- a/torch_xla/csrc/xla_lower_util.cpp
+++ b/torch_xla/csrc/xla_lower_util.cpp
@@ -1026,4 +1026,64 @@ xla::XlaOp BuildAddcmul(xla::XlaOp input, xla::XlaOp t1, xla::XlaOp t2,
       input, XlaHelpers::PromotedMul(XlaHelpers::PromotedMul(t1, t2), val));
 }
 
+xla::XlaOp BuildCdistForward(xla::XlaOp x1, xla::XlaOp x2, xla::XlaOp p,
+                             bool use_hamming, bool use_chebyshev) {
+  const xla::Shape& x1_shape = XlaHelpers::ShapeOfXlaOp(x1);
+  const xla::Shape& x2_shape = XlaHelpers::ShapeOfXlaOp(x2);
+  p = MaybeConvertTo(p, x1_shape.element_type());
+
+  XLA_CHECK(x1_shape.rank() == x2_shape.rank() && x1_shape.rank() >= 2)
+      << "x1 and x2 must have the same rank with >= 2 dimensions";
+
+  int rank = x1_shape.rank();
+
+  XLA_CHECK(x1_shape.dimensions(rank - 1) == x2_shape.dimensions(rank - 1))
+      << "The last dimension of x1 and x2 must match";
+
+  for (int dim = 0; dim < rank - 2; dim++) {
+    XLA_CHECK(x1_shape.dimensions(dim) == x2_shape.dimensions(dim))
+        << absl::StrCat("The ", dim, "th dimension of x1 and x2 must match");
+  }
+
+  std::vector<int64_t> bcast_shape(x1_shape.dimensions().begin(),
+                                   x1_shape.dimensions().end());
+  bcast_shape.insert(bcast_shape.begin() + rank - 1,
+                     x2_shape.dimensions(rank - 2));
+  xla::XlaOp x1_bcast =
+      xla::BroadcastInDim(BuildUnsqueeze(x1, rank - 1), bcast_shape,
+                          torch::lazy::Iota<int64_t>(rank + 1));
+  xla::XlaOp x2_bcast =
+      xla::BroadcastInDim(BuildUnsqueeze(x2, rank - 2), bcast_shape,
+                          torch::lazy::Iota<int64_t>(rank + 1));
+
+  if (use_hamming) {
+    // handle p == 0
+    xla::XlaOp diff = xla::ConvertElementType(xla::Ne(x1_bcast, x2_bcast),
+                                              x1_shape.element_type());
+    xla::XlaOp init_value = xla::Zero(x1.builder(), x1_shape.element_type());
+    xla::XlaOp reduced = xla::Reduce(
+        diff, init_value,
+        XlaHelpers::CreateAddComputation(x1_shape.element_type()), {rank});
+    return reduced;
+  } else if (use_chebyshev) {
+    // handle p == +inf
+    xla::XlaOp diff = xla::Abs(x1_bcast - x2_bcast);
+    xla::XlaOp init_value = xla::Zero(x1.builder(), x1_shape.element_type());
+    xla::XlaOp reduced = xla::Reduce(
+        diff, init_value,
+        XlaHelpers::CreateMaxComputation(x1_shape.element_type()), {rank});
+    return reduced;
+  } else {
+    // handle general case
+    xla::XlaOp diff = xla::Pow(xla::Abs(x1_bcast - x2_bcast), p);
+    xla::XlaOp init_value = xla::Zero(x1.builder(), x1_shape.element_type());
+    xla::XlaOp reduced = xla::Reduce(
+        diff, init_value,
+        XlaHelpers::CreateAddComputation(x1_shape.element_type()), {rank});
+    xla::XlaOp one = xla::One(x1.builder(), x1_shape.element_type());
+    xla::XlaOp p_norm = xla::Pow(reduced, xla::Div(one, p));
+    return p_norm;
+  }
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/xla_lower_util.cpp
+++ b/torch_xla/csrc/xla_lower_util.cpp
@@ -1055,8 +1055,7 @@ xla::XlaOp BuildCdistForward(xla::XlaOp x1, xla::XlaOp x2, xla::XlaOp p,
   xla::XlaOp x2_bcast =
       xla::BroadcastInDim(BuildUnsqueeze(x2, rank - 2), bcast_shape,
                           torch::lazy::Iota<int64_t>(rank + 1));
-  xla::XlaOp init_value =
-      xla::Zero(x1.builder(), x1_shape.element_type());
+  xla::XlaOp init_value = xla::Zero(x1.builder(), x1_shape.element_type());
 
   if (use_hamming) {
     // handle p == 0

--- a/torch_xla/csrc/xla_lower_util.h
+++ b/torch_xla/csrc/xla_lower_util.h
@@ -125,4 +125,7 @@ xla::XlaOp BuildAddcdiv(xla::XlaOp input, xla::XlaOp t1, xla::XlaOp t2,
 xla::XlaOp BuildAddcmul(xla::XlaOp input, xla::XlaOp t1, xla::XlaOp t2,
                         xla::XlaOp val);
 
+xla::XlaOp BuildCdistForward(xla::XlaOp x1, xla::XlaOp x2, xla::XlaOp p,
+                             bool use_hamming, bool use_chebyshev);
+
 }  // namespace torch_xla

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -345,6 +345,7 @@ supported:
   - pixel_unshuffle
   - select_backward
   - linalg_pinv.atol_rtol_tensor
+  - _cdist_forward
   # The same applies to these ops, but we already have direct lowerings for them
   # - _trilinear
   # - logsumexp.out


### PR DESCRIPTION
This PR adds `aten::_cdist_forward`. `torch.cdist` has two implementations, this PR covers the general case when p=[0,+inf] while the special case (use_mm_for_euclid_dist) is already supported through composite ops.