### PR TITLE
Fix tf_patches/f16_abi_clang.diff ill-format.

### DIFF
--- a/tf_patches/f16_abi_clang.diff
+++ b/tf_patches/f16_abi_clang.diff
@@ -17,3 +17,4 @@ index 9fe020d5937..32774c2f3c0 100644
  // Older versions of Clang don't have _Float16. Since both float and _Float16
  // are passed in the same register we can use the wider type and careful casting
  // to conform to x86_64 psABI. This only works with the assumption that we're
+


### PR DESCRIPTION
Without this fix, `git apply` command failed with
```
(base) jenkins@ecaf13a10ec0:/workspace/pytorch/xla/third_party/tensorflow$ git apply ../../tf_patches/f16_abi_clang.diff
error: corrupt patch at line 19
```
The file needs a newline at the end.