### PR TITLE
Add virtual device metrics

### DIFF
--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1451,6 +1451,7 @@ void InitXlaModuleBindings(py::module m) {
   m.def("_xla_mark_sharding", [](const at::Tensor& input,
                                  const py::list& tile_assignment,
                                  bool replicated = false, bool manual = false) {
+    TORCH_LAZY_COUNTER("XlaMarkSharding", 1);
     xla::OpSharding sharding =
         ShardingUtil::CreateOpSharding(tile_assignment, replicated, manual);
     XLATensorPtr xtensor = bridge::GetXlaTensor(input);
@@ -1464,6 +1465,7 @@ void InitXlaModuleBindings(py::module m) {
     at::Tensor cpu_tensor;
     if (xla::sys_util::GetEnvBool("XLA_USE_SPMD", false) &&
         xtensor->CurrentTensorData().has_value()) {
+      TORCH_LAZY_COUNTER("VirtualDeviceUsage", 1);
       // When virtual device is enabled for SPMD, we defer the initial data
       // transfer to the device and retain the original data on the host, until
       // the sharded data transfer.


### PR DESCRIPTION
Adding metrics so that we can verify in the profile when (and how often) the virtual device optimization is used during mark_sharding.

---
It looks like there are already metrics for Transfer To/From Server
https://github.com/pytorch/xla/blob/803052c154011ca8fd3c93cdc39e8a72056189f1/third_party/xla_client/pjrt_computation_client.cc#L120-L121
 https://github.com/pytorch/xla/blob/803052c154011ca8fd3c93cdc39e8a72056189f1/third_party/xla_client/pjrt_computation_client.cc#L177-L178