### PR TITLE
Lower _native_batch_norm_legit

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -238,6 +238,7 @@ allowed_opinfo = set(
             AllowedOpInfoEntry('where'),
             AllowedOpInfoEntry('norm', 'fro'),
             AllowedOpInfoEntry('special.erfcx'),
+            AllowedOpInfoEntry('_native_batch_norm_legit'),
 
             # Duplicate Redundant entries for this test.
             # AllowedOpInfoEntry('polygamma', 'polygamma_n_1'),

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1866,6 +1866,44 @@ XLANativeFunctions::native_batch_norm(
 }
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor>
+XLANativeFunctions::_native_batch_norm_legit(
+    const at::Tensor& input, const c10::optional<at::Tensor>& weight,
+    const c10::optional<at::Tensor>& bias, at::Tensor& running_mean,
+    at::Tensor& running_var, bool training, double momentum, double eps) {
+  TORCH_LAZY_FN_COUNTER("xla::");
+  XLATensorPtr input_tensor = bridge::GetXlaTensor(input);
+  const torch::lazy::BackendDevice& device = input_tensor->GetDevice();
+  XLATensorPtr running_mean_tensor = bridge::GetXlaTensor(running_mean);
+  XLATensorPtr running_var_tensor = bridge::GetXlaTensor(running_var);
+  auto outputs = tensor_methods::native_batch_norm(
+      bridge::GetXlaTensor(input), bridge::GetOrCreateXlaTensor(weight, device),
+      bridge::GetOrCreateXlaTensor(bias, device), running_mean_tensor,
+      running_var_tensor, training, momentum, eps);
+  return std::make_tuple(bridge::AtenFromXlaTensor(std::get<0>(outputs)),
+                         bridge::AtenFromXlaTensor(std::get<1>(outputs)),
+                         bridge::AtenFromXlaTensor(std::get<2>(outputs)));
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor>
+XLANativeFunctions::_native_batch_norm_legit(
+    const at::Tensor& input, const c10::optional<at::Tensor>& weight,
+    const c10::optional<at::Tensor>& bias, bool training, double momentum,
+    double eps) {
+  TORCH_LAZY_FN_COUNTER("xla::");
+  XLATensorPtr input_tensor = bridge::GetXlaTensor(input);
+  const torch::lazy::BackendDevice& device = input_tensor->GetDevice();
+  XLATensorPtr null_running_mean_tensor = XLATensorPtr();
+  XLATensorPtr null_running_var_tensor = XLATensorPtr();
+  auto outputs = tensor_methods::native_batch_norm(
+      bridge::GetXlaTensor(input), bridge::GetOrCreateXlaTensor(weight, device),
+      bridge::GetOrCreateXlaTensor(bias, device), null_running_mean_tensor,
+      null_running_var_tensor, training, momentum, eps);
+  return std::make_tuple(bridge::AtenFromXlaTensor(std::get<0>(outputs)),
+                         bridge::AtenFromXlaTensor(std::get<1>(outputs)),
+                         bridge::AtenFromXlaTensor(std::get<2>(outputs)));
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor>
 XLANativeFunctions::native_batch_norm_backward(
     const at::Tensor& grad_out, const at::Tensor& input,
     const c10::optional<at::Tensor>& weight,

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -331,6 +331,8 @@ supported:
   - where.self
   - xlogy.Tensor
   - zero_
+  - _native_batch_norm_legit
+  - _native_batch_norm_legit.no_stats
   # Below are all operators that are "composite" in core,
   # but require us to explicitly re-enable functionalization in order to use them.
   # Why? These operators are all CompositeExplicitAutograd, which mean that they run


### PR DESCRIPTION
New op is being added in https://github.com/pytorch/pytorch/pull/88697/files and has similar sematics as `native_batch_norm`. These ops will only be used in dynamo and currently blocks https://github.com/pytorch/pytorch/pull/88449

I don't think this op will be triggered in c++ or enable the opinfo test.