### PR TITLE
Add note [Note: Re-using upstream TensorImpl]

### DIFF
--- a/torch_xla/csrc/tensor_impl.h
+++ b/torch_xla/csrc/tensor_impl.h
@@ -8,6 +8,14 @@
 
 namespace torch_xla {
 
+// [Note: Re-using upstream TensorImpl] As part of the LTC migration effort,
+// we tried to re-use the upstream LTCTensorImpl (torch/csrc/lazy/core/tensor_impl.h) 
+// instead of having our own version of XLATensorImpl. However, LTCTensorImpl defines
+// its own set of hard-coded dispatch keys in its constructor and has functions that
+// call this constructor. In addition, updating XLATensorImpl to extend LTCTensorImpl
+// does not produce much benefit since that wouldn't remove much duplicate code. 
+// As a result, we decided to keep and use XLATensorImpl. 
+
 // Tensor implementation class used to be fed to the at::Tensor.
 // Its scope is just to handle an XLATensor.
 class XLATensorImpl : public c10::TensorImpl {

--- a/torch_xla/csrc/tensor_impl.h
+++ b/torch_xla/csrc/tensor_impl.h
@@ -9,12 +9,13 @@
 namespace torch_xla {
 
 // [Note: Re-using upstream TensorImpl] As part of the LTC migration effort,
-// we tried to re-use the upstream LTCTensorImpl (torch/csrc/lazy/core/tensor_impl.h) 
-// instead of having our own version of XLATensorImpl. However, LTCTensorImpl defines
-// its own set of hard-coded dispatch keys in its constructor and has functions that
-// call this constructor. In addition, updating XLATensorImpl to extend LTCTensorImpl
-// does not produce much benefit since that wouldn't remove much duplicate code. 
-// As a result, we decided to keep and use XLATensorImpl. 
+// we tried to re-use the upstream LTCTensorImpl
+// (torch/csrc/lazy/core/tensor_impl.h) instead of having our own version of
+// XLATensorImpl. However, LTCTensorImpl defines its own set of hard-coded
+// dispatch keys in its constructor and has functions that call this
+// constructor. In addition, updating XLATensorImpl to extend LTCTensorImpl does
+// not produce much benefit since that wouldn't remove much duplicate code. As a
+// result, we decided to keep and use XLATensorImpl.
 
 // Tensor implementation class used to be fed to the at::Tensor.
 // Its scope is just to handle an XLATensor.

--- a/wonjoo.py
+++ b/wonjoo.py
@@ -1,0 +1,5 @@
+import torch
+import torch_xla
+
+device = "xla:0"
+a_xla = torch.tensor([1, 2], device=device)

--- a/wonjoo.py
+++ b/wonjoo.py
@@ -1,5 +1,0 @@
-import torch
-import torch_xla
-
-device = "xla:0"
-a_xla = torch.tensor([1, 2], device=device)


### PR DESCRIPTION
Add note [Note: Re-using upstream TensorImpl]

---
We decided not to re-use the upstream LTCTensorImpl. Adding a note for future reference. The LTC design doc is updated to reflect this as well. 