### PR TITLE
Correctly configure PJRT execution when nprocs=1.

### DIFF
--- a/test/pjrt/test_experimental_pjrt.py
+++ b/test/pjrt/test_experimental_pjrt.py
@@ -42,7 +42,7 @@ class TestExperimentalPjrt(parameterized.TestCase):
                    pjrt.global_device_count())
 
   def test_world_size(self):
-    self.assertEqual(xm.xrt_world_size(), pjrt.global_device_count())
+    self.assertEqual(xm.xrt_world_size(), pjrt.world_size())
 
   def test_xla_device_error(self):
     with self.assertRaises(IndexError):

--- a/test/pjrt/test_experimental_pjrt_tpu.py
+++ b/test/pjrt/test_experimental_pjrt_tpu.py
@@ -11,6 +11,7 @@ import torch_xla.core.xla_env_vars as xenv
 import torch_xla.core.xla_model as xm
 from torch_xla.experimental import pjrt
 from torch_xla.experimental import tpu
+import torch_xla.distributed.xla_multiprocessing as xmp
 
 
 class TestExperimentalPjrtTpu(parameterized.TestCase):
@@ -99,6 +100,18 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
 
     devices = pjrt._run_multiprocess(xm.xla_device)
     self.assertDictEqual(devices, expected)
+
+  @staticmethod
+  def _fail_on_nonfirst_device(i):
+    assert i == 0, f"the device index {i} must be 0 in nprocs=1"
+
+  def test_xla_devices_single_process_one_chip_one_device_spawn(self):
+    accelerators = ['v3-8', 'v4-8']
+
+    if self.accelerator_type not in accelerators:
+      raise NotImplementedError('Test not implemented for {}'.format(
+          self.accelerator_type))
+    xmp.spawn(self._fail_on_nonfirst_device, nprocs=1)
 
   def test_default_xla_devices(self):
     accelerator_num_devices = {

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -159,7 +159,7 @@ def xrt_world_size(defval=1):
     The number of devices which is taking part of the replication.
   """
   if pjrt.using_pjrt():
-    return pjrt.global_device_count()
+    return pjrt.world_size()
 
   return xu.getenv_as(xenv.WORLD_SIZE, int, defval=defval)
 

--- a/torch_xla/distributed/xla_multiprocessing.py
+++ b/torch_xla/distributed/xla_multiprocessing.py
@@ -386,7 +386,7 @@ def spawn(fn,
     return None.
   """
   if pjrt.using_pjrt():
-    return pjrt.spawn(fn, start_method, args)
+    return pjrt.spawn(fn, nprocs, start_method, args)
 
   if not _is_xla_config():
     # If this is not an XLA setup, jump to normal multi-processing.

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -263,8 +263,10 @@ def _run_singleprocess(fn: Callable[..., R],
 
       return fn()
 
-    init_pjrt_process_group()
-    return executor.submit(_thread_fn, xm.xla_device()).result()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+      init_pjrt_process_group()
+
+      return executor.submit(_thread_fn, xm.xla_device()).result()
 
 
 @requires_pjrt

--- a/torch_xla/experimental/tpu.py
+++ b/torch_xla/experimental/tpu.py
@@ -108,6 +108,15 @@ def get_worker_ips() -> List[str]:
 
   return ips if len(ips) > 1 else ['localhost']
 
+def configure_one_chip_topology() -> None:
+  """Configures TPU topology environment variables for one process and chip.
+
+  Must be run before using any XLA devices.
+  """
+  os.environ.setdefault(xenv.TPU_VISIBLE_CHIPS, '0')
+  os.environ.setdefault(xenv.TPU_CHIPS_PER_PROCESS_BOUNDS, '1,1,1')
+  os.environ.setdefault(xenv.TPU_PROCESS_BOUNDS, '1,1,1')
+
 
 def configure_topology(local_rank: int,
                        local_world_size: int,

--- a/torch_xla/experimental/tpu.py
+++ b/torch_xla/experimental/tpu.py
@@ -108,6 +108,7 @@ def get_worker_ips() -> List[str]:
 
   return ips if len(ips) > 1 else ['localhost']
 
+
 def configure_one_chip_topology() -> None:
   """Configures TPU topology environment variables for one process and chip.
 


### PR DESCRIPTION
Currently there is not easy way to tweak a model written with pjrt.run_multiprocess to run with single core/device easily. This is a useful feature when debugging some model failure.

In the XRT world, we can pass the `num_process` as 1 to `xmp.spawn`, and this should be mirrored in PJRT.