### PR TITLE
Introduce CreateShardedIrValue API

### DIFF
--- a/test/test_xla_sharding.py
+++ b/test/test_xla_sharding.py
@@ -129,11 +129,6 @@ class XlaShardingTest(unittest.TestCase):
     # Adding 0 to the tensor force graph compilation, which would catch IR hash
     # collisions
     self.assertTrue(torch.allclose(xt1 + 0, xt2 + 0))
-    
-    # Check that hashes are different for the sharded and non-sharded tensors
-    hash1 = torch_xla._XLAC._get_graph_hash([xt1])
-    hash2 = torch_xla._XLAC._get_graph_hash([xt2])
-    self.assertNotEqual(hash1, hash2)
 
     # Check that hashes are different for the sharded and non-sharded tensors
     hash1 = torch_xla._XLAC._get_graph_hash([xt1])

--- a/test/test_xla_sharding.py
+++ b/test/test_xla_sharding.py
@@ -135,6 +135,10 @@ class XlaShardingTest(unittest.TestCase):
     hash2 = torch_xla._XLAC._get_graph_hash([xt2])
     self.assertNotEqual(hash1, hash2)
 
+    # Adding 0 to the tensor force graph compilation, which would catch IR hashi
+    # collisions
+    self.assertTrue(torch.allclose(xt1 + 0, xt2 + 0))
+
 
 class VirtualDeviceTest(XlaShardingTest):
 

--- a/test/test_xla_sharding.py
+++ b/test/test_xla_sharding.py
@@ -135,10 +135,6 @@ class XlaShardingTest(unittest.TestCase):
     hash2 = torch_xla._XLAC._get_graph_hash([xt2])
     self.assertNotEqual(hash1, hash2)
 
-    # Adding 0 to the tensor force graph compilation, which would catch IR hashi
-    # collisions
-    self.assertTrue(torch.allclose(xt1 + 0, xt2 + 0))
-
 
 class VirtualDeviceTest(XlaShardingTest):
 

--- a/test/test_xla_sharding.py
+++ b/test/test_xla_sharding.py
@@ -129,6 +129,11 @@ class XlaShardingTest(unittest.TestCase):
     # Adding 0 to the tensor force graph compilation, which would catch IR hash
     # collisions
     self.assertTrue(torch.allclose(xt1 + 0, xt2 + 0))
+    
+    # Check that hashes are different for the sharded and non-sharded tensors
+    hash1 = torch_xla._XLAC._get_graph_hash([xt1])
+    hash2 = torch_xla._XLAC._get_graph_hash([xt2])
+    self.assertNotEqual(hash1, hash2)
 
     # Check that hashes are different for the sharded and non-sharded tensors
     hash1 = torch_xla._XLAC._get_graph_hash([xt1])

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1501,7 +1501,7 @@ void InitXlaModuleBindings(py::module m) {
         std::vector<XLATensor::ShardingSpecPtr>{new_sharding_spec},
         std::vector<std::string>{GetVirtualDevice().toString()})[0];
     xtensor->SetXlaData(xla_data);
-    xtensor->SetShardingSpec(*new_sharding_spec);
+    xtensor->CreateShardedIrValue(sharding);
   });
   m.def("_xla_clear_sharding", [](const at::Tensor& input) {
     XLATensorPtr xtensor = bridge::GetXlaTensor(input);

--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -209,6 +209,7 @@ torch::lazy::hash_t XlaNode::CreateShardingHash(
                                            (uint32_t)shape_proto.dimensions());
   sharding_hash = torch::lazy::HashCombine(
       sharding_hash, (uint32_t)sharding.is_dynamic_dimension());
+
   return sharding_hash;
 }
 

--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -175,7 +175,6 @@ const xla::Shape& GetXlaShape(const torch::lazy::Value& value) {
 torch::lazy::hash_t XlaNode::CreateShardingHash(
     std::shared_ptr<xla::OpSharding> sharding, torch::lazy::hash_t hash_seed) {
   torch::lazy::hash_t sharding_hash = hash_seed;
-<<<<<<< HEAD
   for (const auto& tile_assignment_dimension :
        sharding->tile_assignment_dimensions()) {
     sharding_hash = torch::lazy::HashCombine(
@@ -189,19 +188,6 @@ torch::lazy::hash_t XlaNode::CreateShardingHash(
   for (const auto& last_tile_dim : sharding->last_tile_dims()) {
     sharding_hash =
         torch::lazy::HashCombine(sharding_hash, (uint32_t)last_tile_dim);
-=======
-  for (const auto& tile_assignment_dimension : sharding->tile_assignment_dimensions()) {
-    sharding_hash = torch::lazy::HashCombine(
-        sharding_hash, (uint32_t)tile_assignment_dimension);
-  }
-  for (const auto& tile_assignment_device : sharding->tile_assignment_devices()) {
-    sharding_hash = torch::lazy::HashCombine(
-        sharding_hash, (uint32_t)tile_assignment_device);
-  }
-  for (const auto& last_tile_dim : sharding->last_tile_dims()) {
-    sharding_hash = torch::lazy::HashCombine(
-        sharding_hash, (uint32_t)last_tile_dim);
->>>>>>> Add sharding hash to IR nodes
   }
   sharding_hash =
       torch::lazy::HashCombine(sharding_hash, (uint32_t)sharding->type());
@@ -210,15 +196,6 @@ torch::lazy::hash_t XlaNode::CreateShardingHash(
 
   xla::ShapeProto shape_proto = sharding->tile_shape();
   sharding_hash = torch::lazy::HashCombine(
-<<<<<<< HEAD
-      sharding_hash, (uint32_t)shape_proto.element_type());
-  for (const auto& dim : shape_proto.dimensions()) {
-    sharding_hash = torch::lazy::HashCombine(sharding_hash, (uint32_t)dim);
-  }
-  for (const auto& is_dyn_dim : shape_proto.is_dynamic_dimension()) {
-    sharding_hash =
-        torch::lazy::HashCombine(sharding_hash, (uint32_t)is_dyn_dim);
-=======
       sharding_hash, (uint32_t)shape_proto.element_type()); 
   for (const auto& dim : shape_proto.dimensions()) {
     sharding_hash = torch::lazy::HashCombine(
@@ -227,9 +204,8 @@ torch::lazy::hash_t XlaNode::CreateShardingHash(
   for (const auto& is_dyn_dim : shape_proto.is_dynamic_dimension()) {
     sharding_hash = torch::lazy::HashCombine(
         sharding_hash, (uint32_t)is_dyn_dim);
->>>>>>> Add sharding hash to IR nodes
   }
-
+  
   return sharding_hash;
 }
 

--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -205,6 +205,10 @@ torch::lazy::hash_t XlaNode::CreateShardingHash(
         torch::lazy::HashCombine(sharding_hash, (uint32_t)is_dyn_dim);
   }
 
+  sharding_hash = torch::lazy::HashCombine(sharding_hash,
+                                           (uint32_t)shape_proto.dimensions());
+  sharding_hash = torch::lazy::HashCombine(
+      sharding_hash, (uint32_t)sharding.is_dynamic_dimension());
   return sharding_hash;
 }
 

--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -196,16 +196,15 @@ torch::lazy::hash_t XlaNode::CreateShardingHash(
 
   xla::ShapeProto shape_proto = sharding->tile_shape();
   sharding_hash = torch::lazy::HashCombine(
-      sharding_hash, (uint32_t)shape_proto.element_type()); 
+      sharding_hash, (uint32_t)shape_proto.element_type());
   for (const auto& dim : shape_proto.dimensions()) {
-    sharding_hash = torch::lazy::HashCombine(
-        sharding_hash, (uint32_t)dim);
+    sharding_hash = torch::lazy::HashCombine(sharding_hash, (uint32_t)dim);
   }
   for (const auto& is_dyn_dim : shape_proto.is_dynamic_dimension()) {
-    sharding_hash = torch::lazy::HashCombine(
-        sharding_hash, (uint32_t)is_dyn_dim);
+    sharding_hash =
+        torch::lazy::HashCombine(sharding_hash, (uint32_t)is_dyn_dim);
   }
-  
+
   return sharding_hash;
 }
 

--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -204,7 +204,7 @@ torch::lazy::hash_t XlaNode::CreateShardingHash(
     sharding_hash =
         torch::lazy::HashCombine(sharding_hash, (uint32_t)is_dyn_dim);
   }
-
+  
   sharding_hash = torch::lazy::HashCombine(sharding_hash,
                                            (uint32_t)shape_proto.dimensions());
   sharding_hash = torch::lazy::HashCombine(

--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -175,6 +175,7 @@ const xla::Shape& GetXlaShape(const torch::lazy::Value& value) {
 torch::lazy::hash_t XlaNode::CreateShardingHash(
     std::shared_ptr<xla::OpSharding> sharding, torch::lazy::hash_t hash_seed) {
   torch::lazy::hash_t sharding_hash = hash_seed;
+<<<<<<< HEAD
   for (const auto& tile_assignment_dimension :
        sharding->tile_assignment_dimensions()) {
     sharding_hash = torch::lazy::HashCombine(
@@ -188,6 +189,19 @@ torch::lazy::hash_t XlaNode::CreateShardingHash(
   for (const auto& last_tile_dim : sharding->last_tile_dims()) {
     sharding_hash =
         torch::lazy::HashCombine(sharding_hash, (uint32_t)last_tile_dim);
+=======
+  for (const auto& tile_assignment_dimension : sharding->tile_assignment_dimensions()) {
+    sharding_hash = torch::lazy::HashCombine(
+        sharding_hash, (uint32_t)tile_assignment_dimension);
+  }
+  for (const auto& tile_assignment_device : sharding->tile_assignment_devices()) {
+    sharding_hash = torch::lazy::HashCombine(
+        sharding_hash, (uint32_t)tile_assignment_device);
+  }
+  for (const auto& last_tile_dim : sharding->last_tile_dims()) {
+    sharding_hash = torch::lazy::HashCombine(
+        sharding_hash, (uint32_t)last_tile_dim);
+>>>>>>> Add sharding hash to IR nodes
   }
   sharding_hash =
       torch::lazy::HashCombine(sharding_hash, (uint32_t)sharding->type());
@@ -196,6 +210,7 @@ torch::lazy::hash_t XlaNode::CreateShardingHash(
 
   xla::ShapeProto shape_proto = sharding->tile_shape();
   sharding_hash = torch::lazy::HashCombine(
+<<<<<<< HEAD
       sharding_hash, (uint32_t)shape_proto.element_type());
   for (const auto& dim : shape_proto.dimensions()) {
     sharding_hash = torch::lazy::HashCombine(sharding_hash, (uint32_t)dim);
@@ -203,6 +218,16 @@ torch::lazy::hash_t XlaNode::CreateShardingHash(
   for (const auto& is_dyn_dim : shape_proto.is_dynamic_dimension()) {
     sharding_hash =
         torch::lazy::HashCombine(sharding_hash, (uint32_t)is_dyn_dim);
+=======
+      sharding_hash, (uint32_t)shape_proto.element_type()); 
+  for (const auto& dim : shape_proto.dimensions()) {
+    sharding_hash = torch::lazy::HashCombine(
+        sharding_hash, (uint32_t)dim);
+  }
+  for (const auto& is_dyn_dim : shape_proto.is_dynamic_dimension()) {
+    sharding_hash = torch::lazy::HashCombine(
+        sharding_hash, (uint32_t)is_dyn_dim);
+>>>>>>> Add sharding hash to IR nodes
   }
 
   return sharding_hash;

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -51,6 +51,11 @@ class XlaNode : public torch::lazy::Node {
           torch::lazy::hash_t hash_seed = default_hash_seed);
 
   XlaNode(torch::lazy::OpKind op, torch::lazy::OpList operands,
+          std::vector<torch::lazy::Shape>&& shapes, xla::Shape xla_shape,
+          xla::OpSharding sharding, size_t num_outputs = 1,
+          torch::lazy::hash_t hash_seed = default_hash_seed);
+
+  XlaNode(torch::lazy::OpKind op, torch::lazy::OpList operands,
           std::vector<torch::lazy::Shape>&& shapes,
           const std::function<xla::Shape()>& xla_shape_fn,
           size_t num_outputs = 1,
@@ -127,13 +132,6 @@ class XlaNode : public torch::lazy::Node {
     return output_sharding_;
   }
 
-  void SetSharding(const xla::OpSharding& sharding);
-
-  void ClearSharding() {
-    output_sharding_ = nullptr;
-    sharding_hash_ = 0;
-  }
-
  private:
   xla::Shape GetOpShape(const std::function<xla::Shape()>& shape_fn) const;
 
@@ -149,7 +147,6 @@ class XlaNode : public torch::lazy::Node {
   xla::Shape xla_shape_;
   torch::lazy::hash_t node_hash_ = 0;
   torch::lazy::hash_t dag_hash_;
-  torch::lazy::hash_t sharding_hash_ = 0;
 
   // Experimental sharding annotation attached to the IR node.
   // TODO(yeounoh): make sure that view update doesn't reset this.

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -204,6 +204,11 @@ class XLATensor : public torch::lazy::LazyTensor {
   // Override to enable SPMD.
   void AssignIrValue(torch::lazy::Value ir_value) const final;
 
+  // Creates a sharded IR node based on the current IR node and the given
+  // sharding. Note that this is marked as const, so that it can be called from
+  // AssignIrValue, but it does modify the object.
+  void CreateShardedIrValue(const ShardingSpec& sharding_spec) const;
+
  private:
   XLATensor(const at::Tensor& tensor, const torch::lazy::BackendDevice& device);
   XLATensor(torch::lazy::BackendDataPtr handle,
@@ -246,6 +251,8 @@ class XLATensor : public torch::lazy::LazyTensor {
   static bool UseEagerDebugMode();
 
   bool ShouldSyncIrNode();
+
+  void CreateUnshardedIrValue();
 
   // We store two shared_ptr of Data in a XLATensor.
   // One in the LazyTensor class as the LazyTensor::Data type


### PR DESCRIPTION
We replace SetSharding/ClearSharding APIs with CreateShardedIRValue, so that we can create hashes for the sharded node upon it's creation rather than updating it after it's been created.