### PR TITLE
api to grab running seed as device data

### DIFF
--- a/test/dynamo/test_dynamo_integrations_util.py
+++ b/test/dynamo/test_dynamo_integrations_util.py
@@ -41,16 +41,11 @@ class PybindTest(unittest.TestCase):
     ])
     assert (expected_tensor_ids == sorted(res_pair[0]))
 
-  def test_get_rng_seed_as_tensor(self):
+  def test_get_base_seed_as_tensor(self):
     device = xm.xla_device()
-    current_seed = xm.get_rng_state(device)
-    new_seed_tensor = torch_xla._XLAC._get_rng_seed_as_tensor(str(device), True)
-    self.assertNotEqual(current_seed, new_seed_tensor.item())
-    current_seed = xm.get_rng_state(device)
-    self.assertEqual(current_seed, new_seed_tensor.item())
-    new_seed_tensor_2 = torch_xla._XLAC._get_rng_seed_as_tensor(
-        str(device), False)
-    self.assertEqual(current_seed, new_seed_tensor_2.item())
+    xm.set_rng_state(23, str(device))
+    base_seed = torch_xla._XLAC._get_base_seed_as_tensor(str(device)).item()
+    self.assertEqual(23, base_seed)
 
   def test_get_seed_info_id(self):
     self.assertEqual(torch_xla._XLAC._get_seed_info_id(), -127389)

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1600,12 +1600,12 @@ void InitXlaModuleBindings(py::module m) {
 
   m.def("_get_seed_info_id", []() -> int64_t { return seed_info_id; });
 
-  m.def("_get_rng_seed_as_tensor",
-        [](const std::string& device_str, bool reset) -> at::IValue {
+  m.def("_get_base_seed_as_tensor",
+        [](const std::string& device_str) -> at::IValue {
           torch::lazy::BackendDevice device =
               bridge::AtenDeviceToXlaDevice(c10::Device(device_str));
           return bridge::AtenFromXlaTensor(torch_xla::XLATensor::Create(
-              XLAGraphExecutor::Get()->GetRngSeedData(device, reset)));
+              XLAGraphExecutor::Get()->GetBaseSeedData(device)));
         });
 
   // Return true if value of the tensor requires a computation.

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -82,8 +82,8 @@ class XLAGraphExecutor {
   torch::lazy::Value GetRngSeed(const torch::lazy::BackendDevice& device);
   void SetRngSeed(const torch::lazy::BackendDevice& device, uint64_t seed);
   uint64_t GetRunningSeed(const torch::lazy::BackendDevice& device);
-  torch::lazy::BackendDataPtr GetRngSeedData(
-      const torch::lazy::BackendDevice& device, bool reset);
+  torch::lazy::BackendDataPtr GetBaseSeedData(
+      const torch::lazy::BackendDevice& device);
 
   void DeviceBarrier(const torch::lazy::BackendDevice& device);
 


### PR DESCRIPTION
First of all, I'd like to reflect my understanding of how random number is used in torchxla:

When tracing modules that uses random numbers like DropOut, torchxla will need call `XLAGraphExecutor::GetRngSeed` to grab the current seed and put the seed into the traced graph. The API has a side effect of updating some DeviceContext object so next time when it's called, the next (different) seed is returned.  Here is an example of the bernoulli op used by Dropout: https://github.com/pytorch/xla/blob/master/torch_xla/csrc/tensor_methods.cpp#L782 . In this example, we can see that the current seed is grabbed as an IR node and used to create the Bernoulli IR node.

In our dynamo/torchxla bridge we reused the traced graph. To make sure we can maintain the numerical correctness (for benchmarking), the bridge should have the same behavior as regular torchxla. This PR change `GetRngSeedData` method to do the same thing as `GetRngSeed` but guarantee to return a DeviceData node. In the bridge whenever we need prepare a graph input which is identified as a seed, we should call `GetRngSeedData`.


