### PR TITLE
[WIP]Disable all failed PyTorch test

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -37,19 +37,19 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_addcmul',  # FIXME: complex dtype
         'test_clamp',  # slow
         'test_clamp_propagates_nans_xla',  # XLA min/max ignores Nans.
-        'test_cummax_cummin', # at::_ops::cummax_out::call(at::Tensor const&, long, at::Tensor&, at::Tensor&)
+        'test_cummax_cummin',  # at::_ops::cummax_out::call(at::Tensor const&, long, at::Tensor&, at::Tensor&)
         'test_cummax_discontiguous',  # Checking contiguity
         'test_cummin_discontiguous',  # Checking contiguity
-        'test_diff_xla_bool', # Received signal 6 & 11
-        'test_diff_xla_float32', # Received signal 6 & 11
-        'test_diff_xla_float64', # Received signal 6 & 11
-        'test_diff_xla_int16', # Received signal 6 & 11
-        'test_diff_xla_int32', # Received signal 6 & 11
-        'test_diff_xla_int64', # Received signal 6 & 11
-        'test_diff_xla_int8', # Received signal 6 & 11
-        'test_diff_xla_uint8', # Received signal 6 & 11
+        'test_diff_xla_bool',  # Received signal 6 & 11
+        'test_diff_xla_float32',  # Received signal 6 & 11
+        'test_diff_xla_float64',  # Received signal 6 & 11
+        'test_diff_xla_int16',  # Received signal 6 & 11
+        'test_diff_xla_int32',  # Received signal 6 & 11
+        'test_diff_xla_int64',  # Received signal 6 & 11
+        'test_diff_xla_int8',  # Received signal 6 & 11
+        'test_diff_xla_uint8',  # Received signal 6 & 11
         'test_discontiguous_out_cumsum',  # Checking contiguity
-        'test_invalid_shapes_grid_sampler_xla', # tsl::CurrentStackTrace[abi:cxx11]()
+        'test_invalid_shapes_grid_sampler_xla',  # tsl::CurrentStackTrace[abi:cxx11]()
         'test_lu_unpack',  # very slow compile
         'test_view',  # doesn't raise
         'test_sub_typing',  # doesn't raise
@@ -216,7 +216,7 @@ DISABLED_TORCH_TESTS_ANY = {
     # test_indexing.py
     'TestIndexingXLA': {
         'test_setitem_expansion_error',  # expecting a different runtime error
-        'test_setitem_scalars', # Received signal 6 & 11
+        'test_setitem_scalars',  # Received signal 6 & 11
         'test_multiple_byte_mask',  # expecting a different runtime error
         'test_empty_slice',  # stride
         'test_byte_tensor_assignment',  # expecting a different runtime error
@@ -224,7 +224,7 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_byte_mask_accumulate',  # expecting a different runtime error
         'test_bool_indices',  # expecting a different runtime error
         'test_index_getitem_copy_bools_slices',  # storage
-        'test_index_setitem_bools_slices', # torch::autograd::dispatch_set_item
+        'test_index_setitem_bools_slices',  # torch::autograd::dispatch_set_item
         'test_getitem_scalars',  # storage
         'test_empty_ndim_index',  # expecting a different runtime error
         'test_index_put_byte_indices_xla',  # expecting a different runtime error
@@ -243,7 +243,7 @@ DISABLED_TORCH_TESTS_ANY = {
 
     # test_nn.py
     'TestNNDeviceTypeXLA': {
-        'test_cross_entropy_label_smoothing_errors_xla', # Received signal 6 & 11
+        'test_cross_entropy_label_smoothing_errors_xla',  # Received signal 6 & 11
         'test_clip_grad_norm_error_if_nonfinite_xla',  # FIXME: edge case of norm
         'test_batchnorm_grad',  # FIXME! UndefinedTensorImpl::_singleton
         'test_nonlinearity_propagate_nan',  # relu6 with a nan tensor returns a tensor([0.]) instead of a nan tensor
@@ -254,12 +254,12 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_batchnorm_eval',  # FIXME! UndefinedTensorImpl::_singleton
         'test_MaxPool2d_indices',  # lowering
         'test_MaxPool1d_indices',  # lowering
-        'test_multi_margin_loss_errors_xla', # Received signal 6 & 11
+        'test_multi_margin_loss_errors_xla',  # Received signal 6 & 11
         'test_softshrink_negative',  # runtime error
         'test_nll_loss_empty_tensor_reduction_mean',  # floating point division 0 by 0, expecting nan but get 0
         'test_nll_loss_invalid_target_dim',  # expecting a specific error message.
         'test_nll_loss_invalid_weights',  # expecting a specific error message.
-        'test_nll_loss_mismatched_batch_xla', # Received signal 6 & 11
+        'test_nll_loss_mismatched_batch_xla',  # Received signal 6 & 11
         'test_fold',  # The gradient check code errors out on type() call, and code is slow on XLA
         'test_unfold',  # The gradient check code errors out on type() call, and code is slow on XLA
         'test_hardsigmoid_grad_xla',  # gradient check is slow
@@ -287,12 +287,12 @@ DISABLED_TORCH_TESTS_ANY = {
 
     # test/nn/test_pooling.py
     'TestPoolingNNDeviceTypeXLA': {
-        'test_AdaptiveMaxPool1d_indices_xla_float32', # THPEngine_run_backward
-        'test_AdaptiveMaxPool2d_indices_xla_float32', # THPEngine_run_backward
-        'test_AdaptiveMaxPool3d_indices_xla_float32', # THPEngine_run_backward
-        'test_MaxPool1d_indices_xla_float32', # THPEngine_run_backward
-        'test_MaxPool2d_indices_xla_float32', # THPEngine_run_backward
-        'test_MaxPool3d_indices_xla_float32', # THPEngine_run_backward
+        'test_AdaptiveMaxPool1d_indices_xla_float32',  # THPEngine_run_backward
+        'test_AdaptiveMaxPool2d_indices_xla_float32',  # THPEngine_run_backward
+        'test_AdaptiveMaxPool3d_indices_xla_float32',  # THPEngine_run_backward
+        'test_MaxPool1d_indices_xla_float32',  # THPEngine_run_backward
+        'test_MaxPool2d_indices_xla_float32',  # THPEngine_run_backward
+        'test_MaxPool3d_indices_xla_float32',  # THPEngine_run_backward
         'test_pool_invalid_size',  # expecting a different runtime error
     },
 
@@ -312,7 +312,7 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_Conv2d_backward_depthwise_xla_float64',  # slow compilation
         'test_conv3d_same_padding_backward_xla',  # XLA tensors do not have storage
         'test_conv3d_valid_padding_backward_xla_float64',  # Jacobian
-        'test_noncontig_conv_grad_xla_float64', # Jacobian
+        'test_noncontig_conv_grad_xla_float64',  # Jacobian
     },
 
     # test/nn/test_multihead_attention.py

--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -37,9 +37,19 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_addcmul',  # FIXME: complex dtype
         'test_clamp',  # slow
         'test_clamp_propagates_nans_xla',  # XLA min/max ignores Nans.
+        'test_cummax_cummin', # at::_ops::cummax_out::call(at::Tensor const&, long, at::Tensor&, at::Tensor&)
         'test_cummax_discontiguous',  # Checking contiguity
         'test_cummin_discontiguous',  # Checking contiguity
+        'test_diff_xla_bool', # Received signal 6 & 11
+        'test_diff_xla_float32', # Received signal 6 & 11
+        'test_diff_xla_float64', # Received signal 6 & 11
+        'test_diff_xla_int16', # Received signal 6 & 11
+        'test_diff_xla_int32', # Received signal 6 & 11
+        'test_diff_xla_int64', # Received signal 6 & 11
+        'test_diff_xla_int8', # Received signal 6 & 11
+        'test_diff_xla_uint8', # Received signal 6 & 11
         'test_discontiguous_out_cumsum',  # Checking contiguity
+        'test_invalid_shapes_grid_sampler_xla', # tsl::CurrentStackTrace[abi:cxx11]()
         'test_lu_unpack',  # very slow compile
         'test_view',  # doesn't raise
         'test_sub_typing',  # doesn't raise
@@ -206,6 +216,7 @@ DISABLED_TORCH_TESTS_ANY = {
     # test_indexing.py
     'TestIndexingXLA': {
         'test_setitem_expansion_error',  # expecting a different runtime error
+        'test_setitem_scalars', # Received signal 6 & 11
         'test_multiple_byte_mask',  # expecting a different runtime error
         'test_empty_slice',  # stride
         'test_byte_tensor_assignment',  # expecting a different runtime error
@@ -213,6 +224,7 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_byte_mask_accumulate',  # expecting a different runtime error
         'test_bool_indices',  # expecting a different runtime error
         'test_index_getitem_copy_bools_slices',  # storage
+        'test_index_setitem_bools_slices', # torch::autograd::dispatch_set_item
         'test_getitem_scalars',  # storage
         'test_empty_ndim_index',  # expecting a different runtime error
         'test_index_put_byte_indices_xla',  # expecting a different runtime error
@@ -231,6 +243,7 @@ DISABLED_TORCH_TESTS_ANY = {
 
     # test_nn.py
     'TestNNDeviceTypeXLA': {
+        'test_cross_entropy_label_smoothing_errors_xla', # Received signal 6 & 11
         'test_clip_grad_norm_error_if_nonfinite_xla',  # FIXME: edge case of norm
         'test_batchnorm_grad',  # FIXME! UndefinedTensorImpl::_singleton
         'test_nonlinearity_propagate_nan',  # relu6 with a nan tensor returns a tensor([0.]) instead of a nan tensor
@@ -241,10 +254,12 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_batchnorm_eval',  # FIXME! UndefinedTensorImpl::_singleton
         'test_MaxPool2d_indices',  # lowering
         'test_MaxPool1d_indices',  # lowering
+        'test_multi_margin_loss_errors_xla', # Received signal 6 & 11
         'test_softshrink_negative',  # runtime error
         'test_nll_loss_empty_tensor_reduction_mean',  # floating point division 0 by 0, expecting nan but get 0
         'test_nll_loss_invalid_target_dim',  # expecting a specific error message.
         'test_nll_loss_invalid_weights',  # expecting a specific error message.
+        'test_nll_loss_mismatched_batch_xla', # Received signal 6 & 11
         'test_fold',  # The gradient check code errors out on type() call, and code is slow on XLA
         'test_unfold',  # The gradient check code errors out on type() call, and code is slow on XLA
         'test_hardsigmoid_grad_xla',  # gradient check is slow
@@ -272,6 +287,12 @@ DISABLED_TORCH_TESTS_ANY = {
 
     # test/nn/test_pooling.py
     'TestPoolingNNDeviceTypeXLA': {
+        'test_AdaptiveMaxPool1d_indices_xla_float32', # THPEngine_run_backward
+        'test_AdaptiveMaxPool2d_indices_xla_float32', # THPEngine_run_backward
+        'test_AdaptiveMaxPool3d_indices_xla_float32', # THPEngine_run_backward
+        'test_MaxPool1d_indices_xla_float32', # THPEngine_run_backward
+        'test_MaxPool2d_indices_xla_float32', # THPEngine_run_backward
+        'test_MaxPool3d_indices_xla_float32', # THPEngine_run_backward
         'test_pool_invalid_size',  # expecting a different runtime error
     },
 
@@ -279,8 +300,10 @@ DISABLED_TORCH_TESTS_ANY = {
     'TestEmbeddingNNDeviceTypeXLA': {
         'test_embedding_backward',  # sparse
         'test_embedding_dense_grad',  # slow
+        'test_embedding_bag_out_of_bounds_idx_xla',  # singal
         'test_EmbeddingBag_per_sample_weights_failures',  # expecting a different runtime error
         'test_embedding_bag_device',  # FIXME! Unsupported device type for sparse layout: xla
+        'test_embedding_scalar_weight_error_xla',  # tsl::CurrentStackTrace[abi:cxx11]
         'test_EmbeddingBag_per_sample_weights_and_no_offsets',  # FIXME! Unsupported device type for sparse layout: xla
     },
 
@@ -288,6 +311,13 @@ DISABLED_TORCH_TESTS_ANY = {
     'TestConvolutionNNDeviceTypeXLA': {
         'test_Conv2d_backward_depthwise_xla_float64',  # slow compilation
         'test_conv3d_same_padding_backward_xla',  # XLA tensors do not have storage
+        'test_conv3d_valid_padding_backward_xla_float64',  # Jacobian
+        'test_noncontig_conv_grad_xla_float64', # Jacobian
+    },
+
+    # test/nn/test_multihead_attention.py
+    'TestMultiheadAttentionNNDeviceTypeXLA': {
+        'test_multihead_attn_fast_path_query_and_bias_have_different_dtypes_xla_float64',  # tsl::CurrentStackTrace
     },
 
     # test_type_promotion.py


### PR DESCRIPTION
Moving python op test from TPU2VM to TPUVM, and tracking ticket: https://buganizer.corp.google.com/issues/260639498

---
Test Environment:
```
contaienr: gcr.io/tpu-pytorch/xla:nightly_3.8_tpuvm

command to create the TPUVM:
  gcloud config set project tpu-pytorch
  export TPU_NAME=manfei_1vm
  export ZONE=us-central1-a
  gcloud compute tpus tpu-vm ssh ${TPU_NAME} --zone ${ZONE} -- -o ProxyCommand='corp-ssh-helper %h %p'
```

---
Script to run all tests under PyTorch/test repo and within PyTorch/XLA/test/run_tests.sh :
```
#!/bin/bash
set -ex

export TF_CPP_LOG_THREAD_ID=1
export WITH_XLA=1 NO_CUDA=1 XLA_DEBUG_GC=2 CC=clang-8 CXX=clang++-8 CLANG_FORMAT="clang-format-7"
export COMPILE_PARALLEL=1 DEBUG=1 XLA_IR_DEBUG=1 XLA_HLO_DEBUG=1 TF_CPP_LOG_THREAD_ID=1
export XRT_WORKERS="localservice:0;grpc://localhost:51011"
export XLA_USE_XRT=1 XRT_DEVICE_MAP="CPU:0;/job:localservice/replica:0/task:0/device:XLA_CPU:0" 

export XLA_CUDA=1
export GITHUB_TORCH_XLA_BOT_TOKEN=84eaa41dc4141a6b3fe81c3097347b2e148342c6

export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:-${CONDA_PREFIX:-"$(dirname $(which conda))/../"}}

export PYTORCH_DIR=/pytorch
export XLA_DIR=$PYTORCH_DIR/xla

# Needs to be kept in sync with .jenkins/pytorch/common_utils.sh in pytorch/pytorch.
export TORCHVISION_COMMIT="$(cat $PYTORCH_DIR/.github/ci_commit_pins/vision.txt)"

# run_torch_xla_tests
XLA_PORT=$(shuf -i 40701-40999 -n 1)
export XRT_WORKERS="localservice:0;grpc://localhost:$XLA_PORT"

export PYTORCH_TESTING_DEVICE_ONLY_FOR="xla"

pushd $XLA_DIR
  echo "Running Python Tests"
  ./test/run_tests.sh
popd

echo "Finish running all python op tests"
```