### PR TITLE
Improve numerical stability of torch.sigmoid

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1883,6 +1883,16 @@ class TestAtenXlaTensor(XlaTestCase):
 
     self.runAtenTest([torch.arange(15, dtype=torch.int32)], test_fn)
 
+  def test_sigmoid_bounds(self):
+    torch.manual_seed(0)
+    xla_device = xm.xla_device()
+    for _ in range(100):
+      x = torch.rand(1000).to(xla_device)
+      lower_bound = torch.sigmoid(x * (-100.0))
+      upper_bound = torch.sigmoid(x * (100.0))
+      assert torch.all(lower_bound >= 0.0)
+      assert torch.all(upper_bound <= 1.0)
+
 
 class MNISTComparator(nn.Module):
 

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -238,14 +238,7 @@ xla::XlaOp BuildPrelu(xla::XlaOp input, xla::XlaOp weight) {
   return xla::Select(xla::Gt(input, zero), input, product);
 }
 
-xla::XlaOp BuildSigmoid(xla::XlaOp input) {
-  const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(input);
-  xla::XlaOp half = XlaHelpers::ScalarValue<float>(0.5, shape.element_type(),
-                                                   input.builder());
-  return half + half * xla::Tanh(half * input);
-  // xla::XlaOp one = xla::One(input.builder(), shape.element_type());
-  // return one / (one + xla::Exp(-input));
-}
+xla::XlaOp BuildSigmoid(xla::XlaOp input) { return xla::Logistic(input); }
 
 xla::XlaOp BuildSiLUBackward(xla::XlaOp grad_output, xla::XlaOp input) {
   const xla::Shape& shape = XlaHelpers::ShapeOfXlaOp(input);

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -243,6 +243,8 @@ xla::XlaOp BuildSigmoid(xla::XlaOp input) {
   xla::XlaOp half = XlaHelpers::ScalarValue<float>(0.5, shape.element_type(),
                                                    input.builder());
   return half + half * xla::Tanh(half * input);
+  // xla::XlaOp one = xla::One(input.builder(), shape.element_type());
+  // return one / (one + xla::Exp(-input));
 }
 
 xla::XlaOp BuildSiLUBackward(xla::XlaOp grad_output, xla::XlaOp input) {


### PR DESCRIPTION
We recently found the torch_xla lowering of `torch.sigmoid` is not numerically stable on GPU. One common use-case of `torch.sigmoid` is to force the output value to be within [0,1].
For example, the following code failed with nan loss because `x = -5.9604645e-08`.
```py
x = torch.sigmoid(torch.tensor([-16.740633],device=device))
y = torch.tensor([1.0],device=device)
print(torch.nn.functional.binary_cross_entropy(x,y)) # print tensor(nan, device='xla:1')
```
Are there any special reasons for torch_xla to use `sigmoid(x) = 0.5+0.5*tanh(0.5*x)` instead of `sigmoid(x) = 1 / (1 + exp(-x))`? 