### PR TITLE
add `auto_wrap_policy` into XLA FSDP for automatic wrapping

### DIFF
--- a/docs/fsdp.md
+++ b/docs/fsdp.md
@@ -22,10 +22,24 @@ Notes:
   * The ZeRO-3 optimizer should be implemented via nested FSDP with `reshard_after_forward=True`. See `test/test_train_mp_mnist_fsdp_with_ckpt.py` and `test/test_train_mp_imagenet_fsdp.py` for an example. 
   * For large models that cannot fit into a single TPU memory or the host CPU memory, one should interleave submodule construction with inner FSDP wrapping. See [`FSDPViTModel`](https://github.com/ronghanghu/vit_10b_fsdp_example/blob/master/run_vit_training.py) for an example.
 * a simple wrapper `checkpoint_module` is provided (based on `torch_xla.utils.checkpoint.checkpoint` from https://github.com/pytorch/xla/pull/3524) to perform [gradient checkpointing](https://spell.ml/blog/gradient-checkpointing-pytorch-YGypLBAAACEAefHs) over a given `nn.Module` instance. See `test/test_train_mp_mnist_fsdp_with_ckpt.py` and `test/test_train_mp_imagenet_fsdp.py` for an example.
+* Auto-wrapping submodules: instead of manually nested FSDP wrapping, one can also specify an `auto_wrap_policy` argument to automatically wrap the submodules with inner FSDP. `size_based_auto_wrap_policy` in `torch_xla.distributed.fsdp.wrap` is an example of `auto_wrap_policy` callable, this policy wraps layers with the number of parameters larger than 100M. `transformer_auto_wrap_policy` in `torch_xla.distributed.fsdp.wrap` is an example of `auto_wrap_policy` callable for transformer-like model architectures.
+
+For example, to automatically wrap all `torch.nn.Conv2d` submodules with inner FSDP, one can use:
+```python3
+from torch_xla.distributed.fsdp.wrap import transformer_auto_wrap_policy
+auto_wrap_policy = partial(transformer_auto_wrap_policy, transformer_layer_cls={torch.nn.Conv2d})
+```
+
+Additionally, one can also specify an `auto_wrapper_callable` argument to use a custom callable wrapper for the submodules (the default wrapper is just the `XlaFullyShardedDataParallel` class itself). For example, one can use the following to apply gradient checkpointing (i.e. activation checkpointing/rematerialization) to each auto-wrapped submodule.
+```python3
+from torch_xla.distributed.fsdp import checkpoint_module
+auto_wrapper_callable = lambda m, *args, **kwargs: XlaFullyShardedDataParallel(
+    checkpoint_module(m), *args, **kwargs)
+```
 * When stepping the optimizer, directly call `optimizer.step` and do not call `xm.optimizer_step`. The latter reduces the gradient across ranks, which is not needed for FSDP (where the parameters are already sharded).
 * When saving model and optimizer checkpoints during training, each training process needs to save its own checkpoint of the (sharded) model and optimizer state dicts (use `master_only=False` and set different paths for each rank in `xm.save`). When resuming, it needs to load the checkpoint for the corresponding rank.
 * Please also save `model.get_shard_metadata()` along with `model.state_dict()` as follows and use `consolidate_sharded_model_checkpoints` to stitch the sharded model checkpoints together into a full model state dict. See `test/test_train_mp_mnist_fsdp_with_ckpt.py` for an example.
-```
+```python3
 ckpt = {
     'model': model.state_dict(),
     'shard_metadata': model.get_shard_metadata(),
@@ -86,12 +100,12 @@ python3 ~/pytorch/xla/test/test_train_mp_imagenet_fsdp.py \
   --lr 0.4 --batch_size 128 --num_warmup_epochs 5 --lr_scheduler_divide_every_n_epochs 30 --lr_scheduler_divisor 10 --num_epochs 100 \
   --use_nested_fsdp
 ```
-You can also add ` --use_gradient_checkpointing` (which needs to be used along with `--use_nested_fsdp`) to apply gradient checkpointing on the residual blocks.
+You can also add ` --use_gradient_checkpointing` (which needs to be used along with `--use_nested_fsdp` or `--auto_wrap_policy`) to apply gradient checkpointing on the residual blocks.
 
 ---
 
 ### Example training scripts on TPU pod (with 10 billion parameters)
 
-To train large models that cannot fit into a single TPU, one should use nested FSDP (wrapping sub-modules with inner FSDP when building the entire model) to implement the ZeRO-3 algorithm.
+To train large models that cannot fit into a single TPU, one should apply auto-wrap or manually wrap the submodules with inner FSDP when building the entire model to implement the ZeRO-3 algorithm.
 
 Please see https://github.com/ronghanghu/vit_10b_fsdp_example for an example of sharded training of a Vision Transformer (ViT) model using this XLA FSDP PR.

--- a/test/test_train_mp_imagenet_fsdp.py
+++ b/test/test_train_mp_imagenet_fsdp.py
@@ -43,6 +43,10 @@ MODEL_OPTS = {
         'choices': ['none', 'size_based', 'type_based'],
         'default': 'none',
     },
+    '--auto_wrap_min_num_params': {
+        'type': int,
+        'default': 1e6,
+    },
     '--use_nested_fsdp': {
         'action': 'store_true',
     },
@@ -227,9 +231,10 @@ def train_imagenet():
   auto_wrapper_callable = None
   if FLAGS.auto_wrap_policy != "none":
     if FLAGS.auto_wrap_policy == "size_based":
-      # auto-wrap all sub-modules with more than 1e6 parameters as an example
+      # auto-wrap all sub-modules with a certain number of parameters (default 1e6)
       auto_wrap_policy = partial(
-          size_based_auto_wrap_policy, min_num_params=1e6)
+          size_based_auto_wrap_policy,
+          min_num_params=FLAGS.auto_wrap_min_num_params)
     elif FLAGS.auto_wrap_policy == "type_based":
       # auto-wrap all sub-modules in torchvision ResNet's BasicBlock or Bottleneck
       # or torchvision transformer's EncoderBlock as an example

--- a/test/test_train_mp_imagenet_fsdp.py
+++ b/test/test_train_mp_imagenet_fsdp.py
@@ -63,8 +63,9 @@ MODEL_OPTS = {
     '--shard_param_on_dim_0': {
         'action': 'store_true',
     },
-    '--pin_layout_in_collective_ops': {
-        'action': 'store_true',
+    '--no_pin_layout_in_collective_ops': {
+        'action': 'store_false',
+        'dest': 'pin_layout_in_collective_ops',
     },
 }
 

--- a/test/test_train_mp_imagenet_fsdp.py
+++ b/test/test_train_mp_imagenet_fsdp.py
@@ -1,4 +1,5 @@
 import args_parse
+from functools import partial
 
 SUPPORTED_MODELS = [
     'alexnet', 'densenet121', 'densenet161', 'densenet169', 'densenet201',
@@ -37,6 +38,10 @@ MODEL_OPTS = {
     },
     '--flatten_parameters': {
         'action': 'store_true',
+    },
+    '--auto_wrap_policy': {
+        'choices': ['none', 'size_based', 'type_based'],
+        'default': 'none',
     },
     '--use_nested_fsdp': {
         'action': 'store_true',
@@ -89,6 +94,8 @@ import torch_xla.distributed.xla_multiprocessing as xmp
 import torch_xla.test.test_utils as test_utils
 
 from torch_xla.distributed.fsdp import XlaFullyShardedDataParallel as FSDP, checkpoint_module
+from torch_xla.distributed.fsdp.wrap import (size_based_auto_wrap_policy,
+                                             transformer_auto_wrap_policy)
 
 DEFAULT_KWARGS = dict(
     batch_size=128,
@@ -215,25 +222,57 @@ def train_imagenet():
 
   device = xm.xla_device()
   model = get_model_property('model_fn')()
-  # Wrap the model with FSDP
-  # You may wrap all, a subset, or none of the sub-modules with inner FSDPs
-  # - to implement ZeRO-2, wrap none of the sub-modules
-  # - to implement ZeRO-3, wrap all of the sub-modules (nested FSDP)
-  # - you may wrap sub-modules at different granularity (e.g. at each resnet
-  #   stage or each residual block or each conv layer).
+  # Automatic wrapping sub-modules with inner FSDP
+  auto_wrap_policy = None
+  auto_wrapper_callable = None
+  if FLAGS.auto_wrap_policy != "none":
+    if FLAGS.auto_wrap_policy == "size_based":
+      # auto-wrap all sub-modules with more than 1e6 parameters as an example
+      auto_wrap_policy = partial(
+          size_based_auto_wrap_policy, min_num_params=1e6)
+    elif FLAGS.auto_wrap_policy == "type_based":
+      # auto-wrap all sub-modules in torchvision ResNet's BasicBlock or Bottleneck
+      # or torchvision transformer's EncoderBlock as an example
+      # (transformer_auto_wrap_policy wraps all sub-modules in transformer_layer_cls)
+      auto_wrap_policy = partial(
+          transformer_auto_wrap_policy,
+          transformer_layer_cls={
+              torchvision.models.resnet.BasicBlock,
+              torchvision.models.resnet.Bottleneck,
+              torchvision.models.vision_transformer.EncoderBlock,
+          })
+    else:
+      raise Exception(f"Invalid auto-wrap policy: {FLAGS.auto_wrap_policy}")
+    if FLAGS.use_gradient_checkpointing:
+      # Apply gradient checkpointing to auto-wrapped sub-modules if specified
+      auto_wrapper_callable = lambda m, *args, **kwargs: FSDP(
+          checkpoint_module(m), *args, **kwargs)
+
   fsdp_wrap = lambda m: FSDP(
       m,
       compute_dtype=getattr(torch, FLAGS.compute_dtype),
       fp32_reduce_scatter=FLAGS.fp32_reduce_scatter,
       flatten_parameters=FLAGS.flatten_parameters,
       shard_param_on_dim_0=FLAGS.shard_param_on_dim_0,
-      pin_layout_in_collective_ops=FLAGS.pin_layout_in_collective_ops)
-  # Apply gradient checkpointing to sub-modules if specified
-  grad_ckpt_wrap = checkpoint_module if FLAGS.use_gradient_checkpointing else (
-      lambda x: x)
+      pin_layout_in_collective_ops=FLAGS.pin_layout_in_collective_ops,
+      auto_wrap_policy=auto_wrap_policy,
+      auto_wrapper_callable=auto_wrapper_callable)
+  # Manually wrapping sub-modules with inner FSDP (if not using auto-wrap)
+  # (in this case, the sub-modules should be wrapped before the base model)
   if FLAGS.use_nested_fsdp:
+    assert FLAGS.auto_wrap_policy == "none", \
+        "--use_nested_fsdp is for manual nested wrapping should only be used" \
+        " without auto-wrapping"
+    # You may wrap all, a subset, or none of the sub-modules with inner FSDPs
+    # - to implement ZeRO-2, wrap none of the sub-modules
+    # - to implement ZeRO-3, wrap all of the sub-modules (nested FSDP)
+    # - you may wrap sub-modules at different granularity (e.g. at each resnet
+    #   stage or each residual block or each conv layer).
     # Here we apply inner FSDP at the level of child modules for ZeRO-3, which
     # corresponds to different stages in resnet (i.e. Stage 1 to 5).
+    # Apply gradient checkpointing to nested-wrapped sub-modules if specified
+    grad_ckpt_wrap = checkpoint_module if FLAGS.use_gradient_checkpointing else (
+        lambda x: x)
     for submodule_name, submodule in model.named_children():
       if sum(p.numel() for p in submodule.parameters()) == 0:
         # Skip those submodules without parameters (i.e. no need to shard them)

--- a/test/test_train_mp_mnist_fsdp_with_ckpt.py
+++ b/test/test_train_mp_mnist_fsdp_with_ckpt.py
@@ -37,8 +37,9 @@ MODEL_OPTS = {
     '--shard_param_on_dim_0': {
         'action': 'store_true',
     },
-    '--pin_layout_in_collective_ops': {
-        'action': 'store_true',
+    '--no_pin_layout_in_collective_ops': {
+        'action': 'store_false',
+        'dest': 'pin_layout_in_collective_ops',
     },
 }
 

--- a/test/test_train_mp_mnist_fsdp_with_ckpt.py
+++ b/test/test_train_mp_mnist_fsdp_with_ckpt.py
@@ -9,6 +9,10 @@ MODEL_OPTS = {
         'choices': ['none', 'size_based', 'type_based'],
         'default': 'none',
     },
+    '--auto_wrap_min_num_params': {
+        'type': int,
+        'default': 1000,
+    },
     '--use_nested_fsdp': {
         'action': 'store_true',
     },
@@ -165,10 +169,11 @@ def train_mnist(flags, **kwargs):
   auto_wrapper_callable = None
   if flags.auto_wrap_policy != "none":
     if flags.auto_wrap_policy == "size_based":
-      # auto-wrap all sub-modules with more than 1000 parameters as an example
+      # auto-wrap all sub-modules with a certain number of parameters (default 1000)
       # (in practice, one should set a larger min_num_params such as 1e8)
       auto_wrap_policy = partial(
-          size_based_auto_wrap_policy, min_num_params=1e3)
+          size_based_auto_wrap_policy,
+          min_num_params=flags.auto_wrap_min_num_params)
     elif flags.auto_wrap_policy == "type_based":
       # auto-wrap all nn.Conv2d and nn.Linear sub-modules as an example
       # (transformer_auto_wrap_policy wraps all sub-modules in transformer_layer_cls)

--- a/torch_xla/distributed/fsdp/wrap.py
+++ b/torch_xla/distributed/fsdp/wrap.py
@@ -1,0 +1,217 @@
+# This file is largely adapted from ``torch.distributed.fsdp.wrap`` in
+# https://github.com/pytorch/pytorch/blob/v1.13.0/torch/distributed/fsdp/wrap.py
+
+from typing import Any, Callable, Set, Tuple, Optional, Type, cast
+
+import torch.nn as nn
+
+
+def always_wrap_policy(*args, **kwargs) -> bool:
+  """
+  A simple wrapper policy that always returns ``True``,
+  i.e. when passed as the `auto_wrap_policy` into FSDP,
+  this will result in all submodules being wrapped as
+  distinct FSDP instances.
+  """
+  return True
+
+
+def lambda_auto_wrap_policy(module: nn.Module, recurse: bool,
+                            unwrapped_params: int, lambda_fn: Callable) -> bool:
+  """
+  A convenient auto wrap policy to wrap submodules based on an arbitrary user
+  function. If `lambda_fn(submodule) == True``, the submodule will be wrapped as
+  a `wrapper_cls` unit.
+  Return if a module should be wrapped during auto wrapping.
+  The first three parameters are required by :func:`_recursive_wrap`.
+  Args:
+     module (nn.Module):
+         The module to be considered in this decision.
+     recurse (bool):
+         Indicate if this is called to make a decision on whether we
+         should recurse down a subgraph of the module structure.
+         If False, it means this function is called to make a decision
+         on whether we should wrap the said module.
+     unwrapped_params (int):
+         The number of parameters yet to be wrapped in this module.
+     lambda_fn (Callable[nn.Module] -> bool):
+         If this returns ``True``, this module will be wrapped by
+         wrapper_cls individually.
+  """
+  if recurse:
+    # always recurse
+    return True
+  else:
+    # if not recursing, decide whether we should wrap for the leaf node or reminder
+    return lambda_fn(module)
+
+
+def transformer_auto_wrap_policy(
+    module: nn.Module,
+    recurse: bool,
+    unwrapped_params: int,
+    transformer_layer_cls: Set[Type[nn.Module]],
+) -> bool:
+  """
+  A convenient auto wrap policy for transformer models. If the submodule
+  is an instance of transformer_layer_cls, the submodule will be wrapped
+  as a FSDP unit. Otherwise, all the other remainder submodules are wrapped
+  by the outermost FSDP unit.
+  Return if a module should be wrapped during FSDP auto wrapping.
+  The first three parameters are required by :func:`_recursive_wrap`.
+  Args:
+     module (nn.Module):
+         The module to be considered in this decision.
+     recurse (bool):
+         Indicate if this is called to make a decision on whether we
+         should recurse down a subgraph of the module structure.
+         If False, it means this function is called to make a decision
+         on whether we should wrap the said module.
+     unwrapped_params (int):
+         The number of parameters yet to be wrapped in this module.
+     transformer_layer_cls (int):
+         Submodules with one of the `transformer_layer_cls` names
+         will be wrapped as separated FSDP units
+  """
+  if recurse:
+    # always recurse
+    return True
+  else:
+    # if not recursing, decide whether we should wrap for the leaf node or reminder
+    return isinstance(module, tuple(transformer_layer_cls))
+
+
+def size_based_auto_wrap_policy(
+    module: nn.Module,
+    recurse: bool,
+    unwrapped_params: int,
+    # These are customizable for this policy function.
+    min_num_params: int = int(1e8),
+    force_leaf_modules: Optional[Set[Type[nn.Module]]] = None,
+    exclude_wrap_modules: Optional[Set[Type[nn.Module]]] = None,
+) -> bool:
+  """A size based auto_wrap_policy function for FSDP API.
+     Return if a module should be wrapped during FSDP auto wrapping.
+     The first three parameters are used by :func:`_recursive_wrap`.
+  Args:
+     module (nn.Module):
+         The module to be considered in this decision.
+     recurse (bool):
+         Indicate if this is called to make a decision on whether we
+         should recurse down a subgraph of the module structure.
+         If False, it means this function is called to make a decision
+         on whether we should wrap the said module.
+     unwrapped_params (int):
+         The number of parameters yet to be wrapped in this module.
+     min_num_params (int):
+         Customizable policy input. It controls the size threshold
+         on how big should a module be to be considered wrapped.
+     force_leaf_modules (Set[Type[nn.Module]]): set of module types to
+         keep as leaves, i.e., their children will never be wrapped.
+     exclude_wrap_modules (Set[Type[nn.Module]]):
+         Customizable set of module types to be excluded in wrapping.
+  """
+  force_leaf_modules = (
+      size_based_auto_wrap_policy.FORCE_LEAF_MODULES
+      if force_leaf_modules is None else force_leaf_modules)
+  exclude_wrap_modules = (
+      size_based_auto_wrap_policy.EXCLUDE_WRAP_MODULES
+      if exclude_wrap_modules is None else exclude_wrap_modules)
+
+  is_large = unwrapped_params >= min_num_params
+  if recurse:
+    # We should recurse if the module is big enough but not in force_leaf_modules list.
+    return is_large and not isinstance(module, tuple(force_leaf_modules))
+  else:
+    # If we are not recursing, determine if we should wrap.
+    return is_large and not isinstance(module, tuple(exclude_wrap_modules))
+
+
+# Set those defaults to the size_based_auto_wrap_policy function. Make them easy to be imported.
+size_based_auto_wrap_policy.EXCLUDE_WRAP_MODULES = {
+    nn.ModuleList, nn.ModuleDict
+}
+size_based_auto_wrap_policy.FORCE_LEAF_MODULES = {nn.MultiheadAttention}
+
+
+def _wrap(module: nn.Module, wrapper_cls: Callable, **kwargs) -> nn.Module:
+  assert wrapper_cls is not None
+  if hasattr(module, '_wrap_overrides'):
+    # If module has a _wrap_overrides attribute, we force overriding the
+    # FSDP config with these attributes for this module. Currently this
+    # is only used to disable mixed precision for BatchNorm when
+    # auto_wrapping.
+    overrides = {**kwargs, **module._wrap_overrides}
+    return wrapper_cls(module, **overrides)
+
+  return wrapper_cls(module, **kwargs)
+
+
+def recursive_wrap(module: nn.Module,
+                   auto_wrap_policy: Callable,
+                   wrapper_cls: Callable,
+                   ignored_modules: Set[nn.Module],
+                   ignored_params: Set[nn.Parameter],
+                   only_wrap_children: bool = False,
+                   **kwargs: Any) -> Tuple[nn.Module, int]:
+  """
+  Automatically wrap child modules of *module* that meet the given
+  criteria with :func:`auto_wrap`. Does not rely on _ConfigAutoWrap.
+  Args:
+      module (nn.Module):
+          module to recursively wrap
+      auto_wrap_policy (Callable):
+          A callable specifying a policy to recursively wrap layers with FSDP.
+      ignored_modules (Set[torch.nn.Module]): Modules to ignore when
+          wrapping.
+      ignored_params (Set[torch.nn.Parameter]): Parameters to ignore when
+          wrapping; these should be the parameters contained in the modules
+          in ``ignored_modules``.
+  Returns:
+      (nn.Module, int):
+          Wrapped module and the number parameters wrapped recursively.
+  """
+  assert auto_wrap_policy is not None, "Must specify auto_wrap_policy."
+  assert wrapper_cls is not None, "Must specify wrapper_cls"
+  # Make sure no child is already wrapped.
+  for _, child in module.named_modules():
+    if child in ignored_modules:
+      continue
+    try:
+      assert not isinstance(child, cast(type, wrapper_cls))
+    except TypeError:
+      # wrapper_cls is a function as opposed to a class type, just bypass above check.
+      pass
+
+  # We count all params, assuming none of them are already wrapped.
+  num_params = sum(
+      p.numel() for p in module.parameters() if p not in ignored_params)
+
+  assert auto_wrap_policy is not None
+  if auto_wrap_policy(module=module, recurse=True, unwrapped_params=num_params):
+    total_wrapped_params = 0
+    # Iterate through the children, recursively wrap if necessary
+    for name, child in module.named_children():
+      if child in ignored_modules:
+        continue
+      wrapped_child, num_wrapped_params = recursive_wrap(
+          module=child,
+          auto_wrap_policy=auto_wrap_policy,
+          wrapper_cls=wrapper_cls,
+          ignored_modules=ignored_modules,
+          ignored_params=ignored_params,
+          **kwargs,
+      )
+      setattr(module, name, wrapped_child)
+      # Keep track of how many parameters have been wrapped
+      total_wrapped_params += num_wrapped_params
+    # decide if we need to wrap the current module,
+    # since the left over parameters exceed the number of params to wrap
+    remainder = num_params - total_wrapped_params
+    if not only_wrap_children and auto_wrap_policy(
+        module=module, recurse=False, unwrapped_params=remainder):
+      # Leaf node or final wrapping of the remainder both happen here.
+      return _wrap(module, wrapper_cls, **kwargs), num_params
+    else:
+      return module, total_wrapped_params
+  return module, 0

--- a/torch_xla/distributed/fsdp/wrap.py
+++ b/torch_xla/distributed/fsdp/wrap.py
@@ -187,7 +187,6 @@ def recursive_wrap(module: nn.Module,
   num_params = sum(
       p.numel() for p in module.parameters() if p not in ignored_params)
 
-  assert auto_wrap_policy is not None
   if auto_wrap_policy(module=module, recurse=True, unwrapped_params=num_params):
     total_wrapped_params = 0
     # Iterate through the children, recursively wrap if necessary


### PR DESCRIPTION
This PR adds the auto-wrapping feature in XLA FSDP, similar to the [native PyTorch FSDP](https://pytorch.org/docs/stable/fsdp.html)'s `auto_wrap_policy` argument.

#### Auto-wrapping submodules based on policies

We now allow to automatically wrap the submodules in an `nn.Module` based on the policy specified in the `auto_wrap_policy` argument to the `XlaFullyShardedDataParallel` class.

For example, one can set
```
from torch_xla.distributed.fsdp.wrap import transformer_auto_wrap_policy
auto_wrap_policy = partial(transformer_auto_wrap_policy, transformer_layer_cls={GPT2Block})
```
to automatically wrap all `GPT2Block` submodules (which is probably the most common scenario in transformer-style models).

Or one can also apply it based on the parameter size of a submodule
```
from torch_xla.distributed.fsdp.wrap import size_based_auto_wrap_policy
auto_wrap_policy = partial(size_based_auto_wrap_policy, min_num_params=1e7)
```
to automatically wrap all submodules with more than e.g. 1e7 (10M) parameters.

There are also more policies such as `lambda_auto_wrap_policy` to determine whether to wrap a module by a custom callable. The wrapping policies are directly borrowed from native PyTorch FSDP policies in https://github.com/pytorch/pytorch/blob/v1.13.0/torch/distributed/fsdp/wrap.py.

#### Gradient checkpointing (i.e. activation checkpointing/rematerialization)

Additionally, now one can also specify an `auto_wrapper_callable` argument to the `XlaFullyShardedDataParallel` class to use a custom callable wrapper for the submodules (default wrapper is just `XlaFullyShardedDataParallel`). For example, one can use the following to apply gradient checkpointing (i.e. activation checkpointing/rematerialization) to each auto-wrapped submodule.

```
from torch_xla.distributed.fsdp import checkpoint_module
auto_wrapper_callable = lambda m, *args, **kwargs: XlaFullyShardedDataParallel(
    checkpoint_module(m), *args, **kwargs)
```

The MNIST and ImageNet examples are updated accordingly to show examples of auto-wrapping usage based on size or classes. Also, this PR changes the MNIST and ImageNet FSDP tests to `pin_layout=True` by default to be consistent with https://github.com/pytorch/xla/pull/4359.

cc: @AlexWertheim @JackCaoG 

---

New tests added:

#### [OK] Test MNIST size-based auto-wrap FSDP (and command line checkpoint consolidation) on v3-8

```bash
python3 -u ~/xla_fsdp_dev/test/test_train_mp_mnist_fsdp_with_ckpt.py \
  --batch_size 16 --drop_last --num_epochs 2 \
  --auto_wrap_policy size_based
```
**Results**: matching expected accuracy for 2 training epochs
```
found 8 checkpoint files in /tmp/mnist-fsdp/final_ckpt_rank-*-of-*.pth
saved consolidated model to /tmp/mnist-fsdp/final_ckpt_consolidated.pth
Checkpoint consolidated, Accuracy=98.91 (note: it can be slightly different from the final training accuracy due to non-sync BatchNorm2d in the model)
Max Accuracy: 98.94%
```

#### [OK] Test MNIST type-based auto-wrap FSDP (and command line checkpoint consolidation) on v3-8

```bash
python3 -u ~/xla_fsdp_dev/test/test_train_mp_mnist_fsdp_with_ckpt.py \
  --batch_size 16 --drop_last --num_epochs 2 \
  --auto_wrap_policy type_based
```
**Results**: matching expected accuracy for 2 training epochs
```
found 8 checkpoint files in /tmp/mnist-fsdp/final_ckpt_rank-*-of-*.pth
saved consolidated model to /tmp/mnist-fsdp/final_ckpt_consolidated.pth
Checkpoint consolidated, Accuracy=98.91 (note: it can be slightly different from the final training accuracy due to non-sync BatchNorm2d in the model)
Max Accuracy: 98.94%
```

#### [OK] Test MNIST type-based auto-wrap FSDP + gradient checkpointing (and command line checkpoint consolidation) on v3-8

```bash
python3 -u ~/xla_fsdp_dev/test/test_train_mp_mnist_fsdp_with_ckpt.py \
  --batch_size 16 --drop_last --num_epochs 2 \
  --auto_wrap_policy type_based --use_gradient_checkpointing
```
**Results**: matching expected accuracy for 2 training epochs
```
found 8 checkpoint files in /tmp/mnist-fsdp/final_ckpt_rank-*-of-*.pth
saved consolidated model to /tmp/mnist-fsdp/final_ckpt_consolidated.pth
Checkpoint consolidated, Accuracy=98.91 (note: it can be slightly different from the final training accuracy due to non-sync BatchNorm2d in the model)
Max Accuracy: 98.94%
```

#### [OK] Test ImageNet ResNet-50 size-based auto-wrap FSDP on v3-8

```bash
python3 -u ~/xla_fsdp_dev/test/test_train_mp_imagenet_fsdp.py \
  --datadir /datasets02/imagenet-1k --drop_last \
  --model resnet50 --test_set_batch_size 64 --eval_interval 10 \
  --lr 0.4 --batch_size 128 --num_warmup_epochs 5 --lr_scheduler_divide_every_n_epochs 30 --lr_scheduler_divisor 10 --num_epochs 100 \
  --auto_wrap_policy size_based
```
**Results**: matching expected accuracy for batch size 128
```
Max Accuracy: 75.79%
```

#### [OK] Test ImageNet ResNet-50 type-based auto-wrap FSDP on v3-8

```bash
python3 -u ~/xla_fsdp_dev/test/test_train_mp_imagenet_fsdp.py \
  --datadir /datasets02/imagenet-1k --drop_last \
  --model resnet50 --test_set_batch_size 64 --eval_interval 10 \
  --lr 0.4 --batch_size 128 --num_warmup_epochs 5 --lr_scheduler_divide_every_n_epochs 30 --lr_scheduler_divisor 10 --num_epochs 100 \
  --auto_wrap_policy type_based
```
**Results**: matching expected accuracy for batch size 128
```
Max Accuracy: 75.99%
```

#### [OK] Test ImageNet ResNet-50 type-based auto-wrap + gradient checkpointing FSDP on v3-8

```bash
python3 -u ~/xla_fsdp_dev/test/test_train_mp_imagenet_fsdp.py \
  --datadir /datasets02/imagenet-1k --drop_last \
  --model resnet50 --test_set_batch_size 64 --eval_interval 10 \
  --lr 0.4 --batch_size 128 --num_warmup_epochs 5 --lr_scheduler_divide_every_n_epochs 30 --lr_scheduler_divisor 10 --num_epochs 100 \
  --auto_wrap_policy type_based --use_gradient_checkpointing
```
**Results**: matching expected accuracy for batch size 128
```
Max Accuracy: 75.93%
```