### PR TITLE
Add a test case for BuildInputOutputAliases

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -140,6 +140,7 @@ function run_op_tests {
   run_pjrt python3 "$CDIR/pjrt/test_mesh_service.py"
   run_pjrt python3 "$CDIR/test_xla_sharding.py"
   run_test python3 "$CDIR/test_operations_hlo.py" "$@" --verbosity=$VERBOSITY
+  run_test python3 "$CDIR/test_input_output_aliases.py"
 }
 
 function run_mp_op_tests {

--- a/test/test_input_output_aliases.py
+++ b/test/test_input_output_aliases.py
@@ -1,0 +1,28 @@
+import sys
+
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.debug.metrics as met
+import unittest
+
+class MetricsTest(unittest.TestCase):
+
+  def test_non_view(self):
+    xla_device = xm.xla_device()
+    t1 = torch.randn(4, 2, 2).to(xla_device)
+    t2 = torch.randn(4, 2, 2).to(xla_device)
+    xm.mark_step()
+
+    t3 = t1 + t2
+    t1 = t1 * 2
+    t2 = t2 + 2
+    xm.mark_step()
+
+    print(met.metric_data("InputOutputAliasCount"))
+    self.assertEqual(met.metric_data("InputOutputAliasCount")[1], 2.0)
+
+
+if __name__ == '__main__':
+  test = unittest.main()
+  sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/test_input_output_aliases.py
+++ b/test/test_input_output_aliases.py
@@ -6,21 +6,31 @@ import torch_xla.core.xla_model as xm
 import torch_xla.debug.metrics as met
 import unittest
 
+
 class MetricsTest(unittest.TestCase):
 
   def test_non_view(self):
     xla_device = xm.xla_device()
+    # This is a special case where we want to sync t1's and t2's
+    # value since they will have device_data ir instead of XLAData.
+    # HLO looks like
+    # ENTRY %IrToHlo.4 (p0.1: f32[4,2,2], p1.2: f32[4,2,2]) -> (f32[4,2,2], f32[4,2,2]) {
+    # %p0.1 = f32[4,2,2]{2,1,0} parameter(0)
+    # %p1.2 = f32[4,2,2]{2,1,0} parameter(1)
+    # ROOT %tuple.3 = (f32[4,2,2]{2,1,0}, f32[4,2,2]{2,1,0}) tuple(f32[4,2,2]{2,1,0} %p0.1, f32[4,2,2]{2,1,0} %p1.2)
+    # }
     t1 = torch.randn(4, 2, 2).to(xla_device)
     t2 = torch.randn(4, 2, 2).to(xla_device)
     xm.mark_step()
+    self.assertEqual(met.metric_data("InputOutputAliasCount")[1], 2.0)
 
+    # check in place op aliasing.
     t3 = t1 + t2
-    t1 = t1 * 2
-    t2 = t2 + 2
+    t1 *= 2.0
+    t2 += 2.0
     xm.mark_step()
 
-    print(met.metric_data("InputOutputAliasCount"))
-    self.assertEqual(met.metric_data("InputOutputAliasCount")[1], 2.0)
+    self.assertEqual(met.metric_data("InputOutputAliasCount")[1], 4.0)
 
 
 if __name__ == '__main__':

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -892,7 +892,7 @@ XLAGraphExecutor::BuildInputOutputAliases(
       }
     }
   }
-  TORCH_LAZY_VALUE_METRIC("InputOutputAliasCount", alias_map.size());
+  TORCH_LAZY_VALUE_METRIC("InputOutputAliasCount", input_output_alias_pair.size());
   return input_output_alias_pair;
 }
 


### PR DESCRIPTION
Summary:
This patch tries to add a test case for `BuildInputOutputAliases` and fixes the corresponding metric which reports a bogus value that's the total number of outputs.

Test Plan:
PJRT_DEVICE=CPU python test/test_input_output_aliases.py