### PR TITLE
[SPMD] Use d2d replication via CopyToDevice

### DIFF
--- a/third_party/xla_client/computation_client.h
+++ b/third_party/xla_client/computation_client.h
@@ -224,6 +224,9 @@ class ComputationClient {
       absl::Span<const TensorSource> tensor_shards, std::string device,
       xla::Shape shape) = 0;
 
+  // Copies `data->buffer` to `dst` device buffer.
+  virtual DataPtr CopyToDevice(DataPtr data, std::string dst) = 0;
+
   // Reads the tensor literal values stored at TPU server sites, behind the
   // supplied handles.
   virtual std::vector<Literal> TransferFromServer(

--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -32,6 +32,8 @@ class PjRtComputationClient : public ComputationClient {
   DataPtr TransferShardsToServer(absl::Span<const TensorSource> tensor_shards,
                                  std::string device, xla::Shape shape) override;
 
+  DataPtr CopyToDevice(DataPtr data, std::string dst) override;
+
   std::vector<ComputationPtr> Compile(
       std::vector<CompileInstance> instances) override;
 

--- a/third_party/xla_client/xrt_computation_client.h
+++ b/third_party/xla_client/xrt_computation_client.h
@@ -264,6 +264,10 @@ class XrtComputationClient : public ComputationClient {
     XLA_ERROR() << __FUNCTION__ << " not implemented";
   }
 
+  DataPtr CopyToDevice(DataPtr data, std::string dst) override {
+    XLA_ERROR() << __FUNCTION__ << " not implemented";
+  }
+
   std::vector<Literal> TransferFromServer(
       absl::Span<const DataPtr> handles) override;
 


### PR DESCRIPTION
Introduce `CopyToDevice` in `PjRtComputationClient` to support d2d data transfer. The feature is tested as part of `TEST_F(XLAShardingTest, InputHandler)` for correctness.