### PR TITLE
Install sympy to ci base docker image

### DIFF
--- a/.circleci/docker/install_conda.sh
+++ b/.circleci/docker/install_conda.sh
@@ -49,6 +49,7 @@ function install_and_setup_conda() {
   /usr/bin/yes | pip install psutil
   /usr/bin/yes | pip install unittest-xml-reporting
   /usr/bin/yes | pip install pytest
+  /usr/bin/yes | pip install sympy
 
 }
 


### PR DESCRIPTION
Some recent builds are failing due to missing `sympy` package, required by the latest `torch`.
```
WARNING:root:No sympy found
Traceback (most recent call last):
  File "setup.py", line 41, in <module>
    from torch.utils.cpp_extension import BuildExtension, CppExtension
  File "/opt/conda/lib/python3.7/site-packages/torch/__init__.py", line 1236, in <module>
    from . import _meta_registrations
  File "/opt/conda/lib/python3.7/site-packages/torch/_meta_registrations.py", line 7, in <module>
    from torch._decomp import _add_op_to_registry, global_decomposition_table, meta_table
  File "/opt/conda/lib/python3.7/site-packages/torch/_decomp/__init__.py", line 168, in <module>
    import torch._decomp.decompositions
  File "/opt/conda/lib/python3.7/site-packages/torch/_decomp/decompositions.py", line 10, in <module>
    import torch._prims as prims
  File "/opt/conda/lib/python3.7/site-packages/torch/_prims/__init__.py", line 34, in <module>
    from torch.fx.experimental.symbolic_shapes import sym_float
  File "/opt/conda/lib/python3.7/site-packages/torch/fx/experimental/symbolic_shapes.py", line 17, in <module>
    from torch._guards import ShapeGuard
  File "/opt/conda/lib/python3.7/site-packages/torch/_guards.py", line 65, in <module>
    class ShapeGuard(NamedTuple):
  File "/opt/conda/lib/python3.7/site-packages/torch/_guards.py", line 66, in ShapeGuard
    expr: sympy.Expr
NameError: name 'sympy' is not defined
```