### PR TITLE
Fix warnings in `xrt_init.py`

### DIFF
--- a/torch_xla/distributed/xrt_init.py
+++ b/torch_xla/distributed/xrt_init.py
@@ -6,7 +6,6 @@ import torch.distributed as dist
 import torch_xla.core.xla_model as xm
 import torch_xla.core.xla_env_vars as xenv
 from torch_xla.utils.utils import get_free_tcp_ports
-from torch_xla.distributed.xla_multiprocessing import _get_devices_per_worker
 
 XRT_SERVER_REGEX = 'torch_xla.distributed._xrt_run_server'
 _TCP_STORE = None
@@ -164,7 +163,7 @@ def init_xrt_context(master_addr=None, master_port=None, store=None):
   Args:
     master_addr (string): This is used to set up the TCPStore. If none is provided, it is obtained
     from the environment variable. Also not required/used if store argument is passed in.
-  	
+
     master_port (int): This is used to set up the TCPStore. If none is provided, it is obtained from
     environment variable. Also not required/used if store argument is passed in.
 
@@ -204,7 +203,7 @@ def init_xrt_context(master_addr=None, master_port=None, store=None):
 
   # This is required if we want to dynamically grab free ports.
   # Useful in shared settings when we cannot predetermine what ports are taken.
-  is_server = True if rank is '0' else False
+  is_server = True if rank == '0' else False
   global _TCP_STORE
   if store is None:
     assert master_addr is not None


### PR DESCRIPTION
There's an unused import that can cause this error:

```
wcromar@t1v-n-bf2f726f-w-0:~$ python3 -c 'import torch_xla.distributed.xla_multiprocessing as xmp'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/wcromar/.local/lib/python3.8/site-packages/torch_xla/distributed/xla_multiprocessing.py", line 12, in <module>
    import torch_xla.core.xla_model as xm
  File "/home/wcromar/.local/lib/python3.8/site-packages/torch_xla/core/xla_model.py", line 14, in <module>
    from torch_xla.experimental import pjrt
  File "/home/wcromar/.local/lib/python3.8/site-packages/torch_xla/experimental/pjrt.py", line 18, in <module>
    import torch_xla.distributed.xla_backend
  File "/home/wcromar/.local/lib/python3.8/site-packages/torch_xla/distributed/xla_backend.py", line 12, in <module>
    from .xrt_init import init_xrt_context
  File "/home/wcromar/.local/lib/python3.8/site-packages/torch_xla/distributed/xrt_init.py", line 9, in <module>
    from torch_xla.distributed.xla_multiprocessing import _get_devices_per_worker
ImportError: cannot import name '_get_devices_per_worker' from partially initialized module 'torch_xla.distributed.xla_multiprocessing' (most likely due to a circular import) (/home/wcromar/.local/lib/python3.8/site-packages/torch_xla/distributed/xla_multiprocessing.py)
```

Using string identity causes this warning:

```
/workspaces/pjrt/pytorch/xla/torch_xla/distributed/xrt_init.py:206: SyntaxWarning: "is" with a literal. Did you mean "=="?
  is_server = True if rank is '0' else False
```

CC @amithrm 
