### PR TITLE
Update xla_base tag to v0.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,8 @@ launch_docker_and_build: &launch_docker_and_build
     # To allow the upstream workflow to access PyTorch/XLA build images, we
     # need to have them in the ECR. This is not expensive, and only pushes it
     # if image layers are not present in the repo.
-    docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:v0.4 >/dev/null
-    docker push ${ECR_DOCKER_IMAGE_BASE}:v0.4 >/dev/null
+    docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:v0.5 >/dev/null
+    docker push ${ECR_DOCKER_IMAGE_BASE}:v0.5 >/dev/null
     sudo pkill -SIGHUP dockerd
     # To enable remote caching, use SCCACHE_BUCKET=${SCCACHE_BUCKET}
     # To disable remote caching, use SCCACHE_BUCKET=${LOCAL_BUCKET}

--- a/.circleci/docker/install_conda.sh
+++ b/.circleci/docker/install_conda.sh
@@ -49,6 +49,7 @@ function install_and_setup_conda() {
   /usr/bin/yes | pip install psutil
   /usr/bin/yes | pip install unittest-xml-reporting
   /usr/bin/yes | pip install pytest
+  /usr/bin/yes | pip install sympy
 
 }
 


### PR DESCRIPTION
This is needed after installing a new package to the current base image.