### PR TITLE
Prevent conda MKL installation, and install via pip

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -149,14 +149,14 @@ function run_torch_xla_tests() {
       fi
     fi
 
-    # pushd test/cpp
-    # echo "Running C++ Tests"
-    # ./run_tests.sh
+    pushd test/cpp
+    echo "Running C++ Tests"
+    ./run_tests.sh
 
-    # if ! [ -x "$(command -v nvidia-smi)"  ]
-    # then
-    #   ./run_tests.sh -X early_sync -F AtenXlaTensorTest.TestEarlySyncLiveTensors -L""
-    # fi
-    # popd
+    if ! [ -x "$(command -v nvidia-smi)"  ]
+    then
+      ./run_tests.sh -X early_sync -F AtenXlaTensorTest.TestEarlySyncLiveTensors -L""
+    fi
+    popd
   popd
 }

--- a/.circleci/docker/install_conda.sh
+++ b/.circleci/docker/install_conda.sh
@@ -30,8 +30,11 @@ function install_and_setup_conda() {
   conda update -y -n base conda
   conda install -y python=$PYTHON_VERSION
 
-  conda install -y numpy=1.18.5 pyyaml mkl-include setuptools cmake cffi typing \
-    tqdm coverage hypothesis dataclasses cython
+  conda install -y nomkl numpy=1.18.5 pyyaml setuptools cmake \
+    cffi typing tqdm coverage hypothesis dataclasses cython
+
+  /usr/bin/yes | pip install mkl==2022.2.1
+  /usr/bin/yes | pip install mkl-include==2022.2.1
   /usr/bin/yes | pip install typing_extensions  # Required for Python<=3.9
   /usr/bin/yes | pip install --upgrade oauth2client
   /usr/bin/yes | pip install lark-parser

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -41,7 +41,7 @@ RUN update-alternatives --install /usr/bin/clang++ clang++ $(which clang++-8) 70
 ENV CC=clang-8
 ENV CXX=clang++-8
 
-RUN pip install mkl mkl-include setuptools typing_extensions cmake requests
+RUN pip install mkl==2022.2.1 mkl-include=2022.2.1 setuptools typing_extensions cmake requests
 
 RUN git clone --recursive --depth=1 https://github.com/pytorch/pytorch.git
 WORKDIR /pytorch

--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -195,9 +195,9 @@ function install_and_setup_conda() {
   conda activate "$ENVNAME"
   export CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 
-  conda install -y numpy pyyaml setuptools cmake cffi typing tqdm coverage tensorboard hypothesis dataclasses
+  conda install -y nomkl numpy pyyaml setuptools cmake cffi typing tqdm coverage tensorboard hypothesis dataclasses
   if [[ $(uname -m) == "x86_64" ]]; then
-    conda install -y mkl-include
+    pip install mkl==2022.2.1 mkl-include==2022.2.1
   fi
 
   /usr/bin/yes | pip install --upgrade google-api-python-client


### PR DESCRIPTION
We want to use a version of MKL that won't cause our tests to crash. The default version pulled by conda crashes, and it looks like conda does not have the same MKL versions available as pip. So, we can use the nomkl conda flag to ensure that we install conda packages without the MKL dependency, and we can add the proper version of MKL with pip afterwards.

Using `nomkl` conda package 
https://anaconda.org/conda-forge/nomkl

Suggested around the web, e.g. by https://stackoverflow.com/questions/71306262/conda-env-broken-after-installing-pytorch-on-m1-intel-mkl-fatal-error

Testing: Built an image on cloudtop and used it to run cpp tests.