### PR TITLE
switch to pinning layout by default in FSDP to avoid data corruption in PJRT and be consistent with xm.all_reduce

### DIFF
--- a/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
+++ b/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
@@ -213,7 +213,7 @@ class XlaFullyShardedDataParallel(nn.Module):
       sharding_rank: Optional[int] = None,
       sharding_world_size: Optional[int] = None,
       shard_param_on_dim_0: bool = False,
-      pin_layout_in_collective_ops: bool = False,
+      pin_layout_in_collective_ops: bool = True,
       _shard_size_multiple: int = 128,
       _use_xla_patched_linear: bool = True,
       _debug_dummy_forward_pass: bool = False,


### PR DESCRIPTION
This PR switches the XLA FSDP implementation to pinning layout by default to avoid data corruption in PJRT and be consistent with `xm.all_reduce`.

cc: @JackCaoG @hjm-aws @AlexWertheim 