### PR TITLE
fix type annotations in FSDP

### DIFF
--- a/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
+++ b/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
@@ -652,7 +652,7 @@ class XlaFullyShardedDataParallel(nn.Module):
             f"sharding_groups={self.sharding_groups}")
     return repr
 
-  def __getattr__(self, name: str) -> Union[Tensor, nn.Module]:
+  def __getattr__(self, name: str) -> Union[torch.Tensor, nn.Module]:
     """Forward missing attributes to wrapped module."""
     try:
       return super().__getattr__(name)  # defer to nn.Module's logic


### PR DESCRIPTION
Fix the FSDP type annotations `Tensor` to `torch.Tensor`.