### PR TITLE
Print xla_shape_ in XlaNode::ToString()

### DIFF
--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -165,6 +165,12 @@ xla::Shape XlaNode::GetOpShape(
   return *shape;
 }
 
+std::string XlaNode::ToString() const {
+  std::stringstream ss;
+  ss << torch::lazy::Node::ToString() << ", xla_shape=" << xla_shape_;
+  return ss.str();
+}
+
 const xla::Shape& GetXlaShape(const torch::lazy::Value& value) {
   XlaNode* casted = dynamic_cast<XlaNode*>(value.node.get());
   return casted->xla_shape(value.index);

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -134,6 +134,8 @@ class XlaNode : public torch::lazy::Node {
     sharding_hash_ = 0;
   }
 
+  std::string ToString() const override;
+
  private:
   xla::Shape GetOpShape(const std::function<xla::Shape()>& shape_fn) const;
 


### PR DESCRIPTION
Summary:
We don't use lazy shape anymore. Therefore, we need to print our own xla shape.

Test Plan:
CI.