### PR TITLE
Fix another error when building r1.12 py38 colab wheel for Huggingface

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -24,7 +24,7 @@ steps:
   entrypoint: bash
   args: ['-c', 'source /pytorch/xla/docker/common.sh && run_deployment_tests']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'gcr.io/tpu-pytorch/xla']
+  args: ['push', '--all-tags', 'gcr.io/tpu-pytorch/xla']
   timeout: 1800s
 - name: 'gcr.io/tpu-pytorch/xla:${_IMAGE_NAME}'
   entrypoint: 'bash'


### PR DESCRIPTION
The last [build](https://pantheon.corp.google.com/cloud-build/builds;region=us-central1/a59e4081-543d-41f5-b8aa-ed7bfafd9794;step=3?jsmode=o&mods=allow_workbench_image_override&project=tpu-pytorch) failed when we tried to push all local images to remote repository:
```
Starting Step #3
Step #3: Already have image (with digest): gcr.io/cloud-builders/docker
Step #3: Using default tag: latest
Step #3: The push refers to repository [gcr.io/tpu-pytorch/xla]
Step #3: tag does not exist: gcr.io/tpu-pytorch/xla:latest
Finished Step #3
ERROR
ERROR: build step 3 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 1
```
It seems similar to b/239442843 so I applied the fix in https://github.com/pytorch/xla/pull/3754