### PR TITLE
Update `libtpu` version to Dec17

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ import zipfile
 base_dir = os.path.dirname(os.path.abspath(__file__))
 third_party_path = os.path.join(base_dir, 'third_party')
 
-_libtpu_version = '0.1.dev20221017'
+_libtpu_version = '0.1.dev20221217'
 _libtpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
 
 


### PR DESCRIPTION
Upgrade libtpu version to Dec 17th to align with that of our recent Tensorflow Pin(updated to Dec 15th) https://github.com/pytorch/xla/pull/4324