### PR TITLE
Support release builds in Terraform triggers

### DIFF
--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -10,7 +10,7 @@ ARG tf_cuda_compute_capabilities="7.0,7.5,8.0"
 
 ARG tpuvm=1
 ARG build_cpp_tests=0
-ARG package_version=1.14.0
+ARG package_version=2.0.0
 
 ARG bazel_jobs=
 
@@ -43,10 +43,13 @@ ENV CXX=clang++-8
 
 RUN pip install mkl mkl-include setuptools typing_extensions cmake requests
 
-RUN git clone --recursive --depth=1 https://github.com/pytorch/pytorch.git
+RUN git clone --depth=1 https://github.com/pytorch/pytorch.git
 WORKDIR /pytorch
 COPY torch_patches/ torch_patches/
-RUN bash -c "torch_pin=$(cat torch_patches/.torch_pin &); git fetch origin ${torch_pin:-master}; git checkout origin/${torch_pin:-master}"
+RUN bash -c 'torch_pin=$(cat torch_patches/.torch_pin &); git fetch origin ${torch_pin:-master}; git checkout FETCH_HEAD'
+RUN git submodule update --init --recursive
+RUN for p in torch_patches/*.diff; do patch -N -p1 < $p; done
+
 
 # Disable CUDA for PyTorch
 ENV USE_CUDA "0"

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -48,7 +48,7 @@ WORKDIR /pytorch
 COPY torch_patches/ torch_patches/
 RUN bash -c 'torch_pin=$(cat torch_patches/.torch_pin &); git fetch origin ${torch_pin:-master}; git checkout FETCH_HEAD'
 RUN git submodule update --init --recursive
-RUN for p in torch_patches/*.diff; do patch -N -p1 < $p; done
+RUN find -wholename 'torch_patches/*.diff' | xargs -r patch -N -p1 -i
 
 
 # Disable CUDA for PyTorch
@@ -71,8 +71,7 @@ FROM builder AS artifacts
 
 COPY tf_patches/ tf_patches/
 COPY third_party/ third_party/
-
-RUN for p in tf_patches/*.diff; do patch -d third_party/tensorflow -N -p1 < $p; done
+RUN find -wholename 'tf_patches/*.diff' | xargs -r patch -d third_party/tensorflow -N -p1 -i
 
 COPY build_torch_xla_libs.sh .
 

--- a/docker/experimental/cloudbuild.yaml
+++ b/docker/experimental/cloudbuild.yaml
@@ -121,15 +121,15 @@ substitutions:
   _RELEASE_IMAGE_URL: ${_IMAGE_REPOSITORY}/torch-xla:${_IMAGE_TAG}
   _ARTIFACTS_IMAGE_URL: ${_IMAGE_REPOSITORY}/artifacts:${_IMAGE_TAG}
   _CACHE_IMAGE_URL: ${_IMAGE_REPOSITORY}/cache
-  _BAZEL_JOBS: '16'
+  _BAZEL_JOBS: '32'
   _CACHE: 'true'
   _CACHE_TTL: '18h'
   _BUILD_ARGS: tpuvm=1,cuda=0
 options:
   # To run in a test project, either point to your pool or replace this with
   # `machineType`. You may have to reduce _BAZEL_JOBS.
-  # workerPool: projects/tpu-pytorch/locations/us-central1/wheel_build
-  machineType: E2_HIGHCPU_32
+  workerPool: projects/tpu-pytorch/locations/us-central1/wheel_build
+  # machineType: E2_HIGHCPU_32
   dynamic_substitutions: true
   substitution_option: 'ALLOW_LOOSE'
 timeout: 24000s

--- a/docker/experimental/cloudbuild.yaml
+++ b/docker/experimental/cloudbuild.yaml
@@ -18,9 +18,6 @@ steps:
 
     args=(${_BUILD_ARGS//,/ })
     flags=(
-      --cache=${_CACHE}
-      --cache-ttl=${_CACHE_TTL}
-      --cache-repo=${_CACHE_IMAGE_URL}
       --build-arg=bazel_jobs=${_BAZEL_JOBS}
       --build-arg=python_version=${_PYTHON_VERSION}
       # TODO: use current version in setup.py
@@ -31,31 +28,27 @@ steps:
   - name: docker
     path: /docker
 - id: 'build-wheels'
-  name: 'gcr.io/kaniko-project/executor:debug'
+  name: 'gcr.io/cloud-builders/docker'
   entrypoint: sh
   args:
   - -cx
   - |
-    /kaniko/executor \
-      --dockerfile=docker/experimental/Dockerfile \
-      --destination=${_ARTIFACTS_IMAGE_URL} \
-      --tar-path=/docker/artifacts-image.tar \
+    docker build . \
+      --file=docker/experimental/Dockerfile \
+      --tag=${_ARTIFACTS_IMAGE_URL} \
       --target=artifacts \
       $(cat /docker/flags.txt)
   timeout: 14400s
   volumes:
   - name: docker
     path: /docker
-- id: 'import-artifacts'
-  name: gcr.io/cloud-builders/docker
+- id: 'push-artifacts'
+  name: 'gcr.io/cloud-builders/docker'
   args:
-  - load
-  - --input
-  - /docker/artifacts-image.tar
-  volumes:
-  - name: docker
-    path: /docker
+  - push
+  - ${_ARTIFACTS_IMAGE_URL}
 - id: 'copy-wheels'
+  waitFor: ['build-wheels']
   name: ${_ARTIFACTS_IMAGE_URL}
   entrypoint: bash
   args:
@@ -67,6 +60,7 @@ steps:
   - name: 'wheels'
     path: /wheels
 - id: 'install-twine'
+  waitFor: ['build-wheels']
   name: python
   entrypoint: pip
   args:
@@ -90,21 +84,26 @@ steps:
     path: /wheels
 - id: 'release-image'
   waitFor: ['build-wheels']
-  name: 'gcr.io/kaniko-project/executor:debug'
+  name: 'gcr.io/cloud-builders/docker'
   entrypoint: sh
   args:
   - -cx
   - |
-    /kaniko/executor \
-      --dockerfile=docker/experimental/Dockerfile \
-      --destination=${_RELEASE_IMAGE_URL} \
+    docker build . \
+      --file=docker/experimental/Dockerfile \
+      --tag=${_RELEASE_IMAGE_URL} \
       $(cat /docker/flags.txt)
   timeout: 14400s
   volumes:
   - name: docker
     path: /docker
+- id: 'push-release'
+  name: 'gcr.io/cloud-builders/docker'
+  args:
+  - push
+  - ${_RELEASE_IMAGE_URL}
 - id: 'tag-image'
-  waitFor: ['release-image']
+  waitFor: ['push-artifacts', 'push-release']
   name: 'google/cloud-sdk'
   entrypoint: bash
   args:
@@ -129,8 +128,8 @@ substitutions:
 options:
   # To run in a test project, either point to your pool or replace this with
   # `machineType`. You may have to reduce _BAZEL_JOBS.
-  workerPool: projects/tpu-pytorch/locations/us-central1/wheel_build
-  # machineType: E2_HIGHCPU_32
+  # workerPool: projects/tpu-pytorch/locations/us-central1/wheel_build
+  machineType: E2_HIGHCPU_32
   dynamic_substitutions: true
   substitution_option: 'ALLOW_LOOSE'
 timeout: 24000s

--- a/docker/experimental/cloudbuild.yaml
+++ b/docker/experimental/cloudbuild.yaml
@@ -127,7 +127,10 @@ substitutions:
   _CACHE_TTL: '18h'
   _BUILD_ARGS: tpuvm=1,cuda=0
 options:
-  machineType: E2_HIGHCPU_32
+  # To run in a test project, either point to your pool or replace this with
+  # `machineType`. You may have to reduce _BAZEL_JOBS.
+  workerPool: projects/tpu-pytorch/locations/us-central1/wheel_build
+  # machineType: E2_HIGHCPU_32
   dynamic_substitutions: true
   substitution_option: 'ALLOW_LOOSE'
 timeout: 24000s

--- a/docker/experimental/terraform/main.tf
+++ b/docker/experimental/terraform/main.tf
@@ -104,7 +104,7 @@ module "r113-py37-tpuvm" {
   source = "./modules/trigger"
 
   release = "1.13"
-  branch = "r1.13"
+  branch = "wcromar/r1.13-kaggle"
   build_on_push = true
   schedule = null
   python_version = "3.7"

--- a/docker/experimental/terraform/modules/trigger/main.tf
+++ b/docker/experimental/terraform/modules/trigger/main.tf
@@ -46,6 +46,7 @@ locals {
 resource "google_cloudbuild_trigger" "build-trigger" {
   location = "global"
   name = local.trigger_name
+  filename = "docker/experimental/cloudbuild.yaml"
 
   dynamic "github" {
     # HACK: `source_to_build` is mutually exclusive with `github`
@@ -65,11 +66,6 @@ resource "google_cloudbuild_trigger" "build-trigger" {
     uri = "https://github.com/pytorch/xla"
     repo_type = "GITHUB"
     ref = "refs/heads/${var.branch}"
-  }
-
-  git_file_source {
-    path = "docker/experimental/cloudbuild.yaml"
-    repo_type = "GITHUB"
   }
 
   substitutions = {

--- a/docker/experimental/terraform/modules/trigger/main.tf
+++ b/docker/experimental/terraform/modules/trigger/main.tf
@@ -69,6 +69,7 @@ resource "google_cloudbuild_trigger" "build-trigger" {
   }
 
   substitutions = {
+    _RELEASE_VERSION = var.release
     _PLATFORM = var.platform
     _BUILD_ARGS = join(",", var.docker_build_args)
     _PYTHON_VERSION = var.python_version

--- a/docker/experimental/terraform/modules/trigger/main.tf
+++ b/docker/experimental/terraform/modules/trigger/main.tf
@@ -1,5 +1,12 @@
+data "google_project" "project" { }
+
 variable "release" {
   type = string
+}
+
+variable "branch" {
+  type = string
+  default = "master"
 }
 
 variable "python_version" {
@@ -16,25 +23,53 @@ variable "docker_build_args" {
   default = [ "tpuvm=1" ]
 }
 
+variable "schedule" {
+  type = string
+  # Format: https://cloud.google.com/scheduler/docs/configuring/cron-job-schedules
+  default = "0 0 * * *"
+}
+
+variable "scheduler_service_account" {
+  type = string
+  default = null
+}
+
+variable "build_on_push" {
+  type = string
+  default = false
+}
+
 locals {
-  trigger_name = format("pytorch-xla-%s-py%s-%s", var.release, replace(var.python_version, ".", ""), var.platform)
+  trigger_name = format("pytorch-xla-%s-py%s-%s", replace(var.release, ".", "-"), replace(var.python_version, ".", ""), var.platform)
 }
 
 resource "google_cloudbuild_trigger" "build-trigger" {
   location = "global"
   name = local.trigger_name
 
+  dynamic "github" {
+    # HACK: `source_to_build` is mutually exclusive with `github`
+    for_each = var.build_on_push ? [1] : []
+
+    content {
+      owner = "pytorch"
+      name = "xla"
+      push {
+        # `branch` is treated as a regex, so look for exact match
+        branch = "^${var.branch}$"
+      }
+    }
+  }
+
   source_to_build {
     uri = "https://github.com/pytorch/xla"
     repo_type = "GITHUB"
-    # TODO: make branch configurable
-    ref = "refs/heads/master"
+    ref = "refs/heads/${var.branch}"
   }
 
   git_file_source {
     path = "docker/experimental/cloudbuild.yaml"
     repo_type = "GITHUB"
-    # TODO: make branch configurable
     revision = "refs/heads/master"
     uri = "https://github.com/pytorch/xla"
   }
@@ -47,11 +82,12 @@ resource "google_cloudbuild_trigger" "build-trigger" {
 }
 
 resource "google_cloud_scheduler_job" "trigger-schedule" {
+  count = var.schedule != null ? 1 : 0
+
   name = format("%s-schedule", local.trigger_name)
   region = "us-central1"
 
-  # Format: https://cloud.google.com/scheduler/docs/configuring/cron-job-schedules
-  schedule = "0 0 * * *"
+  schedule = var.schedule
   time_zone = "America/Los_Angeles"
 
   http_target {
@@ -59,8 +95,7 @@ resource "google_cloud_scheduler_job" "trigger-schedule" {
     uri = "https://cloudbuild.googleapis.com/v1/projects/${google_cloudbuild_trigger.build-trigger.project}/triggers/${google_cloudbuild_trigger.build-trigger.trigger_id}:run"
 
     oauth_token {
-      # TODO: Include this SA in config
-      service_account_email = "cloud-build-trigger-scheduler@tpu-pytorch.iam.gserviceaccount.com"
+      service_account_email = var.scheduler_service_account
     }
   }
 }

--- a/docker/experimental/terraform/modules/trigger/main.tf
+++ b/docker/experimental/terraform/modules/trigger/main.tf
@@ -49,7 +49,7 @@ resource "google_cloudbuild_trigger" "build-trigger" {
   filename = "docker/experimental/cloudbuild.yaml"
 
   dynamic "github" {
-    # HACK: `source_to_build` is mutually exclusive with `github`
+    # HACK: only add `github` section at all when building on push
     for_each = var.build_on_push ? [1] : []
 
     content {

--- a/docker/experimental/terraform/modules/trigger/main.tf
+++ b/docker/experimental/terraform/modules/trigger/main.tf
@@ -70,8 +70,6 @@ resource "google_cloudbuild_trigger" "build-trigger" {
   git_file_source {
     path = "docker/experimental/cloudbuild.yaml"
     repo_type = "GITHUB"
-    revision = "refs/heads/master"
-    uri = "https://github.com/pytorch/xla"
   }
 
   substitutions = {


### PR DESCRIPTION
- Make `schedule` configurable and optional
- Add `build_on_push` option for unscheduled builds
- Put scheduler service account in Terraform config
- Add a worker pool with more resources to Terraform and GCB yaml
- Fix some bugs with applying torch patches and pins
- Remove Kaniko caching and replace with `docker build`. Kaniko was producing and caching invalid images ([known issue](https://www.github.com/GoogleContainerTools/kaniko/issues/1059)). We can revisit image caching later.

The hackery I use with `for_each` and `count` in Terraform are apparently the [normal](https://stackoverflow.com/a/60231673) [way](https://stackoverflow.com/a/70594607) to apply resources conditionally.

Test build with [patched `r1.13` branch](https://github.com/pytorch/xla/tree/wcromar/r1.13-kaggle) passed: 
![image](https://user-images.githubusercontent.com/15197278/210418108-7be8587b-7a56-4d48-9e41-b62708d621f7.png)
