### PR TITLE
Update CI test scripts to allow continuing on test failures

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -2,6 +2,12 @@
 
 set -ex
 
+# See Note [Keep Going]
+CONTINUE_ON_ERROR=false
+if [[ "$CONTINUE_ON_ERROR" != "1" ]]; then
+  set +e
+fi
+
 # System default cmake 3.10 cannot find mkl, so point it to the right place.
 # CMAKE_PREFIX_PATH will default to (in this order):
 # 1. CMAKE_PREFIX_PATH (if it exists)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,6 +229,22 @@ assert_no_torch_pin: &assert_no_torch_pin
         echo "No ${TORCH_PIN} found, safe to land..."
       fi
 
+assert_continue_on_error_is_false: &assert_continue_on_error_is_false
+  name: Make sure CONTINUE_ON_ERROR flags are set to false before merging
+  command: |
+      CONTINUE_ON_ERROR="CONTINUE_ON_ERROR=true"
+      if grep -Fxq "$CONTINUE_ON_ERROR" ./test/run_tests.sh
+      then
+        echo "Please set CONTINUE_ON_ERROR at test/run_tests.sh to false before landing."
+        exit 1
+      fi
+      if grep -Fxq "$CONTINUE_ON_ERROR" ./.circleci/common.sh
+      then
+        echo "Please set CONTINUE_ON_ERROR at .circleci/common.sh to false before landing."
+        exit 1
+      fi
+      echo "CONTINUE_ON_ERROR flags are set to false, safe to land..."
+
 ci_params: &ci_params
   parameters:
     resource_class:
@@ -263,6 +279,14 @@ jobs:
         <<: *run_clang_format
     - run:
         <<: *run_yapf
+
+  continue_on_error_is_false:
+    machine:
+      image: ubuntu-2004:202111-02
+    steps:
+    - checkout
+    - run:
+        <<: *assert_continue_on_error_is_false
 
   pytorch_xla_run_build:
     <<: *run_build

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -6,6 +6,19 @@ MAX_GRAPH_SIZE=500
 GRAPH_CHECK_FREQUENCY=100
 VERBOSITY=2
 
+# Note [Keep Going]
+#
+# Set the `CONTINUE_ON_ERROR` flag to `true` to make the CircleCI tests continue on error.
+# This will allow you to see all the failures on your PR, not stopping with the first
+# test failure like the default behavior.
+#
+# This flag should be set to `false`` by default. After testing your changes, make sure
+# to set this flag back to `false`` before you merge your PR. 
+CONTINUE_ON_ERROR=false
+if [[ "$CONTINUE_ON_ERROR" != "1" ]]; then
+  set +e
+fi
+
 while getopts 'LM:C:V:' OPTION
 do
   case $OPTION in


### PR DESCRIPTION
Initial commit for https://github.com/pytorch/xla/issues/4348.

This PR introduces a new flag in `run_tests.sh` (for CPU CI) and `common.sh` (for GPU CI) called `CONTINUE_ON_ERROR` that simply unsets `set +e` flag on the bash scripts. Unsetting this flag will allow the test to continue on error. This feature is already supported on PyTorch (more details at https://github.com/pytorch/xla/issues/4348). This is useful when a developer wants to gauge the impact of their changes on the CI initially at a glance.

Since the `CONTINUE_ON_ERROR` is manually set by developers for now, this PR also introduces a new linter check called `continue_on_error_is_false` that runs on each submitted commit. Similar to our our existing `linter_check_no_torch_pin`, this fails if a commit has merged with `CONTINUE_ON_ERROR` flag being set to `true`. Tested this locally and is working as intended, an example failure will `exit 1` with the failure message:
```
Please set CONTINUE_ON_ERROR at .circleci/common.sh to false before landing.
```

For follow-up, we'll want to make this more sophisticated as noted in the issue above. In high level, we want to:
1. Be able to continue on error based on GitHub PR label "keep-going"
2. Output a summary of failures at the end of the CI run. 