### PR TITLE
Make Dynamo execution also save the graph when XLA_SAVE_TENSORS_FILE …

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -84,6 +84,11 @@ function run_eager_debug {
   XLA_USE_EAGER_DEBUG_MODE=1 run_test "$@"
 }
 
+function run_save_tensor_file {
+  echo "Running in save tensor file mode: $@"
+  XLA_SAVE_TENSORS_FILE="/tmp/xla_test_save_ir.txt" run_test "$@"
+}
+
 function run_xla_backend_mp {
   echo "Running XLA backend multiprocessing test: $@"
   MASTER_ADDR=localhost MASTER_PORT=6000 run_test "$@"
@@ -143,6 +148,7 @@ function run_op_tests {
   run_test python3 "$CDIR/test_metrics.py"
   run_test python3 "$CDIR/dynamo/test_dynamo_integrations_util.py"
   run_test python3 "$CDIR/dynamo/test_dynamo.py"
+  run_save_tensor_file python3 "$CDIR/dynamo/test_dynamo_graph_dump.py"
   run_downcast_bf16 python3 "$CDIR/test_data_type.py"
   run_use_bf16 python3 "$CDIR/test_data_type.py"
   run_test python3 "$CDIR/test_torch_distributed_xla_backend.py"

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1705,6 +1705,7 @@ void InitXlaModuleBindings(py::module m) {
             }
           }
 
+          XLAGraphExecutor::Get()->MaybeDumpGraph("dynamo", hash);
           auto results = XLAGraphExecutor::Get()->ExecuteComputationWithBarrier(
               cachedComputation->computation, parameters_data, device);
           std::vector<at::Tensor> retlist;


### PR DESCRIPTION
…is configured

Currently dynamo execution will not save the graph into the file since it directly go through the `_run_cached_graph` pybind. This is a bit inconvenient when debugging dynamo.

sample graph
```
[dynamo]
TensorsGraphInfo:
  extract_compiled_graph (/pytorch/torch/_dynamo/optimizations/torchxla_integration.py:132)
  fwd (/pytorch/torch/_dynamo/optimizations/backends.py:771)
  _fn (/pytorch/torch/_dynamo/eval_frame.py:212)
  fn_simple_dynamo (dynamo/test_dynamo_graph_dump.py:20)
  _fn (/pytorch/torch/_dynamo/eval_frame.py:212)
  test_dump_graph_with_dynamo_execution (dynamo/test_dynamo_graph_dump.py:31)
  run (/root/anaconda3/envs/pytorch/lib/python3.7/unittest/case.py:628)
  __call__ (/root/anaconda3/envs/pytorch/lib/python3.7/unittest/case.py:676)
  run (/root/anaconda3/envs/pytorch/lib/python3.7/unittest/suite.py:122)
  __call__ (/root/anaconda3/envs/pytorch/lib/python3.7/unittest/suite.py:84)
  run (/root/anaconda3/envs/pytorch/lib/python3.7/unittest/suite.py:122)
  __call__ (/root/anaconda3/envs/pytorch/lib/python3.7/unittest/suite.py:84)
  run (/root/anaconda3/envs/pytorch/lib/python3.7/unittest/runner.py:176)
  runTests (/root/anaconda3/envs/pytorch/lib/python3.7/unittest/main.py:271)
  __init__ (/root/anaconda3/envs/pytorch/lib/python3.7/unittest/main.py:101)
  <module> (dynamo/test_dynamo_graph_dump.py:40)

Hashes: (d88504b1b3dc9ace690ef1218a1c161e)

## BEGIN_GRAPH
IR {
  %0 = f32[] prim::Constant(), location=forward@<eval_with_key>.1:7, value=1
  %1 = f32[] xla::device_data(), location=forward@<eval_with_key>.1:6, device=CPU:0
  %2 = f32[] aten::sin(%1), location=forward@<eval_with_key>.1:6
  %3 = f32[] aten::mul(%2, %0), location=forward@<eval_with_key>.1:7
  %4 = f32[] xla::device_data(), location=forward@<eval_with_key>.1:5, device=CPU:0
  %5 = f32[] aten::cos(%4), location=forward@<eval_with_key>.1:5
  %6 = f32[] aten::add(%5, %3), location=forward@<eval_with_key>.1:7, ROOT=0
}
```
the frame is a bit misleading since the real caller is `_run_cached_graph` but I guess it is acceptable.