### PR TITLE
[SPMD] Use sharding annotation from XLATensor data as ground truth.

### DIFF
--- a/test/test_xla_sharding.py
+++ b/test/test_xla_sharding.py
@@ -129,8 +129,7 @@ class BasicShardingTest(XlaShardingTest):
     xt2 = xt.clone()
 
     # check the original sharding spec is preserved after clone()
-    self.assertEqual(sharding_spec,
-        torch_xla._XLAC._get_xla_sharding_spec(xt))
+    self.assertEqual(sharding_spec, torch_xla._XLAC._get_xla_sharding_spec(xt))
 
     # check the cloned sharding spec is the same
     self.assertEqual(

--- a/test/test_xla_sharding.py
+++ b/test/test_xla_sharding.py
@@ -125,7 +125,14 @@ class BasicShardingTest(XlaShardingTest):
     xt = torch.randn(2, 4, 8, 16).to(xm.xla_device())
     xs.mark_sharding(xt, self._get_mesh((1, 1, 1, self.n_devices)),
                      (0, 1, 2, 3))
+    sharding_spec = torch_xla._XLAC._get_xla_sharding_spec(xt)
     xt2 = xt.clone()
+
+    # check the original sharding spec is preserved after clone()
+    self.assertEqual(sharding_spec,
+        torch_xla._XLAC._get_xla_sharding_spec(xt))
+
+    # check the cloned sharding spec is the same
     self.assertEqual(
         torch_xla._XLAC._get_xla_sharding_spec(xt),
         torch_xla._XLAC._get_xla_sharding_spec(xt2))

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -81,7 +81,8 @@ XLATensorPtr XLATensor::Create(
   ShardingSpecPtr sharding = nullptr;
   if (ir_value) {
     auto* xla_node = dynamic_cast<XlaNode*>(ir_value.node.get());
-    sharding = xla_node->GetSharding();
+    sharding =
+        std::make_shared<XLATensor::ShardingSpec>(*xla_node->GetSharding());
   }
   XLATensorPtr xtensor = c10::make_intrusive<XLATensor>(
       XLATensor(std::move(ir_value), device, logical_element_type, sharding));

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -226,8 +226,6 @@ void XLATensor::SetShardingSpec(const ShardingSpec& sharding) {
       !ShardingUtil::EqualShardingSpecs(sharding, *sharding_spec())) {
     TORCH_LAZY_COUNTER("SetShardingSpec", 1);
     data()->sharding = std::make_shared<ShardingSpec>(sharding);
-    // dynamic_cast<XlaNode*>(GetIrValue().node.get())
-    //     ->SetSharding(sharding.sharding);
   }
 }
 void XLATensor::ClearShardingSpec() {

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -226,6 +226,8 @@ void XLATensor::SetShardingSpec(const ShardingSpec& sharding) {
       !ShardingUtil::EqualShardingSpecs(sharding, *sharding_spec())) {
     TORCH_LAZY_COUNTER("SetShardingSpec", 1);
     data()->sharding = std::make_shared<ShardingSpec>(sharding);
+    // dynamic_cast<XlaNode*>(GetIrValue().node.get())
+    //     ->SetSharding(sharding.sharding);
   }
 }
 void XLATensor::ClearShardingSpec() {

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -202,7 +202,7 @@ class XLATensor : public torch::lazy::LazyTensor {
   // Clear sharding annotation attached to the IR value and transfer sharded
   // data back to host.
   void ClearShardingSpec();
-  ShardingSpecPtr sharding_spec() const { return data()->sharding; }
+  ShardingSpecPtr sharding_spec() const;
 
   void SetStorage(const c10::Storage& storage) { storage_ = storage; }
   const c10::Storage& Storage() const { return storage_; }

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -53,6 +53,9 @@ using XLATensorPtr = c10::intrusive_ptr<XLATensor>;
 
 class XLATensor : public torch::lazy::LazyTensor {
  public:
+  struct ShardingSpec;
+  using ShardingSpecPtr = std::shared_ptr<ShardingSpec>;
+
   // This is the core XLA tensor data structure where all the tensor data is
   // held. The XLA tensor is nothing more than a shared pointer to a Data
   // object.
@@ -78,6 +81,7 @@ class XLATensor : public torch::lazy::LazyTensor {
     ~Data();
 
     std::shared_ptr<View> view;
+    ShardingSpecPtr sharding = nullptr;
     // TODO: remove this in favor of torch::lazy::Shape within ir_value.
     c10::optional<at::ScalarType> logical_element_type;
   };
@@ -192,14 +196,13 @@ class XLATensor : public torch::lazy::LazyTensor {
 
     xla::OpSharding sharding;
   };
-  using ShardingSpecPtr = std::shared_ptr<ShardingSpec>;
 
   // Annotate the IR value with ShardingSpec.
   void SetShardingSpec(const ShardingSpec& sharding_spec);
   // Clear sharding annotation attached to the IR value and transfer sharded
   // data back to host.
   void ClearShardingSpec();
-  ShardingSpecPtr sharding_spec() const;
+  ShardingSpecPtr sharding_spec() const { return data()->sharding; }
 
   void SetStorage(const c10::Storage& storage) { storage_ = storage; }
   const c10::Storage& Storage() const { return storage_; }

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -62,26 +62,34 @@ class XLATensor : public torch::lazy::LazyTensor {
   struct Data : public torch::lazy::LazyTensor::Data {
     Data(torch::lazy::BackendDataPtr handle,
          const torch::lazy::BackendDevice& device,
-         c10::optional<at::ScalarType> logical_element_type)
+         c10::optional<at::ScalarType> logical_element_type,
+         ShardingSpecPtr sharding = nullptr)
         : torch::lazy::LazyTensor::Data(handle, device),
-          logical_element_type(logical_element_type) {}
+          logical_element_type(logical_element_type),
+          sharding(sharding) {}
     Data(torch::lazy::Value ir_value, const torch::lazy::BackendDevice& device,
-         c10::optional<at::ScalarType> logical_element_type)
+         c10::optional<at::ScalarType> logical_element_type,
+         ShardingSpecPtr sharding = nullptr)
         : torch::lazy::LazyTensor::Data(ir_value, device),
-          logical_element_type(logical_element_type) {}
-    Data(at::Tensor tensor_data, const torch::lazy::BackendDevice& device)
+          logical_element_type(logical_element_type),
+          sharding(sharding) {}
+    Data(at::Tensor tensor_data, const torch::lazy::BackendDevice& device,
+         ShardingSpecPtr sharding = nullptr)
         : torch::lazy::LazyTensor::Data(tensor_data, device),
-          logical_element_type(tensor_data.scalar_type()) {}
+          logical_element_type(tensor_data.scalar_type()),
+          sharding(sharding) {}
     Data(std::shared_ptr<View> view, const torch::lazy::BackendDevice& device,
-         c10::optional<at::ScalarType> logical_element_type)
+         c10::optional<at::ScalarType> logical_element_type,
+         ShardingSpecPtr sharding = nullptr)
         : torch::lazy::LazyTensor::Data(device),
           view(std::move(view)),
-          logical_element_type(logical_element_type) {}
+          logical_element_type(logical_element_type),
+          sharding(sharding) {}
 
     ~Data();
 
     std::shared_ptr<View> view;
-    ShardingSpecPtr sharding = nullptr;
+    ShardingSpecPtr sharding;
     // TODO: remove this in favor of torch::lazy::Shape within ir_value.
     c10::optional<at::ScalarType> logical_element_type;
   };

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -89,6 +89,10 @@ class XLATensor : public torch::lazy::LazyTensor {
     ~Data();
 
     std::shared_ptr<View> view;
+    // The user provided sharding spec is attached to `XLATensor::Data`
+    // and all sharding look-up should refer to it as source of truth.
+    // A copy of the sharding spec is attached to the IR node via
+    // `SetShardingSpec` and also during the sync tensor collection.
     ShardingSpecPtr sharding;
     // TODO: remove this in favor of torch::lazy::Shape within ir_value.
     c10::optional<at::ScalarType> logical_element_type;

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -896,7 +896,11 @@ XLATensorPtr clamp(const XLATensorPtr& input,
 }
 
 XLATensorPtr clone(const XLATensorPtr& input) {
-  return input->CreateFrom(input->GetIrValue());
+  XLATensorPtr cloned = input->CreateFrom(input->GetIrValue());
+  if (input->sharding_spec() != nullptr) {
+    cloned->SetShardingSpec(*input->sharding_spec());
+  }
+  return cloned;
 }
 
 XLATensorPtr constant_pad_nd(const XLATensorPtr& input,
@@ -2150,6 +2154,11 @@ void copy_(XLATensorPtr& input, XLATensorPtr& src) {
           torch::lazy::ToVector<int64_t>(input_shape.get().dimensions()));
     }
     input->UpdateFromTensor(std::move(src_tensor), /*sync=*/false);
+  }
+
+  // Preserves sharding when copying.
+  if (src->sharding_spec() != nullptr) {
+    input->SetShardingSpec(*src->sharding_spec());
   }
 }
 

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -463,14 +463,15 @@ XLAGraphExecutor::SyncTensorCollection XLAGraphExecutor::CollectSyncTensors(
           // Add only tensors which need to be synced.
           coll.hash = torch::lazy::HashCombine(coll.hash, ir_value.hash());
           coll.indices.push_back(i);
-        }
-        // `sharding_spec()` checks sharding equality. If IR node has no
-        // sharding, then sync XLATensor sharding to the IR node. XLATensor's
-        // sharding takes the precedence as the source of the truth.
-        XLATensor::ShardingSpecPtr sharding = tensors[i]->sharding_spec();
-        if (sharding) {
-          dynamic_cast<XlaNode*>(ir_value.node.get())
-              ->SetSharding(sharding->sharding);
+
+          // `sharding_spec()` checks sharding equality. If IR node has no
+          // sharding, then sync XLATensor sharding to the IR node. XLATensor's
+          // sharding takes the precedence as the source of the truth.
+          XLATensor::ShardingSpecPtr sharding = tensors[i]->sharding_spec();
+          if (sharding) {
+            dynamic_cast<XlaNode*>(ir_value.node.get())
+                ->SetSharding(sharding->sharding);
+          }
         }
       } else if (config.force_ltc_data) {
         // The tensor only has at::Tensor data. We need to queue it for a

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -463,15 +463,14 @@ XLAGraphExecutor::SyncTensorCollection XLAGraphExecutor::CollectSyncTensors(
           // Add only tensors which need to be synced.
           coll.hash = torch::lazy::HashCombine(coll.hash, ir_value.hash());
           coll.indices.push_back(i);
-
-          // `sharding_spec()` checks sharding equality. If IR node has no
-          // sharding, then sync XLATensor sharding to the IR node. XLATensor's
-          // sharding takes the precedence as the source of the truth.
-          XLATensor::ShardingSpecPtr sharding = tensors[i]->sharding_spec();
-          if (sharding) {
-            dynamic_cast<XlaNode*>(ir_value.node.get())
-                ->SetSharding(sharding->sharding);
-          }
+        }
+        // `sharding_spec()` checks sharding equality. If IR node has no
+        // sharding, then sync XLATensor sharding to the IR node. XLATensor's
+        // sharding takes the precedence as the source of the truth.
+        XLATensor::ShardingSpecPtr sharding = tensors[i]->sharding_spec();
+        if (sharding) {
+          dynamic_cast<XlaNode*>(ir_value.node.get())
+              ->SetSharding(sharding->sharding);
         }
       } else if (config.force_ltc_data) {
         // The tensor only has at::Tensor data. We need to queue it for a


### PR DESCRIPTION
Use `XLATensor` data to hold a copy of user specified sharding annotation. This way, the IR node truncation and reset should not accidentally remove the sharding annotation, which should be removed via explicit `clear_sharding`.
- `XLATensor::sharding_spec` returns sharding from `XLATensor::data` (source of the truth)
- `XLATensor::Data` constructors now have `sharding` (default to `nullptr`) argument
- `CollectSyncTensors` check for sharding equality if IR sharding exists, and syncs the shardings from `XLATensor::Data` to IR nodes otherwise. 
- Shallow copying `XLATensor` should copy sharding annotation
- Deep copying `XLATensor` should persist sharding annotation

Also, 
- Added a debugging probe in `AssignIrValue`.