### PR TITLE
[LTC] Final tweaks on XLATensor and XLAGraphExecutor

### DIFF
--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -96,6 +96,10 @@ XLATensorPtr XLATensor::Create(
   return xtensor;
 }
 
+XLATensorPtr XLATensor::Create(std::shared_ptr<Data> data) {
+  return c10::make_intrusive<XLATensor>(XLATensor(std::move(data)));
+}
+
 XLATensor::XLATensor(const at::Tensor& tensor,
                      const torch::lazy::BackendDevice& device)
     : XLATensor(std::make_shared<Data>(tensor, device)) {}

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -221,11 +221,11 @@ class XLATensor : public torch::lazy::LazyTensor {
             c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
   XLATensor(std::shared_ptr<Data> data);
 
- private:
   static XLATensorPtr Create(
       std::shared_ptr<View> view, const torch::lazy::BackendDevice& device,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
 
+  // TODO(alanwaketan): Reuse the upstream one once Functionalization is done.
   void SetXlaData(torch::lazy::BackendDataPtr handle, bool sync);
 
   View::IrNode GetViewUpdate(const std::shared_ptr<View>& view) const;

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -87,10 +87,10 @@ class XLATensor : public torch::lazy::LazyTensor {
   static XLATensorPtr Create(
       torch::lazy::BackendDataPtr handle,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
-
   static XLATensorPtr Create(
       torch::lazy::Value ir_value, const torch::lazy::BackendDevice& device,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
+  static XLATensorPtr Create(std::shared_ptr<Data> data);
 
   // Create a new XLA tensor with the same metadata of the input tensor (with
   // possible overrides), and the new IR value.
@@ -260,10 +260,6 @@ class XLATensor : public torch::lazy::LazyTensor {
   // points to the same storage, and thus alias of each other.
   // FIXME(alanwaketan): Remove this once we have functionalization (bdhirsh).
   c10::Storage storage_;
-
-  // TODO: This is temporarily until we fully inherit LazyTensor and
-  // LazyGraphExecutor.
-  friend class XLAGraphExecutor;
 };
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -121,8 +121,10 @@ class XLATensor : public torch::lazy::LazyTensor {
   void ShallowCopyTo(XLATensorPtr dest) const;
 
   // Assigns the tensor value to the XLA tensor.
+  // TODO(alanwaketan): Reuse the upstream one once Functionalization is done.
   void SetTensor(at::Tensor tensor);
 
+  // TODO(alanwaketan): Reuse the upstream ones once Functionalization is done.
   void UpdateFromTensor(at::Tensor tensor, bool sync);
   void UpdateFromTensorOut(at::Tensor tensor);
   void UpdateFromTensorOut(const XLATensorPtr& tensor);
@@ -143,24 +145,27 @@ class XLATensor : public torch::lazy::LazyTensor {
 
   // Fetches the XLA data behind the tensor. If the tensor has a graph defining
   // its current value, executes the graph and fetches the XLA data result.
+  // TODO(alanwaketan): Reuse the upstream ones once Functionalization is done.
   torch::lazy::BackendDataPtr GetXlaData();
-
   void SetXlaData(torch::lazy::BackendDataPtr handle);
 
   // Retrieves the current IR XlaNode, or nullptr in case no active IR XlaNode
   // is available.
+  // TODO(alanwaketan): Reuse the upstream ones once Functionalization is done.
   torch::lazy::Value CurrentIrValue() const;
 
   // Retrieves the IR Node representing this XLATensor. One will be created if
   // missing. Note that although this is a const API, it actually changes the
   // internal state of the object.
+  // TODO(alanwaketan): Reuse the upstream ones once Functionalization is done.
   torch::lazy::Value GetIrValue() const;
-
   void SetIrValue(torch::lazy::Value ir_value, bool inplace = true);
   void SetInPlaceIrValue(torch::lazy::Value ir_value);
 
+  // TODO(alanwaketan): Reuse the upstream one once Functionalization is done.
   c10::optional<at::Tensor> CurrentTensorData() const;
 
+  // We don't use the upstream MakeOutputTensors to return XLATensorPtr instead.
   std::vector<XLATensorPtr> MakeOutputTensors(
       torch::lazy::NodePtr node, bool inherit_logical_type = true) const;
 
@@ -214,10 +219,6 @@ class XLATensor : public torch::lazy::LazyTensor {
   XLATensor(std::shared_ptr<View> view,
             const torch::lazy::BackendDevice& device,
             c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
-
-  // TODO: This is temporarily until we fully inherit LazyTensor and
-  // LazyGraphExecutor.
- public:
   XLATensor(std::shared_ptr<Data> data);
 
  private:

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -82,7 +82,7 @@ std::vector<XLATensorPtr> XLAGraphExecutor::DeviceContextArena::GetLiveTensors(
           std::dynamic_pointer_cast<XLATensor::Data>(uid_wptr.second.lock());
       if (data != nullptr) {
         tensors.push_back(
-            c10::make_intrusive<XLATensor>(XLATensor(std::move(data))));
+            XLATensor::Create(std::move(data)));
       }
     }
   };

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -81,8 +81,7 @@ std::vector<XLATensorPtr> XLAGraphExecutor::DeviceContextArena::GetLiveTensors(
       auto data =
           std::dynamic_pointer_cast<XLATensor::Data>(uid_wptr.second.lock());
       if (data != nullptr) {
-        tensors.push_back(
-            XLATensor::Create(std::move(data)));
+        tensors.push_back(XLATensor::Create(std::move(data)));
       }
     }
   };

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -786,7 +786,6 @@ XLAGraphExecutor::ScheduleSyncTensorsGraph(
         TF_VLOG(3) << "Executing IR graph hash "
                    << torch::lazy::HashToString(hash)
                    << " on devices: " << absl::StrJoin(devices, ",");
-        // TODO(jwtan): Remove the WrapXlaData when inherits LazyGraphExecutor.
         results = WrapXlaData(xla::ComputationClient::Get()->ExecuteReplicated(
             *async->cached_computation->computation->client_computation(),
             device_arguments, devices,


### PR DESCRIPTION
Summary:
Fixes some TODOs and adds some comments on XLATensor and XLAGraphExecutor. This is the final move for LTC migration.

Test Plan:
CI.