### PR TITLE
manually lower addcmul and addcdiv in 1.13

### DIFF
--- a/.torch_pin
+++ b/.torch_pin
@@ -1,1 +1,1 @@
-release/1.13
+tags/v1.13.0

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -607,33 +607,35 @@ at::Tensor XLANativeFunctions::add(const at::Tensor& self,
                     });
 }
 
-XLATensorPtr XLATensor::addcdiv(const XLATensorPtr& input,
-                                const at::Scalar& value,
-                                const XLATensorPtr& tensor1,
-                                const XLATensorPtr& tensor2) {
-  torch::lazy::Value constant = GetIrValueForScalar(
-      value, tensor1->shape().get().element_type(), input->GetDevice());
-  torch::lazy::Value div = tensor1->GetIrValue() / tensor2->GetIrValue();
-  return input->CreateFrom(input->GetIrValue() + div * constant);
+at::Tensor XLANativeFunctions::addcdiv(const at::Tensor& self,
+                                       const at::Tensor& tensor1,
+                                       const at::Tensor& tensor2,
+                                       const at::Scalar& value) {
+  XLA_FN_COUNTER("xla::");
+  return bridge::AtenFromXlaTensor(XLATensor::addcdiv(
+      bridge::GetXlaTensor(self), value, bridge::GetXlaTensor(tensor1),
+      bridge::GetXlaTensor(tensor2)));
 }
 
-void XLATensor::addcdiv_(XLATensorPtr& input, const at::Scalar& value,
-                         const XLATensorPtr& tensor1,
-                         const XLATensorPtr& tensor2) {
-  torch::lazy::Value constant = GetIrValueForScalar(
-      value, tensor1->shape().get().element_type(), input->GetDevice());
-  torch::lazy::Value div = tensor1->GetIrValue() / tensor2->GetIrValue();
-  input->SetInPlaceIrValue(input->GetIrValue() + div * constant);
+at::Tensor& XLANativeFunctions::addcdiv_(at::Tensor& self,
+                                         const at::Tensor& tensor1,
+                                         const at::Tensor& tensor2,
+                                         const at::Scalar& value) {
+  XLA_FN_COUNTER("xla::");
+  XLATensorPtr self_tensor = bridge::GetXlaTensor(self);
+  XLATensor::addcdiv_(self_tensor, value, bridge::GetXlaTensor(tensor1),
+                      bridge::GetXlaTensor(tensor2));
+  return self;
 }
 
-XLATensorPtr XLATensor::addcmul(const XLATensorPtr& input,
-                                const at::Scalar& value,
-                                const XLATensorPtr& tensor1,
-                                const XLATensorPtr& tensor2) {
-  torch::lazy::Value constant = GetIrValueForScalar(
-      value, tensor1->shape().get().element_type(), input->GetDevice());
-  torch::lazy::Value mul = tensor1->GetIrValue() * tensor2->GetIrValue();
-  return input->CreateFrom(input->GetIrValue() + mul * constant);
+at::Tensor XLANativeFunctions::addcmul(const at::Tensor& self,
+                                       const at::Tensor& tensor1,
+                                       const at::Tensor& tensor2,
+                                       const at::Scalar& value) {
+  XLA_FN_COUNTER("xla::");
+  return bridge::AtenFromXlaTensor(XLATensor::addcmul(
+      bridge::GetXlaTensor(self), value, bridge::GetXlaTensor(tensor1),
+      bridge::GetXlaTensor(tensor2)));
 }
 
 at::Tensor XLANativeFunctions::addmm(const at::Tensor& self,

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -607,6 +607,35 @@ at::Tensor XLANativeFunctions::add(const at::Tensor& self,
                     });
 }
 
+XLATensorPtr XLATensor::addcdiv(const XLATensorPtr& input,
+                                const at::Scalar& value,
+                                const XLATensorPtr& tensor1,
+                                const XLATensorPtr& tensor2) {
+  torch::lazy::Value constant = GetIrValueForScalar(
+      value, tensor1->shape().get().element_type(), input->GetDevice());
+  torch::lazy::Value div = tensor1->GetIrValue() / tensor2->GetIrValue();
+  return input->CreateFrom(input->GetIrValue() + div * constant);
+}
+
+void XLATensor::addcdiv_(XLATensorPtr& input, const at::Scalar& value,
+                         const XLATensorPtr& tensor1,
+                         const XLATensorPtr& tensor2) {
+  torch::lazy::Value constant = GetIrValueForScalar(
+      value, tensor1->shape().get().element_type(), input->GetDevice());
+  torch::lazy::Value div = tensor1->GetIrValue() / tensor2->GetIrValue();
+  input->SetInPlaceIrValue(input->GetIrValue() + div * constant);
+}
+
+XLATensorPtr XLATensor::addcmul(const XLATensorPtr& input,
+                                const at::Scalar& value,
+                                const XLATensorPtr& tensor1,
+                                const XLATensorPtr& tensor2) {
+  torch::lazy::Value constant = GetIrValueForScalar(
+      value, tensor1->shape().get().element_type(), input->GetDevice());
+  torch::lazy::Value mul = tensor1->GetIrValue() * tensor2->GetIrValue();
+  return input->CreateFrom(input->GetIrValue() + mul * constant);
+}
+
 at::Tensor XLANativeFunctions::addmm(const at::Tensor& self,
                                      const at::Tensor& mat1,
                                      const at::Tensor& mat2,

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -55,22 +55,6 @@ torch_xla::XlaOpVector AdaptiveAvgPool3dBackward::Lower(
   return ReturnOp(xla_output, loctx);
 }
 
-torch_xla::XlaOpVector Addcdiv::Lower(LoweringContext* loctx) const {
-  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
-  xla::XlaOp xla_t1 = loctx->GetOutputOp(operand(1));
-  xla::XlaOp xla_t2 = loctx->GetOutputOp(operand(2));
-  xla::XlaOp xla_val = loctx->GetOutputOp(operand(3));
-  return ReturnOp(BuildAddcdiv(xla_input, xla_t1, xla_t2, xla_val), loctx);
-}
-
-torch_xla::XlaOpVector Addcmul::Lower(LoweringContext* loctx) const {
-  xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
-  xla::XlaOp xla_t1 = loctx->GetOutputOp(operand(1));
-  xla::XlaOp xla_t2 = loctx->GetOutputOp(operand(2));
-  xla::XlaOp xla_val = loctx->GetOutputOp(operand(3));
-  return ReturnOp(BuildAddcmul(xla_input, xla_t1, xla_t2, xla_val), loctx);
-}
-
 torch_xla::XlaOpVector All::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
   std::vector<int64_t> dimensions =

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -647,6 +647,35 @@ XLATensorPtr XLATensor::add(
       logical_element_type);
 }
 
+XLATensorPtr XLATensor::addcdiv(const XLATensorPtr& input,
+                                const at::Scalar& value,
+                                const XLATensorPtr& tensor1,
+                                const XLATensorPtr& tensor2) {
+  torch::lazy::Value constant = GetIrValueForScalar(
+      value, tensor1->shape().get().element_type(), input->GetDevice());
+  torch::lazy::Value div = tensor1->GetIrValue() / tensor2->GetIrValue();
+  return input->CreateFrom(input->GetIrValue() + div * constant);
+}
+
+void XLATensor::addcdiv_(XLATensorPtr& input, const at::Scalar& value,
+                         const XLATensorPtr& tensor1,
+                         const XLATensorPtr& tensor2) {
+  torch::lazy::Value constant = GetIrValueForScalar(
+      value, tensor1->shape().get().element_type(), input->GetDevice());
+  torch::lazy::Value div = tensor1->GetIrValue() / tensor2->GetIrValue();
+  input->SetInPlaceIrValue(input->GetIrValue() + div * constant);
+}
+
+XLATensorPtr XLATensor::addcmul(const XLATensorPtr& input,
+                                const at::Scalar& value,
+                                const XLATensorPtr& tensor1,
+                                const XLATensorPtr& tensor2) {
+  torch::lazy::Value constant = GetIrValueForScalar(
+      value, tensor1->shape().get().element_type(), input->GetDevice());
+  torch::lazy::Value mul = tensor1->GetIrValue() * tensor2->GetIrValue();
+  return input->CreateFrom(input->GetIrValue() + mul * constant);
+}
+
 XLATensorPtr XLATensor::addmm(const XLATensorPtr& input,
                               const XLATensorPtr& weight,
                               const XLATensorPtr& bias) {

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -6,8 +6,6 @@ full_codegen:
   - abs
   - all
   - all.dim
-  - addcdiv
-  - addcmul
   - amax
   - amin
   - any
@@ -121,6 +119,9 @@ supported:
   - adaptive_max_pool2d_backward
   - add.Scalar
   - add.Tensor
+  - addcdiv
+  - addcdiv_
+  - addcmul
   - addmm
   - alias
   - arange.start_out


### PR DESCRIPTION
Partially revert https://github.com/pytorch/xla/commit/6bfcd242b2d5be81dac31dd5dbe24165ab652fc4 for 1.13, we will fix it more properly in nightly. 

This should fix https://github.com/pytorch/xla/issues/4213 for 1.13.

FYI @aws-rhsoln @Liyang90 