### PR TITLE
Enable PJRT C API with `libtpu-nightly`

### DIFF
--- a/test/pjrt/test_experimental_pjrt_tpu.py
+++ b/test/pjrt/test_experimental_pjrt_tpu.py
@@ -1,5 +1,6 @@
 import concurrent.futures
 import os
+import time
 from typing import Dict
 from unittest import mock
 import requests
@@ -10,6 +11,7 @@ import torch.nn as nn
 from absl.testing import absltest, parameterized
 import torch_xla.core.xla_env_vars as xenv
 import torch_xla.core.xla_model as xm
+import torch_xla.debug.metrics as met
 from torch_xla.experimental import pjrt
 from torch_xla.experimental import tpu
 import torch_xla.distributed.xla_multiprocessing as xmp
@@ -250,6 +252,29 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
       self.assertIsInstance(device['coords'], list)
       self.assertIsInstance(device['core_on_chip'], int)
 
+  def _execute_time_metric():
+    # Initialize the client before starting the timer.
+    xm.xla_device()
+
+    begin = time.perf_counter_ns()
+    value = (torch.randn(10000, 10000, device=xm.xla_device()) *
+      torch.randn(10000, 10000, device=xm.xla_device()))
+    value_mean = value.mean()
+    xm.mark_step()
+    cpu_value = value_mean.cpu()
+    wall_time_ns = time.perf_counter_ns() - begin
+    _, execute_time_ns, _ = met.metric_data('ExecuteTime')
+
+    return execute_time_ns
+
+  def test_execute_time_metric(self):
+    results = pjrt._run_multiprocess(self._execute_time_metric)
+
+    for i, v in results.items():
+      expected_time_seconds = .1
+      self.assertGreater(v, expected_time_seconds * 1e-9,
+          f"Expected exectue time of {i} to take more than "
+          f"{expected_time_seconds} seconds, got {v / 1e9} seconds")
 
 class TestTpuCollectiveOps(parameterized.TestCase):
 

--- a/test/pjrt/test_experimental_pjrt_tpu.py
+++ b/test/pjrt/test_experimental_pjrt_tpu.py
@@ -252,13 +252,15 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
       self.assertIsInstance(device['coords'], list)
       self.assertIsInstance(device['core_on_chip'], int)
 
+  @staticmethod
   def _execute_time_metric():
     # Initialize the client before starting the timer.
     xm.xla_device()
 
     begin = time.perf_counter_ns()
-    value = (torch.randn(10000, 10000, device=xm.xla_device()) *
-      torch.randn(10000, 10000, device=xm.xla_device()))
+    value = (
+        torch.randn(10000, 10000, device=xm.xla_device()) *
+        torch.randn(10000, 10000, device=xm.xla_device()))
     value_mean = value.mean()
     xm.mark_step()
     cpu_value = value_mean.cpu()
@@ -272,9 +274,11 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
 
     for i, v in results.items():
       expected_time_seconds = .1
-      self.assertGreater(v, expected_time_seconds * 1e-9,
+      self.assertGreater(
+          v, expected_time_seconds * 1e-9,
           f"Expected exectue time of {i} to take more than "
           f"{expected_time_seconds} seconds, got {v / 1e9} seconds")
+
 
 class TestTpuCollectiveOps(parameterized.TestCase):
 

--- a/third_party/xla_client/env_vars.cc
+++ b/third_party/xla_client/env_vars.cc
@@ -22,7 +22,7 @@ const char* const kEnvPjRtTpuMaxInflightComputations =
     "PJRT_TPU_MAX_INFLIGHT_COMPUTATIONS";
 const char* const kEnvPjrtAsyncCpuClient = "PJRT_CPU_ASYNC_CLIENT";
 const char* const kEnvPjrtAsyncGpuClient = "PJRT_GPU_ASYNC_CLIENT";
-const char* const kEnvLibtpuLibraryPath = "LIBTPU_LIBRARY_PATH";
+const char* const kEnvTpuLibraryPath = "TPU_LIBRARY_PATH";
 
 }  // namespace env
 }  // namespace xla

--- a/third_party/xla_client/env_vars.cc
+++ b/third_party/xla_client/env_vars.cc
@@ -22,6 +22,7 @@ const char* const kEnvPjRtTpuMaxInflightComputations =
     "PJRT_TPU_MAX_INFLIGHT_COMPUTATIONS";
 const char* const kEnvPjrtAsyncCpuClient = "PJRT_CPU_ASYNC_CLIENT";
 const char* const kEnvPjrtAsyncGpuClient = "PJRT_GPU_ASYNC_CLIENT";
+const char* const kEnvLibtpuLibraryPath = "LIBTPU_LIBRARY_PATH";
 
 }  // namespace env
 }  // namespace xla

--- a/third_party/xla_client/env_vars.h
+++ b/third_party/xla_client/env_vars.h
@@ -22,7 +22,7 @@ extern const char* const kEnvPjRtDevice;
 extern const char* const kEnvPjRtTpuMaxInflightComputations;
 extern const char* const kEnvPjrtAsyncCpuClient;
 extern const char* const kEnvPjrtAsyncGpuClient;
-extern const char* const kEnvLibtpuLibraryPath;
+extern const char* const kEnvTpuLibraryPath;
 
 }  // namespace env
 }  // namespace xla

--- a/third_party/xla_client/env_vars.h
+++ b/third_party/xla_client/env_vars.h
@@ -22,6 +22,7 @@ extern const char* const kEnvPjRtDevice;
 extern const char* const kEnvPjRtTpuMaxInflightComputations;
 extern const char* const kEnvPjrtAsyncCpuClient;
 extern const char* const kEnvPjrtAsyncGpuClient;
+extern const char* const kEnvLibtpuLibraryPath;
 
 }  // namespace env
 }  // namespace xla

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -62,8 +62,7 @@ PjRtComputationClient::PjRtComputationClient() {
   } else if (device_type == "TPU_C_API") {
     TF_VLOG(1) << "Initializing PjRt C API client...";
     XLA_CHECK_OK(stream_executor::tpu::LoadPjrtPlugin(
-        "tpu",
-        sys_util::GetEnvString(env::kEnvTpuLibraryPath, "libtpu.so")));
+        "tpu", sys_util::GetEnvString(env::kEnvTpuLibraryPath, "libtpu.so")));
     client_ = std::move(xla::GetCApiClient("TPU").value());
   } else if (device_type == "GPU") {
     TF_VLOG(1) << "Initializing PjRt GPU client...";

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -63,7 +63,7 @@ PjRtComputationClient::PjRtComputationClient() {
     TF_VLOG(1) << "Initializing PjRt C API client...";
     XLA_CHECK_OK(stream_executor::tpu::LoadPjrtPlugin(
         "tpu",
-        sys_util::GetEnvString(env::kEnvLibtpuLibraryPath, "libtpu.so")));
+        sys_util::GetEnvString(env::kEnvTpuLibraryPath, "libtpu.so")));
     client_ = std::move(xla::GetCApiClient("TPU").value());
   } else if (device_type == "GPU") {
     TF_VLOG(1) << "Initializing PjRt GPU client...";
@@ -312,11 +312,10 @@ PjRtComputationClient::ExecuteComputation(
   execute_options.untuple_result = options.explode_tuple;
   execute_options.strict_shape_checking = false;
 
-  std::optional<PjRtFuture<Status>> returned_future;
+  // std::optional<PjRtFuture<Status>> returned_future;
   std::vector<std::unique_ptr<xla::PjRtBuffer>> results =
       pjrt_computation.executable
-          ->ExecuteSharded(buffers, pjrt_device, execute_options,
-                           returned_future)
+          ->ExecuteSharded(buffers, pjrt_device, execute_options)
           .value();
 
   // Signal that `ExecuteSharded` has completed for the ExecuteTime metric.

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -321,7 +321,8 @@ PjRtComputationClient::ExecuteComputation(
 
   // Signal that `ExecuteSharded` has completed for the ExecuteTime metric.
   // Copies the `timed` shared pointer into the lambda.
-  // TODO(wcromar): Uncomment this when we update past TF commit TODO
+  // TODO(wcromar): Uncomment this when we update past TF commit
+  // b8f59020ea0e9e6fba0e9c5e7be88271703eaf9e
   // returned_future->OnReady([timed](Status unused) mutable { timed.reset();
   // });
 

--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -125,10 +125,6 @@ class PjRtComputationClient : public ComputationClient {
   std::shared_ptr<PjRtClient> client_;
   std::unordered_map<std::string, xla::PjRtDevice* const> string_to_device_;
   std::shared_ptr<std::vector<std::string>> replication_devices_;
-  // TODO(wcromar): remove this when C API supports
-  // kImmutableUntilTransferCompletes
-  xla::PjRtClient::HostBufferSemantics host_buffer_semantics_ =
-      xla::PjRtClient::HostBufferSemantics::kImmutableUntilTransferCompletes;
 
   xla::PjRtDevice* StringToPjRtDevice(const std::string& device);
 


### PR DESCRIPTION
As of our last TF update, the `libtpu-nightly` package contains the new PJRT C API.

- Use `GetHloModules` now that it's implemented
- Switch `ExecuteSharded` to use `on_device_shape` to match `ExecuteReplicated`
- Use `xla::PjRtClient::HostBufferSemantics::kImmutableUntilTransferCompletes` now that it's implemented
- Temporary hack: copy `TimedSection` pointer to output buffers' `OnReady` callbacks. Futures with `ExecuteSharded`  are [already implemented](https://github.com/tensorflow/tensorflow/commit/b8f59020ea0e9e6fba0e9c5e7be88271703eaf9e) and will be available in the next libtpu update (thanks @jyingl3!)
- Add a TPU test for the `ExecuteTime` metric to make sure I'm using the callback correctly.
- Explicitly load TPU PJRT plugin to address a [TODO in TensorFlow](https://github.com/tensorflow/tensorflow/blob/a0c74d196a21b9d1230820d31e15492ec84d07a6/tensorflow/compiler/xla/stream_executor/tpu/pjrt_api.cc#L43-L51)

Tested manually with `test_experimental_pjrt_tpu.py` and `test_train_mp_imagenet.py` on TPU v4.