### PR TITLE
Pjrt device attributes

### DIFF
--- a/test/pjrt/test_experimental_pjrt_tpu.py
+++ b/test/pjrt/test_experimental_pjrt_tpu.py
@@ -246,7 +246,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
   def test_device_attributes(self):
     result = pjrt._run_multiprocess(self._device_attributes)
     for device in result.values():
-      self.assertListEqual(['coords', 'core_on_chip'], list(device.keys()))
+      self.assertCountEqual(['coords', 'core_on_chip'], list(device.keys()))
       self.assertIsInstance(device['coords'], list)
       self.assertIsInstance(device['core_on_chip'], int)
 

--- a/test/pjrt/test_experimental_pjrt_tpu.py
+++ b/test/pjrt/test_experimental_pjrt_tpu.py
@@ -349,5 +349,6 @@ class TestTpuCollectiveOps(parameterized.TestCase):
       np.testing.assert_array_equal(value, [[[-ordinal] * len(results),
                                              list(range(len(results)))]])
 
+
 if __name__ == '__main__':
   absltest.main()

--- a/test/pjrt/test_experimental_pjrt_tpu.py
+++ b/test/pjrt/test_experimental_pjrt_tpu.py
@@ -239,6 +239,16 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
           results,
           {i: torch.device(f'xla:{i}') for i in range(expected_num_devices)})
 
+  @staticmethod
+  def _device_attributes():
+    return pjrt.device_attributes(str(xm.xla_device()))
+
+  def test_device_attributes(self):
+    result = pjrt._run_multiprocess(self._device_attributes)
+    for device in result.values():
+      self.assertListEqual(['coords', 'core_on_chip'], list(device.keys()))
+      self.assertIsInstance(device['coords'], list)
+      self.assertIsInstance(device['core_on_chip'], int)
 
 class TestTpuCollectiveOps(parameterized.TestCase):
 
@@ -338,7 +348,6 @@ class TestTpuCollectiveOps(parameterized.TestCase):
     for ordinal, value in results.items():
       np.testing.assert_array_equal(value, [[[-ordinal] * len(results),
                                              list(range(len(results)))]])
-
 
 if __name__ == '__main__':
   absltest.main()

--- a/test/pjrt/test_experimental_pjrt_tpu.py
+++ b/test/pjrt/test_experimental_pjrt_tpu.py
@@ -250,6 +250,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
       self.assertIsInstance(device['coords'], list)
       self.assertIsInstance(device['core_on_chip'], int)
 
+
 class TestTpuCollectiveOps(parameterized.TestCase):
 
   @staticmethod

--- a/test/pjrt/test_train_pjrt_mnist.py
+++ b/test/pjrt/test_train_pjrt_mnist.py
@@ -178,6 +178,8 @@ def train_mnist(flags):
 if __name__ == '__main__':
   torch.set_default_tensor_type('torch.FloatTensor')
 
+  print('TEST:', pjrt.device_attributes("xla:0"))
+  sys.exit(21)
   results = pjrt._run_multiprocess(train_mnist, FLAGS)
   print('Replica max_accuracy:', pprint.pformat(results))
   accuracy = np.mean(list(results.values()))

--- a/test/pjrt/test_train_pjrt_mnist.py
+++ b/test/pjrt/test_train_pjrt_mnist.py
@@ -178,8 +178,6 @@ def train_mnist(flags):
 if __name__ == '__main__':
   torch.set_default_tensor_type('torch.FloatTensor')
 
-  print('TEST:', pjrt.device_attributes("xla:0"))
-  sys.exit(21)
   results = pjrt._run_multiprocess(train_mnist, FLAGS)
   print('Replica max_accuracy:', pprint.pformat(results))
   accuracy = np.mean(list(results.values()))

--- a/third_party/xla_client/computation_client.h
+++ b/third_party/xla_client/computation_client.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/types/optional.h"
 #include "absl/types/span.h"
 #include "tensorflow/compiler/xla/client/xla_computation.h"
@@ -305,11 +306,12 @@ class ComputationClient {
 
   virtual int GetNumProcesses() const = 0;
 
-  using DeviceAttributes =
+  using DeviceAttribute =
       std::variant<std::string, int64_t, std::vector<int64_t>, float>;
 
-  virtual std::map<std::string, DeviceAttributes> GetDeviceAttributes(
-      const std::string& device) = 0;
+  virtual const absl::flat_hash_map<std::string,
+                                    xla::ComputationClient::DeviceAttribute>&
+  GetDeviceAttributes(const std::string& device) = 0;
 
   virtual void SetReplicationDevices(
       std::shared_ptr<std::vector<std::string>> devices) = 0;

--- a/third_party/xla_client/computation_client.h
+++ b/third_party/xla_client/computation_client.h
@@ -305,10 +305,11 @@ class ComputationClient {
 
   virtual int GetNumProcesses() const = 0;
 
-  using DeviceAttributes = std::variant<std::string, int64_t, std::vector<int64_t>, float>;
+  using DeviceAttributes =
+      std::variant<std::string, int64_t, std::vector<int64_t>, float>;
 
-  virtual std::map<std::string, DeviceAttributes>
-      GetDeviceAttributes(const std::string& device) = 0;
+  virtual std::map<std::string, DeviceAttributes> GetDeviceAttributes(
+      const std::string& device) = 0;
 
   virtual void SetReplicationDevices(
       std::shared_ptr<std::vector<std::string>> devices) = 0;

--- a/third_party/xla_client/computation_client.h
+++ b/third_party/xla_client/computation_client.h
@@ -305,8 +305,6 @@ class ComputationClient {
 
   virtual int GetNumProcesses() const = 0;
 
-  // TODO: add a new variable for std::variant<std::string, int64_t, std::vector<int64_t>, float>
-  // maybe:
   using DeviceAttributes = std::variant<std::string, int64_t, std::vector<int64_t>, float>;
 
   virtual std::map<std::string, DeviceAttributes>

--- a/third_party/xla_client/computation_client.h
+++ b/third_party/xla_client/computation_client.h
@@ -307,8 +307,9 @@ class ComputationClient {
 
   // TODO: add a new variable for std::variant<std::string, int64_t, std::vector<int64_t>, float>
   // maybe:
-  // using DeviceAttributes = std::variant<std::string, int64_t, std::vector<int64_t>, float>;
-  virtual std::map<std::string, std::variant<std::string, int64_t, std::vector<int64_t>, float>>
+  using DeviceAttributes = std::variant<std::string, int64_t, std::vector<int64_t>, float>;
+
+  virtual std::map<std::string, DeviceAttributes>
       GetDeviceAttributes(const std::string& device) = 0;
 
   virtual void SetReplicationDevices(

--- a/third_party/xla_client/computation_client.h
+++ b/third_party/xla_client/computation_client.h
@@ -305,6 +305,12 @@ class ComputationClient {
 
   virtual int GetNumProcesses() const = 0;
 
+  // TODO: add a new variable for std::variant<std::string, int64_t, std::vector<int64_t>, float>
+  // maybe:
+  // using DeviceAttributes = std::variant<std::string, int64_t, std::vector<int64_t>, float>;
+  virtual std::map<std::string, std::variant<std::string, int64_t, std::vector<int64_t>, float>>
+      GetDeviceAttributes(const std::string& device) = 0;
+
   virtual void SetReplicationDevices(
       std::shared_ptr<std::vector<std::string>> devices) = 0;
 

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -443,6 +443,20 @@ int PjRtComputationClient::GetNumProcesses() const {
   return max_process_index + 1;
 };
 
+std::map<std::string, xla::PjRtDeviceAttribute>
+PjRtComputationClient::GetDeviceAttributes(const std::string& device) {
+  XLA_CHECK(string_to_device_.find(device) != string_to_device_.end())
+      << "Unknown device " << device;
+  const absl::flat_hash_map<std::string, xla::PjRtDeviceAttribute>& attributes =
+      string_to_device_[device]->Attributes();
+
+  std::map<std::string, xla::PjRtDeviceAttribute> map;
+  for (auto const& [name, value] : attributes) {
+    map[name] = value;
+  }
+  return map;
+}
+
 void PjRtComputationClient::SetReplicationDevices(
     std::shared_ptr<std::vector<std::string>> devices) {
   replication_devices_ = std::move(devices);

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -443,18 +443,11 @@ int PjRtComputationClient::GetNumProcesses() const {
   return max_process_index + 1;
 };
 
-std::map<std::string, xla::PjRtDeviceAttribute>
+const absl::flat_hash_map<std::string, xla::ComputationClient::DeviceAttribute>&
 PjRtComputationClient::GetDeviceAttributes(const std::string& device) {
   XLA_CHECK(string_to_device_.find(device) != string_to_device_.end())
       << "Unknown device " << device;
-  const absl::flat_hash_map<std::string, xla::PjRtDeviceAttribute>& attributes =
-      string_to_device_[device]->Attributes();
-
-  std::map<std::string, xla::PjRtDeviceAttribute> map;
-  for (auto const& [name, value] : attributes) {
-    map[name] = value;
-  }
-  return map;
+  return string_to_device_[device]->Attributes();
 }
 
 void PjRtComputationClient::SetReplicationDevices(

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -445,9 +445,7 @@ int PjRtComputationClient::GetNumProcesses() const {
 
 const absl::flat_hash_map<std::string, xla::ComputationClient::DeviceAttribute>&
 PjRtComputationClient::GetDeviceAttributes(const std::string& device) {
-  XLA_CHECK(string_to_device_.find(device) != string_to_device_.end())
-      << "Unknown device " << device;
-  return string_to_device_[device]->Attributes();
+  return PjRtComputationClient::StringToPjRtDevice(device)->Attributes();
 }
 
 void PjRtComputationClient::SetReplicationDevices(

--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -60,7 +60,7 @@ class PjRtComputationClient : public ComputationClient {
 
   int GetNumProcesses() const override;
 
-  std::map<std::string, xla::PjRtDeviceAttribute>
+  std::map<std::string, DeviceAttributes>
       GetDeviceAttributes(const std::string& device) override;
 
   void SetReplicationDevices(

--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -60,8 +60,8 @@ class PjRtComputationClient : public ComputationClient {
 
   int GetNumProcesses() const override;
 
-  std::map<std::string, DeviceAttributes>
-      GetDeviceAttributes(const std::string& device) override;
+  std::map<std::string, DeviceAttributes> GetDeviceAttributes(
+      const std::string& device) override;
 
   void SetReplicationDevices(
       std::shared_ptr<std::vector<std::string>> devices) override;

--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -60,6 +60,9 @@ class PjRtComputationClient : public ComputationClient {
 
   int GetNumProcesses() const override;
 
+  std::map<std::string, xla::PjRtDeviceAttribute>
+      GetDeviceAttributes(const std::string& device) override;
+
   void SetReplicationDevices(
       std::shared_ptr<std::vector<std::string>> devices) override;
 

--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -60,8 +60,9 @@ class PjRtComputationClient : public ComputationClient {
 
   int GetNumProcesses() const override;
 
-  std::map<std::string, DeviceAttributes> GetDeviceAttributes(
-      const std::string& device) override;
+  const absl::flat_hash_map<std::string,
+                            xla::ComputationClient::DeviceAttribute>&
+  GetDeviceAttributes(const std::string& device) override;
 
   void SetReplicationDevices(
       std::shared_ptr<std::vector<std::string>> devices) override;

--- a/third_party/xla_client/xrt_computation_client.h
+++ b/third_party/xla_client/xrt_computation_client.h
@@ -315,7 +315,7 @@ class XrtComputationClient : public ComputationClient {
     XLA_ERROR() << __FUNCTION__ << " not implemented";
   }
 
-  std::map<std::string, std::variant<std::string, int64_t, std::vector<int64_t>, float>>
+  std::map<std::string, DeviceAttributes>
   GetDeviceAttributes(const std::string& device) override {
     XLA_ERROR() << __FUNCTION__ << " not implemented";
   }

--- a/third_party/xla_client/xrt_computation_client.h
+++ b/third_party/xla_client/xrt_computation_client.h
@@ -315,8 +315,9 @@ class XrtComputationClient : public ComputationClient {
     XLA_ERROR() << __FUNCTION__ << " not implemented";
   }
 
-  std::map<std::string, DeviceAttributes> GetDeviceAttributes(
-      const std::string& device) override {
+  const absl::flat_hash_map<std::string,
+                            xla::ComputationClient::DeviceAttribute>&
+  GetDeviceAttributes(const std::string& device) override {
     XLA_ERROR() << __FUNCTION__ << " not implemented";
   }
 

--- a/third_party/xla_client/xrt_computation_client.h
+++ b/third_party/xla_client/xrt_computation_client.h
@@ -315,8 +315,8 @@ class XrtComputationClient : public ComputationClient {
     XLA_ERROR() << __FUNCTION__ << " not implemented";
   }
 
-  std::map<std::string, DeviceAttributes>
-  GetDeviceAttributes(const std::string& device) override {
+  std::map<std::string, DeviceAttributes> GetDeviceAttributes(
+      const std::string& device) override {
     XLA_ERROR() << __FUNCTION__ << " not implemented";
   }
 

--- a/third_party/xla_client/xrt_computation_client.h
+++ b/third_party/xla_client/xrt_computation_client.h
@@ -315,6 +315,11 @@ class XrtComputationClient : public ComputationClient {
     XLA_ERROR() << __FUNCTION__ << " not implemented";
   }
 
+  std::map<std::string, std::variant<std::string, int64_t, std::vector<int64_t>, float>>
+  GetDeviceAttributes(const std::string& device) override {
+    XLA_ERROR() << __FUNCTION__ << " not implemented";
+  }
+
   void SetReplicationDevices(
       std::shared_ptr<std::vector<std::string>> devices) override;
 

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1173,6 +1173,17 @@ void InitXlaModuleBindings(py::module m) {
   m.def("_xla_get_device_ordinal", [](const std::string& device_str) {
     return bridge::AtenDeviceToXlaDevice(device_str).ordinal();
   });
+  m.def("_xla_get_device_attributes", [](const std::string& device_str) {
+    std::map<std::string, std::variant<std::string, int64_t, std::vector<int64_t>, float>> attributes =
+        xla::ComputationClient::Get()->GetDeviceAttributes(
+        bridge::AtenDeviceToXlaDevice(device_str).toString());
+
+    py::dict dict;
+    for (auto const& [name, value] : attributes) {
+      dict[py::str(name)] = py::cast(value);
+    }
+    return dict;
+  });
   m.def("_xla_set_rng_seed",
         [](uint64_t seed, const std::string& device) {
           SetRngSeed(seed, device);

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1174,9 +1174,9 @@ void InitXlaModuleBindings(py::module m) {
     return bridge::AtenDeviceToXlaDevice(device_str).ordinal();
   });
   m.def("_xla_get_device_attributes", [](const std::string& device_str) {
-    std::map<std::string, 
-             std::variant<std::string, int64_t, std::vector<int64_t>, float>> 
-        attributes = xla::ComputationClient::Get()->GetDeviceAttributes(
+    const absl::flat_hash_map<
+        std::string, xla::ComputationClient::DeviceAttribute>& attributes =
+        xla::ComputationClient::Get()->GetDeviceAttributes(
             bridge::AtenDeviceToXlaDevice(device_str).toString());
 
     py::dict dict;

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1174,9 +1174,10 @@ void InitXlaModuleBindings(py::module m) {
     return bridge::AtenDeviceToXlaDevice(device_str).ordinal();
   });
   m.def("_xla_get_device_attributes", [](const std::string& device_str) {
-    std::map<std::string, std::variant<std::string, int64_t, std::vector<int64_t>, float>> attributes =
-        xla::ComputationClient::Get()->GetDeviceAttributes(
-        bridge::AtenDeviceToXlaDevice(device_str).toString());
+    std::map<std::string, 
+             std::variant<std::string, int64_t, std::vector<int64_t>, float>> 
+        attributes = xla::ComputationClient::Get()->GetDeviceAttributes(
+            bridge::AtenDeviceToXlaDevice(device_str).toString());
 
     py::dict dict;
     for (auto const& [name, value] : attributes) {

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -152,6 +152,9 @@ def process_index() -> int:
 def process_count() -> int:
   return torch_xla._XLAC._xla_get_num_processes()
 
+@requires_pjrt
+def device_attributes(device: str) -> Dict[str, object]:
+  return torch_xla._XLAC._xla_get_device_attributes(device)
 
 def _merge_replica_results(
     replica_results: List[Tuple[int, R]]) -> Dict[int, R]:

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -152,9 +152,11 @@ def process_index() -> int:
 def process_count() -> int:
   return torch_xla._XLAC._xla_get_num_processes()
 
+
 @requires_pjrt
 def device_attributes(device: str) -> Dict[str, object]:
   return torch_xla._XLAC._xla_get_device_attributes(device)
+
 
 def _merge_replica_results(
     replica_results: List[Tuple[int, R]]) -> Dict[int, R]:


### PR DESCRIPTION
Add device attributes to PjRt
using the computation_client (along with pjrt_computation_client and xrt_computation_client)
added unit tests for the new method and passing.