### PR TITLE
Revert "Update TF pin  for `libtpu-nightly==0.1.dev.20221223` compatible commit"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ import zipfile
 base_dir = os.path.dirname(os.path.abspath(__file__))
 third_party_path = os.path.join(base_dir, 'third_party')
 
-_libtpu_version = '0.1.dev20221223'
+_libtpu_version = '0.1.dev20221217'
 _libtpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
 
 

--- a/tf_patches/stream_executor.diff
+++ b/tf_patches/stream_executor.diff
@@ -28,3 +28,17 @@ index 722fa93147b..16790810d1f 100644
  )
 
  tf_proto_library(
+diff --git a/tensorflow/compiler/xla/runtime/module_registry.cc b/tensorflow/compiler/xla/runtime/module_registry.cc
+index 6f7f5c1a4a8..ffe7836d85e 100644
+--- a/tensorflow/compiler/xla/runtime/module_registry.cc
++++ b/tensorflow/compiler/xla/runtime/module_registry.cc
+@@ -69,7 +69,7 @@ ModulesState::InitializeUserData(CustomCall::UserData& user_data) {
+     ref_vec.push_back(std::move(*ref));
+   }
+ 
+-  return ref_vec;
++  return {std::move(ref_vec)};
+ }
+ 
+ }  // namespace runtime
+


### PR DESCRIPTION
Reverts pytorch/xla#4399, due to wheel build failures.