### PR TITLE
Change all size node logical_element_type to be compatible with the underlying XLA device.

### DIFF
--- a/torch_xla/csrc/ops/dynamic_ir.cpp
+++ b/torch_xla/csrc/ops/dynamic_ir.cpp
@@ -62,11 +62,14 @@ XlaOpVector SizeNode::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::GetDimensionSize(input, this->dim_), loctx);
 }
 
-std::string SizeNode::ToString() const { return "SizeNode"; }
+std::string SizeNode::ToString() const { return "aten::size for size"; }
 
 SizeAdd::SizeAdd(torch::lazy::Value a, torch::lazy::Value b)
     : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::add")},
-              {a, b}, xla::ShapeUtil::MakeShape(xla::S64, {}), 1) {
+              {a, b},
+              xla::ShapeUtil::MakeShape(
+                  GetShapeDimensionType(/*device=*/nullptr), {}),
+              1) {
   const torch::lazy::DimensionNode* dim_node_0 = DimCast(operand(0));
   const torch::lazy::DimensionNode* dim_node_1 = DimCast(operand(1));
   // SizeAdd can only be perfomed between two DimensionNode
@@ -85,7 +88,7 @@ int64_t SizeAdd::getDynamicValue() const {
   return dim_node_0->getDynamicValue() + dim_node_1->getDynamicValue();
 }
 
-std::string SizeAdd::ToString() const { return "SizeAdd"; }
+std::string SizeAdd::ToString() const { return "aten::add for size"; }
 
 XlaOpVector SizeAdd::Lower(LoweringContext* loctx) const {
   auto input1 = loctx->GetOutputOp(operand(0));
@@ -95,7 +98,7 @@ XlaOpVector SizeAdd::Lower(LoweringContext* loctx) const {
 
 SizeEq::SizeEq(torch::lazy::Value a, torch::lazy::Value b)
     : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::eq")},
-              {a, b}, xla::ShapeUtil::MakeShape(xla::S64, {}), 1) {
+              {a, b}, GetShapeDimensionType(/*device=*/nullptr), {}), 1) {
   const torch::lazy::DimensionNode* dim_node_0 = DimCast(operand(0));
   const torch::lazy::DimensionNode* dim_node_1 = DimCast(operand(1));
   XLA_CHECK(dim_node_0);
@@ -116,7 +119,7 @@ SizeConstant::SizeConstant(int64_t val) : Scalar(c10::Scalar{val}, xla::S64){};
 
 SizeMul::SizeMul(torch::lazy::Value a, torch::lazy::Value b)
     : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::mul")},
-              {a, b}, xla::ShapeUtil::MakeShape(xla::S64, {}), 1) {
+              {a, b}, GetShapeDimensionType(/*device=*/nullptr), {}), 1) {
   const torch::lazy::DimensionNode* dim_node_0 = DimCast(operand(0));
   const torch::lazy::DimensionNode* dim_node_1 = DimCast(operand(1));
   // SizeMul can only be perfomed between two DimensionNode
@@ -145,7 +148,7 @@ XlaOpVector SizeMul::Lower(LoweringContext* loctx) const {
 
 SizeDiv::SizeDiv(torch::lazy::Value a, torch::lazy::Value b)
     : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::div")},
-              {a, b}, xla::ShapeUtil::MakeShape(xla::S64, {}), 1) {
+              {a, b}, GetShapeDimensionType(/*device=*/nullptr), {}), 1) {
   const torch::lazy::DimensionNode* dim_node_0 = DimCast(operand(0));
   const torch::lazy::DimensionNode* dim_node_1 = DimCast(operand(1));
   // SizeDiv can only be perfomed between two DimensionNode


### PR DESCRIPTION
Rather than using the hardcode s64, we change all size node logical_element_type to be compatible with the underlying XLA device: cpu supports s64 but tpu only support s32.