### PR TITLE
Fix worker pool name in GCB config

### DIFF
--- a/docker/experimental/cloudbuild.yaml
+++ b/docker/experimental/cloudbuild.yaml
@@ -21,7 +21,7 @@ steps:
       --build-arg=bazel_jobs=${_BAZEL_JOBS}
       --build-arg=python_version=${_PYTHON_VERSION}
       # TODO: use current version in setup.py
-      --build-arg=package_version="1.14.0.dev$(date +%Y%m%d)${_PLATFORM:++$_PLATFORM}"
+      --build-arg=package_version="2.0.0.dev$(date +%Y%m%d)${_PLATFORM:++$_PLATFORM}"
       ${args[@]/#/--build-arg=})
     echo ${flags[@]} | tee /docker/flags.txt
   volumes:
@@ -128,7 +128,8 @@ substitutions:
 options:
   # To run in a test project, either point to your pool or replace this with
   # `machineType`. You may have to reduce _BAZEL_JOBS.
-  workerPool: projects/tpu-pytorch/locations/us-central1/wheel_build
+  pool:
+    name: projects/tpu-pytorch/locations/us-central1/wheel_build
   # machineType: E2_HIGHCPU_32
   dynamic_substitutions: true
   substitution_option: 'ALLOW_LOOSE'

--- a/docker/experimental/cloudbuild.yaml
+++ b/docker/experimental/cloudbuild.yaml
@@ -129,7 +129,7 @@ options:
   # To run in a test project, either point to your pool or replace this with
   # `machineType`. You may have to reduce _BAZEL_JOBS.
   pool:
-    name: projects/tpu-pytorch/locations/us-central1/wheel_build
+    name: 'projects/tpu-pytorch/locations/us-central1/workerPools/wheel_build'
   # machineType: E2_HIGHCPU_32
   dynamic_substitutions: true
   substitution_option: 'ALLOW_LOOSE'


### PR DESCRIPTION
I had the format for the pool name incorrect: https://cloud.google.com/build/docs/api/reference/rest/v1/projects.builds#Build.PoolOption

This should match the other cloud build config:

https://github.com/pytorch/xla/blob/acfb22750b39820dffb99e639d493cc633654d35/docker/cloudbuild.yaml#L45-L46

Also fix the package version