### PR TITLE
Initialize logical_element_type before sharding in XLATensor::Data

### DIFF
--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -107,13 +107,13 @@ class XLATensor : public torch::lazy::LazyTensor {
     ~Data();
 
     std::shared_ptr<View> view;
+    // TODO: remove this in favor of torch::lazy::Shape within ir_value.
+    c10::optional<at::ScalarType> logical_element_type;
     // The user provided sharding spec is attached to `XLATensor::Data`
     // and all sharding look-up should refer to it as source of truth.
     // A copy of the sharding spec is attached to the IR node via
     // `SetShardingSpec` and also during the sync tensor collection.
     ShardingSpecPtr sharding;
-    // TODO: remove this in favor of torch::lazy::Shape within ir_value.
-    c10::optional<at::ScalarType> logical_element_type;
   };
 
   static XLATensorPtr Create(const at::Tensor& tensor,


### PR DESCRIPTION
Fixes
```
Step #0: /pytorch/xla/torch_xla/csrc/tensor.h:86:11: warning: field 'logical_element_type' will be initialized after field 'sharding' [-Wreorder]
Step #0:           logical_element_type(logical_element_type),
Step #0:           ^
```
warning.