### PR TITLE
Update CONTINUE_ON_ERROR if statement in CircleCI bash scripts

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -4,7 +4,7 @@ set -ex
 
 # See Note [Keep Going]
 CONTINUE_ON_ERROR=false
-if [[ "$CONTINUE_ON_ERROR" != "1" ]]; then
+if [[ "$CONTINUE_ON_ERROR" == "1" ]]; then
   set +e
 fi
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -15,7 +15,7 @@ VERBOSITY=2
 # This flag should be set to `false`` by default. After testing your changes, make sure
 # to set this flag back to `false`` before you merge your PR. 
 CONTINUE_ON_ERROR=false
-if [[ "$CONTINUE_ON_ERROR" != "1" ]]; then
+if [[ "$CONTINUE_ON_ERROR" == "1" ]]; then
   set +e
 fi
 


### PR DESCRIPTION
Fixes a wrong if-statement introduced by https://github.com/pytorch/xla/pull/4385.

---
The `continue_on_error` should be enabled when the flag is set to true. The previous PR mistakenly continued when the flag was set to false. 