### PR TITLE
Rotate GITHUB_TORCH_XLA_BOT_TOKEN and use a new account

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,4 +341,3 @@ workflows:
               only:
                 - master
                 - /release\/.*/
-                - test_new_token  # TODO(yeounoh) remove before merging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ launch_docker_and_build: &launch_docker_and_build
     echo "declare -x XLA_USE_XRT=1" >> /home/circleci/project/xla_env
     echo "declare -x XLA_CUDA=1" >> /home/circleci/project/xla_env
     echo "declare -x USE_CUDA=0" >> /home/circleci/project/env
-    echo "declare -x GITHUB_TORCH_XLA_BOT_TOKEN=${GITHUB_TORCH_XLA_BOT_TOKEN}" >> /home/circleci/project/xla_env
+    echo "declare -x GITHUB_TORCH_XLA_BOT_TOKEN=${GITHUB_TORCH_XLA_BOT_2_TOKEN}" >> /home/circleci/project/xla_env
     echo "declare -x CIRCLE_PULL_REQUEST=${CIRCLE_PULL_REQUEST}" >> /home/circleci/project/env
     echo "declare -x CIRCLE_PROJECT_USERNAME=${CIRCLE_PROJECT_USERNAME}" >> /home/circleci/project/env
     echo "declare -x CIRCLE_PROJECT_REPONAME=${CIRCLE_PROJECT_REPONAME}" >> /home/circleci/project/env
@@ -341,3 +341,4 @@ workflows:
               only:
                 - master
                 - /release\/.*/
+                - test_new_token  # TODO(yeounoh) remove before merging

--- a/.circleci/doc_push.sh
+++ b/.circleci/doc_push.sh
@@ -13,7 +13,7 @@ popd
 
 echo "Pushing to public"
 git config --global user.email "torchxla@gmail.com"
-git config --global user.name "torchxlabot"
+git config --global user.name "torchxlabot2"
 GH_PAGES_BRANCH=gh-pages
 GH_PAGES_DIR=gh-pages-tmp
 CURRENT_COMMIT=`git rev-parse HEAD`
@@ -47,7 +47,7 @@ if [[ $git_status ]]; then
 /usr/bin/expect <<DONE
 spawn git push origin "$GH_PAGES_BRANCH"
 expect "Username*"
-send "torchxlabot\n"
+send "torchxlabot2\n"
 expect "Password*"
 send "$::env(GITHUB_TORCH_XLA_BOT_TOKEN)\n"
 expect eof


### PR DESCRIPTION
In response to the recent security alert from CircleCI, we are rotating the key and the torchxlabot account.