### PR TITLE
Enable xla_sharding_test.py except the virtual device related ones

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -13,7 +13,7 @@ VERBOSITY=2
 # test failure like the default behavior.
 #
 # This flag should be set to `false`` by default. After testing your changes, make sure
-# to set this flag back to `false`` before you merge your PR. 
+# to set this flag back to `false`` before you merge your PR.
 CONTINUE_ON_ERROR=false
 if [[ "$CONTINUE_ON_ERROR" == "1" ]]; then
   set +e
@@ -158,7 +158,7 @@ function run_op_tests {
   run_pjrt python3 "$CDIR/pjrt/test_experimental_tpu.py"
   run_pjrt python3 "$CDIR/pjrt/test_ddp.py"
   run_pjrt python3 "$CDIR/pjrt/test_mesh_service.py"
-  # run_pjrt python3 "$CDIR/test_xla_sharding.py"
+  run_pjrt python3 "$CDIR/test_xla_sharding.py"
   run_test python3 "$CDIR/test_operations_hlo.py" "$@" --verbosity=$VERBOSITY
   run_test python3 "$CDIR/test_input_output_aliases.py"
 }

--- a/test/test_xla_sharding.py
+++ b/test/test_xla_sharding.py
@@ -196,6 +196,7 @@ class VirtualDeviceTest(XlaShardingTest):
     os.environ["XLA_USE_SPMD"] = "1"
     super().setUpClass()
 
+  @unittest.skip("disable due to CI test failures")
   def test_mark_sharding(self):
     partition_spec = (0, 1)
     xt1 = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]],
@@ -209,6 +210,7 @@ class VirtualDeviceTest(XlaShardingTest):
                          dtype=torch.float,
                          device=xm.xla_device())))
 
+  @unittest.skip("disable due to CI test failures")
   def test_metrics_recorded(self):
     met.clear_counters()
     partition_spec = (0, 1)
@@ -219,6 +221,7 @@ class VirtualDeviceTest(XlaShardingTest):
     self.assertIn("VirtualDeviceUsage", met.counter_names())
     self.assertNotEqual(met.counter_value("VirtualDeviceUsage"), 0)
 
+  @unittest.skip("disable due to CI test failures")
   def test_model_weight_metrics(self):
     met.clear_counters()
     partition_spec = (0, 1)
@@ -228,6 +231,7 @@ class VirtualDeviceTest(XlaShardingTest):
     self.assertIn("VirtualDeviceUsage", met.counter_names())
     self.assertNotEqual(met.counter_value("VirtualDeviceUsage"), 0)
 
+  @unittest.skip("disable due to CI test failures")
   def test_no_sharding(self):
     t1 = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]],
                       dtype=torch.float,
@@ -239,6 +243,7 @@ class VirtualDeviceTest(XlaShardingTest):
     t3_expected = [9.0, 9.0, 9.0, 9.0, 9.0, 9.0, 9.0, 9.0]
     self.assertEqual(t3.tolist()[0], t3_expected)
 
+  @unittest.skip("disable due to CI test failures")
   def test_outbound_data_metrics(self):
     partition_spec = (0, 1)
 


### PR DESCRIPTION
This is to check & re-enable parts of the sharding tests. This way, we can have some coverage while debugging the failing ones.

cc the virtual device related ones seem to be failing in CI (I think I was able to run them on tpuvm/locally). Could you help looking into the regression, @steventk-g ?