### PR TITLE
Make dyanmo execute async

### DIFF
--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1709,7 +1709,7 @@ void InitXlaModuleBindings(py::module m) {
             }
           }
           auto results = XLAGraphExecutor::Get()->ExecuteComputationWithBarrier(
-              hash, parameters_data, device);
+              hash, std::move(parameters_data), device);
           std::vector<at::Tensor> retlist;
           {
             TORCH_LAZY_TIMED("RunCachedGraphOutputData");

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1716,7 +1716,6 @@ void InitXlaModuleBindings(py::module m) {
               parameters_data.push_back(dataptr);
             }
           }
-
           XLAGraphExecutor::Get()->MaybeDumpGraph("dynamo", hash);
           auto results = XLAGraphExecutor::Get()->ExecuteComputationWithBarrier(
               cachedComputation->computation, parameters_data, device);

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -140,9 +140,9 @@ void XLAGraphExecutor::DeviceContextArena::SaveGraphAsString(
 }
 
 void XLAGraphExecutor::DeviceContextArena::SaveOutputShapes(
-    torch::lazy::hash_t hash, std::vector<xla::Shape> outptu_shapes) {
+    torch::lazy::hash_t hash, std::vector<xla::Shape> output_shapes) {
   if (hash_to_output_shape_map.find(hash) == hash_to_output_shape_map.end()) {
-    hash_to_output_shape_map[hash] = std::move(outptu_shapes);
+    hash_to_output_shape_map[hash] = std::move(output_shapes);
   }
 }
 
@@ -386,13 +386,13 @@ torch::lazy::hash_t XLAGraphExecutor::GetGraphHash(
   SyncTensorCollection coll = CollectSyncTensors(tensors, config);
   absl::Span<const size_t> indices = coll.indices;
   std::vector<torch::lazy::Value> ir_values;
-  std::vector<xla::Shape> outptu_shapes;
+  std::vector<xla::Shape> output_shapes;
   ir_values.reserve(indices.size());
-  outptu_shapes.reserve(indices.size());
+  output_shapes.reserve(indices.size());
   for (auto index : indices) {
     XLATensorPtr tensor = tensors[index];
     ir_values.push_back(tensor->CurrentIrValue());
-    outptu_shapes.push_back(MakeShapeWithDeviceLayout(
+    output_shapes.push_back(MakeShapeWithDeviceLayout(
         tensor->shape(),
         static_cast<XlaDeviceType>(tensor->GetDevice().type())));
   }
@@ -400,7 +400,7 @@ torch::lazy::hash_t XLAGraphExecutor::GetGraphHash(
   torch::lazy::hash_t res_hash = torch::lazy::HashCombine(
       coll.hash, torch::lazy::Hash(po_data.parameter_sequence));
   DeviceContextArena::Get()->SaveOutputShapes(res_hash,
-                                              std::move(outptu_shapes));
+                                              std::move(output_shapes));
   DeviceContextArena::Get()->SaveGraphAsString(res_hash, tensors,
                                                &coll.indices);
   return res_hash;

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -209,12 +209,21 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
         const std::vector<size_t>* indices,
         DebugUtil::GraphFormat format = DebugUtil::GetDefaultGraphFormat());
 
+    void SaveOutputShapes(torch::lazy::hash_t hash,
+                          std::vector<xla::Shape> outptu_shapes);
+
     std::string GetGraphByHash(torch::lazy::hash_t hash);
 
+    std::vector<xla::Shape>* GetOutputShapesByHash(torch::lazy::hash_t hash);
+
    private:
+    // Below two maps are used for dynamo integration.
     std::unordered_map<torch::lazy::hash_t, std::string,
                        torch::lazy::HashReducer>
         hash_to_graph_map;
+    std::unordered_map<torch::lazy::hash_t, std::vector<xla::Shape>,
+                       torch::lazy::HashReducer>
+        hash_to_output_shape_map;
     // We override this to use TensorToXlaData().
     torch::lazy::Value IrValueFromScalar(
         const at::Scalar& value, at::ScalarType scalar_type,

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -161,7 +161,7 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
   ComputationCache* GetComputationCache();
 
   std::vector<torch::lazy::BackendDataPtr> ExecuteComputationWithBarrier(
-      torch::lazy::ComputationPtr computation,
+      torch::lazy::hash_t hash,
       c10::ArrayRef<torch::lazy::BackendDataPtr> arguments,
       const torch::lazy::BackendDevice& device);
 

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -214,6 +214,10 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
 
     std::string GetGraphByHash(torch::lazy::hash_t hash);
 
+    // Return shapes is a pointer to the saved vector. Caller should be careful
+    // if this pointer will be saved and access later since the value might be
+    // changed. This should be fine in most cases since PyTorch/XLA tracing is
+    // signle threaded.
     std::vector<xla::Shape>* GetOutputShapesByHash(torch::lazy::hash_t hash);
 
    private:

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -162,7 +162,7 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
 
   std::vector<torch::lazy::BackendDataPtr> ExecuteComputationWithBarrier(
       torch::lazy::hash_t hash,
-      c10::ArrayRef<torch::lazy::BackendDataPtr> arguments,
+      std::vector<torch::lazy::BackendDataPtr> arguments,
       const torch::lazy::BackendDevice& device);
 
   void ClearPendingIrs(std::vector<XLATensorPtr> tensors,


### PR DESCRIPTION
This is to implement https://github.com/pytorch/xla/issues/4402,

I verified `test/dynamo/test_dynamo.py` worked. Next I will try to rerun the inference and training benchmark to verified this does not regress inference and hopefully make training faster.


Update:
for training

command I used
```
XLA_IR_DEBUG=0 XLA_HLO_DEBUG=0 USE_FAKE_TENSOR=0 python benchmarks/dynamo/torchbench.py --randomize-input --performance --trace-on-xla --training --backend=aot_torchxla_trace_once --only $model -n 10
```
on TPUv4 nightly with/without this change

| model | with this change | without this change | speed up | 
| --- | ----------- | ----------- |----------- |
| resnet50 | 0.758x | 0.724x | 1.047
| resnet18 | 0.665x | 0.653x | 1.018
| BERT_pytorch | 1.441x | 1.400x | 1.029
| resnext50_32x4d | 0.870x | 0.849x | 1.025
| alexnet | 0.632x | 0.662x | 0.955
| mobilenet_v2 | 0.549x | 0.539x | 1.019
| mnasnet1_0 | 0.698x | 0.669x | 1.043
| vgg16  | 0.712x | 0.721x | 0.988
| average |           |             | 1.0155

At least for the single step training, overlapping the execution and training does not help the speed too much.

FYI @wconstab @shunting314 @alanwaketan @wonjoolee95 