### PR TITLE
Fix nightly whl build issue & introduce new knobs in cloudbuild.yaml

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,8 @@ FROM "${base_image}"
 
 ARG python_version="3.7"
 ARG release_version="nightly"
+ARG xla_branch=""
+ARG example_branch="master"
 ARG cuda="0"
 ARG cuda_compute="3.7,7.0,7.5,8.0"
 ARG cxx_abi="1"
@@ -41,15 +43,17 @@ ENV BAZEL_JOBS "${bazel_jobs}"
 # cloud build. Otherwise, just use local.
 # https://github.com/GoogleCloudPlatform/cloud-builders/issues/435
 COPY . /pytorch/xla
-RUN if [ "${git_clone}" = "true" ]; then github_branch="${release_version}" && \
-  if [ "${release_version}" = "nightly" ]; then github_branch="master"; fi && \
+RUN if [ "${git_clone}" = "true" ]; then \
+  if [ -z "${xla_branch}" ]; then xla_branch="${release_version}" && example_branch="${release_version}"; fi && \
+  if [ "${xla_branch}" = "nightly" ]; then xla_branch="master" && example_branch="master"; fi && \
+  echo "\n ${xla_branch} \n" && \
   cd /pytorch && \
   rm -rf xla && \
-  git clone -b "${github_branch}" --recursive https://github.com/pytorch/xla && \
+  git clone -b "${xla_branch}" --recursive https://github.com/pytorch/xla && \
   cd / && \
-  git clone -b "${github_branch}" --recursive https://github.com/pytorch-tpu/examples tpu-examples; fi
+  git clone -b "${example_branch}" --recursive https://github.com/pytorch-tpu/examples tpu-examples; fi
 
-RUN cd /pytorch && bash xla/scripts/build_torch_wheels.sh ${python_version} ${release_version}
+RUN cd /pytorch && bash xla/scripts/build_torch_wheels.sh ${python_version} ${release_version} ${xla_branch}
 
 # Set LD_PRELOAD to use tcmalloc if for tpuvm mode.
 ENV LD_PRELOAD=${tpuvm:+"/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4"}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,7 +46,7 @@ COPY . /pytorch/xla
 RUN if [ "${git_clone}" = "true" ]; then \
   if [ -z "${xla_branch}" ]; then xla_branch="${release_version}" && example_branch="${release_version}"; fi && \
   if [ "${xla_branch}" = "nightly" ]; then xla_branch="master" && example_branch="master"; fi && \
-  echo "\n ${xla_branch} \n" && \
+  echo "\nxla_branch: ${xla_branch} example_branch: ${example_branch} \n" && \
   cd /pytorch && \
   rm -rf xla && \
   git clone -b "${xla_branch}" --recursive https://github.com/pytorch/xla && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,7 @@ ARG cxx_abi="1"
 ARG tpuvm=""
 ARG bazel_jobs=""
 ARG git_clone="true"
+ARG build_cpp_tests="0"
 
 RUN apt-get update
 RUN apt-get install -y git sudo python-pip python3-pip
@@ -53,7 +54,7 @@ RUN if [ "${git_clone}" = "true" ]; then \
   cd / && \
   git clone -b "${example_branch}" --recursive https://github.com/pytorch-tpu/examples tpu-examples; fi
 
-RUN cd /pytorch && bash xla/scripts/build_torch_wheels.sh ${python_version} ${release_version} ${xla_branch}
+RUN cd /pytorch && bash xla/scripts/build_torch_wheels.sh ${python_version} ${release_version} ${build_cpp_tests}
 
 # Set LD_PRELOAD to use tcmalloc if for tpuvm mode.
 ENV LD_PRELOAD=${tpuvm:+"/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4"}

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -13,6 +13,7 @@ steps:
           '--build-arg', 'bazel_jobs=${_BAZEL_JOBS}',
           '--build-arg', 'git_clone=${_GIT_CLONE}',
           '--build-arg', 'cuda_compute=${_CUDA_COMPUTE}',
+          '--build-arg', 'xla_branch=${_GITHUB_XLA_BRANCH}',
           '-t', 'gcr.io/tpu-pytorch/xla:${_IMAGE_NAME}',
           '-f', 'docker/Dockerfile', '.'
         ]
@@ -41,6 +42,7 @@ substitutions:
     _BAZEL_JOBS: ''
     _GIT_CLONE: 'true'
     _CUDA_COMPUTE: '3.7,7.0,7.5,8.0'
+    _GITHUB_XLA_BRANCH: ''
 options:
     pool:
       name: 'projects/tpu-pytorch/locations/us-central1/workerPools/wheel_build'

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -15,6 +15,7 @@ steps:
           '--build-arg', 'cuda_compute=${_CUDA_COMPUTE}',
           '--build-arg', 'xla_branch=${_GITHUB_XLA_BRANCH}',
           '--build-arg', 'examle_branch=${_GITHUB_EXAMPLE_BRANCH}',
+          '--build-arg', 'build_cpp_tests=${_BUILD_CPP_TESTS}',
           '-t', 'gcr.io/tpu-pytorch/xla:${_IMAGE_NAME}',
           '-f', 'docker/Dockerfile', '.'
         ]
@@ -45,6 +46,7 @@ substitutions:
     _CUDA_COMPUTE: '3.7,7.0,7.5,8.0'
     _GITHUB_XLA_BRANCH: ''
     _GITHUB_EXAMPLE_BRANCH: 'master'
+    _BUILD_CPP_TESTS: '0'
 options:
     pool:
       name: 'projects/tpu-pytorch/locations/us-central1/workerPools/wheel_build'

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -14,6 +14,7 @@ steps:
           '--build-arg', 'git_clone=${_GIT_CLONE}',
           '--build-arg', 'cuda_compute=${_CUDA_COMPUTE}',
           '--build-arg', 'xla_branch=${_GITHUB_XLA_BRANCH}',
+          '--build-arg', 'examle_branch=${_GITHUB_EXAMPLE_BRANCH}',
           '-t', 'gcr.io/tpu-pytorch/xla:${_IMAGE_NAME}',
           '-f', 'docker/Dockerfile', '.'
         ]
@@ -43,6 +44,7 @@ substitutions:
     _GIT_CLONE: 'true'
     _CUDA_COMPUTE: '3.7,7.0,7.5,8.0'
     _GITHUB_XLA_BRANCH: ''
+    _GITHUB_EXAMPLE_BRANCH: 'master'
 options:
     pool:
       name: 'projects/tpu-pytorch/locations/us-central1/workerPools/wheel_build'

--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -5,6 +5,7 @@ set -x  # Display commands being run.
 
 PYTHON_VERSION=$1
 RELEASE_VERSION=$2  # rX.Y or nightly
+BUILD_CPP_TESTS="${3:-0}"
 DEFAULT_PYTHON_VERSION=3.6
 DEBIAN_FRONTEND=noninteractive
 
@@ -266,8 +267,7 @@ function build_and_install_torch_xla() {
     export XLA_CPU_USE_ACL=1
   fi
 
-  # TODO: reenable after fixing the cpp test build
-  BUILD_CPP_TESTS=0 python setup.py bdist_wheel
+  python setup.py bdist_wheel
   pip install dist/*.whl
   if [ "$TPUVM_MODE" == "1" ]; then
     pip install torch_xla[tpuvm]

--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -197,7 +197,8 @@ function install_and_setup_conda() {
 
   conda install -y numpy pyyaml setuptools cmake cffi typing tqdm coverage tensorboard hypothesis dataclasses
   if [[ $(uname -m) == "x86_64" ]]; then
-    conda install -y mkl-include
+    # Overwrite mkl packages here, since nomkl conflicts with the anaconda env setup.
+    pip install mkl==2022.2.1 mkl_include==2022.2.1
   fi
 
   /usr/bin/yes | pip install --upgrade google-api-python-client


### PR DESCRIPTION
This addresses a number of nightly cloudbuild build (buliding torch_xla whl) issues:
- update `mkl` versions to `2022.2.1` and fix/verify C++ test build issues in GCB docker.
- introduce `_GITHUB_XLA_BRANCH` & `_GITHUB_EXAMPLE_BRANCH` to build non-release or nightly branches in the cloud build triggers.
- introduce `_BUILD_CPP_TESTS` to toggle cpp test builds in cloud build triggers.