### PR TITLE
 Udpate TF pin to enable `libtpu-nightly==0.1.dev.20221223`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,7 @@ RUN if [ "${git_clone}" = "true" ]; then \
   cd / && \
   git clone -b "${example_branch}" --recursive https://github.com/pytorch-tpu/examples tpu-examples; fi
 
-RUN cd /pytorch && bash xla/scripts/build_torch_wheels.sh ${python_version} ${release_version} ${build_cpp_tests}
+RUN cd /pytorch/xla && bash scripts/build_torch_wheels.sh ${python_version} ${release_version} ${build_cpp_tests}
 
 # Set LD_PRELOAD to use tcmalloc if for tpuvm mode.
 ENV LD_PRELOAD=${tpuvm:+"/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4"}

--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -182,7 +182,7 @@ function install_and_setup_conda() {
   fi
   ENVNAME="pytorch"
   if conda env list | awk '{print $1}' | grep "^$ENVNAME$"; then
-    conda remove --name "$ENVNAME" --all
+    conda remove -y --name "$ENVNAME" --all
   fi
   if [ -z "$PYTHON_VERSION" ]; then
     PYTHON_VERSION=$DEFAULT_PYTHON_VERSION

--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -252,6 +252,12 @@ function build_and_install_torch() {
 
   python setup.py bdist_wheel
   pip install dist/*.whl
+
+  # collect_wheels expects this
+  if [ ! -d "/pytorch/dist" ]; then
+    mkdir -p /pytorch/dist
+    cp dist/*.whl /pytorch/dist/
+  fi
 }
 
 function build_and_install_torch_xla() {
@@ -273,6 +279,12 @@ function build_and_install_torch_xla() {
     pip install torch_xla[tpuvm]
     sudo apt-get install -y google-perftools
   fi
+
+  # collect_wheels expects this
+  if [ ! -d "/pytorch/xla/dist" ]; then
+    mkdir -p /pytorch/xla/dist
+    cp dist/*.whl /pytorch/xla/dist/
+  fi
 }
 
 function install_torchvision_from_source() {
@@ -284,6 +296,12 @@ function install_torchvision_from_source() {
   python setup.py bdist_wheel
   pip install dist/*.whl
   popd
+
+  # collect_wheels expects this
+  if [ ! -d "/pytorch/vision/dist" ]; then
+    mkdir -p /pytorch/vision/dist
+    cp vision/dist/*.whl /pytorch/vision/dist/
+  fi
 }
 
 function install_torchaudio_from_source() {
@@ -293,6 +311,12 @@ function install_torchaudio_from_source() {
   python setup.py bdist_wheel
   pip install dist/*.whl
   popd
+
+  # collect_wheels expects this
+  if [ ! -d "/pytorch/audio/dist" ]; then
+    mkdir -p /pytorch/audio/dist
+    cp audio/dist/*.whl /pytorch/audio/dist/
+  fi
 }
 
 function main() {

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ import zipfile
 base_dir = os.path.dirname(os.path.abspath(__file__))
 third_party_path = os.path.join(base_dir, 'third_party')
 
-_libtpu_version = '0.1.dev20221217'
+_libtpu_version = '0.1.dev20221223'
 _libtpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
 
 

--- a/tf_patches/stream_executor.diff
+++ b/tf_patches/stream_executor.diff
@@ -28,17 +28,3 @@ index 722fa93147b..16790810d1f 100644
  )
 
  tf_proto_library(
-diff --git a/tensorflow/compiler/xla/runtime/module_registry.cc b/tensorflow/compiler/xla/runtime/module_registry.cc
-index 6f7f5c1a4a8..ffe7836d85e 100644
---- a/tensorflow/compiler/xla/runtime/module_registry.cc
-+++ b/tensorflow/compiler/xla/runtime/module_registry.cc
-@@ -69,7 +69,7 @@ ModulesState::InitializeUserData(CustomCall::UserData& user_data) {
-     ref_vec.push_back(std::move(*ref));
-   }
- 
--  return ref_vec;
-+  return {std::move(ref_vec)};
- }
- 
- }  // namespace runtime
-


### PR DESCRIPTION
This is to enable libtpu-nightly==0.1.dev.20221223 -- it was previously reverted because of GCB build issues.