### PR TITLE
[WIP] PJRT rendezvous handler for `torch.distributed`

### DIFF
--- a/test/pjrt/test_torch_distributed.py
+++ b/test/pjrt/test_torch_distributed.py
@@ -1,0 +1,51 @@
+from absl.testing import absltest, parameterized
+import os
+import sys
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+import torch_xla.core.xla_model as xm
+import torch_xla.experimental.pjrt_backend
+from torch_xla.experimental import pjrt
+
+
+class TestTorchDistributedPjrt(parameterized.TestCase):
+
+  @staticmethod
+  def _all_gather(index: int):
+    dist.init_process_group('xla', init_method='pjrt://')
+    t = torch.tensor([index], dtype=torch.int32, device=xm.xla_device())
+    output = [torch.zeros_like(t) for _ in range(dist.get_world_size())]
+    dist.all_gather(output, t)
+    output_tensor = torch.concat(output)
+    xm.mark_step()
+
+    # print(output)
+    torch.testing.assert_close(output_tensor.cpu(), torch.arange(0, dist.get_world_size(), 1, dtype=torch.int32))
+
+  def test_all_gather_spawn(self):
+    pjrt.spawn(self._all_gather)
+
+  def test_all_gather_spawn_threads(self):
+    p = torch.multiprocessing.Process(target=pjrt.spawn_threads, args=(self._all_gather,))
+    p.start()
+    p.join()
+
+  @staticmethod
+  def _ddp_init(index: int):
+    dist.init_process_group('xla', init_method='pjrt://')
+    device = xm.xla_device()
+    model = nn.Linear(10, 10).to(device)
+    ddp_model = DDP(model)
+
+  def test_ddp_init_spawn(self):
+    pjrt.spawn(self._ddp_init)
+
+  def test_ddp_init_spawn_threads(self):
+    p = torch.multiprocessing.Process(target=pjrt.spawn_threads, args=(self._ddp_init,))
+    p.start()
+    p.join()
+
+if __name__ == '__main__':
+  absltest.main()

--- a/test/pjrt/test_torch_distributed.py
+++ b/test/pjrt/test_torch_distributed.py
@@ -21,7 +21,6 @@ class TestTorchDistributedPjrt(parameterized.TestCase):
     output_tensor = torch.concat(output)
     xm.mark_step()
 
-    # print(output)
     torch.testing.assert_close(output_tensor.cpu(), torch.arange(0, dist.get_world_size(), 1, dtype=torch.int32))
 
   def test_all_gather_spawn(self):

--- a/torch_xla/experimental/pjrt_backend.py
+++ b/torch_xla/experimental/pjrt_backend.py
@@ -1,0 +1,37 @@
+import datetime
+import threading
+
+import torch.distributed as dist
+from torch.testing._internal.distributed import multi_threaded_pg
+from torch_xla.distributed import xla_backend
+from torch_xla.experimental import pjrt, tpu
+import torch_xla.utils.utils as xu
+
+store = None
+store_lock = threading.Lock()
+
+
+def _pjrt_rendezvous_handler(url: str,
+                             timeout: datetime.timedelta = ...,
+                             **kwargs):
+  master_ip = xu.getenv_as('MASTER_ADDR', str)
+  if not master_ip:
+    master_ip = tpu.discover_master_worker_ip() if pjrt.device_type(
+    ) == 'TPU' else 'localhost'
+
+  master_port = xu.getenv_as('MASTER_PORT', int, 12355)
+  with store_lock:
+    global store
+    if not store:
+      store = dist.TCPStore(
+          master_ip,
+          master_port,
+          pjrt.process_count(),
+          is_master=pjrt.process_index() == 0)
+
+  yield (store, pjrt.global_ordinal(), pjrt.world_size())
+
+
+multi_threaded_pg._install_threaded_pg()
+
+dist.register_rendezvous_handler('pjrt', _pjrt_rendezvous_handler)


### PR DESCRIPTION
Implement a custom rendezvous handler for PJRT, enabling the `pjrt://` `init_method` for `dist.init_process_group`.

- Supports multiple threads (with the help of the experimental [`ThreadLocalWorld`](https://github.com/pytorch/pytorch/blob/9d20d6d5ec5c0ac5ff00e4967f480f07ba0bb2bf/torch/testing/_internal/distributed/multi_threaded_pg.py#L295-L329))
- Automatically infer `rank` and `world_size` from the runtime.
- Remove `torch.distributed` initialization from `xmp.spawn`. Instead, just run `dist.init_process_group` like normal.