### PR TITLE
Lower masked_scatter to fix masked_scatter op test in xla/test/test_ops.py

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -5443,8 +5443,7 @@ TEST_F(AtenXlaTensorTest, TestMaskedScatter) {
       // calls.
       ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
     }
-    ExpectCounterChanged("xla::masked_scatter_",
-                         cpp_test::GetIgnoredCounters());
+    ExpectCounterChanged("xla::masked_scatter", cpp_test::GetIgnoredCounters());
     ResetCounters();
   });
 }

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -117,7 +117,7 @@ allowed_opinfo = set(
             AllowedOpInfoEntry('lt'),
             AllowedOpInfoEntry('lu_unpack'),
             AllowedOpInfoEntry('masked_fill'),
-            AllowedOpInfoEntry('masked_scatter')
+            AllowedOpInfoEntry('masked_scatter'),
             AllowedOpInfoEntry('masked_select'),
             AllowedOpInfoEntry('matrix_exp'),
             AllowedOpInfoEntry('max', 'binary'),

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -117,6 +117,7 @@ allowed_opinfo = set(
             AllowedOpInfoEntry('lt'),
             AllowedOpInfoEntry('lu_unpack'),
             AllowedOpInfoEntry('masked_fill'),
+            AllowedOpInfoEntry('masked_scatter')
             AllowedOpInfoEntry('masked_select'),
             AllowedOpInfoEntry('matrix_exp'),
             AllowedOpInfoEntry('max', 'binary'),
@@ -346,9 +347,6 @@ allowed_opinfo = set(
             # Worked locally (but failing on CI both CPU and CUDA)
             # app.circleci.com/pipelines/github/pytorch/xla/9130/workflows/71c74f3d-1735-4328-81b5-784d6e6744da/jobs/17998
             # AllowedOpInfoEntry('var_mean'),
-
-            # Failed after functionalization
-            # AllowedOpInfoEntry('masked_scatter'), # crash
         }))
 
 

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1662,14 +1662,13 @@ at::Tensor& XLANativeFunctions::masked_fill_(at::Tensor& self,
   return masked_fill_(self, mask, value.item());
 }
 
-at::Tensor& XLANativeFunctions::masked_scatter_(at::Tensor& self,
-                                                const at::Tensor& mask,
-                                                const at::Tensor& source) {
+at::Tensor XLANativeFunctions::masked_scatter(const at::Tensor& self,
+                                              const at::Tensor& mask,
+                                              const at::Tensor& source) {
   TORCH_LAZY_FN_COUNTER("xla::");
   XLATensorPtr self_tensor = bridge::GetXlaTensor(self);
-  tensor_methods::masked_scatter_(self_tensor, bridge::GetXlaTensor(mask),
-                                  bridge::GetXlaTensor(source));
-  return self;
+  return bridge::AtenFromXlaTensor(tensor_methods::masked_scatter(
+      self_tensor, bridge::GetXlaTensor(mask), bridge::GetXlaTensor(source)));
 }
 
 at::Tensor XLANativeFunctions::masked_select(const at::Tensor& self,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1545,11 +1545,20 @@ void masked_fill_(XLATensorPtr& input, const XLATensorPtr& mask,
       value));
 }
 
-void masked_scatter_(XLATensorPtr& input, const XLATensorPtr& mask,
-                     const XLATensorPtr& source) {
+XLATensorPtr masked_scatter(XLATensorPtr& input, const XLATensorPtr& mask,
+                            const XLATensorPtr& source) {
   torch::lazy::ScopePusher ir_scope(at::aten::masked_scatter.toQualString());
-  input->SetIrValue(torch::lazy::MakeNode<MaskedScatter>(
-      input->GetIrValue(), MaybeExpand(mask->GetIrValue(), input->shape()),
+  auto input_value = input->GetIrValue();
+  // This ensures that input tensor is at least the same shape as mask tensor.
+  // Note that we can't use the existing MaybeExpand function since
+  // input tensor may sometimes be bigger than the mask tensor, and MaybeExpand
+  // requires the first parameter to always be less or equal to the second
+  // parameter.
+  if (input->shape().get().dimensions() < mask->shape().get().dimensions()) {
+    input_value = MaybeExpand(input->GetIrValue(), mask->shape());
+  }
+  return input->CreateFrom(torch::lazy::MakeNode<MaskedScatter>(
+      input_value, MaybeExpand(mask->GetIrValue(), GetXlaShape(input_value)),
       source->GetIrValue()));
 }
 

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -488,8 +488,8 @@ XLATensorPtr lt(const XLATensorPtr& input, const XLATensorPtr& other);
 void masked_fill_(XLATensorPtr& input, const XLATensorPtr& mask,
                   const at::Scalar& value);
 
-void masked_scatter_(XLATensorPtr& input, const XLATensorPtr& mask,
-                     const XLATensorPtr& source);
+XLATensorPtr masked_scatter(XLATensorPtr& input, const XLATensorPtr& mask,
+                            const XLATensorPtr& source);
 
 XLATensorPtr masked_select(const XLATensorPtr& input, const XLATensorPtr& mask);
 

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -213,7 +213,7 @@ supported:
   - logsumexp
   - masked_fill_.Scalar
   - masked_fill_.Tensor
-  - masked_scatter_
+  - masked_scatter
   - masked_select
   - max
   - max.dim


### PR DESCRIPTION
Lower masked_scatter to fix masked_scatter op test in xla/test/test_ops.py #4438

This PR removes the old in-place version of the `masked_scatter_` op with the out-of-place version `masked_scatter`. It also updates the tensor broadcasting logic to fix the `masked_scatter` python op tests which is explained in a comment below. 

---

Earlier investigations (just for context):

Initially, the `masked_scatter` op test failed with:
```
RuntimeError: The operator aten::as_strided appears to be a view operator, but it has no implementation for the backend "xla:0". View operators don't support falling back to run on the CPU, since the tensor's storage cannot be shared across devices.
```

Tried to fix it by just lowering `masked_scatter` with a manual functionalization pass, but it failed due to segmentation fault. 

Then finally tried to manually lower `masked_scatter` by reusing the existing lowered in-place op `maksed_scatter_`. Now the segmentation fault is gone, but failing due to tensor comparison:
```
AssertionError: Tensor-likes are not close!

Mismatched elements: 13 / 25 (52.0%)
Greatest absolute difference: 14.423441886901855 at index (4, 3) (up to 0.001 allowed)
Greatest relative difference: 13.10500368692721 at index (1, 4) (up to 0.001 allowed)
```
