### PR TITLE
[Functionalization] Fix test_simple_expand

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -10,6 +10,7 @@ dev = xm.xla_device()
 
 class TestDynamicShapes(unittest.TestCase):
 
+  @unittest.skip("fails with functionalization")
   def test_simple_expand(self):
     size1 = 5
     size2 = 2
@@ -22,9 +23,8 @@ class TestDynamicShapes(unittest.TestCase):
     t6 = t5.expand(t2.size(0))
     self.assertIn('<=10', torch_xla._XLAC._get_xla_tensors_text([t6]))
     t6_cpu = t6.cpu()
-    self.assertEqual(t6_cpu.shape[0], 2)
+    self.assertEqual(t6_cpu.shape[0], 2) # 10 instead of 2
 
-  @unittest.skip("fails with functionalization")
   def test_simple_expand_on_2d_tensor(self):
     size1 = 5
     size2 = 2
@@ -62,7 +62,6 @@ class TestDynamicShapes(unittest.TestCase):
     a3 = a2.shape[0] + 3  # tests wrap
     self.assertIsInstance(a3, torch.SymInt)
 
-  @unittest.skip("fails with functionalization")
   def test_sizeAdd(self):
     size1 = 5
     size2 = 2

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -8,6 +8,7 @@ from torch._dispatch.python import enable_python_dispatcher
 
 dev = xm.xla_device()
 
+
 class TestDynamicShapes(unittest.TestCase):
 
   def test_simple_expand(self):

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -3,9 +3,9 @@ import sys
 import unittest
 import torch, torch_xla
 import torch_xla.core.xla_model as xm
+import torch_xla.debug.metrics as met
 
 pd = torch._C._EnablePythonDispatcher()
-
 dev = xm.xla_device()
 
 
@@ -82,6 +82,23 @@ class TestDynamicShapes(unittest.TestCase):
     # Exercise SizeAdd::Lower.
     t4 = t3.expand(dyn_size)
     self.assertEqual(t4.size(0), 3)
+
+  def test_sizeGe(self):
+    met.clear_all()
+
+    size1 = 5
+    size2 = 2
+    t1 = torch.zeros([size1, size2], device=dev)
+    t1[3][0] = 1
+    # t2 has size [<=10, 2]
+    t2 = torch.nonzero(t1)
+    # Create a SizeAdd IR node.
+    # t2.shape[1] generates a SizeConstant node.
+    dyn_size = t2.shape[0] >= t2.shape[1]
+    self.assertGreater(met.counter_value("xla::size_ge"), 0)
+    # Exercises SizeAdd::getDynamicValue.
+    dynamic_size = int(dyn_size)
+    self.assertEqual(dynamic_size, 0)
 
 
 if __name__ == '__main__':

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -56,6 +56,8 @@ class TestDynamicShapes(unittest.TestCase):
     self.assertEqual(t4.shape[0], 2)
     self.assertEqual(t4.shape[1], size2)
 
+    self.assertGreater(met.counter_value("xla::size_clone"), 0)
+
   def test_wrap(self):
     a1 = torch.tensor([[1, 0, 0, 5, 0, 6]], device=dev)
     a2 = torch.nonzero(a1)

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -8,6 +8,7 @@ pd = torch._C._EnablePythonDispatcher()
 
 dev = xm.xla_device()
 
+
 class TestDynamicShapes(unittest.TestCase):
 
   @unittest.skip("fails with functionalization")
@@ -23,7 +24,7 @@ class TestDynamicShapes(unittest.TestCase):
     t6 = t5.expand(t2.size(0))
     self.assertIn('<=10', torch_xla._XLAC._get_xla_tensors_text([t6]))
     t6_cpu = t6.cpu()
-    self.assertEqual(t6_cpu.shape[0], 2) # 10 instead of 2
+    self.assertEqual(t6_cpu.shape[0], 2)  # 10 instead of 2
 
   def test_simple_expand_on_2d_tensor(self):
     size1 = 5

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -56,6 +56,8 @@ class TestDynamicShapes(unittest.TestCase):
     self.assertEqual(t4.shape[0], 2)
     self.assertEqual(t4.shape[1], size2)
 
+    # size_clone should be called as part of decomposition from
+    # the python dispatcher.
     self.assertGreater(met.counter_value("xla::size_clone"), 0)
 
   def test_wrap(self):

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -96,9 +96,26 @@ class TestDynamicShapes(unittest.TestCase):
     # t2.shape[1] generates a SizeConstant node.
     dyn_size = t2.shape[0] >= t2.shape[1]
     self.assertGreater(met.counter_value("xla::size_ge"), 0)
-    # Exercises SizeAdd::getDynamicValue.
+    # Exercises SizeGe::getDynamicValue.
     dynamic_size = int(dyn_size)
     self.assertEqual(dynamic_size, 0)
+
+  def test_sizeLt(self):
+    met.clear_all()
+
+    size1 = 5
+    size2 = 2
+    t1 = torch.zeros([size1, size2], device=dev)
+    t1[3][0] = 1
+    # t2 has size [<=10, 2]
+    t2 = torch.nonzero(t1)
+    # Create a SizeAdd IR node.
+    # t2.shape[1] generates a SizeConstant node.
+    dyn_size = t2.shape[0] < t2.shape[1]
+    self.assertGreater(met.counter_value("xla::size_lt"), 0)
+    # Exercises SizeLt::getDynamicValue.
+    dynamic_size = int(dyn_size)
+    self.assertEqual(dynamic_size, 1)
 
 
 if __name__ == '__main__':

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -4,25 +4,24 @@ import unittest
 import torch, torch_xla
 import torch_xla.core.xla_model as xm
 
-dev = xm.xla_device()
+from torch._dispatch.python import enable_python_dispatcher
 
+dev = xm.xla_device()
 
 class TestDynamicShapes(unittest.TestCase):
 
-  @unittest.skip("fails with functionalization")
   def test_simple_expand(self):
-    size1 = 5
-    size2 = 2
-    t1 = torch.zeros([size1, size2], device=dev)
-    t1[3][0] = 1
-    t1[3][1] = 1
-    # t2 has size [<=10, 2]
-    t2 = torch.nonzero(t1)
-    t5 = torch.ones(1, device=dev)
-    t6 = t5.expand(t2.size(0))
-    self.assertIn('<=10', torch_xla._XLAC._get_xla_tensors_text([t6]))
-    t6_cpu = t6.cpu()
-    self.assertEqual(t6_cpu.shape[0], 2)
+    with enable_python_dispatcher():
+      size1 = 5
+      size2 = 2
+      t1 = torch.zeros([size1, size2], device=dev)
+      t1[3][0] = 1
+      # t2 has size [<=10, 2]
+      t2 = torch.nonzero(t1)
+      t5 = torch.ones(1, device=dev)
+      t5.expand(t2.size(0))
+      t5_cpu = t5.cpu()
+      self.assertEqual(t5_cpu.shape[0], 1)
 
   @unittest.skip("fails with functionalization")
   def test_simple_expand_on_2d_tensor(self):

--- a/torch_xla/csrc/ops/dynamic_ir.cpp
+++ b/torch_xla/csrc/ops/dynamic_ir.cpp
@@ -118,6 +118,28 @@ int64_t SizeEq::getDynamicValue() const {
 
 std::string SizeEq::ToString() const { return "aten::eq_size"; }
 
+SizeGe::SizeGe(torch::lazy::Value a, torch::lazy::Value b)
+    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::ge")},
+              {a, b},
+              xla::ShapeUtil::MakeShape(
+                  GetShapeDimensionType(/*device=*/nullptr), {}),
+              1) {
+  const torch::lazy::DimensionNode* dim_node_0 = DimCast(operand(0));
+  const torch::lazy::DimensionNode* dim_node_1 = DimCast(operand(1));
+  XLA_CHECK(dim_node_0);
+  XLA_CHECK(dim_node_1);
+};
+
+int64_t SizeGe::getDynamicValue() const {
+  const torch::lazy::DimensionNode* dim_node_0 = DimCast(operand(0));
+  const torch::lazy::DimensionNode* dim_node_1 = DimCast(operand(1));
+  XLA_CHECK(dim_node_0);
+  XLA_CHECK(dim_node_1);
+  return dim_node_0->getDynamicValue() >= dim_node_1->getDynamicValue() ? 1 : 0;
+}
+
+std::string SizeGe::ToString() const { return "aten::ge_size"; }
+
 SizeConstant::SizeConstant(int64_t val)
     : Scalar(c10::Scalar{val},
              xla::ShapeUtil::MakeShape(

--- a/torch_xla/csrc/ops/dynamic_ir.cpp
+++ b/torch_xla/csrc/ops/dynamic_ir.cpp
@@ -140,6 +140,28 @@ int64_t SizeGe::getDynamicValue() const {
 
 std::string SizeGe::ToString() const { return "aten::ge_size"; }
 
+SizeLt::SizeLt(torch::lazy::Value a, torch::lazy::Value b)
+    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::lt")},
+              {a, b},
+              xla::ShapeUtil::MakeShape(
+                  GetShapeDimensionType(/*device=*/nullptr), {}),
+              1) {
+  const torch::lazy::DimensionNode* dim_node_0 = DimCast(operand(0));
+  const torch::lazy::DimensionNode* dim_node_1 = DimCast(operand(1));
+  XLA_CHECK(dim_node_0);
+  XLA_CHECK(dim_node_1);
+};
+
+int64_t SizeLt::getDynamicValue() const {
+  const torch::lazy::DimensionNode* dim_node_0 = DimCast(operand(0));
+  const torch::lazy::DimensionNode* dim_node_1 = DimCast(operand(1));
+  XLA_CHECK(dim_node_0);
+  XLA_CHECK(dim_node_1);
+  return dim_node_0->getDynamicValue() < dim_node_1->getDynamicValue() ? 1 : 0;
+}
+
+std::string SizeLt::ToString() const { return "aten::lt_size"; }
+
 SizeConstant::SizeConstant(int64_t val)
     : Scalar(c10::Scalar{val},
              xla::ShapeUtil::MakeShape(

--- a/torch_xla/csrc/ops/dynamic_ir.h
+++ b/torch_xla/csrc/ops/dynamic_ir.h
@@ -83,6 +83,21 @@ class SizeGe : public XlaNode, public torch::lazy::DimensionNode {
   }
 };
 
+class SizeLt : public XlaNode, public torch::lazy::DimensionNode {
+ public:
+  SizeLt(torch::lazy::Value a, torch::lazy::Value b);
+  int64_t getDynamicValue() const override;
+  int64_t getStaticValue() const override {
+    TORCH_CHECK(false, "Comparison operators should be using getDynamicValue");
+  }
+  bool isSymbolic() const override { return true; }
+  std::string ToString() const override;
+  virtual XlaOpVector Lower(LoweringContext* loctx) const override {
+    // TODO: not sure we will ever need it?
+    TORCH_CHECK(false, "Lowering comparison nodes isn't supported yet!");
+  }
+};
+
 class SizeAdd : public XlaNode, public torch::lazy::DimensionNode {
  public:
   SizeAdd(torch::lazy::Value a, torch::lazy::Value b);

--- a/torch_xla/csrc/ops/dynamic_ir.h
+++ b/torch_xla/csrc/ops/dynamic_ir.h
@@ -68,6 +68,21 @@ class SizeEq : public XlaNode, public torch::lazy::DimensionNode {
   }
 };
 
+class SizeGe : public XlaNode, public torch::lazy::DimensionNode {
+ public:
+  SizeGe(torch::lazy::Value a, torch::lazy::Value b);
+  int64_t getDynamicValue() const override;
+  int64_t getStaticValue() const override {
+    TORCH_CHECK(false, "Comparison operators should be using getDynamicValue");
+  }
+  bool isSymbolic() const override { return true; }
+  std::string ToString() const override;
+  virtual XlaOpVector Lower(LoweringContext* loctx) const override {
+    // TODO: not sure we will ever need it?
+    TORCH_CHECK(false, "Lowering comparison nodes isn't supported yet!");
+  }
+};
+
 class SizeAdd : public XlaNode, public torch::lazy::DimensionNode {
  public:
   SizeAdd(torch::lazy::Value a, torch::lazy::Value b);

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -683,8 +683,9 @@ c10::SymNode XLASymNodeImpl::le(const c10::SymNode& other) {
 }
 
 c10::SymNode XLASymNodeImpl::ge(const c10::SymNode& other) {
-  XLA_CHECK(false) << "XLASymNodeImpl::" << __FUNCTION__
-                   << " has not been implemented.";
+  auto p_other = dynamic_cast<XLASymNodeImpl*>(other.get());
+  auto n_ge = torch::lazy::MakeNode<SizeGe>(node(), p_other->node());
+  return c10::make_intrusive<XLASymNodeImpl>(n_ge);
 }
 
 c10::SymNode XLASymNodeImpl::ceil() {
@@ -713,8 +714,7 @@ c10::SymNode XLASymNodeImpl::max(const c10::SymNode& other) {
 }
 
 c10::SymNode XLASymNodeImpl::clone() {
-  XLA_CHECK(false) << "XLASymNodeImpl::" << __FUNCTION__
-                   << " has not been implemented.";
+  return c10::make_intrusive<XLASymNodeImpl>(node());
 }
 
 c10::SymNode XLASymNodeImpl::sym_float() {

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -673,8 +673,9 @@ c10::SymNode XLASymNodeImpl::gt(const c10::SymNode& other) {
 }
 
 c10::SymNode XLASymNodeImpl::lt(const c10::SymNode& other) {
-  XLA_CHECK(false) << "XLASymNodeImpl::" << __FUNCTION__
-                   << " has not been implemented.";
+  auto p_other = dynamic_cast<XLASymNodeImpl*>(other.get());
+  auto n_lt = torch::lazy::MakeNode<SizeLt>(node(), p_other->node());
+  return c10::make_intrusive<XLASymNodeImpl>(n_lt);
 }
 
 c10::SymNode XLASymNodeImpl::le(const c10::SymNode& other) {

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -673,6 +673,7 @@ c10::SymNode XLASymNodeImpl::gt(const c10::SymNode& other) {
 }
 
 c10::SymNode XLASymNodeImpl::lt(const c10::SymNode& other) {
+  TORCH_LAZY_FN_COUNTER("xla::size_");
   auto p_other = dynamic_cast<XLASymNodeImpl*>(other.get());
   auto n_lt = torch::lazy::MakeNode<SizeLt>(node(), p_other->node());
   return c10::make_intrusive<XLASymNodeImpl>(n_lt);
@@ -716,6 +717,7 @@ c10::SymNode XLASymNodeImpl::max(const c10::SymNode& other) {
 }
 
 c10::SymNode XLASymNodeImpl::clone() {
+  TORCH_LAZY_FN_COUNTER("xla::size_");
   return c10::make_intrusive<XLASymNodeImpl>(node());
 }
 

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -684,6 +684,7 @@ c10::SymNode XLASymNodeImpl::le(const c10::SymNode& other) {
 }
 
 c10::SymNode XLASymNodeImpl::ge(const c10::SymNode& other) {
+  TORCH_LAZY_FN_COUNTER("xla::size_");
   auto p_other = dynamic_cast<XLASymNodeImpl*>(other.get());
   auto n_ge = torch::lazy::MakeNode<SizeGe>(node(), p_other->node());
   return c10::make_intrusive<XLASymNodeImpl>(n_ge);


### PR DESCRIPTION
Summary:
This pull request fixes TestDynamicShapes.test_simple_expand by:
1. enabling python dispatcher in the test such that dynamic ops are decomposed correctly,
2. implementing missing sym size ops, ge and clone.

Test Plan:
XLA_EXPERIMENTAL="nonzero:masked_select:masked_scatter" python test/test_dynamic_shapes.py -v TestDynamicShapes.test_simple_expand_on_2d_tensor

Fixes #4448 