### PR TITLE
Enable dynamo unit tests

### DIFF
--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -26,7 +26,6 @@ class DynamoInferenceBasicTest(unittest.TestCase):
   def run_model_with_dynamo(self, model, data):
     return model(data)
 
-  @unittest.skip("fails with functionalization")
   def test_simple_model(self):
     device = xm.xla_device()
     x = torch.tensor(100.0)
@@ -47,7 +46,6 @@ class DynamoInferenceBasicTest(unittest.TestCase):
     res_cpu_3 = self.fn_simple(x + y, y * 3)
     torch.allclose(res_cpu, res_xla_dynamo_3.cpu())
 
-  @unittest.skip("fails with functionalization")
   def test_resnet18(self):
     device = xm.xla_device()
     batch_size = xu.getenv_as('BATCH_SIZE', int, defval=4)
@@ -97,7 +95,6 @@ class DynamoTrainingBasicTest(unittest.TestCase):
   def run_model_with_dynamo(self, model, data, target):
     return self.train_model(model, data, target)
 
-  @unittest.skip("fails with functionalization")
   def test_simple_model(self):
     torch._dynamo.reset()
     device = xm.xla_device()
@@ -124,7 +121,6 @@ class DynamoTrainingBasicTest(unittest.TestCase):
     torch.allclose(res_cpu, res_xla_dynamo.cpu())
     torch.allclose(input.grad, xla_input.grad.cpu())
 
-  @unittest.skip("fails with functionalization")
   def test_resnet18(self):
     torch._dynamo.reset()
     met.clear_counters()


### PR DESCRIPTION
Attempt to fix https://github.com/pytorch/xla/issues/4414. 

---
More details are in the issue above, but to quick a little more details on XLA's side -- the dynamo unit tests were failing after functionalization was enabled with error:
```
[2023-01-09 09:08:37,385] torch._dynamo.utils: [WARNING] Unsupported: meta converter nyi with fake tensor propagation.
```
Thanks to Ed's investigation, the root cause of this failure was narrowed down to `torch._is_functional_tensor(t)` resulting to `True` (at https://github.com/pytorch/pytorch/blob/master/torch/_subclasses/meta_utils.py#L473). Previous to enabling functionalization, this `if` statement results to `False` but now it equates to `True` since now XLA tensors are functional tensors. And because this equates to `True`, the code returns `NotImplemented` at https://github.com/pytorch/pytorch/blob/master/torch/_subclasses/meta_utils.py#L490. We don't want this, as we want this function to properly return a tensor by going into the code as lines https://github.com/pytorch/pytorch/blob/master/torch/_subclasses/meta_utils.py#L491-L508. 

I've added a commit in upstream PR https://github.com/pytorch/pytorch/pull/88787 (commit: https://github.com/pytorch/pytorch/pull/88787/commits/c29cfe4d02d9d3479961fc1423f87d1fb29aa959) to exclude XLA tensors in the if statement to return `NotImplemented`. 

After this fix, I can see that the dynamo tests passes locally. It might potentially break other tests, I'll wait for the CI to verify. 