### PR TITLE
Adds Keep Going to CPP tests

### DIFF
--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -10,6 +10,12 @@ RMBUILD=1
 LOGFILE=/tmp/pytorch_cpp_test.log
 XLA_EXPERIMENTAL="nonzero:masked_select"
 
+# See Note [Keep Going]
+CONTINUE_ON_ERROR=false
+if [[ "$CONTINUE_ON_ERROR" == "1" ]]; then
+  set +e
+fi
+
 if [ "$DEBUG" == "1" ]; then
   BUILDTYPE="Debug"
 fi


### PR DESCRIPTION
Summary:
CPP tests was recently re-enabled but without the new keep going feature. Let's add it.

Test Plan:
CI.