### PR TITLE
[Functionalization] Enable cpp tests

### DIFF
--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -4,7 +4,7 @@ RUNDIR="$(cd "$(dirname "$0")" ; pwd -P)"
 BUILDDIR="$RUNDIR/build"
 BUILDTYPE="Release"
 VERB=
-FILTER="--gtest_filter=-AtenXlaTensorTest.TestMaskedFill"
+FILTER="--gtest_filter=-AtenXlaTensorTest.TestMaskedFill*"
 BUILD_ONLY=0
 RMBUILD=1
 LOGFILE=/tmp/pytorch_cpp_test.log

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -4,7 +4,7 @@ RUNDIR="$(cd "$(dirname "$0")" ; pwd -P)"
 BUILDDIR="$RUNDIR/build"
 BUILDTYPE="Release"
 VERB=
-FILTER="--gtest_filter=-AtenXlaTensorTest.TestMaskedFill*"
+FILTER="--gtest_filter=-AtenXlaTensorTest.TestMaskedFill*:AtenXlaTensorTest.TestKlDivBackward"
 BUILD_ONLY=0
 RMBUILD=1
 LOGFILE=/tmp/pytorch_cpp_test.log

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -4,7 +4,7 @@ RUNDIR="$(cd "$(dirname "$0")" ; pwd -P)"
 BUILDDIR="$RUNDIR/build"
 BUILDTYPE="Release"
 VERB=
-FILTER=
+FILTER="-AtenXlaTensorTest.TestMaskedFill"
 BUILD_ONLY=0
 RMBUILD=1
 LOGFILE=/tmp/pytorch_cpp_test.log
@@ -62,7 +62,6 @@ cmake "$RUNDIR" \
   -DPYTHON_LIBRARY=$(python -c "import distutils.sysconfig as sysconfig; print(sysconfig.get_config_var('LIBDIR') + '/' + sysconfig.get_config_var('LDLIBRARY'))")
 make -j $VERB
 
-# Disable CPP tests for functionalizatoin until we fix all the python tests.
 if [ $BUILD_ONLY -eq 0 ]; then
   if [ "$LOGFILE" != "" ]; then
     ./test_ptxla ${FILTER:+"$FILTER"} 2> $LOGFILE

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -4,7 +4,7 @@ RUNDIR="$(cd "$(dirname "$0")" ; pwd -P)"
 BUILDDIR="$RUNDIR/build"
 BUILDTYPE="Release"
 VERB=
-FILTER="--gtest_filter=-AtenXlaTensorTest.TestMaskedFill*:AtenXlaTensorTest.TestKlDivBackward"
+FILTER=
 BUILD_ONLY=0
 RMBUILD=1
 LOGFILE=/tmp/pytorch_cpp_test.log

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -4,7 +4,7 @@ RUNDIR="$(cd "$(dirname "$0")" ; pwd -P)"
 BUILDDIR="$RUNDIR/build"
 BUILDTYPE="Release"
 VERB=
-FILTER="-AtenXlaTensorTest.TestMaskedFill"
+FILTER="--gtest_filter=-AtenXlaTensorTest.TestMaskedFill"
 BUILD_ONLY=0
 RMBUILD=1
 LOGFILE=/tmp/pytorch_cpp_test.log

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -63,13 +63,13 @@ cmake "$RUNDIR" \
 make -j $VERB
 
 # Disable CPP tests for functionalizatoin until we fix all the python tests.
-# if [ $BUILD_ONLY -eq 0 ]; then
-#   if [ "$LOGFILE" != "" ]; then
-#     ./test_ptxla ${FILTER:+"$FILTER"} 2> $LOGFILE
-#   else
-#     ./test_ptxla ${FILTER:+"$FILTER"}
-#   fi
-# fi
+if [ $BUILD_ONLY -eq 0 ]; then
+  if [ "$LOGFILE" != "" ]; then
+    ./test_ptxla ${FILTER:+"$FILTER"} 2> $LOGFILE
+  else
+    ./test_ptxla ${FILTER:+"$FILTER"}
+  fi
+fi
 popd
 if [ $RMBUILD -eq 1 -a $BUILD_ONLY -eq 0 ]; then
   rm -rf "$BUILDDIR"

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -8667,6 +8667,7 @@ TEST_F(AtenXlaTensorTest, TestMaskedFillInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestMaskedFillBroadcast) {
+  GTEST_SKIP() << "SegFault after functionalization";
   torch::Tensor input =
       torch::rand({2, 5, 4, 3}, torch::TensorOptions(torch::kFloat));
   torch::Tensor mask =

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -8616,6 +8616,7 @@ TEST_F(AtenXlaTensorTest, TestUnsqueezeInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestMaskedFill) {
+  GTEST_SKIP() << "SegFault after functionalization";
   torch::Tensor input =
       torch::rand({2, 3}, torch::TensorOptions(torch::kFloat));
   torch::Tensor mask =
@@ -8634,6 +8635,7 @@ TEST_F(AtenXlaTensorTest, TestMaskedFill) {
 }
 
 TEST_F(AtenXlaTensorTest, TestMaskedFillInPlace) {
+  GTEST_SKIP() << "SegFault after functionalization";
   torch::Scalar value(42);
   torch::Tensor mask =
       torch::randint(0, 2, {2, 3}, torch::TensorOptions(torch::kBool));
@@ -11074,6 +11076,7 @@ TEST_F(AtenXlaTensorTest, TestBCEWithLogitsBackward) {
 }
 
 TEST_F(AtenXlaTensorTest, TestKlDivBackward) {
+  GTEST_SKIP() << "SegFault after functionalization";
   torch::Tensor input = torch::rand(
       {4, 3}, torch::TensorOptions(torch::kFloat).requires_grad(true));
   torch::Tensor target = torch::rand(

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -998,6 +998,7 @@ TEST_F(AtenXlaTensorTest, TestLogDet) {
 }
 
 TEST_F(AtenXlaTensorTest, TestSLogDet) {
+  GTEST_SKIP() << "Needs additional lowering after functionalization";
   static const int dims[] = {4, 7};
   for (auto m : dims) {
     torch::Tensor a =
@@ -1969,6 +1970,7 @@ TEST_F(AtenXlaTensorTest, TestGroupNormBackward) {
 }
 
 TEST_F(AtenXlaTensorTest, TestInstanceNorm) {
+  GTEST_SKIP() << "Needs additional lowering after functionalization";
   int batch = 5;
   int num_channels = 20;
   torch::Tensor input = torch::rand({batch, num_channels, 10, 10},
@@ -3816,6 +3818,7 @@ TEST_F(AtenXlaTensorTest, TestLinear) {
 }
 
 TEST_F(AtenXlaTensorTest, TestPinverse) {
+  GTEST_SKIP() << "Needs additional lowering after functionalization";
   torch::Tensor input =
       torch::rand({4, 6}, torch::TensorOptions(torch::kFloat));
   torch::Tensor result = torch::pinverse(input);
@@ -4052,6 +4055,7 @@ TEST_F(AtenXlaTensorTest, TestEinsumPyTorchLowerRepeatedAxis) {
 }
 
 TEST_F(AtenXlaTensorTest, TestEinsumPyTorchLowerRepeatedAxisBackward) {
+  GTEST_SKIP() << "Needs additional lowering after functionalization";
   torch::Tensor x = torch::rand(
       {2, 3, 3}, torch::TensorOptions(torch::kFloat).requires_grad(true));
   torch::Tensor y =
@@ -4893,6 +4897,7 @@ TEST_F(AtenXlaTensorTest, TestIndexSelectRank0) {
 }
 
 TEST_F(AtenXlaTensorTest, TestInverse) {
+  GTEST_SKIP() << "Needs additional lowering after functionalization";
   torch::Tensor a = torch::randn({5, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::inverse(a);
   ForEachDevice([&](const torch::Device& device) {
@@ -4973,6 +4978,7 @@ static c10::SymInt make_symint(const torch::lazy::NodePtr& p) {
 }
 
 TEST_F(AtenXlaTensorTest, TestExpandSymIntSymbolic) {
+  GTEST_SKIP() << "Needs additional DS support after functionalization";
   torch::Tensor a = torch::ones({3, 4}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = a.expand({2, 3, 4}, /*implicit=*/false);
 
@@ -5004,6 +5010,7 @@ TEST_F(AtenXlaTensorTest, TestExpandSymIntSymbolic) {
 }
 
 TEST_F(AtenXlaTensorTest, TestExpandSymIntDynamic) {
+  GTEST_SKIP() << "Needs additional DS support after functionalization";
   torch::Tensor a = torch::ones({3, 4}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = a.expand({2, 3, 4}, /*implicit=*/false);
 
@@ -5135,6 +5142,7 @@ TEST_F(AtenXlaTensorTest, TestOneIndexTransfer) {
 }
 
 TEST_F(AtenXlaTensorTest, TestNonzero) {
+  GTEST_SKIP() << "Needs additional DS support after functionalization";
   torch::Tensor a = torch::zeros({4, 2}, torch::TensorOptions(torch::kFloat));
   a[0][1] = 1.0;
   a[1][0] = 2.0;
@@ -6130,6 +6138,7 @@ TEST_F(AtenXlaTensorTest, TestReluInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestPrelu) {
+  GTEST_SKIP() << "Needs additional lowering after functionalization";
   int channel_size = 3;
   torch::Tensor input =
       torch::rand({2, channel_size, 4}, torch::TensorOptions(torch::kFloat));
@@ -9166,6 +9175,7 @@ TEST_F(AtenXlaTensorTest, TestDiagRank2) {
 }
 
 TEST_F(AtenXlaTensorTest, TestDiagFlat) {
+  GTEST_SKIP() << "Needs additional lowering after functionalization";
   torch::Tensor input =
       torch::rand({4, 3, 6, 7}, torch::TensorOptions(torch::kFloat));
   for (int diagonal = -10; diagonal < 10; ++diagonal) {
@@ -11120,6 +11130,7 @@ TEST_F(AtenXlaTensorTest, TestEmbeddingBackward) {
 }
 
 TEST_F(AtenXlaTensorTest, TestAmpForeachNonFiniteCheckAndUnscale) {
+  GTEST_SKIP() << "Needs additional meta tensor support after functionalization";
   XlaDeviceType hw_type =
       static_cast<XlaDeviceType>(GetDefaultDevice()->type());
   if (hw_type != XlaDeviceType::GPU && hw_type != XlaDeviceType::CPU) {
@@ -11467,6 +11478,7 @@ TEST_F(AtenXlaTensorTest, TestNanToNum) {
 }
 
 TEST_F(AtenXlaTensorTest, TestNanToNumInplace) {
+  GTEST_SKIP() << "Needs additional meta tensor support after functionalization";
   for (torch::ScalarType scalar_type :
        {torch::kHalf, torch::kFloat, torch::kDouble, torch::kShort, torch::kInt,
         torch::kLong}) {

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -4969,7 +4969,8 @@ TEST_F(AtenXlaTensorTest, TestExpandSymIntStatic) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::expand_copy_symint", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::expand_copy_symint",
+                       cpp_test::GetIgnoredCounters());
 }
 
 static c10::SymInt make_symint(const torch::lazy::NodePtr& p) {
@@ -5006,7 +5007,8 @@ TEST_F(AtenXlaTensorTest, TestExpandSymIntSymbolic) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::expand_copy_symint", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::expand_copy_symint",
+                       cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestExpandSymIntDynamic) {
@@ -5036,7 +5038,8 @@ TEST_F(AtenXlaTensorTest, TestExpandSymIntDynamic) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::expand_copy_symint", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::expand_copy_symint",
+                       cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestEye) {
@@ -11130,7 +11133,8 @@ TEST_F(AtenXlaTensorTest, TestEmbeddingBackward) {
 }
 
 TEST_F(AtenXlaTensorTest, TestAmpForeachNonFiniteCheckAndUnscale) {
-  GTEST_SKIP() << "Needs additional meta tensor support after functionalization";
+  GTEST_SKIP()
+      << "Needs additional meta tensor support after functionalization";
   XlaDeviceType hw_type =
       static_cast<XlaDeviceType>(GetDefaultDevice()->type());
   if (hw_type != XlaDeviceType::GPU && hw_type != XlaDeviceType::CPU) {
@@ -11478,7 +11482,8 @@ TEST_F(AtenXlaTensorTest, TestNanToNum) {
 }
 
 TEST_F(AtenXlaTensorTest, TestNanToNumInplace) {
-  GTEST_SKIP() << "Needs additional meta tensor support after functionalization";
+  GTEST_SKIP()
+      << "Needs additional meta tensor support after functionalization";
   for (torch::ScalarType scalar_type :
        {torch::kHalf, torch::kFloat, torch::kDouble, torch::kShort, torch::kInt,
         torch::kLong}) {

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -2334,7 +2334,8 @@ TEST_F(AtenXlaTensorTest, TestKlDiv) {
         AllClose(output, xla_output);
       });
       ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-      ExpectCounterChanged("xla::kl_div", cpp_test::GetIgnoredCounters());
+      ExpectCounterChanged("xla::mul", cpp_test::GetIgnoredCounters());
+      ExpectCounterChanged("xla::sub", cpp_test::GetIgnoredCounters());
     }
   }
 }
@@ -3444,7 +3445,7 @@ TEST_F(AtenXlaTensorTest, TestBartlettWindow) {
 
     ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
     ExpectCounterChanged("xla::arange_out", cpp_test::GetIgnoredCounters());
-    ExpectCounterChanged("xla::slice", cpp_test::GetIgnoredCounters());
+    ExpectCounterChanged("xla::slice_copy", cpp_test::GetIgnoredCounters());
   }
 }
 
@@ -3576,7 +3577,7 @@ TEST_F(AtenXlaTensorTest, TestSiLUBackward) {
         device, testfn);
   });
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::silu_backward", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::sigmoid", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestSigmoid) {
@@ -3737,7 +3738,7 @@ TEST_F(AtenXlaTensorTest, TestMvOut) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::mv_out", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::mv", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestBatchAddBatchMatMul) {
@@ -4156,7 +4157,6 @@ TEST_F(AtenXlaTensorTest, TestBilinear) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::_trilinear", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestUpsampleNearest2D) {
@@ -4954,7 +4954,7 @@ TEST_F(AtenXlaTensorTest, TestExpandAs) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::expand", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::expand_copy", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestExpandSymIntStatic) {
@@ -4969,7 +4969,7 @@ TEST_F(AtenXlaTensorTest, TestExpandSymIntStatic) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::expand_symint", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::expand_copy_symint", cpp_test::GetIgnoredCounters());
 }
 
 static c10::SymInt make_symint(const torch::lazy::NodePtr& p) {
@@ -5006,7 +5006,7 @@ TEST_F(AtenXlaTensorTest, TestExpandSymIntSymbolic) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::expand_symint", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::expand_copy_symint", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestExpandSymIntDynamic) {
@@ -5036,7 +5036,7 @@ TEST_F(AtenXlaTensorTest, TestExpandSymIntDynamic) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::expand_symint", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::expand_copy_symint", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestEye) {
@@ -5097,7 +5097,7 @@ TEST_F(AtenXlaTensorTest, TestBroadcastTensors) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::expand", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::expand_copy", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestOneIndex) {
@@ -6799,7 +6799,7 @@ TEST_F(AtenXlaTensorTest, TestSelu) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::selu", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::elu", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestSeluInPlace) {
@@ -6814,7 +6814,7 @@ TEST_F(AtenXlaTensorTest, TestSeluInPlace) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::selu_", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::elu", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestCelu) {
@@ -6845,7 +6845,7 @@ TEST_F(AtenXlaTensorTest, TestCeluInPlace) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::celu_", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::celu", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestGelu) {
@@ -6958,7 +6958,7 @@ TEST_F(AtenXlaTensorTest, TestReshape) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::view", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::view_copy", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestResize) {
@@ -7109,7 +7109,7 @@ TEST_F(AtenXlaTensorTest, TestNarrow) {
       });
 
       ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-      ExpectCounterChanged("xla::slice", cpp_test::GetIgnoredCounters());
+      ExpectCounterChanged("xla::slice_copy", cpp_test::GetIgnoredCounters());
     }
   }
 }
@@ -7133,7 +7133,7 @@ TEST_F(AtenXlaTensorTest, TestNarrowUpdate) {
       });
 
       ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-      ExpectCounterChanged("xla::slice", cpp_test::GetIgnoredCounters());
+      ExpectCounterChanged("xla::slice_copy", cpp_test::GetIgnoredCounters());
     }
   }
 }
@@ -7157,7 +7157,7 @@ TEST_F(AtenXlaTensorTest, TestNarrowUpdateBaseCheck) {
       });
 
       ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-      ExpectCounterChanged("xla::slice", cpp_test::GetIgnoredCounters());
+      ExpectCounterChanged("xla::slice_copy", cpp_test::GetIgnoredCounters());
     }
   }
 }
@@ -7190,7 +7190,7 @@ TEST_F(AtenXlaTensorTest, TestNarrowUpdateTwoSlices) {
         });
 
         ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-        ExpectCounterChanged("xla::slice", cpp_test::GetIgnoredCounters());
+        ExpectCounterChanged("xla::slice_copy", cpp_test::GetIgnoredCounters());
       }
     }
   }
@@ -7217,7 +7217,7 @@ TEST_F(AtenXlaTensorTest, TestNarrowUpdateView) {
       });
 
       ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-      ExpectCounterChanged("xla::slice", cpp_test::GetIgnoredCounters());
+      ExpectCounterChanged("xla::slice_copy", cpp_test::GetIgnoredCounters());
     }
   }
 }
@@ -7244,7 +7244,7 @@ TEST_F(AtenXlaTensorTest, TestNarrowInNarrowUpdate) {
         });
 
         ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-        ExpectCounterChanged("xla::slice", cpp_test::GetIgnoredCounters());
+        ExpectCounterChanged("xla::slice_copy", cpp_test::GetIgnoredCounters());
       }
     }
   }
@@ -7280,7 +7280,7 @@ TEST_F(AtenXlaTensorTest, TestViewAs) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::view", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::view_copy", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestLogSoftmax) {
@@ -8796,7 +8796,7 @@ TEST_F(AtenXlaTensorTest, TestPixelShuffle) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::permute", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::permute_copy", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestSumToSize) {
@@ -9720,7 +9720,7 @@ TEST_F(AtenXlaTensorTest, TestMeshgrid) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::view", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::view_copy", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestConstantPad) {


### PR DESCRIPTION
Summary:
This pull request enables cpp tests for the functionalization branch. To do so:
1: It skips a bunch of tests that needs to be fixed later;
2: It updates the ExpectCounterChanged for some tests because the expected ops get new decompositions.

Test Plan:
CI