### PR TITLE
Enable lowering for upsample_bilinear2d with scale factor

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2911,7 +2911,7 @@ at::Tensor XLANativeFunctions::upsample_bilinear2d(
       torch::lazy::ToVector<int64_t>(output_size);
   if ((scales_h && *scales_h != 1.0) || (scales_w && *scales_w != 1.0)) {
     scaled_output_size = GetOutputSizeWithScale(input_dims, scales_h, scales_w,
-                                            scaled_output_size);
+                                                scaled_output_size);
   }
   return bridge::AtenFromXlaTensor(tensor_methods::upsample_bilinear2d(
       self_tensor, scaled_output_size, align_corners));

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2911,6 +2911,11 @@ at::Tensor XLANativeFunctions::upsample_bilinear2d(
   if ((scales_h && *scales_h != 1.0) || (scales_w && *scales_w != 1.0)) {
     scaled_output_size = GetOutputSizeWithScale(input_dims, scales_h, scales_w,
                                                 scaled_output_size);
+    if (!output_size.empty()) {
+      XLA_CHECK(scaled_output_size.at(0) == output_size.at(0) &&
+                scaled_output_size.at(1) == output_size.at(1))
+          << "Inferred output size and output_size from upstream are different";
+    }
   }
   return bridge::AtenFromXlaTensor(tensor_methods::upsample_bilinear2d(
       self_tensor, scaled_output_size, align_corners));


### PR DESCRIPTION
This fixes #2703

Enable lowering for upsample_bilinear2d with scale factor

Added a new unit tests of upsample_bilinear2d with scale factor != 1. The test will fail with the current implementation, since it will fallback to Aten with scale factor != 1. The test passed after the lowering for upsample_bilinear2d with scale factor is supported.