### PR TITLE
[Functionalization] Fix cpp tests

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -998,7 +998,7 @@ TEST_F(AtenXlaTensorTest, TestLogDet) {
 }
 
 TEST_F(AtenXlaTensorTest, TestSLogDet) {
-  GTEST_SKIP() << "Needs additional lowering after functionalization";
+  // GTEST_SKIP() << "Needs additional lowering after functionalization";
   static const int dims[] = {4, 7};
   for (auto m : dims) {
     torch::Tensor a =
@@ -3818,7 +3818,7 @@ TEST_F(AtenXlaTensorTest, TestLinear) {
 }
 
 TEST_F(AtenXlaTensorTest, TestPinverse) {
-  GTEST_SKIP() << "Needs additional lowering after functionalization";
+  // GTEST_SKIP() << "Needs additional lowering after functionalization";
   torch::Tensor input =
       torch::rand({4, 6}, torch::TensorOptions(torch::kFloat));
   torch::Tensor result = torch::pinverse(input);
@@ -4055,7 +4055,7 @@ TEST_F(AtenXlaTensorTest, TestEinsumPyTorchLowerRepeatedAxis) {
 }
 
 TEST_F(AtenXlaTensorTest, TestEinsumPyTorchLowerRepeatedAxisBackward) {
-  GTEST_SKIP() << "Needs additional lowering after functionalization";
+  // GTEST_SKIP() << "Needs additional lowering after functionalization";
   torch::Tensor x = torch::rand(
       {2, 3, 3}, torch::TensorOptions(torch::kFloat).requires_grad(true));
   torch::Tensor y =
@@ -4896,7 +4896,7 @@ TEST_F(AtenXlaTensorTest, TestIndexSelectRank0) {
 }
 
 TEST_F(AtenXlaTensorTest, TestInverse) {
-  GTEST_SKIP() << "Needs additional lowering after functionalization";
+  // GTEST_SKIP() << "Needs additional lowering after functionalization";
   torch::Tensor a = torch::randn({5, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::inverse(a);
   ForEachDevice([&](const torch::Device& device) {
@@ -9188,7 +9188,10 @@ TEST_F(AtenXlaTensorTest, TestDiagFlat) {
     });
 
     ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-    ExpectCounterChanged("xla::diag_embed", cpp_test::GetIgnoredCounters());
+    ExpectCounterChanged("xla::zero_", cpp_test::GetIgnoredCounters());
+    ExpectCounterChanged("xla::view_copy_symint", cpp_test::GetIgnoredCounters());
+    ExpectCounterChanged("xla::_to_copy", cpp_test::GetIgnoredCounters());
+    ExpectCounterChanged("xla::_copy_from", cpp_test::GetIgnoredCounters());
   }
 }
 

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -6141,7 +6141,6 @@ TEST_F(AtenXlaTensorTest, TestReluInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestPrelu) {
-  GTEST_SKIP() << "Needs additional lowering after functionalization";
   int channel_size = 3;
   torch::Tensor input =
       torch::rand({2, channel_size, 4}, torch::TensorOptions(torch::kFloat));
@@ -6156,7 +6155,7 @@ TEST_F(AtenXlaTensorTest, TestPrelu) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::prelu", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::_prelu_kernel", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestHardshrink) {
@@ -9179,7 +9178,6 @@ TEST_F(AtenXlaTensorTest, TestDiagRank2) {
 }
 
 TEST_F(AtenXlaTensorTest, TestDiagFlat) {
-  GTEST_SKIP() << "Needs additional lowering after functionalization";
   torch::Tensor input =
       torch::rand({4, 3, 6, 7}, torch::TensorOptions(torch::kFloat));
   for (int diagonal = -10; diagonal < 10; ++diagonal) {

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -998,7 +998,7 @@ TEST_F(AtenXlaTensorTest, TestLogDet) {
 }
 
 TEST_F(AtenXlaTensorTest, TestSLogDet) {
-  // GTEST_SKIP() << "Needs additional lowering after functionalization";
+  GTEST_SKIP() << "Needs additional lowering after functionalization";
   static const int dims[] = {4, 7};
   for (auto m : dims) {
     torch::Tensor a =
@@ -3818,7 +3818,7 @@ TEST_F(AtenXlaTensorTest, TestLinear) {
 }
 
 TEST_F(AtenXlaTensorTest, TestPinverse) {
-  // GTEST_SKIP() << "Needs additional lowering after functionalization";
+  GTEST_SKIP() << "Needs additional lowering after functionalization";
   torch::Tensor input =
       torch::rand({4, 6}, torch::TensorOptions(torch::kFloat));
   torch::Tensor result = torch::pinverse(input);
@@ -4055,7 +4055,7 @@ TEST_F(AtenXlaTensorTest, TestEinsumPyTorchLowerRepeatedAxis) {
 }
 
 TEST_F(AtenXlaTensorTest, TestEinsumPyTorchLowerRepeatedAxisBackward) {
-  // GTEST_SKIP() << "Needs additional lowering after functionalization";
+  GTEST_SKIP() << "Needs additional lowering after functionalization";
   torch::Tensor x = torch::rand(
       {2, 3, 3}, torch::TensorOptions(torch::kFloat).requires_grad(true));
   torch::Tensor y =
@@ -4896,7 +4896,7 @@ TEST_F(AtenXlaTensorTest, TestIndexSelectRank0) {
 }
 
 TEST_F(AtenXlaTensorTest, TestInverse) {
-  // GTEST_SKIP() << "Needs additional lowering after functionalization";
+  GTEST_SKIP() << "Needs additional lowering after functionalization";
   torch::Tensor a = torch::randn({5, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::inverse(a);
   ForEachDevice([&](const torch::Device& device) {

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -9189,7 +9189,8 @@ TEST_F(AtenXlaTensorTest, TestDiagFlat) {
 
     ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
     ExpectCounterChanged("xla::zero_", cpp_test::GetIgnoredCounters());
-    ExpectCounterChanged("xla::view_copy_symint", cpp_test::GetIgnoredCounters());
+    ExpectCounterChanged("xla::view_copy_symint",
+                         cpp_test::GetIgnoredCounters());
     ExpectCounterChanged("xla::_to_copy", cpp_test::GetIgnoredCounters());
     ExpectCounterChanged("xla::_copy_from", cpp_test::GetIgnoredCounters());
   }

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -9189,7 +9189,7 @@ TEST_F(AtenXlaTensorTest, TestDiagFlat) {
     });
 
     ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-    ExpectCounterChanged("xla::diag", cpp_test::GetIgnoredCounters());
+    ExpectCounterChanged("xla::diag_embed", cpp_test::GetIgnoredCounters());
   }
 }
 

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -4055,7 +4055,6 @@ TEST_F(AtenXlaTensorTest, TestEinsumPyTorchLowerRepeatedAxis) {
 }
 
 TEST_F(AtenXlaTensorTest, TestEinsumPyTorchLowerRepeatedAxisBackward) {
-  GTEST_SKIP() << "Needs additional lowering after functionalization";
   torch::Tensor x = torch::rand(
       {2, 3, 3}, torch::TensorOptions(torch::kFloat).requires_grad(true));
   torch::Tensor y =

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -1970,7 +1970,6 @@ TEST_F(AtenXlaTensorTest, TestGroupNormBackward) {
 }
 
 TEST_F(AtenXlaTensorTest, TestInstanceNorm) {
-  GTEST_SKIP() << "Needs additional lowering after functionalization";
   int batch = 5;
   int num_channels = 20;
   torch::Tensor input = torch::rand({batch, num_channels, 10, 10},

--- a/test/cpp/torch_xla_test.cpp
+++ b/test/cpp/torch_xla_test.cpp
@@ -42,7 +42,6 @@ void XlaTest::TearDown() {
 static void ExpectCounterNotChanged_(
     const std::vector<MetricsSnapshot::ChangedCounter>& changed) {
   for (auto& change_counter : changed) {
-    std::cout << "WONJOO: change_counter=" << std::endl;
     TF_LOG(INFO) << "Counter '" << change_counter.name
                  << "' changed: " << change_counter.before << " -> "
                  << change_counter.after;

--- a/test/cpp/torch_xla_test.cpp
+++ b/test/cpp/torch_xla_test.cpp
@@ -42,6 +42,7 @@ void XlaTest::TearDown() {
 static void ExpectCounterNotChanged_(
     const std::vector<MetricsSnapshot::ChangedCounter>& changed) {
   for (auto& change_counter : changed) {
+    std::cout << "WONJOO: change_counter=" << std::endl;
     TF_LOG(INFO) << "Counter '" << change_counter.name
                  << "' changed: " << change_counter.before << " -> "
                  << change_counter.after;

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2305,29 +2305,6 @@ at::Tensor XLANativeFunctions::pow(const at::Scalar& self,
       tensor_methods::pow(self, bridge::GetXlaTensor(exponent)));
 }
 
-// at::Tensor XLANativeFunctions::prelu(const at::Tensor& self,
-//                                      const at::Tensor& weight) {
-//   TORCH_LAZY_FN_COUNTER("xla::");
-//   // If multiple weights, check channel size == number of weights.
-//   int64_t weight_num = weight.numel();
-//   if (weight.numel() > 1) {
-//     int64_t input_dim = self.dim();
-//     XLA_CHECK_GT(input_dim, 0) << "Input tensor dimension cannot be 0";
-
-//     int64_t channel_size = input_dim > 1 ? self.size(1) : 1;
-//     XLA_CHECK_EQ(channel_size, weight_num)
-//         << "Mismatch of parameter numbers and input channel size. Found "
-//            "parameter numbers = "
-//         << weight_num << " and channel size = " << channel_size;
-//   }
-
-//   XLATensorPtr self_tensor = bridge::GetXlaTensor(self);
-//   XLATensorPtr weight_tensor = bridge::GetXlaTensor(weight);
-
-//   return bridge::AtenFromXlaTensor(
-//       tensor_methods::prelu(self_tensor, weight_tensor));
-// }
-
 at::Tensor XLANativeFunctions::_prelu_kernel(const at::Tensor& self,
                                              const at::Tensor& weight) {
   TORCH_LAZY_FN_COUNTER("xla::");

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2295,7 +2295,29 @@ at::Tensor XLANativeFunctions::pow(const at::Scalar& self,
 at::Tensor XLANativeFunctions::prelu(const at::Tensor& self,
                                      const at::Tensor& weight) {
   TORCH_LAZY_FN_COUNTER("xla::");
+  // If multiple weights, check channel size == number of weights.
+  int64_t weight_num = weight.numel();
+  if (weight.numel() > 1) {
+    int64_t input_dim = self.dim();
+    XLA_CHECK_GT(input_dim, 0) << "Input tensor dimension cannot be 0";
 
+    int64_t channel_size = input_dim > 1 ? self.size(1) : 1;
+    XLA_CHECK_EQ(channel_size, weight_num)
+        << "Mismatch of parameter numbers and input channel size. Found "
+           "parameter numbers = "
+        << weight_num << " and channel size = " << channel_size;
+  }
+
+  XLATensorPtr self_tensor = bridge::GetXlaTensor(self);
+  XLATensorPtr weight_tensor = bridge::GetXlaTensor(weight);
+
+  return bridge::AtenFromXlaTensor(
+      tensor_methods::prelu(self_tensor, weight_tensor));
+}
+
+at::Tensor XLANativeFunctions::_prelu_kernel(const at::Tensor& self,
+                                             const at::Tensor& weight) {
+  TORCH_LAZY_FN_COUNTER("xla::");
   // If multiple weights, check channel size == number of weights.
   int64_t weight_num = weight.numel();
   if (weight.numel() > 1) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1120,34 +1120,6 @@ at::Tensor XLANativeFunctions::diag(const at::Tensor& self, int64_t diagonal) {
       tensor_methods::diag(bridge::GetXlaTensor(self), diagonal));
 }
 
-at::Tensor XLANativeFunctions::diag_embed(const at::Tensor& self,
-                                          int64_t offset, int64_t dim1,
-                                          int64_t dim2) {
-  TORCH_LAZY_FN_COUNTER("xla::");
-  XLATensorPtr self_tensor = bridge::TryGetXlaTensor(self);
-
-  auto input_shape = self_tensor->shape();
-  int64_t nDims = input_shape.get().rank() + 1;
-  int64_t dim1_wrapped = at::maybe_wrap_dim(dim1, nDims);
-  int64_t dim2_wrapped = at::maybe_wrap_dim(dim2, nDims);
-  XLA_CHECK(dim1_wrapped != dim2_wrapped)
-      << "diagonal dimensions cannot be identical " << dim1 << ", " << dim2;
-
-  int64_t new_dim_len = std::abs(offset) + self_tensor->size(-1);
-  auto sizes = xla::util::ToVector<int64_t>(input_shape.get().dimensions());
-  sizes.pop_back();
-  sizes.insert(sizes.begin() + std::min(dim1_wrapped, dim2_wrapped),
-               new_dim_len);
-  sizes.insert(sizes.begin() + std::max(dim1_wrapped, dim2_wrapped),
-               new_dim_len);
-  XLATensorPtr result = tensor_methods::full(sizes, 0, self_tensor->GetDevice(),
-                                             self_tensor->dtype());
-  auto diag =
-      tensor_methods::diagonal(result, offset, dim1_wrapped, dim2_wrapped);
-  tensor_methods::copy_(diag, self_tensor);
-  return bridge::AtenFromXlaTensor(result);
-}
-
 at::Tensor XLANativeFunctions::diagonal_copy(const at::Tensor& self,
                                              int64_t offset, int64_t dim1,
                                              int64_t dim2) {
@@ -2333,28 +2305,28 @@ at::Tensor XLANativeFunctions::pow(const at::Scalar& self,
       tensor_methods::pow(self, bridge::GetXlaTensor(exponent)));
 }
 
-at::Tensor XLANativeFunctions::prelu(const at::Tensor& self,
-                                     const at::Tensor& weight) {
-  TORCH_LAZY_FN_COUNTER("xla::");
-  // If multiple weights, check channel size == number of weights.
-  int64_t weight_num = weight.numel();
-  if (weight.numel() > 1) {
-    int64_t input_dim = self.dim();
-    XLA_CHECK_GT(input_dim, 0) << "Input tensor dimension cannot be 0";
+// at::Tensor XLANativeFunctions::prelu(const at::Tensor& self,
+//                                      const at::Tensor& weight) {
+//   TORCH_LAZY_FN_COUNTER("xla::");
+//   // If multiple weights, check channel size == number of weights.
+//   int64_t weight_num = weight.numel();
+//   if (weight.numel() > 1) {
+//     int64_t input_dim = self.dim();
+//     XLA_CHECK_GT(input_dim, 0) << "Input tensor dimension cannot be 0";
 
-    int64_t channel_size = input_dim > 1 ? self.size(1) : 1;
-    XLA_CHECK_EQ(channel_size, weight_num)
-        << "Mismatch of parameter numbers and input channel size. Found "
-           "parameter numbers = "
-        << weight_num << " and channel size = " << channel_size;
-  }
+//     int64_t channel_size = input_dim > 1 ? self.size(1) : 1;
+//     XLA_CHECK_EQ(channel_size, weight_num)
+//         << "Mismatch of parameter numbers and input channel size. Found "
+//            "parameter numbers = "
+//         << weight_num << " and channel size = " << channel_size;
+//   }
 
-  XLATensorPtr self_tensor = bridge::GetXlaTensor(self);
-  XLATensorPtr weight_tensor = bridge::GetXlaTensor(weight);
+//   XLATensorPtr self_tensor = bridge::GetXlaTensor(self);
+//   XLATensorPtr weight_tensor = bridge::GetXlaTensor(weight);
 
-  return bridge::AtenFromXlaTensor(
-      tensor_methods::prelu(self_tensor, weight_tensor));
-}
+//   return bridge::AtenFromXlaTensor(
+//       tensor_methods::prelu(self_tensor, weight_tensor));
+// }
 
 at::Tensor XLANativeFunctions::_prelu_kernel(const at::Tensor& self,
                                              const at::Tensor& weight) {
@@ -3282,6 +3254,13 @@ XLANativeFunctions::convolution_backward(
       convolution_backward)>::call(grad_output, input, weight, bias_sizes,
                                    stride, padding, dilation, transposed,
                                    output_padding, groups, output_mask);
+}
+
+at::Tensor XLANativeFunctions::diag_embed(const at::Tensor& self,
+                                          int64_t offset, int64_t dim1,
+                                          int64_t dim2) {
+  return at::functionalization::functionalize_aten_op<ATEN_OP(
+      diag_embed)>::call(self, offset, dim1, dim2);
 }
 
 at::Tensor XLANativeFunctions::embedding_symint(const at::Tensor& weight,

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1052,6 +1052,19 @@ XLANativeFunctions::convolution_backward_overrideable(
                      : at::Tensor());
 }
 
+at::Tensor XLANativeFunctions::copy(const at::Tensor& self,
+                                    const at::Tensor& src, bool non_blocking) {
+  TORCH_LAZY_FN_COUNTER("xla::");
+  return _copy_from(src, self, non_blocking);
+}
+
+at::Tensor& XLANativeFunctions::copy_(at::Tensor& self, const at::Tensor& src,
+                                      bool non_blocking) {
+  TORCH_LAZY_FN_COUNTER("xla::");
+  at::Tensor result = _copy_from(self, src, non_blocking);
+  return result;
+}
+
 at::Tensor XLANativeFunctions::cross(const at::Tensor& self,
                                      const at::Tensor& other,
                                      c10::optional<int64_t> dim) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1061,8 +1061,8 @@ at::Tensor XLANativeFunctions::copy(const at::Tensor& self,
 at::Tensor& XLANativeFunctions::copy_(at::Tensor& self, const at::Tensor& src,
                                       bool non_blocking) {
   TORCH_LAZY_FN_COUNTER("xla::");
-  at::Tensor result = _copy_from(self, src, non_blocking);
-  return result;
+  _copy_from(src, self, non_blocking);
+  return self;
 }
 
 at::Tensor XLANativeFunctions::cross(const at::Tensor& self,

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -227,13 +227,8 @@ xla::XlaOp BuildPrelu(xla::XlaOp input, xla::XlaOp weight) {
   const xla::Shape& input_shape = XlaHelpers::ShapeOfXlaOp(input);
   const xla::Shape& weight_shape = XlaHelpers::ShapeOfXlaOp(weight);
 
-  int64_t weight_num = xla::ShapeUtil::ElementsIn(weight_shape);
-  int64_t broadcast_dim = weight_num == 1 ? 0 : 1;
-
   xla::XlaOp zero = xla::Zero(input.builder(), input_shape.element_type());
-  xla::XlaOp broadcasted_weight =
-      xla::BroadcastInDim(weight, input_shape.dimensions(), {broadcast_dim});
-  xla::XlaOp product = xla::Mul(input, broadcasted_weight);
+  xla::XlaOp product = xla::Mul(input, weight);
 
   return xla::Select(xla::Gt(input, zero), input, product);
 }

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -157,6 +157,8 @@ supported:
   - constant_pad_nd
   - convolution_backward_overrideable
   - convolution_overrideable
+  - copy
+  - copy_
   - cross
   - cumprod
   - cumsum

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -164,7 +164,6 @@ supported:
   - cumsum
   - detach_copy
   - diag
-  - diag_embed
   - diagonal_copy
   - diagonal_scatter
   - div.Scalar
@@ -257,7 +256,6 @@ supported:
   - pow.Scalar
   - pow.Tensor_Scalar
   - pow.Tensor_Tensor
-  - prelu
   - _prelu_kernel
   - prod
   - prod.dim_int
@@ -347,6 +345,7 @@ supported:
   # but their implementations call view operators (which we need to functionalize away).
   - affine_grid_generator
   - block_diag
+  - diag_embed
   - _convolution
   - convolution_backward
   - embedding

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -162,6 +162,7 @@ supported:
   - cumsum
   - detach_copy
   - diag
+  - diag_embed
   - diagonal_copy
   - diagonal_scatter
   - div.Scalar

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -255,6 +255,7 @@ supported:
   - pow.Tensor_Scalar
   - pow.Tensor_Tensor
   - prelu
+  - _prelu_kernel
   - prod
   - prod.dim_int
   - put_


### PR DESCRIPTION
Summary:
Lowers ops `copy`, `copy_`, `_prelu_kernel`, and `diag_embed` to fix cpp tests that were failing with functionalization. 

Note that we lower both `copy` and `copy_` ops. When we only lower `copy` op, the in-place version `copy_` op gets auto-generated. However, upstream PyTorch had an assertion that this auto-generated was wrong. To by pass, we're manually lowering `copy_` as well.