### PR TITLE
Basic test for `PjrtComputationClient`.

### DIFF
--- a/third_party/xla_client/BUILD
+++ b/third_party/xla_client/BUILD
@@ -1,25 +1,21 @@
-licenses(["notice"])  # Apache 2.0
-
-package(default_visibility = ["//tensorflow:internal"])
-
+load("//tensorflow/compiler/xla:xla.bzl", "xla_cc_test")
 load(
     "//tensorflow:tensorflow.bzl",
-    "tf_cc_binary",
-    "tf_cc_shared_object",
-    "tf_cc_test",
     "if_with_tpu_support",
+    "tf_cc_shared_object",
 )
 load(
     "//tensorflow/tsl/platform/default:build_config.bzl",
-    "tf_additional_all_protos",
-    "tf_proto_library",
     "tf_proto_library_cc",
-    "tf_proto_library_py",
 )
 load(
     "//tensorflow/tsl/platform/default:cuda_build_defs.bzl",
     "if_cuda_is_configured",
 )
+
+licenses(["notice"])  # Apache 2.0
+
+package(default_visibility = ["//tensorflow:internal"])
 
 exports_files(
     [
@@ -79,8 +75,8 @@ cc_library(
         "metrics_reader.cc",
         "multi_wait.cc",
         "nccl_distributed.cc",
-        "profiler.cc",
         "pjrt_computation_client.cc",
+        "profiler.cc",
         "record_reader.cc",
         "sys_util.cc",
         "tf_logging.cc",
@@ -104,8 +100,8 @@ cc_library(
         "metrics_reader.h",
         "multi_wait.h",
         "nccl_distributed.h",
-        "profiler.h",
         "pjrt_computation_client.h",
+        "profiler.h",
         "record_reader.h",
         "sys_util.h",
         "tf_logging.h",
@@ -186,4 +182,26 @@ cc_library(
         "//tensorflow/compiler/jit:xla_tpu_jit",
     ]),
     alwayslink = 1,
+)
+
+xla_cc_test(
+    name = "pjrt_computation_client_test",
+    srcs = ["pjrt_computation_client_test.cc"],
+    deps = [
+        ":computation_client_impl",
+        "//tensorflow/compiler/xla:literal",
+        "//tensorflow/compiler/xla:literal_util",
+        "//tensorflow/compiler/xla:shape_util",
+        "//tensorflow/compiler/xla:status",
+        "//tensorflow/compiler/xla:statusor",
+        "//tensorflow/compiler/xla/client:xla_builder",
+        "//tensorflow/compiler/xla/client:xla_computation",
+        "//tensorflow/compiler/xla/tests:literal_test_util",
+        "//tensorflow/compiler/xla/tools:hlo_module_loader",
+        "//tensorflow/core/platform:logging",
+        "//tensorflow/tsl/lib/core:status_test_util",
+        "//tensorflow/tsl/platform:env",
+        "//tensorflow/tsl/platform:test",
+        "//tensorflow/tsl/platform:test_main",
+    ],
 )

--- a/third_party/xla_client/pjrt_computation_client_test.cc
+++ b/third_party/xla_client/pjrt_computation_client_test.cc
@@ -61,7 +61,8 @@ TEST(PjRtComputationClientTest, Init) {
       xla::LiteralUtil::CreateR2<float>({{5.0f, 6.0f}, {7.0f, 8.0f}});
 
   // Compile the graph.
-  auto cptr = client->Compile(std::move(instances));
+  std::vector<ComputationClient::ComputationPtr> computations =
+      client->Compile(std::move(instances));
 
   // Copy inputs to device.
   ComputationClient::ExecuteComputationOptions options{};
@@ -70,9 +71,9 @@ TEST(PjRtComputationClientTest, Init) {
       TensorSourceFromLiteral(device, literal_y)};
 
   // Execute the graph.
-  auto results = client->ExecuteComputation(
-      *cptr[0], client->TransferToServer(absl::MakeConstSpan(args)), device,
-      options);
+  std::vector<ComputationClient::DataPtr> results = client->ExecuteComputation(
+      *computations[0], client->TransferToServer(absl::MakeConstSpan(args)),
+      device, options);
 
   // Copy the output from device back to host and assert correctness..
   ASSERT_EQ(results.size(), 1);

--- a/third_party/xla_client/pjrt_computation_client_test.cc
+++ b/third_party/xla_client/pjrt_computation_client_test.cc
@@ -1,0 +1,86 @@
+#include "tensorflow/compiler/xla/xla_client/pjrt_computation_client.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "tensorflow/compiler/xla/client/xla_builder.h"
+#include "tensorflow/compiler/xla/client/xla_computation.h"
+#include "tensorflow/compiler/xla/literal.h"
+#include "tensorflow/compiler/xla/literal_util.h"
+#include "tensorflow/compiler/xla/status.h"
+#include "tensorflow/compiler/xla/statusor.h"
+#include "tensorflow/compiler/xla/tests/literal_test_util.h"
+#include "tensorflow/compiler/xla/xla_client/computation_client.h"
+#include "tensorflow/core/platform/logging.h"
+#include "tensorflow/tsl/lib/core/status_test_util.h"
+#include "tensorflow/tsl/platform/env.h"
+#include "tensorflow/tsl/platform/test.h"
+
+namespace xla {
+
+tsl::StatusOr<xla::XlaComputation> MakeComputation() {
+  xla::Shape input_shape =
+      xla::ShapeUtil::MakeShape(xla::PrimitiveType::F32, {2, 2});
+  xla::XlaBuilder builder("AddComputation");
+  xla::XlaOp x = xla::Parameter(&builder, 0, input_shape, "x");
+  xla::XlaOp y = xla::Parameter(&builder, 1, input_shape, "y");
+  xla::XlaOp sum = xla::Add(x, y);
+  return builder.Build();
+}
+
+ComputationClient::TensorSource TensorSourceFromLiteral(
+    const std::string& device, const xla::Literal& literal) {
+  auto populate_fn = [&](const ComputationClient::TensorSource& source_tensor,
+                         void* dest_buffer, size_t dest_buffer_size) {
+    std::memcpy(dest_buffer, literal.data<float>().data(),
+                dest_buffer_size * sizeof(literal.data<float>().data()));
+  };
+  return ComputationClient::TensorSource(literal.shape(), device,
+                                         std::move(populate_fn));
+}
+
+TEST(PjRtComputationClientTest, Init) {
+  // Get a CPU client.
+  tsl::setenv("PJRT_DEVICE", "CPU", true);
+  auto client = std::make_unique<PjRtComputationClient>();
+  std::string device = client->GetDefaultDevice();
+
+  // Compose a computation.
+  auto shape = xla::ShapeUtil::MakeShape(xla::F32, {2, 2});
+  std::vector<ComputationClient::CompileInstance> instances;
+  instances.push_back(ComputationClient::CompileInstance(
+      std::move(MakeComputation().value()), device,
+      client->GetCompilationDevices(device, client->GetLocalDevices()),
+      &shape));
+
+  // Prepare inputs.
+  xla::Literal literal_x =
+      xla::LiteralUtil::CreateR2<float>({{1.0f, 2.0f}, {3.0f, 4.0f}});
+  xla::Literal literal_y =
+      xla::LiteralUtil::CreateR2<float>({{5.0f, 6.0f}, {7.0f, 8.0f}});
+
+  // Compile the graph.
+  auto cptr = client->Compile(std::move(instances));
+
+  // Copy inputs to device.
+  ComputationClient::ExecuteComputationOptions options{};
+  std::vector<ComputationClient::TensorSource> args = {
+      TensorSourceFromLiteral(device, literal_x),
+      TensorSourceFromLiteral(device, literal_y)};
+
+  // Execute the graph.
+  auto results = client->ExecuteComputation(
+      *cptr[0], client->TransferToServer(absl::MakeConstSpan(args)), device,
+      options);
+
+  // Copy the output from device back to host and assert correctness..
+  ASSERT_EQ(results.size(), 1);
+  auto result_literals = client->TransferFromServer(results);
+  ASSERT_THAT(result_literals, ::testing::SizeIs(1));
+  EXPECT_TRUE(xla::LiteralTestUtil::Equal(
+      xla::LiteralUtil::CreateR2<float>({{6.0f, 8.0f}, {10.0f, 12.0f}}),
+      result_literals[0]));
+}
+
+}  // namespace xla

--- a/third_party/xla_client/xrt_computation_client.cc
+++ b/third_party/xla_client/xrt_computation_client.cc
@@ -236,6 +236,8 @@ int64_t GetMaxTensorsPartitionSize() {
 
 }  // namespace
 
+const int64_t DataHandleLocker::dummy_handle = -151235;
+
 XrtComputationClient::Device::Device(const std::string& device_str) {
   std::vector<std::string> parts = absl::StrSplit(device_str, ':');
   XLA_CHECK_EQ(parts.size(), 2) << device_str;

--- a/third_party/xla_client/xrt_computation_client.h
+++ b/third_party/xla_client/xrt_computation_client.h
@@ -74,7 +74,7 @@ class XrtLocker {
 
 class DataHandleLocker : public XrtLocker {
  public:
-  static const int64_t dummy_handle = -151235;
+  static const int64_t dummy_handle;
 };
 
 class XrtComputationClient : public ComputationClient {


### PR DESCRIPTION
For now, the test does an end-to-end exercise of the client: it transfers tensors to device, compiles a computation (R2 add),
 and transfers the result back to host, ensuring correctness.

This works on CPU for now and is not yet executed during releases.