### PR TITLE
Remove "skip test" on already passing tests.

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -11,7 +11,6 @@ dev = xm.xla_device()
 
 class TestDynamicShapes(unittest.TestCase):
 
-  @unittest.skip("fails with functionalization")
   def test_simple_expand(self):
     size1 = 5
     size2 = 2
@@ -24,7 +23,7 @@ class TestDynamicShapes(unittest.TestCase):
     t6 = t5.expand(t2.size(0))
     self.assertIn('<=10', torch_xla._XLAC._get_xla_tensors_text([t6]))
     t6_cpu = t6.cpu()
-    self.assertEqual(t6_cpu.shape[0], 2)  # 10 instead of 2
+    self.assertEqual(t6_cpu.shape[0], 2)
 
   def test_simple_expand_on_2d_tensor(self):
     size1 = 5


### PR DESCRIPTION
https://github.com/pytorch/xla/pull/4452 has fixed the `expand` dynamic shape tests.