### PR TITLE
Fix HLO dump file names for PJRT

### DIFF
--- a/third_party/xla_client/sys_util.cc
+++ b/third_party/xla_client/sys_util.cc
@@ -18,7 +18,9 @@ std::string GetEnvOrdinalPath(const char* name, const std::string& defval,
                               const int64_t ordinal) {
   std::string path = GetEnvString(name, defval);
   if (!path.empty()) {
-    path = absl::StrCat(path, ".", ordinal);
+    if (ordinal >= 0) {
+      path = absl::StrCat(path, ".", ordinal);
+    }
   }
   return path;
 }

--- a/third_party/xla_client/sys_util.cc
+++ b/third_party/xla_client/sys_util.cc
@@ -15,15 +15,17 @@ std::string GetEnvString(const char* name, const std::string& defval) {
 }
 
 std::string GetEnvOrdinalPath(const char* name, const std::string& defval,
-                              const char* ordinal_env) {
+                              const int64_t ordinal) {
   std::string path = GetEnvString(name, defval);
   if (!path.empty()) {
-    int64_t ordinal = GetEnvInt(ordinal_env, -1);
-    if (ordinal >= 0) {
-      path = absl::StrCat(path, ".", ordinal);
-    }
+    path = absl::StrCat(path, ".", ordinal);
   }
   return path;
+}
+
+std::string GetEnvOrdinalPath(const char* name, const std::string& defval,
+                              const char* ordinal_env) {
+  return GetEnvOrdinalPath(name, defval, GetEnvInt(ordinal_env, -1));
 }
 
 int64_t GetEnvInt(const char* name, int64_t defval) {

--- a/third_party/xla_client/sys_util.h
+++ b/third_party/xla_client/sys_util.h
@@ -10,6 +10,9 @@ namespace sys_util {
 
 std::string GetEnvString(const char* name, const std::string& defval);
 
+std::string GetEnvOrdinalPath(const char* name, const std::string& defval,
+                              const int64_t ordinal);
+
 std::string GetEnvOrdinalPath(
     const char* name, const std::string& defval,
     const char* ordinal_env = "XRT_SHARD_LOCAL_ORDINAL");

--- a/torch_xla/csrc/debug_util.cpp
+++ b/torch_xla/csrc/debug_util.cpp
@@ -116,8 +116,8 @@ void DebugUtil::SaveTensorsGraphInfo(const char* name,
                                      absl::Span<const XLATensorPtr> tensors,
                                      const std::vector<size_t>* indices,
                                      GraphFormat format) {
-  static const std::string save_file =
-      xla::sys_util::GetEnvOrdinalPath("XLA_SAVE_TENSORS_FILE", "");
+  thread_local const std::string save_file = xla::sys_util::GetEnvOrdinalPath(
+      "XLA_SAVE_TENSORS_FILE", "", GetCurrentDevice().ordinal());
   if (!save_file.empty()) {
     static std::mutex lock;
     std::string info = GetTensorsGraphInfo(tensors, indices, format);


### PR DESCRIPTION
`SaveTensorsGraphInfo` relied on a global save file path and ordinal (as an env var) and wrote all HLO dumps to the same file. Use thread local ordinal and save file path to support PJRT.

Added a PJRT multi-CPU test and tested manually with XRT.