### PR TITLE
Switch to pytorch sccache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,8 @@ launch_docker_and_build: &launch_docker_and_build
     # To allow the upstream workflow to access PyTorch/XLA build images, we
     # need to have them in the ECR. This is not expensive, and only pushes it
     # if image layers are not present in the repo.
-    docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:v0.6 >/dev/null
-    docker push ${ECR_DOCKER_IMAGE_BASE}:v0.6 >/dev/null
+    docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:v0.7 >/dev/null
+    docker push ${ECR_DOCKER_IMAGE_BASE}:v0.7 >/dev/null
     sudo pkill -SIGHUP dockerd
     # To enable remote caching, use SCCACHE_BUCKET=${SCCACHE_BUCKET}
     # To disable remote caching, use SCCACHE_BUCKET=${LOCAL_BUCKET}

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -88,7 +88,7 @@ ENV RUSTUP_HOME /opt/rustup
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN . $CARGO_HOME/env && \
-    git clone --recursive https://github.com/mozilla/sccache.git && \
+    git clone --recursive https://github.com/pytorch/sccache.git && \
     cd sccache && \
     cargo install sccache && \
     cd .. && \


### PR DESCRIPTION
Recently, there are some flaky sccache start-up failures on PyTorch when building XLA, for example:

* https://hud.pytorch.org/pytorch/pytorch/commit/c5cb46ecdbc0c21697d99e240116bc3411674744

The full list can be found [here](https://hud.pytorch.org/failure/sccache%3A%20error%3A%20Timed%20out%20waiting%20for%20server%20startup).  The error, strangely, comes only from XLA.

It turns out that XLA `pytorch/xla_base:v0.6` uses upstream sccache from `https://github.com/mozilla/sccache.git` while the rest of PyTorch CI uses a custom fork from `https://github.com/pytorch/sccache.git` as defined in https://github.com/pytorch/pytorch/blob/master/.circleci/docker/common/install_cache.sh#L12

IMO, it's easier to stick to `https://github.com/pytorch/sccache.git` as the rest of the CI till we have the capacity to do the switch back to upstream sccache.

AFAIK, `https://github.com/pytorch/sccache.git` has some fixes to work with nvcc.