### PR TITLE
Forward fix for 81763

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -1878,9 +1878,6 @@ TEST_F(AtenXlaTensorTest, TestFrobeniusNormInDim) {
           torch::frobenius_norm(xla_a, {dim}, /*keepdim=*/false);
       AllClose(b, xla_b);
     });
-
-    ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-    ExpectCounterChanged("xla::norm", cpp_test::GetIgnoredCounters());
   }
 }
 
@@ -1894,10 +1891,6 @@ TEST_F(AtenXlaTensorTest, TestFrobeniusNormInDims) {
           torch::frobenius_norm(xla_a, dims, /*keepdim=*/false);
       AllClose(b, xla_b);
     });
-
-    ExpectCounterNotChanged("aten::(?!real|conj).*",
-                            cpp_test::GetIgnoredCounters());
-    ExpectCounterChanged("xla::sqrt", cpp_test::GetIgnoredCounters());
   }
 }
 


### PR DESCRIPTION
See https://github.com/pytorch/pytorch/pull/81763#issuecomment-1399187907 and https://github.com/pytorch/pytorch/pull/81763#issuecomment-1399318349

Now FrobeniusNorm is just left for backwards compatibility, and it dispatches to `at::norm`, which dispatches to `xla::norm`. As such, we don't need the `sqrt` counters as they will not be updated. We remove these checks as those from `TestNorm*` do not have them either.

It's not very clear to me how to handle this merge, as it's a forward fix. I guess we should simply merge it and then revert https://github.com/pytorch/pytorch/pull/92634 in master? cc @huydhn @kit1980