### PR TITLE
[Functionalization] Fix SPMD tests

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -110,7 +110,7 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     xm.mark_step()  # mark_step should preserve the sharding
     self.assertEqual(sharding_spec, torch_xla._XLAC._get_xla_sharding_spec(xt))
 
-  @unittest.skip("fails with functionalization")
+  # @unittest.skip("fails with functionalization")
   def test_optimizer_step_with_sharding(self):
     model = self.SimpleLinear().to(xm.xla_device())
     xs.mark_sharding(model.fc1.weight, self._get_mesh((1, self.n_devices)),
@@ -132,7 +132,7 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     self.assertEqual(sharding_spec,
                      torch_xla._XLAC._get_xla_sharding_spec(model.fc1.weight))
 
-  @unittest.skip("fails with functionalization")
+  # @unittest.skip("fails with functionalization")
   def test_inplace_add_with_sharding(self):
     xt = torch.ones(2, 2).to(xm.xla_device())
     xs.mark_sharding(xt, self._get_mesh((1, self.n_devices)), (0, 1))

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -110,7 +110,6 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     xm.mark_step()  # mark_step should preserve the sharding
     self.assertEqual(sharding_spec, torch_xla._XLAC._get_xla_sharding_spec(xt))
 
-  # @unittest.skip("fails with functionalization")
   def test_optimizer_step_with_sharding(self):
     model = self.SimpleLinear().to(xm.xla_device())
     xs.mark_sharding(model.fc1.weight, self._get_mesh((1, self.n_devices)),
@@ -132,7 +131,6 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     self.assertEqual(sharding_spec,
                      torch_xla._XLAC._get_xla_sharding_spec(model.fc1.weight))
 
-  # @unittest.skip("fails with functionalization")
   def test_inplace_add_with_sharding(self):
     xt = torch.ones(2, 2).to(xm.xla_device())
     xs.mark_sharding(xt, self._get_mesh((1, self.n_devices)), (0, 1))

--- a/test/spmd/test_xla_virtual_device.py
+++ b/test/spmd/test_xla_virtual_device.py
@@ -42,15 +42,13 @@ class VirtualDeviceTest(test_xla_sharding_base.XlaShardingTest):
     self.assertIn("VirtualDeviceUsage", met.counter_names())
     self.assertNotEqual(met.counter_value("VirtualDeviceUsage"), 0)
 
-  @unittest.skip("fails with functionalization")
   def test_model_weight_metrics(self):
     met.clear_counters()
     partition_spec = (0, 1)
     model = nn.Linear(128, 64).to(xm.xla_device())
     xs.mark_sharding(model.weight, self._get_mesh((1, self.n_devices)),
                      partition_spec)
-    self.assertIn("VirtualDeviceUsage", met.counter_names())
-    self.assertNotEqual(met.counter_value("VirtualDeviceUsage"), 0)
+    self.assertNotIn("VirtualDeviceUsage", met.counter_names())
 
   def test_no_sharding(self):
     t1 = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]],

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2359,10 +2359,17 @@ void XLANativeFunctions::_propagate_xla_data(const at::Tensor& input,
   TORCH_LAZY_FN_COUNTER("xla::");
   // This op is only called when functionalize pass is transforming an in-place
   // op. Therefore, we can populate some meta data to maintain any optimization
-  // for in-place ops we have in hands. 1) Aid XLA's InputOutputAlias.
+  // for in-place ops we have in hands.
+
+  // 1) Aid XLA's InputOutputAlias.
   auto input_tensor = bridge::GetXlaTensor(input);
   auto output_tensor = bridge::GetXlaTensor(output);
   output_tensor->data()->alias_id = input_tensor->GetUniqueId();
+
+  // 2) Aid SPMD.
+  if (input_tensor->sharding_spec()) {
+    output_tensor->SetShardingSpec(*(input_tensor->sharding_spec()));
+  }
 }
 
 at::Tensor& XLANativeFunctions::put_(at::Tensor& self, const at::Tensor& index,


### PR DESCRIPTION
Summary:
This pull request tries to fix three SPMD tests that fails with Functionalization.
1. test_model_weight_metrics: Before Functionalization, model.weight is an at::tensor stored in the XLATensor, but it's an IRValue now. Therefore, the test no longer holds true.
2. test_optimizer_step_with_sharding/test_inplace_add_with_sharding: we propagate the sharding spec via _propagate_xla_data which  is an operator that help us during in-place op functionalized pass.

Test Plan:
CI.