### PR TITLE
Remove deprecated torch.symeig

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -934,33 +934,6 @@ TEST_F(AtenXlaTensorTest, TestQR) {
   }
 }
 
-TEST_F(AtenXlaTensorTest, TestSymEig) {
-  static const int dims[] = {4, 7};
-  for (auto m : dims) {
-    for (bool eigenvectors : {true, false}) {
-      for (bool upper : {true, false}) {
-        torch::Tensor a =
-            torch::rand({m, m}, torch::TensorOptions(torch::kFloat));
-        torch::Tensor sym_a = a.mm(a.t());
-        auto b = torch::symeig(sym_a, eigenvectors, upper);
-        ForEachDevice([&](const torch::Device& device) {
-          torch::Tensor xla_a = CopyToDevice(sym_a, device);
-          auto xla_b = torch::symeig(xla_a, eigenvectors, upper);
-          AllClose(std::get<0>(b), std::get<0>(xla_b), /*rtol=*/3e-2,
-                   /*atol=*/1e-2);
-          if (eigenvectors) {
-            AllClose(std::get<1>(b).abs(), std::get<1>(xla_b).abs(),
-                     /*rtol=*/3e-2,
-                     /*atol=*/1e-2);
-          } else {
-            EXPECT_EQ(std::get<1>(b).sizes(), std::get<1>(xla_b).sizes());
-          }
-        });
-      }
-    }
-  }
-}
-
 TEST_F(AtenXlaTensorTest, TestCholesky) {
   static const int dims[] = {4, 7};
   for (auto m : dims) {

--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -104,7 +104,6 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_unfold_all_devices_and_dtypes',  # uses half
         'test_tensor_pow_tensor',  # lowering
         'test_tensor_factories_empty',  # uses half
-        'test_symeig',
         'test_svd',
         'test_svd_no_singularvectors',
         'test_svd_lowrank',

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -276,7 +276,6 @@ allowed_opinfo = set(
             # AllowedOpInfoEntry('asinh'),
             # AllowedOpInfoEntry('atan'),
             # AllowedOpInfoEntry('atanh'),
-            # AllowedOpInfoEntry('symeig'),
             # AllowedOpInfoEntry('cos'),
             # AllowedOpInfoEntry('cosh'),
             # AllowedOpInfoEntry('cov'),

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2777,15 +2777,6 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> XLANativeFunctions::svd(
                          bridge::AtenFromXlaTensor(std::get<2>(results)));
 }
 
-std::tuple<at::Tensor, at::Tensor> XLANativeFunctions::symeig(
-    const at::Tensor& self, bool eigenvectors, bool upper) {
-  TORCH_LAZY_FN_COUNTER("xla::");
-  auto results =
-      tensor_methods::symeig(bridge::GetXlaTensor(self), eigenvectors, upper);
-  return std::make_tuple(bridge::AtenFromXlaTensor(std::get<0>(results)),
-                         bridge::AtenFromXlaTensor(std::get<1>(results)));
-}
-
 at::Tensor XLANativeFunctions::t(const at::Tensor& self) {
   TORCH_LAZY_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(

--- a/torch_xla/csrc/ops/symeig.cpp
+++ b/torch_xla/csrc/ops/symeig.cpp
@@ -45,7 +45,7 @@ xla::Shape NodeOutputShape(const torch::lazy::Value& input, bool eigenvectors,
 }  // namespace
 
 SymEig::SymEig(const torch::lazy::Value& input, bool eigenvectors, bool lower)
-    : XlaNode(torch::lazy::OpKind(at::aten::symeig), {input},
+    : XlaNode(torch::lazy::OpKind(at::aten::linalg_eigh), {input},
               [&]() { return NodeOutputShape(input, eigenvectors, lower); },
               /*num_outputs=*/2, torch::lazy::MHash(eigenvectors, lower)),
       eigenvectors_(eigenvectors),

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -118,7 +118,6 @@
 #include "torch_xla/csrc/ops/std_mean.h"
 #include "torch_xla/csrc/ops/sum.h"
 #include "torch_xla/csrc/ops/svd.h"
-#include "torch_xla/csrc/ops/symeig.h"
 #include "torch_xla/csrc/ops/threshold.h"
 #include "torch_xla/csrc/ops/threshold_backward.h"
 #include "torch_xla/csrc/ops/topk.h"
@@ -2425,15 +2424,6 @@ std::tuple<XLATensorPtr, XLATensorPtr, XLATensorPtr> svd(
   return std::make_tuple(input->CreateFrom(torch::lazy::Value(node, 0)),
                          input->CreateFrom(torch::lazy::Value(node, 1)),
                          input->CreateFrom(torch::lazy::Value(node, 2)));
-}
-
-std::tuple<XLATensorPtr, XLATensorPtr> symeig(const XLATensorPtr& input,
-                                              bool eigenvectors, bool upper) {
-  // SymEig takes lower instead of upper, hence the negation.
-  torch::lazy::NodePtr node =
-      torch::lazy::MakeNode<SymEig>(input->GetIrValue(), eigenvectors, !upper);
-  return std::make_tuple(input->CreateFrom(torch::lazy::Value(node, 0)),
-                         input->CreateFrom(torch::lazy::Value(node, 1)));
 }
 
 XLATensorPtr tanh_backward(const XLATensorPtr& grad_output,

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -805,9 +805,6 @@ XLATensorPtr sum(const XLATensorPtr& input, std::vector<int64_t> dimensions,
 std::tuple<XLATensorPtr, XLATensorPtr, XLATensorPtr> svd(
     const XLATensorPtr& input, bool some, bool compute_uv);
 
-std::tuple<XLATensorPtr, XLATensorPtr> symeig(const XLATensorPtr& input,
-                                              bool eigenvectors, bool upper);
-
 XLATensorPtr take(const XLATensorPtr& input, const XLATensorPtr& index);
 
 XLATensorPtr tanh_backward(const XLATensorPtr& grad_output,

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -307,7 +307,6 @@ supported:
   - sum
   - sum.dim_IntList
   - svd
-  - symeig
   - t
   - t_
   - tanh_backward


### PR DESCRIPTION
Split https://github.com/pytorch/xla/pull/3272 into separate PRs, this PR just removes the symeig function.