### PR TITLE
[PJRT] Release the GIL during `TransferFromServer`

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -497,3 +497,8 @@ variables:
         - List of metrics percentiles to record.
       type: string
       default_value: "0.01:0.05:0.1:0.2:0.5:0.8:0.9:0.95:0.99"
+    XLA_RELEASE_GIL_DURING_TRANSFER:
+      descripton:
+        - Release Python's GIL when transferring data from the runtime.
+      type: bool
+      default_value: true

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -642,7 +642,7 @@ std::vector<at::Tensor> XLAGraphExecutor::GetTensorsFused(
   // completes. Release the GIL so other threads can proceed and unblock any
   // collective computations.
   PyThreadState* save = nullptr;
-  if (PyGILState_Check()) {
+  if (Py_IsInitialized() && PyGILState_Check()) {
     save = PyEval_SaveThread();
   }
   std::vector<xla::Literal> literals =

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -646,7 +646,10 @@ std::vector<at::Tensor> XLAGraphExecutor::GetTensorsFused(
   // possible, prefer to release the GIL in the python bindings before copying
   // this pattern.
   PyThreadState* save = nullptr;
-  if (Py_IsInitialized() && PyGILState_Check()) {
+  // TODO(wcromar): Remove this setting when we are more confident
+  static const bool release_gil = xla::sys_util::GetEnvBool(
+    "XLA_RELEASE_GIL_DURING_TRANSFER", true);
+  if (release_gil && Py_IsInitialized() && PyGILState_Check()) {
     save = PyEval_SaveThread();
   }
   std::vector<xla::Literal> literals =

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -641,6 +641,10 @@ std::vector<at::Tensor> XLAGraphExecutor::GetTensorsFused(
   // Execution is async in PJRT, so TransferFromServer may block until execution
   // completes. Release the GIL so other threads can proceed and unblock any
   // collective computations.
+  // HACK: This method may be called outside of python (mainly in C++ tests) or
+  // when the GIL is already released, so we must check both cases here. If
+  // possible, prefer to release the GIL in the python bindings before copying
+  // this pattern.
   PyThreadState* save = nullptr;
   if (Py_IsInitialized() && PyGILState_Check()) {
     save = PyEval_SaveThread();

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -639,6 +639,9 @@ std::vector<at::Tensor> XLAGraphExecutor::GetTensorsFused(
                        : absl::Span<const torch::lazy::BackendDataPtr>());
 
 
+  // Execution is async in PJRT, so TransferFromServer may block until execution
+  // completes. Release the GIL so other threads can proceed and unblock any
+  // collective computations.
   PyThreadState *save = nullptr;
   if (PyGILState_Check()) {
     save = PyEval_SaveThread();

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -647,8 +647,8 @@ std::vector<at::Tensor> XLAGraphExecutor::GetTensorsFused(
   // this pattern.
   PyThreadState* save = nullptr;
   // TODO(wcromar): Remove this setting when we are more confident
-  static const bool release_gil = xla::sys_util::GetEnvBool(
-    "XLA_RELEASE_GIL_DURING_TRANSFER", true);
+  static const bool release_gil =
+      xla::sys_util::GetEnvBool("XLA_RELEASE_GIL_DURING_TRANSFER", true);
   if (release_gil && Py_IsInitialized() && PyGILState_Check()) {
     save = PyEval_SaveThread();
   }

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -638,16 +638,16 @@ std::vector<at::Tensor> XLAGraphExecutor::GetTensorsFused(
       async != nullptr ? async->tensors_data
                        : absl::Span<const torch::lazy::BackendDataPtr>());
 
-
   // Execution is async in PJRT, so TransferFromServer may block until execution
   // completes. Release the GIL so other threads can proceed and unblock any
   // collective computations.
-  PyThreadState *save = nullptr;
+  PyThreadState* save = nullptr;
   if (PyGILState_Check()) {
     save = PyEval_SaveThread();
   }
-  std::vector<xla::Literal> literals = xla::ComputationClient::Get()->TransferFromServer(
-        UnwrapXlaData(tensors_data));
+  std::vector<xla::Literal> literals =
+      xla::ComputationClient::Get()->TransferFromServer(
+          UnwrapXlaData(tensors_data));
   if (save) {
     PyEval_RestoreThread(save);
   }


### PR DESCRIPTION
Because execution in PJRT is asynchronous, if we call `TransferFromServer` on a buffer produced by a computation that is in progress, `TransferToServer` will block until the underlying buffer is ready. However, in this case, the thread calling `TransferFromServer` is also holding the [GIL](https://wiki.python.org/moin/GlobalInterpreterLock). That means that in a multithreaded context, we can end up with a deadlock where one thread is holding the GIL indefinitely while it waits for another replica to participate in a computation, and the thread that must run that computation is blocked because the first thread is holding the GIL.

This started happening consistently with PJRT on TPU v3 some time in mid-December, triggered by an unrelated commit. I confirmed the GIL deadlock by inspecting hanging threads with `gdb`:

<details>
<summary>`gdb` output</summary>

```
Thread 456 (Thread 0x7f3aa37fe700 (LWP 856191)):
#0  syscall () at ../sysdeps/unix/sysv/linux/x86_64/syscall.S:38
#1  0x00007f405a13278e in absl::lts_20220623::synchronization_internal::Waiter::Wait(absl::lts_20220623::synchronization_internal::KernelTimeout) () from /pytorch/xla/torch_xla/lib/libxla_computation_client.so
#2  0x00007f405a132652 in AbslInternalPerThreadSemWait_lts_20220623 () from /pytorch/xla/torch_xla/lib/libxla_computation_client.so
#3  0x00007f405a133a43 in absl::lts_20220623::Mutex::Block(absl::lts_20220623::base_internal::PerThreadSynch*) () from /pytorch/xla/torch_xla/lib/libxla_computation_client.so
#4  0x00007f404d4d7c9c in absl::lts_20220623::Mutex::LockSlowWithDeadline(absl::lts_20220623::MuHowS const*, absl::lts_20220623::Condition const*, absl::lts_20220623::synchronization_internal::KernelTimeout, int) [clone .cold.39] () from /pytorch/xla/torch_xla/lib/libxla_computation_client.so
#5  0x00007f404d4d7cb0 in absl::lts_20220623::Mutex::LockSlow(absl::lts_20220623::MuHowS const*, absl::lts_20220623::Condition const*, int) () from /pytorch/xla/torch_xla/lib/libxla_computation_client.so
#6  0x00007f405a1351d3 in absl::lts_20220623::Notification::WaitForNotification() const () from /pytorch/xla/torch_xla/lib/libxla_computation_client.so
#7  0x00007f404d7d5275 in xla::PjRtComputationClient::TransferFromServer(absl::lts_20220623::Span<std::shared_ptr<xla::ComputationClient::Data> const>) () from /pytorch/xla/torch_xla/lib/libxla_computation_client.so
```

```
Thread 452 (Thread 0x7fa11bfff700 (LWP 1271425)):
Traceback (most recent call first):
  Waiting for the GIL
  <built-in method write of _io.TextIOWrapper object at remote 0x7fa81e9d0040>
  <built-in method print of module object at remote 0x7fa81ea2c310>
  (frame information optimized out)
  File "/usr/local/lib/python3.8/site-packages/torch/_tensor.py", line 935, in __hash__
    return id(self)
```
</details>

This problem was irrelevant to XRT for two reasons:

1. Each replica runs in a distinct process, so they don't share a GIL. (This is also the reason why this problem does not manifest on TPU v4 with PJRT).
1. Execution is synchronous in XRT, so `TransferFromServer` will never block and wait for a result.

We have to do one of the following to prevent this deadlock:

1. Don't release the device lock until execution is finished. This will block e.g. device transfers. In my experiments with different ways of doing this, I saw a consistent 5-10% performance degradation.
2. Release the GIL while calling `TransferFromServer` to allow other threads to move forward.

This PR implements (2) to preserve performance.
