### PR TITLE
[Functionalization] Fix test_non_view

### DIFF
--- a/test/test_input_output_aliases.py
+++ b/test/test_input_output_aliases.py
@@ -10,7 +10,6 @@ import unittest
 # TODO(alanwaketan): add test for views.
 class InputOutputAliasesTest(unittest.TestCase):
 
-  @unittest.skip("Broke by functionalization. why? No views at all...")
   def test_non_view(self):
     xla_device = xm.xla_device()
     # This is a special case where we want to sync t1's and t2's

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2354,6 +2354,17 @@ at::Tensor XLANativeFunctions::prod(const at::Tensor& self, int64_t dim,
                            PromoteIntegralType(self.scalar_type(), dtype)));
 }
 
+void XLANativeFunctions::_propagate_xla_data(const at::Tensor& input,
+                                             const at::Tensor& output) {
+  TORCH_LAZY_FN_COUNTER("xla::");
+  // This op is only called when functionalize pass is transforming an in-place
+  // op. Therefore, we can populate some meta data to maintain any optimization
+  // for in-place ops we have in hands. 1) Aid XLA's InputOutputAlias.
+  auto input_tensor = bridge::GetXlaTensor(input);
+  auto output_tensor = bridge::GetXlaTensor(output);
+  output_tensor->data()->alias_id = input_tensor->GetUniqueId();
+}
+
 at::Tensor& XLANativeFunctions::put_(at::Tensor& self, const at::Tensor& index,
                                      const at::Tensor& source,
                                      bool accumulate) {

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -86,25 +86,33 @@ class XLATensor : public torch::lazy::LazyTensor {
          ShardingSpecPtr sharding = nullptr)
         : torch::lazy::LazyTensor::Data(handle, device),
           logical_element_type(logical_element_type),
-          sharding(sharding) {}
+          sharding(sharding) {
+      alias_id = unique_id;
+    }
     Data(torch::lazy::Value ir_value, const torch::lazy::BackendDevice& device,
          c10::optional<at::ScalarType> logical_element_type,
          ShardingSpecPtr sharding = nullptr)
         : torch::lazy::LazyTensor::Data(ir_value, device),
           logical_element_type(logical_element_type),
-          sharding(sharding) {}
+          sharding(sharding) {
+      alias_id = unique_id;
+    }
     Data(at::Tensor tensor_data, const torch::lazy::BackendDevice& device,
          ShardingSpecPtr sharding = nullptr)
         : torch::lazy::LazyTensor::Data(tensor_data, device),
           logical_element_type(tensor_data.scalar_type()),
-          sharding(sharding) {}
+          sharding(sharding) {
+      alias_id = unique_id;
+    }
     Data(std::shared_ptr<View> view, const torch::lazy::BackendDevice& device,
          c10::optional<at::ScalarType> logical_element_type,
          ShardingSpecPtr sharding = nullptr)
         : torch::lazy::LazyTensor::Data(device),
           view(std::move(view)),
           logical_element_type(logical_element_type),
-          sharding(sharding) {}
+          sharding(sharding) {
+      alias_id = unique_id;
+    }
 
     ~Data();
 
@@ -116,6 +124,10 @@ class XLATensor : public torch::lazy::LazyTensor {
     // A copy of the sharding spec is attached to the IR node via
     // `SetShardingSpec` and also during the sync tensor collection.
     ShardingSpecPtr sharding;
+    // This is used to enable XLA's InputOutputAlias. It's inited
+    // with unique_id, and then only get updated during the in-place
+    // op funtionalize pass to point to the input.
+    int64_t alias_id{0};
   };
 
   static XLATensorPtr Create(const at::Tensor& tensor,

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -1029,7 +1029,7 @@ XLAGraphExecutor::BuildInputOutputAliases(
   // those buffers are no longer needed after execution.
   for (size_t i = 0; i < indices.size(); ++i) {
     size_t tensor_index = indices[i];
-    int64_t tensor_id = tensors[tensor_index]->GetUniqueId();
+    int64_t tensor_id = tensors[tensor_index]->data()->alias_id;
     output_tensor_id_map[tensor_id] = i;
   }
   const auto& parameters_data = lowering_ctx->GetParametersData();

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -261,6 +261,7 @@ supported:
   - _prelu_kernel
   - prod
   - prod.dim_int
+  - _propagate_xla_data
   - put_
   - qr
   - random_


### PR DESCRIPTION
Summary:
This pull request implements the _propagate_xla_data op to propagate information through the in-place ops transform pass in during functionalization such that we can preserve the InputOutputAlias optimization.

I have tried to compare the usage of InputOutputAlias with and without Functionalization by using resnet fake data with one epoch:
Without Func:
```
Metric: InputOutputAliasCount
  TotalSamples: 11
  Accumulator: 1071.00
  ValueRate: 0.90 / second
  Rate: 0.00927083 / second
  Percentiles: 1%=0.00; 5%=0.00; 10%=0.00; 20%=0.00; 50%=1.00; 80%=267.00; 90%=320.00; 95%=481.00; 99%=481.00
```

With Func:
```
Metric: InputOutputAliasCount
  TotalSamples: 13
  Accumulator: 859.00
  ValueRate: 0.54 / second
  Rate: 0.0082071 / second
  Percentiles: 1%=0.00; 5%=0.00; 10%=0.00; 20%=0.00; 50%=1.00; 80%=214.00; 90%=214.00; 95%=269.00; 99%=269.00
```

Test Plan:
CI
