### PR TITLE
[Functionalization] Mark test_logcumsumexp NTBF

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -203,7 +203,7 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_copy_',  # test against complex32 which is nto supported
         'test_assertRaisesRegex_ignore_msg_non_native_device_xla',  # segfault on wheel sanity test
         'test_index_reduce',  # TODO @wonjoo fails with functionalization
-        'test_logcumsumexp_xla',  # TODO @wonjoo fails with functionalization
+        'test_logcumsumexp_xla',  # doesn't raise, pytorch/pytorch#92912
         'test_narrow_copy_non_contiguous',  # New test, fails with functionalization
     },
 


### PR DESCRIPTION
Summary:
test_logcumsumexp fails because the shape check on logcumsumexp.out is not executed after functionalized decomposition. As disccused in pytorch/pytorch#92912, this will be hard to fix. Since we never lower logcumsumexp, our users are highly likely not going to use it.

Test Plan:
CI.