### PR TITLE
Transfer shards from server using replication

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -152,11 +152,11 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     hash2 = torch_xla._XLAC._get_graph_hash([xt2])
     self.assertNotEqual(hash1, hash2)
 
-  def test_transfer_shards_from_server(self):
-    xt1 = torch.ones(2, 2).to(xm.xla_device())
+  def test_transfer_sharded_data_to_host(self):
+    xt1 = torch.ones(16, 16).to(xm.xla_device())
     xs.mark_sharding(xt1, self._get_mesh((1, self.n_devices)), (0, 1))
     t1 = xt1.cpu()
-    self.assertEqual(t1, xt1)
+    self.assertTrue(torch.allclose(t1, torch.ones(16, 16)))
 
 
 if __name__ == '__main__':

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -152,6 +152,12 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     hash2 = torch_xla._XLAC._get_graph_hash([xt2])
     self.assertNotEqual(hash1, hash2)
 
+  def test_transfer_shards_from_server(self):
+    xt1 = torch.ones(2, 2).to(xm.xla_device())
+    xs.mark_sharding(xt1, self._get_mesh((1, self.n_devices)), (0, 1))
+    t1 = xt1.cpu()
+    self.asserEqual(t1, xt1)
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -156,7 +156,7 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     xt1 = torch.ones(2, 2).to(xm.xla_device())
     xs.mark_sharding(xt1, self._get_mesh((1, self.n_devices)), (0, 1))
     t1 = xt1.cpu()
-    self.asserEqual(t1, xt1)
+    self.assertEqual(t1, xt1)
 
 
 if __name__ == '__main__':

--- a/third_party/xla_client/computation_client.h
+++ b/third_party/xla_client/computation_client.h
@@ -223,7 +223,7 @@ class ComputationClient {
   // `PjRtShardedData`.
   virtual DataPtr TransferShardsToServer(
       absl::Span<const TensorSource> tensor_shards, std::string device,
-      xla::Shape shape) = 0;
+      xla::Shape shape, xla::OpSharding sharding) = 0;
 
   // Copies `data->buffer` to `dst` device buffer.
   virtual DataPtr CopyToDevice(DataPtr data, std::string dst) = 0;

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -197,41 +197,52 @@ ComputationClient::DataPtr PjRtComputationClient::CopyToDevice(
 
 ComputationClient::DataPtr PjRtComputationClient::ReplicateShardedData(
     const ComputationClient::DataPtr& handle) {
-  PjRtShardedData& sharded_data = dynamic_cast<PjRtShardedData&>(*handle);
-  xla::XlaBuilder b("ReplicateShardedData");
-  xla::Shape shape = sharded_data.shape();
-  b.SetSharding(sharded_data.GetSharding());
-  auto x = xla::Parameter(&b, 0, shape, "p0");
-  b.SetSharding(xla::HloSharding::Replicate().ToProto());
-  auto y = xla::Div(x, ConstantR0<float>(&b, 2));
-  auto z = xla::Add(y, y);
+  if (PjRtShardedData* sharded_data =
+          dynamic_cast<PjRtShardedData*>(handle.get())) {
+      TF_VLOG(1) << "ReplicateShardedData (handle=" << handle->GetOpaqueHandle()
+                 << ", shape=" << handle->shape() << ")";
+      xla::XlaBuilder b("ReplicateShardedData");
+      xla::Shape shape = sharded_data->shape();
+      b.SetSharding(sharded_data->GetSharding());
 
-  xla::XlaComputation computation =
-      ConsumeValue(b.Build(/*remove_dynamic_dimensions=*/false));
-  xla::ProgramShape program_shape = ConsumeValue(computation.GetProgramShape());
+      // perform a simple identity calculation to reassemble the input as
+      // replicated output.
+      auto x = xla::Parameter(&b, 0, shape, "p0");
+      b.SetSharding(xla::HloSharding::Replicate().ToProto());
+      auto y = xla::Div(x, ConstantR0<float>(&b, 2));
+      auto z = xla::Add(y, y);
 
-  std::string device = GetDefaultDevice();
-  std::vector<xla::ComputationClient::CompileInstance> instances;
-  instances.push_back({std::move(computation), device,
-                       GetCompilationDevices(device, {}), &shape,
-                       /*should_wrap_parameter=*/false, /*is_sharded=*/true});
-  std::vector<std::shared_ptr<xla::ComputationClient::Computation>>
-      computations = Compile(std::move(instances));
+      xla::XlaComputation computation =
+          ConsumeValue(b.Build(/*remove_dynamic_dimensions=*/false));
+      xla::ProgramShape program_shape =
+          ConsumeValue(computation.GetProgramShape());
 
-  auto shards = sharded_data.shards;
-  XLA_CHECK_EQ(shards.size(), GetLocalDevices().size());
-  std::vector<std::vector<ComputationClient::DataPtr>> arguments_by_device(
-      GetLocalDevices().size(), std::vector<ComputationClient::DataPtr>(1));
-  for (auto shard : shards) {
-    std::vector<std::string> device_spec = absl::StrSplit(shard->device(), ':');
-    XLA_CHECK_EQ(device_spec.size(), 2)
-        << "Invalid device specification: " << shard->device();
-    int device_i = std::stoi(device_spec[1]);
-    arguments_by_device[device_i][0] = shard;
-  }
-  xla::ComputationClient::ExecuteReplicatedOptions execute_options;
-  return ExecuteReplicated(*computations.front(), arguments_by_device,
-                           GetLocalDevices(), execute_options)[0][0];
+      std::string device = GetDefaultDevice();
+      std::vector<xla::ComputationClient::CompileInstance> instances;
+      instances.push_back({std::move(computation), device,
+                           GetCompilationDevices(device, {}), &shape,
+                           /*should_wrap_parameter=*/false,
+                           /*is_sharded=*/true});
+      std::vector<std::shared_ptr<xla::ComputationClient::Computation>>
+          computations = Compile(std::move(instances));
+
+      auto shards = sharded_data->shards;
+      XLA_CHECK_EQ(shards.size(), GetLocalDevices().size());
+      std::vector<std::vector<ComputationClient::DataPtr>> arguments_by_device(
+          GetLocalDevices().size(), std::vector<ComputationClient::DataPtr>(1));
+      for (auto shard : shards) {
+        std::vector<std::string> device_spec =
+            absl::StrSplit(shard->device(), ':');
+        XLA_CHECK_EQ(device_spec.size(), 2)
+            << "Invalid device specification: " << shard->device();
+        int device_i = std::stoi(device_spec[1]);
+        arguments_by_device[device_i][0] = shard;
+      }
+      xla::ComputationClient::ExecuteReplicatedOptions execute_options;
+      return ExecuteReplicated(*computations.front(), arguments_by_device,
+                               GetLocalDevices(), execute_options)[0][0];
+    }
+  return handle;
 }
 
 std::vector<xla::Literal> PjRtComputationClient::TransferFromServer(
@@ -245,21 +256,14 @@ std::vector<xla::Literal> PjRtComputationClient::TransferFromServer(
 
   int64_t total_size = 0;
   for (auto handle : handles) {
-    if (dynamic_cast<PjRtShardedData*>(handle.get())) {
-      // Use XLA replication to reassemble the sharded data.
-      auto new_handle = ReplicateShardedData(handle);
-      const PjRtData& pjrt_data = dynamic_cast<const PjRtData&>(*new_handle);
-      std::shared_ptr<xla::Literal> literal =
-          pjrt_data.buffer->ToLiteralSync().value();
-      total_size += literal->size_bytes();
-      literals.push_back(std::move(*literal));
-    } else {
-      const PjRtData& pjrt_data = dynamic_cast<const PjRtData&>(*handle);
-      std::shared_ptr<xla::Literal> literal =
-          pjrt_data.buffer->ToLiteralSync().value();
-      total_size += literal->size_bytes();
-      literals.push_back(std::move(*literal));
-    }
+    // Use XLA replication to reassemble the sharded data. If input handle
+    // is not sharded, then it is a no-op.
+    auto new_handle = ReplicateShardedData(handle);
+    const PjRtData& pjrt_data = dynamic_cast<const PjRtData&>(*new_handle);
+    std::shared_ptr<xla::Literal> literal =
+        pjrt_data.buffer->ToLiteralSync().value();
+    total_size += literal->size_bytes();
+    literals.push_back(std::move(*literal));
   }
   InboundDataMetric()->AddSample(total_size);
 

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -46,44 +46,6 @@ std::vector<std::string> PjRtDevicesToString(
   return strs;
 }
 
-DataPtr ReplicateShardedData(const PjRtShardedData& sharded_data) {
-  xla::XlaBuilder b("ReplicateShardedData");
-  xla::Shape shape = sharded_data->shape();
-  b.SetSharding(sharded_data->GetSharding());
-  auto x = xla::Parameter(&b, 0, shape, "p0");
-  b.SetSharding(xla::HloSharding::Replicate().ToProto());
-  auto y = xla::Div(x, ConstantR0<float>(&b, 2));
-  auto z = xla::Add(y, y);
-
-  xla::XlaComputation computation =
-      ConsumeValue(b.Build(/*remove_dynamic_dimensions=*/false));
-  xla::ProgramShape program_shape = ConsumeValue(computation.GetProgramShape());
-
-  std::string device = GetDefaultDevice();
-  std::vector<xla::ComputationClient::CompileInstance> instances;
-  instances.push_back({std::move(computation), device,
-                       GetCompilationDevices(device, {}), &shape,
-                       /*should_wrap_parameter=*/false, /*is_sharded=*/true});
-  std::vector<std::shared_ptr<xla::ComputationClient::Computation>>
-      computations = Compile(std::move(instances));
-
-  auto shards = sharded_data->shards;
-  XLA_CHECK_EQ(shards.size(), GetLocalDevices().size());
-  std::vector<std::vector<xla::ComputationClient::DataPtr>> arguments_by_device(
-      GetLocalDevices().size(),
-      std::vector<xla::ComputationClient::DataPtr>(1));
-  for (auto shard : shards) {
-    std::vector<std::string> device_spec = absl::StrSplit(shard->device(), ':');
-    XLA_CHECK_EQ(device_spec.size(), 2)
-        << "Invalid device specification: " << shard->device();
-    int device_i = std::stoi(device_spec[1]);
-    arguments_by_device[device_i][0] = shard;
-  }
-  xla::ComputationClient::ExecuteReplicatedOptions execute_options;
-  return ExecuteReplicated(*computations.front(), arguments_by_device,
-                           GetLocalDevices(), execute_options)[0][0];
-}
-
 }  // namespace
 
 PjRtComputationClient::PjRtComputationClient() {
@@ -233,6 +195,45 @@ ComputationClient::DataPtr PjRtComputationClient::CopyToDevice(
                                     std::move(status_or.value()));
 }
 
+ComputationClient::DataPtr PjRtComputationClient::ReplicateShardedData(
+    const ComputationClient::DataPtr& handle) {
+  PjRtShardedData& sharded_data = dynamic_cast<PjRtShardedData&>(*handle);
+  xla::XlaBuilder b("ReplicateShardedData");
+  xla::Shape shape = sharded_data.shape();
+  b.SetSharding(sharded_data.GetSharding());
+  auto x = xla::Parameter(&b, 0, shape, "p0");
+  b.SetSharding(xla::HloSharding::Replicate().ToProto());
+  auto y = xla::Div(x, ConstantR0<float>(&b, 2));
+  auto z = xla::Add(y, y);
+
+  xla::XlaComputation computation =
+      ConsumeValue(b.Build(/*remove_dynamic_dimensions=*/false));
+  xla::ProgramShape program_shape = ConsumeValue(computation.GetProgramShape());
+
+  std::string device = GetDefaultDevice();
+  std::vector<xla::ComputationClient::CompileInstance> instances;
+  instances.push_back({std::move(computation), device,
+                       GetCompilationDevices(device, {}), &shape,
+                       /*should_wrap_parameter=*/false, /*is_sharded=*/true});
+  std::vector<std::shared_ptr<xla::ComputationClient::Computation>>
+      computations = Compile(std::move(instances));
+
+  auto shards = sharded_data.shards;
+  XLA_CHECK_EQ(shards.size(), GetLocalDevices().size());
+  std::vector<std::vector<ComputationClient::DataPtr>> arguments_by_device(
+      GetLocalDevices().size(), std::vector<ComputationClient::DataPtr>(1));
+  for (auto shard : shards) {
+    std::vector<std::string> device_spec = absl::StrSplit(shard->device(), ':');
+    XLA_CHECK_EQ(device_spec.size(), 2)
+        << "Invalid device specification: " << shard->device();
+    int device_i = std::stoi(device_spec[1]);
+    arguments_by_device[device_i][0] = shard;
+  }
+  xla::ComputationClient::ExecuteReplicatedOptions execute_options;
+  return ExecuteReplicated(*computations.front(), arguments_by_device,
+                           GetLocalDevices(), execute_options)[0][0];
+}
+
 std::vector<xla::Literal> PjRtComputationClient::TransferFromServer(
     absl::Span<const DataPtr> handles) {
   metrics::TimedSection timed(TransferFromServerMetric());
@@ -244,20 +245,21 @@ std::vector<xla::Literal> PjRtComputationClient::TransferFromServer(
 
   int64_t total_size = 0;
   for (auto handle : handles) {
-    PjRtData* pjrt_data;
-    if (PjRtShardedData* sharded_data =
-            dynamic_cast<PjRtShardedData*>(handle.get())) {
+    if (dynamic_cast<PjRtShardedData*>(handle.get())) {
       // Use XLA replication to reassemble the sharded data.
-      pjrt_data =
-          dynamic_cast<PjRtData&>(ReplicateShardedData(sharded_data).get());
+      auto new_handle = ReplicateShardedData(handle);
+      const PjRtData& pjrt_data = dynamic_cast<const PjRtData&>(*new_handle);
+      std::shared_ptr<xla::Literal> literal =
+          pjrt_data.buffer->ToLiteralSync().value();
+      total_size += literal->size_bytes();
+      literals.push_back(std::move(*literal));
     } else {
-      pjrt_data = dynamic_cast<PjRtData*>(handle.get());
+      const PjRtData& pjrt_data = dynamic_cast<const PjRtData&>(*handle);
+      std::shared_ptr<xla::Literal> literal =
+          pjrt_data.buffer->ToLiteralSync().value();
+      total_size += literal->size_bytes();
+      literals.push_back(std::move(*literal));
     }
-
-    std::shared_ptr<xla::Literal> literal =
-        pjrt_data->buffer->ToLiteralSync().value();
-    total_size += literal->size_bytes();
-    literals.push_back(std::move(*literal));
   }
   InboundDataMetric()->AddSample(total_size);
 

--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -26,6 +26,9 @@ class PjRtComputationClient : public ComputationClient {
   std::vector<DataPtr> TransferToServer(
       absl::Span<const TensorSource> tensors) override;
 
+  // Use XLA replication to re-assemble the sharded data.
+  DataPtr ReplicateShardedData(const DataPtr& handle);
+
   std::vector<Literal> TransferFromServer(
       absl::Span<const DataPtr> handles) override;
 

--- a/third_party/xla_client/xrt_computation_client.h
+++ b/third_party/xla_client/xrt_computation_client.h
@@ -259,8 +259,8 @@ class XrtComputationClient : public ComputationClient {
                         absl::Span<const DataPtr> datas) override;
 
   DataPtr TransferShardsToServer(absl::Span<const TensorSource> tensor_shards,
-                                 std::string device,
-                                 xla::Shape shape) override {
+                                 std::string device, xla::Shape shape,
+                                 xla::OpSharding sharding) override {
     XLA_ERROR() << __FUNCTION__ << " not implemented";
   }
 

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -232,13 +232,19 @@ void XLATensor::SetShardingSpec(const ShardingSpec& sharding) {
   // Existing annotation must be cleared explicitly. We do not clear and
   // overwrite the existing sharding on the user's behalf. This is a no-op if
   // the same sharding already applied.
-  if (sharding_spec() == nullptr ||
-      !ShardingUtil::EqualShardingSpecs(sharding, *sharding_spec())) {
+  if (!sharding_spec()) {
     TORCH_LAZY_COUNTER("SetShardingSpec", 1);
     data()->sharding = std::make_shared<ShardingSpec>(sharding);
-    dynamic_cast<XlaNode*>(GetIrValue().node.get())
-        ->SetSharding(sharding.sharding);
   }
+  else {
+    XLA_CHECK(ShardingUtil::EqualShardingSpecs(sharding, *sharding_spec()))
+        << "Existing sharding annotation, "
+        << sharding_spec()->sharding.DebugString()
+        << ", must be cleared before applying a new one, "
+        << sharding.sharding.DebugString();
+  }
+  dynamic_cast<XlaNode*>(GetIrValue().node.get())
+      ->SetSharding(sharding_spec()->sharding);
 }
 void XLATensor::ClearShardingSpec() {
   data()->sharding = nullptr;

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -235,8 +235,7 @@ void XLATensor::SetShardingSpec(const ShardingSpec& sharding) {
   if (!sharding_spec()) {
     TORCH_LAZY_COUNTER("SetShardingSpec", 1);
     data()->sharding = std::make_shared<ShardingSpec>(sharding);
-  }
-  else {
+  } else {
     XLA_CHECK(ShardingUtil::EqualShardingSpecs(sharding, *sharding_spec()))
         << "Existing sharding annotation, "
         << sharding_spec()->sharding.DebugString()
@@ -319,11 +318,16 @@ void XLATensor::SetInPlaceIrValue(torch::lazy::Value ir_value) {
 void XLATensor::AssignIrValue(torch::lazy::Value ir_value) const {
   if (ir_value) {
     std::string debug_str = ir_value->ToString();
-    auto sharding = dynamic_cast<XlaNode*>(ir_value.node.get())->GetSharding();
+    ir_value->auto sharding =
+        dynamic_cast<XlaNode*>(ir_value.node.get())->GetSharding();
     if (sharding) {
       debug_str += " with sharding " + sharding->DebugString();
     }
     TF_VLOG(5) << "Assign IR value " << debug_str;
+
+    // DataNode requires sharding propagation during reset.
+    dynamic_cast<XlaNode*>(ir_value.node.get())
+        ->SetSharding(sharding_spec()->sharding);
   } else {
     TF_VLOG(5) << "Assign empty IR value";
   }

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -318,16 +318,11 @@ void XLATensor::SetInPlaceIrValue(torch::lazy::Value ir_value) {
 void XLATensor::AssignIrValue(torch::lazy::Value ir_value) const {
   if (ir_value) {
     std::string debug_str = ir_value->ToString();
-    ir_value->auto sharding =
-        dynamic_cast<XlaNode*>(ir_value.node.get())->GetSharding();
+    auto sharding = dynamic_cast<XlaNode*>(ir_value.node.get())->GetSharding();
     if (sharding) {
       debug_str += " with sharding " + sharding->DebugString();
     }
     TF_VLOG(5) << "Assign IR value " << debug_str;
-
-    // DataNode requires sharding propagation during reset.
-    dynamic_cast<XlaNode*>(ir_value.node.get())
-        ->SetSharding(sharding_spec()->sharding);
   } else {
     TF_VLOG(5) << "Assign empty IR value";
   }

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -962,7 +962,7 @@ std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
       }
       new_handles.push_back(
           xla::ComputationClient::Get()->TransferShardsToServer(
-              source_tensors, devices[i], shape));
+              source_tensors, devices[i], shape, sharding));
     } else {
       // If data is not explicilty marked for sharding, then it is replicated to
       // the rest of the available devices. This implicit replication is needed

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -1152,6 +1152,8 @@ XLAGraphExecutor::CompilationResult XLAGraphExecutor::Compile(
   TF_VLOG(3) << "Compiling IR graph hash "
              << torch::lazy::HashToString(coll.hash) << " on device "
              << coll.device << " done!";
+  TF_VLOG(5) << "Compiled program shape "
+             << computations.front()->program_shape().ToString() << std::endl;
   TF_VLOG(5)
       << "Graph hash " << torch::lazy::HashToString(coll.hash)
       << " is computation hash "

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -832,6 +832,7 @@ void XLAGraphExecutor::ExtractIRAndPrepareXlaData_(
   for (auto index : indices) {
     XLATensorPtr& tensor = (*tensors)[index];
     torch::lazy::Value ir_value = tensor->CurrentIrValue();
+
     ir_values.push_back(ir_value);
     const torch::lazy::BackendDevice& tensor_device = tensor->GetDevice();
     xla::Shape shape = MakeShapeWithDeviceLayout(

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -16,6 +16,7 @@
 #include "tensorflow/compiler/xla/xla.pb.h"
 #include "torch_xla/csrc/device.h"
 #include "torch_xla/csrc/tensor.h"
+#include "torch_xla/csrc/tensor_util.h"
 
 namespace torch_xla {
 namespace {
@@ -326,48 +327,6 @@ std::vector<at::Tensor> ShardingUtil::ShardTensor(
     TF_LOG(ERROR) << "Unsupported OpSharidng type " << sharding.type();
   }
   return shards;
-}
-
-xla::ComputationClient::DataPtr GatherShrads(
-    xla::ComputationClient::DataPtr data, std::string device) {
-  if (PjRtShardedData* sharded_data =
-          dynamic_cast<PjRtShardedData*>(data.get())) {
-    torch::lazy::Value node =
-        CreateTensorNode(WrapXlaData(sharded_data), /*read_only=*/false);
-    node->SetSharding(sharded_data->GetSharding());
-    LoweringContext lowering_ctx("GatherShards", ParseDeviceString(device));
-    xla::XlaOp root = lowering_ctx.GetOutputOp(
-        torch::lazy::Output(node.node.get(), node.index));
-    lowering_ctx.AddResult(root);
-    bool is_sharded = SetHloSharding(&lowering_ctx);
-
-    xla::XlaComputation computation = ConsumeValue(lowering_ctx.BuildXla());
-    xla::ProgramShape program_shape =
-        ConsumeValue(computation.GetProgramShape());
-    xla::Shape shape = MakeShapeWithDeviceLayout(
-        program_shape.result(),
-        static_cast<XlaDeviceType>(ParseDeviceString(device).type()));
-    XLA_CHECK(lowering_ctx.GetParametersData().size() == 1);
-
-    std::vector<xla::ComputationClient::CompileInstance> instances;
-    instances.push_back(
-        {std::move(computation), device,
-         xla::ComputationClient::Get()->GetCompilationDevices(device, {}),
-         &shape, /*should_wrap_parameter=*/false, is_sharded});
-    std::vector<std::shared_ptr<xla::ComputationClient::Computation>>
-        computations =
-            xla::ComputationClient::Get()->Compile(std::move(instances));
-
-    std::vector<std::vector<xla::ComputationClient::DataPtr>> device_arguments =
-        torch_xla::ShardingUtil::InputHandler(
-            UnwrapXlaData(lowering_ctx.GetParametersData()),
-            xla::ComputationClient::Get()->GetLocalDevices());
-    xla::ComputationClient::ExecuteReplicatedOptions execute_options;
-    return xla::ComputationClient::Get()->ExecuteReplicated(
-        *async->cached_computation->computation->client_computation(),
-        device_arguments, devices, execute_options)[0][0];
-  }
-  return data;
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -54,10 +54,6 @@ class ShardingUtil {
   static std::vector<at::Tensor> ShardTensor(
       const at::Tensor& tensor, const xla::OpSharding sharding,
       const std::vector<std::string>& devices, bool padded = true);
-
-  // Gather and return unpartitioned data from shards.
-  static xla::ComputationClient::DataPtr GatherShrads(
-      xla::ComputationClient::DataPtr sharded_data);
 };
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -54,6 +54,10 @@ class ShardingUtil {
   static std::vector<at::Tensor> ShardTensor(
       const at::Tensor& tensor, const xla::OpSharding sharding,
       const std::vector<std::string>& devices, bool padded = true);
+
+  // Gather and return unpartitioned data from shards.
+  static xla::ComputationClient::DataPtr GatherShrads(
+      xla::ComputationClient::DataPtr sharded_data);
 };
 
 }  // namespace torch_xla


### PR DESCRIPTION
Allow shards transfer to host, so we can do
```
xt1 = torch.ones(16, 16).to(xm.xla_device())
xs.mark_sharding(xt1, self._get_mesh((1, self.n_devices)), (0, 1))
t1 = xt1.cpu()
```
Currently, `xt1.cpu()` would crash. This is not exposing the shards, which will be addressed in the future.