### PR TITLE
Temp disable cpp test TestNonzero

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -5169,6 +5169,9 @@ TEST_F(AtenXlaTensorTest, TestOneIndexTransfer) {
 }
 
 TEST_F(AtenXlaTensorTest, TestNonzero) {
+  // skip this test until the related bug(b/266636840) is fixed.
+  return;
+
   torch::Tensor a = torch::zeros({4, 2}, torch::TensorOptions(torch::kFloat));
   a[0][1] = 1.0;
   a[1][0] = 2.0;


### PR DESCRIPTION
like https://github.com/pytorch/xla/issues/4501

Temp disable cpp test TestNonzero;

Cpp test `TestNonzero` failed in the #4493's old CI log:
```
[ RUN      ] AtenXlaTensorTest.TestNonzero
unknown file: Failure
C++ exception with description "/tmp/pytorch/xla/torch_xla/csrc/aten_xla_type.cpp:1132: SymIntArrayRef expected to contain only concrete integers
Exception raised from asIntArrayRefSlow at /tmp/pytorch/c10/core/SymIntArrayRef.h:41 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x7d (0x7f5d03aa6add in /tmp/pytorch/torch/lib/libc10.so)
frame #1: c10::detail::torchCheckFail(char const*, char const*, unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) + 0xd9 (0x7f5d03aa50d9 in /tmp/pytorch/torch/lib/libc10.so)
frame #2: torch_xla::XLANativeFunctions::empty_symint(c10::ArrayRef<c10::SymInt>, c10::optional<c10::ScalarType>, c10::optional<c10::Layout>, c10::optional<c10::Device>, c10::optional<bool>, c10::optional<c10::MemoryFormat>) + 0x414 (0x7f5d03393014 in /tmp/pytorch/xla/build/lib.linux-x86_64-cpython-37/libptxla.so)
frame #3: <unknown function> + 0x29ebec (0x7f5d03463bec in /tmp/pytorch/xla/build/lib.linux-x86_64-cpython-37/libptxla.so)
frame #4: <unknown function> + 0x1f1076e (0x7f5cd34c076e in /tmp/pytorch/torch/lib/libtorch_cpu.so)
frame #5: at::_ops::empty_memory_format::redispatch(c10::DispatchKeySet, c10::ArrayRef<c10::SymInt>, c10::optional<c10::ScalarType>, c10::optional<c10::Layout>, c10::optional<c10::Device>, c10::optional<bool>, c10::optional<c10::MemoryFormat>) + 0x78 (0x7f5cd33e4ed8 in /tmp/pytorch/torch/lib/libtorch_cpu.so)
frame #6: <unknown function> + 0x220c541 (0x7f5cd37bc541 in /tmp/pytorch/torch/lib/libtorch_cpu.so)
frame #7: at::_ops::empty_memory_format::call(c10::ArrayRef<c10::SymInt>, c10::optional<c10::ScalarType>, c10::optional<c10::Layout>, c10::optional<c10::Device>, c10::optional<bool>, c10::optional<c10::MemoryFormat>) + 0x12c (0x7f5cd33e4adc in /tmp/pytorch/torch/lib/libtorch_cpu.so)
frame #8: <unknown function> + 0x11de989 (0x7f5cd278e989 in /tmp/pytorch/torch/lib/libtorch_cpu.so)
frame #9: at::native::_to_copy(at::Tensor const&, c10::optional<c10::ScalarType>, c10::optional<c10::Layout>, c10::optional<c10::Device>, c10::optional<bool>, bool, c10::optional<c10::MemoryFormat>) + 0x769 (0x7f5cd2aaf979 in /tmp/pytorch/torch/lib/libtorch_cpu.so)
frame #10: <unknown function> + 0x2512e10 (0x7f5cd3ac2e10 in /tmp/pytorch/torch/lib/libtorch_cpu.so)
frame #11: at::_ops::_to_copy::redispatch(c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::ScalarType>, c10::optional<c10::Layout>, c10::optional<c10::Device>, c10::optional<bool>, bool, c10::optional<c10::MemoryFormat>) + 0x90 (0x7f5cd3097700 in /tmp/pytorch/torch/lib/libtorch_cpu.so)
frame #12: <unknown function> + 0x221ee65 (0x7f5cd37cee65 in /tmp/pytorch/torch/lib/libtorch_cpu.so)
frame #13: at::_ops::_to_copy::redispatch(c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::ScalarType>, c10::optional<c10::Layout>, c10::optional<c10::Device>, c10::optional<bool>, bool, c10::optional<c10::MemoryFormat>) + 0x90 (0x7f5cd3097700 in /tmp/pytorch/torch/lib/libtorch_cpu.so)
frame #14: <unknown function> + 0x3a11c35 (0x7f5cd4fc1c35 in /tmp/pytorch/torch/lib/libtorch_cpu.so)
frame #15: at::_ops::_to_copy::call(at::Tensor const&, c10::optional<c10::ScalarType>, c10::optional<c10::Layout>, c10::optional<c10::Device>, c10::optional<bool>, bool, c10::optional<c10::MemoryFormat>) + 0x174 (0x7f5cd3097414 in /tmp/pytorch/torch/lib/libtorch_cpu.so)
frame #16: at::native::to(at::Tensor const&, c10::ScalarType, bool, bool, c10::optional<c10::MemoryFormat>) + 0x6d (0x7f5cd2ab13dd in /tmp/pytorch/torch/lib/libtorch_cpu.so)
frame #17: <unknown function> + 0x270bbbf (0x7f5cd3cbbbbf in /tmp/pytorch/torch/lib/libtorch_cpu.so)
frame #18: at::_ops::to_dtype::call(at::Tensor const&, c10::ScalarType, bool, bool, c10::optional<c10::MemoryFormat>) + 0x156 (0x7f5cd327a3e6 in /tmp/pytorch/torch/lib/libtorch_cpu.so)
frame #19: at::native::_cast_Long(at::Tensor const&, bool) + 0x47 (0x7f5cd2ae24b7 in /tmp/pytorch/torch/lib/libtorch_cpu.so)
frame #20: <unknown function> + 0x26d0a4f (0x7f5cd3c80a4f in /tmp/pytorch/torch/lib/libtorch_cpu.so)
frame #21: at::_ops::_cast_Long::call(at::Tensor const&, bool) + 0x12a (0x7f5cd35656ba in /tmp/pytorch/torch/lib/libtorch_cpu.so)
frame #22: ./test_ptxla() [0x6e7240]
frame #23: torch_xla::cpp_test::ForEachDevice(absl::lts_20220623::Span<torch_xla::DeviceType const>, std::function<void (c10::Device const&)> const&) + 0x140 (0x5a3ea0 in ./test_ptxla)
frame #24: torch_xla::cpp_test::AtenXlaTensorTest_TestNonzero_Test::TestBody() + 0x457 (0x624057 in ./test_ptxla)
frame #25: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) + 0x7e (0x821bbe in ./test_ptxla)
frame #26: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) + 0x7b (0x80653b in ./test_ptxla)
frame #27: testing::Test::Run() + 0xd9 (0x7e0359 in ./test_ptxla)
frame #28: testing::TestInfo::Run() + 0x10d (0x7e110d in ./test_ptxla)
frame #29: testing::TestSuite::Run() + 0x110 (0x7e1970 in ./test_ptxla)
frame #30: testing::internal::UnitTestImpl::RunAllTests() + 0x473 (0x7f2633 in ./test_ptxla)
frame #31: bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) + 0x7e (0x8257ce in ./test_ptxla)
frame #32: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) + 0x7b (0x808ecb in ./test_ptxla)
frame #33: testing::UnitTest::Run() + 0xd4 (0x7f2174 in ./test_ptxla)
frame #34: main + 0x1c (0x5a189c in ./test_ptxla)
frame #35: __libc_start_main + 0xe7 (0x7f5cd0c23c87 in /lib/x86_64-linux-gnu/libc.so.6)
frame #36: _start + 0x2a (0x5a17ba in ./test_ptxla)
" thrown in the test body.
[  FAILED  ] AtenXlaTensorTest.TestNonzero (18 ms)
```
https://app.circleci.com/pipelines/github/pytorch/xla/15932/workflows/524764eb-d960-4868-8683-c4323373145d/jobs/37538
