### PR TITLE
Add initial support for `scatter_reduce`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -284,7 +284,7 @@ if build_mode not in ['clean']:
   generate_xla_lazy_code(base_dir)
 
   # Build the support libraries (ie, TF).
-  build_extra_libraries(base_dir, build_mode=build_mode)
+  #build_extra_libraries(base_dir, build_mode=build_mode)
 
   # Copy libtpu.so into torch_xla/lib
   maybe_bundle_libtpu(base_dir)

--- a/setup.py
+++ b/setup.py
@@ -284,7 +284,7 @@ if build_mode not in ['clean']:
   generate_xla_lazy_code(base_dir)
 
   # Build the support libraries (ie, TF).
-  #build_extra_libraries(base_dir, build_mode=build_mode)
+  build_extra_libraries(base_dir, build_mode=build_mode)
 
   # Copy libtpu.so into torch_xla/lib
   maybe_bundle_libtpu(base_dir)

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -4879,6 +4879,200 @@ TEST_F(AtenXlaTensorTest, TestScatterAddInPlace) {
   }
 }
 
+TEST_F(AtenXlaTensorTest, TestScatterReduceSum) {
+  torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
+  for (int dim = 0; dim < 2; ++dim) {
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 5; j++) {
+        c[i][j] = (i + j) % c.sizes()[dim];
+      }
+    }
+    torch::Tensor d = torch::scatter_reduce(a, dim, c, b, "sum");
+    ForEachDevice([&](const torch::Device& device) {
+      torch::Tensor xla_a = CopyToDevice(a, device);
+      torch::Tensor xla_b = CopyToDevice(b, device);
+      torch::Tensor xla_c = CopyToDevice(c, device);
+      torch::Tensor xla_d = torch::scatter_reduce(xla_a, dim, xla_c, xla_b, "sum");
+      AllClose(d, xla_d);
+    });
+  }
+
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::scatter_reduce", cpp_test::GetIgnoredCounters());
+}
+
+TEST_F(AtenXlaTensorTest, TestScatterReduceSumInPlace) {
+  torch::Tensor b = torch::rand({4, 4}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor c = torch::empty({4, 4}, torch::TensorOptions(torch::kLong));
+  for (int i = 0; i < 4; i++) {
+    for (int j = 0; j < 4; j++) {
+      c[i][j] = (i + j) % 4;
+    }
+  }
+  for (int dim = 0; dim < 2; ++dim) {
+    ForEachDevice([&](const torch::Device& device) {
+      torch::Tensor a =
+          torch::rand({4, 4}, torch::TensorOptions(torch::kFloat));
+      torch::Tensor xla_a = CopyToDevice(a, device);
+      torch::Tensor d = a.scatter_reduce_(dim, c, b, "sum");
+      torch::Tensor xla_b = CopyToDevice(b, device);
+      torch::Tensor xla_c = CopyToDevice(c, device);
+      torch::Tensor xla_d = xla_a.scatter_reduce_(dim, xla_c, xla_b, "sum");
+      AllClose(d, xla_d);
+      AllClose(a, xla_a);
+    });
+
+    ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+    ExpectCounterChanged("xla::scatter_reduce", cpp_test::GetIgnoredCounters());
+  }
+}
+
+TEST_F(AtenXlaTensorTest, TestScatterReduceProd) {
+  torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
+  for (int dim = 0; dim < 2; ++dim) {
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 5; j++) {
+        c[i][j] = (i + j) % c.sizes()[dim];
+      }
+    }
+    torch::Tensor d = torch::scatter_reduce(a, dim, c, b, "prod");
+    ForEachDevice([&](const torch::Device& device) {
+      torch::Tensor xla_a = CopyToDevice(a, device);
+      torch::Tensor xla_b = CopyToDevice(b, device);
+      torch::Tensor xla_c = CopyToDevice(c, device);
+      torch::Tensor xla_d = torch::scatter_reduce(xla_a, dim, xla_c, xla_b, "prod");
+      AllClose(d, xla_d);
+    });
+  }
+
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::scatter_reduce", cpp_test::GetIgnoredCounters());
+}
+
+TEST_F(AtenXlaTensorTest, TestScatterReduceProdInPlace) {
+  torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
+  for (int dim = 0; dim < 2; ++dim) {
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 5; j++) {
+        c[i][j] = (i + j) % c.sizes()[dim];
+      }
+    }
+    torch::Tensor d = torch::scatter_reduce(a, dim, c, b, "prod");
+    ForEachDevice([&](const torch::Device& device) {
+      torch::Tensor xla_a = CopyToDevice(a, device);
+      torch::Tensor xla_b = CopyToDevice(b, device);
+      torch::Tensor xla_c = CopyToDevice(c, device);
+      torch::Tensor xla_d = xla_a.scatter_reduce(dim, xla_c, xla_b, "prod");
+      AllClose(d, xla_d);
+    });
+  }
+
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::scatter_reduce", cpp_test::GetIgnoredCounters());
+}
+
+TEST_F(AtenXlaTensorTest, TestScatterReduceMin) {
+  torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
+  for (int dim = 0; dim < 2; ++dim) {
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 5; j++) {
+        c[i][j] = (i + j) % c.sizes()[dim];
+      }
+    }
+    torch::Tensor d = torch::scatter_reduce(a, dim, c, b, "amin");
+    ForEachDevice([&](const torch::Device& device) {
+      torch::Tensor xla_a = CopyToDevice(a, device);
+      torch::Tensor xla_b = CopyToDevice(b, device);
+      torch::Tensor xla_c = CopyToDevice(c, device);
+      torch::Tensor xla_d = torch::scatter_reduce(xla_a, dim, xla_c, xla_b, "amin");
+      AllClose(d, xla_d);
+    });
+  }
+
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::scatter_reduce", cpp_test::GetIgnoredCounters());
+}
+
+TEST_F(AtenXlaTensorTest, TestScatterReduceMinInPlace) {
+  torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
+  for (int dim = 0; dim < 2; ++dim) {
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 5; j++) {
+        c[i][j] = (i + j) % c.sizes()[dim];
+      }
+    }
+    torch::Tensor d = torch::scatter_reduce(a, dim, c, b, "amin");
+    ForEachDevice([&](const torch::Device& device) {
+      torch::Tensor xla_a = CopyToDevice(a, device);
+      torch::Tensor xla_b = CopyToDevice(b, device);
+      torch::Tensor xla_c = CopyToDevice(c, device);
+      torch::Tensor xla_d = xla_a.scatter_reduce(dim, xla_c, xla_b, "amin");
+      AllClose(d, xla_d);
+    });
+  }
+
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::scatter_reduce", cpp_test::GetIgnoredCounters());
+}
+
+TEST_F(AtenXlaTensorTest, TestScatterReduceMax) {
+  torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
+  for (int dim = 0; dim < 2; ++dim) {
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 5; j++) {
+        c[i][j] = (i + j) % c.sizes()[dim];
+      }
+    }
+    torch::Tensor d = torch::scatter_reduce(a, dim, c, b, "amax");
+    ForEachDevice([&](const torch::Device& device) {
+      torch::Tensor xla_a = CopyToDevice(a, device);
+      torch::Tensor xla_b = CopyToDevice(b, device);
+      torch::Tensor xla_c = CopyToDevice(c, device);
+      torch::Tensor xla_d = scatter_reduce(xla_a, dim, xla_c, xla_b, "amax");
+      AllClose(d, xla_d);
+    });
+  }
+
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::scatter_reduce", cpp_test::GetIgnoredCounters());
+}
+
+TEST_F(AtenXlaTensorTest, TestScatterReduceMaxInPlace) {
+  torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
+  for (int dim = 0; dim < 2; ++dim) {
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 5; j++) {
+        c[i][j] = (i + j) % c.sizes()[dim];
+      }
+    }
+    torch::Tensor d = torch::scatter_reduce(a, dim, c, b, "amax");
+    ForEachDevice([&](const torch::Device& device) {
+      torch::Tensor xla_a = CopyToDevice(a, device);
+      torch::Tensor xla_b = CopyToDevice(b, device);
+      torch::Tensor xla_c = CopyToDevice(c, device);
+      torch::Tensor xla_d = xla_a.scatter_reduce(dim, xla_c, xla_b, "amax");
+      AllClose(d, xla_d);
+    });
+  }
+
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::scatter_reduce", cpp_test::GetIgnoredCounters());
+}
+
 TEST_F(AtenXlaTensorTest, TestIndexSelect) {
   for (torch::ScalarType scalar_type :
        {torch::kFloat, torch::kByte, torch::kChar, torch::kShort, torch::kInt,

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -4924,10 +4924,9 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceSumInPlace) {
       AllClose(d, xla_d);
       AllClose(a, xla_a);
     });
-
-    ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-    ExpectCounterChanged("xla::scatter_reduce", cpp_test::GetIgnoredCounters());
   }
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::scatter_reduce", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceProd) {

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -4894,7 +4894,8 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceSum) {
       torch::Tensor xla_a = CopyToDevice(a, device);
       torch::Tensor xla_b = CopyToDevice(b, device);
       torch::Tensor xla_c = CopyToDevice(c, device);
-      torch::Tensor xla_d = torch::scatter_reduce(xla_a, dim, xla_c, xla_b, "sum");
+      torch::Tensor xla_d =
+          torch::scatter_reduce(xla_a, dim, xla_c, xla_b, "sum");
       AllClose(d, xla_d);
     });
   }
@@ -4944,7 +4945,8 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceProd) {
       torch::Tensor xla_a = CopyToDevice(a, device);
       torch::Tensor xla_b = CopyToDevice(b, device);
       torch::Tensor xla_c = CopyToDevice(c, device);
-      torch::Tensor xla_d = torch::scatter_reduce(xla_a, dim, xla_c, xla_b, "prod");
+      torch::Tensor xla_d =
+          torch::scatter_reduce(xla_a, dim, xla_c, xla_b, "prod");
       AllClose(d, xla_d);
     });
   }
@@ -4992,7 +4994,8 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceMin) {
       torch::Tensor xla_a = CopyToDevice(a, device);
       torch::Tensor xla_b = CopyToDevice(b, device);
       torch::Tensor xla_c = CopyToDevice(c, device);
-      torch::Tensor xla_d = torch::scatter_reduce(xla_a, dim, xla_c, xla_b, "amin");
+      torch::Tensor xla_d =
+          torch::scatter_reduce(xla_a, dim, xla_c, xla_b, "amin");
       AllClose(d, xla_d);
     });
   }

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2512,6 +2512,28 @@ at::Tensor XLANativeFunctions::scatter_add(const at::Tensor& self, int64_t dim,
   return scatter_reduce_helper(self, dim, index, src, "add");
 }
 
+at::Tensor XLANativeFunctions::scatter_reduce(const at::Tensor & self, 
+                                              int64_t dim, 
+                                              const at::Tensor & index, 
+                                              const at::Tensor & src, 
+                                              c10::string_view reduce, 
+                                              bool include_self) {
+  TORCH_LAZY_FN_COUNTER("xla::");
+  if (reduce == "sum" || reduce == "prod" || reduce == "amin") {
+    return bridge::AtenFromXlaTensor(
+        tensor_methods::scatter_reduce(bridge::GetXlaTensor(self), dim,
+                                       bridge::GetXlaTensor(index),
+                                       bridge::GetXlaTensor(src), 
+                                       reduce, include_self));
+  } else {
+    return at::native::call_fallback_fn<
+        &xla_cpu_fallback, ATEN_OP2(scatter_reduce, two)>::call(self, dim,
+                                                                index, src,
+                                                                reduce, 
+                                                                include_self);
+  }
+}
+
 at::Tensor XLANativeFunctions::select(const at::Tensor& self, int64_t dim,
                                       int64_t index) {
   TORCH_LAZY_FN_COUNTER("xla::");

--- a/torch_xla/csrc/ops/scatter_reduce.cpp
+++ b/torch_xla/csrc/ops/scatter_reduce.cpp
@@ -1,0 +1,46 @@
+#include "torch_xla/csrc/ops/scatter_reduce.h"
+
+#include "torch_xla/csrc/convert_ops.h"
+#include "torch_xla/csrc/helpers.h"
+#include "torch_xla/csrc/lowering_context.h"
+#include "torch_xla/csrc/xla_lower_util.h"
+
+namespace torch_xla {
+
+ScatterReduce::ScatterReduce(const torch::lazy::Value& input,
+                             const torch::lazy::Value& index,
+                             const torch::lazy::Value& src, 
+                             c10::string_view reduce,
+                             bool include_self, int64_t dim)
+    : XlaNode(torch::lazy::OpKind(at::aten::scatter_reduce), {input, index, src},
+              GetXlaShape(input),
+              /*num_outputs=*/1, torch::lazy::MHash(dim)),
+      reduce_(reduce), include_self_(include_self), dim_(dim) {}
+
+torch::lazy::NodePtr ScatterReduce::Clone(torch::lazy::OpList operands) const {
+  return torch::lazy::MakeNode<ScatterReduce>(operands.at(0), operands.at(1),
+                                              operands.at(2), reduce_, 
+                                              include_self_, dim_);
+}
+
+XlaOpVector ScatterReduce::Lower(LoweringContext* loctx) const {
+  xla::XlaOp input = loctx->GetOutputOp(operand(0));
+  xla::XlaOp index = loctx->GetOutputOp(operand(1));
+  xla::XlaOp src = loctx->GetOutputOp(operand(2));
+  XlaOpCombiner combiner;
+  if (reduce_ == "sum") combiner = NumericAddCombiner();
+  else if (reduce_ == "prod") combiner = NumericMulCombiner();
+  else if (reduce_ == "amin") combiner = NumericMinCombiner();
+  else if (reduce_ == "amax") combiner = NumericMaxCombiner();
+  ScatterOptions options(combiner);
+  return ReturnOp(
+      CreateScatter(loctx->device(), input, index, src, dim_, options), loctx);
+}
+
+std::string ScatterReduce::ToString() const {
+  std::stringstream ss;
+  ss << XlaNode::ToString() << ", dim=" << dim_;
+  return ss.str();
+}
+
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/scatter_reduce.h
+++ b/torch_xla/csrc/ops/scatter_reduce.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "torch_xla/csrc/ir.h"
+
+namespace torch_xla {
+
+class ScatterReduce : public XlaNode {
+ public:
+  ScatterReduce(const torch::lazy::Value& input,
+                const torch::lazy::Value& index,
+                const torch::lazy::Value& src, c10::string_view reduce,
+                bool include_self, int64_t dim);
+
+  std::string ToString() const override;
+
+  torch::lazy::NodePtr Clone(torch::lazy::OpList operands) const override;
+
+  XlaOpVector Lower(LoweringContext* loctx) const override;
+
+  int64_t dim() const { return dim_; };
+
+ private:
+  c10::string_view reduce_;
+  bool include_self_;
+  int64_t dim_;
+};
+
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/scatter_reduce.h
+++ b/torch_xla/csrc/ops/scatter_reduce.h
@@ -7,9 +7,8 @@ namespace torch_xla {
 class ScatterReduce : public XlaNode {
  public:
   ScatterReduce(const torch::lazy::Value& input,
-                const torch::lazy::Value& index,
-                const torch::lazy::Value& src, c10::string_view reduce,
-                bool include_self, int64_t dim);
+                const torch::lazy::Value& index, const torch::lazy::Value& src,
+                c10::string_view reduce, bool include_self, int64_t dim);
 
   std::string ToString() const override;
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -108,6 +108,7 @@
 #include "torch_xla/csrc/ops/scalar.h"
 #include "torch_xla/csrc/ops/scatter.h"
 #include "torch_xla/csrc/ops/scatter_add.h"
+#include "torch_xla/csrc/ops/scatter_reduce.h"
 #include "torch_xla/csrc/ops/send.h"
 #include "torch_xla/csrc/ops/sgd_optimizer_step.h"
 #include "torch_xla/csrc/ops/softmax.h"
@@ -2179,6 +2180,16 @@ XLATensorPtr scatter_add(const XLATensorPtr& input, int64_t dim,
       value, input->shape(), input->GetDevice());
   return input->CreateFrom(torch::lazy::MakeNode<ScatterAdd>(
       input->GetIrValue(), index->GetIrValue(), constant,
+      torch::lazy::GetCanonicalDimensionIndex(dim,
+                                              input->shape().get().rank())));
+}
+
+XLATensorPtr scatter_reduce(const XLATensorPtr& input, int64_t dim,
+                            const XLATensorPtr& index, const XLATensorPtr& src,
+                            c10::string_view reduce, bool include_self) {
+  return input->CreateFrom(torch::lazy::MakeNode<ScatterReduce>(
+      input->GetIrValue(), index->GetIrValue(), src->GetIrValue(),
+      reduce, include_self,
       torch::lazy::GetCanonicalDimensionIndex(dim,
                                               input->shape().get().rank())));
 }

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2188,8 +2188,8 @@ XLATensorPtr scatter_reduce(const XLATensorPtr& input, int64_t dim,
                             const XLATensorPtr& index, const XLATensorPtr& src,
                             c10::string_view reduce, bool include_self) {
   return input->CreateFrom(torch::lazy::MakeNode<ScatterReduce>(
-      input->GetIrValue(), index->GetIrValue(), src->GetIrValue(),
-      reduce, include_self,
+      input->GetIrValue(), index->GetIrValue(), src->GetIrValue(), reduce,
+      include_self,
       torch::lazy::GetCanonicalDimensionIndex(dim,
                                               input->shape().get().rank())));
 }

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -715,6 +715,10 @@ XLATensorPtr scatter_add(const XLATensorPtr& input, int64_t dim,
 XLATensorPtr scatter_add(const XLATensorPtr& input, int64_t dim,
                          const XLATensorPtr& index, const at::Scalar& value);
 
+XLATensorPtr scatter_reduce(const XLATensorPtr& input, int64_t dim,
+                            const XLATensorPtr& index, const XLATensorPtr& src,
+                            c10::string_view reduce, bool include_self);
+
 XLATensorPtr select(const XLATensorPtr& input, int64_t dim, int64_t index);
 
 void selu_(XLATensorPtr& input);

--- a/torch_xla/csrc/xla_lower_util.cpp
+++ b/torch_xla/csrc/xla_lower_util.cpp
@@ -634,6 +634,40 @@ XlaOpCombiner NumericAddCombiner() {
   };
 }
 
+XlaOpCombiner NumericMulCombiner() {
+  return [](xla::XlaOp x, xla::XlaOp y) -> xla::XlaOp {
+    xla::XlaOp numeric_x = ConvertToNumeric(x);
+    xla::XlaOp numeric_y = ConvertToNumeric(y);
+    xla::XlaOp numeric_sum = numeric_x * numeric_y;
+    return ConvertTo(numeric_sum, XlaHelpers::TypeOfXlaOp(numeric_sum),
+                     XlaHelpers::TypeOfXlaOp(x),
+                     /*device=*/nullptr);
+  };
+}
+
+XlaOpCombiner NumericMinCombiner() {
+  return [](xla::XlaOp x, xla::XlaOp y) -> xla::XlaOp {
+    xla::XlaOp numeric_x = ConvertToNumeric(x);
+    xla::XlaOp numeric_y = ConvertToNumeric(y);
+    xla::XlaOp numeric_sum = xla::Min(numeric_x, numeric_y);
+    //xla::XlaOp numeric_sum = xla::Min(numeric_x, numeric_y);
+    return ConvertTo(numeric_sum, XlaHelpers::TypeOfXlaOp(numeric_sum),
+                     XlaHelpers::TypeOfXlaOp(x),
+                     /*device=*/nullptr);
+  };
+}
+
+XlaOpCombiner NumericMaxCombiner() {
+  return [](xla::XlaOp x, xla::XlaOp y) -> xla::XlaOp {
+    xla::XlaOp numeric_x = ConvertToNumeric(x);
+    xla::XlaOp numeric_y = ConvertToNumeric(y);
+    xla::XlaOp numeric_sum = xla::Max(numeric_x, numeric_y);
+    return ConvertTo(numeric_sum, XlaHelpers::TypeOfXlaOp(numeric_sum),
+                     XlaHelpers::TypeOfXlaOp(x),
+                     /*device=*/nullptr);
+  };
+}
+
 xla::XlaOp CreateScatter(const torch::lazy::BackendDevice& device,
                          xla::XlaOp input, xla::XlaOp index, xla::XlaOp source,
                          int64_t dim, const ScatterOptions& options) {

--- a/torch_xla/csrc/xla_lower_util.cpp
+++ b/torch_xla/csrc/xla_lower_util.cpp
@@ -650,7 +650,7 @@ XlaOpCombiner NumericMinCombiner() {
     xla::XlaOp numeric_x = ConvertToNumeric(x);
     xla::XlaOp numeric_y = ConvertToNumeric(y);
     xla::XlaOp numeric_sum = xla::Min(numeric_x, numeric_y);
-    //xla::XlaOp numeric_sum = xla::Min(numeric_x, numeric_y);
+    // xla::XlaOp numeric_sum = xla::Min(numeric_x, numeric_y);
     return ConvertTo(numeric_sum, XlaHelpers::TypeOfXlaOp(numeric_sum),
                      XlaHelpers::TypeOfXlaOp(x),
                      /*device=*/nullptr);

--- a/torch_xla/csrc/xla_lower_util.h
+++ b/torch_xla/csrc/xla_lower_util.h
@@ -65,6 +65,12 @@ using XlaOpCombiner = std::function<xla::XlaOp(xla::XlaOp, xla::XlaOp)>;
 
 XlaOpCombiner NumericAddCombiner();
 
+XlaOpCombiner NumericMulCombiner();
+
+XlaOpCombiner NumericMinCombiner();
+
+XlaOpCombiner NumericMaxCombiner();
+
 struct ScatterOptions {
   explicit ScatterOptions(XlaOpCombiner combiner)
       : combiner(std::move(combiner)) {}

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -279,6 +279,7 @@ supported:
   - scatter.value
   - scatter.value_reduce
   - scatter_add
+  - scatter_reduce.two
   - select.int
   - selu_
   - sigmoid


### PR DESCRIPTION
In this PR, I added the OP lowering pass for `scatter_reduce` ([link](https://pytorch.org/docs/stable/generated/torch.Tensor.scatter_reduce_.html#torch.Tensor.scatter_reduce_)). For this initial support, only the following reduce modes are supported: `sum`, `prod`, `amin`, and `amax`. Moreover, the option for `include_self` must be `true` (which is also by default).