### PR TITLE
[Functionalization] Re-enable some of the dynamic shape test

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -11,7 +11,6 @@ dev = xm.xla_device()
 
 class TestDynamicShapes(unittest.TestCase):
 
-  @unittest.skip("Needs to lower ne")
   def test_simple_expand(self):
     size1 = 5
     size2 = 2
@@ -26,7 +25,6 @@ class TestDynamicShapes(unittest.TestCase):
     t6_cpu = t6.cpu()
     self.assertEqual(t6_cpu.shape[0], 2)
 
-  @unittest.skip("Needs to lower ne")
   def test_simple_expand_on_2d_tensor(self):
     size1 = 5
     size2 = 2
@@ -68,7 +66,6 @@ class TestDynamicShapes(unittest.TestCase):
     a3 = a2.shape[0] + 3  # tests wrap
     self.assertIsInstance(a3, torch.SymInt)
 
-  @unittest.skip("Needs to lower ne")
   def test_sizeAdd(self):
     size1 = 5
     size2 = 2
@@ -120,6 +117,23 @@ class TestDynamicShapes(unittest.TestCase):
     dyn_size = t2.shape[0] < t2.shape[1]
     self.assertGreater(met.counter_value("xla::size_lt"), 0)
     # Exercises SizeLt::getDynamicValue.
+    dynamic_size = int(dyn_size)
+    self.assertEqual(dynamic_size, 1)
+
+  def test_sizeNe(self):
+    met.clear_all()
+
+    size1 = 5
+    size2 = 2
+    t1 = torch.zeros([size1, size2], device=dev)
+    t1[3][0] = 1
+    # t2 has size [<=10, 2]
+    t2 = torch.nonzero(t1)
+    # Create a SizeAdd IR node.
+    # t2.shape[1] generates a SizeConstant node.
+    dyn_size = t2.shape[0] != t2.shape[1]
+    self.assertGreater(met.counter_value("xla::size_ne"), 0)
+    # Exercises SizeNe::getDynamicValue.
     dynamic_size = int(dyn_size)
     self.assertEqual(dynamic_size, 1)
 

--- a/torch_xla/csrc/ops/dynamic_ir.cpp
+++ b/torch_xla/csrc/ops/dynamic_ir.cpp
@@ -118,6 +118,28 @@ int64_t SizeEq::getDynamicValue() const {
 
 std::string SizeEq::ToString() const { return "aten::eq_size"; }
 
+SizeNe::SizeNe(torch::lazy::Value a, torch::lazy::Value b)
+    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::ne")},
+              {a, b},
+              xla::ShapeUtil::MakeShape(
+                  GetShapeDimensionType(/*device=*/nullptr), {}),
+              1) {
+  const torch::lazy::DimensionNode* dim_node_0 = DimCast(operand(0));
+  const torch::lazy::DimensionNode* dim_node_1 = DimCast(operand(1));
+  XLA_CHECK(dim_node_0);
+  XLA_CHECK(dim_node_1);
+};
+
+int64_t SizeNe::getDynamicValue() const {
+  const torch::lazy::DimensionNode* dim_node_0 = DimCast(operand(0));
+  const torch::lazy::DimensionNode* dim_node_1 = DimCast(operand(1));
+  XLA_CHECK(dim_node_0);
+  XLA_CHECK(dim_node_1);
+  return dim_node_0->getDynamicValue() != dim_node_1->getDynamicValue() ? 1 : 0;
+}
+
+std::string SizeNe::ToString() const { return "aten::ne_size"; }
+
 SizeGe::SizeGe(torch::lazy::Value a, torch::lazy::Value b)
     : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::ge")},
               {a, b},

--- a/torch_xla/csrc/ops/dynamic_ir.h
+++ b/torch_xla/csrc/ops/dynamic_ir.h
@@ -68,6 +68,21 @@ class SizeEq : public XlaNode, public torch::lazy::DimensionNode {
   }
 };
 
+class SizeNe : public XlaNode, public torch::lazy::DimensionNode {
+ public:
+  SizeNe(torch::lazy::Value a, torch::lazy::Value b);
+  int64_t getDynamicValue() const override;
+  int64_t getStaticValue() const override {
+    TORCH_CHECK(false, "Comparison operators should be using getDynamicValue");
+  }
+  bool isSymbolic() const override { return true; }
+  std::string ToString() const override;
+  virtual XlaOpVector Lower(LoweringContext* loctx) const override {
+    // TODO: not sure we will ever need it?
+    TORCH_CHECK(false, "Lowering comparison nodes isn't supported yet!");
+  }
+};
+
 class SizeGe : public XlaNode, public torch::lazy::DimensionNode {
  public:
   SizeGe(torch::lazy::Value a, torch::lazy::Value b);

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -607,6 +607,11 @@ bool XLATensor::ShouldSyncIrNode() {
   return this->data()->ir_value->op() != xla_device_data;
 }
 
+bool XLASymNodeImpl::is_bool() {
+  // TODO: handle not is int
+  return true;
+}
+
 bool XLASymNodeImpl::is_int() {
   // TODO: handle not is int
   return true;
@@ -663,8 +668,10 @@ c10::SymNode XLASymNodeImpl::eq(const c10::SymNode& other) {
 }
 
 c10::SymNode XLASymNodeImpl::ne(const c10::SymNode& other) {
-  XLA_CHECK(false) << "XLASymNodeImpl::" << __FUNCTION__
-                   << " has not been implemented.";
+  TORCH_LAZY_FN_COUNTER("xla::size_");
+  auto p_other = dynamic_cast<XLASymNodeImpl*>(other.get());
+  auto n_ne = torch::lazy::MakeNode<SizeNe>(node(), p_other->node());
+  return c10::make_intrusive<XLASymNodeImpl>(n_ne);
 }
 
 c10::SymNode XLASymNodeImpl::gt(const c10::SymNode& other) {
@@ -744,6 +751,10 @@ int64_t XLASymNodeImpl::guard_int(const char* file, int64_t line) {
 double XLASymNodeImpl::guard_float(const char* file, int64_t line) {
   XLA_CHECK(false) << "XLASymNodeImpl::" << __FUNCTION__
                    << " has not been implemented.";
+}
+
+bool XLASymNodeImpl::guard_bool(const char* file, int64_t line) {
+  return bool_();
 }
 
 int64_t XLASymNodeImpl::int_() {

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -609,8 +609,10 @@ bool XLATensor::ShouldSyncIrNode() {
 
 bool XLASymNodeImpl::is_bool() {
   auto op = node()->op().op;
-  // Reference: https://github.com/pytorch/pytorch/blob/master/torch/fx/experimental/symbolic_shapes.py#L403
-  if (op == at::aten::eq || op == at::aten::ne || op == at::aten::ge || op == at::aten::lt) {
+  // Reference:
+  // https://github.com/pytorch/pytorch/blob/master/torch/fx/experimental/symbolic_shapes.py#L403
+  if (op == at::aten::eq || op == at::aten::ne || op == at::aten::ge ||
+      op == at::aten::lt) {
     return true;
   }
   return false;

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -608,8 +608,12 @@ bool XLATensor::ShouldSyncIrNode() {
 }
 
 bool XLASymNodeImpl::is_bool() {
-  // TODO: handle not is int
-  return true;
+  auto op = node()->op().op;
+  // Reference: https://github.com/pytorch/pytorch/blob/master/torch/fx/experimental/symbolic_shapes.py#L403
+  if (op == at::aten::eq || op == at::aten::ne || op == at::aten::ge || op == at::aten::lt) {
+    return true;
+  }
+  return false;
 }
 
 bool XLASymNodeImpl::is_int() {
@@ -754,6 +758,7 @@ double XLASymNodeImpl::guard_float(const char* file, int64_t line) {
 }
 
 bool XLASymNodeImpl::guard_bool(const char* file, int64_t line) {
+  // TODO: Take advantages of file and line.
   return bool_();
 }
 

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -30,6 +30,7 @@ namespace torch_xla {
 class TORCH_API XLASymNodeImpl : public c10::SymNodeImpl {
  public:
   XLASymNodeImpl(torch::lazy::NodePtr ptr) : node_(std::move(ptr)) {}
+  bool is_bool() override;
   bool is_int() override;
   bool is_float() override;
   c10::SymNode add(const c10::SymNode& other) override;
@@ -56,6 +57,7 @@ class TORCH_API XLASymNodeImpl : public c10::SymNodeImpl {
   c10::SymNode wrap_float(double num) override;
   int64_t guard_int(const char* file, int64_t line) override;
   double guard_float(const char* file, int64_t line) override;
+  bool guard_bool(const char* file, int64_t line) override;
   int64_t int_() override;
   bool bool_() override;
   std::string str() override;


### PR DESCRIPTION
Summary:
The dynamic shape tests are broken because of upstream changes that decompose dynamic ops into different ways. Adds new lowering to fix that.

Corresponding upstream changes for SymBool: https://github.com/pytorch/pytorch/pull/92149.

Test Plan:
CI