### PR TITLE
Optimize Dynamo Training Execute

### DIFF
--- a/test/dynamo/test_num_output.py
+++ b/test/dynamo/test_num_output.py
@@ -104,3 +104,8 @@ class TestNumOutput(unittest.TestCase):
   def test_direct_return_with_duplicated_inplace_update(self):
     self.do_test(
         DirectReturnWithDuplicatedInplaceUpdateModule, expected_num_output=3)
+
+
+if __name__ == '__main__':
+  test = unittest.main()
+  sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/torch_xla/core/dynamo_bridge.py
+++ b/torch_xla/core/dynamo_bridge.py
@@ -315,7 +315,10 @@ def extract_compiled_graph(xla_model: torch.fx.GraphModule, xla_args):
     if debug:
       print(f"optimized_mod takes {time.time() - enter_ts} seconds overall")
 
-    xm.mark_step()
+    if any(
+        torch_xla._XLAC._check_device_tensor_need_materialization(
+            str(xm.xla_device()))):
+      xm.mark_step()
     none_remover.add_nones(result)
     return result
 

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -941,7 +941,7 @@ def _run_step_closures():
   return devctx
 
 
-def mark_step():
+def mark_step(wait=False):
   if xu.getenv_as('XLA_EMIT_STEPLOG', bool, False):
     print(
         'torch_xla.core.xla_model::mark_step\n',
@@ -950,7 +950,7 @@ def mark_step():
         flush=True)
   torch_xla._XLAC._xla_step_marker(
       torch_xla._XLAC._xla_get_default_device(), [],
-      wait=xu.getenv_as('XLA_SYNC_WAIT', bool, False))
+      wait=xu.getenv_as('XLA_SYNC_WAIT', bool, wait))
   # Only emit metrics from the first local device index, to avoid emitting the
   # same values from different threads.
   if is_master_ordinal():

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -792,6 +792,37 @@ std::string GetPyTypeString(py::handle obj) {
   return type;
 }
 
+std::vector<bool> check_materialization_helper(
+    const std::vector<XLATensorPtr>& xtensors) {
+  std::vector<bool> need_materialization;
+  need_materialization.reserve(xtensors.size());
+  for (auto& xtensor : xtensors) {
+    if (!xtensor) {
+      // input tensor is not a xla tensor
+      need_materialization.push_back(false);
+    } else if (xtensor->CurrentDataHandle() != nullptr) {
+      // input tensor has xla_data which means it is already on device
+      need_materialization.push_back(false);
+    } else if (xtensor->CurrentIrValue().node != nullptr) {
+      torch::lazy::NodePtr node = xtensor->CurrentIrValue().node;
+      if (torch_xla::DeviceData::Cast(xtensor->CurrentIrValue().node.get()) !=
+          nullptr) {
+        need_materialization.push_back(false);
+      } else {
+        // input tensor is an IR other than DeviceData which means a
+        // compuation is required to get the value of this tensor.
+        need_materialization.push_back(true);
+      }
+    } else {
+      // TODO: maybe also handle it is a XLATensor with tensor_data case
+      XLA_CHECK(false)
+          << "_check_tensor_need_materialization "
+             "currently does not handle XLATensor without XLAData and IR";
+    }
+  }
+  return need_materialization;
+}
+
 void BuildProfilerSubmodule(py::module* m) {
   py::module profiler = m->def_submodule("profiler", "Profiler integration");
   py::class_<xla::profiler::ProfilerServer,
@@ -1633,38 +1664,26 @@ void InitXlaModuleBindings(py::module m) {
         });
 
   // Return true if value of the tensor requires a computation.
-  m.def(
-      "_check_tensor_need_materialization",
-      [](const std::vector<at::Tensor>& tensors) -> std::vector<bool> {
-        std::vector<bool> need_materialization;
-        need_materialization.reserve(tensors.size());
-        for (auto& tensor : tensors) {
-          auto xtensor = bridge::TryGetXlaTensor(tensor);
-          if (!xtensor) {
-            // input tensor is not a xla tensor
-            need_materialization.push_back(false);
-          } else if (xtensor->CurrentDataHandle() != nullptr) {
-            // input tensor has xla_data which means it is already on device
-            need_materialization.push_back(false);
-          } else if (xtensor->CurrentIrValue().node != nullptr) {
-            torch::lazy::NodePtr node = xtensor->CurrentIrValue().node;
-            if (torch_xla::DeviceData::Cast(
-                    xtensor->CurrentIrValue().node.get()) != nullptr) {
-              need_materialization.push_back(false);
-            } else {
-              // input tensor is an IR other than DeviceData which means a
-              // compuation is required to get the value of this tensor.
-              need_materialization.push_back(true);
-            }
-          } else {
-            // TODO: maybe also handle it is a XLATensor with tensor_data case
-            XLA_CHECK(false)
-                << "_check_tensor_need_materialization "
-                   "currently does not handle XLATensor without XLAData and IR";
+  m.def("_check_tensor_need_materialization",
+        [](const std::vector<at::Tensor>& tensors) -> std::vector<bool> {
+          std::vector<XLATensorPtr> xtensors;
+          xtensors.reserve(tensors.size());
+          for (const at::Tensor& tensor : tensors) {
+            xtensors.push_back(bridge::TryGetXlaTensor(tensor));
           }
-        }
-        return need_materialization;
-      });
+          return check_materialization_helper(xtensors);
+        });
+
+  // Return true if value of the any tensor in this devicerequires a
+  // computation.
+  m.def("_check_device_tensor_need_materialization",
+        [](const std::string& device_str) -> std::vector<bool> {
+          auto opt_device = GetOptionalDevice(device_str);
+          std::vector<XLATensorPtr> xtensors =
+              XLAGraphExecutor::Get()->GetLiveTensors(
+                  opt_device ? &opt_device.value() : nullptr);
+          return check_materialization_helper(xtensors);
+        });
 
   m.def("_get_graph_hash", [](const std::vector<at::Tensor>& tensors) {
     std::vector<XLATensorPtr> xtensors;

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -161,8 +161,7 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
   ComputationCache* GetComputationCache();
 
   std::vector<torch::lazy::BackendDataPtr> ExecuteComputationWithBarrier(
-      torch::lazy::hash_t hash,
-      std::vector<torch::lazy::BackendDataPtr> arguments,
+      torch::lazy::hash_t hash, const std::vector<at::IValue>& graph_inputs,
       const torch::lazy::BackendDevice& device);
 
   void ClearPendingIrs(std::vector<XLATensorPtr> tensors,


### PR DESCRIPTION
This will help https://github.com/pytorch/xla/issues/4475

Currently each dynamo training step(without optimizer) will result in 5 graph execution

They are
1. `sync_multi` to sync input to fwd graph
2. Execute the fwd graph
3. `sync_multi` to sync input to bwd graph
4. Execute bwd graph
5. `mark_step` at the end of `optimized_mod`

My finding is that
1. The first graph executation is uecessary. It is triggered by `GetXlaData` in 
https://github.com/pytorch/xla/blob/661ab6d27bdf94483c141a6c218e8be9712b5528/torch_xla/csrc/init_python_bindings.cpp#L1700-L1702
However if I check the HLO, it is actually a `DeviceData` IR(not sure why). We don't need to call `applyPendingGraph` to trigger execeution to retrive the XLAData. Hence my fix in `GetXlaData`

2. The graph 3 and graph 5 are both triggered by `aot_autograd`. Instead of use `xla_sync_multi` to only sync the partial pending tensors and use `mark_step` to sync the rest, we can just do one `mark_step` in the beginning to combine 2 graphs. One thing to note is that we need to make first `mark_step` to be blocking.

With above 2 fixes, we can cut graph from 5 -> 3. 

With the latest change, I am seeing a much more promising result
<google-sheets-html-origin><style type="text/css"><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}--></style>

model | Old Speed Up | new Speed up
-- | -- | --
resnet50 | 0.758 | 0.937
resnet18 | 0.66 | 1.003
BERT_pytorch | 1.441 | 1.869
resnext50_32x4d | 0.87 | 1.139
alexnet | 0.632 | 0.802
mobilenet_v2 | 0.549 | 0.672
mnasnet1_0 | 0.698 | 0.967
vgg16 | 0.712 | 0.742
timm_vision_transformer | 1.275 | 1.69
squeezenet1_1 | 0.72 | 0.958
Avg | 0.8315 | 1.0779