### PR TITLE
Move XLA testing to Python-3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,8 @@ launch_docker_and_build: &launch_docker_and_build
     # To allow the upstream workflow to access PyTorch/XLA build images, we
     # need to have them in the ECR. This is not expensive, and only pushes it
     # if image layers are not present in the repo.
-    docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:v0.8 >/dev/null
-    docker push ${ECR_DOCKER_IMAGE_BASE}:v0.8 >/dev/null
+    docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:v0.9 >/dev/null
+    docker push ${ECR_DOCKER_IMAGE_BASE}:v0.9 >/dev/null
     sudo pkill -SIGHUP dockerd
     # To enable remote caching, use SCCACHE_BUCKET=${SCCACHE_BUCKET}
     # To disable remote caching, use SCCACHE_BUCKET=${LOCAL_BUCKET}
@@ -87,7 +87,6 @@ calculate_docker_image: &calculate_docker_image
     # For staging our build image in ECR for upstream testing
     echo "declare -x ECR_DOCKER_IMAGE_BASE=308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/xla_base" >> "${BASH_ENV}"
     # For PyTorch/XLA CI workflow, we only pull & push to gcr.io
-    BASE_IMAGE_TAG="3.7-11.2.0-cudnn8-devel-ubuntu18.04-mini"
     echo "declare -x GCR_DOCKER_IMAGE=gcr.io/tpu-pytorch/xla_base:latest" >> "${BASH_ENV}"
 
 run_build: &run_build

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -3,7 +3,7 @@
 ARG base_image="nvidia/cuda:11.2.0-cudnn8-devel-ubuntu18.04"
 FROM "${base_image}"
 
-ARG python_version="3.7"
+ARG python_version="3.8"
 ARG cuda="1"
 ARG cuda_compute="5.2,7.5"
 ARG cc="clang-8"


### PR DESCRIPTION
As 3.7 is approaching EOL and getting deprecated in pytorch/pytorch

Also, remove misleading `BASE_IMAGE_TAG` which is defined, but not used anywhere according to
https://cs.github.com/?scopeName=All+repos&scope=&q=BASE_IMAGE_TAG+repo%3Apytorch%2Fxla