### PR TITLE
Enable python 3.8 and resolve dependency issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,8 @@ launch_docker_and_build: &launch_docker_and_build
     # To allow the upstream workflow to access PyTorch/XLA build images, we
     # need to have them in the ECR. This is not expensive, and only pushes it
     # if image layers are not present in the repo.
+    # Note: disable the following 2 lines while testing a new image, so we do not
+    # push to the upstream.
     docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:v0.9 >/dev/null
     docker push ${ECR_DOCKER_IMAGE_BASE}:v0.9 >/dev/null
     sudo pkill -SIGHUP dockerd

--- a/.circleci/docker/install_conda.sh
+++ b/.circleci/docker/install_conda.sh
@@ -46,7 +46,7 @@ function install_and_setup_conda() {
   /usr/bin/yes | pip install "cmake>=3.18" --upgrade
   /usr/bin/yes | pip install absl-py
   # Additional PyTorch requirements
-  /usr/bin/yes | pip install scikit-image scipy==1.1.0  # >1.1.0 breaks PyTorch tests
+  /usr/bin/yes | pip install scikit-image scipy==1.6.3
   /usr/bin/yes | pip install boto3==1.16.34
   /usr/bin/yes | pip install mypy==0.812
   /usr/bin/yes | pip install psutil


### PR DESCRIPTION
CI docker image is now on Python 3.8, and requires scipy version bump.