### PR TITLE
Align the dynamo dump file with the lazy

### DIFF
--- a/test/dynamo/test_dynamo_graph_dump.py
+++ b/test/dynamo/test_dynamo_graph_dump.py
@@ -26,6 +26,7 @@ class DynamoGraphDumpTest(unittest.TestCase):
     save_file = os.getenv('XLA_SAVE_TENSORS_FILE')
     if not save_file:
       assert False, "This test should be run with XLA_SAVE_TENSORS_FILE"
+    save_file += '.0'
     device = xm.xla_device()
     xla_x = torch.tensor(100.0).to(device)
     xla_y = torch.tensor(200.0).to(device)

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -133,7 +133,8 @@ void XLAGraphExecutor::DeviceContextArena::SaveGraphAsString(
     torch::lazy::hash_t hash, absl::Span<const XLATensorPtr> tensors,
     const std::vector<size_t>* indices, DebugUtil::GraphFormat format) {
   static bool should_save_graph =
-      xla::sys_util::GetEnvOrdinalPath("XLA_SAVE_TENSORS_FILE", "") != "";
+      xla::sys_util::GetEnvOrdinalPath("XLA_SAVE_TENSORS_FILE", "",
+                                       GetCurrentDevice().ordinal()) != "";
   if (should_save_graph &&
       hash_to_graph_map.find(hash) == hash_to_graph_map.end()) {
     hash_to_graph_map[hash] =
@@ -410,8 +411,8 @@ torch::lazy::hash_t XLAGraphExecutor::GetGraphHash(
 
 void XLAGraphExecutor::MaybeDumpGraph(std::string name,
                                       torch::lazy::hash_t hash) {
-  static const std::string save_file =
-      xla::sys_util::GetEnvOrdinalPath("XLA_SAVE_TENSORS_FILE", "");
+  thread_local const std::string save_file = xla::sys_util::GetEnvOrdinalPath(
+      "XLA_SAVE_TENSORS_FILE", "", GetCurrentDevice().ordinal());
   if (!save_file.empty()) {
     std::string graph = DeviceContextArena::Get()->GetGraphByHash(hash);
     if (graph.size() == 0) {


### PR DESCRIPTION
Due to https://github.com/pytorch/xla/commit/b9efeeb4f7a86ec7e7394730128e7312d7c86ca3, dynamo and lazy currently dumps to 2 different file.