### PR TITLE
Reset Nvidia cuda-keyring in the CI env setup

### DIFF
--- a/.circleci/setup_ci_environment.sh
+++ b/.circleci/setup_ci_environment.sh
@@ -27,10 +27,9 @@ echo \
   $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 # Set up NVIDIA docker repo
+distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
 curl -s -L --retry 3 https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
-echo "deb https://nvidia.github.io/nvidia-container-runtime/ubuntu20.04/amd64 /" | sudo tee -a /etc/apt/sources.list.d/nvidia-docker.list
-echo "deb https://nvidia.github.io/libnvidia-container/ubuntu20.04/amd64 /" | sudo tee -a /etc/apt/sources.list.d/nvidia-docker.list
-echo "deb https://nvidia.github.io/nvidia-docker/ubuntu20.04/amd64 /" | sudo tee -a /etc/apt/sources.list.d/nvidia-docker.list
+curl -k -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
 
 # Remove unnecessary sources
 sudo rm -f /etc/apt/sources.list.d/google-chrome.list


### PR DESCRIPTION
Address the CI breakage,
```
Hit:16 http://ppa.launchpad.net/openjdk-r/ppa/ubuntu focal InRelease
Err:6 https://cli-assets.heroku.com/apt ./ InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 536F8F1DE80F6A35
Get:17 https://nvidia.github.io/nvidia-docker/ubuntu20.04/amd64  Packages [4,488 B]
Reading package lists... Done        
E: The repository 'https://nvidia.github.io/libnvidia-container/ubuntu20.04/amd64  Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: https://cli-assets.heroku.com/apt ./ InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 536F8F1DE80F6A35

Exited with code exit status 100
```