### PR TITLE
Fix bug in ShardTensor to generate correct shards for each device

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -58,11 +58,14 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     expected = t + t
 
     xt = t.to(xm.xla_device())
-    xs.mark_sharding(xt, self._get_mesh((1, 1, 1, self.n_devices)),
+    # Shard along two axes if four or more devices are available
+    z_dim = 2 if self.n_devices >= 4 else 1
+    xs.mark_sharding(xt, self._get_mesh((1, 1, z_dim, self.n_devices // z_dim)),
                      (0, 1, 2, 3))
-    annotation = '{devices=[1,1,1,%d]%s}' % (self.n_devices, ','.join([
-        str(i) for i in range(self.n_devices)
-    ])) if self.n_devices > 1 else '{maximal device=0}'
+    annotation = '{devices=[1,1,%d,%d]%s}' % (
+        z_dim, self.n_devices // z_dim,
+        ','.join([str(i) for i in range(self.n_devices)
+                 ])) if self.n_devices > 1 else '{maximal device=0}'
     self.assertEqual(annotation, torch_xla._XLAC._get_xla_sharding_spec(xt))
 
     actual = (xt + xt).cpu()


### PR DESCRIPTION
During multihost testing, it was found that the shard tiling was not being applied consistently, resulting in repeated results in the resulting tensor.

This change ensures that the tiles are generated based on the row-major ordering of the tile index. It also generalizes the logic to allow for higher than 5-dimensional sharding.

This issue was originally missed in unit tests because all devices were on a single axis. This change updates `test_mark_sharding_4d` to shard along two axes to check the logic here.