### PR TITLE
Implement missing XLASymNodeImpl::Sub

### DIFF
--- a/test/cpp/test_ir.cpp
+++ b/test/cpp/test_ir.cpp
@@ -142,7 +142,7 @@ TEST_F(IrTest, TestSizeNodeDynamic) {
 
   torch::lazy::NodePtr size_node_nonzero_0 =
       torch::lazy::MakeNode<SizeNode>(nonzero_node, 0);
-  EXPECT_EQ(size_node_nonzero_0->ToString(), "aten::size_size");
+  EXPECT_EQ(size_node_nonzero_0->ToString(), "aten::size");
   torch::lazy::NodePtr size_node_nonzero_1 =
       torch::lazy::MakeNode<SizeNode>(nonzero_node, 1);
   std::shared_ptr<torch::lazy::DimensionNode> dim_node_0 =
@@ -172,7 +172,7 @@ TEST_F(IrTest, TestSizeAddNode) {
       torch::lazy::MakeNode<SizeNode>(scalar_node, 1);
   torch::lazy::NodePtr size_node_add =
       torch::lazy::MakeNode<SizeAdd>(size_node_0, size_node_1);
-  EXPECT_EQ(size_node_add->ToString(), "aten::add_size");
+  EXPECT_EQ(size_node_add->ToString(), "aten::size_add");
   std::shared_ptr<torch::lazy::DimensionNode> dim_node_add =
       std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node_add);
 
@@ -250,7 +250,7 @@ TEST_F(IrTest, TestSizeMulNode) {
       torch::lazy::MakeNode<SizeNode>(scalar_node, 1);
   torch::lazy::NodePtr size_node_mul =
       torch::lazy::MakeNode<SizeMul>(size_node_0, size_node_1);
-  EXPECT_EQ(size_node_mul->ToString(), "aten::mul_size");
+  EXPECT_EQ(size_node_mul->ToString(), "aten::size_mul");
   std::shared_ptr<torch::lazy::DimensionNode> dim_node_mul =
       std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node_mul);
 
@@ -298,7 +298,7 @@ TEST_F(IrTest, TestSizeDivNode) {
       torch::lazy::MakeNode<SizeNode>(scalar_node, 1);
   torch::lazy::NodePtr size_node_div =
       torch::lazy::MakeNode<SizeDiv>(size_node_0, size_node_1);
-  EXPECT_EQ(size_node_div->ToString(), "aten::div_size");
+  EXPECT_EQ(size_node_div->ToString(), "aten::size_div");
   std::shared_ptr<torch::lazy::DimensionNode> dim_node_div =
       std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node_div);
 

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -99,6 +99,27 @@ class TestDynamicShapes(unittest.TestCase):
     t4 = t3.expand(dyn_size)
     self.assertEqual(t4.size(0), 3)
 
+  def test_sizeSub(self):
+    size1 = 5
+    size2 = 2
+    t1 = torch.zeros([size1, size2], device=dev)
+    t1[0][0] = 1
+    t1[1][0] = 1
+    t1[2][0] = 1
+    # t2 has size [<=10, 2] with dynamic size [3, 2]
+    t2 = torch.nonzero(t1)
+    dyn_size = t2.shape[0] - t2.shape[1]
+    # Exercises SizeSub::getDynamicValue.
+    dynamic_size = int(dyn_size)
+    self.assertEqual(dynamic_size, 1)
+    # Exercise SizeAdd::getStaticValue.
+    self.assertEqual(str(dyn_size), '<=8')
+
+    t3 = torch.ones(1, device=dev)
+    # Exercise SizeAdd::Lower.
+    t4 = t3.expand(dyn_size)
+    self.assertEqual(t4.size(0), 1)
+
   def get_dynamic_tensor(self):
     a1 = torch.tensor([[1, 0, 0, 5, 0, 6]], device=dev)
     a2 = torch.nonzero(a1)

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -3,6 +3,7 @@ import sys
 import unittest
 import torch, torch_xla
 import torch_xla.core.xla_model as xm
+import torch_xla.debug.metrics as met
 
 pd = torch._C._EnablePythonDispatcher()
 dev = xm.xla_device()
@@ -109,6 +110,7 @@ class TestDynamicShapes(unittest.TestCase):
     # t2 has size [<=10, 2] with dynamic size=[3, 2]
     t2 = torch.nonzero(t1)
     dyn_size = t2.shape[0] - t2.shape[1]
+    self.assertGreater(met.counter_value("xla::size_sub"), 0)
     # Exercises SizeSub::getDynamicValue.
     dynamic_size = int(dyn_size)
     self.assertEqual(dynamic_size, 1)

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -106,17 +106,17 @@ class TestDynamicShapes(unittest.TestCase):
     t1[0][0] = 1
     t1[1][0] = 1
     t1[2][0] = 1
-    # t2 has size [<=10, 2] with dynamic size [3, 2]
+    # t2 has size [<=10, 2] with dynamic size=[3, 2]
     t2 = torch.nonzero(t1)
     dyn_size = t2.shape[0] - t2.shape[1]
     # Exercises SizeSub::getDynamicValue.
     dynamic_size = int(dyn_size)
     self.assertEqual(dynamic_size, 1)
-    # Exercise SizeAdd::getStaticValue.
+    # Exercise SizeSub::getStaticValue.
     self.assertEqual(str(dyn_size), '<=8')
 
     t3 = torch.ones(1, device=dev)
-    # Exercise SizeAdd::Lower.
+    # Exercise SizeSub::Lower.
     t4 = t3.expand(dyn_size)
     self.assertEqual(t4.size(0), 1)
 

--- a/torch_xla/csrc/ops/dynamic_ir.cpp
+++ b/torch_xla/csrc/ops/dynamic_ir.cpp
@@ -97,11 +97,13 @@ XlaOpVector SizeAdd::Lower(LoweringContext* loctx) const {
 }
 
 SizeSub::SizeSub(torch::lazy::Value a, torch::lazy::Value b)
-    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::sub")}, // TODO: should it be something like aten::size_sub? Try it out.
+    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString(
+                  "aten::sub")},  // TODO: should it be something like
+                                  // aten::size_sub? Try it out.
               {a, b},
               xla::ShapeUtil::MakeShape(
-                  GetShapeDimensionType(/*device*/nullptr), {}),
-              1){
+                  GetShapeDimensionType(/*device*/ nullptr), {}),
+              1) {
   const torch::lazy::DimensionNode* dim_node_0 = DimCast(operand(0));
   const torch::lazy::DimensionNode* dim_node_1 = DimCast(operand(1));
   XLA_CHECK(dim_node_0);
@@ -114,7 +116,7 @@ int64_t SizeSub::getDynamicValue() const {
   const torch::lazy::DimensionNode* dim_node_1 = DimCast(operand(1));
   XLA_CHECK(dim_node_0);
   XLA_CHECK(dim_node_1);
-  return dim_node_0->getDynamicValue() - dim_node_1->getDynamicValue(); 
+  return dim_node_0->getDynamicValue() - dim_node_1->getDynamicValue();
 }
 
 std::string SizeSub::ToString() const { return "aten::sub_size"; }

--- a/torch_xla/csrc/ops/dynamic_ir.cpp
+++ b/torch_xla/csrc/ops/dynamic_ir.cpp
@@ -65,11 +65,12 @@ XlaOpVector SizeNode::Lower(LoweringContext* loctx) const {
 std::string SizeNode::ToString() const { return "aten::size"; }
 
 SizeAdd::SizeAdd(torch::lazy::Value a, torch::lazy::Value b)
-    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::size_add")},
-              {a, b},
-              xla::ShapeUtil::MakeShape(
-                  GetShapeDimensionType(/*device=*/nullptr), {}),
-              1) {
+    : XlaNode(
+          torch::lazy::OpKind{c10::Symbol::fromQualString("aten::size_add")},
+          {a, b},
+          xla::ShapeUtil::MakeShape(GetShapeDimensionType(/*device=*/nullptr),
+                                    {}),
+          1) {
   const torch::lazy::DimensionNode* dim_node_0 = DimCast(operand(0));
   const torch::lazy::DimensionNode* dim_node_1 = DimCast(operand(1));
   // SizeAdd can only be perfomed between two DimensionNode
@@ -154,11 +155,12 @@ SizeConstant::SizeConstant(int64_t val)
                  GetShapeDimensionType(/*device=*/nullptr), {})){};
 
 SizeMul::SizeMul(torch::lazy::Value a, torch::lazy::Value b)
-    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::size_mul")},
-              {a, b},
-              xla::ShapeUtil::MakeShape(
-                  GetShapeDimensionType(/*device=*/nullptr), {}),
-              1) {
+    : XlaNode(
+          torch::lazy::OpKind{c10::Symbol::fromQualString("aten::size_mul")},
+          {a, b},
+          xla::ShapeUtil::MakeShape(GetShapeDimensionType(/*device=*/nullptr),
+                                    {}),
+          1) {
   const torch::lazy::DimensionNode* dim_node_0 = DimCast(operand(0));
   const torch::lazy::DimensionNode* dim_node_1 = DimCast(operand(1));
   // SizeMul can only be perfomed between two DimensionNode
@@ -186,11 +188,12 @@ XlaOpVector SizeMul::Lower(LoweringContext* loctx) const {
 }
 
 SizeDiv::SizeDiv(torch::lazy::Value a, torch::lazy::Value b)
-    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::size_div")},
-              {a, b},
-              xla::ShapeUtil::MakeShape(
-                  GetShapeDimensionType(/*device=*/nullptr), {}),
-              1) {
+    : XlaNode(
+          torch::lazy::OpKind{c10::Symbol::fromQualString("aten::size_div")},
+          {a, b},
+          xla::ShapeUtil::MakeShape(GetShapeDimensionType(/*device=*/nullptr),
+                                    {}),
+          1) {
   const torch::lazy::DimensionNode* dim_node_0 = DimCast(operand(0));
   const torch::lazy::DimensionNode* dim_node_1 = DimCast(operand(1));
   // SizeDiv can only be perfomed between two DimensionNode

--- a/torch_xla/csrc/ops/dynamic_ir.cpp
+++ b/torch_xla/csrc/ops/dynamic_ir.cpp
@@ -97,13 +97,12 @@ XlaOpVector SizeAdd::Lower(LoweringContext* loctx) const {
 }
 
 SizeSub::SizeSub(torch::lazy::Value a, torch::lazy::Value b)
-    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString(
-                  "aten::sub")},  // TODO: should it be something like
-                                  // aten::size_sub? Try it out.
-              {a, b},
-              xla::ShapeUtil::MakeShape(
-                  GetShapeDimensionType(/*device*/ nullptr), {}),
-              1) {
+    : XlaNode(
+          torch::lazy::OpKind{c10::Symbol::fromQualString("aten::size_sub")},
+          {a, b},
+          xla::ShapeUtil::MakeShape(GetShapeDimensionType(/*device*/ nullptr),
+                                    {}),
+          1) {
   const torch::lazy::DimensionNode* dim_node_0 = DimCast(operand(0));
   const torch::lazy::DimensionNode* dim_node_1 = DimCast(operand(1));
   XLA_CHECK(dim_node_0);

--- a/torch_xla/csrc/ops/dynamic_ir.cpp
+++ b/torch_xla/csrc/ops/dynamic_ir.cpp
@@ -62,10 +62,10 @@ XlaOpVector SizeNode::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::GetDimensionSize(input, this->dim_), loctx);
 }
 
-std::string SizeNode::ToString() const { return "aten::size_size"; }
+std::string SizeNode::ToString() const { return "aten::size"; }
 
 SizeAdd::SizeAdd(torch::lazy::Value a, torch::lazy::Value b)
-    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::add")},
+    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::size_add")},
               {a, b},
               xla::ShapeUtil::MakeShape(
                   GetShapeDimensionType(/*device=*/nullptr), {}),
@@ -88,7 +88,7 @@ int64_t SizeAdd::getDynamicValue() const {
   return dim_node_0->getDynamicValue() + dim_node_1->getDynamicValue();
 }
 
-std::string SizeAdd::ToString() const { return "aten::add_size"; }
+std::string SizeAdd::ToString() const { return "aten::size_add"; }
 
 XlaOpVector SizeAdd::Lower(LoweringContext* loctx) const {
   auto input1 = loctx->GetOutputOp(operand(0));
@@ -118,7 +118,7 @@ int64_t SizeSub::getDynamicValue() const {
   return dim_node_0->getDynamicValue() - dim_node_1->getDynamicValue();
 }
 
-std::string SizeSub::ToString() const { return "aten::sub_size"; }
+std::string SizeSub::ToString() const { return "aten::size_sub"; }
 
 XlaOpVector SizeSub::Lower(LoweringContext* loctx) const {
   xla::XlaOp input0 = loctx->GetOutputOp(operand(0));
@@ -127,7 +127,7 @@ XlaOpVector SizeSub::Lower(LoweringContext* loctx) const {
 }
 
 SizeEq::SizeEq(torch::lazy::Value a, torch::lazy::Value b)
-    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::eq")},
+    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::size_eq")},
               {a, b},
               xla::ShapeUtil::MakeShape(
                   GetShapeDimensionType(/*device=*/nullptr), {}),
@@ -146,7 +146,7 @@ int64_t SizeEq::getDynamicValue() const {
   return dim_node_0->getDynamicValue() == dim_node_1->getDynamicValue() ? 1 : 0;
 }
 
-std::string SizeEq::ToString() const { return "aten::eq_size"; }
+std::string SizeEq::ToString() const { return "aten::size_eq"; }
 
 SizeConstant::SizeConstant(int64_t val)
     : Scalar(c10::Scalar{val},
@@ -154,7 +154,7 @@ SizeConstant::SizeConstant(int64_t val)
                  GetShapeDimensionType(/*device=*/nullptr), {})){};
 
 SizeMul::SizeMul(torch::lazy::Value a, torch::lazy::Value b)
-    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::mul")},
+    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::size_mul")},
               {a, b},
               xla::ShapeUtil::MakeShape(
                   GetShapeDimensionType(/*device=*/nullptr), {}),
@@ -177,7 +177,7 @@ int64_t SizeMul::getDynamicValue() const {
   return dim_node_0->getDynamicValue() * dim_node_1->getDynamicValue();
 }
 
-std::string SizeMul::ToString() const { return "aten::mul_size"; }
+std::string SizeMul::ToString() const { return "aten::size_mul"; }
 
 XlaOpVector SizeMul::Lower(LoweringContext* loctx) const {
   auto input1 = loctx->GetOutputOp(operand(0));
@@ -186,7 +186,7 @@ XlaOpVector SizeMul::Lower(LoweringContext* loctx) const {
 }
 
 SizeDiv::SizeDiv(torch::lazy::Value a, torch::lazy::Value b)
-    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::div")},
+    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::size_div")},
               {a, b},
               xla::ShapeUtil::MakeShape(
                   GetShapeDimensionType(/*device=*/nullptr), {}),
@@ -213,7 +213,7 @@ int64_t SizeDiv::getDynamicValue() const {
   return dim_node_0->getDynamicValue() / dim_node_1->getDynamicValue();
 }
 
-std::string SizeDiv::ToString() const { return "aten::div_size"; }
+std::string SizeDiv::ToString() const { return "aten::size_div"; }
 
 XlaOpVector SizeDiv::Lower(LoweringContext* loctx) const {
   auto input1 = loctx->GetOutputOp(operand(0));

--- a/torch_xla/csrc/ops/dynamic_ir.h
+++ b/torch_xla/csrc/ops/dynamic_ir.h
@@ -82,16 +82,16 @@ class SizeAdd : public XlaNode, public torch::lazy::DimensionNode {
 };
 
 class SizeSub : public XlaNode, public torch::lazy::DimensionNode {
-  public:
-   SizeSub(torch::lazy::Value a, torch::lazy::Value b);
-   int64_t getDynamicValue() const override;
-   int64_t getStaticValue() const override { return upper_bound_; }
-   bool isSymbolic() const override { return true; }
-   std::string ToString() const override;
-   virtual XlaOpVector Lower(LoweringContext* loctx) const override;
+ public:
+  SizeSub(torch::lazy::Value a, torch::lazy::Value b);
+  int64_t getDynamicValue() const override;
+  int64_t getStaticValue() const override { return upper_bound_; }
+  bool isSymbolic() const override { return true; }
+  std::string ToString() const override;
+  virtual XlaOpVector Lower(LoweringContext* loctx) const override;
 
-  private:
-   int64_t upper_bound_;
+ private:
+  int64_t upper_bound_;
 };
 
 class SizeMul : public XlaNode, public torch::lazy::DimensionNode {

--- a/torch_xla/csrc/ops/dynamic_ir.h
+++ b/torch_xla/csrc/ops/dynamic_ir.h
@@ -92,7 +92,7 @@ class SizeSub : public XlaNode, public torch::lazy::DimensionNode {
 
   private:
    int64_t upper_bound_;
-}
+};
 
 class SizeMul : public XlaNode, public torch::lazy::DimensionNode {
  public:

--- a/torch_xla/csrc/ops/dynamic_ir.h
+++ b/torch_xla/csrc/ops/dynamic_ir.h
@@ -81,6 +81,19 @@ class SizeAdd : public XlaNode, public torch::lazy::DimensionNode {
   int64_t upper_bound_;
 };
 
+class SizeSub : public XlaNode, public torch::lazy::DimensionNode {
+  public:
+   SizeSub(torch::lazy::Value a, torch::lazy::Value b);
+   int64_t getDynamicValue() const override;
+   int64_t getStaticValue() const override { return upper_bound_; }
+   bool isSymbolic() const override { return true; }
+   std::string ToString() const override;
+   virtual XlaOpVector Lower(LoweringContext* loctx) const override;
+
+  private:
+   int64_t upper_bound_;
+}
+
 class SizeMul : public XlaNode, public torch::lazy::DimensionNode {
  public:
   SizeMul(torch::lazy::Value a, torch::lazy::Value b);

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -639,9 +639,9 @@ c10::SymNode XLASymNodeImpl::add(const c10::SymNode& other) {
 }
 
 c10::SymNode XLASymNodeImpl::sub(const c10::SymNode& other) {
-  torch_xla::XLASymNodeImpl p_other = dynamic_case<XLASymNodeImpl*>(other.get());
-  torch::lazy::NodePtr n_sub = torch::lazy::MakeNode<SizeSub>(node(), p_other->other());
-  return c10::make_instrusive<XLASymNodeImpl>(n_sub);
+  torch_xla::XLASymNodeImpl* p_other = dynamic_cast<XLASymNodeImpl*>(other.get());
+  torch::lazy::NodePtr n_sub = torch::lazy::MakeNode<SizeSub>(node(), p_other->node());
+  return c10::make_intrusive<XLASymNodeImpl>(n_sub);
 }
 
 c10::SymNode XLASymNodeImpl::mul(const c10::SymNode& other) {

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -639,8 +639,9 @@ c10::SymNode XLASymNodeImpl::add(const c10::SymNode& other) {
 }
 
 c10::SymNode XLASymNodeImpl::sub(const c10::SymNode& other) {
-  XLA_CHECK(false) << "XLASymNodeImpl::" << __FUNCTION__
-                   << " has not been implemented.";
+  torch_xla::XLASymNodeImpl p_other = dynamic_case<XLASymNodeImpl*>(other.get());
+  torch::lazy::NodePtr n_sub = torch::lazy::MakeNode<SizeSub>(node(), p_other->other());
+  return c10::make_instrusive<XLASymNodeImpl>(n_sub);
 }
 
 c10::SymNode XLASymNodeImpl::mul(const c10::SymNode& other) {

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -639,6 +639,8 @@ c10::SymNode XLASymNodeImpl::add(const c10::SymNode& other) {
 }
 
 c10::SymNode XLASymNodeImpl::sub(const c10::SymNode& other) {
+  TORCH_LAZY_FN_COUNTER("xla::size_");
+  
   torch_xla::XLASymNodeImpl* p_other =
       dynamic_cast<XLASymNodeImpl*>(other.get());
   torch::lazy::NodePtr n_sub =

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -640,7 +640,7 @@ c10::SymNode XLASymNodeImpl::add(const c10::SymNode& other) {
 
 c10::SymNode XLASymNodeImpl::sub(const c10::SymNode& other) {
   TORCH_LAZY_FN_COUNTER("xla::size_");
-  
+
   torch_xla::XLASymNodeImpl* p_other =
       dynamic_cast<XLASymNodeImpl*>(other.get());
   torch::lazy::NodePtr n_sub =

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -639,8 +639,10 @@ c10::SymNode XLASymNodeImpl::add(const c10::SymNode& other) {
 }
 
 c10::SymNode XLASymNodeImpl::sub(const c10::SymNode& other) {
-  torch_xla::XLASymNodeImpl* p_other = dynamic_cast<XLASymNodeImpl*>(other.get());
-  torch::lazy::NodePtr n_sub = torch::lazy::MakeNode<SizeSub>(node(), p_other->node());
+  torch_xla::XLASymNodeImpl* p_other =
+      dynamic_cast<XLASymNodeImpl*>(other.get());
+  torch::lazy::NodePtr n_sub =
+      torch::lazy::MakeNode<SizeSub>(node(), p_other->node());
   return c10::make_intrusive<XLASymNodeImpl>(n_sub);
 }
 


### PR DESCRIPTION
This is to unblock the failing dynamic shape tests when functionalization is enabled.