### PR TITLE
Make it an error when ask for a non symbolic size of a symbolic tensor

### DIFF
--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -114,6 +114,9 @@ void XLATensorImpl::shallow_copy_from(
 }
 
 at::IntArrayRef XLATensorImpl::sizes_custom() const {
+  if (sym_sizes_) {
+    XLA_CHECK(false) << "Asking for a non symbolic size of a symbolic tensor.";
+  }
   const_cast<XLATensorImpl*>(this)->SetupSizeProperties();
   return sizes_default();
 }

--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -114,9 +114,7 @@ void XLATensorImpl::shallow_copy_from(
 }
 
 at::IntArrayRef XLATensorImpl::sizes_custom() const {
-  if (sym_sizes_) {
-    XLA_CHECK(false) << "Asking for a non symbolic size of a symbolic tensor.";
-  }
+  XLA_CHECK(!has_symbolic_sizes_strides_) << "Cannot call sizes() on an XLA tensor with symbolic sizes/strides";
   const_cast<XLATensorImpl*>(this)->SetupSizeProperties();
   return sizes_default();
 }

--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -114,7 +114,8 @@ void XLATensorImpl::shallow_copy_from(
 }
 
 at::IntArrayRef XLATensorImpl::sizes_custom() const {
-  XLA_CHECK(!has_symbolic_sizes_strides_) << "Cannot call sizes() on an XLA tensor with symbolic sizes/strides";
+  XLA_CHECK(!has_symbolic_sizes_strides_)
+      << "Cannot call sizes() on an XLA tensor with symbolic sizes/strides";
   const_cast<XLATensorImpl*>(this)->SetupSizeProperties();
   return sizes_default();
 }

--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -115,7 +115,8 @@ void XLATensorImpl::shallow_copy_from(
 
 at::IntArrayRef XLATensorImpl::sizes_custom() const {
   XLA_CHECK(!has_symbolic_sizes_strides_)
-      << "Cannot call sizes() on an XLA tensor with symbolic sizes/strides";
+      << "Cannot call sizes_custom() on an XLA tensor with symbolic "
+         "sizes/strides";
   const_cast<XLATensorImpl*>(this)->SetupSizeProperties();
   return sizes_default();
 }


### PR DESCRIPTION
This is to address issue https://github.com/pytorch/xla/issues/4466, similar to what pytorch does at https://github.com/pytorch/pytorch/blob/75e04f6dade799ee12c262f65d3739e905b96fa5/c10/core/TensorImpl.h#L622-L628