### PR TITLE
Re-enable more dynamic shape tests

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -4880,7 +4880,10 @@ TEST_F(AtenXlaTensorTest, TestScatterAddInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceSum) {
-  GTEST_SKIP() << "Unrecognized `reduce` at https://github.com/pytorch/xla/blob/933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/scatter_reduce.cpp#L42 after functionalization";
+  GTEST_SKIP() << "Unrecognized `reduce` at "
+                  "https://github.com/pytorch/xla/blob/"
+                  "933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/"
+                  "scatter_reduce.cpp#L42 after functionalization";
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -4931,7 +4934,10 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceSumInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceProd) {
-  GTEST_SKIP() << "Unrecognized `reduce` at https://github.com/pytorch/xla/blob/933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/scatter_reduce.cpp#L42 after functionalization";
+  GTEST_SKIP() << "Unrecognized `reduce` at "
+                  "https://github.com/pytorch/xla/blob/"
+                  "933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/"
+                  "scatter_reduce.cpp#L42 after functionalization";
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -4957,7 +4963,10 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceProd) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceProdInPlace) {
-  GTEST_SKIP() << "Unrecognized `reduce` at https://github.com/pytorch/xla/blob/933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/scatter_reduce.cpp#L42 after functionalization";
+  GTEST_SKIP() << "Unrecognized `reduce` at "
+                  "https://github.com/pytorch/xla/blob/"
+                  "933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/"
+                  "scatter_reduce.cpp#L42 after functionalization";
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -4982,7 +4991,10 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceProdInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceMin) {
-  GTEST_SKIP() << "Unrecognized `reduce` at https://github.com/pytorch/xla/blob/933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/scatter_reduce.cpp#L42 after functionalization";
+  GTEST_SKIP() << "Unrecognized `reduce` at "
+                  "https://github.com/pytorch/xla/blob/"
+                  "933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/"
+                  "scatter_reduce.cpp#L42 after functionalization";
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -5008,7 +5020,10 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceMin) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceMinInPlace) {
-  GTEST_SKIP() << "Unrecognized `reduce` at https://github.com/pytorch/xla/blob/933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/scatter_reduce.cpp#L42 after functionalization";
+  GTEST_SKIP() << "Unrecognized `reduce` at "
+                  "https://github.com/pytorch/xla/blob/"
+                  "933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/"
+                  "scatter_reduce.cpp#L42 after functionalization";
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -5033,7 +5048,10 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceMinInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceMax) {
-  GTEST_SKIP() << "Unrecognized `reduce` at https://github.com/pytorch/xla/blob/933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/scatter_reduce.cpp#L42 after functionalization";
+  GTEST_SKIP() << "Unrecognized `reduce` at "
+                  "https://github.com/pytorch/xla/blob/"
+                  "933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/"
+                  "scatter_reduce.cpp#L42 after functionalization";
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -5058,7 +5076,10 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceMax) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceMaxInPlace) {
-  GTEST_SKIP() << "Unrecognized `reduce` at https://github.com/pytorch/xla/blob/933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/scatter_reduce.cpp#L42 after functionalization";
+  GTEST_SKIP() << "Unrecognized `reduce` at "
+                  "https://github.com/pytorch/xla/blob/"
+                  "933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/"
+                  "scatter_reduce.cpp#L42 after functionalization";
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -4880,6 +4880,7 @@ TEST_F(AtenXlaTensorTest, TestScatterAddInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceSum) {
+  GTEST_SKIP() << "Unrecognized `reduce` at https://github.com/pytorch/xla/blob/933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/scatter_reduce.cpp#L42 after functionalization";
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -4930,6 +4931,7 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceSumInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceProd) {
+  GTEST_SKIP() << "Unrecognized `reduce` at https://github.com/pytorch/xla/blob/933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/scatter_reduce.cpp#L42 after functionalization";
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -4955,6 +4957,7 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceProd) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceProdInPlace) {
+  GTEST_SKIP() << "Unrecognized `reduce` at https://github.com/pytorch/xla/blob/933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/scatter_reduce.cpp#L42 after functionalization";
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -4979,6 +4982,7 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceProdInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceMin) {
+  GTEST_SKIP() << "Unrecognized `reduce` at https://github.com/pytorch/xla/blob/933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/scatter_reduce.cpp#L42 after functionalization";
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -5004,6 +5008,7 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceMin) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceMinInPlace) {
+  GTEST_SKIP() << "Unrecognized `reduce` at https://github.com/pytorch/xla/blob/933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/scatter_reduce.cpp#L42 after functionalization";
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -5028,6 +5033,7 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceMinInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceMax) {
+  GTEST_SKIP() << "Unrecognized `reduce` at https://github.com/pytorch/xla/blob/933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/scatter_reduce.cpp#L42 after functionalization";
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -5052,6 +5058,7 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceMax) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceMaxInPlace) {
+  GTEST_SKIP() << "Unrecognized `reduce` at https://github.com/pytorch/xla/blob/933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/scatter_reduce.cpp#L42 after functionalization";
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));

--- a/test/test_dynamic_shape_models.py
+++ b/test/test_dynamic_shape_models.py
@@ -45,7 +45,6 @@ class Feedforward(torch.nn.Module):
 )
 class TestDynamicShapeModels(unittest.TestCase):
 
-  @unittest.skip("Broke by functionalization")
   def test_forward_pass_dynamic_input_correctness(self):
     losses = []
     for _ in range(2):

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -749,10 +749,6 @@ class TestDynamicShape(XlaTestCase):
         torch.masked_select(x, mask), 0)
     self.assertEqual(x_dim0_shape.item(), 3)
 
-  @unittest.skip(
-      "Temporarily disable test. See  https://github.com/pytorch/xla/issues/4501"
-  )
-  # @unittest.skip("Crash with dynamic shape")
   def test_nonzero_cast(self):
     t1 = torch.ones(5, 2, device=xm.xla_device())
     # Result of the nonzero should be the index type. Currently

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1481,7 +1481,6 @@ class TestAtenXlaTensor(XlaTestCase):
     xla_b.scatter_add_(0, xla_index, xla_a)
     self.assertEqual(b, xla_b)
 
-  @unittest.skip("Fail with run_dynamic")
   def test_squeeze_nonzero(self):
 
     def test_fn(a):

--- a/torch_xla/csrc/ops/dynamic_ir.cpp
+++ b/torch_xla/csrc/ops/dynamic_ir.cpp
@@ -150,7 +150,7 @@ int64_t SizeEq::getDynamicValue() const {
 std::string SizeEq::ToString() const { return "aten::size_eq"; }
 
 SizeNe::SizeNe(torch::lazy::Value a, torch::lazy::Value b)
-    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::ne")},
+    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::size_ne")},
               {a, b},
               xla::ShapeUtil::MakeShape(
                   GetShapeDimensionType(/*device=*/nullptr), {}),
@@ -169,10 +169,10 @@ int64_t SizeNe::getDynamicValue() const {
   return dim_node_0->getDynamicValue() != dim_node_1->getDynamicValue() ? 1 : 0;
 }
 
-std::string SizeNe::ToString() const { return "aten::ne_size"; }
+std::string SizeNe::ToString() const { return "aten::size_ne"; }
 
 SizeGe::SizeGe(torch::lazy::Value a, torch::lazy::Value b)
-    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::ge")},
+    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::size_ge")},
               {a, b},
               xla::ShapeUtil::MakeShape(
                   GetShapeDimensionType(/*device=*/nullptr), {}),
@@ -191,10 +191,10 @@ int64_t SizeGe::getDynamicValue() const {
   return dim_node_0->getDynamicValue() >= dim_node_1->getDynamicValue() ? 1 : 0;
 }
 
-std::string SizeGe::ToString() const { return "aten::ge_size"; }
+std::string SizeGe::ToString() const { return "aten::size_ge"; }
 
 SizeLt::SizeLt(torch::lazy::Value a, torch::lazy::Value b)
-    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::lt")},
+    : XlaNode(torch::lazy::OpKind{c10::Symbol::fromQualString("aten::size_lt")},
               {a, b},
               xla::ShapeUtil::MakeShape(
                   GetShapeDimensionType(/*device=*/nullptr), {}),
@@ -213,7 +213,7 @@ int64_t SizeLt::getDynamicValue() const {
   return dim_node_0->getDynamicValue() < dim_node_1->getDynamicValue() ? 1 : 0;
 }
 
-std::string SizeLt::ToString() const { return "aten::lt_size"; }
+std::string SizeLt::ToString() const { return "aten::size_lt"; }
 
 SizeConstant::SizeConstant(int64_t val)
     : Scalar(c10::Scalar{val},

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -626,8 +626,8 @@ bool XLASymNodeImpl::is_bool() {
   c10::Symbol op = node()->op().op;
   // Reference:
   // https://github.com/pytorch/pytorch/blob/master/torch/fx/experimental/symbolic_shapes.py#L403
-  if (op == c10::Symbol::fromQualString("aten::size_eq") || 
-      op == c10::Symbol::fromQualString("aten::size_ne") || 
+  if (op == c10::Symbol::fromQualString("aten::size_eq") ||
+      op == c10::Symbol::fromQualString("aten::size_ne") ||
       op == c10::Symbol::fromQualString("aten::size_ge") ||
       op == c10::Symbol::fromQualString("aten::size_lt")) {
     return true;

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -623,11 +623,13 @@ bool XLATensor::ShouldSyncIrNode() {
 }
 
 bool XLASymNodeImpl::is_bool() {
-  auto op = node()->op().op;
+  c10::Symbol op = node()->op().op;
   // Reference:
   // https://github.com/pytorch/pytorch/blob/master/torch/fx/experimental/symbolic_shapes.py#L403
-  if (op == at::aten::eq || op == at::aten::ne || op == at::aten::ge ||
-      op == at::aten::lt) {
+  if (op == c10::Symbol::fromQualString("aten::size_eq") || 
+      op == c10::Symbol::fromQualString("aten::size_ne") || 
+      op == c10::Symbol::fromQualString("aten::size_ge") ||
+      op == c10::Symbol::fromQualString("aten::size_lt")) {
     return true;
   }
   return false;


### PR DESCRIPTION
This pr unifies all size_nodes to have op kind to be `size_op` and re-enables the following test:
- test_forward_pass_dynamic_input_correctness
- test_nonzero_cast
- test_squeeze_nonzero