### PR TITLE
Skip git pull if we're in the xla repo

### DIFF
--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -86,14 +86,17 @@ function maybe_install_sources {
     popd
   fi
 
-  # Check if we have cloned pytorch and cd into the pytorch dir. Within the pytorch
-  # dir there is a subdir `torch`.
-  if [ ! -d "torch" ]; then
+  # Check if we have cloned pytorch or xla and cd into the pytorch dir. 
+  # Within the pytorch dir there is a subdir `torch`, and within xla 
+  # is `torch_xla`.
+  if [ ! -d "torch" && ! -d "torch_xla" ]; then
     sudo apt-get install -y git
     git clone --recursive https://github.com/pytorch/pytorch.git
     cd pytorch
     git clone --recursive https://github.com/pytorch/xla.git
     export RELEASE_VERSION="nightly"
+  elif [ -d "torch_xla" ]; then
+    cd ..
   fi
 }
 


### PR DESCRIPTION
Today, the wheel build script is designed to run on our docker images. However, this script has been duplicating the pytorch and xla repos due to some old logic, which has result in a large image. This has impacts for image pull and container start times, and can introduce issues with running containers on TPUVMs with limited storage capacity.

Specifically, this is affecting our CI, causing timeouts before the kubernetes pod running our container can start. This change is intended to cut down the image size to improve container start times and restore TPU CI to green.