### PR TITLE
Remove unused docker tagging in .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,9 +83,6 @@ calculate_docker_image: &calculate_docker_image
   command: |
     # Just a quick smoke test to see if we can actually extract the tag
     git clone --quiet https://github.com/pytorch/pytorch.git "/tmp/pytorch"
-    git -C /tmp/pytorch rev-parse HEAD:.circleci/docker
-    DOCKER_TAG=$(git -C /tmp/pytorch rev-parse HEAD:.circleci/docker)
-    echo "declare -x DOCKER_TAG=${DOCKER_TAG}" >> "${BASH_ENV}"
     # For staging our build image in ECR for upstream testing
     echo "declare -x ECR_DOCKER_IMAGE_BASE=308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/xla_base" >> "${BASH_ENV}"
     # For PyTorch/XLA CI workflow, we only pull & push to gcr.io

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,8 +81,6 @@ download_docker: &download_docker
 calculate_docker_image: &calculate_docker_image
   name: Calculate docker image
   command: |
-    # Just a quick smoke test to see if we can actually extract the tag
-    git clone --quiet https://github.com/pytorch/pytorch.git "/tmp/pytorch"
     # For staging our build image in ECR for upstream testing
     echo "declare -x ECR_DOCKER_IMAGE_BASE=308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/xla_base" >> "${BASH_ENV}"
     # For PyTorch/XLA CI workflow, we only pull & push to gcr.io


### PR DESCRIPTION
The docker tag is not used. We use a version tag instead. This fixes the issue because extracting the tag was failing.