### PR TITLE
Actual build and install sccache from source

### DIFF
--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -90,7 +90,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN . $CARGO_HOME/env && \
     git clone --recursive https://github.com/pytorch/sccache.git && \
     cd sccache && \
-    cargo install sccache && \
+    cargo install --path . && \
     cd .. && \
     rm -rf sccache
 


### PR DESCRIPTION
This is a miss from my previous PR https://github.com/pytorch/xla/pull/4489.  I didn't realize that the existing command `cargo install sccache` would download, build, and install sccache (v0.3.3) from upstream repo like conda. That command never even uses the local checkout from git.  So in fact, https://github.com/pytorch/xla/pull/4489 is a no-op.

The correct command to use is `cargo install --path .` to build and install from local source.