### PR TITLE
[PJRT] Only alias inputs and outputs when `force_ltc_sync == True`

### DIFF
--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -1102,7 +1102,8 @@ XLAGraphExecutor::CompilationResult XLAGraphExecutor::Compile(
   // TODO(yeounoh) aliasing is disabled for partitioned computation,
   // since the current aliasing compares the unpartitioned input and output
   // shapes which can lead to an incorrect aliasing pairs if sharded.
-  if (enable_aliasing && coll.config.sync_ltc_data && !is_sharded) {
+  if (enable_aliasing && coll.config.sync_ltc_data &&
+      coll.config.force_ltc_data && !is_sharded) {
     // We can only alias at the step barrier, when force_ltc_data is true.
     // Consider the case:
     //   1. Tensor A(DEVICE_DATA)


### PR DESCRIPTION
Updating logic to match comment.

According to the [documentation for PJRT](https://github.com/tensorflow/tensorflow/blob/769156e6c72950a6e838242aad4cd20bab21accf/tensorflow/compiler/xla/pjrt/pjrt_client.h#L1151-L1154), when an input buffer is aliased to an output of an executable, the original input buffer is no longer available. When we reference the `DataPtr` that holds the buffer again, we will inevitably see this error: `RuntimeError: ./tensorflow/compiler/xla/xla_client/pjrt_computation_client.h:140 : Check failed: HasValue()`

Fixes the following failing C++ tests on CPU:

```
[  FAILED  ] AtenXlaTensorTest.TestAvgPool2DBackward
[  FAILED  ] AtenXlaTensorTest.TestAvgPool3DBackward
[  FAILED  ] AtenXlaTensorTest.TestAvgPool2DNoBatchBackward
[  FAILED  ] AtenXlaTensorTest.TestAvgPool3DNoBatchBackward
[  FAILED  ] AtenXlaTensorTest.TestAddMatMulBackward
```