### PR TITLE
[Functionalization] Fix ScatterReduce

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -4880,10 +4880,6 @@ TEST_F(AtenXlaTensorTest, TestScatterAddInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceSum) {
-  GTEST_SKIP() << "Unrecognized `reduce` at "
-                  "https://github.com/pytorch/xla/blob/"
-                  "933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/"
-                  "scatter_reduce.cpp#L42 after functionalization";
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -4934,10 +4930,6 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceSumInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceProd) {
-  GTEST_SKIP() << "Unrecognized `reduce` at "
-                  "https://github.com/pytorch/xla/blob/"
-                  "933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/"
-                  "scatter_reduce.cpp#L42 after functionalization";
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -4963,10 +4955,6 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceProd) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceProdInPlace) {
-  GTEST_SKIP() << "Unrecognized `reduce` at "
-                  "https://github.com/pytorch/xla/blob/"
-                  "933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/"
-                  "scatter_reduce.cpp#L42 after functionalization";
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -4991,10 +4979,6 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceProdInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceMin) {
-  GTEST_SKIP() << "Unrecognized `reduce` at "
-                  "https://github.com/pytorch/xla/blob/"
-                  "933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/"
-                  "scatter_reduce.cpp#L42 after functionalization";
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -5020,10 +5004,6 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceMin) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceMinInPlace) {
-  GTEST_SKIP() << "Unrecognized `reduce` at "
-                  "https://github.com/pytorch/xla/blob/"
-                  "933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/"
-                  "scatter_reduce.cpp#L42 after functionalization";
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -5048,10 +5028,6 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceMinInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceMax) {
-  GTEST_SKIP() << "Unrecognized `reduce` at "
-                  "https://github.com/pytorch/xla/blob/"
-                  "933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/"
-                  "scatter_reduce.cpp#L42 after functionalization";
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -5076,10 +5052,6 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceMax) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceMaxInPlace) {
-  GTEST_SKIP() << "Unrecognized `reduce` at "
-                  "https://github.com/pytorch/xla/blob/"
-                  "933dcc21c51676f72a41f2989f5bbba760a498c0/torch_xla/csrc/ops/"
-                  "scatter_reduce.cpp#L42 after functionalization";
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));

--- a/torch_xla/csrc/ops/scatter_reduce.h
+++ b/torch_xla/csrc/ops/scatter_reduce.h
@@ -19,7 +19,7 @@ class ScatterReduce : public XlaNode {
   int64_t dim() const { return dim_; };
 
  private:
-  c10::string_view reduce_;
+  std::string reduce_;
   bool include_self_;
   int64_t dim_;
 };


### PR DESCRIPTION
Summary:
ScatterReduce::reduce_ uses a unsafe type c10::string_view to store the string. Replace it with std::string and re-enable all previous failing tests.

Test Plan:
TPU_LIBRARY_PATH=/home/ptxla/.local/lib/python3.8/site-packages/libtpu/libtpu.so PJRT_DEVICE=CPU test/cpp/build/test_ptxla --gtest_filter=AtenXlaTensorTest.TestScatterReduce*