### PR TITLE
Fix ScatterReduce

### DIFF
--- a/torch_xla/csrc/ops/scatter_reduce.h
+++ b/torch_xla/csrc/ops/scatter_reduce.h
@@ -19,7 +19,7 @@ class ScatterReduce : public XlaNode {
   int64_t dim() const { return dim_; };
 
  private:
-  c10::string_view reduce_;
+  std::string reduce_;
   bool include_self_;
   int64_t dim_;
 };


### PR DESCRIPTION
Summary:
ScatterReduce::reduce_ uses a unsafe type c10::string_view to store the string. Replace it with std::string and re-enable all previous failing tests.

Test Plan:
CI.