### PR TITLE
[PjRt] Skip OpByOpExecutorTest with PJRT

### DIFF
--- a/test/cpp/cpp_test_util.cpp
+++ b/test/cpp/cpp_test_util.cpp
@@ -428,5 +428,11 @@ torch::lazy::NodePtr CreateNonZeroNode2d(int64_t num_non_zero_element,
   return nonzero_node;
 }
 
+bool UsingPjRt() {
+  static bool using_pjrt =
+      !xla::sys_util::GetEnvString("PJRT_DEVICE", "").empty();
+  return using_pjrt;
+}
+
 }  // namespace cpp_test
 }  // namespace torch_xla

--- a/test/cpp/cpp_test_util.h
+++ b/test/cpp/cpp_test_util.h
@@ -10,6 +10,7 @@
 
 #include "absl/types/span.h"
 #include "tensorflow/compiler/xla/xla_client/computation_client.h"
+#include "tensorflow/compiler/xla/xla_client/sys_util.h"
 #include "torch_xla/csrc/debug_util.h"
 #include "torch_xla/csrc/device.h"
 #include "torch_xla/csrc/ir.h"
@@ -112,6 +113,8 @@ void TestBackward(
 
 torch::lazy::NodePtr CreateNonZeroNode2d(int64_t num_non_zero_element,
                                          int64_t num_row, int64_t num_col);
+
+bool UsingPjRt();
 
 }  // namespace cpp_test
 }  // namespace torch_xla

--- a/test/cpp/cpp_test_util.h
+++ b/test/cpp/cpp_test_util.h
@@ -10,7 +10,6 @@
 
 #include "absl/types/span.h"
 #include "tensorflow/compiler/xla/xla_client/computation_client.h"
-#include "tensorflow/compiler/xla/xla_client/sys_util.h"
 #include "torch_xla/csrc/debug_util.h"
 #include "torch_xla/csrc/device.h"
 #include "torch_xla/csrc/ir.h"

--- a/test/cpp/test_op_by_op_executor.cpp
+++ b/test/cpp/test_op_by_op_executor.cpp
@@ -13,6 +13,10 @@ namespace torch_xla {
 namespace cpp_test {
 
 TEST(OpByOpExecutorTest, TestSimpleAdd) {
+  if (UsingPjRt()) {
+    GTEST_SKIP();
+  }
+
   ForEachDevice([&](const torch::lazy::BackendDevice& device) {
     at::Tensor a = at::rand({4, 16, 3}, at::TensorOptions(at::kFloat));
     at::Tensor b = at::rand({4, 16, 3}, at::TensorOptions(at::kFloat));
@@ -31,6 +35,10 @@ TEST(OpByOpExecutorTest, TestSimpleAdd) {
 }
 
 TEST(OpByOpExecutorTest, TestStack) {
+  if (UsingPjRt()) {
+    GTEST_SKIP();
+  }
+
   ForEachDevice([&](const torch::lazy::BackendDevice& device) {
     at::Tensor a = at::rand({4, 8, 3}, at::TensorOptions(at::kFloat));
     at::Tensor b = at::rand({4, 8, 3}, at::TensorOptions(at::kFloat));
@@ -50,6 +58,10 @@ TEST(OpByOpExecutorTest, TestStack) {
 }
 
 TEST(OpByOpExecutorTest, TestAsyncStack) {
+  if (UsingPjRt()) {
+    GTEST_SKIP();
+  }
+
   ForEachDevice([&](const torch::lazy::BackendDevice& device) {
     at::Tensor a = at::rand({4, 8, 3}, at::TensorOptions(at::kFloat));
     at::Tensor b = at::rand({4, 8, 3}, at::TensorOptions(at::kFloat));


### PR DESCRIPTION
Skip these failing C++ tests:

```
[  FAILED  ] OpByOpExecutorTest.TestSimpleAdd
[  FAILED  ] OpByOpExecutorTest.TestStack
[  FAILED  ] OpByOpExecutorTest.TestAsyncStack
```