### PR TITLE
Add expand symint python test and re-enable some previously disabled dynamic shape tests.

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -5207,66 +5207,6 @@ static c10::SymInt make_symint(const torch::lazy::NodePtr& p) {
       static_cast<c10::SymNode>(c10::make_intrusive<XLASymNodeImpl>(p)));
 }
 
-TEST_F(AtenXlaTensorTest, TestExpandSymIntSymbolic) {
-  torch::Tensor a = torch::ones({3, 4}, torch::TensorOptions(torch::kFloat));
-  torch::Tensor b = a.expand({2, 3, 4}, /*implicit=*/false);
-
-  // create a symbolic symint with value 2 and upperbound 2. This symint is
-  // symbolic(since it wraps around a sizeNode) but not really dynamic.
-  torch::lazy::Value scalar_value =
-      torch::lazy::Value(ScalarOp(1.0, xla::F32), 0);
-  std::vector<int64_t> target_size = {2, 3, 4};
-  torch::lazy::NodePtr expand_node =
-      torch::lazy::MakeNode<Expand>(scalar_value, target_size);
-  torch::lazy::Value expand_value = torch::lazy::Value(expand_node, 0);
-  torch::lazy::NodePtr size_node =
-      torch::lazy::MakeNode<SizeNode>(expand_value, /*dim=*/0);
-  // This is not a dynamic size from xla perspective but it is a symint that
-  // wraps around a SizeNode instead of a scalar.
-  c10::SymInt dynamic_symint = make_symint(size_node);
-
-  ForEachDevice([&](const torch::Device& device) {
-    torch::Tensor xla_a = CopyToDevice(a, device);
-    torch::Tensor xla_b = xla_a.expand_symint(
-        c10::SymIntArrayRef({dynamic_symint, c10::SymInt(3), c10::SymInt(4)}),
-        /*implicit=*/false);
-    EXPECT_EQ(ToCpuTensor(xla_b).sum().item().toInt(), 24);
-    AllClose(b, xla_b);
-  });
-
-  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::expand_symint", cpp_test::GetIgnoredCounters());
-}
-
-TEST_F(AtenXlaTensorTest, TestExpandSymIntDynamic) {
-  torch::Tensor a = torch::ones({3, 4}, torch::TensorOptions(torch::kFloat));
-  torch::Tensor b = a.expand({2, 3, 4}, /*implicit=*/false);
-
-  // use non_zero to create a symbolic symint with upper bound 100 and real
-  // value 2
-  int64_t num_non_zero_element = 2;
-  int64_t num_row = 10;
-  int64_t num_col = 10;
-  torch::lazy::NodePtr nonzero_node =
-      CreateNonZeroNode2d(num_non_zero_element, num_row, num_col);
-
-  torch::lazy::NodePtr size_node_nonzero_0 =
-      torch::lazy::MakeNode<SizeNode>(nonzero_node, 0);
-  c10::SymInt dynamic_symint = make_symint(size_node_nonzero_0);
-
-  ForEachDevice([&](const torch::Device& device) {
-    torch::Tensor xla_a = CopyToDevice(a, device);
-    torch::Tensor xla_b = xla_a.expand_symint(
-        c10::SymIntArrayRef({dynamic_symint, c10::SymInt(3), c10::SymInt(4)}),
-        /*implicit=*/false);
-    EXPECT_EQ(ToCpuTensor(xla_b).sum().item().toInt(), 24);
-    AllClose(b, xla_b);
-  });
-
-  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::expand_symint", cpp_test::GetIgnoredCounters());
-}
-
 TEST_F(AtenXlaTensorTest, TestEye) {
   int n = 5;
   ForEachDevice([&](const torch::Device& device) {

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -5309,13 +5309,6 @@ TEST_F(AtenXlaTensorTest, TestOneIndexTransfer) {
   }
 }
 
-// Temporarily disable test. Original issue
-// https://github.com/pytorch/xla/issues/4501 has been resolved. The next error
-// is https://gist.github.com/vanbasten23/b3a79e0cc7f17edc0018eb83cdd5d738 (see
-// https://github.com/pytorch/xla/issues/4432 for more info). The next error
-// happens on TPU but not on CPU.
-//
-/*
 TEST_F(AtenXlaTensorTest, TestNonzero) {
   torch::Tensor a = torch::zeros({4, 2}, torch::TensorOptions(torch::kFloat));
   a[0][1] = 1.0;
@@ -5335,7 +5328,6 @@ TEST_F(AtenXlaTensorTest, TestNonzero) {
     ResetCounters();
   });
 }
-*/
 
 TEST_F(AtenXlaTensorTest, TestMaskedSelect) {
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -134,7 +134,7 @@ function run_op_tests {
   run_dynamic python3 "$CDIR/../../test/test_type_promotion.py" "$@" -v TestTypePromotionXLA
   run_dynamic python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_dynamic python3 "$CDIR/test_dynamic_shapes.py"
-  # run_dynamic python3 "$CDIR/test_dynamic_shape_models.py" "$@" --verbosity=$VERBOSITY
+  run_dynamic python3 "$CDIR/test_dynamic_shape_models.py" "$@" --verbosity=$VERBOSITY
   run_opbyop python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_eager_debug python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_async_scalar python3 "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1619,7 +1619,8 @@ class TestOpBuilder(test_utils.XlaTestCase):
     ]
     results = xu.as_list(aten_fn(*tensors, **kwargs))
     xla_results = xu.as_list(op(*xla_tensors, **kwargs))
-    self.compareResults(results, xla_results, max_diff_count, rel_err=rel_err, abs_err=abs_err)
+    self.compareResults(
+        results, xla_results, max_diff_count, rel_err=rel_err, abs_err=abs_err)
 
   def test_add(self):
 

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -756,7 +756,7 @@ class TestDynamicShape(XlaTestCase):
     # able to cast it to any other type without error.
     t2 = torch.nonzero(t1.int()).float()
     xm.mark_step()
-  
+
   def test_expand_symint_correctness(self):
     dev = xm.xla_device()
     size1 = 5

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -19,9 +19,6 @@ import collections
 import copy
 import itertools
 import math
-from numbers import Number
-import numpy
-import random
 import re
 import torch
 import torch.autograd as ad
@@ -44,6 +41,7 @@ import torch_xla.core.functions as xf
 import torch_xla.debug.profiler as xp
 import torchvision
 import unittest
+import test_utils
 
 DeviceSupport = collections.namedtuple('DeviceSupport', ['num_devices'])
 
@@ -58,33 +56,6 @@ def _gen_int_tensor(*args, **kwargs):
 
 def _gen_mask(size):
   return torch.randint(0, 2, size, dtype=torch.bool)
-
-
-class Holder(object):
-  pass
-
-
-def _iter_indices(tensor):
-  if tensor.dim() == 0:
-    return range(0)
-  if tensor.dim() == 1:
-    return range(tensor.size(0))
-  return itertools.product(*(range(s) for s in tensor.size()))
-
-
-def _is_iterable(obj):
-  try:
-    iter(obj)
-    return True
-  except TypeError:
-    return False
-
-
-def _set_rng_seed(seed):
-  torch.manual_seed(seed)
-  random.seed(seed)
-  numpy.random.seed(seed)
-  xm.set_rng_state(seed)
 
 
 def _get_device_support(devname):
@@ -139,357 +110,7 @@ def _zeros_like(tensor_list):
   return zeros_tensors
 
 
-def _prepare_tensors_for_diff(ta, tb):
-  a = ta.to(device='cpu')
-  b = tb.to(device='cpu')
-  if a.dtype == torch.float16 or a.dtype == torch.bfloat16:
-    a = a.to(torch.float32)
-  if b.dtype == torch.float16 or b.dtype == torch.bfloat16:
-    b = b.to(torch.float32)
-  if b.dtype != a.dtype:
-    b = b.to(a.dtype)
-  if xu.getenv_as('TEST_PRINT_TENSORS', bool, defval=False):
-    print('Tensor A ({}):\n{}'.format(ta.device, a), file=sys.stderr)
-    print('Tensor B ({}):\n{}'.format(tb.device, b), file=sys.stderr)
-  return a, b
-
-
-def _dump_differences(target, result, rtol=1e-5, atol=1e-3, max_diff_count=0):
-  env = Holder()
-  env.max_diff = 0.0
-  env.max_rel = None
-  env.max_index = None
-  env.diff_count = 0
-
-  def check_values(a, b, index):
-    a, b = _prepare_tensors_for_diff(a, b)
-    r = max(abs(a), abs(b)) * rtol
-    diff = abs(a - b)
-    if diff > max(r, atol):
-      print('a={}\tb={}\tdiff={}\tindex={}'.format(a, b, diff, index))
-      env.diff_count += 1
-      if diff > env.max_diff:
-        env.max_diff = diff
-        env.max_rel = diff / max(abs(a), abs(b))
-        env.max_index = index
-
-  if isinstance(target, torch.Tensor):
-    assert isinstance(result, torch.Tensor)
-    assert target.size() == result.size()
-    if target.dim() > 0:
-      for i in _iter_indices(target):
-        check_values(target[i], result[i], i)
-        if max_diff_count > 0 and env.diff_count >= max_diff_count:
-          break
-    else:
-      check_values(target.item(), result.item(), 0)
-  elif isinstance(target, (list, tuple)):
-    assert isinstance(result, (list, tuple))
-    assert len(target) == len(result)
-    for i, v in enumerate(target):
-      check_values(v, result[i], [i])
-      if max_diff_count > 0 and env.diff_count >= max_diff_count:
-        break
-  elif isinstance(target, float):
-    assert isinstance(result, float)
-    check_values(target, result, [])
-  if env.max_index is not None:
-    print('\nmax_diff={}\tmax_rel={}\tindex={}'.format(env.max_diff,
-                                                       env.max_rel,
-                                                       env.max_index))
-
-
-class XlaTestCase(unittest.TestCase):
-  PRECISION = 1e-5
-  STRING_CLASSES = (str, bytes)
-
-  def __init__(self, method_name='runTest'):
-    super(XlaTestCase, self).__init__(method_name)
-
-  def setUp(self):
-    _set_rng_seed(1234)
-
-  def safeCoalesce(self, t):
-    tc = t.coalesce()
-    self.assertEqual(tc.to_dense(), t.to_dense())
-    self.assertTrue(tc.is_coalesced())
-    # Our code below doesn't work when nnz is 0, because
-    # then it's a 0D tensor, not a 2D tensor.
-    if t._nnz() == 0:
-      self.assertEqual(t._indices(), tc._indices())
-      self.assertEqual(t._values(), tc._values())
-      return tc
-
-    value_map = {}
-    for idx, val in zip(t._indices().t(), t._values()):
-      idx_tup = tuple(idx.tolist())
-      if idx_tup in value_map:
-        value_map[idx_tup] += val
-      else:
-        value_map[idx_tup] = val.clone() if isinstance(val,
-                                                       torch.Tensor) else val
-
-    new_indices = sorted(list(value_map.keys()))
-    new_values = [value_map[idx] for idx in new_indices]
-    if t._values().ndimension() < 2:
-      new_values = t._values().new(new_values)
-    else:
-      new_values = torch.stack(new_values)
-    new_indices = t._indices().new(new_indices).t()
-    tg = t.new(new_indices, new_values, t.size())
-
-    self.assertEqual(tc._indices(), tg._indices())
-    self.assertEqual(tc._values(), tg._values())
-    if t.is_coalesced():
-      self.assertEqual(tc._indices(), t._indices())
-      self.assertEqual(tc._values(), t._values())
-
-    return tg
-
-  # This has been copied from pytorch/test/common_utils.py in order to decouple
-  # PyTorch/XLA tests from pytorch tests. We use this API only with a very
-  # limited set of object types, so it could be eventually simplified.
-  def assertEqual(self, x, y, prec=None, message='', allow_inf=False):
-    if isinstance(prec, str) and message == '':
-      message = prec
-      prec = None
-    if prec is None:
-      prec = self.PRECISION
-    if isinstance(x, torch.Tensor) and isinstance(y, Number):
-      self.assertEqual(
-          x.item(), y, prec=prec, message=message, allow_inf=allow_inf)
-    elif isinstance(y, torch.Tensor) and isinstance(x, Number):
-      self.assertEqual(
-          x, y.item(), prec=prec, message=message, allow_inf=allow_inf)
-    elif isinstance(x, torch.Tensor) and isinstance(y, numpy.bool_):
-      self.assertEqual(
-          x.item(), y, prec=prec, message=message, allow_inf=allow_inf)
-    elif isinstance(y, torch.Tensor) and isinstance(x, numpy.bool_):
-      self.assertEqual(
-          x, y.item(), prec=prec, message=message, allow_inf=allow_inf)
-    elif isinstance(x, torch.Tensor) and isinstance(y, torch.Tensor):
-
-      def assertTensorsEqual(a, b):
-        super(XlaTestCase, self).assertEqual(a.size(), b.size(), message)
-        if a.numel() > 0:
-          a, b = _prepare_tensors_for_diff(a, b)
-          if (a.dtype == torch.bool) != (b.dtype == torch.bool):
-            raise TypeError('Was expecting both tensors to be bool type.')
-          else:
-            if a.dtype == torch.bool and b.dtype == torch.bool:
-              # we want to respect precision but as bool doesn't support substraction,
-              # boolean tensor has to be converted to int
-              a = a.to(torch.int)
-              b = b.to(torch.int)
-
-            diff = a - b
-            # check that NaNs are in the same locations
-            nan_mask = torch.isnan(a)
-            self.assertTrue(torch.equal(nan_mask, torch.isnan(b)), message)
-            diff[nan_mask] = 0
-            # inf check if allow_inf=True
-            if allow_inf:
-              inf_mask = torch.isinf(a)
-              inf_sign = inf_mask.sign()
-              self.assertTrue(
-                  torch.equal(inf_sign,
-                              torch.isinf(b).sign()), message)
-              diff[inf_mask] = 0
-            # TODO: implement abs on CharTensor (int8)
-            if diff.is_signed() and diff.dtype != torch.int8:
-              diff = diff.abs()
-            max_err = diff.max()
-            self.assertLessEqual(max_err, prec, message)
-
-      super(XlaTestCase, self).assertEqual(x.is_sparse, y.is_sparse, message)
-      super(XlaTestCase, self).assertEqual(x.is_quantized, y.is_quantized,
-                                           message)
-      if x.is_sparse:
-        x = self.safeCoalesce(x)
-        y = self.safeCoalesce(y)
-        assertTensorsEqual(x._indices(), y._indices())
-        assertTensorsEqual(x._values(), y._values())
-      elif x.is_quantized and y.is_quantized:
-        self.assertEqual(
-            x.qscheme(),
-            y.qscheme(),
-            prec=prec,
-            message=message,
-            allow_inf=allow_inf)
-        if x.qscheme() == torch.per_tensor_affine:
-          self.assertEqual(
-              x.q_scale(),
-              y.q_scale(),
-              prec=prec,
-              message=message,
-              allow_inf=allow_inf)
-          self.assertEqual(
-              x.q_zero_point(),
-              y.q_zero_point(),
-              prec=prec,
-              message=message,
-              allow_inf=allow_inf)
-        elif x.qscheme() == torch.per_channel_affine:
-          self.assertEqual(
-              x.q_per_channel_scales(),
-              y.q_per_channel_scales(),
-              prec=prec,
-              message=message,
-              allow_inf=allow_inf)
-          self.assertEqual(
-              x.q_per_channel_zero_points(),
-              y.q_per_channel_zero_points(),
-              prec=prec,
-              message=message,
-              allow_inf=allow_inf)
-          self.assertEqual(
-              x.q_per_channel_axis(),
-              y.q_per_channel_axis(),
-              prec=prec,
-              message=message)
-        self.assertEqual(x.dtype, y.dtype)
-        self.assertEqual(
-            x.int_repr().to(torch.int32),
-            y.int_repr().to(torch.int32),
-            prec=prec,
-            message=message,
-            allow_inf=allow_inf)
-      else:
-        assertTensorsEqual(x, y)
-    elif isinstance(x, self.STRING_CLASSES) and isinstance(
-        y, self.STRING_CLASSES):
-      super(XlaTestCase, self).assertEqual(x, y, message)
-    elif type(x) == set and type(y) == set:
-      super(XlaTestCase, self).assertEqual(x, y, message)
-    elif isinstance(x, dict) and isinstance(y, dict):
-      if isinstance(x, collections.OrderedDict) and isinstance(
-          y, collections.OrderedDict):
-        self.assertEqual(
-            x.items(),
-            y.items(),
-            prec=prec,
-            message=message,
-            allow_inf=allow_inf)
-      else:
-        self.assertEqual(
-            set(x.keys()),
-            set(y.keys()),
-            prec=prec,
-            message=message,
-            allow_inf=allow_inf)
-        key_list = list(x.keys())
-        self.assertEqual([x[k] for k in key_list], [y[k] for k in key_list],
-                         prec=prec,
-                         message=message,
-                         allow_inf=allow_inf)
-    elif _is_iterable(x) and _is_iterable(y):
-      super(XlaTestCase, self).assertEqual(len(x), len(y), message)
-      for x_, y_ in zip(x, y):
-        self.assertEqual(
-            x_, y_, prec=prec, message=message, allow_inf=allow_inf)
-    elif isinstance(x, bool) and isinstance(y, bool):
-      super(XlaTestCase, self).assertEqual(x, y, message)
-    elif isinstance(x, Number) and isinstance(y, Number):
-      if abs(x) == math.inf or abs(y) == math.inf:
-        if allow_inf:
-          super(XlaTestCase, self).assertEqual(x, y, message)
-        else:
-          self.fail('Expected finite numeric values - x={}, y={}'.format(x, y))
-        return
-      super(XlaTestCase, self).assertLessEqual(abs(x - y), prec, message)
-    else:
-      super(XlaTestCase, self).assertEqual(x, y, message)
-
-  def assertEqualRel(self, out, expected, rel_err=1e-2, abs_err=1e-5):
-    try:
-      out, expected = _prepare_tensors_for_diff(out, expected)
-      nan_mask = torch.isnan(expected)
-      self.assertTrue(torch.equal(nan_mask, torch.isnan(out)))
-      out[nan_mask] = 0
-      expected[nan_mask] = 0
-      inf_mask = torch.isinf(expected)
-      self.assertTrue(torch.equal(inf_mask, torch.isinf(out)))
-      out[inf_mask] = 0
-      expected[inf_mask] = 0
-      diff_tensor = (out - expected).abs().float()
-      max_rel_err = torch.max(out.abs(), expected.abs()).float() * rel_err
-      # Allow higher relative differences as long as we're still below the
-      # absolute error.
-      max_abs_err = torch.max(max_rel_err,
-                              torch.ones_like(out).float() * abs_err)
-      super(XlaTestCase, self).assertEqual(diff_tensor.size(),
-                                           max_abs_err.size())
-      if (diff_tensor.numel() > 0 and
-          torch.le(diff_tensor, max_abs_err).min().item() == 0):
-        self.fail('Relative error higher than the maximum tolerance')
-    except:
-      _dump_differences(
-          expected,
-          out,
-          rtol=rel_err,
-          atol=abs_err,
-          max_diff_count=FLAGS.max_diff_count)
-      raise
-
-  def assertEqualDbg(self, out, expected):
-    try:
-      super(XlaTestCase, self).assertEqual(out, expected)
-    except:
-      _dump_differences(
-          expected,
-          out,
-          rtol=1e-8,
-          atol=1e-8,
-          max_diff_count=FLAGS.max_diff_count)
-      raise
-
-  def makeComparable(self, value):
-    if isinstance(value, torch.Tensor):
-      if value.dtype == torch.bool:
-        value = value.to(dtype=torch.uint8)
-      if xm.is_xla_tensor(value.data):
-        return value.data.cpu()
-      return value.data
-    return value
-
-  def maybePrintGraph(self, tensors):
-    env = os.environ.get('TEST_PRINT_GRAPH', '').lower()
-    if env:
-      if env == 'text':
-        print(
-            'Test Graph:\n{}'.format(
-                torch_xla._XLAC._get_xla_tensors_text(tensors)),
-            file=sys.stderr)
-      elif env == 'hlo':
-        print(
-            'Test Graph:\n{}'.format(
-                torch_xla._XLAC._get_xla_tensors_hlo(tensors)),
-            file=sys.stderr)
-      else:
-        raise RuntimeError('Invalid TEST_PRINT_GRAPH value: {}'.format(env))
-
-  def compareResults(self, results, xla_results, rel_err=1e-2, abs_err=1e-5):
-    self.maybePrintGraph(xla_results)
-    for at, xt in zip(results, xla_results):
-      self.assertEqualRel(
-          self.makeComparable(xt),
-          self.makeComparable(at),
-          rel_err=rel_err,
-          abs_err=abs_err)
-
-  def runAtenTest(self, tensors, fn, device=None, rel_err=1e-2, abs_err=1e-5):
-    if device is None:
-      device = xm.xla_device()
-    tensors = xu.as_list(tensors)
-    xla_tensors = [
-        x.to(device).detach().requires_grad_(x.requires_grad) for x in tensors
-    ]
-    results = xu.as_list(fn(*tensors))
-    xla_results = xu.as_list(fn(*xla_tensors))
-    self.compareResults(results, xla_results, rel_err=rel_err, abs_err=abs_err)
-
-
-class TestToXlaTensorArena(XlaTestCase):
+class TestToXlaTensorArena(test_utils.XlaTestCase):
 
   def test(self):
     xla_device = xm.xla_device()
@@ -525,7 +146,7 @@ class TestToXlaTensorArena(XlaTestCase):
     self.assertTrue(check_fn(xla_data))
 
 
-class TestParallelLoader(XlaTestCase):
+class TestParallelLoader(test_utils.XlaTestCase):
 
   def test(self):
     devices = [torch.device(x) for x in xm.get_xla_supported_devices()]
@@ -542,7 +163,7 @@ class TestParallelLoader(XlaTestCase):
         self.assertEqual(target.device, device)
 
 
-class TestAtenTensorTo(XlaTestCase):
+class TestAtenTensorTo(test_utils.XlaTestCase):
 
   def test(self):
     devices = xm.get_xla_supported_devices()
@@ -582,7 +203,7 @@ class XlaMNIST(nn.Module):
     return F.log_softmax(x, dim=1)
 
 
-class TestParallelTensorMNIST(XlaTestCase):
+class TestParallelTensorMNIST(test_utils.XlaTestCase):
 
   def test(self):
     devices = xm.get_xla_supported_devices()
@@ -612,7 +233,7 @@ class TestParallelTensorMNIST(XlaTestCase):
     model_parallel(loop_fn, train_loader)
 
 
-class TestParallelTensorResnet18(XlaTestCase):
+class TestParallelTensorResnet18(test_utils.XlaTestCase):
 
   def test(self):
     devices = xm.get_xla_supported_devices()
@@ -643,7 +264,7 @@ class TestParallelTensorResnet18(XlaTestCase):
     model_parallel(loop_fn, train_loader)
 
 
-class TestLongGraphChain(XlaTestCase):
+class TestLongGraphChain(test_utils.XlaTestCase):
 
   def test(self):
     device = xm.xla_device()
@@ -656,10 +277,11 @@ class TestLongGraphChain(XlaTestCase):
     for i in range(0, 2000):
       x = x + 2 * y
       xla_x = xla_x + 2 * xla_y
-    self.assertEqualRel(x, xla_x.cpu(), rel_err=1e-3, abs_err=5)
+    self.assertEqualRel(
+        x, xla_x.cpu(), FLAGS.max_diff_count, rel_err=1e-3, abs_err=5)
 
 
-class TestSelect(XlaTestCase):
+class TestSelect(test_utils.XlaTestCase):
 
   def test_get_xla_tensor(self):
     x = _gen_tensor(14, 24, 8, device=xm.xla_device())
@@ -669,7 +291,7 @@ class TestSelect(XlaTestCase):
     self.assertEqual(tx, sx.data.cpu())
 
 
-class TestRandom(XlaTestCase):
+class TestRandom(test_utils.XlaTestCase):
 
   def test_random_from_to_bool(self):
     for from_val, to_val in [[0, 1], [0, 2], [1, 2]]:
@@ -680,7 +302,7 @@ class TestRandom(XlaTestCase):
       self.assertTrue((to_val - delta) <= x.to(torch.int).max() < to_val)
 
 
-class TestBinaryCrossEntropyLimitValue(XlaTestCase):
+class TestBinaryCrossEntropyLimitValue(test_utils.XlaTestCase):
 
   def test_cross_entropy_loss(self):
 
@@ -694,7 +316,7 @@ class TestBinaryCrossEntropyLimitValue(XlaTestCase):
       self.runAtenTest([pred - offset, target], test_fn)
 
 
-class TestNllLossLimitValue(XlaTestCase):
+class TestNllLossLimitValue(test_utils.XlaTestCase):
 
   def test_nll_loss_inf(self):
 
@@ -720,7 +342,7 @@ class TestNllLossLimitValue(XlaTestCase):
       self.runAtenTest([logits, target_tensor], test_fn)
 
 
-class TestInterOpSyncTensors(XlaTestCase):
+class TestInterOpSyncTensors(test_utils.XlaTestCase):
 
   def test_inter_op_sync(self):
 
@@ -734,48 +356,7 @@ class TestInterOpSyncTensors(XlaTestCase):
     self.runAtenTest([x], test_fn)
 
 
-class TestDynamicShape(XlaTestCase):
-
-  def test_nonzero_shape(self):
-    x = torch.tensor((0, 1, 2, 0, 3, 4), device=xm.xla_device())
-    x_dim0_shape = torch_xla._XLAC._get_xla_tensor_dimension_size(
-        torch.nonzero(x, as_tuple=False), 0)
-    self.assertEqual(x_dim0_shape.item(), 4)
-
-  def test_masked_select_shape(self):
-    x = torch.tensor((0, 1, 2, 0, 3, 4), device=xm.xla_device())
-    mask = x.ge(2)
-    x_dim0_shape = torch_xla._XLAC._get_xla_tensor_dimension_size(
-        torch.masked_select(x, mask), 0)
-    self.assertEqual(x_dim0_shape.item(), 3)
-
-  def test_nonzero_cast(self):
-    t1 = torch.ones(5, 2, device=xm.xla_device())
-    # Result of the nonzero should be the index type. Currently
-    # index type is s64 on cpu and gpu, but s32 on TPU. We should be
-    # able to cast it to any other type without error.
-    t2 = torch.nonzero(t1.int()).float()
-    xm.mark_step()
-
-  def test_expand_symint_correctness(self):
-    dev = xm.xla_device()
-    size1 = 5
-    size2 = 2
-    t1 = torch.ones([size1, size2])
-    expand_out_aten = t1.expand(2, size1, size2)
-
-    t2 = torch.zeros([size1, size2], device=dev)
-    t2[3][0] = 1
-    t2[3][1] = 1
-    # t2 has size [<=10, 2]
-    t3 = torch.nonzero(t2)
-    t4 = torch.ones([size1, size2], device=dev)
-    expand_out_xla = t4.expand(t3.shape[0], size1, size2)
-    self.assertEqual(t3.shape[0], 2)
-    self.assertEqual(expand_out_aten.cpu(), expand_out_xla.cpu())
-
-
-class TestOptimizationBarrier(XlaTestCase):
+class TestOptimizationBarrier(test_utils.XlaTestCase):
 
   def test_optimization_barrier_correctness(self):
     device = xm.xla_device()
@@ -789,7 +370,7 @@ class TestOptimizationBarrier(XlaTestCase):
     self.assertEqual(z, x + y)
 
 
-class TestDataType(XlaTestCase):
+class TestDataType(test_utils.XlaTestCase):
 
   def test_mixed_dtype_tuple(self):
 
@@ -804,7 +385,7 @@ class TestDataType(XlaTestCase):
     self.assertEqual(a_cast.dtype, torch.bfloat16)
 
 
-class TestAtenXlaTensor(XlaTestCase):
+class TestAtenXlaTensor(test_utils.XlaTestCase):
 
   def test_get_real_xla_devices(self):
     devices = xm.get_xla_supported_devices()
@@ -1952,7 +1533,7 @@ class MNISTComparator(nn.Module):
     return x
 
 
-class TestModelComparator(XlaTestCase):
+class TestModelComparator(test_utils.XlaTestCase):
 
   def test(self):
     SEED = 42
@@ -1979,7 +1560,7 @@ class TestModelComparator(XlaTestCase):
     self.assertEqual(len(report), 0)
 
 
-class TestAsyncScalar(XlaTestCase):
+class TestAsyncScalar(test_utils.XlaTestCase):
 
   def test_rng_seed_transfer(self):
     xla_device = xm.xla_device()
@@ -2015,7 +1596,7 @@ class TestAsyncScalar(XlaTestCase):
       assert met.metric_data("TransferToServerAsync") == None
 
 
-class TestOpBuilder(XlaTestCase):
+class TestOpBuilder(test_utils.XlaTestCase):
 
   def runOpBuilderTest(self,
                        name,
@@ -2141,7 +1722,7 @@ class TestOpBuilder(XlaTestCase):
         })
 
 
-class MpDecoratorTest(XlaTestCase):
+class MpDecoratorTest(test_utils.XlaTestCase):
 
   @xtu.mp_test
   def test_mp_decorator(self):
@@ -2149,7 +1730,7 @@ class MpDecoratorTest(XlaTestCase):
     self.assertTrue(xla_device.type == 'xla')
 
 
-class XpTraceTest(XlaTestCase):
+class XpTraceTest(test_utils.XlaTestCase):
 
   def test_non_empty_scope(self):
     with self.assertRaisesRegex(
@@ -2158,7 +1739,7 @@ class XpTraceTest(XlaTestCase):
         xm.mark_step()
 
 
-class RegisterXLAKeyTest(XlaTestCase):
+class RegisterXLAKeyTest(test_utils.XlaTestCase):
 
   def test_multi_init_xla_backend(self):
     torch_xla._XLAC._init_xla_lazy_backend()
@@ -2166,7 +1747,7 @@ class RegisterXLAKeyTest(XlaTestCase):
     self.assertEqual(met.counter_value("RegisterXLAFunctions"), 1)
 
 
-class TestGeneric(XlaTestCase):
+class TestGeneric(test_utils.XlaTestCase):
 
   def test_zeros_like_patch(self):
     a = torch.ones(3, 3)

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -280,7 +280,12 @@ class TestLongGraphChain(test_utils.XlaTestCase):
     for i in range(0, 2000):
       x = x + 2 * y
       xla_x = xla_x + 2 * xla_y
-    self.assertEqualRel(x, xla_x.cpu(), rel_err=1e-3, abs_err=5, max_diff_count=FLAGS.max_diff_count)
+    self.assertEqualRel(
+        x,
+        xla_x.cpu(),
+        rel_err=1e-3,
+        abs_err=5,
+        max_diff_count=FLAGS.max_diff_count)
 
 
 class TestSelect(test_utils.XlaTestCase):

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1602,6 +1602,7 @@ class TestOpBuilder(test_utils.XlaTestCase):
                        name,
                        tensors,
                        opfn,
+                       max_diff_count=FLAGS.max_diff_count,
                        aten_fn=None,
                        device=None,
                        rel_err=1e-2,
@@ -1618,7 +1619,7 @@ class TestOpBuilder(test_utils.XlaTestCase):
     ]
     results = xu.as_list(aten_fn(*tensors, **kwargs))
     xla_results = xu.as_list(op(*xla_tensors, **kwargs))
-    self.compareResults(results, xla_results, rel_err=rel_err, abs_err=abs_err)
+    self.compareResults(results, xla_results, max_diff_count, rel_err=rel_err, abs_err=abs_err)
 
   def test_add(self):
 

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -772,7 +772,6 @@ class TestDynamicShape(XlaTestCase):
     t4 = torch.ones([size1, size2], device=dev)
     expand_out_xla = t4.expand(t3.shape[0], size1, size2)
     self.assertEqual(t3.shape[0], 2)
-    print(expand_out_xla)
     self.assertEqual(expand_out_aten.cpu(), expand_out_xla.cpu())
 
 

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -749,9 +749,6 @@ class TestDynamicShape(XlaTestCase):
         torch.masked_select(x, mask), 0)
     self.assertEqual(x_dim0_shape.item(), 3)
 
-  @unittest.skip(
-      "Temporarily disable test. See  https://github.com/pytorch/xla/issues/4501"
-  )
   def test_nonzero_cast(self):
     t1 = torch.ones(5, 2, device=xm.xla_device())
     # Result of the nonzero should be the index type. Currently

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -302,8 +302,12 @@ class XlaTestCase(unittest.TestCase):
     else:
       super(XlaTestCase, self).assertEqual(x, y, message)
 
-
-  def assertEqualRel(self, out, expected, rel_err=1e-2, abs_err=1e-5, max_diff_count=0):
+  def assertEqualRel(self,
+                     out,
+                     expected,
+                     rel_err=1e-2,
+                     abs_err=1e-5,
+                     max_diff_count=0):
     try:
       out, expected = _prepare_tensors_for_diff(out, expected)
       nan_mask = torch.isnan(expected)
@@ -334,17 +338,12 @@ class XlaTestCase(unittest.TestCase):
           max_diff_count=max_diff_count)
       raise
 
-
   def assertEqualDbg(self, out, expected, max_diff_count=0):
     try:
       super(XlaTestCase, self).assertEqual(out, expected)
     except:
       _dump_differences(
-          expected,
-          out,
-          rtol=1e-8,
-          atol=1e-8,
-          max_diff_count=max_diff_count)
+          expected, out, rtol=1e-8, atol=1e-8, max_diff_count=max_diff_count)
       raise
 
   def makeComparable(self, value):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,391 @@
+import sys
+import os
+import math
+from numbers import Number
+import collections
+import unittest
+import itertools
+import torch
+import numpy
+import random
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.utils.utils as xu
+
+
+def _set_rng_seed(seed):
+  torch.manual_seed(seed)
+  random.seed(seed)
+  numpy.random.seed(seed)
+  xm.set_rng_state(seed)
+
+
+def _prepare_tensors_for_diff(ta, tb):
+  a = ta.to(device='cpu')
+  b = tb.to(device='cpu')
+  if a.dtype == torch.float16 or a.dtype == torch.bfloat16:
+    a = a.to(torch.float32)
+  if b.dtype == torch.float16 or b.dtype == torch.bfloat16:
+    b = b.to(torch.float32)
+  if b.dtype != a.dtype:
+    b = b.to(a.dtype)
+  if xu.getenv_as('TEST_PRINT_TENSORS', bool, defval=False):
+    print('Tensor A ({}):\n{}'.format(ta.device, a), file=sys.stderr)
+    print('Tensor B ({}):\n{}'.format(tb.device, b), file=sys.stderr)
+  return a, b
+
+
+def _is_iterable(obj):
+  try:
+    iter(obj)
+    return True
+  except TypeError:
+    return False
+
+
+def _iter_indices(tensor):
+  if tensor.dim() == 0:
+    return range(0)
+  if tensor.dim() == 1:
+    return range(tensor.size(0))
+  return itertools.product(*(range(s) for s in tensor.size()))
+
+
+class Holder(object):
+  pass
+
+
+def _dump_differences(target, result, rtol=1e-5, atol=1e-3, max_diff_count=0):
+  env = Holder()
+  env.max_diff = 0.0
+  env.max_rel = None
+  env.max_index = None
+  env.diff_count = 0
+
+  def check_values(a, b, index):
+    a, b = _prepare_tensors_for_diff(a, b)
+    r = max(abs(a), abs(b)) * rtol
+    diff = abs(a - b)
+    if diff > max(r, atol):
+      print('a={}\tb={}\tdiff={}\tindex={}'.format(a, b, diff, index))
+      env.diff_count += 1
+      if diff > env.max_diff:
+        env.max_diff = diff
+        env.max_rel = diff / max(abs(a), abs(b))
+        env.max_index = index
+
+  if isinstance(target, torch.Tensor):
+    assert isinstance(result, torch.Tensor)
+    assert target.size() == result.size()
+    if target.dim() > 0:
+      for i in _iter_indices(target):
+        check_values(target[i], result[i], i)
+        if max_diff_count > 0 and env.diff_count >= max_diff_count:
+          break
+    else:
+      check_values(target.item(), result.item(), 0)
+  elif isinstance(target, (list, tuple)):
+    assert isinstance(result, (list, tuple))
+    assert len(target) == len(result)
+    for i, v in enumerate(target):
+      check_values(v, result[i], [i])
+      if max_diff_count > 0 and env.diff_count >= max_diff_count:
+        break
+  elif isinstance(target, float):
+    assert isinstance(result, float)
+    check_values(target, result, [])
+  if env.max_index is not None:
+    print('\nmax_diff={}\tmax_rel={}\tindex={}'.format(env.max_diff,
+                                                       env.max_rel,
+                                                       env.max_index))
+
+
+class XlaTestCase(unittest.TestCase):
+  PRECISION = 1e-5
+  STRING_CLASSES = (str, bytes)
+
+  def __init__(self, method_name='runTest'):
+    super(XlaTestCase, self).__init__(method_name)
+
+  def setUp(self):
+    _set_rng_seed(1234)
+
+  def safeCoalesce(self, t):
+    tc = t.coalesce()
+    self.assertEqual(tc.to_dense(), t.to_dense())
+    self.assertTrue(tc.is_coalesced())
+    # Our code below doesn't work when nnz is 0, because
+    # then it's a 0D tensor, not a 2D tensor.
+    if t._nnz() == 0:
+      self.assertEqual(t._indices(), tc._indices())
+      self.assertEqual(t._values(), tc._values())
+      return tc
+
+    value_map = {}
+    for idx, val in zip(t._indices().t(), t._values()):
+      idx_tup = tuple(idx.tolist())
+      if idx_tup in value_map:
+        value_map[idx_tup] += val
+      else:
+        value_map[idx_tup] = val.clone() if isinstance(val,
+                                                       torch.Tensor) else val
+
+    new_indices = sorted(list(value_map.keys()))
+    new_values = [value_map[idx] for idx in new_indices]
+    if t._values().ndimension() < 2:
+      new_values = t._values().new(new_values)
+    else:
+      new_values = torch.stack(new_values)
+    new_indices = t._indices().new(new_indices).t()
+    tg = t.new(new_indices, new_values, t.size())
+
+    self.assertEqual(tc._indices(), tg._indices())
+    self.assertEqual(tc._values(), tg._values())
+    if t.is_coalesced():
+      self.assertEqual(tc._indices(), t._indices())
+      self.assertEqual(tc._values(), t._values())
+
+    return tg
+
+  # This has been copied from pytorch/test/common_utils.py in order to decouple
+  # PyTorch/XLA tests from pytorch tests. We use this API only with a very
+  # limited set of object types, so it could be eventually simplified.
+  def assertEqual(self, x, y, prec=None, message='', allow_inf=False):
+    if isinstance(prec, str) and message == '':
+      message = prec
+      prec = None
+    if prec is None:
+      prec = self.PRECISION
+    if isinstance(x, torch.Tensor) and isinstance(y, Number):
+      self.assertEqual(
+          x.item(), y, prec=prec, message=message, allow_inf=allow_inf)
+    elif isinstance(y, torch.Tensor) and isinstance(x, Number):
+      self.assertEqual(
+          x, y.item(), prec=prec, message=message, allow_inf=allow_inf)
+    elif isinstance(x, torch.Tensor) and isinstance(y, numpy.bool_):
+      self.assertEqual(
+          x.item(), y, prec=prec, message=message, allow_inf=allow_inf)
+    elif isinstance(y, torch.Tensor) and isinstance(x, numpy.bool_):
+      self.assertEqual(
+          x, y.item(), prec=prec, message=message, allow_inf=allow_inf)
+    elif isinstance(x, torch.Tensor) and isinstance(y, torch.Tensor):
+
+      def assertTensorsEqual(a, b):
+        super(XlaTestCase, self).assertEqual(a.size(), b.size(), message)
+        if a.numel() > 0:
+          a, b = _prepare_tensors_for_diff(a, b)
+          if (a.dtype == torch.bool) != (b.dtype == torch.bool):
+            raise TypeError('Was expecting both tensors to be bool type.')
+          else:
+            if a.dtype == torch.bool and b.dtype == torch.bool:
+              # we want to respect precision but as bool doesn't support substraction,
+              # boolean tensor has to be converted to int
+              a = a.to(torch.int)
+              b = b.to(torch.int)
+
+            diff = a - b
+            # check that NaNs are in the same locations
+            nan_mask = torch.isnan(a)
+            self.assertTrue(torch.equal(nan_mask, torch.isnan(b)), message)
+            diff[nan_mask] = 0
+            # inf check if allow_inf=True
+            if allow_inf:
+              inf_mask = torch.isinf(a)
+              inf_sign = inf_mask.sign()
+              self.assertTrue(
+                  torch.equal(inf_sign,
+                              torch.isinf(b).sign()), message)
+              diff[inf_mask] = 0
+            # TODO: implement abs on CharTensor (int8)
+            if diff.is_signed() and diff.dtype != torch.int8:
+              diff = diff.abs()
+            max_err = diff.max()
+            self.assertLessEqual(max_err, prec, message)
+
+      super(XlaTestCase, self).assertEqual(x.is_sparse, y.is_sparse, message)
+      super(XlaTestCase, self).assertEqual(x.is_quantized, y.is_quantized,
+                                           message)
+      if x.is_sparse:
+        x = self.safeCoalesce(x)
+        y = self.safeCoalesce(y)
+        assertTensorsEqual(x._indices(), y._indices())
+        assertTensorsEqual(x._values(), y._values())
+      elif x.is_quantized and y.is_quantized:
+        self.assertEqual(
+            x.qscheme(),
+            y.qscheme(),
+            prec=prec,
+            message=message,
+            allow_inf=allow_inf)
+        if x.qscheme() == torch.per_tensor_affine:
+          self.assertEqual(
+              x.q_scale(),
+              y.q_scale(),
+              prec=prec,
+              message=message,
+              allow_inf=allow_inf)
+          self.assertEqual(
+              x.q_zero_point(),
+              y.q_zero_point(),
+              prec=prec,
+              message=message,
+              allow_inf=allow_inf)
+        elif x.qscheme() == torch.per_channel_affine:
+          self.assertEqual(
+              x.q_per_channel_scales(),
+              y.q_per_channel_scales(),
+              prec=prec,
+              message=message,
+              allow_inf=allow_inf)
+          self.assertEqual(
+              x.q_per_channel_zero_points(),
+              y.q_per_channel_zero_points(),
+              prec=prec,
+              message=message,
+              allow_inf=allow_inf)
+          self.assertEqual(
+              x.q_per_channel_axis(),
+              y.q_per_channel_axis(),
+              prec=prec,
+              message=message)
+        self.assertEqual(x.dtype, y.dtype)
+        self.assertEqual(
+            x.int_repr().to(torch.int32),
+            y.int_repr().to(torch.int32),
+            prec=prec,
+            message=message,
+            allow_inf=allow_inf)
+      else:
+        assertTensorsEqual(x, y)
+    elif isinstance(x, self.STRING_CLASSES) and isinstance(
+        y, self.STRING_CLASSES):
+      super(XlaTestCase, self).assertEqual(x, y, message)
+    elif type(x) == set and type(y) == set:
+      super(XlaTestCase, self).assertEqual(x, y, message)
+    elif isinstance(x, dict) and isinstance(y, dict):
+      if isinstance(x, collections.OrderedDict) and isinstance(
+          y, collections.OrderedDict):
+        self.assertEqual(
+            x.items(),
+            y.items(),
+            prec=prec,
+            message=message,
+            allow_inf=allow_inf)
+      else:
+        self.assertEqual(
+            set(x.keys()),
+            set(y.keys()),
+            prec=prec,
+            message=message,
+            allow_inf=allow_inf)
+        key_list = list(x.keys())
+        self.assertEqual([x[k] for k in key_list], [y[k] for k in key_list],
+                         prec=prec,
+                         message=message,
+                         allow_inf=allow_inf)
+    elif _is_iterable(x) and _is_iterable(y):
+      super(XlaTestCase, self).assertEqual(len(x), len(y), message)
+      for x_, y_ in zip(x, y):
+        self.assertEqual(
+            x_, y_, prec=prec, message=message, allow_inf=allow_inf)
+    elif isinstance(x, bool) and isinstance(y, bool):
+      super(XlaTestCase, self).assertEqual(x, y, message)
+    elif isinstance(x, Number) and isinstance(y, Number):
+      if abs(x) == math.inf or abs(y) == math.inf:
+        if allow_inf:
+          super(XlaTestCase, self).assertEqual(x, y, message)
+        else:
+          self.fail('Expected finite numeric values - x={}, y={}'.format(x, y))
+        return
+      super(XlaTestCase, self).assertLessEqual(abs(x - y), prec, message)
+    else:
+      super(XlaTestCase, self).assertEqual(x, y, message)
+
+  def assertEqualRel(self,
+                     out,
+                     expected,
+                     max_diff_count,
+                     rel_err=1e-2,
+                     abs_err=1e-5):
+    try:
+      out, expected = _prepare_tensors_for_diff(out, expected)
+      nan_mask = torch.isnan(expected)
+      self.assertTrue(torch.equal(nan_mask, torch.isnan(out)))
+      out[nan_mask] = 0
+      expected[nan_mask] = 0
+      inf_mask = torch.isinf(expected)
+      self.assertTrue(torch.equal(inf_mask, torch.isinf(out)))
+      out[inf_mask] = 0
+      expected[inf_mask] = 0
+      diff_tensor = (out - expected).abs().float()
+      max_rel_err = torch.max(out.abs(), expected.abs()).float() * rel_err
+      # Allow higher relative differences as long as we're still below the
+      # absolute error.
+      max_abs_err = torch.max(max_rel_err,
+                              torch.ones_like(out).float() * abs_err)
+      super(XlaTestCase, self).assertEqual(diff_tensor.size(),
+                                           max_abs_err.size())
+      if (diff_tensor.numel() > 0 and
+          torch.le(diff_tensor, max_abs_err).min().item() == 0):
+        self.fail('Relative error higher than the maximum tolerance')
+    except:
+      _dump_differences(
+          expected,
+          out,
+          rtol=rel_err,
+          atol=abs_err,
+          max_diff_count=max_diff_count)
+      raise
+
+  def assertEqualDbg(self, out, expected, max_diff_count):
+    try:
+      super(XlaTestCase, self).assertEqual(out, expected)
+    except:
+      _dump_differences(
+          expected, out, rtol=1e-8, atol=1e-8, max_diff_count=max_diff_count)
+      raise
+
+  def makeComparable(self, value):
+    if isinstance(value, torch.Tensor):
+      if value.dtype == torch.bool:
+        value = value.to(dtype=torch.uint8)
+      if xm.is_xla_tensor(value.data):
+        return value.data.cpu()
+      return value.data
+    return value
+
+  def maybePrintGraph(self, tensors):
+    env = os.environ.get('TEST_PRINT_GRAPH', '').lower()
+    if env:
+      if env == 'text':
+        print(
+            'Test Graph:\n{}'.format(
+                torch_xla._XLAC._get_xla_tensors_text(tensors)),
+            file=sys.stderr)
+      elif env == 'hlo':
+        print(
+            'Test Graph:\n{}'.format(
+                torch_xla._XLAC._get_xla_tensors_hlo(tensors)),
+            file=sys.stderr)
+      else:
+        raise RuntimeError('Invalid TEST_PRINT_GRAPH value: {}'.format(env))
+
+  def compareResults(self, results, xla_results, rel_err=1e-2, abs_err=1e-5):
+    self.maybePrintGraph(xla_results)
+    for at, xt in zip(results, xla_results):
+      self.assertEqualRel(
+          self.makeComparable(xt),
+          self.makeComparable(at),
+          rel_err=rel_err,
+          abs_err=abs_err)
+
+  def runAtenTest(self, tensors, fn, device=None, rel_err=1e-2, abs_err=1e-5):
+    if device is None:
+      device = xm.xla_device()
+    tensors = xu.as_list(tensors)
+    xla_tensors = [
+        x.to(device).detach().requires_grad_(x.requires_grad) for x in tensors
+    ]
+    results = xu.as_list(fn(*tensors))
+    xla_results = xu.as_list(fn(*xla_tensors))
+    self.compareResults(results, xla_results, rel_err=rel_err, abs_err=abs_err)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -371,12 +371,13 @@ class XlaTestCase(unittest.TestCase):
       else:
         raise RuntimeError('Invalid TEST_PRINT_GRAPH value: {}'.format(env))
 
-  def compareResults(self, results, xla_results, rel_err=1e-2, abs_err=1e-5):
+  def compareResults(self, results, xla_results, max_diff_count, rel_err=1e-2, abs_err=1e-5):
     self.maybePrintGraph(xla_results)
     for at, xt in zip(results, xla_results):
       self.assertEqualRel(
           self.makeComparable(xt),
           self.makeComparable(at),
+          max_diff_count,
           rel_err=rel_err,
           abs_err=abs_err)
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -44,16 +44,16 @@ def _is_iterable(obj):
     return False
 
 
+class Holder(object):
+  pass
+
+
 def _iter_indices(tensor):
   if tensor.dim() == 0:
     return range(0)
   if tensor.dim() == 1:
     return range(tensor.size(0))
   return itertools.product(*(range(s) for s in tensor.size()))
-
-
-class Holder(object):
-  pass
 
 
 def _dump_differences(target, result, rtol=1e-5, atol=1e-3, max_diff_count=0):
@@ -302,12 +302,8 @@ class XlaTestCase(unittest.TestCase):
     else:
       super(XlaTestCase, self).assertEqual(x, y, message)
 
-  def assertEqualRel(self,
-                     out,
-                     expected,
-                     max_diff_count,
-                     rel_err=1e-2,
-                     abs_err=1e-5):
+
+  def assertEqualRel(self, out, expected, rel_err=1e-2, abs_err=1e-5, max_diff_count=0):
     try:
       out, expected = _prepare_tensors_for_diff(out, expected)
       nan_mask = torch.isnan(expected)
@@ -338,12 +334,17 @@ class XlaTestCase(unittest.TestCase):
           max_diff_count=max_diff_count)
       raise
 
-  def assertEqualDbg(self, out, expected, max_diff_count):
+
+  def assertEqualDbg(self, out, expected, max_diff_count=0):
     try:
       super(XlaTestCase, self).assertEqual(out, expected)
     except:
       _dump_differences(
-          expected, out, rtol=1e-8, atol=1e-8, max_diff_count=max_diff_count)
+          expected,
+          out,
+          rtol=1e-8,
+          atol=1e-8,
+          max_diff_count=max_diff_count)
       raise
 
   def makeComparable(self, value):
@@ -371,18 +372,12 @@ class XlaTestCase(unittest.TestCase):
       else:
         raise RuntimeError('Invalid TEST_PRINT_GRAPH value: {}'.format(env))
 
-  def compareResults(self,
-                     results,
-                     xla_results,
-                     max_diff_count,
-                     rel_err=1e-2,
-                     abs_err=1e-5):
+  def compareResults(self, results, xla_results, rel_err=1e-2, abs_err=1e-5):
     self.maybePrintGraph(xla_results)
     for at, xt in zip(results, xla_results):
       self.assertEqualRel(
           self.makeComparable(xt),
           self.makeComparable(at),
-          max_diff_count,
           rel_err=rel_err,
           abs_err=abs_err)
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,10 +1,11 @@
-import sys
-import os
-import math
-from numbers import Number
 import collections
-import unittest
 import itertools
+import math
+import os
+import sys
+import unittest
+from numbers import Number
+
 import torch
 import numpy
 import random

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -371,7 +371,12 @@ class XlaTestCase(unittest.TestCase):
       else:
         raise RuntimeError('Invalid TEST_PRINT_GRAPH value: {}'.format(env))
 
-  def compareResults(self, results, xla_results, max_diff_count, rel_err=1e-2, abs_err=1e-5):
+  def compareResults(self,
+                     results,
+                     xla_results,
+                     max_diff_count,
+                     rel_err=1e-2,
+                     abs_err=1e-5):
     self.maybePrintGraph(xla_results)
     for at, xt in zip(results, xla_results):
       self.assertEqualRel(


### PR DESCRIPTION
This PR:
- add expand_symint test to replace the cpp counterpart test: AtenXlaTensorTest.TestExpandSymIntSymbolic and AtenXlaTensorTest.TestExpandSymIntDynamic
- re-enable test AtenXlaTensorTest.TestNonzero
- re-enable test TestDynamicShape.test_nonzero_cast