### PR TITLE
Fix test_forward_pass_dynamic_input_compile_once

### DIFF
--- a/test/test_dynamic_shape_models.py
+++ b/test/test_dynamic_shape_models.py
@@ -135,9 +135,9 @@ class TestDynamicShapeModels(unittest.TestCase):
       for j in range(num_features):
         x_test[i][j] = 1
         num_non_zero_added += 1
-        if num_non_zero_added == num_non_zero_added:
+        if num_non_zero_added == num_non_zeros:
           break
-      if num_non_zero_added == num_non_zero_added:
+      if num_non_zero_added == num_non_zeros:
         break
 
     num_non_zero_added = 0
@@ -145,7 +145,7 @@ class TestDynamicShapeModels(unittest.TestCase):
     for i in range(num_test_samples * 2):
       y_test[i] = 1
       num_non_zero_added += 1
-      if num_non_zero_added == num_non_zero_added:
+      if num_non_zero_added == num_non_zeros:
         break
 
     x_test_xla = x_test.to(device)

--- a/test/test_dynamic_shape_models.py
+++ b/test/test_dynamic_shape_models.py
@@ -73,8 +73,8 @@ class TestDynamicShapeModels(unittest.TestCase):
     for i in range(10):
       num_features = 2
       num_test_samples = 5
-      x_test, y_test = self.create_dynamic_test_data(num_test_samples,
-                                                     num_features, xla_dev, num_non_zeros=i)
+      x_test, y_test = self.create_dynamic_test_data(
+          num_test_samples, num_features, xla_dev, num_non_zeros=i)
 
       model = Feedforward(num_features, hidden_size=10).to(xla_dev)
       criterion = torch.nn.BCELoss()
@@ -88,7 +88,9 @@ class TestDynamicShapeModels(unittest.TestCase):
           num_compilation = met.metric_data('CompileTime')[0]
           num_compilation_recorded = True
         else:
-          self.assertEqual(num_compilation, met.metric_data('CompileTime')[0], 'number of compilation should not increase.')
+          self.assertEqual(num_compilation,
+                           met.metric_data('CompileTime')[0],
+                           'number of compilation should not increase.')
 
   @unittest.skip(
       "disable it due to https://github.com/pytorch/xla/pull/4322#issuecomment-1374312614."
@@ -122,7 +124,11 @@ class TestDynamicShapeModels(unittest.TestCase):
       xm.mark_step()
     print('Test passed.')
 
-  def create_dynamic_test_data(self, num_test_samples, num_features, device, num_non_zeros = 1):
+  def create_dynamic_test_data(self,
+                               num_test_samples,
+                               num_features,
+                               device,
+                               num_non_zeros=1):
     x_test = torch.zeros(num_test_samples, num_features)
     num_non_zero_added = 0
     for i in range(num_test_samples):


### PR DESCRIPTION
The current `test_forward_pass_dynamic_input_compile_once` is easy to break: the number of compilation varies when the functionalization is enabled or not. This PR is intended to make it more stable.