### PR TITLE
[PJRT] Slice literals to return correct dynamic shape

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -158,8 +158,10 @@ function run_torch_xla_tests() {
     pushd test/cpp
     echo "Running C++ Tests on XRT"
     ./run_tests.sh
-    echo "Running C++ Tests on PJRT"
-    PJRT_DEVICE=CPU ./run_tests.sh
+    if [ -z "$GPU_NUM_DEVICES" ];  then
+      echo "Running C++ Tests on PJRT"
+      PJRT_DEVICE=CPU ./run_tests.sh
+    fi
 
     if ! [ -x "$(command -v nvidia-smi)"  ]
     then

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -156,8 +156,10 @@ function run_torch_xla_tests() {
     fi
 
     pushd test/cpp
-    echo "Running C++ Tests"
+    echo "Running C++ Tests on XRT"
     ./run_tests.sh
+    echo "Running C++ Tests on PJRT"
+    PJRT_DEVICE=CPU ./run_tests.sh
 
     if ! [ -x "$(command -v nvidia-smi)"  ]
     then

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -158,7 +158,8 @@ function run_torch_xla_tests() {
     pushd test/cpp
     echo "Running C++ Tests on XRT"
     ./run_tests.sh
-    if [ -z "$GPU_NUM_DEVICES" ];  then
+    # TODO(wcromar): Enable PJRT C++ tests on GPU
+    if [ -z "$GPU_NUM_DEVICES" ]; then
       echo "Running C++ Tests on PJRT"
       PJRT_DEVICE=CPU ./run_tests.sh
     fi

--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -129,6 +129,8 @@ class PjRtComputationClient : public ComputationClient {
   std::shared_ptr<PjRtClient> client_;
   std::unordered_map<std::string, xla::PjRtDevice* const> string_to_device_;
   std::shared_ptr<std::vector<std::string>> replication_devices_;
+  // TODO(wcromar): Remove this when PJRT C API supports logical_on_device_shape
+  bool supports_logical_on_device_shape_ = true;
 
   xla::PjRtDevice* StringToPjRtDevice(const std::string& device);
 


### PR DESCRIPTION
PJRT allocates a literal according to the maximum bounded size of a buffer: https://github.com/tensorflow/tensorflow/blob/315e5e897f20d111afd1d65fbeaefeca233c9672/tensorflow/compiler/xla/pjrt/pjrt_client.h#L825-L826

This leads to dynamically shaped tensors being padded with uninitialized data up to the dynamic size. For example:

```
PJRT_DEVICE=CPU XLA_EXPERIMENTAL=nonzero python3
>>> import torch
>>> import torch_xla.core.xla_model as xm
>>> x = torch.randn((2, 2), device=xm.xla_device())
>>> i = torch.tensor([[False, True], [False, False]], device=xm.xla_device())
>>> x
tensor([[ 1.3344,  1.0886],
        [-1.3762,  1.0890]], device='xla:0')
>>> x[i]
tensor([1.0886e+00, 7.9192e+08, 9.2642e+19, 1.0769e-19], device='xla:0')
```

Unfortunately, the underlying runtime implementations copy the entire buffer up to the bounded size into whichever `xla::Literal` we pass into `ToLiteralSync` ([TFRT:CPU, for example](https://github.com/tensorflow/tensorflow/blob/ef82912d9d452dd24ade8407e24649b9736cba2b/tensorflow/compiler/xla/pjrt/tfrt_cpu_pjrt_client.cc#L1085)), which prevents us from just passing in a correctly-sized literal. Instead, we must let PJRT copy the data into a larger literal, and copy the slice of the data we need into a smaller literal.

This change if effectively a no-op for any buffer that already has a static shape. The PJRT C API does not support `logical_on_device_shape` yet, so the behavior is effectively unchanged. I confirmed this change does not affect the performance of our ResNet50 benchmark on TPU v4.

Fixes the remaining C++ tests on CPU.