### PR TITLE
Update CUDA ver to 11.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,8 @@ launch_docker_and_build: &launch_docker_and_build
     # if image layers are not present in the repo.
     # Note: disable the following 2 lines while testing a new image, so we do not
     # push to the upstream.
-    # docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:v1.0 >/dev/null
-    # docker push ${ECR_DOCKER_IMAGE_BASE}:v1.0 >/dev/null
+    docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:v1.0 >/dev/null
+    docker push ${ECR_DOCKER_IMAGE_BASE}:v1.0 >/dev/null
     sudo pkill -SIGHUP dockerd
     # To enable remote caching, use SCCACHE_BUCKET=${SCCACHE_BUCKET}
     # To disable remote caching, use SCCACHE_BUCKET=${LOCAL_BUCKET}
@@ -84,7 +84,7 @@ calculate_docker_image: &calculate_docker_image
     # For staging our build image in ECR for upstream testing
     echo "declare -x ECR_DOCKER_IMAGE_BASE=308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/xla_base" >> "${BASH_ENV}"
     # For PyTorch/XLA CI workflow, we only pull & push to gcr.io
-    echo "declare -x GCR_DOCKER_IMAGE=gcr.io/tpu-pytorch/xla_base:cuda_11_7" >> "${BASH_ENV}"
+    echo "declare -x GCR_DOCKER_IMAGE=gcr.io/tpu-pytorch/xla_base:latest" >> "${BASH_ENV}"
 
 run_build: &run_build
   resource_class: 2xlarge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,8 @@ launch_docker_and_build: &launch_docker_and_build
     # if image layers are not present in the repo.
     # Note: disable the following 2 lines while testing a new image, so we do not
     # push to the upstream.
-    docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:v0.9 >/dev/null
-    docker push ${ECR_DOCKER_IMAGE_BASE}:v0.9 >/dev/null
+    # docker tag ${GCR_DOCKER_IMAGE} ${ECR_DOCKER_IMAGE_BASE}:v1.0 >/dev/null
+    # docker push ${ECR_DOCKER_IMAGE_BASE}:v1.0 >/dev/null
     sudo pkill -SIGHUP dockerd
     # To enable remote caching, use SCCACHE_BUCKET=${SCCACHE_BUCKET}
     # To disable remote caching, use SCCACHE_BUCKET=${LOCAL_BUCKET}
@@ -84,7 +84,7 @@ calculate_docker_image: &calculate_docker_image
     # For staging our build image in ECR for upstream testing
     echo "declare -x ECR_DOCKER_IMAGE_BASE=308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/xla_base" >> "${BASH_ENV}"
     # For PyTorch/XLA CI workflow, we only pull & push to gcr.io
-    echo "declare -x GCR_DOCKER_IMAGE=gcr.io/tpu-pytorch/xla_base:latest" >> "${BASH_ENV}"
+    echo "declare -x GCR_DOCKER_IMAGE=gcr.io/tpu-pytorch/xla_base:cuda_11_7" >> "${BASH_ENV}"
 
 run_build: &run_build
   resource_class: 2xlarge

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -1,6 +1,6 @@
 # This requires cuda & cudnn packages pre-installed in the base image.
 # Other available cuda images are listed at https://hub.docker.com/r/nvidia/cuda
-ARG base_image="nvidia/cuda:11.2.0-cudnn8-devel-ubuntu18.04"
+ARG base_image="nvidia/cuda:11.7.0-cudnn8-devel-ubuntu18.04"
 FROM "${base_image}"
 
 ARG python_version="3.8"

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -42,10 +42,6 @@ ENV CXXFLAGS "${CXXFLAGS} -D_GLIBCXX_USE_CXX11_ABI=${cxx_abi}"
 # Whether to build for TPUVM mode
 ENV TPUVM_MODE "${tpuvm}"
 
-# Remove deprecated deb repo:
-# https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64
-RUN rm /etc/apt/sources.list.d/nvidia-ml.list
-
 # Rotate nvidia repo public key (last updated: 04/27/2022)
 # Unfortunately, nvidia/cuda image is shipped with invalid public key
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub

--- a/.circleci/docker/cloudbuild.yaml
+++ b/.circleci/docker/cloudbuild.yaml
@@ -23,7 +23,7 @@ options:
     substitution_option: 'ALLOW_LOOSE'
 substitutions:
     _CUDA: '1'
-    _CUDA_TAG: '11.2.0-cudnn8-devel-ubuntu18.04'
+    _CUDA_TAG: '11.7.0-cudnn8-devel-ubuntu18.04'
     _PYTHON_VERSION: '3.7'
     _TAG_NAME: '${_PYTHON_VERSION}-${_CUDA_TAG}-mini'
 timeout: 3000s


### PR DESCRIPTION
PyTorch 2.0 will move to CUDA 11.7, CUDNN 8.5.0.96 -- and we are still teseting and releasing wheels/images with CUDA 11.2. More details about PyTorch CUDA support plan, https://pytorch.org/blog/deprecation-cuda-python-support/