### PR TITLE
Update the list of supported CUDA images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,26 +65,36 @@ The following pre-built docker images are available. For running dockers, check 
 | Version | Cloud TPU VMs Docker |
 | --- | ----------- |
 1.13 | `gcr.io/tpu-pytorch/xla:r1.13_3.8_tpuvm` |
-1.12 | `gcr.io/tpu-pytorch/xla:r1.12_3.8_tpuvm` | 
+1.12 | `gcr.io/tpu-pytorch/xla:r1.12_3.8_tpuvm` |
 nightly | `gcr.io/tpu-pytorch/xla:nightly_3.8_tpuvm` |
 nightly at date | `gcr.io/tpu-pytorch/xla:nightly_3.8_YYYYMMDD` |
 
 <br/>
 
-| Version | GPU CUDA 11.2 + Python 3.7 Docker | 
+| Version | GPU CUDA 11.2 + Python 3.7 Docker |
 | --- | ----------- |
 1.13 | `gcr.io/tpu-pytorch/xla:r1.13_3.7_cuda_11.2` |
 1.12 | `gcr.io/tpu-pytorch/xla:r1.12_3.7_cuda_11.2` |
-nightly | `gcr.io/tpu-pytorch/xla:nightly_3.7_cuda_11.2` |
-nightly at date | `gcr.io/tpu-pytorch/xla:nightly_3.7_cuda_11.2_YYYYMMDD`  |
 
 <br/>
 
 | Version | GPU CUDA 11.2 + Python 3.8 Docker |
 | --- | ----------- |
 | 1.13 | `gcr.io/tpu-pytorch/xla:r1.13_3.8_cuda_11.2` |
-| nightly | `gcr.io/tpu-pytorch/xla:nightly_3.8_cuda_11.2` |
-| nightly at date(>=20221128) | `gcr.io/tpu-pytorch/xla:nightly_3.8_cuda_11.2_YYYYMMDD` |
+
+<br/>
+
+| Version | GPU CUDA 11.7 + Python 3.8 Docker |
+| --- | ----------- |
+| nightly | `gcr.io/tpu-pytorch/xla:nightly_3.8_cuda_11.7` |
+| nightly at date(>=20230210) | `gcr.io/tpu-pytorch/xla:nightly_3.8_cuda_11.7_YYYYMMDD` |
+
+<br/>
+
+| Version | GPU CUDA 11.8 + Python 3.8 Docker |
+| --- | ----------- |
+| nightly | `gcr.io/tpu-pytorch/xla:nightly_3.8_cuda_11.8` |
+| nightly at date(>=20230210) | `gcr.io/tpu-pytorch/xla:nightly_3.8_cuda_11.8_YYYYMMDD` |
 
 To run on [compute instances with GPUs](https://cloud.google.com/compute/docs/gpus/create-vm-with-gpus).
 


### PR DESCRIPTION
We will start publishing CUDA 11.7 and CUDA 11.8 nightly images from 20230210, tentatively. 