### PR TITLE
[PJRT] Use TFRT TPU client by default

### DIFF
--- a/test/pjrt/test_experimental_pjrt.py
+++ b/test/pjrt/test_experimental_pjrt.py
@@ -1,8 +1,6 @@
-import concurrent.futures
 import os
-import time
+from unittest import mock
 
-import torch
 import torch_xla
 from absl.testing import absltest, parameterized
 import torch_xla.core.xla_env_vars as xenv
@@ -14,6 +12,12 @@ class TestExperimentalPjrt(parameterized.TestCase):
 
   def setUp(self):
     pjrt.set_device_type('CPU')
+
+  @parameterized.parameters(('CPU', 'CPU'), ('GPU', 'GPU'), ('TPU', 'TPU'),
+                            ('TPU_C_API', 'TPU'), ('TPU_LEGACY', 'TPU'))
+  def test_device_type(self, pjrt_device, expected):
+    with mock.patch.dict(os.environ, {'PJRT_DEVICE': pjrt_device}, clear=True):
+      self.assertEqual(pjrt.device_type(), expected)
 
   def test_using_pjrt(self):
     del os.environ[xenv.PJRT_DEVICE]

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -55,17 +55,17 @@ PjRtComputationClient::PjRtComputationClient() {
     bool async = sys_util::GetEnvBool(env::kEnvPjrtAsyncCpuClient, true);
     int cpu_device_count = sys_util::GetEnvInt(env::kEnvNumCpu, 1);
     client_ = std::move(xla::GetTfrtCpuClient(async, cpu_device_count).value());
-  } else if (device_type == "TPU_LEGACY") {
-    TF_VLOG(1) << "Initializing PjRt StreamExecutor TPU client...";
-    int64_t max_inflight_computations = sys_util::GetEnvInt(
-        env::kEnvPjRtTpuMaxInflightComputations, /*defval=*/32);
-    client_ = xla::GetTpuClient(max_inflight_computations).value();
   } else if (device_type == "TPU" || device_type == "TPU_C_API") {
     TF_VLOG(1) << "Initializing TFRT TPU client...";
     XLA_CHECK_OK(pjrt::LoadPjrtPlugin(
         "tpu", sys_util::GetEnvString(env::kEnvTpuLibraryPath, "libtpu.so")));
     supports_logical_on_device_shape_ = false;
     client_ = std::move(xla::GetCApiClient("TPU").value());
+  } else if (device_type == "TPU_LEGACY") {
+    TF_VLOG(1) << "Initializing PjRt StreamExecutor TPU client...";
+    int64_t max_inflight_computations = sys_util::GetEnvInt(
+        env::kEnvPjRtTpuMaxInflightComputations, /*defval=*/32);
+    client_ = xla::GetTpuClient(max_inflight_computations).value();
   } else if (device_type == "GPU") {
     TF_VLOG(1) << "Initializing PjRt GPU client...";
     bool async = sys_util::GetEnvBool(env::kEnvPjrtAsyncGpuClient, true);

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -55,13 +55,13 @@ PjRtComputationClient::PjRtComputationClient() {
     bool async = sys_util::GetEnvBool(env::kEnvPjrtAsyncCpuClient, true);
     int cpu_device_count = sys_util::GetEnvInt(env::kEnvNumCpu, 1);
     client_ = std::move(xla::GetTfrtCpuClient(async, cpu_device_count).value());
-  } else if (device_type == "TPU") {
-    TF_VLOG(1) << "Initializing PjRt TPU client...";
+  } else if (device_type == "TPU_LEGACY") {
+    TF_VLOG(1) << "Initializing PjRt StreamExecutor TPU client...";
     int64_t max_inflight_computations = sys_util::GetEnvInt(
         env::kEnvPjRtTpuMaxInflightComputations, /*defval=*/32);
     client_ = xla::GetTpuClient(max_inflight_computations).value();
-  } else if (device_type == "TPU_C_API") {
-    TF_VLOG(1) << "Initializing PjRt C API client...";
+  } else if (device_type == "TPU" || device_type == "TPU_C_API") {
+    TF_VLOG(1) << "Initializing TFRT TPU client...";
     XLA_CHECK_OK(pjrt::LoadPjrtPlugin(
         "tpu", sys_util::GetEnvString(env::kEnvTpuLibraryPath, "libtpu.so")));
     supports_logical_on_device_shape_ = false;

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -34,7 +34,7 @@ def set_device_type(pjrt_device: str) -> None:
 def device_type() -> Optional[str]:
   """Returns the currrent PjRt device type."""
   pjrt_device = xu.getenv_as(xenv.PJRT_DEVICE, str)
-  return 'TPU' if pjrt_device and pjrt_device.startswith('TPU') else pjrt_device
+  return pjrt_device.split('_')[0] if pjrt_device else pjrt_device
 
 
 def using_pjrt() -> bool:


### PR DESCRIPTION
This PR changes the behavior of `PJRT_DEVICE=TPU` to initialize a TFRT:TPU client through the PJRT C API. This is equivalent to `PJRT_DEVICE=TPU_C_API` before this PR.

I'm leaving `PJRT_DEVICE=TPU_C_API` for compatibility, and I'll include the StreamExecutor runtime as `PJRT_DEVICE=TPU_LEGACY` through at least the next release.

Example output:

```
$ PJRT_DEVICE=TPU TF_CPP_MIN_LOG_LEVEL=0 python -c 'import torch_xla.core.xla_model as xm; print(xm.xla_device())'
INFO:torch_xla:Letting libtpu.so load fail during _XLAC import. libtpu.so will be loaded from `libtpu` Python package when the ComputationClient is created.
2023-02-10 01:07:47.629434: I tensorflow/compiler/xla/stream_executor/tpu/tpu_initializer_helper.cc:266] Libtpu path is: libtpu.so
INFO:torch_xla:Using bundled libtpu.so (/workspaces/pjrt/pytorch/xla/torch_xla/lib/libtpu.so)
2023-02-10 01:07:47.733143: I tensorflow/compiler/xla/pjrt/pjrt_api.cc:96] GetPjrtApi was found for tpu at /workspaces/pjrt/pytorch/xla/torch_xla/lib/libtpu.so
2023-02-10 01:07:47.733212: I tensorflow/compiler/xla/pjrt/pjrt_api.cc:69] PJRT_Api is set for device type tpu
2023-02-10 01:07:47.733227: I tensorflow/compiler/xla/stream_executor/tpu/tpu_initializer_helper.cc:266] Libtpu path is: /workspaces/pjrt/pytorch/xla/torch_xla/lib/libtpu.so
2023-02-10 01:07:51.005663: I tensorflow/compiler/xla/pjrt/pjrt_c_api_client.cc:80] PjRtCApiClient created.
xla:0
$ PJRT_DEVICE=TPU_C_API TF_CPP_MIN_LOG_LEVEL=0 python -c 'import torch_xla.core.xla_model as xm; print(xm.xla_device())'
INFO:torch_xla:Letting libtpu.so load fail during _XLAC import. libtpu.so will be loaded from `libtpu` Python package when the ComputationClient is created.
2023-02-10 01:08:02.201162: I tensorflow/compiler/xla/stream_executor/tpu/tpu_initializer_helper.cc:266] Libtpu path is: libtpu.so
INFO:torch_xla:Using bundled libtpu.so (/workspaces/pjrt/pytorch/xla/torch_xla/lib/libtpu.so)
2023-02-10 01:08:02.304545: I tensorflow/compiler/xla/pjrt/pjrt_api.cc:96] GetPjrtApi was found for tpu at /workspaces/pjrt/pytorch/xla/torch_xla/lib/libtpu.so
2023-02-10 01:08:02.304611: I tensorflow/compiler/xla/pjrt/pjrt_api.cc:69] PJRT_Api is set for device type tpu
2023-02-10 01:08:02.304621: I tensorflow/compiler/xla/stream_executor/tpu/tpu_initializer_helper.cc:266] Libtpu path is: /workspaces/pjrt/pytorch/xla/torch_xla/lib/libtpu.so
2023-02-10 01:08:05.607381: I tensorflow/compiler/xla/pjrt/pjrt_c_api_client.cc:80] PjRtCApiClient created.
xla:0
$  PJRT_DEVICE=TPU_LEGACY TF_CPP_MIN_LOG_LEVEL=0 python -c 'import torch_xla.core.xla_model as xm; print(xm.xla_device())'
INFO:torch_xla:Letting libtpu.so load fail during _XLAC import. libtpu.so will be loaded from `libtpu` Python package when the ComputationClient is created.
2023-02-10 01:07:30.820580: I tensorflow/compiler/xla/stream_executor/tpu/tpu_initializer_helper.cc:266] Libtpu path is: libtpu.so
INFO:torch_xla:Using bundled libtpu.so (/workspaces/pjrt/pytorch/xla/torch_xla/lib/libtpu.so)
2023-02-10 01:07:30.924830: I tensorflow/compiler/xla/stream_executor/tpu/tpu_initializer_helper.cc:266] Libtpu path is: /workspaces/pjrt/pytorch/xla/torch_xla/lib/libtpu.so
2023-02-10 01:07:34.253140: I tensorflow/compiler/xla/service/service.cc:169] XLA service 0x563cf8c0da50 initialized for platform TPU (this does not guarantee that XLA will be used). Devices:
2023-02-10 01:07:34.253204: I tensorflow/compiler/xla/service/service.cc:177]   StreamExecutor device (0): TPU, 2a886c8
2023-02-10 01:07:34.253214: I tensorflow/compiler/xla/service/service.cc:177]   StreamExecutor device (1): TPU, 2a886c8
2023-02-10 01:07:34.253221: I tensorflow/compiler/xla/service/service.cc:177]   StreamExecutor device (2): TPU, 2a886c8
2023-02-10 01:07:34.253227: I tensorflow/compiler/xla/service/service.cc:177]   StreamExecutor device (3): TPU, 2a886c8
```