### PR TITLE
Add the counter check for dynamo tests

### DIFF
--- a/torch_xla/core/dynamo_bridge.py
+++ b/torch_xla/core/dynamo_bridge.py
@@ -315,10 +315,6 @@ def extract_compiled_graph(xla_model: torch.fx.GraphModule, xla_args):
     if debug:
       print(f"optimized_mod takes {time.time() - enter_ts} seconds overall")
 
-    if any(
-        torch_xla._XLAC._check_device_tensor_need_materialization(
-            str(xm.xla_device()))):
-      xm.mark_step()
     none_remover.add_nones(result)
     return result
 


### PR DESCRIPTION
Cleaning up the test and add the counter check back so it does not regress. There are some open issues but I want to get this one merge first

1. I have to remove the `mark_step` at the end of the optim_mod to get 3 graphs per step, I think this somehow has to do with `grad`
2. accessing `data.grad.cpu()` after backward after step 1 actually will trigger additional graph execution, I think this is due 1 above. It seems to me that `input.grad` does not fully materialized after the backward computation. It has pending IR like
```
print(torch_xla._XLAC._get_xla_tensors_text([data.grad]))
IR {
  %0 = f32[] prim::Constant(), xla_shape=f32[], value=1
  %1 = f32[4,3,224,224]{3,2,1,0} aten::expand(%0), xla_shape=f32[4,3,224,224]{3,2,1,0}, size=(4, 3, 224, 224)
  %2 = f32[4,3,224,224]{3,2,1,0} xla::device_data(), xla_shape=f32[4,3,224,224]{3,2,1,0}, device=CPU:0
  %3 = f32[4,3,224,224]{3,2,1,0} aten::mul(%2, %1), xla_shape=f32[4,3,224,224]{3,2,1,0}
  %4 = f32[4,3,224,224]{3,2,1,0} xla::device_data(), xla_shape=f32[4,3,224,224]{3,2,1,0}, device=CPU:0
  %5 = f32[4,3,224,224]{3,2,1,0} aten::add(%4, %3), xla_shape=f32[4,3,224,224]{3,2,1,0}, ROOT=0
}

FYI @shunting314 @wconstab 
```

I think we didn't hit this issue in the torch bench because we only run for 1 step and we have `mark_step` between steps to clear things up. I will continue looking into this issue, I think the right thing to do is to add a optimizer step in the test I have, which should simulate the real use case and that can also capture the `input.grad` in the same graph.

FYI @shunting314 @wconstab 