### PR TITLE
Support dynamism on "transpose" operation.

### DIFF
--- a/test/test_dynamic_shape_models.py
+++ b/test/test_dynamic_shape_models.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import sys
 
 parser = argparse.ArgumentParser(add_help=False)
@@ -12,6 +13,9 @@ import torch
 import torch_xla.core.xla_model as xm
 import torch_xla.debug.metrics as met
 
+# It enables us to run python implementations of CompositeAutogradImplicit ops.
+# CompositeAutogradImplicit means we don't have an explicit backward formula for an op instead an op is composed of a bunch of ops that do have backward formulas and combines this formulas is equivalent to differentiating the op explicitly.
+pd = torch._C._EnablePythonDispatcher()
 xla_dev = xm.xla_device()
 
 
@@ -93,9 +97,6 @@ class TestDynamicShapeModels(unittest.TestCase):
                            met.metric_data('CompileTime')[0],
                            'number of compilation should not increase.')
 
-  @unittest.skip(
-      "disable it due to https://github.com/pytorch/xla/pull/4322#issuecomment-1374312614."
-  )
   def test_backward_pass_with_dynamic_input(self):
     num_features = 2
     num_test_samples = 5
@@ -157,5 +158,8 @@ class TestDynamicShapeModels(unittest.TestCase):
 
 
 if __name__ == '__main__':
+  assert os.environ['XLA_EXPERIMENTAL'] != ''
   test = unittest.main(verbosity=FLAGS.verbosity, exit=False)
+  # DISABLE PYTHON DISPATCHER FLAG
+  del pd
   sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/test_dynamic_shape_models.py
+++ b/test/test_dynamic_shape_models.py
@@ -97,6 +97,9 @@ class TestDynamicShapeModels(unittest.TestCase):
                            met.metric_data('CompileTime')[0],
                            'number of compilation should not increase.')
 
+  @unittest.skip(
+      "disable it due to https://github.com/pytorch/xla/pull/4322#issuecomment-1374312614."
+  )
   def test_backward_pass_with_dynamic_input(self):
     num_features = 2
     num_test_samples = 5

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -144,6 +144,22 @@ class TestDynamicShapes(test_utils.XlaTestCase):
     self.assertIsInstance(t2.shape[1], int)
     self.assertEqual(t2.shape[1], 2)
 
+  def test_t_copy(self):
+    t1 = torch.tensor([[1,0,0,5,0,6],[1,3,2,0,0,1]], device=dev)
+    t2 = torch.nonzero(t1)
+    # t2.shape=torch.Size([<=12, 2]) with real size [7, 2]
+    self.assertEqual(str(t2.shape[0]), '<=12')
+    self.assertEqual(str(t2.shape[1]), '2')
+
+    t2_t = torch.t(t2)
+
+    self.assertIsInstance(t2_t.shape[0], int)
+    self.assertIsInstance(t2_t.shape[1], torch.SymInt)
+    self.assertEqual(str(t2_t.shape[0]), '2')
+    self.assertEqual(str(t2_t.shape[1]), '<=12')
+    self.assertEqual(t2_t.shape[0], 2)
+    self.assertEqual(t2_t.shape[1], 7)
+
   def test_nonzero_shape(self):
     x = torch.tensor((0, 1, 2, 0, 3, 4), device=xm.xla_device())
     x_dim0_shape = torch_xla._XLAC._get_xla_tensor_dimension_size(

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -9,7 +9,6 @@ import test_utils
 pd = torch._C._EnablePythonDispatcher()
 dev = xm.xla_device()
 
-
 class TestDynamicShapes(test_utils.XlaTestCase):
 
   def test_simple_expand(self):

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -9,6 +9,7 @@ import test_utils
 pd = torch._C._EnablePythonDispatcher()
 dev = xm.xla_device()
 
+
 class TestDynamicShapes(test_utils.XlaTestCase):
 
   def test_simple_expand(self):
@@ -144,7 +145,7 @@ class TestDynamicShapes(test_utils.XlaTestCase):
     self.assertEqual(t2.shape[1], 2)
 
   def test_t_copy(self):
-    t1 = torch.tensor([[1,0,0,5,0,6],[1,3,2,0,0,1]], device=dev)
+    t1 = torch.tensor([[1, 0, 0, 5, 0, 6], [1, 3, 2, 0, 0, 1]], device=dev)
     t2 = torch.nonzero(t1)
     # t2.shape=torch.Size([<=12, 2]) with real size [7, 2]
     self.assertEqual(str(t2.shape[0]), '<=12')

--- a/torch_xla/csrc/ops/permute.cpp
+++ b/torch_xla/csrc/ops/permute.cpp
@@ -44,9 +44,9 @@ std::string Permute::ToString() const {
 
 xla::Shape Permute::MakePermuteShape(const xla::Shape& source_shape,
                                      absl::Span<const int64_t> permutation) {
-  return XlaHelpers::GetDynamicReshape(
-      source_shape,
-      XlaHelpers::Permute(permutation, source_shape.dimensions()));
+  auto output_static_dims = XlaHelpers::Permute(permutation, source_shape.dimensions());
+  auto output_dyn_dims = XlaHelpers::Permute(permutation, source_shape.dynamic_dimensions());
+  return xla::ShapeUtil::MakeShape(source_shape.element_type(), output_static_dims, output_dyn_dims);
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/permute.cpp
+++ b/torch_xla/csrc/ops/permute.cpp
@@ -44,9 +44,12 @@ std::string Permute::ToString() const {
 
 xla::Shape Permute::MakePermuteShape(const xla::Shape& source_shape,
                                      absl::Span<const int64_t> permutation) {
-  auto output_static_dims = XlaHelpers::Permute(permutation, source_shape.dimensions());
-  auto output_dyn_dims = XlaHelpers::Permute(permutation, source_shape.dynamic_dimensions());
-  return xla::ShapeUtil::MakeShape(source_shape.element_type(), output_static_dims, output_dyn_dims);
+  auto output_static_dims =
+      XlaHelpers::Permute(permutation, source_shape.dimensions());
+  auto output_dyn_dims =
+      XlaHelpers::Permute(permutation, source_shape.dynamic_dimensions());
+  return xla::ShapeUtil::MakeShape(source_shape.element_type(),
+                                   output_static_dims, output_dyn_dims);
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2517,7 +2517,7 @@ XLATensorPtr trace(const XLATensorPtr& input) {
 }
 
 XLATensorPtr transpose(const XLATensorPtr& input, int64_t dim0, int64_t dim1) {
-  auto input_shape = input->shape();
+  xla::util::MaybeRef<xla::Shape> input_shape = input->shape();
   ViewInfo view_info;
   if (input_shape.get().rank() <= 1) {
     // return a view of self if input rank <=1
@@ -2525,7 +2525,7 @@ XLATensorPtr transpose(const XLATensorPtr& input, int64_t dim0, int64_t dim1) {
     view_info = ViewInfo(ViewInfo::Type::kNoOp, GetXlaShape(ir_value),
                          GetXlaShape(ir_value));
   } else {
-    auto permute_dims = torch::lazy::MakeTransposePermutation(
+    std::vector<int64_t> permute_dims = torch::lazy::MakeTransposePermutation(
         /*dim0=*/dim0, /*dim1=*/dim1, /*rank=*/input_shape.get().rank());
     view_info = ViewInfo(ViewInfo::Type::kPermute, input_shape, permute_dims);
   }


### PR DESCRIPTION
Currently the `test_backward_pass_with_dynamic_input` tests failed with error:
```
RuntimeError: /workspaces/work/pytorch/xla/torch_xla/csrc/helpers.cpp:273 : Check failed: out_size <= size_at_dyndim / input_shape.dimensions( input_dynamic_dimension) (2 vs. 1)
*** Begin stack trace ***
        tsl::CurrentStackTrace[abi:cxx11]()
        torch_xla::XlaHelpers::GetDynamicReshapeInfo(xla::Shape const&, absl::lts_20220623::Span<long const>)
        torch_xla::XlaHelpers::GetDynamicReshape(xla::Shape const&, absl::lts_20220623::Span<long const>)
        torch_xla::Permute::MakePermuteShape(xla::Shape const&, absl::lts_20220623::Span<long const>)
        torch_xla::ViewInfo::ViewInfo(torch_xla::ViewInfo::Type, xla::Shape, std::vector<long, std::allocator<long> >)
        torch_xla::tensor_methods::transpose(c10::intrusive_ptr<torch_xla::XLATensor, c10::detail::intrusive_target_default_null_type<torch_xla::XLATensor> > const&, long, long)
        torch_xla::XLANativeFunctions::t_copy(at::Tensor const&)
...
*** End stack trace ***
Unable to map dynamic dimension of shape s32[<=12,2]{1,0} to output sizes (2, 12)
```
This PR is intended to fix this error.

With this PR, the above test fails with another error:
```
======================================================================
ERROR: test_backward_pass_with_dynamic_input (__main__.TestDynamicShapeModels)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "pytorch/xla/test/test_dynamic_shape_models.py", line 115, in test_backward_pass_with_dynamic_input
    loss.backward()
  File "/home/ptxla/.local/lib/python3.8/site-packages/torch/_tensor.py", line 488, in backward
    torch.autograd.backward(
  File "/home/ptxla/.local/lib/python3.8/site-packages/torch/autograd/__init__.py", line 197, in backward
    Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
RuntimeError: `InlinedVector::at(size_type) const` failed bounds check
```
From the [stacktrace](https://paste.googleplex.com/6299248223059968), it seems something is wrong with `XLANativeFunctions::unsqueeze_copy` which I will fix in the next PR.