### PR TITLE
[Functionalization] Properly skip test_empty_strided

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -599,7 +599,7 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     xla_result = xla_base[:, torch.empty(0, 6, dtype=torch.int64)]
     self.assertEqual(result, xla_result)
 
-  @unittest.skip("Produce wrong results on grad_input")
+  @unittest.skip("grad_input produces wrong results after functionalization. pytorch/pytorch#91199")
   def test_empty_strided(self):
     xla_device = xm.xla_device()
     m = nn.Conv1d(4, 6, kernel_size=3, groups=2)

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -599,7 +599,9 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     xla_result = xla_base[:, torch.empty(0, 6, dtype=torch.int64)]
     self.assertEqual(result, xla_result)
 
-  @unittest.skip("grad_input produces wrong results after functionalization. pytorch/pytorch#91199")
+  @unittest.skip(
+      "grad_input produces wrong results after functionalization. pytorch/pytorch#91199"
+  )
   def test_empty_strided(self):
     xla_device = xm.xla_device()
     m = nn.Conv1d(4, 6, kernel_size=3, groups=2)


### PR DESCRIPTION
Summary:
Functionalization breaks torch.autograd.grad for us. The reason to skip the test is due to the followings:
1. We don't have other test cases or use cases that suggest we officially support torch.autograd.grad.
2. This test case suggested that it's testing test_empty_strided and not torch.autograd.grad.
3. We have cpp test: AtenXlaTensorTest.TestEmptyStrided to test empty_strided and it passes.

Therefore, we believe temporarily breaking torch.autograd.grad should be okay and we should skip the test. pytorch/pytorch#91199 is tracking the progress of the fix.

Test Plan:
CI.