### PR TITLE
Skip execution for extract_compiled_graph

### DIFF
--- a/test/dynamo/test_dynamo_integrations_util.py
+++ b/test/dynamo/test_dynamo_integrations_util.py
@@ -109,8 +109,8 @@ class PybindTest(unittest.TestCase):
     xla_dummy_model = dummy_model.to(xla_device)
     xla_out = xla_dummy_model(xla_input)
     hash = torch_xla._XLAC._get_graph_hash([xla_out])
-    # Force trigger an execution to cache this computation.
-    torch_xla._XLAC._xla_sync_multi([xla_out], [])
+    # Warm up the cache.
+    torch_xla._XLAC._xla_warm_up_cache([xla_out], [])
 
     # It is the caller of `run_cached_graph`'s job to make sure the input order
     # matches the graph input order. Upstream dynamo has a more completed

--- a/test/dynamo/test_num_output.py
+++ b/test/dynamo/test_num_output.py
@@ -82,10 +82,10 @@ class TestNumOutput(unittest.TestCase):
     graph_input_matcher = GraphInputMatcher(tensor_id_to_arg_idx,
                                             graph_input_tensor_ids,
                                             graph_input_xla_values)
-    torch_xla._XLAC._xla_sync_multi(outputs, [])
+    torch_xla._XLAC._xla_warm_up_cache(outputs, [])
 
     def run_cached_graph(*inputs):
-      torch_xla._XLAC._xla_sync_multi(inputs, [])
+      torch_xla._XLAC._xla_warm_up_cache(inputs, [])
       xla_graph_inputs = graph_input_matcher(inputs)
       xla_graph_outputs = torch_xla._XLAC._run_cached_graph(
           xla_graph_hash, xla_graph_inputs)

--- a/torch_xla/core/dynamo_bridge.py
+++ b/torch_xla/core/dynamo_bridge.py
@@ -275,8 +275,8 @@ def extract_compiled_graph(xla_model: torch.fx.GraphModule, xla_args):
                                           graph_input_tensor_ids,
                                           graph_input_xla_values)
 
-  # compiles+runs graph rooted at tensors in 'args_and_out'
-  torch_xla._XLAC._xla_sync_multi(args_and_out, [])
+  # compiles and cache graph rooted at tensors in 'args_and_out'
+  torch_xla._XLAC._xla_warm_up_cache(args_and_out, [])
   torch_xla._XLAC._clear_pending_irs(str(xm.xla_device()))
 
   def optimized_mod(*args):

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -329,7 +329,7 @@ std::pair<at::Tensor, std::shared_ptr<torch::lazy::Value>> Recv(
 
 void SyncTensors(const std::vector<at::Tensor>& tensors,
                  const std::vector<std::string>& devices, bool wait,
-                 bool sync_xla_data) {
+                 bool sync_xla_data, bool warm_up_cache_only = false) {
   std::vector<XLATensorPtr> xtensors =
       GetXlaTensors(tensors, /*want_all=*/false);
   XLAGraphExecutor::Get()->SyncTensorsGraph(&xtensors, devices, wait,
@@ -1240,6 +1240,14 @@ void InitXlaModuleBindings(py::module m) {
         },
         py::arg("tensors"), py::arg("devices"), py::arg("wait") = true,
         py::arg("sync_xla_data") = true);
+  m.def("_xla_warm_up_cache",
+        [](const std::vector<at::Tensor>& tensors,
+           const std::vector<std::string>& devices) {
+          NoGilSection nogil;
+          SyncTensors(tensors, devices, /*wait=*/false, /*sync_xla_data=*/false,
+                      /*warm_up_cache_only=*/true);
+        },
+        py::arg("tensors"), py::arg("devices"));
   m.def("_xla_sync_live_tensors",
         [](const std::string& device, const std::vector<std::string>& devices,
            bool wait) {

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -333,7 +333,7 @@ void SyncTensors(const std::vector<at::Tensor>& tensors,
   std::vector<XLATensorPtr> xtensors =
       GetXlaTensors(tensors, /*want_all=*/false);
   XLAGraphExecutor::Get()->SyncTensorsGraph(&xtensors, devices, wait,
-                                            sync_xla_data);
+                                            sync_xla_data, warm_up_cache_only);
 }
 
 void SyncLiveTensors(const std::string& device_str,

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -332,6 +332,9 @@ void XLAGraphExecutor::SyncTensorsGraph(std::vector<XLATensorPtr>* tensors,
       xla::sys_util::GetEnvBool("XLA_SYNC_TENSORS_OPBYOP", false);
   SyncTensorsConfig config;
   config.sync_ltc_data = sync_ltc_data;
+  if (warm_up_cache_only) {
+    config.force_ltc_data = false;
+  }
   if (op_by_op) {
     OpByOpAsync async = SyncTensorsGraphOpByOp(tensors, devices, config);
     if (wait) {
@@ -397,6 +400,7 @@ torch::lazy::hash_t XLAGraphExecutor::GetGraphHash(
     const std::vector<XLATensorPtr>& tensors) {
   SyncTensorsConfig config;
   config.sync_ltc_data = true;
+  config.force_ltc_data = false;
 
   SyncTensorCollection coll = CollectSyncTensors(tensors, config);
   absl::Span<const size_t> indices = coll.indices;

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -115,7 +115,7 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
   // We don't use the upstream one given we have OpbyOp mode.
   void SyncTensorsGraph(std::vector<XLATensorPtr>* tensors,
                         absl::Span<const std::string> devices, bool wait,
-                        bool sync_ltc_data);
+                        bool sync_ltc_data, bool warm_up_cache_only = false);
 
   // Makes sure that any outstanding IR operation accumulated over live tensors,
   // gets turned into device data. If wait is true, the sync operation will be
@@ -338,7 +338,7 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
   // our CachedComputation is different from upstream.
   std::shared_ptr<Async> SyncTensorsGraphInternal(
       std::vector<XLATensorPtr>* tensors, absl::Span<const std::string> devices,
-      const SyncTensorsConfig& config);
+      const SyncTensorsConfig& config, bool warm_up_cache_only = false);
 };
 
 }  // namespace torch_xla


### PR DESCRIPTION
Currently we use `xla_sync_multi` to force a execution which will warm up the cache for future dynamo runs, this is not ideal because
1. execution can be time consuming
2. `xla_sync_multi` is considered as a `mark_step` like sync and will trigger buffer aliasing. However we actually saved some XLA data when we cache the dynamo graph. Those buffer might be aliased during the `xla_sync_multi` and cause random crash when we actually execute the dynamo graph

confirmed that this change does not regress speed on TPU when running torchbench.

FYI @wconstab @will-cromar 