### PR TITLE
Remove reference to `torch._six` compat layer

### DIFF
--- a/scripts/bench_tensor_io.py
+++ b/scripts/bench_tensor_io.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 import argparse
 import threading
 import torch

--- a/scripts/cond_patch.py
+++ b/scripts/cond_patch.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 import argparse
 import glob
 import os

--- a/scripts/debug_run.py
+++ b/scripts/debug_run.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 import argparse
 import copy
 import getpass

--- a/scripts/dump_stacks.py
+++ b/scripts/dump_stacks.py
@@ -6,8 +6,6 @@
 #  echo 0 > /proc/sys/kernel/yama/ptrace_scope
 #
 
-from __future__ import print_function
-
 import argparse
 import stack_trace_parse as stp
 import subprocess

--- a/scripts/fixup_binary.py
+++ b/scripts/fixup_binary.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 import argparse
 import glob
 import os

--- a/scripts/gcsfs_bench.py
+++ b/scripts/gcsfs_bench.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 import argparse
 import concurrent.futures
 import time

--- a/scripts/grab_graphs.py
+++ b/scripts/grab_graphs.py
@@ -2,8 +2,6 @@
 # Parses the output of XLA_SAVE_TENSORS_FILE and produces statistics about graph
 # types and Python frames.
 
-from __future__ import print_function
-
 import argparse
 import collections
 import difflib

--- a/scripts/grab_metrics.py
+++ b/scripts/grab_metrics.py
@@ -8,8 +8,6 @@
 #   --synth 'LiveDataHandles:CreateDataHandles - DestroyDataHandles'
 #
 
-from __future__ import print_function
-
 import argparse
 import collections
 import fileinput

--- a/scripts/normalize_graph_text.py
+++ b/scripts/normalize_graph_text.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 import argparse
 import os
 import re

--- a/scripts/stack_trace_parse.py
+++ b/scripts/stack_trace_parse.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 import argparse
 import collections
 import re

--- a/scripts/tf_log_filter.py
+++ b/scripts/tf_log_filter.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 import argparse
 import os
 import re

--- a/test/metrics_compare_utils_test.py
+++ b/test/metrics_compare_utils_test.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 
 import torch

--- a/test/test_xla_dist.py
+++ b/test/test_xla_dist.py
@@ -1,6 +1,4 @@
 """Tests for xla_dist."""
-from __future__ import division
-from __future__ import print_function
 
 import cloud_tpu_client
 import uuid

--- a/torch_xla/_patched_functions.py
+++ b/torch_xla/_patched_functions.py
@@ -1,7 +1,7 @@
 import inspect
 import torch
 import torch.nn as nn
-from torch._six import inf
+from torch import inf
 from typing import Iterable, Union, Optional
 
 _tensor_or_tensors = Union[torch.Tensor, Iterable[torch.Tensor]]

--- a/torch_xla/core/xla_builder.py
+++ b/torch_xla/core/xla_builder.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import print_function
-
 import torch
 import torch_xla
 

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import collections
 import io
 import sys

--- a/torch_xla/core/xla_op_registry.py
+++ b/torch_xla/core/xla_op_registry.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import print_function
-
 import pickle
 import sys
 import threading

--- a/torch_xla/debug/graph_saver.py
+++ b/torch_xla/debug/graph_saver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import collections
 import os
 import threading

--- a/torch_xla/debug/metrics.py
+++ b/torch_xla/debug/metrics.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import torch_xla
 
 

--- a/torch_xla/debug/metrics_saver.py
+++ b/torch_xla/debug/metrics_saver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import threading
 import torch_xla

--- a/torch_xla/debug/model_comparator.py
+++ b/torch_xla/debug/model_comparator.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import division
-from __future__ import print_function
-
 import argparse
 import os
 import re

--- a/torch_xla/distributed/data_parallel.py
+++ b/torch_xla/distributed/data_parallel.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import print_function
-
 import os
 from copy import deepcopy
 import sys

--- a/torch_xla/distributed/parallel_loader.py
+++ b/torch_xla/distributed/parallel_loader.py
@@ -1,7 +1,3 @@
-from __future__ import division
-from __future__ import print_function
-
-from six import iteritems, itervalues
 import threading
 import torch
 import torch_xla
@@ -94,7 +90,7 @@ class ParallelLoader(object):
     thread = threading.Thread(target=self._loader_worker)
     thread.daemon = True
     thread.start()
-    for dqueue in itervalues(self._queues):
+    for dqueue in self._queues.values():
       thread = threading.Thread(target=self._worker, args=(dqueue,))
       thread.daemon = True
       thread.start()
@@ -122,7 +118,7 @@ class ParallelLoader(object):
 
   def close(self):
     self._done = True
-    for dqueue in itervalues(self._queues):
+    for dqueue in self._queues.values():
       dqueue.queue.close()
       dqueue.loader_queue.close()
 

--- a/torch_xla/distributed/worker.py
+++ b/torch_xla/distributed/worker.py
@@ -1,7 +1,3 @@
-from __future__ import division
-from __future__ import print_function
-
-
 class Worker(object):
 
   def __init__(self, internal_ip, machine_type, zone):

--- a/torch_xla/distributed/xla_dist.py
+++ b/torch_xla/distributed/xla_dist.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 """Tool to distribute training on Cloud TPU Pods."""
-from __future__ import division
-from __future__ import print_function
 
 import argparse
 import cloud_tpu_client

--- a/torch_xla/distributed/xla_multiprocessing.py
+++ b/torch_xla/distributed/xla_multiprocessing.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import print_function
-
 import collections
 import os
 import re

--- a/torch_xla/utils/cached_dataset.py
+++ b/torch_xla/utils/cached_dataset.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import print_function
-
 import json
 import io
 import os

--- a/torch_xla/utils/checkpoint_tagger.py
+++ b/torch_xla/utils/checkpoint_tagger.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import print_function
-
 import collections
 import json
 

--- a/torch_xla/utils/gcsfs.py
+++ b/torch_xla/utils/gcsfs.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import print_function
-
 import builtins
 import collections
 import glob

--- a/torch_xla/utils/keyd_queue.py
+++ b/torch_xla/utils/keyd_queue.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import collections
 import threading
 

--- a/torch_xla/utils/serialization.py
+++ b/torch_xla/utils/serialization.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import print_function
-
 import os
 import shutil
 

--- a/torch_xla/utils/tf_record_reader.py
+++ b/torch_xla/utils/tf_record_reader.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import print_function
-
 import torch_xla
 
 

--- a/torch_xla/utils/utils.py
+++ b/torch_xla/utils/utils.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import print_function
-
 from concurrent import futures
 import contextlib
 import copy


### PR DESCRIPTION
Remove reference to `torch._six`, required by pytorch/pytorch#94709.

- pytorch/pytorch#94709