### PR TITLE
[Functionalization] Lower `masked_fill.Tensor` and `masked_fill.Scalar` ops

### DIFF
--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -8792,7 +8792,6 @@ TEST_F(AtenXlaTensorTest, TestUnsqueezeInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestMaskedFill) {
-  // GTEST_SKIP() << "SegFault after functionalization";
   torch::Tensor input =
       torch::rand({2, 3}, torch::TensorOptions(torch::kFloat));
   torch::Tensor mask =
@@ -8811,7 +8810,6 @@ TEST_F(AtenXlaTensorTest, TestMaskedFill) {
 }
 
 TEST_F(AtenXlaTensorTest, TestMaskedFillInPlace) {
-  // GTEST_SKIP() << "SegFault after functionalization";
   torch::Scalar value(42);
   torch::Tensor mask =
       torch::randint(0, 2, {2, 3}, torch::TensorOptions(torch::kBool));
@@ -8831,7 +8829,6 @@ TEST_F(AtenXlaTensorTest, TestMaskedFillInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestMaskedFillBroadcast) {
-  // GTEST_SKIP() << "SegFault after functionalization";
   torch::Tensor input =
       torch::rand({2, 5, 4, 3}, torch::TensorOptions(torch::kFloat));
   torch::Tensor mask =
@@ -11301,8 +11298,8 @@ TEST_F(AtenXlaTensorTest, TestEmbeddingBackward) {
 }
 
 TEST_F(AtenXlaTensorTest, TestAmpForeachNonFiniteCheckAndUnscale) {
-  // GTEST_SKIP()
-  //     << "Needs additional meta tensor support after functionalization";
+  GTEST_SKIP()
+      << "Needs additional meta tensor support after functionalization";
   XlaDeviceType hw_type =
       static_cast<XlaDeviceType>(GetDefaultDevice()->type());
   if (hw_type != XlaDeviceType::GPU && hw_type != XlaDeviceType::CPU) {
@@ -11650,8 +11647,8 @@ TEST_F(AtenXlaTensorTest, TestNanToNum) {
 }
 
 TEST_F(AtenXlaTensorTest, TestNanToNumInplace) {
-  // GTEST_SKIP()
-  //     << "Needs additional meta tensor support after functionalization";
+  GTEST_SKIP()
+      << "Needs additional meta tensor support after functionalization";
   for (torch::ScalarType scalar_type :
        {torch::kHalf, torch::kFloat, torch::kDouble, torch::kShort, torch::kInt,
         torch::kLong}) {

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -8828,11 +8828,29 @@ TEST_F(AtenXlaTensorTest, TestMaskedFillInPlace) {
   ExpectCounterChanged("xla::masked_fill", cpp_test::GetIgnoredCounters());
 }
 
-TEST_F(AtenXlaTensorTest, TestMaskedFillBroadcast) {
+TEST_F(AtenXlaTensorTest, TestMaskedFillBroadcast1) {
   torch::Tensor input =
       torch::rand({2, 5, 4, 3}, torch::TensorOptions(torch::kFloat));
   torch::Tensor mask =
       torch::randint(0, 2, {4, 1}, torch::TensorOptions(torch::kBool));
+  torch::Scalar value(42);
+  torch::Tensor result = torch::masked_fill(input, mask, value);
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_input = CopyToDevice(input, device);
+    torch::Tensor xla_mask = CopyToDevice(mask, device);
+    torch::Tensor xla_result = torch::masked_fill(xla_input, xla_mask, value);
+    AllClose(result, xla_result);
+  });
+
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::masked_fill", cpp_test::GetIgnoredCounters());
+}
+
+TEST_F(AtenXlaTensorTest, TestMaskedFillBroadcast2) {
+  torch::Tensor input =
+      torch::rand({2, 1}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor mask =
+      torch::randint(0, 2, {2, 3}, torch::TensorOptions(torch::kBool));
   torch::Scalar value(42);
   torch::Tensor result = torch::masked_fill(input, mask, value);
   ForEachDevice([&](const torch::Device& device) {

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -11272,7 +11272,6 @@ TEST_F(AtenXlaTensorTest, TestBCEWithLogitsBackward) {
 }
 
 TEST_F(AtenXlaTensorTest, TestKlDivBackward) {
-  GTEST_SKIP() << "SegFault after functionalization";
   torch::Tensor input = torch::rand(
       {4, 3}, torch::TensorOptions(torch::kFloat).requires_grad(true));
   torch::Tensor target = torch::rand(

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -8792,7 +8792,7 @@ TEST_F(AtenXlaTensorTest, TestUnsqueezeInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestMaskedFill) {
-  GTEST_SKIP() << "SegFault after functionalization";
+  // GTEST_SKIP() << "SegFault after functionalization";
   torch::Tensor input =
       torch::rand({2, 3}, torch::TensorOptions(torch::kFloat));
   torch::Tensor mask =
@@ -8807,11 +8807,11 @@ TEST_F(AtenXlaTensorTest, TestMaskedFill) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::masked_fill_", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::masked_fill", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestMaskedFillInPlace) {
-  GTEST_SKIP() << "SegFault after functionalization";
+  // GTEST_SKIP() << "SegFault after functionalization";
   torch::Scalar value(42);
   torch::Tensor mask =
       torch::randint(0, 2, {2, 3}, torch::TensorOptions(torch::kBool));
@@ -8827,11 +8827,11 @@ TEST_F(AtenXlaTensorTest, TestMaskedFillInPlace) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::masked_fill_", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::masked_fill", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestMaskedFillBroadcast) {
-  GTEST_SKIP() << "SegFault after functionalization";
+  // GTEST_SKIP() << "SegFault after functionalization";
   torch::Tensor input =
       torch::rand({2, 5, 4, 3}, torch::TensorOptions(torch::kFloat));
   torch::Tensor mask =
@@ -8846,7 +8846,7 @@ TEST_F(AtenXlaTensorTest, TestMaskedFillBroadcast) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::masked_fill_", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::masked_fill", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestFill) {
@@ -11301,8 +11301,8 @@ TEST_F(AtenXlaTensorTest, TestEmbeddingBackward) {
 }
 
 TEST_F(AtenXlaTensorTest, TestAmpForeachNonFiniteCheckAndUnscale) {
-  GTEST_SKIP()
-      << "Needs additional meta tensor support after functionalization";
+  // GTEST_SKIP()
+  //     << "Needs additional meta tensor support after functionalization";
   XlaDeviceType hw_type =
       static_cast<XlaDeviceType>(GetDefaultDevice()->type());
   if (hw_type != XlaDeviceType::GPU && hw_type != XlaDeviceType::CPU) {
@@ -11650,8 +11650,8 @@ TEST_F(AtenXlaTensorTest, TestNanToNum) {
 }
 
 TEST_F(AtenXlaTensorTest, TestNanToNumInplace) {
-  GTEST_SKIP()
-      << "Needs additional meta tensor support after functionalization";
+  // GTEST_SKIP()
+  //     << "Needs additional meta tensor support after functionalization";
   for (torch::ScalarType scalar_type :
        {torch::kHalf, torch::kFloat, torch::kDouble, torch::kShort, torch::kInt,
         torch::kLong}) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1668,27 +1668,6 @@ at::Tensor XLANativeFunctions::masked_fill(const at::Tensor& self,
       self_tensor, bridge::GetXlaTensor(mask), value));
 }
 
-at::Tensor& XLANativeFunctions::masked_fill_(at::Tensor& self,
-                                             const at::Tensor& mask,
-                                             const at::Scalar& value) {
-  std::cout << "WONJOO: masked_fill_.Scalar" << std::endl;
-  TORCH_LAZY_FN_COUNTER("xla::");
-  XLATensorPtr self_tensor = bridge::GetXlaTensor(self);
-  tensor_methods::masked_fill_(self_tensor, bridge::GetXlaTensor(mask), value);
-  return self;
-}
-
-at::Tensor& XLANativeFunctions::masked_fill_(at::Tensor& self,
-                                             const at::Tensor& mask,
-                                             const at::Tensor& value) {
-  std::cout << "WONJOO: masked_fill_.Tensor" << std::endl;
-  TORCH_LAZY_FN_COUNTER("xla::");
-  XLA_CHECK_EQ(value.dim(), 0) << "masked_fill_ only supports a 0-dimensional "
-                               << "value tensor, but got tensor "
-                               << "with " << value.dim() << " dimension(s).";
-  return masked_fill_(self, mask, value.item());
-}
-
 at::Tensor XLANativeFunctions::masked_scatter(const at::Tensor& self,
                                               const at::Tensor& mask,
                                               const at::Tensor& source) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1643,9 +1643,35 @@ at::Tensor XLANativeFunctions::xlogy(const at::Tensor& self,
       bridge::GetXlaTensor(self), bridge::GetXlaTensor(other)));
 }
 
+at::Tensor XLANativeFunctions::masked_fill(const at::Tensor& self,
+                                           const at::Tensor& mask,
+                                           const at::Tensor& value) {
+  // return at::functionalization::functionalize_aten_op<ATEN_OP2(
+  //     masked_fill, Tensor)>::call(self, mask, value);
+  std::cout << "WONJOO: masked_fill.Tensor" << std::endl;
+  TORCH_LAZY_FN_COUNTER("xla::");
+  XLA_CHECK_EQ(value.dim(), 0) << "masked_fill_ only supports a 0-dimensional "
+                               << "value tensor, but got tensor "
+                               << "with " << value.dim() << " dimension(s).";
+  return masked_fill(self, mask, value.item());
+}
+
+at::Tensor XLANativeFunctions::masked_fill(const at::Tensor& self,
+                                           const at::Tensor& mask,
+                                           const at::Scalar& value) {
+  // return at::functionalization::functionalize_aten_op<ATEN_OP2(
+  //     masked_fill, Scalar)>::call(self, mask, value);
+  std::cout << "WONJOO: masked_fill.Scalar" << std::endl;
+  TORCH_LAZY_FN_COUNTER("xla::");
+  XLATensorPtr self_tensor = bridge::GetXlaTensor(self);
+  return bridge::AtenFromXlaTensor(tensor_methods::masked_fill(
+      self_tensor, bridge::GetXlaTensor(mask), value));
+}
+
 at::Tensor& XLANativeFunctions::masked_fill_(at::Tensor& self,
                                              const at::Tensor& mask,
                                              const at::Scalar& value) {
+  std::cout << "WONJOO: masked_fill_.Scalar" << std::endl;
   TORCH_LAZY_FN_COUNTER("xla::");
   XLATensorPtr self_tensor = bridge::GetXlaTensor(self);
   tensor_methods::masked_fill_(self_tensor, bridge::GetXlaTensor(mask), value);
@@ -1655,6 +1681,7 @@ at::Tensor& XLANativeFunctions::masked_fill_(at::Tensor& self,
 at::Tensor& XLANativeFunctions::masked_fill_(at::Tensor& self,
                                              const at::Tensor& mask,
                                              const at::Tensor& value) {
+  std::cout << "WONJOO: masked_fill_.Tensor" << std::endl;
   TORCH_LAZY_FN_COUNTER("xla::");
   XLA_CHECK_EQ(value.dim(), 0) << "masked_fill_ only supports a 0-dimensional "
                                << "value tensor, but got tensor "
@@ -3389,20 +3416,6 @@ at::Tensor XLANativeFunctions::linalg_pinv(
     const c10::optional<at::Tensor>& rtol, bool hermitian) {
   return at::functionalization::functionalize_aten_op<ATEN_OP2(
       linalg_pinv, atol_rtol_tensor)>::call(self, atol, rtol, hermitian);
-}
-
-at::Tensor XLANativeFunctions::masked_fill(const at::Tensor& self,
-                                           const at::Tensor& mask,
-                                           const at::Tensor& value) {
-  return at::functionalization::functionalize_aten_op<ATEN_OP2(
-      masked_fill, Tensor)>::call(self, mask, value);
-}
-
-at::Tensor XLANativeFunctions::masked_fill(const at::Tensor& self,
-                                           const at::Tensor& mask,
-                                           const at::Scalar& value) {
-  return at::functionalization::functionalize_aten_op<ATEN_OP2(
-      masked_fill, Scalar)>::call(self, mask, value);
 }
 
 at::Tensor XLANativeFunctions::mvlgamma(const at::Tensor& self, int64_t p) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1646,9 +1646,6 @@ at::Tensor XLANativeFunctions::xlogy(const at::Tensor& self,
 at::Tensor XLANativeFunctions::masked_fill(const at::Tensor& self,
                                            const at::Tensor& mask,
                                            const at::Tensor& value) {
-  // return at::functionalization::functionalize_aten_op<ATEN_OP2(
-  //     masked_fill, Tensor)>::call(self, mask, value);
-  std::cout << "WONJOO: masked_fill.Tensor" << std::endl;
   TORCH_LAZY_FN_COUNTER("xla::");
   XLA_CHECK_EQ(value.dim(), 0) << "masked_fill_ only supports a 0-dimensional "
                                << "value tensor, but got tensor "
@@ -1659,9 +1656,6 @@ at::Tensor XLANativeFunctions::masked_fill(const at::Tensor& self,
 at::Tensor XLANativeFunctions::masked_fill(const at::Tensor& self,
                                            const at::Tensor& mask,
                                            const at::Scalar& value) {
-  // return at::functionalization::functionalize_aten_op<ATEN_OP2(
-  //     masked_fill, Scalar)>::call(self, mask, value);
-  std::cout << "WONJOO: masked_fill.Scalar" << std::endl;
   TORCH_LAZY_FN_COUNTER("xla::");
   XLATensorPtr self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(tensor_methods::masked_fill(

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1545,14 +1545,6 @@ XLATensorPtr masked_fill(XLATensorPtr& input, const XLATensorPtr& mask,
       value));
 }
 
-void masked_fill_(XLATensorPtr& input, const XLATensorPtr& mask,
-                  const at::Scalar& value) {
-  torch::lazy::ScopePusher ir_scope(at::aten::masked_fill.toQualString());
-  input->SetIrValue(torch::lazy::MakeNode<MaskedFill>(
-      input->GetIrValue(), MaybeExpand(mask->GetIrValue(), input->shape()),
-      value));
-}
-
 XLATensorPtr masked_scatter(XLATensorPtr& input, const XLATensorPtr& mask,
                             const XLATensorPtr& source) {
   torch::lazy::ScopePusher ir_scope(at::aten::masked_scatter.toQualString());

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1542,7 +1542,10 @@ XLATensorPtr masked_fill(XLATensorPtr& input, const XLATensorPtr& mask,
   torch::lazy::ScopePusher ir_scope(at::aten::masked_fill.toQualString());
   auto input_value = input->GetIrValue();
   // Expand input tensor to mask if needed (same as masked_scatter below).
-  if (input->shape().get().dimensions() < mask->shape().get().dimensions()) {
+  // An additional check makes sure to only expand if the rank of input tensor
+  // is less than that of the mask tensor.
+  if (input->shape().get().rank() < mask->shape().get().rank() &&
+      input->shape().get().dimensions() < mask->shape().get().dimensions()) {
     input_value = MaybeExpand(input->GetIrValue(), mask->shape());
   }
   return input->CreateFrom(torch::lazy::MakeNode<MaskedFill>(

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1537,6 +1537,14 @@ XLATensorPtr lt(const XLATensorPtr& input, const XLATensorPtr& other) {
   return DispatchComparisonOp(at::aten::lt, input, other);
 }
 
+XLATensorPtr masked_fill(XLATensorPtr& input, const XLATensorPtr& mask,
+                         const at::Scalar& value) {
+  torch::lazy::ScopePusher ir_scope(at::aten::masked_fill.toQualString());
+  return input->CreateFrom(torch::lazy::MakeNode<MaskedFill>(
+      input->GetIrValue(), MaybeExpand(mask->GetIrValue(), input->shape()),
+      value));
+}
+
 void masked_fill_(XLATensorPtr& input, const XLATensorPtr& mask,
                   const at::Scalar& value) {
   torch::lazy::ScopePusher ir_scope(at::aten::masked_fill.toQualString());

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1544,7 +1544,7 @@ XLATensorPtr masked_fill(XLATensorPtr& input, const XLATensorPtr& mask,
   // Expand input tensor to mask if needed (same as masked_scatter below).
   // An additional check makes sure to only expand if the rank of input tensor
   // is less than that of the mask tensor.
-  if (input->shape().get().rank() < mask->shape().get().rank() &&
+  if (input->shape().get().rank() <= mask->shape().get().rank() &&
       input->shape().get().dimensions() < mask->shape().get().dimensions()) {
     input_value = MaybeExpand(input->GetIrValue(), mask->shape());
   }

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -487,10 +487,6 @@ XLATensorPtr lt(const XLATensorPtr& input, const XLATensorPtr& other);
 XLATensorPtr masked_fill(XLATensorPtr& input, const XLATensorPtr& mask,
                          const at::Scalar& value);
 
-// In-place version of the method above.
-void masked_fill_(XLATensorPtr& input, const XLATensorPtr& mask,
-                  const at::Scalar& value);
-
 XLATensorPtr masked_scatter(XLATensorPtr& input, const XLATensorPtr& mask,
                             const XLATensorPtr& source);
 

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -484,6 +484,9 @@ XLATensorPtr lt(const XLATensorPtr& input, const at::Scalar& other);
 
 XLATensorPtr lt(const XLATensorPtr& input, const XLATensorPtr& other);
 
+XLATensorPtr masked_fill(XLATensorPtr& input, const XLATensorPtr& mask,
+                         const at::Scalar& value);
+
 // In-place version of the method above.
 void masked_fill_(XLATensorPtr& input, const XLATensorPtr& mask,
                   const at::Scalar& value);

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -211,6 +211,8 @@ supported:
   - log2
   - log10
   - logsumexp
+  - masked_fill.Scalar
+  - masked_fill.Tensor
   - masked_fill_.Scalar
   - masked_fill_.Tensor
   - masked_scatter
@@ -367,8 +369,6 @@ supported:
   - _trilinear
   - linalg_pinv.atol_rtol_tensor
   - _cdist_forward
-  - masked_fill.Scalar
-  - masked_fill.Tensor
   - mvlgamma
   - permute
   # The same applies to these ops, but we already have direct lowerings for them

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -213,8 +213,6 @@ supported:
   - logsumexp
   - masked_fill.Scalar
   - masked_fill.Tensor
-  - masked_fill_.Scalar
-  - masked_fill_.Tensor
   - masked_scatter
   - masked_select
   - max


### PR DESCRIPTION
[Functionalization] Lower masked_fill.Tensor and masked_fill.Scalar ops

---
In the pytorch/xla/functionalization branch, we previously lowered the `masked_fill` ops to just pass through to functionalization. This was causing seg fault, as it caused an infinite dispatch loop like:
```
[call] op=[aten::masked_fill.Scalar], key=[AutogradXLA]
  [redispatch] op=[aten::masked_fill.Scalar], key=[Functionalize]
   [callBoxed] op=[aten::masked_fill.Scalar], key=[XLA]
    [redispatchBoxed] op=[aten::masked_fill.Scalar], key=[Meta]
     [call] op=[aten::clone], key=[Functionalize]
      [callBoxed] op=[aten::clone], key=[XLA]
     [call] op=[aten::masked_fill_.Scalar], key=[Functionalize]
      [call] op=[aten::masked_fill_.Scalar], key=[Meta]
      [call] op=[aten::masked_fill.Scalar], key=[XLA]
```
This PR properly lowers these ops. 