### PR TITLE
Disable `test_operations.py` tests failing on TPU

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -49,6 +49,13 @@ import test_utils
 DeviceSupport = collections.namedtuple('DeviceSupport', ['num_devices'])
 
 
+def _is_on_tpu():
+  return 'XRT_TPU_CONFIG' in os.environ or pjrt.device_type() == 'TPU'
+
+
+skipOnTpu = unittest.skipIf(_is_on_tpu(), 'Not supported on TPU')
+
+
 def _gen_tensor(*args, **kwargs):
   return torch.randn(*args, **kwargs)
 
@@ -702,6 +709,7 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     vset = b.sum().item()
     self.assertEqual(a.sum().item(), 10.0 * vset + (4.0 - vset))
 
+  @skipOnTpu
   def test_pow_integer_types(self):
     self.runAtenTest(torch.randint(10, (2, 2)), lambda x: torch.pow(x, 2))
     self.runAtenTest(torch.randint(10, (2, 2)), lambda x: torch.pow(2, x))
@@ -709,6 +717,7 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     self.runAtenTest(torch.randint(10, (2, 2)), lambda x: x.pow_(2))
     self.runAtenTest(torch.randint(10, (2, 2)), lambda x: x.pow_(x))
 
+  @skipOnTpu
   def test_matmul_integer_types(self):
     # all variance of matmul: dot/mv/mm/bmm
     self.runAtenTest((torch.randint(10, (2,)), torch.randint(10, (2,))),
@@ -723,11 +732,13 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     self.runAtenTest((torch.randint(10, (10, 3, 4)), torch.randint(10, (4, 5))),
                      lambda x, y: torch.matmul(x, y))
 
+  @skipOnTpu
   def test_addmm_integer_types(self):
     self.runAtenTest((torch.randint(10, (2, 3)), torch.randint(
         10, (2, 3)), torch.randint(10, (3, 3))),
                      lambda x, y, z: torch.addmm(x, y, z))
 
+  @skipOnTpu
   def test_baddmm_integer_types(self):
     self.runAtenTest(
         (torch.randint(10, (10, 3, 5)), torch.randint(10, (10, 3, 4)),

--- a/test/tpu/pjrt_test_job.yaml
+++ b/test/tpu/pjrt_test_job.yaml
@@ -27,6 +27,7 @@ spec:
     - bash
     - -c
     - |
+      python3 pytorch/xla/test/pjrt/test_operations.py -v
       python3 pytorch/xla/test/pjrt/test_experimental_pjrt_tpu.py
     volumeMounts:
     - mountPath: /dev/shm


### PR DESCRIPTION
These 4 tests fail with error messages like these on both XRT and PJRT:

```
test_baddmm_integer_types (__main__.TestAtenXlaTensor) ... 2023-02-14 18:19:56.358333: E tensorflow/core/tpu/kernels/tpu_compilation_cache_external.cc:113] While rewriting computation to not contain X64 element types, XLA encountered an HLO for which this rewriting is not implemented: %dot.6 = s64[10,3,5]{2,1,0} dot(s64[10,3,4]{0,2,1} %p1.4, s64[10,4,5]{0,2,1} %p0.3), lhs_batch_dims={0}, lhs_contracting_dims={2}, rhs_batch_dims={0}, rhs_contracting_dims={1}, operand_precision={highest,highest}
2023-02-14 18:19:56.358430: F tensorflow/core/tpu/kernels/tpu_program_group.cc:86] Check failed: xla_tpu_programs.size() > 0 (0 vs. 0)
```

Confirmed with these commands

```
XRT_TPU_CONFIG="localservice;0;localhost:51011" TPU_NUM_DEVICES=4 python pytorch/xla/test/test_operations.py -v
PJRT_DEVICE=TPU_LEGACY python pytorch/xla/test/test_operations.py -v
PJRT_DEVICE=TPU python pytorch/xla/test/test_operations.py -v
```