### PR TITLE
Make WaitDeviceOps block until device execution finishes

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1667,7 +1667,7 @@ class TestWaitDeviceOps(test_utils.XlaTestCase):
     xm.mark_step()
     xm.wait_device_ops()
     self.assertTrue("ExecuteTime" in met.metric_names() or
-                    ExecuteChainedTime in met.metric_names())
+                    "ExecuteChainedTime" in met.metric_names())
 
 
 class TestOpBuilder(test_utils.XlaTestCase):

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1656,10 +1656,13 @@ class TestWaitDeviceOps(test_utils.XlaTestCase):
 
   def test_wait_device_ops(self):
     xm.xla_device()
-    value = torch.randn(
-        10000, 10000, device=xm.xla_device()) * torch.randn(
-            10000, 10000, device=xm.xla_device())
-    value_mean = value.mean()
+    value = torch.randn(10000, 10000, device=xm.xla_device())
+    val_list = []
+    val_mean_list = []
+    for _ in range(30):
+      new_val = value * torch.randn(10000, 10000, device=xm.xla_device())
+      val_list.append(new_val)
+      val_mean_list.append(new_val.mean())
     xm.mark_step()
     self.assertNotIn("ExecuteTime", met.metric_names())
     xm.wait_device_ops()

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1659,13 +1659,15 @@ class TestWaitDeviceOps(test_utils.XlaTestCase):
     value = torch.randn(10000, 10000, device=xm.xla_device())
     val_list = []
     val_mean_list = []
-    for _ in range(30):
+    met.clear_all()
+    for _ in range(5):
       new_val = value * torch.randn(10000, 10000, device=xm.xla_device())
       val_list.append(new_val)
       val_mean_list.append(new_val.mean())
     xm.mark_step()
     xm.wait_device_ops()
-    self.assertIn("ExecuteTime", met.metric_names())
+    self.assertTrue("ExecuteTime" in met.metric_names() or
+                    ExecuteChainedTime in met.metric_names())
 
 
 class TestOpBuilder(test_utils.XlaTestCase):

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1652,6 +1652,20 @@ class TestAsyncScalar(test_utils.XlaTestCase):
       assert met.metric_data("TransferToServerAsync") == None
 
 
+class TestWaitDeviceOps(test_utils.XlaTestCase):
+
+  def test_wait_device_ops(self):
+    xm.xla_device()
+    value = torch.randn(
+        10000, 10000, device=xm.xla_device()) * torch.randn(
+            10000, 10000, device=xm.xla_device())
+    value_mean = value.mean()
+    xm.mark_step()
+    self.assertNotIn("ExecuteTime", met.metric_names())
+    xm.wait_device_ops()
+    self.assertIn("ExecuteTime", met.metric_names())
+
+
 class TestOpBuilder(test_utils.XlaTestCase):
 
   def runOpBuilderTest(self,

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1664,7 +1664,6 @@ class TestWaitDeviceOps(test_utils.XlaTestCase):
       val_list.append(new_val)
       val_mean_list.append(new_val.mean())
     xm.mark_step()
-    self.assertNotIn("ExecuteTime", met.metric_names())
     xm.wait_device_ops()
     self.assertIn("ExecuteTime", met.metric_names())
 

--- a/third_party/xla_client/computation_client.h
+++ b/third_party/xla_client/computation_client.h
@@ -326,6 +326,9 @@ class ComputationClient {
 
   virtual void PrepareToExit() = 0;
 
+  // Block until all device computation finishes.
+  virtual void WaitDeviceExections(const std::vector<std::string>& devices) = 0;
+
   // Utility API around the vector based Compile() API to compile a single
   // computation.
   ComputationPtr Compile(XlaComputation computation,

--- a/third_party/xla_client/computation_client.h
+++ b/third_party/xla_client/computation_client.h
@@ -326,8 +326,8 @@ class ComputationClient {
 
   virtual void PrepareToExit() = 0;
 
-  // Block until all device computation finishes.
-  virtual void WaitDeviceExections(const std::vector<std::string>& devices) = 0;
+  // Block until all device's async operation is finished.
+  virtual void WaitDeviceOps(const std::vector<std::string>& devices) = 0;
 
   // Utility API around the vector based Compile() API to compile a single
   // computation.

--- a/third_party/xla_client/computation_client.h
+++ b/third_party/xla_client/computation_client.h
@@ -326,7 +326,8 @@ class ComputationClient {
 
   virtual void PrepareToExit() = 0;
 
-  // Block until all device's async operation is finished.
+  // Block until pass in devices' async operation are finished. If empty, all
+  // the local devices will be waited for.
   virtual void WaitDeviceOps(const std::vector<std::string>& devices) = 0;
 
   // Utility API around the vector based Compile() API to compile a single

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -1,6 +1,7 @@
 #include "third_party/xla_client/pjrt_computation_client.h"
 
 #include <algorithm>
+#include <unordered_set>
 
 #include "absl/strings/ascii.h"
 #include "absl/types/span.h"
@@ -420,7 +421,7 @@ PjRtComputationClient::ExecuteComputation(
                            returned_future)
           .value();
 
-  // Grab the shared lock and block the `WaitDeviceOps` untill buffer is ready.
+  // Grab the shared lock and block the `WaitDeviceOps` until buffer is ready.
   auto lock = lock_device_shared(device);
   // Signal that `ExecuteSharded` has completed for the ExecuteTime metric.
   // Copies the `timed` shared pointer into the lambda.
@@ -572,7 +573,7 @@ std::unique_lock<std::shared_mutex> PjRtComputationClient::lock_device(
 
 void PjRtComputationClient::WaitDeviceOps(
     const std::vector<std::string>& devices) {
-  std::set<std::string> wait_devices;
+  std::unordered_set<std::string> wait_devices;
   if (!devices.empty()) {
     for (auto& device_str : devices) {
       wait_devices.insert(device_str);

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -9,6 +9,7 @@
 #include "tensorflow/compiler/xla/client/xla_computation.h"
 #include "tensorflow/compiler/xla/layout_util.h"
 #include "tensorflow/compiler/xla/literal.h"
+#include "tensorflow/compiler/xla/pjrt/distributed/distributed.h"
 #include "tensorflow/compiler/xla/pjrt/gpu/se_gpu_pjrt_client.h"
 #include "tensorflow/compiler/xla/pjrt/pjrt_api.h"
 #include "tensorflow/compiler/xla/pjrt/pjrt_c_api_client.h"
@@ -16,7 +17,6 @@
 #include "tensorflow/compiler/xla/pjrt/pjrt_executable.h"
 #include "tensorflow/compiler/xla/pjrt/tfrt_cpu_pjrt_client.h"
 #include "tensorflow/compiler/xla/pjrt/tpu_client.h"
-#include "tensorflow/compiler/xla/pjrt/distributed/distributed.h"
 #include "tensorflow/compiler/xla/shape.h"
 #include "tensorflow/core/profiler/lib/traceme.h"
 #include "third_party/xla_client/computation_client.h"
@@ -27,6 +27,42 @@
 namespace xla {
 
 namespace {
+
+class PJRTLocker {
+ public:
+  void Lock() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    cv_.wait(lock, [this] { return !locked_; });
+    locked_ = true;
+  }
+
+  void Unlock() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    locked_ = false;
+    cv_.notify_all();
+  }
+
+  void Barrier() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    cv_.wait(lock, [this] { return !locked_; });
+    cv_.notify_all();
+  }
+
+ private:
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  bool locked_ = false;
+  std::exception_ptr exptr_;
+};
+
+std::shared_ptr<PJRTLocker> GetLockerForDevice(std::string device) {
+  static std::unordered_map<std::string, std::shared_ptr<PJRTLocker>>
+      device_lockers;
+  if (device_lockers.find(device) == device_lockers.end()) {
+    device_lockers[device] = std::make_shared<PJRTLocker>();
+  }
+  return device_lockers[device];
+}
 
 std::string PjRtDeviceToString(PjRtDevice* const device) {
   std::string platform =
@@ -48,15 +84,17 @@ std::vector<std::string> PjRtDevicesToString(
 }
 
 // Initializes a distributed runtime client if dist_service_addr is specified
-std::shared_ptr<DistributedRuntimeClient> MaybeInitializeDistributedRuntimeClient(
-    int local_rank, std::string dist_service_addr) {
+std::shared_ptr<DistributedRuntimeClient>
+MaybeInitializeDistributedRuntimeClient(int local_rank,
+                                        std::string dist_service_addr) {
   std::shared_ptr<DistributedRuntimeClient> client;
   if (!dist_service_addr.empty()) {
     xla::DistributedRuntimeClient::Options options;
     /* TODO(jonbolin): Use global rank for multi-host setup */
     options.node_id = local_rank;
-    client = xla::GetDistributedRuntimeClient(dist_service_addr, options,
-        /*use_coordination_service=*/false);
+    client =
+        xla::GetDistributedRuntimeClient(dist_service_addr, options,
+                                         /*use_coordination_service=*/false);
     XLA_CHECK(client->Connect().ok())
         << "Failed to initialize distributed runtime client";
   }
@@ -89,14 +127,16 @@ PjRtComputationClient::PjRtComputationClient() {
     int local_rank = sys_util::GetEnvInt(env::kEnvLocalRank, 0);
     std::string dist_service_addr =
         sys_util::GetEnvString(env::kEnvPjrtDistServiceAddr, "");
-    auto distributed_client = MaybeInitializeDistributedRuntimeClient(
-        local_rank, dist_service_addr);
-    auto allowed_devices = std::make_optional<std::set<int>>(std::set{local_rank});
-    client_ = std::move(xla::GetStreamExecutorGpuClient(
-                  /*asynchronous=*/async, GpuAllocatorConfig{},
-                  /*distributed_client=*/distributed_client, /*node_id=*/local_rank,
-                  allowed_devices = allowed_devices)
-                  .value());
+    auto distributed_client =
+        MaybeInitializeDistributedRuntimeClient(local_rank, dist_service_addr);
+    auto allowed_devices =
+        std::make_optional<std::set<int>>(std::set{local_rank});
+    client_ =
+        std::move(xla::GetStreamExecutorGpuClient(
+                      /*asynchronous=*/async, GpuAllocatorConfig{},
+                      /*distributed_client=*/distributed_client,
+                      /*node_id=*/local_rank, allowed_devices = allowed_devices)
+                      .value());
   } else {
     XLA_ERROR() << absl::StrFormat("Unknown %s '%s'", env::kEnvPjRtDevice,
                                    device_type);
@@ -415,9 +455,16 @@ PjRtComputationClient::ExecuteComputation(
                            returned_future)
           .value();
 
+  std::shared_ptr<PJRTLocker> locker = GetLockerForDevice(device);
+  locker->Lock();
+
   // Signal that `ExecuteSharded` has completed for the ExecuteTime metric.
   // Copies the `timed` shared pointer into the lambda.
-  returned_future->OnReady([timed](Status unused) mutable { timed.reset(); });
+  returned_future->OnReady([timed, locker](Status unused) mutable {
+    timed.reset();
+    locker->Unlock();
+    TF_VLOG(3) << "returned_future->OnReady finished";
+  });
 
   std::vector<DataPtr> datas;
   datas.reserve(results.size());
@@ -545,6 +592,27 @@ xla::PjRtDevice* PjRtComputationClient::StringToPjRtDevice(
       << "Unknown device " << device;
   xla::PjRtDevice* pjrt_device = string_to_device_[device];
   return pjrt_device;
+}
+
+void PjRtComputationClient::WaitDeviceExections(
+    const std::vector<std::string>& devices) {
+  std::set<std::string> wait_devices;
+  if (!devices.empty()) {
+    for (auto& device_str : devices) {
+      wait_devices.insert(device_str);
+    }
+  } else {
+    for (auto& device_str : GetLocalDevices()) {
+      wait_devices.insert(device_str);
+    }
+  }
+  for (const std::string& device_str : wait_devices) {
+    TF_VLOG(3) << "Waiting for device execution for " << device_str << " to finish";
+    std::shared_ptr<PJRTLocker> locker = GetLockerForDevice(device_str);
+    locker->Barrier();
+    TF_VLOG(3) << "Waiting for device execution for " << device_str
+               << " to finish.. Done";
+  }
 }
 
 std::map<std::string, Metric> PjRtComputationClient::GetMetrics() const {

--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -75,6 +75,8 @@ class PjRtComputationClient : public ComputationClient {
 
   void PrepareToExit() override { return; };
 
+  void WaitDeviceExections(const std::vector<std::string>& devices) override;
+
   // NOT IMPLEMENTED
 
   void TransferToServer(absl::Span<const TensorSource> tensors,

--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -2,6 +2,8 @@
 #define XLA_CLIENT_PJRT_COMPUTATION_CLIENT_H_
 
 #include <cstdint>
+#include <mutex>
+#include <shared_mutex>
 
 #include "absl/types/span.h"
 #include "tensorflow/compiler/xla/client/xla_computation.h"
@@ -75,7 +77,7 @@ class PjRtComputationClient : public ComputationClient {
 
   void PrepareToExit() override { return; };
 
-  void WaitDeviceExections(const std::vector<std::string>& devices) override;
+  void WaitDeviceOps(const std::vector<std::string>& devices) override;
 
   // NOT IMPLEMENTED
 
@@ -131,10 +133,15 @@ class PjRtComputationClient : public ComputationClient {
   std::shared_ptr<PjRtClient> client_;
   std::unordered_map<std::string, xla::PjRtDevice* const> string_to_device_;
   std::shared_ptr<std::vector<std::string>> replication_devices_;
+  std::unordered_map<std::string, std::unique_ptr<std::shared_mutex>>
+      device_locks_;
   // TODO(wcromar): Remove this when PJRT C API supports logical_on_device_shape
   bool supports_logical_on_device_shape_ = true;
 
   xla::PjRtDevice* StringToPjRtDevice(const std::string& device);
+  std::shared_lock<std::shared_mutex> lock_device_shared(
+      const std::string& device);
+  std::unique_lock<std::shared_mutex> lock_device(const std::string& device);
 
   struct PjRtData : public Data {
     PjRtData(std::string device, Shape device_shape)

--- a/third_party/xla_client/xrt_computation_client.h
+++ b/third_party/xla_client/xrt_computation_client.h
@@ -334,9 +334,9 @@ class XrtComputationClient : public ComputationClient {
 
   void PrepareToExit() override;
 
-  void WaitDeviceExections(const std::vector<std::string>& devices) override {
+  void WaitDeviceOps(const std::vector<std::string>& devices) override {
     // XRT Device Computation is guranteed to finish when ExecuteComputation
-    // returns. No need to implement WaitDeviceExections.
+    // returns. No need to implement WaitDeviceOps.
     return;
   };
 

--- a/third_party/xla_client/xrt_computation_client.h
+++ b/third_party/xla_client/xrt_computation_client.h
@@ -334,6 +334,12 @@ class XrtComputationClient : public ComputationClient {
 
   void PrepareToExit() override;
 
+  void WaitDeviceExections(const std::vector<std::string>& devices) override {
+    // XRT Device Computation is guranteed to finish when ExecuteComputation
+    // returns. No need to implement WaitDeviceExections.
+    return;
+  };
+
   static Worker ParseWorker(const std::string& worker);
 
   static std::string GetMultiProcessingDevice();

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1266,7 +1266,7 @@ void InitXlaModuleBindings(py::module m) {
         [](const std::vector<std::string>& devices) {
           NoGilSection nogil;
           XLAGraphExecutor::Get()->WaitDeviceOps(devices);
-          xla::ComputationClient::Get()->WaitDeviceExections(devices);
+          xla::ComputationClient::Get()->WaitDeviceOps(devices);
         },
         py::arg("devices"));
   m.def("_xla_counter_names", []() {

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1266,6 +1266,7 @@ void InitXlaModuleBindings(py::module m) {
         [](const std::vector<std::string>& devices) {
           NoGilSection nogil;
           XLAGraphExecutor::Get()->WaitDeviceOps(devices);
+          xla::ComputationClient::Get()->WaitDeviceExections(devices);
         },
         py::arg("devices"));
   m.def("_xla_counter_names", []() {


### PR DESCRIPTION
In PyTorch/XLA we have a device lock, current thread/process will need device lock if
1. want to transfer data from device
2. execute a program

In the execution, we let the async thread to hold the device lock(until `ExecuteComputation` call finished) while the main process can start tracing for the next iteration. Next process will be blocked when it tries to prepare the input for the current execution because at that point we need last execution to be finished otherwise we might see input to current program as a placeholder.

PJRT go a step further, it let `ExecuteComputation` return before the actual device execution finished. This can further increase the overlap between 2 steps. However this also make `ExecuteTime` metrics inaccurate and `WaitDeviceOps`(which suppose to wait for device exectuion to finish but it actually only waits for the device lock to be release) unreliable. 

For the `ExecuteTime`, we fixed it in https://github.com/pytorch/xla/commit/afe7bb6b6562edcd368055899e17c691824575ac . In this pr I did a similar trick by introducing a new lock that can correclt reflect the `DeviceExectuion` finishes and make `WaitDeviceOps` depend on that.


In a tweaked test, I was able to see
```
2023-02-15 01:49:55.201317: I  401088 /pytorch/xla/torch_xla/csrc/xla_graph_executor.cpp:616] Executing Dynamo IR graph hash 8abb69318a12f48b7f71aab2a071be6f on device CPU:0 ...


wait_device_ops



....



2023-02-15 01:49:55.404479: I  400859 tensorflow/compiler/xla/xla_client/pjrt_computation_client.cc:610] Waiting for device execution forCPU:0 to finish

2023-02-15 01:49:55.404541: I  400859 tensorflow/compiler/xla/xla_client/pjrt_computation_client.cc:613] Waiting for device execution forCPU:0 to finish.. Done

wait_device_ops done
```

TODO:
make sure this does not regress our speed on TPU.

FYI @stgpetrovic @alanwaketan 