### PR TITLE
Jack cao g/test torch compile usage

### DIFF
--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -59,7 +59,8 @@ class DynamoInferenceBasicTest(unittest.TestCase):
     xm.wait_device_ops()
     met.clear_all()
     for data, _ in loader:
-      dynamo_resnet18 = torch.compile(xla_resnet18, backend='torchxla_trace_once')
+      dynamo_resnet18 = torch.compile(
+          xla_resnet18, backend='torchxla_trace_once')
       output = dynamo_resnet18(data)
       torch.allclose(resnet18(data.cpu()), output.cpu())
     # We only expect one graph for the resnet18 inference.
@@ -90,10 +91,6 @@ class DynamoTrainingBasicTest(unittest.TestCase):
     loss = loss_fn(pred, target)
     loss.backward()
     return pred
-
-  @torch.compile(backend='aot_torchxla_trace_once')
-  def run_model_with_dynamo(self, model, data, target):
-    return self.train_model(model, data, target)
 
   def test_simple_model(self):
     torch._dynamo.reset()
@@ -142,8 +139,11 @@ class DynamoTrainingBasicTest(unittest.TestCase):
     xm.mark_step()
     xm.wait_device_ops()
     met.clear_all()
+
+    dynamo_train_model = torch.compile(
+        self.train_model, backend='aot_torchxla_trace_once')
     for data, target in loader:
-      xla_output = self.run_model_with_dynamo(xla_resnet18, data, target)
+      xla_output = dynamo_train_model(xla_resnet18, data, target)
       cpu_data = data.detach().cpu()
       cpu_data.requires_grad = True
       cpu_target = target.detach().cpu()

--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -18,11 +18,11 @@ class DynamoInferenceBasicTest(unittest.TestCase):
     b = torch.sin(y)
     return a + b
 
-  @dynamo.optimize('torchxla_trace_once')
+  @torch.compile(backend='torchxla_trace_once')
   def fn_simple_dynamo(self, x, y):
     return self.fn_simple(x, y)
 
-  @dynamo.optimize('torchxla_trace_once')
+  @torch.compile(backend='torchxla_trace_once')
   def run_model_with_dynamo(self, model, data):
     return model(data)
 
@@ -83,7 +83,7 @@ class DynamoTrainingBasicTest(unittest.TestCase):
     loss.backward()
     return loss
 
-  @dynamo.optimize('aot_torchxla_trace_once')
+  @torch.compile(backend='aot_torchxla_trace_once')
   def fn_simple_dynamo(self, input):
     return self.fn_simple(input)
 
@@ -94,7 +94,7 @@ class DynamoTrainingBasicTest(unittest.TestCase):
     loss.backward()
     return pred
 
-  @dynamo.optimize('aot_torchxla_trace_once')
+  @torch.compile(backend='aot_torchxla_trace_once')
   def run_model_with_dynamo(self, model, data, target):
     return self.train_model(model, data, target)
 


### PR DESCRIPTION
Update the test to use the more standard `torch.compile` api following the guide in https://pytorch.org/tutorials/intermediate/torch_compile_tutorial.html

I left one test to use `@torch.compile` decorator and another one to use `torch.compile` directly to make sure we cover both cases.