### PR TITLE
Disable C++ ops tests failing on XRT TPU

### DIFF
--- a/test/cpp/cpp_test_util.cpp
+++ b/test/cpp/cpp_test_util.cpp
@@ -22,6 +22,8 @@ namespace cpp_test {
 namespace {
 
 void DumpDifferences(const at::Tensor& tensor1, const at::Tensor& tensor2) {
+  static bool dump_differences =
+      xla::sys_util::GetEnvBool("XLA_TEST_DUMP_DIFFERENCES", true);
   static bool dump_tensors =
       xla::sys_util::GetEnvBool("XLA_TEST_DUMP_TENSORS", false);
   at::Tensor dtensor1 = tensor1;
@@ -32,8 +34,10 @@ void DumpDifferences(const at::Tensor& tensor1, const at::Tensor& tensor2) {
   if (tensor2.dtype() == at::kBool) {
     dtensor2 = tensor2.toType(at::kByte);
   }
-  at::Tensor diff = dtensor1 - dtensor2;
-  std::cerr << "Difference Tensor:\n" << diff << "\n";
+  if (dump_differences) {
+    at::Tensor diff = dtensor1 - dtensor2;
+    std::cerr << "Difference Tensor:\n" << diff << "\n";
+  }
   if (dump_tensors) {
     std::cerr << "Compared Tensors:\n"
               << tensor1 << "\n-vs-\n"
@@ -432,6 +436,13 @@ bool UsingPjRt() {
   static bool using_pjrt =
       !xla::sys_util::GetEnvString("PJRT_DEVICE", "").empty();
   return using_pjrt;
+}
+
+bool UsingTpu() {
+  static bool using_tpu =
+      absl::StartsWith(xla::sys_util::GetEnvString("PJRT_DEVICE", ""), "TPU") ||
+      !xla::sys_util::GetEnvString("XRT_TPU_CONFIG", "").empty();
+  return using_tpu;
 }
 
 }  // namespace cpp_test

--- a/test/cpp/cpp_test_util.h
+++ b/test/cpp/cpp_test_util.h
@@ -115,5 +115,7 @@ torch::lazy::NodePtr CreateNonZeroNode2d(int64_t num_non_zero_element,
 
 bool UsingPjRt();
 
+bool UsingTpu();
+
 }  // namespace cpp_test
 }  // namespace torch_xla

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -4118,6 +4118,9 @@ TEST_F(AtenXlaTensorTest, TestEinsumExtraSpaces) {
 }
 
 TEST_F(AtenXlaTensorTest, TestEinsumLarge4D) {
+  if (UsingTpu()) {
+    GTEST_SKIP();
+  }
   torch::Tensor a =
       torch::rand({8, 16, 1024, 128}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b =
@@ -10987,6 +10990,9 @@ TEST_F(AtenXlaTensorTest, TestAddMatMulBackward) {
 }
 
 TEST_F(AtenXlaTensorTest, TestBinaryCrossEntropyBackward) {
+  if (UsingTpu()) {
+    GTEST_SKIP();
+  }
   int batch = 6;
   int classes = 2;
   for (auto dtype : {torch::kFloat, torch::kDouble}) {

--- a/test/cpp/test_aten_xla_tensor.cpp
+++ b/test/cpp/test_aten_xla_tensor.cpp
@@ -280,6 +280,9 @@ TEST_F(AtenXlaTensorTest, TestSubScalarInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestSymSizes) {
+  if (UsingTpu()) {
+    GTEST_SKIP();
+  }
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor a = torch::rand({2, 3}, torch::TensorOptions(torch::kFloat));
     torch::Tensor xla_a = CopyToDevice(a, device);
@@ -3114,6 +3117,10 @@ TEST_F(AtenXlaTensorTest, TestNeg) {
 }
 
 TEST_F(AtenXlaTensorTest, TestBitwiseNot) {
+  if (UsingTpu()) {
+    GTEST_SKIP();
+  }
+
   std::vector<torch::ScalarType> types(
       {torch::kByte, torch::kChar, torch::kShort, torch::kInt, torch::kLong});
 
@@ -3863,6 +3870,9 @@ TEST_F(AtenXlaTensorTest, TestEinsumOuterBackward) {
 }
 
 TEST_F(AtenXlaTensorTest, TestEinsumBatchMatMul) {
+  if (UsingTpu()) {
+    GTEST_SKIP();
+  }
   torch::Tensor a = torch::rand({3, 2, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5, 4}, torch::TensorOptions(torch::kFloat));
   std::string equation = "bij,bjk->bik";
@@ -3880,6 +3890,9 @@ TEST_F(AtenXlaTensorTest, TestEinsumBatchMatMul) {
 }
 
 TEST_F(AtenXlaTensorTest, TestEinsumBatchMatMulBackward) {
+  if (UsingTpu()) {
+    GTEST_SKIP();
+  }
   torch::Tensor a = torch::rand(
       {3, 2, 5}, torch::TensorOptions(torch::kFloat).requires_grad(true));
   torch::Tensor b = torch::rand(
@@ -4930,6 +4943,9 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceSumInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceProd) {
+  if (UsingTpu()) {
+    GTEST_SKIP();
+  }
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -4955,6 +4971,9 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceProd) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceProdInPlace) {
+  if (UsingTpu()) {
+    GTEST_SKIP();
+  }
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -4979,6 +4998,9 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceProdInPlace) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceMin) {
+  if (UsingTpu()) {
+    GTEST_SKIP();
+  }
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -5004,6 +5026,9 @@ TEST_F(AtenXlaTensorTest, TestScatterReduceMin) {
 }
 
 TEST_F(AtenXlaTensorTest, TestScatterReduceMinInPlace) {
+  if (UsingTpu()) {
+    GTEST_SKIP();
+  }
   torch::Tensor a = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::rand({3, 5}, torch::TensorOptions(torch::kFloat));
   torch::Tensor c = torch::empty({3, 5}, torch::TensorOptions(torch::kLong));
@@ -6333,6 +6358,9 @@ TEST_F(AtenXlaTensorTest, TestHardshrink) {
 }
 
 TEST_F(AtenXlaTensorTest, TestHardshrinkWithMixedDataType) {
+  if (UsingTpu()) {
+    GTEST_SKIP();
+  }
   torch::Tensor lambdaTensor =
       torch::scalar_tensor(0., torch::TensorOptions(torch::kFloat32));
   // It seems the below .item() will convert a kFloat64 to a kFloat32 if I
@@ -10817,6 +10845,9 @@ TEST_F(AtenXlaTensorTest, TestHardshrinkBackward) {
 }
 
 TEST_F(AtenXlaTensorTest, TestHardshrinkBackwardWithMixedDataType) {
+  if (UsingTpu()) {
+    GTEST_SKIP();
+  }
   torch::Tensor lambdaTensor =
       torch::scalar_tensor(0., torch::TensorOptions(torch::kFloat32));
   torch::Scalar lambda = lambdaTensor.item();
@@ -10845,6 +10876,9 @@ TEST_F(AtenXlaTensorTest, TestSoftshrinkBackward) {
 }
 
 TEST_F(AtenXlaTensorTest, TestSoftshrinkBackwardWithMixedDataType) {
+  if (UsingTpu()) {
+    GTEST_SKIP();
+  }
   torch::Tensor lambdaTensor =
       torch::scalar_tensor(0., torch::TensorOptions(torch::kFloat32));
   torch::Scalar lambda = lambdaTensor.item();

--- a/test/cpp/test_tensor.cpp
+++ b/test/cpp/test_tensor.cpp
@@ -413,6 +413,9 @@ TEST_F(TensorTest, TestBatchNorm1D) {
 }
 
 TEST_F(TensorTest, TestConv2D) {
+  if (UsingTpu()) {
+    GTEST_SKIP();
+  }
   int in_channels = 9;
   int out_channels = 3;
   int kernel_size = 5;
@@ -550,6 +553,9 @@ TEST_F(TensorTest, TestConv2DNonSquare) {
 }
 
 TEST_F(TensorTest, TestConv3D) {
+  if (UsingTpu()) {
+    GTEST_SKIP();
+  }
   int in_channels = 9;
   int out_channels = 3;
   int kernel_size = 5;


### PR DESCRIPTION
All of these tests are currently failing with these settings on a v4-8:

```
$ XRT_TPU_CONFIG="localservice;0;localhost:51011" TPU_NUM_DEVICES=4 TPUVM_MODE=1 XLA_TEST_DUMP_DIFFERENCES=0 bash pytorch/xla/test/cpp/run_tests.sh -KL
[...]
[  FAILED  ] 15 tests, listed below:
[  FAILED  ] AtenXlaTensorTest.TestSymSizes
[  FAILED  ] AtenXlaTensorTest.TestBitwiseNot
[  FAILED  ] AtenXlaTensorTest.TestEinsumBatchMatMul
[  FAILED  ] AtenXlaTensorTest.TestEinsumBatchMatMulBackward
[  FAILED  ] AtenXlaTensorTest.TestEinsumLarge4D
[  FAILED  ] AtenXlaTensorTest.TestScatterReduceProd
[  FAILED  ] AtenXlaTensorTest.TestScatterReduceProdInPlace
[  FAILED  ] AtenXlaTensorTest.TestScatterReduceMin
[  FAILED  ] AtenXlaTensorTest.TestScatterReduceMinInPlace
[  FAILED  ] AtenXlaTensorTest.TestHardshrinkWithMixedDataType
[  FAILED  ] AtenXlaTensorTest.TestHardshrinkBackwardWithMixedDataType
[  FAILED  ] AtenXlaTensorTest.TestSoftshrinkBackwardWithMixedDataType
[  FAILED  ] AtenXlaTensorTest.TestBinaryCrossEntropyBackward
[  FAILED  ] TensorTest.TestConv2D
[  FAILED  ] TensorTest.TestConv3D
```

If any of these should not be failing, we can file bugs to follow up.

Also add a new setting `XLA_TEST_DUMP_DIFFERENCES` to prevent `AtenXlaTensorTest.TestEinsumLarge4D` from dumping a `(8, 16, 1024, 128)` tensor to stdout.