### PR TITLE
Disable docker sandbox

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,7 +10,8 @@ build --announce_rc
 # TODO(goranpetrovic): figure out visibility of tensorflow libraries.
 build --nocheck_visibility
 
-#build --define open_source_build=true
+# We can set this to `standalone` after https://github.com/bazelbuild/bazel/issues/15359 is resolved.
+build --spawn_strategy=sandboxed
 
 build --enable_platform_specific_config
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -12,9 +12,6 @@ build --nocheck_visibility
 
 #build --define open_source_build=true
 
-# We can set this to `standalone` after https://github.com/bazelbuild/bazel/issues/15359 is resolved.
-build --spawn_strategy=sandboxed
-
 build --enable_platform_specific_config
 
 build --experimental_cc_shared_library

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,7 @@ ENV BUNDLE_LIBTPU "${tpuvm}"
 ENV BAZEL_JOBS "${bazel_jobs}"
 
 # This makes the bazel build behave more consistently, but runs slower.
-ENV XLA_SANDBOX_BUILD "0"
+ENV XLA_SANDBOX_BUILD "1"
 ENV XLA_SANDBOX_BASE "/dev/shm"
 
 # To get around issue of Cloud Build with recursive submodule update

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,7 @@ ENV BUNDLE_LIBTPU "${tpuvm}"
 ENV BAZEL_JOBS "${bazel_jobs}"
 
 # This makes the bazel build behave more consistently, but runs slower.
-ENV XLA_SANDBOX_BUILD "1"
+ENV XLA_SANDBOX_BUILD "0"
 ENV XLA_SANDBOX_BASE "/dev/shm"
 
 # To get around issue of Cloud Build with recursive submodule update

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -55,7 +55,7 @@ RUN find torch_patches -name '*.diff' | xargs -t -r -n 1 patch -N -p1 -l -i
 ENV USE_CUDA "0"
 
 ARG package_version
-RUN PYTORCH_BUILD_VERSION=${package_version} PYTORCH_BUILD_NUMBER=1 python setup.py bdist_wheel
+# RUN PYTORCH_BUILD_VERSION=${package_version} PYTORCH_BUILD_NUMBER=1 python setup.py bdist_wheel
 
 RUN pip install dist/*.whl
 

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -92,6 +92,7 @@ ARG tf_cuda_compute_capabilities
 ARG bazel_jobs
 ARG build_cpp_tests
 ARG package_version
+RUN df -h && free -h
 RUN TORCH_XLA_VERSION=${package_version} BUILD_CPP_TESTS=${build_cpp_tests} TPUVM_MODE=${tpuvm} BUNDLE_LIBTPU=${tpuvm} XLA_CUDA=${cuda} TF_CUDA_COMPUTE_CAPABILITIES=${tf_cuda_compute_capabilities} python setup.py bdist_wheel
 
 # Expunge cache to keep image size under control

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -77,7 +77,7 @@ COPY WORKSPACE .
 COPY build_torch_xla_libs.sh .
 
 # TODO: Remove this when it's not required anymore
-ENV XLA_SANDBOX_BUILD=0
+ENV XLA_SANDBOX_BUILD=1
 ENV XLA_SANDBOX_BASE "/dev/shm"
 
 COPY torch_xla/ torch_xla/

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -74,7 +74,7 @@ COPY third_party/ third_party/
 COPY build_torch_xla_libs.sh .
 
 # TODO: Remove this when it's not required anymore
-ENV XLA_SANDBOX_BUILD=0
+ENV XLA_SANDBOX_BUILD=1
 ENV XLA_SANDBOX_BASE "/dev/shm"
 
 ARG tpuvm

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -17,7 +17,6 @@ ARG bazel_jobs=
 # Contains all build dependencies for PT/XLA
 FROM python:${python_version}-${debian_version} AS builder
 
-RUN df -h
 RUN apt-get update
 RUN apt-get install -y curl gnupg libomp5 libopenblas-dev
 RUN pip install numpy pyyaml

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -77,7 +77,7 @@ COPY WORKSPACE .
 COPY build_torch_xla_libs.sh .
 
 # TODO: Remove this when it's not required anymore
-ENV XLA_SANDBOX_BUILD=1
+ENV XLA_SANDBOX_BUILD=0
 ENV XLA_SANDBOX_BASE "/dev/shm"
 
 COPY torch_xla/ torch_xla/

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -77,18 +77,16 @@ COPY build_torch_xla_libs.sh .
 ENV XLA_SANDBOX_BUILD=1
 ENV XLA_SANDBOX_BASE "/dev/shm"
 
-ARG tpuvm
-ARG cuda
-ARG tf_cuda_compute_capabilities
-ARG bazel_jobs
-RUN TPUVM_MODE=${tpuvm} XLA_CUDA=${cuda} BAZEL_JOBS=${bazel_jobs} TF_CUDA_COMPUTE_CAPABILITIES=${tf_cuda_compute_capabilities} bash build_torch_xla_libs.sh -O -D_GLIBCXX_USE_CXX11_ABI=1
-
 COPY torch_xla/ torch_xla/
 COPY setup.py .
 COPY xla_native_functions.yaml .
 
 COPY scripts/ scripts/
 
+ARG tpuvm
+ARG cuda
+ARG tf_cuda_compute_capabilities
+ARG bazel_jobs
 ARG build_cpp_tests
 ARG package_version
 RUN TORCH_XLA_VERSION=${package_version} BUILD_CPP_TESTS=${build_cpp_tests} TPUVM_MODE=${tpuvm} BUNDLE_LIBTPU=${tpuvm} XLA_CUDA=${cuda} TF_CUDA_COMPUTE_CAPABILITIES=${tf_cuda_compute_capabilities} python setup.py bdist_wheel

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -17,6 +17,7 @@ ARG bazel_jobs=
 # Contains all build dependencies for PT/XLA
 FROM python:${python_version}-${debian_version} AS builder
 
+RUN df -h
 RUN apt-get update
 RUN apt-get install -y curl gnupg libomp5 libopenblas-dev
 RUN pip install numpy pyyaml
@@ -55,9 +56,9 @@ RUN find torch_patches -name '*.diff' | xargs -t -r -n 1 patch -N -p1 -l -i
 ENV USE_CUDA "0"
 
 ARG package_version
-# RUN PYTORCH_BUILD_VERSION=${package_version} PYTORCH_BUILD_NUMBER=1 python setup.py bdist_wheel
+RUN PYTORCH_BUILD_VERSION=${package_version} PYTORCH_BUILD_NUMBER=1 python setup.py bdist_wheel
 
-# RUN pip install dist/*.whl
+RUN pip install dist/*.whl
 
 RUN curl -LO https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64
 RUN mv bazelisk-linux-amd64 /usr/local/bin/bazel
@@ -92,8 +93,7 @@ ARG tf_cuda_compute_capabilities
 ARG bazel_jobs
 ARG build_cpp_tests
 ARG package_version
-RUN df -h && mount -o remount,size=7G /dev/shm && df -h
-RUN TORCH_XLA_VERSION=${package_version} BUILD_CPP_TESTS=${build_cpp_tests} TPUVM_MODE=${tpuvm} BUNDLE_LIBTPU=${tpuvm} XLA_CUDA=${cuda} TF_CUDA_COMPUTE_CAPABILITIES=${tf_cuda_compute_capabilities} python setup.py bdist_wheel
+RUN --mount=type=tmpfs,target=/dev/shm,rw TORCH_XLA_VERSION=${package_version} BUILD_CPP_TESTS=${build_cpp_tests} TPUVM_MODE=${tpuvm} BUNDLE_LIBTPU=${tpuvm} XLA_CUDA=${cuda} TF_CUDA_COMPUTE_CAPABILITIES=${tf_cuda_compute_capabilities} python setup.py bdist_wheel
 
 # Expunge cache to keep image size under control
 RUN bazel clean --expunge

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -92,7 +92,7 @@ ARG tf_cuda_compute_capabilities
 ARG bazel_jobs
 ARG build_cpp_tests
 ARG package_version
-RUN df -h && free -h
+RUN df -h && mount -o remount,size=7G /dev/shm && df -h
 RUN TORCH_XLA_VERSION=${package_version} BUILD_CPP_TESTS=${build_cpp_tests} TPUVM_MODE=${tpuvm} BUNDLE_LIBTPU=${tpuvm} XLA_CUDA=${cuda} TF_CUDA_COMPUTE_CAPABILITIES=${tf_cuda_compute_capabilities} python setup.py bdist_wheel
 
 # Expunge cache to keep image size under control

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -70,6 +70,7 @@ WORKDIR /pytorch/xla/
 FROM builder AS artifacts
 
 COPY third_party/ third_party/
+COPY tf_patches/ tf_patches/
 COPY .bazelrc .
 COPY .bazelversion .
 COPY WORKSPACE .

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -70,7 +70,9 @@ WORKDIR /pytorch/xla/
 FROM builder AS artifacts
 
 COPY third_party/ third_party/
-
+COPY .bazelrc .
+COPY .bazelversion .
+COPY WORKSPACE .
 COPY build_torch_xla_libs.sh .
 
 # TODO: Remove this when it's not required anymore

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -57,7 +57,7 @@ ENV USE_CUDA "0"
 ARG package_version
 # RUN PYTORCH_BUILD_VERSION=${package_version} PYTORCH_BUILD_NUMBER=1 python setup.py bdist_wheel
 
-RUN pip install dist/*.whl
+# RUN pip install dist/*.whl
 
 RUN curl -LO https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64
 RUN mv bazelisk-linux-amd64 /usr/local/bin/bazel

--- a/docker/experimental/cloudbuild.yaml
+++ b/docker/experimental/cloudbuild.yaml
@@ -1,12 +1,4 @@
 steps:
-# We only need to update submodules in triggers. User must update submodule
-# before local runs because .git is not present.
-- name: 'alpine/git'
-  entrypoint: sh
-  args:
-  - -c
-  - |
-    git submodule update --init || echo No git repository found
 - id: 'common-flags'
   name: 'bash'
   args:

--- a/test/tpu/cloudbuild.yaml
+++ b/test/tpu/cloudbuild.yaml
@@ -19,7 +19,7 @@ steps:
     '--build-arg',
     'tpuvm=1',
     '--build-arg',
-    'bazel_jobs=8'
+    'bazel_jobs=16'
   ]
 - name: 'docker'
   id: push-image
@@ -59,4 +59,8 @@ steps:
     kubectl logs -f $pod_name --container=pjrt-test
 timeout: 18000s # 3 hours
 options:
- machineType: 'N1_HIGHCPU_32'
+  # To run in a test project, either point to your pool or replace this with
+  # `machineType`. You may have to reduce _BAZEL_JOBS.
+  pool:
+    name: 'projects/tpu-pytorch/locations/us-central1/workerPools/wheel_build'
+  # machineType: E2_HIGHCPU_32

--- a/test/tpu/cloudbuild.yaml
+++ b/test/tpu/cloudbuild.yaml
@@ -15,7 +15,7 @@ steps:
     'docker/experimental/Dockerfile',
     '-t',
     'gcr.io/$PROJECT_ID/pytorch-xla-test:$BUILD_ID',
-    '--shm-size=16G',
+    '--shm-size=7G',
     '--build-arg',
     'tpuvm=1',
   ]

--- a/test/tpu/cloudbuild.yaml
+++ b/test/tpu/cloudbuild.yaml
@@ -10,13 +10,12 @@ steps:
   id: build-image
   args: [
     'build',
-    '--shm-size',
-    '7g',
     '.',
     '-f',
     'docker/experimental/Dockerfile',
     '-t',
     'gcr.io/$PROJECT_ID/pytorch-xla-test:$BUILD_ID',
+    '--shm-size=16G',
     '--build-arg',
     'tpuvm=1',
   ]
@@ -58,4 +57,4 @@ steps:
     kubectl logs -f $pod_name --container=pjrt-test
 timeout: 18000s # 3 hours
 options:
- machineType: E2_HIGHCPU_32
+ machineType: 'N1_HIGHCPU_32'

--- a/test/tpu/cloudbuild.yaml
+++ b/test/tpu/cloudbuild.yaml
@@ -6,14 +6,6 @@ substitutions:
   # Location of GKE cluster.
   _CLUSTER_ZONE: 'europe-west4-a'
 steps:
-# We only need to update submodules in triggers. User must update submodule
-# before local runs because .git is not present.
-- name: 'alpine/git'
-  entrypoint: sh
-  args:
-  - -c
-  - |
-    git submodule update --init || echo No git repository found
 - name: 'docker'
   id: build-image
   args: [

--- a/test/tpu/cloudbuild.yaml
+++ b/test/tpu/cloudbuild.yaml
@@ -19,7 +19,7 @@ steps:
     '--build-arg',
     'tpuvm=1',
     '--build-arg',
-    'bazel_jobs=16'
+    'bazel_jobs=32'
   ]
 - name: 'docker'
   id: push-image

--- a/test/tpu/cloudbuild.yaml
+++ b/test/tpu/cloudbuild.yaml
@@ -10,12 +10,13 @@ steps:
   id: build-image
   args: [
     'build',
+    '--shm-size',
+    '7g',
     '.',
     '-f',
     'docker/experimental/Dockerfile',
     '-t',
     'gcr.io/$PROJECT_ID/pytorch-xla-test:$BUILD_ID',
-    '--shm-size=7g',
     '--build-arg',
     'tpuvm=1',
   ]

--- a/test/tpu/cloudbuild.yaml
+++ b/test/tpu/cloudbuild.yaml
@@ -15,7 +15,7 @@ steps:
     'docker/experimental/Dockerfile',
     '-t',
     'gcr.io/$PROJECT_ID/pytorch-xla-test:$BUILD_ID',
-    '--shm-size=7G',
+    '--shm-size=7g',
     '--build-arg',
     'tpuvm=1',
   ]

--- a/test/tpu/cloudbuild.yaml
+++ b/test/tpu/cloudbuild.yaml
@@ -18,8 +18,6 @@ steps:
     '--shm-size=16G',
     '--build-arg',
     'tpuvm=1',
-    '--build-arg',
-    'bazel_jobs=8'
   ]
 - name: 'docker'
   id: push-image

--- a/test/tpu/cloudbuild.yaml
+++ b/test/tpu/cloudbuild.yaml
@@ -19,7 +19,7 @@ steps:
     '--build-arg',
     'tpuvm=1',
     '--build-arg',
-    'bazel_jobs=32'
+    'bazel_jobs=8'
   ]
 - name: 'docker'
   id: push-image
@@ -59,8 +59,4 @@ steps:
     kubectl logs -f $pod_name --container=pjrt-test
 timeout: 18000s # 3 hours
 options:
-  # To run in a test project, either point to your pool or replace this with
-  # `machineType`. You may have to reduce _BAZEL_JOBS.
-  pool:
-    name: 'projects/tpu-pytorch/locations/us-central1/workerPools/wheel_build'
-  # machineType: E2_HIGHCPU_32
+ machineType: E2_HIGHCPU_32


### PR DESCRIPTION
Revert to local builds on cloud vs sandboxed (shm size issues).

There are a couple of issues there that intermingle.

Bazel has a [bug](https://github.com/bazelbuild/bazel/issues/15359) where the cppmap files don't get included as deps when building with clang when not in sandbox, from an external repository (local repository is OK). Using a cache might alleviate this.
The suggested solution is building in the sandbox.

For some reason, `docker build --shm-size=16g` does not prduce a 16g `/dev/shm` (it is actually 64M which is the default). There are differences in docker build/run but during build it should have 16g but it does not (as checked with `RUN df -h` showing 64M).

So the solution for this issue is to build sandboxed (without cache, unlike the other build that has cache and does not suffer from this; we could replicate that in tpu tests too), and in docker, but to run with `RUN --mount=type=tmpfs,target=/dev/shm,rw cmd` which then mounts `tmfps` as `/dev/shm` and builds properly. The build needs about `4G` of temp files so `16G` is an overkill there.

This makes the build work (avoid bazel bug by sandboxing), and makes it fast (avoid sandbox base being on HDD, and avoid docker `shm-size` issue by mounting the `tmpfs`).

We can rework this as needed in the future when we streamline all different builds into a single config.