### PR TITLE
Revert to local nonsandboxed builds with GCC

### DIFF
--- a/build_torch_xla_libs.sh
+++ b/build_torch_xla_libs.sh
@@ -42,6 +42,9 @@ if [[ "$XLA_SANDBOX_BUILD" == "1" ]]; then
   BUILD_STRATEGY="sandboxed --sandbox_base=${SANDBOX_BASE}"
 else
   # We can remove this after https://github.com/bazelbuild/bazel/issues/15359 is resolved
+  # Use GCC locally since clang does not work except with sanboxing, and sandboxing causes pjrt crashes.
+  unset CXX
+  unset CC
   BUILD_STRATEGY="local"
 fi
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,7 @@ ENV BUNDLE_LIBTPU "${tpuvm}"
 ENV BAZEL_JOBS "${bazel_jobs}"
 
 # This makes the bazel build behave more consistently, but runs slower.
-ENV XLA_SANDBOX_BUILD "1"
+ENV XLA_SANDBOX_BUILD "0"
 ENV XLA_SANDBOX_BASE "/dev/shm"
 
 # To get around issue of Cloud Build with recursive submodule update

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -77,7 +77,7 @@ COPY WORKSPACE .
 COPY build_torch_xla_libs.sh .
 
 # TODO: Remove this when it's not required anymore
-ENV XLA_SANDBOX_BUILD=1
+ENV XLA_SANDBOX_BUILD=0
 ENV XLA_SANDBOX_BASE "/dev/shm"
 
 COPY torch_xla/ torch_xla/

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -92,7 +92,7 @@ ARG tf_cuda_compute_capabilities
 ARG bazel_jobs
 ARG build_cpp_tests
 ARG package_version
-RUN --mount=type=tmpfs,target=/dev/shm,rw TORCH_XLA_VERSION=${package_version} BUILD_CPP_TESTS=${build_cpp_tests} TPUVM_MODE=${tpuvm} BUNDLE_LIBTPU=${tpuvm} XLA_CUDA=${cuda} TF_CUDA_COMPUTE_CAPABILITIES=${tf_cuda_compute_capabilities} python setup.py bdist_wheel
+RUN TORCH_XLA_VERSION=${package_version} BUILD_CPP_TESTS=${build_cpp_tests} TPUVM_MODE=${tpuvm} BUNDLE_LIBTPU=${tpuvm} XLA_CUDA=${cuda} TF_CUDA_COMPUTE_CAPABILITIES=${tf_cuda_compute_capabilities} python setup.py bdist_wheel
 
 # Expunge cache to keep image size under control
 RUN bazel clean --expunge

--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -8,11 +8,10 @@ ARG cudnn_version=8.1.1.33
 ARG cuda_repo=ubuntu1804
 ARG tf_cuda_compute_capabilities="7.0,7.5,8.0"
 
+ARG bazel_jobs
 ARG tpuvm=1
 ARG build_cpp_tests=0
 ARG package_version=2.0.0
-
-ARG bazel_jobs=
 
 # Contains all build dependencies for PT/XLA
 FROM python:${python_version}-${debian_version} AS builder
@@ -21,7 +20,7 @@ RUN apt-get update
 RUN apt-get install -y curl gnupg libomp5 libopenblas-dev
 RUN pip install numpy pyyaml
 
-ARG cuda
+ARG cudTPUVM_MODEa
 ARG cuda_version
 ARG cudnn_version
 ARG cuda_repo
@@ -92,7 +91,7 @@ ARG tf_cuda_compute_capabilities
 ARG bazel_jobs
 ARG build_cpp_tests
 ARG package_version
-RUN TORCH_XLA_VERSION=${package_version} BUILD_CPP_TESTS=${build_cpp_tests} TPUVM_MODE=${tpuvm} BUNDLE_LIBTPU=${tpuvm} XLA_CUDA=${cuda} TF_CUDA_COMPUTE_CAPABILITIES=${tf_cuda_compute_capabilities} python setup.py bdist_wheel
+RUN TORCH_XLA_VERSION=${package_version} BUILD_CPP_TESTS=${build_cpp_tests} BAZEL_JOBS=${bazel_jobs} TPUVM_MODE=${tpuvm} BUNDLE_LIBTPU=${tpuvm} XLA_CUDA=${cuda} TF_CUDA_COMPUTE_CAPABILITIES=${tf_cuda_compute_capabilities} python setup.py bdist_wheel
 
 # Expunge cache to keep image size under control
 RUN bazel clean --expunge

--- a/test/tpu/cloudbuild.yaml
+++ b/test/tpu/cloudbuild.yaml
@@ -18,6 +18,8 @@ steps:
     '--shm-size=16G',
     '--build-arg',
     'tpuvm=1',
+    '--build-arg',
+    'bazel_jobs=8'
   ]
 - name: 'docker'
   id: push-image


### PR DESCRIPTION
Revert to default compiler (gcc, unsetting potential clang CC/CXX), and local builds due to bazel issues in sandbox builds.