### PR TITLE
Lower aten::_unique2

### DIFF
--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -8,7 +8,7 @@ FILTER=
 BUILD_ONLY=0
 RMBUILD=1
 LOGFILE=/tmp/pytorch_cpp_test.log
-XLA_EXPERIMENTAL="nonzero:masked_select"
+XLA_EXPERIMENTAL="nonzero:masked_select:unique"
 
 if [ "$DEBUG" == "1" ]; then
   BUILDTYPE="Debug"

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -76,7 +76,7 @@ function run_xla_hlo_debug {
 
 function run_dynamic {
   echo "Running in DynamicShape mode: $@"
-  XLA_EXPERIMENTAL="nonzero:masked_select:masked_scatter" run_test "$@"
+  XLA_EXPERIMENTAL="nonzero:masked_select:masked_scatter:unique" run_test "$@"
 }
 
 function run_eager_debug {

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -192,7 +192,8 @@ class TestDynamicShapes(test_utils.XlaTestCase):
 
     self.runAtenTest([torch.randint(4, 10, size=(10,)) for _ in range(2)] +
                      [torch.randint(4, 10, size=(10, 10)) for _ in range(2)] +
-                     [torch.rand(10, 10) for _ in range(2)], test_fn)
+                     [torch.rand(10, 10) for _ in range(2)] + [torch.ones(1)],
+                     test_fn)
 
 
 if __name__ == '__main__':

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -178,6 +178,22 @@ class TestDynamicShapes(test_utils.XlaTestCase):
     self.assertEqual(t3.shape[0], 2)
     self.assertEqual(expand_out_aten.cpu(), expand_out_xla.cpu())
 
+  def test_unique_correctness(self):
+
+    def test_fn(*tensors):
+      results = []
+      for t in tensors:
+        results += [torch.unique(t, sorted=True)]
+        results += list(torch.unique(t, sorted=True, return_inverse=True))
+        results += list(
+            torch.unique(
+                t, sorted=True, return_inverse=True, return_counts=True))
+      return results
+
+    self.runAtenTest([torch.randint(4, 10, size=(10,)) for _ in range(2)] +
+                     [torch.randint(4, 10, size=(10, 10)) for _ in range(2)] +
+                     [torch.rand(10, 10) for _ in range(2)], test_fn)
+
 
 if __name__ == '__main__':
   assert os.environ['XLA_EXPERIMENTAL'] != ''

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3190,4 +3190,16 @@ at::Tensor XLANativeFunctions::_cdist_forward(
       bridge::GetXlaTensor(x1), bridge::GetXlaTensor(x2), p));
 }
 
+std::tuple<at::Tensor, at::Tensor, at::Tensor> XLANativeFunctions::_unique2(
+    const at::Tensor& self, bool sorted, bool return_inverse,
+    bool return_counts) {
+  TORCH_LAZY_FN_COUNTER("xla::");
+  std::tuple<XLATensorPtr, XLATensorPtr, XLATensorPtr> res =
+      tensor_methods::unique2(bridge::GetXlaTensor(self), sorted,
+                              return_inverse, return_counts);
+  return std::make_tuple(bridge::AtenFromXlaTensor(std::get<0>(res)),
+                         bridge::AtenFromXlaTensor(std::get<1>(res)),
+                         bridge::AtenFromXlaTensor(std::get<2>(res)));
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/unique2.cpp
+++ b/torch_xla/csrc/ops/unique2.cpp
@@ -1,26 +1,22 @@
 #include "torch_xla/csrc/ops/unique2.h"
 
-#include "absl/strings/str_join.h"
-#include "tensorflow/compiler/xla/client/lib/comparators.h"
-#include "tensorflow/compiler/xla/client/lib/constants.h"
-#include "third_party/xla_client/debug_macros.h"
-#include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/lowering_context.h"
-#include "torch_xla/csrc/ops/convolution_overrideable.h"
-#include "torch_xla/csrc/ops/infer_output_shape.h"
+#include "torch_xla/csrc/tensor_util.h"
+#include "torch_xla/csrc/xla_lower_util.h"
 
 namespace torch_xla {
 namespace {
 
-xla::Shape NodeOutputShape(const torch::lazy::Value& input, bool return_inverse,
-                           bool return_counts) {
+xla::Shape NodeOutputShape(const torch::lazy::Value& input) {
   xla::Shape input_shape = GetXlaShape(input);
   int64_t num_elements = xla::ShapeUtil::ElementsIn(input_shape);
+  xla::PrimitiveType indices_type = GetShapeDimensionType(/*device=*/nullptr);
   xla::Shape unique_elements_shape =
       xla::ShapeUtil::MakeShape(input_shape.element_type(), {num_elements});
   xla::Shape inverse_indices_shape =
-      xla::ShapeUtil::MakeShape(xla::S64, input_shape.dimensions());
-  xla::Shape counts_shape = xla::ShapeUtil::MakeShape(xla::S64, {num_elements});
+      xla::ShapeUtil::MakeShape(indices_type, input_shape.dimensions());
+  xla::Shape counts_shape =
+      xla::ShapeUtil::MakeShape(indices_type, {num_elements});
   unique_elements_shape.set_dynamic_dimension(0, true);
   counts_shape.set_dynamic_dimension(0, true);
   return xla::ShapeUtil::MakeTupleShape(
@@ -29,140 +25,18 @@ xla::Shape NodeOutputShape(const torch::lazy::Value& input, bool return_inverse,
 
 }  // namespace
 
-Unique2::Unique2(const torch::lazy::Value& input, bool sorted,
-                 bool return_inverse, bool return_counts)
+Unique2::Unique2(const torch::lazy::Value& input)
     : XlaNode(torch::lazy::OpKind(at::aten::_unique2), {input},
-              [&]() {
-                return NodeOutputShape(input, return_inverse, return_counts);
-              },
-              /*num_outputs=*/3,
-              torch::lazy::MHash(return_inverse, return_counts)),
-      sorted_(sorted),  // sorted is always true for xla backend
-      return_inverse_(return_inverse),
-      return_counts_(return_counts) {}
+              [&]() { return NodeOutputShape(input); },
+              /*num_outputs=*/3) {}
 
 torch::lazy::NodePtr Unique2::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Unique2>(operands.at(0), sorted_,
-                                        return_inverse_, return_counts_);
-}
-
-xla::XlaComputation MakeScatterUpdateComputation(
-    xla::PrimitiveType element_type) {
-  xla::XlaBuilder cb("ScatterCombiner");
-  xla::Shape xla_scalar_shape = xla::ShapeUtil::MakeShape(element_type, {});
-  xla::XlaOp p0 = xla::Parameter(&cb, 0, xla_scalar_shape, "p0");
-  xla::XlaOp result = xla::Parameter(&cb, 1, xla_scalar_shape, "p1");
-  return ConsumeValue(cb.Build(result));
-}
-
-xla::XlaComputation MakeScatterCountComputation(
-    xla::PrimitiveType element_type) {
-  xla::XlaBuilder cb("ScatterCombiner");
-  xla::Shape xla_scalar_shape = xla::ShapeUtil::MakeShape(element_type, {});
-  xla::XlaOp p0 = xla::Parameter(&cb, 0, xla_scalar_shape, "p0");
-  xla::XlaOp result = xla::Parameter(&cb, 1, xla_scalar_shape, "p1");
-  result = xla::Add(p0, xla::One(&cb, element_type));
-  return ConsumeValue(cb.Build(result));
+  return torch::lazy::MakeNode<Unique2>(operands.at(0));
 }
 
 XlaOpVector Unique2::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
-  xla::XlaBuilder* builder = input.builder();
-  xla::Shape input_shape = XlaHelpers::ShapeOfXlaOp(input);
-  int64_t num_elements = xla::ShapeUtil::ElementsIn(input_shape);
-  xla::XlaOp input_flattened = XlaHelpers::Flatten(input);
-  xla::XlaOp indices =
-      xla::Iota(builder, xla::PrimitiveType::S32, num_elements);
-  xla::XlaComputation comparator = xla::CreateScalarLtComputation(
-      {input_shape.element_type(), xla::PrimitiveType::S32}, builder);
-  xla::XlaOp sorted = xla::Sort({input_flattened, indices}, comparator);
-  xla::XlaOp sorted_elements = xla::GetTupleElement(sorted, 0);
-  xla::XlaOp sorted_indices = xla::GetTupleElement(sorted, 1);
-  // adjacent difference
-  xla::XlaOp right = xla::Slice(sorted_elements, {1}, {num_elements}, {1});
-  xla::XlaOp left = xla::Slice(sorted_elements, {0}, {num_elements - 1}, {1});
-  xla::XlaOp diff =
-      xla::ConvertElementType(xla::Ne(right, left), xla::PrimitiveType::S32);
-  xla::XlaOp adjacent_diff =
-      xla::Pad(diff, xla::Zero(builder, xla::PrimitiveType::S32),
-               xla::MakeEdgePaddingConfig({{1, 0}}));
-  xla::XlaOp cumsum = xla::ReduceWindowWithGeneralPadding(
-      adjacent_diff, xla::Zero(builder, xla::PrimitiveType::S32),
-      XlaHelpers::CreateAddComputation(xla::PrimitiveType::S32), {num_elements},
-      {1},
-      /*base_dilations=*/{}, /*window_dilations=*/{}, {{num_elements - 1, 0}});
-  xla::ScatterDimensionNumbers scatter_dnums;
-  //   operand = s32[3,3] parameter(0)
-  //   indices = s32[2] parameter(1)
-  //   updates = s32[3,2] parameter(2)
-  //   scatter = s32[3,3] scatter(operand, indices, updates),
-  //       to_apply=update_computation,
-  //       update_window_dims={0},
-  //       inserted_window_dims={1},
-  //       scatter_dims_to_operand_dims={1},
-  //       index_vector_dim=1
-
-  // Example of a 1-D scatter that updates two [1,3] tensors in a tensor of
-  // shape [3,3]:
-  //
-  //   operand = s32[3,3] parameter(0)
-  //   indices = s32[2] parameter(1)
-  //   updates = s32[2,3] parameter(2)
-  //   scatter = s32[3,3] scatter(operand, indices, updates),
-  //       to_apply=update_computation,
-  //       update_window_dims={1},
-  //       inserted_window_dims={0},
-  //       scatter_dims_to_operand_dims={0},
-  //       index_vector_dim=1
-  scatter_dnums.set_index_vector_dim(1);
-  scatter_dnums.add_inserted_window_dims(0);
-  scatter_dnums.add_scatter_dims_to_operand_dims(0);
-  scatter_dnums.add_update_window_dims(1);
-  xla::XlaOp sorted_elements_reshaped =
-      xla::Reshape(sorted_elements, {num_elements, 1});
-  xla::XlaOp unique_elements = xla::Scatter(
-      xla::Zeros(builder, xla::ShapeUtil::MakeShape(input_shape.element_type(),
-                                                    {num_elements, 1})),
-      cumsum, sorted_elements_reshaped,
-      MakeScatterUpdateComputation(input_shape.element_type()), scatter_dnums,
-      /*indices_are_sorted=*/true, /*unique_indices=*/false);
-  xla::XlaOp unique_elements_reshaped = XlaHelpers::Flatten(unique_elements);
-  xla::XlaOp cumsum_reshaped = xla::Reshape(cumsum, {num_elements, 1});
-  xla::XlaOp inverse_index = xla::Scatter(
-      xla::Zeros(builder, xla::ShapeUtil::MakeShape(xla::PrimitiveType::S32,
-                                                    {num_elements, 1})),
-      sorted_indices, cumsum_reshaped,
-      MakeScatterUpdateComputation(xla::PrimitiveType::S32), scatter_dnums,
-      /*indices_are_sorted=*/false, /*unique_indices=*/true);
-  xla::XlaOp inverse_index_reshaped = xla::Reshape(
-      XlaHelpers::Flatten(inverse_index), input_shape.dimensions());
-
-  xla::XlaOp counts = xla::Scatter(
-      xla::Zeros(builder, xla::ShapeUtil::MakeShape(xla::PrimitiveType::S32,
-                                                    {num_elements, 1})),
-      cumsum, cumsum_reshaped,
-      MakeScatterCountComputation(xla::PrimitiveType::S32), scatter_dnums,
-      /*indices_are_sorted=*/true, /*unique_indices=*/false);
-
-  xla::XlaOp counts_reshaped = XlaHelpers::Flatten(counts);
-  xla::XlaOp num_unique_elements =
-      xla::Reduce(adjacent_diff, xla::Zero(builder, xla::PrimitiveType::S32),
-                  XlaHelpers::CreateAddComputation(xla::PrimitiveType::S32),
-                  {0}) +
-      xla::One(builder, xla::PrimitiveType::S32);
-
-  std::vector<xla::XlaOp> output = {
-      xla::SetDimensionSize(unique_elements_reshaped, num_unique_elements, 0),
-      inverse_index_reshaped,
-      xla::SetDimensionSize(counts_reshaped, num_unique_elements, 0)};
-  return ReturnOps(output, loctx);
-}  // namespace torch_xla
-
-std::string Unique2::ToString() const {
-  std::stringstream ss;
-  ss << XlaNode::ToString() << ", sorted=(" << sorted_ << "), return_inverse=("
-     << return_inverse_ << "), return_counts=" << return_counts_;
-  return ss.str();
+  return ReturnOps(BuildUnique2(input), loctx);
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/unique2.cpp
+++ b/torch_xla/csrc/ops/unique2.cpp
@@ -1,0 +1,168 @@
+#include "torch_xla/csrc/ops/unique2.h"
+
+#include "absl/strings/str_join.h"
+#include "tensorflow/compiler/xla/client/lib/comparators.h"
+#include "tensorflow/compiler/xla/client/lib/constants.h"
+#include "third_party/xla_client/debug_macros.h"
+#include "torch_xla/csrc/helpers.h"
+#include "torch_xla/csrc/lowering_context.h"
+#include "torch_xla/csrc/ops/convolution_overrideable.h"
+#include "torch_xla/csrc/ops/infer_output_shape.h"
+
+namespace torch_xla {
+namespace {
+
+xla::Shape NodeOutputShape(const torch::lazy::Value& input, bool return_inverse,
+                           bool return_counts) {
+  xla::Shape input_shape = GetXlaShape(input);
+  int64_t num_elements = xla::ShapeUtil::ElementsIn(input_shape);
+  xla::Shape unique_elements_shape =
+      xla::ShapeUtil::MakeShape(input_shape.element_type(), {num_elements});
+  xla::Shape inverse_indices_shape =
+      xla::ShapeUtil::MakeShape(xla::S64, input_shape.dimensions());
+  xla::Shape counts_shape = xla::ShapeUtil::MakeShape(xla::S64, {num_elements});
+  unique_elements_shape.set_dynamic_dimension(0, true);
+  counts_shape.set_dynamic_dimension(0, true);
+  return xla::ShapeUtil::MakeTupleShape(
+      {unique_elements_shape, inverse_indices_shape, counts_shape});
+}
+
+}  // namespace
+
+Unique2::Unique2(const torch::lazy::Value& input, bool sorted,
+                 bool return_inverse, bool return_counts)
+    : XlaNode(torch::lazy::OpKind(at::aten::_unique2), {input},
+              [&]() {
+                return NodeOutputShape(input, return_inverse, return_counts);
+              },
+              /*num_outputs=*/3,
+              torch::lazy::MHash(return_inverse, return_counts)),
+      sorted_(sorted),  // sorted is always true for xla backend
+      return_inverse_(return_inverse),
+      return_counts_(return_counts) {}
+
+torch::lazy::NodePtr Unique2::Clone(torch::lazy::OpList operands) const {
+  return torch::lazy::MakeNode<Unique2>(operands.at(0), sorted_,
+                                        return_inverse_, return_counts_);
+}
+
+xla::XlaComputation MakeScatterUpdateComputation(
+    xla::PrimitiveType element_type) {
+  xla::XlaBuilder cb("ScatterCombiner");
+  xla::Shape xla_scalar_shape = xla::ShapeUtil::MakeShape(element_type, {});
+  xla::XlaOp p0 = xla::Parameter(&cb, 0, xla_scalar_shape, "p0");
+  xla::XlaOp result = xla::Parameter(&cb, 1, xla_scalar_shape, "p1");
+  return ConsumeValue(cb.Build(result));
+}
+
+xla::XlaComputation MakeScatterCountComputation(
+    xla::PrimitiveType element_type) {
+  xla::XlaBuilder cb("ScatterCombiner");
+  xla::Shape xla_scalar_shape = xla::ShapeUtil::MakeShape(element_type, {});
+  xla::XlaOp p0 = xla::Parameter(&cb, 0, xla_scalar_shape, "p0");
+  xla::XlaOp result = xla::Parameter(&cb, 1, xla_scalar_shape, "p1");
+  result = xla::Add(p0, xla::One(&cb, element_type));
+  return ConsumeValue(cb.Build(result));
+}
+
+XlaOpVector Unique2::Lower(LoweringContext* loctx) const {
+  xla::XlaOp input = loctx->GetOutputOp(operand(0));
+  xla::XlaBuilder* builder = input.builder();
+  xla::Shape input_shape = XlaHelpers::ShapeOfXlaOp(input);
+  int64_t num_elements = xla::ShapeUtil::ElementsIn(input_shape);
+  xla::XlaOp input_flattened = XlaHelpers::Flatten(input);
+  xla::XlaOp indices =
+      xla::Iota(builder, xla::PrimitiveType::S32, num_elements);
+  xla::XlaComputation comparator = xla::CreateScalarLtComputation(
+      {input_shape.element_type(), xla::PrimitiveType::S32}, builder);
+  xla::XlaOp sorted = xla::Sort({input_flattened, indices}, comparator);
+  xla::XlaOp sorted_elements = xla::GetTupleElement(sorted, 0);
+  xla::XlaOp sorted_indices = xla::GetTupleElement(sorted, 1);
+  // adjacent difference
+  xla::XlaOp right = xla::Slice(sorted_elements, {1}, {num_elements}, {1});
+  xla::XlaOp left = xla::Slice(sorted_elements, {0}, {num_elements - 1}, {1});
+  xla::XlaOp diff =
+      xla::ConvertElementType(xla::Ne(right, left), xla::PrimitiveType::S32);
+  xla::XlaOp adjacent_diff =
+      xla::Pad(diff, xla::Zero(builder, xla::PrimitiveType::S32),
+               xla::MakeEdgePaddingConfig({{1, 0}}));
+  xla::XlaOp cumsum = xla::ReduceWindowWithGeneralPadding(
+      adjacent_diff, xla::Zero(builder, xla::PrimitiveType::S32),
+      XlaHelpers::CreateAddComputation(xla::PrimitiveType::S32), {num_elements},
+      {1},
+      /*base_dilations=*/{}, /*window_dilations=*/{}, {{num_elements - 1, 0}});
+  xla::ScatterDimensionNumbers scatter_dnums;
+  //   operand = s32[3,3] parameter(0)
+  //   indices = s32[2] parameter(1)
+  //   updates = s32[3,2] parameter(2)
+  //   scatter = s32[3,3] scatter(operand, indices, updates),
+  //       to_apply=update_computation,
+  //       update_window_dims={0},
+  //       inserted_window_dims={1},
+  //       scatter_dims_to_operand_dims={1},
+  //       index_vector_dim=1
+
+  // Example of a 1-D scatter that updates two [1,3] tensors in a tensor of
+  // shape [3,3]:
+  //
+  //   operand = s32[3,3] parameter(0)
+  //   indices = s32[2] parameter(1)
+  //   updates = s32[2,3] parameter(2)
+  //   scatter = s32[3,3] scatter(operand, indices, updates),
+  //       to_apply=update_computation,
+  //       update_window_dims={1},
+  //       inserted_window_dims={0},
+  //       scatter_dims_to_operand_dims={0},
+  //       index_vector_dim=1
+  scatter_dnums.set_index_vector_dim(1);
+  scatter_dnums.add_inserted_window_dims(0);
+  scatter_dnums.add_scatter_dims_to_operand_dims(0);
+  scatter_dnums.add_update_window_dims(1);
+  xla::XlaOp sorted_elements_reshaped =
+      xla::Reshape(sorted_elements, {num_elements, 1});
+  xla::XlaOp unique_elements = xla::Scatter(
+      xla::Zeros(builder, xla::ShapeUtil::MakeShape(input_shape.element_type(),
+                                                    {num_elements, 1})),
+      cumsum, sorted_elements_reshaped,
+      MakeScatterUpdateComputation(input_shape.element_type()), scatter_dnums,
+      /*indices_are_sorted=*/true, /*unique_indices=*/false);
+  xla::XlaOp unique_elements_reshaped = XlaHelpers::Flatten(unique_elements);
+  xla::XlaOp cumsum_reshaped = xla::Reshape(cumsum, {num_elements, 1});
+  xla::XlaOp inverse_index = xla::Scatter(
+      xla::Zeros(builder, xla::ShapeUtil::MakeShape(xla::PrimitiveType::S32,
+                                                    {num_elements, 1})),
+      sorted_indices, cumsum_reshaped,
+      MakeScatterUpdateComputation(xla::PrimitiveType::S32), scatter_dnums,
+      /*indices_are_sorted=*/false, /*unique_indices=*/true);
+  xla::XlaOp inverse_index_reshaped = xla::Reshape(
+      XlaHelpers::Flatten(inverse_index), input_shape.dimensions());
+
+  xla::XlaOp counts = xla::Scatter(
+      xla::Zeros(builder, xla::ShapeUtil::MakeShape(xla::PrimitiveType::S32,
+                                                    {num_elements, 1})),
+      cumsum, cumsum_reshaped,
+      MakeScatterCountComputation(xla::PrimitiveType::S32), scatter_dnums,
+      /*indices_are_sorted=*/true, /*unique_indices=*/false);
+
+  xla::XlaOp counts_reshaped = XlaHelpers::Flatten(counts);
+  xla::XlaOp num_unique_elements =
+      xla::Reduce(adjacent_diff, xla::Zero(builder, xla::PrimitiveType::S32),
+                  XlaHelpers::CreateAddComputation(xla::PrimitiveType::S32),
+                  {0}) +
+      xla::One(builder, xla::PrimitiveType::S32);
+
+  std::vector<xla::XlaOp> output = {
+      xla::SetDimensionSize(unique_elements_reshaped, num_unique_elements, 0),
+      inverse_index_reshaped,
+      xla::SetDimensionSize(counts_reshaped, num_unique_elements, 0)};
+  return ReturnOps(output, loctx);
+}  // namespace torch_xla
+
+std::string Unique2::ToString() const {
+  std::stringstream ss;
+  ss << XlaNode::ToString() << ", sorted=(" << sorted_ << "), return_inverse=("
+     << return_inverse_ << "), return_counts=" << return_counts_;
+  return ss.str();
+}
+
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/unique2.h
+++ b/torch_xla/csrc/ops/unique2.h
@@ -1,27 +1,16 @@
 #pragma once
 
-#include "absl/types/span.h"
-#include "tensorflow/compiler/xla/xla_data.pb.h"
 #include "torch_xla/csrc/ir.h"
 
 namespace torch_xla {
 
-// IR node for 2D & 3D convolutions with or without bias.
 class Unique2 : public XlaNode {
  public:
-  Unique2(const torch::lazy::Value& input, bool sorted, bool return_inverse,
-          bool return_counts);
+  Unique2(const torch::lazy::Value& input);
 
   torch::lazy::NodePtr Clone(torch::lazy::OpList operands) const override;
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
-
-  std::string ToString() const override;
-
- private:
-  bool sorted_;
-  bool return_inverse_;
-  bool return_counts_;
 };
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/unique2.h
+++ b/torch_xla/csrc/ops/unique2.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "absl/types/span.h"
+#include "tensorflow/compiler/xla/xla_data.pb.h"
+#include "torch_xla/csrc/ir.h"
+
+namespace torch_xla {
+
+// IR node for 2D & 3D convolutions with or without bias.
+class Unique2 : public XlaNode {
+ public:
+  Unique2(const torch::lazy::Value& input, bool sorted, bool return_inverse,
+          bool return_counts);
+
+  torch::lazy::NodePtr Clone(torch::lazy::OpList operands) const override;
+
+  XlaOpVector Lower(LoweringContext* loctx) const override;
+
+  std::string ToString() const override;
+
+ private:
+  bool sorted_;
+  bool return_inverse_;
+  bool return_counts_;
+};
+
+}  // namespace torch_xla

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -124,6 +124,7 @@
 #include "torch_xla/csrc/ops/topk.h"
 #include "torch_xla/csrc/ops/triangular_solve.h"
 #include "torch_xla/csrc/ops/uniform.h"
+#include "torch_xla/csrc/ops/unique2.h"
 #include "torch_xla/csrc/ops/unsqueeze.h"
 #include "torch_xla/csrc/ops/upsample_bilinear2d.h"
 #include "torch_xla/csrc/ops/upsample_bilinear2d_backward.h"
@@ -2577,6 +2578,16 @@ void uniform_(XLATensorPtr& input, double from, double to) {
       XLAGraphExecutor::Get()->GetIrValueForScalar(
           to, input_shape.get().element_type(), input->GetDevice()),
       XLAGraphExecutor::Get()->GetRngSeed(input->GetDevice()), input_shape));
+}
+
+std::tuple<XLATensorPtr, XLATensorPtr, XLATensorPtr> unique2(
+    const XLATensorPtr& input, bool sorted, bool return_inverse,
+    bool return_counts) {
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<Unique2>(
+      input->GetIrValue(), sorted, return_inverse, return_counts);
+  return std::make_tuple(input->CreateFrom(torch::lazy::Value(node, 0)),
+                         input->CreateFrom(torch::lazy::Value(node, 1)),
+                         input->CreateFrom(torch::lazy::Value(node, 2)));
 }
 
 XLATensorPtr unsqueeze(const XLATensorPtr& input, int64_t dim) {

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2583,8 +2583,10 @@ void uniform_(XLATensorPtr& input, double from, double to) {
 std::tuple<XLATensorPtr, XLATensorPtr, XLATensorPtr> unique2(
     const XLATensorPtr& input, bool sorted, bool return_inverse,
     bool return_counts) {
-  torch::lazy::NodePtr node = torch::lazy::MakeNode<Unique2>(
-      input->GetIrValue(), sorted, return_inverse, return_counts);
+  // Note: sorted, return_inverse, return_counts are always treated as True on
+  // XLA device.
+  torch::lazy::NodePtr node =
+      torch::lazy::MakeNode<Unique2>(input->GetIrValue());
   return std::make_tuple(input->CreateFrom(torch::lazy::Value(node, 0)),
                          input->CreateFrom(torch::lazy::Value(node, 1)),
                          input->CreateFrom(torch::lazy::Value(node, 2)));

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -851,6 +851,10 @@ std::vector<XLATensorPtr> unbind(const XLATensorPtr& input, int64_t dim);
 
 void uniform_(XLATensorPtr& input, double from, double to);
 
+std::tuple<XLATensorPtr, XLATensorPtr, XLATensorPtr> unique2(
+    const XLATensorPtr& input, bool sorted, bool return_inverse,
+    bool return_counts);
+
 // Insert a dimension of size one at the specified position.
 XLATensorPtr unsqueeze(const XLATensorPtr& input, int64_t dim);
 

--- a/torch_xla/csrc/xla_lower_util.h
+++ b/torch_xla/csrc/xla_lower_util.h
@@ -137,4 +137,6 @@ xla::XlaOp BuildAddcmul(xla::XlaOp input, xla::XlaOp t1, xla::XlaOp t2,
 xla::XlaOp BuildCdistForward(xla::XlaOp x1, xla::XlaOp x2, xla::XlaOp p,
                              bool use_hamming, bool use_chebyshev);
 
+std::vector<xla::XlaOp> BuildUnique2(xla::XlaOp input);
+
 }  // namespace torch_xla

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -321,6 +321,7 @@ supported:
   - triangular_solve
   - unbind.int
   - uniform_
+  - _unique2
   - unsqueeze
   - unsqueeze_
   - upsample_bilinear2d


### PR DESCRIPTION
This PR adds `aten::_unique2`. Similar to `aten::nonzero`, this op is currently marked as experimental.