### PR TITLE
[FSDP] Add meta device and torchdistx deferred_init feature in FSDP

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -184,6 +184,7 @@ function run_mp_op_tests {
   run_xla_backend_mp python3 "$CDIR/test_torch_distributed_reduce_scatter_xla_backend.py"
   run_xla_backend_mp python3 "$CDIR/test_ddp.py"
   run_xla_backend_mp python3 "$CDIR/test_fsdp_auto_wrap.py"
+  run_xla_backend_mp python3 "$CDIR/test_torch_distributed_fsdp_meta.py"
 }
 
 function run_tests {

--- a/test/test_torch_distributed_fsdp_meta.py
+++ b/test/test_torch_distributed_fsdp_meta.py
@@ -1,0 +1,155 @@
+import torch
+import torch.nn as nn
+from torch_xla.distributed.fsdp import XlaFullyShardedDataParallel
+from torch_xla.distributed.fsdp.wrap import (
+    always_wrap_policy as always_wrap,)
+
+import torch.distributed as dist
+import torch_xla.distributed.xla_multiprocessing as xmp
+import torch_xla.core.xla_model as xm
+
+import traceback
+
+_TORCHDISTX_AVAIL = True
+try:
+  from torchdistx import deferred_init
+except ImportError:
+  _TORCHDISTX_AVAIL = False
+
+
+def _reset_params_if_meta(is_meta, model):
+  # For torchdistX init, we don't need to call reset_params, as
+  # deferred_init(model).materialize() is equivalent to model().
+  if is_meta:
+    model.reset_parameters()
+
+
+class MyLinear(nn.Linear):
+  """
+    Linear layer with deterministic reset_parameters for testing.
+    """
+
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+
+  def reset_parameters(self, *args, **kwargs):
+    with torch.no_grad():
+      self.weight.fill_(1)
+
+
+class MyModel(nn.Module):
+
+  def __init__(self, device):
+    super().__init__()
+    self.lin1 = MyLinear(2, 2, bias=False, device=device)
+    self.lin2 = MyLinear(2, 2, bias=False, device=device)
+
+  def forward(self, x):
+    return self.lin2(self.lin1(x))
+
+  def reset_parameters(self, *args, **kwargs):
+    for m in [self.lin1, self.lin2]:
+      if not isinstance(m, XlaFullyShardedDataParallel):
+        m.reset_parameters()
+
+
+def _init_with_reset_params(module):
+  """
+    to_empty + reset_parameters() init function example for modules
+    initailized with device="meta"
+    """
+  is_meta = any(t.is_meta for t in module.parameters())
+  if is_meta:
+    module.to_empty(device=xm.xla_device())
+  with torch.no_grad():
+    module.reset_parameters()
+
+
+def _init_with_torchdistX(module):
+  """
+    torchdistX-based deferred module initialization function example
+    using ``materialize_module``.
+    """
+  assert _TORCHDISTX_AVAIL
+
+  def check_fn(k):
+    return not isinstance(k, XlaFullyShardedDataParallel)
+
+  deferred_init.materialize_module(module, check_fn=check_fn)
+
+
+class TestFSDPWithMetaDevice():
+
+  def _compare_fsdp(self, fsdp1, fsdp2):
+    for p1, p2 in zip(fsdp1.parameters(), fsdp2.parameters()):
+      assert (torch.allclose(p1.cpu(), p2.cpu()))
+
+  def _test_simple_model_with_meta_device(self, meta_module_fn, init_fn=None):
+    # Create model on meta device and wrap with FSDP.
+    model = meta_module_fn()
+    inp = torch.randn(10, 2, device=xm.xla_device())
+
+    fsdp_meta = XlaFullyShardedDataParallel(
+        model,
+        auto_wrap_policy=always_wrap,
+        param_init_fn=init_fn,
+    )
+    meta_opt = torch.optim.SGD(fsdp_meta.parameters(), lr=1e-3)
+    fsdp_meta(inp).sum().backward()
+    meta_opt.step()
+    xm.mark_step()
+
+    regular = MyModel(device=xm.xla_device())
+    fsdp_regular = XlaFullyShardedDataParallel(
+        regular, auto_wrap_policy=always_wrap)
+    regular_opt = torch.optim.SGD(fsdp_regular.parameters(), lr=1e-3)
+    fsdp_regular(inp).sum().backward()
+    regular_opt.step()
+    xm.mark_step()
+
+    self._compare_fsdp(fsdp_meta, fsdp_regular)
+
+  def test_simple_model_with_meta_device_reset_params(self):
+
+    def meta_module_fn():
+      return MyModel(device="meta")
+
+    self._test_simple_model_with_meta_device(meta_module_fn,
+                                             _init_with_reset_params)
+
+  def test_simple_model_with_meta_default_reset_params(self):
+
+    def meta_module_fn():
+      return MyModel(device="meta")
+
+    self._test_simple_model_with_meta_device(meta_module_fn)
+
+  def test_simple_model_with_torchdistX_init_fn(self):
+
+    def meta_module_fn():
+      return deferred_init.deferred_init(MyModel, device=xm.xla_device())
+
+    self._test_simple_model_with_meta_device(
+        meta_module_fn, init_fn=_init_with_torchdistX)
+
+  def test_simple_model_with_default_torchdistX(self):
+
+    def meta_module_fn():
+      return deferred_init.deferred_init(MyModel, device=xm.xla_device())
+
+    self._test_simple_model_with_meta_device(meta_module_fn)
+
+
+def _mp_fn(index):
+  dist.init_process_group(
+      'xla', world_size=xm.xrt_world_size(), rank=xm.get_ordinal())
+  test = TestFSDPWithMetaDevice()
+  test.test_simple_model_with_meta_device_reset_params()
+  test.test_simple_model_with_meta_default_reset_params()
+  if _TORCHDISTX_AVAIL:
+    test.test_simple_model_with_torchdistX_init_fn()
+    test.test_simple_model_with_default_torchdistX()
+
+
+if __name__ == '__main__':
+  xmp.spawn(_mp_fn, args=())

--- a/torch_xla/distributed/fsdp/_init_utils.py
+++ b/torch_xla/distributed/fsdp/_init_utils.py
@@ -90,8 +90,7 @@ def _get_orig_params(
   """
     Returns an iterator over the original parameters in ``module``, ignoring
     the parameters in ``ignored_params``, any ``FlatParameter`` s (which may be
-    present due to nested FSDP wrapping), and any original parameters already
-    flattened (only relevant when ``use_orig_params=True``).
+    present due to nested FSDP wrapping).
     """
   param_gen = module.parameters()
   try:

--- a/torch_xla/distributed/fsdp/_init_utils.py
+++ b/torch_xla/distributed/fsdp/_init_utils.py
@@ -1,0 +1,103 @@
+import collections
+import warnings
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    Iterable,
+    Iterator,
+    List,
+    no_type_check,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
+
+import torch
+import torch.nn as nn
+import torch_xla.core.xla_model as xm
+
+from .xla_flatten_params_wrapper import FlatParameter
+
+_TORCHDISTX_AVAIL = True
+try:
+  from torchdistx import deferred_init, fake  # type: ignore[import]
+except ImportError:
+  _TORCHDISTX_AVAIL = False
+
+
+def _materialize_module(
+    module: nn.Module,
+    param_init_fn: Optional[Callable[[nn.Module], None]],
+    ignored_params: Set[nn.Parameter],
+    deferred_init_check_fn: Callable,
+) -> bool:
+  """
+    Materializes the wrapped module ``module`` in place if needed: either
+    if the module has parameters that use meta device or are torchdistX
+    fake tensors.
+    This method uses ``param_init_fn`` to materialize the module if the
+    function is not ``None`` and falls back to default behavior otherwise.
+    For meta device, this moves the module to ``device_from_device_id`` if
+    it is not ``None`` or the current device otherwise and calls
+    ``reset_parameters()``, and for torchdistX fake tensors, this calls
+    ``deferred_init.materialize_module()``.
+    Returns:
+        bool: ``True`` if ``module`` was materialized and ``False`` if this was
+        a no-op.
+    """
+  managed_params = list(_get_orig_params(module, ignored_params))
+  is_meta_module = any(param.is_meta for param in managed_params)
+  is_torchdistX_deferred_init = (
+      not is_meta_module and _TORCHDISTX_AVAIL and
+      any(fake.is_fake(param) for param in managed_params))
+  materialization_device = xm.xla_device()
+  if (is_meta_module or
+      is_torchdistX_deferred_init) and param_init_fn is not None:
+    if not callable(param_init_fn):
+      raise ValueError(
+          f"Expected {param_init_fn} to be callable but got {type(param_init_fn)}"
+      )
+    param_init_fn(module)
+    return True
+  elif is_meta_module:
+    # Run default meta device initialization
+    module.to_empty(device=materialization_device)
+    try:
+      with torch.no_grad():
+        module.reset_parameters()  # type: ignore[operator]
+    except BaseException as e:
+      warnings.warn("Unable to call `reset_parameters()` for module on meta "
+                    f"device with error {str(e)}. Please ensure your "
+                    "module implements a `reset_parameters()` method.")
+      raise e
+    return True
+  elif is_torchdistX_deferred_init:
+    # Run default torchdistX initialization
+    deferred_init.materialize_module(module, check_fn=deferred_init_check_fn)
+    module.to(materialization_device)
+    return True
+  return False
+
+
+def _get_orig_params(
+    module: nn.Module,
+    ignored_params: Set[nn.Parameter],
+) -> Iterator[nn.Parameter]:
+  """
+    Returns an iterator over the original parameters in ``module``, ignoring
+    the parameters in ``ignored_params``, any ``FlatParameter`` s (which may be
+    present due to nested FSDP wrapping), and any original parameters already
+    flattened (only relevant when ``use_orig_params=True``).
+    """
+  param_gen = module.parameters()
+  try:
+    while True:
+      param = next(param_gen)
+      if param not in ignored_params and not isinstance(param, FlatParameter):
+        yield param
+  except StopIteration:
+    pass

--- a/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
+++ b/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
@@ -257,7 +257,7 @@ class XlaFullyShardedDataParallel(nn.Module):
             ``materialize_module``, or the passed in ``param_init_fn``, if it is not
             ``None``. The same ``Callable`` is applied to initialize all meta modules.
             Note that this initialization function is applied before doing any FSDP sharding
-            logic.
+            logic. And the torchdistX is an experimental package that is not fully tested in the CI.
             Example::
                 >>> # xdoctest: +SKIP("undefined variables")
                 >>> module = MyModule(device="meta")
@@ -450,7 +450,8 @@ class XlaFullyShardedDataParallel(nn.Module):
 
     _materialize_module(
         module,
-        param_init_fn, [],
+        param_init_fn,
+        [],  # TODO: ignored_params is set to empty now, pass in correct params when this feature is fully enabled
         deferred_init_check_fn=lambda k: not isinstance(k, wrapper_cls))
 
     # Only handle params which are not already sharded. This enables

--- a/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
+++ b/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
@@ -37,6 +37,7 @@ import torch_xla.core.xla_model as xm
 from .xla_flatten_params_wrapper import XlaFlattenParamsWrapper
 from .utils import dummy_all_gather, dummy_all_reduce, dummy_reduce_scatter, apply_xla_patch_to_nn_linear
 from .wrap import recursive_wrap
+from ._init_utils import _materialize_module
 
 FLOAT_DTYPES = [torch.float32, torch.float16, torch.bfloat16]
 
@@ -239,6 +240,36 @@ class XlaFullyShardedDataParallel(nn.Module):
               auto_wrapper_callable = lambda m, *args, **kwargs: XlaFullyShardedDataParallel(
                   checkpoint_module(m), *args, **kwargs)
 
+        param_init_fn (Optional[Callable[[nn.Module], None]]):
+            A ``Callable[torch.nn.Module] -> None`` that
+            specifies how modules that are currently on the meta device should be initialized
+            onto an actual device. Note that as of v1.12, we detect modules on the meta
+            device via ``is_meta`` check and apply a default initialization that calls
+            ``reset_parameters`` method on the passed in ``nn.Module`` if ``param_init_fn``
+            is not specified, otherwise we run ``param_init_fn`` to initialize the passed
+            in ``nn.Module``. In particular, this means that if ``is_meta=True`` for any
+            module parameters for modules that will be wrapped with FSDP and ``param_init_fn``
+            is not specified, we assume your module properly implements a ``reset_parameters()``
+            and will throw errors if not. Note that additionally, we offer support for modules
+            initialized with torchdistX's (https://github.com/pytorch/torchdistX)
+            ``deferred_init`` API. In this case, deferred modules would be initialized
+            by a default initialization function that calls torchdistX's
+            ``materialize_module``, or the passed in ``param_init_fn``, if it is not
+            ``None``. The same ``Callable`` is applied to initialize all meta modules.
+            Note that this initialization function is applied before doing any FSDP sharding
+            logic.
+            Example::
+                >>> # xdoctest: +SKIP("undefined variables")
+                >>> module = MyModule(device="meta")
+                >>> def my_init_fn(module):
+                >>>     # responsible for initializing a module, such as with reset_parameters
+                >>>     ...
+                >>> fsdp_model = FSDP(module, param_init_fn=my_init_fn, auto_wrap_policy=size_based_auto_wrap_policy)
+                >>> print(next(fsdp_model.parameters()).device) # current CUDA device
+                >>> # With torchdistX
+                >>> module = deferred_init.deferred_init(MyModule, device="cuda")
+                >>> # Will initialize via deferred_init.materialize_module().
+                >>> fsdp_model = FSDP(module, auto_wrap_policy=size_based_auto_wrap_policy)
   """
 
   def __init__(
@@ -261,6 +292,7 @@ class XlaFullyShardedDataParallel(nn.Module):
       pin_layout_in_collective_ops: bool = True,
       auto_wrap_policy: Optional[Callable] = None,
       auto_wrapper_callable: Optional[Callable] = None,
+      param_init_fn: Optional[Callable[[nn.Module], None]] = None,
       _shard_size_multiple: int = 128,
       _use_xla_patched_linear: bool = True,
       _debug_dummy_forward_pass: bool = False,
@@ -291,11 +323,12 @@ class XlaFullyShardedDataParallel(nn.Module):
 
     super().__init__()
 
+    wrapper_cls = auto_wrapper_callable or XlaFullyShardedDataParallel
     if auto_wrap_policy is not None:
       auto_wrap_kwargs = {
           "module": module,
           "auto_wrap_policy": auto_wrap_policy,
-          "wrapper_cls": auto_wrapper_callable or XlaFullyShardedDataParallel,
+          "wrapper_cls": wrapper_cls,
           "ignored_modules": [],
           "ignored_params": [],
           "only_wrap_children": True,  # avoid double wrapping the root
@@ -318,6 +351,7 @@ class XlaFullyShardedDataParallel(nn.Module):
           pin_layout_in_collective_ops=pin_layout_in_collective_ops,
           # `auto_wrap_policy` doesn't need to be specified in auto-wrapping
           # `auto_wrapper_callable`` doesn't need to be specified in auto-wrapping
+          param_init_fn=param_init_fn,
           _shard_size_multiple=_shard_size_multiple,
           _use_xla_patched_linear=_use_xla_patched_linear,
           _debug_dummy_forward_pass=_debug_dummy_forward_pass,
@@ -413,6 +447,11 @@ class XlaFullyShardedDataParallel(nn.Module):
       # backward pass will use its weight parameter rather than an intermediate result.
       # (see https://github.com/pytorch/xla/issues/3811 for details)
       module = apply_xla_patch_to_nn_linear(module)
+
+    _materialize_module(
+        module,
+        param_init_fn, [],
+        deferred_init_check_fn=lambda k: not isinstance(k, wrapper_cls))
 
     # Only handle params which are not already sharded. This enables
     # sharding individual layers of a Module, with an outer wrapper to


### PR DESCRIPTION
This PR brings the deferred initialization from torch FSDP into torch-xla FSDP

To use the FSDP with auto_wrap, we will likely to encounter a OOM issue when instantiate the gigantic model before wrapping it with FSDP.

```
model = gigantic_model() ----> OOM here
model = XlaFullyShardedDataParallel(
      model,
      auto_wrap_policy=always_wrap
)
```

To address this issue, we need a mechanism to delay the initialization to the FSDP stage, where we should initialize the model layer by layer (module by module) and partition the parameters immediately to reduce the peak memory. To achieve this, we need two things: 1) During the instantiation we should not allocate the memory immediately. 2) Re-initialize the sub module correctly.

There are two ways to delay the memory allocation. The first one is the `meta` device. The actual memory allocation will not happen to the tensors with `meta` device, and only in the FSDP stage we move the tensors from meta device to xla device, allocate the memory and re-do the initialization. 

```
module = MyModule(device="meta")
def my_init_fn(module):
   # responsible for initializing a module, such as with reset_parameters
   ...
fsdp_model = FSDP(module, param_init_fn=my_init_fn, auto_wrap_policy=size_based_auto_wrap_policy)
```
However, this method has a duplicated-initalization problem that is also raised in PyTorch-FSDP https://github.com/pytorch/pytorch/issues/90465. This problem will cause the initialization result mismatches.

The second approach is to use torchdistX package. Once the module is wrapped by `deferred_init`, all the tensors inside will become fake tensors. And It provides extra ability to record the operations applied to the fake tensors. When we want to materialize the module, it will allocate the memory and replay all the operations.

```
# With torchdistX
module = deferred_init.deferred_init(MyModule)
# Will initialize via deferred_init.materialize_module().
fsdp_model = FSDP(module, auto_wrap_policy=size_based_auto_wrap_policy)
```

TorchdistX part is tested locally with source-build torchdistx. The disadvantage of this approach is that the official support of torchdistX is till PT1.12. I tried the other versions. It can work with PT-XLA 1.13 out-of-the-box and need minor changes to work with latest PT. I don't know why they stop maintaining this package. Feel free to comment on it if anyone has insights.

@JackCaoG @ronghanghu 