### PR TITLE
[FSDP] Fix pre-hook check when module is only used in forward

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -184,6 +184,7 @@ function run_mp_op_tests {
   run_xla_backend_mp python3 "$CDIR/test_torch_distributed_multi_all_reduce_xla_backend.py"
   run_xla_backend_mp python3 "$CDIR/test_torch_distributed_reduce_scatter_xla_backend.py"
   run_xla_backend_mp python3 "$CDIR/test_ddp.py"
+  run_xla_backend_mp python3 "$CDIR/test_fsdp_auto_wrap.py"
 }
 
 function run_tests {

--- a/test/test_fsdp_auto_wrap.py
+++ b/test/test_fsdp_auto_wrap.py
@@ -1,0 +1,56 @@
+import torch
+import torch_xla
+import torch_xla.utils.utils as xu
+import torch_xla.core.xla_model as xm
+import torch_xla.distributed.xla_multiprocessing as xmp
+import test_utils
+
+from torch_xla.distributed.fsdp import XlaFullyShardedDataParallel
+from torch_xla.distributed.fsdp.wrap import always_wrap_policy
+
+import sys
+import unittest
+
+
+class TestNoBackwardModule(test_utils.XlaTestCase):
+
+  class MyModel(torch.nn.Module):
+
+    def __init__(self, input_size, hidden_size):
+      super().__init__()
+      self.input_size = input_size
+      self.hidden_size = hidden_size
+      self.fc1 = torch.nn.Linear(self.input_size, self.hidden_size)
+      self.fc2 = torch.nn.Linear(self.input_size, self.hidden_size)
+
+    def forward(self, x):
+      hidden1 = self.fc1(x)
+      hidden2 = self.fc2(x)
+      return hidden1, hidden2
+
+  def test(self):
+    dev = xm.xla_device()
+    input = torch.zeros([16, 16], device=dev)
+    model = self.MyModel(input_size=16, hidden_size=4)
+    model = XlaFullyShardedDataParallel(
+        model, auto_wrap_policy=always_wrap_policy)
+    model.to(dev)
+    hid1, hid2 = model(input)
+    loss = hid1.sum()
+    loss.backward()
+    xm.mark_step()
+
+
+def _mp_fn(index):
+  device = xm.xla_device()
+  if xm.xla_device_hw(device) in ('TPU', 'GPU'):
+    test = unittest.main(exit=False)
+    sys.exit(0 if test.result.wasSuccessful() else 1)
+  else:
+    print(
+        'Default device {} is not a TPU or GPU device'.format(device),
+        file=sys.stderr)
+
+
+if __name__ == '__main__':
+  xmp.spawn(_mp_fn, args=())

--- a/test/test_fsdp_auto_wrap.py
+++ b/test/test_fsdp_auto_wrap.py
@@ -13,7 +13,9 @@ import unittest
 
 
 class TestNoBackwardModule(test_utils.XlaTestCase):
-
+  # Test the FSDP autowrap feature with a module containing a submodule
+  # that is only used in forward (fc2 below), to make sure it doesn't
+  # fail by the hook assertion.
   class MyModel(torch.nn.Module):
 
     def __init__(self, input_size, hidden_size):

--- a/test/test_train_mp_imagenet_fsdp.py
+++ b/test/test_train_mp_imagenet_fsdp.py
@@ -353,10 +353,7 @@ def train_imagenet():
     run_eval = ((not FLAGS.test_only_at_end and
                  epoch % FLAGS.eval_interval == 0) or epoch == FLAGS.num_epochs)
     if run_eval:
-      # TODO(alanwaketan): Investigate why inference would impact
-      # the next epoch's training.
-      with torch.no_grad():
-        accuracy = test_loop_fn(test_device_loader, epoch)
+      accuracy = test_loop_fn(test_device_loader, epoch)
       xm.master_print('Epoch {} test end {}, Accuracy={:.2f}'.format(
           epoch, test_utils.now(), accuracy))
       max_accuracy = max(accuracy, max_accuracy)

--- a/test/test_train_mp_imagenet_fsdp.py
+++ b/test/test_train_mp_imagenet_fsdp.py
@@ -353,7 +353,10 @@ def train_imagenet():
     run_eval = ((not FLAGS.test_only_at_end and
                  epoch % FLAGS.eval_interval == 0) or epoch == FLAGS.num_epochs)
     if run_eval:
-      accuracy = test_loop_fn(test_device_loader, epoch)
+      # TODO(alanwaketan): Investigate why inference would impact
+      # the next epoch's training.
+      with torch.no_grad():
+        accuracy = test_loop_fn(test_device_loader, epoch)
       xm.master_print('Epoch {} test end {}, Accuracy={:.2f}'.format(
           epoch, test_utils.now(), accuracy))
       max_accuracy = max(accuracy, max_accuracy)

--- a/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
+++ b/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
@@ -891,7 +891,7 @@ class XlaFullyShardedDataParallel(nn.Module):
       # This can be used to debug FSDP parameter memory consumption.
       outputs = self._dummy_forward(*args, **kwargs)
 
-    if self.reshard_after_forward or not self.training:
+    if self.reshard_after_forward:
       output_opt_barrier_tensors = []
       if self.optimization_barrier_in_forward:
         # Ensure that the full parameters of this FSDP module are freed
@@ -986,8 +986,8 @@ class XlaFullyShardedDataParallel(nn.Module):
     Returns:
         outputs: new outputs with hooks registered if they requires gradient.
     """
-    if not torch.is_grad_enabled() or not self.training:
-      return outputs  # don't register hooks if grad isn't enabled or the model is in eval mode
+    if not torch.is_grad_enabled():
+      return outputs  # don't register hooks if grad isn't enabled
 
     if self._is_root:
       # This actually means that only root instance has
@@ -1091,8 +1091,8 @@ class XlaFullyShardedDataParallel(nn.Module):
     backward pass. Otherwise, the next forward pass will not register
     a new hook, which is needed for a new forward pass.
     """
-    if not torch.is_grad_enabled() or not self.training:
-      return  # don't register grad hooks if grad isn't enabled or the model is in eval mode
+    if not torch.is_grad_enabled():
+      return  # don't register grad hooks if grad isn't enabled
     for p in self.full_params:
       if p.requires_grad:
         if hasattr(p, "_shard_bwd_hook"):

--- a/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
+++ b/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
@@ -891,7 +891,7 @@ class XlaFullyShardedDataParallel(nn.Module):
       # This can be used to debug FSDP parameter memory consumption.
       outputs = self._dummy_forward(*args, **kwargs)
 
-    if self.reshard_after_forward:
+    if self.reshard_after_forward or not self.training:
       output_opt_barrier_tensors = []
       if self.optimization_barrier_in_forward:
         # Ensure that the full parameters of this FSDP module are freed
@@ -986,8 +986,8 @@ class XlaFullyShardedDataParallel(nn.Module):
     Returns:
         outputs: new outputs with hooks registered if they requires gradient.
     """
-    if not torch.is_grad_enabled():
-      return outputs  # don't register hooks if grad isn't enabled
+    if not torch.is_grad_enabled() or not self.training:
+      return outputs  # don't register hooks if grad isn't enabled or the model is in eval mode
 
     if self._is_root:
       # This actually means that only root instance has
@@ -1091,8 +1091,8 @@ class XlaFullyShardedDataParallel(nn.Module):
     backward pass. Otherwise, the next forward pass will not register
     a new hook, which is needed for a new forward pass.
     """
-    if not torch.is_grad_enabled():
-      return  # don't register grad hooks if grad isn't enabled
+    if not torch.is_grad_enabled() or not self.training:
+      return  # don't register grad hooks if grad isn't enabled or the model is in eval mode
     for p in self.full_params:
       if p.requires_grad:
         if hasattr(p, "_shard_bwd_hook"):
@@ -1266,7 +1266,7 @@ class XlaFullyShardedDataParallel(nn.Module):
           m.assert_state(TrainingState.IDLE)
           # The module won't trigger post_backward_hook, so we free the
           # full params here.
-          self._free_full_params(
+          m._free_full_params(
               m.full_params,
               apply_opt_barrier=self.optimization_barrier_in_backward)
         elif any(p.requires_grad for p in m.parameters()):

--- a/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
+++ b/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
@@ -1260,7 +1260,8 @@ class XlaFullyShardedDataParallel(nn.Module):
 
     # Update root and nested FSDP's hooks and flags.
     for m in self.modules():  # includes self
-      if isinstance(m, XlaFullyShardedDataParallel):
+      if isinstance(
+          m, XlaFullyShardedDataParallel) and m._pre_backward_hook_has_run:
         _finalize_parameters(m)
         m._pre_backward_hook_has_run = False
         if any(p.requires_grad for p in m.parameters()):


### PR DESCRIPTION
In a corner case, a sub-module is only used in forward but not in backward. The assert_state will fail because the module is still in BACKWARD_IDLE state. Add condition to make sure the module has run in backward.
@ronghanghu @JackCaoG 