### PR TITLE
Fix torch-xla MSELoss to handle mixed datatype, also reuse the IR datatype instead of converting to input's.

### DIFF
--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1681,9 +1681,14 @@ XLATensorPtr mm(const XLATensorPtr& input, const XLATensorPtr& weight) {
 
 XLATensorPtr mse_loss(const XLATensorPtr& input, const XLATensorPtr& target,
                       int64_t reduction) {
+  // Here we explictly pass c10::nullopt as logical_element_type because
+  // otherwise result will inherit the input's logical_element_type. In the
+  // case of mse_loss(long, float16) -> float16, we want to derive the dtype
+  // from IR value instead of input's logical_element_type.
   return input->CreateFrom(
       torch::lazy::MakeNode<MseLoss>(input->GetIrValue(), target->GetIrValue(),
-                                     GetXlaReductionMode(reduction)));
+                                     GetXlaReductionMode(reduction)),
+      c10::nullopt);
 }
 
 XLATensorPtr mse_loss_backward(const XLATensorPtr& grad_output,


### PR DESCRIPTION
Here is the test script:
```py
import torch
torch.manual_seed(0)

import torch.nn.functional as F
import torch_xla.core.xla_model as xm

x_ = torch.randn((32,))
target_ = torch.randn((32,))

def xla():
    device = xm.xla_device()
    x = x_.to(device, dtype=torch.bfloat16).requires_grad_()
    target = target_.to(device, dtype=torch.float32)
    out = F.mse_loss(x, target)
    print("xla out:", out, out.dtype)
    out.backward()
    grad = x.grad
    print("xla grad:", grad, grad.dtype)
    return out, grad


def cpu():
    torch.manual_seed(0)
    # cannot do float16 here, as cpu doesn't do datatype conversion to align our_grad to input
    x = x_.to(dtype=torch.float32).requires_grad_() 
    target = target_.to(dtype=torch.float32)
    out = F.mse_loss(x, target)
    print("cpu out:", out, out.dtype)
    out.backward()
    grad = x.grad
    print("cpu grad:", grad, grad.dtype)
    return out, grad

out_cpu, grad_cpu = cpu()
out_xla, grad_xla = xla()
print(torch.allclose(out_xla.cpu(), out_cpu, rtol=1e-03, atol=1e-03))
print(torch.allclose(grad_xla.cpu().to(dtype=torch.float32), grad_cpu, rtol=1e-03, atol=1e-03))
```


Before fix, we will get error which complains that there are mixed datatype
```bash
torch-dev-env) ubuntu@ip-172-31-42-74:~$ python test.py
2023-02-22 09:27:56.852431: F ./third_party/xla_client/debug_macros.h:27] Non-OK-status: status.status() status: INTERNAL: during context [hlo verifier]: Seen floating point types of different precisions in %sub
tract.3 = f32[32]{0} subtract(bf16[32]{0} %p1.2, f32[32]{0} %p0.1), but mixed precision is disallowed.

Failed after pipeline-start
*** Begin stack trace ***
        tsl::CurrentStackTrace[abi:cxx11]()
        ...
```

after fix
```bash
xla out: tensor(2.3176, device='xla:0', grad_fn=<MseLossBackward0>) torch.float32
xla grad: tensor([-0.0320, -0.0742,  0.0152, -0.0427,  0.0255,  0.0361, -0.0598, -0.1592,
         0.0265, -0.1289,  0.0400,  0.0160, -0.0251, -0.0669,  0.1621,  0.0835,
        -0.0425, -0.1602, -0.0305,  0.0383,  0.0518, -0.0728, -0.0554,  0.1406,
         0.0747, -0.0830, -0.1060, -0.2021,  0.1826,  0.1758, -0.0547, -0.0183],
       device='xla:0', dtype=torch.bfloat16) torch.bfloat16
cpu out: tensor(2.3178, grad_fn=<MseLossBackward0>) torch.float32
cpu grad: tensor([-0.0320, -0.0740,  0.0151, -0.0426,  0.0256,  0.0362, -0.0598, -0.1598,
         0.0265, -0.1285,  0.0400,  0.0160, -0.0252, -0.0665,  0.1616,  0.0837,
        -0.0425, -0.1605, -0.0305,  0.0385,  0.0518, -0.0727, -0.0553,  0.1405,
         0.0748, -0.0831, -0.1059, -0.2017,  0.1825,  0.1763, -0.0546, -0.0183]) torch.float32
True
True
```

Note that without the change at [here](https://github.com/pytorch/xla/compare/master...aws-bowencc:xla:master?expand=1#diff-c40872d86a12e0231e3ebf02164c63f605856544b6237da42d0f90ad0f6b9ea4R1691), the output datatype for the xla in the test script will be torch.bfloat16 instead of torch.float32. 

While it is obviously better for torch-xla to handle mixed datatype for operators like GPU/CPU, so users will have a better experience when they move their workload to xla. I am wondering why we need to do type conversion after retrieving xla IR and convert it to input's datatype by default.