### PR TITLE
Add regex matching for release branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,7 +337,7 @@ workflows:
             branches:
               ignore:
                 - master
-                - /release\/.*/
+                - ^r\d*\.?\d*$
       - linter_check_no_torch_pin:
           filters:
             branches:


### PR DESCRIPTION
This will match any decimal number with a leading `r`, e.g. `r1.13`, `r2.0`, or `r123.456`

Tested with https://regex101.com/