### PR TITLE
[Functionalization] Unskip test_exponential

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -204,7 +204,6 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_index_reduce',  # TODO @wonjoo fails with functionalization
         'test_logcumsumexp_xla',  # doesn't raise, pytorch/pytorch#92912
         'test_narrow_copy_non_contiguous',  # the test is added for CPU, pytorch/pytorch#91789
-        'test_exponential',  # fails with functionalization
     },
 
     # test_view_ops.py


### PR DESCRIPTION
Summary:
test_exponential should be fixed by upstream: pytorch/pytorch#93053.

Test Plan:
CI.