### PR TITLE
[Functionalization] Manually redispatch convolution_backward to functionalize pass

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -285,8 +285,8 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_upsamplingBilinear2d_xla',  # precision on GPU/TPU, slow compilation on CPU
         # torch.autograd.gradcheck.GradcheckError: Jacobian mismatch for output 0 with respect to input 0
         'test_GRU_grad_and_gradgrad_xla_float64',  # TODO @wonjoo fails with functionalization
-        'test_LSTM_grad_and_gradgrad_xla_float64'  # TODO @wonjoo fails with functionalization
-        'test_conv_empty_input'  # fails with functionalization
+        'test_LSTM_grad_and_gradgrad_xla_float64',  # TODO @wonjoo fails with functionalization
+        'test_conv_empty_input',  # fails with functionalization
     },
 
     # test/nn/test_dropout.py

--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -286,6 +286,7 @@ DISABLED_TORCH_TESTS_ANY = {
         # torch.autograd.gradcheck.GradcheckError: Jacobian mismatch for output 0 with respect to input 0
         'test_GRU_grad_and_gradgrad_xla_float64',  # TODO @wonjoo fails with functionalization
         'test_LSTM_grad_and_gradgrad_xla_float64'  # TODO @wonjoo fails with functionalization
+        'test_conv_empty_input'  # fails with functionalization
     },
 
     # test/nn/test_dropout.py

--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -204,7 +204,6 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_index_reduce',  # TODO @wonjoo fails with functionalization
         'test_logcumsumexp_xla',  # doesn't raise, pytorch/pytorch#92912
         'test_narrow_copy_non_contiguous',  # the test is added for CPU, pytorch/pytorch#91789
-        'test_conv_transposed_backward_agnostic_to_memory_format_xla',  # fails with functionalization
     },
 
     # test_view_ops.py
@@ -286,7 +285,6 @@ DISABLED_TORCH_TESTS_ANY = {
         # torch.autograd.gradcheck.GradcheckError: Jacobian mismatch for output 0 with respect to input 0
         'test_GRU_grad_and_gradgrad_xla_float64',  # TODO @wonjoo fails with functionalization
         'test_LSTM_grad_and_gradgrad_xla_float64',  # TODO @wonjoo fails with functionalization
-        'test_conv_empty_input',  # fails with functionalization
     },
 
     # test/nn/test_dropout.py

--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -204,6 +204,7 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_index_reduce',  # TODO @wonjoo fails with functionalization
         'test_logcumsumexp_xla',  # doesn't raise, pytorch/pytorch#92912
         'test_narrow_copy_non_contiguous',  # the test is added for CPU, pytorch/pytorch#91789
+        'test_conv_transposed_backward_agnostic_to_memory_format_xla',  # fails with functionalization
     },
 
     # test_view_ops.py

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1590,6 +1590,17 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
         for dtype in (torch.long, torch.int32, torch.bool)
     ], test_fn)
 
+  def test_conv2d_backward(self):
+    # Somehow eager cpu produces different results than us, and
+    # therefore we can't compare eager and xla.
+    conv = nn.Conv2d(1, 1, kernel_size=1).to('xla')
+    input = torch.tensor([[[[2077.0]]]]).to('xla')
+
+    output = conv(input)
+    loss = torch.sum(output)
+    loss.backward()
+    self.assertTrue(torch.allclose(conv.weight.grad.cpu(), torch.tensor([[[[2077.0]]]])))
+
 
 class MNISTComparator(nn.Module):
 

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1599,7 +1599,8 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     output = conv(input)
     loss = torch.sum(output)
     loss.backward()
-    self.assertTrue(torch.allclose(conv.weight.grad.cpu(), torch.tensor([[[[2077.0]]]])))
+    self.assertTrue(
+        torch.allclose(conv.weight.grad.cpu(), torch.tensor([[[[2077.0]]]])))
 
 
 class MNISTComparator(nn.Module):

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3286,23 +3286,29 @@ XLANativeFunctions::convolution_backward(
     at::IntArrayRef stride, at::IntArrayRef padding, at::IntArrayRef dilation,
     bool transposed, at::IntArrayRef output_padding, int64_t groups,
     ::std::array<bool, 3> output_mask) {
-  // TODO (alanwaketan): Let's resuse `at::functionalization::functionalize_aten_op`
-  // after upstream has solved its issue.
-  auto func_grad_output = at::functionalization::impl::to_functional_tensor(grad_output);
+  // TODO (alanwaketan): Let's resuse
+  // `at::functionalization::functionalize_aten_op` after upstream has solved
+  // its issue.
+  auto func_grad_output =
+      at::functionalization::impl::to_functional_tensor(grad_output);
   auto func_input = at::functionalization::impl::to_functional_tensor(input);
   auto func_weight = at::functionalization::impl::to_functional_tensor(weight);
 
   auto curr_tls = c10::impl::tls_local_dispatch_key_set();
   auto tls_reenable_functionalize = c10::impl::PODLocalDispatchKeySet();
   tls_reenable_functionalize.set_included(curr_tls.included_);
-  tls_reenable_functionalize.set_excluded(curr_tls.excluded_.remove(c10::DispatchKey::Functionalize));
+  tls_reenable_functionalize.set_excluded(
+      curr_tls.excluded_.remove(c10::DispatchKey::Functionalize));
   c10::impl::ForceDispatchKeyGuard guard_(tls_reenable_functionalize);
-  auto results = at::native::convolution_backward(func_grad_output, func_input, func_weight, bias_sizes,
-                                  stride, padding, dilation, transposed,
-                                  output_padding, groups, output_mask);
+  auto results = at::native::convolution_backward(
+      func_grad_output, func_input, func_weight, bias_sizes, stride, padding,
+      dilation, transposed, output_padding, groups, output_mask);
 
-
-  return std::make_tuple(at::functionalization::impl::from_functional_tensor(std::get<0>(results)), at::functionalization::impl::from_functional_tensor(std::get<1>(results)), at::functionalization::impl::from_functional_tensor(std::get<2>(results)));
+  return std::make_tuple(
+      at::functionalization::impl::from_functional_tensor(std::get<0>(results)),
+      at::functionalization::impl::from_functional_tensor(std::get<1>(results)),
+      at::functionalization::impl::from_functional_tensor(
+          std::get<2>(results)));
 }
 
 at::Tensor XLANativeFunctions::diag_embed(const at::Tensor& self,

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3267,31 +3267,6 @@ at::Tensor XLANativeFunctions::block_diag(at::TensorList tensors) {
       block_diag)>::call(tensors);
 }
 
-at::Tensor XLANativeFunctions::_convolution(
-    const at::Tensor& input, const at::Tensor& weight,
-    const c10::optional<at::Tensor>& bias, at::IntArrayRef stride,
-    at::IntArrayRef padding, at::IntArrayRef dilation, bool transposed,
-    at::IntArrayRef output_padding, int64_t groups, bool benchmark,
-    bool deterministic, bool cudnn_enabled, bool allow_tf32) {
-  return at::functionalization::functionalize_aten_op<ATEN_OP(
-      _convolution)>::call(input, weight, bias, stride, padding, dilation,
-                           transposed, output_padding, groups, benchmark,
-                           deterministic, cudnn_enabled, allow_tf32);
-}
-
-::std::tuple<at::Tensor, at::Tensor, at::Tensor>
-XLANativeFunctions::convolution_backward(
-    const at::Tensor& grad_output, const at::Tensor& input,
-    const at::Tensor& weight, at::OptionalIntArrayRef bias_sizes,
-    at::IntArrayRef stride, at::IntArrayRef padding, at::IntArrayRef dilation,
-    bool transposed, at::IntArrayRef output_padding, int64_t groups,
-    ::std::array<bool, 3> output_mask) {
-  return at::functionalization::functionalize_aten_op<ATEN_OP(
-      convolution_backward)>::call(grad_output, input, weight, bias_sizes,
-                                   stride, padding, dilation, transposed,
-                                   output_padding, groups, output_mask);
-}
-
 at::Tensor XLANativeFunctions::diag_embed(const at::Tensor& self,
                                           int64_t offset, int64_t dim1,
                                           int64_t dim2) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3289,6 +3289,8 @@ XLANativeFunctions::convolution_backward(
   // TODO (alanwaketan): Let's resuse
   // `at::functionalization::functionalize_aten_op` after upstream has solved
   // its issue.
+  // The following is adopted from aten/src/ATen/FunctionalTensorWrapper.cpp:
+  // functionalize_op_helper.
   auto func_grad_output =
       at::functionalization::impl::to_functional_tensor(grad_output);
   auto func_input = at::functionalization::impl::to_functional_tensor(input);

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3286,6 +3286,8 @@ XLANativeFunctions::convolution_backward(
     at::IntArrayRef stride, at::IntArrayRef padding, at::IntArrayRef dilation,
     bool transposed, at::IntArrayRef output_padding, int64_t groups,
     ::std::array<bool, 3> output_mask) {
+  // TODO (alanwaketan): Let's resuse `at::functionalization::functionalize_aten_op`
+  // after upstream has solved its issue.
   auto func_grad_output = at::functionalization::impl::to_functional_tensor(grad_output);
   auto func_input = at::functionalization::impl::to_functional_tensor(input);
   auto func_weight = at::functionalization::impl::to_functional_tensor(weight);

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -349,6 +349,8 @@ supported:
   # but their implementations call view operators (which we need to functionalize away).
   - affine_grid_generator
   - block_diag
+  - _convolution
+  - convolution_backward
   - diag_embed
   - embedding
   - _euclidean_dist

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -350,8 +350,6 @@ supported:
   - affine_grid_generator
   - block_diag
   - diag_embed
-  - _convolution
-  - convolution_backward
   - embedding
   - _euclidean_dist
   - slice_backward


### PR DESCRIPTION
Summary:
For any CompositeExplicitAutograd ops, we are supposed to explicitly re-enable functionalization such that any decomposed ops within those ops get functionalized as well.

However, if directly calling into at::functionalization::functionalize_aten_op, convolution_backward will somehow omit convolution_backward_overridable which is our own kernel to calculate convolution. Thus, no grads are produced.

To workaround the issue, we manually redispatch convolution_backward to functionalize pass.

Test Plan:
PJRT_DEVICE=TPU python test/test_operations.py -v -k test_conv2d_backward