### PR TITLE
[PJRT] Use the new local rank env var to calculate local_ordinal

### DIFF
--- a/test/pjrt/test_experimental_pjrt_tpu.py
+++ b/test/pjrt/test_experimental_pjrt_tpu.py
@@ -27,9 +27,9 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
       self.accelerator_type = tpu_env['ACCELERATOR_TYPE']
       # Number of logical devices per single-host TPU
       self.num_devices = {
-        'v2-8': 8,
-        'v3-8': 8,
-        'v4-8': 4,
+          'v2-8': 8,
+          'v3-8': 8,
+          'v4-8': 4,
       }[self.accelerator_type]
     except requests.HTTPError as e:
       raise EnvironmentError(
@@ -141,8 +141,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
       devices = [torch.device(d) for d in f.result()]
 
     self.assertListEqual(
-        devices,
-        [torch.device(f'xla:{i}') for i in range(self.num_devices)])
+        devices, [torch.device(f'xla:{i}') for i in range(self.num_devices)])
 
   @parameterized.named_parameters(('xla_model', xm.get_ordinal),
                                   ('pjrt', pjrt.global_ordinal))

--- a/test/pjrt/test_experimental_pjrt_tpu.py
+++ b/test/pjrt/test_experimental_pjrt_tpu.py
@@ -25,6 +25,12 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
     try:
       tpu_env = tpu.get_tpu_env()
       self.accelerator_type = tpu_env['ACCELERATOR_TYPE']
+      # Number of logical devices per single-host TPU
+      self.num_devices = {
+        'v2-8': 8,
+        'v3-8': 8,
+        'v4-8': 4,
+      }[self.accelerator_type]
     except requests.HTTPError as e:
       raise EnvironmentError(
           'Failed to get TPU metadata. Are you running on a TPU?') from e
@@ -130,23 +136,13 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
       tpu.version() <= 2,
       'This test is not currently supported on v2 TPUVMs or earlier.')
   def test_default_xla_devices(self):
-    accelerator_num_devices = {
-        'v3-8': 8,
-        'v4-8': 4,
-    }
-
-    if self.accelerator_type not in accelerator_num_devices:
-      raise NotImplementedError('Test not implemented for {}'.format(
-          self.accelerator_type))
-    expected_num_devices = accelerator_num_devices[self.accelerator_type]
-
     with concurrent.futures.ProcessPoolExecutor(max_workers=1) as e:
       f = e.submit(xm.get_xla_supported_devices, 'TPU')
       devices = [torch.device(d) for d in f.result()]
 
     self.assertListEqual(
         devices,
-        [torch.device(f'xla:{i}') for i in range(expected_num_devices)])
+        [torch.device(f'xla:{i}') for i in range(self.num_devices)])
 
   @parameterized.named_parameters(('xla_model', xm.get_ordinal),
                                   ('pjrt', pjrt.global_ordinal))
@@ -154,19 +150,9 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
       tpu.version() <= 2,
       'This test is not currently supported on v2 TPUVMs or earlier.')
   def test_global_ordinal(self, ordinal_func):
-    accelerator_num_devices = {
-        'v3-8': 8,
-        'v4-8': 4,
-    }
-
-    if self.accelerator_type not in accelerator_num_devices:
-      raise NotImplementedError('Test not implemented for {}'.format(
-          self.accelerator_type))
-    expected_num_devices = accelerator_num_devices[self.accelerator_type]
-
     results = pjrt._run_multiprocess(ordinal_func)
     values = list(results.values())
-    self.assertListEqual(sorted(values), list(range(expected_num_devices)))
+    self.assertListEqual(sorted(values), list(range(self.num_devices)))
 
   @parameterized.named_parameters(('xla_model', xm.get_local_ordinal),
                                   ('pjrt', pjrt.local_ordinal))
@@ -174,19 +160,8 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
       tpu.version() <= 2,
       'This test is not currently supported on v2 TPUVMs or earlier.')
   def test_local_ordinal(self, ordinal_func):
-    accelerator_num_devices = {
-        'v3-8': 8,
-        'v4-8': 4,
-    }
-
-    if self.accelerator_type not in accelerator_num_devices:
-      raise NotImplementedError('Test not implemented for {}'.format(
-          self.accelerator_type))
-    expected_num_devices = accelerator_num_devices[self.accelerator_type]
-
     results = pjrt._run_multiprocess(ordinal_func)
-    values = list(results.values())
-    self.assertListEqual(sorted(values), list(range(expected_num_devices)))
+    self.assertCountEqual(results.values(), list(range(self.num_devices)))
 
   @staticmethod
   def _local_ordinal_with_discontiguous_global_ordinal_v4():
@@ -202,7 +177,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
   def test_local_ordinal_with_discontiguous_global_ordinal_v4(self):
     results = pjrt._run_multiprocess(
         self._local_ordinal_with_discontiguous_global_ordinal_v4)
-    self.assertSameElements(results.values(), [0, 1, 2, 3])
+    self.assertCountEqual(results.values(), [0, 1, 2, 3])
 
   @absltest.skipIf(tpu.version() < 4, "Not implemented")
   def test_local_ordinal_with_discontiguous_global_ordinal_v4_threaded(self):
@@ -211,7 +186,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
 
     results = pjrt._run_multiprocess(
         self._local_ordinal_with_discontiguous_global_ordinal_v4)
-    self.assertSameElements(results.values(), [0, 1, 2, 3])
+    self.assertCountEqual(results.values(), [0, 1, 2, 3])
 
   @staticmethod
   def _spawn_threads() -> Dict[int, torch.device]:
@@ -224,22 +199,12 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
       tpu.version() <= 2,
       'This test is not currently supported on v2 TPUVMs or earlier.')
   def test_spawn_threads(self):
-    accelerator_num_devices = {
-        'v3-8': 8,
-        'v4-8': 4,
-    }
-
-    if self.accelerator_type not in accelerator_num_devices:
-      raise NotImplementedError('Test not implemented for {}'.format(
-          self.accelerator_type))
-    expected_num_devices = accelerator_num_devices[self.accelerator_type]
-
     with concurrent.futures.ProcessPoolExecutor(max_workers=1) as e:
       results = e.submit(self._spawn_threads).result()
 
       self.assertDictEqual(
           results,
-          {i: torch.device(f'xla:{i}') for i in range(expected_num_devices)})
+          {i: torch.device(f'xla:{i}') for i in range(self.num_devices)})
 
   @staticmethod
   def _device_attributes():

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -169,7 +169,7 @@ def local_ordinal() -> int:
   """Returns local ordinal of this thread within this host.
 
   Local ordinal is in range [0, local_device_count)."""
-  local_rank = xu.getenv_as('LOCAL_RANK', int, 0)
+  local_rank = xu.getenv_as(xenv.PJRT_LOCAL_PROCESS_RANK, int, 0)
   devices_per_process = addressable_device_count()
   return local_rank * devices_per_process + xla_device().index
 


### PR DESCRIPTION
Fix some assertions that erroneously let the unit tests pass, and enable more unit tests on the TPU CI to catch bugs like this in the future.