### PR TITLE
[Functionalization] Move nan_to_num_ and _amp_foreach_non_finite_check_and_unscale_ op tests to python

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -456,20 +456,24 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
 
   def test_nan_to_num_in_place(self):
     t = torch.tensor([float('nan'), float('nan'), -float('nan'), 3.14])
-    t.nan_to_num_(1.0, 2.0, 3.0)
-    t_xla = t.to(xm.xla_device())
-    t_xla.nan_to_num_(1.0, 2.0, 3.0)
-    self.assertEqual(t.data, t_xla.data.cpu())
+
+    def fn(x):
+      x.nan_to_num_(1.0, 2.0, 3.0)
+      return x
+
+    self.runAtenTest(t, fn)
 
   @skipOnTpu
   def test_nan_to_num_in_place_with_inf(self):
     # Since TPU converts double to float (unlike CPU), the Inf entries are
     # expected to be different. Skipping tests for Inf entries.
     t = torch.tensor([float('nan'), float('inf'), -float('inf'), 3.14])
-    t.nan_to_num_(1.0, 2.0, 3.0)
-    t_xla = t.to(xm.xla_device())
-    t_xla.nan_to_num_(1.0, 2.0, 3.0)
-    self.assertEqual(t.data, t_xla.data.cpu())
+
+    def fn(x):
+      x.nan_to_num_(1.0, 2.0, 3.0)
+      return x
+
+    self.runAtenTest(t, fn)
 
   @skipOnTpu
   def test_amp_foreach_non_finite_check_and_unscale_(self):


### PR DESCRIPTION
Move `nan_to_num_` and `_amp_foreach_non_finite_check_and_unscale_` op tests to python

--- 

Even after https://github.com/pytorch/pytorch/pull/94633, we were still seeing failures complaining about meta tensor support. However, these ops were succeeding during manual tests in Python. My guess would be that somewhere during the  decomposition in the C++ world is causing some problems. However, for now, moving these op tests to Python.

Locally, I can see they succeed:
```
(base) jenkins@26d7adccbc26:/workspace/pytorch/xla$ python test/test_operations.py
----------------------------------------------------------------------
Ran 1 test in 0.224s

OK
(base) jenkins@26d7adccbc26:/workspace/pytorch/xla$ python test/test_operations.py
----------------------------------------------------------------------
Ran 1 test in 0.242s

OK
(base) jenkins@26d7adccbc26:/workspace/pytorch/xla$ 

```