### PR TITLE
Fix starting profiler server in resnet training test script

### DIFF
--- a/test/test_train_mp_imagenet.py
+++ b/test/test_train_mp_imagenet.py
@@ -234,6 +234,9 @@ def train_imagenet():
       summary_writer=writer)
   loss_fn = nn.CrossEntropyLoss()
 
+  if FLAGS.profile:
+    server = xp.start_server(FLAGS.profiler_port)
+
   def train_loop_fn(loader, epoch):
     tracker = xm.RateTracker()
     model.train()
@@ -307,6 +310,4 @@ def _mp_fn(index, flags):
 
 
 if __name__ == '__main__':
-  if FLAGS.profile:
-    server = xp.start_server(FLAGS.profiler_port)
   xmp.spawn(_mp_fn, args=(FLAGS,), nprocs=FLAGS.num_cores)


### PR DESCRIPTION
`test/test_train_mp_imagenet.py` fails with `--profile`. This patch fixes the profiler failure on commit `8949dd124d6eb7dfe`. However, both `test_train_mp_imagenet.py` and `test_profile_mp_mnist.py` hangs after rebase.

This diff makes the profiler server starting in `test/test_train_mp_imagenet.py` to be consistent with `test/test_profile_mp_mnist.py`, resolving the `--profile` failure.