### PR TITLE
Add feature to increase the number of host to device transfer threads

### DIFF
--- a/test/test_train_mp_imagenet.py
+++ b/test/test_train_mp_imagenet.py
@@ -91,7 +91,7 @@ import torch_xla.distributed.xla_backend
 
 DEFAULT_KWARGS = dict(
     batch_size=128,
-    test_set_batch_size=128,
+    test_set_batch_size=64,
     num_epochs=18,
     momentum=0.9,
     lr=0.1,

--- a/test/test_train_mp_imagenet.py
+++ b/test/test_train_mp_imagenet.py
@@ -54,6 +54,9 @@ MODEL_OPTS = {
     '--host_to_device_transfer_threads': {
         'type': int,
     },
+    '--use_v4_optimized_kwargs': {
+        'action': 'store_true',
+    },
 }
 
 FLAGS = args_parse.parse_common_options(
@@ -107,6 +110,9 @@ DEFAULT_KWARGS = dict(
 #  Best config to achieve peak performance on TPU v4
 #    1. It is recommended to use this config in conjuntion with XLA_USE_BF16=1 Flag.
 #    2. Hyperparameters can be tuned to further improve the accuracy.
+#  usage: python3 /usr/share/pytorch/xla/test/test_train_mp_imagenet.py --model=resnet50 \
+#         --fake_data --num_epochs=10 --log_steps=300 \
+#         --profile   --use_v4_optimized_kwargs  --drop_last
 OPTIMIZED_KWARGS_v4 = dict(
     batch_size=128,
     test_set_batch_size=128,
@@ -137,7 +143,9 @@ MODEL_SPECIFIC_DEFAULTS = {
 
 # Set any args that were not explicitly given by the user.
 # DEFAULT_KWARGS in the below line can be replaced with OPTIMIZED_KWARGS for performance.
-default_value_dict = MODEL_SPECIFIC_DEFAULTS.get(FLAGS.model, DEFAULT_KWARGS)
+default_value_dict = MODEL_SPECIFIC_DEFAULTS.get(
+    FLAGS.model,
+    OPTIMIZED_KWARGS_v4 if FLAGS.use_v4_optimized_kwargs else DEFAULT_KWARGS)
 for arg, value in default_value_dict.items():
   if getattr(FLAGS, arg) is None:
     setattr(FLAGS, arg, value)

--- a/test/test_train_mp_imagenet.py
+++ b/test/test_train_mp_imagenet.py
@@ -104,7 +104,7 @@ DEFAULT_KWARGS = dict(
     host_to_device_transfer_threads=1,
 )
 
-#  Best config to achieve peak performance on v4-8
+#  Best config to achieve peak performance on TPU v4
 #    1. It is recommended to use this config in conjuntion with XLA_USE_BF16=1 Flag.
 #    2. Hyperparameters can be tuned to further improve the accuracy.
 

--- a/test/test_train_mp_imagenet.py
+++ b/test/test_train_mp_imagenet.py
@@ -103,13 +103,12 @@ DEFAULT_KWARGS = dict(
     num_workers=8,
     host_to_device_transfer_threads=1,
 )
-'''
-Best config to achieve peak performance on v4-8
 
-  1. It is recommended to use this config in conjuntion with XLA_USE_BF16=1 Flag. 
-  2. Hyperparameters can be tuned to further improve the accuracy.
-'''
-OPTIMIZED_KWARGS = dict(
+#  Best config to achieve peak performance on v4-8
+#    1. It is recommended to use this config in conjuntion with XLA_USE_BF16=1 Flag.
+#    2. Hyperparameters can be tuned to further improve the accuracy.
+
+OPTIMIZED_KWARGS_v4 = dict(
     batch_size=128,
     test_set_batch_size=128,
     num_epochs=18,
@@ -136,10 +135,9 @@ MODEL_SPECIFIC_DEFAULTS = {
                 'lr_scheduler_type': 'WarmupAndExponentialDecayScheduler',
             })
 }
-'''
-Set any args that were not explicitly given by the user.
-DEFAULT_KWARGS in the below line can be replaced with OPTIMIZED_KWARGS for performance.
-'''
+
+# Set any args that were not explicitly given by the user.
+# DEFAULT_KWARGS in the below line can be replaced with OPTIMIZED_KWARGS for performance.
 default_value_dict = MODEL_SPECIFIC_DEFAULTS.get(FLAGS.model, DEFAULT_KWARGS)
 for arg, value in default_value_dict.items():
   if getattr(FLAGS, arg) is None:

--- a/test/test_train_mp_imagenet.py
+++ b/test/test_train_mp_imagenet.py
@@ -54,7 +54,7 @@ MODEL_OPTS = {
     '--host_to_device_transfer_threads': {
         'type': int,
     },
-    '--use_v4_optimized_kwargs': {
+    '--use_optimized_kwargs': {
         'action': 'store_true',
     },
 }
@@ -112,7 +112,7 @@ DEFAULT_KWARGS = dict(
 #    2. Hyperparameters can be tuned to further improve the accuracy.
 #  usage: python3 /usr/share/pytorch/xla/test/test_train_mp_imagenet.py --model=resnet50 \
 #         --fake_data --num_epochs=10 --log_steps=300 \
-#         --profile   --use_v4_optimized_kwargs  --drop_last
+#         --profile   --use_optimized_kwargs  --drop_last
 OPTIMIZED_KWARGS_v4 = dict(
     batch_size=128,
     test_set_batch_size=128,
@@ -145,7 +145,7 @@ MODEL_SPECIFIC_DEFAULTS = {
 # DEFAULT_KWARGS in the below line can be replaced with OPTIMIZED_KWARGS for performance.
 default_value_dict = MODEL_SPECIFIC_DEFAULTS.get(
     FLAGS.model,
-    OPTIMIZED_KWARGS_v4 if FLAGS.use_v4_optimized_kwargs else DEFAULT_KWARGS)
+    OPTIMIZED_KWARGS_v4 if FLAGS.use_optimized_kwargs else DEFAULT_KWARGS)
 for arg, value in default_value_dict.items():
   if getattr(FLAGS, arg) is None:
     setattr(FLAGS, arg, value)

--- a/test/test_train_mp_imagenet.py
+++ b/test/test_train_mp_imagenet.py
@@ -107,7 +107,6 @@ DEFAULT_KWARGS = dict(
 #  Best config to achieve peak performance on TPU v4
 #    1. It is recommended to use this config in conjuntion with XLA_USE_BF16=1 Flag.
 #    2. Hyperparameters can be tuned to further improve the accuracy.
-
 OPTIMIZED_KWARGS_v4 = dict(
     batch_size=128,
     test_set_batch_size=128,

--- a/test/test_train_mp_imagenet.py
+++ b/test/test_train_mp_imagenet.py
@@ -112,7 +112,7 @@ DEFAULT_KWARGS = dict(
 #    2. Hyperparameters can be tuned to further improve the accuracy.
 #  usage: python3 /usr/share/pytorch/xla/test/test_train_mp_imagenet.py --model=resnet50 \
 #         --fake_data --num_epochs=10 --log_steps=300 \
-#         --profile   --use_optimized_kwargs tpuv4  --drop_last
+#         --profile   --use_optimized_kwargs=tpuv4  --drop_last
 OPTIMIZED_KWARGS = {
     'tpuv4':
         dict(

--- a/torch_xla/distributed/parallel_loader.py
+++ b/torch_xla/distributed/parallel_loader.py
@@ -69,6 +69,9 @@ class ParallelLoader(object):
       where the worker threads deposit tensors which have already been sent to
       devices.
       Default: 4
+    host_to_device_transfer_threads (int, optional): The number of threads that
+      work in parallel to transfer data from loader queue to device queue.
+      Default: 1
   """
 
   def __init__(self,
@@ -77,7 +80,8 @@ class ParallelLoader(object):
                batchdim=0,
                batches_per_execution=1,
                loader_prefetch_size=8,
-               device_prefetch_size=4):
+               device_prefetch_size=4,
+               host_to_device_transfer_threads=1):
     self._loader = loader
     self._devices = [torch.device(x) for x in devices]
     self._batchdim = batchdim
@@ -91,9 +95,10 @@ class ParallelLoader(object):
     thread.daemon = True
     thread.start()
     for dqueue in self._queues.values():
-      thread = threading.Thread(target=self._worker, args=(dqueue,))
-      thread.daemon = True
-      thread.start()
+      for i in range(host_to_device_transfer_threads):
+        thread = threading.Thread(target=self._worker, args=(dqueue,))
+        thread.daemon = True
+        thread.start()
 
   def per_device_loader(self, device):
     """Retrieves the loader iterator object for the given device.


### PR DESCRIPTION
This config improves the ResNet training performance on TPU v4 chips. 

```
Epoch 3 train begin 19:02:08
| Training Device=xla:0/1 Epoch=3 Step=5100 Loss=3.82812 Rate=2014.43 GlobalRate=1220.24 Time=19:02:14
| Training Device=xla:0/3 Epoch=3 Step=5100 Loss=3.39062 Rate=2014.43 GlobalRate=1223.24 Time=19:02:14
| Training Device=xla:0/0 Epoch=3 Step=5100 Loss=3.64062 Rate=2014.44 GlobalRate=1221.29 Time=19:02:14
| Training Device=xla:0/2 Epoch=3 Step=5100 Loss=3.34375 Rate=2014.61 GlobalRate=1221.54 Time=19:02:14
| Training Device=xla:0/0 Epoch=3 Step=5400 Loss=3.51562 Rate=2221.05 GlobalRate=1254.91 Time=19:02:30
| Training Device=xla:0/3 Epoch=3 Step=5400 Loss=3.40625 Rate=2221.03 GlobalRate=1256.85 Time=19:02:30
| Training Device=xla:0/1 Epoch=3 Step=5400 Loss=3.54688 Rate=2221.02 GlobalRate=1253.85 Time=19:02:30
| Training Device=xla:0/2 Epoch=3 Step=5400 Loss=3.43750 Rate=2221.59 GlobalRate=1255.17 Time=19:02:30
| Training Device=xla:0/1 Epoch=3 Step=5700 Loss=2.89062 Rate=2267.96 GlobalRate=1284.59 Time=19:02:47
| Training Device=xla:0/3 Epoch=3 Step=5700 Loss=3.50000 Rate=2267.92 GlobalRate=1287.56 Time=19:02:47
| Training Device=xla:0/0 Epoch=3 Step=5700 Loss=3.42188 Rate=2267.86 GlobalRate=1285.63 Time=19:02:47
| Training Device=xla:0/2 Epoch=3 Step=5700 Loss=3.45312 Rate=2268.25 GlobalRate=1285.89 Time=19:02:47
| Training Device=xla:0/0 Epoch=3 Step=6000 Loss=3.03125 Rate=2323.80 GlobalRate=1315.59 Time=19:03:03
| Training Device=xla:0/3 Epoch=3 Step=6000 Loss=3.32812 Rate=2323.76 GlobalRate=1317.51 Time=19:03:03
| Training Device=xla:0/1 Epoch=3 Step=6000 Loss=3.28125 Rate=2323.71 GlobalRate=1314.55 Time=19:03:03
| Training Device=xla:0/2 Epoch=3 Step=6000 Loss=3.37500 Rate=2323.66 GlobalRate=1315.84 Time=19:03:03
| Training Device=xla:0/1 Epoch=3 Step=6300 Loss=3.51562 Rate=2377.17 GlobalRate=1343.67 Time=19:03:19
| Training Device=xla:0/0 Epoch=3 Step=6300 Loss=3.12500 Rate=2377.16 GlobalRate=1344.70 Time=19:03:19
| Training Device=xla:0/3 Epoch=3 Step=6300 Loss=3.37500 Rate=2377.15 GlobalRate=1346.61 Time=19:03:19
| Training Device=xla:0/2 Epoch=3 Step=6300 Loss=3.12500 Rate=2377.08 GlobalRate=1344.95 Time=19:03:19
| Training Device=xla:0/3 Epoch=3 Step=6600 Loss=3.31250 Rate=2368.34 GlobalRate=1373.45 Time=19:03:35
| Training Device=xla:0/0 Epoch=3 Step=6600 Loss=3.20312 Rate=2368.35 GlobalRate=1371.56 Time=19:03:35
| Training Device=xla:0/1 Epoch=3 Step=6600 Loss=3.10938 Rate=2368.32 GlobalRate=1370.53 Time=19:03:35
| Training Device=xla:0/2 Epoch=3 Step=6600 Loss=3.04688 Rate=2367.79 GlobalRate=1371.79 Time=19:03:35
| Training Device=xla:0/3 Epoch=3 Step=6900 Loss=3.20312 Rate=2376.36 GlobalRate=1399.20 Time=19:03:51
| Training Device=xla:0/1 Epoch=3 Step=6900 Loss=3.20312 Rate=2376.36 GlobalRate=1396.30 Time=19:03:51
| Training Device=xla:0/0 Epoch=3 Step=6900 Loss=3.23438 Rate=2376.29 GlobalRate=1397.32 Time=19:03:51
| Training Device=xla:0/2 Epoch=3 Step=6900 Loss=3.26562 Rate=2376.85 GlobalRate=1397.57 Time=19:03:51
| Training Device=xla:0/2 Epoch=3 Step=7200 Loss=3.03125 Rate=2481.11 GlobalRate=1424.40 Time=19:04:06
| Training Device=xla:0/0 Epoch=3 Step=7200 Loss=3.18750 Rate=2480.62 GlobalRate=1424.14 Time=19:04:06
| Training Device=xla:0/3 Epoch=3 Step=7200 Loss=3.26562 Rate=2480.56 GlobalRate=1426.01 Time=19:04:06
| Training Device=xla:0/1 Epoch=3 Step=7200 Loss=3.17188 Rate=2480.55 GlobalRate=1423.12 Time=19:04:06
Epoch 3 train end 19:04:20
Epoch 3 test begin 19:04:20
| Test Device=xla:0/0 Step=0 Epoch=3 Time=19:04:21
| Test Device=xla:0/3 Step=0 Epoch=3 Time=19:04:22
| Test Device=xla:0/1 Step=0 Epoch=3 Time=19:04:22
| Test Device=xla:0/2 Step=0 Epoch=3 Time=19:04:22
Epoch 3 test end 19:04:28, Accuracy=31.63
