### PR TITLE
Update env-setup.py

### DIFF
--- a/contrib/scripts/env-setup.py
+++ b/contrib/scripts/env-setup.py
@@ -25,7 +25,7 @@ TORCHVISION_WHEEL_TMPL = 'torchvision-{whl_version}-cp{py_version}-cp{py_version
 VERSION_REGEX = re.compile(r'^(\d+\.)+\d+$')
 
 def is_gpu_runtime():
-  return int(os.environ.get('COLAB_GPU', 0)) == 1
+  return os.environ.get('COLAB_GPU', 0) == '1'
 
 
 def is_tpu_runtime():


### PR DESCRIPTION
- os.environ.get('COLAB_GPU', 0) returns ' ' when GPU runtime is not used and '1' when GPU runtime is used.
- Hence attempting to typecaste os.environ.get('COLAB_GPU', 0) to int throws " ValueError: invalid literal for int() with base 10: '' when GPU runtime is not used.