### PR TITLE
Fix dynamo test no op

### DIFF
--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -31,16 +31,16 @@ class DynamoInferenceBasicTest(unittest.TestCase):
     res_cpu = self.fn_simple(x, y)
     res_xla_dynamo = self.fn_simple_dynamo(xla_x, xla_y)
     self.assertIn('xla::add', met.counter_names())
-    torch.allclose(res_cpu, res_xla_dynamo.cpu())
+    assert torch.allclose(res_cpu, res_xla_dynamo.cpu())
     # verifiy that tracing is skipped in following runs
     met.clear_counters()
     res_xla_dynamo_2 = self.fn_simple_dynamo(xla_x, xla_y)
     self.assertNotIn('xla::add', met.counter_names())
-    torch.allclose(res_cpu, res_xla_dynamo_2.cpu())
+    assert torch.allclose(res_cpu, res_xla_dynamo_2.cpu())
     # verify that dynamo can handle different inputs
     res_xla_dynamo_3 = self.fn_simple_dynamo(xla_x + xla_y, xla_y * 3)
     res_cpu_3 = self.fn_simple(x + y, y * 3)
-    torch.allclose(res_cpu, res_xla_dynamo_3.cpu())
+    assert torch.allclose(res_cpu_3, res_xla_dynamo_3.cpu())
 
   def test_resnet18(self):
     device = xm.xla_device()
@@ -52,7 +52,9 @@ class DynamoInferenceBasicTest(unittest.TestCase):
         sample_count=sample_count)
     resnet18 = torchvision.models.resnet18()
     resnet18.eval()
-    xla_resnet18 = torchvision.models.resnet18().to(device)
+    xla_resnet18 = torchvision.models.resnet18()
+    xla_resnet18.load_state_dict(resnet18.state_dict())
+    xla_resnet18.to(device)
     xla_resnet18.eval()
     # materalize the fake data for test purpose
     xm.mark_step()
@@ -62,7 +64,8 @@ class DynamoInferenceBasicTest(unittest.TestCase):
       dynamo_resnet18 = torch.compile(
           xla_resnet18, backend='torchxla_trace_once')
       output = dynamo_resnet18(data)
-      torch.allclose(resnet18(data.cpu()), output.cpu())
+      output_cpu = resnet18(data.cpu())
+      assert torch.allclose(output_cpu, output.cpu(), rtol=1e-05, atol=1e-05)
     # We only expect one graph for the resnet18 inference.
     self.assertEqual(met.metric_data('CompileTime')[0], 1)
     self.assertEqual(met.metric_data('ExecuteTime')[0], sample_count)
@@ -101,22 +104,22 @@ class DynamoTrainingBasicTest(unittest.TestCase):
     res_cpu = self.fn_simple(input)
     res_xla_dynamo = self.fn_simple_dynamo(xla_input)
     self.assertIn('xla::nll_loss_backward', met.counter_names())
-    torch.allclose(res_cpu, res_xla_dynamo.cpu())
-    torch.allclose(input.grad, xla_input.grad.cpu())
+    assert torch.allclose(res_cpu, res_xla_dynamo.cpu())
+    assert torch.allclose(input.grad, xla_input.grad.cpu())
     # verifiy that tracing is skipped in following runs
     xla_input.grad = None
     met.clear_counters()
     res_xla_dynamo_2 = self.fn_simple_dynamo(xla_input)
     self.assertNotIn('xla::nll_loss_backward', met.counter_names())
-    torch.allclose(res_cpu, res_xla_dynamo.cpu())
-    torch.allclose(input.grad, xla_input.grad.cpu())
+    assert torch.allclose(res_cpu, res_xla_dynamo_2.cpu())
+    assert torch.allclose(input.grad, xla_input.grad.cpu())
     # verify that dynamo can handle different inputs
     input.grad = None
     xla_input.grad = None
     res_xla_dynamo_3 = self.fn_simple_dynamo(xla_input * 2)
     res_cpu_3 = self.fn_simple(input * 2)
-    torch.allclose(res_cpu, res_xla_dynamo.cpu())
-    torch.allclose(input.grad, xla_input.grad.cpu())
+    assert torch.allclose(res_cpu_3, res_xla_dynamo_3.cpu())
+    assert torch.allclose(input.grad, xla_input.grad.cpu())
 
   def test_resnet18(self):
     torch._dynamo.reset()
@@ -148,7 +151,8 @@ class DynamoTrainingBasicTest(unittest.TestCase):
       cpu_data.requires_grad = True
       cpu_target = target.detach().cpu()
       cpu_output = self.train_model(resnet18, cpu_data, cpu_target)
-      torch.allclose(xla_output.cpu(), cpu_output.cpu())
+      assert torch.allclose(
+          xla_output.cpu(), cpu_output.cpu(), rtol=1e-05, atol=1e-05)
       # TODO(JackCaoG): Understand why `data.grad` is a pending IR starting
       # from second iteration instead of a `DeviceData`
       # torch.allclose(data.grad.cpu(), cpu_data.grad)


### PR DESCRIPTION
Currently all of the `torch.allclose` in the `test_dynamo.py` is no op since `torch.allclose` returns a bool instead of fail when it failed to match two inputs. Correct the test, this pr need to be backported to 2.0 branch.

In the long term, we should not compare the dynamo result vs cpu result, since with optimization, the result very likely be off. A better approach is to compare the result of dynamo vs result with lazy.