### PR TITLE
[PJRT] Remove start method from `_run_singleprocess`

### DIFF
--- a/test/pjrt/test_experimental_pjrt_tpu.py
+++ b/test/pjrt/test_experimental_pjrt_tpu.py
@@ -118,16 +118,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
 
     xmp.spawn(_assert, nprocs=1)
 
-  @absltest.skipIf(
-      tpu.version() <= 2,
-      'This test is not currently supported on v2 TPUVMs or earlier.')
   def test_xla_devices_single_process_one_chip_one_device_spawn(self):
-    accelerators = ['v3-8', 'v4-8']
-
-    if self.accelerator_type not in accelerators:
-      raise NotImplementedError('Test not implemented for {}'.format(
-          self.accelerator_type))
-
     # Avoid initializing the TPU client in the parent process
     with concurrent.futures.ProcessPoolExecutor(max_workers=1) as executor:
       executor.submit(self._fail_on_nonfirst_device).result()
@@ -194,9 +185,6 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
 
     return results
 
-  @absltest.skipIf(
-      tpu.version() <= 2,
-      'This test is not currently supported on v2 TPUVMs or earlier.')
   def test_spawn_threads(self):
     with concurrent.futures.ProcessPoolExecutor(max_workers=1) as e:
       results = e.submit(self._spawn_threads).result()

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -257,8 +257,6 @@ def _run_singleprocess(fn: Callable[..., R], *args, **kwargs) -> Dict[int, R]:
   Args:
     fn: Function to run on the device devices
     args: args to pass to `fn`
-    start_method: The Python `multiprocessing` process creation method.
-      Default: `spawn`
     kwargs: kwargs to pass to `fn`
 
   Returns:
@@ -360,7 +358,7 @@ def spawn(fn: Callable,
   spawn_fn = _SpawnFn(fn, *args)
 
   if nprocs == 1:
-    return _run_singleprocess(spawn_fn, start_method=start_method)
+    return _run_singleprocess(spawn_fn)
   elif nprocs is not None:
     logging.warning('Unsupported nprocs (%d), ignoring...' % nprocs)
 


### PR DESCRIPTION
Since `_run_singleprocess` doesn't spawn anything, it doesn't have a `start_method`

Enable more unit tests that would have caught this bug in CI.