### PR TITLE
Make pytorch cuda build configureable

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,7 @@ ARG python_version="3.7"
 ARG release_version="nightly"
 ARG xla_branch=""
 ARG example_branch="master"
+ARG pytorch_cuda="0"
 ARG cuda="0"
 ARG cuda_compute="3.7,7.0,7.5,8.0"
 ARG cxx_abi="1"
@@ -21,7 +22,7 @@ RUN apt-get install -y git sudo python-pip python3-pip
 RUN git clone https://github.com/pytorch/pytorch
 
 # Disable CUDA for PyTorch
-ENV USE_CUDA "0"
+ENV USE_CUDA "${pytorch_cuda}"
 
 # Enable CUDA for XLA
 ENV XLA_CUDA "${cuda}"

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -7,6 +7,7 @@ steps:
           'build',
           '--shm-size', '16gb',
           '--build-arg', 'base_image=${_DOCKER_BASE_IMAGE}',
+          '--build-arg', 'pytorch_cuda=${_PYTORCH_CUDA}',
           '--build-arg', 'cuda=${_CUDA}',
           '--build-arg', 'python_version=${_PYTHON_VERSION}',
           '--build-arg', 'release_version=${_RELEASE_VERSION}',
@@ -36,6 +37,7 @@ steps:
 
 substitutions:
     _DOCKER_BASE_IMAGE: 'debian:buster'
+    _PYTORCH_CUDA: '0'
     _CUDA: '0'
     _PYTHON_VERSION: '3.6'
     _RELEASE_VERSION: 'nightly'  # or rX.Y

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -21,7 +21,7 @@ steps:
           '-t', 'gcr.io/tpu-pytorch/xla:${_IMAGE_NAME}',
           '-f', 'docker/Dockerfile', '.'
         ]
-  timeout: 14400s
+  timeout: 20400s
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: bash
   args: ['-c', 'docker tag gcr.io/tpu-pytorch/xla:${_IMAGE_NAME} gcr.io/tpu-pytorch/xla:${_IMAGE_NAME}_$(date -u +%Y%m%d)']


### PR DESCRIPTION
This is to check if we can build both pytorch and xla with CUDA enabled. If this work, it will solve https://github.com/pytorch/xla/issues/4713