### PR TITLE
Remove Bazel sha256 checksum for GitHub archive links

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,7 +23,6 @@ http_archive(
         "//tf_patches:thread_local_random.diff",
         "//tf_patches:xplane.diff",
     ],
-    sha256 = "0fdf5067cd9827be2ae14c2ac59cd482e678134b125943be278ad23ea5342181",
     strip_prefix = "tensorflow-f7759359f8420d3ca7b9fd19493f2a01bd47b4ef",
     urls = [
         "https://github.com/tensorflow/tensorflow/archive/f7759359f8420d3ca7b9fd19493f2a01bd47b4ef.tar.gz",


### PR DESCRIPTION
This is related to a GitHub CI outage on PyTorch we had a while ago https://github.com/pytorch/pytorch/issues/94346.  TLDR; Bazel sha256 checksum from GitHub could change as I documented in https://github.com/pytorch/pytorch/pull/95039.  And action item from PyTorch is to remove this field from Bazel WORKSPACE, which has been done in https://github.com/pytorch/pytorch/pull/95039.

I'm trying to make the same change on XLA Bazel WORKSPACE here.