### PR TITLE
Make tpu ci run test for dynamic shape.

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -88,7 +88,7 @@ function run_xla_hlo_debug {
 
 function run_dynamic {
   echo "Running in DynamicShape mode: $@"
-  XLA_EXPERIMENTAL="nonzero:masked_select:masked_scatter" PJRT_DEVICE= run_test "$@"
+  XLA_EXPERIMENTAL="nonzero:masked_select:masked_scatter" run_test "$@"
 }
 
 function run_eager_debug {

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -88,7 +88,7 @@ function run_xla_hlo_debug {
 
 function run_dynamic {
   echo "Running in DynamicShape mode: $@"
-  XLA_EXPERIMENTAL="nonzero:masked_select:masked_scatter" run_test "$@"
+  XLA_EXPERIMENTAL="nonzero:masked_select:masked_scatter" PJRT_DEVICE= run_test "$@"
 }
 
 function run_eager_debug {

--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -51,3 +51,21 @@ spec:
     env:
     - name: PJRT_DEVICE
       value: TPU
+  - name: xla-test-tpu-legacy
+    securityContext:
+      privileged: true
+    image: gcr.io/$PROJECT_ID/pytorch-xla-test:$BUILD_ID
+    command:
+    - bash
+    - -c
+    - |
+      python3 pytorch/xla/test/test_dynamic_shape_models.py -v
+      python3 pytorch/xla/test/test_dynamic_shapes.py -v
+    volumeMounts:
+    - mountPath: /dev/shm
+      name: dshm
+    env:
+    - name: PJRT_DEVICE
+      value: TPU_LEGACY
+    - name: XLA_EXPERIMENTAL
+      value: nonzero:masked_select

--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -45,27 +45,11 @@ spec:
       python3 pytorch/xla/test/spmd/test_xla_sharding.py
       python3 pytorch/xla/test/spmd/test_xla_virtual_device.py
       python3 pytorch/xla/test/spmd/test_train_spmd_linear_model.py
+      PJRT_DEVICE=TPU_LEGACY XLA_EXPERIMENTAL=nonzero:masked_select python3 pytorch/xla/test/test_dynamic_shape_models.py -v
+      PJRT_DEVICE=TPU_LEGACY XLA_EXPERIMENTAL=nonzero:masked_select python3 pytorch/xla/test/test_dynamic_shapes.py -v
     volumeMounts:
     - mountPath: /dev/shm
       name: dshm
     env:
     - name: PJRT_DEVICE
       value: TPU
-  - name: xla-test-tpu-legacy
-    securityContext:
-      privileged: true
-    image: gcr.io/$PROJECT_ID/pytorch-xla-test:$BUILD_ID
-    command:
-    - bash
-    - -c
-    - |
-      python3 pytorch/xla/test/test_dynamic_shape_models.py -v
-      python3 pytorch/xla/test/test_dynamic_shapes.py -v
-    volumeMounts:
-    - mountPath: /dev/shm
-      name: dshm
-    env:
-    - name: PJRT_DEVICE
-      value: TPU_LEGACY
-    - name: XLA_EXPERIMENTAL
-      value: nonzero:masked_select


### PR DESCRIPTION
Make TPU CI run tests for dynamic shape with `XLA_EXPERIMENTAL="nonzero:masked_select"` and `PJRT_DEVICE=TPU_LEGACY`. 

Since we start running dynamic shape related test on pjrt stream executor instead of xrt stream executor, I don't think the current GPU test would cover the scenario.