### PR TITLE
Revert "Remove Bazel sha256 checksum for GitHub archive links"

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,6 +22,7 @@ http_archive(
         "//tf_patches:thread_local_random.diff",
         "//tf_patches:xplane.diff",
     ],
+    sha256 = "0fdf5067cd9827be2ae14c2ac59cd482e678134b125943be278ad23ea5342181",
     strip_prefix = "tensorflow-f7759359f8420d3ca7b9fd19493f2a01bd47b4ef",
     urls = [
         "https://github.com/tensorflow/tensorflow/archive/f7759359f8420d3ca7b9fd19493f2a01bd47b4ef.tar.gz",


### PR DESCRIPTION
Reverts pytorch/xla#4731 since it seems to break pytorch/xla head build.

@huydhn FYI