### PR TITLE
Re-enable dynamo tests with TODOs

### DIFF
--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -14,6 +14,10 @@ import unittest
 
 class DynamoInferenceBasicTest(unittest.TestCase):
 
+  @classmethod
+  def setUpClass(self):
+    torch.manual_seed(42)
+
   def fn_simple(self, x, y):
     a = torch.cos(x)
     b = torch.sin(y)
@@ -78,6 +82,10 @@ class DynamoInferenceBasicTest(unittest.TestCase):
 
 
 class DynamoTrainingBasicTest(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(self):
+    torch.manual_seed(42)
 
   def fn_simple(self, input):
     loss_fn = torch.nn.CrossEntropyLoss()
@@ -175,6 +183,10 @@ class DynamoTrainingBasicTest(unittest.TestCase):
 
 
 class DynamoTrainingOptimizerTest(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(self):
+    torch.manual_seed(42)
 
   def fn_simple(self, input, optimizer):
     loss_fn = torch.nn.CrossEntropyLoss()

--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -11,12 +11,18 @@ import torch._dynamo as dynamo
 import torchvision
 import unittest
 
+# Setup import folders.
+xla_test_folder = os.path.dirname(os.path.dirname(os.path.abspath(sys.argv[0])))
+sys.path.append(xla_test_folder)
+
+import test_utils
+
 
 class DynamoInferenceBasicTest(unittest.TestCase):
 
   @classmethod
   def setUpClass(self):
-    torch.manual_seed(42)
+    test_utils._set_rng_seed(42)
 
   def fn_simple(self, x, y):
     a = torch.cos(x)
@@ -85,7 +91,7 @@ class DynamoTrainingBasicTest(unittest.TestCase):
 
   @classmethod
   def setUpClass(self):
-    torch.manual_seed(42)
+    test_utils._set_rng_seed(42)
 
   def fn_simple(self, input):
     loss_fn = torch.nn.CrossEntropyLoss()
@@ -186,7 +192,7 @@ class DynamoTrainingOptimizerTest(unittest.TestCase):
 
   @classmethod
   def setUpClass(self):
-    torch.manual_seed(42)
+    test_utils._set_rng_seed(42)
 
   def fn_simple(self, input, optimizer):
     loss_fn = torch.nn.CrossEntropyLoss()

--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -276,7 +276,7 @@ class DynamoTrainingOptimizerTest(unittest.TestCase):
         met.metric_data('RunCachedGraphInputData')[0], sample_count * 3)
     self.assertEqual(
         met.metric_data('RunCachedGraphOutputData')[0], sample_count * 3)
-        
+
 
 if __name__ == '__main__':
   test = unittest.main()


### PR DESCRIPTION
Re-enable dynamo tests with TODOs

---

Had a quick sync with Jack earlier today regarding the failing dynamo tests. Given that we want to prevent new possible regressions and that only `CompileTime` metrics differ, we're re-enabling these tests for now. 

I'll keep https://github.com/pytorch/xla/issues/4680 open and post findings/updates there. 