### PR TITLE
Introduce a new flag to disable functionalization tensor wrapping

### DIFF
--- a/torch_xla/csrc/aten_xla_bridge.cpp
+++ b/torch_xla/csrc/aten_xla_bridge.cpp
@@ -356,7 +356,7 @@ at::Tensor AtenFromXlaTensor(XLATensorPtr xla_tensor) {
       // into a functional wrapper later.
       return out;
     } else {
-      auto wrapped = at::functionalization::impl::to_functional_tensor(out);
+      auto wrapped = MaybeWrapTensorToFunctional(out);
       return wrapped;
     }
   } else {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1551,14 +1551,14 @@ at::Tensor XLANativeFunctions::lift(const at::Tensor& tensor) {
   TORCH_LAZY_FN_COUNTER("xla::");
   TORCH_INTERNAL_ASSERT(
       !at::functionalization::impl::isFunctionalTensor(tensor));
-  return at::functionalization::impl::to_functional_tensor(tensor);
+  return MaybeWrapTensorToFunctional(tensor);
 }
 
 at::Tensor XLANativeFunctions::lift_fresh(const at::Tensor& tensor) {
   TORCH_LAZY_FN_COUNTER("xla::");
   TORCH_INTERNAL_ASSERT(
       !at::functionalization::impl::isFunctionalTensor(tensor));
-  return at::functionalization::impl::to_functional_tensor(tensor);
+  return MaybeWrapTensorToFunctional(tensor);
 }
 
 std::tuple<at::Tensor, at::Tensor> XLANativeFunctions::linalg_inv_ex(
@@ -3323,10 +3323,9 @@ XLANativeFunctions::convolution_backward(
   // its issue.
   // The following is adopted from aten/src/ATen/FunctionalTensorWrapper.cpp:
   // functionalize_op_helper.
-  auto func_grad_output =
-      at::functionalization::impl::to_functional_tensor(grad_output);
-  auto func_input = at::functionalization::impl::to_functional_tensor(input);
-  auto func_weight = at::functionalization::impl::to_functional_tensor(weight);
+  auto func_grad_output = MaybeWrapTensorToFunctional(grad_output);
+  auto func_input = MaybeWrapTensorToFunctional(input);
+  auto func_weight = MaybeWrapTensorToFunctional(weight);
 
   auto curr_tls = c10::impl::tls_local_dispatch_key_set();
   auto tls_reenable_functionalize = c10::impl::PODLocalDispatchKeySet();

--- a/torch_xla/csrc/torch_util.cpp
+++ b/torch_xla/csrc/torch_util.cpp
@@ -46,6 +46,15 @@ at::Tensor UnwrapNumber(const at::Tensor& tensor, at::ScalarType dtype) {
                                                            : tensor;
 }
 
+at::Tensor MaybeWrapTensorToFunctional(const at::Tensor& tensor) {
+  bool disable_functionalization =
+      xla::sys_util::GetEnvBool("DISABLE_FUNCTIONALIZATION", false);
+  if (disable_functionalization) {
+    return tensor;
+  }
+  return at::functionalization::impl::to_functional_tensor(tensor);
+}
+
 }  // namespace torch_xla
 
 namespace torch {

--- a/torch_xla/csrc/torch_util.cpp
+++ b/torch_xla/csrc/torch_util.cpp
@@ -48,7 +48,7 @@ at::Tensor UnwrapNumber(const at::Tensor& tensor, at::ScalarType dtype) {
 
 at::Tensor MaybeWrapTensorToFunctional(const at::Tensor& tensor) {
   bool disable_functionalization =
-      xla::sys_util::GetEnvBool("DISABLE_FUNCTIONALIZATION", false);
+      xla::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false);
   if (disable_functionalization) {
     return tensor;
   }

--- a/torch_xla/csrc/torch_util.h
+++ b/torch_xla/csrc/torch_util.h
@@ -60,8 +60,8 @@ at::Scalar MakeFloatScalar(T value) {
 // Unwraps tensor to target dtype if it's a wrapped number.
 at::Tensor UnwrapNumber(const at::Tensor& tensor, at::ScalarType dtype);
 
-// Wraps tensor to functional tensor if DISABLE_FUNCTIONALIZATION is false or
-// not set.
+// Wraps tensor to functional tensor if XLA_DISABLE_FUNCTIONALIZATION is false
+// or not set.
 at::Tensor MaybeWrapTensorToFunctional(const at::Tensor& tensor);
 
 // Checks whether a c10::optional<Tensor> is defined.

--- a/torch_xla/csrc/torch_util.h
+++ b/torch_xla/csrc/torch_util.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/ATen.h>
+#include <ATen/FunctionalTensorWrapper.h>
 #include <c10/core/ScalarType.h>
 #include <c10/util/Optional.h>
 
@@ -58,6 +59,10 @@ at::Scalar MakeFloatScalar(T value) {
 
 // Unwraps tensor to target dtype if it's a wrapped number.
 at::Tensor UnwrapNumber(const at::Tensor& tensor, at::ScalarType dtype);
+
+// Wraps tensor to functional tensor if DISABLE_FUNCTIONALIZATION is false or
+// not set.
+at::Tensor MaybeWrapTensorToFunctional(const at::Tensor& tensor);
 
 // Checks whether a c10::optional<Tensor> is defined.
 inline bool IsDefined(const c10::optional<at::Tensor>& tensor) {

--- a/torch_xla/csrc/torch_util.h
+++ b/torch_xla/csrc/torch_util.h
@@ -61,7 +61,8 @@ at::Scalar MakeFloatScalar(T value) {
 at::Tensor UnwrapNumber(const at::Tensor& tensor, at::ScalarType dtype);
 
 // Wraps tensor to functional tensor if XLA_DISABLE_FUNCTIONALIZATION is false
-// or not set.
+// or not set. For unwrapping, `torch::lazy::maybe_unwrap_functional()` will
+// only unwrap tensors that are functional. So, nothing needs to be done there.
 at::Tensor MaybeWrapTensorToFunctional(const at::Tensor& tensor);
 
 // Checks whether a c10::optional<Tensor> is defined.


### PR DESCRIPTION
Partially picks up https://github.com/pytorch/xla/pull/4747/

---

Sometimes, we may want to disable functionalization tensor wrapping. For example, in dynamo-xla bridge the fx graph we're passed is already functionalized by PyTorch and does not need additional functionalization from us. This PR introduces a flag to disable functionalization. Note that this flag is not yet used anywhere in this PR.

Test: CI