### PR TITLE
Fix XLASymNodeImpl::has_hint

### DIFF
--- a/torch_xla/csrc/ops/dynamic_ir.cpp
+++ b/torch_xla/csrc/ops/dynamic_ir.cpp
@@ -333,8 +333,7 @@ SizeError::SizeError()
           {},
           xla::ShapeUtil::MakeShape(GetShapeDimensionType(/*device=*/nullptr),
                                     {}),
-          1) {
-};
+          1){};
 
 int64_t SizeError::getDynamicValue() const {
   XLA_CHECK(false) << "SizeError shouldn't be called.";

--- a/torch_xla/csrc/ops/dynamic_ir.cpp
+++ b/torch_xla/csrc/ops/dynamic_ir.cpp
@@ -327,4 +327,25 @@ XlaOpVector SizeMod::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::Rem(input1, input2), loctx);
 }
 
+SizeError::SizeError()
+    : XlaNode(
+          torch::lazy::OpKind{c10::Symbol::fromQualString("aten::size_error")},
+          {},
+          xla::ShapeUtil::MakeShape(GetShapeDimensionType(/*device=*/nullptr),
+                                    {}),
+          1) {
+};
+
+int64_t SizeError::getDynamicValue() const {
+  XLA_CHECK(false) << "SizeError shouldn't be called.";
+  return -1;
+}
+
+std::string SizeError::ToString() const { return "aten::size_error"; }
+
+XlaOpVector SizeError::Lower(LoweringContext* loctx) const {
+  XLA_CHECK(false) << "SizeError shouldn't be called.";
+  return ReturnOp({}, loctx);
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/dynamic_ir.h
+++ b/torch_xla/csrc/ops/dynamic_ir.h
@@ -12,6 +12,7 @@
 #include "torch/csrc/lazy/core/dynamic_ir.h"
 #include "torch_xla/csrc/ir.h"
 #include "torch_xla/csrc/ops/scalar.h"
+#include "third_party/xla_client/debug_macros.h"
 
 namespace torch_xla {
 
@@ -176,6 +177,22 @@ class SizeMod : public XlaNode, public torch::lazy::DimensionNode {
 
  private:
   int64_t upper_bound_;
+};
+
+class SizeError : public XlaNode, public torch::lazy::DimensionNode {
+ public:
+  SizeError();
+  int64_t getDynamicValue() const override;
+  int64_t getStaticValue() const override {
+    XLA_CHECK(false) << "SizeError shouldn't be called.";
+    return -1;
+  }
+  bool isSymbolic() const override { 
+    XLA_CHECK(false) << "SizeError shouldn't be called.";
+    return true;
+  }
+  std::string ToString() const override;
+  virtual XlaOpVector Lower(LoweringContext* loctx) const override;
 };
 
 const torch::lazy::DimensionNode* DimCast(torch::lazy::Output output);

--- a/torch_xla/csrc/ops/dynamic_ir.h
+++ b/torch_xla/csrc/ops/dynamic_ir.h
@@ -9,10 +9,10 @@
 #include <utility>
 #include <vector>
 
+#include "third_party/xla_client/debug_macros.h"
 #include "torch/csrc/lazy/core/dynamic_ir.h"
 #include "torch_xla/csrc/ir.h"
 #include "torch_xla/csrc/ops/scalar.h"
-#include "third_party/xla_client/debug_macros.h"
 
 namespace torch_xla {
 
@@ -187,7 +187,7 @@ class SizeError : public XlaNode, public torch::lazy::DimensionNode {
     XLA_CHECK(false) << "SizeError shouldn't be called.";
     return -1;
   }
-  bool isSymbolic() const override { 
+  bool isSymbolic() const override {
     XLA_CHECK(false) << "SizeError shouldn't be called.";
     return true;
   }

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -849,9 +849,7 @@ bool XLASymNodeImpl::bool_() {
 // "a SymInt has_hint" is equivalent to "a SymInt is backed". Unbacked SymInt is
 // the result of a data dependent output like nonzero; we don't know what the
 // value is because it's data dependent.
-bool XLASymNodeImpl::has_hint() {
-  return false;
-}
+bool XLASymNodeImpl::has_hint() { return false; }
 
 std::string XLASymNodeImpl::str() {
   return "<=" + std::to_string(DimCast(node().get())->getStaticValue());

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -750,8 +750,8 @@ c10::SymNode XLASymNodeImpl::sym_max(const c10::SymNode& other) {
 }
 
 c10::SymNode XLASymNodeImpl::sym_or(const c10::SymNode& other) {
-  XLA_CHECK(false) << "XLASymNodeImpl::" << __FUNCTION__
-                   << " has not been implemented.";
+  auto error_node = torch::lazy::MakeNode<SizeError>();
+  return c10::make_intrusive<XLASymNodeImpl>(error_node, PyType::BOOL);
 }
 
 c10::SymNode XLASymNodeImpl::sym_and(const c10::SymNode& other) {
@@ -789,10 +789,12 @@ c10::SymNode XLASymNodeImpl::is_channels_last_strides_3d(
   XLA_CHECK(false) << "XLASymNodeImpl::" << __FUNCTION__
                    << " has not been implemented.";
 }
+
+// xw32: what's the reason that this function should never be called in practice?
 c10::SymNode XLASymNodeImpl::is_non_overlapping_and_dense(
     at::ArrayRef<c10::SymNode> sizes, at::ArrayRef<c10::SymNode> strides) {
-  XLA_CHECK(false) << "XLASymNodeImpl::" << __FUNCTION__
-                   << " has not been implemented.";
+  auto error_node = torch::lazy::MakeNode<SizeError>();
+  return c10::make_intrusive<XLASymNodeImpl>(error_node, PyType::BOOL);
 }
 
 c10::SymNode XLASymNodeImpl::clone() {
@@ -813,6 +815,11 @@ c10::SymNode XLASymNodeImpl::wrap_int(int64_t num) {
 c10::SymNode XLASymNodeImpl::wrap_float(double num) {
   XLA_CHECK(false) << "XLASymNodeImpl::" << __FUNCTION__
                    << " has not been implemented.";
+}
+
+c10::SymNode XLASymNodeImpl::wrap_bool(bool num) {
+  auto cnst = torch::lazy::MakeNode<SizeConstant>(num);
+  return c10::make_intrusive<XLASymNodeImpl>(cnst, PyType::BOOL);
 }
 
 int64_t XLASymNodeImpl::guard_int(const char* file, int64_t line) {
@@ -843,10 +850,16 @@ bool XLASymNodeImpl::bool_() {
 // "a SymInt has_hint" is equivalent to "a SymInt is backed". Unbacked SymInt is
 // the result of a data dependent output like nonzero; we don't know what the
 // value is because it's data dependent.
+// xw32: what's the justification that this function can always return false?
+// What if we have
+/*
+t0=torch.zeros(3)
+t2=torch.nonzero(t1)
+sz=t2.shape[0]+t0.shape[0]
+*/
+// then sz is always an unbacked SymInt.
 bool XLASymNodeImpl::has_hint() {
-  if (is_int() || is_float() || is_bool()) {
-    return true;
-  }
+  std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": " << std::endl;
   return false;
 }
 

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -840,7 +840,15 @@ bool XLASymNodeImpl::bool_() {
   return dn->getDynamicValue() != 0;
 }
 
-bool XLASymNodeImpl::has_hint() { return true; }
+// "a SymInt has_hint" is equivalent to "a SymInt is backed". Unbacked SymInt is
+// the result of a data dependent output like nonzero; we don't know what the
+// value is because it's data dependent.
+bool XLASymNodeImpl::has_hint() {
+  if (is_int() || is_float() || is_bool()) {
+    return true;
+  }
+  return false;
+}
 
 std::string XLASymNodeImpl::str() {
   return "<=" + std::to_string(DimCast(node().get())->getStaticValue());

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -790,7 +790,6 @@ c10::SymNode XLASymNodeImpl::is_channels_last_strides_3d(
                    << " has not been implemented.";
 }
 
-// xw32: what's the reason that this function should never be called in practice?
 c10::SymNode XLASymNodeImpl::is_non_overlapping_and_dense(
     at::ArrayRef<c10::SymNode> sizes, at::ArrayRef<c10::SymNode> strides) {
   auto error_node = torch::lazy::MakeNode<SizeError>();
@@ -850,16 +849,7 @@ bool XLASymNodeImpl::bool_() {
 // "a SymInt has_hint" is equivalent to "a SymInt is backed". Unbacked SymInt is
 // the result of a data dependent output like nonzero; we don't know what the
 // value is because it's data dependent.
-// xw32: what's the justification that this function can always return false?
-// What if we have
-/*
-t0=torch.zeros(3)
-t2=torch.nonzero(t1)
-sz=t2.shape[0]+t0.shape[0]
-*/
-// then sz is always an unbacked SymInt.
 bool XLASymNodeImpl::has_hint() {
-  std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": " << std::endl;
   return false;
 }
 

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -749,6 +749,9 @@ c10::SymNode XLASymNodeImpl::sym_max(const c10::SymNode& other) {
                    << " has not been implemented.";
 }
 
+// It is used to compute contiguity fields on tensors like "is non overlapping
+// and dense" and it's never fetched. If they are never fetched it is fine for
+// them to error only if poked.
 c10::SymNode XLASymNodeImpl::sym_or(const c10::SymNode& other) {
   auto error_node = torch::lazy::MakeNode<SizeError>();
   return c10::make_intrusive<XLASymNodeImpl>(error_node, PyType::BOOL);
@@ -790,6 +793,9 @@ c10::SymNode XLASymNodeImpl::is_channels_last_strides_3d(
                    << " has not been implemented.";
 }
 
+// It is used to compute contiguity fields on tensors like "is non overlapping
+// and dense" and it's never fetched. If they are never fetched it is fine for
+// them to error only if poked.
 c10::SymNode XLASymNodeImpl::is_non_overlapping_and_dense(
     at::ArrayRef<c10::SymNode> sizes, at::ArrayRef<c10::SymNode> strides) {
   auto error_node = torch::lazy::MakeNode<SizeError>();
@@ -849,6 +855,10 @@ bool XLASymNodeImpl::bool_() {
 // "a SymInt has_hint" is equivalent to "a SymInt is backed". Unbacked SymInt is
 // the result of a data dependent output like nonzero; we don't know what the
 // value is because it's data dependent.
+// Returning false here because PyTorch/XLA only creates a SymNodeImpl for
+// nonzero output, such as in XLATensorImpl::SetupSymSizeProperties(). During
+// propagation such as sz = t1.shape[0] + t2.shape[1] where former argument is
+// an unbacked SymInt and latter is backed, sz remains to be an unbacked SymInt.
 bool XLASymNodeImpl::has_hint() { return false; }
 
 std::string XLASymNodeImpl::str() {

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -83,6 +83,7 @@ class TORCH_API XLASymNodeImpl final : public c10::SymNodeImpl {
   c10::SymNode sym_float() override;
   c10::SymNode wrap_int(int64_t num) override;
   c10::SymNode wrap_float(double num) override;
+  c10::SymNode wrap_bool(bool num) override;
   int64_t guard_int(const char* file, int64_t line) override;
   double guard_float(const char* file, int64_t line) override;
   bool guard_bool(const char* file, int64_t line) override;


### PR DESCRIPTION
This PR modifies `XLASymNodeImpl::has_hint` implementation and also implements missing XLASymNodeImpl methods: `is_non_overlapping_and_dense`, `wrap_bool`, and `sym_or`.

Currently, torch_xla's [implementation](https://github.com/pytorch/xla/blob/5da150236974aa892124891f9729350df3a9f99f/torch_xla/csrc/ops/dynamic_ir.h#L39-L54) is we track 2 fields: upper_bound and real_size separately. When we trace a program
```
# assuming x has shape torch.Size([10])
y = torch.nonzero(x) 
```
we only know and propagate `y`'s upper_bound. (`print(y)` outputs `torch.Size([<=10, 1])`.) To obtain its real value, either:
- PyTorch/XLA has to compile and execute via a `mark_step` call explicitly
- the code encounter a condition or assertion (such as `assert(y.shape[0], 2)` for example.) which torch_xla implicitly trigger a compilation and execution.

Test plan: `is_non_overlapping_and_dense`, `wrap_bool`, and `sym_or` are covered by the test ` TestDynamicShapeModels.test_backward_pass_with_dynamic_input_multibatch_correctness` and `TestDynamicShapes.test_t_copy`.