### PR TITLE
[Functionalization] Lower as_strided_scatter properly

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -26,6 +26,7 @@
 #include "torch_xla/csrc/generated/XLANativeFunctions.h"
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/ops/as_strided.h"
+#include "torch_xla/csrc/ops/as_strided_view_update.h"
 #include "torch_xla/csrc/ops/einsum_utilities.h"
 #include "torch_xla/csrc/ops/index_ops.h"
 #include "torch_xla/csrc/pooling.h"
@@ -735,11 +736,7 @@ at::Tensor XLANativeFunctions::as_strided_scatter(
                                                               storage_offset);
   }
   auto mutated_view_ = bridge::GetXlaTensor(mutated_view);
-  auto base_clone = tensor_methods::clone(base_);
-  auto base_clone_slice = tensor_methods::as_strided(
-      base_clone, xsize, xstride, XlaHelpers::I64Optional(storage_offset));
-  tensor_methods::copy_(base_clone_slice, mutated_view_);
-  return bridge::AtenFromXlaTensor(base_clone);
+  return bridge::AtenFromXlaTensor(base_->CreateFrom(torch::lazy::MakeNode<AsStridedViewUpdate>(base_->GetIrValue(), mutated_view_->GetIrValue(), torch::lazy::ToVector<int64_t>(base_->shape().get().dimensions()), xstride, storage_offset.value_or(0))));
 }
 
 at::Tensor XLANativeFunctions::atan2(const at::Tensor& self,

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -736,7 +736,11 @@ at::Tensor XLANativeFunctions::as_strided_scatter(
                                                               storage_offset);
   }
   auto mutated_view_ = bridge::GetXlaTensor(mutated_view);
-  return bridge::AtenFromXlaTensor(base_->CreateFrom(torch::lazy::MakeNode<AsStridedViewUpdate>(base_->GetIrValue(), mutated_view_->GetIrValue(), torch::lazy::ToVector<int64_t>(base_->shape().get().dimensions()), xstride, storage_offset.value_or(0))));
+  return bridge::AtenFromXlaTensor(
+      base_->CreateFrom(torch::lazy::MakeNode<AsStridedViewUpdate>(
+          base_->GetIrValue(), mutated_view_->GetIrValue(),
+          torch::lazy::ToVector<int64_t>(base_->shape().get().dimensions()),
+          xstride, storage_offset.value_or(0))));
 }
 
 at::Tensor XLANativeFunctions::atan2(const at::Tensor& self,


### PR DESCRIPTION
Summary:
The current lowering of as_strided_scatter is using a hack that utilize our old view infra to reapply value updates to the base view. Let's lower it properly by using AsStridedViewUpdate.

Test Plan:
PJRT_DEVICE=CPU python ../test/test_view_ops.py -v -k TestViewOpsXLA.test_as_strided