### PR TITLE
Enable torch_xla whl build with python 3.9

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,12 +16,16 @@ ARG bazel_jobs=""
 ARG git_clone="true"
 ARG build_cpp_tests="0"
 
+ENV BUILD_CPP_TESTS "${build_cpp_tests}"
+
 RUN apt-get update
-RUN apt-get install -y git sudo python-pip python3-pip
+RUN apt-get install -y git sudo python3-pip
 RUN git clone https://github.com/pytorch/pytorch
 
-# Disable CUDA for PyTorch
+# Disable CUDA for PyTorch and ensure the pre-built wheel works
+# on Colab with no libmpi installed.
 ENV USE_CUDA "0"
+ENV USE_MPI "0"
 
 # Enable CUDA for XLA
 ENV XLA_CUDA "${cuda}"

--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -6,7 +6,7 @@ set -x  # Display commands being run.
 PYTHON_VERSION=$1
 RELEASE_VERSION=$2  # rX.Y or nightly
 BUILD_CPP_TESTS="${3:-0}"
-DEFAULT_PYTHON_VERSION=3.6
+DEFAULT_PYTHON_VERSION=3.8
 DEBIAN_FRONTEND=noninteractive
 
 ACL_VERSION=v22.05 # Arm Compute Library version
@@ -86,8 +86,8 @@ function maybe_install_sources {
     popd
   fi
 
-  # Check if we have cloned pytorch or xla and cd into the pytorch dir. 
-  # Within the pytorch dir there is a subdir `torch`, and within xla 
+  # Check if we have cloned pytorch or xla and cd into the pytorch dir.
+  # Within the pytorch dir there is a subdir `torch`, and within xla
   # is `torch_xla`.
   if [ ! -d "torch" && ! -d "torch_xla" ]; then
     sudo apt-get install -y git
@@ -202,6 +202,7 @@ function install_and_setup_conda() {
   conda install -y numpy pyyaml setuptools cmake cffi typing tqdm coverage tensorboard hypothesis dataclasses
   if [[ $(uname -m) == "x86_64" ]]; then
     # Overwrite mkl packages here, since nomkl conflicts with the anaconda env setup.
+    conda remove -y tbb
     pip install mkl==2022.2.1 mkl_include==2022.2.1
   fi
 


### PR DESCRIPTION
* Set default build Python ver 3.6 -> 3.8
* Bug fixes for Python 3.9 whl builds (tbb package was blocking the build)