### PR TITLE
[Functionalization] detach_copy use set_ instead of _copy_from

### DIFF
--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -177,8 +177,7 @@ class DynamoTrainingBasicTest(unittest.TestCase):
     # Graph 2: backward
     # Graph 3: sync input for backward
     # Graph 4: sync input for backward (TODO(JackCaoG) understand why there are two graphs)
-    # TODO @wonjoo CompileTime has increased to 5 after enabling functionalization (#4680)
-    self.assertEqual(met.metric_data('CompileTime')[0], 5)
+    self.assertEqual(met.metric_data('CompileTime')[0], 4)
     # We execute 3 grphs per step.
     self.assertEqual(met.metric_data('ExecuteTime')[0], sample_count * 3)
     # one for each forward and one for each backward
@@ -284,11 +283,9 @@ class DynamoTrainingOptimizerTest(unittest.TestCase):
     # Graph 3: optimizer
     # Graph 4: sync input for backward
     # Graph 5: sync input for backward (TODO(JackCaoG) understand why there are two graphs)
-    # TODO @wonjoo CompileTime has increased 5->7 after enabling functionalization (#4680)
-    self.assertEqual(met.metric_data('CompileTime')[0], 7)
+    self.assertEqual(met.metric_data('CompileTime')[0], 5)
     # We execute 4 grphs per step when optimizer is enabled.
-    # TODO @wonjoo ExecuteTime has increased by 1 after enabling functionalization (#4680)
-    self.assertEqual(met.metric_data('ExecuteTime')[0], (sample_count * 4) + 1)
+    self.assertEqual(met.metric_data('ExecuteTime')[0], sample_count * 4)
     # one for each forward, backward and optimizer
     self.assertEqual(
         met.metric_data('RunCachedGraphInputData')[0], sample_count * 3)

--- a/test/pjrt/test_experimental_pjrt_tpu.py
+++ b/test/pjrt/test_experimental_pjrt_tpu.py
@@ -248,9 +248,6 @@ class TestTpuCollectiveOps(parameterized.TestCase):
   @parameterized.named_parameters(('synchronized_parameters', True),
                                   ('unsynchronized_parameters', False))
   def test_broadcast_master_param(self, sync):
-    # TODO(wcromar): Re-enable this test
-    if sync:
-      self.skipTest('Failing')
     results = pjrt._run_multiprocess(self._broadcast, sync)
     master_params = results[0]
     for ordinal, worker_params in results.items():

--- a/test/spmd/test_xla_virtual_device.py
+++ b/test/spmd/test_xla_virtual_device.py
@@ -48,7 +48,8 @@ class VirtualDeviceTest(test_xla_sharding_base.XlaShardingTest):
     model = nn.Linear(128, 64).to(xm.xla_device())
     xs.mark_sharding(model.weight, self._get_mesh((1, self.n_devices)),
                      partition_spec)
-    self.assertNotIn("VirtualDeviceUsage", met.counter_names())
+    self.assertIn("VirtualDeviceUsage", met.counter_names())
+    self.assertNotEqual(met.counter_value("VirtualDeviceUsage"), 0)
 
   def test_no_sharding(self):
     t1 = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]],

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -459,7 +459,7 @@ at::Tensor& XLANativeFunctions::_amp_update_scale_(at::Tensor& current_scale,
 
 at::Tensor XLANativeFunctions::_copy_from(const at::Tensor& self,
                                           const at::Tensor& dst,
-                                          bool non_blocking) {
+                                          bool /*non_blocking*/) {
   TORCH_LAZY_FN_COUNTER("xla::");
   auto dst_tensor = bridge::TryGetXlaTensor(dst);
   auto self_tensor = bridge::TryGetXlaTensor(self);
@@ -1092,7 +1092,7 @@ at::Tensor XLANativeFunctions::detach_copy(const at::Tensor& self) {
   auto new_tensor =
       empty_symint(self.sym_sizes(), at::typeMetaToScalarType(self.dtype()),
                    c10::nullopt, self.device(), c10::nullopt, c10::nullopt);
-  return _copy_from(self, new_tensor, true);
+  return set_(new_tensor, self);
 }
 
 at::Tensor XLANativeFunctions::diag(const at::Tensor& self, int64_t diagonal) {


### PR DESCRIPTION
Summary:
It looks like `_copy_from` somehow is not working correctly with PJRT on devices other than xla:0. Let's use set_ which also more loyally represents the semantics of detach.

Test Plan:
PJRT_DEVICE=TPU python test/pjrt/test_experimental_pjrt_tpu.py TestTpuCollectiveOps.test_broadcast_master_param_synchronized_parameters