### PR TITLE
Enable ubuntu:focal for Colab

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,8 @@ ENV BUILD_CPP_TESTS "${build_cpp_tests}"
 
 RUN apt-get update
 RUN apt-get install -y git sudo python3-pip
+# To enable `base_image=ubuntu:focal`
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
 RUN git clone https://github.com/pytorch/pytorch
 
 # Disable CUDA for PyTorch and ensure the pre-built wheel works


### PR DESCRIPTION
Colab has moved to `ubuntu:focal` as base image, and this one liner seems to enable the build.

Tested locally (docker) and on the cloud (GCB).