### PR TITLE
[Functionalization] Properly skip GRU and LSTM tests

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -283,8 +283,8 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_CTCLoss_no_batch_dim_xla',  # Value out of range
         'test_upsamplingBilinear2d_xla',  # precision on GPU/TPU, slow compilation on CPU
         # torch.autograd.gradcheck.GradcheckError: Jacobian mismatch for output 0 with respect to input 0
-        'test_GRU_grad_and_gradgrad_xla_float64',  # Broke by functionalization, #4711
-        'test_LSTM_grad_and_gradgrad_xla_float64',  # Broke by functionalization, #4711
+        'test_GRU_grad_and_gradgrad_xla_float64',  # grad check failure
+        'test_LSTM_grad_and_gradgrad_xla_float64',  # grad check failure
     },
 
     # test/nn/test_dropout.py
@@ -422,8 +422,6 @@ DISABLED_TORCH_TESTS_TPU_ONLY = {
         'test_EmbeddingBag_per_sample_weights_and_new_offsets_xla',  # server side crash
         'test_EmbeddingBag_per_sample_weights_and_offsets_xla',  # server side crash
         'test_upsamplingNearest2d_xla',  # precision
-        'test_GRU_grad_and_gradgrad_xla_float64',  # grad check failure
-        'test_LSTM_grad_and_gradgrad_xla_float64',  # grad check failure
         'test_conv3d_valid_padding_backward_xla',  # grad check failure
         'test_ctc_loss_xla',  # runtime overflow error
         'test_upsamplingBicubic2d_xla',  # grad check failure


### PR DESCRIPTION
Summary:
test_GRU_grad_and_gradgrad_xla_float64 and test_LSTM_grad_and_gradgrad_xla_float64 have been failing for a long time for the same reason in TPU. Not sure if it worth fixing these two tests just for CPU/GPU. Let's skip them.

Test Plan:
CI.

FIXES #4711.