### PR TITLE
Add support for XLA_DISABLE_FUNCTIONALIZATION flag

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -66,6 +66,11 @@ function run_test {
   fi
 }
 
+function run_test_without_functionalization {
+  echo "Running with XLA_DISABLE_FUNCTIONALIZATION: $@"
+  XLA_DISABLE_FUNCTIONALIZATION=1 run_test "$@"
+}
+
 function run_use_bf16 {
   echo "Running with XLA_USE_BF16: $@"
   XLA_USE_BF16=1 run_test "$@"
@@ -161,6 +166,7 @@ function run_op_tests {
   run_eager_debug  "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_test "$CDIR/test_grad_checkpoint.py"
   run_test "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  run_test_without_functionalization "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_test "$CDIR/test_async_closures.py"
   run_test "$CDIR/test_xla_dist.py"
   run_test "$CDIR/test_profiler.py"

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -965,6 +965,9 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     b = torch.ones([2, 2])
     self.runAtenTest((a, b), func)
 
+  @unittest.skipIf(
+      os.environ.get('XLA_DISABLE_FUNCTIONALIZATION'),
+      'Metrics differ when functionalization is disabled.')
   def test_set(self):
     met.clear_all()
 
@@ -982,6 +985,9 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     # shouldn't crash
     self.assertTrue(torch.allclose(t2.cpu(), torch.zeros(10)))
 
+  @unittest.skipIf(
+      os.environ.get('XLA_DISABLE_FUNCTIONALIZATION'),
+      'Metrics differ when functionalization is disabled.')
   def test_replace_xla_tensor(self):
     met.clear_all()
 

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2728,6 +2728,7 @@ at::Tensor XLANativeFunctions::slice_copy(const at::Tensor& self, int64_t dim,
                                           c10::optional<int64_t> start,
                                           c10::optional<int64_t> end,
                                           int64_t step) {
+  std::cout << "WONJOO: slice_copy" << std::endl;
   TORCH_LAZY_FN_COUNTER("xla::");
   int64_t start_val = start.has_value() ? start.value() : 0;
   int64_t end_val = end.has_value() ? end.value() : INT64_MAX;
@@ -2738,6 +2739,7 @@ at::Tensor XLANativeFunctions::slice_copy(const at::Tensor& self, int64_t dim,
 at::Tensor XLANativeFunctions::slice_scatter(
     const at::Tensor& base, const at::Tensor& mutated_view, int64_t dim,
     c10::optional<int64_t> start, c10::optional<int64_t> end, int64_t step) {
+  std::cout << "WONJOO: slice_scatter" << std::endl;
   TORCH_LAZY_FN_COUNTER("xla::");
   auto base_ = bridge::GetXlaTensor(base);
   auto mutated_view_ = bridge::GetXlaTensor(mutated_view);
@@ -3420,6 +3422,11 @@ at::Tensor XLANativeFunctions::select_backward_symint(
 
 at::Tensor XLANativeFunctions::select_symint(const at::Tensor& self,
                                              int64_t dim, c10::SymInt index) {
+  std::cout << "WONJOO: select_symint" << std::endl;
+  if (xla::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
+    std::cout << "WONJOO: select_symint, func disabled" << std::endl;
+    return select_copy(self, dim, index.expect_int());
+  }                           
   return at::functionalization::functionalize_aten_op_symint<ATEN_OP2(
       select, int)>::call(self, dim, index);
 }
@@ -3427,6 +3434,11 @@ at::Tensor XLANativeFunctions::select_symint(const at::Tensor& self,
 at::Tensor XLANativeFunctions::slice(const at::Tensor& self, int64_t dim,
                                      c10::optional<int64_t> start,
                                      c10::optional<int64_t> end, int64_t step) {
+  std::cout << "WONJOO: slice.Tensor" << std::endl;
+  if (xla::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
+    std::cout << "WONJOO: slice, func disabled" << std::endl;
+    return slice_copy(self, dim, start, end, step);
+  }
   return at::functionalization::functionalize_aten_op<ATEN_OP2(
       slice, Tensor)>::call(self, dim, start, end, step);
 }
@@ -3467,6 +3479,7 @@ at::Tensor XLANativeFunctions::slice_backward(const at::Tensor& grad_output,
                                               at::IntArrayRef input_sizes,
                                               int64_t dim, int64_t start,
                                               int64_t end, int64_t step) {
+  std::cout << "WONJOO: slice_backward" << std::endl;
   return at::functionalization::functionalize_aten_op<ATEN_OP(
       slice_backward)>::call(grad_output, input_sizes, dim, start, end, step);
 }

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3382,6 +3382,12 @@ at::Tensor XLANativeFunctions::new_empty_strided_symint(
     const at::Tensor& self, at::SymIntArrayRef size, at::SymIntArrayRef stride,
     c10::optional<at::ScalarType> dtype, c10::optional<at::Layout> layout,
     c10::optional<at::Device> device, c10::optional<bool> pin_memory) {
+  std::cout << "WONJOO: new_empty_strided_symint" << std::endl;
+  if (xla::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
+    std::cout << "WONJOO: new_empty_strided_symint, func disabled" << std::endl;
+    return at::native::new_empty_strided_symint(self, size, stride, dtype, layout,
+                                                device, pin_memory);
+  }
   return at::functionalization::functionalize_aten_op_symint<ATEN_OP(
       new_empty_strided)>::call(self, size, stride, dtype, layout, device,
                                 pin_memory);

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3321,8 +3321,15 @@ XLANativeFunctions::convolution_backward(
     ::std::array<bool, 3> output_mask) {
   if (xla::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
     return at::native::call_fallback_fn<
-        &xla_cpu_fallback,
-        ATEN_OP(convolution_backward)>::call(grad_output, input, weight, bias_sizes, stride, padding, dilation, transposed, output_padding, groups, output_mask);
+        &xla_cpu_fallback, ATEN_OP(convolution_backward)>::call(grad_output,
+                                                                input, weight,
+                                                                bias_sizes,
+                                                                stride, padding,
+                                                                dilation,
+                                                                transposed,
+                                                                output_padding,
+                                                                groups,
+                                                                output_mask);
   }
 
   // TODO (alanwaketan): Let's resuse
@@ -3381,8 +3388,8 @@ at::Tensor XLANativeFunctions::new_empty_strided_symint(
     c10::optional<at::ScalarType> dtype, c10::optional<at::Layout> layout,
     c10::optional<at::Device> device, c10::optional<bool> pin_memory) {
   if (xla::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
-    return at::native::new_empty_strided_symint(self, size, stride, dtype, layout,
-                                                device, pin_memory);
+    return at::native::new_empty_strided_symint(self, size, stride, dtype,
+                                                layout, device, pin_memory);
   }
   return at::functionalization::functionalize_aten_op_symint<ATEN_OP(
       new_empty_strided)>::call(self, size, stride, dtype, layout, device,
@@ -3426,7 +3433,7 @@ at::Tensor XLANativeFunctions::select_symint(const at::Tensor& self,
                                              int64_t dim, c10::SymInt index) {
   if (xla::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
     return select_copy(self, dim, index.expect_int());
-  }                           
+  }
   return at::functionalization::functionalize_aten_op_symint<ATEN_OP2(
       select, int)>::call(self, dim, index);
 }

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3319,6 +3319,12 @@ XLANativeFunctions::convolution_backward(
     at::IntArrayRef stride, at::IntArrayRef padding, at::IntArrayRef dilation,
     bool transposed, at::IntArrayRef output_padding, int64_t groups,
     ::std::array<bool, 3> output_mask) {
+  if (xla::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
+    return at::native::call_fallback_fn<
+        &xla_cpu_fallback,
+        ATEN_OP(convolution_backward)>::call(grad_output, input, weight, bias_sizes, stride, padding, dilation, transposed, output_padding, groups, output_mask);
+  }
+
   // TODO (alanwaketan): Let's resuse
   // `at::functionalization::functionalize_aten_op` after upstream has solved
   // its issue.
@@ -3484,7 +3490,6 @@ at::Tensor XLANativeFunctions::permute(const at::Tensor& self,
 }
 
 // See note [Disabling Functionalization]
-
 at::Tensor XLANativeFunctions::as_strided(
     const at::Tensor& self, at::IntArrayRef size, at::IntArrayRef stride,
     c10::optional<int64_t> storage_offset) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3532,4 +3532,13 @@ at::Tensor XLANativeFunctions::diagonal(const at::Tensor& self, int64_t offset,
       tensor_methods::diagonal(bridge::GetXlaTensor(self), offset, dim1, dim2));
 }
 
+at::Tensor XLANativeFunctions::view_symint(const at::Tensor& self,
+                                           at::SymIntArrayRef sym_size) {
+  // TODO: support symbolic sizes
+  auto size = C10_AS_INTARRAYREF_SLOW(sym_size);
+  TORCH_LAZY_FN_COUNTER("xla::");
+  return bridge::AtenFromXlaTensor(tensor_methods::view(
+      bridge::GetXlaTensor(self), XlaHelpers::I64List(size)));
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2728,7 +2728,6 @@ at::Tensor XLANativeFunctions::slice_copy(const at::Tensor& self, int64_t dim,
                                           c10::optional<int64_t> start,
                                           c10::optional<int64_t> end,
                                           int64_t step) {
-  std::cout << "WONJOO: slice_copy" << std::endl;
   TORCH_LAZY_FN_COUNTER("xla::");
   int64_t start_val = start.has_value() ? start.value() : 0;
   int64_t end_val = end.has_value() ? end.value() : INT64_MAX;
@@ -2739,7 +2738,6 @@ at::Tensor XLANativeFunctions::slice_copy(const at::Tensor& self, int64_t dim,
 at::Tensor XLANativeFunctions::slice_scatter(
     const at::Tensor& base, const at::Tensor& mutated_view, int64_t dim,
     c10::optional<int64_t> start, c10::optional<int64_t> end, int64_t step) {
-  std::cout << "WONJOO: slice_scatter" << std::endl;
   TORCH_LAZY_FN_COUNTER("xla::");
   auto base_ = bridge::GetXlaTensor(base);
   auto mutated_view_ = bridge::GetXlaTensor(mutated_view);
@@ -3382,9 +3380,7 @@ at::Tensor XLANativeFunctions::new_empty_strided_symint(
     const at::Tensor& self, at::SymIntArrayRef size, at::SymIntArrayRef stride,
     c10::optional<at::ScalarType> dtype, c10::optional<at::Layout> layout,
     c10::optional<at::Device> device, c10::optional<bool> pin_memory) {
-  std::cout << "WONJOO: new_empty_strided_symint" << std::endl;
   if (xla::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
-    std::cout << "WONJOO: new_empty_strided_symint, func disabled" << std::endl;
     return at::native::new_empty_strided_symint(self, size, stride, dtype, layout,
                                                 device, pin_memory);
   }
@@ -3428,9 +3424,7 @@ at::Tensor XLANativeFunctions::select_backward_symint(
 
 at::Tensor XLANativeFunctions::select_symint(const at::Tensor& self,
                                              int64_t dim, c10::SymInt index) {
-  std::cout << "WONJOO: select_symint" << std::endl;
   if (xla::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
-    std::cout << "WONJOO: select_symint, func disabled" << std::endl;
     return select_copy(self, dim, index.expect_int());
   }                           
   return at::functionalization::functionalize_aten_op_symint<ATEN_OP2(
@@ -3440,9 +3434,7 @@ at::Tensor XLANativeFunctions::select_symint(const at::Tensor& self,
 at::Tensor XLANativeFunctions::slice(const at::Tensor& self, int64_t dim,
                                      c10::optional<int64_t> start,
                                      c10::optional<int64_t> end, int64_t step) {
-  std::cout << "WONJOO: slice.Tensor" << std::endl;
   if (xla::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
-    std::cout << "WONJOO: slice, func disabled" << std::endl;
     return slice_copy(self, dim, start, end, step);
   }
   return at::functionalization::functionalize_aten_op<ATEN_OP2(
@@ -3485,7 +3477,6 @@ at::Tensor XLANativeFunctions::slice_backward(const at::Tensor& grad_output,
                                               at::IntArrayRef input_sizes,
                                               int64_t dim, int64_t start,
                                               int64_t end, int64_t step) {
-  std::cout << "WONJOO: slice_backward" << std::endl;
   return at::functionalization::functionalize_aten_op<ATEN_OP(
       slice_backward)>::call(grad_output, input_sizes, dim, start, end, step);
 }
@@ -3512,14 +3503,12 @@ at::Tensor XLANativeFunctions::permute(const at::Tensor& self,
 at::Tensor XLANativeFunctions::as_strided(
     const at::Tensor& self, at::IntArrayRef size, at::IntArrayRef stride,
     c10::optional<int64_t> storage_offset) {
-  std::cout << "WONJOO: as_strided" << std::endl;
   TORCH_LAZY_FN_COUNTER("xla::");
   XLATensorPtr self_tensor = bridge::GetXlaTensor(self);
   auto xsize = XlaHelpers::I64List(size);
   auto xstride = XlaHelpers::I64List(stride);
   if (!AsStrided::StrideIsSupported(self_tensor->shape(), xsize, xstride,
                                     storage_offset.value_or(0))) {
-    std::cout << "WONJOO: as_strided fallback" << std::endl;
     return at::native::call_fallback_fn<
         &xla_cpu_fallback, ATEN_OP(as_strided)>::call(self, size, stride,
                                                       storage_offset);
@@ -3532,14 +3521,12 @@ at::Tensor XLANativeFunctions::as_strided(
 const at::Tensor& XLANativeFunctions::as_strided_(
     const at::Tensor& self, at::IntArrayRef size, at::IntArrayRef stride,
     c10::optional<int64_t> storage_offset) {
-std::cout << "WONJOO: as_strided_" << std::endl;
   TORCH_LAZY_FN_COUNTER("xla::");
   XLATensorPtr self_tensor = bridge::GetXlaTensor(self);
   auto xsize = XlaHelpers::I64List(size);
   auto xstride = XlaHelpers::I64List(stride);
   if (!AsStrided::StrideIsSupported(self_tensor->shape(), xsize, xstride,
                                     storage_offset.value_or(0))) {
-    std::cout << "WONJOO: as_strided_ fallback" << std::endl;
     return at::native::call_fallback_fn<
         &xla_cpu_fallback, ATEN_OP(as_strided_)>::call(self, size, stride,
                                                        storage_offset);

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3319,6 +3319,7 @@ XLANativeFunctions::convolution_backward(
     at::IntArrayRef stride, at::IntArrayRef padding, at::IntArrayRef dilation,
     bool transposed, at::IntArrayRef output_padding, int64_t groups,
     ::std::array<bool, 3> output_mask) {
+  // See Note: [Disabling functionalization]
   if (xla::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
     return at::native::call_fallback_fn<
         &xla_cpu_fallback, ATEN_OP(convolution_backward)>::call(grad_output,
@@ -3331,7 +3332,6 @@ XLANativeFunctions::convolution_backward(
                                                                 groups,
                                                                 output_mask);
   }
-
   // TODO (alanwaketan): Let's resuse
   // `at::functionalization::functionalize_aten_op` after upstream has solved
   // its issue.
@@ -3387,6 +3387,7 @@ at::Tensor XLANativeFunctions::new_empty_strided_symint(
     const at::Tensor& self, at::SymIntArrayRef size, at::SymIntArrayRef stride,
     c10::optional<at::ScalarType> dtype, c10::optional<at::Layout> layout,
     c10::optional<at::Device> device, c10::optional<bool> pin_memory) {
+  // See Note: [Disabling functionalization]
   if (xla::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
     return at::native::new_empty_strided_symint(self, size, stride, dtype,
                                                 layout, device, pin_memory);
@@ -3431,6 +3432,7 @@ at::Tensor XLANativeFunctions::select_backward_symint(
 
 at::Tensor XLANativeFunctions::select_symint(const at::Tensor& self,
                                              int64_t dim, c10::SymInt index) {
+  // See Note: [Disabling functionalization]
   if (xla::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
     return select_copy(self, dim, index.expect_int());
   }
@@ -3441,6 +3443,7 @@ at::Tensor XLANativeFunctions::select_symint(const at::Tensor& self,
 at::Tensor XLANativeFunctions::slice(const at::Tensor& self, int64_t dim,
                                      c10::optional<int64_t> start,
                                      c10::optional<int64_t> end, int64_t step) {
+  // See Note: [Disabling functionalization]
   if (xla::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
     return slice_copy(self, dim, start, end, step);
   }
@@ -3506,7 +3509,7 @@ at::Tensor XLANativeFunctions::permute(const at::Tensor& self,
       self, dims);
 }
 
-// See note [Disabling Functionalization]
+// For ops below, see note [Disabling Functionalization]
 at::Tensor XLANativeFunctions::as_strided(
     const at::Tensor& self, at::IntArrayRef size, at::IntArrayRef stride,
     c10::optional<int64_t> storage_offset) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3532,6 +3532,22 @@ at::Tensor XLANativeFunctions::diagonal(const at::Tensor& self, int64_t offset,
       tensor_methods::diagonal(bridge::GetXlaTensor(self), offset, dim1, dim2));
 }
 
+at::Tensor XLANativeFunctions::expand_symint(const at::Tensor& self,
+                                             at::SymIntArrayRef sym_size,
+                                             bool implicit) {
+  TORCH_LAZY_FN_COUNTER("xla::");
+  c10::optional<at::IntArrayRef> size = c10::asIntArrayRefSlowOpt(sym_size);
+  if (size.has_value()) {
+    return bridge::AtenFromXlaTensor(tensor_methods::expand(
+        bridge::GetXlaTensor(self), torch::lazy::ToVector<int64_t>(*size)));
+  } else {
+    // at least one of the dimension is symbolic, use the sym_int version of the
+    // node
+    return bridge::AtenFromXlaTensor(
+        tensor_methods::expand_symint(bridge::GetXlaTensor(self), sym_size));
+  }
+}
+
 at::Tensor XLANativeFunctions::view_symint(const at::Tensor& self,
                                            at::SymIntArrayRef sym_size) {
   // TODO: support symbolic sizes

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -376,6 +376,7 @@ supported:
   - as_strided
   - as_strided_
   - diagonal
+  - view
 symint:
   - embedding
   - empty.memory_format
@@ -389,6 +390,8 @@ symint:
   - select.int
   # See Note: [functionalization and CompositeExplicitAutograd]
   - reshape
+  # See Note: [Disabling functionalization]
+  - view
 autograd:
   - einsum
   - max_pool2d

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -376,6 +376,7 @@ supported:
   - as_strided
   - as_strided_
   - diagonal
+  - expand
   - view
 symint:
   - embedding
@@ -391,6 +392,7 @@ symint:
   # See Note: [functionalization and CompositeExplicitAutograd]
   - reshape
   # See Note: [Disabling functionalization]
+  - expand
   - view
 autograd:
   - einsum

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -288,7 +288,6 @@ supported:
   - scatter.value_reduce
   - scatter_add
   - scatter_reduce.two
-  - select.int
   - select_copy.int
   - select_scatter
   - selu_

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -372,6 +372,10 @@ supported:
   # The same applies to these ops, but we already have direct lowerings for them
   # - logsumexp.out
   # Note: [Disabling functionalization]
+  # The ops below are no longer needed when functionalization is enabled. 
+  # However, we sometimes may want to disable functionalization (A/B testing,
+  # debugging, etc). The ops below exist only to disable functionalization,
+  # new features/functionalities should not depend on these ops.
   - as_strided
   - as_strided_
   - diagonal

--- a/xla_native_functions.yaml
+++ b/xla_native_functions.yaml
@@ -372,6 +372,10 @@ supported:
   - permute
   # The same applies to these ops, but we already have direct lowerings for them
   # - logsumexp.out
+  # Note: [Disabling functionalization]
+  - as_strided
+  - as_strided_
+  - diagonal
 symint:
   - embedding
   - empty.memory_format


### PR DESCRIPTION
Add support for XLA_DISABLE_FUNCTIONALIZATION flag
    
This change adds support for XLA_DISABLE_FUNCTIONALIZATION. This involves restoring some of the deleted ops when we enabled functionalization and updating some ops to fall back to pre-functionalization state. This change also adds a new test suite that runs test_operations.py with functionalization disabled. 


Test plan: `source run_tests.sh` and CI

---
Ops that are completely restored:
  - as_strided
  - as_strided_
  - diagonal
  - expand
  - view

Ops that are modified by checking `XLA_DISABLE_FUNCTIONALIZATION` flag
- convolution_backward
- new_empty_strided_symint
- select_symint
- slice
- as_strided

---
Skipped tests (these two tests were added as part of the funtionalization commit, skipping when `XLA_DISABLE_FUNCTIONALIZATION` is set to true)
- test_replace_xla_tensor
- test_set

Fixed tests
- test_ailing_slice (`slice`)
- test_as_strided (`as_strided`, `as_strided_`)
- test_conv2d_backward (`convlution_backward`)
- test_diagonal (`diagonal`)
- test_expand (`expand`)
- test_flip (`view`)
- test_index_bool (`select_symint`)
- test_inplace_view (`view`, `new_empty_strided_symint`)
- test_matmul_integer_types (`view`)
- test_negative_slice (`slice`)
- test_pred_one_hot (`select_symint`)
- test_rrelu_module (`select_symint`)
- test_slice (`slice`)
- test_spooky_ailing (`select_symint`)
- test_squeeze_nonzero (`new_empty_strided_symint`)
- test_view_1718 (`view`)
- test_view_and_copy_ (`view`)
- test_view_out_computation (`view`)
- TestParallelTensorMNIST.test (`convlution_backward`)
- TestParallelTensorResnet18.test (`convlution_backward`)

cc @alanwaketan 