### PR TITLE
[FSDP] Adopts XLA_DISABLE_FUNCTIONALIZATION

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -147,6 +147,7 @@ function run_torch_xla_tests() {
       if [ -x "$(command -v nvidia-smi)" ]; then
         PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
         PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --auto_wrap_policy type_based --use_small_fake_sample --num_epochs=1
+        XLA_DISABLE_FUNCTIONALIZATION=1 PJRT_DEVICE=GPU python test/test_train_mp_mnist_fsdp_with_ckpt.py --batch_size 16 --drop_last --num_epochs 2 --use_nested_fsdp
         # Syncfree SGD optimizer tests
         if [ -d ./torch_xla/amp/syncfree ]; then
           echo "Running Syncfree Optimizer Test"

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -147,7 +147,7 @@ function run_torch_xla_tests() {
       if [ -x "$(command -v nvidia-smi)" ]; then
         PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
         PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --auto_wrap_policy type_based --use_small_fake_sample --num_epochs=1
-        XLA_DISABLE_FUNCTIONALIZATION=1 PJRT_DEVICE=GPU python test/test_train_mp_mnist_fsdp_with_ckpt.py --batch_size 16 --drop_last --num_epochs 2 --use_nested_fsdp
+        XLA_DISABLE_FUNCTIONALIZATION=1 PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
         # Syncfree SGD optimizer tests
         if [ -d ./torch_xla/amp/syncfree ]; then
           echo "Running Syncfree Optimizer Test"

--- a/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
+++ b/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
@@ -40,7 +40,9 @@ from .wrap import recursive_wrap
 from ._init_utils import _materialize_module
 
 import os
-XLA_DISABLE_FUNCTIONALIZATION = bool(os.environ['XLA_DISABLE_FUNCTIONALIZATION'])
+
+XLA_DISABLE_FUNCTIONALIZATION = bool(
+    os.environ['XLA_DISABLE_FUNCTIONALIZATION'])
 
 FLOAT_DTYPES = [torch.float32, torch.float16, torch.bfloat16]
 
@@ -1416,17 +1418,19 @@ class XlaFullyShardedDataParallel(nn.Module):
         with torch.autograd._unsafe_preserve_version_counter(p):
           if self._shard_param_on_dim_0:
             if XLA_DISABLE_FUNCTIONALIZATION:
-              p.data = p_padded[:p_shard._orig_size[0]]  # Old behavior before Functionalization.
+              p.data = p_padded[:p_shard._orig_size[
+                  0]]  # Old behavior before Functionalization.
             else:
               torch_xla._XLAC._replace_xla_tensor(
-                p, p_padded[:p_shard._orig_size[0]])
+                  p, p_padded[:p_shard._orig_size[0]])
           else:
             if XLA_DISABLE_FUNCTIONALIZATION:
-              p.data = p_padded[:p_shard._orig_size.numel()].view(p_shard._orig_size)  # Old behavior before Functionalization.
+              p.data = p_padded[:p_shard._orig_size.numel()].view(
+                  p_shard._orig_size)  # Old behavior before Functionalization.
             else:
               torch_xla._XLAC._replace_xla_tensor(
-                p,
-                p_padded[:p_shard._orig_size.numel()].view(p_shard._orig_size))
+                  p, p_padded[:p_shard._orig_size.numel()].view(
+                      p_shard._orig_size))
         p._has_full_param = True
 
     self.has_full_params = True

--- a/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
+++ b/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
@@ -42,7 +42,7 @@ from ._init_utils import _materialize_module
 import os
 
 XLA_DISABLE_FUNCTIONALIZATION = bool(
-    os.environ['XLA_DISABLE_FUNCTIONALIZATION'])
+    os.environ.get('XLA_DISABLE_FUNCTIONALIZATION', False))
 
 FLOAT_DTYPES = [torch.float32, torch.float16, torch.bfloat16]
 


### PR DESCRIPTION
Summary:
Functionalization introduces a huge memory regression around 59% for GPT-2 with FSDP. The regression comes from two parts:
1. one is just introduced by funtionalization mechanism.
2. another is bought by the torch_xla._XLAC._replace_xla_tensor() change.
We already have the XLA_DISABLE_FUNCTIONALIZATION flag to workaround the 1st part, and then here we adopt the flag to workaround the 2nd part.

Test Plan:
XLA_DISABLE_FUNCTIONALIZATION=1 PJRT_DEVICE=TPU python test/test_train_mp_mnist_fsdp_with_ckpt.py --batch_size 16 --drop_last --num_epochs 2 --use_nested_fsdp --metrics_debug