### PR TITLE
[Profiler] Introduce trace_me decorator

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1899,6 +1899,15 @@ class XpTraceTest(test_utils.XlaTestCase):
       with xp.Trace('conv1'):
         xm.mark_step()
 
+  def test_non_empty_scope_decorator(self):
+    @xp.trace_me("conv2")
+    def func():
+      xm.mark_step()
+
+    with self.assertRaisesRegex(
+        RuntimeError, r'Expecting scope to be empty but it is conv2'):
+      func()
+
 
 class RegisterXLAKeyTest(test_utils.XlaTestCase):
 

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1900,12 +1900,13 @@ class XpTraceTest(test_utils.XlaTestCase):
         xm.mark_step()
 
   def test_non_empty_scope_decorator(self):
+
     @xp.trace_me("conv2")
     def func():
       xm.mark_step()
 
-    with self.assertRaisesRegex(
-        RuntimeError, r'Expecting scope to be empty but it is conv2'):
+    with self.assertRaisesRegex(RuntimeError,
+                                r'Expecting scope to be empty but it is conv2'):
       func()
 
 

--- a/torch_xla/debug/profiler.py
+++ b/torch_xla/debug/profiler.py
@@ -160,11 +160,16 @@ class StepTrace(Trace):
     xm.mark_step()
     super().__exit__(type, value, traceback)
 
+
 def trace_me(scope: str):
+
   def decorator_trace_me(func):
+
     @functools.wraps(func)
     def wrapper_trace_me(*args, **kwargs):
-        with Trace(scope):
-          return func(*args, **kwargs)
+      with Trace(scope):
+        return func(*args, **kwargs)
+
     return wrapper_trace_me
+
   return decorator_trace_me

--- a/torch_xla/debug/profiler.py
+++ b/torch_xla/debug/profiler.py
@@ -1,3 +1,4 @@
+import functools
 import torch_xla
 import torch_xla.core.xla_model as xm
 
@@ -158,3 +159,12 @@ class StepTrace(Trace):
       del self.scope
     xm.mark_step()
     super().__exit__(type, value, traceback)
+
+def trace_me(scope: str):
+  def decorator_trace_me(func):
+    @functools.wraps(func)
+    def wrapper_trace_me(*args, **kwargs):
+        with Trace(scope):
+          return func(*args, **kwargs)
+    return wrapper_trace_me
+  return decorator_trace_me


### PR DESCRIPTION
Summary:
This pull request introduces a new profiler API called trace_me decorator. I find it very tedious if I want to scope a method as I need to first use the `xp.Trace("")` context manager and then indent the whole method. Now, you can just do:
```python
import torch_xla.debug.profiler as xp

@xp.trace_me("forward")
def forward:
...
```

Test Plan:
PJRT_DEVICE=CPU python test/test_operations.py -v -k XpTraceTest