### PR TITLE
Update python to 3.9 for GPU colab wheels

### DIFF
--- a/contrib/colab/DC-GAN.ipynb
+++ b/contrib/colab/DC-GAN.ipynb
@@ -55,7 +55,7 @@
     }
    ],
    "source": [
-    "!pip install cloud-tpu-client==0.10 torch==2.0.0 torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-2.0-cp39-cp39-linux_x86_64.whl"
+    "#!pip install cloud-tpu-client==0.10 torch==2.0.0 torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-2.0-cp39-cp39-linux_x86_64.whl"
    ]
   },
   {
@@ -69,13 +69,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "id": "J1Vfg-rH8bF4"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Defaulting to user installation because normal site-packages is not writeable\n",
+      "\u001b[31mERROR: torch_xla-2.0-cp39-cp39-linux_x86_64.whl is not a supported wheel on this platform.\u001b[0m\u001b[31m\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
    "source": [
-    "#!pip install cloud-tpu-client==0.10 torch==2.0.0 torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp38-cp38-linux_x86_64.whl --force-reinstall "
+    "!pip install cloud-tpu-client==0.10 torch==2.0.0 torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp39-cp39-linux_x86_64.whl --force-reinstall "
    ]
   },
   {

--- a/contrib/colab/Distributing_Large_Embedding_tables.ipynb
+++ b/contrib/colab/Distributing_Large_Embedding_tables.ipynb
@@ -69,7 +69,7 @@
    },
    "outputs": [],
    "source": [
-    "#!pip install cloud-tpu-client==0.10 torch==2.0.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp38-cp38-linux_x86_64.whl --force-reinstall "
+    "#!pip install cloud-tpu-client==0.10 torch==2.0.0 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp39-cp39-linux_x86_64.whl --force-reinstall "
    ]
   },
   {

--- a/contrib/colab/getting-started.ipynb
+++ b/contrib/colab/getting-started.ipynb
@@ -96,7 +96,7 @@
    },
    "outputs": [],
    "source": [
-    "#!pip install cloud-tpu-client==0.10 torch==2.0.0  torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp38-cp38-linux_x86_64.whl --force-reinstall "
+    "#!pip install cloud-tpu-client==0.10 torch==2.0.0  torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp39-cp39-linux_x86_64.whl --force-reinstall "
    ]
   },
   {

--- a/contrib/colab/issue-report.ipynb
+++ b/contrib/colab/issue-report.ipynb
@@ -38,7 +38,7 @@
    },
    "outputs": [],
    "source": [
-    "#!pip install cloud-tpu-client==0.10 torch==2.0.0 torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp38-cp38-linux_x86_64.whl --force-reinstall "
+    "#!pip install cloud-tpu-client==0.10 torch==2.0.0 torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp39-cp39-linux_x86_64.whl --force-reinstall "
    ]
   },
   {

--- a/contrib/colab/mnist-training.ipynb
+++ b/contrib/colab/mnist-training.ipynb
@@ -77,7 +77,7 @@
    },
    "outputs": [],
    "source": [
-    "#!pip install cloud-tpu-client==0.10 torch==2.0.0 torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp38-cp38-linux_x86_64.whl --force-reinstall "
+    "#!pip install cloud-tpu-client==0.10 torch==2.0.0 torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp39-cp39-linux_x86_64.whl --force-reinstall "
    ]
   },
   {

--- a/contrib/colab/multi-core-alexnet-fashion-mnist.ipynb
+++ b/contrib/colab/multi-core-alexnet-fashion-mnist.ipynb
@@ -71,7 +71,7 @@
    },
    "outputs": [],
    "source": [
-    "#!pip install cloud-tpu-client==0.10 torch==2.0.0 torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp38-cp38-linux_x86_64.whl --force-reinstall "
+    "#!pip install cloud-tpu-client==0.10 torch==2.0.0 torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp39-cp39-linux_x86_64.whl --force-reinstall "
    ]
   },
   {

--- a/contrib/colab/resnet18-training.ipynb
+++ b/contrib/colab/resnet18-training.ipynb
@@ -49,7 +49,7 @@
    },
    "outputs": [],
    "source": [
-    "#!pip install cloud-tpu-client==0.10 torch==2.0.0 torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp38-cp38-linux_x86_64.whl --force-reinstall "
+    "#!pip install cloud-tpu-client==0.10 torch==2.0.0 torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp39-cp39-linux_x86_64.whl --force-reinstall "
    ]
   },
   {

--- a/contrib/colab/resnet50-inference.ipynb
+++ b/contrib/colab/resnet50-inference.ipynb
@@ -76,7 +76,7 @@
    },
    "outputs": [],
    "source": [
-    "#!pip install cloud-tpu-client==0.10 torch==2.0.0 torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp38-cp38-linux_x86_64.whl --force-reinstall "
+    "#!pip install cloud-tpu-client==0.10 torch==2.0.0 torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp39-cp39-linux_x86_64.whl --force-reinstall "
    ]
   },
   {

--- a/contrib/colab/single-core-alexnet-fashion-mnist.ipynb
+++ b/contrib/colab/single-core-alexnet-fashion-mnist.ipynb
@@ -59,7 +59,7 @@
    },
    "outputs": [],
    "source": [
-    "#!pip install cloud-tpu-client==0.10 torch==2.0.0 torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp38-cp38-linux_x86_64.whl --force-reinstall "
+    "#!pip install cloud-tpu-client==0.10 torch==2.0.0 torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp39-cp39-linux_x86_64.whl --force-reinstall "
    ]
   },
   {

--- a/contrib/colab/style_transfer_inference.ipynb
+++ b/contrib/colab/style_transfer_inference.ipynb
@@ -83,7 +83,7 @@
    },
    "outputs": [],
    "source": [
-    "#!pip install cloud-tpu-client==0.10 torch==2.0.0 torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp38-cp38-linux_x86_64.whl --force-reinstall "
+    "#!pip install cloud-tpu-client==0.10 torch==2.0.0 torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp39-cp39-linux_x86_64.whl --force-reinstall "
    ]
   },
   {

--- a/contrib/colab/xla_builder_autograd.ipynb
+++ b/contrib/colab/xla_builder_autograd.ipynb
@@ -55,7 +55,7 @@
    },
    "outputs": [],
    "source": [
-    "#!pip install cloud-tpu-client==0.10 torch==2.0.0 torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp38-cp38-linux_x86_64.whl --force-reinstall "
+    "#!pip install cloud-tpu-client==0.10 torch==2.0.0 torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp39-cp39-linux_x86_64.whl --force-reinstall "
    ]
   },
   {


### PR DESCRIPTION
Testing: Try the following in a Colab notebook on GPU 
```
!pip install cloud-tpu-client==0.10 torch==2.0.0 torchvision==0.15.1 https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp39-cp39-linux_x86_64.whl --force-reinstall 
```