### PR TITLE
[FSDP] Don't use detach in _rebuild_full_params

### DIFF
--- a/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
+++ b/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
@@ -1390,7 +1390,7 @@ class XlaFullyShardedDataParallel(nn.Module):
 
     for p, p_shard in zip(self.full_params, self.sharded_params):
       if not p._has_full_param:
-        p_shard_data = p_shard.detach()
+        p_shard_data = p_shard
         if apply_opt_barrier:
           self.optimization_barrier_op([p_shard_data])
         if p_shard_data.dtype != self.compute_dtype:


### PR DESCRIPTION
Summary:
Somehow the `detach_copy` implementation has some issues with FSDP that it messed up with FSDP's memory management mechanism. Let's not use it.

Before:
![image](https://user-images.githubusercontent.com/8573935/227429128-9082a4c3-396a-4fe0-8e99-c8da2feac138.png)

After:
![image](https://user-images.githubusercontent.com/8573935/227429170-bb46a416-a128-4ceb-9bc7-42c29d427f38.png)

Test Plan:
CI.