### PR TITLE
[Functionalization] Slightly improve detach_copy

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1103,10 +1103,7 @@ at::Tensor XLANativeFunctions::cumsum(const at::Tensor& self, int64_t dim,
 // TODO(alanwaketan): Let's rewrite a without reusing other native functions.
 at::Tensor XLANativeFunctions::detach_copy(const at::Tensor& self) {
   TORCH_LAZY_FN_COUNTER("xla::");
-  auto new_tensor =
-      empty_symint(self.sym_sizes(), at::typeMetaToScalarType(self.dtype()),
-                   c10::nullopt, self.device(), c10::nullopt, c10::nullopt);
-  return set_(new_tensor, self);
+  return bridge::AtenFromXlaTensor(bridge::GetXlaTensor(self));
 }
 
 at::Tensor XLANativeFunctions::diag(const at::Tensor& self, int64_t diagonal) {


### PR DESCRIPTION
Summary:
Somehow the current `detach_copy` has increased the memory usage of GPT-2 with FSDP a lot, see #4813. We may not implement it correctly. This fix won't fix the memory overhead as well.

Test Plan:
CI.