### PR TITLE
[PJRT] Count TPU chips by PCI IDs

### DIFF
--- a/test/pjrt/test_experimental_tpu.py
+++ b/test/pjrt/test_experimental_tpu.py
@@ -33,11 +33,16 @@ class TestExperimentalTpu(parameterized.TestCase):
   def test_num_available_chips(self, num_tpu_chips):
     vendor_id_files = []
     vendor_ids = ['0x1234', '0x4321', '0xabcd'
-                 ] + [f'0x{tpu._GOOGLE_PCI_VENDOR_ID}'] * num_tpu_chips
-    for v in vendor_ids:
-      f = self.create_tempfile()
-      f.write_text(v)
-      vendor_id_files.append(f.full_path)
+                 ] + [tpu._GOOGLE_PCI_VENDOR_ID] * num_tpu_chips
+    for vendor in vendor_ids:
+      tmpdir = self.create_tempdir()
+      vendor_file = tmpdir.create_file('vendor', content=vendor)
+
+      device = tpu._TPU_PCI_DEVICE_IDS[
+          0] if vendor == tpu._GOOGLE_PCI_VENDOR_ID else '0x7890'
+      tmpdir.create_file('device', content=device)
+
+      vendor_id_files.append(vendor_file.full_path)
 
     with mock.patch.object(glob, 'glob', return_value=vendor_id_files):
       self.assertEqual(tpu.num_available_chips(), num_tpu_chips)

--- a/test/pjrt/test_experimental_tpu.py
+++ b/test/pjrt/test_experimental_tpu.py
@@ -32,7 +32,7 @@ class TestExperimentalTpu(parameterized.TestCase):
   )
   def test_num_available_chips(self, num_tpu_chips):
     vendor_id_files = []
-    vendor_ids = ['0x1234', '0x4321', 'abcd'
+    vendor_ids = ['0x1234', '0x4321', '0xabcd'
                  ] + [f'0x{tpu._GOOGLE_PCI_VENDOR_ID}'] * num_tpu_chips
     for v in vendor_ids:
       f = self.create_tempfile()

--- a/test/pjrt/test_experimental_tpu.py
+++ b/test/pjrt/test_experimental_tpu.py
@@ -25,15 +25,15 @@ class TestExperimentalTpu(parameterized.TestCase):
 
     self.assertEqual(n, expected)
 
-
   @parameterized.named_parameters(
-    ('no_chips', 0),
-    ('one_chip', 1),
-    ('four_chips', 4),
+      ('no_chips', 0),
+      ('one_chip', 1),
+      ('four_chips', 4),
   )
   def test_num_available_chips(self, num_tpu_chips):
     vendor_id_files = []
-    vendor_ids = ['0x1234', '0x4321', 'abcd'] + [f'0x{tpu._GOOGLE_PCI_VENDOR_ID}'] * num_tpu_chips
+    vendor_ids = ['0x1234', '0x4321', 'abcd'
+                 ] + [f'0x{tpu._GOOGLE_PCI_VENDOR_ID}'] * num_tpu_chips
     for v in vendor_ids:
       f = self.create_tempfile()
       f.write_text(v)
@@ -41,7 +41,6 @@ class TestExperimentalTpu(parameterized.TestCase):
 
     with mock.patch.object(glob, 'glob', return_value=vendor_id_files):
       self.assertEqual(tpu.num_available_chips(), num_tpu_chips)
-
 
   @parameterized.named_parameters(
       ('default_one_host', None, 4),

--- a/test/pjrt/test_experimental_tpu.py
+++ b/test/pjrt/test_experimental_tpu.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import textwrap
 
@@ -23,6 +24,24 @@ class TestExperimentalTpu(parameterized.TestCase):
       n = tpu.process_bounds_size()
 
     self.assertEqual(n, expected)
+
+
+  @parameterized.named_parameters(
+    ('no_chips', 0),
+    ('one_chip', 1),
+    ('four_chips', 4),
+  )
+  def test_num_available_chips(self, num_tpu_chips):
+    vendor_id_files = []
+    vendor_ids = ['0x1234', '0x4321', 'abcd'] + [f'0x{tpu._GOOGLE_PCI_VENDOR_ID}'] * num_tpu_chips
+    for v in vendor_ids:
+      f = self.create_tempfile()
+      f.write_text(v)
+      vendor_id_files.append(f.full_path)
+
+    with mock.patch.object(glob, 'glob', return_value=vendor_id_files):
+      self.assertEqual(tpu.num_available_chips(), num_tpu_chips)
+
 
   @parameterized.named_parameters(
       ('default_one_host', None, 4),

--- a/torch_xla/experimental/tpu.py
+++ b/torch_xla/experimental/tpu.py
@@ -84,7 +84,8 @@ def num_available_chips() -> int:
   """Returns the number of TPU chips attached through PCI."""
   pci_vendors_files = glob.glob('/sys/bus/pci/devices/*/vendor')
   pci_vendors = [
-    pathlib.Path(path).read_text().strip() for path in pci_vendors_files]
+      pathlib.Path(path).read_text().strip() for path in pci_vendors_files
+  ]
   # HACK: Assumes all Google devices are TPU chips
   num_chips = pci_vendors.count(f'0x{_GOOGLE_PCI_VENDOR_ID}')
   return num_chips


### PR DESCRIPTION
Following up on this conversation: https://github.com/pytorch/xla/pull/4720#discussion_r1125172534

This is more future-proof than checking for just `/dev/accel*`, since Google's PCI vendor ID and device IDs will be consistent across machines.