### PR TITLE
[PJRT] Improve `HasValue()` error message

### DIFF
--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -164,7 +164,7 @@ class PjRtComputationClient : public ComputationClient {
         : Data(std::move(device), std::move(device_shape)), buffer(buffer) {}
 
     OpaqueHandle GetOpaqueHandle() override {
-      XLA_CHECK(HasValue());
+      XLA_CHECK(HasValue()) << (buffer == nullptr ? "buffer is null" : "buffer is deleted");
       return reinterpret_cast<std::uintptr_t>(buffer.get());
     };
     void Assign(const Data& data) override;

--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -164,7 +164,8 @@ class PjRtComputationClient : public ComputationClient {
         : Data(std::move(device), std::move(device_shape)), buffer(buffer) {}
 
     OpaqueHandle GetOpaqueHandle() override {
-      XLA_CHECK(HasValue()) << (buffer == nullptr ? "buffer is null" : "buffer is deleted");
+      XLA_CHECK(HasValue())
+          << (buffer == nullptr ? "buffer is null" : "buffer is deleted");
       return reinterpret_cast<std::uintptr_t>(buffer.get());
     };
     void Assign(const Data& data) override;


### PR DESCRIPTION
The current error looks something like this:

```
RuntimeError: ./third_party/xla_client/pjrt_computation_client.h:167 : Check failed: HasValue() 
```

This can either mean the buffer is null _or_ a non-null buffer has been deleted by the runtime. But, we don't actually tell the user or developer which one of these is true, which makes debugging harder than it has to be.

cc @gkroiz 