### PR TITLE
Add support to build PyTorch/XLA with PyTorch installed from pip.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,11 +74,24 @@ To build from source:
   sudo apt-get update
   ```
 
-* Build _PyTorch_ from source following the regular [instructions](https://github.com/pytorch/pytorch#from-source).
+* Prepare _PyTorch_.
 
-  ```Shell
-  python setup.py install
-  ```
+  * You can either build _PyTorch_ from source following the regular [instructions](https://github.com/pytorch/pytorch#from-source).
+
+    ```Shell
+    python setup.py install
+    ```
+
+  * or install PyTorch from PyPI source. The PyTorch version should match with your XLA branch.
+
+    ```Shell
+    # Use CPU version PyTorch if you are building PyTorch/XLA without CUDA support
+    # Otherwise use the regular version.
+    pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+
+    # Export this environment variable before build the PyTorch/XLA source
+    export BUILD_CPP_TESTS_USE_SITE_PYTORCH=1
+    ```
 
 * Install Bazelisk following the [instructions](https://github.com/bazelbuild/bazelisk#requirements). Bazelisk automatically picks a good version of Bazel for PyTorch/XLA build.
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,10 @@
 #   BUILD_CPP_TESTS=1
 #     build the C++ tests
 #
+#   BUILD_CPP_TESTS_USE_SITE_PYTORCH=0
+#     build the C++ tests with PyTorch installed in python site packages
+#     instead of local compiled PyTorch source directory.
+#
 #   XLA_DEBUG=0
 #     build the xla/xrt client in debug mode
 #

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -7,7 +7,14 @@ endif()
 set(GTEST_DIR "${CMAKE_BINARY_DIR}/gtest")
 
 get_filename_component(PTXLA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." ABSOLUTE)
-get_filename_component(PT_DIR "${PTXLA_DIR}/.." ABSOLUTE)
+
+set(USE_SITELIB_PYTORCH $ENV{BUILD_CPP_TESTS_USE_SITE_PYTORCH})
+if (NOT ${USE_SITELIB_PYTORCH} STREQUAL "1")
+  get_filename_component(PT_DIR "${PTXLA_DIR}/.." ABSOLUTE)
+else()
+  message("Python library path: ${PYTHON_LIBRARY_DIR}")
+  set(PT_DIR ${PYTHON_LIBRARY_DIR})
+endif()
 
 file(GLOB PTXLA_LIBDIRS "${PTXLA_DIR}/build/lib.*")
 list(GET PTXLA_LIBDIRS 0 PTXLA_LIBDIR)

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -57,6 +57,7 @@ pushd "$BUILDDIR"
 cmake "$RUNDIR" \
   -DCMAKE_BUILD_TYPE=$BUILDTYPE \
   -DPYTHON_INCLUDE_DIR=$(python -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())") \
+  -DPYTHON_LIBRARY_DIR=$(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())") \
   -DPYTHON_LIBRARY=$(python -c "import distutils.sysconfig as sysconfig; print(sysconfig.get_config_var('LIBDIR') + '/' + sysconfig.get_config_var('LDLIBRARY'))")
 make -j $VERB
 


### PR DESCRIPTION
Add a new env var BUILD_CPP_TESTS_USE_SITE_PYTORCH to fix the build of cpp test with PyTorch installed from pip.