### PR TITLE
Apply input sharding to all compatible input tensors

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -10,6 +10,7 @@ import torch
 import torch.nn.functional as F
 import torch_xla
 from torch_xla.experimental import pjrt
+import torch_xla.experimental.xla_sharding as xs
 import torch_xla.core.xla_env_vars as xenv
 import torch_xla.debug.metrics_saver as ms
 import torch_xla.utils.utils as xu
@@ -1080,15 +1081,17 @@ def _maybe_convert_to_cpu(data, convert=True):
   return ToXlaTensorArena(convert_fn, select_fn).transform(data)
 
 
-def send_cpu_data_to_device(data, device, input_sharding=None):
+def send_cpu_data_to_device(data,
+                            device,
+                            input_sharding: xs.ShardingSpec = None):
 
   def convert_fn(tensors):
     devices = [str(device)] * len(tensors)
     xtensors = torch_xla._XLAC._xla_tensors_from_aten(tensors, devices)
     if input_sharding:
-      assert(len(xtensors) == 2), \
-        f"Expected input data and label pair, but got {xtensors}."
-      input_sharding.apply(xtensors[0])
+      for xtensor in xtensors:
+        if input_sharding.can_apply(xtensor):
+          input_sharding.apply(xtensor)
     return xtensors
 
   def select_fn(v):

--- a/torch_xla/distributed/parallel_loader.py
+++ b/torch_xla/distributed/parallel_loader.py
@@ -72,6 +72,9 @@ class ParallelLoader(object):
     host_to_device_transfer_threads (int, optional): The number of threads that
       work in parallel to transfer data from loader queue to device queue.
       Default: 1
+    input_sharding (ShardingSpec, optional): Sharding spec to apply to
+      compatible input tensors after loading.
+      Default: None
   """
 
   def __init__(self,

--- a/torch_xla/experimental/xla_sharding.py
+++ b/torch_xla/experimental/xla_sharding.py
@@ -148,6 +148,12 @@ class ShardingSpec:
   mesh: Mesh
   partition_spec: Tuple[Union[int, None]]
 
+  def can_apply(self, t: torch.Tensor) -> bool:
+    """
+    Test whether the ShardingSpec is compatible with the given torch.Tensor.
+    """
+    return len(self.partition_spec) == len(t.shape)
+
   def apply(self, t: torch.Tensor):
     # TODO(yeounoh) use virtual device interface when available.
     assert (t.device == xm.xla_device())


### PR DESCRIPTION
The existing implementation expects a single (input, label) pair, but in practice we see multiple such pairs or, in the case of GPT-2, input_ids and attention_mask. This change will support these additional use cases.