### PR TITLE
Use 'HEAD' instead of 'master' for PyTorch sources clone

### DIFF
--- a/docker/experimental/Dockerfile
+++ b/docker/experimental/Dockerfile
@@ -45,7 +45,7 @@ RUN pip install mkl mkl-include setuptools typing_extensions cmake requests
 RUN git clone --depth=1 https://github.com/pytorch/pytorch.git
 WORKDIR /pytorch
 COPY torch_patches/ torch_patches/
-RUN bash -c 'torch_pin=$(cat torch_patches/.torch_pin &); git fetch origin ${torch_pin:-master}; git checkout FETCH_HEAD'
+RUN bash -c 'torch_pin=$(cat torch_patches/.torch_pin &); git fetch origin ${torch_pin:-HEAD}; git checkout FETCH_HEAD'
 RUN git submodule update --init --recursive
 RUN find torch_patches -name '*.diff' | xargs -t -r -n 1 patch -N -p1 -l -i
 


### PR DESCRIPTION
PyTorch repo changed their default branch from master to main and removed most of the files in the master.
This PR fixes the reference. 

This fixes [ci-tpu-test-trigger](https://pantheon.corp.google.com/cloud-build/triggers;region=global/edit/167e62a3-3607-4862-8baf-8ed484132844?project=tpu-pytorch), see [fixed build](https://pantheon.corp.google.com/cloud-build/builds;region=global/2729ace0-d6ab-4c0e-a27e-d5a4d04f9913?project=tpu-pytorch) (running on this branch).