### PR TITLE
[Draft] Move partition outside of extract_compile_graph for dynamo CPU fallback

### DIFF
--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -820,10 +820,7 @@ std::vector<bool> check_materialization_helper(
         need_materialization.push_back(true);
       }
     } else {
-      // TODO: maybe also handle it is a XLATensor with tensor_data case
-      XLA_CHECK(false)
-          << "_check_tensor_need_materialization "
-             "currently does not handle XLATensor without XLAData and IR";
+			need_materialization.push_back(true);
     }
   }
   return need_materialization;


### PR DESCRIPTION
In this PR, I modified the cpu fallback logic, where I move the capability partitioner outside of `extract_compile_graph`. I rename the original function into `extract_internal`, which will be called by the fused graphs (i.e., the graphs that can be lowered to XLA). In this code, I hardcoded the OP check function to ensure my test works. This is the test that I use:
```python
import torch
import torch_xla

import torch_xla.core.xla_model as xm
import torch_xla.debug.metrics as met
import torch._dynamo as dynamo
    
@dynamo.optimize("torchxla_trace_once")
def fn_fallback(M, mat1, mat2, beta):
    # xla currently only support alpha and beta == 1
    A = torch.cummin(M, 1)
    B = torch.add(A[0], mat1)
    return torch.add(B, mat2)
    
M = torch.randn(5, 10, device=xm.xla_device())
mat1 = torch.randn(5, 10, device=xm.xla_device())
mat2 = torch.randn(5, 10, device=xm.xla_device())  
      
res = fn_fallback(M, mat1, mat2, 0.5)
        
print(res)
```
The `torch.cummin` function cannot be lowered to XLA. With my code, the above code can work successfully without having any issue.

----
Graph after partitioning
```
def forward(self, L_M_ : torch.Tensor, L_mat1_ : torch.Tensor, L_mat2_ : torch.Tensor):
    l_m_ = L_M_
    l_mat1_ = L_mat1_
    l_mat2_ = L_mat2_
    cummin = torch.cummin(l_m_, 1);  l_m_ = None
    getitem = cummin[0];  cummin = None
    fused_0 = self.fused_0(getitem, l_mat1_, l_mat2_);  getitem = l_mat1_ = l_mat2_ = None
    return (fused_0,)
```
You can see that the two `torch.add` functions are fused.

cc @alanwaketan 