### PR TITLE
[Distributed] Remove sea-of-devices mode

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -420,11 +420,7 @@ def _get_all_reduce_token():
   return token, devctx
 
 
-def all_reduce(reduce_type,
-               inputs,
-               scale=1.0,
-               groups=None,
-               pin_layout=True):
+def all_reduce(reduce_type, inputs, scale=1.0, groups=None, pin_layout=True):
   """Performs an inplace reduce operation on the input tensor(s).
 
   Args:
@@ -455,9 +451,8 @@ def all_reduce(reduce_type,
   token, devctx = _get_all_reduce_token()
   groups = groups or []
   if isinstance(inputs, torch.Tensor):
-    result = torch_xla._XLAC._xla_all_reduce(reduce_type, inputs, token,
-                                              scale, groups,
-                                              pin_layout)
+    result = torch_xla._XLAC._xla_all_reduce(reduce_type, inputs, token, scale,
+                                             groups, pin_layout)
     devctx.all_reduce_token = result[1]
     results = [result[0]]
   else:

--- a/torch_xla/distributed/xla_multiprocessing.py
+++ b/torch_xla/distributed/xla_multiprocessing.py
@@ -132,8 +132,7 @@ def _setup_world_size(pf_cfg):
   if pf_cfg.dev_kind == 'CPU':
     # Since XLA CPU does not support across device reduces, and suport only one
     # device per process, we make each CPU device look like if it was a single
-    # process host, and use torch.distributed for inter-host reductions (like in
-    # the sea-of-devices case).
+    # process host, and use torch.distributed for inter-host reductions.
     os.environ[xenv.HOST_WORLD_SIZE] = str(world_size)
   else:
     os.environ[xenv.HOST_WORLD_SIZE] = str(host_world_size)


### PR DESCRIPTION
Summary:
This change removes sea-of-devices mode which is no longer valid and simply the code in all_reduce a lot. This is the 1st step to adopt pytorch/pytorch#93173.

Test Plan:
PJRT_DEVICE=TPU python test/test_mp_sync_batch_norm.py
PJRT_DEVICE=TPU python test/test_mp_replication.py
and CI...