### PR TITLE
Pin setuptools version to fix vision build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,7 +56,8 @@ RUN if [ "${git_clone}" = "true" ]; then \
   echo "\nxla_branch: ${xla_branch} example_branch: ${example_branch} \n" && \
   cd /pytorch && \
   rm -rf xla && \
-  git clone -b "${xla_branch}" --recursive https://github.com/pytorch/xla && \
+  # Temp fix ti make trigger to pick up the right branch for build
+  git clone -b JackCaoG/fix_vision_build --recursive https://github.com/pytorch/xla && \
   cd / && \
   git clone -b "${example_branch}" --recursive https://github.com/pytorch-tpu/examples tpu-examples; fi
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,8 +56,7 @@ RUN if [ "${git_clone}" = "true" ]; then \
   echo "\nxla_branch: ${xla_branch} example_branch: ${example_branch} \n" && \
   cd /pytorch && \
   rm -rf xla && \
-  # Temp fix ti make trigger to pick up the right branch for build
-  git clone -b JackCaoG/fix_vision_build --recursive https://github.com/pytorch/xla && \
+  git clone -b "${xla_branch}" --recursive https://github.com/pytorch/xla && \
   cd / && \
   git clone -b "${example_branch}" --recursive https://github.com/pytorch-tpu/examples tpu-examples; fi
 

--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -199,7 +199,7 @@ function install_and_setup_conda() {
   conda activate "$ENVNAME"
   export CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 
-  conda install -y numpy pyyaml setuptools cmake cffi typing tqdm coverage tensorboard hypothesis dataclasses
+  conda install -y numpy pyyaml setuptools==65.6.3 cmake cffi typing tqdm coverage tensorboard hypothesis dataclasses
   if [[ $(uname -m) == "x86_64" ]]; then
     # Overwrite mkl packages here, since nomkl conflicts with the anaconda env setup.
     conda remove -y tbb


### PR DESCRIPTION
Currently wheel build failed with 
```
Step #0: + git clone -b main https://github.com/pytorch/vision.git
Step #0:  [0m [91mCloning into 'vision'...
Step #0:  [0m/pytorch/vision /pytorch
Step #0:  [91m+ pushd vision
Step #0: + python setup.py bdist_wheel
Step #0:  [0m [91mTraceback (most recent call last):
Step #0:   File "setup.py", line 68, in <module>
Step #0:     pillow_req = "pillow-simd" if get_dist("pillow-simd") is not None else "pillow"
Step #0:   File "setup.py", line 22, in get_dist
Step #0:     return get_distribution(pkgname)
Step #0:   File "/root/anaconda3/envs/pytorch/lib/python3.8/site-packages/pkg_resources/__init__.py", line 514, in get_distribution
Step #0:     dist = get_provider(dist)
Step #0:   File "/root/anaconda3/envs/pytorch/lib/python3.8/site-packages/pkg_resources/__init__.py", line 386, in get_provider
Step #0:     return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]
Step #0:   File "/root/anaconda3/envs/pytorch/lib/python3.8/site-packages/pkg_resources/__init__.py", line 956, in require
Step #0:     needed = self.resolve(parse_requirements(requirements))
Step #0:   File "/root/anaconda3/envs/pytorch/lib/python3.8/site-packages/pkg_resources/__init__.py", line 815, in resolve
Step #0:     dist = self._resolve_dist(
Step #0:   File "/root/anaconda3/envs/pytorch/lib/python3.8/site-packages/pkg_resources/__init__.py", line 844, in _resolve_dist
Step #0:     env = Environment(self.entries)
Step #0:   File "/root/anaconda3/envs/pytorch/lib/python3.8/site-packages/pkg_resources/__init__.py", line 1044, in __init__
Step #0:     self.scan(search_path)
Step #0:   File "/root/anaconda3/envs/pytorch/lib/python3.8/site-packages/pkg_resources/__init__.py", line 1077, in scan
Step #0:     self.add(dist)
Step #0:   File "/root/anaconda3/envs/pytorch/lib/python3.8/site-packages/pkg_resources/__init__.py", line 1096, in add
Step #0:     dists.sort(key=operator.attrgetter('hashcmp'), reverse=True)
Step #0:   File "/root/anaconda3/envs/pytorch/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2631, in hashcmp
Step #0:     self.parsed_version,
Step #0:   File "/root/anaconda3/envs/pytorch/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2678, in parsed_version
Step #0:     self._parsed_version = parse_version(self.version)
Step #0:   File "/root/anaconda3/envs/pytorch/lib/python3.8/site-packages/pkg_resources/_vendor/packaging/version.py", line 266, in __init__
Step #0:     raise InvalidVersion(f"Invalid version: '{version}'")
Step #0: pkg_resources.extern.packaging.version.InvalidVersion: Invalid version: '4.0.0-unsupported'
Step #0: The command '/bin/sh -c cd /pytorch/xla && bash scripts/build_torch_wheels.sh ${python_version} ${release_version} ${build_cpp_tests}' returned a non-zero code: 1

```

which I confirmed is caused by the setuptools `66.0.0`. Need to run trigger to confirm this will fix the build