### PR TITLE
[PJRT] Make `rendezvous` optional in `xm.save`

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -1031,11 +1031,7 @@ def optimizer_step(optimizer,
   return loss
 
 
-def save(data,
-         file_or_path,
-         master_only=True,
-         global_master=False,
-         sync=True):
+def save(data, file_or_path, master_only=True, global_master=False, sync=True):
   """Saves the input data into a file.
 
   The saved data is transferred to PyTorch CPU device before being saved, so a

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -1035,7 +1035,7 @@ def save(data,
          file_or_path,
          master_only=True,
          global_master=False,
-         rendezvous=True):
+         sync=True):
   """Saves the input data into a file.
 
   The saved data is transferred to PyTorch CPU device before being saved, so a
@@ -1060,9 +1060,9 @@ def save(data,
       controls whether every host's master (if ``global_master`` is ``False``)
       saves the content, or only the global master (ordinal 0).
       Default: False
-    rendezvous (bool, optional): Whether to synchronize all replicas after
-      saving tensors. If True, all replicas must call `xm.save` or the main
-      process will hang.
+    sync (bool, optional): Whether to synchronize all replicas after saving
+      tensors. If True, all replicas must call `xm.save` or the main process
+      will hang.
   """
   should_write_data = not master_only or is_master_ordinal(
       local=not global_master)
@@ -1070,7 +1070,7 @@ def save(data,
   cpu_data = _maybe_convert_to_cpu(data, convert=should_write_data)
   if should_write_data:
     torch.save(cpu_data, file_or_path)
-  if rendezvous:
+  if sync:
     rendezvous('torch_xla.core.xla_model.save')
 
 


### PR DESCRIPTION
In particular, the `accelerator.save_state` function is only called by the master in HuggingFace Accelerate. If we try to rendezvous with the other replicas, then the `rendezvous` call will hang forever.

Tested with [my WIP fork of HF Accelerate](https://github.com/will-cromar/accelerate/tree/wcromar/pjrt).