### PR TITLE
Revert "Apply input sharding to all compatible input tensors"

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -10,7 +10,6 @@ import torch
 import torch.nn.functional as F
 import torch_xla
 from torch_xla.experimental import pjrt
-import torch_xla.experimental.xla_sharding as xs
 import torch_xla.core.xla_env_vars as xenv
 import torch_xla.debug.metrics_saver as ms
 import torch_xla.utils.utils as xu
@@ -1081,17 +1080,15 @@ def _maybe_convert_to_cpu(data, convert=True):
   return ToXlaTensorArena(convert_fn, select_fn).transform(data)
 
 
-def send_cpu_data_to_device(data,
-                            device,
-                            input_sharding: xs.ShardingSpec = None):
+def send_cpu_data_to_device(data, device, input_sharding=None):
 
   def convert_fn(tensors):
     devices = [str(device)] * len(tensors)
     xtensors = torch_xla._XLAC._xla_tensors_from_aten(tensors, devices)
     if input_sharding:
-      for xtensor in xtensors:
-        if input_sharding.can_apply(xtensor):
-          input_sharding.apply(xtensor)
+      assert(len(xtensors) == 2), \
+        f"Expected input data and label pair, but got {xtensors}."
+      input_sharding.apply(xtensors[0])
     return xtensors
 
   def select_fn(v):

--- a/torch_xla/distributed/parallel_loader.py
+++ b/torch_xla/distributed/parallel_loader.py
@@ -72,9 +72,6 @@ class ParallelLoader(object):
     host_to_device_transfer_threads (int, optional): The number of threads that
       work in parallel to transfer data from loader queue to device queue.
       Default: 1
-    input_sharding (ShardingSpec, optional): Sharding spec to apply to
-      compatible input tensors after loading.
-      Default: None
   """
 
   def __init__(self,

--- a/torch_xla/experimental/xla_sharding.py
+++ b/torch_xla/experimental/xla_sharding.py
@@ -148,12 +148,6 @@ class ShardingSpec:
   mesh: Mesh
   partition_spec: Tuple[Union[int, None]]
 
-  def can_apply(self, t: torch.Tensor) -> bool:
-    """
-    Test whether the ShardingSpec is compatible with the given torch.Tensor.
-    """
-    return len(self.partition_spec) == len(t.shape)
-
   def apply(self, t: torch.Tensor):
     # TODO(yeounoh) use virtual device interface when available.
     assert (t.device == xm.xla_device())


### PR DESCRIPTION
Reverts pytorch/xla#4872

This breaks mnist.
```
root@t1v-n-307ffe96-w-0:/workspaces/work/pytorch/xla# PJRT_DEVICE=TPU python test/test_train_mp_mnist.py --num_epochs=1
Traceback (most recent call last):
  File "test/test_train_mp_mnist.py", line 2, in <module>
    from torch_xla.experimental import pjrt
  File "/workspaces/work/pytorch/xla/torch_xla/experimental/pjrt.py", line 14, in <module>
    import torch_xla.core.xla_model as xm
  File "/workspaces/work/pytorch/xla/torch_xla/core/xla_model.py", line 11, in <module>
    import torch_xla.experimental.xla_sharding as xs
  File "/workspaces/work/pytorch/xla/torch_xla/experimental/xla_sharding.py", line 10, in <module>
    from torch_xla.experimental.pjrt import requires_pjrt
ImportError: cannot import name 'requires_pjrt' from partially initialized module 'torch_xla.experimental.pjrt' (most likely due to a circular import) (/workspaces/work/pytorch/xla/torch_xla/experimental/pjrt.py)
```