### PR TITLE
[Distributed] Move the cached all reduce token to C++

### DIFF
--- a/test/test_zero1.py
+++ b/test/test_zero1.py
@@ -11,7 +11,8 @@ import unittest
 class XlaZeRO1Test(unittest.TestCase):
 
   @unittest.skipIf(pjrt.device_type() == 'TPU', "Crash on TPU")
-  @unittest.skipIf(pjrt.device_type() == 'GPU', "TODO(alanwaketan): Fix it for the token change.")
+  @unittest.skipIf(pjrt.device_type() == 'GPU',
+                   "TODO(alanwaketan): Fix it for the token change.")
   def test_zero1(self):
     device = xm.xla_device()
 

--- a/test/test_zero1.py
+++ b/test/test_zero1.py
@@ -11,6 +11,7 @@ import unittest
 class XlaZeRO1Test(unittest.TestCase):
 
   @unittest.skipIf(pjrt.device_type() == 'TPU', "Crash on TPU")
+  @unittest.skipIf(pjrt.device_type() == 'GPU', "TODO(alanwaketan): Fix it for the token change.")
   def test_zero1(self):
     device = xm.xla_device()
 

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -452,8 +452,9 @@ def all_reduce(reduce_type, inputs, scale=1.0, groups=None, pin_layout=True):
     torch_xla._XLAC._set_all_reduce_token(result[1])
     results = [result[0]]
   else:
-    torch_xla._XLAC._set_all_reduce_token(torch_xla._XLAC._xla_all_reduce_inplace(
-        reduce_type, inputs, token, scale, groups, pin_layout))
+    torch_xla._XLAC._set_all_reduce_token(
+        torch_xla._XLAC._xla_all_reduce_inplace(reduce_type, inputs, token,
+                                                scale, groups, pin_layout))
     results = inputs
 
   return results[0] if isinstance(inputs, torch.Tensor) else results

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -412,10 +412,7 @@ def _fetch_gradients(optimizer):
 
 def _get_all_reduce_token():
   devctx = _get_device_context()
-  token = getattr(devctx, 'all_reduce_token', None)
-  if token is None:
-    token = torch_xla._XLAC._xla_create_token(devctx.device)
-    devctx.all_reduce_token = token
+  token = torch_xla._XLAC._get_all_reduce_token(devctx.device)
   return token, devctx
 
 

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -272,7 +272,7 @@ def set_replication(device, devices):
   else:
     torch_xla._XLAC._xla_set_replication_devices([])
     devctx.device_index = 0
-  torch_xla._XLAC._set_all_reduce_token(None)
+  torch_xla._XLAC._set_all_reduce_token(devctx.device, None)
   torch_xla._XLAC._xla_set_default_device(device)
 
 
@@ -449,10 +449,10 @@ def all_reduce(reduce_type, inputs, scale=1.0, groups=None, pin_layout=True):
   if isinstance(inputs, torch.Tensor):
     result = torch_xla._XLAC._xla_all_reduce(reduce_type, inputs, token, scale,
                                              groups, pin_layout)
-    torch_xla._XLAC._set_all_reduce_token(result[1])
+    torch_xla._XLAC._set_all_reduce_token(devctx.device, result[1])
     results = [result[0]]
   else:
-    torch_xla._XLAC._set_all_reduce_token(
+    torch_xla._XLAC._set_all_reduce_token(devctx.device,
         torch_xla._XLAC._xla_all_reduce_inplace(reduce_type, inputs, token,
                                                 scale, groups, pin_layout))
     results = inputs
@@ -546,12 +546,12 @@ def all_gather(value, dim=0, groups=None, output=None, pin_layout=True):
     new_token = torch_xla._XLAC._xla_all_gather_out(output, value, token, dim,
                                                     shard_count, groups or [],
                                                     pin_layout)
-    torch_xla._XLAC._set_all_reduce_token(new_token)
+    torch_xla._XLAC._set_all_reduce_token(devctx.device, new_token)
     return output
 
   result = torch_xla._XLAC._xla_all_gather(value, token, dim, shard_count,
                                            groups or [], pin_layout)
-  torch_xla._XLAC._set_all_reduce_token(result[1])
+  torch_xla._XLAC._set_all_reduce_token(devctx.device, result[1])
   return result[0]
 
 
@@ -588,7 +588,7 @@ def all_to_all(value,
   result = torch_xla._XLAC._xla_all_to_all(value, token, split_dimension,
                                            concat_dimension, split_count,
                                            groups or [], pin_layout)
-  torch_xla._XLAC._set_all_reduce_token(result[1])
+  torch_xla._XLAC._set_all_reduce_token(devctx.device, result[1])
   return result[0]
 
 
@@ -613,7 +613,7 @@ def collective_permute(value, pairs):
   """
   token, devctx = _get_all_reduce_token()
   result = torch_xla._XLAC._xla_collective_permute(value, token, pairs)
-  torch_xla._XLAC._set_all_reduce_token(result[1])
+  torch_xla._XLAC._set_all_reduce_token(devctx.device, result[1])
   return result[0]
 
 
@@ -663,7 +663,7 @@ def send(value, channel_id):
   # The input will be returned as result.
   input_as_result, new_token = torch_xla._XLAC._xla_send(
       value, token, channel_id)
-  torch_xla._XLAC._set_all_reduce_token(new_token)
+  torch_xla._XLAC._set_all_reduce_token(devctx.device, new_token)
   return input_as_result
 
 
@@ -678,7 +678,7 @@ def recv(output, channel_id):
   """
   token, devctx = _get_all_reduce_token()
   result, new_token = torch_xla._XLAC._xla_recv(output, token, channel_id)
-  torch_xla._XLAC._set_all_reduce_token(new_token)
+  torch_xla._XLAC._set_all_reduce_token(devctx.device, new_token)
   return result
 
 
@@ -727,13 +727,13 @@ def reduce_scatter(reduce_type,
                                                         scatter_dim,
                                                         shard_count, groups or
                                                         [], pin_layout)
-    torch_xla._XLAC._set_all_reduce_token(new_token)
+    torch_xla._XLAC._set_all_reduce_token(devctx.device, new_token)
     return output
 
   result = torch_xla._XLAC._xla_reduce_scatter(reduce_type, input, token, scale,
                                                scatter_dim, shard_count,
                                                groups or [], pin_layout)
-  torch_xla._XLAC._set_all_reduce_token(result[1])
+  torch_xla._XLAC._set_all_reduce_token(devctx.device, result[1])
   return result[0]
 
 
@@ -803,7 +803,7 @@ def mark_step(wait=False):
   if is_master_ordinal():
     ms.save_metrics()
   devctx = _run_step_closures()
-  torch_xla._XLAC._set_all_reduce_token(None)
+  torch_xla._XLAC._set_all_reduce_token(devctx.device, None)
 
 
 def wait_device_ops(devices=[]):

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -452,7 +452,8 @@ def all_reduce(reduce_type, inputs, scale=1.0, groups=None, pin_layout=True):
     torch_xla._XLAC._set_all_reduce_token(devctx.device, result[1])
     results = [result[0]]
   else:
-    torch_xla._XLAC._set_all_reduce_token(devctx.device,
+    torch_xla._XLAC._set_all_reduce_token(
+        devctx.device,
         torch_xla._XLAC._xla_all_reduce_inplace(reduce_type, inputs, token,
                                                 scale, groups, pin_layout))
     results = inputs

--- a/torch_xla/csrc/cross_replica_reduces.cpp
+++ b/torch_xla/csrc/cross_replica_reduces.cpp
@@ -85,7 +85,8 @@ std::vector<xla::ReplicaGroup> CreateReduceGroups(
   return reduce_groups;
 }
 
-std::shared_ptr<torch::lazy::Value> CreateToken(const torch::lazy::BackendDevice& device) {
+std::shared_ptr<torch::lazy::Value> CreateToken(
+    const torch::lazy::BackendDevice& device) {
   // This should be using xla::CreateToken() once we have added Token support to
   // XLA AllReduce(). Meanwhile we use a constant as token, and we handle it
   // accordingly in cross_replica_reduces.cpp.
@@ -274,7 +275,8 @@ ReduceScatterResult BuildReduceScatter(
   return {reduce_result, token_handler.GetNewToken(reduce_result)};
 }
 
-const torch::lazy::Value& GetAllReduceToken(const torch::lazy::BackendDevice& device) {
+const torch::lazy::Value& GetAllReduceToken(
+    const torch::lazy::BackendDevice& device) {
   if (!g_token) {
     g_token = CreateToken(device);
   }

--- a/torch_xla/csrc/cross_replica_reduces.cpp
+++ b/torch_xla/csrc/cross_replica_reduces.cpp
@@ -281,4 +281,8 @@ const torch::lazy::Value& GetAllReduceToken(const torch::lazy::BackendDevice& de
   return *g_token;
 }
 
+void ResetAllReduceToken() {
+  g_token.reset();
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/cross_replica_reduces.cpp
+++ b/torch_xla/csrc/cross_replica_reduces.cpp
@@ -281,8 +281,8 @@ const torch::lazy::Value& GetAllReduceToken(const torch::lazy::BackendDevice& de
   return *g_token;
 }
 
-void ResetAllReduceToken() {
-  g_token.reset();
+void SetAllReduceToken(const std::shared_ptr<torch::lazy::Value>& token) {
+  g_token = token;
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/cross_replica_reduces.cpp
+++ b/torch_xla/csrc/cross_replica_reduces.cpp
@@ -11,9 +11,12 @@
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/layout_manager.h"
 #include "torch_xla/csrc/token_handler.h"
+#include "torch_xla/csrc/xla_graph_executor.h"
 
 namespace torch_xla {
 namespace {
+
+thread_local std::shared_ptr<torch::lazy::Value> g_token;
 
 struct PerTypeContext {
   std::vector<xla::XlaOp> ops;
@@ -80,6 +83,18 @@ std::vector<xla::ReplicaGroup> CreateReduceGroups(
     reduce_groups.push_back(std::move(rgroup));
   }
   return reduce_groups;
+}
+
+std::shared_ptr<torch::lazy::Value> CreateToken(const torch::lazy::BackendDevice& device) {
+  // This should be using xla::CreateToken() once we have added Token support to
+  // XLA AllReduce(). Meanwhile we use a constant as token, and we handle it
+  // accordingly in cross_replica_reduces.cpp.
+  // This needs to be device data (hence coming in as XLA computation parameter)
+  // as otherwise the XLA compiler passes will remove it, vanishing its
+  // sequencing effects.
+  torch::lazy::Value ir_value = XLAGraphExecutor::Get()->GetDeviceDataIrValue(
+      0.0, xla::PrimitiveType::F32, device);
+  return std::make_shared<torch::lazy::Value>(std::move(ir_value));
 }
 
 }  // namespace
@@ -257,6 +272,13 @@ ReduceScatterResult BuildReduceScatter(
   }
 
   return {reduce_result, token_handler.GetNewToken(reduce_result)};
+}
+
+const torch::lazy::Value& GetAllReduceToken(const torch::lazy::BackendDevice& device) {
+  if (!g_token) {
+    g_token = CreateToken(device);
+  }
+  return *g_token;
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/cross_replica_reduces.cpp
+++ b/torch_xla/csrc/cross_replica_reduces.cpp
@@ -16,8 +16,8 @@
 namespace torch_xla {
 namespace {
 
-// For V3, we have 4 processes and each process has 2 threads to manage the 8
-// cores. Therefore, we need different tokens for different threads.
+// For V3-8 + PJRT, we have 4 processes and each process has 2 threads to manage
+// the 8 cores. Therefore, we need different tokens for different threads.
 std::unordered_map<int64_t, std::shared_ptr<torch::lazy::Value>>
     g_all_reduce_tokens;
 

--- a/torch_xla/csrc/cross_replica_reduces.cpp
+++ b/torch_xla/csrc/cross_replica_reduces.cpp
@@ -16,9 +16,10 @@
 namespace torch_xla {
 namespace {
 
-// For V3, we have 4 processes and each process has 2 threads to manage the 8 cores.
-// Therefore, we need different tokens for different threads.
-std::unordered_map<int64_t, std::shared_ptr<torch::lazy::Value>> g_all_reduce_tokens;
+// For V3, we have 4 processes and each process has 2 threads to manage the 8
+// cores. Therefore, we need different tokens for different threads.
+std::unordered_map<int64_t, std::shared_ptr<torch::lazy::Value>>
+    g_all_reduce_tokens;
 
 struct PerTypeContext {
   std::vector<xla::XlaOp> ops;
@@ -287,7 +288,8 @@ const torch::lazy::Value& GetAllReduceToken(
   return *it->second;
 }
 
-void SetAllReduceToken(const torch::lazy::BackendDevice& device, const std::shared_ptr<torch::lazy::Value>& token) {
+void SetAllReduceToken(const torch::lazy::BackendDevice& device,
+                       const std::shared_ptr<torch::lazy::Value>& token) {
   g_all_reduce_tokens[device.ordinal()] = token;
 }
 

--- a/torch_xla/csrc/cross_replica_reduces.h
+++ b/torch_xla/csrc/cross_replica_reduces.h
@@ -79,5 +79,6 @@ ReduceScatterResult BuildReduceScatter(
     const std::vector<std::vector<int64_t>>& groups, bool pin_layout);
 
 const torch::lazy::Value& GetAllReduceToken();
+void ResetAllReduceToken();
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/cross_replica_reduces.h
+++ b/torch_xla/csrc/cross_replica_reduces.h
@@ -80,6 +80,6 @@ ReduceScatterResult BuildReduceScatter(
     const std::vector<std::vector<int64_t>>& groups, bool pin_layout);
 
 const torch::lazy::Value& GetAllReduceToken(const torch::lazy::BackendDevice& device);
-void ResetAllReduceToken();
+void SetAllReduceToken(const std::shared_ptr<torch::lazy::Value>& token);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/cross_replica_reduces.h
+++ b/torch_xla/csrc/cross_replica_reduces.h
@@ -81,6 +81,7 @@ ReduceScatterResult BuildReduceScatter(
 
 const torch::lazy::Value& GetAllReduceToken(
     const torch::lazy::BackendDevice& device);
-void SetAllReduceToken(const torch::lazy::BackendDevice& device, const std::shared_ptr<torch::lazy::Value>& token);
+void SetAllReduceToken(const torch::lazy::BackendDevice& device,
+                       const std::shared_ptr<torch::lazy::Value>& token);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/cross_replica_reduces.h
+++ b/torch_xla/csrc/cross_replica_reduces.h
@@ -4,6 +4,7 @@
 
 #include "absl/types/span.h"
 #include "tensorflow/compiler/xla/client/xla_builder.h"
+#include "torch/csrc/lazy/core/ir.h"
 
 namespace torch_xla {
 
@@ -76,5 +77,7 @@ ReduceScatterResult BuildReduceScatter(
     AllReduceType reduce_type, xla::XlaOp input, xla::XlaOp token, double scale,
     int64_t scatter_dim, int64_t shard_count,
     const std::vector<std::vector<int64_t>>& groups, bool pin_layout);
+
+const torch::lazy::Value& GetAllReduceToken();
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/cross_replica_reduces.h
+++ b/torch_xla/csrc/cross_replica_reduces.h
@@ -79,7 +79,8 @@ ReduceScatterResult BuildReduceScatter(
     int64_t scatter_dim, int64_t shard_count,
     const std::vector<std::vector<int64_t>>& groups, bool pin_layout);
 
-const torch::lazy::Value& GetAllReduceToken(const torch::lazy::BackendDevice& device);
+const torch::lazy::Value& GetAllReduceToken(
+    const torch::lazy::BackendDevice& device);
 void SetAllReduceToken(const std::shared_ptr<torch::lazy::Value>& token);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/cross_replica_reduces.h
+++ b/torch_xla/csrc/cross_replica_reduces.h
@@ -81,6 +81,6 @@ ReduceScatterResult BuildReduceScatter(
 
 const torch::lazy::Value& GetAllReduceToken(
     const torch::lazy::BackendDevice& device);
-void SetAllReduceToken(const std::shared_ptr<torch::lazy::Value>& token);
+void SetAllReduceToken(const torch::lazy::BackendDevice& device, const std::shared_ptr<torch::lazy::Value>& token);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/cross_replica_reduces.h
+++ b/torch_xla/csrc/cross_replica_reduces.h
@@ -5,6 +5,7 @@
 #include "absl/types/span.h"
 #include "tensorflow/compiler/xla/client/xla_builder.h"
 #include "torch/csrc/lazy/core/ir.h"
+#include "torch_xla/csrc/device.h"
 
 namespace torch_xla {
 
@@ -78,7 +79,7 @@ ReduceScatterResult BuildReduceScatter(
     int64_t scatter_dim, int64_t shard_count,
     const std::vector<std::vector<int64_t>>& groups, bool pin_layout);
 
-const torch::lazy::Value& GetAllReduceToken();
+const torch::lazy::Value& GetAllReduceToken(const torch::lazy::BackendDevice& device);
 void ResetAllReduceToken();
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1602,14 +1602,14 @@ void InitXlaModuleBindings(py::module m) {
           return XLANativeFunctions::set_(self, source);
         });
   m.def("_get_all_reduce_token",
-      [](const std::string& device_str) -> const torch::lazy::Value& {
-        auto device = GetDeviceOrCurrent(device_str);
-        return GetAllReduceToken(device);
-      });
+        [](const std::string& device_str) -> const torch::lazy::Value& {
+          auto device = GetDeviceOrCurrent(device_str);
+          return GetAllReduceToken(device);
+        });
   m.def("_set_all_reduce_token",
-    [](const std::shared_ptr<torch::lazy::Value>& token) {
-      SetAllReduceToken(token);
-    });
+        [](const std::shared_ptr<torch::lazy::Value>& token) {
+          SetAllReduceToken(token);
+        });
 
   /* The distributed runtime service is used by the PjRt GPU client. */
   py::class_<xla::DistributedRuntimeService,

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1607,8 +1607,9 @@ void InitXlaModuleBindings(py::module m) {
           return GetAllReduceToken(device);
         });
   m.def("_set_all_reduce_token",
-        [](const std::shared_ptr<torch::lazy::Value>& token) {
-          SetAllReduceToken(token);
+        [](const std::string& device_str, const std::shared_ptr<torch::lazy::Value>& token) {
+          auto device = GetDeviceOrCurrent(device_str);
+          SetAllReduceToken(device, token);
         });
 
   /* The distributed runtime service is used by the PjRt GPU client. */

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1621,9 +1621,9 @@ void InitXlaModuleBindings(py::module m) {
         auto device = GetDeviceOrCurrent(device_str);
         return GetAllReduceToken(device);
       });
-  m.def("_reset_all_reduce_token",
-    []() {
-      ResetAllReduceToken();
+  m.def("_set_all_reduce_token",
+    [](const std::shared_ptr<torch::lazy::Value>& token) {
+      SetAllReduceToken(token);
     });
 
   /* The distributed runtime service is used by the PjRt GPU client. */

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1607,7 +1607,8 @@ void InitXlaModuleBindings(py::module m) {
           return GetAllReduceToken(device);
         });
   m.def("_set_all_reduce_token",
-        [](const std::string& device_str, const std::shared_ptr<torch::lazy::Value>& token) {
+        [](const std::string& device_str,
+           const std::shared_ptr<torch::lazy::Value>& token) {
           auto device = GetDeviceOrCurrent(device_str);
           SetAllReduceToken(device, token);
         });

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1616,6 +1616,15 @@ void InitXlaModuleBindings(py::module m) {
         [](at::Tensor& self, const at::Tensor& source) -> at::Tensor& {
           return XLANativeFunctions::set_(self, source);
         });
+  m.def("_get_all_reduce_token",
+      [](const std::string& device_str) -> const torch::lazy::Value& {
+        auto device = GetDeviceOrCurrent(device_str);
+        return GetAllReduceToken(device);
+      });
+  m.def("_reset_all_reduce_token",
+    []() {
+      ResetAllReduceToken();
+    });
 
   /* The distributed runtime service is used by the PjRt GPU client. */
   py::class_<xla::DistributedRuntimeService,

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -1,7 +1,6 @@
 #include "torch_xla/csrc/tensor.h"
 
 #include <algorithm>
-#include <atomic>
 #include <cmath>
 #include <condition_variable>
 #include <exception>

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -3,7 +3,6 @@
 #include <Python.h>
 
 #include <algorithm>
-#include <atomic>
 #include <cmath>
 #include <condition_variable>
 #include <exception>


### PR DESCRIPTION
Summary:
For all the cc ops, we use a token to introduce control dependencies among them such that they will be executed in order. This token is cached in the Python layer and this pull request moves it to C++ given the upcoming https://github.com/pytorch/pytorch/issues/93173 won't carry the token from Python to C++.

Test Plan:
CI.