### PR TITLE
[Distributed] Hide token from Python for _xla_all_reduce path

### DIFF
--- a/test/test_mp_replication.py
+++ b/test/test_mp_replication.py
@@ -11,14 +11,20 @@ def _mp_fn(index):
   if world_size > 1:
     ones = torch.ones((2, 3))
     twos = ones + 1.0
+    threes = ones + 2.0
     xones = ones.to(device)
     xtwos = twos.to(device)
+    xthrees = threes.to(device)
     xm.all_reduce(xm.REDUCE_SUM, [xones, xtwos])
+    xthrees = xm.all_reduce(xm.REDUCE_SUM, xthrees)
 
     if (not xones.cpu().allclose(ones * float(world_size)) or
-        not xtwos.cpu().allclose(twos * float(world_size))):
+        not xtwos.cpu().allclose(twos * float(world_size)) or
+        not xthrees.cpu().allclose(threes * float(world_size))):
       print('xm.all_reduce() produced wrong reductions', file=sys.stderr)
       print(xones, file=sys.stderr)
+      print(xtwos, file=sys.stderr)
+      print(xthrees, file=sys.stderr)
       sys.exit(1)
   else:
     print(

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -444,13 +444,13 @@ def all_reduce(reduce_type, inputs, scale=1.0, groups=None, pin_layout=True):
     this function performs an inplace all-reduce op on the input tensors, and
     returns the list/tuple itself.
   """
-  token, devctx = _get_all_reduce_token()
   groups = groups or []
   if isinstance(inputs, torch.Tensor):
     result = torch_xla._XLAC._xla_all_reduce(reduce_type, inputs, scale,
                                              groups, pin_layout)
     results = [result]
   else:
+    token, _ = _get_all_reduce_token()
     torch_xla._XLAC._set_all_reduce_token(
         devctx.device,
         torch_xla._XLAC._xla_all_reduce_inplace(reduce_type, inputs, token,

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -447,10 +447,9 @@ def all_reduce(reduce_type, inputs, scale=1.0, groups=None, pin_layout=True):
   token, devctx = _get_all_reduce_token()
   groups = groups or []
   if isinstance(inputs, torch.Tensor):
-    result = torch_xla._XLAC._xla_all_reduce(reduce_type, inputs, token, scale,
+    result = torch_xla._XLAC._xla_all_reduce(reduce_type, inputs, scale,
                                              groups, pin_layout)
-    torch_xla._XLAC._set_all_reduce_token(devctx.device, result[1])
-    results = [result[0]]
+    results = [result]
   else:
     torch_xla._XLAC._set_all_reduce_token(
         devctx.device,

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -446,8 +446,8 @@ def all_reduce(reduce_type, inputs, scale=1.0, groups=None, pin_layout=True):
   """
   groups = groups or []
   if isinstance(inputs, torch.Tensor):
-    result = torch_xla._XLAC._xla_all_reduce(reduce_type, inputs, scale,
-                                             groups, pin_layout)
+    result = torch_xla._XLAC._xla_all_reduce(reduce_type, inputs, scale, groups,
+                                             pin_layout)
     results = [result]
   else:
     token, _ = _get_all_reduce_token()

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -450,7 +450,7 @@ def all_reduce(reduce_type, inputs, scale=1.0, groups=None, pin_layout=True):
                                              pin_layout)
     results = [result]
   else:
-    token, _ = _get_all_reduce_token()
+    token, devctx = _get_all_reduce_token()
     torch_xla._XLAC._set_all_reduce_token(
         devctx.device,
         torch_xla._XLAC._xla_all_reduce_inplace(reduce_type, inputs, token,

--- a/torch_xla/csrc/cross_replica_reduces.cpp
+++ b/torch_xla/csrc/cross_replica_reduces.cpp
@@ -293,8 +293,8 @@ void SetAllReduceToken(const torch::lazy::BackendDevice& device,
   g_all_reduce_tokens[device.ordinal()] = token;
 }
 
-void ResetAllReduceToken() {
-  g_token.reset();
+void SetAllReduceToken(const std::shared_ptr<torch::lazy::Value>& token) {
+  g_token = token;
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/cross_replica_reduces.cpp
+++ b/torch_xla/csrc/cross_replica_reduces.cpp
@@ -293,8 +293,4 @@ void SetAllReduceToken(const torch::lazy::BackendDevice& device,
   g_all_reduce_tokens[device.ordinal()] = token;
 }
 
-void SetAllReduceToken(const std::shared_ptr<torch::lazy::Value>& token) {
-  g_token = token;
-}
-
 }  // namespace torch_xla

--- a/torch_xla/csrc/cross_replica_reduces.cpp
+++ b/torch_xla/csrc/cross_replica_reduces.cpp
@@ -293,4 +293,8 @@ void SetAllReduceToken(const torch::lazy::BackendDevice& device,
   g_all_reduce_tokens[device.ordinal()] = token;
 }
 
+void ResetAllReduceToken() {
+  g_token.reset();
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -205,18 +205,14 @@ std::shared_ptr<torch::lazy::Value> AllReduceInPlace(
                                  scale, replica_groups, pin_layout));
 }
 
-std::pair<at::Tensor, std::shared_ptr<torch::lazy::Value>> AllReduce(
+at::Tensor AllReduce(
     const std::string& reduce_type, const at::Tensor& input,
-    const std::shared_ptr<torch::lazy::Value>& token, double scale,
+    double scale,
     const std::vector<std::vector<int64_t>>& replica_groups, bool pin_layout) {
-  XLATensorPtr result;
-  torch::lazy::Value new_token;
-  std::tie(result, new_token) = tensor_methods::all_reduce(
-      bridge::GetXlaTensor(input), *token, GetReduceType(reduce_type), scale,
+  auto result = tensor_methods::all_reduce(
+      bridge::GetXlaTensor(input), GetReduceType(reduce_type), scale,
       replica_groups, pin_layout);
-  return std::pair<at::Tensor, std::shared_ptr<torch::lazy::Value>>(
-      bridge::AtenFromXlaTensor(std::move(result)),
-      std::make_shared<torch::lazy::Value>(new_token));
+  return bridge::AtenFromXlaTensor(std::move(result));
 }
 
 std::pair<at::Tensor, std::shared_ptr<torch::lazy::Value>> ReduceScatter(
@@ -1014,23 +1010,17 @@ void InitXlaModuleBindings(py::module m) {
         return new_token;
       });
   m.def("_xla_all_reduce",
-        [](const std::string& reduce_type, const at::Tensor& input,
-           const std::shared_ptr<torch::lazy::Value>& token, double scale,
+        [](const std::string& reduce_type, const at::Tensor& input, double scale,
            const py::list& groups, bool pin_layout) {
           std::vector<std::vector<int64_t>> replica_groups =
               CreateReduceGroups(groups);
           at::Tensor result;
-          std::shared_ptr<torch::lazy::Value> new_token;
           {
             NoGilSection nogil;
-            std::tie(result, new_token) = AllReduce(
-                reduce_type, input, token, scale, replica_groups, pin_layout);
+            result = AllReduce(
+                reduce_type, input, scale, replica_groups, pin_layout);
           }
-          auto result_tuple = py::tuple(2);
-          result_tuple[0] = torch::autograd::make_variable(
-              result, /*requires_grad=*/input.requires_grad());
-          result_tuple[1] = new_token;
-          return result_tuple;
+          return result;
         });
   m.def("_xla_all_to_all",
         [](const at::Tensor& input,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -337,7 +337,8 @@ XLATensorPtr all_reduce(const XLATensorPtr& input, AllReduceType reduce_type,
   torch::lazy::NodePtr node = torch::lazy::MakeNode<AllReduce>(
       reduce_type, input_values, GetAllReduceToken(input->GetDevice()), scale,
       std::move(groups), pin_layout);
-  SetAllReduceToken(input->GetDevice(), std::make_shared<torch::lazy::Value>(node, 1));
+  SetAllReduceToken(input->GetDevice(),
+                    std::make_shared<torch::lazy::Value>(node, 1));
   return input->CreateFrom(torch::lazy::Value(node, 0));
 }
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -336,7 +336,8 @@ std::pair<XLATensorPtr, torch::lazy::Value> all_reduce(
     std::vector<std::vector<int64_t>> groups, bool pin_layout) {
   std::vector<torch::lazy::Value> input_values({input->GetIrValue()});
   torch::lazy::NodePtr node = torch::lazy::MakeNode<AllReduce>(
-      reduce_type, input_values, token, scale, std::move(groups), pin_layout);
+      reduce_type, input_values, GetAllReduceToken(input->GetDevice()), scale, std::move(groups), pin_layout);
+  SetAllReduceToken(std::make_shared<torch::lazy::Value>(node, 1));
   return {input->CreateFrom(torch::lazy::Value(node, 0)),
           torch::lazy::Value(node, 1)};
 }

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -337,7 +337,7 @@ XLATensorPtr all_reduce(const XLATensorPtr& input, AllReduceType reduce_type,
   torch::lazy::NodePtr node = torch::lazy::MakeNode<AllReduce>(
       reduce_type, input_values, GetAllReduceToken(input->GetDevice()), scale,
       std::move(groups), pin_layout);
-  SetAllReduceToken(std::make_shared<torch::lazy::Value>(node, 1));
+  SetAllReduceToken(input->GetDevice(), std::make_shared<torch::lazy::Value>(node, 1));
   return input->CreateFrom(torch::lazy::Value(node, 0));
 }
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -330,13 +330,13 @@ XLATensorPtr DispatchComparisonOp(c10::Symbol kind, const XLATensorPtr& input,
 //////////////////////////////////////////////////////////////////////////////
 // XLA dedicated operators follows here, listed in alphabetical order.
 //////////////////////////////////////////////////////////////////////////////
-XLATensorPtr all_reduce(
-    const XLATensorPtr& input,
-    AllReduceType reduce_type, double scale,
-    std::vector<std::vector<int64_t>> groups, bool pin_layout) {
+XLATensorPtr all_reduce(const XLATensorPtr& input, AllReduceType reduce_type,
+                        double scale, std::vector<std::vector<int64_t>> groups,
+                        bool pin_layout) {
   std::vector<torch::lazy::Value> input_values({input->GetIrValue()});
   torch::lazy::NodePtr node = torch::lazy::MakeNode<AllReduce>(
-      reduce_type, input_values, GetAllReduceToken(input->GetDevice()), scale, std::move(groups), pin_layout);
+      reduce_type, input_values, GetAllReduceToken(input->GetDevice()), scale,
+      std::move(groups), pin_layout);
   SetAllReduceToken(std::make_shared<torch::lazy::Value>(node, 1));
   return input->CreateFrom(torch::lazy::Value(node, 0));
 }

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -330,16 +330,15 @@ XLATensorPtr DispatchComparisonOp(c10::Symbol kind, const XLATensorPtr& input,
 //////////////////////////////////////////////////////////////////////////////
 // XLA dedicated operators follows here, listed in alphabetical order.
 //////////////////////////////////////////////////////////////////////////////
-std::pair<XLATensorPtr, torch::lazy::Value> all_reduce(
-    const XLATensorPtr& input, const torch::lazy::Value& token,
+XLATensorPtr all_reduce(
+    const XLATensorPtr& input,
     AllReduceType reduce_type, double scale,
     std::vector<std::vector<int64_t>> groups, bool pin_layout) {
   std::vector<torch::lazy::Value> input_values({input->GetIrValue()});
   torch::lazy::NodePtr node = torch::lazy::MakeNode<AllReduce>(
       reduce_type, input_values, GetAllReduceToken(input->GetDevice()), scale, std::move(groups), pin_layout);
   SetAllReduceToken(std::make_shared<torch::lazy::Value>(node, 1));
-  return {input->CreateFrom(torch::lazy::Value(node, 0)),
-          torch::lazy::Value(node, 1)};
+  return input->CreateFrom(torch::lazy::Value(node, 0));
 }
 
 torch::lazy::Value all_reduce_(XLATensorPtr& input,

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -8,8 +8,8 @@ namespace tensor_methods {
 //////////////////////////////////////////////////////////////////////////////
 // XLA dedicated operators follows here, listed in alphabetical order.
 //////////////////////////////////////////////////////////////////////////////
-std::pair<XLATensorPtr, torch::lazy::Value> all_reduce(
-    const XLATensorPtr& input, const torch::lazy::Value& token,
+XLATensorPtr all_reduce(
+    const XLATensorPtr& input,
     AllReduceType reduce_type, double scale,
     std::vector<std::vector<int64_t>> groups, bool pin_layout);
 

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -8,10 +8,9 @@ namespace tensor_methods {
 //////////////////////////////////////////////////////////////////////////////
 // XLA dedicated operators follows here, listed in alphabetical order.
 //////////////////////////////////////////////////////////////////////////////
-XLATensorPtr all_reduce(
-    const XLATensorPtr& input,
-    AllReduceType reduce_type, double scale,
-    std::vector<std::vector<int64_t>> groups, bool pin_layout);
+XLATensorPtr all_reduce(const XLATensorPtr& input, AllReduceType reduce_type,
+                        double scale, std::vector<std::vector<int64_t>> groups,
+                        bool pin_layout);
 
 torch::lazy::Value all_reduce_(XLATensorPtr& input,
                                const torch::lazy::Value& token,


### PR DESCRIPTION
Summary:
Now that we have the token cached in the C++ layer, and we really don't need to expose it to Python anymore. This is a first effort to to route one of the all_reduce to use the C++ cached token and remove the token from the pipes.  This is one of the efforts to integrate https://github.com/pytorch/pytorch/issues/93173.

Test Plan:
PJRT_DEVICE=TPU python test/test_mp_replication.py