### PR TITLE
[Distributed] Adopts traceable all_reduce

### DIFF
--- a/test/test_mp_replication.py
+++ b/test/test_mp_replication.py
@@ -12,15 +12,20 @@ def _mp_fn(index):
     ones = torch.ones((2, 3))
     twos = ones + 1.0
     threes = ones + 2.0
+    fours = ones + 3.0
+    scale = 0.5
     xones = ones.to(device)
     xtwos = twos.to(device)
     xthrees = threes.to(device)
+    xfours = fours.to(device)
     xm.all_reduce(xm.REDUCE_SUM, [xones, xtwos])
     xthrees = xm.all_reduce(xm.REDUCE_SUM, xthrees)
+    xfours = xm.all_reduce(xm.REDUCE_SUM, xfours, scale=scale)
 
     if (not xones.cpu().allclose(ones * float(world_size)) or
         not xtwos.cpu().allclose(twos * float(world_size)) or
-        not xthrees.cpu().allclose(threes * float(world_size))):
+        not xthrees.cpu().allclose(threes * float(world_size)) or
+        not xfours.cpu().allclose(fours * float(world_size) * scale)):
       print('xm.all_reduce() produced wrong reductions', file=sys.stderr)
       print(xones, file=sys.stderr)
       print(xtwos, file=sys.stderr)

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -450,10 +450,11 @@ def all_reduce(reduce_type, inputs, scale=1.0, groups=None, pin_layout=True):
     result = None
     if scale == 1.0 and groups == [] and pin_layout:
       # TODO(alanwaketan): Support groups.
-      result = torch.ops.c10d_functional.all_reduce(inputs, reduce_type, "", [], 0)
+      result = torch.ops.c10d_functional.all_reduce(inputs, reduce_type, "", [],
+                                                    0)
     else:
-      result = torch_xla._XLAC._xla_all_reduce(reduce_type, inputs, scale, groups,
-                                             pin_layout)
+      result = torch_xla._XLAC._xla_all_reduce(reduce_type, inputs, scale,
+                                               groups, pin_layout)
     results = [result]
   else:
     token, devctx = _get_all_reduce_token()

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -450,6 +450,7 @@ def all_reduce(reduce_type, inputs, scale=1.0, groups=None, pin_layout=True):
     result = None
     if scale == 1.0 and groups == [] and pin_layout:
       # TODO(alanwaketan): Support groups.
+      # Only c10d_functional version cc ops are traceable by Dynamo.
       result = torch.ops.c10d_functional.all_reduce(inputs, reduce_type, "", [],
                                                     0)
     else:

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -5,6 +5,7 @@ import threading
 import time
 from typing import List, Optional
 import torch
+import torch.distributed._functional_collectives
 import torch.nn.functional as F
 import torch_xla
 from torch_xla.experimental import pjrt
@@ -446,7 +447,12 @@ def all_reduce(reduce_type, inputs, scale=1.0, groups=None, pin_layout=True):
   """
   groups = groups or []
   if isinstance(inputs, torch.Tensor):
-    result = torch_xla._XLAC._xla_all_reduce(reduce_type, inputs, scale, groups,
+    result = None
+    if scale == 1.0 and groups == [] and pin_layout:
+      # TODO(alanwaketan): Support groups.
+      result = torch.ops.c10d_functional.all_reduce(inputs, reduce_type, "", [], 0)
+    else:
+      result = torch_xla._XLAC._xla_all_reduce(reduce_type, inputs, scale, groups,
                                              pin_layout)
     results = [result]
   else:

--- a/torch_xla/csrc/cross_replica_reduces.cpp
+++ b/torch_xla/csrc/cross_replica_reduces.cpp
@@ -104,19 +104,23 @@ std::shared_ptr<torch::lazy::Value> CreateToken(
 }
 
 ////////////////////////////////////////////////////////////////////////////////////
-// The traceable collectives integration follows here, listed in alphabetical order.
-// RFC: https://github.com/pytorch/pytorch/issues/93173
+// The traceable collectives integration follows here, listed in alphabetical
+// order. RFC: https://github.com/pytorch/pytorch/issues/93173
 ////////////////////////////////////////////////////////////////////////////////////
 
-// tag is ignored as it's only used in PyTorch to provide backward compatibility with the traditional process group API.
-at::Tensor all_reduce(const at::Tensor & self, c10::string_view reduceOp, c10::string_view /*tag*/, at::IntArrayRef /*ranks*/, int64_t /*group_size*/) {
+// tag is ignored as it's only used in PyTorch to provide backward compatibility
+// with the traditional process group API.
+at::Tensor all_reduce(const at::Tensor& self, c10::string_view reduceOp,
+                      c10::string_view /*tag*/, at::IntArrayRef /*ranks*/,
+                      int64_t /*group_size*/) {
   TORCH_LAZY_FN_COUNTER("xla::");
   auto self_tensor = bridge::GetXlaTensor(self);
-  // TODO(alanwaketan): Use ranks and group_size to generate groups. Currently we just suse {} as a workaround.
-  // Scale is always 1.0 here, and we always pin layout.
-  auto result = tensor_methods::all_reduce(
-      self_tensor, GetReduceType(reduceOp), /*scale*/1.0,
-      /*groups*/{}, /*pin_layout*/true);
+  // TODO(alanwaketan): Use ranks and group_size to generate groups. Currently
+  // we just suse {} as a workaround. Scale is always 1.0 here, and we always
+  // pin layout.
+  auto result = tensor_methods::all_reduce(self_tensor, GetReduceType(reduceOp),
+                                           /*scale*/ 1.0,
+                                           /*groups*/ {}, /*pin_layout*/ true);
   return bridge::AtenFromXlaTensor(result);
 }
 

--- a/torch_xla/csrc/cross_replica_reduces.cpp
+++ b/torch_xla/csrc/cross_replica_reduces.cpp
@@ -6,10 +6,12 @@
 #include "third_party/xla_client/debug_macros.h"
 #include "third_party/xla_client/util.h"
 #include "torch/csrc/lazy/core/util.h"
+#include "torch_xla/csrc/aten_xla_bridge.h"
 #include "torch_xla/csrc/convert_ops.h"
 #include "torch_xla/csrc/device.h"
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/layout_manager.h"
+#include "torch_xla/csrc/tensor_methods.h"
 #include "torch_xla/csrc/token_handler.h"
 #include "torch_xla/csrc/xla_graph_executor.h"
 
@@ -99,6 +101,27 @@ std::shared_ptr<torch::lazy::Value> CreateToken(
   torch::lazy::Value ir_value = XLAGraphExecutor::Get()->GetDeviceDataIrValue(
       0.0, xla::PrimitiveType::F32, device);
   return std::make_shared<torch::lazy::Value>(std::move(ir_value));
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// The traceable collectives integration follows here, listed in alphabetical order.
+// RFC: https://github.com/pytorch/pytorch/issues/93173
+////////////////////////////////////////////////////////////////////////////////////
+
+// tag is ignored as it's only used in PyTorch to provide backward compatibility with the traditional process group API.
+at::Tensor all_reduce(const at::Tensor & self, c10::string_view reduceOp, c10::string_view /*tag*/, at::IntArrayRef /*ranks*/, int64_t /*group_size*/) {
+  TORCH_LAZY_FN_COUNTER("xla::");
+  auto self_tensor = bridge::GetXlaTensor(self);
+  // TODO: Use ranks and group_size to generate groups. Currently we just suse {} as a workaround.
+  // Scale is always 1.0 here, and we always pin layout.
+  auto result = tensor_methods::all_reduce(
+      self_tensor, GetReduceType(reduceOp), /*scale*/1.0,
+      /*groups*/{}, /*pin_layout*/true);
+  return bridge::AtenFromXlaTensor(result);
+}
+
+TORCH_LIBRARY_IMPL(c10d_functional, XLA, m) {
+  m.impl("all_reduce", all_reduce);
 }
 
 }  // namespace
@@ -291,6 +314,23 @@ const torch::lazy::Value& GetAllReduceToken(
 void SetAllReduceToken(const torch::lazy::BackendDevice& device,
                        const std::shared_ptr<torch::lazy::Value>& token) {
   g_all_reduce_tokens[device.ordinal()] = token;
+}
+
+AllReduceType GetReduceType(c10::string_view reduce_type) {
+  if (reduce_type == "sum") {
+    return AllReduceType::kSum;
+  } else if (reduce_type == "mul") {
+    return AllReduceType::kMul;
+  } else if (reduce_type == "and") {
+    return AllReduceType::kAnd;
+  } else if (reduce_type == "or") {
+    return AllReduceType::kOr;
+  } else if (reduce_type == "min") {
+    return AllReduceType::kMin;
+  } else if (reduce_type == "max") {
+    return AllReduceType::kMax;
+  }
+  XLA_ERROR() << "Unknown AllReduce type: " << reduce_type;
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/cross_replica_reduces.cpp
+++ b/torch_xla/csrc/cross_replica_reduces.cpp
@@ -112,7 +112,7 @@ std::shared_ptr<torch::lazy::Value> CreateToken(
 at::Tensor all_reduce(const at::Tensor & self, c10::string_view reduceOp, c10::string_view /*tag*/, at::IntArrayRef /*ranks*/, int64_t /*group_size*/) {
   TORCH_LAZY_FN_COUNTER("xla::");
   auto self_tensor = bridge::GetXlaTensor(self);
-  // TODO: Use ranks and group_size to generate groups. Currently we just suse {} as a workaround.
+  // TODO(alanwaketan): Use ranks and group_size to generate groups. Currently we just suse {} as a workaround.
   // Scale is always 1.0 here, and we always pin layout.
   auto result = tensor_methods::all_reduce(
       self_tensor, GetReduceType(reduceOp), /*scale*/1.0,

--- a/torch_xla/csrc/cross_replica_reduces.h
+++ b/torch_xla/csrc/cross_replica_reduces.h
@@ -84,4 +84,6 @@ const torch::lazy::Value& GetAllReduceToken(
 void SetAllReduceToken(const torch::lazy::BackendDevice& device,
                        const std::shared_ptr<torch::lazy::Value>& token);
 
+AllReduceType GetReduceType(c10::string_view reduce_type);
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -154,23 +154,6 @@ std::vector<XLATensorPtr> GetXlaTensors(const std::vector<at::Tensor>& tensors,
   return xtensors;
 }
 
-AllReduceType GetReduceType(const std::string& reduce_type) {
-  if (reduce_type == "sum") {
-    return AllReduceType::kSum;
-  } else if (reduce_type == "mul") {
-    return AllReduceType::kMul;
-  } else if (reduce_type == "and") {
-    return AllReduceType::kAnd;
-  } else if (reduce_type == "or") {
-    return AllReduceType::kOr;
-  } else if (reduce_type == "min") {
-    return AllReduceType::kMin;
-  } else if (reduce_type == "max") {
-    return AllReduceType::kMax;
-  }
-  XLA_ERROR() << "Unknown AllReduce type: " << reduce_type;
-}
-
 std::vector<std::vector<int64_t>> CreateReduceGroups(const py::list& groups) {
   std::vector<std::vector<int64_t>> replica_groups;
   for (auto& group : groups) {


### PR DESCRIPTION
Summary:
This pull request adopts the traceable all_reduce as mentioned in https://github.com/pytorch/pytorch/issues/93173.
1. It registers an implementation to c10d_functional.all_reduce via TORCH_LIBRARY_IMPL interface.
2. It then hooks xm.all_reduce to use the torch.ops.c10d_functional.all_reduce op, which will route to the above implementation.
3. Currently it only supports a very basic usage that assumes scale == 1.0 and groups == [] and pin_layout.

Test Plan:
PJRT_DEVICE=TPU python test/test_mp_replication.py