### PR TITLE
Skip test/test_zero1.py for TPU

### DIFF
--- a/test/test_zero1.py
+++ b/test/test_zero1.py
@@ -3,12 +3,14 @@ import torch.nn as nn
 import torch_xla
 import torch_xla.core.xla_model as xm
 from torch_xla.distributed.zero_redundancy_optimizer import ZeroRedundancyOptimizer
+from torch_xla.experimental import pjrt
 
 import unittest
 
 
 class XlaZeRO1Test(unittest.TestCase):
 
+  @unittest.skipIf(pjrt.device_type() == 'TPU', "Crash on TPU")
   def test_zero1(self):
     device = xm.xla_device()
 


### PR DESCRIPTION
Summary:
The test crashes on my TPU V4-8 run. The test is introduced in #4648.

Test Plan:
N.A.