### PR TITLE
Apply sharding to all compatible input tensors

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -935,9 +935,9 @@ def send_cpu_data_to_device(data, device, input_sharding=None):
     devices = [str(device)] * len(tensors)
     xtensors = torch_xla._XLAC._xla_tensors_from_aten(tensors, devices)
     if input_sharding:
-      assert(len(xtensors) == 2), \
-        f"Expected input data and label pair, but got {xtensors}."
-      input_sharding.apply(xtensors[0])
+      for xtensor in xtensors:
+        if input_sharding.can_apply(xtensor):
+          input_sharding.apply(xtensor)
     return xtensors
 
   def select_fn(v):

--- a/torch_xla/distributed/parallel_loader.py
+++ b/torch_xla/distributed/parallel_loader.py
@@ -72,6 +72,9 @@ class ParallelLoader(object):
     host_to_device_transfer_threads (int, optional): The number of threads that
       work in parallel to transfer data from loader queue to device queue.
       Default: 1
+    input_sharding (ShardingSpec, optional): Sharding spec to apply to
+      compatible input tensors after loading.
+      Default: None
   """
 
   def __init__(self,

--- a/torch_xla/experimental/xla_sharding.py
+++ b/torch_xla/experimental/xla_sharding.py
@@ -148,6 +148,12 @@ class ShardingSpec:
   mesh: Mesh
   partition_spec: Tuple[Union[int, None]]
 
+  def can_apply(self, t: torch.Tensor) -> bool:
+    """
+    Test whether the ShardingSpec is compatible with the given torch.Tensor.
+    """
+    return len(self.partition_spec) == len(t.shape)
+
   def apply(self, t: torch.Tensor):
     # TODO(yeounoh) use virtual device interface when available.
     assert (t.device == xm.xla_device())


### PR DESCRIPTION
Removes the circular import introduced in https://github.com/pytorch/xla/pull/4872 and reverted in https://github.com/pytorch/xla/pull/4911.

Verified with a run of mnist and SPMD resnet50:

```
root@t1v-n-f494979e-w-0:/workspaces/work/pytorch/xla/test# PJRT_DEVICE=TPU python test_train_mp_mnist.py --num_epochs=1
...
/home/ptxla/.local/lib/python3.8/site-packages/torchvision/io/image.py:13: UserWarning: Failed to load image Python extension: 'libc10_cuda.so: cannot open shared object file: No such file or directory'If you don't plan on using image functionality from `torchvision.io`, you can ignore this warning. Otherwise, there might be something wrong with your environment. Did you have `libjpeg` or `libpng` installed before building `torchvision` from source?
  warn(
| Training Device=xla:0/1 Epoch=1 Step=0 Loss=2.43866 Rate=14.43 GlobalRate=14.43 Time=19:43:02
| Training Device=xla:0/0 Epoch=1 Step=0 Loss=2.39480 Rate=14.43 GlobalRate=14.43 Time=19:43:02
| Training Device=xla:0/3 Epoch=1 Step=0 Loss=2.38561 Rate=14.39 GlobalRate=14.39 Time=19:43:02
| Training Device=xla:0/2 Epoch=1 Step=0 Loss=2.40065 Rate=14.37 GlobalRate=14.37 Time=19:43:02
```

```
root@t1v-n-f494979e-w-0:/workspaces/work/pytorch/xla/test/spmd# XLA_USE_SPMD=1 PJRT_DEVICE=TPU python test_train_spmd_imagenet.py --fake_data --sharding batch --profile
/home/ptxla/.local/lib/python3.8/site-packages/torchvision/io/image.py:13: UserWarning: Failed to load image Python extension: 'libc10_cuda.so: cannot open shared object file: No such file or directory'If you don't plan on using image functionality from `torchvision.io`, you can ignore this warning. Otherwise, there might be something wrong with your environment. Did you have `libjpeg` or `libpng` installed before building `torchvision` from source?
  warn(
==> Preparing data..
Sharding input along batch dimension with mesh [[[[0]]]


 [[[1]]]


 [[[2]]]


 [[[3]]]]
Epoch 1 train begin 19:44:03
| Training Device=xla:0/0 Epoch=1 Step=0 Loss=6.89059 Rate=2.05 GlobalRate=2.05 Time=19:45:06
| Training Device=xla:0/0 Epoch=1 Step=20 Loss=6.79297 Rate=705.80 GlobalRate=41.58 Time=19:45:08
```