### PR TITLE
Use dynamic shape support in TFRT TPU and CPU

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,6 +14,7 @@ http_archive(
     patch_tool = "patch",
     patches = [
         "//tf_patches:cache_urls.diff",
+        "//tf_patches:cpu_dynamic_shape.diff",
         "//tf_patches:f16_abi_clang.diff",
         "//tf_patches:gpu_race_condition.diff",
         "//tf_patches:grpc_version.diff",

--- a/tf_patches/cpu_dynamic_shape.diff
+++ b/tf_patches/cpu_dynamic_shape.diff
@@ -1,0 +1,61 @@
+# Required for dynamic shape on TFRT:CPU. Remove when we sync past https://github.com/tensorflow/tensorflow/commit/7f045484290f57ec3dc91877af77de39275a4f78
+diff --git a/tensorflow/compiler/xla/pjrt/tfrt_cpu_pjrt_client.cc b/tensorflow/compiler/xla/pjrt/tfrt_cpu_pjrt_client.cc
+index f23bbc13e8c..25f68ffab74 100644
+--- a/tensorflow/compiler/xla/pjrt/tfrt_cpu_pjrt_client.cc
++++ b/tensorflow/compiler/xla/pjrt/tfrt_cpu_pjrt_client.cc
+@@ -1075,18 +1075,25 @@ PjRtFuture<Status> TfrtCpuBuffer::ToLiteral(MutableLiteralBase* literal) {
+
+   bool should_sync_copy = device_buffer_wait_avs.empty() &&
+                           literal->size_bytes() < kSmallDataTransferByteSize;
++  StatusOr<Shape> device_shape = logical_on_device_shape();
++  if (!device_shape.ok()) {
++    return PjRtFuture<Status>(device_shape.status());
++  }
+   if (should_sync_copy) {
+     if (!on_device_shape().IsTuple()) {
+       const std::shared_ptr<MaybeOwningCpuMemory>& b =
+           device_buffer->Buffers()[0];
+-      std::memcpy(literal->untyped_data(), b->data(), b->size());
++      std::memcpy(literal->untyped_data(), b->data(),
++                  ShapeUtil::ByteSizeOf(*device_shape));
+     } else {
+       // Tuple case.
+       int num_leaves = literal->shape().tuple_shapes().size();
+       for (int i = 0; i < num_leaves; ++i) {
+         const std::shared_ptr<MaybeOwningCpuMemory>& b =
+             device_buffer->Buffers()[i];
+-        std::memcpy(literal->untyped_data({i}), b->data(), b->size());
++        std::memcpy(
++            literal->untyped_data({i}), b->data(),
++            ShapeUtil::ByteSizeOf(ShapeUtil::GetSubshape(*device_shape, {i})));
+       }
+     }
+     // Unblock ToLiteral caller.
+@@ -1101,7 +1108,7 @@ PjRtFuture<Status> TfrtCpuBuffer::ToLiteral(MutableLiteralBase* literal) {
+         client()->pjrt_client_thread_pool(), device_buffer_wait_avs,
+         [this, device_buffer_wait_avs = std::move(device_buffer_wait_avs_copy),
+          literal, ready_event = ready_event.CopyRef(), device_buffer,
+-         ready_on_exit = std::move(ready_on_exit)]() mutable {
++         device_shape, ready_on_exit = std::move(ready_on_exit)]() mutable {
+           tsl::profiler::TraceMe traceme("D2H Dispatch");
+           // Errors in src buffer are surfaced to user.
+           for (const auto& av : device_buffer_wait_avs) {
+@@ -1115,14 +1122,17 @@ PjRtFuture<Status> TfrtCpuBuffer::ToLiteral(MutableLiteralBase* literal) {
+           if (!on_device_shape().IsTuple()) {
+             const std::shared_ptr<MaybeOwningCpuMemory>& b =
+                 device_buffer->Buffers()[0];
+-            std::memcpy(literal->untyped_data(), b->data(), b->size());
++            std::memcpy(literal->untyped_data(), b->data(),
++                        ShapeUtil::ByteSizeOf(*device_shape));
+           } else {
+             // Tuple case.
+             int num_leaves = literal->shape().tuple_shapes().size();
+             for (int i = 0; i < num_leaves; ++i) {
+               const std::shared_ptr<MaybeOwningCpuMemory>& b =
+                   device_buffer->Buffers()[i];
+-              std::memcpy(literal->untyped_data({i}), b->data(), b->size());
++              std::memcpy(literal->untyped_data({i}), b->data(),
++                          ShapeUtil::ByteSizeOf(
++                              ShapeUtil::GetSubshape(*device_shape, {i})));
+             }
+           }

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -326,24 +326,8 @@ std::vector<xla::Literal> PjRtComputationClient::TransferFromServer(
     xla::Shape target_shape = ShapeUtil::DeviceShapeToHostShape(
         pjrt_data.buffer->logical_on_device_shape().value());
     auto& literal = literals.emplace_back(target_shape);
+    XLA_CHECK_OK(pjrt_data.buffer->ToLiteralSync(&literal));
 
-    // PJRT will always try to copy the full bounded size into our literal. If
-    // the bounded size is larger than the logical output size, we have to
-    // allocate a bounded-size literal and copy a slice of the values into our
-    // output literal.
-    if (pjrt_data.buffer->on_device_shape().is_static()) {
-      XLA_CHECK_OK(pjrt_data.buffer->ToLiteralSync(&literal));
-    } else {
-      xla::Shape bounded_shape = ShapeUtil::DeviceShapeToHostShape(
-          pjrt_data.buffer->on_device_shape());
-      xla::Literal bounded_literal(bounded_shape);
-      XLA_CHECK_OK(pjrt_data.buffer->ToLiteralSync(&bounded_literal));
-      XLA_CHECK_OK(literal.CopySliceFrom(
-          bounded_literal,
-          /*src_base=*/std::vector<int64_t>(target_shape.rank(), 0),
-          /*dest_base=*/std::vector<int64_t>(target_shape.rank(), 0),
-          /*copy_size=*/target_shape.dimensions()));
-    }
     total_size += literal.size_bytes();
   }
   InboundDataMetric()->AddSample(total_size);


### PR DESCRIPTION
Removing a workaround for a bug in PJRT where it would crash or return incorrect results for dynamic buffers. The underlying issue is already fixed for TPU in our current TF pin, and the fix is present for CPU in https://github.com/tensorflow/tensorflow/commit/7f045484290f57ec3dc91877af77de39275a4f78.

For some reason, this workaround does not work for TFRT TPU specifically, but it does work for SE TPU, TFRT CPU, and SE GPU. Temporarily patching the CPU fix so I can remove the workaround altogether. After this CL, _all C++ tests pass on TFRT TPU_. 

```
[==========] 692 tests from 12 test suites ran. (10908461 ms total)
[  PASSED  ] 675 tests.
[  SKIPPED ] 17 tests, listed below:
```