### PR TITLE
[Distributed] Make xm.all_gather a single graph in Dynamo

### DIFF
--- a/test/test_mp_all_gather.py
+++ b/test/test_mp_all_gather.py
@@ -5,8 +5,10 @@ import torch_xla
 import torch_xla.core.xla_model as xm
 import torch_xla.distributed.xla_multiprocessing as xmp
 
+
 def all_gather(tensor, dim):
   return xm.all_gather(tensor, dim=dim)
+
 
 def _mp_fn(index):
   device = xm.xla_device()
@@ -27,7 +29,8 @@ def _mp_fn(index):
     # Dynamo won't do graph breaks.
     xm.get_ordinal()
     xm.xrt_world_size()
-    compiled_all_gather= torch.compile(all_gather, backend='torchxla_trace_once', fullgraph=True)
+    compiled_all_gather = torch.compile(
+        all_gather, backend='torchxla_trace_once', fullgraph=True)
     ordinal_tensor = torch.tensor([index], dtype=torch.float).to(device)
     result = compiled_all_gather(ordinal_tensor, dim=0)
 

--- a/test/test_mp_all_gather.py
+++ b/test/test_mp_all_gather.py
@@ -15,10 +15,8 @@ def _mp_fn(index):
   world_size = xm.xrt_world_size()
   if xm.xla_device_hw(device) in ('TPU', 'GPU'):
     # Testing with a single replica group
-    compiled_all_gather = torch.compile(
-        all_gather, backend='torchxla_trace_once', fullgraph=True)
     ordinal_tensor = torch.tensor([index], dtype=torch.float).to(device)
-    result = compiled_all_gather(ordinal_tensor, dim=0)
+    result = xm.all_gather(ordinal_tensor, dim=0)
 
     cpu_result = result.cpu()
     expected = torch.arange(0, world_size, dtype=torch.float)
@@ -27,8 +25,10 @@ def _mp_fn(index):
       print(f'[{index}] {cpu_result}', file=sys.stderr)
       sys.exit(1)
 
+    compiled_all_gather = torch.compile(
+        all_gather, backend='torchxla_trace_once', fullgraph=True)
     ordinal_tensor = torch.tensor([index], dtype=torch.float).to(device)
-    result = xm.all_gather(ordinal_tensor, dim=0)
+    result = compiled_all_gather(ordinal_tensor, dim=0)
 
     cpu_result = result.cpu()
     expected = torch.arange(0, world_size, dtype=torch.float)

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -97,7 +97,7 @@ def xrt_world_size(defval=1):
   if pjrt.using_pjrt():
     g_xrt_world_size = pjrt.world_size()
   else:
-    g_xrt_world_size = xu.getenv_as(xenv.XRT_WORLD_SIZE, int, defval=defval)
+    g_xrt_world_size = xu.getenv_as(xenv.WORLD_SIZE, int, defval=defval)
   return g_xrt_world_size
 
 g_ordinal = None

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -135,6 +135,7 @@ def get_ordinal(defval=0):
   Returns:
     The replication ordinal of the current thread.
   """
+  global _ORDINAL
   if _ORDINAL is not None:
     return _ORDINAL
 

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -30,6 +30,7 @@ _DEVICE_CONTEXTS_LOCK = threading.Lock()
 _WORLD_SIZE = None
 _ORDINAL = None
 
+
 def _init_world_size_ordinal():
   global _WORLD_SIZE, _ORDINAL
 
@@ -37,12 +38,13 @@ def _init_world_size_ordinal():
     return
 
   # We don't support V3-8. See Note [V3-8 Threading]
-  if tpu.version() <= 3:
+  if tpu.version() < 3:
     return
 
   if _WORLD_SIZE is None:
     _WORLD_SIZE = xrt_world_size()
     _ORDINAL = get_ordinal()
+
 
 class DeviceContext(object):
 
@@ -113,6 +115,7 @@ def xrt_world_size(defval=1):
 
   if pjrt.using_pjrt():
     return pjrt.world_size()
+
   return xu.getenv_as(xenv.WORLD_SIZE, int, defval=defval)
 
 
@@ -134,6 +137,7 @@ def get_ordinal(defval=0):
 
   if pjrt.using_pjrt():
     return pjrt.global_ordinal()
+
   return xu.getenv_as(xenv.ORDINAL, int, defval=defval)
 
 

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -27,6 +27,9 @@ REDUCE_MAX = 'max'
 _DEVICE_CONTEXTS = dict()
 _DEVICE_CONTEXTS_LOCK = threading.Lock()
 
+# Note [Dynamo WORLD_SIEZ and ORDINAL]
+# Belows are workaround to cache the ordinal and world_size such that
+# Dynamo won't do graph breaks when xm.xrt_world_size() and xm.get_ordinal() are called.
 _WORLD_SIZE = None
 _ORDINAL = None
 
@@ -38,7 +41,7 @@ def _init_world_size_ordinal():
     return
 
   # We don't support V3-8. See Note [V3-8 Threading]
-  if tpu.version() < 3:
+  if pjrt.device_type() == 'TPU' and tpu.version() < 4:
     return
 
   if _WORLD_SIZE is None:

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -78,7 +78,10 @@ def get_xla_supported_devices(devkind=None, max_devices=None):
     if kind_devices:
       return kind_devices[:max_devices] if max_devices else kind_devices
 
+
 g_xrt_world_size = None
+
+
 def xrt_world_size(defval=1):
   """Retrieves the number of devices which is taking part of the replication.
 
@@ -100,9 +103,12 @@ def xrt_world_size(defval=1):
     g_xrt_world_size = xu.getenv_as(xenv.WORLD_SIZE, int, defval=defval)
   return g_xrt_world_size
 
+
 # See Note [V3-8 Threading]
-g_ordinal = {}
+g_ordinals = {}
 g_thread_id = None
+
+
 def get_ordinal(defval=0):
   """Retrieves the replication ordinal of the current thread.
 
@@ -116,17 +122,17 @@ def get_ordinal(defval=0):
   Returns:
     The replication ordinal of the current thread.
   """
-  global g_ordinal
+  global g_ordinals
   global g_thread_id
   if g_thread_id is not None:
-    return g_ordinal[g_thread_id]
+    return g_ordinals[g_thread_id]
   g_thread_id = threading.get_native_id()
 
   if pjrt.using_pjrt():
-    g_ordinal[g_thread_id] = pjrt.global_ordinal()
+    g_ordinals[g_thread_id] = pjrt.global_ordinal()
   else:
-    g_ordinal[g_thread_id] = xu.getenv_as(xenv.ORDINAL, int, defval=defval)
-  return g_ordinal[g_thread_id]
+    g_ordinals[g_thread_id] = xu.getenv_as(xenv.ORDINAL, int, defval=defval)
+  return g_ordinals[g_thread_id]
 
 
 def get_local_ordinal(defval=0):

--- a/torch_xla/csrc/cross_replica_reduces.cpp
+++ b/torch_xla/csrc/cross_replica_reduces.cpp
@@ -18,6 +18,7 @@
 namespace torch_xla {
 namespace {
 
+// Note [V3-8 Threading]
 // For V3-8 + PJRT, we have 4 processes and each process has 2 threads to manage
 // the 8 cores. Therefore, we need different tokens for different threads.
 std::unordered_map<int64_t, std::shared_ptr<torch::lazy::Value>>

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -235,8 +235,7 @@ def _run_thread_per_device(
   def _thread_fn(device: torch.device):
     torch_xla._XLAC._xla_set_default_device(device)
 
-    # Belows are workaround to cache the ordinal and world_size such that
-    # Dynamo won't do graph breaks when xm.xrt_world_size() and xm.get_ordinal() are called.
+    # See Note Note [Dynamo WORLD_SIEZ and ORDINAL].
     xm._init_world_size_ordinal()
 
     return fn()

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -236,9 +236,8 @@ def _run_thread_per_device(
     torch_xla._XLAC._xla_set_default_device(device)
 
     # Belows are workaround to cache the ordinal and world_size such that
-    # Dynamo won't do graph breaks when they are called.
-    xm.xrt_world_size()
-    xm.get_ordinal()
+    # Dynamo won't do graph breaks when xm.xrt_world_size() and xm.get_ordinal() are called.
+    xm._init_world_size_ordinal()
 
     return fn()
 

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -235,6 +235,11 @@ def _run_thread_per_device(
   def _thread_fn(device: torch.device):
     torch_xla._XLAC._xla_set_default_device(device)
 
+    # Belows are workaround to cache the ordinal and world_size such that
+    # Dynamo won't do graph breaks when they are called.
+    xm.xrt_world_size()
+    xm.get_ordinal()
+
     return fn()
 
   with concurrent.futures.ThreadPoolExecutor(


### PR DESCRIPTION
Summary:
This pull request makes xm.all_gather, the _all_gather_using_all_reduce path, a single graph in Dynamo. To do that, it:
1. removes a hardware type check, specialize CPU doesn't seem to be worth it.
2. caches ordinal and xrt_world_size.

Test Plan:
PJRT_DEVICE=TPU python test/test_mp_all_gather.py