### PR TITLE
Add a GCB trigger that applies Terraform configuration on push.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/infra @will-cromar @JackCaoG @mateuszlewko @stgpetrovic

--- a/infra/terraform_modules/apply_terraform_trigger/apply_terraform_trigger.tf
+++ b/infra/terraform_modules/apply_terraform_trigger/apply_terraform_trigger.tf
@@ -1,20 +1,50 @@
+variable "config_directory" {
+  type = string
+}
+
+variable "include_files" {
+  type    = list(string)
+  default = []
+}
+
+variable "branch" {
+  type = string
+}
+
+variable "description" {
+  default = ""
+}
+
+variable "worker_pool_id" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
 module "cloud_build" {
   source = "../build_trigger"
 
-  name                    = "provision-terraform"
-  github_repo             = "pytorch/xla"
-  scheduler_account_email = var.scheduler_account_email
-  timeout_minutes         = var.timeout_minutes
-  worker_pool_id          = var.worker_pool_id
-  description             = var.description
-  location                = var.location
+  name            = var.name
+  github_repo     = "pytorch/xla"
+  timeout_minutes = 60
+  worker_pool_id  = var.worker_pool_id
+  description     = var.description
 
-  trigger_on_push     = var.trigger_on_push
-  trigger_on_schedule = var.trigger_on_schedule
+  trigger_on_push = { branch = var.branch }
 
-  steps = concat(
-    local.fetch_ansible_build_config,
-    local.build_and_push_docker_image_steps,
-    length(var.wheels_srcs) > 0 ? local.collect_and_publish_wheels_steps : []
-  )
+  steps = [
+    {
+      id         = "apply_terraform"
+      name       = "hashicorp/terraform:latest"
+      entrypoint = "sh"
+      args = [
+        "-c", join(" ", [
+          "terraform -chdir=${var.config_directory} init &&",
+          "terraform -chdir=${var.config_directory} apply -auto-approve",
+        ])
+      ]
+    },
+  ]
 }

--- a/infra/terraform_modules/apply_terraform_trigger/apply_terraform_trigger.tf
+++ b/infra/terraform_modules/apply_terraform_trigger/apply_terraform_trigger.tf
@@ -1,0 +1,20 @@
+module "cloud_build" {
+  source = "../build_trigger"
+
+  name                    = "provision-terraform"
+  github_repo             = "pytorch/xla"
+  scheduler_account_email = var.scheduler_account_email
+  timeout_minutes         = var.timeout_minutes
+  worker_pool_id          = var.worker_pool_id
+  description             = var.description
+  location                = var.location
+
+  trigger_on_push     = var.trigger_on_push
+  trigger_on_schedule = var.trigger_on_schedule
+
+  steps = concat(
+    local.fetch_ansible_build_config,
+    local.build_and_push_docker_image_steps,
+    length(var.wheels_srcs) > 0 ? local.collect_and_publish_wheels_steps : []
+  )
+}

--- a/infra/terraform_modules/apply_terraform_trigger/apply_terraform_trigger.tf
+++ b/infra/terraform_modules/apply_terraform_trigger/apply_terraform_trigger.tf
@@ -11,16 +11,13 @@ variable "branch" {
   type = string
 }
 
-variable "description" {
-  default = ""
-}
-
 variable "worker_pool_id" {
   type = string
 }
 
 variable "name" {
-  type = string
+  type    = string
+  default = "terraform-provision-trigger"
 }
 
 data "google_project" "project" {}
@@ -43,6 +40,10 @@ resource "google_project_iam_member" "runner_is_editor" {
   member  = "serviceAccount:${google_service_account.runner_account.email}"
 }
 
+variable "location" {
+  default = "us-central1"
+}
+
 module "cloud_build" {
   source = "../build_trigger"
 
@@ -50,10 +51,11 @@ module "cloud_build" {
   github_repo     = "pytorch/xla"
   timeout_minutes = 60
   worker_pool_id  = var.worker_pool_id
-  description     = var.description
+  description     = "Trigger that provisions Terraform setup in ${var.config_directory}."
   service_account = google_service_account.runner_account.id
   logging         = "CLOUD_LOGGING_ONLY"
   trigger_on_push = { branch = var.branch }
+  location        = var.location
 
   steps = [
     {

--- a/infra/terraform_modules/build_trigger/build_trigger.tf
+++ b/infra/terraform_modules/build_trigger/build_trigger.tf
@@ -62,6 +62,10 @@ variable "timeout_minutes" {
   default = 60
 }
 
+variable "service_account" {
+  default = ""
+}
+
 variable "location" {
   default = "us-central1"
 }
@@ -71,6 +75,10 @@ variable "substitutions" {
   default = {}
 }
 
+variable "logging" {
+  default = ""
+}
+
 locals {
   github_repo_parts = split("/", var.github_repo)
 }
@@ -78,9 +86,10 @@ locals {
 # Detailed documentation on CloudBuild parameters:
 # https://cloud.google.com/build/docs/api/reference/rest/v1/projects.builds#resource-build
 resource "google_cloudbuild_trigger" "trigger" {
-  name        = var.name
-  description = var.description
-  location    = var.location
+  name            = var.name
+  description     = var.description
+  location        = var.location
+  service_account = var.service_account
 
   # Source (context) in which build trigger will run when triggered on branch or tag push.
   # The source exact version will be the commit which caused the trigger event (push).
@@ -145,6 +154,7 @@ resource "google_cloudbuild_trigger" "trigger" {
       substitution_option   = "ALLOW_LOOSE"
       dynamic_substitutions = true
       worker_pool           = var.worker_pool_id
+      logging               = var.logging
     }
 
     timeout = "${var.timeout_minutes * 60}s"

--- a/infra/tpu-pytorch-releases/artifacts_builds.tf
+++ b/infra/tpu-pytorch-releases/artifacts_builds.tf
@@ -133,15 +133,3 @@ module "versioned_builds" {
   worker_pool_id  = module.worker_pool.id
   docker_repo_url = module.docker_registry.url
 }
-
-module "terraform_apply" {
-  source = "../terraform_modules/apply_terraform_trigger"
-
-  include_files    = ["infra/**"]
-  name             = "terraform-provision-trigger"
-  branch           = "master"
-  description      = "Trigger that provisions Terraform setup in infra/tpu-pytorch-releases/cloud_builds.tf"
-  config_directory = "infra/tpu-pytorch-releases"
-
-  worker_pool_id = module.worker_pool.id
-}

--- a/infra/tpu-pytorch-releases/artifacts_builds.tf
+++ b/infra/tpu-pytorch-releases/artifacts_builds.tf
@@ -133,3 +133,15 @@ module "versioned_builds" {
   worker_pool_id  = module.worker_pool.id
   docker_repo_url = module.docker_registry.url
 }
+
+module "terraform_apply" {
+  source = "../terraform_modules/apply_terraform_trigger"
+
+  include_files    = ["infra/**"]
+  name             = "terraform-provision-trigger"
+  branch           = "master"
+  description      = "Trigger that provisions Terraform setup in infra/tpu-pytorch-releases/cloud_builds.tf"
+  config_directory = "infra/tpu-pytorch-releases"
+
+  worker_pool_id = module.worker_pool.id
+}

--- a/infra/tpu-pytorch-releases/infra_triggers.tf
+++ b/infra/tpu-pytorch-releases/infra_triggers.tf
@@ -1,0 +1,11 @@
+module "terraform_apply" {
+  source = "../terraform_modules/apply_terraform_trigger"
+
+  include_files    = ["infra/**"]
+  name             = "terraform-provision-trigger"
+  branch           = "master"
+  description      = "Trigger that provisions Terraform setup in infra/tpu-pytorch-releases/cloud_builds.tf"
+  config_directory = "infra/tpu-pytorch-releases"
+
+  worker_pool_id = module.worker_pool.id
+}

--- a/infra/tpu-pytorch/infra_triggers.tf
+++ b/infra/tpu-pytorch/infra_triggers.tf
@@ -3,7 +3,8 @@ module "terraform_apply" {
 
   include_files    = ["infra/**"]
   branch           = "master"
-  config_directory = "infra/tpu-pytorch-releases"
+  config_directory = "infra/tpu-pytorch"
 
   worker_pool_id = module.worker_pool.id
+  location       = "global"
 }


### PR DESCRIPTION
**This is a proposal for automatic enforcement of Terraform setup.**

This trigger will automatically enforce Terraform setup of the `pytorch-xla-releases` project on pushes to master branch (in any files in `infra/` was modified.

Adding such trigger requires provisioning a service account with certain roles.
Added a CODEOWNERS file to ensure only certain people can approve infra changes that will be automatically enforced. **However, this works only if reviews are marked as required** (https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners) 