### PR TITLE
Remove rendezvous from `xm.save`

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -885,7 +885,7 @@ def optimizer_step(optimizer,
   return loss
 
 
-def save(data, file_or_path, master_only=True, global_master=False, sync=True):
+def save(data, file_or_path, master_only=True, global_master=False):
   """Saves the input data into a file.
 
   The saved data is transferred to PyTorch CPU device before being saved, so a
@@ -920,8 +920,6 @@ def save(data, file_or_path, master_only=True, global_master=False, sync=True):
   cpu_data = _maybe_convert_to_cpu(data, convert=should_write_data)
   if should_write_data:
     torch.save(cpu_data, file_or_path)
-  if sync:
-    rendezvous('torch_xla.core.xla_model.save')
 
 
 def _maybe_convert_to_cpu(data, convert=True):

--- a/torch_xla/utils/serialization.py
+++ b/torch_xla/utils/serialization.py
@@ -74,7 +74,6 @@ def save(data, path, master_only=True, global_master=False):
   ref_data = _rewrite_data(_get_tensors_folder(path), data, should_write_data)
   if should_write_data:
     torch.save(ref_data, path)
-  xm.rendezvous('torch_xla.utils.serialization.save')
 
 
 def load(path):


### PR DESCRIPTION
Currently, CI workloads are hanging at test_save_api in test_operations.py. I can confirm this locally.

- https://github.com/pytorch/xla/pull/4905 removes `CollectiveContext`. Along with some irrelevant legacy code, this PR also removes some logic that effectively removes collectives from the graph when the replication is disabled: https://github.com/pytorch/xla/pull/4905/files#diff-6734a7aa95d34d8767b335ddaf4bc8f07df93a09ff77fbf079b66d99adcc7850L80-L84
- Importantly, [xm.save calls xm.rendezvous](https://github.com/pytorch/xla/blob/085742982696ce41ba93e231e15b532d18098848/torch_xla/core/xla_model.py#L923-L924), which (on PJRT) [calls XLA all_gather](https://github.com/pytorch/xla/blob/085742982696ce41ba93e231e15b532d18098848/torch_xla/experimental/pjrt.py#L439)
- That means that all calls to xm.save invoke a collective. If one replica in the runtime calls a collective, all others must call it as well
- In a single-device context such as this unit test, the old implementation of `CollectiveContext` would have disabled `requires_intercore_reduce` and `requires_interhost_reduce`, preventing an actual collective from being put in the HLO.
- Without `CollectiveContext`, you could only call `xm.save` in a multiprocessing context (assuming there are multiple addressable devices)


This PR entirely removes `rendezvous ` from `save`, so it essentially becomes a thin wrapper around `torch.save`. That means that code that only calls `torch.save` from the master (or another subset of replicas) may just drop in `xm.save` as a replacement, without having to call it on every other replica.

Related: https://github.com/pytorch/xla/pull/4907

Will run TPU CI tests locally to verify fix.