### PR TITLE
[PJRT] Add `tpu.num_available_devices` to get number of XLA TPU devices

### DIFF
--- a/test/pjrt/test_experimental_tpu.py
+++ b/test/pjrt/test_experimental_tpu.py
@@ -48,6 +48,18 @@ class TestExperimentalTpu(parameterized.TestCase):
       self.assertEqual(tpu.num_available_chips(), num_tpu_chips)
 
   @parameterized.named_parameters(
+      ('v2-8', 2, 4, 8),
+      ('v3-8', 3, 4, 8),
+      ('v4-8', 4, 4, 4),
+      ('v4-8_one_chip', 4, 1, 1),
+  )
+  def test_num_available_devices(self, version, num_tpu_chips, expected):
+    with mock.patch.object(
+        tpu, 'version', return_value=version), mock.patch.object(
+            tpu, 'num_available_chips', return_value=num_tpu_chips):
+      self.assertEqual(tpu.num_available_devices(), expected)
+
+  @parameterized.named_parameters(
       ('default_one_host', None, 4),
       ('one_process_one_host', '1,1,1', 1),
       ('multi_process_one_host', '2,2,1', 4),

--- a/torch_xla/experimental/tpu.py
+++ b/torch_xla/experimental/tpu.py
@@ -106,10 +106,16 @@ def num_available_chips() -> int:
 
 
 def num_logical_cores_per_chip() -> int:
+  """Returns number of XLA TPU devices per physical chip on the current host."""
   return 2 if version() <= 3 else 1
 
 
 def num_available_devices() -> int:
+  """Returns number of XLA TPU devices on the current host.
+
+  Note: this does not intitialize the computation client and is safe to call
+  before `xmp.spawn`.
+  """
   return num_available_chips() * num_logical_cores_per_chip()
 
 

--- a/torch_xla/experimental/tpu.py
+++ b/torch_xla/experimental/tpu.py
@@ -105,6 +105,14 @@ def num_available_chips() -> int:
   return num_chips
 
 
+def num_logical_cores_per_chip() -> int:
+  return 2 if version() <= 3 else 1
+
+
+def num_available_devices() -> int:
+  return num_available_chips() * num_logical_cores_per_chip()
+
+
 def num_local_processes() -> int:
   """Returns number of processes to create on this host."""
   local_chips = num_available_chips()


### PR DESCRIPTION
This can be used to get the expected number of total TPU devices without initializing the client like we were able to do with `TPU_NUM_DEVICES` in XRT, without the user having to manually set it.