### PR TITLE
Fix test_mp_save

### DIFF
--- a/test/test_mp_save.py
+++ b/test/test_mp_save.py
@@ -40,7 +40,7 @@ def _mp_fn(index, temp_file):
   dd = _create_state_dict(device)
   xm.save(dd, temp_file)
   # User needs to manually rendezvous since only master process
-  # will perfomrn the save and other processes needs to wait.
+  # will perform the save and other processes needs to wait.
   # This is also aligned with the `torch.save`
   xm.rendezvous('torch_xla.core.xla_model.save')
   ldd = torch.load(temp_file)

--- a/test/test_mp_save.py
+++ b/test/test_mp_save.py
@@ -39,6 +39,10 @@ def _mp_fn(index, temp_file):
   device = xm.xla_device()
   dd = _create_state_dict(device)
   xm.save(dd, temp_file)
+  # User needs to manually rendezvous since only master process
+  # will perfomrn the save and other processes needs to wait.
+  # This is also aligned with the `torch.save`
+  xm.rendezvous('torch_xla.core.xla_model.save')
   ldd = torch.load(temp_file)
   pdd = _get_data_str(ldd)
   data = xm.rendezvous('xm_save_test', pdd)


### PR DESCRIPTION
In https://github.com/pytorch/xla/commit/4f7f3dcd4b82aaa9acfcb63057cebd80e989ebf7 we removed the `rendezvous` in `xm.save`, hence we need to manually do it in the test to guarantee the correctness.