### PR TITLE
Increase the default XLA_IR_SHAPE_CACHE_SIZE to accomunate the larger…

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -271,7 +271,7 @@ variables:
       description:
         - Size for the shape cache used by XLA.
       type: int
-      default_value: 4096
+      default_value: 12288
     XLA_DEVDATA_CACHE_SIZE:
       description:
         - Max cache size for XLA Data cache.

--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -21,7 +21,7 @@ using ShapeCache =
 
 ShapeCache* GetShapeCache() {
   static int64_t shape_cache_size =
-      xla::sys_util::GetEnvInt("XLA_IR_SHAPE_CACHE_SIZE", 4096);
+      xla::sys_util::GetEnvInt("XLA_IR_SHAPE_CACHE_SIZE", 12288);
   static ShapeCache* cache = new ShapeCache(shape_cache_size);
   return cache;
 }


### PR DESCRIPTION
… model size

Hopefully this will resolve https://github.com/pytorch/xla/issues/4914. Increase the cache size to 3x until we have chance to rerun diffusion model to figure out the real cache size.