### PR TITLE
Fix typo in dev-image trigger definition

### DIFF
--- a/infra/tpu-pytorch/cloud_builds.tf
+++ b/infra/tpu-pytorch/cloud_builds.tf
@@ -5,8 +5,8 @@ module "dev_image" {
 
   ansible_branch = "master"
   trigger_on_push = {
-    branch        = "master"
-    include_files = ["infra/**"]
+    branch         = "master"
+    included_files = ["infra/**"]
   }
 
   image_name = "development"


### PR DESCRIPTION
Unfortunately Terraform doesn't raise error if we pass extraneous (or mistyped) attributes to object, see: https://github.com/hashicorp/terraform/issues/30608.