### PR TITLE
Pass -no-color to Terraform invocation

### DIFF
--- a/infra/terraform_modules/apply_terraform_trigger/apply_terraform_trigger.tf
+++ b/infra/terraform_modules/apply_terraform_trigger/apply_terraform_trigger.tf
@@ -64,8 +64,8 @@ module "cloud_build" {
       entrypoint = "sh"
       args = [
         "-c", join(" ", [
-          "terraform -chdir=${var.config_directory} init &&",
-          "terraform -chdir=${var.config_directory} apply -auto-approve",
+          "terraform -no-color -chdir=${var.config_directory} init &&",
+          "terraform -no-color -chdir=${var.config_directory} apply -auto-approve",
         ])
       ]
     },


### PR DESCRIPTION
This will prevent printing ASCII color tags in the output ("[0m[1m")