### PR TITLE
Bazel test linking

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -128,7 +128,6 @@ coverage --instrumentation_filter="//torch_xla/,//third_party/"
 build:coverage --combined_report=lcov
 build:coverage --strategy=CoverageReport=sandboxed,local
 build:coverage --test_tag_filters=-nocoverage
-build:coverage --nocache_test_results
 
 ############################################################################
 ############## TensorFlow .bazelrc greatest hits ###########################

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -173,8 +173,8 @@ function run_torch_xla_tests() {
         PJRT_DEVICE=CPU ./run_tests.sh $EXTRA_ARGS
       fi
       if [ "$USE_COVERAGE" != "0" ]; then
-        genhtml bazel-out/_coverage/_coverage_report.dat -o ~/htmlcov/cpp/cpp_lcov.info
-        mv ./bazel-out/_coverage/_coverage_report.dat ~/htmlcov/cpp_lcov.info
+        genhtml $XLA_DIR/bazel-out/_coverage/_coverage_report.dat -o ~/htmlcov/cpp/cpp_lcov.info
+        mv $XLA_DIR/bazel-out/_coverage/_coverage_report.dat ~/htmlcov/cpp_lcov.info
       fi
     popd
   popd

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ run_test: &run_test
       <<: *download_docker
   - run:
       name: Test
-      no_output_timeout: "1h"
+      no_output_timeout: "3h"
       command: |
         docker exec -u jenkins $(cat .docker_pid) bash -c '. ~/.bashrc && .circleci/test.sh'
 
@@ -189,7 +189,7 @@ run_test_coverage: &run_test_coverage
       <<: *download_docker
   - run:
       name: Test
-      no_output_timeout: "2h"
+      no_output_timeout: "3h"
       command: |
         docker exec -u jenkins $(cat .docker_pid) bash -c \
         '. ~/.bashrc && USE_COVERAGE=1 .circleci/test.sh'

--- a/test/cpp/BUILD
+++ b/test/cpp/BUILD
@@ -55,6 +55,7 @@ ptxla_cc_library(
         "//torch_xla/csrc:tensor",
         "@com_google_googletest//:gtest",
     ],
+    alwayslink = True,
 )
 
 ptxla_cc_library(
@@ -68,6 +69,7 @@ ptxla_cc_library(
         "@com_google_googletest//:gtest",
         "@org_tensorflow//tensorflow/compiler/xla:permutation_util",
     ],
+    alwayslink = True,
 )
 
 ptxla_cc_library(
@@ -79,6 +81,7 @@ ptxla_cc_library(
         "@com_google_googletest//:gtest",
         "@org_tensorflow//tensorflow/compiler/xla:shape_util",
     ],
+    alwayslink = True,
 )
 
 ptxla_cc_library(
@@ -89,6 +92,7 @@ ptxla_cc_library(
         "//torch_xla/csrc:tensor",
         "@com_google_googletest//:gtest",
     ],
+    alwayslink = True,
 )
 
 ptxla_cc_library(
@@ -106,6 +110,7 @@ ptxla_cc_library(
         "@org_tensorflow//tensorflow/compiler/xla:shape_util",
         "@org_tensorflow//tensorflow/compiler/xla/client:xla_builder",
     ],
+    alwayslink = True,
 )
 
 ptxla_cc_library(
@@ -116,6 +121,7 @@ ptxla_cc_library(
         "//torch_xla/csrc:tensor",
         "@com_google_googletest//:gtest",
     ],
+    alwayslink = True,
 )
 
 ptxla_cc_library(
@@ -127,6 +133,7 @@ ptxla_cc_library(
         "//torch_xla/csrc:tensor",
         "@com_google_googletest//:gtest",
     ],
+    alwayslink = True,
 )
 
 ptxla_cc_library(
@@ -137,6 +144,7 @@ ptxla_cc_library(
         "//torch_xla/csrc:tensor",
         "@com_google_googletest//:gtest",
     ],
+    alwayslink = True,
 )
 
 ptxla_cc_library(
@@ -151,6 +159,7 @@ ptxla_cc_library(
         "@com_google_googletest//:gtest",
         "@org_tensorflow//tensorflow/compiler/xla:xla_data_proto_cc",
     ],
+    alwayslink = True,
 )
 
 # Keep all the tests in the same binary as long as XRT is supported.
@@ -159,7 +168,7 @@ ptxla_cc_library(
 # but XRT gRPC ports cannot be reused and are inhereted from the environment.
 ptxla_cc_test(
     name = "main",
-    timeout = "long",
+    size = "enormous",
     srcs = ["main.cpp"],
     deps = [
         ":test_aten_xla_tensor",

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -77,7 +77,7 @@ fi
 
 
 if [ "$LOGFILE" != "" ]; then
-  bazel $BAZEL_VERB $EXTRA_FLAGS --test_output=streamed //third_party/xla_client:all //test/cpp:all ${FILTER:+"$FILTER"} 2> $LOGFILE
+  bazel $BAZEL_VERB $EXTRA_FLAGS --nocache_test_results --test_verbose_timeout_warnings --test_output=streamed //third_party/xla_client:all //test/cpp:all ${FILTER:+"$FILTER"} 2> $LOGFILE
 else
-  bazel $BAZEL_VERB $EXTRA_FLAGS --test_output=streamed //third_party/xla_client:all //test/cpp:all ${FILTER:+"$FILTER"}
+  bazel $BAZEL_VERB $EXTRA_FLAGS --nocache_test_results --test_verbose_timeout_warnings --test_output=streamed //third_party/xla_client:all //test/cpp:all ${FILTER:+"$FILTER"}
 fi

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -77,7 +77,7 @@ fi
 
 
 if [ "$LOGFILE" != "" ]; then
-  bazel $BAZEL_VERB $EXTRA_FLAGS --nocache_test_results --test_verbose_timeout_warnings --test_output=streamed //third_party/xla_client:all //test/cpp:all ${FILTER:+"$FILTER"} 2> $LOGFILE
+  bazel $BAZEL_VERB $EXTRA_FLAGS --test_output=streamed //third_party/xla_client:all //test/cpp:all ${FILTER:+"$FILTER"} 2> $LOGFILE
 else
-  bazel $BAZEL_VERB $EXTRA_FLAGS --nocache_test_results --test_verbose_timeout_warnings --test_output=streamed //third_party/xla_client:all //test/cpp:all ${FILTER:+"$FILTER"}
+  bazel $BAZEL_VERB $EXTRA_FLAGS --test_output=streamed //third_party/xla_client:all //test/cpp:all ${FILTER:+"$FILTER"}
 fi


### PR DESCRIPTION
Link all tests into a single binary; make sure linker does not eliminate libraries.
Fix the coverage directory.