### PR TITLE
Fix -no-color argument positioning

### DIFF
--- a/infra/terraform_modules/apply_terraform_trigger/apply_terraform_trigger.tf
+++ b/infra/terraform_modules/apply_terraform_trigger/apply_terraform_trigger.tf
@@ -64,8 +64,8 @@ module "cloud_build" {
       entrypoint = "sh"
       args = [
         "-c", join(" ", [
-          "terraform -no-color -chdir=${var.config_directory} init &&",
-          "terraform -no-color -chdir=${var.config_directory} apply -auto-approve",
+          "terraform -chdir=${var.config_directory} init -no-color &&",
+          "terraform -chdir=${var.config_directory} apply -no-color -auto-approve",
         ])
       ]
     },


### PR DESCRIPTION
Actually the argument must be placed after 'apply' or 'init'.