### PR TITLE
Support coverage when compiling for CUDA.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -55,6 +55,10 @@ build:cuda --@org_tensorflow//tensorflow/compiler/xla/python:enable_gpu=true
 build:cuda --define=xla_python_enable_gpu=true
 build:cuda --cxxopt=-DXLA_CUDA=1
 
+# Coverage with cuda/gcc/nvcc requires manually setting coverage flags.
+coverage:cuda --cxxopt=--coverage
+coverage:cuda --linkopt=-lgcov
+
 build:acl --define==build_with_acl=true
 
 build:nonccl --define=no_nccl_support=true


### PR DESCRIPTION
Passing `--config=cuda` to bazel makes it use a nvcc/gcc compiler infrastructure in `@local_config_cuda` that is immune to the `bazel coverage` intervention in coverage flags. Setting those flags manually solves the problem.