### PR TITLE
Support coverage when compiling for CUDA.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -55,6 +55,10 @@ build:cuda --@org_tensorflow//tensorflow/compiler/xla/python:enable_gpu=true
 build:cuda --define=xla_python_enable_gpu=true
 build:cuda --cxxopt=-DXLA_CUDA=1
 
+# Coverage with cuda/gcc/nvcc requires manually setting coverage flags.
+coverage:cuda --cxxopt=--coverage
+coverage:cuda --linkopt=-lgcov
+
 build:acl --define==build_with_acl=true
 
 build:nonccl --define=no_nccl_support=true

--- a/.bazelrc
+++ b/.bazelrc
@@ -56,7 +56,7 @@ build:cuda --define=xla_python_enable_gpu=true
 build:cuda --cxxopt=-DXLA_CUDA=1
 
 # Coverage with cuda/gcc/nvcc requires manually setting coverage flags.
-coverage:cuda --cxxopt=--coverage
+coverage:cuda --per_file_copt=-external/.*@--coverage
 coverage:cuda --linkopt=-lgcov
 
 build:acl --define==build_with_acl=true

--- a/.bazelrc
+++ b/.bazelrc
@@ -56,7 +56,7 @@ build:cuda --define=xla_python_enable_gpu=true
 build:cuda --cxxopt=-DXLA_CUDA=1
 
 # Coverage with cuda/gcc/nvcc requires manually setting coverage flags.
-coverage:cuda --per_file_copt=-external/.*@--coverage
+coverage:cuda --per_file_copt=-external/.*,-test/.*@--coverage
 coverage:cuda --linkopt=-lgcov
 
 build:acl --define==build_with_acl=true

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -167,13 +167,19 @@ function run_torch_xla_tests() {
     fi
     if [ -x "$(command -v nvidia-smi)" ]; then
       PJRT_DEVICE=GPU test/cpp/run_tests.sh $EXTRA_ARGS
-      cp $XLA_DIR/bazel-out/_coverage/_coverage_report.dat /tmp/cov1.dat
+      if [ "$USE_COVERAGE" != "0" ]; then
+        cp $XLA_DIR/bazel-out/_coverage/_coverage_report.dat /tmp/cov1.dat
+      fi
       PJRT_DEVICE=GPU test/cpp/run_tests.sh -X early_sync -F AtenXlaTensorTest.TestEarlySyncLiveTensors -L"" $EXTRA_ARGS
-      cp $XLA_DIR/bazel-out/_coverage/_coverage_report.dat /tmp/cov2.dat
-      lcov --add-tracefile /tmp/cov1.dat -a /tmp/cov2.dat -o /tmp/merged.dat
+      if [ "$USE_COVERAGE" != "0" ]; then
+        cp $XLA_DIR/bazel-out/_coverage/_coverage_report.dat /tmp/cov2.dat
+        lcov --add-tracefile /tmp/cov1.dat -a /tmp/cov2.dat -o /tmp/merged.dat
+      fi
     else
       PJRT_DEVICE=CPU test/cpp/run_tests.sh $EXTRA_ARGS
-      cp $XLA_DIR/bazel-out/_coverage/_coverage_report.dat /tmp/merged.dat
+      if [ "$USE_COVERAGE" != "0" ]; then
+        cp $XLA_DIR/bazel-out/_coverage/_coverage_report.dat /tmp/merged.dat
+      fi
     fi
     if [ "$USE_COVERAGE" != "0" ]; then
       genhtml /tmp/merged.dat -o ~/htmlcov/cpp/cpp_lcov.info

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -157,25 +157,27 @@ function run_torch_xla_tests() {
       fi
     fi
 
-    pushd test/cpp
-      echo "Running C++ Tests on PJRT"
-      EXTRA_ARGS=""
-      if [ "$USE_COVERAGE" != "0" ]; then
-	      EXTRA_ARGS="-C"
-      fi
-      if [ ! -z "$GCLOUD_SERVICE_KEY_FILE" ]; then
-	      EXTRA_ARGS="$EXTRA_ARGS -R"
-      fi
-      if [ -x "$(command -v nvidia-smi)" ]; then
-        PJRT_DEVICE=GPU ./run_tests.sh $EXTRA_ARGS
-        PJRT_DEVICE=GPU ./run_tests.sh -X early_sync -F AtenXlaTensorTest.TestEarlySyncLiveTensors -L"" $EXTRA_ARGS
-      else
-        PJRT_DEVICE=CPU ./run_tests.sh $EXTRA_ARGS
-      fi
-      if [ "$USE_COVERAGE" != "0" ]; then
-        genhtml $XLA_DIR/bazel-out/_coverage/_coverage_report.dat -o ~/htmlcov/cpp/cpp_lcov.info
-        mv $XLA_DIR/bazel-out/_coverage/_coverage_report.dat ~/htmlcov/cpp_lcov.info
-      fi
-    popd
+    echo "Running C++ Tests on PJRT"
+    EXTRA_ARGS=""
+    if [ "$USE_COVERAGE" != "0" ]; then
+	    EXTRA_ARGS="-C"
+    fi
+    if [ ! -z "$GCLOUD_SERVICE_KEY_FILE" ]; then
+	    EXTRA_ARGS="$EXTRA_ARGS -R"
+    fi
+    if [ -x "$(command -v nvidia-smi)" ]; then
+      PJRT_DEVICE=GPU test/cpp/run_tests.sh $EXTRA_ARGS
+      cp $XLA_DIR/bazel-out/_coverage/_coverage_report.dat /tmp/cov1.dat
+      PJRT_DEVICE=GPU test/cpp/run_tests.sh -X early_sync -F AtenXlaTensorTest.TestEarlySyncLiveTensors -L"" $EXTRA_ARGS
+      cp $XLA_DIR/bazel-out/_coverage/_coverage_report.dat /tmp/cov2.dat
+      lcov --add-tracefile /tmp/cov1.dat -a /tmp/cov2.dat -o /tmp/merged.dat
+    else
+      PJRT_DEVICE=CPU test/cpp/run_tests.sh $EXTRA_ARGS
+      cp $XLA_DIR/bazel-out/_coverage/_coverage_report.dat /tmp/merged.dat
+    fi
+    if [ "$USE_COVERAGE" != "0" ]; then
+      genhtml /tmp/merged.dat -o ~/htmlcov/cpp/cpp_lcov.info
+      mv /tmp/merged.dat ~/htmlcov/cpp_lcov.info
+    fi
   popd
 }


### PR DESCRIPTION
Passing `--config=cuda` to bazel makes it use a nvc/gcc compiler infrastructure in `@local_config_cuda` that is immune to the `bazel coverage` intervention in coverage flags. Setting those flags manually solves the problem.