### PR TITLE
[PJRT] Cache world size and ordinal only when addressable_device_count == 1

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -37,11 +37,8 @@ _ORDINAL = None
 def _init_world_size_ordinal():
   global _WORLD_SIZE, _ORDINAL
 
-  if not pjrt.using_pjrt():
-    return
-
-  # We don't support V3-8. See Note [V3-8 Threading]
-  if pjrt.device_type() == 'TPU' and tpu.version() < 4:
+  # Dynamo doesn't support XRT or multithreaded PJRT. See Note [V3-8 Threading]
+  if not pjrt.using_pjrt() or pjrt.addressable_device_count() > 1:
     return
 
   if _WORLD_SIZE is None:


### PR DESCRIPTION
We currently check TPU version instead, which gives incorrect results when debugging multithreaded workloads on TPU v4 (e.g. `TPU_PROCESS_BOUNDS=1,1,1 TPU_CHIPS_PER_PROCESS_BOUNDS=2,2,1 TPU_VISIBLE_CHIPS=0,1,2,3`)