### PR TITLE
Add Python 3.10 nightly build

### DIFF
--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -4,6 +4,10 @@ nightly_package_version = "2.0"
 nightly_builds = [
   { accelerator = "tpu" },
   {
+    accelerator  = "tpu"
+    python_version = "3.10"
+  },
+  {
     accelerator  = "cuda"
     cuda_version = "11.8"
   },


### PR DESCRIPTION
<details>

<summary>terraform plan</summary>

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.nightly_builds["3.10_tpuvm"].module.cloud_build.google_cloudbuild_trigger.trigger will be created
  + resource "google_cloudbuild_trigger" "trigger" {
      + create_time = (known after apply)
      + description = "Builds nightly xla:nightly_3.10_tpuvm' TPU docker image and corresponding wheels for PyTorch/XLA. Trigger managed by Terraform setup in infra/tpu-pytorch-releases/artifacts_builds.tf."
      + id          = (known after apply)
      + location    = "us-central1"
      + name        = "nightly-3-10-tpuvm"
      + project     = (known after apply)
      + trigger_id  = (known after apply)

      + approval_config {
          + approval_required = (known after apply)
        }

      + build {
          + timeout = "21600s"

          + options {
              + dynamic_substitutions = true
              + substitution_option   = "ALLOW_LOOSE"
              + worker_pool           = "projects/tpu-pytorch-releases/locations/us-central1/workerPools/main"
            }

          + step {
              + args = [
                  + "fetch",
                  + "--unshallow",
                ]
              + id   = "git_fetch"
              + name = "gcr.io/cloud-builders/git"
            }
          + step {
              + args = [
                  + "checkout",
                  + "origin/master",
                ]
              + id   = "git_checkout"
              + name = "gcr.io/cloud-builders/git"
            }
          + step {
              + args       = [
                  + "-c",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"nightly_release\":\"true\",\"package_version\":\"2.0\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"HEAD\",\"xla_git_rev\":\"HEAD\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.10_tpuvm)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.10_tpuvm_$(date +%Y%m%d))\" -t=local_image",
                ]
              + dir        = "infra/ansible"
              + entrypoint = "bash"
              + id         = "build_xla_docker_image"
              + name       = "gcr.io/cloud-builders/docker"
            }
          + step {
              + args       = [
                  + "-c",
                  + "docker push --all-tags us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla",
                ]
              + entrypoint = "bash"
              + id         = "push_xla_docker_image"
              + name       = "gcr.io/cloud-builders/docker"
            }
          + step {
              + args       = [
                  + "-c",
                  + "echo The following wheels will be published && ls /dist/*.whl && cp /dist/*.whl /wheels",
                ]
              + entrypoint = "bash"
              + id         = "copy_wheels_to_volume"
              + name       = "local_image"

              + volumes {
                  + name = "wheels"
                  + path = "/wheels"
                }
            }
          + step {
              + args       = [
                  + "-c",
                  + "gsutil cp /wheels/*.whl gs://pytorch-xla-releases/wheels/tpuvm",
                ]
              + entrypoint = "bash"
              + id         = "upload_wheels_to_storage_bucket"
              + name       = "gcr.io/cloud-builders/gsutil"

              + volumes {
                  + name = "wheels"
                  + path = "/wheels"
                }
            }
        }

      + source_to_build {
          + ref       = "refs/heads/master"
          + repo_type = "GITHUB"
          + uri       = "https://github.com/pytorch/xla"
        }
    }

  # module.nightly_builds["3.10_tpuvm"].module.cloud_build.module.schedule_triggers[0].google_cloud_scheduler_job.trigger_schedule will be created
  + resource "google_cloud_scheduler_job" "trigger_schedule" {
      + id        = (known after apply)
      + name      = "nightly-3-10-tpuvm-schedule"
      + paused    = (known after apply)
      + project   = (known after apply)
      + region    = (known after apply)
      + schedule  = "0 0 * * *"
      + state     = (known after apply)
      + time_zone = "America/Los_Angeles"

      + http_target {
          + http_method = "POST"
          + uri         = (known after apply)

          + oauth_token {
              + service_account_email = "build-triggers-scheduler@tpu-pytorch-releases.iam.gserviceaccount.com"
            }
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```

</details>