### PR TITLE
Wrap implicitly-replicated data in PjRtShardedData

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -2,6 +2,7 @@ import copy
 
 import unittest
 import numpy as np
+import os
 
 import torch
 from torch import nn
@@ -14,6 +15,11 @@ import test_xla_sharding_base
 
 
 class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
+
+  @classmethod
+  def setUpClass(cls):
+    os.environ["XLA_USE_SPMD"] = "1"
+    super().setUpClass()
 
   def test_xla_sharded_tensor(self):
     partition_spec = (0, 1)

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -228,6 +228,11 @@ ComputationClient::DataPtr PjRtComputationClient::TransferShardsToServer(
     xla::Shape shape, xla::OpSharding sharding) {
   TF_VLOG(1) << "TransferShardsToServer with " << tensor_shards.size()
              << " shards.";
+  // TODO(jonbolin): Consider using CopyToDevice when sharding is REPLICATED.
+  // We are opting out of CopyToDevice for now due to the synchronization
+  // issues observed in ShardingUtil::InputHandler, but because CopyToDevice
+  // directly copies buffers between devices using ICI, it can be much faster
+  // than transferring from the host to each device.
   auto data_shards = TransferToServer(tensor_shards);
   std::vector<std::shared_ptr<PjRtData>> pjrt_data_shards;
   for (auto& shard : data_shards) {
@@ -265,6 +270,10 @@ ComputationClient::DataPtr PjRtComputationClient::ReplicateShardedData(
           dynamic_cast<PjRtShardedData*>(handle.get())) {
     TF_VLOG(1) << "ReplicateShardedData (handle=" << handle->GetOpaqueHandle()
                << ", shape=" << handle->shape() << ")";
+    if (sharded_data->GetSharding().type() == xla::OpSharding::REPLICATED) {
+      // Data is replicated, return the first shard
+      return sharded_data->shards[0];
+    }
     xla::XlaBuilder b("ReplicateShardedData");
     xla::Shape shape = sharded_data->shape();
     b.SetSharding(sharded_data->GetSharding());

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -43,6 +43,7 @@
 #include "torch_xla/csrc/tensor_util.h"
 #include "torch_xla/csrc/torch_util.h"
 #include "torch_xla/csrc/xla_graph_executor.h"
+#include "torch_xla/csrc/xla_sharding_util.h"
 
 // [Implementation Guidelines]
 // - If you want to call a at::func which doesn't have a kernel registered
@@ -474,7 +475,7 @@ at::Tensor XLANativeFunctions::_copy_from(const at::Tensor& self,
   if (!self_tensor) {
     static bool sync_update =
         xla::sys_util::GetEnvBool("XLA_TENSOR_UPDATE_SYNC", true) &&
-        !xla::sys_util::GetEnvBool("XLA_USE_SPMD", false);
+        !ShardingUtil::UseVirtualDevice();
     XLA_CHECK(dst_tensor);
     dst_tensor->UpdateFromTensor(self, /*sync=*/sync_update);
   } else if (!dst_tensor) {

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -497,10 +497,9 @@ void XLATensor::SetTensor(at::Tensor tensor) {
 }
 
 void XLATensor::UpdateFromTensor(at::Tensor tensor, bool sync) {
-  torch::lazy::BackendDevice device =
-      xla::sys_util::GetEnvBool("XLA_USE_SPMD", false)
-          ? ParseDeviceString("SPMD:0")
-          : GetDevice();
+  torch::lazy::BackendDevice device = ShardingUtil::UseVirtualDevice()
+                                          ? ParseDeviceString("SPMD:0")
+                                          : GetDevice();
   if (sync) {
     at::Tensor typed_tensor =
         torch::lazy::CopyTensor(tensor, dtype(), /*copy=*/false);

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -48,6 +48,19 @@ std::vector<int64_t> TileAssignmentDimensions(
 
 }  // namespace
 
+bool ShouldUseVirtualDevice() {
+  bool use_virtual_device = xla::sys_util::GetEnvBool("XLA_USE_SPMD", false);
+  if (use_virtual_device) {
+    TF_LOG(INFO) << "Using SPMD virtual device optimization";
+  }
+  return use_virtual_device;
+}
+
+bool ShardingUtil::UseVirtualDevice() {
+  static bool use_virtual_device = ShouldUseVirtualDevice();
+  return use_virtual_device;
+}
+
 bool ShardingUtil::SetHloSharding(LoweringContext* lowering_ctx) {
   bool is_sharded = false;
   for (std::pair<torch::lazy::Output, xla::XlaOp> elem :
@@ -203,25 +216,12 @@ ShardingUtil::InputHandler(
   for (int64_t argument_i = 0; argument_i < arguments.size(); ++argument_i) {
     auto shards =
         xla::ComputationClient::Get()->GetDataShards(arguments[argument_i]);
-    if (shards.size() > 1) {
-      // Input is sharded across addressable devices
-      for (auto shard : shards) {
-        int global_ordinal = ParseDeviceString(shard->device()).ordinal();
-        int device_i = device_index[global_ordinal];
-        arguments_by_device[device_i][argument_i] = shard;
-      }
-    } else {
-      // Input is replicated across addressable devices
-      int global_ordinal = ParseDeviceString(shards[0]->device()).ordinal();
-      int source_device_i = device_index[global_ordinal];
-      arguments_by_device[source_device_i][argument_i] = shards[0];
-      for (int64_t device_i = 0; device_i < devices.size(); ++device_i) {
-        if (device_i != source_device_i) {
-          arguments_by_device[device_i][argument_i] =
-              xla::ComputationClient::Get()->CopyToDevice(shards[0],
-                                                          devices[device_i]);
-        }
-      }
+    // With SPMD execution, all input is distributed across addressable devices,
+    // either by sharding or replication.
+    for (auto shard : shards) {
+      int global_ordinal = ParseDeviceString(shard->device()).ordinal();
+      int device_i = device_index[global_ordinal];
+      arguments_by_device[device_i][argument_i] = shard;
     }
   }
 
@@ -236,35 +236,36 @@ std::vector<xla::ComputationClient::DataPtr> ShardingUtil::OutputHandler(
   outputs.reserve(sharding_specs.size());
   for (int i = 0; i < sharding_specs.size(); ++i) {
     XLATensor::ShardingSpecPtr sharding = sharding_specs[i];
-    if (sharding &&
+    if (replicated_output && sharding &&
         (sharding->sharding.type() != xla::OpSharding::REPLICATED)) {
       XLA_CHECK(sharding->shape.has_value())
           << "Sharding or Wrapping data shards in OutputHandler requires "
              "unpartitioned tensor shape.";
-      if (replicated_output) {
-        // Reshards replicated output if `sharding` is present.
-        std::vector<at::Tensor> tensors = XlaDataToTensors(
-            {WrapXlaData(sharded_results[0][i])},
-            TensorTypeFromXlaType(sharding->shape.value().element_type()));
-        outputs.push_back(UnwrapXlaData(CreateTensorsData(
-            tensors, {sharding},
-            std::vector<std::string>{GetVirtualDevice().toString()})[0]));
-      } else {
-        // Creates a PjRtShardedData from output shards.
-        // TODO(yeounoh) consider propagating input sharding to output.
-        std::vector<xla::ComputationClient::DataPtr> shards;
-        shards.reserve(sharded_results.size());
-        for (int j = 0; j < sharded_results.size(); ++j) {
-          XLA_CHECK(sharded_results[j][i]->HasValue());
-          shards.push_back(sharded_results[j][i]);
-        }
-        outputs.push_back(xla::ComputationClient::Get()->WrapDataShards(
-            shards, GetVirtualDevice().toString(), sharding->shape.value(),
-            sharding->sharding));
-      }
+      // Reshards replicated output if `sharding` is present.
+      // TODO(yeounoh) consider propagating input sharding to output.
+      std::vector<at::Tensor> tensors = XlaDataToTensors(
+          {WrapXlaData(sharded_results[0][i])},
+          TensorTypeFromXlaType(sharding->shape.value().element_type()));
+      outputs.push_back(UnwrapXlaData(CreateTensorsData(
+          tensors, {sharding},
+          std::vector<std::string>{GetVirtualDevice().toString()})[0]));
     } else {
-      // Replicated results
-      outputs.push_back(sharded_results[0][i]);
+      std::vector<xla::ComputationClient::DataPtr> shards;
+      shards.reserve(sharded_results.size());
+      for (int j = 0; j < sharded_results.size(); ++j) {
+        XLA_CHECK(sharded_results[j][i]->HasValue());
+        shards.push_back(sharded_results[j][i]);
+      }
+      if (!sharding) {
+        // Without an explicit sharding annotation, the output is implicitly
+        // replicated
+        sharding = std::make_shared<XLATensor::ShardingSpec>(
+            xla::HloSharding::Replicate().ToProto(),
+            sharded_results[0][i]->shape());
+      }
+      outputs.push_back(xla::ComputationClient::Get()->WrapDataShards(
+          shards, GetVirtualDevice().toString(), sharding->shape.value(),
+          sharding->sharding));
     }
   }
   return outputs;

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -14,6 +14,10 @@ namespace torch_xla {
 
 class ShardingUtil {
  public:
+  // Test whether the XLA_USE_SPMD environment variable is set to enable the
+  // virtual device optimization.
+  static bool UseVirtualDevice();
+
   // Annotates HLO instructions in the lowered computation and returns true if
   // the computation needs to be compiled with SPMD partitioning. For this call
   // to be effective, this needs to be called after the lowering and before

--- a/torch_xla/experimental/xla_sharding.py
+++ b/torch_xla/experimental/xla_sharding.py
@@ -157,5 +157,4 @@ class ShardingSpec:
   def apply(self, t: torch.Tensor):
     # TODO(yeounoh) use virtual device interface when available.
     assert (t.device == xm.xla_device())
-    assert (xu.check_env_flag('XLA_USE_SPMD'))
     mark_sharding(t, self.mesh, self.partition_spec)


### PR DESCRIPTION
This change wraps replicated tensors in `PjRtShardedData`, when the `XLA_USE_SPMD` environment variable is set. Doing so eliminates the overhead from implicitly replicating tensors each step, since the replicated handles are tracked within the `PjRtShardedData` wrapper. On Hugginface GPT-2, this decreases TPU idle time between steps from ~450ms to ~8ms

This takes effect in three places:
- Unsharded `CreateTensorsData`
- Sharded `CreateTensorsData` when sharding is null
- `TensorToXlaData` when the virtual device optimization is bypassed (as is the case for scalars/seeds)

Additionally, this change adds a static variable to test whether the virtual device is active to avoid querying the environment variable each time, and it adds the requirement that the environment variable is set to run in SPMD mode.