### PR TITLE
Add trigger for dev image with cuda support

### DIFF
--- a/infra/tpu-pytorch/cloud_builds.tf
+++ b/infra/tpu-pytorch/cloud_builds.tf
@@ -1,7 +1,32 @@
-module "dev_image" {
-  source = "../terraform_modules/xla_docker_build"
+variable "dev_images" {
+  type = list(object({
+    accelerator    = string
+    arch           = optional(string, "amd64")
+    python_version = optional(string, "3.8")
+    cuda_version   = optional(string, "11.8")
 
-  trigger_name = "dev-image"
+    # Additional tags on top of uniquely generated tag based on accelerator,
+    # python and cuda versions.
+    extra_tags = optional(list(string), [])
+  }))
+}
+
+locals {
+  dev_images_dict = {
+    for di in var.dev_images :
+    format("%s_%s",
+      di.python_version,
+      di.accelerator == "tpu" ? "tpuvm" : format("cuda_%s", di.cuda_version)
+    ) => di
+  }
+}
+
+module "dev_images" {
+  source   = "../terraform_modules/xla_docker_build"
+  for_each = local.dev_images_dict
+
+  # Replace `.` and `_` with `-` as they're not allowed in trigger name.
+  trigger_name = "dev-${replace(each.key, "/[_.]/", "-")}"
 
   ansible_branch = "master"
   trigger_on_push = {
@@ -10,26 +35,31 @@ module "dev_image" {
   }
 
   image_name = "development"
-  image_tags = [
-    "tpu",
-    # Append _YYYYMMDD suffix to nightly image name.
-    "tpu_$(date +%Y%m%d)",
-  ]
+  image_tags = concat(each.value.extra_tags, [
+    each.key,
+    # Append _YYYYMMDD suffix to the dev image name.
+    "${each.key}_$(date +%Y%m%d)",
+  ])
+
   dockerfile = "development.Dockerfile"
   description = join(" ", [
-    "Build development image with TPU support.",
-    "Trigger managed by Terraform setup in",
-    "infra/tpu-pytorch/cloud_builds.tf.",
+    "Builds development:${each.key} image.",
+    "Trigger managed by Terraform setup in infra/tpu-pytorch/cloud_builds.tf.",
   ])
 
   build_args = {
-    python_version = "3.8"
+    python_version = each.value.python_version
     debian_version = "buster"
   }
 
   ansible_vars = {
-    arch        = "amd64"
-    accelerator = "tpu"
+    xla_git_rev     = "$COMMIT_ID"
+    pytorch_git_rev = "main"
+
+    accelerator    = each.value.accelerator
+    arch           = each.value.arch
+    python_version = each.value.python_version
+    cuda_version   = each.value.cuda_version
   }
 
   docker_repo_url = module.docker_registry.url

--- a/infra/tpu-pytorch/dev_images.auto.tfvars
+++ b/infra/tpu-pytorch/dev_images.auto.tfvars
@@ -1,0 +1,11 @@
+dev_images = [
+  {
+    accelerator = "tpu"
+    extra_tags  = ["tpu"]
+  },
+  {
+    accelerator  = "cuda"
+    cuda_version = "11.8"
+    extra_tags   = ["cuda"]
+  }
+]


### PR DESCRIPTION
Refactor dev images resource (module instance) to produce triggers from a list.

Terraform plan:

1. Delete previous dev-image trigger (it's safe).
2. Add 2 new ones.

```
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
  - destroy

Terraform will perform the following actions:

  # module.dev_image.module.cloud_build.google_cloudbuild_trigger.trigger will be destroyed
  # (because google_cloudbuild_trigger.trigger is not in configuration)
  - resource "google_cloudbuild_trigger" "trigger" {
      - create_time        = "2023-04-03T14:18:13.727011882Z" -> null
      - description        = "Build development image with TPU support. Trigger managed by Terraform setup in infra/tpu-pytorch/cloud_builds.tf." -> null
      - disabled           = false -> null
      - id                 = "projects/tpu-pytorch/triggers/9bb1439d-5e5c-4860-a883-4b749d2696bd" -> null
      - ignored_files      = [] -> null
      - include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS" -> null
      - included_files     = [
          - "infra/**",
        ] -> null
      - location           = "global" -> null
      - name               = "dev-image" -> null
      - project            = "tpu-pytorch" -> null
      - substitutions      = {} -> null
      - tags               = [] -> null
      - trigger_id         = "9bb1439d-5e5c-4860-a883-4b749d2696bd" -> null

      - approval_config {
          - approval_required = false -> null
        }

      - build {
          - images        = [] -> null
          - substitutions = {} -> null
          - tags          = [] -> null
          - timeout       = "3600s" -> null

          - options {
              - disk_size_gb           = 0 -> null
              - dynamic_substitutions  = true -> null
              - env                    = [] -> null
              - secret_env             = [] -> null
              - source_provenance_hash = [] -> null
              - substitution_option    = "ALLOW_LOOSE" -> null
              - worker_pool            = "projects/tpu-pytorch/locations/us-central1/workerPools/main" -> null
            }

          - step {
              - args       = [
                  - "fetch",
                  - "--unshallow",
                ] -> null
              - env        = [] -> null
              - id         = "git_fetch" -> null
              - name       = "gcr.io/cloud-builders/git" -> null
              - secret_env = [] -> null
              - wait_for   = [] -> null
            }
          - step {
              - args       = [
                  - "checkout",
                  - "origin/master",
                ] -> null
              - env        = [] -> null
              - id         = "git_checkout" -> null
              - name       = "gcr.io/cloud-builders/git" -> null
              - secret_env = [] -> null
              - wait_for   = [] -> null
            }
          - step {
              - args       = [
                  - "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=development.Dockerfile . --build-arg=debian_version=buster --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch/docker/development:$(echo tpu)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch/docker/development:$(echo tpu_$(date +%Y%m%d))\" -t=local_image",
                ] -> null
              - dir        = "infra/ansible" -> null
              - entrypoint = "bash" -> null
              - env        = [] -> null
              - id         = "build_development_docker_image" -> null
              - name       = "gcr.io/cloud-builders/docker" -> null
              - secret_env = [] -> null
              - wait_for   = [] -> null
            }
          - step {
              - args       = [
                  - "-c",
                  - "docker push --all-tags us-central1-docker.pkg.dev/tpu-pytorch/docker/development",
                ] -> null
              - entrypoint = "bash" -> null
              - env        = [] -> null
              - id         = "push_development_docker_image" -> null
              - name       = "gcr.io/cloud-builders/docker" -> null
              - secret_env = [] -> null
              - wait_for   = [] -> null
            }
        }

      - github {
          - name  = "xla" -> null
          - owner = "pytorch" -> null

          - push {
              - branch       = "^master$" -> null
              - invert_regex = false -> null
            }
        }
    }

  # module.dev_images["3.8_cuda_11.8"].module.cloud_build.google_cloudbuild_trigger.trigger will be created
  + resource "google_cloudbuild_trigger" "trigger" {
      + create_time        = (known after apply)
      + description        = "Builds development:3.8_cuda_11.8 image. Trigger managed by Terraform setup in infra/tpu-pytorch/cloud_builds.tf."
      + id                 = (known after apply)
      + include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
      + included_files     = [
          + "infra/**",
        ]
      + location           = "global"
      + name               = "dev-3-8-cuda-11-8"
      + project            = (known after apply)
      + trigger_id         = (known after apply)

      + approval_config {
          + approval_required = (known after apply)
        }

      + build {
          + timeout = "3600s"

          + options {
              + dynamic_substitutions = true
              + substitution_option   = "ALLOW_LOOSE"
              + worker_pool           = "projects/tpu-pytorch/locations/us-central1/workerPools/main"
            }

          + step {
              + args = [
                  + "fetch",
                  + "--unshallow",
                ]
              + id   = "git_fetch"
              + name = "gcr.io/cloud-builders/git"
            }
          + step {
              + args = [
                  + "checkout",
                  + "origin/master",
                ]
              + id   = "git_checkout"
              + name = "gcr.io/cloud-builders/git"
            }
          + step {
              + args       = [
                  + "-c",
                  + "docker build --progress=plain --network=cloudbuild -f=development.Dockerfile . --build-arg=debian_version=buster --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_ID\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch/docker/development:$(echo cuda)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch/docker/development:$(echo 3.8_cuda_11.8)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch/docker/development:$(echo 3.8_cuda_11.8_$(date +%Y%m%d))\" -t=local_image",
                ]
              + dir        = "infra/ansible"
              + entrypoint = "bash"
              + id         = "build_development_docker_image"
              + name       = "gcr.io/cloud-builders/docker"
            }
          + step {
              + args       = [
                  + "-c",
                  + "docker push --all-tags us-central1-docker.pkg.dev/tpu-pytorch/docker/development",
                ]
              + entrypoint = "bash"
              + id         = "push_development_docker_image"
              + name       = "gcr.io/cloud-builders/docker"
            }
        }

      + github {
          + name  = "xla"
          + owner = "pytorch"

          + push {
              + branch = "^master$"
            }
        }
    }

  # module.dev_images["3.8_tpuvm"].module.cloud_build.google_cloudbuild_trigger.trigger will be created
  + resource "google_cloudbuild_trigger" "trigger" {
      + create_time        = (known after apply)
      + description        = "Builds development:3.8_tpuvm image. Trigger managed by Terraform setup in infra/tpu-pytorch/cloud_builds.tf."
      + id                 = (known after apply)
      + include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
      + included_files     = [
          + "infra/**",
        ]
      + location           = "global"
      + name               = "dev-3-8-tpuvm"
      + project            = (known after apply)
      + trigger_id         = (known after apply)

      + approval_config {
          + approval_required = (known after apply)
        }

      + build {
          + timeout = "3600s"

          + options {
              + dynamic_substitutions = true
              + substitution_option   = "ALLOW_LOOSE"
              + worker_pool           = "projects/tpu-pytorch/locations/us-central1/workerPools/main"
            }

          + step {
              + args = [
                  + "fetch",
                  + "--unshallow",
                ]
              + id   = "git_fetch"
              + name = "gcr.io/cloud-builders/git"
            }
          + step {
              + args = [
                  + "checkout",
                  + "origin/master",
                ]
              + id   = "git_checkout"
              + name = "gcr.io/cloud-builders/git"
            }
          + step {
              + args       = [
                  + "-c",
                  + "docker build --progress=plain --network=cloudbuild -f=development.Dockerfile . --build-arg=debian_version=buster --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_ID\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch/docker/development:$(echo tpu)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch/docker/development:$(echo 3.8_tpuvm)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch/docker/development:$(echo 3.8_tpuvm_$(date +%Y%m%d))\" -t=local_image",
                ]
              + dir        = "infra/ansible"
              + entrypoint = "bash"
              + id         = "build_development_docker_image"
              + name       = "gcr.io/cloud-builders/docker"
            }
          + step {
              + args       = [
                  + "-c",
                  + "docker push --all-tags us-central1-docker.pkg.dev/tpu-pytorch/docker/development",
                ]
              + entrypoint = "bash"
              + id         = "push_development_docker_image"
              + name       = "gcr.io/cloud-builders/docker"
            }
        }

      + github {
          + name  = "xla"
          + owner = "pytorch"

          + push {
              + branch = "^master$"
            }
        }
    }

Plan: 2 to add, 0 to change, 1 to destroy.
```

