### PR TITLE
Replace COMMIT_ID with COMMIT_SHA

### DIFF
--- a/infra/tpu-pytorch/cloud_builds.tf
+++ b/infra/tpu-pytorch/cloud_builds.tf
@@ -53,7 +53,7 @@ module "dev_images" {
   }
 
   ansible_vars = {
-    xla_git_rev     = "$COMMIT_ID"
+    xla_git_rev     = "$COMMIT_SHA"
     pytorch_git_rev = "main"
 
     accelerator    = each.value.accelerator


### PR DESCRIPTION
COMMIT_SHA is substituted by cloud build, not commit_id.