### PR TITLE
Rearrange coverage config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -56,7 +56,6 @@ build:cuda --define=xla_python_enable_gpu=true
 build:cuda --cxxopt=-DXLA_CUDA=1
 
 # Coverage with cuda/gcc/nvcc requires manually setting coverage flags.
-coverage:cuda --per_file_copt=third_party/.*,torch_xla/.*@--coverage
 coverage:cuda --linkopt=-lgcov
 
 build:acl --define==build_with_acl=true
@@ -125,13 +124,15 @@ build:compdb --features=-layering_check
 # Compiling tests requires Java.
 build --java_runtime_version=remotejdk_11
 
-# Coverage requires Java and GCC.
+# Coverage setup.
 coverage --config=coverage
-coverage --build_tests_only
-coverage --instrumentation_filter="//torch_xla/,//third_party/"
+coverage --instrumentation_filter="//torch_xla[/:],//third_party[/:],-//test[/:]"
 coverage --combined_report=lcov
 coverage --nocache_test_results
-build:coverage --strategy=CoverageReport=sandboxed,local
+
+# Only instrument the repository, not external dependencies.
+build:coverage --per_file_copt=-external/.*,-test/.*@--coverage
+
 build:coverage --test_tag_filters=-nocoverage
 
 ############################################################################

--- a/.bazelrc
+++ b/.bazelrc
@@ -56,6 +56,7 @@ build:cuda --define=xla_python_enable_gpu=true
 build:cuda --cxxopt=-DXLA_CUDA=1
 
 # Coverage with cuda/gcc/nvcc requires manually setting coverage flags.
+coverage:cuda --per_file_copt=third_party/.*,torch_xla/.*@--coverage
 coverage:cuda --linkopt=-lgcov
 
 build:acl --define==build_with_acl=true
@@ -129,9 +130,10 @@ coverage --config=coverage
 coverage --instrumentation_filter="//torch_xla[/:],//third_party[/:],-//test[/:]"
 coverage --combined_report=lcov
 coverage --nocache_test_results
+build:coverage --strategy=CoverageReport=sandboxed,local
 
-# Only instrument the repository, not external dependencies.
-build:coverage --per_file_copt=-external/.*,-test/.*@--coverage
+# Required for downloading coverage information; otherwise coverage succeeds but not present.
+coverage --remote_download_outputs=all
 
 build:coverage --test_tag_filters=-nocoverage
 


### PR DESCRIPTION
The root cause of coverage "not working" is that we don't download its cached output from the remote cache.

Specifying to download all build results, not only the toplevel (binaries vs all objects) for coverage also fetches remote coverage stuff and it works.

It's always worked, but was not available locally for the scripts to copy.

Coverage report file only changes if tests cover new lines or new symbols, or new files appear, which doesnnot happen on every PR. Its hash remains the same so it's not recreated, but just cached and not downloaded.

I'll open an issue with bazel to try to argue that the coverage report dat file *should be* considered a top level result in case of `bazel coverage` invocations. For now, we download *all* build objects from cache, to get the coverage report as well.