### PR TITLE
Fix coverage for C++ in XLA.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -126,14 +126,12 @@ build:compdb --features=-layering_check
 build --java_runtime_version=remotejdk_11
 
 # Coverage setup.
+coverage --build_tests_only
 coverage --config=coverage
 coverage --instrumentation_filter="//torch_xla[/:],//third_party[/:],-//test[/:]"
 coverage --combined_report=lcov
 coverage --nocache_test_results
 build:coverage --strategy=CoverageReport=sandboxed,local
-
-# Required for downloading coverage information; otherwise coverage succeeds but not present.
-coverage --remote_download_outputs=all
 
 build:coverage --test_tag_filters=-nocoverage
 

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -69,6 +69,9 @@ fi
 if [[ "$XLA_CUDA" == "1" ]]; then
   EXTRA_FLAGS="$EXTRA_FLAGS --config=cuda"
 fi
+if [[ "$BAZEL_VERB" == "coverage" ]]; then
+  EXTRA_FLAGS="$EXTRA_FLAGS --remote_download_outputs=all" # for lcov symlink
+fi
 
 
 if [ "$LOGFILE" != "" ]; then


### PR DESCRIPTION
The root cause is very contrived. `bazel coverage` works well, and calculates the coverage. The output `lcov` data is written and a deterministic symlink is provided for it under `bazel-out`.

On the second run, the file disappears. The reason is that we use a remote cache, and that we don't download all artifacts from the build, just the toplevel artifacts. From bazel 7.0.0, coverage symlinks will be included, but for now we have to specify that we want to download all outputs; we only want to do this when doing coverage.

We cannot specify this in the `.bazelrc` file because the coverage command inherits the flags from the remote build command; one of the flags there is setting the minimal output for fetching the toplevel objects, but it actually sets three separate flags, and we can only override the one here, so we end up in an bad state: still downloading the minimal output that does not yet support symlinks. Overriding the flag on the CLI works because it gets the highest priority and overrides the same flag from the remote build config.

This is not easy to test in the CI because on the uncached run it always works, but on the second PR where the code coverage hash has not changed, which is often the case, it resolves to the cached symlink that is not fetched and fails subsequently.