### PR TITLE
[PJRT] Reduce the number of CPU transfers in rendezvous

### DIFF
--- a/test/pjrt/test_mesh_service.py
+++ b/test/pjrt/test_mesh_service.py
@@ -55,7 +55,8 @@ class PjRtMeshServiceTest(parameterized.TestCase):
     return met.counter_value('xla::_to_cpu')
 
   def test_rendezvous_default_payload_cpu_transfers(self):
-    results = pjrt._run_multiprocess(self.rendezvous_default_payload_cpu_transfers)
+    results = pjrt._run_multiprocess(
+        self.rendezvous_default_payload_cpu_transfers)
 
     # Expect one CPU transfer: the max size of all payloads
     for val in results.values():

--- a/test/pjrt/test_mesh_service.py
+++ b/test/pjrt/test_mesh_service.py
@@ -54,7 +54,7 @@ class PjRtMeshServiceTest(parameterized.TestCase):
 
     return met.counter_value('xla::_to_cpu')
 
-  def test_rendezvous_default_payload_unlowered_ops(self):
+  def test_rendezvous_default_payload_cpu_transfers(self):
     results = pjrt._run_multiprocess(self.rendezvous_default_payload_cpu_transfers)
 
     # Expect one CPU transfer: the max size of all payloads

--- a/test/pjrt/test_mesh_service.py
+++ b/test/pjrt/test_mesh_service.py
@@ -1,6 +1,7 @@
 import functools
 from absl.testing import absltest, parameterized
 
+import torch_xla.debug.metrics as met
 import torch_xla.core.xla_model as xm
 from torch_xla.experimental import pjrt
 
@@ -46,6 +47,19 @@ class PjRtMeshServiceTest(parameterized.TestCase):
 
     expected = [b''] * len(results)
     self.assertDictEqual(results, {r: expected for r in results})
+
+  @staticmethod
+  def rendezvous_default_payload_cpu_transfers():
+    xm.rendezvous('test rendezvous')
+
+    return met.counter_value('xla::_to_cpu')
+
+  def test_rendezvous_default_payload_unlowered_ops(self):
+    results = pjrt._run_multiprocess(self.rendezvous_default_payload_cpu_transfers)
+
+    # Expect one CPU transfer: the max size of all payloads
+    for val in results.values():
+      self.assertEqual(val, 1)
 
   def test_rendezvous_string_payload(self):
     test_fn = functools.partial(xm.rendezvous, 'test rendezvous', "")

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -443,6 +443,7 @@ def rendezvous(tag: str, payload: bytes,
   )).to(xm.xla_device())
   raw_data = xm.all_gather(padded_data)
   data_list = torch.split(raw_data, max_size)
+
   payloads = [d[:sz] for d, sz in zip(data_list, sizes.cpu())]
   xm.mark_step()
 

--- a/torch_xla/experimental/pjrt.py
+++ b/torch_xla/experimental/pjrt.py
@@ -434,7 +434,7 @@ def rendezvous(tag: str, payload: bytes,
   xm.mark_step()
 
   # If all payloads are empty, return immediately to avoid more CPU transfers
-  if max_size < 1:
+  if max_size.item() < 1:
     return [b'' for _ in range(sizes.size()[0])]
 
   padded_data = torch.nn.functional.pad(data, (
@@ -443,8 +443,7 @@ def rendezvous(tag: str, payload: bytes,
   )).to(xm.xla_device())
   raw_data = xm.all_gather(padded_data)
   data_list = torch.split(raw_data, max_size)
-
-  payloads = [d[:sz] for d, sz in zip(data_list, sizes)]
+  payloads = [d[:sz] for d, sz in zip(data_list, sizes.cpu())]
   xm.mark_step()
 
   return [bytes(p.cpu().tolist()) for p in payloads]


### PR DESCRIPTION
- If the payloads are all empty, just return empty data immediately rather than transferring padding
- For non-empty data, transfer the sizes to CPU once rather than once per replica