### PR TITLE
Set some helpful defaults in TPU devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,9 @@
   "name": "pytorch_xla",
   "image": "us-central1-docker.pkg.dev/tpu-pytorch/docker/development:tpu",
   "privileged": true,
+  "runArgs": [
+    "--shm-size=16G"
+  ],
   "containerEnv": {
     "TPUVM_MODE": "1",
     "BAZEL_REMOTE_CACHE": "1",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
   "containerEnv": {
     "TPUVM_MODE": "1",
     "BAZEL_REMOTE_CACHE": "1",
-    "SILO_NAME": "cache-silo-${localEnv:USER}"
+    "SILO_NAME": "cache-silo-${localEnv:USER}-tpuvm"
   },
   "initializeCommand": "docker pull us-central1-docker.pkg.dev/tpu-pytorch/docker/development:tpu",
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,15 @@
 {
   "name": "pytorch_xla",
   "image": "us-central1-docker.pkg.dev/tpu-pytorch/docker/development:tpu",
-  "runArgs": [
-    "--privileged"
-  ],
+  "privileged": true,
+  "containerEnv": {
+    "TPUVM_MODE": "1",
+    "BAZEL_REMOTE_CACHE": "1",
+    "SILO_NAME": "cache-silo-${localEnv:USER}"
+  },
   "initializeCommand": "docker pull us-central1-docker.pkg.dev/tpu-pytorch/docker/development:tpu",
   "customizations": {
     "vscode": {
-      "settings": {},
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
         "ms-vscode.cpptools-themes",
@@ -17,7 +19,8 @@
         "StackBuild.bazel-stack-vscode-cc",
         "xaver.clang-format",
         "ryanluker.vscode-coverage-gutters",
-        "ms-azuretools.vscode-docker"
+        "ms-azuretools.vscode-docker",
+        "ms-python.python"
       ]
     }
   }


### PR DESCRIPTION
- Use the [`privileged` option](https://containers.dev/implementors/json_reference/#general-properties)
- Add increased `--shm-size`
- Enable Bazel remote caching with a unique silo by default
- Add the Python VSCode extension