### PR TITLE
Expose SharingUtil functions to generate global index slices

### DIFF
--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -68,6 +68,20 @@ class ShardingUtil {
       std::vector<XLATensor::ShardingSpecPtr> sharding_specs,
       bool replicated_output = true);
 
+  // Returns the shape of the resulting shards of `tensor` after applying
+  // `sharding`. This assumes the shards will be padded to ensure they all
+  // have the same shape.
+  static std::vector<int64_t> GetShardShape(const at::Tensor& tensor,
+                                            const xla::OpSharding sharding);
+
+  // Uses the provided `sharding` spec and expected shard shape to determine the
+  // index slices for the shards which belong on `devices`. Only supports
+  // `REPLICATED` and `OTHER` sharding types.
+  static std::vector<std::vector<at::indexing::TensorIndex>>
+  GetShardIndicesForDevices(const std::vector<int64_t>& shard_shape,
+                            const xla::OpSharding sharding,
+                            const std::vector<std::string>& devices);
+
   // Shards a tensor and returns the sharded tensors which belong on `devices`
   // based on the `sharding` spec. REPLICATED sharding should result in shards
   // identical to the input; OTHERS (tiled) sharding result in shards where


### PR DESCRIPTION
To support exposing XLAShards with global index information, we need to expose the logic to calculate the index slices for a given device's shard. This is done by introducing two new ShardingUtil methods: `GetShardShape` and `GetShardIndicesForDevices`. These new methods are used by `ShardTensor`, and they will also later be used to generate the index slices of a local shard which will be exposed in Python through `XLAShard`.