### PR TITLE
Revert "Apply sharding when creating tensors data in data loader"

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -967,11 +967,11 @@ def send_cpu_data_to_device(data, device, input_sharding=None):
 
   def convert_fn(tensors):
     devices = [str(device)] * len(tensors)
-    shardings = None
+    xtensors = torch_xla._XLAC._xla_tensors_from_aten(tensors, devices)
     if input_sharding:
-      shardings = [input_sharding.xla_spec(t) for t in tensors]
-    xtensors = torch_xla._XLAC._xla_tensors_from_aten(tensors, devices,
-                                                      shardings)
+      for xtensor in xtensors:
+        if input_sharding.can_apply(xtensor):
+          input_sharding.apply(xtensor)
     return xtensors
 
   def select_fn(v):

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -410,25 +410,13 @@ std::ptrdiff_t GetTensorId(const at::Tensor& tensor) {
 
 std::vector<at::Tensor> GetXlaTensorsFromAten(
     const std::vector<at::Tensor>& aten_tensors,
-    const std::vector<std::string>& devices,
-    const std::optional<std::vector<XLATensor::ShardingSpecPtr>>
-        sharding_specs) {
-  std::vector<std::shared_ptr<torch::lazy::BackendData>> data_handles;
-  if (sharding_specs.has_value()) {
-    data_handles = CreateTensorsData(aten_tensors, sharding_specs.value(),
-                                     GetXlaDevices(devices));
-  } else {
-    data_handles = CreateTensorsData(aten_tensors, GetXlaDevices(devices));
-  }
+    const std::vector<std::string>& devices) {
+  auto data_handles = CreateTensorsData(aten_tensors, GetXlaDevices(devices));
 
   std::vector<at::Tensor> xla_tensors;
   xla_tensors.reserve(data_handles.size());
-  for (int i = 0; i < data_handles.size(); i++) {
-    auto& data_handle = data_handles[i];
+  for (auto& data_handle : data_handles) {
     XLATensorPtr xla_tensor = XLATensor::Create(std::move(data_handle));
-    if (sharding_specs.has_value() && sharding_specs.value()[i] != nullptr) {
-      xla_tensor->SetShardingSpec(*sharding_specs.value()[i]);
-    }
     xla_tensors.push_back(bridge::AtenFromXlaTensor(std::move(xla_tensor)));
   }
   return xla_tensors;
@@ -916,36 +904,21 @@ void InitXlaModuleBindings(py::module m) {
         [](const std::vector<at::Tensor>& tensors) -> std::string {
           return GetTensorsHloGraph(tensors);
         });
-  py::class_<XLATensor::ShardingSpec, XLATensor::ShardingSpecPtr>(
-      m, "XlaShardingSpec")
-      .def(py::init([](at::Tensor tensor, py::list& tile_assignment,
-                       bool replicated, bool manual) {
-        auto op_sharding =
-            ShardingUtil::CreateOpSharding(tile_assignment, replicated, manual);
-        auto shape = CreateComputationShapeFromTensor(tensor, nullptr);
-        return std::make_shared<XLATensor::ShardingSpec>(op_sharding, shape);
-      }));
-  m.def("_xla_tensors_from_aten",
-        [](const std::vector<at::Tensor>& tensors,
-           const std::vector<std::string>& devices,
-           const std::optional<std::vector<XLATensor::ShardingSpecPtr>>&
-               shardings) {
-          std::vector<at::Tensor> result;
-          {
-            NoGilSection nogil;
-            std::vector<at::Tensor> xla_tensors =
-                GetXlaTensorsFromAten(tensors, devices, shardings);
-            result.reserve(xla_tensors.size());
-            for (size_t i = 0; i < xla_tensors.size(); ++i) {
-              result.push_back(torch::autograd::make_variable(
-                  xla_tensors[i],
-                  /*requires_grad=*/tensors.at(i).requires_grad()));
-            }
-          }
-          return result;
-        },
-        py::arg("tensors"), py::arg("devices"),
-        py::arg("shardings") = py::none());
+  m.def("_xla_tensors_from_aten", [](const std::vector<at::Tensor>& tensors,
+                                     const std::vector<std::string>& devices) {
+    std::vector<at::Tensor> result;
+    {
+      NoGilSection nogil;
+      std::vector<at::Tensor> xla_tensors =
+          GetXlaTensorsFromAten(tensors, devices);
+      result.reserve(xla_tensors.size());
+      for (size_t i = 0; i < xla_tensors.size(); ++i) {
+        result.push_back(torch::autograd::make_variable(
+            xla_tensors[i], /*requires_grad=*/tensors.at(i).requires_grad()));
+      }
+    }
+    return result;
+  });
   m.def("_xla_get_cpu_tensors", [](const std::vector<at::Tensor>& tensors) {
     std::vector<at::Tensor> result;
     {

--- a/torch_xla/experimental/xla_sharding.py
+++ b/torch_xla/experimental/xla_sharding.py
@@ -1,6 +1,6 @@
 import os
 from collections import OrderedDict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 import torch
 import torch_xla
 import torch_xla.core.xla_model as xm
@@ -78,7 +78,7 @@ def mark_sharding(t: Union[torch.Tensor, XLAShardedTensor], mesh: Mesh,
     Annotates the tensor provided with XLA partition spec. Internally,
     it annotates the corresponding XLATensor as sharded for the XLA SpmdPartitioner pass.
     Args:
-        t (Union[torch.Tensor, XLAShardedTensor]): input tensor to be annotated with partition_spec.
+        t (Union[torch.Tensor, XLAShardedTensor]): input tensor to be annotated with partition_sepc.
 
         mesh (Mesh): describes the logical XLA device topology and the underlying device IDs.
 
@@ -147,29 +147,6 @@ def clear_sharding(t: Union[torch.Tensor, XLAShardedTensor]) -> torch.Tensor:
 class ShardingSpec:
   mesh: Mesh
   partition_spec: Tuple[Union[int, None]]
-
-  # Derived fields
-  _tile_assignment: List[int] = field(init=False)
-  _replicated: bool = field(init=False)
-  _partial: bool = field(init=False)
-
-  def __post_init__(self):
-    self._tile_assignment = self.mesh.get_logical_mesh().tolist()
-    self._replicated = all(d is None for d in self.partition_spec)
-    self._partial = not self._replicated and any(
-        d is None for d in self.partition_spec)
-    # TODO(yeounoh) support partially replicated sharding.
-    assert not self._partial, "Partial replication is currently not supported"
-
-  def xla_spec(self, t: torch.Tensor) -> Union['XlaShardingSpec', None]:
-    """
-    Create an XlaShardingSpec for the given tensor. If the tensor is
-    incompatible with the ShardingSpec, returns None.
-    """
-    if not self.can_apply(t):
-      return None
-    return torch_xla._XLAC.XlaShardingSpec(t, self._tile_assignment,
-                                           self._replicated, False)
 
   def can_apply(self, t: torch.Tensor) -> bool:
     """


### PR DESCRIPTION
Reverts pytorch/xla#4995
since it failed the TPU CI 
```
Step #4 - "run_e2e_tests": + python3 /src/pytorch/xla/test/spmd/test_xla_sharding.py
Step #4 - "run_e2e_tests": .........F...
Step #4 - "run_e2e_tests": ======================================================================
Step #4 - "run_e2e_tests": FAIL: test_send_cpu_data_to_device_with_sharding (__main__.BasicShardingTest)
Step #4 - "run_e2e_tests": ----------------------------------------------------------------------
Step #4 - "run_e2e_tests": Traceback (most recent call last):
Step #4 - "run_e2e_tests":   File "/src/pytorch/xla/test/spmd/test_xla_sharding.py", line 188, in test_send_cpu_data_to_device_with_sharding
Step #4 - "run_e2e_tests":     self.assertEqual(outbound, tensor.element_size() * tensor.nelement())
Step #4 - "run_e2e_tests": AssertionError: 128.0 != 64
Step #4 - "run_e2e_tests": 
Step #4 - "run_e2e_tests": ----------------------------------------------------------------------
Step #4 - "run_e2e_tests": Ran 13 tests in 0.408s
Step #4 - "run_e2e_tests": 
Step #4 - "run_e2e_tests": FAILED (failures=1)
Step #4 - "run_e2e_tests": ++ kubectl get pod/xla-test-job-2xs9w -o 'jsonpath={.status.containerStatuses[?(@.name=="xla-test")].state.terminated.exitCode}'
Step #4 - "run_e2e_tests": + exit 1
Finished Step #4 - "run_e2e_tests"
ERROR
ERROR: build step 4 "google/cloud-sdk" failed: step exited with non-zero status: 1
```