### PR TITLE
Update devcontainer dependencies

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,12 @@
 {
   "name": "pytorch_xla",
   "image": "us-central1-docker.pkg.dev/tpu-pytorch/docker/development:tpu",
-  "privileged": true,
   "runArgs": [
+    "--privileged",
+    "--net=host",
     "--shm-size=16G"
   ],
   "containerEnv": {
-    "TPUVM_MODE": "1",
     "BAZEL_REMOTE_CACHE": "1",
     "SILO_NAME": "cache-silo-${localEnv:USER}-tpuvm"
   },

--- a/infra/ansible/config/pip.yaml
+++ b/infra/ansible/config/pip.yaml
@@ -29,7 +29,7 @@ pip:
       - typing
       - typing_extensions
       - sympy
-      - yapf
+      - yapf==0.30.0
 
     build_amd64:
       - mkl


### PR DESCRIPTION
- The `privileged: true` field wasn't working as expected for me, so putting it back in `runArgs`
- Enable host networking in dev container to make running TPU tests easier
- Match build stage's `yapf` version to `CONTRIBUTING.md` and CI
- `TPUVM_MODE` is already set in `infra/ansible/config/env.yaml`, so we don't need to set it in `devcontainer.json` 