### PR TITLE
Apply sharding when creating tensors data in data loader

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -9,6 +9,7 @@ from torch import nn
 import torch.optim as optim
 import torch_xla
 import torch_xla.core.xla_model as xm
+import torch_xla.debug.metrics as met
 import torch_xla.experimental.xla_sharding as xs
 from torch_xla.experimental.xla_sharded_tensor import XLAShardedTensor
 import test_xla_sharding_base
@@ -169,6 +170,30 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     xs.mark_sharding(xt1, self._get_mesh((1, self.n_devices)), (0, 1))
     t1 = xt1.cpu()
     self.assertTrue(torch.allclose(t1, torch.ones(16, 16)))
+
+  def test_send_cpu_data_to_device_with_sharding(self):
+    xm.mark_step()  # Execute pending graph to avoid contaminating metrics
+    met.clear_all()
+    tensor = torch.arange(16, dtype=torch.float32).reshape(4, 4)
+    mesh = self._get_mesh((1, self.n_devices))
+
+    # Create a ShardingSpec and use it to shard the tensor while sending to device
+    sharding_spec = xs.ShardingSpec(mesh, (0, 1))
+    self.assertTrue(sharding_spec.can_apply(tensor))
+    xtensors = xm.send_cpu_data_to_device([tensor],
+                                          xm.xla_device(),
+                                          input_sharding=sharding_spec)
+    self.assertEqual(len(xtensors), 1)
+    outbound = met.metric_data("OutboundData")[1]
+    self.assertEqual(outbound, tensor.element_size() * tensor.nelement())
+
+    # Verify the resulting sharding annotation matches an explicit `mark_sharding` call
+    xt = xtensors[0]
+    explicit_xt = tensor.to(xm.xla_device())
+    xs.mark_sharding(explicit_xt, mesh, (0, 1))
+    self.assertEqual(
+        torch_xla._XLAC._get_xla_sharding_spec(xt),
+        torch_xla._XLAC._get_xla_sharding_spec(explicit_xt))
 
 
 if __name__ == '__main__':

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -967,11 +967,11 @@ def send_cpu_data_to_device(data, device, input_sharding=None):
 
   def convert_fn(tensors):
     devices = [str(device)] * len(tensors)
-    xtensors = torch_xla._XLAC._xla_tensors_from_aten(tensors, devices)
+    shardings = None
     if input_sharding:
-      for xtensor in xtensors:
-        if input_sharding.can_apply(xtensor):
-          input_sharding.apply(xtensor)
+      shardings = [input_sharding.xla_spec(t) for t in tensors]
+    xtensors = torch_xla._XLAC._xla_tensors_from_aten(tensors, devices,
+                                                      shardings)
     return xtensors
 
   def select_fn(v):


### PR DESCRIPTION
This change re-introduces #4995, which was reverted due to a failed unit test. The unit test failed due to a faulty metrics assertion - running on TPU v2 or v3, the sharding of the 4x4 tensor is padded due to there being 8 XLA devices, changing the total data transfer. This change modifies the shape of the test tensor to support up to 16 devices without padding.