### PR TITLE
Expose local shards as XLAShard

### DIFF
--- a/test/cpp/test_xla_sharding.cpp
+++ b/test/cpp/test_xla_sharding.cpp
@@ -55,17 +55,17 @@ TEST_F(XLAShardingTest, GetShardIndicesForDevices) {
   });
   auto sharding = xla::HloSharding::Tile(mesh).ToProto();
   auto shard_shape = ShardingUtil::GetShardShape(tensor, sharding);
-  auto shard_indices =
-      ShardingUtil::GetShardIndicesForDevices(shard_shape, sharding, devices);
+  auto shard_indices = ShardingUtil::GetShardIndicesForDevices(
+      shard_shape, tensor.sizes().vec(), sharding, devices);
   EXPECT_EQ(shard_indices.size(), devices.size());
   /* Tiled indices should be:
                  dim=0 dim=1
        device=0  [0:4,  0:4]
-       device=1  [0:4,  4:8]
+       device=1  [0:4,  4:7]
        device=2  [4:8,  0:4]
-       device=3  [4:8,  4:8] */
+       device=3  [4:8,  4:7] */
   std::vector<std::vector<int>> slice_starts = {{0, 0}, {0, 4}, {4, 0}, {4, 4}};
-  std::vector<std::vector<int>> slice_ends = {{4, 4}, {4, 8}, {8, 4}, {8, 8}};
+  std::vector<std::vector<int>> slice_ends = {{4, 4}, {4, 7}, {8, 4}, {8, 7}};
   for (int device = 0; device < shard_indices.size(); ++device) {
     EXPECT_EQ(shard_indices[device].size(), tensor.sizes().size());
     for (int dim = 0; dim < shard_indices[device].size(); ++dim) {
@@ -79,8 +79,8 @@ TEST_F(XLAShardingTest, GetShardIndicesForDevices) {
 
   sharding = xla::HloSharding::Replicate().ToProto();
   shard_shape = ShardingUtil::GetShardShape(tensor, sharding);
-  shard_indices =
-      ShardingUtil::GetShardIndicesForDevices(shard_shape, sharding, devices);
+  shard_indices = ShardingUtil::GetShardIndicesForDevices(
+      shard_shape, tensor.sizes().vec(), sharding, devices);
   EXPECT_EQ(shard_indices.size(), devices.size());
   for (int i = 0; i < devices.size(); ++i) {
     EXPECT_EQ(shard_indices[i].size(), 1);

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1537,6 +1537,70 @@ void InitXlaModuleBindings(py::module m) {
     }
     return std::string();
   });
+  // Returns the local shards of the tensor, with values taken from the
+  // underlying ComputationClient::GetDataShards. As such, the shards will
+  // contain any padding that was applied to ensure they all have the same
+  // shape. Note that this padding is _not_ included in the global indices
+  // returned by `_get_local_shard_indices`.
+  m.def("_get_local_shards",
+        [](const at::Tensor& input) -> std::vector<at::Tensor> {
+          XLATensorPtr xtensor = bridge::GetXlaTensor(input);
+          XLA_CHECK(xtensor->GetXlaData() != nullptr)
+              << "Shard data is not available";
+          XLA_CHECK(xtensor->sharding_spec() != nullptr)
+              << "Tensor is not sharded";
+          XLA_CHECK(ShardingUtil::UseVirtualDevice())
+              << "Virtual device must be enabled to use _get_local_shards";
+          auto handle = UnwrapXlaData(xtensor->GetXlaData());
+          auto shard_handles =
+              xla::ComputationClient::Get()->GetDataShards(handle);
+          std::vector<at::Tensor> shards;
+          for (auto& shard_handle : shard_handles) {
+            auto xshard = XLATensor::Create(WrapXlaData(shard_handle));
+            shards.push_back(bridge::AtenFromXlaTensor(std::move(xshard)));
+          }
+          return shards;
+        });
+  // Returns the indices of the shards into the global tensor as either
+  // a Python list of slices for each dimension or a Python Ellipsis object
+  // indicating that the tensor is replicated. These indices will not reflect
+  // any padding that has been applied to the shards.
+  m.def("_get_local_shard_indices",
+        [](const at::Tensor& input,
+           const std::vector<std::string>& devices) -> std::vector<py::object> {
+          XLATensorPtr xtensor = bridge::GetXlaTensor(input);
+          XLA_CHECK(xtensor->sharding_spec() != nullptr)
+              << "Tensor is not sharded";
+          auto sharding = xtensor->sharding_spec()->sharding;
+          auto shard_shape = ShardingUtil::GetShardShape(input, sharding);
+          auto xla_devices = GetXlaDevices(devices);
+          auto indices = ShardingUtil::GetShardIndicesForDevices(
+              shard_shape, input.sizes().vec(), sharding, xla_devices);
+
+          // Convert each vector<TensorIndex> to List[py::slice] or py::ellipsis
+          std::vector<py::object> result;
+          result.reserve(xla_devices.size());
+          for (auto& device_indices : indices) {
+            XLA_CHECK(device_indices.size() > 0)
+                << "Unexpected empty shard indices for tensor " << input;
+            if (device_indices[0].is_ellipsis()) {
+              result.push_back(py::ellipsis());
+            } else {
+              std::vector<py::object> device_slices;
+              for (auto& tensor_index : device_indices) {
+                XLA_CHECK(tensor_index.is_slice())
+                    << "Unexpected TensorIndex type: " << tensor_index;
+                auto slice = tensor_index.slice();
+                ssize_t start = slice.start().expect_int();
+                ssize_t stop = slice.stop().expect_int();
+                ssize_t step = slice.step().expect_int();
+                device_slices.push_back(py::slice(start, stop, step));
+              }
+              result.push_back(py::cast(device_slices));
+            }
+          }
+          return result;
+        });
   // This is useful for debugging and generating a partitioned HLO separately
   // outside the actual compilation & execution. This allows testing with
   // different partitioning configurations.

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -79,6 +79,7 @@ class ShardingUtil {
   // `REPLICATED` and `OTHER` sharding types.
   static std::vector<std::vector<at::indexing::TensorIndex>>
   GetShardIndicesForDevices(const std::vector<int64_t>& shard_shape,
+                            const std::vector<int64_t>& tensor_shape,
                             const xla::OpSharding sharding,
                             const std::vector<std::string>& devices);
 

--- a/torch_xla/experimental/xla_sharded_tensor.py
+++ b/torch_xla/experimental/xla_sharded_tensor.py
@@ -3,15 +3,37 @@ from torch.utils._pytree import tree_map
 import torch_xla
 
 from dataclasses import dataclass
-from typing import List, Tuple, Iterator
+from typing import List, Tuple, Iterator, Union
 import contextlib
 import collections
 
 
 @dataclass
 class XLAShard:
+  # A snapshot of the shard data from the time of XLAShard creation.
   data: torch.Tensor
-  rank: int
+
+  # The indices of the shard into the global tensor. If the tensor is replicated
+  # across local devices, the value of `indices` is Ellipsis. Otherwise, it is a
+  # list of the index slices across each dimension.
+  # The indices do not reflect padding, since the padding does not exist on the
+  # global tensor.
+  indices: Union[type(Ellipsis), List[slice]]
+
+  # TODO(jonbolin): Expose replica rank with partial replication
+  # rank: int
+
+  def cpu(self) -> 'XLAShard':
+    return XLAShard(self.data.cpu(), self.indices)
+
+  @property
+  def unpadded_data(self) -> torch.Tensor:
+    ''' Returns a copy of `data` with padding removed '''
+    unpadded_indices = self.indices
+    # Replicated data has Ellipsis as indices
+    if self.indices != Ellipsis:
+      unpadded_indices = [slice(0, s.stop - s.start) for s in self.indices]
+    return self.data[unpadded_indices]
 
 
 @contextlib.contextmanager
@@ -41,13 +63,6 @@ class XLAShardedTensor(torch.Tensor):
   # data still remain on individual device as sharded or replicated.
   # Note: we should drop this reference, and force all gather on each access.
   global_tensor: torch.Tensor
-  # Shards on the devices are materialized/available after the lazy
-  # execution of the SPMDPartitioned HLO graph; otherwise,
-  # local_shards is set to `None`. Each XLAShard points to
-  # torch.Tensor (xla::device_data).
-  # Note: we can consider returning a callback or even define
-  # sharding at XLAShardedTensor construction after pjrt migration.
-  local_shards: List[XLAShard] = None
   # A logical device topology, each element describes
   # a number of devices in the corresponding axis.
   # NOTE: we could use more specific device-rank mapping, e.g., ShardingSpec,
@@ -79,6 +94,21 @@ class XLAShardedTensor(torch.Tensor):
         requires_grad=kwargs.get("requires_grad", False))
     r.global_tensor = elem.detach() if r.requires_grad else elem
     return r
+
+  # Shards on the devices are materialized/available after the lazy
+  # execution of the SPMDPartitioned HLO graph. Each XLAShard points
+  # to torch.Tensor (xla::device_data). The shards represent a snapshot
+  # of the underlying tensor's value and will NOT remain up-to-date with the
+  # underlying tensor - the shards should be regenerated whenever an updated
+  # value is needed. Additionally, the shards will include any padding
+  # which results from the sharding.
+  @property
+  def local_shards(self) -> List[XLAShard]:
+    shards = torch_xla._XLAC._get_local_shards(self.global_tensor)
+    devices = [str(shard.device) for shard in shards]
+    indices = torch_xla._XLAC._get_local_shard_indices(self.global_tensor,
+                                                       devices)
+    return [XLAShard(s, i) for s, i in zip(shards, indices)]
 
   @property
   def sharding_spec(self):


### PR DESCRIPTION
This change exposes local shards as XLAShard containing the shard data and indices into the global tensor. The exposed shards will contain padding, while the indices will be into the unpadded global tensor. Because of this, an additional field `unpadded_data` is introduced to remove padding from the shards.

To support the indices not containing padding, a change is made to `ShardingUtil::GetShardIndicesForDevices`. Previously, this method returned the shard indices as though the global tensor were padded, and the index slicing operations ignored indices which were out-of-bound. This change ensures that the end index is bounded to the tensor dimension sizes, and slices with `start` beyond `stop` do not select any indices (e.g. `tensor[4:3] = tensor([])`)