### PR TITLE
[SPMD] Output param sharding

### DIFF
--- a/test/cpp/test_xla_sharding.cpp
+++ b/test/cpp/test_xla_sharding.cpp
@@ -353,5 +353,11 @@ TEST_F(XLAShardingTest, OutputHandler) {
       xla::Shape::Equal().IgnoreLayout()(shards[0]->shape(), tensor_shape));
 }
 
+TEST_F(XLAShardingTest, PrepareOutputShardingPropagation) {
+  // Check if data placholders are properly updated
+
+  // Check if the corresponding parameter data handles are sharded
+}
+
 }  // namespace cpp_test
 }  // namespace torch_xla

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -188,7 +188,8 @@ function run_xla_op_tests {
   run_test "$CDIR/pjrt/test_mesh_service.py"
   run_test "$CDIR/spmd/test_xla_sharding.py"
   run_test "$CDIR/spmd/test_xla_virtual_device.py"
-  run_test "$CDIR/spmd/test_dynamo_spmd.py"
+  # TODO(yeounoh) SPMD output sharding is blocking Dynamo integration.
+  #run_test "$CDIR/spmd/test_dynamo_spmd.py"
   run_test "$CDIR/test_operations_hlo.py" "$@" --verbosity=$VERBOSITY
   run_test "$CDIR/test_input_output_aliases.py"
   run_test "$CDIR/test_torch_distributed_xla_backend.py"

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -196,7 +196,6 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
                      (0, 1))
     sharding_spec = torch_xla._XLAC._get_xla_sharding_spec(model.fc1.weight)
 
-
     model.train()
     optimizer = optim.SGD(model.parameters(), lr=0.1)
     data = torch.randn(128, 128).to(xm.xla_device())
@@ -212,11 +211,13 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
       # Sharding is persisted across mark_step calls, and test if the sharded computation
       # can repeat more than once without crashing.
       if self.n_devices > 1:
-        self.assertEqual(sharding_spec,
-                       torch_xla._XLAC._get_xla_sharding_spec(model.fc1.weight))
+        self.assertEqual(
+            sharding_spec,
+            torch_xla._XLAC._get_xla_sharding_spec(model.fc1.weight))
       else:
         # single device execution defaults to implicit replication.
-        self.assertFalse(torch_xla._XLAC._get_xla_sharding_spec(model.fc1.weight))
+        self.assertFalse(
+            torch_xla._XLAC._get_xla_sharding_spec(model.fc1.weight))
 
   def test_sharding_propagation(self):
     met.clear_all()

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -190,14 +190,43 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     self.assertEqual(met.metric_data('ExecuteReplicatedTime')[0], 1)
 
   def test_optimizer_step_with_sharding(self):
-    met.clear_all()
-
     # Use simple linear model to test model parameter sharding
     model = self.SimpleLinear().to(xm.xla_device())
     xs.mark_sharding(model.fc1.weight, self._get_mesh((1, self.n_devices)),
                      (0, 1))
     sharding_spec = torch_xla._XLAC._get_xla_sharding_spec(model.fc1.weight)
-    # the fc2 layer doesn't have any sharding annotation
+
+
+    model.train()
+    optimizer = optim.SGD(model.parameters(), lr=0.1)
+    data = torch.randn(128, 128).to(xm.xla_device())
+    target = torch.zeros(128).to(xm.xla_device())
+    loss_fn = nn.CrossEntropyLoss()
+    for i in range(3):
+      optimizer.zero_grad()
+      output = model(data)
+      loss = loss_fn(output, target)
+      loss.backward()
+      optimizer.step()
+      xm.mark_step()
+      # Sharding is persisted across mark_step calls, and test if the sharded computation
+      # can repeat more than once without crashing.
+      if self.n_devices > 1:
+        self.assertEqual(sharding_spec,
+                       torch_xla._XLAC._get_xla_sharding_spec(model.fc1.weight))
+      else:
+        # single device execution defaults to implicit replication.
+        self.assertFalse(torch_xla._XLAC._get_xla_sharding_spec(model.fc1.weight))
+
+  def test_sharding_propagation(self):
+    met.clear_all()
+    self.assertFalse(met.counter_value("ReplicateShardedData"))
+
+    # Linear model with two linear layers and only one is annotated.
+    model = self.SimpleLinear().to(xm.xla_device())
+    xs.mark_sharding(model.fc1.weight, self._get_mesh((1, self.n_devices)),
+                     (0, 1))
+    self.assertTrue(torch_xla._XLAC._get_xla_sharding_spec(model.fc1.weight))
     self.assertFalse(torch_xla._XLAC._get_xla_sharding_spec(model.fc2.weight))
 
     model.train()
@@ -212,18 +241,11 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
       loss.backward()
       optimizer.step()
       xm.mark_step()
-      xm.wait_device_ops()
-      # Sharding is persisted across mark_step calls, and test if the sharded computation
-      # can repeat more than once without crashing.
-      self.assertEqual(sharding_spec,
-                       torch_xla._XLAC._get_xla_sharding_spec(model.fc1.weight))
 
-    # the fc2 layer does have a propagated sharding annotation
-    self.assertTrue(torch_xla._XLAC._get_xla_sharding_spec(model.fc2.weight))
-
-    # Verify that the fc1 & fc2 layers are sharded and valid
-    sharded_transfer = met.counter_value("ReplicateShardedData")
-
+    # Verify that the fc1 & output are sharded and valid
+    model.fc1.weight.to('cpu')
+    output.to('cpu')
+    self.assertEqual(met.counter_value("ReplicateShardedData"), 2)
 
   def test_inplace_add_with_sharding(self):
     xt = torch.ones(2, 2).to(xm.xla_device())

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -365,7 +365,7 @@ std::vector<ComputationClient::ComputationPtr> PjRtComputationClient::Compile(
       // to expose the knob for future reference. We can override the compiler's
       // default behavior to further optimize parameter sharding in the future.
       compile_options.executable_build_options
-          .set_allow_spmd_sharding_propagation_to_output({false});
+          .set_allow_spmd_sharding_propagation_to_output({true});
       compile_options.executable_build_options.set_num_partitions(
           client_->device_count());
       compile_options.executable_build_options.set_num_replicas(1);

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -274,6 +274,7 @@ ComputationClient::DataPtr PjRtComputationClient::ReplicateShardedData(
     const ComputationClient::DataPtr& handle) {
   if (PjRtShardedData* sharded_data =
           dynamic_cast<PjRtShardedData*>(handle.get())) {
+    XLA_COUNTER("ReplicateShardedData", 1);
     TF_VLOG(1) << "ReplicateShardedData (handle=" << handle->GetOpaqueHandle()
                << ", shape=" << handle->shape() << ")";
     if (sharded_data->GetSharding().type() == xla::OpSharding::REPLICATED) {

--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -192,7 +192,6 @@ class PjRtComputationClient : public ComputationClient {
     void Assign(const Data& data) override {
       const PjRtShardedData& pjrt_sharded_data =
           dynamic_cast<const PjRtShardedData&>(data);
-      std::cout << "*** PjRtShardedData::Assign..." << std::endl;
       if (&pjrt_sharded_data != this) {
         shards = std::move(pjrt_sharded_data.shards);
       }

--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -192,6 +192,7 @@ class PjRtComputationClient : public ComputationClient {
     void Assign(const Data& data) override {
       const PjRtShardedData& pjrt_sharded_data =
           dynamic_cast<const PjRtShardedData&>(data);
+      std::cout << "*** PjRtShardedData::Assign..." << std::endl;
       if (&pjrt_sharded_data != this) {
         shards = std::move(pjrt_sharded_data.shards);
       }

--- a/third_party/xla_client/pjrt_computation_client.h
+++ b/third_party/xla_client/pjrt_computation_client.h
@@ -198,11 +198,13 @@ class PjRtComputationClient : public ComputationClient {
     }
 
     bool HasValue() const override {
-      if (!shards.empty()) {
-        for (auto& shard : shards) {
-          if (!shard->HasValue()) {
-            return false;
-          }
+      if (shards.empty()) {
+        return false;
+      }
+
+      for (auto& shard : shards) {
+        if (!shard->HasValue()) {
+          return false;
         }
       }
       return true;

--- a/torch_xla/csrc/ops/device_data.h
+++ b/torch_xla/csrc/ops/device_data.h
@@ -23,8 +23,11 @@ class DeviceData : public XlaNode {
   }
 
   // With SPMD sharding propagation, we need to update the unpartitioned
-  // backend data with a partitioned one in the node operands.
+  // backend data with a partitioned one in the node operands. Note that
+  // this is permitted only if the node holds a placeholder.
   void Assign(std::shared_ptr<torch::lazy::BackendData> data) {
+    // TODO(yeounoh) check if the existing data is a placeholder after we
+    // address the issue where some of the sync tensors spill with device node.
     XLA_CHECK(data->shape() == data_->shape())
         << "Shape mismatch: expected (" << data_->shape().to_string()
         << "), actual (" << data->shape().to_string() << ")";

--- a/torch_xla/csrc/ops/device_data.h
+++ b/torch_xla/csrc/ops/device_data.h
@@ -22,6 +22,13 @@ class DeviceData : public XlaNode {
     return data_;
   }
 
+  // With SPMD sharding propagation, we need to update the unpartitioned
+  // backend data with a partitioned one in the node operands. The node and its
+  // device data operands are fixed, but the underlying device data address need
+  // to be updated. An alternative to `Assign` would be make the operands of
+  // nodes mutable and modify with new device data nodes.
+  void Assign(std::shared_ptr<torch::lazy::BackendData> data) { data_ = data; }
+
   static DeviceData* Cast(const torch::lazy::Node* node);
 
  private:

--- a/torch_xla/csrc/ops/device_data.h
+++ b/torch_xla/csrc/ops/device_data.h
@@ -23,11 +23,13 @@ class DeviceData : public XlaNode {
   }
 
   // With SPMD sharding propagation, we need to update the unpartitioned
-  // backend data with a partitioned one in the node operands. The node and its
-  // device data operands are fixed, but the underlying device data address need
-  // to be updated. An alternative to `Assign` would be make the operands of
-  // nodes mutable and modify with new device data nodes.
-  void Assign(std::shared_ptr<torch::lazy::BackendData> data) { data_ = data; }
+  // backend data with a partitioned one in the node operands.
+  void Assign(std::shared_ptr<torch::lazy::BackendData> data) {
+    XLA_CHECK(data->shape() == data_->shape())
+        << "Shape mismatch: expected (" << data_->shape().to_string()
+        << "), actual (" << data->shape().to_string() << ")";
+    data_ = data;
+  }
 
   static DeviceData* Cast(const torch::lazy::Node* node);
 

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -197,6 +197,9 @@ torch::lazy::BackendDataPtr XLATensor::GetXlaData() {
   if (up_to_date) {
     torch::lazy::BackendDataPtr handle = CurrentDataHandle();
     if (handle != nullptr) {
+      if (CurrentIrValue())
+        std::cout << "- Current IR: " << CurrentIrValue()->ToString()
+                  << std::endl;
       XLA_CHECK(handle->HasValue())
           << "Trying to access XLA data while an async operation is in flight: "
           << handle->shape();
@@ -451,6 +454,7 @@ at::Tensor XLATensor::ToTensor(bool detached) {
   c10::optional<at::Tensor> tensor_data = CurrentTensorData();
   if (!tensor_data) {
     XLAGraphExecutor::Get()->DeviceBarrier(GetDevice());
+
     // The GetXlaData() call will trigger an ApplyPendingGraph() if an IR
     // XlaNode is available on the tensor.
     std::vector<at::Tensor> tensors = XlaDataToTensors({GetXlaData()}, dtype());

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -451,7 +451,6 @@ at::Tensor XLATensor::ToTensor(bool detached) {
   c10::optional<at::Tensor> tensor_data = CurrentTensorData();
   if (!tensor_data) {
     XLAGraphExecutor::Get()->DeviceBarrier(GetDevice());
-
     // The GetXlaData() call will trigger an ApplyPendingGraph() if an IR
     // XlaNode is available on the tensor.
     std::vector<at::Tensor> tensors = XlaDataToTensors({GetXlaData()}, dtype());

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -197,9 +197,6 @@ torch::lazy::BackendDataPtr XLATensor::GetXlaData() {
   if (up_to_date) {
     torch::lazy::BackendDataPtr handle = CurrentDataHandle();
     if (handle != nullptr) {
-      if (CurrentIrValue())
-        std::cout << "- Current IR: " << CurrentIrValue()->ToString()
-                  << std::endl;
       XLA_CHECK(handle->HasValue())
           << "Trying to access XLA data while an async operation is in flight: "
           << handle->shape();

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -277,12 +277,6 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
       const std::vector<XLATensorPtr>& tensors,
       absl::Span<const size_t> indices);
 
-  void CollectShardingSpecs(
-      std::vector<XLATensorPtr>* tensors, absl::Span<const size_t> indices,
-      ComputationPtr computation,
-      std::vector<torch::lazy::BackendDataPtr>* data_placeholders,
-      std::vector<XLATensor::ShardingSpecPtr>* sharding_specs);
-
   // TODO(alanwaketan): Reuse the upstream one once Functionalization is done.
   std::vector<torch::lazy::BackendDataPtr> SetTensorData(
       std::vector<XLATensorPtr>* tensors, const SyncTensorsConfig& config,

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -280,7 +280,7 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
   void CollectShardingSpecs(
       std::vector<XLATensorPtr>* tensors, absl::Span<const size_t> indices,
       ComputationPtr computation,
-      std::vector<torch::lazy::BackendDataPtr>* data_placholders,
+      std::vector<torch::lazy::BackendDataPtr>* data_placeholders,
       std::vector<XLATensor::ShardingSpecPtr>* sharding_specs);
 
   // TODO(alanwaketan): Reuse the upstream one once Functionalization is done.

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -248,7 +248,7 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
       const std::vector<XLATensorPtr>& tensors,
       const SyncTensorsConfig& config);
 
-  // Waits for this SyncTensorCollection's device barrier and acuire the lock.
+  // Waits for this SyncTensorCollection's device barrier and acquire the lock.
   // Override to enable SPMD.
   void TensorCollectionBarrier(SyncTensorCollection* coll) final;
 
@@ -277,8 +277,11 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
       const std::vector<XLATensorPtr>& tensors,
       absl::Span<const size_t> indices);
 
-  std::vector<XLATensor::ShardingSpecPtr> CollectShardingSpecs(
-      std::vector<XLATensorPtr>* tensors, absl::Span<const size_t> indices);
+  void CollectShardingSpecs(
+      std::vector<XLATensorPtr>* tensors, absl::Span<const size_t> indices,
+      ComputationPtr computation,
+      std::vector<torch::lazy::BackendDataPtr>* data_placholders,
+      std::vector<XLATensor::ShardingSpecPtr>* sharding_specs);
 
   // TODO(alanwaketan): Reuse the upstream one once Functionalization is done.
   std::vector<torch::lazy::BackendDataPtr> SetTensorData(

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -236,7 +236,6 @@ std::vector<xla::ComputationClient::DataPtr> ShardingUtil::OutputHandler(
   std::vector<xla::ComputationClient::DataPtr> outputs;
   outputs.reserve(sharding_specs.size());
   for (int i = 0; i < sharding_specs.size(); ++i) {
-    std::cout << "- sharding specs " << i << ", ";
     XLATensor::ShardingSpecPtr sharding = sharding_specs[i];
     if (replicated_output && sharding &&
         (sharding->sharding.type() != xla::OpSharding::REPLICATED)) {
@@ -269,7 +268,6 @@ std::vector<xla::ComputationClient::DataPtr> ShardingUtil::OutputHandler(
           shards, GetVirtualDevice().toString(), sharding->shape.value(),
           sharding->sharding));
     }
-    std::cout << std::endl;
   }
   return outputs;
 }
@@ -398,38 +396,36 @@ void ShardingUtil::ShardingContextArena::RegisterShardingPropagation(
     torch::lazy::BackendData* src_data, XLATensorPtr tensor) {
   // Override if already present and keep the latest.
   propagation_map[src_data] = tensor;
+  TF_VLOG(5) << "Registering sharding propagation to "
+             << (tensor->GetIrValue() ? tensor->GetIrValue()->ToString()
+                                      : "empty node.");
 }
 
 void ShardingUtil::ShardingContextArena::ApplyShardingPropagation(
     torch::lazy::Value ir_value) {
-  // TODO(yeounoh) need to check all the nested operands.
-  const torch::lazy::Node* node = ir_value.node.get();
-  std::vector<const torch::lazy::Node*> queue{node};
+  std::vector<const torch::lazy::Node*> queue{ir_value.node.get()};
+  std::unordered_map<const torch::lazy::Node*, int64_t> emitted;
   while (!queue.empty()) {
-    node = queue.back();
+    const torch::lazy::Node* node = queue.back();
     queue.pop_back();
-    for (const torch::lazy::Output output : node->operands()) {
-      std::cout << "-operand IR: " << output.node->ToString() << std::endl;
-      // torch::lazy::BackendDataPtr backend_data =
-      //     torch::lazy::getBackend()->GetComputationDataFromNode(output.node);
-      DeviceData* device_data_node = DeviceData::Cast(output.node);
-      if ((device_data_node != nullptr) &&
-          (propagation_map.find(device_data_node->data().get()) !=
-           propagation_map.end())) {
-        // The tensor has been sharding annotated by the compiler sharding
-        // propagation. It holds either an updated device handle or a DeviceData
-        // node.
-        const auto tensor = propagation_map[device_data_node->data().get()];
-        device_data_node->Assign(tensor->data()->handle);
-        std::cout << "-- updated IR: " << tensor->GetIrValue()->ToString()
-                  << std::endl;
-
-        // TODO(yeounoh) an alternative approach to `Assign`
-        // operands[i] =
-        //     torch::lazy::Output(tensor->GetIrValue().node.get(),
-        //     output.index);
-      } else {
-        queue.push_back(output.node);
+    if (emitted.find(node) == emitted.end()) {
+      emitted[node] = emitted.size();
+      for (const torch::lazy::Output output : node->operands()) {
+        DeviceData* device_data_node = DeviceData::Cast(output.node);
+        if ((device_data_node != nullptr) &&
+            (propagation_map.find(device_data_node->data().get()) !=
+             propagation_map.end())) {
+          // The tensor has been sharding annotated by the compiler sharding
+          // propagation. It holds either an updated device handle or a
+          // DeviceData node.
+          const auto tensor = propagation_map[device_data_node->data().get()];
+          device_data_node->Assign(tensor->data()->handle);
+          TF_VLOG(5) << "Applying sharding propagation to "
+                     << (tensor->GetIrValue() ? tensor->GetIrValue()->ToString()
+                                              : "empty node.");
+        } else {
+          queue.push_back(output.node);
+        }
       }
     }
   }

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -112,14 +112,19 @@ class ShardingUtil {
     void RegisterShardingPropagation(torch::lazy::BackendData* src_data,
                                      XLATensorPtr tensor);
 
-    // Update data placeholder in the operands if it is partitioned by the
-    // compiler sharding propagation.
+    void ClearShardingPropagation() { propagation_map.clear(); }
+
+    // Update BackendDataPtr in the operands of the IR value nodeif, if the
+    // device data has been partitioned by the sharding propagation.
+    // TODO(yeounoh) this may increase the tracing time and trace twice in the
+    // worst case.
     void ApplyShardingPropagation(torch::lazy::Value ir_value);
 
     int size() { return propagation_map.size(); }
 
    private:
     // Below two maps are used for dynamo integration.
+    // TODO(yeounoh) save partitioned BackendData ptr instead of XLATensorPtr.
     std::unordered_map<torch::lazy::BackendData*, XLATensorPtr> propagation_map;
   };
 };


### PR DESCRIPTION
This is a follow-up work of #4721 , to shard the computation outputs. This will help us avoid resharding the replicated outputs for more efficient stepping. Most notably, 
- we introduce `ShardingUtil::PrepareOutputShardingPropagation` to extract `SharidngSpecPtr` from sync tensors and prepare `PjRtShardedData` placeholders. 
- remove the logic to prepare PjRtShardedData placeholders in `ExtractIRAndPrepareXlaData_` 
- remove `CollectSharidngSpecs` also in favor of `PrepareOutputShardingPropagation`.