### PR TITLE
Disable cmake macros

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -8,7 +8,7 @@ tf_cc_shared_object(
     copts = [
         "-DTORCH_API_INCLUDE_EXTENSION_H",
         "-DTORCH_EXTENSION_NAME=_XLAC",
-        "-DC10_USING_CUSTOM_GENERATED_MACROS"
+        "-DC10_USING_CUSTOM_GENERATED_MACROS",
         "-fopenmp",
         "-fPIC",
         "-fwrapv",

--- a/BUILD
+++ b/BUILD
@@ -8,6 +8,7 @@ tf_cc_shared_object(
     copts = [
         "-DTORCH_API_INCLUDE_EXTENSION_H",
         "-DTORCH_EXTENSION_NAME=_XLAC",
+        "-DC10_USING_CUSTOM_GENERATED_MACROS"
         "-fopenmp",
         "-fPIC",
         "-fwrapv",


### PR DESCRIPTION
When building pytorchxla, we need to inform pytorch headers that we're not using CMake.

https://github.com/pytorch/pytorch/blob/5ac48eb353247e86684bfafa8e371eccd17951d7/c10/macros/Macros.h#L11-L19