### PR TITLE
Add executeReplicated metrics

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -123,7 +123,7 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     xs.mark_sharding(xt, self._get_mesh((1, self.n_devices)), (0, 1))
     xt += 2
     sharding_spec = torch_xla._XLAC._get_xla_sharding_spec(xt)
-    xm.mark_step()  # mark_step should preserve the sharding
+    xm.mark_step()
     xm.wait_device_ops()
     self.assertEqual(met.metric_data('ExecuteReplicatedTime')[0], 1)
 

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -9,6 +9,7 @@ from torch import nn
 import torch.optim as optim
 import torch_xla
 import torch_xla.core.xla_model as xm
+import torch_xla.debug.metrics as met
 import torch_xla.experimental.xla_sharding as xs
 from torch_xla.experimental.xla_sharded_tensor import XLAShardedTensor
 import test_xla_sharding_base
@@ -115,6 +116,16 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     sharding_spec = torch_xla._XLAC._get_xla_sharding_spec(xt)
     xm.mark_step()  # mark_step should preserve the sharding
     self.assertEqual(sharding_spec, torch_xla._XLAC._get_xla_sharding_spec(xt))
+
+  def test_execute_replicated_metrics(self):
+    met.clear_all()
+    xt = torch.ones(2, 2).to(xm.xla_device())
+    xs.mark_sharding(xt, self._get_mesh((1, self.n_devices)), (0, 1))
+    xt += 2
+    sharding_spec = torch_xla._XLAC._get_xla_sharding_spec(xt)
+    xm.mark_step()  # mark_step should preserve the sharding
+    xm.wait_device_ops()
+    self.assertEqual(met.metric_data('ExecuteReplicatedTime')[0], 1)
 
   def test_optimizer_step_with_sharding(self):
     # Use simple linear model to test model parameter sharding

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <unordered_set>
+#include <vector>
 
 #include "absl/strings/ascii.h"
 #include "absl/types/span.h"
@@ -28,6 +29,8 @@
 namespace xla {
 
 namespace {
+
+static std::string spmd_device_str = "SPMD:0";
 
 // Initializes a distributed runtime client if dist_service_addr is specified
 std::shared_ptr<DistributedRuntimeClient>
@@ -129,6 +132,8 @@ PjRtComputationClient::PjRtComputationClient() {
     string_to_device_.emplace(device_str, device);
     device_locks_.emplace(device_str, std::make_unique<std::shared_mutex>());
   }
+  // manually create the device_locks for SPMD device
+  device_locks_.emplace(spmd_device_str, std::make_unique<std::shared_mutex>());
 }
 
 void PjRtComputationClient::PjRtData::Assign(const Data& data) {
@@ -492,6 +497,13 @@ PjRtComputationClient::ExecuteReplicated(
     const std::vector<std::vector<ComputationClient::DataPtr>>& arguments,
     absl::Span<const std::string> devices,
     const ExecuteReplicatedOptions& options) {
+  // Shared ownership of the timed section ensures that it will only get logged
+  // once both `ExecuteReplicated` and the async work in `Execute` are
+  // complete; a copy is held from the lambda that releases it when done.
+  auto timed =
+      std::make_shared<metrics::TimedSection>(ExecuteReplicatedMetric());
+  tsl::profiler::TraceMe activity("PjRtComputationClient::ExecuteReplicated",
+                                  tsl::profiler::TraceMeLevel::kInfo);
   const PjRtComputation& pjrt_computation =
       dynamic_cast<const PjRtComputation&>(computation);
   XLA_CHECK(devices.size() == arguments.size())
@@ -524,13 +536,32 @@ PjRtComputationClient::ExecuteReplicated(
   // Required as of cl/518733871
   execute_options.use_major_to_minor_data_layout_for_callbacks = true;
 
+  std::optional<std::vector<PjRtFuture<Status>>> returned_futures;
+  returned_futures.emplace();
   std::vector<std::vector<std::unique_ptr<PjRtBuffer>>> results =
-      pjrt_computation.executable->Execute(argument_handles, execute_options)
+      pjrt_computation.executable
+          ->Execute(argument_handles, execute_options, returned_futures)
           .value();
 
   std::vector<std::vector<ComputationClient::DataPtr>> data_handles;
   data_handles.reserve(results.size());
   std::vector<size_t> dims(results.size());
+
+  // Grab the shared lock and block the `WaitDeviceOps` until buffer is ready.
+  // Since this is the SPMD code path.
+  // There is no points to grab devices lock for every individual device.
+  auto lock = lock_device_shared(spmd_device_str);
+  TF_VLOG(3) << "ExecuteReplicated grep the lock for " << spmd_device_str;
+  // Signal that `ExecuteReplicated` has completed for one of the devices the
+  // ExecuteReplicatedTime metric. Here, we assume that all devices will finish
+  // execution roughly at the same time, hence only use one of the
+  // returned_futures. Copies the `timed` shared pointer into the lambda.
+  (*returned_futures)[0].OnReady(
+      [timed, lock = std::move(lock)](Status unused) mutable {
+        timed.reset();
+        TF_VLOG(3) << "ExecuteReplicated returned_future->OnReady finished";
+      });
+
   for (int32_t i = 0; i < results.size(); ++i) {
     xla::PjRtDevice* pjrt_device = StringToPjRtDevice(devices[i]);
     XLA_CHECK(pjrt_device->IsAddressable())

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -551,7 +551,7 @@ PjRtComputationClient::ExecuteReplicated(
   // Since this is the SPMD code path.
   // There is no points to grab devices lock for every individual device.
   auto lock = lock_device_shared(spmd_device_str);
-  TF_VLOG(3) << "ExecuteReplicated grep the lock for " << spmd_device_str;
+  TF_VLOG(3) << "ExecuteReplicated grab the lock for " << spmd_device_str;
   // Signal that `ExecuteReplicated` has completed for one of the devices the
   // ExecuteReplicatedTime metric. Here, we assume that all devices will finish
   // execution roughly at the same time, hence only use one of the

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -536,8 +536,7 @@ PjRtComputationClient::ExecuteReplicated(
   // Required as of cl/518733871
   execute_options.use_major_to_minor_data_layout_for_callbacks = true;
 
-  std::optional<std::vector<PjRtFuture<Status>>> returned_futures;
-  returned_futures.emplace();
+  std::optional<std::vector<PjRtFuture<Status>>> returned_futures(devices.size());
   std::vector<std::vector<std::unique_ptr<PjRtBuffer>>> results =
       pjrt_computation.executable
           ->Execute(argument_handles, execute_options, returned_futures)

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1222,7 +1222,12 @@ void InitXlaModuleBindings(py::module m) {
         [](const std::vector<std::string>& devices) {
           NoGilSection nogil;
           XLAGraphExecutor::Get()->WaitDeviceOps(devices);
-          xla::ComputationClient::Get()->WaitDeviceOps(devices);
+          if (ShardingUtil::UseVirtualDevice()) {
+            std::vector<std::string> spmd_device = {"SPMD:0"};
+            xla::ComputationClient::Get()->WaitDeviceOps(spmd_device);
+          } else {
+            xla::ComputationClient::Get()->WaitDeviceOps(devices);
+          }
         },
         py::arg("devices"));
   m.def("_xla_counter_names", []() {

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -565,6 +565,7 @@ XLAGraphExecutor::SyncTensorCollection XLAGraphExecutor::CollectSyncTensors(
 void XLAGraphExecutor::TensorCollectionBarrier(SyncTensorCollection* coll) {
   torch::lazy::LazyGraphExecutor::TensorCollectionBarrier(coll);
   // TODO(yeounoh) lock SPMD device
+  TF_VLOG(4) << "waiting barrier for device " << coll->device.toString();
 }
 
 std::vector<torch::lazy::BackendDataPtr>

--- a/torch_xla/debug/metrics.py
+++ b/torch_xla/debug/metrics.py
@@ -75,7 +75,7 @@ def short_metrics_report(counter_names: list = None, metric_names: list = None):
     counter_names = ['CachedCompile', 'MarkStep']
   if not metric_names:
     metric_names = [
-        'CompileTime', 'ExecuteTime', 'TransferToServerTime',
-        'TransferFromServerTime'
+        'CompileTime', 'ExecuteTime', 'ExecuteReplicatedTime',
+        'TransferToServerTime', 'TransferFromServerTime'
     ]
   return torch_xla._XLAC._short_xla_metrics_report(counter_names, metric_names)


### PR DESCRIPTION
This pr is similar to previous pr https://github.com/pytorch/xla/commit/6d1158cfb375bf17298491b86a064f1ce025d263. In this pr I added the `ExecuteReplicatedMetric` to `ExecuteReplicated` functions. However since the PJRT execution is async, in order to make the `ExecuteReplicatedMetric` accurate, we can not rely on the function return. We have to use the `returned_futures.OnReady` function to determine the actual duration of the execution.

On top of the `OnReady` function we have to add, we also need a way for `waitDeviceOps` to wait for the execution to actually finished instead hence we need another lock in the PJRT level. The lock at `XLAGraphExecutor` level only wait for the `ExecuteReplicated` function return, but that doesn't means execution actually finished since it is async.


a couple things I have to work around
1. during most of the tracing, we use `TPU:0` as the device, however we uses `SPMD:0` as the device when it comes to the data movement. This is a bit confusing but I decided to use `SPMD:0` as the device lock name in PJRT level, since in PJRT we sees a vector of addressable devices(`TPU:0` -> `TPU:3`), it would be more confusing to use `TPU:0` as the lock name.
2. In ExecuteReplicated, there will be 4 `returned_futures` on v4-8, since there are 4 executions happens. I just pick the first return future assuming all of them will finish ~ the same time.


I will do a through review of how we handle `SPMD:0` devices after this pr, it is confusing when to use what devices.


Here is the sample log to explain how lock works

```
2023-05-17 18:55:25.594536: I torch_xla/csrc/xla_graph_executor.cpp:568] waiting barrier for device TPU:0

--> grab XLAGraphExecutor lock for TPU:0

2023-05-17 18:55:25.610473: I torch_xla/csrc/xla_graph_executor.cpp:960] Executing IR graph hash 9fbe82f547fe1c00fea546299c8fb68e on devices: TPU:0,TPU:1,TPU:2,TPU:3
2023-05-17 18:55:25.613481: I third_party/xla_client/pjrt_computation_client.cc:554] ExecuteReplicated grep the lock for SPMD:0

--> grab the PJRT lock for SPMD:0

2023-05-17 18:55:25.613524: I third_party/xla_client/pjrt_computation_client.cc:586] Returning 4 sets of results with dimensions [1,1,1,1].

--> after async function finished, we will release XLAGraphExecutor lock

2023-05-17 18:55:25.614203: I third_party/xla_client/pjrt_computation_client.cc:562] ExecuteReplicated returned_future->OnReady finished

--> release the PJRT SPMD:0 lock when execution actually finished
```