### PR TITLE
frmat cc files

### DIFF
--- a/third_party/xla_client/pjrt_computation_client_test.cc
+++ b/third_party/xla_client/pjrt_computation_client_test.cc
@@ -13,9 +13,9 @@
 #include "tensorflow/compiler/xla/status.h"
 #include "tensorflow/compiler/xla/statusor.h"
 #include "tensorflow/compiler/xla/tests/literal_test_util.h"
-#include "tensorflow/tsl/platform/logging.h"
 #include "tensorflow/tsl/lib/core/status_test_util.h"
 #include "tensorflow/tsl/platform/env.h"
+#include "tensorflow/tsl/platform/logging.h"
 #include "tensorflow/tsl/platform/test.h"
 #include "third_party/xla_client/computation_client.h"
 

--- a/third_party/xla_client/record_reader.cc
+++ b/third_party/xla_client/record_reader.cc
@@ -1,8 +1,8 @@
 #include "third_party/xla_client/record_reader.h"
 
+#include "tensorflow/tsl/platform/env.h"
 #include "tensorflow/tsl/platform/errors.h"
 #include "tensorflow/tsl/platform/strcat.h"
-#include "tensorflow/tsl/platform/env.h"
 #include "third_party/xla_client/debug_macros.h"
 
 namespace xla {
@@ -14,8 +14,7 @@ RecordReader::RecordReader(std::string path, const std::string& compression,
   tsl::Env* env = tsl::Env::Default();
   XLA_CHECK_OK(env->NewRandomAccessFile(path_, &file_));
   tsl::io::RecordReaderOptions options =
-      tsl::io::RecordReaderOptions::CreateRecordReaderOptions(
-          compression);
+      tsl::io::RecordReaderOptions::CreateRecordReaderOptions(compression);
   options.buffer_size = buffer_size;
   reader_.reset(new tsl::io::RecordReader(file_.get(), options));
 }

--- a/third_party/xla_client/xla_util_test.cc
+++ b/third_party/xla_client/xla_util_test.cc
@@ -11,8 +11,8 @@
 #include "tensorflow/compiler/xla/client/xla_builder.h"
 #include "tensorflow/compiler/xla/client/xla_computation.h"
 #include "tensorflow/tsl/lib/core/status_test_util.h"
-#include "tensorflow/tsl/platform/protobuf.h"
 #include "tensorflow/tsl/platform/errors.h"
+#include "tensorflow/tsl/platform/protobuf.h"
 #include "tensorflow/tsl/platform/status_matchers.h"
 #include "tensorflow/tsl/protobuf/error_codes.pb.h"
 #include "xla_util.h"
@@ -36,10 +36,10 @@ StatusOr<MessageType> ParseTextProto(const std::string& text_proto) {
   tsl::protobuf::TextFormat::Parser parser;
   MessageType parsed_proto;
   tsl::protobuf::io::ArrayInputStream input_stream(text_proto.data(),
-                                                          text_proto.size());
+                                                   text_proto.size());
   if (!parser.Parse(&input_stream, &parsed_proto)) {
     return tsl::errors::InvalidArgument("Could not parse text proto: ",
-                                               text_proto);
+                                        text_proto);
   }
   return parsed_proto;
 }

--- a/third_party/xla_client/xrt_computation_client.cc
+++ b/third_party/xla_client/xrt_computation_client.cc
@@ -17,9 +17,9 @@
 #include "tensorflow/compiler/xla/util.h"
 #include "tensorflow/compiler/xrt/xrt_util.h"
 #include "tensorflow/tsl/framework/allocator.h"
+#include "tensorflow/tsl/lib/math/math_util.h"
 #include "tensorflow/tsl/profiler/lib/traceme.h"
 #include "tensorflow/tsl/util/device_name_utils.h"
-#include "tensorflow/tsl/lib/math/math_util.h"
 #include "third_party/xla_client/env_vars.h"
 #include "third_party/xla_client/multi_wait.h"
 #include "third_party/xla_client/sys_util.h"
@@ -406,8 +406,8 @@ std::vector<ComputationClient::DataPtr>
 XrtComputationClient::TransferToServerInternal(
     absl::Span<const TensorSource> tensors, absl::Span<const DataPtr> datas) {
   metrics::TimedSection timed(TransferToServerMetric());
-  tsl::profiler::TraceMe activity(
-      "TransferToServerInternal", tsl::profiler::TraceMeLevel::kInfo);
+  tsl::profiler::TraceMe activity("TransferToServerInternal",
+                                  tsl::profiler::TraceMeLevel::kInfo);
 
   // If datas are passed in, don't create new datas but modify the passed in
   // datas.
@@ -418,8 +418,8 @@ XrtComputationClient::TransferToServerInternal(
   auto mwait = std::make_shared<util::MultiWait>(tensors.size());
   std::map<XrtSession*, SessionWork> session_work_map;
   {
-    tsl::profiler::TraceMe activity(
-        "TransferToServerTransform", tsl::profiler::TraceMeLevel::kInfo);
+    tsl::profiler::TraceMe activity("TransferToServerTransform",
+                                    tsl::profiler::TraceMeLevel::kInfo);
     metrics::TimedSection timed(TransferToServerTransformMetric());
 
     for (size_t i = 0; i < tensors.size(); ++i) {
@@ -505,8 +505,8 @@ XrtComputationClient::TransferToServerInternal(
 std::vector<Literal> XrtComputationClient::TransferFromServer(
     absl::Span<const DataPtr> handles) {
   metrics::TimedSection timed(TransferFromServerMetric());
-  tsl::profiler::TraceMe activity(
-      "TransferFromServer", tsl::profiler::TraceMeLevel::kInfo);
+  tsl::profiler::TraceMe activity("TransferFromServer",
+                                  tsl::profiler::TraceMeLevel::kInfo);
 
   int64_t max_partition_size = GetMaxTensorsPartitionSize();
   std::list<XrtSessionCache::SessionMap> session_maps;
@@ -573,8 +573,8 @@ std::vector<Literal> XrtComputationClient::TransferFromServer(
 std::vector<ComputationClient::ComputationPtr> XrtComputationClient::Compile(
     std::vector<CompileInstance> instances) {
   metrics::TimedSection timed(CompileMetric());
-  tsl::profiler::TraceMe activity(
-      "Compile", tsl::profiler::TraceMeLevel::kInfo);
+  tsl::profiler::TraceMe activity("Compile",
+                                  tsl::profiler::TraceMeLevel::kInfo);
 
   std::mutex lock;
   auto mwait = std::make_shared<util::MultiWait>(instances.size());
@@ -680,8 +680,8 @@ XrtComputationClient::ExecuteComputation(
     const Computation& computation, absl::Span<const DataPtr> arguments,
     const std::string& device, const ExecuteComputationOptions& options) {
   metrics::TimedSection timed(ExecuteMetric());
-  tsl::profiler::TraceMe activity(
-      "ExecuteComputation", tsl::profiler::TraceMeLevel::kInfo);
+  tsl::profiler::TraceMe activity("ExecuteComputation",
+                                  tsl::profiler::TraceMeLevel::kInfo);
 
   XrtSessionCache::SessionMap session_map;
   tensorflow::ClientSession::FeedType feed_inputs;
@@ -709,8 +709,8 @@ XrtComputationClient::ExecuteReplicated(
     absl::Span<const std::string> devices,
     const ExecuteReplicatedOptions& options) {
   metrics::TimedSection timed(ExecuteReplicatedMetric());
-  tsl::profiler::TraceMe activity(
-      "ExecuteReplicated", tsl::profiler::TraceMeLevel::kInfo);
+  tsl::profiler::TraceMe activity("ExecuteReplicated",
+                                  tsl::profiler::TraceMeLevel::kInfo);
 
   XrtSessionCache::SessionMap session_map;
   tensorflow::ClientSession::FeedType feed_inputs;
@@ -731,8 +731,8 @@ XrtComputationClient::RunComputations(
     absl::Span<const Computation* const> computations,
     absl::Span<const std::string> devices,
     const tensorflow::ClientSession::FeedType& feed_inputs) {
-  tsl::profiler::TraceMe activity(
-      "RunComputations", tsl::profiler::TraceMeLevel::kInfo);
+  tsl::profiler::TraceMe activity("RunComputations",
+                                  tsl::profiler::TraceMeLevel::kInfo);
   // In the PyTorch/XRT interface we keep a map (options_.workers_map) from a
   // worker+taskno, to the GRPC server which is the entry point for that worker.
   // Since XRT could re-distribute ops internally, if we have N hosts
@@ -797,8 +797,8 @@ XrtComputationClient::ExecuteParallel(
     absl::Span<const std::string> devices,
     const ExecuteParallelOptions& options) {
   metrics::TimedSection timed(ExecuteParallelMetric());
-  tsl::profiler::TraceMe activity(
-      "ExecuteParallel", tsl::profiler::TraceMeLevel::kInfo);
+  tsl::profiler::TraceMe activity("ExecuteParallel",
+                                  tsl::profiler::TraceMeLevel::kInfo);
 
   XrtSessionCache::SessionMap session_map;
   tensorflow::ClientSession::FeedType feed_inputs;
@@ -832,8 +832,8 @@ void XrtComputationClient::SetupExecConfig(const Device& device,
 
 std::vector<ComputationClient::DataPtr> XrtComputationClient::ExecuteChained(
     absl::Span<const ExecuteChainedOp> ops, const std::string& device) {
-  tsl::profiler::TraceMe activity(
-      "ExecuteChained", tsl::profiler::TraceMeLevel::kInfo);
+  tsl::profiler::TraceMe activity("ExecuteChained",
+                                  tsl::profiler::TraceMeLevel::kInfo);
   static int64_t split_mode = sys_util::GetEnvInt("XRT_SPLIT_CHAINED_EXEC", 0);
   return split_mode ? ExecuteChainedSplit(ops, device)
                     : ExecuteChainedXrt(ops, device);
@@ -1203,8 +1203,8 @@ void XrtComputationClient::ReleaseHandles(
         XrtSession*, const tensorflow::Scope&, const std::string&)>&
         op_generator,
     metrics::Metric* timed_metric, metrics::Counter* destroy_counter) {
-  tsl::profiler::TraceMe activity(
-      "ReleaseHandles", tsl::profiler::TraceMeLevel::kInfo);
+  tsl::profiler::TraceMe activity("ReleaseHandles",
+                                  tsl::profiler::TraceMeLevel::kInfo);
   std::vector<DeviceHandle> released_handles;
   {
     std::lock_guard<std::mutex> lock(lock_);
@@ -1713,7 +1713,7 @@ void XrtComputationClient::InitSession(XrtSession* session) const {
   struct InitNode {
     int count;
     const XrtSession::CachedNode& (XrtComputationClient::*node_ctor)(
-        XrtSession*, const tensorflow::Scope&, const std::string&) const;
+        XrtSession*, const tensorflow::Scope&, const std::string&)const;
   } const init_nodes[] = {
       {16, &XrtComputationClient::GetCompileNode},
       {16, &XrtComputationClient::GetExecuteNode},

--- a/third_party/xla_client/xrt_local_service.cc
+++ b/third_party/xla_client/xrt_local_service.cc
@@ -5,11 +5,11 @@
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 #include "tensorflow/compiler/xla/stream_executor/tpu/tpu_initializer_helper.h"
-#include "tensorflow/tsl/platform/errors.h"
-#include "tensorflow/tsl/platform/status.h"
 #include "tensorflow/core/protobuf/cluster.pb.h"
 #include "tensorflow/core/protobuf/tensorflow_server.pb.h"
 #include "tensorflow/core/public/session_options.h"
+#include "tensorflow/tsl/platform/errors.h"
+#include "tensorflow/tsl/platform/status.h"
 
 namespace xla {
 namespace {


### PR DESCRIPTION
I am not exactly sure why this is not being picking up by our linter in CI.. maybe it is a clang-format-7 config issue? in https://app.circleci.com/pipelines/github/pytorch/xla/19119/workflows/2da649a9-939f-47d0-8f6a-054707e9e3d3/jobs/47203 it does show that cc file is being formatted as well.