### PR TITLE
Fix how we find C++ source files when formatting.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,7 @@ run_clang_format: &run_clang_format
       exit 1
     fi
 
-    find -name '*.cpp' -o -name '*.h' -name '*.cc' | xargs clang-format-7 -i -style=file
+    find -name '*.cpp' -o -name '*.h' -o -name '*.cc' | xargs clang-format-7 -i -style=file
     git_status=$(git status --porcelain)
     if [[ $git_status ]]; then
       git diff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ If your PR touches the C++ source files, please run the following command before
 # If your PR only changes foo.cpp, run the following in xla/ folder
 clang-format-7 -i -style=file /PATH/TO/foo.cpp
 # To format all cpp files, run the following in xla/ folder
-find -name '*.cpp' -o -name '*.h' | xargs clang-format-7 -i -style=file
+find -name '*.cpp' -o -name '*.h' -o -name '*.cc' | xargs clang-format-7 -i -style=file
 ```
 
 ### Python Style Guide

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -536,7 +536,8 @@ PjRtComputationClient::ExecuteReplicated(
   // Required as of cl/518733871
   execute_options.use_major_to_minor_data_layout_for_callbacks = true;
 
-  std::optional<std::vector<PjRtFuture<Status>>> returned_futures(devices.size());
+  std::optional<std::vector<PjRtFuture<Status>>> returned_futures(
+      devices.size());
   std::vector<std::vector<std::unique_ptr<PjRtBuffer>>> results =
       pjrt_computation.executable
           ->Execute(argument_handles, execute_options, returned_futures)


### PR DESCRIPTION
When formatting C++, the `.cc` files are not found (`xla_client` code), due to the missing logical or `-o` operator on `find(1)`.