### PR TITLE
[CI] Move lintcheck from Circle to GHA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,68 +223,6 @@ run_test_coverage: &run_test_coverage
   - store_artifacts:
       path: htmlcov
 
-run_clang_format: &run_clang_format
-  name: Run clang-format
-  command: |
-    sudo apt-get update
-    sudo apt install -y clang-format-7
-    git_status=$(git status --porcelain)
-    if [[ $git_status ]]; then
-      echo "Checkout code is not clean"
-      echo "${git_status}"
-      exit 1
-    fi
-
-    find -name '*.cpp' -o -name '*.h' -o -name '*.cc' | xargs clang-format-7 -i -style=file
-    git_status=$(git status --porcelain)
-    if [[ $git_status ]]; then
-      git diff
-      echo "clang-format-7 recommends the changes above, please manually apply them OR automatically apply the changes "
-      echo "by running \"clang-format-7 -i -style=file /PATH/TO/foo.cpp\" to the following files"
-      echo "${git_status}"
-      exit 1
-    else
-      echo "PASSED C++ format"
-    fi
-
-run_yapf: &run_yapf
-  name: Run yapf
-  command: |
-    pyenv install 3.7.0
-    pyenv global 3.7.0
-    pip install --upgrade pip
-    pip install yapf==0.30.0
-
-    git_status=$(git status --porcelain)
-    if [[ $git_status ]]; then
-      echo "Checkout code is not clean"
-      echo "${git_status}"
-      exit 1
-    fi
-
-    yapf -i -r *.py test/ scripts/ torch_xla/
-    git_status=$(git status --porcelain)
-    if [[ $git_status ]]; then
-      git diff
-      echo "yapf recommends the changes above, please manually apply them OR automatically apply the changes "
-      echo "by running `yapf -i /PATH/TO/foo.py` to the following files"
-      echo "${git_status}"
-      exit 1
-    else
-      echo "PASSED Python format"
-    fi
-
-assert_no_torch_pin: &assert_no_torch_pin
-  name: Make sure torch_patches/.torch_pin is removed before merging
-  command: |
-      TORCH_PIN=./torch_patches/.torch_pin
-      if [[ -f "${TORCH_PIN}" ]]; then
-        echo "Please remove ${TORCH_PIN} before landing."
-        exit 1
-      else
-        echo "No ${TORCH_PIN} found, safe to land..."
-      fi
-
 assert_continue_on_error_is_false: &assert_continue_on_error_is_false
   name: Make sure CONTINUE_ON_ERROR flags are set to false before merging
   command: |
@@ -314,28 +252,6 @@ ci_params: &ci_params
   resource_class: << parameters.resource_class >>
 
 jobs:
-  linter_check:
-    machine:
-      image: ubuntu-2004:202111-02
-    steps:
-    - checkout
-    - run:
-        <<: *run_clang_format
-    - run:
-        <<: *run_yapf
-
-  linter_check_no_torch_pin:
-    machine:
-      image: ubuntu-2004:202111-02
-    steps:
-    - checkout
-    - run:
-        <<: *assert_no_torch_pin
-    - run:
-        <<: *run_clang_format
-    - run:
-        <<: *run_yapf
-
   continue_on_error_is_false:
     machine:
       image: ubuntu-2004:202111-02
@@ -362,18 +278,6 @@ jobs:
 workflows:
   build:
     jobs:
-      - linter_check:
-          filters:
-            branches:
-              ignore:
-                - master
-                - ^r\d*\.?\d*$
-      - linter_check_no_torch_pin:
-          filters:
-            branches:
-              only:
-                - master
-                - ^r\d*\.?\d*$
       - pytorch_xla_run_build
       - pytorch_xla_run_test:
           name: pytorch_xla_run_CPU_test

--- a/.github/workflows/lintercheck.yml
+++ b/.github/workflows/lintercheck.yml
@@ -1,0 +1,79 @@
+name: Linter check
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags:
+      - r[0-9]+.[0-9]+
+
+jobs:
+  linter_check:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+      - run: pip install yapf==0.30.0
+
+      - name: Check no TORCH_PIN
+        if: github.event_name == 'push' && github.event.ref == 'master'
+        shell: bash
+        run: |
+          TORCH_PIN=./torch_patches/.torch_pin
+          if [[ -f "${TORCH_PIN}" ]]; then
+            echo "Please remove ${TORCH_PIN} before landing."
+            exit 1
+          else
+            echo "No ${TORCH_PIN} found, safe to land..."
+          fi
+      - name: Run clang-format
+        shell: bash
+        env:
+          CLANG_FORMAT: clang-format-7
+        run: |
+          sudo apt-get update
+          sudo apt install -y "${CLANG_FORMAT}"
+          git_status=$(git status --porcelain)
+          if [[ $git_status ]]; then
+            echo "Checkout code is not clean"
+            echo "${git_status}"
+            exit 1
+          fi
+
+          find . -name '*.cpp' -o -name '*.h' -name '*.cc' | xargs "${CLANG_FORMAT}" -i -style=file
+          git_status=$(git status --porcelain)
+          if [[ $git_status ]]; then
+            git diff
+            echo "${CLANG_FORMAT} recommends the changes above, please manually apply them OR automatically apply the changes "
+            echo "by running \"${CLANG_FORMAT} -i -style=file /PATH/TO/foo.cpp\" to the following files"
+            echo "${git_status}"
+            exit 1
+          else
+            echo "PASSED C++ format"
+          fi
+      - name: Run yapf
+        shell: bash
+        run: |
+          git_status=$(git status --porcelain)
+          if [[ $git_status ]]; then
+            echo "Checkout code is not clean"
+            echo "${git_status}"
+            exit 1
+          fi
+
+          yapf -i -r *.py test/ scripts/ torch_xla/
+          git_status=$(git status --porcelain)
+          if [[ $git_status ]]; then
+            git diff
+            echo "yapf recommends the changes above, please manually apply them OR automatically apply the changes "
+            echo "by running `yapf -i /PATH/TO/foo.py` to the following files"
+            echo "${git_status}"
+            exit 1
+          else
+            echo "PASSED Python format"
+          fi


### PR DESCRIPTION
Should be a no-op, simple move the lintcheck logic from `.circleci/config.yml` to `.github/workflows/lintercheck.yml`, with few small exceptions:
 - Instead of having two workflows, one for pull and one for trunk, use one but skip `TORCH_PIN` check on pull
 - Move `clang-format` package name/executable to environment variable (by the way, `clang-format-14` finds a lots of violations)