### PR TITLE
Move development image trigger to the -releases GCP project and public docker repo.

### DIFF
--- a/infra/tpu-pytorch-releases/README.md
+++ b/infra/tpu-pytorch-releases/README.md
@@ -3,6 +3,10 @@
 This setup configures all resources for building public artifacts: docker images
 and python wheels.
 
+In addition to public artifacts, the setup also configures:
+* Cloud Build trigger for the public development Docker image (`dev-image`).
+
+
 ## Cloud Build Triggers
 
 This section explains how to add, modify and run Cloud Build triggers to:

--- a/infra/tpu-pytorch-releases/dev_images.auto.tfvars
+++ b/infra/tpu-pytorch-releases/dev_images.auto.tfvars
@@ -1,0 +1,11 @@
+dev_images = [
+  {
+    accelerator = "tpu"
+    extra_tags  = ["tpu"]
+  },
+  {
+    accelerator  = "cuda"
+    cuda_version = "11.8"
+    extra_tags   = ["cuda"]
+  }
+]

--- a/infra/tpu-pytorch-releases/dev_images.tf
+++ b/infra/tpu-pytorch-releases/dev_images.tf
@@ -1,0 +1,69 @@
+variable "dev_images" {
+  type = list(object({
+    accelerator    = string
+    arch           = optional(string, "amd64")
+    python_version = optional(string, "3.8")
+    cuda_version   = optional(string, "11.8")
+
+    # Additional tags on top of uniquely generated tag based on accelerator,
+    # python and cuda versions.
+    extra_tags = optional(list(string), [])
+  }))
+}
+
+locals {
+  dev_images_dict = {
+    for di in var.dev_images :
+    format("%s_%s",
+      di.python_version,
+      di.accelerator == "tpu" ? "tpuvm" : format("cuda_%s", di.cuda_version)
+    ) => di
+  }
+}
+
+module "dev_images" {
+  source   = "../terraform_modules/xla_docker_build"
+  for_each = local.dev_images_dict
+
+  # Replace `.` and `_` with `-` as they're not allowed in trigger name.
+  trigger_name = "dev-${replace(each.key, "/[_.]/", "-")}"
+
+  ansible_branch = "master"
+  trigger_on_push = {
+    branch         = "master"
+    included_files = ["infra/**"]
+  }
+
+  image_name = "development"
+  image_tags = concat(each.value.extra_tags, [
+    each.key,
+    # Append _YYYYMMDD suffix to the dev image name.
+    "${each.key}_$(date +%Y%m%d)",
+  ])
+
+  dockerfile = "development.Dockerfile"
+  description = join(" ", [
+    "Builds development:${each.key} image.",
+    "Trigger managed by Terraform setup in infra/tpu-pytorch-releases/dev_images.tf.",
+  ])
+
+  build_args = {
+    python_version = each.value.python_version
+    debian_version = "buster"
+  }
+
+  ansible_vars = {
+    xla_git_rev     = "$COMMIT_SHA"
+    pytorch_git_rev = "main"
+
+    accelerator    = each.value.accelerator
+    arch           = each.value.arch
+    python_version = each.value.python_version
+    cuda_version   = each.value.cuda_version
+  }
+
+  docker_repo_url = module.docker_registry.url
+  worker_pool_id  = module.worker_pool.id
+  timeout_minutes = 60
+  location        = "global"
+}

--- a/infra/tpu-pytorch/README.md
+++ b/infra/tpu-pytorch/README.md
@@ -1,6 +1,5 @@
 # Terraform setup for pytorch-xla GCP project
 
 This setup configures:
-* Cloud Build trigger for the development Docker image (`dev-image`).
-* Private docker repository for the dev images and experiments (`docker`).
+* Private docker repository (`docker`).
 * CI test trigger.


### PR DESCRIPTION
This trigger will upload dev images to the public `us-central1-docker.pkg.dev/tpu-pytorch-releases/docker` repository, so the they may be used by contributors.

After this PR is merged and the configuration is updated, I'll:
1. Trigger new Cloud Build so that the dev images are produced.
2. Update devcontainer.json to point to the new image.
3. Remove old trigger.
4. Some time later we can manually remove old dev images from the `us-central1-docker.pkg.dev/tpu-pytorch/docker` repo.