### PR TITLE
Add load_local_shards to XLAShardedTensor

### DIFF
--- a/torch_xla/csrc/tensor_util.h
+++ b/torch_xla/csrc/tensor_util.h
@@ -80,6 +80,12 @@ std::vector<xla::Shape> GetComponentShapes(const xla::Shape& shape);
 xla::Shape MakeShapeWithDeviceLayout(const xla::Shape& shape,
                                      XlaDeviceType hw_type);
 
+// Copy the tensor's data into the destination buffer.
+void PopulateTensorBuffer(const at::Tensor& tensor,
+                          const xla::Shape& dest_shape, void* dest_buffer,
+                          size_t dest_buffer_size,
+                          const torch::lazy::BackendDevice& device);
+
 // Create the XLA shape to be used within a lowered XLA computation, to
 // represent a given tensor data.
 xla::Shape CreateComputationShapeFromTensor(

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -121,6 +121,12 @@ class ShardingUtil {
       ComputationPtr computation,
       std::vector<torch::lazy::BackendDataPtr>* data_placeholders,
       std::vector<XLATensor::ShardingSpecPtr>* sharding_specs);
+
+  // Transfers the individual shards to the devices and returns a DataPtr for
+  // the PjRtShardedData wrapping the shards.
+  static xla::ComputationClient::DataPtr CreateShardedData(
+      std::vector<at::Tensor>& shards, std::vector<std::string>& devices,
+      xla::Shape global_shape, xla::OpSharding sharding);
 };
 
 }  // namespace torch_xla

--- a/torch_xla/experimental/xla_sharded_tensor.py
+++ b/torch_xla/experimental/xla_sharded_tensor.py
@@ -20,6 +20,9 @@ class XLAShard:
   # global tensor.
   indices: Union[type(Ellipsis), List[slice]]
 
+  # The device this shard's data originated from.
+  shard_device: str
+
   # TODO(jonbolin): Expose replica rank with partial replication
   # rank: int
 
@@ -103,7 +106,16 @@ class XLAShardedTensor(torch.Tensor):
     devices = [str(shard.device) for shard in shards]
     indices = torch_xla._XLAC._get_local_shard_indices(self.global_tensor,
                                                        devices)
-    return [XLAShard(s.cpu(), i) for s, i in zip(shards, indices)]
+    return [
+        XLAShard(s.cpu(), i, d) for s, i, d in zip(shards, indices, devices)
+    ]
+
+  # Load the given list of local shards into the underlying tensor's data
+  # on the local devices.
+  def load_local_shards_(self, shards: List[XLAShard]):
+    data = [s.data for s in shards]
+    devices = [s.shard_device for s in shards]
+    torch_xla._XLAC._load_local_shards(self.global_tensor, data, devices)
 
   @property
   def sharding_spec(self):


### PR DESCRIPTION
This change enables loading a list of local `XLAShard` on CPU into a sharded tensor's device data. To do this, the function `ShardingUtil::CreateShardedData` is added which transfers a list of local CPU shards to the devices and wraps the resulting handles in PjRtShardedData.

A few notes:
- Only non-replicated sharding is allowed to ensure the underlying shards remain consistent with their sharding (e.g. to prevent passing different tensors as shards to a replicated tensor).
- `PopulateTensorBuffer` is exposed from `tensor_util` for use in `ShardingUtil::CreateShardedData`.
- Each `XLAShard` will now also track which device it originated from.