### PR TITLE
[CI] Do not collect coverage on regular test jobs

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -46,7 +46,7 @@ TORCH_XLA_DIR=$(cd ~; dirname "$(python -c 'import torch_xla; print(torch_xla.__
 COVERAGE_FILE="$CDIR/../.coverage"
 
 function run_coverage {
-  if [ "$USE_COVERAGE" != "0" ]; then
+  if [ "${USE_COVERAGE:-0}" != "0" ]; then
     coverage run --source="$TORCH_XLA_DIR" -p "$@"
   else
     python3 "$@"


### PR DESCRIPTION
By setting `USE_COVERAGE` to `0` if not defined.

This logic/regression was introduced by https://github.com/pytorch/xla/pull/4682 which defines `USE_COVERAGE` here https://github.com/pytorch/xla/blob/9d9e089ba956b62ab0a6ff5d109dd33267ae896e/.circleci/common.sh#L112 But fails to export it, which results in `USE_COVERAGE` being undefined and as result run for regular jobs, as one can observe for example from the following [CPU_test_and_push_doc job](https://app.circleci.com/pipelines/github/pytorch/xla/19235/workflows/35bc2ca6-bbac-45d5-8bd3-4a47d1fdce6f/jobs/47539):

>  + '[' '' '!=' 0 ']'
> + coverage run --source=/opt/conda/lib/python3.8/site-packages/torch_xla-2.1.0-py3.8-linux-x86_64.egg/torch_xla -p /tmp/pytorch/xla/test/test_operations.py --verbosity=2

Please note, that for [CPU_test_coverage job](https://app.circleci.com/pipelines/github/pytorch/xla/19235/workflows/35bc2ca6-bbac-45d5-8bd3-4a47d1fdce6f/jobs/47538) this envvar is properly defined:
> + '[' 1 '!=' 0 ']'
> + coverage run --source=/opt/conda/lib/python3.8/site-packages/torch_xla-2.1.0-py3.8-linux-x86_64.egg/torch_xla -p /tmp/pytorch/xla/test/test_operations.py --verbosity=2

And with the change [CPU_test job](https://app.circleci.com/pipelines/github/pytorch/xla/19242/workflows/a7a095a2-9222-4b72-9f8e-38fc18058fda/jobs/47549) works as expected:
> + '[' 0 '!=' 0 ']'
> + python3 /tmp/pytorch/xla/test/test_operations.py --verbosity=2