### PR TITLE
Change dev images trigger location to us-centeral1

### DIFF
--- a/infra/tpu-pytorch-releases/dev_images.tf
+++ b/infra/tpu-pytorch-releases/dev_images.tf
@@ -65,5 +65,4 @@ module "dev_images" {
   docker_repo_url = module.docker_registry.url
   worker_pool_id  = module.worker_pool.id
   timeout_minutes = 60
-  location        = "global"
 }


### PR DESCRIPTION
Default option is us-centeral1. Git repo is connected only to us-centeral1 region in the GCP pytorch-xla-releases project, not global.