### PR TITLE
Add dev container config for external contributors

### DIFF
--- a/.devcontainer/tpu-contributor/devcontainer.json
+++ b/.devcontainer/tpu-contributor/devcontainer.json
@@ -1,16 +1,12 @@
 {
-  "name": "pytorch_xla",
-  "image": "us-central1-docker.pkg.dev/tpu-pytorch/docker/development:tpu",
+  "name": "tpu-contributor",
+  "image": "us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:tpu",
   "runArgs": [
     "--privileged",
     "--net=host",
     "--shm-size=16G"
   ],
-  "containerEnv": {
-    "BAZEL_REMOTE_CACHE": "1",
-    "SILO_NAME": "cache-silo-${localEnv:USER}-tpuvm"
-  },
-  "initializeCommand": "docker pull us-central1-docker.pkg.dev/tpu-pytorch/docker/development:tpu",
+  "initializeCommand": "docker pull us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:tpu",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/tpu-internal/devcontainer.json
+++ b/.devcontainer/tpu-internal/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "name": "tpu-internal",
+  "image": "us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:tpu",
+  "runArgs": [
+    "--privileged",
+    "--net=host",
+    "--shm-size=16G"
+  ],
+  "containerEnv": {
+    "BAZEL_REMOTE_CACHE": "1",
+    "SILO_NAME": "cache-silo-${localEnv:USER}-tpuvm"
+  },
+  "initializeCommand": "docker pull us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:tpu",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "llvm-vs-code-extensions.vscode-clangd",
+        "ms-vscode.cpptools-themes",
+        "BazelBuild.vscode-bazel",
+        "DevonDCarew.bazel-code",
+        "StackBuild.bazel-stack-vscode",
+        "StackBuild.bazel-stack-vscode-cc",
+        "xaver.clang-format",
+        "ryanluker.vscode-coverage-gutters",
+        "ms-azuretools.vscode-docker",
+        "ms-python.python"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
1. Now when you invoke "Reopen in Container" there will by 2 options: `tpu-internal` and `tpu-contributor`. The second one doesn't use bazel cache.
2. Both dev containers now use the public docker development image.