### PR TITLE
Fix minor issues with GHA workflow

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -15,6 +15,7 @@ on:
         type: string
         description: Runner type for the test
         default: linux.12xlarge
+
     secrets:
       gcloud-service-key:
         required: true
@@ -27,6 +28,7 @@ on:
 jobs:
   build:
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: 60
     outputs:
       docker-image: ${{ steps.upload-docker-image.outputs.docker-image }}
     env:

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   push-docs:
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: 45
     env:
       DOCKER_IMAGE: ${{ inputs.docker-image }}
       WORKDIR: /var/lib/jenkins/workspace
@@ -40,7 +41,7 @@ jobs:
           pid=$(docker run -e GITHUB_TORCH_XLA_BOT_TOKEN -t -d -w "$WORKDIR" "${DOCKER_IMAGE}")
           echo "${GCLOUD_SERVICE_KEY}" | docker exec -i "${pid}" sh -c "cat >> /tmp/pytorch/xla/default_credentials.json"
           echo "pid=${pid}" >> "${GITHUB_ENV}"
-      - name: Test
+      - name: Build & publish docs
         shell: bash
         run: docker exec -u jenkins "${pid}" bash -c '. ~/.bashrc && .circleci/doc_push.sh'
       - name: Teardown Linux

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -11,16 +11,18 @@ on:
         type: string
         description: Runner type for the test
         default: linux.12xlarge
-      build-docs:
-        required: false
-        type: boolean
-        description: Set to true to build docs
-        default: false
       collect-coverage:
         required: false
         type: boolean
         description: Set to true to collect coverage information
         default: false
+      timeout-minutes:
+        required: false
+        type: number
+        default: 270
+        description: |
+          Set the maximum (in minutes) how long the workflow should take to finish
+
     secrets:
       gcloud-service-key:
         required: true
@@ -28,6 +30,7 @@ on:
 jobs:
   test:
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     env:
       DOCKER_IMAGE: ${{ inputs.docker-image }}
       WORKDIR: /var/lib/jenkins/workspace

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,6 +28,7 @@ jobs:
     needs: build
     with:
       docker-image: ${{ needs.build.outputs.docker-image }}
+      timeout-minutes: 90
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
 
@@ -38,35 +39,38 @@ jobs:
     with:
       docker-image: ${{ needs.build.outputs.docker-image }}
       runner: linux.8xlarge.nvidia.gpu
+      timeout-minutes: 180
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
 
   test-cpu-coverage:
     name: "Collect CPU test coverage"
-    if: github.event_name == 'push' && github.event.ref == 'master'
+    if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
     uses: ./.github/workflows/_test.yml
     needs: build
     with:
       docker-image: ${{ needs.build.outputs.docker-image }}
       collect-coverage: true
+      timeout-minutes: 120
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
 
   test-gpu-coverage:
     name: "Collect GPU test coverage"
-    if: github.event_name == 'push' && github.event.ref == 'master'
+    if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
     uses: ./.github/workflows/_test.yml
     needs: build
     with:
       docker-image: ${{ needs.build.outputs.docker-image }}
       runner: linux.8xlarge.nvidia.gpu
+      timeout-minutes: 210
       collect-coverage: true
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
 
   push-docs:
-    name: "Build & ublish docs"
-    if: github.event_name == 'push' && (github.event.ref == 'master' || startsWith(github.event.ref, 'refs/tags/r'))
+    name: "Build & publish docs"
+    if: github.event_name == 'push' && (github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/tags/r'))
     uses: ./.github/workflows/_docs.yml
     needs: build
     with:

--- a/.github/workflows/lintercheck.yml
+++ b/.github/workflows/lintercheck.yml
@@ -21,7 +21,7 @@ jobs:
       - run: pip install yapf==0.30.0
 
       - name: Check no TORCH_PIN
-        if: github.event_name == 'push' && github.event.ref == 'master'
+        if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
         shell: bash
         run: |
           TORCH_PIN=./torch_patches/.torch_pin


### PR DESCRIPTION
First of all, fix dispatch trigger, as `github.event.ref` should contain full branch name prefixed by `refs/heads`
Add `timeout-minutes` parameter to `_test.yml` workflow and pass it from `build_and_test.yml`
Set build workflow timeout to 1 hour
