### PR TITLE
[Functionalization] Remove CreateAsStridedViewInfo

### DIFF
--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -131,6 +131,7 @@
 #include "torch_xla/csrc/ops/view.h"
 #include "torch_xla/csrc/runtime/debug_macros.h"
 #include "torch_xla/csrc/runtime/metrics.h"
+#include "torch_xla/csrc/runtime/sys_util.h"
 #include "torch_xla/csrc/runtime/util.h"
 #include "torch_xla/csrc/runtime/xla_util.h"
 #include "torch_xla/csrc/shape_builder.h"
@@ -731,7 +732,7 @@ XLATensorPtr as_strided(const XLATensorPtr& input, std::vector<int64_t> size,
                         std::vector<int64_t> stride,
                         c10::optional<int64_t> storage_offset) {
   // See Note: [Disabling functionalization]
-  if (xla::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
+  if (runtime::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
     auto input_shape = input->shape();
     return input->CreateViewTensor(CreateAsStridedViewInfo(
         input_shape, std::move(size), std::move(stride), storage_offset));

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -730,6 +730,12 @@ XLATensorPtr argmin(const XLATensorPtr& input) {
 XLATensorPtr as_strided(const XLATensorPtr& input, std::vector<int64_t> size,
                         std::vector<int64_t> stride,
                         c10::optional<int64_t> storage_offset) {
+  // See Note: [Disabling functionalization]
+  if (xla::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
+    auto input_shape = input->shape();
+    return input->CreateViewTensor(CreateAsStridedViewInfo(
+        input_shape, std::move(size), std::move(stride), storage_offset));
+  }
   return input->CreateFrom(torch::lazy::MakeNode<AsStrided>(
       input->GetIrValue(), std::move(size), std::move(stride),
       storage_offset.value_or(0)));

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -730,9 +730,9 @@ XLATensorPtr argmin(const XLATensorPtr& input) {
 XLATensorPtr as_strided(const XLATensorPtr& input, std::vector<int64_t> size,
                         std::vector<int64_t> stride,
                         c10::optional<int64_t> storage_offset) {
-  auto input_shape = input->shape();
-  return input->CreateViewTensor(CreateAsStridedViewInfo(
-      input_shape, std::move(size), std::move(stride), storage_offset));
+  return input->CreateFrom(torch::lazy::MakeNode<AsStrided>(
+          input->GetIrValue(),
+          std::move(size), std::move(stride), storage_offset.value_or(0)));
 }
 
 void as_strided_(XLATensorPtr& input, std::vector<int64_t> size,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -731,8 +731,8 @@ XLATensorPtr as_strided(const XLATensorPtr& input, std::vector<int64_t> size,
                         std::vector<int64_t> stride,
                         c10::optional<int64_t> storage_offset) {
   return input->CreateFrom(torch::lazy::MakeNode<AsStrided>(
-          input->GetIrValue(),
-          std::move(size), std::move(stride), storage_offset.value_or(0)));
+      input->GetIrValue(), std::move(size), std::move(stride),
+      storage_offset.value_or(0)));
 }
 
 void as_strided_(XLATensorPtr& input, std::vector<int64_t> size,


### PR DESCRIPTION
Summary:
This PR removes the usage of CreateAsStridedViewInfo in tensor_methods::as_strided.

Test Plan:
PJRT_DEVICE=CPU python ../test/test_view_ops.py -v -k TestViewOpsXLA.test_as_strided