### PR TITLE
Support output param sharding in dynamo + spmd

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -190,8 +190,7 @@ function run_xla_op_tests {
   run_test "$CDIR/pjrt/test_mesh_service.py"
   run_test "$CDIR/spmd/test_xla_sharding.py"
   run_test "$CDIR/spmd/test_xla_virtual_device.py"
-  # TODO(yeounoh) SPMD output sharding is blocking Dynamo integration.
-  #run_test "$CDIR/spmd/test_dynamo_spmd.py"
+  run_test "$CDIR/spmd/test_dynamo_spmd.py"
   run_test "$CDIR/test_operations_hlo.py" "$@" --verbosity=$VERBOSITY
   run_test "$CDIR/test_input_output_aliases.py"
   run_test "$CDIR/test_torch_distributed_xla_backend.py"

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -650,24 +650,26 @@ XLAGraphExecutor::ExecuteComputationWithBarrier(
   coll.indices.reserve(tensors.size());
   std::unordered_set<int64_t> tensor_ids;
   for (size_t i = 0; i < tensors.size(); ++i) {
-    // std::cout << "[WONJOO] i=" << i << std::endl;
-    // if (tensor_ids.insert(tensors[i]->GetUniqueId()).second &&
-    //     // A tensor's xla_data might not be up to date if there is a view
-    //     // associated with it. Make sure to sync those tensors here too.
-    //     (tensors[i]->CurrentDataHandle() == nullptr ||
-    //      (tensors[i]->data()->view != nullptr &&
-    //       !tensors[i]->data()->view->IsUpToDate()))) {
-    //   torch::lazy::Value ir_value = tensors[i]->CurrentIrValue();
-    //   std::cout << "[WONJOO]   in if 1" << i << std::endl;
-    //   if (ir_value) {
-    //     if (ShouldSyncIrValue(ir_value)) {
-    //       std::cout << "[WONJOO]   in if 2" << i << std::endl;
-    //       // Add only tensors which need to be synced.
-    //       coll.indices.push_back(i);
-    //     }
-    //   }
-    // }
-    coll.indices.push_back(i);
+    std::cout << "[WONJOO] i=" << i << std::endl;
+    if (tensor_ids.insert(tensors[i]->GetUniqueId()).second &&
+        // A tensor's xla_data might not be up to date if there is a view
+        // associated with it. Make sure to sync those tensors here too.
+        (tensors[i]->CurrentDataHandle() == nullptr ||
+         (tensors[i]->data()->view != nullptr &&
+          !tensors[i]->data()->view->IsUpToDate()))) {
+      torch::lazy::Value ir_value = tensors[i]->CurrentIrValue();
+      std::cout << "[WONJOO]   in if 1" << i << std::endl;
+      if (ir_value) {
+        if (ShouldSyncIrValue(ir_value)) {
+          std::cout << "[WONJOO]   in if 2" << i << std::endl;
+          // Add only tensors which need to be synced.
+          coll.indices.push_back(i);
+        }
+      }
+    }
+
+    // is this necessary?
+    // coll.indices.push_back(i);
   }
 
   std::cout << "WONJOO: tensors=" << tensors << std::endl;

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -635,12 +635,14 @@ XLAGraphExecutor::ExecuteComputationWithBarrier(
     }
   }
 
-  // Mimic the `PrepareOutputShardingPropagation` function at xla_sharding_util.cpp.
-  // One subtle difference is that in this path, we don't have explicit `tensors`.
-  // However, we already have `output_shapes` and `device` which were what the `tensors`
-  // were used for in the original `PrepareOutputShardingPropagation` function.
+  // Mimic the `PrepareOutputShardingPropagation` function at
+  // xla_sharding_util.cpp. One subtle difference is that in this path, we don't
+  // have explicit `tensors`. However, we already have `output_shapes` and
+  // `device` which were what the `tensors` were used for in the original
+  // `PrepareOutputShardingPropagation` function.
   std::vector<XLATensor::ShardingSpecPtr> sharding_specs(placeholders.size());
-  auto computation_proto = cachedComputation->computation->computation().proto();
+  auto computation_proto =
+      cachedComputation->computation->computation().proto();
   std::vector<xla::OpSharding> output_shardings;
   if (computation_proto.has_spmd_output_sharding()) {
     if (computation_proto.spmd_output_sharding().tuple_shardings().size() > 0) {
@@ -665,18 +667,16 @@ XLAGraphExecutor::ExecuteComputationWithBarrier(
       // Tensor sharding annotation type is non-zero (sharded).
       sharding_specs[i] = std::make_shared<XLATensor::ShardingSpec>(
           output_shardings[i],
-          MakeShapeWithDeviceLayout(
-              (*output_shapes)[i],
-              static_cast<XlaDeviceType>(device.type())));
+          MakeShapeWithDeviceLayout((*output_shapes)[i],
+                                    static_cast<XlaDeviceType>(device.type())));
     } else {
       // Clear sharding if the output parameter is no longer sharded, this
       // assumes that the output is implicitly replicated and wrapped inside
       // PjRtShardedData.
       sharding_specs[i] = std::make_shared<XLATensor::ShardingSpec>(
           xla::HloSharding::Replicate().ToProto(),
-          MakeShapeWithDeviceLayout(
-              (*output_shapes)[i],
-              static_cast<XlaDeviceType>(device.type())));
+          MakeShapeWithDeviceLayout((*output_shapes)[i],
+                                    static_cast<XlaDeviceType>(device.type())));
     }
 
     // Create sharded data placeholder, this will be used to
@@ -684,8 +684,7 @@ XLAGraphExecutor::ExecuteComputationWithBarrier(
     // replication.
     auto sharded_data_placeholder =
         WrapXlaData(xla::GetComputationClient()->WrapDataShards(
-            {}, GetVirtualDevice().toString(),
-            sharding_specs[i]->shape.value(),
+            {}, GetVirtualDevice().toString(), sharding_specs[i]->shape.value(),
             sharding_specs[i]->sharding));
 
     // Register the sharded data placeholder to the tensor and its node.

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -717,7 +717,7 @@ XLAGraphExecutor::ExecuteComputationWithBarrier(
                     *async->cached_computation->computation
                          ->client_computation(),
                     device_arguments, devices, execute_options),
-                sharding_specs, /*replicated_output=*/false);
+                sharding_specs);
         results = WrapXlaData(outputs);
         TF_VLOG(3) << "Executing Dynamo IR sharded graph hash "
                    << torch::lazy::HashToString(hash) << " on devices "

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -641,54 +641,62 @@ XLAGraphExecutor::ExecuteComputationWithBarrier(
   // `device` which were what the `tensors` were used for in the original
   // `PrepareOutputShardingPropagation` function.
   std::vector<XLATensor::ShardingSpecPtr> sharding_specs(placeholders.size());
-  auto computation_proto =
-      cachedComputation->computation->computation().proto();
-  std::vector<xla::OpSharding> output_shardings;
-  if (computation_proto.has_spmd_output_sharding()) {
-    if (computation_proto.spmd_output_sharding().tuple_shardings().size() > 0) {
-      auto tuple_shardings =
-          computation_proto.spmd_output_sharding().tuple_shardings();
-      output_shardings = std::vector<xla::OpSharding>(tuple_shardings.begin(),
-                                                      tuple_shardings.end());
-    } else {
-      output_shardings = std::vector<xla::OpSharding>{
-          computation_proto.spmd_output_sharding()};
-    }
-  }
-
-  // Output parameter sharding annotations, defaults to REPLICATED(0) if unset.
-  if (output_shardings.empty()) {
-    // Initializes with default sharding type, REPLCIATED.
-    output_shardings.resize(placeholders.size());
-  }
-
-  for (int i = 0; i < placeholders.size(); ++i) {
-    if (output_shardings[i].type()) {
-      // Tensor sharding annotation type is non-zero (sharded).
-      sharding_specs[i] = std::make_shared<XLATensor::ShardingSpec>(
-          output_shardings[i],
-          MakeShapeWithDeviceLayout((*output_shapes)[i],
-                                    static_cast<XlaDeviceType>(device.type())));
-    } else {
-      // Clear sharding if the output parameter is no longer sharded, this
-      // assumes that the output is implicitly replicated and wrapped inside
-      // PjRtShardedData.
-      sharding_specs[i] = std::make_shared<XLATensor::ShardingSpec>(
-          xla::HloSharding::Replicate().ToProto(),
-          MakeShapeWithDeviceLayout((*output_shapes)[i],
-                                    static_cast<XlaDeviceType>(device.type())));
+  if (ShardingUtil::UseVirtualDevice()) {
+    // std::vector<XLATensor::ShardingSpecPtr>
+    // sharding_specs(placeholders.size());
+    auto computation_proto =
+        cachedComputation->computation->computation().proto();
+    std::vector<xla::OpSharding> output_shardings;
+    if (computation_proto.has_spmd_output_sharding()) {
+      if (computation_proto.spmd_output_sharding().tuple_shardings().size() >
+          0) {
+        auto tuple_shardings =
+            computation_proto.spmd_output_sharding().tuple_shardings();
+        output_shardings = std::vector<xla::OpSharding>(tuple_shardings.begin(),
+                                                        tuple_shardings.end());
+      } else {
+        output_shardings = std::vector<xla::OpSharding>{
+            computation_proto.spmd_output_sharding()};
+      }
     }
 
-    // Create sharded data placeholder, this will be used to
-    // hold the corresponding computation results for both sharding &
-    // replication.
-    auto sharded_data_placeholder =
-        WrapXlaData(xla::GetComputationClient()->WrapDataShards(
-            {}, GetVirtualDevice().toString(), sharding_specs[i]->shape.value(),
-            sharding_specs[i]->sharding));
+    // Output parameter sharding annotations, defaults to REPLICATED(0) if
+    // unset.
+    if (output_shardings.empty()) {
+      // Initializes with default sharding type, REPLCIATED.
+      output_shardings.resize(placeholders.size());
+    }
 
-    // Register the sharded data placeholder to the tensor and its node.
-    placeholders[i] = sharded_data_placeholder;
+    for (int i = 0; i < placeholders.size(); ++i) {
+      if (output_shardings[i].type()) {
+        // Tensor sharding annotation type is non-zero (sharded).
+        sharding_specs[i] = std::make_shared<XLATensor::ShardingSpec>(
+            output_shardings[i],
+            MakeShapeWithDeviceLayout(
+                (*output_shapes)[i],
+                static_cast<XlaDeviceType>(device.type())));
+      } else {
+        // Clear sharding if the output parameter is no longer sharded, this
+        // assumes that the output is implicitly replicated and wrapped inside
+        // PjRtShardedData.
+        sharding_specs[i] = std::make_shared<XLATensor::ShardingSpec>(
+            xla::HloSharding::Replicate().ToProto(),
+            MakeShapeWithDeviceLayout(
+                (*output_shapes)[i],
+                static_cast<XlaDeviceType>(device.type())));
+      }
+
+      // Create sharded data placeholder, this will be used to
+      // hold the corresponding computation results for both sharding &
+      // replication.
+      auto sharded_data_placeholder =
+          WrapXlaData(xla::GetComputationClient()->WrapDataShards(
+              {}, GetVirtualDevice().toString(),
+              sharding_specs[i]->shape.value(), sharding_specs[i]->sharding));
+
+      // Register the sharded data placeholder to the tensor and its node.
+      placeholders[i] = sharded_data_placeholder;
+    }
   }
 
   std::shared_ptr<XLAGraphExecutor::Async> async = std::make_shared<Async>(

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -642,8 +642,6 @@ XLAGraphExecutor::ExecuteComputationWithBarrier(
   // `PrepareOutputShardingPropagation` function.
   std::vector<XLATensor::ShardingSpecPtr> sharding_specs(placeholders.size());
   if (ShardingUtil::UseVirtualDevice()) {
-    // std::vector<XLATensor::ShardingSpecPtr>
-    // sharding_specs(placeholders.size());
     auto computation_proto =
         cachedComputation->computation->computation().proto();
     std::vector<xla::OpSharding> output_shardings;

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -635,66 +635,11 @@ XLAGraphExecutor::ExecuteComputationWithBarrier(
     }
   }
 
-  // Mimic the `PrepareOutputShardingPropagation` function at
-  // xla_sharding_util.cpp. One subtle difference is that in this path, we don't
-  // have explicit `tensors`. However, we already have `output_shapes` and
-  // `device` which were what the `tensors` were used for in the original
-  // `PrepareOutputShardingPropagation` function.
   std::vector<XLATensor::ShardingSpecPtr> sharding_specs(placeholders.size());
   if (ShardingUtil::UseVirtualDevice()) {
-    auto computation_proto =
-        cachedComputation->computation->computation().proto();
-    std::vector<xla::OpSharding> output_shardings;
-    if (computation_proto.has_spmd_output_sharding()) {
-      if (computation_proto.spmd_output_sharding().tuple_shardings().size() >
-          0) {
-        auto tuple_shardings =
-            computation_proto.spmd_output_sharding().tuple_shardings();
-        output_shardings = std::vector<xla::OpSharding>(tuple_shardings.begin(),
-                                                        tuple_shardings.end());
-      } else {
-        output_shardings = std::vector<xla::OpSharding>{
-            computation_proto.spmd_output_sharding()};
-      }
-    }
-
-    // Output parameter sharding annotations, defaults to REPLICATED(0) if
-    // unset.
-    if (output_shardings.empty()) {
-      // Initializes with default sharding type, REPLCIATED.
-      output_shardings.resize(placeholders.size());
-    }
-
-    for (int i = 0; i < placeholders.size(); ++i) {
-      if (output_shardings[i].type()) {
-        // Tensor sharding annotation type is non-zero (sharded).
-        sharding_specs[i] = std::make_shared<XLATensor::ShardingSpec>(
-            output_shardings[i],
-            MakeShapeWithDeviceLayout(
-                (*output_shapes)[i],
-                static_cast<XlaDeviceType>(device.type())));
-      } else {
-        // Clear sharding if the output parameter is no longer sharded, this
-        // assumes that the output is implicitly replicated and wrapped inside
-        // PjRtShardedData.
-        sharding_specs[i] = std::make_shared<XLATensor::ShardingSpec>(
-            xla::HloSharding::Replicate().ToProto(),
-            MakeShapeWithDeviceLayout(
-                (*output_shapes)[i],
-                static_cast<XlaDeviceType>(device.type())));
-      }
-
-      // Create sharded data placeholder, this will be used to
-      // hold the corresponding computation results for both sharding &
-      // replication.
-      auto sharded_data_placeholder =
-          WrapXlaData(xla::GetComputationClient()->WrapDataShards(
-              {}, GetVirtualDevice().toString(),
-              sharding_specs[i]->shape.value(), sharding_specs[i]->sharding));
-
-      // Register the sharded data placeholder to the tensor and its node.
-      placeholders[i] = sharded_data_placeholder;
-    }
+    ShardingUtil::PrepareOutputShardingPropagation(
+        placeholders, sharding_specs, output_shapes,
+        cachedComputation->computation, device);
   }
 
   std::shared_ptr<XLAGraphExecutor::Async> async = std::make_shared<Async>(

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -621,7 +621,7 @@ void ShardingUtil::PrepareOutputShardingPropagation(
     // hold the corresponding computation results for both sharding &
     // replication.
     auto sharded_data_placeholder =
-        WrapXlaData(xla::GetComputationClient()->WrapDataShards(
+        WrapXlaData(runtime::GetComputationClient()->WrapDataShards(
             {}, GetVirtualDevice().toString(), sharding_specs[i]->shape.value(),
             sharding_specs[i]->sharding));
 

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -574,6 +574,62 @@ void ShardingUtil::PrepareOutputShardingPropagation(
   }
 }
 
+void ShardingUtil::PrepareOutputShardingPropagation(
+    std::vector<torch::lazy::BackendDataPtr>& placeholders,
+    std::vector<XLATensor::ShardingSpecPtr>& sharding_specs,
+    std::vector<xla::Shape>* output_shapes, ComputationPtr computation,
+    const torch::lazy::BackendDevice& device) {
+  auto computation_proto = computation->computation().proto();
+  std::vector<xla::OpSharding> output_shardings;
+  if (computation_proto.has_spmd_output_sharding()) {
+    if (computation_proto.spmd_output_sharding().tuple_shardings().size() > 0) {
+      auto tuple_shardings =
+          computation_proto.spmd_output_sharding().tuple_shardings();
+      output_shardings = std::vector<xla::OpSharding>(tuple_shardings.begin(),
+                                                      tuple_shardings.end());
+    } else {
+      output_shardings = std::vector<xla::OpSharding>{
+          computation_proto.spmd_output_sharding()};
+    }
+  }
+
+  // Output parameter sharding annotations, defaults to REPLICATED(0) if
+  // unset.
+  if (output_shardings.empty()) {
+    // Initializes with default sharding type, REPLCIATED.
+    output_shardings.resize(placeholders.size());
+  }
+
+  for (int i = 0; i < placeholders.size(); ++i) {
+    if (output_shardings[i].type()) {
+      // Tensor sharding annotation type is non-zero (sharded).
+      sharding_specs[i] = std::make_shared<XLATensor::ShardingSpec>(
+          output_shardings[i],
+          MakeShapeWithDeviceLayout((*output_shapes)[i],
+                                    static_cast<XlaDeviceType>(device.type())));
+    } else {
+      // Clear sharding if the output parameter is no longer sharded, this
+      // assumes that the output is implicitly replicated and wrapped inside
+      // PjRtShardedData.
+      sharding_specs[i] = std::make_shared<XLATensor::ShardingSpec>(
+          xla::HloSharding::Replicate().ToProto(),
+          MakeShapeWithDeviceLayout((*output_shapes)[i],
+                                    static_cast<XlaDeviceType>(device.type())));
+    }
+
+    // Create sharded data placeholder, this will be used to
+    // hold the corresponding computation results for both sharding &
+    // replication.
+    auto sharded_data_placeholder =
+        WrapXlaData(xla::GetComputationClient()->WrapDataShards(
+            {}, GetVirtualDevice().toString(), sharding_specs[i]->shape.value(),
+            sharding_specs[i]->sharding));
+
+    // Register the sharded data placeholder to the tensor and its node.
+    placeholders[i] = sharded_data_placeholder;
+  }
+}
+
 runtime::ComputationClient::DataPtr ShardingUtil::CreateShardedData(
     std::vector<at::Tensor>& local_shards, std::vector<std::string>& devices,
     xla::Shape global_shape, xla::OpSharding sharding) {

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -124,6 +124,17 @@ class ShardingUtil {
       std::vector<torch::lazy::BackendDataPtr>* data_placeholders,
       std::vector<XLATensor::ShardingSpecPtr>* sharding_specs);
 
+    // Mimic the function above, but for dynamo code path. 
+    // One subtle difference is that in dynamo code path, we don't
+    // have explicit `tensors`. However, we have `output_shapes` and
+    // `device` which were what the `tensors` were used for in the original
+    // `PrepareOutputShardingPropagation` function.
+  static void PrepareOutputShardingPropagation(
+      std::vector<torch::lazy::BackendDataPtr>& placeholders,
+      std::vector<XLATensor::ShardingSpecPtr>& sharding_specs,
+      std::vector<xla::Shape>* output_shapes, ComputationPtr cachedComputation,
+      const torch::lazy::BackendDevice& device);
+
   // Transfers the individual shards to the devices and returns a DataPtr for
   // the PjRtShardedData wrapping the shards.
   static runtime::ComputationClient::DataPtr CreateShardedData(


### PR DESCRIPTION
Attempts to fix the dynamo + spmd that was broken by the recent output param sharding (https://github.com/pytorch/xla/pull/5018)

Idea is to prepare the output sharding propagation (i.e., call the `PrepareOutputShardingPropagation` https://github.com/pytorch/xla/blob/master/torch_xla/csrc/xla_sharding_util.h#L105) in the dynamo bridge in the `ExecuteComputationWithBarrier` function, similar to what's happening at https://github.com/pytorch/xla/blame/master/torch_xla/csrc/xla_graph_executor.cpp#L1068. 

A comment in the code pasted here for more info:
```
  // Mimic the `PrepareOutputShardingPropagation` function at
  // xla_sharding_util.cpp. One subtle difference is that in this path, we don't
  // have explicit `tensors`. However, we already have `output_shapes` and
  // `device` which were what the `tensors` were used for in the original
  // `PrepareOutputShardingPropagation` function.
```

---

Test plan: `PJRT_DEVICE=TPU python test/spmd/test_dynamo_spmd.py` and CI