### PR TITLE
Revert "Disable cmake macros"

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -8,7 +8,6 @@ tf_cc_shared_object(
     copts = [
         "-DTORCH_API_INCLUDE_EXTENSION_H",
         "-DTORCH_EXTENSION_NAME=_XLAC",
-        "-DC10_USING_CUSTOM_GENERATED_MACROS",
         "-fopenmp",
         "-fPIC",
         "-fwrapv",


### PR DESCRIPTION
Reverts pytorch/xla#5021 as it does not solve the underlying problem (of headers not being installed in `torch/include`)

As one can see in https://github.com/pytorch/pytorch/pull/102446 XLA can be built without this change