### PR TITLE
Checkout Ansible setup at origin's master, not local, untracked master.

### DIFF
--- a/infra/terraform_modules/xla_docker_build/variables.tf
+++ b/infra/terraform_modules/xla_docker_build/variables.tf
@@ -21,6 +21,7 @@ variable "description" {
 
 variable "ansible_git_rev" {
   # Checkout Ansible setup (/infra/ansible) at current Cloud Build commit.
+  # Use `origin/<branch>` for branches.
   default = "$COMMIT_SHA"
 }
 

--- a/infra/tpu-pytorch-releases/artifacts_builds.tf
+++ b/infra/tpu-pytorch-releases/artifacts_builds.tf
@@ -106,7 +106,7 @@ module "versioned_builds" {
 
   # Use Ansible setup from master branch for versioned release, because source
   # code at older version doesn't contain Ansible setup.
-  ansible_git_rev = "master"
+  ansible_git_rev = "origin/master"
   trigger_on_push = { tag = each.value.git_tag }
 
   trigger_name = replace(each.key, "/[_.]/", "-")


### PR DESCRIPTION
This will ensure that older versioned builds get the newest Ansible setup version.