### PR TITLE
[CI] Pass CXX_ABI to cpp tests

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -114,6 +114,7 @@ function run_torch_xla_tests() {
     export GPU_NUM_DEVICES=2
   fi
   export PYTORCH_TESTING_DEVICE_ONLY_FOR="xla"
+  export CXX_ABI=$(python -c "import torch;print(int(torch._C._GLIBCXX_USE_CXX11_ABI))")
 
   pushd $XLA_DIR
     echo "Running Python Tests"

--- a/setup.py
+++ b/setup.py
@@ -208,7 +208,7 @@ extra_compile_args = []
 cxx_abi = os.getenv(
     'CXX_ABI', default='') or getattr(torch._C, '_GLIBCXX_USE_CXX11_ABI', None)
 if cxx_abi is not None:
-  extra_compile_args += ['-D_GLIBCXX_USE_CXX11_ABI={}'.format(int(cxx_abi))]
+  extra_compile_args.append(f'-D_GLIBCXX_USE_CXX11_ABI={int(cxx_abi)}')
 
 
 class BazelExtension(Extension):

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -56,7 +56,12 @@ if [[ "$TPUVM_MODE" == "1" ]]; then
   EXTRA_FLAGS="$EXTRA_FLAGS --config=tpu"
 fi
 
-# Handle remote builds and remote cache. Use a CI-private cache silo to avoid cachce polution.
+# Match CXX_ABI flags with XLAC.so build
+if [[ -n "${CXX_ABI}" ]]; then
+  EXTRA_FLAGS="${EXTRA_FLAGS} -cxxopt=-D_GLIBCXX_USE_CXX11_ABI=${CXX_ABI}"
+fi
+
+# Handle remote builds and remote cache. Use a CI-private cache silo to avoid cache pollution.
 if [[ "$BAZEL_REMOTE_CACHE" == "1" ]]; then
   EXTRA_FLAGS="$EXTRA_FLAGS --config=remote_cache"
   if [[ ! -z "$GCLOUD_SERVICE_KEY_FILE" ]]; then

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -58,7 +58,7 @@ fi
 
 # Match CXX_ABI flags with XLAC.so build
 if [[ -n "${CXX_ABI}" ]]; then
-  EXTRA_FLAGS="${EXTRA_FLAGS} -cxxopt=-D_GLIBCXX_USE_CXX11_ABI=${CXX_ABI}"
+  EXTRA_FLAGS="${EXTRA_FLAGS} --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=${CXX_ABI}"
 fi
 
 # Handle remote builds and remote cache. Use a CI-private cache silo to avoid cache pollution.


### PR DESCRIPTION
This should allow bazel to reuse majority of the build artifacts between
XLAC.so and cpp tests builds. Otherwise, different `cxx_opts` options
forces build system to start everything anew.
