### PR TITLE
Add StableHLO Dump Python API

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -78,6 +78,7 @@ jobs:
           echo "declare -x CC=clang-8 CXX=clang++-8" | docker exec -i "${pid}" sh -c "cat >> xla_env"
           echo "declare -x XLA_USE_XRT=1" | docker exec -i "${pid}" sh -c "cat >> xla_env"
           echo "declare -x XLA_CUDA=1" | docker exec -i "${pid}" sh -c "cat >> xla_env"
+          echo "declare -x BAZEL_REMOTE_CACHE=1" | docker exec -i "${pid}" sh -c "cat >> xla_env"
           echo "${GCLOUD_SERVICE_KEY}" | docker exec -i "${pid}" sh -c "cat >> default_credentials.json"
 
       - name: Build

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -78,7 +78,6 @@ jobs:
           echo "declare -x CC=clang-8 CXX=clang++-8" | docker exec -i "${pid}" sh -c "cat >> xla_env"
           echo "declare -x XLA_USE_XRT=1" | docker exec -i "${pid}" sh -c "cat >> xla_env"
           echo "declare -x XLA_CUDA=1" | docker exec -i "${pid}" sh -c "cat >> xla_env"
-          echo "declare -x BAZEL_REMOTE_CACHE=1" | docker exec -i "${pid}" sh -c "cat >> xla_env"
           echo "${GCLOUD_SERVICE_KEY}" | docker exec -i "${pid}" sh -c "cat >> default_credentials.json"
 
       - name: Build

--- a/test/test_stablehlo_dump.py
+++ b/test/test_stablehlo_dump.py
@@ -1,7 +1,6 @@
 import torch_xla
 import torch_xla.core.xla_model as xm
 import torch
-
 '''
 The following MLIR module should be dump in this test
 module @IrToHlo.9 attributes {mhlo.cross_program_prefetches = [], mhlo.dynamic_parameter_bindings = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {

--- a/test/test_stablehlo_dump.py
+++ b/test/test_stablehlo_dump.py
@@ -1,0 +1,28 @@
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch
+
+'''
+The following MLIR module should be dump in this test
+module @IrToHlo.9 attributes {mhlo.cross_program_prefetches = [], mhlo.dynamic_parameter_bindings = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<1xi64>, %arg1: tensor<1xi64>) -> tuple<tensor<1xi64>, tensor<1xi64>, tensor<1xi64>> {
+    %0 = stablehlo.constant dense<1> : tensor<i64>
+    %1 = stablehlo.constant dense<1> : tensor<1xi64>
+    %2 = stablehlo.multiply %arg1, %1 : tensor<1xi64>
+    %3 = stablehlo.add %arg0, %2 : tensor<1xi64>
+    %4 = stablehlo.tuple %arg0, %arg1, %3 {xla_shape = "(s64[1]{0}, s64[1]{0}, s64[1]{0})"} : tuple<tensor<1xi64>, tensor<1xi64>, tensor<1xi64>>
+    return %4 : tuple<tensor<1xi64>, tensor<1xi64>, tensor<1xi64>>
+  }
+}
+'''
+
+x = torch.tensor([3], device=xm.xla_device())
+y = torch.tensor([3], device=xm.xla_device())
+z = x + y
+
+# Example usage of dumping StableHLO given output tensors
+stablehlo = xm.get_xla_tensors_stablehlostep([z])
+print(stablehlo)
+# Example usage of dump StableHLO of the entire graph
+stablehlo = xm.xla_get_stablehlo()
+print(stablehlo)

--- a/test/test_stablehlo_dump.py
+++ b/test/test_stablehlo_dump.py
@@ -26,7 +26,6 @@ class StableHloDumpTest(unittest.TestCase):
     output = xla_resnet18(data)
     stablehlo = xm.get_stablehlo()
     self.assertEqual(stablehlo.count("convolution"), 20)
-    print(stablehlo)
 
 
 if __name__ == '__main__':

--- a/test/test_stablehlo_dump.py
+++ b/test/test_stablehlo_dump.py
@@ -25,7 +25,9 @@ class StableHloDumpTest(unittest.TestCase):
     data = torch.randn(4, 3, 224, 224, device=device)
     output = xla_resnet18(data)
     stablehlo = xm.get_stablehlo([output])
-    self.assertEqual(stablehlo.count("convolution"), 20)
+    self.assertEqual(stablehlo.count("stablehlo.convolution"), 20)
+    stablehlo = xm.get_stablehlo()
+    self.assertEqual(stablehlo.count("stablehlo.convolution"), 20)
 
 
 if __name__ == '__main__':

--- a/test/test_stablehlo_dump.py
+++ b/test/test_stablehlo_dump.py
@@ -24,7 +24,7 @@ class StableHloDumpTest(unittest.TestCase):
     xla_resnet18 = xla_resnet18.to(device)
     data = torch.randn(4, 3, 224, 224, device=device)
     output = xla_resnet18(data)
-    stablehlo = xm.get_stablehlo()
+    stablehlo = xm.get_stablehlo([output])
     self.assertEqual(stablehlo.count("convolution"), 20)
 
 

--- a/test/test_stablehlo_dump.py
+++ b/test/test_stablehlo_dump.py
@@ -20,8 +20,8 @@ y = torch.tensor([3], device=xm.xla_device())
 z = x + y
 
 # Example usage of dumping StableHLO given output tensors
-stablehlo = xm.get_xla_tensors_stablehlostep([z])
-print(stablehlo)
+stablehlo = xm.xla_get_stablehlo([z])
+# print(stablehlo)
 # Example usage of dump StableHLO of the entire graph
 stablehlo = xm.xla_get_stablehlo()
-print(stablehlo)
+# print(stablehlo)

--- a/test/test_stablehlo_dump.py
+++ b/test/test_stablehlo_dump.py
@@ -20,8 +20,8 @@ y = torch.tensor([3], device=xm.xla_device())
 z = x + y
 
 # Example usage of dumping StableHLO given output tensors
-stablehlo = xm.xla_get_stablehlo([z])
+stablehlo = xm.get_stablehlo([z])
 # print(stablehlo)
 # Example usage of dump StableHLO of the entire graph
-stablehlo = xm.xla_get_stablehlo()
+stablehlo = xm.get_stablehlo()
 # print(stablehlo)

--- a/third_party/xla_client/BUILD
+++ b/third_party/xla_client/BUILD
@@ -347,6 +347,19 @@ cc_library(
 )
 
 cc_library(
+    name = "stablehlo_helper",
+    srcs = ["stablehlo_helper.cc"],
+    hdrs = ["stablehlo_helper.h"],
+    deps = [
+        ":types",
+        ":xla_util",
+        "@org_tensorflow//tensorflow/compiler/xla/translate/hlo_to_mhlo:hlo_to_mlir_hlo",
+        "@org_tensorflow//tensorflow/compiler/xla/translate/mhlo_to_hlo:mlir_hlo_to_hlo",
+        "@org_tensorflow//tensorflow/compiler/xla/mlir_hlo:all_passes",
+    ],
+)
+
+cc_library(
     name = "sys_util",
     srcs = ["sys_util.cc"],
     hdrs = ["sys_util.h"],

--- a/third_party/xla_client/stablehlo_helper.cc
+++ b/third_party/xla_client/stablehlo_helper.cc
@@ -25,39 +25,47 @@ static std::string getMlirModuleStr(mlir::ModuleOp& mlir_module) {
 }
 
 static absl::Status hloToMhloHelper(const HloModuleProto* proto,
-                            mlir::ModuleOp* mlir_module) {
+                                    mlir::ModuleOp* mlir_module) {
   auto status = ConvertHloToMlirHlo(*mlir_module, proto,
                                     /*import_all_computations=*/false);
   if (!status.ok()) {
     return status;
   }
   if (!mlir::verify(*mlir_module).succeeded()) {
-    return absl::Status(absl::StatusCode::kInternal, "MHLO Module from HLO -> MHLO conversion is not legal.");
+    return absl::Status(
+        absl::StatusCode::kInternal,
+        "MHLO Module from HLO -> MHLO conversion is not legal.");
   }
   return absl::OkStatus();
 }
 
 static absl::Status mhloToStablehloHelper(mlir::ModuleOp* mlir_module,
-                                  mlir::MLIRContext* context) {
+                                          mlir::MLIRContext* context) {
   mlir::PassManager pm(context);
   pm.addPass(mlir::mhlo::createHloLegalizeToStablehloPass());
   if (!mlir::succeeded(pm.run(*mlir_module))) {
-    return absl::Status(absl::StatusCode::kInternal, "StableHLO Module from MHLO -> StableHLO conversion is not leagal.");
+    return absl::Status(
+        absl::StatusCode::kInternal,
+        "StableHLO Module from MHLO -> StableHLO conversion is not leagal.");
   }
-  return absl::OkStatus();;
+  return absl::OkStatus();
+  ;
 }
 
 std::string hloToStablehloStr(const HloModuleProto* proto) {
   mlir::MLIRContext context;
   mlir::ModuleOp mlir_module =
       mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
-  static const std::string err_msg = "Please open a github issue to PyTorch/XLA.\nOriginal HLO dump:\n";
+  static const std::string err_msg =
+      "Please open a github issue to PyTorch/XLA.\nOriginal HLO dump:\n";
   auto status = hloToMhloHelper(proto, &mlir_module);
-  XLA_CHECK(status.ok()) <<
-    "HLO -> MHLO conversion failed.\n" << status.message() << err_msg << getHloModuleStr(proto);
+  XLA_CHECK(status.ok()) << "HLO -> MHLO conversion failed.\n"
+                         << status.message() << err_msg
+                         << getHloModuleStr(proto);
   status = mhloToStablehloHelper(&mlir_module, &context);
-  XLA_CHECK(status.ok()) <<
-    "MHLO -> StableHLO conversion failed.\n" << status.message() << err_msg << getHloModuleStr(proto);
+  XLA_CHECK(status.ok()) << "MHLO -> StableHLO conversion failed.\n"
+                         << status.message() << err_msg
+                         << getHloModuleStr(proto);
   return getMlirModuleStr(mlir_module);
 }
 

--- a/third_party/xla_client/stablehlo_helper.cc
+++ b/third_party/xla_client/stablehlo_helper.cc
@@ -1,0 +1,44 @@
+#include "third_party/xla_client/stablehlo_helper.h"
+
+#include <iostream>
+
+#include "mlir/IR/Verifier.h"       // from @llvm-project
+#include "mlir/Pass/PassManager.h"  // from @llvm-project
+#include "tensorflow/compiler/xla/mlir_hlo/mhlo/transforms/passes.h"
+#include "tensorflow/compiler/xla/translate/hlo_to_mhlo/hlo_to_mlir_hlo.h"
+#include "tensorflow/compiler/xla/translate/mhlo_to_hlo/mlir_hlo_to_hlo.h"
+#include "third_party/xla_client/debug_macros.h"
+#include "third_party/xla_client/xla_util.h"
+
+namespace xla {
+
+static void hlo_mhlo_helper(const HloModuleProto* proto,
+                            mlir::ModuleOp* mlir_module) {
+  auto status = ConvertHloToMlirHlo(*mlir_module, proto,
+                                    /*import_all_computations*/ false);
+  XLA_CHECK(status.ok()) << "error in HLO -> MHLO conversion.";
+  XLA_CHECK(mlir::verify(*mlir_module).succeeded())
+      << "mhlo from hlo2mhlo verify not ok.";
+}
+
+static void mhlo_stablehlo_helper(mlir::ModuleOp* mlir_module,
+                                  mlir::MLIRContext* context) {
+  mlir::PassManager pm(context);
+  pm.addPass(mlir::mhlo::createHloLegalizeToStablehloPass());
+  XLA_CHECK(mlir::succeeded(pm.run(*mlir_module)))
+      << "mhlo to stablehlo not ok";
+}
+
+std::string hlo_to_stablehlo_str(const HloModuleProto* proto) {
+  mlir::MLIRContext context;
+  mlir::ModuleOp mlir_module =
+      mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+  hlo_mhlo_helper(proto, &mlir_module);
+  mhlo_stablehlo_helper(&mlir_module, &context);
+  std::string txt_mlir_module;
+  llvm::raw_string_ostream os{txt_mlir_module};
+  mlir_module.print(os);
+  return txt_mlir_module;
+}
+
+}  // namespace xla

--- a/third_party/xla_client/stablehlo_helper.cc
+++ b/third_party/xla_client/stablehlo_helper.cc
@@ -12,33 +12,53 @@
 
 namespace xla {
 
-static void hlo_mhlo_helper(const HloModuleProto* proto,
-                            mlir::ModuleOp* mlir_module) {
-  auto status = ConvertHloToMlirHlo(*mlir_module, proto,
-                                    /*import_all_computations*/ false);
-  XLA_CHECK(status.ok()) << "HLO -> MHLO conversion failed.";
-  XLA_CHECK(mlir::verify(*mlir_module).succeeded())
-      << "MHLO from HLO->MHLO is not leagal.";
+static std::string getHloModuleStr(const HloModuleProto* proto) {
+  auto hlo_module = xla::util::CreateModuleFromProto(*proto);
+  return hlo_module.value()->ToString();
 }
 
-static void mhlo_stablehlo_helper(mlir::ModuleOp* mlir_module,
-                                  mlir::MLIRContext* context) {
-  mlir::PassManager pm(context);
-  pm.addPass(mlir::mhlo::createHloLegalizeToStablehloPass());
-  XLA_CHECK(mlir::succeeded(pm.run(*mlir_module)))
-      << "MHLO -> StableHLO conversion failed.";
-}
-
-std::string hlo_to_stablehlo_str(const HloModuleProto* proto) {
-  mlir::MLIRContext context;
-  mlir::ModuleOp mlir_module =
-      mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
-  hlo_mhlo_helper(proto, &mlir_module);
-  mhlo_stablehlo_helper(&mlir_module, &context);
+static std::string getMlirModuleStr(mlir::ModuleOp& mlir_module) {
   std::string txt_mlir_module;
   llvm::raw_string_ostream os{txt_mlir_module};
   mlir_module.print(os);
   return txt_mlir_module;
+}
+
+static absl::Status hloToMhloHelper(const HloModuleProto* proto,
+                            mlir::ModuleOp* mlir_module) {
+  auto status = ConvertHloToMlirHlo(*mlir_module, proto,
+                                    /*import_all_computations=*/false);
+  if (!status.ok()) {
+    return status;
+  }
+  if (!mlir::verify(*mlir_module).succeeded()) {
+    return absl::Status(absl::StatusCode::kInternal, "MHLO Module from HLO -> MHLO conversion is not legal.");
+  }
+  return absl::OkStatus();
+}
+
+static absl::Status mhloToStablehloHelper(mlir::ModuleOp* mlir_module,
+                                  mlir::MLIRContext* context) {
+  mlir::PassManager pm(context);
+  pm.addPass(mlir::mhlo::createHloLegalizeToStablehloPass());
+  if (!mlir::succeeded(pm.run(*mlir_module))) {
+    return absl::Status(absl::StatusCode::kInternal, "StableHLO Module from MHLO -> StableHLO conversion is not leagal.");
+  }
+  return absl::OkStatus();;
+}
+
+std::string hloToStablehloStr(const HloModuleProto* proto) {
+  mlir::MLIRContext context;
+  mlir::ModuleOp mlir_module =
+      mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+  static const std::string err_msg = "Please open a github issue to PyTorch/XLA.\nOriginal HLO dump:\n";
+  auto status = hloToMhloHelper(proto, &mlir_module);
+  XLA_CHECK(status.ok()) <<
+    "HLO -> MHLO conversion failed.\n" << status.message() << err_msg << getHloModuleStr(proto);
+  status = mhloToStablehloHelper(&mlir_module, &context);
+  XLA_CHECK(status.ok()) <<
+    "MHLO -> StableHLO conversion failed.\n" << status.message() << err_msg << getHloModuleStr(proto);
+  return getMlirModuleStr(mlir_module);
 }
 
 }  // namespace xla

--- a/third_party/xla_client/stablehlo_helper.cc
+++ b/third_party/xla_client/stablehlo_helper.cc
@@ -16,9 +16,9 @@ static void hlo_mhlo_helper(const HloModuleProto* proto,
                             mlir::ModuleOp* mlir_module) {
   auto status = ConvertHloToMlirHlo(*mlir_module, proto,
                                     /*import_all_computations*/ false);
-  XLA_CHECK(status.ok()) << "error in HLO -> MHLO conversion.";
+  XLA_CHECK(status.ok()) << "HLO -> MHLO conversion failed.";
   XLA_CHECK(mlir::verify(*mlir_module).succeeded())
-      << "mhlo from hlo2mhlo verify not ok.";
+      << "MHLO from HLO->MHLO is not leagal.";
 }
 
 static void mhlo_stablehlo_helper(mlir::ModuleOp* mlir_module,
@@ -26,7 +26,7 @@ static void mhlo_stablehlo_helper(mlir::ModuleOp* mlir_module,
   mlir::PassManager pm(context);
   pm.addPass(mlir::mhlo::createHloLegalizeToStablehloPass());
   XLA_CHECK(mlir::succeeded(pm.run(*mlir_module)))
-      << "mhlo to stablehlo not ok";
+      << "MHLO -> StableHLO conversion failed.";
 }
 
 std::string hlo_to_stablehlo_str(const HloModuleProto* proto) {

--- a/third_party/xla_client/stablehlo_helper.cc
+++ b/third_party/xla_client/stablehlo_helper.cc
@@ -26,8 +26,8 @@ static std::string getMlirModuleStr(mlir::ModuleOp& mlir_module) {
 
 static absl::Status hloToMhloHelper(const HloModuleProto* proto,
                                     mlir::ModuleOp* mlir_module) {
-  auto status = ConvertHloToMlirHlo(*mlir_module, proto,
-                                    /*import_all_computations=*/false);
+  auto status = xla::ConvertHloToMlirHlo(*mlir_module, proto,
+                                         /*import_all_computations=*/false);
   if (!status.ok()) {
     return status;
   }

--- a/third_party/xla_client/stablehlo_helper.h
+++ b/third_party/xla_client/stablehlo_helper.h
@@ -1,11 +1,11 @@
-#ifndef XLA_MHLO_HELPER_H_
-#define XLA_MHLO_HELPER_H_
+#ifndef STABLEHLO_HELPER_H_
+#define STABLEHLO_HELPER_H_
 
 #include "tensorflow/compiler/xla/client/xla_computation.h"
 
 namespace xla {
 
-std::string hlo_to_stablehlo_str(const HloModuleProto* proto);
+std::string hloToStablehloStr(const HloModuleProto* proto);
 
 }
 

--- a/third_party/xla_client/stablehlo_helper.h
+++ b/third_party/xla_client/stablehlo_helper.h
@@ -1,0 +1,17 @@
+#ifndef XLA_MHLO_HELPER_H_
+#define XLA_MHLO_HELPER_H_
+
+#include "tensorflow/compiler/xla/client/xla_computation.h"
+
+namespace mlir {
+class ModuleOp;
+class MLIRContext;
+}  // namespace mlir
+
+namespace xla {
+
+std::string hlo_to_stablehlo_str(const HloModuleProto* proto);
+
+}
+
+#endif

--- a/third_party/xla_client/stablehlo_helper.h
+++ b/third_party/xla_client/stablehlo_helper.h
@@ -3,11 +3,6 @@
 
 #include "tensorflow/compiler/xla/client/xla_computation.h"
 
-namespace mlir {
-class ModuleOp;
-class MLIRContext;
-}  // namespace mlir
-
 namespace xla {
 
 std::string hlo_to_stablehlo_str(const HloModuleProto* proto);

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -841,13 +841,23 @@ def mark_step(wait=False):
   torch_xla._XLAC._set_all_reduce_token(devctx.device, None)
 
 
-def get_xla_tensors_stablehlostep(tensors):
-  return torch_xla._XLAC._get_xla_tensors_stablehlo(tensors)
+def xla_get_stablehlo(tensors=[]):
+  """Get StableHLO dump for the computation graph in string format.
 
+  If tensors is not empty, the graph containing the provided tensors will be dump.
+  If tensors is empty, the whole graph will be dump.
 
-def xla_get_stablehlo():
-  return torch_xla._XLAC._xla_get_stablehlo(
-      torch_xla._XLAC._xla_get_default_device(), [])
+  Args:
+    tensors (list[torch.Tensor], optional): The tensors contained in the StableHLO graph.
+
+  Returns:
+    StableHLO in string format.
+  """
+  if len(tensors) == 0:
+    return torch_xla._XLAC._xla_get_stablehlo(
+        torch_xla._XLAC._xla_get_default_device(), [])
+  else:
+    return torch_xla._XLAC._get_xla_tensors_stablehlo(tensors)
 
 
 def wait_device_ops(devices=[]):

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -840,12 +840,15 @@ def mark_step(wait=False):
   devctx = _run_step_closures()
   torch_xla._XLAC._set_all_reduce_token(devctx.device, None)
 
+
 def get_xla_tensors_stablehlostep(tensors):
   return torch_xla._XLAC._get_xla_tensors_stablehlo(tensors)
 
+
 def xla_get_stablehlo():
   return torch_xla._XLAC._xla_get_stablehlo(
-            torch_xla._XLAC._xla_get_default_device(), [])
+      torch_xla._XLAC._xla_get_default_device(), [])
+
 
 def wait_device_ops(devices=[]):
   """Waits for all the async operations on the given devices to complete.

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -844,8 +844,8 @@ def mark_step(wait=False):
 def get_stablehlo(tensors=[]):
   """Get StableHLO for the computation graph in string format.
 
-  If tensors is empty, the whole computation graph will be dump.
-  If tensors is not empty, the graph containing the provided tensors will be dump.
+  If `tensors` is empty, the whole computation graph will be dump.
+  If `tensors` is not empty, the graph containing the provided tensors will be dump.
 
   Args:
     tensors (list[torch.Tensor], optional): The tensors contained in the StableHLO graph.

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -840,6 +840,12 @@ def mark_step(wait=False):
   devctx = _run_step_closures()
   torch_xla._XLAC._set_all_reduce_token(devctx.device, None)
 
+def get_xla_tensors_stablehlostep(tensors):
+  return torch_xla._XLAC._get_xla_tensors_stablehlo(tensors)
+
+def xla_get_stablehlo():
+  return torch_xla._XLAC._xla_get_stablehlo(
+            torch_xla._XLAC._xla_get_default_device(), [])
 
 def wait_device_ops(devices=[]):
   """Waits for all the async operations on the given devices to complete.

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -842,16 +842,16 @@ def mark_step(wait=False):
 
 
 def get_stablehlo(tensors=[]):
-  """Get StableHLO dump for the computation graph in string format.
+  """Get StableHLO for the computation graph in string format.
 
+  If tensors is empty, the whole computation graph will be dump.
   If tensors is not empty, the graph containing the provided tensors will be dump.
-  If tensors is empty, the whole graph will be dump.
 
   Args:
     tensors (list[torch.Tensor], optional): The tensors contained in the StableHLO graph.
 
   Returns:
-    StableHLO in string format.
+    StableHLO Module in string format.
   """
   if len(tensors) == 0:
     return torch_xla._XLAC._get_stablehlo(

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -844,7 +844,7 @@ def mark_step(wait=False):
 def get_stablehlo(tensors=[]):
   """Get StableHLO for the computation graph in string format.
 
-  If `tensors` is not empty, the graph with `tensors` as outputs will be dump
+  If `tensors` is not empty, the graph with `tensors` as outputs will be dump.
   If `tensors` is empty, the whole computation graph will be dump.
   TODO(lsy323): When `tensors` is empty, the some intermediate tensors will also be
   dump as outputs. Need further investigation.

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -858,11 +858,8 @@ def get_stablehlo(tensors=[]):
   Returns:
     StableHLO Module in string format.
   """
-  if len(tensors) == 0:
-    return torch_xla._XLAC._get_stablehlo(
-        torch_xla._XLAC._xla_get_default_device(), [])
-  else:
-    return torch_xla._XLAC._get_xla_tensors_stablehlo(tensors)
+  return torch_xla._XLAC._get_stablehlo(
+      tensors, torch_xla._XLAC._xla_get_default_device(), [])
 
 
 def wait_device_ops(devices=[]):

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -844,8 +844,13 @@ def mark_step(wait=False):
 def get_stablehlo(tensors=[]):
   """Get StableHLO for the computation graph in string format.
 
+  If `tensors` is not empty, the graph with `tensors` as outputs will be dump
   If `tensors` is empty, the whole computation graph will be dump.
-  If `tensors` is not empty, the graph containing the provided tensors will be dump.
+  TODO(lsy323): When `tensors` is empty, the some intermediate tensors will also be
+  dump as outputs. Need further investigation.
+
+  For inference graph, it is recommended to pass the model outputs to `tensors`.
+  For training graph, it is not straightforward to identify the "outputs". Using empty `tensors` is recommended.
 
   Args:
     tensors (list[torch.Tensor], optional): The tensors contained in the StableHLO graph.

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -841,7 +841,7 @@ def mark_step(wait=False):
   torch_xla._XLAC._set_all_reduce_token(devctx.device, None)
 
 
-def xla_get_stablehlo(tensors=[]):
+def get_stablehlo(tensors=[]):
   """Get StableHLO dump for the computation graph in string format.
 
   If tensors is not empty, the graph containing the provided tensors will be dump.
@@ -854,7 +854,7 @@ def xla_get_stablehlo(tensors=[]):
     StableHLO in string format.
   """
   if len(tensors) == 0:
-    return torch_xla._XLAC._xla_get_stablehlo(
+    return torch_xla._XLAC._get_stablehlo(
         torch_xla._XLAC._xla_get_default_device(), [])
   else:
     return torch_xla._XLAC._get_xla_tensors_stablehlo(tensors)

--- a/torch_xla/csrc/BUILD
+++ b/torch_xla/csrc/BUILD
@@ -120,6 +120,7 @@ ptxla_cc_library(
         ":shape_helper",
         "//third_party/xla_client:async_task",
         "//third_party/xla_client:runtime",
+        "//third_party/xla_client:stablehlo_helper",
         "//third_party/xla_client:unique",
         "//third_party/xla_client:xla_util",
         "@com_google_absl//absl/hash",

--- a/torch_xla/csrc/debug_util.cpp
+++ b/torch_xla/csrc/debug_util.cpp
@@ -79,7 +79,7 @@ std::string DebugUtil::GetTensorsGraphHlo(
   }
   return DumpUtil::ToHlo(root_values,
                          unique_device ? *unique_device : GetCurrentDevice(),
-                         /*to_stablehlo=*/ dump_stablehlo);
+                         /*to_stablehlo=*/dump_stablehlo);
 }
 
 std::string DebugUtil::GetTensorsGraphInfo(

--- a/torch_xla/csrc/debug_util.cpp
+++ b/torch_xla/csrc/debug_util.cpp
@@ -55,8 +55,8 @@ DebugUtil::GraphFormat DebugUtil::GetDefaultGraphFormat() {
 }
 
 std::string DebugUtil::GetTensorsGraphHlo(
-    absl::Span<const XLATensorPtr> tensors,
-    const std::vector<size_t>* indices) {
+    absl::Span<const XLATensorPtr> tensors, const std::vector<size_t>* indices,
+    bool dump_stablehlo) {
   std::vector<torch::lazy::Value> root_values;
   xla::util::Unique<torch::lazy::BackendDevice> unique_device;
   if (indices != nullptr) {
@@ -79,7 +79,7 @@ std::string DebugUtil::GetTensorsGraphHlo(
   }
   return DumpUtil::ToHlo(root_values,
                          unique_device ? *unique_device : GetCurrentDevice(),
-                         /* to_stablehlo */ true);
+                         /* to_stablehlo */ dump_stablehlo);
 }
 
 std::string DebugUtil::GetTensorsGraphInfo(

--- a/torch_xla/csrc/debug_util.cpp
+++ b/torch_xla/csrc/debug_util.cpp
@@ -79,7 +79,7 @@ std::string DebugUtil::GetTensorsGraphHlo(
   }
   return DumpUtil::ToHlo(root_values,
                          unique_device ? *unique_device : GetCurrentDevice(),
-                         /* to_stablehlo */ dump_stablehlo);
+                         /*to_stablehlo=*/ dump_stablehlo);
 }
 
 std::string DebugUtil::GetTensorsGraphInfo(

--- a/torch_xla/csrc/debug_util.cpp
+++ b/torch_xla/csrc/debug_util.cpp
@@ -139,7 +139,7 @@ std::string DebugUtil::GetTensorsGraphInfo(
   } else if (format == GraphFormat::kStableHlo) {
     graph_str = DumpUtil::ToHlo(
         root_values, unique_device ? *unique_device : GetCurrentDevice(),
-        /* to_stablehlo */ true);
+        /*to_stablehlo=*/true);
   } else {
     XLA_ERROR() << "Invalid graph format: " << format;
   }

--- a/torch_xla/csrc/debug_util.h
+++ b/torch_xla/csrc/debug_util.h
@@ -16,6 +16,7 @@ class DebugUtil {
     kText,
     kDot,
     kHlo,
+    kStableHlo,
   };
 
   static GraphFormat GetDefaultGraphFormat();
@@ -27,6 +28,10 @@ class DebugUtil {
       absl::Span<const XLATensorPtr> tensors,
       const std::vector<size_t>* indices,
       GraphFormat format = GetDefaultGraphFormat());
+
+  // Get 
+  static std::string GetTensorsGraphHlo(absl::Span<const XLATensorPtr> tensors,
+                                        const std::vector<size_t>* indices);
 
   // If the environment variable XLA_SAVE_TENSORS_FILE is set to the proper
   // output path, an instance of the report returned by GetTensorsGraphInfo() is

--- a/torch_xla/csrc/debug_util.h
+++ b/torch_xla/csrc/debug_util.h
@@ -21,6 +21,11 @@ class DebugUtil {
 
   static GraphFormat GetDefaultGraphFormat();
 
+  // Return HLO/StableHLO gragh of the index selected tensors in string format.
+  static std::string GetTensorsGraphHlo(absl::Span<const XLATensorPtr> tensors,
+                                        const std::vector<size_t>* indices,
+                                        bool dump_stablehlo = true);
+
   // Dumps the current Python frame and the IR Graph whose roots are the IR
   // values held at the tensors. If indices is not nullptr, it selects the
   // indices of the tensors whose graph will be emitted.
@@ -28,10 +33,6 @@ class DebugUtil {
       absl::Span<const XLATensorPtr> tensors,
       const std::vector<size_t>* indices,
       GraphFormat format = GetDefaultGraphFormat());
-
-  // Get 
-  static std::string GetTensorsGraphHlo(absl::Span<const XLATensorPtr> tensors,
-                                        const std::vector<size_t>* indices);
 
   // If the environment variable XLA_SAVE_TENSORS_FILE is set to the proper
   // output path, an instance of the report returned by GetTensorsGraphInfo() is

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1279,7 +1279,7 @@ void InitXlaModuleBindings(py::module m) {
           StepMarker(device, devices, wait);
         },
         py::arg("device") = "", py::arg("devices"), py::arg("wait") = true);
-  m.def("_xla_get_stablehlo",
+  m.def("_get_stablehlo",
         [](const std::string& device,
            const std::vector<std::string>& devices) -> std::string {
           NoGilSection nogil;

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1275,8 +1275,7 @@ void InitXlaModuleBindings(py::module m) {
         },
         py::arg("device") = "", py::arg("devices"), py::arg("wait") = true);
   m.def("_get_stablehlo",
-        [](const std::vector<at::Tensor>& tensors,
-           const std::string& device,
+        [](const std::vector<at::Tensor>& tensors, const std::string& device,
            const std::vector<std::string>& devices) -> std::string {
           NoGilSection nogil;
           if (tensors.empty()) {

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -398,7 +398,8 @@ static std::string GetLiveTensorsStableHLO(
                                   tsl::profiler::TraceMeLevel::kInfo);
   torch::lazy::BackendDevice device = GetDeviceOrCurrent(device_str);
   auto tensors = XLAGraphExecutor::Get()->GetLiveTensors(&device);
-  return XLAGraphExecutor::Get()->SyncTensorsGraphDumpHlo(&tensors, devices);
+  return XLAGraphExecutor::Get()->DumpHloComputation(tensors,
+                                                     /*to_stablehlo=*/true);
 }
 
 void ClearPendingIrs(const std::string& device_str) {

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -398,8 +398,7 @@ static std::string GetLiveTensorsStableHLO(
                                   tsl::profiler::TraceMeLevel::kInfo);
   torch::lazy::BackendDevice device = GetDeviceOrCurrent(device_str);
   auto tensors = XLAGraphExecutor::Get()->GetLiveTensors(&device);
-  return XLAGraphExecutor::Get()->SyncTensorsGraphDumpHlo(
-      &tensors, devices);
+  return XLAGraphExecutor::Get()->SyncTensorsGraphDumpHlo(&tensors, devices);
 }
 
 void ClearPendingIrs(const std::string& device_str) {

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -399,7 +399,7 @@ static std::string GetLiveTensorsStableHLO(
   torch::lazy::BackendDevice device = GetDeviceOrCurrent(device_str);
   auto tensors = XLAGraphExecutor::Get()->GetLiveTensors(&device);
   return XLAGraphExecutor::Get()->SyncTensorsGraphDumpHlo(
-      &tensors, devices, /*sync_ltc_data=*/true);
+      &tensors, devices);
 }
 
 void ClearPendingIrs(const std::string& device_str) {
@@ -930,7 +930,7 @@ void InitXlaModuleBindings(py::module m) {
         });
   m.def("_get_xla_tensors_stablehlo",
         [](const std::vector<at::Tensor>& tensors) -> std::string {
-          return GetTensorsHloGraph(tensors, true);
+          return GetTensorsHloGraph(tensors, /*get_stable_hlo=*/true);
         });
   py::class_<XLATensor::ShardingSpec, XLATensor::ShardingSpecPtr>(
       m, "XlaShardingSpec")

--- a/torch_xla/csrc/ir_dump_util.cpp
+++ b/torch_xla/csrc/ir_dump_util.cpp
@@ -9,7 +9,11 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/types/optional.h"
 #include "third_party/xla_client/debug_macros.h"
+<<<<<<< HEAD
 #include "third_party/xla_client/runtime.h"
+=======
+#include "third_party/xla_client/stablehlo_helper.h"
+>>>>>>> 0f98d62b... enable stablehlo dump
 #include "third_party/xla_client/xla_util.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/tensor_util.h"
@@ -252,7 +256,8 @@ std::string DumpUtil::PostOrderToText(
 }
 
 std::string DumpUtil::ToHlo(c10::ArrayRef<torch::lazy::Value> values,
-                            const torch::lazy::BackendDevice& device) {
+                            const torch::lazy::BackendDevice& device,
+                            bool to_stable_hlo) {
   LoweringContext lowering_ctx("IrToHlo", device);
   for (auto& ir_value : values) {
     lowering_ctx.AddResult(
@@ -276,10 +281,13 @@ std::string DumpUtil::ToHlo(c10::ArrayRef<torch::lazy::Value> values,
     std::vector<std::shared_ptr<xla::ComputationClient::Computation>>
         computations =
             xla::GetComputationClient()->Compile(std::move(instances));
-    return ConsumeValue(
-        xla::util::GetComputationHloText(computations[0]->computation()));
+    computation = std::move(computations[0]->move_computation());
   }
-  return ConsumeValue(xla::util::GetComputationHloText(computation));
+  if (to_stable_hlo) {
+    return hlo_to_stablehlo_str(&computation.proto());
+  } else {
+    return ConsumeValue(xla::util::GetComputationHloText(computation));
+  }
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ir_dump_util.cpp
+++ b/torch_xla/csrc/ir_dump_util.cpp
@@ -9,11 +9,8 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/types/optional.h"
 #include "third_party/xla_client/debug_macros.h"
-<<<<<<< HEAD
 #include "third_party/xla_client/runtime.h"
-=======
 #include "third_party/xla_client/stablehlo_helper.h"
->>>>>>> 0f98d62b... enable stablehlo dump
 #include "third_party/xla_client/xla_util.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/tensor_util.h"

--- a/torch_xla/csrc/ir_dump_util.cpp
+++ b/torch_xla/csrc/ir_dump_util.cpp
@@ -281,7 +281,7 @@ std::string DumpUtil::ToHlo(c10::ArrayRef<torch::lazy::Value> values,
     computation = std::move(computations[0]->move_computation());
   }
   if (to_stable_hlo) {
-    return hlo_to_stablehlo_str(&computation.proto());
+    return hloToStablehloStr(&computation.proto());
   } else {
     return ConsumeValue(xla::util::GetComputationHloText(computation));
   }

--- a/torch_xla/csrc/ir_dump_util.h
+++ b/torch_xla/csrc/ir_dump_util.h
@@ -26,7 +26,7 @@ class DumpUtil {
 
   static std::string ToHlo(c10::ArrayRef<torch::lazy::Value> values,
                            const torch::lazy::BackendDevice& device,
-                           bool to_stable_hlo = false);
+                           bool to_stablehlo = false);
 };
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ir_dump_util.h
+++ b/torch_xla/csrc/ir_dump_util.h
@@ -25,7 +25,8 @@ class DumpUtil {
       absl::Span<const torch::lazy::Node* const> roots);
 
   static std::string ToHlo(c10::ArrayRef<torch::lazy::Value> values,
-                           const torch::lazy::BackendDevice& device);
+                           const torch::lazy::BackendDevice& device,
+                           bool to_stable_hlo = false);
 };
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -365,13 +365,6 @@ std::string XLAGraphExecutor::SyncTensorsGraphDumpHlo(
                                   tsl::profiler::TraceMeLevel::kInfo);
   SyncTensorsConfig config;
   SyncTensorCollection coll = CollectSyncTensors(*tensors, config);
-  if (!coll.indices.empty()) {
-    /* Enure previous execution is complete before exiting this
-     * function */
-    TensorCollectionBarrier(&coll);
-  } else {
-    return "";
-  }
   return DebugUtil::GetTensorsGraphHlo(*tensors, &coll.indices);
 }
 

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -360,12 +360,10 @@ void XLAGraphExecutor::SyncTensorsGraph(std::vector<XLATensorPtr>* tensors,
 }
 
 std::string XLAGraphExecutor::SyncTensorsGraphDumpHlo(
-    std::vector<XLATensorPtr>* tensors, absl::Span<const std::string> devices,
-    bool sync_ltc_data) {
+    std::vector<XLATensorPtr>* tensors, absl::Span<const std::string> devices) {
   tsl::profiler::TraceMe activity("SyncTensorsGraphDumpHlo",
                                   tsl::profiler::TraceMeLevel::kInfo);
   SyncTensorsConfig config;
-  config.sync_ltc_data = sync_ltc_data;
   SyncTensorCollection coll = CollectSyncTensors(*tensors, config);
   if (coll.indices.empty()) {
     /* Enure previous execution is complete before exiting this

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -365,10 +365,11 @@ std::string XLAGraphExecutor::SyncTensorsGraphDumpHlo(
                                   tsl::profiler::TraceMeLevel::kInfo);
   SyncTensorsConfig config;
   SyncTensorCollection coll = CollectSyncTensors(*tensors, config);
-  if (coll.indices.empty()) {
+  if (!coll.indices.empty()) {
     /* Enure previous execution is complete before exiting this
      * function */
     TensorCollectionBarrier(&coll);
+  } else {
     return "";
   }
   return DebugUtil::GetTensorsGraphHlo(*tensors, &coll.indices);

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -126,8 +126,7 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
   // tensors are synced. The graph won't be compiled and executed. This workflow
   // is created for HLO/StableHLO dump.
   std::string SyncTensorsGraphDumpHlo(std::vector<XLATensorPtr>* tensors,
-                                      absl::Span<const std::string> devices,
-                                      bool sync_ltc_data);
+                                      absl::Span<const std::string> devices);
 
   // Makes sure that any outstanding IR operation accumulated over live tensors,
   // gets turned into device data. If wait is true, the sync operation will be

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -102,7 +102,8 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
   // Dumps the XLA HLO text of the computation accumulated in the graph which is
   // attached the tensors.
   // We don't use upstream DumpBackendComputation given we have our own format.
-  std::string DumpHloComputation(const std::vector<XLATensorPtr>& tensors);
+  std::string DumpHloComputation(const std::vector<XLATensorPtr>& tensors,
+                                 bool dump_stablehlo = false);
 
   // Retrieves the set of XLA tensors which are currently live in the system,
   // for the given device. If device is nullptr, the live tensors for all
@@ -120,6 +121,11 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
   void SyncTensorsGraph(std::vector<XLATensorPtr>* tensors,
                         absl::Span<const std::string> devices, bool wait,
                         bool sync_ltc_data, bool warm_up_cache_only = false);
+
+  // 
+  std::string SyncTensorsGraphDumpHlo(std::vector<XLATensorPtr>* tensors,
+                                      absl::Span<const std::string> devices,
+                                      bool sync_ltc_data);
 
   // Makes sure that any outstanding IR operation accumulated over live tensors,
   // gets turned into device data. If wait is true, the sync operation will be

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -122,12 +122,6 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
                         absl::Span<const std::string> devices, bool wait,
                         bool sync_ltc_data, bool warm_up_cache_only = false);
 
-  // An early-return version of SyncTensorsGraph, the function returns after the
-  // tensors are synced. The graph won't be compiled and executed. This workflow
-  // is created for HLO/StableHLO dump.
-  std::string SyncTensorsGraphDumpHlo(std::vector<XLATensorPtr>* tensors,
-                                      absl::Span<const std::string> devices);
-
   // Makes sure that any outstanding IR operation accumulated over live tensors,
   // gets turned into device data. If wait is true, the sync operation will be
   // run synchronously. The devices argument, if not empty, tells the devices

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -122,7 +122,9 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
                         absl::Span<const std::string> devices, bool wait,
                         bool sync_ltc_data, bool warm_up_cache_only = false);
 
-  // 
+  // An early-return version of SyncTensorsGraph, the function returns after the
+  // tensors are synced. The graph won't be compiled and executed. This workflow
+  // is created for HLO/StableHLO dump.
   std::string SyncTensorsGraphDumpHlo(std::vector<XLATensorPtr>* tensors,
                                       absl::Span<const std::string> devices,
                                       bool sync_ltc_data);

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -15,7 +15,6 @@ namespace torch_xla {
 
 class ShardingUtil {
  public:
-
   // This maps to `torch_xla.experimental.xla_sharding.ShardingType` enum type.
   enum ShardingType {
     REPLICATED = 0,


### PR DESCRIPTION
In this PR, new Python APIs and debugging flag to dump StableHLO are added. The StableHLO is generated from HLO -> StableHLO conversion instead of emitted from PyTorch/XLA natively.
 
### StableHLO dump Python API
`xm.get_stablehlo(tensors : List[torch.tensor] = []) -> string`

Returns the StableHLO in string format. If `tensors` is not empty, dump the graph containing the tensors in the parameters. If `tensors` is empty, dump the whole graph.

In this API, no XLA compilation and graph execution is done. So a new workflow with early return is added to `XlaGraphExecutor` to support this use case.

### Enable StableHLO dump via Debugging flag
Currently, environmental variable `XLA_SAVE_TENSORS_FILE` and `XLA_SAVE_TENSORS_FMT=hlo` are set to dump HLO for debugging before the XLA compilation. Add support to use `XLA_SAVE_TENSORS_FMT=stablehlo` to dump StableHLO in the existing debugging workflow.

### Implementation
1. Add helper function (`hlo_to_stablehlo_str`) to do HLO->StableHLO conversion and dump StableHLO in string format.
2. Add a new parameter to extend `DumpUtil::ToHlo` for StableHLO dumping.
5. Add a new workflow in `XlaGraphExecutor` to return early (Before XLA compilation and execution) and dump StableHLO

### Test
An example script to use the StableHLO API is added to `test/test_stablehlo_dump.py`
