### PR TITLE
[FIX]fix a typo in TROUBLESHOOTING.md

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -33,7 +33,7 @@ import torch_xla.debug.metrics as met
 # For short report that only contains a few key metrics.
 print(met.short_metrics_report())
 # For full report that includes all metrics.
-print(met.short_metrics_report())
+print(met.metrics_report())
 ```
 
 ## Understand The Metrics Report


### PR DESCRIPTION
- Problems
  + It may be a typo here. `torch_xla.debug.metrics.short_metrics_report()` that contains a few key metrics,  `torch_xla.debug.metrics.metrics_report()` that includes all metrics.
- Solutions
  + fix the TROUBLESHOOTING.md