### PR TITLE
[OpenXLA] Delete unused `tensor_shape.h` dep

### DIFF
--- a/torch_xla/csrc/convolution.cpp
+++ b/torch_xla/csrc/convolution.cpp
@@ -2,7 +2,6 @@
 
 #include "tensorflow/compiler/tf2xla/kernels/conv_op_helpers.h"
 #include "tensorflow/compiler/xla/client/lib/constants.h"
-#include "tensorflow/core/framework/tensor_shape.h"
 #include "third_party/xla_client/debug_macros.h"
 #include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/shape_helper.h"


### PR DESCRIPTION
Before migrate PyTorch/XLA to pull XLA from OpenXLA, PyTorch/XLA want to delete some unused TensorFlow deps for clean