### PR TITLE
Restrict the mark_sharding api to devicedata

### DIFF
--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1528,6 +1528,9 @@ void InitXlaModuleBindings(py::module m) {
           XLA_CHECK(ShardingUtil::UseVirtualDevice())
               << "Please set `XLA_USE_SPMD=1`";
           XLATensorPtr xtensor = bridge::GetXlaTensor(input);
+          // We should not call mark_sharding on tensors with a pending
+          // computation
+          XLA_CHECK(!check_materialization_helper({xtensor})[0]);
           xla::OpSharding sharding = ShardingUtil::CreateOpSharding(
               tile_assignment, group_assignment, replication_groups,
               ShardingUtil::ShardingType(sharding_type));


### PR DESCRIPTION
This pr restrict the `mark_sharding` to device data. 

Through on a second thought this will disable the usage like
```
t1 = torch.randn(100, device='xla:0')
t1.mark_sharding()...
```

since randn will produce a pending computation.