### PR TITLE
Remove duplicate shard exposure API

### DIFF
--- a/torch_xla/experimental/xla_sharded_tensor.py
+++ b/torch_xla/experimental/xla_sharded_tensor.py
@@ -121,11 +121,6 @@ class XLAShardedTensor(torch.Tensor):
   def sharding_spec(self):
     return torch_xla._XLAC._get_xla_sharding_spec(self.global_tensor)
 
-  @property
-  def shards(self):
-    # Return a list of local shards
-    return NotImplemented
-
   def __repr__(self):
     return f"XLAShardedTensor({self.global_tensor})"
 


### PR DESCRIPTION
Shards are exposed through the `local_shards` API, but there is a duplicate `shards` API. This change removes `shards` in favor of `local_shards`, since `local_shards` is more clear that only addressable shards are available.