### PR TITLE
Add utility functions for distributed checkpointing

### DIFF
--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -26,6 +26,9 @@ class ShardingUtil {
     PARTIAL = 5
   };
 
+  // Determine the ShardingType of the given xla::OpSharding.
+  static ShardingType GetShardingType(xla::OpSharding& sharding);
+
   // Test whether the XLA_USE_SPMD environment variable is set to enable the
   // virtual device optimization.
   static bool UseVirtualDevice();

--- a/torch_xla/experimental/xla_sharding.py
+++ b/torch_xla/experimental/xla_sharding.py
@@ -4,11 +4,11 @@ from dataclasses import dataclass, field
 import torch
 import torch_xla
 import torch_xla.core.xla_model as xm
-from torch_xla.experimental.xla_sharded_tensor import XLAShardedTensor
+from torch_xla.experimental.xla_sharded_tensor import XLAShardedTensor, XLAShard
 import torch_xla.runtime as xr
 
 import numpy as np
-from typing import Tuple, Union, List
+from typing import Tuple, Union, List, Any
 from enum import IntEnum
 
 
@@ -193,6 +193,17 @@ def clear_sharding(t: Union[torch.Tensor, XLAShardedTensor]) -> torch.Tensor:
   if isinstance(t, XLAShardedTensor):
     return t.global_tensor
   return t
+
+
+def wrap_if_sharded(x: Any) -> Any:
+  """
+  If the input is a sharded tensor, return an XLAShardedTensor wrapping it.
+  Otherwise, returns the input.
+  """
+  if (isinstance(x, torch.Tensor) and not isinstance(x, XLAShardedTensor) and
+      torch_xla._XLAC._get_xla_sharding_type(x) is not None):
+    return XLAShardedTensor(x)
+  return x
 
 
 @dataclass


### PR DESCRIPTION
This change adds a few utility functions to support distributed checkpointing. The following changes are included:
- Add `sharding_type` to `XLAShardedTensor` to get the ShardingType
- Add `wrap_if_sharded` to convert `torch.Tensor` into `XLAShardedTensor` if the underlying data is sharded.
- Remove `devices` parameter from `_get_local_shard_indices` and instead always return the shard indices in the order of the shards
- Clamp the `start` bound of the index slices to the tensor's size.
- Add a setter to the `unpadded_data` property of `XLAShard`