### PR TITLE
Implement SPMDLoadPlanner to enable distributed checkpoint loading

### DIFF
--- a/test/spmd/test_xla_distributed_checkpoint.py
+++ b/test/spmd/test_xla_distributed_checkpoint.py
@@ -1,0 +1,165 @@
+import os
+import tempfile
+import unittest
+import test_xla_sharding_base
+
+import torch
+import torch.distributed.checkpoint as dist_cp
+import torch_xla.core.xla_model as xm
+import torch_xla.runtime as xr
+import torch_xla.experimental.xla_sharding as xs
+
+from torch.distributed.checkpoint.default_planner import (
+    create_default_local_save_plan,
+    create_default_global_save_plan,
+)
+from torch_xla.experimental.distributed_checkpoint import SPMDLoadPlanner
+
+
+class DistributedCheckpointTestBase(test_xla_sharding_base.XlaShardingTest):
+
+  @classmethod
+  def setUpClass(cls):
+    os.environ['XLA_USE_SPMD'] = '1'
+    super().setUpClass()
+
+  def _get_sharded_model(self, mesh_shape=None):
+    # Return a sharded SimpleLinear model with fc1.weight sharded and
+    # fc2.weight explicitly replicated
+    mesh_shape = mesh_shape or (1, self.n_devices)
+    model = self.SimpleLinear().to(xm.xla_device())
+    mesh = self._get_mesh(mesh_shape)
+    xs.mark_sharding(model.fc1.weight, mesh, (0, 1))
+    xs.mark_sharding(model.fc2.weight, mesh, (None, None))
+    return model
+
+  def _get_default_local_metadata(self):
+    # Create a default Metadata instance for a SimpleLinear model by using
+    # the default local save plan on the model's CPU state_dict
+    cpu_state_dict = self.SimpleLinear().state_dict()
+    local_plan = create_default_local_save_plan(cpu_state_dict, True)
+    _, md = create_default_global_save_plan([local_plan])
+    return md
+
+  def _same_shard_data(self, shards, others) -> bool:
+    for a, b in zip(shards, others):
+      if not torch.allclose(a.data, b.data):
+        return False
+    return True
+
+
+class ReshardingTest(DistributedCheckpointTestBase):
+
+  def _save_and_restore(self,
+                        model_in,
+                        model_out,
+                        save_planner=None,
+                        load_planner=None):
+    """
+    Checkpoint model_in using the provided save_planner and load into model_out
+    using the provided load_planner, and assert model_out equals model_in after
+    the load. If either planner is not specified, the DefaultPlanner is used.
+    """
+    tmpdir = tempfile.mkdtemp()
+
+    # Save an unsharded model using the provided save planner
+    dist_cp.save_state_dict(
+        state_dict=model_in.state_dict(),
+        storage_writer=dist_cp.FileSystemWriter(tmpdir),
+        planner=save_planner,
+        no_dist=True,  # Single-host checkpoint doesn't require a process group
+    )
+
+    # Load the checkpoint using the provided load planner
+    for p1, p2 in zip(model_in.parameters(), model_out.parameters()):
+      self.assertFalse(torch.allclose(p1, p2))
+    dist_cp.load_state_dict(
+        state_dict=model_out.state_dict(),
+        storage_reader=dist_cp.FileSystemReader(tmpdir),
+        planner=load_planner,
+        no_dist=True,  # Single-host checkpoint doesn't require a process group
+    )
+    for p1, p2 in zip(model_in.parameters(), model_out.parameters()):
+      self.assertTrue(torch.allclose(p1, p2))
+
+  def test_unsharded_to_sharded(self):
+    # Save an unsharded model using the DefaultSavePlanner and load into a
+    # sharded model using the SPMDLoadPlanner
+    model = self.SimpleLinear().to(xm.xla_device())
+    sharded_model = self._get_sharded_model()
+    self._save_and_restore(model, sharded_model, load_planner=SPMDLoadPlanner())
+
+
+class SPMDLoadPlannerTest(DistributedCheckpointTestBase):
+
+  def _get_load_planner(self, model):
+    # Create an SPMDLoadPlanner for the given model.
+    md = self._get_default_local_metadata()
+    planner = SPMDLoadPlanner()
+    planner.set_up_planner(model.state_dict(), md, True)
+    return planner
+
+  def test_state_dict_separation(self):
+    model = self._get_sharded_model()
+    planner = self._get_load_planner(model)
+    if self.n_devices > 1:
+      # The state_dict should be flattened and separated
+      self.assertCountEqual(planner.sharded_state_dict, ['fc1.weight'])
+      # `fc2.weight` should be in the unsharded_state_dict despite having
+      # an explicit mark_sharding call because it is replicated.
+      self.assertCountEqual(planner.unsharded_state_dict,
+                            ['fc1.bias', 'fc2.weight', 'fc2.bias'])
+    else:
+      # With a single device, no tensors are sharded.
+      self.assertCountEqual(
+          planner.unsharded_state_dict,
+          ['fc1.weight', 'fc1.bias', 'fc2.weight', 'fc2.bias'])
+
+  def test_local_load_plan(self):
+    model = self._get_sharded_model()
+    planner = self._get_load_planner(model)
+    plan = planner.create_local_plan()
+    parameter_count = len(list(model.parameters()))
+    if self.n_devices > 1:
+      # When the model is sharded across devices, fc1.weight will result in
+      # self.n_devices ReadItems while all other tensors result in a single
+      # ReadItem.
+      sharded_read_items = [
+          ri for ri in plan.items if ri.dest_index.fqn == 'fc1.weight'
+      ]
+      self.assertEqual(self.n_devices, len(sharded_read_items))
+      # Every other parameter should have a single ReadItem
+      unsharded_read_items = set(plan.items) - set(sharded_read_items)
+      self.assertEqual(parameter_count - 1, len(unsharded_read_items))
+    else:
+      # If unsharded, there should be a single ReadItem per model parameter
+      self.assertEqual(parameter_count, len(plan.items))
+
+  @unittest.skipIf(xr.global_device_count() == 1,
+                   "Multiple devices required to shard tensors")
+  def test_resolve_and_commit_sharded_tensor(self):
+    model = self._get_sharded_model()
+    planner = self._get_load_planner(model)
+    plan = planner.create_local_plan()
+
+    xtensor = xs.wrap_if_sharded(model.fc1.weight)
+    old_shards = xtensor.local_shards
+    sharded_read_items = [
+        ri for ri in plan.items if ri.dest_index.fqn == 'fc1.weight'
+    ]
+    self.assertEqual(self.n_devices, len(sharded_read_items))
+    for read_item in sharded_read_items:
+      # Before all ReadItems have been processed, the tensor shards should not
+      # be updated
+      self.assertTrue(self._same_shard_data(xtensor.local_shards, old_shards))
+      tensor = planner.resolve_tensor(read_item)
+      tensor *= -1
+      planner.commit_tensor(read_item, tensor)
+    # After all ReadItems are processed, the local_shards should reflect the new
+    # values
+    self.assertFalse(self._same_shard_data(xtensor.local_shards, old_shards))
+
+
+if __name__ == '__main__':
+  test = unittest.main()
+  sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/spmd/test_xla_distributed_checkpoint.py
+++ b/test/spmd/test_xla_distributed_checkpoint.py
@@ -123,7 +123,7 @@ class SPMDLoadPlannerTest(DistributedCheckpointTestBase):
     if self.n_devices > 1:
       # When the model is sharded across devices, fc1.weight will result in
       # self.n_devices ReadItems while all other tensors result in a single
-      # ReadItem.
+      # ReadItem because the checkpoint metadata is unsharded.
       sharded_read_items = [
           ri for ri in plan.items if ri.dest_index.fqn == 'fc1.weight'
       ]

--- a/torch_xla/experimental/distributed_checkpoint.py
+++ b/torch_xla/experimental/distributed_checkpoint.py
@@ -1,0 +1,241 @@
+import io
+import numpy as np
+import torch
+import torch_xla
+import torch_xla.experimental.xla_sharding as xs
+
+from torch.distributed.checkpoint.default_planner import (
+    create_default_local_load_plan,
+    create_default_global_load_plan,
+)
+from torch.distributed.checkpoint.planner import (
+    SavePlanner,
+    LoadPlanner,
+    SavePlan,
+    LoadPlan,
+    ReadItem,
+    WriteItem,
+)
+from torch.distributed.checkpoint.planner_helpers import (
+    create_read_items_for_chunk_list,)
+from torch.distributed.checkpoint.metadata import (
+    ChunkStorageMetadata,
+    MetadataIndex,
+    Metadata,
+    STATE_DICT_TYPE,
+)
+from torch.distributed.checkpoint._nested_dict import (
+    FLATTEN_MAPPING,
+    flatten_state_dict,
+)
+from torch.distributed.checkpoint.utils import find_state_dict_object
+from torch.distributed.checkpoint._traverse import set_element
+from torch.distributed._shard._utils import narrow_tensor_by_index
+from torch.utils._pytree import tree_map
+from torch_xla.experimental.xla_sharding import (XLAShardedTensor, XLAShard,
+                                                 ShardingType)
+from typing import Any, Dict, List, Tuple, Union
+
+__all__ = [
+    "SPMDSavePlanner",
+    "SPMDLoadPlanner",
+]
+
+
+class SPMDSavePlanner(SavePlanner):
+  """
+  SPMDSavePlanner provides an implementation of the SavePlanner interface
+  which handles state_dicts containing XLAShardedTensor or List[XLAShard].
+  """
+
+  def set_up_planner(self, state_dict: STATE_DICT_TYPE,
+                     is_coordinator: bool) -> None:
+    raise NotImplemented
+
+  def create_local_plan(self) -> SavePlan:
+    raise NotImplemented
+
+  def create_global_plan(
+      self, all_plans: List[SavePlan]) -> Tuple[List[SavePlan], Metadata]:
+    raise NotImplemented
+
+  def finish_plan(self, new_plan: SavePlan) -> SavePlan:
+    raise NotImplemented
+
+  def resolve_data(self,
+                   write_item: WriteItem) -> Union[torch.Tensor, io.BytesIO]:
+    raise NotImplemented
+
+
+class SPMDLoadPlanner(LoadPlanner):
+  """
+  SPMDLoadPlanner provides an implementation of the LoadPlanner interface
+  which handles state_dicts containing XLAShardedTensor.
+
+  The input state_dict should already be sharded and on the XLA device, and
+  tensors and shards will be loaded in-place.
+  """
+
+  def __init__(self):
+    # Checkpoint metadata
+    self.metadata: Metadata = None
+
+    # Whether this host is the checkpoint coordinator
+    self.is_coordinator: bool = False
+
+    # The original state_dict passed to `set_up_planner`
+    self.original_state_dict: STATE_DICT_TYPE = None
+
+    # Mappings created after flattening the state_dict
+    self.mappings: FLATTEN_MAPPING = None
+
+    # Flattened state_dict tracking all sharded tensors to be restored
+    self.sharded_state_dict: Dict[str, XLAShardedTensor] = None
+
+    # Flattend state_dict tracking all other state_dict items
+    self.unsharded_state_dict: Dict[str, Any] = None
+
+    # Upon the first `resolve_tensor` call for a ReadItem associated with a
+    # sharded tensor, all local shards are moved to CPU via
+    # `XLAShardedTensor::local_shards` and are tracked in `_local_shards`.
+    # The checkpoint data will be loaded into _local_shards on CPU and
+    # moved to the underlying tensor via `XLAShardedTensor::load_local_shards_`
+    # when the last shard is fully committed in `commit_tensor`.
+    self._local_shards: Dict[str, List[XLAShard]] = {}
+
+    # Track how many tensor elements remain to be read for a sharded tensor.
+    self._pending_elements: Dict[str, int] = {}
+
+  def set_up_planner(
+      self,
+      state_dict: STATE_DICT_TYPE,
+      metadata: Metadata,
+      is_coordinator: bool,
+  ) -> None:
+    self.metadata = metadata
+    self.is_coordinator = is_coordinator
+    self.original_state_dict = state_dict
+
+    # Flatten the state_dict to allow separating sharded XLA tensors from
+    # types that can be handled by the default planner, and ensure all sharded
+    # tensors are wrapped in XLAShardedTensor
+    state_dict, self.mappings = flatten_state_dict(state_dict)
+    state_dict = tree_map(xs.wrap_if_sharded, state_dict)
+
+    # Select only XLAShardedTensors which are not replicated, since the
+    # default planner can handle everything else.
+    self.sharded_state_dict = {
+        k: v for k, v in state_dict.items() if _is_sharded_tensor(v)
+    }
+    unsharded = dict(state_dict.items() - self.sharded_state_dict.items())
+    self.unsharded_state_dict = tree_map(_unwrap_sharded_tensor, unsharded)
+
+  def create_local_plan(self) -> LoadPlan:
+    # Create the load plan for unsharded data
+    plan = create_default_local_load_plan(self.unsharded_state_dict,
+                                          self.metadata)
+    # Extend the plan for sharded tensor data
+    xla_read_items = _create_xla_read_items(self.sharded_state_dict,
+                                            self.metadata)
+    plan.items.extend(xla_read_items)
+    return plan
+
+  def create_global_plan(self, global_plan: List[LoadPlan]) -> List[LoadPlan]:
+    # Processing the local plans to create a global plan does not depend on
+    # the underlying tensor types, so we can directly reuse the default
+    # planner logic.
+    return create_default_global_load_plan(global_plan)
+
+  def finish_plan(self, central_plan: LoadPlan) -> LoadPlan:
+    return central_plan
+
+  def load_bytes(self, read_item: ReadItem, value: io.BytesIO) -> None:
+    # Write the value into the original state_dict to load in-place
+    set_element(
+        self.original_state_dict,
+        self.mappings[read_item.dest_index.fqn],
+        torch.load(value),
+    )
+
+  def resolve_tensor(self, read_item: ReadItem) -> torch.Tensor:
+    tensor = self.lookup_tensor(read_item.dest_index)
+    return self.transform_tensor(read_item, tensor)
+
+  def lookup_tensor(self, index: MetadataIndex) -> torch.Tensor:
+    if index.fqn in self.unsharded_state_dict:
+      return find_state_dict_object(self.unsharded_state_dict, index)
+
+    if index.fqn not in self._local_shards:
+      xtensor = self.sharded_state_dict[index.fqn]
+      self._local_shards[index.fqn] = xtensor.local_shards
+      # Calculate the expected number of reads for all shards of the tensor
+      self._pending_elements[index.fqn] = 0
+      for shard in self._local_shards[index.fqn]:
+        self._pending_elements[index.fqn] += shard.unpadded_data.numel()
+
+    xla_shard = self._local_shards[index.fqn][index.index]
+    assert index.offset == torch.Size(
+        ind.start for ind in xla_shard.indices
+    ), "ReadItem does not correspond to the correct shard"
+    # Return padded data since the tensor will be narrowed to match
+    # the ReadItem in `transform_tensor`.
+    return xla_shard.data
+
+  def transform_tensor(self, read_item: ReadItem, tensor: torch.Tensor):
+    offsets = read_item.dest_offsets
+    index = read_item.dest_index
+    if index.fqn in self.sharded_state_dict:
+      # Update offsets to index into the shard rather than the global tensor
+      shard = self._local_shards[index.fqn][index.index]
+      offsets = torch.Size(d - i.start for d, i in zip(offsets, shard.indices))
+    return narrow_tensor_by_index(tensor, offsets, read_item.lengths)
+
+  def commit_tensor(self, read_item: ReadItem, tensor: torch.Tensor) -> None:
+    fqn = read_item.dest_index.fqn
+    if fqn not in self.sharded_state_dict:
+      return
+
+    self._pending_elements[fqn] -= np.prod(read_item.lengths)
+    assert self._pending_elements[
+        fqn] >= 0, f"Too many writes for tensor {index.fqn}"
+    if self._pending_elements[fqn] == 0:
+      # Load local shards into the XLAShardedTensor and release the shards
+      # from CPU
+      local_shards = self._local_shards.pop(fqn)
+      self.sharded_state_dict[fqn].load_local_shards_(local_shards)
+
+
+def _create_chunk_from_shard_index(index: List[slice]) -> ChunkStorageMetadata:
+  return ChunkStorageMetadata(
+      offsets=torch.Size(ind.start for ind in index),
+      sizes=torch.Size(ind.stop - ind.start for ind in index))
+
+
+def _create_xla_read_items(sharded_state_dict: STATE_DICT_TYPE,
+                           metadata: Metadata) -> List[ReadItem]:
+  """
+  Iterate through the state_dict and return ReadItems for all local shards.
+  """
+  items = []
+  for fqn, t in sharded_state_dict.items():
+    assert isinstance(t, XLAShardedTensor
+                     ), "_create_xla_read_items only accepts XLAShardedTensor"
+    md = metadata.state_dict_metadata[fqn]
+    # Since local shards are currently moved to CPU on creation, we need to get
+    # the shard indices indirectly to avoid unnecessarily consuming host memory.
+    shard_indices = torch_xla._XLAC._get_local_shard_indices(t.global_tensor)
+    chunks = [_create_chunk_from_shard_index(index) for index in shard_indices]
+    items.extend(create_read_items_for_chunk_list(fqn, md, chunks))
+  return items
+
+
+def _is_sharded_tensor(x: Any) -> bool:
+  """Return true if the tensor's data is sharded across multiple devices"""
+  return isinstance(
+      x, XLAShardedTensor) and x.sharding_type != ShardingType.REPLICATED
+
+
+def _unwrap_sharded_tensor(x: Any) -> Any:
+  if isinstance(x, XLAShardedTensor):
+    return x.global_tensor
+  return x


### PR DESCRIPTION
This implements the [LoadPlanner interface](https://github.com/pytorch/pytorch/blob/2800a04a17d727dc12353dbea4f4007682194822/torch/distributed/checkpoint/planner.py#L245) from torch.distributed.checkpoint. This implementation only directly handles sharded tensors and relies on the default planner's logic for everything else.

A high-level overview of each of the Planner interface methods:
- `set_up_planner`: Called with the state_dict to be restored and metadata from the checkpoint. Our implementation will split the state_dict into a sharded and unsharded portion so that we can defer to the default planner logic for the unsharded part.
- `create_local_plan`: ReadItems are generated for every item in the state_dict. The default planner is used for the unsharded objects, and we generate a ReadItem for each shard of each XLAShardedTensor with non-REPLICATED sharding type.
- `create_global_plan`: The coordinator process makes any global decisions for the restoration. There is no custom logic here.
- `finish_plan`: The process can adjust its plan after global coordination. Again, no custom logic here.
- `load_bytes`: This is how non-tensor data is restored. We defer to the default planner's logic.
- `resolve_tensor`: This function returns a tensor to store the read result of the associated ReadItem. If the ReadItem doesn't correspond to a sharded tensor, we defer to the default planner logic. Otherwise, we return the unpadded data of the local shard associated with the ReadItem.
- `commit_tensor`: This is called after the data has been loaded into the tensor. This is a no-op in the default planner, but for sharded tensors we track each shard that has been committed. Once all shards are committed for a tensor, they are loaded into the XLAShardedTensor.

This PR depends on https://github.com/pytorch/xla/pull/5128 for some utility functions.