### PR TITLE
[SPMD] Set replicated output false

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -183,14 +183,14 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
 
   def test_mark_sharding_partial(self):
     device = xm.xla_device()
-    xt1 = torch.randn(4, 4).to(xm.xla_device())
-    xt2 = torch.randn(4, 4).to(xm.xla_device())
-    expected = (xt1 @ xt2).cpu()
+    t1 = torch.randn(4, 4).to(xm.xla_device())
+    t2 = torch.randn(4, 4).to(xm.xla_device())
+    expected = (t1 @ t2).cpu()
 
     # Shard along two axes if four or more devices are available
     z_dim = 2 if self.n_devices >= 4 else 1
     mesh = self._get_mesh((z_dim, self.n_devices // z_dim))
-    xs.mark_sharding(xt1, mesh, (0, None))
+    xt1 = xs.mark_sharding(t1, mesh, (0, None))
 
     # partial replication requires >1 devices; otherwise, it's replicated.
     if self.n_devices > 1:
@@ -200,7 +200,11 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
       self.assertTrue('[%d,1,%d]' %
                       (z_dim, self.n_devices //
                        z_dim) in torch_xla._XLAC._get_xla_sharding_spec(xt1))
-    actual = (xt1 @ xt2).cpu()
+    # replicated group should share the same data content.
+    if (self.n_devices // z_dim) > 1:
+      shards = xt1.local_shards
+      self.assertTrue(torch.allclose(shards[0].data == shards[1].data))
+    actual = (xt1 @ t2).cpu()
     self.assertTrue(torch.allclose(expected, actual))
 
   def test_partial_replication_addmm(self):

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -332,7 +332,8 @@ ComputationClient::DataPtr PjRtComputationClient::ReplicateShardedData(
 
     std::vector<std::vector<ComputationClient::DataPtr>> arguments_by_device(
         GetLocalDevices().size(), std::vector<ComputationClient::DataPtr>(1));
-    for (auto shard : shards) {
+    for (int i = 0; i < shards.size(); ++i) {
+      auto shard = shards[i];
       std::vector<std::string> device_spec =
           absl::StrSplit(shard->device(), ':');
       XLA_CHECK_EQ(device_spec.size(), 2)

--- a/third_party/xla_client/pjrt_computation_client.cc
+++ b/third_party/xla_client/pjrt_computation_client.cc
@@ -332,8 +332,7 @@ ComputationClient::DataPtr PjRtComputationClient::ReplicateShardedData(
 
     std::vector<std::vector<ComputationClient::DataPtr>> arguments_by_device(
         GetLocalDevices().size(), std::vector<ComputationClient::DataPtr>(1));
-    for (int i = 0; i < shards.size(); ++i) {
-      auto shard = shards[i];
+    for (auto shard : shards) {
       std::vector<std::string> device_spec =
           absl::StrSplit(shard->device(), ':');
       XLA_CHECK_EQ(device_spec.size(), 2)

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -15,7 +15,6 @@ namespace torch_xla {
 
 class ShardingUtil {
  public:
-
   // This maps to `torch_xla.experimental.xla_sharding.ShardingType` enum type.
   enum ShardingType {
     REPLICATED = 0,
@@ -71,16 +70,15 @@ class ShardingUtil {
   // of arguments (innner). This requires `sharding_specs` of the same size as
   // the number of arguments. `sharding_specs` can contain `nullptr` if the
   // corresponding result argument is not sharded. The replicated execution
-  // leaves the results in replicated states, which is aligned with the default
-  // exepctation `replicated_output=true`. However, if we override the
-  // compiler's default behavior and allow the execution to return sharded
-  // results, then we should set `replicated_output=false` and wrap sharded
-  // arguments into `PjRtShardedData`. This returns a vector of size that is
-  // equal to the number of arguments.
+  // `replicated_output=true` leaves the results in replicated states, which is
+  // aligned with the default exepctation of XLA compiler. However, we override
+  // the compiler's default behavior and allow the execution to return sharded
+  // results and wrap sharded arguments into `PjRtShardedData`. This returns a
+  // vector of size that is equal to the number of arguments.
   static std::vector<xla::ComputationClient::DataPtr> OutputHandler(
       std::vector<std::vector<xla::ComputationClient::DataPtr>> sharded_results,
       std::vector<XLATensor::ShardingSpecPtr> sharding_specs,
-      bool replicated_output = true);
+      bool replicated_output = false);
 
   // Returns the shape of the resulting shards of `tensor` after applying
   // `sharding`. This assumes the shards will be padded to ensure they all


### PR DESCRIPTION
After benchmarking and testing we are more confident that we could/should leave output sharding by default.

I also made a slight change to one of the existing unit tests, for partial replication.
