### PR TITLE
Revert "[SPMD] Set replicated output false"

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -183,14 +183,14 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
 
   def test_mark_sharding_partial(self):
     device = xm.xla_device()
-    t1 = torch.randn(4, 4).to(xm.xla_device())
-    t2 = torch.randn(4, 4).to(xm.xla_device())
-    expected = (t1 @ t2).cpu()
+    xt1 = torch.randn(4, 4).to(xm.xla_device())
+    xt2 = torch.randn(4, 4).to(xm.xla_device())
+    expected = (xt1 @ xt2).cpu()
 
     # Shard along two axes if four or more devices are available
     z_dim = 2 if self.n_devices >= 4 else 1
     mesh = self._get_mesh((z_dim, self.n_devices // z_dim))
-    xt1 = xs.mark_sharding(t1, mesh, (0, None))
+    xs.mark_sharding(xt1, mesh, (0, None))
 
     # partial replication requires >1 devices; otherwise, it's replicated.
     if self.n_devices > 1:
@@ -200,11 +200,7 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
       self.assertTrue('[%d,1,%d]' %
                       (z_dim, self.n_devices //
                        z_dim) in torch_xla._XLAC._get_xla_sharding_spec(xt1))
-    # replicated group should share the same data content.
-    if (self.n_devices // z_dim) > 1:
-      shards = xt1.local_shards
-      self.assertTrue(torch.allclose(shards[0].data == shards[1].data))
-    actual = (xt1 @ t2).cpu()
+    actual = (xt1 @ xt2).cpu()
     self.assertTrue(torch.allclose(expected, actual))
 
   def test_partial_replication_addmm(self):

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -15,6 +15,7 @@ namespace torch_xla {
 
 class ShardingUtil {
  public:
+
   // This maps to `torch_xla.experimental.xla_sharding.ShardingType` enum type.
   enum ShardingType {
     REPLICATED = 0,
@@ -70,15 +71,16 @@ class ShardingUtil {
   // of arguments (innner). This requires `sharding_specs` of the same size as
   // the number of arguments. `sharding_specs` can contain `nullptr` if the
   // corresponding result argument is not sharded. The replicated execution
-  // `replicated_output=true` leaves the results in replicated states, which is
-  // aligned with the default exepctation of XLA compiler. However, we override
-  // the compiler's default behavior and allow the execution to return sharded
-  // results and wrap sharded arguments into `PjRtShardedData`. This returns a
-  // vector of size that is equal to the number of arguments.
+  // leaves the results in replicated states, which is aligned with the default
+  // exepctation `replicated_output=true`. However, if we override the
+  // compiler's default behavior and allow the execution to return sharded
+  // results, then we should set `replicated_output=false` and wrap sharded
+  // arguments into `PjRtShardedData`. This returns a vector of size that is
+  // equal to the number of arguments.
   static std::vector<xla::ComputationClient::DataPtr> OutputHandler(
       std::vector<std::vector<xla::ComputationClient::DataPtr>> sharded_results,
       std::vector<XLATensor::ShardingSpecPtr> sharding_specs,
-      bool replicated_output = false);
+      bool replicated_output = true);
 
   // Returns the shape of the resulting shards of `tensor` after applying
   // `sharding`. This assumes the shards will be padded to ensure they all


### PR DESCRIPTION
Reverts pytorch/xla#5139, since it break TPU CI.