### PR TITLE
[OpenXLA] Delete unused `topology.proto` after delete XRT

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,6 +50,7 @@ http_archive(
         "//tf_patches:thread_local_random.diff",
         "//tf_patches:topk_rewriter.diff",
         "//tf_patches:triton_filesystem.diff",
+        "//tf_patches:xla_bzl.diff",
         "//tf_patches:xplane.diff",
     ],
     strip_prefix = "tensorflow-d577af9cac504776a2d0ddbb0a445ba311aa1fea",

--- a/torch_xla/csrc/runtime/mesh_service.proto
+++ b/torch_xla/csrc/runtime/mesh_service.proto
@@ -1,7 +1,5 @@
 syntax = "proto2";
 
-import "tensorflow/core/protobuf/tpu/topology.proto";
-
 package torch_xla.runtime.service.grpc;
 
 message Device {
@@ -17,7 +15,6 @@ message Worker {
 }
 
 message Config {
-  optional tensorflow.tpu.TopologyProto proto = 1;
   repeated Worker workers = 2;
   required int64 mesh_size = 3;
 }

--- a/torch_xla/csrc/runtime/mesh_service.proto
+++ b/torch_xla/csrc/runtime/mesh_service.proto
@@ -15,6 +15,7 @@ message Worker {
 }
 
 message Config {
+  optional int64 placeholder = 1;
   repeated Worker workers = 2;
   required int64 mesh_size = 3;
 }


### PR DESCRIPTION
Before PyTorch migrate to pull XLA from OpenXLA, delete some unused TensorFlow deps after deprecated XRT