### PR TITLE
[OpenXLA] Replace `tf_cc_shared_object` with `cc_binary`

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -3,7 +3,7 @@ load(
     "tf_cc_shared_object",
 )
 
-load("@tsl//tsl/platform/default:rules_cc.bzl", "cc_binary")
+load("@org_tensorflow//tensorflow/tsl/platform/default:rules_cc.bzl", "cc_binary")
 
 cc_binary(
     name = "_XLAC.so",

--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,12 @@
 cc_binary(
     name = "_XLAC.so",
+    copts = [
+        "-DTORCH_API_INCLUDE_EXTENSION_H",
+        "-DTORCH_EXTENSION_NAME=_XLAC",
+        "-fopenmp",
+        "-fPIC",
+        "-fwrapv",
+    ],
     linkopts = [
         "-Wl,-rpath,$$ORIGIN/torch_xla/lib",  # for libtpu
         "-Wl,-soname,_XLAC.so",

--- a/BUILD
+++ b/BUILD
@@ -7,13 +7,6 @@ load("@org_tensorflow//tensorflow/tsl/platform/default:rules_cc.bzl", "cc_binary
 
 cc_binary(
     name = "_XLAC.so",
-    copts = [
-        "-DTORCH_API_INCLUDE_EXTENSION_H",
-        "-DTORCH_EXTENSION_NAME=_XLAC",
-        "-fopenmp",
-        "-fPIC",
-        "-fwrapv",
-    ],
     linkopts = [
         "-Wl,-rpath,$$ORIGIN/torch_xla/lib",  # for libtpu
     ],

--- a/BUILD
+++ b/BUILD
@@ -1,10 +1,3 @@
-load(
-    "@org_tensorflow//tensorflow:tensorflow.bzl",
-    "tf_cc_shared_object",
-)
-
-load("@org_tensorflow//tensorflow/tsl/platform/default:rules_cc.bzl", "cc_binary")
-
 cc_binary(
     name = "_XLAC.so",
     linkopts = [

--- a/BUILD
+++ b/BUILD
@@ -3,7 +3,9 @@ load(
     "tf_cc_shared_object",
 )
 
-tf_cc_shared_object(
+load("@tsl//tsl/platform/default:rules_cc.bzl", "cc_binary")
+
+cc_binary(
     name = "_XLAC.so",
     copts = [
         "-DTORCH_API_INCLUDE_EXTENSION_H",

--- a/BUILD
+++ b/BUILD
@@ -5,11 +5,13 @@ load(
 
 load("@org_tensorflow//tensorflow/tsl/platform/default:rules_cc.bzl", "cc_binary")
 
-tf_cc_shared_object(
+cc_binary(
     name = "_XLAC.so",
     linkopts = [
         "-Wl,-rpath,$$ORIGIN/torch_xla/lib",  # for libtpu
+        "-Wl,-soname,_XLAC.so",
     ],
+    linkshared = 1,
     visibility = ["//visibility:public"],
     deps = [
         "//torch_xla/csrc:init_python_bindings",

--- a/BUILD
+++ b/BUILD
@@ -5,7 +5,7 @@ load(
 
 load("@org_tensorflow//tensorflow/tsl/platform/default:rules_cc.bzl", "cc_binary")
 
-cc_binary(
+tf_cc_shared_object(
     name = "_XLAC.so",
     linkopts = [
         "-Wl,-rpath,$$ORIGIN/torch_xla/lib",  # for libtpu

--- a/setup.py
+++ b/setup.py
@@ -207,7 +207,10 @@ GCLOUD_KEY_FILE = os.getenv('GCLOUD_SERVICE_KEY_FILE', default='')
 CACHE_SILO_NAME = os.getenv('SILO_NAME', default='dev')
 BAZEL_JOBS = os.getenv('BAZEL_JOBS', default='')
 
-extra_compile_args = []
+extra_compile_args = [
+  "-DTORCH_API_INCLUDE_EXTENSION_H",
+  "-DTORCH_EXTENSION_NAME=_XLAC",
+  "-fopenmp", "-fPIC", "-fwrapv",]
 cxx_abi = os.getenv(
     'CXX_ABI', default='') or getattr(torch._C, '_GLIBCXX_USE_CXX11_ABI', None)
 if cxx_abi is not None:

--- a/setup.py
+++ b/setup.py
@@ -207,10 +207,7 @@ GCLOUD_KEY_FILE = os.getenv('GCLOUD_SERVICE_KEY_FILE', default='')
 CACHE_SILO_NAME = os.getenv('SILO_NAME', default='dev')
 BAZEL_JOBS = os.getenv('BAZEL_JOBS', default='')
 
-extra_compile_args = [
-  "-DTORCH_API_INCLUDE_EXTENSION_H",
-  "-DTORCH_EXTENSION_NAME=_XLAC",
-  "-fopenmp", "-fPIC", "-fwrapv",]
+extra_compile_args = []
 cxx_abi = os.getenv(
     'CXX_ABI', default='') or getattr(torch._C, '_GLIBCXX_USE_CXX11_ABI', None)
 if cxx_abi is not None:

--- a/third_party/xla_client/BUILD
+++ b/third_party/xla_client/BUILD
@@ -1,8 +1,4 @@
 load(
-    "@org_tensorflow//tensorflow:tensorflow.bzl",
-    "tf_cc_shared_object",
-)
-load(
     "@org_tensorflow//tensorflow/tsl/platform/default:build_config.bzl",
     "tf_proto_library_cc",
 )
@@ -532,7 +528,7 @@ cc_library(
     ],
 )
 
-tf_cc_shared_object(
+cc_binary(
     name = "libxla_computation_client.so",
     linkopts = select({
         "@org_tensorflow//tensorflow:windows": [],
@@ -540,8 +536,10 @@ tf_cc_shared_object(
             "-z defs",
             "-Wl,--version-script",  #  This line must be directly followed by the version_script.lds file
             "$(location :tf_version_script.lds)",
+            "-Wl,-soname,libxla_computation_client.so",
         ],
     }),
+    linkshared = 1,
     visibility = ["//visibility:public"],
     deps = [
         ":computation_client",


### PR DESCRIPTION
Before Migrate to pull xla from openxla, pytorch/xla will delete or replace some tensorflow deps or funcs