### PR TITLE
Err when both operands of torch.add have dynamic dimensions

### DIFF
--- a/test/ds/test_dynamic_shapes.py
+++ b/test/ds/test_dynamic_shapes.py
@@ -385,6 +385,25 @@ class TestDynamicShapes(test_utils.XlaTestCase):
     self.assertRaises(RuntimeError, lambda: torch.add(t2, t4))
     self.assertRaises(RuntimeError, lambda: torch.add(t4, t2))
 
+  def test_add_two_dynamic_tensors(self):
+    t1 = torch.tensor([[1, 0, 3, 5, 0, 6]], device=dev)
+    t2 = torch.nonzero(t1)
+    t3 = torch.tensor([[1]], device=dev)
+    t4 = torch.nonzero(t3)
+
+    # t2.shape=torch.Size([<=6, 2]) with real size [4, 2]
+    # t4.shape=torch.Size([<=1, 2]) with real size [1, 2]
+    self.assertRaises(RuntimeError, lambda: torch.add(t2, t4))
+    self.assertRaises(RuntimeError, lambda: torch.add(t4, t2))
+
+    # For now, we disallow if both operands have the same upper bound and real size.
+    # This is consistent with PyTorch's behavior.
+    # t2.shape=torch.Size([<=6, 2]) with real size [4, 2]
+    # t6.shape=torch.Size([<=6, 2]) with real size [4, 2]
+    t5 = torch.tensor([[1, 0, 3, 5, 0, 6]], device=dev)
+    t6 = torch.nonzero(t5)
+    self.assertRaises(RuntimeError, lambda: torch.add(t2, t6))
+
   def test_clone(self):
     t1 = torch.tensor([1, 0, 3, 5, 0, 6], device=dev)
     # t2.shape=torch.Size([<=6, 1]) with real size [4, 1]

--- a/test/ds/test_dynamic_shapes.py
+++ b/test/ds/test_dynamic_shapes.py
@@ -348,7 +348,7 @@ class TestDynamicShapes(test_utils.XlaTestCase):
     t3 = torch.tensor([[1, 1]], device=dev)
 
     # t2.shape=torch.Size([<=6, 2]) with real size [4, 2]
-    # t3.shape=torch.Size([1, 2]) with real size [2, 2]
+    # t3.shape=torch.Size([1, 2]) with real size [1, 2]
     t4 = torch.add(t2, t3)
     self.assertIsInstance(t4.shape[0], torch.SymInt)
     self.assertEqual(str(t4.shape[0]), '<=6')

--- a/test/ds/test_dynamic_shapes.py
+++ b/test/ds/test_dynamic_shapes.py
@@ -385,17 +385,6 @@ class TestDynamicShapes(test_utils.XlaTestCase):
     self.assertRaises(RuntimeError, lambda: torch.add(t2, t4))
     self.assertRaises(RuntimeError, lambda: torch.add(t4, t2))
 
-  def test_add_two_dynamic_tensors(self):
-    t1 = torch.tensor([[1, 0, 3, 5, 0, 6]], device=dev)
-    t2 = torch.nonzero(t1)
-    t3 = torch.tensor([[1]], device=dev)
-    t4 = torch.nonzero(t3)
-
-    # t2.shape=torch.Size([<=6, 2]) with real size [4, 2]
-    # t4.shape=torch.Size([<=1, 2]) with real size [1, 2]
-    self.assertRaises(RuntimeError, lambda: torch.add(t2, t4))
-    self.assertRaises(RuntimeError, lambda: torch.add(t4, t2))
-
     # For now, we disallow if both operands have the same upper bound and real size.
     # This is consistent with PyTorch's behavior.
     # t2.shape=torch.Size([<=6, 2]) with real size [4, 2]

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -638,8 +638,9 @@ at::Tensor XLANativeFunctions::add(const at::Tensor& self,
                                    const at::Tensor& other,
                                    const at::Scalar& alpha) {
   TORCH_LAZY_FN_COUNTER("xla::");
-  XLA_CHECK(!tensor_has_dym_dim(self) && !tensor_has_dym_dim(other))
-      << "Both operands of torch.add have dynamic dimensions. This is not "
+  XLA_CHECK(!(tensor_has_dym_dim(self) && tensor_has_dym_dim(other)))
+      << "Both operands of torch.add cannot have dynamic dimensions at the "
+         "same time. This is not "
          "supported in PyTorch/XLA.";
 
   at::native::alpha_check(at::result_type(self, other), alpha);

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -638,6 +638,10 @@ at::Tensor XLANativeFunctions::add(const at::Tensor& self,
                                    const at::Tensor& other,
                                    const at::Scalar& alpha) {
   TORCH_LAZY_FN_COUNTER("xla::");
+  XLA_CHECK(!tensor_has_dym_dim(self) && !tensor_has_dym_dim(other))
+      << "Both operands of torch.add have dynamic dimensions. This is not "
+         "supported in PyTorch/XLA.";
+
   at::native::alpha_check(at::result_type(self, other), alpha);
   return DoBinaryOp(self, other,
                     [&](const XLATensorPtr& xself, const XLATensorPtr& xother,

--- a/torch_xla/csrc/tensor_util.h
+++ b/torch_xla/csrc/tensor_util.h
@@ -141,6 +141,11 @@ xla_expand_outplace(const at::Tensor& to_expand1, const at::Tensor& to_expand2,
                              at::expand_copy(to_expand3, expanded_size)));
 }
 
+inline bool tensor_has_dym_dim(at::Tensor t) {
+  c10::SymIntArrayRef sym_sizes = t.sym_sizes();
+  return !c10::asIntArrayRefSlowOpt(sym_sizes).has_value();
+}
+
 inline std::vector<at::Tensor> xla_expand_outplace(at::TensorList to_expand) {
   // expands a list of Tensors; ignores undefined (null) tensors
   bool first = true;


### PR DESCRIPTION
This is consistent to what PyTorch [does](https://github.com/pytorch/xla/pull/4868#issuecomment-1533935866).