### PR TITLE
Bypass virtual device when creating IR node for view

### DIFF
--- a/test/spmd/test_xla_virtual_device.py
+++ b/test/spmd/test_xla_virtual_device.py
@@ -77,6 +77,15 @@ class VirtualDeviceTest(test_xla_sharding_base.XlaShardingTest):
     self.assertLess(outbound_with_virtual_device,
                     2 * xt1.nelement() * xt1.element_size())
 
+  def test_view_assign(self):
+    t = torch.randn(4, 4)
+    xt = t.to(xm.xla_device())
+    s = xt.narrow(0, 0, 2)
+    s.copy_(torch.ones(2, 4))
+    self.assertTrue(torch.allclose(s.cpu(), torch.ones(2, 4)))
+    self.assertTrue(torch.allclose(xt[:2], s))
+    self.assertTrue(torch.allclose(xt[2:].cpu(), t[2:]))
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -492,10 +492,10 @@ void XLATensor::SetTensor(at::Tensor tensor) {
 }
 
 void XLATensor::UpdateFromTensor(at::Tensor tensor, bool sync) {
-  torch::lazy::BackendDevice device = ShardingUtil::UseVirtualDevice()
-                                          ? ParseDeviceString("SPMD:0")
-                                          : GetDevice();
   if (sync) {
+    torch::lazy::BackendDevice device = ShardingUtil::UseVirtualDevice()
+                                            ? ParseDeviceString("SPMD:0")
+                                            : GetDevice();
     at::Tensor typed_tensor =
         torch::lazy::CopyTensor(tensor, dtype(), /*copy=*/false);
     SetIrValue(GetIrValueForTensor(typed_tensor, device),
@@ -506,7 +506,8 @@ void XLATensor::UpdateFromTensor(at::Tensor tensor, bool sync) {
     data()->handle = nullptr;
     AssignIrValue(torch::lazy::Value());
     if (data()->view != nullptr) {
-      torch::lazy::Value ir_value = GetIrValueForTensor(coyped_tensor, device);
+      torch::lazy::Value ir_value =
+          GetIrValueForTensor(coyped_tensor, GetDevice());
       data()->view = UpdateView(data()->view, std::move(ir_value));
     }
   }


### PR DESCRIPTION
When updating a view's IR node, we should not place the data on virtual device. When the IR value is created on virtual device, the node's DataPtr will be a placeholder and the IR does not track a reference to the underlying tensor. This results in a null buffer being used in the computation.

I have added a unit test which captures a minimal reproduction of the problem. It fails with `buffer is null` without this change but passes with it.