### PR TITLE
[StableHLO] Add MLIR optimization pass to remove Tuple outputs in MHLO/StableHLO

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -841,7 +841,7 @@ def mark_step(wait=False):
   torch_xla._XLAC._set_all_reduce_token(devctx.device, None)
 
 
-def get_stablehlo(tensors=[]):
+def get_stablehlo(tensors=None):
   """Get StableHLO for the computation graph in string format.
 
   If `tensors` is not empty, the graph with `tensors` as outputs will be dump.
@@ -858,6 +858,8 @@ def get_stablehlo(tensors=[]):
   Returns:
     StableHLO Module in string format.
   """
+  if tensors is None:
+    tensors = []
   return torch_xla._XLAC._get_stablehlo(
       tensors, torch_xla._XLAC._xla_get_default_device(), [])
 


### PR DESCRIPTION
#### Background
By default, HLO->MHLO converter generates MHLO with return op with `mhlo.tuple`, that's because in HLO, multiple return values are not supported, multiple return values are packed into a tuple. The tuple output in MHLO got propagated to StableHLO. It makes more sense 

#### Changes
- Add optimization pass to expand the return op with tuple, then apply Canonicalization pass to remove the unused tuple op.
- Enhancement in `get_stablehlo` API, update the default argument from an empty list to `None`, to align with the Python best practice.

#### Before Optimizatoin
```
module @IrToHlo.12 attributes {mhlo.cross_program_prefetches = [], mhlo.dynamic_parameter_bindings = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
  func.func @main(%arg0: tensor<10x3x100x100xf32>, %arg1: tensor<10x3x100x100xf32>) -> tuple<tensor<10x3x100x100xf32>> {
    %0 = stablehlo.cosine %arg1 : tensor<10x3x100x100xf32>
    %1 = stablehlo.constant dense<1.000000e+00> : tensor<f32>
    %2 = stablehlo.constant dense<1.000000e+00> : tensor<1x1x1x1xf32>
    %3 = stablehlo.reshape %2 : (tensor<1x1x1x1xf32>) -> tensor<f32>
    %4 = stablehlo.broadcast_in_dim %3, dims = [] : (tensor<f32>) -> tensor<10x3x100x100xf32>
    %5 = stablehlo.multiply %arg0, %4 : tensor<10x3x100x100xf32>
    %6 = stablehlo.add %0, %5 : tensor<10x3x100x100xf32>
    %7 = stablehlo.tuple %6 {xla_shape = "(f32[10,3,100,100]{3,2,1,0})"} : tuple<tensor<10x3x100x100xf32>>
    return %7 : tuple<tensor<10x3x100x100xf32>>
  }
}
```
#### After
```
module @IrToHlo.12 attributes {mhlo.cross_program_prefetches = [], mhlo.dynamic_parameter_bindings = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
  func.func @main(%arg0: tensor<10x3x100x100xf32>, %arg1: tensor<10x3x100x100xf32>) -> tensor<10x3x100x100xf32> {
    %0 = stablehlo.cosine %arg1 : tensor<10x3x100x100xf32>
    %1 = stablehlo.add %0, %arg0 : tensor<10x3x100x100xf32>
    return %1 : tensor<10x3x100x100xf32>
  }
}
```