### PR TITLE
Implement SPMDSavePlanner to take distributed checkpoints

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -191,6 +191,7 @@ function run_xla_op_tests {
   run_test "$CDIR/spmd/test_xla_sharding.py"
   run_test "$CDIR/spmd/test_xla_virtual_device.py"
   run_test "$CDIR/spmd/test_dynamo_spmd.py"
+  run_test "$CDIR/spmd/test_xla_distributed_checkpoint.py"
   run_test "$CDIR/test_operations_hlo.py" "$@" --verbosity=$VERBOSITY
   run_test "$CDIR/test_input_output_aliases.py"
   run_test "$CDIR/test_torch_distributed_xla_backend.py"

--- a/torch_xla/experimental/_distributed_checkpoint_helpers.py
+++ b/torch_xla/experimental/_distributed_checkpoint_helpers.py
@@ -1,0 +1,170 @@
+# TODO(jonbolin): These are copies of some upstream APIs which are not yet
+# stable. Once the upstream makes these stable, we should take a dependency on
+# their APIs.
+
+import torch
+
+from torch.distributed.checkpoint.planner import SavePlan
+from typing import (
+    Callable,
+    Collection,
+    Dict,
+    List,
+    Mapping,
+    MutableMapping,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+)
+from torch.distributed.checkpoint.metadata import (
+    STATE_DICT_TYPE,)
+
+PATH_ITEM = Union[str, int]
+OBJ_PATH = Tuple[PATH_ITEM, ...]
+FLATTEN_MAPPING = Dict[str, OBJ_PATH]
+
+STATE_DICT_ITEM = object
+CONTAINER_TYPE = MutableMapping[PATH_ITEM, STATE_DICT_ITEM]
+
+
+def _keep_visiting_tensors(value: STATE_DICT_ITEM) -> bool:
+  return isinstance(value, torch.Tensor)
+
+
+def _traverse_state_dict(
+    state_dict: STATE_DICT_TYPE,
+    visitor: Callable[[OBJ_PATH, STATE_DICT_ITEM], None],
+    keep_traversing: Callable[[STATE_DICT_ITEM], bool] = _keep_visiting_tensors,
+) -> None:
+  """
+    Invoke ``visitor`` for each value recursively in ``state_dict``.
+    Traversal is short-circuited when if finds a collection for which ``keep_visiting_tensors`` evaluates
+    to false for all elements.
+    By default, all collections with at least one ``torch.Tensor`` element are traversed.
+    Visitor takes a path argument that is a tuple of the keys used to reach it.
+    """
+
+  # a value is terminal if it has no other containers values inside it
+  def _is_terminal(value: STATE_DICT_ITEM) -> bool:
+    values: Collection[STATE_DICT_ITEM]
+    if isinstance(value, Mapping):
+      values = value.values()
+    elif isinstance(value, list):
+      values = value
+    else:
+      return True
+
+    for entry in values:
+      if isinstance(entry, (Mapping, list)) and not _is_terminal(entry):
+        return False
+      if keep_traversing is not None and keep_traversing(entry):
+        return False
+    return True
+
+  def _traverse_obj(path: OBJ_PATH, value: STATE_DICT_ITEM) -> None:
+    if _is_terminal(value):
+      visitor(path, value)
+    elif isinstance(value, Mapping):
+      for k, v in value.items():
+        _traverse_obj(path + (str(k),), v)
+    elif isinstance(value, list):
+      for i, v in enumerate(value):
+        _traverse_obj(path + (i,), v)
+
+  for key, value in state_dict.items():
+    _traverse_obj((str(key),), value)
+
+
+# TODO(jonbolin): Take a dependency on the upstream implementation when the APIs
+# are stable
+# https://github.com/pytorch/pytorch/blob/d1cecd9c32ba700c27f2b0716bf2cbef41469495/torch/distributed/checkpoint/_traverse.py#L80
+def set_element(root_dict: STATE_DICT_TYPE, path: OBJ_PATH,
+                value: STATE_DICT_ITEM) -> None:
+  """
+    Set ``value`` in ``root_dict`` along the ``path`` object path.
+    """
+  cur_container = cast(CONTAINER_TYPE, root_dict)
+
+  def extend_list(lst: List[STATE_DICT_ITEM], idx: int) -> None:
+    while len(lst) <= idx:
+      lst.append(None)
+
+  for i in range(1, len(path)):
+    prev_key = path[i - 1]
+    key = path[i]
+    def_val = cast(STATE_DICT_ITEM, {} if type(key) == str else [])
+
+    if isinstance(cur_container, Mapping):
+      cur_container = cast(CONTAINER_TYPE,
+                           cur_container.setdefault(prev_key, def_val))
+    else:
+      extend_list(cur_container, prev_key)
+      if cur_container[prev_key] is None:
+        cur_container[prev_key] = def_val
+      cur_container = cur_container[prev_key]
+
+  key = path[-1]
+  if type(key) == int:
+    extend_list(cast(List[STATE_DICT_ITEM], cur_container), key)
+
+  cur_container[key] = value
+
+
+# TODO(jonbolin): Take a dependency on the upstream implementation when the APIs
+# are stable
+# https://github.com/pytorch/pytorch/blob/d1cecd9c32ba700c27f2b0716bf2cbef41469495/torch/distributed/checkpoint/_nested_dict.py#L27
+def flatten_state_dict(
+    state_dict: STATE_DICT_TYPE,) -> Tuple[STATE_DICT_TYPE, FLATTEN_MAPPING]:
+  """
+    Flatten ``state_dict`` made of nested dicts and lists into a top level dictionary.
+    Use ``unflatten_state_dict`` to revert this process.
+    Returns:
+        A tuple with the flatten state_dict and a mapping from original to new state_dict.
+    N.B. The new keys are derived from the object paths, joined by dot.
+        For example: ``{ 'a': {'b':...}}`` results in the key `a.b`.
+    """
+  flattened: STATE_DICT_TYPE = {}
+  mappings: FLATTEN_MAPPING = {}
+
+  def flat_copy(path: OBJ_PATH, value: STATE_DICT_ITEM) -> None:
+    new_fqn = ".".join(map(str, path))
+    if new_fqn in flattened:
+      raise ValueError(f"duplicated flatten key {new_fqn}")
+    flattened[new_fqn] = value
+    mappings[new_fqn] = path
+
+  _traverse_state_dict(state_dict, flat_copy)
+  return flattened, mappings
+
+
+# TODO(jonbolin): Take a dependency on the upstream implementation when the APIs
+# are stable.
+# https://github.com/pytorch/pytorch/blob/d1cecd9c32ba700c27f2b0716bf2cbef41469495/torch/distributed/checkpoint/_dedup_tensors.py#L29
+def dedup_tensors(all_plans: List[SavePlan]) -> List[SavePlan]:
+  all_plans = list(all_plans)
+  key_to_plan: Dict[MetadataIndex, List[int]] = {}
+  for plan_idx, plan in enumerate(all_plans):
+    for write_item in plan.items:
+      key_to_plan.setdefault(write_item.index, []).append(plan_idx)
+
+  replicated_items = {k: v for k, v in key_to_plan.items() if len(v) > 1}
+
+  # Remove duplicates by always keeping the first entry.
+  # Compute the per-rank remove set.
+  plan_to_keys: Dict[int, List[MetadataIndex]] = {}
+  for key, plans in replicated_items.items():
+    for plan_idx in plans[1:]:
+      plan_to_keys.setdefault(plan_idx, []).append(key)
+
+  for plan_idx, keys in plan_to_keys.items():
+    key_set = set(keys)
+    # rewrite items and remove elements
+    new_items = [
+        write_item for write_item in all_plans[plan_idx].items
+        if write_item.index not in key_set
+    ]
+    all_plans[plan_idx] = dataclasses.replace(
+        all_plans[plan_idx], items=new_items)
+
+  return all_plans

--- a/torch_xla/experimental/distributed_checkpoint.py
+++ b/torch_xla/experimental/distributed_checkpoint.py
@@ -32,7 +32,6 @@ from torch.distributed.checkpoint.metadata import (
     STATE_DICT_TYPE,
 )
 from torch.distributed.checkpoint.utils import find_state_dict_object
-from torch.distributed._shard._utils import narrow_tensor_by_index
 from torch.utils._pytree import tree_map
 from torch_xla.experimental.xla_sharding import (XLAShardedTensor, XLAShard,
                                                  ShardingType)
@@ -41,6 +40,7 @@ from torch_xla.experimental._distributed_checkpoint_helpers import (
     flatten_state_dict,
     dedup_tensors,
     set_element,
+    narrow_tensor_by_index,
 )
 from typing import Any, Dict, List, Tuple, Union
 

--- a/torch_xla/experimental/distributed_checkpoint.py
+++ b/torch_xla/experimental/distributed_checkpoint.py
@@ -31,17 +31,17 @@ from torch.distributed.checkpoint.metadata import (
     Metadata,
     STATE_DICT_TYPE,
 )
-from torch.distributed.checkpoint._nested_dict import (
-    FLATTEN_MAPPING,
-    flatten_state_dict,
-)
 from torch.distributed.checkpoint.utils import find_state_dict_object
-from torch.distributed.checkpoint._dedup_tensors import dedup_tensors
-from torch.distributed.checkpoint._traverse import set_element
 from torch.distributed._shard._utils import narrow_tensor_by_index
 from torch.utils._pytree import tree_map
 from torch_xla.experimental.xla_sharding import (XLAShardedTensor, XLAShard,
                                                  ShardingType)
+from torch_xla.experimental._distributed_checkpoint_helpers import (
+    FLATTEN_MAPPING,
+    flatten_state_dict,
+    dedup_tensors,
+    set_element,
+)
 from typing import Any, Dict, List, Tuple, Union
 
 __all__ = [

--- a/torch_xla/experimental/distributed_checkpoint.py
+++ b/torch_xla/experimental/distributed_checkpoint.py
@@ -75,7 +75,8 @@ class SPMDSavePlanner(SavePlanner):
     # Upon the first `resolve_data` call for a WriteItem associated with a
     # sharded tensor, all local shards are moved to CPU via
     # `XLAShardedTensor::local_shards` and are tracked in `_local_shards` until
-    # the shard's data is resolved.
+    # the shard's data is resolved. This allows only transferring the shards
+    # to CPU once.
     self._local_shards: Dict[str, List[XLAShard]] = {}
 
   def set_up_planner(self, state_dict: STATE_DICT_TYPE,

--- a/torch_xla/experimental/distributed_checkpoint.py
+++ b/torch_xla/experimental/distributed_checkpoint.py
@@ -1,12 +1,16 @@
+import dataclasses
 import io
 import numpy as np
 import torch
 import torch_xla
 import torch_xla.experimental.xla_sharding as xs
 
+from collections import ChainMap
 from torch.distributed.checkpoint.default_planner import (
     create_default_local_load_plan,
     create_default_global_load_plan,
+    create_default_local_save_plan,
+    create_default_global_save_plan,
 )
 from torch.distributed.checkpoint.planner import (
     SavePlanner,
@@ -15,6 +19,9 @@ from torch.distributed.checkpoint.planner import (
     LoadPlan,
     ReadItem,
     WriteItem,
+    WriteItemType,
+    TensorProperties,
+    TensorWriteData,
 )
 from torch.distributed.checkpoint.planner_helpers import (
     create_read_items_for_chunk_list,)
@@ -29,6 +36,7 @@ from torch.distributed.checkpoint._nested_dict import (
     flatten_state_dict,
 )
 from torch.distributed.checkpoint.utils import find_state_dict_object
+from torch.distributed.checkpoint._dedup_tensors import dedup_tensors
 from torch.distributed.checkpoint._traverse import set_element
 from torch.distributed._shard._utils import narrow_tensor_by_index
 from torch.utils._pytree import tree_map
@@ -45,26 +53,108 @@ __all__ = [
 class SPMDSavePlanner(SavePlanner):
   """
   SPMDSavePlanner provides an implementation of the SavePlanner interface
-  which handles state_dicts containing XLAShardedTensor or List[XLAShard].
+  which handles state_dicts containing XLAShardedTensor.
+
+  This implementation is based on the DefaultSavePlanner from
+  https://github.com/pytorch/pytorch/blob/main/torch/distributed/checkpoint/default_planner.py
   """
+
+  def __init__(self):
+    # Whether this host is the checkpoint coordinator
+    self.is_coordinator: bool = False
+
+    # Mappings created after flattening the state_dict
+    self.mappings: FLATTEN_MAPPING = None
+
+    # Flattened state_dict tracking all sharded tensors to be checkpointed
+    self.sharded_state_dict: Dict[str, XLAShardedTensor] = None
+
+    # Flattend state_dict tracking all other state_dict items
+    self.unsharded_state_dict: Dict[str, Any] = None
+
+    # Upon the first `resolve_data` call for a WriteItem associated with a
+    # sharded tensor, all local shards are moved to CPU via
+    # `XLAShardedTensor::local_shards` and are tracked in `_local_shards` until
+    # the shard's data is resolved.
+    self._local_shards: Dict[str, List[XLAShard]] = {}
 
   def set_up_planner(self, state_dict: STATE_DICT_TYPE,
                      is_coordinator: bool) -> None:
-    raise NotImplemented
+    self.is_coordinator = is_coordinator
+
+    # Flatten the state_dict to allow separating sharded XLA tensors from
+    # types that can be handled by the default planner, and ensure all sharded
+    # tensors are wrapped in XLAShardedTensor
+    state_dict, self.mappings = flatten_state_dict(state_dict)
+    state_dict = tree_map(xs.wrap_if_sharded, state_dict)
+
+    # Select only XLAShardedTensors which are not replicated, since the
+    # default planner can handle everything else.
+    self.sharded_state_dict = {
+        k: v for k, v in state_dict.items() if _is_sharded_tensor(v)
+    }
+    unsharded = dict(state_dict.items() - self.sharded_state_dict.items())
+    self.unsharded_state_dict = tree_map(_unwrap_xla_sharded_tensor, unsharded)
 
   def create_local_plan(self) -> SavePlan:
-    raise NotImplemented
+    # Create the save plan for unsharded data
+    plan = create_default_local_save_plan(self.unsharded_state_dict,
+                                          self.is_coordinator)
+    # Track the flattened mappings in the plan metadata
+    plan = dataclasses.replace(plan, planner_data=self.mappings)
+
+    # Extend the plan for sharded tensor data
+    xla_write_items = _create_xla_write_items(self.sharded_state_dict)
+    plan.items.extend(xla_write_items)
+    return plan
 
   def create_global_plan(
       self, all_plans: List[SavePlan]) -> Tuple[List[SavePlan], Metadata]:
-    raise NotImplemented
+    # Deduplicate write items across plans
+    all_plans = dedup_tensors(all_plans)
+
+    global_plan, metadata = create_default_global_save_plan(all_plans)
+
+    # Combine mappings from all plans
+    planner_data_dict = [p.planner_data for p in global_plan]
+    merged_mappings = dict(ChainMap(*planner_data_dict))
+    metadata = dataclasses.replace(metadata, planner_data=merged_mappings)
+
+    return global_plan, metadata
 
   def finish_plan(self, new_plan: SavePlan) -> SavePlan:
-    raise NotImplemented
+    return new_plan
 
   def resolve_data(self,
                    write_item: WriteItem) -> Union[torch.Tensor, io.BytesIO]:
-    raise NotImplemented
+    obj = self.lookup_object(write_item.index)
+    return self.transform_object(write_item, obj)
+
+  def lookup_object(self, index: MetadataIndex) -> Any:
+    if index.fqn in self.unsharded_state_dict:
+      return self.unsharded_state_dict[index.fqn]
+
+    if index.fqn not in self._local_shards:
+      xtensor = self.sharded_state_dict[index.fqn]
+      assert isinstance(xtensor,
+                        XLAShardedTensor), f"Unsupported object type: {xtensor}"
+      self._local_shards[index.fqn] = xtensor.local_shards
+
+    shard = self._local_shards[index.fqn][index.index]
+    assert shard is not None, f"WriteItem has already been processed: {index}"
+    assert index.offset == torch.Size(
+        ind.start for ind in shard.indices
+    ), "WriteItem does not correspond to the correct shard"
+    # Release the local shard
+    self._local_shards[index.fqn][index.index] = None
+    return shard.unpadded_data
+
+  def transform_object(self, write_item: WriteItem, object: Any):
+    if write_item.type == WriteItemType.BYTE_IO:
+      bytes = io.BytesIO()
+      torch.save(object, bytes)
+      object = bytes
+    return object
 
 
 class SPMDLoadPlanner(LoadPlanner):
@@ -212,6 +302,52 @@ class SPMDLoadPlanner(LoadPlanner):
       # from CPU
       local_shards = self._local_shards.pop(fqn)
       self.sharded_state_dict[fqn].load_local_shards_(local_shards)
+
+
+def _create_write_item_from_indices(fqn: str, shard_index: int,
+                                    indices: List[slice],
+                                    global_size: torch.Size,
+                                    properties: TensorProperties) -> WriteItem:
+  offsets = torch.Size(ind.start for ind in indices)
+  sizes = torch.Size(ind.stop - ind.start for ind in indices)
+  return WriteItem(
+      index=MetadataIndex(fqn, offsets, shard_index),
+      type=WriteItemType.SHARD,
+      tensor_data=TensorWriteData(
+          chunk=ChunkStorageMetadata(
+              offsets=offsets,
+              sizes=sizes,
+          ),
+          properties=properties,
+          size=global_size,
+      ),
+  )
+
+
+def _create_write_items_for_xla_sharded_tensor(
+    fqn: str, t: XLAShardedTensor) -> List[WriteItem]:
+  items = []
+  # Since local shards are currently moved to CPU on creation, we need to get
+  # the shard indices indirectly to avoid unnecessarily consuming host memory.
+  shard_indices = torch_xla._XLAC._get_local_shard_indices(t.global_tensor)
+  prop = TensorProperties.create_from_tensor(t)
+  for shard_ind, indices in enumerate(shard_indices):
+    write_item = _create_write_item_from_indices(fqn, shard_ind, indices,
+                                                 t.size(), prop)
+    items.append(write_item)
+  return items
+
+
+def _create_xla_write_items(state_dict: STATE_DICT_TYPE) -> List[WriteItem]:
+  """
+  Iterate through the state_dict and return WriteItems for all local shards
+  """
+  items = []
+  for fqn, v in state_dict.items():
+    assert isinstance(v, XLAShardedTensor
+                     ), '_create_xla_write_items only accepts XLAShardedTensor'
+    items.extend(_create_write_items_for_xla_sharded_tensor(fqn, v))
+  return items
 
 
 def _create_chunk_from_shard_index(index: List[slice]) -> ChunkStorageMetadata:


### PR DESCRIPTION
This implements the [SavePlanner interface](https://github.com/pytorch/pytorch/blob/2800a04a17d727dc12353dbea4f4007682194822/torch/distributed/checkpoint/planner.py#L92) from torch.distributed.checkpoint. This implementation only directly handles sharded tensors and relies on the default planner's logic for everything else.

A high-level overview of each of the SavePlanner interface methods:

`set_up_planner`: Called with the state_dict to be checkpointed. Our implementation will split the state_dict into a sharded and unsharded portion so that we can defer to the default planner logic for the unsharded part.
`create_local_plan`: WriteItems are generated for every item in the state_dict. The default planner is used for the unsharded objects, and we generate a WriteItem for each shard of each XLAShardedTensor with non-REPLICATED sharding type.
`create_global_plan`: The coordinator process makes any global decisions for the restoration. There is no custom logic here.
`finish_plan`: The process can adjust its plan after global coordination. Again, no custom logic here.
`resolve_data`: Return the data to be written for a given WriteItem. We return the local shard for sharded tensors or relevant portions

This change also enables distributed checkpointing tests in CI.