### PR TITLE
[OpenXLA] Delete `core:lib` in `libxla_computation_client.so`

### DIFF
--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -566,7 +566,6 @@ cc_binary(
         "@org_tensorflow//tensorflow/compiler/xla/client:xla_builder",
         "@org_tensorflow//tensorflow/compiler/xla/client:xla_computation",
         "@org_tensorflow//tensorflow/compiler/xla/client/lib:svd",
-        "@org_tensorflow//tensorflow/core:lib",
         "@org_tensorflow//tensorflow/tsl/platform/cloud:gcs_file_system",
     ],
 )


### PR DESCRIPTION
Before migrate to pull XLA from OpenXLA, PyTorch/XLA delete/replace some unused deps from TensorFlow to OpenXLA