### PR TITLE
[OpenXLA] Delete `core:lib` in `torch_xla/csrc/BUILD`

### DIFF
--- a/torch_xla/csrc/BUILD
+++ b/torch_xla/csrc/BUILD
@@ -146,7 +146,6 @@ ptxla_cc_library(
         "@org_tensorflow//tensorflow/compiler/xla/client/lib:sorting",
         "@org_tensorflow//tensorflow/compiler/xla/client/lib:svd",
         "@org_tensorflow//tensorflow/compiler/xla/stream_executor:dnn",
-        "@org_tensorflow//tensorflow/core:lib",
         "@org_tensorflow//tensorflow/core/framework:tensor_shape",
         "@org_tensorflow//tensorflow/core/lib/core:errors",
         "@org_tensorflow//tensorflow/core/lib/gtl:inlined_vector",


### PR DESCRIPTION
Before migrate to pull XLA from OpenXLA, PyTorch/XLA delete/replace deps from TensorFlow to OpenXLA