### PR TITLE
[Functionalization] Remove View in tensor_methods::narrow

### DIFF
--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1841,15 +1841,15 @@ XLATensorPtr narrow(const XLATensorPtr& input, int64_t dim, int64_t start,
   if (runtime::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
     ViewInfo::Type view_type = (xla::ShapeUtil::ElementsIn(input_shape) ==
                                 xla::ShapeUtil::ElementsIn(narrow_shape))
-                                  ? ViewInfo::Type::kReshape
-                                  : ViewInfo::Type::kNarrow;
+                                   ? ViewInfo::Type::kReshape
+                                   : ViewInfo::Type::kNarrow;
     ViewInfo view_info(view_type, std::move(narrow_shape), input_shape);
     view_info.indices[dim] = indices[dim];
     return input->CreateViewTensor(std::move(view_info));
   }
 
-  return input->CreateFrom(torch::lazy::MakeNode<GenericSlice>(input->GetIrValue(), std::move(indices),
-                                                 narrow_shape.dimensions()));
+  return input->CreateFrom(torch::lazy::MakeNode<GenericSlice>(
+      input->GetIrValue(), std::move(indices), narrow_shape.dimensions()));
 }
 
 std::tuple<XLATensorPtr, XLATensorPtr, XLATensorPtr> native_batch_norm(

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1838,6 +1838,10 @@ XLATensorPtr narrow(const XLATensorPtr& input, int64_t dim, int64_t start,
           input_shape.get().dimensions()),
       dim, start);
   return input->CreateViewTensor(std::move(view_info));
+
+
+  torch::lazy::MakeNode<GenericSlice>(ir_value, view_info.indices,
+                                                 view_info.shape.dimensions());
 }
 
 std::tuple<XLATensorPtr, XLATensorPtr, XLATensorPtr> native_batch_norm(

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -53,6 +53,7 @@
 #include "torch_xla/csrc/ops/flip.h"
 #include "torch_xla/csrc/ops/gather.h"
 #include "torch_xla/csrc/ops/generic.h"
+#include "torch_xla/csrc/ops/generic_slice.h"
 #include "torch_xla/csrc/ops/get_dimensions_size.h"
 #include "torch_xla/csrc/ops/hardtanh_backward.h"
 #include "torch_xla/csrc/ops/index_ops.h"
@@ -131,6 +132,7 @@
 #include "torch_xla/csrc/ops/view.h"
 #include "torch_xla/csrc/runtime/debug_macros.h"
 #include "torch_xla/csrc/runtime/metrics.h"
+#include "torch_xla/csrc/runtime/sys_util.h"
 #include "torch_xla/csrc/runtime/util.h"
 #include "torch_xla/csrc/runtime/xla_util.h"
 #include "torch_xla/csrc/shape_builder.h"
@@ -1825,23 +1827,29 @@ XLATensorPtr narrow(const XLATensorPtr& input, int64_t dim, int64_t start,
                     int64_t length) {
   auto input_shape = input->shape();
   dim = torch::lazy::GetCanonicalDimensionIndex(dim, input_shape.get().rank());
+
   xla::Shape narrow_shape = input_shape;
   narrow_shape.set_dimensions(dim, length);
 
-  ViewInfo::Type view_type = (xla::ShapeUtil::ElementsIn(input_shape) ==
-                              xla::ShapeUtil::ElementsIn(narrow_shape))
-                                 ? ViewInfo::Type::kReshape
-                                 : ViewInfo::Type::kNarrow;
-  ViewInfo view_info(view_type, std::move(narrow_shape), input_shape);
-  view_info.indices[dim] = torch::lazy::GetCanonicalPosition(
+  std::vector<int64_t> indices(input_shape.get().rank(), 0);
+  indices[dim] = torch::lazy::GetCanonicalPosition(
       torch_xla::runtime::util::ToVector<int64_t>(
           input_shape.get().dimensions()),
       dim, start);
-  return input->CreateViewTensor(std::move(view_info));
 
+  // See Note: [Disabling functionalization]
+  if (runtime::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
+    ViewInfo::Type view_type = (xla::ShapeUtil::ElementsIn(input_shape) ==
+                                xla::ShapeUtil::ElementsIn(narrow_shape))
+                                  ? ViewInfo::Type::kReshape
+                                  : ViewInfo::Type::kNarrow;
+    ViewInfo view_info(view_type, std::move(narrow_shape), input_shape);
+    view_info.indices[dim] = indices[dim];
+    return input->CreateViewTensor(std::move(view_info));
+  }
 
-  torch::lazy::MakeNode<GenericSlice>(ir_value, view_info.indices,
-                                                 view_info.shape.dimensions());
+  return input->CreateFrom(torch::lazy::MakeNode<GenericSlice>(input->GetIrValue(), std::move(indices),
+                                                 narrow_shape.dimensions()));
 }
 
 std::tuple<XLATensorPtr, XLATensorPtr, XLATensorPtr> native_batch_norm(

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -124,11 +124,11 @@ class ShardingUtil {
       std::vector<torch::lazy::BackendDataPtr>* data_placeholders,
       std::vector<XLATensor::ShardingSpecPtr>* sharding_specs);
 
-    // Mimic the function above, but for dynamo code path. 
-    // One subtle difference is that in dynamo code path, we don't
-    // have explicit `tensors`. However, we have `output_shapes` and
-    // `device` which were what the `tensors` were used for in the original
-    // `PrepareOutputShardingPropagation` function.
+  // Mimic the function above, but for dynamo code path.
+  // One subtle difference is that in dynamo code path, we don't
+  // have explicit `tensors`. However, we have `output_shapes` and
+  // `device` which were what the `tensors` were used for in the original
+  // `PrepareOutputShardingPropagation` function.
   static void PrepareOutputShardingPropagation(
       std::vector<torch::lazy::BackendDataPtr>& placeholders,
       std::vector<XLATensor::ShardingSpecPtr>& sharding_specs,


### PR DESCRIPTION
Summary:
This pull request removes the View path in tensor_methods::narrow when
Functionalization is enabled.

Test Plan:
PJRT_DEVICE=CPU python ../test/test_view_ops.py -v -k TestViewOpsXLA.test_narrow
PJRT_DEVICE=CPU XLA_DISABLE_FUNCTIONALIZATION=1 python ../test/test_view_ops.py -v -k TestViewOpsXLA.test_narrow