### PR TITLE
[Functionalization] Remove View in tensor_methods::diagonal

### DIFF
--- a/test/cpp/test_aten_xla_tensor_3.cpp
+++ b/test/cpp/test_aten_xla_tensor_3.cpp
@@ -86,6 +86,8 @@ TEST_F(AtenXlaTensorTest, TestDiagonal) {
       AllClose(output, xla_output);
     });
   }
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::diagonal", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestDiagonalNonSquare) {


### PR DESCRIPTION
[Functionalization] Remove View in tensor_methods::diagonal

---

Test plan:
- Python test (verified passing locally): `PJRT_DEVICE=CPU python ../test/test_view_ops.py -v -k TestViewOpsXLA.test_diagonal_view`

- CPP test (didn't run as building cpp test fails locally, I'll let CI verify): `source /workspace/scripts/xlaCppTest.sh Diagonal`