### PR TITLE
[Functionalization] Remove View in tensor_methods::permute

### DIFF
--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2071,8 +2071,8 @@ XLATensorPtr permute(const XLATensorPtr& input,
     return input->CreateViewTensor(std::move(view_info));
   }
 
-  return input->CreateFrom(torch::lazy::MakeNode<Permute>(
-      input->GetIrValue(), dimensions));
+  return input->CreateFrom(
+      torch::lazy::MakeNode<Permute>(input->GetIrValue(), dimensions));
 }
 
 XLATensorPtr pow(const XLATensorPtr& input, const at::Scalar& exponent) {

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2072,7 +2072,7 @@ XLATensorPtr permute(const XLATensorPtr& input,
   }
 
   return input->CreateFrom(torch::lazy::MakeNode<Permute>(
-      input->GetIrValue(), xla::InversePermutation(dimensions)));
+      input->GetIrValue(), dimensions));
 }
 
 XLATensorPtr pow(const XLATensorPtr& input, const at::Scalar& exponent) {


### PR DESCRIPTION
[Functionalization] Remove View in tensor_methods::permute

---

Test plan 

- Passing locally: `PJRT_DEVICE=CPU python ../test/test_view_ops.py -v -k TestViewOpsXLA.test_permute_view`
