### PR TITLE
[Functionalization] Remove views in alias

### DIFF
--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2717,9 +2717,13 @@ XLATensorPtr upsample_nearest2d_backward(const XLATensorPtr& grad_output,
 
 XLATensorPtr alias(const XLATensorPtr& input) {
   torch::lazy::Value ir_value = input->GetIrValue();
-  ViewInfo view_info(ViewInfo::Type::kNoOp, GetXlaShape(ir_value),
+    // See Note: [Disabling functionalization]
+  if (runtime::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
+    ViewInfo view_info(ViewInfo::Type::kNoOp, GetXlaShape(ir_value),
                      GetXlaShape(ir_value));
-  return input->CreateViewTensor(std::move(view_info));
+    return input->CreateViewTensor(std::move(view_info));
+  }
+  return input->CreateFrom(ir_value);
 }
 
 XLATensorPtr view(const XLATensorPtr& input,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2717,10 +2717,10 @@ XLATensorPtr upsample_nearest2d_backward(const XLATensorPtr& grad_output,
 
 XLATensorPtr alias(const XLATensorPtr& input) {
   torch::lazy::Value ir_value = input->GetIrValue();
-    // See Note: [Disabling functionalization]
+  // See Note: [Disabling functionalization]
   if (runtime::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
     ViewInfo view_info(ViewInfo::Type::kNoOp, GetXlaShape(ir_value),
-                     GetXlaShape(ir_value));
+                       GetXlaShape(ir_value));
     return input->CreateViewTensor(std::move(view_info));
   }
   return input->CreateFrom(ir_value);


### PR DESCRIPTION
Summary:
Remove the usage of CreateViewTensor in tensor_methods::alias.

Test Plan:
CI.