### PR TITLE
Revert "[OpenXLA] Replace `core:lib` in `util` from TensorFlow to ten…

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -167,7 +167,7 @@ build:linux --config=dynamic_kernels
 # the monolitih build because otherwise there are missing dependencies and
 # linking fails.
 build --define framework_shared_object=false
-build --define tsl_protobuf_header_only=false
+build --define tsl_protobuf_header_only=true
 
 build --define=use_fast_cpp_protos=true
 build --define=allow_oversize_protos=true

--- a/test/cpp/BUILD
+++ b/test/cpp/BUILD
@@ -65,8 +65,6 @@ ptxla_cc_test(
         "//torch_xla/csrc:tensor",
         "@com_google_googletest//:gtest_main",
         "@org_tensorflow//tensorflow/compiler/xla:shape_util",
-        "@org_tensorflow//tensorflow/tsl/util:stats_calculator_test",
-        "@org_tensorflow//tensorflow/tsl/util:device_name_utils_test",
     ],
 )
 
@@ -132,7 +130,6 @@ ptxla_cc_test(
         "//torch_xla/csrc:tensor",
         "@com_google_googletest//:gtest_main",
         "@org_tensorflow//tensorflow/compiler/xla:xla_data_proto_cc",
-        "@org_tensorflow//tensorflow/tsl/profiler/utils:session_manager",
     ],
 )
 

--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -99,7 +99,6 @@ cc_library(
     ":sys_util",
     ":types",
     ":util",
-    "@org_tensorflow//tensorflow/tsl/platform:stacktrace_handler",
     "@org_tensorflow//tensorflow/compiler/xla:literal_util",
     "@org_tensorflow//tensorflow/compiler/xla/client:xla_computation",
     "@com_google_absl//absl/memory",
@@ -443,7 +442,7 @@ cc_library(
         "@com_google_absl//absl/types:span",
         "@org_tensorflow//tensorflow/compiler/xla:statusor",
         "@org_tensorflow//tensorflow/compiler/xla:types",
-        "@org_tensorflow//tensorflow/tsl/platform:hash",
+        "@org_tensorflow//tensorflow/core:lib",
     ],
 )
 


### PR DESCRIPTION
…sorflow/compiler/xla (#5197)"

This reverts commit 0eeaefb2341c3beea65545f278cdbd998f5a8399.