### PR TITLE
Add tesor debugging util API

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1772,12 +1772,12 @@ class TestDebuggingUtil(test_utils.XlaTestCase):
     t2_info = torch_xla._XLAC._get_xla_tensor_debug_info(t2)
     self.assertIn('XLA Shape: f32[5]', t2_info)
     self.assertIn('aten::add', t2_info)
-    self.assertIn('XLAData: \nNone', t2_info)
+    self.assertIn('XLAData: None', t2_info)
 
     # after makr_step XLAData should present
     xm.mark_step()
     t2_info_new = torch_xla._XLAC._get_xla_tensor_debug_info(t2)
-    self.assertNotIn('XLAData: \nNone', t2_info_new)
+    self.assertNotIn('XLAData: None', t2_info_new)
     self.assertIn('Data Shape: f32[5]', t2_info_new)
     self.assertIn('IR: None', t2_info_new)
 

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1760,6 +1760,10 @@ class TestWaitDeviceOps(test_utils.XlaTestCase):
 class TestDebuggingUtil(test_utils.XlaTestCase):
 
   def test_get_xla_tensor_debug_info(self):
+    if xu.getenv_as('XLA_USE_EAGER_DEBUG_MODE', str, '1'):
+      # ignore this test for eager debug mode since it will
+      # mess up the IR.
+      return
     device = xm.xla_device()
     # test non xla tensor
     cpu_t1 = torch.randn(5)

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -381,10 +381,10 @@ std::string GetXLATensorDebugInfo(const at::Tensor& tensor) {
   }
 
   torch::lazy::BackendDataPtr handle = xtensor->CurrentDataHandle();
-  ss << "XLAData: \n";
+  ss << "XLAData: ";
   if (handle) {
     auto data = UnwrapXlaData(handle);
-    ss << "  Data Device: " << data->device() << "\n";
+    ss << "\n  Data Device: " << data->device() << "\n";
     ss << "  Data Shape: " << data->shape().ToString() << "\n";
   } else {
     ss << "None\n";


### PR DESCRIPTION
I think having an internal API to dump XLATensor info is useful in debugging, it can dump something similar to 
```
XLATensor {
TensorID: 5
Device: CPU:0
XLA Shape: f32[5]
IR: [] aten::add, xla_shape=f32[5]{0}
XLAData: None
Tensor on host: None
}
```

I didn't include view since I assume view will not be there after we clean up the functionization pass.