### PR TITLE
[Traceable Collectives] Hide token for _xla_all_reduce_inplace

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -486,8 +486,8 @@ def all_reduce(reduce_type, inputs, scale=1.0, groups=None, pin_layout=True):
                                                groups, pin_layout)
     results = [result]
   else:
-    torch_xla._XLAC._xla_all_reduce_inplace(reduce_type, inputs,
-                                                scale, groups, pin_layout)
+    torch_xla._XLAC._xla_all_reduce_inplace(reduce_type, inputs, scale, groups,
+                                            pin_layout)
     results = inputs
 
   return results[0] if isinstance(inputs, torch.Tensor) else results

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -486,11 +486,8 @@ def all_reduce(reduce_type, inputs, scale=1.0, groups=None, pin_layout=True):
                                                groups, pin_layout)
     results = [result]
   else:
-    token, devctx = _get_all_reduce_token()
-    torch_xla._XLAC._set_all_reduce_token(
-        devctx.device,
-        torch_xla._XLAC._xla_all_reduce_inplace(reduce_type, inputs, token,
-                                                scale, groups, pin_layout))
+    torch_xla._XLAC._xla_all_reduce_inplace(reduce_type, inputs,
+                                                scale, groups, pin_layout)
     results = inputs
 
   return results[0] if isinstance(inputs, torch.Tensor) else results

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -354,7 +354,8 @@ torch::lazy::Value all_reduce(const std::vector<XLATensorPtr>& inputs,
     input_values.push_back(input->GetIrValue());
   }
   torch::lazy::NodePtr node = torch::lazy::MakeNode<AllReduce>(
-      reduce_type, input_values, GetAllReduceToken(inputs.front()->GetDevice()), scale, std::move(groups), pin_layout);
+      reduce_type, input_values, GetAllReduceToken(inputs.front()->GetDevice()),
+      scale, std::move(groups), pin_layout);
   for (size_t i = 0; i < inputs.size(); ++i) {
     inputs[i]->SetInPlaceIrValue(torch::lazy::Value(node, i));
   }

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -15,14 +15,7 @@ XLATensorPtr all_reduce(const XLATensorPtr& input, AllReduceType reduce_type,
                         double scale, std::vector<std::vector<int64_t>> groups,
                         bool pin_layout);
 
-torch::lazy::Value all_reduce_(XLATensorPtr& input,
-                               const torch::lazy::Value& token,
-                               AllReduceType reduce_type, double scale,
-                               std::vector<std::vector<int64_t>> groups,
-                               bool pin_layout);
-
-torch::lazy::Value all_reduce(std::vector<XLATensorPtr>* inputs,
-                              const torch::lazy::Value& token,
+torch::lazy::Value all_reduce(const std::vector<XLATensorPtr>& inputs,
                               AllReduceType reduce_type, double scale,
                               std::vector<std::vector<int64_t>> groups,
                               bool pin_layout);


### PR DESCRIPTION
Summary:
This is a follow up on #4913 to hide the cc tokens for _xla_all_reduce_inplace path.

Test Plan:
PJRT_DEVICE=TPU python test/test_mp_replication.py