### PR TITLE
Fix set_default_tensor_type usage since it is deprecated

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2098,7 +2098,7 @@ class TestGeneric(test_utils.XlaTestCase):
 
 
 if __name__ == '__main__':
-  torch.set_default_tensor_type('torch.FloatTensor')
+  torch.set_default_dtype(torch.float32)
   torch.manual_seed(42)
   torch_xla._XLAC._xla_set_use_full_mat_mul_precision(
       use_full_mat_mul_precision=True)


### PR DESCRIPTION
This is to fix
```
/usr/local/lib/python3.8/site-packages/torch/__init__.py:615: UserWarning: torch.set_default_tensor_type() is deprecated as of PyTorch 2.1, please use torch.set_default_dtype() and torch.set_default_device() as alternatives. (Triggered internally at /src/pytorch/torch/csrc/tensor/python_tensor.cpp:453.)
```