### PR TITLE
Add function to generate stablehlo based callable from pytorch model

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,6 +28,7 @@ xla_model
 .. autofunction:: get_rng_state
 .. autofunction:: get_memory_info
 .. autofunction:: get_stablehlo
+.. autofunction:: get_stablehlo_bytecode
 
 .. automodule:: torch_xla.core.functions
 .. autofunction:: all_reduce

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -185,7 +185,9 @@ function run_xla_op_tests {
   run_xla_ir_debug "$CDIR/test_env_var_mapper.py"
   run_xla_hlo_debug "$CDIR/test_env_var_mapper.py"
   run_xla_hlo_debug "$CDIR/stablehlo/test_stablehlo_dump.py"
-  run_xla_hlo_debug "$CDIR/stablehlo/test_stablehlo_inference.py"
+  # TODO(qihqi): this test require tensorflow to run. need to setup separate
+  #     CI with tf.
+  # run_xla_hlo_debug "$CDIR/stablehlo/test_stablehlo_inference.py"
   run_test "$CDIR/pjrt/test_runtime.py"
   run_test "$CDIR/pjrt/test_runtime_multi_cpu.py"
   run_test "$CDIR/pjrt/test_internal_tpu.py"

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -185,6 +185,7 @@ function run_xla_op_tests {
   run_xla_ir_debug "$CDIR/test_env_var_mapper.py"
   run_xla_hlo_debug "$CDIR/test_env_var_mapper.py"
   run_xla_hlo_debug "$CDIR/stablehlo/test_stablehlo_dump.py"
+  run_xla_hlo_debug "$CDIR/stablehlo/test_stablehlo_inference.py"
   run_test "$CDIR/pjrt/test_runtime.py"
   run_test "$CDIR/pjrt/test_runtime_multi_cpu.py"
   run_test "$CDIR/pjrt/test_internal_tpu.py"

--- a/test/stablehlo/test_stablehlo_inference.py
+++ b/test/stablehlo/test_stablehlo_inference.py
@@ -1,0 +1,49 @@
+import torch_xla
+import torch_xla.core.xla_model as xm
+from torch_xla.experimental.stablehlo_saved_model import export_torch_model
+import torch
+import torchvision
+
+import tempfile
+import unittest
+
+
+class StableHLOTest(unittest.TestCase):
+
+  def test_resnet18_inference(self):
+    resnet18 = torchvision.models.resnet18()
+    data = torch.randn(4, 3, 224, 224)
+    output = resnet18(data)
+    output_np = output.detach().numpy()
+
+    exported = export_torch_model(resnet18, (data,), output_np.shape,
+                                  output_np.dtype)
+    output2 = torch.tensor(exported(data.detach().numpy()).numpy())
+
+    self.assertTrue(torch.allclose(output, output2, atol=1e-5))
+
+  def test_resnet18_save_load(self):
+    import tensorflow as tf
+    resnet18 = torchvision.models.resnet18()
+    data = torch.randn(4, 3, 224, 224)
+    output = resnet18(data)
+    output_np = output.detach().numpy()
+
+    exported = export_torch_model(resnet18, (data,), output_np.shape,
+                                  output_np.dtype)
+    tf_m = tf.Module()
+    tf_m.f = tf.function(
+        exported,
+        autograph=False,
+        input_signature=[tf.TensorSpec([4, 3, 224, 224], tf.float32)])
+    with tempfile.TemporaryDirectory() as tempdir:
+      tf.saved_model.save(tf_m, tempdir)
+      loaded_m = tf.saved_model.load(tempdir)
+      res = loaded_m.f(data.detach().numpy())
+      output2 = torch.tensor(res.numpy())
+      self.assertTrue(torch.allclose(output, output2, atol=1e-5))
+
+
+if __name__ == '__main__':
+  test = unittest.main()
+  sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/stablehlo/test_stablehlo_inference.py
+++ b/test/stablehlo/test_stablehlo_inference.py
@@ -8,7 +8,7 @@ import tempfile
 import unittest
 
 
-class StableHLOTest(unittest.TestCase):
+class StableHLOInferenceTest(unittest.TestCase):
 
   def test_resnet18_inference(self):
     resnet18 = torchvision.models.resnet18()
@@ -16,8 +16,10 @@ class StableHLOTest(unittest.TestCase):
     output = resnet18(data)
     output_np = output.detach().numpy()
 
-    exported = export_torch_model(resnet18, (data,), output_np.shape,
-                                  output_np.dtype)
+    exported = export_torch_model(
+        resnet18,
+        (data,),
+    )
     output2 = torch.tensor(exported(data.detach().numpy()).numpy())
 
     self.assertTrue(torch.allclose(output, output2, atol=1e-5))
@@ -29,8 +31,10 @@ class StableHLOTest(unittest.TestCase):
     output = resnet18(data)
     output_np = output.detach().numpy()
 
-    exported = export_torch_model(resnet18, (data,), output_np.shape,
-                                  output_np.dtype)
+    exported = export_torch_model(
+        resnet18,
+        (data,),
+    )
     tf_m = tf.Module()
     tf_m.f = tf.function(
         exported,

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -838,7 +838,7 @@ def mark_step(wait=False):
   torch_xla._XLAC._set_all_reduce_token(devctx.device, None)
 
 
-def get_stablehlo(tensors=None):
+def get_stablehlo(tensors=None) -> str:
   """Get StableHLO for the computation graph in string format.
 
   If `tensors` is not empty, the graph with `tensors` as outputs will be dump.
@@ -860,7 +860,31 @@ def get_stablehlo(tensors=None):
   if tensors is None:
     tensors = []
   return torch_xla._XLAC._get_stablehlo(
-      tensors, torch_xla._XLAC._xla_get_default_device(), [])
+      tensors, torch_xla._XLAC._xla_get_default_device(), [],
+      False).decode('utf-8')
+
+
+def get_stablehlo_bytecode(tensors=None) -> bytes:
+  """Get StableHLO for the computation graph in bytecode format.
+
+  If `tensors` is not empty, the graph with `tensors` as outputs will be dump.
+  If `tensors` is empty, the whole computation graph will be dump.
+  TODO(lsy323): When `tensors` is empty, the some intermediate tensors will also be
+  dump as outputs. Need further investigation.
+
+  For inference graph, it is recommended to pass the model outputs to `tensors`.
+  For training graph, it is not straightforward to identify the "outputs". Using empty `tensors` is recommended.
+
+  Args:
+    tensors (list[torch.Tensor], optional): The tensors contained in the StableHLO graph.
+
+  Returns:
+    StableHLO Module in bytecode format.
+  """
+  if tensors is None:
+    tensors = []
+  return torch_xla._XLAC._get_stablehlo(
+      tensors, torch_xla._XLAC._xla_get_default_device(), [], True)
 
 
 def wait_device_ops(devices=[]):

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -852,7 +852,7 @@ def get_stablehlo(tensors=None) -> str:
   To enable source line info in StableHLO, please set env var XLA_HLO_DEBUG=1.
 
   Args:
-    tensors (list[torch.Tensor], optional): The tensors contained in the StableHLO graph.
+    tensors (list[torch.Tensor], optional): Tensors that represent the output/root of the StableHLO graph.
 
   Returns:
     StableHLO Module in string format.
@@ -876,7 +876,7 @@ def get_stablehlo_bytecode(tensors=None) -> bytes:
   For training graph, it is not straightforward to identify the "outputs". Using empty `tensors` is recommended.
 
   Args:
-    tensors (list[torch.Tensor], optional): The tensors contained in the StableHLO graph.
+    tensors (list[torch.Tensor], optional): Tensors that represent the output/root of the StableHLO graph.
 
   Returns:
     StableHLO Module in bytecode format.

--- a/torch_xla/csrc/debug_util.cpp
+++ b/torch_xla/csrc/debug_util.cpp
@@ -80,7 +80,7 @@ std::string DebugUtil::GetTensorsGraphHlo(
   }
   return DumpUtil::ToHlo(root_values,
                          unique_device ? *unique_device : GetCurrentDevice(),
-                         /*to_stablehlo=*/dump_stablehlo);
+                         EmitMode::kStableHloReadable);
 }
 
 std::string DebugUtil::GetTensorsGraphInfo(
@@ -140,7 +140,7 @@ std::string DebugUtil::GetTensorsGraphInfo(
   } else if (format == GraphFormat::kStableHlo) {
     graph_str = DumpUtil::ToHlo(
         root_values, unique_device ? *unique_device : GetCurrentDevice(),
-        /*to_stablehlo=*/true);
+        EmitMode::kStableHloReadable);
   } else {
     XLA_ERROR() << "Invalid graph format: " << format;
   }

--- a/torch_xla/csrc/ir_dump_util.cpp
+++ b/torch_xla/csrc/ir_dump_util.cpp
@@ -254,7 +254,7 @@ std::string DumpUtil::PostOrderToText(
 
 std::string DumpUtil::ToHlo(c10::ArrayRef<torch::lazy::Value> values,
                             const torch::lazy::BackendDevice& device,
-                            bool to_stable_hlo) {
+                            EmitMode mode) {
   LoweringContext lowering_ctx("IrToHlo", device);
   for (auto& ir_value : values) {
     lowering_ctx.AddResult(
@@ -280,10 +280,15 @@ std::string DumpUtil::ToHlo(c10::ArrayRef<torch::lazy::Value> values,
             runtime::GetComputationClient()->Compile(std::move(instances));
     computation = std::move(computations[0]->move_computation());
   }
-  if (to_stable_hlo) {
-    return runtime::hloToStablehloStr(&computation.proto());
-  } else {
-    return ConsumeValue(runtime::util::GetComputationHloText(computation));
+  switch (mode) {
+    case EmitMode::kHloReadable:
+      return ConsumeValue(runtime::util::GetComputationHloText(computation));
+    case EmitMode::kStableHloReadable:
+      return runtime::hloToStablehlo(&computation.proto(),
+                                     /* emit_bytecode = */ false);
+    case EmitMode::kStableHloBytecode:
+      return runtime::hloToStablehlo(&computation.proto(),
+                                     /* emit_bytecode = */ true);
   }
 }
 

--- a/torch_xla/csrc/ir_dump_util.h
+++ b/torch_xla/csrc/ir_dump_util.h
@@ -10,6 +10,13 @@
 
 namespace torch_xla {
 
+enum class EmitMode {
+    kHloReadable,
+    kStableHloReadable,
+    kStableHloBytecode,
+};
+
+
 class DumpUtil {
  public:
   static std::string ToDot(absl::Span<const torch::lazy::Node* const> nodes);
@@ -26,7 +33,7 @@ class DumpUtil {
 
   static std::string ToHlo(c10::ArrayRef<torch::lazy::Value> values,
                            const torch::lazy::BackendDevice& device,
-                           bool to_stablehlo = false);
+                           EmitMode mode = EmitMode::kHloReadable);
 };
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -364,6 +364,7 @@ cc_library(
         "@org_tensorflow//tensorflow/compiler/xla/translate/hlo_to_mhlo:hlo_to_mlir_hlo",
         "@org_tensorflow//tensorflow/compiler/xla/translate/mhlo_to_hlo:mlir_hlo_to_hlo",
         "@org_tensorflow//tensorflow/compiler/xla/mlir_hlo:all_passes",
+        "@stablehlo//:stablehlo_serialization",
     ],
 )
 

--- a/torch_xla/csrc/runtime/stablehlo_helper.h
+++ b/torch_xla/csrc/runtime/stablehlo_helper.h
@@ -6,7 +6,7 @@
 namespace torch_xla {
 namespace runtime {
 
-std::string hloToStablehloStr(const xla::HloModuleProto* proto);
+std::string hloToStablehlo(const xla::HloModuleProto* proto, bool emit_bytecode);
 
 }  // namespace runtime
 }  // namespace torch_xla

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -319,7 +319,7 @@ torch::lazy::BackendDataPtr XLAGraphExecutor::GetBaseSeedData(
 }
 
 std::string XLAGraphExecutor::DumpHloComputation(
-    const std::vector<XLATensorPtr>& tensors, bool dump_stablehlo) {
+    const std::vector<XLATensorPtr>& tensors, EmitMode mode) {
   std::vector<torch::lazy::Value> ir_values;
   for (auto& tensor : tensors) {
     torch::lazy::Value ir_value = tensor->CurrentIrValue();
@@ -328,7 +328,7 @@ std::string XLAGraphExecutor::DumpHloComputation(
     }
   }
   return !ir_values.empty()
-             ? DumpUtil::ToHlo(ir_values, GetCurrentDevice(), dump_stablehlo)
+             ? DumpUtil::ToHlo(ir_values, GetCurrentDevice(), mode)
              : std::string();
 }
 

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -27,6 +27,7 @@
 #include "torch_xla/csrc/tensor.h"
 #include "torch_xla/csrc/torch_util.h"
 #include "torch_xla/csrc/view.h"
+#include "torch_xla/csrc/ir_dump_util.h"
 
 namespace torch_xla {
 
@@ -105,7 +106,7 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
   // attached the tensors.
   // We don't use upstream DumpBackendComputation given we have our own format.
   std::string DumpHloComputation(const std::vector<XLATensorPtr>& tensors,
-                                 bool dump_stablehlo = false);
+                                 EmitMode mode = EmitMode::kHloReadable);
 
   // Retrieves the set of XLA tensors which are currently live in the system,
   // for the given device. If device is nullptr, the live tensors for all

--- a/torch_xla/experimental/stablehlo_saved_model.py
+++ b/torch_xla/experimental/stablehlo_saved_model.py
@@ -1,0 +1,119 @@
+import copy
+import shutil
+import os
+import re
+import numpy as np
+import torch
+from torch import nn
+import torch_xla
+from torch_xla.core import xla_model as xm
+import tensorflow as tf
+import torchvision
+import torch._dynamo as torchdynamo
+
+from tensorflow.compiler.tf2xla.python import xla as tfxla
+
+from typing import Tuple, Type, Callable
+
+import sys
+
+
+class SHLOModel:
+
+  def __init__(self, model_bytecode, pos_to_orig_pos, pos_to_param,
+               output_shape, output_dtype):
+    self.model_bytecode = model_bytecode
+    self.pos_to_orig_pos = pos_to_orig_pos
+    self.pos_to_param = pos_to_param
+    self._total_number = len(pos_to_orig_pos) + len(pos_to_param)
+
+    self.tout = (output_dtype,)
+    self.sout = (tuple(output_shape),)
+
+  def __call__(self, *args):
+
+    call_args = []
+    for i in range(self._total_number):
+      if i in self.pos_to_orig_pos:
+        call_args.append(args[self.pos_to_orig_pos[i]])
+      else:
+        call_args.append(self.pos_to_param[i])
+
+    return tfxla.call_module(
+        tuple(call_args),
+        version=5,
+        Tout=self.tout,  # dtype information
+        Sout=self.sout,  # Shape information
+        function_list=[],
+        platforms=('CPU',),
+        module=self.model_bytecode,
+    )[0]
+
+
+def export_torch_model(model: torch.nn.Module,
+                       sample_inputs: Tuple[torch.Tensor],
+                       output_shape: Tuple[int], output_dtype):
+  """Convert model into a callable backed by StableHLO.
+    
+  Args:
+      model: torch.nn.Module - a pytorch model
+      sample_inputs: Tuple[torch.Tensor] - The input to this model
+      output_shape: Tuple[int] - Shape of the output
+      output_dtype: dtype - numpy dtype for the output
+
+  This function will return a callable backed by StableHLO such that,
+
+  model(*sample_inputs) ==  export_torch_model(model, sample_inputs)(*sample_inputs)
+  (up to numerics)
+
+  In other words, returned callable have the same calling convention of the input model, and
+  on the sample input, or inputs sufficiently similar* to sample input,  
+  it is will to return same result as the original model.
+
+  * sufficiently similar input because this function will use tracing to extract the model operations
+    so it might specialize on the shapes of the sample input.
+  
+  For now, model has to only take Tensors as input and has to return 1 tensor as output.
+
+  """
+
+  # Materialize the computation before this call to make sure that StableHLO
+  # captured below only reflect the model passed in
+  xm.mark_step()
+  model = copy.deepcopy(model)
+  sample_inputs = copy.deepcopy(sample_inputs)
+
+  device = xm.xla_device()
+  model.to(device=device)
+  sample_inputs_lazy = tuple(map(lambda x: x.to(device=device), sample_inputs))
+  input_ids = {
+      torch_xla._XLAC._xla_get_tensor_id(tensor): i
+      for i, tensor in enumerate(sample_inputs_lazy)
+  }
+  output = model(*sample_inputs_lazy)
+  stablehlo_bytecode = xm.get_stablehlo_bytecode([output])
+
+  (
+      graph_input_tensor_ids,
+      graph_input_xla_values,
+  ) = torch_xla._XLAC._get_tensors_xla_device_data_node([output])
+
+  pos_to_orig_pos = {}
+  pos_to_param = {}
+  for hlo_input_pos, tensor_id in enumerate(graph_input_tensor_ids):
+    if tensor_id in input_ids:  # this is input
+      pos_to_orig_pos[hlo_input_pos] = input_ids[tensor_id]
+    else:
+      pos_to_param[hlo_input_pos] = graph_input_xla_values[
+          hlo_input_pos].detach().cpu().numpy()
+
+  stablehlo_model = SHLOModel(stablehlo_bytecode, pos_to_orig_pos, pos_to_param,
+                              output_shape, output_dtype)
+  # Remove all of the pending IR from all live tensors. The assumptions are
+  # 1. With the  `xm.mark_step` in the beginning of this call, every XLATensor
+  # should be materialized
+  # 2. All of the pending IRs are result of the one inference
+  # should be removed to avoid extra computation executed and in place updates op
+  # mistakenlly update the input tensors.
+  torch_xla._XLAC._clear_pending_irs(str(xm.xla_device()))
+  return stablehlo_model

--- a/torch_xla/experimental/stablehlo_saved_model.py
+++ b/torch_xla/experimental/stablehlo_saved_model.py
@@ -7,6 +7,8 @@ import torch
 from torch import nn
 import torch_xla
 from torch_xla.core import xla_model as xm
+from torch_xla.core import dynamo_bridge
+from torch_xla.debug import metrics
 import tensorflow as tf
 import torchvision
 import torch._dynamo as torchdynamo
@@ -18,6 +20,18 @@ from typing import Tuple, Type, Callable
 import sys
 
 
+def _get_numpy_dtype(dtype):
+  return {
+      torch.double: np.double,
+      torch.float32: np.float32,
+      torch.half: np.half,
+      torch.long: int,
+      torch.int32: np.int32,
+      torch.int16: np.int16,
+      torch.bool: bool,
+  }.get(dtype)
+
+
 class SHLOModel:
 
   def __init__(self, model_bytecode, pos_to_orig_pos, pos_to_param,
@@ -27,7 +41,7 @@ class SHLOModel:
     self.pos_to_param = pos_to_param
     self._total_number = len(pos_to_orig_pos) + len(pos_to_param)
 
-    self.tout = (output_dtype,)
+    self.tout = (_get_numpy_dtype(output_dtype),)
     self.sout = (tuple(output_shape),)
 
   def __call__(self, *args):
@@ -51,10 +65,9 @@ class SHLOModel:
 
 
 def export_torch_model(model: torch.nn.Module,
-                       sample_inputs: Tuple[torch.Tensor],
-                       output_shape: Tuple[int], output_dtype):
+                       sample_inputs: Tuple[torch.Tensor]):
   """Convert model into a callable backed by StableHLO.
-    
+
   Args:
       model: torch.nn.Module - a pytorch model
       sample_inputs: Tuple[torch.Tensor] - The input to this model
@@ -67,12 +80,12 @@ def export_torch_model(model: torch.nn.Module,
   (up to numerics)
 
   In other words, returned callable have the same calling convention of the input model, and
-  on the sample input, or inputs sufficiently similar* to sample input,  
+  on the sample input, or inputs sufficiently similar* to sample input,
   it is will to return same result as the original model.
 
   * sufficiently similar input because this function will use tracing to extract the model operations
     so it might specialize on the shapes of the sample input.
-  
+
   For now, model has to only take Tensors as input and has to return 1 tensor as output.
 
   """
@@ -80,6 +93,7 @@ def export_torch_model(model: torch.nn.Module,
   # Materialize the computation before this call to make sure that StableHLO
   # captured below only reflect the model passed in
   xm.mark_step()
+  metrics.clear_counters()
   model = copy.deepcopy(model)
   sample_inputs = copy.deepcopy(sample_inputs)
 
@@ -91,6 +105,10 @@ def export_torch_model(model: torch.nn.Module,
       for i, tensor in enumerate(sample_inputs_lazy)
   }
   output = model(*sample_inputs_lazy)
+  if fallback_ops := dynamo_bridge.get_fallback_ops():
+    message = "This model contains ops not capturable by Pytorch/XLA: {}".format(
+        "\n".join(fallback_ops))
+    raise RuntimeError(message)
   stablehlo_bytecode = xm.get_stablehlo_bytecode([output])
 
   (
@@ -108,7 +126,7 @@ def export_torch_model(model: torch.nn.Module,
           hlo_input_pos].detach().cpu().numpy()
 
   stablehlo_model = SHLOModel(stablehlo_bytecode, pos_to_orig_pos, pos_to_param,
-                              output_shape, output_dtype)
+                              output.shape, output.dtype)
   # Remove all of the pending IR from all live tensors. The assumptions are
   # 1. With the  `xm.mark_step` in the beginning of this call, every XLATensor
   # should be materialized


### PR DESCRIPTION
Added function
`torch_xla.experimental.stablehlo_saved_model.export_pytorch_model`. This function will take a pytorch Module and convert it into stablehlo bytecode.