### PR TITLE
Unset the hardcoded XLATensorImpl.is_non_overlapping_and_dense_

### DIFF
--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -80,7 +80,6 @@ XLATensorImpl::XLATensorImpl(XLATensor&& tensor)
     auto autocast_xla_ks = c10::DispatchKeySet(c10::DispatchKey::AutocastXLA);
     key_set_ = (key_set_ - autocast_xla_ks) | autocast_cuda_ks;
   }
-  is_non_overlapping_and_dense_ = false;
   const_cast<XLATensorImpl*>(this)->SetupSizeProperties();
   set_sizes_and_strides(sym_sizes_, c10::fromIntArrayRefSlow(
                                         sizes_and_strides_.strides_arrayref()));


### PR DESCRIPTION
This PR is intended to revert https://github.com/pytorch/xla/pull/2682 due to its conversation.