### PR TITLE
[Functionalization] Remove view in view_symint

### DIFF
--- a/test/ds/test_dynamic_shapes.py
+++ b/test/ds/test_dynamic_shapes.py
@@ -248,6 +248,8 @@ class TestDynamicShapes(test_utils.XlaTestCase):
     t5 = torch.tensor([1, 1, 3, 5, 1, 6], device=dev)
     t6 = torch.nonzero(t5)
     t7 = torch.ones((2, 3), device=dev)
+    # t6.shape=torch.Size([<=6, 1]) with real size [6, 1]
+    # t6 = [[0], [1], [2], [3], [4], [5]]
     t8 = t7.view(t6.shape[0])
     self.assertIsInstance(t8.shape[0], torch.SymInt)
     self.assertEqual(str(t8.shape[0]), '<=6')

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3758,7 +3758,8 @@ at::Tensor XLANativeFunctions::expand_symint(const at::Tensor& self,
 
 at::Tensor XLANativeFunctions::view_symint(const at::Tensor& self,
                                            at::SymIntArrayRef sym_size) {
-  // TODO: support symbolic sizes
+  // Dynamic shape is only supported when the functionalization is enabled.
+  // So only the functionalization version of this function view_copy_symint support dynamic shape.
   auto size = C10_AS_INTARRAYREF_SLOW(sym_size);
   TORCH_LAZY_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(tensor_methods::view(

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3759,7 +3759,8 @@ at::Tensor XLANativeFunctions::expand_symint(const at::Tensor& self,
 at::Tensor XLANativeFunctions::view_symint(const at::Tensor& self,
                                            at::SymIntArrayRef sym_size) {
   // Dynamic shape is only supported when the functionalization is enabled.
-  // So only the functionalization version of this function view_copy_symint support dynamic shape.
+  // So only the functionalization version of this function view_copy_symint
+  // support dynamic shape.
   auto size = C10_AS_INTARRAYREF_SLOW(sym_size);
   TORCH_LAZY_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(tensor_methods::view(

--- a/torch_xla/csrc/convolution_helper.h
+++ b/torch_xla/csrc/convolution_helper.h
@@ -3,10 +3,10 @@
 
 #include <string>
 
+#include "tensorflow/compiler/xla/client/xla_builder.h"
 #include "tensorflow/compiler/xla/xla_data.pb.h"
 #include "tensorflow/tsl/lib/gtl/inlined_vector.h"
 #include "tensorflow/tsl/platform/stringpiece.h"
-#include "tensorflow/compiler/xla/client/xla_builder.h"
 
 namespace torch_xla {
 
@@ -137,8 +137,8 @@ struct ConvOpAttrs {
 
 // -------------Convolution Helper Data Structure End-------------------------
 
-// -------------Convolution Helper Function Start------------------------- 
-// Convolution helper functions below are copied from TF2XLA bridge 
+// -------------Convolution Helper Function Start-------------------------
+// Convolution helper functions below are copied from TF2XLA bridge
 // This part of helpers are origionally from
 // https://github.com/tensorflow/tensorflow/blob/7f47eaf439d2b81de1aa24b10ed57eabd519dbdb/tensorflow/core/util/tensor_format.h
 
@@ -236,8 +236,9 @@ inline int GetTensorSpatialDimIndex(int num_dims, TensorFormat format,
 tsl::Status ConvBackpropComputeDimensionsV2(
     tsl::StringPiece label, int num_spatial_dims, const xla::Shape& input_shape,
     const xla::Shape& filter_shape, const xla::Shape& out_backprop_shape,
-    absl::Span<const tsl::int32> dilations, const std::vector<tsl::int32>& strides,
-    Padding padding, TensorFormat data_format, ConvBackpropDimensions* dims,
+    absl::Span<const tsl::int32> dilations,
+    const std::vector<tsl::int32>& strides, Padding padding,
+    TensorFormat data_format, ConvBackpropDimensions* dims,
     absl::Span<const int64_t> explicit_paddings);
 
 // This part of helpers are origionally from
@@ -245,18 +246,17 @@ tsl::Status ConvBackpropComputeDimensionsV2(
 
 // Wrapper for ConvGeneralDilated with checking dims.
 tsl::StatusOr<xla::XlaOp> MakeXlaBackpropInputConvOp(
-    tsl::StringPiece type_string, const xla::Shape& input_shape, xla::XlaOp filter,
-    xla::XlaOp out_backprop, const ConvOpAttrs& attrs,
+    tsl::StringPiece type_string, const xla::Shape& input_shape,
+    xla::XlaOp filter, xla::XlaOp out_backprop, const ConvOpAttrs& attrs,
     xla::XlaOp* input_sizes = nullptr);
 
 // Wrapper for ConvGeneralDilated with checking dims.
-tsl::StatusOr<xla::XlaOp> MakeXlaBackpropFilterConvOp(tsl::StringPiece type_string,
-                                                 xla::XlaOp activations,
-                                                 const xla::Shape& filter_shape,
-                                                 xla::XlaOp gradients,
-                                                 const ConvOpAttrs& attrs);
+tsl::StatusOr<xla::XlaOp> MakeXlaBackpropFilterConvOp(
+    tsl::StringPiece type_string, xla::XlaOp activations,
+    const xla::Shape& filter_shape, xla::XlaOp gradients,
+    const ConvOpAttrs& attrs);
 
-// -------------Convolution Helper Function End------------------------- 
+// -------------Convolution Helper Function End-------------------------
 
 }  // namespace torch_xla
 

--- a/torch_xla/csrc/ops/view.cpp
+++ b/torch_xla/csrc/ops/view.cpp
@@ -31,6 +31,11 @@ ViewOp::ViewOp(const torch::lazy::Value& input,
               /*num_outputs=*/1, torch::lazy::MHash(output_size)),
       output_size_(std::move(output_size)) {}
 
+ViewOp::ViewOp(const torch::lazy::Value& input, xla::Shape output_shape)
+    : XlaNode(torch::lazy::OpKind(at::aten::view), {input},
+              output_shape, /*num_outputs=*/1, torch::lazy::MHash(torch::lazy::ToVector<int64_t>(output_shape.dimensions()), torch::lazy::ToVector<bool>(output_shape.dynamic_dimensions()))),
+      output_size_(torch::lazy::ToVector<int64_t>(output_shape.dimensions())) {}
+
 XlaOpVector ViewOp::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
   xla::XlaOp output = BuildView(input, output_size_);

--- a/torch_xla/csrc/ops/view.cpp
+++ b/torch_xla/csrc/ops/view.cpp
@@ -32,8 +32,12 @@ ViewOp::ViewOp(const torch::lazy::Value& input,
       output_size_(std::move(output_size)) {}
 
 ViewOp::ViewOp(const torch::lazy::Value& input, xla::Shape output_shape)
-    : XlaNode(torch::lazy::OpKind(at::aten::view), {input},
-              output_shape, /*num_outputs=*/1, torch::lazy::MHash(torch::lazy::ToVector<int64_t>(output_shape.dimensions()), torch::lazy::ToVector<bool>(output_shape.dynamic_dimensions()))),
+    : XlaNode(
+          torch::lazy::OpKind(at::aten::view), {input}, output_shape,
+          /*num_outputs=*/1,
+          torch::lazy::MHash(
+              torch::lazy::ToVector<int64_t>(output_shape.dimensions()),
+              torch::lazy::ToVector<bool>(output_shape.dynamic_dimensions()))),
       output_size_(torch::lazy::ToVector<int64_t>(output_shape.dimensions())) {}
 
 XlaOpVector ViewOp::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/view.h
+++ b/torch_xla/csrc/ops/view.h
@@ -10,6 +10,7 @@ namespace torch_xla {
 class ViewOp : public XlaNode {
  public:
   ViewOp(const torch::lazy::Value& input, std::vector<int64_t> output_size);
+  ViewOp(const torch::lazy::Value& input, xla::Shape output_shape);
 
   XlaOpVector Lower(LoweringContext* loctx) const override;
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2791,8 +2791,8 @@ XLATensorPtr view_symint(const XLATensorPtr& input,
                        input_shape);
     return input->CreateViewTensor(std::move(view_info));
   }
-  return input->CreateFrom(torch::lazy::MakeNode<ViewOp>(
-      input->GetIrValue(), result_shape));
+  return input->CreateFrom(
+      torch::lazy::MakeNode<ViewOp>(input->GetIrValue(), result_shape));
 }
 
 XLATensorPtr view_as_complex_copy(const XLATensorPtr& input) {

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2788,11 +2788,12 @@ XLATensorPtr view_symint(const XLATensorPtr& input,
   // See Note: [Disabling functionalization]
   if (runtime::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
     ViewInfo view_info(ViewInfo::Type::kReshape, std::move(result_shape),
-                      input_shape);
+                       input_shape);
     return input->CreateViewTensor(std::move(view_info));
   }
   return input->CreateFrom(torch::lazy::MakeNode<ViewOp>(
-      input->GetIrValue(), torch::lazy::ToVector<int64_t>(result_shape.dimensions())));
+      input->GetIrValue(),
+      torch::lazy::ToVector<int64_t>(result_shape.dimensions())));
 }
 
 XLATensorPtr view_as_complex_copy(const XLATensorPtr& input) {

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2778,16 +2778,21 @@ XLATensorPtr view(const XLATensorPtr& input,
 
 XLATensorPtr view_symint(const XLATensorPtr& input,
                          at::SymIntArrayRef sym_size) {
-  torch_xla::runtime::util::MaybeRef<xla::Shape> input_shape = input->shape();
+  auto input_shape = input->shape();
   SymIntElements size_elements(sym_size);
   std::vector<int64_t> complete_dimensions = GetCompleteShape(
       size_elements.GetUpperBounds(), input_shape.get().dimensions());
   xla::Shape result_shape = xla::ShapeUtil::MakeShape(
       input_shape.get().element_type(), complete_dimensions,
       size_elements.GetDynamicDims());
-  ViewInfo view_info(ViewInfo::Type::kReshape, std::move(result_shape),
-                     input_shape);
-  return input->CreateViewTensor(std::move(view_info));
+  // See Note: [Disabling functionalization]
+  if (runtime::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
+    ViewInfo view_info(ViewInfo::Type::kReshape, std::move(result_shape),
+                      input_shape);
+    return input->CreateViewTensor(std::move(view_info));
+  }
+  return input->CreateFrom(torch::lazy::MakeNode<ViewOp>(
+      input->GetIrValue(), torch::lazy::ToVector<int64_t>(result_shape.dimensions())));
 }
 
 XLATensorPtr view_as_complex_copy(const XLATensorPtr& input) {

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2792,8 +2792,7 @@ XLATensorPtr view_symint(const XLATensorPtr& input,
     return input->CreateViewTensor(std::move(view_info));
   }
   return input->CreateFrom(torch::lazy::MakeNode<ViewOp>(
-      input->GetIrValue(),
-      torch::lazy::ToVector<int64_t>(result_shape.dimensions())));
+      input->GetIrValue(), result_shape));
 }
 
 XLATensorPtr view_as_complex_copy(const XLATensorPtr& input) {


### PR DESCRIPTION
Summary:
This pull request removes views in tensor_method::view_symint.

Test Plan:
XLA_DISABLE_FUNCTIONALIZATION=1 PJRT_DEVICE=TPU python ../test/test_view_ops.py -v -k TestViewOpsXLA.test_view_view PJRT_DEVICE=TPU python ../test/test_view_ops.py -v -k TestViewOpsXLA.test_view_view