### PR TITLE
[Traceable Collecive] Hide token for all_gather

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -549,8 +549,8 @@ def all_gather(value, dim=0, groups=None, output=None, pin_layout=True):
     # All replicas belong to a single group
     shard_count = xrt_world_size()
 
-  result = torch_xla._XLAC._xla_all_gather(value, dim, shard_count,
-                                           groups or [], pin_layout)
+  result = torch_xla._XLAC._xla_all_gather(value, dim, shard_count, groups or
+                                           [], pin_layout)
   if output != None:
     output = result
   return result

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -549,10 +549,17 @@ def all_gather(value, dim=0, groups=None, output=None, pin_layout=True):
     # All replicas belong to a single group
     shard_count = xrt_world_size()
 
+  token, devctx = _get_all_reduce_token()
+  if output != None:
+    # Call the out of place version of the all_gather
+    new_token = torch_xla._XLAC._xla_all_gather_out(output, value, token, dim,
+                                                    shard_count, groups or [],
+                                                    pin_layout)
+    torch_xla._XLAC._set_all_reduce_token(devctx.device, new_token)
+    return output
+
   result = torch_xla._XLAC._xla_all_gather(value, dim, shard_count, groups or
                                            [], pin_layout)
-  if output != None:
-    output = result
   return result
 
 

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -538,9 +538,9 @@ def all_gather(value, dim=0, groups=None, output=None, pin_layout=True):
     # all_reduce based all_gather for this purpose.
     return _all_gather_using_all_reduce(
         value, dim=dim, groups=groups, pin_layout=True)
+
   if dim < 0:
     dim = value.dim() + dim
-  token, devctx = _get_all_reduce_token()
   if groups:
     shard_count = len(groups[0])
     assert all(len(group) == shard_count for group in groups), \
@@ -548,18 +548,12 @@ def all_gather(value, dim=0, groups=None, output=None, pin_layout=True):
   else:
     # All replicas belong to a single group
     shard_count = xrt_world_size()
-  if output != None:
-    # Call the out of place version of the all_gather
-    new_token = torch_xla._XLAC._xla_all_gather_out(output, value, token, dim,
-                                                    shard_count, groups or [],
-                                                    pin_layout)
-    torch_xla._XLAC._set_all_reduce_token(devctx.device, new_token)
-    return output
 
   result = torch_xla._XLAC._xla_all_gather(value, token, dim, shard_count,
                                            groups or [], pin_layout)
-  torch_xla._XLAC._set_all_reduce_token(devctx.device, result[1])
-  return result[0]
+  if output != None:
+    output = result
+  return result
 
 
 def all_to_all(value,

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -549,7 +549,7 @@ def all_gather(value, dim=0, groups=None, output=None, pin_layout=True):
     # All replicas belong to a single group
     shard_count = xrt_world_size()
 
-  result = torch_xla._XLAC._xla_all_gather(value, token, dim, shard_count,
+  result = torch_xla._XLAC._xla_all_gather(value, dim, shard_count,
                                            groups or [], pin_layout)
   if output != None:
     output = result

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -173,14 +173,14 @@ std::vector<std::pair<int64_t, int64_t>> CreateSourceTargetPairs(
   return source_target_pairs;
 }
 
-std::shared_ptr<torch::lazy::Value> AllReduceInPlace(
+void AllReduceInPlace(
     const std::string& reduce_type, const std::vector<at::Tensor>& tensors,
     double scale, const std::vector<std::vector<int64_t>>& replica_groups,
     bool pin_layout) {
   std::vector<XLATensorPtr> xtensors =
       GetXlaTensors(tensors, /*want_all=*/true);
-  return std::make_shared<torch::lazy::Value>(tensor_methods::all_reduce(
-      xtensors, GetReduceType(reduce_type), scale, replica_groups, pin_layout));
+  tensor_methods::all_reduce(
+      xtensors, GetReduceType(reduce_type), scale, replica_groups, pin_layout);
 }
 
 at::Tensor AllReduce(const std::string& reduce_type, const at::Tensor& input,
@@ -221,30 +221,13 @@ std::shared_ptr<torch::lazy::Value> ReduceScatterOut(
   return std::make_shared<torch::lazy::Value>(new_token);
 }
 
-std::pair<at::Tensor, std::shared_ptr<torch::lazy::Value>> AllGather(
-    const at::Tensor& input, const std::shared_ptr<torch::lazy::Value>& token,
+at::Tensor AllGather(
+    const at::Tensor& input,
     int64_t dim, int64_t shard_count,
     const std::vector<std::vector<int64_t>>& replica_groups, bool pin_layout) {
-  XLATensorPtr result;
-  torch::lazy::Value new_token;
-  std::tie(result, new_token) =
-      tensor_methods::all_gather(bridge::GetXlaTensor(input), *token, dim,
-                                 shard_count, replica_groups, pin_layout);
-  return {bridge::AtenFromXlaTensor(std::move(result)),
-          std::make_shared<torch::lazy::Value>(new_token)};
-}
-
-std::shared_ptr<torch::lazy::Value> AllGatherOut(
-    at::Tensor& output, const at::Tensor& input,
-    const std::shared_ptr<torch::lazy::Value>& token, int64_t dim,
-    int64_t shard_count,
-    const std::vector<std::vector<int64_t>>& replica_groups, bool pin_layout) {
-  XLATensorPtr out = bridge::GetXlaTensor(output);
-  torch::lazy::Value new_token;
-  new_token = tensor_methods::all_gather_out(out, bridge::GetXlaTensor(input),
-                                             *token, dim, shard_count,
-                                             replica_groups, pin_layout);
-  return std::make_shared<torch::lazy::Value>(new_token);
+  auto result = tensor_methods::all_gather(bridge::GetXlaTensor(input), dim,
+                                                   shard_count, replica_groups, pin_layout);
+  return bridge::AtenFromXlaTensor(std::move(result));
 }
 
 std::pair<at::Tensor, std::shared_ptr<torch::lazy::Value>> AllToAll(
@@ -906,39 +889,18 @@ void InitXlaModuleBindings(py::module m) {
           return result_tuple;
         });
   m.def("_xla_all_gather", [](const at::Tensor& input,
-                              const std::shared_ptr<torch::lazy::Value>& token,
                               int64_t dim, int64_t shard_count,
                               const py::list& groups, bool pin_layout) {
     std::vector<std::vector<int64_t>> replica_groups =
         CreateReduceGroups(groups);
     at::Tensor result;
-    std::shared_ptr<torch::lazy::Value> new_token;
     {
       NoGilSection nogil;
-      std::tie(result, new_token) =
-          AllGather(input, token, dim, shard_count, replica_groups, pin_layout);
+      result =
+          AllGather(input, dim, shard_count, replica_groups, pin_layout);
     }
-    auto result_tuple = py::tuple(2);
-    result_tuple[0] = torch::autograd::make_variable(
-        result, /*requires_grad=*/input.requires_grad());
-    result_tuple[1] = new_token;
-    return result_tuple;
+    return result;
   });
-  m.def("_xla_all_gather_out",
-        [](at::Tensor& output, const at::Tensor& input,
-           const std::shared_ptr<torch::lazy::Value>& token, int64_t dim,
-           int64_t shard_count, const py::list& groups, bool pin_layout) {
-          std::vector<std::vector<int64_t>> replica_groups =
-              CreateReduceGroups(groups);
-          at::Tensor result;
-          std::shared_ptr<torch::lazy::Value> new_token;
-          {
-            NoGilSection nogil;
-            new_token = AllGatherOut(output, input, token, dim, shard_count,
-                                     replica_groups, pin_layout);
-          }
-          return new_token;
-        });
   m.def("_xla_collective_permute",
         [](const at::Tensor& input,
            const std::shared_ptr<torch::lazy::Value>& token,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -346,9 +346,8 @@ XLATensorPtr all_reduce(const XLATensorPtr& input, AllReduceType reduce_type,
 }
 
 void all_reduce(const std::vector<XLATensorPtr>& inputs,
-                              AllReduceType reduce_type, double scale,
-                              std::vector<std::vector<int64_t>> groups,
-                              bool pin_layout) {
+                AllReduceType reduce_type, double scale,
+                std::vector<std::vector<int64_t>> groups, bool pin_layout) {
   std::vector<torch::lazy::Value> input_values;
   input_values.reserve(inputs.size());
   for (auto& input : inputs) {
@@ -401,13 +400,13 @@ std::pair<XLATensorPtr, torch::lazy::Value> all_to_all(
           torch::lazy::Value(node, 1)};
 }
 
-XLATensorPtr all_gather(
-    const XLATensorPtr& input, int64_t dim,
-    int64_t shard_count, std::vector<std::vector<int64_t>> groups,
-    bool pin_layout) {
+XLATensorPtr all_gather(const XLATensorPtr& input, int64_t dim,
+                        int64_t shard_count,
+                        std::vector<std::vector<int64_t>> groups,
+                        bool pin_layout) {
   torch::lazy::NodePtr node = torch::lazy::MakeNode<AllGather>(
-      input->GetIrValue(), GetAllReduceToken(input->GetDevice()), dim, shard_count, std::move(groups),
-      pin_layout);
+      input->GetIrValue(), GetAllReduceToken(input->GetDevice()), dim,
+      shard_count, std::move(groups), pin_layout);
   SetAllReduceToken(input->GetDevice(),
                     std::make_shared<torch::lazy::Value>(node, 1));
   return input->CreateFrom(torch::lazy::Value(node, 0));

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -412,6 +412,19 @@ XLATensorPtr all_gather(const XLATensorPtr& input, int64_t dim,
   return input->CreateFrom(torch::lazy::Value(node, 0));
 }
 
+torch::lazy::Value all_gather_out(XLATensorPtr& output,
+                                  const XLATensorPtr& input,
+                                  const torch::lazy::Value& token, int64_t dim,
+                                  int64_t shard_count,
+                                  std::vector<std::vector<int64_t>> groups,
+                                  bool pin_layout) {
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<AllGather>(
+      input->GetIrValue(), token, dim, shard_count, std::move(groups),
+      pin_layout);
+  output->SetIrValue(torch::lazy::Value(node, 0));
+  return torch::lazy::Value(node, 1);
+}
+
 std::pair<XLATensorPtr, torch::lazy::Value> collective_permute(
     const XLATensorPtr& input, const torch::lazy::Value& token,
     std::vector<std::pair<int64_t, int64_t>> source_target_pairs) {

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -345,7 +345,7 @@ XLATensorPtr all_reduce(const XLATensorPtr& input, AllReduceType reduce_type,
   return input->CreateFrom(torch::lazy::Value(node, 0));
 }
 
-torch::lazy::Value all_reduce(const std::vector<XLATensorPtr>& inputs,
+void all_reduce(const std::vector<XLATensorPtr>& inputs,
                               AllReduceType reduce_type, double scale,
                               std::vector<std::vector<int64_t>> groups,
                               bool pin_layout) {
@@ -360,7 +360,8 @@ torch::lazy::Value all_reduce(const std::vector<XLATensorPtr>& inputs,
   for (size_t i = 0; i < inputs.size(); ++i) {
     inputs[i]->SetInPlaceIrValue(torch::lazy::Value(node, i));
   }
-  return torch::lazy::Value(node, inputs.size());
+  SetAllReduceToken(inputs.front()->GetDevice(),
+                    std::make_shared<torch::lazy::Value>(node, inputs.size()));
 }
 
 std::pair<XLATensorPtr, torch::lazy::Value> reduce_scatter(
@@ -400,28 +401,16 @@ std::pair<XLATensorPtr, torch::lazy::Value> all_to_all(
           torch::lazy::Value(node, 1)};
 }
 
-std::pair<XLATensorPtr, torch::lazy::Value> all_gather(
-    const XLATensorPtr& input, const torch::lazy::Value& token, int64_t dim,
+XLATensorPtr all_gather(
+    const XLATensorPtr& input, int64_t dim,
     int64_t shard_count, std::vector<std::vector<int64_t>> groups,
     bool pin_layout) {
   torch::lazy::NodePtr node = torch::lazy::MakeNode<AllGather>(
-      input->GetIrValue(), token, dim, shard_count, std::move(groups),
+      input->GetIrValue(), GetAllReduceToken(input->GetDevice()), dim, shard_count, std::move(groups),
       pin_layout);
-  return {input->CreateFrom(torch::lazy::Value(node, 0)),
-          torch::lazy::Value(node, 1)};
-}
-
-torch::lazy::Value all_gather_out(XLATensorPtr& output,
-                                  const XLATensorPtr& input,
-                                  const torch::lazy::Value& token, int64_t dim,
-                                  int64_t shard_count,
-                                  std::vector<std::vector<int64_t>> groups,
-                                  bool pin_layout) {
-  torch::lazy::NodePtr node = torch::lazy::MakeNode<AllGather>(
-      input->GetIrValue(), token, dim, shard_count, std::move(groups),
-      pin_layout);
-  output->SetIrValue(torch::lazy::Value(node, 0));
-  return torch::lazy::Value(node, 1);
+  SetAllReduceToken(input->GetDevice(),
+                    std::make_shared<torch::lazy::Value>(node, 1));
+  return input->CreateFrom(torch::lazy::Value(node, 0));
 }
 
 std::pair<XLATensorPtr, torch::lazy::Value> collective_permute(

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -43,6 +43,13 @@ XLATensorPtr all_gather(const XLATensorPtr& input, int64_t dim,
                         std::vector<std::vector<int64_t>> groups,
                         bool pin_layout);
 
+torch::lazy::Value all_gather_out(XLATensorPtr& output,
+                                  const XLATensorPtr& input,
+                                  const torch::lazy::Value& token, int64_t dim,
+                                  int64_t shard_count,
+                                  std::vector<std::vector<int64_t>> groups,
+                                  bool pin_layout);
+
 std::pair<XLATensorPtr, torch::lazy::Value> collective_permute(
     const XLATensorPtr& input, const torch::lazy::Value& token,
     std::vector<std::pair<int64_t, int64_t>> source_target_pairs);

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -15,7 +15,7 @@ XLATensorPtr all_reduce(const XLATensorPtr& input, AllReduceType reduce_type,
                         double scale, std::vector<std::vector<int64_t>> groups,
                         bool pin_layout);
 
-torch::lazy::Value all_reduce(const std::vector<XLATensorPtr>& inputs,
+void all_reduce(const std::vector<XLATensorPtr>& inputs,
                               AllReduceType reduce_type, double scale,
                               std::vector<std::vector<int64_t>> groups,
                               bool pin_layout);
@@ -39,17 +39,10 @@ std::pair<XLATensorPtr, torch::lazy::Value> all_to_all(
     int64_t split_dimension, int64_t concat_dimension, int64_t split_count,
     std::vector<std::vector<int64_t>> groups, bool pin_layout);
 
-std::pair<XLATensorPtr, torch::lazy::Value> all_gather(
-    const XLATensorPtr& input, const torch::lazy::Value& token, int64_t dim,
+XLATensorPtr all_gather(
+    const XLATensorPtr& input, int64_t dim,
     int64_t shard_count, std::vector<std::vector<int64_t>> groups,
     bool pin_layout);
-
-torch::lazy::Value all_gather_out(XLATensorPtr& output,
-                                  const XLATensorPtr& input,
-                                  const torch::lazy::Value& token, int64_t dim,
-                                  int64_t shard_count,
-                                  std::vector<std::vector<int64_t>> groups,
-                                  bool pin_layout);
 
 std::pair<XLATensorPtr, torch::lazy::Value> collective_permute(
     const XLATensorPtr& input, const torch::lazy::Value& token,

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -16,9 +16,8 @@ XLATensorPtr all_reduce(const XLATensorPtr& input, AllReduceType reduce_type,
                         bool pin_layout);
 
 void all_reduce(const std::vector<XLATensorPtr>& inputs,
-                              AllReduceType reduce_type, double scale,
-                              std::vector<std::vector<int64_t>> groups,
-                              bool pin_layout);
+                AllReduceType reduce_type, double scale,
+                std::vector<std::vector<int64_t>> groups, bool pin_layout);
 
 std::pair<XLATensorPtr, torch::lazy::Value> reduce_scatter(
     const XLATensorPtr& input, const torch::lazy::Value& token,
@@ -39,10 +38,10 @@ std::pair<XLATensorPtr, torch::lazy::Value> all_to_all(
     int64_t split_dimension, int64_t concat_dimension, int64_t split_count,
     std::vector<std::vector<int64_t>> groups, bool pin_layout);
 
-XLATensorPtr all_gather(
-    const XLATensorPtr& input, int64_t dim,
-    int64_t shard_count, std::vector<std::vector<int64_t>> groups,
-    bool pin_layout);
+XLATensorPtr all_gather(const XLATensorPtr& input, int64_t dim,
+                        int64_t shard_count,
+                        std::vector<std::vector<int64_t>> groups,
+                        bool pin_layout);
 
 std::pair<XLATensorPtr, torch::lazy::Value> collective_permute(
     const XLATensorPtr& input, const torch::lazy::Value& token,


### PR DESCRIPTION
Summary:
This pull request does the following:
1. It hides token for all_gather.
2. It fixes an issue with the last all_reduce_in_place PR where it forgot to set the token.

Test Plan:
PJRT_DEVICE=TPU python test/test_mp_all_gather.py