### PR TITLE
Only run the main CI workflow on PRs targeting master and release branches

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -50,30 +50,6 @@ jobs:
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
 
-  build-xrt:
-    name: "Build XLA with XRT"
-    uses: ./.github/workflows/_build.yml
-    with:
-      ecr-docker-image-base: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/xla_base
-      gcr-docker-image: gcr.io/tpu-pytorch/xla_base:latest
-      disable_xrt: 0
-      cuda: 0
-    secrets:
-      gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
-
-  test-xrt-cpu:
-    name: "Test XRT with CPU"
-    uses: ./.github/workflows/_test.yml
-    needs: build-xrt
-    with:
-      docker-image: ${{ needs.build-xrt.outputs.docker-image }}
-      timeout-minutes: 90
-      disable-xrt: 0
-      disable-pjrt: 1
-      test-script: 'test_xrt.sh'
-    secrets:
-      gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
-
   test-cpu-coverage:
     name: "Collect CPU test coverage"
     if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,6 +1,9 @@
 name: Build & Test
 on:
   pull_request:
+    branches:
+      - master
+      - r[0-9]+.[0-9]+
   push:
     branches:
       - master


### PR DESCRIPTION
Skip XRT tests in main CI since they conflict with the workflow running on the `xrt` branch:

`tag invalid: The image tag 'latest-xrt-025a2750e282762b3a3bd7c34d798f3112502b52' already exists in the 'pytorch/xla_base' repository and cannot be overwritten because the repository is immutable.`