### PR TITLE
Remove `test_experimental_pjrt_tpu.py` from TPU CI

### DIFF
--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -42,7 +42,6 @@ spec:
     - -cxe
     - |
       python3 /src/pytorch/xla/test/test_operations.py -v
-      python3 /src/pytorch/xla/test/pjrt/test_experimental_pjrt_tpu.py
       python3 /src/pytorch/xla/test/pjrt/test_runtime_tpu.py
       python3 /src/pytorch/xla/test/spmd/test_xla_sharding.py
       python3 /src/pytorch/xla/test/spmd/test_xla_virtual_device.py


### PR DESCRIPTION
Added by accident in #5161

```
Step #4 - "run_e2e_tests": + python3 /src/pytorch/xla/test/pjrt/test_experimental_pjrt_tpu.py
Step #4 - "run_e2e_tests": python3: can't open file '/src/pytorch/xla/test/pjrt/test_experimental_pjrt_tpu.py': [Errno 2] No such file or directory
Step #4 - "run_e2e_tests": ++ kubectl get pod/xla-test-job-vvtwc -o 'jsonpath={.status.containerStatuses[?(@.name=="xla-test")].state.terminated.exitCode}'
```