### PR TITLE
Add IAM roles for cloudbuild_editors

### DIFF
--- a/infra/tpu-pytorch-releases/iam.auto.tfvars
+++ b/infra/tpu-pytorch-releases/iam.auto.tfvars
@@ -4,3 +4,6 @@ project_admins = [
   "user:goranpetrovic@google.com",
   "user:jackcao@google.com",
 ]
+
+cloudbuild_editors = [
+]

--- a/infra/tpu-pytorch-releases/iam.tf
+++ b/infra/tpu-pytorch-releases/iam.tf
@@ -5,6 +5,11 @@ variable "project_admins" {
   default = []
 }
 
+variable "cloudbuild_editors" {
+  type    = list(string)
+  default = []
+}
+
 resource "google_project_iam_member" "project_iam_admins" {
   for_each = toset(var.project_admins)
 
@@ -18,5 +23,13 @@ resource "google_project_iam_member" "storage_admins" {
 
   project = data.google_project.project.project_id
   role    = "roles/storage.admin"
+  member  = each.value
+}
+
+resource "google_project_iam_member" "cloudbuild_editor" {
+  for_each = toset(var.cloudbuild_editors)
+
+  project = data.google_project.project.project_id
+  role    = "roles/cloudbuild.builds.editor"
   member  = each.value
 }


### PR DESCRIPTION
This allows to specify users that can run and create new cloud build triggers.