### PR TITLE
Install `expecttest` in xla_test_job.yaml

### DIFF
--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -41,6 +41,8 @@ spec:
     - bash
     - -cxe
     - |
+      pip install expecttest
+
       python3 /src/pytorch/xla/test/test_operations.py -v
       python3 /src/pytorch/xla/test/pjrt/test_runtime_tpu.py
       python3 /src/pytorch/xla/test/spmd/test_xla_sharding.py


### PR DESCRIPTION
TPU CI is currently failing:

```
Step #4 - "run_e2e_tests": + python3 /src/pytorch/xla/test/test_autocast.py
Step #4 - "run_e2e_tests": Traceback (most recent call last):
Step #4 - "run_e2e_tests":   File "/src/pytorch/xla/test/test_autocast.py", line 14, in <module>
Step #4 - "run_e2e_tests":     from torch.testing._internal.autocast_test_lists import AutocastTestLists
Step #4 - "run_e2e_tests":   File "/usr/local/lib/python3.8/site-packages/torch/testing/_internal/autocast_test_lists.py", line 2, in <module>
Step #4 - "run_e2e_tests":     from torch.testing._internal.common_utils import TEST_WITH_ROCM
Step #4 - "run_e2e_tests":   File "/usr/local/lib/python3.8/site-packages/torch/testing/_internal/common_utils.py", line 59, in <module>
Step #4 - "run_e2e_tests":     import expecttest
Step #4 - "run_e2e_tests": ModuleNotFoundError: No module named 'expecttest'
```