### PR TITLE
Add nightly build for cuda 12

### DIFF
--- a/infra/ansible/config/cuda_deps.yaml
+++ b/infra/ansible/config/cuda_deps.yaml
@@ -3,10 +3,12 @@
 cuda_deps:
   # List all libcudnn8 versions with `apt list -a libcudnn8`
   libcudnn:
+    "12.0": libcudnn8=8.8.0.121-1+cuda12.0
     "11.8": libcudnn8=8.8.0.121-1+cuda11.8
     "11.7": libcudnn8=8.5.0.96-1+cuda11.7
     "11.2": libcudnn8=8.1.1.33-1+cuda11.2
   libcudnn-dev:
+    "12.0": libcudnn8-dev=8.8.0.121-1+cuda12.0 
     "11.8": libcudnn8-dev=8.8.0.121-1+cuda11.8
     "11.7": libcudnn8-dev=8.5.0.96-1+cuda11.7
     "11.2": libcudnn8-dev=8.1.1.33-1+cuda11.2

--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -9,6 +9,10 @@ nightly_builds = [
   },
   {
     accelerator  = "cuda"
+    cuda_version = "12.0"
+  },
+  {
+    accelerator  = "cuda"
     cuda_version = "11.8"
   },
   {


### PR DESCRIPTION
Add nightly build for cuda 12

---

According to https://developer.nvidia.com/rdp/cudnn-archive and https://ubuntu.pkgs.org/18.04/cuda-amd64/libcudnn8-dev_8.5.0.96-1+cuda11.7_amd64.deb.html, we should use `libcudnn8=8.8.0.121-1+cuda12.0` for CUDA 12. 