### PR TITLE
Jack cao g/fix spmd buff is null

### DIFF
--- a/test/spmd/test_xla_virtual_device.py
+++ b/test/spmd/test_xla_virtual_device.py
@@ -77,6 +77,16 @@ class VirtualDeviceTest(test_xla_sharding_base.XlaShardingTest):
     self.assertLess(outbound_with_virtual_device,
                     2 * xt1.nelement() * xt1.element_size())
 
+  def test_non_tensor_scalar(self):
+    sharding_spec = xs.ShardingSpec(self._get_mesh((1, self.n_devices)), (0, 1))
+    # tensor will have device as `SPMD:0` in c++
+    xt1 = xm.send_cpu_data_to_device([torch.randn(3, 3)],
+                                     xm.xla_device(),
+                                     input_sharding=sharding_spec)[0]
+    print(torch_xla._XLAC._get_xla_tensor_debug_info(xt1))
+    xt2 = xt1 / 0.5
+    torch.allclose(xt2.cpu(), xt1.cpu() / 0.5)
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/test/spmd/test_xla_virtual_device.py
+++ b/test/spmd/test_xla_virtual_device.py
@@ -83,7 +83,8 @@ class VirtualDeviceTest(test_xla_sharding_base.XlaShardingTest):
     xt1 = xm.send_cpu_data_to_device([torch.randn(3, 3)],
                                      xm.xla_device(),
                                      input_sharding=sharding_spec)[0]
-    print(torch_xla._XLAC._get_xla_tensor_debug_info(xt1))
+    # we will transfer 0.5 as a device_data to the 'SPMD:0' device, need to make sure
+    # that virtual device can handle this case.
     xt2 = xt1 / 0.5
     torch.allclose(xt2.cpu(), xt1.cpu() / 0.5)
 

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -437,8 +437,6 @@ std::vector<ComputationClient::ComputationPtr> PjRtComputationClient::Compile(
           device_assignment);
     }
 
-    xla::PjRtDevice* pjrt_device =
-        StringToPjRtDevice(instance.compilation_device);
     std::unique_ptr<xla::PjRtLoadedExecutable> executable =
         ConsumeValue(client_->Compile(instance.computation, compile_options));
 

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -164,7 +164,8 @@ class PjRtComputationClient : public ComputationClient {
 
     OpaqueHandle GetOpaqueHandle() override {
       XLA_CHECK(HasValue())
-          << (buffer == nullptr ? "buffer is null" : "buffer is deleted");
+          << "buffer with shape " << shape().ToString() << " on device "
+          << device() << (buffer == nullptr ? " is null" : " is deleted");
       return reinterpret_cast<std::uintptr_t>(buffer.get());
     };
     void Assign(const Data& data) override;

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -602,6 +602,7 @@ torch::lazy::BackendDataPtr TensorToXlaData(
   TORCH_LAZY_TIMED("TensorToData");
   if (ShardingUtil::UseVirtualDevice()) {
     // Scalar value will be replicated, no need to delay the transfer here.
+    // TODO(JackCaoG): fix this for more general cases.
     if (device.type() == (int8_t)XlaDeviceType::SPMD && shape.rank() > 0) {
       // When SPMD is enabled, we want to delay the data transfer for XLA
       // tensors until the data is sharded. So, we skip the data transfer

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -601,7 +601,8 @@ torch::lazy::BackendDataPtr TensorToXlaData(
     const torch::lazy::BackendDevice& device) {
   TORCH_LAZY_TIMED("TensorToData");
   if (ShardingUtil::UseVirtualDevice()) {
-    if (device.type() == (int8_t)XlaDeviceType::SPMD) {
+    // Scalar value will be replicated, no need to delay the transfer here.
+    if (device.type() == (int8_t)XlaDeviceType::SPMD && shape.rank() > 0) {
       // When SPMD is enabled, we want to delay the data transfer for XLA
       // tensors until the data is sharded. So, we skip the data transfer
       // here and simply return a placeholder for the backend data ptr.


### PR DESCRIPTION
Currently resnet50 batch sharding will fail with  `buffer is null`. The root cause is that virtual device will try to delay the transfer of the `at::Tensor` to device until we know the sharding annotation(when mark_step is called, all tensor without sharding will be considered as replicated).

However for a case like
```
xt2 = xt1 / 0.5
```
we will transfer scalar `0.5` to the device since it is part of the computation. If virtual device kicks in, we will create a data placeholder for `0.5`. The problem is there is no `XLATensor` corresponding to the `scalar 0.5`. During the `mark_step`, we will just ignore this place holder which result in this `buffer_is_null` error.


I think the long term fix is to only use `virtual_device` for value that actually has a `XLATensor`, I need to change the function signature to make caller explicitly about the `at::tensor` it is trying to send is a actual pytorch tensor or just a temp scalar.