### PR TITLE
Disable Bazel remote cache for forked PR

### DIFF
--- a/scripts/run_bazel_coverage.sh
+++ b/scripts/run_bazel_coverage.sh
@@ -2,11 +2,20 @@
 export XRT_DEVICE_MAP="CPU:0;/job:localservice/replica:0/task:0/device:XLA_CPU:0"
 export XRT_WORKERS="localservice:0;grpc://localhost:40934"
 export XLA_EXPERIMENTAL="nonzero:masked_select"
-bazel coverage --config=remote_cache --remote_default_exec_properties=cache-silo-key=cache-silo-coverage //...
+
+if [ ! -z "$GCLOUD_SERVICE_KEY_FILE" ]; then
+  file_size=$(stat -c%s "$GCLOUD_SERVICE_KEY_FILE")
+  if [ "$file_size" -le 1 ]; then
+    BAZEL_REMOTE_CACHE_CONFIG=""
+  fi
+fi
+BAZEL_REMOTE_CACHE_CONFIG="--config=remote_cache --remote_default_exec_properties=cache-silo-key=cache-silo-coverage"
+
+bazel coverage $BAZEL_REMOTE_CACHE_CONFIG //...
 cp "$(bazel info output_path)/_coverage/_coverage_report.dat" /tmp/cov_xrt.dat
 
 export PJRT_DEVICE="CPU"
-bazel coverage --config=remote_cache --remote_default_exec_properties=cache-silo-key=cache-silo-coverage //test/...
+bazel coverage $BAZEL_REMOTE_CACHE_CONFIG //test/...
 cp "$(bazel info output_path)/_coverage/_coverage_report.dat" /tmp/cov_pjrt.dat
 
 # requires `apt-get install lcov`

--- a/scripts/run_bazel_coverage.sh
+++ b/scripts/run_bazel_coverage.sh
@@ -3,13 +3,13 @@ export XRT_DEVICE_MAP="CPU:0;/job:localservice/replica:0/task:0/device:XLA_CPU:0
 export XRT_WORKERS="localservice:0;grpc://localhost:40934"
 export XLA_EXPERIMENTAL="nonzero:masked_select"
 
+BAZEL_REMOTE_CACHE_CONFIG="--config=remote_cache --remote_default_exec_properties=cache-silo-key=cache-silo-coverage"
 if [ ! -z "$GCLOUD_SERVICE_KEY_FILE" ]; then
   file_size=$(stat -c%s "$GCLOUD_SERVICE_KEY_FILE")
   if [ "$file_size" -le 1 ]; then
     BAZEL_REMOTE_CACHE_CONFIG=""
   fi
 fi
-BAZEL_REMOTE_CACHE_CONFIG="--config=remote_cache --remote_default_exec_properties=cache-silo-key=cache-silo-coverage"
 
 bazel coverage $BAZEL_REMOTE_CACHE_CONFIG //...
 cp "$(bazel info output_path)/_coverage/_coverage_report.dat" /tmp/cov_xrt.dat

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@
 #   CXX_ABI=""
 #     value for cxx_abi flag; if empty, it is infered from `torch._C`.
 #
-# add another commit so the branch pr commit is different from fork pr
 from __future__ import print_function
 
 from setuptools import setup, find_packages, distutils, Extension, command

--- a/setup.py
+++ b/setup.py
@@ -251,18 +251,18 @@ class BuildBazelExtension(command.build_ext.build_ext):
       bazel_argv.append('--config=tpu')
 
     # Remote cache authentication.
-    # if not GCLOUD_KEY_FILE:
-    #   os.environ['BAZEL_REMOTE_CACHE'] = 0
-    # if _check_env_flag('BAZEL_REMOTE_CACHE'):
-    #   bazel_argv.append('--config=remote_cache')
+    print("check GCLOUD_KEY_FILE: {}".format(GCLOUD_KEY_FILE))
+    if not GCLOUD_KEY_FILE:
+      if _check_env_flag('BAZEL_REMOTE_CACHE'):
+        bazel_argv.append('--config=remote_cache')
 
-    # if GCLOUD_KEY_FILE:
-    #   bazel_argv.append('--google_credentials=%s' % GCLOUD_KEY_FILE)
-    #   if not _check_env_flag('BAZEL_REMOTE_CACHE'):
-    #     bazel_argv.append('--config=remote_cache')
-    # if CACHE_SILO_NAME:
-    #   bazel_argv.append('--remote_default_exec_properties=cache-silo-key=%s' %
-    #                     CACHE_SILO_NAME)
+      if GCLOUD_KEY_FILE:
+        bazel_argv.append('--google_credentials=%s' % GCLOUD_KEY_FILE)
+        if not _check_env_flag('BAZEL_REMOTE_CACHE'):
+          bazel_argv.append('--config=remote_cache')
+      if CACHE_SILO_NAME:
+        bazel_argv.append('--remote_default_exec_properties=cache-silo-key=%s' %
+                          CACHE_SILO_NAME)
 
     if _check_env_flag('BUILD_CPP_TESTS', default='0'):
       bazel_argv.append('//test/cpp:all')

--- a/setup.py
+++ b/setup.py
@@ -251,10 +251,9 @@ class BuildBazelExtension(command.build_ext.build_ext):
       bazel_argv.append('--config=tpu')
 
     # Remote cache authentication.
-    print("check GCLOUD_KEY_FILE: {}".format(GCLOUD_KEY_FILE))
-    print("check if file exists: {}".format(os.path.exists(GCLOUD_KEY_FILE)))
-    print("check size: {}".format(os.path.getsize(GCLOUD_KEY_FILE)))
-    if GCLOUD_KEY_FILE:
+    gclout_key_file_size = os.path.getsize(GCLOUD_KEY_FILE)
+    # Temporary workaround to allow PRs from forked repo to run CI.
+    if gclout_key_file_size > 1:
       if _check_env_flag('BAZEL_REMOTE_CACHE'):
         bazel_argv.append('--config=remote_cache')
 

--- a/setup.py
+++ b/setup.py
@@ -251,6 +251,8 @@ class BuildBazelExtension(command.build_ext.build_ext):
       bazel_argv.append('--config=tpu')
 
     # Remote cache authentication.
+    if not GCLOUD_KEY_FILE:
+      os.environ['BAZEL_REMOTE_CACHE'] = 0
     if _check_env_flag('BAZEL_REMOTE_CACHE'):
       bazel_argv.append('--config=remote_cache')
 

--- a/setup.py
+++ b/setup.py
@@ -252,7 +252,8 @@ class BuildBazelExtension(command.build_ext.build_ext):
 
     # Remote cache authentication.
     gclout_key_file_size = os.path.getsize(GCLOUD_KEY_FILE)
-    # Temporary workaround to allow PRs from forked repo to run CI.
+    # Temporary workaround to allow PRs from forked repo to run CI. See details at (#5259).
+    # TODO: Remove the check once self-hosted GHA workers are avaialble to CPU/GPU CI.
     if gclout_key_file_size > 1:
       if _check_env_flag('BAZEL_REMOTE_CACHE'):
         bazel_argv.append('--config=remote_cache')

--- a/setup.py
+++ b/setup.py
@@ -252,7 +252,7 @@ class BuildBazelExtension(command.build_ext.build_ext):
 
     # Remote cache authentication.
     print("check GCLOUD_KEY_FILE: {}".format(GCLOUD_KEY_FILE))
-    if not GCLOUD_KEY_FILE:
+    if GCLOUD_KEY_FILE:
       if _check_env_flag('BAZEL_REMOTE_CACHE'):
         bazel_argv.append('--config=remote_cache')
 

--- a/setup.py
+++ b/setup.py
@@ -254,6 +254,9 @@ class BuildBazelExtension(command.build_ext.build_ext):
     gclout_key_file_size = os.path.getsize(GCLOUD_KEY_FILE)
     # Temporary workaround to allow PRs from forked repo to run CI. See details at (#5259).
     # TODO: Remove the check once self-hosted GHA workers are avaialble to CPU/GPU CI.
+    print("check GCLOUD_KEY_FILE: {}".format(GCLOUD_KEY_FILE))
+    print("check if file exists: {}".format(os.path.exists(GCLOUD_KEY_FILE)))
+    print("check size: {}".format(os.path.getsize(GCLOUD_KEY_FILE)))
     if gclout_key_file_size > 1:
       if _check_env_flag('BAZEL_REMOTE_CACHE'):
         bazel_argv.append('--config=remote_cache')

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@
 #   CXX_ABI=""
 #     value for cxx_abi flag; if empty, it is infered from `torch._C`.
 #
-
+# add another commit so the branch pr commit is different from fork pr
 from __future__ import print_function
 
 from setuptools import setup, find_packages, distutils, Extension, command

--- a/setup.py
+++ b/setup.py
@@ -252,6 +252,8 @@ class BuildBazelExtension(command.build_ext.build_ext):
 
     # Remote cache authentication.
     print("check GCLOUD_KEY_FILE: {}".format(GCLOUD_KEY_FILE))
+    print("check if file exists: {}".format(os.path.exists(GCLOUD_KEY_FILE)))
+    print("check size: {}".format(os.path.getsize(GCLOUD_KEY_FILE)))
     if GCLOUD_KEY_FILE:
       if _check_env_flag('BAZEL_REMOTE_CACHE'):
         bazel_argv.append('--config=remote_cache')

--- a/setup.py
+++ b/setup.py
@@ -251,18 +251,18 @@ class BuildBazelExtension(command.build_ext.build_ext):
       bazel_argv.append('--config=tpu')
 
     # Remote cache authentication.
-    if not GCLOUD_KEY_FILE:
-      os.environ['BAZEL_REMOTE_CACHE'] = 0
-    if _check_env_flag('BAZEL_REMOTE_CACHE'):
-      bazel_argv.append('--config=remote_cache')
+    # if not GCLOUD_KEY_FILE:
+    #   os.environ['BAZEL_REMOTE_CACHE'] = 0
+    # if _check_env_flag('BAZEL_REMOTE_CACHE'):
+    #   bazel_argv.append('--config=remote_cache')
 
-    if GCLOUD_KEY_FILE:
-      bazel_argv.append('--google_credentials=%s' % GCLOUD_KEY_FILE)
-      if not _check_env_flag('BAZEL_REMOTE_CACHE'):
-        bazel_argv.append('--config=remote_cache')
-    if CACHE_SILO_NAME:
-      bazel_argv.append('--remote_default_exec_properties=cache-silo-key=%s' %
-                        CACHE_SILO_NAME)
+    # if GCLOUD_KEY_FILE:
+    #   bazel_argv.append('--google_credentials=%s' % GCLOUD_KEY_FILE)
+    #   if not _check_env_flag('BAZEL_REMOTE_CACHE'):
+    #     bazel_argv.append('--config=remote_cache')
+    # if CACHE_SILO_NAME:
+    #   bazel_argv.append('--remote_default_exec_properties=cache-silo-key=%s' %
+    #                     CACHE_SILO_NAME)
 
     if _check_env_flag('BUILD_CPP_TESTS', default='0'):
       bazel_argv.append('//test/cpp:all')

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -61,6 +61,13 @@ if [[ -n "${CXX_ABI}" ]]; then
   EXTRA_FLAGS="${EXTRA_FLAGS} --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=${CXX_ABI}"
 fi
 
+# Override BAZEL_REMOTE_CACHE if GLOUD_SERVICE_KEY_FILE is 1 byte
+if [ ! -z "$GCLOUD_SERVICE_KEY_FILE" ]; then
+  file_size=$(stat -c%s "$GCLOUD_SERVICE_KEY_FILE")
+  if [ "$file_size" -le 1 ]; then
+    BAZEL_REMOTE_CACHE=0
+  fi
+fi
 # Handle remote builds and remote cache. Use a CI-private cache silo to avoid cache pollution.
 if [[ "$BAZEL_REMOTE_CACHE" == "1" ]]; then
   EXTRA_FLAGS="$EXTRA_FLAGS --config=remote_cache"


### PR DESCRIPTION
### Background
Since forked PRs doesn't have access to Github Repository secrets, the gcloud credentials passed by secrets cannot be picked up by forked PRs, causing the CI to fail due to empty gcloud credential files.

Thanks to @stgpetrovic pointing out, whenever the self-hosted workers are used in CI, the workers will have access to the remote cache thus the credential won't be needed at that time.

cc @mateuszlewko who is working on using self-hosted workers in TPU CI.

### Temporary Solution
Since gcloud credential is only required when Bazel remote cache is enabled, the size of the credential file is checked in `setup.py`, if the credential is empty (Actually the credential file is 1 byte), we assume it's triggered from a forked PR and skip the remote cache.

### Next Step
After the self-hosted workers are setup for CPU/GPU CI, we can remove the gcloud credential in `setup.py`.
