### PR TITLE
Update Sharded graph HLO dumping

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -454,6 +454,19 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     t3_expected = [9.0, 9.0, 9.0, 9.0, 9.0, 9.0, 9.0, 9.0]
     self.assertEqual(t3.tolist()[0], t3_expected)
 
+  def test_xla_sharded_hlo_dump(self):
+    partition_spec = (0, 1)
+    xt1 = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]],
+                       dtype=torch.float,
+                       device=xm.xla_device())
+    xst1 = xs.mark_sharding(xt1, self._get_mesh((1, self.n_devices)),
+                            partition_spec)
+    xst2 = xst1 + 5
+    hlo = torch_xla._XLAC._get_xla_tensors_hlo([xst2.global_tensor])
+    self.assertIn('%p1.4 = f32[1,8]{1,0} parameter(1), sharding', hlo)
+    # scalar 5 should be replicated
+    self.assertIn('%p0.2 = f32[] parameter(0), sharding={replicated}', hlo)
+
   @unittest.skipIf(xr.device_type() == 'TPU', "Crash on TPU v2")
   @unittest.skipUnless(
       xm.get_xla_supported_devices("TPU"),

--- a/torch_xla/csrc/ir_dump_util.cpp
+++ b/torch_xla/csrc/ir_dump_util.cpp
@@ -263,23 +263,8 @@ std::string DumpUtil::ToHlo(c10::ArrayRef<torch::lazy::Value> values,
 
   // Annotate HLO sharding selectively in the compuation.
   // This is no-op if an instruction doesn't have any sharding annotation.
-  bool is_sharded = ShardingUtil::SetHloSharding(&lowering_ctx);
+  ShardingUtil::SetHloSharding(&lowering_ctx);
   xla::XlaComputation computation = ConsumeValue(lowering_ctx.BuildXla());
-  if (is_sharded) {
-    xla::Shape shape = MakeShapeWithDeviceLayout(
-        ConsumeValue(computation.GetProgramShape()).result(),
-        static_cast<XlaDeviceType>(device.type()));
-    std::vector<runtime::ComputationClient::CompileInstance> instances;
-    instances.push_back({std::move(computation), device.toString(),
-                         runtime::GetComputationClient()->GetCompilationDevices(
-                             device.toString(), {}),
-                         &shape,
-                         /*parameter_is_tupled_arguments=*/false, is_sharded});
-    std::vector<std::shared_ptr<runtime::ComputationClient::Computation>>
-        computations =
-            runtime::GetComputationClient()->Compile(std::move(instances));
-    computation = std::move(computations[0]->move_computation());
-  }
   switch (mode) {
     case EmitMode::kHloReadable:
       return ConsumeValue(runtime::util::GetComputationHloText(computation));


### PR DESCRIPTION
Currently if we try to dump the HLO graph for a sharded computation, the logic in `DumpUtil::ToHlo` will return the post-optimization HLO, which contains a bunch of `fused_compuation.clone` and it is pretty unreadable. I think we want the HLO that's closer to the original IR for the debugging purpose, after this change, we will see something like
```
HloModule IrToHlo.8, entry_computation_layout={(f32[], f32[1,8]{1,0})->(f32[1,8]{1,0})}

ENTRY %IrToHlo.8 (p0.2: f32[], p1.4: f32[1,8]) -> (f32[1,8]) {
  %p1.4 = f32[1,8]{1,0} parameter(1), sharding={devices=[1,4]0,1,2,3}
  %p0.2 = f32[] parameter(0), sharding={replicated}
  %constant.1 = f32[] constant(1)
  %multiply.3 = f32[] multiply(f32[] %p0.2, f32[] %constant.1)
  %broadcast.5 = f32[1,8]{1,0} broadcast(f32[] %multiply.3), dimensions={}
  %add.6 = f32[1,8]{1,0} add(f32[1,8]{1,0} %p1.4, f32[1,8]{1,0} %broadcast.5)
  ROOT %tuple.7 = (f32[1,8]{1,0}) tuple(f32[1,8]{1,0} %add.6)
}
```

which gives us enough information about the input sharding which is useful.