### PR TITLE
Make TPU detection more robust

### DIFF
--- a/torch_xla/runtime.py
+++ b/torch_xla/runtime.py
@@ -35,7 +35,7 @@ def _maybe_select_default_device():
   logging.warning('PJRT is now the default runtime. For more information, see '
                   'https://github.com/pytorch/xla/blob/master/docs/pjrt.md')
   # Check for libtpu _and_ the TPU device
-  if torch_xla._found_libtpu and os.path.exists('/dev/accel0'):
+  if torch_xla._found_libtpu and tpu.num_available_chips() > 0:
     logging.warning('libtpu.so and TPU device found. Setting PJRT_DEVICE=TPU.')
     os.environ[xenv.PJRT_DEVICE] = 'TPU'
   # TODO(wcromar): Detect GPU device


### PR DESCRIPTION
Detect the TPU devices by PCI IDs, not by `/dev` path.