### PR TITLE
Remove or improve several hardcoded TPU test conditions

### DIFF
--- a/test/pjrt/test_runtime_tpu.py
+++ b/test/pjrt/test_runtime_tpu.py
@@ -95,7 +95,8 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
     self.assertDictEqual(devices_per_process, expected)
 
   def test_xla_devices_single_process_all_chips(self):
-    expected = _ordinal_to_device(cores_per_process=tpu.num_available_devices())
+    expected = _ordinal_to_device(
+        processes=1, cores_per_process=tpu.num_available_devices())
 
     os.environ[xenv.TPU_VISIBLE_CHIPS] = '0,1,2,3'
     os.environ[xenv.TPU_PROCESS_BOUNDS] = '1,1,1'


### PR DESCRIPTION
Use chips and logical cores instead of TPU versions to generate expected values.