### PR TITLE
Always do build_ext in python setup.py develop

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@
 from __future__ import print_function
 
 from setuptools import setup, find_packages, distutils, Extension, command
+from setuptools.command import develop
 from torch.utils.cpp_extension import BuildExtension
 import posixpath
 import contextlib
@@ -292,6 +293,13 @@ class BuildBazelExtension(command.build_ext.build_ext):
     shutil.copyfile(ext_bazel_bin_path, ext_dest_path)
 
 
+class Develop(develop.develop):
+
+  def run(self):
+    self.run_command("build_ext")
+    super().run()
+
+
 setup(
     name=os.environ.get('TORCH_XLA_PACKAGE_NAME', 'torch_xla'),
     version=version,
@@ -323,4 +331,5 @@ setup(
     cmdclass={
         'build_ext': BuildBazelExtension,
         'clean': Clean,
+        'develop': Develop,
     })


### PR DESCRIPTION
Bazel should figure out that _XLAC.so is current
or not, and trigger rebuild if any cpp files changed.