### PR TITLE
Clean bazel stuff on distutils clean.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,6 @@ class Clean(distutils.command.clean.clean):
   def bazel_clean_(self):
     self.spawn(['bazel', 'clean', '--expunge'])
 
-
   def run(self):
     import glob
     import re

--- a/setup.py
+++ b/setup.py
@@ -160,6 +160,10 @@ def maybe_bundle_libtpu(base_dir):
 
 class Clean(distutils.command.clean.clean):
 
+  def bazel_clean_(self):
+    self.spawn(['bazel', 'clean', '--expunge'])
+
+
   def run(self):
     import glob
     import re
@@ -179,6 +183,8 @@ class Clean(distutils.command.clean.clean):
               os.remove(filename)
             except OSError:
               shutil.rmtree(filename, ignore_errors=True)
+
+    self.execute(self.bazel_clean_, (), msg="Cleaning bazel outputs")
 
     # It's an old-style class in Python 2.7...
     distutils.command.clean.clean.run(self)


### PR DESCRIPTION
Invoke `bazel clean --expunge` when `python setup.py clean` is run.