### PR TITLE
Fix the error when export_torch_model is given a non-tensor

### DIFF
--- a/test/stablehlo/test_stablehlo_dump.py
+++ b/test/stablehlo/test_stablehlo_dump.py
@@ -3,6 +3,11 @@ import torch_xla.core.xla_model as xm
 import torch
 import torchvision
 import unittest
+from torch import nn
+
+from typing import Tuple
+
+Tensor = torch.Tensor
 
 
 class StableHloDumpTest(unittest.TestCase):
@@ -28,6 +33,56 @@ class StableHloDumpTest(unittest.TestCase):
     stablehlo = xm.get_stablehlo()
     self.assertEqual(stablehlo.count("stablehlo.convolution"), 20)
     self.assertGreater(stablehlo.count("#loc"), 0)
+
+
+class ElementwiseAdd(nn.Module):
+
+  def __init__(self) -> None:
+    super().__init__()
+
+  def forward(self, x: Tensor, y: Tensor) -> Tensor:
+    return x + y
+
+  def get_random_inputs(self) -> Tuple[Tensor, Tensor]:
+    return (torch.randn(1, 3), torch.randn(1, 3))
+
+
+class Cat(nn.Module):
+
+  def __init__(self) -> None:
+    super().__init__()
+
+  # def forward(self, tensors, dim=0):
+  def forward(self, *args: Tensor, dim: int) -> Tensor:
+    return torch.cat(args, dim)
+
+
+class SimpleExportTest(unittest.TestCase):
+
+  def export_stable_hlo(self, model, args, kwargs=None):
+    if kwargs is None:
+      kwargs = {}
+    device = xm.xla_device()
+    model.eval()
+    model = model.to(device)
+    args = tuple(i.to(device) for i in args if hasattr(i, 'to'))
+    output = model(*args, **kwargs)
+    if not isinstance(output, tuple):
+      output = [output]
+    return xm.get_stablehlo(output)
+
+  def test_add(self):
+    model = ElementwiseAdd()
+    inputs = model.get_random_inputs()
+    self.export_stable_hlo(model, inputs)  # works
+
+  def test_cat(self):
+    model = Cat()
+    inputs = (torch.randn(10, 10), torch.randn(10, 10))
+    kwargs = {'dim': 1}
+    stablehlo = self.export_stable_hlo(model, inputs, kwargs)
+    # FIXME: Currently the dim=1 is hard coded
+    self.assertTrue('dim = 1' in stablehlo)
 
 
 if __name__ == '__main__':

--- a/test/stablehlo/test_stablehlo_inference.py
+++ b/test/stablehlo/test_stablehlo_inference.py
@@ -47,6 +47,25 @@ class StableHLOInferenceTest(unittest.TestCase):
       output2 = torch.tensor(res.numpy())
       self.assertTrue(torch.allclose(output, output2, atol=1e-5))
 
+  def test_add_float(self):
+
+    class AddFloat(torch.nn.Module):
+
+      def __init__(self) -> None:
+        super().__init__()
+
+      # def forward(self, tensors, dim=0):
+      def forward(self, x, y):
+        return x + y
+
+    m = AddFloat()
+    data = (torch.randn(100, 100), 4.4)
+    output = m(*data)
+    exported = export_torch_model(m, data)
+    output2 = torch.tensor(exported(data[0].detach().numpy(), data[1]).numpy())
+
+    self.assertTrue(torch.allclose(output, output2, atol=1e-5))
+
 
 if __name__ == '__main__':
   test = unittest.main()


### PR DESCRIPTION
However the generated StableHLO graph still hardcodes the non-tensor value. this is not correct, will fix later.