### PR TITLE
Add `runtime.host_index`

### DIFF
--- a/test/pjrt/test_internal_tpu.py
+++ b/test/pjrt/test_internal_tpu.py
@@ -84,6 +84,14 @@ class TestExperimentalTpu(parameterized.TestCase):
 
     self.assertEqual(i, expected)
 
+  @parameterized.parameters(('0', 0), ('1', 1), ('15', 15))
+  def test_worker_id(self, worker_id, expected):
+    with mock.patch.object(
+        tpu, 'get_tpu_env', return_value={xenv.WORKER_ID: worker_id}):
+      i = tpu.worker_id()
+
+    self.assertEqual(i, expected)
+
   @parameterized.named_parameters(
       ('v4',
        textwrap.dedent("""

--- a/test/pjrt/test_runtime.py
+++ b/test/pjrt/test_runtime.py
@@ -81,6 +81,9 @@ class TestExperimentalPjrt(parameterized.TestCase):
       else:
         self.assertIsNone(xr.device_type())
 
+  def test_host_index(self):
+    self.assertEqual(xr.host_index(), 0)
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/torch_xla/_internal/tpu.py
+++ b/torch_xla/_internal/tpu.py
@@ -47,10 +47,10 @@ _TPU_PCI_DEVICE_IDS = [
 
 
 class TpuEnv(TypedDict):
-  accelerator_type: str
-  tpu_process_bounds: str
-  tpu_chips_per_process_bound: str
-  worker_id: int
+  ACCELERATOR_TYPE: str
+  TPU_PROCESS_BOUNDS: str
+  TPU_CHIPS_PER_HOST_BOUNDS: str
+  WORKER_ID: int
 
 
 class MeshShape(NamedTuple):
@@ -131,6 +131,12 @@ def num_local_processes() -> int:
 def task_id() -> Optional[int]:
   """Returns index of this process within all TPU worker processes, if any."""
   return xu.getenv_as(xenv.CLOUD_TPU_TASK_ID, int)
+
+
+def worker_id() -> int:
+  """Returns the ID of the current TPU worker."""
+  env = get_tpu_env()
+  return int(env[xenv.WORKER_ID])
 
 
 def _using_env_vars() -> bool:

--- a/torch_xla/runtime.py
+++ b/torch_xla/runtime.py
@@ -182,3 +182,12 @@ def device_attributes(device: str) -> Dict[str, object]:
 @requires_pjrt
 def global_device_attributes() -> List[Dict[str, object]]:
   return torch_xla._XLAC._xla_get_all_device_attributes()
+
+
+@requires_pjrt
+def host_index() -> int:
+  if device_type() == 'TPU':
+    return tpu.worker_id()
+
+  # TODO: Update this when we support multi-host GPU
+  return 0


### PR DESCRIPTION
See https://github.com/Lightning-AI/lightning/issues/17982#issuecomment-1622255670

This is only meaningfully implemented for TPUs right now, as we don't support multi-host GPU or CPU yet. Also fix keys in `TpuEnv` `TypedDict`.

cc @carmocca 