### PR TITLE
[SPMD][Virtual Device]All tensors should be in SPMD:0 C++ device

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -394,8 +394,7 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
 
     # Adding 0 to the tensor force graph compilation, which would catch IR hash
     # collisions
-    # TODO(JackCaoG): invesgate why `torch.allclose(xt1, xt2))` will crash
-    self.assertTrue(torch.allclose((xt1 + 0).cpu(), (xt2 + 0).cpu()))
+    self.assertTrue(torch.allclose(xt1 + 0, xt2 + 0))
 
     # Check that hashes are different for the sharded and non-sharded tensors
     hash1 = torch_xla._XLAC._get_graph_hash([xt1])

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -314,7 +314,6 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     xt = torch.ones(2, 2).to(xm.xla_device())
     xs.mark_sharding(xt, self._get_mesh((1, self.n_devices)), (0, 1))
     xt += 2
-    sharding_spec = torch_xla._XLAC._get_xla_sharding_spec(xt)
     xm.mark_step()
     xm.wait_device_ops()
     self.assertEqual(met.metric_data('ExecuteReplicatedTime')[0], 1)

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -394,7 +394,8 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
 
     # Adding 0 to the tensor force graph compilation, which would catch IR hash
     # collisions
-    self.assertTrue(torch.allclose(xt1 + 0, xt2 + 0))
+    # TODO(JackCaoG): invesgate why `torch.allclose(xt1, xt2))` will crash
+    self.assertTrue(torch.allclose((xt1 + 0).cpu(), (xt2 + 0).cpu()))
 
     # Check that hashes are different for the sharded and non-sharded tensors
     hash1 = torch_xla._XLAC._get_graph_hash([xt1])

--- a/test/spmd/test_xla_virtual_device.py
+++ b/test/spmd/test_xla_virtual_device.py
@@ -103,7 +103,7 @@ class VirtualDeviceTest(test_xla_sharding_base.XlaShardingTest):
                      torch_xla._XLAC._get_xla_tensor_debug_info(xt2))
 
   def test_virtual_device_no_upload(self):
-    met.clear_counters()
+    met.clear_all()
     device = xm.xla_device()
     t1 = torch.randn(5, 5).to(device)
     t1_debug_info = torch_xla._XLAC._get_xla_tensor_debug_info(t1)
@@ -116,7 +116,7 @@ class VirtualDeviceTest(test_xla_sharding_base.XlaShardingTest):
     self.assertIn("XLAData: None", t1_debug_info)
 
   def test_virtual_device_upload_after_mark_sharding(self):
-    met.clear_counters()
+    met.clear_all()
     partition_spec = (0, 1)
     device = xm.xla_device()
     t1 = torch.randn(8, 8).to(device)
@@ -131,15 +131,13 @@ class VirtualDeviceTest(test_xla_sharding_base.XlaShardingTest):
     self.assertIn("TransferToServerTime", met.metric_names())
 
   def test_virtual_device_upload_after_tracing(self):
-    met.clear_counters()
+    met.clear_all()
     device = xm.xla_device()
     t1 = torch.randn(8, 8).to(device)
     t1_debug_info = torch_xla._XLAC._get_xla_tensor_debug_info(t1)
     self.assertIn("Tensor on host: with size [8, 8]", t1_debug_info)
     t2 = t1 + t1
     t1_debug_info_new = torch_xla._XLAC._get_xla_tensor_debug_info(t1)
-    import pdb
-    pdb.set_trace()
     # tensor should be uploaded to device after being used as input to other op.
     self.assertIn("Tensor on host: None", t1_debug_info_new)
     self.assertIn("xla::device_data", t1_debug_info_new)

--- a/test/spmd/test_xla_virtual_device.py
+++ b/test/spmd/test_xla_virtual_device.py
@@ -79,9 +79,6 @@ class VirtualDeviceTest(test_xla_sharding_base.XlaShardingTest):
 
   def test_non_tensor_scalar(self):
     sharding_spec = xs.ShardingSpec(self._get_mesh((1, self.n_devices)), (0, 1))
-    # TODO(JackCaoG)currently, execution will only happen if there is at least one
-    # tensor on non-spmd:0 device.
-    t1 = torch.randn(3, 3, device=xm.xla_device())
     # tensor will have device as `SPMD:0` in c++
     xt1 = xm.send_cpu_data_to_device([torch.randn(3, 3)],
                                      xm.xla_device(),
@@ -95,9 +92,6 @@ class VirtualDeviceTest(test_xla_sharding_base.XlaShardingTest):
   def test_mark_step_on_virtual_device(self):
     xm.mark_step()
     sharding_spec = xs.ShardingSpec(self._get_mesh((1, self.n_devices)), (0, 1))
-    # TODO(JackCaoG)currently, execution will only happen if there is at least one
-    # tensor on non-spmd:0 device.
-    t1 = torch.randn(3, 3, device=xm.xla_device())
     # tensor will have device as `SPMD:0` in c++
     xt1 = xm.send_cpu_data_to_device([torch.randn(3, 3)],
                                      xm.xla_device(),

--- a/test/spmd/test_xla_virtual_device.py
+++ b/test/spmd/test_xla_virtual_device.py
@@ -102,6 +102,65 @@ class VirtualDeviceTest(test_xla_sharding_base.XlaShardingTest):
     self.assertNotIn('aten::div',
                      torch_xla._XLAC._get_xla_tensor_debug_info(xt2))
 
+  def test_virtual_device_no_upload(self):
+    met.clear_counters()
+    device = xm.xla_device()
+    t1 = torch.randn(5, 5).to(device)
+    t1_debug_info = torch_xla._XLAC._get_xla_tensor_debug_info(t1)
+    # t1's upload to device should be deferred
+    self.assertIn("Tensor on host: with size [5, 5]", t1_debug_info)
+    self.assertNotIn("TransferToServerTime", met.metric_names())
+    # t1 should be on SPMD device under spmd context
+    self.assertIn("Device: SPMD:0", t1_debug_info)
+    self.assertIn("IR: None", t1_debug_info)
+    self.assertIn("XLAData: None", t1_debug_info)
+
+  def test_virtual_device_upload_after_mark_sharding(self):
+    met.clear_counters()
+    partition_spec = (0, 1)
+    device = xm.xla_device()
+    t1 = torch.randn(8, 8).to(device)
+    t1_debug_info = torch_xla._XLAC._get_xla_tensor_debug_info(t1)
+    self.assertIn("Tensor on host: with size [8, 8]", t1_debug_info)
+    xs.mark_sharding(t1, self._get_mesh((1, self.n_devices)), partition_spec)
+    t1_debug_info_new = torch_xla._XLAC._get_xla_tensor_debug_info(t1)
+    # tensor should be uploaded to device after mark_sharding
+    self.assertIn("Tensor on host: None", t1_debug_info_new)
+    self.assertIn("xla::device_data", t1_debug_info_new)
+    self.assertIn("XLAShardedData", t1_debug_info_new)
+    self.assertIn("TransferToServerTime", met.metric_names())
+
+  def test_virtual_device_upload_after_tracing(self):
+    met.clear_counters()
+    device = xm.xla_device()
+    t1 = torch.randn(8, 8).to(device)
+    t1_debug_info = torch_xla._XLAC._get_xla_tensor_debug_info(t1)
+    self.assertIn("Tensor on host: with size [8, 8]", t1_debug_info)
+    t2 = t1 + t1
+    t1_debug_info_new = torch_xla._XLAC._get_xla_tensor_debug_info(t1)
+    import pdb
+    pdb.set_trace()
+    # tensor should be uploaded to device after being used as input to other op.
+    self.assertIn("Tensor on host: None", t1_debug_info_new)
+    self.assertIn("xla::device_data", t1_debug_info_new)
+    self.assertIn("TransferToServerTime", met.metric_names())
+
+  def test_virtual_device_upload_for_sharded_dataloader(self):
+    met.clear_counters()
+    device = xm.xla_device()
+    sharding_spec = xs.ShardingSpec(self._get_mesh((1, self.n_devices)), (0, 1))
+    # tensor will have device as `SPMD:0` in c++
+    t1 = xm.send_cpu_data_to_device([torch.randn(8, 8)],
+                                    device,
+                                    input_sharding=sharding_spec)[0]
+    t1_debug_info = torch_xla._XLAC._get_xla_tensor_debug_info(t1)
+    self.assertIn("Device: SPMD:0", t1_debug_info)
+    # tensor should be uploaded to device after send_cpu_data_to_device + sharding_spec
+    self.assertIn("Tensor on host: None", t1_debug_info)
+    self.assertIn("xla::device_data", t1_debug_info)
+    self.assertIn("XLAShardedData", t1_debug_info)
+    self.assertIn("TransferToServerTime", met.metric_names())
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/torch_xla/csrc/aten_xla_bridge.cpp
+++ b/torch_xla/csrc/aten_xla_bridge.cpp
@@ -39,10 +39,15 @@ class AtenXlaDeviceMapper {
 
  private:
   AtenXlaDeviceMapper() {
-    for (auto& device_str :
-         torch_xla::runtime::GetComputationClient()->GetLocalDevices()) {
-      devices_.emplace_back(ParseDeviceString(device_str));
-      devices_ordinals_[devices_.back()] = devices_.size() - 1;
+    if (UseVirtualDevice()) {
+      devices_.emplace_back(ParseDeviceString("SPMD:0"));
+      devices_ordinals_[devices_.back()] = 0;
+    } else {
+      for (auto& device_str :
+           torch_xla::runtime::GetComputationClient()->GetLocalDevices()) {
+        devices_.emplace_back(ParseDeviceString(device_str));
+        devices_ordinals_[devices_.back()] = devices_.size() - 1;
+      }
     }
   }
 

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -467,7 +467,7 @@ at::Tensor XLANativeFunctions::_copy_from(const at::Tensor& self,
   if (!self_tensor) {
     static bool sync_update =
         runtime::sys_util::GetEnvBool("XLA_TENSOR_UPDATE_SYNC", true) &&
-        !ShardingUtil::UseVirtualDevice();
+        !UseVirtualDevice();
     XLA_CHECK(dst_tensor);
     dst_tensor->UpdateFromTensor(self, /*sync=*/sync_update);
   } else if (!dst_tensor) {

--- a/torch_xla/csrc/device.h
+++ b/torch_xla/csrc/device.h
@@ -42,6 +42,10 @@ static inline torch::lazy::BackendDevice GetDeviceOrCurrent(
   return device != nullptr ? *device : GetCurrentDevice();
 }
 
+// Test whether the XLA_USE_SPMD environment variable is set to enable the
+// virtual device optimization.
+bool UseVirtualDevice();
+
 }  // namespace torch_xla
 
 #endif  // XLA_TORCH_XLA_CSRC_DEVICE_H_

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -388,7 +388,7 @@ std::string GetXLATensorDebugInfo(const at::Tensor& tensor) {
   auto at_tensor = xtensor->CurrentTensorData();
   ss << "Tensor on host: ";
   if (at_tensor) {
-    ss << " with size " << at_tensor->sizes() << "\n";
+    ss << "with size " << at_tensor->sizes() << "\n";
   } else {
     ss << "None\n";
   }

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1498,7 +1498,6 @@ void InitXlaModuleBindings(py::module m) {
           << "Input shard shape must include padding: " << shard.sizes()
           << " vs " << shard_shape;
     }
-    // auto xla_devices = GetXlaDevices(devices);
     auto xla_data = ShardingUtil::CreateShardedData(shards, devices,
                                                     xtensor->shape(), sharding);
     xtensor->SetXlaData(WrapXlaData(xla_data));

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1498,8 +1498,8 @@ void InitXlaModuleBindings(py::module m) {
           << "Input shard shape must include padding: " << shard.sizes()
           << " vs " << shard_shape;
     }
-    auto xla_devices = GetXlaDevices(devices);
-    auto xla_data = ShardingUtil::CreateShardedData(shards, xla_devices,
+    // auto xla_devices = GetXlaDevices(devices);
+    auto xla_data = ShardingUtil::CreateShardedData(shards, devices,
                                                     xtensor->shape(), sharding);
     xtensor->SetXlaData(WrapXlaData(xla_data));
   });

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -533,6 +533,10 @@ PjRtComputationClient::ExecuteComputation(
                << device;
     // Grab the shared lock and block the `WaitDeviceOps` until buffer is
     // ready.
+    // TODO(JackCaoG): This lock should acquired outside of the lockfn and
+    // passed in. It is possible that lockfn started after ExecuteComputation
+    // released the xla_graph_executor lock, which will create a short windows
+    // where device is unlcoked while execution is still running.
     auto lock = lock_device_shared(device);
     TF_VLOG(5) << "ExecuteComputation acquiring PJRT device lock for " << device
                << " Done";

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -338,6 +338,7 @@ torch::lazy::Value XLATensor::GetIrValue() const {
   c10::optional<at::Tensor> tensor_data = CurrentTensorData();
   XLA_CHECK(tensor_data);
   AssignIrValue(GetIrValueForTensor(*tensor_data, GetDevice()));
+  data()->tensor_data = c10::nullopt;
   return data()->ir_value;
 }
 

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -492,9 +492,8 @@ void XLATensor::SetTensor(at::Tensor tensor) {
 }
 
 void XLATensor::UpdateFromTensor(at::Tensor tensor, bool sync) {
-  torch::lazy::BackendDevice device = ShardingUtil::UseVirtualDevice()
-                                          ? ParseDeviceString("SPMD:0")
-                                          : GetDevice();
+  torch::lazy::BackendDevice device =
+      UseVirtualDevice() ? ParseDeviceString("SPMD:0") : GetDevice();
   if (sync) {
     at::Tensor typed_tensor =
         torch::lazy::CopyTensor(tensor, dtype(), /*copy=*/false);

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -600,7 +600,7 @@ torch::lazy::BackendDataPtr TensorToXlaData(
     const at::Tensor& tensor, const xla::Shape& shape,
     const torch::lazy::BackendDevice& device) {
   TORCH_LAZY_TIMED("TensorToData");
-  if (ShardingUtil::UseVirtualDevice()) {
+  if (UseVirtualDevice()) {
     // Scalar value will be replicated, no need to delay the transfer here.
     // TODO(JackCaoG): fix this for more general cases.
     if (device.type() == (int8_t)XlaDeviceType::SPMD && shape.rank() > 0) {
@@ -856,7 +856,7 @@ std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
   TORCH_LAZY_TIMED("TensorToData");
   XLA_CHECK_EQ(tensors.size(), devices.size());
 
-  if (ShardingUtil::UseVirtualDevice()) {
+  if (UseVirtualDevice()) {
     // When running in SPMD mode, tensors here in the unsharded
     // CreateTensorsData should be implicitly replicated to all devices.
     // This case should always apply when using SPMD regardless
@@ -936,7 +936,7 @@ std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
 
     std::vector<runtime::ComputationClient::TensorSource> source_tensors;  // in
     std::vector<runtime::ComputationClient::DataPtr> new_handles;  // out
-    if (ShardingUtil::UseVirtualDevice()) {
+    if (UseVirtualDevice()) {
       // GetLocalDevices returns the list of local devices specified by their
       // global ordinals (e.g. ["TPU:4", "TPU:5", "TPU:6", "TPU:7"]).
       std::vector<std::string> local_devices =

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -108,7 +108,7 @@ bool Use32BitLong() {
 
 bool IsTpuDevice(XlaDeviceType hw_type) {
   // TODO(JackCaoG): We can't assume all SPMD device are TPU deivce.
-  return hw_type == XlaDeviceType::TPU && hw_type == XlaDeviceType::SPMD;
+  return hw_type == XlaDeviceType::TPU || hw_type == XlaDeviceType::SPMD;
 }
 
 xla::PrimitiveType XlaTypeFromTensorType(

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -601,18 +601,6 @@ torch::lazy::BackendDataPtr TensorToXlaData(
     const torch::lazy::BackendDevice& device) {
   TORCH_LAZY_TIMED("TensorToData");
   if (UseVirtualDevice()) {
-    // Scalar value will be replicated, no need to delay the transfer here.
-    // TODO(JackCaoG): fix this for more general cases.
-    if (device.type() == (int8_t)XlaDeviceType::SPMD && shape.rank() > 0) {
-      // When SPMD is enabled, we want to delay the data transfer for XLA
-      // tensors until the data is sharded. So, we skip the data transfer
-      // here and simply return a placeholder for the backend data ptr.
-      // Data will only be transferred via CreateTensorsData, when users
-      // call the mark_sharding API.
-      return WrapXlaData(runtime::GetComputationClient()->CreateDataPlaceholder(
-          "SPMD:0", shape));
-    }
-
     // The tensor is bypassing the virtual device, so it should be replicated
     // to all devices.
     std::vector<std::string> local_devices =

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -107,8 +107,10 @@ bool Use32BitLong() {
 }
 
 bool IsTpuDevice(XlaDeviceType hw_type) {
-  // TODO(JackCaoG): We can't assume all SPMD device are TPU deivce.
-  return hw_type == XlaDeviceType::TPU || hw_type == XlaDeviceType::SPMD;
+  static bool spmd_device_is_tpu =
+      (hw_type == XlaDeviceType::SPMD) &&
+      runtime::GetComputationClient()->GetDefaultDevice().find("TPU") == 0;
+  return (hw_type == XlaDeviceType::TPU) || spmd_device_is_tpu;
 }
 
 xla::PrimitiveType XlaTypeFromTensorType(

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -649,7 +649,7 @@ XLAGraphExecutor::ExecuteComputationWithBarrier(
   }
 
   std::vector<XLATensor::ShardingSpecPtr> sharding_specs(placeholders.size());
-  if (ShardingUtil::UseVirtualDevice()) {
+  if (UseVirtualDevice()) {
     ShardingUtil::PrepareOutputShardingPropagation(
         placeholders, sharding_specs, output_shapes,
         cachedComputation->computation, device);

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -395,15 +395,20 @@ void XLAGraphExecutor::WaitDeviceOps(absl::Span<const std::string> devices) {
       wait_devices.insert(ParseDeviceString(device_str));
     }
   } else {
-    for (auto& device_str :
-         runtime::GetComputationClient()->GetLocalDevices()) {
-      wait_devices.insert(ParseDeviceString(device_str));
+    if (UseVirtualDevice()) {
+      wait_devices.insert(ParseDeviceString("SPMD:0"));
+    } else {
+      for (auto& device_str :
+           runtime::GetComputationClient()->GetLocalDevices()) {
+        wait_devices.insert(ParseDeviceString(device_str));
+      }
     }
   }
   // The DeviceLockerArena::Get()->LockDevices() API returns a vector of
   // torch::lazy::ExceptionCleanup object, which is going to be freed
   // immediately, turning this operation into a lock barrier.
   DeviceLockerArena::Get()->LockDevices(wait_devices);
+  TF_VLOG(4) << "XLAGraphExecutor::WaitDeviceOps completed";
 }
 
 std::vector<at::Tensor> XLAGraphExecutor::GetTensors(

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -141,20 +141,6 @@ std::vector<std::vector<int64_t>> ExtractGroupMembers(
 
 }  // namespace
 
-bool ShouldUseVirtualDevice() {
-  bool use_virtual_device =
-      runtime::sys_util::GetEnvBool("XLA_USE_SPMD", false);
-  if (use_virtual_device) {
-    TF_LOG(INFO) << "Using SPMD virtual device optimization";
-  }
-  return use_virtual_device;
-}
-
-bool ShardingUtil::UseVirtualDevice() {
-  static bool use_virtual_device = ShouldUseVirtualDevice();
-  return use_virtual_device;
-}
-
 bool ShardingUtil::SetHloSharding(LoweringContext* lowering_ctx) {
   bool is_sharded = false;
   for (std::pair<torch::lazy::Output, xla::XlaOp> elem :

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -28,10 +28,6 @@ class ShardingUtil {
   // Determine the ShardingType of the given xla::OpSharding.
   static ShardingType GetShardingType(xla::OpSharding& sharding);
 
-  // Test whether the XLA_USE_SPMD environment variable is set to enable the
-  // virtual device optimization.
-  static bool UseVirtualDevice();
-
   // Annotates HLO instructions in the lowered computation and returns true if
   // the computation needs to be compiled with SPMD partitioning. For this call
   // to be effective, this needs to be called after the lowering and before

--- a/torch_xla/experimental/xla_sharded_tensor.py
+++ b/torch_xla/experimental/xla_sharded_tensor.py
@@ -112,7 +112,7 @@ class XLAShardedTensor(torch.Tensor):
     shards, devices = torch_xla._XLAC._get_local_shards(self.global_tensor)
     indices = torch_xla._XLAC._get_local_shard_indices(self.global_tensor)
     return [
-        XLAShard(s.cpu(), i, d) for s, i, d in zip(shards, indices, devices)
+        XLAShard(s, i, d) for s, i, d in zip(shards, indices, devices)
     ]
 
   # Load the given list of local shards into the underlying tensor's data

--- a/torch_xla/experimental/xla_sharded_tensor.py
+++ b/torch_xla/experimental/xla_sharded_tensor.py
@@ -111,9 +111,7 @@ class XLAShardedTensor(torch.Tensor):
   def local_shards(self) -> List[XLAShard]:
     shards, devices = torch_xla._XLAC._get_local_shards(self.global_tensor)
     indices = torch_xla._XLAC._get_local_shard_indices(self.global_tensor)
-    return [
-        XLAShard(s, i, d) for s, i, d in zip(shards, indices, devices)
-    ]
+    return [XLAShard(s, i, d) for s, i, d in zip(shards, indices, devices)]
 
   # Load the given list of local shards into the underlying tensor's data
   # on the local devices.

--- a/torch_xla/experimental/xla_sharded_tensor.py
+++ b/torch_xla/experimental/xla_sharded_tensor.py
@@ -109,8 +109,7 @@ class XLAShardedTensor(torch.Tensor):
   # which results from the sharding.
   @property
   def local_shards(self) -> List[XLAShard]:
-    shards = torch_xla._XLAC._get_local_shards(self.global_tensor)
-    devices = [str(shard.device) for shard in shards]
+    shards, devices = torch_xla._XLAC._get_local_shards(self.global_tensor)
     indices = torch_xla._XLAC._get_local_shard_indices(self.global_tensor)
     return [
         XLAShard(s.cpu(), i, d) for s, i, d in zip(shards, indices, devices)


### PR DESCRIPTION
Context:
On current head, depending on how you created sharded tensor, the XLATensor(in C++)'s device might be either `SPMD:0` or `TPU:0`. This creates a bunch of issues and make codes really hard to understand. In this par I want to make all XLATensor device to be SPMD:0.

Other things I changed
1. for distributed checkpointing, each sharded used to be on devices like `xla:0`, `xla:1` ... I changed them to the actual hardware device like `tpu:0`, `tpu:1` since I only want to expose `xla:0` as virtual device to the user. This is fine on TPU but if we want to take a checkpoint on TPU and load it to GPU it will cause an error. I think we can just mark it as a todo now. @jonb377 FYI
2. Currently in some edge cases virtual device will create data placeholder for things when sharding is unkown. I think we should never do that since it is very problematic. IMO the only places that virtual device needs to optimize is
```
device = xm.xla_device()
fc = nn.Linear(FLAGS.input_dim, FLAGS.input_dim // 2)
fc.to(device)                                       ----> virtual device should delay the transfer
xs.mark_sharding(fc.parameters[0], sharding_spec)         ----> transfer the parameter[0] to device sharded

fc(input)                                                ----> all other paramter should be replicated
xm.mark_step()                                        ----> no device upload should happen during mark_step
```

TODO:
There are a bunch of places we use `UseVirtualDevice` to check things, we should check `XLATensor->Device()` whenever possible instead.