### PR TITLE
Disable torch._dynamo.config.automatic_dynamic_shapes

### DIFF
--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -68,7 +68,6 @@ class DynamoInferenceBasicTest(unittest.TestCase):
     res_cpu_3 = self.fn_simple(x + y, y * 3)
     self.assertTrue(torch.allclose(res_cpu_3, res_xla_dynamo_3.cpu()))
 
-  @unittest.skip("currently failing at head")
   def test_simple_model_with_different_input_shape(self):
     met.clear_counters()
     device = xm.xla_device()

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -125,9 +125,9 @@ atexit.register(_prepare_to_exit)
 _apply_patches()
 _init_xla_lazy_backend()
 
-# This is to temporarily disable the automtic dynamic shape in PyTorch Dynamo, 
-# which was enabled by https://github.com/pytorch/pytorch/pull/103623. 
-# While we come up with a long term fix, we'll set this flag to False to 
+# This is to temporarily disable the automtic dynamic shape in PyTorch Dynamo,
+# which was enabled by https://github.com/pytorch/pytorch/pull/103623.
+# While we come up with a long term fix, we'll set this flag to False to
 # keep PyTorch/XLA CI healthy.
 # TODO @wonjoo come up with a long term fix in Dynamo.
 torch._dynamo.config.automatic_dynamic_shapes = False

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -124,3 +124,10 @@ def _init_xla_lazy_backend():
 atexit.register(_prepare_to_exit)
 _apply_patches()
 _init_xla_lazy_backend()
+
+# This is to temporarily disable the automtic dynamic shape in PyTorch Dynamo, 
+# which was enabled by https://github.com/pytorch/pytorch/pull/103623. 
+# While we come up with a long term fix, we'll set this flag to False to 
+# keep PyTorch/XLA CI healthy.
+# TODO @wonjoo come up with a long term fix in Dynamo.
+torch._dynamo.config.automatic_dynamic_shapes = False


### PR DESCRIPTION
With https://github.com/pytorch/pytorch/pull/103623 that enables dynamic shape on PyTorch Dynamo by default, our test DynamoInferenceBasicTest.test_simple_model_with_different_input_shape was broken. 

More context: https://github.com/pytorch/pytorch/pull/103623#issuecomment-1622571952

While we investigate for a long term fix, manually setting this flag (https://github.com/pytorch/pytorch/pull/103623/files#diff-5f3e7e4866f93af05691e2382d2258cad959091492f900583a49e55266f5e897L67) to False.

With this, the test is succeeding again:
```
wonjoo@t1v-n-9eb87547-w-0:~/pytorch/xla$ python3 test/dynamo/test_dynamo.py DynamoInferenceBasicTest.test_simple_model_with_different_input_shape
.
----------------------------------------------------------------------
Ran 1 test in 3.191s

OK

```

cc @JackCaoG, let me know if you think this is okay. 