### PR TITLE
Lower squeeze_copy.dims

### DIFF
--- a/codegen/xla_native_functions.yaml
+++ b/codegen/xla_native_functions.yaml
@@ -311,6 +311,7 @@ supported:
   - sqrt
   - squeeze_copy
   - squeeze_copy.dim
+  - squeeze_copy.dims
   - stack
   - std
   - std.correction

--- a/test/cpp/test_aten_xla_tensor_4.cpp
+++ b/test/cpp/test_aten_xla_tensor_4.cpp
@@ -932,6 +932,18 @@ TEST_F(AtenXlaTensorTest, TestSqueezeOne) {
   }
 }
 
+TEST_F(AtenXlaTensorTest, TestSqueezeMultipleDims) {
+  torch::Tensor input =
+      torch::rand({2, 1, 3, 1}, torch::TensorOptions(torch::kFloat));
+  std::vector<int64_t> dims = {1, 2, 3};
+  torch::Tensor output = torch::squeeze(input, dims);
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_input = CopyToDevice(input, device);
+    torch::Tensor xla_output = torch::squeeze(xla_input, dims);
+    AllClose(output, xla_output);
+  });
+}
+
 TEST_F(AtenXlaTensorTest, TestSqueezeOneInPlace) {
   int rank = 4;
   for (int dim = -rank; dim < rank; ++dim) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2915,6 +2915,13 @@ at::Tensor XLANativeFunctions::squeeze_copy(const at::Tensor& self,
       tensor_methods::squeeze(bridge::GetXlaTensor(self), dim));
 }
 
+at::Tensor XLANativeFunctions::squeeze_copy(const at::Tensor& self,
+                                            at::IntArrayRef dim) {
+  TORCH_LAZY_FN_COUNTER("xla::");
+  return bridge::AtenFromXlaTensor(tensor_methods::squeeze(
+      bridge::GetXlaTensor(self), torch::lazy::ToVector<int64_t>(dim)));
+}
+
 at::Tensor XLANativeFunctions::stack(at::TensorList tensors, int64_t dim) {
   TORCH_LAZY_FN_COUNTER("xla::");
   return bridge::AtenFromXlaTensor(

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2474,6 +2474,22 @@ XLATensorPtr squeeze(const XLATensorPtr& input, int64_t dim) {
   return view(input, output_dimensions);
 }
 
+XLATensorPtr squeeze(const XLATensorPtr& input, std::vector<int64_t> dims) {
+  auto input_shape = input->shape();
+  std::vector<int64_t> input_dimensions =
+      torch_xla::runtime::util::ToVector<int64_t>(
+          input_shape.get().dimensions());
+  std::vector<int64_t> output_dimensions;
+  for (int64_t dim : dims) {
+    if (dim >= input_dimensions.size()) continue;
+    int64_t squeeze_dim =
+        torch::lazy::GetCanonicalDimensionIndex(dim, input_dimensions.size());
+    output_dimensions = BuildSqueezedDimensions(input_dimensions, squeeze_dim);
+    input_dimensions = output_dimensions;
+  }
+  return view(input, output_dimensions);
+}
+
 XLATensorPtr stack(absl::Span<const XLATensorPtr> tensors, int64_t dim) {
   XLA_CHECK_GT(tensors.size(), 0);
   std::vector<torch::lazy::Value> values;

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -785,6 +785,9 @@ XLATensorPtr squeeze(const XLATensorPtr& input);
 // unchanged input otherwise.
 XLATensorPtr squeeze(const XLATensorPtr& input, int64_t dim);
 
+// Same as above, but with a tuple of dims.
+XLATensorPtr squeeze(const XLATensorPtr& input, std::vector<int64_t> dims);
+
 // In-place versions of the methods above.
 void squeeze_(XLATensorPtr& input);
 void squeeze_(XLATensorPtr& input, int64_t dim);


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/5276

---

Test plan:
`bazel test //test/cpp/... --test_filter=AtenXlaTensorTest.TestSqueezeMultipleDims`