### PR TITLE
Update inline style code to multiline

### DIFF
--- a/torch_xla/csrc/aten_xla_bridge.cpp
+++ b/torch_xla/csrc/aten_xla_bridge.cpp
@@ -150,9 +150,13 @@ std::vector<at::Tensor> XlaCreateTensorList(const at::ITensorListRef& tensors) {
   std::vector<bool> to_translate(tensors.size());
   size_t ix = 0;
   for (const auto& tensor : tensors) {
-    if (!tensor.defined()) continue;
+    if (!tensor.defined()) {
+      continue;
+    }
     auto inner_tensor = torch::lazy::maybe_unwrap_functional(tensor);
-    if (!inner_tensor.defined()) continue;
+    if (!inner_tensor.defined()) {
+      continue;
+    }
 
     auto xtensor = TryGetXlaTensor(tensor);
     if (xtensor) {

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2482,7 +2482,9 @@ XLATensorPtr squeeze(const XLATensorPtr& input, std::vector<int64_t> dims) {
           input_shape.get().dimensions());
   std::vector<int64_t> output_dimensions;
   for (int64_t dim : dims) {
-    if (dim >= input_dimensions.size()) continue;
+    if (dim >= input_dimensions.size()) {
+      continue;
+    }
     int64_t squeeze_dim =
         torch::lazy::GetCanonicalDimensionIndex(dim, input_dimensions.size());
     output_dimensions = BuildSqueezedDimensions(input_dimensions, squeeze_dim);


### PR DESCRIPTION
Follow-up to https://github.com/pytorch/xla/pull/5286, fixing some inline style code in `squeeze.dims` op and other places like:
```
if (something) continue;
```
to multiline:
```
if (something) {
  continue;
}
```

Test plan:
CI