### PR TITLE
[SPMD] Allow dumping post optimizations hlo

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -420,3 +420,9 @@ variables:
           StableHLO workflow is mature.
       type: bool
       default_value: false
+    XLA_DUMP_POST_OPTIMIZATIONS:
+      descripton:
+        - Dump the HLO graph after optimizations. You need to use it together
+          with XLA_SAVE_TENSORS_FMT='hlo' and XLA_SAVE_TENSORS_FILE='your/location'.
+      type: bool
+      default_value: false

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -584,6 +584,16 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
 
     self.assertTrue(torch.allclose(expected, actual.cpu()))
 
+  @patch.dict(os.environ, {"XLA_DUMP_POST_OPTIMIZATIONS": "1"})
+  def test_xla_sharded_hlo_dump_post_optimizations(self):
+    t1 = torch.randn(1, 128).to(xm.xla_device())
+    t2 = torch.randn(128, 1).to(xm.xla_device())
+    xs.mark_sharding(t1, self._get_mesh((1, self.n_devices)), (0, 1))
+
+    t3 = t1 @ t2
+    hlo = torch_xla._XLAC._get_xla_tensors_hlo([t3])
+    self.assertIn('all-reduce', hlo)
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -592,7 +592,8 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
 
     t3 = t1 @ t2
     hlo = torch_xla._XLAC._get_xla_tensors_hlo([t3])
-    self.assertIn('all-reduce', hlo)
+    if self.n_devices > 1:
+      self.assertIn('all-reduce', hlo)
 
 
 if __name__ == '__main__':

--- a/torch_xla/csrc/ir_dump_util.cpp
+++ b/torch_xla/csrc/ir_dump_util.cpp
@@ -266,7 +266,8 @@ std::string DumpUtil::ToHlo(c10::ArrayRef<torch::lazy::Value> values,
   auto is_sharded = ShardingUtil::SetHloSharding(&lowering_ctx);
   xla::XlaComputation computation = ConsumeValue(lowering_ctx.BuildXla());
 
-  static bool dump_post_optimizations = runtime::sys_util::GetEnvBool("XLA_DUMP_POST_OPTIMIZATIONS", false);
+  static bool dump_post_optimizations =
+      runtime::sys_util::GetEnvBool("XLA_DUMP_POST_OPTIMIZATIONS", false);
   if (dump_post_optimizations) {
     xla::Shape shape = MakeShapeWithDeviceLayout(
         ConsumeValue(computation.GetProgramShape()).result(),

--- a/torch_xla/csrc/ir_dump_util.cpp
+++ b/torch_xla/csrc/ir_dump_util.cpp
@@ -263,8 +263,26 @@ std::string DumpUtil::ToHlo(c10::ArrayRef<torch::lazy::Value> values,
 
   // Annotate HLO sharding selectively in the compuation.
   // This is no-op if an instruction doesn't have any sharding annotation.
-  ShardingUtil::SetHloSharding(&lowering_ctx);
+  auto is_sharded = ShardingUtil::SetHloSharding(&lowering_ctx);
   xla::XlaComputation computation = ConsumeValue(lowering_ctx.BuildXla());
+
+  static bool dump_post_optimizations = runtime::sys_util::GetEnvBool("XLA_DUMP_POST_OPTIMIZATIONS", false);
+  if (dump_post_optimizations) {
+    xla::Shape shape = MakeShapeWithDeviceLayout(
+        ConsumeValue(computation.GetProgramShape()).result(),
+        static_cast<XlaDeviceType>(device.type()));
+    std::vector<runtime::ComputationClient::CompileInstance> instances;
+    instances.push_back({std::move(computation), device.toString(),
+                         runtime::GetComputationClient()->GetCompilationDevices(
+                             device.toString(), {}),
+                         &shape,
+                         /*parameter_is_tupled_arguments=*/false, is_sharded});
+    std::vector<std::shared_ptr<runtime::ComputationClient::Computation>>
+        computations =
+            runtime::GetComputationClient()->Compile(std::move(instances));
+    computation = std::move(computations[0]->move_computation());
+  }
+
   switch (mode) {
     case EmitMode::kHloReadable:
       return ConsumeValue(runtime::util::GetComputationHloText(computation));


### PR DESCRIPTION
Summary:
This pull request partial reverts the change in #5266 to re-enble dumping post optimizations hlo.

Test Plan:
XLA_USE_SPMD=1 PJRT_DEVICE=TPU python test/spmd/test_xla_sharding.py -v -k test_xla_sharded_hlo_dump_post_optimizations