### PR TITLE
Enable Some input output aliasing under SPMD

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -734,6 +734,18 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     if self.n_devices > 1:
       self.assertIn('all-reduce', hlo)
 
+  def test_sharded_tensor_aliasing(self):
+    met.clear_all()
+    partition_spec = (0, 1)
+    xt1 = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]],
+                       dtype=torch.float,
+                       device=xm.xla_device())
+    xst1 = xs.mark_sharding(xt1, self._get_mesh((1, self.n_devices)),
+                            partition_spec)
+    xst1 += 1
+    xm.mark_step()
+    self.assertEqual(met.metric_data("InputOutputAliasCount")[0], 1)
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -354,6 +354,15 @@ std::string GetTensorsHloGraph(const std::vector<at::Tensor>& tensors,
   return XLAGraphExecutor::Get()->DumpHloComputation(xtensors, mode);
 }
 
+std::string GetXLAShardingSpec(const XLATensorPtr xtensor) {
+  auto sharding_spec = xtensor->sharding_spec();
+  if (sharding_spec != nullptr) {
+    auto hlo_sharding = xla::HloSharding::FromProto(sharding_spec->sharding);
+    return hlo_sharding->ToString();
+  }
+  return std::string();
+}
+
 std::string GetXLATensorDebugInfo(const at::Tensor& tensor) {
   auto xtensor = bridge::TryGetXlaTensor(tensor);
   if (!xtensor) {
@@ -364,6 +373,11 @@ std::string GetXLATensorDebugInfo(const at::Tensor& tensor) {
   ss << "TensorID: " << xtensor->GetUniqueId() << "\n";
   ss << "Device: " << xtensor->GetDevice() << "\n";
   ss << "XLA Shape: " << xtensor->shape().get().ToString() << "\n";
+
+  std::string sharding_spec_str = GetXLAShardingSpec(xtensor);
+  ss << "ShardingSpec: "
+     << ((sharding_spec_str.size() > 0) ? sharding_spec_str : "None");
+  ss << "\n";
 
   torch::lazy::Value ir_value = xtensor->CurrentIrValue();
   ss << "IR: ";
@@ -1380,12 +1394,7 @@ void InitXlaModuleBindings(py::module m) {
   });
   m.def("_get_xla_sharding_spec", [](const at::Tensor& input) -> std::string {
     XLATensorPtr xtensor = bridge::GetXlaTensor(input);
-    auto sharding_spec = xtensor->sharding_spec();
-    if (sharding_spec != nullptr) {
-      auto hlo_sharding = xla::HloSharding::FromProto(sharding_spec->sharding);
-      return hlo_sharding->ToString();
-    }
-    return std::string();
+    return GetXLAShardingSpec(xtensor);
   });
   m.def("_get_xla_sharding_type",
         [](const at::Tensor& input) -> std::optional<int> {

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -181,6 +181,11 @@ bool ShardingUtil::EqualShardingSpecs(const XLATensor::ShardingSpec& a,
   return xla::protobuf_util::ProtobufEquals(a.sharding, b.sharding);
 }
 
+bool ShardingUtil::EqualOpShardings(const xla::OpSharding& a,
+                                    const xla::OpSharding& b) {
+  return xla::protobuf_util::ProtobufEquals(a, b);
+}
+
 xla::OpSharding ShardingUtil::CreateOpSharding(
     const py::list& tile_assignment, const py::list& group_assignment,
     const py::list& replication_groups, ShardingType sharding_type) {

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -38,6 +38,10 @@ class ShardingUtil {
   static bool EqualShardingSpecs(const XLATensor::ShardingSpec& a,
                                  const XLATensor::ShardingSpec& b);
 
+  // Returns true if two OpShardings are the same.
+  static bool EqualOpShardings(const xla::OpSharding& a,
+                               const xla::OpSharding& b);
+
   // Creates an xla::OpSharding. `tile_assignmnent` is required for TILED
   // `sharding_type` and `replication_groups` for `PARTIAL`.
   static xla::OpSharding CreateOpSharding(const py::list& tile_assignment,


### PR DESCRIPTION
I was able to see buffer being aliased when running conv sharding for `Resnet50`. 

Note that this pr mostly enables aliasing for parameters that we explictly call `mark_sharding` and applied in place operation in optimizer(in place operation will inherit the sharding in XLATensor level). For those tensors that does not have explicit output sharding we currently skipped aliasing since compiler might assign different sharing.