### PR TITLE
[SPMD] Multi-host batch sharded data loading

### DIFF
--- a/test/cpp/test_xla_sharding.cpp
+++ b/test/cpp/test_xla_sharding.cpp
@@ -36,18 +36,22 @@ class XLAShardingTest : public AtenXlaTensorTestBase {};
 
 TEST_F(XLAShardingTest, GetShardShape) {
   auto tensor = at::ones({8, 7}, at::TensorOptions(at::kFloat));
+  xla::Shape tensor_shape = CreateComputationShapeFromTensor(tensor, GetDefaultDevice());
   xla::Array2D<int64_t> mesh({
       {0, 1},
       {2, 3},
   });
   auto sharding = xla::HloSharding::Tile(mesh).ToProto();
+  auto sharding_spec = std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
+
   auto shard_shape =
-      ShardingUtil::GetShardShape(tensor.sizes().vec(), sharding);
+      ShardingUtil::GetShardShape(sharding_spec);
   // For tiled sharding, each dimension should be halved
   EXPECT_EQ(shard_shape, std::vector<int64_t>({4, 4}));
 
   sharding = xla::HloSharding::Replicate().ToProto();
-  shard_shape = ShardingUtil::GetShardShape(tensor.sizes().vec(), sharding);
+  sharding_spec->sharding = sharding;
+  shard_shape = ShardingUtil::GetShardShape(sharding_spec);
   // For replicated sharding, each dimension should be preserved
   EXPECT_EQ(shard_shape, std::vector<int64_t>({8, 7}));
 }
@@ -56,13 +60,15 @@ TEST_F(XLAShardingTest, GetShardIndicesForDevices) {
   std::vector<std::string> devices = {"TPU:0", "TPU:1", "TPU:2", "TPU:3"};
 
   auto tensor = at::ones({8, 7}, at::TensorOptions(at::kFloat));
+  xla::Shape tensor_shape = CreateComputationShapeFromTensor(tensor, nullptr);
   xla::Array2D<int64_t> mesh({
       {0, 1},
       {2, 3},
   });
   auto sharding = xla::HloSharding::Tile(mesh).ToProto();
+  auto sharding_spec = std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
   auto shard_shape =
-      ShardingUtil::GetShardShape(tensor.sizes().vec(), sharding);
+      ShardingUtil::GetShardShape(sharding_spec);
   auto shard_indices = ShardingUtil::GetShardIndicesForDevices(
       shard_shape, tensor.sizes().vec(), sharding, devices);
   EXPECT_EQ(shard_indices.size(), devices.size());
@@ -86,7 +92,8 @@ TEST_F(XLAShardingTest, GetShardIndicesForDevices) {
   }
 
   sharding = xla::HloSharding::Replicate().ToProto();
-  shard_shape = ShardingUtil::GetShardShape(tensor.sizes().vec(), sharding);
+  sharding_spec->sharding = sharding;
+  shard_shape = ShardingUtil::GetShardShape(sharding_spec);
   shard_indices = ShardingUtil::GetShardIndicesForDevices(
       shard_shape, tensor.sizes().vec(), sharding, devices);
   EXPECT_EQ(shard_indices.size(), devices.size());
@@ -96,20 +103,6 @@ TEST_F(XLAShardingTest, GetShardIndicesForDevices) {
   }
 }
 
-// TEST_F(XLAShardingTest, GetShardIndicesForBatchShardedTensor) {
-//     std::vector<std::string> devices = {"TPU:0", "TPU:1", "TPU:2", "TPU:3"};
-
-//     auto tensor = at::ones({8, 7}, at::TensorOptions(at::kFloat));
-//     xla::Array2D<int64_t> mesh({
-//       {0},
-//       {1},
-//       {2},
-//       {3},
-//     });
-//     auto sharding = xla::HloSharding::Tile(mesh).ToProto();
-//     auto shard_shape =
-//       ShardingUtil::GetShardShape(tensor.sizes().vec(), sharding);
-// }
 
 TEST_F(XLAShardingTest, ShardTensor) {
   std::vector<std::string> devices = {"TPU:0", "TPU:1", "TPU:2", "TPU:3",
@@ -117,13 +110,15 @@ TEST_F(XLAShardingTest, ShardTensor) {
 
   // 1D tiled
   at::Tensor tensor = at::ones({8}, at::TensorOptions(at::kFloat));
+  xla::Shape tensor_shape = CreateComputationShapeFromTensor(tensor, nullptr);
   xla::OpSharding sharding =
       xla::HloSharding::Tile1D(
           CreateComputationShapeFromTensor(tensor, GetDefaultDevice()),
           devices.size())
           .ToProto();
+  auto sharding_spec = std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
   auto shards =
-      ShardingUtil::ShardTensor(tensor, sharding, devices, /*padded=*/false);
+      ShardingUtil::ShardTensor(tensor, sharding_spec, devices, /*padded=*/false);
   EXPECT_EQ(shards.size(), 8);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({1}));
   EXPECT_EQ(shards[1].sizes(), c10::ArrayRef<long>({1}));
@@ -131,13 +126,15 @@ TEST_F(XLAShardingTest, ShardTensor) {
   // 2D tiled, The first dim is halved and the last replicated. The last shard
   // size should be smaller in dim=1 because it's not evenly divisible.
   tensor = at::ones({8, 7, 4}, at::TensorOptions(at::kFloat));
+  tensor_shape = CreateComputationShapeFromTensor(tensor, nullptr);
   xla::Array2D<int64_t> mesh({
       {0, 1, 2, 3},
       {4, 5, 6, 7},
   });
   sharding = xla::HloSharding::Tile(mesh).ToProto();
+  sharding_spec = std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
   shards =
-      ShardingUtil::ShardTensor(tensor, sharding, devices, /*padded=*/false);
+      ShardingUtil::ShardTensor(tensor, sharding_spec, devices, /*padded=*/false);
   EXPECT_EQ(shards.size(), 8);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({4, 2, 4}));
   EXPECT_EQ(shards[7].sizes(), c10::ArrayRef<long>({4, 1, 4}));
@@ -146,16 +143,18 @@ TEST_F(XLAShardingTest, ShardTensor) {
   // size should be smaller in dim=1 because it's not evenly divisible.
   xla::Array3D<int64_t> cube({{{0, 1}, {2, 3}, {4, 5}, {6, 7}}});
   sharding = xla::HloSharding::Tile(cube).ToProto();
+  sharding_spec->sharding = sharding;
   shards =
-      ShardingUtil::ShardTensor(tensor, sharding, devices, /*padded=*/false);
+      ShardingUtil::ShardTensor(tensor, sharding_spec, devices, /*padded=*/false);
   EXPECT_EQ(shards.size(), 8);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({8, 2, 2}));
   EXPECT_EQ(shards[7].sizes(), c10::ArrayRef<long>({8, 1, 2}));
 
   // Replicated, all shards should be identical.
   sharding = xla::HloSharding::Replicate().ToProto();
+  sharding_spec->sharding = sharding;
   shards =
-      ShardingUtil::ShardTensor(tensor, sharding, devices, /*padded=*/false);
+      ShardingUtil::ShardTensor(tensor, sharding_spec, devices, /*padded=*/false);
   EXPECT_EQ(shards.size(), 8);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({8, 7, 4}));
   EXPECT_EQ(shards[7].sizes(), c10::ArrayRef<long>({8, 7, 4}));
@@ -164,17 +163,19 @@ TEST_F(XLAShardingTest, ShardTensor) {
   // last shard size should be smaller in dim=2 because it's not evenly
   // divisible.
   tensor = at::ones({1, 8, 7, 4}, at::TensorOptions(at::kFloat));
+  tensor_shape = CreateComputationShapeFromTensor(tensor, nullptr);
   xla::Array4D<int64_t> tesseract({{{{0, 1}, {2, 3}, {4, 5}, {6, 7}}}});
   sharding = xla::HloSharding::Tile(tesseract).ToProto();
+  sharding_spec = std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
   shards =
-      ShardingUtil::ShardTensor(tensor, sharding, devices, /*padded=*/false);
+      ShardingUtil::ShardTensor(tensor, sharding_spec, devices, /*padded=*/false);
   EXPECT_EQ(shards.size(), 8);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({1, 8, 2, 2}));
   EXPECT_EQ(shards[7].sizes(), c10::ArrayRef<long>({1, 8, 1, 2}));
 
   // 4D tiled and padded, all shard sizes should be idential.
   shards =
-      ShardingUtil::ShardTensor(tensor, sharding, devices, /*padded=*/true);
+      ShardingUtil::ShardTensor(tensor, sharding_spec, devices, /*padded=*/true);
   EXPECT_EQ(shards.size(), 8);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({1, 8, 2, 2}));
   EXPECT_EQ(shards[7].sizes(), c10::ArrayRef<long>({1, 8, 2, 2}));
@@ -183,18 +184,20 @@ TEST_F(XLAShardingTest, ShardTensor) {
   // last shard size should be smaller in dim=2 because it's not evenly
   // divisible.
   tensor = at::ones({10, 1, 8, 7, 4}, at::TensorOptions(at::kFloat));
+  tensor_shape = CreateComputationShapeFromTensor(tensor, nullptr);
   xla::Array<int64_t> hypercube(std::vector<int64_t>{1, 1, 2, 2, 2});
   hypercube.FillIota(0);
   sharding = xla::HloSharding::Tile(hypercube).ToProto();
+  sharding_spec = std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
   shards =
-      ShardingUtil::ShardTensor(tensor, sharding, devices, /*padded=*/false);
+      ShardingUtil::ShardTensor(tensor, sharding_spec, devices, /*padded=*/false);
   EXPECT_EQ(shards.size(), 8);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({10, 1, 4, 4, 2}));
   EXPECT_EQ(shards[7].sizes(), c10::ArrayRef<long>({10, 1, 4, 3, 2}));
 
   // 5D tiled and padded, all shard sizes should be identical.
   shards =
-      ShardingUtil::ShardTensor(tensor, sharding, devices, /*padded=*/true);
+      ShardingUtil::ShardTensor(tensor, sharding_spec, devices, /*padded=*/true);
   EXPECT_EQ(shards.size(), 8);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({10, 1, 4, 4, 2}));
   EXPECT_EQ(shards[7].sizes(), c10::ArrayRef<long>({10, 1, 4, 4, 2}));
@@ -205,16 +208,17 @@ TEST_F(XLAShardingTest, ShardTensorMultiHost) {
 
   // 2D tiled, The first dim is halved and the last replicated.
   at::Tensor tensor = at::ones({8, 7, 4}, at::TensorOptions(at::kFloat));
+  xla::Shape tensor_shape = CreateComputationShapeFromTensor(tensor, nullptr);
   xla::Array2D<int64_t> mesh({
       {4, 5, 0, 1},
       {6, 7, 2, 3},
   });
   auto sharding = xla::HloSharding::Tile(mesh).ToProto();
-
+  auto sharding_spec = std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
   // For devices at the start of the mesh, all shards should have the same
   // unpadded shape.
   auto shards =
-      ShardingUtil::ShardTensor(tensor, sharding, devices, /*padded=*/false);
+      ShardingUtil::ShardTensor(tensor, sharding_spec, devices, /*padded=*/false);
   EXPECT_EQ(shards.size(), 4);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({4, 2, 4}));
   EXPECT_EQ(shards[3].sizes(), c10::ArrayRef<long>({4, 2, 4}));
@@ -226,22 +230,45 @@ TEST_F(XLAShardingTest, ShardTensorMultiHost) {
       {2, 3, 6, 7},
   });
   sharding = xla::HloSharding::Tile(mesh).ToProto();
+  sharding_spec->sharding = sharding;
   shards =
-      ShardingUtil::ShardTensor(tensor, sharding, devices, /*padded=*/false);
+      ShardingUtil::ShardTensor(tensor, sharding_spec, devices, /*padded=*/false);
   EXPECT_EQ(shards.size(), 4);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({4, 2, 4}));
   EXPECT_EQ(shards[3].sizes(), c10::ArrayRef<long>({4, 1, 4}));
 }
 
+TEST_F(XLAShardingTest, ShardTensorMiniBatch) {
+  std::vector<std::string> devices = {"TPU:4", "TPU:5", "TPU:6", "TPU:7"};
+  at::Tensor minibatch_tensor = at::ones({8, 7, 4}, at::TensorOptions(at::kFloat));
+  xla::Shape tensor_shape = CreateComputationShapeFromTensor(minibatch_tensor, nullptr);
+  tensor_shape.set_dimensions(0,minibatch_tensor.sizes()[0] * 2); // Assuming 2 hosts
+  xla::Array2D<int64_t> mesh({
+      {0}, {1}, {2}, {3},
+      {4}, {5}, {6}, {7},
+  });
+
+  auto sharding = xla::HloSharding::Tile(mesh).ToProto();
+  auto sharding_spec = std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape, /*minibatch=*/true);
+  auto shards =
+      ShardingUtil::ShardTensor(minibatch_tensor, sharding_spec, devices, /*padded=*/false);
+  EXPECT_EQ(shards.size(), 4);
+  EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({2, 7, 4}));
+  EXPECT_EQ(shards[3].sizes(), c10::ArrayRef<long>({2, 7, 4}));
+
+}
+
 TEST_F(XLAShardingTest, EqualShardingSpecs) {
+  auto tensor = at::ones({8, 7}, at::TensorOptions(at::kFloat));
+  xla::Shape tensor_shape = CreateComputationShapeFromTensor(tensor, nullptr);
   XLATensor::ShardingSpec tiled_2d(xla::HloSharding::Tile({
                                                               {0, 1, 2, 3},
                                                               {4, 5, 6, 7},
                                                           })
-                                       .ToProto());
+                                       .ToProto(), tensor_shape);
   XLATensor::ShardingSpec tiled_3d(
-      xla::HloSharding::Tile({{{0, 1}, {2, 3}, {4, 5}, {6, 7}}}).ToProto());
-  XLATensor::ShardingSpec replicated(xla::HloSharding::Replicate().ToProto());
+      xla::HloSharding::Tile({{{0, 1}, {2, 3}, {4, 5}, {6, 7}}}).ToProto(), tensor_shape);
+  XLATensor::ShardingSpec replicated(xla::HloSharding::Replicate().ToProto(), tensor_shape);
   EXPECT_TRUE(ShardingUtil::EqualShardingSpecs(tiled_2d, tiled_2d));
   EXPECT_FALSE(ShardingUtil::EqualShardingSpecs(tiled_2d, tiled_3d));
   EXPECT_TRUE(ShardingUtil::EqualShardingSpecs(replicated, replicated));
@@ -255,13 +282,14 @@ TEST_F(XLAShardingTest, CreateTensorsData) {
   }
 
   std::vector<at::Tensor> tensors(2);
-  std::fill_n(tensors.begin(), tensors.size(),
-              at::ones({8, 8}, at::TensorOptions(at::kFloat)));
+  auto tensor = at::ones({8, 8}, at::TensorOptions(at::kFloat));
+  xla::Shape tensor_shape = CreateComputationShapeFromTensor(tensor, nullptr);
+  std::fill_n(tensors.begin(), tensors.size(), tensor);
   std::vector<std::string> devices(2);
   std::fill_n(devices.begin(), devices.size(), GetDefaultDevice()->toString());
   std::vector<XLATensor::ShardingSpecPtr> shardings = {
       nullptr, std::make_shared<XLATensor::ShardingSpec>(
-                   xla::HloSharding::Replicate().ToProto())};
+                   xla::HloSharding::Replicate().ToProto(), tensor_shape)};
   std::vector<torch::lazy::BackendDataPtr> tensors_data =
       CreateTensorsData(tensors, shardings, devices);
 
@@ -303,12 +331,13 @@ TEST_F(XLAShardingTest, InputHandler) {
   }
 
   std::vector<at::Tensor> tensors(2);
-  std::fill_n(tensors.begin(), tensors.size(),
-              at::ones({8, 8}, at::TensorOptions(at::kFloat)));
+  auto tensor = at::ones({8, 8}, at::TensorOptions(at::kFloat));
+  xla::Shape tensor_shape = CreateComputationShapeFromTensor(tensor, nullptr);
+  std::fill_n(tensors.begin(), tensors.size(),tensor);
   std::vector<std::string> devices = {"TPU:0", "TPU:1"};
   std::vector<XLATensor::ShardingSpecPtr> shardings = {
       nullptr, std::make_shared<XLATensor::ShardingSpec>(
-                   xla::HloSharding::Replicate().ToProto())};
+                   xla::HloSharding::Replicate().ToProto(), tensor_shape)};
   std::vector<torch::lazy::BackendDataPtr> tensors_data =
       CreateTensorsData(tensors, shardings, devices);
 

--- a/test/cpp/test_xla_sharding.cpp
+++ b/test/cpp/test_xla_sharding.cpp
@@ -36,16 +36,17 @@ class XLAShardingTest : public AtenXlaTensorTestBase {};
 
 TEST_F(XLAShardingTest, GetShardShape) {
   auto tensor = at::ones({8, 7}, at::TensorOptions(at::kFloat));
-  xla::Shape tensor_shape = CreateComputationShapeFromTensor(tensor, GetDefaultDevice());
+  xla::Shape tensor_shape =
+      CreateComputationShapeFromTensor(tensor, GetDefaultDevice());
   xla::Array2D<int64_t> mesh({
       {0, 1},
       {2, 3},
   });
   auto sharding = xla::HloSharding::Tile(mesh).ToProto();
-  auto sharding_spec = std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
+  auto sharding_spec =
+      std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
 
-  auto shard_shape =
-      ShardingUtil::GetShardShape(sharding_spec);
+  auto shard_shape = ShardingUtil::GetShardShape(sharding_spec);
   // For tiled sharding, each dimension should be halved
   EXPECT_EQ(shard_shape, std::vector<int64_t>({4, 4}));
 
@@ -66,9 +67,9 @@ TEST_F(XLAShardingTest, GetShardIndicesForDevices) {
       {2, 3},
   });
   auto sharding = xla::HloSharding::Tile(mesh).ToProto();
-  auto sharding_spec = std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
-  auto shard_shape =
-      ShardingUtil::GetShardShape(sharding_spec);
+  auto sharding_spec =
+      std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
+  auto shard_shape = ShardingUtil::GetShardShape(sharding_spec);
   auto shard_indices = ShardingUtil::GetShardIndicesForDevices(
       shard_shape, tensor.sizes().vec(), sharding, devices);
   EXPECT_EQ(shard_indices.size(), devices.size());
@@ -103,7 +104,6 @@ TEST_F(XLAShardingTest, GetShardIndicesForDevices) {
   }
 }
 
-
 TEST_F(XLAShardingTest, ShardTensor) {
   std::vector<std::string> devices = {"TPU:0", "TPU:1", "TPU:2", "TPU:3",
                                       "TPU:4", "TPU:5", "TPU:6", "TPU:7"};
@@ -116,9 +116,10 @@ TEST_F(XLAShardingTest, ShardTensor) {
           CreateComputationShapeFromTensor(tensor, GetDefaultDevice()),
           devices.size())
           .ToProto();
-  auto sharding_spec = std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
-  auto shards =
-      ShardingUtil::ShardTensor(tensor, sharding_spec, devices, /*padded=*/false);
+  auto sharding_spec =
+      std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
+  auto shards = ShardingUtil::ShardTensor(tensor, sharding_spec, devices,
+                                          /*padded=*/false);
   EXPECT_EQ(shards.size(), 8);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({1}));
   EXPECT_EQ(shards[1].sizes(), c10::ArrayRef<long>({1}));
@@ -132,9 +133,10 @@ TEST_F(XLAShardingTest, ShardTensor) {
       {4, 5, 6, 7},
   });
   sharding = xla::HloSharding::Tile(mesh).ToProto();
-  sharding_spec = std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
-  shards =
-      ShardingUtil::ShardTensor(tensor, sharding_spec, devices, /*padded=*/false);
+  sharding_spec =
+      std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
+  shards = ShardingUtil::ShardTensor(tensor, sharding_spec, devices,
+                                     /*padded=*/false);
   EXPECT_EQ(shards.size(), 8);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({4, 2, 4}));
   EXPECT_EQ(shards[7].sizes(), c10::ArrayRef<long>({4, 1, 4}));
@@ -144,8 +146,8 @@ TEST_F(XLAShardingTest, ShardTensor) {
   xla::Array3D<int64_t> cube({{{0, 1}, {2, 3}, {4, 5}, {6, 7}}});
   sharding = xla::HloSharding::Tile(cube).ToProto();
   sharding_spec->sharding = sharding;
-  shards =
-      ShardingUtil::ShardTensor(tensor, sharding_spec, devices, /*padded=*/false);
+  shards = ShardingUtil::ShardTensor(tensor, sharding_spec, devices,
+                                     /*padded=*/false);
   EXPECT_EQ(shards.size(), 8);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({8, 2, 2}));
   EXPECT_EQ(shards[7].sizes(), c10::ArrayRef<long>({8, 1, 2}));
@@ -153,8 +155,8 @@ TEST_F(XLAShardingTest, ShardTensor) {
   // Replicated, all shards should be identical.
   sharding = xla::HloSharding::Replicate().ToProto();
   sharding_spec->sharding = sharding;
-  shards =
-      ShardingUtil::ShardTensor(tensor, sharding_spec, devices, /*padded=*/false);
+  shards = ShardingUtil::ShardTensor(tensor, sharding_spec, devices,
+                                     /*padded=*/false);
   EXPECT_EQ(shards.size(), 8);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({8, 7, 4}));
   EXPECT_EQ(shards[7].sizes(), c10::ArrayRef<long>({8, 7, 4}));
@@ -166,16 +168,17 @@ TEST_F(XLAShardingTest, ShardTensor) {
   tensor_shape = CreateComputationShapeFromTensor(tensor, nullptr);
   xla::Array4D<int64_t> tesseract({{{{0, 1}, {2, 3}, {4, 5}, {6, 7}}}});
   sharding = xla::HloSharding::Tile(tesseract).ToProto();
-  sharding_spec = std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
-  shards =
-      ShardingUtil::ShardTensor(tensor, sharding_spec, devices, /*padded=*/false);
+  sharding_spec =
+      std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
+  shards = ShardingUtil::ShardTensor(tensor, sharding_spec, devices,
+                                     /*padded=*/false);
   EXPECT_EQ(shards.size(), 8);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({1, 8, 2, 2}));
   EXPECT_EQ(shards[7].sizes(), c10::ArrayRef<long>({1, 8, 1, 2}));
 
   // 4D tiled and padded, all shard sizes should be idential.
-  shards =
-      ShardingUtil::ShardTensor(tensor, sharding_spec, devices, /*padded=*/true);
+  shards = ShardingUtil::ShardTensor(tensor, sharding_spec, devices,
+                                     /*padded=*/true);
   EXPECT_EQ(shards.size(), 8);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({1, 8, 2, 2}));
   EXPECT_EQ(shards[7].sizes(), c10::ArrayRef<long>({1, 8, 2, 2}));
@@ -188,16 +191,17 @@ TEST_F(XLAShardingTest, ShardTensor) {
   xla::Array<int64_t> hypercube(std::vector<int64_t>{1, 1, 2, 2, 2});
   hypercube.FillIota(0);
   sharding = xla::HloSharding::Tile(hypercube).ToProto();
-  sharding_spec = std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
-  shards =
-      ShardingUtil::ShardTensor(tensor, sharding_spec, devices, /*padded=*/false);
+  sharding_spec =
+      std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
+  shards = ShardingUtil::ShardTensor(tensor, sharding_spec, devices,
+                                     /*padded=*/false);
   EXPECT_EQ(shards.size(), 8);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({10, 1, 4, 4, 2}));
   EXPECT_EQ(shards[7].sizes(), c10::ArrayRef<long>({10, 1, 4, 3, 2}));
 
   // 5D tiled and padded, all shard sizes should be identical.
-  shards =
-      ShardingUtil::ShardTensor(tensor, sharding_spec, devices, /*padded=*/true);
+  shards = ShardingUtil::ShardTensor(tensor, sharding_spec, devices,
+                                     /*padded=*/true);
   EXPECT_EQ(shards.size(), 8);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({10, 1, 4, 4, 2}));
   EXPECT_EQ(shards[7].sizes(), c10::ArrayRef<long>({10, 1, 4, 4, 2}));
@@ -214,11 +218,12 @@ TEST_F(XLAShardingTest, ShardTensorMultiHost) {
       {6, 7, 2, 3},
   });
   auto sharding = xla::HloSharding::Tile(mesh).ToProto();
-  auto sharding_spec = std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
+  auto sharding_spec =
+      std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
   // For devices at the start of the mesh, all shards should have the same
   // unpadded shape.
-  auto shards =
-      ShardingUtil::ShardTensor(tensor, sharding_spec, devices, /*padded=*/false);
+  auto shards = ShardingUtil::ShardTensor(tensor, sharding_spec, devices,
+                                          /*padded=*/false);
   EXPECT_EQ(shards.size(), 4);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({4, 2, 4}));
   EXPECT_EQ(shards[3].sizes(), c10::ArrayRef<long>({4, 2, 4}));
@@ -231,8 +236,8 @@ TEST_F(XLAShardingTest, ShardTensorMultiHost) {
   });
   sharding = xla::HloSharding::Tile(mesh).ToProto();
   sharding_spec->sharding = sharding;
-  shards =
-      ShardingUtil::ShardTensor(tensor, sharding_spec, devices, /*padded=*/false);
+  shards = ShardingUtil::ShardTensor(tensor, sharding_spec, devices,
+                                     /*padded=*/false);
   EXPECT_EQ(shards.size(), 4);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({4, 2, 4}));
   EXPECT_EQ(shards[3].sizes(), c10::ArrayRef<long>({4, 1, 4}));
@@ -240,22 +245,31 @@ TEST_F(XLAShardingTest, ShardTensorMultiHost) {
 
 TEST_F(XLAShardingTest, ShardTensorMiniBatch) {
   std::vector<std::string> devices = {"TPU:4", "TPU:5", "TPU:6", "TPU:7"};
-  at::Tensor minibatch_tensor = at::ones({8, 7, 4}, at::TensorOptions(at::kFloat));
-  xla::Shape tensor_shape = CreateComputationShapeFromTensor(minibatch_tensor, nullptr);
-  tensor_shape.set_dimensions(0,minibatch_tensor.sizes()[0] * 2); // Assuming 2 hosts
+  at::Tensor minibatch_tensor =
+      at::ones({8, 7, 4}, at::TensorOptions(at::kFloat));
+  xla::Shape tensor_shape =
+      CreateComputationShapeFromTensor(minibatch_tensor, nullptr);
+  tensor_shape.set_dimensions(
+      0, minibatch_tensor.sizes()[0] * 2);  // Assuming 2 hosts
   xla::Array2D<int64_t> mesh({
-      {0}, {1}, {2}, {3},
-      {4}, {5}, {6}, {7},
+      {0},
+      {1},
+      {2},
+      {3},
+      {4},
+      {5},
+      {6},
+      {7},
   });
 
   auto sharding = xla::HloSharding::Tile(mesh).ToProto();
-  auto sharding_spec = std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape, /*minibatch=*/true);
-  auto shards =
-      ShardingUtil::ShardTensor(minibatch_tensor, sharding_spec, devices, /*padded=*/false);
+  auto sharding_spec = std::make_shared<XLATensor::ShardingSpec>(
+      sharding, tensor_shape, /*minibatch=*/true);
+  auto shards = ShardingUtil::ShardTensor(minibatch_tensor, sharding_spec,
+                                          devices, /*padded=*/false);
   EXPECT_EQ(shards.size(), 4);
   EXPECT_EQ(shards[0].sizes(), c10::ArrayRef<long>({2, 7, 4}));
   EXPECT_EQ(shards[3].sizes(), c10::ArrayRef<long>({2, 7, 4}));
-
 }
 
 TEST_F(XLAShardingTest, EqualShardingSpecs) {
@@ -265,10 +279,13 @@ TEST_F(XLAShardingTest, EqualShardingSpecs) {
                                                               {0, 1, 2, 3},
                                                               {4, 5, 6, 7},
                                                           })
-                                       .ToProto(), tensor_shape);
+                                       .ToProto(),
+                                   tensor_shape);
   XLATensor::ShardingSpec tiled_3d(
-      xla::HloSharding::Tile({{{0, 1}, {2, 3}, {4, 5}, {6, 7}}}).ToProto(), tensor_shape);
-  XLATensor::ShardingSpec replicated(xla::HloSharding::Replicate().ToProto(), tensor_shape);
+      xla::HloSharding::Tile({{{0, 1}, {2, 3}, {4, 5}, {6, 7}}}).ToProto(),
+      tensor_shape);
+  XLATensor::ShardingSpec replicated(xla::HloSharding::Replicate().ToProto(),
+                                     tensor_shape);
   EXPECT_TRUE(ShardingUtil::EqualShardingSpecs(tiled_2d, tiled_2d));
   EXPECT_FALSE(ShardingUtil::EqualShardingSpecs(tiled_2d, tiled_3d));
   EXPECT_TRUE(ShardingUtil::EqualShardingSpecs(replicated, replicated));
@@ -333,7 +350,7 @@ TEST_F(XLAShardingTest, InputHandler) {
   std::vector<at::Tensor> tensors(2);
   auto tensor = at::ones({8, 8}, at::TensorOptions(at::kFloat));
   xla::Shape tensor_shape = CreateComputationShapeFromTensor(tensor, nullptr);
-  std::fill_n(tensors.begin(), tensors.size(),tensor);
+  std::fill_n(tensors.begin(), tensors.size(), tensor);
   std::vector<std::string> devices = {"TPU:0", "TPU:1"};
   std::vector<XLATensor::ShardingSpecPtr> shardings = {
       nullptr, std::make_shared<XLATensor::ShardingSpec>(

--- a/test/cpp/test_xla_sharding.cpp
+++ b/test/cpp/test_xla_sharding.cpp
@@ -245,9 +245,9 @@ TEST_F(XLAShardingTest, ShardTensorMiniBatch) {
   std::vector<std::string> devices = {"TPU:4", "TPU:5", "TPU:6", "TPU:7"};
   at::Tensor minibatch_tensor =
       at::ones({8, 7, 4}, at::TensorOptions(at::kFloat));
-  xla::Shape tensor_shape =
+  xla::Shape global_shape =
       CreateComputationShapeFromTensor(minibatch_tensor, GetDefaultDevice());
-  tensor_shape.set_dimensions(
+  global_shape.set_dimensions(
       0, minibatch_tensor.sizes()[0] * 2);  // Assuming 2 hosts
   xla::Array3D<int64_t> mesh({
       {{0}},
@@ -262,7 +262,7 @@ TEST_F(XLAShardingTest, ShardTensorMiniBatch) {
 
   auto sharding = xla::HloSharding::Tile(mesh).ToProto();
   auto sharding_spec = std::make_shared<XLATensor::ShardingSpec>(
-      sharding, tensor_shape, /*minibatch=*/true);
+      sharding, global_shape, /*minibatch=*/true);
   auto shards = ShardingUtil::ShardTensor(minibatch_tensor, sharding_spec,
                                           devices, /*padded=*/true);
   EXPECT_EQ(shards.size(), 4);

--- a/test/cpp/test_xla_sharding.cpp
+++ b/test/cpp/test_xla_sharding.cpp
@@ -96,6 +96,21 @@ TEST_F(XLAShardingTest, GetShardIndicesForDevices) {
   }
 }
 
+// TEST_F(XLAShardingTest, GetShardIndicesForBatchShardedTensor) {
+//     std::vector<std::string> devices = {"TPU:0", "TPU:1", "TPU:2", "TPU:3"};
+
+//     auto tensor = at::ones({8, 7}, at::TensorOptions(at::kFloat));
+//     xla::Array2D<int64_t> mesh({
+//       {0},
+//       {1},
+//       {2},
+//       {3},
+//     });
+//     auto sharding = xla::HloSharding::Tile(mesh).ToProto();
+//     auto shard_shape =
+//       ShardingUtil::GetShardShape(tensor.sizes().vec(), sharding);
+// }
+
 TEST_F(XLAShardingTest, ShardTensor) {
   std::vector<std::string> devices = {"TPU:0", "TPU:1", "TPU:2", "TPU:3",
                                       "TPU:4", "TPU:5", "TPU:6", "TPU:7"};

--- a/test/cpp/test_xla_sharding.cpp
+++ b/test/cpp/test_xla_sharding.cpp
@@ -41,12 +41,13 @@ TEST_F(XLAShardingTest, GetShardShape) {
       {2, 3},
   });
   auto sharding = xla::HloSharding::Tile(mesh).ToProto();
-  auto shard_shape = ShardingUtil::GetShardShape(tensor, sharding);
+  auto shard_shape =
+      ShardingUtil::GetShardShape(tensor.sizes().vec(), sharding);
   // For tiled sharding, each dimension should be halved
   EXPECT_EQ(shard_shape, std::vector<int64_t>({4, 4}));
 
   sharding = xla::HloSharding::Replicate().ToProto();
-  shard_shape = ShardingUtil::GetShardShape(tensor, sharding);
+  shard_shape = ShardingUtil::GetShardShape(tensor.sizes().vec(), sharding);
   // For replicated sharding, each dimension should be preserved
   EXPECT_EQ(shard_shape, std::vector<int64_t>({8, 7}));
 }
@@ -60,7 +61,8 @@ TEST_F(XLAShardingTest, GetShardIndicesForDevices) {
       {2, 3},
   });
   auto sharding = xla::HloSharding::Tile(mesh).ToProto();
-  auto shard_shape = ShardingUtil::GetShardShape(tensor, sharding);
+  auto shard_shape =
+      ShardingUtil::GetShardShape(tensor.sizes().vec(), sharding);
   auto shard_indices = ShardingUtil::GetShardIndicesForDevices(
       shard_shape, tensor.sizes().vec(), sharding, devices);
   EXPECT_EQ(shard_indices.size(), devices.size());
@@ -84,7 +86,7 @@ TEST_F(XLAShardingTest, GetShardIndicesForDevices) {
   }
 
   sharding = xla::HloSharding::Replicate().ToProto();
-  shard_shape = ShardingUtil::GetShardShape(tensor, sharding);
+  shard_shape = ShardingUtil::GetShardShape(tensor.sizes().vec(), sharding);
   shard_indices = ShardingUtil::GetShardIndicesForDevices(
       shard_shape, tensor.sizes().vec(), sharding, devices);
   EXPECT_EQ(shard_indices.size(), devices.size());

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -792,11 +792,24 @@ void InitXlaModuleBindings(py::module m) {
                        const py::list& group_assignment,
                        const py::list& replication_groups, int sharding_type,
                        bool minibatch) {
+        xla::Shape tensor_shape =
+            CreateComputationShapeFromTensor(tensor, nullptr);
+        int num_local_devices =
+            runtime::GetComputationClient()->GetLocalDevices().size();
+        int num_global_devices =
+            runtime::GetComputationClient()->GetAllDevices().size();
+        if (minibatch) {
+          XLA_CHECK(tile_assignment.size() == num_global_devices)
+              << "Sharding of input is only supported along batch dimension";
+        }
+        int batch_dim_shape =
+            tensor.sizes()[0] * num_global_devices / num_local_devices;
+        tensor_shape.set_dimensions(0, batch_dim_shape);
         return std::make_shared<XLATensor::ShardingSpec>(
             ShardingUtil::CreateOpSharding(
                 tile_assignment, group_assignment, replication_groups,
                 ShardingUtil::ShardingType(sharding_type)),
-            CreateComputationShapeFromTensor(tensor, nullptr), minibatch);
+            tensor_shape, minibatch);
       }));
   m.def("_xla_tensors_from_aten",
         [](const std::vector<at::Tensor>& tensors,

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -801,10 +801,10 @@ void InitXlaModuleBindings(py::module m) {
         if (minibatch) {
           XLA_CHECK(tile_assignment.size() == num_global_devices)
               << "Sharding of input is only supported along batch dimension";
+          int batch_dim_shape =
+              tensor.sizes()[0] * num_global_devices / num_local_devices;
+          tensor_shape.set_dimensions(0, batch_dim_shape);
         }
-        int batch_dim_shape =
-            tensor.sizes()[0] * num_global_devices / num_local_devices;
-        tensor_shape.set_dimensions(0, batch_dim_shape);
         return std::make_shared<XLATensor::ShardingSpec>(
             ShardingUtil::CreateOpSharding(
                 tile_assignment, group_assignment, replication_groups,

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1554,8 +1554,8 @@ void InitXlaModuleBindings(py::module m) {
     auto shard_shape = ShardingUtil::GetShardShape(sharding_spec);
     for (auto shard : shards) {
       XLA_CHECK(shard.sizes() == shard_shape)
-          << "Input shard shape must include padding: " << shard.sizes()
-          << " vs " << shard_shape;
+          << "Input shard shape must include padding: " << shard.sizes();
+          // << " vs " << shard_shape;
     }
     auto xla_data = ShardingUtil::CreateShardedData(shards, devices,
                                                     xtensor->shape(), sharding);

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1555,7 +1555,7 @@ void InitXlaModuleBindings(py::module m) {
     for (auto shard : shards) {
       XLA_CHECK(shard.sizes() == shard_shape)
           << "Input shard shape must include padding: " << shard.sizes();
-          // << " vs " << shard_shape;
+      // << " vs " << shard_shape;
     }
     auto xla_data = ShardingUtil::CreateShardedData(shards, devices,
                                                     xtensor->shape(), sharding);

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -253,7 +253,6 @@ class XLATensor : public torch::lazy::LazyTensor {
   // XLA SPMD sharding spec annoation. The XLA tensor uses this to create
   // HloSharding for replication, manual and tile shardings.
   struct ShardingSpec {
-    ShardingSpec(const xla::OpSharding& sharding) : sharding(sharding) {}
     ShardingSpec(const xla::OpSharding& sharding, const xla::Shape& shape)
         : sharding(sharding), shape(shape) {}
     ShardingSpec(const xla::OpSharding& sharding, const xla::Shape& shape,
@@ -262,7 +261,7 @@ class XLATensor : public torch::lazy::LazyTensor {
 
     xla::OpSharding sharding;
     // Optional source tensor shape unpartitioned.
-    std::optional<xla::Shape> shape;
+    xla::Shape shape;
     // Parameter for represent input batch in sharded along batch axes
     bool minibatch = false;
   };

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -256,10 +256,15 @@ class XLATensor : public torch::lazy::LazyTensor {
     ShardingSpec(const xla::OpSharding& sharding) : sharding(sharding) {}
     ShardingSpec(const xla::OpSharding& sharding, const xla::Shape& shape)
         : sharding(sharding), shape(shape) {}
+    ShardingSpec(const xla::OpSharding& sharding, const xla::Shape& shape,
+                 const bool& minibatch)
+        : sharding(sharding), shape(shape), minibatch(minibatch) {}
 
     xla::OpSharding sharding;
     // Optional source tensor shape unpartitioned.
     std::optional<xla::Shape> shape;
+    // Parameter for represent input batch in sharded along batch axes
+    bool minibatch = false;
   };
 
   // Annotate the IR value with ShardingSpec.

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -955,11 +955,11 @@ std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
       // The execution requires consistent shard sizes, and the zero-padded
       // values should be ignored.
       std::vector<at::Tensor> local_shards =
-          ShardingUtil::ShardTensor(tensors[i], sharding, local_devices,
-                                    /*padded=*/true, /*minibatch=*/minibatch);
+          ShardingUtil::ShardTensor(tensors[i], shardings[i], local_devices,
+                                    /*padded=*/true);
       if (minibatch) {  // change global shape as tensor is already sharded
                         // accross batch dimesion.
-        shape = shardings[i]->shape.value();
+        shape = shardings[i]->shape;
       }
       new_handles.push_back(ShardingUtil::CreateShardedData(
           local_shards, local_devices, shape, sharding));

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -942,7 +942,7 @@ std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
       std::vector<std::string> local_devices =
           runtime::GetComputationClient()->GetLocalDevices();
       xla::OpSharding sharding;
-      bool minibatch;
+      bool minibatch = false;
       if (shardings[i] != nullptr) {
         sharding = shardings[i]->sharding;
         minibatch = shardings[i]->minibatch;
@@ -959,7 +959,7 @@ std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
                                     /*padded=*/true, /*minibatch=*/minibatch);
       if (minibatch) {  // change global shape as tensor is already sharded
                         // accross batch dimesion.
-        continue;
+        shape = shardings[i]->shape.value();
       }
       new_handles.push_back(ShardingUtil::CreateShardedData(
           local_shards, local_devices, shape, sharding));

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -373,9 +373,9 @@ std::vector<runtime::ComputationClient::DataPtr> ShardingUtil::OutputHandler(
 }
 
 std::vector<int64_t> ShardingUtil::GetShardShape(
-    const at::Tensor& tensor, const xla::OpSharding sharding) {
+    const std::vector<int64_t>& tensor_shape, const xla::OpSharding sharding) {
   if (sharding.type() == xla::OpSharding::REPLICATED) {
-    return tensor.sizes().vec();
+    return tensor_shape;
   } else if (sharding.type() == xla::OpSharding::OTHER) {
     auto tile_shape = sharding.tile_assignment_dimensions();
 
@@ -385,9 +385,10 @@ std::vector<int64_t> ShardingUtil::GetShardShape(
       if (sharding.replicate_on_last_tile_dim() && j == tile_shape.size() - 1) {
         continue;
       }
-      shard_shape.push_back(tensor.sizes()[j] / tile_shape[j] +
-                            (tensor.sizes()[j] % tile_shape[j] != 0));
+      shard_shape.push_back(tensor_shape[j] / tile_shape[j] +
+                            (tensor_shape[j] % tile_shape[j] != 0));
     }
+
     return shard_shape;
   } else {
     TF_LOG(ERROR) << "Unsupported OpSharding type " << sharding.type();
@@ -398,7 +399,7 @@ std::vector<std::vector<at::indexing::TensorIndex>>
 ShardingUtil::GetShardIndicesForDevices(
     const std::vector<int64_t>& shard_shape,
     const std::vector<int64_t>& tensor_shape, const xla::OpSharding sharding,
-    const std::vector<std::string>& devices) {
+    const std::vector<std::string>& devices, const bool minibatch) {
   // `shard_indices[dev][dim]` represents the index slice for dimension `dim`
   // that belongs on device `devices[dev]` if the tensor is sharded. If
   // `sharding` is REPLICATED, `shard_indices[dev]` will only have a single
@@ -414,7 +415,27 @@ ShardingUtil::GetShardIndicesForDevices(
     std::fill_n(shard_indices.begin(), shard_indices.size(), indices);
   } else if (sharding.type() == xla::OpSharding::OTHER) {
     auto device_index = build_index_map(devices);
-    std::vector<int64_t> tile_assignment_devices(
+    if (minibatch) {
+      // shard tensor local to host
+      int start = 0;
+      for (int i = 0; i < devices.size(); i++) {
+        std::vector<at::indexing::TensorIndex> indices;
+        for (int j = tile_shape.size() - 1; j >= 0; j--) {
+          if (sharding.replicate_on_last_tile_dim() &&
+              j == tile_shape.size() - 1) {
+            continue;
+          }
+          auto slice = at::indexing::Slice(0, shard_shape[j]);
+          if (j == 0) {  // batch axis
+            slice = at::indexing::Slice(start, start + shard_shape[j]);
+          }
+          indices.push_back(slice);
+        }
+        std::reverse(indices.begin(), indices.end());
+        shard_indices[i] = indices;
+      }
+    } else {
+      std::vector<int64_t> tile_assignment_devices(
         sharding.tile_assignment_devices().begin(),
         sharding.tile_assignment_devices().end());
     if (!sharding.iota_reshape_dims().empty()) {
@@ -425,41 +446,43 @@ ShardingUtil::GetShardIndicesForDevices(
           tileAssignment.array().begin(), tileAssignment.array().end());
     }
     for (size_t i = 0; i < tile_assignment_devices.size(); i++) {
-      int64_t core = tile_assignment_devices[i];
-      if (device_index.find(core) == device_index.end()) {
-        // Skip any shards whose device is not part of the `devices` list.
-        continue;
-      }
-
-      // Given the shard's row-major index `i`, we need to calculate shard's
-      // coordinates (n_0, ..., n_d) in the tiling to generate the index slices.
-      // Using `N_j = tile_shape[j]` and `0 <= n_j < N_j`, the following
-      // equation needs to be solved for all n_j:
-      //            `i = n_d + N_d * (n_{d-1} + N_{d-1} * (... + (N_1 * n_0)))`
-      // Let `offset_j = n_j + N_j * (n_{j-1} + N_{j-1} * (... + (N_1 * n_0)))`.
-      // Then `offset_d = i`, `n_j = offset_j % N_j`, and `offset_{j-1} =
-      // offset_j / N_j`.
-      int offset = i;
-      std::vector<at::indexing::TensorIndex> indices;
-      for (int j = tile_shape.size() - 1; j >= 0; j--) {
-        if (sharding.replicate_on_last_tile_dim() &&
-            j == tile_shape.size() - 1) {
-          // the last tile assignment dimension is replicated, which implies
-          // that the consecutive `tile_shape[j]` devices hold the replicated.
-          offset /= tile_shape[j];
+        int64_t core = tile_assignment_devices[i];
+        if (device_index.find(core) == device_index.end()) {
+          // Skip any shards whose device is not part of the `devices` list.
           continue;
         }
-        int64_t n_j = offset % tile_shape[j];
-        // Clamp the slice bounds to the tensor shape to accurately reflect
-        // the shard size without padding.
-        int start = std::min(n_j * shard_shape[j], tensor_shape[j]);
-        int end = std::min((n_j + 1) * shard_shape[j], tensor_shape[j]);
-        auto slice = at::indexing::Slice(start, end);
-        indices.push_back(at::indexing::TensorIndex(slice));
-        offset /= tile_shape[j];
+
+        // Given the shard's row-major index `i`, we need to calculate shard's
+        // coordinates (n_0, ..., n_d) in the tiling to generate the index
+        // slices. Using `N_j = tile_shape[j]` and `0 <= n_j < N_j`, the
+        // following equation needs to be solved for all n_j:
+        //            `i = n_d + N_d * (n_{d-1} + N_{d-1} * (... + (N_1 *
+        //            n_0)))`
+        // Let `offset_j = n_j + N_j * (n_{j-1} + N_{j-1} * (... + (N_1 *
+        // n_0)))`. Then `offset_d = i`, `n_j = offset_j % N_j`, and
+        // `offset_{j-1} = offset_j / N_j`.
+        int offset = i;
+        std::vector<at::indexing::TensorIndex> indices;
+        for (int j = tile_shape.size() - 1; j >= 0; j--) {
+          if (sharding.replicate_on_last_tile_dim() &&
+              j == tile_shape.size() - 1) {
+            // the last tile assignment dimension is replicated, which implies
+            // that the consecutive `tile_shape[j]` devices hold the replicated.
+            offset /= tile_shape[j];
+            continue;
+          }
+          int64_t n_j = offset % tile_shape[j];
+          // Clamp the slice bounds to the tensor shape to accurately reflect
+          // the shard size without padding.
+          int start = std::min(n_j * shard_shape[j], tensor_shape[j]);
+          int end = std::min((n_j + 1) * shard_shape[j], tensor_shape[j]);
+          auto slice = at::indexing::Slice(start, end);
+          indices.push_back(at::indexing::TensorIndex(slice));
+          offset /= tile_shape[j];
+        }
+        std::reverse(indices.begin(), indices.end());
+        shard_indices[device_index[core]] = indices;
       }
-      std::reverse(indices.begin(), indices.end());
-      shard_indices[device_index[core]] = indices;
     }
   } else {
     TF_LOG(ERROR) << "Unsupported OpSharding type " << sharding.type();
@@ -469,7 +492,7 @@ ShardingUtil::GetShardIndicesForDevices(
 
 std::vector<at::Tensor> ShardingUtil::ShardTensor(
     const at::Tensor& tensor, const xla::OpSharding sharding,
-    const std::vector<std::string>& devices, bool padded) {
+    const std::vector<std::string>& devices, bool padded, bool minibatch) {
   TF_LOG(INFO) << "ShardTensor with sharding type(" << sharding.type() << ")..."
                << std::endl;
   auto device_index = build_index_map(devices);
@@ -480,9 +503,12 @@ std::vector<at::Tensor> ShardingUtil::ShardTensor(
     XLA_CHECK(sharding.tile_shape().dimensions_size() <= 2);
     XLA_CHECK(tensor.sizes().size() >= sharding.tile_shape().dimensions_size());
 
-    auto shard_shape = GetShardShape(tensor, sharding);
+    auto shard_shape = GetShardShape(tensor.sizes().vec(), sharding);
+    if (minibatch) {
+      shard_shape[0] = tensor.sizes().vec()[0] / devices.size();
+    }
     auto shard_indices = GetShardIndicesForDevices(
-        shard_shape, tensor.sizes().vec(), sharding, devices);
+        shard_shape, tensor.sizes().vec(), sharding, devices, minibatch);
 
     for (size_t i = 0; i < shard_indices.size(); i++) {
       at::Tensor shard = tensor.index(

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -7,6 +7,7 @@
 
 #include "torch/csrc/lazy/core/ir_util.h"
 #include "torch_xla/csrc/device.h"
+#include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/ops/device_data.h"
 #include "torch_xla/csrc/runtime/runtime.h"
 #include "torch_xla/csrc/tensor.h"
@@ -339,13 +340,13 @@ std::vector<runtime::ComputationClient::DataPtr> ShardingUtil::OutputHandler(
     XLATensor::ShardingSpecPtr sharding = sharding_specs[i];
     if (replicated_output && sharding &&
         (sharding->sharding.type() != xla::OpSharding::REPLICATED)) {
-      XLA_CHECK(sharding->shape.has_value())
-          << "Sharding or Wrapping data shards in OutputHandler requires "
-             "unpartitioned tensor shape.";
+      // XLA_CHECK(sharding->shape.has_value())
+      //     << "Sharding or Wrapping data shards in OutputHandler requires "
+      //        "unpartitioned tensor shape.";
       // Reshards replicated output if `sharding` is present.
       std::vector<at::Tensor> tensors = XlaDataToTensors(
           {WrapXlaData(sharded_results[0][i])},
-          TensorTypeFromXlaType(sharding->shape.value().element_type()));
+          TensorTypeFromXlaType(sharding->shape.element_type()));
       outputs.push_back(UnwrapXlaData(CreateTensorsData(
           tensors, {sharding},
           std::vector<std::string>{GetVirtualDevice().toString()})[0]));
@@ -365,7 +366,7 @@ std::vector<runtime::ComputationClient::DataPtr> ShardingUtil::OutputHandler(
             sharded_results[0][i]->shape());
       }
       outputs.push_back(runtime::GetComputationClient()->WrapDataShards(
-          shards, GetVirtualDevice().toString(), sharding->shape.value(),
+          shards, GetVirtualDevice().toString(), sharding->shape,
           sharding->sharding));
     }
   }
@@ -373,7 +374,10 @@ std::vector<runtime::ComputationClient::DataPtr> ShardingUtil::OutputHandler(
 }
 
 std::vector<int64_t> ShardingUtil::GetShardShape(
-    const std::vector<int64_t>& global_shape, const xla::OpSharding sharding) {
+    const XLATensor::ShardingSpecPtr shardings) {
+  auto sharding = shardings->sharding;
+  auto global_shape = XlaHelpers::GetAllDimensions(shardings->shape);
+  TF_LOG(ERROR) << "Print global shape" << global_shape;
   if (sharding.type() == xla::OpSharding::REPLICATED) {
     return global_shape;
   } else if (sharding.type() == xla::OpSharding::OTHER) {
@@ -396,7 +400,7 @@ std::vector<int64_t> ShardingUtil::GetShardShape(
 }
 
 std::vector<std::vector<at::indexing::TensorIndex>>
-ShardingUtil::GetShardIndicesForBatchShardedTensor(
+ShardingUtil::GetShardIndicesForMinibatchTensor(
     const std::vector<int64_t>& shard_shape,
     const std::vector<int64_t>& tensor_shape, const xla::OpSharding sharding,
     const std::vector<std::string>& devices) {
@@ -493,8 +497,10 @@ ShardingUtil::GetShardIndicesForDevices(
 }
 
 std::vector<at::Tensor> ShardingUtil::ShardTensor(
-    const at::Tensor& tensor, const xla::OpSharding sharding,
-    const std::vector<std::string>& devices, bool padded, bool minibatch) {
+    const at::Tensor& tensor, const XLATensor::ShardingSpecPtr shardings,
+    const std::vector<std::string>& devices, bool padded) {
+  auto sharding = shardings->sharding;
+  bool minibatch = shardings->minibatch;
   TF_LOG(INFO) << "ShardTensor with sharding type(" << sharding.type() << ")..."
                << std::endl;
   auto device_index = build_index_map(devices);
@@ -505,13 +511,13 @@ std::vector<at::Tensor> ShardingUtil::ShardTensor(
     XLA_CHECK(sharding.tile_shape().dimensions_size() <= 2);
     XLA_CHECK(tensor.sizes().size() >= sharding.tile_shape().dimensions_size());
 
-    auto shard_shape = GetShardShape(tensor.sizes().vec(), sharding);
-    if (minibatch) {
-      shard_shape[0] = tensor.sizes().vec()[0] / devices.size();
-    }
+    auto shard_shape = GetShardShape(shardings);
+    // if (minibatch) {
+    //   shard_shape[0] = tensor.sizes().vec()[0] / devices.size();
+    // }
     std::vector<std::vector<at::indexing::TensorIndex>> shard_indices;
     if (minibatch) {
-      shard_indices = GetShardIndicesForBatchShardedTensor(
+      shard_indices = GetShardIndicesForMinibatchTensor(
           shard_shape, tensor.sizes().vec(), sharding, devices);
     } else {
       shard_indices = GetShardIndicesForDevices(
@@ -606,8 +612,7 @@ void ShardingUtil::PrepareOutputShardingPropagation(
     // replication.
     auto sharded_data_placeholder =
         WrapXlaData(runtime::GetComputationClient()->WrapDataShards(
-            {}, GetVirtualDevice().toString(),
-            (*sharding_specs)[i]->shape.value(),
+            {}, GetVirtualDevice().toString(), (*sharding_specs)[i]->shape,
             (*sharding_specs)[i]->sharding));
 
     // Register the sharded data placeholder to the tensor and its node.
@@ -670,7 +675,7 @@ void ShardingUtil::PrepareOutputShardingPropagation(
     // replication.
     auto sharded_data_placeholder =
         WrapXlaData(runtime::GetComputationClient()->WrapDataShards(
-            {}, GetVirtualDevice().toString(), sharding_specs[i]->shape.value(),
+            {}, GetVirtualDevice().toString(), sharding_specs[i]->shape,
             sharding_specs[i]->sharding));
 
     // Register the sharded data placeholder to the tensor and its node.

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -502,8 +502,8 @@ std::vector<at::Tensor> ShardingUtil::ShardTensor(
     const std::vector<std::string>& devices, bool padded) {
   auto sharding = shardings->sharding;
   bool minibatch = shardings->minibatch;
-  TF_LOG(INFO) << "ShardTensor with sharding type(" << sharding.type() << ")... and minibatch = " << minibatch
-               << std::endl;
+  TF_LOG(INFO) << "ShardTensor with sharding type(" << sharding.type()
+               << ")... and minibatch = " << minibatch << std::endl;
   auto device_index = build_index_map(devices);
   std::vector<at::Tensor> shards(devices.size());
   if (sharding.type() == xla::OpSharding::REPLICATED) {

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -147,7 +147,7 @@ class ShardingUtil {
   // the PjRtShardedData wrapping the shards.
   static runtime::ComputationClient::DataPtr CreateShardedData(
       std::vector<at::Tensor>& shards, std::vector<std::string>& devices,
-      xla::Shape global_shape, xla::OpSharding sharding);
+      const XLATensor::ShardingSpecPtr& sharding_spec);
 };
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -103,8 +103,6 @@ class ShardingUtil {
   // called when input is sharded along the batch axis.
   static std::vector<std::vector<at::indexing::TensorIndex>>
   GetShardIndicesForMinibatchTensor(const std::vector<int64_t>& shard_shape,
-                                    const std::vector<int64_t>& tensor_shape,
-                                    const xla::OpSharding sharding,
                                     const std::vector<std::string>& devices);
 
   // Shards a tensor and returns the sharded tensors which belong on `devices`

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -88,7 +88,7 @@ class ShardingUtil {
   // `sharding`. This assumes the shards will be padded to ensure they all
   // have the same shape.
   static std::vector<int64_t> GetShardShape(
-      const std::vector<int64_t>& tensor_shape, const xla::OpSharding sharding);
+      const XLATensor::ShardingSpecPtr shardings);
 
   // Uses the provided `sharding` spec and expected shard shape to determine the
   // index slices for the shards which belong on `devices`. Only supports
@@ -102,10 +102,10 @@ class ShardingUtil {
   // Returns the indices for the shards. Supports `OTHER` sharding types and
   // called when input is sharded along the batch axis.
   static std::vector<std::vector<at::indexing::TensorIndex>>
-  GetShardIndicesForBatchShardedTensor(const std::vector<int64_t>& shard_shape,
-                                       const std::vector<int64_t>& tensor_shape,
-                                       const xla::OpSharding sharding,
-                                       const std::vector<std::string>& devices);
+  GetShardIndicesForMinibatchTensor(const std::vector<int64_t>& shard_shape,
+                                    const std::vector<int64_t>& tensor_shape,
+                                    const xla::OpSharding sharding,
+                                    const std::vector<std::string>& devices);
 
   // Shards a tensor and returns the sharded tensors which belong on `devices`
   // based on the `sharding` spec. REPLICATED sharding should result in shards
@@ -117,9 +117,8 @@ class ShardingUtil {
   // The the returned tensors will be in 1:1 correspondence with the `devices`
   // vector, so the `i`th result will belong on the `i`th device.
   static std::vector<at::Tensor> ShardTensor(
-      const at::Tensor& tensor, const xla::OpSharding sharding,
-      const std::vector<std::string>& devices, bool padded = true,
-      bool minibatch = false);
+      const at::Tensor& tensor, const XLATensor::ShardingSpecPtr shardings,
+      const std::vector<std::string>& devices, bool padded = true);
 
   // Prepares output sharding propagation by extracting output parameter
   // ShardingSpec into `sharding_specs` from the SPMD compiled `computation` and

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -97,8 +97,15 @@ class ShardingUtil {
   GetShardIndicesForDevices(const std::vector<int64_t>& shard_shape,
                             const std::vector<int64_t>& tensor_shape,
                             const xla::OpSharding sharding,
-                            const std::vector<std::string>& devices,
-                            const bool minibatch = false);
+                            const std::vector<std::string>& devices);
+
+  // Returns the indices for the shards. Supports `OTHER` sharding types and
+  // called when input is sharded along the batch axis.
+  static std::vector<std::vector<at::indexing::TensorIndex>>
+  GetShardIndicesForBatchShardedTensor(const std::vector<int64_t>& shard_shape,
+                                       const std::vector<int64_t>& tensor_shape,
+                                       const xla::OpSharding sharding,
+                                       const std::vector<std::string>& devices);
 
   // Shards a tensor and returns the sharded tensors which belong on `devices`
   // based on the `sharding` spec. REPLICATED sharding should result in shards

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -87,8 +87,8 @@ class ShardingUtil {
   // Returns the shape of the resulting shards of `tensor` after applying
   // `sharding`. This assumes the shards will be padded to ensure they all
   // have the same shape.
-  static std::vector<int64_t> GetShardShape(const at::Tensor& tensor,
-                                            const xla::OpSharding sharding);
+  static std::vector<int64_t> GetShardShape(
+      const std::vector<int64_t>& tensor_shape, const xla::OpSharding sharding);
 
   // Uses the provided `sharding` spec and expected shard shape to determine the
   // index slices for the shards which belong on `devices`. Only supports
@@ -97,7 +97,8 @@ class ShardingUtil {
   GetShardIndicesForDevices(const std::vector<int64_t>& shard_shape,
                             const std::vector<int64_t>& tensor_shape,
                             const xla::OpSharding sharding,
-                            const std::vector<std::string>& devices);
+                            const std::vector<std::string>& devices,
+                            const bool minibatch = false);
 
   // Shards a tensor and returns the sharded tensors which belong on `devices`
   // based on the `sharding` spec. REPLICATED sharding should result in shards
@@ -110,7 +111,8 @@ class ShardingUtil {
   // vector, so the `i`th result will belong on the `i`th device.
   static std::vector<at::Tensor> ShardTensor(
       const at::Tensor& tensor, const xla::OpSharding sharding,
-      const std::vector<std::string>& devices, bool padded = true);
+      const std::vector<std::string>& devices, bool padded = true,
+      bool minibatch = false);
 
   // Prepares output sharding propagation by extracting output parameter
   // ShardingSpec into `sharding_specs` from the SPMD compiled `computation` and

--- a/torch_xla/experimental/xla_sharding.py
+++ b/torch_xla/experimental/xla_sharding.py
@@ -468,6 +468,7 @@ def wrap_if_sharded(x: Any) -> Any:
 class ShardingSpec:
   mesh: Mesh
   partition_spec: Tuple[Union[int, None]]
+  minibatch: Optional[bool] = False
 
   # Derived fields
   _tile_assignment: List[int] = field(init=False)
@@ -494,7 +495,8 @@ class ShardingSpec:
     return torch_xla._XLAC.XlaShardingSpec(t, self._tile_assignment,
                                            self._group_assignment,
                                            self._replication_groups,
-                                           int(self._sharding_type))
+                                           int(self._sharding_type),
+                                           self.minibatch)
 
   def can_apply(self, t: torch.Tensor) -> bool:
     """


### PR DESCRIPTION
This PR is changing the way we do multi-host data loading. Here are some changes user script will need. 
1. Add a Sampler 
```
sampler = torch.utils.data.DistributedSampler(dataset, num_replicas = xr.process_count(), rank = xr.process_index())
```
2. Using sampler in `torch.utils.data.DataLoader`
```
loader = torch.utils.data.DataLoader(
        dataset,
        batch_size=FLAGS.batch_size // xr.process_count(),
        sampler=sampler,
        drop_last=FLAGS.drop_last,
        shuffle=False)
 ```
3. Change sharding_spec in `MpDeviceLoader`
```
loader = pl.MpDeviceLoader(
          loader,
          device,
          input_sharding=xs.ShardingSpec(input_mesh, (0, 1, 2, 3), minibatch = True))
 ```
`minibatch` flag denotes that input is already sharded along the batch axes. Multi-host dataloading currently only supports batch dimension sharding.