### PR TITLE
Disable cxx_abi when building PyTorch/XLA in r2.0.

### DIFF
--- a/infra/ansible/config/env.yaml
+++ b/infra/ansible/config/env.yaml
@@ -32,6 +32,7 @@ build_env:
     XLA_SANDBOX_BUILD: 1
     BAZEL_REMOTE_CACHE: 1
     SILO_NAME: "cache-silo-{{ arch }}-{{ accelerator }}"
+    _GLIBCXX_USE_CXX11_ABI: 0
 
   amd64:
     ARCH: amd64

--- a/infra/ansible/roles/build_srcs/tasks/main.yaml
+++ b/infra/ansible/roles/build_srcs/tasks/main.yaml
@@ -24,7 +24,7 @@
 
 - name: Build XLA computation client library
   ansible.builtin.command:
-    cmd: bash build_torch_xla_libs.sh -O -D_GLIBCXX_USE_CXX11_ABI=1
+    cmd: bash build_torch_xla_libs.sh
     chdir: "{{ (src_root, 'pytorch/xla') | path_join }}"
   environment: "{{ env_vars }}"
   when: build_torch_xla_libs_result.stat.exists

--- a/infra/ansible/roles/fetch_srcs/tasks/main.yaml
+++ b/infra/ansible/roles/fetch_srcs/tasks/main.yaml
@@ -20,6 +20,25 @@
       dest: "{{ (src_root, 'pytorch/xla') | path_join }}"
       version: "{{ xla_git_rev }}"
 
+- name: Find *.diff files in pytorch/xla/torch_patches
+  ansible.builtin.find:
+    path: "{{ (src_root, 'pytorch/xla/torch_patches') | path_join }}"
+    pattern: "*.diff"
+  register: torch_patches
+
+- name: Apply patches to PyTorch
+  ansible.posix.patch:
+    src: "{{ item }}"
+    # Use source file on the target machine instead of the one where
+    # the playbook is located. Has no effect when the target machine is
+    # localhost.
+    remote_src: true
+    strip: 1
+    ignore_whitespace: true
+    basedir: "{{ (src_root, 'pytorch/') | path_join }}"
+  loop: "{{ torch_patches.files | map(attribute='path') }}"
+  ignore_errors: true
+
 - name: Find *.diff files in pytorch/xla/tf_patches
   ansible.builtin.find:
     path: "{{ (src_root, 'pytorch/xla/tf_patches') | path_join }}"


### PR DESCRIPTION
Following Mateusz's [suggestion](https://github.com/pytorch/xla/issues/5325#issuecomment-1643808739) to disable cxx_abi for pytorch/xla branch r2.0.