### PR TITLE
fix amp dtype setting for GPU

### DIFF
--- a/torch_xla/amp/autocast_mode.py
+++ b/torch_xla/amp/autocast_mode.py
@@ -6,8 +6,9 @@ from typing import Any
 class autocast(torch.amp.autocast_mode.autocast):
   r"""
     See :class:`torch.autocast`.
-    ``torch_xla.amp.autocast(device, args...)`` is equivalent to ``torch.autocast("xla", args...)`` for TPUs
-    ``torch.autocast("cuda", args...)`` for GPUs.
+    ``torch_xla.amp.autocast(device, **kwargs)`` is equivalent to 
+    ``torch.autocast("xla", **kwargs)`` for TPUs
+    ``torch.autocast("cuda", **kwargs)`` for GPUs.
     """
 
   def __init__(self,

--- a/torch_xla/amp/autocast_mode.py
+++ b/torch_xla/amp/autocast_mode.py
@@ -13,15 +13,19 @@ class autocast(torch.amp.autocast_mode.autocast):
   def __init__(self,
                device,
                enabled: bool = True,
-               dtype: torch.dtype = torch.bfloat16,
+               dtype: torch.dtype = None,
                cache_enabled: bool = True):
     if xm.xla_device_hw(device) == 'GPU':
+      if dtype is None:
+        dtype = torch.float16
       super().__init__(
           "cuda",
           enabled=enabled,
           dtype=dtype,
           cache_enabled=cache_enabled)
     elif xm.xla_device_hw(device) == 'TPU':
+      if dtype is None:
+        dtype = torch.bfloat16
       super().__init__(
           "xla", enabled=enabled, dtype=dtype, cache_enabled=cache_enabled)
     else:

--- a/torch_xla/amp/autocast_mode.py
+++ b/torch_xla/amp/autocast_mode.py
@@ -19,10 +19,7 @@ class autocast(torch.amp.autocast_mode.autocast):
       if dtype is None:
         dtype = torch.float16
       super().__init__(
-          "cuda",
-          enabled=enabled,
-          dtype=dtype,
-          cache_enabled=cache_enabled)
+          "cuda", enabled=enabled, dtype=dtype, cache_enabled=cache_enabled)
     elif xm.xla_device_hw(device) == 'TPU':
       if dtype is None:
         dtype = torch.bfloat16

--- a/torch_xla/amp/autocast_mode.py
+++ b/torch_xla/amp/autocast_mode.py
@@ -19,7 +19,7 @@ class autocast(torch.amp.autocast_mode.autocast):
       super().__init__(
           "cuda",
           enabled=enabled,
-          dtype=torch.float16,
+          dtype=dtype,
           cache_enabled=cache_enabled)
     elif xm.xla_device_hw(device) == 'TPU':
       super().__init__(


### PR DESCRIPTION
As [discussed before](https://github.com/pytorch/xla/pull/5161#discussion_r1245566331), we should directly pass dtype to `torch.amp.autocast_mode.autocast` for GPU device.
cc @JackCaoG @cowanmeg 