### PR TITLE
Make all-reduce a no-op when world size is 1

### DIFF
--- a/test/test_torch_distributed_xla_backend.py
+++ b/test/test_torch_distributed_xla_backend.py
@@ -1,5 +1,6 @@
 import contextlib
 import functools
+import os
 import re
 from unittest import mock
 
@@ -39,6 +40,8 @@ class XlaBackendTest(parameterized.TestCase):
 
   @classmethod
   def setUpClass(cls):
+    # Add no-op all-reduce ops to HLO
+    os.environ['XLA_ALWAYS_ALLREDUCE'] = '1'
     dist.init_process_group('xla', init_method='pjrt://')
 
   def tearDown(self) -> None:

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -451,7 +451,8 @@ def all_reduce(reduce_type, inputs, scale=1.0, groups=None, pin_layout=True):
   groups = groups or []
 
   # No-op if there is only one device
-  if xrt_world_size() == 1:
+  if xrt_world_size() == 1 and not xu.getenv_as('XLA_ALWAYS_ALLREDUCE', bool,
+                                                False):
     if isinstance(inputs, torch.Tensor):
       return inputs.clone()
     else:

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -449,6 +449,14 @@ def all_reduce(reduce_type, inputs, scale=1.0, groups=None, pin_layout=True):
     returns the list/tuple itself.
   """
   groups = groups or []
+
+  # No-op if there is only one device
+  if xrt_world_size() == 1:
+    if isinstance(inputs, torch.Tensor):
+      return inputs.clone()
+    else:
+      return inputs
+
   if isinstance(inputs, torch.Tensor):
     result = None
     if scale == 1.0 and groups == [] and pin_layout:


### PR DESCRIPTION
All reduce was a no-op if `xm.set_replication` was not called before https://github.com/pytorch/xla/commit/397ea4d571c7b6363779a5b960afe3e71132e0b7. This lets you easily debug scripts with one process, even if there are multiple runtime devices present. If there are multiple runtime devices, you must run the collective on all of them.

Example command that hangs before this PR (since MP collectives don't actually work on CPU):

```
PJRT_DEVICE=CPU CPU_NUM_DEVICES=2 python pytorch/xla/test/test_train_mp_mnist.py --fake_data --num_cores=1
```

More importantly, this allows single-process debugging (ie `xmp.spawn(..., nprocs=1)`) on TPU v2/v3, where there are always at least two runtime devices.

It looks like this logic only applied to `all_reduce` in the last release. I can add other no-ops in a follow-up if we believe that is the correct behavior for all of them.