### PR TITLE
Revert "Checkout Ansible setup at origin's master, not local, untracked master."

### DIFF
--- a/infra/terraform_modules/xla_docker_build/variables.tf
+++ b/infra/terraform_modules/xla_docker_build/variables.tf
@@ -21,7 +21,6 @@ variable "description" {
 
 variable "ansible_git_rev" {
   # Checkout Ansible setup (/infra/ansible) at current Cloud Build commit.
-  # Use `origin/<branch>` for branches.
   default = "$COMMIT_SHA"
 }
 

--- a/infra/tpu-pytorch-releases/artifacts_builds.tf
+++ b/infra/tpu-pytorch-releases/artifacts_builds.tf
@@ -176,7 +176,7 @@ module "versioned_builds" {
 
   # Use Ansible setup from master branch for versioned release, because source
   # code at older version doesn't contain Ansible setup.
-  ansible_git_rev = "origin/master"
+  ansible_git_rev = "master"
   trigger_on_push = { tag = each.value.git_tag }
 
   trigger_name = replace(each.key, "/[_.]/", "-")


### PR DESCRIPTION
Reverts pytorch/xla#5106

See https://github.com/pytorch/xla/issues/5325 for details. In summary, I disabled cxx_abi in r2.0 branch but once we ran the trigger it didn't pick up my change. Looking at the [log](https://github.com/pytorch/xla/issues/5325#issuecomment-1648791918), it first check out the correct commit (on r2.0 branch) and then switched back to origin/master (because of this PR.). To unblock the dlvm p1 ticket (need py 3.10, cuda 11.8, r2.0 torch_xla wheel), I need to revert this PR for now.  