### PR TITLE
Don't rewrite index hints in global save planning

### DIFF
--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -47,6 +47,7 @@ spec:
       python3 /src/pytorch/xla/test/pjrt/test_runtime_tpu.py
       python3 /src/pytorch/xla/test/spmd/test_xla_sharding.py
       python3 /src/pytorch/xla/test/spmd/test_xla_virtual_device.py
+      python3 /src/pytorch/xla/test/spmd/test_xla_distributed_checkpoint.py
       python3 /src/pytorch/xla/test/spmd/test_train_spmd_linear_model.py
       python3 /src/pytorch/xla/test/spmd/test_spmd_xla_model_api.py
       XLA_EXPERIMENTAL=nonzero:masked_select python3 /src/pytorch/xla/test/ds/test_dynamic_shape_models.py -v


### PR DESCRIPTION
For XLAShardedTensor, we expect the index hints to remain unchanged after global planning. The default save plan rewrites index hints to support ShardedTensor, which breaks multihost checkpointing. This change uses https://github.com/pytorch/pytorch/pull/105861 to avoid modifying index hints during global planning.

This will also enable distributed checkpointing tests in TPU CI, enables resharding tests, and fixes some bugs from `_CpuShard` support that were missed due to the lacking CI coverage.

The new test `test_multihost_checkpoint` will be used in a nightly test running on multiple hosts.