### PR TITLE
[BE] use self.assertEquals instead of str equality in test_zero1.py

### DIFF
--- a/test/test_zero1.py
+++ b/test/test_zero1.py
@@ -33,20 +33,20 @@ class XlaZeRO1Test(unittest.TestCase):
 
     opt1.step()
     opt2.step()
-    assert str(opt1.state_dict()) == str(opt2.state_dict()['base'])
+    self.assertEquals(opt1.state_dict(), opt2.state_dict()['base'])
 
     s1 = opt1.state_dict()
     s2 = opt2.state_dict()
     opt1.load_state_dict(s1)
     opt2.load_state_dict(s2)
-    assert str(opt1.state_dict()) == str(opt2.state_dict()['base'])
+    self.assertEquals(opt1.state_dict(), opt2.state_dict()['base'])
 
     # step still runnable
     opt1.step()
     opt2.step()
     opt1.load_state_dict(s1)
     opt2.load_state_dict(s2)
-    assert str(opt1.state_dict()) == str(opt2.state_dict()['base'])
+    self.assertEquals(opt1.state_dict(), opt2.state_dict()['base'])
 
     # step still runnable
     opt1.step()


### PR DESCRIPTION
Make the error messaging more useful. Recently came across this error which the vanilla assert was not helpful.
![image](https://github.com/pytorch/xla/assets/31798555/0b3096b4-1ee8-4985-9287-17e7835a34d9)

Where the error occurred: https://hud.pytorch.org/pr/106082

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #5358

