### PR TITLE
[Dynamo|TPU] Tweak `atol` and `rtol` for `test_simple_model_with_different_input_shape` on TPU

### DIFF
--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -95,7 +95,7 @@ class DynamoInferenceBasicTest(unittest.TestCase):
         torch.allclose(
             res_xla_dynamo_3.cpu(),
             self.fn_simple(xla_z.cpu(), xla_z.cpu()),
-            rtol=1e-05, 
+            rtol=1e-05,
             atol=1e-05))
 
   @skipOnTpu

--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -92,8 +92,11 @@ class DynamoInferenceBasicTest(unittest.TestCase):
     res_xla_dynamo_3 = self.fn_simple_dynamo(xla_z, xla_z)
     self.assertEqual(met.metric_data('CompileTime')[0], compile_count + 1)
     self.assertTrue(
-        torch.allclose(res_xla_dynamo_3.cpu(),
-                       self.fn_simple(xla_z.cpu(), xla_z.cpu()), rtol=1e-05, atol=1e-05))
+        torch.allclose(
+            res_xla_dynamo_3.cpu(),
+            self.fn_simple(xla_z.cpu(), xla_z.cpu()), 
+            rtol=1e-05, 
+            atol=1e-05))
 
   @skipOnTpu
   def test_resnet18(self):

--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -91,10 +91,6 @@ class DynamoInferenceBasicTest(unittest.TestCase):
     # dynamo to recognize this is a different graph and let XLA to retrace/recompile
     res_xla_dynamo_3 = self.fn_simple_dynamo(xla_z, xla_z)
     self.assertEqual(met.metric_data('CompileTime')[0], compile_count + 1)
-    print("res_xla_dynamo_3.cpu()")
-    print(res_xla_dynamo_3.cpu())
-    print("self.fn_simple(xla_z.cpu(), xla_z.cpu())")
-    print(self.fn_simple(xla_z.cpu(), xla_z.cpu()))
     self.assertTrue(
         torch.allclose(res_xla_dynamo_3.cpu(),
                        self.fn_simple(xla_z.cpu(), xla_z.cpu()), rtol=1e-05, atol=1e-05))

--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -91,9 +91,13 @@ class DynamoInferenceBasicTest(unittest.TestCase):
     # dynamo to recognize this is a different graph and let XLA to retrace/recompile
     res_xla_dynamo_3 = self.fn_simple_dynamo(xla_z, xla_z)
     self.assertEqual(met.metric_data('CompileTime')[0], compile_count + 1)
+    print("res_xla_dynamo_3.cpu()")
+    print(res_xla_dynamo_3.cpu())
+    print("self.fn_simple(xla_z.cpu(), xla_z.cpu())")
+    print(self.fn_simple(xla_z.cpu(), xla_z.cpu()))
     self.assertTrue(
         torch.allclose(res_xla_dynamo_3.cpu(),
-                       self.fn_simple(xla_z.cpu(), xla_z.cpu())))
+                       self.fn_simple(xla_z.cpu(), xla_z.cpu()), rtol=1e-05, atol=1e-05))
 
   @skipOnTpu
   def test_resnet18(self):

--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -94,7 +94,7 @@ class DynamoInferenceBasicTest(unittest.TestCase):
     self.assertTrue(
         torch.allclose(
             res_xla_dynamo_3.cpu(),
-            self.fn_simple(xla_z.cpu(), xla_z.cpu()), 
+            self.fn_simple(xla_z.cpu(), xla_z.cpu()),
             rtol=1e-05, 
             atol=1e-05))
 


### PR DESCRIPTION
Before bring `Dynamo` to TPU CI, tweak `atol` and `rtol` for `test_simple_model_with_different_input_shape` on TPU