### PR TITLE
Update dynamo cpu fallback op to aten::_foobar

### DIFF
--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -175,8 +175,8 @@ class DynamoCpuFallbackTest(unittest.TestCase):
   def test_operator_fallback(self):
 
     def fn_fallback(t):
-      # As of 05/18/2023, torch.median is not lowered by PyTorch/XLA
-      return torch.median(t)
+      # aten::_foobar is aux function that's used for testing purposes only
+      return torch._foobar(t)
 
     torch._dynamo.reset()
     met.clear_counters()
@@ -211,8 +211,8 @@ class DynamoCpuFallbackTest(unittest.TestCase):
 
     def fn_fallback(t):
       t_2 = torch.mul(t, 2)
-      # As of 05/18/2023, torch.median is not lowered by PyTorch/XLA
-      t_3 = torch.median(t_2)
+      # aten::_foobar is aux function that's used for testing purposes only
+      t_3 = torch._foobar(t_2)
       t_4 = torch.mul(t_3, 2)
       return t_4
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/pull/5376

Test plan:
Dynamo CPU fallback unit tests passing locally:
```
(base) wonjoo@wonjoo-cpu:~/pytorch/xla$ python test/dynamo/test_dynamo.py DynamoCpuFallbackTest.test_operator_fallback
/home/wonjoo/miniconda3/lib/python3.10/site-packages/torchvision/io/image.py:13: UserWarning: Failed to load image Python extension: 'libc10_cuda.so: cannot open shared object file: No such file or directory'If you don't plan on using image functionality from `torchvision.io`, you can ignore this warning. Otherwise, there might be something wrong with your environment. Did you have `libjpeg` or `libpng` installed before building `torchvision` from source?
  warn(
.
----------------------------------------------------------------------
Ran 1 test in 0.101s

OK
(base) wonjoo@wonjoo-cpu:~/pytorch/xla$ python test/dynamo/test_dynamo.py DynamoCpuFallbackTest.test_fallback_multiple_submodules
/home/wonjoo/miniconda3/lib/python3.10/site-packages/torchvision/io/image.py:13: UserWarning: Failed to load image Python extension: 'libc10_cuda.so: cannot open shared object file: No such file or directory'If you don't plan on using image functionality from `torchvision.io`, you can ignore this warning. Otherwise, there might be something wrong with your environment. Did you have `libjpeg` or `libpng` installed before building `torchvision` from source?
  warn(
.
----------------------------------------------------------------------
Ran 1 test in 0.115s

OK
(base) wonjoo@wonjoo-cpu:~/pytorch/xla$ 
```