### PR TITLE
Fix ReplicateShardedData for int type

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -764,6 +764,14 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     self.assertNotIn('convert(s32[8]{0} %get-tuple-element.25), sharding',
                      torch_xla._XLAC._get_xla_tensors_hlo([xt_index]))
 
+  def test_sharded_tensor_to_cpu_int_type(self):
+    partition_spec = (0, 1)
+    t1 = torch.arange(64).reshape(8, 8)
+    xt1 = t1.clone().to(xm.xla_device())
+    xst1 = xs.mark_sharding(xt1, self._get_mesh((self.n_devices, 1)),
+                            partition_spec)
+    self.assertTrue(torch.allclose(t1, xst1.cpu()))
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/torch_xla/csrc/runtime/computation_client.h
+++ b/torch_xla/csrc/runtime/computation_client.h
@@ -140,13 +140,16 @@ class ComputationClient {
                     std::vector<std::string> devices,
                     const xla::Shape* output_shape,
                     bool parameter_is_tupled_arguments = false,
-                    bool is_sharded = false)
+                    bool is_sharded = false,
+                    bool allow_spmd_sharding_propagation_to_output = true)
         : computation(std::move(computation)),
           compilation_device(std::move(compilation_device)),
           devices(std::move(devices)),
           output_shape(output_shape),
           parameter_is_tupled_arguments(parameter_is_tupled_arguments),
-          is_sharded(is_sharded) {}
+          is_sharded(is_sharded),
+          allow_spmd_sharding_propagation_to_output(
+              allow_spmd_sharding_propagation_to_output) {}
 
     xla::XlaComputation computation;
     std::string compilation_device;
@@ -154,6 +157,7 @@ class ComputationClient {
     const xla::Shape* output_shape = nullptr;
     bool parameter_is_tupled_arguments;
     bool is_sharded;
+    bool allow_spmd_sharding_propagation_to_output;
   };
 
   struct ExecuteComputationOptions : public ClientExecuteOptions {};


### PR DESCRIPTION
We used to perform `res = (res/2) + (res/2)` as identify function to get the unsharded result. However the `res/2` part will make result always even for the int type. This pr performs a `res + 0` and force the compiler not to overwrite the output sharding instead.