### PR TITLE
Revert "Partially replicate lower-rank tensors"

### DIFF
--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1375,17 +1375,13 @@ void InitXlaModuleBindings(py::module m) {
   m.def("_xla_mark_sharding",
         [](const at::Tensor& input, const py::list& tile_assignment,
            const py::list& group_assignment, const py::list& replication_groups,
-           int sharding_type, bool tensor_rank_less_than_mesh) {
+           int sharding_type) {
           TORCH_LAZY_COUNTER("XlaMarkSharding", 1);
           XLA_CHECK(UseVirtualDevice()) << "Please set `XLA_USE_SPMD=1`";
           XLATensorPtr xtensor = bridge::GetXlaTensor(input);
           xla::OpSharding sharding = ShardingUtil::CreateOpSharding(
               tile_assignment, group_assignment, replication_groups,
               ShardingUtil::ShardingType(sharding_type));
-          if (tensor_rank_less_than_mesh) {
-            // Replicate the lower-rank tensor along the last mesh dimension.
-            sharding.set_replicate_on_last_tile_dim(true);
-          }
           auto new_sharding_spec = std::make_shared<XLATensor::ShardingSpec>(
               sharding,
               MakeShapeWithDeviceLayout(

--- a/torch_xla/experimental/xla_sharding.py
+++ b/torch_xla/experimental/xla_sharding.py
@@ -412,26 +412,35 @@ def mark_sharding(t: Union[torch.Tensor, XLAShardedTensor], mesh: Mesh,
   assert len(specs) == len(np.unique(specs)), \
     f"Each device mesh dimension should appear at most once in partition_spec {partition_spec}."
 
-  tensor_rank_less_than_mesh = len(t.shape) < len(mesh.get_logical_mesh().shape)
-  if tensor_rank_less_than_mesh:
-    assert len(mesh.get_logical_mesh().shape) == len(
-        t.shape) + 1, 'Tensor rank must be equal to or one less than mesh rank'
-    tile_assignment = _get_tile_assignment(mesh, partition_spec + (None,))
-  else:
-    tile_assignment = _get_tile_assignment(mesh, partition_spec)
+  # check for sharding 2D tensor on a 3D mesh
+  original_shape = tuple(t.shape)
+  # number of dims to expand on tensor
+  tensor_expand = 0
+  if tensor_expand < len(mesh.get_logical_mesh().shape) - len(partition_spec):
+    tensor_expand = len(mesh.get_logical_mesh().shape) - len(partition_spec)
+    partition_spec = (None,) * tensor_expand + partition_spec
+    shape = (1,) * tensor_expand + (*original_shape,)
+    t = t.expand(shape)
+
+  tile_assignment = _get_tile_assignment(mesh, partition_spec)
   sharding_type = _get_sharding_type(partition_spec, num_devices)
   group_assignment, replication_groups = _get_group_assignment(
       sharding_type, partition_spec, tile_assignment)
 
+  def tensor_squeeze(t, tensor_expand):
+    if tensor_expand:
+      t = torch.squeeze(t, dim=tuple(range(tensor_expand)))
+    return t
+
   if isinstance(t, XLAShardedTensor):
     torch_xla._XLAC._xla_mark_sharding(t.global_tensor, tile_assignment,
                                        group_assignment, replication_groups,
-                                       int(sharding_type),
-                                       tensor_rank_less_than_mesh)
+                                       int(sharding_type))
+    t = tensor_squeeze(t, tensor_expand)
     return t
   torch_xla._XLAC._xla_mark_sharding(t, tile_assignment, group_assignment,
-                                     replication_groups, int(sharding_type),
-                                     tensor_rank_less_than_mesh)
+                                     replication_groups, int(sharding_type))
+  t = tensor_squeeze(t, tensor_expand)
   return XLAShardedTensor(t)
 
 


### PR DESCRIPTION
Reverts pytorch/xla#5409, as it's still not unblocking the multi-slice test. We can manually force replicating the last dim, but needs to be more careful with actual shard generation. Will address & land a proper fix in #5411 