### PR TITLE
[SPMD] named partition spec support

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -720,8 +720,8 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
 
   def test_named_partition_spec(self):
     xt1 = torch.arange(64).reshape(8, 8).to(xm.xla_device())
-    mesh = xs.Mesh(list(range(self.n_devices)), (1, self.n_devices),
-                   ('data', 'model'))
+    mesh = xs.Mesh(
+        list(range(self.n_devices)), (1, self.n_devices), ('data', 'model'))
     partition_spec = ('model', 'data')
     xs.mark_sharding(xt1, mesh, partition_spec)
     sharding_spec = torch_xla._XLAC._get_xla_sharding_spec(xt1)

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -718,6 +718,18 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
                             partition_spec)
     self.assertTrue(torch.allclose(t1, xst1.cpu()))
 
+  def test_named_partition_spec(self):
+    xt1 = torch.arange(64).reshape(8, 8).to(xm.xla_device())
+    mesh = xs.Mesh(list(range(self.n_devices)), (1, self.n_devices),
+                   ('data', 'model'))
+    partition_spec = ('model', 'data')
+    xs.mark_sharding(xt1, mesh, partition_spec)
+    sharding_spec = torch_xla._XLAC._get_xla_sharding_spec(xt1)
+    if self.n_devices > 1:
+      self.assertTrue(f"devices=[{self.n_devices},1]" in sharding_spec)
+    else:
+      self.assertTrue("replicated" in sharding_spec)
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/torch_xla/experimental/xla_sharding.py
+++ b/torch_xla/experimental/xla_sharding.py
@@ -66,7 +66,8 @@ class Mesh:
 
   def shape(self):
     if self.axis_names is None:
-      return OrderedDict((dim, size) for dim, size in enumerate(self.mesh_shape))
+      return OrderedDict(
+          (dim, size) for dim, size in enumerate(self.mesh_shape))
     return OrderedDict(
         (name, size) for name, size in zip(self.axis_names, self.mesh_shape))
 
@@ -378,13 +379,15 @@ def _translate_named_partition_spec(mesh: Mesh, partition_spec: Tuple):
         raise ValueError(f"Axis name {p} is not defined in the given mesh")
       _partition_spec.append(idx)
     else:
-      raise ValueError(f"Spec type {type(p)} is not supported in partition spec")
+      raise ValueError(
+          f"Spec type {type(p)} is not supported in partition spec")
   return _partition_spec
 
 
 @xr.requires_pjrt
-def mark_sharding(t: Union[torch.Tensor, XLAShardedTensor], mesh: Mesh,
-                  partition_spec: Tuple[Union[int, None]]) -> XLAShardedTensor:
+def mark_sharding(
+    t: Union[torch.Tensor, XLAShardedTensor], mesh: Mesh,
+    partition_spec: Tuple[Union[int, str, None]]) -> XLAShardedTensor:
   """
     Annotates the tensor provided with XLA partition spec. Internally,
     it annotates the corresponding XLATensor as sharded for the XLA SpmdPartitioner pass.
@@ -393,7 +396,7 @@ def mark_sharding(t: Union[torch.Tensor, XLAShardedTensor], mesh: Mesh,
 
         mesh (Mesh): describes the logical XLA device topology and the underlying device IDs.
 
-        partition_spec (Tuple[int, None]): A tuple of device_mesh dimension index or `None`.
+        partition_spec (Tuple[int, str, None]): A tuple of device_mesh dimension index or `None`. Each index is an int or str if the mesh axis is named.
         This specifies how each input rank is sharded (index to mesh_shape) or replicated (None).
         For example, we can shard an 8x10 tensor 4-way row-wise, and replicate column-wise.
         >> input = torch.randn(8, 10)


### PR DESCRIPTION
Now supports axis names `str` in partition spec:
```python
 mesh = xs.Mesh(list(range(self.n_devices)), (1, self.n_devices), ('data', 'model'))
 partition_spec = ('model', 'data')
 xs.mark_sharding(xt1, mesh, partition_spec)
```