### PR TITLE
[PJRT|TPU] Update `test_xla_devices_single_process_all_chips` for expected device number

### DIFF
--- a/test/pjrt/test_runtime_tpu.py
+++ b/test/pjrt/test_runtime_tpu.py
@@ -92,11 +92,10 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
     devices_per_process = pjrt.run_multiprocess(xm.xla_device)
     self.assertDictEqual(devices_per_process, expected)
 
+  @absltest.skipIf(tpu.num_available_devices() > 4, "Not implemented")
   def test_xla_devices_single_process_all_chips(self):
-    cores_per_process = tpu.num_available_devices()
     expected = _ordinal_to_device(
-        processes=1,
-        cores_per_process=cores_per_process if cores_per_process <= 4 else 4)
+        processes=1, cores_per_process=tpu.num_available_devices())
 
     os.environ[xenv.TPU_VISIBLE_CHIPS] = '0,1,2,3'
     os.environ[xenv.TPU_PROCESS_BOUNDS] = '1,1,1'

--- a/test/pjrt/test_runtime_tpu.py
+++ b/test/pjrt/test_runtime_tpu.py
@@ -14,14 +14,8 @@ from torch_xla import runtime as xr
 from torch_xla._internal import pjrt
 from torch_xla._internal import tpu
 import torch_xla.distributed.xla_multiprocessing as xmp
-import unittest
 
 assert tpu.num_available_chips() > 0, 'Must be run on a TPU!'
-
-def _is_on_tpu():
-  return 'XRT_TPU_CONFIG' in os.environ or xr.device_type() == 'TPU'
-
-skipOnTpu = unittest.skipIf(_is_on_tpu(), 'Not supported on TPU')
 
 def _ordinal_to_device(processes=None,
                        cores_per_process=None) -> Dict[int, torch.device]:
@@ -101,17 +95,11 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
     cores_per_process=tpu.num_available_devices()
     expected = _ordinal_to_device(
         processes=1, cores_per_process=cores_per_process if cores_per_process<=4 else 4)
-    print("cores_per_process")
-    print(tpu.num_available_devices())
-    print("expected")
-    print(expected)
 
     os.environ[xenv.TPU_VISIBLE_CHIPS] = '0,1,2,3'
     os.environ[xenv.TPU_PROCESS_BOUNDS] = '1,1,1'
 
     devices = pjrt.run_multiprocess(xm.xla_device)
-    print("deivices")
-    print(devices)
     self.assertDictEqual(devices, expected)
 
   def test_xla_devices_single_process_one_chip(self):

--- a/test/pjrt/test_runtime_tpu.py
+++ b/test/pjrt/test_runtime_tpu.py
@@ -101,7 +101,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
     expected = _ordinal_to_device(
         processes=1, cores_per_process=tpu.num_available_devices())
     print("cores_per_process")
-    print(cores_per_process)
+    print(tpu.num_available_devices())
     print("expected")
     print(expected)
 

--- a/test/pjrt/test_runtime_tpu.py
+++ b/test/pjrt/test_runtime_tpu.py
@@ -97,15 +97,20 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
     devices_per_process = pjrt.run_multiprocess(xm.xla_device)
     self.assertDictEqual(devices_per_process, expected)
 
-  @skipOnTpu
   def test_xla_devices_single_process_all_chips(self):
     expected = _ordinal_to_device(
         processes=1, cores_per_process=tpu.num_available_devices())
+    print("cores_per_process")
+    print(cores_per_process)
+    print("expected")
+    print(expected)
 
     os.environ[xenv.TPU_VISIBLE_CHIPS] = '0,1,2,3'
     os.environ[xenv.TPU_PROCESS_BOUNDS] = '1,1,1'
 
     devices = pjrt.run_multiprocess(xm.xla_device)
+    print("deivices")
+    print(devices)
     self.assertDictEqual(devices, expected)
 
   def test_xla_devices_single_process_one_chip(self):

--- a/test/pjrt/test_runtime_tpu.py
+++ b/test/pjrt/test_runtime_tpu.py
@@ -17,6 +17,7 @@ import torch_xla.distributed.xla_multiprocessing as xmp
 
 assert tpu.num_available_chips() > 0, 'Must be run on a TPU!'
 
+
 def _ordinal_to_device(processes=None,
                        cores_per_process=None) -> Dict[int, torch.device]:
   """Returns a dict of global ordinals and their expected `torch.device` value.

--- a/test/pjrt/test_runtime_tpu.py
+++ b/test/pjrt/test_runtime_tpu.py
@@ -92,7 +92,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
     devices_per_process = pjrt.run_multiprocess(xm.xla_device)
     self.assertDictEqual(devices_per_process, expected)
 
-  @absltest.skipIf(tpu.num_available_devices() > 4, "Not implemented")
+  @absltest.skipIf(tpu.num_available_chips() != 4, "Not implemented")
   def test_xla_devices_single_process_all_chips(self):
     expected = _ordinal_to_device(
         processes=1, cores_per_process=tpu.num_available_devices())

--- a/test/pjrt/test_runtime_tpu.py
+++ b/test/pjrt/test_runtime_tpu.py
@@ -17,6 +17,10 @@ import torch_xla.distributed.xla_multiprocessing as xmp
 
 assert tpu.num_available_chips() > 0, 'Must be run on a TPU!'
 
+def _is_on_tpu():
+  return 'XRT_TPU_CONFIG' in os.environ or xr.device_type() == 'TPU'
+
+skipOnTpu = unittest.skipIf(_is_on_tpu(), 'Not supported on TPU')
 
 def _ordinal_to_device(processes=None,
                        cores_per_process=None) -> Dict[int, torch.device]:
@@ -92,6 +96,7 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
     devices_per_process = pjrt.run_multiprocess(xm.xla_device)
     self.assertDictEqual(devices_per_process, expected)
 
+  @skipOnTpu
   def test_xla_devices_single_process_all_chips(self):
     expected = _ordinal_to_device(
         processes=1, cores_per_process=tpu.num_available_devices())

--- a/test/pjrt/test_runtime_tpu.py
+++ b/test/pjrt/test_runtime_tpu.py
@@ -98,8 +98,9 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
     self.assertDictEqual(devices_per_process, expected)
 
   def test_xla_devices_single_process_all_chips(self):
+    cores_per_process=tpu.num_available_devices()
     expected = _ordinal_to_device(
-        processes=1, cores_per_process=tpu.num_available_devices())
+        processes=1, cores_per_process=cores_per_process if cores_per_process<=4 else 4)
     print("cores_per_process")
     print(tpu.num_available_devices())
     print("expected")

--- a/test/pjrt/test_runtime_tpu.py
+++ b/test/pjrt/test_runtime_tpu.py
@@ -93,9 +93,10 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
     self.assertDictEqual(devices_per_process, expected)
 
   def test_xla_devices_single_process_all_chips(self):
-    cores_per_process=tpu.num_available_devices()
+    cores_per_process = tpu.num_available_devices()
     expected = _ordinal_to_device(
-        processes=1, cores_per_process=cores_per_process if cores_per_process<=4 else 4)
+        processes=1,
+        cores_per_process=cores_per_process if cores_per_process <= 4 else 4)
 
     os.environ[xenv.TPU_VISIBLE_CHIPS] = '0,1,2,3'
     os.environ[xenv.TPU_PROCESS_BOUNDS] = '1,1,1'

--- a/test/pjrt/test_runtime_tpu.py
+++ b/test/pjrt/test_runtime_tpu.py
@@ -14,6 +14,7 @@ from torch_xla import runtime as xr
 from torch_xla._internal import pjrt
 from torch_xla._internal import tpu
 import torch_xla.distributed.xla_multiprocessing as xmp
+import unittest
 
 assert tpu.num_available_chips() > 0, 'Must be run on a TPU!'
 


### PR DESCRIPTION
For `test_xla_devices_single_process_all_chips`, edit expected device number to match expected TPU configs