### PR TITLE
Add repo for libcudnn8=8.7.0.84 and CUDA 11.8

### DIFF
--- a/infra/ansible/config/apt.yaml
+++ b/infra/ansible/config/apt.yaml
@@ -50,7 +50,9 @@ apt:
   signing_keys:
     - url: https://apt.llvm.org/llvm-snapshot.gpg.key
       keyring: /usr/share/keyrings/llvm.pgp
-    - url: "https://developer.download.nvidia.com/compute/cuda/repos/{{ cuda_repo }}/x86_64/3bf863cc.pub"
+    # Get the recent key version from
+    # https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#network-repo-installation-for-debian.
+    - url: "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub"
       keyring: /usr/share/keyrings/cuda.pgp
 
   repos:

--- a/infra/ansible/config/cuda_deps.yaml
+++ b/infra/ansible/config/cuda_deps.yaml
@@ -4,11 +4,11 @@ cuda_deps:
   # List all libcudnn8 versions with `apt list -a libcudnn8`
   libcudnn:
     "12.0": libcudnn8=8.8.0.121-1+cuda12.0
-    "11.8": libcudnn8=8.8.0.121-1+cuda11.8
+    "11.8": libcudnn8=8.7.0.84-1+cuda11.8
     "11.7": libcudnn8=8.5.0.96-1+cuda11.7
     "11.2": libcudnn8=8.1.1.33-1+cuda11.2
   libcudnn-dev:
-    "12.0": libcudnn8-dev=8.8.0.121-1+cuda12.0 
-    "11.8": libcudnn8-dev=8.8.0.121-1+cuda11.8
+    "12.0": libcudnn8-dev=8.8.0.121-1+cuda12.0
+    "11.8": libcudnn8-dev=8.7.0.84-1+cuda11.8
     "11.7": libcudnn8-dev=8.5.0.96-1+cuda11.7
     "11.2": libcudnn8-dev=8.1.1.33-1+cuda11.2

--- a/infra/ansible/config/vars.yaml
+++ b/infra/ansible/config/vars.yaml
@@ -1,5 +1,5 @@
 # Used for fetching cuda from the right repo, see apt.yaml.
-cuda_repo: ubuntu1804
+cuda_repo: debian11
 cuda_version: "11.8"
 # Used for fetching clang from the right repo, see apt.yaml.
 llvm_debian_repo: buster


### PR DESCRIPTION
1. Use debian11 repo for CUDA deps (seems to work anyway on debian 10).
2. Remove variables from nvidia repo key. The key is fixed (doesn't depend on repo, contrary to the docs). The latest version can be taken directly from nvidia's docs (added link).

This change will only affect nightly builds for CUDA 11.8.

Related: https://github.com/pytorch/xla/issues/5419