### PR TITLE
Update XLA pin to 2023/08/08

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -43,9 +43,9 @@ http_archive(
         "//openxla_patches:gpu_race_condition.diff",
         "//openxla_patches:constexpr_return.diff",
     ],
-    strip_prefix = "xla-9b339c6fa10f6e964e21b58e40217661f7824bae",
+    strip_prefix = "xla-e37758ae52993f11c977e1441a7405ac65a2daea",
     urls = [
-        "https://github.com/openxla/xla/archive/9b339c6fa10f6e964e21b58e40217661f7824bae.tar.gz",
+        "https://github.com/openxla/xla/archive/e37758ae52993f11c977e1441a7405ac65a2daea.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -43,9 +43,9 @@ http_archive(
         "//openxla_patches:gpu_race_condition.diff",
         "//openxla_patches:constexpr_return.diff",
     ],
-    strip_prefix = "xla-e37758ae52993f11c977e1441a7405ac65a2daea",
+    strip_prefix = "xla-cd2cf5c34931e4fc1cacf83bfc480a5b93f05f6d",
     urls = [
-        "https://github.com/openxla/xla/archive/e37758ae52993f11c977e1441a7405ac65a2daea.tar.gz",
+        "https://github.com/openxla/xla/archive/cd2cf5c34931e4fc1cacf83bfc480a5b93f05f6d.tar.gz",
     ],
 )
 

--- a/bazel/rules_def.bzl
+++ b/bazel/rules_def.bzl
@@ -24,7 +24,7 @@ def ptxla_cc_test(
         **kwargs):
     xla_cc_test(
         linkstatic = True,
-        extra_copts = copts + [
+        copts = copts + [
             "-isystemexternal/torch",  # Required for system includes.
             "-fexceptions",  # Required for testing crashes.
         ],

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ import zipfile
 
 base_dir = os.path.dirname(os.path.abspath(__file__))
 
-_libtpu_version = '0.1.dev20230808'
+_libtpu_version = '0.1.dev20230809'
 _libtpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
 
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ import zipfile
 
 base_dir = os.path.dirname(os.path.abspath(__file__))
 
-_libtpu_version = '0.1.dev20230703'
+_libtpu_version = '0.1.dev20230808'
 _libtpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
 
 

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1628,12 +1628,11 @@ void InitXlaModuleBindings(py::module m) {
           XLA_CHECK(num_nodes > 0)
               << "num_nodes must be positive: " << num_nodes;
 
-          xla::DistributedRuntimeServiceImpl::Options options;
+          xla::CoordinationServiceImpl::Options options;
           options.num_nodes = num_nodes;
-          return std::move(xla::GetDistributedRuntimeService(
-                               dist_service_addr, options,
-                               /*use_coordination_service=*/false)
-                               .value());
+          return std::move(
+              xla::GetDistributedRuntimeService(dist_service_addr, options)
+                  .value());
         });
 
   BuildProfilerSubmodule(&m);

--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -97,6 +97,7 @@ cc_library(
     "@xla//xla/pjrt:tfrt_cpu_pjrt_client",
     "@xla//xla/pjrt:pjrt_c_api_client",
     "@tsl//tsl/profiler/lib:traceme",
+    "@tsl//tsl/platform/cloud:gcs_file_system",
     "@com_google_absl//absl/strings",
     "@com_google_absl//absl/types:span",
   ],

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -29,7 +29,7 @@
 #include "xla/pjrt/tfrt_cpu_pjrt_client.h"
 #include "xla/pjrt/tpu_client.h"
 #include "xla/shape.h"
-#include "xla/stream_executor/tpu/tpu_initializer_helper.h"
+#include "xla/stream_executor/tpu/tpu_initializer_framework_helper.h"
 
 using xla::internal::XlaBuilderFriend;
 
@@ -49,9 +49,7 @@ MaybeInitializeDistributedRuntimeClient(int local_rank,
     xla::DistributedRuntimeClient::Options options;
     /* TODO(jonbolin): Use global rank for multi-host setup */
     options.node_id = local_rank;
-    client =
-        xla::GetDistributedRuntimeClient(dist_service_addr, options,
-                                         /*use_coordination_service=*/false);
+    client = xla::GetDistributedRuntimeClient(dist_service_addr, options);
     XLA_CHECK(client->Connect().ok())
         << "Failed to initialize distributed runtime client";
   }


### PR DESCRIPTION
I had to update the gcc-10 locally to make it build(thanks @lsy323 for the help), the command I used is
```
 1225  [2023-08-09 16:55:27] echo 'deb http://deb.debian.org/debian bullseye main' >> /etc/apt/sources.list
 1226  [2023-08-09 16:55:35] sudo apt update
 1227  [2023-08-09 16:55:52] sudo apt install gcc-10
 1228  [2023-08-09 16:58:28] gcc --version
```
assuming you are using the dev container, after this you should see
```
root@dada83f25caf:/src/pytorch/xla# gcc --version
gcc (Debian 10.2.1-6) 10.2.1 20210110
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

I was able to verify that on v3-8, resnet50 spmd speed does not regress
```
Epoch 1 train begin 18:08:17
| Training Device=xla:0/0 Epoch=1 Step=0 Loss=6.89059 Rate=33.94 GlobalRate=33.94 Time=18:09:18
| Training Device=xla:0/0 Epoch=1 Step=20 Loss=5.32911 Rate=3106.94 GlobalRate=629.86 Time=18:09:26
| Training Device=xla:0/0 Epoch=1 Step=40 Loss=0.62358 Rate=3994.76 GlobalRate=1087.50 Time=18:09:34
| Training Device=xla:0/0 Epoch=1 Step=60 Loss=0.01664 Rate=4588.41 GlobalRate=1462.34 Time=18:09:43
| Training Device=xla:0/0 Epoch=1 Step=80 Loss=0.00676 Rate=4817.95 GlobalRate=1770.98 Time=18:09:51
| Training Device=xla:0/0 Epoch=1 Step=100 Loss=0.00539 Rate=4630.87 GlobalRate=2012.93 Time=18:10:00
| Training Device=xla:0/0 Epoch=1 Step=120 Loss=0.00484 Rate=4783.34 GlobalRate=2229.60 Time=18:10:08
```