### PR TITLE
Add warning to Linear patching when Linear subclasses are used

### DIFF
--- a/torch_xla/distributed/fsdp/utils.py
+++ b/torch_xla/distributed/fsdp/utils.py
@@ -144,7 +144,7 @@ def apply_xla_patch_to_nn_linear(module):
       return
     if getattr(forward_method, "__func__", None) != torch.nn.Linear.forward:
       m_cls = m.__class__
-      if issubclass(m_cls, torch.nn.Linear):
+      if m_cls is not torch.nn.Linear and issubclass(m_cls, torch.nn.Linear):
         logging.warning(
           f"`{m_cls.__module__}.{m_cls.__name__}` is a subclass of `torch.nn.Linear`. PyTorch XLA needs to monkeypatch"
           " `torch.nn.Linear` so that the backward pass will explicitly use the weight parameter to resolve"

--- a/torch_xla/distributed/fsdp/utils.py
+++ b/torch_xla/distributed/fsdp/utils.py
@@ -146,9 +146,9 @@ def apply_xla_patch_to_nn_linear(module):
       m_cls = m.__class__
       if m_cls is not torch.nn.Linear and issubclass(m_cls, torch.nn.Linear):
         logging.warning(
-          f"`{m_cls.__module__}.{m_cls.__name__}` is a subclass of `torch.nn.Linear`. PyTorch XLA needs to monkeypatch"
-          " `torch.nn.Linear` so that the backward pass will explicitly use the weight parameter to resolve"
-          " https://github.com/pytorch/xla/issues/3811. This might result in increased memory usage."
+            f"`{m_cls.__module__}.{m_cls.__name__}` is a subclass of `torch.nn.Linear`. PyTorch XLA needs to monkeypatch"
+            " `torch.nn.Linear` so that the backward pass will explicitly use the weight parameter to resolve"
+            " https://github.com/pytorch/xla/issues/3811. This might result in increased memory usage."
         )
       return
 


### PR DESCRIPTION
The current Linear patching code assumes that the Linear layer will not be subclassed.

LoRA layers are generally implemented by subclassing Linear: https://github.com/microsoft/LoRA/blob/main/loralib/layers.py#L90

This means that the patching logic is completely and silently skipped for them. XLA should try to support them, in the meantime, this PR adds a warning to give some visibility into the issue for users who could experience issues related to this.

cc @gkroiz 