### PR TITLE
[PJRT] Support `torchrun` with `pjrt://` `init_method`

### DIFF
--- a/test/pjrt/test_torchrun.py
+++ b/test/pjrt/test_torchrun.py
@@ -1,0 +1,38 @@
+import logging
+
+from absl.testing import absltest
+import torch
+import torch.distributed as dist
+import torch_xla.core.xla_model as xm
+import torch_xla.experimental.pjrt_backend
+import torch_xla.runtime as xr
+import torch_xla.utils.utils as xu
+
+
+class TestTorchrun(absltest.TestCase):
+
+  def test_all_gather(self):
+    dist.init_process_group('xla', init_method='pjrt://')
+
+    dist_world_size = xu.getenv_as('WORLD_SIZE', int)
+    devices_per_thread = xr.addressable_device_count()
+
+    expected_world_size = dist_world_size * devices_per_thread
+
+    rank = torch.tensor([dist.get_rank()],
+                        dtype=torch.float32,
+                        device=xm.xla_device())
+    output = [rank.clone() for _ in range(expected_world_size)]
+    dist.all_gather(output, rank)
+    result = torch.concat(output)
+    xm.mark_step()
+
+    expected = torch.arange(0, expected_world_size, step=1, dtype=torch.float32)
+    torch.testing.assert_close(result.cpu(), expected)
+
+
+if __name__ == '__main__':
+  if not dist.is_torchelastic_launched():
+    logging.fatal('Test must be launched with torchrun!')
+
+  absltest.main()

--- a/test/pjrt/test_torchrun.py
+++ b/test/pjrt/test_torchrun.py
@@ -1,6 +1,5 @@
-import logging
-
 from absl.testing import absltest
+from absl import logging
 import torch
 import torch.distributed as dist
 import torch_xla.core.xla_model as xm
@@ -33,6 +32,7 @@ class TestTorchrun(absltest.TestCase):
 
 if __name__ == '__main__':
   if not dist.is_torchelastic_launched():
-    logging.fatal('Test must be launched with torchrun!')
+    logging.error('Test must be launched with torchrun!')
+    exit(1)
 
   absltest.main()

--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -55,7 +55,6 @@ spec:
       XLA_EXPERIMENTAL=nonzero:masked_select python3 /src/pytorch/xla/test/ds/test_dynamic_shapes.py -v
       python3 /src/pytorch/xla/test/test_autocast.py
       python3 /src/pytorch/xla/test/dynamo/test_dynamo.py
-      torchrun --nnodes 1 --nproc-per-node 4 /src/pytorch/xla/test/pjrt/test_torchrun.py
     volumeMounts:
     - mountPath: /dev/shm
       name: dshm

--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -55,7 +55,7 @@ spec:
       XLA_EXPERIMENTAL=nonzero:masked_select python3 /src/pytorch/xla/test/ds/test_dynamic_shapes.py -v
       python3 /src/pytorch/xla/test/test_autocast.py
       python3 /src/pytorch/xla/test/dynamo/test_dynamo.py
-      torchrun --nnodes 1 --nproc-per-node 4 pytorch/xla/test/pjrt/test_torchrun.py
+      torchrun --nnodes 1 --nproc-per-node 4 /src/pytorch/xla/test/pjrt/test_torchrun.py
     volumeMounts:
     - mountPath: /dev/shm
       name: dshm

--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -55,6 +55,7 @@ spec:
       XLA_EXPERIMENTAL=nonzero:masked_select python3 /src/pytorch/xla/test/ds/test_dynamic_shapes.py -v
       python3 /src/pytorch/xla/test/test_autocast.py
       python3 /src/pytorch/xla/test/dynamo/test_dynamo.py
+      torchrun --nnodes 1 --nproc-per-node 4 pytorch/xla/test/pjrt/test_torchrun.py
     volumeMounts:
     - mountPath: /dev/shm
       name: dshm

--- a/torch_xla/_internal/pjrt.py
+++ b/torch_xla/_internal/pjrt.py
@@ -55,7 +55,8 @@ def _run_thread_per_device(
   """
   initializer_fn(local_rank, local_world_size)
 
-  num_threads = len(xm.get_xla_supported_devices())
+  devices = xm.get_xla_supported_devices()
+  num_threads = len(devices)
 
   @functools.wraps(fn)
   def _thread_fn(device: torch.device):

--- a/torch_xla/experimental/pjrt_backend.py
+++ b/torch_xla/experimental/pjrt_backend.py
@@ -3,7 +3,6 @@ import logging
 import threading
 
 import torch.distributed as dist
-from torch.testing._internal.distributed import multi_threaded_pg
 from torch_xla.distributed import xla_backend
 from torch_xla import runtime as xr
 from torch_xla._internal import pjrt
@@ -48,6 +47,7 @@ def _pjrt_rendezvous_handler(url: str,
 
 
 if tpu.num_available_chips() > 0 and tpu.version() <= 3:
+  from torch.testing._internal.distributed import multi_threaded_pg
   logging.warning('Patching torch.distributed state to support multithreading.')
   logging.warning('torch.distributed support on TPU v2 and v3 is experimental.')
   multi_threaded_pg._install_threaded_pg()

--- a/torch_xla/experimental/pjrt_backend.py
+++ b/torch_xla/experimental/pjrt_backend.py
@@ -49,7 +49,8 @@ def _pjrt_rendezvous_handler(url: str,
 if tpu.num_available_chips() > 0 and tpu.version() <= 3:
   from torch.testing._internal.distributed import multi_threaded_pg
   logging.warning('Patching torch.distributed state to support multithreading.')
-  logging.warning('torch.distributed support on TPU v2 and v3 is experimental.')
+  logging.warning('torch.distributed support on TPU v2 and v3 is experimental '
+                  'and does not support torchrun.')
   multi_threaded_pg._install_threaded_pg()
 
 dist.register_rendezvous_handler('pjrt', _pjrt_rendezvous_handler)

--- a/torch_xla/experimental/pjrt_backend.py
+++ b/torch_xla/experimental/pjrt_backend.py
@@ -1,10 +1,12 @@
 import datetime
+import logging
 import threading
 
 import torch.distributed as dist
 from torch.testing._internal.distributed import multi_threaded_pg
 from torch_xla.distributed import xla_backend
 from torch_xla import runtime as xr
+from torch_xla._internal import pjrt
 from torch_xla._internal import tpu
 import torch_xla.utils.utils as xu
 
@@ -15,6 +17,12 @@ _store_lock = threading.Lock()
 def _pjrt_rendezvous_handler(url: str,
                              timeout: datetime.timedelta = ...,
                              **kwargs):
+  # Assume `xmp.spawn` has not been called when using torchrun
+  if dist.is_torchelastic_launched():
+    local_world_size = xu.getenv_as('LOCAL_WORLD_SIZE', int)
+    local_rank = xu.getenv_as('LOCAL_RANK', int)
+    pjrt.initialize_multiprocess(local_rank, local_world_size)
+
   master_ip = xu.getenv_as('MASTER_ADDR', str)
   if not master_ip:
     master_ip = tpu.discover_master_worker_ip() if xr.device_type(
@@ -24,15 +32,24 @@ def _pjrt_rendezvous_handler(url: str,
   with _store_lock:
     global _store
     if not _store:
-      _store = dist.TCPStore(
-          master_ip,
-          master_port,
-          xr.process_count(),
-          is_master=xr.process_index() == 0)
+      if xu.getenv_as('TORCHELASTIC_USE_AGENT_STORE', str) == 'True':
+        attempt = xu.getenv_as('TORCHELASTIC_RESTART_COUNT', int, defval=0)
+        tcp_store = dist.TCPStore(
+            master_ip, master_port, xr.process_count(), is_master=False)
+        _store = dist.PrefixStore(f"/worker/attempt_{attempt}", tcp_store)
+      else:
+        _store = dist.TCPStore(
+            master_ip,
+            master_port,
+            xr.process_count(),
+            is_master=xr.process_index() == 0)
 
   yield (_store, xr.global_ordinal(), xr.world_size())
 
 
-multi_threaded_pg._install_threaded_pg()
+if tpu.num_available_chips() > 0 and tpu.version() <= 3:
+  logging.warning('Patching torch.distributed state to support multithreading.')
+  logging.warning('torch.distributed support on TPU v2 and v3 is experimental.')
+  multi_threaded_pg._install_threaded_pg()
 
 dist.register_rendezvous_handler('pjrt', _pjrt_rendezvous_handler)


### PR DESCRIPTION
- Generalize `pjrt.init_multiprocess` and call it from the `pjrt://` `init_method`. If PJRT is not initialized before the rendezvous, xm.world_size will be incorrect.
- Use the torchrun server for `torch.dist`'s store when available.
- Add a warning when patching torch.distributed.

Tested manually on TPU v4 with `torchrun --nnodes 1 --nproc-per-node 4 pytorch/xla/test/pjrt/test_torchrun.py`. We should add this to the TPU v4 CI when it is implemented. I don't think there's a way to make this test work on TPU v2.

cc @aws-kingrj 