### PR TITLE
Remove base image override from TPU CI build

### DIFF
--- a/infra/tpu-pytorch/test_triggers.tf
+++ b/infra/tpu-pytorch/test_triggers.tf
@@ -20,8 +20,7 @@ module "tpu_e2e_tests" {
   ])
 
   build_args = {
-    python_version = "3.8"
-    debian_version = "buster"
+    python_version = "3.10"
   }
 
   ansible_vars = {


### PR DESCRIPTION
This will let us test new base images in pending PRs without having to merge to master. cc @qihqi 

Also update Python version to 3.10 to match nightly builds.

Terraform plan:

```
Terraform will perform the following actions:

  # module.tpu_e2e_tests.module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch/triggers/8e11b2bb-f1f1-4d48-ac05-315f16d15c5d"
        name               = "ci-tpu-test-trigger"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=e2e_tests.Dockerfile . --build-arg=debian_version=buster --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"disable_xrt\":\"1\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch/docker/pytorch-xla-test:$(echo $BUILD_ID)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=e2e_tests.Dockerfile . --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"disable_xrt\":\"1\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch/docker/pytorch-xla-test:$(echo $BUILD_ID)\" -t=local_image",
                ]
                id               = "build_pytorch-xla-test_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (5 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```