### PR TITLE
Remove Docker image override from dev image

### DIFF
--- a/infra/tpu-pytorch-releases/dev_images.tf
+++ b/infra/tpu-pytorch-releases/dev_images.tf
@@ -48,7 +48,6 @@ module "dev_images" {
 
   build_args = {
     python_version = each.value.python_version
-    debian_version = "buster"
   }
 
   ansible_vars = {


### PR DESCRIPTION
Terraform plan:

```
Terraform will perform the following actions:

  # module.dev_images["3.8_cuda_11.8"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/6a99159e-7d7c-402f-9e92-35b73754b650"
        name               = "dev-3-8-cuda-11-8"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=development.Dockerfile . --build-arg=debian_version=buster --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:$(echo cuda)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:$(echo 3.8_cuda_11.8)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:$(echo 3.8_cuda_11.8_$(date +%Y%m%d))\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=development.Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:$(echo cuda)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:$(echo 3.8_cuda_11.8)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:$(echo 3.8_cuda_11.8_$(date +%Y%m%d))\" -t=local_image",
                ]
                id               = "build_development_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (4 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.dev_images["3.8_tpuvm"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/c907325a-f187-49aa-836f-732950c3697b"
        name               = "dev-3-8-tpuvm"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=development.Dockerfile . --build-arg=debian_version=buster --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:$(echo tpu)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:$(echo 3.8_tpuvm)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:$(echo 3.8_tpuvm_$(date +%Y%m%d))\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=development.Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:$(echo tpu)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:$(echo 3.8_tpuvm)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:$(echo 3.8_tpuvm_$(date +%Y%m%d))\" -t=local_image",
                ]
                id               = "build_development_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (4 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```