### PR TITLE
Modify kokoro to make it work

### DIFF
--- a/.kokoro/Dockerfile
+++ b/.kokoro/Dockerfile
@@ -1,0 +1,55 @@
+FROM us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:tpu
+WORKDIR /
+RUN apt-get update
+RUN apt-get -y upgrade
+RUN pip install pytest tf-nightly
+RUN mkdir -p /xla
+
+# Builds and configure sccache
+ENV OPENSSL_INCLUDE_DIR /usr/include/openssl
+ENV OPENSSL_LIB_DIR /usr/lib/x86_64-linux-gnu
+
+ENV CARGO_HOME /opt/cargo
+ENV RUSTUP_HOME /opt/rustup
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN . $CARGO_HOME/env && \
+    git clone --recursive https://github.com/pytorch/sccache.git && \
+    cd sccache && \
+    cargo install --path . && \
+    cd .. && \
+    rm -rf sccache
+
+ENV PATH $CARGO_HOME/bin:$PATH
+
+ADD ./ /xla
+
+WORKDIR /xla
+RUN touch env
+RUN touch xla_env
+RUN touch default_credentials.json
+ARG USE_MKLDNN=0
+ARG USE_FBGEMM=0
+ARG USE_OPENMP=0
+ARG BUILD_NVFUSER=0
+ARG USE_KINETO=0
+ARG USE_NCCL=0
+ARG USE_XNNPACK=0
+ARG USE_QNNPACK=0
+ARG USE_PYTORCH_QNNPACK=0
+ARG USE_CUDA=0
+ARG BUILD_TEST=0
+RUN bash .circleci/build.sh
+
+WORKDIR /tmp/pytorch/xla
+
+WORKDIR /
+RUN git clone --quiet https://github.com/pytorch/vision.git "/vision"
+WORKDIR /vision
+RUN python setup.py install
+
+WORKDIR /tmp/pytorch/xla
+
+ENV PJRT_DEVICE=CPU
+ENV XLA_STABLEHLO_COMPILE=1
+ENTRYPOINT pytest test/stablehlo

--- a/.kokoro/Dockerfile
+++ b/.kokoro/Dockerfile
@@ -2,33 +2,13 @@ FROM us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:tpu
 WORKDIR /
 RUN apt-get update
 RUN apt-get -y upgrade
+RUN apt-get -y install clang time
 RUN pip install pytest tf-nightly
-RUN mkdir -p /xla
-
-# Builds and configure sccache
-ENV OPENSSL_INCLUDE_DIR /usr/include/openssl
-ENV OPENSSL_LIB_DIR /usr/lib/x86_64-linux-gnu
-
-ENV CARGO_HOME /opt/cargo
-ENV RUSTUP_HOME /opt/rustup
-
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-RUN . $CARGO_HOME/env && \
-    git clone --recursive https://github.com/pytorch/sccache.git && \
-    cd sccache && \
-    cargo install --path . && \
-    cd .. && \
-    rm -rf sccache
-
-ENV PATH $CARGO_HOME/bin:$PATH
-
-ADD ./ /xla
-
-WORKDIR /xla
-RUN touch env
-RUN touch xla_env
-RUN touch default_credentials.json
 ARG USE_MKLDNN=0
+ARG SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2
+ARG DISABLE_XRT=1
+ARG XLA_CUDA=0
+ARG BAZEL_REMOTE_CACHE=1
 ARG USE_FBGEMM=0
 ARG USE_OPENMP=0
 ARG BUILD_NVFUSER=0
@@ -39,17 +19,38 @@ ARG USE_QNNPACK=0
 ARG USE_PYTORCH_QNNPACK=0
 ARG USE_CUDA=0
 ARG BUILD_TEST=0
-RUN bash .circleci/build.sh
+ARG USE_CACHE=1
 
-WORKDIR /tmp/pytorch/xla
+# install pytorch
+ARG PYTORCH_DIR=/pytorch
+ARG XLA_DIR=$PYTORCH_DIR/xla
+RUN git clone --quiet https://github.com/pytorch/pytorch.git "$PYTORCH_DIR"
 
+WORKDIR /pytorch
+RUN pip install cmake ninja
+RUN pip install  -r requirements.txt
+RUN bash .ci/docker/common/install_cache.sh
+RUN time python setup.py install
+RUN /opt/cache/bin/sccache --show-stats
+
+# install torchvision
 WORKDIR /
 RUN git clone --quiet https://github.com/pytorch/vision.git "/vision"
 WORKDIR /vision
 RUN python setup.py install
 
-WORKDIR /tmp/pytorch/xla
+# install torch xla
+ADD ./ /pytorch/xla
+WORKDIR /pytorch/xla
+RUN cp keystore_content/77422_pytorch_tpu_cloud_build default_credentials.json
+ARG SCCACHE="$(which sccache)"
 
+WORKDIR /pytorch/xla
+ARG GCLOUD_SERVICE_KEY_FILE="/pytorch/xla/default_credentials.json"
+ARG SILO_NAME='cache-silo-ci-gcc-11'  # cache bucket for CI
+RUN time pip install -e .
+
+# Run tests
 ENV PJRT_DEVICE=CPU
 ENV XLA_STABLEHLO_COMPILE=1
 ENTRYPOINT pytest test/stablehlo

--- a/.kokoro/build_and_run_stablehlo_tests.sh
+++ b/.kokoro/build_and_run_stablehlo_tests.sh
@@ -1,31 +1,7 @@
 #!/bin/bash
-
 set -ex
-
 DEBIAN_FRONTEND=noninteractive
-
-PYTORCH_DIR="${KOKORO_ARTIFACTS_DIR}/github/pytorch"
-XLA_DIR=$PYTORCH_DIR/xla
-git clone --quiet https://github.com/pytorch/pytorch.git "$PYTORCH_DIR"
-cp -r "${KOKORO_ARTIFACTS_DIR}/github/xla" "$XLA_DIR"
-source ${XLA_DIR}/.kokoro/common.sh
-
-TORCHVISION_COMMIT="$(cat $PYTORCH_DIR/.github/ci_commit_pins/vision.txt)"
-
-install_environments
-
-set +e
-# build pytorch
-pushd $PYTORCH_DIR
-pip install --user .
-popd
-build_torch_xla $XLA_DIR
-pushd $XLA_DIR
-LOGFILE=/tmp/pytorch_py_test.log
-TEST_DIR=test/stablehlo
-for FILE in $(ls $TEST_DIR); do
-    XLA_STABLEHLO_COMPILE=1 python $TEST_DIR/$FILE | tee $LOGFILE
-done
-
-
-
+XLA_DIR="${KOKORO_ARTIFACTS_DIR}/github/xla"
+cd $XLA_DIR
+docker build . -f=.kokoro/Dockerfile -t xladocker
+docker run -it xladocker

--- a/.kokoro/build_and_run_stablehlo_tests.sh
+++ b/.kokoro/build_and_run_stablehlo_tests.sh
@@ -3,5 +3,6 @@ set -ex
 DEBIAN_FRONTEND=noninteractive
 XLA_DIR="${KOKORO_ARTIFACTS_DIR}/github/xla"
 cd $XLA_DIR
+cp $KOKORO_KEYSTORE_DIR ./keystore_content -r
 docker build . -f=.kokoro/Dockerfile -t xladocker
-docker run -it xladocker
+docker -v "$KOKORO_KEYSTORE_DIR:/tmp/keystore" run xladocker

--- a/.kokoro/presubmit.cfg
+++ b/.kokoro/presubmit.cfg
@@ -5,3 +5,13 @@
 
 build_file: "xla/.kokoro/build_and_run_stablehlo_tests.sh"
 timeout_mins: 360
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 77422
+      keyname: "pytorch_tpu_cloud_build"
+      backend: "blade:keystore-fastconfigpush"
+    }
+  }
+}


### PR DESCRIPTION
Previously kokoro CI has been passing;
https://fusion2.corp.google.com/invocations/5013bc47-b656-4d66-8cc2-d669a20dcdd3/targets/cloud-tpu%2Ftorchxla%2Fgithub%2Fpresubmit/log

but the log actually have failed tests.
This change will try to 1. make `set -e` stick and 2. make the tests actually pass