### PR TITLE
update ansible remote cache key

### DIFF
--- a/infra/ansible/config/env.yaml
+++ b/infra/ansible/config/env.yaml
@@ -31,7 +31,7 @@ build_env:
     PYTORCH_BUILD_VERSION: "{{ package_version }}"
     XLA_SANDBOX_BUILD: 1
     BAZEL_REMOTE_CACHE: 1
-    SILO_NAME: "cache-silo-{{ arch }}-{{ accelerator }}"
+    SILO_NAME: "cache-silo-{{ arch }}-{{ accelerator }}-{{ clang_version }}"
     DISABLE_XRT: "{{ disable_xrt }}"
 
   amd64:


### PR DESCRIPTION
cuda nightly whl failed with the following error after Debian is upgraded to Bullseye which uses gcc-10. Update cache key to clean the bazel cache.
```
Step #2 - "build_xla_docker_image":     [0 / 69] [Prepa] action 'SolibSymlink _solib_local/_U@torch_S_S_Clibtorch___Ubuild_Slib/libtorch.so'
Step #2 - "build_xla_docker_image":     ERROR: /root/.cache/bazel/_bazel_root/2ba57cc32d8c1f12152416615363d16d/external/zlib/BUILD.bazel:5:11: Compiling infback.c failed: undeclared inclusion(s) in rule '@zlib//:zlib':
Step #2 - "build_xla_docker_image":     this rule is missing dependency declarations for the following files included by 'infback.c':
Step #2 - "build_xla_docker_image":       '/usr/lib/gcc/x86_64-linux-gnu/8/include/stddef.h'
Step #2 - "build_xla_docker_image":       '/usr/lib/gcc/x86_64-linux-gnu/8/include-fixed/limits.h'
Step #2 - "build_xla_docker_image":       '/usr/lib/gcc/x86_64-linux-gnu/8/include-fixed/syslimits.h'
Step #2 - "build_xla_docker_image":       '/usr/lib/gcc/x86_64-linux-gnu/8/include/stdarg.h'
[a few more similar errors]
```