### PR TITLE
Fix data type in Pow with Scalar base and Tensor exponent

### DIFF
--- a/test/cpp/test_aten_xla_tensor_1.cpp
+++ b/test/cpp/test_aten_xla_tensor_1.cpp
@@ -3679,7 +3679,7 @@ TEST_F(AtenXlaTensorTest, TestPowScalarTensor) {
   torch::Tensor result = torch::pow(base, exponent);
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor xla_exponent = CopyToDevice(exponent, device);
-    torch::Tensor xla_result = torch::pow(base, xla_exponent);
+    torch::Tensor xla_result = torch::pow(base, xla_exponent).to(torch::kFloat);
     AllClose(result, xla_result, /*rtol=*/1e-3, /*atol=*/1e-5);
   });
 
@@ -3694,6 +3694,19 @@ TEST_F(AtenXlaTensorTest, TestPowIntExponent) {
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor xla_base = CopyToDevice(base, device);
     torch::Tensor xla_result = torch::pow(xla_base, exponent);
+    AllClose(result, xla_result, /*rtol=*/1e-3, /*atol=*/1e-5);
+  });
+
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+}
+
+TEST_F(AtenXlaTensorTest, TestPowFloatScalarBaseIntExponent) {
+  torch::Scalar base = .5;
+  torch::Tensor exponent = torch::randint(0, 100, {4, 2});
+  torch::Tensor result = torch::pow(base, exponent);
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_exponent = CopyToDevice(exponent, device);
+    torch::Tensor xla_result = torch::pow(base, xla_exponent).to(torch::kFloat);
     AllClose(result, xla_result, /*rtol=*/1e-3, /*atol=*/1e-5);
   });
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2080,10 +2080,8 @@ XLATensorPtr pow(const at::Scalar& input, const XLATensorPtr& exponent) {
   torch::lazy::NodePtr pow_node = Pow(input_node, exponent->GetIrValue());
   at::ScalarType input_dtype = GetScalarType(input);
   at::ScalarType exp_dtype = exponent->dtype();
-  at::ScalarType promoted_dtype =
-    TensorTypeFromXlaType(
-      XlaHelpers::PromoteType(TensorTypeToRawXlaType(input_dtype),
-                TensorTypeToRawXlaType(exp_dtype)));
+  at::ScalarType promoted_dtype = TensorTypeFromXlaType(XlaHelpers::PromoteType(
+      TensorTypeToRawXlaType(input_dtype), TensorTypeToRawXlaType(exp_dtype)));
   return exponent->CreateFrom(pow_node, promoted_dtype);
 }
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2074,9 +2074,17 @@ XLATensorPtr pow(const XLATensorPtr& input, const XLATensorPtr& exponent) {
 }
 
 XLATensorPtr pow(const at::Scalar& input, const XLATensorPtr& exponent) {
+  const torch::lazy::BackendDevice& device = exponent->GetDevice();
   torch::lazy::Value input_node = XLAGraphExecutor::Get()->GetIrValueForScalar(
-      input, exponent->shape(), exponent->GetDevice());
-  return exponent->CreateFrom(Pow(input_node, exponent->GetIrValue()));
+      input, MakeXlaPrimitiveType(GetScalarType(input), &device), device);
+  torch::lazy::NodePtr pow_node = Pow(input_node, exponent->GetIrValue());
+  at::ScalarType input_dtype = GetScalarType(input);
+  at::ScalarType exp_dtype = exponent->dtype();
+  at::ScalarType promoted_dtype =
+    TensorTypeFromXlaType(
+      XlaHelpers::PromoteType(TensorTypeToRawXlaType(input_dtype),
+                TensorTypeToRawXlaType(exp_dtype)));
+  return exponent->CreateFrom(pow_node, promoted_dtype);
 }
 
 XLATensorPtr prelu(const XLATensorPtr& input, const XLATensorPtr& weight) {


### PR DESCRIPTION
This fixes #5118. When pow base is a floating point scalar, exponent is an int tensor, the result is wrong.

The root cause is the following
- when the scalar is converted to Lazy IR from `at::Scalar`, it's using the shape info of exponent tensor. This makes the scalar to have integer dtype when exponent is an integer tensor.
- Another problem is that the result tensor is created by `exponent->CreateFrom`, which uses exponent primitive type by default, leading to the result tensor has the same dtype as exponent. However, we should use the promoted dtype for the result tensor.

The following changes are made to resolve the above 2 problems:

- Use Scalar dtype when Lazy IR Node is created.
- Use promoted dtype for the result tensor

Issue with the fix:

I found when a Python constant is captured into `at::Scalar`, fp32/64 are not distinguished any more ([code ref](https://github.com/pytorch/pytorch/blob/4ee622476702fba3480572cbc712b552fd878605/c10/core/Scalar.h#L258C16-L270)), the dtype check util function in PyTorch/XLA [here] is doing the same(https://github.com/pytorch/xla/blob/028df4da388468fa9a41b1f98ea08bfce13b4c63/torch_xla/csrc/torch_util.cpp#L49). This causes the result to be in either double dtype or integer dtype. However the default floating point dtype in Python is float32, and the PyTorch eager gives float32 result. This discrepancy needs to be investigated. I have to cast the xla tensor back to fp32 in the cpp tests now

To generate the same dtype as PyTorch Eager, we need to distinguish float32/64 when the Python constant is captured into an `aten::Scalar`.