### PR TITLE
[Dynamo][SPMD] Fix the input sharding for dynamo

### DIFF
--- a/test/spmd/test_dynamo_spmd.py
+++ b/test/spmd/test_dynamo_spmd.py
@@ -72,6 +72,19 @@ class DynamoSpmdInferenceTest(test_xla_sharding_base.XlaShardingTest):
     dynamo_res = dynamo_linear(xla_y)
     self.assertEqual(met.counter_value('UncachedOutputSharding'), 1)
 
+  def test_dynamo_sharded_input(self):
+    device = xm.xla_device()
+    linear = SimpleLinear().to(device)
+    linear.eval()
+    xla_x = torch.randn(8, 128, device=device)
+    xs.mark_sharding(xla_x, self._get_mesh((1, self.n_devices)), (1, 0))
+    xla_res = linear(xla_x)
+    xm.mark_step()
+
+    dynamo_linear = torch.compile(linear, backend="openxla")
+    dynamo_res = dynamo_linear(xla_x)
+    torch.allclose(xla_res.cpu(), dynamo_res.cpu())
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -692,11 +692,9 @@ void ShardingUtil::PrepareOutputShardingPropagation(
     // Register the sharded data placeholder to the tensor and its node.
     (*data_placeholders)[i] = sharded_data_placeholder;
     xtensor->data()->handle = (*data_placeholders)[i];
-    if (auto ir_value = xtensor->CurrentIrValue()) {
-      if (DeviceData* device_data_node =
-              DeviceData::Cast(ir_value.node.get())) {
-        device_data_node->Assign(xtensor->data()->handle);
-      }
+    // TODO(JackCaoG): Invesgate why output tensor has IR value here.
+    if (xtensor->CurrentIrValue()) {
+      xtensor->AssignIrValue(torch::lazy::Value());
     }
   }
 }


### PR DESCRIPTION
without this change the test failed with
```
but got buffer with incompatible size 1024 (s64[]{:T(128)})
```

the real issue is that after `mark_step` there is a dangling `DeviceData` IR which blocks the correct `DeviceData` IR being created using the real `PjrtData` object. This will creates all sorts of issue including the `TensorID` in the `DeviceData`'s info being missing.

I still need to figure out why the `DeviceData` Ir still exist in the middle of the `mark_step`, it should get deleted during the `CollectSyncTensor` step(given this is considered as the output of the current execution).