### PR TITLE
bump the timeout for CI

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -38,7 +38,7 @@ on:
 jobs:
   build:
     runs-on: ${{ inputs.runner }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     outputs:
       docker-image: ${{ steps.upload-docker-image.outputs.docker-image }}
     env:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,4 +1,3 @@
-name: Build & Test
 on:
   pull_request:
     branches:
@@ -45,7 +44,7 @@ jobs:
     with:
       docker-image: ${{ needs.build.outputs.docker-image }}
       runner: linux.8xlarge.nvidia.gpu
-      timeout-minutes: 180
+      timeout-minutes: 240
       disable-xrt: 1
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}


### PR DESCRIPTION
PR from the fork can not use the remote cache hence it is easier to time out. Bump both build and test timeout for this purpose.