### PR TITLE
Add topological sorting to dynamo partitions

### DIFF
--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -245,22 +245,22 @@ class DynamoCpuFallbackTest(unittest.TestCase):
     cpu_res = fn_fallback(t)
     xla_dynamo_res = dynamo_fn(t_xla)
     self.assertTrue(torch.allclose(cpu_res, xla_dynamo_res.cpu()))
-    self.assertEqual(met.metric_data('CompileTime')[0], 4)
-    self.assertEqual(met.metric_data('ExecuteTime')[0], 8)
+    self.assertEqual(met.metric_data('CompileTime')[0], 3)
+    self.assertEqual(met.metric_data('ExecuteTime')[0], 10)
 
     # Second tracing
     met.clear_counters()
     xla_dynamo_res_2 = dynamo_fn(t_xla)
     self.assertTrue(torch.allclose(cpu_res, xla_dynamo_res_2.cpu()))
-    self.assertEqual(met.metric_data('CompileTime')[0], 4)
-    self.assertEqual(met.metric_data('ExecuteTime')[0], 10)
+    self.assertEqual(met.metric_data('CompileTime')[0], 3)
+    self.assertEqual(met.metric_data('ExecuteTime')[0], 12)
 
     # Verify that dynamo can handle different inputs
     xla_dynamo_res_3 = dynamo_fn(t_xla * 3)
     cpu_res_3 = fn_fallback(t * 3)
     self.assertTrue(torch.allclose(cpu_res_3, xla_dynamo_res_3.cpu()))
-    self.assertEqual(met.metric_data('CompileTime')[0], 5)
-    self.assertEqual(met.metric_data('ExecuteTime')[0], 12)
+    self.assertEqual(met.metric_data('CompileTime')[0], 4)
+    self.assertEqual(met.metric_data('ExecuteTime')[0], 15)
 
 
 class DynamoTrainingBasicTest(unittest.TestCase):

--- a/torch_xla/core/dynamo_bridge.py
+++ b/torch_xla/core/dynamo_bridge.py
@@ -424,7 +424,8 @@ def extract_compiled_graph(xla_model: torch.fx.GraphModule, xla_args):
 
   # partition the model
   supported_ops = XlaOperatorSupport()
-  partitioner = CapabilityBasedPartitioner(xla_model, supported_ops, allows_single_node_partition=True)
+  partitioner = CapabilityBasedPartitioner(
+      xla_model, supported_ops, allows_single_node_partition=True)
   partitions = partitioner.propose_partitions()
 
   # propose_partitions() does not guarantee topolgical order, so sort it manually


### PR DESCRIPTION
As a follow-up to https://github.com/pytorch/xla/pull/5309, this PR sets `allows_single_node_partition=True` and calls `torch.fx.passes.utils.fuser_utils.topo_sort` to ensure the topological ordering of the partitioned nodes. 

With the topological ordering added, the test `test_simple_model_with_in_place_ops` succeeds consistently (previously, we were seeing occasional failure due to the unsorted partitioned nodes when `allows_single_node_partition=True`). 

Test plan:
- `python test/dynamo/test_dynamo.py` all passing locally
- CI