### PR TITLE
Introduce `torch_xla.runtime.use_spmd()`

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -248,7 +248,8 @@ variables:
       default_value: false
     XLA_USE_SPMD:
       description:
-        - Whether or not to use the SPMD virtual device optimization.
+        - Deprecated. Whether or not to use the SPMD virtual device optimization.
+          Use `torch_xla.runtime.set_use_spmd()` instead.
       type: bool
       default_value: false
     SPLIT_EXECUTOR_CACHE_SIZE:

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -249,7 +249,7 @@ variables:
     XLA_USE_SPMD:
       description:
         - Deprecated. Whether or not to use the SPMD virtual device optimization.
-          Use `torch_xla.runtime.set_use_spmd()` instead.
+          Use `torch_xla.runtime.use_spmd()` instead.
       type: bool
       default_value: false
     SPLIT_EXECUTOR_CACHE_SIZE:

--- a/test/spmd/test_dynamo_spmd.py
+++ b/test/spmd/test_dynamo_spmd.py
@@ -34,7 +34,7 @@ class DynamoSpmdInferenceTest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    xr.set_use_spmd()
+    xr.use_spmd()
     super().setUpClass()
 
   def test_dynamo_spmd_basic(self):
@@ -72,19 +72,6 @@ class DynamoSpmdInferenceTest(test_xla_sharding_base.XlaShardingTest):
     self.assertEqual(met.counter_value('UncachedOutputSharding'), 1)
     dynamo_res = dynamo_linear(xla_y)
     self.assertEqual(met.counter_value('UncachedOutputSharding'), 1)
-
-  def test_dynamo_sharded_input(self):
-    device = xm.xla_device()
-    linear = SimpleLinear().to(device)
-    linear.eval()
-    xla_x = torch.randn(8, 128, device=device)
-    xs.mark_sharding(xla_x, self._get_mesh((1, self.n_devices)), (1, 0))
-    xla_res = linear(xla_x)
-    xm.mark_step()
-
-    dynamo_linear = torch.compile(linear, backend="openxla")
-    dynamo_res = dynamo_linear(xla_x)
-    torch.allclose(xla_res.cpu(), dynamo_res.cpu())
 
 
 if __name__ == '__main__':

--- a/test/spmd/test_dynamo_spmd.py
+++ b/test/spmd/test_dynamo_spmd.py
@@ -4,6 +4,7 @@ import sys
 import torch
 import torch.nn as nn
 import torch_xla
+import torch_xla.runtime as xr
 import torch_xla.core.xla_model as xm
 import torch_xla.experimental.xla_sharding as xs
 import torch_xla.debug.metrics as met
@@ -33,7 +34,7 @@ class DynamoSpmdInferenceTest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    os.environ["XLA_USE_SPMD"] = "1"
+    xr.set_use_spmd()
     super().setUpClass()
 
   def test_dynamo_spmd_basic(self):

--- a/test/spmd/test_spmd_graph_dump.py
+++ b/test/spmd/test_spmd_graph_dump.py
@@ -18,7 +18,7 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    os.environ["XLA_USE_SPMD"] = "1"
+    xr.set_use_spmd()
     super().setUpClass()
 
   def test_dump_with_output_sharding(self):

--- a/test/spmd/test_spmd_graph_dump.py
+++ b/test/spmd/test_spmd_graph_dump.py
@@ -18,7 +18,7 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    xr.set_use_spmd()
+    xr.use_spmd()
     super().setUpClass()
 
   def test_dump_with_output_sharding(self):

--- a/test/spmd/test_xla_distributed_checkpoint.py
+++ b/test/spmd/test_xla_distributed_checkpoint.py
@@ -24,7 +24,7 @@ class DistributedCheckpointTestBase(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    xr.set_use_spmd()
+    xr.use_spmd()
     super().setUpClass()
 
   def _get_sharded_model(self, mesh_shape=None):

--- a/test/spmd/test_xla_distributed_checkpoint.py
+++ b/test/spmd/test_xla_distributed_checkpoint.py
@@ -24,7 +24,7 @@ class DistributedCheckpointTestBase(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    os.environ['XLA_USE_SPMD'] = '1'
+    xr.set_use_spmd()
     super().setUpClass()
 
   def _get_sharded_model(self, mesh_shape=None):

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -26,7 +26,7 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    xr.set_use_spmd()
+    xr.use_spmd()
     super().setUpClass()
 
   def test_xla_sharded_tensor(self):

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -26,7 +26,7 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    os.environ["XLA_USE_SPMD"] = "1"
+    xr.set_use_spmd()
     super().setUpClass()
 
   def test_xla_sharded_tensor(self):

--- a/test/spmd/test_xla_spmd_python_api_interaction.py
+++ b/test/spmd/test_xla_spmd_python_api_interaction.py
@@ -59,7 +59,7 @@ class BasicRuntimeAPITest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    os.environ["XLA_USE_SPMD"] = "1"
+    xr.set_use_spmd()
     super().setUpClass()
 
   def test_local_process_count(self):

--- a/test/spmd/test_xla_spmd_python_api_interaction.py
+++ b/test/spmd/test_xla_spmd_python_api_interaction.py
@@ -6,6 +6,7 @@ import torch
 import torch_xla
 import torch_xla.core.xla_model as xm
 from torch_xla import runtime as xr
+
 import test_xla_sharding_base
 
 
@@ -102,6 +103,13 @@ class BasicRuntimeAPITest(test_xla_sharding_base.XlaShardingTest):
       self.assertGreaterEqual(xr.addressable_runtime_device_count(), 4)
     elif device_type == "CPU":
       self.assertEqual(xr.addressable_runtime_device_count(), 1)
+
+  def test_runtime_spmd_api(self):
+    self.assertTrue(xr.is_spmd())
+    del os.environ["XLA_USE_SPMD"]
+    self.assertFalse(xr.is_spmd())
+    # reset for other test cases
+    os.environ["XLA_USE_SPMD"] = "1"
 
 
 if __name__ == '__main__':

--- a/test/spmd/test_xla_spmd_python_api_interaction.py
+++ b/test/spmd/test_xla_spmd_python_api_interaction.py
@@ -13,7 +13,7 @@ class BasicXMAPITest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    xr.set_use_spmd()
+    xr.use_spmd()
     super().setUpClass()
 
   def test_get_xla_supported_devices(self):
@@ -59,7 +59,7 @@ class BasicRuntimeAPITest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    xr.set_use_spmd()
+    xr.use_spmd()
     super().setUpClass()
 
   def test_local_process_count(self):

--- a/test/spmd/test_xla_spmd_python_api_interaction.py
+++ b/test/spmd/test_xla_spmd_python_api_interaction.py
@@ -13,7 +13,7 @@ class BasicXMAPITest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    os.environ["XLA_USE_SPMD"] = "1"
+    xr.set_use_spmd()
     super().setUpClass()
 
   def test_get_xla_supported_devices(self):

--- a/test/spmd/test_xla_virtual_device.py
+++ b/test/spmd/test_xla_virtual_device.py
@@ -6,6 +6,7 @@ import unittest
 import torch
 from torch import nn
 import torch_xla
+import torch_xla.runtime as xr
 import torch_xla.core.xla_model as xm
 import torch_xla.debug.metrics as met
 import torch_xla.experimental.xla_sharding as xs
@@ -16,7 +17,7 @@ class VirtualDeviceTest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    os.environ["XLA_USE_SPMD"] = "1"
+    xr.set_use_spmd()
     super().setUpClass()
 
   def test_mark_sharding(self):

--- a/test/spmd/test_xla_virtual_device.py
+++ b/test/spmd/test_xla_virtual_device.py
@@ -17,7 +17,7 @@ class VirtualDeviceTest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    xr.set_use_spmd()
+    xr.use_spmd()
     super().setUpClass()
 
   def test_mark_sharding(self):

--- a/torch_xla/csrc/device.cpp
+++ b/torch_xla/csrc/device.cpp
@@ -29,7 +29,7 @@ std::string XlaDeviceTypeToString(XlaDeviceType hw_type) {
 
 // This is set when any device is initialized, so to prevent using non-virtual
 // device and virtual device together.
-static bool lock_spmd_config = false;
+static bool spmd_config_is_locked = false;
 
 }  // namespace
 
@@ -117,11 +117,11 @@ bool ShouldUseVirtualDevice() {
 }
 
 bool UseVirtualDevice() {
-  lock_spmd_config = true;
+  spmd_config_is_locked = true;
   static bool use_virtual_device = ShouldUseVirtualDevice();
   return use_virtual_device;
 }
 
-bool GetLockSpmdConfig() { return lock_spmd_config; }
+bool GetLockSpmdConfig() { return spmd_config_is_locked; }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/device.cpp
+++ b/torch_xla/csrc/device.cpp
@@ -113,6 +113,7 @@ bool ShouldUseVirtualDevice() {
 }
 
 bool UseVirtualDevice() {
+  lock_spmd_config = true;
   static bool use_virtual_device = ShouldUseVirtualDevice();
   return use_virtual_device;
 }

--- a/torch_xla/csrc/device.cpp
+++ b/torch_xla/csrc/device.cpp
@@ -27,6 +27,10 @@ std::string XlaDeviceTypeToString(XlaDeviceType hw_type) {
   XLA_ERROR() << "Invalid device type";
 }
 
+// This is set when any device is initialized, so to prevent using non-virtual
+// device and virtual device together.
+static bool lock_spmd_config = false;
+
 }  // namespace
 
 std::string DeviceType::toString() const {
@@ -113,9 +117,11 @@ bool ShouldUseVirtualDevice() {
 }
 
 bool UseVirtualDevice() {
-  lock_spmd_config = true;
+  use_virtual_device = true;
   static bool use_virtual_device = ShouldUseVirtualDevice();
   return use_virtual_device;
 }
+
+bool GetLockSpmdConfig() { return lock_spmd_config; }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/device.cpp
+++ b/torch_xla/csrc/device.cpp
@@ -117,7 +117,7 @@ bool ShouldUseVirtualDevice() {
 }
 
 bool UseVirtualDevice() {
-  use_virtual_device = true;
+  lock_spmd_config = true;
   static bool use_virtual_device = ShouldUseVirtualDevice();
   return use_virtual_device;
 }

--- a/torch_xla/csrc/device.h
+++ b/torch_xla/csrc/device.h
@@ -47,9 +47,9 @@ static inline torch::lazy::BackendDevice GetDeviceOrCurrent(
 // and sets `lock_spmd_config` to block switching the SPMD mode.
 bool UseVirtualDevice();
 
-// This is set when any device is initialized, so to prevent using non-virtual
-// device and virtual device together.
-static bool lock_spmd_config = false;
+// Return true if SPMD config can be switches. That is, no device has been
+// initialized, yet.
+bool GetLockSpmdConfig();
 
 }  // namespace torch_xla
 

--- a/torch_xla/csrc/device.h
+++ b/torch_xla/csrc/device.h
@@ -43,8 +43,13 @@ static inline torch::lazy::BackendDevice GetDeviceOrCurrent(
 }
 
 // Test whether the XLA_USE_SPMD environment variable is set to enable the
-// virtual device optimization.
+// virtual device optimization. This API is called before every device init,
+// and sets `lock_spmd_config` to block switching the SPMD mode.
 bool UseVirtualDevice();
+
+// This is set when any device is initialized, so to prevent using non-virtual
+// device and virtual device together.
+static bool lock_spmd_config = false;
 
 }  // namespace torch_xla
 

--- a/torch_xla/csrc/device.h
+++ b/torch_xla/csrc/device.h
@@ -44,7 +44,7 @@ static inline torch::lazy::BackendDevice GetDeviceOrCurrent(
 
 // Test whether the XLA_USE_SPMD environment variable is set to enable the
 // virtual device optimization. This API is called before every device init,
-// and sets `lock_spmd_config` to block switching the SPMD mode.
+// and sets `spmd_config_is_locked` to block switching the SPMD mode.
 bool UseVirtualDevice();
 
 // Return true if SPMD config can be switches. That is, no device has been

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -852,7 +852,7 @@ void InitXlaModuleBindings(py::module m) {
         [](const at::Tensor& tensor) { return GetTensorViewAliasId(tensor); });
   m.def("_xla_get_tensor_id",
         [](const at::Tensor& tensor) { return GetTensorId(tensor); });
-  m.def("_xla_get_lock_spmd_config", []() { return GetLockSpmdConfig(); });
+  m.def("_xla_get_spmd_config_is_locked", []() { return GetLockSpmdConfig(); });
   m.def("_xla_get_devices", []() {
     if (UseVirtualDevice()) {
       // Under SPMD context, there is only one virtual devices from user

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1374,22 +1374,22 @@ void InitXlaModuleBindings(py::module m) {
                 weight_decay, eps, amsgrad, maximize, use_adamw);
           }
         });
-  m.def("_xla_mark_sharding",
-        [](const at::Tensor& input, const py::list& tile_assignment,
-           const py::list& group_assignment, const py::list& replication_groups,
-           int sharding_type) {
-          TORCH_LAZY_COUNTER("XlaMarkSharding", 1);
-          XLA_CHECK(UseVirtualDevice())
-              << "Please enable SPMD via `torch_xla.runtime.use_spmd()`";
-          XLATensorPtr xtensor = bridge::GetXlaTensor(input);
-          xla::OpSharding sharding = ShardingUtil::CreateOpSharding(
-              tile_assignment, group_assignment, replication_groups,
-              ShardingUtil::ShardingType(sharding_type));
-          auto new_sharding_spec = std::make_shared<XLATensor::ShardingSpec>(
-              sharding,
-              MakeShapeWithDeviceLayout(
-                  xtensor->shape(),
-                  static_cast<XlaDeviceType>(xtensor->GetDevice().type())));
+  m.def("_xla_mark_sharding", [](const at::Tensor& input,
+                                 const py::list& tile_assignment,
+                                 const py::list& group_assignment,
+                                 const py::list& replication_groups,
+                                 int sharding_type) {
+    TORCH_LAZY_COUNTER("XlaMarkSharding", 1);
+    XLA_CHECK(UseVirtualDevice())
+        << "Please enable SPMD via `torch_xla.runtime.use_spmd()`";
+    XLATensorPtr xtensor = bridge::GetXlaTensor(input);
+    xla::OpSharding sharding = ShardingUtil::CreateOpSharding(
+        tile_assignment, group_assignment, replication_groups,
+        ShardingUtil::ShardingType(sharding_type));
+    auto new_sharding_spec = std::make_shared<XLATensor::ShardingSpec>(
+        sharding, MakeShapeWithDeviceLayout(
+                      xtensor->shape(),
+                      static_cast<XlaDeviceType>(xtensor->GetDevice().type())));
 
     // For Non DeviceData IR values, we directly attach the sharding spec
     // to the xtensor.

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -852,7 +852,7 @@ void InitXlaModuleBindings(py::module m) {
         [](const at::Tensor& tensor) { return GetTensorViewAliasId(tensor); });
   m.def("_xla_get_tensor_id",
         [](const at::Tensor& tensor) { return GetTensorId(tensor); });
-  m.def("_xla_get_lock_spmd_config", []() { return lock_spmd_config; });
+  m.def("_xla_get_lock_spmd_config", []() { return GetLockSpmdConfig(); });
   m.def("_xla_get_devices", []() {
     if (UseVirtualDevice()) {
       // Under SPMD context, there is only one virtual devices from user

--- a/torch_xla/runtime.py
+++ b/torch_xla/runtime.py
@@ -217,13 +217,15 @@ def use_spmd():
                   "Use torch_xla.runtime.use_spmd() "
                   "without setting XLA_USE_SPMD env-var.")
 
-  if torch_xla._XLAC._xla_get_lock_spmd_config() and not xu.check_env_flag("XLA_USE_SPMD"):
+  if torch_xla._XLAC._xla_get_lock_spmd_config(
+  ) and not xu.check_env_flag("XLA_USE_SPMD"):
     raise RuntimeError(
         "Please set SPMD mode before initializting non-virtual XLA device. "
         "Call use_spmd() in the beginning of the program.")
 
   # TODO(yeounoh) replace this when we fully deprecate the flag.
   os.environ["XLA_USE_SPMD"] = "1"
+
 
 @requires_pjrt
 def is_spmd():

--- a/torch_xla/runtime.py
+++ b/torch_xla/runtime.py
@@ -209,18 +209,18 @@ def addressable_runtime_device_count() -> int:
 
 # API to enable SPMD mode. This is a recommended way to enable SPMD.
 # TODO(yeounoh) this does not block users from using XLA_USE_SPMD flag, yet.
-# we will enforce `set_use_spmd()` once the flag is fully deprecated.
+# we will enforce `use_spmd()` once the flag is fully deprecated.
 @requires_pjrt
-def set_use_spmd():
+def use_spmd():
   if os.environ.get("XLA_USE_SPMD") is not None:
     warnings.warn("XLA_USE_SPMD is being deprecated. "
-                  "Use torch_xla.runtime.set_use_spmd() "
+                  "Use torch_xla.runtime.use_spmd() "
                   "without setting XLA_USE_SPMD env-var.")
 
   if torch_xla._XLAC._xla_get_lock_spmd_config():
     raise RuntimeError(
         "Please set SPMD mode before initializting non-virtual XLA device. "
-        "Call set_use_spmd() in the beginning of the program.")
+        "Call use_spmd() in the beginning of the program.")
 
   # TODO(yeounoh) replace this when we fully deprecate the flag.
   os.environ["XLA_USE_SPMD"] = "1"

--- a/torch_xla/runtime.py
+++ b/torch_xla/runtime.py
@@ -218,8 +218,9 @@ def set_use_spmd():
                   "without setting XLA_USE_SPMD env-var.")
 
   if torch_xla._XLAC._xla_get_lock_spmd_config():
-    raise RuntimeError("Please set SPMD mode before initializting non-virtual XLA device. "
-                       "Call set_use_spmd() in the beginning of the program.")
+    raise RuntimeError(
+        "Please set SPMD mode before initializting non-virtual XLA device. "
+        "Call set_use_spmd() in the beginning of the program.")
 
   # TODO(yeounoh) replace this when we fully deprecate the flag.
   os.environ["XLA_USE_SPMD"] = "1"

--- a/torch_xla/runtime.py
+++ b/torch_xla/runtime.py
@@ -217,10 +217,16 @@ def use_spmd():
                   "Use torch_xla.runtime.use_spmd() "
                   "without setting XLA_USE_SPMD env-var.")
 
-  if torch_xla._XLAC._xla_get_lock_spmd_config():
+  if torch_xla._XLAC._xla_get_lock_spmd_config() and not xu.check_env_flag("XLA_USE_SPMD"):
     raise RuntimeError(
         "Please set SPMD mode before initializting non-virtual XLA device. "
         "Call use_spmd() in the beginning of the program.")
 
   # TODO(yeounoh) replace this when we fully deprecate the flag.
   os.environ["XLA_USE_SPMD"] = "1"
+
+@requires_pjrt
+def is_spmd():
+  """Returns if SPMD is set for execution."""
+  # TODO(yeounoh) replace this when we fully deprecate the flag.
+  return xu.check_env_flag('XLA_USE_SPMD')

--- a/torch_xla/runtime.py
+++ b/torch_xla/runtime.py
@@ -217,7 +217,7 @@ def use_spmd():
                   "Use torch_xla.runtime.use_spmd() "
                   "without setting XLA_USE_SPMD env-var.")
 
-  if torch_xla._XLAC._xla_get_lock_spmd_config(
+  if torch_xla._XLAC._xla_get_spmd_config_is_locked(
   ) and not xu.check_env_flag("XLA_USE_SPMD"):
     raise RuntimeError(
         "Please set SPMD mode before initializting non-virtual XLA device. "


### PR DESCRIPTION
This is the first step to deprecate `XLA_USE_SPMD` flag, to enable SPMD. While the flag is being deprecated, we will allow both usages, where user can either set `XLA_USE_SPMD=1` flag or call `torch_xla.runtime.use_spmd()` in their script/program.

The recommended way is to use `use_spmd()` API, as follows:
```python
import torch_xla.runtime as xr
xr.use_spmd()
assert xr.is_spmd() == True
```
and it raises a warning, if user set `XLA_USE_SPMD` before the invocation.