### PR TITLE
Enabling sharding device data IR

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -741,7 +741,17 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     self.assertNotEqual(torch_xla._XLAC._get_xla_sharding_spec(xla_x), '')
     xm.mark_step()
     self.assertTrue(torch.allclose(xla_y.cpu(), xla_x.cpu() * 5))
-    # check that xla_x is being sharded
+
+  def test_shard_device_data_ir_after_mark_step(self):
+    device = xm.xla_device()
+    xla_x = torch.randn(8, 128, device=device)
+    x = xla_x.cpu()
+    # xla_x now becomes a device data IR without XLAData
+    xm.mark_step()
+
+    xs.mark_sharding(xla_x, self._get_mesh((1, self.n_devices)), (1, 0))
+    self.assertNotEqual(torch_xla._XLAC._get_xla_sharding_spec(xla_x), '')
+    self.assertTrue(torch.allclose(xla_x.cpu(), x))
 
 
 if __name__ == '__main__':

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1389,12 +1389,15 @@ void InitXlaModuleBindings(py::module m) {
                   xtensor->shape(),
                   static_cast<XlaDeviceType>(xtensor->GetDevice().type())));
 
-          // For IR values, we directly attach the sharding spec to the xtensor.
+          // For Non DeviceData IR values, we directly attach the sharding spec
+          // to the xtensor.
           if (xtensor->CurrentIrValue()) {
-            // TODO(alanwaketan): Do we want to check if there is any existing
-            // sharding spec? It seems okay to directly overwrite it.
-            xtensor->SetShardingSpec(*new_sharding_spec);
-            return;
+            const DeviceData* device_data_node =
+                DeviceData::Cast(xtensor->CurrentIrValue().node.get());
+            if (!device_data_node) {
+              xtensor->SetShardingSpec(*new_sharding_spec);
+              return;
+            }
           }
 
           // For data, we need to deal with the data transfers between

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1428,7 +1428,7 @@ void InitXlaModuleBindings(py::module m) {
       // must be present on the backend device.
       XLA_CHECK((xtensor->CurrentDataHandle() &&
                  xtensor->CurrentDataHandle()->HasValue()) ||
-                    device_data_node = nullptr)
+                device_data_node != nullptr)
           << "Cannot shard tensor. Data does not present on any device.";
       std::vector<XLATensorPtr> xla_tensors{xtensor};
       cpu_tensor = XLAGraphExecutor::Get()->GetTensors(&xla_tensors)[0];

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -263,7 +263,7 @@ XLATensor::ShardingSpecPtr XLATensor::sharding_spec() const {
                                   xla_node->xla_shape()}))
           << "Sharding on tensor: "
           << xla::HloSharding::FromProto(sharding->sharding)->ToString()
-          << "sharding on IR: "
+          << ", sharding on IR: "
           << xla::HloSharding::FromProto(*xla_node->GetSharding(ir_value.index))
                  ->ToString();
     }

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -260,7 +260,12 @@ XLATensor::ShardingSpecPtr XLATensor::sharding_spec() const {
     if (xla_node->GetSharding(ir_value.index)) {
       XLA_CHECK(ShardingUtil::EqualShardingSpecs(
           *sharding, ShardingSpec{*xla_node->GetSharding(ir_value.index),
-                                  xla_node->xla_shape()}));
+                                  xla_node->xla_shape()}))
+          << "Sharding on tensor: "
+          << xla::HloSharding::FromProto(sharding->sharding)->ToString()
+          << "sharding on IR: "
+          << xla::HloSharding::FromProto(*xla_node->GetSharding(ir_value.index))
+                 ->ToString();
     }
   }
   return sharding;


### PR DESCRIPTION
Without this change, we will treat a DeviceData IR as a regular IR but what we should do is to treat it like a Data and reshard it when `mark_sharding` is called.