### PR TITLE
Update artifacts.auto.tfvars for 2.1 release

### DIFF
--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -36,6 +36,11 @@ xrt_nightly_builds = [
 # Built on push to specific tag.
 versioned_builds = [
   {
+    git_tag         = "v2.1.0"
+    package_version = "2.1"
+    accelerator     = "tpu"
+  },
+  {
     git_tag         = "v2.0.0"
     package_version = "2.0"
     accelerator     = "tpu"
@@ -44,6 +49,25 @@ versioned_builds = [
     git_tag         = "v1.13.0"
     package_version = "1.13"
     accelerator     = "tpu"
+  },
+  {
+    git_tag         = "v2.1.0"
+    package_version = "2.1"
+    accelerator     = "cuda"
+    cuda_version    = "11.8"
+  },
+  {
+    git_tag         = "v2.1.0"
+    package_version = "2.1"
+    accelerator     = "cuda"
+    cuda_version    = "11.8"
+    python_version  = "3.10"
+  },
+  {
+    git_tag         = "v2.1.0"
+    package_version = "2.1",
+    accelerator     = "cuda"
+    cuda_version    = "11.7"
   },
   {
     git_tag         = "v2.0.0"

--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -41,6 +41,12 @@ versioned_builds = [
     accelerator     = "tpu"
   },
   {
+    git_tag         = "v2.1.0"
+    package_version = "2.1"
+    accelerator     = "tpu"
+    python_version = "3.10"
+  },
+  {
     git_tag         = "v2.0.0"
     package_version = "2.0"
     accelerator     = "tpu"

--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -52,6 +52,12 @@ versioned_builds = [
   },
   {
     git_tag         = "v2.1.0"
+    package_version = "2.1",
+    accelerator     = "cuda"
+    cuda_version    = "12.0"
+  },
+  {
+    git_tag         = "v2.1.0"
     package_version = "2.1"
     accelerator     = "cuda"
     cuda_version    = "11.8"
@@ -62,12 +68,6 @@ versioned_builds = [
     accelerator     = "cuda"
     cuda_version    = "11.8"
     python_version  = "3.10"
-  },
-  {
-    git_tag         = "v2.1.0"
-    package_version = "2.1",
-    accelerator     = "cuda"
-    cuda_version    = "11.7"
   },
   {
     git_tag         = "v2.0.0"


### PR DESCRIPTION
Update artifacts.auto.tfvars for 2.1 release. The actual branch cut will be on 08/28. We'll continue to sync this branch with master on a daily basis. Setting this up now to see if there will be any errors when we create these new triggers for 2.1.

Tag for 2.1 has also been added -- https://github.com/pytorch/xla/tags.