### PR TITLE
Fix FSDP for Models with Frozen Weights

### DIFF
--- a/test/test_torch_distributed_fsdp_frozen_weight.py
+++ b/test/test_torch_distributed_fsdp_frozen_weight.py
@@ -1,4 +1,5 @@
 import os
+
 os.environ["XLA_DISABLE_FUNCTIONALIZATION"] = "1"
 
 import sys
@@ -10,26 +11,26 @@ from torch_xla.distributed.fsdp import XlaFullyShardedDataParallel as FSDP
 
 
 def _mp_fn(index):
-    dev = xm.xla_device()
-    if xm.xla_device_hw(dev) not in ('TPU', 'GPU'):
-      print(
+  dev = xm.xla_device()
+  if xm.xla_device_hw(dev) not in ('TPU', 'GPU'):
+    print(
         'Default device {} is not a TPU or GPU device'.format(dev),
         file=sys.stderr)
-      return
+    return
 
-    model = nn.Linear(1024, 1024)
-    model.weight.requires_grad = False  # the weight param is frozen
+  model = nn.Linear(1024, 1024)
+  model.weight.requires_grad = False  # the weight param is frozen
 
-    model = FSDP(model)  # wrapping the linear module with FSDP
+  model = FSDP(model)  # wrapping the linear module with FSDP
 
-    input = torch.rand((2, 1024), device=xm.xla_device())
+  input = torch.rand((2, 1024), device=xm.xla_device())
 
-    output = model(input)
-    loss = torch.sum(output)
-    loss.backward()
-    assert not any(p._has_full_param for p in model.full_params), \
-      'Expecting all the full params to be freed at this moment.'
+  output = model(input)
+  loss = torch.sum(output)
+  loss.backward()
+  assert not any(p._has_full_param for p in model.full_params), \
+    'Expecting all the full params to be freed at this moment.'
 
 
 if __name__ == "__main__":
-    xmp.spawn(_mp_fn, args=())
+  xmp.spawn(_mp_fn, args=())

--- a/test/test_torch_distributed_fsdp_frozen_weight.py
+++ b/test/test_torch_distributed_fsdp_frozen_weight.py
@@ -1,7 +1,3 @@
-import os
-
-os.environ["XLA_DISABLE_FUNCTIONALIZATION"] = "1"
-
 import sys
 import torch
 import torch.nn as nn

--- a/test/test_torch_distributed_fsdp_frozen_weight.py
+++ b/test/test_torch_distributed_fsdp_frozen_weight.py
@@ -1,0 +1,35 @@
+import os
+os.environ["XLA_DISABLE_FUNCTIONALIZATION"] = "1"
+
+import sys
+import torch
+import torch.nn as nn
+import torch_xla.core.xla_model as xm
+import torch_xla.distributed.xla_multiprocessing as xmp
+from torch_xla.distributed.fsdp import XlaFullyShardedDataParallel as FSDP
+
+
+def _mp_fn(index):
+    dev = xm.xla_device()
+    if xm.xla_device_hw(dev) not in ('TPU', 'GPU'):
+      print(
+        'Default device {} is not a TPU or GPU device'.format(dev),
+        file=sys.stderr)
+      return
+
+    model = nn.Linear(1024, 1024)
+    model.weight.requires_grad = False  # the weight param is frozen
+
+    model = FSDP(model)  # wrapping the linear module with FSDP
+
+    input = torch.rand((2, 1024), device=xm.xla_device())
+
+    output = model(input)
+    loss = torch.sum(output)
+    loss.backward()
+    assert not any(p._has_full_param for p in model.full_params), \
+      'Expecting all the full params to be freed at this moment.'
+
+
+if __name__ == "__main__":
+    xmp.spawn(_mp_fn, args=())


### PR DESCRIPTION
Fixing the issue where XLAFSDP is not freeing the full params of the frozen parameters (`requires_grad==False`) after a backward pass.