### PR TITLE
[SPMD] Fix XLA_DUMP_POST_OPTIMIZATIONS test

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -170,6 +170,7 @@ function run_xla_op_tests {
   run_test "$CDIR/pjrt/test_ddp.py"
   run_test "$CDIR/pjrt/test_mesh_service.py"
   run_test "$CDIR/spmd/test_xla_sharding.py"
+  run_test "$CDIR/spmd/test_xla_sharding_hlo.py"
   run_test "$CDIR/spmd/test_xla_virtual_device.py"
   run_test "$CDIR/spmd/test_dynamo_spmd.py"
   run_test "$CDIR/spmd/test_xla_distributed_checkpoint.py"

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -682,7 +682,6 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
 
     self.assertTrue(torch.allclose(expected, actual.cpu()))
 
-  @unittest.skipIf(xr.device_type() == 'TPU', "Does not work on TPU v2")
   @patch.dict(os.environ, {"XLA_DUMP_POST_OPTIMIZATIONS": "1"})
   def test_xla_sharded_hlo_dump_post_optimizations(self):
     t1 = torch.randn(1, 128).to(xm.xla_device())

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -682,17 +682,6 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
 
     self.assertTrue(torch.allclose(expected, actual.cpu()))
 
-  @patch.dict(os.environ, {"XLA_DUMP_POST_OPTIMIZATIONS": "1"})
-  def test_xla_sharded_hlo_dump_post_optimizations(self):
-    t1 = torch.randn(1, 128).to(xm.xla_device())
-    t2 = torch.randn(128, 1).to(xm.xla_device())
-    xs.mark_sharding(t1, self._get_mesh((1, self.n_devices)), (0, 1))
-
-    t3 = t1 @ t2
-    hlo = torch_xla._XLAC._get_xla_tensors_hlo([t3])
-    if self.n_devices > 1:
-      self.assertIn('all-reduce', hlo)
-
   def test_sharded_tensor_aliasing(self):
     met.clear_all()
     partition_spec = (0, 1)

--- a/test/spmd/test_xla_sharding_hlo.py
+++ b/test/spmd/test_xla_sharding_hlo.py
@@ -13,6 +13,7 @@ import torch_xla.experimental.xla_sharding as xs
 
 import test_xla_sharding_base
 
+
 class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
@@ -30,6 +31,7 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     hlo = torch_xla._XLAC._get_xla_tensors_hlo([t3])
     if self.n_devices > 1:
       self.assertIn('all-reduce', hlo)
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/test/spmd/test_xla_sharding_hlo.py
+++ b/test/spmd/test_xla_sharding_hlo.py
@@ -1,0 +1,36 @@
+import copy
+
+import unittest
+from unittest.mock import patch
+import os
+import sys
+
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+import torch_xla.core.xla_model as xm
+import torch_xla.experimental.xla_sharding as xs
+
+import test_xla_sharding_base
+
+class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
+
+  @classmethod
+  def setUpClass(cls):
+    xr.use_spmd()
+    super().setUpClass()
+
+  @patch.dict(os.environ, {"XLA_DUMP_POST_OPTIMIZATIONS": "1"})
+  def test_xla_sharded_hlo_dump_post_optimizations(self):
+    t1 = torch.randn(1, 128).to(xm.xla_device())
+    t2 = torch.randn(128, 1).to(xm.xla_device())
+    xs.mark_sharding(t1, self._get_mesh((1, self.n_devices)), (0, 1))
+
+    t3 = t1 @ t2
+    hlo = torch_xla._XLAC._get_xla_tensors_hlo([t3])
+    if self.n_devices > 1:
+      self.assertIn('all-reduce', hlo)
+
+if __name__ == '__main__':
+  test = unittest.main()
+  sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/torch_xla/csrc/ir_dump_util.cpp
+++ b/torch_xla/csrc/ir_dump_util.cpp
@@ -266,7 +266,7 @@ std::string DumpUtil::ToHlo(c10::ArrayRef<torch::lazy::Value> values,
   auto is_sharded = ShardingUtil::SetHloSharding(&lowering_ctx);
   xla::XlaComputation computation = ConsumeValue(lowering_ctx.BuildXla());
 
-  static bool dump_post_optimizations =
+  bool dump_post_optimizations =
       runtime::sys_util::GetEnvBool("XLA_DUMP_POST_OPTIMIZATIONS", false);
   if (dump_post_optimizations) {
     xla::Shape shape = MakeShapeWithDeviceLayout(

--- a/torch_xla/csrc/ir_dump_util.cpp
+++ b/torch_xla/csrc/ir_dump_util.cpp
@@ -266,7 +266,7 @@ std::string DumpUtil::ToHlo(c10::ArrayRef<torch::lazy::Value> values,
   auto is_sharded = ShardingUtil::SetHloSharding(&lowering_ctx);
   xla::XlaComputation computation = ConsumeValue(lowering_ctx.BuildXla());
 
-  bool dump_post_optimizations =
+  static bool dump_post_optimizations =
       runtime::sys_util::GetEnvBool("XLA_DUMP_POST_OPTIMIZATIONS", false);
   if (dump_post_optimizations) {
     xla::Shape shape = MakeShapeWithDeviceLayout(


### PR DESCRIPTION
Summary:
XLA_DUMP_POST_OPTIMIZATIONS was set as static which means that the value will be fixed during the whole test run for a particular test suite.

Therefore, let's make a separate file.

Test Plan:
PJRT_DEVICE=TPU USE_XLA_SPMD=1 python test/spmd/test_xla_sharding.py
PJRT_DEVICE=TPU USE_XLA_SPMD=1 python test/spmd/test_xla_sharding_hlo.py