### PR TITLE
[original author: mrnikwaws] fixing incorrect stride information on xla tensors 

### DIFF
--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -228,8 +228,8 @@ void XLATensorImpl::SetupSymSizeProperties() {
   sym_sizes_ = sym_sizes;
 
   c10::SymInt prod{1};
- 
-  while (index > 0 ) {
+
+  while (index > 0) {
     --index;
     sym_strides[index] = prod;
     prod *= sym_sizes[index];

--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -229,12 +229,12 @@ void XLATensorImpl::SetupSymSizeProperties() {
 
   c10::SymInt prod{1};
  
-  while( index > 0 ) {
-    --index; 
+  while (index > 0 ) {
+    --index;
     sym_strides[index] = prod;
     prod *= sym_sizes[index];
   }
- 
+
   sym_strides_ = sym_strides;
 }
 

--- a/torch_xla/csrc/tensor_impl.h
+++ b/torch_xla/csrc/tensor_impl.h
@@ -46,6 +46,7 @@ class XLATensorImpl : public c10::TensorImpl {
   c10::SymIntArrayRef sym_sizes_custom() const override;
   c10::SymInt sym_numel_custom() const override;
   at::IntArrayRef strides_custom() const override;
+  c10::SymIntArrayRef sym_strides_custom() const override;
 
   int64_t dim_custom() const override;
 
@@ -67,6 +68,7 @@ class XLATensorImpl : public c10::TensorImpl {
 
   XLATensorPtr tensor_;
   std::vector<c10::SymInt> sym_sizes_;
+  std::vector<c10::SymInt> sym_strides_;
   size_t generation_ = 0;
 };
 


### PR DESCRIPTION
- fixing incorrect xla tensor stride information
- breaks log softmax lowering
- tested on AWS Neuron internal testing
- original author mrnikwaws
- old PR #5468