### PR TITLE
Support tuples in partition spec

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1,5 +1,6 @@
 import copy
 
+from itertools import chain
 import unittest
 from unittest.mock import patch
 import math
@@ -346,6 +347,40 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     self.assertEqual(
         torch_xla._XLAC._get_xla_sharding_spec(t), "{devices=[%d]%s}" %
         (self.n_devices, ','.join(str(x) for x in range(self.n_devices))))
+  
+  @unittest.skipUnless(xr.global_runtime_device_count() >= 4,
+                       "Multiple devices required for tupled partition spec")
+  def test_named_partial_tupled_partition_spec(self):
+    mesh = xs.Mesh(range(self.n_devices), (1, 2, self.n_devices // 2), ('r', 'b', 'm'))
+    # Shard the first dimension on `r` and `b`, replicate the second dimension
+    t = torch.randn(16, 16).to(xm.xla_device())
+    xs.mark_sharding(t, mesh, (('r', 'b'), None))
+    self.assertEqual(
+        torch_xla._XLAC._get_xla_sharding_spec(t), "{devices=[2,1,%d]%s last_tile_dim_replicate}" %
+        (self.n_devices // 2, ','.join(str(x) for x in range(self.n_devices))))
+
+    # Replicate the first dimension, shard the second on `b` and `m`
+    u = torch.randn(16, 16).to(xm.xla_device())
+    xs.mark_sharding(u, mesh, (None, ('b', 'm')))
+    self.assertEqual(
+        torch_xla._XLAC._get_xla_sharding_spec(u), "{devices=[1,%d]%s}" %
+        (self.n_devices, ','.join(str(x) for x in range(self.n_devices))))
+
+    # Replicate the first dimension, shard the second on `r` and `m`
+    v = torch.randn(16, 16).to(xm.xla_device())
+    xs.mark_sharding(v, mesh, (None, ('r', 'm')))
+    device_order = chain(range(0, self.n_devices, 2), range(1, self.n_devices, 2))
+    self.assertEqual(
+        torch_xla._XLAC._get_xla_sharding_spec(v), "{devices=[1,%d,2]%s last_tile_dim_replicate}" %
+        (self.n_devices // 2, ','.join(str(x) for x in device_order)))
+
+    # Replicate the first dimension, shard the second on `m` and `b`
+    v = torch.randn(16, 16).to(xm.xla_device())
+    xs.mark_sharding(v, mesh, (None, ('m', 'b')))
+    device_order = chain(range(0, self.n_devices, 2), range(1, self.n_devices, 2))
+    self.assertEqual(
+        torch_xla._XLAC._get_xla_sharding_spec(v), "{devices=[1,%d]%s}" %
+        (self.n_devices, ','.join(str(x) for x in device_order)))
 
   def test_partial_replication_addmm(self):
     device = xm.xla_device()

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -348,6 +348,17 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
         torch_xla._XLAC._get_xla_sharding_spec(t), "{devices=[%d]%s}" %
         (self.n_devices, ','.join(str(x) for x in range(self.n_devices))))
 
+  def test_foo(self):
+    mesh = xs.Mesh(
+        range(self.n_devices), (1, 2, self.n_devices // 2), ('r', 'b', 'm'))
+    # Replicate the first dimension, shard the second on `b` and `m`
+    u = torch.randn(16, 16).to(xm.xla_device())
+    xs.mark_sharding(u, mesh, (None, ('b', 'm')))
+    self.assertEqual(
+        torch_xla._XLAC._get_xla_sharding_spec(u), "{devices=[1,%d]%s}" %
+        (self.n_devices, ','.join(str(x) for x in range(self.n_devices))))
+
+
   @unittest.skipUnless(xr.global_runtime_device_count() >= 4,
                        "Multiple devices required for tupled partition spec")
   def test_named_partial_tupled_partition_spec(self):
@@ -386,6 +397,13 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     self.assertEqual(
         torch_xla._XLAC._get_xla_sharding_spec(v), "{devices=[1,%d]%s}" %
         (self.n_devices, ','.join(str(x) for x in device_order)))
+
+  @unittest.skipUnless(xr.global_runtime_device_count() > 1, 'At least 2 devices needed for 2D mesh')
+  def test_3d_tensor_2d_mesh(self):
+    mesh = self._get_mesh((2, self.n_devices // 2))
+    t = torch.randn(16, 16, 16).to(xm.xla_device())
+    xs.mark_sharding(t, mesh, (None, 0, 1))
+    self.assertEqual(torch_xla._XLAC._get_xla_sharding_spec(t), '{devices=[1,2,2]0,1,2,3}')
 
   def test_partial_replication_addmm(self):
     device = xm.xla_device()

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -347,16 +347,18 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     self.assertEqual(
         torch_xla._XLAC._get_xla_sharding_spec(t), "{devices=[%d]%s}" %
         (self.n_devices, ','.join(str(x) for x in range(self.n_devices))))
-  
+
   @unittest.skipUnless(xr.global_runtime_device_count() >= 4,
                        "Multiple devices required for tupled partition spec")
   def test_named_partial_tupled_partition_spec(self):
-    mesh = xs.Mesh(range(self.n_devices), (1, 2, self.n_devices // 2), ('r', 'b', 'm'))
+    mesh = xs.Mesh(
+        range(self.n_devices), (1, 2, self.n_devices // 2), ('r', 'b', 'm'))
     # Shard the first dimension on `r` and `b`, replicate the second dimension
     t = torch.randn(16, 16).to(xm.xla_device())
     xs.mark_sharding(t, mesh, (('r', 'b'), None))
     self.assertEqual(
-        torch_xla._XLAC._get_xla_sharding_spec(t), "{devices=[2,1,%d]%s last_tile_dim_replicate}" %
+        torch_xla._XLAC._get_xla_sharding_spec(t),
+        "{devices=[2,1,%d]%s last_tile_dim_replicate}" %
         (self.n_devices // 2, ','.join(str(x) for x in range(self.n_devices))))
 
     # Replicate the first dimension, shard the second on `b` and `m`
@@ -369,15 +371,18 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     # Replicate the first dimension, shard the second on `r` and `m`
     v = torch.randn(16, 16).to(xm.xla_device())
     xs.mark_sharding(v, mesh, (None, ('r', 'm')))
-    device_order = chain(range(0, self.n_devices, 2), range(1, self.n_devices, 2))
+    device_order = chain(
+        range(0, self.n_devices, 2), range(1, self.n_devices, 2))
     self.assertEqual(
-        torch_xla._XLAC._get_xla_sharding_spec(v), "{devices=[1,%d,2]%s last_tile_dim_replicate}" %
+        torch_xla._XLAC._get_xla_sharding_spec(v),
+        "{devices=[1,%d,2]%s last_tile_dim_replicate}" %
         (self.n_devices // 2, ','.join(str(x) for x in device_order)))
 
     # Replicate the first dimension, shard the second on `m` and `b`
     v = torch.randn(16, 16).to(xm.xla_device())
     xs.mark_sharding(v, mesh, (None, ('m', 'b')))
-    device_order = chain(range(0, self.n_devices, 2), range(1, self.n_devices, 2))
+    device_order = chain(
+        range(0, self.n_devices, 2), range(1, self.n_devices, 2))
     self.assertEqual(
         torch_xla._XLAC._get_xla_sharding_spec(v), "{devices=[1,%d]%s}" %
         (self.n_devices, ','.join(str(x) for x in device_order)))

--- a/torch_xla/experimental/xla_sharding.py
+++ b/torch_xla/experimental/xla_sharding.py
@@ -531,7 +531,8 @@ class ShardingSpec:
 
   @xr.requires_pjrt
   def __post_init__(self):
-    partition_spec, mesh = self.partition_spec, self.mesh
+    mesh = self.mesh
+    partition_spec = _translate_named_partition_spec(mesh, self.partition_spec)
     tile_assignment = _get_tile_assignment(mesh, partition_spec)
     self._tile_assignment = tile_assignment.tolist()
     self._sharding_type = _get_sharding_type(partition_spec,

--- a/torch_xla/experimental/xla_sharding.py
+++ b/torch_xla/experimental/xla_sharding.py
@@ -434,9 +434,9 @@ def mark_sharding(
         partition_spec (Tuple[Tuple, int, str, None]): A tuple of device_mesh dimension index or
           `None`. Each index is an int, str if the mesh axis is named, or tuple of int or str.
           This specifies how each input rank is sharded (index to mesh_shape) or replicated (None).
-          When a tuple is specified, the input tensor will be sharded along all logical axes in the
-          tuple. Note that the order the mesh axes are specified in the tuple will impact the
-          resulting sharding.
+          When a tuple is specified, the corresponding input tensor axis will be sharded along all
+          logical axes in the tuple. Note that the order the mesh axes are specified in the tuple
+          will impact the resulting sharding.
         For example, we can shard an 8x10 tensor 4-way row-wise, and replicate column-wise.
         >> input = torch.randn(8, 10)
         >> mesh_shape = (4, 2)

--- a/torch_xla/experimental/xla_sharding.py
+++ b/torch_xla/experimental/xla_sharding.py
@@ -367,8 +367,8 @@ def _get_tile_assignment(
 # contains the participating device IDs. `group_assignment` describes the group
 # placement and the overall mesh, where each element is the group ID.
 # The tile_assignment should be the result of `_get_tile_assignment` so that all
-# tiled dimensions are in the first indices and replicated dimensions are in the
-# remaining indices.
+# tiled dimensions are in the first axes and replicated dimensions are in the
+# remaining axes.
 def _get_group_assignment(sharding_type: ShardingType,
                           tile_assignment: np.ndarray, tensor_rank: int,
                           replicate_dims: Set[int]) -> Tuple[List, List]:
@@ -431,8 +431,12 @@ def mark_sharding(
 
         mesh (Mesh): describes the logical XLA device topology and the underlying device IDs.
 
-        partition_spec (Tuple[int, str, None]): A tuple of device_mesh dimension index or `None`. Each index is an int or str if the mesh axis is named.
-        This specifies how each input rank is sharded (index to mesh_shape) or replicated (None).
+        partition_spec (Tuple[Tuple, int, str, None]): A tuple of device_mesh dimension index or
+          `None`. Each index is an int, str if the mesh axis is named, or tuple of int or str.
+          This specifies how each input rank is sharded (index to mesh_shape) or replicated (None).
+          When a tuple is specified, the input tensor will be sharded along all logical axes in the
+          tuple. Note that the order the mesh axes are specified in the tuple will impact the
+          resulting sharding.
         For example, we can shard an 8x10 tensor 4-way row-wise, and replicate column-wise.
         >> input = torch.randn(8, 10)
         >> mesh_shape = (4, 2)


### PR DESCRIPTION
In general, a single mesh should be used across all shardings in an SPMD program. This change simplifies the reuse of a mesh by allowing multiple logical mesh axes to be specified for a single tensor axis in the partition spec.

For example, with a (2, 16, 16) mesh with logical axes (replica, data, model), the same mesh can be used for parameter and activation sharding as follows:

```
mesh = xs.Mesh(range(512), (2, 16, 16), ('replica', 'data', 'model'))

xs.mark_sharding(input, mesh, (('replica', 'data'), None))
xs.mark_sharding(parameter, mesh, ('data', 'model'))
xs.mark_sharding(activation, mesh, (('replica', 'data'), 'model')
```

To summarize the changes:
- We will always permute the mesh in `_get_tile_assignment`, even in the partial replication case
- `_get_group_assignment` now operates over the permuted tile assignment instead of the unmodified logical mesh.
- `_get_group_assignment` no longer takes the partition spec as input; instead, the group tile shape is derived based on the replicated tensor dimensions and the tensor rank, both of which are derived from the partition spec.