### PR TITLE
Add ShardingSpec to XLATensor when it is created with a PJRTShardedData

### DIFF
--- a/test/spmd/test_dynamo_spmd.py
+++ b/test/spmd/test_dynamo_spmd.py
@@ -53,6 +53,18 @@ class DynamoSpmdInferenceTest(test_xla_sharding_base.XlaShardingTest):
     # TODO(JackCaoG): add counter checks after ExecuteReplicated also creates
     # a ExecuteMetric.
 
+  def test_dynamo_spmd_output_sharding_spec(self):
+    device = xm.xla_device()
+    linear = SimpleLinear().to(device)
+    linear.eval()
+    xla_x = torch.randn(1, 128, device=device)
+    xs.mark_sharding(linear.fc2.weight, self._get_mesh((1, self.n_devices)),
+                     (1, 0))
+    dynamo_linear = torch.compile(linear, backend="openxla")
+    dynamo_res = dynamo_linear(xla_x)
+    self.assertNotIn('ShardingSpec: None',
+                     torch_xla._XLAC._get_xla_tensor_debug_info(dynamo_res))
+
   @unittest.skip(
       "test is flaky, UncachedOutputSharding sometime doesn't show up. most likely a waitdeviceop issue"
   )

--- a/torch_xla/csrc/runtime/computation_client.h
+++ b/torch_xla/csrc/runtime/computation_client.h
@@ -53,6 +53,10 @@ class ComputationClient {
 
     virtual std::string ToString() const = 0;
 
+    virtual bool HasSharding() const = 0;
+
+    virtual xla::OpSharding GetSharding() const = 0;
+
    private:
     std::string device_;
     xla::Shape shape_;

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -175,6 +175,14 @@ class PjRtComputationClient : public ComputationClient {
       return buffer != nullptr && !buffer->IsDeleted();
     };
 
+    bool HasSharding() const override { return false; }
+
+    xla::OpSharding GetSharding() const override {
+      XLA_CHECK(false) << "GetSharding should not be called on PjRtData, check "
+                          "HasSharding first";
+      return xla::OpSharding();
+    }
+
     std::string ToString() const override {
       std::stringstream ss;
       ss << "XLAData: \n";
@@ -238,7 +246,9 @@ class PjRtComputationClient : public ComputationClient {
       return ss.str();
     }
 
-    xla::OpSharding GetSharding() { return sharding; }
+    bool HasSharding() const override { return true; }
+
+    xla::OpSharding GetSharding() const override { return sharding; }
 
     std::vector<std::shared_ptr<PjRtData>> shards;
     xla::OpSharding sharding;

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -35,6 +35,7 @@
 #include "torch_xla/csrc/runtime/cache.h"
 #include "torch_xla/csrc/runtime/debug_macros.h"
 #include "torch_xla/csrc/runtime/env_vars.h"
+#include "torch_xla/csrc/runtime/pjrt_computation_client.h"
 #include "torch_xla/csrc/runtime/sys_util.h"
 #include "torch_xla/csrc/runtime/thread_pool.h"
 #include "torch_xla/csrc/runtime/unique.h"
@@ -102,7 +103,14 @@ XLATensor::XLATensor(const at::Tensor& tensor,
 XLATensor::XLATensor(torch::lazy::BackendDataPtr handle,
                      c10::optional<at::ScalarType> logical_element_type)
     : XLATensor(std::make_shared<Data>(handle, handle->device(),
-                                       logical_element_type)) {}
+                                       logical_element_type)) {
+  // if data is sharded we need to carry the sharding spec over.
+  runtime::ComputationClient::DataPtr data = UnwrapXlaData(handle);
+  if (data->HasSharding()) {
+    ShardingSpec sharding_spec(data->GetSharding(), data->shape());
+    SetShardingSpec(sharding_spec);
+  }
+}
 
 XLATensor::XLATensor(torch::lazy::Value ir_value,
                      const torch::lazy::BackendDevice& device,


### PR DESCRIPTION
When a tensor is crated with `PJRTShardedData` XLATensor currently does not have `ShardingSpec`. This is mostly an issue for dynamo.

