### PR TITLE
[SPMD] Patch nn.Linear

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -765,6 +765,7 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     self.assertNotEqual(torch_xla._XLAC._get_xla_sharding_spec(xla_x), '')
     self.assertTrue(torch.allclose(xla_x.cpu(), x))
 
+
 if __name__ == '__main__':
   test = unittest.main()
   sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -765,38 +765,6 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     self.assertNotEqual(torch_xla._XLAC._get_xla_sharding_spec(xla_x), '')
     self.assertTrue(torch.allclose(xla_x.cpu(), x))
 
-  def test_patched_linear_3D(self):
-    linear_cpu = nn.Linear(2, 4, bias=False)
-    input_cpu = torch.randn(4, 3, 2, requires_grad=True)
-    input_cpu.retain_grad()
-    output_cpu = linear_cpu(input_cpu)
-
-    # It looks like nn.Module.to is in-place.
-    linear = copy.deepcopy(linear_cpu).to('xla')
-    from torch_xla.distributed.fsdp.utils import apply_xla_patch_to_nn_linear
-    apply_xla_patch_to_nn_linear(linear, xs.xla_patched_nn_linear_forward)
-    input = copy.deepcopy(input_cpu).to('xla')
-    input.retain_grad()
-    output = linear(input)
-
-    # Make sure that we don't have any reshapes in the patched linear.
-    hlo = torch_xla._XLAC._get_xla_tensors_hlo([output])
-    self.assertNotIn("reshape", hlo)
-
-    # Make sure the forward result is correct.
-    self.assertTrue(torch.allclose(output.cpu(), output_cpu))
-
-    # Now work on the backward.
-    linear_cpu.weight.retain_grad()
-    loss_cpu = output_cpu.sum()
-    loss_cpu.backward()
-
-    loss =output.sum()
-    loss.backward()
-
-    self.assertTrue(torch.allclose(linear.weight.grad.cpu(), linear_cpu.weight.grad))
-    self.assertTrue(torch.allclose(input.grad.cpu(), input_cpu.grad))
-
 if __name__ == '__main__':
   test = unittest.main()
   sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -44,7 +44,7 @@ import torch_xla.utils.serialization as xser
 import torch_xla.core.xla_model as xm
 import torch_xla.core.functions as xf
 import torch_xla.debug.profiler as xp
-# import torchvision
+import torchvision
 import unittest
 import test_utils
 

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1742,6 +1742,34 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     self.assertTrue(torch.allclose(input.grad.cpu(), input_cpu.grad))
     self.assertTrue(torch.allclose(linear.bias.grad.cpu(), linear_cpu.bias.grad))
 
+  def test_patched_linear_1D_bias(self):
+    linear_cpu = nn.Linear(2, 4)
+    input_cpu = torch.randn(2, requires_grad=True)
+    input_cpu.retain_grad()
+    output_cpu = linear_cpu(input_cpu)
+
+    # It looks like nn.Module.to is in-place.
+    linear = copy.deepcopy(linear_cpu).to('xla')
+    apply_xla_patch_to_nn_linear(linear, xs.xla_patched_nn_linear_forward)
+    input = copy.deepcopy(input_cpu).to('xla')
+    input.retain_grad()
+    output = linear(input)
+
+    # Make sure the forward result is correct.
+    self.assertTrue(torch.allclose(output.cpu(), output_cpu))
+
+    # Now work on the backward.
+    linear_cpu.weight.retain_grad()
+    loss_cpu = output_cpu.sum()
+    loss_cpu.backward()
+
+    loss =output.sum()
+    loss.backward()
+
+    self.assertTrue(torch.allclose(linear.weight.grad.cpu(), linear_cpu.weight.grad))
+    self.assertTrue(torch.allclose(input.grad.cpu(), input_cpu.grad))
+    self.assertTrue(torch.allclose(linear.bias.grad.cpu(), linear_cpu.bias.grad))
+
 
 class MNISTComparator(nn.Module):
 

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -32,9 +32,11 @@ import torch_xla
 import torch_xla.core.xla_builder as xb
 import torch_xla.core.xla_op_registry as xor
 import torch_xla.distributed.data_parallel as dp
+from torch_xla.distributed.fsdp.utils import apply_xla_patch_to_nn_linear
 import torch_xla.debug.metrics as met
 import torch_xla.debug.model_comparator as mc
 import torch_xla.distributed.parallel_loader as pl
+import torch_xla.experimental.xla_sharding as xs
 from torch_xla import runtime as xr
 import torch_xla.test.test_utils as xtu
 import torch_xla.utils.utils as xu
@@ -42,7 +44,7 @@ import torch_xla.utils.serialization as xser
 import torch_xla.core.xla_model as xm
 import torch_xla.core.functions as xf
 import torch_xla.debug.profiler as xp
-import torchvision
+# import torchvision
 import unittest
 import test_utils
 
@@ -1655,6 +1657,62 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     loss.backward()
     self.assertTrue(
         torch.allclose(conv.weight.grad.cpu(), torch.tensor([[[[2077.0]]]])))
+
+  def test_patched_linear_3D(self):
+    linear_cpu = nn.Linear(2, 4, bias=False)
+    input_cpu = torch.randn(4, 3, 2, requires_grad=True)
+    input_cpu.retain_grad()
+    output_cpu = linear_cpu(input_cpu)
+
+    # It looks like nn.Module.to is in-place.
+    linear = copy.deepcopy(linear_cpu).to('xla')
+    apply_xla_patch_to_nn_linear(linear, xs.xla_patched_nn_linear_forward)
+    input = copy.deepcopy(input_cpu).to('xla')
+    input.retain_grad()
+    output = linear(input)
+
+    # Make sure that we don't have any reshapes in the patched linear.
+    hlo = torch_xla._XLAC._get_xla_tensors_hlo([output])
+    self.assertNotIn("reshape", hlo)
+
+    # Make sure the forward result is correct.
+    self.assertTrue(torch.allclose(output.cpu(), output_cpu))
+
+    # Now work on the backward.
+    linear_cpu.weight.retain_grad()
+    loss_cpu = output_cpu.sum()
+    loss_cpu.backward()
+
+    loss =output.sum()
+    loss.backward()
+
+    self.assertTrue(torch.allclose(linear.weight.grad.cpu(), linear_cpu.weight.grad))
+    self.assertTrue(torch.allclose(input.grad.cpu(), input_cpu.grad))
+
+  def test_patched_linear_3D_bias(self):
+    linear_cpu = nn.Linear(2, 4)
+    input_cpu = torch.randn(4, 3, 2)
+    output_cpu = linear_cpu(input_cpu)
+
+    # It looks like nn.Module.to is in-place.
+    linear = copy.deepcopy(linear_cpu).to('xla')
+    apply_xla_patch_to_nn_linear(linear, xs.xla_patched_nn_linear_forward)
+    input = copy.deepcopy(input_cpu).to('xla')
+    output = linear(input)
+
+    # We will have some reshapes on the bias. So skip the check here.
+    # Make sure the forward result is correct.
+    self.assertTrue(torch.allclose(output.cpu(), output_cpu))
+
+    # Now work on the backward.
+    linear_cpu.weight.retain_grad()
+    loss_cpu = output_cpu.sum()
+    loss_cpu.backward()
+
+    loss =output.sum()
+    loss.backward()
+
+    self.assertTrue(torch.allclose(linear.bias.grad.cpu(), linear_cpu.bias.grad))
 
 
 class MNISTComparator(nn.Module):

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1683,10 +1683,11 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     loss_cpu = output_cpu.sum()
     loss_cpu.backward()
 
-    loss =output.sum()
+    loss = output.sum()
     loss.backward()
 
-    self.assertTrue(torch.allclose(linear.weight.grad.cpu(), linear_cpu.weight.grad))
+    self.assertTrue(
+        torch.allclose(linear.weight.grad.cpu(), linear_cpu.weight.grad))
     self.assertTrue(torch.allclose(input.grad.cpu(), input_cpu.grad))
 
   def test_patched_linear_3D_bias(self):
@@ -1709,10 +1710,11 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     loss_cpu = output_cpu.sum()
     loss_cpu.backward()
 
-    loss =output.sum()
+    loss = output.sum()
     loss.backward()
 
-    self.assertTrue(torch.allclose(linear.bias.grad.cpu(), linear_cpu.bias.grad))
+    self.assertTrue(
+        torch.allclose(linear.bias.grad.cpu(), linear_cpu.bias.grad))
 
   def test_patched_linear_2D_bias(self):
     linear_cpu = nn.Linear(2, 4)
@@ -1735,12 +1737,14 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     loss_cpu = output_cpu.sum()
     loss_cpu.backward()
 
-    loss =output.sum()
+    loss = output.sum()
     loss.backward()
 
-    self.assertTrue(torch.allclose(linear.weight.grad.cpu(), linear_cpu.weight.grad))
+    self.assertTrue(
+        torch.allclose(linear.weight.grad.cpu(), linear_cpu.weight.grad))
     self.assertTrue(torch.allclose(input.grad.cpu(), input_cpu.grad))
-    self.assertTrue(torch.allclose(linear.bias.grad.cpu(), linear_cpu.bias.grad))
+    self.assertTrue(
+        torch.allclose(linear.bias.grad.cpu(), linear_cpu.bias.grad))
 
   def test_patched_linear_1D_bias(self):
     linear_cpu = nn.Linear(2, 4)
@@ -1763,12 +1767,14 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     loss_cpu = output_cpu.sum()
     loss_cpu.backward()
 
-    loss =output.sum()
+    loss = output.sum()
     loss.backward()
 
-    self.assertTrue(torch.allclose(linear.weight.grad.cpu(), linear_cpu.weight.grad))
+    self.assertTrue(
+        torch.allclose(linear.weight.grad.cpu(), linear_cpu.weight.grad))
     self.assertTrue(torch.allclose(input.grad.cpu(), input_cpu.grad))
-    self.assertTrue(torch.allclose(linear.bias.grad.cpu(), linear_cpu.bias.grad))
+    self.assertTrue(
+        torch.allclose(linear.bias.grad.cpu(), linear_cpu.bias.grad))
 
 
 class MNISTComparator(nn.Module):

--- a/torch_xla/distributed/fsdp/utils.py
+++ b/torch_xla/distributed/fsdp/utils.py
@@ -122,7 +122,9 @@ def _xla_patched_nn_linear_forward(m, input):
   return XLAPatchedLinear.apply(input, m.weight, m.bias)
 
 
-def apply_xla_patch_to_nn_linear(module, patched_function=_xla_patched_nn_linear_forward):
+def apply_xla_patch_to_nn_linear(module,
+                                 patched_function=_xla_patched_nn_linear_forward
+                                ):
   """
   Recursively apply a patch to the forward pass of `nn.Linear` layers
   to enable using `XLAPatchedLinear.apply` as `torch.nn.functional.linear`,

--- a/torch_xla/distributed/fsdp/utils.py
+++ b/torch_xla/distributed/fsdp/utils.py
@@ -122,7 +122,7 @@ def _xla_patched_nn_linear_forward(m, input):
   return XLAPatchedLinear.apply(input, m.weight, m.bias)
 
 
-def apply_xla_patch_to_nn_linear(module):
+def apply_xla_patch_to_nn_linear(module, patched_function=_xla_patched_nn_linear_forward):
   """
   Recursively apply a patch to the forward pass of `nn.Linear` layers
   to enable using `XLAPatchedLinear.apply` as `torch.nn.functional.linear`,
@@ -144,7 +144,7 @@ def apply_xla_patch_to_nn_linear(module):
     if getattr(forward_method, "__func__", None) != torch.nn.Linear.forward:
       return
 
-    patched_forward_method = MethodType(_xla_patched_nn_linear_forward, m)
+    patched_forward_method = MethodType(patched_function, m)
     m._nn_linear_forward_original = forward_method
     setattr(m, forward_method_name, patched_forward_method)
 

--- a/torch_xla/experimental/xla_sharding.py
+++ b/torch_xla/experimental/xla_sharding.py
@@ -528,7 +528,7 @@ class XLAPatchedLinear(torch.autograd.Function):
   A patched version of `torch.nn.functional.linear` that uses einsum instead
   of torch.matmul which will flatten the tensors to 2D and collide the sharded
   dimensions. The torch.matmul default behavior makes it very hard for XLA compiler
-  to propogate the sharding annotation.
+  to propagate the sharding annotation.
 
   TODO (alanwaketan): Let's patch it on the dispatcher level.
   """

--- a/torch_xla/experimental/xla_sharding.py
+++ b/torch_xla/experimental/xla_sharding.py
@@ -521,3 +521,40 @@ class ShardingSpec:
     # TODO(yeounoh) use virtual device interface when available.
     assert (t.device == xm.xla_device())
     mark_sharding(t, self.mesh, self.partition_spec)
+
+
+class XLAPatchedLinear(torch.autograd.Function):
+  """
+  A patched version of `torch.nn.functional.linear` that uses einsum instead
+  of torch.matmul which will flatten the tensors to 2D and collide the sharded
+  dimensions. The torch.matmul default behavior makes it very hard for XLA compiler
+  to propogate the sharding annotation.
+
+  TODO (alanwaketan): Let's patch it on the dispatcher level.
+  """
+
+  @staticmethod
+  def forward(ctx, input, weight, bias=None):
+    # bias is an optional argument
+    ctx.save_for_backward(input, weight, bias)
+    with torch.no_grad():
+      assert bias is None
+      return torch.einsum('bln,mn->blm', input, weight)
+
+  @staticmethod
+  def backward(ctx, grad_output):
+    input, weight, bias = ctx.saved_tensors
+    grad_input = grad_weight = grad_bias = None
+
+    if ctx.needs_input_grad[0]:
+      grad_input = torch.einsum('blm,mn->bln', grad_output, weight)
+    if ctx.needs_input_grad[1]:
+      grad_weight = torch.einsum('blm,bln->mn', grad_output, input)
+    if bias is not None and ctx.needs_input_grad[2]:
+      grad_output_flat = grad_output.flatten(start_dim=0, end_dim=-2)
+      grad_bias = grad_output_flat.sum(0)
+
+    return grad_input, grad_weight, grad_bias
+
+def xla_patched_nn_linear_forward(m, input):
+  return XLAPatchedLinear.apply(input, m.weight, m.bias)

--- a/torch_xla/experimental/xla_sharding.py
+++ b/torch_xla/experimental/xla_sharding.py
@@ -557,5 +557,6 @@ class XLAPatchedLinear(torch.autograd.Function):
 
     return grad_input, grad_weight, grad_bias
 
+
 def xla_patched_nn_linear_forward(m, input):
   return XLAPatchedLinear.apply(input, m.weight, m.bias)

--- a/torch_xla/experimental/xla_sharding.py
+++ b/torch_xla/experimental/xla_sharding.py
@@ -538,7 +538,7 @@ class XLAPatchedLinear(torch.autograd.Function):
     # bias is an optional argument
     ctx.save_for_backward(input, weight, bias)
     with torch.no_grad():
-      product = torch.einsum('bln,mn->blm', input, weight)
+      product = torch.einsum('...n,mn->...m', input, weight)
       if bias is None:
         return product
       return product + bias
@@ -549,11 +549,11 @@ class XLAPatchedLinear(torch.autograd.Function):
     grad_input = grad_weight = grad_bias = None
 
     if ctx.needs_input_grad[0]:
-      grad_input = torch.einsum('blm,mn->bln', grad_output, weight)
+      grad_input = torch.einsum('...m,mn->...n', grad_output, weight)
     if ctx.needs_input_grad[1]:
-      grad_weight = torch.einsum('blm,bln->mn', grad_output, input)
+      grad_weight = torch.einsum('...m,...n->mn', grad_output, input)
     if bias is not None and ctx.needs_input_grad[2]:
-      grad_bias = torch.einsum('blm->m', grad_output)
+      grad_bias = torch.einsum('...m->m', grad_output)
 
     return grad_input, grad_weight, grad_bias
 


### PR DESCRIPTION
Summary:
This pull request introduces a patched version of `torch.nn.functional.linear` that uses einsum instead of torch.matmul which will flatten the tensors to 2D and collide the sharded dimensions. The torch.matmul default behavior makes it very hard for XLA compiler to propagate the sharding annotation.

Test Plan:
PJRT_DEVICE=CPU python test/test_operations.py -v -k test_patched_linear