### PR TITLE
Always use ExecuteReplicated with SPMD

### DIFF
--- a/test/spmd/test_xla_virtual_device.py
+++ b/test/spmd/test_xla_virtual_device.py
@@ -63,6 +63,13 @@ class VirtualDeviceTest(test_xla_sharding_base.XlaShardingTest):
     t3_expected = [9.0, 9.0, 9.0, 9.0, 9.0, 9.0, 9.0, 9.0]
     self.assertEqual(t3.tolist()[0], t3_expected)
 
+  def test_no_sharding_1d(self):
+    t1 = torch.arange(9, dtype=torch.float, device=xm.xla_device())
+    t2 = torch.arange(9, dtype=torch.float, device=xm.xla_device())
+    t3 = t1 + t2
+    t3_expected = list(range(0, 18, 2))
+    self.assertEqual(t3.tolist(), t3_expected)
+
   def test_outbound_data_metrics(self):
     partition_spec = (0, 1)
 

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -1329,8 +1329,10 @@ XLAGraphExecutor::CompilationResult XLAGraphExecutor::Compile(
         torch::lazy::Output(ir_value.node.get(), ir_value.index));
     lowering_ctx.AddResult(root);
   }
+  // Always execute sharded when running in SPMD mode
+  bool is_sharded = (coll.device == GetVirtualDevice());
   // Annotate HLO sharding selectively in the compuation.
-  bool is_sharded = ShardingUtil::SetHloSharding(&lowering_ctx);
+  ShardingUtil::SetHloSharding(&lowering_ctx);
 
   std::vector<std::pair<int64_t, int64_t>> input_output_alias_pair;
   // TODO(yeounoh) aliasing is disabled for partitioned computation,


### PR DESCRIPTION
SPMD computations should always follow the ExecuteReplicated codepath, even when there are no sharding annotations present in the HLO.