### PR TITLE
[SPMD] Use actual device instead of SPMD:0 as the BackendDevice

### DIFF
--- a/torch_xla/csrc/aten_xla_bridge.cpp
+++ b/torch_xla/csrc/aten_xla_bridge.cpp
@@ -39,15 +39,10 @@ class AtenXlaDeviceMapper {
 
  private:
   AtenXlaDeviceMapper() {
-    if (UseVirtualDevice()) {
-      devices_.emplace_back(ParseDeviceString("SPMD:0"));
-      devices_ordinals_[devices_.back()] = 0;
-    } else {
-      for (auto& device_str :
-           torch_xla::runtime::GetComputationClient()->GetLocalDevices()) {
-        devices_.emplace_back(ParseDeviceString(device_str));
-        devices_ordinals_[devices_.back()] = devices_.size() - 1;
-      }
+    for (auto& device_str :
+         torch_xla::runtime::GetComputationClient()->GetLocalDevices()) {
+      devices_.emplace_back(ParseDeviceString(device_str));
+      devices_ordinals_[devices_.back()] = devices_.size() - 1;
     }
   }
 


### PR DESCRIPTION
fix #5497, we should use actual device type instead of SPMD:0 as BackendDevice to make it recognizable to PyTorch.