### PR TITLE
Add dtype check to amp for tpu

### DIFF
--- a/docs/amp.md
+++ b/docs/amp.md
@@ -25,7 +25,7 @@ for input, target in data:
     loss.backward()
     xm.optimizer_step.(optimizer)
 ```
-`autocast(xm.xla_device())` aliases `torch.amp.autocast('xla')` when the XLA Device is a TPU. Alternatively, if a script is only used with TPUs, then `torch.amp.autocast('xla')` can be directly used.
+`autocast(xm.xla_device())` aliases `torch.autocast('xla')` when the XLA Device is a TPU. Alternatively, if a script is only used with TPUs, then `torch.autocast('xla', dtype=torch.bfloat16)` can be directly used.
 
 Please file an issue or submit a pull request if there is an operator that should be autocasted that is not included.
 

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -403,6 +403,10 @@ class TestAutocastTPU(TestAutocastBase):
       self._run_autocast_outofplace(
           op, args, torch.float32, module=None, out_type=out_type)
 
+  def test_autocast_tpu_check_dtype(self):
+    with autocast(xm.xla_device(), dtype=torch.float16):
+      assert not torch.is_autocast_xla_enabled()
+
 
 if __name__ == "__main__":
   test = unittest.main(verbosity=FLAGS.verbosity, exit=False)

--- a/torch_xla/amp/autocast_mode.py
+++ b/torch_xla/amp/autocast_mode.py
@@ -1,6 +1,7 @@
 import torch
 import torch_xla.core.xla_model as xm
 from typing import Any
+import warnings
 
 
 class autocast(torch.amp.autocast_mode.autocast):
@@ -24,6 +25,12 @@ class autocast(torch.amp.autocast_mode.autocast):
     elif xm.xla_device_hw(device) == 'TPU':
       if dtype is None:
         dtype = torch.bfloat16
+      if dtype != torch.bfloat16:
+        error_message = "In TPU autocast, but the target dtype is not supported. Disabling autocast.\n"
+        error_message += (
+            "TPU Autocast only supports dtype of torch.bfloat16 currently.")
+        warnings.warn(error_message)
+        enabled = False
       super().__init__(
           "xla", enabled=enabled, dtype=dtype, cache_enabled=cache_enabled)
     else:


### PR DESCRIPTION
Disable autocast and warn user when they attempt to use AMP with a dtype other than bfloat16 on TPU.