### PR TITLE
[WIP][SPMD] Propogate replicated output

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -286,6 +286,9 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     xm.wait_device_ops()
     expected = expected.cpu()
 
+    # Clear sharding spec
+    xs.clear_sharding(t1)
+
     # Shard along two axes if four or more devices are available
     z_dim = 2 if self.n_devices >= 4 else 1
     mesh = self._get_mesh((z_dim, self.n_devices // z_dim))
@@ -315,6 +318,9 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     xm.mark_step()
     xm.wait_device_ops()
     expected = expected.cpu()
+
+    # Clear sharding spec
+    xs.clear_sharding(t1)
 
     # Shard along two axes if four or more devices are available
     z_dim = 2 if self.n_devices >= 4 else 1
@@ -351,6 +357,10 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     xm.mark_step()  # To re-materialize xx, xw, and xb.
     xm.wait_device_ops()
     expected = expected.cpu()
+
+    # Clear sharding spec
+    xs.clear_sharding(xx)
+    xs.clear_sharding(xw)
 
     xs.mark_sharding(xx, mesh, (0, None))
     xs.mark_sharding(xw, mesh, (None, 1))
@@ -434,14 +444,9 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
       xm.mark_step()
       # Sharding is persisted across mark_step calls, and test if the sharded computation
       # can repeat more than once without crashing.
-      if self.n_devices > 1:
-        self.assertEqual(
-            sharding_spec,
-            torch_xla._XLAC._get_xla_sharding_spec(model.fc1.weight))
-      else:
-        # single device execution defaults to implicit replication.
-        self.assertFalse(
-            torch_xla._XLAC._get_xla_sharding_spec(model.fc1.weight))
+      self.assertEqual(
+          sharding_spec,
+          torch_xla._XLAC._get_xla_sharding_spec(model.fc1.weight))
 
   def test_sharding_propagation(self):
     met.clear_all()
@@ -757,6 +762,9 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     x = xla_x.cpu()
     # xla_x now becomes a device data IR without XLAData
     xm.mark_step()
+
+    # Clear sharding spec
+    xs.clear_sharding(xla_x)
 
     xs.mark_sharding(xla_x, self._get_mesh((1, self.n_devices)), (1, 0))
     self.assertNotEqual(torch_xla._XLAC._get_xla_sharding_spec(xla_x), '')

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -661,25 +661,12 @@ void ShardingUtil::PrepareOutputShardingPropagation(
 
   for (int i = 0; i < indices.size(); ++i) {
     auto xtensor = (*tensors)[indices[i]];
-    if (output_shardings[i].type()) {
-      // Tensor sharding annotation type is non-zero (sharded).
-      (*sharding_specs)[i] = std::make_shared<XLATensor::ShardingSpec>(
-          output_shardings[i],
-          MakeShapeWithDeviceLayout(
-              xtensor->shape().get(),
-              static_cast<XlaDeviceType>(xtensor->GetDevice().type())));
-      xtensor->SetShardingSpec(*(*sharding_specs)[i]);
-    } else {
-      // Clear sharding if the output parameter is no longer sharded, this
-      // assumes that the output is implicitly replicated and wrapped inside
-      // PjRtShardedData.
-      (*sharding_specs)[i] = std::make_shared<XLATensor::ShardingSpec>(
-          xla::HloSharding::Replicate().ToProto(),
-          MakeShapeWithDeviceLayout(
-              xtensor->shape().get(),
-              static_cast<XlaDeviceType>(xtensor->GetDevice().type())));
-      xtensor->ClearShardingSpec();
-    }
+    (*sharding_specs)[i] = std::make_shared<XLATensor::ShardingSpec>(
+        output_shardings[i],
+        MakeShapeWithDeviceLayout(
+            xtensor->shape().get(),
+            static_cast<XlaDeviceType>(xtensor->GetDevice().type())));
+    xtensor->SetShardingSpec(*(*sharding_specs)[i]);
 
     // Create sharded data placeholder, this will be used to
     // hold the corresponding computation results for both sharding &


### PR DESCRIPTION
Summary:
During the LLaMA2 experiements, I disovered that manually marking 1D tensors to be replicated can greatly save a lot of memory. Then I disocvered that explicitly replicated spec will get dropped after mark_step. That is caused by PrepareOutputShardingPropagation where it explicitly clear the sharding spec for replicated output. So, I went ahead and fix that.

Further, I did some experiements of propogating replicated output and that drop the requirements of manually replicating 1D tensors. Hence, I made this change.

I'm still not quite sure why, so this is WIP.

Test Plan:
PJRT_DEVICE=TPU python test/spmd/test_xla_sharding.py