### PR TITLE
Replace pytree_to_str with treespec_dumps

### DIFF
--- a/torch_xla/stablehlo.py
+++ b/torch_xla/stablehlo.py
@@ -325,8 +325,8 @@ def _exported_program_to_stablehlo_bundle(exported_model,
       input_signature=input_signatures,
       output_signature=output_signature,
       input_locations=input_locations,
-      input_pytree_spec=pytree.pytree_to_str(exported_model.call_spec.in_spec),
-      output_pytree_spec=pytree.pytree_to_str(
+      input_pytree_spec=pytree.treespec_dumps(exported_model.call_spec.in_spec),
+      output_pytree_spec=pytree.treespec_dumps(
           exported_model.call_spec.out_spec),
   )
   bundle = StableHLOModelBundle(


### PR DESCRIPTION
`pytree_to_str` is deprecated. [Internally](https://github.com/pytorch/pytorch/blob/main/torch/utils/_pytree.py#L532) it simply calls `treespec_dumps`. 

We should use `treespec_dumps` directly instead of using `pytree_to_str`.

This PR fixes the following warning:
```
>>> stablehlo_program = exported_program_to_stablehlo(exported)
/usr/local/lib/python3.8/site-packages/torch/utils/_pytree.py:533: UserWarning: pytree_to_str is deprecated. Please use treespec_dumps
  warnings.warn("pytree_to_str is deprecated. Please use treespec_dumps")
```