### PR TITLE
Enable megacore_dense by default (#5520)

### DIFF
--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -40,6 +40,7 @@ def _setup_default_env():
   _set_missing_env('GRPC_VERBOSITY', 'ERROR')
   _set_missing_env('ALLOW_MULTIPLE_LIBTPU_LOAD', '1')
   _set_missing_env('TPU_ML_PLATFORM', 'PyTorch/XLA')
+  _set_missing_env('TPU_MEGACORE', 'megacore_dense')
 
 
 _fd, _tmp_fname = -1, ''


### PR DESCRIPTION
Cherry-picking https://github.com/pytorch/xla/pull/5520 onto the r2.1 branch.

CI is being ran against the upstream PyTorch 2.1 branch.