### PR TITLE
Add option to unbundle libtpu

### DIFF
--- a/infra/ansible/config/env.yaml
+++ b/infra/ansible/config/env.yaml
@@ -46,5 +46,4 @@ build_env:
   tpu:
     ACCELERATOR: tpu
     TPUVM_MODE: 1
-    BUNDLE_LIBTPU: 1
-
+    BUNDLE_LIBTPU: "{{ bundle_libtpu }}"

--- a/infra/ansible/config/vars.yaml
+++ b/infra/ansible/config/vars.yaml
@@ -10,5 +10,5 @@ package_version: 2.1.0
 nightly_release: false
 # Whether to disable XRT during build
 disable_xrt: 0
-# Whether to preinstall libtpu in the PyTorch/XLA wheel
+# Whether to preinstall libtpu in the PyTorch/XLA wheel. Ignored for GPU build.
 bundle_libtpu: 1

--- a/infra/ansible/config/vars.yaml
+++ b/infra/ansible/config/vars.yaml
@@ -10,3 +10,5 @@ package_version: 2.1.0
 nightly_release: false
 # Whether to disable XRT during build
 disable_xrt: 0
+# Whether to preinstall libtpu in the PyTorch/XLA wheel
+bundle_libtpu: 1

--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -44,7 +44,8 @@ versioned_builds = [
     git_tag         = "v2.1.0"
     package_version = "2.1"
     accelerator     = "tpu"
-    python_version = "3.10"
+    python_version  = "3.10"
+    bundle_libtpu   = "0"
   },
   {
     git_tag         = "v2.0.0"

--- a/infra/tpu-pytorch-releases/artifacts_builds.tf
+++ b/infra/tpu-pytorch-releases/artifacts_builds.tf
@@ -9,6 +9,7 @@ variable "nightly_builds" {
       cuda_version   = optional(string, "11.8")
       python_version = optional(string, "3.8")
       arch           = optional(string, "amd64")
+      bundle_libtpu  = optional(string, "1")
     })
   )
 
@@ -38,6 +39,7 @@ variable "versioned_builds" {
       python_version  = optional(string, "3.8")
       cuda_version    = optional(string, "11.8")
       arch            = optional(string, "amd64")
+      bundle_libtpu   = optional(string, "1")
     })
   )
 


### PR DESCRIPTION
Remove libtpu from 2.1 build. Ansible changes should be cherry-picked to the 2.1 branch. cc @wonjoolee95 

Terraform plan:

<details>

```
  # module.nightly_builds["3.10_tpuvm"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id             = "projects/tpu-pytorch-releases/locations/us-central1/triggers/d1ce3be7-be03-49b9-a965-649b3f2a0b55"
        name           = "nightly-3-10-tpuvm"
        tags           = []
        # (9 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"nightly_release\":\"true\",\"package_version\":\"2.1.0\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.10_tpuvm)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.10_tpuvm_$(date +%Y%m%d))\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"nightly_release\":\"true\",\"package_version\":\"2.1.0\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.10_tpuvm)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.10_tpuvm_$(date +%Y%m%d))\" -t=local_image",
                ]
                id               = "build_xla_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.nightly_builds["3.8_cuda_11.7"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id             = "projects/tpu-pytorch-releases/locations/us-central1/triggers/9803f073-d8b5-400d-8b61-248596ddde7d"
        name           = "nightly-3-8-cuda-11-7"
        tags           = []
        # (9 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"cuda_version\":\"11.7\",\"nightly_release\":\"true\",\"package_version\":\"2.1.0\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.8_cuda_11.7)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.8_cuda_11.7_$(date +%Y%m%d))\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.7\",\"nightly_release\":\"true\",\"package_version\":\"2.1.0\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.8_cuda_11.7)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.8_cuda_11.7_$(date +%Y%m%d))\" -t=local_image",
                ]
                id               = "build_xla_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.nightly_builds["3.8_cuda_11.8"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id             = "projects/tpu-pytorch-releases/locations/us-central1/triggers/e46033e7-3124-4519-9636-6c9658b9e739"
        name           = "nightly-3-8-cuda-11-8"
        tags           = []
        # (9 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"nightly_release\":\"true\",\"package_version\":\"2.1.0\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.8_cuda_11.8)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.8_cuda_11.8_$(date +%Y%m%d))\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"nightly_release\":\"true\",\"package_version\":\"2.1.0\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.8_cuda_11.8)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.8_cuda_11.8_$(date +%Y%m%d))\" -t=local_image",
                ]
                id               = "build_xla_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.nightly_builds["3.8_cuda_12.0"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id             = "projects/tpu-pytorch-releases/locations/us-central1/triggers/fb7e9e91-dd73-451c-936b-13a9fb59c39f"
        name           = "nightly-3-8-cuda-12-0"
        tags           = []
        # (9 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"cuda_version\":\"12.0\",\"nightly_release\":\"true\",\"package_version\":\"2.1.0\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.8_cuda_12.0)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.8_cuda_12.0_$(date +%Y%m%d))\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"12.0\",\"nightly_release\":\"true\",\"package_version\":\"2.1.0\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.8_cuda_12.0)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.8_cuda_12.0_$(date +%Y%m%d))\" -t=local_image",
                ]
                id               = "build_xla_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.nightly_builds["3.8_tpuvm"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id             = "projects/tpu-pytorch-releases/locations/us-central1/triggers/32ebfc3e-e112-4776-9c97-7e8052fd4941"
        name           = "nightly-3-8-tpuvm"
        tags           = []
        # (9 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"nightly_release\":\"true\",\"package_version\":\"2.1.0\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.8_tpuvm)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.8_tpuvm_$(date +%Y%m%d))\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"nightly_release\":\"true\",\"package_version\":\"2.1.0\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.8_tpuvm)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_3.8_tpuvm_$(date +%Y%m%d))\" -t=local_image",
                ]
                id               = "build_xla_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r1.12_3.7_cuda_11.2"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/83d9fe75-563d-4c4d-8a20-33b09f9fdb17"
        name               = "r1-12-3-7-cuda-11-2"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=cuda_version=11.2 --build-arg=git_tag=v1.12.0 --build-arg=package_version=1.12 --build-arg=python_version=3.7 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"cuda_version\":\"11.2\",\"git_tag\":\"v1.12.0\",\"package_version\":\"1.12\",\"python_version\":\"3.7\",\"pytorch_git_rev\":\"v1.12.0\",\"xla_git_rev\":\"v1.12.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r1.12_3.7_cuda_11.2)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.2 --build-arg=git_tag=v1.12.0 --build-arg=package_version=1.12 --build-arg=python_version=3.7 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.2\",\"git_tag\":\"v1.12.0\",\"package_version\":\"1.12\",\"python_version\":\"3.7\",\"pytorch_git_rev\":\"v1.12.0\",\"xla_git_rev\":\"v1.12.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r1.12_3.7_cuda_11.2)\" -t=local_image",
                ]
                id               = "build_xla_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r1.13_3.7_cuda_11.2"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/9c7d2e24-701e-4fe4-94fe-1a5bf57a4aae"
        name               = "r1-13-3-7-cuda-11-2"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=cuda_version=11.2 --build-arg=git_tag=v1.13.0 --build-arg=package_version=1.13 --build-arg=python_version=3.7 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"cuda_version\":\"11.2\",\"git_tag\":\"v1.13.0\",\"package_version\":\"1.13\",\"python_version\":\"3.7\",\"pytorch_git_rev\":\"v1.13.0\",\"xla_git_rev\":\"v1.13.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r1.13_3.7_cuda_11.2)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.2 --build-arg=git_tag=v1.13.0 --build-arg=package_version=1.13 --build-arg=python_version=3.7 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.2\",\"git_tag\":\"v1.13.0\",\"package_version\":\"1.13\",\"python_version\":\"3.7\",\"pytorch_git_rev\":\"v1.13.0\",\"xla_git_rev\":\"v1.13.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r1.13_3.7_cuda_11.2)\" -t=local_image",
                ]
                id               = "build_xla_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r1.13_3.8_cuda_11.2"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/ebb0bce0-f86d-46bd-8064-dfcdae031d96"
        name               = "r1-13-3-8-cuda-11-2"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=cuda_version=11.2 --build-arg=git_tag=v1.13.0 --build-arg=package_version=1.13 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"cuda_version\":\"11.2\",\"git_tag\":\"v1.13.0\",\"package_version\":\"1.13\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v1.13.0\",\"xla_git_rev\":\"v1.13.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r1.13_3.8_cuda_11.2)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.2 --build-arg=git_tag=v1.13.0 --build-arg=package_version=1.13 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.2\",\"git_tag\":\"v1.13.0\",\"package_version\":\"1.13\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v1.13.0\",\"xla_git_rev\":\"v1.13.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r1.13_3.8_cuda_11.2)\" -t=local_image",
                ]
                id               = "build_xla_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r1.13_3.8_tpuvm"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/6c01b84d-28fb-4128-9b2a-a903298e234f"
        name               = "r1-13-3-8-tpuvm"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=tpu --build-arg=arch=amd64 --build-arg=cuda_version=11.8 --build-arg=git_tag=v1.13.0 --build-arg=package_version=1.13 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"git_tag\":\"v1.13.0\",\"package_version\":\"1.13\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v1.13.0\",\"xla_git_rev\":\"v1.13.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r1.13_3.8_tpuvm)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=tpu --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.8 --build-arg=git_tag=v1.13.0 --build-arg=package_version=1.13 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v1.13.0\",\"package_version\":\"1.13\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v1.13.0\",\"xla_git_rev\":\"v1.13.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r1.13_3.8_tpuvm)\" -t=local_image",
                ]
                id               = "build_xla_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r2.0_3.10_cuda_11.8"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/98c54ed4-d414-48be-a1b8-031dea702b96"
        name               = "r2-0-3-10-cuda-11-8"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=cuda_version=11.8 --build-arg=git_tag=v2.0.0 --build-arg=package_version=2.0 --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.0.0\",\"package_version\":\"2.0\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"v2.0.0\",\"xla_git_rev\":\"v2.0.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.0_3.10_cuda_11.8)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.8 --build-arg=git_tag=v2.0.0 --build-arg=package_version=2.0 --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.0.0\",\"package_version\":\"2.0\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"v2.0.0\",\"xla_git_rev\":\"v2.0.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.0_3.10_cuda_11.8)\" -t=local_image",
                ]
                id               = "build_xla_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r2.0_3.8_cuda_11.7"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/1151b31d-04c8-4dbb-b1c8-be7d0eab6fed"
        name               = "r2-0-3-8-cuda-11-7"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=cuda_version=11.7 --build-arg=git_tag=v2.0.0 --build-arg=package_version=2.0 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"cuda_version\":\"11.7\",\"git_tag\":\"v2.0.0\",\"package_version\":\"2.0\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.0.0\",\"xla_git_rev\":\"v2.0.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.0_3.8_cuda_11.7)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.7 --build-arg=git_tag=v2.0.0 --build-arg=package_version=2.0 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.7\",\"git_tag\":\"v2.0.0\",\"package_version\":\"2.0\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.0.0\",\"xla_git_rev\":\"v2.0.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.0_3.8_cuda_11.7)\" -t=local_image",
                ]
                id               = "build_xla_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r2.0_3.8_cuda_11.8"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/5ecbf793-5290-41d4-a99c-7055cadd06ca"
        name               = "r2-0-3-8-cuda-11-8"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=cuda_version=11.8 --build-arg=git_tag=v2.0.0 --build-arg=package_version=2.0 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.0.0\",\"package_version\":\"2.0\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.0.0\",\"xla_git_rev\":\"v2.0.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.0_3.8_cuda_11.8)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.8 --build-arg=git_tag=v2.0.0 --build-arg=package_version=2.0 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.0.0\",\"package_version\":\"2.0\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.0.0\",\"xla_git_rev\":\"v2.0.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.0_3.8_cuda_11.8)\" -t=local_image",
                ]
                id               = "build_xla_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r2.0_3.8_tpuvm"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/200aa1c6-a7a2-4630-8715-aeff337a5da0"
        name               = "r2-0-3-8-tpuvm"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=tpu --build-arg=arch=amd64 --build-arg=cuda_version=11.8 --build-arg=git_tag=v2.0.0 --build-arg=package_version=2.0 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.0.0\",\"package_version\":\"2.0\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.0.0\",\"xla_git_rev\":\"v2.0.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.0_3.8_tpuvm)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=tpu --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.8 --build-arg=git_tag=v2.0.0 --build-arg=package_version=2.0 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.0.0\",\"package_version\":\"2.0\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.0.0\",\"xla_git_rev\":\"v2.0.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.0_3.8_tpuvm)\" -t=local_image",
                ]
                id               = "build_xla_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r2.1_3.10_cuda_11.8"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/3a9c9bc6-42f8-42c0-bff3-91c00e55fd51"
        name               = "r2-1-3-10-cuda-11-8"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=cuda_version=11.8 --build-arg=git_tag=v2.1.0 --build-arg=package_version=2.1 --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"v2.1.0\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1_3.10_cuda_11.8)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.8 --build-arg=git_tag=v2.1.0 --build-arg=package_version=2.1 --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"v2.1.0\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1_3.10_cuda_11.8)\" -t=local_image",
                ]
                id               = "build_xla_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r2.1_3.10_tpuvm"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/52d653bf-ab2c-4819-90a7-9c0b5545c67c"
        name               = "r2-1-3-10-tpuvm"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=tpu --build-arg=arch=amd64 --build-arg=cuda_version=11.8 --build-arg=git_tag=v2.1.0 --build-arg=package_version=2.1 --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"v2.1.0\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1_3.10_tpuvm)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=tpu --build-arg=arch=amd64 --build-arg=bundle_libtpu=0 --build-arg=cuda_version=11.8 --build-arg=git_tag=v2.1.0 --build-arg=package_version=2.1 --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"bundle_libtpu\":\"0\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"v2.1.0\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1_3.10_tpuvm)\" -t=local_image",
                ]
                id               = "build_xla_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r2.1_3.8_cuda_11.8"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/a5fe77d5-41af-42db-bcf8-d95c4a1617c6"
        name               = "r2-1-3-8-cuda-11-8"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=cuda_version=11.8 --build-arg=git_tag=v2.1.0 --build-arg=package_version=2.1 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.1.0\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1_3.8_cuda_11.8)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.8 --build-arg=git_tag=v2.1.0 --build-arg=package_version=2.1 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.1.0\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1_3.8_cuda_11.8)\" -t=local_image",
                ]
                id               = "build_xla_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r2.1_3.8_cuda_12.0"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/af81363f-2460-4bac-86eb-e412e070ee14"
        name               = "r2-1-3-8-cuda-12-0"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=cuda_version=12.0 --build-arg=git_tag=v2.1.0 --build-arg=package_version=2.1 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"cuda_version\":\"12.0\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.1.0\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1_3.8_cuda_12.0)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=12.0 --build-arg=git_tag=v2.1.0 --build-arg=package_version=2.1 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"12.0\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.1.0\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1_3.8_cuda_12.0)\" -t=local_image",
                ]
                id               = "build_xla_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r2.1_3.8_tpuvm"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
      ~ description        = "Builds official xla:r2.1_3.8_tpuvm' TPU docker image and corresponding wheels for PyTorch/XLA." -> "Builds official xla:r2.1_3.8_tpuvm' TPU docker image and corresponding wheels for PyTorch/XLA. Trigger managed by Terraform setup in infra/tpu-pytorch-releases/artifacts_builds.tf."
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/beb9db69-7419-48a4-97ee-48ba8d1df319"
        name               = "r2-1-3-8-tpuvm"
        tags               = []
        # (9 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=tpu --build-arg=arch=amd64 --build-arg=cuda_version=11.8 --build-arg=git_tag=v2.1.0 --build-arg=package_version=2.1 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.1.0-rc1\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1_3.8_tpuvm)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=tpu --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.8 --build-arg=git_tag=v2.1.0 --build-arg=package_version=2.1 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.1.0\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1_3.8_tpuvm)\" -t=local_image",
                ]
                id               = "build_xla_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 18 to change, 0 to destroy.
```

</details>

TLDR this change adds a `bundle_libtpu: 1` option to every build except for the 2.1 TPU VM build.