### PR TITLE
Revert 2.1 terraform changes

### DIFF
--- a/infra/ansible/roles/fetch_srcs/defaults/main.yaml
+++ b/infra/ansible/roles/fetch_srcs/defaults/main.yaml
@@ -1,3 +1,3 @@
 # See https://docs.ansible.com/ansible/latest/collections/ansible/builtin/git_module.html#parameter-version
-pytorch_git_rev: v2.1.0-rc2
+pytorch_git_rev: HEAD
 xla_git_rev: HEAD

--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -37,13 +37,11 @@ xrt_nightly_builds = [
 versioned_builds = [
   {
     git_tag         = "v2.1.0"
-    pytorch_git_tag = "v2.1.0-rc2"
     package_version = "2.1"
     accelerator     = "tpu"
   },
   {
     git_tag         = "v2.1.0"
-    pytorch_git_tag = "v2.1.0-rc2"
     package_version = "2.1"
     accelerator     = "tpu"
     python_version = "3.10"
@@ -60,21 +58,18 @@ versioned_builds = [
   },
   {
     git_tag         = "v2.1.0"
-    pytorch_git_tag = "v2.1.0-rc2"
     package_version = "2.1",
     accelerator     = "cuda"
     cuda_version    = "12.0"
   },
   {
     git_tag         = "v2.1.0"
-    pytorch_git_tag = "v2.1.0-rc2"
     package_version = "2.1"
     accelerator     = "cuda"
     cuda_version    = "11.8"
   },
   {
     git_tag         = "v2.1.0"
-    pytorch_git_tag = "v2.1.0-rc2"
     package_version = "2.1"
     accelerator     = "cuda"
     cuda_version    = "11.8"

--- a/infra/tpu-pytorch-releases/artifacts_builds.tf
+++ b/infra/tpu-pytorch-releases/artifacts_builds.tf
@@ -33,7 +33,6 @@ variable "versioned_builds" {
   type = list(
     object({
       git_tag         = string
-      pytorch_git_tag = string
       package_version = string
       accelerator     = string
       python_version  = optional(string, "3.8")
@@ -80,7 +79,7 @@ module "nightly_builds" {
   ansible_vars = merge(each.value, {
     package_version = var.nightly_package_version
     nightly_release = true
-    pytorch_git_rev = "v2.1.0-rc2"
+    pytorch_git_rev = "main"
     xla_git_rev     = "$COMMIT_SHA"
   })
 
@@ -127,7 +126,7 @@ module "xrt_nightly_builds" {
   ansible_vars = merge(each.value, {
     package_version = var.nightly_package_version
     nightly_release = true
-    pytorch_git_rev = "v2.1.0-rc2"
+    pytorch_git_rev = "main"
     xla_git_rev     = "$COMMIT_SHA"
   })
 
@@ -171,7 +170,7 @@ module "versioned_builds" {
   for_each = local.versioned_builds_dict
 
   ansible_vars = merge(each.value, {
-    pytorch_git_rev = each.value.pytorch_git_tag
+    pytorch_git_rev = each.value.git_tag
     xla_git_rev     = each.value.git_tag
   })
 

--- a/infra/tpu-pytorch-releases/dev_images.tf
+++ b/infra/tpu-pytorch-releases/dev_images.tf
@@ -52,7 +52,7 @@ module "dev_images" {
 
   ansible_vars = {
     xla_git_rev     = "$COMMIT_SHA"
-    pytorch_git_rev = "v2.1.0-rc2"
+    pytorch_git_rev = "main"
 
     accelerator    = each.value.accelerator
     arch           = each.value.arch

--- a/infra/tpu-pytorch/test_triggers.tf
+++ b/infra/tpu-pytorch/test_triggers.tf
@@ -27,7 +27,7 @@ module "tpu_e2e_tests" {
     arch            = "amd64"
     accelerator     = "tpu"
     disable_xrt     = "1"
-    pytorch_git_rev = "v2.1.0-rc2"
+    pytorch_git_rev = "main"
     # The commit ID associated with the triggered build. Substituted when
     # Cloud Build is triggered.
     xla_git_rev = "$COMMIT_SHA"


### PR DESCRIPTION
Partially reverts https://github.com/pytorch/xla/pull/5529 to revert the terraform changes as ansible changes are to be made on master.

The `torch_pin` is left as it is, since we want to keep running this `r2.1` CI against the upstream PyTorch 2.1 branch. 