### PR TITLE
[do not review] Debug gpu ci with new xla flag XLA_PYTHON_CLIENT_PREALLOCATE

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -155,10 +155,9 @@ function run_torch_xla_tests() {
 
       # GPU tests
       if [ -x "$(command -v nvidia-smi)" ]; then
-        # These tests fail on GPU with 03/30 TF-pin update (https://github.com/pytorch/xla/pull/4840)
-        # PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
-        # PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --auto_wrap_policy type_based --use_small_fake_sample --num_epochs=1
-        # XLA_DISABLE_FUNCTIONALIZATION=1 PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
+        PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
+        PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --auto_wrap_policy type_based --use_small_fake_sample --num_epochs=1
+        XLA_DISABLE_FUNCTIONALIZATION=1 PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
         # Syncfree SGD optimizer tests
         if [ -d ./torch_xla/amp/syncfree ]; then
           echo "Running Syncfree Optimizer Test"

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -155,9 +155,9 @@ function run_torch_xla_tests() {
 
       # GPU tests
       if [ -x "$(command -v nvidia-smi)" ]; then
-        PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
-        PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --auto_wrap_policy type_based --use_small_fake_sample --num_epochs=1
-        XLA_DISABLE_FUNCTIONALIZATION=1 PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
+        PJRT_DEVICE=GPU XLA_PYTHON_CLIENT_MEM_FRACTION=0.8 python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
+        PJRT_DEVICE=GPU XLA_PYTHON_CLIENT_MEM_FRACTION=0.8 python test/test_train_mp_imagenet_fsdp.py --fake_data --auto_wrap_policy type_based --use_small_fake_sample --num_epochs=1
+        XLA_DISABLE_FUNCTIONALIZATION=1 PJRT_DEVICE=GPU XLA_PYTHON_CLIENT_MEM_FRACTION=0.8 python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
         # Syncfree SGD optimizer tests
         if [ -d ./torch_xla/amp/syncfree ]; then
           echo "Running Syncfree Optimizer Test"

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -155,9 +155,9 @@ function run_torch_xla_tests() {
 
       # GPU tests
       if [ -x "$(command -v nvidia-smi)" ]; then
-        PJRT_DEVICE=GPU XLA_PYTHON_CLIENT_MEM_FRACTION=0.8 python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
-        PJRT_DEVICE=GPU XLA_PYTHON_CLIENT_MEM_FRACTION=0.8 python test/test_train_mp_imagenet_fsdp.py --fake_data --auto_wrap_policy type_based --use_small_fake_sample --num_epochs=1
-        XLA_DISABLE_FUNCTIONALIZATION=1 PJRT_DEVICE=GPU XLA_PYTHON_CLIENT_MEM_FRACTION=0.8 python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
+        PJRT_DEVICE=GPU XLA_PYTHON_CLIENT_PREALLOCATE=false python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
+        PJRT_DEVICE=GPU XLA_PYTHON_CLIENT_PREALLOCATE=false python test/test_train_mp_imagenet_fsdp.py --fake_data --auto_wrap_policy type_based --use_small_fake_sample --num_epochs=1
+        XLA_DISABLE_FUNCTIONALIZATION=1 PJRT_DEVICE=GPU XLA_PYTHON_CLIENT_PREALLOCATE=false python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
         # Syncfree SGD optimizer tests
         if [ -d ./torch_xla/amp/syncfree ]; then
           echo "Running Syncfree Optimizer Test"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,6 +42,7 @@ http_archive(
         "//openxla_patches:f16_abi_clang.diff",
         "//openxla_patches:gpu_race_condition.diff",
         "//openxla_patches:constexpr_return.diff",
+        "//openxla_patches:service.diff",
     ],
     strip_prefix = "xla-cd2cf5c34931e4fc1cacf83bfc480a5b93f05f6d",
     urls = [

--- a/openxla_patches/service.diff
+++ b/openxla_patches/service.diff
@@ -1,0 +1,14 @@
+delete this patch after openxla pin updated to date after or equal to 08/09
+diff --git a/xla/service/layout_assignment.cc b/xla/service/layout_assignment.cc
+index f69224f42..43feda2a0 100644
+--- a/xla/service/layout_assignment.cc
++++ b/xla/service/layout_assignment.cc
+@@ -154,7 +154,7 @@ OperandLayoutConstraint::OperandLayoutConstraint(
+       instruction_(instruction),
+       operand_no_(operand_no) {
+   CHECK(shape_layout.LayoutIsSet());
+-  CHECK(ShapeUtil::CompatibleIgnoringElementType(
++  CHECK(ShapeUtil::CompatibleKind(
+       shape_layout.shape(), instruction->operand(operand_no)->shape()))
+       << shape_layout.shape() << " is not compatible with "
+       << instruction->operand(operand_no)->shape() << " (for operand "

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -27,7 +27,6 @@ def _setup_xla_flags():
       flags, (('xla_gpu_simplify_all_fp_conversions', 'false'),))
   flags = _set_missing_flags(flags,
                              (('xla_gpu_force_compilation_parallelism', '8'),))
-  flags = _set_missing_flags(flags, (('XLA_PYTHON_CLIENT_MEM_FRACTION', '0.8'),))
   os.environ['XLA_FLAGS'] = ' '.join(flags)
 
 

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -27,6 +27,7 @@ def _setup_xla_flags():
       flags, (('xla_gpu_simplify_all_fp_conversions', 'false'),))
   flags = _set_missing_flags(flags,
                              (('xla_gpu_force_compilation_parallelism', '8'),))
+  flags = _set_missing_flags(flags, (('XLA_PYTHON_CLIENT_MEM_FRACTION', '0.8'),))
   os.environ['XLA_FLAGS'] = ' '.join(flags)
 
 


### PR DESCRIPTION
- Set XLA_PYTHON_CLIENT_MEM_FRACTION to 0.8
- try the fix
- get the patch
- use XLA_PYTHON_CLIENT_PREALLOCATE=false
