### PR TITLE
Allow to override PyTorch git revision and set it to v2.1.0-rc2 for 2.1 releases

### DIFF
--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -4,7 +4,7 @@ nightly_package_version = "2.1.0"
 nightly_builds = [
   { accelerator = "tpu" },
   {
-    accelerator  = "tpu"
+    accelerator    = "tpu"
     python_version = "3.10"
   },
   {
@@ -24,7 +24,7 @@ nightly_builds = [
 # TODO: Remove this after the 2.1 release
 xrt_nightly_builds = [
   {
-    accelerator  = "tpu"
+    accelerator    = "tpu"
     python_version = "3.10"
   },
   {
@@ -37,11 +37,13 @@ xrt_nightly_builds = [
 versioned_builds = [
   {
     git_tag         = "v2.1.0"
+    pytorch_git_rev = "v2.1.0-rc2"
     package_version = "2.1"
     accelerator     = "tpu"
   },
   {
     git_tag         = "v2.1.0"
+    pytorch_git_rev = "v2.1.0-rc2"
     package_version = "2.1"
     accelerator     = "tpu"
     python_version  = "3.10"
@@ -59,18 +61,21 @@ versioned_builds = [
   },
   {
     git_tag         = "v2.1.0"
+    pytorch_git_rev = "v2.1.0-rc2"
     package_version = "2.1",
     accelerator     = "cuda"
     cuda_version    = "12.0"
   },
   {
     git_tag         = "v2.1.0"
+    pytorch_git_rev = "v2.1.0-rc2"
     package_version = "2.1"
     accelerator     = "cuda"
     cuda_version    = "11.8"
   },
   {
     git_tag         = "v2.1.0"
+    pytorch_git_rev = "v2.1.0-rc2"
     package_version = "2.1"
     accelerator     = "cuda"
     cuda_version    = "11.8"

--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -38,13 +38,13 @@ versioned_builds = [
   {
     git_tag         = "v2.1.0"
     pytorch_git_rev = "v2.1.0-rc2"
-    package_version = "2.1"
+    package_version = "2.1.0rc2"
     accelerator     = "tpu"
   },
   {
     git_tag         = "v2.1.0"
     pytorch_git_rev = "v2.1.0-rc2"
-    package_version = "2.1"
+    package_version = "2.1.0rc2"
     accelerator     = "tpu"
     python_version  = "3.10"
     bundle_libtpu   = "0"
@@ -62,21 +62,21 @@ versioned_builds = [
   {
     git_tag         = "v2.1.0"
     pytorch_git_rev = "v2.1.0-rc2"
-    package_version = "2.1",
+    package_version = "2.1.0rc2",
     accelerator     = "cuda"
     cuda_version    = "12.0"
   },
   {
     git_tag         = "v2.1.0"
     pytorch_git_rev = "v2.1.0-rc2"
-    package_version = "2.1"
+    package_version = "2.1.0rc2"
     accelerator     = "cuda"
     cuda_version    = "11.8"
   },
   {
     git_tag         = "v2.1.0"
     pytorch_git_rev = "v2.1.0-rc2"
-    package_version = "2.1"
+    package_version = "2.1.0rc2"
     accelerator     = "cuda"
     cuda_version    = "11.8"
     python_version  = "3.10"

--- a/infra/tpu-pytorch-releases/artifacts_builds.tf
+++ b/infra/tpu-pytorch-releases/artifacts_builds.tf
@@ -36,6 +36,8 @@ variable "versioned_builds" {
       git_tag         = string
       package_version = string
       accelerator     = string
+      # Fetch PyTorch at a given revision (e.g. git tag), otherwise use git_tag.
+      pytorch_git_rev = optional(string, "")
       python_version  = optional(string, "3.8")
       cuda_version    = optional(string, "11.8")
       arch            = optional(string, "amd64")
@@ -172,7 +174,9 @@ module "versioned_builds" {
   for_each = local.versioned_builds_dict
 
   ansible_vars = merge(each.value, {
-    pytorch_git_rev = each.value.git_tag
+    // Override `pytorch_git_rev` set in each value of `versioned_builds_dict`
+    // if it's left empty.
+    pytorch_git_rev = coalesce(each.value.pytorch_git_rev, each.value.git_tag)
     xla_git_rev     = each.value.git_tag
   })
 
@@ -200,7 +204,10 @@ module "versioned_builds" {
     : "cuda/${each.value.cuda_version}"
   }"
   wheels_srcs = ["/dist/*.whl"]
-  build_args  = each.value
+  # Pass docker build args to infra/ansible/Dockerfile, other than `ansible_vars`.
+  build_args = {
+    python_version = each.value.python_version
+  }
 
   worker_pool_id  = module.worker_pool.id
   docker_repo_url = module.docker_registry.url


### PR DESCRIPTION
This change allows to overwrite `pytorch_git_rev` in the `artifacts.auto.tfvars`. I saw that you may want to use a different revision for pytorch.

Additionally, I cleaned up arguments passed to the Dockerfile, as only `python_version` is used. The rest of the parameters are passed to `ansible_vars` build arg, which is then passed directly to ansible.

In the diff below you can see: "pytorch_git_rev\":\"v2.1.0-rc2\", and that some build args were removed.

Terraform plan:
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.versioned_builds["r1.12_3.7_cuda_11.2"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/83d9fe75-563d-4c4d-8a20-33b09f9fdb17"
        name               = "r1-12-3-7-cuda-11-2"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args       = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.2 --build-arg=git_tag=v1.12.0 --build-arg=package_version=1.12 --build-arg=python_version=3.7 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.2\",\"git_tag\":\"v1.12.0\",\"package_version\":\"1.12\",\"python_version\":\"3.7\",\"pytorch_git_rev\":\"v1.12.0\",\"xla_git_rev\":\"v1.12.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r1.12_3.7_cuda_11.2)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.7 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.2\",\"git_tag\":\"v1.12.0\",\"package_version\":\"1.12\",\"python_version\":\"3.7\",\"pytorch_git_rev\":\"v1.12.0\",\"xla_git_rev\":\"v1.12.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r1.12_3.7_cuda_11.2)\" -t=local_image",
                ]
                id         = "build_xla_docker_image"
                name       = "gcr.io/cloud-builders/docker"
                # (5 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r1.13_3.7_cuda_11.2"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/9c7d2e24-701e-4fe4-94fe-1a5bf57a4aae"
        name               = "r1-13-3-7-cuda-11-2"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args       = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.2 --build-arg=git_tag=v1.13.0 --build-arg=package_version=1.13 --build-arg=python_version=3.7 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.2\",\"git_tag\":\"v1.13.0\",\"package_version\":\"1.13\",\"python_version\":\"3.7\",\"pytorch_git_rev\":\"v1.13.0\",\"xla_git_rev\":\"v1.13.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r1.13_3.7_cuda_11.2)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.7 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.2\",\"git_tag\":\"v1.13.0\",\"package_version\":\"1.13\",\"python_version\":\"3.7\",\"pytorch_git_rev\":\"v1.13.0\",\"xla_git_rev\":\"v1.13.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r1.13_3.7_cuda_11.2)\" -t=local_image",
                ]
                id         = "build_xla_docker_image"
                name       = "gcr.io/cloud-builders/docker"
                # (5 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r1.13_3.8_cuda_11.2"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/ebb0bce0-f86d-46bd-8064-dfcdae031d96"
        name               = "r1-13-3-8-cuda-11-2"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args       = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.2 --build-arg=git_tag=v1.13.0 --build-arg=package_version=1.13 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.2\",\"git_tag\":\"v1.13.0\",\"package_version\":\"1.13\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v1.13.0\",\"xla_git_rev\":\"v1.13.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r1.13_3.8_cuda_11.2)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.2\",\"git_tag\":\"v1.13.0\",\"package_version\":\"1.13\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v1.13.0\",\"xla_git_rev\":\"v1.13.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r1.13_3.8_cuda_11.2)\" -t=local_image",
                ]
                id         = "build_xla_docker_image"
                name       = "gcr.io/cloud-builders/docker"
                # (5 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r1.13_3.8_tpuvm"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/6c01b84d-28fb-4128-9b2a-a903298e234f"
        name               = "r1-13-3-8-tpuvm"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args       = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=tpu --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.8 --build-arg=git_tag=v1.13.0 --build-arg=package_version=1.13 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v1.13.0\",\"package_version\":\"1.13\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v1.13.0\",\"xla_git_rev\":\"v1.13.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r1.13_3.8_tpuvm)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v1.13.0\",\"package_version\":\"1.13\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v1.13.0\",\"xla_git_rev\":\"v1.13.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r1.13_3.8_tpuvm)\" -t=local_image",
                ]
                id         = "build_xla_docker_image"
                name       = "gcr.io/cloud-builders/docker"
                # (5 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r2.0_3.10_cuda_11.8"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/98c54ed4-d414-48be-a1b8-031dea702b96"
        name               = "r2-0-3-10-cuda-11-8"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args       = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.8 --build-arg=git_tag=v2.0.0 --build-arg=package_version=2.0 --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.0.0\",\"package_version\":\"2.0\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"v2.0.0\",\"xla_git_rev\":\"v2.0.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.0_3.10_cuda_11.8)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.0.0\",\"package_version\":\"2.0\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"v2.0.0\",\"xla_git_rev\":\"v2.0.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.0_3.10_cuda_11.8)\" -t=local_image",
                ]
                id         = "build_xla_docker_image"
                name       = "gcr.io/cloud-builders/docker"
                # (5 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r2.0_3.8_cuda_11.7"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/1151b31d-04c8-4dbb-b1c8-be7d0eab6fed"
        name               = "r2-0-3-8-cuda-11-7"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args       = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.7 --build-arg=git_tag=v2.0.0 --build-arg=package_version=2.0 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.7\",\"git_tag\":\"v2.0.0\",\"package_version\":\"2.0\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.0.0\",\"xla_git_rev\":\"v2.0.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.0_3.8_cuda_11.7)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.7\",\"git_tag\":\"v2.0.0\",\"package_version\":\"2.0\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.0.0\",\"xla_git_rev\":\"v2.0.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.0_3.8_cuda_11.7)\" -t=local_image",
                ]
                id         = "build_xla_docker_image"
                name       = "gcr.io/cloud-builders/docker"
                # (5 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r2.0_3.8_cuda_11.8"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/5ecbf793-5290-41d4-a99c-7055cadd06ca"
        name               = "r2-0-3-8-cuda-11-8"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args       = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.8 --build-arg=git_tag=v2.0.0 --build-arg=package_version=2.0 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.0.0\",\"package_version\":\"2.0\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.0.0\",\"xla_git_rev\":\"v2.0.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.0_3.8_cuda_11.8)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.0.0\",\"package_version\":\"2.0\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.0.0\",\"xla_git_rev\":\"v2.0.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.0_3.8_cuda_11.8)\" -t=local_image",
                ]
                id         = "build_xla_docker_image"
                name       = "gcr.io/cloud-builders/docker"
                # (5 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r2.0_3.8_tpuvm"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/200aa1c6-a7a2-4630-8715-aeff337a5da0"
        name               = "r2-0-3-8-tpuvm"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args       = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=tpu --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.8 --build-arg=git_tag=v2.0.0 --build-arg=package_version=2.0 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.0.0\",\"package_version\":\"2.0\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.0.0\",\"xla_git_rev\":\"v2.0.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.0_3.8_tpuvm)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.0.0\",\"package_version\":\"2.0\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.0.0\",\"xla_git_rev\":\"v2.0.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.0_3.8_tpuvm)\" -t=local_image",
                ]
                id         = "build_xla_docker_image"
                name       = "gcr.io/cloud-builders/docker"
                # (5 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r2.1_3.10_cuda_11.8"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/3a9c9bc6-42f8-42c0-bff3-91c00e55fd51"
        name               = "r2-1-3-10-cuda-11-8"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args       = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.8 --build-arg=git_tag=v2.1.0 --build-arg=package_version=2.1 --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"v2.1.0\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1_3.10_cuda_11.8)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"v2.1.0-rc2\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1_3.10_cuda_11.8)\" -t=local_image",
                ]
                id         = "build_xla_docker_image"
                name       = "gcr.io/cloud-builders/docker"
                # (5 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r2.1_3.10_tpuvm"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/52d653bf-ab2c-4819-90a7-9c0b5545c67c"
        name               = "r2-1-3-10-tpuvm"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args       = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=tpu --build-arg=arch=amd64 --build-arg=bundle_libtpu=0 --build-arg=cuda_version=11.8 --build-arg=git_tag=v2.1.0 --build-arg=package_version=2.1 --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"bundle_libtpu\":\"0\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"v2.1.0\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1_3.10_tpuvm)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"bundle_libtpu\":\"0\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"v2.1.0-rc2\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1_3.10_tpuvm)\" -t=local_image",
                ]
                id         = "build_xla_docker_image"
                name       = "gcr.io/cloud-builders/docker"
                # (5 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r2.1_3.8_cuda_11.8"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/a5fe77d5-41af-42db-bcf8-d95c4a1617c6"
        name               = "r2-1-3-8-cuda-11-8"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args       = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.8 --build-arg=git_tag=v2.1.0 --build-arg=package_version=2.1 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.1.0\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1_3.8_cuda_11.8)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.1.0-rc2\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1_3.8_cuda_11.8)\" -t=local_image",
                ]
                id         = "build_xla_docker_image"
                name       = "gcr.io/cloud-builders/docker"
                # (5 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r2.1_3.8_cuda_12.0"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/af81363f-2460-4bac-86eb-e412e070ee14"
        name               = "r2-1-3-8-cuda-12-0"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args       = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=cuda --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=12.0 --build-arg=git_tag=v2.1.0 --build-arg=package_version=2.1 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"12.0\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.1.0\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1_3.8_cuda_12.0)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"12.0\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.1.0-rc2\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1_3.8_cuda_12.0)\" -t=local_image",
                ]
                id         = "build_xla_docker_image"
                name       = "gcr.io/cloud-builders/docker"
                # (5 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r2.1_3.8_tpuvm"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/beb9db69-7419-48a4-97ee-48ba8d1df319"
        name               = "r2-1-3-8-tpuvm"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args       = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=accelerator=tpu --build-arg=arch=amd64 --build-arg=bundle_libtpu=1 --build-arg=cuda_version=11.8 --build-arg=git_tag=v2.1.0 --build-arg=package_version=2.1 --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.1.0\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1_3.8_tpuvm)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.1.0-rc2\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1_3.8_tpuvm)\" -t=local_image",
                ]
                id         = "build_xla_docker_image"
                name       = "gcr.io/cloud-builders/docker"
                # (5 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 13 to change, 0 to destroy.
```