### PR TITLE
Fix pip install command typo in GPU doc.

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -155,10 +155,9 @@ function run_torch_xla_tests() {
 
       # GPU tests
       if [ -x "$(command -v nvidia-smi)" ]; then
-        # These tests fail on GPU with 03/30 TF-pin update (https://github.com/pytorch/xla/pull/4840)
-        # PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
-        # PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --auto_wrap_policy type_based --use_small_fake_sample --num_epochs=1
-        # XLA_DISABLE_FUNCTIONALIZATION=1 PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
+        PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
+        PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --auto_wrap_policy type_based --use_small_fake_sample --num_epochs=1
+        XLA_DISABLE_FUNCTIONALIZATION=1 PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
         # Syncfree SGD optimizer tests
         if [ -d ./torch_xla/amp/syncfree ]; then
           echo "Running Syncfree Optimizer Test"

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -155,9 +155,10 @@ function run_torch_xla_tests() {
 
       # GPU tests
       if [ -x "$(command -v nvidia-smi)" ]; then
-        PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
-        PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --auto_wrap_policy type_based --use_small_fake_sample --num_epochs=1
-        XLA_DISABLE_FUNCTIONALIZATION=1 PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
+        # These tests fail on GPU with 03/30 TF-pin update (https://github.com/pytorch/xla/pull/4840)
+        # PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
+        # PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --auto_wrap_policy type_based --use_small_fake_sample --num_epochs=1
+        # XLA_DISABLE_FUNCTIONALIZATION=1 PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
         # Syncfree SGD optimizer tests
         if [ -d ./torch_xla/amp/syncfree ]; then
           echo "Running Syncfree Optimizer Test"

--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -51,7 +51,7 @@ Thu Dec  8 06:24:29 2022
 
 ### Wheel
 ```
-pip3 install torch=2.0
+pip3 install torch==2.0
 pip3 install https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp38-cp38-linux_x86_64.whl
 ```
 

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -27,7 +27,6 @@ def _setup_xla_flags():
       flags, (('xla_gpu_simplify_all_fp_conversions', 'false'),))
   flags = _set_missing_flags(flags,
                              (('xla_gpu_force_compilation_parallelism', '8'),))
-  flags = _set_missing_flags(flags, (('XLA_PYTHON_CLIENT_MEM_FRACTION', '0.8'),))
   os.environ['XLA_FLAGS'] = ' '.join(flags)
 
 

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -27,6 +27,7 @@ def _setup_xla_flags():
       flags, (('xla_gpu_simplify_all_fp_conversions', 'false'),))
   flags = _set_missing_flags(flags,
                              (('xla_gpu_force_compilation_parallelism', '8'),))
+  flags = _set_missing_flags(flags, (('XLA_PYTHON_CLIENT_MEM_FRACTION', '0.8'),))
   os.environ['XLA_FLAGS'] = ' '.join(flags)
 
 


### PR DESCRIPTION
Without the fix, we'd get:
```
root@f1fc43f5b53a:/# pip3 install torch=2.0

ERROR: Invalid requirement: 'torch=2.0'
Hint: = is not a valid operator. Did you mean == ?

[notice] A new release of pip is available: 23.0.1 -> 23.2.1
[notice] To update, run: pip install --upgrade pip
root@f1fc43f5b53a:/#
```