### PR TITLE
Remove `on_device_shape` and `logical_on_device_shape`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,6 +42,7 @@ http_archive(
         "//openxla_patches:f16_abi_clang.diff",
         "//openxla_patches:gpu_race_condition.diff",
         "//openxla_patches:constexpr_return.diff",
+        "//openxla_patches:pjrt_c_api_dynamic_dimensions.diff",
     ],
     strip_prefix = "xla-7a371ed44aba34f83d6d3d1159d2e6d0d327c603",
     urls = [

--- a/openxla_patches/pjrt_c_api_dynamic_dimensions.diff
+++ b/openxla_patches/pjrt_c_api_dynamic_dimensions.diff
@@ -1,0 +1,46 @@
+diff --git a/xla/pjrt/pjrt_c_api_client.cc b/xla/pjrt/pjrt_c_api_client.cc
+index 565aa2208..2278ab6c4 100644
+--- a/xla/pjrt/pjrt_c_api_client.cc
++++ b/xla/pjrt/pjrt_c_api_client.cc
+@@ -1658,6 +1658,24 @@ bool PjRtCApiBuffer::has_dynamic_dimensions() const {
+   return args.num_dynamic_dims > 0;
+ }
+ 
++
++absl::Span<const bool> PjRtCApiBuffer::is_dynamic_dimension() const {
++  PJRT_Buffer_DynamicDimensionIndices_Args args;
++  args.struct_size = PJRT_Buffer_DynamicDimensionIndices_Args_STRUCT_SIZE;
++  args.priv = nullptr;
++  args.buffer = buffer_.get();
++
++  pjrt::LogFatalIfPjrtError(
++    pjrt_c_api()->PJRT_Buffer_DynamicDimensionIndices(&args), pjrt_c_api());
++
++  absl::InlinedVector<bool, 4> dynamic_dimensions(dimensions().size());
++  for (int i = 0; i < args.num_dynamic_dims; ++i) {
++    dynamic_dimensions[args.dynamic_dim_indices[i]] = true;
++  }
++
++  return dynamic_dimensions;
++}
++
+ StatusOr<std::vector<int64_t>> PjRtCApiBuffer::logical_dimensions() {
+   PJRT_Buffer_UnpaddedDimensions_Args args;
+   args.struct_size = PJRT_Buffer_UnpaddedDimensions_Args_STRUCT_SIZE;
+diff --git a/xla/pjrt/pjrt_c_api_client.h b/xla/pjrt/pjrt_c_api_client.h
+index b2e2de349..2687b5371 100644
+--- a/xla/pjrt/pjrt_c_api_client.h
++++ b/xla/pjrt/pjrt_c_api_client.h
+@@ -379,11 +379,7 @@ class PjRtCApiBuffer : public PjRtBuffer {
+ 
+   bool has_dynamic_dimensions() const override;
+ 
+-  absl::Span<const bool> is_dynamic_dimension() const override {
+-    LOG(FATAL) << "PjRtCApiBuffer::is_dynamic_dimension() not implemented. "
+-               << "Considering using has_dynamic_dimensions() or "
+-                  "logical_dimensions() if applicable.";
+-  }
++  absl::Span<const bool> is_dynamic_dimension() const override;
+ 
+   StatusOr<std::vector<int64_t>> logical_dimensions() override;
+ 

--- a/openxla_patches/pjrt_c_api_dynamic_dimensions.diff
+++ b/openxla_patches/pjrt_c_api_dynamic_dimensions.diff
@@ -1,37 +1,55 @@
 diff --git a/xla/pjrt/pjrt_c_api_client.cc b/xla/pjrt/pjrt_c_api_client.cc
-index 565aa2208..2278ab6c4 100644
+index d45b9377c..92d244750 100644
 --- a/xla/pjrt/pjrt_c_api_client.cc
 +++ b/xla/pjrt/pjrt_c_api_client.cc
-@@ -1658,6 +1658,24 @@ bool PjRtCApiBuffer::has_dynamic_dimensions() const {
+@@ -1489,6 +1489,34 @@ bool PjRtCApiBuffer::has_dynamic_dimensions() const {
    return args.num_dynamic_dims > 0;
  }
  
-+
 +absl::Span<const bool> PjRtCApiBuffer::is_dynamic_dimension() const {
-+  PJRT_Buffer_DynamicDimensionIndices_Args args;
-+  args.struct_size = PJRT_Buffer_DynamicDimensionIndices_Args_STRUCT_SIZE;
-+  args.priv = nullptr;
-+  args.buffer = buffer_.get();
++  {
++    absl::MutexLock lock(&mu_);
++    if (!is_dynamic_dimension_.has_value()) {
++      absl::InlinedVector<bool, InlineRank()>& is_dynamic_dimension_value =
++          is_dynamic_dimension_.emplace();
++      is_dynamic_dimension_value.assign(dimensions().size(), false);
 +
-+  pjrt::LogFatalIfPjrtError(
-+    pjrt_c_api()->PJRT_Buffer_DynamicDimensionIndices(&args), pjrt_c_api());
-+
-+  absl::InlinedVector<bool, 4> dynamic_dimensions(dimensions().size());
-+  for (int i = 0; i < args.num_dynamic_dims; ++i) {
-+    dynamic_dimensions[args.dynamic_dim_indices[i]] = true;
++      PJRT_Buffer_DynamicDimensionIndices_Args args;
++      args.struct_size = PJRT_Buffer_DynamicDimensionIndices_Args_STRUCT_SIZE;
++      args.priv = nullptr;
++      args.buffer = buffer_.get();
++      const PJRT_Api* api = pjrt_c_api();
++      std::unique_ptr<PJRT_Error, pjrt::PJRT_ErrorDeleter> error(
++          api->PJRT_Buffer_DynamicDimensionIndices(&args),
++          pjrt::MakeErrorDeleter(api));
++      if (error && pjrt::GetErrorCode(error.get(), api) ==
++                       PJRT_Error_Code_UNIMPLEMENTED) {
++        return *is_dynamic_dimension_;
++      }
++      for (int i = 0; i < args.num_dynamic_dims; ++i) {
++        is_dynamic_dimension_value[args.dynamic_dim_indices[i]] = true;
++      }
++    }
 +  }
-+
-+  return dynamic_dimensions;
++  return *is_dynamic_dimension_;
 +}
 +
  StatusOr<std::vector<int64_t>> PjRtCApiBuffer::logical_dimensions() {
    PJRT_Buffer_UnpaddedDimensions_Args args;
    args.struct_size = PJRT_Buffer_UnpaddedDimensions_Args_STRUCT_SIZE;
 diff --git a/xla/pjrt/pjrt_c_api_client.h b/xla/pjrt/pjrt_c_api_client.h
-index b2e2de349..2687b5371 100644
+index b9597f923..5101b09a9 100644
 --- a/xla/pjrt/pjrt_c_api_client.h
 +++ b/xla/pjrt/pjrt_c_api_client.h
-@@ -379,11 +379,7 @@ class PjRtCApiBuffer : public PjRtBuffer {
+@@ -23,6 +23,7 @@ limitations under the License.
+ #include <utility>
+ #include <vector>
+ 
++#include "absl/container/inlined_vector.h"
+ #include "xla/pjrt/c/pjrt_c_api.h"
+ #include "xla/pjrt/c/pjrt_c_api_helpers.h"
+ #include "xla/pjrt/pjrt_client.h"
+@@ -320,11 +321,7 @@ class PjRtCApiBuffer : public PjRtBuffer {
  
    bool has_dynamic_dimensions() const override;
  
@@ -44,3 +62,13 @@ index b2e2de349..2687b5371 100644
  
    StatusOr<std::vector<int64_t>> logical_dimensions() override;
  
+@@ -407,6 +404,9 @@ class PjRtCApiBuffer : public PjRtBuffer {
+   std::shared_ptr<PjRtFuture<Status>::Promise> readiness_promise_;
+   // Set and cached the first time layout() is called.
+   mutable std::optional<xla::Layout> layout_;
++  // Set and cached the first time is_dynamic_dimension() is called.
++  mutable std::optional<absl::InlinedVector<bool, InlineRank()>>
++      is_dynamic_dimension_;
+   // Used to synchronize concurrent setting of cached values.
+   mutable absl::Mutex mu_;
+ };

--- a/openxla_patches/pjrt_c_api_dynamic_dimensions.diff
+++ b/openxla_patches/pjrt_c_api_dynamic_dimensions.diff
@@ -1,8 +1,8 @@
 diff --git a/xla/pjrt/pjrt_c_api_client.cc b/xla/pjrt/pjrt_c_api_client.cc
-index d45b9377c..92d244750 100644
+index ef0b6686c..c0341e81e 100644
 --- a/xla/pjrt/pjrt_c_api_client.cc
 +++ b/xla/pjrt/pjrt_c_api_client.cc
-@@ -1489,6 +1489,34 @@ bool PjRtCApiBuffer::has_dynamic_dimensions() const {
+@@ -1584,6 +1584,34 @@ bool PjRtCApiBuffer::has_dynamic_dimensions() const {
    return args.num_dynamic_dims > 0;
  }
  
@@ -38,18 +38,18 @@ index d45b9377c..92d244750 100644
    PJRT_Buffer_UnpaddedDimensions_Args args;
    args.struct_size = PJRT_Buffer_UnpaddedDimensions_Args_STRUCT_SIZE;
 diff --git a/xla/pjrt/pjrt_c_api_client.h b/xla/pjrt/pjrt_c_api_client.h
-index b9597f923..5101b09a9 100644
+index 9c460f246..279608e60 100644
 --- a/xla/pjrt/pjrt_c_api_client.h
 +++ b/xla/pjrt/pjrt_c_api_client.h
-@@ -23,6 +23,7 @@ limitations under the License.
- #include <utility>
+@@ -27,6 +27,7 @@ limitations under the License.
  #include <vector>
  
+ #include "absl/container/flat_hash_map.h"
 +#include "absl/container/inlined_vector.h"
- #include "xla/pjrt/c/pjrt_c_api.h"
- #include "xla/pjrt/c/pjrt_c_api_helpers.h"
- #include "xla/pjrt/pjrt_client.h"
-@@ -320,11 +321,7 @@ class PjRtCApiBuffer : public PjRtBuffer {
+ #include "absl/log/check.h"
+ #include "absl/log/log.h"
+ #include "absl/strings/string_view.h"
+@@ -369,11 +370,7 @@ class PjRtCApiBuffer : public PjRtBuffer {
  
    bool has_dynamic_dimensions() const override;
  
@@ -62,7 +62,7 @@ index b9597f923..5101b09a9 100644
  
    StatusOr<std::vector<int64_t>> logical_dimensions() override;
  
-@@ -407,6 +404,9 @@ class PjRtCApiBuffer : public PjRtBuffer {
+@@ -455,6 +452,9 @@ class PjRtCApiBuffer : public PjRtBuffer {
    std::shared_ptr<PjRtFuture<Status>::Promise> readiness_promise_;
    // Set and cached the first time layout() is called.
    mutable std::optional<xla::Layout> layout_;

--- a/openxla_patches/pjrt_c_api_dynamic_dimensions.diff
+++ b/openxla_patches/pjrt_c_api_dynamic_dimensions.diff
@@ -1,3 +1,5 @@
+# Partial backport of 6308dba2903e78961ac4122f361bc91b09f36891. Remove in next
+# pin update.
 diff --git a/xla/pjrt/pjrt_c_api_client.cc b/xla/pjrt/pjrt_c_api_client.cc
 index ef0b6686c..c0341e81e 100644
 --- a/xla/pjrt/pjrt_c_api_client.cc

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -164,6 +164,12 @@ class PjRtComputationClient : public ComputationClient {
              std::shared_ptr<xla::PjRtBuffer> buffer)
         : Data(std::move(device), std::move(device_shape)), buffer(buffer) {}
 
+    PjRtData(std::string device, std::shared_ptr<xla::PjRtBuffer> buffer)
+        : Data(std::move(device),
+               xla::Shape(buffer->element_type(), buffer->dimensions(),
+                          buffer->is_dynamic_dimension(), {})),
+          buffer(buffer) {}
+
     OpaqueHandle GetOpaqueHandle() override {
       XLA_CHECK(HasValue())
           << "buffer with shape " << shape().ToString() << " on device "


### PR DESCRIPTION
These were removed from the PJRT C API client recently in this commit: https://github.com/tensorflow/tensorflow/commit/840633cb23ae111075999514484fd5416f0cef83

Instead, we can rebuild the shapes from the decomposed components. In the future, we should see if we can remove `Shape` from `ComputationClient::Data` entirely in favor of `dimensions`, `layout`, etc.