### PR TITLE
Make cpu tensor on XLA dynamo backend a warning instead of error

### DIFF
--- a/torch_xla/core/dynamo_bridge.py
+++ b/torch_xla/core/dynamo_bridge.py
@@ -1,6 +1,7 @@
 import copy
 import dataclasses
 import operator
+import warnings
 
 import functools
 import itertools
@@ -457,8 +458,10 @@ def extract_compiled_graph(xla_model: torch.fx.GraphModule, xla_args):
 
   for xla_arg in xla_args:
     if xla_arg.device.type != 'xla':
-      raise RuntimeError(
-          'For openxla dynamo backend, please move all tensors to XLA device')
+      warnings.warn(
+          "Found tensor with shape " + str(xla_arg.size()) + " on " +
+          str(xla_arg.device) +
+          ". Please move all tensors to xla device to execute on XLA device.")
 
   cloned_args = [
       torch.clone(xla_arg) if isinstance(xla_arg, torch.Tensor) else xla_arg


### PR DESCRIPTION
Logic in fallback partitioner(https://github.com/pytorch/xla/blob/f38e4a5079b27f29ad6af71d8f0be54648439ba8/torch_xla/core/dynamo_bridge.py#L424-L426) actually can handle the non-xla tensor. Instead of throwing a runtime error, it is better to throw a warning. 

I run into this when trying to enable the HF stablediffusion with HF, there is one place it hardcoded a CPU tensor. Instead of raising a runtime error, let partitioner fallback is a better UX I think. Will need to backport this change to the release branch. 