### PR TITLE
Add upstream PyTorch dependency to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -341,6 +341,7 @@ setup(
         BazelExtension('//:_XLAC.so'),
     ],
     install_requires=[
+        'torch~=2.1.0',
         'absl-py>=1.0.0',
         'cloud-tpu-client>=0.10.0',
         'pyyaml',


### PR DESCRIPTION
Tested with RC builds from this thread: https://dev-discuss.pytorch.org/t/pytorch-2-1-rc1-is-produced-for-pytorch-vision-and-audio/1479

When PyTorch and PT/XLA are released on PyPI, we will be able to install both with `pip install torch_xla`.