### PR TITLE
Change `pjrt://` init method to `xla://`

### DIFF
--- a/test/pjrt/test_ddp.py
+++ b/test/pjrt/test_ddp.py
@@ -6,7 +6,7 @@ import torch.distributed as dist
 import torch.nn as nn
 from torch.nn.parallel import DistributedDataParallel as DDP
 import torch_xla.core.xla_model as xm
-import torch_xla.experimental.pjrt_backend
+import torch_xla.distributed.xla_backend
 from torch_xla import runtime as xr
 from torch_xla._internal import pjrt, tpu
 
@@ -24,7 +24,7 @@ class TestPjRtDistributedDataParallel(parameterized.TestCase):
 
   @staticmethod
   def _ddp_init(index: int = ...):
-    dist.init_process_group('xla', init_method='pjrt://')
+    dist.init_process_group('xla', init_method='xla://')
     device = xm.xla_device()
     model = nn.Linear(10, 10).to(device)
     ddp_model = DDP(model)
@@ -41,7 +41,7 @@ class TestPjRtDistributedDataParallel(parameterized.TestCase):
   def test_ddp_correctness(self, use_large_net: bool):
     pjrt.run_multiprocess(
         util.ddp_correctness,
-        init_method='pjrt://',
+        init_method='xla://',
         use_large_net=use_large_net,
         debug=FLAGS.debug)
 

--- a/test/pjrt/test_torchrun.py
+++ b/test/pjrt/test_torchrun.py
@@ -3,7 +3,7 @@ from absl import logging
 import torch
 import torch.distributed as dist
 import torch_xla.core.xla_model as xm
-import torch_xla.experimental.pjrt_backend
+import torch_xla.distributed.xla_backend
 import torch_xla.runtime as xr
 import torch_xla.utils.utils as xu
 
@@ -11,7 +11,7 @@ import torch_xla.utils.utils as xu
 class TestTorchrun(absltest.TestCase):
 
   def test_all_gather(self):
-    dist.init_process_group('xla', init_method='pjrt://')
+    dist.init_process_group('xla', init_method='xla://')
 
     dist_world_size = xu.getenv_as('WORLD_SIZE', int)
     devices_per_thread = xr.addressable_device_count()

--- a/test/test_torch_distributed_xla_backend.py
+++ b/test/test_torch_distributed_xla_backend.py
@@ -10,7 +10,6 @@ import torch.distributed as dist
 import torch_xla
 import torch_xla.core.xla_model as xm
 import torch_xla.distributed.xla_backend
-import torch_xla.experimental.pjrt_backend
 from torch_xla import runtime as xr
 
 
@@ -42,7 +41,7 @@ class XlaBackendTest(parameterized.TestCase):
   def setUpClass(cls):
     # Add no-op all-reduce ops to HLO
     os.environ['XLA_ALWAYS_ALLREDUCE'] = '1'
-    dist.init_process_group('xla', init_method='pjrt://')
+    dist.init_process_group('xla', init_method='xla://')
 
   def tearDown(self) -> None:
     # Purge all computations attached the device.

--- a/test/test_train_mp_imagenet.py
+++ b/test/test_train_mp_imagenet.py
@@ -31,7 +31,7 @@ MODEL_OPTS = {
     '--ddp': {
         'action': 'store_true',
     },
-    # Use pjrt:// init_method instead of env:// for `torch.distributed`.
+    # Use xla:// init_method instead of env:// for `torch.distributed`.
     # Required for DDP on TPU v2/v3 when using PJRT.
     '--pjrt_distributed': {
         'action': 'store_true',
@@ -180,8 +180,7 @@ def _train_update(device, step, loss, tracker, epoch, writer):
 
 def train_imagenet():
   if FLAGS.pjrt_distributed:
-    import torch_xla.experimental.pjrt_backend
-    dist.init_process_group('xla', init_method='pjrt://')
+    dist.init_process_group('xla', init_method='xla://')
   elif FLAGS.ddp:
     dist.init_process_group(
         'xla', world_size=xm.xrt_world_size(), rank=xm.get_ordinal())

--- a/test/test_train_mp_mnist.py
+++ b/test/test_train_mp_mnist.py
@@ -77,8 +77,7 @@ def _train_update(device, step, loss, tracker, epoch, writer):
 
 def train_mnist(flags, **kwargs):
   if flags.pjrt_distributed:
-    import torch_xla.experimental.pjrt_backend
-    dist.init_process_group('xla', init_method='pjrt://')
+    dist.init_process_group('xla', init_method='xla://')
   elif flags.ddp:
     dist.init_process_group(
         'xla', world_size=xm.xrt_world_size(), rank=xm.get_ordinal())

--- a/torch_xla/_internal/rendezvous.py
+++ b/torch_xla/_internal/rendezvous.py
@@ -1,0 +1,47 @@
+import datetime
+import logging
+import threading
+
+import torch.distributed as dist
+from torch_xla.distributed import xla_backend
+from torch_xla import runtime as xr
+from torch_xla._internal import pjrt
+from torch_xla._internal import tpu
+import torch_xla.utils.utils as xu
+
+_store = None
+_store_lock = threading.Lock()
+
+
+def pjrt_rendezvous_handler(url: str,
+                            timeout: datetime.timedelta = ...,
+                            **kwargs):
+  # Assume `xmp.spawn` has not been called when using torchrun
+  if dist.is_torchelastic_launched():
+    local_world_size = xu.getenv_as('LOCAL_WORLD_SIZE', int)
+    local_rank = xu.getenv_as('LOCAL_RANK', int)
+    pjrt.initialize_multiprocess(local_rank, local_world_size)
+
+  master_ip = xu.getenv_as('MASTER_ADDR', str)
+  if not master_ip:
+    master_ip = tpu.discover_master_worker_ip() if xr.device_type(
+    ) == 'TPU' else 'localhost'
+
+  master_port = xu.getenv_as('MASTER_PORT', int, 12355)
+  world_size = xr.world_size()
+  with _store_lock:
+    global _store
+    if not _store:
+      if xu.getenv_as('TORCHELASTIC_USE_AGENT_STORE', str) == 'True':
+        attempt = xu.getenv_as('TORCHELASTIC_RESTART_COUNT', int, defval=0)
+        tcp_store = dist.TCPStore(
+            master_ip, master_port, xr.process_count(), is_master=False)
+        _store = dist.PrefixStore(f"/worker/attempt_{attempt}", tcp_store)
+      else:
+        _store = dist.TCPStore(
+            master_ip,
+            master_port,
+            xr.process_count(),
+            is_master=xr.process_index() == 0)
+
+  yield (_store, xr.global_ordinal(), world_size)

--- a/torch_xla/distributed/xla_backend.py
+++ b/torch_xla/distributed/xla_backend.py
@@ -1,6 +1,7 @@
 import torch
 import torch.distributed as dist
 import torch_xla.core.xla_model as xm
+from torch_xla._internal import rendezvous
 import logging
 import os
 from torch._C._distributed_c10d import ProcessGroup
@@ -15,6 +16,8 @@ def _register_xla_backend():
 
 
 _register_xla_backend()
+
+dist.register_rendezvous_handler('xla', rendezvous.pjrt_rendezvous_handler)
 
 
 def _ret_work(ret):

--- a/torch_xla/experimental/pjrt_backend.py
+++ b/torch_xla/experimental/pjrt_backend.py
@@ -1,51 +1,9 @@
-import datetime
 import logging
-import threading
 
 import torch.distributed as dist
 from torch_xla.distributed import xla_backend
-from torch_xla import runtime as xr
-from torch_xla._internal import pjrt
+from torch_xla._internal import rendezvous
 from torch_xla._internal import tpu
-import torch_xla.utils.utils as xu
-
-_store = None
-_store_lock = threading.Lock()
-
-
-def _pjrt_rendezvous_handler(url: str,
-                             timeout: datetime.timedelta = ...,
-                             **kwargs):
-  # Assume `xmp.spawn` has not been called when using torchrun
-  if dist.is_torchelastic_launched():
-    local_world_size = xu.getenv_as('LOCAL_WORLD_SIZE', int)
-    local_rank = xu.getenv_as('LOCAL_RANK', int)
-    pjrt.initialize_multiprocess(local_rank, local_world_size)
-
-  master_ip = xu.getenv_as('MASTER_ADDR', str)
-  if not master_ip:
-    master_ip = tpu.discover_master_worker_ip() if xr.device_type(
-    ) == 'TPU' else 'localhost'
-
-  master_port = xu.getenv_as('MASTER_PORT', int, 12355)
-  world_size = xr.world_size()
-  with _store_lock:
-    global _store
-    if not _store:
-      if xu.getenv_as('TORCHELASTIC_USE_AGENT_STORE', str) == 'True':
-        attempt = xu.getenv_as('TORCHELASTIC_RESTART_COUNT', int, defval=0)
-        tcp_store = dist.TCPStore(
-            master_ip, master_port, xr.process_count(), is_master=False)
-        _store = dist.PrefixStore(f"/worker/attempt_{attempt}", tcp_store)
-      else:
-        _store = dist.TCPStore(
-            master_ip,
-            master_port,
-            xr.process_count(),
-            is_master=xr.process_index() == 0)
-
-  yield (_store, xr.global_ordinal(), world_size)
-
 
 if tpu.num_available_chips() > 0 and tpu.version() <= 3:
   from torch.testing._internal.distributed import multi_threaded_pg
@@ -54,4 +12,4 @@ if tpu.num_available_chips() > 0 and tpu.version() <= 3:
                   'and does not support torchrun.')
   multi_threaded_pg._install_threaded_pg()
 
-dist.register_rendezvous_handler('pjrt', _pjrt_rendezvous_handler)
+dist.register_rendezvous_handler('pjrt', rendezvous.pjrt_rendezvous_handler)

--- a/torch_xla/runtime.py
+++ b/torch_xla/runtime.py
@@ -8,7 +8,6 @@ import torch
 import torch_xla
 import torch_xla.core.xla_env_vars as xenv
 import torch_xla.core.xla_model as xm
-import torch_xla.distributed.xla_backend
 import torch_xla.utils.utils as xu
 import torch_xla._internal.tpu as tpu
 


### PR DESCRIPTION
- Rename `pjrt://` init method to `xla://`
- Register `xla://` init method with `xla` backend to save the user an import statement
- Experimental `pjrt_backend` package will remain and register the old `pjrt://` name for compatibility
  - Experimental package will also keep hack for TPU v2/v3. This will not move into stable API