### PR TITLE
Add bundled libtpu build for Python 3.10

### DIFF
--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -61,6 +61,7 @@ versioned_builds = [
     package_version = "2.1.0rc2+libtpu"
     accelerator     = "tpu"
     python_version  = "3.10"
+    bundle_libtpu   = "1"
   },
   {
     git_tag         = "v2.0.0"

--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -45,6 +45,7 @@ versioned_builds = [
     pytorch_git_rev = "v2.1.0-rc2"
     package_version = "2.1.0rc2"
     accelerator     = "tpu"
+    bundle_libtpu   = "0"
   },
   {
     git_tag         = "v2.1.0"
@@ -53,6 +54,13 @@ versioned_builds = [
     accelerator     = "tpu"
     python_version  = "3.10"
     bundle_libtpu   = "0"
+  },
+  {
+    git_tag         = "v2.1.0"
+    pytorch_git_rev = "v2.1.0-rc2"
+    package_version = "2.1.0rc2+libtpu"
+    accelerator     = "tpu"
+    python_version  = "3.10"
   },
   {
     git_tag         = "v2.0.0"

--- a/infra/tpu-pytorch-releases/artifacts_builds.tf
+++ b/infra/tpu-pytorch-releases/artifacts_builds.tf
@@ -69,7 +69,7 @@ locals {
   versioned_builds_dict = {
     for b in var.versioned_builds :
     format("r%s_%s_%s",
-      b.package_version,
+      replace(b.package_version, "+", "_"),
       b.python_version,
       b.accelerator == "tpu" ? "tpuvm" : format("cuda_%s", b.cuda_version)
     ) => b


### PR DESCRIPTION
We can use the bundled build for Kaggle.

Unbundle libtpu from the Python 3.8 build so we can upload it to PyPI too if needed.

Terraform plan:

<details>

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # module.versioned_builds["r2.1.0rc2_3.8_tpuvm"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch-releases/locations/us-central1/triggers/48c1edce-2097-4d5b-87bf-c3a9f662584a"
        name               = "r2-1-0rc2-3-8-tpuvm"
        tags               = []
        # (10 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1.0rc2\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.1.0-rc2\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1.0rc2_3.8_tpuvm)\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"bundle_libtpu\":\"0\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1.0rc2\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"v2.1.0-rc2\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1.0rc2_3.8_tpuvm)\" -t=local_image",
                ]
                id               = "build_xla_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.versioned_builds["r2.1.0rc2_libtpu_3.10_tpuvm"].module.cloud_build.google_cloudbuild_trigger.trigger will be created
  + resource "google_cloudbuild_trigger" "trigger" {
      + create_time        = (known after apply)
      + description        = "Builds official xla:r2.1.0rc2_libtpu_3.10_tpuvm' TPU docker image and corresponding wheels for PyTorch/XLA. Trigger managed by Terraform setup in infra/tpu-pytorch-releases/artifacts_builds.tf."
      + id                 = (known after apply)
      + include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
      + included_files     = []
      + location           = "us-central1"
      + name               = "r2-1-0rc2-libtpu-3-10-tpuvm"
      + project            = (known after apply)
      + trigger_id         = (known after apply)

      + approval_config {
          + approval_required = (known after apply)
        }

      + build {
          + timeout = "21600s"

          + options {
              + dynamic_substitutions = true
              + substitution_option   = "ALLOW_LOOSE"
              + worker_pool           = "projects/tpu-pytorch-releases/locations/us-central1/workerPools/main"
            }

          + step {
              + args = [
                  + "fetch",
                  + "--unshallow",
                ]
              + id   = "git_fetch"
              + name = "gcr.io/cloud-builders/git"
            }
          + step {
              + args = [
                  + "checkout",
                  + "$COMMIT_SHA",
                ]
              + id   = "git_checkout"
              + name = "gcr.io/cloud-builders/git"
            }
          + step {
              + args       = [
                  + "-c",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"bundle_libtpu\":\"1\",\"cuda_version\":\"11.8\",\"git_tag\":\"v2.1.0\",\"package_version\":\"2.1.0rc2+libtpu\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"v2.1.0-rc2\",\"xla_git_rev\":\"v2.1.0\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1.0rc2_libtpu_3.10_tpuvm)\" -t=local_image",
                ]
              + dir        = "infra/ansible"
              + entrypoint = "bash"
              + id         = "build_xla_docker_image"
              + name       = "gcr.io/cloud-builders/docker"
            }
          + step {
              + args       = [
                  + "-c",
                  + "docker push --all-tags us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla",
                ]
              + entrypoint = "bash"
              + id         = "push_xla_docker_image"
              + name       = "gcr.io/cloud-builders/docker"
            }
          + step {
              + args       = [
                  + "-c",
                  + "echo The following wheels will be published && ls /dist/*.whl && cp /dist/*.whl /wheels",
                ]
              + entrypoint = "bash"
              + id         = "copy_wheels_to_volume"
              + name       = "local_image"

              + volumes {
                  + name = "wheels"
                  + path = "/wheels"
                }
            }
          + step {
              + args       = [
                  + "-c",
                  + "gsutil cp /wheels/*.whl gs://pytorch-xla-releases/wheels/tpuvm",
                ]
              + entrypoint = "bash"
              + id         = "upload_wheels_to_storage_bucket"
              + name       = "gcr.io/cloud-builders/gsutil"

              + volumes {
                  + name = "wheels"
                  + path = "/wheels"
                }
            }
        }

      + github {
          + name  = "xla"
          + owner = "pytorch"

          + push {
              + tag = "^v2.1.0$"
            }
        }
    }

Plan: 1 to add, 1 to change, 0 to destroy.
```
</details>