### PR TITLE
Support for mulit-hop input output aliases.

### DIFF
--- a/test/test_input_output_aliases.py
+++ b/test/test_input_output_aliases.py
@@ -28,6 +28,7 @@ class InputOutputAliasesTest(unittest.TestCase):
     # check in place op aliasing.
     t3 = t1 + t2
     t1 *= 2.0
+    t1 *= 2.0
     t2 += 2.0
     xm.mark_step()
 

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2396,7 +2396,11 @@ void XLANativeFunctions::_propagate_xla_data(const at::Tensor& input,
   // 1) Aid XLA's InputOutputAlias.
   auto input_tensor = bridge::GetXlaTensor(input);
   auto output_tensor = bridge::GetXlaTensor(output);
-  output_tensor->data()->alias_id = input_tensor->GetUniqueId();
+  if (input_tensor->CurrentIrValue()->op() == xla_device_data) {
+    output_tensor->data()->alias_id = input_tensor->GetUniqueId();
+  } else {
+    output_tensor->data()->alias_id = input_tensor->data()->alias_id;
+  }
 
   // 2) Aid SPMD.
   if (input_tensor->sharding_spec()) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -33,6 +33,7 @@
 #include "torch_xla/csrc/ops/unselect.h"
 #include "torch_xla/csrc/ops/update_slice.h"
 #include "torch_xla/csrc/ops/view.h"
+#include "torch_xla/csrc/ops/xla_ops.h"
 #include "torch_xla/csrc/pooling.h"
 #include "torch_xla/csrc/runtime/debug_macros.h"
 #include "torch_xla/csrc/runtime/metrics.h"


### PR DESCRIPTION
For in-place operations, XLA utilizes InputOutputAlias to reuse buffers for inputs and outputs. However, the current implementation only allows reusing buffers for a single in-place operation. If a tensor undergoes multiple in-place operations, only the inputs and outputs of the last operation can reuse buffers, while previous in-place operations cannot. The goal of this commit is to allow multiple in-place operations to reuse a single buffer, thereby reducing memory usage.

cc @JackCaoG @bdhirsh 