### PR TITLE
Enable xla:gpu autocast for bfloat16 if not restricted

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -44,7 +44,7 @@ jobs:
     with:
       docker-image: ${{ needs.build.outputs.docker-image }}
       runner: linux.8xlarge.nvidia.gpu
-      timeout-minutes: 240
+      timeout-minutes: 300
       disable-xrt: 1
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}

--- a/test/spmd/test_xla_spmd_python_api_interaction.py
+++ b/test/spmd/test_xla_spmd_python_api_interaction.py
@@ -6,6 +6,7 @@ import torch
 import torch_xla
 import torch_xla.core.xla_model as xm
 from torch_xla import runtime as xr
+from torch_xla.amp import autocast
 
 import test_xla_sharding_base
 
@@ -110,6 +111,20 @@ class BasicRuntimeAPITest(test_xla_sharding_base.XlaShardingTest):
     self.assertFalse(xr.is_spmd())
     # reset for other test cases
     os.environ["XLA_USE_SPMD"] = "1"
+
+  @unittest.skipIf(xr.device_type() not in ['GPU', 'TPU'], f"TPU/GPU autocast test.")
+  def test_xla_autocast_api(self):
+    device = xm.xla_device()
+    t1 = torch.ones([2,3], device=device, dtype=torch.float32)
+    t2 = torch.ones([3,2], device=device, dtype=torch.float32)
+    with autocast(device, dtype=torch.bfloat16):
+      t3 = torch.matmul(t1, t2)
+
+    if xm.get_xla_supported_devices("GPU"):
+      # TODO(yeounoh) update when we support bfloat16 for XLA:GPU
+      self.assertTrue(t3.dtype == torch.float16)
+    elif xm.get_xla_supported_devices("TPU"):
+      self.assertTrue(t3.dtype == torch.bfloat16)
 
 
 if __name__ == '__main__':

--- a/test/spmd/test_xla_spmd_python_api_interaction.py
+++ b/test/spmd/test_xla_spmd_python_api_interaction.py
@@ -117,22 +117,18 @@ class BasicAutocastAPITest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    try:
-      torch.tensor([1.], dtype=torch.bfloat16, device=xm.xla_device())
-      cls.is_bf16_supported = True
-    except Exception as e:
-      cls.is_bf16_supported = False
     xr.use_spmd()
     super().setUpClass()
 
-  @unittest.skipIf(xr.device_type() not in ['GPU', 'TPU'], f"TPU/GPU autocast test.")
+  @unittest.skipIf(xr.device_type() not in ['GPU', 'TPU'],
+                   f"TPU/GPU autocast test.")
   def test_xla_autocast_api(self):
     device = xm.xla_device()
-    t1 = torch.ones([2,3], device=device, dtype=torch.float32)
-    t2 = torch.ones([3,2], device=device, dtype=torch.float32)
+    t1 = torch.ones([2, 3], device=device, dtype=torch.float32)
+    t2 = torch.ones([3, 2], device=device, dtype=torch.float32)
     with autocast(device, dtype=torch.bfloat16):
       t3 = torch.matmul(t1, t2)
-    expected_dtype = torch.bfloat16 if self.is_bf16_supported else torch.float16
+    expected_dtype = torch.bfloat16 if xr.is_bf16_supported() else torch.float16
     self.assertTrue(t3.dtype == expected_dtype)
 
 

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -301,7 +301,7 @@ class TestAutocastCuda(TestAutocastBase):
 
   def setUp(self):
     super(TestAutocastCuda, self).setUp()
-    self.is_autocast_enabled = torch.is_autocast_enabled
+    self.is_autocast_enabled = torch.is_autocast_xla_enabled
     self.autocast_lists = AutocastTestLists(torch.device(xm.xla_device()))
     self.autocast_unsupported_lists = AutocastCudaTestUnsupportedLists()
 

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -334,6 +334,14 @@ class TestAutocastCuda(TestAutocastBase):
       self._run_autocast_outofplace(
           op, args, torch.float32, add_kwargs=maybe_kwargs)
 
+  def test_autocast_torch_bf16(self):
+    for op_with_args in self.get_autocast_list('torch_bf16'):
+      op, args, maybe_kwargs = self.args_maybe_kwargs(op_with_args)
+      # TODO(yeounoh) update the tests when we support bfloat16 for XLA:GPU
+      self._run_autocast_outofplace(
+          op, args, torch.float16, add_kwargs=maybe_kwargs)
+
+
   def test_autocast_torch_need_autocast_promote(self):
     for op, args in self.get_autocast_list('torch_need_autocast_promote'):
       self._run_autocast_outofplace(op, args, torch.float32)

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -296,8 +296,8 @@ class TestAutocastBase(unittest.TestCase):
     self.assertFalse(self.is_autocast_enabled())
 
 
-@unittest.skipIf(not xm.get_xla_supported_devices("TPU")
-                 and not xm.get_xla_supported_devices("GPU"), f"XLA autocast test.")
+@unittest.skipIf(not xm.get_xla_supported_devices("TPU") and
+                 not xm.get_xla_supported_devices("GPU"), f"XLA autocast test.")
 class TestAutocastXLA(TestAutocastBase):
 
   def setUp(self):

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -296,75 +296,12 @@ class TestAutocastBase(unittest.TestCase):
     self.assertFalse(self.is_autocast_enabled())
 
 
-@unittest.skipIf(not xm.get_xla_supported_devices("GPU"), f"GPU autocast test.")
-class TestAutocastCuda(TestAutocastBase):
+@unittest.skipIf(not xm.get_xla_supported_devices("TPU")
+                 and not xm.get_xla_supported_devices("GPU"), f"XLA autocast test.")
+class TestAutocastXLA(TestAutocastBase):
 
   def setUp(self):
-    super(TestAutocastCuda, self).setUp()
-    self.is_autocast_enabled = torch.is_autocast_xla_enabled
-    self.autocast_lists = AutocastTestLists(torch.device(xm.xla_device()))
-    self.autocast_unsupported_lists = AutocastCudaTestUnsupportedLists()
-
-  def test_autocast_nn_fp16(self):
-    with torch.backends.cudnn.flags(enabled=True, deterministic=True):
-      for op, args in self.get_autocast_list('nn_fp16'):
-        self._run_autocast_outofplace(
-            op, args, torch.float16, module=torch._C._nn)
-
-  def test_autocast_linalg_fp16(self):
-    with torch.backends.cudnn.flags(enabled=True, deterministic=True):
-      for op, args in self.get_autocast_list('linalg_fp16'):
-        self._run_autocast_outofplace(
-            op, args, torch.float16, module=torch._C._linalg)
-
-  def test_autocast_methods_fp16(self):
-    with torch.backends.cudnn.flags(enabled=True, deterministic=True):
-      for op, args in self.get_autocast_list('methods_fp16'):
-        self._run_autocast_outofplace(op, args, torch.float16, module=None)
-
-  def test_autocast_banned(self):
-    with torch.cuda.amp.autocast():
-      for op, args, module in self.get_autocast_list('banned'):
-        with self.assertRaises(RuntimeError):
-          getattr(module, op)(*args)
-
-  def test_autocast_torch_fp32(self):
-    for op_with_args in self.get_autocast_list('torch_fp32'):
-      op, args, maybe_kwargs = self.args_maybe_kwargs(op_with_args)
-      self._run_autocast_outofplace(
-          op, args, torch.float32, add_kwargs=maybe_kwargs)
-
-  def test_autocast_torch_need_autocast_promote(self):
-    for op, args in self.get_autocast_list('torch_need_autocast_promote'):
-      self._run_autocast_outofplace(op, args, torch.float32)
-
-  def test_autocast_torch_expect_builtin_promote(self):
-    for op, args, out_type in self.get_autocast_list(
-        'torch_expect_builtin_promote'):
-      self._run_autocast_outofplace(op, args, torch.float32, out_type=out_type)
-
-  def test_autocast_nn_fp32(self):
-    for op, args in self.get_autocast_list('nn_fp32'):
-      self._run_autocast_outofplace(
-          op, args, torch.float32, module=torch._C._nn)
-
-  def test_autocast_methods_fp32(self):
-    for op, args in self.get_autocast_list('methods_fp32'):
-      print("autocast fp32", op)
-      self._run_autocast_outofplace(op, args, torch.float32, module=None)
-
-  def test_autocast_methods_expect_builtin_promote(self):
-    for op, args, out_type in self.get_autocast_list(
-        'methods_expect_builtin_promote'):
-      self._run_autocast_outofplace(
-          op, args, torch.float32, module=None, out_type=out_type)
-
-
-@unittest.skipIf(not xm.get_xla_supported_devices("TPU"), f"TPU autocast test.")
-class TestAutocastTPU(TestAutocastBase):
-
-  def setUp(self):
-    super(TestAutocastTPU, self).setUp()
+    super(TestAutocastXLA, self).setUp()
     self.is_autocast_enabled = torch.is_autocast_xla_enabled
     self.autocast_lists = AutocastTPUTestLists(torch.device(xm.xla_device()))
 

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -170,7 +170,7 @@ class AutocastCudaTestExtraLists(object):
 
     element0_fp32 = (torch.randn(1, dtype=torch.float32, device=dev),)
 
-    # This is currently not part of AutocastTestLists and excludes `relu`
+    # This is currently not part of AutocastTestLists and excludes `relu`, `addbmm`
     self.torch_bf16 = [
         ("conv1d", conv_args_fp32[0]),
         ("conv2d", conv_args_fp32[1]),
@@ -183,9 +183,6 @@ class AutocastCudaTestExtraLists(object):
                      torch.randn((n, n, n), device=dev, dtype=torch.float32),
                      torch.randn((n, n, n), device=dev, dtype=torch.float32))),
         ("addmm", mat1_fp32 + mat2_fp32 + mat3_fp32),
-        ("addbmm",
-         mat0_fp32 + (torch.randn((n, n, n), device=dev, dtype=torch.float32),
-                      torch.randn((n, n, n), device=dev, dtype=torch.float32))),
         ("conv_tbc", (torch.randn((10, 7, 3), device=dev, dtype=torch.float32),
                       torch.randn((5, 3, 5), device=dev, dtype=torch.float32),
                       torch.randn(5, device=dev, dtype=torch.float32), 0)),

--- a/torch_xla/amp/autocast_mode.py
+++ b/torch_xla/amp/autocast_mode.py
@@ -6,29 +6,25 @@ import warnings
 
 class autocast(torch.amp.autocast_mode.autocast):
   r"""
-    See :class:`torch.autocast`.
-    ``torch_xla.amp.autocast(device, **kwargs)`` is equivalent to 
-    ``torch.autocast("xla", **kwargs)`` for TPUs
-    ``torch.autocast("cuda", **kwargs)`` for GPUs.
-    """
+  `torch.autocast` for XLA backend devices. See :class:`torch.autocast`.
+  ``torch_xla.amp.autocast(device, **kwargs)`` is equivalent to
+  ``torch.autocast("xla", **kwargs)`` for XLA:TPU and XLA:GPU backends.
+  """
 
   def __init__(self,
                device,
                enabled: bool = True,
                dtype: torch.dtype = None,
                cache_enabled: bool = True):
-    if xm.xla_device_hw(device) == 'GPU':
-      if dtype is None:
-        dtype = torch.float16
-      super().__init__(
-          "cuda", enabled=enabled, dtype=dtype, cache_enabled=cache_enabled)
-    elif xm.xla_device_hw(device) == 'TPU':
+    assert 'xla' in device.__str__(), "torch_xla.autocast is available for XLA:TPU, XLA:GPU"
+    xla_device = xm.xla_device_hw(device)
+    if xla_device in ['TPU', 'GPU']:
       if dtype is None:
         dtype = torch.bfloat16
       if dtype != torch.bfloat16:
-        error_message = "In TPU autocast, but the target dtype is not supported. Disabling autocast.\n"
+        error_message = "In torch_xla autocast, but the target dtype is not supported. Disabling autocast.\n"
         error_message += (
-            "TPU Autocast only supports dtype of torch.bfloat16 currently.")
+            "torch_xla Autocast only supports dtype of torch.bfloat16 currently.")
         warnings.warn(error_message)
         enabled = False
       super().__init__(

--- a/torch_xla/amp/autocast_mode.py
+++ b/torch_xla/amp/autocast_mode.py
@@ -16,7 +16,8 @@ class autocast(torch.amp.autocast_mode.autocast):
                enabled: bool = True,
                dtype: torch.dtype = None,
                cache_enabled: bool = True):
-    assert 'xla' in device.__str__(), "torch_xla.autocast is available for XLA:TPU, XLA:GPU"
+    assert 'xla' in device.__str__(
+    ), "torch_xla.autocast is available for XLA:TPU, XLA:GPU"
     xla_device = xm.xla_device_hw(device)
     if xla_device in ['TPU', 'GPU']:
       if dtype is None:
@@ -24,7 +25,8 @@ class autocast(torch.amp.autocast_mode.autocast):
       if dtype != torch.bfloat16:
         error_message = "In torch_xla autocast, but the target dtype is not supported. Disabling autocast.\n"
         error_message += (
-            "torch_xla Autocast only supports dtype of torch.bfloat16 currently.")
+            "torch_xla Autocast only supports dtype of torch.bfloat16 currently."
+        )
         warnings.warn(error_message)
         enabled = False
       super().__init__(

--- a/torch_xla/amp/autocast_mode.py
+++ b/torch_xla/amp/autocast_mode.py
@@ -22,20 +22,25 @@ class autocast(torch.amp.autocast_mode.autocast):
 
     self._enabled = enabled
     self._xla_device = xm.xla_device_hw(device)
-    if self._xla_device is 'GPU':
+    if self._xla_device == 'GPU':
       # TODO(yeounoh) support torch.bfloat16 in XLA:GPU for eligible HW
       if dtype is None:
         dtype = torch.float16
-      if dtype == torch.bfloat16:
+      if dtype == torch.bfloat16 and not torch.cuda.is_available():
         error_message = "In XLA:GPU autocast, bfloat16 is currently not supported.\n"
-        error_message += ("It is treated as float16, which is the default XLA:GPU autocast dtype.")
+        error_message += (
+            "It is treated as float16, which is the default cuda autocast dtype."
+        )
         warnings.warn(error_message)
         # This has been the default behavior for XLA:GPU, since r2.0
         dtype = torch.float16
       self._dtype = dtype
       super().__init__(
-          "cuda", enabled=enabled, dtype=self._dtype, cache_enabled=cache_enabled)
-    elif self._xla_device is 'TPU':
+          "cuda",
+          enabled=enabled,
+          dtype=self._dtype,
+          cache_enabled=cache_enabled)
+    elif self._xla_device == 'TPU':
       if dtype is None:
         dtype = torch.bfloat16
       if dtype != torch.bfloat16:
@@ -46,7 +51,10 @@ class autocast(torch.amp.autocast_mode.autocast):
         enabled = False
       self._dtype = dtype
       super().__init__(
-          "xla", enabled=enabled, dtype=self._dtype, cache_enabled=cache_enabled)
+          "xla",
+          enabled=enabled,
+          dtype=self._dtype,
+          cache_enabled=cache_enabled)
     else:
       print(
           'Warning: AMP only supported for XLA:TPU and XLA:GPU. Ignoring autocast.'
@@ -55,16 +63,17 @@ class autocast(torch.amp.autocast_mode.autocast):
   def __enter__(self):
     # This ensures that xla autocast is enabled even for XLA:GPU, which calls
     # `torch.amp.autocast_mode.autocast` with `cuda` backend.
-    if self._xla_device is 'GPU':
+    if self._xla_device == 'GPU':
       self.prev = torch.is_autocast_xla_enabled()  # type: ignore[attr-defined]
-      self.prev_dtype = torch.get_autocast_xla_dtype()  # type: ignore[attr-defined]
+      self.prev_dtype = torch.get_autocast_xla_dtype(
+      )  # type: ignore[attr-defined]
       torch.set_autocast_xla_enabled(self._enabled)
       torch.set_autocast_xla_dtype(self._dtype)
     return super().__enter__()
 
   def __exit__(self, exc_type: Any, exc_val: Any,
                exc_tb: Any):  # type: ignore[override]
-    if self._xla_device is 'GPU':
+    if self._xla_device == 'GPU':
       torch.set_autocast_xla_enabled(self.prev)
       torch.set_autocast_xla_dtype(self.prev_dtype)
     return super().__exit__(exc_type, exc_val, exc_tb)

--- a/torch_xla/amp/autocast_mode.py
+++ b/torch_xla/amp/autocast_mode.py
@@ -1,5 +1,6 @@
 import torch
 import torch_xla.core.xla_model as xm
+from torch_xla import runtime as xr
 from typing import Any
 import warnings
 
@@ -8,7 +9,8 @@ class autocast(torch.amp.autocast_mode.autocast):
   r"""
   `torch.autocast` for XLA backend devices. See :class:`torch.autocast`.
   ``torch_xla.amp.autocast(device, **kwargs)`` is equivalent to
-  ``torch.autocast("xla", **kwargs)`` for XLA:TPU and XLA:GPU backends.
+  ``torch.autocast("xla", **kwargs)`` for XLA:GPU and XLA:TPU for dtype torch.bfloat16,
+  ``torch.autocast("cuda", **kwargs)`` for XLA:GPU and other dtypes.
   """
 
   def __init__(self,
@@ -27,7 +29,7 @@ class autocast(torch.amp.autocast_mode.autocast):
       if dtype is None:
         dtype = torch.float16
       elif dtype == torch.bfloat16:
-        if self._is_bf16_supported() and not torch.cuda.is_avaliable():
+        if xr.is_bf16_supported() and not torch.cuda.is_available():
           # XLA:GPU with bfloat16 should run on `xla` backend
           # unless torch.autocast is compiled with cuda.
           backend = 'xla'
@@ -82,10 +84,3 @@ class autocast(torch.amp.autocast_mode.autocast):
 
   def __call__(self, func):
     return super().__call__(func)
-
-  def _is_bf16_supported(self):
-    try:
-      torch.tensor([1.], dtype=torch.bfloat16, device=xm.xla_device())
-      return True
-    except Exception as e:
-      return False

--- a/torch_xla/amp/autocast_mode.py
+++ b/torch_xla/amp/autocast_mode.py
@@ -16,31 +16,57 @@ class autocast(torch.amp.autocast_mode.autocast):
                enabled: bool = True,
                dtype: torch.dtype = None,
                cache_enabled: bool = True):
+    # `torch_xla.amp.autocast` is intended for XLA backend, with AutocastXLA dispatch key.
     assert 'xla' in device.__str__(
     ), "torch_xla.autocast is available for XLA:TPU, XLA:GPU"
-    xla_device = xm.xla_device_hw(device)
-    if xla_device in ['TPU', 'GPU']:
+
+    self._enabled = enabled
+    self._xla_device = xm.xla_device_hw(device)
+    if self._xla_device is 'GPU':
+      # TODO(yeounoh) support torch.bfloat16 in XLA:GPU for eligible HW
+      if dtype is None:
+        dtype = torch.float16
+      if dtype == torch.bfloat16:
+        error_message = "In XLA:GPU autocast, bfloat16 is currently not supported.\n"
+        error_message += ("It is treated as float16, which is the default XLA:GPU autocast dtype.")
+        warnings.warn(error_message)
+        # This has been the default behavior for XLA:GPU, since r2.0
+        dtype = torch.float16
+      self._dtype = dtype
+      super().__init__(
+          "cuda", enabled=enabled, dtype=self._dtype, cache_enabled=cache_enabled)
+    elif self._xla_device is 'TPU':
       if dtype is None:
         dtype = torch.bfloat16
       if dtype != torch.bfloat16:
-        error_message = "In torch_xla autocast, but the target dtype is not supported. Disabling autocast.\n"
+        error_message = "In XLA:TPU autocast, but the target dtype is not supported. Disabling autocast.\n"
         error_message += (
-            "torch_xla Autocast only supports dtype of torch.bfloat16 currently."
-        )
+            "TPU Autocast only supports dtype of torch.bfloat16 currently.")
         warnings.warn(error_message)
         enabled = False
+      self._dtype = dtype
       super().__init__(
-          "xla", enabled=enabled, dtype=dtype, cache_enabled=cache_enabled)
+          "xla", enabled=enabled, dtype=self._dtype, cache_enabled=cache_enabled)
     else:
       print(
           'Warning: AMP only supported for XLA:TPU and XLA:GPU. Ignoring autocast.'
       )
 
   def __enter__(self):
+    # This ensures that xla autocast is enabled even for XLA:GPU, which calls
+    # `torch.amp.autocast_mode.autocast` with `cuda` backend.
+    if self._xla_device is 'GPU':
+      self.prev = torch.is_autocast_xla_enabled()  # type: ignore[attr-defined]
+      self.prev_dtype = torch.get_autocast_xla_dtype()  # type: ignore[attr-defined]
+      torch.set_autocast_xla_enabled(self._enabled)
+      torch.set_autocast_xla_dtype(self._dtype)
     return super().__enter__()
 
   def __exit__(self, exc_type: Any, exc_val: Any,
                exc_tb: Any):  # type: ignore[override]
+    if self._xla_device is 'GPU':
+      torch.set_autocast_xla_enabled(self.prev)
+      torch.set_autocast_xla_dtype(self.prev_dtype)
     return super().__exit__(exc_type, exc_val, exc_tb)
 
   def __call__(self, func):

--- a/torch_xla/amp/autocast_mode.py
+++ b/torch_xla/amp/autocast_mode.py
@@ -23,20 +23,22 @@ class autocast(torch.amp.autocast_mode.autocast):
     self._enabled = enabled
     self._xla_device = xm.xla_device_hw(device)
     if self._xla_device == 'GPU':
-      # TODO(yeounoh) support torch.bfloat16 in XLA:GPU for eligible HW
+      backend = 'cuda'
       if dtype is None:
         dtype = torch.float16
-      if dtype == torch.bfloat16 and not torch.cuda.is_available():
-        error_message = "In XLA:GPU autocast, bfloat16 is currently not supported.\n"
-        error_message += (
-            "It is treated as float16, which is the default cuda autocast dtype."
-        )
-        warnings.warn(error_message)
-        # This has been the default behavior for XLA:GPU, since r2.0
-        dtype = torch.float16
+      elif dtype == torch.bfloat16:
+        if self._is_bf16_supported() and not torch.cuda.is_avaliable():
+          # XLA:GPU with bfloat16 should run on `xla` backend
+          # unless torch.autocast is compiled with cuda.
+          backend = 'xla'
+        else:
+          # This has been the default behavior for unsupported bfloat16 dtype
+          dtype = torch.float16
+          error_message = "In XLA:GPU autocast, but bfloat16 is not supported on this HW.\n"
+          error_message += ("Using the default cuda autocast dtype float16.")
       self._dtype = dtype
       super().__init__(
-          "cuda",
+          backend,
           enabled=enabled,
           dtype=self._dtype,
           cache_enabled=cache_enabled)
@@ -80,3 +82,10 @@ class autocast(torch.amp.autocast_mode.autocast):
 
   def __call__(self, func):
     return super().__call__(func)
+
+  def _is_bf16_supported(self):
+    try:
+      torch.tensor([1.], dtype=torch.bfloat16, device=xm.xla_device())
+      return True
+    except Exception as e:
+      return False

--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -72,9 +72,8 @@ XLATensorImpl::XLATensorImpl(XLATensor&& tensor)
                       bridge::XlaDeviceToAtenDevice(tensor.GetDevice())),
       tensor_(c10::make_intrusive<XLATensor>(std::move(tensor))) {
   // AutocastCUDA is used for GPU, and AutocastXLA for XLA:TPU and XLA:GPU.
-  // When we didn't support autocast for XLA:GPU, we replaced AutocastXLA with
-  // AutocastCUDA and fell back to the torch autocast implementation for `cuda`
-  // device backend.
+  // AutocastXLA should be used with torch_xla.amp.autocast and it calls
+  // torch.autocast with proper device type, based on actual XLA HW type.
   const_cast<XLATensorImpl*>(this)->SetupSizeProperties();
   set_sizes_and_strides(sym_sizes_, c10::fromIntArrayRefSlow(
                                         sizes_and_strides_.strides_arrayref()));

--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -71,9 +71,15 @@ XLATensorImpl::XLATensorImpl(XLATensor&& tensor)
                       GetTypeMeta(tensor),
                       bridge::XlaDeviceToAtenDevice(tensor.GetDevice())),
       tensor_(c10::make_intrusive<XLATensor>(std::move(tensor))) {
-  // AutocastCUDA is used for GPU, and AutocastXLA for XLA:TPU and XLA:GPU.
-  // AutocastXLA should be used with torch_xla.amp.autocast and it calls
-  // torch.autocast with proper device type, based on actual XLA HW type.
+  // Update the Autocast key based off the backend device.
+  // Upstream TensorImpl cannot differentiate between XLA:TPU and XLA:GPU
+  // so we must manually update Autocast to AutocastCUDA on XLA:GPU.
+  torch::lazy::BackendDevice current_device = GetCurrentDevice();
+  if (static_cast<XlaDeviceType>(current_device.type()) == XlaDeviceType::GPU) {
+    auto autocast_cuda_ks = c10::DispatchKeySet(c10::DispatchKey::AutocastCUDA);
+    auto autocast_xla_ks = c10::DispatchKeySet(c10::DispatchKey::AutocastXLA);
+    key_set_ = (key_set_ - autocast_xla_ks) | autocast_cuda_ks;
+  }
   const_cast<XLATensorImpl*>(this)->SetupSizeProperties();
   set_sizes_and_strides(sym_sizes_, c10::fromIntArrayRefSlow(
                                         sizes_and_strides_.strides_arrayref()));

--- a/torch_xla/runtime.py
+++ b/torch_xla/runtime.py
@@ -84,6 +84,16 @@ def requires_pjrt(fn: FN) -> FN:
   return wrapper
 
 
+def is_bf16_supported():
+  """Returns whether torch.bfloat16 is supported on this environment.
+  """
+  try:
+    torch.tensor([1.], dtype=torch.bfloat16, device=xm.xla_device())
+    return True
+  except Exception as e:
+    return False
+
+
 @requires_pjrt
 def xla_device(n: Optional[int] = None,
                devkind: Optional[str] = None) -> torch.device:


### PR DESCRIPTION
`torch_xla.amp.autocast` was not using `XLA:GPU` but `torch.cuda` (GPU) backend. We should use `XLA` devices for XLA tensors, and for running `torch_xla.amp.autocast`.

Clarification 1:
> AMP executes on XLA:GPU, unless it's bfloat16 in which case, it has to fall back to cuda and requires USE_CUDA=1. We should address it.

This pytorch/pytorch#109302 to update the dispatcher comment is not needed. This also addresses #5497.