### PR TITLE
Set PyTorch git revision to v2.1.0-rc5 for 2.1 releases

### DIFF
--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -42,15 +42,15 @@ xrt_nightly_builds = [
 versioned_builds = [
   {
     git_tag         = "v2.1.0"
-    pytorch_git_rev = "v2.1.0-rc4"
-    package_version = "2.1.0rc4"
+    pytorch_git_rev = "v2.1.0-rc5"
+    package_version = "2.1.0rc5"
     accelerator     = "tpu"
     bundle_libtpu   = "0"
   },
   {
     git_tag         = "v2.1.0"
-    pytorch_git_rev = "v2.1.0-rc4"
-    package_version = "2.1.0rc4"
+    pytorch_git_rev = "v2.1.0-rc5"
+    package_version = "2.1.0rc5"
     accelerator     = "tpu"
     python_version  = "3.10"
     bundle_libtpu   = "0"
@@ -75,22 +75,22 @@ versioned_builds = [
   },
   {
     git_tag         = "v2.1.0"
-    pytorch_git_rev = "v2.1.0-rc4"
-    package_version = "2.1.0rc4",
+    pytorch_git_rev = "v2.1.0-rc5"
+    package_version = "2.1.0rc5",
     accelerator     = "cuda"
     cuda_version    = "12.0"
   },
   {
     git_tag         = "v2.1.0"
-    pytorch_git_rev = "v2.1.0-rc4"
-    package_version = "2.1.0rc4"
+    pytorch_git_rev = "v2.1.0-rc5"
+    package_version = "2.1.0rc5"
     accelerator     = "cuda"
     cuda_version    = "11.8"
   },
   {
     git_tag         = "v2.1.0"
-    pytorch_git_rev = "v2.1.0-rc4"
-    package_version = "2.1.0rc4"
+    pytorch_git_rev = "v2.1.0-rc5"
+    package_version = "2.1.0rc5"
     accelerator     = "cuda"
     cuda_version    = "11.8"
     python_version  = "3.10"

--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -57,8 +57,8 @@ versioned_builds = [
   },
   {
     git_tag         = "v2.1.0"
-    pytorch_git_rev = "v2.1.0-rc2"
-    package_version = "2.1.0rc2+libtpu"
+    pytorch_git_rev = "v2.1.0-rc5"
+    package_version = "2.1.0rc5+libtpu"
     accelerator     = "tpu"
     python_version  = "3.10"
     bundle_libtpu   = "1"

--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -42,15 +42,15 @@ xrt_nightly_builds = [
 versioned_builds = [
   {
     git_tag         = "v2.1.0"
-    pytorch_git_rev = "v2.1.0-rc2"
-    package_version = "2.1.0rc2"
+    pytorch_git_rev = "v2.1.0-rc4"
+    package_version = "2.1.0rc4"
     accelerator     = "tpu"
     bundle_libtpu   = "0"
   },
   {
     git_tag         = "v2.1.0"
-    pytorch_git_rev = "v2.1.0-rc2"
-    package_version = "2.1.0rc2"
+    pytorch_git_rev = "v2.1.0-rc4"
+    package_version = "2.1.0rc4"
     accelerator     = "tpu"
     python_version  = "3.10"
     bundle_libtpu   = "0"
@@ -75,22 +75,22 @@ versioned_builds = [
   },
   {
     git_tag         = "v2.1.0"
-    pytorch_git_rev = "v2.1.0-rc2"
-    package_version = "2.1.0rc2",
+    pytorch_git_rev = "v2.1.0-rc4"
+    package_version = "2.1.0rc4",
     accelerator     = "cuda"
     cuda_version    = "12.0"
   },
   {
     git_tag         = "v2.1.0"
-    pytorch_git_rev = "v2.1.0-rc2"
-    package_version = "2.1.0rc2"
+    pytorch_git_rev = "v2.1.0-rc4"
+    package_version = "2.1.0rc4"
     accelerator     = "cuda"
     cuda_version    = "11.8"
   },
   {
     git_tag         = "v2.1.0"
-    pytorch_git_rev = "v2.1.0-rc2"
-    package_version = "2.1.0rc2"
+    pytorch_git_rev = "v2.1.0-rc4"
+    package_version = "2.1.0rc4"
     accelerator     = "cuda"
     cuda_version    = "11.8"
     python_version  = "3.10"


### PR DESCRIPTION
Set PyTorch git revision to v2.1.0-rc5 for 2.1 releases