### PR TITLE
Improve bernoulli rng-bit-generation memory footprint (#5581)

### DIFF
--- a/torch_xla/csrc/random.h
+++ b/torch_xla/csrc/random.h
@@ -5,8 +5,12 @@
 
 namespace torch_xla {
 
+// Set downcast to true if the caller knows the |maxval - minval| is appropriate
+// for f16 dtype. We avoid computing the range on-the-fly since it incurs an XLA
+// computation.
 xla::XlaOp RngUniform(xla::XlaOp seed, const xla::Shape& shape,
-                      xla::XlaOp minval, xla::XlaOp maxval);
+                      xla::XlaOp minval, xla::XlaOp maxval,
+                      bool downcast = false);
 
 xla::XlaOp RngDiscreteUniform(xla::XlaOp seed, const xla::Shape& shape,
                               xla::XlaOp minval, xla::XlaOp maxval);

--- a/torch_xla/csrc/xla_lower_util.cpp
+++ b/torch_xla/csrc/xla_lower_util.cpp
@@ -476,7 +476,8 @@ xla::XlaOp BuildBernoulli(xla::XlaOp probability, xla::XlaOp seed,
       xla::Zero(probability.builder(), probability_shape.element_type());
   xla::XlaOp one =
       xla::One(probability.builder(), probability_shape.element_type());
-  xla::XlaOp noise = RngUniform(seed, probability_shape, zero, one);
+  xla::XlaOp noise =
+      RngUniform(seed, probability_shape, zero, one, /*downcast=*/true);
   return xla::ConvertElementType(xla::Lt(noise, probability), type);
 }
 


### PR DESCRIPTION
cherry-pick #5581 in r2.1
* Allow downcasting RngUniform genenration for Bernoulli

@yeounoh 