### PR TITLE
Cache OpSharding by mesh and partition_spec

### DIFF
--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -199,10 +199,12 @@ void XlaNode::UpdateShardingHash() {
       sharding_hash_ = torch::lazy::HashCombine(
           sharding_hash_, (uint32_t)tile_assignment_dimension);
     }
-    for (const auto& tile_assignment_device :
-         sharding->tile_assignment_devices()) {
-      sharding_hash_ = torch::lazy::HashCombine(
-          sharding_hash_, (uint32_t)tile_assignment_device);
+    {
+      const int64_t* data = sharding->tile_assignment_devices().data();
+      const size_t size_in_bytes =
+          sharding->tile_assignment_devices().size() * sizeof(*data);
+      sharding_hash_ =
+          torch::lazy::HashBlock(data, size_in_bytes, sharding_hash_);
     }
     for (const auto& last_tile_dim : sharding->last_tile_dims()) {
       sharding_hash_ =

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -194,6 +194,7 @@ bool ShardingUtil::EqualOpShardings(const xla::OpSharding& a,
 xla::OpSharding ShardingUtil::CreateOpSharding(
     const py::list& tile_assignment, const py::list& group_assignment,
     const py::list& replication_groups, ShardingType sharding_type) {
+  TORCH_LAZY_COUNTER("CreateOpSharding", 1);
   xla::OpSharding sharding;
   switch (sharding_type) {
     case ShardingType::MANUAL: {

--- a/torch_xla/experimental/xla_sharding.py
+++ b/torch_xla/experimental/xla_sharding.py
@@ -96,8 +96,9 @@ class Mesh:
     replicate_dims = {i for i, d in enumerate(partition_spec) if d is None}
     group_assignment, replication_groups = _get_group_assignment(
         sharding_type, tile_assignment, len(partition_spec), replicate_dims)
-    return torch_xla._XLAC.OpSharding(tile_assignment.tolist(), group_assignment,
-                                     replication_groups, int(sharding_type))
+    return torch_xla._XLAC.OpSharding(tile_assignment.tolist(),
+                                      group_assignment, replication_groups,
+                                      int(sharding_type))
 
 
 # HybridDevice class has been inspired from jax's mesh_utils: https://github.com/google/jax/blob/fc5960f2b8b7a0ef74dbae4e27c5c08ff1564cff/jax/experimental/mesh_utils.py#L4

--- a/torch_xla/runtime.py
+++ b/torch_xla/runtime.py
@@ -205,6 +205,7 @@ def global_runtime_device_attributes() -> List[Dict[str, object]]:
 
 
 @requires_pjrt
+@functools.lru_cache()
 def global_runtime_device_count() -> int:
   """Returns the total number of runtime devices across all processes/hosts."""
   return len(torch_xla._XLAC._xla_get_all_runtime_devices())


### PR DESCRIPTION
For large meshes, generating the OpSharding proto is expensive to generate and can increase tracing time. The value is easily cached for reuse across steps during tracing. 

This change also optimizes `UpdateShardingHash` to better handle a large number of devices and caches the return value for `xr.global_runtime_device_count`, both of which become more significant overheads with a greater number of devices. 

