### PR TITLE
Don't trigger CI build on release tag push

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - master
       - r[0-9]+.[0-9]+
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
The second run will fail because the first one already ran, e.g. `tag invalid: The image tag 'latest-1e6c11d1ff124ca79fa57e8de42333beb7895c8e' already exists in the 'pytorch/xla_base' repository and cannot be overwritten because the repository is immutable.`