### PR TITLE
Cherry-pick: Don't trigger CI build on release tag push

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - master
       - r[0-9]+.[0-9]+
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Copy of #5594 on release branch