### PR TITLE
Workaround that einsum with FakeTensor input

### DIFF
--- a/torch_xla/csrc/aten_xla_bridge.cpp
+++ b/torch_xla/csrc/aten_xla_bridge.cpp
@@ -75,6 +75,15 @@ XLATensorPtr TryGetXlaTensor(const at::Tensor& tensor) {
   return impl->tensor();
 }
 
+std::vector<XLATensorPtr> TryGetXlaTensors(const at::ITensorListRef& tensors) {
+  std::vector<XLATensorPtr> xla_tensors;
+  xla_tensors.reserve(tensors.size());
+  for (const auto& tensor : tensors) {
+    xla_tensors.push_back(bridge::TryGetXlaTensor(tensor));
+  }
+  return xla_tensors;
+}
+
 bool IsXlaTensor(const at::Tensor& tensor) {
   return GetXlaTensorImpl(tensor) != nullptr;
 }

--- a/torch_xla/csrc/aten_xla_bridge.h
+++ b/torch_xla/csrc/aten_xla_bridge.h
@@ -16,6 +16,9 @@ namespace bridge {
 
 XLATensorPtr TryGetXlaTensor(const at::Tensor& tensor);
 
+// Same as above, applied to a list of tensors.
+std::vector<XLATensorPtr> TryGetXlaTensors(const at::ITensorListRef& tensors);
+
 bool IsXlaTensor(const at::Tensor& tensor);
 
 // Extracts the XLATensorPtr out of our version of at::Tensor. Throws an

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1170,12 +1170,19 @@ at::Tensor XLANativeFunctions::einsum(c10::string_view equation,
                      [](unsigned char x) { return std::isspace(x); }),
       cleansed_equation.end());
 
-  std::vector<XLATensorPtr> xla_tensors = bridge::GetXlaTensors(tensors);
+  std::vector<XLATensorPtr> xla_tensors = bridge::TryGetXlaTensors(tensors);
+  bool all_xla_tensor_is_valid = true;
+  for (const XLATensorPtr xla_tensor : xla_tensors) {
+    if (!xla_tensor) {
+      all_xla_tensor_is_valid = false;
+      break;
+    }
+  }
 
   TORCH_LAZY_FN_COUNTER("xla::");
   // Einsum operations with more than 2 operands, like bilinear operations, are
   // not currently supported in XLA
-  if (tensors.size() < 1 || tensors.size() > 2 ||
+  if (tensors.size() < 1 || tensors.size() > 2 || !all_xla_tensor_is_valid ||
       !EinsumUtilities::EquationIsValid(cleansed_equation) ||
       TensorsAreOfType(xla_tensors, at::ScalarType::Long)) {
     TORCH_LAZY_COUNTER("EinsumFallback", 1);

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1171,10 +1171,10 @@ at::Tensor XLANativeFunctions::einsum(c10::string_view equation,
       cleansed_equation.end());
 
   std::vector<XLATensorPtr> xla_tensors = bridge::TryGetXlaTensors(tensors);
-  bool all_xla_tensor_is_valid = true;
+  bool all_xla_tensors_are_valid = true;
   for (const XLATensorPtr xla_tensor : xla_tensors) {
     if (!xla_tensor) {
-      all_xla_tensor_is_valid = false;
+      all_xla_tensors_are_valid = false;
       break;
     }
   }
@@ -1182,7 +1182,7 @@ at::Tensor XLANativeFunctions::einsum(c10::string_view equation,
   TORCH_LAZY_FN_COUNTER("xla::");
   // Einsum operations with more than 2 operands, like bilinear operations, are
   // not currently supported in XLA
-  if (tensors.size() < 1 || tensors.size() > 2 || !all_xla_tensor_is_valid ||
+  if (tensors.size() < 1 || tensors.size() > 2 || !all_xla_tensors_are_valid ||
       !EinsumUtilities::EquationIsValid(cleansed_equation) ||
       TensorsAreOfType(xla_tensors, at::ScalarType::Long)) {
     TORCH_LAZY_COUNTER("EinsumFallback", 1);


### PR DESCRIPTION
This pr worked around the https://github.com/pytorch/xla/issues/5530 by letting einsum fallback to CPU if input is fake tensor