### PR TITLE
Build `xrt` branch against PyTorch 2.1

### DIFF
--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -27,14 +27,19 @@ nightly_builds = [
 ]
 
 # TODO: Remove this after the 2.1 release
-xrt_nightly_builds = [
+xrt_versioned_builds = [
   {
     accelerator    = "tpu"
     python_version = "3.10"
+    pytorch_git_rev = "v2.1.0-rc5"
+    package_version = "2.1.0rc5+xrt"
   },
   {
     accelerator  = "cuda"
+    python_version = "3.10"
     cuda_version = "12.0"
+    pytorch_git_rev = "v2.1.0-rc5"
+    package_version = "2.1.0rc5+xrt"
   },
 ]
 

--- a/infra/tpu-pytorch-releases/artifacts_builds.tf
+++ b/infra/tpu-pytorch-releases/artifacts_builds.tf
@@ -17,10 +17,12 @@ variable "nightly_builds" {
 }
 
 // TODO: Remove this after the 2.1 release
-variable "xrt_nightly_builds" {
+variable "xrt_versioned_builds" {
   type = list(
     object({
+      package_version = string
       accelerator    = string
+      pytorch_git_rev = optional(string, "")
       cuda_version   = optional(string, "11.8")
       python_version = optional(string, "3.8")
       arch           = optional(string, "amd64")
@@ -58,9 +60,10 @@ locals {
   }
 
   // TODO: Remove this after the 2.1 release
-  xrt_nightly_builds_dict = {
-    for b in var.xrt_nightly_builds :
-    format("%s_%s",
+  xrt_versioned_builds_dict = {
+    for b in var.xrt_versioned_builds :
+    format("r%s_%s_%s",
+      replace(b.package_version, "+", "_"),
       b.python_version,
       b.accelerator == "tpu" ? "tpuvm" : format("cuda_%s", b.cuda_version)
     ) => b
@@ -123,9 +126,9 @@ module "nightly_builds" {
 }
 
 // TODO: Remove this after the 2.1 release
-module "xrt_nightly_builds" {
+module "xrt_versioned_builds" {
   source   = "../terraform_modules/xla_docker_build"
-  for_each = local.xrt_nightly_builds_dict
+  for_each = local.xrt_versioned_builds_dict
 
   ansible_vars = merge(each.value, {
     package_version = var.nightly_package_version
@@ -136,16 +139,16 @@ module "xrt_nightly_builds" {
 
   trigger_on_schedule = { schedule = "0 0 * * *", branch = "xrt" }
 
-  trigger_name = "nightly-xrt-${replace(each.key, "/[_.]/", "-")}"
+  trigger_name = replace(each.key, "/[_.]/", "-")
   image_name   = "xla"
   image_tags = [
-    "nightly_xrt_${each.key}",
+    each.key,
     # Append _YYYYMMDD suffix to nightly image name.
-    "nightly_xrt_${each.key}_$(date +%Y%m%d)",
+    "${each.key}_$(date +%Y%m%d)",
   ]
 
   description = join(" ", [
-    "Builds nightly xla:nightly_${each.key}' ${
+    "Builds nightly xla:${each.key}' ${
       each.value.accelerator == "tpu"
       ? "TPU"
       : format("CUDA %s", each.value.cuda_version)

--- a/infra/tpu-pytorch-releases/artifacts_builds.tf
+++ b/infra/tpu-pytorch-releases/artifacts_builds.tf
@@ -131,8 +131,6 @@ module "xrt_versioned_builds" {
   for_each = local.xrt_versioned_builds_dict
 
   ansible_vars = merge(each.value, {
-    package_version = var.nightly_package_version
-    nightly_release = true
     pytorch_git_rev = "main"
     xla_git_rev     = "$COMMIT_SHA"
   })


### PR DESCRIPTION
- Use `+xrt` identifier in package version to distinguish these builds from the main builds.
- Wheels will still go to the `wheels/xrt` folder to prevent name conflicts.
- Docker images and triggers have `_xrt` after the release version.

Please double-check that I didn't miss any names that could conflict with the main builds.

Terraform plan:

<details>

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  - destroy

Terraform will perform the following actions:

  # module.xrt_nightly_builds["3.10_tpuvm"].module.cloud_build.google_cloudbuild_trigger.trigger will be destroyed
  # (because google_cloudbuild_trigger.trigger is not in configuration)
  - resource "google_cloudbuild_trigger" "trigger" {
      - create_time    = "2023-06-28T08:52:00.883330931Z" -> null
      - description    = "Builds nightly xla:nightly_3.10_tpuvm' TPU docker image and corresponding wheels for PyTorch/XLA. Trigger managed by Terraform setup in infra/tpu-pytorch-releases/artifacts_builds.tf." -> null
      - disabled       = false -> null
      - id             = "projects/tpu-pytorch-releases/locations/us-central1/triggers/71efcc21-8e67-423d-aeea-8e16db0f3153" -> null
      - ignored_files  = [] -> null
      - included_files = [] -> null
      - location       = "us-central1" -> null
      - name           = "nightly-xrt-3-10-tpuvm" -> null
      - project        = "tpu-pytorch-releases" -> null
      - substitutions  = {} -> null
      - tags           = [] -> null
      - trigger_id     = "71efcc21-8e67-423d-aeea-8e16db0f3153" -> null

      - approval_config {
          - approval_required = false -> null
        }

      - build {
          - images        = [] -> null
          - substitutions = {} -> null
          - tags          = [] -> null
          - timeout       = "21600s" -> null

          - options {
              - disk_size_gb           = 0 -> null
              - dynamic_substitutions  = true -> null
              - env                    = [] -> null
              - secret_env             = [] -> null
              - source_provenance_hash = [] -> null
              - substitution_option    = "ALLOW_LOOSE" -> null
              - worker_pool            = "projects/tpu-pytorch-releases/locations/us-central1/workerPools/main" -> null
            }

          - step {
              - allow_exit_codes = [] -> null
              - allow_failure    = false -> null
              - args             = [
                  - "fetch",
                  - "--unshallow",
                ] -> null
              - env              = [] -> null
              - id               = "git_fetch" -> null
              - name             = "gcr.io/cloud-builders/git" -> null
              - secret_env       = [] -> null
              - wait_for         = [] -> null
            }
          - step {
              - allow_exit_codes = [] -> null
              - allow_failure    = false -> null
              - args             = [
                  - "checkout",
                  - "$COMMIT_SHA",
                ] -> null
              - env              = [] -> null
              - id               = "git_checkout" -> null
              - name             = "gcr.io/cloud-builders/git" -> null
              - secret_env       = [] -> null
              - wait_for         = [] -> null
            }
          - step {
              - allow_exit_codes = [] -> null
              - allow_failure    = false -> null
              - args             = [
                  - "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"nightly_release\":\"true\",\"package_version\":\"2.2.0\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_xrt_3.10_tpuvm)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_xrt_3.10_tpuvm_$(date +%Y%m%d))\" -t=local_image",
                ] -> null
              - dir              = "infra/ansible" -> null
              - entrypoint       = "bash" -> null
              - env              = [] -> null
              - id               = "build_xla_docker_image" -> null
              - name             = "gcr.io/cloud-builders/docker" -> null
              - secret_env       = [] -> null
              - wait_for         = [] -> null
            }
          - step {
              - allow_exit_codes = [] -> null
              - allow_failure    = false -> null
              - args             = [
                  - "-c",
                  - "docker push --all-tags us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla",
                ] -> null
              - entrypoint       = "bash" -> null
              - env              = [] -> null
              - id               = "push_xla_docker_image" -> null
              - name             = "gcr.io/cloud-builders/docker" -> null
              - secret_env       = [] -> null
              - wait_for         = [] -> null
            }
          - step {
              - allow_exit_codes = [] -> null
              - allow_failure    = false -> null
              - args             = [
                  - "-c",
                  - "echo The following wheels will be published && ls /dist/*.whl && cp /dist/*.whl /wheels",
                ] -> null
              - entrypoint       = "bash" -> null
              - env              = [] -> null
              - id               = "copy_wheels_to_volume" -> null
              - name             = "local_image" -> null
              - secret_env       = [] -> null
              - wait_for         = [] -> null

              - volumes {
                  - name = "wheels" -> null
                  - path = "/wheels" -> null
                }
            }
          - step {
              - allow_exit_codes = [] -> null
              - allow_failure    = false -> null
              - args             = [
                  - "-c",
                  - "gsutil cp /wheels/*.whl gs://pytorch-xla-releases/wheels/xrt/tpuvm",
                ] -> null
              - entrypoint       = "bash" -> null
              - env              = [] -> null
              - id               = "upload_wheels_to_storage_bucket" -> null
              - name             = "gcr.io/cloud-builders/gsutil" -> null
              - secret_env       = [] -> null
              - wait_for         = [] -> null

              - volumes {
                  - name = "wheels" -> null
                  - path = "/wheels" -> null
                }
            }
        }

      - source_to_build {
          - ref       = "refs/heads/xrt" -> null
          - repo_type = "GITHUB" -> null
          - uri       = "https://github.com/pytorch/xla" -> null
        }
    }

  # module.xrt_nightly_builds["3.8_cuda_12.0"].module.cloud_build.google_cloudbuild_trigger.trigger will be destroyed
  # (because google_cloudbuild_trigger.trigger is not in configuration)
  - resource "google_cloudbuild_trigger" "trigger" {
      - create_time    = "2023-06-28T08:52:00.875871516Z" -> null
      - description    = "Builds nightly xla:nightly_3.8_cuda_12.0' CUDA 12.0 docker image and corresponding wheels for PyTorch/XLA. Trigger managed by Terraform setup in infra/tpu-pytorch-releases/artifacts_builds.tf." -> null
      - disabled       = false -> null
      - id             = "projects/tpu-pytorch-releases/locations/us-central1/triggers/b006ff18-028e-4797-889c-12f716d8d4a2" -> null
      - ignored_files  = [] -> null
      - included_files = [] -> null
      - location       = "us-central1" -> null
      - name           = "nightly-xrt-3-8-cuda-12-0" -> null
      - project        = "tpu-pytorch-releases" -> null
      - substitutions  = {} -> null
      - tags           = [] -> null
      - trigger_id     = "b006ff18-028e-4797-889c-12f716d8d4a2" -> null

      - approval_config {
          - approval_required = false -> null
        }

      - build {
          - images        = [] -> null
          - substitutions = {} -> null
          - tags          = [] -> null
          - timeout       = "21600s" -> null

          - options {
              - disk_size_gb           = 0 -> null
              - dynamic_substitutions  = true -> null
              - env                    = [] -> null
              - secret_env             = [] -> null
              - source_provenance_hash = [] -> null
              - substitution_option    = "ALLOW_LOOSE" -> null
              - worker_pool            = "projects/tpu-pytorch-releases/locations/us-central1/workerPools/main" -> null
            }

          - step {
              - allow_exit_codes = [] -> null
              - allow_failure    = false -> null
              - args             = [
                  - "fetch",
                  - "--unshallow",
                ] -> null
              - env              = [] -> null
              - id               = "git_fetch" -> null
              - name             = "gcr.io/cloud-builders/git" -> null
              - secret_env       = [] -> null
              - wait_for         = [] -> null
            }
          - step {
              - allow_exit_codes = [] -> null
              - allow_failure    = false -> null
              - args             = [
                  - "checkout",
                  - "$COMMIT_SHA",
                ] -> null
              - env              = [] -> null
              - id               = "git_checkout" -> null
              - name             = "gcr.io/cloud-builders/git" -> null
              - secret_env       = [] -> null
              - wait_for         = [] -> null
            }
          - step {
              - allow_exit_codes = [] -> null
              - allow_failure    = false -> null
              - args             = [
                  - "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"cuda_version\":\"12.0\",\"nightly_release\":\"true\",\"package_version\":\"2.2.0\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_xrt_3.8_cuda_12.0)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo nightly_xrt_3.8_cuda_12.0_$(date +%Y%m%d))\" -t=local_image",
                ] -> null
              - dir              = "infra/ansible" -> null
              - entrypoint       = "bash" -> null
              - env              = [] -> null
              - id               = "build_xla_docker_image" -> null
              - name             = "gcr.io/cloud-builders/docker" -> null
              - secret_env       = [] -> null
              - wait_for         = [] -> null
            }
          - step {
              - allow_exit_codes = [] -> null
              - allow_failure    = false -> null
              - args             = [
                  - "-c",
                  - "docker push --all-tags us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla",
                ] -> null
              - entrypoint       = "bash" -> null
              - env              = [] -> null
              - id               = "push_xla_docker_image" -> null
              - name             = "gcr.io/cloud-builders/docker" -> null
              - secret_env       = [] -> null
              - wait_for         = [] -> null
            }
          - step {
              - allow_exit_codes = [] -> null
              - allow_failure    = false -> null
              - args             = [
                  - "-c",
                  - "echo The following wheels will be published && ls /dist/*.whl && cp /dist/*.whl /wheels",
                ] -> null
              - entrypoint       = "bash" -> null
              - env              = [] -> null
              - id               = "copy_wheels_to_volume" -> null
              - name             = "local_image" -> null
              - secret_env       = [] -> null
              - wait_for         = [] -> null

              - volumes {
                  - name = "wheels" -> null
                  - path = "/wheels" -> null
                }
            }
          - step {
              - allow_exit_codes = [] -> null
              - allow_failure    = false -> null
              - args             = [
                  - "-c",
                  - "gsutil cp /wheels/*.whl gs://pytorch-xla-releases/wheels/xrt/cuda/12.0",
                ] -> null
              - entrypoint       = "bash" -> null
              - env              = [] -> null
              - id               = "upload_wheels_to_storage_bucket" -> null
              - name             = "gcr.io/cloud-builders/gsutil" -> null
              - secret_env       = [] -> null
              - wait_for         = [] -> null

              - volumes {
                  - name = "wheels" -> null
                  - path = "/wheels" -> null
                }
            }
        }

      - source_to_build {
          - ref       = "refs/heads/xrt" -> null
          - repo_type = "GITHUB" -> null
          - uri       = "https://github.com/pytorch/xla" -> null
        }
    }

  # module.xrt_versioned_builds["r2.1.0rc5_xrt_3.10_cuda_12.0"].module.cloud_build.google_cloudbuild_trigger.trigger will be created
  + resource "google_cloudbuild_trigger" "trigger" {
      + create_time = (known after apply)
      + description = "Builds nightly xla:r2.1.0rc5_xrt_3.10_cuda_12.0' CUDA 12.0 docker image and corresponding wheels for PyTorch/XLA. Trigger managed by Terraform setup in infra/tpu-pytorch-releases/artifacts_builds.tf."
      + id          = (known after apply)
      + location    = "us-central1"
      + name        = "r2-1-0rc5-xrt-3-10-cuda-12-0"
      + project     = (known after apply)
      + trigger_id  = (known after apply)

      + approval_config {
          + approval_required = (known after apply)
        }

      + build {
          + timeout = "21600s"

          + options {
              + dynamic_substitutions = true
              + substitution_option   = "ALLOW_LOOSE"
              + worker_pool           = "projects/tpu-pytorch-releases/locations/us-central1/workerPools/main"
            }

          + step {
              + args = [
                  + "fetch",
                  + "--unshallow",
                ]
              + id   = "git_fetch"
              + name = "gcr.io/cloud-builders/git"
            }
          + step {
              + args = [
                  + "checkout",
                  + "$COMMIT_SHA",
                ]
              + id   = "git_checkout"
              + name = "gcr.io/cloud-builders/git"
            }
          + step {
              + args       = [
                  + "-c",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"cuda_version\":\"12.0\",\"nightly_release\":\"true\",\"package_version\":\"2.2.0\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1.0rc5_xrt_3.10_cuda_12.0)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1.0rc5_xrt_3.10_cuda_12.0_$(date +%Y%m%d))\" -t=local_image",
                ]
              + dir        = "infra/ansible"
              + entrypoint = "bash"
              + id         = "build_xla_docker_image"
              + name       = "gcr.io/cloud-builders/docker"
            }
          + step {
              + args       = [
                  + "-c",
                  + "docker push --all-tags us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla",
                ]
              + entrypoint = "bash"
              + id         = "push_xla_docker_image"
              + name       = "gcr.io/cloud-builders/docker"
            }
          + step {
              + args       = [
                  + "-c",
                  + "echo The following wheels will be published && ls /dist/*.whl && cp /dist/*.whl /wheels",
                ]
              + entrypoint = "bash"
              + id         = "copy_wheels_to_volume"
              + name       = "local_image"

              + volumes {
                  + name = "wheels"
                  + path = "/wheels"
                }
            }
          + step {
              + args       = [
                  + "-c",
                  + "gsutil cp /wheels/*.whl gs://pytorch-xla-releases/wheels/xrt/cuda/12.0",
                ]
              + entrypoint = "bash"
              + id         = "upload_wheels_to_storage_bucket"
              + name       = "gcr.io/cloud-builders/gsutil"

              + volumes {
                  + name = "wheels"
                  + path = "/wheels"
                }
            }
        }

      + source_to_build {
          + ref       = "refs/heads/xrt"
          + repo_type = "GITHUB"
          + uri       = "https://github.com/pytorch/xla"
        }
    }

  # module.xrt_versioned_builds["r2.1.0rc5_xrt_3.10_tpuvm"].module.cloud_build.google_cloudbuild_trigger.trigger will be created
  + resource "google_cloudbuild_trigger" "trigger" {
      + create_time = (known after apply)
      + description = "Builds nightly xla:r2.1.0rc5_xrt_3.10_tpuvm' TPU docker image and corresponding wheels for PyTorch/XLA. Trigger managed by Terraform setup in infra/tpu-pytorch-releases/artifacts_builds.tf."
      + id          = (known after apply)
      + location    = "us-central1"
      + name        = "r2-1-0rc5-xrt-3-10-tpuvm"
      + project     = (known after apply)
      + trigger_id  = (known after apply)

      + approval_config {
          + approval_required = (known after apply)
        }

      + build {
          + timeout = "21600s"

          + options {
              + dynamic_substitutions = true
              + substitution_option   = "ALLOW_LOOSE"
              + worker_pool           = "projects/tpu-pytorch-releases/locations/us-central1/workerPools/main"
            }

          + step {
              + args = [
                  + "fetch",
                  + "--unshallow",
                ]
              + id   = "git_fetch"
              + name = "gcr.io/cloud-builders/git"
            }
          + step {
              + args = [
                  + "checkout",
                  + "$COMMIT_SHA",
                ]
              + id   = "git_checkout"
              + name = "gcr.io/cloud-builders/git"
            }
          + step {
              + args       = [
                  + "-c",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"nightly_release\":\"true\",\"package_version\":\"2.2.0\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1.0rc5_xrt_3.10_tpuvm)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1.0rc5_xrt_3.10_tpuvm_$(date +%Y%m%d))\" -t=local_image",
                ]
              + dir        = "infra/ansible"
              + entrypoint = "bash"
              + id         = "build_xla_docker_image"
              + name       = "gcr.io/cloud-builders/docker"
            }
          + step {
              + args       = [
                  + "-c",
                  + "docker push --all-tags us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla",
                ]
              + entrypoint = "bash"
              + id         = "push_xla_docker_image"
              + name       = "gcr.io/cloud-builders/docker"
            }
          + step {
              + args       = [
                  + "-c",
                  + "echo The following wheels will be published && ls /dist/*.whl && cp /dist/*.whl /wheels",
                ]
              + entrypoint = "bash"
              + id         = "copy_wheels_to_volume"
              + name       = "local_image"

              + volumes {
                  + name = "wheels"
                  + path = "/wheels"
                }
            }
          + step {
              + args       = [
                  + "-c",
                  + "gsutil cp /wheels/*.whl gs://pytorch-xla-releases/wheels/xrt/tpuvm",
                ]
              + entrypoint = "bash"
              + id         = "upload_wheels_to_storage_bucket"
              + name       = "gcr.io/cloud-builders/gsutil"

              + volumes {
                  + name = "wheels"
                  + path = "/wheels"
                }
            }
        }

      + source_to_build {
          + ref       = "refs/heads/xrt"
          + repo_type = "GITHUB"
          + uri       = "https://github.com/pytorch/xla"
        }
    }

  # module.xrt_nightly_builds["3.10_tpuvm"].module.cloud_build.module.schedule_triggers[0].google_cloud_scheduler_job.trigger_schedule will be destroyed
  # (because google_cloud_scheduler_job.trigger_schedule is not in configuration)
  - resource "google_cloud_scheduler_job" "trigger_schedule" {
      - attempt_deadline = "180s" -> null
      - id               = "projects/tpu-pytorch-releases/locations/us-central1/jobs/nightly-xrt-3-10-tpuvm-schedule" -> null
      - name             = "nightly-xrt-3-10-tpuvm-schedule" -> null
      - paused           = false -> null
      - project          = "tpu-pytorch-releases" -> null
      - region           = "us-central1" -> null
      - schedule         = "0 0 * * *" -> null
      - state            = "ENABLED" -> null
      - time_zone        = "America/Los_Angeles" -> null

      - http_target {
          - headers     = {} -> null
          - http_method = "POST" -> null
          - uri         = "https://cloudbuild.googleapis.com/v1/projects/tpu-pytorch-releases/locations/us-central1/triggers/71efcc21-8e67-423d-aeea-8e16db0f3153:run" -> null

          - oauth_token {
              - scope                 = "https://www.googleapis.com/auth/cloud-platform" -> null
              - service_account_email = "build-triggers-scheduler@tpu-pytorch-releases.iam.gserviceaccount.com" -> null
            }
        }
    }

  # module.xrt_nightly_builds["3.8_cuda_12.0"].module.cloud_build.module.schedule_triggers[0].google_cloud_scheduler_job.trigger_schedule will be destroyed
  # (because google_cloud_scheduler_job.trigger_schedule is not in configuration)
  - resource "google_cloud_scheduler_job" "trigger_schedule" {
      - attempt_deadline = "180s" -> null
      - id               = "projects/tpu-pytorch-releases/locations/us-central1/jobs/nightly-xrt-3-8-cuda-12-0-schedule" -> null
      - name             = "nightly-xrt-3-8-cuda-12-0-schedule" -> null
      - paused           = false -> null
      - project          = "tpu-pytorch-releases" -> null
      - region           = "us-central1" -> null
      - schedule         = "0 0 * * *" -> null
      - state            = "ENABLED" -> null
      - time_zone        = "America/Los_Angeles" -> null

      - http_target {
          - headers     = {} -> null
          - http_method = "POST" -> null
          - uri         = "https://cloudbuild.googleapis.com/v1/projects/tpu-pytorch-releases/locations/us-central1/triggers/b006ff18-028e-4797-889c-12f716d8d4a2:run" -> null

          - oauth_token {
              - scope                 = "https://www.googleapis.com/auth/cloud-platform" -> null
              - service_account_email = "build-triggers-scheduler@tpu-pytorch-releases.iam.gserviceaccount.com" -> null
            }
        }
    }

  # module.xrt_versioned_builds["r2.1.0rc5_xrt_3.10_cuda_12.0"].module.cloud_build.module.schedule_triggers[0].google_cloud_scheduler_job.trigger_schedule will be created
  + resource "google_cloud_scheduler_job" "trigger_schedule" {
      + id        = (known after apply)
      + name      = "r2-1-0rc5-xrt-3-10-cuda-12-0-schedule"
      + paused    = (known after apply)
      + project   = (known after apply)
      + region    = (known after apply)
      + schedule  = "0 0 * * *"
      + state     = (known after apply)
      + time_zone = "America/Los_Angeles"

      + http_target {
          + http_method = "POST"
          + uri         = (known after apply)

          + oauth_token {
              + service_account_email = "build-triggers-scheduler@tpu-pytorch-releases.iam.gserviceaccount.com"
            }
        }
    }

  # module.xrt_versioned_builds["r2.1.0rc5_xrt_3.10_tpuvm"].module.cloud_build.module.schedule_triggers[0].google_cloud_scheduler_job.trigger_schedule will be created
  + resource "google_cloud_scheduler_job" "trigger_schedule" {
      + id        = (known after apply)
      + name      = "r2-1-0rc5-xrt-3-10-tpuvm-schedule"
      + paused    = (known after apply)
      + project   = (known after apply)
      + region    = (known after apply)
      + schedule  = "0 0 * * *"
      + state     = (known after apply)
      + time_zone = "America/Los_Angeles"

      + http_target {
          + http_method = "POST"
          + uri         = (known after apply)

          + oauth_token {
              + service_account_email = "build-triggers-scheduler@tpu-pytorch-releases.iam.gserviceaccount.com"
            }
        }
    }

Plan: 4 to add, 0 to change, 4 to destroy.
```

</details>