### PR TITLE
XLA pin downgrade to 20230825 (#5592)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -43,9 +43,9 @@ http_archive(
         "//openxla_patches:gpu_race_condition.diff",
         "//openxla_patches:constexpr_return.diff",
     ],
-    strip_prefix = "xla-7a371ed44aba34f83d6d3d1159d2e6d0d327c603",
+    strip_prefix = "xla-97a5f819faf9ff793b7ba68ff1f31f74f9459c18",
     urls = [
-        "https://github.com/openxla/xla/archive/7a371ed44aba34f83d6d3d1159d2e6d0d327c603.tar.gz",
+        "https://github.com/openxla/xla/archive/97a5f819faf9ff793b7ba68ff1f31f74f9459c18.tar.gz",
     ],
 )
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ import zipfile
 
 base_dir = os.path.dirname(os.path.abspath(__file__))
 
-_libtpu_version = '0.1.dev20230826'
+_libtpu_version = '0.1.dev20230825'
 _libtpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
 
 


### PR DESCRIPTION
Cherry-pick #5592

Summary:
The 20230826 version contains https://github.com/openxla/xla/commit/3b8a5398ea9e479311d5c0c34bb1ae255551f9d4 whch regresses our LLaMA2 GSPMD training benchmark. Let's rollback to version before it.

Test Plan:
CI.