### PR TITLE
Use XLA's new API to setup aliasing

### DIFF
--- a/test/spmd/test_xla_sharding_hlo.py
+++ b/test/spmd/test_xla_sharding_hlo.py
@@ -10,6 +10,7 @@ import torch_xla
 import torch_xla.runtime as xr
 import torch_xla.core.xla_model as xm
 import torch_xla.experimental.xla_sharding as xs
+import torch_xla.debug.metrics as met
 
 import test_xla_sharding_base
 
@@ -31,6 +32,37 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     hlo = torch_xla._XLAC._get_xla_tensors_hlo([t3])
     if self.n_devices > 1:
       self.assertIn('all-reduce', hlo)
+
+  def test_xla_replicated_input_output_alias(self):
+    xla_device = xm.xla_device()
+    t1 = torch.randn(8, 8).to(xla_device)
+    t2 = torch.randn(8, 8).to(xla_device)
+
+    # check in place op aliasing.
+    t3 = t1 + t2
+    t1 *= 2.0
+    t2 += 2.0
+    xm.mark_step()
+    # expected post-optimization HLO with "XLA_FLAGS=--xla_dump_to=/tmp/hlo_dir"
+    # HloModule SyncTensorsGraph.18, is_scheduled=true, input_output_alias={ {0}: (0, {}, may-alias), {1}: (1, {}, may-alias) }, entry_computation_layout={(f32[8,8]{1,0:T(8,128)}, f32[8,8]{1,0:T(8,128)}, f32[]{:T(128)})->(f32[8,8]{1,0:T(8,128)}, f32[8,8]{1,0:T(8,128)}, f32[8,8]{1,0:T(8,128)})}, allow_spmd_sharding_propagation_to_output={true}
+    self.assertEqual(met.metric_data("InputOutputAliasCount")[1], 2.0)
+
+  def test_xla_sharded_input_output_alias(self):
+    xla_device = xm.xla_device()
+    t1 = torch.randn(8, 8).to(xla_device)
+    t2 = torch.randn(8, 8).to(xla_device)
+
+    xs.mark_sharding(t1, self._get_mesh((1, self.n_devices)), (0, 1))
+    xs.mark_sharding(t2, self._get_mesh((1, self.n_devices)), (0, 1))
+
+    # check in place op aliasing.
+    t3 = t1 + t2
+    t1 *= 2.0
+    t2 += 2.0
+    xm.mark_step()
+    # expected post-optimization HLO with "XLA_FLAGS=--xla_dump_to=/tmp/hlo_dir"
+    # HloModule SyncTensorsGraph.18, is_scheduled=true, input_output_alias={ {0}: (0, {}, may-alias), {1}: (1, {}, may-alias) }, entry_computation_layout={(f32[8,8]{1,0:T(8,128)}, f32[8,8]{1,0:T(8,128)}, f32[]{:T(128)})->(f32[8,8]{1,0:T(8,128)}, f32[8,8]{1,0:T(8,128)}, f32[8,8]{1,0:T(8,128)})}, allow_spmd_sharding_propagation_to_output={true}
+    self.assertEqual(met.metric_data("InputOutputAliasCount")[1], 2.0)
 
 
 if __name__ == '__main__':

--- a/test/test_input_output_aliases.py
+++ b/test/test_input_output_aliases.py
@@ -31,6 +31,31 @@ class InputOutputAliasesTest(unittest.TestCase):
     t2 += 2.0
     xm.mark_step()
 
+    # hlo looks like
+    # HloModule SyncTensorsGraph.18, is_scheduled=true, input_output_alias={ {0}: (0, {}, may-alias), {1}: (1, {}, may-alias) }, entry_computation_layout={(f32[4,2,2]{0,2,1:T(2,128)}, f32[4,2,2]{0,2,1:T(2,128)}, f32[]{:T(128)})->(f32[4,2,2]{0,2,1:T(2,128)}, f32[4,2,2]{0,2,1:T(2,128)}, f32[4,2,2]{0,2,1:T(2,128)})}
+    #
+    # fused_computation {
+    #   param_0 = f32[4,2,2]{0,2,1:T(2,128)} parameter(0)
+    #   param_1.1 = f32[]{:T(128)S(6)} parameter(1)
+    #   broadcast.1 = f32[4,2,2]{0,2,1:T(2,128)} broadcast(param_1.1), dimensions={}
+    #   add.0 = f32[4,2,2]{0,2,1:T(2,128)} add(param_0, broadcast.1)
+    #   param_2 = f32[4,2,2]{0,2,1:T(2,128)} parameter(2)
+    #   add.1 = f32[4,2,2]{0,2,1:T(2,128)} add(param_2, param_0)
+    #   multiply.0.clone.1 = f32[4,2,2]{0,2,1:T(2,128)} multiply(param_2, broadcast.1)
+    #   ROOT tuple.1 = (f32[4,2,2]{0,2,1:T(2,128)}, f32[4,2,2]{0,2,1:T(2,128)}, f32[4,2,2]{0,2,1:T(2,128)}) tuple(add.0, add.1, multiply.0.clone.1)
+    # } // fused_computation
+
+    # ENTRY SyncTensorsGraph.18 {
+    #   p2.10 = f32[]{:T(128)} parameter(2)
+    #   p1.8 = f32[4,2,2]{0,2,1:T(2,128)} parameter(1)
+    #   p0.6 = f32[4,2,2]{0,2,1:T(2,128)} parameter(0)
+    #   copy.4 = f32[]{:T(128)S(6)} copy(p2.10)
+    #   fusion = (f32[4,2,2]{0,2,1:T(2,128)}, f32[4,2,2]{0,2,1:T(2,128)}, f32[4,2,2]{0,2,1:T(2,128)}) fusion(p0.6, copy.4, p1.8), kind=kLoop, calls=fused_computation
+    #   get-tuple-element.4 = f32[4,2,2]{0,2,1:T(2,128)} get-tuple-element(fusion), index=2
+    #   get-tuple-element.3 = f32[4,2,2]{0,2,1:T(2,128)} get-tuple-element(fusion), index=1
+    #   get-tuple-element.5 = f32[4,2,2]{0,2,1:T(2,128)} get-tuple-element(fusion), index=0
+    #   ROOT tuple.2 = (f32[4,2,2]{0,2,1:T(2,128)}, f32[4,2,2]{0,2,1:T(2,128)}, f32[4,2,2]{0,2,1:T(2,128)}) tuple(get-tuple-element.3, get-tuple-element.4, get-tuple-element.5)
+    # } // SyncTensorsGraph.18
     self.assertEqual(met.metric_data("InputOutputAliasCount")[1], 4.0)
 
 

--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -339,7 +339,7 @@ class XlaHelpers {
   static xla::StatusOr<xla::XlaComputation> WrapXlaComputation(
       const xla::XlaComputation& computation,
       const std::vector<xla::Shape>& parameter_shapes,
-      std::vector<std::pair<int64_t, int64_t>> input_output_alias_pair);
+      const std::vector<size_t>& buffer_donor_indices);
 
   static torch::lazy::Shape ConvertXlaShapeToLazy(const xla::Shape& shape);
 

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -1230,19 +1230,18 @@ std::shared_ptr<XLAGraphExecutor::Async> XLAGraphExecutor::TryRunCachedSync(
       coll->device.toString(), std::move(cached_computation), tensor_data_vec);
 }
 
-std::vector<std::pair<int64_t, int64_t>>
-XLAGraphExecutor::BuildInputOutputAliases(
+std::vector<size_t> XLAGraphExecutor::SetBufferDonors(
     const std::vector<XLATensorPtr>& tensors, absl::Span<const size_t> indices,
     LoweringContext* lowering_ctx) {
-  std::unordered_map<int64_t, size_t> output_tensor_id_map;
-  std::vector<std::pair<int64_t, int64_t>> input_output_alias_pair;
+  std::unordered_set<int64_t> output_tensor_ids;
+  std::vector<size_t> buffer_donor_indexs;
   // tensors[indices] represent all tensors that needs to be updated after
   // the execution. We can only alias the current buffer of these tensors since
   // those buffers are no longer needed after execution.
   for (size_t i = 0; i < indices.size(); ++i) {
     size_t tensor_index = indices[i];
     int64_t tensor_id = tensors[tensor_index]->data()->alias_id;
-    output_tensor_id_map[tensor_id] = i;
+    output_tensor_ids.insert(tensor_id);
   }
   const auto& parameters_data = lowering_ctx->GetParametersData();
   std::vector<ssize_t> alias_map(indices.size(), -1);
@@ -1251,60 +1250,19 @@ XLAGraphExecutor::BuildInputOutputAliases(
         static_cast<torch::lazy::LazyGraphExecutor::DeviceDataInfo*>(
             parameters_data[i]->info());
     if (data_info != nullptr && !data_info->read_only) {
-      auto it = output_tensor_id_map.find(data_info->tensor_id);
+      auto it = output_tensor_ids.find(data_info->tensor_id);
       // Parameter buffer's TensorId in output_tensor_id_map means
       // this buffer is not needed after execution since XLATensor will get a
       // new buffer.
-      if (it != output_tensor_id_map.end()) {
-        size_t output_index = it->second;
-        xla::XlaOp root = lowering_ctx->GetResult(output_index);
-        const xla::Shape& root_shape = ShapeHelper::ShapeOfXlaOp(root);
-        auto parameter_data_shape = UnwrapXlaData(parameters_data[i])->shape();
-        // Need to check whether existing buffer and the new value has the same
-        // shape and the existing buffer has not been aliased before aliasing
-        // the existing and new buffer.
-
-        bool equal_sharding;
-        // get sharding for the parameter data
-        std::optional<xla::OpSharding> parameter_sharding =
-            torch_xla::runtime::GetComputationClient()->GetDataSharding(
-                UnwrapXlaData(parameters_data[i]));
-        // get sharding for output tensor
-        size_t output_tensor_index = indices[output_index];
-        XLATensor::ShardingSpecPtr output_sharding =
-            tensors[output_tensor_index]->sharding_spec();
-        if (!parameter_sharding && !output_sharding) {
-          // Both parameter and output does not have sharding.
-          // TODO(JackCaoG): It is possible that output might get a sharding
-          // after sharding propagation. Consier not aliased here(if under SPMD
-          // mode).
-          equal_sharding = true;
-        } else if (parameter_sharding && output_sharding) {
-          equal_sharding = ShardingUtil::EqualOpShardings(
-              *parameter_sharding, output_sharding->sharding);
-        } else {
-          // one of the parameter and output does not have sharding.
-          equal_sharding = false;
-        }
-
-        if (parameter_data_shape == root_shape && alias_map[output_index] < 0 &&
-            equal_sharding) {
-          // parameter is not a tuple so param_index will always be {}
-          lowering_ctx->builder()->SetUpAlias(
-              {/*output_index=*/static_cast<int64_t>(output_index)},
-              /*param_number=*/i, /*param_index=*/{});
-          alias_map[output_index] = i;
-          input_output_alias_pair.push_back(std::make_pair(i, output_index));
-
-          TF_VLOG(6) << "Aliased paramter " << i << " with output "
-                     << output_index << ": " << parameter_data_shape;
-        }
+      if (it != output_tensor_ids.end()) {
+        buffer_donor_indexs.push_back(i);
+        lowering_ctx->builder()->AddBufferDonor(/*param_number=*/i,
+                                                /*param_index=*/{});
       }
     }
   }
-  TORCH_LAZY_VALUE_METRIC("InputOutputAliasCount",
-                          input_output_alias_pair.size());
-  return input_output_alias_pair;
+  TORCH_LAZY_VALUE_METRIC("InputOutputAliasCount", buffer_donor_indexs.size());
+  return buffer_donor_indexs;
 }
 
 XLAGraphExecutor::CompilationResult XLAGraphExecutor::Compile(
@@ -1337,7 +1295,7 @@ XLAGraphExecutor::CompilationResult XLAGraphExecutor::Compile(
   // Annotate HLO sharding selectively in the compuation.
   ShardingUtil::SetHloSharding(&lowering_ctx);
 
-  std::vector<std::pair<int64_t, int64_t>> input_output_alias_pair;
+  std::vector<size_t> buffer_donor_indices;
   // TODO(yeounoh) aliasing is disabled for partitioned computation,
   // since the current aliasing compares the unpartitioned input and output
   // shapes which can lead to an incorrect aliasing pairs if sharded.
@@ -1367,8 +1325,8 @@ XLAGraphExecutor::CompilationResult XLAGraphExecutor::Compile(
     // will later fetch the new value of A, which is incorrect.
     // But, when we issue a step barrier (force_ltc_data == true) we have to
     // turn everything into DEVICE_DATA, so we can activate aliasing.
-    input_output_alias_pair =
-        BuildInputOutputAliases(tensors, coll.indices, &lowering_ctx);
+    buffer_donor_indices =
+        SetBufferDonors(tensors, coll.indices, &lowering_ctx);
   }
 
   xla::XlaComputation computation = ConsumeValue(lowering_ctx.BuildXla());
@@ -1382,7 +1340,7 @@ XLAGraphExecutor::CompilationResult XLAGraphExecutor::Compile(
                << " parameters. Threadshold = "
                << parameter_wrapping_threadshold;
     computation = ConsumeValue(XlaHelpers::WrapXlaComputation(
-        computation, program_shape.parameters(), input_output_alias_pair));
+        computation, program_shape.parameters(), buffer_donor_indices));
     program_shape = ConsumeValue(computation.GetProgramShape());
   }
   xla::Shape shape = MakeShapeWithDeviceLayout(

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -337,9 +337,9 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
       PostOrderData* po_data,
       const std::vector<torch::lazy::BackendDataPtr>& tensor_data_vec);
 
-  std::vector<std::pair<int64_t, int64_t>> BuildInputOutputAliases(
-      const std::vector<XLATensorPtr>& tensors,
-      absl::Span<const size_t> indices, LoweringContext* lowering_ctx);
+  std::vector<size_t> SetBufferDonors(const std::vector<XLATensorPtr>& tensors,
+                                      absl::Span<const size_t> indices,
+                                      LoweringContext* lowering_ctx);
 
   // We don't use upstream Compile to have BuildInputOutputAliases.
   CompilationResult Compile(const std::vector<XLATensorPtr>& tensors,


### PR DESCRIPTION
XLA provided this new `AddBufferDonor` API to replace the old `SetUpAlias` one. The advantage of this new API is that it doesn't require the caller to explicitly match the computation input and output, which is hard to do in SPMD context since we don't know how compiler wants to shard the output. The `AddBufferDonor` promise that as long as user can tell which input buffer is not required after the execution, compiler can reuse this buffer for output.

TODO
1. add test
2. verify on SPMD