### PR TITLE
Enable float16 dtype for xla autocast

### DIFF
--- a/torch_xla/amp/autocast_mode.py
+++ b/torch_xla/amp/autocast_mode.py
@@ -28,7 +28,7 @@ class autocast(torch.amp.autocast_mode.autocast):
       backend = 'cuda'
       if dtype is None:
         dtype = torch.float16
-      elif dtype == torch.bfloat16:
+      elif dtype == torch.bfloat16 or dtype == torch.float16:
         if xr.is_bf16_supported() and not torch.cuda.is_available():
           # XLA:GPU with bfloat16 should run on `xla` backend
           # unless torch.autocast is compiled with cuda.


### PR DESCRIPTION
Enable float16 dtype for xla autocast after [pytorch#109554](https://github.com/pytorch/pytorch/pull/109554), this should be supported, with `xla:cast`:
```
IR {
  %0 = f32[] prim::Constant(), xla_shape=f32[], value=1
  %1 = f32[3,2]{1,0} aten::expand(%0), xla_shape=f32[3,2]{1,0}, size=(3, 2), dynamic_dims=(0, 0)
  %2 = f16[3,2]{1,0} xla::cast(%1), xla_shape=f16[3,2]{1,0}, type=f16, dtype=Half, stype=Float
  %3 = f32[] prim::Constant(), xla_shape=f32[], value=1
  %4 = f32[2,3]{1,0} aten::expand(%3), xla_shape=f32[2,3]{1,0}, size=(2, 3), dynamic_dims=(0, 0)
  %5 = f16[2,3]{1,0} xla::cast(%4), xla_shape=f16[2,3]{1,0}, type=f16, dtype=Half, stype=Float
  %6 = f16[2,2]{1,0} aten::mm(%5, %2), xla_shape=f16[2,2]{1,0}, ROOT=0
}
```

Do not merge until pytorch#109554 is merged.