### PR TITLE
Support of vstack and hstack op lowering.

### DIFF
--- a/codegen/xla_native_functions.yaml
+++ b/codegen/xla_native_functions.yaml
@@ -194,6 +194,7 @@ supported:
   - gelu_backward
   - hardtanh
   - hardtanh_backward
+  - hstack
   - index.Tensor
   - index_add
   - index_copy
@@ -343,6 +344,7 @@ supported:
   - view_as_complex_copy
   - view_as_real_copy
   - view_copy
+  - vstack
   - where.self
   - xlogy.Tensor
   - zero_

--- a/test/cpp/test_aten_xla_tensor_2.cpp
+++ b/test/cpp/test_aten_xla_tensor_2.cpp
@@ -990,6 +990,44 @@ TEST_F(AtenXlaTensorTest, TestMeanInDimsKeepCast) {
   }
 }
 
+TEST_F(AtenXlaTensorTest, TestStack) {
+  torch::Tensor a = torch::rand({4, 3, 4}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor b = torch::rand({4, 3, 4}, torch::TensorOptions(torch::kFloat));
+  for (auto dim : {-3, -2, -1, 0, 1, 2}) {
+    torch::Tensor c = torch::stack({a, b}, dim);
+    ForEachDevice([&](const torch::Device& device) {
+      torch::Tensor xla_a = CopyToDevice(a, device);
+      torch::Tensor xla_b = CopyToDevice(b, device);
+      torch::Tensor xla_c = torch::stack({xla_a, xla_b}, dim);
+      AllEqual(c, xla_c);
+    });
+  }
+}
+
+TEST_F(AtenXlaTensorTest, TestHstack) {
+  torch::Tensor a = torch::rand({4, 3, 4}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor b = torch::rand({4, 3, 4}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor c = torch::hstack({a, b});
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_a = CopyToDevice(a, device);
+    torch::Tensor xla_b = CopyToDevice(b, device);
+    torch::Tensor xla_c = torch::hstack({xla_a, xla_b});
+    AllEqual(c, xla_c);
+  });
+}
+
+TEST_F(AtenXlaTensorTest, TestVstack) {
+  torch::Tensor a = torch::rand({4, 3, 4}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor b = torch::rand({4, 3, 4}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor c = torch::vstack({a, b});
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_a = CopyToDevice(a, device);
+    torch::Tensor xla_b = CopyToDevice(b, device);
+    torch::Tensor xla_c = torch::vstack({xla_a, xla_b});
+    AllEqual(c, xla_c);
+  });
+}
+
 TEST_F(AtenXlaTensorTest, TestStd) {
   torch::Tensor a = torch::rand({4, 3, 4}, torch::TensorOptions(torch::kFloat));
   for (auto unbiased : {true, false}) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1372,6 +1372,10 @@ at::Tensor XLANativeFunctions::hardtanh_backward(const at::Tensor& grad_output,
       max_val));
 }
 
+at::Tensor XLANativeFunctions::hstack(at::TensorList tensors) {
+  return stack(tensors, 0);
+}
+
 at::Tensor XLANativeFunctions::index(
     const at::Tensor& self,
     const c10::List<c10::optional<at::Tensor>>& indices) {
@@ -3291,6 +3295,10 @@ at::Tensor XLANativeFunctions::view_copy_symint(const at::Tensor& self,
          "supported, please file a feature request against PyTorch/XLA.";
   return bridge::AtenFromXlaTensor(
       tensor_methods::view_symint(xla_input, shape));
+}
+
+at::Tensor XLANativeFunctions::vstack(at::TensorList tensors) {
+  return stack(tensors, 0);
 }
 
 at::Tensor XLANativeFunctions::where(const at::Tensor& condition,


### PR DESCRIPTION
Solves #5611 

1. Add the op lowering support for `hstack` and `vstack`;
2. Add the code unit test for `stack`, `hstack` and `vstack`.