### PR TITLE
Add cuda 12.1 support by adding cuda 12.1 trigger

### DIFF
--- a/infra/ansible/config/cuda_deps.yaml
+++ b/infra/ansible/config/cuda_deps.yaml
@@ -3,11 +3,13 @@
 cuda_deps:
   # List all libcudnn8 versions with `apt list -a libcudnn8`
   libcudnn:
+    "12.1": libcudnn8=8.9.2.26-1+cuda12.1
     "12.0": libcudnn8=8.8.0.121-1+cuda12.0
     "11.8": libcudnn8=8.7.0.84-1+cuda11.8
     "11.7": libcudnn8=8.5.0.96-1+cuda11.7
     "11.2": libcudnn8=8.1.1.33-1+cuda11.2
   libcudnn-dev:
+    "12.1": libcudnn8-dev=8.9.2.26-1+cuda12.1
     "12.0": libcudnn8-dev=8.8.0.121-1+cuda12.0
     "11.8": libcudnn8-dev=8.7.0.84-1+cuda11.8
     "11.7": libcudnn8-dev=8.5.0.96-1+cuda11.7

--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -9,6 +9,10 @@ nightly_builds = [
   },
   {
     accelerator  = "cuda"
+    cuda_version = "12.1"
+  },
+  {
+    accelerator  = "cuda"
     cuda_version = "12.0"
   },
   {


### PR DESCRIPTION
Per [PyTorch's release page](https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-compatibility-matrix), PyTorch has added experimental support for `CUDA 12.1, CUDNN 8.9.2.26`. We should do the same.