### PR TITLE
Clean up README for 2.1 release branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # PyTorch/XLA
 
-<b>Current CI status:</b>  ![GitHub Actions
-status](https://github.com/pytorch/xla/actions/workflows/build_and_test.yml/badge.svg)
-
 Note: PyTorch/XLA r2.1 will be the last release with XRT available as a legacy
 runtime. Our main release build will not include XRT, but it will be available
-in a separate package.
+in a separate package. See our [main README](https://github.com/pytorch/xla) for
+all available builds, including GPU builds.
 
 PyTorch/XLA is a Python package that uses the [XLA deep learning
 compiler](https://www.tensorflow.org/xla) to connect the [PyTorch deep learning
@@ -28,7 +26,7 @@ started:
 To install PyTorch/XLA a new VM:
 
 ```
-pip install torch~=2.1.0 torch_xla[tpu]~=2.1.0 -f https://storage.googleapis.com/libtpu-releases/libtpu_releases.html
+pip install torch~=2.1.0 torch_xla[tpu]~=2.1.0 -f https://storage.googleapis.com/libtpu-releases/index.html
 ```
 
 To update your existing training loop, make the following changes:
@@ -130,136 +128,14 @@ Our comprehensive user guides are available at:
 
 ## Available docker images and wheels
 
-### Wheel
-
-| Version | Cloud TPU VMs Wheel |
-| --- | ----------- |
-| 2.0 (Python 3.8) | `https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch_xla-2.0-cp38-cp38-linux_x86_64.whl` |
-| nightly >= 2023/04/25 (Python 3.8) | `https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-nightly-cp38-cp38-linux_x86_64.whl` |
-| nightly >= 2023/04/25 (Python 3.10) | `https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-nightly-cp310-cp310-linux_x86_64.whl` |
-
-<details>
-    <summary>older versions</summary>
-
-| Version | Cloud TPU VMs Wheel |
-|---------|-------------------|
-| 1.13 | `https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch_xla-1.13-cp38-cp38-linux_x86_64.whl` |
-| 1.12 | `https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch_xla-1.12-cp38-cp38-linux_x86_64.whl` |
-| 1.11 | `https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch_xla-1.11-cp38-cp38-linux_x86_64.whl` |
-| 1.10 | `https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch_xla-1.10-cp38-cp38-linux_x86_64.whl` |
-| nightly <= 2023/04/25 |  `https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch_xla-nightly-cp38-cp38-linux_x86_64.whl` |
-
-</details>
-
-<br/>
-
-Note: For TPU Pod customers using XRT (our legacy runtime), we have custom
-wheels for `torch`, `torchvision`, and `torch_xla` at
-`https://storage.googleapis.com/tpu-pytorch/wheels/xrt`.
-
-| Package | Cloud TPU VMs Wheel (XRT on Pod, Legacy Only) |
-| --- | ----------- |
-| torch_xla | `https://storage.googleapis.com/tpu-pytorch/wheels/xrt/torch_xla-2.0-cp38-cp38-linux_x86_64.whl` |
-| torch | `https://storage.googleapis.com/tpu-pytorch/wheels/xrt/torch-2.0-cp38-cp38-linux_x86_64.whl` |
-| torchvision | `https://storage.googleapis.com/tpu-pytorch/wheels/xrt/torchvision-2.0-cp38-cp38-linux_x86_64.whl` |
-
-<br/>
-
-| Version | GPU Wheel + Python 3.8 |
-| --- | ----------- |
-| 2.0 + CUDA 11.8 | `https://storage.googleapis.com/tpu-pytorch/wheels/cuda/118/torch_xla-2.0-cp38-cp38-linux_x86_64.whl` |
-| 2.0 + CUDA 11.7 | `https://storage.googleapis.com/tpu-pytorch/wheels/cuda/117/torch_xla-2.0-cp38-cp38-linux_x86_64.whl` |
-| 1.13 | `https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.13-cp38-cp38-linux_x86_64.whl` |
-| nightly + CUDA 12.0 >= 2023/06/27| `https://storage.googleapis.com/pytorch-xla-releases/wheels/cuda/12.0/torch_xla-nightly-cp38-cp38-linux_x86_64.whl` |
-| nightly + CUDA 11.8 <= 2023/04/25| `https://storage.googleapis.com/tpu-pytorch/wheels/cuda/118/torch_xla-nightly-cp38-cp38-linux_x86_64.whl` |
-| nightly + CUDA 11.8 >= 2023/04/25| `https://storage.googleapis.com/pytorch-xla-releases/wheels/cuda/11.8/torch_xla-nightly-cp38-cp38-linux_x86_64.whl` |
-
-<br/>
-
-| Version | GPU Wheel + Python 3.7 |
-| --- | ----------- |
-| 1.13 | `https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.13-cp37-cp37m-linux_x86_64.whl` |
-| 1.12 | `https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.12-cp37-cp37m-linux_x86_64.whl` |
-| 1.11 | `https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-1.11-cp37-cp37m-linux_x86_64.whl` |
-| nightly | `https://storage.googleapis.com/tpu-pytorch/wheels/cuda/112/torch_xla-nightly-cp37-cp37-linux_x86_64.whl` |
-
-<br/>
-
-| Version | Colab TPU Wheel |
-| --- | ----------- |
-| 2.0 | `https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-2.0-cp310-cp310-linux_x86_64.whl` |
-
-You can also add `+yyyymmdd` after `torch_xla-nightly` to get the nightly wheel
-of a specified date. To get the companion pytorch and torchvision nightly wheel,
-replace the `torch_xla` with `torch` or `torchvision` on above wheel links.
-
-#### Installing libtpu (before PyTorch/XLA 2.0)
-
-For PyTorch/XLA release r2.0 and older and when developing PyTorch/XLA, install
-the `libtpu` pip package with the following command:
-
-```
-pip3 install torch_xla[tpuvm]
-```
-
-This is only required on Cloud TPU VMs.
-
-### Docker
-
-| Version | Cloud TPU VMs Docker |
-| --- | ----------- |
-2.0 | `gcr.io/tpu-pytorch/xla:r2.0_3.8_tpuvm` |
-1.13 | `gcr.io/tpu-pytorch/xla:r1.13_3.8_tpuvm` |
-nightly python 3.10 | `us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.10_tpuvm` |
-nightly python 3.8 | `us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.8_tpuvm` |
-nightly python 3.10(>= 2023/04/25) | `us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.10_tpuvm_YYYYMMDD` |
-nightly python 3.8(>= 2023/04/25) | `us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.8_tpuvm_YYYYMMDD` |
-nightly at date(< 2023/04/25) | `gcr.io/tpu-pytorch/xla:nightly_3.8_tpuvm_YYYYMMDD` |
-
-<br/>
-
-| Version | GPU CUDA 12.0 + Python 3.8 Docker |
-| --- | ----------- |
-| nightly | `us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.8_cuda_12.0` |
-| nightly at date(>=2023/06/27) | `us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.8_cuda_12.0_YYYYMMDD` |
-
-<br/>
-
-| Version | GPU CUDA 11.8 + Python 3.8 Docker |
-| --- | ----------- |
-| 2.0 | `gcr.io/tpu-pytorch/xla:r2.0_3.8_cuda_11.8` |
-| nightly | `us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.8_cuda_11.8` |
-| nightly at date(>=2023/04/25) | `us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.8_cuda_11.8_YYYYMMDD` |
-| nightly at date(<2023/04/25) | `gcr.io/tpu-pytorch/xla:nightly_3.8_cuda_11.8_YYYYMMDD` |
-
-<br/>
-
-| Version | GPU CUDA 11.7 + Python 3.8 Docker |
-| --- | ----------- |
-| 2.0 | `gcr.io/tpu-pytorch/xla:r2.0_3.8_cuda_11.7` |
-
-<br/>
-
-| Version | GPU CUDA 11.2 + Python 3.8 Docker |
-| --- | ----------- |
-| 1.13 | `gcr.io/tpu-pytorch/xla:r1.13_3.8_cuda_11.2` |
-
-<br/>
-
-| Version | GPU CUDA 11.2 + Python 3.7 Docker |
-| --- | ----------- |
-1.13 | `gcr.io/tpu-pytorch/xla:r1.13_3.7_cuda_11.2` |
-1.12 | `gcr.io/tpu-pytorch/xla:r1.12_3.7_cuda_11.2` |
-
-
-To run on [compute instances with
-GPUs](https://cloud.google.com/compute/docs/gpus/create-vm-with-gpus).
+For all builds and all versions of `torch-xla`, see our main [GitHub
+README](https://github.com/pytorch/xla).
 
 ## Troubleshooting
 
 If PyTorch/XLA isn't performing as expected, see the [troubleshooting
-guide](TROUBLESHOOTING.md), which has suggestions for debugging and optimizing
-your network(s).
+guide](https://github.com/pytorch/xla/blob/master/TROUBLESHOOTING.md), which has
+suggestions for debugging and optimizing your network(s).
 
 ## Providing Feedback
 
@@ -269,7 +145,8 @@ reports, feature requests, build issues, etc. are all welcome!
 
 ## Contributing
 
-See the [contribution guide](CONTRIBUTING.md).
+See the [contribution
+guide](https://github.com/pytorch/xla/blob/master/CONTRIBUTING.md).
 
 ## Disclaimer
 

--- a/setup.py
+++ b/setup.py
@@ -356,7 +356,7 @@ setup(
     },
     extras_require={
         # On Cloud TPU VM install with:
-        # pip install torch_xla[tpu] -f https://storage.googleapis.com/libtpu-releases/libtpu_releases.html
+        # pip install torch_xla[tpu] -f https://storage.googleapis.com/libtpu-releases/index.html
         'tpu': [f'libtpu-nightly=={_libtpu_version}'],
     },
     cmdclass={


### PR DESCRIPTION
- Remove CI status badge
- Refer to main README for list of all build versions
- Change `libtpu_releases.html` to `index.html` (also update corresponding setup.py comment)
- Fix some broken relative links