### PR TITLE
Fix log spam when libtpu is loaded

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,6 +42,7 @@ http_archive(
         "//openxla_patches:f16_abi_clang.diff",
         "//openxla_patches:gpu_race_condition.diff",
         "//openxla_patches:constexpr_return.diff",
+        "//openxla_patches:pjrt_api_tsl_logging.diff",
         "//openxla_patches:pjrt_c_api_dynamic_dimensions.diff",
     ],
     strip_prefix = "xla-97a5f819faf9ff793b7ba68ff1f31f74f9459c18",

--- a/openxla_patches/pjrt_api_tsl_logging.diff
+++ b/openxla_patches/pjrt_api_tsl_logging.diff
@@ -1,0 +1,21 @@
+# Fixes log spam when loading libtpu. We should fix this upstream.
+diff --git a/xla/pjrt/pjrt_api.cc b/xla/pjrt/pjrt_api.cc
+index 132cfaff0..887e842e0 100644
+--- a/xla/pjrt/pjrt_api.cc
++++ b/xla/pjrt/pjrt_api.cc
+@@ -17,7 +17,6 @@ limitations under the License.
+
+ #include <utility>
+
+-#include "absl/log/log.h"
+ #include "absl/status/status.h"
+ #include "absl/strings/str_cat.h"
+ #include "xla/pjrt/c/pjrt_c_api.h"
+@@ -33,6 +32,7 @@ limitations under the License.
+ #include "xla/pjrt/c/pjrt_c_api_helpers.h"
+ #include "xla/status.h"
+ #include "xla/statusor.h"
++#include "tsl/platform/logging.h"
+ #include "tsl/platform/errors.h"
+
+ namespace pjrt {


### PR DESCRIPTION
Swap absl logging for TSL logging, since we don't initialize absl.

Currently, every process prints this warning:

```
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1692408336.588809 3320398 tpu_initializer_framework_helper.cc:78] Libtpu path is: /usr/local/lib/python3.8/site-packages/libtpu/libtpu.so
I0000 00:00:1692408374.448069 3320398 pjrt_c_api_client.cc:110] PjRtCApiClient created.
```

With this PR, those logs are visible only if you enabled verbose logging:

```
# python rand.py 
tensor([[-0.5182, -0.7280, -0.1179],
        [-0.7625,  1.7006, -0.2758],
        [-1.1760, -1.6168, -0.9752]], device='xla:0')
# TF_CPP_MIN_LOG_LEVEL=0 python rand.py 
2023-09-19 19:04:55.129028: I external/xla/xla/pjrt/pjrt_api.cc:98] GetPjrtApi was found for tpu at /usr/local/lib/python3.8/site-packages/libtpu/libtpu.so
2023-09-19 19:04:55.129101: I external/xla/xla/pjrt/pjrt_api.cc:67] PJRT_Api is set for device type tpu
2023-09-19 19:04:55.129109: I external/xla/xla/pjrt/pjrt_api.cc:72] PJRT plugin for tpu has PJRT API version 0.23. The framework PJRT API version is 0.23.
2023-09-19 19:04:58.376339: I external/xla/xla/pjrt/pjrt_c_api_client.cc:116] PjRtCApiClient created.
tensor([[-0.5182, -0.7280, -0.1179],
        [-0.7625,  1.7006, -0.2758],
        [-1.1760, -1.6168, -0.9752]], device='xla:0')
```

I will propose this fix in upstream OpenXLA, then we can remove this patch after the next pin update.
