### PR TITLE
Autocat test helper dtype default needs to be unset

### DIFF
--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -261,7 +261,7 @@ class TestAutocastBase(unittest.TestCase):
                                out_type=None,
                                module=torch,
                                add_kwargs=None,
-                               autocast_dtype=torch.float16):
+                               autocast_dtype=None):
     # helper to cast args
     def cast(val, to_type):
       if isinstance(val, torch.Tensor):


### PR DESCRIPTION
Autocat test helper dtype default needs to be unset.

Test plan:
- tested on a TPU VM
- tested on a GPU VM