### PR TITLE
Support persistent computation caching to disk

### DIFF
--- a/torch_xla/csrc/runtime/cache.h
+++ b/torch_xla/csrc/runtime/cache.h
@@ -2,6 +2,7 @@
 #define XLA_CLIENT_CACHE_H_
 
 #include <sys/stat.h>
+#include <torch/csrc/lazy/core/metrics.h>
 
 #include <filesystem>
 #include <fstream>

--- a/torch_xla/csrc/runtime/cache.h
+++ b/torch_xla/csrc/runtime/cache.h
@@ -1,10 +1,15 @@
 #ifndef XLA_CLIENT_CACHE_H_
 #define XLA_CLIENT_CACHE_H_
 
+#include <sys/stat.h>
+
+#include <filesystem>
+#include <fstream>
 #include <functional>
 #include <list>
 #include <memory>
 #include <mutex>
+#include <sstream>
 #include <unordered_map>
 #include <utility>
 
@@ -12,22 +17,32 @@ namespace torch_xla {
 namespace runtime {
 namespace util {
 
+template <typename K, typename T, typename H = std::hash<K>,
+          typename E = std::equal_to<K>>
+class AbstractCache {
+ public:
+  using TypePtr = std::shared_ptr<T>;
+  virtual TypePtr Add(K key, TypePtr object) = 0;
+  virtual TypePtr Get(const K& key) = 0;
+  virtual bool Erase(const K& key) = 0;
+  virtual void Clear() = 0;
+};
+
 // Generic key and object cache with LRU expiration policy. The objects of type
 // T will be stored as std::shared_ptr<T> and taken and returned as such, by the
 // cache API.
 template <typename K, typename T, typename H = std::hash<K>,
           typename E = std::equal_to<K>>
-class Cache {
+class Cache : public AbstractCache<K, T, H, E> {
  public:
   using TypePtr = std::shared_ptr<T>;
   using Element = std::pair<K, TypePtr>;
-
   explicit Cache(size_t max_size) : max_size_(max_size) {}
 
   // Adds an object to the cache, unless it already exists. If the cache grows
   // beyond the limit set during construction, the oldest used object will be
   // removed from the cache.
-  TypePtr Add(K key, TypePtr object) {
+  TypePtr Add(K key, TypePtr object) override {
     std::lock_guard<std::mutex> slock(lock_);
     element_list_.emplace_front(Element(std::move(key), std::move(object)));
     auto it = element_list_.begin();
@@ -47,7 +62,7 @@ class Cache {
   // the LRU list gets moved to the head of the list.
   // Returns nullptr if no object with the specified key is found within the
   // cache.
-  TypePtr Get(const K& key) {
+  TypePtr Get(const K& key) override {
     std::lock_guard<std::mutex> slock(lock_);
     auto it = element_map_.find(&key);
     if (it == element_map_.end()) {
@@ -57,7 +72,7 @@ class Cache {
     return it->second->second;
   }
 
-  bool Erase(const K& key) {
+  bool Erase(const K& key) override {
     std::lock_guard<std::mutex> slock(lock_);
     auto it = element_map_.find(&key);
     if (it == element_map_.end()) {
@@ -69,7 +84,7 @@ class Cache {
     return true;
   }
 
-  void Clear() {
+  void Clear() override {
     std::lock_guard<std::mutex> slock(lock_);
     element_map_.clear();
     element_list_.clear();
@@ -104,6 +119,81 @@ class Cache {
   size_t max_size_ = 0;
   ElementList element_list_;
   ElementMap element_map_;
+};
+
+template <typename K, typename T, typename H = std::hash<K>,
+          typename E = std::equal_to<K>>
+class PersistentCache : public AbstractCache<K, T, H, E> {
+ public:
+  using TypePtr = std::shared_ptr<T>;
+
+  explicit PersistentCache(
+      int kMaxCacheSize, std::string cache_dir,
+      std::function<void(TypePtr&, std::ostream&)> serialize,
+      std::function<TypePtr(std::istream&)> deserialize)
+      : memcache_(kMaxCacheSize),
+        cache_dir_(cache_dir),
+        serialize_(serialize),
+        deserialize_(deserialize) {
+    std::filesystem::create_directories(cache_dir);
+  }
+
+  TypePtr Add(K key, TypePtr obj) override {
+    std::string path = GetPath(key);
+    if (!Exists(path)) {
+      std::ofstream out(path, std::ios::binary);
+      serialize_(obj, out);
+    }
+    return memcache_.Add(key, obj);
+  }
+
+  TypePtr Get(const K& key) override {
+    TypePtr mem = memcache_.Get(key);
+    if (mem) {
+      return mem;
+    }
+    std::string path = GetPath(key);
+    if (!Exists(path)) {
+      TORCH_LAZY_COUNTER("PersistentCacheMiss", 1);
+      return nullptr;
+    }
+    std::ifstream in(path, std::ios::binary);
+    TypePtr val = deserialize_(in);
+    if (!val) {
+      TORCH_LAZY_COUNTER("PersistentCacheDeserializeFailure", 1);
+      return nullptr;
+    }
+    TORCH_LAZY_COUNTER("PersistentCacheHit", 1);
+    // Make sure the memcache tracks the value to prevent multiple loads
+    return memcache_.Add(key, val);
+  }
+
+  void Clear() override {
+    memcache_.Clear();
+    // TODO(jonbolin): Clear the cache on disk
+  }
+
+  bool Erase(const K& key) override {
+    memcache_.Erase(key);
+    return std::remove(GetPath(key).c_str());
+  }
+
+ private:
+  std::string GetPath(K key) {
+    std::stringstream ss;
+    ss << cache_dir_ << "/" << key << ".bin";
+    return ss.str();
+  }
+
+  bool Exists(std::string path) {
+    struct stat buffer;
+    return stat(path.c_str(), &buffer) == 0;
+  }
+
+  Cache<K, T, H, E> memcache_;
+  std::function<void(TypePtr&, std::ostream&)> serialize_;
+  std::function<TypePtr(std::istream&)> deserialize_;
+  std::string cache_dir_;
 };
 
 }  // namespace util

--- a/torch_xla/csrc/runtime/computation_client.h
+++ b/torch_xla/csrc/runtime/computation_client.h
@@ -335,6 +335,14 @@ class ComputationClient {
   virtual std::vector<ComputationPtr> Compile(
       std::vector<CompileInstance> instances) = 0;
 
+  // Serialize a computation to the given ostream.
+  virtual bool SerializeComputation(ComputationPtr computation,
+                                    std::ostream& out) = 0;
+
+  // Deserialize an isteam back to a Computation. The input stream should yield
+  // the result of a SerializeComputation call.
+  virtual ComputationPtr DeserializeComputation(std::istream& in) = 0;
+
   // Executes computation with arguments and returns the result.
   // The passed device must match the common device of the arguments Data.
   // If options.explode_tuple is true, the output tuple will be decomposed into

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -1,5 +1,8 @@
 #include "torch_xla/csrc/runtime/pjrt_computation_client.h"
 
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+
 #include <algorithm>
 #include <unordered_set>
 #include <vector>
@@ -525,6 +528,66 @@ std::vector<ComputationClient::ComputationPtr> PjRtComputationClient::Compile(
   }
 
   return computations;
+}
+
+bool PjRtComputationClient::SerializeComputation(ComputationPtr computation,
+                                                 std::ostream& out) {
+  XLA_CHECK(computation->devices().size() == 1 &&
+            computation->devices()[0] == "SPMD:0")
+      << "Persistent compilation cache only supports SPMD";
+  const PjRtComputation& pjrt_computation =
+      dynamic_cast<const PjRtComputation&>(*computation);
+
+  google::protobuf::io::OstreamOutputStream zero_copy_stream(&out);
+  google::protobuf::io::CodedOutputStream coded_stream(&zero_copy_stream);
+
+  auto computation_proto = computation->computation().proto();
+  coded_stream.WriteVarint64(computation_proto.ByteSize());
+  if (!computation_proto.SerializeToCodedStream(&coded_stream)) return false;
+
+  auto program_shape_proto = computation->program_shape().ToProto();
+  coded_stream.WriteVarint64(program_shape_proto.ByteSize());
+  if (!program_shape_proto.SerializeToCodedStream(&coded_stream)) return false;
+
+  auto executable = pjrt_computation.executable->SerializeExecutable();
+  if (!executable.ok()) return false;
+  coded_stream.WriteVarint64(executable->size());
+  coded_stream.WriteString(*executable);
+  return true;
+}
+
+ComputationClient::ComputationPtr PjRtComputationClient::DeserializeComputation(
+    std::istream& in) {
+  xla::HloModuleProto computation_proto;
+  xla::ProgramShapeProto program_shape_proto;
+  google::protobuf::io::IstreamInputStream zero_copy_stream(&in);
+  google::protobuf::io::CodedInputStream coded_stream(&zero_copy_stream);
+
+  uint64_t computation_size;
+  coded_stream.ReadVarint64(&computation_size);
+  auto limit = coded_stream.PushLimit(computation_size);
+  if (!computation_proto.ParseFromCodedStream(&coded_stream)) return nullptr;
+  coded_stream.PopLimit(limit);
+
+  uint64_t program_shape_size;
+  coded_stream.ReadVarint64(&program_shape_size);
+  limit = coded_stream.PushLimit(program_shape_size);
+  if (!program_shape_proto.ParseFromCodedStream(&coded_stream)) return nullptr;
+  coded_stream.PopLimit(limit);
+
+  uint64_t executable_size;
+  coded_stream.ReadVarint64(&executable_size);
+  std::string serialized;
+  serialized.resize(executable_size + 1);
+  if (!coded_stream.ReadString(&serialized, executable_size)) return nullptr;
+  auto executable = client_->DeserializeExecutable(serialized, std::nullopt);
+  if (!executable.ok()) return nullptr;
+
+  // TODO(jonbolin): Only supports SPMD-mode execution
+  std::vector<std::string> devices = {"SPMD:0"};
+  return std::make_shared<PjRtComputation>(
+      xla::XlaComputation(computation_proto),
+      xla::ProgramShape(program_shape_proto), devices, std::move(*executable));
 }
 
 std::vector<ComputationClient::DataPtr>

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -576,8 +576,8 @@ ComputationClient::ComputationPtr PjRtComputationClient::DeserializeComputation(
 
   // TODO(jonbolin): Only supports SPMD-mode execution
   std::vector<std::string> devices = {"SPMD:0"};
-  return std::make_shared<PjRtComputation>(
-      std::move(computation), *program_shape, devices, std::move(executable));
+  return std::make_shared<PjRtComputation>(std::move(computation), devices,
+                                           std::move(executable));
 }
 
 std::vector<ComputationClient::DataPtr>

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -51,6 +51,10 @@ class PjRtComputationClient : public ComputationClient {
   std::vector<ComputationPtr> Compile(
       std::vector<CompileInstance> instances) override;
 
+  bool SerializeComputation(ComputationPtr computation, std::ostream& out);
+
+  ComputationPtr DeserializeComputation(std::istream& in);
+
   std::vector<DataPtr> ExecuteComputation(
       const Computation& computation, absl::Span<const DataPtr> arguments,
       const std::string& device,

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -473,7 +473,7 @@ XLAGraphExecutor::ComputationCache* createComputationCache() {
       runtime::sys_util::GetEnvInt("XLA_COMPILATION_CACHE_SIZE", 1024);
   static std::string persistentCacheDir = runtime::sys_util::GetEnvString(
       "XLA_PERSISTENT_COMPILATION_CACHE_PATH", "");
-  if (persistentCacheDir != "") {
+  if (!persistentCacheDir.empty()) {
     auto serialize_fn = [](auto& computation, auto& ostream) -> bool {
       return runtime::GetComputationClient()->SerializeComputation(
           computation->computation->client_computation(), ostream);

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -488,8 +488,10 @@ XLAGraphExecutor::ComputationCache* createComputationCache() {
       return std::make_shared<XLAGraphExecutor::CachedComputation>(
           computation, /*is_sharded=*/true);
     };
+    /* In a distributed SPMD context, only one worker should write. */
+    bool readonly = runtime::GetComputationClient()->GetProcessIndex() != 0;
     return new XLAGraphExecutor::PersistentCache(
-        kMaxCacheSize, persistentCacheDir, serialize_fn, deserialize_fn);
+        kMaxCacheSize, persistentCacheDir, readonly, serialize_fn, deserialize_fn);
   }
   return new XLAGraphExecutor::MemoryCache(kMaxCacheSize);
 }

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -490,8 +490,9 @@ XLAGraphExecutor::ComputationCache* createComputationCache() {
     };
     /* In a distributed SPMD context, only one worker should write. */
     bool readonly = runtime::GetComputationClient()->GetProcessIndex() != 0;
-    return new XLAGraphExecutor::PersistentCache(
-        kMaxCacheSize, persistentCacheDir, readonly, serialize_fn, deserialize_fn);
+    return new XLAGraphExecutor::PersistentCache(kMaxCacheSize,
+                                                 persistentCacheDir, readonly,
+                                                 serialize_fn, deserialize_fn);
   }
   return new XLAGraphExecutor::MemoryCache(kMaxCacheSize);
 }

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -166,8 +166,14 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
   };
 
   using ComputationCache =
+      runtime::util::AbstractCache<torch::lazy::hash_t, CachedComputation,
+                                   torch::lazy::HashReducer>;
+  using MemoryCache =
       runtime::util::Cache<torch::lazy::hash_t, CachedComputation,
                            torch::lazy::HashReducer>;
+  using PersistentCache =
+      runtime::util::PersistentCache<torch::lazy::hash_t, CachedComputation,
+                                     torch::lazy::HashReducer>;
 
   ComputationCache* GetComputationCache();
 


### PR DESCRIPTION
Allow saving computations to disk for reuse across executions. Only supports SPMD-mode for now. To use, configure the environment variable `XLA_PERSISTENT_CACHE_PATH` to the correct path for the persistent cache to live.

The persistent cache does *not* use LRU to evict compilation results from disk.

This change depends on https://github.com/pytorch/xla/pull/5633 to stabilize the hash for `Constant` ops.