### PR TITLE
Create cuda 12.1 dev image trigger.

### DIFF
--- a/infra/tpu-pytorch-releases/dev_images.auto.tfvars
+++ b/infra/tpu-pytorch-releases/dev_images.auto.tfvars
@@ -8,4 +8,9 @@ dev_images = [
     cuda_version = "11.8"
     extra_tags   = ["cuda"]
   }
+  {
+    accelerator  = "cuda"
+    cuda_version = "12.1"
+    extra_tags   = ["cuda"]
+  }
 ]


### PR DESCRIPTION
Need to test multihost local change on a newer cuda version than 11.8, since we support cuda 12.1 now.

Without this trigger, it's very tricky/non-trivial to set up all dependencies and environment variable correctly in order to build torch_xla.