### PR TITLE
Fix accidental override of XRT PyTorch branch

### DIFF
--- a/infra/tpu-pytorch-releases/artifacts_builds.tf
+++ b/infra/tpu-pytorch-releases/artifacts_builds.tf
@@ -131,7 +131,6 @@ module "xrt_versioned_builds" {
   for_each = local.xrt_versioned_builds_dict
 
   ansible_vars = merge(each.value, {
-    pytorch_git_rev = "main"
     xla_git_rev     = "$COMMIT_SHA"
   })
 

--- a/infra/tpu-pytorch-releases/dev_images.auto.tfvars
+++ b/infra/tpu-pytorch-releases/dev_images.auto.tfvars
@@ -7,7 +7,7 @@ dev_images = [
     accelerator  = "cuda"
     cuda_version = "11.8"
     extra_tags   = ["cuda"]
-  }
+  },
   {
     accelerator  = "cuda"
     cuda_version = "12.1"


### PR DESCRIPTION
Fix missing comma in #5628 

Terraform plan includes #5628 since the change did not deploy

<details>

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # module.dev_images["3.8_cuda_12.1"].module.cloud_build.google_cloudbuild_trigger.trigger will be created
  + resource "google_cloudbuild_trigger" "trigger" {
      + create_time        = (known after apply)
      + description        = "Builds development:3.8_cuda_12.1 image. Trigger managed by Terraform setup in infra/tpu-pytorch-releases/dev_images.tf."
      + id                 = (known after apply)
      + include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
      + included_files     = [
          + "infra/**",
        ]
      + location           = "us-central1"
      + name               = "dev-3-8-cuda-12-1"
      + project            = (known after apply)
      + trigger_id         = (known after apply)

      + approval_config {
          + approval_required = (known after apply)
        }

      + build {
          + timeout = "3600s"

          + options {
              + dynamic_substitutions = true
              + substitution_option   = "ALLOW_LOOSE"
              + worker_pool           = "projects/tpu-pytorch-releases/locations/us-central1/workerPools/main"
            }

          + step {
              + args = [
                  + "fetch",
                  + "--unshallow",
                ]
              + id   = "git_fetch"
              + name = "gcr.io/cloud-builders/git"
            }
          + step {
              + args = [
                  + "checkout",
                  + "$COMMIT_SHA",
                ]
              + id   = "git_checkout"
              + name = "gcr.io/cloud-builders/git"
            }
          + step {
              + args       = [
                  + "-c",
                  + "docker build --progress=plain --network=cloudbuild -f=development.Dockerfile . --build-arg=python_version=3.8 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"cuda_version\":\"12.1\",\"python_version\":\"3.8\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:$(echo cuda)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:$(echo 3.8_cuda_12.1)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:$(echo 3.8_cuda_12.1_$(date +%Y%m%d))\" -t=local_image",
                ]
              + dir        = "infra/ansible"
              + entrypoint = "bash"
              + id         = "build_development_docker_image"
              + name       = "gcr.io/cloud-builders/docker"
            }
          + step {
              + args       = [
                  + "-c",
                  + "docker push --all-tags us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development",
                ]
              + entrypoint = "bash"
              + id         = "push_development_docker_image"
              + name       = "gcr.io/cloud-builders/docker"
            }
        }

      + github {
          + name  = "xla"
          + owner = "pytorch"

          + push {
              + branch = "^master$"
            }
        }
    }

  # module.xrt_versioned_builds["r2.1.0rc5_xrt_3.10_cuda_12.0"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id             = "projects/tpu-pytorch-releases/locations/us-central1/triggers/9ed0ca8d-d6af-4001-b70c-fe760990f8ed"
        name           = "r2-1-0rc5-xrt-3-10-cuda-12-0"
        tags           = []
        # (9 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"cuda_version\":\"12.0\",\"package_version\":\"2.1.0rc5+xrt\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1.0rc5_xrt_3.10_cuda_12.0)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1.0rc5_xrt_3.10_cuda_12.0_$(date +%Y%m%d))\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"cuda\",\"arch\":\"amd64\",\"cuda_version\":\"12.0\",\"package_version\":\"2.1.0rc5+xrt\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"v2.1.0-rc5\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1.0rc5_xrt_3.10_cuda_12.0)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1.0rc5_xrt_3.10_cuda_12.0_$(date +%Y%m%d))\" -t=local_image",
                ]
                id               = "build_xla_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.xrt_versioned_builds["r2.1.0rc5_xrt_3.10_tpuvm"].module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id             = "projects/tpu-pytorch-releases/locations/us-central1/triggers/d672a2a3-0ce1-4a67-8ba1-a1a252e6956b"
        name           = "r2-1-0rc5-xrt-3-10-tpuvm"
        tags           = []
        # (9 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (3 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  - "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"package_version\":\"2.1.0rc5+xrt\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1.0rc5_xrt_3.10_tpuvm)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1.0rc5_xrt_3.10_tpuvm_$(date +%Y%m%d))\" -t=local_image",
                  + "docker build --progress=plain --network=cloudbuild -f=Dockerfile . --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"cuda_version\":\"11.8\",\"package_version\":\"2.1.0rc5+xrt\",\"python_version\":\"3.10\",\"pytorch_git_rev\":\"v2.1.0-rc5\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1.0rc5_xrt_3.10_tpuvm)\" -t=\"us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:$(echo r2.1.0rc5_xrt_3.10_tpuvm_$(date +%Y%m%d))\" -t=local_image",
                ]
                id               = "build_xla_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (7 unchanged attributes hidden)
            }

            # (6 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

Plan: 1 to add, 2 to change, 0 to destroy.
```

</details>

Note this difference: `"pytorch_git_rev\":\"main\"` vs `\"pytorch_git_rev\":\"v2.1.0-rc5\"`