### PR TITLE
Stabilize Constant hash across processes

### DIFF
--- a/torch_xla/csrc/ops/constant.cpp
+++ b/torch_xla/csrc/ops/constant.cpp
@@ -4,12 +4,16 @@
 #include <sstream>
 
 #include "torch_xla/csrc/lowering_context.h"
+#include "torch_xla/csrc/runtime/xla_util.h"
+#include "torch_xla/csrc/torch_util.h"
+#include "xla/layout_util.h"
+#include "xla/shape_util.h"
 
 namespace torch_xla {
 
 Constant::Constant(xla::Literal value)
     : XlaNode(torch::lazy::OpKind(at::prim::Constant), value.shape(),
-              /*num_outputs=*/1, absl::Hash<xla::LiteralBase>{}(value)),
+              /*num_outputs=*/1, LiteralHash(value)),
       value_(std::move(value)) {}
 
 std::string Constant::ToString() const {
@@ -28,6 +32,25 @@ torch::lazy::NodePtr Constant::Clone(torch::lazy::OpList operands) const {
 
 XlaOpVector Constant::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::ConstantLiteral(loctx->builder(), value_), loctx);
+}
+
+// Based on the AbslHash implementation in
+// https://github.com/openxla/xla/blob/46baaafb19d6819d01b3f91be78b5a1e8cc9e14f/xla/literal.h#L323-L341
+// AbslHash randomizes the seed for each process, so the resulting hash is not
+// suitable for persistent storage.
+torch::lazy::hash_t LiteralHash(const xla::Literal& l) {
+  auto hash = torch::lazy::Hash(l.shape());
+  xla::ShapeUtil::ForEachSubshape(l.shape(), [&](const xla::Shape& subshape,
+                                                 const xla::ShapeIndex& index) {
+    if (!subshape.IsArray()) {
+      return;
+    }
+    XLA_CHECK(xla::LayoutUtil::IsDenseArray(subshape));
+    auto data = absl::MakeConstSpan(
+        static_cast<const char*>(l.untyped_data(index)), l.size_bytes(index));
+    hash = torch::lazy::HashCombine(torch::lazy::Hash(data), hash);
+  });
+  return hash;
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/constant.h
+++ b/torch_xla/csrc/ops/constant.h
@@ -21,6 +21,8 @@ class Constant : public XlaNode {
   xla::Literal value_;
 };
 
+torch::lazy::hash_t LiteralHash(const xla::Literal& l);
+
 }  // namespace torch_xla
 
 #endif  // XLA_TORCH_XLA_CSRC_OPS_CONSTANT_H_


### PR DESCRIPTION
The hash for `Constant` ops currently depends on the [AbslHash implementation](https://github.com/openxla/xla/blob/46baaafb19d6819d01b3f91be78b5a1e8cc9e14f/xla/literal.h#L323-L341) for XLA literals. AbslHash intentionally randomizes the hash seed on every process, so this breaks the persistent compilation caching in https://github.com/pytorch/xla/pull/5623.

This change ports the AbslHash logic to use torch::lazy::hash to ensure the hash is consistent across executions.