### PR TITLE
Update xla base image to support CUDA 12.0

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -27,6 +27,11 @@ if which sccache > /dev/null; then
   sccache --zero-stats
 fi
 
+# Allow bash to find missing pakcage versions
+if [[ -e /opt/conda/lib/libtinfo.so.6 ]]; then
+  rm /opt/conda/lib/libtinfo.so.6
+fi
+
 rebase_pull_request_on_target_branch
 
 pushd $PYTORCH_DIR
@@ -49,6 +54,7 @@ source $XLA_DIR/xla_env
 export GCLOUD_SERVICE_KEY_FILE="$XLA_DIR/default_credentials.json"
 export SILO_NAME='cache-silo-ci-gcc-11'  # cache bucket for CI
 export BUILD_CPP_TESTS='1'
+
 build_torch_xla $XLA_DIR
 
 popd

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -77,6 +77,10 @@ function install_deps_pytorch_xla() {
 
   sudo apt-get -qq update
 
+  # Hack similar to https://github.com/pytorch/pytorch/pull/105227/files#diff-9e59213240d3b55d2ddc53c8c096db9eece0665d64f46473454f9dc0c10fd804
+  # TODO(yeounoh) confirm that this is not needed here.
+  sudo rm /opt/conda/lib/libstdc++.so*
+
   sudo apt-get -qq install npm nodejs
 
   # Install LCOV and llvm-cov to generate C++ coverage reports
@@ -91,33 +95,6 @@ function install_deps_pytorch_xla() {
   fi
 
   sudo ln -s "$(command -v bazelisk)" /usr/bin/bazel
-
-  # Install gcc-11
-  sudo apt-get update
-  # Update ppa for GCC
-  sudo apt-get install -y software-properties-common
-  sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  sudo apt update -y
-  sudo apt install -y gcc-11
-  sudo apt install -y g++-11
-  sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100
-  sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100
-
-  # Installing gcc/g++-11 could break existing toolchain.
-  sudo apt install --reinstall libffi-dev
-  sudo apt install -y gcc-10 g++-10
-  export CC=gcc-10
-  export CXX=g++-10
-
-  export NVCC_PREPEND_FLAGS='-ccbin /usr/bin/g++-11'
-
-  # Hack similar to https://github.com/pytorch/pytorch/pull/105227/files#diff-9e59213240d3b55d2ddc53c8c096db9eece0665d64f46473454f9dc0c10fd804
-  sudo rm /opt/conda/lib/libstdc++.so*
-
-  # Update gcov for test coverage
-  sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-11 100
-  sudo update-alternatives --install /usr/bin/gcov-dump gcov-dump /usr/bin/gcov-dump-11 100
-  sudo update-alternatives --install /usr/bin/gcov-tool gcov-tool /usr/bin/gcov-tool-11 100
 
   # Symnlink the missing cuda headers if exists
   CUBLAS_PATTERN="/usr/include/cublas*"

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -103,6 +103,12 @@ function install_deps_pytorch_xla() {
   sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100
   sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100
 
+  # Installing gcc/g++-11 could break existing toolchain.
+  sudo apt install --reinstall libffi-dev
+  sudo apt install -y gcc-10 g++-10
+  export CC=gcc-10
+  export CXX=g++-10
+
   export NVCC_PREPEND_FLAGS='-ccbin /usr/bin/g++-11'
 
   # Hack similar to https://github.com/pytorch/pytorch/pull/105227/files#diff-9e59213240d3b55d2ddc53c8c096db9eece0665d64f46473454f9dc0c10fd804

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -5,9 +5,9 @@ FROM "${base_image}"
 
 ARG python_version="3.10"
 ARG cuda="1"
-ARG cuda_compute="5.2,7.5,8.0"
-ARG cc="clang-8"
-ARG cxx="clang++-8"
+ARG cuda_compute="7.0,7.5,8.0"
+ARG cc="gcc-11"
+ARG cxx="g++-11"
 ARG cxx_abi="1"
 ARG tpuvm=""
 
@@ -95,6 +95,7 @@ ENV PATH $CARGO_HOME/bin:$PATH
 ADD ./install_conda.sh install_conda.sh
 RUN sudo chown jenkins ./install_conda.sh
 RUN bash ./install_conda.sh "${python_version}" /opt/conda
+ENV LD_LIBRARY_PATH /opt/conda/lib:/usr/local/lib:$LD_LIBRARY_PATH
 
 RUN echo "conda activate base" >> ~/.bashrc
 RUN echo "export TF_CPP_LOG_THREAD_ID=1" >> ~/.bashrc

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -11,6 +11,8 @@ ARG cxx="clang++-8"
 ARG cxx_abi="1"
 ARG tpuvm=""
 
+ENV DEBIAN_FRONTEND noninteractive
+
 # Disable CUDA for PyTorch
 ENV USE_CUDA "0"
 
@@ -44,8 +46,10 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/
 # Install base system packages
 RUN apt-get clean && apt-get update
 RUN apt-get upgrade -y
-RUN apt-get install --fix-missing -y python-pip python3-pip git curl libopenblas-dev vim jq \
+RUN apt-get install --fix-missing -y python3-pip git curl libopenblas-dev vim jq \
     apt-transport-https ca-certificates procps openssl sudo wget libssl-dev libc6-dbg
+RUN echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
+RUN sudo apt-get install -y -q
 
 # Install clang & llvm
 ADD ./install_llvm_clang.sh install_llvm_clang.sh

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -1,11 +1,11 @@
 # This requires cuda & cudnn packages pre-installed in the base image.
 # Other available cuda images are listed at https://hub.docker.com/r/nvidia/cuda
-ARG base_image="nvidia/cuda:11.7.0-cudnn8-devel-ubuntu18.04"
+ARG base_image="nvidia/cuda:12.0.1-cudnn8-devel-ubuntu20.04"
 FROM "${base_image}"
 
-ARG python_version="3.8"
+ARG python_version="3.10"
 ARG cuda="1"
-ARG cuda_compute="5.2,7.5"
+ARG cuda_compute="5.2,7.5,8.0"
 ARG cc="clang-8"
 ARG cxx="clang++-8"
 ARG cxx_abi="1"
@@ -39,7 +39,7 @@ ENV TPUVM_MODE "${tpuvm}"
 
 # Rotate nvidia repo public key (last updated: 04/27/2022)
 # Unfortunately, nvidia/cuda image is shipped with invalid public key
-RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
 
 # Install base system packages
 RUN apt-get clean && apt-get update

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -62,10 +62,6 @@ RUN bash ./install_llvm_clang.sh
 ADD ./install_valgrind.sh install_valgrind.sh
 RUN bash ./install_valgrind.sh
 
-# Install nccl 2.18.3 for CUDA 12.0.1
-ADD ./install_nccl.sh install_nccl.sh
-RUN bash ./install_nccl.sh
-
 # Sets up jenkins user.
 RUN useradd jenkins && \
     mkdir /home/jenkins && \

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -5,7 +5,7 @@ FROM "${base_image}"
 
 ARG python_version="3.10"
 ARG cuda="1"
-ARG cuda_compute="7.0,7.5,8.0"
+ARG cuda_compute="sm_70,sm_75,compute_80"
 ARG cc="gcc-11"
 ARG cxx="g++-11"
 ARG cxx_abi="1"
@@ -20,6 +20,8 @@ ENV USE_CUDA "0"
 ENV XLA_CUDA "${cuda}"
 ENV TF_CUDA_COMPUTE_CAPABILITIES "${cuda_compute}"
 ENV TF_CUDA_PATHS "/usr/local/cuda,/usr/include,/usr"
+ENV TF_CUDA_VERSION "12"
+ENV TF_CUDNN_VERSION "8"
 
 # CUDA build guidance
 ENV NVIDIA_VISIBLE_DEVICES all

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -60,6 +60,10 @@ RUN bash ./install_llvm_clang.sh
 ADD ./install_valgrind.sh install_valgrind.sh
 RUN bash ./install_valgrind.sh
 
+# Install nccl 2.18.3 for CUDA 12.0.1
+ADD ./install_nccl.sh install_nccl.sh
+RUN bash ./install_nccl.sh
+
 # Sets up jenkins user.
 RUN useradd jenkins && \
     mkdir /home/jenkins && \

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -35,11 +35,12 @@ ENV CUDA_PATH /usr/local/cuda
 # Set C/C++ compilers
 ENV CC "${cc}"
 ENV CXX "${cxx}"
+ENV NVCC_PREPEND_FLAGS "-ccbin /usr/bin/${cxx}"
 
 # Whether to build for TPUVM mode
 ENV TPUVM_MODE "${tpuvm}"
 
-# Rotate nvidia repo public key (last updated: 04/27/2022)
+# Rotate nvidia repo public key (last checked: 09/21/2023)
 # Unfortunately, nvidia/cuda image is shipped with invalid public key
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
 

--- a/.circleci/docker/cloudbuild.yaml
+++ b/.circleci/docker/cloudbuild.yaml
@@ -23,7 +23,7 @@ options:
     substitution_option: 'ALLOW_LOOSE'
 substitutions:
     _CUDA: '1'
-    _CUDA_TAG: '11.7.0-cudnn8-devel-ubuntu18.04'
-    _PYTHON_VERSION: '3.7'
+    _CUDA_TAG: '12.0.1-cudnn8-devel-ubuntu20.04'  # nvidia/cuda:12.0.1-cudnn8-devel-ubuntu20.04
+    _PYTHON_VERSION: '3.10'
     _TAG_NAME: '${_PYTHON_VERSION}-${_CUDA_TAG}-mini'
 timeout: 3000s

--- a/.circleci/docker/install_conda.sh
+++ b/.circleci/docker/install_conda.sh
@@ -54,6 +54,11 @@ function install_and_setup_conda() {
   /usr/bin/yes | pip install pytest
   /usr/bin/yes | pip install sympy
 
+  sudo apt install -y libtinfo-dev python-is-python3
+  conda install -c conda-forge ncurses
+
+  # Ensure /opt/conda/lib/libtinfo.so.6 version information is available.
+  sudo apt install -y libtinfo-dev
 }
 
 install_and_setup_conda

--- a/.circleci/docker/install_conda.sh
+++ b/.circleci/docker/install_conda.sh
@@ -30,7 +30,7 @@ function install_and_setup_conda() {
   conda update -y -n base conda
   conda install -y python=$PYTHON_VERSION
 
-  conda install -y nomkl numpy pyyaml setuptools cmake \
+  conda install -y nomkl numpy pyyaml setuptools cmake git \
     cffi typing tqdm coverage hypothesis dataclasses cython
 
   /usr/bin/yes | pip install mkl==2022.2.1

--- a/.circleci/docker/install_conda.sh
+++ b/.circleci/docker/install_conda.sh
@@ -30,7 +30,7 @@ function install_and_setup_conda() {
   conda update -y -n base conda
   conda install -y python=$PYTHON_VERSION
 
-  conda install -y nomkl numpy=1.18.5 pyyaml setuptools cmake \
+  conda install -y nomkl numpy pyyaml setuptools cmake \
     cffi typing tqdm coverage hypothesis dataclasses cython
 
   /usr/bin/yes | pip install mkl==2022.2.1
@@ -46,9 +46,9 @@ function install_and_setup_conda() {
   /usr/bin/yes | pip install "cmake>=3.18" --upgrade
   /usr/bin/yes | pip install absl-py
   # Additional PyTorch requirements
-  /usr/bin/yes | pip install scikit-image scipy==1.6.3
-  /usr/bin/yes | pip install boto3==1.16.34
-  /usr/bin/yes | pip install mypy==0.812
+  /usr/bin/yes | pip install scikit-image scipy
+  /usr/bin/yes | pip install boto3
+  /usr/bin/yes | pip install mypy
   /usr/bin/yes | pip install psutil
   /usr/bin/yes | pip install unittest-xml-reporting
   /usr/bin/yes | pip install pytest

--- a/.circleci/docker/install_llvm_clang.sh
+++ b/.circleci/docker/install_llvm_clang.sh
@@ -16,24 +16,26 @@ function debian_version {
 
 function install_llvm_clang() {
   local DEBVER=$(debian_version)
-  if ! apt-get install -y -s clang-8 > /dev/null 2>&1 ; then
-    maybe_append "deb http://apt.llvm.org/${DEBVER}/ llvm-toolchain-${DEBVER}-8 main" /etc/apt/sources.list
-    maybe_append "deb-src http://apt.llvm.org/${DEBVER}/ llvm-toolchain-${DEBVER}-8 main" /etc/apt/sources.list
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-    sudo apt-get update
-  fi
-  # TODO(yeounoh) remove after fully migrating away from clang-8.
-  sudo apt-get install -y clang-8 clang++-8
-  sudo apt-get install -y llvm-8 llvm-8-dev llvm-8-tools
-  if [[ -e /usr/bin/clang ]]; then
-    sudo unlink /usr/bin/clang
-  fi
-  if [[ -e /usr/bin/clang++ ]]; then
-    sudo unlink /usr/bin/clang++
-  fi
-  sudo ln -s /usr/bin/clang-8 /usr/bin/clang
-  sudo ln -s /usr/bin/clang++-8 /usr/bin/clang++
-  export CC=clang-8 CXX=clang++-8
+
+  # Install gcc-11
+  # TODO(yeounoh) consolidate different compilers into one, perferably gcc/g++-10,
+  # that are also used in ansible. Remove CC/CXX exports afterwards.
+  sudo apt-get update
+  # Update ppa for GCC
+  sudo apt-get install -y software-properties-common
+  sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  sudo apt update -y
+  sudo apt install -y gcc-11 g++-11
+  sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100
+  sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100
+  export CC=gcc-11
+  export CXX=g++-11
+  export NVCC_PREPEND_FLAGS='-ccbin /usr/bin/g++-11'
+
+  # Update gcov for test coverage
+  sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-11 100
+  sudo update-alternatives --install /usr/bin/gcov-dump gcov-dump /usr/bin/gcov-dump-11 100
+  sudo update-alternatives --install /usr/bin/gcov-tool gcov-tool /usr/bin/gcov-tool-11 100
 }
 
 install_llvm_clang

--- a/.circleci/docker/install_llvm_clang.sh
+++ b/.circleci/docker/install_llvm_clang.sh
@@ -25,6 +25,14 @@ function install_llvm_clang() {
   # Build config also sets CC=clang-8, CXX=clang++-8
   sudo apt-get install -y clang-8 clang++-8
   sudo apt-get install -y llvm-8 llvm-8-dev llvm-8-tools
+
+  # TODO(yeounoh) enable clang-10+ for future dev images
+  if [[ -e /usr/bin/clang ]]; then
+    sudo unlink /usr/bin/clang
+  fi
+  if [[ -e /usr/bin/clang++ ]]; then
+    sudo unlink /usr/bin/clang++
+  fi
   sudo ln -s /usr/bin/clang-8 /usr/bin/clang
   sudo ln -s /usr/bin/clang++-8 /usr/bin/clang++
   export CC=clang-8 CXX=clang++-8

--- a/.circleci/docker/install_llvm_clang.sh
+++ b/.circleci/docker/install_llvm_clang.sh
@@ -22,11 +22,9 @@ function install_llvm_clang() {
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
     sudo apt-get update
   fi
-  # Build config also sets CC=clang-8, CXX=clang++-8
+  # TODO(yeounoh) remove after fully migrating away from clang-8.
   sudo apt-get install -y clang-8 clang++-8
   sudo apt-get install -y llvm-8 llvm-8-dev llvm-8-tools
-
-  # TODO(yeounoh) enable clang-10+ for future dev images
   if [[ -e /usr/bin/clang ]]; then
     sudo unlink /usr/bin/clang
   fi

--- a/.circleci/docker/install_nccl.sh
+++ b/.circleci/docker/install_nccl.sh
@@ -4,10 +4,7 @@ set -e
 set -x
 
 function install_nccl() {
-  sudo apt-add-repository ppa:graphics-drivers/ppa
-  sudo apt update
-  sudo apt install libnccl2=2.18.3-1+cuda12.0.1 libnccl-dev=2.18.3-1+cuda12.0.1_libnccl-2.18.3
-  ncclinfo
+  sudo apt-get install -y --allow-change-held-packages libnccl2 libnccl-dev
 }
 
 install_nccl

--- a/.circleci/docker/install_nccl.sh
+++ b/.circleci/docker/install_nccl.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+set -x
+
+function install_nccl() {
+  sudo apt-add-repository ppa:graphics-drivers/ppa
+  sudo apt update
+  sudo apt install libnccl2=2.18.3-1+cuda12.0.1 libnccl-dev=2.18.3-1+cuda12.0.1_libnccl-2.18.3
+  ncclinfo
+}
+
+install_nccl

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -74,7 +74,7 @@ jobs:
             # Note: disable the following 2 lines while testing a new image, so we do not
             # push to the upstream.
             docker tag "${GCR_DOCKER_IMAGE}" "${ECR_DOCKER_IMAGE_BASE}:v1.0" >/dev/null
-            docker push "${ECR_DOCKER_IMAGE_BASE}:v1.1" >/dev/null
+            #docker push "${ECR_DOCKER_IMAGE_BASE}:v1.1" >/dev/null
       - name: Start the container
         shell: bash
         run: |

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -74,7 +74,7 @@ jobs:
             # Note: disable the following 2 lines while testing a new image, so we do not
             # push to the upstream.
             docker tag "${GCR_DOCKER_IMAGE}" "${ECR_DOCKER_IMAGE_BASE}:v1.0" >/dev/null
-            docker push "${ECR_DOCKER_IMAGE_BASE}:v1.0" >/dev/null
+            docker push "${ECR_DOCKER_IMAGE_BASE}:v1.1" >/dev/null
       - name: Start the container
         shell: bash
         run: |

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -87,7 +87,7 @@ jobs:
         shell: bash
         run: |
           echo "declare -x SCCACHE_BUCKET=${SCCACHE_BUCKET}" | docker exec -i "${pid}" sh -c "cat >> env"
-          echo "declare -x CC=clang-8 CXX=clang++-8" | docker exec -i "${pid}" sh -c "cat >> xla_env"
+          echo "declare -x CC=gcc CXX=g++" | docker exec -i "${pid}" sh -c "cat >> xla_env"
           echo "declare -x DISABLE_XRT=${DISABLE_XRT}" | docker exec -i "${pid}" sh -c "cat >> xla_env"
           echo "declare -x XLA_CUDA=${XLA_CUDA}" | docker exec -i "${pid}" sh -c "cat >> xla_env"
           echo "declare -x BAZEL_REMOTE_CACHE=1" | docker exec -i "${pid}" sh -c "cat >> xla_env"

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Prepare build env
         shell: bash
         run: |
-          echo "declare -x SCCACHE_BUCKET=${SCCACHE_BUCKET}" | docker exec -i "${pid}" sh -c "cat >> env""
+          echo "declare -x SCCACHE_BUCKET=${SCCACHE_BUCKET}" | docker exec -i "${pid}" sh -c "cat >> env"
           echo "declare -x CC=gcc CXX=g++" | docker exec -i "${pid}" sh -c "cat >> xla_env"
           echo "declare -x DISABLE_XRT=${DISABLE_XRT}" | docker exec -i "${pid}" sh -c "cat >> xla_env"
           echo "declare -x XLA_CUDA=${XLA_CUDA}" | docker exec -i "${pid}" sh -c "cat >> xla_env"

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -86,8 +86,7 @@ jobs:
       - name: Prepare build env
         shell: bash
         run: |
-          echo "declare -x SCCACHE_BUCKET=${SCCACHE_BUCKET}" | docker exec -i "${pid}" sh -c "cat >> env"
-          echo "declare -x NCCL_DEBUG=INFO" | docker exec -i "${pid}" sh -c "cat >> env"
+          echo "declare -x SCCACHE_BUCKET=${SCCACHE_BUCKET}" | docker exec -i "${pid}" sh -c "cat >> env""
           echo "declare -x CC=gcc CXX=g++" | docker exec -i "${pid}" sh -c "cat >> xla_env"
           echo "declare -x DISABLE_XRT=${DISABLE_XRT}" | docker exec -i "${pid}" sh -c "cat >> xla_env"
           echo "declare -x XLA_CUDA=${XLA_CUDA}" | docker exec -i "${pid}" sh -c "cat >> xla_env"

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -87,6 +87,7 @@ jobs:
         shell: bash
         run: |
           echo "declare -x SCCACHE_BUCKET=${SCCACHE_BUCKET}" | docker exec -i "${pid}" sh -c "cat >> env"
+          echo "declare -x NCCL_DEBUG=INFO" | docker exec -i "${pid}" sh -c "cat >> env"
           echo "declare -x CC=gcc CXX=g++" | docker exec -i "${pid}" sh -c "cat >> xla_env"
           echo "declare -x DISABLE_XRT=${DISABLE_XRT}" | docker exec -i "${pid}" sh -c "cat >> xla_env"
           echo "declare -x XLA_CUDA=${XLA_CUDA}" | docker exec -i "${pid}" sh -c "cat >> xla_env"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -19,7 +19,7 @@ jobs:
     uses: ./.github/workflows/_build.yml
     with:
       ecr-docker-image-base: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/xla_base
-      gcr-docker-image: gcr.io/tpu-pytorch/xla_base:latest
+      gcr-docker-image: gcr.io/tpu-pytorch/xla_base:cuda_12_0
       disable_xrt: 1
       cuda: 1
     secrets:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -19,7 +19,7 @@ jobs:
     uses: ./.github/workflows/_build.yml
     with:
       ecr-docker-image-base: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/xla_base
-      gcr-docker-image: gcr.io/tpu-pytorch/xla_base:cuda_12_2
+      gcr-docker-image: gcr.io/tpu-pytorch/xla_base:cuda_12_0
       disable_xrt: 1
       cuda: 1
     secrets:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -19,7 +19,7 @@ jobs:
     uses: ./.github/workflows/_build.yml
     with:
       ecr-docker-image-base: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/xla_base
-      gcr-docker-image: gcr.io/tpu-pytorch/xla_base:cuda_12_0
+      gcr-docker-image: gcr.io/tpu-pytorch/xla_base:cuda_12_0_nccl_2_18_0
       disable_xrt: 1
       cuda: 1
     secrets:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -19,7 +19,7 @@ jobs:
     uses: ./.github/workflows/_build.yml
     with:
       ecr-docker-image-base: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/xla_base
-      gcr-docker-image: gcr.io/tpu-pytorch/xla_base:cuda_12_0
+      gcr-docker-image: gcr.io/tpu-pytorch/xla_base:cuda_12_2
       disable_xrt: 1
       cuda: 1
     secrets:

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ torch_xla/csrc/version.cpp
 
 # Clangd cache directory
 .cache/*
+
+# VS extension directory
+.VS*


### PR DESCRIPTION
Our CI GPU test complained about cuda and ptxas version mismatch. We need to support CUDA 12.0+.

Test plan: create a test image and run CI and the tests to verify. Once everything is good, we will push and bump the xla_base version in the upstream repo.

cc @lsy323 