### PR TITLE
Fix bug for low-precision ranges

### DIFF
--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -334,10 +334,13 @@ class XlaHelpers {
   static xla::XlaOp PromotedLogicalUnaryOp(
       xla::XlaOp op, const std::function<xla::XlaOp(xla::XlaOp)>& unary_op);
 
-  template <typename T>
-  static xla::Literal Range(T start, T end, T step) {
+  // T is the returned type, A is the type used for accumulation. In general,
+  // A should have higher-or-equal-precision to T.
+  template <typename T, typename A = T>
+  static xla::Literal Range(A start, A end, A step) {
+    std::vector<A> accumulated = runtime::util::Range<A>(start, end, step);
     return xla::LiteralUtil::CreateR1<T>(
-        runtime::util::Range<T>(start, end, step));
+        std::vector<T>(accumulated.begin(), accumulated.end()));
   }
 
   static xla::PrecisionConfig::Precision mat_mul_precision() {

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -431,20 +431,16 @@ torch::lazy::NodePtr ARange(const at::Scalar& start, const at::Scalar& end,
   xla::Literal values;
   switch (type) {
     case xla::PrimitiveType::BF16:
-      values = XlaHelpers::Range<tsl::bfloat16>(
-          static_cast<tsl::bfloat16>(start.toFloat()),
-          static_cast<tsl::bfloat16>(end.toFloat()),
-          static_cast<tsl::bfloat16>(step.toFloat()));
+      values = XlaHelpers::Range<tsl::bfloat16, double>(
+          start.toDouble(), end.toDouble(), step.toDouble());
       break;
     case xla::PrimitiveType::F16:
-      values =
-          XlaHelpers::Range<xla::half>(static_cast<xla::half>(start.toHalf()),
-                                       static_cast<xla::half>(end.toHalf()),
-                                       static_cast<xla::half>(step.toHalf()));
+      values = XlaHelpers::Range<xla::half, double>(
+          start.toDouble(), end.toDouble(), step.toDouble());
       break;
     case xla::PrimitiveType::F32:
-      values = XlaHelpers::Range<float>(start.toFloat(), end.toFloat(),
-                                        step.toFloat());
+      values = XlaHelpers::Range<float, double>(
+          start.toDouble(), end.toDouble(), step.toDouble());
       break;
     case xla::PrimitiveType::F64:
       values = XlaHelpers::Range<double>(start.toDouble(), end.toDouble(),

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -447,24 +447,24 @@ torch::lazy::NodePtr ARange(const at::Scalar& start, const at::Scalar& end,
                                          step.toDouble());
       break;
     case xla::PrimitiveType::U8:
-      values = XlaHelpers::Range<uint8_t>(start.toByte(), end.toByte(),
-                                          step.toByte());
+      values = XlaHelpers::Range<uint8_t, uint64_t>(
+          start.toLong(), end.toLong(), step.toLong());
       break;
     case xla::PrimitiveType::S8:
-      values = XlaHelpers::Range<int8_t>(start.toChar(), end.toChar(),
-                                         step.toChar());
+      values = XlaHelpers::Range<int8_t, int64_t>(start.toLong(), end.toLong(),
+                                                  step.toLong());
       break;
     case xla::PrimitiveType::S16:
-      values = XlaHelpers::Range<int16_t>(start.toShort(), end.toShort(),
-                                          step.toShort());
+      values = XlaHelpers::Range<int16_t, int64_t>(start.toLong(), end.toLong(),
+                                                   step.toLong());
       break;
     case xla::PrimitiveType::U16:
-      values =
-          XlaHelpers::Range<uint16_t>(start.toInt(), end.toInt(), step.toInt());
+      values = XlaHelpers::Range<uint16_t, uint64_t>(
+          start.toLong(), end.toLong(), step.toLong());
       break;
     case xla::PrimitiveType::S32:
-      values =
-          XlaHelpers::Range<int32_t>(start.toInt(), end.toInt(), step.toInt());
+      values = XlaHelpers::Range<int32_t, int64_t>(start.toLong(), end.toLong(),
+                                                   step.toLong());
       break;
     case xla::PrimitiveType::U32:
       values = XlaHelpers::Range<uint32_t>(start.toLong(), end.toLong(),

--- a/torch_xla/csrc/xla_lower_util.cpp
+++ b/torch_xla/csrc/xla_lower_util.cpp
@@ -764,8 +764,8 @@ xla::XlaOp BuildLinspace(const torch::lazy::BackendDevice& device,
 
   std::tie(start, end) = XlaHelpers::PromoteValues(start, end);
   xla::XlaOp indices = xla::ConvertElementType(
-      xla::ConstantLiteral(start.builder(),
-                           XlaHelpers::Range<int64_t>(0, steps, 1)),
+      xla::ConstantLiteral(start.builder(), XlaHelpers::Range<int64_t, int64_t>(
+                                                0ll, steps, 1ll)),
       XlaHelpers::TypeOfXlaOp(start));
 
   xla::XlaOp last_index = XlaHelpers::ScalarValue(

--- a/torch_xla/csrc/xla_lower_util.cpp
+++ b/torch_xla/csrc/xla_lower_util.cpp
@@ -764,8 +764,8 @@ xla::XlaOp BuildLinspace(const torch::lazy::BackendDevice& device,
 
   std::tie(start, end) = XlaHelpers::PromoteValues(start, end);
   xla::XlaOp indices = xla::ConvertElementType(
-      xla::ConstantLiteral(start.builder(), XlaHelpers::Range<int64_t, int64_t>(
-                                                0ll, steps, 1ll)),
+      xla::ConstantLiteral(start.builder(),
+                           XlaHelpers::Range<int64_t>(0l, steps, 1l)),
       XlaHelpers::TypeOfXlaOp(start));
 
   xla::XlaOp last_index = XlaHelpers::ScalarValue(


### PR DESCRIPTION
When creating a range on the XLA device using low-precision floating types like bf16, the process will hang. For example, this will hang:

```
$ python -c 'import torch, torch_xla; print(torch.arange(255, 260, dtype=torch.bfloat16, device="xla"))'
# Hangs
```

Meanwhile, upstream torch executes successfully:

```
$ python -c 'import torch, torch_xla; print(torch.arange(255, 260, dtype=torch.bfloat16))'
tensor([255., 256., 256., 258., 260.], dtype=torch.bfloat16)
```

The issue is that when generating the range, we accumulate in the low-precision data type. In the case of bfloat16, numbers like 257 and 259 don't have a representation in the number format, so we enter an infinite loop adding 1 to 256. We should accumulate in a higher-precision format before downcasting to the actual datatype.

With this change, our result matches that of the upstream:

```
$ python -c 'import torch, torch_xla; print(torch.arange(255, 260, dtype=torch.bfloat16, device="xla"))'
tensor([255., 256., 256., 258., 260.], device='xla:0', dtype=torch.bfloat16)
```

