### PR TITLE
[Docs] Fix small typo in README about DDP

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If you're using `DistributedDataParallel`, make the following changes:
 +  dist.init_process_group("xla", init_method='xla://')
 +
 +  model.to(xm.xla_device())
-+  # `gradient_as_bucket_view=tpu` required for XLA
++  # `gradient_as_bucket_view=True` required for XLA
 +  ddp_model = DDP(model, gradient_as_bucket_view=True)
 
 -  model = model.to(rank)


### PR DESCRIPTION
Seems like it should be `gradient_as_bucket_view=True`.