### PR TITLE
Disable ABI on master branch.

### DIFF
--- a/infra/ansible/config/env.yaml
+++ b/infra/ansible/config/env.yaml
@@ -33,6 +33,7 @@ build_env:
     BAZEL_REMOTE_CACHE: 1
     SILO_NAME: "cache-silo-{{ arch }}-{{ accelerator }}-{{ clang_version }}"
     DISABLE_XRT: "{{ disable_xrt }}"
+    _GLIBCXX_USE_CXX11_ABI: 0
 
   amd64:
     ARCH: amd64

--- a/infra/ansible/roles/build_srcs/tasks/main.yaml
+++ b/infra/ansible/roles/build_srcs/tasks/main.yaml
@@ -17,18 +17,6 @@
     name: "{{ pytorch_wheels.files | map(attribute='path') }}"
     state: "forcereinstall"
 
-- name: Check if build_torch_xla_libs.sh script exists
-  stat:
-    path: "{{ (src_root, 'pytorch/xla/build_torch_xla_libs.sh') | path_join }}"
-  register: build_torch_xla_libs_result
-
-- name: Build XLA computation client library
-  ansible.builtin.command:
-    cmd: bash build_torch_xla_libs.sh -O -D_GLIBCXX_USE_CXX11_ABI=1
-    chdir: "{{ (src_root, 'pytorch/xla') | path_join }}"
-  environment: "{{ env_vars }}"
-  when: build_torch_xla_libs_result.stat.exists
-
 - name: Build PyTorch/XLA
   ansible.builtin.command:
     cmd: python setup.py bdist_wheel


### PR DESCRIPTION
The reverted [PR ](https://github.com/pytorch/xla/pull/5641) results from we built pytorch with abi on and built pytorch/xla with abi off, hence the TPU CI error "ImportError: /usr/local/lib/python3.10/site-packages/_XLAC.cpython-310-x86_64-linux-gnu.so: undefined symbol: _ZN5torch4lazy13MetricFnValueEd". We had the similar [gh issue](https://github.com/pytorch/xla/issues/2649) before.

I'll make sure the TPU CI is green before submitting the PR.

