### PR TITLE
Expose replica_id in XLAShard

### DIFF
--- a/test/cpp/test_xla_sharding.cpp
+++ b/test/cpp/test_xla_sharding.cpp
@@ -71,9 +71,9 @@ TEST_F(XLAShardingTest, GetShardIndicesForDevices) {
   auto sharding_spec =
       std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
   auto shard_shape = ShardingUtil::GetShardShape(sharding_spec);
-  auto shard_indices = ShardingUtil::GetShardIndicesForDevices(
+  auto indices_and_rank = ShardingUtil::GetShardRankAndIndicesForDevices(
       shard_shape, tensor.sizes().vec(), sharding, devices);
-  EXPECT_EQ(shard_indices.size(), devices.size());
+  EXPECT_EQ(indices_and_rank.size(), devices.size());
   /* Tiled indices should be:
                  dim=0 dim=1
        device=0  [0:4,  0:4]
@@ -82,11 +82,14 @@ TEST_F(XLAShardingTest, GetShardIndicesForDevices) {
        device=3  [4:8,  4:7] */
   std::vector<std::vector<int>> slice_starts = {{0, 0}, {0, 4}, {4, 0}, {4, 4}};
   std::vector<std::vector<int>> slice_ends = {{4, 4}, {4, 7}, {8, 4}, {8, 7}};
-  for (int device = 0; device < shard_indices.size(); ++device) {
-    EXPECT_EQ(shard_indices[device].size(), tensor.sizes().size());
-    for (int dim = 0; dim < shard_indices[device].size(); ++dim) {
-      EXPECT_TRUE(shard_indices[device][dim].is_slice());
-      auto slice = shard_indices[device][dim].slice();
+  for (int device = 0; device < indices_and_rank.size(); ++device) {
+    auto& shard_rank = indices_and_rank[device].first;
+    EXPECT_EQ(shard_rank, 0);  // Shard rank is always 0 for tiled sharding.
+    auto& shard_indices = indices_and_rank[device].second;
+    EXPECT_EQ(shard_indices.size(), tensor.sizes().size());
+    for (int dim = 0; dim < shard_indices.size(); ++dim) {
+      EXPECT_TRUE(shard_indices[dim].is_slice());
+      auto slice = shard_indices[dim].slice();
       EXPECT_EQ(slice.start(), slice_starts[device][dim]);
       EXPECT_EQ(slice.stop(), slice_ends[device][dim]);
       EXPECT_EQ(slice.step(), 1);
@@ -95,12 +98,13 @@ TEST_F(XLAShardingTest, GetShardIndicesForDevices) {
   sharding = xla::HloSharding::Replicate().ToProto();
   sharding_spec->sharding = sharding;
   shard_shape = ShardingUtil::GetShardShape(sharding_spec);
-  shard_indices = ShardingUtil::GetShardIndicesForDevices(
+  indices_and_rank = ShardingUtil::GetShardRankAndIndicesForDevices(
       shard_shape, tensor.sizes().vec(), sharding, devices);
-  EXPECT_EQ(shard_indices.size(), devices.size());
+  EXPECT_EQ(indices_and_rank.size(), devices.size());
   for (int i = 0; i < devices.size(); ++i) {
-    EXPECT_EQ(shard_indices[i].size(), 1);
-    EXPECT_TRUE(shard_indices[i][0].is_ellipsis());
+    auto& shard_indices = indices_and_rank[i].second;
+    EXPECT_EQ(shard_indices.size(), 1);
+    EXPECT_TRUE(shard_indices[0].is_ellipsis());
   }
 }
 

--- a/test/cpp/test_xla_sharding.cpp
+++ b/test/cpp/test_xla_sharding.cpp
@@ -71,9 +71,9 @@ TEST_F(XLAShardingTest, GetShardIndicesForDevices) {
   auto sharding_spec =
       std::make_shared<XLATensor::ShardingSpec>(sharding, tensor_shape);
   auto shard_shape = ShardingUtil::GetShardShape(sharding_spec);
-  auto rank_and_indices = ShardingUtil::GetShardRankAndIndicesForDevices(
+  auto replica_and_indices = ShardingUtil::GetShardReplicaAndIndicesForDevices(
       shard_shape, tensor.sizes().vec(), sharding, devices);
-  EXPECT_EQ(rank_and_indices.size(), devices.size());
+  EXPECT_EQ(replica_and_indices.size(), devices.size());
   /* Tiled indices should be:
                  dim=0 dim=1
        device=0  [0:4,  0:4]
@@ -82,10 +82,11 @@ TEST_F(XLAShardingTest, GetShardIndicesForDevices) {
        device=3  [4:8,  4:7] */
   std::vector<std::vector<int>> slice_starts = {{0, 0}, {0, 4}, {4, 0}, {4, 4}};
   std::vector<std::vector<int>> slice_ends = {{4, 4}, {4, 7}, {8, 4}, {8, 7}};
-  for (int device = 0; device < rank_and_indices.size(); ++device) {
-    auto& shard_rank = rank_and_indices[device].first;
-    EXPECT_EQ(shard_rank, 0);  // Shard rank is always 0 for tiled sharding.
-    auto& shard_indices = rank_and_indices[device].second;
+  for (int device = 0; device < replica_and_indices.size(); ++device) {
+    auto& shard_replica_id = replica_and_indices[device].first;
+    EXPECT_EQ(shard_replica_id,
+              0);  // Shard replica_id is always 0 for tiled sharding.
+    auto& shard_indices = replica_and_indices[device].second;
     EXPECT_EQ(shard_indices.size(), tensor.sizes().size());
     for (int dim = 0; dim < shard_indices.size(); ++dim) {
       EXPECT_TRUE(shard_indices[dim].is_slice());
@@ -98,13 +99,13 @@ TEST_F(XLAShardingTest, GetShardIndicesForDevices) {
   sharding = xla::HloSharding::Replicate().ToProto();
   sharding_spec->sharding = sharding;
   shard_shape = ShardingUtil::GetShardShape(sharding_spec);
-  rank_and_indices = ShardingUtil::GetShardRankAndIndicesForDevices(
+  replica_and_indices = ShardingUtil::GetShardReplicaAndIndicesForDevices(
       shard_shape, tensor.sizes().vec(), sharding, devices);
-  EXPECT_EQ(rank_and_indices.size(), devices.size());
+  EXPECT_EQ(replica_and_indices.size(), devices.size());
   for (int i = 0; i < devices.size(); ++i) {
-    auto& rank = rank_and_indices[i].first;
-    EXPECT_EQ(rank, i);  // Shard rank should equal global ordinal.
-    auto& shard_indices = rank_and_indices[i].second;
+    auto& replica_id = replica_and_indices[i].first;
+    EXPECT_EQ(replica_id, i);  // Shard replica_id should equal global ordinal.
+    auto& shard_indices = replica_and_indices[i].second;
     EXPECT_EQ(shard_indices.size(), 1);
     EXPECT_TRUE(shard_indices[0].is_ellipsis());
   }

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -77,8 +77,8 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
       else:
         self.assertIsInstance(shard.indices, type(Ellipsis))
       self.assertTrue(torch.allclose(shard.data, t[shard.indices]))
-      # Tiled sharding makes all shards rank 0.
-      self.assertEqual(shard.rank, 0)
+      # Tiled sharding makes all shards have replica_id 0.
+      self.assertEqual(shard.replica_id, 0)
 
   def test_padded_xla_shards(self):
     num_element = self.n_devices + 1  # Ensure padding with two or more devices
@@ -107,8 +107,8 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
       else:
         self.assertIsInstance(shard.indices, type(Ellipsis))
       self.assertTrue(torch.allclose(shard.unpadded_data, t[shard.indices]))
-      # Tiled sharding makes all shards rank 0.
-      self.assertEqual(shard.rank, 0)
+      # Tiled sharding makes all shards have replica_id 0.
+      self.assertEqual(shard.replica_id, 0)
 
   def test_replicated_xla_shards(self):
     num_element = self.n_devices
@@ -124,8 +124,8 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
       self.assertIsInstance(shard.indices, type(Ellipsis))
       self.assertTrue(torch.allclose(shard.data, t[shard.indices]))
       self.assertTrue(torch.allclose(shard.data, shard.unpadded_data))
-      # Replicated sharding sets the shard rank to the device ordinal
-      self.assertEqual(shard.rank, i)
+      # Replicated sharding sets the shard replica_id to the device ordinal
+      self.assertEqual(shard.replica_id, i)
 
   @unittest.skipUnless(xr.global_runtime_device_count() >= 4,
                        "Multiple devices required for partial replication")
@@ -150,10 +150,10 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
       self.assertEqual(shard.indices[1], slice(start, end, 1))
       self.assertTrue(torch.allclose(shard.data, t[shard.indices]))
       self.assertTrue(torch.allclose(shard.data, shard.unpadded_data))
-      # The rank should be coincide with the replication group for the device.
-      # Given the mesh shape, the shard rank will be the device's row in the
-      # mesh, which is device_id // 2
-      self.assertEqual(shard.rank, i // 2)
+      # The replica_id should be coincide with the replication group for the
+      # device. Given the mesh shape, the shard replica_id will be the device's
+      # row in the mesh, which is device_id // 2
+      self.assertEqual(shard.replica_id, i // 2)
 
   def test_load_local_shards(self):
     num_element = self.n_devices

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -68,7 +68,7 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     for i, shard in enumerate(shards):
       self.assertEqual(shard.data.device, torch.device('cpu'))
       self.assertEqual(shard.data.shape, (shard_len,))
-      start, end = (i, i + 1) * shard_len
+      start, end = i * shard_len, (i + 1) * shard_len
       expected = torch.arange(start, end, dtype=torch.float32)
       self.assertTrue(torch.allclose(shard.data, expected))
       if isinstance(shard.indices, list):
@@ -77,6 +77,8 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
       else:
         self.assertIsInstance(shard.indices, type(Ellipsis))
       self.assertTrue(torch.allclose(shard.data, t[shard.indices]))
+      # Tiled sharding makes all shards rank 0.
+      self.assertEqual(shard.rank, 0)
 
   def test_padded_xla_shards(self):
     num_element = self.n_devices + 1  # Ensure padding with two or more devices
@@ -105,6 +107,8 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
       else:
         self.assertIsInstance(shard.indices, type(Ellipsis))
       self.assertTrue(torch.allclose(shard.unpadded_data, t[shard.indices]))
+      # Tiled sharding makes all shards rank 0.
+      self.assertEqual(shard.rank, 0)
 
   def test_replicated_xla_shards(self):
     num_element = self.n_devices
@@ -120,6 +124,36 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
       self.assertIsInstance(shard.indices, type(Ellipsis))
       self.assertTrue(torch.allclose(shard.data, t[shard.indices]))
       self.assertTrue(torch.allclose(shard.data, shard.unpadded_data))
+      # Replicated sharding sets the shard rank to the device ordinal
+      self.assertEqual(shard.rank, i)
+
+  @unittest.skipUnless(xr.global_runtime_device_count() >= 4,
+                       "Multiple devices required for partial replication")
+  def test_partially_replicated_xla_shards(self):
+    num_element = 256
+    mesh = self._get_mesh((self.n_devices // 2, 2))
+    t = torch.arange(num_element, dtype=torch.float32).reshape((16, 16))
+    # Partial replication along the 0th tensor axis, shard 2-way on the 1st
+    xt = xs.mark_sharding(t.to(xm.xla_device()), mesh, (None, 1))
+    shard_len = t.shape[1] // 2
+
+    shards = xt.local_shards
+    self.assertEqual(len(shards), self.n_devices)
+    for i, shard in enumerate(shards):
+      self.assertEqual(shard.data.device, torch.device('cpu'))
+      self.assertEqual(shard.data.shape, (t.shape[0], shard_len))
+      self.assertEqual(len(shard.indices), len(t.shape))
+      start, end = (i % 2) * shard_len, ((i % 2) + 1) * shard_len
+      # All shards should contain the full range for dim 0
+      self.assertEqual(shard.indices[0], slice(0, t.shape[0], 1))
+      # The index range should be sharded for dim 1
+      self.assertEqual(shard.indices[1], slice(start, end, 1))
+      self.assertTrue(torch.allclose(shard.data, t[shard.indices]))
+      self.assertTrue(torch.allclose(shard.data, shard.unpadded_data))
+      # The rank should be coincide with the replication group for the device.
+      # Given the mesh shape, the shard rank will be the device's row in the
+      # mesh, which is device_id // 2
+      self.assertEqual(shard.rank, i // 2)
 
   def test_load_local_shards(self):
     num_element = self.n_devices

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1694,13 +1694,14 @@ void InitXlaModuleBindings(py::module m) {
           }
           return std::make_tuple(shards, str_devices);
         });
-  // For each local shard, returns the replica_id and the indices into the
-  // global tensor as either a Python list of slices for each dimension or a
-  // Python Ellipsis object indicating that the tensor is replicated. These
-  // indices will not reflect any padding that has been applied to the shards.
-  // The order of the returned indices matches the order of the shards returned
-  // from
-  // `_get_local_shards`.
+  // For each local shard, returns the tuple:
+  //        (replica_id: int, indices: Union[List[Slice], Ellipsis]),
+  // where `replica_id` is the replica the shard belongs to and `indices` index
+  // into the global tensor. The value of `indices` is either a Python list of
+  // slices for each dimension or an Ellipsis object indicating that the tensor
+  // is replicated. These indices will not reflect any padding that has been
+  // applied to the shards. The order of the returned indices matches the order
+  // of the shards returned from `_get_local_shards`.
   m.def("_get_local_shard_replica_and_indices",
         [](const at::Tensor& input) -> std::vector<std::pair<int, py::object>> {
           XLATensorPtr xtensor = bridge::GetXlaTensor(input);

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -547,9 +547,7 @@ std::vector<at::Tensor> ShardingUtil::ShardTensor(
       // Extract only the indices, the rank is unnecessary for sharding.
       std::transform(rank_and_indices.begin(), rank_and_indices.end(),
                      std::back_inserter(shard_indices),
-                     [](auto& pair) -> std::vector<at::indexing::TensorIndex> {
-                       return pair.second;
-                     });
+                     [](auto& pair) { return pair.second; });
     }
 
     for (size_t i = 0; i < shard_indices.size(); i++) {

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -93,11 +93,14 @@ class ShardingUtil {
   // Uses the provided `sharding` spec and expected shard shape to determine the
   // index slices for the shards which belong on `devices`. Only supports
   // `REPLICATED` and `OTHER` sharding types.
-  static std::vector<std::vector<at::indexing::TensorIndex>>
-  GetShardIndicesForDevices(const std::vector<int64_t>& shard_shape,
-                            const std::vector<int64_t>& tensor_shape,
-                            const xla::OpSharding sharding,
-                            const std::vector<std::string>& devices);
+  // For each input device, returns a pair of the shard's rank among its
+  // replicas and a vector of TensorIndex denoting the offset of the device's
+  // shard into the global tensor.
+  static std::vector<std::pair<int, std::vector<at::indexing::TensorIndex>>>
+  GetShardRankAndIndicesForDevices(const std::vector<int64_t>& shard_shape,
+                                   const std::vector<int64_t>& tensor_shape,
+                                   const xla::OpSharding sharding,
+                                   const std::vector<std::string>& devices);
 
   // Returns the indices for the shards. Supports `OTHER` sharding types and
   // called when input is sharded along the batch axis.

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -93,14 +93,14 @@ class ShardingUtil {
   // Uses the provided `sharding` spec and expected shard shape to determine the
   // index slices for the shards which belong on `devices`. Only supports
   // `REPLICATED` and `OTHER` sharding types.
-  // For each input device, returns a pair of the shard's rank among its
-  // replicas and a vector of TensorIndex denoting the offset of the device's
-  // shard into the global tensor.
+  // For each input device, returns a pair of the shard's replica_id and a
+  // vector of TensorIndex denoting the offset of the device's shard into the
+  // global tensor.
   static std::vector<std::pair<int, std::vector<at::indexing::TensorIndex>>>
-  GetShardRankAndIndicesForDevices(const std::vector<int64_t>& shard_shape,
-                                   const std::vector<int64_t>& tensor_shape,
-                                   const xla::OpSharding sharding,
-                                   const std::vector<std::string>& devices);
+  GetShardReplicaAndIndicesForDevices(const std::vector<int64_t>& shard_shape,
+                                      const std::vector<int64_t>& tensor_shape,
+                                      const xla::OpSharding sharding,
+                                      const std::vector<std::string>& devices);
 
   // Returns the indices for the shards. Supports `OTHER` sharding types and
   // called when input is sharded along the batch axis.

--- a/torch_xla/experimental/distributed_checkpoint.py
+++ b/torch_xla/experimental/distributed_checkpoint.py
@@ -333,7 +333,8 @@ def _create_write_items_for_xla_sharded_tensor(
   items = []
   # Since local shards are currently moved to CPU on creation, we need to get
   # the shard indices indirectly to avoid unnecessarily consuming host memory.
-  shard_indices = torch_xla._XLAC._get_local_shard_indices(t.global_tensor)
+  shard_indices = torch_xla._XLAC._get_local_shard_rank_and_indices(
+      t.global_tensor)
   prop = TensorProperties.create_from_tensor(t)
   for shard_ind, indices in enumerate(shard_indices):
     write_item = _create_write_item_from_indices(fqn, shard_ind, indices,
@@ -389,7 +390,8 @@ def _create_xla_read_items(sharded_state_dict: STATE_DICT_TYPE,
     md = metadata.state_dict_metadata[fqn]
     # Since local shards are currently moved to CPU on creation, we need to get
     # the shard indices indirectly to avoid unnecessarily consuming host memory.
-    shard_indices = torch_xla._XLAC._get_local_shard_indices(t.global_tensor)
+    _, shard_indices = torch_xla._XLAC._get_local_shard_rank_and_indices(
+        t.global_tensor)
     chunks = [_create_chunk_from_shard_index(index) for index in shard_indices]
     items.extend(create_read_items_for_chunk_list(fqn, md, chunks))
   return items

--- a/torch_xla/experimental/distributed_checkpoint.py
+++ b/torch_xla/experimental/distributed_checkpoint.py
@@ -333,10 +333,10 @@ def _create_write_items_for_xla_sharded_tensor(
   items = []
   # Since local shards are currently moved to CPU on creation, we need to get
   # the shard indices indirectly to avoid unnecessarily consuming host memory.
-  rank_and_indices = torch_xla._XLAC._get_local_shard_rank_and_indices(
+  replica_and_indices = torch_xla._XLAC._get_local_shard_replica_and_indices(
       t.global_tensor)
   prop = TensorProperties.create_from_tensor(t)
-  for shard_ind, (_, indices) in enumerate(rank_and_indices):
+  for shard_ind, (_, indices) in enumerate(replica_and_indices):
     write_item = _create_write_item_from_indices(fqn, shard_ind, indices,
                                                  t.size(), prop)
     items.append(write_item)
@@ -390,10 +390,10 @@ def _create_xla_read_items(sharded_state_dict: STATE_DICT_TYPE,
     md = metadata.state_dict_metadata[fqn]
     # Since local shards are currently moved to CPU on creation, we need to get
     # the shard indices indirectly to avoid unnecessarily consuming host memory.
-    rank_and_indices = torch_xla._XLAC._get_local_shard_rank_and_indices(
+    replica_and_indices = torch_xla._XLAC._get_local_shard_replica_and_indices(
         t.global_tensor)
     chunks = [
-        _create_chunk_from_shard_index(ind) for _, ind in rank_and_indices
+        _create_chunk_from_shard_index(ind) for _, ind in replica_and_indices
     ]
     items.extend(create_read_items_for_chunk_list(fqn, md, chunks))
   return items

--- a/torch_xla/experimental/xla_sharded_tensor.py
+++ b/torch_xla/experimental/xla_sharded_tensor.py
@@ -23,12 +23,14 @@ class XLAShard:
   # The device this shard's data originated from.
   shard_device: str
 
-  # The shard's rank among its replicas. The value depends on the sharding:
-  #  - REPLICATED: the shard device's global rank.
-  #  - TILED:      always 0.
-  #  - PARTIAL:    the rank of the shard among its replicas as determined by the
-  #                replica group assignment
-  rank: int
+  # The replica this shard belongs to, as determined by the sharding. The
+  # replica is determined differently for each sharding type:
+  #  - TILED:       Since the tensor isn't replicated, replica_id is always 0.
+  #  - PARTIAL:     replica_id is taken from the OpSharding and is a value in
+  #                 the range [0, num_replica).
+  #  - REPLICATED:  Since the tensor is fully replicated, replica_id is the
+  #                 device's global ordinal.
+  replica_id: int
 
   @property
   def unpadded_data(self) -> torch.Tensor:
@@ -114,10 +116,13 @@ class XLAShardedTensor(torch.Tensor):
   @property
   def local_shards(self) -> List[XLAShard]:
     shards, devices = torch_xla._XLAC._get_local_shards(self.global_tensor)
-    rank_and_indices = torch_xla._XLAC._get_local_shard_rank_and_indices(
+    replica_and_indices = torch_xla._XLAC._get_local_shard_replica_and_indices(
         self.global_tensor)
-    zipped = zip(shards, rank_and_indices, devices)
-    return [XLAShard(data, ind, dev, rank) for data, (rank, ind), dev in zipped]
+    zipped = zip(shards, replica_and_indices, devices)
+    return [
+        XLAShard(data, indices, dev, replica)
+        for data, (replica, indices), dev in zipped
+    ]
 
   # Load the given list of local shards into the underlying tensor's data
   # on the local devices.


### PR DESCRIPTION
To optimize distributed checkpoint writing, we should distribute the writes for replicated shards across the hosts tracking the shard. This PR exposes the replica ID of each shard, which can be used to select a host responsible for writing when preparing the global plan. The value of `replica_id` depends on the type of sharding:
- `REPLICATED`: Since every host has a copy of the shard and there is no tiling, the replica ID is equal to the global device ordinal.
- `TILED`: When fully tiled, each shard lives only on a single device, so the replica id is always 0.
- `PARTIAL`: Partial replication is the main use case for `replica_id`. With this sharding type, the replica id is taken from the last tile dimension, which indicates the replication group assignment.

Selecting the shard's `replica_id` depends on the tiling assignment for partial replication, which is a small extension to the existing logic for `GetShardIndicesForDevices`. I opted to refactor this method to also return the shard's rank instead of declaring a new method. 

Aside from the refactor for the return type, the actual logic for choosing shard's replica_id is added to `ShardingUtil:: GetShardReplicaAndIndicesForDevices` in `torch_xla/csrc/xla_sharding_util.cpp`, and the change to add `replica_id` to `XLAShard` is in `xla_sharded_tensor.py`