### PR TITLE
Fix `masked_fill` broadcasting.

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -309,6 +309,19 @@ class TestSelect(test_utils.XlaTestCase):
     tx = t.select(1, 12)
     self.assertEqual(tx, sx.data.cpu())
 
+  def test_masked_fill_scalar(self):
+
+    def fn(tensor):
+      # Build a mask from the first line of tensor.
+      # Also, make it have the same rank as the original tensor.
+      mask = tensor[0].ge(0.5).unsqueeze(dim=0)
+      # Call masked_fill.
+      return tensor.masked_fill(mask, 10)
+
+    x = _gen_tensor(2, 2, device=xm.xla_device())
+    x_cpu = x.cpu()
+    self.assertEqual(fn(x_cpu), fn(x))
+
 
 class TestRandom(test_utils.XlaTestCase):
 


### PR DESCRIPTION
This PR fixes tensor broadcasting for `masked_fill(input, mask, scalar)`. Specifically, when they have the same rank.

**Problem:** when both `input` and `mask` were same rank tensors, say `[2, 2]` and `[2, 1]` respectively, we always expanded the `input`.

**Solution:** inlined part of the code of `XlaHelpers::PromoteShapes` (without the type comparison).