### PR TITLE
Disable xla backend for SPMD

### DIFF
--- a/test/spmd/test_xla_spmd_python_api_interaction.py
+++ b/test/spmd/test_xla_spmd_python_api_interaction.py
@@ -3,7 +3,9 @@ import os
 import sys
 
 import torch
+import torch.distributed as dist
 import torch_xla
+import torch_xla.distributed.xla_backend
 import torch_xla.core.xla_model as xm
 from torch_xla import runtime as xr
 from torch_xla.amp import autocast
@@ -130,6 +132,18 @@ class BasicAutocastAPITest(test_xla_sharding_base.XlaShardingTest):
       t3 = torch.matmul(t1, t2)
     expected_dtype = torch.bfloat16 if xr.is_bf16_supported() else torch.float16
     self.assertTrue(t3.dtype == expected_dtype)
+
+
+class BasicDistributedTest(test_xla_sharding_base.XlaShardingTest):
+  @classmethod
+  def setUpClass(cls):
+    xr.use_spmd()
+    return super().setUpClass()
+
+  def test_xla_backend(self):
+    # XLA backend is not supported with SPMD
+    with self.assertRaises(AssertionError):
+      dist.init_process_group('xla', init_method='xla://')
 
 
 if __name__ == '__main__':

--- a/test/spmd/test_xla_spmd_python_api_interaction.py
+++ b/test/spmd/test_xla_spmd_python_api_interaction.py
@@ -135,6 +135,7 @@ class BasicAutocastAPITest(test_xla_sharding_base.XlaShardingTest):
 
 
 class BasicDistributedTest(test_xla_sharding_base.XlaShardingTest):
+
   @classmethod
   def setUpClass(cls):
     xr.use_spmd()

--- a/torch_xla/distributed/xla_backend.py
+++ b/torch_xla/distributed/xla_backend.py
@@ -1,6 +1,7 @@
 import torch
 import torch.distributed as dist
 import torch_xla.core.xla_model as xm
+import torch_xla.runtime as xr
 from torch_xla._internal import rendezvous
 import logging
 import os
@@ -8,6 +9,8 @@ from torch._C._distributed_c10d import ProcessGroup
 
 
 def _create_xla_process_group(prefix_store, rank, size, timeout):
+  assert not xr.is_spmd(
+  ), "XLA backend is not supported with SPMD. Please use a CPU process group instead."
   return ProcessGroupXla(prefix_store, rank, size, timeout)
 
 


### PR DESCRIPTION
We should not allow using the xla backend with SPMD mode execution. Conceptually, SPMD has a single replica, and users should not need to directly manage collectives on the devices since the compiler will determine where the collectives should be.