### PR TITLE
Support synchronous saving and loading in CheckpointManager

### DIFF
--- a/test/spmd/test_xla_distributed_checkpoint.py
+++ b/test/spmd/test_xla_distributed_checkpoint.py
@@ -26,9 +26,9 @@ def run_with_tmpdir(f):
 
   @functools.wraps(f)
   def run(*args, **kwargs):
-    assert 'tmpdir' not in kwargs
     with tempfile.TemporaryDirectory() as tmpdir:
-      f(*args, **kwargs, tmpdir=tmpdir)
+      kwargs.setdefault('tmpdir', tmpdir)
+      f(*args, **kwargs)
 
   return run
 
@@ -338,7 +338,7 @@ class CheckpointManagerTest(DistributedCheckpointTestBase):
     super().setUp()
     # Initialize the a minimal process group
     dist.init_process_group(
-        init_method='tcp://127.1:8932', world_size=1, rank=0)
+        backend='gloo', init_method='tcp://127.1:8932', world_size=1, rank=0)
 
   def tearDown(self):
     super().tearDown()

--- a/test/spmd/test_xla_distributed_checkpoint.py
+++ b/test/spmd/test_xla_distributed_checkpoint.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import sys
 import tempfile
@@ -15,9 +16,21 @@ from torch.distributed.checkpoint.default_planner import (
     create_default_local_save_plan,
     create_default_global_save_plan,
 )
-from torch_xla.experimental.distributed_checkpoint import SPMDLoadPlanner, SPMDSavePlanner
+from torch_xla.experimental.distributed_checkpoint import SPMDLoadPlanner, SPMDSavePlanner, CheckpointManager
 from torch_xla.experimental.distributed_checkpoint._helpers import (
     _sharded_cpu_state_dict, _CpuShards, _is_sharded_tensor)
+
+
+# Wrapper to manage a temporary directory for the wrapped test
+def run_with_tmpdir(f):
+
+  @functools.wraps(f)
+  def run(*args, **kwargs):
+    assert 'tmpdir' not in kwargs
+    with tempfile.TemporaryDirectory() as tmpdir:
+      f(*args, **kwargs, tmpdir=tmpdir)
+
+  return run
 
 
 class DistributedCheckpointTestBase(test_xla_sharding_base.XlaShardingTest):
@@ -317,6 +330,78 @@ class DistributedCheckpointHelpersTest(DistributedCheckpointTestBase):
       else:
         self.assertTrue(isinstance(param, torch.Tensor))
         self.assertTrue(param.device == torch.device("cpu"))
+
+
+class CheckpointManagerTest(DistributedCheckpointTestBase):
+
+  def setUp(self):
+    super().setUp()
+    # Initialize the a minimal process group
+    dist.init_process_group(
+        init_method='tcp://127.1:8932', world_size=1, rank=0)
+
+  def tearDown(self):
+    super().tearDown()
+    # Destroy the CPU process group after the test
+    dist.destroy_process_group()
+
+  @run_with_tmpdir
+  def test_manager_checkpointing(self, tmpdir):
+    chkpt_mgr = CheckpointManager(tmpdir, save_period=10)
+    state_dict = self._get_sharded_model().state_dict()
+
+    # Take a checkpoint on step 0
+    self.assertTrue(chkpt_mgr.save(0, state_dict))
+
+    # Load the checkpoint into a new state_dict
+    new_state_dict = self._get_sharded_model().state_dict()
+    self.assertFalse(
+        any(
+            torch.allclose(v, new_state_dict[k])
+            for k, v in state_dict.items()))
+    chkpt_mgr.restore(0, new_state_dict)
+    self.assertTrue(
+        all(
+            torch.allclose(v, new_state_dict[k])
+            for k, v in state_dict.items()))
+
+  @run_with_tmpdir
+  def test_manager_step_tracking(self, tmpdir):
+    chkpt_mgr = CheckpointManager(tmpdir, save_period=10)
+    state_dict = self._get_sharded_model().state_dict()
+
+    # No steps are being tracked initially
+    self.assertEqual(chkpt_mgr.all_steps(), [])
+
+    # Steps not divisible by 10 should not be saved
+    for step in range(1, 10):
+      self.assertFalse(chkpt_mgr.save(step, state_dict))
+      self.assertEqual(chkpt_mgr.all_steps(), [])
+
+    # Steps divisible by 10 should be saved
+    saved = set()
+    for step in range(0, 100, 10):
+      self.assertTrue(chkpt_mgr.save(step, state_dict))
+      saved.add(step)
+      self.assertEqual(set(chkpt_mgr.all_steps()), saved)
+
+  @run_with_tmpdir
+  def test_manager_max_to_keep(self, tmpdir):
+    chkpt_mgr = CheckpointManager(tmpdir, save_period=10, max_to_keep=2)
+    state_dict = self._get_sharded_model().state_dict()
+
+    # No steps are being tracked initially
+    self.assertEqual(chkpt_mgr.all_steps(), [])
+
+    self.assertTrue(chkpt_mgr.save(10, state_dict))
+    self.assertEqual(set(chkpt_mgr.all_steps()), {10})
+
+    self.assertTrue(chkpt_mgr.save(20, state_dict))
+    self.assertEqual(set(chkpt_mgr.all_steps()), {10, 20})
+
+    # The oldest checkpoint should be erased
+    self.assertTrue(chkpt_mgr.save(30, state_dict))
+    self.assertEqual(set(chkpt_mgr.all_steps()), {30, 20})
 
 
 if __name__ == '__main__':

--- a/test/spmd/test_xla_distributed_checkpoint.py
+++ b/test/spmd/test_xla_distributed_checkpoint.py
@@ -347,7 +347,7 @@ class CheckpointManagerTest(DistributedCheckpointTestBase):
 
   @run_with_tmpdir
   def test_manager_checkpointing(self, tmpdir):
-    chkpt_mgr = CheckpointManager(tmpdir, save_period=10)
+    chkpt_mgr = CheckpointManager(tmpdir, save_interval=10)
     state_dict = self._get_sharded_model().state_dict()
 
     # Take a checkpoint on step 0
@@ -367,7 +367,7 @@ class CheckpointManagerTest(DistributedCheckpointTestBase):
 
   @run_with_tmpdir
   def test_manager_step_tracking(self, tmpdir):
-    chkpt_mgr = CheckpointManager(tmpdir, save_period=10)
+    chkpt_mgr = CheckpointManager(tmpdir, save_interval=10)
     state_dict = self._get_sharded_model().state_dict()
 
     # No steps are being tracked initially
@@ -387,7 +387,7 @@ class CheckpointManagerTest(DistributedCheckpointTestBase):
 
   @run_with_tmpdir
   def test_manager_max_to_keep(self, tmpdir):
-    chkpt_mgr = CheckpointManager(tmpdir, save_period=10, max_to_keep=2)
+    chkpt_mgr = CheckpointManager(tmpdir, save_interval=10, max_to_keep=2)
     state_dict = self._get_sharded_model().state_dict()
 
     # No steps are being tracked initially
@@ -408,7 +408,7 @@ class CheckpointManagerTest(DistributedCheckpointTestBase):
     self.assertEqual(set(chkpt_mgr.all_steps()), {30, 10})
 
     # The deletion order should persist across executions
-    chkpt_mgr = CheckpointManager(tmpdir, save_period=10, max_to_keep=2)
+    chkpt_mgr = CheckpointManager(tmpdir, save_interval=10, max_to_keep=2)
     self.assertTrue(chkpt_mgr.save(20, state_dict))
     self.assertEqual(set(chkpt_mgr.all_steps()), {20, 10})
 

--- a/test/spmd/test_xla_distributed_checkpoint.py
+++ b/test/spmd/test_xla_distributed_checkpoint.py
@@ -403,6 +403,15 @@ class CheckpointManagerTest(DistributedCheckpointTestBase):
     self.assertTrue(chkpt_mgr.save(30, state_dict))
     self.assertEqual(set(chkpt_mgr.all_steps()), {30, 20})
 
+    # The oldest is selected by creation timestamp, not step
+    self.assertTrue(chkpt_mgr.save(10, state_dict))
+    self.assertEqual(set(chkpt_mgr.all_steps()), {30, 10})
+
+    # The deletion order should persist across executions
+    chkpt_mgr = CheckpointManager(tmpdir, save_period=10, max_to_keep=2)
+    self.assertTrue(chkpt_mgr.save(20, state_dict))
+    self.assertEqual(set(chkpt_mgr.all_steps()), {20, 10})
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/torch_xla/experimental/distributed_checkpoint/manager.py
+++ b/torch_xla/experimental/distributed_checkpoint/manager.py
@@ -84,15 +84,15 @@ class CheckpointManager:
   # checkpoint's step.
   base_path: Union[str, os.PathLike]
 
-  # The period to take checkpoints, in steps.
-  save_period: int
+  # The interval to take checkpoints, in steps.
+  save_interval: int
 
   # The maximum number of checkpoints to keep.
   max_to_keep: int
 
   def __init__(self,
                path: str,
-               save_period: int,
+               save_interval: int,
                max_to_keep: Optional[int] = 0,
                async_queue_size: Optional[int] = 1):
     """
@@ -101,7 +101,7 @@ class CheckpointManager:
 
     Args:
       path: The base path for the CheckpointManager to write checkpoints into.
-      save_period: The number of steps between saving checkpoints.
+      save_interval: The number of steps between saving checkpoints.
       max_to_keep: The maximum number of checkpoints to be tracked by the
             CheckpointManager. When a new checkpoint will be taken, the
             checkpoint for the lowest tracked step will be deleted.
@@ -115,12 +115,12 @@ class CheckpointManager:
             pending at a time.
     """
     assert dist.is_initialized(), "A process group is required."
-    assert save_period > 0, "save_period must be positive"
+    assert save_interval > 0, "save_interval must be positive"
     assert async_queue_size > 0, "async_queue_size must be positive"
     assert max_to_keep >= 0, "max_to_keep must be non-negative"
 
     self.base_path = path
-    self.save_period = save_period
+    self.save_interval = save_interval
     self.max_to_keep = max_to_keep
 
     self._tracked_chkpts = self._load_tracked_chkpts()
@@ -168,7 +168,7 @@ class CheckpointManager:
     a preemption has been detected.
     """
     # TODO(jonbolin): Support preemption notice for auto checkpointing
-    return step % self.save_period == 0
+    return step % self.save_interval == 0
 
   def save(self,
            step,


### PR DESCRIPTION
This PR adds the initial functionality for CheckpointManager to manage synchronously taking checkpoints, restoring checkpoints, and managing how many checkpoints it tracks.