### PR TITLE
Reduce unnecessary tensor allocation in Adam and AdamW

### DIFF
--- a/torch_xla/amp/syncfree/adam.py
+++ b/torch_xla/amp/syncfree/adam.py
@@ -89,12 +89,12 @@ class Adam(torch.optim.Adam):
                 p, memory_format=torch.preserve_format)
 
             if group['amsgrad']:
-                # Maintains max of all exp. moving avg. of sq. grad. values
-                state['max_exp_avg_sq'] = torch.zeros_like(
-                    p, memory_format=torch.preserve_format)
+              # Maintains max of all exp. moving avg. of sq. grad. values
+              state['max_exp_avg_sq'] = torch.zeros_like(
+                  p, memory_format=torch.preserve_format)
             else:
-                state['max_exp_avg_sq'] = torch.empty(
-                    0, dtype=torch.float, device=xm.xla_device())
+              state['max_exp_avg_sq'] = torch.empty(
+                  0, dtype=torch.float, device=xm.xla_device())
 
           exp_avgs.append(state['exp_avg'])
           exp_avg_sqs.append(state['exp_avg_sq'])

--- a/torch_xla/amp/syncfree/adam.py
+++ b/torch_xla/amp/syncfree/adam.py
@@ -1,5 +1,6 @@
 import torch
 from torch import Tensor
+import torch_xla.core.xla_model as xm
 from . import _functional as F
 
 
@@ -86,9 +87,14 @@ class Adam(torch.optim.Adam):
             # Exponential moving average of squared gradient values
             state['exp_avg_sq'] = torch.zeros_like(
                 p, memory_format=torch.preserve_format)
-            # Maintains max of all exp. moving avg. of sq. grad. values
-            state['max_exp_avg_sq'] = torch.zeros_like(
-                p, memory_format=torch.preserve_format)
+
+            if group['amsgrad']:
+                # Maintains max of all exp. moving avg. of sq. grad. values
+                state['max_exp_avg_sq'] = torch.zeros_like(
+                    p, memory_format=torch.preserve_format)
+            else:
+                state['max_exp_avg_sq'] = torch.empty(
+                    0, dtype=torch.float, device=xm.xla_device())
 
           exp_avgs.append(state['exp_avg'])
           exp_avg_sqs.append(state['exp_avg_sq'])

--- a/torch_xla/amp/syncfree/adamw.py
+++ b/torch_xla/amp/syncfree/adamw.py
@@ -87,12 +87,12 @@ class AdamW(torch.optim.AdamW):
                 p, memory_format=torch.preserve_format)
 
             if group['amsgrad']:
-                # Maintains max of all exp. moving avg. of sq. grad. values
-                state['max_exp_avg_sq'] = torch.zeros_like(
-                    p, memory_format=torch.preserve_format)
+              # Maintains max of all exp. moving avg. of sq. grad. values
+              state['max_exp_avg_sq'] = torch.zeros_like(
+                  p, memory_format=torch.preserve_format)
             else:
-                state['max_exp_avg_sq'] = torch.empty(
-                    0, dtype=torch.float, device=xm.xla_device())
+              state['max_exp_avg_sq'] = torch.empty(
+                  0, dtype=torch.float, device=xm.xla_device())
 
           exp_avgs.append(state['exp_avg'])
           exp_avg_sqs.append(state['exp_avg_sq'])

--- a/torch_xla/amp/syncfree/adamw.py
+++ b/torch_xla/amp/syncfree/adamw.py
@@ -1,5 +1,6 @@
 import torch
 from torch import Tensor
+import torch_xla.core.xla_model as xm
 from . import _functional as F
 
 
@@ -84,9 +85,14 @@ class AdamW(torch.optim.AdamW):
             # Exponential moving average of squared gradient values
             state['exp_avg_sq'] = torch.zeros_like(
                 p, memory_format=torch.preserve_format)
-            # Maintains max of all exp. moving avg. of sq. grad. values
-            state['max_exp_avg_sq'] = torch.zeros_like(
-                p, memory_format=torch.preserve_format)
+
+            if group['amsgrad']:
+                # Maintains max of all exp. moving avg. of sq. grad. values
+                state['max_exp_avg_sq'] = torch.zeros_like(
+                    p, memory_format=torch.preserve_format)
+            else:
+                state['max_exp_avg_sq'] = torch.empty(
+                    0, dtype=torch.float, device=xm.xla_device())
 
           exp_avgs.append(state['exp_avg'])
           exp_avg_sqs.append(state['exp_avg_sq'])

--- a/torch_xla/csrc/ops/adam_optimizer_step.cpp
+++ b/torch_xla/csrc/ops/adam_optimizer_step.cpp
@@ -29,7 +29,7 @@ AdamOptimizerStep::AdamOptimizerStep(
               {found_inf, step, param, grad, exp_avg, exp_avg_sq,
                max_exp_avg_sq, beta1, beta2, lr, weight_decay, eps},
               NodeOutputShape(step, param),
-              /*num_outputs=*/5,
+              /*num_outputs=*/(use_amsgrad ? 5 : 4),
               torch::lazy::MHash(use_weight_decay, use_amsgrad, use_adamw)),
       use_weight_decay_(use_weight_decay),
       use_amsgrad_(use_amsgrad),

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -525,7 +525,9 @@ void adam_optimizer_step_(const XLATensorPtr& found_inf, XLATensorPtr& step,
   param->SetInPlaceIrValue(torch::lazy::Value(node, 1));
   exp_avg->SetInPlaceIrValue(torch::lazy::Value(node, 2));
   exp_avg_sq->SetInPlaceIrValue(torch::lazy::Value(node, 3));
-  max_exp_avg_sq->SetInPlaceIrValue(torch::lazy::Value(node, 4));
+  if (amsgrad) {
+    max_exp_avg_sq->SetInPlaceIrValue(torch::lazy::Value(node, 4));
+  }
 }
 
 std::vector<XLATensorPtr> user_computation(


### PR DESCRIPTION
This commit will reduce unnecessary tensor allocation in Adam and AdamW when `amsgrad` is False. cc @JackCaoG 