### PR TITLE
Support SPMD through the xla:// init_method

### DIFF
--- a/test/pjrt/test_runtime_tpu.py
+++ b/test/pjrt/test_runtime_tpu.py
@@ -238,6 +238,13 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
           f"Expected exectue time of {i} to take more than "
           f"{expected_time_seconds} seconds, got {v / 1e9} seconds")
 
+  @mock.patch('torch_xla._internal.tpu.get_worker_ips')
+  def test_master_ip_discovery(self, patched_get_worker_ips):
+    # A basic test to verify the non-SPMD codepath returns the correct IP. Two
+    # IPs are needed to avoid the short-circuit return of localhost.
+    patched_get_worker_ips.return_value = ['10.0.0.1', '10.0.0.2']
+    self.assertTrue(xr.get_master_ip(), '10.0.0.1')
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/test/spmd/test_xla_distributed_checkpoint.py
+++ b/test/spmd/test_xla_distributed_checkpoint.py
@@ -477,6 +477,15 @@ class CheckpointManagerTest(DistributedCheckpointTestBase):
             torch.allclose(v, new_state_dict[k])
             for k, v in state_dict.items()))
 
+  @unittest.skipUnless(xr.device_type() == 'TPU',
+                       'TPU required for worker IP discovery')
+  @unittest.mock.patch('torch_xla._internal.tpu.get_worker_ips')
+  def test_master_ip_discovery(self, patched_get_worker_ips):
+    # A basic test to verify the SPMD codepath returns the correct IP. Two IPs
+    # are needed to avoid the short-circuit return of localhost.
+    patched_get_worker_ips.return_value = ['10.0.0.1', '10.0.0.2']
+    self.assertTrue(xr.get_master_ip(), '10.0.0.1')
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/torch_xla/_internal/rendezvous.py
+++ b/torch_xla/_internal/rendezvous.py
@@ -28,7 +28,6 @@ def pjrt_rendezvous_handler(url: str,
     ) == 'TPU' else 'localhost'
 
   master_port = xu.getenv_as('MASTER_PORT', int, 12355)
-  world_size = xr.process_count()
   with _store_lock:
     global _store
     if not _store:
@@ -44,7 +43,8 @@ def pjrt_rendezvous_handler(url: str,
             xr.process_count(),
             is_master=xr.process_index() == 0)
 
-  # In SPMD, the rank is the process index, while in multiprocess it should be
-  # the device ordinal.
+  # In SPMD, the world size and rank are determined by the process count and
+  # index, while in multiprocess they are based on the device count and ordinal.
+  world_size = xr.process_count() if xr.is_spmd() else xr.world_size()
   rank = xr.process_index() if xr.is_spmd() else xr.global_ordinal()
   yield (_store, rank, world_size)

--- a/torch_xla/runtime.py
+++ b/torch_xla/runtime.py
@@ -242,3 +242,14 @@ def is_spmd():
   """Returns if SPMD is set for execution."""
   # TODO(yeounoh) replace this when we fully deprecate the flag.
   return xu.check_env_flag('XLA_USE_SPMD')
+
+
+@requires_pjrt
+def get_master_ip() -> str:
+  """Retrieve the master worker IP for the runtime. This calls into
+  backend-specific discovery APIs.
+
+  Returns master worker's IP address as a string."""
+  if device_type() == 'TPU':
+    return tpu.discover_master_worker_ip()
+  raise RuntimeError(f'IP discovery not supported for device: {device_type()}')


### PR DESCRIPTION
For distributed checkpointing, a CPU process group is required to coordinate the checkpoint. This requires knowledge of the master worker IP address, which can be cumbersome for the user to configure manually.

In multiprocess, we support auto-discovery of the master worker IP through `tpu.discover_master_worker_ip`. The multiprocess implementation requires manually invoking collectives to broadcast the master IP to all workers. This change adds support for master worker IP discovery using the SPMD APIs.

Note that the `xla://` init_method is a general rendezvous that is not specific to the XLA backend, so this change enables creating the requisite CPU process group through, e.g.:

```
import torch_xla.runtime as xr
import torch_xla.distributed.xla_backend
import torch.distributed as dist

xr.use_spmd()
dist.init_process_group(backend='gloo', init_method='xla://')
```