### PR TITLE
Add support for `_unsafe_index`.

### DIFF
--- a/codegen/xla_native_functions.yaml
+++ b/codegen/xla_native_functions.yaml
@@ -130,6 +130,7 @@ supported:
   - _to_cpu
   - _to_copy
   - _unsafe_view
+  - _unsafe_index.Tensor
   - adaptive_max_pool2d
   - adaptive_max_pool2d_backward
   - add.Scalar

--- a/test/dynamo/test_bridge.py
+++ b/test/dynamo/test_bridge.py
@@ -78,6 +78,19 @@ class ModuleInplaceUpdate(nn.Module):
     return (torch.randn(10), torch.randn(10))
 
 
+class UpsampleModule(nn.Module):
+
+  def __init__(self):
+    super().__init__()
+    self.upsample = nn.Upsample(scale_factor=2)
+
+  def forward(self, x):
+    return self.upsample(x)
+
+  def get_random_inputs(self):
+    return (torch.randn((1, 1, 5)),)
+
+
 def allclose(expected, actual):
 
   def unwrap(cont):
@@ -179,6 +192,7 @@ def make_training_test(model_cls):
 
     model = model.to(device=xla_dev)
     inputs = tuple(inp.to(device=xla_dev) for inp in inputs)
+    inputs = tuple(inp.requires_grad_() for inp in inputs)
 
     # do baseline
     baseline_model = copy.deepcopy(model)
@@ -206,6 +220,7 @@ class TorchXLAReuseGraphTest(torch._dynamo.test_case.TestCase):
 
   test_training_linear = make_training_test(LinearModule)
   test_training_maxpool = make_training_test(MaxPoolModule)
+  test_training_upsample = make_training_test(UpsampleModule)
 
 
 if __name__ == "__main__":

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -626,6 +626,14 @@ at::Tensor XLANativeFunctions::_unsafe_view(const at::Tensor& self,
   return view_copy_symint(self, c10::fromIntArrayRefSlow(size));
 }
 
+at::Tensor XLANativeFunctions::_unsafe_index(
+    const at::Tensor& self,
+    const c10::List<c10::optional<at::Tensor>>& indices) {
+  TORCH_LAZY_FN_COUNTER("xla::");
+  return index(self, indices);
+}
+
+
 at::Tensor XLANativeFunctions::add(const at::Tensor& self,
                                    const at::Tensor& other,
                                    const at::Scalar& alpha) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -633,7 +633,6 @@ at::Tensor XLANativeFunctions::_unsafe_index(
   return index(self, indices);
 }
 
-
 at::Tensor XLANativeFunctions::add(const at::Tensor& self,
                                    const at::Tensor& other,
                                    const at::Scalar& alpha) {


### PR DESCRIPTION
This PR adds support for `_unsafe_index` by aliasing `index`.

**Problem:** `_unsafe_index` was hitting the CPU fallback execution flow, which moved the tensors to CPU (including `self`)
- The CPU fallback was calling the dispatcher again: `at::index`
- That, was getting dispatched to the XLA implementation (error, since `self` lives on CPU)

This problem affected a few Torchbench benchmarks running with `openxla` backend: `Super_SloMo`, `doctr_det_predictor`, `pytorch_unet`, ...