### PR TITLE
pass bundle object to make_tf_function

### DIFF
--- a/torch_xla/tf_saved_model_integration.py
+++ b/torch_xla/tf_saved_model_integration.py
@@ -36,7 +36,8 @@ def _wrap_as_tf_func(func, bundle):
   return inner
 
 
-def make_tf_function(stablehlo_program: stablehlo.StableHLOGraphModule, bundle=None):
+def make_tf_function(stablehlo_program: stablehlo.StableHLOGraphModule,
+                     bundle=None):
   if bundle is None:
     return _wrap_as_tf_func(stablehlo_program._bundle.stablehlo_funcs[0],
                             stablehlo_program._bundle)
@@ -88,7 +89,8 @@ def save_stablehlo_graph_as_tf(
   input_signatures = list(
       _make_input_signatures(bundle.stablehlo_funcs[0].meta))
   tfm.f = tf.function(
-      make_tf_function(stablehlo_program, bundle), input_signature=input_signatures)
+      make_tf_function(stablehlo_program, bundle),
+      input_signature=input_signatures)
   tfm._variables = (
       list(bundle.state_dict.values()) + bundle.additional_constants)
   signatures = {serving_key: tfm.f.get_concrete_function(*input_signatures)}

--- a/torch_xla/tf_saved_model_integration.py
+++ b/torch_xla/tf_saved_model_integration.py
@@ -36,9 +36,11 @@ def _wrap_as_tf_func(func, bundle):
   return inner
 
 
-def make_tf_function(stablehlo_program: stablehlo.StableHLOGraphModule):
-  return _wrap_as_tf_func(stablehlo_program._bundle.stablehlo_funcs[0],
-                          stablehlo_program._bundle)
+def make_tf_function(stablehlo_program: stablehlo.StableHLOGraphModule, bundle=None):
+  if bundle is None:
+    return _wrap_as_tf_func(stablehlo_program._bundle.stablehlo_funcs[0],
+                            stablehlo_program._bundle)
+  return _wrap_as_tf_func(stablehlo_program._bundle.stablehlo_funcs[0], bundle)
 
 
 def _make_input_signatures(
@@ -86,7 +88,7 @@ def save_stablehlo_graph_as_tf(
   input_signatures = list(
       _make_input_signatures(bundle.stablehlo_funcs[0].meta))
   tfm.f = tf.function(
-      make_tf_function(stablehlo_program), input_signature=input_signatures)
+      make_tf_function(stablehlo_program, bundle), input_signature=input_signatures)
   tfm._variables = (
       list(bundle.state_dict.values()) + bundle.additional_constants)
   signatures = {serving_key: tfm.f.get_concrete_function(*input_signatures)}


### PR DESCRIPTION
In tf_saved_model_integration, we need to pass the bundle object created within `save_stablehlo_graph_as_tf`, to the make_tf_function, which then use the tf.Varaibles in the bundle to define input args for xla call module. In this way, the weights won't be inlined in the GraphDef, and the resulting graph size will significantly reduce.