### PR TITLE
Patch RNG for better memory utilization in dropout layers

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,6 +30,7 @@ python_configure(
 # b) get the sha256 hash of the commit by running:
 #    curl -L https://github.com/openxla/xla/archive/<git hash>.tar.gz | sha256sum
 #    and update the sha256 with the result.
+<<<<<<< HEAD
 http_archive(
     name = "xla",
     patch_args = [
@@ -49,6 +50,28 @@ http_archive(
         "https://github.com/openxla/xla/archive/4f8381651977dff16b1d86bb4b198eb733c5f478.tar.gz",
     ],
 )
+=======
+# http_archive(
+#     name = "xla",
+#     patch_args = [
+#         "-l",
+#         "-p1",
+#     ],
+#     patch_tool = "patch",
+#     patches = [
+#         "//openxla_patches:cache_urls.diff",
+#         "//openxla_patches:f16_abi_clang.diff",
+#         "//openxla_patches:gpu_race_condition.diff",
+#         "//openxla_patches:constexpr_return.diff",
+#         "//openxla_patches:pjrt_api_tsl_logging.diff",
+#         "//openxla_patches:pjrt_c_api_dynamic_dimensions.diff",
+#     ],
+#     strip_prefix = "xla-97a5f819faf9ff793b7ba68ff1f31f74f9459c18",
+#     urls = [
+#         "https://github.com/openxla/xla/archive/97a5f819faf9ff793b7ba68ff1f31f74f9459c18.tar.gz",
+#     ],
+# )
+>>>>>>> 86256b63f (Use local xla repo)
 
 # For development, one often wants to make changes to the OpenXLA repository as well
 # as the PyTorch/XLA repository. You can override the pinned repository above with a
@@ -58,10 +81,10 @@ http_archive(
 #    bazel --override_repository=xla=/path/to/openxla
 #    or
 # b) by commenting out the http_archive above and uncommenting the following:
-# local_repository(
-#    name = "xla",
-#    path = "/path/to/openxla",
-# )
+local_repository(
+   name = "xla",
+   path = "/home/yeounoh/xla",
+)
 
 # Initialize OpenXLA's external dependencies.
 load("@xla//:workspace4.bzl", "xla_workspace4")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -83,7 +83,7 @@ http_archive(
 # b) by commenting out the http_archive above and uncommenting the following:
 local_repository(
    name = "xla",
-   path = "/home/yeounoh/xla",
+   path = "/home/yeounoh/openxla",
 )
 
 # Initialize OpenXLA's external dependencies.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,7 +30,6 @@ python_configure(
 # b) get the sha256 hash of the commit by running:
 #    curl -L https://github.com/openxla/xla/archive/<git hash>.tar.gz | sha256sum
 #    and update the sha256 with the result.
-<<<<<<< HEAD
 http_archive(
     name = "xla",
     patch_args = [
@@ -50,28 +49,6 @@ http_archive(
         "https://github.com/openxla/xla/archive/4f8381651977dff16b1d86bb4b198eb733c5f478.tar.gz",
     ],
 )
-=======
-# http_archive(
-#     name = "xla",
-#     patch_args = [
-#         "-l",
-#         "-p1",
-#     ],
-#     patch_tool = "patch",
-#     patches = [
-#         "//openxla_patches:cache_urls.diff",
-#         "//openxla_patches:f16_abi_clang.diff",
-#         "//openxla_patches:gpu_race_condition.diff",
-#         "//openxla_patches:constexpr_return.diff",
-#         "//openxla_patches:pjrt_api_tsl_logging.diff",
-#         "//openxla_patches:pjrt_c_api_dynamic_dimensions.diff",
-#     ],
-#     strip_prefix = "xla-97a5f819faf9ff793b7ba68ff1f31f74f9459c18",
-#     urls = [
-#         "https://github.com/openxla/xla/archive/97a5f819faf9ff793b7ba68ff1f31f74f9459c18.tar.gz",
-#     ],
-# )
->>>>>>> 86256b63f (Use local xla repo)
 
 # For development, one often wants to make changes to the OpenXLA repository as well
 # as the PyTorch/XLA repository. You can override the pinned repository above with a
@@ -81,10 +58,10 @@ http_archive(
 #    bazel --override_repository=xla=/path/to/openxla
 #    or
 # b) by commenting out the http_archive above and uncommenting the following:
-local_repository(
-   name = "xla",
-   path = "/home/yeounoh/openxla",
-)
+# local_repository(
+#    name = "xla",
+#    path = "/path/to/openxla",
+# )
 
 # Initialize OpenXLA's external dependencies.
 load("@xla//:workspace4.bzl", "xla_workspace4")

--- a/test/test_operations_hlo.py
+++ b/test/test_operations_hlo.py
@@ -60,6 +60,13 @@ class TestOperationsHlo(unittest.TestCase):
         [p.grad for p in mod.parameters() if p.requires_grad])
     assert 'f64' not in hlo_text
 
+  def test_dropout_by_u8_mask(self):
+    mod = torch.nn.Dropout().to(xm.xla_device())
+    a = torch.rand(20, 16, dtype=torch.bfloat16).to(xm.xla_device())
+    b = mod(a)
+    hlo_text = torch_xla._XLAC._get_xla_tensors_hlo([b])
+    assert 'u8' in hlo_text
+
 
 if __name__ == '__main__':
   torch.set_default_tensor_type('torch.FloatTensor')

--- a/torch_xla/csrc/random.cpp
+++ b/torch_xla/csrc/random.cpp
@@ -64,8 +64,8 @@ xla::XlaOp MakeUniformBoundaryValue(xla::XlaOp val, bool downcast = false) {
   xla::PrimitiveType element_type = XlaHelpers::TypeOfXlaOp(val);
   if (element_type == xla::PrimitiveType::BF16 ||
       element_type == xla::PrimitiveType::F16) {
-    auto dtype =
-        downcast ? xla::PrimitiveType::F8E5M2 : xla::PrimitiveType::F32;
+    // Use BF16 if `downcast` is set.
+    auto dtype = downcast ? xla::PrimitiveType::BF16 : xla::PrimitiveType::F32;
     return xla::ConvertElementType(val, dtype);
   } else if (xla::primitive_util::IsComplexType(element_type)) {
     return xla::Real(val);
@@ -78,7 +78,7 @@ xla::Shape MakeRngShape(const xla::Shape& shape, bool downcast = false) {
   xla::Shape rng_shape(shape);
   if (element_type == xla::PrimitiveType::BF16 ||
       element_type == xla::PrimitiveType::F16) {
-    // TODO(yeounoh) consider using xla::PrimitiveType::F8E5M2 for downcast.
+    // This controls the bit width and we use 8-bit if `downcast` is set.
     auto dtype =
         downcast ? xla::PrimitiveType::F8E5M2 : xla::PrimitiveType::F32;
     rng_shape.set_element_type(dtype);

--- a/torch_xla/csrc/random.cpp
+++ b/torch_xla/csrc/random.cpp
@@ -64,7 +64,8 @@ xla::XlaOp MakeUniformBoundaryValue(xla::XlaOp val, bool downcast = false) {
   xla::PrimitiveType element_type = XlaHelpers::TypeOfXlaOp(val);
   if (element_type == xla::PrimitiveType::BF16 ||
       element_type == xla::PrimitiveType::F16) {
-    auto dtype = downcast ? xla::PrimitiveType::F16 : xla::PrimitiveType::F32;
+    auto dtype =
+        downcast ? xla::PrimitiveType::F8E5M2 : xla::PrimitiveType::F32;
     return xla::ConvertElementType(val, dtype);
   } else if (xla::primitive_util::IsComplexType(element_type)) {
     return xla::Real(val);

--- a/torch_xla/csrc/random.cpp
+++ b/torch_xla/csrc/random.cpp
@@ -77,6 +77,7 @@ xla::Shape MakeRngShape(const xla::Shape& shape, bool downcast = false) {
   xla::Shape rng_shape(shape);
   if (element_type == xla::PrimitiveType::BF16 ||
       element_type == xla::PrimitiveType::F16) {
+    // TODO(yeounoh) consider using xla::PrimitiveType::F8E5M2
     auto dtype = downcast ? xla::PrimitiveType::F16 : xla::PrimitiveType::F32;
     rng_shape.set_element_type(dtype);
   } else if (xla::primitive_util::IsComplexType(element_type)) {

--- a/torch_xla/csrc/random.cpp
+++ b/torch_xla/csrc/random.cpp
@@ -77,8 +77,9 @@ xla::Shape MakeRngShape(const xla::Shape& shape, bool downcast = false) {
   xla::Shape rng_shape(shape);
   if (element_type == xla::PrimitiveType::BF16 ||
       element_type == xla::PrimitiveType::F16) {
-    // TODO(yeounoh) consider using xla::PrimitiveType::F8E5M2
-    auto dtype = downcast ? xla::PrimitiveType::F16 : xla::PrimitiveType::F32;
+    // TODO(yeounoh) consider using xla::PrimitiveType::F8E5M2 for downcast.
+    auto dtype =
+        downcast ? xla::PrimitiveType::F8E5M2 : xla::PrimitiveType::F32;
     rng_shape.set_element_type(dtype);
   } else if (xla::primitive_util::IsComplexType(element_type)) {
     rng_shape.set_element_type(


### PR DESCRIPTION
The patch has landed in OpenXLA https://github.com/openxla/xla/pull/6015, we can enable this now, to reduce memory pressure in `nn.Dropout` layer.

DO_NOT_MERGE until the next pin update. 