### PR TITLE
Ensure dist runtime is in sync before shutting down.

### DIFF
--- a/test/pjrt/test_runtime_gpu.py
+++ b/test/pjrt/test_runtime_gpu.py
@@ -178,7 +178,6 @@ class TestExperimentalPjrtGpu(parameterized.TestCase):
     return out.cpu().numpy()
 
   # 2023-08-02 04:16:36.520884: F external/xla/xla/service/layout_assignment.cc:157] Check failed: ShapeUtil::Compatible(shape_layout.shape(), instruction->operand(operand_no)->shape()) f32[1]{0} is not compatible with f32[2]{0} (for operand 0 of instruction %reduce-scatter.10 = f32[1]{0} reduce-scatter(f32[2]{0} %add.5), replica_groups={}, constrain_layout=true, dimensions={0}, to_apply=%AddComputation.6)
-  @unittest.skip("Failed with known error.")
   @parameterized.named_parameters(('pinned', True), ('unpinned', False))
   def test_reduce_scatter(self, pin_layout):
     results = pjrt.run_multiprocess(self._reduce_scatter, pin_layout)

--- a/torch_xla/_internal/gpu.py
+++ b/torch_xla/_internal/gpu.py
@@ -1,6 +1,8 @@
 import os
 import torch_xla.core.xla_env_vars as xenv
 
+distributed_service = None
+
 
 def num_local_processes() -> int:
   """Returns number of processes to create on this host.

--- a/torch_xla/_internal/gpu.py
+++ b/torch_xla/_internal/gpu.py
@@ -1,6 +1,4 @@
 import os
-import atexit
-import torch_xla
 import torch_xla.core.xla_env_vars as xenv
 
 distributed_service = None
@@ -17,28 +15,3 @@ def num_local_processes() -> int:
       "Must set `GPU_NUM_DEVICES` environment variable to use the PjRt GPU client"
   os.environ[xenv.LOCAL_WORLD_SIZE] = os.environ[xenv.GPU_NUM_DEVICES]
   return int(os.environ[xenv.LOCAL_WORLD_SIZE])
-
-
-def initialize_distributed_runtime(global_world_size: int) -> None:
-  """Configures GPU distributed runtime parameters.
-
-  Must be run before using any XLA devices.
-
-  Args:
-    global_world_size: number of devices in the cluster.
-  """
-  if global_world_size > 1:
-    global distributed_service
-    if distributed_service is None:
-      num_nodes = global_world_size
-      distributed_service = torch_xla._XLAC._xla_get_distributed_runtime_service(
-          num_nodes)
-      atexit.register(shutdown_distributed_runtime)
-
-
-def shutdown_distributed_runtime() -> None:
-  """Destroy the distributed runtime after a distributed computation."""
-  global distributed_service
-  if distributed_service:
-    distributed_service.shutdown()
-    distributed_service = None

--- a/torch_xla/_internal/gpu.py
+++ b/torch_xla/_internal/gpu.py
@@ -1,8 +1,6 @@
 import os
 import torch_xla.core.xla_env_vars as xenv
 
-distributed_service = None
-
 
 def num_local_processes() -> int:
   """Returns number of processes to create on this host.

--- a/torch_xla/_internal/pjrt.py
+++ b/torch_xla/_internal/pjrt.py
@@ -104,14 +104,6 @@ def _run_singleprocess(fn: Callable[..., R], *args, **kwargs) -> Dict[int, R]:
   return fn(*args, **kwargs)
 
 
-# xw32 delete later
-def should_initialize_dist_runtime(local_rank: int):
-  if dist.is_torchelastic_launched():
-    assert xenv.RANK in os.environ, 'Environment variable is not set.'
-    return xu.getenv_as(xenv.RANK, int) == 0
-  return local_rank == 0
-
-
 @runtime.requires_pjrt
 def initialize_multiprocess(local_rank: int, local_world_size: int):
   os.environ.setdefault(xenv.PJRT_LOCAL_PROCESS_RANK, str(local_rank))
@@ -121,12 +113,6 @@ def initialize_multiprocess(local_rank: int, local_world_size: int):
     tpu.configure_topology(local_rank, local_world_size)
   elif runtime.device_type() == 'NEURON':
     neuron.initialize_env(local_rank)
-  # elif runtime.device_type() in ('GPU', 'ROCM', 'CUDA'):
-    # global_world_size = xu.getenv_as(
-        # xenv.WORLD_SIZE, int, xu.getenv_as(xenv.LOCAL_WORLD_SIZE, int, 1))
-    # assert global_world_size >= 0
-    # if should_initialize_dist_runtime(local_rank):
-      # gpu.initialize_distributed_runtime(global_world_size)
 
   devices = xm.get_xla_supported_devices()
   xm.set_replication(xm.xla_device(), devices)

--- a/torch_xla/_internal/pjrt.py
+++ b/torch_xla/_internal/pjrt.py
@@ -104,6 +104,7 @@ def _run_singleprocess(fn: Callable[..., R], *args, **kwargs) -> Dict[int, R]:
   return fn(*args, **kwargs)
 
 
+# xw32 delete later
 def should_initialize_dist_runtime(local_rank: int):
   if dist.is_torchelastic_launched():
     assert xenv.RANK in os.environ, 'Environment variable is not set.'
@@ -120,12 +121,12 @@ def initialize_multiprocess(local_rank: int, local_world_size: int):
     tpu.configure_topology(local_rank, local_world_size)
   elif runtime.device_type() == 'NEURON':
     neuron.initialize_env(local_rank)
-  elif runtime.device_type() in ('GPU', 'ROCM', 'CUDA'):
-    global_world_size = xu.getenv_as(
-        xenv.WORLD_SIZE, int, xu.getenv_as(xenv.LOCAL_WORLD_SIZE, int, 1))
-    assert global_world_size >= 0
-    if should_initialize_dist_runtime(local_rank):
-      gpu.initialize_distributed_runtime(global_world_size)
+  # elif runtime.device_type() in ('GPU', 'ROCM', 'CUDA'):
+    # global_world_size = xu.getenv_as(
+        # xenv.WORLD_SIZE, int, xu.getenv_as(xenv.LOCAL_WORLD_SIZE, int, 1))
+    # assert global_world_size >= 0
+    # if should_initialize_dist_runtime(local_rank):
+      # gpu.initialize_distributed_runtime(global_world_size)
 
   devices = xm.get_xla_supported_devices()
   xm.set_replication(xm.xla_device(), devices)

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1915,30 +1915,6 @@ void InitXlaModuleBindings(py::module m) {
           SetAllReduceToken(device, token);
         });
 
-  /* The distributed runtime service is used by the PjRt GPU client. */
-  py::class_<xla::DistributedRuntimeService,
-             std::unique_ptr<xla::DistributedRuntimeService>>
-      distributed_runtime_service(m, "DistributedRuntimeService");
-  distributed_runtime_service.def("shutdown",
-                                  &xla::DistributedRuntimeService::Shutdown,
-                                  py::call_guard<py::gil_scoped_release>());
-  m.def(
-      "_xla_get_distributed_runtime_service",
-      [](int num_nodes) -> std::unique_ptr<xla::DistributedRuntimeService> {
-        std::string master_addr =
-            runtime::sys_util::GetEnvString("MASTER_ADDR", "localhost");
-        std::string port =
-            runtime::sys_util::GetEnvString("XLA_COORDINATOR_PORT", "8547");
-        std::string dist_service_addr = absl::StrJoin({master_addr, port}, ":");
-        XLA_CHECK(num_nodes > 0) << "num_nodes must be positive: " << num_nodes;
-
-        xla::CoordinationServiceImpl::Options options;
-        options.num_nodes = num_nodes;
-        return std::move(
-            xla::GetDistributedRuntimeService(dist_service_addr, options)
-                .value());
-      });
-
   BuildProfilerSubmodule(&m);
   BuildLoweringContextSubmodule(&m);
 

--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -88,6 +88,7 @@ cc_library(
   deps = [
     ":computation_client",
     ":debug_macros",
+    ":distributed_runtime",
     ":env_vars",
     ":multi_wait",
     ":stablehlo_helper",
@@ -160,6 +161,17 @@ cc_library(
         ":debug_macros",
         ":metrics",
         ":util",
+    ],
+)
+
+cc_library(
+    name = "distributed_runtime",
+    srcs = ["distributed_runtime.cc"],
+    hdrs = ["distributed_runtime.h"],
+    deps = [
+        ":debug_macros",
+        ":sys_util",
+        "@xla//xla/pjrt/distributed",
     ],
 )
 

--- a/torch_xla/csrc/runtime/distributed_runtime.cc
+++ b/torch_xla/csrc/runtime/distributed_runtime.cc
@@ -28,8 +28,17 @@ DistributedRuntime::DistributedRuntime(int global_rank) {
   dist_runtime_client_ = xla::GetDistributedRuntimeClient(dist_service_addr, client_options);
   XLA_CHECK(dist_runtime_client_->Connect().ok())
       << "Failed to initialize distributed runtime client";
-  // atexit(shutdown)
+  // atexit(shutdown);
   // XLA_CHECK(atexit(shutdown) == 0);
+}
+
+DistributedRuntime::~DistributedRuntime(){
+  if (dist_runtime_client_ != nullptr) {
+    XLA_CHECK(dist_runtime_client_->Shutdown().ok()) << "Failed to shut down the distributed runtime client.";
+  }
+  if (dist_runtime_service_ != nullptr) {
+    dist_runtime_service_->Shutdown();
+  } 
 }
 
 std::shared_ptr<xla::DistributedRuntimeClient> DistributedRuntime::GetClient() {

--- a/torch_xla/csrc/runtime/distributed_runtime.cc
+++ b/torch_xla/csrc/runtime/distributed_runtime.cc
@@ -7,32 +7,41 @@
 namespace torch_xla {
 namespace runtime {
 
+const std::string default_coordinator_port = "8547";
+
 DistributedRuntime::DistributedRuntime(int global_rank) {
+  std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": DistributedRuntime::DistributedRuntime begins with global_rank=" << global_rank << std::endl;
   std::string master_addr =
           runtime::sys_util::GetEnvString("MASTER_ADDR", "localhost");
   std::string port =
-      runtime::sys_util::GetEnvString("XLA_COORDINATOR_PORT", "8547");
+      runtime::sys_util::GetEnvString("XLA_COORDINATOR_PORT", default_coordinator_port);
   std::string dist_service_addr = absl::StrJoin({master_addr, port}, ":");
   if (global_rank == 0) {
-    XLA_CHECK(!sys_util::GetEnvString("WORLD_SIZE", "").empty() || !sys_util::GetEnvString("LOCAL_WORLD_SIZE", "").empty()) << "WORLD_SIZE and LOCAL_WORLD_SIZE should be empty at the same time.";
-    int global_world_size = sys_util::GetEnvInt("WORLD_SIZE", sys_util::GetEnvInt("LOCAL_WORLD_SIZE", -1));
+    std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": creating distributed runtime service." << std::endl;
+    // XLA_CHECK(!sys_util::GetEnvString("WORLD_SIZE", "").empty() || !sys_util::GetEnvString("LOCAL_WORLD_SIZE", "").empty()) << "WORLD_SIZE and LOCAL_WORLD_SIZE should be empty at the same time.";
+    int local_world_size = sys_util::GetEnvInt("LOCAL_WORLD_SIZE", 1);
+    int global_world_size = sys_util::GetEnvInt("WORLD_SIZE", local_world_size);
     XLA_CHECK(global_world_size > 0) << "WORLD_SIZE and LOCAL_WORLD_SIZE should not be empty at the same time.";
     xla::CoordinationServiceImpl::Options service_options;
     service_options.num_nodes = global_world_size;
     XLA_CHECK(xla::GetDistributedRuntimeService(dist_service_addr, service_options).ok()) << "Failed to initialize distributed runtime service.";
     dist_runtime_service_ = xla::GetDistributedRuntimeService(dist_service_addr, service_options).value();
+    std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": created a distributed runtime service. global_rank=" << global_rank << ", global_world_size=" << global_world_size << std::endl;
   }
 
-  xla::DistributedRuntimeClient::Options client_options;
-  client_options.node_id = global_rank;
-  dist_runtime_client_ = xla::GetDistributedRuntimeClient(dist_service_addr, client_options);
-  XLA_CHECK(dist_runtime_client_->Connect().ok())
-      << "Failed to initialize distributed runtime client";
+  // xla::DistributedRuntimeClient::Options client_options;
+  // client_options.node_id = global_rank;
+  // dist_runtime_client_ = xla::GetDistributedRuntimeClient(dist_service_addr, client_options);
+  // XLA_CHECK(dist_runtime_client_->Connect().ok())
+  //     << "Failed to initialize distributed runtime client";
+  // std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": created a distributed runtime client." << std::endl;
   // atexit(shutdown);
   // XLA_CHECK(atexit(shutdown) == 0);
 }
 
 DistributedRuntime::~DistributedRuntime(){
+  std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ":" << std::endl;
+
   if (dist_runtime_client_ != nullptr) {
     XLA_CHECK(dist_runtime_client_->Shutdown().ok()) << "Failed to shut down the distributed runtime client.";
   }
@@ -41,8 +50,22 @@ DistributedRuntime::~DistributedRuntime(){
   } 
 }
 
-std::shared_ptr<xla::DistributedRuntimeClient> DistributedRuntime::GetClient() {
-  XLA_CHECK(dist_runtime_client_ != nullptr) << "dist_runtime_client_ has not been initialized yet.";
+std::shared_ptr<xla::DistributedRuntimeClient> DistributedRuntime::GetClient(int global_rank) {
+  if (dist_runtime_client_ != nullptr) {
+    return dist_runtime_client_;
+  }
+  std::string master_addr =
+          runtime::sys_util::GetEnvString("MASTER_ADDR", "localhost");
+  std::string port =
+      runtime::sys_util::GetEnvString("XLA_COORDINATOR_PORT", default_coordinator_port);
+  std::string dist_service_addr = absl::StrJoin({master_addr, port}, ":");
+
+  xla::DistributedRuntimeClient::Options client_options;
+  client_options.node_id = global_rank;
+  dist_runtime_client_ = xla::GetDistributedRuntimeClient(dist_service_addr, client_options);
+  XLA_CHECK(dist_runtime_client_->Connect().ok())
+      << "Failed to initialize distributed runtime client";
+  std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": created a distributed runtime client." << std::endl;
   return dist_runtime_client_;
 }
 

--- a/torch_xla/csrc/runtime/distributed_runtime.cc
+++ b/torch_xla/csrc/runtime/distributed_runtime.cc
@@ -51,7 +51,8 @@ DistributedRuntime::~DistributedRuntime() {
 std::shared_ptr<xla::DistributedRuntimeClient> DistributedRuntime::GetClient(
     int global_rank) {
   XLA_CHECK(dist_runtime_client_ != nullptr)
-      << "distributed runtime client is null." return dist_runtime_client_;
+      << "distributed runtime client is null.";
+  return dist_runtime_client_;
 }
 
 void DistributedRuntime::shutdown() {

--- a/torch_xla/csrc/runtime/distributed_runtime.cc
+++ b/torch_xla/csrc/runtime/distributed_runtime.cc
@@ -1,0 +1,50 @@
+#include <stdlib.h>
+
+#include "torch_xla/csrc/runtime/debug_macros.h"
+#include "torch_xla/csrc/runtime/distributed_runtime.h"
+#include "torch_xla/csrc/runtime/sys_util.h"
+
+namespace torch_xla {
+namespace runtime {
+
+DistributedRuntime::DistributedRuntime(int global_rank) {
+  std::string master_addr =
+          runtime::sys_util::GetEnvString("MASTER_ADDR", "localhost");
+  std::string port =
+      runtime::sys_util::GetEnvString("XLA_COORDINATOR_PORT", "8547");
+  std::string dist_service_addr = absl::StrJoin({master_addr, port}, ":");
+  if (global_rank == 0) {
+    XLA_CHECK(!sys_util::GetEnvString("WORLD_SIZE", "").empty() || !sys_util::GetEnvString("LOCAL_WORLD_SIZE", "").empty()) << "WORLD_SIZE and LOCAL_WORLD_SIZE should be empty at the same time.";
+    int global_world_size = sys_util::GetEnvInt("WORLD_SIZE", sys_util::GetEnvInt("LOCAL_WORLD_SIZE", -1));
+    XLA_CHECK(global_world_size > 0) << "WORLD_SIZE and LOCAL_WORLD_SIZE should not be empty at the same time.";
+    xla::CoordinationServiceImpl::Options service_options;
+    service_options.num_nodes = global_world_size;
+    XLA_CHECK(xla::GetDistributedRuntimeService(dist_service_addr, service_options).ok()) << "Failed to initialize distributed runtime service.";
+    dist_runtime_service_ = xla::GetDistributedRuntimeService(dist_service_addr, service_options).value();
+  }
+
+  xla::DistributedRuntimeClient::Options client_options;
+  client_options.node_id = global_rank;
+  dist_runtime_client_ = xla::GetDistributedRuntimeClient(dist_service_addr, client_options);
+  XLA_CHECK(dist_runtime_client_->Connect().ok())
+      << "Failed to initialize distributed runtime client";
+  // atexit(shutdown)
+  // XLA_CHECK(atexit(shutdown) == 0);
+}
+
+std::shared_ptr<xla::DistributedRuntimeClient> DistributedRuntime::GetClient() {
+  XLA_CHECK(dist_runtime_client_ != nullptr) << "dist_runtime_client_ has not been initialized yet.";
+  return dist_runtime_client_;
+}
+
+void DistributedRuntime::shutdown() {
+  if (dist_runtime_client_ != nullptr) {
+    XLA_CHECK(dist_runtime_client_->Shutdown().ok()) << "Failed to shut down the distributed runtime client.";
+  }
+  if (dist_runtime_service_ != nullptr) {
+    dist_runtime_service_->Shutdown();
+  }
+}
+
+}
+}

--- a/torch_xla/csrc/runtime/distributed_runtime.cc
+++ b/torch_xla/csrc/runtime/distributed_runtime.cc
@@ -1,32 +1,10 @@
 #include "torch_xla/csrc/runtime/distributed_runtime.h"
 
-#include <stdlib.h>
-
 #include "torch_xla/csrc/runtime/debug_macros.h"
 #include "torch_xla/csrc/runtime/sys_util.h"
 
 namespace torch_xla {
 namespace runtime {
-
-// Each instantiation and full specialization of std::atomic<> represents a type that different threads can simultaneously operate on (their instances), without raising undefined behavior.
-std::atomic<xla::DistributedRuntimeClient*> distributed_runtime_client(nullptr);
-std::once_flag distributed_runtime_client_once;
-
-xla::DistributedRuntimeClient* CreateClient(int global_rank) {
-  auto distributed_runtime = DistributedRuntime(global_rank);
-  xla::DistributedRuntimeClient* client = distributed_runtime.GetClient().get();
-  XLA_CHECK(client);
-  return client;
-}
-
-xla::DistributedRuntimeClient* GetDistributedRuntimeClient(int global_rank) {
-  std::call_once(distributed_runtime_client_once, 
-  [&]() {distributed_runtime_client=std::move(CreateClient(global_rank)); });
-  return distributed_runtime_client.load();
-}
-
-
-
 
 const std::string default_coordinator_port = "8547";
 
@@ -50,7 +28,6 @@ DistributedRuntime::DistributedRuntime(int global_rank) {
     dist_runtime_service_ =
         xla::GetDistributedRuntimeService(dist_service_addr, service_options)
             .value();
-    //atexit(shutdown_service)
   }
 
   xla::DistributedRuntimeClient::Options client_options;
@@ -59,12 +36,9 @@ DistributedRuntime::DistributedRuntime(int global_rank) {
       xla::GetDistributedRuntimeClient(dist_service_addr, client_options);
   XLA_CHECK(dist_runtime_client_->Connect().ok())
       << "Failed to initialize distributed runtime client";
-  //atexit(shutdown_client)
-  std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": both dist runtime service/client are created." << std::endl;
 }
 
 DistributedRuntime::~DistributedRuntime() {
-  std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": shutting down dist runtime client and service." << std::endl;
   if (dist_runtime_client_ != nullptr) {
     XLA_CHECK(dist_runtime_client_->Shutdown().ok())
         << "Failed to shut down the distributed runtime client.";
@@ -74,24 +48,22 @@ DistributedRuntime::~DistributedRuntime() {
   }
 }
 
-std::shared_ptr<xla::DistributedRuntimeClient> DistributedRuntime::GetClient() {
+std::shared_ptr<xla::DistributedRuntimeClient> DistributedRuntime::GetClient(
+    int global_rank) {
   XLA_CHECK(dist_runtime_client_ != nullptr)
       << "distributed runtime client is null.";
   return dist_runtime_client_;
 }
 
-void DistributedRuntime::shutdown_service(void) {
-  if (dist_runtime_service_ != nullptr) {
-    dist_runtime_service_->Shutdown();
-    dist_runtime_service_ = nullptr;
-  }
-}
-
-void DistributedRuntime::shutdown_client(void) {
+void DistributedRuntime::shutdown() {
   if (dist_runtime_client_ != nullptr) {
     XLA_CHECK(dist_runtime_client_->Shutdown().ok())
         << "Failed to shut down the distributed runtime client.";
     dist_runtime_client_ = nullptr;
+  }
+  if (dist_runtime_service_ != nullptr) {
+    dist_runtime_service_->Shutdown();
+    dist_runtime_service_ = nullptr;
   }
 }
 

--- a/torch_xla/csrc/runtime/distributed_runtime.cc
+++ b/torch_xla/csrc/runtime/distributed_runtime.cc
@@ -1,7 +1,6 @@
-#include <stdlib.h>
+#include "torch_xla/csrc/runtime/distributed_runtime.h"
 
 #include "torch_xla/csrc/runtime/debug_macros.h"
-#include "torch_xla/csrc/runtime/distributed_runtime.h"
 #include "torch_xla/csrc/runtime/sys_util.h"
 
 namespace torch_xla {
@@ -10,73 +9,62 @@ namespace runtime {
 const std::string default_coordinator_port = "8547";
 
 DistributedRuntime::DistributedRuntime(int global_rank) {
-  std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": DistributedRuntime::DistributedRuntime begins with global_rank=" << global_rank << std::endl;
   std::string master_addr =
-          runtime::sys_util::GetEnvString("MASTER_ADDR", "localhost");
-  std::string port =
-      runtime::sys_util::GetEnvString("XLA_COORDINATOR_PORT", default_coordinator_port);
+      runtime::sys_util::GetEnvString("MASTER_ADDR", "localhost");
+  std::string port = runtime::sys_util::GetEnvString("XLA_COORDINATOR_PORT",
+                                                     default_coordinator_port);
   std::string dist_service_addr = absl::StrJoin({master_addr, port}, ":");
   if (global_rank == 0) {
-    std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": creating distributed runtime service." << std::endl;
-    // XLA_CHECK(!sys_util::GetEnvString("WORLD_SIZE", "").empty() || !sys_util::GetEnvString("LOCAL_WORLD_SIZE", "").empty()) << "WORLD_SIZE and LOCAL_WORLD_SIZE should be empty at the same time.";
     int local_world_size = sys_util::GetEnvInt("LOCAL_WORLD_SIZE", 1);
     int global_world_size = sys_util::GetEnvInt("WORLD_SIZE", local_world_size);
-    XLA_CHECK(global_world_size > 0) << "WORLD_SIZE and LOCAL_WORLD_SIZE should not be empty at the same time.";
+    XLA_CHECK(global_world_size > 0) << "WORLD_SIZE and LOCAL_WORLD_SIZE "
+                                        "should not be empty at the same time.";
     xla::CoordinationServiceImpl::Options service_options;
     service_options.num_nodes = global_world_size;
-    XLA_CHECK(xla::GetDistributedRuntimeService(dist_service_addr, service_options).ok()) << "Failed to initialize distributed runtime service.";
-    dist_runtime_service_ = xla::GetDistributedRuntimeService(dist_service_addr, service_options).value();
-    std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": created a distributed runtime service. global_rank=" << global_rank << ", global_world_size=" << global_world_size << std::endl;
+    XLA_CHECK(
+        xla::GetDistributedRuntimeService(dist_service_addr, service_options)
+            .ok())
+        << "Failed to initialize distributed runtime service.";
+    dist_runtime_service_ =
+        xla::GetDistributedRuntimeService(dist_service_addr, service_options)
+            .value();
   }
-
-  // xla::DistributedRuntimeClient::Options client_options;
-  // client_options.node_id = global_rank;
-  // dist_runtime_client_ = xla::GetDistributedRuntimeClient(dist_service_addr, client_options);
-  // XLA_CHECK(dist_runtime_client_->Connect().ok())
-  //     << "Failed to initialize distributed runtime client";
-  // std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": created a distributed runtime client." << std::endl;
-  // atexit(shutdown);
-  // XLA_CHECK(atexit(shutdown) == 0);
-}
-
-DistributedRuntime::~DistributedRuntime(){
-  std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ":" << std::endl;
-
-  if (dist_runtime_client_ != nullptr) {
-    XLA_CHECK(dist_runtime_client_->Shutdown().ok()) << "Failed to shut down the distributed runtime client.";
-  }
-  if (dist_runtime_service_ != nullptr) {
-    dist_runtime_service_->Shutdown();
-  } 
-}
-
-std::shared_ptr<xla::DistributedRuntimeClient> DistributedRuntime::GetClient(int global_rank) {
-  if (dist_runtime_client_ != nullptr) {
-    return dist_runtime_client_;
-  }
-  std::string master_addr =
-          runtime::sys_util::GetEnvString("MASTER_ADDR", "localhost");
-  std::string port =
-      runtime::sys_util::GetEnvString("XLA_COORDINATOR_PORT", default_coordinator_port);
-  std::string dist_service_addr = absl::StrJoin({master_addr, port}, ":");
 
   xla::DistributedRuntimeClient::Options client_options;
   client_options.node_id = global_rank;
-  dist_runtime_client_ = xla::GetDistributedRuntimeClient(dist_service_addr, client_options);
+  dist_runtime_client_ =
+      xla::GetDistributedRuntimeClient(dist_service_addr, client_options);
   XLA_CHECK(dist_runtime_client_->Connect().ok())
       << "Failed to initialize distributed runtime client";
-  std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": created a distributed runtime client." << std::endl;
-  return dist_runtime_client_;
+}
+
+DistributedRuntime::~DistributedRuntime() {
+  if (dist_runtime_client_ != nullptr) {
+    XLA_CHECK(dist_runtime_client_->Shutdown().ok())
+        << "Failed to shut down the distributed runtime client.";
+  }
+  if (dist_runtime_service_ != nullptr) {
+    dist_runtime_service_->Shutdown();
+  }
+}
+
+std::shared_ptr<xla::DistributedRuntimeClient> DistributedRuntime::GetClient(
+    int global_rank) {
+  XLA_CHECK(dist_runtime_client_ != nullptr)
+      << "distributed runtime client is null." return dist_runtime_client_;
 }
 
 void DistributedRuntime::shutdown() {
   if (dist_runtime_client_ != nullptr) {
-    XLA_CHECK(dist_runtime_client_->Shutdown().ok()) << "Failed to shut down the distributed runtime client.";
+    XLA_CHECK(dist_runtime_client_->Shutdown().ok())
+        << "Failed to shut down the distributed runtime client.";
+    dist_runtime_client_ = nullptr;
   }
   if (dist_runtime_service_ != nullptr) {
     dist_runtime_service_->Shutdown();
+    dist_runtime_service_ = nullptr;
   }
 }
 
-}
-}
+}  // namespace runtime
+}  // namespace torch_xla

--- a/torch_xla/csrc/runtime/distributed_runtime.h
+++ b/torch_xla/csrc/runtime/distributed_runtime.h
@@ -8,28 +8,25 @@
 namespace torch_xla {
 namespace runtime {
 
-xla::DistributedRuntimeClient* GetDistributedRuntimeClient(int global_rank);
-
 class DistributedRuntime {
  public:
-  DistributedRuntime(int global_rank);
-  // static DistributedRuntime& getInstance(int global_rank) {
-  //   static DistributedRuntime dist_runtime_instance(global_rank);
-  //   return dist_runtime_instance;
-  // }
+  static DistributedRuntime& getInstance(int global_rank) {
+    static DistributedRuntime dist_runtime_instance(global_rank);
+    return dist_runtime_instance;
+  }
   ~DistributedRuntime();
-  // DistributedRuntime(DistributedRuntime const&) = delete;
-  // void operator=(DistributedRuntime const&) = delete;
+  DistributedRuntime(DistributedRuntime const&) = delete;
+  void operator=(DistributedRuntime const&) = delete;
 
-  std::shared_ptr<xla::DistributedRuntimeClient> GetClient();
+  std::shared_ptr<xla::DistributedRuntimeClient> GetClient(int global_rank);
 
  private:
+  DistributedRuntime(int global_rank);
 
   std::unique_ptr<xla::DistributedRuntimeService> dist_runtime_service_;
   std::shared_ptr<xla::DistributedRuntimeClient> dist_runtime_client_;
 
-  void shutdown_service();
-  void shutdown_client();
+  void shutdown();
 };
 
 }  // namespace runtime

--- a/torch_xla/csrc/runtime/distributed_runtime.h
+++ b/torch_xla/csrc/runtime/distributed_runtime.h
@@ -10,6 +10,7 @@ namespace runtime {
 
 class DistributedRuntime {
  public:
+  static const std::string default_coordinator_port;
   static DistributedRuntime& getInstance(int global_rank,
                                          std::string master_addr,
                                          std::string port) {
@@ -21,7 +22,7 @@ class DistributedRuntime {
   DistributedRuntime(DistributedRuntime const&) = delete;
   void operator=(DistributedRuntime const&) = delete;
 
-  std::shared_ptr<xla::DistributedRuntimeClient> GetClient(int global_rank);
+  std::shared_ptr<xla::DistributedRuntimeClient> GetClient();
 
  private:
   DistributedRuntime(int global_rank, std::string master_addr,
@@ -29,8 +30,6 @@ class DistributedRuntime {
 
   std::unique_ptr<xla::DistributedRuntimeService> dist_runtime_service_;
   std::shared_ptr<xla::DistributedRuntimeClient> dist_runtime_client_;
-
-  void shutdown();
 };
 
 }  // namespace runtime

--- a/torch_xla/csrc/runtime/distributed_runtime.h
+++ b/torch_xla/csrc/runtime/distributed_runtime.h
@@ -8,25 +8,28 @@
 namespace torch_xla {
 namespace runtime {
 
+xla::DistributedRuntimeClient* GetDistributedRuntimeClient(int global_rank);
+
 class DistributedRuntime {
  public:
-  static DistributedRuntime& getInstance(int global_rank) {
-    static DistributedRuntime dist_runtime_instance(global_rank);
-    return dist_runtime_instance;
-  }
+  DistributedRuntime(int global_rank);
+  // static DistributedRuntime& getInstance(int global_rank) {
+  //   static DistributedRuntime dist_runtime_instance(global_rank);
+  //   return dist_runtime_instance;
+  // }
   ~DistributedRuntime();
-  DistributedRuntime(DistributedRuntime const&) = delete;
-  void operator=(DistributedRuntime const&) = delete;
+  // DistributedRuntime(DistributedRuntime const&) = delete;
+  // void operator=(DistributedRuntime const&) = delete;
 
-  std::shared_ptr<xla::DistributedRuntimeClient> GetClient(int global_rank);
+  std::shared_ptr<xla::DistributedRuntimeClient> GetClient();
 
  private:
-  DistributedRuntime(int global_rank);
 
   std::unique_ptr<xla::DistributedRuntimeService> dist_runtime_service_;
   std::shared_ptr<xla::DistributedRuntimeClient> dist_runtime_client_;
 
-  void shutdown();
+  void shutdown_service();
+  void shutdown_client();
 };
 
 }  // namespace runtime

--- a/torch_xla/csrc/runtime/distributed_runtime.h
+++ b/torch_xla/csrc/runtime/distributed_runtime.h
@@ -10,10 +10,19 @@ namespace runtime {
   
 class DistributedRuntime {
   public:
-   DistributedRuntime(int global_rank);
+   static DistributedRuntime& getInstance(int global_rank) {
+     static DistributedRuntime dist_runtime_instance(global_rank);
+     return dist_runtime_instance;
+   }
+   ~DistributedRuntime();
+   DistributedRuntime(DistributedRuntime const&) = delete;
+   void operator=(DistributedRuntime const&) = delete;
+
    std::shared_ptr<xla::DistributedRuntimeClient> GetClient();
 
   private:
+   DistributedRuntime(int global_rank);
+
    std::unique_ptr<xla::DistributedRuntimeService> dist_runtime_service_;
    std::shared_ptr<xla::DistributedRuntimeClient> dist_runtime_client_;
 

--- a/torch_xla/csrc/runtime/distributed_runtime.h
+++ b/torch_xla/csrc/runtime/distributed_runtime.h
@@ -1,0 +1,26 @@
+#ifndef XLA_CLIENT_DISTRIBUTED_RUNTIME_H_
+#define XLA_CLIENT_DISTRIBUTED_RUNTIME_H_
+
+#include <memory>
+
+#include "xla/pjrt/distributed/distributed.h"
+
+namespace torch_xla {
+namespace runtime {
+  
+class DistributedRuntime {
+  public:
+   DistributedRuntime(int global_rank);
+   std::shared_ptr<xla::DistributedRuntimeClient> GetClient();
+
+  private:
+   std::unique_ptr<xla::DistributedRuntimeService> dist_runtime_service_;
+   std::shared_ptr<xla::DistributedRuntimeClient> dist_runtime_client_;
+
+   void shutdown();
+};
+
+}
+}
+
+#endif // XLA_CLIENT_DISTRIBUTED_RUNTIME_H_

--- a/torch_xla/csrc/runtime/distributed_runtime.h
+++ b/torch_xla/csrc/runtime/distributed_runtime.h
@@ -7,29 +7,29 @@
 
 namespace torch_xla {
 namespace runtime {
-  
+
 class DistributedRuntime {
-  public:
-   static DistributedRuntime& getInstance(int global_rank) {
-     static DistributedRuntime dist_runtime_instance(global_rank);
-     return dist_runtime_instance;
-   }
-   ~DistributedRuntime();
-   DistributedRuntime(DistributedRuntime const&) = delete;
-   void operator=(DistributedRuntime const&) = delete;
+ public:
+  static DistributedRuntime& getInstance(int global_rank) {
+    static DistributedRuntime dist_runtime_instance(global_rank);
+    return dist_runtime_instance;
+  }
+  ~DistributedRuntime();
+  DistributedRuntime(DistributedRuntime const&) = delete;
+  void operator=(DistributedRuntime const&) = delete;
 
-   std::shared_ptr<xla::DistributedRuntimeClient> GetClient(int global_rank);
+  std::shared_ptr<xla::DistributedRuntimeClient> GetClient(int global_rank);
 
-  private:
-   DistributedRuntime(int global_rank);
+ private:
+  DistributedRuntime(int global_rank);
 
-   std::unique_ptr<xla::DistributedRuntimeService> dist_runtime_service_;
-   std::shared_ptr<xla::DistributedRuntimeClient> dist_runtime_client_;
+  std::unique_ptr<xla::DistributedRuntimeService> dist_runtime_service_;
+  std::shared_ptr<xla::DistributedRuntimeClient> dist_runtime_client_;
 
-   void shutdown();
+  void shutdown();
 };
 
-}
-}
+}  // namespace runtime
+}  // namespace torch_xla
 
-#endif // XLA_CLIENT_DISTRIBUTED_RUNTIME_H_
+#endif  // XLA_CLIENT_DISTRIBUTED_RUNTIME_H_

--- a/torch_xla/csrc/runtime/distributed_runtime.h
+++ b/torch_xla/csrc/runtime/distributed_runtime.h
@@ -18,7 +18,7 @@ class DistributedRuntime {
    DistributedRuntime(DistributedRuntime const&) = delete;
    void operator=(DistributedRuntime const&) = delete;
 
-   std::shared_ptr<xla::DistributedRuntimeClient> GetClient();
+   std::shared_ptr<xla::DistributedRuntimeClient> GetClient(int global_rank);
 
   private:
    DistributedRuntime(int global_rank);

--- a/torch_xla/csrc/runtime/distributed_runtime.h
+++ b/torch_xla/csrc/runtime/distributed_runtime.h
@@ -10,8 +10,11 @@ namespace runtime {
 
 class DistributedRuntime {
  public:
-  static DistributedRuntime& getInstance(int global_rank) {
-    static DistributedRuntime dist_runtime_instance(global_rank);
+  static DistributedRuntime& getInstance(int global_rank,
+                                         std::string master_addr,
+                                         std::string port) {
+    static DistributedRuntime dist_runtime_instance(global_rank, master_addr,
+                                                    port);
     return dist_runtime_instance;
   }
   ~DistributedRuntime();
@@ -21,7 +24,8 @@ class DistributedRuntime {
   std::shared_ptr<xla::DistributedRuntimeClient> GetClient(int global_rank);
 
  private:
-  DistributedRuntime(int global_rank);
+  DistributedRuntime(int global_rank, std::string master_addr,
+                     std::string port);
 
   std::unique_ptr<xla::DistributedRuntimeService> dist_runtime_service_;
   std::shared_ptr<xla::DistributedRuntimeClient> dist_runtime_client_;

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -110,14 +110,13 @@ PjRtComputationClient::PjRtComputationClient() {
     bool async = sys_util::GetEnvBool(env::kEnvPjrtAsyncGpuClient, true);
     int local_process_rank = sys_util::GetEnvInt(env::kEnvPjRtLocalRank, 0);
     int global_process_rank = sys_util::GetEnvInt("RANK", local_process_rank);
-    const std::string default_coordinator_port = "8547";
     std::string master_addr =
         runtime::sys_util::GetEnvString("MASTER_ADDR", "localhost");
     std::string port = runtime::sys_util::GetEnvString(
-        "XLA_COORDINATOR_PORT", default_coordinator_port);
+        "XLA_COORDINATOR_PORT", DistributedRuntime::default_coordinator_port);
     std::shared_ptr<xla::DistributedRuntimeClient> distributed_client =
         DistributedRuntime::getInstance(global_process_rank, master_addr, port)
-            .GetClient(global_process_rank);
+            .GetClient();
     auto allowed_devices =
         std::make_optional<std::set<int>>(std::set{local_process_rank});
     xla::PjRtClient::KeyValueGetCallback kv_get = nullptr;

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -134,7 +134,8 @@ PjRtComputationClient::PjRtComputationClient() {
     int local_process_rank = sys_util::GetEnvInt(env::kEnvPjRtLocalRank, 0);
 
     int global_process_rank = sys_util::GetEnvInt("RANK", local_process_rank);
-    std::shared_ptr<xla::DistributedRuntimeClient> distributed_client = DistributedRuntime::getInstance(global_process_rank).GetClient();
+    std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": Initializing PjRt GPU client for global_process_rank=" << global_process_rank << std::endl;
+    std::shared_ptr<xla::DistributedRuntimeClient> distributed_client = DistributedRuntime::getInstance(global_process_rank).GetClient(global_process_rank);
     //auto distributed_client =
         //MaybeInitializeDistributedRuntimeClient(global_process_rank);
     auto allowed_devices =
@@ -153,8 +154,9 @@ PjRtComputationClient::PjRtComputationClient() {
         return distributed_client->KeyValueSet(absl::StrCat(key_prefix, k), v);
       };
     }
+    int local_world_size = sys_util::GetEnvInt("LOCAL_WORLD_SIZE", 1);
     int global_world_size = sys_util::GetEnvInt(
-        "WORLD_SIZE", sys_util::GetEnvInt("LOCAL_WORLD_SIZE", 1));
+        "WORLD_SIZE", local_world_size);
     TF_VLOG(3) << "Getting StreamExecutorGpuClient for node_id="
                << global_process_rank << ", num_nodes=" << global_world_size;
     client_ = std::move(xla::GetStreamExecutorGpuClient(

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -134,8 +134,9 @@ PjRtComputationClient::PjRtComputationClient() {
     int local_process_rank = sys_util::GetEnvInt(env::kEnvPjRtLocalRank, 0);
 
     int global_process_rank = sys_util::GetEnvInt("RANK", local_process_rank);
-    auto distributed_client =
-        MaybeInitializeDistributedRuntimeClient(global_process_rank);
+    std::shared_ptr<xla::DistributedRuntimeClient> distributed_client = DistributedRuntime::getInstance(global_process_rank).GetClient();
+    //auto distributed_client =
+        //MaybeInitializeDistributedRuntimeClient(global_process_rank);
     auto allowed_devices =
         std::make_optional<std::set<int>>(std::set{local_process_rank});
     xla::PjRtClient::KeyValueGetCallback kv_get = nullptr;

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -111,9 +111,10 @@ PjRtComputationClient::PjRtComputationClient() {
     int local_process_rank = sys_util::GetEnvInt(env::kEnvPjRtLocalRank, 0);
 
     int global_process_rank = sys_util::GetEnvInt("RANK", local_process_rank);
-    std::shared_ptr<xla::DistributedRuntimeClient> distributed_client =
-        DistributedRuntime::getInstance(global_process_rank)
-            .GetClient(global_process_rank);
+    // std::shared_ptr<xla::DistributedRuntimeClient> distributed_client =
+    //     DistributedRuntime::getInstance(global_process_rank)
+    //         .GetClient(global_process_rank);
+    xla::DistributedRuntimeClient* distributed_client = GetDistributedRuntimeClient(global_process_rank);
     auto allowed_devices =
         std::make_optional<std::set<int>>(std::set{local_process_rank});
     xla::PjRtClient::KeyValueGetCallback kv_get = nullptr;

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -109,10 +109,14 @@ PjRtComputationClient::PjRtComputationClient() {
     TF_VLOG(1) << "Initializing PjRt GPU client...";
     bool async = sys_util::GetEnvBool(env::kEnvPjrtAsyncGpuClient, true);
     int local_process_rank = sys_util::GetEnvInt(env::kEnvPjRtLocalRank, 0);
-
     int global_process_rank = sys_util::GetEnvInt("RANK", local_process_rank);
+    const std::string default_coordinator_port = "8547";
+    std::string master_addr =
+        runtime::sys_util::GetEnvString("MASTER_ADDR", "localhost");
+    std::string port = runtime::sys_util::GetEnvString(
+        "XLA_COORDINATOR_PORT", default_coordinator_port);
     std::shared_ptr<xla::DistributedRuntimeClient> distributed_client =
-        DistributedRuntime::getInstance(global_process_rank)
+        DistributedRuntime::getInstance(global_process_rank, master_addr, port)
             .GetClient(global_process_rank);
     auto allowed_devices =
         std::make_optional<std::set<int>>(std::set{local_process_rank});

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -38,29 +38,6 @@ namespace {
 
 static std::string spmd_device_str = "SPMD:0";
 
-// Initializes a distributed runtime client if dist_service_addr is specified
-std::shared_ptr<xla::DistributedRuntimeClient>
-MaybeInitializeDistributedRuntimeClient(int local_rank) {
-  std::shared_ptr<xla::DistributedRuntimeClient> client;
-  int global_world_size = sys_util::GetEnvInt(
-      "WORLD_SIZE", sys_util::GetEnvInt("LOCAL_WORLD_SIZE", 1));
-  if (global_world_size < 2) {
-    return std::move(client);
-  }
-  std::string master_addr = sys_util::GetEnvString("MASTER_ADDR", "localhost");
-  std::string port =
-      runtime::sys_util::GetEnvString("XLA_COORDINATOR_PORT", "8547");
-  std::string dist_service_addr = absl::StrJoin({master_addr, port}, ":");
-  xla::DistributedRuntimeClient::Options options;
-  options.node_id = local_rank;
-  TF_VLOG(3) << "Getting distributed runtime client for address="
-             << dist_service_addr << ", node_id=" << options.node_id;
-  client = xla::GetDistributedRuntimeClient(dist_service_addr, options);
-  XLA_CHECK(client->Connect().ok())
-      << "Failed to initialize distributed runtime client";
-  return std::move(client);
-}
-
 // Builds a map from the device's global ordinal to its index in the `devices`
 // array.
 std::unordered_map<int, int> build_index_map(
@@ -134,10 +111,9 @@ PjRtComputationClient::PjRtComputationClient() {
     int local_process_rank = sys_util::GetEnvInt(env::kEnvPjRtLocalRank, 0);
 
     int global_process_rank = sys_util::GetEnvInt("RANK", local_process_rank);
-    std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": Initializing PjRt GPU client for global_process_rank=" << global_process_rank << std::endl;
-    std::shared_ptr<xla::DistributedRuntimeClient> distributed_client = DistributedRuntime::getInstance(global_process_rank).GetClient(global_process_rank);
-    //auto distributed_client =
-        //MaybeInitializeDistributedRuntimeClient(global_process_rank);
+    std::shared_ptr<xla::DistributedRuntimeClient> distributed_client =
+        DistributedRuntime::getInstance(global_process_rank)
+            .GetClient(global_process_rank);
     auto allowed_devices =
         std::make_optional<std::set<int>>(std::set{local_process_rank});
     xla::PjRtClient::KeyValueGetCallback kv_get = nullptr;
@@ -155,15 +131,14 @@ PjRtComputationClient::PjRtComputationClient() {
       };
     }
     int local_world_size = sys_util::GetEnvInt("LOCAL_WORLD_SIZE", 1);
-    int global_world_size = sys_util::GetEnvInt(
-        "WORLD_SIZE", local_world_size);
+    int global_world_size = sys_util::GetEnvInt("WORLD_SIZE", local_world_size);
     TF_VLOG(3) << "Getting StreamExecutorGpuClient for node_id="
                << global_process_rank << ", num_nodes=" << global_world_size;
     client_ = std::move(xla::GetStreamExecutorGpuClient(
-                            /*asynchronous=*/async, xla::GpuAllocatorConfig{},
+                            /*asynchronous=*/async,
+                            /*allocator_config=*/xla::GpuAllocatorConfig{},
                             /*node_id=*/global_process_rank,
-                            /*num_nodes=*/
-                            global_world_size,
+                            /*num_nodes=*/global_world_size,
                             /*allowed_devices=*/allowed_devices,
                             /*platform_name=*/"gpu",
                             /*should_stage_host_to_device_transfers=*/true,

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -111,10 +111,9 @@ PjRtComputationClient::PjRtComputationClient() {
     int local_process_rank = sys_util::GetEnvInt(env::kEnvPjRtLocalRank, 0);
 
     int global_process_rank = sys_util::GetEnvInt("RANK", local_process_rank);
-    // std::shared_ptr<xla::DistributedRuntimeClient> distributed_client =
-    //     DistributedRuntime::getInstance(global_process_rank)
-    //         .GetClient(global_process_rank);
-    xla::DistributedRuntimeClient* distributed_client = GetDistributedRuntimeClient(global_process_rank);
+    std::shared_ptr<xla::DistributedRuntimeClient> distributed_client =
+        DistributedRuntime::getInstance(global_process_rank)
+            .GetClient(global_process_rank);
     auto allowed_devices =
         std::make_optional<std::set<int>>(std::set{local_process_rank});
     xla::PjRtClient::KeyValueGetCallback kv_get = nullptr;

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -9,6 +9,7 @@
 #include "pjrt_computation_client.h"
 #include "torch_xla/csrc/runtime/computation_client.h"
 #include "torch_xla/csrc/runtime/debug_macros.h"
+#include "torch_xla/csrc/runtime/distributed_runtime.h"
 #include "torch_xla/csrc/runtime/env_vars.h"
 #include "torch_xla/csrc/runtime/multi_wait.h"
 #include "torch_xla/csrc/runtime/stablehlo_helper.h"

--- a/torch_xla/test/test_utils.py
+++ b/torch_xla/test/test_utils.py
@@ -30,6 +30,7 @@ def mp_test(func):
   """
 
   def wrapper(*args, **kwargs):
+    print('xw32 args=', args, ', kwargs=', kwargs)
     proc = multiprocessing.Process(target=func, args=args, kwargs=kwargs)
     proc.start()
     proc.join()

--- a/torch_xla/test/test_utils.py
+++ b/torch_xla/test/test_utils.py
@@ -30,7 +30,6 @@ def mp_test(func):
   """
 
   def wrapper(*args, **kwargs):
-    print('xw32 args=', args, ', kwargs=', kwargs)
     proc = multiprocessing.Process(target=func, args=args, kwargs=kwargs)
     proc.start()
     proc.join()


### PR DESCRIPTION
This PR
- make sure all dist runtime clients finish the job before the dist runtime service is shut down.
- extracts a new DistributedRuntime class wrapping dist runtime. The class will be shared with dist checkpointing.

Test plan:
1. PJRT_DEVICE=GPU GPU_NUM_DEVICES=2 python pytorch/xla/test/pjrt/test_runtime_gpu.py
2. PJRT_DEVICE=GPU torchrun --nnodes 1 --nproc-per-node 2 pytorch/xla/test/pjrt/test_torchrun.py
3. PJRT_DEVICE=GPU GPU_NUM_DEVICES=2 python pytorch/xla/test/test_operations.py MpDecoratorTest.test_mp_decorator