### PR TITLE
Update OpenXLA pin to 20231022

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -44,9 +44,9 @@ http_archive(
         "//openxla_patches:f16_abi_clang.diff",
         "//openxla_patches:gpu_topk_rewriter.diff",
     ],
-    strip_prefix = "xla-51b59cfb1999c6f1b3ec59851675044b2c502aae",
+    strip_prefix = "xla-4f8381651977dff16b1d86bb4b198eb733c5f478",
     urls = [
-        "https://github.com/openxla/xla/archive/51b59cfb1999c6f1b3ec59851675044b2c502aae.tar.gz",
+        "https://github.com/openxla/xla/archive/4f8381651977dff16b1d86bb4b198eb733c5f478.tar.gz",
     ],
 )
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ import zipfile
 
 base_dir = os.path.dirname(os.path.abspath(__file__))
 
-_libtpu_version = '0.1.dev20231010'
+_libtpu_version = '0.1.dev20231022'
 _libtpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
 
 


### PR DESCRIPTION
Summary:
This pull request updates OpenXLA pin to a recent version to re-enable nighly libtpu for some hardware.

Test Plan:
CI