### PR TITLE
Ignore nodes from dynamo graph that represent non-XLA tensors.

### DIFF
--- a/torch_xla/core/dynamo_bridge.py
+++ b/torch_xla/core/dynamo_bridge.py
@@ -505,9 +505,11 @@ def extract_compiled_graph(xla_model: torch.fx.GraphModule, xla_args):
   class XlaOperatorSupport(torch.fx.passes.operator_support.OperatorSupport):
 
     def is_node_supported(self, submodules, node: torch.fx.Node) -> bool:
-      return node.op in [
-          "call_function", "call_module", "call_method"
-      ] and (node not in fallback_ops or node.target == operator.getitem)
+      val = node.meta.get("val")
+      return node.op in ["call_function", "call_module", "call_method"] and (
+          node not in fallback_ops or
+          node.target == operator.getitem) and (val is not None and isinstance(
+              val, torch.Tensor) and is_xla_tensor(val))
 
   # partition the model
   supported_ops = XlaOperatorSupport()


### PR DESCRIPTION
Fix: #5722 

This PR adds another condition to `CapabilityBasedPartitioner`: whether its traced value is an XLA tensor or not. This is necessary, since dynamo bridge expects only XLA output tensors for things like computing the graph hash.

**Implementation summary:** we rely on `node.meta["val"]` value populated by FX proxy tensors. It provides us tensor metadata, such as the running device.