### PR TITLE
Promote in convolution

### DIFF
--- a/torch_xla/csrc/convolution.cpp
+++ b/torch_xla/csrc/convolution.cpp
@@ -348,7 +348,8 @@ xla::XlaOp BuildConvolutionOverrideableBias(
   xla::XlaOp bias_broadcast =
       xla::Transpose(xla::Broadcast(bias, broadcast_sizes),
                      BiasTransposePermutation(broadcast_sizes.size() + 1));
-  return conv + bias_broadcast;
+  auto promoted = XlaHelpers::Promote(conv, bias_broadcast);
+  return promoted.first + promoted.second;
 }
 
 ConvGrads BuildConvolutionBackwardOverrideable(


### PR DESCRIPTION
Currently this model:

```
m = timm.create_model("efficientformerv2_s0",
        pretrained=True, scriptable=True).eval()`
```

will fail to convert to stablehlo because we use mixed shape in Conv. this is allowed in HLO but not in mhlo.

Workaroudn by manually promoting