### PR TITLE
Make the git version appears in pip

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -41,7 +41,7 @@ variables:
         - Build the xla client with CUDA enabled.
       type: bool
       default_value: false
-    VERSIONED_XLA_BUILD:
+    GIT_VERSIONED_XLA_BUILD:
       description:
         - Creates a versioned build. In particular, appends a git sha to the
           version number string

--- a/infra/ansible/config/env.yaml
+++ b/infra/ansible/config/env.yaml
@@ -34,6 +34,7 @@ build_env:
     SILO_NAME: "cache-silo-{{ arch }}-{{ accelerator }}-{{ clang_version }}"
     DISABLE_XRT: "{{ disable_xrt }}"
     _GLIBCXX_USE_CXX11_ABI: 0
+    GIT_VERSIONED_XLA_BUILD: "{{ nightly_release }}"
 
   amd64:
     ARCH: amd64

--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -267,7 +267,7 @@ function build_and_install_torch() {
 function build_and_install_torch_xla() {
   git submodule update --init --recursive
   if [ "${RELEASE_VERSION}" = "nightly" ]; then
-    export GIT_VERSIONED_XLA_BUILD=1
+    export GIT_VERSIONED_XLA_BUILD=true
   else
     export TORCH_XLA_VERSION=${RELEASE_VERSION:1}  # r0.5 -> 0.5
   fi

--- a/scripts/build_torch_wheels.sh
+++ b/scripts/build_torch_wheels.sh
@@ -267,7 +267,7 @@ function build_and_install_torch() {
 function build_and_install_torch_xla() {
   git submodule update --init --recursive
   if [ "${RELEASE_VERSION}" = "nightly" ]; then
-    export VERSIONED_XLA_BUILD=1
+    export GIT_VERSIONED_XLA_BUILD=1
   else
     export TORCH_XLA_VERSION=${RELEASE_VERSION:1}  # r0.5 -> 0.5
   fi

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@
 #     specify the version of PyTorch/XLA, rather than the hard-coded version
 #     in this file; used when we're building binaries for distribution
 #
-#   VERSIONED_XLA_BUILD
-#     creates a versioned build
+#   GIT_VERSIONED_XLA_BUILD
+#     creates a git versioned build
 #
 #   TORCH_XLA_PACKAGE_NAME
 #     change the package name to something other than 'torch_xla'
@@ -101,7 +101,7 @@ def get_git_head_sha(base_dir):
 
 def get_build_version(xla_git_sha):
   version = os.getenv('TORCH_XLA_VERSION', '2.2.0')
-  if _check_env_flag('VERSIONED_XLA_BUILD', default='1'):
+  if _check_env_flag('GIT_VERSIONED_XLA_BUILD', default='TRUE'):
     try:
       version += '+git' + xla_git_sha[:7]
     except Exception:

--- a/setup.py
+++ b/setup.py
@@ -101,9 +101,9 @@ def get_git_head_sha(base_dir):
 
 def get_build_version(xla_git_sha):
   version = os.getenv('TORCH_XLA_VERSION', '2.2.0')
-  if _check_env_flag('VERSIONED_XLA_BUILD', default='0'):
+  if _check_env_flag('VERSIONED_XLA_BUILD', default='1'):
     try:
-      version += '+' + xla_git_sha[:7]
+      version += '+git' + xla_git_sha[:7]
     except Exception:
       pass
   return version


### PR DESCRIPTION
Summary:
This change makes the git version appears in pip by default. For any official release, we should turn that off by setting VERSIONED_XLA_BUILD=0.

Here is how it looks like:
torch                        2.2.0a0+git6ac8451
torch-xla                    2.2.0+git43cd6b5

Test Plan:
Manual.