### PR TITLE
Set --xla_latency_hiding_scheduler_rerun to 1

### DIFF
--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -33,6 +33,8 @@ def _setup_xla_flags():
   # shared memory limit 95% leads to OOM. Each rerun will choose a value
   # 0.9x of the previous run, and the number of rerun is set to 1 now.
   # Shared memory limit refers to --xla_tpu_scheduler_percent_shared_memory_limit.
+  # Lower shared memory limit means less communiation and computation overlapping,
+  # and thus worse performance.
   flags = _set_missing_flags(flags,
                              (('xla_latency_hiding_scheduler_rerun', '1'),))
   os.environ['XLA_FLAGS'] = ' '.join(flags)

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -29,6 +29,12 @@ def _setup_xla_flags():
       flags, (('xla_gpu_simplify_all_fp_conversions', 'false'),))
   flags = _set_missing_flags(flags,
                              (('xla_gpu_force_compilation_parallelism', '8'),))
+  # This flag will rerun the latency hidding scheduler if the default
+  # shared memory limit 95% leads to OOM. Each rerun will choose a value
+  # 0.9x of the previous run, and the number of rerun is set to 1 now.
+  # Shared memory limit refers to --xla_tpu_scheduler_percent_shared_memory_limit.
+  flags = _set_missing_flags(flags,
+                             (('xla_latency_hiding_scheduler_rerun', '1'),))
   os.environ['XLA_FLAGS'] = ' '.join(flags)
 
 


### PR DESCRIPTION
Summary:
This flag will rerun the latency hidding scheduler if the default
shared memory limit 95% leads to OOM. Each rerun will choose a value
0.9x of the previous run, and the number of rerun is set to 1 now.
Shared memory limit refers to --xla_tpu_scheduler_percent_shared_memory_limit.
Lower shared memory limit means less communiation and computation overlapping,
and thus worse performance.

Test Plan:
Tested on Llama 2 7B on V4-32.