### PR TITLE
Use default method in stablehlo txt/bytecode getter

### DIFF
--- a/torch_xla/stablehlo.py
+++ b/torch_xla/stablehlo.py
@@ -73,10 +73,14 @@ class StableHLOGraphModule:
       res = pytree.tree_unflatten(res, out_spec)
     return res
 
-  def get_stablehlo_bytecode(self, method_name):
+  def get_stablehlo_bytecode(self, method_name=None):
+    if method_name is None:
+      method_name = self._default_method
     return self._name_to_stablehlo[method_name].bytecode
 
-  def get_stablehlo_text(self, method_name):
+  def get_stablehlo_text(self, method_name=None):
+    if method_name is None:
+      method_name = self._default_method
     return self._name_to_stablehlo[method_name].text
 
   def save(self, directory_path):


### PR DESCRIPTION
User doesn't specify the default method name in the StablehloGraphModule, so the default method name should be used in stablehlo txt/bytecode getter method of StablehloGraphModule