### PR TITLE
Correct the multinode training doc

### DIFF
--- a/docs/pjrt.md
+++ b/docs/pjrt.md
@@ -200,7 +200,7 @@ To use GPUs with PJRT, simply set `PJRT_DEVICE=GPU` and configure
 `GPU_NUM_DEVICES` to the number of devices on the host. For example:
 
 ```
-PJRT_DEVICE=GPU GPU_NUM_DEVICES=4 python3 xla/test/test_train_mp_imagenet.py --fake_data --pjrt_distributed --batch_size=128 --num_epochs=1
+PJRT_DEVICE=GPU GPU_NUM_DEVICES=4 python3 xla/test/test_train_mp_imagenet.py --fake_data --batch_size=128 --num_epochs=1
 ```
 
 You can also use `torchrun` to initiate the single-node multi-GPU training. For example,

--- a/docs/pjrt.md
+++ b/docs/pjrt.md
@@ -206,7 +206,7 @@ PJRT_DEVICE=GPU GPU_NUM_DEVICES=4 python3 xla/test/test_train_mp_imagenet.py --f
 You can also use `torchrun` to initiate the single-node multi-GPU training. For example,
 
 ```
-PJRT_DEVICE=GPU torchrun --nnodes 1 --nproc-per-node ${NUM_GPU_DEVICES} xla/test/test_train_mp_imagenet.py --fake_data --batch_size=128 --num_epochs=1
+PJRT_DEVICE=GPU torchrun --nnodes 1 --nproc-per-node ${NUM_GPU_DEVICES} xla/test/test_train_mp_imagenet.py --fake_data --pjrt_distributed --batch_size=128 --num_epochs=1
 ```
 
 In the above example, `--nnodes` means how many machines (physical machines or VMs) to be used (it is 1 since we do single-node training). `--nproc-per-node` means how many GPU devices to be used.

--- a/docs/pjrt.md
+++ b/docs/pjrt.md
@@ -200,7 +200,7 @@ To use GPUs with PJRT, simply set `PJRT_DEVICE=GPU` and configure
 `GPU_NUM_DEVICES` to the number of devices on the host. For example:
 
 ```
-PJRT_DEVICE=GPU GPU_NUM_DEVICES=4 python3 xla/test/test_train_mp_imagenet.py --fake_data --batch_size=128 --num_epochs=1
+PJRT_DEVICE=GPU GPU_NUM_DEVICES=4 python3 xla/test/test_train_mp_imagenet.py --fake_data --pjrt_distributed --batch_size=128 --num_epochs=1
 ```
 
 You can also use `torchrun` to initiate the single-node multi-GPU training. For example,
@@ -248,7 +248,7 @@ On the second GPU machine, run
 --rdzv_endpoint="<MACHINE_0_IP_ADDRESS>:12355" pytorch/xla/test/test_train_mp_imagenet_torchrun.py  --fake_data --pjrt_distributed --batch_size=128 --num_epochs=1
 ```
 
-the difference between the 2 commands above are `--node_rank` and potentially `--nproc_per_node` if you want to use different number of GPU devices on each machine. All the rest are identical.
+the difference between the 2 commands above are `--node_rank` and potentially `--nproc_per_node` if you want to use different number of GPU devices on each machine. All the rest are identical. For more information about `torchrun`, please refer to this [page](https://pytorch.org/docs/stable/elastic/run.html).
 
 ## Differences from XRT
 

--- a/docs/pjrt.md
+++ b/docs/pjrt.md
@@ -245,7 +245,7 @@ On the second GPU machine, run
 --nnodes=2 \
 --node_rank=1 \
 --nproc_per_node=4 \
---rdzv_endpoint="<MACHINE_0_IP_ADDRESS>:12355" pytorch/xla/test/test_train_mp_imagenet_torchrun.py  --fake_data --pjrt_distributed --batch_size=128 --num_epochs=1
+--rdzv_endpoint="<MACHINE_0_IP_ADDRESS>:12355" pytorch/xla/test/test_train_mp_imagenet.py  --fake_data --pjrt_distributed --batch_size=128 --num_epochs=1
 ```
 
 the difference between the 2 commands above are `--node_rank` and potentially `--nproc_per_node` if you want to use different number of GPU devices on each machine. All the rest are identical. For more information about `torchrun`, please refer to this [page](https://pytorch.org/docs/stable/elastic/run.html).

--- a/test/test_train_mp_imagenet.py
+++ b/test/test_train_mp_imagenet.py
@@ -34,11 +34,6 @@ MODEL_OPTS = {
     '--pjrt_distributed': {
         'action': 'store_true',
     },
-    # Use xla:// init_method instead of env:// for `torch.distributed`.
-    # Required for DDP on TPU v2/v3 when using PJRT.
-    '--pjrt_distributed': {
-        'action': 'store_true',
-    },
     '--profile': {
         'action': 'store_true',
     },
@@ -376,7 +371,6 @@ def _mp_fn(index, flags):
 
 if __name__ == '__main__':
   if dist.is_torchelastic_launched():
-    # output error AttributeError: module 'torch_xla.core.xla_env_vars' has no attribute 'MASTER_ADDR'
     _mp_fn(xu.getenv_as(xenv.LOCAL_RANK, int), FLAGS)
   else:
     xmp.spawn(_mp_fn, args=(FLAGS,), nprocs=FLAGS.num_cores)

--- a/test/test_train_mp_mnist.py
+++ b/test/test_train_mp_mnist.py
@@ -5,6 +5,9 @@ MODEL_OPTS = {
     '--ddp': {
         'action': 'store_true',
     },
+    '--pjrt_distributed': {
+        'action': 'store_true',
+    },
 }
 
 FLAGS = args_parse.parse_common_options(
@@ -73,7 +76,7 @@ def _train_update(device, step, loss, tracker, epoch, writer):
 
 
 def train_mnist(flags, **kwargs):
-  if flags.ddp:
+  if flags.ddp or flags.pjrt_distributed:
     dist.init_process_group('xla', init_method='xla://')
 
   torch.manual_seed(1)


### PR DESCRIPTION
This PR
- adds `--pjrt_distributed` flag back due to https://github.com/pytorch/xla/pull/5732#issuecomment-1783549211.
- makes some correction to the multinode training doc.
- fix remaining comments in the previous pr https://github.com/pytorch/xla/pull/5704