### PR TITLE
Configure PATH and LD_LIBRARY_PATH to include cuda

### DIFF
--- a/infra/ansible/config/env.yaml
+++ b/infra/ansible/config/env.yaml
@@ -16,6 +16,8 @@ release_env:
   cuda:
     TF_CUDA_COMPUTE_CAPABILITIES: 7.0,7.5,8.0
     XLA_CUDA: 1
+    PATH=/usr/local/cuda-{{ cuda_version }}/bin${PATH:+:${PATH}}
+    LD_LIBRARY_PATH=/usr/local/cuda-{{ cuda_version }}/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 
 # Variables that will be passed to shell environment only for building PyTorch and XLA libs.
 build_env:
@@ -44,6 +46,8 @@ build_env:
   cuda:
     TF_CUDA_COMPUTE_CAPABILITIES: 7.0,7.5,8.0
     XLA_CUDA: 1
+    PATH=/usr/local/cuda-{{ cuda_version }}/bin${PATH:+:${PATH}}
+    LD_LIBRARY_PATH=/usr/local/cuda-{{ cuda_version }}/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 
   tpu:
     ACCELERATOR: tpu

--- a/infra/ansible/config/env.yaml
+++ b/infra/ansible/config/env.yaml
@@ -16,8 +16,8 @@ release_env:
   cuda:
     TF_CUDA_COMPUTE_CAPABILITIES: 7.0,7.5,8.0
     XLA_CUDA: 1
-    PATH=/usr/local/cuda-{{ cuda_version }}/bin${PATH:+:${PATH}}
-    LD_LIBRARY_PATH=/usr/local/cuda-{{ cuda_version }}/lib64:/usr/local/cuda-{{ cuda_version }}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+    PATH: /usr/local/cuda-{{ cuda_version }}/bin:/usr/local/nvidia/bin${PATH:+:${PATH}}
+    LD_LIBRARY_PATH: /usr/local/cuda-{{ cuda_version }}/lib64:/usr/local/cuda-{{ cuda_version }}/lib:/usr/local/nvidia/lib64:/usr/local/nvidia/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}:/usr/local/lib
 
 # Variables that will be passed to shell environment only for building PyTorch and XLA libs.
 build_env:
@@ -46,8 +46,8 @@ build_env:
   cuda:
     TF_CUDA_COMPUTE_CAPABILITIES: 7.0,7.5,8.0
     XLA_CUDA: 1
-    PATH=/usr/local/cuda-{{ cuda_version }}/bin${PATH:+:${PATH}}
-    LD_LIBRARY_PATH=/usr/local/cuda-{{ cuda_version }}/lib64:/usr/local/cuda-{{ cuda_version }}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+    PATH: /usr/local/cuda-{{ cuda_version }}/bin:/usr/local/nvidia/bin${PATH:+:${PATH}}
+    LD_LIBRARY_PATH: /usr/local/cuda-{{ cuda_version }}/lib64:/usr/local/cuda-{{ cuda_version }}/lib:/usr/local/nvidia/lib64:/usr/local/nvidia/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}:/usr/local/lib
 
   tpu:
     ACCELERATOR: tpu

--- a/infra/ansible/config/env.yaml
+++ b/infra/ansible/config/env.yaml
@@ -17,7 +17,7 @@ release_env:
     TF_CUDA_COMPUTE_CAPABILITIES: 7.0,7.5,8.0
     XLA_CUDA: 1
     PATH=/usr/local/cuda-{{ cuda_version }}/bin${PATH:+:${PATH}}
-    LD_LIBRARY_PATH=/usr/local/cuda-{{ cuda_version }}/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+    LD_LIBRARY_PATH=/usr/local/cuda-{{ cuda_version }}/lib64:/usr/local/cuda-{{ cuda_version }}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 
 # Variables that will be passed to shell environment only for building PyTorch and XLA libs.
 build_env:
@@ -47,7 +47,7 @@ build_env:
     TF_CUDA_COMPUTE_CAPABILITIES: 7.0,7.5,8.0
     XLA_CUDA: 1
     PATH=/usr/local/cuda-{{ cuda_version }}/bin${PATH:+:${PATH}}
-    LD_LIBRARY_PATH=/usr/local/cuda-{{ cuda_version }}/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+    LD_LIBRARY_PATH=/usr/local/cuda-{{ cuda_version }}/lib64:/usr/local/cuda-{{ cuda_version }}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 
   tpu:
     ACCELERATOR: tpu


### PR DESCRIPTION
An mandatory [step](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#mandatory-actions) after installing cuda is to configure PATH and LD_LIBRARY_PATH, such as
```
export PATH=/usr/local/cuda-11.8/bin${PATH:+:${PATH}}
export LD_LIBRARY_PATH=/usr/local/cuda-11.8/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
```
This PR intends to add the above 2 lines to bashrc/zshrc in the torch_xla cuda docker image so that users don't have to do it themselves.