### PR TITLE
Transfer data directly to the device

### DIFF
--- a/test/spmd/test_xla_distributed_checkpoint.py
+++ b/test/spmd/test_xla_distributed_checkpoint.py
@@ -212,7 +212,6 @@ class SPMDLoadPlannerTest(DistributedCheckpointTestBase):
 
   @unittest.skipIf(xr.global_runtime_device_count() == 1,
                    "Multiple devices required to shard tensors")
-  @unittest.skip("Hanging in TPU CI")
   def test_resolve_and_commit_sharded_tensor(self):
     model = self._get_sharded_model()
     planner = self._get_load_planner(model)

--- a/test/spmd/test_xla_distributed_checkpoint.py
+++ b/test/spmd/test_xla_distributed_checkpoint.py
@@ -212,6 +212,7 @@ class SPMDLoadPlannerTest(DistributedCheckpointTestBase):
 
   @unittest.skipIf(xr.global_runtime_device_count() == 1,
                    "Multiple devices required to shard tensors")
+  @unittest.skip("Hanging in TPU CI")
   def test_resolve_and_commit_sharded_tensor(self):
     model = self._get_sharded_model()
     planner = self._get_load_planner(model)

--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -1,4 +1,9 @@
 load(
+    "//bazel:rules_def.bzl",
+    "ptxla_cc_test",
+)
+
+load(
     "@tsl//tsl/platform/default:cuda_build_defs.bzl",
     "if_cuda_is_configured",
 )
@@ -61,6 +66,7 @@ cc_library(
     ":metrics_reader",
     ":metrics",
     ":sys_util",
+    ":tensor_source",
     ":types",
     ":util",
     ":xla_coordinator",
@@ -93,6 +99,7 @@ cc_library(
     ":env_vars",
     ":multi_wait",
     ":stablehlo_helper",
+    ":tensor_source",
     ":tf_logging",
     ":thread_pool",
     ":xla_coordinator",
@@ -294,6 +301,17 @@ cc_library(
 )
 
 cc_library(
+  name = "tensor_source",
+  hdrs = ["tensor_source.h"],
+  deps = [
+      ":debug_macros",
+      "@xla//xla:literal",
+      "@xla//xla:shape_util",
+      "@torch//:headers",
+  ]
+)
+
+cc_library(
     name = "types",
     hdrs = ["types.h"],
     deps = [
@@ -377,25 +395,27 @@ cc_test(
     ],
 )
 
-# TODO(goranpetrovic): reenable when `xla_cc_test` is fixed upstream.
-# xla_cc_test(
-#     name = "pjrt_computation_client_test",
-#     srcs = ["pjrt_computation_client_test.cc"],
-#     deps = [
-#         ":computation_client",
-#         "@xla//xla:literal",
-#         "@xla//xla:literal_util",
-#         "@xla//xla:shape_util",
-#         "@xla//xla:status",
-#         "@xla//xla:statusor",
-#         "@xla//xla/client:xla_builder",
-#         "@xla//xla/client:xla_computation",
-#         "@xla//xla/tests:literal_test_util",
-#         "@xla//xla/tools:hlo_module_loader",
-#         "@org_tensorflow//tensorflow/core/platform:logging",
-#         "@tsl//tsl/lib/core:status_test_util",
-#         "@tsl//tsl/platform:env",
-#         "@tsl//tsl/platform:test",
-#         "@tsl//tsl/platform:test_main",
-#     ],
-# )
+ptxla_cc_test(
+    name = "pjrt_computation_client_test",
+    srcs = ["pjrt_computation_client_test.cc"],
+    deps = [
+        ":computation_client",
+        ":pjrt_computation_client",
+        ":tensor_source",
+        "@xla//xla:literal",
+        "@xla//xla:literal_util",
+        "@xla//xla:shape_util",
+        "@xla//xla:status",
+        "@xla//xla:statusor",
+        "@xla//xla/client:xla_builder",
+        "@xla//xla/client:xla_computation",
+        "@xla//xla/tests:literal_test_util",
+        "@xla//xla/tools:hlo_module_loader",
+        "@tsl//tsl/lib/core:status_test_util",
+        "@tsl//tsl/platform:env",
+        "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:logging",
+        "@tsl//tsl/platform:test",
+        "@tsl//tsl/platform:test_main",
+    ],
+)

--- a/torch_xla/csrc/runtime/computation_client.h
+++ b/torch_xla/csrc/runtime/computation_client.h
@@ -271,6 +271,9 @@ class ComputationClient {
 
   // Reads the tensor literal values stored at TPU server sites, behind the
   // supplied handles.
+  // Note: `TransferFromServer` call will block until the `DataPtrs` are ready
+  // if they were created by `TransferToServer` or `Execute*`. Calling this from
+  // python while holding the GIL can cause deadlocks!
   virtual std::vector<xla::Literal> TransferFromServer(
       absl::Span<const DataPtr> handles) = 0;
 

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -302,8 +302,8 @@ std::vector<ComputationClient::DataPtr> PjRtComputationClient::TransferToServer(
     std::shared_ptr<xla::PjRtBuffer> buffer =
         std::move(client_
                       ->BufferFromHostBuffer(
-                          tensor->data(), tensor->shape().element_type(),
-                          tensor->shape().dimensions(), tensor->byte_strides(),
+                          tensor->data(), tensor->primitive_type(),
+                          tensor->dimensions(), tensor->byte_strides(),
                           xla::PjRtClient::HostBufferSemantics::
                               kImmutableUntilTransferCompletes,
                           [tensor]() { /* frees tensor */ }, pjrt_device)

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -297,6 +297,8 @@ std::vector<ComputationClient::DataPtr> PjRtComputationClient::TransferToServer(
   for (auto& tensor : tensors) {
     xla::PjRtDevice* pjrt_device = StringToPjRtDevice(tensor->device());
 
+    total_size += xla::ShapeUtil::ByteSizeOf(tensor->shape());
+
     std::shared_ptr<xla::PjRtBuffer> buffer =
         std::move(client_
                       ->BufferFromHostBuffer(
@@ -308,8 +310,7 @@ std::vector<ComputationClient::DataPtr> PjRtComputationClient::TransferToServer(
                       .value());
 
     ComputationClient::DataPtr data =
-        std::make_shared<PjRtData>(tensor->device(), buffer);
-    total_size += xla::ShapeUtil::ByteSizeOf(data->shape());
+        std::make_shared<PjRtData>(tensor->device(), tensor->shape(), buffer);
     datas.push_back(data);
   }
   OutboundDataMetric()->AddSample(total_size);

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -297,8 +297,6 @@ std::vector<ComputationClient::DataPtr> PjRtComputationClient::TransferToServer(
   for (auto& tensor : tensors) {
     xla::PjRtDevice* pjrt_device = StringToPjRtDevice(tensor->device());
 
-    total_size += xla::ShapeUtil::ByteSizeOf(tensor->shape());
-
     std::shared_ptr<xla::PjRtBuffer> buffer =
         std::move(client_
                       ->BufferFromHostBuffer(
@@ -310,7 +308,8 @@ std::vector<ComputationClient::DataPtr> PjRtComputationClient::TransferToServer(
                       .value());
 
     ComputationClient::DataPtr data =
-        std::make_shared<PjRtData>(tensor->device(), tensor->shape(), buffer);
+        std::make_shared<PjRtData>(tensor->device(), buffer);
+    total_size += xla::ShapeUtil::ByteSizeOf(data->shape());
     datas.push_back(data);
   }
   OutboundDataMetric()->AddSample(total_size);

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -37,7 +37,7 @@ class PjRtComputationClient : public ComputationClient {
   std::optional<xla::OpSharding> GetDataSharding(DataPtr handle) override;
 
   std::vector<DataPtr> TransferToServer(
-      absl::Span<const TensorSource> tensors) override;
+      absl::Span<const std::shared_ptr<const TensorSource>> tensors) override;
 
   // Use XLA replication to re-assemble the sharded data.
   DataPtr ReplicateShardedData(const DataPtr& handle);
@@ -45,9 +45,9 @@ class PjRtComputationClient : public ComputationClient {
   std::vector<xla::Literal> TransferFromServer(
       absl::Span<const DataPtr> handles) override;
 
-  DataPtr TransferShardsToServer(absl::Span<const TensorSource> tensor_shards,
-                                 std::string device, xla::Shape shape,
-                                 xla::OpSharding sharding) override;
+  DataPtr TransferShardsToServer(
+      absl::Span<const std::shared_ptr<const TensorSource>> tensor_shards,
+      std::string device, xla::Shape shape, xla::OpSharding sharding) override;
 
   DataPtr CopyToDevice(DataPtr data, std::string dst) override;
 

--- a/torch_xla/csrc/runtime/pjrt_computation_client_test.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client_test.cc
@@ -7,6 +7,8 @@
 #include <vector>
 
 #include "torch_xla/csrc/runtime/computation_client.h"
+#include "torch_xla/csrc/runtime/pjrt_computation_client.h"
+#include "torch_xla/csrc/runtime/tensor_source.h"
 #include "tsl/lib/core/status_test_util.h"
 #include "tsl/platform/env.h"
 #include "tsl/platform/logging.h"
@@ -30,17 +32,6 @@ tsl::StatusOr<xla::XlaComputation> MakeComputation() {
   xla::XlaOp y = xla::Parameter(&builder, 1, input_shape, "y");
   xla::XlaOp sum = xla::Add(x, y);
   return builder.Build();
-}
-
-ComputationClient::TensorSource TensorSourceFromLiteral(
-    const std::string& device, const xla::Literal& literal) {
-  auto populate_fn = [&](const ComputationClient::TensorSource& source_tensor,
-                         void* dest_buffer, size_t dest_buffer_size) {
-    std::memcpy(dest_buffer, literal.data<float>().data(),
-                dest_buffer_size * sizeof(literal.data<float>().data()));
-  };
-  return ComputationClient::TensorSource(literal.shape(), device,
-                                         std::move(populate_fn));
 }
 
 TEST(PjRtComputationClientTest, Init) {
@@ -69,9 +60,9 @@ TEST(PjRtComputationClientTest, Init) {
 
   // Copy inputs to device.
   ComputationClient::ExecuteComputationOptions options{};
-  std::vector<ComputationClient::TensorSource> args = {
-      TensorSourceFromLiteral(device, literal_x),
-      TensorSourceFromLiteral(device, literal_y)};
+  std::vector<std::shared_ptr<const TensorSource>> args = {
+      std::make_shared<LiteralSource>(std::move(literal_x), device),
+      std::make_shared<LiteralSource>(std::move(literal_y), device)};
 
   // Execute the graph.
   std::vector<ComputationClient::DataPtr> results = client->ExecuteComputation(

--- a/torch_xla/csrc/runtime/tensor_source.h
+++ b/torch_xla/csrc/runtime/tensor_source.h
@@ -1,0 +1,70 @@
+#ifndef XLA_CLIENT_TENSOR_SOURCE_H_
+#define XLA_CLIENT_TENSOR_SOURCE_H_
+
+#include <ATen/Tensor.h>
+
+#include <vector>
+
+#include "torch_xla/csrc/runtime/debug_macros.h"
+#include "xla/literal.h"
+#include "xla/shape.h"
+#include "xla/shape_util.h"
+
+namespace torch_xla {
+namespace runtime {
+
+// Owns a contiguous block of data with the shape and layout matching `shape()`.
+class TensorSource {
+ public:
+  TensorSource(std::string device) : device_(std::move(device)){};
+
+  virtual const void* data() const = 0;
+
+  virtual const xla::Shape& shape() const = 0;
+
+  const std::string& device() const { return device_; }
+
+  std::vector<int64_t> byte_strides() const {
+    std::vector<int64_t> byte_strides(shape().dimensions_size());
+    XLA_CHECK_OK(
+        xla::ShapeUtil::ByteStrides(shape(), absl::MakeSpan(byte_strides)));
+    return byte_strides;
+  }
+
+ private:
+  std::string device_;
+};
+
+class AtenSource : public TensorSource {
+ public:
+  AtenSource(const at::Tensor& tensor, xla::Shape shape, std::string device)
+      : TensorSource(std::move(device)),
+        tensor_(std::move(tensor.contiguous())),
+        shape_(std::move(shape)) {}
+
+  const void* data() const override { return tensor_.const_data_ptr(); }
+
+  const xla::Shape& shape() const override { return shape_; }
+
+ private:
+  at::Tensor tensor_;
+  xla::Shape shape_;
+};
+
+class LiteralSource : public TensorSource {
+ public:
+  LiteralSource(xla::Literal literal, std::string device)
+      : TensorSource(std::move(device)), literal_(std::move(literal)) {}
+
+  const void* data() const override { return literal_.untyped_data(); }
+
+  const xla::Shape& shape() const override { return literal_.shape(); }
+
+ private:
+  xla::Literal literal_;
+};
+
+}  // namespace runtime
+}  // namespace torch_xla
+
+#endif  // XLA_CLIENT_COMPUTATION_CLIENT_H_

--- a/torch_xla/csrc/runtime/tensor_source.h
+++ b/torch_xla/csrc/runtime/tensor_source.h
@@ -38,7 +38,7 @@ class AtenSource : public TensorSource {
  public:
   AtenSource(const at::Tensor& tensor, xla::PrimitiveType target_type,
              std::string device)
-      : TensorSource(std::move(device)), target_type_(target_type_) {
+      : TensorSource(std::move(device)), target_type_(target_type) {
     at::ScalarType target_torch_type = TorchTypeFromXlaType(primitive_type());
     if (target_torch_type != tensor.type().scalarType()) {
       TORCH_LAZY_COUNTER("AtenSourceDowncasts", 1);

--- a/torch_xla/csrc/runtime/tensor_source.h
+++ b/torch_xla/csrc/runtime/tensor_source.h
@@ -36,7 +36,8 @@ class TensorSource {
 
 class AtenSource : public TensorSource {
  public:
-  AtenSource(const at::Tensor& tensor, xla::PrimitiveType target_type, std::string device)
+  AtenSource(const at::Tensor& tensor, xla::PrimitiveType target_type,
+             std::string device)
       : TensorSource(std::move(device)), target_type_(target_type_) {
     at::ScalarType target_torch_type = TorchTypeFromXlaType(primitive_type());
     if (target_torch_type != tensor.type().scalarType()) {

--- a/torch_xla/csrc/runtime/tensor_source.h
+++ b/torch_xla/csrc/runtime/tensor_source.h
@@ -24,11 +24,20 @@ class TensorSource {
 
   const std::string& device() const { return device_; }
 
-  std::vector<int64_t> byte_strides() const {
+  virtual std::vector<int64_t> byte_strides() const {
     std::vector<int64_t> byte_strides(shape().dimensions_size());
     XLA_CHECK_OK(
         xla::ShapeUtil::ByteStrides(shape(), absl::MakeSpan(byte_strides)));
     return byte_strides;
+  }
+
+  virtual std::vector<int64_t> dimensions() const {
+    auto dimensions = shape().dimensions();
+    return {dimensions.begin(), dimensions.end()};
+  }
+
+  virtual xla::PrimitiveType primitive_type() const {
+    return shape().element_type();
   }
 
  private:
@@ -45,6 +54,50 @@ class AtenSource : public TensorSource {
   const void* data() const override { return tensor_.const_data_ptr(); }
 
   const xla::Shape& shape() const override { return shape_; }
+
+  std::vector<int64_t> byte_strides() const override {
+    std::vector<int64_t> strides;
+    for (auto& stride : tensor_.strides()) {
+      strides.push_back(stride * tensor_.itemsize());
+    }
+    return strides;
+  }
+
+  std::vector<int64_t> dimensions() const override {
+    auto sizes = tensor_.sizes();
+    return {sizes.begin(), sizes.end()};
+  }
+
+  // xla::PrimitiveType primitive_type() const override {
+  //   switch (tensor_.type().scalarType()) {
+  //     case at::ScalarType::Double:
+  //       return xla::PrimitiveType::F64;
+  //     case at::ScalarType::Float:
+  //       return xla::PrimitiveType::F32;
+  //     case at::ScalarType::BFloat16:
+  //       return xla::PrimitiveType::BF16;
+  //     case at::ScalarType::Half:
+  //       return xla::PrimitiveType::F16;
+  //     case at::ScalarType::Bool:
+  //       return xla::PrimitiveType::PRED;
+  //     case at::ScalarType::Byte:
+  //       return xla::PrimitiveType::U8;
+  //     case at::ScalarType::Char:
+  //       return xla::PrimitiveType::S8;
+  //     case at::ScalarType::Short:
+  //       return xla::PrimitiveType::S16;
+  //     case at::ScalarType::Int:
+  //       return xla::PrimitiveType::S32;
+  //     case at::ScalarType::Long:
+  //       return xla::PrimitiveType::S64;
+  //     case at::ScalarType::ComplexFloat:
+  //       return xla::PrimitiveType::C64;
+  //     case at::ScalarType::ComplexDouble:
+  //       return xla::PrimitiveType::C128;
+  //     default:
+  //       XLA_ERROR() << "Type not supported: " << tensor_.type().scalarType();
+  //   }
+  // }
 
  private:
   at::Tensor tensor_;

--- a/torch_xla/csrc/runtime/tensor_source.h
+++ b/torch_xla/csrc/runtime/tensor_source.h
@@ -6,6 +6,7 @@
 
 #include <vector>
 
+#include "torch_xla/csrc/dtype.h"
 #include "torch_xla/csrc/runtime/debug_macros.h"
 #include "xla/literal.h"
 #include "xla/shape.h"
@@ -13,45 +14,6 @@
 
 namespace torch_xla {
 namespace runtime {
-
-namespace {
-
-// TODO: consolidate
-at::ScalarType TensorTypeFromXlaType(xla::PrimitiveType xla_type) {
-  switch (xla_type) {
-    case xla::PrimitiveType::BF16:
-      return at::ScalarType::BFloat16;
-    case xla::PrimitiveType::F16:
-      return at::ScalarType::Half;
-    case xla::PrimitiveType::F32:
-      return at::ScalarType::Float;
-    case xla::PrimitiveType::F64:
-      return at::ScalarType::Double;
-    case xla::PrimitiveType::PRED:
-      return at::ScalarType::Bool;
-    case xla::PrimitiveType::U8:
-      return at::ScalarType::Byte;
-    case xla::PrimitiveType::S8:
-      return at::ScalarType::Char;
-    case xla::PrimitiveType::S16:
-    case xla::PrimitiveType::U16:
-      return at::ScalarType::Short;
-    case xla::PrimitiveType::S32:
-    case xla::PrimitiveType::U32:
-      return at::ScalarType::Int;
-    case xla::PrimitiveType::S64:
-    case xla::PrimitiveType::U64:
-      return at::ScalarType::Long;
-    case xla::PrimitiveType::C64:
-      return at::ScalarType::ComplexFloat;
-    case xla::PrimitiveType::C128:
-      return at::ScalarType::ComplexDouble;
-    default:
-      XLA_ERROR() << "XLA type not supported: " << xla_type;
-  }
-}
-
-}  // namespace
 
 // Owns a contiguous block of data with the shape and layout matching `shape()`.
 class TensorSource {

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -35,7 +35,7 @@ namespace torch_xla {
 namespace {
 
 struct DataAsync {
-  std::vector<runtime::ComputationClient::TensorSource> source_tensors;
+  std::vector<std::shared_ptr<const runtime::TensorSource>> source_tensors;
   std::vector<torch::lazy::BackendDataPtr> async_datas;
   std::vector<runtime::util::ExceptionCleanup> handle_unlockers;
 };
@@ -479,15 +479,9 @@ torch::lazy::BackendDataPtr TensorToXlaData(
                                            sharding_spec);
   }
 
-  auto populate_fn =
-      [&](const runtime::ComputationClient::TensorSource& source_tensor,
-          void* dest_buffer, size_t dest_buffer_size) {
-        PopulateTensorBuffer(tensor, source_tensor.shape, dest_buffer,
-                             dest_buffer_size, device);
-      };
-
-  std::vector<runtime::ComputationClient::TensorSource> source_tensors;
-  source_tensors.emplace_back(shape, device.toString(), std::move(populate_fn));
+  std::vector<std::shared_ptr<const runtime::TensorSource>> source_tensors;
+  source_tensors.push_back(
+      std::make_shared<runtime::AtenSource>(tensor, shape, device.toString()));
 
   auto handles =
       runtime::GetComputationClient()->TransferToServer(source_tensors);
@@ -709,19 +703,12 @@ std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
     return WrapXlaData(handles);
   }
 
-  std::vector<runtime::ComputationClient::TensorSource> source_tensors;
+  std::vector<std::shared_ptr<const runtime::TensorSource>> source_tensors;
   for (size_t i = 0; i < tensors.size(); ++i) {
     torch::lazy::BackendDevice device = ParseDeviceString(devices[i]);
     xla::Shape shape = CreateComputationShapeFromTensor(tensors[i], &device);
-    auto populate_fn =
-        [&, i, device](
-            const runtime::ComputationClient::TensorSource& source_tensor,
-            void* dest_buffer, size_t dest_buffer_size) {
-          PopulateTensorBuffer(tensors[i], source_tensor.shape, dest_buffer,
-                               dest_buffer_size, device);
-        };
-    source_tensors.emplace_back(std::move(shape), devices[i],
-                                std::move(populate_fn));
+    source_tensors.push_back(std::make_shared<runtime::AtenSource>(
+        tensors[i], std::move(shape), devices[i]));
   }
   return WrapXlaData(
       runtime::GetComputationClient()->TransferToServer(source_tensors));
@@ -740,7 +727,8 @@ std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
     torch::lazy::BackendDevice device = ParseDeviceString(devices[i]);
     xla::Shape shape = CreateComputationShapeFromTensor(tensors[i], &device);
 
-    std::vector<runtime::ComputationClient::TensorSource> source_tensors;  // in
+    std::vector<std::shared_ptr<const runtime::TensorSource>>
+        source_tensors;                                            // in
     std::vector<runtime::ComputationClient::DataPtr> new_handles;  // out
     if (static_cast<XlaDeviceType>(device.type()) == XlaDeviceType::SPMD) {
       // GetLocalDevices returns the list of local devices specified by their
@@ -756,15 +744,8 @@ std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
       new_handles.push_back(ShardingUtil::CreateShardedData(
           local_shards, local_devices, shardings[i]));
     } else {
-      auto populate_fn =
-          [&, i, device](
-              const runtime::ComputationClient::TensorSource& source_tensor,
-              void* dest_buffer, size_t dest_buffer_size) {
-            PopulateTensorBuffer(tensors[i], source_tensor.shape, dest_buffer,
-                                 dest_buffer_size, device);
-          };
-      source_tensors.emplace_back(std::move(shape), devices[i],
-                                  std::move(populate_fn));
+      source_tensors.push_back(std::make_shared<runtime::AtenSource>(
+          tensors[i], std::move(shape), devices[i]));
       new_handles =
           runtime::GetComputationClient()->TransferToServer(source_tensors);
     }

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -480,8 +480,8 @@ torch::lazy::BackendDataPtr TensorToXlaData(
   }
 
   std::vector<std::shared_ptr<const runtime::TensorSource>> source_tensors;
-  source_tensors.push_back(
-      std::make_shared<runtime::AtenSource>(tensor, shape.element_type(), device.toString()));
+  source_tensors.push_back(std::make_shared<runtime::AtenSource>(
+      tensor, shape.element_type(), device.toString()));
 
   auto handles =
       runtime::GetComputationClient()->TransferToServer(source_tensors);
@@ -707,7 +707,9 @@ std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
   for (size_t i = 0; i < tensors.size(); ++i) {
     torch::lazy::BackendDevice device = ParseDeviceString(devices[i]);
     source_tensors.push_back(std::make_shared<runtime::AtenSource>(
-        tensors[i], MaybeDowncastForDevice(tensors[i].type().scalarType(), device), devices[i]));
+        tensors[i],
+        MaybeDowncastForDevice(tensors[i].type().scalarType(), device),
+        devices[i]));
   }
   return WrapXlaData(
       runtime::GetComputationClient()->TransferToServer(source_tensors));
@@ -743,7 +745,9 @@ std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
           local_shards, local_devices, shardings[i]));
     } else {
       source_tensors.push_back(std::make_shared<runtime::AtenSource>(
-          tensors[i], MaybeDowncastForDevice(tensors[i].type().scalarType(), device), devices[i]));
+          tensors[i],
+          MaybeDowncastForDevice(tensors[i].type().scalarType(), device),
+          devices[i]));
       new_handles =
           runtime::GetComputationClient()->TransferToServer(source_tensors);
     }

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -772,7 +772,7 @@ xla::Literal GetTensorLiteral(const at::Tensor& tensor, const xla::Shape* shape,
 }
 
 std::vector<xla::Literal> ReleaseGilAndTransferData(
-  absl::Span<const torch::lazy::BackendDataPtr> xla_data) {
+    absl::Span<const torch::lazy::BackendDataPtr> xla_data) {
   // HACK: This method may be called outside of python (mainly in C++ tests) or
   // when the GIL is already released, so we must check both cases here. If
   // possible, prefer to release the GIL in the python bindings before copying

--- a/torch_xla/csrc/tensor_util.h
+++ b/torch_xla/csrc/tensor_util.h
@@ -29,7 +29,7 @@ at::Tensor MakeTensorFromXlaLiteral(const xla::Literal& literal,
 // block until `DataPtr`s are ready. Release the GIL so other threads can
 // proceed and unblock any transfers or collective computations.
 std::vector<xla::Literal> ReleaseGilAndTransferData(
-  absl::Span<const torch::lazy::BackendDataPtr> xla_data);
+    absl::Span<const torch::lazy::BackendDataPtr> xla_data);
 
 // TODO LTC @wonjoo - Migrate to upstream after Device -> BackendDevice
 std::vector<at::Tensor> XlaDataToTensors(

--- a/torch_xla/csrc/tensor_util.h
+++ b/torch_xla/csrc/tensor_util.h
@@ -25,6 +25,12 @@ std::vector<int64_t> ComputeShapeStrides(const xla::Shape& shape);
 at::Tensor MakeTensorFromXlaLiteral(const xla::Literal& literal,
                                     at::ScalarType dest_element_type);
 
+// Execution and data transfer are async in PJRT, so TransferFromServer may
+// block until `DataPtr`s are ready. Release the GIL so other threads can
+// proceed and unblock any transfers or collective computations.
+std::vector<xla::Literal> ReleaseGilAndTransferData(
+  absl::Span<const torch::lazy::BackendDataPtr> xla_data);
+
 // TODO LTC @wonjoo - Migrate to upstream after Device -> BackendDevice
 std::vector<at::Tensor> XlaDataToTensors(
     absl::Span<const torch::lazy::BackendDataPtr> xla_data,

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -727,11 +727,10 @@ runtime::ComputationClient::DataPtr ShardingUtil::CreateShardedData(
   }
   for (int64_t j = 0; j < devices.size(); ++j) {
     auto shard_device = ParseDeviceString(devices[j]);
+    auto shard_shape =
+        CreateComputationShapeFromTensor(local_shards[j], &shard_device);
     source_tensors.push_back(std::make_shared<runtime::AtenSource>(
-        local_shards[j],
-        MaybeDowncastForDevice(local_shards[j].type().scalarType(),
-                               shard_device),
-        devices[j]));
+        local_shards[j], shard_shape, devices[j]));
   }
   return runtime::GetComputationClient()->TransferShardsToServer(
       source_tensors, GetVirtualDevice().toString(), global_shape, sharding);

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -728,7 +728,10 @@ runtime::ComputationClient::DataPtr ShardingUtil::CreateShardedData(
   for (int64_t j = 0; j < devices.size(); ++j) {
     auto shard_device = ParseDeviceString(devices[j]);
     source_tensors.push_back(std::make_shared<runtime::AtenSource>(
-        local_shards[j], MaybeDowncastForDevice(local_shards[j].type().scalarType(), shard_device), devices[j]));
+        local_shards[j],
+        MaybeDowncastForDevice(local_shards[j].type().scalarType(),
+                               shard_device),
+        devices[j]));
   }
   return runtime::GetComputationClient()->TransferShardsToServer(
       source_tensors, GetVirtualDevice().toString(), global_shape, sharding);

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -712,7 +712,7 @@ runtime::ComputationClient::DataPtr ShardingUtil::CreateShardedData(
     const XLATensor::ShardingSpecPtr& sharding_spec) {
   XLA_CHECK(local_shards.size() == devices.size())
       << "A device must be speficied for each shard";
-  std::vector<runtime::ComputationClient::TensorSource> source_tensors;
+  std::vector<std::shared_ptr<const runtime::TensorSource>> source_tensors;
   xla::Shape global_shape;
   xla::OpSharding sharding;
   if (sharding_spec == nullptr) {
@@ -729,15 +729,8 @@ runtime::ComputationClient::DataPtr ShardingUtil::CreateShardedData(
     auto shard_device = ParseDeviceString(devices[j]);
     auto shard_shape =
         CreateComputationShapeFromTensor(local_shards[j], &shard_device);
-    auto populate_fn =
-        [&, j, shard_device](
-            const runtime::ComputationClient::TensorSource& source_tensor,
-            void* dest_buffer, size_t dest_buffer_size) {
-          PopulateTensorBuffer(local_shards[j], source_tensor.shape,
-                               dest_buffer, dest_buffer_size, shard_device);
-        };
-    source_tensors.emplace_back(shard_shape, devices[j],
-                                std::move(populate_fn));
+    source_tensors.push_back(std::make_shared<runtime::AtenSource>(
+        local_shards[j], shard_shape, devices[j]));
   }
   return runtime::GetComputationClient()->TransferShardsToServer(
       source_tensors, GetVirtualDevice().toString(), global_shape, sharding);

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -727,10 +727,8 @@ runtime::ComputationClient::DataPtr ShardingUtil::CreateShardedData(
   }
   for (int64_t j = 0; j < devices.size(); ++j) {
     auto shard_device = ParseDeviceString(devices[j]);
-    auto shard_shape =
-        CreateComputationShapeFromTensor(local_shards[j], &shard_device);
     source_tensors.push_back(std::make_shared<runtime::AtenSource>(
-        local_shards[j], shard_shape, devices[j]));
+        local_shards[j], MaybeDowncastForDevice(local_shards[j].type().scalarType(), shard_device), devices[j]));
   }
   return runtime::GetComputationClient()->TransferShardsToServer(
       source_tensors, GetVirtualDevice().toString(), global_shape, sharding);


### PR DESCRIPTION
Take two. See the notes from the original PR #5752

New changes:

- Use the actual byte strides of the input `at::Tensor` instead of the strides in the `xla::Shape`.
- Downcast the input `at::Tensor` if the target type differs from the actual type.
- Release the GIL in `XlaDataToTensors`, since `at::Tensor` destruction after `TransferToServer` can deadlock with `TransferFromServer`.