### PR TITLE
Lower AtenFull op

### DIFF
--- a/codegen/xla_native_functions.yaml
+++ b/codegen/xla_native_functions.yaml
@@ -192,6 +192,7 @@ supported:
   - floor_divide
   - fmod.Scalar
   - fmod.Tensor
+  - full
   - gather
   - gelu
   - gelu_backward

--- a/test/cpp/test_aten_xla_tensor_1.cpp
+++ b/test/cpp/test_aten_xla_tensor_1.cpp
@@ -139,8 +139,7 @@ TEST_F(AtenXlaTensorTest, TestFull) {
   });
 
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::empty", cpp_test::GetIgnoredCounters());
-  ExpectCounterChanged("xla::fill_", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::full", cpp_test::GetIgnoredCounters());
 }
 
 TEST_F(AtenXlaTensorTest, TestFullLike) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1331,23 +1331,22 @@ at::Tensor XLANativeFunctions::fmod(const at::Tensor& self,
                     });
 }
 
-at::Tensor XLANativeFunctions::full(at::IntArrayRef size, 
-                                    const at::Scalar & fill_value, 
-                                    c10::optional<at::ScalarType> dtype, 
-                                    c10::optional<at::Layout> layout, 
-                                    c10::optional<at::Device> device, 
+at::Tensor XLANativeFunctions::full(at::IntArrayRef size,
+                                    const at::Scalar& fill_value,
+                                    c10::optional<at::ScalarType> dtype,
+                                    c10::optional<at::Layout> layout,
+                                    c10::optional<at::Device> device,
                                     c10::optional<bool> pin_memory) {
   TORCH_LAZY_FN_COUNTER("xla::");
   // Fall back to CPU if layout or pin_memory are not default
-  if (layout.value_or(at::Layout::Strided) != at::Layout::Strided || pin_memory.value_or(false)) {
-    return at::native::call_fallback_fn<&xla_cpu_fallback, ATEN_OP(full)>::call(size, fill_value, dtype, layout, device, pin_memory);
+  if (layout.value_or(at::Layout::Strided) != at::Layout::Strided ||
+      pin_memory.value_or(false)) {
+    return at::native::call_fallback_fn<&xla_cpu_fallback, ATEN_OP(full)>::call(
+        size, fill_value, dtype, layout, device, pin_memory);
   }
   return bridge::AtenFromXlaTensor(tensor_methods::full(
-    absl::Span<const int64_t>(size),
-    fill_value,
-    GetXlaDeviceOrCurrent(device),
-    at::dtype_or_default(dtype)
-  ));
+      absl::Span<const int64_t>(size), fill_value,
+      GetXlaDeviceOrCurrent(device), at::dtype_or_default(dtype)));
 }
 
 at::Tensor XLANativeFunctions::gather(const at::Tensor& self, int64_t dim,

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1331,6 +1331,25 @@ at::Tensor XLANativeFunctions::fmod(const at::Tensor& self,
                     });
 }
 
+at::Tensor XLANativeFunctions::full(at::IntArrayRef size, 
+                                    const at::Scalar & fill_value, 
+                                    c10::optional<at::ScalarType> dtype, 
+                                    c10::optional<at::Layout> layout, 
+                                    c10::optional<at::Device> device, 
+                                    c10::optional<bool> pin_memory) {
+  TORCH_LAZY_FN_COUNTER("xla::");
+  // Fall back to CPU if layout or pin_memory are not default
+  if (layout.value_or(at::Layout::Strided) != at::Layout::Strided || pin_memory.value_or(false)) {
+    return at::native::call_fallback_fn<&xla_cpu_fallback, ATEN_OP(full)>::call(size, fill_value, dtype, layout, device, pin_memory);
+  }
+  return bridge::AtenFromXlaTensor(tensor_methods::full(
+    absl::Span<const int64_t>(size),
+    fill_value,
+    GetXlaDeviceOrCurrent(device),
+    at::dtype_or_default(dtype)
+  ));
+}
+
 at::Tensor XLANativeFunctions::gather(const at::Tensor& self, int64_t dim,
                                       const at::Tensor& index,
                                       bool /* sparse_grad */) {


### PR DESCRIPTION
Fixes #5780 

This is my first attempt at op lowering, and I have a couple questions:

1) Do we want to fallback to the pytorch/aten CPU version of this op if the `layout` and/or `pin_memory` values are not the default? I saw this pattern in other places in in `aten_xla_type.cpp`, and the `tensor_methods::full` function in XLA doesn't support these parameters, so it seemed like the right thing to do, but I'm not sure.

2) I notice `full` was not listed in `xla_native_functions.yaml` (as expected) but there IS an existing test for it in `test_aten_xla_tensor_1.cpp` called `TestFull`, which seems to verify that we use `xla::empty` followed by `xla::fill_` to create a tensor with the fill value. So I just changed this test to check that we are instead using the new `full` method implemented in this PR. I confirmed the test is passing with these changes, and failing without the changes. Is this the correct thing to do here?