### PR TITLE
[PJRT] Use TPU profiler plugin

### DIFF
--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -83,6 +83,7 @@ cc_library(
     ":debug_macros",
     ":env_vars",
     ":multi_wait",
+    ":profiler",
     ":stablehlo_helper",
     ":tensor_source",
     ":tf_logging",
@@ -97,6 +98,7 @@ cc_library(
     "@xla//xla/pjrt:pjrt_client",
     "@xla//xla/pjrt:tfrt_cpu_pjrt_client",
     "@xla//xla/pjrt:pjrt_c_api_client",
+    "@xla//xla/pjrt/c:pjrt_c_api_hdrs",
     "@tsl//tsl/profiler/lib:traceme",
     "@tsl//tsl/platform/cloud:gcs_file_system",
     "@com_google_absl//absl/strings",
@@ -194,18 +196,34 @@ cc_library(
     ],
 )
 
+# Profiler silently fails unless we link these backends
+cc_library(
+  name = "profiler_backends",
+  visibility = ["//visibility:private"],
+  deps = [
+    "@xla//xla/backends/profiler/cpu:host_tracer",
+    "@xla//xla/backends/profiler/cpu:metadata_collector",
+  ] + if_cuda_is_configured([
+    "@xla//xla/backends/profiler/gpu:device_tracer",
+  ]),
+  alwayslink = True,
+)
+
 cc_library(
     name = "profiler",
     srcs = ["profiler.cc"],
     hdrs = ["profiler.h"],
     deps = [
+      ":debug_macros",
+      ":profiler_backends",
+      "@xla//xla/backends/profiler/plugin:profiler_c_api_hdrs",
+      "@xla//xla/backends/profiler/plugin:plugin_tracer",
+      "@xla//xla/pjrt/c:pjrt_c_api_profiler_extension_hdrs",
       "@tsl//tsl/platform:status",
+      "@tsl//tsl/profiler/lib:profiler_factory",
       "@tsl//tsl/profiler/rpc:profiler_server_impl",
       "@tsl//tsl/profiler/rpc/client:capture_profile",
       "@com_google_absl//absl/container:flat_hash_map",
-
-      # Profiler silently fails unless we include this
-      "@xla//xla/backends/profiler:profiler_backends",
 
       # TODO: We get missing symbol errors without these deps. Why aren't they
       # included transitively from TensorFlow/TSL?

--- a/torch_xla/csrc/runtime/profiler.cc
+++ b/torch_xla/csrc/runtime/profiler.cc
@@ -1,13 +1,35 @@
 #include "torch_xla/csrc/runtime/profiler.h"
 
 #include "absl/container/flat_hash_map.h"
+#include "torch_xla/csrc/runtime/debug_macros.h"
 #include "tsl/platform/status.h"
+#include "tsl/profiler/lib/profiler_factory.h"
 #include "tsl/profiler/rpc/client/capture_profile.h"
 #include "tsl/profiler/rpc/profiler_server.h"
+#include "xla/backends/profiler/plugin/plugin_tracer.h"
+#include "xla/backends/profiler/plugin/profiler_c_api.h"
+#include "xla/pjrt/c/pjrt_c_api_profiler_extension.h"
 
 namespace torch_xla {
 namespace runtime {
 namespace profiler {
+
+namespace {
+
+const PLUGIN_Profiler_Api* FindProfilerApi(const PJRT_Api* pjrt_api) {
+  const PJRT_Structure_Base* next =
+      reinterpret_cast<const PJRT_Structure_Base*>(pjrt_api->extension_start);
+  while (next != nullptr &&
+         next->type != PJRT_Structure_Type::PJRT_Structure_Type_Profiler) {
+    next = next->next;
+  }
+  if (next == nullptr) {
+    return nullptr;
+  }
+  return reinterpret_cast<const PJRT_Profiler_Extension*>(next)->profiler_api;
+}
+
+}  // namespace
 
 struct ProfilerServer::Impl {
   Impl() : server(new tsl::profiler::ProfilerServer()) {}
@@ -33,6 +55,19 @@ tsl::Status Trace(
       /*include_dataset_ops=*/false, duration_ms, num_tracing_attempts,
       options);
 }
+
+void RegisterProfilerForPlugin(const PJRT_Api* c_api) {
+  const PLUGIN_Profiler_Api* profiler_api = FindProfilerApi(c_api);
+  XLA_CHECK(profiler_api);
+
+  tsl::profiler::ProfilerFactory create_func =
+      [profiler_api](const tensorflow::ProfileOptions& options) {
+        return std::make_unique<xla::profiler::PluginTracer>(profiler_api,
+                                                             options);
+      };
+  tsl::profiler::RegisterProfilerFactory(std::move(create_func));
+}
+
 }  // namespace profiler
 }  // namespace runtime
 }  // namespace torch_xla

--- a/torch_xla/csrc/runtime/profiler.h
+++ b/torch_xla/csrc/runtime/profiler.h
@@ -5,6 +5,7 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "tsl/platform/status.h"
+#include "xla/pjrt/c/pjrt_c_api.h"
 
 namespace torch_xla {
 namespace runtime {
@@ -27,6 +28,8 @@ tsl::Status Trace(
     int num_tracing_attempts,
     const absl::flat_hash_map<std::string, std::variant<int, std::string>>&
         options);
+
+void RegisterProfilerForPlugin(const PJRT_Api* c_api);
 
 }  // namespace profiler
 }  // namespace runtime


### PR DESCRIPTION
The [`tpu_tracer` backend](https://github.com/openxla/xla/blob/34b419269fa7477155086730670e2aa740d80a0d/xla/backends/profiler/tpu/tpu_tracer.cc#L177) uses a static initializer that requires us to set `TPU_LIBRARY_PATH`, which required us to roll back #5731. Instead, use the new PJRT C API profiler extension API to register the TPU profiler.

- Add new API `profiler::RegisterProfilerForPlugin` that we can reuse for other plugins as needed. Mostly copied from JAX's pybind to do the same thing: https://github.com/openxla/xla/blob/34b419269fa7477155086730670e2aa740d80a0d/xla/python/profiler.cc#L90-L105
- If we register both the profielr plugin and the default `tpu_tracer` starting a profiler sessions triggers a crash. Since the issue is (again) a static initializer, define our own `profiler_backends` target that excludes `tpu_tracer` from the build entirely.
  - Piggyback fix: include the GPU device tracer again after https://github.com/openxla/xla/commit/d73a491ea57ea1a57a0a03d3276deff9e367f686. We can remove this after we move GPU support into a plugin.

Confirmed that TPU device traces still show up after this change.
