### PR TITLE
Revert "[HotFix] disable test_set temporarily"

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -990,9 +990,7 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     b = torch.ones([2, 2])
     self.runAtenTest((a, b), func)
 
-  # TODO - upstream behavior has changed and results in expected DestroyXlaTensor
-  # counter as of 11/13/2023. Re-enable after reviewing the change.
-  @unittest.skipIf(True or XLA_DISABLE_FUNCTIONALIZATION,
+  @unittest.skipIf(XLA_DISABLE_FUNCTIONALIZATION,
                    'Metrics differ when functionalization is disabled.')
   def test_set(self):
     met.clear_all()


### PR DESCRIPTION
Reverts pytorch/xla#5792, as it seems to be passing again on the nightly. Verifying in the CI.