### PR TITLE
Add a persistent cache

### DIFF
--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -107,6 +107,9 @@ cc_library(
 cc_library(
     name = "cache",
     hdrs = ["cache.h"],
+    deps = [
+      "@torch//:headers",
+    ],
 )
 
 cc_test(
@@ -114,8 +117,9 @@ cc_test(
     size = "small",
     srcs = ["cache_test.cc"],
     deps = [
-        ":cache",
-        "@com_google_googletest//:gtest_main",
+      ":cache",
+      "@torch//:libtorch_cpu",  # For TORCH_LAZY_COUNTER
+      "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/torch_xla/csrc/runtime/cache.h
+++ b/torch_xla/csrc/runtime/cache.h
@@ -133,8 +133,8 @@ class PersistentCache : public AbstractCache<K, T, H, E> {
 
   explicit PersistentCache(int kMaxMemoryCacheSize, std::string cache_dir,
                            bool readonly,
-                           std::function<std::string(TypePtr&)> serialize,
-                           std::function<TypePtr(std::string&)> deserialize)
+                           std::function<std::string(const TypePtr&)> serialize,
+                           std::function<TypePtr(const std::string&)> deserialize)
       : memory_cache_(kMaxMemoryCacheSize),
         cache_dir_(cache_dir),
         readonly_(readonly),
@@ -211,7 +211,7 @@ class PersistentCache : public AbstractCache<K, T, H, E> {
   std::string GetPath(K key) {
     std::stringstream ss;
     ss << key;
-    return cache_dir_ / std::filesystem::path(ss.str());
+    return cache_dir_ / ss.str();
   }
 
   bool Exists(std::string path) {
@@ -225,8 +225,8 @@ class PersistentCache : public AbstractCache<K, T, H, E> {
   }
 
   Cache<K, T, H, E> memory_cache_;
-  std::function<std::string(TypePtr&)> serialize_;
-  std::function<TypePtr(std::string&)> deserialize_;
+  std::function<std::string(const TypePtr&)> serialize_;
+  std::function<TypePtr(const std::string&)> deserialize_;
   std::filesystem::path cache_dir_;
   std::mutex lock_;
   bool readonly_;

--- a/torch_xla/csrc/runtime/cache.h
+++ b/torch_xla/csrc/runtime/cache.h
@@ -1,10 +1,16 @@
 #ifndef XLA_CLIENT_CACHE_H_
 #define XLA_CLIENT_CACHE_H_
 
+#include <sys/stat.h>
+#include <torch/csrc/lazy/core/metrics.h>
+
+#include <filesystem>
+#include <fstream>
 #include <functional>
 #include <list>
 #include <memory>
 #include <mutex>
+#include <sstream>
 #include <unordered_map>
 #include <utility>
 
@@ -12,22 +18,32 @@ namespace torch_xla {
 namespace runtime {
 namespace util {
 
+template <typename K, typename T, typename H = std::hash<K>,
+          typename E = std::equal_to<K>>
+class AbstractCache {
+ public:
+  using TypePtr = std::shared_ptr<T>;
+  virtual TypePtr Add(K key, TypePtr object) = 0;
+  virtual TypePtr Get(const K& key) = 0;
+  virtual bool Erase(const K& key) = 0;
+  virtual void Clear() = 0;
+};
+
 // Generic key and object cache with LRU expiration policy. The objects of type
 // T will be stored as std::shared_ptr<T> and taken and returned as such, by the
 // cache API.
 template <typename K, typename T, typename H = std::hash<K>,
           typename E = std::equal_to<K>>
-class Cache {
+class Cache : public AbstractCache<K, T, H, E> {
  public:
   using TypePtr = std::shared_ptr<T>;
   using Element = std::pair<K, TypePtr>;
-
   explicit Cache(size_t max_size) : max_size_(max_size) {}
 
   // Adds an object to the cache, unless it already exists. If the cache grows
   // beyond the limit set during construction, the oldest used object will be
   // removed from the cache.
-  TypePtr Add(K key, TypePtr object) {
+  TypePtr Add(K key, TypePtr object) override {
     std::lock_guard<std::mutex> slock(lock_);
     element_list_.emplace_front(Element(std::move(key), std::move(object)));
     auto it = element_list_.begin();
@@ -47,7 +63,7 @@ class Cache {
   // the LRU list gets moved to the head of the list.
   // Returns nullptr if no object with the specified key is found within the
   // cache.
-  TypePtr Get(const K& key) {
+  TypePtr Get(const K& key) override {
     std::lock_guard<std::mutex> slock(lock_);
     auto it = element_map_.find(&key);
     if (it == element_map_.end()) {
@@ -57,7 +73,7 @@ class Cache {
     return it->second->second;
   }
 
-  bool Erase(const K& key) {
+  bool Erase(const K& key) override {
     std::lock_guard<std::mutex> slock(lock_);
     auto it = element_map_.find(&key);
     if (it == element_map_.end()) {
@@ -69,7 +85,7 @@ class Cache {
     return true;
   }
 
-  void Clear() {
+  void Clear() override {
     std::lock_guard<std::mutex> slock(lock_);
     element_map_.clear();
     element_list_.clear();
@@ -104,6 +120,107 @@ class Cache {
   size_t max_size_ = 0;
   ElementList element_list_;
   ElementMap element_map_;
+};
+
+// A persistent cache which serializes values to disk. This wraps a Cache
+// instance, so values will only be read from disk once and subsequent reads
+// will go through the wrapped Cache.
+template <typename K, typename T, typename H = std::hash<K>,
+          typename E = std::equal_to<K>>
+class PersistentCache : public AbstractCache<K, T, H, E> {
+ public:
+  using TypePtr = std::shared_ptr<T>;
+
+  explicit PersistentCache(int kMaxMemoryCacheSize, std::string cache_dir,
+                           bool readonly,
+                           std::function<std::string(TypePtr&)> serialize,
+                           std::function<TypePtr(std::string&)> deserialize)
+      : memory_cache_(kMaxMemoryCacheSize),
+        cache_dir_(cache_dir),
+        readonly_(readonly),
+        serialize_(serialize),
+        deserialize_(deserialize) {
+    std::filesystem::create_directories(cache_dir);
+  }
+
+  // Add the value to the persistent cache. This only writes to disk if no
+  // existing value is tracked to avoid unnecessary serialization overhead.
+  // The value will also be tracked in memory, so subsequent Get calls will not
+  // incur deserialization.
+  // If the cache is readonly, nothing is written to disk.
+  TypePtr Add(K key, TypePtr obj) override {
+    std::string path = GetPath(key);
+    if (!Exists(path) && !readonly_) {
+      std::ofstream out(path, std::ios::binary);
+      out << serialize_(obj);
+    }
+    return memory_cache_.Add(key, obj);
+  }
+
+  // Get the TypePtr associated with the key. This method will first check
+  // if the key is tracked in memory, and if not it will check for a persisted
+  // version on disk.
+  TypePtr Get(const K& key) override {
+    TypePtr mem = memory_cache_.Get(key);
+    if (mem) {
+      return mem;
+    }
+
+    std::string path = GetPath(key);
+    if (!Exists(path)) {
+      TORCH_LAZY_COUNTER("PersistentCacheMiss", 1);
+      return nullptr;
+    }
+    std::stringstream ss;
+    std::ifstream in(path, std::ios::binary);
+    ss << in.rdbuf();
+    std::string serialization = ss.str();
+
+    TypePtr val = deserialize_(serialization);
+    if (!val) {
+      TORCH_LAZY_COUNTER("PersistentCacheDeserializeFailure", 1);
+      // Remove the serialized value from disk to allow a new value to be stored
+      Erase(key);
+      return nullptr;
+    }
+    TORCH_LAZY_COUNTER("PersistentCacheHit", 1);
+    // Make sure the memory_cache_ tracks the value to prevent multiple loads
+    return memory_cache_.Add(key, val);
+  }
+
+  void Clear() override {
+    memory_cache_.Clear();
+    // Delete and recreate the cache directory on disk.
+    if (!readonly_) {
+      std::filesystem::remove_all(cache_dir_);
+      std::filesystem::create_directories(cache_dir_);
+    }
+  }
+
+  bool Erase(const K& key) override {
+    memory_cache_.Erase(key);
+    return !readonly_ && std::filesystem::remove(GetPath(key));
+  }
+
+  Cache<K, T, H, E>& GetMemoryCache() { return memory_cache_; }
+
+ private:
+  std::string GetPath(K key) {
+    std::stringstream ss;
+    ss << key;
+    return cache_dir_ / std::filesystem::path(ss.str());
+  }
+
+  bool Exists(std::string path) {
+    struct stat buffer;
+    return stat(path.c_str(), &buffer) == 0;
+  }
+
+  Cache<K, T, H, E> memory_cache_;
+  std::function<std::string(TypePtr&)> serialize_;
+  std::function<TypePtr(std::string&)> deserialize_;
+  std::filesystem::path cache_dir_;
+  bool readonly_;
 };
 
 }  // namespace util

--- a/torch_xla/csrc/runtime/cache_test.cc
+++ b/torch_xla/csrc/runtime/cache_test.cc
@@ -3,6 +3,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <iostream>
 #include <memory>
 #include <string>
 
@@ -35,6 +36,123 @@ TEST(UtilTest, XlaUtilCacheTest) {
   EXPECT_TRUE(cache.Erase(-1));
   ptr = cache.Get(-1);
   EXPECT_EQ(ptr, nullptr);
+}
+
+TEST(UtilTest, XlaUtilPersistentCacheTest) {
+  static const int kMaxSize = 64;
+  auto serialize_fn = [](std::shared_ptr<std::string> value) -> std::string {
+    return *value;
+  };
+  auto deserialize_fn = [](std::string value) -> std::shared_ptr<std::string> {
+    return std::make_shared<std::string>(value);
+  };
+  char format[] = "/tmp/tmp.XXXXXX";
+  char* tmpdir = mkdtemp(format);
+  std::cerr << "Made tmpdir " << std::string(tmpdir) << std::endl;
+  ASSERT_NE(tmpdir, nullptr);
+  auto cache = std::make_unique<PersistentCache<int, std::string>>(
+      kMaxSize, std::string(tmpdir), /*readonly=*/false, serialize_fn,
+      deserialize_fn);
+
+  // Add more than kMaxSize so that the memory cache will evict some from LRU.
+  for (int i = 0; i < 2 * kMaxSize; ++i) {
+    std::string istr = std::to_string(i);
+    auto ptr = cache->Add(i, std::make_shared<std::string>(istr));
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(*ptr, istr);
+
+    ptr = cache->Get(i);
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(*ptr, istr);
+  }
+
+  // Ensure that the cache is able to Get all values even though the memory
+  // cache doesn't track them.
+  for (int i = 0; i < 2 * kMaxSize; ++i) {
+    std::string istr = std::to_string(i);
+    // Read through the memory cache should miss
+    auto ptr = cache->GetMemoryCache().Get(i);
+    EXPECT_EQ(ptr, nullptr);
+
+    // Read through the persistent cache should hit
+    ptr = cache->Get(i);
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(*ptr, istr);
+  }
+
+  // Verify erasure works.
+  auto ptr = cache->Add(-1, std::make_shared<std::string>("MINUS"));
+  ASSERT_NE(ptr, nullptr);
+  EXPECT_EQ(*ptr, "MINUS");
+  EXPECT_TRUE(cache->Erase(-1));
+  ptr = cache->Get(-1);
+  EXPECT_EQ(ptr, nullptr);
+
+  // Test a readonly cache
+  cache = std::make_unique<PersistentCache<int, std::string>>(
+      kMaxSize, std::string(tmpdir), /*readonly=*/true, serialize_fn,
+      deserialize_fn);
+
+  // Add values in the range [2 * kMaxSize, 4 * kMaxSize), which are disjoint
+  // from what were added by the non-readonly cache.
+  for (int i = 2 * kMaxSize; i < 4 * kMaxSize; ++i) {
+    std::string istr = std::to_string(i);
+    auto ptr = cache->Add(i, std::make_shared<std::string>(istr));
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(*ptr, istr);
+
+    // Read through the memory cache
+    ptr = cache->Get(i);
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(*ptr, istr);
+  }
+
+  // Values which were added by the non-readonly cache should still be
+  // accessible.
+  for (int i = 0; i < 2 * kMaxSize; ++i) {
+    std::string istr = std::to_string(i);
+    // Read through the memory cache should miss
+    auto ptr = cache->GetMemoryCache().Get(i);
+    EXPECT_EQ(ptr, nullptr);
+
+    // Read through the persistent cache should hit
+    ptr = cache->Get(i);
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(*ptr, istr);
+
+    // Attempts to erase should fail
+    ASSERT_TRUE(!cache->Erase(i));
+  }
+
+  // Any values added by the readonly cache should not be accessible, since
+  // they have been evicted from the memory cache.
+  for (int i = 2 * kMaxSize; i < 3 * kMaxSize; ++i) {
+    ASSERT_EQ(cache->Get(i), nullptr);
+  }
+
+  // Clearing the readonly cache should not impact existing values on disk.
+  cache->Clear();
+  for (int i = 0; i < 2 * kMaxSize; ++i) {
+    // The memory cache has been cleared, so no values are tracked.
+    ASSERT_EQ(cache->GetMemoryCache().Get(i), nullptr);
+    // The persistent cache will read from disk.
+    ASSERT_NE(cache->Get(i), nullptr);
+  }
+
+  // Recreate in non-readonly mode for a final Clear to erase all values on
+  // disk.
+  cache = std::make_unique<PersistentCache<int, std::string>>(
+      kMaxSize, std::string(tmpdir), /*readonly=*/false, serialize_fn,
+      deserialize_fn);
+  cache->Clear();
+  for (int i = 0; i < 4 * kMaxSize; ++i) {
+    // The memory cache has been cleared, so no values are tracked.
+    ASSERT_EQ(cache->GetMemoryCache().Get(i), nullptr);
+    // The persistent cache will read from disk.
+    ASSERT_EQ(cache->Get(i), nullptr);
+  }
+
+  unlink(tmpdir);
 }
 
 }  // namespace util


### PR DESCRIPTION
This changes adds a new PersistentCache instance which will read and write to disk to enable persistent compilation caching. The PersistentCache is currently not used anywhere, but in a later change, the PersistentCache will replace the Cache in the XlaGraphExecutor when persistent caching is enabled.