### PR TITLE
Enable persistent compilation caching

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -210,6 +210,7 @@ function run_xla_op_tests3 {
   run_test "$CDIR/test_input_output_aliases.py"
   run_test "$CDIR/test_torch_distributed_xla_backend.py"
   run_torchrun "$CDIR/pjrt/test_torchrun.py"
+  run_test "$CDIR/test_persistent_cache.py"
   # NOTE: this line below is testing export and don't care about GPU
   PJRT_DEVICE=CPU CPU_NUM_DEVICES=1 run_coverage "$CDIR/test_core_aten_ops.py"
 }

--- a/test/test_persistent_cache.py
+++ b/test/test_persistent_cache.py
@@ -1,0 +1,117 @@
+import functools
+import os
+from subprocess import run, STDOUT, PIPE
+import sys
+import tempfile
+import unittest
+
+import torch_xla.runtime as xr
+
+
+# Wrapper to manage a temporary directory for the wrapped test
+def run_with_tmpdir(f):
+
+  @functools.wraps(f)
+  def run(*args, **kwargs):
+    with tempfile.TemporaryDirectory() as tmpdir:
+      kwargs.setdefault('tmpdir', tmpdir)
+      f(*args, **kwargs)
+
+  return run
+
+
+# Basic command to generate a simple graph and perform metrics assertions
+METRICS_CMD_FMT = r'''
+import os
+import torch
+import torch_xla.core.xla_model as xm
+import torch_xla.debug.metrics as met
+import torch_xla.runtime as xr
+
+if 'TEST_WITH_SPMD' in os.environ:
+  xr.use_spmd()
+
+t = torch.randn(4, 4).to(xm.xla_device())
+s = t @ t
+xm.mark_step()
+
+for counter, value in %s:
+  actual = met.counter_value(counter)
+  assert actual == value, \
+    f'Unexpected value for counter {counter}: expected {value}, got {actual}'
+'''
+
+
+@unittest.skipUnless(xr.device_type() in {'TPU', 'GPU'},
+                     'Device type does not support persistent caching')
+class PersistentCacheTest(unittest.TestCase):
+  """
+  Test suite to verify compilation cache across processes. Tests will run
+  multiple Python subprocesses which use the XLA runtime to populate the cache
+  and perform assertions on the metrics generated.
+  """
+
+  def _run_with_metric_assertions(self, env: dict, metric_expectations: dict):
+    cmd = METRICS_CMD_FMT % list(metric_expectations.items())
+    proc = run([sys.executable, '-c', cmd], env=env, stdout=PIPE, stderr=STDOUT)
+    self.assertEqual(proc.returncode, 0,
+                     f'Non-zero exit code, output:\n{proc.stdout.decode()}')
+
+  def _run_tests(self, tmpdir, use_spmd=False):
+    cache_dir = os.path.join(tmpdir, 'cache')
+    env = os.environ.copy()
+    env['XLA_PERSISTENT_CACHE_PATH'] = cache_dir
+    if use_spmd:
+      env['TEST_WITH_SPMD'] = '1'
+
+    # Use subtests to avoid having to prime the cache for each test.
+    with self.subTest('The first attempt should miss on the persistent cache'):
+      self._run_with_metric_assertions(env, {
+          'PersistentCacheMiss': 1,
+          'PersistentCacheHit': None
+      })
+
+    with self.subTest('A second run should hit the cache'):
+      self._run_with_metric_assertions(env, {
+          'PersistentCacheMiss': None,
+          'PersistentCacheHit': 1
+      })
+
+    with self.subTest('Ignored XLA flags should not impact the hash'):
+      env['XLA_FLAGS'] = f'--xla_dump_disable_metadata'
+      self._run_with_metric_assertions(env, {
+          'PersistentCacheMiss': None,
+          'PersistentCacheHit': 1
+      })
+
+    with self.subTest('Non-ignored LIBTPU_INIT_ARGS should impact the hash'):
+      env['LIBTPU_INIT_ARGS'] = '--xla_enable_async_collective_permute=true'
+      self._run_with_metric_assertions(env, {
+          'PersistentCacheMiss': 1,
+          'PersistentCacheHit': None
+      })
+
+    with self.subTest('Corrupt serialization should not be loaded'):
+      for fname in os.listdir(cache_dir):
+        with open(os.path.join(cache_dir, fname), 'wb') as f:
+          f.write(b'')
+      self._run_with_metric_assertions(
+          env, {
+              'PersistentCacheMiss': None,
+              'PersistentCacheHit': None,
+              'PersistentCacheDeserializeFailure': 1
+          })
+
+  @run_with_tmpdir
+  def test_persistent_cache(self, tmpdir):
+    self._run_tests(tmpdir)
+
+  @unittest.skipUnless(xr.device_type() == 'TPU', 'TPU required for SPMD')
+  @run_with_tmpdir
+  def test_persistent_cache_spmd(self, tmpdir):
+    self._run_tests(tmpdir, use_spmd=True)
+
+
+if __name__ == '__main__':
+  test = unittest.main()
+  sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/test_persistent_cache.py
+++ b/test/test_persistent_cache.py
@@ -20,25 +20,60 @@ def run_with_tmpdir(f):
   return run
 
 
-# Basic command to generate a simple graph and perform metrics assertions
-METRICS_CMD_FMT = r'''
+# Command to generate a simple graph and perform correctness/metrics assertions.
+# There are four methods supported by configuring the environment for the test:
+#  - Single-device (default): The program runs a computation on a single XLA
+#    device.
+#  - Unsharded SPMD: Setting TEST_WITH_SPMD will run the computation replicated
+#    across all devices.
+#  - Sharded SPMD: Setting TEST_WITH_SPMD and MARK_SHARDING will shard the
+#    computation across all devices.
+#  - Multiprocess: Setting TEST_WITH_MP will run the same computation across all
+#    devices using multiprocessing.
+TEST_FMT = r'''
 import os
 import torch
 import torch_xla.core.xla_model as xm
 import torch_xla.debug.metrics as met
+import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
+ 
+def test_fn(rank=None):
+  if rank is not None:
+    # In a multiprocess setting, rank will be set to the process rank. For MP,
+    # we need to change the cache dir for each process to avoid a race condition
+    # where one process loads the compilation result of another, which would
+    # break the metrics assertion.
+    os.environ['XLA_PERSISTENT_CACHE_PATH'] = \
+      os.path.join(os.environ['XLA_PERSISTENT_CACHE_PATH'], str(rank))
 
-if 'TEST_WITH_SPMD' in os.environ:
-  xr.use_spmd()
+  t = torch.randn(16)
+  expected = t + t
 
-t = torch.randn(4, 4).to(xm.xla_device())
-s = t @ t
-xm.mark_step()
+  xt = t.to(xm.xla_device())
+  if {'TEST_WITH_SPMD', 'MARK_SHARDING'} <= os.environ.keys():
+    n_dev = xr.global_runtime_device_count()
+    mesh = xs.Mesh(range(n_dev), (n_dev,))
+    xs.mark_sharding(xt, mesh, (0,))
 
-for counter, value in %s:
-  actual = met.counter_value(counter)
-  assert actual == value, \
-    f'Unexpected value for counter {counter}: expected {value}, got {actual}'
+  s = xt + xt
+  xm.mark_step()
+  assert torch.allclose(s.cpu(), expected), \
+    f'Incorrect result! expected {expected}, got {s.cpu()}'
+
+  for counter, value in %s:
+    actual = met.counter_value(counter)
+    assert actual == value, \
+      f'Unexpected value for counter {counter}: expected {value}, got {actual}'
+
+if __name__ == '__main__':
+  if 'TEST_WITH_MP' in os.environ:
+    import torch_xla.distributed.xla_multiprocessing as xmp
+    xmp.spawn(test_fn, start_method='fork')
+  else:
+    if 'TEST_WITH_SPMD' in os.environ:
+      xr.use_spmd()
+    test_fn()
 '''
 
 
@@ -52,17 +87,15 @@ class PersistentCacheTest(unittest.TestCase):
   """
 
   def _run_with_metric_assertions(self, env: dict, metric_expectations: dict):
-    cmd = METRICS_CMD_FMT % list(metric_expectations.items())
+    cmd = TEST_FMT % list(metric_expectations.items())
     proc = run([sys.executable, '-c', cmd], env=env, stdout=PIPE, stderr=STDOUT)
     self.assertEqual(proc.returncode, 0,
                      f'Non-zero exit code, output:\n{proc.stdout.decode()}')
 
-  def _run_tests(self, tmpdir, use_spmd=False):
-    cache_dir = os.path.join(tmpdir, 'cache')
+  @run_with_tmpdir
+  def test_persistent_cache(self, tmpdir):
     env = os.environ.copy()
-    env['XLA_PERSISTENT_CACHE_PATH'] = cache_dir
-    if use_spmd:
-      env['TEST_WITH_SPMD'] = '1'
+    env['XLA_PERSISTENT_CACHE_PATH'] = tmpdir
 
     # Use subtests to avoid having to prime the cache for each test.
     with self.subTest('The first attempt should miss on the persistent cache'):
@@ -91,9 +124,17 @@ class PersistentCacheTest(unittest.TestCase):
           'PersistentCacheHit': None
       })
 
+    if xr.device_type() == 'TPU':
+      with self.subTest('SPMD should result in a different hash'):
+        env['TEST_WITH_SPMD'] = '1'
+        self._run_with_metric_assertions(env, {
+            'PersistentCacheMiss': 1,
+            'PersistentCacheHit': None
+        })
+
     with self.subTest('Corrupt serialization should not be loaded'):
-      for fname in os.listdir(cache_dir):
-        with open(os.path.join(cache_dir, fname), 'wb') as f:
+      for fname in os.listdir(tmpdir):
+        with open(os.path.join(tmpdir, fname), 'wb') as f:
           f.write(b'')
       self._run_with_metric_assertions(
           env, {
@@ -102,14 +143,43 @@ class PersistentCacheTest(unittest.TestCase):
               'PersistentCacheDeserializeFailure': 1
           })
 
-  @run_with_tmpdir
-  def test_persistent_cache(self, tmpdir):
-    self._run_tests(tmpdir)
-
   @unittest.skipUnless(xr.device_type() == 'TPU', 'TPU required for SPMD')
   @run_with_tmpdir
   def test_persistent_cache_spmd(self, tmpdir):
-    self._run_tests(tmpdir, use_spmd=True)
+    env = os.environ.copy()
+    env.update({
+        'XLA_PERSISTENT_CACHE_PATH': tmpdir,
+        'TEST_WITH_SPMD': '1',
+        'MARK_SHARDING': '1',
+    })
+    with self.subTest('Warm the cache'):
+      self._run_with_metric_assertions(env, {
+          'PersistentCacheMiss': 1,
+          'PersistentCacheHit': None,
+      })
+    with self.subTest('Sharded computation should yield correct result'):
+      self._run_with_metric_assertions(env, {
+          'PersistentCacheMiss': None,
+          'PersistentCacheHit': 1,
+      })
+
+  @run_with_tmpdir
+  def test_persistent_cache_mp(self, tmpdir):
+    env = os.environ.copy()
+    env.update({
+        'XLA_PERSISTENT_CACHE_PATH': tmpdir,
+        'TEST_WITH_MP': '1',
+    })
+    with self.subTest('Warm the cache'):
+      self._run_with_metric_assertions(env, {
+          'PersistentCacheMiss': 1,
+          'PersistentCacheHit': None,
+      })
+    with self.subTest('MP computation should yield correct result after load'):
+      self._run_with_metric_assertions(env, {
+          'PersistentCacheMiss': None,
+          'PersistentCacheHit': 1,
+      })
 
 
 if __name__ == '__main__':

--- a/test/test_persistent_cache.py
+++ b/test/test_persistent_cache.py
@@ -1,10 +1,15 @@
+from absl.testing import absltest, parameterized
+from concurrent.futures import ProcessPoolExecutor
 import functools
 import os
-from subprocess import run, STDOUT, PIPE
 import sys
 import tempfile
-import unittest
 
+import torch
+import torch_xla.core.xla_model as xm
+import torch_xla.debug.metrics as met
+import torch_xla.distributed.spmd as xs
+import torch_xla.distributed.xla_multiprocessing as xmp
 import torch_xla.runtime as xr
 
 
@@ -20,168 +25,92 @@ def run_with_tmpdir(f):
   return run
 
 
-# Command to generate a simple graph and perform correctness/metrics assertions.
-# There are four methods supported by configuring the environment for the test:
-#  - Single-device (default): The program runs a computation on a single XLA
-#    device.
-#  - Unsharded SPMD: Setting TEST_WITH_SPMD will run the computation replicated
-#    across all devices.
-#  - Sharded SPMD: Setting TEST_WITH_SPMD and MARK_SHARDING will shard the
-#    computation across all devices.
-#  - Multiprocess: Setting TEST_WITH_MP will run the same computation across all
-#    devices using multiprocessing.
-TEST_FMT = r'''
-import os
-import torch
-import torch_xla.core.xla_model as xm
-import torch_xla.debug.metrics as met
-import torch_xla.distributed.spmd as xs
-import torch_xla.runtime as xr
- 
-def test_fn(rank=None):
-  if rank is not None:
-    # In a multiprocess setting, rank will be set to the process rank. For MP,
-    # we need to change the cache dir for each process to avoid a race condition
-    # where one process loads the compilation result of another, which would
-    # break the metrics assertion.
-    os.environ['XLA_PERSISTENT_CACHE_PATH'] = \
-      os.path.join(os.environ['XLA_PERSISTENT_CACHE_PATH'], str(rank))
+def _test_spawn(fn, args):
+  # Use a new ProcessPoolExecutor for each test to release device locks.
+  with ProcessPoolExecutor() as pool:
+    pool.submit(fn, *args).result()
 
-  t = torch.randn(16)
+
+def _assert_correctness_and_metrics(t, xt, metrics):
   expected = t + t
-
-  xt = t.to(xm.xla_device())
-  if {'TEST_WITH_SPMD', 'MARK_SHARDING'} <= os.environ.keys():
-    n_dev = xr.global_runtime_device_count()
-    mesh = xs.Mesh(range(n_dev), (n_dev,))
-    xs.mark_sharding(xt, mesh, (0,))
-
   s = xt + xt
   xm.mark_step()
   assert torch.allclose(s.cpu(), expected), \
     f'Incorrect result! expected {expected}, got {s.cpu()}'
-
-  for counter, value in %s:
+  for counter, value in metrics.items():
     actual = met.counter_value(counter)
     assert actual == value, \
       f'Unexpected value for counter {counter}: expected {value}, got {actual}'
 
-if __name__ == '__main__':
-  if 'TEST_WITH_MP' in os.environ:
-    import torch_xla.distributed.xla_multiprocessing as xmp
-    xmp.spawn(test_fn, start_method='fork')
-  else:
-    if 'TEST_WITH_SPMD' in os.environ:
-      xr.use_spmd()
-    test_fn()
-'''
+
+def _mp_test(rank, metrics):
+  # In MP, the cache dir must be different for each process to avoid a race
+  # condition where one process loads the compilation result of another, which
+  # would break the metrics assertion.
+  os.environ['XLA_PERSISTENT_CACHE_PATH'] = \
+    os.path.join(os.environ['XLA_PERSISTENT_CACHE_PATH'], str(rank))
+
+  t = torch.randn(16)
+  xt = t.to(xm.xla_device())
+  _assert_correctness_and_metrics(t, xt, metrics)
 
 
-@unittest.skipUnless(xr.device_type() in {'TPU', 'GPU'},
+def _single_device_test(metrics):
+  t = torch.randn(16)
+  xt = t.to(xm.xla_device())
+  _assert_correctness_and_metrics(t, xt, metrics)
+
+
+def _spmd_replicated_test(metrics):
+  xr.use_spmd()
+  t = torch.randn(16)
+  xt = t.to(xm.xla_device())
+  _assert_correctness_and_metrics(t, xt, metrics)
+
+
+def _spmd_sharded_test(metrics):
+  xr.use_spmd()
+  t = torch.randn(16)
+
+  xt = t.to(xm.xla_device())
+  n_dev = xr.global_runtime_device_count()
+  mesh = xs.Mesh(range(n_dev), (n_dev,))
+  xs.mark_sharding(xt, mesh, (0,))
+  _assert_correctness_and_metrics(t, xt, metrics)
+
+
+@absltest.skipUnless(xr.device_type() in {'TPU', 'GPU'},
                      'Device type does not support persistent caching')
-class PersistentCacheTest(unittest.TestCase):
+class PersistentCacheTest(parameterized.TestCase):
   """
   Test suite to verify compilation cache across processes. Tests will run
   multiple Python subprocesses which use the XLA runtime to populate the cache
   and perform assertions on the metrics generated.
   """
 
-  def _run_with_metric_assertions(self, env: dict, metric_expectations: dict):
-    cmd = TEST_FMT % list(metric_expectations.items())
-    proc = run([sys.executable, '-c', cmd], env=env, stdout=PIPE, stderr=STDOUT)
-    self.assertEqual(proc.returncode, 0,
-                     f'Non-zero exit code, output:\n{proc.stdout.decode()}')
-
+  @parameterized.named_parameters(
+      ('mp', xmp.spawn, _mp_test),
+      ('single_device', _test_spawn, _single_device_test),
+      ('spmd_replicated', _test_spawn, _spmd_replicated_test),
+      ('spmd_sharded', _test_spawn, _spmd_sharded_test),
+  )
   @run_with_tmpdir
-  def test_persistent_cache(self, tmpdir):
-    env = os.environ.copy()
-    env['XLA_PERSISTENT_CACHE_PATH'] = tmpdir
+  def test_persistent_cache(self, launch_method, test_fn, tmpdir):
+    os.environ['XLA_PERSISTENT_CACHE_PATH'] = tmpdir
 
-    # Use subtests to avoid having to prime the cache for each test.
-    with self.subTest('The first attempt should miss on the persistent cache'):
-      self._run_with_metric_assertions(env, {
-          'PersistentCacheMiss': 1,
-          'PersistentCacheHit': None
-      })
+    # Run once to warm the cache
+    launch_method(test_fn, ({
+        'PersistentCacheMiss': 1,
+        'PersistentCacheHit': None
+    },))
 
-    with self.subTest('A second run should hit the cache'):
-      self._run_with_metric_assertions(env, {
-          'PersistentCacheMiss': None,
-          'PersistentCacheHit': 1
-      })
-
-    with self.subTest('Ignored XLA flags should not impact the hash'):
-      env['XLA_FLAGS'] = f'--xla_dump_disable_metadata'
-      self._run_with_metric_assertions(env, {
-          'PersistentCacheMiss': None,
-          'PersistentCacheHit': 1
-      })
-
-    with self.subTest('Non-ignored LIBTPU_INIT_ARGS should impact the hash'):
-      env['LIBTPU_INIT_ARGS'] = '--xla_enable_async_collective_permute=true'
-      self._run_with_metric_assertions(env, {
-          'PersistentCacheMiss': 1,
-          'PersistentCacheHit': None
-      })
-
-    if xr.device_type() == 'TPU':
-      with self.subTest('SPMD should result in a different hash'):
-        env['TEST_WITH_SPMD'] = '1'
-        self._run_with_metric_assertions(env, {
-            'PersistentCacheMiss': 1,
-            'PersistentCacheHit': None
-        })
-
-    with self.subTest('Corrupt serialization should not be loaded'):
-      for fname in os.listdir(tmpdir):
-        with open(os.path.join(tmpdir, fname), 'wb') as f:
-          f.write(b'')
-      self._run_with_metric_assertions(
-          env, {
-              'PersistentCacheMiss': None,
-              'PersistentCacheHit': None,
-              'PersistentCacheDeserializeFailure': 1
-          })
-
-  @unittest.skipUnless(xr.device_type() == 'TPU', 'TPU required for SPMD')
-  @run_with_tmpdir
-  def test_persistent_cache_spmd(self, tmpdir):
-    env = os.environ.copy()
-    env.update({
-        'XLA_PERSISTENT_CACHE_PATH': tmpdir,
-        'TEST_WITH_SPMD': '1',
-        'MARK_SHARDING': '1',
-    })
-    with self.subTest('Warm the cache'):
-      self._run_with_metric_assertions(env, {
-          'PersistentCacheMiss': 1,
-          'PersistentCacheHit': None,
-      })
-    with self.subTest('Sharded computation should yield correct result'):
-      self._run_with_metric_assertions(env, {
-          'PersistentCacheMiss': None,
-          'PersistentCacheHit': 1,
-      })
-
-  @run_with_tmpdir
-  def test_persistent_cache_mp(self, tmpdir):
-    env = os.environ.copy()
-    env.update({
-        'XLA_PERSISTENT_CACHE_PATH': tmpdir,
-        'TEST_WITH_MP': '1',
-    })
-    with self.subTest('Warm the cache'):
-      self._run_with_metric_assertions(env, {
-          'PersistentCacheMiss': 1,
-          'PersistentCacheHit': None,
-      })
-    with self.subTest('MP computation should yield correct result after load'):
-      self._run_with_metric_assertions(env, {
-          'PersistentCacheMiss': None,
-          'PersistentCacheHit': 1,
-      })
+    # The second run should hit the cache
+    launch_method(test_fn, ({
+        'PersistentCacheMiss': None,
+        'PersistentCacheHit': 1
+    },))
 
 
 if __name__ == '__main__':
-  test = unittest.main()
+  test = absltest.main()
   sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/test_persistent_cache.py
+++ b/test/test_persistent_cache.py
@@ -79,7 +79,7 @@ def _spmd_sharded_test(metrics):
   _assert_correctness_and_metrics(t, xt, metrics)
 
 
-@absltest.skipUnless(xr.device_type() in {'TPU', 'GPU'},
+@absltest.skipUnless(xr.device_type() in {'TPU', 'CUDA'},
                      'Device type does not support persistent caching')
 class PersistentCacheTest(parameterized.TestCase):
   """

--- a/torch_xla/csrc/runtime/computation_client.h
+++ b/torch_xla/csrc/runtime/computation_client.h
@@ -281,6 +281,13 @@ class ComputationClient {
   virtual std::vector<ComputationPtr> Compile(
       std::vector<CompileInstance> instances) = 0;
 
+  // Serialize a computation to a string.
+  virtual std::string SerializeComputation(ComputationPtr computation) = 0;
+
+  // Deserialize a string resulting from SerializeComputation back to a
+  // Computation. If the deserialization fails, nullptr is returned.
+  virtual ComputationPtr DeserializeComputation(std::string& serialized) = 0;
+
   // Returns a hash of the current compilation environment.
   virtual torch::lazy::hash_t HashCompilationEnv() = 0;
 

--- a/torch_xla/csrc/runtime/computation_client.h
+++ b/torch_xla/csrc/runtime/computation_client.h
@@ -282,11 +282,13 @@ class ComputationClient {
       std::vector<CompileInstance> instances) = 0;
 
   // Serialize a computation to a string.
-  virtual std::string SerializeComputation(ComputationPtr computation) = 0;
+  virtual std::string SerializeComputation(
+      const ComputationPtr computation) = 0;
 
   // Deserialize a string resulting from SerializeComputation back to a
   // Computation. If the deserialization fails, nullptr is returned.
-  virtual ComputationPtr DeserializeComputation(std::string& serialized) = 0;
+  virtual ComputationPtr DeserializeComputation(
+      const std::string& serialized) = 0;
 
   // Returns a hash of the current compilation environment.
   virtual torch::lazy::hash_t HashCompilationEnv() = 0;

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -598,6 +598,41 @@ std::vector<ComputationClient::ComputationPtr> PjRtComputationClient::Compile(
   return computations;
 }
 
+std::string PjRtComputationClient::SerializeComputation(
+    ComputationPtr computation) {
+  const PjRtComputation& pjrt_computation =
+      dynamic_cast<const PjRtComputation&>(*computation);
+
+  return ConsumeValue(pjrt_computation.executable->SerializeExecutable());
+}
+
+ComputationClient::ComputationPtr PjRtComputationClient::DeserializeComputation(
+    std::string& serialized) {
+  auto executable_or = client_->DeserializeExecutable(serialized, std::nullopt);
+  if (!executable_or.ok()) {
+    TF_LOG(WARNING) << "Failed to deserialize executable: "
+                    << executable_or.status();
+    return nullptr;
+  }
+  auto executable = std::move(*executable_or);
+
+  auto hlo_modules = executable->GetHloModules();
+  if (!hlo_modules.ok()) {
+    TF_LOG(WARNING)
+        << "Failed to retrieve HLO modules from deserialized executable";
+    return nullptr;
+  }
+  XLA_CHECK(hlo_modules->size() == 1)
+      << "Only a single module is supported for persistent computation "
+         "caching. Please unset the XLA_PERSISTENT_CACHE_PATH "
+         "variable to disable persistent caching.";
+  xla::XlaComputation computation((*hlo_modules)[0]->ToProto());
+
+  std::vector<std::string> devices = {GetDefaultDevice()};
+  return std::make_shared<PjRtComputation>(std::move(computation), devices,
+                                           std::move(executable));
+}
+
 torch::lazy::hash_t PjRtComputationClient::HashCompilationEnv() {
   // TODO(jonbolin): Incorporate CompileOptions into the hash. These are
   // deterministically generated at the moment, so they don't need to be

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -628,7 +628,8 @@ ComputationClient::ComputationPtr PjRtComputationClient::DeserializeComputation(
          "variable to disable persistent caching.";
   xla::XlaComputation computation((*hlo_modules)[0]->ToProto());
 
-  std::vector<std::string> devices = {GetDefaultDevice()};
+  std::vector<std::string> devices = {UseVirtualDevice() ? spmd_device_str
+                                                         : GetDefaultDevice()};
   return std::make_shared<PjRtComputation>(std::move(computation), devices,
                                            std::move(executable));
 }

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -599,7 +599,7 @@ std::vector<ComputationClient::ComputationPtr> PjRtComputationClient::Compile(
 }
 
 std::string PjRtComputationClient::SerializeComputation(
-    ComputationPtr computation) {
+    const ComputationPtr computation) {
   const PjRtComputation& pjrt_computation =
       dynamic_cast<const PjRtComputation&>(*computation);
 
@@ -607,7 +607,7 @@ std::string PjRtComputationClient::SerializeComputation(
 }
 
 ComputationClient::ComputationPtr PjRtComputationClient::DeserializeComputation(
-    std::string& serialized) {
+    const std::string& serialized) {
   auto executable_or = client_->DeserializeExecutable(serialized, std::nullopt);
   if (!executable_or.ok()) {
     TF_LOG(WARNING) << "Failed to deserialize executable: "

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -54,6 +54,10 @@ class PjRtComputationClient : public ComputationClient {
   std::vector<ComputationPtr> Compile(
       std::vector<CompileInstance> instances) override;
 
+  std::string SerializeComputation(ComputationPtr computation) override;
+
+  ComputationPtr DeserializeComputation(std::string& serialized) override;
+
   std::vector<DataPtr> ExecuteComputation(
       const Computation& computation, absl::Span<const DataPtr> arguments,
       const std::string& device,

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -54,9 +54,9 @@ class PjRtComputationClient : public ComputationClient {
   std::vector<ComputationPtr> Compile(
       std::vector<CompileInstance> instances) override;
 
-  std::string SerializeComputation(ComputationPtr computation) override;
+  std::string SerializeComputation(const ComputationPtr computation) override;
 
-  ComputationPtr DeserializeComputation(std::string& serialized) override;
+  ComputationPtr DeserializeComputation(const std::string& serialized) override;
 
   std::vector<DataPtr> ExecuteComputation(
       const Computation& computation, absl::Span<const DataPtr> arguments,

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -80,7 +80,7 @@ XLAGraphExecutor::ComputationCache* CreateComputationCache() {
   static const size_t kMaxCacheSize =
       runtime::sys_util::GetEnvInt("XLA_COMPILATION_CACHE_SIZE", 1024);
   static const bool readonlyPersistentCache =
-      runtime::sys_util::GetEnvBool("XLA_PERSISTENT_CACHE_RO", false);
+      runtime::sys_util::GetEnvBool("XLA_PERSISTENT_CACHE_READ_ONLY", false);
   static std::string persistentCacheDir =
       runtime::sys_util::GetEnvString("XLA_PERSISTENT_CACHE_PATH", "");
   if (!persistentCacheDir.empty()) {
@@ -94,10 +94,8 @@ XLAGraphExecutor::ComputationCache* CreateComputationCache() {
           runtime::GetComputationClient()->DeserializeComputation(
               serialization);
       if (!computation) return nullptr;
-      bool is_sharded = bridge::GetDefaultDevice()->toString() ==
-                        GetVirtualDevice().toString();
       return std::make_shared<XLAGraphExecutor::CachedComputation>(
-          computation, /*is_sharded=*/is_sharded);
+          computation, /*is_sharded=*/UseVirtualDevice());
     };
     return new XLAGraphExecutor::PersistentCache(
         kMaxCacheSize, persistentCacheDir, readonlyPersistentCache,

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -76,6 +76,36 @@ bool ShouldSyncIrValue(const torch::lazy::Value& ir_value) {
   return ir_value->op() != xla_not_supported;
 }
 
+XLAGraphExecutor::ComputationCache* CreateComputationCache() {
+  static const size_t kMaxCacheSize =
+      runtime::sys_util::GetEnvInt("XLA_COMPILATION_CACHE_SIZE", 1024);
+  static const bool readonlyPersistentCache =
+      runtime::sys_util::GetEnvBool("XLA_PERSISTENT_CACHE_RO", false);
+  static std::string persistentCacheDir =
+      runtime::sys_util::GetEnvString("XLA_PERSISTENT_CACHE_PATH", "");
+  if (!persistentCacheDir.empty()) {
+    auto serialize_fn = [](auto& computation) -> std::string {
+      return runtime::GetComputationClient()->SerializeComputation(
+          computation->computation);
+    };
+    auto deserialize_fn = [](auto& serialization)
+        -> std::shared_ptr<XLAGraphExecutor::CachedComputation> {
+      auto computation =
+          runtime::GetComputationClient()->DeserializeComputation(
+              serialization);
+      if (!computation) return nullptr;
+      bool is_sharded = bridge::GetDefaultDevice()->toString() ==
+                        GetVirtualDevice().toString();
+      return std::make_shared<XLAGraphExecutor::CachedComputation>(
+          computation, /*is_sharded=*/is_sharded);
+    };
+    return new XLAGraphExecutor::PersistentCache(
+        kMaxCacheSize, persistentCacheDir, readonlyPersistentCache,
+        serialize_fn, deserialize_fn);
+  }
+  return new XLAGraphExecutor::MemoryCache(kMaxCacheSize);
+}
+
 }  // namespace
 
 auto XLAGraphExecutor::DeviceContextArena::Get() -> DeviceContextArena* {
@@ -477,9 +507,7 @@ void XLAGraphExecutor::MaybeDumpGraph(std::string name,
 }
 
 XLAGraphExecutor::ComputationCache* XLAGraphExecutor::GetComputationCache() {
-  static const size_t kMaxCacheSize =
-      runtime::sys_util::GetEnvInt("XLA_COMPILATION_CACHE_SIZE", 1024);
-  static ComputationCache* cache = new ComputationCache(kMaxCacheSize);
+  static ComputationCache* cache = CreateComputationCache();
   return cache;
 }
 

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -84,13 +84,15 @@ XLAGraphExecutor::ComputationCache* CreateComputationCache() {
   static std::string persistentCacheDir =
       runtime::sys_util::GetEnvString("XLA_PERSISTENT_CACHE_PATH", "");
   if (!persistentCacheDir.empty()) {
-    auto serialize_fn = [](auto& computation) -> std::string {
+    auto serialize_fn =
+        [](XLAGraphExecutor::ComputationCache::TypePtr computation)
+        -> std::string {
       return runtime::GetComputationClient()->SerializeComputation(
           computation->computation);
     };
-    auto deserialize_fn = [](auto& serialization)
-        -> std::shared_ptr<XLAGraphExecutor::CachedComputation> {
-      auto computation =
+    auto deserialize_fn = [](std::string serialization)
+        -> XLAGraphExecutor::ComputationCache::TypePtr {
+      runtime::ComputationClient::ComputationPtr computation =
           runtime::GetComputationClient()->DeserializeComputation(
               serialization);
       if (!computation) return nullptr;

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -163,8 +163,14 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
   };
 
   using ComputationCache =
+      runtime::util::AbstractCache<torch::lazy::hash_t, CachedComputation,
+                                   torch::lazy::HashReducer>;
+  using MemoryCache =
       runtime::util::Cache<torch::lazy::hash_t, CachedComputation,
                            torch::lazy::HashReducer>;
+  using PersistentCache =
+      runtime::util::PersistentCache<torch::lazy::hash_t, CachedComputation,
+                                     torch::lazy::HashReducer>;
 
   ComputationCache* GetComputationCache();
 


### PR DESCRIPTION
This change enables persistent caching by combining #5800 and #5803. It uses the serialization functionality in PjRtLoadedExecutable to convert the executables to/from strings, which are written to disk by the persistent cache.

The persistent cache is enabled by setting the environment variable `XLA_PERSISTENT_CACHE_PATH` to the desired compilation cache path. An additional environment variable `XLA_PERSISTENT_CACHE_READ_ONLY` can be used to control whether the cache is readonly, which can be useful when the cache is shared across workers in an SPMD setting.

Note that the persistent cache does not perform any eviction, so it is currently up to the user to clean the cache.