### PR TITLE
[SPMD] fix bug with XLAShardedTensor.__repr__

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -42,6 +42,20 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     # TODO(244003536) add more tests for XLAShardedTensror.
     self.assertTrue(isinstance(xst1, XLAShardedTensor))
 
+  def test_xla_sharded_tensor_repr(self):
+    xt = torch.randn(128, 128).to(xm.xla_device())
+    model = self.SimpleLinear().to(xm.xla_device())
+
+    mesh = self._get_mesh((1, self.n_devices))
+    partition_spec = (0, 1)
+    xst = xs.mark_sharding(xt, mesh, partition_spec)
+    self.assertTrue(isinstance(xst, XLAShardedTensor))
+
+    xt_output = model(xt)
+    self.assertTrue('XLAShardedTensor' not in str(xt_output))
+    xst_output = model(xst)
+    self.assertTrue('XLAShardedTensor' in str(xst_output))
+
   def test_sharded_tensor_debug_info(self):
     partition_spec = (0, 1)
     xt1 = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]],

--- a/torch_xla/distributed/spmd/xla_sharded_tensor.py
+++ b/torch_xla/distributed/spmd/xla_sharded_tensor.py
@@ -142,6 +142,10 @@ class XLAShardedTensor(torch.Tensor):
     return ShardingType(sharding_type)
 
   def __repr__(self):
+    if not hasattr(self, "global_tensor"):
+      # materialize a copy of sharded global_tensnor and keep the actual data
+      # sharded on the XLA devices.
+      return str(self.cpu())
     return f"XLAShardedTensor({self.global_tensor})"
 
   @classmethod


### PR DESCRIPTION
Fix #5798 . The XLAShardedTensor (its global_tensor) is not, yet marterialized in case of output sharding propagation. Using a re-assembled copy for `__repr__()` should fix it. 