### PR TITLE
Parallelize device-to-host transfers

### DIFF
--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -462,6 +462,8 @@ std::vector<xla::Literal> PjRtComputationClient::TransferFromServer(
   metrics::TimedSection timed(TransferFromServerMetric());
   tsl::profiler::TraceMe activity("PjRtComputationClient::TransferFromServer",
                                   tsl::profiler::TraceMeLevel::kInfo);
+  std::vector<xla::PjRtFuture<tsl::Status>> futures;
+  futures.reserve(handles.size());
   std::vector<xla::Literal> literals;
   literals.reserve(handles.size());
   int64_t total_size = 0;
@@ -471,11 +473,15 @@ std::vector<xla::Literal> PjRtComputationClient::TransferFromServer(
     auto new_handle = ReplicateShardedData(handle);
     const PjRtData& pjrt_data = dynamic_cast<const PjRtData&>(*new_handle);
 
-    auto& literal =
+    xla::Literal& literal =
         literals.emplace_back(host_output_shape(pjrt_data.buffer.get()));
-    XLA_CHECK_OK(pjrt_data.buffer->ToLiteralSync(&literal));
+    futures.push_back(pjrt_data.buffer->ToLiteral(&literal));
 
     total_size += literal.size_bytes();
+  }
+  for (auto& future : futures) {
+    tsl::Status status = future.Await();
+    XLA_CHECK_OK(status);
   }
   InboundDataMetric()->AddSample(total_size);
 


### PR DESCRIPTION
For async checkpointing, it is important to unblock training as quickly as possible. Training can only be unblocked when all data has been moved off of device onto the host to free up device memory.

One bottleneck I found was that in TransferFromServer, the tensors are transferred using `ToLiteralSync`, meaning each tensor is transferred sequentially. In benchmarking a 2B parameter model, parallelizing these transfers decreased the time spent in TransferFromServer from 5.1s to 1.8s, ~65% reduction.

There is still significant overhead from copying the resulting xla::Literal into torch.Tensor, but that's for another PR.