### PR TITLE
Copy input tensors before async transfer

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -387,6 +387,6 @@ class XlaTestCase(unittest.TestCase):
     xla_tensors = [
         x.to(device).detach().requires_grad_(x.requires_grad) for x in tensors
     ]
-    results = xu.as_list(fn(*tensors))
+    results = xu.as_list(fn(*(t.clone() for t in tensors)))
     xla_results = xu.as_list(fn(*xla_tensors))
     self.compareResults(results, xla_results, rel_err=rel_err, abs_err=abs_err)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -387,6 +387,6 @@ class XlaTestCase(unittest.TestCase):
     xla_tensors = [
         x.to(device).detach().requires_grad_(x.requires_grad) for x in tensors
     ]
-    results = xu.as_list(fn(*(t.clone() for t in tensors)))
+    results = xu.as_list(fn(*tensors))
     xla_results = xu.as_list(fn(*xla_tensors))
     self.compareResults(results, xla_results, rel_err=rel_err, abs_err=abs_err)

--- a/torch_xla/csrc/runtime/tensor_source.h
+++ b/torch_xla/csrc/runtime/tensor_source.h
@@ -54,7 +54,8 @@ class AtenSource : public TensorSource {
     if (target_torch_type != tensor.type().scalarType()) {
       TORCH_LAZY_COUNTER("AtenSourceDowncasts", 1);
     }
-    tensor_ = std::move(tensor.to(target_torch_type, /*non_blocking=*/false, /*copy=*/true, at::MemoryFormat::Contiguous));
+    tensor_ = std::move(tensor.to(target_torch_type, /*non_blocking=*/false,
+                                  /*copy=*/true, at::MemoryFormat::Contiguous));
   }
 
   const void* data() const override { return tensor_.const_data_ptr(); }

--- a/torch_xla/csrc/runtime/tensor_source.h
+++ b/torch_xla/csrc/runtime/tensor_source.h
@@ -53,10 +53,8 @@ class AtenSource : public TensorSource {
     at::ScalarType target_torch_type = TorchTypeFromXlaType(primitive_type());
     if (target_torch_type != tensor.type().scalarType()) {
       TORCH_LAZY_COUNTER("AtenSourceDowncasts", 1);
-      tensor_ = std::move(tensor.to(target_torch_type).contiguous());
-    } else {
-      tensor_ = std::move(tensor.contiguous());
     }
+    tensor_ = std::move(tensor.to(target_torch_type, /*non_blocking=*/false, /*copy=*/true, at::MemoryFormat::Contiguous));
   }
 
   const void* data() const override { return tensor_.const_data_ptr(); }


### PR DESCRIPTION
This fixes a subtle edge case introduced with #5772. When we start a transfer asynchronously, this creates a window where changes to the source tensor may be partially reflected in the destination tensor.

Concretely, since our unit test implementation runs tests once on eager CPU and once on XLA, this can potentially double the changes in the test (ie make a change on CPU, that change moves to the XLA device, and we make the change again in the XLA executable). Our TPU CI is catching this intermittently in `TestAtenXlaTensor.test_diagonal_write_transposed_r3`.

I was able to reproduce this case consistently by locally, patching OpenXLA to make transfers much slower, but I don't think this case is unit-testable.

Two fixes:

- Always copy the input tensor before running an async transfer. I'd like this fix to be temporary.
- ~Clone the test input tensor before running the eager version.~

Somehow, copying the tensor within PyTorch is still much faster than copying the PyTorch tensor to an `xla::Literal` before #5772. The baseline for `TransferToServerTime` in one epoch of ResNet50 on v4-8 was 20 seconds vs 250 ms now.

Long term, I'd like to eliminate this fix and instead respect the `non_blocking` argument to `.to()`. For blocking transfers, we don't need the copy to prevent concurrent changes, which will save host memory. For non-blocking transfers, we can either still perform the copy or simply caution users, since this is not the default case. Since that's a substantial change to behavior either way, I'd rather make it after the next release cut.

Similar issues are possible for non-blocking transfers between GPU and CPU in eager mode. There don't seem to be any tools to lock changes to the source tensors that I can find, nor does there seem to be a general API to tell if a Tensor is ready. The recommended way to synchronize transfers is to [check the CUDA device stream](https://discuss.pytorch.org/t/how-to-wait-on-non-blocking-copying-from-gpu-to-cpu/157010).