### PR TITLE
Update artifacts.auto.tfvars for 2.2 release

### DIFF
--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -55,23 +55,6 @@ xrt_versioned_builds = [
   },
 ]
 
-# TODO: Remove this after the 2.2 release
-xrt_versioned_builds = [
-  {
-    accelerator    = "tpu"
-    python_version = "3.10"
-    pytorch_git_rev = "v2.2.0"
-    package_version = "2.2.0+xrt"
-  },
-  {
-    accelerator  = "cuda"
-    python_version = "3.10"
-    cuda_version = "12.0"
-    pytorch_git_rev = "v2.2.0"
-    package_version = "2.2.0+xrt"
-  },
-]
-
 # Built on push to specific tag.
 versioned_builds = [
   # Remove libtpu from PyPI builds

--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -38,62 +38,40 @@ nightly_builds = [
   }
 ]
 
-# TODO: Remove this after the 2.1 release
-xrt_versioned_builds = [
-  {
-    accelerator    = "tpu"
-    python_version = "3.10"
-    pytorch_git_rev = "v2.1.0"
-    package_version = "2.1.0+xrt"
-  },
-  {
-    accelerator  = "cuda"
-    python_version = "3.10"
-    cuda_version = "12.0"
-    pytorch_git_rev = "v2.1.0"
-    package_version = "2.1.0+xrt"
-  },
-]
-
 # Built on push to specific tag.
 versioned_builds = [
   # Remove libtpu from PyPI builds
   {
-    git_tag         = "v2.2.0"
-    pytorch_git_rev = "v2.2.0"
+    git_tag         = "v2.2.0-rc1"
     package_version = "2.2.0"
     accelerator     = "tpu"
     bundle_libtpu   = "0"
   },
   {
-    git_tag         = "v2.2.0"
-    pytorch_git_rev = "v2.2.0"
+    git_tag         = "v2.2.0-rc1"
     package_version = "2.2.0"
     accelerator     = "tpu"
     python_version  = "3.9"
     bundle_libtpu   = "0"
   },
   {
-    git_tag         = "v2.2.0"
-    pytorch_git_rev = "v2.2.0"
-    package_version = "2.2.0"
+    git_tag         = "v2.2.0-rc1"
+    package_version = "2.2.0-rc1"
     accelerator     = "tpu"
     python_version  = "3.10"
     bundle_libtpu   = "0"
   },
   {
-    git_tag         = "v2.2.0"
-    pytorch_git_rev = "v2.2.0"
-    package_version = "2.2.0"
+    git_tag         = "v2.2.0-rc1"
+    package_version = "2.2.0-rc1"
     accelerator     = "tpu"
     python_version  = "3.11"
     bundle_libtpu   = "0"
   },
   # Bundle libtpu for Kaggle
   {
-    git_tag         = "v2.2.0"
-    pytorch_git_rev = "v2.2.0"
-    package_version = "2.2.0+libtpu"
+    git_tag         = "v2.2.0-rc1"
+    package_version = "2.2.0-rc1+libtpu"
     accelerator     = "tpu"
     python_version  = "3.10"
     bundle_libtpu   = "1"
@@ -149,38 +127,40 @@ versioned_builds = [
     accelerator     = "tpu"
   },
   {
-    git_tag         = "v2.2.0"
-    pytorch_git_rev = "v2.2.0"
-    package_version = "2.2.0",
-    accelerator     = "cuda"
-    cuda_version    = "12.0"
-  },
-  {
-    git_tag         = "v2.2.0"
-    pytorch_git_rev = "v2.2.0"
-    package_version = "2.2.0"
+    git_tag         = "v2.2.0-rc1"
+    package_version = "2.2.0-rc1"
     accelerator     = "cuda"
     cuda_version    = "11.8"
   },
   {
-    git_tag         = "v2.2.0"
-    pytorch_git_rev = "v2.2.0"
-    package_version = "2.2.0"
+    git_tag         = "v2.2.0-rc1"
+    package_version = "2.2.0-rc1"
+    accelerator     = "cuda"
+    cuda_version    = "12.0"
+  },
+  {
+    git_tag         = "v2.2.0-rc1"
+    package_version = "2.2.0-rc1"
     accelerator     = "cuda"
     cuda_version    = "12.1"
   },
   {
-    git_tag         = "v2.2.0"
-    pytorch_git_rev = "v2.2.0"
-    package_version = "2.2.0"
+    git_tag         = "v2.2.0-rc1"
+    package_version = "2.2.0-rc1"
     accelerator     = "cuda"
     cuda_version    = "11.8"
     python_version  = "3.10"
   },
   {
-    git_tag         = "v2.2.0"
-    pytorch_git_rev = "v2.2.0"
-    package_version = "2.2.0"
+    git_tag         = "v2.2.0-rc1"
+    package_version = "2.2.0-rc1"
+    accelerator     = "cuda"
+    cuda_version    = "12.0"
+    python_version  = "3.10"
+  },
+  {
+    git_tag         = "v2.2.0-rc1"
+    package_version = "2.2.0-rc1"
     accelerator     = "cuda"
     cuda_version    = "12.1"
     python_version  = "3.10"

--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -43,13 +43,13 @@ versioned_builds = [
   # Remove libtpu from PyPI builds
   {
     git_tag         = "v2.2.0-rc1"
-    package_version = "2.2.0"
+    package_version = "2.2.0-rc1"
     accelerator     = "tpu"
     bundle_libtpu   = "0"
   },
   {
     git_tag         = "v2.2.0-rc1"
-    package_version = "2.2.0"
+    package_version = "2.2.0-rc1"
     accelerator     = "tpu"
     python_version  = "3.9"
     bundle_libtpu   = "0"

--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -55,9 +55,66 @@ xrt_versioned_builds = [
   },
 ]
 
+# TODO: Remove this after the 2.2 release
+xrt_versioned_builds = [
+  {
+    accelerator    = "tpu"
+    python_version = "3.10"
+    pytorch_git_rev = "v2.2.0"
+    package_version = "2.2.0+xrt"
+  },
+  {
+    accelerator  = "cuda"
+    python_version = "3.10"
+    cuda_version = "12.0"
+    pytorch_git_rev = "v2.2.0"
+    package_version = "2.2.0+xrt"
+  },
+]
+
 # Built on push to specific tag.
 versioned_builds = [
   # Remove libtpu from PyPI builds
+  {
+    git_tag         = "v2.2.0"
+    pytorch_git_rev = "v2.2.0"
+    package_version = "2.2.0"
+    accelerator     = "tpu"
+    bundle_libtpu   = "0"
+  },
+  {
+    git_tag         = "v2.2.0"
+    pytorch_git_rev = "v2.2.0"
+    package_version = "2.2.0"
+    accelerator     = "tpu"
+    python_version  = "3.9"
+    bundle_libtpu   = "0"
+  },
+  {
+    git_tag         = "v2.2.0"
+    pytorch_git_rev = "v2.2.0"
+    package_version = "2.2.0"
+    accelerator     = "tpu"
+    python_version  = "3.10"
+    bundle_libtpu   = "0"
+  },
+  {
+    git_tag         = "v2.2.0"
+    pytorch_git_rev = "v2.2.0"
+    package_version = "2.2.0"
+    accelerator     = "tpu"
+    python_version  = "3.11"
+    bundle_libtpu   = "0"
+  },
+  # Bundle libtpu for Kaggle
+  {
+    git_tag         = "v2.2.0"
+    pytorch_git_rev = "v2.2.0"
+    package_version = "2.2.0+libtpu"
+    accelerator     = "tpu"
+    python_version  = "3.10"
+    bundle_libtpu   = "1"
+  },
   {
     git_tag         = "v2.1.0"
     pytorch_git_rev = "v2.1.0"
@@ -107,6 +164,43 @@ versioned_builds = [
     git_tag         = "v1.13.0"
     package_version = "1.13"
     accelerator     = "tpu"
+  },
+  {
+    git_tag         = "v2.2.0"
+    pytorch_git_rev = "v2.2.0"
+    package_version = "2.2.0",
+    accelerator     = "cuda"
+    cuda_version    = "12.0"
+  },
+  {
+    git_tag         = "v2.2.0"
+    pytorch_git_rev = "v2.2.0"
+    package_version = "2.2.0"
+    accelerator     = "cuda"
+    cuda_version    = "11.8"
+  },
+  {
+    git_tag         = "v2.2.0"
+    pytorch_git_rev = "v2.2.0"
+    package_version = "2.2.0"
+    accelerator     = "cuda"
+    cuda_version    = "12.1"
+  },
+  {
+    git_tag         = "v2.2.0"
+    pytorch_git_rev = "v2.2.0"
+    package_version = "2.2.0"
+    accelerator     = "cuda"
+    cuda_version    = "11.8"
+    python_version  = "3.10"
+  },
+  {
+    git_tag         = "v2.2.0"
+    pytorch_git_rev = "v2.2.0"
+    package_version = "2.2.0"
+    accelerator     = "cuda"
+    cuda_version    = "12.1"
+    python_version  = "3.10"
   },
   {
     git_tag         = "v2.1.0"


### PR DESCRIPTION
Add the 2.2 release build similar to 2.1. We will trigger the 2.2 wheel build for xl-ml test. Refer to 2.1 release [PR](https://github.com/pytorch/xla/pull/5483)

Tag for 2.2 has also been added -- https://github.com/pytorch/xla/tags.