### PR TITLE
[dynamo] Move CPU tensor constructor nodes to XLA.

### DIFF
--- a/test/dynamo/test_bridge.py
+++ b/test/dynamo/test_bridge.py
@@ -222,12 +222,12 @@ class TorchXLAReuseGraphTest(torch._dynamo.test_case.TestCase):
   test_training_maxpool = make_training_test(MaxPoolModule)
   test_training_upsample = make_training_test(UpsampleModule)
 
-  def _compile_and_check(self, thing, args, backend="openxla"):
-    r = thing(*args)
+  def _compile_and_check(self, fn, args, backend="openxla"):
+    r = fn(*args)
     xm.mark_step()
 
-    compiled_thing = torch.compile(backend=backend)(thing)
-    compiled_r = compiled_thing(*args)
+    compiled_fn = torch.compile(backend=backend)(fn)
+    compiled_r = compiled_fn(*args)
     xm.mark_step()
 
     self.assertEqual(r, compiled_r)

--- a/test/dynamo/test_bridge.py
+++ b/test/dynamo/test_bridge.py
@@ -222,6 +222,16 @@ class TorchXLAReuseGraphTest(torch._dynamo.test_case.TestCase):
   test_training_maxpool = make_training_test(MaxPoolModule)
   test_training_upsample = make_training_test(UpsampleModule)
 
+  def _compile_and_check(self, thing, args, backend="openxla"):
+    r = thing(*args)
+    xm.mark_step()
+
+    compiled_thing = torch.compile(backend=backend)(thing)
+    compiled_r = compiled_thing(*args)
+    xm.mark_step()
+
+    self.assertEqual(r, compiled_r)
+
   def test_non_tensor_args_for_partition(self):
 
     class Emb(torch.nn.Embedding):
@@ -233,23 +243,28 @@ class TorchXLAReuseGraphTest(torch._dynamo.test_case.TestCase):
     module = Emb()
     module.to(device)
 
-    @torch.compile(backend="openxla_eval")
     def foo(x):
       return module(x)
 
     x = torch.randint(0, 10, (10,), device=device)
-    foo(x)
+    self._compile_and_check(foo, (x,), backend="openxla_eval")
 
   def test_inputs_not_computed(self):
 
-    @torch.compile(backend="openxla")
     def foo(x):
       return x * 2
 
     device = xm.xla_device()
     x = torch.rand(5, device=device)
     x = x.unsqueeze(dim=-1)
-    foo(x)
+    self._compile_and_check(foo, (x,))
+
+  def test_factory_copy(self):
+
+    def foo(device):
+      return torch.arange(5, device="cpu").to(device)
+
+    self._compile_and_check(foo, (xm.xla_device(),))
 
 
 if __name__ == "__main__":

--- a/torch_xla/core/dynamo_bridge.py
+++ b/torch_xla/core/dynamo_bridge.py
@@ -456,6 +456,7 @@ class InputCollector(torch.fx.Interpreter):
 
 
 class XLAConstructorMoverPass(ConstructorMoverPass):
+
   def __init__(self):
     super().__init__("xla", inplace=True)
 
@@ -471,10 +472,8 @@ class XLAConstructorMoverPass(ConstructorMoverPass):
     # in this case, there should be a device keyword-argument
     # where its type is the same as the target device.
     device = node.kwargs.get("device")
-    return (
-      device is not None
-      and device.type == self.target
-    )
+    return (device is not None and device.type == self.target)
+
 
 def extract_compiled_graph(xla_model: torch.fx.GraphModule, xla_args):
   # Synchronize xla_args, so that each FunctionalTensorWrapper argument updates its


### PR DESCRIPTION
Fixes: #5722 
Depends on PyTorch PR: https://github.com/pytorch/pytorch/pull/114539

This PR introduces `XLAConstructorMoverPass`: a FX graph pass inherited from PyTorch's `ConstructorMoverPass`. It turns FX nodes that create CPU tensors into nodes that create XLA tensors.

Affected benchmarks: `hf_GPT2`