### PR TITLE
Fix get_gpu_name returning empty name.

### DIFF
--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -143,7 +143,7 @@ def get_cpu_name():
 def get_gpu_name():
   gpu_names = subprocess.check_output(
       ["nvidia-smi", "--query-gpu=gpu_name", "--format=csv"],
-      encoding='utf-8').split("\n")[1:]
+      encoding='utf-8').split("\n")[1:-1]
   if len(gpu_names) == 1:
     return gpu_names[0]
   return "One of " + ", ".join(gpu_names)


### PR DESCRIPTION
Repro in python shell
>>> subprocess.check_output(["nvidia-smi", "--query-gpu=gpu_name", "--format=csv"], encoding='utf-8').split("\n")[1:]
['NVIDIA A100-SXM4-40GB', '']

Tested fix
>>> subprocess.check_output(["nvidia-smi", "--query-gpu=gpu_name", "--format=csv"], encoding='utf-8').split("\n")[1:-1]
['NVIDIA A100-SXM4-40GB']