### PR TITLE
Fix zero-1 bug for inferring local ranks

### DIFF
--- a/torch_xla/distributed/zero_redundancy_optimizer.py
+++ b/torch_xla/distributed/zero_redundancy_optimizer.py
@@ -83,7 +83,15 @@ class ZeroRedundancyOptimizer(Optimizer):
 
   def init_zero(self):
     self.local_world_size = len(self.sharding_groups[0])
-    self.local_rank = self.global_rank // len(self.sharding_groups)
+    # Infer the local rank from the group
+    self.local_rank = None
+    for group in self.sharding_groups:
+      if self.global_rank in group:
+        if not isinstance(group, list):
+          group = list(group)
+        self.local_rank = group.index(self.global_rank)
+    if self.local_rank is None:
+      raise ValueError(f"Current rank {self.global_rank} is missing from the sharding_groups {self.sharding_groups}")
     # Shard parameters for use in optimizer
     sharded_param_groups = self._shard_parameters()
     # Optimizer initialization

--- a/torch_xla/distributed/zero_redundancy_optimizer.py
+++ b/torch_xla/distributed/zero_redundancy_optimizer.py
@@ -91,7 +91,9 @@ class ZeroRedundancyOptimizer(Optimizer):
           group = list(group)
         self.local_rank = group.index(self.global_rank)
     if self.local_rank is None:
-      raise ValueError(f"Current rank {self.global_rank} is missing from the sharding_groups {self.sharding_groups}")
+      raise ValueError(
+          f"Current rank {self.global_rank} is missing from the sharding_groups {self.sharding_groups}"
+      )
     # Shard parameters for use in optimizer
     sharded_param_groups = self._shard_parameters()
     # Optimizer initialization


### PR DESCRIPTION
Fix a bug how zero-1 optimizer infer the local ranks. Before this PR zero-1 is doing `self.local_rank = self.global_rank // len(self.sharding_groups)`, which might possibly introduce wrong results when distribution strategy is complicated. For example,  assuming with PP=4, DP=8 on a single node, the DP groups will be like [[0-7], [8-15], [16-23], [24-31]]. However every rank in the same DP group will have same local rank for zero-1.

The fix is to use the existing sharding groups to infer the local rank, i.e. find the index of current rank in the sharding group that holds the rank.