### PR TITLE
Allow benchmark runner config: `openxla` for inference runs.

### DIFF
--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -85,11 +85,7 @@ class ExperimentLoader:
         experiment_config["accelerator"] == "cuda" and
         not experiment_config["xla"]):
       return False
-    if experiment_config["dynamo"] == "openxla_eval" and not (
-        experiment_config["xla"] and experiment_config["test"] == "eval"):
-      return False
-    if experiment_config["dynamo"] == "openxla" and not (
-        experiment_config["xla"] and experiment_config["test"] == "train"):
+    if experiment_config["dynamo"] == "openxla" and not experiment_config["xla"]:
       return False
     if (experiment_config["xla"] and
         not is_xla_device_available(experiment_config["accelerator"].upper())):

--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -501,7 +501,7 @@ def parse_args(args=None):
       "--collect-full-output",
       action="store_true",
       help="""Whether to collect full output for training. Set this to true if we
-        want to verify the numerical correctness of graidents. But that may
+        want to verify the numerical correctness of gradients. But that may
         cause time measurement not accurate""",
   )
 
@@ -557,13 +557,13 @@ def parse_args(args=None):
       type=str,
       default="./output/",
       help="Directory specifying where to dump profiling information (summary, and trace)",
-  ),
+  )
 
   parser.add_argument(
       "--profile-cuda-cpu-collect",
       action="store_true",
       help="Whether to collect CPU/GPU profiling information in the resulting file.",
-  ),
+  )
 
   parser.add_argument(
       "--xla-flags",


### PR DESCRIPTION
This PR modifies the benchmarking script, enabling `openxla` dynamo backend for inference runs.