### PR TITLE
Fix bad error message when `PjRtComputationClient` throws exception

### DIFF
--- a/torch_xla/csrc/runtime/runtime.cc
+++ b/torch_xla/csrc/runtime/runtime.cc
@@ -30,7 +30,7 @@ std::unique_ptr<ComputationClient> CreateClient() {
 
 }  // namespace
 
-ComputationClient* GetComputationClient(bool create = true) {
+ComputationClient* GetComputationClient(bool create) {
   static std::unique_ptr<ComputationClient> client = nullptr;
   if (!client && create) {
     static std::once_flag flag;

--- a/torch_xla/csrc/runtime/runtime.cc
+++ b/torch_xla/csrc/runtime/runtime.cc
@@ -27,7 +27,7 @@ ComputationClient* GetComputationClient() {
 
     XLA_CHECK(client);
 
-    g_computation_client_initialized.exchange(true);
+    g_computation_client_initialized = true;
     return client;
   }();
 

--- a/torch_xla/csrc/runtime/runtime.cc
+++ b/torch_xla/csrc/runtime/runtime.cc
@@ -34,7 +34,7 @@ ComputationClient* GetComputationClient(bool create = true) {
   static std::unique_ptr<ComputationClient> client = nullptr;
   if (!client && create) {
     static std::once_flag flag;
-    std::call_once(flag, [](){ client = CreateClient(); });
+    std::call_once(flag, []() { client = CreateClient(); });
   }
   return client.get();
 }

--- a/torch_xla/csrc/runtime/runtime.h
+++ b/torch_xla/csrc/runtime/runtime.h
@@ -7,7 +7,7 @@ namespace torch_xla {
 namespace runtime {
 
 // Returns the ComputationClient singleton.
-ComputationClient* GetComputationClient();
+ComputationClient* GetComputationClient(bool create = true);
 
 ComputationClient* GetComputationClientIfInitialized();
 

--- a/torch_xla/csrc/runtime/runtime.h
+++ b/torch_xla/csrc/runtime/runtime.h
@@ -7,7 +7,7 @@ namespace torch_xla {
 namespace runtime {
 
 // Returns the ComputationClient singleton.
-ComputationClient* GetComputationClient(bool create = true);
+ComputationClient* GetComputationClient();
 
 ComputationClient* GetComputationClientIfInitialized();
 


### PR DESCRIPTION
The `g_computation_client_initialized` doesn't get reset in this case, leading to incorrect behavior in `GetComputationClientIfInitialized`. Make `CreateClient` anonymous so we can't call it twice by accident.

Example from @jonb377:

```
ptxla@t1v-n-f494979e-w-0:/workspaces/work/pytorch/xla$ python -c 'import torch_xla; torch_xla._XLAC._xla_get_runtime_devices()'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
RuntimeError: torch_xla/csrc/runtime/runtime.cc:27 : $PJRT_DEVICE is not set.

Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/workspaces/work/pytorch/xla/torch_xla/__init__.py", line 127, in _prepare_to_exit
    _XLAC._prepare_to_exit()
RuntimeError: torch_xla/csrc/runtime/runtime.cc:17 : Check failed: !was_initialized 
*** Begin stack trace ***
        tsl::CurrentStackTrace[abi:cxx11]()

        torch_xla::runtime::GetComputationClient()


        PyCFunction_Call
        _PyObject_MakeTpCall
        _PyEval_EvalFrameDefault
        _PyFunction_Vectorcall
        PyVectorcall_Call

        Py_FinalizeEx
        Py_RunMain
        Py_BytesMain
        __libc_start_main
        _start
*** End stack trace ***
ComputationClient already initialized
```

`ComputationClient` was never initialized, so it doesn't make sense to print `ComputationClient already initialized`.