### PR TITLE
Error when changing `PJRT_DEVICE` after runtime initialized

### DIFF
--- a/test/pjrt/test_runtime.py
+++ b/test/pjrt/test_runtime.py
@@ -22,6 +22,26 @@ class TestExperimentalPjrt(parameterized.TestCase):
     with mock.patch.dict(os.environ, {'PJRT_DEVICE': pjrt_device}, clear=True):
       self.assertEqual(xr.device_type(), expected)
 
+  def test_set_device_type(self):
+    with mock.patch.dict(
+        os.environ, {'PJRT_DEVICE': 'CPU'}, clear=True), mock.patch.object(
+            torch_xla._XLAC, '_xla_runtime_is_initialized', return_value=False):
+      xr.set_device_type('TOASTER')
+      self.assertEqual(os.environ['PJRT_DEVICE'], 'TOASTER')
+
+  def test_set_device_type_error(self):
+    with mock.patch.dict(
+        os.environ, {'PJRT_DEVICE': 'CPU'}, clear=True), mock.patch.object(
+            torch_xla._XLAC, '_xla_runtime_is_initialized', return_value=True):
+      with self.assertRaises(RuntimeError):
+        xr.set_device_type('TPU')
+
+  def test_set_device_type_same_device(self):
+    with mock.patch.dict(
+        os.environ, {'PJRT_DEVICE': 'CPU'}, clear=True), mock.patch.object(
+            torch_xla._XLAC, '_xla_runtime_is_initialized', return_value=True):
+      xr.set_device_type('CPU')
+
   def test_requires_pjrt(self):
     with mock.patch.dict(
         os.environ, {'PJRT_SELECT_DEFAULT_DEVICE': '0'}, clear=True):

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -932,6 +932,7 @@ void BuildLoweringContextSubmodule(py::module* m) {
 
 void InitXlaModuleBindings(py::module m) {
   m.def("_prepare_to_exit", []() { PrepareToExit(); });
+  m.def("_xla_runtime_is_initialized", []() { return runtime::GetComputationClientIfInitialized() != nullptr; });
   m.def("_get_git_revs", []() { return GetRevisions(); });
   m.def("_get_xla_tensor_dimension_size",
         [](const at::Tensor& tensor, int dim) {

--- a/torch_xla/runtime.py
+++ b/torch_xla/runtime.py
@@ -23,6 +23,10 @@ def set_device_type(pjrt_device: str) -> None:
   Args:
     pjrt_device: 'TPU' or 'CPU'
   """
+  if torch_xla._XLAC._xla_runtime_is_initialized() and os.environ.get(
+      xenv.PJRT_DEVICE) != pjrt_device:
+    raise RuntimeError('XLA runtime is already initialized!')
+
   os.environ[xenv.PJRT_DEVICE] = pjrt_device
 
 


### PR DESCRIPTION
See #5942

Example:

```
>>> import torch_xla.runtime as xr
>>> import torch_xla.core.xla_model as xm
>>> xr.set_device_type('CPU')
>>> xm.xla_device()
>>> xr.set_device_type('TPU')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.8/site-packages/torch_xla-2.2.0+gitb9475d9-py3.8-linux-x86_64.egg/torch_xla/runtime.py", line 28, in set_device_type
    raise error_type('XLA runtime is already initialized!')
RuntimeError: XLA runtime is already initialized!
```