### PR TITLE
Reduce benchmark experiment filename string.

### DIFF
--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -183,9 +183,7 @@ class BenchmarkExperiment:
     d = OrderedDict()
     d["experiment_name"] = self.experiment_name
     d["accelerator"] = self.accelerator
-    d["accelerator_model"] = self.accelerator_model
     d["xla"] = self.xla
-    d["xla_flags"] = self.xla_flags
     d["dynamo"] = self.dynamo
     d["test"] = self.test
     d["batch_size"] = self.batch_size

--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -177,13 +177,21 @@ class BenchmarkExperiment:
 
   @property
   def filename_str(self):
+    d = self.to_dict()
+
+    # Remove these 2 components that may end up making the filename too big.
+    d.pop("accelerator_model", None)
+    d.pop("xla_flags", None)
+
     return "-".join(str(v) for v in self.to_dict().values()).replace(" ", "")
 
   def to_dict(self):
     d = OrderedDict()
     d["experiment_name"] = self.experiment_name
     d["accelerator"] = self.accelerator
+    d["accelerator_model"] = self.accelerator_model
     d["xla"] = self.xla
+    d["xla_flags"] = self.xla_flags
     d["dynamo"] = self.dynamo
     d["test"] = self.test
     d["batch_size"] = self.batch_size

--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -177,8 +177,7 @@ class BenchmarkExperiment:
 
   @property
   def filename_str(self):
-    return "-".join(
-        str(x) if x is not None else 'None' for x in self.to_dict().values())
+    return "-".join(str(v) for v in self.to_dict().values()).replace(" ", "")
 
   def to_dict(self):
     d = OrderedDict()


### PR DESCRIPTION
This PR removes both `accelerator_model` and `xla_flags` from the list of components of the filename string for a given benchmark experiment.

**Problem:** some filesystems (e.g. ext4)  have limitations on filename length (e.g. 255 bytes)
- `accelerator_model` gathers the model of all available GPUs (16 A100 ended up with a 400+ bytes filename)
- `xla_flags` might not get there, but I guess it's better to leave this one out