### PR TITLE
Optimize autocast tests.

### DIFF
--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -230,18 +230,13 @@ class AutocastCudaTestUnsupportedLists(object):
 
 class TestAutocastBase(unittest.TestCase):
   
-  count = 0
-
   @classmethod
   def setUpClass(cls):
-    print('xw32 calling setupClass line235, cls=', cls)
     cls.autocast_lists = AutocastTestLists(torch.device(xm.xla_device()))
-    print('xw32 cls.autocast_lists=', cls.autocast_lists)
     cls.autocast_unsupported_lists = None
 
   @classmethod
   def tearDownClass(cls):
-    print('xw32 cls.autocast_lists=', cls.autocast_lists)
     del cls.autocast_lists
 
   def setUp(self):
@@ -253,7 +248,6 @@ class TestAutocastBase(unittest.TestCase):
 
   @classmethod
   def get_autocast_list(cls, list_name):
-    print('cls=', cls)
     if cls.autocast_unsupported_lists:
       return [
           tp for tp in getattr(cls.autocast_lists, list_name)
@@ -276,9 +270,6 @@ class TestAutocastBase(unittest.TestCase):
                                module=torch,
                                add_kwargs=None,
                                autocast_dtype=None):
-    TestAutocastBase.count += 1
-    # print('Run test count=', TestAutocastBase.count)
-    # helper to cast args
     def cast(val, to_type):
       if isinstance(val, torch.Tensor):
         return val.to(to_type) if val.is_floating_point() else val
@@ -374,7 +365,6 @@ class TestAutocastCuda(TestAutocastBase):
     self.is_autocast_enabled = torch.is_autocast_xla_enabled
 
   def test_autocast_nn_fp16(self):
-    # print('xw32 TestAutocastCuda.get_autocast_list(nn_fp16)=', TestAutocastCuda.get_autocast_list('nn_fp16'))
     with torch.backends.cudnn.flags(enabled=True, deterministic=True):
       for op, args in TestAutocastCuda.get_autocast_list('nn_fp16'):
         self._run_autocast_outofplace(
@@ -398,20 +388,12 @@ class TestAutocastCuda(TestAutocastBase):
           getattr(module, op)(*args)
 
   def test_autocast_torch_fp32(self):
-    #print('xw32 TestAutocastCuda.get_autocast_list(torch_fp32)=', TestAutocastCuda.get_autocast_list('torch_fp32'))
     for op_with_args in TestAutocastCuda.get_autocast_list('torch_fp32'):
-      print('xw32 op_with_args=', op_with_args)
       op, args, maybe_kwargs = self.args_maybe_kwargs(op_with_args)
       self._run_autocast_outofplace(
           op, args, torch.float32, add_kwargs=maybe_kwargs)
-    print('===========')
-    for op_with_args in TestAutocastCuda.get_autocast_list('torch_fp32'):
-      print('xw32 op_with_args=', op_with_args)
 
-  # focus 1
   def test_autocast_torch_bf16(self):
-    #print('xw32 getattr(TestAutocastCuda.autocast_lists_extra, torch_bf16)=', getattr(TestAutocastCuda.autocast_lists_extra, 'torch_bf16'))
-    start = time.time()
     bf16_test_list = [
         tp for tp in getattr(TestAutocastCuda.autocast_lists_extra, 'torch_bf16')
     ]
@@ -424,11 +406,8 @@ class TestAutocastCuda(TestAutocastBase):
           torch.bfloat16,
           add_kwargs=maybe_kwargs,
           autocast_dtype=torch.bfloat16)
-    end = time.time()
-    print('xw32 test passed. Time used=', (end-start))
 
   def test_autocast_torch_need_autocast_promote(self):
-    #print('xw32 TestAutocastCuda.get_autocast_list(torch_need_autocast_promote)=', TestAutocastCuda.get_autocast_list('torch_need_autocast_promote'))
     for op, args in TestAutocastCuda.get_autocast_list('torch_need_autocast_promote'):
       self._run_autocast_outofplace(op, args, torch.float32)
 
@@ -437,17 +416,12 @@ class TestAutocastCuda(TestAutocastBase):
         'torch_expect_builtin_promote'):
       self._run_autocast_outofplace(op, args, torch.float32, out_type=out_type)
 
-  # focus 0
   def test_autocast_nn_fp32(self):
-    #print('xw32 TestAutocastCuda.get_autocast_list(nn_fp16)=', TestAutocastCuda.get_autocast_list('nn_fp16'))
-    start = time.time()
     for op, args in TestAutocastCuda.get_autocast_list('nn_fp32'):
       print("op=", op)
       # print("op=", op, ', args=', args)
       self._run_autocast_outofplace(
           op, args, torch.float32, module=torch._C._nn)
-    end = time.time()
-    print('xw32 test passed. Time used=', (end-start))
 
   def test_autocast_methods_fp32(self):
     for op, args in TestAutocastCuda.get_autocast_list('methods_fp32'):

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -12,7 +12,6 @@ import collections
 import unittest
 from torch.testing._internal.autocast_test_lists import AutocastTestLists
 from torch_xla.amp import autocast, GradScaler
-import time
 
 
 class AutocastTPUTestLists:
@@ -270,6 +269,7 @@ class TestAutocastBase(unittest.TestCase):
                                module=torch,
                                add_kwargs=None,
                                autocast_dtype=None):
+    # helper to cast args
     def cast(val, to_type):
       if isinstance(val, torch.Tensor):
         return val.to(to_type) if val.is_floating_point() else val
@@ -346,7 +346,6 @@ class TestAutocastBase(unittest.TestCase):
                         "torch.{} result did not match control".format(op))
       self.assertTrue(self.is_autocast_enabled())
     self.assertFalse(self.is_autocast_enabled())
-    
 
 
 @unittest.skipIf(not xm.get_xla_supported_devices("CUDA"),
@@ -399,7 +398,6 @@ class TestAutocastCuda(TestAutocastBase):
     ]
     for op_with_args in bf16_test_list:
       op, args, maybe_kwargs = self.args_maybe_kwargs(op_with_args)
-      print('op=', op)
       self._run_autocast_outofplace(
           op,
           args,
@@ -418,8 +416,6 @@ class TestAutocastCuda(TestAutocastBase):
 
   def test_autocast_nn_fp32(self):
     for op, args in TestAutocastCuda.get_autocast_list('nn_fp32'):
-      print("op=", op)
-      # print("op=", op, ', args=', args)
       self._run_autocast_outofplace(
           op, args, torch.float32, module=torch._C._nn)
 

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -12,6 +12,7 @@ import collections
 import unittest
 from torch.testing._internal.autocast_test_lists import AutocastTestLists
 from torch_xla.amp import autocast, GradScaler
+import time
 
 
 class AutocastTPUTestLists:
@@ -228,25 +229,38 @@ class AutocastCudaTestUnsupportedLists(object):
 
 
 class TestAutocastBase(unittest.TestCase):
+  
+  count = 0
+
+  @classmethod
+  def setUpClass(cls):
+    print('xw32 calling setupClass line235, cls=', cls)
+    cls.autocast_lists = AutocastTestLists(torch.device(xm.xla_device()))
+    print('xw32 cls.autocast_lists=', cls.autocast_lists)
+    cls.autocast_unsupported_lists = None
+
+  @classmethod
+  def tearDownClass(cls):
+    print('xw32 cls.autocast_lists=', cls.autocast_lists)
+    del cls.autocast_lists
 
   def setUp(self):
     super(TestAutocastBase, self).setUp()
     self.is_autocast_enabled = None
-    self.autocast_lists = None
-    self.autocast_unsupported_lists = None
 
   def tearDown(self):
-    del self.autocast_lists
     super(TestAutocastBase, self).tearDown()
 
-  def get_autocast_list(self, list_name):
-    if self.autocast_unsupported_lists:
+  @classmethod
+  def get_autocast_list(cls, list_name):
+    print('cls=', cls)
+    if cls.autocast_unsupported_lists:
       return [
-          tp for tp in getattr(self.autocast_lists, list_name)
-          if tp[0] not in getattr(self.autocast_unsupported_lists, list_name)
+          tp for tp in getattr(cls.autocast_lists, list_name)
+          if tp[0] not in getattr(cls.autocast_unsupported_lists, list_name)
       ]
     else:
-      return [tp for tp in getattr(self.autocast_lists, list_name)]
+      return [tp for tp in getattr(cls.autocast_lists, list_name)]
 
   def args_maybe_kwargs(self, op_with_args):
     if len(op_with_args) == 2:
@@ -262,6 +276,8 @@ class TestAutocastBase(unittest.TestCase):
                                module=torch,
                                add_kwargs=None,
                                autocast_dtype=None):
+    TestAutocastBase.count += 1
+    # print('Run test count=', TestAutocastBase.count)
     # helper to cast args
     def cast(val, to_type):
       if isinstance(val, torch.Tensor):
@@ -339,127 +355,152 @@ class TestAutocastBase(unittest.TestCase):
                         "torch.{} result did not match control".format(op))
       self.assertTrue(self.is_autocast_enabled())
     self.assertFalse(self.is_autocast_enabled())
+    
 
 
 @unittest.skipIf(not xm.get_xla_supported_devices("CUDA"),
                  f"CUDA autocast test.")
 class TestAutocastCuda(TestAutocastBase):
 
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+    cls.autocast_lists_extra = AutocastCudaTestExtraLists(
+        torch.device(xm.xla_device()))
+    cls.autocast_unsupported_lists = AutocastCudaTestUnsupportedLists()
+
   def setUp(self):
     super(TestAutocastCuda, self).setUp()
     self.is_autocast_enabled = torch.is_autocast_xla_enabled
-    self.autocast_lists = AutocastTestLists(torch.device(xm.xla_device()))
-    self.autocast_lists_extra = AutocastCudaTestExtraLists(
-        torch.device(xm.xla_device()))
-    self.autocast_unsupported_lists = AutocastCudaTestUnsupportedLists()
 
   def test_autocast_nn_fp16(self):
+    # print('xw32 TestAutocastCuda.get_autocast_list(nn_fp16)=', TestAutocastCuda.get_autocast_list('nn_fp16'))
     with torch.backends.cudnn.flags(enabled=True, deterministic=True):
-      for op, args in self.get_autocast_list('nn_fp16'):
+      for op, args in TestAutocastCuda.get_autocast_list('nn_fp16'):
         self._run_autocast_outofplace(
             op, args, torch.float16, module=torch._C._nn)
 
   def test_autocast_linalg_fp16(self):
     with torch.backends.cudnn.flags(enabled=True, deterministic=True):
-      for op, args in self.get_autocast_list('linalg_fp16'):
+      for op, args in TestAutocastCuda.get_autocast_list('linalg_fp16'):
         self._run_autocast_outofplace(
             op, args, torch.float16, module=torch._C._linalg)
 
   def test_autocast_methods_fp16(self):
     with torch.backends.cudnn.flags(enabled=True, deterministic=True):
-      for op, args in self.get_autocast_list('methods_fp16'):
+      for op, args in TestAutocastCuda.get_autocast_list('methods_fp16'):
         self._run_autocast_outofplace(op, args, torch.float16, module=None)
 
   def test_autocast_banned(self):
     with torch.cuda.amp.autocast():
-      for op, args, module in self.get_autocast_list('banned'):
+      for op, args, module in TestAutocastCuda.get_autocast_list('banned'):
         with self.assertRaises(RuntimeError):
           getattr(module, op)(*args)
 
   def test_autocast_torch_fp32(self):
-    for op_with_args in self.get_autocast_list('torch_fp32'):
+    #print('xw32 TestAutocastCuda.get_autocast_list(torch_fp32)=', TestAutocastCuda.get_autocast_list('torch_fp32'))
+    for op_with_args in TestAutocastCuda.get_autocast_list('torch_fp32'):
+      print('xw32 op_with_args=', op_with_args)
       op, args, maybe_kwargs = self.args_maybe_kwargs(op_with_args)
       self._run_autocast_outofplace(
           op, args, torch.float32, add_kwargs=maybe_kwargs)
+    print('===========')
+    for op_with_args in TestAutocastCuda.get_autocast_list('torch_fp32'):
+      print('xw32 op_with_args=', op_with_args)
 
+  # focus 1
   def test_autocast_torch_bf16(self):
+    #print('xw32 getattr(TestAutocastCuda.autocast_lists_extra, torch_bf16)=', getattr(TestAutocastCuda.autocast_lists_extra, 'torch_bf16'))
+    start = time.time()
     bf16_test_list = [
-        tp for tp in getattr(self.autocast_lists_extra, 'torch_bf16')
+        tp for tp in getattr(TestAutocastCuda.autocast_lists_extra, 'torch_bf16')
     ]
     for op_with_args in bf16_test_list:
       op, args, maybe_kwargs = self.args_maybe_kwargs(op_with_args)
+      print('op=', op)
       self._run_autocast_outofplace(
           op,
           args,
           torch.bfloat16,
           add_kwargs=maybe_kwargs,
           autocast_dtype=torch.bfloat16)
+    end = time.time()
+    print('xw32 test passed. Time used=', (end-start))
 
   def test_autocast_torch_need_autocast_promote(self):
-    for op, args in self.get_autocast_list('torch_need_autocast_promote'):
+    #print('xw32 TestAutocastCuda.get_autocast_list(torch_need_autocast_promote)=', TestAutocastCuda.get_autocast_list('torch_need_autocast_promote'))
+    for op, args in TestAutocastCuda.get_autocast_list('torch_need_autocast_promote'):
       self._run_autocast_outofplace(op, args, torch.float32)
 
   def test_autocast_torch_expect_builtin_promote(self):
-    for op, args, out_type in self.get_autocast_list(
+    for op, args, out_type in TestAutocastCuda.get_autocast_list(
         'torch_expect_builtin_promote'):
       self._run_autocast_outofplace(op, args, torch.float32, out_type=out_type)
 
+  # focus 0
   def test_autocast_nn_fp32(self):
-    for op, args in self.get_autocast_list('nn_fp32'):
+    #print('xw32 TestAutocastCuda.get_autocast_list(nn_fp16)=', TestAutocastCuda.get_autocast_list('nn_fp16'))
+    start = time.time()
+    for op, args in TestAutocastCuda.get_autocast_list('nn_fp32'):
+      print("op=", op)
+      # print("op=", op, ', args=', args)
       self._run_autocast_outofplace(
           op, args, torch.float32, module=torch._C._nn)
+    end = time.time()
+    print('xw32 test passed. Time used=', (end-start))
 
   def test_autocast_methods_fp32(self):
-    for op, args in self.get_autocast_list('methods_fp32'):
-      print("autocast fp32", op)
+    for op, args in TestAutocastCuda.get_autocast_list('methods_fp32'):
       self._run_autocast_outofplace(op, args, torch.float32, module=None)
 
   def test_autocast_methods_expect_builtin_promote(self):
-    for op, args, out_type in self.get_autocast_list(
+    for op, args, out_type in TestAutocastCuda.get_autocast_list(
         'methods_expect_builtin_promote'):
       self._run_autocast_outofplace(
           op, args, torch.float32, module=None, out_type=out_type)
 
-
 @unittest.skipIf(not xm.get_xla_supported_devices("TPU"), f"TPU autocast test.")
 class TestAutocastTPU(TestAutocastBase):
+
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
 
   def setUp(self):
     super(TestAutocastTPU, self).setUp()
     self.is_autocast_enabled = torch.is_autocast_xla_enabled
-    self.autocast_lists = AutocastTPUTestLists(torch.device(xm.xla_device()))
 
   def test_autocast_methods_bf16(self):
-    for op, args in self.get_autocast_list('methods_bf16'):
+    for op, args in TestAutocastTPU.get_autocast_list('methods_bf16'):
       self._run_autocast_outofplace(op, args, torch.bfloat16, module=None)
 
   def test_autocast_torch_fp32(self):
-    for op_with_args in self.get_autocast_list('torch_fp32'):
+    for op_with_args in TestAutocastTPU.get_autocast_list('torch_fp32'):
       op, args, maybe_kwargs = self.args_maybe_kwargs(op_with_args)
       self._run_autocast_outofplace(
           op, args, torch.float32, add_kwargs=maybe_kwargs)
 
   def test_autocast_torch_need_autocast_promote(self):
-    for op, args in self.get_autocast_list('torch_need_autocast_promote'):
+    for op, args in TestAutocastTPU.get_autocast_list('torch_need_autocast_promote'):
       self._run_autocast_outofplace(op, args, torch.float32)
 
   def test_autocast_torch_expect_builtin_promote(self):
-    for op, args, out_type in self.get_autocast_list(
+    for op, args, out_type in TestAutocastTPU.get_autocast_list(
         'torch_expect_builtin_promote'):
       self._run_autocast_outofplace(op, args, torch.float32, out_type=out_type)
 
   def test_autocast_nn_fp32(self):
-    for op, args in self.get_autocast_list('nn_fp32'):
+    for op, args in TestAutocastTPU.get_autocast_list('nn_fp32'):
       self._run_autocast_outofplace(
           op, args, torch.float32, module=torch._C._nn)
 
   def test_autocast_methods_fp32(self):
-    for op, args in self.get_autocast_list('methods_fp32'):
+    for op, args in TestAutocastTPU.get_autocast_list('methods_fp32'):
       print("autocast fp32", op)
       self._run_autocast_outofplace(op, args, torch.float32, module=None)
 
   def test_autocast_methods_expect_builtin_promote(self):
-    for op, args, out_type in self.get_autocast_list(
+    for op, args, out_type in TestAutocastTPU.get_autocast_list(
         'methods_expect_builtin_promote'):
       self._run_autocast_outofplace(
           op, args, torch.float32, module=None, out_type=out_type)

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -228,7 +228,7 @@ class AutocastCudaTestUnsupportedLists(object):
 
 
 class TestAutocastBase(unittest.TestCase):
-  
+
   @classmethod
   def setUpClass(cls):
     cls.autocast_lists = AutocastTestLists(torch.device(xm.xla_device()))
@@ -394,7 +394,8 @@ class TestAutocastCuda(TestAutocastBase):
 
   def test_autocast_torch_bf16(self):
     bf16_test_list = [
-        tp for tp in getattr(TestAutocastCuda.autocast_lists_extra, 'torch_bf16')
+        tp
+        for tp in getattr(TestAutocastCuda.autocast_lists_extra, 'torch_bf16')
     ]
     for op_with_args in bf16_test_list:
       op, args, maybe_kwargs = self.args_maybe_kwargs(op_with_args)
@@ -406,7 +407,8 @@ class TestAutocastCuda(TestAutocastBase):
           autocast_dtype=torch.bfloat16)
 
   def test_autocast_torch_need_autocast_promote(self):
-    for op, args in TestAutocastCuda.get_autocast_list('torch_need_autocast_promote'):
+    for op, args in TestAutocastCuda.get_autocast_list(
+        'torch_need_autocast_promote'):
       self._run_autocast_outofplace(op, args, torch.float32)
 
   def test_autocast_torch_expect_builtin_promote(self):
@@ -428,6 +430,7 @@ class TestAutocastCuda(TestAutocastBase):
         'methods_expect_builtin_promote'):
       self._run_autocast_outofplace(
           op, args, torch.float32, module=None, out_type=out_type)
+
 
 @unittest.skipIf(not xm.get_xla_supported_devices("TPU"), f"TPU autocast test.")
 class TestAutocastTPU(TestAutocastBase):
@@ -451,7 +454,8 @@ class TestAutocastTPU(TestAutocastBase):
           op, args, torch.float32, add_kwargs=maybe_kwargs)
 
   def test_autocast_torch_need_autocast_promote(self):
-    for op, args in TestAutocastTPU.get_autocast_list('torch_need_autocast_promote'):
+    for op, args in TestAutocastTPU.get_autocast_list(
+        'torch_need_autocast_promote'):
       self._run_autocast_outofplace(op, args, torch.float32)
 
   def test_autocast_torch_expect_builtin_promote(self):

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -231,7 +231,6 @@ class TestAutocastBase(unittest.TestCase):
 
   @classmethod
   def setUpClass(cls):
-    cls.autocast_lists = AutocastTestLists(torch.device(xm.xla_device()))
     cls.autocast_unsupported_lists = None
 
   @classmethod
@@ -355,6 +354,7 @@ class TestAutocastCuda(TestAutocastBase):
   @classmethod
   def setUpClass(cls):
     super().setUpClass()
+    cls.autocast_lists = AutocastTestLists(torch.device(xm.xla_device()))
     cls.autocast_lists_extra = AutocastCudaTestExtraLists(
         torch.device(xm.xla_device()))
     cls.autocast_unsupported_lists = AutocastCudaTestUnsupportedLists()
@@ -437,6 +437,7 @@ class TestAutocastTPU(TestAutocastBase):
 
   @classmethod
   def setUpClass(cls):
+    cls.autocast_lists = AutocastTPUTestLists(torch.device(xm.xla_device()))
     super().setUpClass()
 
   def setUp(self):

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -437,8 +437,8 @@ class TestAutocastTPU(TestAutocastBase):
 
   @classmethod
   def setUpClass(cls):
-    cls.autocast_lists = AutocastTPUTestLists(torch.device(xm.xla_device()))
     super().setUpClass()
+    cls.autocast_lists = AutocastTPUTestLists(torch.device(xm.xla_device()))
 
   def setUp(self):
     super(TestAutocastTPU, self).setUp()
@@ -471,7 +471,6 @@ class TestAutocastTPU(TestAutocastBase):
 
   def test_autocast_methods_fp32(self):
     for op, args in TestAutocastTPU.get_autocast_list('methods_fp32'):
-      print("autocast fp32", op)
       self._run_autocast_outofplace(op, args, torch.float32, module=None)
 
   def test_autocast_methods_expect_builtin_promote(self):


### PR DESCRIPTION
This PR speeds up the test_autocast by setting up autocast_lists, autocast_lists_extra, autocast_unsupported_lists before each test suite instead of each test.

The test suite test_autocast.py has been really slow. (Takes 82 min for [TestAutocastCuda](https://screenshot.googleplex.com/9pjvMCmhYLzGN8W) on HEAD because it creates a new autocast_lists, autocast_lists_extra, autocast_unsupported_lists for each test.

The test `_run_autocast_outofplace` cast out of place, and tensor.to(dtype) returns a copy of the tensor so each test does not change the input tensor. I print the `op and args` in`for op, args in TestAutocastCuda.get_autocast_list('linalg_fp16')` before and after the test runs and the result seems to be identical.

