### PR TITLE
Add graph hash to save tensor output

### DIFF
--- a/test/dynamo/test_dynamo_graph_dump.py
+++ b/test/dynamo/test_dynamo_graph_dump.py
@@ -32,10 +32,14 @@ class DynamoGraphDumpTest(unittest.TestCase):
     xla_y = torch.tensor(200.0).to(device)
     res_xla_dynamo = self.fn_simple_dynamo(xla_x, xla_y)
     with open(save_file, 'rb') as f:
-      current_line = sum(1 for line in f)
+      lines = f.readlines()
+      current_line = len(lines)
+      self.assertIn('Graph Hash:', lines[-5].decode())
     with open(save_file, 'rb') as f:
       res_xla_dynamo_2 = self.fn_simple_dynamo(xla_x, xla_y)
-      new_line = sum(1 for line in f)
+      lines = f.readlines()
+      new_line = len(lines)
+      self.assertIn('Graph Hash:', lines[-5].decode())
     self.assertGreater(new_line, current_line)
 
 

--- a/test/spmd/test_spmd_graph_dump.py
+++ b/test/spmd/test_spmd_graph_dump.py
@@ -45,7 +45,7 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     if should_dump_output_sharding:
       self.assertIn('OUTPUT_SHARDING_END', str(lines[-2]))
     else:
-      self.assertIn('END_GRAPH', str(lines[-3]))
+      self.assertIn('END_GRAPH', str(lines[-2]))
 
 
 if __name__ == '__main__':

--- a/torch_xla/csrc/debug_util.h
+++ b/torch_xla/csrc/debug_util.h
@@ -51,6 +51,8 @@ class DebugUtil {
   static void SaveOutputShardingInfo(std::vector<XLATensorPtr>* tensors,
                                      absl::Span<const size_t> indices);
 
+  static void SaveGraphHash(torch::lazy::hash_t graph_hash);
+
   static bool ExperimentEnabled(const std::string& name);
 
   // warning, this function should only be called when a graph execution is

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -1335,6 +1335,7 @@ XLAGraphExecutor::SyncTensorsGraphInternal(
   PostOrderData po_data = RunPostOrder(ir_values, &coll);
   coll.hash = torch::lazy::HashCombine(
       coll.hash, torch::lazy::Hash(po_data.parameter_sequence));
+  DebugUtil::SaveGraphHash(coll.hash);
   TF_VLOG(4) << "Parameter sequence graph hash "
              << torch::lazy::HashToString(coll.hash);
   std::shared_ptr<Async> async =

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -146,8 +146,11 @@ void XLAGraphExecutor::DeviceContextArena::SaveGraphAsString(
       "";
   if (should_save_graph &&
       hash_to_graph_map.find(hash) == hash_to_graph_map.end()) {
-    hash_to_graph_map[hash] =
-        DebugUtil::GetTensorsGraphInfo(tensors, indices, format);
+    std::stringstream ss;
+    ss << DebugUtil::GetTensorsGraphInfo(tensors, indices, format);
+    ss << "Graph Hash: " << torch::lazy::HashToString(hash)
+       << "\n\n## END_GRAPH\n\n";
+    hash_to_graph_map[hash] = ss.str();
   }
 }
 


### PR DESCRIPTION
Currently when we save `XLA_SAVE_TENSORS_FILE`, only the root hash is included, but not graph hash. We want graph hash since we output graph hash in `PT_XLA_DEBUG=1`, user should be able to map graph hash and the graph in the output tensor file. In this pr we will also attach the graph pr at the end of each graph.

```
[ScheduleSyncTensorsGraph]
TensorsGraphInfo:
  test_2d_tensor_3d_mesh (test_xla_sharding.py:736)
  _callTestMethod (/usr/local/lib/python3.8/unittest/case.py:633)
  run (/usr/local/lib/python3.8/unittest/case.py:676)
  __call__ (/usr/local/lib/python3.8/unittest/case.py:736)
  run (/usr/local/lib/python3.8/unittest/suite.py:122)
  __call__ (/usr/local/lib/python3.8/unittest/suite.py:84)
  run (/usr/local/lib/python3.8/unittest/suite.py:122)
  __call__ (/usr/local/lib/python3.8/unittest/suite.py:84)
  run (/usr/local/lib/python3.8/unittest/runner.py:176)
  runTests (/usr/local/lib/python3.8/unittest/main.py:271)
  __init__ (/usr/local/lib/python3.8/unittest/main.py:101)
  <module> (test_xla_sharding.py:1052)

Root Hashes: (1436329e82afaefef67b56ba9c737f05)

## BEGIN_GRAPH
IR {
  %0 = f32[] prim::Constant(), xla_shape=f32[]
  %1 = f32[16,16]{1,0} aten::expand(%0), xla_shape=f32[16,16]{1,0}
  %2 = f32[16,16]{1,0} xla::device_data(), xla_shape=f32[16,16]{1,0}
  %3 = f32[16,16]{1,0} aten::mul(%2, %1), xla_shape=f32[16,16]{1,0}
  %4 = f32[16,16]{1,0} xla::device_data(), xla_shape=f32[16,16]{1,0}
  %5 = f32[16,16]{1,0} aten::add(%4, %3), xla_shape=f32[16,16]{1,0}, ROOT=0
}

Graph Hash: d82d933c571fffe5a3c46b442381fdb8
```

Reason that I need to attach `Graph Hash` in a separate function is that `SaveTensorsGraphInfo` must be run before `ExtractIRAndPrepareXlaData_ ` otherwise the IR of each tensor will be reset. However graph hash is only known after `RunPostOrder ` which depends on `ExtractIRAndPrepareXlaData_`. It is not ideal but I think it is OK for now.