### PR TITLE
ZeRO1: Add bucketting logic to control the size of tensors for all-gather/reduce-scatter

### DIFF
--- a/test/test_mp_all_gather.py
+++ b/test/test_mp_all_gather.py
@@ -95,6 +95,42 @@ def _mp_fn(index):
             file=sys.stderr)
         print(f'[{index}] {cpu_result}', file=sys.stderr)
         sys.exit(1)
+
+    # Testing with a single replica group and tensor list as input (Bucketized)
+    # TODO: add support for list input with pin_layout=True and output=None
+    result_list = xm.all_gather_bucketized(
+        ordinal_tensors, dim=0, pin_layout=False)
+
+    for i, result in enumerate(result_list):
+      cpu_result = result.cpu()
+      expected = i * 1000 + torch.arange(world_size, dtype=torch.float)
+      if not cpu_result.allclose(expected):
+        print(
+            'xm.all_gather_bucketized() produced wrong reductions for item {i} in result list',
+            file=sys.stderr)
+        print(f'[{index}] {cpu_result}', file=sys.stderr)
+        sys.exit(1)
+
+    # Testing with a single replica group and tensor list as input and output!=None (out-of-place) (Bucketized)
+    # Reuse ordinal_tensors from previous test
+    output_tensors = [
+        torch.zeros([world_size], dtype=torch.float).to(device)
+        for i in range(input_list_size)
+    ]
+    # TODO: add support for list input with pin_layout=True and output!=None
+    result_list = xm.all_gather_bucketized(
+        ordinal_tensors, dim=0, output=output_tensors, pin_layout=False)
+
+    for i, result in enumerate(result_list):
+      cpu_result = result.cpu()
+      expected = i * 1000 + torch.arange(world_size, dtype=torch.float)
+      if not cpu_result.allclose(expected):
+        print(
+            'xm.all_gather() produced wrong reductions for item {i} in result list',
+            file=sys.stderr)
+        print(f'[{index}] {cpu_result}', file=sys.stderr)
+        sys.exit(1)
+
     # TODO: add test for torch.compile when support for list input is ready
 
   else:

--- a/test/test_mp_all_gather.py
+++ b/test/test_mp_all_gather.py
@@ -131,6 +131,30 @@ def _mp_fn(index):
         print(f'[{index}] {cpu_result}', file=sys.stderr)
         sys.exit(1)
 
+    # Testing with a single replica group and tensor list as input and output!=None (out-of-place) (Bucketized, zero bucket size)
+    # Reuse ordinal_tensors from previous test
+    output_tensors = [
+        torch.zeros([world_size], dtype=torch.float).to(device)
+        for i in range(input_list_size)
+    ]
+    # TODO: add support for list input with pin_layout=True and output!=None
+    result_list = xm.all_gather_bucketized(
+        ordinal_tensors,
+        dim=0,
+        output=output_tensors,
+        pin_layout=False,
+        bucket_cap_mb=0)
+
+    for i, result in enumerate(result_list):
+      cpu_result = result.cpu()
+      expected = i * 1000 + torch.arange(world_size, dtype=torch.float)
+      if not cpu_result.allclose(expected):
+        print(
+            'xm.all_gather() produced wrong reductions for item {i} in result list',
+            file=sys.stderr)
+        print(f'[{index}] {cpu_result}', file=sys.stderr)
+        sys.exit(1)
+
     # TODO: add test for torch.compile when support for list input is ready
 
   else:

--- a/test/test_mp_reduce_scatter.py
+++ b/test/test_mp_reduce_scatter.py
@@ -139,6 +139,37 @@ def _mp_fn(index):
       assert res.cpu().allclose(expected)
 
     xm.rendezvous('test_reduce_scatter_list_input_output_bucketized')
+
+    # Testing reduce-scatter with list input and output (buckettized, but zero bucket size)
+    output_list = [
+        torch.rand((32, shard_size * world_size, 32))
+        for _ in range(input_list_size)
+    ]
+    xoutput_list = [output.to(device) for output in output_list]
+
+    # TODO: fix the broken case with pin_layout=True
+    res_list = xm.reduce_scatter_bucketized(
+        xm.REDUCE_SUM,
+        xrand_list,
+        scale,
+        scatter_dim,
+        world_size,
+        output=xoutput_list,
+        bucket_cap_mb=0,
+        pin_layout=False)
+
+    assert (xoutput_list == res_list)
+    for i, res in enumerate(xoutput_list):
+      expected_world = xm.all_reduce(xm.REDUCE_SUM, xrand_list[i], scale)
+      xm.mark_step()
+
+      slice_idx = torch.tensor(
+          list(range(index * shard_size, (index + 1) * shard_size)))
+      expected = expected_world.cpu().index_select(scatter_dim, slice_idx)
+      assert res.cpu().allclose(expected)
+
+    xm.rendezvous(
+        'test_reduce_scatter_list_input_output_bucketized, zero bucket size')
   else:
     print(
         'Default device {} is not a TPU device'.format(device), file=sys.stderr)

--- a/test/test_mp_reduce_scatter.py
+++ b/test/test_mp_reduce_scatter.py
@@ -111,7 +111,7 @@ def _mp_fn(index):
 
     xm.rendezvous('test_reduce_scatter_list_input_output')
 
-    # Testing reduce-scatter with list input and output
+    # Testing reduce-scatter with list input and output (buckettized)
     output_list = [
         torch.rand((32, shard_size * world_size, 32))
         for _ in range(input_list_size)

--- a/test/test_mp_reduce_scatter.py
+++ b/test/test_mp_reduce_scatter.py
@@ -55,6 +55,33 @@ def _mp_fn(index):
 
     xm.rendezvous('test_reduce_scatter_list_input')
 
+    # Testing reduce-scatter with list input bucketized
+    rand_list = [
+        torch.rand((32, shard_size * world_size, 32))
+        for _ in range(input_list_size)
+    ]
+    xrand_list = [rand.to(device) for rand in rand_list]
+
+    # TODO: fix the broken case with pin_layout=True
+    res_list = xm.reduce_scatter_bucketized(
+        xm.REDUCE_SUM,
+        xrand_list,
+        scale,
+        scatter_dim,
+        world_size,
+        pin_layout=False)
+
+    for i, res in enumerate(res_list):
+      expected_world = xm.all_reduce(xm.REDUCE_SUM, xrand_list[i], scale)
+      xm.mark_step()
+
+      slice_idx = torch.tensor(
+          list(range(index * shard_size, (index + 1) * shard_size)))
+      expected = expected_world.cpu().index_select(scatter_dim, slice_idx)
+      assert res.cpu().allclose(expected)
+
+    xm.rendezvous('test_reduce_scatter_list_input_bucketized')
+
     # Testing reduce-scatter with list input and output
     output_list = [
         torch.rand((32, shard_size * world_size, 32))
@@ -83,6 +110,35 @@ def _mp_fn(index):
       assert res.cpu().allclose(expected)
 
     xm.rendezvous('test_reduce_scatter_list_input_output')
+
+    # Testing reduce-scatter with list input and output
+    output_list = [
+        torch.rand((32, shard_size * world_size, 32))
+        for _ in range(input_list_size)
+    ]
+    xoutput_list = [output.to(device) for output in output_list]
+
+    # TODO: fix the broken case with pin_layout=True
+    res_list = xm.reduce_scatter_bucketized(
+        xm.REDUCE_SUM,
+        xrand_list,
+        scale,
+        scatter_dim,
+        world_size,
+        output=xoutput_list,
+        pin_layout=False)
+
+    assert (xoutput_list == res_list)
+    for i, res in enumerate(xoutput_list):
+      expected_world = xm.all_reduce(xm.REDUCE_SUM, xrand_list[i], scale)
+      xm.mark_step()
+
+      slice_idx = torch.tensor(
+          list(range(index * shard_size, (index + 1) * shard_size)))
+      expected = expected_world.cpu().index_select(scatter_dim, slice_idx)
+      assert res.cpu().allclose(expected)
+
+    xm.rendezvous('test_reduce_scatter_list_input_output_bucketized')
   else:
     print(
         'Default device {} is not a TPU device'.format(device), file=sys.stderr)

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -659,7 +659,7 @@ def all_gather(value, dim=0, groups=None, output=None, pin_layout=True):
         if tensor.numel() != output_selected.numel():
           raise ValueError(
               f"`output` tensor size doesn't match `input` tensor size for tensor list index {idx}: "
-              f"{output_selected.numel() vs tensor.numel().")
+              f"{output_selected.numel()} vs {tensor.numel()}.")
 
       # Tensor is larger than bucket_cap, don't bucketize
       if tensor_bytes > bucket_cap:
@@ -933,7 +933,7 @@ def reduce_scatter(reduce_type,
         if tensor.numel() != output_selected.numel():
           raise ValueError(
               f"`output` tensor size doesn't match `input` tensor size for tensor list index {idx}: "
-              f"{output_selected.numel() vs tensor.numel().")
+              f"{output_selected.numel()} vs {tensor.numel()}.")
 
       # Tensor is larger than bucket_cap, don't bucketize
       if tensor_bytes > bucket_cap:

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -619,9 +619,9 @@ def all_gather(value, dim=0, groups=None, output=None, pin_layout=True):
         raise TypeError(
             f"`output` needs to be a list of Tensors, but given {type(output)}."
         )
-      if len(output) != len(input):
-        raise ValueError("`output` length doesn't match `input` length: "
-                         f"{len(output)} vs {len(input)}.")
+      if len(output) != len(value):
+        raise ValueError("`output` length doesn't match `value` length: "
+                         f"{len(output)} vs {len(value)}.")
 
     # helper function for bucketing
     def _all_gather_coalesced(tensor_list, output_list=None):
@@ -650,8 +650,8 @@ def all_gather(value, dim=0, groups=None, output=None, pin_layout=True):
     else:
       divisor = xrt_world_size()
     bucket_cap = bucket_cap / divisor
-    for idx, tensor in enumerate(value):
 
+    for idx, tensor in enumerate(value):
       tensor_bytes = tensor.numel() * tensor.element_size()
       output_selected = None
       if output != None:
@@ -673,7 +673,7 @@ def all_gather(value, dim=0, groups=None, output=None, pin_layout=True):
         else:
           tensor_bucket.append(tensor)
           if output != None:
-            output_bucket.append(output[i])
+            output_bucket.append(output[idx])
           out_tensors.extend(
               _all_gather_coalesced(tensor_bucket, output_bucket))
         total = 0
@@ -925,7 +925,7 @@ def reduce_scatter(reduce_type,
     bucket_cap = int(
         os.getenv("ALL_GATHER_REDUCE_SCATTER_BUCKET_CAP_MB",
                   _ALL_GATHER_REDUCE_SCATTER_BUCKET_CAP_MB)) * 1024 * 1024
-    for i, tensor in enumerate(input):
+    for idx, tensor in enumerate(input):
       tensor_bytes = tensor.numel() * tensor.element_size()
       output_selected = None
       if output != None:
@@ -947,7 +947,7 @@ def reduce_scatter(reduce_type,
         else:
           tensor_bucket.append(tensor)
           if output != None:
-            output_bucket.append(output[i])
+            output_bucket.append(output[idx])
           out_tensors.extend(
               _reduce_scatter_coalesced(tensor_bucket, output_bucket))
         total = 0

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -1,6 +1,7 @@
 import io
 import itertools
 import logging
+import os
 import sys
 import re
 import threading
@@ -37,6 +38,9 @@ _WORLD_SIZE = None
 _ORDINAL = None
 
 XLA_LIB = Library("xla", "DEF")
+
+# Default bucket size for all-gather and reduce-scatter
+_ALL_GATHER_REDUCE_SCATTER_BUCKET_CAP_MB = 160
 
 
 def _init_world_size_ordinal():
@@ -608,30 +612,83 @@ def all_gather(value, dim=0, groups=None, output=None, pin_layout=True):
       raise RuntimeError(
           "For xm.all_gather with list of tensors input, pin_layout=True is not yet supported."
       )
-    if output != None:
-      if not isinstance(output, list) or any(
-          not isinstance(v, torch.Tensor) for v in output):
-        raise TypeError(
-            f"`output` needs to be a list of Tensors, but given {type(output)}."
-        )
-      if len(output) != len(value):
-        raise ValueError("`output` length doesn't match `input` length: "
-                         f"{len(output)} vs {len(input)}.")
-      # Call the out of place version of the reduce_scatter
-      new_token = torch_xla._XLAC._xla_all_gather_coalesced_out(
-          output, value, token, dim, shard_count, groups or [], pin_layout)
-      torch_xla._XLAC._set_all_reduce_token(devctx.device, new_token)
-      return output
+    def _all_gather_coalesced(tensor_list, output_list=None):
+      if output_list != None:
+        if not isinstance(output_list, list) or any(
+            not isinstance(v, torch.Tensor) for v in output_list):
+          raise TypeError(
+              f"`output` needs to be a list of Tensors, but given {type(output_list)}."
+          )
+        if len(output_list) != len(tensor_list):
+          raise ValueError("`output` length doesn't match `input` length: "
+                           f"{len(output_list)} vs {len(tensor_list)}.")
+        # Call the out of place version of the reduce_scatter
+        new_token = torch_xla._XLAC._xla_all_gather_coalesced_out(
+            output_list, tensor_list, token, dim, shard_count, groups or [], pin_layout)
+        torch_xla._XLAC._set_all_reduce_token(devctx.device, new_token)
+        return output_list
 
-    result = torch_xla._XLAC._xla_all_gather_coalesced(value, token, dim,
-                                                       shard_count, groups or
-                                                       [], pin_layout)
-    torch_xla._XLAC._set_all_reduce_token(devctx.device, result[-1])
-    return result[:-1]
+      result = torch_xla._XLAC._xla_all_gather_coalesced(tensor_list, token, dim,
+                                                         shard_count, groups or
+                                                         [], pin_layout)
+      torch_xla._XLAC._set_all_reduce_token(devctx.device, result[-1])
+      return result[:-1]
+
+    total = 0
+    tensor_bucket = []
+    output_bucket = []
+    out_tensors = []
+    bucket_cap = int(os.getenv(
+                      "ALL_GATHER_REDUCE_SCATTER_BUCKET_CAP_MB",
+                      _ALL_GATHER_REDUCE_SCATTER_BUCKET_CAP_MB
+                    )) * 1024 * 1024
+    divisor = len(groups[0]) if type(groups[0]) == list else len(groups)
+    bucket_cap = bucket_cap / divisor
+    for idx, tensor in enumerate(value):
+      
+      tensor_bytes = tensor.numel() * tensor.element_size()
+      output_selected = None
+      if output != None:
+        output_selected = [output[idx]]
+        if tensor.numel() != output_selected.numel():
+          raise ValueError(f"`output` tensor size doesn't match `input` tensor size for list index {idx}: "
+                           f"{output_selected.numel() vs tensor.numel().")
+
+      # Tensor is larger than bucket_cap, don't bucketize
+      if tensor_bytes > bucket_cap:
+        # Flush out previous buckets even if they don't fill up
+        if total >= 0.5*bucket_cap or (total + tensor_bytes) > 2*bucket_cap:
+          out_tensors.extend(_all_gather_coalesced(tensor_bucket, output_bucket))
+          out_tensors.extend(_all_gather_coalesced([tensor], output_selected))
+        else:
+          tensor_bucket.append(tensor)
+          output_bucket.append(output_selected)
+          out_tensors.extend(_all_gather_coalesced(tensor_bucket, output_bucket))
+        total = 0
+        tensor_bucket = []
+        output_bucket = []
+        continue
+
+      # Bucketize till the total spills over
+      total += tensor_bytes
+      if total > bucket_cap:
+        out_tensors.extend(_all_gather_coalesced(tensor_bucket, output_bucket))
+        total = tensor_bytes
+        tensor_bucket = []
+        output_bucket = []
+      tensor_bucket.append(tensor)
+      output_bucket.append(output_selected)
+
+    # Flush the last remaining bucket
+    if len(tensor_bucket):
+      out_tensors.extend(_all_gather_coalesced(tensor_bucket, output_bucket))
+
+    assert len(out_tensors) == len(value)
+
+    return out_tensors
   else:
     raise TypeError("`value` needs to be a Tensor or a list of Tensors, but "
                     f"given {type(value)}.")
-
 
 def all_to_all(value,
                split_dimension,
@@ -836,11 +893,62 @@ def reduce_scatter(reduce_type,
       torch_xla._XLAC._set_all_reduce_token(devctx.device, new_token)
       return output
 
+<<<<<<< HEAD
     result = torch_xla._XLAC._xla_reduce_scatter_coalesced(
         reduce_type, input, token, scale, scatter_dim, shard_count, groups or
         [], pin_layout)
     torch_xla._XLAC._set_all_reduce_token(devctx.device, result[-1])
     return result[:-1]
+=======
+    def _reduce_scatter_coalesced(tensor_list, out_tensor_bucket):
+      result = torch_xla._XLAC._xla_reduce_scatter_coalesced(
+        reduce_type, out_tensor_bucket, tensor_list, token, scale, scatter_dim, shard_count,
+        groups or [], pin_layout)
+      torch_xla._XLAC._set_all_reduce_token(devctx.device, result[-1])
+      return result[:-1]
+
+    total = 0
+    tensor_bucket = []
+    out_tensor_bucket = []
+    out_tensors = []
+    bucket_cap = int(os.getenv(
+                      "ALL_GATHER_REDUCE_SCATTER_BUCKET_CAP_MB",
+                      _ALL_GATHER_REDUCE_SCATTER_BUCKET_CAP_MB
+                    )) * 1024 * 1024
+    for i, tensor in enumerate(input):
+      tensor_bytes = tensor.numel() * tensor.element_size()
+
+      # Tensor is larger than bucket_cap, don't bucketize
+      if tensor_bytes > bucket_cap:
+        # Flush out previous buckets even if they don't fill up
+        if total >= 0.5*bucket_cap or (total + tensor_bytes) > 2*bucket_cap:
+          out_tensors.extend(_reduce_scatter_coalesced(tensor_bucket, out_tensor_bucket))
+          out_tensors.extend(_reduce_scatter_coalesced([tensor], [output[i]] if output else []))
+        else:
+          tensor_bucket.append(tensor)
+          if output != None:
+            out_tensor_bucket.append(output[i])
+          out_tensors.extend(_reduce_scatter_coalesced(tensor_bucket, out_tensor_bucket))
+        total = 0
+        tensor_bucket = []
+        continue
+
+      # Bucketize till the total spills over
+      total += tensor_bytes
+      if total > bucket_cap:
+        out_tensors.extend(_reduce_scatter_coalesced(tensor_bucket, out_tensor_bucket))
+        total = tensor_bytes
+        tensor_bucket = []
+        out_tensor_bucket = []
+      tensor_bucket.append(tensor)
+      if output != None:
+        out_tensor_bucket.append(output[i])
+
+    # Flush the last remaining bucket
+    if len(tensor_bucket):
+        out_tensors.extend(_reduce_scatter_coalesced(tensor_bucket, out_tensor_bucket))
+    return out_tensors
+>>>>>>> add bucketting logic to control the size of tensors for all-gather and reduce-scatter
   else:
     raise TypeError("`input` needs to be a Tensor or a list of Tensors, but "
                     f"given {type(input)}.")

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -644,7 +644,10 @@ def all_gather(value, dim=0, groups=None, output=None, pin_layout=True):
     bucket_cap = int(
         os.getenv("ALL_GATHER_REDUCE_SCATTER_BUCKET_CAP_MB",
                   _ALL_GATHER_REDUCE_SCATTER_BUCKET_CAP_MB)) * 1024 * 1024
-    divisor = len(groups[0]) if type(groups[0]) == list else len(groups)
+    if groups:
+      divisor = len(groups[0]) if type(groups[0]) == list else len(groups)
+    else:
+      divisor = xrt_world_size()
     bucket_cap = bucket_cap / divisor
     for idx, tensor in enumerate(value):
       

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -1,7 +1,6 @@
 import io
 import itertools
 import logging
-import os
 import sys
 import re
 import threading
@@ -608,7 +607,6 @@ def all_gather(value, dim=0, groups=None, output=None, pin_layout=True):
   # Now the input should be a list of Tensors.
   elif isinstance(value, list) and all(
       isinstance(v, torch.Tensor) for v in value):
-    # sanity checks
     if pin_layout:
       raise RuntimeError(
           "For xm.all_gather with list of tensors input, pin_layout=True is not yet supported."
@@ -620,89 +618,113 @@ def all_gather(value, dim=0, groups=None, output=None, pin_layout=True):
             f"`output` needs to be a list of Tensors, but given {type(output)}."
         )
       if len(output) != len(value):
-        raise ValueError("`output` length doesn't match `value` length: "
-                         f"{len(output)} vs {len(value)}.")
+        raise ValueError("`output` length doesn't match `input` length: "
+                         f"{len(output)} vs {len(input)}.")
+      # Call the out of place version of the reduce_scatter
+      new_token = torch_xla._XLAC._xla_all_gather_coalesced_out(
+          output, value, token, dim, shard_count, groups or [], pin_layout)
+      torch_xla._XLAC._set_all_reduce_token(devctx.device, new_token)
+      return output
 
-    # helper function for bucketing
-    def _all_gather_coalesced(tensor_list, output_list=[]):
-      if output_list != []:
-        if len(output_list) != len(tensor_list):
-          raise ValueError(
-              "_all_gather_coalesced: `output_list` length doesn't match `tensor_list` length: "
-              f"{len(output_list)} vs {len(tensor_list)}.")
-        # Call the out of place version of the reduce_scatter
-        new_token = torch_xla._XLAC._xla_all_gather_coalesced_out(
-            output_list, tensor_list, token, dim, shard_count, groups or [],
-            pin_layout)
-        torch_xla._XLAC._set_all_reduce_token(devctx.device, new_token)
-        return output_list
+    result = torch_xla._XLAC._xla_all_gather_coalesced(value, token, dim,
+                                                       shard_count, groups or
+                                                       [], pin_layout)
+    torch_xla._XLAC._set_all_reduce_token(devctx.device, result[-1])
+    return result[:-1]
+  else:
+    raise TypeError("`value` needs to be a Tensor or a list of Tensors, but "
+                    f"given {type(value)}.")
 
-      result = torch_xla._XLAC._xla_all_gather_coalesced(
-          tensor_list, token, dim, shard_count, groups or [], pin_layout)
-      torch_xla._XLAC._set_all_reduce_token(devctx.device, result[-1])
-      return result[:-1]
 
-    #return _all_gather_coalesced(value, output if output else [])
+def all_gather_bucketized(input_list,
+                          dim=0,
+                          groups=None,
+                          output=None,
+                          pin_layout=True,
+                          bucket_cap_mb=160):
+  """Performs an all-gather operation along a given dimension, with bucketization.
 
-    total = 0
-    tensor_bucket = []
-    output_bucket = []
-    out_tensors = []
-    bucket_cap = int(
-        os.getenv("ALL_GATHER_REDUCE_SCATTER_BUCKET_CAP_MB",
-                  _ALL_GATHER_REDUCE_SCATTER_BUCKET_CAP_MB)) * 1024 * 1024
-    if groups:
-      divisor = len(groups[0]) if type(groups[0]) == list else len(groups)
+  Args:
+    See all_gather for the args: dim, groups, output, pin_layout
+    input_list: List of input tensors
+    bucket_cap_mb: Number of MegaBytes of the tensor bucket to fill before doing all-gather.
+
+  Returns:
+    A list of tensors each of which has, in the ``dim`` dimension, all the values from the
+    participating replicas.
+  """
+  # sanity checks
+  if pin_layout:
+    raise RuntimeError(
+        "For xm.all_gather_bucketized, pin_layout=True is not yet supported.")
+  if not isinstance(input_list, list) or any(
+      not isinstance(v, torch.Tensor) for v in input_list):
+    raise TypeError(
+        f"`input_list` needs to be a list of Tensors, but given {type(input_list)}."
+    )
+  if output != None:
+    if not isinstance(output, list) or any(
+        not isinstance(v, torch.Tensor) for v in output):
+      raise TypeError(
+          f"`output` needs to be a list of Tensors, but given {type(output)}.")
+    if len(output) != len(input_list):
+      raise ValueError("`output` length doesn't match `input_list` length: "
+                       f"{len(output)} vs {len(input_list)}.")
+
+  def _all_gather_coalesced(_input_list, _output_list=None):
+    return all_gather(
+        value=_input_list,
+        dim=dim,
+        groups=groups,
+        output=_output_list,
+        pin_layout=pin_layout)
+
+  total = 0
+  tensor_bucket = []
+  output_bucket = [] if output else None
+  out_tensors = []
+  bucket_cap = bucket_cap_mb * 1024 * 1024
+  if groups:
+    divisor = len(groups[0]) if type(groups[0]) == list else len(groups)
+  else:
+    divisor = xrt_world_size()
+  bucket_cap = bucket_cap / divisor
+
+  for idx, tensor in enumerate(input_list):
+    tensor_bytes = tensor.numel() * tensor.element_size()
+
+    # Aim for target bucket_cap_mb: flush new tensor with bucket if bucket content
+    # is small (1/2 cap) but don't combine if combined total is over 2x cap
+    total_new = total + tensor_bytes
+    if tensor_bytes > bucket_cap and total < 0.5 * bucket_cap and total_new <= 2 * bucket_cap:
+      tensor_bucket.append(tensor)
+      if output != None:
+        output_bucket.append(output[idx])
+      out_tensors.extend(_all_gather_coalesced(tensor_bucket, output_bucket))
+      total = 0
+      tensor_bucket = []
+      output_bucket = [] if output else None
     else:
-      divisor = xrt_world_size()
-    bucket_cap = bucket_cap / divisor
-
-    for idx, tensor in enumerate(value):
-      tensor_bytes = tensor.numel() * tensor.element_size()
-
-      # Tensor is larger than bucket_cap, don't bucketize
-      if tensor_bytes > bucket_cap:
-        # Flush out previous buckets even if they don't fill up
-        if total >= 0.5 * bucket_cap or (total + tensor_bytes) > 2 * bucket_cap:
-          if len(tensor_bucket):
-            out_tensors.extend(
-                _all_gather_coalesced(tensor_bucket, output_bucket))
-          out_tensors.extend(
-              _all_gather_coalesced([tensor], [output[idx]] if output else []))
-        else:
-          tensor_bucket.append(tensor)
-          if output != None:
-            output_bucket.append(output[idx])
+      # Bucketize till the total spills over
+      if total_new > bucket_cap:
+        if len(tensor_bucket):
           out_tensors.extend(
               _all_gather_coalesced(tensor_bucket, output_bucket))
         total = 0
         tensor_bucket = []
-        output_bucket = []
-        continue
-
-      # Bucketize till the total spills over
-      total += tensor_bytes
-      if total > bucket_cap:
-        if len(tensor_bucket):
-          out_tensors.extend(
-              _all_gather_coalesced(tensor_bucket, output_bucket))
-        total = tensor_bytes
-        tensor_bucket = []
-        output_bucket = []
+        output_bucket = [] if output else None
+      total = total_new
       tensor_bucket.append(tensor)
       if output != None:
         output_bucket.append(output[idx])
 
-    # Flush the last remaining bucket
-    if len(tensor_bucket):
-      out_tensors.extend(_all_gather_coalesced(tensor_bucket, output_bucket))
+  # Flush the last remaining bucket
+  if len(tensor_bucket):
+    out_tensors.extend(_all_gather_coalesced(tensor_bucket, output_bucket))
 
-    assert len(out_tensors) == len(value)
+  assert len(out_tensors) == len(input_list)
 
-    return out_tensors
-  else:
-    raise TypeError("`value` needs to be a Tensor or a list of Tensors, but "
-                    f"given {type(value)}.")
+  return out_tensors
 
 
 def all_to_all(value,
@@ -892,7 +914,6 @@ def reduce_scatter(reduce_type,
   # Now the input should be a list of Tensors.
   elif isinstance(input, list) and all(
       isinstance(v, torch.Tensor) for v in input):
-    # sanity checks
     if output != None:
       if not isinstance(output, list) or any(
           not isinstance(v, torch.Tensor) for v in output):
@@ -902,81 +923,116 @@ def reduce_scatter(reduce_type,
       if len(output) != len(input):
         raise ValueError("`output` length doesn't match `input` length: "
                          f"{len(output)} vs {len(input)}.")
-    # helper function for bucketing
-    def _reduce_scatter_coalesced(tensor_list, output_list=[]):
-      if output_list != []:
-        if len(output_list) != len(tensor_list):
-          raise ValueError(
-              "_reduce_scatter_coalesced: `output_list` length doesn't match `tensor_list` length: "
-              f"{len(output_list)} vs {len(tensor_list)}.")
-        # Call the out of place version of the reduce_scatter
-        new_token = torch_xla._XLAC._xla_reduce_scatter_coalesced_out(
-            reduce_type, output_list, tensor_list, token, scale, scatter_dim,
-            shard_count, groups or [], pin_layout)
-        torch_xla._XLAC._set_all_reduce_token(devctx.device, new_token)
-        return output_list
-
-      result = torch_xla._XLAC._xla_reduce_scatter_coalesced(
-          reduce_type, tensor_list, token, scale, scatter_dim, shard_count,
+      # Call the out of place version of the reduce_scatter
+      new_token = torch_xla._XLAC._xla_reduce_scatter_coalesced_out(
+          reduce_type, output, input, token, scale, scatter_dim, shard_count,
           groups or [], pin_layout)
-      torch_xla._XLAC._set_all_reduce_token(devctx.device, result[-1])
-      return result[:-1]
+      torch_xla._XLAC._set_all_reduce_token(devctx.device, new_token)
+      return output
 
-    total = 0
-    tensor_bucket = []
-    output_bucket = []
-    out_tensors = []
-    bucket_cap = int(
-        os.getenv("ALL_GATHER_REDUCE_SCATTER_BUCKET_CAP_MB",
-                  _ALL_GATHER_REDUCE_SCATTER_BUCKET_CAP_MB)) * 1024 * 1024
-    for idx, tensor in enumerate(input):
-      tensor_bytes = tensor.numel() * tensor.element_size()
+    result = torch_xla._XLAC._xla_reduce_scatter_coalesced(
+        reduce_type, input, token, scale, scatter_dim, shard_count, groups or
+        [], pin_layout)
+    torch_xla._XLAC._set_all_reduce_token(devctx.device, result[-1])
+    return result[:-1]
+  else:
+    raise TypeError("`input` needs to be a Tensor or a list of Tensors, but "
+                    f"given {type(input)}.")
 
-      # Tensor is larger than bucket_cap, don't bucketize
-      if tensor_bytes > bucket_cap:
-        # Flush out previous buckets even if they don't fill up
-        if total >= 0.5 * bucket_cap or (total + tensor_bytes) > 2 * bucket_cap:
-          if len(tensor_bucket):
-            out_tensors.extend(
-                _reduce_scatter_coalesced(tensor_bucket, output_bucket))
-          out_tensors.extend(
-              _reduce_scatter_coalesced([tensor],
-                                        [output[idx]] if output else []))
-        else:
-          tensor_bucket.append(tensor)
-          if output != None:
-            output_bucket.append(output[idx])
+
+def reduce_scatter_bucketized(reduce_type,
+                              input_list,
+                              scale,
+                              scatter_dim,
+                              shard_count,
+                              groups=None,
+                              output=None,
+                              pin_layout=True,
+                              bucket_cap_mb=160):
+  """Performs a XLA `ReduceScatter()` operation on a list of tensors (bucketized).
+
+  See: https://www.tensorflow.org/xla/operation_semantics#reducescatter
+
+  Args:
+    see reduce_scatter for reduce_type, scale, scatter_dim, shard_count, groups, pin_layout
+    input_list: List of input tensors
+    output: Optional list of output torch.Tensor
+    bucket_cap_mb: Number of MegaBytes of the tensor bucket to fill before doing all-gather.
+
+  Returns:
+    A list of `torch.Tensors` with all the values reduced across replicas. Each process
+    gets a shard split along the `scatter_dim`. All other dimensions are
+    the same as the input.
+  """
+  token, devctx = _get_all_reduce_token()
+
+  if not isinstance(input_list, list) or any(
+      not isinstance(v, torch.Tensor) for v in input_list):
+    raise TypeError(
+        f"`input_list` needs to be a list of Tensors, but given {type(input_list)}."
+    )
+  if output != None:
+    if not isinstance(output, list) or any(
+        not isinstance(v, torch.Tensor) for v in output):
+      raise TypeError(
+          f"`output` needs to be a list of Tensors, but given {type(output)}.")
+    if len(output) != len(input_list):
+      raise ValueError("`output` length doesn't match `input_list` length: "
+                       f"{len(output)} vs {len(input_list)}.")
+
+  def _reduce_scatter_coalesced(_input_list, _output_list=None):
+    return reduce_scatter(
+        reduce_type=reduce_type,
+        input=_input_list,
+        scale=scale,
+        scatter_dim=scatter_dim,
+        shard_count=shard_count,
+        groups=groups,
+        output=_output_list,
+        pin_layout=pin_layout)
+
+  total = 0
+  tensor_bucket = []
+  output_bucket = [] if output else None
+  out_tensors = []
+  bucket_cap = bucket_cap_mb * 1024 * 1024
+
+  for idx, tensor in enumerate(input_list):
+    tensor_bytes = tensor.numel() * tensor.element_size()
+
+    # Aim for target bucket_cap_mb: flush new tensor with bucket if bucket content
+    # is small (1/2 cap) but don't combine if combined total is over 2x cap
+    total_new = total + tensor_bytes
+    if tensor_bytes > bucket_cap and total < 0.5 * bucket_cap and total_new <= 2 * bucket_cap:
+      tensor_bucket.append(tensor)
+      if output != None:
+        output_bucket.append(output[idx])
+      out_tensors.extend(
+          _reduce_scatter_coalesced(tensor_bucket, output_bucket))
+      total = 0
+      tensor_bucket = []
+      output_bucket = [] if output else None
+    else:
+      # Bucketize till the total spills over
+      if total_new > bucket_cap:
+        if len(tensor_bucket):
           out_tensors.extend(
               _reduce_scatter_coalesced(tensor_bucket, output_bucket))
         total = 0
         tensor_bucket = []
-        output_bucket = []
-        continue
-
-      # Bucketize till the total spills over
-      total += tensor_bytes
-      if total > bucket_cap:
-        if len(tensor_bucket):
-          out_tensors.extend(
-              _reduce_scatter_coalesced(tensor_bucket, output_bucket))
-        total = tensor_bytes
-        tensor_bucket = []
-        output_bucket = []
+        output_bucket = [] if output else None
+      total = total_new
       tensor_bucket.append(tensor)
       if output != None:
         output_bucket.append(output[idx])
 
-    # Flush the last remaining bucket
-    if len(tensor_bucket):
-      out_tensors.extend(
-          _reduce_scatter_coalesced(tensor_bucket, output_bucket))
+  # Flush the last remaining bucket
+  if len(tensor_bucket):
+    out_tensors.extend(_reduce_scatter_coalesced(tensor_bucket, output_bucket))
 
-    assert len(out_tensors) == len(input)
+  assert len(out_tensors) == len(input_list)
 
-    return out_tensors
-  else:
-    raise TypeError("`input` needs to be a Tensor or a list of Tensors, but "
-                    f"given {type(input)}.")
+  return out_tensors
 
 
 def add_step_closure(closure, args=(), run_async=False):

--- a/torch_xla/distributed/zero_redundancy_optimizer.py
+++ b/torch_xla/distributed/zero_redundancy_optimizer.py
@@ -245,8 +245,9 @@ class ZeroRedundancyOptimizer(Optimizer):
     clip_coeff = torch.tensor(
         max_norm, device=self.device, dtype=self.optimizer_dtype) / (
             self._grad_norm + 1e-6)
-    clip_value = torch.where(clip_coeff < 1, clip_coeff, 
-                             torch.tensor(1., device=self.device, dtype=self.optimizer_dtype))
+    clip_value = torch.where(
+        clip_coeff < 1, clip_coeff,
+        torch.tensor(1., device=self.device, dtype=self.optimizer_dtype))
     for param_group in self.base_optimizer.param_groups:
       for p in param_group['params']:
         if p.grad is not None:

--- a/torch_xla/distributed/zero_redundancy_optimizer.py
+++ b/torch_xla/distributed/zero_redundancy_optimizer.py
@@ -243,10 +243,10 @@ class ZeroRedundancyOptimizer(Optimizer):
     self._grad_norm = self._calc_grad_norm(norm_type)
 
     clip_coeff = torch.tensor(
-        max_norm, device=self.device) / (
+        max_norm, device=self.device, dtype=self.optimizer_dtype) / (
             self._grad_norm + 1e-6)
-    clip_value = torch.where(clip_coeff < 1, clip_coeff,
-                             torch.tensor(1., device=self.device))
+    clip_value = torch.where(clip_coeff < 1, clip_coeff, 
+                             torch.tensor(1., device=self.device, dtype=self.optimizer_dtype))
     for param_group in self.base_optimizer.param_groups:
       for p in param_group['params']:
         if p.grad is not None:

--- a/torch_xla/distributed/zero_redundancy_optimizer.py
+++ b/torch_xla/distributed/zero_redundancy_optimizer.py
@@ -284,14 +284,14 @@ class ZeroRedundancyOptimizer(Optimizer):
 
     if self.coalesce_cc:
       grad_shard = xm.reduce_scatter(
-                    xm.REDUCE_SUM,
-                    padded_grads,
-                    scale=1.0 / self.local_world_size,
-                    scatter_dim=0,
-                    shard_count=self.local_world_size,
-                    pin_layout=self.pin_layout,
-                    groups=self.sharding_groups,
-                  )
+          xm.REDUCE_SUM,
+          padded_grads,
+          scale=1.0 / self.local_world_size,
+          scatter_dim=0,
+          shard_count=self.local_world_size,
+          pin_layout=self.pin_layout,
+          groups=self.sharding_groups,
+      )
       index = 0
       for param_group, sharded_param_group in zip(
           self.param_groups, self.base_optimizer.param_groups):
@@ -335,14 +335,14 @@ class ZeroRedundancyOptimizer(Optimizer):
                 groups=self.sharding_groups,
             )
             param.data.copy_(padded_param.data[:param.size(0)])
-    
+
     if self.coalesce_cc:
       padded_params = xm.all_gather(
-                        sharded_data,
-                        dim=0,
-                        pin_layout=self.pin_layout,
-                        groups=self.sharding_groups,
-                      )
+          sharded_data,
+          dim=0,
+          pin_layout=self.pin_layout,
+          groups=self.sharding_groups,
+      )
       index = 0
       for param_group, sharded_param_group in zip(
           self.param_groups, self.base_optimizer.param_groups):

--- a/torch_xla/distributed/zero_redundancy_optimizer.py
+++ b/torch_xla/distributed/zero_redundancy_optimizer.py
@@ -60,6 +60,7 @@ class ZeroRedundancyOptimizer(Optimizer):
       sharding_groups: Optional[Any] = None,
       grad_norm_groups: Optional[Any] = None,
       lazy_init: bool = False,
+      coalesce_cc: bool = False,
       **defaults: Any,
   ):
     super().__init__(params, defaults)
@@ -76,6 +77,7 @@ class ZeroRedundancyOptimizer(Optimizer):
     self.grad_clipping = grad_clipping
     self.max_norm = max_norm if max_norm is not None else 1.0
     self.pin_layout = pin_layout
+    self.coalesce_cc = coalesce_cc
 
     self.inited = False
     if not lazy_init:
@@ -256,6 +258,7 @@ class ZeroRedundancyOptimizer(Optimizer):
 
     # Reduce full gradients across ranks
     # Assign gradient shards to the respective parameter shards
+    padded_grads = []
     for param_group, sharded_param_group in zip(
         self.param_groups, self.base_optimizer.param_groups):
       for param, shard in zip(param_group['params'],
@@ -263,19 +266,44 @@ class ZeroRedundancyOptimizer(Optimizer):
         if param.grad is not None:
           padded_grad = self._pad_to_world_size(param.grad,
                                                 self.local_world_size)
-          grad_shard = xm.reduce_scatter(
-              xm.REDUCE_SUM,
-              padded_grad,
-              scale=1.0 / self.local_world_size,
-              scatter_dim=0,
-              shard_count=self.local_world_size,
-              pin_layout=self.pin_layout,
-              groups=self.sharding_groups,
-          )
+          if self.coalesce_cc:
+            padded_grads.append(padded_grad)
+          else:
+            grad_shard = xm.reduce_scatter(
+                xm.REDUCE_SUM,
+                padded_grad,
+                scale=1.0 / self.local_world_size,
+                scatter_dim=0,
+                shard_count=self.local_world_size,
+                pin_layout=self.pin_layout,
+                groups=self.sharding_groups,
+            )
+            if grad_shard.dtype != self.optimizer_dtype:
+              grad_shard = grad_shard.to(dtype=self.optimizer_dtype)
+            shard.grad = grad_shard
 
-          if grad_shard.dtype != self.optimizer_dtype:
-            grad_shard = grad_shard.to(dtype=self.optimizer_dtype)
+    if self.coalesce_cc:
+      grad_shard = xm.reduce_scatter(
+                    xm.REDUCE_SUM,
+                    padded_grads,
+                    scale=1.0 / self.local_world_size,
+                    scatter_dim=0,
+                    shard_count=self.local_world_size,
+                    pin_layout=self.pin_layout,
+                    groups=self.sharding_groups,
+                  )
+      index = 0
+      for param_group, sharded_param_group in zip(
+          self.param_groups, self.base_optimizer.param_groups):
+        for param, shard in zip(param_group['params'],
+                                sharded_param_group['params']):
+          if param.grad is not None:
+            grad_shard = grad_shards[index]
+
+            if grad_shard.dtype != self.optimizer_dtype:
+              grad_shard = grad_shard.to(dtype=self.optimizer_dtype)
           shard.grad = grad_shard
+          index += 1
 
     if self.grad_clipping:
       # Update unscale/clip with sub partitions
@@ -288,6 +316,7 @@ class ZeroRedundancyOptimizer(Optimizer):
     self.base_optimizer.zero_grad(set_to_none=True)
 
     # All gather the new weights across the ranks and assign them to the full parameters
+    sharded_data = []
     for param_group, sharded_param_group in zip(
         self.param_groups, self.base_optimizer.param_groups):
       for param, shard in zip(param_group['params'],
@@ -296,13 +325,33 @@ class ZeroRedundancyOptimizer(Optimizer):
           shard_data = shard.data
           if param.dtype != self.optimizer_dtype:
             shard_data = shard_data.to(dtype=param.dtype)
-          padded_param = xm.all_gather(
-              shard_data,
-              dim=0,
-              pin_layout=self.pin_layout,
-              groups=self.sharding_groups,
-          )
-          param.data.copy_(padded_param.data[:param.size(0)])
+          if self.coalesce_cc:
+            sharded_data.append(shard_data)
+          else:
+            padded_param = xm.all_gather(
+                shard_data,
+                dim=0,
+                pin_layout=self.pin_layout,
+                groups=self.sharding_groups,
+            )
+            param.data.copy_(padded_param.data[:param.size(0)])
+    
+    if self.coalesce_cc:
+      padded_params = xm.all_gather(
+                        sharded_data,
+                        dim=0,
+                        pin_layout=self.pin_layout,
+                        groups=self.sharding_groups,
+                      )
+      index = 0
+      for param_group, sharded_param_group in zip(
+          self.param_groups, self.base_optimizer.param_groups):
+        for param, shard in zip(param_group['params'],
+                                sharded_param_group['params']):
+          if param.grad is not None:
+            padded_param = padded_params[index]
+            param.data.copy_(padded_param.data[:param.size(0)])
+            index += 1
 
     # sync back
     self._sync_param_groups(self.base_optimizer.param_groups, self.param_groups)

--- a/torch_xla/distributed/zero_redundancy_optimizer.py
+++ b/torch_xla/distributed/zero_redundancy_optimizer.py
@@ -316,7 +316,6 @@ class ZeroRedundancyOptimizer(Optimizer):
                                 sharded_param_group['params']):
           if param.grad is not None:
             grad_shard = grad_shards[index]
-
             if grad_shard.dtype != self.optimizer_dtype:
               grad_shard = grad_shard.to(dtype=self.optimizer_dtype)
             shard.grad = grad_shard

--- a/torch_xla/distributed/zero_redundancy_optimizer.py
+++ b/torch_xla/distributed/zero_redundancy_optimizer.py
@@ -314,8 +314,8 @@ class ZeroRedundancyOptimizer(Optimizer):
 
             if grad_shard.dtype != self.optimizer_dtype:
               grad_shard = grad_shard.to(dtype=self.optimizer_dtype)
-          shard.grad = grad_shard
-          index += 1
+            shard.grad = grad_shard
+            index += 1
 
     if self.grad_clipping:
       # Update unscale/clip with sub partitions


### PR DESCRIPTION
This PR updates XLA ZeRO1 implementation to use [allgather coalesed](https://github.com/pytorch/xla/pull/5950) and [reduce-scatter coalesced](https://github.com/pytorch/xla/pull/5956).