### PR TITLE
handle dim_size=0 in slice

### DIFF
--- a/test/cpp/test_aten_xla_tensor_1.cpp
+++ b/test/cpp/test_aten_xla_tensor_1.cpp
@@ -1505,6 +1505,18 @@ TEST_F(AtenXlaTensorTest, TestSlice) {
   });
 }
 
+TEST_F(AtenXlaTensorTest, TestSliceZeroDimSize) {
+  torch::Tensor a =
+      torch::rand({0, 24, 16}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor b = torch::slice(a, 0, 0, -1, 1);
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_a = CopyToDevice(a, device);
+    torch::Tensor xla_b = torch::slice(xla_a, 0, 0, -1, 1);
+    EXPECT_EQ(xla_b.numel(), 0);
+    EXPECT_EQ(b.numel(), 0);
+  });
+}
+
 TEST_F(AtenXlaTensorTest, TestTake) {
   torch::Tensor a = torch::rand({4, 4}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::randint(16, {5}, torch::TensorOptions(torch::kLong));

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2375,14 +2375,16 @@ XLATensorPtr slice(const XLATensorPtr& input, int64_t dim, int64_t start,
                    int64_t end, int64_t step) {
   auto input_shape = input->shape();
   dim = torch::lazy::GetCanonicalDimensionIndex(dim, input_shape.get().rank());
-  start = torch::lazy::GetCanonicalPosition(
-      torch_xla::runtime::util::ToVector<int64_t>(
-          input_shape.get().dimensions()),
-      dim, start);
-  end = torch::lazy::GetCanonicalPosition(
-      torch_xla::runtime::util::ToVector<int64_t>(
-          input_shape.get().dimensions()),
-      dim, end);
+  std::vector<int64_t> input_dims = torch_xla::runtime::util::ToVector<int64_t>(
+      input_shape.get().dimensions());
+  if (input_dims[dim] == 0) {
+    // `GetCanonicalDimensionIndex` doesn't support case where dim size = 0.
+    // So we add a special handling in torch_xla.
+    return input->CreateFrom(
+        torch::lazy::MakeNode<Select>(input->GetIrValue(), dim, 0, 0, step));
+  }
+  start = torch::lazy::GetCanonicalPosition(input_dims, dim, start);
+  end = torch::lazy::GetCanonicalPosition(input_dims, dim, end);
   // PyTorch allows tensor[-1:0] to return a 0-dim tensor.
   if (start > end) {
     end = start;


### PR DESCRIPTION
In the lowering of `slice`, if the `dim_size=0`, will it hit the assertion in the upstream helper function [ref](https://github.com/pytorch/pytorch/blob/main/torch/csrc/lazy/core/helpers.cpp#L29) (args are dim = -1, rank = 0).

minimal repro of the issue
```
x = torch.rand(0,1,512)
x = x.to(xm.xla_device())
y = torch.ops.aten.slice(x, 0,0,-1,2)
```

The expected behavior of slice a empty tensor is to give an empty tensor

We add a special handling case for `dim_size=0` in this PR to workaround the constraint in `GetCanonicalDimensionIndex`. 

~An upstream PR to fix `GetCanonicalDimensionIndex` for this special case will be provided later.~
After having a second thought, it may not be reasonable to have `GetCanonicalDimensionIndex` to support `dim_size=0`, because a dim with size of 0 cannot be indexed. (e.g. t has size `[0,1,2]`, then`t[0,:,:]` and `t[-1,:,:]`) are both invalid, and `GetCanonicalDimensionIndex` is intended to Canonicalize index. So I think it makes more sense to keep the special handling in the `slice` lowering.