### PR TITLE
Fix CUDA profiling dump.

### DIFF
--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -178,7 +178,7 @@ class BenchmarkExperiment:
   @property
   def filename_str(self):
     return "-".join(
-        str(x) if x is not None else 'null' for x in self.to_dict().values())
+        str(x) if x is not None else 'None' for x in self.to_dict().values())
 
   def to_dict(self):
     d = OrderedDict()

--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -177,7 +177,8 @@ class BenchmarkExperiment:
 
   @property
   def filename_str(self):
-    return "-".join(self.to_dict().values())
+    return "-".join(
+        str(x) if x is not None else 'null' for x in self.to_dict().values())
 
   def to_dict(self):
     d = OrderedDict()

--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -242,17 +242,17 @@ class ExperimentRunner:
           'Profiling enabled, but dumping tracing/kernel summary disabled.')
       return
 
-    with_configuration_suffix = lambda name, ext: f"{name}-{benchmark_model.filename_str}-{benchmark_experiment.filename_str}.{ext}"
+    create_prof_filename = lambda name, ext: f"ptprofile-{name}-{benchmark_model.filename_str}-{benchmark_experiment.filename_str}.{ext}"
     model_name = benchmark_model.model_name
     file_path = os.path.join(self._args.profile_cuda_dump, model_name)
     os.makedirs(file_path, exist_ok=True)
     prof.export_chrome_trace(
-        os.path.join(file_path, with_configuration_suffix("trace", "json")))
+        os.path.join(file_path, create_prof_filename("trace", "json")))
 
     kernel_dump = prof.key_averages().table(
         sort_by="cuda_time_total", row_limit=500)
     with open(
-        os.path.join(file_path, with_configuration_suffix("kernel_dump",
+        os.path.join(file_path, create_prof_filename("kernel_dump",
                                                           "txt")), "a") as f:
       f.write(kernel_dump)
 

--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -252,8 +252,8 @@ class ExperimentRunner:
     kernel_dump = prof.key_averages().table(
         sort_by="cuda_time_total", row_limit=500)
     with open(
-        os.path.join(file_path, create_prof_filename("kernel_dump",
-                                                          "txt")), "a") as f:
+        os.path.join(file_path, create_prof_filename("kernel_dump", "txt")),
+        "a") as f:
       f.write(kernel_dump)
 
   def collect_profile_to_metrics(self, prof, metrics):

--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -235,20 +235,25 @@ class ExperimentRunner:
       inputs_list.append(inputs)
     return inputs_list
 
-  def dump_profile_info(self, prof, model_name):
+  def dump_profile_info(self, prof, benchmark_model, benchmark_experiment):
     assert prof is not None, 'Expecting profiler to be defined!'
     if not self._args.profile_cuda_dump:
       logger.warning(
           'Profiling enabled, but dumping tracing/kernel summary disabled.')
       return
 
-    file_path = f"/tmp/{model_name}-profile"
+    with_configuration_suffix = lambda name, ext: f"{name}-{benchmark_model.filename_str}-{benchmark_experiment.filename_str}.{ext}"
+    model_name = benchmark_model.model_name
+    file_path = os.path.join(self._args.profile_cuda_dump, model_name)
     os.makedirs(file_path, exist_ok=True)
-    prof.export_chrome_trace(os.path.join(file_path, "trace.json"))
+    prof.export_chrome_trace(
+        os.path.join(file_path, with_configuration_suffix("trace", "json")))
 
     kernel_dump = prof.key_averages().table(
         sort_by="cuda_time_total", row_limit=500)
-    with open(os.path.join(file_path, "kernel_dump.txt"), "a") as f:
+    with open(
+        os.path.join(file_path, with_configuration_suffix("kernel_dump",
+                                                          "txt")), "a") as f:
       f.write(kernel_dump)
 
   def collect_profile_to_metrics(self, prof, metrics):
@@ -329,7 +334,7 @@ class ExperimentRunner:
 
     t_end = time.perf_counter()
     if enable_prof:
-      self.dump_profile_info(prof, benchmark_model.model_name)
+      self.dump_profile_info(prof, benchmark_model, benchmark_experiment)
       self.collect_profile_to_metrics(prof, metrics)
 
     metrics["total_time"] = t_end - t_start
@@ -555,7 +560,7 @@ def parse_args(args=None):
   parser.add_argument(
       "--profile-cuda-dump",
       type=str,
-      default="./output/",
+      default="",
       help="Directory specifying where to dump profiling information (summary, and trace)",
   )
 


### PR DESCRIPTION
Now we take into consideration the directory to dump kernel profile and traces. Additionally there is also a support for gathering the e2e profiling information across the entire benchmark suite. Previously it was not possible due to conflicting resulting filenames.