### PR TITLE
Fix tensor to xla dtype conversion error

### DIFF
--- a/torch_xla/csrc/dtype.cpp
+++ b/torch_xla/csrc/dtype.cpp
@@ -80,7 +80,8 @@ bool IsTpuDevice(XlaDeviceType hw_type) {
       (hw_type == XlaDeviceType::SPMD) &&
       // HACK: find a better way to decide if SPMD is actually a TPU without
       // accessing the runtime.
-      runtime::sys_util::GetEnvString("PJRT_DEVICE", "") == "TPU";
+      runtime::sys_util::GetEnvString("PJRT_DEVICE", "").find("TPU") !=
+          std::string::npos;
   return (hw_type == XlaDeviceType::TPU) || spmd_device_is_tpu;
 }
 


### PR DESCRIPTION
This addresses a minor bug in dtype conversion for TPU. It was surfaced during SPMD unit testing on v5 with `PJRT_DEVICE=TPU_C_API`.