### PR TITLE
benchmarks/result_analyzer: set default output format to csv

### DIFF
--- a/benchmarks/result_analyzer.py
+++ b/benchmarks/result_analyzer.py
@@ -229,7 +229,7 @@ def parse_args(args=None):
 
   parser.add_argument(
       "--output-format",
-      default="jsonl",
+      default="csv",
       type=str,
       choices=["jsonl", "csv"],
       help="Specify the output format.",


### PR DESCRIPTION
To match our documentation.

Moreover, note that using JSON output can lead to confusion: we read in all jsonl files in the output directory, and therefore after running the script twice, we try to read (and fail) the previously-generated jsonl file. With CSV this is not a problem.