### PR TITLE
Add out-of-place reduce-scatter coalescing

### DIFF
--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -393,14 +393,12 @@ torch::lazy::Value reduce_scatter_out(XLATensorPtr& output,
 }
 
 std::pair<std::vector<XLATensorPtr>, torch::lazy::Value>
-reduce_scatter_coalesced(const std::vector<XLATensorPtr>& outputs,
-                         const std::vector<XLATensorPtr>& inputs,
+reduce_scatter_coalesced(const std::vector<XLATensorPtr>& inputs,
                          const torch::lazy::Value& token,
                          AllReduceType reduce_type, double scale,
                          int64_t scatter_dim, int64_t shard_count,
                          std::vector<std::vector<int64_t>> groups,
                          bool pin_layout) {
-  XLA_CHECK(outputs.empty() || outputs.size() == inputs.size());
   std::vector<torch::lazy::Value> input_values;
   input_values.reserve(inputs.size());
   for (auto& input : inputs) {
@@ -412,11 +410,28 @@ reduce_scatter_coalesced(const std::vector<XLATensorPtr>& outputs,
   std::vector<XLATensorPtr> result;
   for (size_t i = 0; i < inputs.size(); ++i) {
     result.emplace_back(inputs[i]->CreateFrom(torch::lazy::Value(node, i)));
-    if (!outputs.empty()) {
-      outputs[i]->SetIrValue(torch::lazy::Value(node, i));
-    }
   }
   return {result, torch::lazy::Value(node, inputs.size())};
+}
+
+torch::lazy::Value reduce_scatter_coalesced_out(
+    const std::vector<XLATensorPtr>& outputs,
+    const std::vector<XLATensorPtr>& inputs, const torch::lazy::Value& token,
+    AllReduceType reduce_type, double scale, int64_t scatter_dim,
+    int64_t shard_count, std::vector<std::vector<int64_t>> groups,
+    bool pin_layout) {
+  std::vector<torch::lazy::Value> input_values;
+  input_values.reserve(inputs.size());
+  for (auto& input : inputs) {
+    input_values.push_back(input->GetIrValue());
+  }
+  torch::lazy::NodePtr node = torch::lazy::MakeNode<ReduceScatterCoalesced>(
+      reduce_type, input_values, token, scale, scatter_dim, shard_count,
+      std::move(groups), pin_layout);
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    outputs[i]->SetIrValue(torch::lazy::Value(node, i));
+  }
+  return torch::lazy::Value(node, inputs.size());
 }
 
 std::pair<XLATensorPtr, torch::lazy::Value> all_to_all(

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -34,13 +34,19 @@ torch::lazy::Value reduce_scatter_out(XLATensorPtr& output,
                                       bool pin_layout);
 
 std::pair<std::vector<XLATensorPtr>, torch::lazy::Value>
-reduce_scatter_coalesced(const std::vector<XLATensorPtr>& outputs,
-                         const std::vector<XLATensorPtr>& inputs,
+reduce_scatter_coalesced(const std::vector<XLATensorPtr>& inputs,
                          const torch::lazy::Value& token,
                          AllReduceType reduce_type, double scale,
                          int64_t scatter_dim, int64_t shard_count,
                          std::vector<std::vector<int64_t>> groups,
                          bool pin_layout);
+
+torch::lazy::Value reduce_scatter_coalesced_out(
+    const std::vector<XLATensorPtr>& outputs,
+    const std::vector<XLATensorPtr>& inputs, const torch::lazy::Value& token,
+    AllReduceType reduce_type, double scale, int64_t scatter_dim,
+    int64_t shard_count, std::vector<std::vector<int64_t>> groups,
+    bool pin_layout);
 
 std::pair<XLATensorPtr, torch::lazy::Value> all_to_all(
     const XLATensorPtr& input, const torch::lazy::Value& token,


### PR DESCRIPTION
In https://github.com/pytorch/xla/pull/5956 we added reduce-scatter coalescing, but the out-of-place was combined with the in-place processing, making it hard to understand/maintain the code.

Per [recommendation](https://github.com/pytorch/xla/pull/5956#discussion_r1416195254) from reviewer, this PR adds the out-of-place version of reduce-scatter coalescing.