### PR TITLE
Move CUDA tensors to CPU before moving to XLA.

### DIFF
--- a/torch_xla/csrc/runtime/tensor_source.h
+++ b/torch_xla/csrc/runtime/tensor_source.h
@@ -54,13 +54,14 @@ class AtenSource : public TensorSource {
     if (target_torch_type != tensor.type().scalarType()) {
       TORCH_LAZY_COUNTER("AtenSourceDowncasts", 1);
     }
-    // TODO(ysiraichi): check, first, if tensor lives in a device that the current
-    // PjRt client has access. If so, we don't need to go through the CPU.
+    // TODO(ysiraichi): check, first, if tensor lives in a device that the
+    // current PjRt client has access. If so, we don't need to go through the
+    // CPU.
     tensor_ = std::move(
         tensor.to(at::TensorOptions().device(at::kCPU).dtype(target_torch_type),
                   /*non_blocking=*/false,
                   /*copy=*/true, at::MemoryFormat::Contiguous));
-    }
+  }
 
   const void* data() const override { return tensor_.const_data_ptr(); }
 

--- a/torch_xla/csrc/runtime/tensor_source.h
+++ b/torch_xla/csrc/runtime/tensor_source.h
@@ -54,9 +54,13 @@ class AtenSource : public TensorSource {
     if (target_torch_type != tensor.type().scalarType()) {
       TORCH_LAZY_COUNTER("AtenSourceDowncasts", 1);
     }
-    tensor_ = std::move(tensor.to(target_torch_type, /*non_blocking=*/false,
-                                  /*copy=*/true, at::MemoryFormat::Contiguous));
-  }
+    // TODO(ysiraichi): check, first, if tensor lives in a device that the current
+    // PjRt client has access. If so, we don't need to go through the CPU.
+    tensor_ = std::move(
+        tensor.to(at::TensorOptions().device(at::kCPU).dtype(target_torch_type),
+                  /*non_blocking=*/false,
+                  /*copy=*/true, at::MemoryFormat::Contiguous));
+    }
 
   const void* data() const override { return tensor_.const_data_ptr(); }
 


### PR DESCRIPTION
Fix: #6010 

This PR moves non-CPU tensors to CPU, before actually moving them to XLA. This is needed because `PjRtClient::BufferFromHostBuffer` (used inside `TransferToServer`) assumes the source tensor is in CPU.

cc @JackCaoG @miladm 