### PR TITLE
Enable CUDA support for PyTorch on CI.

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -41,8 +41,7 @@ apply_patches
 
 python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
 
-# We always build PyTorch without CUDA support.
-export USE_CUDA=0
+export USE_CUDA=1
 python setup.py install
 
 sccache --show-stats


### PR DESCRIPTION
This PR enables CUDA support for PyTorch for CI builds. Since [it's the recommended way](https://github.com/pytorch/xla/blob/master/docs/gpu.md#develop-pytorchxla-on-a-gpu-instance-build-pytorchxla-from-source-with-gpu-support) of installing PyTorch/XLA, we should also test it.