### PR TITLE
Move 0-dimensional tensors to CPU before copying to XLA.

### DIFF
--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -384,7 +384,7 @@ torch::lazy::Value XLATensor::GetIrValueForTensor(
       return ScalarOp(std::move(value),
                       MakeXlaPrimitiveType(tensor.scalar_type(), &device));
     }
-    data = XLAGraphExecutor::Get()->GetDeviceData(tensor, device);
+    data = XLAGraphExecutor::Get()->GetDeviceData(tensor.cpu(), device);
     read_only = true;
   } else {
     TORCH_LAZY_TIMED("IrValueTensorToXlaData");


### PR DESCRIPTION
Follow-up: #6010 

This PR introduces the same fixes as #6060, but for 0-dimensional tensors, specifically. That is because these tensors have a different execution path in PyTorch/XLA. They go first through the Lazy API, where a hash is computed by trying to access the tensor elements directly. Thus, the tensor must live on CPU for that.

cc @JackCaoG @miladm 