### PR TITLE
Increase delay in trace_detached test

### DIFF
--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -113,7 +113,7 @@ class ProfilerTest(unittest.TestCase):
       flags.profile_step = 10
       flags.profile_epoch = 1
       flags.profile_logdir = logdir
-      flags.profile_duration_ms = 5000
+      flags.profile_duration_ms = 1000
 
       test_profile_mp_mnist.train_mnist(
           flags,

--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -113,7 +113,7 @@ class ProfilerTest(unittest.TestCase):
       flags.profile_step = 10
       flags.profile_epoch = 1
       flags.profile_logdir = logdir
-      flags.profile_duration_ms = 1000
+      flags.profile_duration_ms = 5000
 
       test_profile_mp_mnist.train_mnist(
           flags,
@@ -125,7 +125,7 @@ class ProfilerTest(unittest.TestCase):
     p.start()
     training_started.wait(60)
     # Delay to allow the profile to capture
-    time.sleep(5)
+    time.sleep(10)
     p.terminate()
     path = self._check_xspace_pb_exist(logdir)
     self._check_trace_namespace_exists(path)


### PR DESCRIPTION
In #6058, the trace_detached test was flaky. This may be due to the tightness in duration of the profile and delay in the test.

Decreasing the duration of the capture will cause some required values to be missing from the proto, so this change instead increases the delay to allow the capture to be fully processed.