### PR TITLE
Fix model initialization.

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -87,17 +87,6 @@ DENY_LIST = {
     "vision_maskrcnn": [{}],
 }
 
-# Models that have to be initialized on CUDA, before being
-# moved to XLA.
-INIT_WITH_CUDA_MODELS = {
-    "moco",
-    "nvidia_deeprecommender",
-    "pytorch_CycleGAN_and_pix2pix",
-    "simple_gpt",
-    "simple_gpt_tp_manual",
-    "timm_efficientdet",
-}
-
 
 class TorchBenchModelLoader(ModelLoader):
 
@@ -160,10 +149,6 @@ class TorchBenchModelLoader(ModelLoader):
             break
         if matched:
           return False
-
-    if benchmark_experiment.xla and dummy_benchmark_model.model_name in INIT_WITH_CUDA_MODELS:
-      return benchmark_experiment.accelerator == "cuda"
-
     return True
 
 
@@ -195,29 +180,16 @@ class TorchBenchModel(BenchmarkModel):
     # workaround "RuntimeError: not allowed to set torch.backends.cudnn flags"
     # torch.backends.__allow_nonbracketed_mutation_flag = True
 
-    xla_should_init_with_cuda = (
-        self.benchmark_experiment.xla and
-        self.model_name in INIT_WITH_CUDA_MODELS)
-
-    if self.benchmark_experiment.accelerator == "cpu":
-      device = "cpu"
-    elif xla_should_init_with_cuda or (self.benchmark_experiment.accelerator
-                                       == "cuda" and
-                                       not self.benchmark_experiment.xla):
-      device = "cuda"
-    else:
-      device = str(self.benchmark_experiment.get_device())
-
     benchmark = benchmark_cls(
         test=self.benchmark_experiment.test,
-        device=device,
+        device=self.benchmark_experiment.accelerator,
         batch_size=self.benchmark_experiment.batch_size,
     )
 
     self.module, self.example_inputs = benchmark.get_module()
 
     # Move the initialized model to XLA device.
-    if xla_should_init_with_cuda:
+    if self.benchmark_experiment.xla:
       device = self.benchmark_experiment.get_device()
       self.module = self.module.to(device)
       self.example_inputs = pytree.tree_map_only(torch.Tensor,

--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -87,13 +87,15 @@ DENY_LIST = {
     "vision_maskrcnn": [{}],
 }
 
+# Models that have to be initialized on CUDA, before being
+# moved to XLA.
 INIT_WITH_CUDA_MODELS = {
-  "moco",
-  "nvidia_deeprecommender",
-  "pytorch_CycleGAN_and_pix2pix",
-  "simple_gpt",
-  "simple_gpt_tp_manual",
-  "timm_efficientdet",
+    "moco",
+    "nvidia_deeprecommender",
+    "pytorch_CycleGAN_and_pix2pix",
+    "simple_gpt",
+    "simple_gpt_tp_manual",
+    "timm_efficientdet",
 }
 
 
@@ -193,11 +195,15 @@ class TorchBenchModel(BenchmarkModel):
     # workaround "RuntimeError: not allowed to set torch.backends.cudnn flags"
     # torch.backends.__allow_nonbracketed_mutation_flag = True
 
-    xla_should_init_with_cuda = (self.benchmark_experiment.xla and self.model_name in INIT_WITH_CUDA_MODELS)
+    xla_should_init_with_cuda = (
+        self.benchmark_experiment.xla and
+        self.model_name in INIT_WITH_CUDA_MODELS)
 
     if self.benchmark_experiment.accelerator == "cpu":
       device = "cpu"
-    elif xla_should_init_with_cuda or (self.benchmark_experiment.accelerator == "cuda" and not self.benchmark_experiment.xla):
+    elif xla_should_init_with_cuda or (self.benchmark_experiment.accelerator
+                                       == "cuda" and
+                                       not self.benchmark_experiment.xla):
       device = "cuda"
     else:
       device = str(self.benchmark_experiment.get_device())
@@ -214,7 +220,9 @@ class TorchBenchModel(BenchmarkModel):
     if xla_should_init_with_cuda:
       device = self.benchmark_experiment.get_device()
       self.module = self.module.to(device)
-      self.example_inputs = pytree.tree_map_only(torch.Tensor, lambda t: t.to(device), self.example_inputs)
+      self.example_inputs = pytree.tree_map_only(torch.Tensor,
+                                                 lambda t: t.to(device),
+                                                 self.example_inputs)
 
     self.benchmark_experiment.batch_size = benchmark.batch_size
 

--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -6,6 +6,7 @@ from os.path import abspath, exists
 import sys
 import torch
 import torch.nn as nn
+import torch.utils._pytree as pytree
 from torch._dynamo.testing import collect_results, reduce_to_scalar_loss
 from torch._dynamo.utils import clone_inputs
 import types
@@ -86,6 +87,15 @@ DENY_LIST = {
     "vision_maskrcnn": [{}],
 }
 
+INIT_WITH_CUDA_MODELS = {
+  "moco",
+  "nvidia_deeprecommender",
+  "pytorch_CycleGAN_and_pix2pix",
+  "simple_gpt",
+  "simple_gpt_tp_manual",
+  "timm_efficientdet",
+}
+
 
 class TorchBenchModelLoader(ModelLoader):
 
@@ -149,6 +159,9 @@ class TorchBenchModelLoader(ModelLoader):
         if matched:
           return False
 
+    if benchmark_experiment.xla and dummy_benchmark_model.model_name in INIT_WITH_CUDA_MODELS:
+      return benchmark_experiment.accelerator == "cuda"
+
     return True
 
 
@@ -180,9 +193,11 @@ class TorchBenchModel(BenchmarkModel):
     # workaround "RuntimeError: not allowed to set torch.backends.cudnn flags"
     # torch.backends.__allow_nonbracketed_mutation_flag = True
 
+    xla_should_init_with_cuda = (self.benchmark_experiment.xla and self.model_name in INIT_WITH_CUDA_MODELS)
+
     if self.benchmark_experiment.accelerator == "cpu":
       device = "cpu"
-    elif self.benchmark_experiment.accelerator == "cuda" and not self.benchmark_experiment.xla:
+    elif xla_should_init_with_cuda or (self.benchmark_experiment.accelerator == "cuda" and not self.benchmark_experiment.xla):
       device = "cuda"
     else:
       device = str(self.benchmark_experiment.get_device())
@@ -194,6 +209,12 @@ class TorchBenchModel(BenchmarkModel):
     )
 
     self.module, self.example_inputs = benchmark.get_module()
+
+    # Move the initialized model to XLA device.
+    if xla_should_init_with_cuda:
+      device = self.benchmark_experiment.get_device()
+      self.module = self.module.to(device)
+      self.example_inputs = pytree.tree_map_only(torch.Tensor, lambda t: t.to(device), self.example_inputs)
 
     self.benchmark_experiment.batch_size = benchmark.batch_size
 


### PR DESCRIPTION
Fix: #6006 #6007 #6011

This PR introduces a set of models that must be first initialized on CUDA, before moving them to XLA. Even though it fixes all those issues, the majority still have some other problems that do not allow them to run successfully:

- `moco`: still fails because it fallbacks to CPU on `allgather` operation
- `nvidia_deeprecommender`: still fails on training
- `pytorch_CycleGAN_and_pix2pix`: PASS
- `simple_gpt`: requires BF16 (same as inductor)
- `simple_gpt_tp_manual`: requires BF16 (same as inductor)
- `timm_efficientdet`: OOM on training (RTX 2060)

cc @JackCaoG @miladm 