### PR TITLE
Set DISABLE_NUMERIC_CC_TOKEN=1 default for Neuron

### DIFF
--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -78,10 +78,6 @@ def _summarize_fn_tracker():
 
 
 def _aws_ec2_inf_trn_init():
-  import importlib.util
-  if importlib.util.find_spec("torch_neuronx") is not None:
-    os.environ["DISABLE_NUMERIC_CC_TOKEN"] = "1"
-
   try:
     from torch_neuronx import xla
   except ImportError:

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -78,6 +78,10 @@ def _summarize_fn_tracker():
 
 
 def _aws_ec2_inf_trn_init():
+  import importlib.util
+  if importlib.util.find_spec("torch_neuronx") is not None:
+    os.environ["DISABLE_NUMERIC_CC_TOKEN"] = "1"
+
   try:
     from torch_neuronx import xla
   except ImportError:

--- a/torch_xla/_internal/neuron.py
+++ b/torch_xla/_internal/neuron.py
@@ -17,5 +17,6 @@ def num_local_processes() -> int:
 
 
 def initialize_env(local_rank):
+  os.environ["DISABLE_NUMERIC_CC_TOKEN"] = "1"
   os.environ["NEURON_PJRT_PROCESS_INDEX"] = str(local_rank)
   os.environ["NEURON_RT_VISIBLE_CORES"] = str(local_rank)


### PR DESCRIPTION
For Neuron we set DISABLE_NUMERIC_CC_TOKEN=1 to avoid extra scalar computation in CC operations. For background see https://github.com/pytorch/xla/pull/3825 .