### PR TITLE
Increase delay in trace_detached test

### DIFF
--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -125,7 +125,7 @@ class ProfilerTest(unittest.TestCase):
     p.start()
     training_started.wait(60)
     # Delay to allow the profile to capture
-    time.sleep(5)
+    time.sleep(10)
     p.terminate()
     path = self._check_xspace_pb_exist(logdir)
     self._check_trace_namespace_exists(path)


### PR DESCRIPTION
Cherry-pick #6075 - the programmatic profile test is due to tightness between the test duration and the profile duration. If we see flakiness on the r2.2 branch, we should pull this in.