### PR TITLE
Fix precision issue of pow(int, float)

### DIFF
--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -30,7 +30,8 @@ def diff_output(testcase, output1, output2, rtol, atol):
     if output2_cpu.dtype != output1.dtype:
       output2_cpu = output2_cpu.to(output1.dtype)
     testcase.assertTrue(
-        torch.allclose(output1, output2_cpu, atol=atol, rtol=rtol))
+        torch.allclose(
+            output1, output2_cpu, atol=atol, rtol=rtol, equal_nan=True))
   elif isinstance(output1, (tuple, list)):
     testcase.assertIsInstance(output2, (tuple, list))
     testcase.assertEqual(len(output1), len(output2))
@@ -3285,7 +3286,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.pow.Scalar, args, kwargs)
 
-  @unittest.skip
   def test_aten_pow_Tensor_Scalar_0(self):
     args = (
         torch.randn((10, 10)).to(torch.float32),
@@ -3294,7 +3294,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.pow.Tensor_Scalar, args, kwargs)
 
-  @unittest.skip
   def test_aten_pow_Tensor_Scalar_1(self):
     args = (
         torch.randn((10, 10)).to(torch.float16),
@@ -3303,7 +3302,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.pow.Tensor_Scalar, args, kwargs)
 
-  @unittest.skip
   def test_aten_pow_Tensor_Scalar_2(self):
     args = (
         torch.randint(0, 10, (10, 10)).to(torch.int32),
@@ -3317,7 +3315,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.pow.Scalar, args, kwargs)
 
-  @unittest.skip
   def test_aten_pow_Tensor_Tensor_0(self):
     args = (
         torch.randn((10, 10)).to(torch.float32),
@@ -3326,7 +3323,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.pow.Tensor_Tensor, args, kwargs)
 
-  @unittest.skip
   def test_aten_pow_Tensor_Tensor_1(self):
     args = (
         torch.randn((10, 10)).to(torch.float16),

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2090,11 +2090,19 @@ XLATensorPtr pow(const XLATensorPtr& input, const at::Scalar& exponent) {
   // optimize
   torch::lazy::Value exponent_node =
       XLAGraphExecutor::Get()->GetIrValueForConstant(exponent, input->shape());
-  return input->CreateFrom(Pow(input->GetIrValue(), exponent_node));
+  torch::lazy::NodePtr node = Pow(input->GetIrValue(), exponent_node);
+  auto* xla_node = dynamic_cast<XlaNode*>(node.get());
+  at::ScalarType dtype =
+      TorchTypeFromXlaType(xla_node->xla_shape().element_type());
+  return input->CreateFrom(node, dtype);
 }
 
 XLATensorPtr pow(const XLATensorPtr& input, const XLATensorPtr& exponent) {
-  return input->CreateFrom(Pow(input->GetIrValue(), exponent->GetIrValue()));
+  torch::lazy::NodePtr node = Pow(input->GetIrValue(), exponent->GetIrValue());
+  auto* xla_node = dynamic_cast<XlaNode*>(node.get());
+  at::ScalarType dtype =
+      TorchTypeFromXlaType(xla_node->xla_shape().element_type());
+  return input->CreateFrom(node, dtype);
 }
 
 XLATensorPtr pow(const at::Scalar& input, const XLATensorPtr& exponent) {

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -262,11 +262,7 @@ torch::lazy::Value XLAGraphExecutor::GetDeviceDataIrValue(
 torch::lazy::Value XLAGraphExecutor::GetIrValueForConstant(
     const at::Scalar& value, const xla::Shape& shape) {
   torch::lazy::Value ir_value =
-      ScalarOp(std::move(value), shape.element_type());
-  if (!shape.dimensions().empty()) {
-    ir_value = torch::lazy::MakeNode<Expand>(
-        ir_value, torch::lazy::ToVector<int64_t>(shape.dimensions()));
-  }
+      ScalarOp(std::move(value), XlaTypeFromTorchType(value.type()));
   return ir_value;
 }
 


### PR DESCRIPTION
fixes: https://github.com/pytorch/xla/issues/5887

Root cause: we are using dtype of first arg to promote the scalar argument.