### PR TITLE
Revert "Allow benchmark runner config: `openxla` for inference runs. …

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -66,10 +66,9 @@ python xla/benchmarks/experiment_runner.py                   \
 You can change the flags to add the configurations you are interested in. The
 `experiment_runner.py` will expand the options to all supported configurations.
 For example, in the case above, it will consider all the possible combinations
-among the flags `--dynamo`, `--xla`, and `--test`, 5 of which are supported:
+among the flags `--dynamo`, `--xla`, and `--test`, 4 of which are supported:
 
   - `dynamo=openxla_eval`, `xla=PJRT`, `test=eval`
-  - `dynamo=openxla`, `xla=PJRT`, `test=eval`
   - `dynamo=openxla`, `xla=PJRT`, `test=train`
   - `dynamo=inductor`, `xla=None`, `test=eval`
   - `dynamo=inductor`, `xla=None`, `test=train`

--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -88,7 +88,8 @@ class ExperimentLoader:
     if experiment_config["dynamo"] == "openxla_eval" and not (
         experiment_config["xla"] and experiment_config["test"] == "eval"):
       return False
-    if experiment_config["dynamo"] == "openxla" and not experiment_config["xla"]:
+    if experiment_config["dynamo"] == "openxla" and not (
+        experiment_config["xla"] and experiment_config["test"] == "train"):
       return False
     if (experiment_config["xla"] and
         not is_xla_device_available(experiment_config["accelerator"].upper())):

--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -531,7 +531,7 @@ def parse_args(args=None):
       "--collect-full-output",
       action="store_true",
       help="""Whether to collect full output for training. Set this to true if we
-        want to verify the numerical correctness of gradients. But that may
+        want to verify the numerical correctness of graidents. But that may
         cause time measurement not accurate""",
   )
 


### PR DESCRIPTION
…(#5939)"

This reverts commit dcdd66e387a2d8ee1ca3352ccca1b53e54a98354.

Introduced openxla to unfold for both training and inference. This is not intended and leads to duplicate experiment runs. 