### PR TITLE
[SPMD] Allow mark_shard scalar tensors

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1066,8 +1066,24 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     x = torch.tensor(1.0).to(xm.xla_device())
     self.assertEqual(len(x.shape), 0)
 
-    with self.assertRaises(ValueError):
-      xs.mark_sharding(x, self._get_mesh((1, self.n_devices)), ())
+    # with self.assertRaises(ValueError):
+    xt = xs.mark_sharding(x, self._get_mesh((1, self.n_devices)), ())
+    self.assertEqual(xt, x)
+    self.assertEqual(xt.sharding_type, xs.ShardingType.REPLICATED)
+    self.assertEqual(xt.sharding_spec, "{replicated}")
+
+    shards = xt.local_shards
+    self.assertEqual(len(shards), self.n_devices)
+    # all shards are REPLICATED.
+    for i, shard in enumerate(shards):
+      self.assertEqual(shard.data.device, torch.device('cpu'))
+      self.assertTrue(torch.allclose(shard.data, torch.tensor(1.0)))
+      self.assertIsInstance(shard.indices, type(Ellipsis))
+      self.assertEqual(shard.replica_id, i)
+
+    # It looks like mesh_shape attribute is never implemented.
+    with self.assertRaises(AttributeError):
+      xt.mesh_shape
 
 
 if __name__ == '__main__':

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1062,6 +1062,13 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
         '%opt-barrier.37 = (f32[1,64]{0,1}, f32[1]{0}, f32[2,64]{1,0}) opt-barrier((f32[1,64]{0,1}, f32[1]{0}, f32[2,64]{1,0}) %tuple.36)',
         hlo)
 
+  def test_mark_shard_scalar(self):
+    x = torch.tensor(1.0).to(xm.xla_device())
+    self.assertEqual(len(x.shape), 0)
+
+    with self.assertRaises(ValueError):
+      xs.mark_sharding(x, self._get_mesh((1, self.n_devices)), ())
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1066,7 +1066,6 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     x = torch.tensor(1.0).to(xm.xla_device())
     self.assertEqual(len(x.shape), 0)
 
-    # with self.assertRaises(ValueError):
     xt = xs.mark_sharding(x, self._get_mesh((1, self.n_devices)), ())
     self.assertEqual(xt, x)
     self.assertEqual(xt.sharding_type, xs.ShardingType.REPLICATED)

--- a/torch_xla/distributed/spmd/xla_sharding.py
+++ b/torch_xla/distributed/spmd/xla_sharding.py
@@ -111,6 +111,12 @@ class Mesh:
     Return the OpSharding for the given partition spec. This is an expensive
     operation as the mesh grows, so the value is cached for reuse.
     """
+    # For scalar tensors, it can only be replicated.
+    # We have made sure len(t.shape) == len(partition_spec)
+    # in mark_sharding API.
+    if len(partition_spec) == 0:
+      return torch_xla._XLAC.OpSharding([], [], [], ShardingType.REPLICATED)
+
     tile_assignment, group_assignment, replication_groups, sharding_type = self._get_op_sharding_args(
         partition_spec)
     return torch_xla._XLAC.OpSharding(tile_assignment, group_assignment,


### PR DESCRIPTION
Summary:
Support mark_shard scalar tensors.

Test Plan:
python test/spmd/test_xla_sharding.py -v -k test_mark_shard_scalar