### PR TITLE
Uncomment test_aten_scatter_add_1

### DIFF
--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -3767,7 +3767,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.scatter_add, args, kwargs)
 
-  @unittest.skip
   def test_aten_scatter_add_1(self):
     args = (
         torch.randn((10, 10)).to(torch.float16),


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/5999

This was a lucky one, the test just seems to pass after uncommenting with the latest rebases with nightly as of today:
```
(base) wonjoo@wonjoo-cpu:~/pytorch/xla$ PJRT_DEVICE=CPU XLA_STABLEHLO_COMPILE=1 XLA_HLO_DEBUG=1 XLA_IR_DEBUG=1 pytest test/test_core_aten_ops.py -k test_aten_scatter_add_1
=================================== test session starts ===================================
platform linux -- Python 3.10.12, pytest-7.4.3, pluggy-1.0.0
rootdir: /home/wonjoo/pytorch
configfile: pytest.ini
plugins: hypothesis-6.81.2, devtools-0.11.0
collected 518 items / 517 deselected / 1 selected                                         

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1702337288.045645 2065484 cpu_client.cc:370] TfrtCpuClient created.
.                                                        [100%]

============================ 1 passed, 517 deselected in 6.44s ============================
```