### PR TITLE
Add flag for equal_nan in test_core_aten_ops.py

### DIFF
--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -23,14 +23,15 @@ def onlyIfPJRTDeviceIsCUDA(fn):
           fn)
 
 
-def diff_output(testcase, output1, output2, rtol, atol):
+def diff_output(testcase, output1, output2, rtol, atol, equal_nan=False):
   if isinstance(output1, torch.Tensor):
     testcase.assertIsInstance(output2, torch.Tensor)
     output2_cpu = output2.detach().cpu()
     if output2_cpu.dtype != output1.dtype:
       output2_cpu = output2_cpu.to(output1.dtype)
     testcase.assertTrue(
-        torch.allclose(output1, output2_cpu, atol=atol, rtol=rtol))
+        torch.allclose(
+            output1, output2_cpu, atol=atol, rtol=rtol, equal_nan=equal_nan))
   elif isinstance(output1, (tuple, list)):
     testcase.assertIsInstance(output2, (tuple, list))
     testcase.assertEqual(len(output1), len(output2))
@@ -40,7 +41,13 @@ def diff_output(testcase, output1, output2, rtol, atol):
     testcase.assertEqual(output1, output2)
 
 
-def run_export_and_compare(testcase, func, args, kwargs, atol=1e-3, rtol=1e-5):
+def run_export_and_compare(testcase,
+                           func,
+                           args,
+                           kwargs,
+                           atol=1e-3,
+                           rtol=1e-5,
+                           equal_nan=False):
   device = xm.xla_device()
   with testcase.subTest('torch_eval'):
     res = func(*args, **kwargs)
@@ -51,7 +58,8 @@ def run_export_and_compare(testcase, func, args, kwargs, atol=1e-3, rtol=1e-5):
                                      lambda x: x.to(device=device), kwargs)
       res_xla = func(*args2, **kwargs2)
       with testcase.subTest('torch_xla_diff:' + str(atol)):
-        diff_output(testcase, res, res_xla, atol=atol, rtol=rtol)
+        diff_output(
+            testcase, res, res_xla, atol=atol, rtol=rtol, equal_nan=equal_nan)
     with testcase.subTest('can_export'):
       exported = torch.export.export(func, args, kwargs)
       with testcase.subTest('can_convert_to_stablehlo'):
@@ -59,7 +67,8 @@ def run_export_and_compare(testcase, func, args, kwargs, atol=1e-3, rtol=1e-5):
         with testcase.subTest('stablehlo_can_run'):
           res2 = shlo(*args, **kwargs)
           with testcase.subTest('stablehlo_diff: ' + str(atol)):
-            diff_output(testcase, res, res2, rtol=rtol, atol=atol)
+            diff_output(
+                testcase, res, res2, rtol=rtol, atol=atol, equal_nan=equal_nan)
 
 
 class AtenOpTest(unittest.TestCase):
@@ -2334,17 +2343,17 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.lift_fresh_copy, args, kwargs)
 
-  @unittest.skip
   def test_aten_log_0(self):
     args = (torch.randn((10, 10)).to(torch.float32),)
     kwargs = dict()
-    run_export_and_compare(self, torch.ops.aten.log, args, kwargs)
+    run_export_and_compare(
+        self, torch.ops.aten.log, args, kwargs, equal_nan=True)
 
-  @unittest.skip
   def test_aten_log_1(self):
     args = (torch.randn((10, 10)).to(torch.float16),)
     kwargs = dict()
-    run_export_and_compare(self, torch.ops.aten.log, args, kwargs)
+    run_export_and_compare(
+        self, torch.ops.aten.log, args, kwargs, equal_nan=True)
 
   def test_aten_log_2(self):
     args = (torch.randint(0, 10, (10, 10)).to(torch.int32),)


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/5873

---

Doing a quick check for the differences (res-res_xla), we can see that results are pretty much equal:
```
WONJOO: at diff_output, output1-output2_cpu=tensor([[        nan,         nan,         nan,         nan,  0.0000e+00,
          0.0000e+00,         nan,         nan,  0.0000e+00,         nan],
        [ 0.0000e+00,  0.0000e+00,  0.0000e+00,  0.0000e+00,  0.0000e+00,
                 nan,         nan,         nan,  0.0000e+00,  0.0000e+00],
        [ 0.0000e+00,         nan,         nan,  0.0000e+00,  0.0000e+00,
                 nan,         nan,  0.0000e+00,  0.0000e+00,  0.0000e+00],
        [ 0.0000e+00,         nan,         nan,  0.0000e+00,         nan,
          0.0000e+00,  0.0000e+00,  0.0000e+00,  0.0000e+00,  0.0000e+00],
        [        nan, -1.4901e-08,         nan,  0.0000e+00,  0.0000e+00,
          0.0000e+00,         nan,         nan,         nan,  0.0000e+00],
        [-3.7253e-09,  0.0000e+00,         nan,         nan,  0.0000e+00,
                 nan,         nan,  0.0000e+00,  2.9802e-08,  0.0000e+00],
        [        nan,         nan,  0.0000e+00,         nan,         nan,
          0.0000e+00,  0.0000e+00,  0.0000e+00,         nan,  0.0000e+00],
        [        nan,  1.1921e-07,         nan,         nan,         nan,
                 nan,         nan,  0.0000e+00,         nan,  0.0000e+00],
        [        nan,  0.0000e+00,         nan,  0.0000e+00,         nan,
                 nan,         nan,  0.0000e+00,  0.0000e+00,  0.0000e+00],
        [ 0.0000e+00,  0.0000e+00,  0.0000e+00,         nan,  0.0000e+00,
                 nan,  0.0000e+00,         nan,         nan,  0.0000e+00]])
```
But we see a bunch of `nan`'s, which is expected for the `aten_log` op as ln(x) is undefined for x <= 0. And looking at the torch.allclose's documentation (https://pytorch.org/docs/stable/generated/torch.allclose.html), we can actually see that there is a flag called `equal_nan` that defaults to `False`. If set to true, this flag is consider two `nan`'s as equal, which is what we want at least for this `aten_log` op. 

Might be a common problem, so added this to our worklog as well at https://github.com/pytorch/xla/issues/5934#issuecomment-1851108609.

---

Testing:
```
(base) wonjoo@wonjoo-cpu:~/pytorch/xla$ PJRT_DEVICE=CPU XLA_STABLEHLO_COMPILE=1 XLA_HLO_DEBUG=1 XLA_IR_DEBUG=1 pytest test/test_core_aten_ops.py -k test_aten_log_0
========================================================= test session starts ==========================================================
platform linux -- Python 3.10.12, pytest-7.4.3, pluggy-1.0.0
rootdir: /home/wonjoo/pytorch
configfile: pytest.ini
plugins: hypothesis-6.81.2, devtools-0.11.0
collected 518 items / 517 deselected / 1 selected                                                                                      

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1702341121.434014 2083317 cpu_client.cc:370] TfrtCpuClient created.
.                                                                                                     [100%]

================================================== 1 passed, 517 deselected in 5.52s ===================================================
I0000 00:00:1702341122.514295 2083317 cpu_client.cc:373] TfrtCpuClient destroyed.
(base) wonjoo@wonjoo-cpu:~/pytorch/xla$ PJRT_DEVICE=CPU XLA_STABLEHLO_COMPILE=1 XLA_HLO_DEBUG=1 XLA_IR_DEBUG=1 pytest test/test_core_aten_ops.py -k test_aten_log_1
========================================================= test session starts ==========================================================
platform linux -- Python 3.10.12, pytest-7.4.3, pluggy-1.0.0
rootdir: /home/wonjoo/pytorch
configfile: pytest.ini
plugins: hypothesis-6.81.2, devtools-0.11.0
collected 518 items / 517 deselected / 1 selected                                                                                      

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1702341130.163798 2083899 cpu_client.cc:370] TfrtCpuClient created.
.                                                                                                     [100%]

================================================== 1 passed, 517 deselected in 5.43s ===================================================
I0000 00:00:1702341131.136986 2083899 cpu_client.cc:373] TfrtCpuClient destroyed.
```