### PR TITLE
Uncomment test_aten_isinf_2 at test_core_aten_ops.py

### DIFF
--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -2230,7 +2230,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.isinf, args, kwargs)
 
-  @unittest.skip
   def test_aten_isinf_2(self):
     args = (torch.randint(0, 10, (10, 10)).to(torch.int32),)
     kwargs = dict()


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/5871

Another lucky one, all tests are passing with nightlies as of today:
```
(base) wonjoo@wonjoo-cpu:~/pytorch/xla$ PJRT_DEVICE=CPU XLA_STABLEHLO_COMPILE=1 XLA_HLO_DEBUG=1 XLA_IR_DEBUG=1 pytest test/test_core_aten_ops.py -k test_aten_isinf_2
========================================================= test session starts ==========================================================
platform linux -- Python 3.10.12, pytest-7.4.3, pluggy-1.0.0
rootdir: /home/wonjoo/pytorch
configfile: pytest.ini
plugins: hypothesis-6.81.2, devtools-0.11.0
collected 518 items / 517 deselected / 1 selected                                                                                      

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1702341297.372533 2086376 cpu_client.cc:370] TfrtCpuClient created.
.                                                                                                     [100%]

================================================== 1 passed, 517 deselected in 5.32s ===================================================
I0000 00:00:1702341298.239374 2086376 cpu_client.cc:373] TfrtCpuClient destroyed.
```