### PR TITLE
Do manual type conversion for isnan op

### DIFF
--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -2246,7 +2246,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.isnan, args, kwargs)
 
-  @unittest.skip
   def test_aten_isnan_2(self):
     args = (torch.randint(0, 10, (10, 10)).to(torch.int32),)
     kwargs = dict()

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -450,6 +450,12 @@ torch_xla::XlaOpVector Inverse::Lower(LoweringContext* loctx) const {
 
 torch_xla::XlaOpVector Isnan::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  // PyTorch allows integral types as input to torch.isnan, however XLA does not.
+  // So we do a manual type conversion for integral types only to keep our bevahior
+  // same as PyTorch. 
+  if (xla::primitive_util::IsIntegralType(XlaHelpers::TypeOfXlaOp(xla_input))) {
+    xla_input = xla::ConvertElementType(xla_input, xla::PrimitiveType::F32);
+  }
   return ReturnOp(xla::IsNan(xla_input), loctx);
 }
 

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -450,9 +450,9 @@ torch_xla::XlaOpVector Inverse::Lower(LoweringContext* loctx) const {
 
 torch_xla::XlaOpVector Isnan::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
-  // PyTorch allows integral types as input to torch.isnan, however XLA does not.
-  // So we do a manual type conversion for integral types only to keep our bevahior
-  // same as PyTorch. 
+  // PyTorch allows integral types as input to torch.isnan, however XLA does
+  // not. So we do a manual type conversion for integral types only to keep our
+  // bevahior same as PyTorch.
   if (xla::primitive_util::IsIntegralType(XlaHelpers::TypeOfXlaOp(xla_input))) {
     xla_input = xla::ConvertElementType(xla_input, xla::PrimitiveType::F32);
   }


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/5872

---

This was actually a PyTorch/XLA feature gap with PyTorch. According to https://pytorch.org/docs/stable/generated/torch.isnan.html, PyTorch allows integral types as input to `torch.isnan`. So doing this works in PyTorch:
```
>>> x = torch.tensor([1, 2, 3], dtype=int)
>>> x
tensor([1, 2, 3])
>>> x.dtype
torch.int64
>>> torch.isnan(x)
tensor([False, False, False])
```

PyTorch/XLA directly calls `xla::IsNan` in our lowering of this op, and XLA only allows floating types for this op. So doing something similar will cause this failure:
```
RuntimeError: Error while lowering: [] aten::isnan, location=__call__@_ops.py:755, xla_shape=pred[10,10]{1,0}, dynamic_dims: ()
XLA builder error: INVALID_ARGUMENT: Operands to IsNan must be real-valued floating-point, but got S32: 
```

This change does a manual type conversion to F32 if this op is given an integral type. 
