### PR TITLE
Re-land experiment runner tests

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -205,11 +205,7 @@ function run_torch_xla_benchmark_tests() {
   XLA_DIR=$1
   pushd $XLA_DIR
     echo "Running Benchmark Tests"
-    if [ -x "$(command -v nvidia-smi)" ]; then
-      PJRT_DEVICE=CUDA test/benchmarks/run_tests.sh -L""
-    else
-      PJRT_DEVICE=CPU test/benchmarks/run_tests.sh -L""
-    fi
+    test/benchmarks/run_tests.sh -L""
 }
 
 function run_torch_xla_tests() {

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -205,7 +205,11 @@ function run_torch_xla_benchmark_tests() {
   XLA_DIR=$1
   pushd $XLA_DIR
     echo "Running Benchmark Tests"
-    test/benchmarks/run_tests.sh -L""
+    if [ -x "$(command -v nvidia-smi)" ]; then
+      PJRT_DEVICE=CUDA test/benchmarks/run_tests.sh -L""
+    else
+      PJRT_DEVICE=CPU test/benchmarks/run_tests.sh -L""
+    fi
 }
 
 function run_torch_xla_tests() {

--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -97,7 +97,7 @@ class ExperimentLoader:
         not experiment_config["xla"]):
       return False
     if (experiment_config["accelerator"] == "cuda" and
-        not experiment_config["xla"] and not torch.cuda.is_available()):
+        not experiment_config["xla"] and not is_xla_device_available("CUDA")):
       return False
     return True
 

--- a/test/benchmarks/run_tests.sh
+++ b/test/benchmarks/run_tests.sh
@@ -39,7 +39,9 @@ function run_make_tests {
 }
 
 function run_python_tests {
+  python3 "$CDIR/test_experiment_runner.py"
   python3 "$CDIR/test_benchmark_experiment.py"
+  python3 "$CDIR/test_benchmark_model.py"
 }
 
 function run_tests {

--- a/test/benchmarks/test_benchmark_model.py
+++ b/test/benchmarks/test_benchmark_model.py
@@ -1,0 +1,18 @@
+import unittest
+
+from benchmark_model import BenchmarkModel
+
+
+class BenchmarkModelTest(unittest.TestCase):
+
+  def test_to_dict(self):
+    bm = BenchmarkModel("torchbench or other", "super_deep_model",
+                        "placeholder")
+    actual = bm.to_dict()
+    self.assertEqual(2, len(actual))
+    self.assertEqual("torchbench or other", actual["suite_name"])
+    self.assertEqual("super_deep_model", actual["model_name"])
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/test/benchmarks/test_experiment_runner.py
+++ b/test/benchmarks/test_experiment_runner.py
@@ -1,0 +1,53 @@
+from absl.testing import absltest
+import unittest
+
+import subprocess
+
+import experiment_runner
+import torch_xla.runtime as xr
+
+EXPERIMENT_RUNNER_PY = experiment_runner.__file__
+
+
+class ExperimentRunnerTest(unittest.TestCase):
+
+  def test_dummy_dry_run(self):
+    child = subprocess.run([
+        "python", EXPERIMENT_RUNNER_PY, "--dynamo=openxla", "--dynamo=inductor",
+        "--xla=PJRT", "--xla=None", "--test=eval", "--test=train",
+        "--suite-name=dummy", "--accelerator=cpu", "--dry-run"
+    ],
+                           capture_output=True,
+                           text=True)
+    expected_in_stderr = [
+        "Number of selected experiment configs: 2",
+        "Number of selected model configs: 1",
+        "'--experiment-config={\"accelerator\": \"cpu\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"test\": \"eval\"}', '--model-config={\"model_name\": \"dummy\"}'",
+        "'--experiment-config={\"accelerator\": \"cpu\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"test\": \"train\"}', '--model-config={\"model_name\": \"dummy\"}'",
+    ]
+    for expected in expected_in_stderr:
+      self.assertIn(expected, child.stderr)
+
+  @absltest.skipUnless(xr.device_type() in {'CUDA'}, 'Needs CUDA accelerator')
+  def test_dummy_dry_run_cuda(self):
+    child = subprocess.run([
+        "python", EXPERIMENT_RUNNER_PY, "--dynamo=openxla", "--dynamo=inductor",
+        "--xla=PJRT", "--xla=None", "--test=eval", "--test=train",
+        "--suite-name=dummy", "--accelerator=cuda", "--dry-run"
+    ],
+                           capture_output=True,
+                           text=True)
+    expected_in_stderr = [
+        "Number of selected experiment configs: 4",
+        "Number of selected model configs: 1",
+        "'--experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"test\": \"eval\"}', '--model-config={\"model_name\": \"dummy\"}'",
+        "'--experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"test\": \"eval\"}', '--model-config={\"model_name\": \"dummy\"}'",
+        "'--experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"test\": \"eval\"}', '--model-config={\"model_name\": \"dummy\"}'",
+        "'--experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"test\": \"train\"}', '--model-config={\"model_name\": \"dummy\"}'",
+    ]
+    for expected in expected_in_stderr:
+      self.assertIn(expected, child.stderr)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
The previous attempt at landing these tests (e.g. #6093) relied on torchbench, which is not available in the CI setup. Instead, rely on the dummy benchmarks.