### PR TITLE
Remove flaky test

### DIFF
--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -93,44 +93,6 @@ class ProfilerTest(unittest.TestCase):
     self._check_trace_namespace_exists(path)
     self._check_metrics_warnings_exist(self.fname)
 
-  def test_trace_detached(self):
-
-    port = xu.get_free_tcp_ports()[0]
-    training_started = multiprocessing.Event()
-    logdir = tempfile.mkdtemp()
-
-    def train_worker():
-      flags = args_parse.parse_common_options(
-          datadir='/tmp/mnist-data',
-          batch_size=16,
-          momentum=0.5,
-          lr=0.01,
-          num_epochs=10)
-      flags.fake_data = True
-      flags.profiler_port = port
-
-      # Set programmatic capture options
-      flags.profile_step = 10
-      flags.profile_epoch = 1
-      flags.profile_logdir = logdir
-      flags.profile_duration_ms = 5000
-
-      test_profile_mp_mnist.train_mnist(
-          flags,
-          training_started=training_started,
-          dynamic_graph=True,
-          fetch_often=True)
-
-    p = multiprocessing.Process(target=train_worker, daemon=True)
-    p.start()
-    training_started.wait(60)
-    # Delay to allow the profile to capture
-    time.sleep(10)
-    p.terminate()
-    path = self._check_xspace_pb_exist(logdir)
-    self._check_trace_namespace_exists(path)
-    self._check_metrics_warnings_exist(self.fname)
-
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)


### PR DESCRIPTION
It appears the test is still flaky after #6075. Since the critical tracing codepath is already covered in the `trace` test, let's just remove it for now.