### PR TITLE
Add comments in benchmark_experiment and generalize workaround for too long strings in `filename_str`

### DIFF
--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -4,7 +4,7 @@ import os
 import torch
 import torch._dynamo as dynamo
 import torch_xla.core.xla_model as xm
-from util import is_xla_device_available, get_accelerator_model
+from util import parse_none_str, is_xla_device_available, get_accelerator_model
 
 logger = logging.getLogger(__name__)
 
@@ -14,21 +14,9 @@ class ExperimentLoader:
   def __init__(self, args):
     self._args = args
 
-  def expand_config_choices(self, config_choices):
-    configs = [{}]
-
-    for key, choices in config_choices.items():
-      tmp_configs = []
-      for config in configs:
-        for choice in choices:
-          tmp_config = config.copy()
-          tmp_config[key] = choice
-          tmp_configs.append(tmp_config)
-      configs = tmp_configs
-
-    return configs
-
   def list_experiment_configs(self):
+
+    # Start with default config.
     config_choices = {
         "accelerator": ["cpu", "cuda", "tpu"],
         "xla": [None, "PJRT", "XRT"],
@@ -37,33 +25,44 @@ class ExperimentLoader:
         "test": ["eval", "train"],
     }
 
+    # Apply command line chocies.
     if self._args.accelerator:
       config_choices["accelerator"] = list(set(self._args.accelerator))
     if self._args.xla:
-      config_choices["xla"] = [
-          x if x != "None" else None for x in list(set(self._args.xla))
-      ]
+      config_choices["xla"] = list(map(parse_none_str, set(self._args.xla)))
     if self._args.dynamo:
-      config_choices["dynamo"] = [
-          x if x != "None" else None for x in list(set(self._args.dynamo))
-      ]
+      config_choices["dynamo"] = list(
+          map(parse_none_str, set(self._args.dynamo)))
     if self._args.test:
       config_choices["test"] = list(set(self._args.test))
     if self._args.xla_flags:
-      config_choices["xla_flags"] = [
-          x if x != "None" else None for x in list(set(self._args.xla_flags))
-      ]
+      config_choices["xla_flags"] = list(
+          map(parse_none_str, set(self._args.xla_flags)))
 
+    # Expand experiment configs and add env vars.
+    logger.info(f"Expand experiment configs:")
     experiment_configs = []
-    for experiment_config in self.expand_config_choices(config_choices):
-      if not self.is_available(experiment_config):
+    for cfg in self._expand_config_choices(config_choices):
+      if not self._is_available(cfg):
         continue
-
-      self._add_experiment_env(experiment_config)
-      experiment_configs.append(experiment_config)
+      logger.info(f"Experiment config (w/o env vars): {cfg}")
+      self._add_experiment_env(cfg)
+      experiment_configs.append(cfg)
     return experiment_configs
 
-  def is_available(self, experiment_config):
+  def _expand_config_choices(self, config_choices):
+    configs = [{}]
+    for k, choices in config_choices.items():
+      new_configs = []
+      for base_cfg in configs:
+        for c in choices:
+          new_cfg = base_cfg.copy()
+          new_cfg[k] = c
+          new_configs.append(new_cfg)
+      configs = new_configs
+    return configs
+
+  def _is_available(self, experiment_config):
     if experiment_config["dynamo"] and experiment_config[
         "dynamo"] not in dynamo.list_backends(exclude_tags=()):
       return False
@@ -88,50 +87,48 @@ class ExperimentLoader:
     return True
 
   def _add_experiment_env(self, experiment_config):
-    process_env = None
+    cfg_xla = experiment_config["xla"]
 
-    if experiment_config["xla"]:
-      # remove env vars that would interfere with subprocess settings
+    # Remove env vars that would interfere with the subprocess.
+    if cfg_xla is not None:
       os.environ.pop("PJRT_DEVICE", None)
       os.environ.pop("XRT_TPU_CONFIG", None)
       os.environ.pop("XLA_FLAGS", None)
 
     process_env = os.environ.copy()
-    if experiment_config["xla"] == "PJRT":
+    if cfg_xla == "PJRT":
       process_env["PJRT_DEVICE"] = experiment_config["accelerator"].upper()
-    elif experiment_config["xla"] == "XRT":
+    elif cfg_xla == "XRT":
       if is_xla_device_available("TPU"):
         process_env["TPU_NUM_DEVICES"] = "1"
         process_env["XRT_TPU_CONFIG"] = "localservice;0;localhost:51011"
       elif is_xla_device_available("CUDA"):
         process_env["GPU_NUM_DEVICES"] = "1"
-    elif not experiment_config["xla"] and is_xla_device_available(
-        experiment_config["accelerator"].upper()):
+    elif cfg_xla is None:
       # In non-xla CPU training experiments, an env var is still needed if an
       # xla device exists, or there will be "Missing XLA configuration" error.
-      process_env["PJRT_DEVICE"] = experiment_config["accelerator"].upper()
+      if is_xla_device_available(experiment_config["accelerator"].upper()):
+        process_env["PJRT_DEVICE"] = experiment_config["accelerator"].upper()
 
     if experiment_config["xla_flags"]:
       process_env["XLA_FLAGS"] = experiment_config["xla_flags"]
 
     experiment_config["process_env"] = process_env
 
-  def load_experiment(self, experiment_config, dummy=False):
+  def load_experiment(self, experiment_config):
     accelerator = experiment_config["accelerator"]
     xla = experiment_config["xla"]
     xla_flags = experiment_config["xla_flags"]
     dynamo = experiment_config["dynamo"]
     test = experiment_config["test"]
     batch_size = experiment_config.get("batch_size", self._args.batch_size)
-    benchmark_experiment = BenchmarkExperiment(
+    return BenchmarkExperiment(
         accelerator=accelerator,
         xla=xla,
         xla_flags=xla_flags,
         dynamo=dynamo,
         test=test,
         batch_size=batch_size)
-
-    return benchmark_experiment
 
 
 class BenchmarkExperiment:
@@ -147,25 +144,26 @@ class BenchmarkExperiment:
 
   def get_device(self):
     if self.xla:
-      device = xm.xla_device(devkind=self.accelerator.upper())
+      return xm.xla_device(devkind=self.accelerator.upper())
     elif self.accelerator == "cpu":
-      device = torch.device("cpu")
+      return torch.device("cpu")
     elif self.accelerator == "cuda":
-      device = torch.device("cuda")
+      return torch.device("cuda")
     else:
       raise NotImplementedError
 
-    return device
-
   @property
   def filename_str(self):
-    d = self.to_dict()
 
-    # Remove these 2 components that may end up making the filename too big.
-    d.pop("accelerator_model", None)
-    d.pop("xla_flags", None)
+    def to_short_string(x):
+      max_len = 32
+      s = str(x)
+      if len(s) > max_len:
+        s = str(hex(hash(s)))
+      return s
 
-    return "-".join(str(v) for v in self.to_dict().values()).replace(" ", "")
+    short_strs = map(to_short_string, self.to_dict().values())
+    return "-".join(short_strs).replace(" ", "")
 
   def to_dict(self):
     d = OrderedDict()

--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -83,7 +83,7 @@ class ExperimentRunner:
           experiment_config_str = json.dumps(experiment_config)
           model_config_str = json.dumps(model_config)
           dummy_benchmark_experiment = self.experiment_loader.load_experiment(
-              experiment_config, dummy=True)
+              experiment_config)
           dummy_benchmark_model = self.model_loader.load_model(
               model_config, dummy_benchmark_experiment, dummy=True)
           experiment_config["process_env"] = process_env

--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -14,6 +14,12 @@ from torch_xla._internal import tpu
 logger = logging.getLogger(__name__)
 
 
+def parse_none_str(a: str):
+  if isinstance(a, str) and a.upper() == "None".upper():
+    return None
+  return a
+
+
 @functools.lru_cache(None)
 def patch_torch_manual_seed():
   """Make torch manual seed deterministic. Helps with accuracy testing."""


### PR DESCRIPTION
`filename_str` ignored `accelerator_model` and `xla_flags`, which will likely cause silent problems when running experiments comparing different flag combinations. To avoid long filenames, which is why flags were not included, we use a hash instead. This also generalized to all properties listed in the configs.