### PR TITLE
Deprecate explicit shape promotion in PyTorch/XLA

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -199,6 +199,7 @@ function run_xla_op_tests3 {
   #     CI with tf.
   run_xla_hlo_debug "$CDIR/stablehlo/test_stablehlo_inference.py"
   run_stablehlo_compile "$CDIR/stablehlo/test_stablehlo_compile.py"
+  run_stablehlo_compile "$CDIR/stablehlo/test_implicit_broadcasting.py"
   run_test "$CDIR/spmd/test_xla_sharding.py"
   run_test "$CDIR/spmd/test_xla_sharding_hlo.py"
   run_test "$CDIR/spmd/test_xla_virtual_device.py"

--- a/test/stablehlo/test_implicit_broadcasting.py
+++ b/test/stablehlo/test_implicit_broadcasting.py
@@ -1,0 +1,48 @@
+import re
+import sys
+import unittest
+
+import torch
+import torch_xla
+from torch_xla.core import xla_model as xm
+from typing import Tuple, Type, Callable, Union, List
+
+# The following tests cover the implcit-broadcasting for static and bounded
+# dynamic shapes.
+
+device = xm.xla_device()
+
+
+class ImplicitBroadcasting(unittest.TestCase):
+
+  def test_same_rank_broadcast(self):
+    a = torch.randn((10, 1)).to(device=device)
+    b = torch.randn((1, 5)).to(device=device)
+    c = a * b
+    stablehlo_text = xm.get_stablehlo([c])
+    self.assertTrue(
+        re.search(r'stablehlo.multiply.* : tensor<10x5xf32>', stablehlo_text)
+        is not None)
+
+  def test_scalar_broadcast(self):
+    a = torch.randn(()).to(device=device)
+    b = torch.randn((1, 5)).to(device=device)
+    c = a * b
+    stablehlo_text = xm.get_stablehlo([c])
+    self.assertTrue(
+        re.search(r'stablehlo.multiply.* : tensor<1x5xf32>', stablehlo_text)
+        is not None)
+
+  def test_different_rank_broadcast(self):
+    a = torch.randn((10, 1)).to(device=device)
+    b = torch.randn((6, 8, 1, 5)).to(device=device)
+    c = a * b
+    stablehlo_text = xm.get_stablehlo([c])
+    self.assertTrue(
+        re.search(r'stablehlo.multiply.* : tensor<6x8x10x5xf32>',
+                  stablehlo_text) is not None)
+
+
+if __name__ == '__main__':
+  test = unittest.main()
+  sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/torch_xla/csrc/convolution.cpp
+++ b/torch_xla/csrc/convolution.cpp
@@ -349,7 +349,9 @@ xla::XlaOp BuildConvolutionOverrideableBias(
       xla::Transpose(xla::Broadcast(bias, broadcast_sizes),
                      BiasTransposePermutation(broadcast_sizes.size() + 1));
   auto promoted = XlaHelpers::Promote(conv, bias_broadcast);
-  return promoted.first + promoted.second;
+  return xla::Add(
+      promoted.first, promoted.second,
+      XlaHelpers::getBroadcastDimensions(promoted.first, promoted.second));
 }
 
 ConvGrads BuildConvolutionBackwardOverrideable(

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -35,17 +35,17 @@ xla::XlaOp BuildComparisonOp(c10::Symbol kind, xla::XlaOp lhs, xla::XlaOp rhs) {
   std::tie(lhs, rhs) = XlaHelpers::Promote(lhs, rhs);
   switch (kind) {
     case at::aten::ne:
-      return xla::Ne(lhs, rhs);
+      return xla::Ne(lhs, rhs, XlaHelpers::getBroadcastDimensions(lhs, rhs));
     case at::aten::eq:
-      return xla::Eq(lhs, rhs);
+      return xla::Eq(lhs, rhs, XlaHelpers::getBroadcastDimensions(lhs, rhs));
     case at::aten::ge:
-      return xla::Ge(lhs, rhs);
+      return xla::Ge(lhs, rhs, XlaHelpers::getBroadcastDimensions(lhs, rhs));
     case at::aten::le:
-      return xla::Le(lhs, rhs);
+      return xla::Le(lhs, rhs, XlaHelpers::getBroadcastDimensions(lhs, rhs));
     case at::aten::gt:
-      return xla::Gt(lhs, rhs);
+      return xla::Gt(lhs, rhs, XlaHelpers::getBroadcastDimensions(lhs, rhs));
     case at::aten::lt:
-      return xla::Lt(lhs, rhs);
+      return xla::Lt(lhs, rhs, XlaHelpers::getBroadcastDimensions(lhs, rhs));
     default:
       XLA_ERROR() << "Invalid comparison operator kind: "
                   << kind.toQualString();
@@ -73,7 +73,9 @@ xla::XlaOp BuildRelu(xla::XlaOp input) {
     // xla::Max doesn't do implicit broadcasting for unbounded dynamism now.
     // TODO(lsy323): Remove this branch once the support is added in XLA.
     auto promoted = XlaHelpers::Promote(input, scalar);
-    return xla::Max(promoted.first, promoted.second);
+    return xla::Max(
+        promoted.first, promoted.second,
+        XlaHelpers::getBroadcastDimensions(promoted.first, promoted.second));
   } else {
     return xla::Max(input, scalar);
   }

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -55,14 +55,19 @@ namespace torch_xla {
                             const torch::lazy::Value& input1) {                \
     auto shape_fn = [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp { \
       auto promoted = XlaHelpers::Promote(operands[0], operands[1]);           \
-      return xla_fn(promoted.first, promoted.second);                          \
+      return xla_fn(promoted.first, promoted.second,                           \
+                    XlaHelpers::getBroadcastDimensions(promoted.first,         \
+                                                       promoted.second));      \
     };                                                                         \
     auto lower_fn = [](const XlaNode& node,                                    \
                        LoweringContext* loctx) -> XlaOpVector {                \
       xla::XlaOp xla_input0 = loctx->GetOutputOp(node.operand(0));             \
       xla::XlaOp xla_input1 = loctx->GetOutputOp(node.operand(1));             \
       auto promoted = XlaHelpers::Promote(xla_input0, xla_input1);             \
-      return node.ReturnOp(xla_fn(promoted.first, promoted.second), loctx);    \
+      return node.ReturnOp(xla_fn(promoted.first, promoted.second,             \
+                                  XlaHelpers::getBroadcastDimensions(          \
+                                      promoted.first, promoted.second)),       \
+                           loctx);                                             \
     };                                                                         \
     return GenericOp(torch::lazy::OpKind(sym), {input0, input1},               \
                      [&]() {                                                   \
@@ -408,7 +413,7 @@ torch::lazy::NodePtr Where(const torch::lazy::Value& condition,
     xla::XlaOp pred_condition =
         ConvertTo(xla_condition, XlaHelpers::TypeOfXlaOp(xla_condition),
                   xla::PrimitiveType::PRED, /*device=*/nullptr);
-    auto promoted_branches = XlaHelpers::PromoteShapes(xla_input, xla_other);
+    auto promoted_branches = XlaHelpers::ValidateShapes(xla_input, xla_other);
     return node.ReturnOp(xla::Select(pred_condition, promoted_branches.first,
                                      promoted_branches.second),
                          loctx);

--- a/torch_xla/csrc/reduction.cpp
+++ b/torch_xla/csrc/reduction.cpp
@@ -86,7 +86,9 @@ xla::XlaOp GetScaleValue(xla::XlaOp input, xla::XlaOp count,
     // XLA Multiply doesn't do implicit broadcasting for unbounded dynamism now.
     // TODO(lsy323): Remove this branch once the support is added in XLA.
     auto promoted = XlaHelpers::Promote(input, scale);
-    return promoted.first * promoted.second;
+    return xla::Mul(
+        promoted.first, promoted.second,
+        XlaHelpers::getBroadcastDimensions(promoted.first, promoted.second));
   } else {
     return input * scale;
   }


### PR DESCRIPTION
## Proposal
Currently, both PyTorch/XLA and XLA handle implicit broadcasting for static/bounded-dynamic shapes. The implicit broadcasting in PyTorch/XLA’s codebase is not uniform: sometimes rely on their own implementation and sometimes on XLA’s implementation. The goal of this document is to investigate removal of implicit-broadcasting support in PyTorch/XLA so as to have a single source of truth in XLA.

## Current state of Broadcasting in PyTorch/XLA vs XLA
Implicit broadcasting, for static and bounded dynamic dimensions, are supported in both PyTorch/XLA and XLA codebase. 

### PyTorch/XLA
[XlaHelpers::Promote](https://github.com/pytorch/xla/blob/b0e7f1b32dfb9776c384eb3e9e1143776f64df75/torch_xla/csrc/helpers.cpp#L632) is used to do the implicit broadcasting using the following utility functions.
  - [torch::lazy::core::GetPromotedShape(shape1, shape2)](https://github.com/pytorch/pytorch/blob/d65e067baa2ef224444e180594c4882b5a55efde/torch/csrc/lazy/core/helpers.cpp#L81) 
  - [XlaHelpers::ImplicitBroadcast(op, op_shape, shape)](https://github.com/pytorch/xla/blob/65cd101f76100bb840bbb199180244055a93ffed/torch_xla/csrc/helpers.cpp#L580) broadcasts op to promote its shape op_shape to final shape determined by the above function. 


However, the handling of implicit broadcasting in PyTorch/XLA codebase is not uniform: some are explicit (e.g. [max](https://github.com/pytorch/xla/blob/2c6e4a773cc70cdea3c606d410b3aef8f7dfb6f7/torch_xla/csrc/ops/ops_lower_fn.cpp#L555) and [arith](https://github.com/pytorch/pytorch/blob/main/torch/csrc/lazy/core/ops/arithmetic_ir_ops.cpp) via XlaHelpers::Promote), while others rely on XlaBuilder’s implicit broadcasting (e.g. in [Relu](https://github.com/pytorch/xla/blob/65cd101f76100bb840bbb199180244055a93ffed/torch_xla/csrc/elementwise.cpp#L69) xla::Max is called without any promotion).

### XLA
HLO currently handles implicit broadcasting for [binary operations](https://github.com/openxla/xla/blob/ff74e9395fb7ec7c8151122ad5e1e56df40fccf4/xla/client/xla_builder.cc#L957), [ternary operation](https://github.com/openxla/xla/blob/ff74e9395fb7ec7c8151122ad5e1e56df40fccf4/xla/client/xla_builder.cc#L1067), and [map](https://github.com/openxla/xla/blob/ff74e9395fb7ec7c8151122ad5e1e56df40fccf4/xla/client/xla_builder.cc#L2569) for static shapes and bounded dynamic shapes in three steps:
   - Extend the rank of the lower ranked operand to the higher ranked operand following the rules defined in [InferInDimBroadcastShape](https://github.com/openxla/xla/blob/ff74e9395fb7ec7c8151122ad5e1e56df40fccf4/xla/service/shape_inference.cc#L871).
  - Broadcast the degenerate dimension to determine the final shape in [InferDegenerateDimensionBroadcastShape](https://github.com/openxla/xla/blob/ff74e9395fb7ec7c8151122ad5e1e56df40fccf4/xla/service/shape_inference.cc#L806).
  - Introduce broadcast and reshape ops to promote the initial operand into the broadcasted final shape in [XlaBuilder::AddBroadcastSequence](https://github.com/openxla/xla/blob/ff74e9395fb7ec7c8151122ad5e1e56df40fccf4/xla/client/xla_builder.cc#L897).

**Here are some important points to note**

1. Currently, PyTorch/XLA calls `XlaHelpers::Promote` before calling the XLaBuilder APIs, for broadcastable operations, ensuring the operands shapes are already promoted and thereby preventing the XLA’s support for implicit broadcasting unexercised.
2. Current both PyTorch/XLA and XLA support "same rank broadcasting" and "scalar broadcasting" with identical semantics (refer to [Appendix](#appendix) for more information). For "different rank broadcasting" XLA explicitly needs a `broadcasting_dimension` specification (refer to [xla-broadcasting-principles](https://www.tensorflow.org/xla/broadcasting#principles)). 

## Design Proposal

Given that the HLO/StableHLO emitted via implicit broadcasting in PyTorch/XLA and XLA are semantically identical (refer to [Appendix](#appendix)), we propose to handle broadcasting only in XLA with the following changes
  - Prevent `XlaHelpers::PromoteShapes` to do implicit broadcasting.
  - Update each call site of  `XlaHelpers::Promote` such that the following XLA client API calls (like xla::Min, xla::Atan2 etc.) accept broadcasting dimensions. 
    - Given that PyTorch supports numpy based implicit-broadcasting [rules](https://github.com/pytorch/xla/blob/e1fe4836792e6cf024a731451fa3e280d50a68f6/torch_xla/csrc/helpers.cpp#L655), it is possible to derive the broadcast_dimensions just using the operand shapes.
```cpp
std::vector<int64_t> XlaHelpers::getBroadcastDimensions(xla::XlaOp op1,
                                                        xla::XlaOp op2) {
  const xla::Shape& shape1 = ShapeHelper::ShapeOfXlaOp(op1);
  const xla::Shape& shape2 = ShapeHelper::ShapeOfXlaOp(op2);
  if (shape1.rank() == 0 || shape2.rank() == 0 ||
      shape1.rank() == shape2.rank())
    return {};

  std::vector<int64_t> broadcast_dimensions(
      shape1.rank() <= shape2.rank() ? shape1.rank() : shape2.rank());
  std::iota(broadcast_dimensions.begin(), broadcast_dimensions.end(),
            std::abs(shape1.rank() - shape2.rank()));
  return broadcast_dimensions;
}
```

## Appendix

### Examples demonstrating the current state
Next we demonstrate the current state of implicit broadcasting in PyTorch/XLA and XLA codebase. To extract the XLA behavior we need to bypass the implicit broadcasting in PyTorch/XLA code using the [patch](https://github.com/pytorch/xla/pull/5945/files). 

#### Same rank broadcasting
##### PyTorch code
```python
import torch
import torch_xla
from torch_xla.core import xla_model as xm
from typing import Tuple, Type, Callable, Union, List

device = xm.xla_device()

## multiply (same axis dynamic)
a = torch.randn((10,1)).to(device=device)
b = torch.randn((1, 5)).to(device=device)


c = a * b
hlo_content = torch_xla._XLAC._get_xla_tensors_hlo([c])
print(hlo_content)
print(xm.get_stablehlo([c]))
```

##### Broadcasting via PyTorch/XLA

```cpp
//HLO
HloModule IrToHlo.11, entry_computation_layout={(f32[1,5]{1,0}, f32[10,1]{1,0})->(f32[10,5]{1,0})}

ENTRY %IrToHlo.11 (p0.1: f32[1,5], p1.2: f32[10,1]) -> (f32[10,5]) {
  %p1.2 = f32[10,1]{1,0} parameter(1)
  %broadcast.6 = f32[10,1]{1,0} broadcast(f32[10,1]{1,0} %p1.2), dimensions={0,1}
  %reshape.7 = f32[10]{0} reshape(f32[10,1]{1,0} %broadcast.6)
  %broadcast.8 = f32[10,5]{1,0} broadcast(f32[10]{0} %reshape.7), dimensions={0}
  %p0.1 = f32[1,5]{1,0} parameter(0)
  %broadcast.3 = f32[1,5]{1,0} broadcast(f32[1,5]{1,0} %p0.1), dimensions={0,1}
  %reshape.4 = f32[5]{0} reshape(f32[1,5]{1,0} %broadcast.3)
  %broadcast.5 = f32[10,5]{1,0} broadcast(f32[5]{0} %reshape.4), dimensions={1}
  %multiply.9 = f32[10,5]{1,0} multiply(f32[10,5]{1,0} %broadcast.8, f32[10,5]{1,0} %broadcast.5)
  ROOT %tuple.10 = (f32[10,5]{1,0}) tuple(f32[10,5]{1,0} %multiply.9)
}

// Stablehlo
module @IrToHlo.11 attributes {mhlo.cross_program_prefetches = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
  func.func @main(%arg0: tensor<1x5xf32>, %arg1: tensor<10x1xf32>) -> tensor<10x5xf32> {
    %0 = stablehlo.reshape %arg1 : (tensor<10x1xf32>) -> tensor<10xf32>
    %1 = stablehlo.broadcast_in_dim %0, dims = [0] : (tensor<10xf32>) -> tensor<10x5xf32>
    %2 = stablehlo.reshape %arg0 : (tensor<1x5xf32>) -> tensor<5xf32>
    %3 = stablehlo.broadcast_in_dim %2, dims = [1] : (tensor<5xf32>) -> tensor<10x5xf32>
    %4 = stablehlo.multiply %1, %3 : tensor<10x5xf32>
    return %4 : tensor<10x5xf32>
  }
}
```

##### Broadcasting via XLA
```cpp
//HLO
HloModule IrToHlo.9, entry_computation_layout={(f32[1,5]{1,0}, f32[10,1]{1,0})->(f32[10,5]{1,0})}

ENTRY %IrToHlo.9 (p0.1: f32[1,5], p1.2: f32[10,1]) -> (f32[10,5]) {
  %p1.2 = f32[10,1]{1,0} parameter(1)
  %reshape.3 = f32[10]{0} reshape(f32[10,1]{1,0} %p1.2)
  %broadcast.4 = f32[10,5]{1,0} broadcast(f32[10]{0} %reshape.3), dimensions={0}
  %p0.1 = f32[1,5]{1,0} parameter(0)
  %reshape.5 = f32[5]{0} reshape(f32[1,5]{1,0} %p0.1)
  %broadcast.6 = f32[10,5]{1,0} broadcast(f32[5]{0} %reshape.5), dimensions={1}
  %multiply.7 = f32[10,5]{1,0} multiply(f32[10,5]{1,0} %broadcast.4, f32[10,5]{1,0} %broadcast.6)
  ROOT %tuple.8 = (f32[10,5]{1,0}) tuple(f32[10,5]{1,0} %multiply.7)
}

// Stablehlo
Same as above
```

#### Scalar Broadcasting

##### PyTorch code
```python
import torch
import torch_xla
from torch_xla.core import xla_model as xm
from typing import Tuple, Type, Callable, Union, List

device = xm.xla_device()

## multiply (same axis dynamic)
a = torch.randn(()).to(device=device)
b = torch.randn((1, 5)).to(device=device)


c = a * b
hlo_content = torch_xla._XLAC._get_xla_tensors_hlo([c])
print(hlo_content)
print(xm.get_stablehlo([c]))
```

##### Broadcasting via PyTorch/XLA 
```cpp
//HLO
HloModule IrToHlo.6, entry_computation_layout={(f32[1,5]{1,0}, f32[])->(f32[1,5]{1,0})}

ENTRY %IrToHlo.6 (p0.1: f32[1,5], p1.2: f32[]) -> (f32[1,5]) {
  %p1.2 = f32[] parameter(1)
  %broadcast.3 = f32[1,5]{1,0} broadcast(f32[] %p1.2), dimensions={}
  %p0.1 = f32[1,5]{1,0} parameter(0)
  %multiply.4 = f32[1,5]{1,0} multiply(f32[1,5]{1,0} %broadcast.3, f32[1,5]{1,0} %p0.1)
  ROOT %tuple.5 = (f32[1,5]{1,0}) tuple(f32[1,5]{1,0} %multiply.4)
}

// Stablehlo
module @IrToHlo.6 attributes {mhlo.cross_program_prefetches = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
  func.func @main(%arg0: tensor<1x5xf32>, %arg1: tensor<f32>) -> tensor<1x5xf32> {
    %0 = stablehlo.broadcast_in_dim %arg1, dims = [] : (tensor<f32>) -> tensor<1x5xf32>
    %1 = stablehlo.multiply %0, %arg0 : tensor<1x5xf32>
    return %1 : tensor<1x5xf32>
  }
}
```

##### Broadcasting via XLA
```cpp
//HLO
// same as above

// Stablehlo
Same as above
```

#### Different rank broadcasting

##### Pytorch code
```python
import torch
import torch_xla
from torch_xla.core import xla_model as xm
from typing import Tuple, Type, Callable, Union, List

device = xm.xla_device()

## multiply (same axis dynamic)
a = torch.randn((10,1)).to(device=device)
b = torch.randn((6, 8, 1, 5)).to(device=device)
c = a * b
hlo_content = torch_xla._XLAC._get_xla_tensors_hlo([c])
print(hlo_content)
print(xm.get_stablehlo([c]))
```

##### Broadcasting via PyTorch/XLA 

```cpp
// HLO
HloModule IrToHlo.12, entry_computation_layout={(f32[6,8,1,5]{3,2,1,0}, f32[10,1]{1,0})->(f32[6,8,10,5]{3,2,1,0})}

ENTRY %IrToHlo.12 (p0.1: f32[6,8,1,5], p1.2: f32[10,1]) -> (f32[6,8,10,5]) {
  %p1.2 = f32[10,1]{1,0} parameter(1)
  %broadcast.6 = f32[10,1]{1,0} broadcast(f32[10,1]{1,0} %p1.2), dimensions={0,1}
  %reshape.7 = f32[10]{0} reshape(f32[10,1]{1,0} %broadcast.6)
  %broadcast.8 = f32[10,5]{1,0} broadcast(f32[10]{0} %reshape.7), dimensions={0}
  %broadcast.9 = f32[6,8,10,5]{3,2,1,0} broadcast(f32[10,5]{1,0} %broadcast.8), dimensions={2,3}
  %p0.1 = f32[6,8,1,5]{3,2,1,0} parameter(0)
  %broadcast.3 = f32[6,8,1,5]{3,2,1,0} broadcast(f32[6,8,1,5]{3,2,1,0} %p0.1), dimensions={0,1,2,3}
  %reshape.4 = f32[6,8,5]{2,1,0} reshape(f32[6,8,1,5]{3,2,1,0} %broadcast.3)
  %broadcast.5 = f32[6,8,10,5]{3,2,1,0} broadcast(f32[6,8,5]{2,1,0} %reshape.4), dimensions={0,1,3}
  %multiply.10 = f32[6,8,10,5]{3,2,1,0} multiply(f32[6,8,10,5]{3,2,1,0} %broadcast.9, f32[6,8,10,5]{3,2,1,0} %broadcast.5)
  ROOT %tuple.11 = (f32[6,8,10,5]{3,2,1,0}) tuple(f32[6,8,10,5]{3,2,1,0} %multiply.10)
}

// Stablehlo
module @IrToHlo.12 attributes {mhlo.cross_program_prefetches = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
  func.func @main(%arg0: tensor<6x8x1x5xf32>, %arg1: tensor<10x1xf32>) -> tensor<6x8x10x5xf32> {
    %0 = stablehlo.reshape %arg1 : (tensor<10x1xf32>) -> tensor<10xf32>
    %1 = stablehlo.broadcast_in_dim %0, dims = [2] : (tensor<10xf32>) -> tensor<6x8x10x5xf32>
    %2 = stablehlo.reshape %arg0 : (tensor<6x8x1x5xf32>) -> tensor<6x8x5xf32>
    %3 = stablehlo.broadcast_in_dim %2, dims = [0, 1, 3] : (tensor<6x8x5xf32>) -> tensor<6x8x10x5xf32>
    %4 = stablehlo.multiply %1, %3 : tensor<6x8x10x5xf32>
    return %4 : tensor<6x8x10x5xf32>
  }
}
```

##### Broadcasting via XLA
XLA [fails](https://github.com/openxla/xla/blob/ea69d22e9fc3545d9582a14eac42e2d9d75127d3/xla/service/shape_inference.cc#L887) as `broadcast_dimensions` has to be specified when ranks are different. 