### PR TITLE
Extract fingerprinting for experiment and model config

### DIFF
--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -41,7 +41,7 @@ def reset_rng_state(benchmark_experiment=None):
   torch.manual_seed(1337)
   random.seed(1337)
   np.random.seed(1337)
-  if benchmark_experiment and benchmark_experiment.xla:
+  if benchmark_experiment is not None and benchmark_experiment.xla is not None:
     device = benchmark_experiment.get_device()
     xm.set_rng_state(1337, str(device))
 


### PR DESCRIPTION
Extract fingerprinting, into a function, which was anonymously implemented in two places before. This is used to resume benchmarking from where it stopped. Configurations are identified by their fingerprint.

Clearly distinguish between the subprocess and the main process in the code, trying to make it more readable. 
