### PR TITLE
Revert "Fix model initialization. (#6076)"

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -5,8 +5,10 @@ import os
 from os.path import abspath, exists
 import sys
 import torch
-import torch.utils._pytree as pytree
-from torch._dynamo.testing import reduce_to_scalar_loss
+import torch.nn as nn
+from torch._dynamo.testing import collect_results, reduce_to_scalar_loss
+from torch._dynamo.utils import clone_inputs
+import types
 from util import move_to_device, set_cwd
 from benchmark_model import ModelLoader, BenchmarkModel
 
@@ -141,6 +143,7 @@ class TorchBenchModelLoader(ModelLoader):
             break
         if matched:
           return False
+
     return True
 
 
@@ -172,23 +175,20 @@ class TorchBenchModel(BenchmarkModel):
     # workaround "RuntimeError: not allowed to set torch.backends.cudnn flags"
     # torch.backends.__allow_nonbracketed_mutation_flag = True
 
+    if self.benchmark_experiment.accelerator == "cpu":
+      device = "cpu"
+    elif self.benchmark_experiment.accelerator == "cuda" and not self.benchmark_experiment.xla:
+      device = "cuda"
+    else:
+      device = str(self.benchmark_experiment.get_device())
+
     benchmark = benchmark_cls(
         test=self.benchmark_experiment.test,
-        device=self.benchmark_experiment.accelerator,
+        device=device,
         batch_size=self.benchmark_experiment.batch_size,
     )
 
     self.module, self.example_inputs = benchmark.get_module()
-
-    # Move the initialized model to XLA device.
-    if self.benchmark_experiment.xla:
-      device = self.benchmark_experiment.get_device()
-      self.module = self.module.to(device)
-      self.example_inputs = pytree.tree_map_only(torch.Tensor,
-                                                 lambda t: t.to(device),
-                                                 self.example_inputs)
-      self.apply_default_precision_config(self.benchmark_experiment.test,
-                                          benchmark)
 
     self.benchmark_experiment.batch_size = benchmark.batch_size
 


### PR DESCRIPTION
This reverts commit 7786d5dfe92bf4d2ab97989916b8c353a414b52a.

`python benchmarks/experiment_runner.py --dynamo=openxla --dynamo=openxla_eval --dynamo=inductor --xla=PJRT --xla=None --test=eval --test=train --suite-name=torchbench --accelerator=cuda  --filter=^alexnet$  --no-resume` fails for openxla benchmarks.