### PR TITLE
Set SPMD mode earlier in sharding tests

### DIFF
--- a/test/spmd/test_dtensor_integration.py
+++ b/test/spmd/test_dtensor_integration.py
@@ -19,7 +19,6 @@ class DTensorIntegrationTest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    xr.use_spmd()
     super().setUpClass()
 
   def test_xla_distribute_tensor(self):
@@ -77,5 +76,6 @@ class DTensorIntegrationTest(test_xla_sharding_base.XlaShardingTest):
 
 
 if __name__ == '__main__':
+  xr.use_spmd()
   test = unittest.main()
   sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/spmd/test_dynamo_spmd.py
+++ b/test/spmd/test_dynamo_spmd.py
@@ -40,7 +40,6 @@ class DynamoSpmdInferenceTest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    xr.use_spmd()
     super().setUpClass()
 
   def test_dynamo_spmd_basic(self):
@@ -230,5 +229,6 @@ class DynamoSpmdInferenceTest(test_xla_sharding_base.XlaShardingTest):
 
 
 if __name__ == '__main__':
+  xr.use_spmd()
   test = unittest.main()
   sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -25,7 +25,6 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    xr.use_spmd()
     super().setUpClass()
 
   @unittest.skipIf(
@@ -805,5 +804,6 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     assert output == fake_output
 
 if __name__ == '__main__':
+  xr.use_spmd()
   test = unittest.main()
   sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/spmd/test_spmd_graph_dump.py
+++ b/test/spmd/test_spmd_graph_dump.py
@@ -18,7 +18,6 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    xr.use_spmd()
     super().setUpClass()
 
   def test_dump_with_output_sharding(self):
@@ -49,5 +48,6 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
 
 
 if __name__ == '__main__':
+  xr.use_spmd()
   test = unittest.main()
   sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/spmd/test_train_spmd_imagenet.py
+++ b/test/spmd/test_train_spmd_imagenet.py
@@ -369,6 +369,7 @@ def train_imagenet():
 
 
 if __name__ == '__main__':
+  xr.use_spmd()
   if FLAGS.profile:
     server = xp.start_server(FLAGS.profiler_port)
 

--- a/test/spmd/test_train_spmd_linear_model.py
+++ b/test/spmd/test_train_spmd_linear_model.py
@@ -14,6 +14,8 @@ from torch_xla.distributed.spmd import Mesh
 import torch.optim as optim
 from torch import nn
 
+xr.use_spmd()
+
 MODEL_OPTS = {
     '--sharding': {
         'choices': ['batch', 'megatron-lm', 'fsdp'],

--- a/test/spmd/test_xla_distributed_checkpoint.py
+++ b/test/spmd/test_xla_distributed_checkpoint.py
@@ -41,7 +41,6 @@ class DistributedCheckpointTestBase(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    xr.use_spmd()
     super().setUpClass()
 
   def _get_sharded_model(self, mesh_shape=None):
@@ -563,5 +562,6 @@ class CheckpointManagerTest(DistributedCheckpointTestBase):
 
 
 if __name__ == '__main__':
+  xr.use_spmd()
   test = unittest.main()
   sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -28,7 +28,6 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    xr.use_spmd()
     super().setUpClass()
 
   def test_xla_sharded_tensor(self):
@@ -1086,5 +1085,6 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
 
 
 if __name__ == '__main__':
+  xr.use_spmd()
   test = unittest.main()
   sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/spmd/test_xla_sharding_hlo.py
+++ b/test/spmd/test_xla_sharding_hlo.py
@@ -18,7 +18,6 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    xr.use_spmd()
     super().setUpClass()
 
   @patch.dict(os.environ, {"XLA_DUMP_POST_OPTIMIZATIONS": "1"})
@@ -34,5 +33,6 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
 
 
 if __name__ == '__main__':
+  xr.use_spmd()
   test = unittest.main()
   sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/spmd/test_xla_spmd_python_api_interaction.py
+++ b/test/spmd/test_xla_spmd_python_api_interaction.py
@@ -17,7 +17,6 @@ class BasicXMAPITest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    xr.use_spmd()
     super().setUpClass()
 
   def test_get_xla_supported_devices(self):
@@ -148,5 +147,6 @@ class BasicDistributedTest(test_xla_sharding_base.XlaShardingTest):
 
 
 if __name__ == '__main__':
+  xr.use_spmd()
   test = unittest.main()
   sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/spmd/test_xla_virtual_device.py
+++ b/test/spmd/test_xla_virtual_device.py
@@ -17,7 +17,6 @@ class VirtualDeviceTest(test_xla_sharding_base.XlaShardingTest):
 
   @classmethod
   def setUpClass(cls):
-    xr.use_spmd()
     super().setUpClass()
 
   def test_mark_sharding(self):
@@ -169,5 +168,6 @@ class VirtualDeviceTest(test_xla_sharding_base.XlaShardingTest):
 
 
 if __name__ == '__main__':
+  xr.use_spmd()
   test = unittest.main()
   sys.exit(0 if test.result.wasSuccessful() else 1)


### PR DESCRIPTION
Hashing the compilation env in the CompuationClient constructor means that we must lock in SPMD mode before initializing the runtime.

That change breaks our unit tests, which only set SPMD mode in `setUpClass`, sometimes occurring after the runtime is initialized.