### PR TITLE
Don't explcitly include virtual device in hash

### DIFF
--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -89,8 +89,6 @@ torch::lazy::hash_t hash_comp_env(
     std::shared_ptr<xla::PjRtClient> client,
     std::vector<xla::PjRtDevice*>& ordered_devices) {
   torch::lazy::hash_t hash = hash::HashXlaEnvVars();
-  // Whether or not SPMD mode is active should influence the hash.
-  hash = torch::lazy::HashCombine(hash, UseVirtualDevice());
   auto topology_desc = client->GetTopologyDescription();
   if (topology_desc.ok()) {
     // Some backends support a topology description which provides a better
@@ -244,6 +242,7 @@ PjRtComputationClient::PjRtComputationClient() {
     std::string device_str = PjRtDeviceToString(device);
     string_to_device_.emplace(device_str, device);
   }
+  comp_env_hash_ = hash_comp_env(client_, ordered_devices);
 
   auto tracked_devices = GetLocalDevices();
   tracked_devices.emplace_back(spmd_device_str);

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -575,6 +575,8 @@ XLAGraphExecutor::SyncTensorCollection XLAGraphExecutor::CollectSyncTensors(
   // hash.
   coll.hash = torch::lazy::HashCombine(
       coll.hash, runtime::GetComputationClient()->HashCompilationEnv());
+  // Whether or not SPMD mode is active should influence the hash.
+  coll.hash = torch::lazy::HashCombine(coll.hash, UseVirtualDevice());
   coll.hash =
       torch::lazy::HashCombine(coll.hash, torch::lazy::StringHash(XLA_GITREV));
   coll.config = config;

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -575,8 +575,6 @@ XLAGraphExecutor::SyncTensorCollection XLAGraphExecutor::CollectSyncTensors(
   // hash.
   coll.hash = torch::lazy::HashCombine(
       coll.hash, runtime::GetComputationClient()->HashCompilationEnv());
-  // Whether or not SPMD mode is active should influence the hash.
-  coll.hash = torch::lazy::HashCombine(coll.hash, UseVirtualDevice());
   coll.hash =
       torch::lazy::HashCombine(coll.hash, torch::lazy::StringHash(XLA_GITREV));
   coll.config = config;


### PR DESCRIPTION
As attempted in #6140, this addresses an issue where the compilation env hash was never initialized. However, this change decouples the virtual device initialization logic from the runtime, allowing `xr.use_spmd` to be called after the runtime has been initialized, which won't break the unit tests.