### PR TITLE
[SPMD] Add a test case for mark_shard scalar tensors

### DIFF
--- a/torch_xla/distributed/spmd/xla_sharding.py
+++ b/torch_xla/distributed/spmd/xla_sharding.py
@@ -111,6 +111,12 @@ class Mesh:
     Return the OpSharding for the given partition spec. This is an expensive
     operation as the mesh grows, so the value is cached for reuse.
     """
+    # For scalar tensors, it can only be replicated.
+    # We have made sure len(t.shape) == len(partition_spec)
+    # in mark_sharding API.
+    if len(partition_spec) == 0:
+      return torch_xla._XLAC.OpSharding([], [], [], ShardingType.REPLICATED)
+
     tile_assignment, group_assignment, replication_groups, sharding_type = self._get_op_sharding_args(
         partition_spec)
     return torch_xla._XLAC.OpSharding(tile_assignment, group_assignment,


### PR DESCRIPTION
Summary:
Support mark_shard scalar tensors.

Test Plan:
python test/spmd/test_xla_sharding.py -v -k test_mark_shard_scalar