### PR TITLE
benchmarks: save timestamp in json output

### DIFF
--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -121,7 +121,11 @@ class ExperimentRunner:
           process_env = benchmark_model.extend_process_env(process_env)
           command = [sys.executable] + sys.argv + [
               f"--experiment-config={json.dumps(experiment_cfg)}"
-          ] + [f"--model-config={json.dumps(model_cfg)}"]
+          ] + [f"--model-config={json.dumps(model_cfg)}"] + [
+              # Note: if "--timestamp foo" is already in sys.argv, we
+              # harmlessly pass "--timestamp foo" again here.
+              f"--timestamp={self._args.timestamp}"
+          ]
           command_str = " ".join(command)
           logger.debug(f"Run `{command_str}`")
           child_process = subprocess.run(
@@ -206,6 +210,7 @@ class ExperimentRunner:
 
     results["metrics"] = metrics
     results["outputs_file"] = outputs_file_name
+    results["timestamp"] = self._args.timestamp
 
     json_str = json.dumps(results, ensure_ascii=False)
     with open(self.output_file, mode="a", encoding="utf-8") as f:
@@ -612,6 +617,13 @@ def parse_args(args=None):
       type=str,
       help="JSON string defining the model configuration. When set an experiment is run with exactly this one configuration.",
   )
+
+  parser.add_argument(
+      "--timestamp",
+      default=time.time(),
+      type=float,
+      help="Timestamp (seconds since the epoch) to assign to the benchmarks.")
+
   return parser.parse_args(args)
 
 

--- a/benchmarks/result_analyzer.py
+++ b/benchmarks/result_analyzer.py
@@ -108,6 +108,8 @@ class ResultAnalyzer:
     runs = []
     for jsonline in jsonlines:
       dataline = json.loads(jsonline)
+      timestamp = dataline[
+          "timestamp"] if "timestamp" in dataline else self.timestamp
       batch_size = dataline["experiment"]["batch_size"]
       batch_side_value = -1 if batch_size is None else batch_size
       xla = dataline["experiment"]["xla"]
@@ -121,7 +123,7 @@ class ResultAnalyzer:
 
       d = {
           "metrics": {
-              "timestamp": int(self.timestamp),
+              "timestamp": int(timestamp),
               "batch_size": batch_side_value,
               "repeat": dataline["repeat"],
               "iterations_per_run": dataline["iterations_per_run"]
@@ -162,8 +164,10 @@ class ResultAnalyzer:
 
     for jsonline in jsonlines:
       dataline = json.loads(jsonline)
+      timestamp = dataline[
+          "timestamp"] if "timestamp" in dataline else self.timestamp
       d = {
-          "timestamp": self.timestamp,
+          "timestamp": timestamp,
           "suite_name": dataline["model"]["suite_name"],
           "model_name": dataline["model"]["model_name"],
           "accelerator": dataline["experiment"]["accelerator"],
@@ -255,8 +259,8 @@ def parse_args(args=None):
 
   parser.add_argument(
       "--timestamp",
-      type=int,
-      help="User provided timestamp. If not provided, get the timestamp in analyzer",
+      type=float,
+      help="User provided timestamp used if the input data does not have it.",
   )
 
   parser.add_argument(


### PR DESCRIPTION
So that benchmarks run from the same invocation get the same timestamp.

I'm adding timestamps to old JSONL output files with this script:

```
import json
import sys

def replace_timestamps(filename, timestamp):
  with open(filename) as read_file:
    for line in read_file:
      try:
        r = json.loads(line.rstrip('\n|\r'))
      except json.JSONDecodeError as e:
        sys.exit(f'Invalid JSONL:\n{line}{e}')
      if 'timestamp' not in r:
        r['timestamp'] = float(timestamp)
      print(json.dumps(r))

def main():
  if len(sys.argv) != 3:
    sys.exit("Usage: add_timestamp.py input_file timestamp")
  filename = sys.argv[1]
  timestamp = sys.argv[2]
  replace_timestamps(filename, timestamp)

if __name__ == '__main__':
  main()
```