### PR TITLE
Promote int to float for tanh operation (consistent with Pytorch)

### DIFF
--- a/test/cpp/test_aten_xla_tensor_2.cpp
+++ b/test/cpp/test_aten_xla_tensor_2.cpp
@@ -2411,6 +2411,20 @@ TEST_F(AtenXlaTensorTest, TestTanh) {
   });
 }
 
+// In torch, tanh works with integer inputs. The same should be true for
+// torch_xla
+TEST_F(AtenXlaTensorTest, TestTanhWithInt) {
+  torch::Tensor a = torch::rand({2, 2});
+  torch::Tensor b = torch::tanh(a);
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_a = CopyToDevice(a, device);
+    torch::Tensor xla_b = torch::tanh(xla_a);
+    AllClose(b, xla_b, /*rtol=*/1e-3, /*atol=*/1e-5);
+  });
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::tanh", cpp_test::GetIgnoredCounters());
+}
+
 TEST_F(AtenXlaTensorTest, TestClampMinMax) {
   torch::Tensor a = torch::rand({2, 2}, torch::TensorOptions(torch::kFloat));
   torch::Scalar min_val(0.311);

--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -4419,7 +4419,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.tanh, args, kwargs)
 
-  @unittest.skip
   def test_aten_tanh_2(self):
     args = (torch.randint(0, 10, (10, 10)).to(torch.int32),)
     kwargs = dict()

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -751,6 +751,11 @@ torch_xla::XlaOpVector Tan::Lower(LoweringContext* loctx) const {
 
 torch_xla::XlaOpVector Tanh::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  if (xla::primitive_util::IsIntegralType(XlaHelpers::TypeOfXlaOp(xla_input))) {
+    xla::PrimitiveType input_type = XlaHelpers::TypeOfXlaOp(xla_input);
+    xla_input = ConvertTo(xla_input, input_type, xla::PrimitiveType::F32,
+                          /*device=*/nullptr);
+  }
   return ReturnOp(xla::Tanh(xla_input), loctx);
 }
 

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -818,7 +818,11 @@ xla::Shape TakeOutputShape(const torch::lazy::Value& input,
 }
 
 xla::Shape TanhOutputShape(const torch::lazy::Value& input) {
-  return GetXlaShape(input);
+  xla::Shape result_shape = GetXlaShape(input);
+  if (xla::primitive_util::IsIntegralType(result_shape.element_type())) {
+    result_shape.set_element_type(xla::PrimitiveType::F32);
+  }
+  return result_shape;
 }
 
 xla::Shape TrilOutputShape(const torch::lazy::Value& input) {


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/5903

---


`test_aten_tanh_2` failed due to:
```
RuntimeError: Error while lowering: [] aten::tanh, location=__call__@_ops.py:755, xla_shape=s32[10,10]{1,0}, dynamic_dims: ()
XLA builder error: INVALID_ARGUMENT: Expected element type in shape to be floating or complex for tanh operation; got S32.: 
```
and tested `torch.tanh` with PyTorch and PyTorch/XLA found tanh support int in torch and didn't support int in torch_xla:
```
# PJRT_DEVICE=TPU python
Python 3.10.13 (main, Sep 11 2023, 13:44:35) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torch
>>> a = torch.randn((10, 10)).to(torch.float32)
>>> b = torch.tanh(a)
>>> 
>>> c = torch.randn((10, 10)).to(torch.float16)
>>> d = torch.tanh(c)
>>> 
>>> e = torch.randint(0, 10, (10, 10)).to(torch.int32)
>>> f = torch.tanh(e)
>>> 
```
and
```
# PJRT_DEVICE=TPU python
Python 3.10.13 (main, Sep 11 2023, 13:44:35) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torch_xla
>>> import torch
>>> import torch_xla.core.xla_model as xm
>>> 
>>> m = torch.randn((10, 10)).to(torch.float32).to(xm.xla_device())
>>> n = torch.tanh(m)
>>> xm.mark_step()
>>> 
>>> o = torch.randn((10, 10)).to(torch.float16).to(xm.xla_device())
>>> p = torch.tanh(o)
>>> xm.mark_step()
>>> 
>>> p
tensor([[-0.4927,  0.6211,  0.7344, -0.6538, -0.1163,  0.6934, -0.5459,  0.8491,
          0.3271,  0.6426],
        [ 0.8691,  0.0098, -0.6626, -0.5479, -0.1429,  0.8721,  0.7822, -0.5654,
         -0.2031, -0.7305],
        [-0.3169, -0.4194, -0.5518, -0.9673, -0.7153,  0.3308, -0.9453,  0.2111,
          0.0225,  0.3533],
        [ 0.8960, -0.9468, -0.4634,  0.3296,  0.3718, -0.7568,  0.5820,  0.8496,
         -0.6841, -0.2422],
        [ 0.9365,  0.3792,  0.6353, -0.8999,  0.2383, -0.7974, -0.2147,  0.7803,
         -0.8359,  0.2301],
        [ 0.5645,  0.1597,  0.6611, -0.0640,  0.8447, -0.7788,  0.7490,  0.7520,
          0.1240,  0.9971],
        [ 0.9321, -0.3833,  0.5806, -0.3262,  0.2537,  0.5693, -0.0315, -0.1746,
         -0.5474, -0.7305],
        [-0.7881, -0.3333,  0.4570,  0.8374,  0.6040,  0.6230, -0.7583, -0.5024,
          0.0081,  0.1105],
        [-0.9502, -0.5894, -0.9702, -0.5542,  0.0744, -0.9463, -0.6182,  0.8442,
         -0.5620, -0.3164],
        [ 0.4314,  0.4834, -0.4500,  0.4678, -0.6094,  0.2517, -0.8950,  0.7876,
         -0.3445,  0.7402]], device='xla:0', dtype=torch.float16)
>>> o
tensor([[-0.5396,  0.7271,  0.9385, -0.7822, -0.1168,  0.8540, -0.6128,  1.2529,
          0.3396,  0.7622],
        [ 1.3291,  0.0098, -0.7974, -0.6152, -0.1439,  1.3408,  1.0508, -0.6411,
         -0.2059, -0.9297],
        [-0.3281, -0.4470, -0.6211, -2.0449, -0.8979,  0.3438, -1.7871,  0.2142,
          0.0225,  0.3691],
        [ 1.4521, -1.8018, -0.5015,  0.3423,  0.3906, -0.9888,  0.6655,  1.2549,
         -0.8369, -0.2471],
        [ 1.7100,  0.3992,  0.7500, -1.4717,  0.2429, -1.0918, -0.2181,  1.0459,
         -1.2070,  0.2343],
        [ 0.6392,  0.1610,  0.7944, -0.0641,  1.2373, -1.0430,  0.9707,  0.9775,
          0.1246,  3.2969],
        [ 1.6729, -0.4038,  0.6631, -0.3386,  0.2593,  0.6465, -0.0315, -0.1764,
         -0.6147, -0.9302],
        [-1.0664, -0.3464,  0.4934,  1.2129,  0.6997,  0.7300, -0.9927, -0.5522,
          0.0081,  0.1110],
        [-1.8350, -0.6768, -2.0996, -0.6245,  0.0745, -1.7930, -0.7217,  1.2354,
         -0.6357, -0.3276],
        [ 0.4617,  0.5273, -0.4846,  0.5073, -0.7080,  0.2573, -1.4463,  1.0654,
         -0.3591,  0.9512]], device='xla:0', dtype=torch.float16)
>>> k = torch.randint(0, 10, (10, 10)).to(torch.int32).to(xm.xla_device())
>>> l = torch.tanh(k)
>>> xm.mark_step()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/root/pytorch/xla/torch_xla/core/xla_model.py", line 891, in mark_step
    torch_xla._XLAC._xla_step_marker(
RuntimeError: Error while lowering: [] aten::tanh, xla_shape=s32[10,10]{1,0}, dynamic_dims: ()
XLA builder error: INVALID_ARGUMENT: Expected element type in shape to be floating or complex for tanh operation; got S32.: 
Frames:

>>> 
>>> exit()
```

so promote int to flost for tanh operation (consistent with PyTorch) like https://github.com/pytorch/xla/pull/4333

---

Testing:
```
# PJRT_DEVICE=CPU XLA_STABLEHLO_COMPILE=1 XLA_HLO_DEBUG=1 XLA_IR_DEBUG=1 pytest test/test_core_aten_ops.py -k test_aten_tanh_0
======================================================= test session starts ========================================================
platform linux -- Python 3.10.13, pytest-7.4.3, pluggy-1.3.0
rootdir: /root/pytorch
configfile: pytest.ini
plugins: hypothesis-6.90.0
collected 518 items / 517 deselected / 1 selected                                                                                  

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1702594442.211401   10039 cpu_client.cc:370] TfrtCpuClient created.
.                                                                                                 [100%]

================================================ 1 passed, 517 deselected in 3.66s =================================================
I0000 00:00:1702594442.890754   10039 cpu_client.cc:373] TfrtCpuClient destroyed.

# PJRT_DEVICE=CPU XLA_STABLEHLO_COMPILE=1 XLA_HLO_DEBUG=1 XLA_IR_DEBUG=1 pytest test/test_core_aten_ops.py -k test_aten_tanh_1
======================================================= test session starts ========================================================
platform linux -- Python 3.10.13, pytest-7.4.3, pluggy-1.3.0
rootdir: /root/pytorch
configfile: pytest.ini
plugins: hypothesis-6.90.0
collected 518 items / 517 deselected / 1 selected                                                                                  

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1702594452.982286   11133 cpu_client.cc:370] TfrtCpuClient created.
.                                                                                                 [100%]

================================================ 1 passed, 517 deselected in 3.70s =================================================
I0000 00:00:1702594453.699757   11133 cpu_client.cc:373] TfrtCpuClient destroyed.

# PJRT_DEVICE=CPU XLA_STABLEHLO_COMPILE=1 XLA_HLO_DEBUG=1 XLA_IR_DEBUG=1 pytest test/test_core_aten_ops.py -k test_aten_tanh_2
======================================================= test session starts ========================================================
platform linux -- Python 3.10.13, pytest-7.4.3, pluggy-1.3.0
rootdir: /root/pytorch
configfile: pytest.ini
plugins: hypothesis-6.90.0
collected 518 items / 517 deselected / 1 selected                                                                                  

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1702594459.261119   12227 cpu_client.cc:370] TfrtCpuClient created.
.                                                                                                 [100%]

================================================ 1 passed, 517 deselected in 3.70s =================================================
I0000 00:00:1702594459.958212   12227 cpu_client.cc:373] TfrtCpuClient destroyed.
```