### PR TITLE
Ignore non-XLA nodes and their direct dependents.

### DIFF
--- a/test/dynamo/test_bridge.py
+++ b/test/dynamo/test_bridge.py
@@ -266,6 +266,17 @@ class TorchXLAReuseGraphTest(torch._dynamo.test_case.TestCase):
 
     self._compile_and_check(foo, (xm.xla_device(),))
 
+  def test_cpu_input(self):
+
+    def foo(xt, t):
+      # Cannot move t to XLA, since it's also an output.
+      return (xt * 5)[t], t
+
+    device = xm.xla_device()
+    xt = torch.rand(5, device=device)
+    t = torch.randint(0, 5, (3,))
+    self._compile_and_check(foo, (xt, t))
+
 
 if __name__ == "__main__":
   from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_bridge.py
+++ b/test/dynamo/test_bridge.py
@@ -266,7 +266,7 @@ class TorchXLAReuseGraphTest(torch._dynamo.test_case.TestCase):
 
     self._compile_and_check(foo, (xm.xla_device(),))
 
-  def test_cpu_input(self):
+  def test_cpu_index_and_output(self):
 
     def foo(xt, t):
       # Cannot move t to XLA, since it's also an output.
@@ -276,6 +276,14 @@ class TorchXLAReuseGraphTest(torch._dynamo.test_case.TestCase):
     xt = torch.rand(5, device=device)
     t = torch.randint(0, 5, (3,))
     self._compile_and_check(foo, (xt, t))
+
+  def test_cpu_stack_input(self):
+
+    def foo(t):
+      return torch.stack([t])
+
+    t = torch.randint(0, 5, (3,))
+    self._compile_and_check(foo, (t,))
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_bridge.py
+++ b/test/dynamo/test_bridge.py
@@ -266,23 +266,40 @@ class TorchXLAReuseGraphTest(torch._dynamo.test_case.TestCase):
 
     self._compile_and_check(foo, (xm.xla_device(),))
 
-  def test_cpu_index_and_output(self):
+  def test_index_flag_unsupported(self):
+    # The indices of the index operation are represented as
+    # a list of objects. If any non-XLA tensors appear, the
+    # index operation should be flagged as unsupported, since
+    # their arguments might be turned into placeholders of the
+    # partition FX graph.
 
     def foo(xt, t):
-      # Cannot move t to XLA, since it's also an output.
-      return (xt * 5)[t], t
+      return xt[t]
 
     device = xm.xla_device()
     xt = torch.rand(5, device=device)
     t = torch.randint(0, 5, (3,))
     self._compile_and_check(foo, (xt, t))
 
-  def test_cpu_stack_input(self):
+  def test_stack_flag_unsupported(self):
+    # Explicit list of tensors arguments.
 
     def foo(t):
       return torch.stack([t])
 
     t = torch.randint(0, 5, (3,))
+    self._compile_and_check(foo, (t,))
+
+  def test_cpu_flag_unsupported(self):
+    # Nodes that return CPU tensors should also be flagged as
+    # unsupported, since their outputs could be turned into
+    # outputs of the partition FX graph.
+
+    def foo(t):
+      return t.cpu()
+
+    device = xm.xla_device()
+    t = torch.randint(0, 5, (3,), device=device)
     self._compile_and_check(foo, (t,))
 
 


### PR DESCRIPTION
Fix: #5966 

This PR generalizes `FallBackNodeCollector` into `UnsupportedNodesCollector`, improving and solving a few issues the old implementation had:

- nodes which resulted in a non-XLA tensor weren't flagged as fallback
- nodes whose arguments were a container with non-XLA tensors weren't flagged as fallback (e.g. `stack`)
- tracking these "unsupported" nodes weren't really only fallback nodes
    - but, nodes that can't exist in partition boundaries (e.g. arguments and return values)