### PR TITLE
[Core Aten] Enable test_aten_minimum_2

### DIFF
--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -2858,7 +2858,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.minimum, args, kwargs)
 
-  @unittest.skip
   def test_aten_minimum_2(self):
     args = (
         torch.randint(0, 10, (10, 10)).to(torch.int32),


### PR DESCRIPTION
Fixes #5990 

Does nothing to fix this. It just works.
```
(venv) cnchan@121d33c4909a:/repo/pytorch/xla$ pytest test/test_core_aten_ops.py -k test_aten_minimum
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.10.12, pytest-7.4.3, pluggy-1.3.0
rootdir: /repo/pytorch
configfile: pytest.ini
plugins: xdist-3.5.0, hypothesis-6.92.0
collected 518 items / 515 deselected / 3 selected                                                                                                                      

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1702622994.407233 2818409 cpu_client.cc:370] TfrtCpuClient created.
...                                                                                                                                   [100%]

================================================================== 3 passed, 515 deselected in 3.55s ===================================================================
I0000 00:00:1702622995.316901 2818409 cpu_client.cc:373] TfrtCpuClient destroyed.
```