### PR TITLE
Catch exception from AMP mismatch.

### DIFF
--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -152,6 +152,9 @@ class ExperimentRunner:
           logger.error("ERROR when launching child process")
           self.save_results(benchmark_experiment, benchmark_model,
                             {"error": str(e)}, None)
+        except ValueError as e:
+          self._fwd_captured_stdout_stderr(e.stdout, e.stderr)
+          logger.exception("ERROR")
 
   def _get_config_fingerprint(self, experiment_config: OrderedDict,
                               model_config: OrderedDict) -> str:


### PR DESCRIPTION
There're a couple of models (yolov3, pytorch_unet, tacotron2) which have AMP mode enabled. If we run the entire benchmarking suite they will crash the main process though. In this PR we catch this, and save the results to the output file.