### PR TITLE
[benchmarks] Collect dynamo counters.

### DIFF
--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -389,7 +389,7 @@ class ExperimentRunner:
           "calls_captured": dyn_utils.counters["stats"]["calls_captured"],
           "unique_graphs": dyn_utils.counters["stats"]["unique_graphs"],
           "graph_breaks": sum(dyn_utils.counters["graph_break"].values()),
-          # NB: The plus removes zero counts
+          # Note: The plus removes zero counts
           "unique_graph_breaks": len(+dyn_utils.counters["graph_break"]),
       })
 


### PR DESCRIPTION
This PR collects a few dynamo counters at each `timed_run`. These are the same collected by the [PyTorch benchmarking script](https://github.com/pytorch/pytorch/blob/main/benchmarks/dynamo/common.py):

- `calls_captured`: number of `call` nodes
- `unique_graphs`: number of compiled sub-graphs
- `graph_breaks`: number of graph breaks
- `unique_graph_breaks`: number of unique graph breaks (i.e. unique reasons) 