### PR TITLE
experiment_runner: revamp options to dump PyTorch/XLA metrics

### DIFF
--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -20,6 +20,14 @@ def parse_none_str(a: str):
   return a
 
 
+def ns_to_s(ns):
+  return ns * 1e-9
+
+
+def us_to_s(us):
+  return us * 1e-6
+
+
 @functools.lru_cache(None)
 def patch_torch_manual_seed():
   """Make torch manual seed deterministic. Helps with accuracy testing."""


### PR DESCRIPTION
Currently enabling profiling requires two steps: (1) enabling profiling with `--profile-cuda`, and (2) choose one (or both) options to dump the profiling into: `--profile-cuda-cpu-collect` to dump to the output JSONL file and/or `--profile-cuda-dump` to point to a directory where profiling output files are written to.

This PR revamps these options by replacing these flags with new ones to specify finer-grained profiling, e.g. we can now just `--dump-pytorch-xla-metrics` without dumping pytorch profiles (`--dump-pytorch-profiles`). Moreover, recording profiling info to the JSONL output file (if any profiling is enabled) becomes mandatory and therefore `--profile-cuda-cpu-collect` goes away.

While at it, add comments on metrics collection and group them in the code.