### PR TITLE
Reduce profiling overhead.

### DIFF
--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -345,12 +345,12 @@ class ExperimentRunner:
 
     enable_prof = self._args.profile_cuda
     metrics = OrderedDict()
-    t_start = time.perf_counter()
+    t_start, t_end = time.perf_counter(), None
     if benchmark_experiment.xla:
       t_trace = 0
 
     def loop(prof=None):
-      nonlocal t_trace
+      nonlocal t_trace, t_end
       for i in range(self._args.iterations_per_run):
         if benchmark_experiment.xla:
           t_trace_start = time.perf_counter()
@@ -366,6 +366,7 @@ class ExperimentRunner:
         if prof:
           prof.step()
       self._synchronize(benchmark_experiment)
+      t_end = time.perf_counter()
       return output
 
     if enable_prof:
@@ -375,7 +376,7 @@ class ExperimentRunner:
     else:
       output = loop()
 
-    t_end = time.perf_counter()
+    assert t_end is not None, "t_end should be modified by the loop!"
     if enable_prof:
       self.dump_profile_info(prof, benchmark_model, benchmark_experiment)
       self.collect_profile_to_metrics(prof, metrics)


### PR DESCRIPTION
This PR reduces profiling overhead we incur when measuring wall time.

**Command**
```
PJRT_DEVICE=CUDA python3 new_xla/benchmarks/experiment_runner.py --dynamo=inductor --xla=None --test=eval --filter=hf_Bert$ --suite-name=torchbench --accelerator=cuda --progress-bar --output-dirname=/tmp/output --repeat=2 --print-subprocess --no-resume --profile-cuda --profile-cuda-dump="/tmp/prof"
```

**Before**
```
cat /tmp/output/results.jsonl
...
"total_time": [14.667701112106442, 0.04353336617350578]
...
```

**After**
```
cat /tmp/output/results.jsonl
...
"total_time": [9.96255146106705, 0.009127002209424973]
...
```

The profiling overhead is still *big*, when run without any profiling then we get
```
cat /tmp/output/results.jsonl
...
"total_time": [9.848785414826125, 0.006039564963430166]
...
```