### PR TITLE
Add workflow file for TPU CI

### DIFF
--- a/.github/workflows/tpu_ci.yml
+++ b/.github/workflows/tpu_ci.yml
@@ -45,4 +45,5 @@ jobs:
           XLA_EXPERIMENTAL=nonzero:masked_select python3 -u test/ds/test_dynamic_shapes.py -v
           python3 -u test/test_autocast.py
           python3 -u test/dynamo/test_dynamo.py
-          python3 -u test/spmd/test_spmd_debugging.py
+          # TODO(mbzomowski): Uncomment once https://github.com/pytorch/xla/issues/6252 is fixed
+          # python3 -u test/spmd/test_spmd_debugging.py

--- a/.github/workflows/tpu_ci.yml
+++ b/.github/workflows/tpu_ci.yml
@@ -32,7 +32,6 @@ jobs:
         run: |
           cd pytorch/xla
           python3 -u test/test_operations.py -v
-          python3 -u test/test_operations.py -v
           python3 -u test/pjrt/test_runtime_tpu.py
           python3 -u test/pjrt/test_collective_ops_tpu.py
           python3 -u test/spmd/test_xla_sharding.py

--- a/.github/workflows/tpu_ci.yml
+++ b/.github/workflows/tpu_ci.yml
@@ -1,0 +1,33 @@
+name: TPU Integration Test
+run-name: TPU Testing
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 16,20,0 * * 1-5'
+jobs:
+  tpu-test:
+    runs-on: v4-runner-set
+    steps:
+      - name: Checkout and Setup PyTorch Repo
+        run: |
+          git clone --recursive https://github.com/pytorch/pytorch
+          cd pytorch/
+          python3 setup.py install --user
+      - name: Checkout PyTorch/XLA Repo
+        uses: actions/checkout@v4
+        with:
+          path: pytorch/xla
+      - name: Run PyTorch/XLA Setup
+        env:
+          BAZEL_VERBOSE: 1
+          BUNDLE_LIBTPU: 1
+          TPUVM_MODE: 1
+        run: |
+          cd pytorch/xla
+          python3 setup.py install --user
+      - name: Run Tests
+        env:
+          PJRT_DEVICE: TPU
+        run: |
+          cd pytorch/xla
+          python3 -u test/test_operations.py -v

--- a/.github/workflows/tpu_ci.yml
+++ b/.github/workflows/tpu_ci.yml
@@ -31,6 +31,7 @@ jobs:
           PJRT_DEVICE: TPU
         run: |
           pip install fsspec
+          pip install rich
           cd pytorch/xla
           python3 -u test/test_operations.py -v
           python3 -u test/pjrt/test_runtime_tpu.py

--- a/.github/workflows/tpu_ci.yml
+++ b/.github/workflows/tpu_ci.yml
@@ -30,6 +30,7 @@ jobs:
         env:
           PJRT_DEVICE: TPU
         run: |
+          pip install fsspec
           cd pytorch/xla
           python3 -u test/test_operations.py -v
           python3 -u test/pjrt/test_runtime_tpu.py

--- a/.github/workflows/tpu_ci.yml
+++ b/.github/workflows/tpu_ci.yml
@@ -2,8 +2,9 @@ name: TPU Integration Test
 run-name: TPU Testing
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 16,20,0 * * 1-5'
+  push:
+    branches:
+      - master
 jobs:
   tpu-test:
     runs-on: v4-runner-set
@@ -31,3 +32,16 @@ jobs:
         run: |
           cd pytorch/xla
           python3 -u test/test_operations.py -v
+          python3 -u test/test_operations.py -v
+          python3 -u test/pjrt/test_runtime_tpu.py
+          python3 -u test/pjrt/test_collective_ops_tpu.py
+          python3 -u test/spmd/test_xla_sharding.py
+          python3 -u test/spmd/test_xla_virtual_device.py
+          python3 -u test/spmd/test_xla_distributed_checkpoint.py
+          python3 -u test/spmd/test_train_spmd_linear_model.py
+          python3 -u test/spmd/test_xla_spmd_python_api_interaction.py
+          XLA_EXPERIMENTAL=nonzero:masked_select python3 -u test/ds/test_dynamic_shape_models.py -v
+          XLA_EXPERIMENTAL=nonzero:masked_select python3 -u test/ds/test_dynamic_shapes.py -v
+          python3 -u test/test_autocast.py
+          python3 -u test/dynamo/test_dynamo.py
+          python3 -u test/spmd/test_spmd_debugging.py


### PR DESCRIPTION
Adding a workflow file for TPU Continuous Integration. This workflow file will run integration tests on a TPU on demand (workflow_dispatch) for PR's, and on a regular schedule.