### PR TITLE
benchmarks/torchbench_model: skip benchmarks that fail to load

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -56,6 +56,8 @@ DENY_LIST = {
             "accelerator": "tpu"
         },
     ],  # not implemented
+    # self.load_benchmark() exits the main process. See issue #6207.
+    "pytorch_CycleGAN_and_pix2pix": [{}],
     "pyhpc_equation_of_state": [{
         "test": "train"
     },],  # not implemented
@@ -68,6 +70,12 @@ DENY_LIST = {
     "pytorch_struct": [{
         "test": "eval"
     },],  # not implemented
+    "pytorch_unet": [
+        {
+            # self.load_benchmark() exits the main process. See issue #6207.
+            "xla": "PJRT",
+        },
+    ],
     "resnet50_quantized_qat": [
         {
             "test": "eval",
@@ -78,6 +86,12 @@ DENY_LIST = {
             "accelerator": "tpu"
         },
     ],  # not implemented
+    "tacotron2": [
+        {
+            # self.load_benchmark() exits the main process. See issue #6207.
+            "xla": "PJRT",
+        },
+    ],
     # https://github.com/pytorch/pytorch/issues/99438
     "vision_maskrcnn": [{}],
 }


### PR DESCRIPTION
In "dfcf306e7 Apply precision config env vars in the root process. (#6152)"
we started running load_benchmark() from experiment_runner's
main process. Unfortunately, load_benchmark() for
some models does exit the calling process, which results
in experiment_runner exiting prematurely.

Work around this issue by adding these models to the deny list,
so that experiment_runner does not die early.