### PR TITLE
Create sharded data placeholders directly

### DIFF
--- a/torch_xla/csrc/runtime/computation_client.h
+++ b/torch_xla/csrc/runtime/computation_client.h
@@ -237,7 +237,7 @@ class ComputationClient {
   // Creates a Data object with no actual device handle in it. The device handle
   // will be populated in an asynchrounous fashion.
   virtual DataPtr CreateDataPlaceholder(std::string device,
-                                        xla::Shape shape) = 0;
+                                        xla::Shape shape, std::optional<xla::OpSharding> sharding = std::nullopt) = 0;
 
   // Returns data shards. We expect this to be called on PjRtShardedData to
   // retrieve the shards. If other data type is passed, it returns the input
@@ -248,7 +248,7 @@ class ComputationClient {
   virtual DataPtr GetDataShard(DataPtr data, size_t index) = 0;
 
   // Returns wrapped data shards as PjRtShardedData.
-  virtual DataPtr WrapDataShards(const std::vector<DataPtr>& shards,
+  virtual DataPtr WrapDataShards(absl::Span<const DataPtr> shards,
                                  std::string device, xla::Shape shape,
                                  xla::OpSharding sharding) = 0;
 

--- a/torch_xla/csrc/runtime/computation_client.h
+++ b/torch_xla/csrc/runtime/computation_client.h
@@ -236,8 +236,9 @@ class ComputationClient {
 
   // Creates a Data object with no actual device handle in it. The device handle
   // will be populated in an asynchrounous fashion.
-  virtual DataPtr CreateDataPlaceholder(std::string device,
-                                        xla::Shape shape, std::optional<xla::OpSharding> sharding = std::nullopt) = 0;
+  virtual DataPtr CreateDataPlaceholder(
+      std::string device, xla::Shape shape,
+      std::optional<xla::OpSharding> sharding = std::nullopt) = 0;
 
   // Returns data shards. We expect this to be called on PjRtShardedData to
   // retrieve the shards. If other data type is passed, it returns the input

--- a/torch_xla/csrc/runtime/ifrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.cc
@@ -176,8 +176,8 @@ xla::OpSharding IfrtComputationClient::IfrtData::GetSharding() const {
 }
 
 ComputationClient::DataPtr IfrtComputationClient::CreateDataPlaceholder(
-    std::string device, xla::Shape shape) {
-  return std::make_shared<IfrtData>(device, shape);
+    std::string device, xla::Shape shape, std::optional<xla::OpSharding> sharding) {
+  return std::make_shared<IfrtData>(std::move(device), std::move(shape), tsl::RCReference<xla::ifrt::Array>(), std::move(sharding));
 }
 
 std::vector<ComputationClient::DataPtr> IfrtComputationClient::GetDataShards(
@@ -211,14 +211,9 @@ ComputationClient::DataPtr IfrtComputationClient::GetDataShard(
 }
 
 ComputationClient::DataPtr IfrtComputationClient::WrapDataShards(
-    const std::vector<DataPtr>& shards, std::string device, xla::Shape shape,
+    absl::Span<const DataPtr> shards, std::string device, xla::Shape shape,
     xla::OpSharding sharding) {
-  // TODO: implement CreateDataPlaceholder for sharded data
-  if (shards.size() == 0) {
-    TF_LOG(INFO) << "creating sharded placeholder";
-    return std::make_shared<IfrtData>(
-        device, shape, tsl::RCReference<xla::ifrt::Array>(), sharding);
-  }
+  XLA_CHECK_EQ(shards.size(), client_->addressable_device_count());
   std::vector<tsl::RCReference<xla::ifrt::Array>> arrays;
   std::vector<xla::ifrt::Shape> shard_shapes;
   for (auto& shard : shards) {

--- a/torch_xla/csrc/runtime/ifrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.cc
@@ -176,8 +176,11 @@ xla::OpSharding IfrtComputationClient::IfrtData::GetSharding() const {
 }
 
 ComputationClient::DataPtr IfrtComputationClient::CreateDataPlaceholder(
-    std::string device, xla::Shape shape, std::optional<xla::OpSharding> sharding) {
-  return std::make_shared<IfrtData>(std::move(device), std::move(shape), tsl::RCReference<xla::ifrt::Array>(), std::move(sharding));
+    std::string device, xla::Shape shape,
+    std::optional<xla::OpSharding> sharding) {
+  return std::make_shared<IfrtData>(std::move(device), std::move(shape),
+                                    tsl::RCReference<xla::ifrt::Array>(),
+                                    std::move(sharding));
 }
 
 std::vector<ComputationClient::DataPtr> IfrtComputationClient::GetDataShards(

--- a/torch_xla/csrc/runtime/ifrt_computation_client.h
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.h
@@ -29,7 +29,9 @@ class IfrtComputationClient : public ComputationClient {
   IfrtComputationClient();
   ~IfrtComputationClient();
 
-  DataPtr CreateDataPlaceholder(std::string device, xla::Shape shape, std::optional<xla::OpSharding> sharding = std::nullopt) override;
+  DataPtr CreateDataPlaceholder(
+      std::string device, xla::Shape shape,
+      std::optional<xla::OpSharding> sharding = std::nullopt) override;
 
   std::vector<DataPtr> GetDataShards(DataPtr data) override;
 

--- a/torch_xla/csrc/runtime/ifrt_computation_client.h
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.h
@@ -29,13 +29,13 @@ class IfrtComputationClient : public ComputationClient {
   IfrtComputationClient();
   ~IfrtComputationClient();
 
-  DataPtr CreateDataPlaceholder(std::string device, xla::Shape shape) override;
+  DataPtr CreateDataPlaceholder(std::string device, xla::Shape shape, std::optional<xla::OpSharding> sharding = std::nullopt) override;
 
   std::vector<DataPtr> GetDataShards(DataPtr data) override;
 
   DataPtr GetDataShard(DataPtr data, size_t index) override;
 
-  DataPtr WrapDataShards(const std::vector<DataPtr>& shards, std::string device,
+  DataPtr WrapDataShards(absl::Span<const DataPtr> shards, std::string device,
                          xla::Shape shape, xla::OpSharding sharding) override;
 
   std::optional<xla::OpSharding> GetDataSharding(DataPtr handle) override;

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -174,8 +174,12 @@ void PjRtComputationClient::PjRtData::Assign(
 }
 
 ComputationClient::DataPtr PjRtComputationClient::CreateDataPlaceholder(
-    std::string device, xla::Shape shape) {
-  return std::make_shared<PjRtData>(device, shape);
+    std::string device, xla::Shape shape, std::optional<xla::OpSharding> sharding) {
+  if (sharding.has_value()) {
+    return std::make_shared<PjRtShardedData>(std::move(device), std::move(shape), std::move(*sharding));
+  }
+
+  return std::make_shared<PjRtData>(std::move(device), std::move(shape));
 }
 
 std::vector<ComputationClient::DataPtr> PjRtComputationClient::GetDataShards(
@@ -213,8 +217,9 @@ ComputationClient::DataPtr PjRtComputationClient::GetDataShard(
 }
 
 ComputationClient::DataPtr PjRtComputationClient::WrapDataShards(
-    const std::vector<DataPtr>& shards, std::string device, xla::Shape shape,
+    absl::Span<const DataPtr> shards, std::string device, xla::Shape shape,
     xla::OpSharding sharding) {
+  XLA_CHECK_EQ(shards.size(), client_->addressable_device_count());
   std::vector<std::shared_ptr<PjRtData>> pjrt_data_shards;
   pjrt_data_shards.reserve(shards.size());
   for (auto& shard : shards) {

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -174,9 +174,11 @@ void PjRtComputationClient::PjRtData::Assign(
 }
 
 ComputationClient::DataPtr PjRtComputationClient::CreateDataPlaceholder(
-    std::string device, xla::Shape shape, std::optional<xla::OpSharding> sharding) {
+    std::string device, xla::Shape shape,
+    std::optional<xla::OpSharding> sharding) {
   if (sharding.has_value()) {
-    return std::make_shared<PjRtShardedData>(std::move(device), std::move(shape), std::move(*sharding));
+    return std::make_shared<PjRtShardedData>(
+        std::move(device), std::move(shape), std::move(*sharding));
   }
 
   return std::make_shared<PjRtData>(std::move(device), std::move(shape));

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -28,13 +28,13 @@ class PjRtComputationClient : public ComputationClient {
   PjRtComputationClient();
   ~PjRtComputationClient();
 
-  DataPtr CreateDataPlaceholder(std::string device, xla::Shape shape) override;
+  DataPtr CreateDataPlaceholder(std::string device, xla::Shape shape, std::optional<xla::OpSharding> sharding = std::nullopt) override;
 
   std::vector<DataPtr> GetDataShards(DataPtr data) override;
 
   DataPtr GetDataShard(DataPtr data, size_t index) override;
 
-  DataPtr WrapDataShards(const std::vector<DataPtr>& shards, std::string device,
+  DataPtr WrapDataShards(absl::Span<const DataPtr> shards, std::string device,
                          xla::Shape shape, xla::OpSharding sharding) override;
 
   std::optional<xla::OpSharding> GetDataSharding(DataPtr handle) override;
@@ -180,6 +180,9 @@ class PjRtComputationClient : public ComputationClient {
 
   struct PjRtShardedData : public Data {
     PjRtShardedData(std::string device, xla::Shape shape) = delete;
+
+    PjRtShardedData(std::string device, xla::Shape shape,
+                    xla::OpSharding sharding) : Data(std::move(device), std::move(shape)), sharding(sharding) {}
 
     PjRtShardedData(std::string device, xla::Shape shape,
                     std::vector<std::shared_ptr<PjRtData>> shards,

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -28,7 +28,9 @@ class PjRtComputationClient : public ComputationClient {
   PjRtComputationClient();
   ~PjRtComputationClient();
 
-  DataPtr CreateDataPlaceholder(std::string device, xla::Shape shape, std::optional<xla::OpSharding> sharding = std::nullopt) override;
+  DataPtr CreateDataPlaceholder(
+      std::string device, xla::Shape shape,
+      std::optional<xla::OpSharding> sharding = std::nullopt) override;
 
   std::vector<DataPtr> GetDataShards(DataPtr data) override;
 
@@ -182,7 +184,8 @@ class PjRtComputationClient : public ComputationClient {
     PjRtShardedData(std::string device, xla::Shape shape) = delete;
 
     PjRtShardedData(std::string device, xla::Shape shape,
-                    xla::OpSharding sharding) : Data(std::move(device), std::move(shape)), sharding(sharding) {}
+                    xla::OpSharding sharding)
+        : Data(std::move(device), std::move(shape)), sharding(sharding) {}
 
     PjRtShardedData(std::string device, xla::Shape shape,
                     std::vector<std::shared_ptr<PjRtData>> shards,

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -588,8 +588,8 @@ std::vector<torch::lazy::BackendDataPtr> ShardingUtil::CreateShardedPlaceholder(
     // hold the corresponding computation results for both sharding &
     // replication.
     auto sharded_data_placeholder =
-        runtime::GetComputationClient()->WrapDataShards(
-            {}, GetVirtualDevice().toString(), sharding_specs[i]->shape,
+        runtime::GetComputationClient()->CreateDataPlaceholder(
+            GetVirtualDevice().toString(), sharding_specs[i]->shape,
             sharding_specs[i]->sharding);
 
     // Register the sharded data placeholder to the tensor and its node.
@@ -644,8 +644,8 @@ void ShardingUtil::PrepareOutputShardingPropagation(
     // hold the corresponding computation results for both sharding &
     // replication.
     auto sharded_data_placeholder =
-        runtime::GetComputationClient()->WrapDataShards(
-            {}, GetVirtualDevice().toString(), (*sharding_specs)[i]->shape,
+        runtime::GetComputationClient()->CreateDataPlaceholder(
+            GetVirtualDevice().toString(), (*sharding_specs)[i]->shape,
             (*sharding_specs)[i]->sharding);
 
     // Register the sharded data placeholder to the tensor and its node.


### PR DESCRIPTION
- Use `CreateDataPlaceholder` to create sharded placeholders
- Require correct number of shards in `WrapDataShards`