### PR TITLE
benchmarks/aggregate: fix --filter breakage

### DIFF
--- a/benchmarks/aggregate.py
+++ b/benchmarks/aggregate.py
@@ -85,6 +85,9 @@ def process_file(args, results_map: Dict[str, Any], filename: str):
           r['experiment']['accelerator_model'])
       if accelerator_model != args.accelerator:
         continue
+      model_name = r['model']['model_name']
+      if skip_model(args, model_name):
+        continue
       dynamo = r['experiment']['dynamo']
       test = r['experiment']['test']
       if test != _test_to_field_name[args.test]:
@@ -100,10 +103,8 @@ def process_file(args, results_map: Dict[str, Any], filename: str):
       std = np.std(total_times[1:], ddof=1) if len(total_times) > 2 else 0.0
       dp = Datapoint(avg, std)
       median_total_time = np.median(total_times[1:])
-      dynamo = r['experiment']['dynamo']
       batch_size = r['experiment']['batch_size']
       timestamp = r['timestamp']
-      model_name = r['model']['model_name']
 
       if timestamp not in results_map:
         results_map[timestamp] = {}

--- a/test/benchmarks/Makefile
+++ b/test/benchmarks/Makefile
@@ -1,4 +1,4 @@
-TEST_ARGS = $(shell echo $@ | perl -pe 's/([^.]*)\.([^.]*)\.([^.]*)\.test/--accelerator=$$1 --test=$$2 --report=$$3/')
+TEST_ARGS = $(shell echo $@ | perl -pe 's/([^.]*)\.([^.]*)\.([^.]*)(?:\.tier([0-9]+))?\.test/--accelerator=$$1 --test=$$2 --report=$$3/; if (defined($$4)) { print "--filter-by-tier=$$4 " }')
 
 TESTS := $(wildcard *.test)
 all: $(TESTS)

--- a/test/benchmarks/v100.inference.latest.tier1.test
+++ b/test/benchmarks/v100.inference.latest.tier1.test
@@ -1,0 +1,2 @@
+# WorkloadNumber,Speedup(Inductor/Oldest Inductor),StdDev,ModelName(Inductor),Speedup(PytorchXLA/Oldest Inductor),StdDev,ModelName(PytorchXLA),Speedup(PytorchXLA_Eval/Oldest Inductor),StdDev,ModelName(PytorchXLA_Eval)
+0,1.51952596,6.914e-05,BERT_pytorch,1.56880282,7.138e-05,BERT_pytorch,1.36859903,6.227e-05,BERT_pytorch


### PR DESCRIPTION
In "bd2ec6f8c benchmarks/aggregate: read JSONL files directly (#6191)" we mistakenly stopped honoring --filter. Fix it and add a test to prevent this from happening again.

While at it, remove the redundant assignment to `dynamo`.