### PR TITLE
Retrieve the local_process_rank from the LOCAL_RANK environment variable.

### DIFF
--- a/torch_xla/csrc/runtime/pjrt_registry.cc
+++ b/torch_xla/csrc/runtime/pjrt_registry.cc
@@ -87,7 +87,7 @@ InitializePjRt(const std::string& device_type) {
              device_type == "ROCM") {
     TF_VLOG(1) << "Initializing PjRt GPU client...";
     bool async = sys_util::GetEnvBool(env::kEnvPjrtAsyncGpuClient, true);
-    int local_process_rank = sys_util::GetEnvInt(env::kEnvPjRtLocalRank, 0);
+    int local_process_rank = sys_util::GetEnvInt("LOCAL_RANK", 0);
     int global_process_rank = sys_util::GetEnvInt("RANK", local_process_rank);
     int local_world_size = sys_util::GetEnvInt("LOCAL_WORLD_SIZE", 1);
     int global_world_size = sys_util::GetEnvInt("WORLD_SIZE", local_world_size);


### PR DESCRIPTION
This PR aims to resolve the problem of launching a distributed job using torchrun.

As described in this [issue](https://github.com/pytorch/xla/issues/5771), there is an issue when using torchrun. After testing the latest code of torch_xla, the problem has undergone some changes.

In the latest code of torch_xla, the [`local_process_rank`](https://github.com/pytorch/xla/blob/2e6e183e0724818f137c8135b34ef273dea33318/torch_xla/csrc/runtime/pjrt_registry.cc#L90C1-L91C1) is always 0, causing all processes to run on GPU:0 when using torchrun.

With torchrun, the value of `local_process_rank` should be obtained from `LOCAL_RANK`.

@vanbasten23 @JackCaoG 