### PR TITLE
Update dtype conversion for aten_tan

### DIFF
--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -689,7 +689,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.atan, args, kwargs)
 
-  @unittest.skip
   def test_aten_atan_2(self):
     args = (torch.randint(0, 10, (10, 10)).to(torch.int32),)
     kwargs = dict()

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -147,6 +147,11 @@ torch_xla::XlaOpVector Asinh::Lower(LoweringContext* loctx) const {
 
 torch_xla::XlaOpVector Atan::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  // PyTorch allows integral types as input to torch.atan while XLA does not,
+  // hence the manual type conversion.
+  if (xla::primitive_util::IsIntegralType(XlaHelpers::TypeOfXlaOp(xla_input))) {
+    xla_input = xla::ConvertElementType(xla_input, xla::PrimitiveType::F32);
+  }
   return ReturnOp(xla::Atan(xla_input), loctx);
 }
 

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -224,7 +224,13 @@ xla::Shape AsinhOutputShape(const torch::lazy::Value& input) {
 }
 
 xla::Shape AtanOutputShape(const torch::lazy::Value& input) {
-  return GetXlaShape(input);
+  xla::Shape result_shape = GetXlaShape(input);
+  // PyTorch allows integral types as input to torch.atan while XLA does not,
+  // hence the manual type conversion.
+  if (xla::primitive_util::IsIntegralType(result_shape.element_type())) {
+    result_shape.set_element_type(xla::PrimitiveType::F32);
+  }
+  return result_shape;
 }
 
 xla::Shape Atan2OutputShape(const torch::lazy::Value& input,


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/5851

Update dtype conversion for aten_tan

Test:
```
(base) wonjoo@wonjoo-cpu:~/pytorch/xla$ pytest test/test_core_aten_ops.py -k test_aten_atan_2
====================================== test session starts =======================================
platform linux -- Python 3.10.12, pytest-7.4.3, pluggy-1.0.0
rootdir: /home/wonjoo/pytorch
configfile: pytest.ini
plugins: hypothesis-6.81.2, devtools-0.11.0
collected 518 items / 517 deselected / 1 selected                                                

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1703028360.275982 2817843 cpu_client.cc:370] TfrtCpuClient created.
.                                                               [100%]

=============================== 1 passed, 517 deselected in 5.49s ================================
I0000 00:00:1703028361.169280 2817843 cpu_client.cc:373] TfrtCpuClient destroyed.
```