### PR TITLE
Add manual type conversion for aten_asin

### DIFF
--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -644,19 +644,16 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.as_strided_copy, args, kwargs)
 
-  @unittest.skip
   def test_aten_asin_0(self):
     args = (torch.randn((10, 10)).to(torch.float32),)
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.asin, args, kwargs)
 
-  @unittest.skip
   def test_aten_asin_1(self):
     args = (torch.randn((10, 10)).to(torch.float16),)
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.asin, args, kwargs)
 
-  @unittest.skip
   def test_aten_asin_2(self):
     args = (torch.randint(0, 10, (10, 10)).to(torch.int32),)
     kwargs = dict()

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -137,6 +137,9 @@ torch_xla::XlaOpVector Argmin::Lower(LoweringContext* loctx) const {
 
 torch_xla::XlaOpVector Asin::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  if (xla::primitive_util::IsIntegralType(XlaHelpers::TypeOfXlaOp(xla_input))) {
+    xla_input = xla::ConvertElementType(xla_input, xla::PrimitiveType::F32);
+  }
   return ReturnOp(xla::Asin(xla_input), loctx);
 }
 

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -216,7 +216,11 @@ xla::Shape ArgminOutputShape(const torch::lazy::Value& input,
 }
 
 xla::Shape AsinOutputShape(const torch::lazy::Value& input) {
-  return GetXlaShape(input);
+  xla::Shape result_shape = GetXlaShape(input);
+  if (xla::primitive_util::IsIntegralType(result_shape.element_type())) {
+    result_shape.set_element_type(xla::PrimitiveType::F32);
+  }
+  return result_shape;
 }
 
 xla::Shape AsinhOutputShape(const torch::lazy::Value& input) {


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/5849

Add manual type conversion for aten_asin

Test:
```
(base) wonjoo@wonjoo-cpu:~/pytorch/xla$ pytest test/test_core_aten_ops.py -k test_aten_asin_0
====================================== test session starts =======================================
platform linux -- Python 3.10.12, pytest-7.4.3, pluggy-1.0.0
rootdir: /home/wonjoo/pytorch
configfile: pytest.ini
plugins: hypothesis-6.81.2, devtools-0.11.0
collected 518 items / 517 deselected / 1 selected                                                

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1703029874.459259 2826678 cpu_client.cc:370] TfrtCpuClient created.
.                                                               [100%]

=============================== 1 passed, 517 deselected in 5.32s ================================
I0000 00:00:1703029875.351485 2826678 cpu_client.cc:373] TfrtCpuClient destroyed.
(base) wonjoo@wonjoo-cpu:~/pytorch/xla$ pytest test/test_core_aten_ops.py -k test_aten_asin_1
====================================== test session starts =======================================
platform linux -- Python 3.10.12, pytest-7.4.3, pluggy-1.0.0
rootdir: /home/wonjoo/pytorch
configfile: pytest.ini
plugins: hypothesis-6.81.2, devtools-0.11.0
collected 518 items / 517 deselected / 1 selected                                                

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1703029882.327068 2827260 cpu_client.cc:370] TfrtCpuClient created.
.                                                               [100%]

=============================== 1 passed, 517 deselected in 5.36s ================================
I0000 00:00:1703029883.248321 2827260 cpu_client.cc:373] TfrtCpuClient destroyed.
(base) wonjoo@wonjoo-cpu:~/pytorch/xla$ pytest test/test_core_aten_ops.py -k test_aten_asin_2
====================================== test session starts =======================================
platform linux -- Python 3.10.12, pytest-7.4.3, pluggy-1.0.0
rootdir: /home/wonjoo/pytorch
configfile: pytest.ini
plugins: hypothesis-6.81.2, devtools-0.11.0
collected 518 items / 517 deselected / 1 selected                                                

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1703029890.191687 2827842 cpu_client.cc:370] TfrtCpuClient created.
.                                                               [100%]

=============================== 1 passed, 517 deselected in 5.43s ================================
I0000 00:00:1703029891.200229 2827842 cpu_client.cc:373] TfrtCpuClient destroyed.
```