### PR TITLE
Update aten_exp to do a manual type conversion

### DIFF
--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -1573,7 +1573,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.exp, args, kwargs)
 
-  @unittest.skip
   def test_aten_exp_2(self):
     args = (torch.randint(0, 10, (10, 10)).to(torch.int32),)
     kwargs = dict()

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -363,6 +363,9 @@ torch_xla::XlaOpVector Erfinv::Lower(LoweringContext* loctx) const {
 
 torch_xla::XlaOpVector Exp::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  if (xla::primitive_util::IsIntegralType(XlaHelpers::TypeOfXlaOp(xla_input))) {
+    xla_input = xla::ConvertElementType(xla_input, xla::PrimitiveType::F32);
+  }
   return ReturnOp(xla::Exp(xla_input), loctx);
 }
 

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -434,7 +434,11 @@ xla::Shape ErfinvOutputShape(const torch::lazy::Value& input) {
 }
 
 xla::Shape ExpOutputShape(const torch::lazy::Value& input) {
-  return GetXlaShape(input);
+  xla::Shape result_shape = GetXlaShape(input);
+  if (xla::primitive_util::IsIntegralType(result_shape.element_type())) {
+    result_shape.set_element_type(xla::PrimitiveType::F32);
+  }
+  return result_shape;
 }
 
 xla::Shape Expm1OutputShape(const torch::lazy::Value& input) {


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/5864

Update aten_exp to do a manual type conversion

Test:
```
(base) wonjoo@wonjoo-cpu:~/pytorch/xla$ pytest test/test_core_aten_ops.py -k test_aten_exp_2
====================================== test session starts =======================================
platform linux -- Python 3.10.12, pytest-7.4.3, pluggy-1.0.0
rootdir: /home/wonjoo/pytorch
configfile: pytest.ini
plugins: hypothesis-6.81.2, devtools-0.11.0
collected 518 items / 517 deselected / 1 selected                                                

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1703030591.272323 2833523 cpu_client.cc:370] TfrtCpuClient created.
.                                                               [100%]

=============================== 1 passed, 517 deselected in 5.36s ================================
I0000 00:00:1703030592.200544 2833523 cpu_client.cc:373] TfrtCpuClient destroyed.
```