### PR TITLE
Enable core aten test and loose tolerance for aten_log10 and aten_log2

### DIFF
--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -2358,19 +2358,23 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.log, args, kwargs)
 
-  @unittest.skip
   def test_aten_log10_0(self):
     args = (torch.randn((10, 10)).to(torch.float32),)
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.log10, args, kwargs)
 
-  @unittest.skip
   def test_aten_log10_1(self):
     args = (torch.randn((10, 10)).to(torch.float16),)
     kwargs = dict()
-    run_export_and_compare(self, torch.ops.aten.log10, args, kwargs)
+    run_export_and_compare(
+        self,
+        torch.ops.aten.log10,
+        args,
+        kwargs,
+        rtol=0.001,
+        atol=0.01,
+    )
 
-  @unittest.skip
   def test_aten_log10_2(self):
     args = (torch.randint(0, 10, (10, 10)).to(torch.int32),)
     kwargs = dict()
@@ -2393,17 +2397,22 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.log1p, args, kwargs)
 
-  @unittest.skip
   def test_aten_log2_0(self):
     args = (torch.randn((10, 10)).to(torch.float32),)
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.log2, args, kwargs)
 
-  @unittest.skip
   def test_aten_log2_1(self):
     args = (torch.randn((10, 10)).to(torch.float16),)
     kwargs = dict()
-    run_export_and_compare(self, torch.ops.aten.log2, args, kwargs)
+    run_export_and_compare(
+        self,
+        torch.ops.aten.log2,
+        args,
+        kwargs,
+        rtol=0.001,
+        atol=0.01,
+    )
 
   def test_aten_log2_2(self):
     args = (torch.randint(0, 10, (10, 10)).to(torch.int32),)


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/5874, fixes https://github.com/pytorch/xla/issues/5876

Enable core aten test and loose tolerance for aten_log10 and aten_log2

Test:
```
(base) wonjoo@wonjoo-cpu:~/pytorch/xla$ pytest test/test_core_aten_ops.py -k test_aten_log10_0
====================================== test session starts =======================================
platform linux -- Python 3.10.12, pytest-7.4.3, pluggy-1.0.0
rootdir: /home/wonjoo/pytorch
configfile: pytest.ini
plugins: hypothesis-6.81.2, devtools-0.11.0
collected 518 items / 517 deselected / 1 selected                                                

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1703104926.348582 2913808 cpu_client.cc:370] TfrtCpuClient created.
.                                                               [100%]

=============================== 1 passed, 517 deselected in 5.73s ================================
I0000 00:00:1703104927.493247 2913808 cpu_client.cc:373] TfrtCpuClient destroyed.
(base) wonjoo@wonjoo-cpu:~/pytorch/xla$ pytest test/test_core_aten_ops.py -k test_aten_log10_1
====================================== test session starts =======================================
platform linux -- Python 3.10.12, pytest-7.4.3, pluggy-1.0.0
rootdir: /home/wonjoo/pytorch
configfile: pytest.ini
plugins: hypothesis-6.81.2, devtools-0.11.0
collected 518 items / 517 deselected / 1 selected                                                

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1703105071.223041 2914392 cpu_client.cc:370] TfrtCpuClient created.
.                                                               [100%]

=============================== 1 passed, 517 deselected in 5.50s ================================
I0000 00:00:1703105072.228877 2914392 cpu_client.cc:373] TfrtCpuClient destroyed.
(base) wonjoo@wonjoo-cpu:~/pytorch/xla$ pytest test/test_core_aten_ops.py -k test_aten_log10_2
====================================== test session starts =======================================
platform linux -- Python 3.10.12, pytest-7.4.3, pluggy-1.0.0
rootdir: /home/wonjoo/pytorch
configfile: pytest.ini
plugins: hypothesis-6.81.2, devtools-0.11.0
collected 518 items / 517 deselected / 1 selected                                                

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1703105174.924546 2914978 cpu_client.cc:370] TfrtCpuClient created.
.                                                               [100%]

=============================== 1 passed, 517 deselected in 5.64s ================================
I0000 00:00:1703105176.100291 2914978 cpu_client.cc:373] TfrtCpuClient destroyed.
```