### PR TITLE
Promote int to float for acos operation (consistent with Pytorch)

### DIFF
--- a/test/cpp/test_aten_xla_tensor_2.cpp
+++ b/test/cpp/test_aten_xla_tensor_2.cpp
@@ -2281,6 +2281,20 @@ TEST_F(AtenXlaTensorTest, TestAcos) {
   });
 }
 
+// In torch, acos works with integer inputs. The same should be true for
+// torch_xla
+TEST_F(AtenXlaTensorTest, TestAcosWithInt) {
+  torch::Tensor a = torch::rand({2, 2});
+  torch::Tensor b = torch::acos(a);
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_a = CopyToDevice(a, device);
+    torch::Tensor xla_b = torch::acos(xla_a);
+    AllClose(b, xla_b, /*rtol=*/1e-3, /*atol=*/1e-5);
+  });
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::acos", cpp_test::GetIgnoredCounters());
+}
+
 TEST_F(AtenXlaTensorTest, TestAcosh) {
   torch::Tensor a =
       torch::rand({2, 2}, torch::TensorOptions(torch::kFloat)) * 100;

--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -91,19 +91,16 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.abs, args, kwargs)
 
-  @unittest.skip
   def test_aten_acos_0(self):
     args = (torch.randn((10, 10)).to(torch.float32),)
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.acos, args, kwargs)
 
-  @unittest.skip
   def test_aten_acos_1(self):
     args = (torch.randn((10, 10)).to(torch.float16),)
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.acos, args, kwargs)
 
-  @unittest.skip
   def test_aten_acos_2(self):
     args = (torch.randint(0, 10, (10, 10)).to(torch.int32),)
     kwargs = dict()

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -23,6 +23,11 @@ torch_xla::XlaOpVector Abs::Lower(LoweringContext* loctx) const {
 
 torch_xla::XlaOpVector Acos::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  if (xla::primitive_util::IsIntegralType(XlaHelpers::TypeOfXlaOp(xla_input))) {
+    xla::PrimitiveType input_type = XlaHelpers::TypeOfXlaOp(xla_input);
+    xla_input = ConvertTo(xla_input, input_type, xla::PrimitiveType::F32,
+                          /*device=*/nullptr);
+  }
   return ReturnOp(xla::Acos(xla_input), loctx);
 }
 

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -48,7 +48,11 @@ xla::Shape AbsOutputShape(const torch::lazy::Value& input) {
 }
 
 xla::Shape AcosOutputShape(const torch::lazy::Value& input) {
-  return GetXlaShape(input);
+  xla::Shape result_shape = GetXlaShape(input);
+  if (xla::primitive_util::IsIntegralType(result_shape.element_type())) {
+    result_shape.set_element_type(xla::PrimitiveType::F32);
+  }
+  return result_shape;
 }
 
 xla::Shape AcoshOutputShape(const torch::lazy::Value& input) {


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/5842

---


`test_aten_acos_2` failed due to:
```
RuntimeError: Error while lowering: [] aten::acos, xla_shape=s32[10,10]{1,0}, dynamic_dims: ()
XLA builder error: INVALID_ARGUMENT: Invalid cast from floating point type to S32 in ConstantR0WithType.: 
Frames:
```
and tested `torch.acos` with PyTorch and PyTorch/XLA found acos support int in torch and didn't support int in torch_xla:
```
# PJRT_DEVICE=TPU python
Python 3.10.13 (main, Sep 11 2023, 13:44:35) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torch
>>> a = torch.randn((10, 10)).to(torch.float32)
>>> b = torch.acos(a)
>>> 
>>> c = torch.randn((10, 10)).to(torch.float16)
>>> d = torch.acos(c)
>>> 
>>> e = torch.randint(0, 10, (10, 10)).to(torch.int32)
>>> f = torch.acos(e)
>>> 
>>> 
>>> exit()
```
and
```
# PJRT_DEVICE=TPU python
Python 3.10.13 (main, Sep 11 2023, 13:44:35) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torch_xla
>>> import torch
>>> import torch_xla.core.xla_model as xm
>>> 
>>> m = torch.randn((10, 10)).to(torch.float32).to(xm.xla_device())
>>> n = torch.acos(m)
>>> xm.mark_step()
>>> 
>>> o = torch.randn((10, 10)).to(torch.float16).to(xm.xla_device())
>>> p = torch.acos(o)
>>> xm.mark_step()
>>> 
>>> p
tensor([[   nan,    nan, 1.6865, 1.3047,    nan, 1.7676,    nan, 0.7212,    nan,
         2.2168],
        [0.6553, 1.1338, 1.4102, 1.5381,    nan, 1.5449, 1.4961, 1.4395, 0.7827,
         1.2129],
        [2.9277, 0.7959, 0.8706, 1.8984, 0.4836, 1.3896, 3.0117, 0.4116, 2.0684,
         1.5166],
        [   nan,    nan, 1.5391, 2.7598, 1.9609, 2.2676,    nan, 1.4980,    nan,
            nan],
        [2.0273, 1.8906, 1.4580,    nan, 1.8018, 0.7100, 2.1855,    nan, 1.2793,
         1.8701],
        [1.8193, 2.1367, 1.2715, 1.5000,    nan, 0.4434, 1.2793,    nan,    nan,
         1.6523],
        [   nan,    nan, 1.6299, 1.8789,    nan, 2.1504, 2.0234,    nan, 2.4062,
         2.1953],
        [0.5640, 2.5410,    nan, 1.2402,    nan,    nan,    nan, 2.3105,    nan,
         1.4219],
        [1.3447, 0.8066,    nan,    nan,    nan, 0.9873,    nan, 2.5215, 1.9180,
         1.7588],
        [0.9551, 0.4634, 2.4258, 1.9951, 2.6250, 2.3145, 0.7339,    nan,    nan,
         2.1641]], device='xla:0', dtype=torch.float16)
>>> o
tensor([[-1.1270, -1.4150, -0.1154,  0.2632,  1.6367, -0.1959,  1.1055,  0.7510,
         -1.6123, -0.6021],
        [ 0.7930,  0.4233,  0.1595,  0.0323,  1.2559,  0.0260,  0.0749,  0.1310,
          0.7090,  0.3503],
        [-0.9771,  0.6997,  0.6445, -0.3220,  0.8853,  0.1801, -0.9917,  0.9165,
         -0.4778,  0.0540],
        [-1.2686,  1.0869,  0.0313, -0.9277, -0.3801, -0.6411, -1.0547,  0.0729,
          1.1924, -1.0273],
        [-0.4412, -0.3142,  0.1122,  1.5215, -0.2286,  0.7583, -0.5771,  1.6660,
          0.2878, -0.2944],
        [-0.2465, -0.5356,  0.2947,  0.0709,  1.6484,  0.9033,  0.2874,  1.2842,
          1.6113, -0.0819],
        [ 2.0293, -1.2822, -0.0592, -0.3037, -1.1924, -0.5469, -0.4377,  1.7822,
         -0.7417, -0.5840],
        [ 0.8452, -0.8252, -1.8975,  0.3250,  1.8320, -1.9912,  1.1797, -0.6743,
          1.2236,  0.1479],
        [ 0.2244,  0.6919, -2.1836,  1.4150,  1.7031,  0.5508,  1.2012, -0.8135,
         -0.3403, -0.1870],
        [ 0.5776,  0.8945, -0.7549, -0.4121, -0.8691, -0.6768,  0.7427, -1.1553,
         -2.0664, -0.5586]], device='xla:0', dtype=torch.float16)
>>> 
>>> k = torch.randint(0, 10, (10, 10)).to(torch.int32).to(xm.xla_device())
>>> l = torch.acos(k)
>>> xm.mark_step()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/root/pytorch/xla/torch_xla/core/xla_model.py", line 894, in mark_step
    torch_xla._XLAC._xla_step_marker(
RuntimeError: Error while lowering: [] aten::acos, xla_shape=s32[10,10]{1,0}, dynamic_dims: ()
XLA builder error: INVALID_ARGUMENT: Invalid cast from floating point type to S32 in ConstantR0WithType.: 
Frames:

>>> 
>>> exit()
```

so promote int to flost for acos operation (consistent with PyTorch) like https://github.com/pytorch/xla/pull/4333

---

Testing:
```
# pytest test/test_core_aten_ops.py -k test_aten_acos_0
=============================================== test session starts ===============================================
platform linux -- Python 3.10.13, pytest-7.4.3, pluggy-1.3.0
rootdir: /root/pytorch
configfile: pytest.ini
plugins: hypothesis-6.90.0
collected 518 items / 517 deselected / 1 selected                                                                 

test/test_core_aten_ops.py .                                                                                [100%]

======================================== 1 passed, 517 deselected in 6.44s ========================================
# pytest test/test_core_aten_ops.py -k test_aten_acos_1
=============================================== test session starts ===============================================
platform linux -- Python 3.10.13, pytest-7.4.3, pluggy-1.3.0
rootdir: /root/pytorch
configfile: pytest.ini
plugins: hypothesis-6.90.0
collected 518 items / 517 deselected / 1 selected                                                                 

test/test_core_aten_ops.py .                                                                                [100%]

======================================== 1 passed, 517 deselected in 6.50s ========================================
# pytest test/test_core_aten_ops.py -k test_aten_acos_2
=============================================== test session starts ===============================================
platform linux -- Python 3.10.13, pytest-7.4.3, pluggy-1.3.0
rootdir: /root/pytorch
configfile: pytest.ini
plugins: hypothesis-6.90.0
collected 518 items / 517 deselected / 1 selected                                                                 

test/test_core_aten_ops.py .                                                                                [100%]

======================================== 1 passed, 517 deselected in 6.60s ========================================
```

didn't test `test_aten_acos_3` due to there is no `test_aten_acos_3` in [test_core_aten_ops.py](https://github.com/pytorch/xla/blob/master/test/test_core_aten_ops.py), [reference](https://github.com/pytorch/xla/blob/bcefe806912304e4f7eae1a75b48c05628fdbdae/test/test_core_aten_ops.py#L94C3-L111C1)