### PR TITLE
benchmarks/torchbench_model: add more benchmarks that fail to load

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -69,12 +69,8 @@ DENY_LIST = {
     "pytorch_struct": [{
         "test": "eval"
     },],  # not implemented
-    "pytorch_unet": [
-        {
-            # self.load_benchmark() exits the main process. See issue #6207.
-            "xla": "PJRT",
-        },
-    ],
+    # self.load_benchmark() exits the main process. See issue #6207.
+    "pytorch_unet": [{}],
     "resnet50_quantized_qat": [
         {
             "test": "eval",
@@ -85,12 +81,8 @@ DENY_LIST = {
             "accelerator": "tpu"
         },
     ],  # not implemented
-    "tacotron2": [
-        {
-            # self.load_benchmark() exits the main process. See issue #6207.
-            "xla": "PJRT",
-        },
-    ],
+    # self.load_benchmark() exits the main process. See issue #6207.
+    "tacotron2": [{}],
     # https://github.com/pytorch/pytorch/issues/99438
     "vision_maskrcnn": [{}],
 }


### PR DESCRIPTION
Add Inductor to the deny list for two benchmarks.

Note: I should have added these already in "3ccb4ed2a benchmarks/torchbench_model: skip benchmarks that fail to load (#6199)". This fixes that oversight.