### PR TITLE
Remove or simplify hardcoded lists of device types

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -132,8 +132,7 @@ function run_torch_xla_python_tests() {
       if [ -x "$(command -v nvidia-smi)" ]; then
         # These tests fail on CUDA with 03/30 TF-pin update (https://github.com/pytorch/xla/pull/4840)
         PJRT_DEVICE=CUDA python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
-        # TODO(xiowei replace gpu with cuda): remove the test below with PJRT_DEVICE=GPU because PJRT_DEVICE=GPU is being deprecated.
-        PJRT_DEVICE=GPU python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
+        PJRT_DEVICE=CUDA python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
         PJRT_DEVICE=CUDA python test/test_train_mp_imagenet_fsdp.py --fake_data --auto_wrap_policy type_based --use_small_fake_sample --num_epochs=1
         XLA_DISABLE_FUNCTIONALIZATION=1 PJRT_DEVICE=CUDA python test/test_train_mp_imagenet_fsdp.py --fake_data --use_nested_fsdp --use_small_fake_sample --num_epochs=1
         # Syncfree SGD optimizer tests

--- a/test/pjrt/test_ddp.py
+++ b/test/pjrt/test_ddp.py
@@ -32,7 +32,7 @@ class TestPjRtDistributedDataParallel(parameterized.TestCase):
   def test_ddp_init(self):
     pjrt.run_multiprocess(self._ddp_init)
 
-  @absltest.skipIf(xr.device_type() in ('GPU', 'CUDA', 'ROCM'),
+  @absltest.skipIf(xr.device_type() == 'CUDA',
                    "GPU device is not supported by pjrt.spawn_threads")
   def test_ddp_init_threaded(self):
     pjrt.spawn_threads(self._ddp_init)

--- a/test/pjrt/test_runtime.py
+++ b/test/pjrt/test_runtime.py
@@ -97,7 +97,7 @@ class TestExperimentalPjrt(parameterized.TestCase):
         xr.using_pjrt()
 
       if expect_using_pjrt:
-        self.assertIn(xr.device_type(), ['CPU', 'CUDA', 'TPU', 'ROCM', 'GPU'])
+        self.assertIn(xr.device_type(), ['CPU', 'CUDA', 'TPU'])
       else:
         self.assertIsNone(xr.device_type())
 

--- a/test/pjrt/test_runtime_gpu.py
+++ b/test/pjrt/test_runtime_gpu.py
@@ -17,7 +17,7 @@ from torch_xla._internal import pjrt
 from absl.testing import absltest, parameterized
 
 
-@unittest.skipIf(xr.device_type() not in ('GPU', 'CUDA', 'ROCM'),
+@unittest.skipIf(xr.device_type() != "CUDA",
                  f"GPU tests should only run on GPU devices.")
 class TestExperimentalPjrtGpu(parameterized.TestCase):
 

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -28,9 +28,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     xr.use_spmd()
     super().setUpClass()
 
-  @unittest.skipUnless(
-      xr.device_type() == 'TPU',
-      f"Requires PJRT_DEVICE set to `TPU`.")
+  @unittest.skipUnless(xr.device_type() == 'TPU',
+                       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_debugging_spmd_single_host_tiled_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     device = xm.xla_device()
@@ -107,9 +106,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipUnless(
-      xr.device_type() == 'TPU',
-      f"Requires PJRT_DEVICE set to `TPU`.")
+  @unittest.skipUnless(xr.device_type() == 'TPU',
+                       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_single_host_partial_replication_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     device = xm.xla_device()
@@ -157,9 +155,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipUnless(
-      xr.device_type() == 'TPU',
-      f"Requires PJRT_DEVICE set to `TPU`.")
+  @unittest.skipUnless(xr.device_type() == 'TPU',
+                       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_single_host_replicated_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     device = xm.xla_device()
@@ -201,9 +198,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipUnless(
-      xr.device_type() == 'CPU',
-      f"Requires PJRT_DEVICE set to `CPU`.")
+  @unittest.skipUnless(xr.device_type() == 'CPU',
+                       f"Requires PJRT_DEVICE set to `CPU`.")
   def test_debugging_spmd_single_host_tiled_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     device = xm.xla_device()
@@ -243,9 +239,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipUnless(
-      xr.device_type() == 'CPU',
-      f"Requires PJRT_DEVICE set to `CPU`.")
+  @unittest.skipUnless(xr.device_type() == 'CPU',
+                       f"Requires PJRT_DEVICE set to `CPU`.")
   def test_single_host_partial_replication_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     device = xm.xla_device()
@@ -286,9 +281,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipUnless(
-      xr.device_type() == 'CPU',
-      f"Requires PJRT_DEVICE set to `CPU`.")
+  @unittest.skipUnless(xr.device_type() == 'CPU',
+                       f"Requires PJRT_DEVICE set to `CPU`.")
   def test_single_host_replicated_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     device = xm.xla_device()
@@ -335,9 +329,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 # e.g.: sharding={devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}
 # e.g.: sharding={replicated}
 
-  @unittest.skipUnless(
-      xr.device_type() == 'TPU',
-      f"Requires PJRT_DEVICE set to `TPU`.")
+  @unittest.skipUnless(xr.device_type() == 'TPU',
+                       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_debugging_spmd_multi_host_tiled_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[2,8]0,4,8,12,2,6,10,14,1,5,9,13,3,7,11,15}'
@@ -446,9 +439,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipUnless(
-      xr.device_type() == 'TPU',
-      f"Requires PJRT_DEVICE set to `TPU`.")
+  @unittest.skipUnless(xr.device_type() == 'TPU',
+                       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_multi_host_partial_replication_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}'
@@ -529,9 +521,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipUnless(
-      xr.device_type() == 'TPU',
-      f"Requires PJRT_DEVICE set to `TPU`.")
+  @unittest.skipUnless(xr.device_type() == 'TPU',
+                       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_multi_host_replicated_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{replicated}'
@@ -564,9 +555,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipUnless(
-      xr.device_type() == 'CPU',
-      f"Requires PJRT_DEVICE set to `CPU`.")
+  @unittest.skipUnless(xr.device_type() == 'CPU',
+                       f"Requires PJRT_DEVICE set to `CPU`.")
   def test_debugging_spmd_multi_host_tiled_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[2,8]0,4,8,12,2,6,10,14,1,5,9,13,3,7,11,15}'
@@ -675,9 +665,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipUnless(
-      xr.device_type() == 'CPU',
-      f"Requires PJRT_DEVICE set to `CPU`.")
+  @unittest.skipUnless(xr.device_type() == 'CPU',
+                       f"Requires PJRT_DEVICE set to `CPU`.")
   def test_multi_host_partial_replication_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}'
@@ -758,9 +747,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipUnless(
-      xr.device_type() == 'CPU',
-      f"Requires PJRT_DEVICE set to `CPU`.")
+  @unittest.skipUnless(xr.device_type() == 'CPU',
+                       f"Requires PJRT_DEVICE set to `CPU`.")
   def test_multi_host_replicated_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{replicated}'

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -28,9 +28,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     xr.use_spmd()
     super().setUpClass()
 
-  @unittest.skipIf(
-      not xr.using_pjrt() or
-      xu.getenv_as(xenv.PJRT_DEVICE, str) in ("GPU", 'CUDA', 'ROCM', 'CPU'),
+  @unittest.skipUnless(
+      xr.device_type() == 'TPU',
       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_debugging_spmd_single_host_tiled_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
@@ -108,9 +107,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipIf(
-      not xr.using_pjrt() or
-      xu.getenv_as(xenv.PJRT_DEVICE, str) in ("GPU", 'CUDA', 'ROCM', 'CPU'),
+  @unittest.skipUnless(
+      xr.device_type() == 'TPU',
       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_single_host_partial_replication_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
@@ -159,9 +157,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipIf(
-      not xr.using_pjrt() or
-      xu.getenv_as(xenv.PJRT_DEVICE, str) in ("GPU", 'CUDA', 'ROCM', 'CPU'),
+  @unittest.skipUnless(
+      xr.device_type() == 'TPU',
       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_single_host_replicated_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
@@ -204,9 +201,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipIf(
-      not xr.using_pjrt() or
-      xu.getenv_as(xenv.PJRT_DEVICE, str) in ("GPU", 'CUDA', 'ROCM', 'TPU'),
+  @unittest.skipUnless(
+      xr.device_type() == 'CPU',
       f"Requires PJRT_DEVICE set to `CPU`.")
   def test_debugging_spmd_single_host_tiled_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
@@ -247,9 +243,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipIf(
-      not xr.using_pjrt() or
-      xu.getenv_as(xenv.PJRT_DEVICE, str) in ("GPU", 'CUDA', 'ROCM', 'TPU'),
+  @unittest.skipUnless(
+      xr.device_type() == 'CPU',
       f"Requires PJRT_DEVICE set to `CPU`.")
   def test_single_host_partial_replication_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
@@ -291,9 +286,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipIf(
-      not xr.using_pjrt() or
-      xu.getenv_as(xenv.PJRT_DEVICE, str) in ("GPU", 'CUDA', 'ROCM', 'TPU'),
+  @unittest.skipUnless(
+      xr.device_type() == 'CPU',
       f"Requires PJRT_DEVICE set to `CPU`.")
   def test_single_host_replicated_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
@@ -341,9 +335,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 # e.g.: sharding={devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}
 # e.g.: sharding={replicated}
 
-  @unittest.skipIf(
-      not xr.using_pjrt() or
-      xu.getenv_as(xenv.PJRT_DEVICE, str) in ("GPU", 'CUDA', 'ROCM', 'CPU'),
+  @unittest.skipUnless(
+      xr.device_type() == 'TPU',
       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_debugging_spmd_multi_host_tiled_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
@@ -453,9 +446,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipIf(
-      not xr.using_pjrt() or
-      xu.getenv_as(xenv.PJRT_DEVICE, str) in ("GPU", 'CUDA', 'ROCM', 'CPU'),
+  @unittest.skipUnless(
+      xr.device_type() == 'TPU',
       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_multi_host_partial_replication_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
@@ -537,9 +529,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipIf(
-      not xr.using_pjrt() or
-      xu.getenv_as(xenv.PJRT_DEVICE, str) in ("GPU", 'CUDA', 'ROCM', 'CPU'),
+  @unittest.skipUnless(
+      xr.device_type() == 'TPU',
       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_multi_host_replicated_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
@@ -573,9 +564,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipIf(
-      not xr.using_pjrt() or
-      xu.getenv_as(xenv.PJRT_DEVICE, str) in ("GPU", 'CUDA', 'ROCM', 'TPU'),
+  @unittest.skipUnless(
+      xr.device_type() == 'CPU',
       f"Requires PJRT_DEVICE set to `CPU`.")
   def test_debugging_spmd_multi_host_tiled_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
@@ -685,9 +675,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipIf(
-      not xr.using_pjrt() or
-      xu.getenv_as(xenv.PJRT_DEVICE, str) in ("GPU", 'CUDA', 'ROCM', 'TPU'),
+  @unittest.skipUnless(
+      xr.device_type() == 'CPU',
       f"Requires PJRT_DEVICE set to `CPU`.")
   def test_multi_host_partial_replication_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
@@ -769,9 +758,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipIf(
-      not xr.using_pjrt() or
-      xu.getenv_as(xenv.PJRT_DEVICE, str) in ("GPU", 'CUDA', 'ROCM', 'TPU'),
+  @unittest.skipUnless(
+      xr.device_type() == 'CPU',
       f"Requires PJRT_DEVICE set to `CPU`.")
   def test_multi_host_replicated_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -28,8 +28,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     xr.use_spmd()
     super().setUpClass()
 
-  @unittest.skipUnless(xr.device_type() == 'TPU',
-                       f"Requires PJRT_DEVICE set to `TPU`.")
+  @unittest.skipIf(xr.device_type() != 'TPU',
+                   f"Requires PJRT_DEVICE set to `TPU`.")
   def test_debugging_spmd_single_host_tiled_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     device = xm.xla_device()
@@ -106,8 +106,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipUnless(xr.device_type() == 'TPU',
-                       f"Requires PJRT_DEVICE set to `TPU`.")
+  @unittest.skipIf(xr.device_type() != 'TPU',
+                   f"Requires PJRT_DEVICE set to `TPU`.")
   def test_single_host_partial_replication_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     device = xm.xla_device()
@@ -155,8 +155,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipUnless(xr.device_type() == 'TPU',
-                       f"Requires PJRT_DEVICE set to `TPU`.")
+  @unittest.skipIf(xr.device_type() != 'TPU',
+                   f"Requires PJRT_DEVICE set to `TPU`.")
   def test_single_host_replicated_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     device = xm.xla_device()
@@ -198,8 +198,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipUnless(xr.device_type() == 'CPU',
-                       f"Requires PJRT_DEVICE set to `CPU`.")
+  @unittest.skipIf(xr.device_type() != 'CPU',
+                   f"Requires PJRT_DEVICE set to `CPU`.")
   def test_debugging_spmd_single_host_tiled_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     device = xm.xla_device()
@@ -239,8 +239,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipUnless(xr.device_type() == 'CPU',
-                       f"Requires PJRT_DEVICE set to `CPU`.")
+  @unittest.skipIf(xr.device_type() != 'CPU',
+                   f"Requires PJRT_DEVICE set to `CPU`.")
   def test_single_host_partial_replication_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     device = xm.xla_device()
@@ -281,8 +281,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipUnless(xr.device_type() == 'CPU',
-                       f"Requires PJRT_DEVICE set to `CPU`.")
+  @unittest.skipIf(xr.device_type() != 'CPU',
+                   f"Requires PJRT_DEVICE set to `CPU`.")
   def test_single_host_replicated_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     device = xm.xla_device()
@@ -329,8 +329,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 # e.g.: sharding={devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}
 # e.g.: sharding={replicated}
 
-  @unittest.skipUnless(xr.device_type() == 'TPU',
-                       f"Requires PJRT_DEVICE set to `TPU`.")
+  @unittest.skipIf(xr.device_type() != 'TPU',
+                   f"Requires PJRT_DEVICE set to `TPU`.")
   def test_debugging_spmd_multi_host_tiled_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[2,8]0,4,8,12,2,6,10,14,1,5,9,13,3,7,11,15}'
@@ -439,8 +439,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipUnless(xr.device_type() == 'TPU',
-                       f"Requires PJRT_DEVICE set to `TPU`.")
+  @unittest.skipIf(xr.device_type() != 'TPU',
+                   f"Requires PJRT_DEVICE set to `TPU`.")
   def test_multi_host_partial_replication_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}'
@@ -521,8 +521,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipUnless(xr.device_type() == 'TPU',
-                       f"Requires PJRT_DEVICE set to `TPU`.")
+  @unittest.skipIf(xr.device_type() != 'TPU',
+                   f"Requires PJRT_DEVICE set to `TPU`.")
   def test_multi_host_replicated_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{replicated}'
@@ -555,8 +555,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipUnless(xr.device_type() == 'CPU',
-                       f"Requires PJRT_DEVICE set to `CPU`.")
+  @unittest.skipIf(xr.device_type() != 'CPU',
+                   f"Requires PJRT_DEVICE set to `CPU`.")
   def test_debugging_spmd_multi_host_tiled_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[2,8]0,4,8,12,2,6,10,14,1,5,9,13,3,7,11,15}'
@@ -665,8 +665,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipUnless(xr.device_type() == 'CPU',
-                       f"Requires PJRT_DEVICE set to `CPU`.")
+  @unittest.skipIf(xr.device_type() != 'CPU',
+                   f"Requires PJRT_DEVICE set to `CPU`.")
   def test_multi_host_partial_replication_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}'
@@ -747,8 +747,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipUnless(xr.device_type() == 'CPU',
-                       f"Requires PJRT_DEVICE set to `CPU`.")
+  @unittest.skipIf(xr.device_type() != 'CPU',
+                   f"Requires PJRT_DEVICE set to `CPU`.")
   def test_multi_host_replicated_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{replicated}'

--- a/test/spmd/test_xla_distributed_checkpoint.py
+++ b/test/spmd/test_xla_distributed_checkpoint.py
@@ -506,8 +506,8 @@ class CheckpointManagerTest(DistributedCheckpointTestBase):
             torch.allclose(v, new_state_dict[k])
             for k, v in state_dict.items()))
 
-  @unittest.skipUnless(xr.device_type() == 'TPU',
-                       'TPU required for worker IP discovery')
+  @unittest.skipIf(xr.device_type() != 'TPU',
+                   'TPU required for worker IP discovery')
   @unittest.mock.patch('torch_xla._internal.tpu.get_worker_ips')
   def test_master_ip_discovery(self, patched_get_worker_ips):
     # A basic test to verify the SPMD codepath returns the correct IP. Two IPs
@@ -543,8 +543,8 @@ class CheckpointManagerTest(DistributedCheckpointTestBase):
       # Scope the PreemptionSyncManager to the lifespan of the test.
       torch_xla._XLAC._deactivate_preemption_sync_manager()
 
-  @unittest.skipUnless(xr.device_type() == 'TPU',
-                       'TPU required for worker IP discovery')
+  @unittest.skipIf(xr.device_type() != 'TPU',
+                   'TPU required for worker IP discovery')
   @run_with_tmpdir
   def test_auto_checkpoint(self, tmpdir):
     # Create a checkpoint manager with a long save interval

--- a/test/spmd/test_xla_sharding_base.py
+++ b/test/spmd/test_xla_sharding_base.py
@@ -9,9 +9,8 @@ import torch_xla.core.xla_env_vars as xenv
 import torch_xla.utils.utils as xu
 
 
-@unittest.skipIf(not xr.using_pjrt() or
-                 xu.getenv_as(xenv.PJRT_DEVICE, str) in ("GPU", 'CUDA', 'ROCM'),
-                 f"Requires PJRT_DEVICE set to `TPU` or `CPU`.")
+@unittest.skipUnless(xr.device_type() in ("TPU", "CPU"),
+                     f"Requires PJRT_DEVICE set to `TPU` or `CPU`.")
 class XlaShardingTest(unittest.TestCase):
 
   class SimpleLinear(nn.Module):

--- a/test/spmd/test_xla_spmd_python_api_interaction.py
+++ b/test/spmd/test_xla_spmd_python_api_interaction.py
@@ -122,7 +122,7 @@ class BasicAutocastAPITest(test_xla_sharding_base.XlaShardingTest):
     xr.use_spmd()
     super().setUpClass()
 
-  @unittest.skipIf(xr.device_type() not in ['GPU', 'TPU', 'CUDA', 'ROCM'],
+  @unittest.skipIf(xr.device_type() not in ['TPU', 'CUDA'],
                    f"TPU/GPU autocast test.")
   def test_xla_autocast_api(self):
     device = xm.xla_device()

--- a/test/test_ddp.py
+++ b/test/test_ddp.py
@@ -16,7 +16,7 @@ class TestXrtDistributedDataParallel(parameterized.TestCase):
     # We cannot run this guard before XMP,
     # see API_GUIDE.md#running-on-multiple-xla-devices-with-multi-processing.
     device = xm.xla_device()
-    if xm.xla_device_hw(device) not in ('GPU', 'TPU', 'CUDA', 'ROCM'):
+    if xm.xla_device_hw(device) not in ('TPU', 'CUDA'):
       print(
           'Default device {} is not a TPU device'.format(device),
           file=sys.stderr)

--- a/test/test_fsdp_auto_wrap.py
+++ b/test/test_fsdp_auto_wrap.py
@@ -31,9 +31,10 @@ class TestNoBackwardModule(test_utils.XlaTestCase):
       hidden2 = self.fc2(x)
       return hidden1, hidden2
 
-  @unittest.skipIf(xr.device_type() == 'CUDA',
-  "This test fails only on GPU with 03/30 TF-pin update (https://github.com/pytorch/xla/pull/4840)"
-                  )
+  @unittest.skipIf(
+      xr.device_type() == 'CUDA',
+      "This test fails only on GPU with 03/30 TF-pin update (https://github.com/pytorch/xla/pull/4840)"
+  )
   def test(self):
     dev = xm.xla_device()
     input = torch.zeros([16, 16], device=dev)

--- a/test/test_fsdp_auto_wrap.py
+++ b/test/test_fsdp_auto_wrap.py
@@ -31,9 +31,8 @@ class TestNoBackwardModule(test_utils.XlaTestCase):
       hidden2 = self.fc2(x)
       return hidden1, hidden2
 
-  @unittest.skipIf(xr.device_type() in (
-      'GPU', 'ROCM', 'CUDA'
-  ), "This test fails only on GPU with 03/30 TF-pin update (https://github.com/pytorch/xla/pull/4840)"
+  @unittest.skipIf(xr.device_type() == 'CUDA',
+  "This test fails only on GPU with 03/30 TF-pin update (https://github.com/pytorch/xla/pull/4840)"
                   )
   def test(self):
     dev = xm.xla_device()
@@ -50,7 +49,7 @@ class TestNoBackwardModule(test_utils.XlaTestCase):
 
 def _mp_fn(index):
   device = xm.xla_device()
-  if xm.xla_device_hw(device) in ('TPU', 'GPU', 'CUDA', 'ROCM'):
+  if xm.xla_device_hw(device) in ('TPU', 'CUDA'):
     test = unittest.main(exit=False)
     sys.exit(0 if test.result.wasSuccessful() else 1)
   else:

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -172,8 +172,7 @@ class MetricsTest(unittest.TestCase):
     report = met.metrics_report()
     self.assertIn("CachedCompile", report)
 
-  @unittest.skipUnless(xr.device_type() == "CPU",
-                       f"This test only works on CPU.")
+  @unittest.skipIf(xr.device_type() != "CPU", f"This test only works on CPU.")
   def test_execute_time_metric(self):
     # Initialize the client before starting the timer.
     xm.xla_device()

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -3,6 +3,7 @@ import time
 
 import torch
 import torch_xla
+import torch_xla.runtime as xr
 import torch_xla.core.xla_model as xm
 import torch_xla.debug.metrics as met
 import unittest
@@ -171,11 +172,8 @@ class MetricsTest(unittest.TestCase):
     report = met.metrics_report()
     self.assertIn("CachedCompile", report)
 
-  @unittest.skipIf(
-      xm.get_xla_supported_devices("CUDA") or
-      xm.get_xla_supported_devices("GPU") or
-      xm.get_xla_supported_devices("ROCM") or
-      xm.get_xla_supported_devices("TPU"), f"This test only works on CPU.")
+  @unittest.skipUnless(
+      xr.device_type() == "CPU", f"This test only works on CPU.")
   def test_execute_time_metric(self):
     # Initialize the client before starting the timer.
     xm.xla_device()

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -172,8 +172,8 @@ class MetricsTest(unittest.TestCase):
     report = met.metrics_report()
     self.assertIn("CachedCompile", report)
 
-  @unittest.skipUnless(
-      xr.device_type() == "CPU", f"This test only works on CPU.")
+  @unittest.skipUnless(xr.device_type() == "CPU",
+                       f"This test only works on CPU.")
   def test_execute_time_metric(self):
     # Initialize the client before starting the timer.
     xm.xla_device()

--- a/test/test_mp_all_gather.py
+++ b/test/test_mp_all_gather.py
@@ -14,7 +14,7 @@ def _mp_fn(index):
   device = xm.xla_device()
   world_size = xm.xrt_world_size()
   input_list_size = 5
-  if xm.xla_device_hw(device) in ('TPU', 'GPU', 'CUDA', 'ROCM', 'NEURON'):
+  if xm.xla_device_hw(device) in ('TPU', 'CUDA', 'NEURON'):
     # Testing with a single replica group
     ordinal_tensor = torch.tensor([index], dtype=torch.float).to(device)
     result = xm.all_gather(ordinal_tensor, dim=0)

--- a/test/test_mp_distributed_mm.py
+++ b/test/test_mp_distributed_mm.py
@@ -9,7 +9,7 @@ import torch_xla.distributed.xla_multiprocessing as xmp
 def _mp_fn(index):
   device = xm.xla_device()
 
-  if xm.xla_device_hw(device) in ('TPU', 'GPU', 'CUDA', 'ROCM'):
+  if xm.xla_device_hw(device) in ('TPU', 'CUDA'):
     world_size = xm.xrt_world_size()
     torch_xla._XLAC._xla_set_use_full_mat_mul_precision(
         use_full_mat_mul_precision=True)

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -453,8 +453,8 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     devices = xm.get_xla_supported_devices()
     xla_devices = torch_xla._XLAC._xla_real_devices(devices)
     for device, xdevice in zip(devices, xla_devices):
-      self.assertTrue(
-          re.match(r'(CPU|GPU|TPU|CUDA|ROCM):\d+$', xdevice) is not None)
+      self.assertIsNotNone(
+          re.fullmatch(r'[A-Z]+:\d+$', xdevice))
 
   def test_negative_slice(self):
     t = _gen_tensor(32, 24, 32)

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -453,8 +453,7 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     devices = xm.get_xla_supported_devices()
     xla_devices = torch_xla._XLAC._xla_real_devices(devices)
     for device, xdevice in zip(devices, xla_devices):
-      self.assertIsNotNone(
-          re.fullmatch(r'[A-Z]+:\d+$', xdevice))
+      self.assertIsNotNone(re.fullmatch(r'[A-Z]+:\d+$', xdevice))
 
   def test_negative_slice(self):
     t = _gen_tensor(32, 24, 32)

--- a/test/test_torch_distributed_all_gather_xla_backend.py
+++ b/test/test_torch_distributed_all_gather_xla_backend.py
@@ -10,7 +10,7 @@ import torch.distributed as dist
 
 def _mp_fn(index):
   device = xm.xla_device()
-  if xm.xla_device_hw(device) in ('TPU', 'GPU', 'CUDA', 'ROCM'):
+  if xm.xla_device_hw(device) in ('TPU', 'CUDA'):
     world_size = xm.xrt_world_size()
     rank = xm.get_ordinal()
 

--- a/test/test_torch_distributed_all_reduce_xla_backend.py
+++ b/test/test_torch_distributed_all_reduce_xla_backend.py
@@ -10,7 +10,7 @@ import torch.distributed as dist
 
 def _mp_fn(index):
   device = xm.xla_device()
-  if xm.xla_device_hw(device) in ('TPU', 'GPU', 'CUDA', 'ROCM'):
+  if xm.xla_device_hw(device) in ('TPU', 'CUDA'):
     world_size = xm.xrt_world_size()
     rank = xm.get_ordinal()
 

--- a/test/test_torch_distributed_multi_all_reduce_xla_backend.py
+++ b/test/test_torch_distributed_multi_all_reduce_xla_backend.py
@@ -10,7 +10,7 @@ import torch.distributed as dist
 
 def _mp_fn(index):
   device = xm.xla_device()
-  if xm.xla_device_hw(device) in ('TPU', 'GPU', 'CUDA', 'ROCM'):
+  if xm.xla_device_hw(device) in ('TPU', 'CUDA'):
     world_size = xm.xrt_world_size()
     rank = xm.get_ordinal()
 

--- a/test/test_torch_distributed_reduce_scatter_xla_backend.py
+++ b/test/test_torch_distributed_reduce_scatter_xla_backend.py
@@ -10,7 +10,7 @@ import torch.distributed as dist
 
 def _mp_fn(index):
   device = xm.xla_device()
-  if xm.xla_device_hw(device) in ('TPU', 'GPU', 'CUDA', 'ROCM'):
+  if xm.xla_device_hw(device) in ('TPU', 'CUDA'):
     world_size = xm.xrt_world_size()
     rank = xm.get_ordinal()
 

--- a/test/test_train_mp_imagenet_amp.py
+++ b/test/test_train_mp_imagenet_amp.py
@@ -221,7 +221,7 @@ def train_imagenet():
   if FLAGS.amp:
     if device_hw == 'TPU':
       scaler = None
-    elif device_hw in ('GPU', 'CUDA', 'ROCM'):
+    elif device_hw == 'CUDA':
       scaler = GradScaler(use_zero_grad=FLAGS.use_zero_grad)
 
   def train_loop_fn(loader, epoch):

--- a/test/test_zero1.py
+++ b/test/test_zero1.py
@@ -13,7 +13,7 @@ import unittest
 class XlaZeRO1Test(TestCase):
 
   @unittest.skipIf(xr.device_type() == 'TPU', "Crash on TPU")
-  @unittest.skipIf(xr.device_type() in ('GPU', 'CUDA', 'ROCM'),
+  @unittest.skipIf(xr.device_type() == 'CUDA',
                    "TODO(alanwaketan): Fix it for the token change.")
   def test_zero1(self):
     device = xm.xla_device()

--- a/torch_xla/_internal/pjrt.py
+++ b/torch_xla/_internal/pjrt.py
@@ -147,7 +147,7 @@ def run_multiprocess(fn: Callable[..., R],
     num_processes = plugins.default().physical_chip_count()
   elif runtime.device_type() == 'TPU':
     num_processes = tpu.num_local_processes()
-  elif runtime.device_type() in ('GPU', 'ROCM', 'CUDA'):
+  elif runtime.device_type() == 'CUDA':
     num_processes = gpu.num_local_processes()
   elif runtime.device_type() == 'NEURON':
     num_processes = neuron.num_local_processes()
@@ -216,7 +216,7 @@ def _initialize_single_process(local_rank: int, local_world_size: int):
 def spawn_threads(fn: Callable, args: Tuple = ()) -> None:
   """Run function in one process with one thread per addressable device."""
   assert runtime.device_type() not in (
-      'GPU', 'ROCM', 'CUDA'), "spawn_threads does not support GPU device"
+      'CUDA'), "spawn_threads does not support GPU device"
   spawn_fn = _SpawnFn(fn, *args)
   _run_thread_per_device(
       local_rank=0,

--- a/torch_xla/amp/autocast_mode.py
+++ b/torch_xla/amp/autocast_mode.py
@@ -25,7 +25,7 @@ class autocast(torch.amp.autocast_mode.autocast):
 
     self._enabled = enabled
     self._xla_device = xm.xla_device_hw(device)
-    if self._xla_device in ('GPU', 'ROCM', 'CUDA'):
+    if self._xla_device == 'CUDA':
       backend = 'cuda'
       self._xla_bfloat16 = False  # True if xla backend with bfloat16 dtype.
       if dtype is None:
@@ -70,7 +70,7 @@ class autocast(torch.amp.autocast_mode.autocast):
   def __enter__(self):
     # This ensures that xla autocast is enabled even for XLA:GPU, which calls
     # `torch.amp.autocast_mode.autocast` with `cuda` backend.
-    if self._xla_device in ('GPU', 'ROCM', 'CUDA'):
+    if self._xla_device == 'CUDA':
       self.prev = torch.is_autocast_xla_enabled()  # type: ignore[attr-defined]
       self.prev_dtype = torch.get_autocast_xla_dtype(
       )  # type: ignore[attr-defined]
@@ -86,7 +86,7 @@ class autocast(torch.amp.autocast_mode.autocast):
 
   def __exit__(self, exc_type: Any, exc_val: Any,
                exc_tb: Any):  # type: ignore[override]
-    if self._xla_device in ('GPU', 'ROCM', 'CUDA'):
+    if self._xla_device == 'CUDA':
       if self._xla_bfloat16:
         # autocast_xla flags will be set by `torch.autocast` and we need to
         # set autocast flags as we call into `torch.autocast` apis.

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -72,7 +72,7 @@ def is_xla_tensor(tensor):
 
 
 def parse_xla_device(device):
-  m = re.match(r'(CPU|TPU|GPU|ROCM|CUDA|XPU|NEURON):(\d+)$', device)
+  m = re.match(r'([A-Z]+):(\d+)$', device)
   if m:
     return (m.group(1), int(m.group(2)))
 
@@ -81,32 +81,38 @@ def get_xla_supported_devices(devkind=None, max_devices=None):
   """Returns a list of supported devices of a given kind.
 
   Args:
-    devkind (string..., optional): If specified, one of `TPU`, `GPU`, `XPU`,
-      `NEURON` or `CPU` (the 'GPU' XLA device is currently not implemented).
+    devkind (string..., optional): If specified, a device type such as `TPU`,
+      `CUDA`, `CPU`, or name of custom PJRT device.
     max_devices (int, optional): The maximum number of devices to be returned of
       that kind.
 
   Returns:
     The list of device strings.
   """
+  # TODO(wcromar): Remove `devkind` after 2.3 release cut. We no longer support
+  # multiple device types.
+  if not devkind:
+    devices = torch_xla._XLAC._xla_get_devices()
+    return devices[:max_devices] if max_devices else devices
+  else:
+    warnings.warn("`devkind` argument is deprecated and will be removed in a "
+                    "future release.", DeprecationWarning)
+
   # TODO(xiowei replace gpu with cuda): Remove the below if statement after r2.2 release.
   if devkind and devkind.casefold() == 'gpu':
     warnings.warn(
-        "GPU as a device name is being deprecate. Please replace it with CUDA such as get_xla_supported_devices(devkind='CUDA'). Similarly, please replace PJRT_DEVICE=GPU with PJRT_DEVICE=CUDA."
+        "GPU as a device name is being deprecated. Replace PJRT_DEVICE=GPU with"
+        " PJRT_DEVICE=CUDA.", DeprecationWarning
     )
     devkind = 'CUDA'
 
   xla_devices = _DEVICES.value
-  devkind = [devkind] if devkind else [
-      'TPU', 'GPU', 'XPU', 'NEURON', 'CPU', 'CUDA', 'ROCM'
-  ]
-  for kind in devkind:
-    kind_devices = []
-    for i, device in enumerate(xla_devices):
-      if re.match(kind + r':\d+$', device):
-        kind_devices.append('xla:{}'.format(i))
-    if kind_devices:
-      return kind_devices[:max_devices] if max_devices else kind_devices
+  kind_devices = []
+  for i, device in enumerate(xla_devices):
+    if re.match(devkind + r':\d+$', device):
+      kind_devices.append('xla:{}'.format(i))
+  if kind_devices:
+    return kind_devices[:max_devices] if max_devices else kind_devices
 
 
 def xrt_world_size(defval=1):
@@ -191,8 +197,8 @@ def xla_device(n=None, devkind=None):
     n (int, optional): The specific instance (ordinal) to be returned. If
       specified, the specific XLA device instance will be returned. Otherwise
       the first device of `devkind` will be returned.
-    devkind (string..., optional): If specified, one of `TPU`, `CUDA`, `XPU`
-      `NEURON`, `ROCM` or `CPU`.
+    devkind (string..., optional): If specified, device type such as `TPU`,
+      `CUDA`, `CPU`, or custom PJRT device. Deprecated.
 
   Returns:
     A `torch.device` with the requested instance.
@@ -230,8 +236,7 @@ def xla_device_hw(device):
       real device.
 
   Returns:
-    A string representation of the hardware type (`CPU`, `TPU`, `XPU`, `NEURON`, `GPU`, `CUDA`, `ROCM`)
-    of the given device.
+    A string representation of the hardware type of the given device.
   """
   real_device = _xla_real_device(device)
   return real_device.split(':')[0]
@@ -558,8 +563,8 @@ def all_gather(value, dim=0, groups=None, output=None, pin_layout=True):
   """
   # _all_gather_using_all_reduce does not support list of tensors as input
   if pin_layout and output == None and isinstance(value, torch.Tensor):
-    # There is not an easy way to pin the all_gather layout on TPU, GPU and NEURON,
-    # use all_reduce based all_gather for this purpose.
+    # There is not an easy way to pin the all_gather layout, so use all_reduce
+    # based all_gather for this purpose.
     return _all_gather_using_all_reduce(
         value, dim=dim, groups=groups, pin_layout=True)
 

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -101,13 +101,6 @@ def get_xla_supported_devices(devkind=None, max_devices=None):
     warnings.warn("`devkind` argument is deprecated and will be removed in a "
                   "future release.")
 
-  # TODO(xiowei replace gpu with cuda): Remove the below if statement after r2.2 release.
-  if devkind and devkind.casefold() == 'gpu':
-    warnings.warn(
-        "GPU as a device name is being deprecated. Replace PJRT_DEVICE=GPU with"
-        " PJRT_DEVICE=CUDA.")
-    devkind = 'CUDA'
-
   xla_devices = _DEVICES.value
   kind_devices = []
   for i, device in enumerate(xla_devices):

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -93,7 +93,10 @@ def get_xla_supported_devices(devkind=None, max_devices=None):
   # multiple device types.
   if not devkind:
     devices = torch_xla._XLAC._xla_get_devices()
-    return [f'xla:{i}' for i, _ in (devices[:max_devices] if max_devices else devices)]
+    return [
+        f'xla:{i}'
+        for i, _ in (devices[:max_devices] if max_devices else devices)
+    ]
   else:
     warnings.warn("`devkind` argument is deprecated and will be removed in a "
                   "future release.")
@@ -102,8 +105,7 @@ def get_xla_supported_devices(devkind=None, max_devices=None):
   if devkind and devkind.casefold() == 'gpu':
     warnings.warn(
         "GPU as a device name is being deprecated. Replace PJRT_DEVICE=GPU with"
-        " PJRT_DEVICE=CUDA."
-    )
+        " PJRT_DEVICE=CUDA.")
     devkind = 'CUDA'
 
   xla_devices = _DEVICES.value

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -95,7 +95,7 @@ def get_xla_supported_devices(devkind=None, max_devices=None):
     devices = torch_xla._XLAC._xla_get_devices()
     return [
         f'xla:{i}'
-        for i, _ in (devices[:max_devices] if max_devices else devices)
+        for i, _ in enumerate(devices[:max_devices] if max_devices else devices)
     ]
   else:
     warnings.warn("`devkind` argument is deprecated and will be removed in a "

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -93,16 +93,16 @@ def get_xla_supported_devices(devkind=None, max_devices=None):
   # multiple device types.
   if not devkind:
     devices = torch_xla._XLAC._xla_get_devices()
-    return devices[:max_devices] if max_devices else devices
+    return [f'xla:{i}' for i, _ in (devices[:max_devices] if max_devices else devices)]
   else:
     warnings.warn("`devkind` argument is deprecated and will be removed in a "
-                    "future release.", DeprecationWarning)
+                  "future release.")
 
   # TODO(xiowei replace gpu with cuda): Remove the below if statement after r2.2 release.
   if devkind and devkind.casefold() == 'gpu':
     warnings.warn(
         "GPU as a device name is being deprecated. Replace PJRT_DEVICE=GPU with"
-        " PJRT_DEVICE=CUDA.", DeprecationWarning
+        " PJRT_DEVICE=CUDA."
     )
     devkind = 'CUDA'
 

--- a/torch_xla/csrc/device.cpp
+++ b/torch_xla/csrc/device.cpp
@@ -9,9 +9,16 @@
 namespace torch_xla {
 namespace {
 
-thread_local absl::optional<torch::lazy::BackendDevice> g_current_device;
+// This is set when any device is initialized, so to prevent using non-virtual
+// device and virtual device together.
+static bool spmd_config_is_locked = false;
 
-std::string XlaDeviceTypeToString(XlaDeviceType hw_type) {
+}  // namespace
+
+
+std::string DeviceType::XlaDeviceTypeToString(XlaDeviceType hw_type) {
+  XLA_CHECK(hw_type != XlaDeviceType::PLUGIN) << "PLUGIN type name unknown";
+
   switch (hw_type) {
     case XlaDeviceType::CPU:
       return "CPU";
@@ -23,21 +30,29 @@ std::string XlaDeviceTypeToString(XlaDeviceType hw_type) {
       return "NEURON";
     case XlaDeviceType::SPMD:
       return "SPMD";
-    case XlaDeviceType::PLUGIN:
-      return "PLUGIN";
+    default:
+      XLA_ERROR() << "Invalid device type";
   }
-  XLA_ERROR() << "Invalid device type";
 }
 
-// This is set when any device is initialized, so to prevent using non-virtual
-// device and virtual device together.
-static bool spmd_config_is_locked = false;
+XlaDeviceType DeviceType::StringToXlaDeviceType(const std::string& type_name) {
+  if (type_name == "SPMD") {
+    return XlaDeviceType::SPMD;
+  } else if (type_name == "TPU") {
+    return XlaDeviceType::TPU;
+  } else if (type_name == "CPU") {
+    return XlaDeviceType::CPU;
+  } else if (type_name == "CUDA") {
+    return XlaDeviceType::CUDA;
+  } else if (type_name == "NEURON") {
+    return XlaDeviceType::NEURON;
+  }
 
-}  // namespace
+  return XlaDeviceType::PLUGIN;
+}
 
 std::string DeviceType::toString() const {
-  return absl::StrCat(XlaDeviceTypeToString(static_cast<XlaDeviceType>(type)),
-                      ":");
+  return absl::StrCat(type_name_, ":");
 }
 
 torch::lazy::BackendDevice ParseDeviceString(const std::string& device_spec) {
@@ -49,26 +64,7 @@ torch::lazy::BackendDevice ParseDeviceString(const std::string& device_spec) {
       << "Invalid device specification: " << device_spec;
 
   int ordinal = std::stoi(device_spec_parts[1]);
-  auto device_type = std::make_shared<DeviceType>();
-  if (device_spec_parts[0] == "SPMD") {
-    device_type->type =
-        static_cast<std::underlying_type_t<XlaDeviceType>>(XlaDeviceType::SPMD);
-  } else if (device_spec_parts[0] == "TPU") {
-    device_type->type =
-        static_cast<std::underlying_type_t<XlaDeviceType>>(XlaDeviceType::TPU);
-  } else if (device_spec_parts[0] == "CPU") {
-    device_type->type =
-        static_cast<std::underlying_type_t<XlaDeviceType>>(XlaDeviceType::CPU);
-  } else if (device_spec_parts[0] == "CUDA") {
-    device_type->type =
-        static_cast<std::underlying_type_t<XlaDeviceType>>(XlaDeviceType::CUDA);
-  } else if (device_spec_parts[0] == "NEURON") {
-    device_type->type = static_cast<std::underlying_type_t<XlaDeviceType>>(
-        XlaDeviceType::NEURON);
-  } else {
-    device_type->type = static_cast<std::underlying_type_t<XlaDeviceType>>(
-        XlaDeviceType::PLUGIN);
-  }
+  auto device_type = std::make_shared<DeviceType>(device_spec_parts[0]);
 
   return torch::lazy::BackendDevice(std::move(device_type), ordinal);
 }

--- a/torch_xla/csrc/device.cpp
+++ b/torch_xla/csrc/device.cpp
@@ -15,7 +15,6 @@ static bool spmd_config_is_locked = false;
 
 }  // namespace
 
-
 std::string DeviceType::XlaDeviceTypeToString(XlaDeviceType hw_type) {
   XLA_CHECK(hw_type != XlaDeviceType::PLUGIN) << "PLUGIN type name unknown";
 

--- a/torch_xla/csrc/device.cpp
+++ b/torch_xla/csrc/device.cpp
@@ -15,12 +15,8 @@ std::string XlaDeviceTypeToString(XlaDeviceType hw_type) {
   switch (hw_type) {
     case XlaDeviceType::CPU:
       return "CPU";
-    case XlaDeviceType::GPU:
-      return "GPU";
     case XlaDeviceType::CUDA:
       return "CUDA";
-    case XlaDeviceType::ROCM:
-      return "ROCM";
     case XlaDeviceType::TPU:
       return "TPU";
     case XlaDeviceType::XPU:
@@ -63,15 +59,9 @@ torch::lazy::BackendDevice ParseDeviceString(const std::string& device_spec) {
   } else if (device_spec_parts[0] == "CPU") {
     device_type->type =
         static_cast<std::underlying_type_t<XlaDeviceType>>(XlaDeviceType::CPU);
-  } else if (device_spec_parts[0] == "ROCM") {
-    device_type->type =
-        static_cast<std::underlying_type_t<XlaDeviceType>>(XlaDeviceType::ROCM);
   } else if (device_spec_parts[0] == "CUDA") {
     device_type->type =
         static_cast<std::underlying_type_t<XlaDeviceType>>(XlaDeviceType::CUDA);
-  } else if (device_spec_parts[0] == "GPU") {
-    device_type->type =
-        static_cast<std::underlying_type_t<XlaDeviceType>>(XlaDeviceType::GPU);
   } else if (device_spec_parts[0] == "XPU") {
     device_type->type =
         static_cast<std::underlying_type_t<XlaDeviceType>>(XlaDeviceType::XPU);

--- a/torch_xla/csrc/device.cpp
+++ b/torch_xla/csrc/device.cpp
@@ -25,6 +25,8 @@ std::string XlaDeviceTypeToString(XlaDeviceType hw_type) {
       return "NEURON";
     case XlaDeviceType::SPMD:
       return "SPMD";
+    case XlaDeviceType::PLUGIN:
+      return "PLUGIN";
   }
   XLA_ERROR() << "Invalid device type";
 }
@@ -69,7 +71,8 @@ torch::lazy::BackendDevice ParseDeviceString(const std::string& device_spec) {
     device_type->type = static_cast<std::underlying_type_t<XlaDeviceType>>(
         XlaDeviceType::NEURON);
   } else {
-    XLA_ERROR() << "Invalid device specification: " << device_spec;
+    device_type->type = static_cast<std::underlying_type_t<XlaDeviceType>>(
+        XlaDeviceType::PLUGIN);
   }
 
   return torch::lazy::BackendDevice(std::move(device_type), ordinal);

--- a/torch_xla/csrc/device.cpp
+++ b/torch_xla/csrc/device.cpp
@@ -19,8 +19,6 @@ std::string XlaDeviceTypeToString(XlaDeviceType hw_type) {
       return "CUDA";
     case XlaDeviceType::TPU:
       return "TPU";
-    case XlaDeviceType::XPU:
-      return "XPU";
     case XlaDeviceType::NEURON:
       return "NEURON";
     case XlaDeviceType::SPMD:
@@ -64,9 +62,6 @@ torch::lazy::BackendDevice ParseDeviceString(const std::string& device_spec) {
   } else if (device_spec_parts[0] == "CUDA") {
     device_type->type =
         static_cast<std::underlying_type_t<XlaDeviceType>>(XlaDeviceType::CUDA);
-  } else if (device_spec_parts[0] == "XPU") {
-    device_type->type =
-        static_cast<std::underlying_type_t<XlaDeviceType>>(XlaDeviceType::XPU);
   } else if (device_spec_parts[0] == "NEURON") {
     device_type->type = static_cast<std::underlying_type_t<XlaDeviceType>>(
         XlaDeviceType::NEURON);

--- a/torch_xla/csrc/device.h
+++ b/torch_xla/csrc/device.h
@@ -18,11 +18,16 @@ namespace torch_xla {
 enum class XlaDeviceType { CPU, CUDA, TPU, NEURON, SPMD, PLUGIN };
 
 struct DeviceType : public torch::lazy::BackendDeviceType {
-  DeviceType(XlaDeviceType xla_device_type) : torch::lazy::BackendDeviceType(static_cast<int>(xla_device_type)), type_name_(XlaDeviceTypeToString(xla_device_type)) { }
-  DeviceType(const std::string& type_name) : torch::lazy::BackendDeviceType(static_cast<int>(StringToXlaDeviceType(type_name))), type_name_(type_name) { }
+  DeviceType(XlaDeviceType xla_device_type)
+      : torch::lazy::BackendDeviceType(static_cast<int>(xla_device_type)),
+        type_name_(XlaDeviceTypeToString(xla_device_type)) {}
+  DeviceType(const std::string& type_name)
+      : torch::lazy::BackendDeviceType(
+            static_cast<int>(StringToXlaDeviceType(type_name))),
+        type_name_(type_name) {}
 
   // TODO(wcromar): do we even want this default constructor?
-  DeviceType() : DeviceType(XlaDeviceType::CPU) {};
+  DeviceType() : DeviceType(XlaDeviceType::CPU){};
 
   std::string toString() const override;
 

--- a/torch_xla/csrc/device.h
+++ b/torch_xla/csrc/device.h
@@ -15,7 +15,7 @@ namespace torch_xla {
 // TODO(yeounoh) `SPMD` is a virtual device that defers data `TransferToDevice`
 // until after the paritioning pass. This avoids transfering  the full input
 // tensor to the device.
-enum class XlaDeviceType { CPU, CUDA, TPU, XPU, NEURON, SPMD, PLUGIN };
+enum class XlaDeviceType { CPU, CUDA, TPU, NEURON, SPMD, PLUGIN };
 
 struct DeviceType : public torch::lazy::BackendDeviceType {
   DeviceType() { type = static_cast<int>(XlaDeviceType::CPU); }

--- a/torch_xla/csrc/device.h
+++ b/torch_xla/csrc/device.h
@@ -26,9 +26,6 @@ struct DeviceType : public torch::lazy::BackendDeviceType {
             static_cast<int>(StringToXlaDeviceType(type_name))),
         type_name_(type_name) {}
 
-  // TODO(wcromar): do we even want this default constructor?
-  DeviceType() : DeviceType(XlaDeviceType::CPU){};
-
   std::string toString() const override;
 
  private:

--- a/torch_xla/csrc/device.h
+++ b/torch_xla/csrc/device.h
@@ -15,7 +15,7 @@ namespace torch_xla {
 // TODO(yeounoh) `SPMD` is a virtual device that defers data `TransferToDevice`
 // until after the paritioning pass. This avoids transfering  the full input
 // tensor to the device.
-enum class XlaDeviceType { CPU, CUDA, ROCM, GPU, TPU, XPU, NEURON, SPMD };
+enum class XlaDeviceType { CPU, CUDA, TPU, XPU, NEURON, SPMD };
 
 struct DeviceType : public torch::lazy::BackendDeviceType {
   DeviceType() { type = static_cast<int>(XlaDeviceType::CPU); }

--- a/torch_xla/csrc/device.h
+++ b/torch_xla/csrc/device.h
@@ -15,7 +15,7 @@ namespace torch_xla {
 // TODO(yeounoh) `SPMD` is a virtual device that defers data `TransferToDevice`
 // until after the paritioning pass. This avoids transfering  the full input
 // tensor to the device.
-enum class XlaDeviceType { CPU, CUDA, TPU, XPU, NEURON, SPMD };
+enum class XlaDeviceType { CPU, CUDA, TPU, XPU, NEURON, SPMD, PLUGIN };
 
 struct DeviceType : public torch::lazy::BackendDeviceType {
   DeviceType() { type = static_cast<int>(XlaDeviceType::CPU); }

--- a/torch_xla/csrc/device.h
+++ b/torch_xla/csrc/device.h
@@ -18,12 +18,19 @@ namespace torch_xla {
 enum class XlaDeviceType { CPU, CUDA, TPU, NEURON, SPMD, PLUGIN };
 
 struct DeviceType : public torch::lazy::BackendDeviceType {
-  DeviceType() { type = static_cast<int>(XlaDeviceType::CPU); }
-  DeviceType(XlaDeviceType xla_device_type) {
-    type = static_cast<int>(xla_device_type);
-  }
+  DeviceType(XlaDeviceType xla_device_type) : torch::lazy::BackendDeviceType(static_cast<int>(xla_device_type)), type_name_(XlaDeviceTypeToString(xla_device_type)) { }
+  DeviceType(const std::string& type_name) : torch::lazy::BackendDeviceType(static_cast<int>(StringToXlaDeviceType(type_name))), type_name_(type_name) { }
+
+  // TODO(wcromar): do we even want this default constructor?
+  DeviceType() : DeviceType(XlaDeviceType::CPU) {};
 
   std::string toString() const override;
+
+ private:
+  std::string type_name_;
+
+  static std::string XlaDeviceTypeToString(XlaDeviceType hw_type);
+  static XlaDeviceType StringToXlaDeviceType(const std::string& type_name);
 };
 
 torch::lazy::BackendDevice ParseDeviceString(const std::string& device_spec);

--- a/torch_xla/csrc/random.cpp
+++ b/torch_xla/csrc/random.cpp
@@ -20,9 +20,7 @@ std::string GetDefaultGitGeneratorName() {
   XlaDeviceType hw_type =
       static_cast<XlaDeviceType>(bridge::GetCurrentDevice().type());
   switch (hw_type) {
-    case XlaDeviceType::GPU:
     case XlaDeviceType::CUDA:
-    case XlaDeviceType::ROCM:
       return "three_fry";
     default:
       return "default";

--- a/torch_xla/csrc/runtime/computation_client.h
+++ b/torch_xla/csrc/runtime/computation_client.h
@@ -316,6 +316,8 @@ class ComputationClient {
 
   virtual std::string GetDefaultDevice() const = 0;
 
+  virtual torch_xla::DeviceType GetDeviceType() const = 0;
+
   virtual size_t GetNumDevices() const = 0;
 
   virtual std::vector<std::string> GetLocalDevices() const = 0;

--- a/torch_xla/csrc/runtime/ifrt_computation_client.h
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.h
@@ -71,6 +71,11 @@ class IfrtComputationClient : public ComputationClient {
 
   std::string GetDefaultDevice() const override;
 
+  torch_xla::DeviceType GetDeviceType() const override {
+    return torch_xla::DeviceType(
+        absl::AsciiStrToUpper(client_->platform_name()));
+  };
+
   std::vector<std::string> GetLocalDevices() const override;
 
   std::vector<std::string> GetAllDevices() const override;

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -74,6 +74,11 @@ class PjRtComputationClient : public ComputationClient {
 
   std::string GetDefaultDevice() const override;
 
+  torch_xla::DeviceType GetDeviceType() const override {
+    return torch_xla::DeviceType(
+        absl::AsciiStrToUpper(client_->platform_name()));
+  };
+
   std::vector<std::string> GetLocalDevices() const override;
 
   std::vector<std::string> GetAllDevices() const override;

--- a/torch_xla/csrc/runtime/pjrt_registry.cc
+++ b/torch_xla/csrc/runtime/pjrt_registry.cc
@@ -83,8 +83,7 @@ InitializePjRt(const std::string& device_type) {
     profiler::RegisterProfilerForPlugin(c_api);
   } else if (device_type == "TPU_LEGACY") {
     XLA_ERROR() << "TPU_LEGACY client is no longer available.";
-  } else if (device_type == "GPU" || device_type == "CUDA" ||
-             device_type == "ROCM") {
+  } else if (device_type == "CUDA") {
     TF_VLOG(1) << "Initializing PjRt GPU client...";
     bool async = sys_util::GetEnvBool(env::kEnvPjrtAsyncGpuClient, true);
     int local_process_rank = sys_util::GetEnvInt(env::kEnvPjRtLocalRank, 0);

--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -76,8 +76,7 @@ XLATensorImpl::XLATensorImpl(XLATensor&& tensor)
   // so we must manually update Autocast to AutocastCUDA on XLA:GPU.
   torch::lazy::BackendDevice current_device = bridge::GetCurrentDevice();
   auto dev_type = static_cast<XlaDeviceType>(current_device.type());
-  if (dev_type == XlaDeviceType::GPU || dev_type == XlaDeviceType::CUDA ||
-      dev_type == XlaDeviceType::ROCM) {
+  if (dev_type == XlaDeviceType::CUDA) {
     auto autocast_cuda_ks = c10::DispatchKeySet(c10::DispatchKey::AutocastCUDA);
     auto autocast_xla_ks = c10::DispatchKeySet(c10::DispatchKey::AutocastXLA);
     key_set_ = (key_set_ - autocast_xla_ks) | autocast_cuda_ks;

--- a/torch_xla/csrc/xla_backend_impl.cpp
+++ b/torch_xla/csrc/xla_backend_impl.cpp
@@ -26,9 +26,8 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
     if (!default_device_type_inited_) {
       // bridge::GetDefaultDevice will trigger the runtime device init, should
       // not do it during class init time.
-      torch::lazy::BackendDevice default_device = *bridge::GetDefaultDevice();
       default_device_type_ = std::make_shared<DeviceType>(
-          static_cast<XlaDeviceType>(default_device.type()));
+          runtime::GetComputationClient()->GetDeviceType());
       default_device_type_inited_ = true;
     }
     return true;

--- a/torch_xla/runtime.py
+++ b/torch_xla/runtime.py
@@ -114,8 +114,7 @@ def xla_device(n: Optional[int] = None,
     A `torch.device` representing an XLA device.
   """
   # TODO(xiowei replace gpu with cuda): Remove the warning message at r2.2 release.
-  pjrt_device = xu.getenv_as(xenv.PJRT_DEVICE, str)
-  if pjrt_device.casefold() == 'gpu':
+  if device_type().casefold() == 'gpu':
     warnings.warn(
         'PJRT_DEVICE=GPU is being deprecate. Please replace PJRT_DEVICE=GPU with PJRT_DEVICE=CUDA.'
     )

--- a/torch_xla/runtime.py
+++ b/torch_xla/runtime.py
@@ -113,12 +113,6 @@ def xla_device(n: Optional[int] = None,
   Returns:
     A `torch.device` representing an XLA device.
   """
-  # TODO(xiowei replace gpu with cuda): Remove the warning message at r2.2 release.
-  if device_type().casefold() == 'gpu':
-    warnings.warn(
-        'PJRT_DEVICE=GPU is being deprecate. Please replace PJRT_DEVICE=GPU with PJRT_DEVICE=CUDA.'
-    )
-
   if n is None:
     return torch.device(torch_xla._XLAC._xla_get_default_device())
 


### PR DESCRIPTION
Allows new device plugins without registering the device type in our code! See #6242 for broader context of this cleanup.

- Add placeholder `PLUGIN` device type for unknown devices
  - Store the actual device name (according to `PjRtClient::platform_name`) in the `DeviceType`, since we still need to pass the device name string across Python/C++ boundary
  - Replace explicit lists of devices with patterns
- Deprecate `devkind` argument, since we only support one PJRT backend at a time
- Remove explicit references to device types that do not have any special cases (XPU, ROCM)
- Remove deprecated `GPU` device type
- Simplify several test skip conditions that had lists of device types

Tested with CPU plugin in #6253 where I change the platform name to `TEST` to simulate an unknown device type. `test_operations.py` passes with that plugin.