### PR TITLE
Add runnable single graph option.

### DIFF
--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -845,6 +845,12 @@ def parse_args(args=None):
       default=False,
       help="Times wall time measurements with pure CUDA events. No kernel launch overhead.",
   )
+  parser.add_argument(
+      "--filter-by-single-graph",
+      action="store_true",
+      default=False,
+      help="Runs the experiment with hard-failing when it detects there will be multiple graphs out of a single compiled region.",
+  )
   return parser.parse_args(args)
 
 

--- a/benchmarks/run_single_graph_bm.sh
+++ b/benchmarks/run_single_graph_bm.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -ex
+
+DATE=$(date +"%Y_%m_%d_%H_%M")
+
+OUT_PATH=xla/benchmarks/bm_results/single_graph/$DATE
+mkdir -p $OUT_PATH
+
+python new_xla/benchmarks/experiment_runner.py \
+    --dynamo=inductor --dynamo=openxla_eval --dynamo=openxla \
+    --xla=None --xla=PJRT \
+    --test=eval \
+    --filter-by-single-graph \
+    --pure-wall-time \
+    --suite-name=torchbench \
+    --accelerator=cuda \
+    --output-dirname=$OUT_PATH \
+    --repeat=5 \
+    --print-subprocess \
+    --no-resume \
+    > $OUT_PATH/stdout.txt 2> $OUT_PATH/stderr.txt
+
+python3 xla/benchmarks/result_analyzer.py \
+    --output-dirname=$OUT_PATH \
+    --database=$OUT_PATH/$DATE.csv


### PR DESCRIPTION
Add an option to run a benchmark suite for fullgraph option only. Add script which invokes the fullgraph option only, and uses `--pure-wall-time` to measure wall time with CUDA events.