### PR TITLE
[DO NOT MERGE] Exporting dynamic version of `google/vit-base-patch16-224` model 

### DIFF
--- a/test/stablehlo/test_implicit_broadcasting.py
+++ b/test/stablehlo/test_implicit_broadcasting.py
@@ -15,7 +15,8 @@ device = xm.xla_device()
 
 class ImplicitBroadcasting(unittest.TestCase):
 
-  def test_same_rank_broadcast(self):
+  ## broadcasting with static shapes
+  def test_same_rank_broadcast_with_static_shapes(self):
     a = torch.randn((10, 1)).to(device=device)
     b = torch.randn((1, 5)).to(device=device)
     c = a * b
@@ -24,7 +25,7 @@ class ImplicitBroadcasting(unittest.TestCase):
         re.search(r'stablehlo.multiply.* : tensor<10x5xf32>', stablehlo_text)
         is not None)
 
-  def test_scalar_broadcast(self):
+  def test_scalar_broadcast_with_static_shapes(self):
     a = torch.randn(()).to(device=device)
     b = torch.randn((1, 5)).to(device=device)
     c = a * b
@@ -33,7 +34,7 @@ class ImplicitBroadcasting(unittest.TestCase):
         re.search(r'stablehlo.multiply.* : tensor<1x5xf32>', stablehlo_text)
         is not None)
 
-  def test_different_rank_broadcast(self):
+  def test_different_rank_broadcast_with_static_shapes(self):
     a = torch.randn((10, 1)).to(device=device)
     b = torch.randn((6, 8, 1, 5)).to(device=device)
     c = a * b
@@ -41,6 +42,131 @@ class ImplicitBroadcasting(unittest.TestCase):
     self.assertTrue(
         re.search(r'stablehlo.multiply.* : tensor<6x8x10x5xf32>',
                   stablehlo_text) is not None)
+
+  ## broadcasting with unbounded dynamic shapes
+  ### (X,?) * c
+  def test_scalar_broadcast_with_unbounded_dynamic_shapes(self):
+    a = torch.randn(()).to(device=device)
+    b = torch.randn((10, 5)).to(device=device)
+    torch_xla._XLAC._xla_mark_dynamic(b, 1)
+    c = a * b
+    stablehlo_text = xm.get_stablehlo([c])
+    self.assertTrue(
+        re.search(
+            r'dynamic_broadcast_in_dim.*=.*\[\].*: \(tensor<f32>, tensor<2xi32>\) -> tensor<10x\?xf32>',
+            stablehlo_text) is not None)
+    self.assertTrue(
+        re.search(
+            r'dynamic_broadcast_in_dim.*=.*\[0, 1\].*: \(tensor<10x\?xf32>, tensor<2xi32>\) -> tensor<10x\?xf32>',
+            stablehlo_text) is not None)
+
+  ### (?) * (X)
+  def test_same_rank_broadcast_with_unbounded_dynamic_shapes_1(self):
+    a = torch.randn((10)).to(device=device)
+    b = torch.randn((10)).to(device=device)
+    torch_xla._XLAC._xla_mark_dynamic(a, 0)
+    c = a * b
+    stablehlo_text = xm.get_stablehlo([c])
+    self.assertTrue(
+        re.search(
+            r'dynamic_broadcast_in_dim.*=.*\[0\].*: \(tensor<\?xf32>, tensor<1xi32>\) -> tensor<\?xf32>',
+            stablehlo_text) is not None)
+    self.assertTrue(
+        re.search(
+            r'dynamic_broadcast_in_dim.*=.*\[0\].*: \(tensor<10xf32>, tensor<1xi32>\) -> tensor<\?xf32>',
+            stablehlo_text) is not None)
+
+  ### (?,?) * (?,1)
+  def test_same_rank_broadcast_with_unbounded_dynamic_shapes_2(self):
+    a = torch.randn((5, 10)).to(device=device)
+    b = torch.randn((5, 1)).to(device=device)
+    torch_xla._XLAC._xla_mark_dynamic(a, 0)
+    torch_xla._XLAC._xla_mark_dynamic(a, 1)
+    torch_xla._XLAC._xla_mark_dynamic(b, 0)
+    c = a * b
+    stablehlo_text = xm.get_stablehlo([c])
+    self.assertTrue(
+        re.search(
+            r'dynamic_broadcast_in_dim.*=.*\[0, 1\].*: \(tensor<\?x\?xf32>, tensor<2xi32>\) -> tensor<\?x\?xf32>',
+            stablehlo_text) is not None)
+    self.assertTrue(
+        re.search(
+            r'dynamic_broadcast_in_dim.*=.*\[0, 1\].*: \(tensor<\?x1xf32>, tensor<2xi32>\) -> tensor<\?x\?xf32>',
+            stablehlo_text) is not None)
+
+  ### (?,?) * (?,?)
+  def test_same_rank_broadcast_with_unbounded_dynamic_shapes_3(self):
+    a = torch.randn((10, 5)).to(device=device)
+    b = torch.randn((10, 5)).to(device=device)
+    torch_xla._XLAC._xla_mark_dynamic(a, 0)
+    torch_xla._XLAC._xla_mark_dynamic(a, 1)
+    torch_xla._XLAC._xla_mark_dynamic(b, 0)
+    torch_xla._XLAC._xla_mark_dynamic(b, 1)
+    c = a * b
+    stablehlo_text = xm.get_stablehlo([c])
+    self.assertTrue(
+        re.search(
+            r'dynamic_broadcast_in_dim.*=.*\[0, 1\].*: \(tensor<\?x\?xf32>, tensor<2xi32>\) -> tensor<\?x\?xf32>',
+            stablehlo_text) is not None)
+    self.assertTrue(
+        re.search(
+            r'dynamic_broadcast_in_dim.*=.*\[0, 1\].*: \(tensor<\?x\?xf32>, tensor<2xi32>\) -> tensor<\?x\?xf32>',
+            stablehlo_text) is not None)
+
+  ### (?,5) * (?,1)
+  def test_same_rank_broadcast_with_unbounded_dynamic_shapes_4(self):
+    a = torch.randn((5, 5)).to(device=device)
+    b = torch.randn((5, 1)).to(device=device)
+    torch_xla._XLAC._xla_mark_dynamic(a, 0)
+    torch_xla._XLAC._xla_mark_dynamic(b, 0)
+    c = a * b
+    stablehlo_text = xm.get_stablehlo([c])
+    self.assertTrue(
+        re.search(
+            r'dynamic_broadcast_in_dim.*=.*\[0, 1\].*: \(tensor<\?x1xf32>, tensor<2xi32>\) -> tensor<\?x5xf32>',
+            stablehlo_text) is not None)
+    self.assertTrue(
+        re.search(
+            r'dynamic_broadcast_in_dim.*=.*\[0, 1\].*: \(tensor<\?x5xf32>, tensor<2xi32>\) -> tensor<\?x5xf32>',
+            stablehlo_text) is not None)
+
+  ### (?,X,?)) * (1,?)
+  def test_different_rank_broadcast_with_unbounded_dynamic_shapes_1(self):
+    a = torch.randn((10, 5, 4)).to(device=device)
+    b = torch.randn((1, 4)).to(device=device)
+    torch_xla._XLAC._xla_mark_dynamic(a, 0)
+    torch_xla._XLAC._xla_mark_dynamic(a, 2)
+    torch_xla._XLAC._xla_mark_dynamic(b, 1)
+    c = a * b
+    stablehlo_text = xm.get_stablehlo([c])
+    self.assertTrue(
+        re.search(
+            r'dynamic_broadcast_in_dim.*=.*\[1, 2\].*: \(tensor<1x\?xf32>, tensor<3xi32>\) -> tensor<\?x5x\?xf32>',
+            stablehlo_text) is not None)
+    self.assertTrue(
+        re.search(
+            r'dynamic_broadcast_in_dim.*=.*\[0, 1, 2\].*: \(tensor<\?x5x\?xf32>, tensor<3xi32>\) -> tensor<\?x5x\?xf32>',
+            stablehlo_text) is not None)
+
+  ### (?,?,?)) * (?,?)
+  def test_different_rank_broadcast_with_unbounded_dynamic_shapes_2(self):
+    a = torch.randn((10, 5, 4)).to(device=device)
+    b = torch.randn((1, 4)).to(device=device)
+    torch_xla._XLAC._xla_mark_dynamic(a, 0)
+    torch_xla._XLAC._xla_mark_dynamic(a, 1)
+    torch_xla._XLAC._xla_mark_dynamic(a, 2)
+    torch_xla._XLAC._xla_mark_dynamic(b, 0)
+    torch_xla._XLAC._xla_mark_dynamic(b, 1)
+    c = a * b
+    stablehlo_text = xm.get_stablehlo([c])
+    self.assertTrue(
+        re.search(
+            r'dynamic_broadcast_in_dim.*=.*\[1, 2\].*: \(tensor<\?x\?xf32>, tensor<3xi32>\) -> tensor<\?x\?x\?xf32>',
+            stablehlo_text) is not None)
+    self.assertTrue(
+        re.search(
+            r'dynamic_broadcast_in_dim.*=.*\[0, 1, 2\].*: \(tensor<\?x\?x\?xf32>, tensor<3xi32>\) -> tensor<\?x\?x\?xf32>',
+            stablehlo_text) is not None)
 
 
 if __name__ == '__main__':

--- a/test/stablehlo/test_implicit_broadcasting.py
+++ b/test/stablehlo/test_implicit_broadcasting.py
@@ -69,11 +69,11 @@ class ImplicitBroadcasting(unittest.TestCase):
     stablehlo_text = xm.get_stablehlo([c])
     self.assertTrue(
         re.search(
-            r'dynamic_broadcast_in_dim.*=.*\[0\].*: \(tensor<\?xf32>, tensor<1xi32>\) -> tensor<\?xf32>',
+            r'dynamic_broadcast_in_dim.*=.*\[0\].*: \(tensor<\?xf32>, tensor<1xi32>\) -> tensor<10xf32>',
             stablehlo_text) is not None)
     self.assertTrue(
         re.search(
-            r'dynamic_broadcast_in_dim.*=.*\[0\].*: \(tensor<10xf32>, tensor<1xi32>\) -> tensor<\?xf32>',
+            r'dynamic_broadcast_in_dim.*=.*\[0\].*: \(tensor<10xf32>, tensor<1xi32>\) -> tensor<10xf32>',
             stablehlo_text) is not None)
 
   ### (?,?) * (?,1)
@@ -166,6 +166,22 @@ class ImplicitBroadcasting(unittest.TestCase):
     self.assertTrue(
         re.search(
             r'dynamic_broadcast_in_dim.*=.*\[0, 1, 2\].*: \(tensor<\?x\?x\?xf32>, tensor<3xi32>\) -> tensor<\?x\?x\?xf32>',
+            stablehlo_text) is not None)
+
+  ### (2,5) * (?)
+  def test_different_rank_broadcast_with_unbounded_dynamic_shapes_3(self):
+    a = torch.randn((2, 5)).to(device=device)
+    b = torch.randn((5)).to(device=device)
+    torch_xla._XLAC._xla_mark_dynamic(b, 0)
+    c = a * b
+    stablehlo_text = xm.get_stablehlo([c])
+    self.assertTrue(
+        re.search(
+            r'dynamic_broadcast_in_dim.*=.*\[0, 1\].*: \(tensor<2x5xf32>, tensor<2xi32>\) -> tensor<2x5xf32>',
+            stablehlo_text) is not None)
+    self.assertTrue(
+        re.search(
+            r'dynamic_broadcast_in_dim.*=.*\[1\].*: \(tensor<\?xf32>, tensor<2xi32>\) -> tensor<2x5xf32>',
             stablehlo_text) is not None)
 
 

--- a/test/stablehlo/test_implicit_broadcasting.py
+++ b/test/stablehlo/test_implicit_broadcasting.py
@@ -44,7 +44,7 @@ class ImplicitBroadcasting(unittest.TestCase):
                   stablehlo_text) is not None)
 
   ## broadcasting with unbounded dynamic shapes
-  ### (X,?) * c
+  ### (10,?) * c
   def test_scalar_broadcast_with_unbounded_dynamic_shapes(self):
     a = torch.randn(()).to(device=device)
     b = torch.randn((10, 5)).to(device=device)
@@ -60,7 +60,7 @@ class ImplicitBroadcasting(unittest.TestCase):
             r'dynamic_broadcast_in_dim.*=.*\[0, 1\].*: \(tensor<10x\?xf32>, tensor<2xi32>\) -> tensor<10x\?xf32>',
             stablehlo_text) is not None)
 
-  ### (?) * (X)
+  ### (?) * (10)
   def test_same_rank_broadcast_with_unbounded_dynamic_shapes_1(self):
     a = torch.randn((10)).to(device=device)
     b = torch.randn((10)).to(device=device)
@@ -130,7 +130,7 @@ class ImplicitBroadcasting(unittest.TestCase):
             r'dynamic_broadcast_in_dim.*=.*\[0, 1\].*: \(tensor<\?x5xf32>, tensor<2xi32>\) -> tensor<\?x5xf32>',
             stablehlo_text) is not None)
 
-  ### (?,X,?)) * (1,?)
+  ### (?,5,?) * (1,?)
   def test_different_rank_broadcast_with_unbounded_dynamic_shapes_1(self):
     a = torch.randn((10, 5, 4)).to(device=device)
     b = torch.randn((1, 4)).to(device=device)
@@ -148,7 +148,7 @@ class ImplicitBroadcasting(unittest.TestCase):
             r'dynamic_broadcast_in_dim.*=.*\[0, 1, 2\].*: \(tensor<\?x5x\?xf32>, tensor<3xi32>\) -> tensor<\?x5x\?xf32>',
             stablehlo_text) is not None)
 
-  ### (?,?,?)) * (?,?)
+  ### (?,?,?) * (?,?)
   def test_different_rank_broadcast_with_unbounded_dynamic_shapes_2(self):
     a = torch.randn((10, 5, 4)).to(device=device)
     b = torch.randn((1, 4)).to(device=device)

--- a/torch_xla/csrc/convolution.cpp
+++ b/torch_xla/csrc/convolution.cpp
@@ -341,13 +341,14 @@ xla::XlaOp BuildConvolutionOverrideableBias(
   xla::XlaOp conv =
       BuildConvolutionOverrideable(input, kernel, stride, padding, dilation,
                                    transposed, output_padding, groups);
-  auto broadcast_sizes = XlaHelpers::SizesOfXlaOp(conv);
+  std::vector<int64_t> conv_dims(XlaHelpers::SizesOfXlaOp(conv).size());
+  std::iota(conv_dims.begin(), conv_dims.end(), 0);
   // Remove the channels dimension.
-  broadcast_sizes.erase(broadcast_sizes.begin() + 1);
+  conv_dims.erase(conv_dims.begin() + 1);
   // Make the bias match the output dimensions.
-  xla::XlaOp bias_broadcast =
-      xla::Transpose(xla::Broadcast(bias, broadcast_sizes),
-                     BiasTransposePermutation(broadcast_sizes.size() + 1));
+  xla::XlaOp bias_broadcast = xla::Transpose(
+      XlaHelpers::DynamicUnboundedBroadcast(bias, conv, conv_dims),
+      BiasTransposePermutation(conv_dims.size() + 1));
   auto promoted = XlaHelpers::Promote(conv, bias_broadcast);
   return xla::Add(
       promoted.first, promoted.second,

--- a/torch_xla/csrc/helpers.cpp
+++ b/torch_xla/csrc/helpers.cpp
@@ -526,8 +526,8 @@ std::pair<xla::XlaOp, xla::XlaOp> XlaHelpers::PromoteSecondValue(
 
 namespace {
 
-// Polulate 'dimensions' and 'dynamic_dimension' respectively with `count`
-// number of dimension sizes and dynamic dimensions from 'shape'.
+// Polulate 'dimensions' and 'dynamic_dimension' from left-most dimensions of
+// 'shape' respective to 'count'.
 void ExtractDimensionSizesAndDynamicDimensionsFromShape(
     const xla::Shape& shape, int64_t count, std::vector<int64_t>& dimensions,
     std::vector<bool>& dynamic_dimensions) {
@@ -578,19 +578,46 @@ xla::Shape XlaHelpers::GetPromotedShape(const xla::Shape& shape1,
     XLA_CHECK(dim1 == dim2 || dim1 == 1 || dim2 == 1 ||
               dim1 == xla::Shape::kUnboundedSize ||
               dim2 == xla::Shape::kUnboundedSize);
-    if (dim1 == 0 || dim2 == 0) {
-      dimensions.push_back(0);
+
+    // TODO: Consider replacing the broadcasting logic below with
+    // 'xla::ShapeInference::InferDegenerateDimensionBroadcastShape' resuing the
+    // existing xla shape inference machinery. The function is better suited for
+    // inferring shape when the participating
+    // ranks are the same. However, the function has private visisbilty and
+    // needs some refactoring before use.
+    if (dim1 == 1 || dim2 == 1) {
+      // dim1 | dim2 | result
+      // 1   | X   | X
+      // 1   | <=X | <=X
+      // 1   | ?   | ?
+      // X   | 1   | X
+      // <=X | 1   | <=X
+      // ?   | 1   | ?
+      dimensions.push_back(dim1 == 1 ? dim2 : dim1);
+      dynamic_dimensions.push_back(dim1 == 1 ? dynamic_dim2 : dynamic_dim1);
+    } else if (dim1 == dim2) {
+      // dim1 | dim2 | result
+      // X   | X   | X
+      // X   | <=X | <=X
+      // <=X | X   | <=X
+      // <=X | <=X | <=X
+      // ?   | ?   | ?
+      dimensions.push_back(dim1);
       dynamic_dimensions.push_back(dynamic_dim1 || dynamic_dim2);
-    } else if (dim1 == xla::Shape::kUnboundedSize ||
-               dim2 == xla::Shape::kUnboundedSize) {
-      dimensions.push_back(xla::Shape::kUnboundedSize);
-      dynamic_dimensions.push_back(true);
     } else {
-      dimensions.push_back(std::max<int64_t>(dim1, dim2));
-      dynamic_dimensions.push_back(dynamic_dim1 || dynamic_dim2);
+      // dim1 == xla::Shape::kUnboundedSize || dim2 ==
+      // xla::Shape::kUnboundedSize
+      //
+      // dim1 | dim2 | result
+      // X   | ?   | X
+      // ?   | X   | X
+      // <=X | ?   | ?
+      // ?   | <=X | ?
+      dimensions.push_back(dim1 == xla::Shape::kUnboundedSize ? dim2 : dim1);
+      dynamic_dimensions.push_back(
+          dim1 == xla::Shape::kUnboundedSize ? dynamic_dim2 : dynamic_dim1);
     }
   }
-
   return xla::ShapeUtil::MakeShape(shape1.element_type(), dimensions,
                                    dynamic_dimensions);
 }
@@ -664,8 +691,8 @@ xla::Shape XlaHelpers::GetPromotedDynamicShape(const xla::Shape& shape1,
           << ", both dimension are static with real size " << ubound1 << " and "
           << ubound2;
     } else {
-      // For now, if both dimension are dynamic and has the same upper bound, we
-      // regard this dimension to be broadcastable.
+      // For now, if both dimension are dynamic and has the same upper bound,
+      // we regard this dimension to be broadcastable.
       XLA_CHECK((is_dim1_dynamic && !is_dim2_dynamic && ubound2 == 1) ||
                 (is_dim2_dynamic && !is_dim1_dynamic && ubound1 == 1) ||
                 (is_dim1_dynamic && is_dim2_dynamic && ubound1 == ubound2))
@@ -694,7 +721,7 @@ std::pair<xla::XlaOp, xla::XlaOp> XlaHelpers::PromoteShapes(xla::XlaOp op1,
   const xla::Shape& shape2 = ShapeHelper::ShapeOfXlaOp(op2);
 
   xla::Shape shape = GetPromotedShape(shape1, shape2);
-  if (shape.is_unbounded_dynamic()) {
+  if (shape1.is_unbounded_dynamic() || shape2.is_unbounded_dynamic()) {
     return ImplicitBroadcastWithUnboundedDynamicShapes(op1, op2, shape);
   }
 
@@ -809,11 +836,10 @@ xla::XlaOp DynamicBroadcastInDim(xla::XlaOp op, const xla::Shape& final_shape,
 std::pair<xla::XlaOp, xla::XlaOp>
 XlaHelpers::ImplicitBroadcastWithUnboundedDynamicShapes(
     xla::XlaOp op1, xla::XlaOp op2, const xla::Shape& shape) {
-  XLA_CHECK(shape.is_unbounded_dynamic());
-
   const xla::Shape& shape1 = ShapeHelper::ShapeOfXlaOp(op1);
   const xla::Shape& shape2 = ShapeHelper::ShapeOfXlaOp(op2);
 
+  XLA_CHECK(shape1.is_unbounded_dynamic() || shape2.is_unbounded_dynamic());
   XLA_CHECK(shape.dimensions().size() ==
             std::max(shape1.dimensions().size(), shape2.dimensions().size()));
 
@@ -839,8 +865,8 @@ XlaHelpers::ImplicitBroadcastWithUnboundedDynamicShapes(
       op2, shape2.dimensions().size(),
       shape.dimensions().size() - shape2.dimensions().size());
 
-  // The broadcasted shape is the max of the individual pre-broadcasted shapes.
-  // final_broadcast_dimensions = max(op1_dims, op2_dims).
+  // The broadcasted shape is the max of the individual pre-broadcasted
+  // shapes. final_broadcast_dimensions = max(op1_dims, op2_dims).
   auto final_broadcast_dimensions =
       xla::Max(xla::ConcatInDim(op1.builder(), op1_dims, {0}),
                xla::ConcatInDim(op2.builder(), op2_dims, {0}));
@@ -905,7 +931,8 @@ xla::StatusOr<xla::XlaComputation> XlaHelpers::WrapXlaComputation(
 
   // Rebuild aliasing.
   for (const auto& [input_index, output_index] : input_output_alias_pair) {
-    // Both input and output will be a tuple so parameter_number will always be
+    // Both input and output will be a tuple so parameter_number will always
+    // be
     // 0
     builder.SetUpAlias(/*output_index=*/xla::ShapeIndex({output_index}),
                        /*param_number=*/0,

--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -166,9 +166,20 @@ class XlaHelpers {
                                          false);
   }
 
+  // If 'output_sizes' are static, then create xla::Reshape. Else
+  // creates custom_call to express dynamic reshape op using the dimension
+  // sizes of 'aux_input'.
   static xla::XlaOp DynamicUnboundedReshape(
       xla::XlaOp input, xla::XlaOp aux_input,
       absl::Span<const int64_t> output_sizes);
+
+  // Broadcasts 'input' shape to
+  // shape(aux_input)[aux_input_dimensions] x shape(input).
+  // This method is used as a replacement for xla::Broadcast when unbounded
+  // dynamic shapes are involved.
+  static xla::XlaOp DynamicUnboundedBroadcast(
+      xla::XlaOp input, xla::XlaOp aux_input,
+      std::vector<int64_t> aux_input_dimensions);
 
   static xla::XlaOp DynamicReshapeAs(xla::XlaOp input, const xla::Shape& shape);
 

--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -267,7 +267,7 @@ class XlaHelpers {
 
   // If any of the shapes of input operations has unbounded dynamic dimensions,
   // performs implicit broadcasting and return the broadcasted operations. For
-  // satic or bounded dynamic input shapes, validate the shapes and return the
+  // static or bounded dynamic input shapes, validate the shapes and return the
   // input operations. The implicit broadcasting in static and bounded dynamic
   // cases will be handled eventually by the XlaBuilder.
   static std::pair<xla::XlaOp, xla::XlaOp> PromoteShapes(xla::XlaOp op1,
@@ -284,11 +284,6 @@ class XlaHelpers {
                                                          xla::XlaOp op2);
 
   // Given the two shape 'shape1' and 'shape2', infers the broadcasted shape.
-  // When the inputs shapes have static or bounded dynamic dimension sizes, the
-  // broadcasted shape is determined using the numpy broadcasting rules. If the
-  // input shapes constitute unbounded dynamic sizes, then the corresponding
-  // dimension size in the inferred broadcasted shape is marked unbounded
-  // dynamic.
   static xla::Shape GetPromotedShape(const xla::Shape& shape1,
                                      const xla::Shape& shape2);
 

--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -265,12 +265,11 @@ class XlaHelpers {
   static std::pair<xla::XlaOp, xla::XlaOp> PromoteSecondValue(xla::XlaOp op1,
                                                               xla::XlaOp op2);
 
-  // Validates the shapes of xla::XlaOp values: Ignore fp-precison if the shapes
-  // of op1 and op2 have same dimensions, otherwise the element-types must
-  // exactly match.  Eventually performs a broadcast with unbounded dynamic
-  // shapes to make sure the shapes of the returned xla::XlaOp values have the
-  // same shape. The first returned xla::XlaOp is op1 or a broadcast of it, and
-  // the second returned xla::XlaOp is either op2 or a broadcast ot it.
+  // If any of the shapes of input operations has unbounded dynamic dimensions,
+  // performs implicit broadcasting and return the broadcasted operations. For
+  // satic or bounded dynamic input shapes, validate the shapes and return the
+  // input operations. The implicit broadcasting in static and bounded dynamic
+  // cases will be handled eventually by the XlaBuilder.
   static std::pair<xla::XlaOp, xla::XlaOp> PromoteShapes(xla::XlaOp op1,
                                                          xla::XlaOp op2);
 

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -413,7 +413,7 @@ torch::lazy::NodePtr Where(const torch::lazy::Value& condition,
     xla::XlaOp pred_condition =
         ConvertTo(xla_condition, XlaHelpers::TypeOfXlaOp(xla_condition),
                   xla::PrimitiveType::PRED, /*device=*/nullptr);
-    auto promoted_branches = XlaHelpers::ValidateShapes(xla_input, xla_other);
+    auto promoted_branches = XlaHelpers::PromoteShapes(xla_input, xla_other);
     return node.ReturnOp(xla::Select(pred_condition, promoted_branches.first,
                                      promoted_branches.second),
                          loctx);


### PR DESCRIPTION
This PR tracks all the changes in PyTorch/XLA codebase to export `google/vit-base-patch16-224` model with the prerequisite that #6219 to be landed first. 

Note that the PR is based on  [Support of implicit broadcasting with unbounded dynamism #6219
](https://github.com/pytorch/xla/pull/6219)  which is yet to be merged. Feel free to review only the followings files/methods which are implemented on top on the artifacts in #6219 

1. File:  [torch_xla/csrc/convolution.cpp](https://github.com/pytorch/xla/compare/test_hf_vit_base_patch16_224?expand=1#diff-248f9badc028ee0ba91dcbe7cf458159bae10a3b9f1f83ef355a8d239ebe947f)
2. File: [torch_xla/csrc/data_ops.cpp](https://github.com/pytorch/xla/compare/test_hf_vit_base_patch16_224?expand=1#diff-b5a3167ee727b71179e55fa6bc702043ddd462efeec7379355db0e930d37500f)
3. File: [torch_xla/csrc/helpers.cpp](https://github.com/pytorch/xla/compare/test_hf_vit_base_patch16_224?expand=1#diff-c14ab4011fe8e7667250544ff6e73592c76994ec321c17f9dec7de9be264a8b9)
   - XlaHelpers::DynamicReshape
   - XlaHelpers::DynamicUnboundedReshape
   - XlaHelpers::DynamicUnboundedBroadcast