### PR TITLE
Set devices argument in dist.Backend.register_backend call.

### DIFF
--- a/torch_xla/distributed/xla_backend.py
+++ b/torch_xla/distributed/xla_backend.py
@@ -15,7 +15,7 @@ def _create_xla_process_group(prefix_store, rank, size, timeout):
 
 
 def _register_xla_backend():
-  dist.Backend.register_backend('xla', _create_xla_process_group)
+  dist.Backend.register_backend('xla', _create_xla_process_group, devices='xla')
 
 
 _register_xla_backend()


### PR DESCRIPTION
This PR sets devices argument in dist.Backend.register_backend call to avoid a warning from upstream pytorch.
Please refer to https://github.com/pytorch/xla/issues/6251 for details.

Test plan: CI.