### PR TITLE
Update XLAShardedTensor to make it traceable

### DIFF
--- a/test/spmd/test_dynamo_spmd.py
+++ b/test/spmd/test_dynamo_spmd.py
@@ -237,13 +237,11 @@ class DynamoSpmdInferenceTest(test_xla_sharding_base.XlaShardingTest):
 
     met.clear_counters()
     device = xm.xla_device()
-    dynamo_fn = torch.compile(
-        my_fn, backend="openxla")
+    dynamo_fn = torch.compile(my_fn, backend="openxla")
     t = torch.tensor([0, 1, 2])
     xla_t = t.to(device)
     xla_result = dynamo_fn(xla_t)
-    print(type(xla_result))
-    # torch.allclose(xla_result.cpu(), dynamo_res.cpu())
+    torch.allclose(xla_result.cpu(), dynamo_res.cpu())
 
 
 if __name__ == '__main__':

--- a/test/spmd/test_dynamo_spmd.py
+++ b/test/spmd/test_dynamo_spmd.py
@@ -240,8 +240,10 @@ class DynamoSpmdInferenceTest(test_xla_sharding_base.XlaShardingTest):
     dynamo_fn = torch.compile(my_fn, backend="openxla")
     t = torch.tensor([0, 1, 2])
     xla_t = t.to(device)
-    xla_result = dynamo_fn(xla_t)
+    xla_result = my_fn(xla_t)
+    dynamo_res = dynamo_fn(xla_t)
     torch.allclose(xla_result.cpu(), dynamo_res.cpu())
+    self.assertTrue(isinstance(dynamo_res, XLAShardedTensor))
 
 
 if __name__ == '__main__':

--- a/torch_xla/core/dynamo_bridge.py
+++ b/torch_xla/core/dynamo_bridge.py
@@ -484,9 +484,9 @@ class XLAConstructorMoverPass(ConstructorMoverPass):
 def extract_compiled_graph(xla_model: torch.fx.GraphModule, xla_args):
   # Synchronize xla_args, so that each FunctionalTensorWrapper argument updates its
   # value reference before actually computing it.
-  # for a in xla_args:
-  #   if isinstance(a, torch.Tensor) and torch._is_functional_tensor(a):
-  #     torch._functionalize_sync(a)
+  for a in xla_args:
+    if isinstance(a, torch.Tensor) and torch._is_functional_tensor(a):
+      torch._functionalize_sync(a)
 
   # This call is critical to make sure xla_args' tensor id show up in graph_input_tensor_ids
   xm.mark_step()

--- a/torch_xla/core/dynamo_bridge.py
+++ b/torch_xla/core/dynamo_bridge.py
@@ -484,9 +484,9 @@ class XLAConstructorMoverPass(ConstructorMoverPass):
 def extract_compiled_graph(xla_model: torch.fx.GraphModule, xla_args):
   # Synchronize xla_args, so that each FunctionalTensorWrapper argument updates its
   # value reference before actually computing it.
-  for a in xla_args:
-    if isinstance(a, torch.Tensor) and torch._is_functional_tensor(a):
-      torch._functionalize_sync(a)
+  # for a in xla_args:
+  #   if isinstance(a, torch.Tensor) and torch._is_functional_tensor(a):
+  #     torch._functionalize_sync(a)
 
   # This call is critical to make sure xla_args' tensor id show up in graph_input_tensor_ids
   xm.mark_step()

--- a/torch_xla/distributed/spmd/xla_sharded_tensor.py
+++ b/torch_xla/distributed/spmd/xla_sharded_tensor.py
@@ -168,3 +168,13 @@ class XLAShardedTensor(torch.Tensor):
       rs = tree_map(wrap,
                     func(*tree_map(unwrap, args), **tree_map(unwrap, kwargs)))
     return rs
+
+    # This method is required to be implemented for tensor subclass to make it traceable.
+    def __tensor_flatten__(self):
+        return ["global_tensor"], (self.mesh_shape, self.partition_spec)
+
+    # This method is required to be implemented for tensor subclass to make it traceable.
+    @staticmethod
+    def __tensor_unflatten__(inner_tensors, metadata, outer_size, outer_stride):
+        return XLAShardedTensor(inner_tensors["global_tensor"])
+

--- a/torch_xla/distributed/spmd/xla_sharded_tensor.py
+++ b/torch_xla/distributed/spmd/xla_sharded_tensor.py
@@ -171,10 +171,9 @@ class XLAShardedTensor(torch.Tensor):
 
     # This method is required to be implemented for tensor subclass to make it traceable.
     def __tensor_flatten__(self):
-        return ["global_tensor"], (self.mesh_shape, self.partition_spec)
+      return ["global_tensor"], (self.mesh_shape, self.partition_spec)
 
     # This method is required to be implemented for tensor subclass to make it traceable.
     @staticmethod
     def __tensor_unflatten__(inner_tensors, metadata, outer_size, outer_stride):
-        return XLAShardedTensor(inner_tensors["global_tensor"])
-
+      return XLAShardedTensor(inner_tensors["global_tensor"])


### PR DESCRIPTION
As follow-up to https://github.com/pytorch/pytorch/issues/115970 and https://github.com/pytorch/xla/pull/6161, this PR adds `__tensor_flatten__` and `__tensor_unflatten__` to `XLAShardedTensor` to make it traceable by Dynamo. 

Some context on the two methods `__tensor_flatten__` and `__tensor_unflatten__`:
- An example of how these methods are implemented in other tensor subclasses: https://github.com/pytorch/pytorch/blob/main/torch/sparse/semi_structured.py#L208
- `__tensor_flatten__` returns two things:
   - List of `strs` that refer to the var name of the `torch.tensor` in the subclass. In our case, that is the `global_tensor` in `XLAShardedTensor`. 
   - Other metadata about the tensor subclass, such as shape, etc. In our case, that is the sharding spec and partitions.

Test plan:
Unit test and CI