### PR TITLE
Add matmul microbenchmark.

### DIFF
--- a/benchmarks/matmul_bench.py
+++ b/benchmarks/matmul_bench.py
@@ -1,0 +1,76 @@
+import torch
+
+import torch_xla.core.xla_model as xm
+
+from microbench import microbench
+from bench import do_bench
+
+torch.set_float32_matmul_precision('high')
+
+
+def generate_gemm_shape(start, end, stride):
+  for n in range(start, end + 1, stride):
+    lhs_shape = (n, n)
+    rhs_shape = (n, n)
+    yield lhs_shape, rhs_shape
+
+
+def get_matmuls(device, dtype, backend):
+  matmuls = []
+  for lhs_shape, rhs_shape in generate_gemm_shape(
+      start=256, end=8192, stride=128):
+    lhs_tensor = torch.randn(lhs_shape, device=device, dtype=dtype)
+    rhs_tensor = torch.randn(rhs_shape, device=device, dtype=dtype)
+    mm = torch.compile(
+        lambda lhs_tensor=lhs_tensor, rhs_tensor=rhs_tensor: torch.matmul(
+            lhs_tensor, rhs_tensor)[0, 0].item(),
+        backend=backend)
+    matmuls.append((lhs_tensor.shape, rhs_tensor.shape, mm))
+  return matmuls
+
+
+def get_test_name(dtype, lhs_shape, rhs_shape):
+  shape_str = lambda sh: 'x'.join([str(dim) for dim in list(sh)])
+  return f"matmul-{dtype}-lhs{shape_str(lhs_shape)}-rhs{shape_str(rhs_shape)}"
+
+
+def main():
+  """Benchmarks squared matrices against each other for both Inductor, and XLA.
+  """
+
+  xla_bench_fn = lambda fn: do_bench(
+      fn,
+      return_mode='min',
+      sync_fn=lambda: xm.wait_device_ops(),
+      device=xm.xla_device())
+  ind_bench_fn = lambda fn: do_bench(
+      fn,
+      return_mode='min',
+      sync_fn=lambda: torch.cuda.synchronize(),
+      device='cuda')
+
+  dtypes = [torch.float32, torch.float16, torch.bfloat16]
+  for dtype in dtypes:
+    for inductor_matmul, xla_matmul in zip(
+        get_matmuls(device='cuda', dtype=dtype, backend='inductor'),
+        get_matmuls(
+            device=xm.xla_device(), dtype=dtype, backend='openxla_eval')):
+      ind_lhs_shape, ind_rhs_shape, ind_fn = inductor_matmul
+      xla_lhs_shape, xla_rhs_shape, xla_fn = xla_matmul
+      assert ind_lhs_shape == xla_lhs_shape, f"Expect matmul shapes to match for benchmarking. Mismatch lhs: {ind_lhs_shape}, rhs: {xla_rhs_shape}"
+      assert ind_rhs_shape == xla_rhs_shape, f"Expect matmul shapes to match for benchmarking. Mistmatch rhs: {ind_rhs_shape}, rhs: {ind_rhs_shape}"
+
+      test_name = get_test_name(dtype, ind_lhs_shape, ind_rhs_shape)
+      result = microbench(
+          test_name,
+          baseline_fn=ind_fn,
+          testing_fn=xla_fn,
+          baseline_bench_fn=ind_bench_fn,
+          testing_bench_fn=xla_bench_fn,
+          baseline_sync_fn=torch.cuda.synchronize,
+          testing_sync_fn=xm.wait_device_ops)
+      print(result)
+
+
+if __name__ == '__main__':
+  main()

--- a/benchmarks/microbench.py
+++ b/benchmarks/microbench.py
@@ -1,0 +1,136 @@
+import os
+
+from dataclasses import dataclass
+from torch.profiler import profile, ProfilerActivity, schedule
+
+WAIT = 2
+WARMUP = 5
+ACTIVE = 3
+DEFAULT_SCHEDULE = schedule(wait=WAIT, warmup=WARMUP, active=ACTIVE)
+PROF_ITERS = WAIT + WARMUP + ACTIVE
+
+
+@dataclass
+class MicrobenchResults:
+  test_name: str
+  testing_speedup: float
+  baseline_wall_ms: float
+  testing_wall_ms: float
+
+  def __str__(self):
+    RED = "\u001B[31m"
+    GREEN = "\u001B[32m"
+    RESET = "\u001B[0m"
+
+    def wrap_in_color(str, color=None):
+      if color is None:
+        return str
+      return f"{color}{str}{RESET}"
+
+    formatted_baseline_wall_ms = f"{self.baseline_wall_ms:.02f}ms"
+    formatted_testing_wall_ms = f"{self.testing_wall_ms:.02f}ms"
+    formatted_speedup = f"{self.testing_speedup:.02f}x"
+    formatted_test_name = self.test_name
+    color = None
+    if self.testing_speedup < 0.95:
+      color = RED
+    if self.testing_speedup > 1.05:
+      color = GREEN
+    formatted_test_name = wrap_in_color(formatted_test_name, color)
+    formatted_baseline_wall_ms = wrap_in_color(formatted_baseline_wall_ms,
+                                               color)
+    formatted_testing_wall_ms = wrap_in_color(formatted_testing_wall_ms, color)
+    formatted_speedup = wrap_in_color(formatted_speedup, color)
+    return f"{formatted_test_name}: speedup={formatted_speedup}; base={formatted_baseline_wall_ms}; test={formatted_testing_wall_ms}"
+
+
+def microbench(test_name,
+               baseline_fn,
+               testing_fn,
+               baseline_bench_fn,
+               testing_bench_fn,
+               baseline_sync_fn,
+               testing_sync_fn,
+               save_profile_to_dir=None):
+  """Benchmarks testing function against baseline function.
+
+  Args:
+      test_name (str): Name of the microbenchmark run.
+      baseline_fn (fn): Baseline function to benchmark against.
+      testing_fn (fn): Test function to be benchmarked.
+      baseline_bench_fn (fn): Benchmarking function for baseline.
+      testing_bench_fn (fn): Benchmarking function for test.
+      baseline_sync_fn (fn): Profiling sync function for baseline.
+      testing_sync_fn (fn): Profiling sync function for test.
+      return_mode (str, optional): Benchmarking should consist of multiple runs. Defaults to 'min'.
+      save_profile_to_dir (_type_, optional): If not None, saves the profiling results for the slowest runs to the `save_profile_to_dir`. Defaults to None.
+
+  Returns:
+      MicrobenchResults: A structure holding `test_name`, speedups, and measured wall times for both functions.
+  """
+
+  assert baseline_bench_fn is not None, "Expect baseline_bench_fn to be defined"
+  assert testing_bench_fn is not None, "Expect testing_bench_fn to be defined"
+
+  baseline_wall_ms, _ = baseline_bench_fn(baseline_fn)
+  testing_wall_ms, _ = testing_bench_fn(testing_fn)
+
+  if save_profile_to_dir and baseline_wall_ms / testing_wall_ms < 0.95:
+    filebase_path = save_profile_to_dir
+    _perf_prof(
+        _get_filepath(filebase_path, test_name, "baseline"), baseline_fn,
+        baseline_sync_fn)
+    _perf_prof(
+        _get_filepath(filebase_path, test_name, "testing"), testing_fn,
+        testing_sync_fn)
+
+  return MicrobenchResults(
+      test_name=test_name,
+      testing_speedup=baseline_wall_ms / testing_wall_ms,
+      baseline_wall_ms=baseline_wall_ms,
+      testing_wall_ms=testing_wall_ms,
+  )
+
+
+def _dump_flame(filepath, prof):
+  """Data can be interpreted with running ./flamegraph.pl --title "CUDA time" --countname "us." /tmp/profiler_stacks.txt > perf_viz.svg"""
+  os.makedirs(filepath, exist_ok=True)
+  filedest = os.path.join(filepath, "flame.txt")
+  prof.export_stacks(filedest)
+
+
+def _dump_kernels(filepath, prof):
+  os.makedirs(filepath, exist_ok=True)
+  filedest = os.path.join(filepath, "kernel.txt")
+  summary = prof.key_averages(group_by_input_shape=True).table(
+      sort_by="cuda_time_total", row_limit=100)
+  with open(filedest, mode='w', encoding='utf-8') as f:
+    f.write(summary)
+
+
+def _dump_trace(filepath, prof):
+  os.makedirs(filepath, exist_ok=True)
+  filedest = os.path.join(filepath, "trace.json")
+  prof.export_chrome_trace(filedest)
+
+
+def _perf_prof(filepath, fn, sync_fn):
+  assert sync_fn is not None
+  with profile(
+      activities=[ProfilerActivity.CUDA, ProfilerActivity.CPU],
+      record_shapes=True,
+      with_flops=True,
+      profile_memory=True,
+      with_stack=True,
+      schedule=DEFAULT_SCHEDULE) as prof:
+    for _ in range(PROF_ITERS):
+      fn()
+      prof.step()
+    sync_fn()
+  _dump_flame(filepath, prof)
+  _dump_trace(filepath, prof)
+  _dump_kernels(filepath, prof)
+
+
+def _get_filepath(filebase, test_name, suffix):
+  return os.path.join(filebase, test_name, suffix)

--- a/benchmarks/microbench.py
+++ b/benchmarks/microbench.py
@@ -93,7 +93,10 @@ def microbench(test_name,
 
 
 def _dump_flame(filepath, prof):
-  """Data can be interpreted with running ./flamegraph.pl --title "CUDA time" --countname "us." /tmp/profiler_stacks.txt > perf_viz.svg"""
+  """Data can be interpreted with running ./flamegraph.pl --title "CUDA time" --countname "us." /tmp/profiler_stacks.txt > perf_viz.svg
+
+  More about flamegraphs, and the flamegraph.pl script can be found in https://pytorch.org/tutorials/recipes/recipes/profiler_recipe.html#visualizing-data-as-a-flame-graph.
+  """
   os.makedirs(filepath, exist_ok=True)
   filedest = os.path.join(filepath, "flame.txt")
   prof.export_stacks(filedest)


### PR DESCRIPTION
With the pure wall time infrastructure came nice
ability to do microbenchmarks easily. I added
the sample microbenchmark for matmul.

Additionally for slower runs it dumps PT profiles/traces of base, and test functions.