### PR TITLE
Update test_spmd_debugging.py to avoid code test code self

### DIFF
--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -123,14 +123,28 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU [0, 1, 2, 3]', "center", vertical="middle"),
+            rich.align.Align('TPU [0, 1]', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU [4, 5, 6, 7]', "center", vertical="middle"),
+            rich.align.Align('TPU [2, 3]', "center", vertical="middle"),
+            (1, 1, 1, 1),
+            style=rich.style.Style(bgcolor=color, color=text_color)))
+    fake_table.add_row(*col)
+    col = []
+    col.append(
+        rich.padding.Padding(
+            rich.align.Align('TPU [4, 5]', "center", vertical="middle"),
+            (1, 1, 1, 1),
+            style=rich.style.Style(bgcolor=color, color=text_color)))
+    fake_table.add_row(*col)
+    col = []
+    col.append(
+        rich.padding.Padding(
+            rich.align.Align('TPU [6, 7]', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -34,17 +34,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_debugging_spmd_single_host_tiled_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
-    device = xm.xla_device()
-    num_devices = self.n_devices
-    if num_devices != 8:
-      self.skipTest("skip num_devices!=8 env to avoid circular reasoning")
-    mesh_shape = (2, num_devices // 2)
-    device_ids = np.array(range(num_devices))
-    mesh = self._get_mesh(mesh_shape)
-    t = torch.randn(8, 4, device=device)
-    partition_spec = (0, 1)
-    xs.mark_sharding(t, mesh, partition_spec)
-    sharding = torch_xla._XLAC._get_xla_sharding_spec(t)
+    sharding={devices=[2,8]0,4,8,12,2,6,10,14,1,5,9,13,3,7,11,15}
     generated_table = visualize_tensor_sharding(t)
     console = rich.console.Console()
     with console.capture() as capture:
@@ -117,18 +107,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_single_host_partial_replication_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
-    device = xm.xla_device()
-    num_devices = self.n_devices
-    if num_devices != 8:
-      self.skipTest("skip num_devices!=8 env to avoid circular reasoning")
-    mesh_shape = (2, num_devices // 2)
-    device_ids = np.array(range(num_devices))
-    mesh = self._get_mesh(mesh_shape)
-
-    partition_spec = (0, None)
-    t = torch.randn(8, 32, device=device)
-    xs.mark_sharding(t, mesh, (0, None))
-    sharding = torch_xla._XLAC._get_xla_sharding_spec(t)
+    sharding={devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}
     generated_table = visualize_tensor_sharding(t)
     console = rich.console.Console()
     with console.capture() as capture:
@@ -171,18 +150,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_single_host_replicated_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
-    device = xm.xla_device()
-    num_devices = self.n_devices
-    if num_devices != 8:
-      self.skipTest("skip num_devices!=8 env to avoid circular reasoning")
-    mesh_shape = (2, num_devices // 2)
-    device_ids = np.array(range(num_devices))
-    mesh = self._get_mesh(mesh_shape)
-
-    partition_spec_replicated = (None, None)
-    t = torch.randn(8, 32, device=device)
-    xs.mark_sharding(t, mesh, partition_spec_replicated)
-    sharding = torch_xla._XLAC._get_xla_sharding_spec(t)
+    sharding = '{replicated}'
     generated_table = visualize_tensor_sharding(t)
     console = rich.console.Console()
     with console.capture() as capture:
@@ -218,18 +186,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
       xu.getenv_as(xenv.PJRT_DEVICE, str) in ("GPU", 'CUDA', 'ROCM', 'TPU'),
       f"Requires PJRT_DEVICE set to `CPU`.")
   def test_debugging_spmd_single_host_tiled_cpu(self):
-    from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
-    device = xm.xla_device()
-    num_devices = self.n_devices
-    if num_devices != 1:
-      self.skipTest("skip num_devices!=1 env to avoid circular reasoning")
-    mesh_shape = (1, num_devices)
-    device_ids = np.array(range(num_devices))
-    mesh = self._get_mesh(mesh_shape)
-    t = torch.randn(8, 4, device=device)
-    partition_spec = (0, 1)
-    xs.mark_sharding(t, mesh, partition_spec)
-    sharding = torch_xla._XLAC._get_xla_sharding_spec(t)
+    sharding={devices=[2,8]0,4,8,12,2,6,10,14,1,5,9,13,3,7,11,15}
     generated_table = visualize_tensor_sharding(t)
     console = rich.console.Console()
     with console.capture() as capture:
@@ -265,18 +222,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
       f"Requires PJRT_DEVICE set to `CPU`.")
   def test_single_host_partial_replication_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
-    device = xm.xla_device()
-    num_devices = self.n_devices
-    if num_devices != 1:
-      self.skipTest("skip num_devices!=1 env to avoid circular reasoning")
-    mesh_shape = (1, num_devices)
-    device_ids = np.array(range(num_devices))
-    mesh = self._get_mesh(mesh_shape)
-
-    partition_spec = (0, None)
-    t = torch.randn(8, 32, device=device)
-    xs.mark_sharding(t, mesh, (0, None))
-    sharding = torch_xla._XLAC._get_xla_sharding_spec(t)
+    sharding={devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}
     generated_table = visualize_tensor_sharding(t)
     console = rich.console.Console()
     with console.capture() as capture:
@@ -312,18 +258,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
       f"Requires PJRT_DEVICE set to `CPU`.")
   def test_single_host_replicated_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
-    device = xm.xla_device()
-    num_devices = self.n_devices
-    if num_devices != 1:
-      self.skipTest("skip num_devices!=1 env to avoid circular reasoning")
-    mesh_shape = (1, num_devices)
-    device_ids = np.array(range(num_devices))
-    mesh = self._get_mesh(mesh_shape)
-
-    partition_spec_replicated = (None, None)
-    t = torch.randn(8, 32, device=device)
-    xs.mark_sharding(t, mesh, partition_spec_replicated)
-    sharding = torch_xla._XLAC._get_xla_sharding_spec(t)
+    sharding = '{replicated}'
     generated_table = visualize_tensor_sharding(t)
     console = rich.console.Console()
     with console.capture() as capture:
@@ -564,8 +499,6 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
   def test_multi_host_replicated_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     num_devices = self.n_devices
-    if num_devices != 8:
-      self.skipTest("skip num_devices!=8 env to avoid circular reasoning")
     sharding = '{replicated}'
     generated_table = visualize_sharding(sharding)
     console = rich.console.Console()

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -36,6 +36,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     device = xm.xla_device()
     num_devices = self.n_devices
+    if num_devices != 8:
+      self.skipTest("skip num_devices!=8 env to avoid circular reasoning")
     mesh_shape = (2, num_devices // 2)
     device_ids = np.array(range(num_devices))
     mesh = self._get_mesh(mesh_shape)
@@ -116,6 +118,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     device = xm.xla_device()
     num_devices = self.n_devices
+    if num_devices != 8:
+      self.skipTest("skip num_devices!=8 env to avoid circular reasoning")
     mesh_shape = (2, num_devices // 2)
     device_ids = np.array(range(num_devices))
     mesh = self._get_mesh(mesh_shape)
@@ -167,6 +171,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     device = xm.xla_device()
     num_devices = self.n_devices
+    if num_devices != 8:
+      self.skipTest("skip num_devices!=8 env to avoid circular reasoning")
     mesh_shape = (2, num_devices // 2)
     device_ids = np.array(range(num_devices))
     mesh = self._get_mesh(mesh_shape)
@@ -212,6 +218,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     device = xm.xla_device()
     num_devices = self.n_devices
+    if num_devices != 1:
+      self.skipTest("skip num_devices!=1 env to avoid circular reasoning")
     mesh_shape = (1, num_devices)
     device_ids = np.array(range(num_devices))
     mesh = self._get_mesh(mesh_shape)
@@ -255,6 +263,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     device = xm.xla_device()
     num_devices = self.n_devices
+    if num_devices != 1:
+      self.skipTest("skip num_devices!=1 env to avoid circular reasoning")
     mesh_shape = (1, num_devices)
     device_ids = np.array(range(num_devices))
     mesh = self._get_mesh(mesh_shape)
@@ -299,6 +309,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     device = xm.xla_device()
     num_devices = self.n_devices
+    if num_devices != 1:
+      self.skipTest("skip num_devices!=1 env to avoid circular reasoning")
     mesh_shape = (1, num_devices)
     device_ids = np.array(range(num_devices))
     mesh = self._get_mesh(mesh_shape)

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -28,8 +28,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     xr.use_spmd()
     super().setUpClass()
 
-  @unittest.skipIf(xr.device_type() not in ('TPU', 'GPU'),
-                   f"Requires PJRT_DEVICE set to `TPU` or `GPU`.")
+  @unittest.skipIf(xr.device_type() == ('CPU'),
+                   f"Requires PJRT_DEVICE set to `TPU`, `GPU`, or `CUDA`.")
   def test_debugging_spmd_single_host_tiled_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[2,4]0,1,2,3,4,5,6,7}'
@@ -52,44 +52,52 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align(xr.device_type() + ' 0', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 0', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align(xr.device_type() + ' 1', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 1', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align(xr.device_type() + ' 2', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 2', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align(xr.device_type() + ' 3', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 3', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align(xr.device_type() + ' 4', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 4', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align(xr.device_type() + ' 5', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 5', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align(xr.device_type() + ' 6', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 6', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align(xr.device_type() + ' 7', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 7', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)
@@ -177,13 +185,12 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
         box=rich.box.SQUARE if not use_color else None)
     col = []
     alltpus = 'TPU [0'
-    for i in range(xr.global_runtime_device_count()-1):
-      alltpus = alltpus + ',' + str(i+1)
+    for i in range(xr.global_runtime_device_count() - 1):
+      alltpus = alltpus + ',' + str(i + 1)
     alltpus = alltpus + ']'
     col.append(
         rich.padding.Padding(
-            rich.align.Align(
-                alltpus, "center", vertical="middle"),
+            rich.align.Align(alltpus, "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -211,7 +211,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align('CPU 0', "center", vertical="middle"),
+            rich.align.Align('CPU [0]', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -368,13 +368,16 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
+    test_debugging_spmd_multi_host_tiled_tpu
+    # console = rich.console.Console() # width=max_width)
+    use_color = True if rich.console.Console().color_system else False 
     fake_table = rich.table.Table(
         show_header=False,
-        show_lines=True,
+        show_lines=not use_color,
         padding=0,
-        highlight=True,
+        highlight=not use_color,
         pad_edge=False,
-        box=rich.box.SQUARE)
+        box=rich.box.SQUARE if not use_color else None)
     col = []
     col.append(
         rich.padding.Padding(

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -28,8 +28,9 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     xr.use_spmd()
     super().setUpClass()
 
-  @unittest.skipIf(xr.device_type() == 'CPU',
-                   f"Requires PJRT_DEVICE set to `TPU`, `GPU`, `CUDA`, or 'ROCM'.")
+  @unittest.skipIf(
+      xr.device_type() == 'CPU',
+      f"Requires PJRT_DEVICE set to `TPU`, `GPU`, `CUDA`, or 'ROCM'.")
   def test_debugging_spmd_single_host_tiled_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[2,4]0,1,2,3,4,5,6,7}'
@@ -107,8 +108,9 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipIf(xr.device_type() == 'CPU',
-                   f"Requires PJRT_DEVICE set to  `TPU`, `GPU`, `CUDA`, or 'ROCM'.")
+  @unittest.skipIf(
+      xr.device_type() == 'CPU',
+      f"Requires PJRT_DEVICE set to  `TPU`, `GPU`, `CUDA`, or 'ROCM'.")
   def test_single_host_partial_replication_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[4,1,2]0,1,2,3,4,5,6,7 last_tile_dim_replicate}'
@@ -131,28 +133,32 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU [0, 1]', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' [0, 1]', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU [2, 3]', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' [2, 3]', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU [4, 5]', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' [4, 5]', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU [6, 7]', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' [6, 7]', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)
@@ -162,8 +168,9 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipIf(xr.device_type() == 'CPU',
-                   f"Requires PJRT_DEVICE set to `TPU`, `GPU`, `CUDA`, or 'ROCM'.")
+  @unittest.skipIf(
+      xr.device_type() == 'CPU',
+      f"Requires PJRT_DEVICE set to `TPU`, `GPU`, `CUDA`, or 'ROCM'.")
   def test_single_host_replicated_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{replicated}'
@@ -184,7 +191,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
         pad_edge=False,
         box=rich.box.SQUARE if not use_color else None)
     col = []
-    alltpus = 'TPU [0'
+    alltpus = xr.device_type() + ' [0'
     for i in range(xr.global_runtime_device_count() - 1):
       alltpus = alltpus + ',' + str(i + 1)
     alltpus = alltpus + ']'
@@ -335,8 +342,9 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 # e.g.: sharding={devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}
 # e.g.: sharding={replicated}
 
-  @unittest.skipIf(xr.device_type() == 'CPU',
-                   f"Requires PJRT_DEVICE set to `TPU`, `GPU`, `CUDA`, or 'ROCM'.")
+  @unittest.skipIf(
+      xr.device_type() == 'CPU',
+      f"Requires PJRT_DEVICE set to `TPU`, `GPU`, `CUDA`, or 'ROCM'.")
   def test_debugging_spmd_multi_host_tiled_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[2,8]0,4,8,12,2,6,10,14,1,5,9,13,3,7,11,15}'
@@ -359,84 +367,100 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 0', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 0', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 4', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 4', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 8', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 8', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 12', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 12', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 2', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 2', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 6', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 6', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 10', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 10', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 14', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 14', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 1', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 1', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 5', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 5', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 9', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 9', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 13', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 13', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 3', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 3', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 7', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 7', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 11', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 11', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 15', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' 15', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)
@@ -446,8 +470,9 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipIf(xr.device_type() == 'CPU',
-                   f"Requires PJRT_DEVICE set to `TPU`, `GPU`, `CUDA`, or 'ROCM'.")
+  @unittest.skipIf(
+      xr.device_type() == 'CPU',
+      f"Requires PJRT_DEVICE set to `TPU`, `GPU`, `CUDA`, or 'ROCM'.")
   def test_multi_host_partial_replication_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}'
@@ -470,56 +495,64 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU [0, 1]', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' [0, 1]', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU [4, 5]', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' [4, 5]', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU [8, 9]', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' [8, 9]', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU [12, 13]', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' [12, 13]', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU [2, 3]', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' [2, 3]', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU [6, 7]', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' [6, 7]', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU [10, 11]', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' [10, 11]', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU [14, 15]', "center", vertical="middle"),
+            rich.align.Align(
+                xr.device_type() + ' [14, 15]', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)
@@ -529,8 +562,9 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipIf(xr.device_type() == 'CPU',
-                   f"Requires PJRT_DEVICE set to `TPU`, `GPU`, `CUDA`, or 'ROCM'.")
+  @unittest.skipIf(
+      xr.device_type() == 'CPU',
+      f"Requires PJRT_DEVICE set to `TPU`, `GPU`, `CUDA`, or 'ROCM'.")
   @unittest.skipIf(xr.global_runtime_device_count() != 8,
                    f"Limit test num_devices to 8 for function consistency")
   def test_multi_host_replicated_tpu(self):
@@ -556,7 +590,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     col.append(
         rich.padding.Padding(
             rich.align.Align(
-                'TPU [0, 1, 2, 3, 4, 5, 6, 7]', "center", vertical="middle"),
+                xr.device_type() + ' [0, 1, 2, 3, 4, 5, 6, 7]', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -563,6 +563,9 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_multi_host_replicated_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
+    num_devices = self.n_devices
+    if num_devices != 8:
+      self.skipTest("skip num_devices!=8 env to avoid circular reasoning")
     sharding = '{replicated}'
     generated_table = visualize_sharding(sharding)
     console = rich.console.Console()

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -29,7 +29,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     super().setUpClass()
 
   @unittest.skipIf(xr.device_type() == 'CPU',
-                   f"Requires PJRT_DEVICE set to `TPU`, `GPU`, or `CUDA`.")
+                   f"Requires PJRT_DEVICE set to `TPU`, `GPU`, `CUDA`, or 'ROCM'.")
   def test_debugging_spmd_single_host_tiled_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[2,4]0,1,2,3,4,5,6,7}'
@@ -107,8 +107,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipIf(xr.device_type() != 'TPU',
-                   f"Requires PJRT_DEVICE set to `TPU`.")
+  @unittest.skipIf(xr.device_type() == 'CPU',
+                   f"Requires PJRT_DEVICE set to  `TPU`, `GPU`, `CUDA`, or 'ROCM'.")
   def test_single_host_partial_replication_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[4,1,2]0,1,2,3,4,5,6,7 last_tile_dim_replicate}'
@@ -162,8 +162,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipIf(xr.device_type() != 'TPU',
-                   f"Requires PJRT_DEVICE set to `TPU`.")
+  @unittest.skipIf(xr.device_type() == 'CPU',
+                   f"Requires PJRT_DEVICE set to `TPU`, `GPU`, `CUDA`, or 'ROCM'.")
   def test_single_host_replicated_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{replicated}'
@@ -335,8 +335,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 # e.g.: sharding={devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}
 # e.g.: sharding={replicated}
 
-  @unittest.skipIf(xr.device_type() != 'TPU',
-                   f"Requires PJRT_DEVICE set to `TPU`.")
+  @unittest.skipIf(xr.device_type() == 'CPU',
+                   f"Requires PJRT_DEVICE set to `TPU`, `GPU`, `CUDA`, or 'ROCM'.")
   def test_debugging_spmd_multi_host_tiled_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[2,8]0,4,8,12,2,6,10,14,1,5,9,13,3,7,11,15}'
@@ -446,8 +446,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipIf(xr.device_type() != 'TPU',
-                   f"Requires PJRT_DEVICE set to `TPU`.")
+  @unittest.skipIf(xr.device_type() == 'CPU',
+                   f"Requires PJRT_DEVICE set to `TPU`, `GPU`, `CUDA`, or 'ROCM'.")
   def test_multi_host_partial_replication_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}'
@@ -529,8 +529,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipIf(xr.device_type() != 'TPU',
-                   f"Requires PJRT_DEVICE set to `TPU`.")
+  @unittest.skipIf(xr.device_type() == 'CPU',
+                   f"Requires PJRT_DEVICE set to `TPU`, `GPU`, `CUDA`, or 'ROCM'.")
   @unittest.skipIf(xr.global_runtime_device_count() != 8,
                    f"Limit test num_devices to 8 for function consistency")
   def test_multi_host_replicated_tpu(self):

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -29,9 +29,9 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     super().setUpClass()
 
   def test_debugging_spmd_single_host_tiled_tpu(self):
-    from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
+    from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[2,8]0,4,8,12,2,6,10,14,1,5,9,13,3,7,11,15}'
-    generated_table = visualize_tensor_sharding(t)
+    generated_table = visualize_sharding(sharding)
     console = rich.console.Console()
     with console.capture() as capture:
       console.print(generated_table)
@@ -98,9 +98,9 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     assert output == fake_output
 
   def test_single_host_partial_replication_tpu(self):
-    from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
+    from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}'
-    generated_table = visualize_tensor_sharding(t)
+    generated_table = visualize_sharding(sharding)
     console = rich.console.Console()
     with console.capture() as capture:
       console.print(generated_table)
@@ -137,9 +137,9 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     assert output == fake_output
 
   def test_single_host_replicated_tpu(self):
-    from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
+    from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{replicated}'
-    generated_table = visualize_tensor_sharding(t)
+    generated_table = visualize_sharding(sharding)
     console = rich.console.Console()
     with console.capture() as capture:
       console.print(generated_table)
@@ -172,8 +172,9 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
   @unittest.skipIf(xr.device_type() != 'CPU',
                    f"Requires PJRT_DEVICE set to `CPU`.")
   def test_debugging_spmd_single_host_tiled_cpu(self):
+    from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[2,8]0,4,8,12,2,6,10,14,1,5,9,13,3,7,11,15}'
-    generated_table = visualize_tensor_sharding(t)
+    generated_table = visualize_sharding(sharding)
     console = rich.console.Console()
     with console.capture() as capture:
       console.print(generated_table)
@@ -205,9 +206,9 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
   @unittest.skipIf(xr.device_type() != 'CPU',
                    f"Requires PJRT_DEVICE set to `CPU`.")
   def test_single_host_partial_replication_cpu(self):
-    from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
+    from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}'
-    generated_table = visualize_tensor_sharding(t)
+    generated_table = visualize_sharding(sharding)
     console = rich.console.Console()
     with console.capture() as capture:
       console.print(generated_table)
@@ -239,9 +240,9 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
   @unittest.skipIf(xr.device_type() != 'CPU',
                    f"Requires PJRT_DEVICE set to `CPU`.")
   def test_single_host_replicated_cpu(self):
-    from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
+    from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{replicated}'
-    generated_table = visualize_tensor_sharding(t)
+    generated_table = visualize_sharding(sharding)
     console = rich.console.Console()
     with console.capture() as capture:
       console.print(generated_table)

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -156,8 +156,6 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
   @unittest.skipIf(xr.device_type() != 'TPU',
                    f"Requires PJRT_DEVICE set to `TPU`.")
-  @unittest.skipIf(xr.global_runtime_device_count() != 8,
-                   f"Limit test num_devices to 8 for function consistency")
   def test_single_host_replicated_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{replicated}'
@@ -178,10 +176,14 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
         pad_edge=False,
         box=rich.box.SQUARE if not use_color else None)
     col = []
+    alltpus = 'TPU [0'
+    for i in range(xr.global_runtime_device_count()-1):
+      alltpus = alltpus + ',' + str(i+1)
+    alltpus = alltpus + ']'
     col.append(
         rich.padding.Padding(
             rich.align.Align(
-                'TPU [0, 1, 2, 3, 4, 5, 6, 7]', "center", vertical="middle"),
+                alltpus, "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)
@@ -753,8 +755,6 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
   @unittest.skipIf(xr.device_type() != 'CPU',
                    f"Requires PJRT_DEVICE set to `CPU`.")
-  @unittest.skipIf(xr.global_runtime_device_count() != 8,
-                   f"Limit test num_devices to 8 for function consistency")
   def test_multi_host_replicated_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{replicated}'
@@ -774,10 +774,14 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
         highlight=not use_color,
         pad_edge=False,
         box=rich.box.SQUARE if not use_color else None)
+    alltpus = 'CPU [0'
+    for i in range(xr.global_runtime_device_count()-1):
+      alltpus = alltpus + ',' + str(i+1)
+    alltpus = alltpus + ']'
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align('CPU [0]', "center", vertical="middle"),
+            rich.align.Align(alltpus, "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -53,7 +53,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
-    use_color = True if rich.console.Console().color_system else False 
+    use_color = True if rich.console.Console().color_system else False
     fake_table = rich.table.Table(
         show_header=False,
         show_lines=not use_color,
@@ -137,7 +137,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
-    use_color = True if rich.console.Console().color_system else False 
+    use_color = True if rich.console.Console().color_system else False
     fake_table = rich.table.Table(
         show_header=False,
         show_lines=not use_color,
@@ -191,7 +191,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
-    use_color = True if rich.console.Console().color_system else False 
+    use_color = True if rich.console.Console().color_system else False
     fake_table = rich.table.Table(
         show_header=False,
         show_lines=not use_color,
@@ -238,7 +238,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
-    use_color = True if rich.console.Console().color_system else False 
+    use_color = True if rich.console.Console().color_system else False
     fake_table = rich.table.Table(
         show_header=False,
         show_lines=not use_color,
@@ -285,7 +285,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
-    use_color = True if rich.console.Console().color_system else False 
+    use_color = True if rich.console.Console().color_system else False
     fake_table = rich.table.Table(
         show_header=False,
         show_lines=not use_color,
@@ -332,7 +332,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
-    use_color = True if rich.console.Console().color_system else False 
+    use_color = True if rich.console.Console().color_system else False
     fake_table = rich.table.Table(
         show_header=False,
         show_lines=not use_color,
@@ -374,7 +374,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
-    use_color = True if rich.console.Console().color_system else False 
+    use_color = True if rich.console.Console().color_system else False
     fake_table = rich.table.Table(
         show_header=False,
         show_lines=not use_color,
@@ -487,7 +487,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
-    use_color = True if rich.console.Console().color_system else False 
+    use_color = True if rich.console.Console().color_system else False
     fake_table = rich.table.Table(
         show_header=False,
         show_lines=not use_color,
@@ -575,7 +575,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
-    use_color = True if rich.console.Console().color_system else False 
+    use_color = True if rich.console.Console().color_system else False
     fake_table = rich.table.Table(
         show_header=False,
         show_lines=not use_color,
@@ -612,7 +612,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
-    use_color = True if rich.console.Console().color_system else False 
+    use_color = True if rich.console.Console().color_system else False
     fake_table = rich.table.Table(
         show_header=False,
         show_lines=not use_color,
@@ -725,7 +725,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
-    use_color = True if rich.console.Console().color_system else False 
+    use_color = True if rich.console.Console().color_system else False
     fake_table = rich.table.Table(
         show_header=False,
         show_lines=not use_color,
@@ -810,7 +810,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
-    use_color = True if rich.console.Console().color_system else False 
+    use_color = True if rich.console.Console().color_system else False
     fake_table = rich.table.Table(
         show_header=False,
         show_lines=not use_color,

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -53,13 +53,14 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
+    use_color = True if rich.console.Console().color_system else False 
     fake_table = rich.table.Table(
         show_header=False,
-        show_lines=True,
+        show_lines=not use_color,
         padding=0,
-        highlight=True,
+        highlight=not use_color,
         pad_edge=False,
-        box=rich.box.SQUARE)
+        box=rich.box.SQUARE if not use_color else None)
     col = []
     col.append(
         rich.padding.Padding(
@@ -136,13 +137,14 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
+    use_color = True if rich.console.Console().color_system else False 
     fake_table = rich.table.Table(
         show_header=False,
-        show_lines=True,
+        show_lines=not use_color,
         padding=0,
-        highlight=True,
+        highlight=not use_color,
         pad_edge=False,
-        box=rich.box.SQUARE)
+        box=rich.box.SQUARE if not use_color else None)
     col = []
     col.append(
         rich.padding.Padding(
@@ -189,13 +191,14 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
+    use_color = True if rich.console.Console().color_system else False 
     fake_table = rich.table.Table(
         show_header=False,
-        show_lines=True,
+        show_lines=not use_color,
         padding=0,
-        highlight=True,
+        highlight=not use_color,
         pad_edge=False,
-        box=rich.box.SQUARE)
+        box=rich.box.SQUARE if not use_color else None)
     col = []
     col.append(
         rich.padding.Padding(
@@ -235,13 +238,14 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
+    use_color = True if rich.console.Console().color_system else False 
     fake_table = rich.table.Table(
         show_header=False,
-        show_lines=True,
+        show_lines=not use_color,
         padding=0,
-        highlight=True,
+        highlight=not use_color,
         pad_edge=False,
-        box=rich.box.SQUARE)
+        box=rich.box.SQUARE if not use_color else None)
     col = []
     col.append(
         rich.padding.Padding(
@@ -281,13 +285,14 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
+    use_color = True if rich.console.Console().color_system else False 
     fake_table = rich.table.Table(
         show_header=False,
-        show_lines=True,
+        show_lines=not use_color,
         padding=0,
-        highlight=True,
+        highlight=not use_color,
         pad_edge=False,
-        box=rich.box.SQUARE)
+        box=rich.box.SQUARE if not use_color else None)
     col = []
     col.append(
         rich.padding.Padding(
@@ -327,13 +332,14 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
+    use_color = True if rich.console.Console().color_system else False 
     fake_table = rich.table.Table(
         show_header=False,
-        show_lines=True,
+        show_lines=not use_color,
         padding=0,
-        highlight=True,
+        highlight=not use_color,
         pad_edge=False,
-        box=rich.box.SQUARE)
+        box=rich.box.SQUARE if not use_color else None)
     col = []
     col.append(
         rich.padding.Padding(
@@ -368,7 +374,6 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
-    # console = rich.console.Console() # width=max_width)
     use_color = True if rich.console.Console().color_system else False 
     fake_table = rich.table.Table(
         show_header=False,
@@ -482,13 +487,14 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
+    use_color = True if rich.console.Console().color_system else False 
     fake_table = rich.table.Table(
         show_header=False,
-        show_lines=True,
+        show_lines=not use_color,
         padding=0,
-        highlight=True,
+        highlight=not use_color,
         pad_edge=False,
-        box=rich.box.SQUARE)
+        box=rich.box.SQUARE if not use_color else None)
     col = []
     col.append(
         rich.padding.Padding(
@@ -566,13 +572,14 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
+    use_color = True if rich.console.Console().color_system else False 
     fake_table = rich.table.Table(
         show_header=False,
-        show_lines=True,
+        show_lines=not use_color,
         padding=0,
-        highlight=True,
+        highlight=not use_color,
         pad_edge=False,
-        box=rich.box.SQUARE)
+        box=rich.box.SQUARE if not use_color else None)
     col = []
     col.append(
         rich.padding.Padding(
@@ -602,13 +609,14 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
+    use_color = True if rich.console.Console().color_system else False 
     fake_table = rich.table.Table(
         show_header=False,
-        show_lines=True,
+        show_lines=not use_color,
         padding=0,
-        highlight=True,
+        highlight=not use_color,
         pad_edge=False,
-        box=rich.box.SQUARE)
+        box=rich.box.SQUARE if not use_color else None)
     col = []
     col.append(
         rich.padding.Padding(
@@ -714,13 +722,14 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
+    use_color = True if rich.console.Console().color_system else False 
     fake_table = rich.table.Table(
         show_header=False,
-        show_lines=True,
+        show_lines=not use_color,
         padding=0,
-        highlight=True,
+        highlight=not use_color,
         pad_edge=False,
-        box=rich.box.SQUARE)
+        box=rich.box.SQUARE if not use_color else None)
     col = []
     col.append(
         rich.padding.Padding(
@@ -798,13 +807,14 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
+    use_color = True if rich.console.Console().color_system else False 
     fake_table = rich.table.Table(
         show_header=False,
-        show_lines=True,
+        show_lines=not use_color,
         padding=0,
-        highlight=True,
+        highlight=not use_color,
         pad_edge=False,
-        box=rich.box.SQUARE)
+        box=rich.box.SQUARE if not use_color else None)
     col = []
     col.append(
         rich.padding.Padding(

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -28,10 +28,10 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     xr.use_spmd()
     super().setUpClass()
 
-  @unittest.skipIf(
-      not xr.using_pjrt() or
-      xu.getenv_as(xenv.PJRT_DEVICE, str) in ("GPU", 'CUDA', 'ROCM', 'CPU'),
-      f"Requires PJRT_DEVICE set to `TPU`.")
+#   @unittest.skipIf(
+#       not xr.using_pjrt() or
+#       xu.getenv_as(xenv.PJRT_DEVICE, str) in ("GPU", 'CUDA', 'ROCM', 'CPU'),
+#       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_debugging_spmd_single_host_tiled_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     sharding={devices=[2,8]0,4,8,12,2,6,10,14,1,5,9,13,3,7,11,15}
@@ -101,10 +101,10 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipIf(
-      not xr.using_pjrt() or
-      xu.getenv_as(xenv.PJRT_DEVICE, str) in ("GPU", 'CUDA', 'ROCM', 'CPU'),
-      f"Requires PJRT_DEVICE set to `TPU`.")
+#   @unittest.skipIf(
+#       not xr.using_pjrt() or
+#       xu.getenv_as(xenv.PJRT_DEVICE, str) in ("GPU", 'CUDA', 'ROCM', 'CPU'),
+#       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_single_host_partial_replication_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     sharding={devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}
@@ -144,10 +144,10 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-  @unittest.skipIf(
-      not xr.using_pjrt() or
-      xu.getenv_as(xenv.PJRT_DEVICE, str) in ("GPU", 'CUDA', 'ROCM', 'CPU'),
-      f"Requires PJRT_DEVICE set to `TPU`.")
+#   @unittest.skipIf(
+#       not xr.using_pjrt() or
+#       xu.getenv_as(xenv.PJRT_DEVICE, str) in ("GPU", 'CUDA', 'ROCM', 'CPU'),
+#       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_single_host_replicated_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     sharding = '{replicated}'

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -156,12 +156,11 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
   @unittest.skipIf(xr.device_type() != 'TPU',
                    f"Requires PJRT_DEVICE set to `TPU`.")
+  @unittest.skipIf(xr.global_runtime_device_count() != 8,
+                   f"Limit test num_devices to 8 for function consistency")
   def test_single_host_replicated_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{replicated}'
-    num_devices = self.n_devices
-    if num_devices != 8:
-      self.skipTest("limit test num_devices to 8 for function consistency")
     generated_table = visualize_sharding(sharding)
     console = rich.console.Console()
     with console.capture() as capture:
@@ -523,12 +522,11 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
   @unittest.skipIf(xr.device_type() != 'TPU',
                    f"Requires PJRT_DEVICE set to `TPU`.")
+  @unittest.skipIf(xr.global_runtime_device_count() != 8,
+                   f"Limit test num_devices to 8 for function consistency")
   def test_multi_host_replicated_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{replicated}'
-    num_devices = self.n_devices
-    if num_devices != 8:
-      self.skipTest("limit test num_devices to 8 for function consistency")
     generated_table = visualize_sharding(sharding)
     console = rich.console.Console()
     with console.capture() as capture:
@@ -755,12 +753,11 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
   @unittest.skipIf(xr.device_type() != 'CPU',
                    f"Requires PJRT_DEVICE set to `CPU`.")
+  @unittest.skipIf(xr.global_runtime_device_count() != 8,
+                   f"Limit test num_devices to 8 for function consistency")
   def test_multi_host_replicated_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{replicated}'
-    num_devices = self.n_devices
-    if num_devices != 8:
-      self.skipTest("limit test num_devices to 8 for function consistency")
     generated_table = visualize_sharding(sharding)
     console = rich.console.Console()
     with console.capture() as capture:

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -368,7 +368,6 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
     color = None
     text_color = None
-    test_debugging_spmd_multi_host_tiled_tpu
     # console = rich.console.Console() # width=max_width)
     use_color = True if rich.console.Console().color_system else False 
     fake_table = rich.table.Table(

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -28,7 +28,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     xr.use_spmd()
     super().setUpClass()
 
-  @unittest.skipIf(xr.device_type() == ('CPU'),
+  @unittest.skipIf(xr.device_type() == 'CPU',
                    f"Requires PJRT_DEVICE set to `TPU`, `GPU`, or `CUDA`.")
   def test_debugging_spmd_single_host_tiled_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -28,7 +28,6 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     xr.use_spmd()
     super().setUpClass()
 
-
   def test_debugging_spmd_single_host_tiled_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     sharding = '{devices=[2,8]0,4,8,12,2,6,10,14,1,5,9,13,3,7,11,15}'
@@ -98,7 +97,6 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     fake_output = fake_capture.get()
     assert output == fake_output
 
-
   def test_single_host_partial_replication_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
     sharding = '{devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}'
@@ -137,7 +135,6 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
       fake_console.print(fake_table)
     fake_output = fake_capture.get()
     assert output == fake_output
-
 
   def test_single_host_replicated_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -774,14 +774,11 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
         highlight=not use_color,
         pad_edge=False,
         box=rich.box.SQUARE if not use_color else None)
-    alltpus = 'CPU [0'
-    for i in range(xr.global_runtime_device_count()-1):
-      alltpus = alltpus + ',' + str(i+1)
-    alltpus = alltpus + ']'
     col = []
+    # PJRT_DEVICE=CPU will only has one CPU, please update once situation change
     col.append(
         rich.padding.Padding(
-            rich.align.Align(alltpus, "center", vertical="middle"),
+            rich.align.Align('CPU [0]', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -28,8 +28,8 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     xr.use_spmd()
     super().setUpClass()
 
-  @unittest.skipIf(xr.device_type() != 'TPU',
-                   f"Requires PJRT_DEVICE set to `TPU`.")
+  @unittest.skipIf(xr.device_type() not in ('TPU', 'GPU'),
+                   f"Requires PJRT_DEVICE set to `TPU` or `GPU`.")
   def test_debugging_spmd_single_host_tiled_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{devices=[2,4]0,1,2,3,4,5,6,7}'
@@ -52,44 +52,44 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 0', "center", vertical="middle"),
+            rich.align.Align(xr.device_type() + ' 0', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 1', "center", vertical="middle"),
+            rich.align.Align(xr.device_type() + ' 1', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 2', "center", vertical="middle"),
+            rich.align.Align(xr.device_type() + ' 2', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 3', "center", vertical="middle"),
+            rich.align.Align(xr.device_type() + ' 3', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)
     col = []
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 4', "center", vertical="middle"),
+            rich.align.Align(xr.device_type() + ' 4', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 5', "center", vertical="middle"),
+            rich.align.Align(xr.device_type() + ' 5', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 6', "center", vertical="middle"),
+            rich.align.Align(xr.device_type() + ' 6', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     col.append(
         rich.padding.Padding(
-            rich.align.Align('TPU 7', "center", vertical="middle"),
+            rich.align.Align(xr.device_type() + ' 7', "center", vertical="middle"),
             (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -34,7 +34,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 #       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_debugging_spmd_single_host_tiled_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
-    sharding={devices=[2,8]0,4,8,12,2,6,10,14,1,5,9,13,3,7,11,15}
+    sharding = '{devices=[2,8]0,4,8,12,2,6,10,14,1,5,9,13,3,7,11,15}'
     generated_table = visualize_tensor_sharding(t)
     console = rich.console.Console()
     with console.capture() as capture:
@@ -107,7 +107,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 #       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_single_host_partial_replication_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
-    sharding={devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}
+    sharding = '{devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}'
     generated_table = visualize_tensor_sharding(t)
     console = rich.console.Console()
     with console.capture() as capture:
@@ -186,7 +186,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
       xu.getenv_as(xenv.PJRT_DEVICE, str) in ("GPU", 'CUDA', 'ROCM', 'TPU'),
       f"Requires PJRT_DEVICE set to `CPU`.")
   def test_debugging_spmd_single_host_tiled_cpu(self):
-    sharding={devices=[2,8]0,4,8,12,2,6,10,14,1,5,9,13,3,7,11,15}
+    sharding = '{devices=[2,8]0,4,8,12,2,6,10,14,1,5,9,13,3,7,11,15}'
     generated_table = visualize_tensor_sharding(t)
     console = rich.console.Console()
     with console.capture() as capture:
@@ -222,7 +222,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
       f"Requires PJRT_DEVICE set to `CPU`.")
   def test_single_host_partial_replication_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
-    sharding={devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}
+    sharding = '{devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}'
     generated_table = visualize_tensor_sharding(t)
     console = rich.console.Console()
     with console.capture() as capture:
@@ -498,7 +498,6 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
       f"Requires PJRT_DEVICE set to `TPU`.")
   def test_multi_host_replicated_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
-    num_devices = self.n_devices
     sharding = '{replicated}'
     generated_table = visualize_sharding(sharding)
     console = rich.console.Console()

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -590,8 +590,9 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
     col.append(
         rich.padding.Padding(
             rich.align.Align(
-                xr.device_type() + ' [0, 1, 2, 3, 4, 5, 6, 7]', "center", vertical="middle"),
-            (1, 1, 1, 1),
+                xr.device_type() + ' [0, 1, 2, 3, 4, 5, 6, 7]',
+                "center",
+                vertical="middle"), (1, 1, 1, 1),
             style=rich.style.Style(bgcolor=color, color=text_color)))
     fake_table.add_row(*col)
     fake_console = rich.console.Console()

--- a/test/spmd/test_spmd_debugging.py
+++ b/test/spmd/test_spmd_debugging.py
@@ -30,7 +30,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
   def test_debugging_spmd_single_host_tiled_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
-    sharding = '{devices=[2,8]0,4,8,12,2,6,10,14,1,5,9,13,3,7,11,15}'
+    sharding = '{devices=[2,4]0,1,2,3,4,5,6,7}'
     generated_table = visualize_sharding(sharding)
     console = rich.console.Console()
     with console.capture() as capture:
@@ -99,7 +99,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
 
   def test_single_host_partial_replication_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
-    sharding = '{devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}'
+    sharding = '{devices=[4,1,2]0,1,2,3,4,5,6,7 last_tile_dim_replicate}'
     generated_table = visualize_sharding(sharding)
     console = rich.console.Console()
     with console.capture() as capture:
@@ -139,6 +139,9 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
   def test_single_host_replicated_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{replicated}'
+    num_devices = self.n_devices
+    if num_devices != 8:
+      self.skipTest("limit test num_devices to 8 for function consistency")
     generated_table = visualize_sharding(sharding)
     console = rich.console.Console()
     with console.capture() as capture:
@@ -173,7 +176,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
                    f"Requires PJRT_DEVICE set to `CPU`.")
   def test_debugging_spmd_single_host_tiled_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
-    sharding = '{devices=[2,8]0,4,8,12,2,6,10,14,1,5,9,13,3,7,11,15}'
+    sharding = '{devices=[2,4]0,1,2,3,4,5,6,7}'
     generated_table = visualize_sharding(sharding)
     console = rich.console.Console()
     with console.capture() as capture:
@@ -207,7 +210,7 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
                    f"Requires PJRT_DEVICE set to `CPU`.")
   def test_single_host_partial_replication_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
-    sharding = '{devices=[8,1,2]0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15 last_tile_dim_replicate}'
+    sharding = '{devices=[4,1,2]0,1,2,3,4,5,6,7 last_tile_dim_replicate}'
     generated_table = visualize_sharding(sharding)
     console = rich.console.Console()
     with console.capture() as capture:
@@ -242,6 +245,9 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
   def test_single_host_replicated_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{replicated}'
+    num_devices = self.n_devices
+    if num_devices != 8:
+      self.skipTest("limit test num_devices to 8 for function consistency")
     generated_table = visualize_sharding(sharding)
     console = rich.console.Console()
     with console.capture() as capture:
@@ -476,6 +482,9 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
   def test_multi_host_replicated_tpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{replicated}'
+    num_devices = self.n_devices
+    if num_devices != 8:
+      self.skipTest("limit test num_devices to 8 for function consistency")
     generated_table = visualize_sharding(sharding)
     console = rich.console.Console()
     with console.capture() as capture:
@@ -705,6 +714,9 @@ class DebuggingSpmdTest(test_xla_sharding_base.XlaShardingTest):
   def test_multi_host_replicated_cpu(self):
     from torch_xla.distributed.spmd.debugging import visualize_sharding
     sharding = '{replicated}'
+    num_devices = self.n_devices
+    if num_devices != 8:
+      self.skipTest("limit test num_devices to 8 for function consistency")
     generated_table = visualize_sharding(sharding)
     console = rich.console.Console()
     with console.capture() as capture:


### PR DESCRIPTION
Fix https://github.com/pytorch/xla/issues/6252

- `test/spmd/test_spmd_debugging.py` was added for test spmd debugging tool, to avoid local test failure and circular reasoning, test based on given sharding string
- add GPU tests by change `@unittest.skipIf(`
- enable local test color check before draw table