### PR TITLE
Fix global_runtime_device_count() for spmd case

### DIFF
--- a/test/cpp/test_xla_sharding.cpp
+++ b/test/cpp/test_xla_sharding.cpp
@@ -339,7 +339,7 @@ TEST_F(XLAShardingTest, CreateTensorsData) {
         torch_xla::runtime::GetComputationClient()->GetDataShards(xla_data);
     EXPECT_EQ(shards.size(), n_devices);
     EXPECT_TRUE(xla::Shape::Equal().IgnoreLayout()(xla_data->shape(),
-                                                    shards[0]->shape()));
+                                                   shards[0]->shape()));
     EXPECT_TRUE(XlaDataValuesEqual(tensors_data[0], shards[0], at::kFloat));
 
     // Returns multiple input shards, replicated

--- a/test/cpp/test_xla_sharding.cpp
+++ b/test/cpp/test_xla_sharding.cpp
@@ -328,21 +328,21 @@ TEST_F(XLAShardingTest, CreateTensorsData) {
   std::vector<torch::lazy::BackendDataPtr> tensors_data =
       CreateTensorsData(tensors, shardings, devices);
 
-  // Returns the input without sharding
-  auto xla_data =
-      std::dynamic_pointer_cast<torch_xla::runtime::ComputationClient::Data>(
-          tensors_data[0]);
-  std::vector<torch_xla::runtime::ComputationClient::DataPtr> shards =
-      torch_xla::runtime::GetComputationClient()->GetDataShards(xla_data);
-  EXPECT_EQ(shards.size(), 1);
-  EXPECT_TRUE(xla::Shape::Equal().IgnoreLayout()(xla_data->shape(),
-                                                 shards[0]->shape()));
-  EXPECT_TRUE(XlaDataValuesEqual(tensors_data[0], shards[0], at::kFloat));
-
-  // Returns multiple input shards, replicated
   int64_t n_devices =
       torch_xla::runtime::GetComputationClient()->GetLocalDevices().size();
   if (n_devices > 1) {
+    // null sharding is treated as replicated.
+    auto xla_data =
+        std::dynamic_pointer_cast<torch_xla::runtime::ComputationClient::Data>(
+            tensors_data[0]);
+    std::vector<torch_xla::runtime::ComputationClient::DataPtr> shards =
+        torch_xla::runtime::GetComputationClient()->GetDataShards(xla_data);
+    EXPECT_EQ(shards.size(), n_devices);
+    EXPECT_TRUE(xla::Shape::Equal().IgnoreLayout()(xla_data->shape(),
+                                                    shards[0]->shape()));
+    EXPECT_TRUE(XlaDataValuesEqual(tensors_data[0], shards[0], at::kFloat));
+
+    // Returns multiple input shards, replicated
     auto sharded_xla_data =
         std::dynamic_pointer_cast<torch_xla::runtime::ComputationClient::Data>(
             tensors_data[1]);

--- a/test/spmd/test_xla_sharding_base.py
+++ b/test/spmd/test_xla_sharding_base.py
@@ -9,8 +9,6 @@ import torch_xla.core.xla_env_vars as xenv
 import torch_xla.utils.utils as xu
 
 
-@unittest.skipUnless(xr.device_type() in ("TPU", "CPU"),
-                     f"Requires PJRT_DEVICE set to `TPU` or `CPU`.")
 class XlaShardingTest(unittest.TestCase):
 
   class SimpleLinear(nn.Module):

--- a/test/spmd/test_xla_spmd_python_api_interaction.py
+++ b/test/spmd/test_xla_spmd_python_api_interaction.py
@@ -99,6 +99,17 @@ class BasicRuntimeAPITest(test_xla_sharding_base.XlaShardingTest):
       self.assertGreaterEqual(xr.global_runtime_device_count(), 4)
     elif device_type == "CPU":
       self.assertEqual(xr.global_runtime_device_count(), 1)
+    elif device_type == 'CUDA':
+      command = 'nvidia-smi --list-gpus | wc -l'
+      result = subprocess.run(
+          command,
+          capture_output=True,
+          shell=True,
+          check=True,
+          text=True,
+      )
+      expected_gpu_cnt = int(result.stdout)
+      self.assertEqual(xr.global_runtime_device_count(), expected_gpu_cnt)
 
   def test_addressable_runtime_device_count(self):
     device_type = os.environ['PJRT_DEVICE']

--- a/test/spmd/test_xla_spmd_python_api_interaction.py
+++ b/test/spmd/test_xla_spmd_python_api_interaction.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import sys
+import subprocess
 
 import torch
 import torch.distributed as dist

--- a/torch_xla/csrc/runtime/pjrt_registry.cc
+++ b/torch_xla/csrc/runtime/pjrt_registry.cc
@@ -97,8 +97,11 @@ InitializePjRt(const std::string& device_type) {
 
     xla::PjRtClient::KeyValueGetCallback kv_get = nullptr;
     xla::PjRtClient::KeyValuePutCallback kv_put = nullptr;
-    auto allowed_devices =
-        std::make_optional<std::set<int>>(std::set{local_process_rank});
+    bool spmd = sys_util::GetEnvBool("XLA_USE_SPMD", false);
+    std::optional<std::set<int>> allowed_devices;
+    if (!spmd) {
+      allowed_devices = std::set{local_process_rank};
+    }
     if (global_world_size > 1) {
       // Use the XlaCoordinator as the distributed key-value store.
       coordinator = std::make_unique<XlaCoordinator>(


### PR DESCRIPTION
This pr fixes global_runtime_device_count() for SPMD case. This fix works on multi-host scenario as well.

Prior this PR, the APIs returns 1. With the PR, global_runtime_device_count() returns all the devices across the host (with torchrun).

Note xr.local_device_count() should still return 1 for SPMD. (fwiw, runtime::GetComputationClient()->GetLocalDevices() gets all the devices on the host even for spmd case, which can be confusing) and xr.global_device_count() still returns 1, as shown in test/spmd/test_xla_spmd_python_api_interaction.py

