### PR TITLE
test_zero1 passes on GPU with latest torch/xla (commit e1c94df)

### DIFF
--- a/test/test_zero1.py
+++ b/test/test_zero1.py
@@ -13,8 +13,6 @@ import unittest
 class XlaZeRO1Test(TestCase):
 
   @unittest.skipIf(xr.device_type() == 'TPU', "Crash on TPU")
-  @unittest.skipIf(xr.device_type() in ('GPU', 'CUDA', 'ROCM'),
-                   "TODO(alanwaketan): Fix it for the token change.")
   def test_zero1(self):
     device = xm.xla_device()
 


### PR DESCRIPTION
This commit reenables test/test_zero1.py for GPU. It is passing with latest torch/xla (commit e1c94df).

https://github.com/pytorch/xla/issues/6260