### PR TITLE
Set min TPU nodes to 0 for TPU CI & disable workflow run on push

### DIFF
--- a/.github/workflows/tpu_ci.yml
+++ b/.github/workflows/tpu_ci.yml
@@ -2,9 +2,6 @@ name: TPU Integration Test
 run-name: TPU Testing
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - master
 jobs:
   tpu-test:
     runs-on: v4-runner-set

--- a/infra/terraform_modules/arc_v4_container_cluster/arc-values.yaml
+++ b/infra/terraform_modules/arc_v4_container_cluster/arc-values.yaml
@@ -1,6 +1,6 @@
 githubConfigUrl: ${github_repo_url}
 githubConfigSecret: github-pat
-minRunners: 0
+minRunners: 1
 maxRunners: ${max_tpu_nodes}
 template:
   spec:

--- a/infra/terraform_modules/arc_v4_container_cluster/main.tf
+++ b/infra/terraform_modules/arc_v4_container_cluster/main.tf
@@ -50,9 +50,9 @@ resource "google_container_node_pool" "arc_v4_tpu_nodes" {
   location           = "us-central2"
   node_locations     = ["us-central2-b"]
   cluster            = google_container_cluster.arc_v4_cluster.name
-  initial_node_count = 0
+  initial_node_count = 1
   autoscaling {
-    total_min_node_count = 0
+    total_min_node_count = 1
     total_max_node_count = var.max_tpu_nodes
     location_policy      = "ANY"
   }


### PR DESCRIPTION
Currently the TPU CI setup is running into a permissions issue while attempting to scale up the number of TPU nodes:

```
2024-01-08T18:44:24Z    INFO    refreshing token    {"githubConfigUrl": "https://github.com/pytorch/xla"}
2024-01-08T18:44:24Z    INFO    getting runner registration token    {"registrationTokenURL": "https://api.github.com/repos/pytorch/xla/actions/runners/registration-token"}
2024-01-08T18:44:24Z    INFO    auto_scaler    unable to create message session. Will try again in 30 seconds    {"error": "failed to get runner registration token on refresh: unexpected response from Actions service during registration token call: 401 - {\"message\":\"Bad credentials\",\"documentation_url\":\"https://docs.github.com/rest\"}"}
```

This PR will disable the workflow activation on push, and also set the minimum number of TPU nodes and ARC runners to 1.