### PR TITLE
fix gpu spmd core dump

### DIFF
--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -679,7 +679,7 @@ PjRtComputationClient::ExecuteReplicated(
 
   using FutureVector = std::vector<xla::PjRtFuture<xla::Status>>;
   std::optional<FutureVector> returned_futures = FutureVector();
-  returned_futures->reserve(devices.size()); 
+  returned_futures->reserve(devices.size());
   std::vector<std::vector<std::unique_ptr<xla::PjRtBuffer>>> results;
   {
     tsl::profiler::TraceMe activity(

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -677,8 +677,8 @@ PjRtComputationClient::ExecuteReplicated(
   TF_VLOG(5) << "ExecuteReplicated acquiring PJRT device lock for "
              << spmd_device_str << " Done";
 
-  using FutureVector = std::vector<xla::PjRtFuture<xla::Status>>;
-  std::optional<FutureVector> returned_futures = FutureVector();
+  std::optional<std::vector<xla::PjRtFuture<xla::Status>>> returned_futures =
+      std::vector<xla::PjRtFuture<xla::Status>>();
   returned_futures->reserve(devices.size());
   std::vector<std::vector<std::unique_ptr<xla::PjRtBuffer>>> results;
   {

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -679,7 +679,6 @@ PjRtComputationClient::ExecuteReplicated(
 
   std::optional<std::vector<xla::PjRtFuture<xla::Status>>> returned_futures =
       std::vector<xla::PjRtFuture<xla::Status>>();
-  returned_futures->reserve(devices.size());
   std::vector<std::vector<std::unique_ptr<xla::PjRtBuffer>>> results;
   {
     tsl::profiler::TraceMe activity(

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -677,8 +677,9 @@ PjRtComputationClient::ExecuteReplicated(
   TF_VLOG(5) << "ExecuteReplicated acquiring PJRT device lock for "
              << spmd_device_str << " Done";
 
-  std::optional<std::vector<xla::PjRtFuture<xla::Status>>> returned_futures(
-      devices.size());
+  using FutureVector = std::vector<xla::PjRtFuture<xla::Status>>;
+  std::optional<FutureVector> returned_futures = FutureVector();
+  returned_futures->reserve(1); 
   std::vector<std::vector<std::unique_ptr<xla::PjRtBuffer>>> results;
   {
     tsl::profiler::TraceMe activity(

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -679,7 +679,7 @@ PjRtComputationClient::ExecuteReplicated(
 
   using FutureVector = std::vector<xla::PjRtFuture<xla::Status>>;
   std::optional<FutureVector> returned_futures = FutureVector();
-  returned_futures->reserve(1); 
+  returned_futures->reserve(devices.size()); 
   std::vector<std::vector<std::unique_ptr<xla::PjRtBuffer>>> results;
   {
     tsl::profiler::TraceMe activity(


### PR DESCRIPTION
This `std::optional<std::vector<xla::PjRtFuture<xla::Status>>> returned_futures(devices.size());` will cause the elements in returned_futures to be initialized with null values, which will cause an error on subsequent attempts to access returned_futures[0]