### PR TITLE
Reenable ZeRO1 test for GPU to enable coverage for reduce-scatter/all-gather

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -234,6 +234,7 @@ function run_mp_op_tests {
   run_test "$CDIR/test_mp_save.py"
   run_test "$CDIR/test_mp_mesh_reduce.py"
   run_test "$CDIR/test_mp_sync_batch_norm.py"
+  run_test "$CDIR/test_mp_early_exit.py"
   run_pt_xla_debug "$CDIR/debug_tool/test_mp_pt_xla_debug.py"
   run_xla_backend_mp "$CDIR/test_torch_distributed_all_gather_xla_backend.py"
   run_xla_backend_mp "$CDIR/test_torch_distributed_all_reduce_xla_backend.py"

--- a/test/test_mp_early_exit.py
+++ b/test/test_mp_early_exit.py
@@ -1,0 +1,26 @@
+import sys
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.distributed.parallel_loader as pl
+import torch_xla.distributed.xla_multiprocessing as xmp
+import torch_xla.utils.utils as xu
+
+
+def _mp_fn(index):
+  device = xm.xla_device()
+  if xm.xla_device_hw(device) in ('TPU', 'GPU', 'CUDA', 'ROCM', 'NEURON'):
+    train_loader = xu.SampleGenerator(
+        data=torch.zeros(1, 12), sample_count=1024)
+    train_loader = pl.MpDeviceLoader(train_loader, device)
+    max_steps = 10
+    for step, inputs in enumerate(train_loader):
+      xm.all_reduce('sum', [inputs], scale=1.0 / xm.xrt_world_size())
+      if step > max_steps:
+        break
+  else:
+    print(f'{device} is not a TPU or GPU device', file=sys.stderr)
+
+
+if __name__ == '__main__':
+  xmp.spawn(_mp_fn, args=())

--- a/test/test_zero1.py
+++ b/test/test_zero1.py
@@ -13,8 +13,6 @@ import unittest
 class XlaZeRO1Test(TestCase):
 
   @unittest.skipIf(xr.device_type() == 'TPU', "Crash on TPU")
-  @unittest.skipIf(xr.device_type() in ('GPU', 'CUDA', 'ROCM'),
-                   "TODO(alanwaketan): Fix it for the token change.")
   def test_zero1(self):
     device = xm.xla_device()
 

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -148,6 +148,8 @@ _aws_ec2_inf_trn_init()
 
 
 def _prepare_to_exit():
+  device = _XLAC._xla_get_default_device()
+  _XLAC._set_all_reduce_token(device, None)
   _XLAC._prepare_to_exit()
   if int(os.environ.get('PT_XLA_DEBUG', '0')):
     _summarize_fn_tracker()


### PR DESCRIPTION
Currently ZeRO1 test/test_zero1.py is disabled for GPU since version 2.1 (https://github.com/pytorch/xla/pull/4912). We should reenable it for GPU to enable coverage for reduce-scatter/all-gather.

This back-port some commits to resolve the segfault seen with this test on GPU and reenable it for regressions.

https://github.com/pytorch/xla/issues/6260