### PR TITLE
Revert "Remove reshape lowering (#6230)"

### DIFF
--- a/codegen/xla_native_functions.yaml
+++ b/codegen/xla_native_functions.yaml
@@ -371,6 +371,7 @@ supported:
   - narrow_copy
   - pixel_shuffle
   - pixel_unshuffle
+  - reshape
   - select_backward
   - select.int
   - slice.Tensor
@@ -403,6 +404,8 @@ symint:
   - narrow_copy
   - select_backward
   - select.int
+  # See Note: [functionalization and CompositeExplicitAutograd]
+  - reshape
   # See Note: [Disabling functionalization]
   - expand
   - view

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3578,6 +3578,16 @@ at::Tensor XLANativeFunctions::pixel_unshuffle(const at::Tensor& self,
       pixel_unshuffle)>::call(self, downscale_factor);
 }
 
+at::Tensor XLANativeFunctions::reshape_symint(const at::Tensor& self,
+                                              c10::SymIntArrayRef shape) {
+  // See Note: [Disabling functionalization]
+  if (runtime::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
+    return at::native::reshape_symint(self, shape);
+  }
+  return at::functionalization::functionalize_aten_op_symint<ATEN_OP(
+      reshape)>::call(self, shape);
+}
+
 at::Tensor XLANativeFunctions::select_backward_symint(
     const at::Tensor& grad_output, c10::SymIntArrayRef input_sizes, int64_t dim,
     c10::SymInt index) {


### PR DESCRIPTION
This reverts commit 0c81365e87553e8d52059f5379ae416a2f5a13cc.

It causes OOMs for some training workloads on GPUs, and slows down others.