### PR TITLE
Backport `PjRtStreamExecutorLoadedExecutable:GetCompileOptions`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,6 +48,7 @@ http_archive(
     patches = [
         "//openxla_patches:cache_urls.diff",
         "//openxla_patches:constexpr_return.diff",
+        "//openxla_patches:gpu_compile_options.diff",
         "//openxla_patches:gpu_race_condition.diff",
         "//openxla_patches:f16_abi_clang.diff",
         "//openxla_patches:quant_dequant_converter.diff",

--- a/openxla_patches/gpu_compile_options.diff
+++ b/openxla_patches/gpu_compile_options.diff
@@ -1,0 +1,17 @@
+# Partial backport of https://github.com/openxla/xla/pull/6807
+# Remove with next XLA pin update.
+diff --git a/xla/pjrt/pjrt_stream_executor_client.h b/xla/pjrt/pjrt_stream_executor_client.h
+index 9267e1e03..dd0471ee6 100644
+--- a/xla/pjrt/pjrt_stream_executor_client.h
++++ b/xla/pjrt/pjrt_stream_executor_client.h
+@@ -869,6 +869,10 @@ class PjRtStreamExecutorLoadedExecutable : public PjRtLoadedExecutable {
+     return executables_;
+   }
+
++  absl::StatusOr<CompileOptions> GetCompileOptions() const override {
++    return compile_options_;
++  }
++
+  protected:
+   bool parameter_is_tupled_arguments() const {
+     return parameter_is_tupled_arguments_;

--- a/plugins/cuda/torch_xla_cuda_plugin/__init__.py
+++ b/plugins/cuda/torch_xla_cuda_plugin/__init__.py
@@ -8,4 +8,4 @@ class GpuPlugin(plugins.DevicePlugin):
 
   def physical_chip_count(self) -> int:
     # TODO: default to actual device count
-    return os.getenv('GPU_NUM_DEVICES', 1)
+    return int(os.getenv('GPU_NUM_DEVICES', '1'))


### PR DESCRIPTION
Partial backport of https://github.com/openxla/xla/pull/6807.  `PjRtStreamExecutorLoadedExecutable:GetCompileOptions` is required for the PJRT C API wrapper. MNIST and `test_operations.py` pass on a single GPU through the PJRT plugin with this change. cc @jyingl3