### PR TITLE
Fix output type of custom calls while lowering quant/dequant torch op to HLO

### DIFF
--- a/torch_xla/csrc/quant_util.cpp
+++ b/torch_xla/csrc/quant_util.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <unordered_map>
 
+#include "torch_xla/csrc/runtime/debug_macros.h"
 #include "torch_xla/csrc/runtime/stablehlo_helper.h"
 
 namespace torch_xla {
@@ -44,7 +45,10 @@ std::string QuantParams::SerializeToAttrDictStr() const {
   }
   ss << "scale=" << SeralizeFloatVector<float>(scale, true) << ',';
   ss << "zero_point=" << SeralizeFloatVector<int>(zero_point) << ',';
-  ss << "storage_type=" << GetTorchDtypeToStablehloDtypeMap().at(dtype) << ',';
+  ss << "storage_type=" << GetTorchDtypeToStablehloDtype(dtype) << ',';
+  if (!GetHloDtypeToStablehloDtypeMap().count(expressed_type))
+    XLA_ERROR() << "Unsupported dtype for conversion from Hlo to Stablehlo: "
+                << dtype;
   ss << "expressed_type=" << GetHloDtypeToStablehloDtypeMap().at(expressed_type)
      << ',';
   ss << "storage_min=" << quant_min << ',';

--- a/torch_xla/csrc/runtime/stablehlo_helper.cc
+++ b/torch_xla/csrc/runtime/stablehlo_helper.cc
@@ -168,14 +168,14 @@ void ConvertStableHloToHlo(mlir::ModuleOp* mlir_module,
                          << getMlirModuleStr(*mlir_module);
 }
 
-const std::unordered_map<std::string, std::string>&
-GetTorchDtypeToStablehloDtypeMap() {
-  static const std::unordered_map<std::string, std::string> m_{
-      {"torch.int8", "si8"},
-      {"torch.uint8", "ui8"},
-      {"torch.int16", "si16"},
-  };
-  return m_;
+const std::string GetTorchDtypeToStablehloDtype(const std::string& dtype) {
+  if (dtype == "torch.int8") return "si8";
+  if (dtype == "torch.uint8") return "ui8";
+  if (dtype == "torch.int16") return "si16";
+  if (dtype == "torch.int32") return "si32";
+  if (dtype == "torch.int64") return "si64";
+  XLA_ERROR() << "Unsupported dtype for conversion to Stablehlo type: "
+              << dtype;
 }
 
 const std::unordered_map<xla::PrimitiveType, std::string>&
@@ -187,9 +187,18 @@ GetHloDtypeToStablehloDtypeMap() {
       {xla::PrimitiveType::U8, "ui8"},   {xla::PrimitiveType::U16, "ui16"},
       {xla::PrimitiveType::U32, "ui32"}, {xla::PrimitiveType::U64, "ui64"},
       {xla::PrimitiveType::F16, "f16"},  {xla::PrimitiveType::BF16, "bf16"},
-      {xla::PrimitiveType::F32, "f32"},
+      {xla::PrimitiveType::F32, "f32"},  {xla::PrimitiveType::F64, "f64"},
   };
   return m_;
+}
+
+xla::PrimitiveType GetTorchIntDtypeToHloDtype(const std::string& dtype) {
+  if (dtype == "torch.int8") return xla::PrimitiveType::S8;
+  if (dtype == "torch.uint8") return xla::PrimitiveType::U8;
+  if (dtype == "torch.int16") return xla::PrimitiveType::S16;
+  if (dtype == "torch.int32") return xla::PrimitiveType::S32;
+  if (dtype == "torch.int64") return xla::PrimitiveType::S64;
+  XLA_ERROR() << "Unsupported dtype for conversion to Hlo type: " << dtype;
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/runtime/stablehlo_helper.h
+++ b/torch_xla/csrc/runtime/stablehlo_helper.h
@@ -22,11 +22,12 @@ void ConvertStableHloToHlo(mlir::ModuleOp* mlir_module,
 
 std::string GetHloModuleStr(const xla::HloModuleProto* proto);
 
-const std::unordered_map<std::string, std::string>&
-GetTorchDtypeToStablehloDtypeMap();
+const std::string GetTorchDtypeToStablehloDtype(const std::string& dtype);
 
 const std::unordered_map<xla::PrimitiveType, std::string>&
 GetHloDtypeToStablehloDtypeMap();
+
+xla::PrimitiveType GetTorchIntDtypeToHloDtype(const std::string& dtype);
 
 }  // namespace torch_xla
 


### PR DESCRIPTION
https://github.com/pytorch/xla/pull/5763 allows lowering the torch quantize/dequantize operations to HLO custom calls. For example, 
the following PyTorch code
```
x = torch.ops.quantized_decomposed.quantize_per_tensor(
    x, 0.4, 2, -128, 127, torch.int8)
x = torch.ops.quantized_decomposed.dequantize_per_tensor(
    x, 0.4, 2, -128, 127, torch.int8)
```

is lowered to the following HLO operations:
```
ENTRY %IrToHlo.5 (p0.1: f32[2,3,4,5]) -> (f32[2,3,4,5]) {
  %p0.1 = f32[2,3,4,5]{3,2,1,0} parameter(0)

  %custom-call.2 = f32[2,3,4,5]{3,2,1,0} custom-call(f32[2,3,4,5]{3,2,1,0} %p0.1), custom_call_target="stablehlo.uniform_quantize", api_version=API_VERSION_TYPED_FFI, backend_config={scale=[0.4],zero_point=[2],storage_type=si8,expressed_type=f32,storage_min=-128,storage_max=127}

  %custom-call.3 = f32[2,3,4,5]{3,2,1,0} custom-call(f32[2,3,4,5]{3,2,1,0} %custom-call.2), custom_call_target="stablehlo.uniform_dequantize", api_version=API_VERSION_TYPED_FFI, backend_config={scale=[0.4],zero_point=[2],storage_type=si8,expressed_type=f32,storage_min=-128,storage_max=127}
  ROOT %tuple.4 = (f32[2,3,4,5]{3,2,1,0}) tuple(f32[2,3,4,5]{3,2,1,0} %custom-call.3)
}
```


Note that the output of custom call corresponding to quantize op has element type `f32`.  The fact that the output of custom_call (for quantize operation) is a float is more of a logical problem as the the result of quantization is generally expected to be in integer domain. Also, note that the choice of output type should not effect the eventual conversion of HLO custom calls to mhlo `uniform.quantize`/`uniform.dequantize` operations. 

Moreover, based on https://github.com/pytorch/pytorch/blob/0b72ce1bd1a4a0596dde4053899b8a9a7999bc47/torch/ao/quantization/fx/_decomposed.py#L164 we set the output element type of dequatize operation to be `f32`

Finally improved the debuggability of the map queries using proper error messages.  

cc @GleasonK 