### PR TITLE
Fix some more core aten opset tests

### DIFF
--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -1438,7 +1438,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.div.Tensor, args, kwargs)
 
-  @unittest.skip
   def test_aten_div_Tensor_2(self):
     args = (
         torch.randint(0, 10, (10, 10)).to(torch.int32),

--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -32,9 +32,9 @@ def diff_output(testcase, output1, output2, rtol, atol, equal_nan=True):
     if output2_cpu.dtype != output1.dtype:
       output2_cpu = output2_cpu.to(output1.dtype)
     # import pdb; pdb.set_trace()
-    # print(f'[WONJOO] output1={output1}')
-    # print(f'[WONJOO] output2_cpu={output2_cpu}')
-    # print(f'[WONJOO] output2_cpu-output1={output2_cpu-output1}')
+    print(f'[WONJOO] output1={output1}')
+    print(f'[WONJOO] output2_cpu={output2_cpu}')
+    print(f'[WONJOO] output2_cpu-output1={output2_cpu-output1}')
     testcase.assertTrue(
         torch.allclose(
             output1, output2_cpu, atol=atol, rtol=rtol, equal_nan=equal_nan))
@@ -3715,23 +3715,44 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.round, args, kwargs)
 
-  @unittest.skip
   def test_aten_rsqrt_0(self):
     args = (torch.randn((10, 10)).to(torch.float32),)
     kwargs = dict()
-    run_export_and_compare(self, torch.ops.aten.rsqrt, args, kwargs)
+    # run_export_and_compare(self, torch.ops.aten.rsqrt, args, kwargs)
+    run_export_and_compare(
+        self,
+        torch.ops.aten.rsqrt,
+        args,
+        kwargs,
+        rtol=0.001,
+        atol=0.01,
+    )
 
-  @unittest.skip
   def test_aten_rsqrt_1(self):
     args = (torch.randn((10, 10)).to(torch.float16),)
     kwargs = dict()
-    run_export_and_compare(self, torch.ops.aten.rsqrt, args, kwargs)
+    # run_export_and_compare(self, torch.ops.aten.rsqrt, args, kwargs)
+    run_export_and_compare(
+        self,
+        torch.ops.aten.rsqrt,
+        args,
+        kwargs,
+        rtol=0.001,
+        atol=0.01,
+    )
 
-  @unittest.skip
   def test_aten_rsqrt_2(self):
     args = (torch.randint(0, 10, (10, 10)).to(torch.int32),)
     kwargs = dict()
-    run_export_and_compare(self, torch.ops.aten.rsqrt, args, kwargs)
+    # run_export_and_compare(self, torch.ops.aten.rsqrt, args, kwargs)
+    run_export_and_compare(
+        self,
+        torch.ops.aten.rsqrt,
+        args,
+        kwargs,
+        rtol=0.001,
+        atol=0.01,
+    )
 
   def test_aten_rsub_Scalar_0(self):
     args = (

--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -139,7 +139,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.acosh, args, kwargs)
 
-  @unittest.skip
   def test_aten_unsqueeze_0(self):
     args = (
         torch.randn((1, 3, 10)).to(torch.float32),
@@ -148,7 +147,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.unsqueeze, args, kwargs)
 
-  @unittest.skip
   def test_aten_unsqueeze_1(self):
     args = (
         torch.randn((1, 3, 10)).to(torch.float16),
@@ -157,7 +155,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.unsqueeze, args, kwargs)
 
-  @unittest.skip
   def test_aten_unsqueeze_2(self):
     args = (
         torch.randint(0, 10, (1, 3, 10)).to(torch.int32),
@@ -166,7 +163,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.unsqueeze, args, kwargs)
 
-  @unittest.skip
   def test_aten_unsqueeze_3(self):
     args = (
         torch.randn((1, 3, 10)).to(torch.float32),
@@ -175,7 +171,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.unsqueeze, args, kwargs)
 
-  @unittest.skip
   def test_aten_unsqueeze_4(self):
     args = (
         torch.randn((1, 3, 10)).to(torch.float16),
@@ -184,7 +179,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.unsqueeze, args, kwargs)
 
-  @unittest.skip
   def test_aten_unsqueeze_5(self):
     args = (
         torch.randint(0, 10, (1, 3, 10)).to(torch.int32),

--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -235,7 +235,6 @@ class AtenOpTest(unittest.TestCase):
     run_export_and_compare(self, torch.ops.aten._adaptive_avg_pool2d, args,
                            kwargs)
 
-  @unittest.skip
   def test_aten_squeeze_dim_0(self):
     args = (
         torch.randn((1, 3, 1, 5)).to(torch.float32),
@@ -244,7 +243,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.squeeze.dim, args, kwargs)
 
-  @unittest.skip
   def test_aten_squeeze_dim_1(self):
     args = (
         torch.randn((1, 3, 1, 5)).to(torch.float32),

--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -24,30 +24,21 @@ def onlyIfPJRTDeviceIsCUDA(fn):
 
 
 def diff_output(testcase, output1, output2, rtol, atol, equal_nan=True):
-  # import pdb; pdb.set_trace()
   if isinstance(output1, torch.Tensor):
-    # print('at 1')
     testcase.assertIsInstance(output2, torch.Tensor)
     output2_cpu = output2.detach().cpu()
     if output2_cpu.dtype != output1.dtype:
       output2_cpu = output2_cpu.to(output1.dtype)
     # import pdb; pdb.set_trace()
-    print(f'[WONJOO] output1={output1}')
-    print(f'[WONJOO] output2_cpu={output2_cpu}')
-    print(f'[WONJOO] output2_cpu-output1={output2_cpu-output1}')
     testcase.assertTrue(
         torch.allclose(
             output1, output2_cpu, atol=atol, rtol=rtol, equal_nan=equal_nan))
   elif isinstance(output1, (tuple, list)):
-    # print('at 2')
     testcase.assertIsInstance(output2, (tuple, list))
     testcase.assertEqual(len(output1), len(output2))
     for o1, o2 in zip(output1, output2):
-      # print(f'o1={o1}')
-      # print(f'o2={o2}')
       diff_output(testcase, o1, o2, rtol, atol)
   else:
-    # print('at 3')
     testcase.assertEqual(output1, output2)
 
 
@@ -58,7 +49,6 @@ def run_export_and_compare(testcase,
                            atol=1e-3,
                            rtol=1e-5,
                            equal_nan=True):
-  # import pdb; pdb.set_trace()
   device = xm.xla_device()
   with testcase.subTest('torch_eval'):
     res = func(*args, **kwargs)
@@ -67,11 +57,8 @@ def run_export_and_compare(testcase,
                                    args)
       kwargs2 = pytree.tree_map_only(torch.Tensor,
                                      lambda x: x.to(device=device), kwargs)
-      print(f'args2={args2}')
-      print(f'kwargs2={kwargs2}')
       res_xla = func(*args2, **kwargs2)
       with testcase.subTest('torch_xla_diff:' + str(atol)):
-        print('subtest torch_xla_diff')
         diff_output(
             testcase, res, res_xla, atol=atol, rtol=rtol, equal_nan=equal_nan)
     with testcase.subTest('can_export'):
@@ -81,7 +68,6 @@ def run_export_and_compare(testcase,
         with testcase.subTest('stablehlo_can_run'):
           res2 = shlo(*args, **kwargs)
           with testcase.subTest('stablehlo_diff: ' + str(atol)):
-            print('subtest stablehlo_diff')
             diff_output(
                 testcase, res, res2, rtol=rtol, atol=atol, equal_nan=equal_nan)
 

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -700,6 +700,11 @@ torch_xla::XlaOpVector Round::Lower(LoweringContext* loctx) const {
 
 torch_xla::XlaOpVector Rsqrt::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  if (xla::primitive_util::IsIntegralType(XlaHelpers::TypeOfXlaOp(xla_input))) {
+    xla::PrimitiveType input_type = XlaHelpers::TypeOfXlaOp(xla_input);
+    xla_input = ConvertTo(xla_input, input_type, xla::PrimitiveType::F32,
+                          /*device=*/nullptr);
+  }
   return ReturnOp(xla::Rsqrt(xla_input), loctx);
 }
 

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -702,8 +702,7 @@ torch_xla::XlaOpVector Rsqrt::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   if (xla::primitive_util::IsIntegralType(XlaHelpers::TypeOfXlaOp(xla_input))) {
     xla::PrimitiveType input_type = XlaHelpers::TypeOfXlaOp(xla_input);
-    xla_input = ConvertTo(xla_input, input_type, xla::PrimitiveType::F32,
-                          /*device=*/nullptr);
+    xla_input = ConvertTo(xla_input, input_type, xla::PrimitiveType::F32);
   }
   return ReturnOp(xla::Rsqrt(xla_input), loctx);
 }

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -777,7 +777,11 @@ xla::Shape RoundOutputShape(const torch::lazy::Value& input) {
 }
 
 xla::Shape RsqrtOutputShape(const torch::lazy::Value& input) {
-  return GetXlaShape(input);
+  xla::Shape result_shape = GetXlaShape(input);
+  if (xla::primitive_util::IsIntegralType(result_shape.element_type())) {
+    result_shape.set_element_type(xla::PrimitiveType::F32);
+  }
+  return result_shape;
 }
 
 xla::Shape SeluOutputShape(const torch::lazy::Value& input) {


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/5893, fixes https://github.com/pytorch/xla/issues/5978, fixes https://github.com/pytorch/xla/issues/5977, fixes https://github.com/pytorch/xla/issues/5860, fixes https://github.com/pytorch/xla/issues/5899

aten_sort
- add manual dtype conversion

aten_unsqueeze
- no-op, just enabling it

aten_squeeze_dim
- no-op, just enabling it

aten_div_Tensor
- no-op, just enabling it

aten_sort
- this is a tricky one -- so according to https://pytorch.org/docs/stable/generated/torch.sort.html, aten_sort returns two things: a namedtuple of (values, indices) is returned, where the values are the sorted values and indices are the indices of the elements in the original input tensor. We want to make sure the 0th index tensor (values) want to equal. However, the other tensor (indices) might be different if there are duplicates. Torch.sort has a optional param `stable` that controls this, but for some reason, trying to pass this `kwargs` is a bit tricky in the way we set up our tests. So I just manually updated the test parameter to be a tensor without repeating values by using `torch.randperm`.

Test plan: CI

