### PR TITLE
Raise an error in `xmp.spawn` if runtime is initialized

### DIFF
--- a/torch_xla/_internal/pjrt.py
+++ b/torch_xla/_internal/pjrt.py
@@ -143,6 +143,10 @@ def run_multiprocess(fn: Callable[..., R],
     Dict of the form {device_ordinal: return_value}, where
     return_value is the result of calling `fn`.
   """
+  if torch_xla._XLAC._xla_runtime_is_initialized():
+    raise RuntimeError('Runtime is already initialized. Do not use the XLA '
+                       'device before calling xmp.spawn.')
+
   if plugins.using_dynamic_plugins():
     num_processes = plugins.default().physical_chip_count()
   elif runtime.device_type() == 'TPU':


### PR DESCRIPTION
See #6274

The new behavior is:

```
>>> import torch_xla.core.xla_model as xm
>>> xm.xla_device()
WARNING:root:PJRT is now the default runtime. For more information, see https://github.com/pytorch/xla/blob/master/docs/pjrt.md
WARNING:root:libtpu.so and TPU device found. Setting PJRT_DEVICE=TPU.
device(type='xla', index=0)
>>> import torch_xla.distributed.xla_multiprocessing as xmp
>>> xmp.spawn(xm.xla_device)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/workspaces/work/pytorch/xla/torch_xla/runtime.py", line 88, in wrapper
    return fn(*args, **kwargs)
  File "/workspaces/work/pytorch/xla/torch_xla/distributed/xla_multiprocessing.py", line 38, in spawn
    return pjrt.spawn(fn, nprocs, start_method, args)
  File "/workspaces/work/pytorch/xla/torch_xla/_internal/pjrt.py", line 211, in spawn
    run_multiprocess(spawn_fn, start_method=start_method)
  File "/workspaces/work/pytorch/xla/torch_xla/runtime.py", line 88, in wrapper
    return fn(*args, **kwargs)
  File "/workspaces/work/pytorch/xla/torch_xla/_internal/pjrt.py", line 147, in run_multiprocess
    raise RuntimeError('Runtime is already initialized. Do not use the XLA '
RuntimeError: Runtime is already initialized. Do not use the XLA device before calling xmp.spawn.
```

The old behavior is:

<details>

```
>>> import torch_xla.core.xla_model as xm
>>> xm.xla_device()
WARNING:root:PJRT is now the default runtime. For more information, see https://github.com/pytorch/xla/blob/master/docs/pjrt.md
WARNING:root:libtpu.so and TPU device found. Setting PJRT_DEVICE=TPU.
device(type='xla', index=0)
>>> import torch_xla.distributed.xla_multiprocessing as xmp
>>> xmp.spawn(xm.xla_device)
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
F0000 00:00:1704933366.826262 2094648 pjrt_registry.cc:77] Non-OK-status: pjrt::LoadPjrtPlugin("tpu", tpu_library_path).status() status: ALREADY_EXISTS: PJRT_Api already exists for device type tpu
*** Begin stack trace ***
        tsl::CurrentStackTrace[abi:cxx11]()

        torch_xla::runtime::PjRtComputationClient::PjRtComputationClient()

        torch_xla::runtime::GetComputationClient()
        torch_xla::bridge::GetDefaultDevice()
        torch_xla::bridge::GetCurrentDevice()
        torch_xla::bridge::GetCurrentAtenDevice()



        _PyObject_MakeTpCall
        _PyEval_EvalFrameDefault

        PyVectorcall_Call

        Py_FinalizeEx
        Py_Exit


        PyRun_SimpleStringFlags

        Py_BytesMain
        __libc_start_main
        _start
*** End stack trace ***

WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
F0000 00:00:1704933366.828160 2094649 pjrt_registry.cc:77] Non-OK-status: pjrt::LoadPjrtPlugin("tpu", tpu_library_path).status() status: ALREADY_EXISTS: PJRT_Api already exists for device type tpu
*** Begin stack trace ***
        tsl::CurrentStackTrace[abi:cxx11]()

        torch_xla::runtime::PjRtComputationClient::PjRtComputationClient()

        torch_xla::runtime::GetComputationClient()
        torch_xla::bridge::GetDefaultDevice()
        torch_xla::bridge::GetCurrentDevice()
        torch_xla::bridge::GetCurrentAtenDevice()



        _PyObject_MakeTpCall
        _PyEval_EvalFrameDefault

        PyVectorcall_Call

        Py_FinalizeEx
        Py_Exit


        PyRun_SimpleStringFlags

        Py_BytesMain
        __libc_start_main
        _start
*** End stack trace ***

WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
F0000 00:00:1704933366.829307 2094651 pjrt_registry.cc:77] Non-OK-status: pjrt::LoadPjrtPlugin("tpu", tpu_library_path).status() status: ALREADY_EXISTS: PJRT_Api already exists for device type tpu
*** Begin stack trace ***
        tsl::CurrentStackTrace[abi:cxx11]()

        torch_xla::runtime::PjRtComputationClient::PjRtComputationClient()

        torch_xla::runtime::GetComputationClient()
        torch_xla::bridge::GetDefaultDevice()
        torch_xla::bridge::GetCurrentDevice()
        torch_xla::bridge::GetCurrentAtenDevice()



        _PyObject_MakeTpCall
        _PyEval_EvalFrameDefault

        PyVectorcall_Call

        Py_FinalizeEx
        Py_Exit


        PyRun_SimpleStringFlags

        Py_BytesMain
        __libc_start_main
        _start
*** End stack trace ***

WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
F0000 00:00:1704933366.829848 2094650 pjrt_registry.cc:77] Non-OK-status: pjrt::LoadPjrtPlugin("tpu", tpu_library_path).status() status: ALREADY_EXISTS: PJRT_Api already exists for device type tpu
*** Begin stack trace ***
        tsl::CurrentStackTrace[abi:cxx11]()

        torch_xla::runtime::PjRtComputationClient::PjRtComputationClient()

        torch_xla::runtime::GetComputationClient()
        torch_xla::bridge::GetDefaultDevice()
        torch_xla::bridge::GetCurrentDevice()
        torch_xla::bridge::GetCurrentAtenDevice()



        _PyObject_MakeTpCall
        _PyEval_EvalFrameDefault

        PyVectorcall_Call

        Py_FinalizeEx
        Py_Exit


        PyRun_SimpleStringFlags

        Py_BytesMain
        __libc_start_main
        _start
*** End stack trace ***

*** Check failure stack trace: ***
    @     0x7f8128df7c39  absl::lts_20230802::log_internal::LogMessageFatal::~LogMessageFatal()
    @     0x7f81205255c0  torch_xla::runtime::InitializePjRt()
    @     0x7f8120e07fb3  torch_xla::runtime::PjRtComputationClient::PjRtComputationClient()
    @     0x7f8120e00b9c  torch_xla::runtime::GetComputationClient()::{lambda()#1}::operator()()
    @     0x7f8120e00f1c  torch_xla::runtime::GetComputationClient()
    @     0x7f81209e0dfd  torch_xla::bridge::GetDefaultDevice()
    @     0x7f81209e0f05  torch_xla::bridge::GetCurrentDevice()
    @     0x7f81209e5857  torch_xla::bridge::GetCurrentAtenDevice()
    @     0x7f812098d955  pybind11::cpp_function::initialize<>()::{lambda()#3}::_FUN()
    @     0x7f81209acd24  pybind11::cpp_function::dispatcher()
    @     0x7f83fb9f3081  cfunction_call_varargs
*** Check failure stack trace: ***
    @     0x7ff7e15b7c39  absl::lts_20230802::log_internal::LogMessageFatal::~LogMessageFatal()
    @     0x7ff7d8ce55c0  torch_xla::runtime::InitializePjRt()
    @     0x7ff7d95c7fb3  torch_xla::runtime::PjRtComputationClient::PjRtComputationClient()
    @     0x7ff7d95c0b9c  torch_xla::runtime::GetComputationClient()::{lambda()#1}::operator()()
    @     0x7ff7d95c0f1c  torch_xla::runtime::GetComputationClient()
    @     0x7ff7d91a0dfd  torch_xla::bridge::GetDefaultDevice()
    @     0x7ff7d91a0f05  torch_xla::bridge::GetCurrentDevice()
    @     0x7ff7d91a5857  torch_xla::bridge::GetCurrentAtenDevice()
    @     0x7ff7d914d955  pybind11::cpp_function::initialize<>()::{lambda()#3}::_FUN()
    @     0x7ff7d916cd24  pybind11::cpp_function::dispatcher()
    @     0x7ffab45f7081  cfunction_call_varargs
https://symbolize.stripped_domain/r/?trace=7f83fb6fdce1,7f83fb6fdd5f,7f8128df751c,7f8128df7c38,7f81205255bf,7f8120e07fb2,7f8120e00b9b,7f8120e00f1b,7f81209e0dfc,7f81209e0f04,7f81209e5856,7f812098d954,7f81209acd23,7f83fb9f3080&map= 
*** SIGABRT received by PID 2094650 (TID 2094650) on cpu 30 from PID 2094650; stack trace: ***
https://symbolize.stripped_domain/r/?trace=7ffab4301ce1,7ffab4301d5f,7ff7e15b751c,7ff7e15b7c38,7ff7d8ce55bf,7ff7d95c7fb2,7ff7d95c0b9b,7ff7d95c0f1b,7ff7d91a0dfc,7ff7d91a0f04,7ff7d91a5856,7ff7d914d954,7ff7d916cd23,7ffab45f7080&map= 
*** SIGABRT received by PID 2094651 (TID 2094651) on cpu 137 from PID 2094651; stack trace: ***
PC: @     0x7f83fb6fdce1  (unknown)  raise
    @     0x7f7d0f2f5067        928  (unknown)
    @     0x7f83fb6fdd60  (unknown)  (unknown)
PC: @     0x7ffab4301ce1  (unknown)  raise
    @     0x7ff3cb2f5067        928  (unknown)
    @     0x7ffab4301d60  651107376  (unknown)
    @     0x7f8128df751d         32  absl::lts_20230802::log_internal::LogMessage::Die()
    @     0x7ff7e15b751d         32  absl::lts_20230802::log_internal::LogMessage::Die()
*** Check failure stack trace: ***
    @     0x7fb6ce8d7c39  absl::lts_20230802::log_internal::LogMessageFatal::~LogMessageFatal()
    @     0x7fb6c60055c0  torch_xla::runtime::InitializePjRt()
    @     0x7fb6c68e7fb3  torch_xla::runtime::PjRtComputationClient::PjRtComputationClient()
    @     0x7fb6c68e0b9c  torch_xla::runtime::GetComputationClient()::{lambda()#1}::operator()()
    @     0x7fb6c68e0f1c  torch_xla::runtime::GetComputationClient()
    @     0x7fb6c64c0dfd  torch_xla::bridge::GetDefaultDevice()
    @     0x7fb6c64c0f05  torch_xla::bridge::GetCurrentDevice()
    @     0x7fb6c64c5857  torch_xla::bridge::GetCurrentAtenDevice()
    @     0x7fb6c646d955  pybind11::cpp_function::initialize<>()::{lambda()#3}::_FUN()
    @     0x7fb6c648cd24  pybind11::cpp_function::dispatcher()
    @     0x7fb9a14b7081  cfunction_call_varargs
https://symbolize.stripped_domain/r/?trace=7fb9a11c1ce1,7fb9a11c1d5f,7fb6ce8d751c,7fb6ce8d7c38,7fb6c60055bf,7fb6c68e7fb2,7fb6c68e0b9b,7fb6c68e0f1b,7fb6c64c0dfc,7fb6c64c0f04,7fb6c64c5856,7fb6c646d954,7fb6c648cd23,7fb9a14b7080&map= 
*** SIGABRT received by PID 2094648 (TID 2094648) on cpu 22 from PID 2094648; stack trace: ***
*** Check failure stack trace: ***
    @     0x7f501347bc39  absl::lts_20230802::log_internal::LogMessageFatal::~LogMessageFatal()
    @     0x7f500aba95c0  torch_xla::runtime::InitializePjRt()
    @     0x7f500b48bfb3  torch_xla::runtime::PjRtComputationClient::PjRtComputationClient()
    @     0x7f500b484b9c  torch_xla::runtime::GetComputationClient()::{lambda()#1}::operator()()
    @     0x7f500b484f1c  torch_xla::runtime::GetComputationClient()
    @     0x7f500b064dfd  torch_xla::bridge::GetDefaultDevice()
    @     0x7f500b064f05  torch_xla::bridge::GetCurrentDevice()
    @     0x7f500b069857  torch_xla::bridge::GetCurrentAtenDevice()
    @     0x7f500b011955  pybind11::cpp_function::initialize<>()::{lambda()#3}::_FUN()
    @     0x7f500b030d24  pybind11::cpp_function::dispatcher()
    @     0x7f52e605b081  cfunction_call_varargs
https://symbolize.stripped_domain/r/?trace=7f52e5d65ce1,7f52e5d65d5f,7f501347b51c,7f501347bc38,7f500aba95bf,7f500b48bfb2,7f500b484b9b,7f500b484f1b,7f500b064dfc,7f500b064f04,7f500b069856,7f500b011954,7f500b030d23,7f52e605b080&map= 
*** SIGABRT received by PID 2094649 (TID 2094649) on cpu 140 from PID 2094649; stack trace: ***
PC: @     0x7fb9a11c1ce1  (unknown)  raise
    @     0x7fb2b32f5067        928  (unknown)
    @     0x7fb9a11c1d60  (unknown)  (unknown)
PC: @     0x7f52e5d65ce1  (unknown)  raise
    @     0x7f4bf72f5067        928  (unknown)
    @     0x7f52e5d65d60  (unknown)  (unknown)
    @     0x7f8128df7c39         16  absl::lts_20230802::log_internal::LogMessageFatal::~LogMessageFatal()
    @     0x7ff7e15b7c39         16  absl::lts_20230802::log_internal::LogMessageFatal::~LogMessageFatal()
    @     0x7fb6ce8d751d         32  absl::lts_20230802::log_internal::LogMessage::Die()
    @     0x7f501347b51d         32  absl::lts_20230802::log_internal::LogMessage::Die()
    @     0x7f81205255c0       1024  torch_xla::runtime::InitializePjRt()
    @     0x7ff7d8ce55c0       1024  torch_xla::runtime::InitializePjRt()
    @     0x7fb6ce8d7c39         16  absl::lts_20230802::log_internal::LogMessageFatal::~LogMessageFatal()
    @     0x7f501347bc39         16  absl::lts_20230802::log_internal::LogMessageFatal::~LogMessageFatal()
    @     0x7f8120e07fb3        480  torch_xla::runtime::PjRtComputationClient::PjRtComputationClient()
    @     0x7ff7d95c7fb3        480  torch_xla::runtime::PjRtComputationClient::PjRtComputationClient()
    @     0x7fb6c60055c0       1024  torch_xla::runtime::InitializePjRt()
    @     0x7f500aba95c0       1024  torch_xla::runtime::InitializePjRt()
    @     0x7f8120e00b9c        496  torch_xla::runtime::GetComputationClient()::{lambda()#1}::operator()()
    @     0x7ff7d95c0b9c        496  torch_xla::runtime::GetComputationClient()::{lambda()#1}::operator()()
    @     0x7fb6c68e7fb3        480  torch_xla::runtime::PjRtComputationClient::PjRtComputationClient()
    @     0x7f500b48bfb3        480  torch_xla::runtime::PjRtComputationClient::PjRtComputationClient()
    @     0x7f8120e00f1c         32  torch_xla::runtime::GetComputationClient()
    @     0x7ff7d95c0f1c         32  torch_xla::runtime::GetComputationClient()
    @     0x7f500b484b9c        496  torch_xla::runtime::GetComputationClient()::{lambda()#1}::operator()()
    @     0x7fb6c68e0b9c        496  torch_xla::runtime::GetComputationClient()::{lambda()#1}::operator()()
    @     0x7f81209e0dfd        480  torch_xla::bridge::GetDefaultDevice()
    @     0x7ff7d91a0dfd        480  torch_xla::bridge::GetDefaultDevice()
    @     0x7f500b484f1c         32  torch_xla::runtime::GetComputationClient()
    @     0x7fb6c68e0f1c         32  torch_xla::runtime::GetComputationClient()
    @     0x7f81209e0f05         64  torch_xla::bridge::GetCurrentDevice()
    @     0x7ff7d91a0f05         64  torch_xla::bridge::GetCurrentDevice()
    @     0x7fb6c64c0dfd        480  torch_xla::bridge::GetDefaultDevice()
    @     0x7f500b064dfd        480  torch_xla::bridge::GetDefaultDevice()
    @     0x7f81209e5857         80  torch_xla::bridge::GetCurrentAtenDevice()
    @     0x7ff7d91a5857         80  torch_xla::bridge::GetCurrentAtenDevice()
    @     0x7f812098d955        128  pybind11::cpp_function::initialize<>()::{lambda()#3}::_FUN()
    @     0x7fb6c64c0f05         64  torch_xla::bridge::GetCurrentDevice()
    @     0x7f500b064f05         64  torch_xla::bridge::GetCurrentDevice()
    @     0x7ff7d914d955        128  pybind11::cpp_function::initialize<>()::{lambda()#3}::_FUN()
    @     0x7f81209acd24        688  pybind11::cpp_function::dispatcher()
    @     0x7f83fb9f3081  (unknown)  cfunction_call_varargs
    @     0x7fb6c64c5857         80  torch_xla::bridge::GetCurrentAtenDevice()
    @     0x7f500b069857         80  torch_xla::bridge::GetCurrentAtenDevice()
    @     0x7f83fbb7c680  (unknown)  (unknown)
https://symbolize.stripped_domain/r/?trace=7f83fb6fdce1,7f7d0f2f5066,7f83fb6fdd5f,7f8128df751c,7f8128df7c38,7f81205255bf,7f8120e07fb2,7f8120e00b9b,7f8120e00f1b,7f81209e0dfc,7f81209e0f04,7f81209e5856,7f812098d954,7f81209acd23,7f83fb9f3080,7f83fbb7c67f&map= 
E0111 00:36:07.067150 2094650 coredump_hook.cc:442] RAW: Remote crash data gathering hook invoked.
E0111 00:36:07.067165 2094650 client.cc:269] RAW: Coroner client retries enabled (b/136286901), will retry for up to 30 sec.
E0111 00:36:07.067171 2094650 coredump_hook.cc:537] RAW: Sending fingerprint to remote end.
E0111 00:36:07.067187 2094650 coredump_hook.cc:546] RAW: Cannot send fingerprint to Coroner: [NOT_FOUND] stat failed on crash reporting socket /var/google/services/logmanagerd/remote_coredump.socket (Is the listener running?): No such file or directory
E0111 00:36:07.067193 2094650 coredump_hook.cc:598] RAW: Dumping core locally.
    @     0x7ff7d916cd24        688  pybind11::cpp_function::dispatcher()
    @     0x7ffab45f7081  (unknown)  cfunction_call_varargs
    @     0x7ffab4780680  (unknown)  (unknown)
https://symbolize.stripped_domain/r/?trace=7ffab4301ce1,7ff3cb2f5066,7ffab4301d5f,7ff7e15b751c,7ff7e15b7c38,7ff7d8ce55bf,7ff7d95c7fb2,7ff7d95c0b9b,7ff7d95c0f1b,7ff7d91a0dfc,7ff7d91a0f04,7ff7d91a5856,7ff7d914d954,7ff7d916cd23,7ffab45f7080,7ffab478067f&map= 
E0111 00:36:07.069147 2094651 coredump_hook.cc:442] RAW: Remote crash data gathering hook invoked.
E0111 00:36:07.069164 2094651 client.cc:269] RAW: Coroner client retries enabled (b/136286901), will retry for up to 30 sec.
E0111 00:36:07.069180 2094651 coredump_hook.cc:537] RAW: Sending fingerprint to remote end.
E0111 00:36:07.069198 2094651 coredump_hook.cc:546] RAW: Cannot send fingerprint to Coroner: [NOT_FOUND] stat failed on crash reporting socket /var/google/services/logmanagerd/remote_coredump.socket (Is the listener running?): No such file or directory
E0111 00:36:07.069212 2094651 coredump_hook.cc:598] RAW: Dumping core locally.
    @     0x7fb6c646d955        128  pybind11::cpp_function::initialize<>()::{lambda()#3}::_FUN()
    @     0x7f500b011955        128  pybind11::cpp_function::initialize<>()::{lambda()#3}::_FUN()
    @     0x7fb6c648cd24        688  pybind11::cpp_function::dispatcher()
    @     0x7f500b030d24        688  pybind11::cpp_function::dispatcher()
    @     0x7f52e605b081  (unknown)  cfunction_call_varargs
    @     0x7fb9a14b7081  (unknown)  cfunction_call_varargs
    @     0x7f52e61e4680  (unknown)  (unknown)
    @     0x7fb9a1640680  (unknown)  (unknown)
https://symbolize.stripped_domain/r/?trace=https://symbolize.stripped_domain/r/?trace=7f52e5d65ce1,7fb9a11c1ce1,7f4bf72f5066,7fb2b32f5066,7f52e5d65d5f,7fb9a11c1d5f,7f501347b51c,7fb6ce8d751c,7f501347bc38,7fb6ce8d7c38,7f500aba95bf,7fb6c60055bf,7f500b48bfb2,7fb6c68e7fb2,7f500b484b9b,7fb6c68e0b9b,7f500b484f1b,7fb6c68e0f1b,7f500b064dfc,7fb6c64c0dfc,7f500b064f04,7fb6c64c0f04,7f500b069856,7fb6c64c5856,7f500b011954,7fb6c646d954,7f500b030d23,7fb6c648cd23,7f52e605b080,7fb9a14b7080,7f52e61e467f7fb9a164067f&map=&map= 
 
E0111 00:36:07.075981 2094649 coredump_hook.cc:442] RAW: Remote crash data gathering hook invoked.
E0111 00:36:07.075981 2094648 coredump_hook.cc:442] RAW: Remote crash data gathering hook invoked.
E0111 00:36:07.075995 2094648 client.cc:269] RAW: Coroner client retries enabled (b/136286901), will retry for up to 30 sec.
E0111 00:36:07.075995 2094649 client.cc:269] RAW: Coroner client retries enabled (b/136286901), will retry for up to 30 sec.
E0111 00:36:07.076012 2094648 coredump_hook.cc:537] RAW: Sending fingerprint to remote end.
E0111 00:36:07.076022 2094649 coredump_hook.cc:537] RAW: Sending fingerprint to remote end.
E0111 00:36:07.076038 2094649 coredump_hook.cc:546] RAW: Cannot send fingerprint to Coroner: [NOT_FOUND] stat failed on crash reporting socket /var/google/services/logmanagerd/remote_coredump.socket (Is the listener running?): No such file or directory
E0111 00:36:07.076041 2094648 coredump_hook.cc:546] RAW: Cannot send fingerprint to Coroner: [NOT_FOUND] stat failed on crash reporting socket /var/google/services/logmanagerd/remote_coredump.socket (Is the listener running?): No such file or directory
E0111 00:36:07.076053 2094649 coredump_hook.cc:598] RAW: Dumping core locally.
E0111 00:36:07.076055 2094648 coredump_hook.cc:598] RAW: Dumping core locally.
```

</details>