### PR TITLE
[Core Aten] Add and enable tests for aten index_select and logical_and

### DIFF
--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -2446,11 +2446,18 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.logical_and, args, kwargs)
 
-  @unittest.skip
   def test_aten_logical_and_2(self):
     args = (
         torch.randint(0, 10, (10, 10)).to(torch.int32),
         torch.randint(0, 10, (10, 10)).to(torch.int32),
+    )
+    kwargs = dict()
+    run_export_and_compare(self, torch.ops.aten.logical_and, args, kwargs)
+    
+  def test_aten_logical_and_3(self):
+    args = (
+        torch.randint(0, 2, (10, 10)).to(torch.bool),
+        torch.randint(0, 2, (10, 10)).to(torch.bool),
     )
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.logical_and, args, kwargs)

--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -2171,7 +2171,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.index_select, args, kwargs)
 
-  @unittest.skip
   def test_aten_index_select_1(self):
     args = (
         torch.randn((2, 10)).to(torch.float16),
@@ -2186,6 +2185,33 @@ class AtenOpTest(unittest.TestCase):
         torch.randint(0, 10, (2, 10)).to(torch.int32),
         1,
         torch.randint(0, 10, (2,)).to(torch.int64),
+    )
+    kwargs = dict()
+    run_export_and_compare(self, torch.ops.aten.index_select, args, kwargs)
+
+  def test_aten_index_select_3(self):
+    args = (
+        torch.randn((2, 10)).to(torch.float32),
+        1,
+        torch.randint(0, 10, (2,)).to(torch.int32),
+    )
+    kwargs = dict()
+    run_export_and_compare(self, torch.ops.aten.index_select, args, kwargs)
+
+  def test_aten_index_select_4(self):
+    args = (
+        torch.randn((2, 10)).to(torch.float16),
+        1,
+        torch.randint(0, 10, (2,)).to(torch.int32),
+    )
+    kwargs = dict()
+    run_export_and_compare(self, torch.ops.aten.index_select, args, kwargs)
+
+  def test_aten_index_select_5(self):
+    args = (
+        torch.randint(0, 10, (2, 10)).to(torch.int32),
+        1,
+        torch.randint(0, 10, (2,)).to(torch.int32),
     )
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.index_select, args, kwargs)
@@ -2453,7 +2479,7 @@ class AtenOpTest(unittest.TestCase):
     )
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.logical_and, args, kwargs)
-    
+
   def test_aten_logical_and_3(self):
     args = (
         torch.randint(0, 2, (10, 10)).to(torch.bool),


### PR DESCRIPTION
Fixes #5987 and #5985

Issues have been fixes so this PR enables the corresponding tests and add more for interesting arg dtypes.
- Add bool tensor tests for `aten.logical_and`
- Add int32 index tensor tests for `aten.index_select`

```
(venv) cnchan@2b16392f2e79:/repo/pytorch/xla$ pytest test/test_core_aten_ops.py -k "aten_index_select or aten_logical_and"
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.10.12, pytest-7.4.4, pluggy-1.3.0
rootdir: /repo/pytorch
configfile: pytest.ini
plugins: hypothesis-6.92.7, xdist-3.5.0
collected 522 items / 512 deselected / 10 selected                                                                                                                     

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1704954932.745979 2448775 cpu_client.cc:370] TfrtCpuClient created.
..........                                                                                                                            [100%]

================================================================== 10 passed, 512 deselected in 3.84s ==================================================================
I0000 00:00:1704954934.223263 2448775 cpu_client.cc:373] TfrtCpuClient destroyed.
``` 