### PR TITLE
Re-land: Fix model initialization.

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -179,6 +179,14 @@ class TorchBenchModel(BenchmarkModel):
 
     self.benchmark_experiment.batch_size = benchmark.batch_size
 
+    # Move the initialized model to XLA device.
+    if self.benchmark_experiment.xla:
+      device = self.benchmark_experiment.get_device()
+      self.module = self.module.to(device)
+      self.example_inputs = pytree.tree_map_only(torch.Tensor,
+                                                 lambda t: t.to(device),
+                                                 self.example_inputs)
+
     # Torchbench has quite different setup for yolov3, so directly passing
     # the right example_inputs
     if self.model_name == "yolov3":
@@ -207,16 +215,9 @@ class TorchBenchModel(BenchmarkModel):
     # workaround "RuntimeError: not allowed to set torch.backends.cudnn flags"
     # torch.backends.__allow_nonbracketed_mutation_flag = True
 
-    if self.benchmark_experiment.accelerator == "cpu":
-      device = "cpu"
-    elif self.benchmark_experiment.accelerator == "cuda" and not self.benchmark_experiment.xla:
-      device = "cuda"
-    else:
-      device = str(self.benchmark_experiment.get_device())
-
     return benchmark_cls(
         test=self.benchmark_experiment.test,
-        device=device,
+        device=self.benchmark_experiment.accelerator,
         batch_size=self.benchmark_experiment.batch_size,
     )
 


### PR DESCRIPTION
Re-land: #6182 #6076

Here are the issues found with the last try:

- `benchmark_cls` was being incorrectly instantiated twice
    -  Using: (i) the specified accelerator; and (ii) the device returned from `benchmark_experiment.get_device()`
- The returned instance was (ii), which caused the regression
- `example_inputs` was being reset after being moved to XLA

As a solution, in this PR:

- `benchmark_cls` is instantiated once, with the specified accelerator
- `self.module` and `self.example_inputs` are moved to XLA in the `set_up` method

I have run the benchmarks mentioned in #6182 and confirmed no regression is present.