### PR TITLE
Enable Tensor index check in both dimension

### DIFF
--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -2207,10 +2207,9 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.index_select, args, kwargs)
 
-  @unittest.skip
   def test_aten_index_Tensor_0(self):
     args = (
-        torch.randn((2, 10)).to(torch.float32),
+        torch.randn((11, 12)).to(torch.float32),
         [
             torch.randint(0, 10, (2,)).to(torch.int64),
         ],
@@ -2218,10 +2217,9 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.index.Tensor, args, kwargs)
 
-  @unittest.skip
   def test_aten_index_Tensor_1(self):
     args = (
-        torch.randn((2, 10)).to(torch.float16),
+        torch.randn((11, 12)).to(torch.float16),
         [
             torch.randint(0, 10, (2,)).to(torch.int64),
         ],
@@ -2229,10 +2227,9 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.index.Tensor, args, kwargs)
 
-  @unittest.skip
   def test_aten_index_Tensor_2(self):
     args = (
-        torch.randint(0, 10, (2, 10)).to(torch.int32),
+        torch.randint(0, 10, (11, 12)).to(torch.int32),
         [
             torch.randint(0, 10, (2,)).to(torch.int64),
         ],

--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -2209,9 +2209,9 @@ class AtenOpTest(unittest.TestCase):
 
   def test_aten_index_Tensor_0(self):
     args = (
-        torch.randn((11, 12)).to(torch.float32),
+        torch.randn((11, 2)).to(torch.float32),
         [
-            torch.randint(0, 10, (2,)).to(torch.int64),
+            torch.randint(5, 10, (2,)).to(torch.int64),
         ],
     )
     kwargs = dict()
@@ -2219,9 +2219,9 @@ class AtenOpTest(unittest.TestCase):
 
   def test_aten_index_Tensor_1(self):
     args = (
-        torch.randn((11, 12)).to(torch.float16),
+        torch.randn((11, 2)).to(torch.float16),
         [
-            torch.randint(0, 10, (2,)).to(torch.int64),
+            torch.randint(5, 10, (2,)).to(torch.int64),
         ],
     )
     kwargs = dict()
@@ -2229,9 +2229,9 @@ class AtenOpTest(unittest.TestCase):
 
   def test_aten_index_Tensor_2(self):
     args = (
-        torch.randint(0, 10, (11, 12)).to(torch.int32),
+        torch.randint(0, 10, (11, 2)).to(torch.int32),
         [
-            torch.randint(0, 10, (2,)).to(torch.int64),
+            torch.randint(5, 10, (2,)).to(torch.int64),
         ],
     )
     kwargs = dict()


### PR DESCRIPTION
Fix https://github.com/pytorch/xla/issues/5870

---

`test_aten_index_Tensor_0` failed due to:
```
IndexError: index 2 is out of bounds for dimension 0 with size 2
```

`test_aten_index_Tensor_1` failed due to:
```
IndexError: index 2 is out of bounds for dimension 0 with size 2
```

`test_aten_index_Tensor_2` failed due to:
```
IndexError: index 6 is out of bounds for dimension 0 with size 2
```

checked with `TORCH.INDEX_SELECT` logic in [doc](https://pytorch.org/docs/stable/generated/torch.index_select.html), we might want to make sure the given index should be limited within the dimension size of the all dimensions, so modify the test code and passed

and tested the `torch.ops.aten.index.Tensor` used default dimension 0, so limit the test code: test tensor with shape (11, 2) and expected line number range [5, 10]
---

Testing:
```
# pytest test/test_core_aten_ops.py -k test_aten_index_Tensor_0
================================================== test session starts ==================================================
platform linux -- Python 3.10.13, pytest-7.4.3, pluggy-1.3.0
rootdir: /root/pytorch
configfile: pytest.ini
plugins: hypothesis-6.90.0
collected 522 items / 521 deselected / 1 selected                                                                       

test/test_core_aten_ops.py .                                                                                      [100%]

=========================================== 1 passed, 521 deselected in 7.14s ===========================================
# pytest test/test_core_aten_ops.py -k test_aten_index_Tensor_1
================================================== test session starts ==================================================
platform linux -- Python 3.10.13, pytest-7.4.3, pluggy-1.3.0
rootdir: /root/pytorch
configfile: pytest.ini
plugins: hypothesis-6.90.0
collected 522 items / 521 deselected / 1 selected                                                                       

test/test_core_aten_ops.py .                                                                                      [100%]

=========================================== 1 passed, 521 deselected in 7.16s ===========================================
# pytest test/test_core_aten_ops.py -k test_aten_index_Tensor_2
================================================== test session starts ==================================================
platform linux -- Python 3.10.13, pytest-7.4.3, pluggy-1.3.0
rootdir: /root/pytorch
configfile: pytest.ini
plugins: hypothesis-6.90.0
collected 522 items / 521 deselected / 1 selected                                                                       

test/test_core_aten_ops.py .                                                                                      [100%]

=========================================== 1 passed, 521 deselected in 7.01s ===========================================
```