### PR TITLE
Correct order of constant vs args

### DIFF
--- a/test/stablehlo/test_exports.py
+++ b/test/stablehlo/test_exports.py
@@ -23,7 +23,7 @@ class TensorConstant(torch.nn.Module):
     super().__init__()
 
   def forward(self, a):
-    return a * torch.tensor(3)
+    return a / torch.tensor(3)
 
 
 class ExportTest(unittest.TestCase):

--- a/torch_xla/stablehlo.py
+++ b/torch_xla/stablehlo.py
@@ -310,8 +310,8 @@ def _exported_program_to_stablehlo_bundle(exported_model,
   with torch.no_grad():
     res = xla_interpreter.run(
         *param_buffer_values,
-        *input_args,
         *ordered_tensor_constants,
+        *input_args,
         enable_io_processing=False)
     res = res[num_mutations:]
 


### PR DESCRIPTION
Previous unit test used multiply; which is commutative and couldnt distinguish the wrong ordering