### PR TITLE
Improve build process for PJRT plugins

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -104,6 +104,7 @@ function build_torch_xla() {
   XLA_DIR=$1
   pushd "$XLA_DIR"
   python setup.py install
+  pip install plugins/cuda --no-build-isolation -v
   popd
 }
 

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -104,7 +104,6 @@ function build_torch_xla() {
   XLA_DIR=$1
   pushd "$XLA_DIR"
   python setup.py install
-  pip install plugins/cuda --no-build-isolation -v
   popd
 }
 

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ torch_xla/csrc/version.cpp
 
 
 # Build system temporary files
-/bazel-*
+bazel-*
 
 # Clangd cache directory
 .cache/*

--- a/build_util.py
+++ b/build_util.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import shutil
 
+
 def check_env_flag(name: str, default: str = '') -> bool:
   return os.getenv(name, default).upper() in ['ON', '1', 'YES', 'TRUE', 'Y']
 
@@ -33,7 +34,7 @@ def bazel_options_from_env() -> Iterable[str]:
   cache_silo_name = os.getenv('SILO_NAME', default='dev')
   if cache_silo_name:
     bazel_flags.append('--remote_default_exec_properties=cache-silo-key=%s' %
-                      cache_silo_name)
+                       cache_silo_name)
 
   if check_env_flag('BUILD_CPP_TESTS', default='0'):
     bazel_flags.append('//test/cpp:all')
@@ -53,8 +54,14 @@ def bazel_options_from_env() -> Iterable[str]:
 
   return bazel_flags
 
-def bazel_build(bazel_target: str, destination_dir: str, options: Iterable[str] = []):
-  bazel_argv = ['bazel', 'build', bazel_target, f"--symlink_prefix={os.path.join(os.getcwd(), 'bazel-')}"]
+
+def bazel_build(bazel_target: str,
+                destination_dir: str,
+                options: Iterable[str] = []):
+  bazel_argv = [
+      'bazel', 'build', bazel_target,
+      f"--symlink_prefix={os.path.join(os.getcwd(), 'bazel-')}"
+  ]
 
   # Remove duplicated flags because they confuse bazel
   flags = set(bazel_options_from_env() + options)
@@ -63,11 +70,12 @@ def bazel_build(bazel_target: str, destination_dir: str, options: Iterable[str] 
   print(' '.join(bazel_argv), flush=True)
   subprocess.check_call(bazel_argv, stdout=sys.stdout, stderr=sys.stderr)
 
-  target_path = bazel_target.replace('@xla//', 'external/xla/').replace('//', '').replace(':', '/')
+  target_path = bazel_target.replace('@xla//', 'external/xla/').replace(
+      '//', '').replace(':', '/')
   output_path = os.path.join('bazel-bin', target_path)
   output_filename = os.path.basename(output_path)
 
   if not os.path.exists(destination_dir):
-      os.makedirs(destination_dir)
+    os.makedirs(destination_dir)
 
   shutil.copyfile(output_path, os.path.join(destination_dir, output_filename))

--- a/build_util.py
+++ b/build_util.py
@@ -1,0 +1,51 @@
+import os
+from typing import Iterable
+
+def check_env_flag(name: str, default: str = '') -> bool:
+  return os.getenv(name, default).upper() in ['ON', '1', 'YES', 'TRUE', 'Y']
+
+
+def bazel_options_from_env() -> Iterable[str]:
+  bazel_flags = []
+
+  if check_env_flag('DEBUG'):
+    bazel_flags.append('--config=dbg')
+
+  if check_env_flag('TPUVM_MODE'):
+    bazel_flags.append('--config=tpu')
+
+  gcloud_key_file = os.getenv('GCLOUD_SERVICE_KEY_FILE', default='')
+  # Remote cache authentication.
+  if gcloud_key_file:
+    # Temporary workaround to allow PRs from forked repo to run CI. See details at (#5259).
+    # TODO: Remove the check once self-hosted GHA workers are available to CPU/GPU CI.
+    gcloud_key_file_size = os.path.getsize(gcloud_key_file)
+    if gcloud_key_file_size > 1:
+      bazel_flags.append('--google_credentials=%s' % gcloud_key_file)
+      bazel_flags.append('--config=remote_cache')
+  else:
+    if check_env_flag('BAZEL_REMOTE_CACHE'):
+      bazel_flags.append('--config=remote_cache')
+
+  cache_silo_name = os.getenv('SILO_NAME', default='dev')
+  if cache_silo_name:
+    bazel_flags.append('--remote_default_exec_properties=cache-silo-key=%s' %
+                      cache_silo_name)
+
+  if check_env_flag('BUILD_CPP_TESTS', default='0'):
+    bazel_flags.append('//test/cpp:all')
+    bazel_flags.append('//torch_xla/csrc/runtime:all')
+
+  bazel_jobs = os.getenv('BAZEL_JOBS', default='')
+  if bazel_jobs:
+    bazel_flags.append('--jobs=%s' % bazel_jobs)
+
+  # Build configuration.
+  if check_env_flag('BAZEL_VERBOSE'):
+    bazel_flags.append('-s')
+  if check_env_flag('XLA_CUDA'):
+    bazel_flags.append('--config=cuda')
+  if check_env_flag('XLA_CPU_USE_ACL'):
+    bazel_flags.append('--config=acl')
+
+  return bazel_flags

--- a/plugins/cpu/README.md
+++ b/plugins/cpu/README.md
@@ -10,15 +10,10 @@ repository (see `bazel build` command below).
 ## Building
 
 ```bash
-# Build PJRT plugin
-bazel build //plugins/cpu:pjrt_c_api_cpu_plugin.so --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=1
-# Copy to package dir
-cp bazel-bin/plugins/cpu/pjrt_c_api_cpu_plugin.so plugins/cpu/torch_xla_cpu_plugin/
-
 # Build wheel
-pip wheel plugins/cpu
+pip wheel plugins/cpu --no-build-isolation -v
 # Or install directly
-pip install plugins/cpu
+pip install plugins/cpu --no-build-isolation -v
 ```
 
 ## Usage

--- a/plugins/cpu/build_util.py
+++ b/plugins/cpu/build_util.py
@@ -1,0 +1,1 @@
+../../build_util.py

--- a/plugins/cpu/pyproject.toml
+++ b/plugins/cpu/pyproject.toml
@@ -12,7 +12,7 @@ description = "CPU PJRT Plugin for testing only"
 requires-python = ">=3.8"
 
 [tool.setuptools.package-data]
-torch_xla_cpu_plugin = ["*.so"]
+torch_xla_cpu_plugin = ["lib/*.so"]
 
 [project.entry-points."torch_xla.plugins"]
 cpu = "torch_xla_cpu_plugin:CpuPlugin"

--- a/plugins/cpu/setup.py
+++ b/plugins/cpu/setup.py
@@ -1,6 +1,7 @@
 import build_util
 import setuptools
 
-build_util.bazel_build('//plugins/cpu:pjrt_c_api_cpu_plugin.so', 'torch_xla_cpu_plugin/lib')
+build_util.bazel_build('//plugins/cpu:pjrt_c_api_cpu_plugin.so',
+                       'torch_xla_cpu_plugin/lib')
 
 setuptools.setup()

--- a/plugins/cpu/setup.py
+++ b/plugins/cpu/setup.py
@@ -1,0 +1,6 @@
+import build_util
+import setuptools
+
+build_util.bazel_build('//plugins/cpu:pjrt_c_api_cpu_plugin.so', 'torch_xla_cpu_plugin/lib')
+
+setuptools.setup()

--- a/plugins/cpu/torch_xla_cpu_plugin/__init__.py
+++ b/plugins/cpu/torch_xla_cpu_plugin/__init__.py
@@ -4,7 +4,7 @@ from torch_xla._internal import tpu
 
 class CpuPlugin(plugins.DevicePlugin):
   def library_path(self) -> str:
-    return os.path.join(os.path.dirname(__file__), 'pjrt_c_api_cpu_plugin.so')
+    return os.path.join(os.path.dirname(__file__), 'lib/pjrt_c_api_cpu_plugin.so')
 
   def physical_chip_count(self) -> int:
     return 1

--- a/plugins/cpu/torch_xla_cpu_plugin/__init__.py
+++ b/plugins/cpu/torch_xla_cpu_plugin/__init__.py
@@ -2,9 +2,12 @@ import os
 from torch_xla.experimental import plugins
 from torch_xla._internal import tpu
 
+
 class CpuPlugin(plugins.DevicePlugin):
+
   def library_path(self) -> str:
-    return os.path.join(os.path.dirname(__file__), 'lib/pjrt_c_api_cpu_plugin.so')
+    return os.path.join(
+        os.path.dirname(__file__), 'lib/pjrt_c_api_cpu_plugin.so')
 
   def physical_chip_count(self) -> int:
     return 1

--- a/plugins/cpu/torch_xla_cpu_plugin/__init__.py
+++ b/plugins/cpu/torch_xla_cpu_plugin/__init__.py
@@ -7,7 +7,7 @@ class CpuPlugin(plugins.DevicePlugin):
 
   def library_path(self) -> str:
     return os.path.join(
-        os.path.dirname(__file__), 'lib/pjrt_c_api_cpu_plugin.so')
+        os.path.dirname(__file__), 'lib', 'pjrt_c_api_cpu_plugin.so')
 
   def physical_chip_count(self) -> int:
     return 1

--- a/plugins/cuda/README.md
+++ b/plugins/cuda/README.md
@@ -8,9 +8,9 @@ repository (see `bazel build` command below).
 
 ```bash
 # Build wheel
-pip wheel plugins/cuda
+pip wheel plugins/cuda --no-build-isolation -v
 # Or install directly
-pip install plugins/cuda
+pip install plugins/cuda --no-build-isolation -v
 ```
 
 ## Usage

--- a/plugins/cuda/README.md
+++ b/plugins/cuda/README.md
@@ -29,7 +29,7 @@ import torch_xla.runtime as xr
 
 # Use dynamic plugin instead of built-in CUDA support
 plugins.use_dynamic_plugins()
-plugins.register_plugin('CUDA', torch_xla_cuda_plugin.GpuPlugin())
+plugins.register_plugin('CUDA', torch_xla_cuda_plugin.CudaPlugin())
 xr.set_device_type('CUDA')
 
 print(xm.xla_device())

--- a/plugins/cuda/README.md
+++ b/plugins/cuda/README.md
@@ -7,11 +7,6 @@ repository (see `bazel build` command below).
 ## Building
 
 ```bash
-# Build PJRT plugin
-bazel build @xla//xla/pjrt/c:pjrt_c_api_gpu_plugin.so --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=1  --config=cuda
-# Copy to package dir
-cp bazel-bin/external/xla/xla/pjrt/c/pjrt_c_api_gpu_plugin.so plugins/cuda/torch_xla_cuda_plugin
-
 # Build wheel
 pip wheel plugins/cuda
 # Or install directly

--- a/plugins/cuda/build_util.py
+++ b/plugins/cuda/build_util.py
@@ -1,0 +1,1 @@
+../../build_util.py

--- a/plugins/cuda/pyproject.toml
+++ b/plugins/cuda/pyproject.toml
@@ -15,4 +15,4 @@ requires-python = ">=3.8"
 torch_xla_cuda_plugin = ["lib/*.so"]
 
 [project.entry-points."torch_xla.plugins"]
-gpu = "torch_xla_cuda_plugin:GpuPlugin"
+cuda = "torch_xla_cuda_plugin:CudaPlugin"

--- a/plugins/cuda/pyproject.toml
+++ b/plugins/cuda/pyproject.toml
@@ -12,7 +12,7 @@ description = "PyTorch/XLA CUDA Plugin"
 requires-python = ">=3.8"
 
 [tool.setuptools.package-data]
-torch_xla_cuda_plugin = ["*.so"]
+torch_xla_cuda_plugin = ["lib/*.so"]
 
 [project.entry-points."torch_xla.plugins"]
 gpu = "torch_xla_cuda_plugin:GpuPlugin"

--- a/plugins/cuda/pyproject.toml
+++ b/plugins/cuda/pyproject.toml
@@ -6,9 +6,9 @@ build-backend = "setuptools.build_meta"
 name = "torch_xla_cuda_plugin"
 version = "0.0.1"
 authors = [
-    {name = "Will Cromar", email = "wcromar@google.com"},
+    {name = "PyTorch/XLA Dev Team", email = "pytorch-xla@googlegroups.com"},
 ]
-description = "CUDA Plugin"
+description = "PyTorch/XLA CUDA Plugin"
 requires-python = ">=3.8"
 
 [tool.setuptools.package-data]

--- a/plugins/cuda/setup.py
+++ b/plugins/cuda/setup.py
@@ -1,31 +1,6 @@
-import subprocess
-import sys
-from typing import Iterable
-import setuptools
-import shutil
-import os
-
 import build_util
+import setuptools
 
-def _bazel_build(bazel_target: str, destination_path: str, options: Iterable[str] = []):
-  bazel_argv = ['bazel', 'build', bazel_target, f"--symlink_prefix={os.path.join(os.getcwd(), 'bazel-')}"]
-
-  # Remove duplicated flags because they confuse bazel
-  flags = set(build_util.bazel_options_from_env() + options)
-  bazel_argv.extend(flags)
-
-  print(' '.join(bazel_argv), flush=True)
-  subprocess.check_call(bazel_argv, stdout=sys.stdout, stderr=sys.stderr)
-
-  target_path = bazel_target.replace('@xla//', 'external/xla/').replace(':', '/')
-  output_path = os.path.join('bazel-bin', target_path)
-  output_filename = os.path.basename(output_path)
-
-  if not os.path.exists(destination_path):
-      os.makedirs(destination_path)
-
-  shutil.copyfile(output_path, os.path.join(destination_path, output_filename))
-
-_bazel_build('@xla//xla/pjrt/c:pjrt_c_api_gpu_plugin.so', 'torch_xla_cuda_plugin/lib', ['--config=cuda'])
+build_util.bazel_build('@xla//xla/pjrt/c:pjrt_c_api_gpu_plugin.so', 'torch_xla_cuda_plugin/lib', ['--config=cuda'])
 
 setuptools.setup()

--- a/plugins/cuda/setup.py
+++ b/plugins/cuda/setup.py
@@ -1,107 +1,63 @@
+import subprocess
+import sys
+from typing import Iterable
 import setuptools
-from setuptools import Extension
-from setuptools.command import build_ext
 import shutil
 import os
-import posixpath
-import torch
-
 
 def _check_env_flag(name, default=''):
   return os.getenv(name, default).upper() in ['ON', '1', 'YES', 'TRUE', 'Y']
-
-
-extra_compile_args = []
-cxx_abi = os.getenv(
-    'CXX_ABI', default='') or getattr(torch._C, '_GLIBCXX_USE_CXX11_ABI', None)
-if cxx_abi is not None:
-  extra_compile_args.append(f'-D_GLIBCXX_USE_CXX11_ABI={int(cxx_abi)}')
-
 
 DEBUG = _check_env_flag('DEBUG')
 GCLOUD_KEY_FILE = os.getenv('GCLOUD_SERVICE_KEY_FILE', default='')
 CACHE_SILO_NAME = os.getenv('SILO_NAME', default='dev')
 BAZEL_JOBS = os.getenv('BAZEL_JOBS', default='')
 
-class BazelExtension(setuptools.Extension):
-  """A C/C++ extension that is defined as a Bazel BUILD target."""
+def _bazel_build(bazel_target: str, destination_path: str, options: Iterable[str] = []):
+  bazel_argv = ['bazel', 'build', bazel_target, f"--symlink_prefix={os.path.join(os.getcwd(), 'bazel-')}"]
+  # for opt in extra_compile_args:
+  #   bazel_argv.append("--cxxopt={}".format(opt))
 
-  def __init__(self, bazel_target):
-    self.bazel_target = bazel_target
-    self.relpath, self.target_name = (
-        bazel_target.replace('@xla//', 'external/xla/').split(':'))
-    print('searchforthisstring', self.relpath)
-    ext_name = os.path.join(
-        self.relpath.replace(posixpath.sep, os.path.sep), self.target_name)
-    if ext_name.endswith('.so'):
-      ext_name = ext_name[:-3]
-    Extension.__init__(self, ext_name, sources=[])
+  # Debug build.
+  if DEBUG:
+    bazel_argv.append('--config=dbg')
 
+  # Remote cache authentication.
+  if GCLOUD_KEY_FILE:
+    # Temporary workaround to allow PRs from forked repo to run CI. See details at (#5259).
+    # TODO: Remove the check once self-hosted GHA workers are available to CPU/GPU CI.
+    gcloud_key_file_size = os.path.getsize(GCLOUD_KEY_FILE)
+    if gcloud_key_file_size > 1:
+      bazel_argv.append('--google_credentials=%s' % GCLOUD_KEY_FILE)
+      bazel_argv.append('--config=remote_cache')
+  else:
+    if _check_env_flag('BAZEL_REMOTE_CACHE'):
+      bazel_argv.append('--config=remote_cache')
+  if CACHE_SILO_NAME:
+    bazel_argv.append('--remote_default_exec_properties=cache-silo-key=%s' %
+                      CACHE_SILO_NAME)
 
-class BuildBazelExtension(build_ext.build_ext):
-  """A command that runs Bazel to build a C/C++ extension."""
+  if BAZEL_JOBS:
+    bazel_argv.append('--jobs=%s' % BAZEL_JOBS)
 
-  def run(self):
-    for ext in self.extensions:
-      self.bazel_build(ext)
-    build_ext.build_ext.run(self)
+  # Build configuration.
+  if _check_env_flag('BAZEL_VERBOSE'):
+    bazel_argv.append('-s')
 
-  def bazel_build(self, ext):
-    if not os.path.exists(self.build_temp):
-      os.makedirs(self.build_temp)
+  bazel_argv.extend(options)
 
-    bazel_argv = [
-        'bazel', 'build', ext.bazel_target,
-        f"--symlink_prefix={os.path.join('plugins/cuda', self.build_temp, 'bazel-')}"
-    ]
-    for opt in extra_compile_args:
-      bazel_argv.append("--cxxopt={}".format(opt))
+  # subprocess.check_call(['pwd'], stdout=sys.stdout, stderr=sys.stderr)
+  subprocess.check_call(bazel_argv, stdout=sys.stdout, stderr=sys.stderr)
 
-    # Debug build.
-    if DEBUG:
-      bazel_argv.append('--config=dbg')
+  target_path = bazel_target.replace('@xla//', 'external/xla/').replace(':', '/')
+  output_path = os.path.join('bazel-bin', target_path)
+  output_filename = os.path.basename(output_path)
 
-    # Remote cache authentication.
-    if GCLOUD_KEY_FILE:
-      # Temporary workaround to allow PRs from forked repo to run CI. See details at (#5259).
-      # TODO: Remove the check once self-hosted GHA workers are available to CPU/GPU CI.
-      gclout_key_file_size = os.path.getsize(GCLOUD_KEY_FILE)
-      if gclout_key_file_size > 1:
-        bazel_argv.append('--google_credentials=%s' % GCLOUD_KEY_FILE)
-        bazel_argv.append('--config=remote_cache')
-    else:
-      if _check_env_flag('BAZEL_REMOTE_CACHE'):
-        bazel_argv.append('--config=remote_cache')
-    if CACHE_SILO_NAME:
-      bazel_argv.append('--remote_default_exec_properties=cache-silo-key=%s' %
-                        CACHE_SILO_NAME)
+  if not os.path.exists(destination_path):
+      os.makedirs(destination_path)
 
-    if BAZEL_JOBS:
-      bazel_argv.append('--jobs=%s' % BAZEL_JOBS)
+  shutil.copyfile(output_path, os.path.join(destination_path, output_filename))
 
-    # Build configuration.
-    if _check_env_flag('BAZEL_VERBOSE'):
-      bazel_argv.append('-s')
+_bazel_build('@xla//xla/pjrt/c:pjrt_c_api_gpu_plugin.so', 'torch_xla_cuda_plugin/lib', ['--config=cuda'])
 
-    bazel_argv.append('--config=cuda')
-
-    self.spawn(bazel_argv)
-
-    ext_bazel_bin_path = os.path.join(self.build_temp, 'bazel-bin', ext.relpath,
-                                      ext.target_name)
-    print(ext_bazel_bin_path)
-    ext_dest_path = self.get_ext_fullpath(ext.name)
-    print(ext_dest_path)
-    ext_dest_dir = os.path.dirname(ext_dest_path)
-    if not os.path.exists(ext_dest_dir):
-      os.makedirs(ext_dest_dir)
-    shutil.copyfile(ext_bazel_bin_path, ext_dest_path)
-
-setuptools.setup(
-    url='https://github.com/pytorch/xla',
-    ext_modules=[
-        BazelExtension('@xla//xla/pjrt/c:pjrt_c_api_gpu_plugin.so'),
-    ],
-    cmdclass={
-        'build_ext': BuildBazelExtension,
-})
+setuptools.setup()

--- a/plugins/cuda/setup.py
+++ b/plugins/cuda/setup.py
@@ -1,0 +1,107 @@
+import setuptools
+from setuptools import Extension
+from setuptools.command import build_ext
+import shutil
+import os
+import posixpath
+import torch
+
+
+def _check_env_flag(name, default=''):
+  return os.getenv(name, default).upper() in ['ON', '1', 'YES', 'TRUE', 'Y']
+
+
+extra_compile_args = []
+cxx_abi = os.getenv(
+    'CXX_ABI', default='') or getattr(torch._C, '_GLIBCXX_USE_CXX11_ABI', None)
+if cxx_abi is not None:
+  extra_compile_args.append(f'-D_GLIBCXX_USE_CXX11_ABI={int(cxx_abi)}')
+
+
+DEBUG = _check_env_flag('DEBUG')
+GCLOUD_KEY_FILE = os.getenv('GCLOUD_SERVICE_KEY_FILE', default='')
+CACHE_SILO_NAME = os.getenv('SILO_NAME', default='dev')
+BAZEL_JOBS = os.getenv('BAZEL_JOBS', default='')
+
+class BazelExtension(setuptools.Extension):
+  """A C/C++ extension that is defined as a Bazel BUILD target."""
+
+  def __init__(self, bazel_target):
+    self.bazel_target = bazel_target
+    self.relpath, self.target_name = (
+        bazel_target.replace('@xla//', 'external/xla/').split(':'))
+    print('searchforthisstring', self.relpath)
+    ext_name = os.path.join(
+        self.relpath.replace(posixpath.sep, os.path.sep), self.target_name)
+    if ext_name.endswith('.so'):
+      ext_name = ext_name[:-3]
+    Extension.__init__(self, ext_name, sources=[])
+
+
+class BuildBazelExtension(build_ext.build_ext):
+  """A command that runs Bazel to build a C/C++ extension."""
+
+  def run(self):
+    for ext in self.extensions:
+      self.bazel_build(ext)
+    build_ext.build_ext.run(self)
+
+  def bazel_build(self, ext):
+    if not os.path.exists(self.build_temp):
+      os.makedirs(self.build_temp)
+
+    bazel_argv = [
+        'bazel', 'build', ext.bazel_target,
+        f"--symlink_prefix={os.path.join('plugins/cuda', self.build_temp, 'bazel-')}"
+    ]
+    for opt in extra_compile_args:
+      bazel_argv.append("--cxxopt={}".format(opt))
+
+    # Debug build.
+    if DEBUG:
+      bazel_argv.append('--config=dbg')
+
+    # Remote cache authentication.
+    if GCLOUD_KEY_FILE:
+      # Temporary workaround to allow PRs from forked repo to run CI. See details at (#5259).
+      # TODO: Remove the check once self-hosted GHA workers are available to CPU/GPU CI.
+      gclout_key_file_size = os.path.getsize(GCLOUD_KEY_FILE)
+      if gclout_key_file_size > 1:
+        bazel_argv.append('--google_credentials=%s' % GCLOUD_KEY_FILE)
+        bazel_argv.append('--config=remote_cache')
+    else:
+      if _check_env_flag('BAZEL_REMOTE_CACHE'):
+        bazel_argv.append('--config=remote_cache')
+    if CACHE_SILO_NAME:
+      bazel_argv.append('--remote_default_exec_properties=cache-silo-key=%s' %
+                        CACHE_SILO_NAME)
+
+    if BAZEL_JOBS:
+      bazel_argv.append('--jobs=%s' % BAZEL_JOBS)
+
+    # Build configuration.
+    if _check_env_flag('BAZEL_VERBOSE'):
+      bazel_argv.append('-s')
+
+    bazel_argv.append('--config=cuda')
+
+    self.spawn(bazel_argv)
+
+    ext_bazel_bin_path = os.path.join(self.build_temp, 'bazel-bin', ext.relpath,
+                                      ext.target_name)
+    print(ext_bazel_bin_path)
+    ext_dest_path = self.get_ext_fullpath(ext.name)
+    print(ext_dest_path)
+    ext_dest_dir = os.path.dirname(ext_dest_path)
+    if not os.path.exists(ext_dest_dir):
+      os.makedirs(ext_dest_dir)
+    shutil.copyfile(ext_bazel_bin_path, ext_dest_path)
+
+setuptools.setup(
+    url='https://github.com/pytorch/xla',
+    ext_modules=[
+        BazelExtension('@xla//xla/pjrt/c:pjrt_c_api_gpu_plugin.so'),
+    ],
+    cmdclass={
+        'build_ext': BuildBazelExtension,
+})

--- a/plugins/cuda/setup.py
+++ b/plugins/cuda/setup.py
@@ -1,6 +1,7 @@
 import build_util
 import setuptools
 
-build_util.bazel_build('@xla//xla/pjrt/c:pjrt_c_api_gpu_plugin.so', 'torch_xla_cuda_plugin/lib', ['--config=cuda'])
+build_util.bazel_build('@xla//xla/pjrt/c:pjrt_c_api_gpu_plugin.so',
+                       'torch_xla_cuda_plugin/lib', ['--config=cuda'])
 
 setuptools.setup()

--- a/plugins/cuda/torch_xla_cuda_plugin/__init__.py
+++ b/plugins/cuda/torch_xla_cuda_plugin/__init__.py
@@ -4,7 +4,7 @@ from torch_xla._internal import tpu
 
 class GpuPlugin(plugins.DevicePlugin):
   def library_path(self) -> str:
-    return os.path.join(os.path.dirname(__file__), 'pjrt_c_api_gpu_plugin.so')
+    return os.path.join(os.path.dirname(__file__), 'lib', 'pjrt_c_api_gpu_plugin.so')
 
   def physical_chip_count(self) -> int:
     # TODO: default to actual device count

--- a/plugins/cuda/torch_xla_cuda_plugin/__init__.py
+++ b/plugins/cuda/torch_xla_cuda_plugin/__init__.py
@@ -1,10 +1,12 @@
 import os
 from torch_xla.experimental import plugins
-from torch_xla._internal import tpu
+
 
 class GpuPlugin(plugins.DevicePlugin):
+
   def library_path(self) -> str:
-    return os.path.join(os.path.dirname(__file__), 'lib', 'pjrt_c_api_gpu_plugin.so')
+    return os.path.join(
+        os.path.dirname(__file__), 'lib', 'pjrt_c_api_gpu_plugin.so')
 
   def physical_chip_count(self) -> int:
     # TODO: default to actual device count

--- a/plugins/cuda/torch_xla_cuda_plugin/__init__.py
+++ b/plugins/cuda/torch_xla_cuda_plugin/__init__.py
@@ -2,7 +2,7 @@ import os
 from torch_xla.experimental import plugins
 
 
-class GpuPlugin(plugins.DevicePlugin):
+class CudaPlugin(plugins.DevicePlugin):
 
   def library_path(self) -> str:
     return os.path.join(

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ def _get_build_mode():
       return sys.argv[i]
 
 
-
 def get_git_head_sha(base_dir):
   xla_git_sha = subprocess.check_output(['git', 'rev-parse', 'HEAD'],
                                         cwd=base_dir).decode('ascii').strip()
@@ -191,6 +190,7 @@ if build_mode not in ['clean']:
   # Copy libtpu.so into torch_xla/lib
   maybe_bundle_libtpu(base_dir)
 
+
 class BazelExtension(Extension):
   """A C/C++ extension that is defined as a Bazel BUILD target."""
 
@@ -222,7 +222,8 @@ class BuildBazelExtension(build_ext.build_ext):
         f"--symlink_prefix={os.path.join(self.build_temp, 'bazel-')}"
     ]
 
-    cxx_abi = os.getenv('CXX_ABI') or getattr(torch._C, '_GLIBCXX_USE_CXX11_ABI', None)
+    cxx_abi = os.getenv('CXX_ABI') or getattr(torch._C,
+                                              '_GLIBCXX_USE_CXX11_ABI', None)
     if cxx_abi is not None:
       bazel_argv.append(f'--cxxopt=-D_GLIBCXX_USE_CXX11_ABI={int(cxx_abi)}')
 

--- a/setup.py
+++ b/setup.py
@@ -46,29 +46,22 @@
 #   CXX_ABI=""
 #     value for cxx_abi flag; if empty, it is inferred from `torch._C`.
 #
-from __future__ import print_function
-
 from setuptools import setup, find_packages, distutils, Extension, command
-from setuptools.command import develop
-from torch.utils.cpp_extension import BuildExtension
+from setuptools.command import develop, build_ext
 import posixpath
 import contextlib
 import distutils.ccompiler
 import distutils.command.clean
-import glob
-import inspect
-import multiprocessing
-import multiprocessing.pool
 import os
-import platform
-import re
 import requests
 import shutil
 import subprocess
 import sys
 import tempfile
-import torch
 import zipfile
+
+import build_util
+import torch
 
 base_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -81,9 +74,6 @@ def _get_build_mode():
     if not sys.argv[i].startswith('-'):
       return sys.argv[i]
 
-
-def _check_env_flag(name, default=''):
-  return os.getenv(name, default).upper() in ['ON', '1', 'YES', 'TRUE', 'Y']
 
 
 def get_git_head_sha(base_dir):
@@ -101,7 +91,7 @@ def get_git_head_sha(base_dir):
 
 def get_build_version(xla_git_sha):
   version = os.getenv('TORCH_XLA_VERSION', '2.2.0')
-  if _check_env_flag('GIT_VERSIONED_XLA_BUILD', default='TRUE'):
+  if build_util.check_env_flag('GIT_VERSIONED_XLA_BUILD', default='TRUE'):
     try:
       version += '+git' + xla_git_sha[:7]
     except Exception:
@@ -135,7 +125,7 @@ def maybe_bundle_libtpu(base_dir):
   with contextlib.suppress(FileNotFoundError):
     os.remove(libtpu_path)
 
-  if not _check_env_flag('BUNDLE_LIBTPU', '0'):
+  if not build_util.check_env_flag('BUNDLE_LIBTPU', '0'):
     return
 
   try:
@@ -201,21 +191,6 @@ if build_mode not in ['clean']:
   # Copy libtpu.so into torch_xla/lib
   maybe_bundle_libtpu(base_dir)
 
-DEBUG = _check_env_flag('DEBUG')
-IS_DARWIN = (platform.system() == 'Darwin')
-IS_WINDOWS = sys.platform.startswith('win')
-IS_LINUX = (platform.system() == 'Linux')
-GCLOUD_KEY_FILE = os.getenv('GCLOUD_SERVICE_KEY_FILE', default='')
-CACHE_SILO_NAME = os.getenv('SILO_NAME', default='dev')
-BAZEL_JOBS = os.getenv('BAZEL_JOBS', default='')
-
-extra_compile_args = []
-cxx_abi = os.getenv(
-    'CXX_ABI', default='') or getattr(torch._C, '_GLIBCXX_USE_CXX11_ABI', None)
-if cxx_abi is not None:
-  extra_compile_args.append(f'-D_GLIBCXX_USE_CXX11_ABI={int(cxx_abi)}')
-
-
 class BazelExtension(Extension):
   """A C/C++ extension that is defined as a Bazel BUILD target."""
 
@@ -230,7 +205,7 @@ class BazelExtension(Extension):
     Extension.__init__(self, ext_name, sources=[])
 
 
-class BuildBazelExtension(command.build_ext.build_ext):
+class BuildBazelExtension(build_ext.build_ext):
   """A command that runs Bazel to build a C/C++ extension."""
 
   def run(self):
@@ -246,49 +221,12 @@ class BuildBazelExtension(command.build_ext.build_ext):
         'bazel', 'build', ext.bazel_target,
         f"--symlink_prefix={os.path.join(self.build_temp, 'bazel-')}"
     ]
-    for opt in extra_compile_args:
-      bazel_argv.append("--cxxopt={}".format(opt))
 
-    # Debug build.
-    if DEBUG:
-      bazel_argv.append('--config=dbg')
+    cxx_abi = os.getenv('CXX_ABI') or getattr(torch._C, '_GLIBCXX_USE_CXX11_ABI', None)
+    if cxx_abi is not None:
+      bazel_argv.append(f'--cxxopt=-D_GLIBCXX_USE_CXX11_ABI={int(cxx_abi)}')
 
-    if _check_env_flag('TPUVM_MODE'):
-      bazel_argv.append('--config=tpu')
-
-    # Remote cache authentication.
-    if GCLOUD_KEY_FILE:
-      # Temporary workaround to allow PRs from forked repo to run CI. See details at (#5259).
-      # TODO: Remove the check once self-hosted GHA workers are available to CPU/GPU CI.
-      gclout_key_file_size = os.path.getsize(GCLOUD_KEY_FILE)
-      if gclout_key_file_size > 1:
-        bazel_argv.append('--google_credentials=%s' % GCLOUD_KEY_FILE)
-        bazel_argv.append('--config=remote_cache')
-    else:
-      if _check_env_flag('BAZEL_REMOTE_CACHE'):
-        bazel_argv.append('--config=remote_cache')
-    if CACHE_SILO_NAME:
-      bazel_argv.append('--remote_default_exec_properties=cache-silo-key=%s' %
-                        CACHE_SILO_NAME)
-
-    if _check_env_flag('BUILD_CPP_TESTS', default='0'):
-      bazel_argv.append('//test/cpp:all')
-      bazel_argv.append('//torch_xla/csrc/runtime:all')
-
-    if BAZEL_JOBS:
-      bazel_argv.append('--jobs=%s' % BAZEL_JOBS)
-
-    # Build configuration.
-    if _check_env_flag('BAZEL_VERBOSE'):
-      bazel_argv.append('-s')
-    if _check_env_flag('XLA_CUDA'):
-      bazel_argv.append('--config=cuda')
-    if _check_env_flag('XLA_CPU_USE_ACL'):
-      bazel_argv.append('--config=acl')
-
-    if IS_WINDOWS:
-      for library_dir in self.library_dirs:
-        bazel_argv.append('--linkopt=/LIBPATH:' + library_dir)
+    bazel_argv.extend(build_util.bazel_options_from_env())
 
     self.spawn(bazel_argv)
 


### PR DESCRIPTION
Note: directly running `setup.py` is now [deprecated](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html). Both plugins are now installable by running `pip install plugin/...`, which runs `setuptools`/`setup.py` in the background. We'll have to deal with this problem in our main `setup.py` build soon too.

- Build plugins within each `setup.py`
    - Note: `BazelExtension` and `BuildBazelExtension` are not necessary for the plugins because they don't expose any functions to Python like `_XLAC` does. Instead, I opted to run bazel in a subprocess before running `setup`. According to `setuptools`'s docs, the "right" way to extend `setuptools` is to [add commands](https://setuptools.pypa.io/en/latest/userguide/extension.html), but custom `setup.py` commands are being deprecated (since you have to invoke it through pip). The documentation doesn't make it clear what the right thing to do here is, so I opted for the most straightforward solution. (Not to mention, the documentation about how to actually write custom commands is also sparse.)
- Move some common bazel setup code to `build_util` and symlink it to plugin directories
  - Note: I can't figure out how to use a local file in a `setup.py` with `pip`'s build isolation, so [I disabled isolation with `--no-build-isolation`](https://stackoverflow.com/questions/62889093/what-does-no-build-isolation-do). The only way I see how to do this is to install our build-time library as a package, but it seems silly to create a package that will only be used to build our real packages in the same repository.

The current state of Python packaging is kind of a mess. See these [three](https://gregoryszorc.com/blog/2023/10/30/my-user-experience-porting-off-setup.py/) [blog](https://chriswarrick.com/blog/2023/01/15/how-to-improve-python-packaging/) [posts](https://chriswarrick.com/blog/2024/01/15/python-packaging-one-year-later/) for a pretty good summary of grievances with the current situation. I'm very open to feedback on this PR, since I'm not at all convinced I'm using the new tools the "right" way (if there even is one).

The bright side is, [`pyproject.toml`](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/) will make it _much_ easier to get away from `setuptools` if we want to do that. Especially when we have to deal with our main `setup.py`, we should look to see if any of the alternatives better support our use case with less hackery. (I did some research this week, but most alternatives, including PyPA's `hatch` do not support C++ extensions).