### PR TITLE
[HOT FIX] Disable GPU CI Coverage in master

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -44,7 +44,7 @@ jobs:
       docker-image: ${{ needs.build.outputs.docker-image }}
       runner: linux.8xlarge.nvidia.gpu
       timeout-minutes: 300
-      collect-coverage: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/master' }}
+      collect-coverage: false #${{ github.event_name == 'push' && github.event.ref == 'refs/heads/master' }}
       disable-xrt: 1
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}


### PR DESCRIPTION
Parallelizing the CI coverage run didn't resolve the timeout issue on the master branch. Not sure if this is a flaky issue or with the GPU runner in GA. Will need to further investigate. For now, disable GPU CI Coverage in master.