### PR TITLE
Clean-up CUDA cache.

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -166,6 +166,14 @@ class TorchBenchModel(BenchmarkModel):
   def __init__(self, suite_name, model_name, benchmark_experiment):
     super().__init__(suite_name, model_name, benchmark_experiment)
 
+  def _cleanup(self):
+    # Garbage-collect right now.
+    gc.collect()
+
+    # If we are using CUDA, clean-up its cache left-over.
+    if self.benchmark_experiment.accelerator == "cuda":
+      torch.cuda.empty_cache()
+
   def set_up(self):
     """Set up module, actual batch_size, example_inputs, and optimizer_class
 
@@ -197,7 +205,7 @@ class TorchBenchModel(BenchmarkModel):
       self.optimizer = benchmark.optimizer
 
     del benchmark
-    gc.collect()
+    self._cleanup()
 
   def load_benchmark(self):
     try:
@@ -247,13 +255,15 @@ class TorchBenchModel(BenchmarkModel):
     elif test == "train" and hasattr(benchmark, 'DEFAULT_TRAIN_CUDA_PRECISION'):
       precision = benchmark.DEFAULT_TRAIN_CUDA_PRECISION
     else:
+      precision = None
       logger.warning("No default precision set. No patching needed.")
-      return None
 
     del benchmark
-    gc.collect()
+    self._cleanup()
 
     precision_flag = None
+    if precision is None:
+      return None
     if precision == "fp16":
       precision_flag = 'XLA_USE_FP16'
     elif precision == "amp":

--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -7,6 +7,7 @@ from os.path import abspath
 import random
 import subprocess
 import torch
+import torch.utils._pytree as pytree
 import sys
 import torch_xla.core.xla_model as xm
 from torch_xla._internal import tpu
@@ -76,16 +77,7 @@ def is_xla_device_available(devkind):
 
 
 def move_to_device(item, device):
-  if isinstance(item, torch.Tensor):
-    return item.to(device=device)
-  elif isinstance(item, list):
-    return [move_to_device(t, device) for t in item]
-  elif isinstance(item, tuple):
-    return tuple(move_to_device(t, device) for t in item)
-  elif isinstance(item, dict):
-    return dict((k, move_to_device(t, device)) for k, t in item.items())
-  else:
-    return item
+  return pytree.tree_map_only(torch.Tensor, lambda t: t.to(device), item)
 
 
 def randomize_input(inputs):


### PR DESCRIPTION
This PR clears CUDA cache on 2 cases:

- `benchmark` instance was deleted (i.e. it was first instantiated with `cuda` as device, but it's not needed anymore)
- inner model has to be moved to an XLA device
    - since #6296, models are first initialized in the original accelerator, and then moved to XLA device

Additionally, it also fixes a bug where the instantiated `benchmark` wouldn't be deleted if it didn't have a default precision set (in `default_precision_flag` property).