### PR TITLE
Add option to register installed plugins automatically

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -346,6 +346,9 @@ setup(
         'absl-py>=1.0.0',
         'cloud-tpu-client>=0.10.0',
         'pyyaml',
+        # importlib.metadata backport required for PJRT plugin discovery prior
+        # to Python 3.10
+        'importlib_metadata>=4.6;python_version<"3.10"'
     ],
     package_data={
         'torch_xla': ['lib/*.so*',],

--- a/setup.py
+++ b/setup.py
@@ -348,7 +348,7 @@ setup(
         'pyyaml',
         # importlib.metadata backport required for PJRT plugin discovery prior
         # to Python 3.10
-        'importlib_metadata>=4.6;python_version<"3.10"'
+        'importlib_metadata>=4.6;python_version<"3.10"',
     ],
     package_data={
         'torch_xla': ['lib/*.so*',],
@@ -356,7 +356,10 @@ setup(
     entry_points={
         'console_scripts': [
             'stablehlo-to-saved-model = torch_xla.tf_saved_model_integration:main'
-        ]
+        ],
+        'torch_xla.plugins': [
+            'tpu = torch_xla._internal.tpu:TpuPlugin',
+        ],
     },
     extras_require={
         # On Cloud TPU VM install with:

--- a/setup.py
+++ b/setup.py
@@ -357,9 +357,7 @@ setup(
         'console_scripts': [
             'stablehlo-to-saved-model = torch_xla.tf_saved_model_integration:main'
         ],
-        'torch_xla.plugins': [
-            'tpu = torch_xla._internal.tpu:TpuPlugin',
-        ],
+        'torch_xla.plugins': ['tpu = torch_xla._internal.tpu:TpuPlugin',],
     },
     extras_require={
         # On Cloud TPU VM install with:

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -171,3 +171,9 @@ _init_xla_lazy_backend()
 torch._dynamo.config.automatic_dynamic_shapes = False
 
 from .stablehlo import save_as_stablehlo, save_torch_model_as_stablehlo
+
+from .experimental import plugins
+
+if os.getenv('XLA_REGISTER_INSTALLED_PLUGINS') == '1':
+  plugins.use_dynamic_plugins()
+  plugins.register_installed_plugins()

--- a/torch_xla/experimental/plugins.py
+++ b/torch_xla/experimental/plugins.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 
@@ -79,4 +80,12 @@ def register_installed_plugins():
   pjrt_entry_points = importlib_metadata.entry_points(group='torch_xla.plugins')
   for ep in pjrt_entry_points:
     device_plugin_class = ep.load()
-    register_plugin(ep.name.upper(), device_plugin_class())
+
+    # HACK: TpuPlugin raises EnvironmentError if libtpu is not installed.
+    # TODO(wcromar): Device if catching `EnvironmentError` is a permanent
+    # behavior or temporary hack.
+    try:
+      register_plugin(ep.name.upper(), device_plugin_class())
+    except EnvironmentError as e:
+      logging.warning(
+          "Failed to register plugin {}".format(ep.name), exc_info=e)

--- a/torch_xla/experimental/plugins.py
+++ b/torch_xla/experimental/plugins.py
@@ -82,7 +82,7 @@ def register_installed_plugins():
     device_plugin_class = ep.load()
 
     # HACK: TpuPlugin raises EnvironmentError if libtpu is not installed.
-    # TODO(wcromar): Device if catching `EnvironmentError` is a permanent
+    # TODO(wcromar): Decide if catching `EnvironmentError` is a permanent
     # behavior or temporary hack.
     try:
       register_plugin(ep.name.upper(), device_plugin_class())


### PR DESCRIPTION
See #6242 for context

- Add `XLA_REGISTER_INSTALLED_PLUGINS` to automatically register any plugin with the `torch_xla.plugins` [entry point](https://setuptools.pypa.io/en/latest/userguide/entry_point.html#entry-points-for-plugins).
- Requires [recent additions to `importlib.metadata`](https://docs.python.org/3/library/importlib.metadata.html#entry-points), which are backported in `importlib_metadata`.
- The default behavior remains the same for now. After this and related PRs are all merged, I'll try switching our CI over, then changing the default behavior if all tests pass. For now, I tested locally.