### PR TITLE
Allow xla bloat16 torch test results with some variances

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -17,6 +17,8 @@ TORCH_TEST_PRECIIONS = {
     'test_pow_xla_float64': 0.0045,
     'test_var_neg_dim_xla_bfloat16': 0.01,
     'test_sum_xla_bfloat16': 0.1,
+    'test_put_xla_bfloat16': 0.05,
+    'test_take_xla_bfloat16': 0.05,
 }
 
 DISABLED_TORCH_TESTS_ANY = {
@@ -205,7 +207,6 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_index_reduce',  # Broke by functionalization, pytorch/pytorch#94471
         'test_logcumsumexp_xla',  # doesn't raise, pytorch/pytorch#92912
         'test_narrow_copy_non_contiguous',  # the test is added for CPU, pytorch/pytorch#91789
-        'test_take_xla_bfloat16',  # precision for CPU and TPU
     },
 
     # test_view_ops.py
@@ -395,6 +396,7 @@ DISABLED_TORCH_TESTS_TPU_ONLY = {
         'test_nondeterministic_alert_grid_sample_3d_xla',  # server side crash
         'test_nondeterministic_alert_index_add_xla',  # server side crash
         'test_put_xla_bfloat16',  # (TPU) 0.46484375 vs. 0.484375
+        'test_take_xla_bfloat16',  # (TPU) -6.53125 vs. -6.5625
         'test_multinomial_constraints',  # server side crash
         'test_multinomial_invalid_distribution',  # server side crash
         'test_multinomial_invalid_xla',  # TODO: only fail on xlml


### PR DESCRIPTION
Allow xla bloat16 torch test results with some variances, as some XLA:CPU tests were failing due to the precision error.