### PR TITLE
fix issue that torchbench uses xla as device instead of tpu

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -228,9 +228,12 @@ class TorchBenchModel(BenchmarkModel):
     # workaround "RuntimeError: not allowed to set torch.backends.cudnn flags"
     # torch.backends.__allow_nonbracketed_mutation_flag = True
 
+    # torchbench uses `xla` as device instead of `tpu`
+    if device:=self.benchmark_experiment.accelerator=='tpu':
+        device = 'xla'
     return benchmark_cls(
         test=self.benchmark_experiment.test,
-        device=self.benchmark_experiment.accelerator,
+        device=device,
         batch_size=self.benchmark_experiment.batch_size,
     )
 

--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -230,7 +230,7 @@ class TorchBenchModel(BenchmarkModel):
 
     # torchbench uses `xla` as device instead of `tpu`
     if device := self.benchmark_experiment.accelerator == 'tpu':
-      device = 'xla'
+      device = str(self.benchmark_experiment.get_device())
     return benchmark_cls(
         test=self.benchmark_experiment.test,
         device=device,

--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -229,8 +229,8 @@ class TorchBenchModel(BenchmarkModel):
     # torch.backends.__allow_nonbracketed_mutation_flag = True
 
     # torchbench uses `xla` as device instead of `tpu`
-    if device:=self.benchmark_experiment.accelerator=='tpu':
-        device = 'xla'
+    if device := self.benchmark_experiment.accelerator == 'tpu':
+      device = 'xla'
     return benchmark_cls(
         test=self.benchmark_experiment.test,
         device=device,


### PR DESCRIPTION
All torchbench TPU tests failed due to the following issue:
```
 File "benchmark/torchbenchmark/models/BERT_pytorch/bert_pytorch/trainer/pretrain.py", line 38, in __init__
    self.device = torch.device(device)
RuntimeError: Expected one of cpu, cuda, ipu, xpu, mkldnn, opengl, opencl, ideep, hip, ve, fpga, ort, xla, lazy, vulkan, mps, meta, hpu, mtia, privateuseone device type at start of device string: tpu
```

Basically they only accept `xla` as device instead of `tpu`. This issue can be simply reproduced with the following command after model installation.
```
PJRT_DEVICE=TPU python experiment_runner.py --suite-name=torchbench --experiment-config=\{\"accelerator\":\"tpu\",\"xla\":\"PJRT\",\"dynamo\":null,\"test\":\"train\",\"xla_flags\":null\} --model-config=\{\"model_name\":\"BERT_pytorch\"\}
```