### PR TITLE
Export no-longer accepts callable; wrap in nn.Module.

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -214,8 +214,7 @@ function run_xla_op_tests3 {
   run_torchrun "$CDIR/pjrt/test_torchrun.py"
   run_test "$CDIR/test_persistent_cache.py"
   # NOTE: this line below is testing export and don't care about GPU
-  # TODO(qihqi): Enable after fix
-  # PJRT_DEVICE=CPU CPU_NUM_DEVICES=1 run_coverage "$CDIR/test_core_aten_ops.py"
+  PJRT_DEVICE=CPU CPU_NUM_DEVICES=1 run_coverage "$CDIR/test_core_aten_ops.py"
 }
 
 #######################################################################################


### PR DESCRIPTION
After https://github.com/pytorch/pytorch/pull/117528 export doesn't accept callables anymore.