### PR TITLE
aggregate.py: add --baseline option

### DIFF
--- a/test/benchmarks/Makefile
+++ b/test/benchmarks/Makefile
@@ -1,19 +1,22 @@
-TEST_ARGS = $(shell echo $@ | perl -pe 's/([^.]*)\.([^.]*)\.([^.]*)(?:\.tier([0-9]+))?\.test/--accelerator=$$1 --test=$$2 --report=$$3/; if (defined($$4)) { print "--filter-by-tier=$$4 " }')
+TEST_ARGS = $(shell echo $@ | perl -pe 's/([^.]*)\.([^.]*)\.([^.]*).*\.test/--accelerator=$$1 --test=$$2 --report=$$3/')
+EMBEDDED_TEST_ARGS = $(shell cat $@ | grep '^# ARGS: ' | perl -pe 's/^# ARGS: (.*)/$$1/')
 
 TESTS := $(wildcard *.test)
 all: $(TESTS)
 .PHONY: $(TESTS) all
 
 ifndef V
-  QUIET_AGGREGATE    = @echo '  ' AGGREGATE $(TEST_ARGS);
+  QUIET_AGGREGATE    = @echo '  ' AGGREGATE $(TEST_ARGS) $(EMBEDDED_TEST_ARGS);
   QUIET_DIFF         = @echo '  ' DIFF $@;
   QUIET_RM           = @echo '  ' RM $@.tmp;
 endif
 
 $(TESTS):
-	$(QUIET_AGGREGATE)python3 ../../benchmarks/aggregate.py $(TEST_ARGS) \
-		--format=csv $(wildcard *.jsonl) > $@.tmp
-	$(QUIET_DIFF)git diff --no-index $@ $@.tmp
+	$(QUIET_AGGREGATE)python3 ../../benchmarks/aggregate.py \
+		--format=csv \
+		$(TEST_ARGS) $(EMBEDDED_TEST_ARGS) \
+		$(wildcard *.jsonl) > $@.tmp
+	$(QUIET_DIFF)git diff -I'^# ARGS: ' --no-index $@ $@.tmp
 	$(QUIET_RM)$(RM) $@.tmp
 
 clean:

--- a/test/benchmarks/v100.inference.latest.tier1.test
+++ b/test/benchmarks/v100.inference.latest.tier1.test
@@ -1,2 +1,3 @@
+# ARGS: --filter-by-tier=1
 # WorkloadNumber,Speedup(Inductor/Oldest Inductor),StdDev,ModelName(Inductor),Speedup(PytorchXLA/Oldest Inductor),StdDev,ModelName(PytorchXLA),Speedup(PytorchXLA_Eval/Oldest Inductor),StdDev,ModelName(PytorchXLA_Eval)
 0,1.51952596,6.914e-05,BERT_pytorch,1.56880282,7.138e-05,BERT_pytorch,1.36859903,6.227e-05,BERT_pytorch

--- a/test/benchmarks/v100.inference.speedup.baseline_latest.test
+++ b/test/benchmarks/v100.inference.speedup.baseline_latest.test
@@ -1,0 +1,4 @@
+# ARGS: --baseline=latest
+# Datetime(UTC),Speedup(Inductor/Latest Inductor),StdDev,Speedup(PytorchXLA/Latest Inductor),StdDev,Speedup(PytorchXLA_Eval/Latest Inductor),StdDev
+2023-11-11 05:32:18.723407,0.71267792,1.621e-05,0.60245072,0.0,0.55375084,0.0
+2023-11-12 05:32:18,1.0,0.0,0.78480315,0.0,0.71435904,0.0


### PR DESCRIPTION
This allows us to pick the latest set of Inductor results as the baseline. This is useful when doing a direct comparison between Inductor and XLA for the latest date.