### PR TITLE
[torchbench] Force `llama_v2_7b_16h` to use SGD.

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -56,6 +56,9 @@ TRAIN_WITH_SGD = {
     "timm_vovnet",
     "vgg16",
     "hf_T5",
+    # PyTorch/benchmark sets its optimizer as SGD.
+    # Otherwise, OOMs.
+    "llama_v2_7b_16h",
 }
 
 # Skip the experiment of a model if any of the experiment configs in the list is fully matched


### PR DESCRIPTION
This PR adds `llama_v2_7b_16h` to the `TRAIN_WITH_SGD` set. Training with Adam makes it OOM on NVIDIA A100 GPUs.

cc @miladm @JackCaoG 