### PR TITLE
Fix coverage CI run bug & re-enable the EmbeddingBag test with 1% tol

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -219,7 +219,7 @@ function run_torch_xla_tests() {
   export CXX_ABI=$(python -c "import torch;print(int(torch._C._GLIBCXX_USE_CXX11_ABI))")
 
   # TODO(yeounoh) test coverage workflow is not parallelized.
-  if [[ -z "$RUN_BENCHMARK_TESTS" && -z "$RUN_CPP_TESTS1" && -z "$RUN_CPP_TESTS2" && -z "$RUN_PYTHON_TESTS" || "$USE_COVERAGE" != "0" ]]; then
+  if [[ -z "$RUN_BENCHMARK_TESTS" && -z "$RUN_CPP_TESTS1" && -z "$RUN_CPP_TESTS2" && -z "$RUN_PYTHON_TESTS" ]]; then
     run_torch_xla_python_tests $PYTORCH_DIR $XLA_DIR $USE_COVERAGE
     run_torch_xla_cpp_tests $PYTORCH_DIR $XLA_DIR $USE_COVERAGE
     run_torch_xla_benchmark_tests $XLA_DIR

--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -19,6 +19,7 @@ TORCH_TEST_PRECIIONS = {
     'test_sum_xla_bfloat16': 0.1,
     'test_put_xla_bfloat16': 0.05,
     'test_take_xla_bfloat16': 0.05,
+    'test_EmbeddingBag_per_sample_weights_and_new_offsets_xla': 0.01,
 }
 
 DISABLED_TORCH_TESTS_ANY = {
@@ -315,7 +316,6 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_embedding_bag_device',  # FIXME! Unsupported device type for sparse layout: xla
         'test_embedding_scalar_weight_error_xla',  # tsl::CurrentStackTrace[abi:cxx11]
         'test_EmbeddingBag_per_sample_weights_and_no_offsets',  # FIXME! Unsupported device type for sparse layout: xla
-        'test_EmbeddingBag_per_sample_weights_and_new_offsets',  # precision
     },
 
     # test/nn/test_convolution.py


### PR DESCRIPTION
This addresses the issues where
- CI run re-running all tests in master branch
- 'test_EmbeddingBag_per_sample_weights_and_new_offsets' test failures due to <1% result variance.