### PR TITLE
[Core Aten Ops] Add test_aten_index_put back

### DIFF
--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -2124,7 +2124,6 @@ class AtenOpTest(unittest.TestCase):
     ))
     run_export_and_compare(self, torch.ops.aten.randint.low, args, kwargs)
 
-  @unittest.skip
   def test_aten_index_put_0(self):
     args = (
         torch.randn((10, 10)).to(torch.float32),
@@ -2147,7 +2146,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.index_put, args, kwargs)
 
-  @unittest.skip
   def test_aten_index_put_2(self):
     args = (
         torch.randint(0, 10, (10, 10)).to(torch.int32),


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/5984

---

Testing

three tests pass directly:
```
# pytest test/test_core_aten_ops.py -k test_aten_index_put_0
================================================== test session starts ===================================================
platform linux -- Python 3.10.13, pytest-7.4.3, pluggy-1.3.0
rootdir: /root/pytorch
configfile: pytest.ini
plugins: hypothesis-6.90.0
collected 523 items / 522 deselected / 1 selected                                                                        

test/test_core_aten_ops.py .                                                                                       [100%]

=========================================== 1 passed, 522 deselected in 59.99s ===========================================
# pytest test/test_core_aten_ops.py -k test_aten_index_put_1
================================================== test session starts ===================================================
platform linux -- Python 3.10.13, pytest-7.4.3, pluggy-1.3.0
rootdir: /root/pytorch
configfile: pytest.ini
plugins: hypothesis-6.90.0
collected 523 items / 522 deselected / 1 selected                                                                        

test/test_core_aten_ops.py .                                                                                       [100%]

=========================================== 1 passed, 522 deselected in 6.93s ============================================
# pytest test/test_core_aten_ops.py -k test_aten_index_put_2
================================================== test session starts ===================================================
platform linux -- Python 3.10.13, pytest-7.4.3, pluggy-1.3.0
rootdir: /root/pytorch
configfile: pytest.ini
plugins: hypothesis-6.90.0
collected 523 items / 522 deselected / 1 selected                                                                        

test/test_core_aten_ops.py .                                                                                       [100%]

=========================================== 1 passed, 522 deselected in 6.89s ============================================
```