### PR TITLE
Add GPU plugin build to CI

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -104,7 +104,7 @@ function build_torch_xla() {
   XLA_DIR=$1
   pushd "$XLA_DIR"
   python setup.py install
-  pip install plugins/cuda -v --no-build-isolation
+  pip install plugins/cuda -v
   popd
 }
 

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -104,7 +104,7 @@ function build_torch_xla() {
   XLA_DIR=$1
   pushd "$XLA_DIR"
   python setup.py install
-  pip install plugins/cuda -v --no-build-isolation
+  PYTHONPATH=. pip install plugins/cuda -v --no-build-isolation
   popd
 }
 

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -104,6 +104,7 @@ function build_torch_xla() {
   XLA_DIR=$1
   pushd "$XLA_DIR"
   python setup.py install
+  pip install plugins/cuda -v --no-build-isolation
   popd
 }
 

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -104,7 +104,7 @@ function build_torch_xla() {
   XLA_DIR=$1
   pushd "$XLA_DIR"
   python setup.py install
-  PYTHONPATH=. pip install plugins/cuda -v --no-build-isolation
+  pip install plugins/cuda -v --no-build-isolation
   popd
 }
 

--- a/infra/ansible/roles/build_srcs/tasks/main.yaml
+++ b/infra/ansible/roles/build_srcs/tasks/main.yaml
@@ -25,7 +25,7 @@
 
 - name: Build PyTorch/XLA CUDA Plugin
   ansible.builtin.command:
-    cmd: pip wheel -w dist plugins/cuda -v --no-build-isolation
+    cmd: pip wheel -w dist plugins/cuda -v
     chdir: "{{ (src_root, 'pytorch/xla') | path_join }}"
   environment: "{{ env_vars }}"
   when: accelerator == "cuda"

--- a/infra/ansible/roles/build_srcs/tasks/main.yaml
+++ b/infra/ansible/roles/build_srcs/tasks/main.yaml
@@ -23,6 +23,13 @@
     chdir: "{{ (src_root, 'pytorch/xla') | path_join }}"
   environment: "{{ env_vars }}"
 
+- name: Build PyTorch/XLA CUDA Plugin
+  ansible.builtin.command:
+    cmd: pip wheel -w dist plugins/cuda -v --no-build-isolation
+    chdir: "{{ (src_root, 'pytorch/xla') | path_join }}"
+  environment: "{{ env_vars }}"
+  when: accelerator == "cuda"
+
 - name: Find XLA *.whl files in pytorch/xla/dist
   ansible.builtin.find:
     path: "{{ (src_root, 'pytorch/xla/dist') | path_join }}"

--- a/plugins/cpu/README.md
+++ b/plugins/cpu/README.md
@@ -11,9 +11,9 @@ repository (see `bazel build` command below).
 
 ```bash
 # Build wheel
-pip wheel plugins/cpu --no-build-isolation -v
+pip wheel plugins/cpu -v
 # Or install directly
-pip install plugins/cpu --no-build-isolation -v
+pip install plugins/cpu -v
 ```
 
 ## Usage

--- a/plugins/cpu/build_util.py
+++ b/plugins/cpu/build_util.py
@@ -1,1 +1,0 @@
-../../build_util.py

--- a/plugins/cpu/setup.py
+++ b/plugins/cpu/setup.py
@@ -1,7 +1,7 @@
 # add `build_util` to import path
 import os
 import sys
-sys.path.append(os.path.join(os.dirname(__file__), '..', '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 
 import build_util
 import setuptools

--- a/plugins/cpu/setup.py
+++ b/plugins/cpu/setup.py
@@ -1,3 +1,8 @@
+# add `build_util` to import path
+import os
+import sys
+sys.path.append(os.path.join(os.dirname(__file__), '..', '..'))
+
 import build_util
 import setuptools
 

--- a/plugins/cpu/setup.py
+++ b/plugins/cpu/setup.py
@@ -1,6 +1,7 @@
-# add `build_util` to import path
 import os
 import sys
+
+# add `build_util` to import path
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 
 import build_util

--- a/plugins/cuda/README.md
+++ b/plugins/cuda/README.md
@@ -8,9 +8,9 @@ repository (see `bazel build` command below).
 
 ```bash
 # Build wheel
-pip wheel plugins/cuda --no-build-isolation -v
+pip wheel plugins/cuda -v
 # Or install directly
-pip install plugins/cuda --no-build-isolation -v
+pip install plugins/cuda -v
 ```
 
 ## Usage

--- a/plugins/cuda/build_util.py
+++ b/plugins/cuda/build_util.py
@@ -1,1 +1,0 @@
-../../build_util.py

--- a/plugins/cuda/setup.py
+++ b/plugins/cuda/setup.py
@@ -1,7 +1,7 @@
 # add `build_util` to import path
 import os
 import sys
-sys.path.append(os.path.join(os.dirname(__file__), '..', '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 
 import build_util
 import setuptools

--- a/plugins/cuda/setup.py
+++ b/plugins/cuda/setup.py
@@ -1,3 +1,8 @@
+# add `build_util` to import path
+import os
+import sys
+sys.path.append(os.path.join(os.dirname(__file__), '..', '..'))
+
 import build_util
 import setuptools
 

--- a/plugins/cuda/setup.py
+++ b/plugins/cuda/setup.py
@@ -1,6 +1,7 @@
-# add `build_util` to import path
 import os
 import sys
+
+# add `build_util` to import path
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 
 import build_util


### PR DESCRIPTION
- Install GPU plugin in CI. With the cache warmed, this doesn't affect the build time much. Cold-start builds are _much_ slower -- over an hour and 40 minutes.
  - We'll only ever have to rebuild the plugin during XLA pin updates and potentially when we update XLA patches. Otherwise, this should be entirely cached, since all of the code comes from XLA.
  - The cold-start build times will get better when we can drop the GPU client from the main build. Then, the CI can build the CPU-only `torch_xla` package, which is much smaller.
- `build_utils` symlinks didn't actually do anything, so remove them. Adjust the Python search path instead.
- Remove build isolation too. This only worked locally because of my specific environment.
- Add plugin build to ansible configs. Tested this locally. I think this will get uploaded to our GCS bucket automatically. Sanity-checking this with the TPU CI (which uses ansible).