### PR TITLE
aggregate.py: allow picking backends to report on

### DIFF
--- a/test/benchmarks/a6000.inference.speedup.test
+++ b/test/benchmarks/a6000.inference.speedup.test
@@ -1,2 +1,2 @@
-# Datetime(UTC),Speedup(Inductor/Oldest Inductor),StdDev,Speedup(PytorchXLA/Oldest Inductor),StdDev,Speedup(PytorchXLA_Eval/Oldest Inductor),StdDev
+# Datetime(UTC),Speedup(Inductor/Oldest Inductor),StdDev,Speedup(XLA+Dynamo/Oldest Inductor),StdDev,Speedup(XLA_Eval+Dynamo/Oldest Inductor),StdDev
 2023-11-11 04:43:56.070348,1.0,0.0,,,0.76855822,0.0

--- a/test/benchmarks/a6000.training.latest.test
+++ b/test/benchmarks/a6000.training.latest.test
@@ -1,3 +1,3 @@
-# WorkloadNumber,Speedup(Inductor/Oldest Inductor),StdDev,ModelName(Inductor),Speedup(PytorchXLA/Oldest Inductor),StdDev,ModelName(PytorchXLA)
+# Workload,Speedup(Inductor/Oldest Inductor),StdDev,ModelName(Inductor),Speedup(XLA+Dynamo/Oldest Inductor),StdDev,ModelName(XLA+Dynamo)
 0,1.0,0.0,BERT_pytorch,2.84589073,0.0,BERT_pytorch
 1,1.0,0.0,Background_Matting,,,

--- a/test/benchmarks/v100.inference.histogram.test
+++ b/test/benchmarks/v100.inference.histogram.test
@@ -1,3 +1,3 @@
-# Datetime(UTC),Inductor p95,Inductor p50,Inductor p5,PytorchXLA p95,PytorchXLA p50,PytorchXLA p5,PytorchXLA_Eval p95,PytorchXLA_Eval p50,PytorchXLA_Eval p5
+# Datetime(UTC),Inductor p95,Inductor p50,Inductor p5,XLA+Dynamo p95,XLA+Dynamo p50,XLA+Dynamo p5,XLA_Eval+Dynamo p95,XLA_Eval+Dynamo p50,XLA_Eval+Dynamo p5
 2023-11-11 05:32:18.723407,1.0,1.0,1.0,0.97631327,0.85586259,0.7354119,0.94359157,0.79447,0.64534844
 2023-11-12 05:32:18,1.50833479,1.40761418,1.30689358,1.52901152,1.17088985,0.81276817,1.33687535,1.05136221,0.76584908

--- a/test/benchmarks/v100.inference.latest.openxla_baseline.test
+++ b/test/benchmarks/v100.inference.latest.openxla_baseline.test
@@ -1,0 +1,3 @@
+# ARGS: --backends openxla+dynamo inductor --baseline=latest --filter-by-tier=1
+# Workload,Speedup(XLA+Dynamo/Latest XLA+Dynamo),StdDev,ModelName(XLA+Dynamo),Speedup(Inductor/Latest XLA+Dynamo),StdDev,ModelName(Inductor)
+0,1.0,0.0,BERT_pytorch,0.96858952,0.0,BERT_pytorch

--- a/test/benchmarks/v100.inference.latest.test
+++ b/test/benchmarks/v100.inference.latest.test
@@ -1,3 +1,3 @@
-# WorkloadNumber,Speedup(Inductor/Oldest Inductor),StdDev,ModelName(Inductor),Speedup(PytorchXLA/Oldest Inductor),StdDev,ModelName(PytorchXLA),Speedup(PytorchXLA_Eval/Oldest Inductor),StdDev,ModelName(PytorchXLA_Eval)
+# Workload,Speedup(Inductor/Oldest Inductor),StdDev,ModelName(Inductor),Speedup(XLA+Dynamo/Oldest Inductor),StdDev,ModelName(XLA+Dynamo),Speedup(XLA_Eval+Dynamo/Oldest Inductor),StdDev,ModelName(XLA_Eval+Dynamo)
 0,1.2957024,0.0,Background_Matting,0.77297688,0.0,Background_Matting,0.7341254,0.0,Background_Matting
 1,1.51952596,6.914e-05,BERT_pytorch,1.56880282,7.138e-05,BERT_pytorch,1.36859903,6.227e-05,BERT_pytorch

--- a/test/benchmarks/v100.inference.latest.tier1.test
+++ b/test/benchmarks/v100.inference.latest.tier1.test
@@ -1,3 +1,3 @@
 # ARGS: --filter-by-tier=1
-# WorkloadNumber,Speedup(Inductor/Oldest Inductor),StdDev,ModelName(Inductor),Speedup(PytorchXLA/Oldest Inductor),StdDev,ModelName(PytorchXLA),Speedup(PytorchXLA_Eval/Oldest Inductor),StdDev,ModelName(PytorchXLA_Eval)
+# Workload,Speedup(Inductor/Oldest Inductor),StdDev,ModelName(Inductor),Speedup(XLA+Dynamo/Oldest Inductor),StdDev,ModelName(XLA+Dynamo),Speedup(XLA_Eval+Dynamo/Oldest Inductor),StdDev,ModelName(XLA_Eval+Dynamo)
 0,1.51952596,6.914e-05,BERT_pytorch,1.56880282,7.138e-05,BERT_pytorch,1.36859903,6.227e-05,BERT_pytorch

--- a/test/benchmarks/v100.inference.speedup.baseline_latest.test
+++ b/test/benchmarks/v100.inference.speedup.baseline_latest.test
@@ -1,4 +1,4 @@
 # ARGS: --baseline=latest
-# Datetime(UTC),Speedup(Inductor/Latest Inductor),StdDev,Speedup(PytorchXLA/Latest Inductor),StdDev,Speedup(PytorchXLA_Eval/Latest Inductor),StdDev
+# Datetime(UTC),Speedup(Inductor/Latest Inductor),StdDev,Speedup(XLA+Dynamo/Latest Inductor),StdDev,Speedup(XLA_Eval+Dynamo/Latest Inductor),StdDev
 2023-11-11 05:32:18.723407,0.71267792,1.621e-05,0.60245072,0.0,0.55375084,0.0
 2023-11-12 05:32:18,1.0,0.0,0.78480315,0.0,0.71435904,0.0

--- a/test/benchmarks/v100.inference.speedup.test
+++ b/test/benchmarks/v100.inference.speedup.test
@@ -1,3 +1,3 @@
-# Datetime(UTC),Speedup(Inductor/Oldest Inductor),StdDev,Speedup(PytorchXLA/Oldest Inductor),StdDev,Speedup(PytorchXLA_Eval/Oldest Inductor),StdDev
+# Datetime(UTC),Speedup(Inductor/Oldest Inductor),StdDev,Speedup(XLA+Dynamo/Oldest Inductor),StdDev,Speedup(XLA_Eval+Dynamo/Oldest Inductor),StdDev
 2023-11-11 05:32:18.723407,1.0,3.217e-05,0.84533378,1.923e-05,0.77700013,1.768e-05
 2023-11-12 05:32:18,1.40315838,3.192e-05,1.10120312,2.505e-05,1.00235887,2.28e-05


### PR DESCRIPTION
With this we also allow picking backends that we ignored until now, namely eager and openxla{,_eval}+lazytensor.

While at it, shorten the printed names of "PytorchXLA" to "XLA" and "WorkloadNumber" to "Workload". This paves the way for an upcoming "tabulate" mode.