### PR TITLE
[torchbench] Re-land: Force `llama_v2_7b_16h` to use SGD.

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -57,6 +57,9 @@ TRAIN_WITH_SGD = {
     "timm_vovnet",
     "vgg16",
     "hf_T5",
+    # PyTorch/benchmark sets its optimizer as SGD.
+    # Otherwise, OOMs.
+    "llama_v2_7b_16h",
 }
 
 # Skip the experiment of a model if any of the experiment configs in the list is fully matched


### PR DESCRIPTION
Relanding #6350. It was reverted by mistake at #6352.

cc @miladm @JackCaoG @zpcore 