### PR TITLE
nightly.sh: pass --always to git describe --tags

### DIFF
--- a/benchmarks/nightly.sh
+++ b/benchmarks/nightly.sh
@@ -151,7 +151,7 @@ cp ${WORKSPACE_RESULTS_DIR:?}/results.jsonl \
    ${NIGHTLY_RESULTS_DIR:?}/${WORKSPACE:?}.jsonl
 
 PYTORCH_GIT_REV=$(git -C pytorch rev-parse --short HEAD)
-XLA_GIT_TAG=$(git -C pytorch/xla describe --tags)
+XLA_GIT_TAG=$(git -C pytorch/xla describe --tags --always)
 GIT_TAGS="PT: ${PYTORCH_GIT_REV:?} XLA: ${XLA_GIT_TAG:?}"
 BM_DIR=${WORKSPACE_DIR:?}/pytorch/xla/benchmarks
 


### PR DESCRIPTION
For some commits we cannot get a tag via `git describe --tags`:

```
$ git -C pytorch/xla describe --tags
fatal: No tags can describe '2f4275f5...'.
Try --always, or create some tags.
```

With --always, we can get the commit as a fallback.