### PR TITLE
Check precision only if on CUDA and not inductor.

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -361,8 +361,8 @@ class TorchBenchModel(BenchmarkModel):
     #   2. Dynamo backend is not inductor: PyTorch/benchmark scripts already
     #      take care of converting the model to the right precision.
     #
-    if not (self.benchmark_experiment.accelerator == "cuda" and
-            self.benchmark_experiment.dynamo != "inductor"):
+    if (self.benchmark_experiment.accelerator != "cuda" or
+        self.benchmark_experiment.dynamo == "inductor"):
       return None
 
     if self.get_cuda_precision() is None:

--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -353,6 +353,18 @@ class TorchBenchModel(BenchmarkModel):
     changes to the PT/XLA bridge so that the input shape
     is properly inferred after issuing converts to `torch.nn.Module`.
     """
+    # At this moment, this method checks the precision flags only if both
+    # of the items below are true:
+    #
+    #   1. Device is CUDA: only check for 'DEFAULT_CUDA_<test>_PRECISION'
+    #
+    #   2. Dynamo backend is not inductor: PyTorch/benchmark scripts already
+    #      take care of converting the model to the right precision.
+    #
+    if not (self.benchmark_experiment.accelerator == "cuda" and
+            self.benchmark_experiment.dynamo != "inductor"):
+      return None
+
     if self.get_cuda_precision() is None:
       return None
 


### PR DESCRIPTION
This PR skips precision flag checking for experiments whose: (i) device is not `cuda`; and (ii) dynamo backends are not `inductor`.

**(i)** the flag checked is aimed towards CUDA only: `DEFAULT_CUDA_<test>_PRECISION`

**(ii)** PyTorch/benchmark scripts already take care of the model conversion for inductor

cc @miladm