### PR TITLE
Avoid fallback for avg_pool -

### DIFF
--- a/test/cpp/test_tensor.cpp
+++ b/test/cpp/test_tensor.cpp
@@ -316,7 +316,8 @@ TEST_F(TensorTest, TestAvgPool2D) {
                            /*kernel_size=*/{kernel_size, kernel_size},
                            /*stride=*/{stride, stride},
                            /*padding=*/{padding, padding},
-                           /*ceil_mode=*/false, count_include_pad);
+                           /*ceil_mode=*/false, count_include_pad,
+                           /*divisor_override=*/std::nullopt);
         ForEachDevice([&](const torch::lazy::BackendDevice& device) {
           XLATensorPtr dev_input = XLATensor::Create(input, device);
           XLATensorPtr dev_output = tensor_methods::avg_pool_nd(
@@ -325,7 +326,8 @@ TEST_F(TensorTest, TestAvgPool2D) {
               /*kernel_size=*/{kernel_size, kernel_size},
               /*stride=*/{stride, stride},
               /*padding=*/{padding, padding},
-              /*ceil_mode=*/false, count_include_pad);
+              /*ceil_mode=*/false, count_include_pad,
+              /*divisor_override=*/std::nullopt);
           AllClose(output, dev_output);
         });
       }
@@ -344,7 +346,8 @@ TEST_F(TensorTest, TestAvgPool2DNonSquare) {
             /*kernel_size=*/{kernel_size, kernel_size + 1},
             /*stride=*/{stride, stride + 1},
             /*padding=*/{padding, padding + 1}, /*ceil_mode=*/false,
-            /*count_include_pad=*/count_include_pad);
+            /*count_include_pad=*/count_include_pad,
+            /*divisor_override=*/std::nullopt);
         ForEachDevice([&](const torch::lazy::BackendDevice& device) {
           XLATensorPtr dev_input = XLATensor::Create(input, device);
           XLATensorPtr dev_output = tensor_methods::avg_pool_nd(
@@ -354,7 +357,8 @@ TEST_F(TensorTest, TestAvgPool2DNonSquare) {
               /*stride=*/{stride, stride + 1},
               /*padding=*/{padding, padding + 1},
               /*ceil_mode=*/false,
-              /*count_include_pad=*/count_include_pad);
+              /*count_include_pad=*/count_include_pad,
+              /*divisor_override=*/std::nullopt);
           AllClose(output, dev_output);
         });
       }

--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -749,6 +749,36 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.avg_pool2d, args, kwargs)
 
+  def test_aten_avg_pool2d_2(self):
+    args = (
+        torch.randn((1, 192, 40, 40)).to(torch.float32),
+        [3, 3],
+        [1, 1],
+        [1, 1],
+        True,
+    )
+    kwargs = dict()
+    run_export_and_compare(self, torch.ops.aten.avg_pool2d, args, kwargs)
+
+  def test_aten_avg_pool2d_3(self):
+    args = (
+        torch.randn((1, 3, 1, 10)).to(torch.float32),
+        [
+            1,
+            2,
+        ],
+        [
+            1,
+            2,
+        ],
+    )
+
+    def avg_pool_divisor(*args):
+      return torch.ops.aten.avg_pool2d(*args, divisor_override=7)
+
+    kwargs = dict()
+    run_export_and_compare(self, avg_pool_divisor, args, kwargs)
+
   def test_aten_avg_pool3d_0(self):
     args = (
         torch.randn((1, 3, 10, 10, 10)).to(torch.float32),

--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -760,25 +760,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.avg_pool2d, args, kwargs)
 
-  def test_aten_avg_pool2d_3(self):
-    args = (
-        torch.randn((1, 3, 1, 10)).to(torch.float32),
-        [
-            1,
-            2,
-        ],
-        [
-            1,
-            2,
-        ],
-    )
-
-    def avg_pool_divisor(*args):
-      return torch.ops.aten.avg_pool2d(*args, divisor_override=7)
-
-    kwargs = dict()
-    run_export_and_compare(self, avg_pool_divisor, args, kwargs)
-
   def test_aten_avg_pool3d_0(self):
     args = (
         torch.randn((1, 3, 10, 10, 10)).to(torch.float32),

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -760,17 +760,11 @@ at::Tensor XLANativeFunctions::avg_pool2d(
     at::IntArrayRef padding, bool ceil_mode, bool count_include_pad,
     c10::optional<int64_t> divisor_override) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
-  if ((ceil_mode && count_include_pad) || divisor_override) {
-    return at::native::call_fallback_fn<
-        &xla_cpu_fallback, ATEN_OP(avg_pool2d)>::call(self, kernel_size, stride,
-                                                      padding, ceil_mode,
-                                                      count_include_pad,
-                                                      divisor_override);
-  }
   return bridge::AtenFromXlaTensor(tensor_methods::avg_pool_nd(
       bridge::GetXlaTensor(self), /*spatial_dim_count=*/2,
       XlaHelpers::I64List(kernel_size), XlaHelpers::I64List(stride),
-      XlaHelpers::I64List(padding), ceil_mode, count_include_pad));
+      XlaHelpers::I64List(padding), ceil_mode, count_include_pad,
+      divisor_override));
 }
 
 at::Tensor XLANativeFunctions::avg_pool2d_backward(
@@ -797,17 +791,11 @@ at::Tensor XLANativeFunctions::avg_pool3d(
     at::IntArrayRef padding, bool ceil_mode, bool count_include_pad,
     c10::optional<int64_t> divisor_override) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
-  if ((ceil_mode && count_include_pad) || divisor_override) {
-    return at::native::call_fallback_fn<
-        &xla_cpu_fallback, ATEN_OP(avg_pool3d)>::call(self, kernel_size, stride,
-                                                      padding, ceil_mode,
-                                                      count_include_pad,
-                                                      divisor_override);
-  }
   return bridge::AtenFromXlaTensor(tensor_methods::avg_pool_nd(
       bridge::GetXlaTensor(self), /*spatial_dim_count=*/3,
       XlaHelpers::I64List(kernel_size), XlaHelpers::I64List(stride),
-      XlaHelpers::I64List(padding), ceil_mode, count_include_pad));
+      XlaHelpers::I64List(padding), ceil_mode, count_include_pad,
+      divisor_override));
 }
 
 at::Tensor XLANativeFunctions::avg_pool3d_backward(

--- a/torch_xla/csrc/ops/avg_pool_nd.cpp
+++ b/torch_xla/csrc/ops/avg_pool_nd.cpp
@@ -1,10 +1,12 @@
 #include "torch_xla/csrc/ops/avg_pool_nd.h"
 
 #include "absl/strings/str_join.h"
+#include "torch_xla/csrc/helpers.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 #include "torch_xla/csrc/pooling.h"
 #include "torch_xla/csrc/runtime/debug_macros.h"
+#include "torch_xla/csrc/shape_helper.h"
 
 namespace torch_xla {
 namespace {
@@ -45,7 +47,8 @@ c10::Symbol AvgPoolNdSymbol(int64_t spatial_dim_count) {
 AvgPoolNd::AvgPoolNd(const torch::lazy::Value& input, int64_t spatial_dim_count,
                      std::vector<int64_t> kernel_size,
                      std::vector<int64_t> stride, std::vector<int64_t> padding,
-                     bool ceil_mode, bool count_include_pad)
+                     bool ceil_mode, bool count_include_pad,
+                     std::optional<int> divisor_override)
     : XlaNode(torch::lazy::OpKind(AvgPoolNdSymbol(spatial_dim_count)), {input},
               [&]() {
                 return NodeOutputShape(input, spatial_dim_count, kernel_size,
@@ -60,7 +63,8 @@ AvgPoolNd::AvgPoolNd(const torch::lazy::Value& input, int64_t spatial_dim_count,
       stride_(std::move(stride)),
       padding_(std::move(padding)),
       ceil_mode_(ceil_mode),
-      count_include_pad_(count_include_pad) {}
+      count_include_pad_(count_include_pad),
+      divisor_override_(divisor_override) {}
 
 torch::lazy::NodePtr AvgPoolNd::Clone(torch::lazy::OpList operands) const {
   return torch::lazy::MakeNode<AvgPoolNd>(operands.at(0), spatial_dim_count_,
@@ -73,6 +77,15 @@ XlaOpVector AvgPoolNd::Lower(LoweringContext* loctx) const {
   xla::XlaOp output =
       BuildAvgPoolNd(input, spatial_dim_count_, kernel_size_, stride_, padding_,
                      ceil_mode_, count_include_pad_);
+  if (divisor_override_) {
+    auto dtype = ShapeHelper::ShapeOfXlaOp(output).element_type();
+    auto* builder = loctx->builder();
+    int size = std::accumulate(kernel_size_.begin(), kernel_size_.end(), 1,
+                               std::multiplies<int>());
+    output = xla::Div(
+        xla::Mul(output, XlaHelpers::ScalarValue(size, dtype, builder)),
+        XlaHelpers::ScalarValue(*divisor_override_, dtype, builder));
+  }
   return ReturnOp(output, loctx);
 }
 

--- a/torch_xla/csrc/ops/avg_pool_nd.h
+++ b/torch_xla/csrc/ops/avg_pool_nd.h
@@ -10,7 +10,8 @@ class AvgPoolNd : public XlaNode {
   AvgPoolNd(const torch::lazy::Value& input, int64_t spatial_dim_count,
             std::vector<int64_t> kernel_size, std::vector<int64_t> stride,
             std::vector<int64_t> padding, bool ceil_mode,
-            bool count_include_pad);
+            bool count_include_pad,
+            std::optional<int> divisor_override = std::nullopt);
 
   torch::lazy::NodePtr Clone(torch::lazy::OpList operands) const override;
 
@@ -40,6 +41,7 @@ class AvgPoolNd : public XlaNode {
   // Whether the counts used to compute the average should include the added
   // padding.
   bool count_include_pad_;
+  std::optional<int> divisor_override_;
 };
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/pooling.cpp
+++ b/torch_xla/csrc/pooling.cpp
@@ -131,47 +131,50 @@ xla::XlaOp RemoveTrivialBatch(xla::XlaOp batch, int64_t original_rank,
 std::vector<std::pair<int64_t, int64_t>> CeilModePadding(
     absl::Span<const int64_t> padding, const xla::Shape& input_shape,
     absl::Span<const int64_t> kernel_size, absl::Span<const int64_t> stride,
-    bool ceil_mode) {
+    bool ceil_mode, bool count_include_pad) {
   std::vector<std::pair<int64_t, int64_t>> ceil_mode_padding;
   for (int i = 0; i < padding.size(); ++i) {
     int64_t left_padding = padding[i];
+    if (count_include_pad) {
+      // if count_include_pad; the padding is added as XLA ops
+      left_padding = 0;
+    }
     int64_t input_size = input_shape.dimensions(2 + i);
     int64_t output_size_rem =
         (input_size + 2 * left_padding - kernel_size[i]) % stride[i];
     int64_t right_padding = left_padding;
     if (ceil_mode && output_size_rem != 0) {
-      int64_t extra_padding = stride[i] - output_size_rem;
-      int64_t new_output_size =
-          (input_size + left_padding + right_padding + extra_padding -
-           kernel_size[i] + stride[i] - 1) /
-              stride[i] +
-          1;
-      // Ensure that the last pooling starts inside the image.
-      if ((new_output_size - 1) * stride[i] < input_size + left_padding) {
-        right_padding += extra_padding;
-      }
+      right_padding += stride[i];
     }
     ceil_mode_padding.emplace_back(left_padding, right_padding);
   }
   return ceil_mode_padding;
 }
 
-// Creates an XLA padding configuration from a padding attribute value.
-xla::PaddingConfig MakeXlaPaddingConfig(absl::Span<const int64_t> padding,
-                                        const xla::Shape& input_shape,
-                                        absl::Span<const int64_t> kernel_size,
-                                        absl::Span<const int64_t> stride,
-                                        bool ceil_mode) {
+xla::PaddingConfig MakeXlaPaddingConfig(absl::Span<const int64_t> padding) {
   xla::PaddingConfig padding_config;
   for (int i = 0; i < 2; ++i) {
     padding_config.add_dimensions();
   }
-  auto ceil_mode_padding =
-      CeilModePadding(padding, input_shape, kernel_size, stride, ceil_mode);
-  for (int i = 0; i < padding.size(); ++i) {
+  for (int pad : padding) {
     xla::PaddingConfig::PaddingConfigDimension* dims =
         padding_config.add_dimensions();
-    const auto dim_padding = ceil_mode_padding[i];
+    dims->set_edge_padding_low(pad);
+    dims->set_edge_padding_high(pad);
+  }
+  return padding_config;
+}
+
+// Creates an XLA padding configuration from a padding attribute value.
+xla::PaddingConfig MakeXlaPaddingConfig(
+    std::vector<std::pair<int64_t, int64_t>> padding) {
+  xla::PaddingConfig padding_config;
+  for (int i = 0; i < 2; ++i) {
+    padding_config.add_dimensions();
+  }
+  for (const auto& dim_padding : padding) {
+    xla::PaddingConfig::PaddingConfigDimension* dims =
+        padding_config.add_dimensions();
     dims->set_edge_padding_low(dim_padding.first);
     dims->set_edge_padding_high(dim_padding.second);
   }
@@ -445,8 +448,9 @@ MaxPoolResult BuildMaxPoolNd(xla::XlaOp input, int64_t spatial_dim_count,
   const xla::Shape& input_shape =
       ShapeHelper::ShapeOfXlaOp(batch_input_info.batch_input);
   xla::XlaOp init_value = xla::MinValue(builder, input_shape.element_type());
-  xla::PaddingConfig padding_config = MakeXlaPaddingConfig(
-      padding, input_shape, kernel_size, stride, ceil_mode);
+  std::vector<std::pair<int64_t, int64_t>> ceil_padding = CeilModePadding(
+      padding, input_shape, kernel_size, stride, ceil_mode, false);
+  xla::PaddingConfig padding_config = MakeXlaPaddingConfig(ceil_padding);
   xla::XlaOp padded_input =
       xla::Pad(batch_input_info.batch_input, init_value, padding_config);
   PoolingOpAttributes pooling_op_attributes =
@@ -485,8 +489,8 @@ xla::XlaOp BuildMaxPoolNdBackward(xla::XlaOp out_backprop, xla::XlaOp input,
       MakePoolingOpAttributes(/*kernel_size_attr=*/kernel_size,
                               /*stride_attr=*/stride);
   std::vector<std::pair<int64_t, int64_t>> window_padding;
-  const auto ceil_mode_padding =
-      CeilModePadding(padding, input_shape, kernel_size, stride, ceil_mode);
+  const auto ceil_mode_padding = CeilModePadding(
+      padding, input_shape, kernel_size, stride, ceil_mode, false);
   window_padding.resize(2);
   window_padding.insert(window_padding.end(), ceil_mode_padding.begin(),
                         ceil_mode_padding.end());
@@ -571,15 +575,27 @@ xla::XlaOp BuildAvgPoolNd(xla::XlaOp input, int64_t spatial_dim_count,
   BatchInput batch_input_info = CreateBatchInput(input, spatial_dim_count);
   const xla::Shape& input_shape =
       ShapeHelper::ShapeOfXlaOp(batch_input_info.batch_input);
-  const auto ceil_mode_padding =
-      CeilModePadding(padding, input_shape, kernel_size, stride, ceil_mode);
+
+  if (count_include_pad) {
+    xla::PaddingConfig padding_config = MakeXlaPaddingConfig(padding);
+    auto dtype = ShapeHelper::ShapeOfXlaOp(input).element_type();
+    auto padding_value = XlaHelpers::ScalarValue(0, dtype, input.builder());
+    batch_input_info.batch_input =
+        xla::Pad(batch_input_info.batch_input, padding_value, padding_config);
+  }
+
+  const auto ceil_mode_padding = CeilModePadding(
+      padding, ShapeHelper::ShapeOfXlaOp(batch_input_info.batch_input),
+      kernel_size, stride, ceil_mode, count_include_pad);
+
   xla::XlaOp batch_result = xla::AvgPool(
       /*operand=*/batch_input_info.batch_input,
       /*kernel_size=*/pooling_op_attributes.kernel_size,
       /*stride=*/pooling_op_attributes.stride,
       /*padding=*/ceil_mode_padding,
       /*data_format=*/MakeNCHWFormat(spatial_dim_count),
-      /*counts_include_padding=*/count_include_pad);
+      /*counts_include_padding=*/false);  // already compensated in XLA
+
   return RemoveTrivialBatch(/*batch=*/batch_result,
                             /*original_rank=*/batch_input_info.original_rank,
                             /*spatial_dim_count=*/spatial_dim_count);
@@ -597,8 +613,8 @@ xla::XlaOp BuildAvgPoolNdBackward(xla::XlaOp out_backprop, xla::XlaOp input,
   BatchInput batch_input_info = CreateBatchInput(input, spatial_dim_count);
   const xla::Shape& gradients_shape =
       ShapeHelper::ShapeOfXlaOp(batch_input_info.batch_input);
-  const auto ceil_mode_padding =
-      CeilModePadding(padding, gradients_shape, kernel_size, stride, ceil_mode);
+  const auto ceil_mode_padding = CeilModePadding(
+      padding, gradients_shape, kernel_size, stride, ceil_mode, false);
   BatchInput batch_out_backprop_info =
       CreateBatchInput(out_backprop, spatial_dim_count);
   xla::XlaOp batch_result = xla::AvgPoolGrad(

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -811,13 +811,15 @@ XLATensorPtr avg_pool_nd(const XLATensorPtr& input, int64_t spatial_dim_count,
                          std::vector<int64_t> kernel_size,
                          std::vector<int64_t> stride,
                          std::vector<int64_t> padding, bool ceil_mode,
-                         bool count_include_pad) {
+                         bool count_include_pad,
+                         std::optional<int> divisor_override) {
   kernel_size = CheckIntList(kernel_size, spatial_dim_count, "kernel_size");
   stride = CheckIntList(stride, spatial_dim_count, "stride", kernel_size);
   padding = CheckIntList(padding, spatial_dim_count, "padding");
   return input->CreateFrom(torch::lazy::MakeNode<AvgPoolNd>(
       input->GetIrValue(), spatial_dim_count, std::move(kernel_size),
-      std::move(stride), std::move(padding), ceil_mode, count_include_pad));
+      std::move(stride), std::move(padding), ceil_mode, count_include_pad,
+      divisor_override));
 }
 
 XLATensorPtr avg_pool_nd_backward(const XLATensorPtr& out_backprop,

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -218,7 +218,8 @@ XLATensorPtr avg_pool_nd(const XLATensorPtr& input, int64_t spatial_dim_count,
                          std::vector<int64_t> kernel_size,
                          std::vector<int64_t> stride,
                          std::vector<int64_t> padding, bool ceil_mode,
-                         bool count_include_pad);
+                         bool count_include_pad,
+                         std::optional<int> divisor_override);
 
 XLATensorPtr avg_pool_nd_backward(const XLATensorPtr& out_backprop,
                                   const XLATensorPtr& input,


### PR DESCRIPTION
By supporting divisor overrides and ceil_mode + count_include_pad property.

When count_include_pad is True, the number of paddings also appear in the denominator. But, if ceil_mode is also true, then, when we round, we can introduce extra padding. ** these paddings are NOT counted in the denominator** Therefore, when ceil_mode is true, we need to manually pad to distinguish padding that should count for denominator and those that shouldnt (i.e. those introduced by ceil_mode)