### PR TITLE
Force install `google-cloud-sdk-gke-gcloud-auth-plugin` to enable TPUCI run_e2e_tests

### DIFF
--- a/infra/terraform_modules/xla_docker_build/xla_docker_build.tf
+++ b/infra/terraform_modules/xla_docker_build/xla_docker_build.tf
@@ -131,7 +131,8 @@ locals {
 
           # Try to setup kubectl credentials the new way,
           # see https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
-          apt-get install google-cloud-sdk-gke-gcloud-auth-plugin -o DPkg::options::="--force-overwrite" -y
+          apt-get uninstall google-cloud-cli-gke-gcloud-auth-plugin
+          apt-get install google-cloud-sdk-gke-gcloud-auth-plugin -y -o DPkg::options::="--force-overwrite"
           export USE_GKE_GCLOUD_AUTH_PLUGIN=True
           apt-get install kubectl
           gcloud container clusters get-credentials $_CLUSTER_NAME --zone $_CLUSTER_ZONE

--- a/infra/terraform_modules/xla_docker_build/xla_docker_build.tf
+++ b/infra/terraform_modules/xla_docker_build/xla_docker_build.tf
@@ -131,7 +131,7 @@ locals {
 
           # Try to setup kubectl credentials the new way,
           # see https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
-          apt-get uninstall google-cloud-cli-gke-gcloud-auth-plugin
+          apt-get remove google-cloud-cli-gke-gcloud-auth-plugin
           apt-get install google-cloud-sdk-gke-gcloud-auth-plugin -y -o DPkg::options::="--force-overwrite"
           export USE_GKE_GCLOUD_AUTH_PLUGIN=True
           apt-get install kubectl

--- a/infra/terraform_modules/xla_docker_build/xla_docker_build.tf
+++ b/infra/terraform_modules/xla_docker_build/xla_docker_build.tf
@@ -131,7 +131,7 @@ locals {
 
           # Try to setup kubectl credentials the new way,
           # see https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
-          apt-get install google-cloud-sdk-gke-gcloud-auth-plugin -o DPkg::options::="--force-overwrite"
+          apt-get install google-cloud-sdk-gke-gcloud-auth-plugin -o DPkg::options::="--force-overwrite" -y
           export USE_GKE_GCLOUD_AUTH_PLUGIN=True
           apt-get install kubectl
           gcloud container clusters get-credentials $_CLUSTER_NAME --zone $_CLUSTER_ZONE


### PR DESCRIPTION
since Jan30, TPU CI start to failed due to there is the existing `google-cloud-cli-gke-gcloud-auth-plugin` before install `google-cloud-sdk-gke-gcloud-auth-plugin`, 

so to bring TPU-CI/CI green, confirm force install `google-cloud-sdk-gke-gcloud-auth-plugin` by `--force-overwrite`