### PR TITLE
Fix distributed checkpoint errors when PyTorch CUDA is enabled.

### DIFF
--- a/test/spmd/test_xla_distributed_checkpoint.py
+++ b/test/spmd/test_xla_distributed_checkpoint.py
@@ -93,7 +93,10 @@ class EndToEndCheckpointTest(DistributedCheckpointTestBase):
     model_out_state_dict = model_out.state_dict()
     dist_cp.save_state_dict(
         state_dict=model_in_state_dict,
-        storage_writer=dist_cp.FileSystemWriter(chkpt_path),
+        storage_writer=dist_cp.FileSystemWriter(
+            chkpt_path,
+            per_thread_copy_ahead=0,
+        ),
         planner=save_planner,
         no_dist=no_dist,
     )

--- a/torch_xla/experimental/distributed_checkpoint/manager.py
+++ b/torch_xla/experimental/distributed_checkpoint/manager.py
@@ -220,7 +220,10 @@ class CheckpointManager:
       self._delete_chkpt_at_step(step)
       dist_cp.save_state_dict(
           state_dict=state_dict,
-          storage_writer=FsspecWriter(path),
+          storage_writer=FsspecWriter(
+              path,
+              per_thread_copy_ahead=0,
+          ),
           planner=xc.SPMDSavePlanner(),
           process_group=self.pg,
       )


### PR DESCRIPTION
This PR fixes the errors found in #6070 CI. Specifically, the tests on `test/spmd/test_xla_distributed_checkpoint.py` fail due to an assertion `tensor.is_cpu`.

**Problem:** PyTorch filesystem writers don't support XLA
- If PyTorch is compiled with CUDA support, we try to move tensors asynchronously to CPU
- However, we only do so for tensors whose device is `cuda`
- Since XLA tensors' device are not `cuda`, those are not moved to CPU (which is why the assertion breaks)

**Solution:** don't allow asynchronous copy
- AFAIU, XLA doesn't support it (XLA to CPU asynchronous copy)
- Compiling PyTorch without CUDA support (previous default) fallbacked to this behavior

@miladm @JackCaoG 