### PR TITLE
Fix model skip yaml file not found issue

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -164,7 +164,7 @@ class TorchBenchModelLoader(ModelLoader):
 
     Looks for `names` in the current directory, up to its two direct parents.
     """
-    for dir in ("./", "../", "../../"):
+    for dir in ("./", "../", "../../", "../../../"):
       for name in names:
         path = os.path.join(dir, name)
         if exists(path):
@@ -193,7 +193,7 @@ class TorchBenchModelLoader(ModelLoader):
     its lists of models into sets of models.
     """
 
-    benchmarks_dir = self._find_near_file(("benchmarks",))
+    benchmarks_dir = self._find_near_file(("pytorch/benchmarks",))
     assert benchmarks_dir is not None, "PyTorch benchmarks folder not found."
 
     skip_file = os.path.join(benchmarks_dir, "dynamo",


### PR DESCRIPTION
1. Also search for path `../../../` in case user place xla under pytorch folder.
2. Both xla and pytorch have a subfolder `benchmarks`.  Use `pytorch/benchmarks` instead to prevent searching under xla.