### PR TITLE
Disambiguate `benchmarks` directory search.

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -193,11 +193,10 @@ class TorchBenchModelLoader(ModelLoader):
     its lists of models into sets of models.
     """
 
-    benchmarks_dir = self._find_near_file(("benchmarks",))
+    benchmarks_dir = self._find_near_file(("benchmarks/dynamo",))
     assert benchmarks_dir is not None, "PyTorch benchmarks folder not found."
 
-    skip_file = os.path.join(benchmarks_dir, "dynamo",
-                             "torchbench_skip_models.yaml")
+    skip_file = os.path.join(benchmarks_dir, "torchbench_skip_models.yaml")
     with open(skip_file) as f:
       data = yaml.safe_load(f)
 


### PR DESCRIPTION
Follow-up: #6428

This PR disambiguates `pytorch/benchmarks` directory from `xla/benchmarks` directory. In order to do that without relying on the name of the directory that the repo lives, we look for `benchmarks/dynamo`, instead. Works, since the `dynamo` directory only exists on `pytorch/benchmarks`.

cc @miladm 