### PR TITLE
Fix benchmark process terminaion issue

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -313,19 +313,16 @@ class TorchBenchModel(BenchmarkModel):
 
   @functools.lru_cache(maxsize=1)
   def benchmark_cls(self):
-    try:
-      module = importlib.import_module(
-          f"torchbenchmark.models.{self.model_name}")
-    except ModuleNotFoundError:
+    for module_src in [
+        f"torchbenchmark.models.{self.model_name}",
+        f"torchbenchmark.models.fb.{self.model_name}"
+    ]:
       try:
-        module = importlib.import_module(
-            f"torchbenchmark.models.fb.{self.model_name}")
+        module = importlib.import_module(module_src)
+        return getattr(module, "Model", None)
       except ModuleNotFoundError:
-        logger.warning(
-            f"Unable to import model {self.model_name} even with falling back to fb model."
-        )
-        return None
-    return getattr(module, "Model", None)
+        logger.warning(f"Unable to import {module_src}.")
+    return None
 
   def load_benchmark(self):
     cant_change_batch_size = (not getattr(self.benchmark_cls(),

--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -317,8 +317,12 @@ class TorchBenchModel(BenchmarkModel):
       module = importlib.import_module(
           f"torchbenchmark.models.{self.model_name}")
     except ModuleNotFoundError:
-      module = importlib.import_module(
-          f"torchbenchmark.models.fb.{self.model_name}")
+      try:
+        module = importlib.import_module(
+             f"torchbenchmark.models.fb.{self.model_name}")
+      except ModuleNotFoundError:
+        logger.warning(f"Unable to import model {self.model_name} even with falling back to fb model.")
+        return None
     return getattr(module, "Model", None)
 
   def load_benchmark(self):

--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -319,9 +319,11 @@ class TorchBenchModel(BenchmarkModel):
     except ModuleNotFoundError:
       try:
         module = importlib.import_module(
-             f"torchbenchmark.models.fb.{self.model_name}")
+            f"torchbenchmark.models.fb.{self.model_name}")
       except ModuleNotFoundError:
-        logger.warning(f"Unable to import model {self.model_name} even with falling back to fb model.")
+        logger.warning(
+            f"Unable to import model {self.model_name} even with falling back to fb model."
+        )
         return None
     return getattr(module, "Model", None)
 


### PR DESCRIPTION
Benchmark run process will be terminated once we are unable to load the model.

Fixes https://github.com/pytorch/xla/issues/6438.