### PR TITLE
Add `benchmarks/dynamo` search option for finding PyTorch skip file.

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -193,7 +193,8 @@ class TorchBenchModelLoader(ModelLoader):
     its lists of models into sets of models.
     """
 
-    benchmarks_dir = self._find_near_file(("pytorch/benchmarks",))
+    benchmarks_dir = self._find_near_file(
+        ("pytorch/benchmarks", "benchmarks/dynamo"))
     assert benchmarks_dir is not None, "PyTorch benchmarks folder not found."
 
     skip_file = os.path.join(benchmarks_dir, "dynamo",


### PR DESCRIPTION
Discussion on: #6434 

cc @miladm 