### PR TITLE
follow-up for #6420

### DIFF
--- a/infra/terraform_modules/xla_docker_build/xla_docker_build.tf
+++ b/infra/terraform_modules/xla_docker_build/xla_docker_build.tf
@@ -131,8 +131,8 @@ locals {
 
           # Try to setup kubectl credentials the new way,
           # see https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
-          apt-get remove google-cloud-cli-gke-gcloud-auth-plugin
-          apt-get install google-cloud-sdk-gke-gcloud-auth-plugin -y -o DPkg::options::="--force-overwrite"
+          apt-get -y remove google-cloud-cli-gke-gcloud-auth-plugin
+          apt-get -y install google-cloud-sdk-gke-gcloud-auth-plugin -o DPkg::options::="--force-overwrite"
           export USE_GKE_GCLOUD_AUTH_PLUGIN=True
           apt-get install kubectl
           gcloud container clusters get-credentials $_CLUSTER_NAME --zone $_CLUSTER_ZONE


### PR DESCRIPTION
TPU CI still [failed](https://github.com/pytorch/xla/runs/21128265706) due to:
```
Step #4 - "run_e2e_tests": + apt-get remove google-cloud-cli-gke-gcloud-auth-plugin
Step #4 - "run_e2e_tests": Reading package lists...
Step #4 - "run_e2e_tests": Building dependency tree...
Step #4 - "run_e2e_tests": Reading state information...
Step #4 - "run_e2e_tests": The following packages will be REMOVED:
Step #4 - "run_e2e_tests":   google-cloud-cli-gke-gcloud-auth-plugin
Step #4 - "run_e2e_tests": 0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
Step #4 - "run_e2e_tests": After this operation, 11.3 MB disk space will be freed.
Step #4 - "run_e2e_tests": Do you want to continue? [Y/n] Abort.
Finished Step #4 - "run_e2e_tests"
```