### PR TITLE
Revert "Avoid fallback for avg_pool -"

### DIFF
--- a/test/cpp/test_tensor.cpp
+++ b/test/cpp/test_tensor.cpp
@@ -316,8 +316,7 @@ TEST_F(TensorTest, TestAvgPool2D) {
                            /*kernel_size=*/{kernel_size, kernel_size},
                            /*stride=*/{stride, stride},
                            /*padding=*/{padding, padding},
-                           /*ceil_mode=*/false, count_include_pad,
-                           /*divisor_override=*/std::nullopt);
+                           /*ceil_mode=*/false, count_include_pad);
         ForEachDevice([&](const torch::lazy::BackendDevice& device) {
           XLATensorPtr dev_input = XLATensor::Create(input, device);
           XLATensorPtr dev_output = tensor_methods::avg_pool_nd(
@@ -326,8 +325,7 @@ TEST_F(TensorTest, TestAvgPool2D) {
               /*kernel_size=*/{kernel_size, kernel_size},
               /*stride=*/{stride, stride},
               /*padding=*/{padding, padding},
-              /*ceil_mode=*/false, count_include_pad,
-              /*divisor_override=*/std::nullopt);
+              /*ceil_mode=*/false, count_include_pad);
           AllClose(output, dev_output);
         });
       }
@@ -346,8 +344,7 @@ TEST_F(TensorTest, TestAvgPool2DNonSquare) {
             /*kernel_size=*/{kernel_size, kernel_size + 1},
             /*stride=*/{stride, stride + 1},
             /*padding=*/{padding, padding + 1}, /*ceil_mode=*/false,
-            /*count_include_pad=*/count_include_pad,
-            /*divisor_override=*/std::nullopt);
+            /*count_include_pad=*/count_include_pad);
         ForEachDevice([&](const torch::lazy::BackendDevice& device) {
           XLATensorPtr dev_input = XLATensor::Create(input, device);
           XLATensorPtr dev_output = tensor_methods::avg_pool_nd(
@@ -357,8 +354,7 @@ TEST_F(TensorTest, TestAvgPool2DNonSquare) {
               /*stride=*/{stride, stride + 1},
               /*padding=*/{padding, padding + 1},
               /*ceil_mode=*/false,
-              /*count_include_pad=*/count_include_pad,
-              /*divisor_override=*/std::nullopt);
+              /*count_include_pad=*/count_include_pad);
           AllClose(output, dev_output);
         });
       }

--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -737,17 +737,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.avg_pool2d, args, kwargs)
 
-  def test_aten_avg_pool2d_2(self):
-    args = (
-        torch.randn((1, 192, 40, 40)).to(torch.float32),
-        [3, 3],
-        [1, 1],
-        [1, 1],
-        True,
-    )
-    kwargs = dict()
-    run_export_and_compare(self, torch.ops.aten.avg_pool2d, args, kwargs)
-
   def test_aten_avg_pool3d_0(self):
     args = (
         torch.randn((1, 3, 10, 10, 10)).to(torch.float32),

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -760,11 +760,17 @@ at::Tensor XLANativeFunctions::avg_pool2d(
     at::IntArrayRef padding, bool ceil_mode, bool count_include_pad,
     c10::optional<int64_t> divisor_override) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
+  if ((ceil_mode && count_include_pad) || divisor_override) {
+    return at::native::call_fallback_fn<
+        &xla_cpu_fallback, ATEN_OP(avg_pool2d)>::call(self, kernel_size, stride,
+                                                      padding, ceil_mode,
+                                                      count_include_pad,
+                                                      divisor_override);
+  }
   return bridge::AtenFromXlaTensor(tensor_methods::avg_pool_nd(
       bridge::GetXlaTensor(self), /*spatial_dim_count=*/2,
       XlaHelpers::I64List(kernel_size), XlaHelpers::I64List(stride),
-      XlaHelpers::I64List(padding), ceil_mode, count_include_pad,
-      divisor_override));
+      XlaHelpers::I64List(padding), ceil_mode, count_include_pad));
 }
 
 at::Tensor XLANativeFunctions::avg_pool2d_backward(
@@ -791,11 +797,17 @@ at::Tensor XLANativeFunctions::avg_pool3d(
     at::IntArrayRef padding, bool ceil_mode, bool count_include_pad,
     c10::optional<int64_t> divisor_override) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
+  if ((ceil_mode && count_include_pad) || divisor_override) {
+    return at::native::call_fallback_fn<
+        &xla_cpu_fallback, ATEN_OP(avg_pool3d)>::call(self, kernel_size, stride,
+                                                      padding, ceil_mode,
+                                                      count_include_pad,
+                                                      divisor_override);
+  }
   return bridge::AtenFromXlaTensor(tensor_methods::avg_pool_nd(
       bridge::GetXlaTensor(self), /*spatial_dim_count=*/3,
       XlaHelpers::I64List(kernel_size), XlaHelpers::I64List(stride),
-      XlaHelpers::I64List(padding), ceil_mode, count_include_pad,
-      divisor_override));
+      XlaHelpers::I64List(padding), ceil_mode, count_include_pad));
 }
 
 at::Tensor XLANativeFunctions::avg_pool3d_backward(

--- a/torch_xla/csrc/ops/avg_pool_nd.h
+++ b/torch_xla/csrc/ops/avg_pool_nd.h
@@ -10,8 +10,7 @@ class AvgPoolNd : public XlaNode {
   AvgPoolNd(const torch::lazy::Value& input, int64_t spatial_dim_count,
             std::vector<int64_t> kernel_size, std::vector<int64_t> stride,
             std::vector<int64_t> padding, bool ceil_mode,
-            bool count_include_pad,
-            std::optional<int> divisor_override = std::nullopt);
+            bool count_include_pad);
 
   torch::lazy::NodePtr Clone(torch::lazy::OpList operands) const override;
 
@@ -41,7 +40,6 @@ class AvgPoolNd : public XlaNode {
   // Whether the counts used to compute the average should include the added
   // padding.
   bool count_include_pad_;
-  std::optional<int> divisor_override_;
 };
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -823,15 +823,13 @@ XLATensorPtr avg_pool_nd(const XLATensorPtr& input, int64_t spatial_dim_count,
                          std::vector<int64_t> kernel_size,
                          std::vector<int64_t> stride,
                          std::vector<int64_t> padding, bool ceil_mode,
-                         bool count_include_pad,
-                         std::optional<int> divisor_override) {
+                         bool count_include_pad) {
   kernel_size = CheckIntList(kernel_size, spatial_dim_count, "kernel_size");
   stride = CheckIntList(stride, spatial_dim_count, "stride", kernel_size);
   padding = CheckIntList(padding, spatial_dim_count, "padding");
   return input->CreateFrom(torch::lazy::MakeNode<AvgPoolNd>(
       input->GetIrValue(), spatial_dim_count, std::move(kernel_size),
-      std::move(stride), std::move(padding), ceil_mode, count_include_pad,
-      divisor_override));
+      std::move(stride), std::move(padding), ceil_mode, count_include_pad));
 }
 
 XLATensorPtr avg_pool_nd_backward(const XLATensorPtr& out_backprop,

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -222,8 +222,7 @@ XLATensorPtr avg_pool_nd(const XLATensorPtr& input, int64_t spatial_dim_count,
                          std::vector<int64_t> kernel_size,
                          std::vector<int64_t> stride,
                          std::vector<int64_t> padding, bool ceil_mode,
-                         bool count_include_pad,
-                         std::optional<int> divisor_override);
+                         bool count_include_pad);
 
 XLATensorPtr avg_pool_nd_backward(const XLATensorPtr& out_backprop,
                                   const XLATensorPtr& input,


### PR DESCRIPTION
Reverts pytorch/xla#6409 to test if this is related to 
```
======================================================================
[2703](https://github.com/pytorch/xla/actions/runs/7747175825/job/21129058373#step:7:2704)FAIL: test_pooling_shape_xla (__main__.TestPoolingNNDeviceTypeXLA)
[2704](https://github.com/pytorch/xla/actions/runs/7747175825/job/21129058373#step:7:2705)Test the output shape calculation for pooling functions
[2705](https://github.com/pytorch/xla/actions/runs/7747175825/job/21129058373#step:7:2706)----------------------------------------------------------------------
[2706](https://github.com/pytorch/xla/actions/runs/7747175825/job/21129058373#step:7:2707)Traceback (most recent call last):
[2707](https://github.com/pytorch/xla/actions/runs/7747175825/job/21129058373#step:7:2708)  File "/opt/conda/lib/python3.8/site-packages/torch/testing/_internal/common_utils.py", line 2697, in wrapper
[2708](https://github.com/pytorch/xla/actions/runs/7747175825/job/21129058373#step:7:2709)    method(*args, **kwargs)
[2709](https://github.com/pytorch/xla/actions/runs/7747175825/job/21129058373#step:7:2710)  File "/opt/conda/lib/python3.8/site-packages/torch/testing/_internal/common_device_type.py", line 418, in instantiated_test
[2710](https://github.com/pytorch/xla/actions/runs/7747175825/job/21129058373#step:7:2711)    result = test(self, **param_kwargs)
[2711](https://github.com/pytorch/xla/actions/runs/7747175825/job/21129058373#step:7:2712)  File "/tmp/pytorch/xla/test/../../test/nn/test_pooling.py", line 705, in test_pooling_shape
[2712](https://github.com/pytorch/xla/actions/runs/7747175825/job/21129058373#step:7:2713)    check((1, 1, 3, 3, 4), (1, 1, 5, 6, 7), kernel_size=1, stride=2, padding=0, ceil_mode=True)
[2713](https://github.com/pytorch/xla/actions/runs/7747175825/job/21129058373#step:7:2714)  File "/tmp/pytorch/xla/test/../../test/nn/test_pooling.py", line 703, in check
[2714](https://github.com/pytorch/xla/actions/runs/7747175825/job/21129058373#step:7:2715)    self.assertEqual(op(t, *args, **kwargs).shape, expected_out_shape[:i + 2])
[2715](https://github.com/pytorch/xla/actions/runs/7747175825/job/21129058373#step:7:2716)  File "/tmp/pytorch/xla/test/pytorch_test_base.py", line 693, in assertEqual
[2716](https://github.com/pytorch/xla/actions/runs/7747175825/job/21129058373#step:7:2717)    return DeviceTypeTestBase.assertEqual(self, x, y, *args, **kwargs)
[2717](https://github.com/pytorch/xla/actions/runs/7747175825/job/21129058373#step:7:2718)  File "/opt/conda/lib/python3.8/site-packages/torch/testing/_internal/common_utils.py", line 3574, in assertEqual
[2718](https://github.com/pytorch/xla/actions/runs/7747175825/job/21129058373#step:7:2719)    raise error_metas.pop()[0].to_error(
[2719](https://github.com/pytorch/xla/actions/runs/7747175825/job/21129058373#step:7:2720)AssertionError: Scalars are not close!
[2720](https://github.com/pytorch/xla/actions/runs/7747175825/job/21129058373#step:7:2721)
[2721](https://github.com/pytorch/xla/actions/runs/7747175825/job/21129058373#step:7:2722)Expected 3 but got 4.
[2722](https://github.com/pytorch/xla/actions/runs/7747175825/job/21129058373#step:7:2723)Absolute difference: 1 (up to 0.001 allowed)
[2723](https://github.com/pytorch/xla/actions/runs/7747175825/job/21129058373#step:7:2724)Relative difference: 0.3333333333333333 (up to 0.001 allowed)
```
on master