### PR TITLE
torchbench_model.py: fix YAML skip file path

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -193,11 +193,11 @@ class TorchBenchModelLoader(ModelLoader):
     its lists of models into sets of models.
     """
 
-    benchmarks_dir = self._find_near_file(
-        ("pytorch/benchmarks", "benchmarks/dynamo"))
-    assert benchmarks_dir is not None, "PyTorch benchmarks folder not found."
+    benchmarks_dynamo_dir = self._find_near_file(
+        ("pytorch/benchmarks/dynamo", "benchmarks/dynamo"))
+    assert benchmarks_dynamo_dir is not None, "PyTorch benchmarks folder not found."
 
-    skip_file = os.path.join(benchmarks_dir, "dynamo",
+    skip_file = os.path.join(benchmarks_dynamo_dir,
                              "torchbench_skip_models.yaml")
     with open(skip_file) as f:
       data = yaml.safe_load(f)


### PR DESCRIPTION
This fixes the following error, caught by yesterday's nightly run:
```
$ cd pytorch
$ python xla/benchmarks/experiment_runner.py --test=eval --test=train --xla=PJRT --dynamo=None --dynamo=openxla --dynamo=openxla_eval --suite-name=torchbench --accelerator=cuda --output-dirname=/tmp/foo --repeat=8 --print-subprocess --timestamp=1706835612
[...]
Traceback (most recent call last):
  File "/home/ecg/nightly_runs/2024-02-02/pytorch/xla/benchmarks/experiment_runner.py", line 908, in <module>
    main()
  File "/home/ecg/nightly_runs/2024-02-02/pytorch/xla/benchmarks/experiment_runner.py", line 903, in main
    runner = ExperimentRunner(args)
  File "/home/ecg/nightly_runs/2024-02-02/pytorch/xla/benchmarks/experiment_runner.py", line 41, in __init__
    self.model_loader = TorchBenchModelLoader(self._args)
  File "/home/ecg/nightly_runs/2024-02-02/pytorch/xla/benchmarks/torchbench_model.py", line 160, in __init__
    self.skip = self.get_skip_data()
  File "/home/ecg/nightly_runs/2024-02-02/pytorch/xla/benchmarks/torchbench_model.py", line 202, in get_skip_data
    with open(skip_file) as f:
FileNotFoundError: [Errno 2] No such file or directory: '/home/ecg/nightly_runs/2024-02-02/pytorch/benchmarks/dynamo/dynamo/torchbench_skip_models.yaml'
```