### PR TITLE
Fix some more core aten ops

### DIFF
--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -1371,41 +1371,38 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.div.Scalar, args, kwargs)
 
-  @unittest.skip
   def test_aten_div_Scalar_mode_0(self):
+    def aten_div_Scalar_mode_rounding_mode_trunc(input, other):
+      return torch.ops.aten.div.Tensor_mode(input, other, rounding_mode='trunc')
+
     args = (
         torch.randn((10, 10)).to(torch.float32),
         0.123,
     )
-    kwargs = dict((
-        "rounding_mode",
-        "trunc",
-    ))
-    run_export_and_compare(self, torch.ops.aten.div.Scalar_mode, args, kwargs)
+    kwargs = dict()
+    run_export_and_compare(self, aten_div_Scalar_mode_rounding_mode_trunc, args, kwargs)
 
-  @unittest.skip
   def test_aten_div_Scalar_mode_1(self):
+    def aten_div_Scalar_mode_rounding_mode_trunc(input, other):
+      return torch.ops.aten.div.Tensor_mode(input, other, rounding_mode='trunc')
+
     args = (
         torch.randn((10, 10)).to(torch.float16),
         0.123,
     )
-    kwargs = dict((
-        "rounding_mode",
-        "trunc",
-    ))
-    run_export_and_compare(self, torch.ops.aten.div.Scalar_mode, args, kwargs)
+    kwargs = dict()
+    run_export_and_compare(self, aten_div_Scalar_mode_rounding_mode_trunc, args, kwargs)
 
-  @unittest.skip
   def test_aten_div_Scalar_mode_2(self):
+    def aten_div_Scalar_mode_rounding_mode_trunc(input, other):
+      return torch.ops.aten.div.Tensor_mode(input, other, rounding_mode='trunc')
+
     args = (
         torch.randint(0, 10, (10, 10)).to(torch.int32),
         0.123,
     )
-    kwargs = dict((
-        "rounding_mode",
-        "trunc",
-    ))
-    run_export_and_compare(self, torch.ops.aten.div.Scalar_mode, args, kwargs)
+    kwargs = dict()
+    run_export_and_compare(self, aten_div_Scalar_mode_rounding_mode_trunc, args, kwargs)
 
   def test_aten_div_Tensor_0(self):
     args = (
@@ -1431,29 +1428,27 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.div.Tensor, args, kwargs)
 
-  @unittest.skip
   def test_aten_div_Tensor_mode_0(self):
-    args = (
-        torch.randn((10, 10)).to(torch.float32),
-        torch.randn((10, 10)).to(torch.float32),
-    )
-    kwargs = dict((
-        "rounding_mode",
-        "trunc",
-    ))
-    run_export_and_compare(self, torch.ops.aten.div.Tensor_mode, args, kwargs)
+    def aten_div_Tensor_mode_rounding_mode_trunc(input, other):
+      return torch.ops.aten.div.Tensor_mode(input, other, rounding_mode='trunc')
 
-  @unittest.skip
+    args = (
+        torch.randn((10, 10)).to(torch.float32),
+        torch.randn((10, 10)).to(torch.float32),
+    )
+    kwargs = dict()
+    run_export_and_compare(self, aten_div_Tensor_mode_rounding_mode_trunc, args, kwargs)
+
   def test_aten_div_Tensor_mode_1(self):
+    def aten_div_Tensor_mode_rounding_mode_trunc(input, other):
+      return torch.ops.aten.div.Tensor_mode(input, other, rounding_mode='trunc')
+
     args = (
         torch.randn((10, 10)).to(torch.float16),
         torch.randn((10, 10)).to(torch.float16),
     )
-    kwargs = dict((
-        "rounding_mode",
-        "trunc",
-    ))
-    run_export_and_compare(self, torch.ops.aten.div.Tensor_mode, args, kwargs)
+    kwargs = dict()
+    run_export_and_compare(self, aten_div_Tensor_mode_rounding_mode_trunc, args, kwargs)
 
   def test_aten_embedding_0(self):
     args = (

--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -3998,7 +3998,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.sin, args, kwargs)
 
-  @unittest.skip
   def test_aten_sin_2(self):
     args = (torch.randint(0, 10, (10, 10)).to(torch.int32),)
     kwargs = dict()

--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -16,8 +16,8 @@ def diff_output(testcase, output1, output2, rtol, atol, equal_nan=True):
     output2_cpu = output2.detach().cpu()
     if output2_cpu.dtype != output1.dtype:
       output2_cpu = output2_cpu.to(output1.dtype)
-    # import pdb
-    # pdb.set_trace()
+    import pdb
+    pdb.set_trace()
     testcase.assertTrue(
         torch.allclose(
             output1, output2_cpu, atol=atol, rtol=rtol, equal_nan=equal_nan))
@@ -48,6 +48,8 @@ def run_export_and_compare(testcase,
                            rtol=1e-5,
                            equal_nan=True):
   device = xm.xla_device()
+  import pdb
+  pdb.set_trace()
   with testcase.subTest('torch_eval'):
     res = func(*args, **kwargs)
     with testcase.subTest('torch_xla_eval'):
@@ -1373,7 +1375,7 @@ class AtenOpTest(unittest.TestCase):
 
   def test_aten_div_Scalar_mode_0(self):
     def aten_div_Scalar_mode_rounding_mode_trunc(input, other):
-      return torch.ops.aten.div.Tensor_mode(input, other, rounding_mode='trunc')
+      return torch.ops.aten.div.Scalar_mode(input, other, rounding_mode='floor')
 
     args = (
         torch.randn((10, 10)).to(torch.float32),
@@ -1384,18 +1386,19 @@ class AtenOpTest(unittest.TestCase):
 
   def test_aten_div_Scalar_mode_1(self):
     def aten_div_Scalar_mode_rounding_mode_trunc(input, other):
-      return torch.ops.aten.div.Tensor_mode(input, other, rounding_mode='trunc')
+      return torch.ops.aten.div.Scalar_mode(input, other, rounding_mode='floor')
 
     args = (
         torch.randn((10, 10)).to(torch.float16),
         0.123,
     )
+
     kwargs = dict()
     run_export_and_compare(self, aten_div_Scalar_mode_rounding_mode_trunc, args, kwargs)
 
   def test_aten_div_Scalar_mode_2(self):
     def aten_div_Scalar_mode_rounding_mode_trunc(input, other):
-      return torch.ops.aten.div.Tensor_mode(input, other, rounding_mode='trunc')
+      return torch.ops.aten.div.Scalar_mode(input, other, rounding_mode='floor')
 
     args = (
         torch.randint(0, 10, (10, 10)).to(torch.int32),

--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -16,8 +16,8 @@ def diff_output(testcase, output1, output2, rtol, atol, equal_nan=True):
     output2_cpu = output2.detach().cpu()
     if output2_cpu.dtype != output1.dtype:
       output2_cpu = output2_cpu.to(output1.dtype)
-    import pdb
-    pdb.set_trace()
+    # import pdb
+    # pdb.set_trace()
     testcase.assertTrue(
         torch.allclose(
             output1, output2_cpu, atol=atol, rtol=rtol, equal_nan=equal_nan))
@@ -48,8 +48,6 @@ def run_export_and_compare(testcase,
                            rtol=1e-5,
                            equal_nan=True):
   device = xm.xla_device()
-  import pdb
-  pdb.set_trace()
   with testcase.subTest('torch_eval'):
     res = func(*args, **kwargs)
     with testcase.subTest('torch_xla_eval'):
@@ -532,54 +530,6 @@ class AtenOpTest(unittest.TestCase):
     args = (torch.randint(0, 10, (10, 10)).to(torch.int32),)
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.argmin, args, kwargs)
-
-  @unittest.skip
-  def test_aten_as_strided_0(self):
-    args = (
-        torch.randn((10, 10)).to(torch.float32),
-        [
-            0,
-            1,
-        ],
-        [
-            0,
-            1,
-        ],
-    )
-    kwargs = dict()
-    run_export_and_compare(self, torch.ops.aten.as_strided, args, kwargs)
-
-  @unittest.skip
-  def test_aten_as_strided_1(self):
-    args = (
-        torch.randn((10, 10)).to(torch.float16),
-        [
-            0,
-            1,
-        ],
-        [
-            0,
-            1,
-        ],
-    )
-    kwargs = dict()
-    run_export_and_compare(self, torch.ops.aten.as_strided, args, kwargs)
-
-  @unittest.skip
-  def test_aten_as_strided_2(self):
-    args = (
-        torch.randint(0, 10, (10, 10)).to(torch.int32),
-        [
-            0,
-            1,
-        ],
-        [
-            0,
-            1,
-        ],
-    )
-    kwargs = dict()
-    run_export_and_compare(self, torch.ops.aten.as_strided, args, kwargs)
 
   @unittest.skip
   def test_aten_as_strided_copy_0(self):
@@ -1374,6 +1324,7 @@ class AtenOpTest(unittest.TestCase):
     run_export_and_compare(self, torch.ops.aten.div.Scalar, args, kwargs)
 
   def test_aten_div_Scalar_mode_0(self):
+
     def aten_div_Scalar_mode_rounding_mode_trunc(input, other):
       return torch.ops.aten.div.Scalar_mode(input, other, rounding_mode='floor')
 
@@ -1382,9 +1333,11 @@ class AtenOpTest(unittest.TestCase):
         0.123,
     )
     kwargs = dict()
-    run_export_and_compare(self, aten_div_Scalar_mode_rounding_mode_trunc, args, kwargs)
+    run_export_and_compare(self, aten_div_Scalar_mode_rounding_mode_trunc, args,
+                           kwargs)
 
   def test_aten_div_Scalar_mode_1(self):
+
     def aten_div_Scalar_mode_rounding_mode_trunc(input, other):
       return torch.ops.aten.div.Scalar_mode(input, other, rounding_mode='floor')
 
@@ -1392,11 +1345,12 @@ class AtenOpTest(unittest.TestCase):
         torch.randn((10, 10)).to(torch.float16),
         0.123,
     )
-
     kwargs = dict()
-    run_export_and_compare(self, aten_div_Scalar_mode_rounding_mode_trunc, args, kwargs)
+    run_export_and_compare(self, aten_div_Scalar_mode_rounding_mode_trunc, args,
+                           kwargs)
 
   def test_aten_div_Scalar_mode_2(self):
+
     def aten_div_Scalar_mode_rounding_mode_trunc(input, other):
       return torch.ops.aten.div.Scalar_mode(input, other, rounding_mode='floor')
 
@@ -1405,7 +1359,8 @@ class AtenOpTest(unittest.TestCase):
         0.123,
     )
     kwargs = dict()
-    run_export_and_compare(self, aten_div_Scalar_mode_rounding_mode_trunc, args, kwargs)
+    run_export_and_compare(self, aten_div_Scalar_mode_rounding_mode_trunc, args,
+                           kwargs)
 
   def test_aten_div_Tensor_0(self):
     args = (
@@ -1432,6 +1387,7 @@ class AtenOpTest(unittest.TestCase):
     run_export_and_compare(self, torch.ops.aten.div.Tensor, args, kwargs)
 
   def test_aten_div_Tensor_mode_0(self):
+
     def aten_div_Tensor_mode_rounding_mode_trunc(input, other):
       return torch.ops.aten.div.Tensor_mode(input, other, rounding_mode='trunc')
 
@@ -1440,9 +1396,11 @@ class AtenOpTest(unittest.TestCase):
         torch.randn((10, 10)).to(torch.float32),
     )
     kwargs = dict()
-    run_export_and_compare(self, aten_div_Tensor_mode_rounding_mode_trunc, args, kwargs)
+    run_export_and_compare(self, aten_div_Tensor_mode_rounding_mode_trunc, args,
+                           kwargs)
 
   def test_aten_div_Tensor_mode_1(self):
+
     def aten_div_Tensor_mode_rounding_mode_trunc(input, other):
       return torch.ops.aten.div.Tensor_mode(input, other, rounding_mode='trunc')
 
@@ -1451,7 +1409,8 @@ class AtenOpTest(unittest.TestCase):
         torch.randn((10, 10)).to(torch.float16),
     )
     kwargs = dict()
-    run_export_and_compare(self, aten_div_Tensor_mode_rounding_mode_trunc, args, kwargs)
+    run_export_and_compare(self, aten_div_Tensor_mode_rounding_mode_trunc, args,
+                           kwargs)
 
   def test_aten_embedding_0(self):
     args = (

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -756,6 +756,10 @@ torch_xla::XlaOpVector SiluBackward::Lower(LoweringContext* loctx) const {
 
 torch_xla::XlaOpVector Sin::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
+  if (xla::primitive_util::IsIntegralType(XlaHelpers::TypeOfXlaOp(xla_input))) {
+    xla::PrimitiveType input_type = XlaHelpers::TypeOfXlaOp(xla_input);
+    xla_input = ConvertTo(xla_input, input_type, xla::PrimitiveType::F32);
+  }
   return ReturnOp(xla::Sin(xla_input), loctx);
 }
 

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -835,7 +835,11 @@ xla::Shape SiluBackwardOutputShape(const torch::lazy::Value& grad_output,
 }
 
 xla::Shape SinOutputShape(const torch::lazy::Value& input) {
-  return GetXlaShape(input);
+  xla::Shape result_shape = GetXlaShape(input);
+  if (xla::primitive_util::IsIntegralType(result_shape.element_type())) {
+    result_shape.set_element_type(xla::PrimitiveType::F32);
+  }
+  return result_shape;
 }
 
 xla::Shape SinhOutputShape(const torch::lazy::Value& input) {


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/5848
- `aten::as_strided` is an op that should never be dispatched to torch_xla, as it is a view op and functionalization pass in PyTorch should decompose into `aten::as_strided_copy` (as noted in https://github.com/pytorch/xla/blob/master/codegen/xla_native_functions.yaml#L387, note that functionalization is, by default, enabled in torch_xla and we want that to be the default/norm).Therefore, remove this from the test.

Fixes https://github.com/pytorch/xla/issues/5861
- Introduce a wrapper to pass in kwarg

Fixes https://github.com/pytorch/xla/issues/5859
- Introduce a wrapper to pass in kwarg

Fixes https://github.com/pytorch/xla/issues/5897
- Do manual dtype conversion in aten_sin