### PR TITLE
Remove assert on zero_point dtype of quantize/dequantize op

### DIFF
--- a/torch_xla/experimental/quantized.py
+++ b/torch_xla/experimental/quantized.py
@@ -50,9 +50,7 @@ def _check_scale_zp(input, scale, zero_point, axis, dtype):
   # The followings are checked:
   # 1. scale, zp are 1D tensor.
   # 2. Lenghth of scale, zp matched the (de)quant dim.
-  # 3. zp dtype is the same as the quantized integer type.
   assert len(scale.shape) == 1 and len(zero_point.shape) == 1
-  assert zero_point.dtype == dtype
   if axis == -1:
     assert scale.numel() == 1 and zero_point.numel() == 1
   else:

--- a/torch_xla/experimental/quantized.py
+++ b/torch_xla/experimental/quantized.py
@@ -50,7 +50,15 @@ def _check_scale_zp(input, scale, zero_point, axis, dtype):
   # The followings are checked:
   # 1. scale, zp are 1D tensor.
   # 2. Lenghth of scale, zp matched the (de)quant dim.
+  # 3. dtype must be integer type
+  # 4. zero_point values must be within the range of dtype.
   assert len(scale.shape) == 1 and len(zero_point.shape) == 1
+  assert 'int' in str(dtype)
+  assert torch.equal(
+      zero_point,
+      torch.clamp(zero_point,
+                  torch.iinfo(dtype).min,
+                  torch.iinfo(dtype).max))
   if axis == -1:
     assert scale.numel() == 1 and zero_point.numel() == 1
   else:


### PR DESCRIPTION
Per the current PT2E implementation, the dtype of zp will always be in `torch.int64` [ref](https://github.com/pytorch/pytorch/blob/3829b55416e115603d21073a8b3710324abae059/torch/ao/quantization/utils.py#L603). From the math calculating the zp, it will always be within the bound [ref](https://github.com/pytorch/pytorch/blob/3829b55416e115603d21073a8b3710324abae059/torch/ao/quantization/utils.py#L581-L586).

- Remove assertion on `zero_point` to have the same dtype as the quantized integer dtype. Assert the dtype has to be integer point.
- Per StableHLO spec on the quantized tensor [ref](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#types) `(C8) storage_min <= zero_points <= storage_max`, add the assertion on the range of zero_point.

cc @sdasgup3 @paulinesho