### PR TITLE
CI: increase build timeout from 180 to 240 minutes

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -38,7 +38,7 @@ on:
 jobs:
   build:
     runs-on: ${{ inputs.runner }}
-    timeout-minutes: 180
+    timeout-minutes: 240
     outputs:
       docker-image: ${{ steps.upload-docker-image.outputs.docker-image }}
     env:


### PR DESCRIPTION
Currently, unless the CI build cache is enabled, builds do time out at 180 minutes. Given that the CI build cache is only enabled on branches on the pytorch/xla repo, contributors external to the project (who therefore cannot push a branch to the pytorch/xla repo) cannot get CI to run.

Fix this by increasing the build timeout to 240 minutes.