### PR TITLE
Lower the embedding op

### DIFF
--- a/test/cpp/test_aten_xla_tensor_5.cpp
+++ b/test/cpp/test_aten_xla_tensor_5.cpp
@@ -261,6 +261,9 @@ TEST_F(AtenXlaTensorTest, TestEmbedding) {
                                            /*scale_grad_by_freq=*/false,
                                            /*sparse=*/false);
     AllClose(b, xla_b);
+    ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+    ExpectCounterChanged("xla::embedding_symint",
+                         cpp_test::GetIgnoredCounters());
   });
 }
 

--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -1418,7 +1418,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.embedding, args, kwargs)
 
-  @unittest.skip
   def test_aten_embedding_1(self):
     args = (
         torch.randn((10, 10)).to(torch.float16),
@@ -1427,7 +1426,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.embedding, args, kwargs)
 
-  @unittest.skip
   def test_aten_embedding_2(self):
     args = (
         torch.randint(0, 10, (10, 10)).to(torch.int32),

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -115,9 +115,10 @@ void CheckSubOperandTypes(at::ScalarType type1, at::ScalarType type2) {
 
 c10::optional<at::ScalarType> PromoteIntegralType(
     at::ScalarType src_dtype, const c10::optional<at::ScalarType>& opt_dtype) {
-  return opt_dtype.has_value() ? opt_dtype.value()
-         : at::isIntegralType(src_dtype, /*includeBool=*/true) ? at::kLong
-                                                               : opt_dtype;
+  return opt_dtype.has_value()
+             ? opt_dtype.value()
+             : at::isIntegralType(src_dtype, /*includeBool=*/true) ? at::kLong
+                                                                   : opt_dtype;
 }
 
 bool IsTypeWithLargerRangeThanLong(torch::ScalarType dtype) {

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -115,10 +115,9 @@ void CheckSubOperandTypes(at::ScalarType type1, at::ScalarType type2) {
 
 c10::optional<at::ScalarType> PromoteIntegralType(
     at::ScalarType src_dtype, const c10::optional<at::ScalarType>& opt_dtype) {
-  return opt_dtype.has_value()
-             ? opt_dtype.value()
-             : at::isIntegralType(src_dtype, /*includeBool=*/true) ? at::kLong
-                                                                   : opt_dtype;
+  return opt_dtype.has_value() ? opt_dtype.value()
+         : at::isIntegralType(src_dtype, /*includeBool=*/true) ? at::kLong
+                                                               : opt_dtype;
 }
 
 bool IsTypeWithLargerRangeThanLong(torch::ScalarType dtype) {
@@ -3515,11 +3514,10 @@ at::Tensor XLANativeFunctions::embedding_symint(const at::Tensor& weight,
     return at::native::embedding_symint(weight, indices, padding_idx,
                                         scale_grad_by_freq, sparse);
   }
-  // TODO: for now route to native, which dispatches supported XLA operations.
-  // We need to make use of the TPU embedding core here eventually.
-  return at::functionalization::functionalize_aten_op_symint<ATEN_OP(
-      embedding)>::call(weight, indices, padding_idx, scale_grad_by_freq,
-                        sparse);
+
+  TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
+  return bridge::AtenFromXlaTensor(tensor_methods::embedding(
+      bridge::GetXlaTensor(weight), bridge::GetXlaTensor(indices)));
 }
 
 at::Tensor XLANativeFunctions::_euclidean_dist(const at::Tensor& x1,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1235,6 +1235,11 @@ XLATensorPtr embedding_dense_backward(const XLATensorPtr& grad_output,
                                             padding_idx, scale_grad_by_freq);
 }
 
+XLATensorPtr embedding(const XLATensorPtr& weight,
+                       const XLATensorPtr& indices) {
+  return tensor_ops::Embedding(weight, indices);
+}
+
 XLATensorPtr exp(const XLATensorPtr& input) {
   return input->CreateFrom(Exp(input->GetIrValue()));
 }

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -359,6 +359,8 @@ XLATensorPtr embedding_dense_backward(const XLATensorPtr& grad_output,
                                       int64_t num_weights, int64_t padding_idx,
                                       bool scale_grad_by_freq);
 
+XLATensorPtr embedding(const XLATensorPtr& weight, const XLATensorPtr& indices);
+
 XLATensorPtr eq(const XLATensorPtr& input, const at::Scalar& other);
 
 XLATensorPtr eq(const XLATensorPtr& input, const XLATensorPtr& other);

--- a/torch_xla/csrc/tensor_ops.cpp
+++ b/torch_xla/csrc/tensor_ops.cpp
@@ -253,7 +253,7 @@ XLATensorPtr Embedding(const XLATensorPtr& weight,
 
   std::vector<int64_t> final_size;
   int64_t num_elements = 1;
-  for (int i = 0; i < weight->shape().get().rank(); i++) {
+  for (int i = 0; i < indices->shape().get().rank(); i++) {
     int64_t dim = indices->shape().get().dimensions(i);
     final_size.push_back(dim);
     num_elements *= dim;

--- a/torch_xla/csrc/tensor_ops.cpp
+++ b/torch_xla/csrc/tensor_ops.cpp
@@ -252,13 +252,17 @@ XLATensorPtr Embedding(const XLATensorPtr& weight,
   }
 
   std::vector<int64_t> final_size;
+  int64_t num_elements = 1;
   for (int i = 0; i < weight->shape().get().rank(); i++) {
-    final_size.push_back(indices->shape().get().dimensions(i));
+    int64_t dim = indices->shape().get().dimensions(i);
+    final_size.push_back(dim);
+    num_elements *= dim;
   }
+
   final_size.push_back(weight->shape().get().dimensions(1));
 
-  XLATensorPtr embeddings =
-      tensor_methods::index_select(weight, 0, tensor_methods::squeeze(indices));
+  XLATensorPtr embeddings = tensor_methods::index_select(
+      weight, 0, tensor_methods::view(indices, {num_elements}));
   return tensor_methods::view(embeddings, final_size);
 }
 

--- a/torch_xla/csrc/tensor_ops.h
+++ b/torch_xla/csrc/tensor_ops.h
@@ -39,6 +39,8 @@ XLATensorPtr EmbeddingDenseBackward(const XLATensorPtr& grad_output,
                                     int64_t num_weights, int64_t padding_idx,
                                     bool scale_grad_by_freq);
 
+XLATensorPtr Embedding(const XLATensorPtr& weight, const XLATensorPtr& indices);
+
 }  // namespace tensor_ops
 }  // namespace torch_xla
 


### PR DESCRIPTION
Reference: https://github.com/pytorch/pytorch/blob/113138aa5575301d914c18bd882d6ab3735aa18a/aten/src/ATen/native/Embedding.cpp#L37

The native pytorch implmentation also uses just the indices and weight matrix. Other options seem to be ignored.