### PR TITLE
[SPMD] Introduce global mesh

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1084,6 +1084,13 @@ class BasicShardingTest(test_xla_sharding_base.XlaShardingTest):
     with self.assertRaises(AttributeError):
       xt.mesh_shape
 
+  def test_global_mesh(self):
+    expected_mesh = self._get_mesh((1, self.n_devices))
+    xs.set_global_mesh(expected_mesh)
+    mesh = xs.get_global_mesh()
+
+    self.assertEqual(id(mesh), id(expected_mesh))
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/torch_xla/distributed/spmd/__init__.py
+++ b/torch_xla/distributed/spmd/__init__.py
@@ -1,7 +1,7 @@
 from .xla_sharded_tensor import XLAShard, XLAShardedTensor
 from .xla_sharding import (Mesh, HybridMesh, ShardingType, ShardingSpec,
                            XLAPatchedLinear, mark_sharding, clear_sharding,
-                           wrap_if_sharded, xla_patched_nn_linear_forward)
+                           wrap_if_sharded, xla_patched_nn_linear_forward, set_global_mesh, get_global_mesh)
 from .api import xla_distribute_tensor, xla_distribute_module
 
 __all__ = [
@@ -18,4 +18,6 @@ __all__ = [
     "xla_distribute_tensor",
     "xla_distribute_module",
     "xla_patched_nn_linear_forward",
+    "set_global_mesh",
+    "get_global_mesh",
 ]

--- a/torch_xla/distributed/spmd/__init__.py
+++ b/torch_xla/distributed/spmd/__init__.py
@@ -1,7 +1,8 @@
 from .xla_sharded_tensor import XLAShard, XLAShardedTensor
 from .xla_sharding import (Mesh, HybridMesh, ShardingType, ShardingSpec,
                            XLAPatchedLinear, mark_sharding, clear_sharding,
-                           wrap_if_sharded, xla_patched_nn_linear_forward, set_global_mesh, get_global_mesh)
+                           wrap_if_sharded, xla_patched_nn_linear_forward,
+                           set_global_mesh, get_global_mesh)
 from .api import xla_distribute_tensor, xla_distribute_module
 
 __all__ = [

--- a/torch_xla/distributed/spmd/xla_sharding.py
+++ b/torch_xla/distributed/spmd/xla_sharding.py
@@ -13,7 +13,6 @@ import itertools
 from typing import Tuple, Union, List, Sequence, Any, Optional, Set
 from enum import IntEnum
 
-
 class Mesh:
   """Describe the logical XLA device topology mesh and the underlying resources.
 
@@ -121,6 +120,18 @@ class Mesh:
         partition_spec)
     return torch_xla._XLAC.OpSharding(tile_assignment, group_assignment,
                                       replication_groups, sharding_type)
+
+
+_GLOBAL_MESH: Mesh = None
+
+def set_global_mesh(mesh: Mesh):
+  global _GLOBAL_MESH
+  _GLOBAL_MESH = mesh
+
+
+def get_global_mesh():
+  global _GLOBAL_MESH
+  return _GLOBAL_MESH
 
 
 # HybridDevice class has been inspired from jax's mesh_utils: https://github.com/google/jax/blob/fc5960f2b8b7a0ef74dbae4e27c5c08ff1564cff/jax/experimental/mesh_utils.py#L4ƒ

--- a/torch_xla/distributed/spmd/xla_sharding.py
+++ b/torch_xla/distributed/spmd/xla_sharding.py
@@ -13,6 +13,7 @@ import itertools
 from typing import Tuple, Union, List, Sequence, Any, Optional, Set
 from enum import IntEnum
 
+
 class Mesh:
   """Describe the logical XLA device topology mesh and the underlying resources.
 
@@ -123,6 +124,7 @@ class Mesh:
 
 
 _GLOBAL_MESH: Mesh = None
+
 
 def set_global_mesh(mesh: Mesh):
   global _GLOBAL_MESH


### PR DESCRIPTION
Summary:
SPMD expects the mesh to be the same across the board. Therefore, introduce the concept of a global mesh to reduce the need to carry the same mesh in the code.

Test Plan:
python test/spmd/test_xla_sharding.py -v -k test_global_mesh