### PR TITLE
Add explicit shape check for index_copy

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1440,7 +1440,7 @@ at::Tensor XLANativeFunctions::index_copy(const at::Tensor& self, int64_t dim,
   // https://pytorch.org/docs/stable/generated/torch.Tensor.index_copy_.html,
   // the dim-th dimension of source tensor must have the same size as the length
   // of index tensor.
-  XLA_CHECK(dim < self_tensor_dims.size() &&
+  XLA_CHECK(dim < source_tensor_dims.size() &&
             source_tensor_dims[dim] == index_tensor_dims[0])
       << "dim-th dimension of the source tensor must have the same size as the "
          "length of index tensor.";


### PR DESCRIPTION
As per https://pytorch.org/docs/stable/generated/torch.Tensor.index_copy_.html, the dim-th dimension of the tensor must have the same size as the length of index. PyTorch behavior: 
```
>>> import torch
>>> x = torch.zeros(5, 3)
>>> t = torch.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=torch.float)
>>> index = torch.tensor([0, 4, 2, 1])
>>> x.index_copy_(0, index, t)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IndexError: index_copy_(): Number of indices (4) should be equal to source.size(dim) (3)
```
Update the torch_xla's `index_copy` lowering to throw a similar error message.

One other check we may want is checking each value in the index tensor to be within the dimensions of the input tensor. But because torch_xla's lowering of `index_copy` uses `xla::Scatter` which requires torch_xla to do some broadcast, doing this bound check for each index seems a bit tricky. So for now, this PR will first add this explicit shape check only.