### PR TITLE
[benchmarks] Increase compilation cache.

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -76,6 +76,7 @@ DENY_LIST = {
         {
             "test": "eval",
             "xla": "PJRT",
+            "dynamo": None,
         },  # TIMEOUT
     ],
     "hf_T5_generate": [
@@ -85,6 +86,7 @@ DENY_LIST = {
         {
             "test": "eval",
             "xla": "PJRT",
+            "dynamo": None,
         },  # TIMEOUT
     ],
     "doctr_det_predictor": [{
@@ -133,6 +135,13 @@ DENY_LIST = {
             "accelerator": "tpu"
         },  # The eval test only supports CPU
     ],
+}
+
+# Models that had more graphs to be compiled than the actual size of
+# the cache.
+NEED_LARGER_CACHE = {
+    "cm3leon_generate",
+    "hf_T5_generate",
 }
 
 
@@ -400,6 +409,9 @@ class TorchBenchModel(BenchmarkModel):
     precision_flag = self.default_precision_flag
     if precision_flag is not None:
       process_env[precision_flag] = '1'
+
+    if self.benchmark_experiment.model_name in NEED_LARGER_CACHE:
+      process_env["XLA_COMPILATION_CACHE_SIZE"] = "2048"
 
   def pick_grad(self):
     # special case

--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -410,7 +410,7 @@ class TorchBenchModel(BenchmarkModel):
     if precision_flag is not None:
       process_env[precision_flag] = '1'
 
-    if self.benchmark_experiment.model_name in NEED_LARGER_CACHE:
+    if self.model_name in NEED_LARGER_CACHE:
       process_env["XLA_COMPILATION_CACHE_SIZE"] = "2048"
 
   def pick_grad(self):


### PR DESCRIPTION
Fix: #5967 

This PR increases the compilation cache for 2 benchmarks that were failing due to an assertion error: `cachedComputation`.

- cm3leon_generate
- hf_T5_generate

It also changes the `DENY_LIST` so that we only skip these benchmarks if they are running on XLA without dynamo (timeout).

cc @miladm 