### PR TITLE
aggregate.py: fix detection of no datapoints

### DIFF
--- a/benchmarks/aggregate.py
+++ b/benchmarks/aggregate.py
@@ -330,7 +330,7 @@ def pr_latest(results_map: Dict[str, Any], args, timestamps: List[str]):
             list, zip(*sorted(zip(acc_map[label], acc_map[model_label]))))
         speedups[i] = list(map(pr_round, speedups[i]))
         break
-  if not speedups[0] or not speedups[1]:
+  if all(not x for x in speedups):
     logger.warning(f'cannot find data for accelerator {args.accelerator}')
     return
 

--- a/test/benchmarks/a6000.training.latest.empty.test
+++ b/test/benchmarks/a6000.training.latest.empty.test
@@ -1,0 +1,1 @@
+# ARGS: --backends openxla+lazytensor --


### PR DESCRIPTION
The existing check became obsolete once we added the --backends flag in PR #6392; in particular, len(speedups) could be 1 when a single backend is passed to --backends. Fix it and add a test to make sure we emit no output to stdout (note that the warning message goes to stderr).