### PR TITLE
Add default flag `xla_tpu_prefer_async_allgather_to_allreduce`

### DIFF
--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -45,9 +45,20 @@ def _setup_libtpu_flags():
   flags = _set_missing_flags(flags,
                              (('xla_latency_hiding_scheduler_rerun', '1'),))
 
+  # This flag will prevent AllGather decomposition into AllReduce by the
+  # compiler when async AllGather is enabled. Decomposed AllGathers are
+  # persisted in-memory and shared between the forward and backward passes,
+  # which can result in the entire model's parameters being in device memory.
+  # However, regular AllGathers are instead rematerialized in the backward pass,
+  # and when they are async this incurs little overhead but significantly
+  # improves device memory usage.
+  flags = _set_missing_flags(
+      flags, (('xla_tpu_prefer_async_allgather_to_allreduce', 'true')))
+
   if tpu.version() == 5:
     default_v5_flags = {
-        # Enable async collectives
+        # TODO(jonbolin): Tune these flags for async collective fusion - v5
+        # requires continuation fusion to run async collectives.
         'xla_enable_async_all_gather': 'true',
         'xla_enable_async_collective_permute': 'true',
     }

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -53,7 +53,7 @@ def _setup_libtpu_flags():
   # and when they are async this incurs little overhead but significantly
   # improves device memory usage.
   flags = _set_missing_flags(
-      flags, (('xla_tpu_prefer_async_allgather_to_allreduce', 'true')))
+      flags, (('xla_tpu_prefer_async_allgather_to_allreduce', 'true'),))
 
   if tpu.version() == 5:
     default_v5_flags = {


### PR DESCRIPTION
AllGather decomposition into AllReduce by the compiler is less memory efficient, the result being shared between the forward and backward pass instead of rematerialized. This problem is particularly pronounced with 1D sharding over a 3D topology.

With FSDPv2 being the easiest entrypoint for SPMD, this issue becomes a blocker for performance at large scale, since most device memory will be allocated for the AllGathered parameters, constraining the batch size. On v4, the problem begins to manifest with v4-128's 4x4x4 topology.

This flag only applies with async AllGather enabled. On v4, this is enabled by default with `TPU_MEGACORE=megacore_dense`. On v5, the flag currently won't take effect because async AG requires continuation fusion, which is currently unstable and not enabled by default.

On a v4-128, enabling this option decreases peak memory usage from 17.5GB to 3GB on a 7B parameter model with the same batch size.