### PR TITLE
Add limit to max inflight TPU computations

### DIFF
--- a/torch_xla/_internal/tpu.py
+++ b/torch_xla/_internal/tpu.py
@@ -346,6 +346,6 @@ class TpuPlugin(plugins.DevicePlugin):
 
   def client_create_options(self):
     return {
-      'max_inflight_computations':
-          xu.getenv_as('XLA_TPU_MAX_INFLIGHT_COMPUTATIONS', int, 4)
+        'max_inflight_computations':
+            xu.getenv_as('XLA_TPU_MAX_INFLIGHT_COMPUTATIONS', int, 4)
     }

--- a/torch_xla/_internal/tpu.py
+++ b/torch_xla/_internal/tpu.py
@@ -343,3 +343,9 @@ class TpuPlugin(plugins.DevicePlugin):
 
   def physical_chip_count(self):
     return num_available_chips()
+
+  def client_create_options(self):
+    return {
+      'max_inflight_computations':
+          xu.getenv_as('XLA_TPU_MAX_INFLIGHT_COMPUTATIONS', int, 4)
+    }


### PR DESCRIPTION
Requires `XLA_REGISTER_INSTALLED_PLUGINS=1` to use `DevicePlugin` API.