### PR TITLE
[benchmarks] Run some models with smaller batch sizes.

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -315,7 +315,8 @@ class TorchBenchModel(BenchmarkModel):
       batch_size = self.benchmark_experiment.batch_size
     elif self.is_training() and self.model_name in self.batch_size["training"]:
       batch_size = self.batch_size["training"][self.model_name]
-    elif self.is_inference() and self.model_name in self.batch_size["inference"]:
+    elif self.is_inference(
+    ) and self.model_name in self.batch_size["inference"]:
       batch_size = self.batch_size["inference"][self.model_name]
 
     # workaround "RuntimeError: not allowed to set torch.backends.cudnn flags"

--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -169,5 +169,3 @@ def find_near_file(self, names):
       if exists(path):
         return abspath(path)
   return None
-
-

--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -156,3 +156,18 @@ def get_tpu_name():
 
 def get_torchbench_test_name(test):
   return {"train": "training", "eval": "inference"}[test]
+
+
+def find_near_file(self, names):
+  """Find a file near the current directory.
+
+  Looks for `names` in the current directory, up to its two direct parents.
+  """
+  for dir in ("./", "../", "../../", "../../../"):
+    for name in names:
+      path = os.path.join(dir, name)
+      if exists(path):
+        return abspath(path)
+  return None
+
+


### PR DESCRIPTION
This PR adapts the code in PyTorch main repo, so that a few models are executed with smaller batch sizes. This is an effort towards making the benchmarking scripts behavior closer.

In summary, 3 new sets are introduced:
- `USE_SMALL_BATCH_SIZE`: batch sizes for training
- `INFERENCE_SMALL_BATCH_SIZE`: batch sizes for inference
- `DONT_CHANGE_BATCH_SIZE`: models whose batch size can't be changed in the command line

cc @miladm 