### PR TITLE
[benchmarks] Fix AMP data-type.

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -383,6 +383,15 @@ class TorchBenchModel(BenchmarkModel):
     return torch.bfloat16
 
   def _get_autocast_with_kwargs(self):
+    kwargs = {}
+
+    # Set the default data-type based on the accelerator.
+    if self.benchmark_experiment.accelerator == "cuda":
+      kwargs["dtype"] = torch.float16
+    else:
+      # Both CPU and TPU autocast mode defaults to bfloat16.
+      kwargs["dtype"] = torch.bfloat16
+
     if self.use_amp():
       kwargs = {"dtype": torch.bfloat16}
       if self.benchmark_experiment.xla:
@@ -394,7 +403,6 @@ class TorchBenchModel(BenchmarkModel):
       else:
         autocast = torch.cuda.amp.autocast
     else:
-      kwargs = {}
       autocast = contextlib.nullcontext
     return (autocast, kwargs)
 

--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -393,7 +393,6 @@ class TorchBenchModel(BenchmarkModel):
       kwargs["dtype"] = torch.bfloat16
 
     if self.use_amp():
-      kwargs = {"dtype": torch.bfloat16}
       if self.benchmark_experiment.xla:
         # Should call device specific autocast implementations.
         # PyTorch/XLA autocast does not run with dynamo, though:


### PR DESCRIPTION
This PR fixes the behavior of AMP, aligning it to [that of PyTorch HUD](https://github.com/pytorch/pytorch/blob/3f4dd9bfa4c43d9d314d50573eacac9afeb474bb/benchmarks/dynamo/common.py#L2007-L2013). Instead of setting a default data-type, we use the default one.

cc @miladm 