### PR TITLE
Revert "[Core Aten Op] bring aten_replication_pad3d test back"

### DIFF
--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -3247,6 +3247,7 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.replication_pad2d, args, kwargs)
 
+  @unittest.skip
   def test_aten_replication_pad3d_0(self):
     args = (
         torch.randn((1, 3, 2, 10)).to(torch.float32),
@@ -3262,6 +3263,7 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.replication_pad3d, args, kwargs)
 
+  @unittest.skip
   def test_aten_replication_pad3d_1(self):
     args = (
         torch.randint(0, 10, (1, 3, 2, 10)).to(torch.int32),


### PR DESCRIPTION
Reverts pytorch/xla#6537

---

Reverting as this op needs an lowering and was mistakenly enabled. 