### PR TITLE
Allow Inductor benchmarks for CPU backends.

### DIFF
--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -74,7 +74,7 @@ class ExperimentLoader:
 
     # Check dynamo backend-specifics constraints.
     if cfg_dynamo == "inductor":
-      if cfg_accelerator != "cuda" or cfg_xla is not None:
+      if cfg_accelerator == "tpu" or cfg_xla is not None:
         return False
     elif cfg_dynamo == "openxla_eval":
       if cfg_xla is None or cfg_test != "eval":

--- a/test/benchmarks/test_experiment_runner.py
+++ b/test/benchmarks/test_experiment_runner.py
@@ -27,10 +27,12 @@ class ExperimentRunnerTest(expecttest.TestCase):
                            capture_output=True,
                            text=True)
     expected_in_stderr = [
-        "Number of selected experiment configs: 2",
+        "Number of selected experiment configs: 4",
         "Number of selected model configs: 1",
         "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cpu\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"test\": \"eval\"}",
         "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cpu\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"test\": \"train\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cpu\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"test\": \"eval\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cpu\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"test\": \"train\"}",
     ]
     for expected in expected_in_stderr:
       self.assertIn(expected, child.stderr)


### PR DESCRIPTION
Unless there was a specific reason to limit to GPU?