### PR TITLE
Add basic device APIs to the top-level `torch_xla` module.

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -211,6 +211,7 @@ function run_xla_op_tests3 {
   run_test "$CDIR/test_torch_distributed_xla_backend.py"
   run_torchrun "$CDIR/pjrt/test_torchrun.py"
   run_test "$CDIR/test_persistent_cache.py"
+  run_test "$CDIR/test_devices.py"
   # NOTE: this line below is testing export and don't care about GPU
   PJRT_DEVICE=CPU CPU_NUM_DEVICES=1 run_coverage "$CDIR/test_core_aten_ops.py"
 }

--- a/test/test_devices.py
+++ b/test/test_devices.py
@@ -7,20 +7,21 @@ import torch_xla.runtime as xr
 
 
 class TestDevices(parameterized.TestCase):
+
   def setUpClass():
     xr.set_device_type('CPU')
     os.environ['CPU_NUM_DEVICES'] = '4'
 
-  @parameterized.parameters(
-      (None, torch.device('xla:0')),
-      (0, torch.device('xla:0')),
-      (3, torch.device('xla:3')))
+  @parameterized.parameters((None, torch.device('xla:0')),
+                            (0, torch.device('xla:0')),
+                            (3, torch.device('xla:3')))
   def test_device(self, index, expected):
     device = xla.device(n=index)
     self.assertEqual(device, expected)
 
   def test_devices(self):
-    self.assertEqual(xla.devices(), [torch.device(f'xla:{i}') for i in range(4)])
+    self.assertEqual(xla.devices(),
+                     [torch.device(f'xla:{i}') for i in range(4)])
 
   def test_real_devices(self):
     self.assertEqual(xla.real_devices(), [f'CPU:{i}' for i in range(4)])

--- a/test/test_devices.py
+++ b/test/test_devices.py
@@ -16,7 +16,7 @@ class TestDevices(parameterized.TestCase):
                             (0, torch.device('xla:0')),
                             (3, torch.device('xla:3')))
   def test_device(self, index, expected):
-    device = xla.device(n=index)
+    device = xla.device(index)
     self.assertEqual(device, expected)
 
   def test_devices(self):

--- a/test/test_devices.py
+++ b/test/test_devices.py
@@ -1,0 +1,33 @@
+import os
+
+from absl.testing import absltest, parameterized
+import torch
+import torch_xla as xla
+import torch_xla.runtime as xr
+
+
+class TestDevices(parameterized.TestCase):
+  def setUpClass():
+    xr.set_device_type('CPU')
+    os.environ['CPU_NUM_DEVICES'] = '4'
+
+  @parameterized.parameters(
+      (None, torch.device('xla:0')),
+      (0, torch.device('xla:0')),
+      (3, torch.device('xla:3')))
+  def test_device(self, index, expected):
+    device = xla.device(n=index)
+    self.assertEqual(device, expected)
+
+  def test_devices(self):
+    self.assertEqual(xla.devices(), [torch.device(f'xla:{i}') for i in range(4)])
+
+  def test_real_devices(self):
+    self.assertEqual(xla.real_devices(), [f'CPU:{i}' for i in range(4)])
+
+  def test_device_count(self):
+    self.assertEqual(xla.device_count(), 4)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -182,3 +182,5 @@ from .experimental import plugins
 if os.getenv('XLA_REGISTER_INSTALLED_PLUGINS') == '1':
   plugins.use_dynamic_plugins()
   plugins.register_installed_plugins()
+
+from .torch_xla import *

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1188,18 +1188,20 @@ void InitXlaModuleBindings(py::module m) {
         runtime::GetComputationClient()->GetAllDevices();
     return all_devices;
   });
-  m.def("_xla_real_devices", [](const std::optional<std::vector<std::string>> devices) {
-    if (!devices) {
-      return runtime::GetComputationClient()->GetLocalDevices();
-    }
+  m.def("_xla_real_devices",
+        [](const std::optional<std::vector<std::string>> devices) {
+          if (!devices) {
+            return runtime::GetComputationClient()->GetLocalDevices();
+          }
 
-    std::vector<std::string> xla_devices;
-    {
-      NoGilSection nogil;
-      xla_devices = GetXlaDevices(*devices);
-    }
-    return xla_devices;
-  }, py::arg("devices") = std::nullopt);
+          std::vector<std::string> xla_devices;
+          {
+            NoGilSection nogil;
+            xla_devices = GetXlaDevices(*devices);
+          }
+          return xla_devices;
+        },
+        py::arg("devices") = std::nullopt);
   m.def("_xla_set_replication_devices",
         [](const std::vector<std::string>& devices) {
           auto replication_devices =

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1188,14 +1188,18 @@ void InitXlaModuleBindings(py::module m) {
         runtime::GetComputationClient()->GetAllDevices();
     return all_devices;
   });
-  m.def("_xla_real_devices", [](const std::vector<std::string>& devices) {
+  m.def("_xla_real_devices", [](const std::optional<std::vector<std::string>> devices) {
+    if (!devices) {
+      return runtime::GetComputationClient()->GetLocalDevices();
+    }
+
     std::vector<std::string> xla_devices;
     {
       NoGilSection nogil;
-      xla_devices = GetXlaDevices(devices);
+      xla_devices = GetXlaDevices(*devices);
     }
     return xla_devices;
-  });
+  }, py::arg("devices") = std::nullopt);
   m.def("_xla_set_replication_devices",
         [](const std::vector<std::string>& devices) {
           auto replication_devices =

--- a/torch_xla/torch_xla.py
+++ b/torch_xla/torch_xla.py
@@ -35,10 +35,11 @@ def real_devices() -> List[str]:
   """Returns local XLA device types and indices.
 
   Returns:
-    A list strings representing the XLA devices available in the current process.
+    A list strings representing the XLA devices available in the current process, e.g. `['TPU:0', 'TPU:1', ...]`.
   """
 
   return torch_xla._XLAC._xla_real_devices()
+
 
 def device_count() -> int:
   return len(real_devices())

--- a/torch_xla/torch_xla.py
+++ b/torch_xla/torch_xla.py
@@ -4,21 +4,21 @@ import torch_xla
 import torch_xla.core.xla_model as xm
 
 
-def device(n: int = None) -> torch.device:
+def device(index: int = None) -> torch.device:
   """Returns a given instance of an XLA device.
 
   If SPMD enables, returns a virtual device that wraps all devices available
   to this process.
 
   Args:
-    n: index of the XLA device to be returned. Corresponds to index in
+    index: index of the XLA device to be returned. Corresponds to index in
       `torch_xla.devices()`.
 
   Returns:
     An XLA `torch.device`.
   """
 
-  return xm.xla_device(n)
+  return xm.xla_device(index)
 
 
 def devices() -> List[torch.device]:
@@ -35,11 +35,13 @@ def real_devices() -> List[str]:
   """Returns local XLA device types and indices.
 
   Returns:
-    A list strings representing the XLA devices available in the current process, e.g. `['TPU:0', 'TPU:1', ...]`.
+    A list strings representing the XLA devices available in the current
+    process, e.g. `['TPU:0', 'TPU:1', ...]`.
   """
 
   return torch_xla._XLAC._xla_real_devices()
 
 
 def device_count() -> int:
+  """Returns number of addressable devices in the current process."""
   return len(real_devices())

--- a/torch_xla/torch_xla.py
+++ b/torch_xla/torch_xla.py
@@ -1,0 +1,44 @@
+from typing import List
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+
+
+def device(n: int = None) -> torch.device:
+  """Returns a given instance of an XLA device.
+
+  If SPMD enables, returns a virtual device that wraps all devices available
+  to this process.
+
+  Args:
+    n: index of the XLA device to be returned. Corresponds to index in
+      `torch_xla.devices()`.
+
+  Returns:
+    An XLA `torch.device`.
+  """
+
+  return xm.xla_device(n)
+
+
+def devices() -> List[torch.device]:
+  """Returns all devices available in the current process.
+
+  Returns:
+    A list of XLA `torch.devices`.
+  """
+
+  return [torch.device(d) for d in xm.get_xla_supported_devices()]
+
+
+def real_devices() -> List[str]:
+  """Returns local XLA device types and indices.
+
+  Returns:
+    A list strings representing the XLA devices available in the current process.
+  """
+
+  return torch_xla._XLAC._xla_real_devices()
+
+def device_count() -> int:
+  return len(real_devices())


### PR DESCRIPTION
Implemented basic device APIs from #6399.

- Add `device`, `devices`, `real_devices`, and `device_count` as described in RFC.
- We already do a substantial amount of setup in `__init__.py` . Add `torch_xla.py` for public functions on `torch_xla` module.

Follow up:
- Update documentation to use new APIs.
- Start deprecating or discouraging usage of old APIs like `xm.xla_device` and `runtime.xla_device`.