### PR TITLE
Conditional run tests that have TF dependency

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -196,9 +196,11 @@ function run_xla_op_tests2 {
 function run_xla_op_tests3 {
   # TODO(qihqi): this test require tensorflow to run. need to setup separate
   #     CI with tf.
+  run_test "$CDIR/stablehlo/test_implicit_broadcasting.py"
+  run_test "$CDIR/stablehlo/test_mark_pattern.py"
+  run_test "$CDIR/stablehlo/test_pt2e_qdq.py"
   run_xla_hlo_debug "$CDIR/stablehlo/test_stablehlo_inference.py"
   run_test "$CDIR/stablehlo/test_stablehlo_compile.py"
-  run_test "$CDIR/stablehlo/test_implicit_broadcasting.py"
   run_test "$CDIR/stablehlo/test_unbounded_dynamism.py"
   run_test "$CDIR/spmd/test_xla_sharding.py"
   run_test "$CDIR/spmd/test_xla_sharding_hlo.py"

--- a/test/stablehlo/test_pt2e_qdq.py
+++ b/test/stablehlo/test_pt2e_qdq.py
@@ -11,8 +11,13 @@ from torch.ao.quantization.quantize_pt2e import convert_pt2e, prepare_pt2e
 from torch.ao.quantization.quantizer.xnnpack_quantizer import (
     XNNPACKQuantizer, get_symmetric_quantization_config)
 from torch_xla import stablehlo
-from torch_xla.tf_saved_model_integration import \
-    save_torch_module_as_tf_saved_model
+from utils import has_tf_package
+
+try:
+  from torch_xla.tf_saved_model_integration import \
+      save_torch_module_as_tf_saved_model
+except ImportError:
+  print("tf is not installed. The tf.saved_model tests will be skipped.")
 
 # Needed to workaround the stablehlo bytecode serialization issue in https://github.com/openxla/stablehlo/issues/1812
 os.environ['STABLEHLO_BYTECODE_FROM_PRETTYPRINT'] = '1'
@@ -43,7 +48,7 @@ def count_fx_graph_nodes(g: torch.fx.Graph, op_dict: Dict[str, List[Callable]]):
 
 def count_qdq_ops(g: torch.fx.Graph):
   op_dict = {
-      "qunatize": _TORCH_QUANTIZE_OPS,
+      "quantize": _TORCH_QUANTIZE_OPS,
       "dequantize": _TORCH_DEQUANTIZE_OPS,
   }
   return count_fx_graph_nodes(g, op_dict)
@@ -68,8 +73,8 @@ class PT2EExportTest(unittest.TestCase):
   def test_per_channel_qdq(self):
     device = xm.xla_device()
     x = torch.randn(2, 3, 4, 5).to(device)
-    scale = torch.tensor([3.2, 5.3, 0.1, 10])
-    zero_point = torch.tensor([1, 2, -1, -2], dtype=torch.int8)
+    scale = torch.tensor([3.2, 5.3, 0.1, 10]).to(device)
+    zero_point = torch.tensor([1, 2, -1, -2], dtype=torch.int64).to(device)
     x = torch.ops.quantized_decomposed.quantize_per_channel(
         x, scale, zero_point, 2, -128, 127, torch.int8)
     x = torch.ops.quantized_decomposed.dequantize_per_channel(
@@ -82,7 +87,6 @@ class PT2EExportTest(unittest.TestCase):
     self.assertEqual(stablehlo_txt.count("stablehlo.uniform_quantize"), 1)
     self.assertEqual(stablehlo_txt.count("stablehlo.uniform_dequantize"), 1)
 
-  @unittest.skip("Failed because PT2E BC break change on constant folding.")
   def test_resnet18(self):
     # Step 1: export resnet18
     args = (torch.randn(1, 3, 224, 224),)
@@ -95,23 +99,25 @@ class PT2EExportTest(unittest.TestCase):
     m = prepare_pt2e(m, quantizer)
 
     # Step 3: Quantize the model
-    m = convert_pt2e(m)
+    m = convert_pt2e(m, fold_quantize=False)
 
     # Trace with torch/xla and export stablehlo
     exported = torch.export.export(m, args)
     stablehlo_gm = stablehlo.exported_program_to_stablehlo(exported)
     stablehlo_txt = stablehlo_gm.get_stablehlo_text()
-    fx_node_cnt = count_qdq_ops(exported.graph_module.graph)
-    self.assertEqual(
-        stablehlo_txt.count("stablehlo.uniform_quantize"),
-        fx_node_cnt["qunatize"])
-    self.assertEqual(
-        stablehlo_txt.count("stablehlo.uniform_dequantize"),
-        fx_node_cnt["dequantize"])
+    # fx_node_cnt = count_qdq_ops(exported.graph_module.graph)
+    # Do not compare the number of qdq with the qdq in FX Graph.
+    # In FX Graph, there will be 2 same dq ops in the backbone path
+    # and the residule path.
+    # The redundant dq ops will be removed by StableHLO
+    # CanonicalizerPass/CSE Pass.
+    self.assertEqual(stablehlo_txt.count("stablehlo.uniform_quantize"), 54)
+    self.assertEqual(stablehlo_txt.count("stablehlo.uniform_dequantize"), 54)
     # Save as tf.saved_model
-    tmp_path = tempfile.mkdtemp()
-    save_torch_module_as_tf_saved_model(m, args, tmp_path)
-    self.assertTrue(os.path.exists(os.path.join(tmp_path, 'saved_model.pb')))
+    if has_tf_package():
+      tmp_path = tempfile.mkdtemp()
+      save_torch_module_as_tf_saved_model(m, args, tmp_path)
+      self.assertTrue(os.path.exists(os.path.join(tmp_path, 'saved_model.pb')))
 
 
 if __name__ == '__main__':

--- a/test/stablehlo/utils.py
+++ b/test/stablehlo/utils.py
@@ -1,0 +1,10 @@
+import functools
+
+
+@functools.lru_cache
+def has_tf_package() -> bool:
+  try:
+    import tensorflow
+    return tensorflow is not None
+  except ImportError:
+    return False


### PR DESCRIPTION
If TF is installed in the env, tests that export stablehlo to tf.saved_model will be run, otherwise they will be skipped.