### PR TITLE
Register OpOverload when OpOverloadPacket is registered

### DIFF
--- a/experimental/torch_xla2/torch_xla2/ops_registry.py
+++ b/experimental/torch_xla2/torch_xla2/ops_registry.py
@@ -24,6 +24,9 @@ class LoweringRegistry:
     return candidate
 
   def register(self, op, lowering):
+    if isinstance(op, torch._ops.OpOverloadPacket):
+      if hasattr(op, 'default'):
+        self.registered_ops[op.default] = lowering
     self.registered_ops[op] = lowering
 
 


### PR DESCRIPTION
There is case that when the op is registered, `OpOverloadPacket<op>` is registered. When the op is called, `OpOverload<op>` is called. Register `OpOverload<op>` when `OpOverloadPacket<op>` is registered to cover this case.

Test:
CI test