### PR TITLE
Add dtype assertion in test, fix dtype in lowering

### DIFF
--- a/experimental/torch_xla2/test/test_core_aten_ops.py
+++ b/experimental/torch_xla2/test/test_core_aten_ops.py
@@ -17,7 +17,10 @@ def diff_output(testcase, output1, output2, rtol, atol, equal_nan=True):
       testcase.assertEqual(
           torch.is_floating_point(output1),
           torch.is_floating_point(output2_cpu),
-          "Outputs are not both floating point or integer point.")
+          "Torch output is_floating_point:{} vs "
+          "JAX output is_floating_point:{}.".format(
+              torch.is_floating_point(output1),
+              torch.is_floating_point(output2_cpu)))
       output2_cpu = output2_cpu.to(output1.dtype)
     testcase.assertTrue(
         torch.allclose(

--- a/experimental/torch_xla2/test/test_core_aten_ops.py
+++ b/experimental/torch_xla2/test/test_core_aten_ops.py
@@ -14,6 +14,10 @@ def diff_output(testcase, output1, output2, rtol, atol, equal_nan=True):
     testcase.assertIsInstance(output2, torch.Tensor)
     output2_cpu = output2.detach().cpu()
     if output2_cpu.dtype != output1.dtype:
+      testcase.assertEqual(
+          torch.is_floating_point(output1),
+          torch.is_floating_point(output2_cpu),
+          "Outputs are not both floating point or integer point.")
       output2_cpu = output2_cpu.to(output1.dtype)
     testcase.assertTrue(
         torch.allclose(
@@ -1503,6 +1507,14 @@ class TestCoreAtenOps(unittest.TestCase):
     args = (
         torch.randint(0, 10, (10, 10)).to(torch.int32),
         0.123,
+    )
+    kwargs = dict()
+    run_export_and_compare(self, torch.ops.aten.fmod.Scalar, args, kwargs)
+
+  def test_aten_fmod_Scalar_3(self):
+    args = (
+        torch.randint(0, 10, (10, 10)).to(torch.int64),
+        3,
     )
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.fmod.Scalar, args, kwargs)

--- a/experimental/torch_xla2/torch_xla2/ops.py
+++ b/experimental/torch_xla2/torch_xla2/ops.py
@@ -236,8 +236,7 @@ def _aten_view_as_complex(input):
 def _aten_div(x, y, rounding_mode=""):
   res = x / y
   if rounding_mode == "trunc":
-    # res = jnp.trunc(res).astype(x.dtype)
-    res = jnp.trunc(res)
+    res = jnp.trunc(res).astype(x.dtype)
   return res
 
 

--- a/experimental/torch_xla2/torch_xla2/ops.py
+++ b/experimental/torch_xla2/torch_xla2/ops.py
@@ -236,6 +236,7 @@ def _aten_view_as_complex(input):
 def _aten_div(x, y, rounding_mode=""):
   res = x / y
   if rounding_mode == "trunc":
+    # res = jnp.trunc(res).astype(x.dtype)
     res = jnp.trunc(res)
   return res
 


### PR DESCRIPTION
[DO NOT REVIEW UNTIL ALL FAILED CASES ARE FIXED]
- Add a new test to capture the return type of `fmod`
- Add assertion on dtype in test. Torch and TorchXLA2 should return both fp or integer results

The following tests failed with the new dtype assertion
```
FAILED test/test_core_aten_ops.py::TestCoreAtenOps::test_aten_addmm_2 - AssertionError: False != True : Outputs are not both floating point or integer point.
FAILED test/test_core_aten_ops.py::TestCoreAtenOps::test_aten_ceil_2 - AssertionError: False != True : Outputs are not both floating point or integer point.
FAILED test/test_core_aten_ops.py::TestCoreAtenOps::test_aten_div_Scalar_mode_2 - AssertionError: True != False : Outputs are not both floating point or integer point.
FAILED test/test_core_aten_ops.py::TestCoreAtenOps::test_aten_floor_2 - AssertionError: False != True : Outputs are not both floating point or integer point.
FAILED test/test_core_aten_ops.py::TestCoreAtenOps::test_aten_hardtanh_2 - AssertionError: False != True : Outputs are not both floating point or integer point.
FAILED test/test_core_aten_ops.py::TestCoreAtenOps::test_aten_masked_fill_Scalar_2 - AssertionError: False != True : Outputs are not both floating point or integer point.
FAILED test/test_core_aten_ops.py::TestCoreAtenOps::test_aten_reflection_pad1d_1 - AssertionError: False != True : Outputs are not both floating point or integer point.
FAILED test/test_core_aten_ops.py::TestCoreAtenOps::test_aten_reflection_pad2d_1 - AssertionError: False != True : Outputs are not both floating point or integer point.
FAILED test/test_core_aten_ops.py::TestCoreAtenOps::test_aten_reflection_pad3d_2 - AssertionError: False != True : Outputs are not both floating point or integer point.
FAILED test/test_core_aten_ops.py::TestCoreAtenOps::test_aten_replication_pad2d_1 - AssertionError: False != True : Outputs are not both floating point or integer point.
FAILED test/test_core_aten_ops.py::TestCoreAtenOps::test_aten_replication_pad3d_1 - AssertionError: False != True : Outputs are not both floating point or integer point.
FAILED test/test_core_aten_ops.py::TestCoreAtenOps::test_aten_trunc_2 - AssertionError: False != True : Outputs are not both floating point or integer point.
```
