### PR TITLE
Add API to donate input buffer for dynamo execution

### DIFF
--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -286,7 +286,7 @@ class DynamoCpuFallbackTest(unittest.TestCase):
     xla_dynamo_res = dynamo_fn(t_xla)
     self.assertTrue(torch.allclose(cpu_res, xla_dynamo_res.cpu()))
     self.assertEqual(met.metric_data('CompileTime')[0], 3)
-    self.assertEqual(met.metric_data('ExecuteTime')[0], 9)
+    self.assertEqual(met.metric_data('ExecuteTime')[0], 7)
 
     # Second tracing
     met.clear_all()

--- a/test/dynamo/test_dynamo_aliasing.py
+++ b/test/dynamo/test_dynamo_aliasing.py
@@ -67,7 +67,8 @@ class TestBufferDonationAliasing(unittest.TestCase):
 
     res = dummy_add_compiled(input)
     # check input's buffer has been aliased.
-    self.assertIn('Data Handle: None',
+    xm.wait_device_ops()
+    self.assertIn('Data Handle: Deleted',
                   torch_xla._XLAC._get_xla_tensor_debug_info(input))
     torch.allclose(input_cloned.cpu() + 1, res.cpu())
 

--- a/test/dynamo/test_dynamo_aliasing.py
+++ b/test/dynamo/test_dynamo_aliasing.py
@@ -25,7 +25,7 @@ class TestBufferDonationUtil(unittest.TestCase):
     self.assertNotEqual(hash_no_donor, hash_with_donor_and_context)
 
 
-class TestBufferDonationAliasing(unittest.TestCase):
+class TestDynamoBufferDonationAliasing(unittest.TestCase):
 
   def dummy_inplace_add(self, input):
     input += 1
@@ -82,6 +82,41 @@ class TestBufferDonationAliasing(unittest.TestCase):
     self.assertFalse(torch_xla._XLAC._set_buffer_donation(res, True))
     self.assertFalse(torch_xla._XLAC._get_buffer_donation(res))
     self.assertNotIn('XlaSetBufferDonation', met.counter_names())
+
+
+class TestNonDynamoBufferDonationAliasing(unittest.TestCase):
+
+  def dummy_fn(self, input):
+    return torch.cos(torch.sin(input))
+
+  # Currently let's skip buffer donation api for the non-dynamo use case
+  def test_buffer_donation_skip_for_non_dynamo(self):
+    device = xm.xla_device()
+    input = torch.randn(5, 5).to(device)
+    xm.mark_step()
+    met.clear_all()
+
+    # We should be able to set buffer donation for input tensor, but when mark_step
+    # triggered, the buffer donation should be ignored.
+    self.assertTrue(torch_xla._XLAC._set_buffer_donation(input, True))
+    res = self.dummy_fn(input)
+    xm.mark_step()
+    # Make sure that input buffer is not aliased and can be used for other compuations.
+    # Also make sure that buffer_donation will not trigger recompilation in non-dynamo.
+    self.assertTrue(torch_xla._XLAC._set_buffer_donation(input, False))
+    res2 = self.dummy_fn(input)
+    xm.mark_step()
+    torch.allclose(res.cpu(), res2.cpu())
+    self.assertEqual(met.metric_data('CompileTime')[0], 1)
+
+  def test_no_op_mark_step_keep_buffer_donation(self):
+    device = xm.xla_device()
+    input = torch.randn(5, 5).to(device)
+    self.assertTrue(torch_xla._XLAC._set_buffer_donation(input, True))
+    xm.mark_step()
+    self.assertTrue(torch_xla._XLAC._get_buffer_donation(input))
+    xm.mark_step()
+    self.assertTrue(torch_xla._XLAC._get_buffer_donation(input))
 
 
 if __name__ == '__main__':

--- a/test/dynamo/test_dynamo_aliasing.py
+++ b/test/dynamo/test_dynamo_aliasing.py
@@ -5,6 +5,17 @@ import torch_xla
 import torch_xla.core.xla_model as xm
 import torch_xla.debug.metrics as met
 
+class TestBufferDonationUtil(unittest.TestCase):
+
+  def test_hash_with_buffer_donor(self):
+    device = xm.xla_device()
+    input = torch.randn(5, 5).to(device)
+    res = torch.cos(input)
+    hash_no_donor = torch_xla._XLAC._get_graph_hash([res])
+    self.assertTrue(torch_xla._XLAC._set_buffer_donation(input, True))
+    hash_with_donor = torch_xla._XLAC._get_graph_hash([res])
+    self.assertNotEqual(hash_no_donor, hash_with_donor)
+
 
 class TestBufferDonationAliasing(unittest.TestCase):
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -172,6 +172,7 @@ function run_xla_op_tests1 {
   run_test "$CDIR/test_metrics.py"
   run_test "$CDIR/test_zero1.py"
   run_test "$CDIR/dynamo/test_dynamo_integrations_util.py"
+  run_test "$CDIR/dynamo/test_dynamo_aliasing.py"
   run_test "$CDIR/dynamo/test_dynamo.py"
   run_test "$CDIR/dynamo/test_bridge.py"
   run_test "$CDIR/dynamo/test_num_output.py"

--- a/torch_xla/csrc/helpers.cpp
+++ b/torch_xla/csrc/helpers.cpp
@@ -905,7 +905,8 @@ xla::XlaOp XlaHelpers::PromotedLogicalUnaryOp(
 xla::StatusOr<xla::XlaComputation> XlaHelpers::WrapXlaComputation(
     const xla::XlaComputation& computation,
     const std::vector<xla::Shape>& parameter_shapes,
-    std::vector<std::pair<int64_t, int64_t>> input_output_alias_pair) {
+    const std::vector<std::pair<int64_t, int64_t>>& input_output_alias_pair,
+    const std::vector<size_t>& buffer_donor_indices) {
   xla::XlaBuilder builder(computation.proto().name());
 
   // Construct a single tuple parameter.
@@ -928,13 +929,20 @@ xla::StatusOr<xla::XlaComputation> XlaHelpers::WrapXlaComputation(
   xla::XlaOp orig_result = xla::Call(&builder, computation, inner_params);
 
   // Rebuild aliasing.
-  for (const auto& [input_index, output_index] : input_output_alias_pair) {
-    // Both input and output will be a tuple so parameter_number will always
-    // be
-    // 0
-    builder.SetUpAlias(/*output_index=*/xla::ShapeIndex({output_index}),
-                       /*param_number=*/0,
-                       /*param_index=*/xla::ShapeIndex({input_index}));
+  if (input_output_alias_pair.size() > 0) {
+    for (const auto& [input_index, output_index] : input_output_alias_pair) {
+      // Both input and output will be a tuple so parameter_number will always
+      // be
+      // 0
+      builder.SetUpAlias(/*output_index=*/xla::ShapeIndex({output_index}),
+                         /*param_number=*/0,
+                         /*param_index=*/xla::ShapeIndex({input_index}));
+    }
+  } else if (buffer_donor_indices.size() > 0) {
+    for (size_t i : buffer_donor_indices) {
+      builder.AddBufferDonor(/*param_number=*/0,
+                             /*param_index=*/xla::ShapeIndex({i}));
+    }
   }
 
   return builder.Build(orig_result);

--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -375,7 +375,8 @@ class XlaHelpers {
   static xla::StatusOr<xla::XlaComputation> WrapXlaComputation(
       const xla::XlaComputation& computation,
       const std::vector<xla::Shape>& parameter_shapes,
-      std::vector<std::pair<int64_t, int64_t>> input_output_alias_pair);
+      const std::vector<std::pair<int64_t, int64_t>>& input_output_alias_pair,
+      const std::vector<size_t>& buffer_donor_indices);
 
   static torch::lazy::Shape ConvertXlaShapeToLazy(const xla::Shape& shape);
 

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2275,14 +2275,12 @@ void InitXlaModuleBindings(py::module m) {
     if (!xtensor) {
       return false;
     } else if (xtensor->CurrentDataHandle() != nullptr) {
-      std::cerr << "trying to access data handle\n";
       auto data = std::dynamic_pointer_cast<runtime::ComputationClient::Data>(
           xtensor->CurrentDataHandle());
       return data->should_donate_buffer();
     } else if (xtensor->CurrentIrValue().node != nullptr) {
       auto device_data =
           torch_xla::DeviceData::Cast(xtensor->CurrentIrValue().node.get());
-      std::cerr << "device data cast done\n";
       if (device_data != nullptr) {
         return device_data->get_buffer_donation();
       } else {

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2244,26 +2244,31 @@ void InitXlaModuleBindings(py::module m) {
     xtensor->MarkDynamicDimension(dim);
   });
 
-  m.def("_set_buffer_donation", [](at::Tensor& input, bool should_donate) {
-    XLATensorPtr xtensor = bridge::GetXlaTensor(input);
-    bool buffer_donation_setted = false;
-    if (!xtensor) {
-      // input tensor is not a XLATensor, return here.
-    } else if (xtensor->CurrentDataHandle() != nullptr) {
-      auto data = std::dynamic_pointer_cast<runtime::ComputationClient::Data>(
-          xtensor->CurrentDataHandle());
-      data->set_should_donate_buffer(should_donate);
-      buffer_donation_setted = true;
-    } else if (xtensor->CurrentIrValue().node != nullptr) {
-      torch::lazy::NodePtr node = xtensor->CurrentIrValue().node;
-      auto device_data = torch_xla::DeviceData::Cast(node.get());
-      if (device_data != nullptr) {
-        device_data->set_buffer_donation(should_donate);
-        buffer_donation_setted = true;
-      }
-    }
-    std::cerr << "buffer_donation_setted = " << buffer_donation_setted << "\n";
-  });
+  m.def("_set_buffer_donation",
+        [](at::Tensor& input, bool should_donate) -> bool {
+          XLATensorPtr xtensor = bridge::GetXlaTensor(input);
+          bool buffer_donation_updated = false;
+          if (!xtensor) {
+            // input tensor is not a XLATensor, return here.
+          } else if (xtensor->CurrentDataHandle() != nullptr) {
+            auto data =
+                std::dynamic_pointer_cast<runtime::ComputationClient::Data>(
+                    xtensor->CurrentDataHandle());
+            data->set_should_donate_buffer(should_donate);
+            buffer_donation_updated = true;
+          } else if (xtensor->CurrentIrValue().node != nullptr) {
+            torch::lazy::NodePtr node = xtensor->CurrentIrValue().node;
+            auto device_data = torch_xla::DeviceData::Cast(node.get());
+            if (device_data != nullptr) {
+              device_data->set_buffer_donation(should_donate);
+              buffer_donation_updated = true;
+            }
+          }
+          if (buffer_donation_updated) {
+            TORCH_LAZY_COUNTER("XlaSetBufferDonation", 1);
+          }
+          return buffer_donation_updated;
+        });
 
   m.def("_get_buffer_donation", [](const at::Tensor& input) -> bool {
     XLATensorPtr xtensor = bridge::GetXlaTensor(input);

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2244,6 +2244,14 @@ void InitXlaModuleBindings(py::module m) {
     xtensor->MarkDynamicDimension(dim);
   });
 
+  // This api will set the `should_donate_buffer_` field in the
+  // ComputationClient::Data. This api is currently only useful if you are
+  // running with `torch.compile`. Buffer assocaited with data with
+  // `should_donate_buffer_` set to true will be donated to the output, You
+  // should only use this api if
+  // 1. You are using torch.compile
+  // 2. You will inplace update a tensor in the `torch.compiled` function(so the
+  //    currnet buffer can be donated after compuation)
   m.def("_set_buffer_donation",
         [](at::Tensor& input, bool should_donate) -> bool {
           XLATensorPtr xtensor = bridge::GetXlaTensor(input);

--- a/torch_xla/csrc/ops/device_data.h
+++ b/torch_xla/csrc/ops/device_data.h
@@ -3,6 +3,8 @@
 
 #include <torch/csrc/lazy/backend/backend_data.h>
 
+#include <iostream>
+
 #include "torch_xla/csrc/ir.h"
 #include "torch_xla/csrc/runtime/computation_client.h"
 
@@ -25,6 +27,15 @@ class DeviceData : public XlaNode {
   void set_buffer_donation(bool should_donate_buffer) {
     std::dynamic_pointer_cast<runtime::ComputationClient::Data>(data_)
         ->set_should_donate_buffer(should_donate_buffer);
+    // std::cerr << std::dynamic_pointer_cast<runtime::ComputationClient::Data>(
+    //                  data_)
+    //                  ->ToString()
+    //           << "\n";
+  }
+
+  bool get_buffer_donation() {
+    return std::dynamic_pointer_cast<runtime::ComputationClient::Data>(data_)
+        ->should_donate_buffer();
   }
 
   // With SPMD sharding propagation, we need to update the unpartitioned

--- a/torch_xla/csrc/ops/device_data.h
+++ b/torch_xla/csrc/ops/device_data.h
@@ -3,8 +3,6 @@
 
 #include <torch/csrc/lazy/backend/backend_data.h>
 
-#include <iostream>
-
 #include "torch_xla/csrc/ir.h"
 #include "torch_xla/csrc/runtime/computation_client.h"
 

--- a/torch_xla/csrc/ops/device_data.h
+++ b/torch_xla/csrc/ops/device_data.h
@@ -27,10 +27,6 @@ class DeviceData : public XlaNode {
   void set_buffer_donation(bool should_donate_buffer) {
     std::dynamic_pointer_cast<runtime::ComputationClient::Data>(data_)
         ->set_should_donate_buffer(should_donate_buffer);
-    // std::cerr << std::dynamic_pointer_cast<runtime::ComputationClient::Data>(
-    //                  data_)
-    //                  ->ToString()
-    //           << "\n";
   }
 
   bool get_buffer_donation() {

--- a/torch_xla/csrc/ops/device_data.h
+++ b/torch_xla/csrc/ops/device_data.h
@@ -22,6 +22,11 @@ class DeviceData : public XlaNode {
     return data_;
   }
 
+  void set_buffer_donation(bool should_donate_buffer) {
+    std::dynamic_pointer_cast<runtime::ComputationClient::Data>(data_)
+        ->set_should_donate_buffer(should_donate_buffer);
+  }
+
   // With SPMD sharding propagation, we need to update the unpartitioned
   // backend data with a partitioned one in the node operands. Note that
   // this is permitted only if the node holds a placeholder.

--- a/torch_xla/csrc/runtime/computation_client.h
+++ b/torch_xla/csrc/runtime/computation_client.h
@@ -51,17 +51,25 @@ class ComputationClient {
   class Data : public torch::lazy::BackendData {
    public:
     // TODO set Device and torch::lazy_shape correctly
-    Data(std::string device, xla::Shape shape)
+    Data(std::string device, xla::Shape shape,
+         bool should_donate_buffer = false)
         : torch::lazy::BackendData(ParseDeviceString(device),
                                    torch::lazy::Shape()),
           xla_device_(device),
-          xla_shape_(std::move(shape)) {}
+          xla_shape_(std::move(shape)),
+          should_donate_buffer_(should_donate_buffer) {}
 
     virtual ~Data() {}
 
     const std::string& device() const { return xla_device_; }
 
     const xla::Shape& shape() const { return xla_shape_; }
+
+    bool should_donate_buffer() const { return should_donate_buffer_; }
+
+    void set_should_donate_buffer(bool should_donate_buffer) {
+      should_donate_buffer_ = should_donate_buffer;
+    }
 
     virtual std::string ToString() const = 0;
 
@@ -72,6 +80,7 @@ class ComputationClient {
    private:
     std::string xla_device_;
     xla::Shape xla_shape_;
+    bool should_donate_buffer_;
   };
 
   using DataPtr = std::shared_ptr<Data>;

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -177,7 +177,7 @@ class PjRtComputationClient : public ComputationClient {
       if (HasValue()) {
         ss << reinterpret_cast<std::uintptr_t>(buffer.get()) << "\n";
       } else {
-        ss << "None\n";
+        ss << (buffer == nullptr ? "None" : "Deleted") << "\n";
       }
       return ss.str();
     }

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -948,6 +948,16 @@ void XLAGraphExecutor::ExtractIRAndPrepareXlaData_(
     torch::lazy::BackendDataPtr handle =
         runtime::GetComputationClient()->CreateDataPlaceholder(
             tensor_device.toString(), std::move(shape));
+
+    // If current IR is a device data, executing the graph will generate a new
+    // Data with the same value. In this case we want to inherit the buffer
+    // donation option from the old Data.
+    auto device_data = torch_xla::DeviceData::Cast(ir_value.node.get());
+    if (device_data && device_data->get_buffer_donation()) {
+      std::dynamic_pointer_cast<runtime::ComputationClient::Data>(handle)
+          ->set_should_donate_buffer(true);
+    }
+
     tensor_data_vec.push_back(handle);
     if (tensor->CurrentDataHandle() == nullptr && config.force_ltc_data) {
       tensor->AssignIrValue(torch::lazy::Value());
@@ -1227,6 +1237,8 @@ std::vector<size_t> XLAGraphExecutor::SetBufferDonors(
       lowering_ctx->builder()->AddBufferDonor(/*param_number=*/i,
                                               /*param_index=*/{});
       cerr << "add buffer donor at index " << i << "\n";
+    } else {
+      cerr << "skip buffer donor at index" << i << "\n";
     }
   }
   TORCH_LAZY_VALUE_METRIC("InputOutputAliasCount", buffer_donor_indexs.size());
@@ -1313,7 +1325,8 @@ XLAGraphExecutor::CompilationResult XLAGraphExecutor::Compile(
                << " parameters. Threadshold = "
                << parameter_wrapping_threadshold;
     computation = ConsumeValue(XlaHelpers::WrapXlaComputation(
-        computation, program_shape.parameters(), input_output_alias_pair));
+        computation, program_shape.parameters(), input_output_alias_pair,
+        buffer_donor_indices));
     program_shape = ConsumeValue(computation.GetProgramShape());
   }
   xla::Shape shape = MakeShapeWithDeviceLayout(

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -320,10 +320,11 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
 
   // We don't use the upstream TryRunCachedSync since
   // our CachedComputation is different from upstream.
-  std::shared_ptr<Async> TryRunCachedSync(
+  std::pair<bool, std::shared_ptr<Async>> TryRunCachedSync(
       std::vector<XLATensorPtr>* tensors, SyncTensorCollection* coll,
       PostOrderData* po_data,
-      const std::vector<torch::lazy::BackendDataPtr>& tensor_data_vec);
+      const std::vector<torch::lazy::BackendDataPtr>& tensor_data_vec,
+      bool warm_up_cache_only);
 
   std::vector<std::pair<int64_t, int64_t>> BuildInputOutputAliases(
       const std::vector<XLATensorPtr>& tensors,

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -329,6 +329,8 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
       const std::vector<XLATensorPtr>& tensors,
       absl::Span<const size_t> indices, LoweringContext* lowering_ctx);
 
+  std::vector<size_t> SetBufferDonors(LoweringContext* lowering_ctx);
+
   // We don't use upstream Compile to have BuildInputOutputAliases.
   CompilationResult Compile(const std::vector<XLATensorPtr>& tensors,
                             absl::Span<const std::string> devices,


### PR DESCRIPTION
This pr adds an api `torch_xla._XLAC._set_buffer_donation` which can be used to mark the buffer associated with current tensor to be donated in the next execution. This api is currently only enabled for dynamo(torch.compile) use case, ti is a no-op in LazyTensor world(since LTC already has the auto aliasing based on inplace op and dynamo's functionization pass remove all inplace ops).

Example usage should be
```
  def dummy_inplace_add(self, input):
    input += 1
    return

  def test_manual_buffer_donation(self):
    device = xm.xla_device()
    input = torch.randn(5, 5).to(device)
    dummy_inplace_add_compiled = torch.compile(
        self.dummy_inplace_add, backend='openxla')

    met.clear_all()
    # input is a device_data, we should be able to set the buffer donation field.
    self.assertTrue(torch_xla._XLAC._set_buffer_donation(input, True))
    # make sure buffer donation setting is correctly updated
    self.assertTrue(torch_xla._XLAC._get_buffer_donation(input))
	
	for _ in range(100):
      # You don't need to keep calling this function if you function does not cause dynamo recompilation.
      # check below for the reason.
      self.assertTrue(torch_xla._XLAC._set_buffer_donation(input, True))
      dummy_inplace_add_compiled(input)
```

Please note a couple things
1. `_set_buffer_donation` is called on a tensor, but being applied to the buffer associated with this tensor. If the tensor you passed in is not a buffer(for example an intermediate tensor that has not been evulated) this api will be no-op and return false.
2. Buffer aliasing is being set up during compilation time. Torch Dynamo also does not track this field, so even if you change `_set_buffer_donation` after first execution(torch.compile compilation triggered at first execution of the compiled function), aliasing will not change. 