### PR TITLE
[Core Aten Ops] Lower reflection_pad1d, reflection_pad1d_backward, reflection_pad3d and reflection_pad3d_backward

### DIFF
--- a/codegen/xla_native_functions.yaml
+++ b/codegen/xla_native_functions.yaml
@@ -282,8 +282,12 @@ supported:
   - random_.from
   - random_.to
   - randperm
+  - reflection_pad1d
+  - reflection_pad1d_backward
   - reflection_pad2d
   - reflection_pad2d_backward
+  - reflection_pad3d
+  - reflection_pad3d_backward
   - remainder.Scalar
   - remainder.Tensor
   - replication_pad1d

--- a/test/cpp/test_aten_xla_tensor_3.cpp
+++ b/test/cpp/test_aten_xla_tensor_3.cpp
@@ -664,7 +664,7 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad1dRank3) {
 }
 
 TEST_F(AtenXlaTensorTest, TestReflectionPad1dBackward) {
-  std::vector<int64_t> pad{2, 3};
+  std::vector<int64_t> pad{2, 2};
   auto testfn = [&](const std::vector<torch::Tensor>& inputs) -> torch::Tensor {
     return torch::reflection_pad1d(inputs[0], pad);
   };
@@ -723,10 +723,10 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad2dBackward) {
   ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
 }
 
-TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank4) {
+TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank5) {
   torch::Tensor input =
-      torch::rand({2, 2, 3, 4}, torch::TensorOptions(torch::kFloat));
-  std::vector<int64_t> pad{2, 2, 2, 2, 2, 2};
+      torch::rand({2, 2, 3, 4, 2}, torch::TensorOptions(torch::kFloat));
+  std::vector<int64_t> pad{1, 2, 2, 2, 2, 2};
   torch::Tensor output = torch::reflection_pad3d(input, pad);
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor xla_input = CopyToDevice(input, device);
@@ -738,9 +738,9 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank4) {
   ExpectCounterChanged("xla::reflection_pad3d", cpp_test::GetIgnoredCounters());
 }
 
-TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank5) {
+TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank6) {
   torch::Tensor input =
-      torch::rand({2, 2, 3, 4, 4}, torch::TensorOptions(torch::kFloat));
+      torch::rand({2, 2, 3, 4, 4, 2}, torch::TensorOptions(torch::kFloat));
   std::vector<int64_t> pad{2, 2, 2, 2, 2, 2};
   torch::Tensor output = torch::reflection_pad3d(input, pad);
   ForEachDevice([&](const torch::Device& device) {
@@ -754,13 +754,13 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank5) {
 }
 
 TEST_F(AtenXlaTensorTest, TestReflectionPad3dBackward) {
-  std::vector<int64_t> pad{2, 3, 1, 2, 1, 1};
+  std::vector<int64_t> pad{2, 2, 1, 2, 1, 1};
   auto testfn = [&](const std::vector<torch::Tensor>& inputs) -> torch::Tensor {
     return torch::reflection_pad3d(inputs[0], pad);
   };
   ForEachDevice([&](const torch::Device& device) {
     TestBackward(
-        {torch::rand({1, 2, 4, 4, 2},
+        {torch::rand({2, 2, 4, 4, 2, 2},
                      torch::TensorOptions(torch::kFloat).requires_grad(true))},
         device, testfn);
   });

--- a/test/cpp/test_aten_xla_tensor_3.cpp
+++ b/test/cpp/test_aten_xla_tensor_3.cpp
@@ -738,9 +738,9 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank5) {
   ExpectCounterChanged("xla::reflection_pad3d", cpp_test::GetIgnoredCounters());
 }
 
-TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank6) {
+TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank4) {
   torch::Tensor input =
-      torch::rand({2, 2, 2, 2, 2, 2}, torch::TensorOptions(torch::kFloat));
+      torch::rand({2, 2, 3, 4}, torch::TensorOptions(torch::kFloat));
   std::vector<int64_t> pad{1, 1, 1, 1, 1, 1};
   torch::Tensor output = torch::reflection_pad3d(input, pad);
   ForEachDevice([&](const torch::Device& device) {

--- a/test/cpp/test_aten_xla_tensor_3.cpp
+++ b/test/cpp/test_aten_xla_tensor_3.cpp
@@ -636,7 +636,7 @@ TEST_F(AtenXlaTensorTest, TestConstantPadIncomplete) {
 TEST_F(AtenXlaTensorTest, TestReflectionPad1dRank2) {
   torch::Tensor input =
       torch::rand({2, 3}, torch::TensorOptions(torch::kFloat));
-  std::vector<int64_t> pad{2, 2, 2};
+  std::vector<int64_t> pad{2, 2};
   torch::Tensor output = torch::reflection_pad1d(input, pad);
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor xla_input = CopyToDevice(input, device);
@@ -651,7 +651,7 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad1dRank2) {
 TEST_F(AtenXlaTensorTest, TestReflectionPad1dRank3) {
   torch::Tensor input =
       torch::rand({2, 3, 4}, torch::TensorOptions(torch::kFloat));
-  std::vector<int64_t> pad{2, 2, 2};
+  std::vector<int64_t> pad{2, 2};
   torch::Tensor output = torch::reflection_pad1d(input, pad);
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor xla_input = CopyToDevice(input, device);
@@ -664,13 +664,13 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad1dRank3) {
 }
 
 TEST_F(AtenXlaTensorTest, TestReflectionPad1dBackward) {
-  std::vector<int64_t> pad{2, 3, 1};
+  std::vector<int64_t> pad{2, 3};
   auto testfn = [&](const std::vector<torch::Tensor>& inputs) -> torch::Tensor {
     return torch::reflection_pad1d(inputs[0], pad);
   };
   ForEachDevice([&](const torch::Device& device) {
     TestBackward(
-        {torch::rand({1, 2, 4},
+        {torch::rand({2, 2, 3},
                      torch::TensorOptions(torch::kFloat).requires_grad(true))},
         device, testfn);
   });
@@ -725,7 +725,7 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad2dBackward) {
 
 TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank4) {
   torch::Tensor input =
-      torch::rand({2, 2, 3, 4, 4}, torch::TensorOptions(torch::kFloat));
+      torch::rand({2, 2, 3, 4}, torch::TensorOptions(torch::kFloat));
   std::vector<int64_t> pad{2, 2, 2, 2, 2, 2};
   torch::Tensor output = torch::reflection_pad3d(input, pad);
   ForEachDevice([&](const torch::Device& device) {
@@ -740,7 +740,7 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank4) {
 
 TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank5) {
   torch::Tensor input =
-      torch::rand({2, 2, 3, 4, 4, 4}, torch::TensorOptions(torch::kFloat));
+      torch::rand({2, 2, 3, 4, 4}, torch::TensorOptions(torch::kFloat));
   std::vector<int64_t> pad{2, 2, 2, 2, 2, 2};
   torch::Tensor output = torch::reflection_pad3d(input, pad);
   ForEachDevice([&](const torch::Device& device) {
@@ -760,7 +760,7 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad3dBackward) {
   };
   ForEachDevice([&](const torch::Device& device) {
     TestBackward(
-        {torch::rand({1, 2, 4, 4, 2, 2},
+        {torch::rand({1, 2, 4, 4, 2},
                      torch::TensorOptions(torch::kFloat).requires_grad(true))},
         device, testfn);
   });

--- a/test/cpp/test_aten_xla_tensor_3.cpp
+++ b/test/cpp/test_aten_xla_tensor_3.cpp
@@ -741,7 +741,7 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank5) {
 TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank6) {
   torch::Tensor input =
       torch::rand({2, 3, 3, 4, 4, 3}, torch::TensorOptions(torch::kFloat));
-  std::vector<int64_t> pad{1, 1, 1, 1, 1, 2};
+  std::vector<int64_t> pad{1, 1, 1, 1, 1, 1};
   torch::Tensor output = torch::reflection_pad3d(input, pad);
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor xla_input = CopyToDevice(input, device);
@@ -754,7 +754,7 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank6) {
 }
 
 TEST_F(AtenXlaTensorTest, TestReflectionPad3dBackward) {
-  std::vector<int64_t> pad{1, 1, 1, 2, 1, 1};
+  std::vector<int64_t> pad{1, 1, 1, 1, 1, 1};
   auto testfn = [&](const std::vector<torch::Tensor>& inputs) -> torch::Tensor {
     return torch::reflection_pad3d(inputs[0], pad);
   };

--- a/test/cpp/test_aten_xla_tensor_3.cpp
+++ b/test/cpp/test_aten_xla_tensor_3.cpp
@@ -754,7 +754,7 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank4) {
 }
 
 TEST_F(AtenXlaTensorTest, TestReflectionPad3dBackward) {
-  std::vector<int64_t> pad{1, 1, 1, 2, 1, 1};
+  std::vector<int64_t> pad{1, 1, 1, 1, 1, 1};
   auto testfn = [&](const std::vector<torch::Tensor>& inputs) -> torch::Tensor {
     return torch::reflection_pad3d(inputs[0], pad);
   };

--- a/test/cpp/test_aten_xla_tensor_3.cpp
+++ b/test/cpp/test_aten_xla_tensor_3.cpp
@@ -726,7 +726,7 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad2dBackward) {
 TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank5) {
   torch::Tensor input =
       torch::rand({2, 2, 3, 4, 2}, torch::TensorOptions(torch::kFloat));
-  std::vector<int64_t> pad{1, 2, 2, 2, 2, 2};
+  std::vector<int64_t> pad{1, 1, 1, 2, 2, 1};
   torch::Tensor output = torch::reflection_pad3d(input, pad);
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor xla_input = CopyToDevice(input, device);
@@ -740,8 +740,8 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank5) {
 
 TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank6) {
   torch::Tensor input =
-      torch::rand({2, 2, 3, 4, 4, 2}, torch::TensorOptions(torch::kFloat));
-  std::vector<int64_t> pad{2, 2, 2, 2, 2, 2};
+      torch::rand({2, 3, 3, 4, 4, 3}, torch::TensorOptions(torch::kFloat));
+  std::vector<int64_t> pad{1, 1, 1, 1, 1, 2};
   torch::Tensor output = torch::reflection_pad3d(input, pad);
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor xla_input = CopyToDevice(input, device);
@@ -754,7 +754,7 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank6) {
 }
 
 TEST_F(AtenXlaTensorTest, TestReflectionPad3dBackward) {
-  std::vector<int64_t> pad{2, 2, 1, 2, 1, 1};
+  std::vector<int64_t> pad{1, 1, 1, 2, 1, 1};
   auto testfn = [&](const std::vector<torch::Tensor>& inputs) -> torch::Tensor {
     return torch::reflection_pad3d(inputs[0], pad);
   };

--- a/test/cpp/test_aten_xla_tensor_3.cpp
+++ b/test/cpp/test_aten_xla_tensor_3.cpp
@@ -740,7 +740,7 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank5) {
 
 TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank6) {
   torch::Tensor input =
-      torch::rand({2, 3, 3, 4, 4, 3}, torch::TensorOptions(torch::kFloat));
+      torch::rand({2, 2, 3, 4, 2, 2}, torch::TensorOptions(torch::kFloat));
   std::vector<int64_t> pad{1, 1, 1, 1, 1, 1};
   torch::Tensor output = torch::reflection_pad3d(input, pad);
   ForEachDevice([&](const torch::Device& device) {
@@ -754,13 +754,13 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank6) {
 }
 
 TEST_F(AtenXlaTensorTest, TestReflectionPad3dBackward) {
-  std::vector<int64_t> pad{1, 1, 1, 1, 1, 1};
+  std::vector<int64_t> pad{2, 3, 1, 2, 2, 2};
   auto testfn = [&](const std::vector<torch::Tensor>& inputs) -> torch::Tensor {
     return torch::reflection_pad3d(inputs[0], pad);
   };
   ForEachDevice([&](const torch::Device& device) {
     TestBackward(
-        {torch::rand({2, 2, 4, 4, 2, 2},
+        {torch::rand({1, 2, 4, 4, 2, 2},
                      torch::TensorOptions(torch::kFloat).requires_grad(true))},
         device, testfn);
   });

--- a/test/cpp/test_aten_xla_tensor_3.cpp
+++ b/test/cpp/test_aten_xla_tensor_3.cpp
@@ -760,7 +760,7 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad3dBackward) {
   };
   ForEachDevice([&](const torch::Device& device) {
     TestBackward(
-        {torch::rand({2, 2, 4, 4, 2, 2},
+        {torch::rand({2, 2, 4, 4, 2},
                      torch::TensorOptions(torch::kFloat).requires_grad(true))},
         device, testfn);
   });

--- a/test/cpp/test_aten_xla_tensor_3.cpp
+++ b/test/cpp/test_aten_xla_tensor_3.cpp
@@ -740,7 +740,7 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank5) {
 
 TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank6) {
   torch::Tensor input =
-      torch::rand({2, 2, 3, 4, 2, 2}, torch::TensorOptions(torch::kFloat));
+      torch::rand({2, 2, 2, 2, 2, 2}, torch::TensorOptions(torch::kFloat));
   std::vector<int64_t> pad{1, 1, 1, 1, 1, 1};
   torch::Tensor output = torch::reflection_pad3d(input, pad);
   ForEachDevice([&](const torch::Device& device) {
@@ -754,7 +754,7 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank6) {
 }
 
 TEST_F(AtenXlaTensorTest, TestReflectionPad3dBackward) {
-  std::vector<int64_t> pad{2, 3, 1, 2, 2, 2};
+  std::vector<int64_t> pad{1, 1, 1, 2, 1, 1};
   auto testfn = [&](const std::vector<torch::Tensor>& inputs) -> torch::Tensor {
     return torch::reflection_pad3d(inputs[0], pad);
   };

--- a/test/cpp/test_aten_xla_tensor_3.cpp
+++ b/test/cpp/test_aten_xla_tensor_3.cpp
@@ -633,6 +633,51 @@ TEST_F(AtenXlaTensorTest, TestConstantPadIncomplete) {
   });
 }
 
+TEST_F(AtenXlaTensorTest, TestReflectionPad1dRank2) {
+  torch::Tensor input =
+      torch::rand({2, 3}, torch::TensorOptions(torch::kFloat));
+  std::vector<int64_t> pad{2, 2, 2};
+  torch::Tensor output = torch::reflection_pad1d(input, pad);
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_input = CopyToDevice(input, device);
+    torch::Tensor xla_output = torch::reflection_pad1d(xla_input, pad);
+    AllClose(output, xla_output);
+  });
+
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::reflection_pad1d", cpp_test::GetIgnoredCounters());
+}
+
+TEST_F(AtenXlaTensorTest, TestReflectionPad1dRank3) {
+  torch::Tensor input =
+      torch::rand({2, 3, 4}, torch::TensorOptions(torch::kFloat));
+  std::vector<int64_t> pad{2, 2, 2};
+  torch::Tensor output = torch::reflection_pad1d(input, pad);
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_input = CopyToDevice(input, device);
+    torch::Tensor xla_output = torch::reflection_pad1d(xla_input, pad);
+    AllClose(output, xla_output);
+  });
+
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::reflection_pad1d", cpp_test::GetIgnoredCounters());
+}
+
+TEST_F(AtenXlaTensorTest, TestReflectionPad1dBackward) {
+  std::vector<int64_t> pad{2, 3, 1};
+  auto testfn = [&](const std::vector<torch::Tensor>& inputs) -> torch::Tensor {
+    return torch::reflection_pad1d(inputs[0], pad);
+  };
+  ForEachDevice([&](const torch::Device& device) {
+    TestBackward(
+        {torch::rand({1, 2, 4},
+                     torch::TensorOptions(torch::kFloat).requires_grad(true))},
+        device, testfn);
+  });
+
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+}
+
 TEST_F(AtenXlaTensorTest, TestReflectionPad2dRank3) {
   torch::Tensor input =
       torch::rand({2, 3, 4}, torch::TensorOptions(torch::kFloat));
@@ -671,6 +716,51 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad2dBackward) {
   ForEachDevice([&](const torch::Device& device) {
     TestBackward(
         {torch::rand({1, 2, 4, 4},
+                     torch::TensorOptions(torch::kFloat).requires_grad(true))},
+        device, testfn);
+  });
+
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+}
+
+TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank4) {
+  torch::Tensor input =
+      torch::rand({2, 2, 3, 4, 4}, torch::TensorOptions(torch::kFloat));
+  std::vector<int64_t> pad{2, 2, 2, 2, 2, 2};
+  torch::Tensor output = torch::reflection_pad3d(input, pad);
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_input = CopyToDevice(input, device);
+    torch::Tensor xla_output = torch::reflection_pad3d(xla_input, pad);
+    AllClose(output, xla_output);
+  });
+
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::reflection_pad3d", cpp_test::GetIgnoredCounters());
+}
+
+TEST_F(AtenXlaTensorTest, TestReflectionPad3dRank5) {
+  torch::Tensor input =
+      torch::rand({2, 2, 3, 4, 4, 4}, torch::TensorOptions(torch::kFloat));
+  std::vector<int64_t> pad{2, 2, 2, 2, 2, 2};
+  torch::Tensor output = torch::reflection_pad3d(input, pad);
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_input = CopyToDevice(input, device);
+    torch::Tensor xla_output = torch::reflection_pad3d(xla_input, pad);
+    AllClose(output, xla_output);
+  });
+
+  ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
+  ExpectCounterChanged("xla::reflection_pad3d", cpp_test::GetIgnoredCounters());
+}
+
+TEST_F(AtenXlaTensorTest, TestReflectionPad3dBackward) {
+  std::vector<int64_t> pad{2, 3, 1, 2, 1, 1};
+  auto testfn = [&](const std::vector<torch::Tensor>& inputs) -> torch::Tensor {
+    return torch::reflection_pad3d(inputs[0], pad);
+  };
+  ForEachDevice([&](const torch::Device& device) {
+    TestBackward(
+        {torch::rand({1, 2, 4, 4, 2, 2},
                      torch::TensorOptions(torch::kFloat).requires_grad(true))},
         device, testfn);
   });

--- a/test/cpp/test_aten_xla_tensor_3.cpp
+++ b/test/cpp/test_aten_xla_tensor_3.cpp
@@ -760,7 +760,7 @@ TEST_F(AtenXlaTensorTest, TestReflectionPad3dBackward) {
   };
   ForEachDevice([&](const torch::Device& device) {
     TestBackward(
-        {torch::rand({1, 2, 4, 4, 2, 2},
+        {torch::rand({2, 2, 4, 4, 2, 2},
                      torch::TensorOptions(torch::kFloat).requires_grad(true))},
         device, testfn);
   });

--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -2943,7 +2943,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.reciprocal, args, kwargs)
 
-  @unittest.skip
   def test_aten_reflection_pad1d_0(self):
     args = (
         torch.randn((10, 10)).to(torch.float32),
@@ -2955,7 +2954,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.reflection_pad1d, args, kwargs)
 
-  @unittest.skip
   def test_aten_reflection_pad1d_1(self):
     args = (
         torch.randint(0, 10, (10, 10)).to(torch.int32),
@@ -2993,7 +2991,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.reflection_pad2d, args, kwargs)
 
-  @unittest.skip
   def test_aten_reflection_pad3d_0(self):
     args = (
         torch.randn((3, 3, 3, 3, 3)).to(torch.float32),
@@ -3009,7 +3006,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.reflection_pad3d, args, kwargs)
 
-  @unittest.skip
   def test_aten_reflection_pad3d_1(self):
     args = (
         torch.randn((3, 3, 3, 3, 3)).to(torch.float16),
@@ -3025,7 +3021,6 @@ class AtenOpTest(unittest.TestCase):
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.reflection_pad3d, args, kwargs)
 
-  @unittest.skip
   def test_aten_reflection_pad3d_2(self):
     args = (
         torch.randint(0, 10, (3, 3, 3, 3, 3)).to(torch.int32),

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2495,6 +2495,22 @@ at::Tensor XLANativeFunctions::randperm(int64_t n,
       n, GetXlaDeviceOrCurrent(device), at::ScalarType::Long));
 }
 
+at::Tensor XLANativeFunctions::reflection_pad1d(const at::Tensor& self,
+                                                at::IntArrayRef padding) {
+  TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
+  return bridge::AtenFromXlaTensor(tensor_methods::reflection_pad1d(
+      bridge::GetXlaTensor(self), torch::lazy::ToVector<int64_t>(padding)));
+}
+
+at::Tensor XLANativeFunctions::reflection_pad1d_backward(
+    const at::Tensor& grad_output, const at::Tensor& self,
+    at::IntArrayRef padding) {
+  TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
+  return bridge::AtenFromXlaTensor(tensor_methods::reflection_pad1d_backward(
+      bridge::GetXlaTensor(grad_output), bridge::GetXlaTensor(self),
+      torch::lazy::ToVector<int64_t>(padding)));
+}
+
 at::Tensor XLANativeFunctions::reflection_pad2d(const at::Tensor& self,
                                                 at::IntArrayRef padding) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
@@ -2507,6 +2523,22 @@ at::Tensor XLANativeFunctions::reflection_pad2d_backward(
     at::IntArrayRef padding) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
   return bridge::AtenFromXlaTensor(tensor_methods::reflection_pad2d_backward(
+      bridge::GetXlaTensor(grad_output), bridge::GetXlaTensor(self),
+      torch::lazy::ToVector<int64_t>(padding)));
+}
+
+at::Tensor XLANativeFunctions::reflection_pad3d(const at::Tensor& self,
+                                                at::IntArrayRef padding) {
+  TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
+  return bridge::AtenFromXlaTensor(tensor_methods::reflection_pad3d(
+      bridge::GetXlaTensor(self), torch::lazy::ToVector<int64_t>(padding)));
+}
+
+at::Tensor XLANativeFunctions::reflection_pad3d_backward(
+    const at::Tensor& grad_output, const at::Tensor& self,
+    at::IntArrayRef padding) {
+  TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
+  return bridge::AtenFromXlaTensor(tensor_methods::reflection_pad3d_backward(
       bridge::GetXlaTensor(grad_output), bridge::GetXlaTensor(self),
       torch::lazy::ToVector<int64_t>(padding)));
 }

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2296,6 +2296,19 @@ XLATensorPtr randperm(int64_t n, const torch::lazy::BackendDevice& device,
   return XLATensor::Create(node, device, scalar_type);
 }
 
+XLATensorPtr reflection_pad1d(const XLATensorPtr& input,
+                              std::vector<int64_t> padding) {
+  return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad1d>(
+      input->GetIrValue(), std::move(padding)));
+}
+
+XLATensorPtr reflection_pad1d_backward(const XLATensorPtr& grad_output,
+                                       const XLATensorPtr& input,
+                                       std::vector<int64_t> padding) {
+  return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad1dBackward>(
+      grad_output->GetIrValue(), input->GetIrValue(), std::move(padding)));
+}
+
 XLATensorPtr reflection_pad2d(const XLATensorPtr& input,
                               std::vector<int64_t> padding) {
   return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad2d>(
@@ -2306,6 +2319,19 @@ XLATensorPtr reflection_pad2d_backward(const XLATensorPtr& grad_output,
                                        const XLATensorPtr& input,
                                        std::vector<int64_t> padding) {
   return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad2dBackward>(
+      grad_output->GetIrValue(), input->GetIrValue(), std::move(padding)));
+}
+
+XLATensorPtr reflection_pad3d(const XLATensorPtr& input,
+                              std::vector<int64_t> padding) {
+  return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad3d>(
+      input->GetIrValue(), std::move(padding)));
+}
+
+XLATensorPtr reflection_pad3d_backward(const XLATensorPtr& grad_output,
+                                       const XLATensorPtr& input,
+                                       std::vector<int64_t> padding) {
+  return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad3dBackward>(
       grad_output->GetIrValue(), input->GetIrValue(), std::move(padding)));
 }
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2298,14 +2298,14 @@ XLATensorPtr randperm(int64_t n, const torch::lazy::BackendDevice& device,
 
 XLATensorPtr reflection_pad1d(const XLATensorPtr& input,
                               std::vector<int64_t> padding) {
-  return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad1d>(
+  return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad2d>(
       input->GetIrValue(), std::move(padding)));
 }
 
 XLATensorPtr reflection_pad1d_backward(const XLATensorPtr& grad_output,
                                        const XLATensorPtr& input,
                                        std::vector<int64_t> padding) {
-  return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad1dBackward>(
+  return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad2dBackward>(
       grad_output->GetIrValue(), input->GetIrValue(), std::move(padding)));
 }
 
@@ -2324,14 +2324,14 @@ XLATensorPtr reflection_pad2d_backward(const XLATensorPtr& grad_output,
 
 XLATensorPtr reflection_pad3d(const XLATensorPtr& input,
                               std::vector<int64_t> padding) {
-  return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad3d>(
+  return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad2d>(
       input->GetIrValue(), std::move(padding)));
 }
 
 XLATensorPtr reflection_pad3d_backward(const XLATensorPtr& grad_output,
                                        const XLATensorPtr& input,
                                        std::vector<int64_t> padding) {
-  return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad3dBackward>(
+  return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad2dBackward>(
       grad_output->GetIrValue(), input->GetIrValue(), std::move(padding)));
 }
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2298,6 +2298,7 @@ XLATensorPtr randperm(int64_t n, const torch::lazy::BackendDevice& device,
 
 XLATensorPtr reflection_pad1d(const XLATensorPtr& input,
                               std::vector<int64_t> padding) {
+  // `ReflectionPad2d` is used due to `at::aten::reflection_pad2d_backward` named already
   return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad2d>(
       input->GetIrValue(), std::move(padding)));
 }
@@ -2305,6 +2306,7 @@ XLATensorPtr reflection_pad1d(const XLATensorPtr& input,
 XLATensorPtr reflection_pad1d_backward(const XLATensorPtr& grad_output,
                                        const XLATensorPtr& input,
                                        std::vector<int64_t> padding) {
+  // `ReflectionPad2dBackward` is used due to `at::aten::reflection_pad2d_backward` named already
   return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad2dBackward>(
       grad_output->GetIrValue(), input->GetIrValue(), std::move(padding)));
 }
@@ -2324,6 +2326,7 @@ XLATensorPtr reflection_pad2d_backward(const XLATensorPtr& grad_output,
 
 XLATensorPtr reflection_pad3d(const XLATensorPtr& input,
                               std::vector<int64_t> padding) {
+  // `ReflectionPad2d` is used due to `at::aten::reflection_pad2d_backward` named already
   return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad2d>(
       input->GetIrValue(), std::move(padding)));
 }
@@ -2331,6 +2334,7 @@ XLATensorPtr reflection_pad3d(const XLATensorPtr& input,
 XLATensorPtr reflection_pad3d_backward(const XLATensorPtr& grad_output,
                                        const XLATensorPtr& input,
                                        std::vector<int64_t> padding) {
+  // `ReflectionPad2dBackward` is used due to `at::aten::reflection_pad2d_backward` named already
   return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad2dBackward>(
       grad_output->GetIrValue(), input->GetIrValue(), std::move(padding)));
 }

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2298,7 +2298,8 @@ XLATensorPtr randperm(int64_t n, const torch::lazy::BackendDevice& device,
 
 XLATensorPtr reflection_pad1d(const XLATensorPtr& input,
                               std::vector<int64_t> padding) {
-  // `ReflectionPad2d` is used due to `at::aten::reflection_pad2d_backward` named already
+  // `ReflectionPad2d` is used due to `at::aten::reflection_pad2d_backward`
+  // named already
   return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad2d>(
       input->GetIrValue(), std::move(padding)));
 }
@@ -2306,7 +2307,8 @@ XLATensorPtr reflection_pad1d(const XLATensorPtr& input,
 XLATensorPtr reflection_pad1d_backward(const XLATensorPtr& grad_output,
                                        const XLATensorPtr& input,
                                        std::vector<int64_t> padding) {
-  // `ReflectionPad2dBackward` is used due to `at::aten::reflection_pad2d_backward` named already
+  // `ReflectionPad2dBackward` is used due to
+  // `at::aten::reflection_pad2d_backward` named already
   return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad2dBackward>(
       grad_output->GetIrValue(), input->GetIrValue(), std::move(padding)));
 }
@@ -2326,7 +2328,8 @@ XLATensorPtr reflection_pad2d_backward(const XLATensorPtr& grad_output,
 
 XLATensorPtr reflection_pad3d(const XLATensorPtr& input,
                               std::vector<int64_t> padding) {
-  // `ReflectionPad2d` is used due to `at::aten::reflection_pad2d_backward` named already
+  // `ReflectionPad2d` is used due to `at::aten::reflection_pad2d_backward`
+  // named already
   return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad2d>(
       input->GetIrValue(), std::move(padding)));
 }
@@ -2334,7 +2337,8 @@ XLATensorPtr reflection_pad3d(const XLATensorPtr& input,
 XLATensorPtr reflection_pad3d_backward(const XLATensorPtr& grad_output,
                                        const XLATensorPtr& input,
                                        std::vector<int64_t> padding) {
-  // `ReflectionPad2dBackward` is used due to `at::aten::reflection_pad2d_backward` named already
+  // `ReflectionPad2dBackward` is used due to
+  // `at::aten::reflection_pad2d_backward` named already
   return input->CreateFrom(torch::lazy::MakeNode<ReflectionPad2dBackward>(
       grad_output->GetIrValue(), input->GetIrValue(), std::move(padding)));
 }

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -716,10 +716,24 @@ void random_(XLATensorPtr& input, int64_t from, int64_t to);
 XLATensorPtr randperm(int64_t n, const torch::lazy::BackendDevice& device,
                       at::ScalarType scalar_type);
 
+XLATensorPtr reflection_pad1d(const XLATensorPtr& input,
+                              std::vector<int64_t> padding);
+
+XLATensorPtr reflection_pad1d_backward(const XLATensorPtr& grad_output,
+                                       const XLATensorPtr& input,
+                                       std::vector<int64_t> padding);
+
 XLATensorPtr reflection_pad2d(const XLATensorPtr& input,
                               std::vector<int64_t> padding);
 
 XLATensorPtr reflection_pad2d_backward(const XLATensorPtr& grad_output,
+                                       const XLATensorPtr& input,
+                                       std::vector<int64_t> padding);
+
+XLATensorPtr reflection_pad3d(const XLATensorPtr& input,
+                              std::vector<int64_t> padding);
+
+XLATensorPtr reflection_pad3d_backward(const XLATensorPtr& grad_output,
                                        const XLATensorPtr& input,
                                        std::vector<int64_t> padding);
 


### PR DESCRIPTION
fix https://github.com/pytorch/xla/issues/6577

---

follow PR for https://github.com/pytorch/xla/pull/6559

---
Test
```bash
# pytest test/test_core_aten_ops.py -k test_aten_reflection_pad1d_0
=========================== test session starts ============================
platform linux -- Python 3.10.13, pytest-8.0.1, pluggy-1.4.0
rootdir: /root/pytorch
configfile: pytest.ini
plugins: hypothesis-6.98.9
collected 490 items / 489 deselected / 1 selected                          

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1708580905.348960  120407 pjrt_api.cc:100] GetPjrtApi was found for tpu at /root/miniconda3/envs/newtorch310/lib/python3.10/site-packages/libtpu/libtpu.so
I0000 00:00:1708580905.349050  120407 pjrt_api.cc:79] PJRT_Api is set for device type tpu
I0000 00:00:1708580905.349063  120407 pjrt_api.cc:146] The PJRT plugin has PJRT API version 0.40. The framework PJRT API version is 0.40.
.                                         [100%]

==================== 1 passed, 489 deselected in 6.52s =====================
# pytest test/test_core_aten_ops.py -k test_aten_reflection_pad1d_1
=========================== test session starts ============================
platform linux -- Python 3.10.13, pytest-8.0.1, pluggy-1.4.0
rootdir: /root/pytorch
configfile: pytest.ini
plugins: hypothesis-6.98.9
collected 490 items / 489 deselected / 1 selected                          

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1708580948.256937  122008 pjrt_api.cc:100] GetPjrtApi was found for tpu at /root/miniconda3/envs/newtorch310/lib/python3.10/site-packages/libtpu/libtpu.so
I0000 00:00:1708580948.257028  122008 pjrt_api.cc:79] PJRT_Api is set for device type tpu
I0000 00:00:1708580948.257039  122008 pjrt_api.cc:146] The PJRT plugin has PJRT API version 0.40. The framework PJRT API version is 0.40.
.                                         [100%]

==================== 1 passed, 489 deselected in 6.77s =====================
# pytest test/test_core_aten_ops.py -k test_aten_reflection_pad3d_0
=========================== test session starts ============================
platform linux -- Python 3.10.13, pytest-8.0.1, pluggy-1.4.0
rootdir: /root/pytorch
configfile: pytest.ini
plugins: hypothesis-6.98.9
collected 490 items / 489 deselected / 1 selected                          

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1708580959.660941  123608 pjrt_api.cc:100] GetPjrtApi was found for tpu at /root/miniconda3/envs/newtorch310/lib/python3.10/site-packages/libtpu/libtpu.so
I0000 00:00:1708580959.661037  123608 pjrt_api.cc:79] PJRT_Api is set for device type tpu
I0000 00:00:1708580959.661047  123608 pjrt_api.cc:146] The PJRT plugin has PJRT API version 0.40. The framework PJRT API version is 0.40.
.                                         [100%]

==================== 1 passed, 489 deselected in 6.89s =====================
# pytest test/test_core_aten_ops.py -k test_aten_reflection_pad3d_1
=========================== test session starts ============================
platform linux -- Python 3.10.13, pytest-8.0.1, pluggy-1.4.0
rootdir: /root/pytorch
configfile: pytest.ini
plugins: hypothesis-6.98.9
collected 490 items / 489 deselected / 1 selected                          

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1708580971.032931  125211 pjrt_api.cc:100] GetPjrtApi was found for tpu at /root/miniconda3/envs/newtorch310/lib/python3.10/site-packages/libtpu/libtpu.so
I0000 00:00:1708580971.033014  125211 pjrt_api.cc:79] PJRT_Api is set for device type tpu
I0000 00:00:1708580971.033027  125211 pjrt_api.cc:146] The PJRT plugin has PJRT API version 0.40. The framework PJRT API version is 0.40.
.                                         [100%]

==================== 1 passed, 489 deselected in 6.94s =====================
# pytest test/test_core_aten_ops.py -k test_aten_reflection_pad3d_2
=========================== test session starts ============================
platform linux -- Python 3.10.13, pytest-8.0.1, pluggy-1.4.0
rootdir: /root/pytorch
configfile: pytest.ini
plugins: hypothesis-6.98.9
collected 490 items / 489 deselected / 1 selected                          

test/test_core_aten_ops.py WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1708580982.132929  126817 pjrt_api.cc:100] GetPjrtApi was found for tpu at /root/miniconda3/envs/newtorch310/lib/python3.10/site-packages/libtpu/libtpu.so
I0000 00:00:1708580982.133012  126817 pjrt_api.cc:79] PJRT_Api is set for device type tpu
I0000 00:00:1708580982.133025  126817 pjrt_api.cc:146] The PJRT plugin has PJRT API version 0.40. The framework PJRT API version is 0.40.
.                                         [100%]

==================== 1 passed, 489 deselected in 6.77s =====================
```

---
Notice: we keep use [`BuildReflectionPadBackward`](https://github.com/pytorch/xla/blob/2cb31440beea341b0d83e7925128867dd4fedd51/torch_xla/csrc/data_ops.cpp#L424) and [`BuildReflectionPad2d`](https://github.com/pytorch/xla/blob/2cb31440beea341b0d83e7925128867dd4fedd51/torch_xla/csrc/data_ops.cpp#L400C12-L400C32) here due to the `at::aten::reflection_pad2d_backward` named already: [code](https://github.com/pytorch/xla/blob/2cb31440beea341b0d83e7925128867dd4fedd51/torch_xla/csrc/ops/reflection_pad2d_backward.cpp#L28)