### PR TITLE
Add ResNet18 per channel quant test, fix assertion in quantize func and name mangling for tf saved model

### DIFF
--- a/torch_xla/tf_saved_model_integration.py
+++ b/torch_xla/tf_saved_model_integration.py
@@ -74,7 +74,7 @@ def _mangle_tf_root_scope_name(name):
   # https://github.com/tensorflow/tensorflow/blob/51b601fa6bb7e801c0b6ae73c25580e40a8b5745/tensorflow/python/framework/ops.py#L3301-L3302
   # The state_dict key doesn't have such constrain,
   # the name need to be mangled when a root-scoped TF variable is created.
-  # 
+  #
   # FX Graph Node may contain characters other than [A-Za-z0-9_.\\-/], replace
   # offending characters with '_'.
   print(f"before mangling {name}")

--- a/torch_xla/tf_saved_model_integration.py
+++ b/torch_xla/tf_saved_model_integration.py
@@ -77,11 +77,9 @@ def _mangle_tf_root_scope_name(name):
   #
   # FX Graph Node may contain characters other than [A-Za-z0-9_.\\-/], replace
   # offending characters with '_'.
-  print(f"before mangling {name}")
   if name[0] in "._\\-/":
     name = 'k' + name
   name = re.sub(r"[^^\w\-/\\]+", "_", name)
-  print(f"after mangling {name}")
   return name
 
 

--- a/torch_xla/tf_saved_model_integration.py
+++ b/torch_xla/tf_saved_model_integration.py
@@ -1,4 +1,5 @@
 import itertools
+import re
 import sys
 import os
 from typing import List, Tuple, Any
@@ -73,10 +74,15 @@ def _mangle_tf_root_scope_name(name):
   # https://github.com/tensorflow/tensorflow/blob/51b601fa6bb7e801c0b6ae73c25580e40a8b5745/tensorflow/python/framework/ops.py#L3301-L3302
   # The state_dict key doesn't have such constrain,
   # the name need to be mangled when a root-scoped TF variable is created.
+  # 
+  # FX Graph Node may contain characters other than [A-Za-z0-9_.\\-/], replace
+  # offending characters with '_'.
+  print(f"before mangling {name}")
   if name[0] in "._\\-/":
-    return 'k' + name
-  else:
-    return name
+    name = 'k' + name
+  name = re.sub(r"[^^\w\-/\\]+", "_", name)
+  print(f"after mangling {name}")
+  return name
 
 
 def save_stablehlo_graph_as_tf(


### PR DESCRIPTION
- Call `torch.Equal` on cpu tensors in the assertions in qdq lowering.
- TF Saved model root name mangling. Replace offending char with `_` e.g. `downsample, '0')_zero_point_1` -> `downsample_0__zero_point_1`
- Add per-channel quant resnet18 test.