### PR TITLE
[benchmarks] Fix YAML file name.

### DIFF
--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -152,3 +152,7 @@ def get_gpu_name():
 
 def get_tpu_name():
   return tpu._get_metadata("accelerator-type")
+
+
+def get_torchbench_test_name(test):
+  return {"train": "training", "eval": "inference"}[test]


### PR DESCRIPTION
This PR fixes the name of the YAML file for skipping TorchBench models modified by https://github.com/pytorch/pytorch/pull/120299. Here's a brief summary:

- `torchbench_skip_models.yaml` was renamed to `torchbench.yaml`
- Test names are: `training` and `inference`
- Removed a few duplicated skips

cc @miladm 