### PR TITLE
Move TPU CI into shared script

### DIFF
--- a/.github/workflows/tpu_ci.yml
+++ b/.github/workflows/tpu_ci.yml
@@ -33,17 +33,4 @@ jobs:
           pip install fsspec
           pip install rich
           cd pytorch/xla
-          python3 -u test/test_operations.py -v
-          python3 -u test/pjrt/test_runtime_tpu.py
-          python3 -u test/pjrt/test_collective_ops_tpu.py
-          python3 -u test/spmd/test_xla_sharding.py
-          python3 -u test/spmd/test_xla_virtual_device.py
-          python3 -u test/spmd/test_xla_distributed_checkpoint.py
-          python3 -u test/spmd/test_train_spmd_linear_model.py
-          python3 -u test/spmd/test_xla_spmd_python_api_interaction.py
-          XLA_EXPERIMENTAL=nonzero:masked_select python3 -u test/ds/test_dynamic_shape_models.py -v
-          XLA_EXPERIMENTAL=nonzero:masked_select python3 -u test/ds/test_dynamic_shapes.py -v
-          python3 -u test/test_autocast.py
-          python3 -u test/dynamo/test_dynamo.py
-          python3 -u test/spmd/test_spmd_debugging.py
-          python3 -u test/test_fori_loop_with_while_loop_simple_add_dispatch_in_torch.py
+          test/tpu/run_tests.sh

--- a/test/tpu/run_tests.sh
+++ b/test/tpu/run_tests.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# TODO: merge with other run_tests
+python3 test/test_operations.py -v
+python3 test/pjrt/test_runtime_tpu.py
+python3 test/pjrt/test_collective_ops_tpu.py
+python3 test/spmd/test_xla_sharding.py
+python3 test/spmd/test_xla_virtual_device.py
+python3 test/spmd/test_xla_distributed_checkpoint.py
+python3 test/spmd/test_train_spmd_linear_model.py
+python3 test/spmd/test_xla_spmd_python_api_interaction.py
+XLA_EXPERIMENTAL=nonzero:masked_select python3 test/ds/test_dynamic_shape_models.py -v
+XLA_EXPERIMENTAL=nonzero:masked_select python3 test/ds/test_dynamic_shapes.py -v
+python3 test/test_autocast.py
+python3 test/dynamo/test_dynamo.py
+python3 test/spmd/test_spmd_debugging.py
+python3 test/pjrt/test_dtypes.py
+python3 test/pjrt/test_dynamic_plugin_tpu.py
+python3 test/test_fori_loop_with_while_loop_simple_add_dispatch_in_torch.py

--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -46,22 +46,7 @@ spec:
       pip install expecttest==0.1.6
       pip install rich
 
-      python3 /src/pytorch/xla/test/test_operations.py -v
-      python3 /src/pytorch/xla/test/pjrt/test_runtime_tpu.py
-      python3 /src/pytorch/xla/test/pjrt/test_collective_ops_tpu.py
-      python3 /src/pytorch/xla/test/spmd/test_xla_sharding.py
-      python3 /src/pytorch/xla/test/spmd/test_xla_virtual_device.py
-      python3 /src/pytorch/xla/test/spmd/test_xla_distributed_checkpoint.py
-      python3 /src/pytorch/xla/test/spmd/test_train_spmd_linear_model.py
-      python3 /src/pytorch/xla/test/spmd/test_xla_spmd_python_api_interaction.py
-      XLA_EXPERIMENTAL=nonzero:masked_select python3 /src/pytorch/xla/test/ds/test_dynamic_shape_models.py -v
-      XLA_EXPERIMENTAL=nonzero:masked_select python3 /src/pytorch/xla/test/ds/test_dynamic_shapes.py -v
-      python3 /src/pytorch/xla/test/test_autocast.py
-      python3 /src/pytorch/xla/test/dynamo/test_dynamo.py
-      python3 /src/pytorch/xla/test/spmd/test_spmd_debugging.py
-      python3 /src/pytorch/xla/test/pjrt/test_dtypes.py
-      python3 /src/pytorch/xla/test/pjrt/test_dynamic_plugin_tpu.py
-      python3 /src/pytorch/xla/test/test_fori_loop_with_while_loop_simple_add_dispatch_in_torch.py
+      /src/pytorch/xla/test/run_tests.sh
     volumeMounts:
     - mountPath: /dev/shm
       name: dshm

--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -46,7 +46,7 @@ spec:
       pip install expecttest==0.1.6
       pip install rich
 
-      /src/pytorch/xla/test/run_tests.sh
+      /src/pytorch/xla/test/tpu/run_tests.sh
     volumeMounts:
     - mountPath: /dev/shm
       name: dshm


### PR DESCRIPTION
Move TPU CI test list into shared file to make it easier to share between systems.