### PR TITLE
Add topological sort after composite grouping pass

### DIFF
--- a/torch_xla/csrc/runtime/stablehlo_composite_helper.cc
+++ b/torch_xla/csrc/runtime/stablehlo_composite_helper.cc
@@ -9,6 +9,7 @@
 #include "absl/strings/str_cat.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/TopologicalSortUtils.h"
 #include "single_include/nlohmann/json.hpp"
 #include "stablehlo/dialect/StablehloOps.h"
 
@@ -277,6 +278,11 @@ class BuildStableHLOCompositePass : public mlir::OperationPass<mlir::ModuleOp> {
       }
     }
 
+    if (!mlir::sortTopologically(composite_op->getBlock())) {
+      composite_op->emitError()
+          << "The graph is not acyclic after the composite creation pass.";
+      return mlir::failure();
+    }
     // The unused impl_ops will be eliminated with canonicalizer.
     return mlir::success();
   }

--- a/torch_xla/csrc/runtime/stablehlo_composite_helper.cc
+++ b/torch_xla/csrc/runtime/stablehlo_composite_helper.cc
@@ -280,7 +280,7 @@ class BuildStableHLOCompositePass : public mlir::OperationPass<mlir::ModuleOp> {
 
     if (!mlir::sortTopologically(composite_op->getBlock())) {
       composite_op->emitError()
-          << "The graph is not acyclic after the composite creation pass.";
+          << "The graph is not acyclic after BuildStableHLOCompositePass pass.";
       return mlir::failure();
     }
     // The unused impl_ops will be eliminated with canonicalizer.


### PR DESCRIPTION
When the composite has multiple output, we the program order of the MLIR module may not be topological sorted after the composite grouping pass. It happens when the producers and the consumers of the composite overlap in program order. Because the composite is inserted after the first composite output, there will be composite input lies after the composite, violating the topological order

e.g.
```
%input1
%input2
%output1
%input3
%output2
```
after composite insertion
```
%input1
%input2
%output1
composite call (%input1, %input2, %input3)
%input3
%output2
```