### PR TITLE
[benchmarks] Set autocast kwargs only if AMP.

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -364,14 +364,14 @@ class TorchBenchModel(BenchmarkModel):
   def _get_autocast_with_kwargs(self):
     kwargs = {}
 
-    # Set the default data-type based on the accelerator.
-    if self.benchmark_experiment.accelerator == "cuda":
-      kwargs["dtype"] = torch.float16
-    else:
-      # Both CPU and TPU autocast mode defaults to bfloat16.
-      kwargs["dtype"] = torch.bfloat16
-
     if self.use_amp():
+      # Set the default data-type based on the accelerator.
+      if self.benchmark_experiment.accelerator == "cuda":
+        kwargs["dtype"] = torch.float16
+      else:
+        # Both CPU and TPU autocast mode defaults to bfloat16.
+        kwargs["dtype"] = torch.bfloat16
+
       if self.benchmark_experiment.xla:
         # Should call device specific autocast implementations.
         # PyTorch/XLA autocast does not run with dynamo, though:


### PR DESCRIPTION
This PR sets the `dtype` kwarg only if AMP is supposed to be used. Previously, leaving the `dtype` kwarg made it so `nullcontext` complained about it. This would crash every inference benchmark.

cc @miladm 