### PR TITLE
Change to correct directory before running v2 TPU CI

### DIFF
--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -46,7 +46,8 @@ spec:
       pip install expecttest==0.1.6
       pip install rich
 
-      /src/pytorch/xla/test/tpu/run_tests.sh
+      cd /src/pytorch/xla
+      test/run_tests.sh
     volumeMounts:
     - mountPath: /dev/shm
       name: dshm


### PR DESCRIPTION
The TPU CI check in #6602 should not have passed:

```
Step #4 - "run_e2e_tests": + /src/pytorch/xla/test/tpu/run_tests.sh
Step #4 - "run_e2e_tests": python3: can't open file '//test/test_operations.py': [Errno 2] No such file or directory
Step #4 - "run_e2e_tests": python3: can't open file '//test/pjrt/test_runtime_tpu.py': [Errno 2] No such file or directory
Step #4 - "run_e2e_tests": python3: can't open file '//test/pjrt/test_collective_ops_tpu.py': [Errno 2] No such file or directory
Step #4 - "run_e2e_tests": python3: can't open file '//test/spmd/test_xla_sharding.py': [Errno 2] No such file or directory
Step #4 - "run_e2e_tests": python3: can't open file '//test/spmd/test_xla_virtual_device.py': [Errno 2] No such file or directory
Step #4 - "run_e2e_tests": python3: can't open file '//test/spmd/test_xla_distributed_checkpoint.py': [Errno 2] No such file or directory
Step #4 - "run_e2e_tests": python3: can't open file '//test/spmd/test_train_spmd_linear_model.py': [Errno 2] No such file or directory
Step #4 - "run_e2e_tests": python3: can't open file '//test/spmd/test_xla_spmd_python_api_interaction.py': [Errno 2] No such file or directory
Step #4 - "run_e2e_tests": python3: can't open file '//test/ds/test_dynamic_shape_models.py': [Errno 2] No such file or directory
Step #4 - "run_e2e_tests": python3: can't open file '//test/ds/test_dynamic_shapes.py': [Errno 2] No such file or directory
Step #4 - "run_e2e_tests": python3: can't open file '//test/test_autocast.py': [Errno 2] No such file or directory
Step #4 - "run_e2e_tests": python3: can't open file '//test/dynamo/test_dynamo.py': [Errno 2] No such file or directory
Step #4 - "run_e2e_tests": python3: can't open file '//test/spmd/test_spmd_debugging.py': [Errno 2] No such file or directory
Step #4 - "run_e2e_tests": python3: can't open file '//test/pjrt/test_dtypes.py': [Errno 2] No such file or directory
Step #4 - "run_e2e_tests": python3: can't open file '//test/pjrt/test_dynamic_plugin_tpu.py': [Errno 2] No such file or directory
Step #4 - "run_e2e_tests": python3: can't open file '//test/test_fori_loop_with_while_loop_simple_add_dispatch_in_torch.py': [Errno 2] No such file or directory
Step #4 - "run_e2e_tests": ++ kubectl get pod/xla-test-job-xwjsh -o 'jsonpath={.status.containerStatuses[?(@.name=="xla-test")].state.terminated.exitCode}'
Step #4 - "run_e2e_tests": + exit
```