### PR TITLE
AliasWithBufferDonorContext wtih default value

### DIFF
--- a/test/dynamo/test_dynamo_aliasing.py
+++ b/test/dynamo/test_dynamo_aliasing.py
@@ -30,13 +30,13 @@ class TestDynamoBufferDonationAliasingWithCustomOp(unittest.TestCase):
 
   def dummy_inplace_mul(self, input):
     # always donate input buffer
-    torch.ops.xla.dynamo_set_buffer_donor(input, True)
+    torch.ops.xla.dynamo_set_buffer_donor_(input, True)
     input *= 1.1
     return
 
   def dummy_mul(self, input):
     # always donate input buffer
-    torch.ops.xla.dynamo_set_buffer_donor(input, True)
+    torch.ops.xla.dynamo_set_buffer_donor_(input, True)
     return input * 1.1
 
   def test_manual_buffer_donation(self):
@@ -49,7 +49,7 @@ class TestDynamoBufferDonationAliasingWithCustomOp(unittest.TestCase):
     met.clear_all()
     dummy_inplace_mul_compiled(input)
     self.assertIn('XlaSetBufferDonation', met.counter_names())
-    # Dynamo will call `dynamo_set_buffer_donor` once on the faketensor and call
+    # Dynamo will call `dynamo_set_buffer_donor_` once on the faketensor and call
     # it again on real tensor in our dynamo bridge.
     self.assertEqual(met.counter_value('XlaSetBufferDonation'), 2)
     torch.allclose(input_cloned.cpu() * 1.1, input.cpu())
@@ -67,7 +67,7 @@ class TestDynamoBufferDonationAliasingWithCustomOp(unittest.TestCase):
     # make sure buffer donation setting is correctly updated
     self.assertTrue(torch_xla._XLAC._get_buffer_donation(input))
     self.assertIn('XlaSetBufferDonation', met.counter_names())
-    # Dynamo will call `dynamo_set_buffer_donor` once on the faketensor and call
+    # Dynamo will call `dynamo_set_buffer_donor_` once on the faketensor and call
     # it again on real tensor in our dynamo bridge.
     self.assertEqual(met.counter_value('XlaSetBufferDonation'), 2)
     self.assertIn('Data Handle: Deleted',
@@ -78,7 +78,7 @@ class TestDynamoBufferDonationAliasingWithCustomOp(unittest.TestCase):
     # use a different function than above dummy add otherwise XLA won't recompile
     def dummy_inplace(input):
       # always donate input buffer
-      torch.ops.xla.dynamo_set_buffer_donor(input, True)
+      torch.ops.xla.dynamo_set_buffer_donor_(input, True)
       input += (0.5 * torch.sin(input))
 
     device = xm.xla_device()

--- a/test/dynamo/test_dynamo_aliasing.py
+++ b/test/dynamo/test_dynamo_aliasing.py
@@ -4,6 +4,7 @@ import torch
 import torch_xla
 import torch_xla.core.xla_model as xm
 import torch_xla.debug.metrics as met
+import torch_xla.experimental.dynamo_set_buffer_donor
 from torch_xla.core.dynamo_bridge import alias_with_buffer_donor_config
 
 
@@ -20,9 +21,82 @@ class TestBufferDonationUtil(unittest.TestCase):
     hash_with_donor = torch_xla._XLAC._get_graph_hash([res])
     self.assertEqual(hash_no_donor, hash_with_donor)
 
-    with alias_with_buffer_donor_config() as context:
+    with alias_with_buffer_donor_config() as saved_config:
       hash_with_donor_and_context = torch_xla._XLAC._get_graph_hash([res])
     self.assertNotEqual(hash_no_donor, hash_with_donor_and_context)
+
+
+class TestDynamoBufferDonationAliasingWithCustomOp(unittest.TestCase):
+
+  def dummy_inplace_mul(self, input):
+    # always donate input buffer
+    torch.ops.xla.dynamo_set_buffer_donor(input, True)
+    input *= 1.1
+    return
+
+  def dummy_mul(self, input):
+    # always donate input buffer
+    torch.ops.xla.dynamo_set_buffer_donor(input, True)
+    return input * 1.1
+
+  def test_manual_buffer_donation(self):
+    device = xm.xla_device()
+    input = torch.randn(5, 5).to(device)
+    input_cloned = torch.clone(input)
+    dummy_inplace_mul_compiled = torch.compile(
+        self.dummy_inplace_mul, backend='openxla')
+
+    met.clear_all()
+    dummy_inplace_mul_compiled(input)
+    self.assertIn('XlaSetBufferDonation', met.counter_names())
+    # Dynamo will call `dynamo_set_buffer_donor` once on the faketensor and call
+    # it again on real tensor in our dynamo bridge.
+    self.assertEqual(met.counter_value('XlaSetBufferDonation'), 2)
+    torch.allclose(input_cloned.cpu() * 1.1, input.cpu())
+
+  def test_manual_buffer_donation_for_non_inplce_op(self):
+    device = xm.xla_device()
+    input = torch.randn(5, 5).to(device)
+    input_cloned = torch.clone(input)
+    dummy_mul_compiled = torch.compile(self.dummy_mul, backend='openxla')
+
+    met.clear_all()
+    res = dummy_mul_compiled(input)
+    # check input's buffer has been aliased.
+    xm.wait_device_ops()
+    # make sure buffer donation setting is correctly updated
+    self.assertTrue(torch_xla._XLAC._get_buffer_donation(input))
+    self.assertIn('XlaSetBufferDonation', met.counter_names())
+    # Dynamo will call `dynamo_set_buffer_donor` once on the faketensor and call
+    # it again on real tensor in our dynamo bridge.
+    self.assertEqual(met.counter_value('XlaSetBufferDonation'), 2)
+    self.assertIn('Data Handle: Deleted',
+                  torch_xla._XLAC._get_xla_tensor_debug_info(input))
+    torch.allclose(input_cloned.cpu() + 1, res.cpu())
+
+  def test_manual_buffer_donation_for_inplce_op_repeat(self):
+    # use a different function than above dummy add otherwise XLA won't recompile
+    def dummy_inplace(input):
+      # always donate input buffer
+      torch.ops.xla.dynamo_set_buffer_donor(input, True)
+      input += (0.5 * torch.sin(input))
+
+    device = xm.xla_device()
+    input = torch.randn(5, 5).to(device)
+    input_cloned = torch.clone(input)
+    dummy_inplace_add_compiled = torch.compile(dummy_inplace, backend='openxla')
+    xm.mark_step()
+    met.clear_all()
+
+    for _ in range(100):
+      dummy_inplace_add_compiled(input)
+    # should_donate_buffer field is attached to the buffer and won't be inherited to
+    # the output buffer(unless execution is a no-op). However dynamo don't track this
+    # field so it will keep executing the graph with input buffer being aliased.
+    self.assertFalse(torch_xla._XLAC._get_buffer_donation(input))
+    # there shouldn't be any recompilation even `should_donate_buffer` field changed after
+    # first execution. This is because Dynamo does not trace this internal field for xla.
+    self.assertEqual(met.metric_data('CompileTime')[0], 1)
 
 
 class TestDynamoBufferDonationAliasing(unittest.TestCase):

--- a/torch_xla/experimental/dynamo_set_buffer_donor.py
+++ b/torch_xla/experimental/dynamo_set_buffer_donor.py
@@ -1,0 +1,22 @@
+import torch
+import torch_xla
+
+from torch.library import impl
+from torch_xla.core.xla_model import XLA_LIB
+
+
+XLA_LIB.define(
+    "dynamo_set_buffer_donor(Tensor t, bool should_donoate) -> Tensor"
+)
+
+
+@impl(XLA_LIB, "dynamo_set_buffer_donor", "XLA")
+def dynamo_set_buffer_donor_xla(t: torch.Tensor, should_donoate: bool):
+  torch_xla._XLAC._set_buffer_donation(t, should_donoate)
+  return t
+
+
+@impl(XLA_LIB, "dynamo_set_buffer_donor", "CompositeExplicitAutograd")
+def dynamo_set_buffer_donor(t: torch.Tensor, should_donoate: bool):
+  # Do nothing for non-xla tensor.
+  return t

--- a/torch_xla/experimental/dynamo_set_buffer_donor.py
+++ b/torch_xla/experimental/dynamo_set_buffer_donor.py
@@ -4,19 +4,17 @@ import torch_xla
 from torch.library import impl
 from torch_xla.core.xla_model import XLA_LIB
 
-
 XLA_LIB.define(
-    "dynamo_set_buffer_donor(Tensor t, bool should_donoate) -> Tensor"
-)
+    "dynamo_set_buffer_donor_(Tensor t, bool should_donoate) -> Tensor")
 
 
-@impl(XLA_LIB, "dynamo_set_buffer_donor", "XLA")
-def dynamo_set_buffer_donor_xla(t: torch.Tensor, should_donoate: bool):
+@impl(XLA_LIB, "dynamo_set_buffer_donor_", "XLA")
+def dynamo_set_buffer_donor_xla_(t: torch.Tensor, should_donoate: bool):
   torch_xla._XLAC._set_buffer_donation(t, should_donoate)
   return t
 
 
-@impl(XLA_LIB, "dynamo_set_buffer_donor", "CompositeExplicitAutograd")
-def dynamo_set_buffer_donor(t: torch.Tensor, should_donoate: bool):
+@impl(XLA_LIB, "dynamo_set_buffer_donor_", "CompositeExplicitAutograd")
+def dynamo_set_buffer_donor_(t: torch.Tensor, should_donoate: bool):
   # Do nothing for non-xla tensor.
   return t


### PR DESCRIPTION
exmaple usage
```
import torch_xla.experimental.dynamo_set_buffer_donor

def dummy_inplace_mul(input):
  # always donate input buffer
  torch.ops.xla.dynamo_set_buffer_donor_(input, True)
  input *= 1.1
  return

device = xm.xla_device()
input = torch.randn(5, 5).to(device)
dummy_inplace_mul_compiled = torch.compile(
    dummy_inplace_mul, backend='openxla')

dummy_inplace_mul_compiled(input)
```