### PR TITLE
[benchmarks] Small fixes for benchmarking script.

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -310,18 +310,14 @@ class TorchBenchModel(BenchmarkModel):
     if cant_change_batch_size:
       self.benchmark_experiment.batch_size = None
 
-    if self.benchmark_experiment.batch_size is not None:
-      batch_size = self.benchmark_experiment.batch_size
-    elif self.is_training() and self.model_name in self.batch_size["training"]:
-      batch_size = self.batch_size["training"][self.model_name]
-    elif self.is_inference(
-    ) and self.model_name in self.batch_size["inference"]:
-      batch_size = self.batch_size["inference"][self.model_name]
-    else:
-      # This should work, since TorchBench relies on class variables:
-      # DEFAULT_TRAIN_BSIZE and DEFAULT_EVAL_BSIZE for setting the default
-      # batch size, instead of default arguments.
-      batch_size = self.benchmark_experiment.batch_size
+    batch_size = self.benchmark_experiment.batch_size
+
+    if batch_size is None:
+      if self.is_training() and self.model_name in self.batch_size["training"]:
+        batch_size = self.batch_size["training"][self.model_name]
+      elif self.is_inference(
+      ) and self.model_name in self.batch_size["inference"]:
+        batch_size = self.batch_size["inference"][self.model_name]
 
     # workaround "RuntimeError: not allowed to set torch.backends.cudnn flags"
     # torch.backends.__allow_nonbracketed_mutation_flag = True

--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -4,7 +4,6 @@ import contextlib
 import importlib
 import logging
 import os
-from os.path import abspath, exists
 import sys
 import torch
 import torch.amp
@@ -306,7 +305,7 @@ class TorchBenchModel(BenchmarkModel):
   def load_benchmark(self):
     cant_change_batch_size = (
         not getattr(self.benchmark_cls(), "ALLOW_CUSTOMIZE_BSIZE", True) or
-        model_name in config_data()["dont_change_batch_size"])
+        self.model_name in config_data()["dont_change_batch_size"])
 
     if cant_change_batch_size:
       self.benchmark_experiment.batch_size = None
@@ -318,6 +317,11 @@ class TorchBenchModel(BenchmarkModel):
     elif self.is_inference(
     ) and self.model_name in self.batch_size["inference"]:
       batch_size = self.batch_size["inference"][self.model_name]
+    else:
+      # This should work, since TorchBench relies on class variables:
+      # DEFAULT_TRAIN_BSIZE and DEFAULT_EVAL_BSIZE for setting the default
+      # batch size, instead of default arguments.
+      batch_size = None
 
     # workaround "RuntimeError: not allowed to set torch.backends.cudnn flags"
     # torch.backends.__allow_nonbracketed_mutation_flag = True

--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -321,7 +321,7 @@ class TorchBenchModel(BenchmarkModel):
       # This should work, since TorchBench relies on class variables:
       # DEFAULT_TRAIN_BSIZE and DEFAULT_EVAL_BSIZE for setting the default
       # batch size, instead of default arguments.
-      batch_size = None
+      batch_size = self.benchmark_experiment.batch_size
 
     # workaround "RuntimeError: not allowed to set torch.backends.cudnn flags"
     # torch.backends.__allow_nonbracketed_mutation_flag = True

--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -158,7 +158,7 @@ def get_torchbench_test_name(test):
   return {"train": "training", "eval": "inference"}[test]
 
 
-def find_near_file(self, names):
+def find_near_file(names):
   """Find a file near the current directory.
 
   Looks for `names` in the current directory, up to its two direct parents.

--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -3,7 +3,7 @@ import functools
 import logging
 import numpy as np
 import os
-from os.path import abspath
+from os.path import abspath, exists
 import random
 import subprocess
 import torch


### PR DESCRIPTION
This PR implements small fixes introduced by past PRs:

- Removes the incorrect `self` argument from the `find_near_file` function that was left-over in the last PR that moved it #6542  
- Replace the variable `model_name` by `TorchBenchModel` attribute of same name
- Select user specified batch size by default

@miladm