### PR TITLE
Skip pytorch test test_parallel_cow_materialize_error

### DIFF
--- a/test/pytorch_test_base.py
+++ b/test/pytorch_test_base.py
@@ -216,6 +216,7 @@ DISABLED_TORCH_TESTS_ANY = {
         'test_index_reduce',  # Broke by functionalization, pytorch/pytorch#94471
         'test_logcumsumexp_xla',  # doesn't raise, pytorch/pytorch#92912
         'test_narrow_copy_non_contiguous',  # the test is added for CPU, pytorch/pytorch#91789
+        'test_parallel_cow_materialize_error_xla',  # disabled in upstream /pytorch/pytorch/pull/120811
     },
 
     # test_view_ops.py


### PR DESCRIPTION
Skip pytorch test test_parallel_cow_materialize_error, similar to upstream -- https://github.com/pytorch/pytorch/pull/120811

---
```
(base) wonjoo@wonjoo-cpu:~/pytorch$ python test/test_torch.py TestTorchDeviceTypeXLA.test_parallel_cow_materialize_error_xla
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1709151604.155100 1762346 cpu_client.cc:404] TfrtCpuClient created.
s
----------------------------------------------------------------------
Ran 1 test in 0.002s

OK (skipped=1)
```