### PR TITLE
handle non-tensor input in tf saved_model input placeholder

### DIFF
--- a/test/stablehlo/utils.py
+++ b/test/stablehlo/utils.py
@@ -1,4 +1,10 @@
 import functools
+import tempfile
+from typing import Any, Dict, Tuple
+
+import numpy as np
+import torch
+from torch.utils import _pytree as pytree
 
 
 @functools.lru_cache
@@ -8,3 +14,39 @@ def has_tf_package() -> bool:
     return tensorflow is not None
   except ImportError:
     return False
+
+
+def wrap_func_as_nn_module(f):
+
+  class M(torch.nn.Module):
+
+    def __init__(self):
+      super().__init__()
+
+    def forward(self, *args):
+      return f(*args)
+
+  return M().eval()
+
+
+def load_save_model_and_inference(path: str, args: Tuple[Any, ...]) -> Dict:
+  assert has_tf_package()
+  import tensorflow as tf
+  loaded_m = tf.saved_model.load(path)
+  tf_input = pytree.tree_map_only(torch.Tensor,
+                                  lambda x: tf.constant(x.numpy()), args)
+  tf_output = loaded_m.f(*tf_input)
+  return tf_output
+
+
+def compare_exported_program_and_saved_model_result(ep, saved_model_path, args):
+  tf_output = load_save_model_and_inference(saved_model_path, args)
+  torch_output = ep(*args)
+  if not isinstance(torch_output, tuple):
+    torch_output = (torch_output,)
+  assert len(torch_output) == len(tf_output)
+  for idx in range(len(torch_output)):
+    torch_output_np = torch_output[idx].numpy()
+    tf_output_np = tf_output[idx].numpy()
+    assert torch_output_np.dtype == tf_output_np.dtype, f"torch dtype: {torch_output[idx].dtype}, tf dtype: {tf_output[idx].dtype}"
+    assert np.allclose(torch_output_np, tf_output_np)

--- a/torch_xla/stablehlo.py
+++ b/torch_xla/stablehlo.py
@@ -399,7 +399,7 @@ def _exported_program_to_stablehlo_bundle(exported_model,
     else:
       signature = VariableSignature(
           shape=[],
-          dtype=str(type(arg)),
+          dtype=type(arg).__name__,
       )
 
     unused_inputs.append((pos, signature))

--- a/torch_xla/tf_saved_model_integration.py
+++ b/torch_xla/tf_saved_model_integration.py
@@ -60,11 +60,16 @@ def _make_input_signatures(
           zip(meta.input_locations, meta.input_signature), meta.unused_inputs)
       if loc.type_ == stablehlo.VariableType.INPUT_ARG
   }
+  primitive_type_to_tf_type = {'int': 'int32', 'float': 'float32'}
   for i in range(len(input_pos_to_spec)):
     spec = input_pos_to_spec[i]
     shape = _get_shape_with_dynamic(spec)
     yield tf.TensorSpec(
-        shape=shape, dtype=getattr(tf, spec.dtype), name=f'args_{i}')
+        shape=shape,
+        dtype=getattr(
+            tf, primitive_type_to_tf_type[spec.dtype]
+            if spec.dtype in primitive_type_to_tf_type else spec.dtype),
+        name=f'args_{i}')
 
 
 def _mangle_tf_root_scope_name(name):


### PR DESCRIPTION
When FX graph has non-tensor input, it would crash because `tf.int/float` doesn't exist. This PR warps Python int/float input as `tf.int32/float32` placeholder in TF. 

We wrap Python int/float as `tf.int32/float32` because `tf.constant(3)` and `tf.constant(3.14)` generate `tf.int32` and `tf.float32` dtype.

Test:
Added test of FX graph with non-tensor input