### PR TITLE
[SPMD] Check the real physical device type if XlaDeviceType::SPMD

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3280,7 +3280,7 @@ at::Tensor XLANativeFunctions::upsample_bilinear2d_backward(
   // our XLA lowering.
   XlaDeviceType hw_type =
       static_cast<XlaDeviceType>(grad_output_tensor->GetDevice().type());
-  if (hw_type != XlaDeviceType::TPU) {
+  if (!CheckTpuDevice(hw_type)) {
     return at::native::call_fallback_fn<
         &xla_cpu_fallback,
         ATEN_OP(upsample_bilinear2d_backward)>::call(grad_output, output_size,
@@ -3335,7 +3335,7 @@ at::Tensor XLANativeFunctions::upsample_nearest2d_backward(
   // our XLA lowering.
   XlaDeviceType hw_type =
       static_cast<XlaDeviceType>(grad_output_tensor->GetDevice().type());
-  if (hw_type != XlaDeviceType::TPU && hw_type != XlaDeviceType::NEURON) {
+  if (!CheckTpuDevice(hw_type) && hw_type != XlaDeviceType::NEURON) {
     return at::native::call_fallback_fn<
         &xla_cpu_fallback,
         ATEN_OP(upsample_nearest2d_backward)>::call(grad_output, output_size,

--- a/torch_xla/csrc/data_ops.cpp
+++ b/torch_xla/csrc/data_ops.cpp
@@ -32,7 +32,7 @@ bool IsSparseGather(const xla::Shape& input_shape,
   // to avoid gather on a single float on TPU.
   XlaDeviceType hw_type =
       static_cast<XlaDeviceType>(bridge::GetCurrentDevice().type());
-  if (hw_type == XlaDeviceType::TPU || hw_type == XlaDeviceType::NEURON) {
+  if (CheckTpuDevice(hw_type) || hw_type == XlaDeviceType::NEURON) {
     // XLA_DENSE_GATHER_FACTOR can be used to finely control the
     // sparsity check.
     static int dense_gather_factor =

--- a/torch_xla/csrc/device.cpp
+++ b/torch_xla/csrc/device.cpp
@@ -89,4 +89,16 @@ bool UseVirtualDevice() {
 
 bool GetLockSpmdConfig() { return spmd_config_is_locked; }
 
+bool CheckTpuDevice(XlaDeviceType hw_type) {
+  if (hw_type == XlaDeviceType::TPU) {
+    return true;
+  }
+
+  std::string pjrt_device = runtime::sys_util::GetEnvString("PJRT_DEVICE", "");
+  if (hw_type == XlaDeviceType::SPMD) {
+    return pjrt_device == "TPU";
+  }
+  return false;
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/device.h
+++ b/torch_xla/csrc/device.h
@@ -48,6 +48,10 @@ bool UseVirtualDevice();
 // initialized, yet.
 bool GetLockSpmdConfig();
 
+// Return true if the physical device type is TPU.
+// TODO(yeounoh) - see if we need to check for AOT compilation device type.
+bool CheckTpuDevice(XlaDeviceType hw_type);
+
 }  // namespace torch_xla
 
 #endif  // XLA_TORCH_XLA_CSRC_DEVICE_H_

--- a/torch_xla/csrc/layout_manager.cpp
+++ b/torch_xla/csrc/layout_manager.cpp
@@ -11,6 +11,7 @@
 #include <unordered_map>
 
 #include "absl/strings/str_split.h"
+#include "torch_xla/csrc/device.h"
 #include "torch_xla/csrc/runtime/debug_macros.h"
 #include "torch_xla/csrc/runtime/sys_util.h"
 #include "torch_xla/csrc/runtime/tf_logging.h"
@@ -186,8 +187,7 @@ xla::Shape MakeArrayShapeFromDimensions(
   }
 
   bool tpu_layout_env = runtime::sys_util::GetEnvBool("XLA_TPU_LAYOUT", true);
-  if (tpu_layout_env && dimensions.size() > 1 &&
-      hw_type == XlaDeviceType::TPU) {
+  if (tpu_layout_env && dimensions.size() > 1 && CheckTpuDevice(hw_type)) {
     return MakeTpuShape(dimensions, dynamic_dimensions, type);
   }
   return MakeTorchTensorLayout(dimensions, dynamic_dimensions, type);

--- a/torch_xla/csrc/resize_ops.cpp
+++ b/torch_xla/csrc/resize_ops.cpp
@@ -267,7 +267,7 @@ xla::XlaOp LowerForward2d(const std::string& target, xla::XlaOp input,
 
   XlaDeviceType hw_type =
       static_cast<XlaDeviceType>(bridge::GetCurrentDevice().type());
-  if (hw_type == XlaDeviceType::TPU || hw_type == XlaDeviceType::NEURON) {
+  if (CheckTpuDevice(hw_type) || hw_type == XlaDeviceType::NEURON) {
     // TPU uses custom call implementation
     resized =
         xla::CustomCall(input.builder(), target, {tinput}, resized_shape,

--- a/torch_xla/csrc/xla_lower_util.cpp
+++ b/torch_xla/csrc/xla_lower_util.cpp
@@ -74,7 +74,7 @@ bool ShouldUseDenseScatter(const torch::lazy::BackendDevice& device,
   static int dense_scatter_factor =
       runtime::sys_util::GetEnvInt("XLA_DENSE_SCATTER_FACTOR", 100);
   XlaDeviceType hw_type = static_cast<XlaDeviceType>(device.type());
-  if (hw_type == XlaDeviceType::TPU) {
+  if (CheckTpuDevice(hw_type)) {
     int64_t input_elements = xla::ShapeUtil::ElementsIn(input_shape);
     int64_t index_elements = xla::ShapeUtil::ElementsIn(index_shape);
     return index_elements * dense_scatter_factor >= input_elements;


### PR DESCRIPTION
This has some performance implications for SPMD workloads, in that
- it induces unnecessary fallbacks in some of our backward pass implementations
- it bypasses our check to use more performance collectives.

Not sure the size of the impact, but we should re-run some of the benchmarks to keep them up-to-date after landing this.