### PR TITLE
disable dynamic shape export test

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -203,7 +203,8 @@ function run_xla_op_tests3 {
   run_test "$CDIR/stablehlo/test_pt2e_qdq.py"
   run_xla_hlo_debug "$CDIR/stablehlo/test_stablehlo_inference.py"
   run_test "$CDIR/stablehlo/test_stablehlo_compile.py"
-  run_test "$CDIR/stablehlo/test_unbounded_dynamism.py"
+  # TODO(lsy323): Will be fixed in #6494
+  # run_test "$CDIR/stablehlo/test_unbounded_dynamism.py"
   run_test "$CDIR/spmd/test_xla_sharding.py"
   run_test "$CDIR/spmd/test_xla_sharding_hlo.py"
   run_test "$CDIR/spmd/test_xla_virtual_device.py"


### PR DESCRIPTION
Upstream removed the `constraints` arg in `torch.export`. The test will be updated to use `dynamic_shapes` in #6494