### PR TITLE
fix csv output error

### DIFF
--- a/benchmarks/result_analyzer.py
+++ b/benchmarks/result_analyzer.py
@@ -180,7 +180,7 @@ class ResultAnalyzer:
           "repeat": dataline["repeat"],
           "iterations_per_run": dataline["iterations_per_run"],
           "error_message": None,
-          "outputs_file": dataline["outputs_file"],
+          "outputs_file": dataline["experiment"].get("outputs_file", ""),
       }
 
       if "error" in dataline["metrics"] and not self._args.hide_errors:


### PR DESCRIPTION
Fix command `python result_analyzer.py --output-format=csv` will return error.