### PR TITLE
Add missing toml package to post-submit CI

### DIFF
--- a/infra/ansible/config/pip.yaml
+++ b/infra/ansible/config/pip.yaml
@@ -25,6 +25,7 @@ pip:
       - six
       - tensorboard
       - tensorboardX
+      - toml
       - tqdm
       - typing
       - typing_extensions


### PR DESCRIPTION
Currently, the post-submit CI fails with error:
```
+ mkdir lcov
+ cp .coverage lcov/
+ coverage-lcov --data_file_path lcov/.coverage
Traceback (most recent call last):
  File "/opt/conda/bin/coverage-lcov", line 5, in <module>
    from coverage_lcov.cli import main
  File "/opt/conda/lib/python3.8/site-packages/coverage_lcov/__init__.py", line 3, in <module>
    import toml
ModuleNotFoundError: No module named 'toml'
Error: Process completed with exit code 1.
```
This PR adds the missing package.