### PR TITLE
[DO NOT REVIEW] Repro post-CI failure

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -35,7 +35,7 @@ jobs:
     with:
       docker-image: ${{ needs.build.outputs.docker-image }}
       timeout-minutes: 120
-      collect-coverage: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/master' }}
+      collect-coverage: true
       disable-xrt: 1
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}


### PR DESCRIPTION
Ideally we should see the CI failure in the CPU test:
```
+ mkdir lcov
+ cp .coverage lcov/
+ coverage-lcov --data_file_path lcov/.coverage
Traceback (most recent call last):
  File "/opt/conda/bin/coverage-lcov", line 5, in <module>
    from coverage_lcov.cli import main
  File "/opt/conda/lib/python3.8/site-packages/coverage_lcov/__init__.py", line 3, in <module>
    import toml
ModuleNotFoundError: No module named 'toml'
Error: Process completed with exit code 1.
```