### PR TITLE
Update base image in the CI.

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -74,8 +74,8 @@ jobs:
             # if image layers are not present in the repo.
             # Note: disable the following 2 lines while testing a new image, so we do not
             # push to the upstream.
-            docker tag "${GCR_DOCKER_IMAGE}" "${ECR_DOCKER_IMAGE_BASE}:v1.1-lite" >/dev/null
-            docker push "${ECR_DOCKER_IMAGE_BASE}:v1.1-lite" >/dev/null
+            docker tag "${GCR_DOCKER_IMAGE}" "${ECR_DOCKER_IMAGE_BASE}:v1.2-lite" >/dev/null
+            docker push "${ECR_DOCKER_IMAGE_BASE}:v1.2-lite" >/dev/null
       - name: Start the container
         shell: bash
         run: |

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -74,8 +74,9 @@ jobs:
             # if image layers are not present in the repo.
             # Note: disable the following 2 lines while testing a new image, so we do not
             # push to the upstream.
-            docker tag "${GCR_DOCKER_IMAGE}" "${ECR_DOCKER_IMAGE_BASE}:v1.2-lite" >/dev/null
-            docker push "${ECR_DOCKER_IMAGE_BASE}:v1.2-lite" >/dev/null
+            # xw32 to uncomment the 2 lines above before merging the PR.
+            # docker tag "${GCR_DOCKER_IMAGE}" "${ECR_DOCKER_IMAGE_BASE}:v1.2-lite" >/dev/null
+            # docker push "${ECR_DOCKER_IMAGE_BASE}:v1.2-lite" >/dev/null
       - name: Start the container
         shell: bash
         run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -23,7 +23,7 @@ jobs:
     uses: ./.github/workflows/_build.yml
     with:
       ecr-docker-image-base: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/xla_base
-      gcr-docker-image: gcr.io/tpu-pytorch/xla_base:dev-3.8_cuda_12.1
+      gcr-docker-image: gcr.io/tpu-pytorch/xla_base:dev-3.8_cuda_12.1_v2
       cuda: 1
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}

--- a/.github/workflows/build_and_test_xrt.yml
+++ b/.github/workflows/build_and_test_xrt.yml
@@ -18,7 +18,7 @@ jobs:
     uses: ./.github/workflows/_build.yml
     with:
       ecr-docker-image-base: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/xla_base
-      gcr-docker-image: gcr.io/tpu-pytorch/xla_base:dev-3.8_cuda_12.1
+      gcr-docker-image: gcr.io/tpu-pytorch/xla_base:dev-3.8_cuda_12.1_v2
       disable_xrt: 0
       cuda: 1
     secrets:


### PR DESCRIPTION
Now that https://github.com/pytorch/xla/pull/6664 added the missing package `toml` and we got the new dev image `us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.8_cuda_12.1` and got a new base ci image `gcr.io/tpu-pytorch/xla_base:dev-3.8_cuda_12.1_v2`, this PR starts using the new base image.