### PR TITLE
Properly lower aten::sub and aten::rsub

### DIFF
--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -473,7 +473,12 @@ xla::XlaOp BuildLerp(xla::XlaOp start, xla::XlaOp end, xla::XlaOp weight) {
 }
 
 xla::XlaOp BuildRsub(xla::XlaOp input, xla::XlaOp other, xla::XlaOp alpha) {
-  // Perform the function: ohter - alpha* input
+  // Three-way shape and value promotion
+  std::tie(input, other) = XlaHelpers::Promote(input, other);
+  std::tie(input, alpha) = XlaHelpers::Promote(input, alpha);
+  std::tie(input, other) = XlaHelpers::Promote(input, other);
+
+  // Perform the function: ohter - alpha * input
   xla::XlaOp mul_result =
       xla::Mul(input, alpha, XlaHelpers::getBroadcastDimensions(input, alpha));
   xla::XlaOp sub_result = xla::Sub(
@@ -482,7 +487,12 @@ xla::XlaOp BuildRsub(xla::XlaOp input, xla::XlaOp other, xla::XlaOp alpha) {
 }
 
 xla::XlaOp BuildSub(xla::XlaOp input, xla::XlaOp other, xla::XlaOp alpha) {
-  // Perform the function: input - alpha* other
+  // Three-way shape and value promotion
+  std::tie(input, other) = XlaHelpers::Promote(input, other);
+  std::tie(input, alpha) = XlaHelpers::Promote(input, alpha);
+  std::tie(input, other) = XlaHelpers::Promote(input, other);
+
+  // Perform the function: input - alpha * other
   xla::XlaOp mul_result =
       xla::Mul(other, alpha, XlaHelpers::getBroadcastDimensions(other, alpha));
   xla::XlaOp sub_result = xla::Sub(

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -478,7 +478,7 @@ xla::XlaOp BuildRsub(xla::XlaOp input, xla::XlaOp other, xla::XlaOp alpha) {
   std::tie(input, alpha) = XlaHelpers::Promote(input, alpha);
   std::tie(input, other) = XlaHelpers::Promote(input, other);
 
-  // Perform the function: ohter - alpha * input
+  // Perform the function: other - alpha * input
   xla::XlaOp mul_result =
       xla::Mul(input, alpha, XlaHelpers::getBroadcastDimensions(input, alpha));
   xla::XlaOp sub_result = xla::Sub(

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -472,4 +472,17 @@ xla::XlaOp BuildLerp(xla::XlaOp start, xla::XlaOp end, xla::XlaOp weight) {
   return add_result;
 }
 
+xla::XlaOp BuildRsub(xla::XlaOp input, xla::XlaOp other, xla::XlaOp alpha) {
+  // Three-way shape and value promotion
+  std::tie(input, other) = XlaHelpers::Promote(input, other);
+  std::tie(other, alpha) = XlaHelpers::Promote(other, alpha);
+
+  // Perform the function = ohter - alpha* input
+  xla::XlaOp sub_result =
+      xla::Mul(input, alpha, XlaHelpers::getBroadcastDimensions(input, alpha));
+  xla::XlaOp mul_result = xla::Sub(
+      other, sub_result, XlaHelpers::getBroadcastDimensions(other, sub_result));
+  return mul_result;
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -478,11 +478,24 @@ xla::XlaOp BuildRsub(xla::XlaOp input, xla::XlaOp other, xla::XlaOp alpha) {
   std::tie(other, alpha) = XlaHelpers::Promote(other, alpha);
 
   // Perform the function = ohter - alpha* input
-  xla::XlaOp sub_result =
+  xla::XlaOp mul_result =
       xla::Mul(input, alpha, XlaHelpers::getBroadcastDimensions(input, alpha));
-  xla::XlaOp mul_result = xla::Sub(
-      other, sub_result, XlaHelpers::getBroadcastDimensions(other, sub_result));
-  return mul_result;
+  xla::XlaOp sub_result = xla::Sub(
+      other, mul_result, XlaHelpers::getBroadcastDimensions(other, mul_result));
+  return sub_result;
+}
+
+xla::XlaOp BuildSub(xla::XlaOp input, xla::XlaOp other, xla::XlaOp alpha) {
+  // Three-way shape and value promotion
+  std::tie(input, other) = XlaHelpers::Promote(input, other);
+  std::tie(other, alpha) = XlaHelpers::Promote(other, alpha);
+
+  // Perform the function = ohter - alpha* input
+  xla::XlaOp mul_result =
+      xla::Mul(other, alpha, XlaHelpers::getBroadcastDimensions(other, alpha));
+  xla::XlaOp sub_result = xla::Sub(
+      input, mul_result, XlaHelpers::getBroadcastDimensions(input, mul_result));
+  return sub_result;
 }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/elementwise.cpp
+++ b/torch_xla/csrc/elementwise.cpp
@@ -473,11 +473,7 @@ xla::XlaOp BuildLerp(xla::XlaOp start, xla::XlaOp end, xla::XlaOp weight) {
 }
 
 xla::XlaOp BuildRsub(xla::XlaOp input, xla::XlaOp other, xla::XlaOp alpha) {
-  // Three-way shape and value promotion
-  std::tie(input, other) = XlaHelpers::Promote(input, other);
-  std::tie(other, alpha) = XlaHelpers::Promote(other, alpha);
-
-  // Perform the function = ohter - alpha* input
+  // Perform the function: ohter - alpha* input
   xla::XlaOp mul_result =
       xla::Mul(input, alpha, XlaHelpers::getBroadcastDimensions(input, alpha));
   xla::XlaOp sub_result = xla::Sub(
@@ -486,11 +482,7 @@ xla::XlaOp BuildRsub(xla::XlaOp input, xla::XlaOp other, xla::XlaOp alpha) {
 }
 
 xla::XlaOp BuildSub(xla::XlaOp input, xla::XlaOp other, xla::XlaOp alpha) {
-  // Three-way shape and value promotion
-  std::tie(input, other) = XlaHelpers::Promote(input, other);
-  std::tie(other, alpha) = XlaHelpers::Promote(other, alpha);
-
-  // Perform the function = ohter - alpha* input
+  // Perform the function: input - alpha* other
   xla::XlaOp mul_result =
       xla::Mul(other, alpha, XlaHelpers::getBroadcastDimensions(other, alpha));
   xla::XlaOp sub_result = xla::Sub(

--- a/torch_xla/csrc/elementwise.h
+++ b/torch_xla/csrc/elementwise.h
@@ -117,6 +117,10 @@ xla::XlaOp BuildEluBackward(xla::XlaOp grad_output, xla::XlaOp output,
 // based on a scalar or tensor weight and returns the resulting out tensor.
 xla::XlaOp BuildLerp(xla::XlaOp start, xla::XlaOp end, xla::XlaOp weight);
 
+// Compuate the rsub function. Subtracts input, scaled by alpha, from other.
+// out = other − alpha * input
+xla::XlaOp BuildRsub(xla::XlaOp input, xla::XlaOp other, xla::XlaOp alpha);
+
 }  // namespace torch_xla
 
 #endif  // XLA_TORCH_XLA_CSRC_ELEMENTWISE_H_

--- a/torch_xla/csrc/elementwise.h
+++ b/torch_xla/csrc/elementwise.h
@@ -121,6 +121,10 @@ xla::XlaOp BuildLerp(xla::XlaOp start, xla::XlaOp end, xla::XlaOp weight);
 // out = other − alpha * input
 xla::XlaOp BuildRsub(xla::XlaOp input, xla::XlaOp other, xla::XlaOp alpha);
 
+// Compuate the sub function. Subtracts other, scaled by alpha, from input.
+// out = input − alpha * other
+xla::XlaOp BuildSub(xla::XlaOp input, xla::XlaOp other, xla::XlaOp alpha);
+
 }  // namespace torch_xla
 
 #endif  // XLA_TORCH_XLA_CSRC_ELEMENTWISE_H_

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -990,4 +990,31 @@ torch::lazy::NodePtr Rsub(const torch::lazy::Value& input,
       std::move(lower_fn));
 }
 
+torch::lazy::NodePtr Sub(const torch::lazy::Value& input,
+                         const torch::lazy::Value& other,
+                         const torch::lazy::Value& alpha) {
+  torch::lazy::ScopePusher ir_scope(at::aten::sub.toQualString());
+  auto lower_fn = [](const XlaNode& node,
+                     LoweringContext* loctx) -> XlaOpVector {
+    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
+    xla::XlaOp xla_other = loctx->GetOutputOp(node.operand(1));
+    xla::XlaOp xla_alpha = loctx->GetOutputOp(node.operand(2));
+    xla::XlaOp xla_output = BuildSub(xla_input, xla_other, xla_alpha);
+    return node.ReturnOp(xla_output, loctx);
+  };
+  auto lower_for_shape_fn =
+      [](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
+    XLA_CHECK_EQ(operands.size(), 3) << "Unexpected number of operands";
+    return BuildSub(operands[0], operands[1], operands[2]);
+  };
+  return GenericOp(
+      torch::lazy::OpKind(at::aten::sub), {input, other, alpha},
+      [&]() {
+        return InferOutputShape(
+            {GetXlaShape(input), GetXlaShape(other), GetXlaShape(alpha)},
+            lower_for_shape_fn);
+      },
+      std::move(lower_fn));
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -963,4 +963,31 @@ torch::lazy::NodePtr ViewAsRealCopy(const torch::lazy::Value& input) {
                    result_shape, std::move(lower_fn));
 }
 
+torch::lazy::NodePtr Rsub(const torch::lazy::Value& input,
+                          const torch::lazy::Value& other,
+                          const torch::lazy::Value& alpha) {
+  torch::lazy::ScopePusher ir_scope(at::aten::rsub.toQualString());
+  auto lower_fn = [](const XlaNode& node,
+                     LoweringContext* loctx) -> XlaOpVector {
+    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
+    xla::XlaOp xla_other = loctx->GetOutputOp(node.operand(1));
+    xla::XlaOp xla_alpha = loctx->GetOutputOp(node.operand(2));
+    xla::XlaOp xla_output = BuildRsub(xla_input, xla_other, xla_alpha);
+    return node.ReturnOp(xla_output, loctx);
+  };
+  auto lower_for_shape_fn =
+      [](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
+    XLA_CHECK_EQ(operands.size(), 3) << "Unexpected number of operands";
+    return BuildRsub(operands[0], operands[1], operands[2]);
+  };
+  return GenericOp(
+      torch::lazy::OpKind(at::aten::rsub), {input, other, alpha},
+      [&]() {
+        return InferOutputShape(
+            {GetXlaShape(input), GetXlaShape(other), GetXlaShape(alpha)},
+            lower_for_shape_fn);
+      },
+      std::move(lower_fn));
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -249,6 +249,10 @@ torch::lazy::NodePtr Rsub(const torch::lazy::Value& input,
                           const torch::lazy::Value& other,
                           const torch::lazy::Value& alpha);
 
+torch::lazy::NodePtr Sub(const torch::lazy::Value& input,
+                         const torch::lazy::Value& other,
+                         const torch::lazy::Value& alpha);
+
 }  // namespace torch_xla
 
 #endif  // XLA_TORCH_XLA_CSRC_OPS_OPS_H_

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -245,6 +245,10 @@ torch::lazy::NodePtr ViewAsComplexCopy(const torch::lazy::Value& input);
 
 torch::lazy::NodePtr ViewAsRealCopy(const torch::lazy::Value& input);
 
+torch::lazy::NodePtr Rsub(const torch::lazy::Value& input,
+                          const torch::lazy::Value& other,
+                          const torch::lazy::Value& alpha);
+
 }  // namespace torch_xla
 
 #endif  // XLA_TORCH_XLA_CSRC_OPS_OPS_H_

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2447,18 +2447,10 @@ XLATensorPtr rsub(const XLATensorPtr& input, const XLATensorPtr& other,
                   c10::optional<at::ScalarType> logical_element_type) {
   torch::lazy::Value alpha_xla = XLAGraphExecutor::Get()->GetIrValueForScalar(
       alpha, other->shape(), logical_element_type, other->GetDevice());
-  static const bool use_new_rsub =
-      runtime::sys_util::GetEnvBool("NEW_OPS", "0");
-  if (use_new_rsub) {
-    std::cout << "NEW_RSUB tensor" << std::endl;
-    return input->CreateFrom(
-        Rsub(input->GetIrValue(), other->GetIrValue(), alpha_xla));
-  } else {
-    std::cout << "OLD_RSUB tensor" << std::endl;
-    return input->CreateFrom(
-        other->GetIrValue() - alpha_xla * input->GetIrValue(),
-        logical_element_type);
-  }
+
+  return input->CreateFrom(
+      Rsub(input->GetIrValue(), other->GetIrValue(), alpha_xla),
+      logical_element_type);
 }
 
 XLATensorPtr rsub(const XLATensorPtr& input, const at::Scalar& other,
@@ -2469,16 +2461,8 @@ XLATensorPtr rsub(const XLATensorPtr& input, const at::Scalar& other,
   torch::lazy::Value other_xla = XLAGraphExecutor::Get()->GetIrValueForScalar(
       other, input->shape(), logical_element_type, input->GetDevice());
 
-  static const bool use_new_rsub =
-      runtime::sys_util::GetEnvBool("NEW_OPS", "0");
-  if (use_new_rsub) {
-    std::cout << "NEW_RSUB Scalar" << std::endl;
-    return input->CreateFrom(Rsub(input->GetIrValue(), other_xla, alpha_xla));
-  } else {
-    std::cout << "OLD_RSUB Scalar" << std::endl;
-    return input->CreateFrom(other_xla - alpha_xla * input->GetIrValue(),
-                             logical_element_type);
-  }
+  return input->CreateFrom(Rsub(input->GetIrValue(), other_xla, alpha_xla),
+                           logical_element_type);
 }
 
 void copy_(XLATensorPtr& input, XLATensorPtr& src) {
@@ -2780,17 +2764,9 @@ XLATensorPtr sub(const XLATensorPtr& input, const XLATensorPtr& other,
         input->GetDevice());
   }
 
-  static const bool use_new_sub = runtime::sys_util::GetEnvBool("NEW_OPS", "0");
-  if (use_new_sub) {
-    std::cout << "NEW_SUB tensor" << std::endl;
-    return input->CreateFrom(
-        Sub(input->GetIrValue(), other->GetIrValue(), alpha_xla));
-  } else {
-    std::cout << "OLD_SUB tensor" << std::endl;
-    return input->CreateFrom(
-        input->GetIrValue() - other->GetIrValue() * alpha_xla,
-        logical_element_type);
-  }
+  return input->CreateFrom(
+      Sub(input->GetIrValue(), other->GetIrValue(), alpha_xla),
+      logical_element_type);
 }
 
 XLATensorPtr sub(const XLATensorPtr& input, const at::Scalar& other,
@@ -2800,15 +2776,9 @@ XLATensorPtr sub(const XLATensorPtr& input, const at::Scalar& other,
       other, input->shape(), logical_element_type, input->GetDevice());
   torch::lazy::Value alpha_xla = XLAGraphExecutor::Get()->GetIrValueForScalar(
       alpha, input->shape(), logical_element_type, input->GetDevice());
-  static const bool use_new_sub = runtime::sys_util::GetEnvBool("NEW_OPS", "0");
-  if (use_new_sub) {
-    std::cout << "NEW_SUB scalar" << std::endl;
-    return input->CreateFrom(Sub(input->GetIrValue(), other_xla, alpha_xla));
-  } else {
-    std::cout << "OLD_SUB scalar" << std::endl;
-    return input->CreateFrom(input->GetIrValue() - other_xla * alpha_xla,
-                             logical_element_type);
-  }
+
+  return input->CreateFrom(Sub(input->GetIrValue(), other_xla, alpha_xla),
+                           logical_element_type);
 }
 
 XLATensorPtr sum(const XLATensorPtr& input, std::vector<int64_t> dimensions,


### PR DESCRIPTION
As described in https://github.com/pytorch/xla/issues/6589 and https://github.com/pytorch/xla/issues/6294, re-implementing the lowering of aten::sub and aten::rsub.

@wonjoolee95 @JackCaoG 