### PR TITLE
Remove `kubectl` install from TPU CI script

### DIFF
--- a/infra/terraform_modules/xla_docker_build/xla_docker_build.tf
+++ b/infra/terraform_modules/xla_docker_build/xla_docker_build.tf
@@ -129,12 +129,6 @@ locals {
           apt-get update
           apt-get -y install gettext
 
-          # Try to setup kubectl credentials the new way,
-          # see https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
-          apt-get -y remove google-cloud-cli-gke-gcloud-auth-plugin
-          apt-get -y install google-cloud-sdk-gke-gcloud-auth-plugin -o DPkg::options::="--force-overwrite"
-          export USE_GKE_GCLOUD_AUTH_PLUGIN=True
-          apt-get install kubectl
           gcloud container clusters get-credentials $_CLUSTER_NAME --zone $_CLUSTER_ZONE
 
           # Export variables to shell environment so that we can pass them into the

--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -47,7 +47,7 @@ spec:
       pip install rich
 
       cd /src/pytorch/xla
-      test/run_tests.sh
+      test/tpu/run_tests.sh
     volumeMounts:
     - mountPath: /dev/shm
       name: dshm


### PR DESCRIPTION
TPU CI is currently failing with this:

```
Step #4 - "run_e2e_tests": E: Repository 'https://packages.cloud.google.com/apt cloud-sdk-bullseye InRelease' changed its 'Origin' value from 'namespaces/google.com:cloudsdktool/repositories/cloud-sdk-bullseye' to 'cloud-sdk-bullseye'
Step #4 - "run_e2e_tests": E: Repository 'https://packages.cloud.google.com/apt cloud-sdk-bullseye InRelease' changed its 'Label' value from 'namespaces/google.com:cloudsdktool/repositories/cloud-sdk-bullseye' to 'cloud-sdk-bullseye
```

Testing to see if this works with the default `google/cloud-sdk` image now...

cc @vanbasten23 