### PR TITLE
Revert "Add missing toml package to post-submit CI"

### DIFF
--- a/infra/ansible/config/pip.yaml
+++ b/infra/ansible/config/pip.yaml
@@ -25,7 +25,6 @@ pip:
       - six
       - tensorboard
       - tensorboardX
-      - toml
       - tqdm
       - typing
       - typing_extensions


### PR DESCRIPTION
Reverts pytorch/xla#6664

https://github.com/pytorch/xla/pull/6670 is a better way to fix the missing package issue.