### PR TITLE
[Infra] Bump python version to 3.10

### DIFF
--- a/infra/tpu-pytorch-releases/dev_images.auto.tfvars
+++ b/infra/tpu-pytorch-releases/dev_images.auto.tfvars
@@ -2,6 +2,7 @@ dev_images = [
   {
     accelerator = "tpu"
     extra_tags  = ["tpu"]
+    python_version = "3.10"
   },
   {
     accelerator  = "cuda"


### PR DESCRIPTION
Summary:
Bump python version to 3.10 to better align witn our TPU VM minimum version.

Test Plan:
N/A