### PR TITLE
Remove `torchvision` from `test_operations`

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -44,7 +44,6 @@ import torch_xla.utils.serialization as xser
 import torch_xla.core.xla_model as xm
 import torch_xla.core.functions as xf
 import torch_xla.debug.profiler as xp
-import torchvision
 import unittest
 import test_utils
 

--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -41,8 +41,6 @@ spec:
     - bash
     - -cxe
     - |
-      # TODO: new TPUCI please remove this short term hack for `RuntimeError: operator torchvision::nms does not exist`
-      pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu121
       pip install expecttest==0.1.6
       pip install rich
 

--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -41,6 +41,8 @@ spec:
     - bash
     - -cxe
     - |
+      # TODO: new TPUCI please remove this short term hack for `RuntimeError: operator torchvision::nms does not exist`
+      pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu121
       pip install expecttest==0.1.6
       pip install rich
 


### PR DESCRIPTION
~Let's see if we can save ourselves a headache and just ignore `torchvision`.~ Nope, we have to keep `torchvision` in the TPU CI for `test_dynamo`.

cc @vanbasten23 @mbzomowski 