### PR TITLE
Not building cuda plugins to unblock upstream ci.

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -105,7 +105,7 @@ function build_torch_xla() {
   XLA_DIR=$1
   pushd "$XLA_DIR"
   python setup.py install
-  pip install plugins/cuda -v
+  # pip install plugins/cuda -v
   popd
 }
 

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -105,6 +105,8 @@ function build_torch_xla() {
   XLA_DIR=$1
   pushd "$XLA_DIR"
   python setup.py install
+  # Need to uncomment the line below.
+  # Currently it fails upstream XLA CI.
   # pip install plugins/cuda -v
   popd
 }


### PR DESCRIPTION
Upstream is failing with:
```
project//llvm:AMDGPUCommonTableGen__gen_dag_isel_genrule; 25s local ... (48 actions, 47 running)
  [5,745 / 6,706] Generating code from table: lib/Target/AMDGPU/AMDGPU.td @llvm-project//llvm:AMDGPUCommonTableGen__gen_register_bank_genrule; 38s local ... (48 actions, 47 running)
  ERROR: /home/jenkins/.cache/bazel/_bazel_jenkins/9e766795b7b58aa74777805232118ec5/external/xla/xla/stream_executor/cuda/BUILD:76:11: Compiling xla/stream_executor/cuda/cuda_platform.cc failed: undeclared inclusion(s) in rule '@xla//xla/stream_executor/cuda:cuda_platform':
  this rule is missing dependency declarations for the following files included by 'xla/stream_executor/cuda/cuda_platform.cc':
    'external/xla/xla/stream_executor/gpu/gpu_driver.h'
    'external/xla/xla/stream_executor/gpu/gpu_types.h'
    'external/xla/xla/stream_executor/gpu/gpu_executor.h'
    'external/xla/xla/stream_executor/gpu/gpu_collectives.h'
    'external/xla/xla/stream_executor/gpu/gpu_kernel.h'
  Target @xla//xla/pjrt/c:pjrt_c_api_gpu_plugin.so failed to build
  Use --verbose_failures to see the command lines of failed build steps.
  INFO: Elapsed time: 120.945s, Critical Path: 74.92s
  INFO: 5679 processes: 3613 internal, 2066 local.
  FAILED: Build did NOT complete successfully
```
This pr stops building the offending cuda plugins.