### PR TITLE
Revert "Change ATEN generator argument type to const std::optional<Generator>&"

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -829,7 +829,7 @@ at::Tensor XLANativeFunctions::baddbmm(const at::Tensor& self,
 }
 
 at::Tensor XLANativeFunctions::bernoulli(
-    const at::Tensor& self, const std::optional<at::Generator>& generator) {
+    const at::Tensor& self, c10::optional<at::Generator> generator) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
   if (generator.has_value() && generator->defined()) {
     return at::native::call_fallback_fn<&xla_cpu_fallback,
@@ -841,8 +841,7 @@ at::Tensor XLANativeFunctions::bernoulli(
 }
 
 at::Tensor XLANativeFunctions::bernoulli(
-    const at::Tensor& self, double p,
-    const std::optional<at::Generator>& generator) {
+    const at::Tensor& self, double p, c10::optional<at::Generator> generator) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
   if (generator.has_value() && generator->defined()) {
     return at::native::call_fallback_fn<
@@ -854,7 +853,7 @@ at::Tensor XLANativeFunctions::bernoulli(
 
 at::Tensor& XLANativeFunctions::bernoulli_(
     at::Tensor& self, const at::Tensor& p,
-    const std::optional<at::Generator>& generator) {
+    c10::optional<at::Generator> generator) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
   if (generator.has_value() && generator->defined()) {
     return at::native::call_fallback_fn<
@@ -1245,8 +1244,7 @@ at::Tensor XLANativeFunctions::expand_copy_symint(const at::Tensor& self,
 }
 
 at::Tensor& XLANativeFunctions::exponential_(
-    at::Tensor& self, double lambd,
-    const std::optional<at::Generator>& generator) {
+    at::Tensor& self, double lambd, c10::optional<at::Generator> generator) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
   if (generator.has_value() && generator->defined()) {
     return at::native::call_fallback_fn<&xla_cpu_fallback,
@@ -1929,7 +1927,7 @@ at::Tensor XLANativeFunctions::mul(const at::Tensor& self,
 
 at::Tensor XLANativeFunctions::multinomial(
     const at::Tensor& self, int64_t num_samples, bool replacement,
-    const std::optional<at::Generator>& generator) {
+    c10::optional<at::Generator> generator) {
   XLA_CHECK(num_samples > 0)
       << "Multinomial number of samples must be greater than 0";
   XLA_CHECK(at::isFloatingType(self.scalar_type()))
@@ -2243,9 +2241,8 @@ at::Tensor XLANativeFunctions::norm(const at::Tensor& self,
       bridge::GetXlaTensor(self), p, c10::nullopt, dim, keepdim));
 }
 
-at::Tensor XLANativeFunctions::normal(
-    const at::Tensor& mean, double std,
-    const std::optional<at::Generator>& generator) {
+at::Tensor XLANativeFunctions::normal(const at::Tensor& mean, double std,
+                                      c10::optional<at::Generator> generator) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
   if (generator.has_value() && generator->defined()) {
     return at::native::call_fallback_fn<
@@ -2256,9 +2253,8 @@ at::Tensor XLANativeFunctions::normal(
       tensor_methods::normal(bridge::GetXlaTensor(mean), std));
 }
 
-at::Tensor XLANativeFunctions::normal(
-    double mean, const at::Tensor& std,
-    const std::optional<at::Generator>& generator) {
+at::Tensor XLANativeFunctions::normal(double mean, const at::Tensor& std,
+                                      c10::optional<at::Generator> generator) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
   if (generator.has_value() && generator->defined()) {
     return at::native::call_fallback_fn<
@@ -2269,9 +2265,9 @@ at::Tensor XLANativeFunctions::normal(
       tensor_methods::normal(mean, bridge::GetXlaTensor(std)));
 }
 
-at::Tensor XLANativeFunctions::normal(
-    const at::Tensor& mean, const at::Tensor& std,
-    const std::optional<at::Generator>& generator) {
+at::Tensor XLANativeFunctions::normal(const at::Tensor& mean,
+                                      const at::Tensor& std,
+                                      c10::optional<at::Generator> generator) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
   if (generator.has_value() && generator->defined()) {
     return at::native::call_fallback_fn<
@@ -2284,7 +2280,7 @@ at::Tensor XLANativeFunctions::normal(
 
 at::Tensor& XLANativeFunctions::normal_(
     at::Tensor& self, double mean, double std,
-    const std::optional<at::Generator>& generator) {
+    c10::optional<at::Generator> generator) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
   if (generator.has_value() && generator->defined()) {
     return at::native::call_fallback_fn<&xla_cpu_fallback,
@@ -2421,7 +2417,7 @@ std::tuple<at::Tensor, at::Tensor> XLANativeFunctions::qr(
 // The value generated should be within (from, to].
 at::Tensor& XLANativeFunctions::random_(
     at::Tensor& self, int64_t from, c10::optional<int64_t> to,
-    const std::optional<at::Generator>& generator) {
+    c10::optional<at::Generator> generator) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
   if (generator.has_value() && generator->defined()) {
     return at::native::call_fallback_fn<
@@ -2441,8 +2437,7 @@ at::Tensor& XLANativeFunctions::random_(
 
 // The value generated should be in (0, to].
 at::Tensor& XLANativeFunctions::random_(
-    at::Tensor& self, int64_t to,
-    const std::optional<at::Generator>& generator) {
+    at::Tensor& self, int64_t to, c10::optional<at::Generator> generator) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
   if (generator.has_value() && generator->defined()) {
     return at::native::call_fallback_fn<&xla_cpu_fallback,
@@ -2458,7 +2453,7 @@ at::Tensor& XLANativeFunctions::random_(
 
 // The value generated should be in (self_type_min, self_type_max).
 at::Tensor& XLANativeFunctions::random_(
-    at::Tensor& self, const std::optional<at::Generator>& generator) {
+    at::Tensor& self, c10::optional<at::Generator> generator) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
   if (generator.has_value() && generator->defined()) {
     return at::native::call_fallback_fn<&xla_cpu_fallback,
@@ -2631,7 +2626,7 @@ at::Tensor XLANativeFunctions::roll(const at::Tensor& self,
 at::Tensor XLANativeFunctions::rrelu_with_noise(
     const at::Tensor& self, const at::Tensor& noise, const at::Scalar& lower,
     const at::Scalar& upper, bool training,
-    const std::optional<at::Generator>& generator) {
+    c10::optional<at::Generator> generator) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
   if (generator.has_value() && generator->defined()) {
     // The fallback path for rrelu_with_noise when training=true is wrong
@@ -3170,7 +3165,7 @@ std::vector<at::Tensor> XLANativeFunctions::unbind_copy(const at::Tensor& self,
 
 at::Tensor& XLANativeFunctions::uniform_(
     at::Tensor& self, double from, double to,
-    const std::optional<at::Generator>& generator) {
+    c10::optional<at::Generator> generator) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
   if (generator.has_value() && generator->defined()) {
     return at::native::call_fallback_fn<&xla_cpu_fallback,


### PR DESCRIPTION
Reverts pytorch/xla#6686

The upstream one is reverted: https://github.com/pytorch/pytorch/pull/120076

@cyyever Please let me know once you reopen a new PR to upstream.