### PR TITLE
fix torchvision installation in tpu ci test setup script

### DIFF
--- a/.github/workflows/tpu_ci.yml
+++ b/.github/workflows/tpu_ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install torchvision
         run: |
           cd pytorch/
-          pip install --no-use-pep517 "git+https://github.com/pytorch/vision.git@$(cat .github/ci_commit_pins/vision.txt)"
+          pip install --user --no-use-pep517 "git+https://github.com/pytorch/vision.git@$(cat .github/ci_commit_pins/vision.txt)"
       - name: Checkout PyTorch/XLA Repo
         uses: actions/checkout@v4
         with:
@@ -41,7 +41,6 @@ jobs:
           PJRT_DEVICE: TPU
         # Jax is needed for pallas tests.
         run: |
-          pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu --user
           pip install fsspec
           pip install rich
           pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html

--- a/.github/workflows/tpu_ci.yml
+++ b/.github/workflows/tpu_ci.yml
@@ -22,7 +22,6 @@ jobs:
           python3 setup.py install --user
       - name: Install torchvision
         run: |
-          git clone --recursive https://github.com/pytorch/pytorch
           cd pytorch/
           pip install --no-use-pep517 "git+https://github.com/pytorch/vision.git@$(cat .github/ci_commit_pins/vision.txt)"
       - name: Checkout PyTorch/XLA Repo

--- a/.github/workflows/tpu_ci.yml
+++ b/.github/workflows/tpu_ci.yml
@@ -2,10 +2,6 @@ name: TPU Integration Test
 run-name: TPU Testing
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - master
-      - r[0-9]+.[0-9]+
   push:
     branches:
       - master
@@ -14,16 +10,10 @@ jobs:
     runs-on: v4-runner-set
     steps:
       - name: Checkout and Setup PyTorch Repo
-        env:
-          _GLIBCXX_USE_CXX11_ABI: 0
         run: |
           git clone --recursive https://github.com/pytorch/pytorch
           cd pytorch/
           python3 setup.py install --user
-      - name: Install torchvision
-        run: |
-          cd pytorch/
-          pip install --user --no-use-pep517 "git+https://github.com/pytorch/vision.git@$(cat .github/ci_commit_pins/vision.txt)"
       - name: Checkout PyTorch/XLA Repo
         uses: actions/checkout@v4
         with:
@@ -41,8 +31,8 @@ jobs:
           PJRT_DEVICE: TPU
         # Jax is needed for pallas tests.
         run: |
-          pip install fsspec --user
-          pip install rich --user
-          pip install --user torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
+          pip install fsspec
+          pip install rich
+          pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
           cd pytorch/xla
           test/tpu/run_tests.sh

--- a/.github/workflows/tpu_ci.yml
+++ b/.github/workflows/tpu_ci.yml
@@ -2,6 +2,10 @@ name: TPU Integration Test
 run-name: TPU Testing
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+      - r[0-9]+.[0-9]+
   push:
     branches:
       - master
@@ -16,6 +20,11 @@ jobs:
           git clone --recursive https://github.com/pytorch/pytorch
           cd pytorch/
           python3 setup.py install --user
+      - name: Install torchvision
+        run: |
+          git clone --recursive https://github.com/pytorch/pytorch
+          cd pytorch/
+          pip install --no-use-pep517 "git+https://github.com/pytorch/vision.git@$(cat .github/ci_commit_pins/vision.txt)"
       - name: Checkout PyTorch/XLA Repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/tpu_ci.yml
+++ b/.github/workflows/tpu_ci.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: v4-runner-set
     steps:
       - name: Checkout and Setup PyTorch Repo
+        env:
+          _GLIBCXX_USE_CXX11_ABI: 0
         run: |
           git clone --recursive https://github.com/pytorch/pytorch
           cd pytorch/
@@ -31,6 +33,7 @@ jobs:
           PJRT_DEVICE: TPU
         # Jax is needed for pallas tests.
         run: |
+          pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu --user
           pip install fsspec
           pip install rich
           pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html

--- a/.github/workflows/tpu_ci.yml
+++ b/.github/workflows/tpu_ci.yml
@@ -41,8 +41,8 @@ jobs:
           PJRT_DEVICE: TPU
         # Jax is needed for pallas tests.
         run: |
-          pip install fsspec
-          pip install rich
-          pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
+          pip install fsspec --user
+          pip install rich --user
+          pip install --user torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
           cd pytorch/xla
           test/tpu/run_tests.sh

--- a/infra/ansible/e2e_tests.Dockerfile
+++ b/infra/ansible/e2e_tests.Dockerfile
@@ -26,6 +26,7 @@ COPY --from=build /src/pytorch/xla/test /src/pytorch/xla/test
 # Copy ci_commit_pins from upstream
 RUN mkdir -p /src/pytorch/.github
 COPY --from=build /src/pytorch/.github/ci_commit_pins /src/pytorch/.github/ci_commit_pins
+RUN pip install --no-use-pep517 "git+https://github.com/pytorch/vision.git@$(cat /src/pytorch/.github/ci_commit_pins/vision.txt)"
 
 # Copy and install wheels.
 WORKDIR /tmp/wheels

--- a/infra/ansible/e2e_tests.Dockerfile
+++ b/infra/ansible/e2e_tests.Dockerfile
@@ -26,7 +26,6 @@ COPY --from=build /src/pytorch/xla/test /src/pytorch/xla/test
 # Copy ci_commit_pins from upstream
 RUN mkdir -p /src/pytorch/.github
 COPY --from=build /src/pytorch/.github/ci_commit_pins /src/pytorch/.github/ci_commit_pins
-RUN pip install --no-use-pep517 "git+https://github.com/pytorch/vision.git@$(cat /src/pytorch/.github/ci_commit_pins/vision.txt)"
 
 # Copy and install wheels.
 WORKDIR /tmp/wheels

--- a/infra/ansible/e2e_tests.Dockerfile
+++ b/infra/ansible/e2e_tests.Dockerfile
@@ -25,7 +25,7 @@ RUN mkdir -p /src/pytorch/xla
 COPY --from=build /src/pytorch/xla/test /src/pytorch/xla/test
 # Copy ci_commit_pins from upstream
 RUN mkdir -p /src/pytorch/.github
-COPY --from=build /src/pytorch/.github/ci_commit_pins /src/pytorch/xla/test/ci_commit_pins
+COPY --from=build /src/pytorch/.github/ci_commit_pins /src/pytorch/.github/ci_commit_pins
 
 # Copy and install wheels.
 WORKDIR /tmp/wheels

--- a/infra/ansible/e2e_tests.Dockerfile
+++ b/infra/ansible/e2e_tests.Dockerfile
@@ -23,6 +23,9 @@ RUN ansible-playbook -vvv playbook.yaml -e "stage=release" -e "${ansible_vars}" 
 # Copy test sources.
 RUN mkdir -p /src/pytorch/xla
 COPY --from=build /src/pytorch/xla/test /src/pytorch/xla/test
+# Copy ci_commit_pins from upstream
+RUN mkdir -p /src/pytorch/.github
+COPY --from=build /src/pytorch/.github/ci_commit_pins /src/pytorch/xla/test/ci_commit_pins
 
 # Copy and install wheels.
 WORKDIR /tmp/wheels

--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -41,7 +41,7 @@ spec:
     - bash
     - -cxe
     - |
-      pip install --no-use-pep517 "git+https://github.com/pytorch/vision.git@2c127da8b5e2e8f44b50994c6cb931bcca267cfe"
+      pip install --no-use-pep517 "git+https://github.com/pytorch/vision.git@$(cat /src/pytorch/.github/ci_commit_pins/vision.txt)"
       pip install expecttest==0.1.6
       pip install rich
       pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html

--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -41,7 +41,6 @@ spec:
     - bash
     - -cxe
     - |
-      pip install --no-use-pep517 "git+https://github.com/pytorch/vision.git@$(cat /src/pytorch/.github/ci_commit_pins/vision.txt)"
       pip install expecttest==0.1.6
       pip install rich
       pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html

--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -41,9 +41,7 @@ spec:
     - bash
     - -cxe
     - |
-      PYTORCH_DIR=/src/pytorch
-      TORCHVISION_COMMIT="$(cat $PYTORCH_DIR/.github/ci_commit_pins/vision.txt)"
-      pip install "git+https://github.com/pytorch/vision.git@$TORCHVISION_COMMIT"
+      pip install --pre torchvision --index-url https://download.pytorch.org/whl/nightly/cu121
       pip install expecttest==0.1.6
       pip install rich
       pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html

--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -41,6 +41,8 @@ spec:
     - bash
     - -cxe
     - |
+      # Torchvision installed from a commit requires torch, need to install after torch is compiled.
+      pip install --no-use-pep517 "git+https://github.com/pytorch/vision.git@$(cat /src/pytorch/.github/ci_commit_pins/vision.txt)"
       pip install expecttest==0.1.6
       pip install rich
       pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html

--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -42,7 +42,9 @@ spec:
     - -cxe
     - |
       # TODO: new TPUCI please remove this short term hack for `RuntimeError: operator torchvision::nms does not exist`
-      pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu121
+      PYTORCH_DIR=/src/pytorch
+      TORCHVISION_COMMIT="$(cat $PYTORCH_DIR/.github/ci_commit_pins/vision.txt)"
+      pip install "git+https://github.com/pytorch/vision.git@$TORCHVISION_COMMIT"
       pip install expecttest==0.1.6
       pip install rich
       pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html

--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -41,7 +41,7 @@ spec:
     - bash
     - -cxe
     - |
-      pip install --pre torchvision --index-url https://download.pytorch.org/whl/nightly/cu121
+      pip install "git+https://github.com/pytorch/vision.git@2c127da8b5e2e8f44b50994c6cb931bcca267cfe"
       pip install expecttest==0.1.6
       pip install rich
       pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html

--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -41,7 +41,7 @@ spec:
     - bash
     - -cxe
     - |
-      pip install "git+https://github.com/pytorch/vision.git@2c127da8b5e2e8f44b50994c6cb931bcca267cfe"
+      pip install --no-use-pep517 "git+https://github.com/pytorch/vision.git@2c127da8b5e2e8f44b50994c6cb931bcca267cfe"
       pip install expecttest==0.1.6
       pip install rich
       pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html

--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -41,7 +41,6 @@ spec:
     - bash
     - -cxe
     - |
-      # TODO: new TPUCI please remove this short term hack for `RuntimeError: operator torchvision::nms does not exist`
       PYTORCH_DIR=/src/pytorch
       TORCHVISION_COMMIT="$(cat $PYTORCH_DIR/.github/ci_commit_pins/vision.txt)"
       pip install "git+https://github.com/pytorch/vision.git@$TORCHVISION_COMMIT"


### PR DESCRIPTION
Currently in TPU CI, we are installing torch nightly whl before running tests, however, in TPU CI, torch_xla is built against PyTorch HEAD. This would cause some compatibility issues. (e.g. Symbol mismatching in .so)

- torchaudio is not needed for CI, remove torchaudio installation in the setup script as well.

-  Instead of installing nightly torchvision, use the torchvision version pinned in PyTorch src folder.