### PR TITLE
Don't terminate the whole process when `Compile` fails

### DIFF
--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -470,11 +470,11 @@ std::vector<ComputationClient::ComputationPtr> PjRtComputationClient::Compile(
       mlir::ModuleOp mlir_module =
           mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
       ConvertHloToStableHlo(instance.computation.mutable_proto(), &mlir_module);
-      executable = ConsumeValue(client_->Compile(mlir_module, compile_options));
+      executable = client_->Compile(mlir_module, compile_options).value();
       StableHloCompileCounter()->AddValue(1);
     } else {
       executable =
-          ConsumeValue(client_->Compile(instance.computation, compile_options));
+          client_->Compile(instance.computation, compile_options).value();
     }
 
     const auto& hlo_modules = ConsumeValue(executable->GetHloModules());


### PR DESCRIPTION
See #6700

```
>>> import torch_xla as xla
>>> import torch
>>> torch.dot(torch.tensor([2, 3], device=xla.device()), torch.tensor([2, 1], device=xla.device()))
WARNING:root:PJRT is now the default runtime. For more information, see https://github.com/pytorch/xla/blob/master/docs/pjrt.md
WARNING:root:libtpu.so and TPU device found. Setting PJRT_DEVICE=TPU.
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1709942790.379654  501354 pjrt_api.cc:100] GetPjrtApi was found for tpu at /usr/local/lib/python3.8/site-packages/libtpu/libtpu.so
I0000 00:00:1709942790.379741  501354 pjrt_api.cc:79] PJRT_Api is set for device type tpu
I0000 00:00:1709942790.379751  501354 pjrt_api.cc:146] The PJRT plugin has PJRT API version 0.40. The framework PJRT API version is 0.40.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.8/site-packages/torch/_tensor.py", line 464, in __repr__
    return torch._tensor_str._str(self, tensor_contents=tensor_contents)
  File "/usr/local/lib/python3.8/site-packages/torch/_tensor_str.py", line 697, in _str
    return _str_intern(self, tensor_contents=tensor_contents)
  File "/usr/local/lib/python3.8/site-packages/torch/_tensor_str.py", line 432, in _str_intern
    self = self.to("cpu")
RuntimeError: Bad StatusOr access: UNIMPLEMENTED: While rewriting computation to not contain X64 element types, XLA encountered an HLO for which this rewriting is not implemented: %dot.3 = s64[] dot(s64[2]{0} %p1.2, s64[2]{0} %p0.1), lhs_contracting_dims={0}, rhs_contracting_dims={0}
```