### PR TITLE
Disable pallas test in tpu ci

### DIFF
--- a/test/tpu/run_tests.sh
+++ b/test/tpu/run_tests.sh
@@ -18,4 +18,5 @@ python3 test/spmd/test_spmd_debugging.py
 python3 test/pjrt/test_dtypes.py
 python3 test/pjrt/test_dynamic_plugin_tpu.py
 python3 test/test_fori_loop_with_while_loop_simple_add_dispatch_in_torch.py
-python3 test/test_pallas.py
+# Disable test since it failed in TPU CI due to jax setup.
+# python3 test/test_pallas.py


### PR DESCRIPTION
TPU CI is failing with
```
Step #4 - "run_e2e_tests": + python3 test/test_pallas.py
Step #4 - "run_e2e_tests": WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
Step #4 - "run_e2e_tests": I0000 00:00:1710194162.272765   61251 pjrt_api.cc:100] GetPjrtApi was found for tpu at /usr/local/lib/python3.10/site-packages/torch_xla/lib/libtpu.so
Step #4 - "run_e2e_tests": I0000 00:00:1710194162.272832   61251 pjrt_api.cc:79] PJRT_Api is set for device type tpu
Step #4 - "run_e2e_tests": I0000 00:00:1710194162.272843   61251 pjrt_api.cc:146] The PJRT plugin has PJRT API version 0.40. The framework PJRT API version is 0.40.
Step #4 - "run_e2e_tests": ...INFO:jax._src.xla_bridge:Unable to initialize backend 'cuda': 
Step #4 - "run_e2e_tests": INFO:jax._src.xla_bridge:Unable to initialize backend 'rocm': module 'jaxlib.xla_extension' has no attribute 'GpuAllocatorConfig'
Step #4 - "run_e2e_tests": INFO:jax._src.xla_bridge:Unable to initialize backend 'tpu': INTERNAL: Failed to open libtpu.so: libtpu.so: cannot open shared object file: No such file or directory
Step #4 - "run_e2e_tests": WARNING:jax._src.xla_bridge:A Google TPU may be present on this machine, but either a TPU-enabled jaxlib or libtpu is not installed. Falling back to cpu.
Step #4 - "run_e2e_tests": E..
Step #4 - "run_e2e_tests": ======================================================================
Step #4 - "run_e2e_tests": ERROR: test_tpu_custom_call_pallas_extract_add_payload (__main__.PallasTest)
Step #4 - "run_e2e_tests": ----------------------------------------------------------------------
Step #4 - "run_e2e_tests": Traceback (most recent call last):
Step #4 - "run_e2e_tests":   File "/src/pytorch/xla/test/test_pallas.py", line 146, in <module>
Step #4 - "run_e2e_tests":     test = unittest.main()
Step #4 - "run_e2e_tests":   File "/usr/local/lib/python3.10/unittest/main.py", line 101, in __init__
Step #4 - "run_e2e_tests":     self.runTests()
Step #4 - "run_e2e_tests":   File "/usr/local/lib/python3.10/unittest/main.py", line 271, in runTests
Step #4 - "run_e2e_tests":     self.result = testRunner.run(self.test)
Step #4 - "run_e2e_tests":   File "/usr/local/lib/python3.10/unittest/runner.py", line 184, in run
Step #4 - "run_e2e_tests":     test(result)
Step #4 - "run_e2e_tests":   File "/usr/local/lib/python3.10/unittest/suite.py", line 84, in __call__
Step #4 - "run_e2e_tests":     return self.run(*args, **kwds)
Step #4 - "run_e2e_tests":   File "/usr/local/lib/python3.10/unittest/suite.py", line 122, in run
Step #4 - "run_e2e_tests":     test(result)
Step #4 - "run_e2e_tests":   File "/usr/local/lib/python3.10/unittest/suite.py", line 84, in __call__
Step #4 - "run_e2e_tests":     return self.run(*args, **kwds)
Step #4 - "run_e2e_tests":   File "/usr/local/lib/python3.10/unittest/suite.py", line 122, in run
Step #4 - "run_e2e_tests":     test(result)
Step #4 - "run_e2e_tests":   File "/usr/local/lib/python3.10/unittest/case.py", line 650, in __call__
Step #4 - "run_e2e_tests":     return self.run(*args, **kwds)
Step #4 - "run_e2e_tests":   File "/usr/local/lib/python3.10/unittest/case.py", line 591, in run
Step #4 - "run_e2e_tests":     self._callTestMethod(testMethod)
Step #4 - "run_e2e_tests":   File "/usr/local/lib/python3.10/unittest/case.py", line 549, in _callTestMethod
Step #4 - "run_e2e_tests":     method()
Step #4 - "run_e2e_tests":   File "/src/pytorch/xla/test/test_pallas.py", line 132, in test_tpu_custom_call_pallas_extract_add_payload
Step #4 - "run_e2e_tests":     ir = jax.jit(add_vectors).lower(jnp.arange(8), jnp.arange(8)).compiler_ir()
Step #4 - "run_e2e_tests":   File "/src/pytorch/xla/test/test_pallas.py", line 126, in add_vectors
Step #4 - "run_e2e_tests":     return pl.pallas_call(
Step #4 - "run_e2e_tests":   File "/usr/local/lib/python3.10/site-packages/jax/_src/pallas/pallas_call.py", line 560, in wrapped
Step #4 - "run_e2e_tests":     out_flat = pallas_call_p.bind(
Step #4 - "run_e2e_tests": jax._src.source_info_util.JaxStackTraceBeforeTransformation: ValueError: Only interpret mode is supported on CPU backend.
Step #4 - "run_e2e_tests": 
Step #4 - "run_e2e_tests": The preceding stack trace is the source of the JAX operation that, once transformed by JAX, triggered the following exception.
Step #4 - "run_e2e_tests": 
Step #4 - "run_e2e_tests": --------------------
Step #4 - "run_e2e_tests": 
Step #4 - "run_e2e_tests": The above exception was the direct cause of the following exception:
Step #4 - "run_e2e_tests": 
Step #4 - "run_e2e_tests": jax.errors.SimplifiedTraceback: For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.
Step #4 - "run_e2e_tests": 
Step #4 - "run_e2e_tests": The above exception was the direct cause of the following exception:
Step #4 - "run_e2e_tests": 
Step #4 - "run_e2e_tests": Traceback (most recent call last):
Step #4 - "run_e2e_tests":   File "/src/pytorch/xla/test/test_pallas.py", line 132, in test_tpu_custom_call_pallas_extract_add_payload
Step #4 - "run_e2e_tests":     ir = jax.jit(add_vectors).lower(jnp.arange(8), jnp.arange(8)).compiler_ir()
Step #4 - "run_e2e_tests":   File "/usr/local/lib/python3.10/site-packages/jax/_src/pallas/pallas_call.py", line 512, in _pallas_call_default_lowering
Step #4 - "run_e2e_tests":     raise ValueError("Only interpret mode is supported on CPU backend.")
Step #4 - "run_e2e_tests": ValueError: Only interpret mode is supported on CPU backend.
```

Disable the pallas test added in #6696 TPU CI for now.