### PR TITLE
add tpu path in tpu ci run test

### DIFF
--- a/test/tpu/run_tests.sh
+++ b/test/tpu/run_tests.sh
@@ -18,5 +18,4 @@ python3 test/spmd/test_spmd_debugging.py
 python3 test/pjrt/test_dtypes.py
 python3 test/pjrt/test_dynamic_plugin_tpu.py
 python3 test/test_fori_loop_with_while_loop_simple_add_dispatch_in_torch.py
-# Disable test since it failed in TPU CI due to jax setup.
-# python3 test/test_pallas.py
+python3 test/test_pallas.py

--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -48,6 +48,7 @@ spec:
       pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
 
       cd /src/pytorch/xla
+      # TODO: pallas test requires JAX, now we need to explicitly set TPU_LIBRARY_PATH for JAX, need a permanent fix.
       TPU_LIBRARY_PATH=/usr/local/lib/python3.10/site-packages/torch_xla/lib/libtpu.so test/tpu/run_tests.sh
     volumeMounts:
     - mountPath: /dev/shm

--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -48,7 +48,7 @@ spec:
       pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
 
       cd /src/pytorch/xla
-      test/tpu/run_tests.sh
+      TPU_LIBRARY_PATH=/usr/local/lib/python3.10/site-packages/torch_xla/lib/libtpu.so test/tpu/run_tests.sh
     volumeMounts:
     - mountPath: /dev/shm
       name: dshm


### PR DESCRIPTION
In #6715, Pallas TPU CI failed because JAX cannot find the `libtpu.so` path
```
INFO:jax._src.xla_bridge:Unable to initialize backend 'tpu': INTERNAL: Failed to open libtpu.so: libtpu.so: cannot open shared object file: No such file or directory
```
The log also shows the path of libtpu.so is in the torch_xla python module folder:
```
I0000 00:00:1710194162.272765   61251 pjrt_api.cc:100] GetPjrtApi was found for tpu at /usr/local/lib/python3.10/site-packages/torch_xla/lib/libtpu.so
```

So it should because the libtpu.so is bundled with the installation of torch_xla. So JAX cannot find the path to libtpu.so

JAX will search `TPU_LIBRARY_PATH` if `libtpu` python module is not installed. In this PR, I added env var `TPU_LIBRARY_PATH` pointing at the `libtpu.so` bundled with torch_xla, when running the TPU testing script. 