### PR TITLE
Allow `int` data-type for `Embedding` indices.

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1610,14 +1610,17 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
   def test_embedding_int_indices(self):
     model = torch.nn.Embedding(1024, 10)
 
-    def test_on_device(device):
-      m = copy.deepcopy(model).to(device)
-      index = torch.ones(1, dtype=torch.int, device=device)
-      return m(index)
+    # 1 and 2-dimensional tensors.
+    # They have different execution paths.
+    for shape in ((5,), (2, 5)):
+      def test_on_device(device):
+        m = copy.deepcopy(model).to(device)
+        index = torch.ones(shape, dtype=torch.int, device=device)
+        return m(index)
 
-    out = test_on_device("cpu")
-    out_x = test_on_device(xm.xla_device())
-    self.assertEqual(out, out_x.cpu())
+      out = test_on_device("cpu")
+      out_x = test_on_device(xm.xla_device())
+      self.assertEqual(out, out_x.cpu())
 
   def test_transpose_1d(self):
 

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1613,6 +1613,7 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     # 1 and 2-dimensional tensors.
     # They have different execution paths.
     for shape in ((5,), (2, 5)):
+
       def test_on_device(device):
         m = copy.deepcopy(model).to(device)
         index = torch.ones(shape, dtype=torch.int, device=device)

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1607,6 +1607,18 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     emb_out = emb(index)
     assert emb_out.dtype == torch.bfloat16
 
+  def test_embedding_int_indices(self):
+    model = torch.nn.Embedding(1024, 10)
+
+    def test_on_device(device):
+      m = copy.deepcopy(model).to(device)
+      index = torch.ones(1, dtype=torch.int, device=device)
+      return m(index)
+
+    out = test_on_device("cpu")
+    out_x = test_on_device(xm.xla_device())
+    self.assertEqual(out, out_x.cpu())
+
   def test_transpose_1d(self):
 
     def test_fn(t1):

--- a/torch_xla/csrc/tensor_ops.cpp
+++ b/torch_xla/csrc/tensor_ops.cpp
@@ -245,7 +245,7 @@ XLATensorPtr EmbeddingDenseBackward(const XLATensorPtr& grad_output,
 XLATensorPtr Embedding(const XLATensorPtr& weight,
                        const XLATensorPtr& indices) {
   XLA_CHECK_EQ(weight->shape().get().rank(), 2);
-  XLA_CHECK_EQ(indices->dtype(), at::ScalarType::Long);
+  XLA_CHECK(indices->dtype() == at::kLong || indices->dtype() == at::kInt);
 
   if (indices->shape().get().rank() == 1) {
     return tensor_methods::index_select(weight, 0, indices);


### PR DESCRIPTION
Fix: #6648 

This PR allows `Int` indices on `Embedding` lowering, instead of strictly checking for `Long` only. This is allowed according to the [documentation](https://pytorch.org/docs/stable/generated/torch.nn.Embedding.html).

cc @miladm @JackCaoG @bhavya01 @lezcano 