### PR TITLE
[SPMD] Use UNKNOWN sharding type for implicit replication

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -188,7 +188,6 @@ function run_torch_xla_cpp_tests() {
     fi
 
     if [ "$USE_COVERAGE" != "0" ]; then
-      # TODO(yeounoh) shard the coverage testing
       if [ -x "$(command -v nvidia-smi)" ]; then
         PJRT_DEVICE=CUDA test/cpp/run_tests.sh $EXTRA_ARGS -L""
         cp $XLA_DIR/bazel-out/_coverage/_coverage_report.dat /tmp/cov1.dat
@@ -235,7 +234,6 @@ function run_torch_xla_tests() {
   export PYTORCH_TESTING_DEVICE_ONLY_FOR="xla"
   export CXX_ABI=$(python -c "import torch;print(int(torch._C._GLIBCXX_USE_CXX11_ABI))")
 
-  # TODO(yeounoh) test coverage workflow is not parallelized.
   if [[ -z "$RUN_BENCHMARK_TESTS" && -z "$RUN_CPP_TESTS1" && -z "$RUN_CPP_TESTS2" && -z "$RUN_PYTHON_TESTS" ]]; then
     run_torch_xla_python_tests $PYTORCH_DIR $XLA_DIR $USE_COVERAGE
     run_torch_xla_cpp_tests $PYTORCH_DIR $XLA_DIR $USE_COVERAGE

--- a/.kokoro/common.sh
+++ b/.kokoro/common.sh
@@ -36,7 +36,6 @@ function install_environments() {
   echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" >> /etc/apt/sources.list.d/google-cloud-sdk.list
   curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 
-  # TODO(yeounoh) fix `GoogleCredentials` import error
   apt-get update
   apt-get -y install google-cloud-cli
   pip install --upgrade google-api-python-client
@@ -95,7 +94,6 @@ function run_torch_xla_tests() {
   pushd $XLA_DIR
     echo "Running integration tests..."
     # Run integration tests with CPU
-    # TODO(yeounoh) use custom GCP project for TPU
     XLA_CUDA=0 USE_COVERAGE=0 XLA_SKIP_TORCH_OP_TESTS=1 XLA_SKIP_XRT_TESTS=1 CONTINUE_ON_ERROR=1 ./test/run_tests.sh
   popd
 }

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -715,8 +715,9 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
     xst2 = xst1 + 5
     hlo = torch_xla._XLAC._get_xla_tensors_hlo([xst2.global_tensor])
     self.assertIn('%p1.4 = f32[1,8]{1,0} parameter(1), sharding', hlo)
-    # scalar 5 should be replicated
-    self.assertIn('%p0.2 = f32[] parameter(0), sharding={replicated}', hlo)
+    # scalar 5 should be implicitly replicated, so the pre-optimization HLO
+    # shouldn't mark it with sharding.
+    self.assertNotIn('%p0.2 = f32[] parameter(0), sharding={replicated}', hlo)
 
   def test_2d_tensor_3d_mesh(self):
     ct1 = torch.randn(16, 16, device='cpu')

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2391,7 +2391,8 @@ void XLANativeFunctions::_propagate_xla_data(const at::Tensor& input,
   output_tensor->data()->alias_id = input_tensor->GetUniqueId();
 
   // 2) Aid SPMD.
-  if (input_tensor->sharding_spec()) {
+  XLATensor::ShardingSpecPtr sharding = input_tensor->sharding_spec();
+  if (sharding && sharding->sharding.type() != xla::OpSharding::UNKNOWN) {
     tensor_methods::custom_sharding_(output_tensor,
                                      input_tensor->sharding_spec());
   }

--- a/torch_xla/csrc/debug_util.cpp
+++ b/torch_xla/csrc/debug_util.cpp
@@ -212,7 +212,7 @@ void DebugUtil::SaveOutputShardingInfo(std::vector<XLATensorPtr>* tensors,
       ss << xla::HloSharding::FromProto(xtensor->sharding_spec()->sharding)
                 ->ToString();
     } else {
-      ss << xla::HloSharding::FromProto(xla::HloSharding::Replicate().ToProto())
+      ss << xla::HloSharding::FromProto(xla::HloSharding::Unknown().ToProto())
                 ->ToString();
     }
     ss << "\n";

--- a/torch_xla/csrc/ir.cpp
+++ b/torch_xla/csrc/ir.cpp
@@ -154,7 +154,7 @@ torch::lazy::hash_t XlaNode::GetOpHash(torch::lazy::OpKind op,
 void XlaNode::SetSharding(const xla::OpSharding& sharding, size_t index) {
   if (output_shardings_.size() == 0) {
     output_shardings_ =
-        std::vector<std::shared_ptr<xla::OpSharding>>(num_outputs());
+        std::vector<std::shared_ptr<xla::OpSharding>>(num_outputs(), nullptr);
   }
   output_shardings_[index] = std::make_shared<xla::OpSharding>(sharding);
   // TODO(JackCaoG): fix this hashing

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -715,12 +715,12 @@ PjRtComputationClient::ExecuteReplicated(
     XLA_CHECK_EQ(output_shapes.size(), num_outputs);
 
     const std::vector<xla::OpSharding>& output_shardings =
-        pjrt_computation.output_shardings_
+        pjrt_computation.output_shardings_.has_value() && num_outputs > 0
             ? *pjrt_computation.output_shardings_
             :
             // Without an explicit sharding annotation, the output is implicitly
-            // replicated
-            std::vector(num_outputs, xla::HloSharding::Replicate().ToProto());
+            // replicated, and we mark explicitly replicated here.
+            std::vector<xla::OpSharding>(num_outputs);
     XLA_CHECK_EQ(output_shardings.size(), num_outputs);
 
     absl::BlockingCounter counter(num_outputs);

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -262,7 +262,7 @@ class XLATensor : public torch::lazy::LazyTensor {
                  const bool& minibatch)
         : sharding(sharding), shape(shape), minibatch(minibatch) {}
 
-    xla::OpSharding sharding;
+    xla::OpSharding sharding = xla::HloSharding::Unknown().ToProto();
     // Optional source tensor shape unpartitioned.
     xla::Shape shape;
     // Parameter for represent input batch in sharded along batch axes
@@ -270,7 +270,8 @@ class XLATensor : public torch::lazy::LazyTensor {
   };
 
   // Annotate the IR value with ShardingSpec.
-  void SetShardingSpec(const ShardingSpec& sharding_spec);
+  void SetShardingSpec(const ShardingSpec& sharding_spec,
+                       bool overwrite = false);
   // Clear sharding annotation attached to the IR value and transfer sharded
   // data back to host.
   void ClearShardingSpec();

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -473,10 +473,8 @@ torch::lazy::BackendDataPtr TensorToXlaData(
         runtime::GetComputationClient()->GetLocalDevices();
     auto replicated_data =
         std::vector<at::Tensor>(local_devices.size(), tensor);
-    auto sharding_spec = std::make_shared<XLATensor::ShardingSpec>(
-        xla::HloSharding::Replicate().ToProto(), shape);
     return ShardingUtil::CreateShardedData(replicated_data, local_devices,
-                                           sharding_spec);
+                                           nullptr);
   }
 
   std::vector<std::shared_ptr<const runtime::TensorSource>> source_tensors;
@@ -704,10 +702,8 @@ std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
       auto shape = CreateComputationShapeFromTensor(tensors[i], &device);
       auto replicated_data =
           std::vector<at::Tensor>(local_devices.size(), tensors[i]);
-      auto sharding_spec = std::make_shared<XLATensor::ShardingSpec>(
-          xla::HloSharding::Replicate().ToProto(), shape);
       handles.push_back(ShardingUtil::CreateShardedData(
-          replicated_data, local_devices, sharding_spec));
+          replicated_data, local_devices, nullptr));
     }
     return WrapXlaData(handles);
   }

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -1090,6 +1090,7 @@ XLAGraphExecutor::ScheduleSyncTensorsGraph(
                 UnwrapXlaData(async->parameters_data), devices,
                 execute_options);
         results = WrapXlaData(outputs);
+        TORCH_LAZY_COUNTER("ExecuteReplicated", 1);
         TF_VLOG(3) << "Executing IR graph hash "
                    << torch::lazy::HashToString(hash)
                    << " on devices: " << absl::StrJoin(devices, ",")
@@ -1101,6 +1102,7 @@ XLAGraphExecutor::ScheduleSyncTensorsGraph(
         results = torch::lazy::getBackend()->ExecuteComputation(
             async->cached_computation->computation, async->parameters_data,
             async->device);
+        TORCH_LAZY_COUNTER("ExecuteComputation", 1);
         TF_VLOG(3) << "Executing IR graph hash "
                    << torch::lazy::HashToString(hash) << " on device "
                    << async->device << " done!";

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -692,7 +692,6 @@ void XLAGraphExecutor::TensorCollectionBarrier(SyncTensorCollection* coll) {
   TF_VLOG(4) << "waiting barrier for device " << coll->device.toString()
              << " start";
   torch::lazy::LazyGraphExecutor::TensorCollectionBarrier(coll);
-  // TODO(yeounoh) lock SPMD device
   TF_VLOG(4) << "waiting barrier for device " << coll->device.toString()
              << " done";
 }
@@ -741,7 +740,7 @@ XLAGraphExecutor::ExecuteComputationWithBarrier(
     if (output_sharding_hash.find(hash) == output_sharding_hash.end()) {
       TORCH_LAZY_COUNTER("UncachedOutputSharding", 1);
       output_sharding_hash[hash] = ShardingUtil::GetOutputSharding(
-          output_shapes, cachedComputation->computation, device);
+          *output_shapes, cachedComputation->computation);
     }
     placeholders =
         ShardingUtil::CreateShardedPlaceholder(output_sharding_hash[hash]);

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -3,6 +3,8 @@
 
 #include <torch/csrc/jit/python/pybind.h>
 
+#include <tuple>
+
 #include "torch_xla/csrc/ir.h"
 #include "torch_xla/csrc/lowering_context.h"
 #include "torch_xla/csrc/runtime/computation_client.h"
@@ -22,7 +24,8 @@ class ShardingUtil {
     TUPLE = 2,
     TILED = 3,
     MANUAL = 4,
-    PARTIAL = 5
+    PARTIAL = 5,
+    UNKNOWN = 6  // implicit replication
   };
 
   // Determine the ShardingType of the given xla::OpSharding.
@@ -86,11 +89,11 @@ class ShardingUtil {
       const at::Tensor& tensor, const XLATensor::ShardingSpecPtr shardings,
       const std::vector<std::string>& devices, bool padded = true);
 
-  // Retrieve output sharding of a given XLA computation.
+  // Retrieve output sharding of a given XLA computation. ShardingSpec::shape
+  // is always on virtual SPMD device.
   static std::vector<XLATensor::ShardingSpecPtr> GetOutputSharding(
-      std::vector<xla::Shape>* output_shapes,
-      runtime::ComputationClient::ComputationPtr computation,
-      const torch::lazy::BackendDevice& device);
+      const std::vector<xla::Shape>& output_shapes,
+      runtime::ComputationClient::ComputationPtr computation);
 
   // Create sharded data placeholders, each corresponding to the individual
   // sharding spec from the input list


### PR DESCRIPTION
This is part of auto-sharding PoC described in #6322 . This PR addresses the following:
* Adapt xla::OpSharding::UNKNOWN for implicit replication type.
* Refactoring of ShardingUtil::GetOutputSharding, ShardingUtil::CreateShardedData
* Remove resolved TODOs

It is important to distinguish implicit and explicit replciation for XLA compiler to generate shardings for.