### PR TITLE
Bump JAX version in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ base_dir = os.path.dirname(os.path.abspath(__file__))
 _date = '20240305'
 _libtpu_version = f'0.1.dev{_date}'
 _libtpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
-_jax_version = f'0.4.25.dev{_date}'
+_jax_version = f'0.4.26.dev{_date}'
 
 
 def _get_build_mode():


### PR DESCRIPTION
#6677 updated the build date, but did not bump the JAX minor version. We need to install this wheel: https://storage.googleapis.com/jax-releases/nightly/nocuda/jaxlib-0.4.26.dev20240305-cp310-cp310-manylinux2014_x86_64.whl

This breaks the TPU CI since we can't install the right JAX version.