### PR TITLE
[Pallas] Add a bfloat16 flash attention test case

### DIFF
--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -158,8 +158,9 @@ class PallasTest(unittest.TestCase):
     pt_kernel = make_kernel_from_pallas(add_vectors, lambda x, y:
                                         (x.shape, x.dtype))
 
-    dtypes = [torch.float32, torch.float
-             ]  # Add doesn't support torch.float64, torch.bfloat16, torch.float16.
+    dtypes = [
+        torch.float32, torch.float
+    ]  # Add doesn't support torch.float64, torch.bfloat16, torch.float16.
     for i in range(len(dtypes)):
       x = torch.randn((i + 1, i + 1), dtype=dtypes[i]).to("xla")
       y = torch.randn((i + 1, i + 1), dtype=dtypes[i]).to("xla")
@@ -177,14 +178,13 @@ class PallasTest(unittest.TestCase):
       output = pt_kernel(x, y)
       self.assertTrue(torch.allclose(output.cpu(), expected_output.cpu()))
 
-
   @unittest.skipIf(xr.device_type() != 'TPU', "This test only works on TPU.")
   @unittest.mock.patch.dict(os.environ, {"XLA_TPU_LAYOUT": "0"})
   def test_tpu_custom_call_pallas_wrap_flash_attention(self):
     from jax.experimental.pallas.ops.tpu.flash_attention import flash_attention
     from torch_xla.experimental.custom_kernel import make_kernel_from_pallas
-    flash_attention_kernel = make_kernel_from_pallas(flash_attention, lambda q, k, v:
-                                        (q.shape, q.dtype))
+    flash_attention_kernel = make_kernel_from_pallas(
+        flash_attention, lambda q, k, v: (q.shape, q.dtype))
 
     def attention(q, k, v):
       attn_weight = q @ k.transpose(-2, -1)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -7,6 +7,7 @@ from torch import nn as nn
 
 import torch_xla
 from torch_xla import runtime as xr
+from torch_xla._internal import tpu
 
 
 class PallasTest(unittest.TestCase):
@@ -178,7 +179,7 @@ class PallasTest(unittest.TestCase):
       output = pt_kernel(x, y)
       self.assertTrue(torch.allclose(output.cpu(), expected_output.cpu()))
 
-  @unittest.skipIf(xr.device_type() != 'TPU', "This test only works on TPU.")
+  @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 3, "This test only works on TPUv3+.")
   @unittest.mock.patch.dict(os.environ, {"XLA_TPU_LAYOUT": "0"})
   def test_tpu_custom_call_pallas_wrap_flash_attention(self):
     from jax.experimental.pallas.ops.tpu.flash_attention import flash_attention

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -179,7 +179,8 @@ class PallasTest(unittest.TestCase):
       output = pt_kernel(x, y)
       self.assertTrue(torch.allclose(output.cpu(), expected_output.cpu()))
 
-  @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 3, "This test only works on TPUv3+.")
+  @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 3,
+                   "This test only works on TPUv3+.")
   @unittest.mock.patch.dict(os.environ, {"XLA_TPU_LAYOUT": "0"})
   def test_tpu_custom_call_pallas_wrap_flash_attention(self):
     from jax.experimental.pallas.ops.tpu.flash_attention import flash_attention


### PR DESCRIPTION
Summary:
Add a bfloat16 flash attention test case.

Test Plan:
python test/test_pallas.py
