### PR TITLE
Register reshape to RegisterAutogradXLA.cpp

### DIFF
--- a/codegen/xla_native_functions.yaml
+++ b/codegen/xla_native_functions.yaml
@@ -380,7 +380,6 @@ supported:
   - narrow_copy
   - pixel_shuffle
   - pixel_unshuffle
-  - reshape
   - select_backward
   - select.int
   - slice.Tensor
@@ -413,13 +412,12 @@ symint:
   - narrow_copy
   - select_backward
   - select.int
-  # See Note: [functionalization and CompositeExplicitAutograd]
-  - reshape
   # See Note: [Disabling functionalization]
   - expand
   - view
 autograd:
   - einsum
+  - reshape
   - max_pool2d
   - max_pool3d
   - native_layer_norm

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3653,13 +3653,17 @@ at::Tensor XLANativeFunctions::pixel_unshuffle(const at::Tensor& self,
       pixel_unshuffle)>::call(self, downscale_factor);
 }
 
-at::Tensor XLANativeFunctions::reshape(const at::Tensor & self, c10::SymIntArrayRef shape) {
+at::Tensor XLANativeFunctions::reshape(const at::Tensor& self,
+                                       at::IntArrayRef shape) {
   // See Note: [Disabling functionalization]
   if (runtime::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
-    return at::native::reshape_symint(self, shape);
+    return at::native::reshape_symint(
+        self,
+        c10::SymIntArrayRef(reinterpret_cast<const c10::SymInt*>(shape.data()),
+                            shape.size()));
   }
-  return at::functionalization::functionalize_aten_op_symint<ATEN_OP(
-      reshape)>::call(self, shape);
+  return at::functionalization::functionalize_aten_op<ATEN_OP(reshape)>::call(
+      self, shape);
 }
 
 at::Tensor XLANativeFunctions::select_backward_symint(

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3663,11 +3663,13 @@ at::Tensor XLANativeFunctions::reshape(const at::Tensor& self,
                             shape.size()));
   }
   auto inner_tensor = torch::lazy::maybe_unwrap_functional(self);
-  return at::functionalization::functionalize_aten_op_symint<ATEN_OP(
-      reshape)>::call(inner_tensor,
-                      c10::SymIntArrayRef(
-                          reinterpret_cast<const c10::SymInt*>(shape.data()),
-                          shape.size()));
+  return MaybeWrapTensorToFunctional(
+      at::functionalization::functionalize_aten_op_symint<ATEN_OP(
+          reshape)>::call(inner_tensor,
+                          c10::SymIntArrayRef(
+                              reinterpret_cast<const c10::SymInt*>(
+                                  shape.data()),
+                              shape.size())));
 }
 
 at::Tensor XLANativeFunctions::select_backward_symint(

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3662,8 +3662,9 @@ at::Tensor XLANativeFunctions::reshape(const at::Tensor& self,
         c10::SymIntArrayRef(reinterpret_cast<const c10::SymInt*>(shape.data()),
                             shape.size()));
   }
+  auto inner_tensor = torch::lazy::maybe_unwrap_functional(self);
   return at::functionalization::functionalize_aten_op_symint<ATEN_OP(
-      reshape)>::call(self,
+      reshape)>::call(inner_tensor,
                       c10::SymIntArrayRef(
                           reinterpret_cast<const c10::SymInt*>(shape.data()),
                           shape.size()));

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3653,8 +3653,7 @@ at::Tensor XLANativeFunctions::pixel_unshuffle(const at::Tensor& self,
       pixel_unshuffle)>::call(self, downscale_factor);
 }
 
-at::Tensor XLANativeFunctions::reshape_symint(const at::Tensor& self,
-                                              c10::SymIntArrayRef shape) {
+at::Tensor XLANativeFunctions::reshape(const at::Tensor & self, c10::SymIntArrayRef shape) {
   // See Note: [Disabling functionalization]
   if (runtime::sys_util::GetEnvBool("XLA_DISABLE_FUNCTIONALIZATION", false)) {
     return at::native::reshape_symint(self, shape);

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3662,8 +3662,11 @@ at::Tensor XLANativeFunctions::reshape(const at::Tensor& self,
         c10::SymIntArrayRef(reinterpret_cast<const c10::SymInt*>(shape.data()),
                             shape.size()));
   }
-  return at::functionalization::functionalize_aten_op<ATEN_OP(reshape)>::call(
-      self, shape);
+  return at::functionalization::functionalize_aten_op_symint<ATEN_OP(
+      reshape)>::call(self,
+                      c10::SymIntArrayRef(
+                          reinterpret_cast<const c10::SymInt*>(shape.data()),
+                          shape.size()));
 }
 
 at::Tensor XLANativeFunctions::select_backward_symint(


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/115816

Previously there is no `reshape` registration in `RegisterAutogradXLA.cpp`, hence this warning message. After this change, we can see it being registered:
```
at::Tensor wrapper_AutogradXLA__reshape(const at::Tensor & self, c10::SymIntArrayRef shape) {
    // No device check
  // DeviceGuard omitted
  return torch_xla::XLANativeFunctions::reshape(self, C10_AS_INTARRAYREF_SLOW(shape));
}
...
    m.impl("reshape",
    TORCH_FN(wrapper_AutogradXLA__reshape));
```
