### PR TITLE
Include auto-sharding configs as part of hash

### DIFF
--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -1510,6 +1510,14 @@ XLAGraphExecutor::SyncTensorsGraphInternal(
           coll.hash, torch::lazy::Hash(buffer_donor_index));
     }
   }
+  if (ShardingUtil::GetAutoSharding()) {
+    std::string xla_auto_spmd = "XLA_AUTO_SPMD=1";
+    coll.hash = torch::lazy::HashCombine(
+        coll.hash, torch::lazy::StringHash(xla_auto_spmd.c_str()));
+    std::string xla_auto_spmd_mesh = "XLA_AUTO_SPMD_MESH=" + sys_util::GetEnvString("XLA_AUTO_SPMD_MESH", "");
+    coll.hash = torch::lazy::HashCombine(
+        coll.hash, torch::lazy::StringHash(xla_auto_spmd_mesh.c_str()));
+  }
 
   DebugUtil::SaveGraphHash(coll.hash);
   TF_VLOG(4) << "Parameter sequence graph hash "

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -517,6 +517,15 @@ torch::lazy::hash_t XLAGraphExecutor::GetGraphHash(
           res_hash, torch::lazy::Hash(buffer_donor_index));
     }
   }
+  {
+    // Auto-sharding configs
+    res_hash = torch::lazy::HashCombine(
+        res_hash, torch::lazy::MHash(ShardingUtil::GetAutoSharding()));
+    res_hash = torch::lazy::HashCombine(
+        res_hash,
+        torch::lazy::StringHash(
+            runtime::sys_util::GetEnvString("XLA_AUTO_SPMD_MESH", "").c_str()));
+  }
   DeviceContextArena::Get()->SaveOutputShapes(res_hash,
                                               std::move(output_shapes));
   DeviceContextArena::Get()->SaveGraphAsString(res_hash, tensors,
@@ -1510,13 +1519,14 @@ XLAGraphExecutor::SyncTensorsGraphInternal(
           coll.hash, torch::lazy::Hash(buffer_donor_index));
     }
   }
-  if (ShardingUtil::GetAutoSharding()) {
+  {
+    // Auto-sharding configs
     coll.hash = torch::lazy::HashCombine(
         coll.hash, torch::lazy::MHash(ShardingUtil::GetAutoSharding()));
     coll.hash = torch::lazy::HashCombine(
         coll.hash,
         torch::lazy::StringHash(
-            sys_util::GetEnvString("XLA_AUTO_SPMD_MESH", "").c_str()));
+            runtime::sys_util::GetEnvString("XLA_AUTO_SPMD_MESH", "").c_str()));
   }
 
   DebugUtil::SaveGraphHash(coll.hash);

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -1511,12 +1511,12 @@ XLAGraphExecutor::SyncTensorsGraphInternal(
     }
   }
   if (ShardingUtil::GetAutoSharding()) {
-    std::string xla_auto_spmd = "XLA_AUTO_SPMD=1";
     coll.hash = torch::lazy::HashCombine(
-        coll.hash, torch::lazy::StringHash(xla_auto_spmd.c_str()));
-    std::string xla_auto_spmd_mesh = "XLA_AUTO_SPMD_MESH=" + sys_util::GetEnvString("XLA_AUTO_SPMD_MESH", "");
+        coll.hash, torch::lazy::MHash(ShardingUtil::GetAutoSharding()));
     coll.hash = torch::lazy::HashCombine(
-        coll.hash, torch::lazy::StringHash(xla_auto_spmd_mesh.c_str()));
+        coll.hash,
+        torch::lazy::StringHash(
+            sys_util::GetEnvString("XLA_AUTO_SPMD_MESH", "").c_str()));
   }
 
   DebugUtil::SaveGraphHash(coll.hash);


### PR DESCRIPTION
This is to support #6322 . We need to include such configs in the hash computation to avoid collision with persistent caching.