### PR TITLE
Fix torchrun on single-process case.

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -137,6 +137,7 @@ function run_torch_xla_python_tests() {
       if [ -x "$(command -v nvidia-smi)" ]; then
         # single-host-single-process
         PJRT_DEVICE=CUDA python3 test/test_train_mp_imagenet.py --fake_data --batch_size=16 --num_epochs=1 --num_cores=1 --num_steps=25 --model=resnet18
+        PJRT_DEVICE=CUDA torchrun --nnodes=1 --node_rank=0 --nproc_per_node=1 pytorch/xla/test/test_train_mp_imagenet.py --fake_data --pjrt_distributed --batch_size=16 --num_epochs=1  --num_steps=25 --model=resnet18
 
         # single-host-multi-process
         num_devices=$(nvidia-smi --list-gpus | wc -l)

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -137,7 +137,7 @@ function run_torch_xla_python_tests() {
       if [ -x "$(command -v nvidia-smi)" ]; then
         # single-host-single-process
         PJRT_DEVICE=CUDA python3 test/test_train_mp_imagenet.py --fake_data --batch_size=16 --num_epochs=1 --num_cores=1 --num_steps=25 --model=resnet18
-        PJRT_DEVICE=CUDA torchrun --nnodes=1 --node_rank=0 --nproc_per_node=1 pytorch/xla/test/test_train_mp_imagenet.py --fake_data --pjrt_distributed --batch_size=16 --num_epochs=1  --num_steps=25 --model=resnet18
+        PJRT_DEVICE=CUDA torchrun --nnodes=1 --node_rank=0 --nproc_per_node=1 test/test_train_mp_imagenet.py --fake_data --pjrt_distributed --batch_size=16 --num_epochs=1  --num_steps=25 --model=resnet18
 
         # single-host-multi-process
         num_devices=$(nvidia-smi --list-gpus | wc -l)

--- a/torch_xla/_internal/pjrt.py
+++ b/torch_xla/_internal/pjrt.py
@@ -98,6 +98,7 @@ def _run_singleprocess(fn: Callable[..., R], *args, **kwargs) -> Dict[int, R]:
   initialize_singleprocess()
   return fn(*args, **kwargs)
 
+
 @runtime.requires_pjrt
 def initialize_singleprocess():
   os.environ.setdefault(xenv.PJRT_LOCAL_PROCESS_COUNT, '1')
@@ -107,6 +108,7 @@ def initialize_singleprocess():
   elif runtime.device_type() == 'TPU':
     tpu.configure_one_chip_topology()
   xm.set_replication(xm.xla_device(), [])
+
 
 @runtime.requires_pjrt
 def initialize_multiprocess(local_rank: int, local_world_size: int):

--- a/torch_xla/_internal/pjrt.py
+++ b/torch_xla/_internal/pjrt.py
@@ -95,17 +95,18 @@ def _run_singleprocess(fn: Callable[..., R], *args, **kwargs) -> Dict[int, R]:
   Returns:
     the result of calling `fn`.
   """
+  initialize_singleprocess()
+  return fn(*args, **kwargs)
+
+@runtime.requires_pjrt
+def initialize_singleprocess():
   os.environ.setdefault(xenv.PJRT_LOCAL_PROCESS_COUNT, '1')
 
   if plugins.using_dynamic_plugins():
     plugins.default().configure_single_process()
   elif runtime.device_type() == 'TPU':
     tpu.configure_one_chip_topology()
-
   xm.set_replication(xm.xla_device(), [])
-
-  return fn(*args, **kwargs)
-
 
 @runtime.requires_pjrt
 def initialize_multiprocess(local_rank: int, local_world_size: int):

--- a/torch_xla/_internal/rendezvous.py
+++ b/torch_xla/_internal/rendezvous.py
@@ -20,7 +20,10 @@ def pjrt_rendezvous_handler(url: str,
   if dist.is_torchelastic_launched():
     local_world_size = xu.getenv_as('LOCAL_WORLD_SIZE', int)
     local_rank = xu.getenv_as('LOCAL_RANK', int)
-    pjrt.initialize_multiprocess(local_rank, local_world_size)
+    if local_world_size > 1:
+      pjrt.initialize_multiprocess(local_rank, local_world_size)
+    else:
+      pjrt.initialize_singleprocess()
 
   master_ip = xu.getenv_as('MASTER_ADDR', str)
   if not master_ip:

--- a/torch_xla/csrc/runtime/pjrt_registry.cc
+++ b/torch_xla/csrc/runtime/pjrt_registry.cc
@@ -133,7 +133,8 @@ InitializePjRt(const std::string& device_type) {
 
     TF_VLOG(3) << "Getting StreamExecutorGpuClient for node_id="
                << global_process_rank << ", num_nodes=" << global_world_size
-               << ", local_process_rank=" << local_process_rank << ", local_world_size=" << local_world_size
+               << ", local_process_rank=" << local_process_rank
+               << ", local_world_size=" << local_world_size
                << ", spmd case=" << sys_util::GetEnvBool("XLA_USE_SPMD", false)
                << ", PJRT_LOCAL_PROCESS_RANK="
                << sys_util::GetEnvString(env::kEnvPjRtLocalRank, "")

--- a/torch_xla/csrc/runtime/pjrt_registry.cc
+++ b/torch_xla/csrc/runtime/pjrt_registry.cc
@@ -133,6 +133,7 @@ InitializePjRt(const std::string& device_type) {
 
     TF_VLOG(3) << "Getting StreamExecutorGpuClient for node_id="
                << global_process_rank << ", num_nodes=" << global_world_size
+               << ", local_process_rank=" << local_process_rank << ", local_world_size=" << local_world_size
                << ", spmd case=" << sys_util::GetEnvBool("XLA_USE_SPMD", false)
                << ", PJRT_LOCAL_PROCESS_RANK="
                << sys_util::GetEnvString(env::kEnvPjRtLocalRank, "")


### PR DESCRIPTION
Today, when use torchrun on single-process, it hangs. This PR intends to fix this issue.

Test: PJRT_DEVICE=CUDA torchrun --nnodes=1 --node_rank=0 --nproc_per_node=1 pytorch/xla/test/test_train_mp_imagenet.py --fake_data --pjrt_distributed --batch_size=16 --num_epochs=1  --num_steps=25 --model=resnet18