### PR TITLE
Use AddBufferDonor to replace SetUpAlias for input output aliasing

### DIFF
--- a/torch_xla/csrc/helpers.cpp
+++ b/torch_xla/csrc/helpers.cpp
@@ -975,7 +975,6 @@ xla::XlaOp XlaHelpers::PromotedLogicalUnaryOp(
 xla::StatusOr<xla::XlaComputation> XlaHelpers::WrapXlaComputation(
     const xla::XlaComputation& computation,
     const std::vector<xla::Shape>& parameter_shapes,
-    const std::vector<std::pair<int64_t, int64_t>>& input_output_alias_pair,
     const std::vector<size_t>& buffer_donor_indices) {
   xla::XlaBuilder builder(computation.proto().name());
 
@@ -999,15 +998,7 @@ xla::StatusOr<xla::XlaComputation> XlaHelpers::WrapXlaComputation(
   xla::XlaOp orig_result = xla::Call(&builder, computation, inner_params);
 
   // Rebuild aliasing.
-  if (input_output_alias_pair.size() > 0) {
-    for (const auto& [input_index, output_index] : input_output_alias_pair) {
-      // Both input and output will be a tuple so parameter_number will always
-      // be 0
-      builder.SetUpAlias(/*output_index=*/xla::ShapeIndex({output_index}),
-                         /*param_number=*/0,
-                         /*param_index=*/xla::ShapeIndex({input_index}));
-    }
-  } else if (buffer_donor_indices.size() > 0) {
+  if (buffer_donor_indices.size() > 0) {
     for (size_t i : buffer_donor_indices) {
       builder.AddBufferDonor(/*param_number=*/0,
                              /*param_index=*/xla::ShapeIndex({i}));

--- a/torch_xla/csrc/helpers.h
+++ b/torch_xla/csrc/helpers.h
@@ -385,7 +385,6 @@ class XlaHelpers {
   static xla::StatusOr<xla::XlaComputation> WrapXlaComputation(
       const xla::XlaComputation& computation,
       const std::vector<xla::Shape>& parameter_shapes,
-      const std::vector<std::pair<int64_t, int64_t>>& input_output_alias_pair,
       const std::vector<size_t>& buffer_donor_indices);
 
   static torch::lazy::Shape ConvertXlaShapeToLazy(const xla::Shape& shape);

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -913,8 +913,7 @@ class PyLoweringContext {
       bool should_wrap_parameter = (program_shape.parameters_size() >= 2);
       if (should_wrap_parameter) {
         computation = ConsumeValue(XlaHelpers::WrapXlaComputation(
-            computation, program_shape.parameters(), input_output_alias_pair,
-            buffer_donor_indices));
+            computation, program_shape.parameters(), buffer_donor_indices));
       }
     }
   }

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -339,13 +339,13 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
       const std::vector<torch::lazy::BackendDataPtr>& tensor_data_vec,
       bool warm_up_cache_only);
 
-  std::vector<std::pair<int64_t, int64_t>> BuildInputOutputAliases(
-      const std::vector<XLATensorPtr>& tensors,
-      absl::Span<const size_t> indices, LoweringContext* lowering_ctx);
+  std::vector<size_t> SetBufferDonors(const std::vector<XLATensorPtr>& tensors,
+                                      absl::Span<const size_t> indices,
+                                      LoweringContext* lowering_ctx);
 
-  std::vector<size_t> SetBufferDonors(LoweringContext* lowering_ctx);
+  std::vector<size_t> SetBufferDonorsFromUserConfig(
+      LoweringContext* lowering_ctx);
 
-  // We don't use upstream Compile to have BuildInputOutputAliases.
   // TODO(yeounoh) auto-sharding can change tensors shardings, which needs to be
   // accounted for in Dynamo integration.
   CompilationResult Compile(std::vector<XLATensorPtr>& tensors,


### PR DESCRIPTION
Existing `SetUpAlias` requires us(PyTorch/XLA) to specify the input and output index we want to alias. This can be difficult for the SPMD use case because we don't know the output sharding hence we can't be sure if input and output will have the same buffer size.

`AddBufferDonor` is a newish API added by XLA team. It only requires us to give compiler a list of input buffer that can be reused for the output. It is up to the compiler to determine how to reuse these buffer. I have been user `AddBufferDonor` for the manual buffer donation for dynamo. In this pr I extend the use case to the auto-aliasing in LTC(the way it works is to determine all of the input buffers that does not have a XLATensor associated and conclude an inplace operation happened so the buffer can be reused).