### PR TITLE
Skip `cdouble` dtype in pow test on TPU

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1963,7 +1963,9 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     ]
 
     if not _is_on_tpu():
-      test_dtypes += [torch.cdouble, ]
+      test_dtypes += [
+          torch.cdouble,
+      ]
 
     for dtype in test_dtypes:
       test(dtype)

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1960,8 +1960,10 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
         torch.float32,
         torch.float64,
         torch.cfloat,
-        torch.cdouble,
     ]
+
+    if not _is_on_tpu():
+      test_dtypes += [torch.cdouble, ]
 
     for dtype in test_dtypes:
       test(dtype)


### PR DESCRIPTION
TPU doesn't support `cdouble` dtype, skip the test on `cdouble` dtype. Fix TPU CI broken by https://github.com/pytorch/xla/pull/6745

TPU CI doesn't run on PR CI, we may want to manually trigger TPU CI when `test/test_operations.py` is modified, or major lowering logic is modified. We have to do this manually before TPU CI is trigger in PR CI conditionally.

cc @ysiraichi 
