### PR TITLE
Add dynamism support to `aten.embedding` and `aten.split_with_sizes`

### DIFF
--- a/test/stablehlo/test_export_fx_passes.py
+++ b/test/stablehlo/test_export_fx_passes.py
@@ -32,6 +32,45 @@ class ExportFxPassTest(unittest.TestCase):
     out2 = ep.module()(*args)
     self.assertTrue(torch.allclose(out1, out2))
 
+  def test_decompose_dynamic_split_with_sizes(self):
+
+    class M(torch.nn.Module):
+
+      def forward(self, x):
+        res = torch.ops.aten.split_with_sizes.default(x, [1, 2, 3], -1)
+        return res[0], res[1]
+
+    args = (torch.rand((3, 10, 6)),)
+    dynamic_shapes = ({0: Dim("dim")},)
+    m = M()
+    ep = export(m, args, dynamic_shapes=dynamic_shapes)
+    out1 = ep.module()(*args)
+    decompose_split_with_sizes(ep.graph_module)
+    ep.graph_module.recompile()
+    self.assertTrue('split_with_sizes' in ep.graph_module.code)
+    out2 = ep.module()(*args)
+    self.assertTrue(torch.allclose(out1[0], out2[0]))
+    self.assertTrue(torch.allclose(out1[1], out2[1]))
+
+  def test_embedding_indices_flatten(self):
+    args = (torch.rand((20, 768)), torch.randint(0, 15,
+                                                 (3, 10)).to(torch.int64))
+    dynamic_shapes = ([None, {0: Dim("bs")}],)
+    m = wrap_func_as_nn_module(torch.ops.aten.embedding.default)
+    ep = export(m, args, dynamic_shapes=dynamic_shapes)
+    print(ep)
+    out1 = ep.module()(*args)
+    flatten_embedding_indices_tensor(ep.graph_module)
+    ep.graph_module.recompile()
+    print(ep)
+    self.assertTrue('aten.view' in ep.graph_module.code)
+    replace_dynamic_view_with_xla_op(ep.graph_module)
+    ep.graph_module.recompile()
+    self.assertTrue('aten.view' not in ep.graph_module.code)
+    self.assertTrue('xla.dynamic_view' in ep.graph_module.code)
+    out2 = ep.module()(*args)
+    self.assertTrue(torch.allclose(out1, out2))
+
   def test_no_op_slice_removal(self):
 
     class M(torch.nn.Module):

--- a/torch_xla/experimental/unbounded_dynamism_export.py
+++ b/torch_xla/experimental/unbounded_dynamism_export.py
@@ -117,6 +117,94 @@ def decompose_dynamic_shape_select(gm: GraphModule):
         graph.erase_node(n)
 
 
+def decompose_split_with_sizes(gm: GraphModule):
+  '''
+  Decompose `split_with_sizes` with symbolic input shape into `aten.slice` ops.
+
+  This is to reuse the unbounded dynamism support added to `aten.slice`.
+  '''
+  graph = gm.graph
+  for n in graph.nodes:
+    if n.op == "call_function" and n.target == aten.split_with_sizes.default:
+      src_node = n.args[0]
+      src_shape = src_node.meta['val'].size()
+      symbolic_dims = [
+          i for i, x in enumerate(src_shape) if not isinstance(x, int)
+      ]
+      if len(symbolic_dims) == 0:
+        continue
+      assert len(symbolic_dims) == 1, "Only 1 dimention can be symbolic."
+      split_sizes = n.args[1]
+      split_dim = n.args[2]
+      assert symbolic_dims[
+          0] != split_dim, "Split along symbolic dim is not supported."
+      with graph.inserting_before(n):
+        start_idx = 0
+        decomposed_slices = []
+        for size in split_sizes:
+          slice_args = (src_node, split_dim, start_idx, start_idx + size)
+          slice_node = graph.call_function(torch.ops.aten.slice.Tensor,
+                                           slice_args)
+          start_idx += size
+          decomposed_slices.append(slice_node)
+        consumers = n.users
+        for consumer in consumers:
+          assert n.op == "call_function" and consumer.target.__name__ == "getitem"
+          slice_idx = consumer.args[1]
+          consumer.replace_all_uses_with(decomposed_slices[slice_idx])
+
+
+def flatten_embedding_indices_tensor(gm: GraphModule):
+  '''
+  Flatten the indices tensor of `aten.embedding.default` to avoid `view` op with
+  symbolic input during LTC tracing.
+
+  The indices tensor will be flattened, the embedding output shape will be recovered.
+
+  The symbolic shape in `aten.view` will be handled by `aten.view` -> `xla.dynamic_view` pass.
+  '''
+  graph = gm.graph
+  for n in graph.nodes:
+    if n.op == "call_function" and n.target == aten.embedding.default:
+      select_src_shape = n.args[1].meta['val'].shape
+      symbolic_dims = [
+          i for i, x in enumerate(select_src_shape) if not isinstance(x, int)
+      ]
+      if len(symbolic_dims) > 0:
+        assert len(symbolic_dims) == 1, "Only 1 dimention can be symbolic."
+        with graph.inserting_before(n):
+          indices_node = n.args[1]
+          indices_shape = indices_node.meta['val'].size()
+          flatten_mul_scale = 1
+          get_dim_size_node = None
+          recover_view_shape = []
+          for dim, size in enumerate(indices_shape):
+            if not isinstance(size, int):
+              get_dim_size_args = (indices_node, dim)
+              get_dim_size_node = graph.call_function(aten.sym_size.int,
+                                                      get_dim_size_args)
+              recover_view_shape.append(get_dim_size_node)
+            else:
+              flatten_mul_scale *= size
+              recover_view_shape.append(size)
+          weight_shape = n.args[0].meta['val'].size()
+          recover_view_shape.append(weight_shape[-1])
+
+          mul_args = (get_dim_size_node, flatten_mul_scale)
+          flatten_size_node = graph.call_function(aten.mul.Scalar, mul_args)
+          view_args = (indices_node, [flatten_size_node])
+          view_node = graph.call_function(aten.view, view_args)
+          new_embedding_args = n.args[0:1] + (view_node,)
+          if len(n.args) > 2:
+            new_embedding_args += n.args[2:]
+          n.args = new_embedding_args
+        with graph.inserting_after(n):
+          recover_view_args = (n, recover_view_shape)
+          recover_view_node = graph.call_function(aten.view, recover_view_args)
+          n.replace_all_uses_with(recover_view_node)
+          recover_view_node.update_arg(0, n)
+
+
 def _is_no_op_slice(n):
   assert n.op == "call_function" and n.target == aten.slice.Tensor
   return n.args[2] == 0 and n.args[3] == torch.iinfo(torch.int64).max
@@ -199,8 +287,10 @@ def replace_dynamic_view_with_xla_op(gm: GraphModule):
         mul_scaler = 1
         sym_size_node = dynamic_src
         mul_node = None
-        if hasattr(dynamic_src.target,
-                   "__name__") and dynamic_src.target.__name__ == "mul":
+        if hasattr(
+            dynamic_src.target,
+            "__name__") and (dynamic_src.target.__name__ == "mul" or
+                             dynamic_src.target.__name__ == "mul.Scalar"):
           assert isinstance(dynamic_src.args[0], int) or isinstance(
               dynamic_src.args[1], int)
           mul_node = dynamic_src
@@ -233,6 +323,7 @@ def dynamic_unsqueeze_to_view(gm: GraphModule):
       ]
       if len(symbolic_dims) == 0:
         continue
+      assert len(symbolic_dims) == 1, "Only 1 dimention can be symbolic."
       view_args = list(src_shape)
       with graph.inserting_before(n):
         for dim in symbolic_dims:
@@ -263,10 +354,12 @@ def exported_program_has_symbolic_input_shape(ep):
 def process_exported_program_with_symbolic_input(ep):
   passes = [
       decompose_dynamic_shape_select,
+      decompose_split_with_sizes,
       remove_no_op_slice,
       decompose_dynamic_native_group_norm,
       decompose_dynamic_native_layer_norm,
       dynamic_unsqueeze_to_view,
+      flatten_embedding_indices_tensor,
       replace_dynamic_expand_with_xla_op,
       replace_dynamic_view_with_xla_op,
   ]


### PR DESCRIPTION
Support dynamism on `aten.embedding` and `aten.split_with_sizes`

- The indices tensors to `aten.embedding` can have more than 1 dimension. During tracing, it will be flattened. To avoid the view op with symbolic output shape, we flatten the indices tensor at FX level and the view with symbolic output shape will be handled by `aten.view` -> `xla.dynamic_view` pass.

- Add an FX pass to decompose `aten.split_with_sizes` into slice ops to reuse the dynamism added to slice.

Test:
- New tests added to test the FX passes and the lowered StableHLO