### PR TITLE
Remove extraneous cd

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,6 @@ We recommend you to use our prebuilt Docker image to start your development work
 
 * Build PyTorch
   ```Shell
-  cd /pytorch/
   python setup.py develop
   ```
 * Build PyTorch/XLA


### PR DESCRIPTION
At this point in the series of commands we are already in the `pytorch` directory. `/pytorch/` does not exist: `bash: cd: /pytorch/: No such file or directory`.