### PR TITLE
Add cuda 12.1 nightly wheels for cp310 and cp311.

### DIFF
--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -19,6 +19,16 @@ nightly_builds = [
     accelerator  = "cuda"
     cuda_version = "12.1"
   },
+  {
+    accelerator  = "cuda"
+    cuda_version = "12.1"
+    python_version = "3.10"
+  },
+  {
+    accelerator  = "cuda"
+    cuda_version = "12.1"
+    python_version = "3.11"
+  },
 ]
 
 # Built on push to specific tag.


### PR DESCRIPTION
cp311 cuda 12.1 nightly wheel is requested in https://github.com/pytorch/xla/issues/6771#issuecomment-2008615850.