### PR TITLE
Install torchvision in release docker

### DIFF
--- a/infra/ansible/Dockerfile
+++ b/infra/ansible/Dockerfile
@@ -20,8 +20,7 @@ ARG ansible_vars
 RUN ansible-playbook -vvv playbook.yaml -e "stage=release" -e "${ansible_vars}" --tags "install_deps"
 
 WORKDIR /tmp/wheels
-COPY --from=build /src/pytorch/dist/*.whl ./
-COPY --from=build /src/pytorch/xla/dist/*.whl ./
+COPY --from=build /dist/*.whl ./
 
 RUN echo "Installing the following wheels" && ls *.whl
 RUN pip install *.whl


### PR DESCRIPTION
Follow up PR to #6756

Only CI testing docker is covered in #6756, cover release docker in this PR.

Release docker is built based on https://github.com/pytorch/xla/blob/master/infra/ansible/Dockerfile. 