### PR TITLE
Inline all scalars by default in export path

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -212,6 +212,7 @@ function run_xla_op_tests2 {
 function run_xla_op_tests3 {
   # TODO(qihqi): this test require tensorflow to run. need to setup separate
   #     CI with tf.
+  run_test "$CDIR/stablehlo/test_exports.py"
   run_test "$CDIR/stablehlo/test_export_fx_passes.py"
   run_test "$CDIR/stablehlo/test_implicit_broadcasting.py"
   run_test "$CDIR/stablehlo/test_mark_pattern.py"

--- a/test/stablehlo/test_exports.py
+++ b/test/stablehlo/test_exports.py
@@ -1,8 +1,11 @@
+import re
 import tempfile
 import unittest
+
 import torch
 import torch.nn.functional as F
-from torch_xla.stablehlo import exported_program_to_stablehlo, StableHLOGraphModule
+from torch_xla.stablehlo import (StableHLOExportOptions, StableHLOGraphModule,
+                                 exported_program_to_stablehlo)
 
 
 class Interpolate(torch.nn.Module):
@@ -63,6 +66,52 @@ class ExportTest(unittest.TestCase):
         program2 = StableHLOGraphModule.load(tempdir)
       result = program2(*arg).detach().cpu()
       self.assertTrue(torch.allclose(ans, result))
+
+  def test_inline_all_scalar(self):
+
+    class M(torch.nn.Module):
+
+      def forward(self, x):
+        return torch.ops.aten.sub(torch.ops.aten.sub(x, 5), 1)
+
+    arg = (torch.randn(10, 10),)
+    model = M()
+
+    ans = model(*arg)
+
+    with torch.no_grad():
+      exported = torch.export.export(model, arg)
+      shlo = exported_program_to_stablehlo(exported)
+      ans2 = shlo(*arg).cpu().to(torch.float32)
+      self.assertTrue(torch.allclose(ans, ans2, atol=1e-5))
+      shlo_text = shlo.get_stablehlo_text()
+      self.assertTrue('stablehlo.constant dense<1.000000e+00>' in shlo_text)
+      self.assertTrue('stablehlo.constant dense<5.000000e+00>' in shlo_text)
+      self.assertFalse(re.search(r'%arg.*tensor<f32>', shlo_text) is not None)
+
+  def test_inline_only_special_scalar(self):
+
+    class M(torch.nn.Module):
+
+      def forward(self, x):
+        return torch.ops.aten.sub(torch.ops.aten.sub(x, 5), 1)
+
+    arg = (torch.randn(10, 10),)
+    model = M()
+
+    ans = model(*arg)
+
+    with torch.no_grad():
+      exported = torch.export.export(model, arg)
+      export_options = StableHLOExportOptions()
+      export_options.inline_all_constant = False
+      shlo = exported_program_to_stablehlo(exported, options=export_options)
+      ans2 = shlo(*arg).cpu().to(torch.float32)
+      self.assertTrue(torch.allclose(ans, ans2, atol=1e-5))
+      shlo_text = shlo.get_stablehlo_text()
+      self.assertTrue('stablehlo.constant dense<1.000000e+00>' in shlo_text)
+      self.assertTrue(re.search(r'%arg.*tensor<f32>', shlo_text) is not None)
+      self.assertFalse('stablehlo.constant dense<5.000000e+00>' in shlo_text)
 
 
 if __name__ == '__main__':

--- a/test/stablehlo/test_mark_pattern.py
+++ b/test/stablehlo/test_mark_pattern.py
@@ -353,6 +353,7 @@ class XlaMarkPatternTest(unittest.TestCase):
     exported = torch.export.export(model, (input_pos, k_val, v_val))
     shlo = stablehlo.exported_program_to_stablehlo(exported)
     shlo_text = shlo.get_stablehlo_text()
+    print(shlo_text)
     self.assertEqual(
         shlo_text.count("stablehlo.composite \"test.update_kv_cache\""), 1)
 

--- a/test/stablehlo/test_mark_pattern.py
+++ b/test/stablehlo/test_mark_pattern.py
@@ -353,7 +353,6 @@ class XlaMarkPatternTest(unittest.TestCase):
     exported = torch.export.export(model, (input_pos, k_val, v_val))
     shlo = stablehlo.exported_program_to_stablehlo(exported)
     shlo_text = shlo.get_stablehlo_text()
-    print(shlo_text)
     self.assertEqual(
         shlo_text.count("stablehlo.composite \"test.update_kv_cache\""), 1)
 

--- a/test/stablehlo/test_unbounded_dynamism.py
+++ b/test/stablehlo/test_unbounded_dynamism.py
@@ -51,9 +51,8 @@ class UnboundedDynamismExportTest(unittest.TestCase):
     shlo_module = exported_program_to_stablehlo(ep)
     shlo_text = shlo_module.get_stablehlo_text()
     self.assertTrue(
-        re.search(
-            r'tensor<f32>.*tensor<\?x197x768xf32>.*->.*tensor<\?x197x768xf32>',
-            shlo_text) is not None)
+        re.search(r'tensor<\?x197x768xf32>.*->.*tensor<\?x197x768xf32>',
+                  shlo_text) is not None)
     if has_tf_package():
       with tempfile.TemporaryDirectory() as tempdir:
         save_torch_module_as_tf_saved_model(
@@ -367,9 +366,8 @@ class UnboundedDynamismExportTest(unittest.TestCase):
     shlo_module = exported_program_to_stablehlo(ep)
     shlo_text = shlo_module.get_stablehlo_text()
     self.assertTrue(
-        re.search(
-            r'tensor<f32>.*tensor<\?x2x768xf32>.*->.*tensor<\?x2x768xf32>',
-            shlo_text) is not None)
+        re.search(r'tensor<\?x2x768xf32>.*->.*tensor<\?x2x768xf32>', shlo_text)
+        is not None)
     if has_tf_package():
       with tempfile.TemporaryDirectory() as tempdir:
         save_torch_module_as_tf_saved_model(

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2233,6 +2233,11 @@ void InitXlaModuleBindings(py::module m) {
   m.def("_set_ir_debug",
         [](bool ir_debug) { FLAGS_torch_lazy_ir_debug = ir_debug; });
   m.def("_get_ir_debug", []() { return FLAGS_torch_lazy_ir_debug; });
+  m.def("_set_xla_all_numbers_special_scalars",
+        [](bool all_numbers_special_scalars) {
+          FLAGS_torch_lazy_all_numbers_special_scalars =
+              all_numbers_special_scalars;
+        });
   m.def("_set_xla_handle_special_scalars", [](bool handle_special_scalars) {
     FLAGS_torch_lazy_handle_special_scalars = handle_special_scalars;
   });


### PR DESCRIPTION
Motivation of the change:

Currently only special scalars (0 or 1) will be inlined in the lowered HLO/StableHLO. In export path with HLFB, lifted scalars generated during tracing would result in additional arg in the `stablehlo.composite`. This makes downstream compiler confusing when mapping the args in the model code and `stablehlo.composite`.

Inlining scalars should work well in the export path. Because `torch.export` doesn't trace non-tensor input at this moment, all non-tensor values are burned in the exported FX graph (with dangling placeholders).

Change:
- Expose a Python API to config Lazy Tensor Core to inline all `at::Scalar`.
- Add an option in StableHLO export to allow caller to config to inline all scalars, or only inline scalars with special values. By default, export will inline all scalars.

Test:
Added new tests cases.
