### PR TITLE
Use fsspec for multihost checkpoint

### DIFF
--- a/test/spmd/test_xla_distributed_checkpoint.py
+++ b/test/spmd/test_xla_distributed_checkpoint.py
@@ -96,6 +96,7 @@ class EndToEndCheckpointTest(DistributedCheckpointTestBase):
         state_dict=model_in_state_dict,
         storage_writer=storage_writer_cls(
             chkpt_path,
+            sync_files=False,
             per_thread_copy_ahead=0,
         ),
         planner=save_planner,


### PR DESCRIPTION
The multihost checkpointing tests need to write to a common storage backend. This is achievable using fsspec in distributed checkpointing.