### PR TITLE
Add environment XLA_USE_DUMMY_STORE for user to choose to use DummyStore

### DIFF
--- a/torch_xla/_internal/rendezvous.py
+++ b/torch_xla/_internal/rendezvous.py
@@ -44,7 +44,7 @@ def pjrt_rendezvous_handler(url: str,
       # process group initialization. In NxD, the store is also used to exchange python
       # objects. So, to use DummyStore, set TORCH_DIST_INIT_BARRIER=0 and NEURON_USE_DUMMY_STORE=1
       if xu.getenv_as('TORCH_DIST_INIT_BARRIER', int, 1) == 0 and xu.getenv_as(
-          'NEURON_USE_DUMMY_STORE', int, 1) == 1:
+          'TORCH_USE_DUMMY_STORE', int, 1) == 1:
         _store = DummyStore()
       elif xu.getenv_as('TORCHELASTIC_USE_AGENT_STORE', str) == 'True':
         attempt = xu.getenv_as('TORCHELASTIC_RESTART_COUNT', int, defval=0)

--- a/torch_xla/_internal/rendezvous.py
+++ b/torch_xla/_internal/rendezvous.py
@@ -39,10 +39,12 @@ def pjrt_rendezvous_handler(url: str,
     global _store
     if not _store:
       # Create DummyStore when user disables TORCH_DIST_INIT_BARRIER
-      # to skip store based barriers. It's safe to do this because store
-      # created by _pjrt_rendezvous_handler is only used as a barrier in
-      # process group initialization.
-      if xu.getenv_as('TORCH_DIST_INIT_BARRIER', int, 1) == 0:
+      # to skip store based barriers. It's safe to do this in Neuron NeMo Megatron
+      # because store created by _pjrt_rendezvous_handler is only used as a barrier
+      # process group initialization. In NxD, the store is also used to exchange python
+      # objects. So, to use DummyStore, set TORCH_DIST_INIT_BARRIER=0 and NEURON_USE_DUMMY_STORE=1
+      if xu.getenv_as('TORCH_DIST_INIT_BARRIER', int, 1) == 0 and xu.getenv_as(
+          'NEURON_USE_DUMMY_STORE', int, 1) == 1:
         _store = DummyStore()
       elif xu.getenv_as('TORCHELASTIC_USE_AGENT_STORE', str) == 'True':
         attempt = xu.getenv_as('TORCHELASTIC_RESTART_COUNT', int, defval=0)

--- a/torch_xla/_internal/rendezvous.py
+++ b/torch_xla/_internal/rendezvous.py
@@ -42,7 +42,7 @@ def pjrt_rendezvous_handler(url: str,
       # to skip store based barriers. It's safe to do this in Neuron NeMo Megatron
       # because store created by _pjrt_rendezvous_handler is only used as a barrier
       # process group initialization. In NxD, the store is also used to exchange python
-      # objects. So, to use DummyStore, set TORCH_DIST_INIT_BARRIER=0 and NEURON_USE_DUMMY_STORE=1
+      # objects. So, to use DummyStore, set TORCH_DIST_INIT_BARRIER=0 and TORCH_USE_DUMMY_STORE=1
       if xu.getenv_as('TORCH_DIST_INIT_BARRIER', int, 1) == 0 and xu.getenv_as(
           'TORCH_USE_DUMMY_STORE', int, 1) == 1:
         _store = DummyStore()

--- a/torch_xla/_internal/rendezvous.py
+++ b/torch_xla/_internal/rendezvous.py
@@ -38,13 +38,12 @@ def pjrt_rendezvous_handler(url: str,
   with _store_lock:
     global _store
     if not _store:
-      # Create DummyStore when user disables TORCH_DIST_INIT_BARRIER
-      # to skip store based barriers. It's safe to do this in Neuron NeMo Megatron
-      # because store created by _pjrt_rendezvous_handler is only used as a barrier
-      # process group initialization. In NxD, the store is also used to exchange python
-      # objects. So, to use DummyStore, set TORCH_DIST_INIT_BARRIER=0 and TORCH_USE_DUMMY_STORE=1
+      # Create DummyStore when user skips store based barrier by setting TORCH_DIST_INIT_BARRIER=0
+      # and enables XLA_USE_DUMMY_STORE=1. It's safe to do so because store created by _pjrt_rendezvous_handler
+      # is only used as a barrier in process groups. If store is needed, user can set XLA_USE_DUMMY_STORE=0 to
+      # use TCPStore.
       if xu.getenv_as('TORCH_DIST_INIT_BARRIER', int, 1) == 0 and xu.getenv_as(
-          'TORCH_USE_DUMMY_STORE', int, 1) == 1:
+          'XLA_USE_DUMMY_STORE', int, 0) == 1:
         _store = DummyStore()
       elif xu.getenv_as('TORCHELASTIC_USE_AGENT_STORE', str) == 'True':
         attempt = xu.getenv_as('TORCHELASTIC_RESTART_COUNT', int, defval=0)


### PR DESCRIPTION
Store in PJRT process group is never used if user skips store based barrier. User can set environment variables `TORCH_DIST_INIT_BARRIER=0` and `XLA_USE_DUMMY_STORE=1` to use DummyStore in initialization. 