### PR TITLE
udpate release tag to rc6

### DIFF
--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -19,10 +19,78 @@ nightly_builds = [
     accelerator  = "cuda"
     cuda_version = "12.1"
   },
+  {
+    accelerator  = "cuda"
+    cuda_version = "12.1"
+    python_version = "3.10"
+  },
+  {
+    accelerator  = "cuda"
+    cuda_version = "12.1"
+    python_version = "3.11"
+  },
 ]
 
 # Built on push to specific tag.
 versioned_builds = [
+  # Remove libtpu from PyPI builds
+  {
+    git_tag         = "v2.3.0-rc6"
+    package_version = "2.3.0-rc6"
+    pytorch_git_rev = "v2.3.0-rc6"
+    accelerator     = "tpu"
+    python_version = "3.8"
+    bundle_libtpu   = "0"
+  },
+  {
+    git_tag         = "v2.3.0-rc6"
+    package_version = "2.3.0-rc6"
+    pytorch_git_rev = "v2.3.0-rc6"
+    accelerator     = "tpu"
+    python_version  = "3.9"
+    bundle_libtpu   = "0"
+  },
+  {
+    git_tag         = "v2.3.0-rc6"
+    package_version = "2.3.0-rc6"
+    pytorch_git_rev = "v2.3.0-rc6"
+    accelerator     = "tpu"
+    python_version  = "3.10"
+    bundle_libtpu   = "0"
+  },
+  {
+    git_tag         = "v2.3.0-rc6"
+    package_version = "2.3.0-rc6"
+    pytorch_git_rev = "v2.3.0-rc6"
+    accelerator     = "tpu"
+    python_version  = "3.11"
+    bundle_libtpu   = "0"
+  },
+  # Bundle libtpu for Kaggle
+  {
+    git_tag         = "v2.3.0-rc6"
+    package_version = "2.3.0-rc6+libtpu"
+    pytorch_git_rev = "v2.3.0-rc6"
+    accelerator     = "tpu"
+    python_version  = "3.10"
+    bundle_libtpu   = "1"
+  },
+  {
+    git_tag         = "v2.3.0-rc6"
+    pytorch_git_rev = "v2.3.0-rc6"
+    package_version = "2.3.0-rc6"
+    accelerator     = "cuda"
+    cuda_version    = "12.1"
+    python_version = "3.8"
+  },
+  {
+    git_tag         = "v2.3.0-rc6"
+    pytorch_git_rev = "v2.3.0-rc6"
+    package_version = "2.3.0-rc6"
+    accelerator     = "cuda"
+    cuda_version    = "12.1"
+    python_version  = "3.10"
+  },
   # Remove libtpu from PyPI builds
   {
     git_tag         = "v2.2.0"


### PR DESCRIPTION
Merge the change to r2.3 release branch instead of master, because our infra can use the config from target branch now. cc @will-cromar 