### PR TITLE
[Backport] Support XLA_USE_BF16

### DIFF
--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -248,6 +248,20 @@ class PallasTest(unittest.TestCase):
     self.assertFalse(torch.allclose(o.cpu(), expected_o.cpu()))
     jax.config.update('jax_default_matmul_precision', jax.lax.Precision.DEFAULT)
 
+  @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 3,
+                   "This test only works on TPUv3+.")
+  @unittest.mock.patch.dict(os.environ, {"XLA_TPU_LAYOUT": "0"})
+  @unittest.mock.patch.dict(os.environ, {"XLA_USE_BF16": "1"})
+  def test_flash_attention_wrapper_bf16(self):
+    from torch_xla.experimental.custom_kernel import flash_attention
+
+    q = torch.randn(3, 2, 128, 4).to("xla")
+    k = torch.randn(3, 2, 128, 4).to("xla")
+    v = torch.randn(3, 2, 128, 4).to("xla")
+
+    # No exception being raised.
+    o = flash_attention(q, k, v)
+
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)


### PR DESCRIPTION
Summary:
XLA_USE_BF16=1 will make all the internal xla tensors to use BF16 but torch.tensor wrappers will still return torch.float. To address this, we need to set the jax tracers correctly to produce the correct Mosaic.

Test Plan:
PJRT_DEVICE=TPU python test/test_pallas.py -v -k test_flash_attention_wrapper_bf16
