### PR TITLE
[SPMD] use UNKNOWN as default sharded data sharding type only for auto-sharding

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -712,9 +712,10 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
     xst2 = xst1 + 5
     hlo = torch_xla._XLAC._get_xla_tensors_hlo([xst2.global_tensor])
     self.assertIn('%p1.3 = f32[1,8]{1,0} parameter(1), sharding', hlo)
-    # scalar 5 should be implicitly replicated, so the pre-optimization HLO
-    # shouldn't mark it with sharding.
-    self.assertNotIn('%p0.2 = f32[] parameter(0), sharding={replicated}', hlo)
+    if torch_xla._XLAC._xla_get_auto_sharding():
+      # scalar 5 should be implicitly replicated, so the pre-optimization HLO
+      # shouldn't mark it with sharding.
+      self.assertNotIn('%p0.2 = f32[] parameter(0), sharding={replicated}', hlo)
 
   def test_2d_tensor_3d_mesh(self):
     ct1 = torch.randn(16, 16, device='cpu')

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -249,9 +249,10 @@ void XLATensor::SetShardingSpec(const ShardingSpec& sharding, bool overwrite) {
   // Existing annotation must be cleared explicitly. We do not clear and
   // overwrite the existing sharding on the user's behalf. This is a no-op if
   // the same sharding already applied.
-  if (!sharding_spec() || overwrite ||
-      sharding_spec()->sharding.type() == xla::OpSharding::REPLICATED ||
-      sharding_spec()->sharding.type() == xla::OpSharding::UNKNOWN) {
+  ShardingSpecPtr current_sharding = sharding_spec();
+  if (!current_sharding || overwrite ||
+      current_sharding->sharding.type() == xla::OpSharding::REPLICATED ||
+      current_sharding->sharding.type() == xla::OpSharding::UNKNOWN) {
     TORCH_LAZY_COUNTER("SetShardingSpec", 1);
     data()->sharding = std::make_shared<ShardingSpec>(sharding);
   } else {
@@ -259,7 +260,7 @@ void XLATensor::SetShardingSpec(const ShardingSpec& sharding, bool overwrite) {
     // the same sharding type.
     XLA_CHECK(ShardingUtil::EqualShardingSpecs(sharding, *sharding_spec()))
         << "Existing sharding annotation, "
-        << sharding_spec()->sharding.DebugString()
+        << current_sharding->sharding.DebugString()
         << ", must be cleared before applying a new one, "
         << sharding.sharding.DebugString();
   }

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -604,7 +604,13 @@ runtime::ComputationClient::DataPtr ShardingUtil::CreateShardedData(
   xla::Shape global_shape;
   xla::OpSharding sharding;
   if (sharding_spec == nullptr) {
-    sharding = xla::HloSharding::Unknown().ToProto();
+    // Unknown type is used to mark implicitly replicated data for
+    // auto-sharding.
+    // TODO(yeounoh) see if we can completely rely on Unknown without inference
+    // performance degradation.
+    sharding = ShardingUtil::GetAutoSharding()
+                   ? xla::HloSharding::Unknown().ToProto()
+                   : xla::HloSharding::Replicate().ToProto();
     // if replicated, global_shape is shape of the tensor.
     auto first_device = ParseDeviceString(devices[0]);
     global_shape =


### PR DESCRIPTION
Using UNKNOWN as default sharded data sharding type degraded SPMD inference performance. I added a comment to do a follow-up investigation, to see if we can completely move to Unknown for non-auto-sharding route as well.

Test plan:
- llama2 inference performance check
- auto-sharding llama2 & gemma checks