### PR TITLE
Reland Install torchvision in release docker #6795

### DIFF
--- a/infra/ansible/Dockerfile
+++ b/infra/ansible/Dockerfile
@@ -22,6 +22,7 @@ RUN ansible-playbook -vvv playbook.yaml -e "stage=release" -e "${ansible_vars}" 
 WORKDIR /tmp/wheels
 COPY --from=build /src/pytorch/dist/*.whl ./
 COPY --from=build /src/pytorch/xla/dist/*.whl ./
+COPY --from=build /dist/torchvision*.whl ./
 
 RUN echo "Installing the following wheels" && ls *.whl
 RUN pip install *.whl


### PR DESCRIPTION
`pip install /dist/*` would fail due to the

The following whls are under `/dist/`
```
-rw-r--r-- 1 root root 133675462 Mar 29 21:38 torch-nightly+20240329-cp310-cp310-linux_x86_64.whl
-rw-r--r-- 1 root root 133675462 Mar 29 21:38 torch-nightly-cp310-cp310-linux_x86_64.whl
-rw-r--r-- 1 root root 199272610 Mar 29 21:38 torch_xla-nightly+20240329-cp310-cp310-linux_x86_64.whl
-rw-r--r-- 1 root root 199272610 Mar 29 21:38 torch_xla-nightly-cp310-cp310-linux_x86_64.whl
-rw-r--r-- 1 root root   1186431 Mar 29 21:39 torchvision-0.19.0a0+2c4665f-cp310-cp310-linux_x86_64.whl
```

If I install the whls one by one, it won't fail, which makes sense. I won't be able to resolve the mystery of `pip`. So I'll just explicitly install the whls in the dockerfile