### PR TITLE
[OpenXLA|Moving TSL to XLA] Remove unused deps from TSL in CPP tests

### DIFF
--- a/test/cpp/BUILD
+++ b/test/cpp/BUILD
@@ -65,8 +65,6 @@ ptxla_cc_test(
         "//torch_xla/csrc:tensor",
         "@com_google_googletest//:gtest_main",
         "@xla//xla:shape_util",
-        "@tsl//tsl/util:stats_calculator_test",
-        "@tsl//tsl/util:device_name_utils_test",
     ],
 )
 


### PR DESCRIPTION
Remove unused deps from TSL in CPP tests, context is OpenXLA is moving TSL to XLA and affected these two unused links, we want to delete them now to reduce needed OpenXLA-pin update for catch changes

cc @ddunl