### PR TITLE
Fix div lowering and core aten test script enhancement

### DIFF
--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -16,6 +16,7 @@ def diff_output(testcase, output1, output2, rtol, atol, equal_nan=True):
     output2_cpu = output2.detach().cpu()
     if output2_cpu.dtype != output1.dtype:
       output2_cpu = output2_cpu.to(output1.dtype)
+    testcase.assertEqual(output1.shape, output2.shape)
     testcase.assertTrue(
         torch.allclose(
             output1, output2_cpu, atol=atol, rtol=rtol, equal_nan=equal_nan))
@@ -1170,6 +1171,14 @@ class AtenOpTest(unittest.TestCase):
     args = (
         torch.randint(0, 10, (10, 10)).to(torch.int32),
         torch.randint(0, 10, (10, 10)).to(torch.int32),
+    )
+    kwargs = dict()
+    run_export_and_compare(self, torch.ops.aten.div.Tensor, args, kwargs)
+  
+  def test_aten_div_Tensor_3(self):
+    args = (
+        torch.rand(1, 3, 4, 1),
+        torch.rand(10),
     )
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.div.Tensor, args, kwargs)

--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -1174,7 +1174,7 @@ class AtenOpTest(unittest.TestCase):
     )
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.div.Tensor, args, kwargs)
-  
+
   def test_aten_div_Tensor_3(self):
     args = (
         torch.rand(1, 3, 4, 1),

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -726,7 +726,9 @@ torch::lazy::NodePtr Div(const torch::lazy::Value& input,
     return node.ReturnOp(BuildDiv(xla_input, xla_divisor), loctx);
   };
   return GenericOp(torch::lazy::OpKind(at::aten::div), {input, divisor},
-                   GetXlaShape(input), std::move(lower_fn));
+                   XlaHelpers::GetPromotedBinaryOpShape(GetXlaShape(input),
+                                                        GetXlaShape(divisor)),
+                   std::move(lower_fn));
 }
 
 torch::lazy::NodePtr MaxUnary(const torch::lazy::Value& input) {


### PR DESCRIPTION
- Fix a shape inf bug in div lowering
- Enhance aten test script. `torch.allclose` would broadcast the operands (e.g. `torch.allclose([3, 1], [4])` would broadcast both operands to `[3,4]` and then compare). Add shape check before `torch.allclose`