### PR TITLE
[benchmarks] Use Torchbench YAML configuration data.

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -100,9 +100,11 @@ NEED_LARGER_CACHE = {
 # File (inside PyTorch main repository): benchmarks/dynamo/torchbench.yaml
 DETECTRON2_MODELS = config_data()["detectron2_models"]
 
-FORCE_AMP_FOR_FP16_BF16_MODELS = config_data()["dtype"]["force_amp_for_fp16_bf16_models"]
+FORCE_AMP_FOR_FP16_BF16_MODELS = config_data(
+)["dtype"]["force_amp_for_fp16_bf16_models"]
 
-FORCE_FP16_FOR_BF16_MODELS = config_data()["dtype"]["force_fp16_for_bf16_models"]
+FORCE_FP16_FOR_BF16_MODELS = config_data(
+)["dtype"]["force_fp16_for_bf16_models"]
 
 
 @functools.lru_cache(maxsize=1)

--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -19,21 +19,6 @@ from benchmark_model import ModelLoader, BenchmarkModel
 
 logger = logging.getLogger(__name__)
 
-DETECTRON2_MODELS = {
-    "detectron2_fasterrcnn_r_101_c4",
-    "detectron2_fasterrcnn_r_101_dc5",
-    "detectron2_fasterrcnn_r_101_fpn",
-    "detectron2_fasterrcnn_r_50_c4",
-    "detectron2_fasterrcnn_r_50_dc5",
-    "detectron2_fasterrcnn_r_50_fpn",
-    "detectron2_maskrcnn_r_101_c4",
-    "detectron2_maskrcnn_r_101_fpn",
-    "detectron2_maskrcnn_r_50_c4",
-    "detectron2_maskrcnn_r_50_fpn",
-    "detectron2_maskrcnn",
-    "detectron2_fcos_r_50_fpn",
-}
-
 # torchbench models that might OOM using Adam.
 # This list was extracted from PyTorch's repository: benchmarks/dynamo/common.py
 TRAIN_WITH_SGD = {
@@ -111,19 +96,13 @@ NEED_LARGER_CACHE = {
     "hf_T5_generate",
 }
 
-# This list was extracted from PyTorch's repository: benchmarks/dynamo/torchbench.py
-FORCE_AMP_FOR_FP16_BF16_MODELS = {
-    "DALLE2_pytorch",
-    "doctr_det_predictor",
-    "doctr_reco_predictor",
-    "Super_SloMo",
-    "tts_angular",
-    "pyhpc_turbulent_kinetic_energy",
-    "detectron2_fcos_r_50_fpn",
-}
+# List of models retrieved from the YAML configuration data.
+# File (inside PyTorch main repository): benchmarks/dynamo/torchbench.yaml
+DETECTRON2_MODELS = config_data()["detectron2_models"]
 
-# This list was extracted from PyTorch's repository: benchmarks/dynamo/torchbench.py
-FORCE_FP16_FOR_BF16_MODELS = {"vision_maskrcnn"}
+FORCE_AMP_FOR_FP16_BF16_MODELS = config_data()["dtype"]["force_amp_for_fp16_bf16_models"]
+
+FORCE_FP16_FOR_BF16_MODELS = config_data()["dtype"]["force_fp16_for_bf16_models"]
 
 
 @functools.lru_cache(maxsize=1)

--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -96,16 +96,6 @@ NEED_LARGER_CACHE = {
     "hf_T5_generate",
 }
 
-# List of models retrieved from the YAML configuration data.
-# File (inside PyTorch main repository): benchmarks/dynamo/torchbench.yaml
-DETECTRON2_MODELS = config_data()["detectron2_models"]
-
-FORCE_AMP_FOR_FP16_BF16_MODELS = config_data(
-)["dtype"]["force_amp_for_fp16_bf16_models"]
-
-FORCE_FP16_FOR_BF16_MODELS = config_data(
-)["dtype"]["force_fp16_for_bf16_models"]
-
 
 @functools.lru_cache(maxsize=1)
 def config_data():
@@ -138,6 +128,17 @@ def config_data():
     return obj
 
   return maybe_list_to_set(data)
+
+
+# List of models retrieved from the YAML configuration data.
+# File (inside PyTorch main repository): benchmarks/dynamo/torchbench.yaml
+DETECTRON2_MODELS = config_data()["detectron2_models"]
+
+FORCE_AMP_FOR_FP16_BF16_MODELS = config_data(
+)["dtype"]["force_amp_for_fp16_bf16_models"]
+
+FORCE_FP16_FOR_BF16_MODELS = config_data(
+)["dtype"]["force_fp16_for_bf16_models"]
 
 
 class TorchBenchModelLoader(ModelLoader):


### PR DESCRIPTION
This PR makes the benchmarking scripts to start using the configuration YAML file exposed by PyTorch. Previously, we were using it only for checking models that should be skipped. From this PR onwards, we are using the configuration file for other things, such as:

- Deciding what should be the data-type
- Checking whether a model is a Detectron2 model

cc @miladm