### PR TITLE
Check pointer when we cast  PjRtLayout to PjRtXlaLayout

### DIFF
--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -57,9 +57,9 @@ std::unordered_map<int, int> build_index_map(
 xla::Shape host_output_shape(xla::PjRtBuffer* buffer) {
   xla::Shape shape = xla::ShapeUtil::MakeShape(
       buffer->element_type(), buffer->logical_dimensions().value());
-  *shape.mutable_layout() =
-      dynamic_cast<const xla::PjRtXlaLayout*>(buffer->layout().get())
-          ->xla_layout();
+  *shape.mutable_layout() = xla::GetXlaLayoutUnsafe(buffer->layout());
+  //     dynamic_cast<const xla::PjRtXlaLayout*>(buffer->layout().get())
+  //         ->xla_layout();
 
   return xla::ShapeUtil::DeviceShapeToHostShape(shape);
 }

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -58,8 +58,6 @@ xla::Shape host_output_shape(xla::PjRtBuffer* buffer) {
   xla::Shape shape = xla::ShapeUtil::MakeShape(
       buffer->element_type(), buffer->logical_dimensions().value());
   *shape.mutable_layout() = xla::GetXlaLayoutUnsafe(buffer->layout());
-  //     dynamic_cast<const xla::PjRtXlaLayout*>(buffer->layout().get())
-  //         ->xla_layout();
 
   return xla::ShapeUtil::DeviceShapeToHostShape(shape);
 }


### PR DESCRIPTION
This PR checks if the `cast` is safe by following the original XLA change https://github.com/openxla/xla/commit/b8109e2f697338e8517d110014ce2160444aa927.

The pin update https://github.com/pytorch/xla/pull/6677 made a change https://github.com/pytorch/xla/blob/895b0c2ea14ae1d5c5daf76056de64df28d1b6f2/torch_xla/csrc/runtime/pjrt_computation_client.cc#L60-L62 which is caused by an XLA change https://github.com/openxla/xla/commit/b8109e2f697338e8517d110014ce2160444aa927. The `GetXlaLayoutUnsafe` is safer because it checks if `tensorflow::down_cast` succeeds and fails early: https://github.com/openxla/xla/blob/956f0ed40f4144a83f9e5aa3a0fe75ab94a81b70/xla/pjrt/pjrt_layout.h#L101-L107

It's unclear it caused the regression but it makes our change consistent with open XLA and it's safer as `dynamic_cast` may fail (return nullptr)