### PR TITLE
Fix vector norm lowering

### DIFF
--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1600,7 +1600,9 @@ XLATensorPtr linalg_vector_norm(const XLATensorPtr& input,
   }
   torch::lazy::Value res = LinalgVectorNorm(input->GetIrValue(), ord,
                                             canonical_dims, keep_dim, dtype);
-  if (!dtype) dtype = input->dtype_optional();
+  if (!dtype) {
+    dtype = input->dtype();
+  }
   xla::PrimitiveType res_intended_type =
       MakeXlaPrimitiveType(*dtype, &input->GetDevice());
   if (GetXlaShape(res).element_type() != res_intended_type) {


### PR DESCRIPTION
`dtype_optional` is an `c10::optional<at::ScalarType>` object, dereferencing it without checking if it's null in line 1605 is not expected.

The logic should be have the result have the same dtype as input if the output dtype is not explicitly set.

Test:
I cannot repro this is a unit test, only in a real model. I think that's because of the randomness in dereferencing `c10::optional`