### PR TITLE
[Backport] Add flash attention as custom op so dynamo can trace it (#6875)

### DIFF
--- a/.github/workflows/tpu_ci.yml
+++ b/.github/workflows/tpu_ci.yml
@@ -21,7 +21,7 @@ jobs:
         env:
           _GLIBCXX_USE_CXX11_ABI: 0
         run: |
-          git clone --recursive https://github.com/pytorch/pytorch
+          git clone -b r2.3 --recursive https://github.com/pytorch/pytorch
           cd pytorch/
           python3 setup.py install --user
       - name: Install torchvision

--- a/.github/workflows/tpu_ci.yml
+++ b/.github/workflows/tpu_ci.yml
@@ -21,7 +21,7 @@ jobs:
         env:
           _GLIBCXX_USE_CXX11_ABI: 0
         run: |
-          git clone -b r2.3 --recursive https://github.com/pytorch/pytorch
+          git clone -b release/2.3 --recursive https://github.com/pytorch/pytorch
           cd pytorch/
           python3 setup.py install --user
       - name: Install torchvision

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -221,6 +221,37 @@ class PallasTest(unittest.TestCase):
 
   @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 3,
                    "This test only works on TPUv3+.")
+  def test_flash_attention_wrapper_with_dynamo(self):
+    jax.config.update('jax_default_matmul_precision', jax.lax.Precision.HIGHEST)
+    from torch_xla.experimental.custom_kernel import flash_attention
+
+    def attention(q, k, v):
+      attn_weight = q @ k.transpose(-2, -1)
+      attn_weight = nn.functional.softmax(attn_weight, dim=-1)
+      attn_output = attn_weight @ v
+      return attn_output
+
+    def flash_attention_wrapper(q, k, v, causal=False):
+      return torch.ops.xla.flash_attention(q, k, v, causal)
+
+    q = torch.randn(3, 2, 128, 4).to("xla")
+    k = torch.randn(3, 2, 128, 4).to("xla")
+    v = torch.randn(3, 2, 128, 4).to("xla")
+
+    compiled_flash_attention = torch.compile(
+        flash_attention_wrapper, backend="openxla")
+    o_no_causal = compiled_flash_attention(q, k, v)
+    o_with_causal = compiled_flash_attention(q, k, v, causal=True)
+    expected_o = attention(q, k, v)
+    self.assertTrue(torch.allclose(o_no_causal.cpu(), expected_o.cpu()))
+    # The causal mask is turned on by default in the wrapper.
+    # It masks out the top right triangle of the attention matrix,
+    # therefore it speeds up the compute but also changes the output.
+    self.assertFalse(torch.allclose(o_with_causal.cpu(), expected_o.cpu()))
+    jax.config.update('jax_default_matmul_precision', jax.lax.Precision.DEFAULT)
+
+  @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 3,
+                   "This test only works on TPUv3+.")
   def test_flash_attention_wrapper_causal(self):
     jax.config.update('jax_default_matmul_precision', jax.lax.Precision.HIGHEST)
     from torch_xla.experimental.custom_kernel import flash_attention

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -216,7 +216,7 @@ class PallasTest(unittest.TestCase):
 
     o = flash_attention(q, k, v)
     expected_o = attention(q, k, v)
-    self.assertTrue(torch.allclose(o.cpu(), expected_o.cpu()))
+    self.assertTrue(torch.allclose(o.cpu(), expected_o.cpu(), atol=1e-05))
     jax.config.update('jax_default_matmul_precision', jax.lax.Precision.DEFAULT)
 
   @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 3,
@@ -243,7 +243,8 @@ class PallasTest(unittest.TestCase):
     o_no_causal = compiled_flash_attention(q, k, v)
     o_with_causal = compiled_flash_attention(q, k, v, causal=True)
     expected_o = attention(q, k, v)
-    self.assertTrue(torch.allclose(o_no_causal.cpu(), expected_o.cpu()))
+    self.assertTrue(
+        torch.allclose(o_no_causal.cpu(), expected_o.cpu(), atol=1e-05))
     # The causal mask is turned on by default in the wrapper.
     # It masks out the top right triangle of the attention matrix,
     # therefore it speeds up the compute but also changes the output.


### PR DESCRIPTION
We intended to add dynamo support for pallas but flash attention support needs to be added.