### PR TITLE
Don't bundle libtpu in nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,16 +207,16 @@ You can also add `+yyyymmdd` after `torch_xla-nightly` to get the nightly wheel
 of a specified date. To get the companion pytorch and torchvision nightly wheel,
 replace the `torch_xla` with `torch` or `torchvision` on above wheel links.
 
-#### Installing libtpu (before PyTorch/XLA 2.0)
+#### Installing libtpu
 
-For PyTorch/XLA release r2.0 and older and when developing PyTorch/XLA, install
-the `libtpu` pip package with the following command:
+Install the `libtpu` pip package with the following command:
 
 ```
 pip3 install torch_xla[tpuvm]
 ```
 
 This is only required on Cloud TPU VMs.
+On Kaggle, the libtpu will be bundled in torch-xla installed.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -207,19 +207,6 @@ You can also add `+yyyymmdd` after `torch_xla-nightly` to get the nightly wheel
 of a specified date. To get the companion pytorch and torchvision nightly wheel,
 replace the `torch_xla` with `torch` or `torchvision` on above wheel links.
 
-#### Installing libtpu
-
-Install the `libtpu` pip package with the following command:
-
-```
-pip3 install torch_xla[tpuvm]
-```
-
-This is only required on Cloud TPU VMs.
-On Kaggle, the libtpu will be bundled in torch-xla installed.
-
-</details>
-
 ### Docker
 
 | Version | Cloud TPU VMs Docker |

--- a/infra/tpu-pytorch-releases/artifacts_builds.tf
+++ b/infra/tpu-pytorch-releases/artifacts_builds.tf
@@ -9,7 +9,7 @@ variable "nightly_builds" {
       cuda_version   = optional(string, "11.8")
       python_version = optional(string, "3.8")
       arch           = optional(string, "amd64")
-      bundle_libtpu  = optional(string, "1")
+      bundle_libtpu  = optional(string, "0")
     })
   )
 
@@ -43,7 +43,7 @@ variable "versioned_builds" {
       python_version  = optional(string, "3.8")
       cuda_version    = optional(string, "11.8")
       arch            = optional(string, "amd64")
-      bundle_libtpu   = optional(string, "1")
+      bundle_libtpu   = optional(string, "0")
     })
   )
 


### PR DESCRIPTION
Summary:
Pallas depends on JAX to run, and JAX by default will use the system libtpu and won't use our own bundled libtpu. In order to have JAX and PyTorch/XLA run side by side, we will need to have them use the same libtpu. The solution could either be setting the TPU_LIBRARY_PATH or having both of them use the same system libtpu. The latter yields a much better UX.

Test Plan:
N.A.