### PR TITLE
[Pallas] Make FlashAttention as torch.autograd.Function

### DIFF
--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -449,9 +449,9 @@ class PallasTest(unittest.TestCase):
     from torch_xla.experimental.custom_kernel import flash_attention
 
     torch.manual_seed(42)
-    q = torch.randn(3, 2, 128, 4, requires_grad=True).to("xla")
-    k = torch.randn(3, 2, 128, 4, requires_grad=True).to("xla")
-    v = torch.randn(3, 2, 128, 4, requires_grad=True).to("xla")
+    q = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
+    k = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
+    v = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
     q.retain_grad()
     k.retain_grad()
     v.retain_grad()
@@ -466,9 +466,9 @@ class PallasTest(unittest.TestCase):
     v_grad = v.grad
 
     torch.manual_seed(42)
-    q = torch.randn(3, 2, 128, 4, requires_grad=True).to("xla")
-    k = torch.randn(3, 2, 128, 4, requires_grad=True).to("xla")
-    v = torch.randn(3, 2, 128, 4, requires_grad=True).to("xla")
+    q = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
+    k = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
+    v = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
     q.retain_grad()
     k.retain_grad()
     v.retain_grad()

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -19,6 +19,7 @@ if xr.device_type() == 'TPU':
 
 
 class PallasTest(unittest.TestCase):
+
   def _attention(self, q, k, v):
     attn_weight = q @ k.transpose(-2, -1)
     attn_weight = nn.functional.softmax(attn_weight, dim=-1)

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -247,9 +247,12 @@ class FlashAttention(torch.autograd.Function):
         o.to(torch.float32) * grad_output.to(torch.float32),
         axis=-1)  # [batch_size, num_heads, q_seq_len]
 
-    expanded_l = l.unsqueeze(-1).expand([-1 for _ in l.shape] + [FlashAttention.MIN_BLOCK_SIZE])
-    expanded_m = m.unsqueeze(-1).expand([-1 for _ in m.shape] + [FlashAttention.MIN_BLOCK_SIZE])
-    expanded_grad_i = grad_i.unsqueeze(-1).expand([-1 for _ in grad_i.shape] + [FlashAttention.MIN_BLOCK_SIZE])
+    expanded_l = l.unsqueeze(-1).expand([-1 for _ in l.shape] +
+                                        [FlashAttention.MIN_BLOCK_SIZE])
+    expanded_m = m.unsqueeze(-1).expand([-1 for _ in m.shape] +
+                                        [FlashAttention.MIN_BLOCK_SIZE])
+    expanded_grad_i = grad_i.unsqueeze(-1).expand(
+        [-1 for _ in grad_i.shape] + [FlashAttention.MIN_BLOCK_SIZE])
 
     if ctx.needs_input_grad[0]:
       payload, _ = trace_pallas(

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -234,9 +234,6 @@ class FlashAttention(torch.autograd.Function):
 
   @staticmethod
   def backward(ctx, grad_output):
-    # Import JAX within the function such that we don't need to call the jax_import_guard()
-    # in the global scope which could cause problems for xmp.spawn.
-    jax_import_guard()
     from jax.experimental.pallas.ops.tpu.flash_attention import _flash_attention_bwd_dq, _flash_attention_bwd_dkv
 
     q, k, v, o, l, m = ctx.saved_tensors
@@ -281,7 +278,7 @@ class FlashAttention(torch.autograd.Function):
               "block_q_major", "block_k_major", "block_k", "sm_scale", "causal",
               "mask_value", "debug"
           ])
-      grad_q = torch.empty(q.shape, dtype=q.dtype).to(xm.xla_device())
+      grad_q = torch.empty(q.shape, dtype=q.dtype).to(q.device())
       torch_xla._XLAC._xla_tpu_custom_call_(
           [grad_q],
           [q, k, v, expanded_l, expanded_m, grad_output, expanded_grad_i],
@@ -317,8 +314,8 @@ class FlashAttention(torch.autograd.Function):
               "block_q_major", "block_k_major", "block_k", "block_q",
               "sm_scale", "causal", "mask_value", "debug"
           ])
-      grad_k = torch.empty(k.shape, dtype=k.dtype).to(xm.xla_device())
-      grad_v = torch.empty(v.shape, dtype=v.dtype).to(xm.xla_device())
+      grad_k = torch.empty(k.shape, dtype=k.dtype).to(k.device())
+      grad_v = torch.empty(v.shape, dtype=v.dtype).to(v.device())
       torch_xla._XLAC._xla_tpu_custom_call_(
           [grad_k, grad_v],
           [q, k, v, expanded_l, expanded_m, grad_output, expanded_grad_i],

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -247,12 +247,9 @@ class FlashAttention(torch.autograd.Function):
         o.to(torch.float32) * grad_output.to(torch.float32),
         axis=-1)  # [batch_size, num_heads, q_seq_len]
 
-    expanded_l = l.unsqueeze(-1).expand(3, 2, 128,
-                                        FlashAttention.MIN_BLOCK_SIZE)
-    expanded_m = m.unsqueeze(-1).expand(3, 2, 128,
-                                        FlashAttention.MIN_BLOCK_SIZE)
-    expanded_grad_i = grad_i.unsqueeze(-1).expand(3, 2, 128,
-                                                  FlashAttention.MIN_BLOCK_SIZE)
+    expanded_l = l.unsqueeze(-1).expand([-1 for _ in l.shape] + [FlashAttention.MIN_BLOCK_SIZE])
+    expanded_m = m.unsqueeze(-1).expand([-1 for _ in m.shape] + [FlashAttention.MIN_BLOCK_SIZE])
+    expanded_grad_i = grad_i.unsqueeze(-1).expand([-1 for _ in grad_i.shape] + [FlashAttention.MIN_BLOCK_SIZE])
 
     if ctx.needs_input_grad[0]:
       payload, _ = trace_pallas(

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -209,7 +209,7 @@ class FlashAttention(torch.autograd.Function):
     _flash_attention_impl = make_kernel_from_pallas(tpu_flash_attention._flash_attention_impl,
                                                      shape_dtype)
     with torch.no_grad():
-      o, *aux = _flash_attention_impl(
+      o = _flash_attention_impl(
           q,
           k,
           v,
@@ -226,6 +226,7 @@ class FlashAttention(torch.autograd.Function):
           static_argnums=range(5, 13))
       if not save_residuals:
         return o
+      o, *aux = o
       l, m = (v[..., 0] for v in aux[-2:])
 
     ctx.save_for_backward(q, k, v, o, l, m)

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -278,7 +278,7 @@ class FlashAttention(torch.autograd.Function):
               "block_q_major", "block_k_major", "block_k", "sm_scale", "causal",
               "mask_value", "debug"
           ])
-      grad_q = torch.empty(q.shape, dtype=q.dtype).to(q.device())
+      grad_q = torch.empty(q.shape, dtype=q.dtype).to(q.device)
       torch_xla._XLAC._xla_tpu_custom_call_(
           [grad_q],
           [q, k, v, expanded_l, expanded_m, grad_output, expanded_grad_i],
@@ -314,8 +314,8 @@ class FlashAttention(torch.autograd.Function):
               "block_q_major", "block_k_major", "block_k", "block_q",
               "sm_scale", "causal", "mask_value", "debug"
           ])
-      grad_k = torch.empty(k.shape, dtype=k.dtype).to(k.device())
-      grad_v = torch.empty(v.shape, dtype=v.dtype).to(v.device())
+      grad_k = torch.empty(k.shape, dtype=k.dtype).to(k.device)
+      grad_v = torch.empty(v.shape, dtype=v.dtype).to(v.device)
       torch_xla._XLAC._xla_tpu_custom_call_(
           [grad_k, grad_v],
           [q, k, v, expanded_l, expanded_m, grad_output, expanded_grad_i],


### PR DESCRIPTION
Summary:
This pull request makes the flash attention kernel as a torch.autograd.Function such that we can enable backward on the kernel.

Test Plan:
PJRT_DEVICE=TPU python test/test_pallas.py -v -k test_flash_attention_backward