### PR TITLE
Manually init absl log to avoid log spam

### DIFF
--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -2,15 +2,9 @@ load(
     "//bazel:rules_def.bzl",
     "ptxla_cc_test",
 )
-
 load(
     "@tsl//tsl/platform/default:cuda_build_defs.bzl",
     "if_cuda_is_configured",
-)
-
-load(
-    "//bazel:rules_def.bzl",
-    "ptxla_cc_test",
 )
 
 licenses(["notice"])  # Apache 2.0
@@ -18,130 +12,130 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
-  name = "runtime",
-  srcs = [
-    "runtime.cc",
-  ],
-  hdrs = [
-    "runtime.h",
-  ],
-  deps = [
-    ":computation_client",
-    ":env_vars",
-    ":pjrt_computation_client",
-    ":ifrt_computation_client",
-    "@tsl//tsl/platform:stacktrace",
-  ],
+    name = "runtime",
+    srcs = [
+        "runtime.cc",
+    ],
+    hdrs = [
+        "runtime.h",
+    ],
+    deps = [
+        ":computation_client",
+        ":env_vars",
+        ":ifrt_computation_client",
+        ":pjrt_computation_client",
+        "@tsl//tsl/platform:stacktrace",
+    ],
 )
 
 cc_library(
-  name = "computation_client",
-  srcs = [
-    "computation_client.cc",
-  ],
-  hdrs = [
-    "computation_client.h",
-  ],
-  copts = [
-    "-isystemexternal/torch",
-  ],
-  deps = [
-    ":debug_macros",
-    ":env_vars",
-    ":metrics_analysis",
-    ":metrics_reader",
-    ":metrics",
-    ":sys_util",
-    ":tensor_source",
-    ":types",
-    ":util",
-    ":xla_coordinator",
-    "//torch_xla/csrc:device",
-    "//torch_xla/csrc:dtype",
-    "@tsl//tsl/platform:stacktrace_handler",
-    "@xla//xla:literal_util",
-    "@xla//xla/client:xla_computation",
-    "@xla//xla/hlo/ir:hlo",
-    "@com_google_absl//absl/memory",
-    "@com_google_absl//absl/strings",
-    "@com_google_absl//absl/types:optional",
-    "@com_google_absl//absl/types:span",
-    "@torch//:headers",
-    "@torch//:runtime_headers",
-  ],
+    name = "computation_client",
+    srcs = [
+        "computation_client.cc",
+    ],
+    hdrs = [
+        "computation_client.h",
+    ],
+    copts = [
+        "-isystemexternal/torch",
+    ],
+    deps = [
+        ":debug_macros",
+        ":env_vars",
+        ":metrics",
+        ":metrics_analysis",
+        ":metrics_reader",
+        ":sys_util",
+        ":tensor_source",
+        ":types",
+        ":util",
+        ":xla_coordinator",
+        "//torch_xla/csrc:device",
+        "//torch_xla/csrc:dtype",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:optional",
+        "@com_google_absl//absl/types:span",
+        "@torch//:headers",
+        "@torch//:runtime_headers",
+        "@tsl//tsl/platform:stacktrace_handler",
+        "@xla//xla:literal_util",
+        "@xla//xla/client:xla_computation",
+        "@xla//xla/hlo/ir:hlo",
+    ],
 )
 
 cc_library(
-  name = "ifrt_computation_client",
-  srcs = [
-    "ifrt_computation_client.cc",
-  ],
-  hdrs = [
-    "ifrt_computation_client.h",
-  ],
-  deps = [
-    ":computation_client",
-    ":debug_macros",
-    ":env_vars",
-    ":pjrt_registry",
-    ":operation_manager",
-    ":stablehlo_helper",
-    ":tf_logging",
-    "@xla//xla:literal",
-    "@xla//xla:shape_util",
-    "@xla//xla/client:xla_computation",
-    "@xla//xla/pjrt/distributed",
-    "@xla//xla/pjrt:pjrt_client",
-    "@xla//xla/python/ifrt",
-    "@xla//xla/python/pjrt_ifrt",
-    "@tsl//tsl/profiler/lib:traceme",
-    "@tsl//tsl/platform/cloud:gcs_file_system",
-    "@com_google_absl//absl/strings",
-    "@com_google_absl//absl/types:span",
-  ],
+    name = "ifrt_computation_client",
+    srcs = [
+        "ifrt_computation_client.cc",
+    ],
+    hdrs = [
+        "ifrt_computation_client.h",
+    ],
+    deps = [
+        ":computation_client",
+        ":debug_macros",
+        ":env_vars",
+        ":operation_manager",
+        ":pjrt_registry",
+        ":stablehlo_helper",
+        ":tf_logging",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:span",
+        "@tsl//tsl/platform/cloud:gcs_file_system",
+        "@tsl//tsl/profiler/lib:traceme",
+        "@xla//xla:literal",
+        "@xla//xla:shape_util",
+        "@xla//xla/client:xla_computation",
+        "@xla//xla/pjrt:pjrt_client",
+        "@xla//xla/pjrt/distributed",
+        "@xla//xla/python/ifrt",
+        "@xla//xla/python/pjrt_ifrt",
+    ],
 )
 
 cc_library(
-  name = "pjrt_computation_client",
-  srcs = [
-    "pjrt_computation_client.cc",
-  ],
-  hdrs = [
-    "pjrt_computation_client.h",
-  ],
-  deps = [
-    ":computation_client",
-    ":debug_macros",
-    ":env_hash",
-    ":env_vars",
-    ":pjrt_registry",
-    ":operation_manager",
-    ":profiler",
-    ":stablehlo_helper",
-    ":tensor_source",
-    ":tf_logging",
-    ":xla_coordinator",
-    "//torch_xla/csrc:thread_pool",
-    "@xla//xla:literal",
-    "@xla//xla:shape_util",
-    "@xla//xla/client:xla_computation",
-    "@xla//xla/pjrt/distributed",
-    "@xla//xla/pjrt:pjrt_client",
-    "@xla//xla/pjrt/c:pjrt_c_api_hdrs",
-    "@tsl//tsl/profiler/lib:traceme",
-    "@tsl//tsl/platform/cloud:gcs_file_system",
-    "@tsl//tsl/platform:env",
-    "@com_google_absl//absl/strings",
-    "@com_google_absl//absl/synchronization",
-    "@com_google_absl//absl/types:span",
-  ],
+    name = "pjrt_computation_client",
+    srcs = [
+        "pjrt_computation_client.cc",
+    ],
+    hdrs = [
+        "pjrt_computation_client.h",
+    ],
+    deps = [
+        ":computation_client",
+        ":debug_macros",
+        ":env_hash",
+        ":env_vars",
+        ":operation_manager",
+        ":pjrt_registry",
+        ":profiler",
+        ":stablehlo_helper",
+        ":tensor_source",
+        ":tf_logging",
+        ":xla_coordinator",
+        "//torch_xla/csrc:thread_pool",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/types:span",
+        "@tsl//tsl/platform:env",
+        "@tsl//tsl/platform/cloud:gcs_file_system",
+        "@tsl//tsl/profiler/lib:traceme",
+        "@xla//xla:literal",
+        "@xla//xla:shape_util",
+        "@xla//xla/client:xla_computation",
+        "@xla//xla/pjrt:pjrt_client",
+        "@xla//xla/pjrt/c:pjrt_c_api_hdrs",
+        "@xla//xla/pjrt/distributed",
+    ],
 )
 
 cc_library(
     name = "cache",
     hdrs = ["cache.h"],
     deps = [
-      "@torch//:headers",
+        "@torch//:headers",
     ],
 )
 
@@ -150,9 +144,9 @@ cc_test(
     size = "small",
     srcs = ["cache_test.cc"],
     deps = [
-      ":cache",
-      "@torch//:libtorch_cpu",  # For TORCH_LAZY_COUNTER
-      "@com_google_googletest//:gtest_main",
+        ":cache",
+        "@com_google_googletest//:gtest_main",
+        "@torch//:libtorch_cpu",  # For TORCH_LAZY_COUNTER
     ],
 )
 
@@ -161,8 +155,8 @@ cc_library(
     hdrs = ["debug_macros.h"],
     deps = [
         ":tf_logging",
-        "@xla//xla:statusor",
         "@tsl//tsl/platform:stacktrace",
+        "@xla//xla:statusor",
     ],
 )
 
@@ -187,29 +181,30 @@ cc_test(
     size = "small",
     srcs = ["env_hash_test.cc"],
     deps = [
-      ":env_hash",
-      "@torch//:libtorch_cpu",  # For torch::lazy::hash
-      "@com_google_googletest//:gtest_main",
+        ":env_hash",
+        "@com_google_googletest//:gtest_main",
+        "@torch//:libtorch_cpu",  # For torch::lazy::hash
     ],
 )
 
 cc_library(
-  name = "pjrt_registry",
-  srcs = ["pjrt_registry.cc"],
-  hdrs = ["pjrt_registry.h"],
-  deps = [
-    ":debug_macros",
-    ":env_hash",
-    ":env_vars",
-    ":profiler",
-    ":sys_util",
-    ":tf_logging",
-    ":xla_coordinator",
-    "@xla//xla/service:gpu_plugin",
-    "@xla//xla/pjrt/gpu:se_gpu_pjrt_client",
-    "@xla//xla/pjrt:tfrt_cpu_pjrt_client",
-    "@xla//xla/pjrt:pjrt_c_api_client",
-  ],
+    name = "pjrt_registry",
+    srcs = ["pjrt_registry.cc"],
+    hdrs = ["pjrt_registry.h"],
+    deps = [
+        ":debug_macros",
+        ":env_hash",
+        ":env_vars",
+        ":profiler",
+        ":sys_util",
+        ":tf_logging",
+        ":xla_coordinator",
+        "@com_google_absl//absl/log:initialize",
+        "@xla//xla/pjrt:pjrt_c_api_client",
+        "@xla//xla/pjrt:tfrt_cpu_pjrt_client",
+        "@xla//xla/pjrt/gpu:se_gpu_pjrt_client",
+        "@xla//xla/service:gpu_plugin",
+    ],
 )
 
 cc_library(
@@ -242,8 +237,8 @@ cc_library(
     deps = [
         ":debug_macros",
         ":sys_util",
-        "@xla//xla/pjrt/distributed",
         "@tsl//tsl/distributed_runtime/preemption:preemption_sync_manager",
+        "@xla//xla/pjrt/distributed",
     ],
 )
 
@@ -263,28 +258,28 @@ cc_library(
 )
 
 cc_library(
-  name = "operation_manager",
-  srcs = ["operation_manager.cc"],
-  hdrs = ["operation_manager.h"],
-  visibility = ["//visibility:private"],
-  deps = [
-    ":debug_macros",
-    ":tf_logging",
-    "@com_google_absl//absl/types:span",
-  ],
+    name = "operation_manager",
+    srcs = ["operation_manager.cc"],
+    hdrs = ["operation_manager.h"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":debug_macros",
+        ":tf_logging",
+        "@com_google_absl//absl/types:span",
+    ],
 )
 
 # Profiler silently fails unless we link these backends
 cc_library(
-  name = "profiler_backends",
-  visibility = ["//visibility:private"],
-  deps = [
-    "@xla//xla/backends/profiler/cpu:host_tracer",
-    "@xla//xla/backends/profiler/cpu:metadata_collector",
-  ] + if_cuda_is_configured([
-    "@xla//xla/backends/profiler/gpu:device_tracer",
-  ]),
-  alwayslink = True,
+    name = "profiler_backends",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@xla//xla/backends/profiler/cpu:host_tracer",
+        "@xla//xla/backends/profiler/cpu:metadata_collector",
+    ] + if_cuda_is_configured([
+        "@xla//xla/backends/profiler/gpu:device_tracer",
+    ]),
+    alwayslink = True,
 )
 
 cc_library(
@@ -292,24 +287,24 @@ cc_library(
     srcs = ["profiler.cc"],
     hdrs = ["profiler.h"],
     deps = [
-      ":tf_logging",
-      ":profiler_backends",
-      "@xla//xla/backends/profiler/plugin:profiler_c_api_hdrs",
-      "@xla//xla/backends/profiler/plugin:plugin_tracer",
-      "@xla//xla/pjrt/c:pjrt_c_api_profiler_extension_hdrs",
-      "@xla//xla:status",
-      "@tsl//tsl/profiler/lib:profiler_factory",
-      "@tsl//tsl/profiler/rpc:profiler_server_impl",
-      "@tsl//tsl/profiler/rpc/client:capture_profile",
-      "@com_google_absl//absl/container:flat_hash_map",
+        ":tf_logging",
+        ":profiler_backends",
+        "@xla//xla/backends/profiler/plugin:profiler_c_api_hdrs",
+        "@xla//xla/backends/profiler/plugin:plugin_tracer",
+        "@xla//xla/pjrt/c:pjrt_c_api_profiler_extension_hdrs",
+        "@xla//xla:status",
+        "@tsl//tsl/profiler/lib:profiler_factory",
+        "@tsl//tsl/profiler/rpc:profiler_server_impl",
+        "@tsl//tsl/profiler/rpc/client:capture_profile",
+        "@com_google_absl//absl/container:flat_hash_map",
 
-      # TODO: We get missing symbol errors without these deps. Why aren't they
-      # included transitively from TensorFlow/TSL?
-      "@tsl//tsl/profiler/protobuf:profiler_analysis_proto_cc_impl",
-      "@tsl//tsl/profiler/protobuf:profiler_options_proto_cc_impl",
-      "@tsl//tsl/profiler/protobuf:profiler_service_proto_cc_impl",
-      "@tsl//tsl/profiler/protobuf:profiler_service_monitor_result_proto_cc_impl",
-      "@tsl//tsl/profiler/rpc/client:profiler_client",
+        # TODO: We get missing symbol errors without these deps. Why aren't they
+        # included transitively from TensorFlow/TSL?
+        "@tsl//tsl/profiler/protobuf:profiler_analysis_proto_cc_impl",
+        "@tsl//tsl/profiler/protobuf:profiler_options_proto_cc_impl",
+        "@tsl//tsl/profiler/protobuf:profiler_service_proto_cc_impl",
+        "@tsl//tsl/profiler/protobuf:profiler_service_monitor_result_proto_cc_impl",
+        "@tsl//tsl/profiler/rpc/client:profiler_client",
     ],
 )
 
@@ -341,15 +336,15 @@ cc_library(
     srcs = ["stablehlo_helper.cc"],
     hdrs = ["stablehlo_helper.h"],
     deps = [
-        ":types",
-        ":xla_util",
-        ":xla_mlir_debuginfo_helper",
         ":stablehlo_composite_helper",
+        ":types",
+        ":xla_mlir_debuginfo_helper",
+        ":xla_util",
         "@stablehlo//:stablehlo_portable_api",
         "@stablehlo//:stablehlo_serialization",
+        "@xla//xla/mlir_hlo:all_passes",
         "@xla//xla/translate/hlo_to_mhlo:hlo_to_mlir_hlo",
         "@xla//xla/translate/mhlo_to_hlo:mlir_hlo_to_hlo",
-        "@xla//xla/mlir_hlo:all_passes",
     ],
 )
 
@@ -384,14 +379,14 @@ cc_library(
 )
 
 cc_library(
-  name = "tensor_source",
-  hdrs = ["tensor_source.h"],
-  deps = [
-      ":debug_macros",
-      "@xla//xla:literal",
-      "@xla//xla:shape_util",
-      "@torch//:headers",
-  ]
+    name = "tensor_source",
+    hdrs = ["tensor_source.h"],
+    deps = [
+        ":debug_macros",
+        "@torch//:headers",
+        "@xla//xla:literal",
+        "@xla//xla:shape_util",
+    ],
 )
 
 cc_library(
@@ -412,9 +407,9 @@ cc_library(
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:span",
+        "@tsl//tsl/platform:hash",
         "@xla//xla:statusor",
         "@xla//xla:types",
-        "@tsl//tsl/platform:hash",
     ],
 )
 
@@ -440,6 +435,8 @@ cc_library(
         ":types",
         ":util",
         "@com_google_absl//absl/types:span",
+        "@torch//:headers",
+        "@tsl//tsl/platform:errors",
         "@xla//xla:shape_util",
         "@xla//xla:status_macros",
         "@xla//xla:types",
@@ -447,8 +444,6 @@ cc_library(
         "@xla//xla/service:hlo_proto_cc",
         "@xla//xla/service:platform_util",
         "@xla//xla/service/spmd:spmd_partitioner",
-        "@tsl//tsl/platform:errors",
-        "@torch//:headers",
     ],
 )
 
@@ -460,12 +455,12 @@ ptxla_cc_test(
         ":xla_util",
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",
-        "@xla//xla:shape_util",
-        "@xla//xla/client:xla_builder",
-        "@xla//xla/client:xla_computation",
         "@tsl//tsl/lib/core:status_test_util",
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:status_matchers",
+        "@xla//xla:shape_util",
+        "@xla//xla/client:xla_builder",
+        "@xla//xla/client:xla_computation",
     ],
 )
 
@@ -476,6 +471,12 @@ ptxla_cc_test(
         ":computation_client",
         ":pjrt_computation_client",
         ":tensor_source",
+        "@tsl//tsl/lib/core:status_test_util",
+        "@tsl//tsl/platform:env",
+        "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:logging",
+        "@tsl//tsl/platform:test",
+        "@tsl//tsl/platform:test_main",
         "@xla//xla:literal",
         "@xla//xla:literal_util",
         "@xla//xla:shape_util",
@@ -485,12 +486,6 @@ ptxla_cc_test(
         "@xla//xla/client:xla_computation",
         "@xla//xla/tests:literal_test_util",
         "@xla//xla/tools:hlo_module_loader",
-        "@tsl//tsl/lib/core:status_test_util",
-        "@tsl//tsl/platform:env",
-        "@tsl//tsl/platform:errors",
-        "@tsl//tsl/platform:logging",
-        "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
@@ -501,6 +496,12 @@ ptxla_cc_test(
         ":computation_client",
         ":ifrt_computation_client",
         ":tensor_source",
+        "@tsl//tsl/lib/core:status_test_util",
+        "@tsl//tsl/platform:env",
+        "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:logging",
+        "@tsl//tsl/platform:test",
+        "@tsl//tsl/platform:test_main",
         "@xla//xla:literal",
         "@xla//xla:literal_util",
         "@xla//xla:shape_util",
@@ -510,11 +511,5 @@ ptxla_cc_test(
         "@xla//xla/client:xla_computation",
         "@xla//xla/tests:literal_test_util",
         "@xla//xla/tools:hlo_module_loader",
-        "@tsl//tsl/lib/core:status_test_util",
-        "@tsl//tsl/platform:env",
-        "@tsl//tsl/platform:errors",
-        "@tsl//tsl/platform:logging",
-        "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )

--- a/torch_xla/csrc/runtime/pjrt_registry.cc
+++ b/torch_xla/csrc/runtime/pjrt_registry.cc
@@ -1,5 +1,6 @@
 #include "torch_xla/csrc/runtime/pjrt_registry.h"
 
+#include "absl/log/initialize.h"
 #include "torch_xla/csrc/runtime/debug_macros.h"
 #include "torch_xla/csrc/runtime/env_vars.h"
 #include "torch_xla/csrc/runtime/profiler.h"
@@ -110,6 +111,8 @@ InitializePjRt(const std::string& device_type) {
     client = std::move(xla::GetTfrtCpuClient(async, cpu_device_count).value());
   } else if (device_type == "TPU") {
     TF_VLOG(1) << "Initializing TFRT TPU client...";
+    // Init the absl logging to avoid the log spam.
+    absl::InitializeLog();
     // Prefer $TPU_LIBRARY_PATH if set
     auto tpu_library_path = sys_util::GetEnvString(
         env::kEnvTpuLibraryPath,


### PR DESCRIPTION
This should get rid of
```
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1712267574.801377  681831 pjrt_api.cc:100] GetPjrtApi was found for tpu at /usr/local/lib/python3.10/site-packages/libtpu/libtpu.so
I0000 00:00:1712267574.801477  681831 pjrt_api.cc:79] PJRT_Api is set for device type tpu
I0000 00:00:1712267574.801484  681831 pjrt_api.cc:146] The PJRT plugin has PJRT API version 0.46. The framework PJRT API version is 0.46.
```
on every init. `torch_xla/csrc/BUILD` was messed by the formater, my only change was to add `"@com_google_absl//absl/log:initialize",`