### PR TITLE
add torch_distributed tests to our TPU CI

### DIFF
--- a/test/tpu/run_tests.sh
+++ b/test/tpu/run_tests.sh
@@ -20,3 +20,7 @@ python3 test/pjrt/test_dtypes.py
 python3 test/pjrt/test_dynamic_plugin_tpu.py
 python3 test/test_fori_loop_with_while_loop_simple_add_dispatch_in_torch.py
 python3 test/test_pallas.py
+python3 test/torch_distributed/test_torch_distributed_all_gather_xla_backend.py
+python3 test/torch_distributed/test_torch_distributed_all_reduce_xla_backend.py
+python3 test/torch_distributed/test_torch_distributed_multi_all_reduce_xla_backend.py
+python3 test/torch_distributed/test_torch_distributed_reduce_scatter_xla_backend.py

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -261,7 +261,7 @@ def xla_replication_devices(local_devices):
         'Cannot replicate across different device types: devices={}/{}'.format(
             local_devices, real_devices))
   device_type = device_types.pop()
-  kind_devices = get_xla_supported_devices(devkind=device_type)
+  kind_devices = get_xla_supported_devices()
   if len(kind_devices) != len(local_devices):
     # Replication can only happen among all devices of one kind.
     raise RuntimeError(


### PR DESCRIPTION
`get_xla_supported_devices ` will deprecate `devkind ` after 2.3 so remove it to avoid warning for all mp tests.

@will-cromar I think now all mp workload will throw this warning since they will all call `xla_replication_devices`. Do you think we should just fix that in the release branch?