### PR TITLE
Fix warning message when running mp workload

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -261,7 +261,7 @@ def xla_replication_devices(local_devices):
         'Cannot replicate across different device types: devices={}/{}'.format(
             local_devices, real_devices))
   device_type = device_types.pop()
-  kind_devices = get_xla_supported_devices(devkind=device_type)
+  kind_devices = get_xla_supported_devices()
   if len(kind_devices) != len(local_devices):
     # Replication can only happen among all devices of one kind.
     raise RuntimeError(


### PR DESCRIPTION
Currently all mp workload will throw a warning message of 
```
/workspaces/dk3/pytorch/xla/torch_xla/core/xla_model.py:105: UserWarning: `devkind` argument is deprecated and will be removed in a future release.
  warnings.warn("`devkind` argument is deprecated and will be removed in a "
```

`devkind` is not doing anything now, it is better to fix this warning message in release. I have a similar pr targeting master too