### PR TITLE
Bump JAX version to match the latest pin update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ base_dir = os.path.dirname(os.path.abspath(__file__))
 _date = '20240404'
 _libtpu_version = f'0.1.dev{_date}'
 _libtpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
-_jax_version = f'0.4.26.dev{_date}'
+_jax_version = f'0.4.27.dev{_date}'
 
 
 def _get_build_mode():


### PR DESCRIPTION
Summary:
This pull request bumps JAX version to match the recent pin update.

Test Plan:
Tested locally.