### PR TITLE
[SPMD] UseVirtualDevice() is set, when XLA_AUTO_SPMD=1

### DIFF
--- a/torch_xla/csrc/device.cpp
+++ b/torch_xla/csrc/device.cpp
@@ -75,7 +75,8 @@ torch::lazy::BackendDevice GetVirtualDevice() {
 
 bool ShouldUseVirtualDevice() {
   bool use_virtual_device =
-      runtime::sys_util::GetEnvBool("XLA_USE_SPMD", false);
+      runtime::sys_util::GetEnvBool("XLA_USE_SPMD", false) ||
+      runtime::sys_util::GetEnvBool("XLA_AUTO_SPMD", false);
   if (use_virtual_device) {
     TF_LOG(INFO) << "Using SPMD virtual device optimization";
   }


### PR DESCRIPTION
This allows doing `XLA_AUTO_SPMD=1` instead of `XLA_USE_SPMD=1 XLA_AUTO_SPMD=1` to enable auto-sharding. `xr.use_spmd(auto=True)` should work the same.