### PR TITLE
[Pallas] Remove torch.empty in tracing

### DIFF
--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -38,7 +38,8 @@ class PallasTest(unittest.TestCase):
     y = torch.arange(8, dtype=torch.int).to("xla")
     expected_output = x + y
 
-    output = torch_xla._XLAC._xla_tpu_custom_call([x, y], payload, [x.shape], [x.dtype])
+    output = torch_xla._XLAC._xla_tpu_custom_call([x, y], payload, [x.shape],
+                                                  [x.dtype])
     self.assertTrue(torch.allclose(output[0].cpu(), expected_output.cpu()))
 
   @unittest.skipIf(xr.device_type() != 'TPU', "This test only works on TPU.")
@@ -51,7 +52,8 @@ class PallasTest(unittest.TestCase):
     x = torch.arange(8, dtype=torch.int).to("xla")
     expected_output = x + 1
 
-    output = torch_xla._XLAC._xla_tpu_custom_call([x], payload, [x.shape], [x.dtype])
+    output = torch_xla._XLAC._xla_tpu_custom_call([x], payload, [x.shape],
+                                                  [x.dtype])
     self.assertTrue(torch.allclose(output[0].cpu(), expected_output.cpu()))
 
   @unittest.skipIf(xr.device_type() != 'TPU', "This test only works on TPU.")
@@ -83,7 +85,8 @@ class PallasTest(unittest.TestCase):
 
     expected_o = self._attention(q, k, v)
 
-    o = torch_xla._XLAC._xla_tpu_custom_call([q, k, v], payload, [q.shape], [q.dtype])
+    o = torch_xla._XLAC._xla_tpu_custom_call([q, k, v], payload, [q.shape],
+                                             [q.dtype])
     self.assertTrue(torch.allclose(o[0].cpu(), expected_o.cpu()))
 
   @unittest.skipIf(xr.device_type() != 'TPU', "This test only works on TPU.")
@@ -374,8 +377,9 @@ class PallasTest(unittest.TestCase):
     l = l.unsqueeze(-1).expand(3, 2, 128, MIN_BLOCK_SIZE)
     m = m.unsqueeze(-1).expand(3, 2, 128, MIN_BLOCK_SIZE)
     grad_i = grad_i.unsqueeze(-1).expand(3, 2, 128, MIN_BLOCK_SIZE)
-    output = torch_xla._XLAC._xla_tpu_custom_call([q, k, v, l, m, grad_o, grad_i],
-                                          payload, [k.shape, v.shape], [k.dtype, v.dtype])
+    output = torch_xla._XLAC._xla_tpu_custom_call(
+        [q, k, v, l, m, grad_o, grad_i], payload, [k.shape, v.shape],
+        [k.dtype, v.dtype])
 
     xm.mark_step()
 
@@ -427,8 +431,7 @@ class PallasTest(unittest.TestCase):
     m = m.unsqueeze(-1).expand(3, 2, 128, MIN_BLOCK_SIZE)
     grad_i = grad_i.unsqueeze(-1).expand(3, 2, 128, MIN_BLOCK_SIZE)
     output = torch_xla._XLAC._xla_tpu_custom_call(
-                                          [q, k, v, l, m, grad_o, grad_i],
-                                          payload, [q.shape], [q.dtype])
+        [q, k, v, l, m, grad_o, grad_i], payload, [q.shape], [q.dtype])
 
     xm.mark_step()
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -38,7 +38,6 @@ class PallasTest(unittest.TestCase):
     y = torch.arange(8, dtype=torch.int).to("xla")
     expected_output = x + y
 
-    print(type(torch.int32))
     output = torch_xla._XLAC._xla_tpu_custom_call([x, y], payload, [x.shape], [x.dtype])
     self.assertTrue(torch.allclose(output[0].cpu(), expected_output.cpu()))
 
@@ -51,7 +50,6 @@ class PallasTest(unittest.TestCase):
 
     x = torch.arange(8, dtype=torch.int).to("xla")
     expected_output = x + 1
-    output = torch.arange(8, dtype=torch.int).to("xla")
 
     output = torch_xla._XLAC._xla_tpu_custom_call([x], payload, [x.shape], [x.dtype])
     self.assertTrue(torch.allclose(output[0].cpu(), expected_output.cpu()))
@@ -63,11 +61,9 @@ class PallasTest(unittest.TestCase):
     #   o_ref[...] = x_ref[...] + 1
     payload = "{\"custom_call_config\": {\"body\": \"TUzvUgFNTElSMTguMC4wZ2l0AAEtCwEDBQcJAQMLAwUDDQcFDxEJBxMVFwNlSQ0BRwcPCw8PDxMLDzMLCwsLZQsLCwsPCw8LEw8PCxMPCxMTDwsLBQNhAQ0bDxMHFw8CpgIfFSsxBRkdQwMdRQMRCwEDAw8nBRsdKQMDCxUXGRsfCyELIyUFHQEBBR8NCWFmZmluZV9tYXA8KGQwKSAtPiAoZDApPgAFIQUjBSUFJxEHAQUpHS0vBSsXBRsBFTM5HTU3BS0XBS8BHTs9BS8XBUUBAwMPQREDBQUxBTMjdHB1Lm1lbW9yeV9zcGFjZTx2bWVtPgAXRwMhAx0BAgInAyEDAwUFAQEBAQIEBKEFARABBwMBBQMRARMHAxMnBQEBAQEHAxENAwcLBhEDBQUBBQcDBz8DAw0GBwMFAwkJBgcDBQUHCwcDCQ0DBwsGCQMFBQMPDwQJBw0DDwUAAQYDAQUBAMIHNdsLEyEv2QsTIyEdKQ1DDRULCxMPDw8NCQsRYnVpbHRpbgBmdW5jAHRwdQBhcml0aAB2ZWN0b3IAbW9kdWxlAHJldHVybgBjb25zdGFudABhZGRpAGxvYWQAYnJvYWRjYXN0AHN0b3JlAC9ob21lL2p3dGFuL3BhbGxhcy9wYWxsYXNfYWRkLnB5AHZhbHVlAGRpbWVuc2lvbl9zZW1hbnRpY3MAZnVuY3Rpb25fdHlwZQBzY2FsYXJfcHJlZmV0Y2gAc2NyYXRjaF9vcGVyYW5kcwBzeW1fbmFtZQBtYWluAC9nZXRbdHJlZT1QeVRyZWVEZWYoKEN1c3RvbU5vZGUoTkRJbmRleGVyWyhQeVRyZWVEZWYoKEN1c3RvbU5vZGUoU2xpY2VbKDAsIDgpXSwgW10pLCkpLCAoOCwpLCAoKSldLCBbXSksKSldAGFkZF9vbmVfdmVjdG9yc19rZXJuZWwAYWRkX3ZlY3RvcnNfb25lADxtb2R1bGU+AC9hZGQAL3N3YXBbdHJlZT1QeVRyZWVEZWYoKEN1c3RvbU5vZGUoTkRJbmRleGVyWyhQeVRyZWVEZWYoKEN1c3RvbU5vZGUoU2xpY2VbKDAsIDgpXSwgW10pLCkpLCAoOCwpLCAoKSldLCBbXSksKSldAA==\", \"needs_layout_passes\": true}}"
 
-    output = torch.arange(8, dtype=torch.int).to("xla")
-
-    # _xla_tpu_custom_call_ requires at least one input.
+    # _xla_tpu_custom_call requires at least one input.
     with self.assertRaises(RuntimeError):
-      torch_xla._XLAC._xla_tpu_custom_call_([output], [], payload)
+      torch_xla._XLAC._xla_tpu_custom_call([], payload, [(8, 1)], [torch.int32])
       output.cpu()
 
   @unittest.skipIf(xr.device_type() != 'TPU', "This test only works on TPU.")
@@ -84,12 +80,11 @@ class PallasTest(unittest.TestCase):
     q = q_mini.broadcast_to(3, 2, 128, 4).to("xla")
     k = k_mini.broadcast_to(3, 2, 128, 4).to("xla")
     v = torch.ones(3, 2, 128, 4).to("xla")
-    o = torch.zeros(3, 2, 128, 4).to("xla")
 
     expected_o = self._attention(q, k, v)
 
-    torch_xla._XLAC._xla_tpu_custom_call_([o], [q, k, v], payload)
-    self.assertTrue(torch.allclose(o.cpu(), expected_o.cpu()))
+    o = torch_xla._XLAC._xla_tpu_custom_call([q, k, v], payload, [q.shape], [q.dtype])
+    self.assertTrue(torch.allclose(o[0].cpu(), expected_o.cpu()))
 
   @unittest.skipIf(xr.device_type() != 'TPU', "This test only works on TPU.")
   @unittest.skip("TODO: Make the tpu_custom_call_ as functional.")
@@ -379,17 +374,14 @@ class PallasTest(unittest.TestCase):
     l = l.unsqueeze(-1).expand(3, 2, 128, MIN_BLOCK_SIZE)
     m = m.unsqueeze(-1).expand(3, 2, 128, MIN_BLOCK_SIZE)
     grad_i = grad_i.unsqueeze(-1).expand(3, 2, 128, MIN_BLOCK_SIZE)
-    grad_k = torch.randn(3, 2, 128, 4).to("xla")
-    grad_v = torch.randn(3, 2, 128, 4).to("xla")
-    torch_xla._XLAC._xla_tpu_custom_call_([grad_k, grad_v],
-                                          [q, k, v, l, m, grad_o, grad_i],
-                                          payload)
+    output = torch_xla._XLAC._xla_tpu_custom_call([q, k, v, l, m, grad_o, grad_i],
+                                          payload, [k.shape, v.shape], [k.dtype, v.dtype])
 
     xm.mark_step()
 
     # TODO: I don't really know how to test the value. Let's do the shape check for now.
-    self.assertEqual(grad_k.shape, (3, 2, 128, 4))
-    self.assertEqual(grad_v.shape, (3, 2, 128, 4))
+    self.assertEqual(output[0].shape, (3, 2, 128, 4))
+    self.assertEqual(output[1].shape, (3, 2, 128, 4))
 
   @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 3,
                    "This test only works on TPUv3+.")
@@ -434,15 +426,14 @@ class PallasTest(unittest.TestCase):
     l = l.unsqueeze(-1).expand(3, 2, 128, MIN_BLOCK_SIZE)
     m = m.unsqueeze(-1).expand(3, 2, 128, MIN_BLOCK_SIZE)
     grad_i = grad_i.unsqueeze(-1).expand(3, 2, 128, MIN_BLOCK_SIZE)
-    grad_q = torch.randn(3, 2, 128, 4).to("xla")
-    torch_xla._XLAC._xla_tpu_custom_call_([grad_q],
+    output = torch_xla._XLAC._xla_tpu_custom_call(
                                           [q, k, v, l, m, grad_o, grad_i],
-                                          payload)
+                                          payload, [q.shape], [q.dtype])
 
     xm.mark_step()
 
     # TODO: I don't really know how to test the value. Let's do the shape check for now.
-    self.assertEqual(grad_q.shape, (3, 2, 128, 4))
+    self.assertEqual(output[0].shape, (3, 2, 128, 4))
 
   @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 3,
                    "This test only works on TPUv3+.")

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -37,10 +37,10 @@ class PallasTest(unittest.TestCase):
     x = torch.arange(8, dtype=torch.int).to("xla")
     y = torch.arange(8, dtype=torch.int).to("xla")
     expected_output = x + y
-    output = torch.arange(8, dtype=torch.int).to("xla")
 
-    torch_xla._XLAC._xla_tpu_custom_call_([output], [x, y], payload)
-    self.assertTrue(torch.allclose(output.cpu(), expected_output.cpu()))
+    print(type(torch.int32))
+    output = torch_xla._XLAC._xla_tpu_custom_call([x, y], payload, [x.shape], [x.dtype])
+    self.assertTrue(torch.allclose(output[0].cpu(), expected_output.cpu()))
 
   @unittest.skipIf(xr.device_type() != 'TPU', "This test only works on TPU.")
   def test_tpu_custom_call_pallas_add_one(self):
@@ -53,8 +53,8 @@ class PallasTest(unittest.TestCase):
     expected_output = x + 1
     output = torch.arange(8, dtype=torch.int).to("xla")
 
-    torch_xla._XLAC._xla_tpu_custom_call_([output], [x], payload)
-    self.assertTrue(torch.allclose(output.cpu(), expected_output.cpu()))
+    output = torch_xla._XLAC._xla_tpu_custom_call([x], payload, [x.shape], [x.dtype])
+    self.assertTrue(torch.allclose(output[0].cpu(), expected_output.cpu()))
 
   @unittest.skipIf(xr.device_type() != 'TPU', "This test only works on TPU.")
   def test_tpu_custom_call_pallas_raise(self):

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2231,12 +2231,16 @@ void InitXlaModuleBindings(py::module m) {
         [](at::Tensor& self, const at::Tensor& source) -> at::Tensor& {
           return XLANativeFunctions::set_(self, source);
         });
-  m.def("_xla_tpu_custom_call_",
-        [](const std::vector<at::Tensor>& outputs,
-           const std::vector<at::Tensor>& inputs, const std::string& payload) {
-          auto x_outputs = bridge::GetXlaTensors(outputs);
-          return tensor_methods::tpu_custom_call_(
-              x_outputs, bridge::GetXlaTensors(inputs), payload);
+  m.def("_xla_tpu_custom_call",
+        [](const std::vector<at::Tensor>& inputs, const std::string& payload, const std::vector<std::vector<int64_t>>& output_shapes, const std::vector<py::object>& output_dtypes) -> std::vector<at::Tensor> {
+          std::vector<at::ScalarType> dtypes;
+          dtypes.reserve(output_dtypes.size());
+          for (auto& dtype : output_dtypes) {
+            dtypes.push_back(reinterpret_cast<THPDtype*>(dtype.ptr())->scalar_type);
+          }
+
+          auto xtensors = tensor_methods::tpu_custom_call(bridge::GetXlaTensors(inputs), payload, output_shapes, dtypes);
+          return bridge::AtenFromXlaTensors(xtensors);
         });
   m.def("_set_xla_custom_op_name_prefix",
         [](const at::Tensor& input, const std::string& op_name_prefix,

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2232,14 +2232,19 @@ void InitXlaModuleBindings(py::module m) {
           return XLANativeFunctions::set_(self, source);
         });
   m.def("_xla_tpu_custom_call",
-        [](const std::vector<at::Tensor>& inputs, const std::string& payload, const std::vector<std::vector<int64_t>>& output_shapes, const std::vector<py::object>& output_dtypes) -> std::vector<at::Tensor> {
+        [](const std::vector<at::Tensor>& inputs, const std::string& payload,
+           const std::vector<std::vector<int64_t>>& output_shapes,
+           const std::vector<py::object>& output_dtypes)
+            -> std::vector<at::Tensor> {
           std::vector<at::ScalarType> dtypes;
           dtypes.reserve(output_dtypes.size());
           for (auto& dtype : output_dtypes) {
-            dtypes.push_back(reinterpret_cast<THPDtype*>(dtype.ptr())->scalar_type);
+            dtypes.push_back(
+                reinterpret_cast<THPDtype*>(dtype.ptr())->scalar_type);
           }
 
-          auto xtensors = tensor_methods::tpu_custom_call(bridge::GetXlaTensors(inputs), payload, output_shapes, dtypes);
+          auto xtensors = tensor_methods::tpu_custom_call(
+              bridge::GetXlaTensors(inputs), payload, output_shapes, dtypes);
           return bridge::AtenFromXlaTensors(xtensors);
         });
   m.def("_set_xla_custom_op_name_prefix",

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -529,6 +529,8 @@ void custom_sharding_(
 }
 
 std::vector<XLATensorPtr> tpu_custom_call(const std::vector<XLATensorPtr>& inputs, const std::string& payload, const std::vector<std::vector<int64_t>>& output_shapes, const std::vector<at::ScalarType>& output_dtypes) {
+  XLA_CHECK(inputs.size() > 0) << "inputs are empty";
+
   std::vector<torch::lazy::Value> values;
   values.reserve(inputs.size());
   for (const auto& input : inputs) {

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -528,7 +528,10 @@ void custom_sharding_(
   input->SetShardingSpec(*sharding_spec);
 }
 
-std::vector<XLATensorPtr> tpu_custom_call(const std::vector<XLATensorPtr>& inputs, const std::string& payload, const std::vector<std::vector<int64_t>>& output_shapes, const std::vector<at::ScalarType>& output_dtypes) {
+std::vector<XLATensorPtr> tpu_custom_call(
+    const std::vector<XLATensorPtr>& inputs, const std::string& payload,
+    const std::vector<std::vector<int64_t>>& output_shapes,
+    const std::vector<at::ScalarType>& output_dtypes) {
   XLA_CHECK(inputs.size() > 0) << "inputs are empty";
 
   std::vector<torch::lazy::Value> values;
@@ -541,8 +544,9 @@ std::vector<XLATensorPtr> tpu_custom_call(const std::vector<XLATensorPtr>& input
   std::vector<xla::Shape> output_xla_shapes;
   output_xla_shapes.reserve(output_shapes.size());
   for (size_t i = 0; i < output_shapes.size(); ++i) {
-    output_xla_shapes.push_back(
-        xla::ShapeUtil::MakeShape(MakeXlaPrimitiveType(output_dtypes[i], &(inputs[0]->GetDevice())), output_shapes[i]));
+    output_xla_shapes.push_back(xla::ShapeUtil::MakeShape(
+        MakeXlaPrimitiveType(output_dtypes[i], &(inputs[0]->GetDevice())),
+        output_shapes[i]));
   }
 
   auto node = torch::lazy::MakeNode<TpuCustomCall>(
@@ -551,7 +555,8 @@ std::vector<XLATensorPtr> tpu_custom_call(const std::vector<XLATensorPtr>& input
   std::vector<XLATensorPtr> outputs;
   outputs.reserve(output_shapes.size());
   for (size_t i = 0; i < output_shapes.size(); ++i) {
-    outputs.push_back(inputs[0]->CreateFrom(torch::lazy::Value(node, i), output_dtypes[i]));
+    outputs.push_back(
+        inputs[0]->CreateFrom(torch::lazy::Value(node, i), output_dtypes[i]));
   }
   return outputs;
 }

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -82,9 +82,7 @@ std::pair<XLATensorPtr, torch::lazy::Value> collective_permute(
 void custom_sharding_(const XLATensorPtr& input,
                       const std::shared_ptr<XLATensor::ShardingSpec>& spec);
 
-void tpu_custom_call_(const std::vector<XLATensorPtr>& output,
-                      const std::vector<XLATensorPtr>& inputs,
-                      const std::string& payload);
+std::vector<XLATensorPtr> tpu_custom_call(const std::vector<XLATensorPtr>& inputs, const std::string& payload, const std::vector<std::vector<int64_t>>& output_shapes, const std::vector<at::ScalarType>& output_dtypes);
 
 XLATensorPtr get_dimensions_size(const XLATensorPtr& input,
                                  std::vector<int64_t> dimensions);

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -82,7 +82,10 @@ std::pair<XLATensorPtr, torch::lazy::Value> collective_permute(
 void custom_sharding_(const XLATensorPtr& input,
                       const std::shared_ptr<XLATensor::ShardingSpec>& spec);
 
-std::vector<XLATensorPtr> tpu_custom_call(const std::vector<XLATensorPtr>& inputs, const std::string& payload, const std::vector<std::vector<int64_t>>& output_shapes, const std::vector<at::ScalarType>& output_dtypes);
+std::vector<XLATensorPtr> tpu_custom_call(
+    const std::vector<XLATensorPtr>& inputs, const std::string& payload,
+    const std::vector<std::vector<int64_t>>& output_shapes,
+    const std::vector<at::ScalarType>& output_dtypes);
 
 XLATensorPtr get_dimensions_size(const XLATensorPtr& input,
                                  std::vector<int64_t> dimensions);

--- a/torch_xla/csrc/xla_lower_util.cpp
+++ b/torch_xla/csrc/xla_lower_util.cpp
@@ -1253,7 +1253,6 @@ xla::XlaOp BuildCustomSharding(const xla::XlaOp& input) {
 std::vector<xla::XlaOp> BuildTpuCustomCall(
     const std::vector<xla::XlaOp>& inputs, const xla::Shape& output_shape,
     const std::string& payload) {
-  XLA_CHECK(inputs.size() > 0) << "inputs are empty";
   XLA_CHECK(output_shape.IsTuple()) << "output_shape is not a tuple";
 
   // We need to enforce the default C-order (major-to-minor) layouts for inputs

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -148,7 +148,7 @@ def make_kernel_from_pallas(kernel: Callable, output_shape_dtype_fn: Callable):
                       list), "The output_shape_dtype_fn should return a list."
     output_shapes = [shape for shape, _ in output_shape_dtype]
     output_dtypes = [dtype for _, dtype in output_shape_dtype]
-    torch_xla._XLAC._xla_tpu_custom_call(tensor_args, payload, output_shapes, output_dtypes)
+    outputs = torch_xla._XLAC._xla_tpu_custom_call(tensor_args, payload, output_shapes, output_dtypes)
 
     # Make the output easier to use.
     if len(outputs) == 1:
@@ -276,11 +276,9 @@ class FlashAttention(torch.autograd.Function):
               "block_q_major", "block_k_major", "block_k", "sm_scale", "causal",
               "mask_value", "debug"
           ])
-      grad_q = torch.empty(q.shape, dtype=q.dtype).to(q.device)
-      torch_xla._XLAC._xla_tpu_custom_call_(
-          [grad_q],
+      grad_q = torch_xla._XLAC._xla_tpu_custom_call(
           [q, k, v, expanded_l, expanded_m, grad_output, expanded_grad_i],
-          payload)
+          payload, [q.shape], [q.dtype])[0]
 
     if ctx.needs_input_grad[1] or ctx.needs_input_grad[2]:
       payload, _ = trace_pallas(
@@ -312,16 +310,13 @@ class FlashAttention(torch.autograd.Function):
               "block_q_major", "block_k_major", "block_k", "block_q",
               "sm_scale", "causal", "mask_value", "debug"
           ])
-      grad_k = torch.empty(k.shape, dtype=k.dtype).to(k.device)
-      grad_v = torch.empty(v.shape, dtype=v.dtype).to(v.device)
-      torch_xla._XLAC._xla_tpu_custom_call_(
-          [grad_k, grad_v],
+      grads = torch_xla._XLAC._xla_tpu_custom_call(
           [q, k, v, expanded_l, expanded_m, grad_output, expanded_grad_i],
-          payload)
-    if not ctx.needs_input_grad[1]:
-      grad_k = None
-    if not ctx.needs_input_grad[2]:
-      grad_v = None
+          payload, [k.shape, v.shape], [k.dtype, v.dtype])
+    if ctx.needs_input_grad[1]:
+      grad_k = grads[0]
+    if ctx.needs_input_grad[2]:
+      grad_v = grads[1]
 
     return grad_q, grad_k, grad_v, None
 

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -148,7 +148,8 @@ def make_kernel_from_pallas(kernel: Callable, output_shape_dtype_fn: Callable):
                       list), "The output_shape_dtype_fn should return a list."
     output_shapes = [shape for shape, _ in output_shape_dtype]
     output_dtypes = [dtype for _, dtype in output_shape_dtype]
-    outputs = torch_xla._XLAC._xla_tpu_custom_call(tensor_args, payload, output_shapes, output_dtypes)
+    outputs = torch_xla._XLAC._xla_tpu_custom_call(tensor_args, payload,
+                                                   output_shapes, output_dtypes)
 
     # Make the output easier to use.
     if len(outputs) == 1:

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -143,14 +143,12 @@ def make_kernel_from_pallas(kernel: Callable, output_shape_dtype_fn: Callable):
         static_argnums=static_argnums,
         static_argnames=static_argnames,
         **kwargs)
-    outputs = []
     output_shape_dtype = output_shape_dtype_fn(*args)
     assert isinstance(output_shape_dtype,
                       list), "The output_shape_dtype_fn should return a list."
-    for output_shape, output_dtype in output_shape_dtype:
-      outputs.append(
-          torch.empty(output_shape, dtype=output_dtype).to(xm.xla_device()))
-    torch_xla._XLAC._xla_tpu_custom_call_(outputs, tensor_args, payload)
+    output_shapes = [shape for shape, _ in output_shape_dtype]
+    output_dtypes = [dtype for _, dtype in output_shape_dtype]
+    torch_xla._XLAC._xla_tpu_custom_call(tensor_args, payload, output_shapes, output_dtypes)
 
     # Make the output easier to use.
     if len(outputs) == 1:


### PR DESCRIPTION
Summary:
Previously we rely on torch.empty to create some empty tensors as the outputs from the Pallas and then make Pallas as in-place ops. However, it turns out that torch.empty will actually allocate memory and therefore it's expansive to use. In this change, I switched to simply pass the shapes and dtypes to construct the graph node.

Test Plan:
PJRT_DEVICE=TPU python test/test_pallas.py

Performance benchmarks can be found: http://shortn/_wdmom7I6q7