### PR TITLE
Set all_reduce_token to null when exiting

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -294,6 +294,7 @@ function run_mp_op_tests {
   run_test "$CDIR/test_mp_mesh_reduce.py"
   run_test "$CDIR/test_mp_sync_batch_norm.py"
   run_test "$CDIR/test_fsdp_auto_wrap.py"
+  run_torchrun "$CDIR/test_mp_early_exit.py"
   run_pt_xla_debug "$CDIR/debug_tool/test_mp_pt_xla_debug.py"
   run_test "$CDIR/torch_distributed/test_torch_distributed_all_gather_xla_backend.py"
   run_test "$CDIR/torch_distributed/test_torch_distributed_all_reduce_xla_backend.py"

--- a/test/test_mp_early_exit.py
+++ b/test/test_mp_early_exit.py
@@ -1,0 +1,32 @@
+from absl import logging
+import sys
+import torch
+import torch.distributed as dist
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.distributed.parallel_loader as pl
+import torch_xla.distributed.xla_backend
+import torch_xla.utils.utils as xu
+
+
+def _mp_fn():
+  dist.init_process_group('xla', init_method='xla://')
+  device = xm.xla_device()
+  if xm.xla_device_hw(device) in ['TPU', 'CUDA']:
+    train_loader = xu.SampleGenerator(
+        data=torch.zeros(1, 12), sample_count=1024)
+    train_loader = pl.MpDeviceLoader(train_loader, device)
+    max_steps = 10
+    for step, inputs in enumerate(train_loader):
+      xm.all_reduce('sum', [inputs], scale=1.0 / xm.xrt_world_size())
+      if step > max_steps:
+        break
+  else:
+    print(f'{device} is not a TPU or GPU device', file=sys.stderr)
+
+
+if __name__ == '__main__':
+  if not dist.is_torchelastic_launched():
+    logging.error('Test must be launched with torchrun!')
+    exit(1)
+  _mp_fn()

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -120,6 +120,8 @@ void PrepareToExit() {
   runtime::ComputationClient* client =
       runtime::GetComputationClientIfInitialized();
   if (client != nullptr) {
+    auto xla_device = GetDeviceOrCurrent("");
+    SetAllReduceToken(xla_device, nullptr);
     XLAGraphExecutor::Get()->WaitDeviceOps({});
   }
 }


### PR DESCRIPTION
This PR has the same purpose as #6247 , fixing the #6246 issue. This PR sets the token only when the client still exists, to avoid the hanging issue in mp test. This PR is reopened because the core issue with this token is frequently encountered.