### PR TITLE
[torch_xla2] Combined tensor.XLADispatchMode() and functions.XLAFunctionMode()

### DIFF
--- a/experimental/torch_xla2/test/test_context.py
+++ b/experimental/torch_xla2/test/test_context.py
@@ -12,8 +12,6 @@ class TestContext(unittest.TestCase):
       self.assertIsInstance(x, tensor.XLATensor2)
       y = x.abs()
       self.assertIsInstance(y, tensor.XLATensor2)
-      # TODO: remove print
-      print(y)
 
   @staticmethod
   @torch_xla2.mode()
@@ -27,8 +25,6 @@ class TestContext(unittest.TestCase):
     x, y = self._test_mode_decorator()
     self.assertIsInstance(x, tensor.XLATensor2)
     self.assertIsInstance(y, tensor.XLATensor2)
-    # TODO: remove print
-    print(x, y)
 
 
 if __name__ == "__main__":

--- a/experimental/torch_xla2/test/test_context.py
+++ b/experimental/torch_xla2/test/test_context.py
@@ -1,0 +1,35 @@
+import unittest
+
+import torch
+import torch_xla2
+from torch_xla2 import tensor
+
+
+class TestContext(unittest.TestCase):
+  def test_mode_context_manager(self):
+    with torch_xla2.mode():
+      x = torch.full((3, 3), -1)
+      self.assertIsInstance(x, tensor.XLATensor2)
+      y = x.abs()
+      self.assertIsInstance(y, tensor.XLATensor2)
+      # TODO: remove print
+      print(y)
+
+  @staticmethod
+  @torch_xla2.mode()
+  def _test_mode_decorator():
+    x = torch.full((3, 3), -1)
+    y = x.abs()
+
+    return x, y
+
+  def test_mode_decorator(self):
+    x, y = self._test_mode_decorator()
+    self.assertIsInstance(x, tensor.XLATensor2)
+    self.assertIsInstance(y, tensor.XLATensor2)
+    # TODO: remove print
+    print(x, y)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/experimental/torch_xla2/torch_xla2/__init__.py
+++ b/experimental/torch_xla2/torch_xla2/__init__.py
@@ -1,11 +1,17 @@
+import contextlib
 import jax
 import torch
 from torch._functorch import make_functional
 from torch.utils import _pytree as pytree
-from torch_xla2 import tensor
-from torch_xla2 import export, _ops, ops_registry, tensor, tf_integration
+from torch_xla2 import export, _ops, ops_registry, tensor, tf_integration, functions
 
 jax.config.update('jax_enable_x64', True)
+
+
+@contextlib.contextmanager
+def mode():
+  with tensor.XLADispatchMode(), functions.XLAFunctionMode():
+    yield
 
 
 def extract_jax(mod: torch.nn.Module):

--- a/experimental/torch_xla2/torch_xla2/functions.py
+++ b/experimental/torch_xla2/torch_xla2/functions.py
@@ -103,7 +103,6 @@ class XLAFunctionMode(torch.overrides.TorchFunctionMode):
                          kwargs=None) -> torch.Tensor:
     jax_func = registry.get(func)
     if not jax_func:
-      logging.info(f'Falling back to default implementation of {func.__name__}')
       return func(*args, **(kwargs or {}))
 
     # TODO: unwrap args here or in implementations?

--- a/experimental/torch_xla2/torch_xla2/functions.py
+++ b/experimental/torch_xla2/torch_xla2/functions.py
@@ -103,7 +103,7 @@ class XLAFunctionMode(torch.overrides.TorchFunctionMode):
                          kwargs=None) -> torch.Tensor:
     jax_func = registry.get(func)
     if not jax_func:
-      logging.warning(f'Falling back to default implementation of {func.__name__}')
+      logging.info(f'Falling back to default implementation of {func.__name__}')
       return func(*args, **(kwargs or {}))
 
     # TODO: unwrap args here or in implementations?


### PR DESCRIPTION
See #6874 and #6854

Implement `torch_xla2.mode` to mark code that should use JAX-based lowerings. 

Some other naming ideas:

- `torch_xla2.jax`
- `torch_xla2.lower`