### PR TITLE
Update XLA pin to 04/08/2024

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,9 +50,9 @@ http_archive(
         "//openxla_patches:gpu_race_condition.diff",
         "//openxla_patches:f16_abi_clang.diff",
     ],
-    strip_prefix = "xla-4386e9238b12df5fcba2220e698bf259cbfea27a",
+    strip_prefix = "xla-1acf05ef0d41181caaf0cd691aa9d453ffc41a73",
     urls = [
-        "https://github.com/openxla/xla/archive/4386e9238b12df5fcba2220e698bf259cbfea27a.tar.gz",
+        "https://github.com/openxla/xla/archive/1acf05ef0d41181caaf0cd691aa9d453ffc41a73.tar.gz",
     ],
 )
 

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ import build_util
 
 base_dir = os.path.dirname(os.path.abspath(__file__))
 
-_date = '20240404'
+_date = '20240409'
 _libtpu_version = f'0.1.dev{_date}'
 _libtpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
 _jax_version = f'0.4.27.dev{_date}'


### PR DESCRIPTION
Built locally and confirmed the resnet speed
```
| Training Device=xla:0/3 Epoch=1 Step=240 Loss=0.01353 Rate=1762.14 GlobalRate=301.96 Time=18:24:42
| Training Device=xla:0/2 Epoch=1 Step=240 Loss=0.01353 Rate=1762.21 GlobalRate=294.18 Time=18:24:42
| Training Device=xla:0/0 Epoch=1 Step=240 Loss=0.01353 Rate=1762.38 GlobalRate=292.51 Time=18:24:42
| Training Device=xla:0/0 Epoch=1 Step=260 Loss=0.01169 Rate=1764.01 GlobalRate=312.49 Time=18:24:43
| Training Device=xla:0/2 Epoch=1 Step=260 Loss=0.01169 Rate=1763.95 GlobalRate=314.24 Time=18:24:43
| Training Device=xla:0/3 Epoch=1 Step=260 Loss=0.01169 Rate=1763.93 GlobalRate=322.44 Time=18:24:43
| Training Device=xla:0/1 Epoch=1 Step=260 Loss=0.01169 Rate=1763.76 GlobalRate=315.41 Time=18:24:43
```

also confirmed that pallas testing can run 
```
root@t1v-n-bafa368c-w-0:/workspaces/dk3/pytorch/xla# python test/test_pallas.py 
..........s.....
----------------------------------------------------------------------
Ran 16 tests in 2.701s
```