### PR TITLE
[torch_xla2] Simplify developer setup steps

### DIFF
--- a/experimental/torch_xla2/README.md
+++ b/experimental/torch_xla2/README.md
@@ -4,7 +4,8 @@
 
 Currently this is only source-installable. Requires Python version >= 3.10.
 
-### NOTE: 
+### NOTE:
+
 Please don't install torch-xla from instructions in
 https://github.com/pytorch/xla/blob/master/CONTRIBUTING.md .
 In particular, the following are not needed:
@@ -18,57 +19,44 @@ TorchXLA2 and torch-xla have different installation instructions, please follow
 the instructions below from scratch (fresh venv / conda environment.)
 
 
-### 1. Install dependencies
+### 1. Installing `torch_xla2`
 
-#### 1.0 (optional) Make a virtualenv / conda env, and activate it.
+#### 1.0 (recommended) Make a virtualenv / conda env
+
+If you are using VSCode, then [you can create a new environment from
+UI](https://code.visualstudio.com/docs/python/environments). Select the
+`dev-requirements.txt` when asked to install project dependencies.
+
+Otherwise create a new environment from the command line.
 
 ```bash
-conda create --name <your_name> python=3.10
-conda activate <your_name>
-```
-Or,
-```bash
+# Option 1: venv
 python -m venv create my_venv
 source my_venv/bin/activate
+
+# Option 2: conda
+conda create --name <your_name> python=3.10
+conda activate <your_name>
+
+# Either way, install the dev requirements.
+pip install -r dev-requirements.txt
 ```
 
-#### 1.1 Install torch CPU, even if your device has GPU or TPU:
+Note: `dev-requirements.txt` will install the CPU-only version of PyTorch.
+
+#### 1.1 Install this package
+
+Install `torch_xla2` from source for your platform:
 
 ```bash
-pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+pip install -e .[cpu]
+pip install -e .[cuda]
+pip install -e .[tpu] -f https://storage.googleapis.com/libtpu-releases/index.html
 ```
 
-Or, follow official instructions in [pytorch.org](https://pytorch.org/get-started/locally/) to install for your OS.
-
-#### 1.2 Install Jax for either GPU or TPU
-
-If you are using Google Cloud TPU, then
-```bash
-pip install jax[tpu] -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
-```
-
-If you are using a machine with NVidia GPU:
+#### 1.2 (optional) verify installation by running tests
 
 ```bash
-pip install --upgrade "jax[cuda12_pip]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-```
-
-If you are using a CPU-only machine:
-```bash
-pip install --upgrade "jax[cpu]"
-```
-
-Or, follow the official instructions in https://jax.readthedocs.io/en/latest/installation.html to install for your OS or Device.
-
-#### 1.3 Install this package
-
-```bash
-pip install -e .
-```
-
-#### 1.4 (optional) verify installation by running tests
-
-```bash
-pip install -r test_requirements.txt
+pip install -r test-requirements.txt
 pytest test
 ```

--- a/experimental/torch_xla2/dev-requirements.txt
+++ b/experimental/torch_xla2/dev-requirements.txt
@@ -1,9 +1,8 @@
-absl-py==2.0.0
-flatbuffers==23.5.26
-jax==0.4.23
-jaxlib==0.4.23
-pytest
-tensorflow
+-f https://download.pytorch.org/whl/torch
 torch==2.2.1+cpu
-immutabledict
-sentencepiece
+torchvision
+torchaudio
+torchtext
+ruff~=0.3.5
+pytest
+pytest-xdist

--- a/experimental/torch_xla2/dev-requirements.txt
+++ b/experimental/torch_xla2/dev-requirements.txt
@@ -1,8 +1,3 @@
 -f https://download.pytorch.org/whl/torch
 torch==2.2.1+cpu
-torchvision
-torchaudio
-torchtext
 ruff~=0.3.5
-pytest
-pytest-xdist

--- a/experimental/torch_xla2/pyproject.toml
+++ b/experimental/torch_xla2/pyproject.toml
@@ -2,29 +2,30 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-
 [project]
 version = "0.0.1"
 name = "torch_xla2"
 dependencies = [
     "absl-py",
-    "flatbuffers",
+    "immutabledict",
+    "jax>=0.4.24",
     "pytest",
-    "tensorflow",
-
-    # Note: Exclude these because otherwise on pip install .
-    # pip will install libs from pypi which is the GPU version
-    # of these libs.
-    # We most likely need CPU version of torch and TPU version of 
-    # jax. So it's best for users to install them by hand
-    # See more at README.md
-    # "jax>=0.4.24",
-    # "jaxlib>=0.4.24",
-    # "torch",
+    "tensorflow-cpu",
+    # Developers should use `dev-requirements.txt` first
+    "torch>=2.2.1",
 ]
+requires-python = ">=3.10"
+license = {file = "LICENSE"}
+
+[project.optional-dependencies]
+cpu = ["jax[cpu]"]
+# Add libtpu index `-f https://storage.googleapis.com/libtpu-releases/index.html`
+tpu = ["jax[tpu]"]
+cuda = ["jax[cuda12]"]
 
 [tool.pytest.ini_options]
 addopts="-n auto"
 
-requires-python = ">=3.10"
-license = {file = "LICENSE"}
+[tool.ruff]
+line-length = 80
+indent-width = 2

--- a/experimental/torch_xla2/pyproject.toml
+++ b/experimental/torch_xla2/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "jax>=0.4.24",
     "pytest",
     "tensorflow-cpu",
-    # Developers should use `dev-requirements.txt` first
+    # Developers should install `dev-requirements.txt` first
     "torch>=2.2.1",
 ]
 requires-python = ">=3.10"

--- a/experimental/torch_xla2/test-requirements.txt
+++ b/experimental/torch_xla2/test-requirements.txt
@@ -1,3 +1,5 @@
 -r dev-requirements.txt
+pytest
+pytest-xdist
 sentencepiece
 expecttest

--- a/experimental/torch_xla2/test-requirements.txt
+++ b/experimental/torch_xla2/test-requirements.txt
@@ -1,0 +1,3 @@
+-r dev-requirements.txt
+sentencepiece
+expecttest

--- a/experimental/torch_xla2/test_requirements.txt
+++ b/experimental/torch_xla2/test_requirements.txt
@@ -1,5 +1,0 @@
-pytest
-immutabledict
-sentencepiece
-pytest-xdist
-expecttest


### PR DESCRIPTION
- Add optional dependencies for CPU, CUDA, and TPU. Use `jax[cuda12]` instead of `jax[cuda12_pip]` since it doesn't require an extra index.
- Make use of global options in `requirements.txt`s to install the CPU version of torch automatically.
- Use `tensorflow-cpu` because it's much smaller
- Recommend using VSCode to set up virtual env
- Update package dependencies
- Update name of `test_requirements` to match `dev-requirements`
- Add `ruff` tool setup and adjust to be more like `yapf` settings in main package. `ruff check` shows 42 errors, so we can start fixing these in future PRs.

Tested locally by deleting my old environment and creating a new one with these instructions.