### PR TITLE
Add ansible stage for building CUDA plugin

### DIFF
--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -33,7 +33,7 @@ jobs:
       image: ${{ inputs.dev-image }}
     env:
       GCLOUD_SERVICE_KEY: ${{ secrets.gcloud-service-key }}
-      GOOGLE_APPLICATION_CREDENTIALS: ~/default_credentials.json
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/default_credentials.json
       BAZEL_JOBS: 16
       BAZEL_REMOTE_CACHE: 1
     steps:
@@ -42,7 +42,7 @@ jobs:
       - name: Setup gcloud
         shell: bash
         run: |
-          echo "${GCLOUD_SERVICE_KEY}" > $GOOGLE_APPLICATION_CREDENTIALS}
+          echo "${GCLOUD_SERVICE_KEY}" > $GOOGLE_APPLICATION_CREDENTIALS
       - name: Build
         shell: bash
         run: |

--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -49,7 +49,7 @@ jobs:
         shell: bash
         run: |
           cd pytorch/xla/infra/ansible
-          ansible-playbook playbook.yaml -vvv -e "stage=build_cuda arch=amd64 accelerator=cuda src_root=${GITHUB_WORKSPACE}" --skip-tags=fetch_srcs,install_deps
+          ansible-playbook playbook.yaml -vvv -e "stage=build_plugin arch=amd64 accelerator=cuda src_root=${GITHUB_WORKSPACE}" --skip-tags=fetch_srcs,install_deps
       - name: Upload wheel
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -49,7 +49,7 @@ jobs:
         shell: bash
         run: |
           cd pytorch/xla/infra/ansible
-          ansible-playbook playbook.yaml -e "stage=build_cuda arch=amd64 accelerator=cuda src_root=${GITHUB_WORKSPACE}" --skip-tags=fetch_srcs,install_deps
+          ansible-playbook playbook.yaml -vvv -e "stage=build_cuda arch=amd64 accelerator=cuda src_root=${GITHUB_WORKSPACE}" --skip-tags=fetch_srcs,install_deps
       - name: Upload wheel
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -48,9 +48,10 @@ jobs:
       - name: Build
         shell: bash
         run: |
+          cd pytorch/xla/infra/ansible
           ansible-playbook playbook.yaml -e "stage=build_cuda arch=amd64 accelerator=cuda src_root=${GITHUB_WORKSPACE}" --skip-tags=fetch_srcs,install_deps
       - name: Upload wheel
         uses: actions/upload-artifact@v4
         with:
           name: cuda-plugin
-          path: ${{ github.workspace }}/dist/*.whl
+          path: /dist/*.whl

--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -36,7 +36,8 @@ jobs:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/default_credentials.json
       BAZEL_JOBS: 16
       BAZEL_REMOTE_CACHE: 1
-      TF_CUDA_COMPUTE_CAPABILITIES: sm_50,sm_70,sm_75,compute_80
+      # TODO: Should also come from ansible
+      TF_CUDA_COMPUTE_CAPABILITIES: 7.0,7.5,8.0,9.0
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -36,6 +36,7 @@ jobs:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/default_credentials.json
       BAZEL_JOBS: 16
       BAZEL_REMOTE_CACHE: 1
+      TF_CUDA_COMPUTE_CAPABILITIES: sm_50,sm_70,sm_75,compute_80
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -50,7 +50,8 @@ jobs:
           cd infra/ansible
           # TODO: don't clone everything again
           ansible-playbook playbook.yaml -e "stage=build_cuda arch=amd64 accelerator=cuda" --skip-tags=install_deps
-      - name: actions/upload-artifact@v4
+      - name: Upload wheel
+        uses: actions/upload-artifact@v4
         with:
           name: cuda-plugin
           path: ${GITHUB_WORKSPACE}/dist/*.whl

--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -36,21 +36,19 @@ jobs:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/default_credentials.json
       BAZEL_JOBS: 16
       BAZEL_REMOTE_CACHE: 1
-      # TODO: Should also come from ansible
-      TF_CUDA_COMPUTE_CAPABILITIES: 7.0,7.5,8.0,9.0
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
       - name: Setup gcloud
         shell: bash
         run: |
           echo "${GCLOUD_SERVICE_KEY}" > $GOOGLE_APPLICATION_CREDENTIALS
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          path: pytorch/xla
       - name: Build
         shell: bash
         run: |
-          mkdir dist
-          # TODO: Use current checkout with ansible instead
-          pip wheel --no-deps -w dist -v plugins/cuda
+          ansible-playbook playbook.yaml -e "stage=build_cuda arch=amd64 accelerator=cuda src_root=${GITHUB_WORKSPACE}" --skip-tags=fetch_srcs,install_deps
       - name: Upload wheel
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -31,8 +31,6 @@ jobs:
     runs-on: ${{ inputs.runner }}
     container:
       image: ${{ inputs.dev-image }}
-      volumes:
-      - ${GITHUB_WORKSPACE}/dist/:/dist/
     env:
       GCLOUD_SERVICE_KEY: ${{ secrets.gcloud-service-key }}
       BAZEL_JOBS: 16
@@ -54,4 +52,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: cuda-plugin
-          path: ${GITHUB_WORKSPACE}/dist/*.whl
+          path: /dist/*.whl

--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup gcloud
         shell: bash
         run: |
-          echo "${GCLOUD_SERVICE_KEY}" > "${GOOGLE_APPLICATION_CREDENTIALS}"
+          echo "${GCLOUD_SERVICE_KEY}" > $GOOGLE_APPLICATION_CREDENTIALS}
       - name: Build
         shell: bash
         run: |

--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -41,7 +41,8 @@ jobs:
       - name: Setup gcloud
         shell: bash
         run: |
-          echo "${GCLOUD_SERVICE_KEY}" >> ~/.config/gcloud/application_default_credentials.json
+          mkdir -p $HOME/.config/gcloud/
+          echo "${GCLOUD_SERVICE_KEY}" >> $HOME/.config/gcloud/application_default_credentials.json
       - name: Build
         shell: bash
         run: |

--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup gcloud
         shell: bash
         run: |
-          echo "${GCLOUD_SERVICE_KEY}" >> default_credentials.json
+          echo "${GCLOUD_SERVICE_KEY}" >> ~/.config/gcloud/application_default_credentials.json
       - name: Build
         shell: bash
         run: |

--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -46,11 +46,11 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          cd infra/ansible
-          # TODO: don't clone everything again
-          ansible-playbook playbook.yaml -e "stage=build_cuda arch=amd64 accelerator=cuda" --skip-tags=install_deps
+          mkdir dist
+          # TODO: Use current checkout with ansible instead
+          pip wheel --no-deps -w dist -v plugins/cuda
       - name: Upload wheel
         uses: actions/upload-artifact@v4
         with:
           name: cuda-plugin
-          path: /dist/*.whl
+          path: ${{ github.workspace }}/dist/*.whl

--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -33,6 +33,7 @@ jobs:
       image: ${{ inputs.dev-image }}
     env:
       GCLOUD_SERVICE_KEY: ${{ secrets.gcloud-service-key }}
+      GOOGLE_APPLICATION_CREDENTIALS: ~/default_credentials.json
       BAZEL_JOBS: 16
       BAZEL_REMOTE_CACHE: 1
     steps:
@@ -41,8 +42,7 @@ jobs:
       - name: Setup gcloud
         shell: bash
         run: |
-          mkdir -p $HOME/.config/gcloud/
-          echo "${GCLOUD_SERVICE_KEY}" >> $HOME/.config/gcloud/application_default_credentials.json
+          echo "${GCLOUD_SERVICE_KEY}" > "${GOOGLE_APPLICATION_CREDENTIALS}"
       - name: Build
         shell: bash
         run: |

--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -1,0 +1,56 @@
+name: build-cuda-plugin
+on:
+  workflow_call:
+    inputs:
+      dev-image:
+        required: true
+        type: string
+        description: Base image for builds
+      runner:
+        required: false
+        type: string
+        description: Runner type for the test
+        default: linux.12xlarge
+      cuda:
+        required: false
+        type: string
+        description: Whether to build XLA with CUDA
+        default: 1
+
+    secrets:
+      gcloud-service-key:
+        required: true
+        description: Secret to access Bazel build cache
+
+    outputs:
+      docker-image:
+        value: ${{ jobs.build.outputs.docker-image }}
+        description: The docker image containing the built PyTorch.
+jobs:
+  build:
+    runs-on: ${{ inputs.runner }}
+    container:
+      image: ${{ inputs.dev-image }}
+      volumes:
+      - ${GITHUB_WORKSPACE}/dist/:/dist/
+    env:
+      GCLOUD_SERVICE_KEY: ${{ secrets.gcloud-service-key }}
+      BAZEL_JOBS: 16
+      BAZEL_REMOTE_CACHE: 1
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Setup gcloud
+        shell: bash
+        run: |
+          echo "${GCLOUD_SERVICE_KEY}" >> default_credentials.json
+      - name: Build
+        shell: bash
+        run: |
+          cd infra/ansible
+          # TODO: don't clone everything again
+          ansible-playbook playbook.yaml -e "stage=build_cuda arch=amd64 accelerator=cuda" --skip-tags=install_deps
+      - name: actions/upload-artifact@v4
+        with:
+          name: cuda-plugin
+          path: ${GITHUB_WORKSPACE}/dist/*.whl

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,6 +28,11 @@ jobs:
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
 
+  build-cuda-plugin:
+    name: "Build XLA CUDA plugin"
+    with:
+      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
+
   test-cpu:
     name: "CPU tests"
     uses: ./.github/workflows/_test.yml

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,7 +32,7 @@ jobs:
     name: "Build XLA CUDA plugin"
     uses: ./.github/workflows/_build_plugin.yml
     with:
-      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
+      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.8_cuda_12.1
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,6 +31,7 @@ jobs:
   build-cuda-plugin:
     name: "Build XLA CUDA plugin"
     with:
+      uses: ./.github/workflows/_build_plugin.yml
       dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
 
   test-cpu:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -30,9 +30,11 @@ jobs:
 
   build-cuda-plugin:
     name: "Build XLA CUDA plugin"
+    uses: ./.github/workflows/_build_plugin.yml
     with:
-      uses: ./.github/workflows/_build_plugin.yml
       dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
+    secrets:
+      gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
 
   test-cpu:
     name: "CPU tests"

--- a/infra/ansible/playbook.yaml
+++ b/infra/ansible/playbook.yaml
@@ -16,7 +16,7 @@
           "Pass the required variable with: --e \"{{ item.name }}=<value>\""
       loop:
         - name: stage
-          pattern: ^(build|build_cuda|release)$
+          pattern: ^(build|build_plugin|release)$
         - name: arch
           pattern: ^(aarch64|amd64)$
         - name: accelerator
@@ -73,7 +73,7 @@
         src_root: "/src"
       tags: fetch_srcs
 
-    # TODO: Rename this to e.g. `build_package`
+    # TODO: better name now that there are two builds
     - role: build_srcs
       vars:
         src_root: "/src"
@@ -85,7 +85,7 @@
       when: stage == "build"
       tags: build_srcs
 
-    - role: build_cuda
+    - role: build_plugin
       vars:
         src_root: "/src"
         env_vars: "{{
@@ -93,8 +93,8 @@
             combine(build_env[arch] | default({}, true)) |
             combine(build_env[accelerator] | default({}, true))
           }}"
-      when: stage == "build_cuda"
-      tags: build_cuda
+      when: stage == "build_plugin"
+      tags: build_plugin
 
     - role: configure_env
       vars:

--- a/infra/ansible/playbook.yaml
+++ b/infra/ansible/playbook.yaml
@@ -16,7 +16,7 @@
           "Pass the required variable with: --e \"{{ item.name }}=<value>\""
       loop:
         - name: stage
-          pattern: ^(build|release)$
+          pattern: ^(build|build_cuda|release)$
         - name: arch
           pattern: ^(aarch64|amd64)$
         - name: accelerator
@@ -73,6 +73,7 @@
         src_root: "/src"
       tags: fetch_srcs
 
+    # TODO: Rename this to e.g. `build_package`
     - role: build_srcs
       vars:
         src_root: "/src"
@@ -81,7 +82,19 @@
             combine(build_env[arch] | default({}, true)) |
             combine(build_env[accelerator] | default({}, true))
           }}"
+      when: stage == "build"
       tags: build_srcs
+
+    - role: build_cuda
+      vars:
+        src_root: "/src"
+        env_vars: "{{
+            build_env.common | default({}, true) |
+            combine(build_env[arch] | default({}, true)) |
+            combine(build_env[accelerator] | default({}, true))
+          }}"
+      when: stage == "build_cuda"
+      tags: build_cuda
 
     - role: configure_env
       vars:

--- a/infra/ansible/roles/build_cuda/tasks/main.yaml
+++ b/infra/ansible/roles/build_cuda/tasks/main.yaml
@@ -1,0 +1,23 @@
+- name: Create /dist directory for exported wheels
+  ansible.builtin.file:
+    path: /dist
+    state: directory
+    mode: '0755'
+
+- name: Build PyTorch/XLA CUDA Plugin
+  ansible.builtin.command:
+    cmd: pip wheel -w /dist plugins/cuda -v
+    chdir: "{{ (src_root, 'pytorch/xla') | path_join }}"
+  environment: "{{ env_vars }}"
+  when: accelerator == "cuda"
+
+- name: Find XLA *.whl files in pytorch/xla/dist
+  ansible.builtin.find:
+    path: "/dist"
+    pattern: "torch_xla_cuda_plugin*.whl"
+  register: cuda_plugin_wheels
+
+- name: Install XLA wheels
+  ansible.builtin.pip:
+    name: "{{ cuda_plugin_wheels.files | map(attribute='path') }}"
+    state: "forcereinstall"

--- a/infra/ansible/roles/build_plugin/tasks/main.yaml
+++ b/infra/ansible/roles/build_plugin/tasks/main.yaml
@@ -11,13 +11,13 @@
   environment: "{{ env_vars }}"
   when: accelerator == "cuda"
 
-- name: Find XLA *.whl files in pytorch/xla/dist
+- name: Find plugin *.whl files in pytorch/xla/dist
   ansible.builtin.find:
     path: "/dist"
     pattern: "torch_xla_cuda_plugin*.whl"
-  register: cuda_plugin_wheels
+  register: plugin_wheels
 
-- name: Install XLA wheels
+- name: Install plugin wheels
   ansible.builtin.pip:
-    name: "{{ cuda_plugin_wheels.files | map(attribute='path') }}"
+    name: "{{ plugin_wheels.files | map(attribute='path') }}"
     state: "forcereinstall"

--- a/infra/ansible/roles/build_srcs/tasks/main.yaml
+++ b/infra/ansible/roles/build_srcs/tasks/main.yaml
@@ -23,13 +23,6 @@
     chdir: "{{ (src_root, 'pytorch/xla') | path_join }}"
   environment: "{{ env_vars }}"
 
-- name: Build PyTorch/XLA CUDA Plugin
-  ansible.builtin.command:
-    cmd: pip wheel -w dist plugins/cuda -v
-    chdir: "{{ (src_root, 'pytorch/xla') | path_join }}"
-  environment: "{{ env_vars }}"
-  when: accelerator == "cuda"
-
 - name: Find XLA *.whl files in pytorch/xla/dist
   ansible.builtin.find:
     path: "{{ (src_root, 'pytorch/xla/dist') | path_join }}"

--- a/plugins/cuda/pyproject.toml
+++ b/plugins/cuda/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "numpy"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/plugins/cuda/pyproject.toml
+++ b/plugins/cuda/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torch_xla_cuda_plugin"
-version = "0.0.1"
 authors = [
     {name = "PyTorch/XLA Dev Team", email = "pytorch-xla@googlegroups.com"},
 ]
 description = "PyTorch/XLA CUDA Plugin"
 requires-python = ">=3.8"
+dynamic = ["version"]
 
 [tool.setuptools.package-data]
 torch_xla_cuda_plugin = ["lib/*.so"]

--- a/plugins/cuda/setup.py
+++ b/plugins/cuda/setup.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import sys
 
@@ -10,4 +11,7 @@ import setuptools
 build_util.bazel_build('@xla//xla/pjrt/c:pjrt_c_api_gpu_plugin.so',
                        'torch_xla_cuda_plugin/lib', ['--config=cuda'])
 
-setuptools.setup()
+setuptools.setup(
+  # TODO: Use a common version file
+  version=f'2.4.0.dev{datetime.date.today().strftime("%Y%m%d")}'
+)


### PR DESCRIPTION
- New github action to build plugin. Future actions will consume it. This will not affect other workflows for now.
  - Runs directly in dev container and publishes build artifact through GHA. Click into the workflow and check it out!
![image](https://github.com/pytorch/xla/assets/15197278/13e2af45-096e-4990-b498-eb4b03830e70)
- The main package and CUDA plugin can be built completely separately, so remove the plugin from build.
- Add nightly version tags to CUDA plugin. It should use the same source as the `torch_xla` main package, but this is still better than 0.0.1
- Add `numpy` to the GPU build environment. The latest XLA pin update requires it.

Long term: we can separate the build flow in our CI into two streams. We can build the main `torch_xla` package _without GPU support_, which will be substantially faster. CPU and TPU tests can launch immediately after this. The GPU plugin will build concurrently. Since there are almost never changes to the OpenXLA binary between pin updates, this will be ~instant unless you update or patch XLA. GPU tests will begin when both the main package and plugin are done building.

There is no impact to existing workflows right now.