### PR TITLE
[SPMD] Support manual sharding

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1100,7 +1100,7 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
 
     self.assertEqual(id(mesh), id(expected_mesh))
 
-  def test__mark_manual_sharding(self):
+  def test_mark_manual_sharding(self):
     x = torch.randn(3, 2)
     xx = x.to(xm.xla_device())
     xt = xs._mark_manual_sharding(xx)

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1107,7 +1107,7 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
 
     hlo = torch_xla._XLAC._get_xla_tensors_hlo([xt.global_tensor])
     self.assertIn(
-        '%p0.1 = f32[3,2]{0,1} parameter(0), sharding={manual}',
+        'parameter(0), sharding={manual}',
         hlo)
 
     self.assertEqual(xt.sharding_type, xs.ShardingType.MANUAL)

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1106,9 +1106,7 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
     xt = xs._mark_manual_sharding(xx)
 
     hlo = torch_xla._XLAC._get_xla_tensors_hlo([xt.global_tensor])
-    self.assertIn(
-        'parameter(0), sharding={manual}',
-        hlo)
+    self.assertIn('parameter(0), sharding={manual}', hlo)
 
     self.assertEqual(xt.sharding_type, xs.ShardingType.MANUAL)
     self.assertEqual(xt.sharding_spec, "{manual}")

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2034,45 +2034,44 @@ void InitXlaModuleBindings(py::module m) {
   m.def("_get_local_shards",
         [](const std::vector<at::Tensor>& input)
             -> std::vector<std::vector<std::pair<at::Tensor, std::string>>> {
-          std::vector<runtime::ComputationClient::DataPtr> handles;
-          std::vector<at::ScalarType> element_types;
-          // Find all shard handles for transfer
+          std::vector<std::vector<std::pair<at::Tensor, std::string>>> result;
           for (auto& tensor : input) {
+            // Find all shard handles for transfer
             XLATensorPtr xtensor = bridge::GetXlaTensor(tensor);
             XLA_CHECK(xtensor->GetXlaData() != nullptr)
                 << "Shard data is not available";
-            XLA_CHECK(xtensor->sharding_spec() != nullptr)
+            auto sharding_spec = xtensor->sharding_spec();
+            XLA_CHECK(sharding_spec != nullptr)
                 << "Tensor is not sharded";
             auto handle =
                 std::dynamic_pointer_cast<runtime::ComputationClient::Data>(
                     xtensor->GetXlaData());
             std::vector<runtime::ComputationClient::DataPtr> shard_handles =
                 runtime::GetComputationClient()->GetDataShards(handle);
-            handles.insert(handles.end(), shard_handles.begin(),
-                           shard_handles.end());
+            std::vector<at::ScalarType> element_types;
             element_types.insert(element_types.end(), shard_handles.size(),
                                  MaybeUpcastToHostTorchType(
                                      shard_handles[0]->shape().element_type()));
-          }
+            std::vector<at::Tensor> cpu_shards =
+                XlaDataToTensors(WrapXlaData(shard_handles), element_types);
 
-          std::vector<at::Tensor> cpu_shards =
-              XlaDataToTensors(WrapXlaData(handles), element_types);
-          // Populate the resulting vector of shards and device strings
-          std::vector<std::vector<std::pair<at::Tensor, std::string>>> result;
-          int shards_per_tensor =
-              runtime::GetComputationClient()->GetLocalDevices().size();
-          result.reserve(cpu_shards.size() / shards_per_tensor);
-          for (int i = 0; i < cpu_shards.size(); i += shards_per_tensor) {
+            // Populate the resulting vector of shards and device strings
+            int shards_per_tensor =
+                runtime::GetComputationClient()->GetLocalDevices().size();
+            if (sharding_spec->sharding.type() == xla::OpSharding::MANUAL) {
+              shards_per_tensor = 1;
+            }
             std::vector<std::pair<at::Tensor, std::string>> shard_devices;
             for (int shard = 0; shard < shards_per_tensor; ++shard) {
-              at::Tensor cpu_shard = cpu_shards[i + shard];
-              std::string source_device = handles[i + shard]->device();
+              at::Tensor cpu_shard = cpu_shards[shard];
+              std::string source_device = shard_handles[shard]->device();
               std::pair<at::Tensor, std::string> shard_dev(cpu_shard,
-                                                           source_device);
+                                                          source_device);
               shard_devices.push_back(shard_dev);
             }
             result.push_back(shard_devices);
           }
+
           return result;
         });
   // For each input tensors' local shards, returns the tuple:

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1899,17 +1899,17 @@ void InitXlaModuleBindings(py::module m) {
         [](const at::Tensor& input, xla::OpSharding sharding) {
           ShardingUtil::XlaMarkSharding(input, sharding);
         });
-  m.def("_mark_manual_sharding",
-      [](const at::Tensor& input, xla::OpSharding sharding) {
-        XLATensorPtr xtensor = bridge::GetXlaTensor(input);
-        bool is_ir = xtensor->CurrentIrValue();
-        if (is_ir) {
-          is_ir = !DeviceData::Cast(xtensor->CurrentIrValue().node.get());
-        }
-        XLA_CHECK(is_ir) << "Marking any data tensors as manual is not supported";
+  m.def("_mark_manual_sharding", [](const at::Tensor& input,
+                                    xla::OpSharding sharding) {
+    XLATensorPtr xtensor = bridge::GetXlaTensor(input);
+    bool is_ir = xtensor->CurrentIrValue();
+    if (is_ir) {
+      is_ir = !DeviceData::Cast(xtensor->CurrentIrValue().node.get());
+    }
+    XLA_CHECK(is_ir) << "Marking any data tensors as manual is not supported";
 
-        ShardingUtil::XlaMarkSharding(input, sharding);
-      });
+    ShardingUtil::XlaMarkSharding(input, sharding);
+  });
   m.def("_xla_mark_sharding_dynamo_custom_op",
         [](const at::Tensor& input, const py::list& tile_assignment,
            const py::list& group_assignment, const py::list& replication_groups,

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2041,8 +2041,7 @@ void InitXlaModuleBindings(py::module m) {
             XLA_CHECK(xtensor->GetXlaData() != nullptr)
                 << "Shard data is not available";
             auto sharding_spec = xtensor->sharding_spec();
-            XLA_CHECK(sharding_spec != nullptr)
-                << "Tensor is not sharded";
+            XLA_CHECK(sharding_spec != nullptr) << "Tensor is not sharded";
             auto handle =
                 std::dynamic_pointer_cast<runtime::ComputationClient::Data>(
                     xtensor->GetXlaData());
@@ -2066,7 +2065,7 @@ void InitXlaModuleBindings(py::module m) {
               at::Tensor cpu_shard = cpu_shards[shard];
               std::string source_device = shard_handles[shard]->device();
               std::pair<at::Tensor, std::string> shard_dev(cpu_shard,
-                                                          source_device);
+                                                           source_device);
               shard_devices.push_back(shard_dev);
             }
             result.push_back(shard_devices);

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -304,7 +304,8 @@ std::vector<int64_t> ShardingUtil::GetShardShape(
   auto sharding = shardings->sharding;
   auto global_shape = shardings->shape.dimensions();
   if (sharding.type() == xla::OpSharding::REPLICATED ||
-      sharding.type() == xla::OpSharding::UNKNOWN || sharding.type() == xla::OpSharding::MANUAL) {
+      sharding.type() == xla::OpSharding::UNKNOWN ||
+      sharding.type() == xla::OpSharding::MANUAL) {
     std::vector<int64_t> globalShape;
     globalShape.assign(global_shape.begin(), global_shape.end());
     return globalShape;
@@ -364,7 +365,8 @@ ShardingUtil::GetShardReplicaAndIndicesForDevices(
       devices.size());
   auto tile_shape = sharding.tile_assignment_dimensions();
   if (sharding.type() == xla::OpSharding::REPLICATED ||
-      sharding.type() == xla::OpSharding::UNKNOWN || sharding.type() == xla::OpSharding::MANUAL) {
+      sharding.type() == xla::OpSharding::UNKNOWN ||
+      sharding.type() == xla::OpSharding::MANUAL) {
     // Use Ellipsis to indicate all dimensions are replicated
     auto ellipsis = TensorIndex(Ellipsis);
     auto indices = std::vector<TensorIndex>({ellipsis});
@@ -600,7 +602,9 @@ runtime::ComputationClient::DataPtr ShardingUtil::CreateShardedData(
     const std::vector<at::Tensor>& local_shards,
     const std::vector<std::string>& devices,
     const XLATensor::ShardingSpecPtr& sharding_spec) {
-  XLA_CHECK(local_shards.size() == devices.size() || (sharding_spec->sharding.type() == xla::OpSharding::MANUAL && local_shards.size() == 1))
+  XLA_CHECK(local_shards.size() == devices.size() ||
+            (sharding_spec->sharding.type() == xla::OpSharding::MANUAL &&
+             local_shards.size() == 1))
       << "A device must be speficied for each shard";
   std::vector<std::shared_ptr<const runtime::TensorSource>> source_tensors;
   xla::Shape global_shape;

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -60,7 +60,7 @@ class ShardingUtil {
 
   // Uses the provided `sharding` spec and expected shard shape to determine the
   // index slices for the shards which belong on `devices`. Only supports
-  // `REPLICATED` and `OTHER` sharding types.
+  // `REPLICATED`, `MANUAL` and `OTHER` sharding types.
   // For each input device, returns a pair of the shard's replica_id and a
   // vector of TensorIndex denoting the offset of the device's shard into the
   // global tensor.

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -80,12 +80,13 @@ class ShardingUtil {
   // based on the `sharding` spec. REPLICATED sharding should result in shards
   // identical to the input; OTHERS (tiled) sharding result in shards where
   // each data dimension is sharded across devices along the same dimension in
-  // the `tile_assignment`; MANUAL sharding result in shards where only the first
-  // device holds the full data; the returned tensor shards vector is indexed by the
-  // device IDs. There is no data duplication. Shards are not padded in case the
-  // input tensor is not evenly partitionable, unless `padded` is set.
-  // The the returned tensors will be in 1:1 correspondence with the `devices`
-  // vector, so the `i`th result will belong on the `i`th device.
+  // the `tile_assignment`; MANUAL sharding result in shards where only the
+  // first device holds the full data; the returned tensor shards vector is
+  // indexed by the device IDs. There is no data duplication. Shards are not
+  // padded in case the input tensor is not evenly partitionable, unless
+  // `padded` is set. The the returned tensors will be in 1:1 correspondence
+  // with the `devices` vector, so the `i`th result will belong on the `i`th
+  // device.
   static std::vector<at::Tensor> ShardTensor(
       const at::Tensor& tensor, const XLATensor::ShardingSpecPtr shardings,
       const std::vector<std::string>& devices, bool padded = true);

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -60,7 +60,7 @@ class ShardingUtil {
 
   // Uses the provided `sharding` spec and expected shard shape to determine the
   // index slices for the shards which belong on `devices`. Only supports
-  // `REPLICATED`, `MANUAL` and `OTHER` sharding types.
+  // `REPLICATED` and `OTHER` sharding types.
   // For each input device, returns a pair of the shard's replica_id and a
   // vector of TensorIndex denoting the offset of the device's shard into the
   // global tensor.
@@ -80,8 +80,7 @@ class ShardingUtil {
   // based on the `sharding` spec. REPLICATED sharding should result in shards
   // identical to the input; OTHERS (tiled) sharding result in shards where
   // each data dimension is sharded across devices along the same dimension in
-  // the `tile_assignment`; MANUAL sharding result in shards where only the
-  // first device holds the full data; the returned tensor shards vector is
+  // the `tile_assignment`; the returned tensor shards vector is
   // indexed by the device IDs. There is no data duplication. Shards are not
   // padded in case the input tensor is not evenly partitionable, unless
   // `padded` is set. The the returned tensors will be in 1:1 correspondence

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -80,7 +80,8 @@ class ShardingUtil {
   // based on the `sharding` spec. REPLICATED sharding should result in shards
   // identical to the input; OTHERS (tiled) sharding result in shards where
   // each data dimension is sharded across devices along the same dimension in
-  // the `tile_assignment`; the returned tensor shards vector is indexed by the
+  // the `tile_assignment`; MANUAL sharding result in shards where only the first
+  // device holds the full data; the returned tensor shards vector is indexed by the
   // device IDs. There is no data duplication. Shards are not padded in case the
   // input tensor is not evenly partitionable, unless `padded` is set.
   // The the returned tensors will be in 1:1 correspondence with the `devices`

--- a/torch_xla/distributed/spmd/__init__.py
+++ b/torch_xla/distributed/spmd/__init__.py
@@ -2,7 +2,8 @@ from .xla_sharded_tensor import XLAShard, XLAShardedTensor
 from .xla_sharding import (Mesh, HybridMesh, ShardingType, ShardingSpec,
                            XLAPatchedLinear, mark_sharding, clear_sharding,
                            wrap_if_sharded, xla_patched_nn_linear_forward,
-                           set_global_mesh, get_global_mesh, _mark_manual_sharding)
+                           set_global_mesh, get_global_mesh,
+                           _mark_manual_sharding)
 from .api import xla_distribute_tensor, xla_distribute_module, auto_policy
 
 __all__ = [

--- a/torch_xla/distributed/spmd/__init__.py
+++ b/torch_xla/distributed/spmd/__init__.py
@@ -2,7 +2,7 @@ from .xla_sharded_tensor import XLAShard, XLAShardedTensor
 from .xla_sharding import (Mesh, HybridMesh, ShardingType, ShardingSpec,
                            XLAPatchedLinear, mark_sharding, clear_sharding,
                            wrap_if_sharded, xla_patched_nn_linear_forward,
-                           set_global_mesh, get_global_mesh)
+                           set_global_mesh, get_global_mesh, _mark_manual_sharding)
 from .api import xla_distribute_tensor, xla_distribute_module, auto_policy
 
 __all__ = [
@@ -22,4 +22,5 @@ __all__ = [
     "xla_patched_nn_linear_forward",
     "set_global_mesh",
     "get_global_mesh",
+    "_mark_manual_sharding",
 ]

--- a/torch_xla/distributed/spmd/xla_sharding.py
+++ b/torch_xla/distributed/spmd/xla_sharding.py
@@ -476,8 +476,12 @@ def _translate_named_partition_spec(mesh: Mesh, partition_spec: Tuple):
 
 def _mark_manual_sharding(
     t: Union[torch.Tensor, XLAShardedTensor]) -> XLAShardedTensor:
+  """
+  This API is meant to be paired with the upcoming pause_spmd&resume_spmd APIs.
+  Don't use it alone.
+  """
   manual_sharding = torch_xla._XLAC.OpSharding([], [], [], ShardingType.MANUAL)
-  torch_xla._XLAC._xla_mark_sharding(unwrap_sharded_tensor(t), manual_sharding)
+  torch_xla._XLAC._mark_manual_sharding(unwrap_sharded_tensor(t), manual_sharding)
   return wrap_as_sharded_tensor(t)
 
 

--- a/torch_xla/distributed/spmd/xla_sharding.py
+++ b/torch_xla/distributed/spmd/xla_sharding.py
@@ -481,7 +481,8 @@ def _mark_manual_sharding(
   Don't use it alone.
   """
   manual_sharding = torch_xla._XLAC.OpSharding([], [], [], ShardingType.MANUAL)
-  torch_xla._XLAC._mark_manual_sharding(unwrap_sharded_tensor(t), manual_sharding)
+  torch_xla._XLAC._mark_manual_sharding(
+      unwrap_sharded_tensor(t), manual_sharding)
   return wrap_as_sharded_tensor(t)
 
 

--- a/torch_xla/distributed/spmd/xla_sharding.py
+++ b/torch_xla/distributed/spmd/xla_sharding.py
@@ -474,6 +474,12 @@ def _translate_named_partition_spec(mesh: Mesh, partition_spec: Tuple):
   return tuple(_partition_spec)
 
 
+def _mark_manual_sharding(t: Union[torch.Tensor, XLAShardedTensor]) -> XLAShardedTensor:
+  manual_sharding = torch_xla._XLAC.OpSharding([], [], [], ShardingType.MANUAL)
+  torch_xla._XLAC._xla_mark_sharding(unwrap_sharded_tensor(t), manual_sharding)
+  return wrap_as_sharded_tensor(t)
+
+
 @xr.requires_pjrt
 def mark_sharding(t: Union[torch.Tensor, XLAShardedTensor],
                   mesh: Mesh,

--- a/torch_xla/distributed/spmd/xla_sharding.py
+++ b/torch_xla/distributed/spmd/xla_sharding.py
@@ -474,7 +474,8 @@ def _translate_named_partition_spec(mesh: Mesh, partition_spec: Tuple):
   return tuple(_partition_spec)
 
 
-def _mark_manual_sharding(t: Union[torch.Tensor, XLAShardedTensor]) -> XLAShardedTensor:
+def _mark_manual_sharding(
+    t: Union[torch.Tensor, XLAShardedTensor]) -> XLAShardedTensor:
   manual_sharding = torch_xla._XLAC.OpSharding([], [], [], ShardingType.MANUAL)
   torch_xla._XLAC._xla_mark_sharding(unwrap_sharded_tensor(t), manual_sharding)
   return wrap_as_sharded_tensor(t)


### PR DESCRIPTION
Summary:
This pull request makes SPMD support the manual sharding type via a new private API called: _mark_manual_sharding. I don't expect users will need to call this function explicitly.

Besides adding support for the sharding annotation, we also need to define the behavior of the data shards. For data, the current behavior is error out.

Test Plan:
PJRT_DEVICE=TPU python test/spmd/test_xla_sharding.py -v -k test__mark_manual_sharding