### PR TITLE
Build plugin during nightly build

### DIFF
--- a/infra/ansible/Dockerfile
+++ b/infra/ansible/Dockerfile
@@ -9,6 +9,7 @@ COPY . /ansible
 
 ARG ansible_vars
 RUN ansible-playbook -vvv playbook.yaml -e "stage=build" -e "${ansible_vars}"
+RUN ansible-playbook -vvv playbook.yaml -e "stage=build_plugin" -e "${ansible_vars}"
 
 FROM python:${python_version}-${debian_version} AS release
 

--- a/infra/ansible/Dockerfile
+++ b/infra/ansible/Dockerfile
@@ -9,7 +9,7 @@ COPY . /ansible
 
 ARG ansible_vars
 RUN ansible-playbook -vvv playbook.yaml -e "stage=build" -e "${ansible_vars}"
-RUN ansible-playbook -vvv playbook.yaml -e "stage=build_plugin" -e "${ansible_vars}"
+RUN ansible-playbook -vvv playbook.yaml -e "stage=build_plugin" -e "${ansible_vars}" --skip-tags=fetch_srcs,install_deps
 
 FROM python:${python_version}-${debian_version} AS release
 

--- a/infra/ansible/e2e_tests.Dockerfile
+++ b/infra/ansible/e2e_tests.Dockerfile
@@ -10,6 +10,7 @@ COPY . /ansible
 # Build PyTorch and PyTorch/XLA wheels.
 ARG ansible_vars
 RUN ansible-playbook -vvv playbook.yaml -e "stage=build" -e "${ansible_vars}"
+RUN ansible-playbook -vvv playbook.yaml -e "stage=build_plugin" -e "${ansible_vars}"
 
 FROM python:${python_version}-${debian_version}
 WORKDIR /ansible

--- a/infra/ansible/e2e_tests.Dockerfile
+++ b/infra/ansible/e2e_tests.Dockerfile
@@ -10,7 +10,7 @@ COPY . /ansible
 # Build PyTorch and PyTorch/XLA wheels.
 ARG ansible_vars
 RUN ansible-playbook -vvv playbook.yaml -e "stage=build" -e "${ansible_vars}"
-RUN ansible-playbook -vvv playbook.yaml -e "stage=build_plugin" -e "${ansible_vars}"
+RUN ansible-playbook -vvv playbook.yaml -e "stage=build_plugin" -e "${ansible_vars}" --skip-tags=fetch_srcs,install_deps
 
 FROM python:${python_version}-${debian_version}
 WORKDIR /ansible

--- a/infra/ansible/roles/build_plugin/tasks/main.yaml
+++ b/infra/ansible/roles/build_plugin/tasks/main.yaml
@@ -11,13 +11,22 @@
   environment: "{{ env_vars }}"
   when: accelerator == "cuda"
 
-- name: Find plugin *.whl files in pytorch/xla/dist
+- name: Find CUDA plugin wheel pytorch/xla/dist
   ansible.builtin.find:
     path: "/dist"
     pattern: "torch_xla_cuda_plugin*.whl"
+  when: accelerator == "cuda"
   register: plugin_wheels
 
-- name: Install plugin wheels
+- name: Install CUDA plugin wheels
   ansible.builtin.pip:
     name: "{{ plugin_wheels.files | map(attribute='path') }}"
     state: "forcereinstall"
+  when: accelerator == "cuda"
+
+# TODO: Pass libtpu to next release stage somehow. This only runs during build
+- name: Install libtpu
+  ansible.builtin.pip:
+    name: torch_xla[tpu]
+    extra_args: -f https://storage.googleapis.com/libtpu-releases/index.html
+  when: accelerator == "tpuvm"

--- a/plugins/cuda/setup.py
+++ b/plugins/cuda/setup.py
@@ -13,5 +13,7 @@ build_util.bazel_build('@xla//xla/pjrt/c:pjrt_c_api_gpu_plugin.so',
 
 setuptools.setup(
   # TODO: Use a common version file
-  version=f'2.4.0.dev{datetime.date.today().strftime("%Y%m%d")}'
+  version=os.getenv(
+      'TORCH_XLA_VERSION',
+      f'2.4.0.dev{datetime.date.today().strftime("%Y%m%d")}')
 )


### PR DESCRIPTION
- Add `build_plugin` phase to docker images so GPU plugin actually gets built
- Install libtpu during `tpu` build for consistency with GPU
  - Unfortunately doesn't solve problem of installing libtpu in the release image. That needs some extra plumbing.
- Prefer `TORCH_XLA_VERSION` set by Cloud Build for GPU plugin version

Tested locally to confirm TPU build doesn't break: `ansible-playbook playbook.yaml -vvv -e "stage=build arch=amd64 accelerator=tpu src_root=/workspaces/work bundle_libtpu=0" --skip-tags=fetch_srcs,install_deps`

Check CI for GPU plugin build.

