### PR TITLE
Add a devcontainer for gpu dev

### DIFF
--- a/.devcontainer/gpu-internal/devcontainer.json
+++ b/.devcontainer/gpu-internal/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "name": "gpu-internal",
+  "image": "us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.8_cuda_12.1",
+  "runArgs": [
+    "--gpus=all",
+    "--net=host",
+    "--shm-size=16G"
+  ],
+  "containerEnv": {
+    "BAZEL_REMOTE_CACHE": "1",
+    "SILO_NAME": "cache-silo-${localEnv:USER}-gpuvm"
+  },
+  "initializeCommand": "docker pull us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.8_cuda_12.1",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "llvm-vs-code-extensions.vscode-clangd",
+        "ms-vscode.cpptools-themes",
+        "BazelBuild.vscode-bazel",
+        "DevonDCarew.bazel-code",
+        "StackBuild.bazel-stack-vscode",
+        "StackBuild.bazel-stack-vscode-cc",
+        "xaver.clang-format",
+        "ryanluker.vscode-coverage-gutters",
+        "ms-azuretools.vscode-docker",
+        "ms-python.python"
+      ]
+    }
+  }
+}

--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -64,8 +64,8 @@ Thu Dec  8 06:24:29 2022
 Make sure `PATH` and `LD_LIBRARY_PATH` environment variables account for cuda. Please do a `echo $PATH` and `echo $LD_LIBRARY_PATH` to verify. If not, please follow [link](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#mandatory-actions) to do so. Example:
 
 ```
-echo "export PATH=/usr/local/cuda-12.1/bin${PATH:+:${PATH}}" >> ~/.bashrc
-echo "export LD_LIBRARY_PATH=/usr/local/cuda-12.1/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" >> ~/.bashrc
+echo "export PATH=\$PATH:/usr/local/cuda-12.1/bin" >> ~/.bashrc
+echo "export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/usr/local/cuda-12.1/lib64" >> ~/.bashrc
 source ~/.bashrc
 ```
 


### PR DESCRIPTION
I think we should have a 3.10 dev image too. 3.8 is too old.