### PR TITLE
[SPMD] Support SPMDShardToFullShape

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1163,7 +1163,6 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
     with self.assertRaises(RuntimeError):
       x = torch_xla._XLAC._spmd_shard_to_full_shape(xt.global_tensor, torch_xla._XLAC.OpSharding([], [], [], xs.ShardingType.REPLICATED), x.shape, x.dtype)
 
-
     xs.clear_sharding(xt)
     xt = xs._mark_manual_sharding(xt)
     xx = torch_xla._XLAC._spmd_shard_to_full_shape(xt.global_tensor, torch_xla._XLAC.OpSharding([], [], [], xs.ShardingType.REPLICATED), x.shape, x.dtype)

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1156,16 +1156,24 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
     x += 1
     # No sharding spec attached.
     with self.assertRaises(RuntimeError):
-      x = torch_xla._XLAC._spmd_shard_to_full_shape(x, torch_xla._XLAC.OpSharding([], [], [], xs.ShardingType.REPLICATED), x.shape, x.dtype)
+      x = torch_xla._XLAC._spmd_shard_to_full_shape(
+          x, torch_xla._XLAC.OpSharding([], [], [], xs.ShardingType.REPLICATED),
+          x.shape, x.dtype)
 
     xt = xs.mark_sharding(x, self._get_mesh((1, self.n_devices)), (0, 1))
     # Not manual sharding.
     with self.assertRaises(RuntimeError):
-      x = torch_xla._XLAC._spmd_shard_to_full_shape(xt.global_tensor, torch_xla._XLAC.OpSharding([], [], [], xs.ShardingType.REPLICATED), x.shape, x.dtype)
+      x = torch_xla._XLAC._spmd_shard_to_full_shape(
+          xt.global_tensor,
+          torch_xla._XLAC.OpSharding([], [], [], xs.ShardingType.REPLICATED),
+          x.shape, x.dtype)
 
     xs.clear_sharding(xt)
     xt = xs._mark_manual_sharding(xt)
-    xx = torch_xla._XLAC._spmd_shard_to_full_shape(xt.global_tensor, torch_xla._XLAC.OpSharding([], [], [], xs.ShardingType.REPLICATED), x.shape, x.dtype)
+    xx = torch_xla._XLAC._spmd_shard_to_full_shape(
+        xt.global_tensor,
+        torch_xla._XLAC.OpSharding([], [], [], xs.ShardingType.REPLICATED),
+        x.shape, x.dtype)
 
     hlo = torch_xla._XLAC._get_xla_tensors_hlo([xx])
     self.assertEqual(xx.shape, x.shape)
@@ -1185,7 +1193,9 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
 
     xx = xx + 1
     xxt = xs._mark_manual_sharding(xx)
-    xxx = torch_xla._XLAC._spmd_shard_to_full_shape(xxt.global_tensor, mesh.get_op_sharding(partition_spec), x.shape, x.dtype)
+    xxx = torch_xla._XLAC._spmd_shard_to_full_shape(
+        xxt.global_tensor, mesh.get_op_sharding(partition_spec), x.shape,
+        x.dtype)
     self.assertEqual(xxx.shape, (8, 8))
 
     self.assertTrue(torch.allclose(x.cpu() + 1, xxx.cpu()))

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1966,6 +1966,22 @@ void InitXlaModuleBindings(py::module m) {
         xla::HloSharding::Manual().ToProto(), shard_shape));
     return bridge::AtenFromXlaTensor(output);
   });
+  m.def("_spmd_shard_to_full_shape", [](const at::Tensor& input, const xla::OpSharding& sharding, const std::vector<int64_t>& output_shape, const py::object& output_dtype) -> at::Tensor {
+    XLATensorPtr xtensor = bridge::GetXlaTensor(input);
+    auto sharding_spec = xtensor->sharding_spec();
+    XLA_CHECK(sharding_spec != nullptr && sharding_spec->sharding.type() == xla::OpSharding::MANUAL) << "Input tensor is not manual sharded";
+
+
+    auto full_shape = xla::ShapeUtil::MakeShape(
+        MakeXlaPrimitiveType(reinterpret_cast<THPDtype*>(output_dtype.ptr())->scalar_type, &(xtensor->GetDevice())),
+        output_shape);
+    auto output = xtensor->CreateFrom(torch::lazy::MakeNode<CustomSharding>(
+        xtensor->GetIrValue(), full_shape,
+        CustomSharding::Type::kSPMDShardToFullShape));
+    output->SetShardingSpec(XLATensor::ShardingSpec(
+        sharding, full_shape));
+    return bridge::AtenFromXlaTensor(output);
+  });
   m.def("_xla_mark_sharding_dynamo_custom_op",
         [](const at::Tensor& input, const py::list& tile_assignment,
            const py::list& group_assignment, const py::list& replication_groups,

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1966,22 +1966,28 @@ void InitXlaModuleBindings(py::module m) {
         xla::HloSharding::Manual().ToProto(), shard_shape));
     return bridge::AtenFromXlaTensor(output);
   });
-  m.def("_spmd_shard_to_full_shape", [](const at::Tensor& input, const xla::OpSharding& sharding, const std::vector<int64_t>& output_shape, const py::object& output_dtype) -> at::Tensor {
-    XLATensorPtr xtensor = bridge::GetXlaTensor(input);
-    auto sharding_spec = xtensor->sharding_spec();
-    XLA_CHECK(sharding_spec != nullptr && sharding_spec->sharding.type() == xla::OpSharding::MANUAL) << "Input tensor is not manual sharded";
+  m.def(
+      "_spmd_shard_to_full_shape",
+      [](const at::Tensor& input, const xla::OpSharding& sharding,
+         const std::vector<int64_t>& output_shape,
+         const py::object& output_dtype) -> at::Tensor {
+        XLATensorPtr xtensor = bridge::GetXlaTensor(input);
+        auto sharding_spec = xtensor->sharding_spec();
+        XLA_CHECK(sharding_spec != nullptr &&
+                  sharding_spec->sharding.type() == xla::OpSharding::MANUAL)
+            << "Input tensor is not manual sharded";
 
-
-    auto full_shape = xla::ShapeUtil::MakeShape(
-        MakeXlaPrimitiveType(reinterpret_cast<THPDtype*>(output_dtype.ptr())->scalar_type, &(xtensor->GetDevice())),
-        output_shape);
-    auto output = xtensor->CreateFrom(torch::lazy::MakeNode<CustomSharding>(
-        xtensor->GetIrValue(), full_shape,
-        CustomSharding::Type::kSPMDShardToFullShape));
-    output->SetShardingSpec(XLATensor::ShardingSpec(
-        sharding, full_shape));
-    return bridge::AtenFromXlaTensor(output);
-  });
+        auto full_shape = xla::ShapeUtil::MakeShape(
+            MakeXlaPrimitiveType(
+                reinterpret_cast<THPDtype*>(output_dtype.ptr())->scalar_type,
+                &(xtensor->GetDevice())),
+            output_shape);
+        auto output = xtensor->CreateFrom(torch::lazy::MakeNode<CustomSharding>(
+            xtensor->GetIrValue(), full_shape,
+            CustomSharding::Type::kSPMDShardToFullShape));
+        output->SetShardingSpec(XLATensor::ShardingSpec(sharding, full_shape));
+        return bridge::AtenFromXlaTensor(output);
+      });
   m.def("_xla_mark_sharding_dynamo_custom_op",
         [](const at::Tensor& input, const py::list& tile_assignment,
            const py::list& group_assignment, const py::list& replication_groups,

--- a/torch_xla/distributed/spmd/xla_sharding.py
+++ b/torch_xla/distributed/spmd/xla_sharding.py
@@ -553,7 +553,7 @@ def mark_sharding(t: Union[torch.Tensor, XLAShardedTensor],
 
 def clear_sharding(t: Union[torch.Tensor, XLAShardedTensor]) -> torch.Tensor:
   """Clear sharding annotation from the input tensor and return a `cpu` casted tensor."""
-  torch_xla._XLAC._xla_clear_sharding(t)
+  torch_xla._XLAC._xla_clear_sharding(unwrap_sharded_tensor(t))
   if isinstance(t, XLAShardedTensor):
     return t.global_tensor
   return t


### PR DESCRIPTION
Summary:
This pull request enables SPMDShardToFullShape. The trickiest part is how to get the full shape, and here is a couple of options:
- [ ] Bookkeeping the shape full shape that enters SPMDFullToShardShape. This is not selected given the output could be created on the fly.
- [ ] Constructing the full shape from the local shard and the sharding spec. This is not selected given there is no way to deal with the padding. We can't examine the data during the tracing time.
- [x] Let users pass the full shape in. This is selected because it's just the most sounded path.

Tes Plan:
PJRT_DEVICE=TPU python test/spmd/test_xla_sharding.py -v -k test_manual_sharding_e2e -k test_spmd_shard_to_full_shape