### PR TITLE
Update CUDA 12.1 dev image to python 3.10

### DIFF
--- a/infra/tpu-pytorch-releases/dev_images.auto.tfvars
+++ b/infra/tpu-pytorch-releases/dev_images.auto.tfvars
@@ -6,13 +6,9 @@ dev_images = [
   },
   {
     accelerator  = "cuda"
-    cuda_version = "11.8"
-    extra_tags   = ["cuda"]
-  },
-  {
-    accelerator  = "cuda"
     cuda_version = "12.1"
     extra_tags   = ["cuda"]
+    python_version = "3.10"
   },
   {
     accelerator  = "cuda"


### PR DESCRIPTION
Remove CUDA 11.8 build. I don't expect we need to update this image again. Existing builds/tags will remain.