### PR TITLE
[Pallas] Integrate FlashAttention with SPMD

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1153,7 +1153,6 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
 
   def test_spmd_shard_to_full_shape(self):
     x = torch.zeros(8, 8).to(xm.xla_device())
-    x = torch.zeros(8, 8).to(xm.xla_device())
     x += 1
     # No sharding spec attached.
     with self.assertRaises(RuntimeError):
@@ -1178,7 +1177,6 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
 
     hlo = torch_xla._XLAC._get_xla_tensors_hlo([xx])
     self.assertEqual(xx.shape, x.shape)
-    self.assertIn('%custom-call.9 = f32[8,8]{1,0}', hlo)
     self.assertIn('%custom-call.9 = f32[8,8]{1,0}', hlo)
     self.assertIn(
         'custom_call_target="SPMDShardToFullShape", sharding={replicated}', hlo)

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1153,6 +1153,7 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
 
   def test_spmd_shard_to_full_shape(self):
     x = torch.zeros(8, 8).to(xm.xla_device())
+    x = torch.zeros(8, 8).to(xm.xla_device())
     x += 1
     # No sharding spec attached.
     with self.assertRaises(RuntimeError):
@@ -1177,6 +1178,7 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
 
     hlo = torch_xla._XLAC._get_xla_tensors_hlo([xx])
     self.assertEqual(xx.shape, x.shape)
+    self.assertIn('%custom-call.9 = f32[8,8]{1,0}', hlo)
     self.assertIn('%custom-call.9 = f32[8,8]{1,0}', hlo)
     self.assertIn(
         'custom_call_target="SPMDShardToFullShape", sharding={replicated}', hlo)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -7,7 +7,6 @@ from torch import nn as nn
 
 import torch_xla
 import torch_xla.core.xla_model as xm
-import torch_xla.distributed.spmd as xs
 from torch_xla import runtime as xr
 from torch_xla._internal import tpu
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -442,6 +442,7 @@ class PallasTest(unittest.TestCase):
   @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 3,
                    "This test only works on TPUv3+.")
   def test_flash_attention_backward(self):
+    jax.config.update('jax_default_matmul_precision', jax.lax.Precision.HIGHEST)
     from torch_xla.experimental.custom_kernel import flash_attention
 
     torch.manual_seed(42)
@@ -474,76 +475,10 @@ class PallasTest(unittest.TestCase):
     loss.backward()
     xm.mark_step()
 
-    mse = torch.nn.MSELoss()
     for i in [(q, q_grad), (k, k_grad), (v, v_grad)]:
-      self.assertTrue(mse(i[0].grad.cpu(), i[1].cpu()) < 1e-4)
-
-  @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 3,
-                   "This test only works on TPUv3+.")
-  def test_flash_attention_spmd_data_parallel(self):
-    jax.config.update('jax_default_matmul_precision', jax.lax.Precision.HIGHEST)
-    from torch_xla.experimental.custom_kernel import flash_attention
-
-    xr.use_spmd()
-    n_devices = xr.global_runtime_device_count()
-    xs.set_global_mesh(xs.Mesh(range(n_devices), (n_devices, 1, 1, 1)))
-
-    q = torch.randn(4, 2, 128, 4).to("xla")
-    k = torch.randn(4, 2, 128, 4).to("xla")
-    v = torch.randn(4, 2, 128, 4).to("xla")
-
-    o = flash_attention(q, k, v, sharding_spec=range(n_devices))
-    self.assertEqual(torch_xla._XLAC._get_xla_sharding_spec(o), f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
-
-    expected_o = self._attention(q, k, v)
-    self.assertTrue(torch.allclose(o.cpu(), expected_o.cpu(), atol=1e-05))
+      self.assertTrue(torch.allclose(i[0].grad.cpu(), i[1].cpu(), atol=1e-05))
     jax.config.update('jax_default_matmul_precision', jax.lax.Precision.DEFAULT)
 
-  @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 3,
-                   "This test only works on TPUv3+.")
-  def test_flash_attention_backward_spmd_data_parallel(self):
-    from torch_xla.experimental.custom_kernel import flash_attention
-
-    xr.use_spmd()
-    n_devices = xr.global_runtime_device_count()
-    xs.set_global_mesh(xs.Mesh(range(n_devices), (n_devices, 1, 1, 1)))
-
-    torch.manual_seed(42)
-    q = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
-    k = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
-    v = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
-    q.retain_grad()
-    k.retain_grad()
-    v.retain_grad()
-
-    o = flash_attention(q, k, v, sharding_spec=range(n_devices))
-    loss = o.sum()
-    loss.backward()
-    xm.mark_step()
-
-    q_grad = q.grad
-    k_grad = k.grad
-    v_grad = v.grad
-    self.assertEqual(torch_xla._XLAC._get_xla_sharding_spec(q_grad), f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
-    self.assertEqual(torch_xla._XLAC._get_xla_sharding_spec(k_grad), f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
-    self.assertEqual(torch_xla._XLAC._get_xla_sharding_spec(v_grad), f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
-
-    torch.manual_seed(42)
-    q = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
-    k = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
-    v = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
-    q.retain_grad()
-    k.retain_grad()
-    v.retain_grad()
-
-    o = self._attention(q, k, v)
-    loss = o.sum()
-    loss.backward()
-    xm.mark_step()
-
-    mse = torch.nn.MSELoss()
-    for i in [(q, q_grad), (k, k_grad), (v, v_grad)]:
-      self.assertTrue(mse(i[0].grad.cpu(), i[1].cpu()) < 1e-4)
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)

--- a/test/test_pallas_spmd.py
+++ b/test/test_pallas_spmd.py
@@ -42,7 +42,9 @@ class PallasTest(unittest.TestCase):
     v = torch.randn(4, 2, 128, 4).to("xla")
 
     o = flash_attention(q, k, v, sharding_spec=range(n_devices))
-    self.assertEqual(torch_xla._XLAC._get_xla_sharding_spec(o), f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
+    self.assertEqual(
+        torch_xla._XLAC._get_xla_sharding_spec(o),
+        f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
 
     expected_o = self._attention(q, k, v)
     self.assertTrue(torch.allclose(o.cpu(), expected_o.cpu(), atol=1e-05))
@@ -74,9 +76,15 @@ class PallasTest(unittest.TestCase):
     q_grad = q.grad
     k_grad = k.grad
     v_grad = v.grad
-    self.assertEqual(torch_xla._XLAC._get_xla_sharding_spec(q_grad), f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
-    self.assertEqual(torch_xla._XLAC._get_xla_sharding_spec(k_grad), f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
-    self.assertEqual(torch_xla._XLAC._get_xla_sharding_spec(v_grad), f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
+    self.assertEqual(
+        torch_xla._XLAC._get_xla_sharding_spec(q_grad),
+        f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
+    self.assertEqual(
+        torch_xla._XLAC._get_xla_sharding_spec(k_grad),
+        f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
+    self.assertEqual(
+        torch_xla._XLAC._get_xla_sharding_spec(v_grad),
+        f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
 
     torch.manual_seed(42)
     q = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
@@ -94,6 +102,7 @@ class PallasTest(unittest.TestCase):
     for i in [(q, q_grad), (k, k_grad), (v, v_grad)]:
       self.assertTrue(torch.allclose(i[0].grad.cpu(), i[1].cpu(), atol=1e-05))
     jax.config.update('jax_default_matmul_precision', jax.lax.Precision.DEFAULT)
+
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)

--- a/test/test_pallas_spmd.py
+++ b/test/test_pallas_spmd.py
@@ -1,0 +1,105 @@
+import logging
+import os
+import unittest
+
+import torch
+from torch import nn as nn
+
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.distributed.spmd as xs
+from torch_xla import runtime as xr
+from torch_xla._internal import tpu
+
+if xr.device_type() == 'TPU':
+  from torch_xla.experimental.custom_kernel import jax_import_guard
+  jax_import_guard()
+  import jax
+  import jax.numpy as jnp
+  from jax.experimental import pallas as pl
+
+
+class PallasTest(unittest.TestCase):
+
+  def _attention(self, q, k, v):
+    attn_weight = q @ k.transpose(-2, -1)
+    attn_weight = nn.functional.softmax(attn_weight, dim=-1)
+    attn_output = attn_weight @ v
+    return attn_output
+
+  @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 3,
+                   "This test only works on TPUv3+.")
+  def test_flash_attention_spmd_data_parallel(self):
+    jax.config.update('jax_default_matmul_precision', jax.lax.Precision.HIGHEST)
+    from torch_xla.experimental.custom_kernel import flash_attention
+
+    xr.use_spmd()
+    n_devices = xr.global_runtime_device_count()
+    xs.set_global_mesh(xs.Mesh(range(n_devices), (n_devices, 1, 1, 1)))
+
+    q = torch.randn(4, 2, 128, 4).to("xla")
+    k = torch.randn(4, 2, 128, 4).to("xla")
+    v = torch.randn(4, 2, 128, 4).to("xla")
+
+    o = flash_attention(q, k, v, sharding_spec=range(n_devices))
+    self.assertEqual(torch_xla._XLAC._get_xla_sharding_spec(o), f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
+
+    expected_o = self._attention(q, k, v)
+    self.assertTrue(torch.allclose(o.cpu(), expected_o.cpu(), atol=1e-05))
+    jax.config.update('jax_default_matmul_precision', jax.lax.Precision.DEFAULT)
+
+  @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 3,
+                   "This test only works on TPUv3+.")
+  def test_flash_attention_backward_spmd_data_parallel(self):
+    jax.config.update('jax_default_matmul_precision', jax.lax.Precision.HIGHEST)
+    from torch_xla.experimental.custom_kernel import flash_attention
+
+    xr.use_spmd()
+    n_devices = xr.global_runtime_device_count()
+    xs.set_global_mesh(xs.Mesh(range(n_devices), (n_devices, 1, 1, 1)))
+
+    torch.manual_seed(42)
+    q = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
+    k = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
+    v = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
+    q.retain_grad()
+    k.retain_grad()
+    v.retain_grad()
+
+    o = flash_attention(q, k, v, sharding_spec=range(n_devices))
+    loss = o.sum()
+    loss.backward()
+    xm.mark_step()
+
+    q_grad = q.grad
+    k_grad = k.grad
+    v_grad = v.grad
+    self.assertEqual(torch_xla._XLAC._get_xla_sharding_spec(q_grad), f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
+    self.assertEqual(torch_xla._XLAC._get_xla_sharding_spec(k_grad), f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
+    self.assertEqual(torch_xla._XLAC._get_xla_sharding_spec(v_grad), f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
+
+    torch.manual_seed(42)
+    q = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
+    k = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
+    v = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
+    q.retain_grad()
+    k.retain_grad()
+    v.retain_grad()
+
+    o = self._attention(q, k, v)
+    loss = o.sum()
+    loss.backward()
+    xm.mark_step()
+
+    for i in [(q, q_grad), (k, k_grad), (v, v_grad)]:
+      self.assertTrue(torch.allclose(i[0].grad.cpu(), i[1].cpu(), atol=1e-05))
+    jax.config.update('jax_default_matmul_precision', jax.lax.Precision.DEFAULT)
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  torch.set_default_dtype(torch.float32)
+  torch.manual_seed(42)
+  torch_xla._XLAC._xla_set_use_full_mat_mul_precision(
+      use_full_mat_mul_precision=True)
+  test = unittest.main()
+  sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/test_pallas_spmd.py
+++ b/test/test_pallas_spmd.py
@@ -41,7 +41,7 @@ class PallasTest(unittest.TestCase):
 
     o = flash_attention(q, k, v, partition_spec=range(n_devices))
     self.assertEqual(
-        torch_xla._XLAC._get_xla_partition_spec(o),
+        torch_xla._XLAC._get_xla_sharding_spec(o),
         f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
 
     expected_o = self._attention(q, k, v)
@@ -72,13 +72,13 @@ class PallasTest(unittest.TestCase):
     k_grad = k.grad
     v_grad = v.grad
     self.assertEqual(
-        torch_xla._XLAC._get_xla_partition_spec(q_grad),
+        torch_xla._XLAC._get_xla_sharding_spec(q_grad),
         f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
     self.assertEqual(
-        torch_xla._XLAC._get_xla_partition_spec(k_grad),
+        torch_xla._XLAC._get_xla_sharding_spec(k_grad),
         f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
     self.assertEqual(
-        torch_xla._XLAC._get_xla_partition_spec(v_grad),
+        torch_xla._XLAC._get_xla_sharding_spec(v_grad),
         f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
 
     torch.manual_seed(42)

--- a/test/test_pallas_spmd.py
+++ b/test/test_pallas_spmd.py
@@ -39,9 +39,9 @@ class PallasTest(unittest.TestCase):
     k = torch.randn(4, 2, 128, 4).to("xla")
     v = torch.randn(4, 2, 128, 4).to("xla")
 
-    o = flash_attention(q, k, v, sharding_spec=range(n_devices))
+    o = flash_attention(q, k, v, partition_spec=range(n_devices))
     self.assertEqual(
-        torch_xla._XLAC._get_xla_sharding_spec(o),
+        torch_xla._XLAC._get_xla_partition_spec(o),
         f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
 
     expected_o = self._attention(q, k, v)
@@ -63,7 +63,7 @@ class PallasTest(unittest.TestCase):
     k.retain_grad()
     v.retain_grad()
 
-    o = flash_attention(q, k, v, sharding_spec=range(n_devices))
+    o = flash_attention(q, k, v, partition_spec=range(n_devices))
     loss = o.sum()
     loss.backward()
     xm.mark_step()
@@ -72,13 +72,13 @@ class PallasTest(unittest.TestCase):
     k_grad = k.grad
     v_grad = v.grad
     self.assertEqual(
-        torch_xla._XLAC._get_xla_sharding_spec(q_grad),
+        torch_xla._XLAC._get_xla_partition_spec(q_grad),
         f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
     self.assertEqual(
-        torch_xla._XLAC._get_xla_sharding_spec(k_grad),
+        torch_xla._XLAC._get_xla_partition_spec(k_grad),
         f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
     self.assertEqual(
-        torch_xla._XLAC._get_xla_sharding_spec(v_grad),
+        torch_xla._XLAC._get_xla_partition_spec(v_grad),
         f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
 
     torch.manual_seed(42)

--- a/test/test_pallas_spmd.py
+++ b/test/test_pallas_spmd.py
@@ -12,6 +12,7 @@ from torch_xla import runtime as xr
 from torch_xla._internal import tpu
 
 if xr.device_type() == 'TPU':
+  from torch_xla.experimental.custom_kernel import flash_attention
   from torch_xla.experimental.custom_kernel import jax_import_guard
   jax_import_guard()
   import jax
@@ -31,9 +32,6 @@ class PallasTest(unittest.TestCase):
                    "This test only works on TPUv3+.")
   def test_flash_attention_spmd_data_parallel(self):
     jax.config.update('jax_default_matmul_precision', jax.lax.Precision.HIGHEST)
-    from torch_xla.experimental.custom_kernel import flash_attention
-
-    xr.use_spmd()
     n_devices = xr.global_runtime_device_count()
     xs.set_global_mesh(xs.Mesh(range(n_devices), (n_devices, 1, 1, 1)))
 
@@ -54,9 +52,6 @@ class PallasTest(unittest.TestCase):
                    "This test only works on TPUv3+.")
   def test_flash_attention_backward_spmd_data_parallel(self):
     jax.config.update('jax_default_matmul_precision', jax.lax.Precision.HIGHEST)
-    from torch_xla.experimental.custom_kernel import flash_attention
-
-    xr.use_spmd()
     n_devices = xr.global_runtime_device_count()
     xs.set_global_mesh(xs.Mesh(range(n_devices), (n_devices, 1, 1, 1)))
 
@@ -110,5 +105,6 @@ if __name__ == '__main__':
   torch.manual_seed(42)
   torch_xla._XLAC._xla_set_use_full_mat_mul_precision(
       use_full_mat_mul_precision=True)
+  xr.use_spmd()
   test = unittest.main()
   sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/torch_xla/distributed/spmd/__init__.py
+++ b/torch_xla/distributed/spmd/__init__.py
@@ -27,4 +27,6 @@ __all__ = [
     "_mark_manual_sharding",
     "enable_manual_sharding",
     "disable_manual_sharding",
+    "enable_manual_sharding",
+    "disable_manual_sharding",
 ]

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -239,18 +239,22 @@ class FlashAttention(torch.autograd.Function):
           False,
           static_argnums=range(5, 13))
       if not save_residuals:
-         # SPMD integration
+        # SPMD integration
         if sharding_spec is not None:
-          o = xs.disable_manual_sharding(o, sharding_spec, ctx.full_shape, mesh=mesh).global_tensor
+          o = xs.disable_manual_sharding(
+              o, sharding_spec, ctx.full_shape, mesh=mesh).global_tensor
         return o
       o, *aux = o
       l, m = (v[..., 0] for v in aux[-2:])
 
     # SPMD integration
     if sharding_spec is not None:
-      o = xs.disable_manual_sharding(o, sharding_spec, ctx.full_shape, mesh=mesh).global_tensor
-      l = xs.disable_manual_sharding(l, sharding_spec[0:3], ctx.full_shape[0:3], mesh=mesh).global_tensor
-      m = xs.disable_manual_sharding(m, sharding_spec[0:3], ctx.full_shape[0:3], mesh=mesh).global_tensor
+      o = xs.disable_manual_sharding(
+          o, sharding_spec, ctx.full_shape, mesh=mesh).global_tensor
+      l = xs.disable_manual_sharding(
+          l, sharding_spec[0:3], ctx.full_shape[0:3], mesh=mesh).global_tensor
+      m = xs.disable_manual_sharding(
+          m, sharding_spec[0:3], ctx.full_shape[0:3], mesh=mesh).global_tensor
 
     ctx.save_for_backward(full_q, full_k, full_v, o, l, m)
     return o
@@ -282,10 +286,14 @@ class FlashAttention(torch.autograd.Function):
       q = xs.enable_manual_sharding(q, sharding_spec, mesh=mesh).global_tensor
       k = xs.enable_manual_sharding(k, sharding_spec, mesh=mesh).global_tensor
       v = xs.enable_manual_sharding(v, sharding_spec, mesh=mesh).global_tensor
-      expanded_l = xs.enable_manual_sharding(expanded_l, sharding_spec, mesh=mesh).global_tensor
-      expanded_m = xs.enable_manual_sharding(expanded_m, sharding_spec, mesh=mesh).global_tensor
-      grad_output = xs.enable_manual_sharding(grad_output, sharding_spec, mesh=mesh).global_tensor
-      expanded_grad_i = xs.enable_manual_sharding(expanded_grad_i, sharding_spec, mesh=mesh).global_tensor
+      expanded_l = xs.enable_manual_sharding(
+          expanded_l, sharding_spec, mesh=mesh).global_tensor
+      expanded_m = xs.enable_manual_sharding(
+          expanded_m, sharding_spec, mesh=mesh).global_tensor
+      grad_output = xs.enable_manual_sharding(
+          grad_output, sharding_spec, mesh=mesh).global_tensor
+      expanded_grad_i = xs.enable_manual_sharding(
+          expanded_grad_i, sharding_spec, mesh=mesh).global_tensor
 
     if ctx.needs_input_grad[0]:
       payload, _ = trace_pallas(
@@ -358,9 +366,12 @@ class FlashAttention(torch.autograd.Function):
 
     # SPMD integration
     if sharding_spec is not None:
-      grad_q = xs.disable_manual_sharding(grad_q, sharding_spec, full_shape, mesh=mesh).global_tensor
-      grad_k = xs.disable_manual_sharding(grad_k, sharding_spec, full_shape, mesh=mesh).global_tensor
-      grad_v = xs.disable_manual_sharding(grad_v, sharding_spec, full_shape, mesh=mesh).global_tensor
+      grad_q = xs.disable_manual_sharding(
+          grad_q, sharding_spec, full_shape, mesh=mesh).global_tensor
+      grad_k = xs.disable_manual_sharding(
+          grad_k, sharding_spec, full_shape, mesh=mesh).global_tensor
+      grad_v = xs.disable_manual_sharding(
+          grad_v, sharding_spec, full_shape, mesh=mesh).global_tensor
 
     return grad_q, grad_k, grad_v, None, None, None
 
@@ -372,8 +383,7 @@ def flash_attention(
     causal=False,
     *,
     sharding_spec=None,
-    mesh=None
-):
+    mesh=None):
   return FlashAttention.apply(q, k, v, causal, sharding_spec, mesh)
 
 


### PR DESCRIPTION
Summary:
This pull request integrating FlashAttention with SPMD. The way it works is to create a manual sharding region for the kernel which means we wraps all the inputs with enable_manual_sharding and all the outputs with disable_manual_sharding.

Added a new test file because the original test file is not SPMD aware.

Test Plan:
PJRT_DEVICE=TPU python test/test_pallas_spmd.py