### PR TITLE
[Pallas] Support segment ids in flash attention

### DIFF
--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -22,6 +22,9 @@ if xr.device_type() == 'TPU':
 
 class PallasTest(unittest.TestCase):
 
+  # This is to create a diagonal mask where only elements within the same segment
+  # can attend to each other. Since the mask is to mask out the unrelevant parts,
+  # therefore we use != instead of ==.
   def _make_attention_mask_from_segment_ids(self, q_segment_ids,
                                             kv_segment_ids):
     return q_segment_ids.view(q_segment_ids.shape[0], 1,
@@ -32,6 +35,7 @@ class PallasTest(unittest.TestCase):
   def _attention(self, q, k, v, *, attn_mask=None):
     attn_weight = q @ k.transpose(-2, -1)
     if attn_mask is not None:
+      # Masked out the unrelevant parts.
       attn_weight = attn_weight.masked_fill(attn_mask,
                                             torch.finfo(attn_weight.dtype).min)
     attn_weight = nn.functional.softmax(attn_weight, dim=-1)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -673,52 +673,46 @@ class PallasTest(unittest.TestCase):
   @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 3,
                    "This test only works on TPUv3+.")
   def test_flash_attention_backward_segment_ids(self):
+    jax.config.update('jax_default_matmul_precision', jax.lax.Precision.HIGHEST)
     from torch_xla.experimental.custom_kernel import flash_attention
-    from jax.experimental.pallas.ops.tpu.flash_attention import flash_attention as jax_flash_attention, SegmentIds
 
-    q = torch.randn(4, 2, 128, 8)
-    k = torch.randn(4, 2, 128, 8)
-    v = torch.randn(4, 2, 128, 8)
-    q_segment_ids = torch.zeros(4, 128)
-    kv_segment_ids = torch.zeros(4, 128)
+    torch.manual_seed(42)
+    q = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
+    k = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
+    v = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
+    q_segment_ids = torch.zeros(4, 128).to("xla")
+    kv_segment_ids = torch.zeros(4, 128).to("xla")
+    q.retain_grad()
+    k.retain_grad()
+    v.retain_grad()
 
-    xla_q = q.to("xla")
-    xla_k = q.to("xla")
-    xla_v = q.to("xla")
-    xla_q.requires_grad = True
-    xla_k.requires_grad = True
-    xla_v.requires_grad = True
-    xla_q.retain_grad()
-    xla_k.retain_grad()
-    xla_v.retain_grad()
-    o = flash_attention(xla_q, xla_k, xla_v) #, False, q_segment_ids.to("xla"), kv_segment_ids.to("xla"))
+    o = flash_attention(q, k, v, False, q_segment_ids, kv_segment_ids)
     loss = o.sum()
     loss.backward()
     xm.mark_step()
 
-    jax_q = jnp.array(q.numpy(), dtype=jnp.float32)
-    jax_k = jnp.array(k.numpy(), dtype=jnp.float32)
-    jax_v = jnp.array(v.numpy(), dtype=jnp.float32)
-    jax_q_segment_ids = jnp.array(q_segment_ids.numpy(), dtype=jnp.float32)
-    jax_kv_segment_ids = jnp.array(kv_segment_ids.numpy(), dtype=jnp.float32)
+    q_grad = q.grad
+    k_grad = k.grad
+    v_grad = v.grad
 
-    def wrapper(q, k, v, *, segment_ids):
-      return jnp.sum(jax_flash_attention(q, k, v)) #, segment_ids=SegmentIds(jax_q_segment_ids, jax_kv_segment_ids)))
+    torch.manual_seed(42)
+    q = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
+    k = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
+    v = torch.randn(4, 2, 128, 8, requires_grad=True).to("xla")
+    q_segment_ids = torch.zeros(4, 128).to("xla")
+    kv_segment_ids = torch.zeros(4, 128).to("xla")
+    q.retain_grad()
+    k.retain_grad()
+    v.retain_grad()
 
-    grads = [torch.from_numpy(
-        np.array(t)) for t in jax.grad(wrapper, argnums=(0, 1, 2))(
-                jax_q,
-                jax_k,
-                jax_v,
-                segment_ids=SegmentIds(jax_q_segment_ids, jax_kv_segment_ids),
-            )]
+    o = self._attention(q, k, v, attn_mask=self._make_attention_mask_from_segment_ids(q_segment_ids, kv_segment_ids))
+    loss = o.sum()
+    loss.backward()
+    xm.mark_step()
 
-    print(xla_q.grad)
-    print(grads[2])
-
-    # self.assertTrue(torch.allclose(xla_q.grad.cpu(), grads[0].cpu(), atol=1e-04))
-    # self.assertTrue(torch.allclose(xla_k.grad.cpu(), grads[1].cpu(), atol=1e-05))
-    # self.assertTrue(torch.allclose(xla_v.grad.cpu(), grads[2].cpu(), atol=1e-05))
+    for i in [(q, q_grad), (k, k_grad), (v, v_grad)]:
+      self.assertTrue(torch.allclose(i[0].grad.cpu(), i[1].cpu(), atol=1e-05))
+    jax.config.update('jax_default_matmul_precision', jax.lax.Precision.DEFAULT)
 
 
 if __name__ == '__main__':

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -242,6 +242,7 @@ class FlashAttention(torch.autograd.Function):
           payload, shapes, dtypes)
 
       if not save_residuals:
+        o = o[0]
         # SPMD integration
         if partition_spec is not None:
           o = xs.disable_manual_sharding(

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -269,8 +269,7 @@ class FlashAttention(torch.autograd.Function):
       args = [q, k, v]
       if segment_ids is not None:
         args += [q_segment_ids, kv_segment_ids]
-      o = torch_xla._XLAC._xla_tpu_custom_call(args, payload, shapes,
-                                                 dtypes)
+      o = torch_xla._XLAC._xla_tpu_custom_call(args, payload, shapes, dtypes)
 
       if not save_residuals:
         o = o[0]
@@ -364,9 +363,8 @@ class FlashAttention(torch.autograd.Function):
       if segment_ids is not None:
         args += [q_segment_ids, kv_segment_ids]
       args += [expanded_l, expanded_m, grad_output, expanded_grad_i]
-      grad_q = torch_xla._XLAC._xla_tpu_custom_call(
-            args,
-            payload, [q.shape], [q.dtype])[0]
+      grad_q = torch_xla._XLAC._xla_tpu_custom_call(args, payload, [q.shape],
+                                                    [q.dtype])[0]
 
     if ctx.needs_input_grad[1] or ctx.needs_input_grad[2]:
       payload, _ = trace_pallas(
@@ -403,7 +401,9 @@ class FlashAttention(torch.autograd.Function):
       if segment_ids is not None:
         args += [q_segment_ids, kv_segment_ids]
       args += [expanded_l, expanded_m, grad_output, expanded_grad_i]
-      grads = torch_xla._XLAC._xla_tpu_custom_call(args, payload, [k.shape, v.shape], [k.dtype, v.dtype])
+      grads = torch_xla._XLAC._xla_tpu_custom_call(args, payload,
+                                                   [k.shape, v.shape],
+                                                   [k.dtype, v.dtype])
     if ctx.needs_input_grad[1]:
       grad_k = grads[0]
     if ctx.needs_input_grad[2]:

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -353,7 +353,6 @@ class FlashAttention(torch.autograd.Function):
           [q, k, v, expanded_l, expanded_m, grad_output, expanded_grad_i],
           payload, [q.shape], [q.dtype])[0]
       else:
-        print("heyheyhey")
         grad_q = torch_xla._XLAC._xla_tpu_custom_call(
           [q, k, v, q_segment_ids, kv_segment_ids, expanded_l, expanded_m, grad_output, expanded_grad_i],
           payload, [q.shape], [q.dtype])[0]


### PR DESCRIPTION
Summary:
This PR is to add segment ids to the flash attention wrapper. The segment ids are a way to create an attention mask where each token can only attend to other tokens within the same segment. The mask is therefore a block diagonal matrix.

To support it, we further split the flash attention forward into tracing and execution part, and implement all the shape operations to make it compatible with the kernel.

Test Plan:
PJRT_DEVICE=TPU python test/test_pallas.py