### PR TITLE
Update jinja and sphinx versions to address the vulnearbility

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 mistune==0.8.4
-sphinx==2.4.4
+sphinx==5.0.0
 docutils==0.16
-Jinja2<3.1
+Jinja2==3.1.3
 m2r
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme


### PR DESCRIPTION
We have to update jinja2 > 3.1 to avoid the reported vulnearabiilty https://github.com/pytorch/xla/security/dependabot/2

Tested locally,
```
preparing documents... done
writing output... [100%] notes/source_of_recompilation                                                              
generating indices... genindex py-modindex done
highlighting module code... [100%] torch_xla.utils.utils                                                            
writing additional pages... search done
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 75 warnings.

The HTML pages are in build.
```