### PR TITLE
Rework docs push

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -47,7 +47,8 @@ jobs:
     - name: Merge changes
       shell: bash
       run: |
-        subdir=${{ env.BRANCH_NAME == 'master' && 'master' || format('{0}/{1}', 'release/', env.BRANCH_NAME) }}
+        subdir=${{ env.BRANCH_NAME == 'master' && 'master' || format('{0}/{1}', 'release', env.BRANCH_NAME) }}
+        mkdir -p gh-pages/$subdir
         cp -fR pytorch/xla/docs/build/* gh-pages/$subdir
     - name: Show diff
       shell: bash

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -11,9 +11,6 @@ on:
         type: string
         description: Runner type for the test
         default: linux.4xlarge
-    secrets:
-      torchxla-bot-token:
-        required: true
 jobs:
   push-docs:
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -22,7 +22,6 @@ jobs:
       image: ${{ inputs.dev-image }}
     env:
       BRANCH_NAME: ${{ github.ref_name }}
-      DOCS_SUBDIR: ${{ env.BRANCH_NAME == 'master' && 'master' || format('{0}/{1}', 'release/', env.BRANCH_NAME) }}
     steps:
     - name: Fetch wheels
       uses: actions/download-artifact@v4
@@ -50,7 +49,9 @@ jobs:
         ref: gh-pages
     - name: Merge changes
       shell: bash
-      run: cp -fR pytorch/xla/docs/build/* gh-pages/${DOCS_SUBDIR}
+      run: |
+        subdir=${{ env.BRANCH_NAME == 'master' && 'master' || format('{0}/{1}', 'release/', env.BRANCH_NAME) }}
+        cp -fR pytorch/xla/docs/build/* gh-pages/$subdir
     - name: Show diff
       shell: bash
       run: |

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -34,9 +34,9 @@ jobs:
       run: |
         pip install /tmp/wheels/*.whl
     - name: Checkout PyTorch/XLA Repo
-        uses: actions/checkout@v4
-        with:
-          path: pytorch/xla
+      uses: actions/checkout@v4
+      with:
+        path: pytorch/xla
     - name: Build docs
       shell: bash
       run: |

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -12,8 +12,8 @@ on:
         description: Runner type for the test
         default: linux.4xlarge
 jobs:
-  push-docs:
-    runs-on: ${{ inputs.runner }}
+  build-docs:
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     container:
       image: ${{ inputs.dev-image }}
@@ -50,8 +50,26 @@ jobs:
         subdir=${{ env.BRANCH_NAME == 'master' && 'master' || format('{0}/{1}', 'release', env.BRANCH_NAME) }}
         mkdir -p gh-pages/$subdir
         cp -fR pytorch/xla/docs/build/* gh-pages/$subdir
-    - name: Show diff
-      shell: bash
-      run: |
-        cd gh-pages
-        git diff
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: 'gh-pages'
+
+  deploy:
+    needs: build-docs
+    runs-on: ubuntu-latest
+    # permissions:
+    #   pages: write
+    #   id-token: write
+
+    # Deploy to the github-pages environment
+    # environment:
+    #   name: github-pages
+    #   url: ${{ steps.deployment.outputs.page_url }}
+
+    # - name: Deploy to GitHub Pages
+    #   id: deployment
+    #   uses: actions/deploy-pages@v4
+
+    - name: Skip
+      run: echo "testing..."

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -2,10 +2,10 @@ name: xla-docs-build
 on:
   workflow_call:
     inputs:
-      docker-image:
+      dev-image:
         required: true
         type: string
-        description: Image to build docs in
+        description: Base image for builds
       runner:
         required: false
         type: string
@@ -18,32 +18,41 @@ jobs:
   push-docs:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 45
+    container:
+      image: ${{ inputs.dev-image }}
     env:
-      DOCKER_IMAGE: ${{ inputs.docker-image }}
-      WORKDIR: /var/lib/jenkins/workspace
+      BRANCH_NAME: ${{ github.ref_name }}
+      DOCS_SUBDIR: ${{ env.BRANCH_NAME == 'master' && 'master' || format('{0}/{1}', 'release/', env.BRANCH_NAME) }}
     steps:
-      - name: Setup Linux
-        uses: pytorch/test-infra/.github/actions/setup-linux@main
-      - name: Setup SSH (Click me for login details)
-        uses: pytorch/test-infra/.github/actions/setup-ssh@main
+    - name: Fetch wheels
+      uses: actions/download-artifact@v4
+      with:
+        name: torch-xla-wheels
+        path: /tmp/wheels/
+    - name: Install wheels
+      shell: bash
+      run: |
+        pip install /tmp/wheels/*.whl
+    - name: Checkout PyTorch/XLA Repo
+        uses: actions/checkout@v4
         with:
-          github-secret: ${{ secrets.GITHUB_TOKEN }}
-          instructions: |
-            Doc builds are done inside container. Interactive session can be started by following:
-              docker exec -it $(docker container ps --format '{{.ID}}') bash
-      - name: Download and run docker image from GCR
-        shell: bash
-        env:
-          GITHUB_TORCH_XLA_BOT_TOKEN: ${{ secrets. torchxla-bot-token }}
-        run: |
-          echo "DOCKER_IMAGE: ${DOCKER_IMAGE}"
-          docker pull "${DOCKER_IMAGE}"
-          pid=$(docker run -e GITHUB_TORCH_XLA_BOT_TOKEN -t -d -w "$WORKDIR" "${DOCKER_IMAGE}")
-          echo "${GCLOUD_SERVICE_KEY}" | docker exec -i "${pid}" sh -c "cat >> /tmp/pytorch/xla/default_credentials.json"
-          echo "pid=${pid}" >> "${GITHUB_ENV}"
-      - name: Build & publish docs
-        shell: bash
-        run: docker exec -u jenkins "${pid}" bash -c '.circleci/doc_push.sh'
-      - name: Teardown Linux
-        uses: pytorch/test-infra/.github/actions/teardown-linux@main
-        if: always()
+          path: pytorch/xla
+    - name: Build docs
+      shell: bash
+      run: |
+        cd pytorch/xla/docs
+        pip install -r requirements.txt
+        sphinx-build -b html source build
+    - name: Checkout GitHub Pages
+      uses: actions/checkout@v4
+      with:
+        path: gh-pages
+        ref: gh-pages
+    - name: Merge changes
+      shell: bash
+      run: cp -fR pytorch/xla/docs/build/* gh-pages/${DOCS_SUBDIR}
+    - name: Show diff
+      shell: bash
+      run: |
+        cd gh-pages
+        git diff

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -54,7 +54,6 @@ jobs:
       uses: actions/upload-pages-artifact@v3
       with:
         path: 'gh-pages'
-
   deploy:
     needs: build-docs
     runs-on: ubuntu-latest
@@ -67,6 +66,7 @@ jobs:
     #   name: github-pages
     #   url: ${{ steps.deployment.outputs.page_url }}
 
+    steps:
     # - name: Deploy to GitHub Pages
     #   id: deployment
     #   uses: actions/deploy-pages@v4

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -57,6 +57,7 @@ jobs:
   deploy:
     needs: build-docs
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     # permissions:
     #   pages: write
     #   id-token: write

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -11,9 +11,9 @@ on:
         type: string
         description: Runner type for the test
         default: linux.4xlarge
-      secrets:
-        torchxla-bot-token:
-          required: true
+    secrets:
+      torchxla-bot-token:
+        required: true
 jobs:
   build-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -11,6 +11,9 @@ on:
         type: string
         description: Runner type for the test
         default: linux.4xlarge
+      secrets:
+        torchxla-bot-token:
+          required: true
 jobs:
   build-docs:
     runs-on: ubuntu-latest
@@ -58,9 +61,6 @@ jobs:
     needs: build-docs
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
-    permissions:
-      pages: write
-      id-token: write
 
     # Deploy to the github-pages environment
     environment:
@@ -70,3 +70,5 @@ jobs:
     - name: Deploy to GitHub Pages
       id: deployment
       uses: actions/deploy-pages@v4
+      with:
+        token: ${{ secrets.torchxla-bot-token }}

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -58,19 +58,15 @@ jobs:
     needs: build-docs
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
-    # permissions:
-    #   pages: write
-    #   id-token: write
+    permissions:
+      pages: write
+      id-token: write
 
     # Deploy to the github-pages environment
-    # environment:
-    #   name: github-pages
-    #   url: ${{ steps.deployment.outputs.page_url }}
-
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-    # - name: Deploy to GitHub Pages
-    #   id: deployment
-    #   uses: actions/deploy-pages@v4
-
-    - name: Skip
-      run: echo "testing..."
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -30,16 +30,6 @@ jobs:
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
 
-  push-docs:
-    name: "Build & publish docs"
-    if: github.event_name == 'push' && (github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/tags/r'))
-    uses: ./.github/workflows/_docs.yml
-    needs: build
-    with:
-      docker-image: ${{ needs.build.outputs.docker-image }}
-    secrets:
-      torchxla-bot-token: ${{ secrets.TORCH_XLA_BOT_TOKEN }}
-
   # New CI workflow
   build-torch-xla:
     name: "Build PyTorch/XLA (TPU)"
@@ -88,3 +78,10 @@ jobs:
     # Only run this for HEAD and releases
     if: github.event_name == 'push'
 
+  push-docs:
+    name: "Build & publish docs"
+    # if: github.event_name == 'push' && (github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/tags/r'))
+    uses: ./.github/workflows/_docs.yml
+    needs: build-torch-xla
+    with:
+      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -80,8 +80,9 @@ jobs:
 
   push-docs:
     name: "Build docs"
-    # if: github.event_name == 'push' && (github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/tags/r'))
     uses: ./.github/workflows/_docs.yml
     needs: build-torch-xla
     with:
       dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
+    secrets:
+      torchxla-bot-token: ${{ secrets.TORCH_XLA_BOT_TOKEN }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -79,7 +79,7 @@ jobs:
     if: github.event_name == 'push'
 
   push-docs:
-    name: "Build & publish docs"
+    name: "Build docs"
     # if: github.event_name == 'push' && (github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/tags/r'))
     uses: ./.github/workflows/_docs.yml
     needs: build-torch-xla


### PR DESCRIPTION
- Follow [current GHA examples](https://github.com/actions/starter-workflows/blob/main/pages/static.yml) for deploying pages.
- Tweak logic for selecting subdir. As near as I can tell, every release commit was updating master's docs: https://github.com/pytorch/xla/blob/b834e49907aab60e096620664ca8ba328ef92141/.circleci/doc_push.sh#L22-L26
- ~Use token from GHA instead of bot account.~ Nope, org policy forbids us from getting a GHA token with write access
- Run docs build for every event, but only publish for pushes. You can check what the generated docs will look like in the `github-pages` artifact (`releases/$PR_NUMBER/merge`)