### PR TITLE
Reland Install torchvision in release docker #6795 (#6860)

### DIFF
--- a/infra/ansible/Dockerfile
+++ b/infra/ansible/Dockerfile
@@ -22,6 +22,7 @@ RUN ansible-playbook -vvv playbook.yaml -e "stage=release" -e "${ansible_vars}" 
 WORKDIR /tmp/wheels
 COPY --from=build /src/pytorch/dist/*.whl ./
 COPY --from=build /src/pytorch/xla/dist/*.whl ./
+COPY --from=build /dist/torchvision*.whl ./
 
 RUN echo "Installing the following wheels" && ls *.whl
 RUN pip install *.whl


### PR DESCRIPTION
Backport to 2.3, since trigger looks at the Dockerfile in the target branch