### PR TITLE
Create rc13 trigger

### DIFF
--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -35,7 +35,7 @@ nightly_builds = [
 versioned_builds = [
   # Remove libtpu from PyPI builds
   {
-    git_tag         = "v2.3.0-rc12"
+    git_tag         = "v2.3.0-rc13"
     package_version = "2.3.0-rc12"
     pytorch_git_rev = "v2.3.0-rc12"
     accelerator     = "tpu"
@@ -43,7 +43,7 @@ versioned_builds = [
     bundle_libtpu   = "0"
   },
   {
-    git_tag         = "v2.3.0-rc12"
+    git_tag         = "v2.3.0-rc13"
     package_version = "2.3.0-rc12"
     pytorch_git_rev = "v2.3.0-rc12"
     accelerator     = "tpu"
@@ -51,7 +51,7 @@ versioned_builds = [
     bundle_libtpu   = "0"
   },
   {
-    git_tag         = "v2.3.0-rc12"
+    git_tag         = "v2.3.0-rc13"
     package_version = "2.3.0-rc12"
     pytorch_git_rev = "v2.3.0-rc12"
     accelerator     = "tpu"
@@ -59,7 +59,7 @@ versioned_builds = [
     bundle_libtpu   = "0"
   },
   {
-    git_tag         = "v2.3.0-rc12"
+    git_tag         = "v2.3.0-rc13"
     package_version = "2.3.0-rc12"
     pytorch_git_rev = "v2.3.0-rc12"
     accelerator     = "tpu"
@@ -68,7 +68,7 @@ versioned_builds = [
   },
   # Bundle libtpu for Kaggle
   {
-    git_tag         = "v2.3.0-rc12"
+    git_tag         = "v2.3.0-rc13"
     package_version = "2.3.0-rc12+libtpu"
     pytorch_git_rev = "v2.3.0-rc12"
     accelerator     = "tpu"
@@ -76,7 +76,7 @@ versioned_builds = [
     bundle_libtpu   = "1"
   },
   {
-    git_tag         = "v2.3.0-rc12"
+    git_tag         = "v2.3.0-rc13"
     pytorch_git_rev = "v2.3.0-rc12"
     package_version = "2.3.0-rc12"
     accelerator     = "cuda"
@@ -84,7 +84,7 @@ versioned_builds = [
     python_version = "3.8"
   },
   {
-    git_tag         = "v2.3.0-rc12"
+    git_tag         = "v2.3.0-rc13"
     pytorch_git_rev = "v2.3.0-rc12"
     package_version = "2.3.0-rc12"
     accelerator     = "cuda"

--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -36,7 +36,7 @@ versioned_builds = [
   # Remove libtpu from PyPI builds
   {
     git_tag         = "v2.3.0-rc13"
-    package_version = "2.3.0-rc12"
+    package_version = "2.3.0-rc13"
     pytorch_git_rev = "v2.3.0-rc12"
     accelerator     = "tpu"
     python_version = "3.8"
@@ -44,7 +44,7 @@ versioned_builds = [
   },
   {
     git_tag         = "v2.3.0-rc13"
-    package_version = "2.3.0-rc12"
+    package_version = "2.3.0-rc13"
     pytorch_git_rev = "v2.3.0-rc12"
     accelerator     = "tpu"
     python_version  = "3.9"
@@ -52,7 +52,7 @@ versioned_builds = [
   },
   {
     git_tag         = "v2.3.0-rc13"
-    package_version = "2.3.0-rc12"
+    package_version = "2.3.0-rc13"
     pytorch_git_rev = "v2.3.0-rc12"
     accelerator     = "tpu"
     python_version  = "3.10"
@@ -60,7 +60,7 @@ versioned_builds = [
   },
   {
     git_tag         = "v2.3.0-rc13"
-    package_version = "2.3.0-rc12"
+    package_version = "2.3.0-rc13"
     pytorch_git_rev = "v2.3.0-rc12"
     accelerator     = "tpu"
     python_version  = "3.11"
@@ -69,7 +69,7 @@ versioned_builds = [
   # Bundle libtpu for Kaggle
   {
     git_tag         = "v2.3.0-rc13"
-    package_version = "2.3.0-rc12+libtpu"
+    package_version = "2.3.0-rc13+libtpu"
     pytorch_git_rev = "v2.3.0-rc12"
     accelerator     = "tpu"
     python_version  = "3.10"
@@ -78,7 +78,7 @@ versioned_builds = [
   {
     git_tag         = "v2.3.0-rc13"
     pytorch_git_rev = "v2.3.0-rc12"
-    package_version = "2.3.0-rc12"
+    package_version = "2.3.0-rc13"
     accelerator     = "cuda"
     cuda_version    = "12.1"
     python_version = "3.8"
@@ -86,7 +86,7 @@ versioned_builds = [
   {
     git_tag         = "v2.3.0-rc13"
     pytorch_git_rev = "v2.3.0-rc12"
-    package_version = "2.3.0-rc12"
+    package_version = "2.3.0-rc13"
     accelerator     = "cuda"
     cuda_version    = "12.1"
     python_version  = "3.10"


### PR DESCRIPTION
The latest rc-12 docker image still has incompatible torchvision, it should be cause the fix PR (https://github.com/pytorch/xla/pull/6955) is not backported onto `r2.3` branch, and release infra is looking at the Dockerfile in the target branch, instead of the Dockerfile in master branch.

Create another rc to verify backporting the fix (https://github.com/pytorch/xla/pull/6955) fixes the incompatible torchvision version in r2.3 images.