### PR TITLE
Temporarily ignore torch commit in CI test

### DIFF
--- a/.github/workflows/_test_python.yml
+++ b/.github/workflows/_test_python.yml
@@ -101,14 +101,18 @@ jobs:
           # TODO: Add these in setup.py
           pip install fsspec
           pip install rich
-      - name: Record PyTorch commit
-        run: echo "PYTORCH_COMMIT=$(python -c 'import torch_xla.version; print(torch_xla.version.__torch_gitrev__)')" >> $GITHUB_ENV
+
+          echo "Import check..."
+          python -c "import torch_xla"
+      # TODO(wcromar): re-enable this because it's important sometimes
+      # - name: Record PyTorch commit
+      #   run: echo "PYTORCH_COMMIT=$(python -c 'import torch_xla.version; print(torch_xla.version.__torch_gitrev__)')" >> $GITHUB_ENV
       - name: Checkout PyTorch Repo
         uses: actions/checkout@v4
         with:
           repository: pytorch/pytorch
           path: pytorch
-          ref: ${{ env.PYTORCH_COMMIT }}
+          # ref: ${{ env.PYTORCH_COMMIT }}
       - name: Checkout PyTorch/XLA Repo
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
It looks like our import is printing something extra to stdout and preventing us from reading the git pin:

```
Run echo "PYTORCH_COMMIT=$(python -c 'import torch_xla.version; print(torch_xla.version.__torch_gitrev__)')" >> $GITHUB_ENV
Error: Unable to process file command 'env' successfully.
Error: Invalid format 'refreshing <module 'torch.ops.quantized_decomposed' from 'torch.ops'> quantize_per_tensor'
```

Ignore the torch commit from the build step so we can run tests again. This means the commit used for the test step may be different than that used for the build step, which is bad. This hack is temporary.