### PR TITLE
Write `torch_xla.version.__torch_gitrev__` to file directly

### DIFF
--- a/.github/workflows/_test_python.yml
+++ b/.github/workflows/_test_python.yml
@@ -110,7 +110,7 @@ jobs:
           python -c "
           import torch_xla.version
           with open('$GITHUB_ENV', 'a') as f:
-            f.write(torch_xla.version.__torch_gitrev__ + '\n')
+            f.write(f'PYTORCH_COMMIT={torch_xla.version.__torch_gitrev__}\n')
           "
       - name: Checkout PyTorch Repo
         uses: actions/checkout@v4

--- a/.github/workflows/_test_python.yml
+++ b/.github/workflows/_test_python.yml
@@ -104,15 +104,20 @@ jobs:
 
           echo "Import check..."
           python -c "import torch_xla"
-      # TODO(wcromar): re-enable this because it's important sometimes
-      # - name: Record PyTorch commit
-      #   run: echo "PYTORCH_COMMIT=$(python -c 'import torch_xla.version; print(torch_xla.version.__torch_gitrev__)')" >> $GITHUB_ENV
+      - name: Record PyTorch commit
+        run: |
+          # Don't just pipe output in shell because imports may do extra logging
+          python -c "
+          import torch_xla.version
+          with open('$GITHUB_ENV', 'a') as f:
+            f.write(torch_xla.version.__torch_gitrev__ + '\n')
+          "
       - name: Checkout PyTorch Repo
         uses: actions/checkout@v4
         with:
           repository: pytorch/pytorch
           path: pytorch
-          # ref: ${{ env.PYTORCH_COMMIT }}
+          ref: ${{ env.PYTORCH_COMMIT }}
       - name: Checkout PyTorch/XLA Repo
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This is a little cursed, but it should work more consistently than the old way.