### PR TITLE
Move test_grad_checkpoint.py to tpu test list

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -162,7 +162,6 @@ function run_xla_op_tests1 {
   run_dynamic "$CDIR/ds/test_dynamic_shapes.py"
   run_dynamic "$CDIR/ds/test_dynamic_shape_models.py" "$@" --verbosity=$VERBOSITY
   run_eager_debug  "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
-  run_test "$CDIR/test_grad_checkpoint.py"
   run_test "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_test_without_functionalization "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_pt_xla_debug "$CDIR/debug_tool/test_pt_xla_debug.py"

--- a/test/tpu/run_tests.sh
+++ b/test/tpu/run_tests.sh
@@ -14,6 +14,7 @@ python3 test/spmd/test_xla_auto_sharding.py
 XLA_EXPERIMENTAL=nonzero:masked_select:nms python3 test/ds/test_dynamic_shape_models.py -v
 XLA_EXPERIMENTAL=nonzero:masked_select:nms python3 test/ds/test_dynamic_shapes.py -v
 python3 test/test_autocast.py
+python3 test/test_grad_checkpoint.py
 python3 test/dynamo/test_dynamo.py
 python3 test/spmd/test_spmd_debugging.py
 python3 test/pjrt/test_dtypes.py


### PR DESCRIPTION
This test might crashed in XLA:CPU in function `dnnl::impl::cpu::x64::avx_gemm_f32::sgemm_nocopy_driver`. I am able to repo it on my TPUVM with `PJRT_DEVICE=CPU`. Moved the test to TPU so upstream won't run this test on CPU