### PR TITLE
Update dynamo test to be less constrain

### DIFF
--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -641,10 +641,7 @@ class DynamoErrorMessageTest(unittest.TestCase):
       # there should be 18 paramters + 1 input
       self.assertGreater(len(w), 15)
       self.assertIn('Found tensor with shape torch.Size', str(w[0].message))
-    # no XLA operation should happens except a empty mark_step. Partitioner should offload all CPU
-    # ops to CPU.
-    self.assertEqual(len(met.counter_names()), 1)
-    self.assertIn('MarkStep', met.counter_names())
+    self.assertLessEqual(len(met.counter_names()), 1)
 
 
 class DynamoOperationsTests(test_utils.XlaTestCase):


### PR DESCRIPTION
This is to address the issue in https://github.com/pytorch/pytorch/pull/124920.  Dynamo will skip the no-op execution. I left the check to be `LessEqual` so we can merge this change without upstream pr. This way merging process is a bit easier.