### PR TITLE
Fix permission issues during CI checkout

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       # See https://github.com/actions/checkout/issues/1014#issuecomment-1906802802
       - name: Fix workspace permissions
-        run: chmod +w -R ${GITHUB_WORKSPACE}; rm -rf ${GITHUB_WORKSPACE}/*;
+        run: chmod +w -R ${GITHUB_WORKSPACE}; rm -rvf ${GITHUB_WORKSPACE}/*;
       - name: Setup Linux
         uses: pytorch/test-infra/.github/actions/setup-linux@main
       - name: Setup SSH (Click me for login details)

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       # See https://github.com/actions/checkout/issues/1014#issuecomment-1906802802
       - name: Fix workspace permissions
-        run: rm -rvf ${GITHUB_WORKSPACE}/*;
+        run: rm -rvf ${GITHUB_WORKSPACE}/*
       - name: Setup Linux
         uses: pytorch/test-infra/.github/actions/setup-linux@main
       - name: Setup SSH (Click me for login details)

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -47,7 +47,9 @@ jobs:
     steps:
       # See https://github.com/actions/checkout/issues/1014#issuecomment-1906802802
       - name: Fix workspace permissions
-        run: rm -rvf ${GITHUB_WORKSPACE}/*
+        run: |
+          ls -la
+          rm -rvf ${GITHUB_WORKSPACE}/*
       - name: Setup Linux
         uses: pytorch/test-infra/.github/actions/setup-linux@main
       - name: Setup SSH (Click me for login details)

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       # See https://github.com/actions/checkout/issues/1014#issuecomment-1906802802
       - name: Fix workspace permissions
-        run: chmod +w -R ${GITHUB_WORKSPACE}; rm -rvf ${GITHUB_WORKSPACE}/*;
+        run: rm -rvf ${GITHUB_WORKSPACE}/*;
       - name: Setup Linux
         uses: pytorch/test-infra/.github/actions/setup-linux@main
       - name: Setup SSH (Click me for login details)

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -45,6 +45,9 @@ jobs:
       XLA_CUDA: ${{ inputs.cuda }}
       BAZEL_JOBS: 16
     steps:
+      # See https://github.com/actions/checkout/issues/1014#issuecomment-1906802802
+      - name: Fix workspace permissions
+        run: chmod +w -R ${GITHUB_WORKSPACE}; rm -rf ${GITHUB_WORKSPACE}/*;
       - name: Setup Linux
         uses: pytorch/test-infra/.github/actions/setup-linux@main
       - name: Setup SSH (Click me for login details)
@@ -54,9 +57,6 @@ jobs:
           instructions: |
             Build is  done inside the container, to start an interactive session run:
               docker exec -it $(docker container ps --format '{{.ID}}') bash
-      # See https://github.com/actions/checkout/issues/1014#issuecomment-1906802802
-      - name: Fix workspace permissions
-        run: chmod +w -R ${GITHUB_WORKSPACE}
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Download docker image from GCR

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -54,6 +54,9 @@ jobs:
           instructions: |
             Build is  done inside the container, to start an interactive session run:
               docker exec -it $(docker container ps --format '{{.ID}}') bash
+      # See https://github.com/actions/checkout/issues/1014#issuecomment-1906802802
+      - name: Fix workspace permissions
+        run: chmod +w -R ${GITHUB_WORKSPACE}
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Download docker image from GCR

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   # Old CI workflow
   build:
-    name: "Build PyTorch/XLA (GPU)"
+    name: "Build upstream CI image"
     uses: ./.github/workflows/_build.yml
     with:
       ecr-docker-image-base: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/xla_base


### PR DESCRIPTION
See the linked issue in the comment. This should fix the random `Error: File was unable to be removed Error: EACCES: permission denied, unlink '/home/ec2-user/actions-runner/_work/xla/xla/pytorch/.bazelignore'` errors.