### PR TITLE
Support `ahead of time (AOT) cross-device compilation`

### DIFF
--- a/torch_xla/csrc/device.h
+++ b/torch_xla/csrc/device.h
@@ -15,7 +15,7 @@ namespace torch_xla {
 // TODO(yeounoh) `SPMD` is a virtual device that defers data `TransferToDevice`
 // until after the paritioning pass. This avoids transfering  the full input
 // tensor to the device.
-enum class XlaDeviceType { CPU, CUDA, TPU, NEURON, SPMD, PLUGIN };
+enum class XlaDeviceType { CPU, CUDA, TPU, NEURON, SPMD, PLUGIN, AOT };
 
 struct DeviceType : public torch::lazy::BackendDeviceType {
   DeviceType(XlaDeviceType xla_device_type)
@@ -36,6 +36,12 @@ struct DeviceType : public torch::lazy::BackendDeviceType {
 };
 
 torch::lazy::BackendDevice ParseDeviceString(const std::string& device_spec);
+
+torch::lazy::BackendDevice GetCrossCompilationDevice();
+
+bool UseCrossCompilationDevice();
+
+bool IsCrossCompilationDevice(const std::string& device);
 
 torch::lazy::BackendDevice GetVirtualDevice();
 

--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -109,6 +109,7 @@ cc_library(
         ":env_hash",
         ":env_vars",
         ":operation_manager",
+        ":pjrt_compile_only",
         ":pjrt_registry",
         ":profiler",
         ":stablehlo_helper",
@@ -188,6 +189,17 @@ cc_test(
 )
 
 cc_library(
+    name = "pjrt_compile_only",
+    srcs = ["pjrt_compile_only.cc"],
+    hdrs = ["pjrt_compile_only.h"],
+    deps = [
+        "@xla//xla/pjrt:pjrt_client",
+        "@xla//xla/pjrt:pjrt_future",
+        "@xla//xla/pjrt:pjrt_compiler",
+    ],
+)
+
+cc_library(
     name = "pjrt_registry",
     srcs = ["pjrt_registry.cc"],
     hdrs = ["pjrt_registry.h"],
@@ -198,6 +210,7 @@ cc_library(
         ":profiler",
         ":sys_util",
         ":tf_logging",
+        ":pjrt_compile_only",
         ":xla_coordinator",
         "@com_google_absl//absl/log:initialize",
         "@xla//xla/pjrt:pjrt_c_api_client",

--- a/torch_xla/csrc/runtime/pjrt_compile_only.cc
+++ b/torch_xla/csrc/runtime/pjrt_compile_only.cc
@@ -58,8 +58,7 @@ StatusOr<std::unique_ptr<PjRtBuffer>> CompileOnlyPjRtBuffer::CopyToMemorySpace(
 }
 
 void CompileOnlyPjRtBuffer::CopyToRemoteDevice(
-    PjRtFuture<std::string> serialized_descriptor,
-    RemoteSendCallback on_done) {
+    PjRtFuture<std::string> serialized_descriptor, RemoteSendCallback on_done) {
   return;
 }
 

--- a/torch_xla/csrc/runtime/pjrt_compile_only.cc
+++ b/torch_xla/csrc/runtime/pjrt_compile_only.cc
@@ -1,0 +1,283 @@
+#include "torch_xla/csrc/runtime/pjrt_compile_only.h"
+
+namespace xla {
+
+const Shape& CompileOnlyPjRtBuffer::on_device_shape() const { return shape_; }
+
+PjRtMemorySpace* CompileOnlyPjRtBuffer::memory_space() const { return nullptr; }
+
+PjRtDevice* CompileOnlyPjRtBuffer::device() const {
+  // return device_.get();
+  return nullptr;
+}
+
+PjRtClient* CompileOnlyPjRtBuffer::client() const {
+  // return client_.get();
+  return nullptr;
+}
+
+StatusOr<std::unique_ptr<xla::PjRtBuffer::ExternalReference>>
+CompileOnlyPjRtBuffer::AcquireExternalReference() {
+  return Unimplemented("");
+}
+
+PjRtFuture<> CompileOnlyPjRtBuffer::ToLiteral(MutableLiteralBase* literal) {
+  return PjRtFuture<>();
+}
+
+PjRtFuture<> CompileOnlyPjRtBuffer::LazyToLiteral(
+    absl::AnyInvocable<absl::StatusOr<MutableLiteralBase*>() &&> generator) {
+  return PjRtFuture<>();
+}
+
+StatusOr<size_t> CompileOnlyPjRtBuffer::GetOnDeviceSizeInBytes() const {
+  return Unimplemented("");
+}
+PjRtFuture<> CompileOnlyPjRtBuffer::CopyRawToHost(void* dst, int64_t offset,
+                                                  int64_t transfer_size) {
+  return PjRtFuture<>();
+}
+
+void CompileOnlyPjRtBuffer::Delete() { return; }
+
+StatusOr<std::unique_ptr<xla::PjRtBuffer::ExternalReference>>
+CompileOnlyPjRtBuffer::ReleaseDeviceMemoryOwnership(
+    bool wait_for_operations_to_complete) {
+  return Unimplemented("");
+}
+
+bool CompileOnlyPjRtBuffer::IsDeleted() { return false; }
+
+StatusOr<std::unique_ptr<PjRtBuffer>> CompileOnlyPjRtBuffer::CopyToDevice(
+    PjRtDevice* dst_device) {
+  return Unimplemented("");
+}
+StatusOr<std::unique_ptr<PjRtBuffer>> CompileOnlyPjRtBuffer::CopyToMemorySpace(
+    PjRtMemorySpace* dst_memory_space) {
+  return Unimplemented("");
+}
+
+void CompileOnlyPjRtBuffer::CopyToRemoteDevice(
+    PjRtFuture<StatusOr<std::string>> serialized_descriptor,
+    RemoteSendCallback on_done) {
+  return;
+}
+
+void CompileOnlyPjRtBuffer::CopyToRemoteDeviceScattered(
+    PjRtFuture<StatusOr<std::vector<std::string>>> serialized_descriptors,
+    std::vector<RemoteSendCallback> callbacks,
+    const ScatterDetails& scatter_details) {
+  return;
+}
+
+PjRtFuture<> CompileOnlyPjRtBuffer::GetReadyFuture() { return PjRtFuture<>(); }
+
+bool CompileOnlyPjRtBuffer::IsOnCpu() const { return false; }
+
+CompileOnlyPjRtDevice::CompileOnlyPjRtDevice(
+    const PjRtDeviceDescription* description)
+    : description_(std::move(description)) {}
+
+const PjRtDeviceDescription& CompileOnlyPjRtDevice::description() const {
+  return *description_;
+}
+void CompileOnlyPjRtDevice::SetClient(PjRtClient* client) { client_ = client; }
+
+PjRtClient* CompileOnlyPjRtDevice::client() const { return client_; }
+bool CompileOnlyPjRtDevice::IsAddressable() const { return false; }
+int CompileOnlyPjRtDevice::local_hardware_id() const {
+  return local_hardware_id_typed().value();
+}
+
+PjRtLocalDeviceId CompileOnlyPjRtDevice::local_device_id() const {
+  return PjRtLocalDeviceId(local_hardware_id_typed().value());
+}
+
+PjRtLocalHardwareId CompileOnlyPjRtDevice::local_hardware_id_typed() const {
+  return PjRtLocalHardwareId(-1);
+}
+
+std::unique_ptr<ScopedAsyncTrackingEvent>
+CompileOnlyPjRtDevice::CreateAsyncTrackingEvent(
+    absl::string_view description) const {
+  return nullptr;
+}
+Status CompileOnlyPjRtDevice::TransferToInfeed(const LiteralSlice& literal) {
+  return Unimplemented("TransferToInfeed is not supported");
+}
+Status CompileOnlyPjRtDevice::TransferFromOutfeed(
+    MutableBorrowingLiteral literal) {
+  return Unimplemented("TransferFromOutfeed is not supported");
+}
+absl::Span<PjRtMemorySpace* const> CompileOnlyPjRtDevice::memory_spaces()
+    const {
+  return {};
+}
+StatusOr<PjRtMemorySpace*> CompileOnlyPjRtDevice::default_memory_space() const {
+  return Unimplemented("default_memory_space is not supported");
+}
+
+CompileOnlyPjRtClient::CompileOnlyPjRtClient(
+    std::shared_ptr<PjRtTopologyDescription> topology)
+    : topology_(std::move(topology)),
+      descriptions_(topology_->DeviceDescriptions()) {
+  // TODO(piz): figure out why the size should be 4 instead of topology_ size 8.
+  descriptions_.resize(4);
+  for (auto& description : descriptions_) {
+    owned_devices_.push_back(
+        std::make_unique<CompileOnlyPjRtDevice>(description.get()));
+    owned_devices_.back()->SetClient(this);
+    devices_.push_back(owned_devices_.back().get());
+  }
+}
+int CompileOnlyPjRtClient::device_count() const { return devices().size(); }
+int CompileOnlyPjRtClient::addressable_device_count() const { return 0; }
+absl::Span<PjRtDevice* const> CompileOnlyPjRtClient::devices() const {
+  return devices_;
+}
+absl::Span<PjRtDevice* const> CompileOnlyPjRtClient::addressable_devices()
+    const {
+  return devices_;
+}
+int CompileOnlyPjRtClient::process_index() const { return 0; }
+
+StatusOr<PjRtDevice*> CompileOnlyPjRtClient::LookupDevice(
+    PjRtGlobalDeviceId global_device_id) const {
+  return Unimplemented("LookupDevice not available with compile-only client.");
+}
+
+StatusOr<PjRtDevice*> CompileOnlyPjRtClient::LookupAddressableDevice(
+    PjRtLocalDeviceId local_device_id) const {
+  return Unimplemented(
+      "LookupAddressableDevice not available with compile-only client.");
+}
+std::shared_ptr<PjRtTopologyDescription> CompileOnlyPjRtClient::get_topology()
+    const {
+  return topology_;
+}
+
+absl::Span<PjRtMemorySpace* const> CompileOnlyPjRtClient::memory_spaces()
+    const {
+  return {};
+}
+
+PjRtRuntimeType CompileOnlyPjRtClient::runtime_type() const {
+  return PjRtRuntimeType::kTfrt;
+}
+
+absl::string_view CompileOnlyPjRtClient::platform_name() const { return "AOT"; }
+absl::string_view CompileOnlyPjRtClient::platform_version() const {
+  return topology_->platform_version();
+}
+PjRtPlatformId CompileOnlyPjRtClient::platform_id() const {
+  return topology_->platform_id();
+}
+StatusOr<DeviceAssignment> CompileOnlyPjRtClient::GetDefaultDeviceAssignment(
+    int num_replicas, int num_partitions) const {
+  return Unimplemented(
+      "GetDefaultDeviceAssignment not available with compile-only client.");
+}
+StatusOr<Layout> CompileOnlyPjRtClient::GetDefaultLayout(
+    PrimitiveType element_type, absl::Span<const int64_t> dims) {
+  return Unimplemented(
+      "GetDefaultLayout not available with compile-only client.");
+}
+
+StatusOr<std::unique_ptr<HloCostAnalysis>>
+CompileOnlyPjRtClient::GetHloCostAnalysis() const {
+  return Unimplemented("");
+}
+
+StatusOr<std::unique_ptr<PjRtLoadedExecutable>> CompileOnlyPjRtClient::Compile(
+    const XlaComputation& computation, CompileOptions options) {
+  return Unimplemented("");
+}
+
+StatusOr<std::unique_ptr<PjRtLoadedExecutable>> CompileOnlyPjRtClient::Compile(
+    mlir::ModuleOp module, CompileOptions options) {
+  return Unimplemented("");
+}
+
+StatusOr<std::unique_ptr<PjRtLoadedExecutable>>
+CompileOnlyPjRtClient::DeserializeExecutable(
+    absl::string_view serialized, std::optional<CompileOptions> options) {
+  return Unimplemented("DeserializeExecutable not implemented.");
+}
+
+StatusOr<std::unique_ptr<xla::PjRtBuffer>>
+CompileOnlyPjRtClient::CreateUninitializedBuffer(const Shape& shape,
+                                                 PjRtDevice* device) {
+  return Unimplemented("CreateUninitializedBuffer not implemented.");
+}
+
+StatusOr<std::unique_ptr<PjRtClient::AsyncHostToDeviceTransferManager>>
+CompileOnlyPjRtClient::CreateBuffersForAsyncHostToDevice(
+    absl::Span<const Shape> shapes, PjRtMemorySpace* memory_space) {
+  return Unimplemented("");
+}
+
+StatusOr<std::unique_ptr<PjRtClient::AsyncHostToDeviceTransferManager>>
+CompileOnlyPjRtClient::CreateBuffersForAsyncHostToDevice(
+    absl::Span<const Shape> shapes, PjRtDevice* device) {
+  return Unimplemented("");
+}
+
+StatusOr<std::unique_ptr<PjRtBuffer>>
+CompileOnlyPjRtClient::BufferFromHostBuffer(
+    const void* data, PrimitiveType type, absl::Span<int64_t const> dims,
+    std::optional<absl::Span<int64_t const>> byte_strides,
+    HostBufferSemantics host_buffer_semantics,
+    absl::AnyInvocable<void() &&> on_done_with_host_buffer,
+    PjRtDevice* device) {
+  // return Unimplemented{""};
+  std::vector<Shape> tuple_shape;
+  absl::Span<const bool> dynamic_dimensions;
+  Shape shape(type, dims, dynamic_dimensions, tuple_shape);
+  return std::make_unique<CompileOnlyPjRtBuffer>(
+      shape, static_cast<CompileOnlyPjRtDevice*>(device), nullptr);
+}
+
+StatusOr<std::unique_ptr<PjRtBuffer>>
+CompileOnlyPjRtClient::BufferFromHostLiteral(const LiteralSlice& literal,
+                                             PjRtDevice* device) {
+  return Unimplemented("");
+}
+
+StatusOr<std::unique_ptr<PjRtBuffer>>
+CompileOnlyPjRtClient::CreateViewOfDeviceBuffer(
+    void* device_ptr, const Shape& shape, PjRtDevice* device,
+    std::function<void()> on_delete_callback,
+    std::optional<std::intptr_t> stream = std::nullopt) {
+  return Unimplemented("");
+}
+
+StatusOr<std::vector<std::unique_ptr<PjRtBuffer>>>
+CompileOnlyPjRtClient::MakeCrossHostReceiveBuffers(
+    absl::Span<const Shape> shapes, PjRtDevice* device,
+    PjRtCrossHostRecvNotifier notifier) {
+  return Unimplemented("");
+}
+
+StatusOr<std::vector<std::unique_ptr<PjRtBuffer>>>
+CompileOnlyPjRtClient::MakeCrossHostReceiveBuffersForGather(
+    absl::Span<const Shape> shapes, std::vector<GatherDetails> gather_details,
+    PjRtDevice* device, PjRtCrossHostRecvNotifier notifier) {
+  return Unimplemented("");
+}
+
+StatusOr<ChannelHandle> CompileOnlyPjRtClient::CreateChannelHandle() {
+  return Unimplemented("");
+}
+
+StatusOr<ChannelHandle>
+CompileOnlyPjRtClient::CreateDeviceToHostChannelHandle() {
+  return Unimplemented("");
+}
+
+StatusOr<ChannelHandle>
+CompileOnlyPjRtClient::CreateHostToDeviceChannelHandle() {
+  return Unimplemented("");
+}
+
+Status CompileOnlyPjRtClient::Defragment() { return Unimplemented(""); }
+}  // namespace xla

--- a/torch_xla/csrc/runtime/pjrt_compile_only.cc
+++ b/torch_xla/csrc/runtime/pjrt_compile_only.cc
@@ -58,13 +58,13 @@ StatusOr<std::unique_ptr<PjRtBuffer>> CompileOnlyPjRtBuffer::CopyToMemorySpace(
 }
 
 void CompileOnlyPjRtBuffer::CopyToRemoteDevice(
-    PjRtFuture<StatusOr<std::string>> serialized_descriptor,
+    PjRtFuture<std::string> serialized_descriptor,
     RemoteSendCallback on_done) {
   return;
 }
 
 void CompileOnlyPjRtBuffer::CopyToRemoteDeviceScattered(
-    PjRtFuture<StatusOr<std::vector<std::string>>> serialized_descriptors,
+    PjRtFuture<std::vector<std::string>> serialized_descriptors,
     std::vector<RemoteSendCallback> callbacks,
     const ScatterDetails& scatter_details) {
   return;

--- a/torch_xla/csrc/runtime/pjrt_compile_only.h
+++ b/torch_xla/csrc/runtime/pjrt_compile_only.h
@@ -58,9 +58,8 @@ class CompileOnlyPjRtBuffer final : public PjRtBuffer {
       PjRtDevice* dst_device) override;
   StatusOr<std::unique_ptr<PjRtBuffer>> CopyToMemorySpace(
       PjRtMemorySpace* dst_memory_space) override;
-  void CopyToRemoteDevice(
-      PjRtFuture<std::string> serialized_descriptor,
-      RemoteSendCallback on_done) override;
+  void CopyToRemoteDevice(PjRtFuture<std::string> serialized_descriptor,
+                          RemoteSendCallback on_done) override;
   void CopyToRemoteDeviceScattered(
       PjRtFuture<std::vector<std::string>> serialized_descriptors,
       std::vector<RemoteSendCallback> callbacks,

--- a/torch_xla/csrc/runtime/pjrt_compile_only.h
+++ b/torch_xla/csrc/runtime/pjrt_compile_only.h
@@ -1,0 +1,202 @@
+#ifndef XLA_CLIENT_PJRT_COMPILE_ONLY_H_
+#define XLA_CLIENT_PJRT_COMPILE_ONLY_H_
+
+#include "xla/pjrt/pjrt_client.h"
+#include "xla/pjrt/pjrt_compiler.h"
+#include "xla/pjrt/pjrt_future.h"
+
+namespace xla {
+
+// forward declaration
+class CompileOnlyPjRtDevice;
+
+class CompileOnlyPjRtClient;
+
+class CompileOnlyPjRtBuffer;
+
+class CompileOnlyPjRtExternalReference : public PjRtBuffer::ExternalReference {
+ public:
+  CompileOnlyPjRtExternalReference(CompileOnlyPjRtClient* client,
+                                   CompileOnlyPjRtBuffer* buffer,
+                                   void* data_ptr)
+      : client_(client), buffer_(buffer) {
+    data_ptr_ = data_ptr;
+  }
+  ~CompileOnlyPjRtExternalReference() override;
+
+ private:
+  CompileOnlyPjRtClient* client_;
+  CompileOnlyPjRtBuffer* buffer_;
+};
+
+class CompileOnlyPjRtBuffer final : public PjRtBuffer {
+ public:
+  CompileOnlyPjRtBuffer(const Shape& shape, CompileOnlyPjRtDevice* device,
+                        CompileOnlyPjRtClient* client) {
+    shape_ = shape;
+    device_ = device;
+    client_ = client;
+  }
+  const Shape& on_device_shape() const override;
+  PjRtMemorySpace* memory_space() const override;
+  PjRtDevice* device() const override;
+  PjRtClient* client() const override;
+  StatusOr<std::unique_ptr<ExternalReference>> AcquireExternalReference()
+      override;
+  PjRtFuture<> ToLiteral(MutableLiteralBase* literal) override;
+  PjRtFuture<> LazyToLiteral(
+      absl::AnyInvocable<absl::StatusOr<MutableLiteralBase*>() &&> generator)
+      override;
+  StatusOr<size_t> GetOnDeviceSizeInBytes() const override;
+  PjRtFuture<> CopyRawToHost(void* dst, int64_t offset,
+                             int64_t transfer_size) override;
+  void Delete() override;
+  StatusOr<std::unique_ptr<ExternalReference>> ReleaseDeviceMemoryOwnership(
+      bool wait_for_operations_to_complete) override;
+  bool IsDeleted() override;
+  StatusOr<std::unique_ptr<PjRtBuffer>> CopyToDevice(
+      PjRtDevice* dst_device) override;
+  StatusOr<std::unique_ptr<PjRtBuffer>> CopyToMemorySpace(
+      PjRtMemorySpace* dst_memory_space) override;
+  void CopyToRemoteDevice(
+      PjRtFuture<StatusOr<std::string>> serialized_descriptor,
+      RemoteSendCallback on_done) override;
+  void CopyToRemoteDeviceScattered(
+      PjRtFuture<StatusOr<std::vector<std::string>>> serialized_descriptors,
+      std::vector<RemoteSendCallback> callbacks,
+      const ScatterDetails& scatter_details) override;
+  PjRtFuture<> GetReadyFuture() override;
+  bool IsOnCpu() const override;
+
+ private:
+  Shape shape_;
+  CompileOnlyPjRtDevice* device_;
+  CompileOnlyPjRtClient* client_;
+};
+
+class CompileOnlyPjRtDevice final : public PjRtDevice {
+ public:
+  explicit CompileOnlyPjRtDevice(const PjRtDeviceDescription* description);
+
+  const PjRtDeviceDescription& description() const override;
+
+  PjRtClient* client() const override;
+  void SetClient(PjRtClient* client);
+  bool IsAddressable() const override;
+  int local_hardware_id() const override;
+
+  PjRtLocalDeviceId local_device_id() const override;
+
+  PjRtLocalHardwareId local_hardware_id_typed() const override;
+  std::unique_ptr<ScopedAsyncTrackingEvent> CreateAsyncTrackingEvent(
+      absl::string_view description) const override;
+  Status TransferToInfeed(const LiteralSlice& literal) override;
+  Status TransferFromOutfeed(MutableBorrowingLiteral literal) override;
+  absl::Span<PjRtMemorySpace* const> memory_spaces() const override;
+  StatusOr<PjRtMemorySpace*> default_memory_space() const override;
+
+  const PjRtDeviceDescription* description_;
+  PjRtClient* client_;
+};
+
+class CompileOnlyPjRtClient final : public xla::PjRtClient {
+ public:
+  explicit CompileOnlyPjRtClient(
+      std::shared_ptr<PjRtTopologyDescription> topology);
+  int device_count() const override;
+  int addressable_device_count() const override;
+  absl::Span<PjRtDevice* const> devices() const override;
+  // if we don't implement this, this will raise error in GetDefaultDevice()
+  absl::Span<PjRtDevice* const> addressable_devices() const override;
+  int process_index() const override;
+
+  StatusOr<PjRtDevice*> LookupDevice(
+      PjRtGlobalDeviceId global_device_id) const override;
+
+  StatusOr<PjRtDevice*> LookupAddressableDevice(
+      PjRtLocalDeviceId local_device_id) const override;
+
+  absl::Span<PjRtMemorySpace* const> memory_spaces() const override;
+
+  PjRtRuntimeType runtime_type() const override;
+
+  absl::string_view platform_name() const override;
+  absl::string_view platform_version() const override;
+  PjRtPlatformId platform_id() const override;
+
+  StatusOr<DeviceAssignment> GetDefaultDeviceAssignment(
+      int num_replicas, int num_partitions) const override;
+  StatusOr<Layout> GetDefaultLayout(PrimitiveType element_type,
+                                    absl::Span<const int64_t> dims) override;
+
+  StatusOr<std::unique_ptr<HloCostAnalysis>> GetHloCostAnalysis()
+      const override;
+
+  StatusOr<std::unique_ptr<PjRtLoadedExecutable>> Compile(
+      const XlaComputation& computation, CompileOptions options) override;
+
+  StatusOr<std::unique_ptr<PjRtExecutable>> CompileUnloaded(
+      const XlaComputation& computation, CompileOptions options);
+
+  StatusOr<std::unique_ptr<PjRtLoadedExecutable>> Compile(
+      mlir::ModuleOp module, CompileOptions options) override;
+
+  StatusOr<std::unique_ptr<PjRtLoadedExecutable>> DeserializeExecutable(
+      absl::string_view serialized, std::optional<CompileOptions> options);
+
+  StatusOr<std::unique_ptr<PjRtBuffer>> CreateUninitializedBuffer(
+      const Shape& shape, PjRtDevice* device) override;
+
+  StatusOr<std::unique_ptr<AsyncHostToDeviceTransferManager>>
+  CreateBuffersForAsyncHostToDevice(absl::Span<const Shape> shapes,
+                                    PjRtMemorySpace* memory_space) override;
+
+  StatusOr<std::unique_ptr<AsyncHostToDeviceTransferManager>>
+  CreateBuffersForAsyncHostToDevice(absl::Span<const Shape> shapes,
+                                    PjRtDevice* device) override;
+
+  StatusOr<std::unique_ptr<PjRtBuffer>> BufferFromHostBuffer(
+      const void* data, PrimitiveType type, absl::Span<int64_t const> dims,
+      std::optional<absl::Span<int64_t const>> byte_strides,
+      HostBufferSemantics host_buffer_semantics,
+      absl::AnyInvocable<void() &&> on_done_with_host_buffer,
+      PjRtDevice* device) override;
+
+  StatusOr<std::unique_ptr<PjRtBuffer>> BufferFromHostLiteral(
+      const LiteralSlice& literal, PjRtDevice* device) override;
+
+  StatusOr<std::unique_ptr<PjRtBuffer>> CreateViewOfDeviceBuffer(
+      void* device_ptr, const Shape& shape, PjRtDevice* device,
+      std::function<void()> on_delete_callback,
+      std::optional<std::intptr_t> stream) override;
+
+  StatusOr<std::vector<std::unique_ptr<PjRtBuffer>>>
+  MakeCrossHostReceiveBuffers(absl::Span<const Shape> shapes,
+                              PjRtDevice* device,
+                              PjRtCrossHostRecvNotifier notifier) override;
+
+  StatusOr<std::vector<std::unique_ptr<PjRtBuffer>>>
+  MakeCrossHostReceiveBuffersForGather(
+      absl::Span<const Shape> shapes, std::vector<GatherDetails> gather_details,
+      PjRtDevice* device, PjRtCrossHostRecvNotifier notifier) override;
+
+  StatusOr<ChannelHandle> CreateChannelHandle() override;
+
+  StatusOr<ChannelHandle> CreateDeviceToHostChannelHandle() override;
+
+  StatusOr<ChannelHandle> CreateHostToDeviceChannelHandle() override;
+
+  Status Defragment() override;
+
+  std::shared_ptr<PjRtTopologyDescription> get_topology() const;
+
+ private:
+  std::shared_ptr<PjRtTopologyDescription> topology_;
+  std::vector<std::unique_ptr<const PjRtDeviceDescription>> descriptions_;
+  std::vector<std::unique_ptr<CompileOnlyPjRtDevice>> owned_devices_;
+  std::vector<PjRtDevice*> devices_;
+};
+
+}  // namespace xla
+
+#endif

--- a/torch_xla/csrc/runtime/pjrt_compile_only.h
+++ b/torch_xla/csrc/runtime/pjrt_compile_only.h
@@ -59,10 +59,10 @@ class CompileOnlyPjRtBuffer final : public PjRtBuffer {
   StatusOr<std::unique_ptr<PjRtBuffer>> CopyToMemorySpace(
       PjRtMemorySpace* dst_memory_space) override;
   void CopyToRemoteDevice(
-      PjRtFuture<StatusOr<std::string>> serialized_descriptor,
+      PjRtFuture<std::string> serialized_descriptor,
       RemoteSendCallback on_done) override;
   void CopyToRemoteDeviceScattered(
-      PjRtFuture<StatusOr<std::vector<std::string>>> serialized_descriptors,
+      PjRtFuture<std::vector<std::string>> serialized_descriptors,
       std::vector<RemoteSendCallback> callbacks,
       const ScatterDetails& scatter_details) override;
   PjRtFuture<> GetReadyFuture() override;

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -298,6 +298,20 @@ class PjRtComputationClient : public ComputationClient {
     std::optional<std::vector<xla::OpSharding>> output_shardings_;
   };
 
+  // Used for AOT compilation.
+  struct PjRtUnloadedComputation : public Computation {
+    PjRtUnloadedComputation(xla::XlaComputation computation,
+                            std::vector<std::string> devices,
+                            std::unique_ptr<xla::PjRtExecutable> executable)
+        : Computation(std::move(computation), std::move(devices)),
+          executable(std::move(executable)) {
+      output_shardings_ = this->executable->GetOutputShardings();
+    }
+
+    std::unique_ptr<xla::PjRtExecutable> executable;
+    std::optional<std::vector<xla::OpSharding>> output_shardings_;
+  };
+
   // Use XLA replication to re-assemble the sharded data.
   std::shared_ptr<PjRtData> ReplicateShardedData(const DataPtr& handle);
 };


### PR DESCRIPTION
## Summary
This is the first commit for supporting AOT compilation. Basically this allows us to compile TPU XLA executable on a CPU devices. Below is the command to run AOT compilation:
```
PJRT_DEVICE=AOT-v4:2x2x1  XLA_PERSISTENT_CACHE_PATH=./  python sample.py
```
In the command, we need two things:
1. Setup `PJRT_DEVICE`  to `AOT-...`. The suffix part should be the topology of the targeting TPU device that we want to compile.
2. Enable persistent cache like `XLA_PERSISTENT_CACHE_PATH=./ `. This will generate the XLA executable file in the current folder.

To use the XLA executable on a TPU device, we can use the following command:
```
PJRT_DEVICE=TPU  XLA_PERSISTENT_CACHE_PATH=./  python sample.py
```
If everything works fine, you should be able to see the executable deserialization successfully.

###  Example of `sample.py`:
```
import torch
import torch_xla
import torch_xla.core.xla_model as xm

a = torch.rand([2,3])
b = torch.rand([2,3])
device = xm.xla_device()
a = a.to(device)
b = b.to(device)

f = torch.hstack([a,b])

# for compile, use torch_xla._XLAC._xla_warm_up_cache([f],[]). you can also use print or mark_step. Those two will trigger errors but can still can produce the executable.
# for execution, use print(f) or mark_step().
```

## Some todo items:
1. Add the unit test for the AOT compilation;
2. Support of dynamo compilation.
