### PR TITLE
Manually push to `gh-pages` branch

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -53,22 +53,11 @@ jobs:
         subdir=${{ env.BRANCH_NAME == 'master' && 'master' || format('{0}/{1}', 'release', env.BRANCH_NAME) }}
         mkdir -p gh-pages/$subdir
         cp -fR pytorch/xla/docs/build/* gh-pages/$subdir
-    - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
-      with:
-        path: 'gh-pages'
-  deploy:
-    needs: build-docs
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-
-    # Deploy to the github-pages environment
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v4
-      with:
-        token: ${{ secrets.torchxla-bot-token }}
+    - name: Deploy
+      shell: bash
+      run: |
+        cd gh-pages
+        git add . -v
+        git commit -m "Update doc from commit ${{ github.sha }}"
+        git remote add pages https://torchxlabot2:${{ secrets.torchxla-bot-token }}@github.com/pytorch/xla
+        git push --dry-run pages gh-pages


### PR DESCRIPTION
`actions/deploy-pages@v4` requires some extra permissions that our robot account does not have.

Testing with a dry run first. `Deploy` should be disabled for PRs before merging.