### PR TITLE
Don't fail docs push if there's nothing to commit

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -66,6 +66,6 @@ jobs:
         git config user.email "pytorchxla@gmail.com"
         git config user.name "torchxlabot2"
         git add . -v
-        git commit -m "Update doc from commit ${{ github.sha }}"
+        git diff --cached --exit-code || git commit -m "Update doc from commit ${{ github.sha }}"
         git push origin gh-pages
       if: github.event_name == 'push'


### PR DESCRIPTION
`git` returns 1 when there's nothing to commit. Check for staged files before committing.

Fixes:

```
Your branch is up to date with 'origin/gh-pages'.

nothing to commit, working tree clean
Error: Process completed with exit code 1.
```

https://github.com/pytorch/xla/actions/runs/8895827594/job/24428956451

This error is harmless but shows up as a failure.