### PR TITLE
Tag CI build with git hash

### DIFF
--- a/.github/workflows/_build_torch_xla.yml
+++ b/.github/workflows/_build_torch_xla.yml
@@ -24,7 +24,6 @@ jobs:
     env:
       GCLOUD_SERVICE_KEY: ${{ secrets.gcloud-service-key }}
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/default_credentials.json
-      GIT_VERSIONED_XLA_BUILD: 1
       BAZEL_JOBS: 16
       BAZEL_REMOTE_CACHE: 1
       BUILD_CPP_TESTS: 1
@@ -47,7 +46,7 @@ jobs:
         shell: bash
         run: |
           cd pytorch/xla/infra/ansible
-          ansible-playbook playbook.yaml -vvv -e "stage=build arch=amd64 accelerator=tpu src_root=${GITHUB_WORKSPACE} bundle_libtpu=0 build_cpp_tests=1 cache_suffix=-ci" --skip-tags=fetch_srcs,install_deps
+          ansible-playbook playbook.yaml -vvv -e "stage=build arch=amd64 accelerator=tpu src_root=${GITHUB_WORKSPACE} bundle_libtpu=0 build_cpp_tests=1 git_versioned_xla_build=1 cache_suffix=-ci" --skip-tags=fetch_srcs,install_deps
       - name: Upload wheel
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/_build_torch_xla.yml
+++ b/.github/workflows/_build_torch_xla.yml
@@ -24,6 +24,7 @@ jobs:
     env:
       GCLOUD_SERVICE_KEY: ${{ secrets.gcloud-service-key }}
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/default_credentials.json
+      GIT_VERSIONED_XLA_BUILD: 1
       BAZEL_JOBS: 16
       BAZEL_REMOTE_CACHE: 1
       BUILD_CPP_TESTS: 1

--- a/infra/ansible/config/env.yaml
+++ b/infra/ansible/config/env.yaml
@@ -33,7 +33,7 @@ build_env:
     BAZEL_REMOTE_CACHE: 1
     SILO_NAME: "cache-silo-{{ arch }}-{{ accelerator }}-{{ clang_version }}{{ cache_suffix }}"
     _GLIBCXX_USE_CXX11_ABI: 0
-    GIT_VERSIONED_XLA_BUILD: "{{ nightly_release }}"
+    GIT_VERSIONED_XLA_BUILD: "{{ nightly_release || git_versioned_xla_build }}"
 
   amd64:
     ARCH: amd64

--- a/infra/ansible/config/env.yaml
+++ b/infra/ansible/config/env.yaml
@@ -33,7 +33,7 @@ build_env:
     BAZEL_REMOTE_CACHE: 1
     SILO_NAME: "cache-silo-{{ arch }}-{{ accelerator }}-{{ clang_version }}{{ cache_suffix }}"
     _GLIBCXX_USE_CXX11_ABI: 0
-    GIT_VERSIONED_XLA_BUILD: "{{ nightly_release || git_versioned_xla_build }}"
+    GIT_VERSIONED_XLA_BUILD: "{{ nightly_release | git_versioned_xla_build }}"
 
   amd64:
     ARCH: amd64

--- a/infra/ansible/config/env.yaml
+++ b/infra/ansible/config/env.yaml
@@ -33,7 +33,7 @@ build_env:
     BAZEL_REMOTE_CACHE: 1
     SILO_NAME: "cache-silo-{{ arch }}-{{ accelerator }}-{{ clang_version }}{{ cache_suffix }}"
     _GLIBCXX_USE_CXX11_ABI: 0
-    GIT_VERSIONED_XLA_BUILD: "{{ nightly_release | git_versioned_xla_build }}"
+    GIT_VERSIONED_XLA_BUILD: "{{ nightly_release or git_versioned_xla_build }}"
 
   amd64:
     ARCH: amd64

--- a/infra/ansible/config/vars.yaml
+++ b/infra/ansible/config/vars.yaml
@@ -16,3 +16,5 @@ bundle_libtpu: 1
 cache_suffix: ""
 # Whether to build C++ tests with `torch_xla` wheel
 build_cpp_tests: 0
+# Whether to tag wheels with git hash, e.g. X.Y.Z+git123abc
+git_versioned_xla_build: false


### PR DESCRIPTION
This will make the logs slightly clearer and bring the git hash back to the generated docs page: https://github.com/pytorch/xla/commit/e0afb7127461b828606374d143e7c3c7687ef1f6