### PR TITLE
Complain when TensorFlow is installed

### DIFF
--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -200,9 +200,10 @@ try:
   dist = importlib.metadata.distribution('tensorflow')
   warnings.warn(
       "`tensorflow` can conflict with `torch-xla`. Prefer `tensorflow-cpu` when"
-      " using PyTorch/XLA. To silence this warning, `pip uninstall tensorflow "
-      " && pip install tensorflow-cpu`. If you are in a notebook environment "
-      "such as Colab or Kaggle, restart your notebook runtime afterwards.")
+      " using PyTorch/XLA. To silence this warning, `pip uninstall -y "
+      "tensorflow && pip install tensorflow-cpu`. If you are in a notebook "
+      "environment such as Colab or Kaggle, restart your notebook runtime "
+      "afterwards.")
 except importlib.metadata.PackageNotFoundError:
   pass
 

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -192,6 +192,20 @@ import torch._functorch.config
 
 torch._functorch.config.view_replay_for_aliased_outputs = True
 
+import importlib.metadata
+import warnings
+
+try:
+  # TensorFlow TPU distribution has the same package name as GPU, but not CPU
+  dist = importlib.metadata.distribution('tensorflow')
+  warnings.warn(
+      "`tensorflow` can conflict with `torch-xla`. Prefer `tensorflow-cpu` when"
+      " using PyTorch/XLA. To silence this warning, `pip uninstall tensorflow "
+      " && pip install tensorflow-cpu`. If you are in a notebook environment "
+      "such as Colab or Kaggle, restart your notebook runtime afterwards.")
+except importlib.metadata.PackageNotFoundError:
+  pass
+
 from .stablehlo import save_as_stablehlo, save_torch_model_as_stablehlo
 
 from .experimental import plugins


### PR DESCRIPTION
Tell users to uninstall `tensorflow` and use `tensorflow-cpu` instead. This issue comes up frequently. Examples:

- https://github.com/pytorch/xla/issues/5625#issuecomment-1743493309
- https://github.com/pytorch/xla/issues/6565#issuecomment-1965333883
- https://github.com/pytorch/xla/issues/6990#issuecomment-2083752391

Example:

```
# python 
...
>>> import torch_xla
/workspaces/work/pytorch/xla/torch_xla/__init__.py:201: UserWarning: `tensorflow` can conflict with `torch-xla`. Prefer `tensorflow-cpu` when using PyTorch/XLA. To silence this warning, `pip uninstall tensorflow  && pip install tensorflow-cpu`. If you are in a notebook environment such as Colab or Kaggle, restart your notebook runtime afterwards.
  warnings.warn(
>>> 
# pip uninstall tensorflow && pip install tensorflow-cpu
...
# python
...
>>> import torch_xla
>>>
```

Checked in Kaggle too:

![image](https://github.com/pytorch/xla/assets/15197278/c147133f-b8a3-4bdb-8fe9-58f15b09f77c)

cc @djherbis @sagelywizard because this will start printing an annoying warning in Kaggle and Colab
