### PR TITLE
Clean up workspace before test

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -46,7 +46,7 @@ jobs:
       BAZEL_JOBS: 16
     steps:
       # See https://github.com/actions/checkout/issues/1014#issuecomment-1906802802
-      - name: Fix workspace permissions
+      - name: Clean up workspace
         run: |
           ls -la
           sudo rm -rvf ${GITHUB_WORKSPACE}/*

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -73,6 +73,11 @@ jobs:
       BAZEL_JOBS: 16
       BAZEL_REMOTE_CACHE: 1
     steps:
+      # See https://github.com/actions/checkout/issues/1014#issuecomment-1906802802
+      - name: Clean up workspace
+        run: |
+          ls -la
+          rm -rvf ${GITHUB_WORKSPACE}/*
       - name: Setup gcloud
         shell: bash
         run: |


### PR DESCRIPTION
Should fix this error:

```
Import check...
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/__w/xla/xla/torch_xla/__init__.py", line 152, in <module>
    from .version import __version__
ModuleNotFoundError: No module named 'torch_xla.version'
```

https://github.com/pytorch/xla/actions/runs/8898851270/job/24437801900

This results from combination of questionable decisions from both GitHub and Python. First, GHA does not guarantee that the workspace is actually empty. In this case, `torch_xla/` is still checked out from a previous run. Since there is a local `torch_xla` directory, Python gives this precedence over the installed `torch_xla` package.

Just delete everything in the workspace before running tests to eliminate non-determinism.