### PR TITLE
Expose python unsafe buffer pointer

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2421,6 +2421,16 @@ class TestGeneric(test_utils.XlaTestCase):
     # 0-dimensional scalar-tensor
     # Has a different execution path than other tensors.
     self._test_move_tensor_cuda_to_xla(torch.tensor(42))
+  
+  def test_unsafe_buffer_pointer(self):
+    xla_tensor_0 = torch.tensor(42, device=xm.xla_device())
+    xla_tensor_1 = torch.ones((5, 5), device=xm.xla_device())
+    buf_ptr_0 = torch_xla._XLAC._unsafe_buffer_pointer(xla_tensor_0)
+    buf_ptr_1 = torch_xla._XLAC._unsafe_buffer_pointer(xla_tensor_1)
+    self.assertGreaterEqual(buf_ptr_0, 0)
+    self.assertGreaterEqual(buf_ptr_1, 0)
+
+
 
 
 class SimpleModelWithDropout(torch.nn.Module):

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2421,28 +2421,24 @@ class TestGeneric(test_utils.XlaTestCase):
     # 0-dimensional scalar-tensor
     # Has a different execution path than other tensors.
     self._test_move_tensor_cuda_to_xla(torch.tensor(42))
-  
+
   def test_unsafe_buffer_pointer(self):
-    xla_device = xm.xla_device() 
-    xla_tensor_0 = torch.tensor(42).to(xla_device) # didn't change anything
-    # `mark_step` ensures xla_tensor_0's CurrentDataHandle() != nullptr
+    xla_device = xm.xla_device()
+    xla_tensor_0 = torch.tensor(42).to(xla_device)
+    # `mark_step` ensures xtensor->CurrentDataHandle() != nullptr
     xm.mark_step()
     buf_ptr_0 = torch_xla._XLAC._unsafe_buffer_pointer(xla_tensor_0)
     self.assertGreaterEqual(buf_ptr_0, 0)
-    print('test_0 passed, buf_ptr_0=', buf_ptr_0)
 
+    # xtensor->CurrentDataHandle() == nullptr but xtensor->CurrentIrValue().node != nullptr and device_data != nullptr
     xla_tensor_1 = torch.tensor(42, device=xm.xla_device())
     buf_ptr_1 = torch_xla._XLAC._unsafe_buffer_pointer(xla_tensor_1)
     self.assertGreaterEqual(buf_ptr_1, 0)
-    print('test_1 passed, buf_ptr_1=', buf_ptr_1)
 
-    # xla_tensor_1 = torch.ones((5, 5), device=xm.xla_device()) # this goes to branch: xtensor->CurrentIrValue().node != nullptr and device_data == nullptr, that is it's not a device_data.
-    xla_tensor_2 = torch.ones((5, 5)).to(xla_device) # this works and goes to branch" xtensor->CurrentIrValue().node != nullptr and device_data != nullptr
+    # xtensor->CurrentDataHandle() == nullptr but xtensor->CurrentIrValue().node != nullptr and device_data != nullptr
+    xla_tensor_2 = torch.ones((5, 5)).to(xla_device)
     buf_ptr_2 = torch_xla._XLAC._unsafe_buffer_pointer(xla_tensor_2)
     self.assertGreaterEqual(buf_ptr_2, 0)
-    print('test_1 passed, buf_ptr_2=', buf_ptr_2)
-
-
 
 
 class SimpleModelWithDropout(torch.nn.Module):

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2482,10 +2482,12 @@ void InitXlaModuleBindings(py::module m) {
               return runtime::GetComputationClient()->UnsafeBufferPointer(
                   UnwrapXlaData(data));
             } else {
-              XLA_ERROR() << "Could not get the buffer pointer.";
+              XLA_ERROR() << "Could not get the buffer pointer for XLATensor "
+                             "with IR that's not DeviceData";
             }
           }
-          XLA_ERROR() << "Could not get the buffer pointer.";
+          XLA_ERROR() << "Could not get the buffer pointer for XLATensor "
+                         "without a data handle or an IR.";
         });
 
   // -------------Dynamo Integration API Start-------------------------

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2475,8 +2475,6 @@ void InitXlaModuleBindings(py::module m) {
                     xtensor->CurrentDataHandle());
             return runtime::GetComputationClient()->UnsafeBufferPointer(data);
           } else if (xtensor->CurrentIrValue().node != nullptr) {
-            // DeviceData* device_data =
-            // torch_xla::DeviceData::Cast(xtensor->CurrentIrValue().node.get());
             DeviceData* device_data =
                 DeviceData::Cast(xtensor->CurrentIrValue().node.get());
             if (device_data != nullptr) {

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2448,8 +2448,10 @@ void InitXlaModuleBindings(py::module m) {
   m.def("_get_buffer_donation", [](const at::Tensor& input) -> bool {
     XLATensorPtr xtensor = bridge::GetXlaTensor(input);
     if (!xtensor) {
+      std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": _get_buffer_donation: xtensor is null" << std::endl;
       return false;
     } else if (xtensor->CurrentDataHandle() != nullptr) {
+      std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": _get_buffer_donation: xtensor->CurrentDataHandle() != nullptr" << std::endl;
       auto data = std::dynamic_pointer_cast<runtime::ComputationClient::Data>(
           xtensor->CurrentDataHandle());
       return data->should_donate_buffer();
@@ -2457,26 +2459,38 @@ void InitXlaModuleBindings(py::module m) {
       auto device_data =
           torch_xla::DeviceData::Cast(xtensor->CurrentIrValue().node.get());
       if (device_data != nullptr) {
+        std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": _get_buffer_donation: xtensor->CurrentIrValue().node != nullptr and device_data != nullptr" << std::endl;
         return device_data->get_buffer_donation();
       } else {
+        std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": _get_buffer_donation: xtensor->CurrentIrValue().node != nullptr and device_data == nullptr" << std::endl;
         return false;
       }
     }
     return false;
   });
 
-  m.def("_unsafe_buffer_pointer", [](const at::Tensor& input) -> int) {
+  m.def("_unsafe_buffer_pointer", [](const at::Tensor& input) -> std::uintptr_t {
     XLATensorPtr xtensor = bridge::GetXlaTensor(input);
     XLA_CHECK(xtensor) << "The input is not an XLA tensor.";
     if (xtensor->CurrentDataHandle() != nullptr) {
+      std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": " << std::endl;
       std::shared_ptr<runtime::ComputationClient::Data> data = std::dynamic_pointer_cast<runtime::ComputationClient::Data>(
           xtensor->CurrentDataHandle());
-      // std::vector<xla::Literal> literals =
-      //   runtime::GetComputationClient()->TransferFromDevice(
-      //       UnwrapXlaData(device_data)); 
-      return runtime::GetComputationClient()->UnsafeBufferPointer(UnwrapXlaData(device_data));
+      return runtime::GetComputationClient()->UnsafeBufferPointer(data);
+    } else if (xtensor->CurrentIrValue().node != nullptr) {
+      // DeviceData* device_data = torch_xla::DeviceData::Cast(xtensor->CurrentIrValue().node.get());
+      DeviceData* device_data = DeviceData::Cast(xtensor->CurrentIrValue().node.get());
+      if (device_data != nullptr) {
+        torch::lazy::BackendDataPtr data = device_data->data();
+        std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": " << std::endl;
+        return runtime::GetComputationClient()->UnsafeBufferPointer(UnwrapXlaData(data));
+      } else {
+        XLA_ERROR() << "Could not get the buffer pointer.";
+        std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": " << std::endl;
+      }
     }
-  }
+    XLA_ERROR() << "Could not get the buffer pointer.";
+  });
 
   // -------------Dynamo Integration API Start-------------------------
   /*

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2465,6 +2465,19 @@ void InitXlaModuleBindings(py::module m) {
     return false;
   });
 
+  m.def("_unsafe_buffer_pointer", [](const at::Tensor& input) -> int) {
+    XLATensorPtr xtensor = bridge::GetXlaTensor(input);
+    XLA_CHECK(xtensor) << "The input is not an XLA tensor.";
+    if (xtensor->CurrentDataHandle() != nullptr) {
+      std::shared_ptr<runtime::ComputationClient::Data> data = std::dynamic_pointer_cast<runtime::ComputationClient::Data>(
+          xtensor->CurrentDataHandle());
+      // std::vector<xla::Literal> literals =
+      //   runtime::GetComputationClient()->TransferFromDevice(
+      //       UnwrapXlaData(device_data)); 
+      return runtime::GetComputationClient()->UnsafeBufferPointer(UnwrapXlaData(device_data));
+    }
+  }
+
   // -------------Dynamo Integration API Start-------------------------
   /*
    * Return tensor ids and at::tensors for all DeviceData nodes that is needed

--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -92,7 +92,6 @@ cc_library(
         "@xla//xla/pjrt/distributed",
         "@xla//xla/python/ifrt",
         "@xla//xla/python/pjrt_ifrt",
-        "@local_config_python//:python_headers",
     ],
 )
 

--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -92,6 +92,7 @@ cc_library(
         "@xla//xla/pjrt/distributed",
         "@xla//xla/python/ifrt",
         "@xla//xla/python/pjrt_ifrt",
+        "@local_config_python//:python_headers",
     ],
 )
 

--- a/torch_xla/csrc/runtime/computation_client.h
+++ b/torch_xla/csrc/runtime/computation_client.h
@@ -302,6 +302,8 @@ class ComputationClient {
   virtual std::vector<xla::Literal> TransferFromDevice(
       absl::Span<const DataPtr> handles) = 0;
 
+  virtual std::uintptr_t UnsafeBufferPointer(const DataPtr handle) = 0;
+
   // Compiles a set of computations.
   virtual std::vector<ComputationPtr> Compile(
       std::vector<CompileInstance> instances) = 0;

--- a/torch_xla/csrc/runtime/ifrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.cc
@@ -397,7 +397,8 @@ tsl::RCReference<xla::ifrt::Array> IfrtComputationClient::ReplicateShardedData(
   return *replicated_output;
 }
 
-std::uintptr_t IfrtComputationClient::UnsafeBufferPointer(const DataPtr handle) {
+std::uintptr_t IfrtComputationClient::UnsafeBufferPointer(
+    const DataPtr handle) {
   XLA_ERROR() << __FUNCTION__ << " not implemented";
 }
 

--- a/torch_xla/csrc/runtime/ifrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.cc
@@ -28,7 +28,6 @@
 #include "xla/python/ifrt/memory.h"
 #include "xla/python/ifrt/sharding.h"
 #include "xla/python/pjrt_ifrt/pjrt_array.h"
-#include "xla/python/py_array.h"
 #include "xla/python/pjrt_ifrt/pjrt_client.h"
 #include "xla/python/pjrt_ifrt/xla_sharding.h"
 #include "xla/shape.h"
@@ -399,12 +398,7 @@ tsl::RCReference<xla::ifrt::Array> IfrtComputationClient::ReplicateShardedData(
 }
 
 std::uintptr_t IfrtComputationClient::UnsafeBufferPointer(const DataPtr handle) {
-  std::shared_ptr<IfrtData> ifrt_data = std::dynamic_pointer_cast<IfrtData>(handle);
-  XLA_CHECK(ifrt_data);
-  xla::PjRtBuffer* pjrt_buffer = xla::GetPjrtBuffer((ifrt_data->buffer.get()));
-  xla::StatusOr<std::uintptr_t> ptr = client_->pjrt_client()->UnsafeBufferPointer(pjrt_buffer);
-  XLA_CHECK(ptr.ok());
-  return ptr.value();
+  XLA_ERROR() << __FUNCTION__ << " not implemented";
 }
 
 std::vector<xla::Literal> IfrtComputationClient::TransferFromDevice(

--- a/torch_xla/csrc/runtime/ifrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.cc
@@ -28,6 +28,7 @@
 #include "xla/python/ifrt/memory.h"
 #include "xla/python/ifrt/sharding.h"
 #include "xla/python/pjrt_ifrt/pjrt_array.h"
+#include "xla/python/py_array.h"
 #include "xla/python/pjrt_ifrt/pjrt_client.h"
 #include "xla/python/pjrt_ifrt/xla_sharding.h"
 #include "xla/shape.h"
@@ -395,6 +396,15 @@ tsl::RCReference<xla::ifrt::Array> IfrtComputationClient::ReplicateShardedData(
               xla::ifrt::ArrayCopySemantics::kAlwaysCopy);
   // TODO: sanity check outputs
   return *replicated_output;
+}
+
+std::uintptr_t IfrtComputationClient::UnsafeBufferPointer(const DataPtr handle) {
+  std::shared_ptr<IfrtData> ifrt_data = std::dynamic_pointer_cast<IfrtData>(handle);
+  XLA_CHECK(ifrt_data);
+  xla::PjRtBuffer* pjrt_buffer = xla::GetPjrtBuffer((ifrt_data->buffer.get()));
+  xla::StatusOr<std::uintptr_t> ptr = client_->pjrt_client()->UnsafeBufferPointer(pjrt_buffer);
+  XLA_CHECK(ptr.ok());
+  return ptr.value();
 }
 
 std::vector<xla::Literal> IfrtComputationClient::TransferFromDevice(

--- a/torch_xla/csrc/runtime/ifrt_computation_client.h
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.h
@@ -53,7 +53,7 @@ class IfrtComputationClient : public ComputationClient {
 
   std::vector<xla::Literal> TransferFromDevice(
       absl::Span<const DataPtr> handles) override;
-  
+
   std::uintptr_t UnsafeBufferPointer(const DataPtr handle) override;
 
   DataPtr TransferShardsToDevice(

--- a/torch_xla/csrc/runtime/ifrt_computation_client.h
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.h
@@ -53,6 +53,8 @@ class IfrtComputationClient : public ComputationClient {
 
   std::vector<xla::Literal> TransferFromDevice(
       absl::Span<const DataPtr> handles) override;
+  
+  std::uintptr_t UnsafeBufferPointer(const DataPtr handle) override;
 
   DataPtr TransferShardsToDevice(
       absl::Span<const std::shared_ptr<const TensorSource>> tensor_shards,

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -458,6 +458,14 @@ std::vector<ComputationClient::DataPtr> PjRtComputationClient::ReshardData(
   return resharded_results;
 }
 
+std::uintptr_t PjRtComputationClient::UnsafeBufferPointer(const DataPtr handle) {
+  std::shared_ptr<PjRtData> pjrt_data = ReplicateShardedData(handle);
+  XLA_CHECK(pjrt_data);
+  xla::StatusOr<std::uintptr_t> ptr = client_->UnsafeBufferPointer(pjrt_data->buffer.get());
+  XLA_CHECK(ptr.ok());
+  return ptr.value();
+}
+
 std::vector<xla::Literal> PjRtComputationClient::TransferFromDevice(
     absl::Span<const DataPtr> handles) {
   metrics::TimedSection timed(TransferFromDeviceMetric());

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -459,10 +459,12 @@ std::vector<ComputationClient::DataPtr> PjRtComputationClient::ReshardData(
 }
 
 std::uintptr_t PjRtComputationClient::UnsafeBufferPointer(const DataPtr handle) {
+  std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": " << std::endl;
   std::shared_ptr<PjRtData> pjrt_data = ReplicateShardedData(handle);
   XLA_CHECK(pjrt_data);
   xla::StatusOr<std::uintptr_t> ptr = client_->UnsafeBufferPointer(pjrt_data->buffer.get());
   XLA_CHECK(ptr.ok());
+  std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": ptr.value()=" << ptr.value() << std::endl;
   return ptr.value();
 }
 

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -460,8 +460,9 @@ std::vector<ComputationClient::DataPtr> PjRtComputationClient::ReshardData(
 
 std::uintptr_t PjRtComputationClient::UnsafeBufferPointer(
     const DataPtr handle) {
-  std::shared_ptr<PjRtData> pjrt_data = ReplicateShardedData(handle);
-  XLA_CHECK(pjrt_data);
+  std::shared_ptr<PjRtData> pjrt_data =
+      std::dynamic_pointer_cast<PjRtData>(handle) XLA_CHECK(pjrt_data)
+      << "handle must be PjRtData, got " << handle->ToString();
   xla::StatusOr<std::uintptr_t> ptr =
       client_->UnsafeBufferPointer(pjrt_data->buffer.get());
   XLA_CHECK(ptr.ok());

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -458,13 +458,13 @@ std::vector<ComputationClient::DataPtr> PjRtComputationClient::ReshardData(
   return resharded_results;
 }
 
-std::uintptr_t PjRtComputationClient::UnsafeBufferPointer(const DataPtr handle) {
-  std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": " << std::endl;
+std::uintptr_t PjRtComputationClient::UnsafeBufferPointer(
+    const DataPtr handle) {
   std::shared_ptr<PjRtData> pjrt_data = ReplicateShardedData(handle);
   XLA_CHECK(pjrt_data);
-  xla::StatusOr<std::uintptr_t> ptr = client_->UnsafeBufferPointer(pjrt_data->buffer.get());
+  xla::StatusOr<std::uintptr_t> ptr =
+      client_->UnsafeBufferPointer(pjrt_data->buffer.get());
   XLA_CHECK(ptr.ok());
-  std::cout << "xw32, file=" << __FILE__ << ", line=" << __LINE__ << "function=" << __FUNCTION__ << ": ptr.value()=" << ptr.value() << std::endl;
   return ptr.value();
 }
 

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -461,8 +461,8 @@ std::vector<ComputationClient::DataPtr> PjRtComputationClient::ReshardData(
 std::uintptr_t PjRtComputationClient::UnsafeBufferPointer(
     const DataPtr handle) {
   std::shared_ptr<PjRtData> pjrt_data =
-      std::dynamic_pointer_cast<PjRtData>(handle) XLA_CHECK(pjrt_data)
-      << "handle must be PjRtData, got " << handle->ToString();
+      std::dynamic_pointer_cast<PjRtData>(handle);
+  XLA_CHECK(pjrt_data) << "handle must be PjRtData, got " << handle->ToString();
   xla::StatusOr<std::uintptr_t> ptr =
       client_->UnsafeBufferPointer(pjrt_data->buffer.get());
   XLA_CHECK(ptr.ok());

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -55,6 +55,8 @@ class PjRtComputationClient : public ComputationClient {
   std::vector<xla::Literal> TransferFromDevice(
       absl::Span<const DataPtr> handles) override;
 
+  std::uintptr_t UnsafeBufferPointer(const DataPtr handle) override;
+
   DataPtr TransferShardsToDevice(
       absl::Span<const std::shared_ptr<const TensorSource>> tensor_shards,
       std::string device, xla::Shape shape, xla::OpSharding sharding) override;

--- a/torch_xla/csrc/unwrap_data.h
+++ b/torch_xla/csrc/unwrap_data.h
@@ -11,6 +11,9 @@
 
 namespace torch_xla {
 
+runtime::ComputationClient::DataPtr UnwrapXlaData(
+    const torch::lazy::BackendDataPtr& data);
+
 std::vector<runtime::ComputationClient::DataPtr> UnwrapXlaData(
     absl::Span<const torch::lazy::BackendDataPtr> datas);
 


### PR DESCRIPTION
Similar to what JAX does https://github.com/openxla/xla/blob/f8cafa2b4ae9d7cf96adca75aaad37952be1a28b/xla/python/py_array.cc#L1598, we can use this helper to make sure dlpack does zero copy, by comparing the buffer point such as https://github.com/google/jax/blob/17d0eb30fa609df2a404543925ca50ae92b5c618/tests/array_interoperability_test.py#L84. This will be used in the followup dlpack PR.