### PR TITLE
Fix torch.full scalar type

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -427,5 +427,4 @@ class TestOpInfo(TestCase):
 instantiate_device_type_tests(TestOpInfo, globals())
 
 if __name__ == '__main__':
-  #run_tests()
   unittest.main()

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -225,6 +225,7 @@ allowed_opinfo = set(
             AllowedOpInfoEntry('norm', 'fro'),
             AllowedOpInfoEntry('special.erfcx'),
             AllowedOpInfoEntry('_native_batch_norm_legit'),
+            AllowedOpInfoEntry('full'),
 
             # Duplicate Redundant entries for this test.
             # AllowedOpInfoEntry('polygamma', 'polygamma_n_1'),

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -394,7 +394,7 @@ class TestOpInfo(TestCase):
           return tuple(map(to_cpu, x))
         elif isinstance(x, dict):
           return {k: to_cpu(v) for k, v in x.items()}
-        elif isinstance(x, (numbers.Number, bool, str)):
+        elif isinstance(x, (numbers.Number, bool, str, torch.dtype)):
           return x
 
         # Passthrough None because some functions wrapped with type promotion

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1471,10 +1471,8 @@ at::Tensor XLANativeFunctions::full(at::IntArrayRef size,
         size, fill_value, dtype, layout, device, pin_memory);
   }
   at::ScalarType intend_dtype;
-  if (dtype) {
+  if (dtype || fill_value.isFloatingPoint()) {
     // Respect the dtype if it is being explictlly passed in.
-    intend_dtype = *dtype;
-  } else if (fill_value.isFloatingPoint()) {
     // All python scalar will be passed in as float64 to the backend, but the
     // default behavior for pytorch is to return a float32 tensor in this case.
     intend_dtype = at::dtype_or_default(dtype);

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1472,7 +1472,7 @@ at::Tensor XLANativeFunctions::full(at::IntArrayRef size,
   }
   return bridge::AtenFromXlaTensor(tensor_methods::full(
       absl::Span<const int64_t>(size), fill_value,
-      GetXlaDeviceOrCurrent(device), at::dtype_or_default(dtype)));
+      GetXlaDeviceOrCurrent(device), dtype ? *dtype : fill_value.type()));
 }
 
 at::Tensor XLANativeFunctions::gather(const at::Tensor& self, int64_t dim,

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1470,9 +1470,20 @@ at::Tensor XLANativeFunctions::full(at::IntArrayRef size,
     return at::native::call_fallback_fn<&xla_cpu_fallback, ATEN_OP(full)>::call(
         size, fill_value, dtype, layout, device, pin_memory);
   }
-  return bridge::AtenFromXlaTensor(tensor_methods::full(
-      absl::Span<const int64_t>(size), fill_value,
-      GetXlaDeviceOrCurrent(device), dtype ? *dtype : fill_value.type()));
+  at::ScalarType intend_dtype;
+  if (dtype) {
+    // Respect the dtype if it is being explictlly passed in.
+    intend_dtype = *dtype;
+  } else if (fill_value.isFloatingPoint()) {
+    // All python scalar will be passed in as float64 to the backend, but the
+    // default behavior for pytorch is to return a float32 tensor in this case.
+    intend_dtype = at::dtype_or_default(dtype);
+  } else {
+    intend_dtype = fill_value.type();
+  }
+  return bridge::AtenFromXlaTensor(
+      tensor_methods::full(absl::Span<const int64_t>(size), fill_value,
+                           GetXlaDeviceOrCurrent(device), intend_dtype));
 }
 
 at::Tensor XLANativeFunctions::gather(const at::Tensor& self, int64_t dim,


### PR DESCRIPTION
This should fix https://github.com/pytorch/xla/issues/6991.

`torch.full` takes scalar and `dtype` is an optional parameter. When `dtype` is not specified, we should respect the scalar's dtype.

Without this change. `torch.full((2,2), False)` will return a tensor with dtype float32 instead of bool.