### PR TITLE
Support torch_xla2 benchmarking using torchbench 

### DIFF
--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -22,8 +22,7 @@ class ExperimentLoader:
         "xla": [None, "PJRT", "XRT"],
         "xla_flags": [None],
         "dynamo": [None, "inductor", "openxla_eval", "openxla"],
-        "torch_xla2": [None, "extract_jax",
-                       "torch_export"],  # options only apply to torch_xla2
+        "torch_xla2": [None],  # options only apply to torch_xla2
         "test": ["eval", "train"],
     }
 

--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -125,7 +125,14 @@ class ExperimentLoader:
 
 class BenchmarkExperiment:
 
-  def __init__(self, accelerator, xla, xla_flags, dynamo, test, batch_size, use_torch_xla2: bool = False):
+  def __init__(self,
+               accelerator,
+               xla,
+               xla_flags,
+               dynamo,
+               test,
+               batch_size,
+               use_torch_xla2: bool = False):
     self.accelerator = accelerator
     self.xla = xla
     self.xla_flags = xla_flags
@@ -142,7 +149,7 @@ class BenchmarkExperiment:
       process_env.pop("PJRT_DEVICE", None)
       process_env.pop("XRT_TPU_CONFIG", None)
       process_env.pop("XLA_FLAGS", None)
-    
+
     if self.use_torch_xla2:
       process_env.pop("JAX_PLATFORMS", self.accelerator.upper())
 

--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -72,6 +72,9 @@ class ExperimentLoader:
         exclude_tags=()):
       return False
 
+    if cfg_dynamo is not None and self._args.torch_xla2:
+      return False
+
     # Check dynamo backend-specifics constraints.
     if cfg_dynamo == "inductor":
       if cfg_accelerator == "tpu" or cfg_xla is not None:
@@ -116,12 +119,13 @@ class ExperimentLoader:
         xla_flags=xla_flags,
         dynamo=dynamo,
         test=test,
-        batch_size=batch_size)
+        batch_size=batch_size,
+        use_torch_xla2=self._args.torch_xla2)
 
 
 class BenchmarkExperiment:
 
-  def __init__(self, accelerator, xla, xla_flags, dynamo, test, batch_size):
+  def __init__(self, accelerator, xla, xla_flags, dynamo, test, batch_size, use_torch_xla2: bool = False):
     self.accelerator = accelerator
     self.xla = xla
     self.xla_flags = xla_flags
@@ -129,6 +133,7 @@ class BenchmarkExperiment:
     self.test = test
     self.batch_size = batch_size
     self.accelerator_model = get_accelerator_model(self.accelerator)
+    self.use_torch_xla2 = use_torch_xla2
 
   def update_process_env(self, process_env):
 

--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -124,7 +124,7 @@ class ExperimentLoader:
         accelerator=accelerator,
         xla=xla,
         xla_flags=xla_flags,
-        torch_xla2=self._args.torch_xla2,
+        torch_xla2=torch_xla2,
         dynamo=dynamo,
         test=test,
         batch_size=batch_size)
@@ -200,6 +200,7 @@ class BenchmarkExperiment:
     d["accelerator_model"] = self.accelerator_model
     d["xla"] = self.xla
     d["xla_flags"] = self.xla_flags
+    d["torch_xla2"] = self.torch_xla2
     d["dynamo"] = self.dynamo
     d["test"] = self.test
     d["batch_size"] = self.batch_size

--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -125,21 +125,21 @@ class ExperimentLoader:
         accelerator=accelerator,
         xla=xla,
         xla_flags=xla_flags,
-        torch_xla2=torch_xla2,
         dynamo=dynamo,
+        torch_xla2=torch_xla2,
         test=test,
         batch_size=batch_size)
 
 
 class BenchmarkExperiment:
 
-  def __init__(self, accelerator, xla, xla_flags, torch_xla2, dynamo, test,
+  def __init__(self, accelerator, xla, xla_flags, dynamo, torch_xla2, test,
                batch_size):
     self.accelerator = accelerator
     self.xla = xla
     self.xla_flags = xla_flags
-    self.torch_xla2 = torch_xla2
     self.dynamo = dynamo
+    self.torch_xla2 = torch_xla2
     self.test = test
     self.batch_size = batch_size
     self.accelerator_model = get_accelerator_model(self.accelerator)
@@ -201,8 +201,8 @@ class BenchmarkExperiment:
     d["accelerator_model"] = self.accelerator_model
     d["xla"] = self.xla
     d["xla_flags"] = self.xla_flags
-    d["torch_xla2"] = self.torch_xla2
     d["dynamo"] = self.dynamo
+    d["torch_xla2"] = self.torch_xla2
     d["test"] = self.test
     d["batch_size"] = self.batch_size
     return d

--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -22,7 +22,7 @@ class ExperimentLoader:
         "xla": [None, "PJRT", "XRT"],
         "xla_flags": [None],
         "dynamo": [None, "inductor", "openxla_eval", "openxla"],
-        "torch_xla2": ["extract_jax",
+        "torch_xla2": [None, "extract_jax",
                        "torch_export"],  # options only apply to torch_xla2
         "test": ["eval", "train"],
     }

--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -71,6 +71,7 @@ class ExperimentLoader:
     cfg_accelerator = experiment_config["accelerator"]
     cfg_xla = experiment_config["xla"]
     cfg_test = experiment_config["test"]
+    cfg_torch_xla2 = experiment_config["torch_xla2"]
 
     # Check that dynamo refers to an existing backend.
     if cfg_dynamo is not None and cfg_dynamo not in dynamo.list_backends(
@@ -78,7 +79,7 @@ class ExperimentLoader:
       return False
 
     # torch_xla2 doesn't support dynamo at this time.
-    if cfg_dynamo is not None and self._args.torch_xla2:
+    if cfg_dynamo is not None and cfg_torch_xla2:
       return False
 
     # Check dynamo backend-specifics constraints.

--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -72,6 +72,7 @@ class ExperimentLoader:
         exclude_tags=()):
       return False
 
+    # torch_xla2 doesn't run with dynamo.
     if cfg_dynamo is not None and self._args.torch_xla2:
       return False
 
@@ -151,7 +152,7 @@ class BenchmarkExperiment:
       process_env.pop("XLA_FLAGS", None)
 
     if self.use_torch_xla2:
-      process_env.pop("JAX_PLATFORMS", self.accelerator.upper())
+      process_env["JAX_PLATFORMS"] = self.accelerator.lower()
 
     if self.xla == "PJRT":
       process_env["PJRT_DEVICE"] = self.accelerator.upper()

--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -142,6 +142,9 @@ class BenchmarkExperiment:
       process_env.pop("PJRT_DEVICE", None)
       process_env.pop("XRT_TPU_CONFIG", None)
       process_env.pop("XLA_FLAGS", None)
+    
+    if self.use_torch_xla2:
+      process_env.pop("JAX_PLATFORMS", self.accelerator.upper())
 
     if self.xla == "PJRT":
       process_env["PJRT_DEVICE"] = self.accelerator.upper()

--- a/benchmarks/benchmark_model.py
+++ b/benchmarks/benchmark_model.py
@@ -120,8 +120,8 @@ class BenchmarkModel:
       import torch_xla2.export
       import torch_xla2
       import jax
-      exported = torch.export.export(self.module, self.sample_inputs)
-      weights, jax_func = torch_xla2.export.export_program_to_jax(exported, self.sample_inputs)
+      exported = torch.export.export(self.module, self.example_inputs)
+      weights, jax_func = torch_xla2.export.export_program_to_jax(exported, self.example_inputs)
       jax_func = jax.jit(jax_func)
       weights = pytree.tree_map_only(jnp.ndarray, lambda x: jax.device_put(x, device), weights)
       # map the module function to jax_func

--- a/benchmarks/benchmark_model.py
+++ b/benchmarks/benchmark_model.py
@@ -121,7 +121,7 @@ class BenchmarkModel:
       import torch_xla2
       import jax
       exported = torch.export.export(self.module, self.example_inputs)
-      weights, jax_func = torch_xla2.export.export_program_to_jax(exported, self.example_inputs)
+      weights, jax_func = torch_xla2.export.exported_program_to_jax(exported, self.example_inputs)
       jax_func = jax.jit(jax_func)
       weights = pytree.tree_map_only(jnp.ndarray, lambda x: jax.device_put(x, device), weights)
       # map the module function to jax_func

--- a/benchmarks/benchmark_model.py
+++ b/benchmarks/benchmark_model.py
@@ -137,12 +137,13 @@ class BenchmarkModel:
                                      weights)
       # map the module function to jax_func
       self.module = lambda x: jax_func(weights, x)
+      self.example_inputs = move_to_device(
+          self.example_inputs, device, self.benchmark_experiment.use_torch_xla2)
     else:
       self.module = self.module.to(self.device)
-
-    self.example_inputs = move_to_device(
-        self.example_inputs, self.device,
-        self.benchmark_experiment.use_torch_xla2)
+      self.example_inputs = move_to_device(
+          self.example_inputs, self.device,
+          self.benchmark_experiment.use_torch_xla2)
 
     if self.benchmark_experiment.dynamo:
       compilation_opts = dynamo_compilation_opts.copy()

--- a/benchmarks/benchmark_model.py
+++ b/benchmarks/benchmark_model.py
@@ -123,25 +123,26 @@ class BenchmarkModel:
       raise NotImplementedError
 
     if self.benchmark_experiment.torch_xla2:
-      # for torch_xla2, we export model to FX graph and move weights to JAX device
       import torch_xla2.export
       import torch_xla2
       import jax
       import jax.numpy as jnp
-      if benchmark_experiment.torch_xla2 == 'torch_export':
+      if self.benchmark_experiment.torch_xla2 == 'torch_export':
+        # for torch_xla2, we export model to FX graph and move weights to JAX device
         exported = torch.export.export(self.module, self.example_inputs)
         weights, jax_func = torch_xla2.export.exported_program_to_jax(exported)
-      elif benchmark_experiment.torch_xla2 == 'extract_jax':
+        jax_func = jax.jit(jax_func)
+        device = jax.devices()[0]
+        weights = pytree.tree_map_only(jnp.ndarray,
+                                       lambda x: jax.device_put(x, device),
+                                       weights)
+      elif self.benchmark_experiment.torch_xla2 == 'extract_jax':
         weights, jax_func = torch_xla2.extract_jax(self.module)
+        jax_func = jax.jit(jax_func)
       else:
         raise ValueError("torch_xla2 option unavailable")
-      jax_func = jax.jit(jax_func)
-      device = jax.devices()[0]
-      weights = pytree.tree_map_only(jnp.ndarray,
-                                     lambda x: jax.device_put(x, device),
-                                     weights)
-      # map the module function to jax_func
-      self.module = lambda x: jax_func(weights, x)
+
+      self.module = lambda x: jax_func(weights, (x,))
       self.example_inputs = move_to_device(self.example_inputs, device,
                                            self.benchmark_experiment.torch_xla2)
     else:

--- a/benchmarks/benchmark_model.py
+++ b/benchmarks/benchmark_model.py
@@ -144,8 +144,6 @@ class BenchmarkModel:
         self.example_inputs, self.device,
         self.benchmark_experiment.use_torch_xla2)
 
-
-
     if self.benchmark_experiment.dynamo:
       compilation_opts = dynamo_compilation_opts.copy()
       compilation_opts['backend'] = self.benchmark_experiment.dynamo

--- a/benchmarks/benchmark_model.py
+++ b/benchmarks/benchmark_model.py
@@ -120,7 +120,7 @@ class BenchmarkModel:
       import torch_xla2.export
       import torch_xla2
       import jax
-      exported = torch.export.export(self.module)
+      exported = torch.export.export(self.module, self.sample_inputs)
       weights, jax_func = torch_xla2.export.export_program_to_jax(exported, self.sample_inputs)
       jax_func = jax.jit(jax_func)
       weights = pytree.tree_map_only(jnp.ndarray, lambda x: jax.device_put(x, device), weights)

--- a/benchmarks/benchmark_model.py
+++ b/benchmarks/benchmark_model.py
@@ -123,13 +123,17 @@ class BenchmarkModel:
       exported = torch.export.export(self.module, self.example_inputs)
       weights, jax_func = torch_xla2.export.exported_program_to_jax(exported)
       jax_func = jax.jit(jax_func)
-      weights = pytree.tree_map_only(jnp.ndarray, lambda x: jax.device_put(x, device), weights)
+      weights = pytree.tree_map_only(jnp.ndarray,
+                                     lambda x: jax.device_put(x, device),
+                                     weights)
       # map the module function to jax_func
       self.module = lambda x: jax_func(weights, x)
-    else:  
+    else:
       self.module = self.module.to(self.device)
-    
-    self.example_inputs = move_to_device(self.example_inputs, self.device, self.benchmark_experiment.use_torch_xla2)
+
+    self.example_inputs = move_to_device(
+        self.example_inputs, self.device,
+        self.benchmark_experiment.use_torch_xla2)
 
     if self.benchmark_experiment.test == "eval":
       self._prepare_for_eval()

--- a/benchmarks/benchmark_model.py
+++ b/benchmarks/benchmark_model.py
@@ -121,7 +121,7 @@ class BenchmarkModel:
       import torch_xla2
       import jax
       exported = torch.export.export(self.module, self.example_inputs)
-      weights, jax_func = torch_xla2.export.exported_program_to_jax(exported, self.example_inputs)
+      weights, jax_func = torch_xla2.export.exported_program_to_jax(exported)
       jax_func = jax.jit(jax_func)
       weights = pytree.tree_map_only(jnp.ndarray, lambda x: jax.device_put(x, device), weights)
       # map the module function to jax_func

--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -284,7 +284,7 @@ class ExperimentRunner:
 
     # Reset state and sync.
     reset_rng_state(benchmark_experiment)
-    if self._args.use_torch_xla2:
+    if self._args.torch_xla2:
       for inputs in inputs_list:
         self._mark_step(benchmark_experiment, inputs)
     else:
@@ -420,7 +420,7 @@ class ExperimentRunner:
 
   def _mark_step(self, benchmark_experiment, tensors_to_check=None):
     if benchmark_experiment.xla:
-      if benchmark_experiment.use_torch_xla2:
+      if benchmark_experiment.torch_xla2:
         assert tensors_to_check is not None, "torch_xla2 requires input tensor to block_until_ready"
         for t in tensors_to_check:
           t.block_until_ready()
@@ -870,8 +870,9 @@ def parse_args(args=None):
   )
   parser.add_argument(
       "--torch-xla2",
-      action="store_true",
-      help="Choose to use torch_xla2 or not.",
+      choices=["extract_jax", "torch_export"],
+      action="append",
+      help="Choose to use torch_xla2 and which mode to use.",
   )
   parser.add_argument(
       "--disable-tf32",

--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -284,7 +284,7 @@ class ExperimentRunner:
 
     # Reset state and sync.
     reset_rng_state(benchmark_experiment)
-    if self._args.torch_xla2:
+    if benchmark_experiment.torch_xla2:
       for inputs in inputs_list:
         self._mark_step(benchmark_experiment, inputs)
     else:

--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -284,7 +284,7 @@ class ExperimentRunner:
 
     # Reset state and sync.
     reset_rng_state(benchmark_experiment)
-    self._mark_step(benchmark_experiment)
+    self._mark_step(benchmark_experiment, inputs_list[0])
     self._synchronize(benchmark_experiment)
     met.clear_all()
     dynamo_utils.counters.clear()

--- a/benchmarks/result_analyzer.py
+++ b/benchmarks/result_analyzer.py
@@ -55,6 +55,7 @@ class ResultAnalyzer:
         "xla": pd.Series(dtype="str"),
         "xla_flags": pd.Series(dtype="str"),
         "dynamo": pd.Series(dtype="str"),
+        "torch_xla2": pd.Series(dtype="str"),
         "test": pd.Series(dtype="str"),
         "batch_size": pd.Series(dtype="int"),
         "repeat": pd.Series(dtype="int"),
@@ -116,6 +117,8 @@ class ResultAnalyzer:
       xla_value = "None" if xla is None else xla
       dynamo = dataline["experiment"]["dynamo"]
       dynamo_value = "None" if dynamo is None else dynamo
+      torch_xla2 = dataline["experiment"]["torch_xla2"]
+      torch_xla2_value = "None" if torch_xla2 is None else torch_xla2
       test = dataline["experiment"]["test"]
       test_value = "None" if test is None else test
       outputs_file = dataline["experiment"].get("outputs_file", None)
@@ -135,6 +138,7 @@ class ResultAnalyzer:
               "accelerator_model": dataline["experiment"]["accelerator_model"],
               "xla": xla_value,
               "dynamo": dynamo_value,
+              "torch_xla2": torch_xla2_value,
               "test": test_value,
               "outputs_file": outputs_file_value
           }
@@ -175,6 +179,7 @@ class ResultAnalyzer:
           "xla": dataline["experiment"]["xla"],
           "xla_flags": dataline["experiment"]["xla_flags"],
           "dynamo": dataline["experiment"]["dynamo"],
+          "torch_xla2": dataline["experiment"]["torch_xla2"],
           "test": dataline["experiment"]["test"],
           "batch_size": dataline["experiment"]["batch_size"],
           "repeat": dataline["repeat"],

--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -50,7 +50,7 @@ def reset_rng_state(benchmark_experiment=None):
   torch.manual_seed(1337)
   random.seed(1337)
   np.random.seed(1337)
-  if benchmark_experiment is not None and benchmark_experiment.xla is not None:
+  if benchmark_experiment is not None and benchmark_experiment.xla is not None and not benchmark_experiment.use_torch_xla2:
     device = benchmark_experiment.get_device()
     xm.set_rng_state(1337, str(device))
 

--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -80,7 +80,8 @@ def move_to_device(item, device, use_torch_xla2: bool = False):
   if use_torch_xla2:
     import torch_xla2
     import jax
-    move_to_device_func = lambda t: jax.device_put(torch_xla2.tensor.t2j(t))
+    move_to_device_func = lambda t: jax.device_put(
+        torch_xla2.tensor.t2j(t), device)
   else:
     move_to_device_func = lambda t: t.to(device)
   return pytree.tree_map_only(torch.Tensor, move_to_device_func, item)

--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -50,7 +50,7 @@ def reset_rng_state(benchmark_experiment=None):
   torch.manual_seed(1337)
   random.seed(1337)
   np.random.seed(1337)
-  if benchmark_experiment is not None and benchmark_experiment.xla is not None and not benchmark_experiment.use_torch_xla2:
+  if benchmark_experiment is not None and benchmark_experiment.xla is not None and benchmark_experiment.torch_xla2 is not None:
     device = benchmark_experiment.get_device()
     xm.set_rng_state(1337, str(device))
 
@@ -76,8 +76,8 @@ def is_xla_device_available(devkind):
   return r.returncode == 0
 
 
-def move_to_device(item, device, use_torch_xla2: bool = False):
-  if use_torch_xla2:
+def move_to_device(item, device, torch_xla2):
+  if torch_xla2:
     import torch_xla2
     import jax
     move_to_device_func = lambda t: jax.device_put(

--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -76,8 +76,14 @@ def is_xla_device_available(devkind):
   return r.returncode == 0
 
 
-def move_to_device(item, device):
-  return pytree.tree_map_only(torch.Tensor, lambda t: t.to(device), item)
+def move_to_device(item, device, use_torch_xla2: bool = False):
+  if use_torch_xla2:
+    import torch_xla2
+    import jax
+    move_to_device_func = lambda t: jax.device_put(torch_xla2.tensor.t2j(t))
+  else:
+    move_to_device_func = lambda t: t.to(device)
+  return pytree.tree_map_only(torch.Tensor, move_to_device_func, item)
 
 
 def cast_to_dtype(item, dtype):

--- a/test/benchmarks/test_benchmark_experiment.py
+++ b/test/benchmarks/test_benchmark_experiment.py
@@ -6,15 +6,16 @@ from benchmark_experiment import BenchmarkExperiment
 class BenchmarkExperimentTest(unittest.TestCase):
 
   def test_to_dict(self):
-    be = BenchmarkExperiment("cpu", "PJRT", "some xla_flags", "openxla",
+    be = BenchmarkExperiment("cpu", "PJRT", "some xla_flags", "openxla", None,
                              "train", "123")
     actual = be.to_dict()
-    self.assertEqual(7, len(actual))
+    self.assertEqual(8, len(actual))
     self.assertEqual("cpu", actual["accelerator"])
     self.assertTrue("accelerator_model" in actual)
     self.assertEqual("PJRT", actual["xla"])
     self.assertEqual("some xla_flags", actual["xla_flags"])
     self.assertEqual("openxla", actual["dynamo"])
+    self.assertEqual(None, actual["torch_xla2"])
     self.assertEqual("train", actual["test"])
     self.assertEqual("123", actual["batch_size"])
 

--- a/test/benchmarks/test_experiment_runner.py
+++ b/test/benchmarks/test_experiment_runner.py
@@ -29,10 +29,10 @@ class ExperimentRunnerTest(expecttest.TestCase):
     expected_in_stderr = [
         "Number of selected experiment configs: 4",
         "Number of selected model configs: 1",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cpu\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"test\": \"eval\"}",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cpu\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"test\": \"train\"}",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cpu\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"test\": \"eval\"}",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cpu\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"test\": \"train\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cpu\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"torch_xla2\": null, \"test\": \"eval\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cpu\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"torch_xla2\": null, \"test\": \"train\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cpu\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"torch_xla2\": null, \"test\": \"eval\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cpu\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"torch_xla2\": null, \"test\": \"train\"}",
     ]
     for expected in expected_in_stderr:
       self.assertIn(expected, child.stderr)
@@ -57,10 +57,10 @@ class ExperimentRunnerTest(expecttest.TestCase):
     expected_in_stderr = [
         "Number of selected experiment configs: 4",
         "Number of selected model configs: 1",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"test\": \"eval\"}",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"test\": \"train\"}",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"test\": \"eval\"}",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"test\": \"train\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"torch_xla2\": null, \"test\": \"eval\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"torch_xla2\": null, \"test\": \"train\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"torch_xla2\": null, \"test\": \"eval\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"torch_xla2\": null, \"test\": \"train\"}",
     ]
     for expected in expected_in_stderr:
       self.assertIn(expected, child.stderr)
@@ -85,8 +85,8 @@ class ExperimentRunnerTest(expecttest.TestCase):
     expected_in_stderr = [
         "Number of selected experiment configs: 2",
         "Number of selected model configs: 1",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"test\": \"eval\"}",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"test\": \"train\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"torch_xla2\": null, \"test\": \"eval\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"torch_xla2\": null, \"test\": \"train\"}",
     ]
     for expected in expected_in_stderr:
       self.assertIn(expected, child.stderr)
@@ -113,11 +113,11 @@ class ExperimentRunnerTest(expecttest.TestCase):
     expected_in_stderr = [
         "Number of selected experiment configs: 5",
         "Number of selected model configs: 1",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla_eval\", \"test\": \"eval\"}",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"test\": \"train\"}",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"test\": \"eval\"}",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"test\": \"eval\"}",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"test\": \"train\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla_eval\", \"torch_xla2\": null, \"test\": \"eval\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"torch_xla2\": null, \"test\": \"train\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"torch_xla2\": null, \"test\": \"eval\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"torch_xla2\": null, \"test\": \"eval\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"torch_xla2\": null, \"test\": \"train\"}",
     ]
     for expected in expected_in_stderr:
       self.assertIn(expected, child.stderr)
@@ -142,12 +142,12 @@ class ExperimentRunnerTest(expecttest.TestCase):
         "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": null, \"test\": \"eval\"}",
         "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": null, \"test\": \"train\"}",
         "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla_eval\", \"test\": \"eval\"}",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"test\": \"eval\"}",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"test\": \"train\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"torch_xla2\": null, \"test\": \"eval\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"torch_xla2\": null, \"test\": \"train\"}",
         "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": null, \"test\": \"eval\"}",
         "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": null, \"test\": \"train\"}",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"test\": \"eval\"}",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"test\": \"train\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"torch_xla2\": null, \"test\": \"eval\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"torch_xla2\": null, \"test\": \"train\"}",
     ]
     for expected in expected_in_stderr:
       self.assertIn(expected, child.stderr)

--- a/test/benchmarks/test_experiment_runner.py
+++ b/test/benchmarks/test_experiment_runner.py
@@ -139,13 +139,13 @@ class ExperimentRunnerTest(expecttest.TestCase):
     expected_in_stderr = [
         "Number of selected experiment configs: 9",
         "Number of selected model configs: 1",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": null, \"test\": \"eval\"}",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": null, \"test\": \"train\"}",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla_eval\", \"test\": \"eval\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": null, \"torch_xla2\": null, \"test\": \"eval\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": null, \"torch_xla2\": null, \"test\": \"train\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla_eval\", \"torch_xla2\": null, \"test\": \"eval\"}",
         "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"torch_xla2\": null, \"test\": \"eval\"}",
         "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": \"PJRT\", \"xla_flags\": null, \"dynamo\": \"openxla\", \"torch_xla2\": null, \"test\": \"train\"}",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": null, \"test\": \"eval\"}",
-        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": null, \"test\": \"train\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": null, \"torch_xla2\": null, \"test\": \"eval\"}",
+        "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": null, \"torch_xla2\": null, \"test\": \"train\"}",
         "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"torch_xla2\": null, \"test\": \"eval\"}",
         "--model-config={\"model_name\": \"dummy\"} --experiment-config={\"accelerator\": \"cuda\", \"xla\": null, \"xla_flags\": null, \"dynamo\": \"inductor\", \"torch_xla2\": null, \"test\": \"train\"}",
     ]


### PR DESCRIPTION
## Summary
Integrate the torch_xla2 testing into the benchmarking.

## Details
The PR ports the torch_xla2 running script based on file [here](https://gist.github.com/qihqi/9b952672b4971bb6697919e7108f8871#file-run-torchbench) into the existing benchmark script.

### How to run
To run the torch_xla2 benchmarking, you need to install the torch_xla2 based on instructions [experimental/torch_xla2/README.md](https://github.com/pytorch/xla/tree/2907ab3093753d8a3516c8f67337a9464bf4ed8a/experimental/torch_xla2)

Currently torch_xla2 doesn't work with dynamo. We need to append flag `--torch-xla2` to switch to torch_xla2, e.g.,
```
export JAX_PLATFORMS=TPU;
python experiment_runner.py \
--suite-name=torchbench \
--accelerator=tpu \
--progress-bar  \
--xla=PJRT  \
--test=eval \
--filter=dcgan \
--torch-xla2
```

In practical, we need to make sure JAX version and torch_xla are using the same PJRT version. I did the openxla pin update (backport) for torch_xla in order to use PJRT `0.47` verison. 

## Sample result
Just tried a simple model `dcgan` on TPU v5p-8, the torch_xla2 performance is impressive:

| benchmark      | platform  | torch_xla version |  backend | median_total_time (s) | compile_time (s) |
|------------|---------|-------|------|------|--------------|
| dcgan (eval)      | v5-8   | torch_xla |  LTC  | 0.0022        |  1.5729 |
| dcgan (eval)      | v5-8   | torch_xla |  openxla  | 0.0005        |  1.8661 |
| dcgan (eval)      | v5-8   | torch_xla2 | jax.jit | 0.0003911869862349704       | 1.464099046002957        |