### PR TITLE
[torch_xla2] Use `torch.Generator` for random number generation in `Environment`

### DIFF
--- a/experimental/torch_xla2/examples/basic_training.py
+++ b/experimental/torch_xla2/examples/basic_training.py
@@ -13,7 +13,7 @@ import torchvision.transforms as transforms
 import torch_xla2.tensor
 
 
-xla_env = torch_xla2.tensor.Environment(0)
+xla_env = torch_xla2.tensor.Environment()
 mode = xla_env.mode()
 
 # PyTorch TensorBoard support

--- a/experimental/torch_xla2/pyproject.toml
+++ b/experimental/torch_xla2/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "pytest",
     "tensorflow-cpu",
     # Developers should install `dev-requirements.txt` first
-    "torch>=2.2.1",
+    "torch>=2.3.0",
 ]
 requires-python = ">=3.10"
 license = {file = "LICENSE"}

--- a/experimental/torch_xla2/test/test_context.py
+++ b/experimental/torch_xla2/test/test_context.py
@@ -5,7 +5,7 @@ import torch_xla2
 from torch_xla2 import tensor
 import torch_xla2.interop
 
-xla_env = tensor.Environment(0)
+xla_env = tensor.Environment()
 
 
 class TestContext(unittest.TestCase):

--- a/experimental/torch_xla2/test/test_context.py
+++ b/experimental/torch_xla2/test/test_context.py
@@ -3,6 +3,7 @@ import unittest
 import torch
 import torch_xla2
 from torch_xla2 import tensor
+import torch_xla2.interop
 
 xla_env = tensor.Environment(0)
 
@@ -52,6 +53,17 @@ class TestContext(unittest.TestCase):
       self.assertIsInstance(y, tensor.XLATensor2)
 
     self.assertFalse(torch.equal(torch_xla2.tensor.j2t(x._elem), torch_xla2.tensor.j2t(y._elem)))
+
+  def test_jit_with_rng(self):
+    @xla_env
+    def random():
+      x = torch.randn(3, 3)
+      y = torch.randn(3, 3)
+      return x @ y
+
+    random_jit = torch_xla2.interop.jax_jit(random)
+    self.assertIsInstance(random_jit(), tensor.XLATensor2)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/experimental/torch_xla2/test/test_context.py
+++ b/experimental/torch_xla2/test/test_context.py
@@ -1,6 +1,7 @@
 import unittest
 
 import torch
+import torch_xla2
 from torch_xla2 import tensor
 
 xla_env = tensor.Environment(0)
@@ -28,6 +29,19 @@ class TestContext(unittest.TestCase):
     self.assertIsInstance(x, tensor.XLATensor2)
     self.assertIsInstance(y, tensor.XLATensor2)
 
+  def test_same_manual_seed(self):
+    with xla_env:
+      torch.manual_seed(1234)
+      x = torch.randn((3, 3))
+      self.assertIsInstance(x, tensor.XLATensor2)
+
+      torch.manual_seed(1234)
+      y = torch.randn((3, 3))
+      self.assertIsInstance(y, tensor.XLATensor2)
+
+      print(x, y)
+
+    torch.testing.assert_close(torch_xla2.tensor.j2t(x._elem), torch_xla2.tensor.j2t(y._elem))
 
 if __name__ == "__main__":
   unittest.main()

--- a/experimental/torch_xla2/test/test_context.py
+++ b/experimental/torch_xla2/test/test_context.py
@@ -56,13 +56,20 @@ class TestContext(unittest.TestCase):
 
   def test_jit_with_rng(self):
     @xla_env
-    def random():
+    def random_op():
       x = torch.randn(3, 3)
       y = torch.randn(3, 3)
       return x @ y
 
-    random_jit = torch_xla2.interop.jax_jit(random)
+    random_jit = torch_xla2.interop.jax_jit(random_op)
     self.assertIsInstance(random_jit(), tensor.XLATensor2)
+
+    # Result always expected to be the same for a jitted function because seeds
+    # are baked in
+    self.assertTrue(
+      torch.equal(
+        torch_xla2.tensor.j2t(random_jit()._elem),
+        torch_xla2.tensor.j2t(random_jit()._elem)))
 
 
 if __name__ == "__main__":

--- a/experimental/torch_xla2/test/test_context.py
+++ b/experimental/torch_xla2/test/test_context.py
@@ -66,11 +66,21 @@ class TestContext(unittest.TestCase):
 
     # Result always expected to be the same for a jitted function because seeds
     # are baked in
-    self.assertTrue(
-      torch.equal(
+    torch.testing.assert_close(
         torch_xla2.tensor.j2t(random_jit()._elem),
-        torch_xla2.tensor.j2t(random_jit()._elem)))
+        torch_xla2.tensor.j2t(random_jit()._elem),
+        atol=0,
+        rtol=0)
 
+  def test_generator_seed(self):
+    with xla_env:
+      x = torch.randn(2, 3, generator=torch.Generator().manual_seed(0))
+      y = torch.randn(2, 3, generator=torch.Generator().manual_seed(0))
+
+    # Values will be different, but still check device, layout, dtype, etc
+    torch.testing.assert_close(
+        torch_xla2.tensor.j2t(x._elem),
+        torch_xla2.tensor.j2t(y._elem))
 
 if __name__ == "__main__":
   unittest.main()

--- a/experimental/torch_xla2/test/test_context.py
+++ b/experimental/torch_xla2/test/test_context.py
@@ -39,9 +39,19 @@ class TestContext(unittest.TestCase):
       y = torch.randn((3, 3))
       self.assertIsInstance(y, tensor.XLATensor2)
 
-      print(x, y)
+    self.assertTrue(torch.equal(torch_xla2.tensor.j2t(x._elem), torch_xla2.tensor.j2t(y._elem)))
 
-    torch.testing.assert_close(torch_xla2.tensor.j2t(x._elem), torch_xla2.tensor.j2t(y._elem))
+  def test_different_manual_seed(self):
+    with xla_env:
+      torch.manual_seed(1234)
+      x = torch.randn((3, 3))
+      self.assertIsInstance(x, tensor.XLATensor2)
+
+      torch.manual_seed(12345)
+      y = torch.randn((3, 3))
+      self.assertIsInstance(y, tensor.XLATensor2)
+
+    self.assertFalse(torch.equal(torch_xla2.tensor.j2t(x._elem), torch_xla2.tensor.j2t(y._elem)))
 
 if __name__ == "__main__":
   unittest.main()

--- a/experimental/torch_xla2/test/test_core_aten_ops.py
+++ b/experimental/torch_xla2/test/test_core_aten_ops.py
@@ -33,7 +33,7 @@ def run_export_and_compare(testcase,
                            rtol=1e-5,
                            equal_nan=True,
                            ignore_indices=False):
-  
+
   with testcase.subTest("torch_eval"):
     res = func(*args, **kwargs)
     with testcase.subTest("torch_xla2_eval"):
@@ -65,7 +65,7 @@ class TestCoreAtenOps(unittest.TestCase):
   def setUp(self):
     super().setUp()
     torch.manual_seed(0)
-    self.env = tensor.Environment(0)
+    self.env = tensor.Environment()
 
   def test_aten_abs_0(self):
     args = (torch.randn((10, 10)).to(torch.float32),)

--- a/experimental/torch_xla2/test/test_functions.py
+++ b/experimental/torch_xla2/test/test_functions.py
@@ -41,36 +41,5 @@ class TestTorchFunctions(parameterized.TestCase):
     torch.testing.assert_close(torch_xla2.tensor.j2t(actual._elem), expected)
 
 
-  @parameterized.named_parameters(
-      ('empty_2d', lambda: torch.empty((2, 3), dtype=torch.int64)),
-      ('randn_1d', lambda: torch.randn(4)),
-      ('randn_2d', lambda: torch.randn(2, 3)),
-  )
-  def test_random_tensor(self, func: Callable[[], torch.Tensor]):
-    expected = func()
-
-    with self.env:
-      actual = func()
-      self.assertIsInstance(actual, torch_xla2.tensor.XLATensor2)
-
-    # Values will be different, but still check device, layout, dtype, etc
-    torch.testing.assert_close(torch_xla2.tensor.j2t(actual._elem), expected,
-                               rtol=float('inf'), atol=float('inf'))
-
-
-  @parameterized.named_parameters(
-      ('randn', lambda g: torch.randn(2, 3, generator=g)),
-  )
-  def test_random_generator(self, func: Callable[[torch.Generator], torch.Tensor]):
-
-    with self.env:
-      x = func(torch.Generator().manual_seed(0))
-      y = func(torch.Generator().manual_seed(0))
-
-    # Values will be different, but still check device, layout, dtype, etc
-    torch.testing.assert_close(
-        torch_xla2.tensor.j2t(x._elem),
-        torch_xla2.tensor.j2t(y._elem))
-
 if __name__ == '__main__':
   absltest.main()

--- a/experimental/torch_xla2/test/test_functions.py
+++ b/experimental/torch_xla2/test/test_functions.py
@@ -58,5 +58,19 @@ class TestTorchFunctions(parameterized.TestCase):
                                rtol=float('inf'), atol=float('inf'))
 
 
+  @parameterized.named_parameters(
+      ('randn', lambda g: torch.randn(2, 3, generator=g)),
+  )
+  def test_random_generator(self, func: Callable[[torch.Generator], torch.Tensor]):
+
+    with self.env:
+      x = func(torch.Generator().manual_seed(0))
+      y = func(torch.Generator().manual_seed(0))
+
+    # Values will be different, but still check device, layout, dtype, etc
+    torch.testing.assert_close(
+        torch_xla2.tensor.j2t(x._elem),
+        torch_xla2.tensor.j2t(y._elem))
+
 if __name__ == '__main__':
   absltest.main()

--- a/experimental/torch_xla2/test/test_functions.py
+++ b/experimental/torch_xla2/test/test_functions.py
@@ -41,5 +41,22 @@ class TestTorchFunctions(parameterized.TestCase):
     torch.testing.assert_close(torch_xla2.tensor.j2t(actual._elem), expected)
 
 
+  @parameterized.named_parameters(
+      ('empty_2d', lambda: torch.empty((2, 3), dtype=torch.int64)),
+      ('randn_1d', lambda: torch.randn(4)),
+      ('randn_2d', lambda: torch.randn(2, 3)),
+  )
+  def test_random_tensor(self, func: Callable[[], torch.Tensor]):
+    expected = func()
+
+    with self.env:
+      actual = func()
+      self.assertIsInstance(actual, torch_xla2.tensor.XLATensor2)
+
+    # Values will be different, but still check device, layout, dtype, etc
+    torch.testing.assert_close(torch_xla2.tensor.j2t(actual._elem), expected,
+                               rtol=float('inf'), atol=float('inf'))
+
+
 if __name__ == '__main__':
   absltest.main()

--- a/experimental/torch_xla2/test/test_functions.py
+++ b/experimental/torch_xla2/test/test_functions.py
@@ -9,7 +9,7 @@ import torch_xla2.tensor
 class TestTorchFunctions(parameterized.TestCase):
 
   def setUp(self):
-    self.env = torch_xla2.tensor.Environment(0)
+    self.env = torch_xla2.tensor.Environment()
 
   @parameterized.named_parameters(
       ('tensor_2d', lambda: torch.tensor([[0.1, 1.2], [2.2, 3.1], [4.9, 5.2]])),

--- a/experimental/torch_xla2/test/test_mutations.py
+++ b/experimental/torch_xla2/test/test_mutations.py
@@ -7,7 +7,7 @@ from torch.testing._internal.common_utils import TestCase
 class TestMutations(TestCase):
 
   def setUp(self):
-    self.env = torch_xla2.tensor.Environment(0)
+    self.env = torch_xla2.tensor.Environment()
 
   def test_add(self):
     with self.env:

--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -652,7 +652,7 @@ class TestOpInfo(TestCase):
     print('op_db size: ', len(op_db), 'testing: ', len(ops_to_test))
 
   def setUp(self):
-    self.env = tensor.Environment(0)
+    self.env = tensor.Environment()
 
   @ops(ops_to_test, allowed_dtypes=(torch.float32, torch.long))
   def test_reference_eager(self, device, dtype, op):

--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -55,7 +55,6 @@ skiplist = {
     "digamma",
     "dist",
     "div",
-    "empty",
     "empty_like",
     "empty_permuted",
     "empty_strided",
@@ -515,7 +514,6 @@ skiplist = {
     "pow",
     "rad2deg",
     "randint",
-    "randn",
     "ravel",
     "real",
     "reciprocal",
@@ -592,6 +590,10 @@ skiplist = {
     "zeros",
 }
 
+random_ops = {
+  'randn',
+  'empty',
+}
 
 def diff_output(testcase, output1, output2, rtol, atol, equal_nan=True):
   if isinstance(output1, torch.Tensor):
@@ -599,11 +601,8 @@ def diff_output(testcase, output1, output2, rtol, atol, equal_nan=True):
     output2_cpu = output2.detach().cpu()
     if output2_cpu.dtype != output1.dtype:
       output2_cpu = output2_cpu.to(output1.dtype)
-    testcase.assertEqual(output1.shape, output2_cpu.shape)
-    testcase.assertEqual(output1.dtype, output2_cpu.dtype)
-    testcase.assertTrue(
-        torch.allclose(
-            output1, output2_cpu, atol=atol, rtol=rtol, equal_nan=equal_nan))
+    torch.testing.assert_close(
+        output2_cpu, output1, rtol=rtol, atol=atol, equal_nan=equal_nan)
   elif isinstance(output1, (tuple, list)):
     testcase.assertIsInstance(output2, (tuple, list))
     testcase.assertEqual(len(output1), len(output2))
@@ -616,10 +615,11 @@ def diff_output(testcase, output1, output2, rtol, atol, equal_nan=True):
 def run_export_and_compare(testcase,
                            func,
                            sample_input,
-                           atol=1e-3,
-                           rtol=1e-5,
+                           check_output=True,
                            equal_nan=True,
                            ignore_indices=False):
+  atol=1e-3 if check_output else float('inf')
+  rtol=1e-5 if check_output else float('inf')
   with testcase.subTest("torch_eval"):
     res = func(sample_input.input, *sample_input.args, **sample_input.kwargs)
     with testcase.subTest("torch_xla2_eval"):
@@ -661,7 +661,8 @@ class TestOpInfo(TestCase):
       t = sample_input.input
       if isinstance(t, torch.Tensor) and t.is_sparse:
         continue
-      run_export_and_compare(self, op, sample_input)
+      check_output = op.name not in random_ops
+      run_export_and_compare(self, op, sample_input, check_output)
 
 
 instantiate_device_type_tests(TestOpInfo, globals())

--- a/experimental/torch_xla2/torch_xla2/__init__.py
+++ b/experimental/torch_xla2/torch_xla2/__init__.py
@@ -10,7 +10,7 @@ env = None
 def default_env():
   global env
   if env is None:
-    env = tensor.Environment(0)
+    env = tensor.Environment()
   return env
 
 

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -300,8 +300,9 @@ def _aten__to_copy(self, **kwargs):
 
 
 @op(torch.ops.aten.empty)
-def _aten_empty(sizes, **kwargs):
-  return jnp.zeros(sizes)
+@op_base.convert_dtype()
+def _aten_empty(sizes, *, dtype=None, **kwargs):
+  return jnp.empty(sizes, dtype=dtype)
 
 
 @op(torch.ops.aten.index_put_)

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -555,7 +555,7 @@ def _aten__native_batch_norm_legit(
     running_var ([DeviceArray]): Running variance of input (C,).
     weight (Optional[DeviceArray]): Scaling factor (gamma) (C,). Can be None.
     bias (Optional[DeviceArray]): Shift factor (beta) (C,). Can be None.
-    training (bool): If True, use batch statistics for normalization. 
+    training (bool): If True, use batch statistics for normalization.
                      If False, use running statistics.
     momentum (float): Momentum factor for updating running statistics.
     eps (float): Small constant for numerical stability.
@@ -572,21 +572,21 @@ def _aten__native_batch_norm_legit(
     # Calculate batch mean and variance
     mean = jnp.mean(input, axis=reduction_dims, keepdims=True)
     saved_mean = jnp.squeeze(mean, reduction_dims)
-    var = jnp.var(input, axis=reduction_dims) 
+    var = jnp.var(input, axis=reduction_dims)
     rstd = jax.lax.rsqrt(var.reshape(reshape_dims) + eps)
     # Update running statistics using momentum
     running_mean = (1 - momentum) * running_mean + momentum * saved_mean
     running_var = (1 - momentum) * running_var + momentum * var
     saved_rstd = jnp.squeeze(rstd, reduction_dims)
   else:
-    rstd = jax.lax.rsqrt(running_var.reshape(reshape_dims) + eps) 
+    rstd = jax.lax.rsqrt(running_var.reshape(reshape_dims) + eps)
     saved_mean = jnp.array([])  # No need to calculate batch statistics in inference mode
     saved_rstd = jnp.array([])
 
   # Normalize
   if training:
     # use batch statistics if training
-    x_hat = (input - mean) * rstd 
+    x_hat = (input - mean) * rstd
   else:
     # Use running statistics in inference mode
     x_hat = (input - running_mean.reshape(reshape_dims)) * rstd
@@ -597,7 +597,7 @@ def _aten__native_batch_norm_legit(
   if bias is not None:
     x_hat += bias.reshape(reshape_dims)    # Reshape bias for broadcasting
 
-  return x_hat, saved_mean, saved_rstd 
+  return x_hat, saved_mean, saved_rstd
 
 
 
@@ -1877,7 +1877,7 @@ def _randn(
   shape = size
   if len(shape) == 1 and isinstance(shape[0], (list, tuple)):
     shape = shape[0]
-  key = env.get_and_rotate_prng_key()
+  key = env.get_and_rotate_prng_key(generator)
   res = jax.random.normal(key, shape)
   if dtype is not None:
     res = res.astype(dtype)
@@ -1900,7 +1900,7 @@ def _rand(
   shape = size
   if len(shape) == 1 and isinstance(shape[0], (list, tuple)):
     shape = shape[0]
-  key = env.get_and_rotate_prng_key()
+  key = env.get_and_rotate_prng_key(generator)
   res = jax.random.uniform(key, shape)
   if dtype is not None:
     res = res.astype(dtype)
@@ -1985,13 +1985,13 @@ def _aten_allclose(input, other, rtol=1e-05, atol=1e-08, equal_nan=False):
 
 @op(torch.ops.aten.native_batch_norm)
 def _aten_native_batch_norm(input, weight, bias, running_mean, running_var, training=False, momentum=0.1, eps=1e-5):
-  
+
   if running_mean is None:
     running_mean = jnp.zeros(input.shape[1])  # Initialize running mean if None
   if running_var is None:
     running_var = jnp.ones(input.shape[1])   # Initialize running variance if None
-  
+
   if training:
     return torch.ops.aten._native_batch_norm_legit(input, weight, bias, running_mean, running_var, training, momentum, eps)
   else:
-    return torch.ops.aten._native_batch_norm_legit_no_training(input, weight, bias, running_mean, running_var, momentum, eps) 
+    return torch.ops.aten._native_batch_norm_legit_no_training(input, weight, bias, running_mean, running_var, momentum, eps)

--- a/experimental/torch_xla2/torch_xla2/ops/jtorch.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jtorch.py
@@ -76,13 +76,21 @@ def _torch_argsort(input, dim=-1, descending=False, stable=False):
     # behavior is the same as a jnp array of rank 1
     expanded = True
     input = jnp.expand_dims(input, 0)
-  res = jnp.argsort(input, axis=dim, descending=descending, 
+  res = jnp.argsort(input, axis=dim, descending=descending,
                      stable=stable)
   if expanded:
     res = res.squeeze()
   return res
 
+
 @register_function(torch.einsum)
 def _einsum(equation, *operands):
   assert isinstance(equation, str), 'Only accept str equation'
   return jnp.einsum(equation, *operands)
+
+
+@register_function(torch.empty)
+@op_base.convert_dtype()
+def _empty(size: Sequence[int], *, dtype=None):
+  return jnp.empty(size, dtype=dtype)
+

--- a/experimental/torch_xla2/torch_xla2/ops/jtorch.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jtorch.py
@@ -87,10 +87,3 @@ def _torch_argsort(input, dim=-1, descending=False, stable=False):
 def _einsum(equation, *operands):
   assert isinstance(equation, str), 'Only accept str equation'
   return jnp.einsum(equation, *operands)
-
-
-@register_function(torch.empty)
-@op_base.convert_dtype()
-def _empty(size: Sequence[int], *, dtype=None, **kwargs):
-  return jnp.empty(size, dtype=dtype)
-

--- a/experimental/torch_xla2/torch_xla2/ops/jtorch.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jtorch.py
@@ -76,12 +76,11 @@ def _torch_argsort(input, dim=-1, descending=False, stable=False):
     # behavior is the same as a jnp array of rank 1
     expanded = True
     input = jnp.expand_dims(input, 0)
-  res = jnp.argsort(input, axis=dim, descending=descending,
+  res = jnp.argsort(input, axis=dim, descending=descending, 
                      stable=stable)
   if expanded:
     res = res.squeeze()
   return res
-
 
 @register_function(torch.einsum)
 def _einsum(equation, *operands):

--- a/experimental/torch_xla2/torch_xla2/ops/jtorch.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jtorch.py
@@ -91,6 +91,6 @@ def _einsum(equation, *operands):
 
 @register_function(torch.empty)
 @op_base.convert_dtype()
-def _empty(size: Sequence[int], *, dtype=None):
+def _empty(size: Sequence[int], *, dtype=None, **kwargs):
   return jnp.empty(size, dtype=dtype)
 

--- a/experimental/torch_xla2/torch_xla2/tensor.py
+++ b/experimental/torch_xla2/torch_xla2/tensor.py
@@ -313,8 +313,7 @@ class Environment(contextlib.ContextDecorator):
     _prng_key: jax.random.PRNGKey
 
 
-    def __init__(self, random_seed):
-        self._prng_key = jax.random.PRNGKey(random_seed)
+    def __init__(self):
         self._function_mode = XLAFunctionMode(self)
         self._dispatch_mode = XLADispatchMode(self)
 


### PR DESCRIPTION
- Pull `jax.random.key`s from `torch.Generator` (either argument or global generator)
- Use `randn` as a test case
  - Fix `empty` because I thought it was required for `randn` (it's probably not)
- Support nondeterministic output in `test_ops`
  - Bonus: use `torch.testing.assert_close` because it prints a much better error message upon failure; instead of `False is not True`, you get:
  
```
E       AssertionError: Scalars are not close!
E       
E       Expected 0 but got 140357434826080.
E       Absolute difference: 140357434826080 (up to 0.001 allowed)
E       Relative difference: inf (up to 1e-05 allowed)
```
  
- Remove manually-managed PRNG key