### PR TITLE
Update non_xla attention to properly support paged_attention dynamo code path

### DIFF
--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -590,18 +590,19 @@ class PallasTest(unittest.TestCase):
 
     def paged_attention_wrapper(q, k, v, seq_lens, page_indices,
                                 pages_per_compute_block):
-      return paged_attention(
-          q_xla,
-          k_pages_xla,
-          v_pages_xla,
-          seq_lens_xla,
-          page_indices_xla,
-          pages_per_compute_block=block_size // page_size,
+      return torch.ops.xla.paged_attention(
+          q,
+          k,
+          v,
+          seq_lens,
+          page_indices,
+          pages_per_compute_block=pages_per_compute_block,
       )
 
     compiled_paged_attention = torch.compile(
         paged_attention_wrapper, backend="openxla")
-    output = paged_attention_wrapper(
+
+    output = compiled_paged_attention(
         q_xla,
         k_pages_xla,
         v_pages_xla,

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -482,7 +482,7 @@ def paged_attention(q, k_pages, v_pages, lengths, page_indices,
   return output.reshape(batch_size, num_heads, head_dim).to(q.dtype)
 
 
-def non_xla_attetion(q, k, v):
+def non_xla_attetion(q, k, v, attention_type):
   # This will be called when dynamo use fake tensor to construct the fake output.
   # We need to make sure output tensor's shape is correct.
   if k.device != torch.device("meta"):
@@ -490,6 +490,7 @@ def non_xla_attetion(q, k, v):
         f'XLA {attention_type} attention should only be applied to tensors on XLA device'
     )
 
+  # Return orignal shape of q.
   return torch.empty_like(q)
 
 
@@ -533,4 +534,4 @@ def paged_attention_non_xla(q: torch.Tensor, k_pages: torch.Tensor,
                             v_pages: torch.Tensor, lengths: torch.Tensor,
                             page_indices: torch.Tensor,
                             pages_per_compute_block: int):
-  return non_xla_attetion(q, k_pages, v_pages)
+  return non_xla_attetion(q, k_pages, v_pages, "paged")

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -482,7 +482,7 @@ def paged_attention(q, k_pages, v_pages, lengths, page_indices,
   return output.reshape(batch_size, num_heads, head_dim).to(q.dtype)
 
 
-def non_xla_attetion(q, k, v, attention_type):
+def non_xla_attetion(q, k, v):
   # This will be called when dynamo use fake tensor to construct the fake output.
   # We need to make sure output tensor's shape is correct.
   if k.device != torch.device("meta"):
@@ -490,11 +490,7 @@ def non_xla_attetion(q, k, v, attention_type):
         f'XLA {attention_type} attention should only be applied to tensors on XLA device'
     )
 
-  # perform a regular attention if input tensors are not on XLA device.
-  attn_weight = q @ k.transpose(-2, -1)
-  attn_weight = torch.nn.functional.softmax(attn_weight, dim=-1)
-  attn_output = attn_weight @ v
-  return attn_output
+  return torch.empty_like(q)
 
 
 XLA_LIB.define(
@@ -537,4 +533,4 @@ def paged_attention_non_xla(q: torch.Tensor, k_pages: torch.Tensor,
                             v_pages: torch.Tensor, lengths: torch.Tensor,
                             page_indices: torch.Tensor,
                             pages_per_compute_block: int):
-  return non_xla_attetion(q, k, v, "paged")
+  return non_xla_attetion(q, k_pages, v_pages)


### PR DESCRIPTION
- Update non_xla attention to properly support paged_attention dynamo code path
- Fix the original broken dynamo unit tests with paged_attention

Test plan:
```
root@1fdc3324aeef:/pytorch/xla# python test/test_pallas.py PallasTest.test_paged_attention_wrapper_with_dynamo
.
----------------------------------------------------------------------
Ran 1 test in 1.798s

OK
```
\+ TPU CI