### PR TITLE
Remove date tag for dev images

### DIFF
--- a/infra/tpu-pytorch-releases/dev_images.tf
+++ b/infra/tpu-pytorch-releases/dev_images.tf
@@ -36,8 +36,6 @@ module "dev_images" {
   image_name = "development"
   image_tags = concat(each.value.extra_tags, [
     each.key,
-    # Append _YYYYMMDD suffix to the dev image name.
-    "${each.key}_$(date +%Y%m%d)",
   ])
 
   dockerfile = "development.Dockerfile"


### PR DESCRIPTION
This will leave old images untagged after they are rebuilt. Hopefully stops annoying notifications about unused old images.

TODO check with terraform plan