### PR TITLE
Run persistent cache test on TPU CI

### DIFF
--- a/test/tpu/run_tests.sh
+++ b/test/tpu/run_tests.sh
@@ -26,3 +26,4 @@ python3 test/torch_distributed/test_torch_distributed_all_gather_xla_backend.py
 python3 test/torch_distributed/test_torch_distributed_all_reduce_xla_backend.py
 python3 test/torch_distributed/test_torch_distributed_multi_all_reduce_xla_backend.py
 python3 test/torch_distributed/test_torch_distributed_reduce_scatter_xla_backend.py
+python3 test/test_persistent_cache.py


### PR DESCRIPTION
Persistent cache test only ran on GPU CI. This change enables it on TPU CI as well.