### PR TITLE
disable failing tests from storage resizing PR

### DIFF
--- a/test/dynamo/test_dynamo_aliasing.py
+++ b/test/dynamo/test_dynamo_aliasing.py
@@ -46,6 +46,9 @@ class TestDynamoBufferDonationAliasingWithCustomOp(unittest.TestCase):
     dummy_inplace_mul_compiled = torch.compile(
         self.dummy_inplace_mul, backend='openxla')
 
+    # TODO: broken by https://github.com/pytorch/pytorch/pull/122434
+    # See https://github.com/pytorch/pytorch/actions/runs/9009145444/job/24755112579
+    return
     met.clear_all()
     dummy_inplace_mul_compiled(input)
     self.assertIn('XlaSetBufferDonation', met.counter_names())
@@ -81,6 +84,9 @@ class TestDynamoBufferDonationAliasingWithCustomOp(unittest.TestCase):
       torch.ops.xla.dynamo_set_buffer_donor_(input, True)
       input += (0.5 * torch.sin(input))
 
+    # TODO: broken by https://github.com/pytorch/pytorch/pull/122434
+    # See https://github.com/pytorch/pytorch/actions/runs/9009145444/job/24755112579
+    return
     device = xm.xla_device()
     input = torch.randn(5, 5).to(device)
     input_cloned = input.cpu().to(device)
@@ -115,6 +121,9 @@ class TestDynamoBufferDonationAliasing(unittest.TestCase):
     dummy_inplace_add_compiled = torch.compile(
         self.dummy_inplace_add, backend='openxla')
 
+    # TODO: broken by https://github.com/pytorch/pytorch/pull/122434
+    # See https://github.com/pytorch/pytorch/actions/runs/9009145444/job/24755112579
+    return
     met.clear_all()
     # input is a device_data, we should be able to set the buffer donation field.
     self.assertTrue(torch_xla._XLAC._set_buffer_donation(input, True))
@@ -151,6 +160,9 @@ class TestDynamoBufferDonationAliasing(unittest.TestCase):
     def dummy_inplace(input):
       input += (0.3 * torch.cos(input))
 
+    # TODO: broken by https://github.com/pytorch/pytorch/pull/122434
+    # See https://github.com/pytorch/pytorch/actions/runs/9009145444/job/24755112579
+    return
     device = xm.xla_device()
     input = torch.randn(5, 5).to(device)
     input_cloned = input.cpu().to(device)


### PR DESCRIPTION
See https://github.com/pytorch/pytorch/pull/122434#issuecomment-2102248483 - synced with @JackCaoG on temporarily failing these tests to unblock the linked PR. Happy to help investigate later!