### PR TITLE
Add option to export FX Node metadata to StableHLO

### DIFF
--- a/test/stablehlo/test_exports.py
+++ b/test/stablehlo/test_exports.py
@@ -133,30 +133,6 @@ class ExportTest(unittest.TestCase):
       shlo = exported_program_to_stablehlo(exported, options=export_options)
       self.assertEqual(shlo._bundle.state_dict, {})
 
-  def test_export_node_metadata(self):
-
-    class M(torch.nn.Module):
-
-      def __init__(self):
-        super().__init__()
-        self.fc1 = torch.nn.Linear(in_features=4, out_features=16, bias=True)
-        self.fc2 = torch.nn.Linear(in_features=16, out_features=10, bias=True)
-
-      def forward(self, x):
-        x = self.fc1(x)
-        x = self.fc2(x)
-        return torch.relu(x)
-
-    args = (torch.rand(2, 4),)
-    ep = torch.export.export(M(), args)
-    export_options = StableHLOExportOptions()
-    export_options.export_node_metadata = True
-    shlo = exported_program_to_stablehlo(ep, options=export_options)
-    shlo_text = shlo.get_stablehlo_text()
-    self.assertTrue('stack_trace' in shlo_text)
-    self.assertTrue('nn_module_stack' in shlo_text)
-    self.assertTrue('source_fn_stack' in shlo_text)
-
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/stablehlo/test_exports.py
+++ b/test/stablehlo/test_exports.py
@@ -133,6 +133,31 @@ class ExportTest(unittest.TestCase):
       shlo = exported_program_to_stablehlo(exported, options=export_options)
       self.assertEqual(shlo._bundle.state_dict, {})
 
+  def test_export_node_metadata(self):
+
+    class M(torch.nn.Module):
+
+      def __init__(self):
+        super().__init__()
+        self.fc1 = torch.nn.Linear(in_features=4, out_features=16, bias=True)
+        self.fc2 = torch.nn.Linear(in_features=16, out_features=10, bias=True)
+
+      def forward(self, x):
+        x = self.fc1(x)
+        x = self.fc2(x)
+        return torch.relu(x)
+
+    args = (torch.rand(2, 4),)
+    ep = torch.export.export(M(), args)
+    export_options = StableHLOExportOptions()
+    export_options.export_node_metadata = True
+    shlo = exported_program_to_stablehlo(ep, options=export_options)
+    shlo_text = shlo.get_stablehlo_text()
+    print(shlo_text)
+    self.assertTrue('stack_trace' in shlo_text)
+    self.assertTrue('nn_module_stack' in shlo_text)
+    self.assertTrue('source_fn_stack' in shlo_text)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/stablehlo/test_exports.py
+++ b/test/stablehlo/test_exports.py
@@ -153,7 +153,6 @@ class ExportTest(unittest.TestCase):
     export_options.export_node_metadata = True
     shlo = exported_program_to_stablehlo(ep, options=export_options)
     shlo_text = shlo.get_stablehlo_text()
-    print(shlo_text)
     self.assertTrue('stack_trace' in shlo_text)
     self.assertTrue('nn_module_stack' in shlo_text)
     self.assertTrue('source_fn_stack' in shlo_text)

--- a/test/stablehlo/test_mlir_debuginfo.py
+++ b/test/stablehlo/test_mlir_debuginfo.py
@@ -1,10 +1,11 @@
-import unittest
 import re
+import unittest
 
 import torch
 import torch_xla
 import torch_xla.experimental.xla_mlir_debuginfo
-from torch_xla.stablehlo import exported_program_to_stablehlo
+from torch_xla.stablehlo import (StableHLOExportOptions,
+                                 exported_program_to_stablehlo)
 
 
 class XlaMlirDebuginfoTest(unittest.TestCase):
@@ -27,6 +28,31 @@ class XlaMlirDebuginfoTest(unittest.TestCase):
         exported_program).get_stablehlo_text()
     self.assertTrue(re.search(r'stablehlo.add.+\"MY_ADD\"', mlir_text))
     self.assertTrue(re.search(r'stablehlo.sub.+\"MY_SUB\"', mlir_text))
+
+  def test_export_node_metadata(self):
+
+    class M(torch.nn.Module):
+
+      def __init__(self):
+        super().__init__()
+        self.fc1 = torch.nn.Linear(in_features=4, out_features=16, bias=True)
+        self.fc2 = torch.nn.Linear(in_features=16, out_features=10, bias=True)
+
+      def forward(self, x):
+        x = self.fc1(x)
+        x = self.fc2(x)
+        return torch.relu(x)
+
+    args = (torch.rand(2, 4),)
+    ep = torch.export.export(M(), args)
+    export_options = StableHLOExportOptions()
+    export_options.export_node_metadata = True
+    shlo = exported_program_to_stablehlo(ep, options=export_options)
+    shlo_text = shlo.get_stablehlo_text()
+    print(shlo_text)
+    self.assertTrue('stack_trace' in shlo_text)
+    self.assertTrue('nn_module_stack' in shlo_text)
+    self.assertTrue('source_fn_stack' in shlo_text)
 
 
 if __name__ == '__main__':

--- a/torch_xla/experimental/xla_mlir_debuginfo.py
+++ b/torch_xla/experimental/xla_mlir_debuginfo.py
@@ -8,7 +8,6 @@ from torch_xla.core.xla_model import XLA_LIB
 # Enable debug info automatically when importing this file. This is necessary
 # to propagate any debug info to downstream MLIR locations.
 os.environ["XLA_HLO_DEBUG"] = "1"
-xla_device = xm.xla_device()
 
 XLA_LIB.define("write_mlir_debuginfo(Tensor x, str data) -> Tensor")
 

--- a/torch_xla/experimental/xla_mlir_debuginfo.py
+++ b/torch_xla/experimental/xla_mlir_debuginfo.py
@@ -31,7 +31,7 @@ def write_mlir_debuginfo(x, data: str):
 
 @torch.library.impl(XLA_LIB, "write_mlir_debuginfo",
                     "CompositeExplicitAutograd")
-def write_mlir_debuginfo(x, data: str):
+def write_mlir_debuginfo_tensor(x, data: str):
   return x
 
 

--- a/torch_xla/stablehlo.py
+++ b/torch_xla/stablehlo.py
@@ -350,6 +350,10 @@ def _exported_program_to_stablehlo_bundle(exported_model,
   if options.export_node_metadata:
     gm_serializer = GraphModuleSerializer(exported_model.graph_signature,
                                           exported_model.module_call_graph)
+    if "XLA_HLO_DEBUG" in os.environ:
+      xla_hlo_debug_env = os.environ["XLA_HLO_DEBUG"]
+    else:
+      xla_hlo_debug_env = "0"
     os.environ["XLA_HLO_DEBUG"] = "1"
   else:
     gm_serializer = None
@@ -478,6 +482,8 @@ def _exported_program_to_stablehlo_bundle(exported_model,
 
   # Recover the global flag to not inline all scalars.
   torch_xla._XLAC._set_xla_all_numbers_special_scalars(False)
+  # Recover the global XLA_HLO_DEBUG flag
+  os.environ["XLA_HLO_DEBUG"] = xla_hlo_debug_env
 
   return bundle
 

--- a/torch_xla/stablehlo.py
+++ b/torch_xla/stablehlo.py
@@ -22,7 +22,6 @@ from torch_xla.experimental.stablehlo_custom_call import (
 from torch_xla.experimental.unbounded_dynamism_export import (
     exported_program_has_symbolic_input_shape,
     process_exported_program_with_symbolic_input)
-from torch_xla.experimental.xla_mlir_debuginfo import write_mlir_debuginfo
 
 
 def _get_numpy_dtype(dtype):
@@ -285,6 +284,7 @@ class XLAExportInterpreter(torch.fx.Interpreter):
     else:
       res = super().run_node(n)
     if self.gm_serializer is not None:
+      from torch_xla.experimental.xla_mlir_debuginfo import write_mlir_debuginfo
       node_metadata = json.dumps(self.gm_serializer.serialize_metadata(n))
       pytree.tree_map_only(torch.Tensor,
                            lambda x: write_mlir_debuginfo(x, node_metadata),

--- a/torch_xla/stablehlo.py
+++ b/torch_xla/stablehlo.py
@@ -11,6 +11,7 @@ import torch
 import torch_xla
 import torch_xla.experimental.quantized
 from torch._decomp import get_decompositions
+from torch._export.serde.serialize import GraphModuleSerializer
 from torch.fx import _pytree as fx_pytree
 from torch.utils import _pytree as pytree
 from torch_xla.core import dynamo_bridge
@@ -64,6 +65,8 @@ class StableHLOExportOptions:
   # Ops that will be mapped to stablehlo.custom_call in the
   # exported StableHLO graph.
   custom_ops_allowed_in_graph: Set[str] = field(default_factory=set)
+  # Export node metadata to NamedLoc in StableHLO.
+  export_node_metadata: bool = False
 
 
 class StableHLOGraphModule:
@@ -219,11 +222,13 @@ class StableHLOModelBundle:
 
 class XLAExportInterpreter(torch.fx.Interpreter):
 
-  def __init__(self, module, device, custom_ops_allowed_in_graph):
+  def __init__(self, module, device, custom_ops_allowed_in_graph,
+               gm_serializer):
     self._device = device
     super().__init__(module)
     self.tensor_id_to_dynamic_dims = {}
     self.custom_ops_allowed_in_graph = custom_ops_allowed_in_graph
+    self.gm_serializer = gm_serializer
 
   def _mark_dynamic(self, tensor, dynamic_dims):
     tid = torch_xla._XLAC._xla_get_tensor_id(tensor)
@@ -266,9 +271,8 @@ class XLAExportInterpreter(torch.fx.Interpreter):
         dynamic_dims = [
             i for i, x in enumerate(fake_t.shape) if not isinstance(x, int)
         ]
-        self._mark_dynamic(res, dynamic_dims)
       return res
-    if n.op == 'call_function':
+    elif n.op == 'call_function':
       if hasattr(n.target, 'namespace'
                 ) and n.target.namespace in self.custom_ops_allowed_in_graph:
         output_shapes, output_dtypes = extract_custom_call_outputs_shape_dtype(
@@ -276,7 +280,16 @@ class XLAExportInterpreter(torch.fx.Interpreter):
         call_name = str(n.target)
         n.target = stablehlo_custom_call
         n.args = (n.args, call_name, output_shapes, output_dtypes)
-    return super().run_node(n)
+      res = super().run_node(n)
+    else:
+      res = super().run_node(n)
+    if self.gm_serializer is not None:
+      node_metadata = json.dumps(self.gm_serializer.serialize_metadata(n))
+      pytree.tree_map_only(
+          torch.Tensor,
+          lambda x: torch_xla._XLAC._set_xla_custom_op_name_prefix(
+              x, node_metadata, 1), res)
+    return res
 
 
 def _extract_input_args(exported_model, options):
@@ -334,8 +347,16 @@ def _exported_program_to_stablehlo_bundle(exported_model,
   if options.inline_all_constant:
     # Inline all constants.
     torch_xla._XLAC._set_xla_all_numbers_special_scalars(True)
+  if options.export_node_metadata:
+    gm_serializer = GraphModuleSerializer(exported_model.graph_signature,
+                                          exported_model.module_call_graph)
+    os.environ["XLA_HLO_DEBUG"] = "1"
+  else:
+    gm_serializer = None
+
   xla_interpreter = XLAExportInterpreter(exported_model.graph_module, device,
-                                         options.custom_ops_allowed_in_graph)
+                                         options.custom_ops_allowed_in_graph,
+                                         gm_serializer)
   with torch.no_grad():
     res = xla_interpreter.run(*_flat_input_args, enable_io_processing=False)
     res = res[num_mutations:]


### PR DESCRIPTION
This fixes https://github.com/pytorch/xla/issues/7014

Example usage
```
ep = torch.export.export(M(), args)
export_options = StableHLOExportOptions()
export_options.export_node_metadata = True
shlo = exported_program_to_stablehlo(ep, options=export_options)
```
The `fx.node.meta`(Including `stack_trace`, `nn_module_stack` and `source_fn_stack`) will be serialized to JSON, stored in the `NameLoc` in StableHLO

Example output
```
module @IrToHlo.24 attributes {mhlo.cross_program_prefetches = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
  func.func @main(%arg0: tensor<10xf32> [unknown], %arg1: tensor<10x16xf32> [unknown], %arg2: tensor<16xf32> [unknown], %arg3: tensor<16x4xf32> [unknown], %arg4: tensor<2x4xf32> [unknown]) -> tensor<2x10xf32> {
    %cst = stablehlo.constant dense<0.000000e+00> : tensor<2x10xf32> [unknown]
    %0 = stablehlo.transpose %arg3, dims = [1, 0] {result_layout = dense<[0, 1]> : tensor<2xindex>, xla_shape = "f32[4,16]{0,1}"} : (tensor<16x4xf32>) -> tensor<4x16xf32> "{\22stack_trace\22: \22  File \\\22/home/lsiyuan/work/pytorch/xla/test/stablehlo/test_exports.py\\\22, line 146, in forward\\n    x = self.fc1(x)\\n\22, \22nn_module_stack\22: \22L__self__,,__main__.ExportTest.test_export_node_metadata.<locals>.M;L__self___fc1,fc1,torch.nn.modules.linear.Linear\22, \22source_fn_stack\22: \22l__self___fc1,torch.nn.modules.linear.Linear\22, \22torch_fn\22: \22linear_1;builtin_function_or_method.linear\22}aten__permute"
    %1 = stablehlo.dot_general %arg4, %0, contracting_dims = [1] x [0], precision = [DEFAULT, DEFAULT] : (tensor<2x4xf32>, tensor<4x16xf32>) -> tensor<2x16xf32> "{\22stack_trace\22: \22  File \\\22/home/lsiyuan/work/pytorch/xla/test/stablehlo/test_exports.py\\\22, line 146, in forward\\n    x = self.fc1(x)\\n\22, \22nn_module_stack\22: \22L__self__,,__main__.ExportTest.test_export_node_metadata.<locals>.M;L__self___fc1,fc1,torch.nn.modules.linear.Linear\22, \22source_fn_stack\22: \22l__self___fc1,torch.nn.modules.linear.Linear\22, \22torch_fn\22: \22linear_1;builtin_function_or_method.linear\22}aten__addmm"
    %2 = stablehlo.broadcast_in_dim %arg2, dims = [1] : (tensor<16xf32>) -> tensor<2x16xf32> "{\22stack_trace\22: \22  File \\\22/home/lsiyuan/work/pytorch/xla/test/stablehlo/test_exports.py\\\22, line 146, in forward\\n    x = self.fc1(x)\\n\22, \22nn_module_stack\22: \22L__self__,,__main__.ExportTest.test_export_node_metadata.<locals>.M;L__self___fc1,fc1,torch.nn.modules.linear.Linear\22, \22source_fn_stack\22: \22l__self___fc1,torch.nn.modules.linear.Linear\22, \22torch_fn\22: \22linear_1;builtin_function_or_method.linear\22}aten__addmm"
    %3 = stablehlo.add %1, %2 : tensor<2x16xf32> "{\22stack_trace\22: \22  File \\\22/home/lsiyuan/work/pytorch/xla/test/stablehlo/test_exports.py\\\22, line 146, in forward\\n    x = self.fc1(x)\\n\22, \22nn_module_stack\22: \22L__self__,,__main__.ExportTest.test_export_node_metadata.<locals>.M;L__self___fc1,fc1,torch.nn.modules.linear.Linear\22, \22source_fn_stack\22: \22l__self___fc1,torch.nn.modules.linear.Linear\22, \22torch_fn\22: \22linear_1;builtin_function_or_method.linear\22}aten__addmm"
    %4 = stablehlo.transpose %arg1, dims = [1, 0] {result_layout = dense<[0, 1]> : tensor<2xindex>, xla_shape = "f32[16,10]{0,1}"} : (tensor<10x16xf32>) -> tensor<16x10xf32> "{\22stack_trace\22: \22  File \\\22/home/lsiyuan/work/pytorch/xla/test/stablehlo/test_exports.py\\\22, line 147, in forward\\n    x = self.fc2(x)\\n\22, \22nn_module_stack\22: \22L__self__,,__main__.ExportTest.test_export_node_metadata.<locals>.M;L__self___fc2,fc2,torch.nn.modules.linear.Linear\22, \22source_fn_stack\22: \22l__self___fc2,torch.nn.modules.linear.Linear\22, \22torch_fn\22: \22linear_2;builtin_function_or_method.linear\22}aten__permute"
    %5 = stablehlo.dot_general %3, %4, contracting_dims = [1] x [0], precision = [DEFAULT, DEFAULT] : (tensor<2x16xf32>, tensor<16x10xf32>) -> tensor<2x10xf32> "{\22stack_trace\22: \22  File \\\22/home/lsiyuan/work/pytorch/xla/test/stablehlo/test_exports.py\\\22, line 147, in forward\\n    x = self.fc2(x)\\n\22, \22nn_module_stack\22: \22L__self__,,__main__.ExportTest.test_export_node_metadata.<locals>.M;L__self___fc2,fc2,torch.nn.modules.linear.Linear\22, \22source_fn_stack\22: \22l__self___fc2,torch.nn.modules.linear.Linear\22, \22torch_fn\22: \22linear_2;builtin_function_or_method.linear\22}aten__addmm"
    %6 = stablehlo.broadcast_in_dim %arg0, dims = [1] : (tensor<10xf32>) -> tensor<2x10xf32> "{\22stack_trace\22: \22  File \\\22/home/lsiyuan/work/pytorch/xla/test/stablehlo/test_exports.py\\\22, line 147, in forward\\n    x = self.fc2(x)\\n\22, \22nn_module_stack\22: \22L__self__,,__main__.ExportTest.test_export_node_metadata.<locals>.M;L__self___fc2,fc2,torch.nn.modules.linear.Linear\22, \22source_fn_stack\22: \22l__self___fc2,torch.nn.modules.linear.Linear\22, \22torch_fn\22: \22linear_2;builtin_function_or_method.linear\22}aten__addmm"
    %7 = stablehlo.add %5, %6 : tensor<2x10xf32> "{\22stack_trace\22: \22  File \\\22/home/lsiyuan/work/pytorch/xla/test/stablehlo/test_exports.py\\\22, line 147, in forward\\n    x = self.fc2(x)\\n\22, \22nn_module_stack\22: \22L__self__,,__main__.ExportTest.test_export_node_metadata.<locals>.M;L__self___fc2,fc2,torch.nn.modules.linear.Linear\22, \22source_fn_stack\22: \22l__self___fc2,torch.nn.modules.linear.Linear\22, \22torch_fn\22: \22linear_2;builtin_function_or_method.linear\22}aten__addmm"
    %8 = stablehlo.maximum %7, %cst : tensor<2x10xf32> "{}aten__relu"
    return %8 : tensor<2x10xf32> [unknown]
  } [unknown]
} [unknown]
```
