### PR TITLE
[benchmarks] Fix AMP setup for torchbench models.

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -224,7 +224,7 @@ class TorchBenchModel(BenchmarkModel):
     gc.collect()
 
     # If we are using CUDA, clean-up its cache left-over.
-    if self.use_accelerator_cuda():
+    if self.is_accelerator_cuda():
       torch.cuda.empty_cache()
 
   def set_up(self):
@@ -253,7 +253,7 @@ class TorchBenchModel(BenchmarkModel):
     if self.benchmark_experiment.xla:
       # First, move the model and the inputs to CPU.
       # This avoids having dupplicated data on CUDA.
-      if self.use_accelerator_cuda():
+      if self.is_accelerator_cuda():
         self.module = self.module.to("cpu")
         self.example_inputs = move_to_device(self.example_inputs, "cpu")
         self._cleanup()
@@ -307,7 +307,7 @@ class TorchBenchModel(BenchmarkModel):
     # torchbench uses `xla` as device instead of `tpu`
     device = (
         str(self.benchmark_experiment.get_device()) if
-        self.use_accelerator_tpu() else self.benchmark_experiment.accelerator)
+        self.is_accelerator_tpu() else self.benchmark_experiment.accelerator)
 
     return self.benchmark_cls()(
         test=self.benchmark_experiment.test,

--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -358,15 +358,17 @@ class TorchBenchModel(BenchmarkModel):
   def _get_autocast_with_kwargs(self):
     kwargs = {}
     if self.use_amp():
-      # Set the default data-type based on the accelerator.
+      # TODO: Should call device specific autocast implementations.
+      # Specifically, we should be using:
+      #   - torch.cuda.amp.autocast for inductor
+      #   - torch_xla.amp.autocast for PyTorch/XLA experiments.
+      # PyTorch/XLA autocast does not run with dynamo, though:
+      # https://github.com/pytorch/xla/issues/6511
       if self.is_accelerator_cuda():
         # For inductor and XLA:CUDA, we use CUDA autocast.
         autocast = torch.cuda.amp.autocast
         kwargs["dtype"] = torch.float16
       elif self.is_accelerator_tpu():
-        # Should call device specific autocast implementations.
-        # PyTorch/XLA autocast does not run with dynamo, though:
-        # https://github.com/pytorch/xla/issues/6511
         autocast = torch.amp.autocast
         kwargs["device_type"] = "xla"
         kwargs["dtype"] = torch.bfloat16

--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -306,8 +306,8 @@ class TorchBenchModel(BenchmarkModel):
 
     # torchbench uses `xla` as device instead of `tpu`
     device = (
-        str(self.benchmark_experiment.get_device()) if
-        self.is_accelerator_tpu() else self.benchmark_experiment.accelerator)
+        str(self.benchmark_experiment.get_device())
+        if self.is_accelerator_tpu() else self.benchmark_experiment.accelerator)
 
     return self.benchmark_cls()(
         test=self.benchmark_experiment.test,
@@ -376,9 +376,8 @@ class TorchBenchModel(BenchmarkModel):
         # Error: AMP is only supported on XLA:CUDA and XLA:TPU.
         name = self.model_name
         accelerator = self.benchmark_experiment.accelerator
-        raise RuntimeError(
-            f"Tried to run {name} with AMP on {accelerator}. "
-            "However, AMP is only supported on cuda and tpu.")
+        raise RuntimeError(f"Tried to run {name} with AMP on {accelerator}. "
+                           "However, AMP is only supported on cuda and tpu.")
     else:
       autocast = contextlib.nullcontext
     return (autocast, kwargs)


### PR DESCRIPTION
Fix: #6556 (and, possibly #6833)

This PR fixes the benchmarks script when running with AMP. Previously, we were calling `torch.amp.autocast(..., device_type="xla")` for both XLA:CUDA and XLA:TPU. However, we should be using `torch.cuda.amp.autocast` for XLA:CUDA (see [this](https://github.com/pytorch/xla/blob/1fa1f858342df29ce7cdf2d18cabb259869f652f/torch_xla/csrc/tensor_impl.cpp#L74-L83) for more details).

**Context:** after #6518, `Super_Slomo` inference started being run using AMP. However, due to #6511, that PR tried to mimic `torch_xla.amp.autocast` behavior, using `torch.amp.autocast`.

cc @miladm @JackCaoG @vanbasten23 @zpcore