### PR TITLE
Add `xla.step` context manager

### DIFF
--- a/test/test_devices.py
+++ b/test/test_devices.py
@@ -50,12 +50,10 @@ class TestDevices(parameterized.TestCase):
     self.assertEqual(met.counter_value('MarkStep'), 1)
 
   def test_step_exception(self):
-    try:
+    with self.assertRaisesRegex(RuntimeError, 'Expected error'):
       with xla.step():
         torch.ones((3, 3), device=xla.device())
-        raise RuntimeError("Expected error")
-    except RuntimeError:
-      pass
+        raise RuntimeError('Expected error')
 
     self.assertEqual(met.counter_value('MarkStep'), 1)
 

--- a/test/test_devices.py
+++ b/test/test_devices.py
@@ -58,7 +58,9 @@ class TestDevices(parameterized.TestCase):
 
   # Should roughly match example given in README
   def test_trivial_model(self):
+
     class TrivialModel(nn.Module):
+
       def __init__(self):
         super().__init__()
         self.linear = nn.Linear(10, 10)

--- a/test/test_devices.py
+++ b/test/test_devices.py
@@ -47,7 +47,7 @@ class TestDevices(parameterized.TestCase):
     with xla.step():
       torch.ones((3, 3), device=xla.device())
 
-    self.assertEqual(met.counter_value('MarkStep'), 1)
+    self.assertEqual(met.counter_value('MarkStep'), 2)
 
   def test_step_exception(self):
     with self.assertRaisesRegex(RuntimeError, 'Expected error'):
@@ -55,7 +55,7 @@ class TestDevices(parameterized.TestCase):
         torch.ones((3, 3), device=xla.device())
         raise RuntimeError('Expected error')
 
-    self.assertEqual(met.counter_value('MarkStep'), 1)
+    self.assertEqual(met.counter_value('MarkStep'), 2)
 
   # Should roughly match example given in README
   def test_trivial_model(self):

--- a/torch_xla/torch_xla.py
+++ b/torch_xla/torch_xla.py
@@ -1,4 +1,6 @@
+import contextlib
 from typing import List
+
 import torch
 import torch_xla
 import torch_xla.core.xla_model as xm

--- a/torch_xla/torch_xla.py
+++ b/torch_xla/torch_xla.py
@@ -64,4 +64,3 @@ def step():
   """
   yield
   xm.mark_step()
-

--- a/torch_xla/torch_xla.py
+++ b/torch_xla/torch_xla.py
@@ -50,3 +50,16 @@ def device_count() -> int:
 def sync():
   """Launches all pending graph operations."""
   xm.mark_step()
+
+
+@contextlib.contextmanager
+def step():
+  """Wraps code that should be dispatched to the runtime.
+
+  Experimental: `xla.step` is still a work in progress. Some code that currently
+  works with `xla.step` but does not follow best practices will become errors in
+  future releases. See https://github.com/pytorch/xla/issues/6751 for context.
+  """
+  yield
+  xm.mark_step()
+

--- a/torch_xla/torch_xla.py
+++ b/torch_xla/torch_xla.py
@@ -62,5 +62,7 @@ def step():
   works with `xla.step` but does not follow best practices will become errors in
   future releases. See https://github.com/pytorch/xla/issues/6751 for context.
   """
-  yield
-  xm.mark_step()
+  try:
+    yield
+  finally:
+    xm.mark_step()

--- a/torch_xla/torch_xla.py
+++ b/torch_xla/torch_xla.py
@@ -62,6 +62,9 @@ def step():
   works with `xla.step` but does not follow best practices will become errors in
   future releases. See https://github.com/pytorch/xla/issues/6751 for context.
   """
+  # Clear pending operations
+  xm.mark_step()
+
   try:
     yield
   finally:


### PR DESCRIPTION
See #6751 

- This implementation is intentionally minimal to start with. The main improvement compared to `sync` is that exceptions are handled sanely.
- Update README example to use `xla.step`. Remove `ParallelLoader` because it mostly does not make a difference for MP, and we should keep our starting point as simple as possible.