### PR TITLE
Add VSCode devcontainer instructions to CONTRIBUTING.md

### DIFF
--- a/.devcontainer/tpu-internal/devcontainer.json
+++ b/.devcontainer/tpu-internal/devcontainer.json
@@ -17,13 +17,13 @@
         "llvm-vs-code-extensions.vscode-clangd",
         "ms-vscode.cpptools-themes",
         "BazelBuild.vscode-bazel",
-        "DevonDCarew.bazel-code",
         "StackBuild.bazel-stack-vscode",
         "StackBuild.bazel-stack-vscode-cc",
         "xaver.clang-format",
         "ryanluker.vscode-coverage-gutters",
         "ms-azuretools.vscode-docker",
-        "ms-python.python"
+        "ms-python.python",
+        "eeyore.yapf"
       ]
     }
   }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ We recommend you to use our prebuilt Docker image to start your development work
   ```bash
   git clone --recursive --depth=1 https://github.com/pytorch/pytorch.git
   git clone https://github.com/pytorch/xla.git pytorch/xla
+  # Optional: use git@github.com:pytorch/xla.git instead if you prefer to use SSH with key forwarding
   ```
 
 * Link (or copy) VSCode configuration to your workspace directory:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,53 @@ You are very welcome to pick issues from [good first issue](https://github.com/p
 If you plan to contribute new features, utility functions or extensions to the core, please first open an issue and discuss the feature with us.
 Sending a PR without discussion might end up resulting in a rejected PR, because we might be taking the core in a different direction than you might be aware of.
 
-## Building Manually
+## Building from source
 
-We recommend you to use our prebuilt Docker image to start your development work. If you want to use VSCode with docker, please refer to this [config](https://github.com/pytorch/xla/tree/master/.devcontainer/tpu-contributor).
+We recommend you to use our prebuilt Docker image to start your development work using one of the two following methods.
+
+### Visual Studio Code Dev Container
+
+* Create an empty directory (optionally on a remote host via SSH) and open it in VSCode. Then, clone PyTorch and PyTorch/XLA:
+
+  ```bash
+  git clone --recursive --depth=1 https://github.com/pytorch/pytorch.git
+  git clone https://github.com/pytorch/xla.git pytorch/xla
+  ```
+
+* Link (or copy) VSCode configuration to your workspace directory:
+
+  ```bash
+  ln -s pytorch/xla/.devcontainer/ .devcontainer
+  ln -s pytorch/xla/contrib/vscode/ .vscode
+  ```
+
+* From VSCode's command menu, run `Reopen in Container` to open your workspace in one of our pre-built Docker containers. Select the correct container config based on your local accelerator (default to `tpu-contributor` if you are not sure).
+
+* Since you are running as root in this container, change ownership of all files:
+
+  ```bash
+  chown -R root:root .
+  ```
+
+* Build PyTorch and PyTorch/XLA:
+
+  ```bash
+  cd pytorch/
+  python setup.py install
+  cd xla/
+  python setup.py develop
+  # Optional: if you're using TPU, install libtpu
+  pip install torch_xla[tpu] -f https://storage.googleapis.com/libtpu-releases/index.html
+  ```
+
+* Test your build
+
+  ```bash
+  python -c 'import torch_xla as xla; print(xla.device())'
+  # Output: xla:0
+  ```
+
+### Manually build in Docker container
 
 * Setup Development Docker Image
 
@@ -41,10 +85,6 @@ We recommend you to use our prebuilt Docker image to start your development work
   cd xla/
   python setup.py develop
   ```
-
-### Build PyTorch/XLA from source with GPU support
-
-Please refer to this [guide](https://github.com/pytorch/xla/blob/master/docs/gpu.md#develop-pytorchxla-on-a-gpu-instance-build-pytorchxla-from-source-with-gpu-support).
 
 ## Before Submitting A Pull Request:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,10 @@ We recommend you to use our prebuilt Docker image to start your development work
   python setup.py develop
   ```
 
+### Additional steps for GPU
+
+Please refer to this [guide](https://github.com/pytorch/xla/blob/master/docs/gpu.md#develop-pytorchxla-on-a-gpu-instance-build-pytorchxla-from-source-with-gpu-support).
+
 ## Before Submitting A Pull Request:
 
 In `pytorch/xla` repo we enforce coding style for both C++ and Python files. Please try to format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,8 @@ We recommend you to use our prebuilt Docker image to start your development work
   ```bash
   ln -s pytorch/xla/.devcontainer/ .devcontainer
   ln -s pytorch/xla/contrib/vscode/ .vscode
+  ln -s pytorch/xla/.style.yapf .style.yapf
+  ln -s pytorch/xla/.clang-format .clang-format
   ```
 
 * From VSCode's command menu, run `Reopen in Container` to open your workspace in one of our pre-built Docker containers. Select the correct container config based on your local accelerator (default to `tpu-contributor` if you are not sure).

--- a/contrib/vscode/settings.json
+++ b/contrib/vscode/settings.json
@@ -14,9 +14,19 @@
     "coverage-gutters.coverageFileNames": [
         "./bazel-out/_coverage/_coverage_report.dat"
     ],
-    "lcov.path": [
-        "./bazel-out/_coverage/_coverage_report.dat"
+    "git.detectSubmodules": false,
+    "[python]": {
+        "editor.defaultFormatter": "eeyore.yapf",
+        "editor.formatOnSave": true,
+    },
+    "python.analysis.exclude": [
+        "**/third_party",
+        "**/build",
+        "**/__pycache__",
+        "**/.git",
     ],
-    "python.formatting.provider": "yapf",
-    "editor.formatOnSave": true
+    "[cpp]": {
+        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.formatOnSave": true,
+    }
 }


### PR DESCRIPTION
Tested these instructions because I broke my build environment and had to start from scratch.

Remove extra GPU instructions because this should be handled by dev container.