### PR TITLE
fix kokoro

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -9,7 +9,7 @@ XLA_DIR=$PYTORCH_DIR/xla
 git clone --quiet https://github.com/pytorch/pytorch.git "$PYTORCH_DIR"
 pushd .
 cd $PYTORCH_DIR
-git submodule update --init --recursive
+git submodule --quiet update --init --recursive
 popd
 cp -r "${KOKORO_ARTIFACTS_DIR}/github/xla" "$XLA_DIR"
 source ${XLA_DIR}/.kokoro/common.sh

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -9,7 +9,7 @@ XLA_DIR=$PYTORCH_DIR/xla
 git clone --quiet https://github.com/pytorch/pytorch.git "$PYTORCH_DIR"
 pushd .
 cd $PYTORCH_DIR
-git git submodule update --init --recursive
+git submodule update --init --recursive
 popd
 cp -r "${KOKORO_ARTIFACTS_DIR}/github/xla" "$XLA_DIR"
 source ${XLA_DIR}/.kokoro/common.sh

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -7,6 +7,10 @@ DEBIAN_FRONTEND=noninteractive
 PYTORCH_DIR="${KOKORO_ARTIFACTS_DIR}/github/pytorch"
 XLA_DIR=$PYTORCH_DIR/xla
 git clone --quiet https://github.com/pytorch/pytorch.git "$PYTORCH_DIR"
+pushd .
+cd $PYTORCH_DIR
+git git submodule update --init --recursive
+popd
 cp -r "${KOKORO_ARTIFACTS_DIR}/github/xla" "$XLA_DIR"
 source ${XLA_DIR}/.kokoro/common.sh
 


### PR DESCRIPTION
kokoro builds are failing in presubmit [link](https://fusion2.corp.google.com/ci/kokoro/prod:cloud-tpu%2Ftorchxla%2Fgithub%2Fpresubmit/activity/ec9c65d1-0e35-483b-9fd1-2e4822935fe6/log):
```
Cloning into '/pytorch/third_party/cpp-httplib'...
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:yhirose/cpp-httplib.git' into submodule path '/pytorch/third_party/cpp-httplib' failed
Failed to clone 'third_party/cpp-httplib' a second time, aborting
Building wheel torch-2.4.0a0+gitd7de4c9
-- Building version 2.4.0a0+gitd7de4c9
 --- Trying to initialize submodules
 --- Submodule initalization failed
Please run:
	git submodule update --init --recursive
Command exited with non-zero status 1
```