### PR TITLE
[benchmarks] Add default value to `move_to_device`.

### DIFF
--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -76,7 +76,7 @@ def is_xla_device_available(devkind):
   return r.returncode == 0
 
 
-def move_to_device(item, device, torch_xla2):
+def move_to_device(item, device, torch_xla2=False):
   if torch_xla2:
     import torch_xla2
     import jax


### PR DESCRIPTION
PR #7013 broke the benchmarking scripts for XLA:CUDA by adding a new parameter to `move_to_device` function, not modifying a few call-sites. This PR fixes this by adding a default value.

Before:
```python
def move_to_device(item, device, torch_xla2):
     ...
```

After:
```python
def move_to_device(item, device, torch_xla2=False):
     ...
```

cc @miladm @zpcore @vanbasten23 