### PR TITLE
Dump HLO HBM usage info

### DIFF
--- a/test/debug_tool/extract_debug_helper.py
+++ b/test/debug_tool/extract_debug_helper.py
@@ -28,6 +28,14 @@ class GraphInfo(NamedTuple):
   num_output: int
 
 
+class PostCompilationInfo(NamedTuple):
+  input_size: str
+  output_size: str
+  aliased_size: str
+  intermediate_size: str
+  program_size: str
+
+
 def extract_graph_infos(lines):
   infos = []
   for i in range(len(lines)):
@@ -39,6 +47,28 @@ def extract_graph_infos(lines):
           'Number of Graph Outputs:')[1].strip()
       infos.append(GraphInfo(hash, int(num_input), int(num_output)))
 
+  return infos
+
+
+def extract_post_compilation_analysis(lines):
+  infos = []
+  i = 0
+  while i < len(lines):
+    if 'Post Compilation Analysis' in lines[i].decode():
+      input_size = lines[i + 1].decode().split('Graph input size: ')[1].strip()
+      output_size = lines[i +
+                          2].decode().split('Graph output size: ')[1].strip()
+      aliased_size = lines[i +
+                           3].decode().split('Aliased Input size: ')[1].strip()
+      intermediate_size = lines[i + 4].decode().split(
+          'Intermediate tensor size: ')[1].strip()
+      program_size = lines[i + 5].decode().split(
+          'Compiled program size: ')[1].strip()
+      infos.append(
+          PostCompilationInfo(input_size, output_size, aliased_size,
+                              intermediate_size, program_size))
+      i += 7
+    i += 1
   return infos
 
 

--- a/test/debug_tool/test_mp_pt_xla_debug.py
+++ b/test/debug_tool/test_mp_pt_xla_debug.py
@@ -32,14 +32,14 @@ def _mp_fn(index):
     # only the local master process should dump the executation analysis
     assert (len(causes) == 1)
     assert ('user mark_step' in causes[0])
-    assert (len(frames) == 2)
+    assert (len(frames) == 3)
     max_frame = os.getenv('PT_XLA_DEBUG_MAX_FRAME', 8)
     # Additonal lines are
     # 1. Python Frame Triggered Execution:
     # 2. ....
     # 3. empty line
     assert (len(frames[0].split('\n')) == max_frame + 3)
-    assert (len(frames[1].split('\n')) == max_frame + 3)
+    assert (len(frames[2].split('\n')) == max_frame + 3)
 
 
 if __name__ == '__main__':

--- a/torch_xla/csrc/debug_util.h
+++ b/torch_xla/csrc/debug_util.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "absl/types/span.h"
+#include "torch_xla/csrc/runtime/computation_client.h"
 #include "torch_xla/csrc/tensor.h"
 
 namespace torch_xla {
@@ -60,6 +61,9 @@ class DebugUtil {
   static void analyze_graph_execution_python_frame(
       GraphAnalysisSource source, torch::lazy::hash_t graph_hash = 0,
       const xla::ProgramShape* program_shape = nullptr);
+
+  static void post_compilation_analysis(
+      runtime::ComputationClient::ComputationPtr computation);
 };
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/runtime/computation_client.h
+++ b/torch_xla/csrc/runtime/computation_client.h
@@ -191,6 +191,10 @@ class ComputationClient {
       return module->ToString();
     }
 
+    virtual const std::string get_memory_info() const {
+      XLA_ERROR() << "Unimplemented";
+    }
+
    private:
     xla::XlaComputation computation_;
     xla::ProgramShape program_shape_;

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -595,12 +595,6 @@ std::vector<ComputationClient::ComputationPtr> PjRtComputationClient::Compile(
     if (memory_stats_status_or.ok()) {
       xla::CompiledMemoryStats memory_stats = memory_stats_status_or.value();
       TF_VLOG(3) << "memory usage detail = " << memory_stats.DebugString();
-      TF_VLOG(3)
-          << "total runtime device memory required to run this program = "
-          << ((memory_stats.output_size_in_bytes +
-               memory_stats.temp_size_in_bytes) >>
-              20)
-          << " MB";
     } else {
       TF_VLOG(3) << "memory usage is not availiable";
     }

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -591,6 +591,20 @@ std::vector<ComputationClient::ComputationPtr> PjRtComputationClient::Compile(
           client_->Compile(instance.computation, compile_options).value();
     }
 
+    auto memory_stats_status_or = executable->GetCompiledMemoryStats();
+    if (memory_stats_status_or.ok()) {
+      xla::CompiledMemoryStats memory_stats = memory_stats_status_or.value();
+      TF_VLOG(3) << "memory usage detail = " << memory_stats.DebugString();
+      TF_VLOG(3)
+          << "total runtime device memory required to run this program = "
+          << ((memory_stats.output_size_in_bytes +
+               memory_stats.temp_size_in_bytes) >>
+              20)
+          << " MB";
+    } else {
+      TF_VLOG(3) << "memory usage is not availiable";
+    }
+
     const auto& hlo_modules = ConsumeValue(executable->GetHloModules());
     xla::HloComputation* hlo_computation = hlo_modules[0]->entry_computation();
     std::shared_ptr<PjRtComputation> pjrt_computation =

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -263,6 +263,15 @@ class PjRtComputationClient : public ComputationClient {
       output_shardings_ = this->executable->GetOutputShardings();
     }
 
+    const std::string get_memory_info() const override {
+      auto memory_stats_status_or = executable->GetCompiledMemoryStats();
+      if (memory_stats_status_or.ok()) {
+        return memory_stats_status_or.value().DebugString();
+      } else {
+        return "memory usage is not availiable";
+      }
+    }
+
     std::unique_ptr<xla::PjRtLoadedExecutable> executable;
     std::optional<std::vector<xla::OpSharding>> output_shardings_;
   };

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -45,6 +45,7 @@
 #include "torch_xla/csrc/runtime/computation_client.h"
 #include "torch_xla/csrc/runtime/debug_macros.h"
 #include "torch_xla/csrc/runtime/env_vars.h"
+#include "torch_xla/csrc/runtime/pjrt_computation_client.h"
 #include "torch_xla/csrc/runtime/runtime.h"
 #include "torch_xla/csrc/runtime/stablehlo_helper.h"
 #include "torch_xla/csrc/runtime/sys_util.h"
@@ -1396,6 +1397,7 @@ XLAGraphExecutor::CompilationResult XLAGraphExecutor::Compile(
   std::vector<std::shared_ptr<runtime::ComputationClient::Computation>>
       computations =
           runtime::GetComputationClient()->Compile(std::move(instances));
+  DebugUtil::post_compilation_analysis(computations[0]);
   TF_VLOG(3) << "Compiling IR graph hash "
              << torch::lazy::HashToString(coll.hash) << " on device "
              << coll.device << " done!";


### PR DESCRIPTION
after enabling the `PT_XLA_DEBUG=1` one should see
```
Compilation Analysis: ================================================================================
Compilation Analysis: Compilation Cause
Compilation Analysis:   mark_step in parallel loader at step end
Compilation Analysis: Graph Info: 
Compilation Analysis:   Graph Hash: aaf3f25f7c1fa61b301aa41ebec815d0
Compilation Analysis:   Number of Graph Inputs: 325
Compilation Analysis:   Number of Graph Outputs: 485
Compilation Analysis: Python Frame Triggered Execution: 
Compilation Analysis:   mark_step (/workspaces/dk3/pytorch/xla/torch_xla/core/xla_model.py:1055)
Compilation Analysis:   next (/workspaces/dk3/pytorch/xla/torch_xla/distributed/parallel_loader.py:44)
Compilation Analysis:   __next__ (/workspaces/dk3/pytorch/xla/torch_xla/distributed/parallel_loader.py:32)
Compilation Analysis:   train_loop_fn (/workspaces/dk3/pytorch/xla/examples/train_resnet_base.py:47)
Compilation Analysis:   start_training (/workspaces/dk3/pytorch/xla/examples/train_resnet_base.py:63)
Compilation Analysis:   <module> (/workspaces/dk3/pytorch/xla/examples/train_resnet_base.py:71)
Compilation Analysis: --------------------------------------------------------------------------------
Compilation Analysis: ================================================================================

Post Compilation Analysis: ================================================================================
Post Compilation Analysis: Input size: 171MB
Post Compilation Analysis: Output size: 204MB
Post Compilation Analysis: Aliased Input size: 0MB
Post Compilation Analysis: Intermediate tensor size: 8491MB
Post Compilation Analysis: Compiled program size: 69MB
Post Compilation Analysis: --------------------------------------------------------------------------------
Post Compilation Analysis: ================================================================================
```