### PR TITLE
Implement `ComputationClient::GetMemoryInfo`

### DIFF
--- a/test/pjrt/test_runtime_tpu.py
+++ b/test/pjrt/test_runtime_tpu.py
@@ -7,6 +7,7 @@ import requests
 
 import torch
 from absl.testing import absltest, parameterized
+import torch_xla
 import torch_xla.core.xla_env_vars as xenv
 import torch_xla.core.xla_model as xm
 import torch_xla.debug.metrics as met
@@ -251,6 +252,17 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
           v, expected_time_seconds * 1e-9,
           f"Expected exectue time of {i} to take more than "
           f"{expected_time_seconds} seconds, got {v / 1e9} seconds")
+
+  @staticmethod
+  def _memory_usage():
+    return torch_xla._XLAC._xla_memory_info(str(torch_xla.device()))
+
+  # TODO: Create a public API and test that instead
+  def test_memory_usage(self):
+    results = pjrt.run_multiprocess(self._memory_usage)
+    for usage in results.values():
+      self.assertIn('bytes_used', usage)
+      self.assertIn('bytes_limit', usage)
 
 
 if __name__ == '__main__':

--- a/test/pjrt/test_runtime_tpu.py
+++ b/test/pjrt/test_runtime_tpu.py
@@ -255,9 +255,8 @@ class TestExperimentalPjrtTpu(parameterized.TestCase):
 
   @staticmethod
   def _memory_usage():
-    return torch_xla._XLAC._xla_memory_info(str(torch_xla.device()))
+    return xm.get_memory_info(torch_xla.device())
 
-  # TODO: Create a public API and test that instead
   def test_memory_usage(self):
     results = pjrt.run_multiprocess(self._memory_usage)
     for usage in results.values():

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -1440,10 +1440,10 @@ class MemoryInfo(TypedDict):
 
 
 def get_memory_info(device: torch.device) -> MemoryInfo:
-  """Retrieves the device memory information.
+  """Retrieves the device memory usage.
 
   Args:
-    device (string): The device whose memory information are requested.
+    device: The device whose memory information are requested.
 
   Returns:
     MemoryInfo dict with memory usage for the given device.

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -7,7 +7,7 @@ import re
 import threading
 import time
 import warnings
-from typing import List, Optional
+from typing import List, Optional, TypedDict
 import torch
 import torch.distributed._functional_collectives
 from torch.library import Library
@@ -1434,15 +1434,19 @@ def fork_rng(device=None, enabled=True):
     set_rng_state(xla_rng_state, device=device)
 
 
-def get_memory_info(device):
+class MemoryInfo(TypedDict):
+  bytes_used: str
+  bytes_limit: int
+
+
+def get_memory_info(device: torch.device) -> MemoryInfo:
   """Retrieves the device memory information.
 
   Args:
     device (string): The device whose memory information are requested.
 
   Returns:
-    A dictionary with `kb_free` (free memory in KB) and `kb_total` (total
-    memory in KB) keys.
+    MemoryInfo dict with memory usage for the given device.
   """
   return torch_xla._XLAC._xla_memory_info(str(device))
 

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1825,7 +1825,6 @@ void InitXlaModuleBindings(py::module m) {
         return GetLiveTensorsReport(nodes_threshold, device);
       },
       py::arg("nodes_threshold") = 100, py::arg("device") = "");
-  py::class_<runtime::ComputationClient::MemoryInfo>(m, "MemoryInfo");
   m.def("_xla_memory_info",
         [](const std::string& device) { return GetMemoryInfo(device); });
   m.def(

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -725,8 +725,8 @@ py::dict GetMemoryInfo(const std::string& device_str) {
         runtime::GetComputationClient()->GetMemoryInfo(device.toString());
   }
   auto py_dict = py::dict();
-  py_dict["kb_free"] = mem_info.kb_free;
-  py_dict["kb_total"] = mem_info.kb_total;
+  py_dict["bytes_used"] = mem_info.bytes_used;
+  py_dict["bytes_limit"] = mem_info.bytes_limit;
   return py_dict;
 }
 
@@ -1825,9 +1825,9 @@ void InitXlaModuleBindings(py::module m) {
         return GetLiveTensorsReport(nodes_threshold, device);
       },
       py::arg("nodes_threshold") = 100, py::arg("device") = "");
-  m.def("_xla_memory_info", [](const std::string& device) -> py::object {
-    return GetMemoryInfo(device);
-  });
+  py::class_<runtime::ComputationClient::MemoryInfo>(m, "MemoryInfo");
+  m.def("_xla_memory_info",
+        [](const std::string& device) { return GetMemoryInfo(device); });
   m.def(
       "_xla_set_use_full_mat_mul_precision",
       [](bool use_full_mat_mul_precision) {

--- a/torch_xla/csrc/runtime/computation_client.h
+++ b/torch_xla/csrc/runtime/computation_client.h
@@ -246,8 +246,8 @@ class ComputationClient {
   struct ExecuteReplicatedOptions : public ClientExecuteOptions {};
 
   struct MemoryInfo {
-    int64_t kb_free = 0;
-    int64_t kb_total = 0;
+    int64_t bytes_used = 0;
+    int64_t bytes_limit = 0;
   };
 
   virtual ~ComputationClient() {}

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -120,11 +120,7 @@ class PjRtComputationClient : public ComputationClient {
 
   bool CoordinatorInitialized() const override;
 
-  // NOT IMPLEMENTED
-
-  MemoryInfo GetMemoryInfo(const std::string& device) override {
-    XLA_ERROR() << __FUNCTION__ << " not implemented";
-  };
+  MemoryInfo GetMemoryInfo(const std::string& device) override;
 
  private:
   std::unique_ptr<xla::PjRtClient> client_;


### PR DESCRIPTION
Implement private API for getting TPU memory allocation. Tweak old API because it's ugly.

Example:

```
>>> import torch_xla
>>> import torch_xla.core.xla_model as xm
>>> torch_xla._XLAC._xla_memory_info(str(xm.xla_device()))
{'bytes_used': 214528, 'bytes_limit': 34088157184}
>>> import jax
>>> jax.devices()[0].memory_stats()
{'num_allocs': 2, 'bytes_in_use': 214528, 'peak_bytes_in_use': 214528, 'largest_alloc_size': 201728, 'bytes_limit': 34088157184, 'bytes_reserved': 0, 'peak_bytes_reserved': 0, 'bytes_reservable_limit': 34088157184, 'largest_free_block_bytes': 34087942656}
```

Creating a nice public API that rounds to a human-readable unit is left as an exercise to the reader.