### PR TITLE
Add data-type promotion to `stack`.

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1998,6 +1998,22 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
 
     self.assertEqual(r, Xr.cpu())
 
+  def test_stack_different_types(self):
+
+    def foo(t0, t1):
+      return torch.stack([t0, t1])
+
+    t0 = torch.rand(10, 10, dtype=torch.bfloat16)
+    t1 = torch.rand(10, 10)
+
+    Xt0 = t0.to(xm.xla_device())
+    Xt1 = t1.to(xm.xla_device())
+
+    r = foo(t0, t1)
+    Xr = foo(Xt0, Xt1)
+
+    self.assertEqual(r, Xr.cpu())
+
 
 class MNISTComparator(nn.Module):
 

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3160,8 +3160,12 @@ at::Tensor XLANativeFunctions::squeeze_copy(const at::Tensor& self,
 
 at::Tensor XLANativeFunctions::stack(at::TensorList tensors, int64_t dim) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
+  at::ScalarType result_type = at::native::result_type(tensors);
+  std::vector<at::Tensor> c_tensors(tensors.size());
+  std::transform(tensors.begin(), tensors.end(), c_tensors.begin(),
+                 [=](const at::Tensor& t) { return t.to(result_type); });
   return bridge::AtenFromXlaTensor(
-      tensor_methods::stack(bridge::GetXlaTensors(tensors), dim));
+      tensor_methods::stack(bridge::GetXlaTensors(c_tensors), dim));
 }
 
 at::Tensor XLANativeFunctions::std(const at::Tensor& self, bool unbiased) {


### PR DESCRIPTION
Fix: #7083 

This PR adds data-type promotion to `stack` operation. Previously, there was none. So, the kernel implicitly expected the arguments to be of the same data-type. This might not be the case when using AMP.

cc @miladm @JackCaoG