### PR TITLE
Add torch_xla2 `export_program_to_stablehlo` API with unbounded dynamism support

### DIFF
--- a/experimental/torch_xla2/README.md
+++ b/experimental/torch_xla2/README.md
@@ -21,7 +21,7 @@ the instructions below from scratch (fresh venv / conda environment.)
 
 ### 1. Installing `torch_xla2`
 
-The following instructions assume you are in the `torch_xla2 directory:
+The following instructions assume you are in the `torch_xla2` directory:
 
 ```
 $ git clone https://github.com/pytorch/xla.git

--- a/experimental/torch_xla2/README.md
+++ b/experimental/torch_xla2/README.md
@@ -21,6 +21,14 @@ the instructions below from scratch (fresh venv / conda environment.)
 
 ### 1. Installing `torch_xla2`
 
+The following instructions assume you are in the `torch_xla2 directory:
+
+```
+$ git clone https://github.com/pytorch/xla.git
+$ cd xla/experimental/torch_xla2
+```
+
+
 #### 1.0 (recommended) Make a virtualenv / conda env
 
 If you are using VSCode, then [you can create a new environment from

--- a/experimental/torch_xla2/pyproject.toml
+++ b/experimental/torch_xla2/pyproject.toml
@@ -8,7 +8,7 @@ name = "torch_xla2"
 dependencies = [
     "absl-py",
     "immutabledict",
-    "jax>=0.4.24",
+    "jax[cpu]>=0.4.24",
     "pytest",
     "tensorflow-cpu",
     # Developers should install `dev-requirements.txt` first

--- a/experimental/torch_xla2/test/test_exports.py
+++ b/experimental/torch_xla2/test/test_exports.py
@@ -54,9 +54,6 @@ class ExportTest(unittest.TestCase):
     self.assertIn("func.func private @clip(%arg0: tensor<500xf32>", module_str)
     self.assertIn("stablehlo.minimum", module_str)
 
-    # Test with dynamic export
-
-
   def test_constant(self):
 
     # Check Accuracy

--- a/experimental/torch_xla2/test/test_exports.py
+++ b/experimental/torch_xla2/test/test_exports.py
@@ -135,7 +135,6 @@ class ExportTest(unittest.TestCase):
         ##   jnp.tensor(dtype=None) maps to f64
         continue
       arg = (torch.randn(10).to(torch_dtype),)
-      print(arg)
       with torch.no_grad():
         exported = torch.export.export(model, arg)
       stablehlo = torch_xla2.export.exported_program_to_stablehlo(exported)

--- a/experimental/torch_xla2/test/test_exports.py
+++ b/experimental/torch_xla2/test/test_exports.py
@@ -93,10 +93,42 @@ class ExportTest(unittest.TestCase):
 
     # Look for dynamic shape artifacts
     self.assertIn("func.func public @main(%arg0: tensor<?x3x200x200xf32>", module_str)
-    self.assertRegex(module_str, "shape_assertion.*s0 >= 3")
-    self.assertRegex(module_str, "shape_assertion.*s0 <= 10")
+    self.assertRegex(module_str, r"shape_assertion.*s0 >= 3")
+    self.assertRegex(module_str, r"shape_assertion.*s0 <= 10")
     self.assertIn("stablehlo.dynamic_broadcast_in_dim", module_str)
     self.assertIn("stablehlo.dynamic_gather", module_str)
+
+  def test_complex_constraint(self):
+    """Test a model with a slightly more complex constraint, where the input
+    shapes are determined by an equation of the other, in this case input shapes
+    are s0{<=10} and s0*2.
+    """
+    class ConcatAddModel(torch.nn.Module):
+      def __init__(self):
+        super().__init__()
+
+      def forward(self, a, b):
+        a = torch.concat([a, a], dim=0)
+        return a + b
+
+    # Arg shapes are a=s0{<=10}, b=s0*2
+    model = ConcatAddModel()
+    args = (torch.rand(2),torch.rand(4))
+    sym_a = torch.export.Dim("a", max=10)
+    sym_b = sym_a*2
+    dynamic_shapes = ({0: sym_a}, {0: sym_b})
+
+    with torch.no_grad():
+      exported = torch.export.export(model, args=args, dynamic_shapes=dynamic_shapes)
+    stablehlo = torch_xla2.export.exported_program_to_stablehlo(exported)
+    module_str = str(stablehlo.mlir_module())
+
+    self.assertIn("stablehlo.constant dense<2>", module_str)
+    self.assertRegex(module_str, r"shape_assertion.*s0 <= 10")
+    self.assertRegex(module_str, r"shape_assertion.*2*s0")
+    self.assertRegex(module_str, r'stablehlo.concatenate.*tensor<\?xf32>')
+    self.assertRegex(module_str, r'stablehlo.add.*tensor<\?xf32>')
+    print(stablehlo.mlir_module())
 
   def test_export_dtypes(self):
     DTYPE_TO_MLIR_STR = {

--- a/experimental/torch_xla2/test/test_exports.py
+++ b/experimental/torch_xla2/test/test_exports.py
@@ -34,33 +34,115 @@ class ExportTest(unittest.TestCase):
 
   def test_interpolate(self):
 
+    # Check Accuracy
     arg = (torch.randn(3, 3, 200, 200),)
     model = Interpolate()
-
     ans = model(*arg)
 
     with torch.no_grad():
       exported = torch.export.export(model, arg)
-      weights, func = torch_xla2.export.exported_program_to_jax(exported)
-      argj = tensor.t2j(arg[0])
-      ans2 = jax.jit(func)(weights, (argj,))[0]
-      ans2 = tensor.j2t(ans2)
-      self.assertTrue(torch.allclose(ans, ans2, atol=1e-3))
+    weights, func = torch_xla2.export.exported_program_to_jax(exported)
+    argj = tensor.t2j(arg[0])
+    ans2 = jax.jit(func)(weights, (argj,))[0]
+    ans2 = tensor.j2t(ans2)
+    self.assertTrue(torch.allclose(ans, ans2, atol=1e-3))
+
+    # Convert to StableHLO
+    stablehlo = torch_xla2.export.exported_program_to_stablehlo(exported)
+    module_str = str(stablehlo.mlir_module())
+    self.assertIn("func.func public @main", module_str)
+    self.assertIn("func.func private @clip(%arg0: tensor<500xf32>", module_str)
+    self.assertIn("stablehlo.minimum", module_str)
+
+    # Test with dynamic export
+
 
   def test_constant(self):
 
+    # Check Accuracy
     arg = (torch.randn(10, 10),)
     model = TensorConstant()
-
     ans = model(*arg)
 
     with torch.no_grad():
       exported = torch.export.export(model, arg)
-      weights, func = torch_xla2.export.exported_program_to_jax(exported)
-      argj = tensor.t2j(arg[0])
-      ans2 = jax.jit(func)(weights, (argj,))[0]
-      ans2 = tensor.j2t(ans2)
-      self.assertTrue(torch.allclose(ans, ans2, atol=1e-5))
+
+    weights, func = torch_xla2.export.exported_program_to_jax(exported)
+    argj = tensor.t2j(arg[0])
+    ans2 = jax.jit(func)(weights, (argj,))[0]
+    ans2 = tensor.j2t(ans2)
+    self.assertTrue(torch.allclose(ans, ans2, atol=1e-5))
+
+    # Convert to StableHLO
+    stablehlo = torch_xla2.export.exported_program_to_stablehlo(exported)
+    module_str = str(stablehlo.mlir_module())
+    self.assertIn("func.func public @main", module_str)
+    self.assertIn("stablehlo.divide", module_str)
+
+  def test_interpolate_dynamic(self):
+    # Export with dynamic dimension constraints on both min and max
+    arg = (torch.randn(3, 3, 200, 200),)
+    model = Interpolate()
+    ans = model(*arg)
+    dynamic_shapes = ({0:  torch.export.Dim("b", min=3, max=10)},)
+
+    with torch.no_grad():
+      exported = torch.export.export(model, arg, dynamic_shapes=dynamic_shapes)
+    stablehlo = torch_xla2.export.exported_program_to_stablehlo(exported)
+    module_str = str(stablehlo.mlir_module())
+
+    # Look for dynamic shape artifacts
+    self.assertIn("func.func public @main(%arg0: tensor<?x3x200x200xf32>", module_str)
+    self.assertRegex(module_str, "shape_assertion.*s0 >= 3")
+    self.assertRegex(module_str, "shape_assertion.*s0 <= 10")
+    self.assertIn("stablehlo.dynamic_broadcast_in_dim", module_str)
+    self.assertIn("stablehlo.dynamic_gather", module_str)
+
+  def test_export_dtypes(self):
+    DTYPE_TO_MLIR_STR = {
+      # NO_MAPPING        : jnp.float0 (signless scalar int)
+      torch.bool          : "i1",
+      # NO_MAPPING        : "i4"
+      torch.int8          : "i8",
+      torch.int16         : "i16",
+      torch.int32         : "i32",
+      torch.int64         : "i64",
+      torch.long          : "i64",
+      # NO_MAPPING        : "ui4"
+      torch.uint8         : "ui8",
+      torch.uint16        : "ui16",
+      torch.uint32        : "ui32",
+      torch.uint64        : "ui64",
+      # NO_MAPPING        : "f8E4M3B11FNUZ"
+      torch.float8_e4m3fn : "f8E4M3FN",
+      # NO_MAPPING        : f8E4M3FNUZ
+      torch.float8_e5m2   : "f8E5M2",
+      # NO_MAPPING        : f8E5M2FNUZ
+      torch.bfloat16      : "bf16",
+      torch.half          : "f16",
+      torch.float16       : "f16",
+      torch.float32       : "f32",
+      torch.float64       : "f64",
+      torch.double        : "f64",
+      torch.complex64     : "complex<f32>",
+      torch.complex128    : "complex<f64>",
+      None                : None,
+    }
+
+    model = TensorConstant()
+    for torch_dtype in torch_xla2.tensor.TORCH_DTYPE_TO_JAX.keys():
+      if torch_dtype == None:
+        ## TODO: Figure out what the None mapping should be, seems like:
+        ##   torch.tensor(dtype=None) maps to f32
+        ##   jnp.tensor(dtype=None) maps to f64
+        continue
+      arg = (torch.randn(10).to(torch_dtype),)
+      print(arg)
+      with torch.no_grad():
+        exported = torch.export.export(model, arg)
+      stablehlo = torch_xla2.export.exported_program_to_stablehlo(exported)
+      module_str = str(stablehlo.mlir_module())
+      self.assertIn(DTYPE_TO_MLIR_STR[torch_dtype], module_str)
 
 
 if __name__ == '__main__':

--- a/experimental/torch_xla2/test/test_symbolic_shapes.py
+++ b/experimental/torch_xla2/test/test_symbolic_shapes.py
@@ -1,0 +1,94 @@
+import unittest
+import torch
+import jax
+import torch_xla2
+
+class AddOne(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  def forward(self, a):
+    return a + 1
+
+class ConcatAddModel(torch.nn.Module):
+  def __init__(self):
+    super().__init__()
+
+  def forward(self, a, b):
+    a = torch.concat([a, a], dim=0)
+    return a + b
+
+class SymbolicShapeTest(unittest.TestCase):
+  """Test possible symbolic shape computations that upstream torch export can
+  emit. Seems to be currently limited to a few binary math operations where one
+  operand is a symbolic variable/expr and the other is a constant integer.
+  """
+
+  def setUp(self):
+    torch.manual_seed(0)
+
+  def test_constraints_min_max(self):
+    """Test a model with basic min/max dimension restrictions 
+    """
+
+    # Arg shapes are a=s0{<=10}, b=s0*2
+    model = AddOne()
+    args = (torch.rand(5),)
+    sym_a = torch.export.Dim("a", min=3, max=10)
+    dynamic_shapes = ({0: sym_a},)
+
+    with torch.no_grad():
+      exported = torch.export.export(model, args=args, dynamic_shapes=dynamic_shapes)
+    stablehlo = torch_xla2.export.exported_program_to_stablehlo(exported)
+    module_str = str(stablehlo.mlir_module())
+
+    self.assertRegex(module_str, r"stablehlo.constant.*3")
+    self.assertRegex(module_str, r"shape_assertion.*s[0-9]+ >= 3")
+    self.assertRegex(module_str, r"stablehlo.constant.*10")
+    self.assertRegex(module_str, r"shape_assertion.*s[0-9]+ <= 10")
+
+  def test_constraints_multiply(self):
+    """Test a model with a slightly more complex constraint, where the input
+    shapes are determined by an equation of the other, in this case input shapes
+    are s0{<=10} and s0*2.
+    """
+    # Arg shapes are a=s0{<=10}, b=s0*2
+    model = ConcatAddModel()
+    args = (torch.rand(2),torch.rand(4))
+    sym_a = torch.export.Dim("a", max=10)
+    sym_b = sym_a*2
+    dynamic_shapes = ({0: sym_a}, {0: sym_b})
+
+    with torch.no_grad():
+      exported = torch.export.export(model, args=args, dynamic_shapes=dynamic_shapes)
+    stablehlo = torch_xla2.export.exported_program_to_stablehlo(exported)
+    module_str = str(stablehlo.mlir_module())
+
+    self.assertRegex(module_str, r"stablehlo.constant.*10")
+    self.assertRegex(module_str, r"shape_assertion.*s[0-9]+ <= 10")
+    self.assertRegex(module_str, r"stablehlo.constant.*2")
+    self.assertRegex(module_str, r"shape_assertion.*2\*s[0-9]+")
+    print(stablehlo.mlir_module())
+  
+  def test_constraint_indirection(self):
+    """Test a model where none of the shapes are directly symbolic variables
+    but all are expressions of symints that don't appear directly in the model.
+    """
+
+    # Arg shapes are b=s0{<=10}*2
+    args = (torch.randn(10, 10),)
+    model = AddOne()
+    sym_a = torch.export.Dim("a", max=10)
+    sym_b = sym_a*2
+    dynamic_shapes = ({0: sym_b},)
+
+    with torch.no_grad():
+      exported = torch.export.export(model, args=args, dynamic_shapes=dynamic_shapes)
+    stablehlo = torch_xla2.export.exported_program_to_stablehlo(exported)
+    module_str = str(stablehlo.mlir_module())
+
+    self.assertRegex(module_str, r"shape_assertion.*s[0-9]+ <= 10")
+    self.assertRegex(module_str, r"shape_assertion.*2\*s[0-9]+")
+    print(stablehlo.mlir_module())
+

--- a/experimental/torch_xla2/test/test_symbolic_shapes.py
+++ b/experimental/torch_xla2/test/test_symbolic_shapes.py
@@ -69,7 +69,6 @@ class SymbolicShapeTest(unittest.TestCase):
     self.assertRegex(module_str, r"shape_assertion.*s[0-9]+ <= 10")
     self.assertRegex(module_str, r"stablehlo.constant.*2")
     self.assertRegex(module_str, r"shape_assertion.*2\*s[0-9]+")
-    print(stablehlo.mlir_module())
   
   def test_constraint_indirection(self):
     """Test a model where none of the shapes are directly symbolic variables
@@ -90,5 +89,4 @@ class SymbolicShapeTest(unittest.TestCase):
 
     self.assertRegex(module_str, r"shape_assertion.*s[0-9]+ <= 10")
     self.assertRegex(module_str, r"shape_assertion.*2\*s[0-9]+")
-    print(stablehlo.mlir_module())
 

--- a/experimental/torch_xla2/test/test_unbounded_dynamism.py
+++ b/experimental/torch_xla2/test/test_unbounded_dynamism.py
@@ -1,0 +1,662 @@
+import re
+import sys
+import unittest
+
+import numpy as np
+import torch
+from torch.export import Dim, export
+from torch_xla2.export import exported_program_to_stablehlo as exp2shlo
+
+## This file is copied from `xla/test/stablehlo/test_unbounded_dynamism.py`
+## To test that torch_xla2 has identical behavior.
+## The only differences in this test files are that torch_xla2 export preserves
+## argument order more often than torch_xla export.
+##
+## This broke ~5 tests, for example: test_bmm_dynamic_out_dim
+##   args = (
+##     torch.rand((8, 128, 256)),
+##     torch.rand((8, 256, 3)),
+##   )
+##   dynamic_shapes = ((None, {2: Dim("dim")}),)
+##   ...
+##   torch_xla_regex = r'%arg.: tensor<8x256x\?xf32>.*%arg.: tensor<8x128x256xf32>.*->.*tensor<8x128x\?xf32>'
+##   torch_xla2_regex = r'%arg.: tensor<8x128x256xf32>.*%arg.: tensor<8x256x\?xf32>.*->.*tensor<8x128x\?xf32>'
+
+# Shim to run tests
+class ExportAdapter():
+  def __init__(self, export):
+    self.export = export
+
+  def get_stablehlo_text(self):
+    return self.export.mlir_module()
+
+def exported_program_to_stablehlo(exported):
+  return ExportAdapter(exp2shlo(exported))
+
+def wrap_func_as_nn_module(f):
+  class M(torch.nn.Module):
+    def __init__(self):
+      super().__init__()
+      
+    def forward(self, *args):
+      return f(*args)
+  return M().eval()
+
+class UnboundedDynamismExportTest(unittest.TestCase):
+
+  def test_add(self):
+    args = (torch.rand((10, 197, 768)), torch.rand((10, 197, 768)))
+    dynamic_shapes = (({0: Dim("dim")}, {0: Dim("dim")}),)
+    m = wrap_func_as_nn_module(torch.ops.aten.add.Tensor)
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(
+            r'tensor<\?x197x768xf32>.*tensor<\?x197x768xf32>.*->.*tensor<\?x197x768xf32>',
+            shlo_text) is not None)
+
+  def test_add_scalar(self):
+    args = (torch.rand((10, 197, 768)), 0.345)
+    dynamic_shapes = (({0: Dim("dim")}, None),)
+    m = wrap_func_as_nn_module(torch.ops.aten.add.Tensor)
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r'tensor<\?x197x768xf32>.*->.*tensor<\?x197x768xf32>',
+                  shlo_text) is not None)
+
+  def test_addmm(self):
+    args = (torch.rand((5)), torch.rand((10, 5)), torch.rand((5, 5)))
+    dynamic_shapes = ((None, {0: Dim("dim")}, None),)
+    m = wrap_func_as_nn_module(torch.ops.aten.addmm.default)
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r'tensor<\?x5xf32>.*->.*tensor<\?x5xf32>', shlo_text)
+        is not None)
+
+  def test_bmm(self):
+    args = (
+        torch.rand((24, 197, 64)),
+        torch.rand((24, 64, 197)),
+    )
+    dynamic_shapes = (({0: Dim("dim")}, {0: Dim("dim")}),)
+    m = wrap_func_as_nn_module(torch.ops.aten.bmm.default)
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(
+            r'%arg.: tensor<\?x197x64xf32>.*%arg.: tensor<\?x64x197xf32>.*->.*tensor<\?x197x197xf32>',
+            shlo_text) is not None)
+
+  def test_bmm_dynamic_out_dim(self):
+    args = (
+        torch.rand((8, 128, 256)),
+        torch.rand((8, 256, 3)),
+    )
+    dynamic_shapes = ((None, {2: Dim("dim")}),)
+    m = wrap_func_as_nn_module(torch.ops.aten.bmm.default)
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(
+            r'%arg.: tensor<8x128x256xf32>.*%arg.: tensor<8x256x\?xf32>.*->.*tensor<8x128x\?xf32>',
+            shlo_text) is not None)
+
+  def test_bmm_dynamic_reduction_dim(self):
+    args = (
+        torch.rand((8, 128, 3)),
+        torch.rand((8, 3, 256)),
+    )
+    dynamic_shapes = (({2: Dim("dim")}, {1: Dim("dim")}),)
+    m = wrap_func_as_nn_module(torch.ops.aten.bmm.default)
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(
+            r'%arg.: tensor<8x128x\?xf32>.*%arg.: tensor<8x\?x256xf32>.*->.*tensor<8x128x256xf32>',
+            shlo_text) is not None)
+
+  def test_cat(self):
+    args = (torch.rand((10, 1, 768)), torch.rand((10, 196, 768)))
+    dynamic_shapes = (({0: Dim("dim")}, {0: Dim("dim")}),)
+    m = wrap_func_as_nn_module(
+        lambda x, y: torch.ops.aten.cat.default([x, y], 1))
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(
+            r'%arg.: tensor<\?x1x768xf32>.*%arg.: tensor<\?x196x768xf32>.*->.*tensor<\?x197x768xf32>',
+            shlo_text) is not None)
+
+  def test_conv(self):
+    args = (
+        torch.rand((10, 3, 224, 224)),
+        torch.rand((5, 3, 16, 16)),
+        torch.rand((5)),
+    )
+    dynamic_shapes = (({0: Dim("dim")}, None, None),)
+    m = wrap_func_as_nn_module(
+        lambda x, y, z: torch.ops.aten.convolution.default(
+            x,
+            y,
+            z,
+            [16, 16],
+            [0, 0],
+            [1, 1],
+            False,
+            [0, 0],
+            1,
+        ))
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r'tensor<\?x3x224x224xf32>.*->.*tensor<\?x5x14x14xf32>',
+                  shlo_text) is not None)
+
+  def test_conv1d(self):
+    args = (
+        torch.rand((3, 1, 800)),
+        torch.rand((512, 1, 10)),
+    )
+    dynamic_shapes = (({0: Dim("dim")}, None),)
+    # dynamic_shapes = None
+    m = wrap_func_as_nn_module(lambda x, y: torch.ops.aten.convolution.default(
+        x,
+        y,
+        None,
+        [5],
+        [0],
+        [1],
+        False,
+        [0],
+        1,
+    ))
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r'tensor<\?x1x800xf32>.*->.*tensor<\?x512x159xf32>',
+                  shlo_text) is not None)
+
+  def test_cumsum(self):
+    args = (torch.rand((10, 5)), 1)
+    dynamic_shapes = (({0: Dim("dim")}, None),)
+    m = wrap_func_as_nn_module(torch.ops.aten.cumsum.default)
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r'tensor<\?x5xf32>.*->.*tensor<\?x5xf32>', shlo_text)
+        is not None)
+
+  def test_div(self):
+    args = (torch.rand((10, 12, 197)), torch.rand((10, 12, 197)))
+    dynamic_shapes = (({0: Dim("dim")}, {0: Dim("dim")}),)
+    m = wrap_func_as_nn_module(torch.ops.aten.div.Tensor)
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(
+            r'tensor<\?x12x197xf32>.*tensor<\?x12x197xf32>.*->.*tensor<\?x12x197xf32>',
+            shlo_text) is not None)
+
+  def test_div_scalar(self):
+    args = (torch.rand((10, 12, 197)), 8.0)
+    dynamic_shapes = (({0: Dim("dim")}, None),)
+    m = wrap_func_as_nn_module(torch.ops.aten.div.Tensor)
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r'tensor<\?x12x197xf32>.*->.*tensor<\?x12x197xf32>',
+                  shlo_text) is not None)
+
+  def test_gelu(self):
+    args = (torch.rand((3, 5)),)
+    dynamic_shapes = (({0: Dim("dim")},),)
+    m = wrap_func_as_nn_module(torch.ops.aten.gelu)
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r'tensor<\?x5xf32>.*->.*tensor<\?x5xf32>', shlo_text)
+        is not None)
+
+  def test_embedding(self):
+
+    class M(torch.nn.Module):
+
+      def forward(self, x, y):
+        res = torch.ops.aten.embedding.default(x, y)
+        return res
+
+    args = (torch.rand((20, 768)), torch.randint(0, 15,
+                                                 (3, 10)).to(torch.int64))
+    dynamic_shapes = (None, {0: Dim("dim")})
+    m = M()
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r"%arg.: tensor<\?x10xi64>.*->.*tensor<\?x10x768xf32>",
+                  shlo_text) is not None)
+
+  def test_mean(self):
+
+    class M(torch.nn.Module):
+
+      def forward(self, x):
+        return torch.mean(x, -1, keepdim=True)
+
+    args = (torch.rand((10, 197, 768)),)
+    dynamic_shapes = ({0: Dim("dim")},)
+    m = M()
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r"%arg.: tensor<\?x197x768xf32>.*->.*tensor<\?x197x1xf32>",
+                  shlo_text) is not None)
+
+  def test_mul(self):
+    args = (torch.rand((10, 2, 768)), torch.rand((10, 2, 768)))
+    dynamic_shapes = (({0: Dim("dim")}, {0: Dim("dim")}),)
+    m = wrap_func_as_nn_module(torch.ops.aten.mul.Tensor)
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(
+            r'tensor<\?x2x768xf32>.*tensor<\?x2x768xf32>.*->.*tensor<\?x2x768xf32>',
+            shlo_text) is not None)
+
+  def test_mul_scalar(self):
+    args = (torch.rand((10, 2, 768)), 0.125)
+    dynamic_shapes = (({0: Dim("dim")}, None),)
+    m = wrap_func_as_nn_module(torch.ops.aten.mul.Tensor)
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r'tensor<\?x2x768xf32>.*->.*tensor<\?x2x768xf32>', shlo_text)
+        is not None)
+
+  def test_ne_scalar(self):
+
+    class M(torch.nn.Module):
+
+      def forward(self, x):
+        return torch.ops.aten.ne.Scalar(x, 1).to(torch.int32)
+
+    args = (torch.rand((3, 5)).to(torch.int64),)
+    dynamic_shapes = ({0: Dim("dim")},)
+    m = M()
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r"%arg.: tensor<\?x5xi64>.*->.*tensor<\?x5xi32>", shlo_text)
+        is not None)
+
+  def test_var(self):
+
+    class M(torch.nn.Module):
+
+      def forward(self, x):
+        return torch.var(x, -1, keepdim=True, correction=0)
+
+    args = (torch.rand((10, 197, 768)),)
+    dynamic_shapes = ({0: Dim("dim")},)
+    m = M()
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r"%arg.: tensor<\?x197x768xf32>.*->.*tensor<\?x197x1xf32>",
+                  shlo_text) is not None)
+
+  def test_native_group_norm(self):
+
+    class M2(torch.nn.Module):
+
+      def __init__(self):
+        super().__init__()
+        self.layer_norm = torch.nn.GroupNorm(
+            num_groups=512, num_channels=512, affine=True)
+
+      def forward(self, x):
+        x = self.layer_norm(x)
+        return x
+
+    args = (torch.rand((10, 512, 159)),)
+    dynamic_shapes = ({0: Dim("dim")},)
+    m = M2()
+    out1 = m(*args)
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r"%arg.: tensor<\?x512x159xf32>.*->.*tensor<\?x512x159xf32>",
+                  shlo_text) is not None)
+
+  def test_native_layer_norm(self):
+
+    class M(torch.nn.Module):
+
+      def forward(self, x, weight, bias):
+        return torch.ops.aten.native_layer_norm.default(x, [768], weight, bias,
+                                                        1e-12)[0]
+
+    args = (
+        torch.rand((10, 197, 768)),
+        torch.rand((768)),
+        torch.rand((768)),
+    )
+    dynamic_shapes = ({0: Dim("dim")}, None, None)
+    m = M()
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r"%arg.: tensor<\?x197x768xf32>.*->.*tensor<\?x197x768xf32>",
+                  shlo_text) is not None)
+
+  def test_permute(self):
+    args = (torch.rand((10, 197, 12, 64)),)
+    dynamic_shapes = (({0: Dim("dim")},),)
+    m = wrap_func_as_nn_module(
+        lambda x: torch.ops.aten.permute.default(x, [0, 2, 1, 3]))
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(
+            r"%arg.: tensor<\?x197x12x64xf32>.*->.*tensor<\?x12x197x64xf32>",
+            shlo_text) is not None)
+
+  def test_select(self):
+    args = (torch.rand((10, 197, 768)), 1, 0)
+    dynamic_shapes = (({0: Dim("dim")}, None, None),)
+    m = wrap_func_as_nn_module(torch.ops.aten.select.int)
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r"%arg.: tensor<\?x197x768xf32>.*->.*tensor<\?x768xf32>",
+                  shlo_text) is not None)
+
+  def test_slice(self):
+    args = (torch.rand((10, 3, 224, 224)), 0, 0, 9223372036854775807)
+    dynamic_shapes = (({0: Dim("dim")}, None, None, None),)
+    m = wrap_func_as_nn_module(torch.ops.aten.slice.Tensor)
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(
+            r"%arg.: tensor<\?x3x224x224xf32>.*->.*tensor<\?x3x224x224xf32>",
+            shlo_text) is not None)
+
+  def test_slice_2(self):
+    args = (torch.rand((10, 3, 224, 224)), 1, 0, 2)
+    dynamic_shapes = (({0: Dim("dim")}, None, None, None),)
+    m = wrap_func_as_nn_module(torch.ops.aten.slice.Tensor)
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(
+            r"%arg.: tensor<\?x3x224x224xf32>.*->.*tensor<\?x2x224x224xf32>",
+            shlo_text) is not None)
+
+  def test_softmax(self):
+    args = (torch.rand((10, 12, 197, 197)), -1, False)
+    dynamic_shapes = (({0: Dim("dim")}, None, None),)
+    m = wrap_func_as_nn_module(torch.ops.aten._softmax.default)
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(
+            r"%arg.: tensor<\?x12x197x197xf32>.*->.*tensor<\?x12x197x197xf32>",
+            shlo_text) is not None)
+
+  def test_sub(self):
+    args = (torch.rand((10, 1, 1, 10)), torch.rand((10, 1, 1, 10)))
+    dynamic_shapes = (({0: Dim("dim")}, {0: Dim("dim")}),)
+    m = wrap_func_as_nn_module(torch.ops.aten.sub.Tensor)
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(
+            r'tensor<\?x1x1x10xf32>.*tensor<\?x1x1x10xf32>.*->.*tensor<\?x1x1x10xf32>',
+            shlo_text) is not None)
+
+  def test_softmax_reduce_on_dynamic_dim(self):
+    args = (torch.rand((1, 8, 128, 3)), -1, False)
+    dynamic_shapes = (({3: Dim("dim")}, None, None),)
+    m = wrap_func_as_nn_module(torch.ops.aten._softmax.default)
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r"%arg.: tensor<1x8x128x\?xf32>.*->.*tensor<1x8x128x\?xf32>",
+                  shlo_text) is not None)
+
+  @unittest.skip("Converted StableHLO contains i1 dtype, not expected.")
+  def test_index(self):
+    args = (torch.rand((2, 10)), torch.arange(5))
+    dynamic_shapes = ((None, {0: Dim("dim")}),)
+    m = wrap_func_as_nn_module(
+        lambda x, y: torch.ops.aten.index.Tensor(x, [None, y]))
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(
+            r"%arg.: tensor<\?xi64>.*%arg.: tensor<2x10xf32>.*->.*tensor<2x\?xf32>",
+            shlo_text) is not None)
+
+  def test_sub_scalar(self):
+    args = (1.0, torch.rand((10, 1, 1, 10)))
+    dynamic_shapes = ((None, {0: Dim("dim")}),)
+    m = wrap_func_as_nn_module(torch.ops.aten.sub.Tensor)
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r'tensor<\?x1x1x10xf32>.*->.*tensor<\?x1x1x10xf32>',
+                  shlo_text) is not None)
+
+  def test_split_with_sizes(self):
+
+    class M(torch.nn.Module):
+
+      def forward(self, x):
+        res = torch.ops.aten.split_with_sizes.default(x, [1, 2, 3], -1)
+        return res[0], res[1], res[2]
+
+    args = (torch.rand((3, 10, 6)),)
+    dynamic_shapes = ({0: Dim("dim")},)
+    m = M()
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(
+            r"%arg.: tensor<\?x10x6xf32>.*->.*tensor<\?x10x1xf32>.*tensor<\?x10x2xf32>.*tensor<\?x10x3xf32>",
+            shlo_text) is not None)
+
+  def test_transpose_on_dynamic_dim(self):
+    args = (torch.rand((1, 8, 3, 256)),)
+    dynamic_shapes = (({2: Dim("dim")},),)
+    m = wrap_func_as_nn_module(
+        lambda x: torch.ops.aten.transpose.int(x, -2, -1))
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r"%arg.: tensor<1x8x\?x256xf32>.*->.*tensor<1x8x256x\?xf32>",
+                  shlo_text) is not None)
+
+  def test_unsqueeze_1(self):
+    args = (torch.rand((3, 10)),)
+    dynamic_shapes = (({0: Dim("dim")},),)
+    m = wrap_func_as_nn_module(lambda x: torch.ops.aten.unsqueeze.default(x, 1))
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r"%arg.: tensor<\?x10xf32>.*->.*tensor<\?x1x10xf32>",
+                  shlo_text) is not None)
+
+  def test_unsqueeze_2(self):
+    args = (torch.rand((1, 1, 3, 256)),)
+    dynamic_shapes = (({2: Dim("dim")},),)
+    m = wrap_func_as_nn_module(lambda x: torch.ops.aten.unsqueeze.default(x, 2))
+    ep = export(m, args=args, dynamic_shapes=dynamic_shapes)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(
+            r"%arg.: tensor<1x1x\?x256xf32>.*->.*tensor<1x1x1x\?x256xf32>",
+            shlo_text) is not None)
+
+  def test_dynamic_view(self):
+
+    class M(torch.nn.Module):
+
+      def __init__(self):
+        super().__init__()
+        self.conv = torch.nn.Conv2d(3, 5, [16, 16])
+
+      def forward(self, x):
+        x = self.conv(x)
+        return x.view(x.shape[0], x.shape[1], -1)
+
+    m = M().eval()
+    args = (torch.rand((10, 3, 224, 224)),)
+    dynamic_shapes = ({0: Dim("bs")},)
+    ep = export(m, args, dynamic_shapes=dynamic_shapes)
+    out1 = ep.module()(*args)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(
+            r"%arg.: tensor<\?x3x224x224xf32>.*->.*tensor<\?x5x43681xf32>",
+            shlo_text) is not None)
+
+  @unittest.skip("Cannot generate aten.sym_numel in the exported program.")
+  def test_dynamic_view_sym_numel(self):
+
+    class M(torch.nn.Module):
+
+      def forward(self, x, range):
+        num_elem = torch.numel(range)
+        return x.view(x.shape[0], x.shape[2], num_elem, x.shape[4])
+
+    m = M().eval()
+    args = (torch.rand((1, 1, 8, 3, 256)), torch.arange(3))
+    dynamic_shapes = ({3: Dim("bs")}, {0: Dim("bs")})
+    ep = export(m, args, dynamic_shapes=dynamic_shapes)
+    out1 = ep.module()(*args)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(
+            r"%arg.: tensor<\?x3x224x224xf32>.*->.*tensor<\?x5x43681xf32>",
+            shlo_text) is not None)
+
+  def test_dynamic_view_non_bs(self):
+
+    class M(torch.nn.Module):
+
+      def forward(self, x):
+        return x.view(x.shape[0], x.shape[1] * x.shape[2], x.shape[3])
+
+    m = M().eval()
+    args = (torch.rand((1, 3, 2, 16)),)
+    dynamic_shapes = ({1: Dim("bs")},)
+    ep = export(m, args, dynamic_shapes=dynamic_shapes)
+    out1 = ep.module()(*args)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r"%arg.: tensor<1x\?x2x16xf32>.*->.*tensor<1x\?x16xf32>",
+                  shlo_text) is not None)
+
+  def test_dynamic_view_multiplier(self):
+
+    class M(torch.nn.Module):
+
+      def forward(self, x):
+        return x.view(x.shape[0] * x.shape[1], -1)
+
+    m = M().eval()
+    args = (torch.rand((10, 197, 768)),)
+    dynamic_shapes = ({0: Dim("bs")},)
+    ep = export(m, args, dynamic_shapes=dynamic_shapes)
+    out1 = ep.module()(*args)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r"%arg.: tensor<\?x197x768xf32>.*->.*tensor<\?x768xf32>",
+                  shlo_text) is not None)
+
+  def test_dynamic_expand(self):
+
+    class M(torch.nn.Module):
+
+      def forward(self, x, image):
+        return x.expand(image.shape[0], -1, -1)
+
+    m = M().eval()
+    args = (torch.rand((1, 1, 768)), torch.rand((10, 3, 224, 224)))
+    dynamic_shapes = (
+        None,
+        {
+            0: Dim("bs")
+        },
+    )
+    ep = export(m, args, dynamic_shapes=dynamic_shapes)
+    out1 = ep.module()(*args)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(r"%arg.: tensor<1x1x768xf32>.*->.*tensor<\?x1x768xf32>",
+                  shlo_text) is not None)
+
+  def test_dynamic_expand_2(self):
+
+    class M(torch.nn.Module):
+
+      def forward(self, x, range):
+        return x.expand(1, 1, 8, range.shape[0], 256)
+
+    m = M().eval()
+    args = (torch.rand((1, 1, 1, 3, 256)), torch.arange(3))
+    dynamic_shapes = ({3: Dim("bs")}, {0: Dim("bs")})
+    ep = export(m, args, dynamic_shapes=dynamic_shapes)
+    out1 = ep.module()(*args)
+    shlo_module = exported_program_to_stablehlo(ep)
+    shlo_text = shlo_module.get_stablehlo_text()
+    self.assertTrue(
+        re.search(
+            r"%arg.: tensor<1x1x1x\?x256xf32>.*->.*tensor<1x1x8x\?x256xf32>",
+            shlo_text) is not None)
+
+
+if __name__ == "__main__":
+  test = unittest.main()
+  sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/experimental/torch_xla2/torch_xla2/export.py
+++ b/experimental/torch_xla2/torch_xla2/export.py
@@ -3,10 +3,13 @@
 import copy
 from typing import Any, Dict, Tuple
 import torch
-from torch_xla2.ops import ops_registry
-from torch_xla2 import tensor
 from torch.utils import _pytree as pytree
-
+from torch_xla2 import tensor
+from torch_xla2.ops import ops_registry
+from jax.experimental import export
+import jax
+import jax.numpy as jnp
+import sympy
 
 
 DEBUG = False
@@ -104,3 +107,115 @@ def exported_program_to_jax(exported_program, export_raw: bool = False):
 
   states = pytree.tree_map_only(torch.Tensor, tensor.t2j, states)
   return states, func
+
+
+def extract_avals(exported):
+  """Return JAX Abstract Value shapes for all input parameters of the exported
+  program. This supports dynamic batch dimensions, including with constraints.
+  """
+
+  def _to_aval(arg_meta, symbolic_shapes):
+    """Convet from torch type to jax abstract value for export tracing
+    """
+    def _get_dim(d):
+      if isinstance(d, torch.SymInt):
+        return symbolic_shapes[str(d)]
+      return d
+
+    def is_scalar(meta):
+      val = meta['val']
+      return isinstance(val, float) or isinstance(val, int) or isinstance(val, bool)
+
+    if is_scalar(arg_meta):
+      return jax.ShapeDtypeStruct([], type(arg_meta['val']))
+
+    tensor_meta = arg_meta['tensor_meta']
+    shape = [_get_dim(d) for d in tensor_meta.shape]
+    return jax.ShapeDtypeStruct(shape, tensor.t2j_dtype(tensor_meta.dtype))
+
+  def _get_inputs(exported):
+    """Return placeholders with input metadata"""
+    placeholders = [p for p in exported.graph.nodes if p.op == "placeholder"]
+    input_placeholders = [
+      p
+      for p, s in zip(placeholders, exported.graph_signature.input_specs)
+      if s.kind == torch.export.graph_signature.InputKind.USER_INPUT
+    ]
+    return input_placeholders
+
+  def _build_symbolic_shapes(range_constraints):
+    """Convert torch SymInt to JAX symbolic_shape and stores in a map using the
+    string name of the torch symbolic int.
+    TODO: There is probably a better way of storing a hash for a symbolic int.
+    This value needs to be looked up again in `_to_aval` to figure out which
+    JAX symbolic to map to for a given torch tensor.
+    """
+    if len(range_constraints) == 0:
+      return None
+
+    def _build_symbolic_constraints(symbol_name, torch_constraint):
+      """Convert torch SymInt constraints to string for JAX symbolic_shape
+      Using sympy may be overkill here, currently PyTorch only uses ValueRanges
+      which allow specifying the min and the max of a value, for example:
+        torch.export.Dim("a", min=5, max=10)
+         ==> ("a >= 5", "a <= 10",)
+      """
+      if not isinstance(torch_constraint, torch.utils._sympy.value_ranges.ValueRanges) or torch_constraint.is_bool:
+        raise TypeError(f"No symbolic constraint handler for: {constraint}")
+
+      constraints = []
+      symbol = sympy.Symbol(symbol_name)
+      if (torch_constraint.lower != 2):
+        constraints.append(symbol >= torch_constraint.lower)
+      if (not torch_constraint.upper.is_infinite):
+        constraints.append(symbol <= torch_constraint.upper)
+      
+      return tuple(sympy.pretty(c, use_unicode=False) for c in constraints)
+
+    def _build_symbolic_shape(scope, symbol_name, constraint):
+      """Returns a JAX symbolic shape for a given symbol_name and constraint
+
+      TODO: JAX has a requirement that you can specify only one of `scope` or
+      `constraints`. It is unclear if the combination is possible in PyTorch,
+      I.e. perhaps this can be triggered by making a symbol which has a max bound
+      of the size of another dimension argument.
+      """
+      constraints = _build_symbolic_constraints(symbol_name, constraint)
+      if len(constraints) > 0:
+        symbolic_shape = jax.experimental.export.symbolic_shape(symbol_name, constraints=constraints)
+      else:
+        symbolic_shape = jax.experimental.export.symbolic_shape(symbol_name, scope=scope)
+      assert len(symbolic_shape) == 1
+      return symbolic_shape[0]
+
+    scope = jax.experimental.export.SymbolicScope(())
+    symbolic_shapes = {}
+    for sym, constraint in range_constraints.items():
+      symbol_name = str(sym)
+      symbolic_shape = _build_symbolic_shape(scope, symbol_name, constraint)
+      symbolic_shapes[symbol_name] = symbolic_shape
+    return symbolic_shapes
+
+  symbolic_shapes = _build_symbolic_shapes(exported.range_constraints)
+  args = _get_inputs(exported)
+
+  if DEBUG:
+    print('Inputs to aval:', args, '--------')
+    for arg in args:
+      print('Meta2Aval', arg.meta, '--> ', _to_aval(arg.meta, symbolic_shapes))
+
+  return [_to_aval(arg.meta, symbolic_shapes) for arg in args]
+
+
+def exported_program_to_stablehlo(exported_program):
+  """Replacement for torch_xla.stablehlo.exported_program_to_stablehlo
+
+  Convert a program exported via torch.export to StableHLO.
+
+  This supports dynamic dimension sizes and generates explicit checks for
+  dynamo guards in the IR using shape_assertion custom_call ops.
+  """
+  weights, func = exported_program_to_jax(exported_program)
+  jax_avals = extract_avals(exported_program)
+  jax_export = export.export(func)(weights, (jax_avals,))
+  return jax_export

--- a/experimental/torch_xla2/torch_xla2/tensor.py
+++ b/experimental/torch_xla2/torch_xla2/tensor.py
@@ -63,27 +63,41 @@ def j2t(x):
   return res
 
 TORCH_DTYPE_TO_JAX = {
-      torch.float16: jnp.dtype('float16'),
-      torch.bfloat16: jnp.dtype('bfloat16'),
-      torch.half: jnp.dtype('float16'),
-      torch.float32: jnp.dtype('float32'),
-      torch.double: jnp.dtype('double'),
-      torch.long: jnp.dtype('int64'),
-      torch.int32: jnp.dtype('int32'),
-      torch.int16: jnp.dtype('int16'),
-      torch.int8: jnp.dtype('int8'),
-      torch.uint8: jnp.dtype('uint8'),
-      torch.bool: jnp.dtype('bool_'),
-      torch.complex64: jnp.dtype('complex64'),
-      torch.complex128: jnp.dtype('complex128'),
-      None: None,
+    # NO_MAPPING        : jnp.float0 (signless scalar int)
+    torch.bool          : jnp.bool_,
+    # NO_MAPPING        : jnp.int4
+    torch.int8          : jnp.int8,
+    torch.int16         : jnp.int16,
+    torch.int32         : jnp.int32,
+    torch.int64         : jnp.int64,
+    torch.long          : jnp.int64,
+    # NO_MAPPING        : jnp.uint4
+    torch.uint8         : jnp.uint8,
+    torch.uint16        : jnp.uint16,
+    torch.uint32        : jnp.uint32,
+    torch.uint64        : jnp.uint64,
+    # NO_MAPPING        : jnp.float8_e4m3b11fnuz
+    torch.float8_e4m3fn : jnp.float8_e4m3fn,
+    # NO_MAPPING        : jnp.float8_e4m3fnuz
+    torch.float8_e5m2   : jnp.float8_e5m2,
+    # NO_MAPPING        : jnp.float8_e5m2fnuz
+    torch.bfloat16      : jnp.bfloat16,
+    torch.half          : jnp.float16,
+    torch.float16       : jnp.float16,
+    torch.float32       : jnp.float32,
+    torch.float64       : jnp.float64,
+    torch.double        : jnp.double,
+    torch.complex64     : jnp.complex64,
+    torch.complex128    : jnp.complex128,
+    None                : None,
 }
 
 JAX_DTYPE_TO_TORCH = {
   value: key for key, value in TORCH_DTYPE_TO_JAX.items()
 }
-# No int4 dtype in torch, map jnp.int4 to torch.int8.
+# Add imprecise mappings for some JAX dtypes which don't have torch analogues
 JAX_DTYPE_TO_TORCH[jnp.dtype('int4')] = torch.int8
+JAX_DTYPE_TO_TORCH[jnp.dtype('uint4')] = torch.uint8
 
 def t2j_dtype(dtype):
   if dtype not in TORCH_DTYPE_TO_JAX:

--- a/experimental/torch_xla2/torch_xla2/tensor.py
+++ b/experimental/torch_xla2/torch_xla2/tensor.py
@@ -63,32 +63,32 @@ def j2t(x):
   return res
 
 TORCH_DTYPE_TO_JAX = {
-    # NO_MAPPING        : jnp.float0 (signless scalar int)
-    torch.bool          : jnp.bool_,
-    # NO_MAPPING        : jnp.int4
-    torch.int8          : jnp.int8,
-    torch.int16         : jnp.int16,
-    torch.int32         : jnp.int32,
-    torch.int64         : jnp.int64,
-    torch.long          : jnp.int64,
+    # NO_MAPPING        : jnp.float0.dtype (signless scalar int),
+    torch.bool          : jnp.bool_.dtype,
+    # NO_MAPPING        : jnp.int4.dtype,
+    torch.int8          : jnp.int8.dtype,
+    torch.int16         : jnp.int16.dtype,
+    torch.int32         : jnp.int32.dtype,
+    torch.int64         : jnp.int64.dtype,
+    torch.long          : jnp.int64.dtype,
     # NO_MAPPING        : jnp.uint4
-    torch.uint8         : jnp.uint8,
-    torch.uint16        : jnp.uint16,
-    torch.uint32        : jnp.uint32,
-    torch.uint64        : jnp.uint64,
-    # NO_MAPPING        : jnp.float8_e4m3b11fnuz
-    torch.float8_e4m3fn : jnp.float8_e4m3fn,
-    # NO_MAPPING        : jnp.float8_e4m3fnuz
-    torch.float8_e5m2   : jnp.float8_e5m2,
-    # NO_MAPPING        : jnp.float8_e5m2fnuz
-    torch.bfloat16      : jnp.bfloat16,
-    torch.half          : jnp.float16,
-    torch.float16       : jnp.float16,
-    torch.float32       : jnp.float32,
-    torch.float64       : jnp.float64,
-    torch.double        : jnp.double,
-    torch.complex64     : jnp.complex64,
-    torch.complex128    : jnp.complex128,
+    torch.uint8         : jnp.uint8.dtype,
+    torch.uint16        : jnp.uint16.dtype,
+    torch.uint32        : jnp.uint32.dtype,
+    torch.uint64        : jnp.uint64.dtype,
+    # NO_MAPPING        : jnp.float8_e4m3b11fnuz.dtype,
+    torch.float8_e4m3fn : jnp.float8_e4m3fn.dtype,
+    # NO_MAPPING        : jnp.float8_e4m3fnuz.dtype,
+    torch.float8_e5m2   : jnp.float8_e5m2.dtype,
+    # NO_MAPPING        : jnp.float8_e5m2fnuz.dtype,
+    torch.bfloat16      : jnp.bfloat16.dtype,
+    torch.half          : jnp.float16.dtype,
+    torch.float16       : jnp.float16.dtype,
+    torch.float32       : jnp.float32.dtype,
+    torch.float64       : jnp.float64.dtype,
+    torch.double        : jnp.double.dtype,
+    torch.complex64     : jnp.complex64.dtype,
+    torch.complex128    : jnp.complex128.dtype,
     None                : None,
 }
 


### PR DESCRIPTION
This PR adds a new StableHLO export API for torch_xla2:

```python
# Module: torch_xla2.export
def export_program_to_stablehlo(exported : torch.ExportedProgram) -> jax.Exported: ...
```

This **is not** a perfect drop-in replacement for `torch_xla.stablehlo.export_program_to_stablehlo` but largely follows the same contract of "IN: torch exported, OUT: StableHLO thing".

The complexity of this PR comes down to `extract_avals`, a function which takes an exported program, and tries to "abstractify" user input values, for example: 

```
# Trivial
torch.tensor(10).to(torch.float64) --> jax.ShapeDtypeStruct([10], dtype=jnp.float64)

# More complicated
FakeTensorValue(..., [s0, 5]) --> jax.ShapeDtypeStruct([jax.symbolic_shape('s0', constraints=...), 5], dtype=jnp.float64)
```

Some cool features of this API:
- High dynamic shape coverage, likely more than `torch_xla.stablehlo.export_program_to_stablehlo`. While HLO has full dynamism parity, I believe there are still more bridge modifications needed to propagate shape throughout. I was able to export ViT and wav2vec models with dynamic batch dims (these are the only two models I tried).
- Dynamo guards are embedded in the exported IR. This is done via JAX's `custom_call @shape_assert` which has support in TF2XLA execution paths (like savedmodel / tf.serving). These custom_call's will either canonicalize away as we refine shapes, or error if we attempt to refine/compile with incompatible shapes.

Tests:
- Added some testpoints to `test_exported.py`
- Forked `test/stablehlo/test_unbounded_dynamism.py` and swapped `export_program_to_stablehlo` impls. We can easily merge the two, but I'm not sure if we're trying to keep torch_xla2 fully independent, in which case maybe forking is OK. All tests passed. A few needed slight regex modifications, which are noted at the top of the new test file (seems more correct now?).
- Tested new dtype mappings (I had some typos which took a bit to debug, would have been easier with some tests).

Possible next steps:
- Make this a drop-in replacement for `torch_xla.stablehlo.export_program_to_stablehlo`
- Add a SavedModel export API which builds on top of this (or make a jax2tf wrapper, unclear what's best, I kind of like how PT/XLA does this today).

Also, a few QoL changes as I got this part of the repo set up for the first time:
- Edited `experimental/torch_xla2/README.md` to include repo clone step for clarity
- Changed base JAX dependency to `"jax[cpu]>=0.4.24",` to avoid downloading CUDA and friends by default
- Added some more `torch.dtype -> jax.dtype` mappings to match with JAX's [`mlir.py` mappings](https://github.com/google/jax/blob/9c01fc5f0f2d1335810772c79ba0a1c329d3d908/jax/_src/interpreters/mlir.py#L154).
