### PR TITLE
Add function for retrieving fallback operations.

### DIFF
--- a/torch_xla/core/dynamo_bridge.py
+++ b/torch_xla/core/dynamo_bridge.py
@@ -100,15 +100,7 @@ class GraphInputMatcher:
 
 
 def get_fallback_ops():
-  fallback_ops = []
-  for opname in metrics.counter_names():
-    if "aten::" not in opname:
-      continue
-    val = int(metrics.counter_value(opname))
-    if val > 0:
-      fallback_ops.append(f"{opname}={val}")
-
-  return fallback_ops
+  return metrics.executed_fallback_ops()
 
 
 # Checks that all input args that are tensors are on the same device.

--- a/torch_xla/csrc/aten_cpu_fallback.cpp
+++ b/torch_xla/csrc/aten_cpu_fallback.cpp
@@ -16,6 +16,18 @@ namespace torch_xla {
 static std::unordered_map<std::string, ::torch_xla::runtime::metrics::Counter*>
     _cpu_fallback_counters;
 
+// Get all the executed fallback operations.
+// In other words, get all of them whose counters are not zero.
+std::vector<std::string> GetFallbackOperations() {
+  std::vector<std::string> fallback;
+  for (auto const& pair : _cpu_fallback_counters) {
+    if (pair.second->Value() != 0) {
+      fallback.push_back(pair.first);
+    }
+  }
+  return fallback;
+}
+
 void xla_cpu_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
   XLA_FN_TRACK(3);
   const auto name = c10::toString(op.operator_name());

--- a/torch_xla/csrc/aten_cpu_fallback.h
+++ b/torch_xla/csrc/aten_cpu_fallback.h
@@ -7,6 +7,8 @@ namespace torch_xla {
 
 void xla_cpu_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack);
 
+std::vector<std::string> GetFallbackOperations();
+
 }  // namespace torch_xla
 
 #endif  // XLA_TORCH_XLA_CSRC_ATEN_CPU_FALLBACK_H_

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -33,6 +33,7 @@
 #include "pybind11/stl_bind.h"
 #include "torch_xla/csrc/XLANativeFunctions.h"
 #include "torch_xla/csrc/aten_autograd_ops.h"
+#include "torch_xla/csrc/aten_cpu_fallback.h"
 #include "torch_xla/csrc/aten_xla_bridge.h"
 #include "torch_xla/csrc/device.h"
 #include "torch_xla/csrc/dl_convertor.h"
@@ -1781,6 +1782,7 @@ void InitXlaModuleBindings(py::module m) {
         }
       },
       py::arg("devices"));
+  m.def("_get_executed_fallback_ops", []() { return GetFallbackOperations(); });
   m.def("_xla_counter_names", []() {
     auto counter_names = torch::lazy::GetCounterNames();
     auto xla_counter_names = runtime::metrics::GetCounterNames();

--- a/torch_xla/debug/metrics.py
+++ b/torch_xla/debug/metrics.py
@@ -79,3 +79,8 @@ def short_metrics_report(counter_names: list = None, metric_names: list = None):
         'TransferToDeviceTime', 'TransferFromDeviceTime'
     ]
   return torch_xla._XLAC._short_xla_metrics_report(counter_names, metric_names)
+
+
+def executed_fallback_ops():
+  """Retrieves a list of operations that were run in fallback mode."""
+  return torch_xla._XLAC._get_executed_fallback_ops()


### PR DESCRIPTION
This PR introduces `GetFallbackOperations` function, which sweeps through the fallback counter map `_cpu_fallback_counters` and returns the name of the functions whose counter is not zero, i.e. name of the fallbacks that were run.

There was a bug within the dynamo bridge that only classified as fallback operation those that came from the `aten` namespace. Other fallback operations, such as those that came from `torchvision::` were being passed on to the next steps, even though they were fallback operations.

This bug is one of the reasons of the issue #5967.

cc @miladm @JackCaoG 