### PR TITLE
Use remote cache for `push` events too

### DIFF
--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -25,7 +25,7 @@ jobs:
       GCLOUD_SERVICE_KEY: ${{ secrets.gcloud-service-key }}
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/default_credentials.json
       BAZEL_JOBS: 16
-      BAZEL_REMOTE_CACHE: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+      BAZEL_REMOTE_CACHE: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Setup gcloud
         shell: bash

--- a/.github/workflows/_build_torch_xla.yml
+++ b/.github/workflows/_build_torch_xla.yml
@@ -25,7 +25,7 @@ jobs:
       GCLOUD_SERVICE_KEY: ${{ secrets.gcloud-service-key }}
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/default_credentials.json
       BAZEL_JOBS: 16
-      BAZEL_REMOTE_CACHE: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+      BAZEL_REMOTE_CACHE: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
       BUILD_CPP_TESTS: 1
     steps:
       - name: Setup gcloud


### PR DESCRIPTION
#7112 only looks at pull request attributes, which will be null for pushes.