### PR TITLE
Make from_dlpack handle cuda synchronization implicitly for input tensors that have __dlpack__ and __dlpack_device__ attributes.

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2655,10 +2655,20 @@ class TestDLPack(parameterized.TestCase):
 
   @onlyIfTorchSupportsCUDA
   @onlyIfPJRTDeviceIsCUDA
-  def test_dlpack_xla_to_pytorch_cuda(self):
+  def test_dlpack_xla_to_pytorch_cuda_legacy(self):
     xla_t1 = torch.arange(5).to(xm.xla_device())
     dlt1 = xdlpack.to_dlpack(xla_t1)
     cuda_t1 = torch.utils.dlpack.from_dlpack(dlt1)
+    self.assertEqual(cuda_t1.device.type, 'cuda')
+    self.assertEqual(cuda_t1.device.index, xla_t1.device.index)
+    cuda_t1[0] = cuda_t1[0] + 20
+    self.assertTrue(torch.allclose(xla_t1.cpu(), cuda_t1.cpu()))
+
+  @onlyIfTorchSupportsCUDA
+  @onlyIfPJRTDeviceIsCUDA
+  def test_dlpack_xla_to_pytorch_cuda_protocol_conversion(self):
+    xla_t1 = torch.arange(5).to(xm.xla_device())
+    cuda_t1 = torch.utils.dlpack.from_dlpack(xla_t1)
     self.assertEqual(cuda_t1.device.type, 'cuda')
     self.assertEqual(cuda_t1.device.index, xla_t1.device.index)
     cuda_t1[0] = cuda_t1[0] + 20

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2592,7 +2592,7 @@ class TestDLPack(parameterized.TestCase):
 
   @onlyIfTorchSupportsCUDA
   @onlyIfPJRTDeviceIsCUDA
-  def test_dlpack_pytorch_cuda_to_xla_legacy(self):
+  def test_dlpack_pytorch_cuda_to_xla(self):
     t1_cuda = torch.arange(5).cuda()
     dlt1 = torch.utils.dlpack.to_dlpack(t1_cuda)
     xla_t1 = xdlpack.from_dlpack(dlt1)
@@ -2624,7 +2624,7 @@ class TestDLPack(parameterized.TestCase):
   @onlyIfTorchSupportsCUDA
   @onlyIfPJRTDeviceIsCUDA
   def test_dlpack_pytorch_cuda_to_xla_protocol_conversion(self):
-    # Unlike the test_dlpack_pytorch_cuda_to_xla_legacy,
+    # Unlike the test_dlpack_pytorch_cuda_to_xla,
     # torch_cuda_tensor has attribute __dlpack__ and __dlpack_device__.
     # From cuda tensors to xla tensors, the synchronization is handdled implicitly.
     t1_cuda = torch.arange(5).cuda()

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2633,7 +2633,6 @@ class TestDLPack(parameterized.TestCase):
     self.assertEqual(xla_t1.device.index, t1_cuda.device.index)
     t1_cuda[0] = t1_cuda[0] + 20
     self.assertTrue(torch.allclose(xla_t1.cpu(), t1_cuda.cpu()))
-    print('xw32 test passed')
 
     t2_cuda = torch.tensor(5).cuda()
     xla_t2 = xdlpack.from_dlpack(t2_cuda)

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2655,20 +2655,10 @@ class TestDLPack(parameterized.TestCase):
 
   @onlyIfTorchSupportsCUDA
   @onlyIfPJRTDeviceIsCUDA
-  def test_dlpack_xla_to_pytorch_cuda_legacy(self):
+  def test_dlpack_xla_to_pytorch_cuda(self):
     xla_t1 = torch.arange(5).to(xm.xla_device())
     dlt1 = xdlpack.to_dlpack(xla_t1)
     cuda_t1 = torch.utils.dlpack.from_dlpack(dlt1)
-    self.assertEqual(cuda_t1.device.type, 'cuda')
-    self.assertEqual(cuda_t1.device.index, xla_t1.device.index)
-    cuda_t1[0] = cuda_t1[0] + 20
-    self.assertTrue(torch.allclose(xla_t1.cpu(), cuda_t1.cpu()))
-
-  @onlyIfTorchSupportsCUDA
-  @onlyIfPJRTDeviceIsCUDA
-  def test_dlpack_xla_to_pytorch_cuda_protocol_conversion(self):
-    xla_t1 = torch.arange(5).to(xm.xla_device())
-    cuda_t1 = torch.utils.dlpack.from_dlpack(xla_t1)
     self.assertEqual(cuda_t1.device.type, 'cuda')
     self.assertEqual(cuda_t1.device.index, xla_t1.device.index)
     cuda_t1[0] = cuda_t1[0] + 20

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1296,6 +1296,9 @@ void InitXlaModuleBindings(py::module m) {
       return runtime::GetComputationClient()->GetLocalDevices();
     }
   });
+  m.def("_get_stream_for_cuda_device", [](const int device_id) {
+    return runtime::GetComputationClient()->GetCudaStreamForDevice(device_id);
+  });
   m.def("_xla_num_devices", []() -> int64_t {
     if (UseVirtualDevice()) {
       return 1;

--- a/torch_xla/csrc/runtime/computation_client.h
+++ b/torch_xla/csrc/runtime/computation_client.h
@@ -361,6 +361,8 @@ class ComputationClient {
   virtual absl::StatusOr<xla::PjRtDevice*> LookupAddressableDevice(
       int local_device_id) const = 0;
 
+  virtual std::intptr_t GetCudaStreamForDevice(int local_device_id) const = 0;
+
   virtual size_t GetNumDevices() const = 0;
 
   virtual std::vector<std::string> GetLocalDevices() const = 0;

--- a/torch_xla/csrc/runtime/ifrt_computation_client.h
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.h
@@ -96,6 +96,10 @@ class IfrtComputationClient : public ComputationClient {
     XLA_ERROR() << __FUNCTION__ << " not implemented";
   }
 
+  std::intptr_t GetCudaStreamForDevice(int local_device_id) const override {
+    XLA_ERROR() << __FUNCTION__ << " not implemented";
+  }
+
   std::vector<std::string> GetLocalDevices() const override;
 
   std::vector<std::string> GetAllDevices() const override;

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -105,10 +105,12 @@ class PjRtComputationClient : public ComputationClient {
   }
 
   std::intptr_t GetCudaStreamForDevice(int local_device_id) const override {
-    absl::StatusOr<xla::PjRtDevice*> pjrt_device = client_->LookupAddressableDevice(
-        xla::PjRtLocalDeviceId(local_device_id));
+    absl::StatusOr<xla::PjRtDevice*> pjrt_device =
+        client_->LookupAddressableDevice(
+            xla::PjRtLocalDeviceId(local_device_id));
     XLA_CHECK(pjrt_device.ok()) << "Failed to get a PjRt device.";
-    absl::StatusOr<std::intptr_t> stream = pjrt_device.value()->GetStreamForExternalReadyEvents();
+    absl::StatusOr<std::intptr_t> stream =
+        pjrt_device.value()->GetStreamForExternalReadyEvents();
     XLA_CHECK(stream.ok()) << "Failed to get a stream.";
     return stream.value();
   }

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -104,6 +104,15 @@ class PjRtComputationClient : public ComputationClient {
         xla::PjRtLocalDeviceId(local_device_id));
   }
 
+  std::intptr_t GetCudaStreamForDevice(int local_device_id) const override {
+    absl::StatusOr<xla::PjRtDevice*> pjrt_device = client_->LookupAddressableDevice(
+        xla::PjRtLocalDeviceId(local_device_id));
+    XLA_CHECK(pjrt_device.ok()) << "Failed to get a PjRt device.";
+    absl::StatusOr<std::intptr_t> stream = pjrt_device.value()->GetStreamForExternalReadyEvents();
+    XLA_CHECK(stream.ok()) << "Failed to get a stream.";
+    return stream.value();
+  }
+
   std::vector<std::string> GetLocalDevices() const override;
 
   std::vector<std::string> GetAllDevices() const override;

--- a/torch_xla/utils/dlpack.py
+++ b/torch_xla/utils/dlpack.py
@@ -20,18 +20,14 @@ class DLDeviceType(enum.IntEnum):
     kDLOneAPI = 14,
 
 def from_dlpack(ext_tensor: Any):
-  print('xw32 from_dlpack line23 is called')
   if hasattr(ext_tensor, '__dlpack_device__') and hasattr(ext_tensor, '__dlpack__'):
     device_type, device_id = ext_tensor.__dlpack_device__()
-    print('xw32 cuda tensor have the __dlpack__ attr, device_type=', device_type)
     if device_type == DLDeviceType.kDLGPU:
       stream = torch_xla._XLAC._get_stream_for_cuda_device(device_id)
-      print('xw32 got cuda stream:', stream)
       dlpack = ext_tensor.__dlpack__(stream=stream)
     else:
       dlpack = ext_tensor.__dlpack__()
   else:
-    print('xw32 cuda tensor doesnt have the __dlpack__ attr')
     dlpack = ext_tensor
 
   return torch_xla._XLAC._from_dlpack(dlpack)

--- a/torch_xla/utils/dlpack.py
+++ b/torch_xla/utils/dlpack.py
@@ -1,4 +1,5 @@
 from typing import Any
+import enum
 import torch_xla
 
 
@@ -19,8 +20,10 @@ class DLDeviceType(enum.IntEnum):
     kDLOneAPI = 14,
 
 def from_dlpack(ext_tensor: Any):
+  print('xw32 from_dlpack line23 is called')
   if hasattr(ext_tensor, '__dlpack_device__') and hasattr(ext_tensor, '__dlpack__'):
     device_type, device_id = ext_tensor.__dlpack_device__()
+    print('xw32 cuda tensor have the __dlpack__ attr, device_type=', device_type)
     if device_type == DLDeviceType.kDLGPU:
       stream = torch_xla._XLAC._get_stream_for_cuda_device(device_id)
       print('xw32 got cuda stream:', stream)
@@ -28,6 +31,7 @@ def from_dlpack(ext_tensor: Any):
     else:
       dlpack = ext_tensor.__dlpack__()
   else:
+    print('xw32 cuda tensor doesnt have the __dlpack__ attr')
     dlpack = ext_tensor
 
   return torch_xla._XLAC._from_dlpack(dlpack)

--- a/torch_xla/utils/dlpack.py
+++ b/torch_xla/utils/dlpack.py
@@ -6,21 +6,24 @@ import torch_xla
 def to_dlpack(xla_tensor: Any):
   return torch_xla._XLAC._to_dlpack(xla_tensor)
 
+
 class DLDeviceType(enum.IntEnum):
-    # Enums as in DLPack specification (aten/src/ATen/dlpack.h)
-    kDLCPU = 1,
-    kDLGPU = 2,
-    kDLCPUPinned = 3,
-    kDLOpenCL = 4,
-    kDLVulkan = 7,
-    kDLMetal = 8,
-    kDLVPI = 9,
-    kDLROCM = 10,
-    kDLExtDev = 12,
-    kDLOneAPI = 14,
+  # Enums as in DLPack specification (aten/src/ATen/dlpack.h)
+  kDLCPU = 1,
+  kDLGPU = 2,
+  kDLCPUPinned = 3,
+  kDLOpenCL = 4,
+  kDLVulkan = 7,
+  kDLMetal = 8,
+  kDLVPI = 9,
+  kDLROCM = 10,
+  kDLExtDev = 12,
+  kDLOneAPI = 14,
+
 
 def from_dlpack(ext_tensor: Any):
-  if hasattr(ext_tensor, '__dlpack_device__') and hasattr(ext_tensor, '__dlpack__'):
+  if hasattr(ext_tensor, '__dlpack_device__') and hasattr(
+      ext_tensor, '__dlpack__'):
     device_type, device_id = ext_tensor.__dlpack_device__()
     if device_type == DLDeviceType.kDLGPU:
       stream = torch_xla._XLAC._get_stream_for_cuda_device(device_id)

--- a/torch_xla/utils/dlpack.py
+++ b/torch_xla/utils/dlpack.py
@@ -5,6 +5,29 @@ import torch_xla
 def to_dlpack(xla_tensor: Any):
   return torch_xla._XLAC._to_dlpack(xla_tensor)
 
+class DLDeviceType(enum.IntEnum):
+    # Enums as in DLPack specification (aten/src/ATen/dlpack.h)
+    kDLCPU = 1,
+    kDLGPU = 2,
+    kDLCPUPinned = 3,
+    kDLOpenCL = 4,
+    kDLVulkan = 7,
+    kDLMetal = 8,
+    kDLVPI = 9,
+    kDLROCM = 10,
+    kDLExtDev = 12,
+    kDLOneAPI = 14,
 
 def from_dlpack(ext_tensor: Any):
-  return torch_xla._XLAC._from_dlpack(ext_tensor)
+  if hasattr(ext_tensor, '__dlpack_device__') and hasattr(ext_tensor, '__dlpack__'):
+    device_type, device_id = ext_tensor.__dlpack_device__()
+    if device_type == DLDeviceType.kDLGPU:
+      stream = torch_xla._XLAC._get_stream_for_cuda_device(device_id)
+      print('xw32 got cuda stream:', stream)
+      dlpack = ext_tensor.__dlpack__(stream=stream)
+    else:
+      dlpack = ext_tensor.__dlpack__()
+  else:
+    dlpack = ext_tensor
+
+  return torch_xla._XLAC._from_dlpack(dlpack)


### PR DESCRIPTION
from_dlpack should leverage `__dlpack__` and `__dlpack_device__` attributes of a tensor. That way, from_dlpack will handle the cuda synchronization implicity. Similar approaches can be found in [pytorch](https://github.com/pytorch/pytorch/blob/6d43c89f37160cbbce98a7161060cd45b61619e6/torch/utils/dlpack.py) and [jax](https://github.com/google/jax/blob/4461b7fe451cdb7c2e3e51bac6e1c0f78a4515bd/jax/_src/dlpack.py#L274-L278).

This PR fixes the direction when we convert an external tensor such as cuda tensor to an XLA tensor via from_dlpack. For the other direction (convert an XLA tensor to CUDA tensor) requires a change in upstream pytorch.