### PR TITLE
Add `jlibrary` module to torch_xla2 for preserving library abstractions during export

### DIFF
--- a/experimental/torch_xla2/test/test_libraries.py
+++ b/experimental/torch_xla2/test/test_libraries.py
@@ -1,0 +1,80 @@
+import unittest
+import jax
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.library import Library, impl, impl_abstract
+import torch_xla2
+from torch_xla2 import tensor
+from torch_xla2.ops import jaten
+from torch_xla2.ops import jlibrary
+
+
+# Create a `mylib` library which has a basic SDPA op.
+m = Library("mylib", "DEF")
+m.define("scaled_dot_product_attention(Tensor q, Tensor k, Tensor v) -> Tensor")
+
+@impl(m, "scaled_dot_product_attention", "CompositeExplicitAutograd")
+def _mylib_scaled_dot_product_attention(q, k, v):
+  """Basic scaled dot product attention without all the flags/features."""
+  q = q.transpose(1, 2)
+  k = k.transpose(1, 2)
+  v = v.transpose(1, 2)
+  y = F.scaled_dot_product_attention(
+      q,
+      k,
+      v,
+      dropout_p=0,
+      is_causal=False,
+      scale=None,
+  )
+  return y.transpose(1, 2)
+
+@impl_abstract("mylib::scaled_dot_product_attention")
+def _mylib_scaled_dot_product_attention_meta(q, k, v):
+  return torch.empty_like(q)
+
+# Register library op as a composite for export using the `@impl` method
+# for a torch decomposition.
+jlibrary.register_torch_composite(
+  "mylib.scaled_dot_product_attention",
+  _mylib_scaled_dot_product_attention,
+  torch.ops.mylib.scaled_dot_product_attention,
+  torch.ops.mylib.scaled_dot_product_attention.default
+)
+
+# Also register ATen softmax as a composite for export in the `mylib` library
+# using the JAX ATen decomposition from `jaten`.
+jlibrary.register_jax_composite(
+  "mylib.softmax",
+  jaten._aten_softmax,
+  torch.ops.aten._softmax,
+  static_argnums=1  # Required by JAX jit
+)
+
+class LibraryTest(unittest.TestCase):
+
+  def setUp(self):
+    torch.manual_seed(0)
+
+  def test_basic_sdpa_library(self):
+
+    class CustomOpExample(torch.nn.Module):
+      def forward(self, q,k,v):
+        x = torch.ops.mylib.scaled_dot_product_attention(q, k, v)
+        x = x + 1
+        return x
+
+    # Export and check for composite operations
+    model = CustomOpExample()
+    arg = torch.rand(32, 8, 128, 64)
+    args = (arg, arg, arg, )
+
+    exported = torch.export.export(model, args=args)
+    stablehlo = torch_xla2.export.exported_program_to_stablehlo(exported)
+    module_str = str(stablehlo.mlir_module())
+
+    ## TODO Update this machinery from producing function calls to producing
+    ## stablehlo.composite ops.
+    self.assertIn("call @mylib.scaled_dot_product_attention", module_str)
+    self.assertIn("call @mylib.softmax", module_str)

--- a/experimental/torch_xla2/torch_xla2/ops/jlibrary.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jlibrary.py
@@ -1,0 +1,69 @@
+"""The `jlibrary` module has functions which help to preserve torch.library ops
+during export. This includes aten ops, and custom operations.
+"""
+
+import torch
+import torch.nn as nn
+import torch_xla2
+from torch_xla2.ops import jaten
+import jax
+import functools
+
+
+def _jit_composite_impl(composite_name, jaxpr_impl, **jit_args):
+  """Wrap a jaxpr in a jitted function with the proper composite name
+  TODO: Make this produce a composite instead of a call.
+  """
+  def composite_impl(*args):
+    return jaxpr_impl(*args)
+  composite_impl.__name__ = composite_name
+  composite_impl.__qualname__ = composite_name
+  return jax.jit(composite_impl, **jit_args)
+
+def register_jax_composite(composite_name, impl, *ops, **jit_args):
+  """Register a composite using a JAX implementation.
+  
+  This is used to register custom lowerings with an explicit jaxpr
+  implementation, such as preserving a specific aten op using a jaten impl.
+
+  For custom torch op registration with a decomposition written in torch,
+  use `register_torch_composite`.
+
+  For jit params and troubleshooting see:
+  https://jax.readthedocs.io/en/latest/_autosummary/jax.jit.html
+  """
+  @jaten.op(*ops)
+  def _composite_impl(*args):
+    return _jit_composite_impl(composite_name, impl, **jit_args)(*args)
+
+def register_torch_composite(composite_name, impl, *ops, **jit_args):
+  """Register a torch decomposition as a composite.
+  This is useful for registerring custom torch op libraries as composite ops.
+
+  The `impl` can be the `@impl` used to define the torch custom library op.
+  This must be a function or module impl that provides the decompositions, and
+  not an instance of the custom op.
+
+  TODO: Better error handling, or can we make this an instance of the op as a param?
+
+  For jit params and troubleshooting see:
+  https://jax.readthedocs.io/en/latest/_autosummary/jax.jit.html
+  """
+  
+  @jaten.op(*ops)
+  def _composite_impl(*args):
+    class ImplWrapper(torch.nn.Module):
+      def __init__(self):
+        super().__init__()
+
+      def forward(self, *args):
+        return impl(*args)
+
+    # Note: avoid refactoring to share code with register_jaxpr_composite.
+    # The `extract_jax` call must live in the `@jaten.op` handler. If called
+    # outside of the handler, we would build the jaxpr representation of the
+    # module once during registration, potentially missing op registrations that
+    # come after. I.e. may miss nested abstractions if we build jaxpr AoT.
+    state, jfn = torch_xla2.extract_jax(ImplWrapper())
+    jaxpr_impl = lambda *args: jfn(state, tuple([*args]))
+    return _jit_composite_impl(composite_name, jaxpr_impl, **jit_args)(*args)

--- a/experimental/torch_xla2/torch_xla2/ops/jlibrary.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jlibrary.py
@@ -12,7 +12,7 @@ import functools
 
 def _jit_composite_impl(composite_name, jaxpr_impl, **jit_args):
   """Wrap a jaxpr in a jitted function with the proper composite name
-  TODO: Make this produce a composite instead of a call.
+  TODO: Wrap JIT in a `stablehlo.composite` op, instead of generating a call op.
   """
   def composite_impl(*args):
     return jaxpr_impl(*args)
@@ -22,6 +22,10 @@ def _jit_composite_impl(composite_name, jaxpr_impl, **jit_args):
 
 def register_jax_composite(composite_name, impl, *ops, **jit_args):
   """Register a composite using a JAX implementation.
+    composite_name - The name of the library op to use in the exported composite
+    impl           - A JAX lowering for the library operation
+    *ops           - Variadic torch.ops to lower using `impl`.
+    **jit_args     - Additional parameters to forward to JAX jit.
   
   This is used to register custom lowerings with an explicit jaxpr
   implementation, such as preserving a specific aten op using a jaten impl.


### PR DESCRIPTION
It is common to want to export torch->stablehlo with hardware-specific abstractions for better kernel support / mapping to compiler IR. This PR introduces the `jlibrary` APIs: `register_torch_composite` and `register_jax_composite`:

```python
def register_torch_composite(composite_name, impl, *ops, **jit_args): 
  """Register a composite using a JAX implementation.
    composite_name - The name of the library op to use in the exported composite
    impl           - A JAX lowering for the library operation
    *ops           - Variadic torch.ops to lower using `impl`.
    **jit_args     - Additional parameters to forward to JAX jit.
    """
  pass

def register_jax_composite(composite_name, impl, *ops, **jit_args):
  """Register a composite using a PyTorch implementation.
    composite_name - The name of the library op to use in the exported composite
    impl           - A torch method lowering for the library operation, can be the torch.library `@impl`.
    *ops           - Variadic torch.ops to lower using `impl`.
    **jit_args     - Additional parameters to forward to JAX jit.
    """
  pass
```

An example usage is provided in `test_libraries.py`, from a high level, to preserve custom library ops, or aten ops that your hardware has support for, use `jlibrary` to register their lowerings, and they will appear in StableHLO when using `torch_xla2.export` APIs.

Interested in feedback on:
- Module name (`jlibrary` since its next to `jtensor` and `jaten` and its a ptxla2 version of `torch.library`)
- Module location (should this be in `ops`?)
- Method names `register_torch_composite` takes a pytorch decomposition, `register_jax_composite` takes a jax decomposition (like jaten)

Followup tasks:
- Update lowering to export as `stablehlo.composites` instead of `call`.
- Add a means of capturing composite attributes (can this be inferred from library op? state_dict?).