### PR TITLE
Update XLA pin as of 20240528

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,7 +50,7 @@ new_local_repository(
 #    curl -L https://github.com/openxla/xla/archive/<git hash>.tar.gz | sha256sum
 #    and update the sha256 with the result.
 
-xla_hash = '1bb87a7438381502a545dccfceb9827ea7085858'
+xla_hash = '98db3e8c8f64dede911fd97605f76aaf6ede1153'
 
 http_archive(
     name = "xla",

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ import build_util
 
 base_dir = os.path.dirname(os.path.abspath(__file__))
 
-_date = '20240523'
+_date = '20240527'
 _libtpu_version = f'0.1.dev{_date}'
 _libtpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
 _jax_version = f'0.4.29.dev{_date}'


### PR DESCRIPTION
Update XLA pin to 20240528, as part of offcall duty. JAX version remains the same.

Smoke testing seems to be good locally, I'll let CI to verify the rest.