### PR TITLE
Revert "`upsample_bilinear`: fix output data-type."

### DIFF
--- a/torch_xla/csrc/resize_ops.cpp
+++ b/torch_xla/csrc/resize_ops.cpp
@@ -21,10 +21,6 @@ xla::XlaOp BuildResize(xla::XlaOp input, const xla::Shape& output_shape,
                        bool is_kernel_bilinear) {
   // Code copied from
   // https://github.com/tensorflow/tensorflow/blob/e51d6ab5730092775d516b18fa4ee85d49602cd8/tensorflow/compiler/tf2xla/kernels/image_resize_ops.cc#L477-L672
-  //
-  // Changes:
-  // - Remove F32 data-type conversion when is_kernel_bilinear
-  //   See: https://github.com/pytorch/xla/issues/7095
 
   // We implement bilinear interpolation and nearest neighbor with a Gather op.
   // For each output pixel, we gather the necessary slices of the input.
@@ -57,7 +53,7 @@ xla::XlaOp BuildResize(xla::XlaOp input, const xla::Shape& output_shape,
       << "input and output must have the same element type";
 
   xla::PrimitiveType original_input_type = input_type;
-  if (xla::primitive_util::IsIntegralType(input_type)) {
+  if (is_kernel_bilinear || xla::primitive_util::IsIntegralType(input_type)) {
     input = xla::ConvertElementType(input, xla::F32);
     input_type = xla::F32;
   }
@@ -214,7 +210,7 @@ xla::XlaOp BuildResize(xla::XlaOp input, const xla::Shape& output_shape,
   absl::InlinedVector<int64_t, 4> perm = {2, 0, 1, 3};
   input = xla::Transpose(input, perm);
 
-  if (original_input_type != input_type) {
+  if (!is_kernel_bilinear && original_input_type != input_type) {
     input = xla::ConvertElementType(input, original_input_type);
   }
   return input;


### PR DESCRIPTION
Reverts pytorch/xla#7111

TPU CI Failure
```
======================================================================
ERROR: test_upsample_bilinear_double (__main__.TestAtenXlaTensor)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/_work/xla/xla/pytorch/xla/test/test_operations.py", line 2116, in test_upsample_bilinear_double
    Xout = foo(Xinp, is_xla=True)
  File "/home/runner/_work/xla/xla/pytorch/xla/test/test_operations.py", line 2106, in foo
    xm.mark_step()
  File "/home/runner/.local/lib/python3.10/site-packages/torch_xla/core/xla_model.py", line 1055, in mark_step
    torch_xla._XLAC._xla_step_marker(
RuntimeError: Bad StatusOr access: UNIMPLEMENTED: While rewriting computation to not contain X64 element types, XLA encountered an HLO for which this rewriting is not implemented: %custom-call.3 = f64[1,20,20,3]{1,2,3,0} custom-call(f64[1,10,10,3]{1,2,3,0} %transpose.2), custom_call_target="ResizeBilinear", backend_config="\"10\""
```