### PR TITLE
Add Python 3.11 version for release build

### DIFF
--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -91,6 +91,14 @@ versioned_builds = [
     cuda_version    = "12.1"
     python_version  = "3.10"
   },
+  {
+    git_tag         = "v2.3.0"
+    pytorch_git_rev = "v2.3.0"
+    package_version = "2.3.0"
+    accelerator     = "cuda"
+    cuda_version    = "12.1"
+    python_version  = "3.11"
+  },
   # Remove libtpu from PyPI builds
   {
     git_tag         = "v2.2.0"


### PR DESCRIPTION
Add Python 3.11 version to our stable release build, as requested by https://github.com/pytorch/xla/issues/7100. 