### PR TITLE
isolate the PJRT dependency between torch_xla and torch_xla2

### DIFF
--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -80,6 +80,7 @@ class ExperimentLoader:
     # torch_xla2 doesn't support dynamo at this time.
     if cfg_dynamo is not None and cfg_torch_xla2:
       return False
+    use_xla2 = True if cfg_torch_xla2 else False
 
     # Check dynamo backend-specifics constraints.
     if cfg_dynamo == "inductor":
@@ -97,8 +98,8 @@ class ExperimentLoader:
       raise NotImplementedError
 
     # Check XLA device available if requested.
-    if cfg_xla is not None and not is_xla_device_available(
-        cfg_accelerator.upper()):
+    if not use_xla2 and cfg_xla is not None and not is_xla_device_available(
+        cfg_accelerator.upper(), use_xla2):
       return False
 
     # Check accelerator constraints.
@@ -151,8 +152,10 @@ class BenchmarkExperiment:
       process_env.pop("XRT_TPU_CONFIG", None)
       process_env.pop("XLA_FLAGS", None)
 
+    use_xla2 = False
     if self.torch_xla2:
       process_env["JAX_PLATFORMS"] = self.accelerator.lower()
+      use_xla2 = True
 
     if self.xla == "PJRT":
       process_env["PJRT_DEVICE"] = self.accelerator.upper()
@@ -165,13 +168,16 @@ class BenchmarkExperiment:
     elif self.xla is None:
       # In non-xla CPU training experiments, an env var is still needed if an
       # xla device exists, or there will be "Missing XLA configuration" error.
-      if is_xla_device_available(self.accelerator.upper()):
+      if is_xla_device_available(self.accelerator.upper(), use_xla2):
         process_env["PJRT_DEVICE"] = self.accelerator.upper()
 
     if self.xla_flags:
       process_env["XLA_FLAGS"] = self.xla_flags
 
   def get_device(self):
+    if self.torch_xla2:
+      # Initiate the model in CPU first for xla2. We will move the model to jax device later.
+      return torch.device("cpu")
     if self.xla:
       return xm.xla_device(devkind=self.accelerator.upper())
     elif self.accelerator == "cpu":

--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -77,10 +77,10 @@ class ExperimentLoader:
         exclude_tags=()):
       return False
 
-    # torch_xla2 doesn't support dynamo at this time.
-    if cfg_dynamo is not None and cfg_torch_xla2:
-      return False
     use_xla2 = True if cfg_torch_xla2 else False
+    # torch_xla2 doesn't support dynamo at this time.
+    if cfg_dynamo is not None and use_xla2:
+      return False
 
     # Check dynamo backend-specifics constraints.
     if cfg_dynamo == "inductor":
@@ -177,6 +177,7 @@ class BenchmarkExperiment:
   def get_device(self):
     if self.torch_xla2:
       # Initiate the model in CPU first for xla2. We will move the model to jax device later.
+      # This is because we don't have xm.xla_device() function in torch_xla2.
       return torch.device("cpu")
     if self.xla:
       return xm.xla_device(devkind=self.accelerator.upper())

--- a/benchmarks/check_xla_device.py
+++ b/benchmarks/check_xla_device.py
@@ -3,11 +3,13 @@ import sys
 assert len(sys.argv) in (2, 3)
 devkind = sys.argv[1]
 
+
 def use_torch_xla2():
   use_xla2 = False
   if len(sys.argv) == 3 and sys.argv[2].lower() == 'true':
     use_xla2 = True
   return use_xla2
+
 
 import os
 os.environ["PJRT_DEVICE"] = devkind

--- a/benchmarks/check_xla_device.py
+++ b/benchmarks/check_xla_device.py
@@ -2,14 +2,17 @@ import sys
 
 assert len(sys.argv) in (2, 3)
 devkind = sys.argv[1]
-use_xla2 = False
-if len(sys.argv) == 3 and sys.argv[2].lower() == 'true':
-  use_xla2 = True
+
+def use_torch_xla2():
+  use_xla2 = False
+  if len(sys.argv) == 3 and sys.argv[2].lower() == 'true':
+    use_xla2 = True
+  return use_xla2
 
 import os
 os.environ["PJRT_DEVICE"] = devkind
 
-if not use_xla2:
+if not use_torch_xla2():
   import torch_xla.core.xla_model as xm
   devlist = xm.get_xla_supported_devices(devkind=devkind)
 else:

--- a/benchmarks/check_xla_device.py
+++ b/benchmarks/check_xla_device.py
@@ -1,12 +1,24 @@
 import sys
-assert len(sys.argv) == 2
+
+assert len(sys.argv) in (2, 3)
 devkind = sys.argv[1]
+use_xla2 = False
+if len(sys.argv) == 3 and sys.argv[2].lower() == 'true':
+  use_xla2 = True
 
 import os
 os.environ["PJRT_DEVICE"] = devkind
 
-import torch_xla.core.xla_model as xm
-devlist = xm.get_xla_supported_devices(devkind=devkind)
+if not use_xla2:
+  import torch_xla.core.xla_model as xm
+  devlist = xm.get_xla_supported_devices(devkind=devkind)
+else:
+  # torch_xla2 needs jax to detect the device
+  os.environ["JAX_PLATFORMS"] = devkind.lower(
+  )  # JAX_PLATFORMS only accepts lower case
+  assert devkind.lower() in ('cpu', 'gpu', 'tpu')
+  import jax
+  devlist = jax.devices(devkind.lower())
 
-if devlist is None or len(devlist) == 0:
+if not devlist:
   sys.exit(1)

--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -428,6 +428,9 @@ class ExperimentRunner:
         xm.mark_step()
 
   def _synchronize(self, benchmark_experiment):
+    if benchmark_experiment.torch_xla2:
+      # torch_xla2 synchronization happens in _mark_step
+      return
     if benchmark_experiment.xla:
       xm.wait_device_ops()
     elif benchmark_experiment.accelerator == "cuda":

--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -50,6 +50,7 @@ def reset_rng_state(benchmark_experiment=None):
   torch.manual_seed(1337)
   random.seed(1337)
   np.random.seed(1337)
+  # TODO(piz): setup the rng state on jax for torch_xla2.
   if benchmark_experiment is not None and benchmark_experiment.xla is not None and benchmark_experiment.torch_xla2 is None:
     device = benchmark_experiment.get_device()
     xm.set_rng_state(1337, str(device))

--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -50,13 +50,13 @@ def reset_rng_state(benchmark_experiment=None):
   torch.manual_seed(1337)
   random.seed(1337)
   np.random.seed(1337)
-  if benchmark_experiment is not None and benchmark_experiment.xla is not None and benchmark_experiment.torch_xla2 is not None:
+  if benchmark_experiment is not None and benchmark_experiment.xla is not None and benchmark_experiment.torch_xla2 is None:
     device = benchmark_experiment.get_device()
     xm.set_rng_state(1337, str(device))
 
 
 @functools.lru_cache(maxsize=3)
-def is_xla_device_available(devkind):
+def is_xla_device_available(devkind, use_xla2: bool = False):
   if devkind not in ["CPU", "CUDA", "TPU"]:
     raise ValueError(devkind)
   # Checking the availability of a given device kind.
@@ -72,7 +72,7 @@ def is_xla_device_available(devkind):
   # For more information: https://github.com/pytorch/xla/pull/5960
   CHECK_XLA_DEVICE_PY = "check_xla_device.py"
   python_file = os.path.join(os.path.dirname(__file__), CHECK_XLA_DEVICE_PY)
-  r = subprocess.run([sys.executable, python_file, devkind])
+  r = subprocess.run([sys.executable, python_file, devkind, str(use_xla2)])
   return r.returncode == 0
 
 


### PR DESCRIPTION
We should not trigger error like:
```
F0529 21:08:47.961712 3737043 pjrt_registry.cc:139] Non-OK-status: tpu_status status: INVALID_ARGUMENT: Mismatched PJRT plugin PJRT API version (0.51) and framework PJRT API version 0.53).
```
when we install the JAX dependency from torch_xla2.

Basically I get rid of checkings for xla devices using torch_xla related functions. In addition, we initiate benchmark models to CPU device first before moving to jax device.