### PR TITLE
[Pallas] Make repeat_with_fixed_output_size not OOM on VMEM

### DIFF
--- a/test/test_gmm.py
+++ b/test/test_gmm.py
@@ -181,7 +181,7 @@ class MegabloxTest(unittest.TestCase):
             'tm': 4
         },
         {
-            'group_sizes': [377,  588,  153, 1638, 3261, 5890,  996, 3481],
+            'group_sizes': [377, 588, 153, 1638, 3261, 5890, 996, 3481],
             'm': 16384,
             'tm': 128
         },
@@ -197,7 +197,8 @@ class MegabloxTest(unittest.TestCase):
       )
 
       torch_meta = _make_group_metadata(
-          group_sizes=torch.tensor(test_grid['group_sizes']).to(torch.int32).to("xla"),
+          group_sizes=torch.tensor(test_grid['group_sizes']).to(
+              torch.int32).to("xla"),
           m=test_grid['m'],
           tm=test_grid['tm'],
           visit_empty_groups=True,

--- a/test/test_gmm.py
+++ b/test/test_gmm.py
@@ -180,6 +180,11 @@ class MegabloxTest(unittest.TestCase):
             'm': 32,
             'tm': 4
         },
+        {
+            'group_sizes': [377,  588,  153, 1638, 3261, 5890,  996, 3481],
+            'm': 16384,
+            'tm': 128
+        },
     ]
 
     for test_grid in test_grids:
@@ -192,7 +197,7 @@ class MegabloxTest(unittest.TestCase):
       )
 
       torch_meta = _make_group_metadata(
-          group_sizes=torch.tensor(test_grid['group_sizes']).to("xla"),
+          group_sizes=torch.tensor(test_grid['group_sizes']).to(torch.int32).to("xla"),
           m=test_grid['m'],
           tm=test_grid['tm'],
           visit_empty_groups=True,

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2210,12 +2210,15 @@ class TestOpBuilder(test_utils.XlaTestCase):
 
   def test_cumsum(self):
     # cumsum won't work with int64 type on TPU
-    data = torch.tensor([1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    data = torch.tensor([
+        1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32).to("xla")
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    ],
+                        dtype=torch.int32).to("xla")
     result = torch.cumsum(data, dim=0)
 
     # As long as it doesn't crash, it's good.

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2208,22 +2208,6 @@ class TestOpBuilder(test_utils.XlaTestCase):
     self.runOpBuilderTest(
         'test_mul', [torch.randn(2, 2), torch.randn(2, 2)], op_fn)
 
-  def test_cumsum(self):
-    # cumsum won't work with int64 type on TPU
-    data = torch.tensor([
-        1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-    ],
-                        dtype=torch.int32).to("xla")
-    result = torch.cumsum(data, dim=0)
-
-    # As long as it doesn't crash, it's good.
-    result.cpu()
-
   def test_conditional(self):
 
     def op_fn(k, a, b, k0=None):

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1147,6 +1147,8 @@ at::Tensor XLANativeFunctions::cumprod(const at::Tensor& self, int64_t dim,
 at::Tensor XLANativeFunctions::cumsum(const at::Tensor& self, int64_t dim,
                                       c10::optional<at::ScalarType> dtype) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
+  XLA_CHECK_NE(self.dtype(), at::ScalarType::Long)
+      << "cumsum is not supported for long tensors.";
   XLATensorPtr self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(
       tensor_methods::cumsum(self_tensor, dim, dtype));

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1147,8 +1147,6 @@ at::Tensor XLANativeFunctions::cumprod(const at::Tensor& self, int64_t dim,
 at::Tensor XLANativeFunctions::cumsum(const at::Tensor& self, int64_t dim,
                                       c10::optional<at::ScalarType> dtype) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
-  XLA_CHECK_NE(self.dtype(), at::ScalarType::Long)
-      << "cumsum is not supported for long tensors.";
   XLATensorPtr self_tensor = bridge::GetXlaTensor(self);
   return bridge::AtenFromXlaTensor(
       tensor_methods::cumsum(self_tensor, dim, dtype));

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -549,6 +549,8 @@ def _make_group_metadata(
     num_tiles: The number of m-dimension tiles to execute including overlapping
       executions. And don't confuse this with m_tiles which is m // tm.
   """
+  assert group_sizes.dtype == torch.int32, "group_sizes must be of torch.int32 dtype."
+
   device = group_sizes.device
   num_groups = group_sizes.shape[0]
 
@@ -701,7 +703,7 @@ def repeat_with_fixed_output_size(input: torch.Tensor, repeats: torch.Tensor,
 
   # tensor([2, 1, 0, 2, 0, 0, 0, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0])
   block_split_indicators = torch.zeros(
-      total_repeat_length, dtype=torch.int64, device=device)
+      total_repeat_length, dtype=torch.int32, device=device)
   block_split_indicators.scatter_add_(0, valid_indices.to(torch.int64),
                                       torch.ones_like(block_split_indicators))
   # out_of_bound indices also scatter to index 0, need to offset them


### PR DESCRIPTION
Summary:
https://openxla.org/xla/operation_semantics#reducewindow doesn't support int64. Let's make sure input to cumsum is always int32.

Test Plan:
python test/test_gmm.py
python test/test_operations.py