### PR TITLE
Use dest_offsets directly in LoadPlanner

### DIFF
--- a/test/spmd/test_xla_distributed_checkpoint.py
+++ b/test/spmd/test_xla_distributed_checkpoint.py
@@ -156,7 +156,7 @@ class EndToEndCheckpointTest(DistributedCheckpointTestBase):
         load_planner=SPMDLoadPlanner())
 
   @unittest.skipIf(xr.global_runtime_device_count() == 1,
-  "Multiple devices needed to change mesh")
+                   "Multiple devices needed to change mesh")
   def test_padded_tensor(self):
     # Use a linear layer with shape not divisible by the number of devices.
     model1 = torch.nn.Linear(127, 63).to('xla')

--- a/test/spmd/test_xla_distributed_checkpoint.py
+++ b/test/spmd/test_xla_distributed_checkpoint.py
@@ -143,6 +143,18 @@ class EndToEndCheckpointTest(DistributedCheckpointTestBase):
         save_planner=SPMDSavePlanner(),
         load_planner=SPMDLoadPlanner())
 
+  @unittest.skipIf(xr.global_runtime_device_count() == 1,
+                   "Multiple devices needed to change mesh")
+  def test_resharding_transpose_device_mesh(self):
+    dim = self.n_devices // 2
+    model1 = self._get_sharded_model(mesh_shape=(dim, self.n_devices // dim))
+    model2 = self._get_sharded_model(mesh_shape=(self.n_devices // dim, dim))
+    self._save_and_restore(
+        model1,
+        model2,
+        save_planner=SPMDSavePlanner(),
+        load_planner=SPMDLoadPlanner())
+
   @unittest.skipUnless('CHKPT_PATH' in os.environ,
                        'CHKPT_PATH must be set for multihost checkpoint')
   def test_multihost_checkpoint(self):

--- a/torch_xla/experimental/distributed_checkpoint/planners.py
+++ b/torch_xla/experimental/distributed_checkpoint/planners.py
@@ -282,11 +282,6 @@ class SPMDLoadPlanner(LoadPlanner):
     lengths and offsets into the global tensor.
     """
     offsets = read_item.dest_offsets
-    index = read_item.dest_index
-    if index.fqn in self.sharded_state_dict:
-      # Update offsets to index into the shard rather than the global tensor
-      shard = self._local_shards[index.fqn][index.index]
-      offsets = torch.Size(d - i.start for d, i in zip(offsets, shard.indices))
     return narrow_tensor_by_index(tensor, offsets, read_item.lengths)
 
   def commit_tensor(self, read_item: ReadItem, tensor: torch.Tensor) -> None:


### PR DESCRIPTION
In [create_read_items_for_chunk_list](https://github.com/pytorch/pytorch/blob/3174e6cb8e2d37210c7569e51dc6a9522110e0f3/torch/distributed/checkpoint/planner_helpers.py#L149), the ReadItem's `dest_offsets` are set to index into the local shard. Despite this, we performed an  translation from global to local indices. This caused issues restoring checkpoints with padded tensors, i.e. where the global tensor size is not evenly divisible by the shard size.

We should instead rely on `dest_offsets` directly to narrow the local shards.