### PR TITLE
[torch_xla2] Add lowerings for `rand_like` and `randn_like`, and enable some opinfo tests

### DIFF
--- a/experimental/torch_xla2/pyproject.toml
+++ b/experimental/torch_xla2/pyproject.toml
@@ -17,10 +17,10 @@ requires-python = ">=3.10"
 license = {file = "LICENSE"}
 
 [project.optional-dependencies]
-cpu = ["jax[cpu]>=0.4.24", "jax[cpu]"]
+cpu = ["jax[cpu]>=0.4.29", "jax[cpu]"]
 # Add libtpu index `-f https://storage.googleapis.com/libtpu-releases/index.html`
-tpu = ["jax[cpu]>=0.4.24", "jax[tpu]"]
-cuda = ["jax[cpu]>=0.4.24", "jax[cuda12]"]
+tpu = ["jax[cpu]>=0.4.29", "jax[tpu]"]
+cuda = ["jax[cpu]>=0.4.29", "jax[cuda12]"]
 
 [tool.pytest.ini_options]
 addopts="-n auto"

--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -325,7 +325,7 @@ skiplist = {
     "unbind",
     "unfold_copy",
     "unfold",
-    "uniform",
+    # "uniform",
     "unique_consecutive",
     "unique",
     "unravel_index",

--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -10,7 +10,7 @@ from torch_xla2 import tensor
 
 
 skiplist = {
-    "__rpow__",  # NOTE: cannot fix because torch test case has undefined behavior 
+    "__rpow__",  # NOTE: cannot fix because torch test case has undefined behavior
                  # such as 0 to negative power.
     "_segment_reduce",
     "_upsample_bilinear2d_aa",
@@ -267,9 +267,7 @@ skiplist = {
     "put",
     "qr",
     "quantile",
-    "rand_like",
     "randint_like",
-    "randn_like",
     "renorm",
     "repeat_interleave",
     "resize_",
@@ -325,7 +323,6 @@ skiplist = {
     "unbind",
     "unfold_copy",
     "unfold",
-    # "uniform",
     "unique_consecutive",
     "unique",
     "unravel_index",
@@ -509,9 +506,13 @@ variant_test_name_to_skip = {
 }
 
 random_ops = {
-  'randn',
   'empty',
   'bernoulli',
+  'randn',
+  'randn_like',
+  'rand',
+  'rand_like',
+  'uniform',
 }
 
 def diff_output(testcase, output1, output2, rtol, atol, equal_nan=True, check_output=True):
@@ -567,7 +568,7 @@ def run_export_and_compare(testcase,
 
 ops_to_test = [
     test for test in op_db
-    if (test.name not in skiplist and 
+    if (test.name not in skiplist and
         test.variant_test_name not in variant_test_name_to_skip)
 ]
 

--- a/experimental/torch_xla2/torch_xla2/decompositions.py
+++ b/experimental/torch_xla2/torch_xla2/decompositions.py
@@ -121,5 +121,4 @@ EXTRA_DECOMP = decomp.get_decompositions([
     torch.ops.aten.replication_pad3d,
     torch.ops.aten.bernoulli,
     torch.ops.aten.rand_like,
-    torch.ops.aten.uniform_,
 ])

--- a/experimental/torch_xla2/torch_xla2/decompositions.py
+++ b/experimental/torch_xla2/torch_xla2/decompositions.py
@@ -1,6 +1,6 @@
 """This file contains some decompositons that are not available in torch stable.
 
-Most likely from Content of 
+Most likely from Content of
 https://github.com/pytorch/pytorch/blob/main/torch/_decomp/decompositions.py
 at main branch HEAD that we find useful here.
 
@@ -29,7 +29,7 @@ aten = torch._ops.ops.aten
 def _try_register(op, impl):
     try:
         register_decomposition(op)(impl)
-    except: 
+    except:
         pass
 
 @out_wrapper()
@@ -121,8 +121,5 @@ EXTRA_DECOMP = decomp.get_decompositions([
     torch.ops.aten.replication_pad3d,
     torch.ops.aten.bernoulli,
     torch.ops.aten.rand_like,
+    torch.ops.aten.uniform_,
 ])
-
-
-
-

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -28,7 +28,7 @@ mutation_ops_to_functional = {
   torch.ops.aten.ge_: torch.ops.aten.ge,
   torch.ops.aten.eq_: torch.ops.aten.eq,
   torch.ops.aten.ne_: torch.ops.aten.ne,
-  # torch.ops.aten.uniform_: torch.ops.aten.uniform,
+  torch.ops.aten.uniform_: torch.ops.aten.uniform,
   torch.ops.aten.relu_: torch.ops.aten.relu,
   torch.ops.aten.normal_: torch.ops.aten.normal,
   torch.ops.aten.squeeze_: torch.ops.aten.squeeze,
@@ -2007,6 +2007,20 @@ def _aten_rand_like(
 ):
   key = env.get_and_rotate_prng_key()
   return jax.random.uniform(key, dtype=dtype or input.dtype, shape=input.shape)
+
+
+@op(torch.ops.aten.uniform, needs_env=True)
+def _aten_uniform(
+  x,
+  low = 0.0,
+  high = 1.0,
+  *,
+  generator = None,
+  env=None,
+):
+  key = env.get_and_rotate_prng_key(generator)
+  res = jax.random.uniform(key, shape=x.shape, minval=low, maxval=high)
+  return res
 
 
 @op(torch.ops.aten.scalar_tensor.default)

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -2009,6 +2009,27 @@ def _rand(
   return res
 
 
+@op(torch.ops.aten.randint, torch.ops.aten.randint.generator, needs_env=True)
+@op_base.convert_dtype(use_default_dtype=False)
+def _randint(
+  high,
+  size,
+  *,
+  generator=None,
+  dtype=None,
+  layout=torch.strided,
+  device=None,
+  pin_memory=False,
+  env=None,
+):
+  shape = size
+  if len(shape) == 1 and isinstance(shape[0], (list, tuple)):
+    shape = shape[0]
+  key = env.get_and_rotate_prng_key(generator)
+  res = jax.random.randint(key, shape, minval=0, maxval=high, dtype=dtype or np.int64)
+  return res
+
+
 @op(torch.ops.aten.rand_like, needs_env=True)
 @op_base.convert_dtype()
 def _aten_rand_like(

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -28,7 +28,7 @@ mutation_ops_to_functional = {
   torch.ops.aten.ge_: torch.ops.aten.ge,
   torch.ops.aten.eq_: torch.ops.aten.eq,
   torch.ops.aten.ne_: torch.ops.aten.ne,
-  torch.ops.aten.uniform_: torch.ops.aten.uniform,
+  # torch.ops.aten.uniform_: torch.ops.aten.uniform,
   torch.ops.aten.relu_: torch.ops.aten.relu,
   torch.ops.aten.normal_: torch.ops.aten.normal,
   torch.ops.aten.squeeze_: torch.ops.aten.squeeze,
@@ -1991,6 +1991,22 @@ def _rand(
   if dtype is not None:
     res = res.astype(dtype)
   return res
+
+
+@op(torch.ops.aten.rand_like, needs_env=True)
+@op_base.convert_dtype()
+def _aten_rand_like(
+  input,
+  *,
+  dtype=None,
+  layout=None,
+  device=None,
+  requires_grad=False,
+  memory_format=torch.preserve_format,
+  env=None,
+):
+  key = env.get_and_rotate_prng_key()
+  return jax.random.uniform(key, dtype=dtype or input.dtype, shape=input.shape)
 
 
 @op(torch.ops.aten.scalar_tensor.default)

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -2035,8 +2035,7 @@ def _aten_uniform(
   env=None,
 ):
   key = env.get_and_rotate_prng_key(generator)
-  res = jax.random.uniform(key, shape=x.shape, minval=low, maxval=high)
-  return res
+  return jax.random.uniform(key, shape=x.shape, minval=low, maxval=high)
 
 
 @op(torch.ops.aten.scalar_tensor.default)

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -1972,7 +1972,7 @@ def _randn(
 
 @op(torch.ops.aten.randn_like, needs_env=True)
 @op_base.convert_dtype()
-def _aten_rand_like(
+def _aten_randn_like(
   x,
   *,
   dtype=None,
@@ -2035,7 +2035,8 @@ def _aten_uniform(
   env=None,
 ):
   key = env.get_and_rotate_prng_key(generator)
-  return jax.random.uniform(key, shape=x.shape, minval=low, maxval=high)
+  return jax.random.uniform(
+      key, shape=x.shape, dtype=x.dtype, minval=low, maxval=high)
 
 
 @op(torch.ops.aten.scalar_tensor.default)

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -1970,6 +1970,22 @@ def _randn(
   return res
 
 
+@op(torch.ops.aten.randn_like, needs_env=True)
+@op_base.convert_dtype()
+def _aten_rand_like(
+  x,
+  *,
+  dtype=None,
+  layout=None,
+  device=None,
+  pin_memory=False,
+  memory_format=torch.preserve_format,
+  env=None,
+):
+  key = env.get_and_rotate_prng_key()
+  return jax.random.normal(key, dtype=dtype or x.dtype, shape=x.shape)
+
+
 @op(torch.ops.aten.rand, needs_env=True)
 @op_base.convert_dtype()
 def _rand(
@@ -1996,17 +2012,17 @@ def _rand(
 @op(torch.ops.aten.rand_like, needs_env=True)
 @op_base.convert_dtype()
 def _aten_rand_like(
-  input,
+  x,
   *,
   dtype=None,
   layout=None,
   device=None,
-  requires_grad=False,
+  pin_memory=False,
   memory_format=torch.preserve_format,
   env=None,
 ):
   key = env.get_and_rotate_prng_key()
-  return jax.random.uniform(key, dtype=dtype or input.dtype, shape=input.shape)
+  return jax.random.uniform(key, dtype=dtype or x.dtype, shape=x.shape)
 
 
 @op(torch.ops.aten.uniform, needs_env=True)

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -228,7 +228,7 @@ def _aten_stack(tensors, dim=0):
 @op(torch.ops.aten._softmax)
 def _aten_softmax(x, dim, halftofloat):
   return jax.nn.softmax(x, dim)
-   
+
 
 def _is_int(x):
   if isinstance(x, int):
@@ -314,7 +314,7 @@ def _aten_expand(x, dims):
   shape = list(x.shape)
   if len(shape) < len(dims):
     shape = [1, ] * (len(dims) - len(shape)) + shape
-    # make sure that dims and shape is the same by 
+    # make sure that dims and shape is the same by
     # left pad with 1s. Otherwise the zip below will
     # truncate
   dims = [fix_dims(p, s) for p, s in zip(dims, shape)]
@@ -945,7 +945,7 @@ def _aten_atanh(self):
   res = _handle_int64_trig(self, jnp.arctanh)
   return res
 
- 
+
 # aten.bincount
 @op(torch.ops.aten.bincount)
 def _aten_bincount(input, weights=None, minlength=0):
@@ -1423,7 +1423,7 @@ def _strided_index(sizes, strides, storage_offset=None):
 
   if storage_offset is not None:
     ind += storage_offset
-  return ind 
+  return ind
 
 # aten.as_strided
 @op(torch.ops.aten.as_strided)
@@ -2007,22 +2007,6 @@ def _rand(
   if dtype is not None:
     res = res.astype(dtype)
   return res
-
-
-@op(torch.ops.aten.rand_like, needs_env=True)
-@op_base.convert_dtype()
-def _aten_rand_like(
-  x,
-  *,
-  dtype=None,
-  layout=None,
-  device=None,
-  pin_memory=False,
-  memory_format=torch.preserve_format,
-  env=None,
-):
-  key = env.get_and_rotate_prng_key()
-  return jax.random.uniform(key, dtype=dtype or x.dtype, shape=x.shape)
 
 
 @op(torch.ops.aten.scalar_tensor.default)


### PR DESCRIPTION
Required for some module initialization. Remove the decomp for `uniform` because `randn` takes different arguments: uniform takes a Tensor and a range, and randn takes a shape.

Enable their respective opinfo tests.