### PR TITLE
Warn when using persistent cache with debug env vars

### DIFF
--- a/torch_xla/csrc/runtime/env_hash.cc
+++ b/torch_xla/csrc/runtime/env_hash.cc
@@ -93,7 +93,7 @@ torch::lazy::hash_t HashXlaEnvVars() {
   // Both XLA_FLAGS and LIBTPU_INIT_ARGS contain XLA flags which impact
   // the compilation result.
   static std::vector<std::string> flag_vars = {"XLA_FLAGS", "LIBTPU_INIT_ARGS"};
-  static std::vector<std::string> raw_vars = {"TPU_MEGACORE"};
+  static std::vector<std::string> raw_vars = {"TPU_MEGACORE", "XLA_HLO_DEBUG"};
   return hash_xla_env_vars(flag_vars, raw_vars);
 }
 

--- a/torch_xla/csrc/runtime/env_hash.cc
+++ b/torch_xla/csrc/runtime/env_hash.cc
@@ -93,7 +93,8 @@ torch::lazy::hash_t HashXlaEnvVars() {
   // Both XLA_FLAGS and LIBTPU_INIT_ARGS contain XLA flags which impact
   // the compilation result.
   static std::vector<std::string> flag_vars = {"XLA_FLAGS", "LIBTPU_INIT_ARGS"};
-  static std::vector<std::string> raw_vars = {"TPU_MEGACORE", "XLA_HLO_DEBUG"};
+  static std::vector<std::string> raw_vars = {"TPU_MEGACORE", "XLA_HLO_DEBUG",
+                                              "XLA_IR_DEBUG"};
   return hash_xla_env_vars(flag_vars, raw_vars);
 }
 

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -100,10 +100,13 @@ XLAGraphExecutor::ComputationCache* CreateComputationCache() {
       return std::make_shared<XLAGraphExecutor::CachedComputation>(
           computation, /*is_sharded=*/UseVirtualDevice());
     };
-    if (runtime::sys_util::GetEnvBool("XLA_HLO_DEBUG", false)) {
-      TF_LOG(WARNING) << "Using persistent compilation cache with XLA_HLO_DEBUG=1 "
-        "is not recommended. Changes to the HLO metadata will not be "
-        "reflected in loaded executables.";
+    if (runtime::sys_util::GetEnvBool("XLA_HLO_DEBUG", false) ||
+        runtime::sys_util::GetEnvBool("XLA_IR_DEBUG", false)) {
+      TF_LOG(WARNING)
+          << "Using persistent compilation cache with XLA_HLO_DEBUG=1 "
+             "or XLA_IR_DEBUG=1 is not recommended. Changes to the HLO "
+             "metadata "
+             "will not be reflected in loaded executables.";
     }
     return new XLAGraphExecutor::PersistentCache(
         kMaxCacheSize, persistentCacheDir, readonlyPersistentCache,

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -100,6 +100,11 @@ XLAGraphExecutor::ComputationCache* CreateComputationCache() {
       return std::make_shared<XLAGraphExecutor::CachedComputation>(
           computation, /*is_sharded=*/UseVirtualDevice());
     };
+    if (runtime::sys_util::GetEnvBool("XLA_HLO_DEBUG", false)) {
+      TF_LOG(WARNING) << "Using persistent compilation cache with XLA_HLO_DEBUG=1 "
+        "is not recommended. Changes to the HLO metadata will not be "
+        "reflected in loaded executables.";
+    }
     return new XLAGraphExecutor::PersistentCache(
         kMaxCacheSize, persistentCacheDir, readonlyPersistentCache,
         serialize_fn, deserialize_fn);

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -105,8 +105,7 @@ XLAGraphExecutor::ComputationCache* CreateComputationCache() {
       TF_LOG(WARNING)
           << "Using persistent compilation cache with XLA_HLO_DEBUG=1 "
              "or XLA_IR_DEBUG=1 is not recommended. Changes to the HLO "
-             "metadata "
-             "will not be reflected in loaded executables.";
+             "metadata will not be reflected in loaded executables.";
     }
     return new XLAGraphExecutor::PersistentCache(
         kMaxCacheSize, persistentCacheDir, readonlyPersistentCache,


### PR DESCRIPTION
See also https://github.com/pytorch/xla/issues/7169

When using the persistent compilation cache, modifications to the HLO metadata will not impact the graph hash, and the persistent cache will load executables compiled with potentially outdated metadata.

This change:
- Modifies the graph hash when `XLA_HLO_DEBUG` or `XLA_IR_DEBUG` is set
- Prints a warning when initializing the persistent cache with `XLA_HLO_DEBUG` or `XLA_IR_DEBUG` set.