### PR TITLE
[Pallas] Make _histogram output int32

### DIFF
--- a/test/test_gmm.py
+++ b/test/test_gmm.py
@@ -251,6 +251,7 @@ class MegabloxTest(unittest.TestCase):
           max=test_grid['max'],
       )
 
+      self.assertEqual(chart.dtype, torch.int32)
       self.assertTrue(torch.all(torch_chart == chart.cpu()))
 
   def test_histogram_raise(self):

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -514,7 +514,7 @@ def _histogram(input: torch.Tensor, min: int, max: int) -> torch.Tensor:
 
   bin_edges = torch.linspace(
       min, max, max - min + 1, dtype=input.dtype).to(input.device)
-  return searchsorted(bin_edges, input)
+  return searchsorted(bin_edges, input).to(torch.int32)
 
 
 # Refence: https://github.com/google/jax/blob/main/jax/experimental/pallas/ops/tpu/megablox/gmm.py#L78


### PR DESCRIPTION
Summary:
Make _histogram output int32 such that it's compatible with TPUs.

Test Plan:
python test/test_gmm.py -v -k test_histogram 