### PR TITLE
Allow user to configure distributed runtime service.

### DIFF
--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -237,6 +237,7 @@ cc_library(
     deps = [
         ":debug_macros",
         ":sys_util",
+        ":env_vars",
         "@xla//xla/tsl/distributed_runtime/preemption:preemption_sync_manager",
         "@xla//xla/pjrt/distributed",
     ],

--- a/torch_xla/csrc/runtime/env_vars.cc
+++ b/torch_xla/csrc/runtime/env_vars.cc
@@ -24,6 +24,12 @@ const char* const kEnvPjrtAllocatorCudaAsync = "PJRT_ALLOCATOR_CUDA_ASYNC";
 const char* const kEnvPjrtAllocatorPreallocate = "PJRT_ALLOCATOR_PREALLOCATE";
 const char* const kEnvPjrtAllocatorFraction = "PJRT_ALLOCATOR_FRACTION";
 const char* const kEnvPjrtDynamicPlugins = "PJRT_DYNAMIC_PLUGINS";
+const char* const kEnvDistSvcHeartbeatIntervalInSec =
+    "DIST_SERVICE_HEARTBEAT_INTERVAL_IN_SEC";
+const char* const kEnvDistSvcMaxMissingHeartbeats =
+    "DIST_SERVICE_MAX_MISSING_HEARTBEATS";
+const char* const kEnvDistSvcShutdownTimeoutInMin =
+    "DIST_SERVICE_SHUTDOWN_TIMEOUT_IN_MIN";
 
 }  // namespace env
 }  // namespace runtime

--- a/torch_xla/csrc/runtime/env_vars.h
+++ b/torch_xla/csrc/runtime/env_vars.h
@@ -34,6 +34,9 @@ extern const char* const kEnvPjrtAllocatorCudaAsync;
 extern const char* const kEnvPjrtAllocatorPreallocate;
 extern const char* const kEnvPjrtAllocatorFraction;
 extern const char* const kEnvPjrtDynamicPlugins;
+extern const char* const kEnvDistSvcHeartbeatIntervalInSec;
+extern const char* const kEnvDistSvcMaxMissingHeartbeats;
+extern const char* const kEnvDistSvcShutdownTimeoutInMin;
 
 }  // namespace env
 }  // namespace runtime

--- a/torch_xla/csrc/runtime/xla_coordinator.cc
+++ b/torch_xla/csrc/runtime/xla_coordinator.cc
@@ -1,6 +1,7 @@
 #include "torch_xla/csrc/runtime/xla_coordinator.h"
 
 #include "torch_xla/csrc/runtime/debug_macros.h"
+#include "torch_xla/csrc/runtime/env_vars.h"
 #include "torch_xla/csrc/runtime/sys_util.h"
 #include "xla/pjrt/distributed/distributed.h"
 
@@ -13,11 +14,23 @@ XlaCoordinator::XlaCoordinator(int global_rank, int world_size,
   if (global_rank == 0) {
     xla::CoordinationServiceImpl::Options service_options;
     service_options.num_nodes = world_size;
+    // Default value can be found in
+    // https://github.com/openxla/xla/blob/4b88636002bc5834d7fe3f862997c66a490987bc/xla/pjrt/distributed/client.h#L63-L72.
+    int heartbeat_interval_sec =
+        sys_util::GetEnvInt(env::kEnvDistSvcHeartbeatIntervalInSec, 10);
+    service_options.heartbeat_interval = absl::Seconds(heartbeat_interval_sec);
+    service_options.max_missing_heartbeats =
+        sys_util::GetEnvInt(env::kEnvDistSvcMaxMissingHeartbeats, 10);
+    int shutdown_timeout =
+        sys_util::GetEnvInt(env::kEnvDistSvcShutdownTimeoutInMin, 5);
+    service_options.shutdown_timeout = absl::Minutes(shutdown_timeout);
+
     xla::StatusOr<std::unique_ptr<xla::DistributedRuntimeService>>
         dist_runtime_service = xla::GetDistributedRuntimeService(
             dist_service_addr, service_options);
     XLA_CHECK(dist_runtime_service.ok())
         << "Failed to initialize distributed runtime service.";
+
     dist_runtime_service_ = std::move(dist_runtime_service.value());
   }
 


### PR DESCRIPTION
On GKE, the multi-host GPU training always fails after 5 min into the training, without a clear error message (see the log on the 2 hosts: https://gist.github.com/vanbasten23/bdced1d993fa604025d318e9d68a2f6b https://gist.github.com/vanbasten23/cc4096a869e0278eb414642dd7662166). It fails on larger model such as LLM but succeeds on smaller model such as resnet.

By following JAX's [example](http://google3/learning/brain/research/jax/lib/jax_service_python.cc;l=135-145;rcl=617156835), we allow user to configure max_missing_heartbeats, heartbeat_interval, distributed_shutdown_timeout. I suspect the failure is due to one of the configuration's default value being too small.