### PR TITLE
Make clip_grad_norm_ follow the input's dtype

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2020,20 +2020,20 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
 
   def test_clip_grad_norm_(self):
 
-      def foo(t):
-        torch.nn.utils.clip_grad_norm_(t, 1.0)
+    def foo(t):
+      torch.nn.utils.clip_grad_norm_(t, 1.0)
 
-      t = torch.rand(10, 10, requires_grad=True, dtype=torch.bfloat16)
-      t.retain_grad()
-      t.grad = torch.rand(10, 10, dtype=torch.bfloat16)
-      xt = t.to(xm.xla_device())
-      xt.grad = t.grad.to(xm.xla_device(), dtype=torch.bfloat16)
+    t = torch.rand(10, 10, requires_grad=True, dtype=torch.bfloat16)
+    t.retain_grad()
+    t.grad = torch.rand(10, 10, dtype=torch.bfloat16)
+    xt = t.to(xm.xla_device())
+    xt.grad = t.grad.to(xm.xla_device(), dtype=torch.bfloat16)
 
-      foo(t)
-      foo(xt)
+    foo(t)
+    foo(xt)
 
-      self.assertEqual(xt.grad.dtype, torch.bfloat16)
-      self.assertEqual(t.grad, xt.grad.cpu())
+    self.assertEqual(xt.grad.dtype, torch.bfloat16)
+    self.assertEqual(t.grad, xt.grad.cpu())
 
   def test_stack_different_types(self):
 

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2018,6 +2018,23 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
 
     self.assertEqual(r, Xr.cpu())
 
+  def test_clip_grad_norm_(self):
+
+      def foo(t):
+        torch.nn.utils.clip_grad_norm_(t, 1.0)
+
+      t = torch.rand(10, 10, requires_grad=True, dtype=torch.bfloat16)
+      t.retain_grad()
+      t.grad = torch.rand(10, 10, dtype=torch.bfloat16)
+      xt = t.to(xm.xla_device())
+      xt.grad = t.grad.to(xm.xla_device(), dtype=torch.bfloat16)
+
+      foo(t)
+      foo(xt)
+
+      self.assertEqual(xt.grad.dtype, torch.bfloat16)
+      self.assertEqual(t.grad, xt.grad.cpu())
+
   def test_stack_different_types(self):
 
     def foo(t0, t1):

--- a/torch_xla/_patched_functions.py
+++ b/torch_xla/_patched_functions.py
@@ -31,9 +31,10 @@ def clip_grad_norm_(parameters: _tensor_or_tensors,
   parameters = list(filter(lambda p: p.grad is not None, parameters))
   max_norm = float(max_norm)
   norm_type = float(norm_type)
-  if len(parameters) == 0:
-    return torch.tensor(0.)
+  dtype = parameters[0].grad.dtype
   device = parameters[0].grad.device
+  if len(parameters) == 0:
+    return torch.tensor(0., dtype=dtype, device=device)
   if norm_type == inf:
     total_norm = max(p.grad.detach().abs().max() for p in parameters)
   else:
@@ -46,9 +47,9 @@ def clip_grad_norm_(parameters: _tensor_or_tensors,
         f'The norm of order {norm_type} for a gradient from `parameters` '
         'is non-finite, so it cannot be clipped. This error can be '
         'disabled with `error_if_nonfinite=False`')
-  clip_coef = torch.tensor(max_norm, device=device) / (total_norm + 1e-6)
+  clip_coef = torch.tensor(max_norm, dtype=dtype, device=device) / (total_norm + 1e-6)
   clip_value = torch.where(clip_coef < 1, clip_coef,
-                           torch.tensor(1., device=device))
+                           torch.tensor(1., dtype=dtype, device=device))
   for p in parameters:
     p.grad.detach().mul_(clip_value)
   return total_norm

--- a/torch_xla/_patched_functions.py
+++ b/torch_xla/_patched_functions.py
@@ -47,7 +47,9 @@ def clip_grad_norm_(parameters: _tensor_or_tensors,
         f'The norm of order {norm_type} for a gradient from `parameters` '
         'is non-finite, so it cannot be clipped. This error can be '
         'disabled with `error_if_nonfinite=False`')
-  clip_coef = torch.tensor(max_norm, dtype=dtype, device=device) / (total_norm + 1e-6)
+  clip_coef = torch.tensor(
+      max_norm, dtype=dtype, device=device) / (
+          total_norm + 1e-6)
   clip_value = torch.where(clip_coef < 1, clip_coef,
                            torch.tensor(1., dtype=dtype, device=device))
   for p in parameters:


### PR DESCRIPTION
Summary:
The correct clipped value uses fp32 regardless of the input dtype. Let's make it follow the input dtype.

Test Plan:
python test/test_operations.py -v -k test_clip_grad_norm_