### PR TITLE
Remove stack dump for compiler failure which can happen often

### DIFF
--- a/torch_xla/csrc/runtime/debug_macros.h
+++ b/torch_xla/csrc/runtime/debug_macros.h
@@ -21,4 +21,10 @@ T ConsumeValue(xla::StatusOr<T>&& status) {
   return std::move(status).value();
 }
 
+template <typename T>
+T ConsumeValueNoStackDump(xla::StatusOr<T>&& status) {
+  TF_CHECK_OK(status.status());
+  return std::move(status).value();
+}
+
 #endif  // XLA_CLIENT_DEBUG_MACROS_H_

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -627,7 +627,7 @@ std::vector<ComputationClient::ComputationPtr> PjRtComputationClient::Compile(
       TF_VLOG(3) << "memory usage is not availiable";
     }
 
-    const auto& hlo_modules = ConsumeValue(executable->GetHloModules());
+    const auto& hlo_modules = ConsumeValueNoStackDump(executable->GetHloModules());
     xla::HloComputation* hlo_computation = hlo_modules[0]->entry_computation();
     std::shared_ptr<PjRtComputation> pjrt_computation =
         std::make_shared<PjRtComputation>(

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -627,7 +627,8 @@ std::vector<ComputationClient::ComputationPtr> PjRtComputationClient::Compile(
       TF_VLOG(3) << "memory usage is not availiable";
     }
 
-    const auto& hlo_modules = ConsumeValueNoStackDump(executable->GetHloModules());
+    const auto& hlo_modules =
+        ConsumeValueNoStackDump(executable->GetHloModules());
     xla::HloComputation* hlo_computation = hlo_modules[0]->entry_computation();
     std::shared_ptr<PjRtComputation> pjrt_computation =
         std::make_shared<PjRtComputation>(


### PR DESCRIPTION
When there's a compilation error, the compiler message is lost among lots of dump messages. This change reduces the amount of dump message so that the compiler message can be more prominent.

For example, the following stack trace (mostly useless) will be removed when there compilation error:

```
E     RuntimeError: torch_xla/csrc/xla_graph_executor.cpp:649 : Check failed: tensor_data                                                                                                            
E     *** Begin stack trace ***                                                                                                                                                                   
E       tsl::CurrentStackTrace()                                                                                                                                                                      
E       torch_xla::XLAGraphExecutor::CollectSyncTensors(std::vector<c10::intrusive_ptr<torch_xla::XLATensor, c10::detail::intrusive_target_default_null_type<torch_xla::XLATensor> >, std::allocator<c
10::intrusive_ptr<torch_xla::XLATensor, c10::detail::intrusive_target_default_null_type<torch_xla::XLATensor> > > > const&, torch::lazy::LazyGraphExecutor::SyncTensorsConfig const&)                 
E       torch_xla::XLAGraphExecutor::SyncTensorsGraphInternal(std::vector<c10::intrusive_ptr<torch_xla::XLATensor, c10::detail::intrusive_target_default_null_type<torch_xla::XLATensor> >, std::alloc
ator<c10::intrusive_ptr<torch_xla::XLATensor, c10::detail::intrusive_target_default_null_type<torch_xla::XLATensor> > > >*, absl::lts_20230802::Span<std::string const>, torch::lazy::LazyGraphExecuto
r::SyncTensorsConfig const&, bool)                                                                                                                                                                    
E       torch_xla::XLAGraphExecutor::SyncTensorsGraph(std::vector<c10::intrusive_ptr<torch_xla::XLATensor, c10::detail::intrusive_target_default_null_type<torch_xla::XLATensor> >, std::allocator<c10
::intrusive_ptr<torch_xla::XLATensor, c10::detail::intrusive_target_default_null_type<torch_xla::XLATensor> > > >*, absl::lts_20230802::Span<std::string const>, bool, bool, bool)                    
E       torch_xla::XLAGraphExecutor::SyncLiveTensorsGraph(torch::lazy::BackendDevice const*, c10::ArrayRef<std::string>, bool)                                                                        
E                                                
E                                                
E                                                
E                                                
E       _PyObject_MakeTpCall                     
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       PyObject_Call                            
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       PyObject_Call                            
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       _PyEval_EvalFrameDefault                 
E                                                
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       _PyObject_FastCallDictTstate             
E       _PyObject_Call_Prepend                   
E                                                
E       _PyObject_MakeTpCall                     
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       PyObject_Call                            
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       _PyEval_EvalFrameDefault                 
E                                                
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       _PyObject_FastCallDictTstate             
E       _PyObject_Call_Prepend                   
E                                                
E       PyObject_Call                            
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       _PyEval_EvalFrameDefault                 
E                                                
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       PyObject_Call                            
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       _PyEval_EvalFrameDefault                 
E                                                
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       _PyObject_FastCallDictTstate             
E       _PyObject_Call_Prepend                   
E                                                
E       _PyObject_MakeTpCall                     
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       PyObject_Call                            
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       _PyEval_EvalFrameDefault                 
E                                                
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       _PyObject_FastCallDictTstate             
E       _PyObject_Call_Prepend                   
E                                                
E       _PyObject_MakeTpCall                     
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       _PyEval_EvalFrameDefault                 
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       PyObject_Call                            
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       _PyEval_EvalFrameDefault                 
E                                                
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       _PyObject_FastCallDictTstate             
E       _PyObject_Call_Prepend                   
E                                                
E       _PyObject_MakeTpCall                     
E       _PyEval_EvalFrameDefault                 
E       _PyFunction_Vectorcall                   
E       _PyEval_EvalFrameDefault                 
E                                                
E       PyEval_EvalCode                          
E                                                
E                                                
E                                                
E       _PyRun_SimpleFileObject                  
E       _PyRun_AnyFileObject                     
E       Py_RunMain                               
E       Py_BytesMain                             
E       __libc_start_main                        
E       _start                                   
E     *** End stack trace ***                    
                                        
```