### PR TITLE
Add stub plugins for XPU and Neuron

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -302,7 +302,11 @@ setup(
         'console_scripts': [
             'stablehlo-to-saved-model = torch_xla.tf_saved_model_integration:main'
         ],
-        'torch_xla.plugins': ['tpu = torch_xla._internal.tpu:TpuPlugin',],
+        'torch_xla.plugins': [
+            'tpu = torch_xla._internal.tpu:TpuPlugin',
+            'neuron = torch_xla._internal.neuron:NeuronPlugin',
+            'xpu = torch_xla._internal.xpu:XpuPlugin'
+        ],
     },
     extras_require={
         # On Cloud TPU VM install with:

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -210,6 +210,7 @@ except importlib.metadata.PackageNotFoundError:
 from .stablehlo import save_as_stablehlo, save_torch_model_as_stablehlo
 
 from .experimental import plugins
+from ._internal import neuron, xpu  # Additional built-in plugins
 
 if os.getenv('XLA_REGISTER_INSTALLED_PLUGINS') == '1':
   plugins.use_dynamic_plugins()

--- a/torch_xla/_internal/xpu.py
+++ b/torch_xla/_internal/xpu.py
@@ -1,0 +1,9 @@
+import os
+
+from torch_xla.experimental import plugins
+
+
+class XpuPlugin(plugins.DevicePlugin):
+
+  def library_path(self):
+    return os.environ.get('XPU_LIBRARY_PATH', 'libxpu.so')


### PR DESCRIPTION
We're currently planning to change the default behavior to look for installed plugin packages instead of hardcoding each device type in `pjrt_registry.cc`. This PR adds stub implementations for XPU and Neuron that match the current behavior in the `torch_xla` package.

Long-term, these plugins should move to separate packages similar to `plugins/cuda`. I'll add some more documentation soon.

See #6242 for context.

cc @aws-kingrj 