### PR TITLE
Fix wrong env flag for using auto sharding in documentation

### DIFF
--- a/docs/spmd.md
+++ b/docs/spmd.md
@@ -524,7 +524,7 @@ You could use these examples on TPU/GPU/CPU single-host and modify it to run on 
 We are introducing a new PyTorch/XLA SPMD feature, called ``auto-sharding``, [RFC](https://github.com/pytorch/xla/issues/6322). This is an experimental feature in `r2.3` and `nightly`, that supports `XLA:TPU` and a single TPUVM host.
 
 PyTorch/XLA auto-sharding can be enabled by one of the following:
-- Setting envvar `XLA_SPMD_AUTO=1`
+- Setting envvar `XLA_AUTO_SPMD=1`
 - Calling the SPMD API in the beginning of your code:
 
 ```python


### PR DESCRIPTION
Could you please consider updating the flag for enabling autosharding to `XLA_AUTO_SPMD` in the doc? It appears that `XLA_SPMD_AUTO` might be a typo. Thank you!

https://github.com/pytorch/xla/blob/5338a3b0ee7560c137006fe1f976be2c6c864dab/torch_xla/runtime.py#L257-L260

https://github.com/pytorch/xla/blob/5338a3b0ee7560c137006fe1f976be2c6c864dab/torch_xla/csrc/xla_sharding_util.cpp#L893-L898