### PR TITLE
[SPMD] Support reduce-scatter in manual sharding

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1213,6 +1213,20 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
     self.assertEqual(xxx.shape, (8, 8))
     self.assertTrue(torch.allclose(x.cpu() + 1, xxx.cpu()))
 
+  def test_spmd_reduce_scatter(self):
+    xs.set_global_mesh(self._get_mesh((1, self.n_devices)))
+    x = torch.randn(4, 4).to(xm.xla_device())
+    print(x)
+
+    # Reduce scatter
+    x = xs.enable_manual_sharding(x, (None, None)).global_tensor
+    x = torch_xla._XLAC._xla_spmd_reduce_scatter(xm.REDUCE_SUM, x, 1.0, 0, 4, [[0, 1, 2, 3]])
+    x = xs.disable_manual_sharding(x, (1, None), (4, 4)).global_tensor
+
+    hlo = torch_xla._XLAC._get_xla_tensors_hlo([x])
+    print(hlo)
+    print(x)
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1221,7 +1221,7 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
     # Reduce scatter
     x = xs.enable_manual_sharding(x, (None, None)).global_tensor
     x = torch_xla._XLAC._xla_spmd_reduce_scatter(xm.REDUCE_SUM, x, 1.0, 0, 4, [[0, 1, 2, 3]])
-    x = xs.disable_manual_sharding(x, (1, None), (4, 4)).global_tensor
+    x = xs.disable_manual_sharding(x, (None, None), (1, 4)).global_tensor
 
     hlo = torch_xla._XLAC._get_xla_tensors_hlo([x])
     print(hlo)

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1219,11 +1219,15 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
 
     # Reduce scatter
     x = xs.enable_manual_sharding(x, (None, None)).global_tensor
-    x = torch_xla._XLAC._xla_spmd_reduce_scatter(xm.REDUCE_SUM, x, 1.0, 0, self.n_devices, [self.device_ids])
+    x = torch_xla._XLAC._xla_spmd_reduce_scatter(xm.REDUCE_SUM, x, 1.0, 0,
+                                                 self.n_devices,
+                                                 [self.device_ids])
     x = xs.disable_manual_sharding(x, (None, None), x.shape).global_tensor
 
     hlo = torch_xla._XLAC._get_xla_tensors_hlo([x])
-    self.assertIn(f"reduce-scatter(f32[8,8]{{1,0}} %custom-call.2), channel_id=1, replica_groups={{{{{','.join([str(x) for x in self.device_ids])}}}}}, use_global_device_ids=true, dimensions={{0}}, to_apply=%AddComputation.3", hlo)
+    self.assertIn(
+        f"reduce-scatter(f32[8,8]{{1,0}} %custom-call.2), channel_id=1, replica_groups={{{{{','.join([str(x) for x in self.device_ids])}}}}}, use_global_device_ids=true, dimensions={{0}}, to_apply=%AddComputation.3",
+        hlo)
 
     expected_x = torch.ones(2, 8) * 4
     self.assertTrue(torch.allclose(x.cpu(), expected_x))
@@ -1234,11 +1238,15 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
 
     # Reduce scatter
     x = xs.enable_manual_sharding(x, (None, None)).global_tensor
-    x = torch_xla._XLAC._xla_spmd_reduce_scatter(xm.REDUCE_SUM, x, 1.0, -1, self.n_devices, [self.device_ids])
+    x = torch_xla._XLAC._xla_spmd_reduce_scatter(xm.REDUCE_SUM, x, 1.0, -1,
+                                                 self.n_devices,
+                                                 [self.device_ids])
     x = xs.disable_manual_sharding(x, (None, None), x.shape).global_tensor
 
     hlo = torch_xla._XLAC._get_xla_tensors_hlo([x])
-    self.assertIn(f"reduce-scatter(f32[8,8]{{1,0}} %custom-call.2), channel_id=1, replica_groups={{{{{','.join([str(x) for x in self.device_ids])}}}}}, use_global_device_ids=true, dimensions={{1}}, to_apply=%AddComputation.3", hlo)
+    self.assertIn(
+        f"reduce-scatter(f32[8,8]{{1,0}} %custom-call.2), channel_id=1, replica_groups={{{{{','.join([str(x) for x in self.device_ids])}}}}}, use_global_device_ids=true, dimensions={{1}}, to_apply=%AddComputation.3",
+        hlo)
 
     expected_x = torch.ones(8, 2) * 4
     self.assertTrue(torch.allclose(x.cpu(), expected_x))

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1228,6 +1228,21 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
     expected_x = torch.ones(2, 8) * 4
     self.assertTrue(torch.allclose(x.cpu(), expected_x))
 
+  def test_spmd_reduce_scatter_canonical_index(self):
+    xs.set_global_mesh(self._get_mesh((1, self.n_devices)))
+    x = torch.ones(8, 8).to(xm.xla_device())
+
+    # Reduce scatter
+    x = xs.enable_manual_sharding(x, (None, None)).global_tensor
+    x = torch_xla._XLAC._xla_spmd_reduce_scatter(xm.REDUCE_SUM, x, 1.0, -1, self.n_devices, [self.device_ids])
+    x = xs.disable_manual_sharding(x, (None, None), x.shape).global_tensor
+
+    hlo = torch_xla._XLAC._get_xla_tensors_hlo([x])
+    self.assertIn(f"reduce-scatter(f32[8,8]{{1,0}} %custom-call.2), channel_id=1, replica_groups={{{{{','.join([str(x) for x in self.device_ids])}}}}}, use_global_device_ids=true, dimensions={{1}}, to_apply=%AddComputation.3", hlo)
+
+    expected_x = torch.ones(8, 2) * 4
+    self.assertTrue(torch.allclose(x.cpu(), expected_x))
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/torch_xla/csrc/cross_replica_reduces.h
+++ b/torch_xla/csrc/cross_replica_reduces.h
@@ -96,6 +96,11 @@ ReduceScatterResult BuildReduceScatter(
     int64_t scatter_dim, int64_t shard_count,
     const std::vector<std::vector<int64_t>>& groups, bool pin_layout);
 
+xla::XlaOp BuildReduceScatter(
+    AllReduceType reduce_type, xla::XlaOp input, double scale,
+    int64_t scatter_dim, int64_t shard_count,
+    const std::vector<std::vector<int64_t>>& groups);
+
 ReduceScatterResultCoalesced BuildReduceScatterCoalesced(
     AllReduceType reduce_type, absl::Span<const xla::XlaOp> inputs,
     xla::XlaOp token, double scale, int64_t scatter_dim, int64_t shard_count,

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1557,6 +1557,16 @@ void InitXlaModuleBindings(py::module m) {
           result_tuple[1] = new_token;
           return result_tuple;
         });
+  m.def("_xla_spmd_reduce_scatter",
+        [](const std::string& reduce_type, const at::Tensor& input,
+           double scale, int64_t scatter_dim, int64_t shard_count, const py::list& groups) {
+          std::vector<std::vector<int64_t>> replica_groups =
+              CreateReduceGroups(groups);
+          auto result =
+              tensor_methods::reduce_scatter(bridge::GetXlaTensor(input), GetReduceType(reduce_type), scale, scatter_dim,
+                            shard_count, replica_groups);
+          return bridge::AtenFromXlaTensor(std::move(result));
+        });
   m.def("_xla_reduce_scatter",
         [](const std::string& reduce_type, const at::Tensor& input,
            const std::shared_ptr<torch::lazy::Value>& token, double scale,

--- a/torch_xla/csrc/ops/reduce_scatter.cpp
+++ b/torch_xla/csrc/ops/reduce_scatter.cpp
@@ -28,6 +28,19 @@ xla::Shape NodeOutputShape(AllReduceType reduce_type,
   return InferOutputShape({GetXlaShape(input), GetXlaShape(token)}, shape_fn);
 }
 
+xla::Shape NodeOutputShape(AllReduceType reduce_type,
+                           const torch::lazy::Value input,
+                           double scale,
+                           int64_t scatter_dim, int64_t shard_count,
+                           const std::vector<std::vector<int64_t>>& groups) {
+  auto shape_fn = [&](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
+    xla::XlaOp inputOp = operands[0];
+    return BuildReduceScatter(reduce_type, inputOp, scale, scatter_dim,
+                           shard_count, groups);
+  };
+  return InferOutputShape({GetXlaShape(input)}, shape_fn);
+}
+
 xla::Shape NodeOutputShapeCoalesced(
     AllReduceType reduce_type, c10::ArrayRef<torch::lazy::Value> inputs,
     const torch::lazy::Value& token, double scale, int64_t scatter_dim,
@@ -73,6 +86,28 @@ ReduceScatter::ReduceScatter(AllReduceType reduce_type,
       groups_(std::move(groups)),
       pin_layout_(pin_layout) {}
 
+ReduceScatter::ReduceScatter(AllReduceType reduce_type,
+                             const torch::lazy::Value& input,
+                             double scale,
+                             int64_t scatter_dim, int64_t shard_count,
+                             std::vector<std::vector<int64_t>> groups)
+    : XlaNode(
+          xla_reduce_scatter, {input},
+          [&]() {
+            return NodeOutputShape(reduce_type, input, scale,
+                                   scatter_dim, shard_count, groups);
+          },
+          /*num_outputs=*/1,
+          torch::lazy::MHash(torch::lazy::GetEnumValue(reduce_type), scale,
+                             scatter_dim, shard_count, groups)),
+      reduce_type_(reduce_type),
+      scale_(scale),
+      scatter_dim_(scatter_dim),
+      shard_count_(shard_count),
+      groups_(std::move(groups)),
+      pin_layout_(false),
+      has_token_(false) {}
+
 ReduceScatterCoalesced::ReduceScatterCoalesced(
     AllReduceType reduce_type, c10::ArrayRef<torch::lazy::Value> inputs,
     const torch::lazy::Value& token, double scale, int64_t scatter_dim,
@@ -111,6 +146,11 @@ torch::lazy::NodePtr ReduceScatterCoalesced::Clone(
 
 XlaOpVector ReduceScatter::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
+  if (!has_token_) {
+    auto result = BuildReduceScatter(
+        reduce_type_, input, scale_, scatter_dim_, shard_count_, groups_);
+    return ReturnOp(result, loctx);
+  }
   xla::XlaOp token = loctx->GetOutputOp(operand(1));
   ReduceScatterResult result =
       BuildReduceScatter(reduce_type_, input, token, scale_, scatter_dim_,

--- a/torch_xla/csrc/ops/reduce_scatter.h
+++ b/torch_xla/csrc/ops/reduce_scatter.h
@@ -12,6 +12,10 @@ class ReduceScatter : public XlaNode {
                 const torch::lazy::Value& token, double scale,
                 int64_t scatter_dim, int64_t shard_count,
                 std::vector<std::vector<int64_t>> groups, bool pin_layout);
+  ReduceScatter(AllReduceType reduce_type, const torch::lazy::Value& input,
+                double scale,
+                int64_t scatter_dim, int64_t shard_count,
+                std::vector<std::vector<int64_t>> groups);
 
   std::string ToString() const override;
 
@@ -34,6 +38,7 @@ class ReduceScatter : public XlaNode {
   int64_t shard_count_;
   std::vector<std::vector<int64_t>> groups_;
   bool pin_layout_;
+  bool has_token_ {true};
 };
 
 class ReduceScatterCoalesced : public XlaNode {

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -386,6 +386,15 @@ std::pair<XLATensorPtr, torch::lazy::Value> reduce_scatter(
           torch::lazy::Value(node, 1)};
 }
 
+XLATensorPtr reduce_scatter(
+    const XLATensorPtr& input,
+    AllReduceType reduce_type, double scale, int64_t scatter_dim,
+    int64_t shard_count, std::vector<std::vector<int64_t>> groups) {
+  return input->CreateFrom(torch::lazy::MakeNode<ReduceScatter>(
+      reduce_type, input->GetIrValue(), scale, scatter_dim, shard_count,
+      std::move(groups)));
+}
+
 torch::lazy::Value reduce_scatter_out(XLATensorPtr& output,
                                       const XLATensorPtr& input,
                                       const torch::lazy::Value& token,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -390,8 +390,9 @@ XLATensorPtr reduce_scatter(
     const XLATensorPtr& input,
     AllReduceType reduce_type, double scale, int64_t scatter_dim,
     int64_t shard_count, std::vector<std::vector<int64_t>> groups) {
+  auto canonical_scatter_dim = torch::lazy::GetCanonicalDimensionIndex(scatter_dim, input->shape().get().rank());
   return input->CreateFrom(torch::lazy::MakeNode<ReduceScatter>(
-      reduce_type, input->GetIrValue(), scale, scatter_dim, shard_count,
+      reduce_type, input->GetIrValue(), scale, canonical_scatter_dim, shard_count,
       std::move(groups)));
 }
 

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -26,6 +26,11 @@ std::pair<XLATensorPtr, torch::lazy::Value> reduce_scatter(
     int64_t shard_count, std::vector<std::vector<int64_t>> groups,
     bool pin_layout);
 
+XLATensorPtr reduce_scatter(
+    const XLATensorPtr& input,
+    AllReduceType reduce_type, double scale, int64_t scatter_dim,
+    int64_t shard_count, std::vector<std::vector<int64_t>> groups);
+
 torch::lazy::Value reduce_scatter_out(XLATensorPtr& output,
                                       const XLATensorPtr& input,
                                       const torch::lazy::Value& token,


### PR DESCRIPTION
Summary:
This PR is to add an experimental suport of cc ops in manual sharding zones. This one adds reduce-scatter as the initial step. The key here is to channel_id, replica_groups, and use_global_device_ids.

Test Plan:
PJRT_DEVICE=TPU XLA_USE_SPMD=1 python test/spmd/test_xla_sharding.py -v -k test_spmd_reduce_scatter