### PR TITLE
Add build trigger for 2.4.0-rc1 release

### DIFF
--- a/infra/ansible/config/cuda_deps.yaml
+++ b/infra/ansible/config/cuda_deps.yaml
@@ -3,6 +3,7 @@
 cuda_deps:
   # List all libcudnn8 versions with `apt list -a libcudnn8`
   libcudnn:
+    "12.4": libcudnn-cuda-12=9.1.1.17-1
     "12.3": libcudnn9-cuda-12=9.0.0.312-1
     "12.1": libcudnn8=8.9.2.26-1+cuda12.1
     "12.0": libcudnn8=8.8.0.121-1+cuda12.0
@@ -10,6 +11,7 @@ cuda_deps:
     "11.7": libcudnn8=8.5.0.96-1+cuda11.7
     "11.2": libcudnn8=8.1.1.33-1+cuda11.2
   libcudnn-dev:
+    "12.4": libcudnn-dev-cuda-12=9.1.1.17-1
     "12.3": libcudnn9-dev-cuda-12=9.0.0.312-1
     "12.1": libcudnn8-dev=8.9.2.26-1+cuda12.1
     "12.0": libcudnn8-dev=8.8.0.121-1+cuda12.0

--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -35,6 +35,64 @@ nightly_builds = [
 versioned_builds = [
   # Remove libtpu from PyPI builds
   {
+    git_tag         = "v2.4.0-rc1"
+    package_version = "2.4.0-rc1"
+    pytorch_git_rev = "v2.4.0-rc1"
+    accelerator     = "tpu"
+    python_version = "3.8"
+    bundle_libtpu   = "0"
+  },
+  {
+    git_tag         = "v2.4.0-rc1"
+    package_version = "2.4.0-rc1"
+    pytorch_git_rev = "v2.4.0-rc1"
+    accelerator     = "tpu"
+    python_version  = "3.9"
+    bundle_libtpu   = "0"
+  },
+  {
+    git_tag         = "v2.4.0-rc1"
+    package_version = "2.4.0-rc1"
+    pytorch_git_rev = "v2.4.0-rc1"
+    accelerator     = "tpu"
+    python_version  = "3.10"
+    bundle_libtpu   = "0"
+  },
+  {
+    git_tag         = "v2.4.0-rc1"
+    package_version = "2.4.0-rc1"
+    pytorch_git_rev = "v2.4.0-rc1"
+    accelerator     = "tpu"
+    python_version  = "3.11"
+    bundle_libtpu   = "0"
+  },
+  # Bundle libtpu for Kaggle
+  {
+    git_tag         = "v2.4.0-rc1"
+    package_version = "2.4.0-rc1+libtpu"
+    pytorch_git_rev = "v2.4.0-rc1"
+    accelerator     = "tpu"
+    python_version  = "3.10"
+    bundle_libtpu   = "1"
+  },
+  {
+    git_tag         = "v2.4.0-rc1"
+    pytorch_git_rev = "v2.4.0-rc1"
+    package_version = "2.4.0-rc1"
+    accelerator     = "cuda"
+    cuda_version    = "12.1"
+    python_version = "3.8"
+  },
+  {
+    git_tag         = "v2.4.0-rc1"
+    pytorch_git_rev = "v2.4.0-rc1"
+    package_version = "2.4.0-rc1"
+    accelerator     = "cuda"
+    cuda_version    = "12.1"
+    python_version  = "3.10"
+  },
+  # Remove libtpu from PyPI builds
+  {
     git_tag         = "v2.3.0"
     package_version = "2.3.0"
     pytorch_git_rev = "v2.3.0"

--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -39,14 +39,6 @@ versioned_builds = [
     package_version = "2.4.0-rc1"
     pytorch_git_rev = "v2.4.0-rc1"
     accelerator     = "tpu"
-    python_version = "3.8"
-    bundle_libtpu   = "0"
-  },
-  {
-    git_tag         = "v2.4.0-rc1"
-    package_version = "2.4.0-rc1"
-    pytorch_git_rev = "v2.4.0-rc1"
-    accelerator     = "tpu"
     python_version  = "3.9"
     bundle_libtpu   = "0"
   },
@@ -77,11 +69,11 @@ versioned_builds = [
   },
   {
     git_tag         = "v2.4.0-rc1"
-    pytorch_git_rev = "v2.4.0-rc1"
     package_version = "2.4.0-rc1"
+    pytorch_git_rev = "v2.4.0-rc1"
     accelerator     = "cuda"
     cuda_version    = "12.1"
-    python_version = "3.8"
+    python_version  = "3.9"
   },
   {
     git_tag         = "v2.4.0-rc1"
@@ -90,6 +82,22 @@ versioned_builds = [
     accelerator     = "cuda"
     cuda_version    = "12.1"
     python_version  = "3.10"
+  },
+  {
+    git_tag         = "v2.4.0-rc1"
+    package_version = "2.4.0-rc1"
+    pytorch_git_rev = "v2.4.0-rc1"
+    accelerator     = "cuda"
+    cuda_version    = "12.1"
+    python_version  = "3.11"
+  },
+  {
+    git_tag         = "v2.4.0-rc1"
+    package_version = "2.4.0-rc1"
+    pytorch_git_rev = "v2.4.0-rc1"
+    accelerator     = "cuda"
+    cuda_version    = "12.4"
+    python_version  = "3.11"
   },
   # Remove libtpu from PyPI builds
   {

--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -97,6 +97,22 @@ versioned_builds = [
     pytorch_git_rev = "v2.4.0-rc1"
     accelerator     = "cuda"
     cuda_version    = "12.4"
+    python_version  = "3.9"
+  },
+  {
+    git_tag         = "v2.4.0-rc1"
+    package_version = "2.4.0-rc1"
+    pytorch_git_rev = "v2.4.0-rc1"
+    accelerator     = "cuda"
+    cuda_version    = "12.4"
+    python_version  = "3.10"
+  },
+  {
+    git_tag         = "v2.4.0-rc1"
+    package_version = "2.4.0-rc1"
+    pytorch_git_rev = "v2.4.0-rc1"
+    accelerator     = "cuda"
+    cuda_version    = "12.4"
     python_version  = "3.11"
   },
   # Remove libtpu from PyPI builds


### PR DESCRIPTION
Similar to https://github.com/pytorch/xla/pull/6688 which added trigger for 2.3 release.

2.4 release tag is rc1 in upstream.