### PR TITLE
force to string output

### DIFF
--- a/benchmarks/result_analyzer.py
+++ b/benchmarks/result_analyzer.py
@@ -123,7 +123,8 @@ class ResultAnalyzer:
       torch_xla2_value = "None" if torch_xla2 is None else torch_xla2
       keep_model_data_on_cuda = dataline["experiment"][
           "keep_model_data_on_cuda"]
-      keep_model_data_on_cuda_value = "None" if keep_model_data_on_cuda is None else str(keep_model_data_on_cuda)
+      keep_model_data_on_cuda_value = "None" if keep_model_data_on_cuda is None else str(
+          keep_model_data_on_cuda)
       test = dataline["experiment"]["test"]
       test_value = "None" if test is None else test
       outputs_file = dataline["experiment"].get("outputs_file", None)

--- a/benchmarks/result_analyzer.py
+++ b/benchmarks/result_analyzer.py
@@ -104,6 +104,7 @@ class ResultAnalyzer:
     return d
 
   # TODO: handle error message properly (database length restriction)
+  # Do not use bool. This will mess up with the bigquery parsing.
   def extract_metrics_jsonl(self, file):
     with open(file, mode="r", encoding="utf-8") as f:
       jsonlines = f.read().splitlines()
@@ -122,7 +123,7 @@ class ResultAnalyzer:
       torch_xla2_value = "None" if torch_xla2 is None else torch_xla2
       keep_model_data_on_cuda = dataline["experiment"][
           "keep_model_data_on_cuda"]
-      keep_model_data_on_cuda_value = "None" if keep_model_data_on_cuda is None else keep_model_data_on_cuda
+      keep_model_data_on_cuda_value = "None" if keep_model_data_on_cuda is None else str(keep_model_data_on_cuda)
       test = dataline["experiment"]["test"]
       test_value = "None" if test is None else test
       outputs_file = dataline["experiment"].get("outputs_file", None)


### PR DESCRIPTION
Out torchbench run fails ([link](https://46c56b977f2b44158661f1ef150119c7-dot-us-central1.composer.googleusercontent.com/dags/pytorchxla-torchbench/grid?dag_run_id=scheduled__2024-06-06T11%3A00%3A00%2B00%3A00&task_id=torchbench_all-v5litepod-4.post_process.process_metrics&tab=logs)) because bigquery is unable to parse bool format:
```
'errors': [{'reason': 'invalid', 'location': 'metadata_value', 'debugInfo': '', 'message': 'Conversion from bool to std::string is unsupported.'}]}
```