### PR TITLE
[SPMD] Fix reduce_scatter for TPUv2

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1213,7 +1213,7 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
     self.assertEqual(xxx.shape, (8, 8))
     self.assertTrue(torch.allclose(x.cpu() + 1, xxx.cpu()))
 
-  @unittest.skipIf(xr.device_type() != 'TPU' and tpu.version() < 4,
+  @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 4,
                    "Only runs on TPUv4")
   def test_spmd_reduce_scatter(self):
     xs.set_global_mesh(self._get_mesh((1, self.n_devices)))
@@ -1234,7 +1234,7 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
     expected_x = torch.ones(8 // self.n_devices, 8) * 4
     self.assertTrue(torch.allclose(x.cpu(), expected_x))
 
-  @unittest.skipIf(xr.device_type() != 'TPU' and tpu.version() < 4,
+  @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 4,
                    "Only runs on TPUv4")
   def test_spmd_reduce_scatter_canonical_index(self):
     xs.set_global_mesh(self._get_mesh((1, self.n_devices)))

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1230,7 +1230,7 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
         f"reduce-scatter(f32[8,8]{{1,0}} %custom-call.2), channel_id=1, replica_groups={{{{{','.join([str(x) for x in self.device_ids])}}}}}, use_global_device_ids=true, dimensions={{0}}, to_apply=%AddComputation.3",
         hlo)
 
-    expected_x = torch.ones(2, 8) * 4
+    expected_x = torch.ones(8 // self.n_devices, 8) * 4
     self.assertTrue(torch.allclose(x.cpu(), expected_x))
 
   @unittest.skipIf(xr.device_type() != 'TPU', "Skip non-TPU device")
@@ -1250,7 +1250,7 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
         f"reduce-scatter(f32[8,8]{{1,0}} %custom-call.2), channel_id=1, replica_groups={{{{{','.join([str(x) for x in self.device_ids])}}}}}, use_global_device_ids=true, dimensions={{1}}, to_apply=%AddComputation.3",
         hlo)
 
-    expected_x = torch.ones(8, 2) * 4
+    expected_x = torch.ones(8, 8 // self.n_devices) * 4
     self.assertTrue(torch.allclose(x.cpu(), expected_x))
 
 

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1216,6 +1216,7 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
   @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 4,
                    "Only runs on TPUv4")
   def test_spmd_reduce_scatter(self):
+    print(tpu.version())
     xs.set_global_mesh(self._get_mesh((1, self.n_devices)))
     x = torch.ones(8, 8).to(xm.xla_device())
 

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1213,7 +1213,7 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
     self.assertEqual(xxx.shape, (8, 8))
     self.assertTrue(torch.allclose(x.cpu() + 1, xxx.cpu()))
 
-  @unittest.skipIf(xr.device_type() != 'TPU', "Skip non-TPU device")
+  @unittest.skipIf(xr.device_type() != 'TPU' and tpu.version() < 4, "Only runs on TPUv4")
   def test_spmd_reduce_scatter(self):
     xs.set_global_mesh(self._get_mesh((1, self.n_devices)))
     x = torch.ones(8, 8).to(xm.xla_device())
@@ -1233,7 +1233,7 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
     expected_x = torch.ones(8 // self.n_devices, 8) * 4
     self.assertTrue(torch.allclose(x.cpu(), expected_x))
 
-  @unittest.skipIf(xr.device_type() != 'TPU', "Skip non-TPU device")
+  @unittest.skipIf(xr.device_type() != 'TPU' and tpu.version() < 4, "Only runs on TPUv4")
   def test_spmd_reduce_scatter_canonical_index(self):
     xs.set_global_mesh(self._get_mesh((1, self.n_devices)))
     x = torch.ones(8, 8).to(xm.xla_device())

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1213,7 +1213,8 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
     self.assertEqual(xxx.shape, (8, 8))
     self.assertTrue(torch.allclose(x.cpu() + 1, xxx.cpu()))
 
-  @unittest.skipIf(xr.device_type() != 'TPU' and tpu.version() < 4, "Only runs on TPUv4")
+  @unittest.skipIf(xr.device_type() != 'TPU' and tpu.version() < 4,
+                   "Only runs on TPUv4")
   def test_spmd_reduce_scatter(self):
     xs.set_global_mesh(self._get_mesh((1, self.n_devices)))
     x = torch.ones(8, 8).to(xm.xla_device())
@@ -1233,7 +1234,8 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
     expected_x = torch.ones(8 // self.n_devices, 8) * 4
     self.assertTrue(torch.allclose(x.cpu(), expected_x))
 
-  @unittest.skipIf(xr.device_type() != 'TPU' and tpu.version() < 4, "Only runs on TPUv4")
+  @unittest.skipIf(xr.device_type() != 'TPU' and tpu.version() < 4,
+                   "Only runs on TPUv4")
   def test_spmd_reduce_scatter_canonical_index(self):
     xs.set_global_mesh(self._get_mesh((1, self.n_devices)))
     x = torch.ones(8, 8).to(xm.xla_device())

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1216,7 +1216,6 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
   @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 4,
                    "Only runs on TPUv4")
   def test_spmd_reduce_scatter(self):
-    print(tpu.version())
     xs.set_global_mesh(self._get_mesh((1, self.n_devices)))
     x = torch.ones(8, 8).to(xm.xla_device())
 


### PR DESCRIPTION
Summary:
Fix reduce_scatter test for TPUv2

Test Plan:
python test/spmd/test_xla_sharding.py -v -k test_spmd_reduce_scatter