### PR TITLE
Bump JAX version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ base_dir = os.path.dirname(os.path.abspath(__file__))
 _date = '20240612'
 _libtpu_version = f'0.1.dev{_date}'
 _libtpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
-_jax_version = f'0.4.29.dev{_date}'
+_jax_version = f'0.4.30.dev{_date}'
 
 
 def _get_build_mode():


### PR DESCRIPTION
For current libtpu pin 20240612, the JAX version has changed to "[jax/jax-0.4.30.dev20240612-py3-none-any.whl](https://storage.googleapis.com/jax-releases/nightly/jax/jax-0.4.30.dev20240612-py3-none-any.whl)
[jax/jax-0.4.30.dev20240612.tar.gz](https://storage.googleapis.com/jax-releases/nightly/jax/jax-0.4.30.dev20240612.tar.gz)"

This is a follow-up of https://github.com/pytorch/xla/pull/7254