### PR TITLE
Backport: Bump jaxversion corresponding to libtpu 0612

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ base_dir = os.path.dirname(os.path.abspath(__file__))
 _date = '20240605'
 _libtpu_version = f'0.1.dev{_date}'
 _libtpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
-_jax_version = f'0.4.29.dev{_date}'
+_jax_version = f'0.4.30.dev{_date}'
 
 
 def _get_build_mode():


### PR DESCRIPTION
Backport https://github.com/pytorch/xla/pull/7258, which should be a part of XLA pin update