### PR TITLE
Enable PJRT plugins by default

### DIFF
--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -213,7 +213,8 @@ from .stablehlo import save_as_stablehlo, save_torch_model_as_stablehlo
 from .experimental import plugins
 from ._internal import neuron, xpu  # Additional built-in plugins
 
-if os.getenv('XLA_REGISTER_INSTALLED_PLUGINS') == '1':
+if os.getenv('XLA_REGISTER_INSTALLED_PLUGINS',
+             '0' if _XLAC._has_cuda_support() else '1') == '1':
   plugins.use_dynamic_plugins()
   plugins.register_installed_plugins()
 

--- a/torch_xla/_internal/tpu.py
+++ b/torch_xla/_internal/tpu.py
@@ -343,7 +343,9 @@ class TpuPlugin(plugins.DevicePlugin):
     return configure_topology(local_rank, local_world_size)
 
   def physical_chip_count(self):
-    return num_available_chips()
+    # HACK: We may reduce the number of processes we spawn depending on TPU
+    # topology settings
+    return num_local_processes()
 
   def client_create_options(self):
     return {

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2461,6 +2461,13 @@ void InitXlaModuleBindings(py::module m) {
           return XlaCustomCall(inputs, payload, output_shapes, output_dtypes,
                                /*is_tpu=*/true);
         });
+  m.def("_has_cuda_support", []() {
+#ifdef GOOGLE_CUDA
+    return true;
+#else
+    return false;
+#endif
+  });
   m.def("_xla_gpu_custom_call",
         [](const std::vector<at::Tensor>& inputs, const std::string& payload,
            const std::vector<std::vector<int64_t>>& output_shapes,


### PR DESCRIPTION
`GOOGLE_CUDA` is defined in bazel by OpenXLA. This will be unset by default. Therefore, we'll use dynamic plugins by default, enabling automatic discovery of the CUDA plugin if you're using the normal/tpu build.

Tested:

```
# python
>>> import os
>>> os.environ['TF_CPP_MIN_LOG_LEVEL'] = '0'
>>> os.environ['TF_CPP_VMODULE'] = 'pjrt_registry=5'
>>> import torch_xla
2024-06-13 17:39:34.217260: I torch_xla/csrc/runtime/pjrt_registry.cc:70] Registering PjRt plugin NEURON
2024-06-13 17:39:34.217363: I torch_xla/csrc/runtime/pjrt_registry.cc:70] Registering PjRt plugin TPU
2024-06-13 17:39:34.217400: I torch_xla/csrc/runtime/pjrt_registry.cc:70] Registering PjRt plugin XPU
>>> torch_xla.device()
WARNING:root:PJRT is now the default runtime. For more information, see https://github.com/pytorch/xla/blob/master/docs/pjrt.md
WARNING:root:libtpu.so and TPU device found. Setting PJRT_DEVICE=TPU.
2024-06-13 17:39:39.318121: I torch_xla/csrc/runtime/pjrt_registry.cc:83] Initializing client for PjRt plugin TPU
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1718300379.343529 1209222 pjrt_api.cc:99] GetPjrtApi was found for tpu at /usr/local/lib/python3.10/site-packages/libtpu/libtpu.so
I0000 00:00:1718300379.343613 1209222 pjrt_api.cc:78] PJRT_Api is set for device type tpu
I0000 00:00:1718300379.343620 1209222 pjrt_api.cc:145] The PJRT plugin has PJRT API version 0.54. The framework PJRT API version is 0.54.
2024-06-13 17:39:42.233641: I external/xla/xla/pjrt/pjrt_c_api_client.cc:127] PjRtCApiClient created.
device(type='xla', index=0)
```

Enables #7249

Nothing changes with the old CUDA build.

```
# PJRT_DEVICE=CUDA python
Python 3.10.14 (main, May 14 2024, 08:51:34) [GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> os.environ['TF_CPP_MIN_LOG_LEVEL'] = '0'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'os' is not defined
>>> import os
>>> os.environ['TF_CPP_MIN_LOG_LEVEL'] = '0'
>>> os.environ['TF_CPP_VMODULE'] = 'pjrt_registry=5'
>>> import torch_xla
>>> torch_xla.devices()
2024-06-13 19:55:16.605772: I torch_xla/csrc/runtime/pjrt_registry.cc:147] Initializing PjRt GPU client...
```

See #6242 