### PR TITLE
Fix benchmark not to assume the input is a list of tensor.

### DIFF
--- a/benchmarks/benchmark_model.py
+++ b/benchmarks/benchmark_model.py
@@ -156,7 +156,6 @@ class BenchmarkModel:
       logger.info(f"Running torch.compile with opts {compilation_opts}")
       self.model_iter_fn = torch.compile(self.model_iter_fn, **compilation_opts)
 
-
   def pick_grad(self):
     if self.benchmark_experiment.test == "eval":
       return torch.no_grad()

--- a/benchmarks/benchmark_model.py
+++ b/benchmarks/benchmark_model.py
@@ -156,6 +156,14 @@ class BenchmarkModel:
       logger.info(f"Running torch.compile with opts {compilation_opts}")
       self.model_iter_fn = torch.compile(self.model_iter_fn, **compilation_opts)
 
+    if keep_model_data_on_cuda:
+
+      def assert_func(t):
+        assert t.device.type.lower(
+        ) == 'cuda', 'When keep_model_data_on_cuda is set, the input data should remain on the CUDA device.'
+
+      pytree.tree_map_only(torch.Tensor, assert_func, self.example_inputs)
+
   def pick_grad(self):
     if self.benchmark_experiment.test == "eval":
       return torch.no_grad()

--- a/benchmarks/benchmark_model.py
+++ b/benchmarks/benchmark_model.py
@@ -156,9 +156,6 @@ class BenchmarkModel:
       logger.info(f"Running torch.compile with opts {compilation_opts}")
       self.model_iter_fn = torch.compile(self.model_iter_fn, **compilation_opts)
 
-    if keep_model_data_on_cuda:
-      assert self.example_inputs[0].device.type.lower(
-      ) == 'cuda', 'When keep_model_data_on_cuda is set, the input data should remain on the CUDA device.'
 
   def pick_grad(self):
     if self.benchmark_experiment.test == "eval":


### PR DESCRIPTION
Currently, it fails with error:
```
Traceback (most recent call last):
  File "xla/benchmarks/experiment_runner.py", line 968, in <module>
    main()
  File "xla/benchmarks/experiment_runner.py", line 964, in main
    runner.run()
  File "xla/benchmarks/experiment_runner.py", line 61, in run
    self.run_single_config()
  File "xla/benchmarks/experiment_runner.py", line 249, in run_single_config
    benchmark_model = self.model_loader.load_model(model_config,
  File "/ansible/pytorch/xla/benchmarks/benchmark_model.py", line 59, in load_model
    benchmark_model.prepare_for_experiment(
  File "/ansible/pytorch/xla/benchmarks/benchmark_model.py", line 160, in prepare_for_experiment
    assert self.example_inputs[0].device.type.lower(
AttributeError: 'list' object has no attribute 'device'
```

It turns out the `self.example_inputs` may not be a list of tensors. 

Test: 
`# CUDA_VISIBLE_DEVICES=0 ZERO_COPY_ENABLED=1 python xla/benchmarks/experiment_runner.py     --suite-name=torchbench     --accelerator=cuda     --progress-bar      --model-config=\{\"model_name\":\"detectron2_fasterrcnn_r_101_c4\"\}     --experiment-config=\{\"accelerator\":\"cuda\",\"xla\":\"PJRT\",\"xla_flags\":null,\"dynamo\":\"openxla\",\"torch_xla2\":null,\"test\":\"train\"\,\"keep_model_data_on_cuda\":true\}     --repeat 1`