### PR TITLE
Clean up and add doc for dynamo_mark_sharding

### DIFF
--- a/docs/spmd.md
+++ b/docs/spmd.md
@@ -414,6 +414,19 @@ pytorch/xla/test/spmd/test_train_spmd_imagenet.py --fake_data --batch_size 128
 
 For more information, please refer to the [SPMD support on GPU RFC](https://github.com/pytorch/xla/issues/6256).
 
+### 
+
+In the 2.3 release, PyTorch/XLA added the custom op `dynamo_mark_sharding` which can be used to perform the activation sharding in a `torch.compile` region. This is the first step to make `torch.compile` + `GSPMD` to be the recommended way of doing the model inference using PyTorch/XLA. Example:
+```
+# Activation output sharding
+import torch_xla.experimental.dynamo_mark_sharding
+device_ids = [i for i in range(self.num_devices)] # List[int]
+mesh_shape = [self.num_devices//2, 1, 2] # List[int]
+axis_names = 'None' # string version of axis_names
+partition_spec = '(0, 1, 2)' # string version of partition spec
+torch.ops.xla.dynamo_mark_sharding(output, device_ids, mesh_shape, axis_names, partition_spec)
+```
+
 
 ## Reference Examples
 

--- a/docs/spmd.md
+++ b/docs/spmd.md
@@ -561,7 +561,7 @@ In the 2.3 release, PyTorch/XLA added the custom op `dynamo_mark_sharding` which
 import torch_xla.experimental.dynamo_mark_sharding
 device_ids = [i for i in range(self.num_devices)] # List[int]
 mesh_shape = [self.num_devices//2, 1, 2] # List[int]
-axis_names = '(data, model)' # string version of axis_names
-partition_spec = '(model, data)' # string version of partition spec
+axis_names = "('data', 'model')" # string version of axis_names
+partition_spec = "('data', 'model')" # string version of partition spec
 torch.ops.xla.dynamo_mark_sharding(output, device_ids, mesh_shape, axis_names, partition_spec)
 ```

--- a/docs/spmd.md
+++ b/docs/spmd.md
@@ -414,19 +414,6 @@ pytorch/xla/test/spmd/test_train_spmd_imagenet.py --fake_data --batch_size 128
 
 For more information, please refer to the [SPMD support on GPU RFC](https://github.com/pytorch/xla/issues/6256).
 
-### 
-
-In the 2.3 release, PyTorch/XLA added the custom op `dynamo_mark_sharding` which can be used to perform the activation sharding in a `torch.compile` region. This is the first step to make `torch.compile` + `GSPMD` to be the recommended way of doing the model inference using PyTorch/XLA. Example:
-```
-# Activation output sharding
-import torch_xla.experimental.dynamo_mark_sharding
-device_ids = [i for i in range(self.num_devices)] # List[int]
-mesh_shape = [self.num_devices//2, 1, 2] # List[int]
-axis_names = 'None' # string version of axis_names
-partition_spec = '(0, 1, 2)' # string version of partition spec
-torch.ops.xla.dynamo_mark_sharding(output, device_ids, mesh_shape, axis_names, partition_spec)
-```
-
 
 ## Reference Examples
 
@@ -565,3 +552,16 @@ the XLA-based auto-sharding pass:
 - `XLA_AUTO_SPMD_MESH`: logical mesh shape to be used for auto-sharding. For example,
 `XLA_AUTO_SPMD_MESH=2,2` corresponds to a 2-by-2 mesh with 4 global devices. If unset,
 a default device mesh shape of `num_devices,1` will be used.
+
+### Activation Sharding
+
+In the 2.3 release, PyTorch/XLA added the custom op `dynamo_mark_sharding` which can be used to perform the activation sharding in a `torch.compile` region. This is part of our ongoing effort to make `torch.compile` + `GSPMD` to be the recommended way of doing the model inference using PyTorch/XLA. Example of using this custom op:
+```
+# Activation output sharding
+import torch_xla.experimental.dynamo_mark_sharding
+device_ids = [i for i in range(self.num_devices)] # List[int]
+mesh_shape = [self.num_devices//2, 1, 2] # List[int]
+axis_names = 'None' # string version of axis_names
+partition_spec = '(0, 1, 2)' # string version of partition spec
+torch.ops.xla.dynamo_mark_sharding(output, device_ids, mesh_shape, axis_names, partition_spec)
+```

--- a/docs/spmd.md
+++ b/docs/spmd.md
@@ -561,7 +561,7 @@ In the 2.3 release, PyTorch/XLA added the custom op `dynamo_mark_sharding` which
 import torch_xla.experimental.dynamo_mark_sharding
 device_ids = [i for i in range(self.num_devices)] # List[int]
 mesh_shape = [self.num_devices//2, 1, 2] # List[int]
-axis_names = 'None' # string version of axis_names
-partition_spec = '(0, 1, 2)' # string version of partition spec
+axis_names = '(data, model)' # string version of axis_names
+partition_spec = '(model, data)' # string version of partition spec
 torch.ops.xla.dynamo_mark_sharding(output, device_ids, mesh_shape, axis_names, partition_spec)
 ```

--- a/torch_xla/distributed/spmd/xla_sharding.py
+++ b/torch_xla/distributed/spmd/xla_sharding.py
@@ -521,10 +521,9 @@ def disable_manual_sharding(t: Union[torch.Tensor, XLAShardedTensor],
 
 
 @xr.requires_pjrt
-def mark_sharding(t: Union[torch.Tensor, XLAShardedTensor],
-                  mesh: Mesh,
-                  partition_spec: Tuple[Union[Tuple, int, str, None]],
-                  use_dynamo_custom_op: bool = False) -> XLAShardedTensor:
+def mark_sharding(
+    t: Union[torch.Tensor, XLAShardedTensor], mesh: Mesh,
+    partition_spec: Tuple[Union[Tuple, int, str, None]]) -> XLAShardedTensor:
   """
     Annotates the tensor provided with XLA partition spec. Internally,
     it annotates the corresponding XLATensor as sharded for the XLA SpmdPartitioner pass.
@@ -573,15 +572,9 @@ def mark_sharding(t: Union[torch.Tensor, XLAShardedTensor],
   assert len(t.shape) == len(partition_spec), \
     f"Partition spec length ({len(partition_spec)}) should be equal to the input rank ({len(t.shape)})."
 
-  if use_dynamo_custom_op:
-    # Allows Dynamo to capture mark_sharding op
-    annotate_func = torch_xla._XLAC._xla_mark_sharding_dynamo_custom_op
-    annotate_func(
-        unwrap_sharded_tensor(t), *mesh._get_op_sharding_args(partition_spec))
-  else:
-    op_sharding = mesh.get_op_sharding(partition_spec)
-    annotate_func = torch_xla._XLAC._xla_mark_sharding
-    annotate_func(unwrap_sharded_tensor(t), op_sharding)
+  op_sharding = mesh.get_op_sharding(partition_spec)
+  annotate_func = torch_xla._XLAC._xla_mark_sharding
+  annotate_func(unwrap_sharded_tensor(t), op_sharding)
   return wrap_as_sharded_tensor(t)
 
 


### PR DESCRIPTION
1. Clean up unused code for dynamo_mark_sharding (remove flag `use_dynamo_custom_op` since it's not used anymore) 
2. Update spmd docs with an example.