### PR TITLE
Avoid log spam (#7278)

### DIFF
--- a/torch_xla/csrc/runtime/pjrt_registry.cc
+++ b/torch_xla/csrc/runtime/pjrt_registry.cc
@@ -82,6 +82,9 @@ InitializePjRt(const std::string& device_type) {
     if (plugin) {
       TF_VLOG(1) << "Initializing client for PjRt plugin " << device_type;
 
+      // Init the absl logging to avoid the log spam.
+      absl::InitializeLog();
+
       std::shared_ptr<xla::KeyValueStoreInterface> kv_store = nullptr;
       if (plugin->requires_xla_coordinator()) {
         int local_process_rank = sys_util::GetEnvInt(


### PR DESCRIPTION
Reason:
This is a regression. Without this fix, PyTorch/XLA will always output a log spam about PJRT version upon loading.

Risk:
Low.