### PR TITLE
Remove use_dynamo_custom_op flag from unit tests

### DIFF
--- a/test/spmd/test_dynamo_spmd.py
+++ b/test/spmd/test_dynamo_spmd.py
@@ -30,8 +30,7 @@ class SimpleLinear(nn.Module):
 
   def forward(self, x):
     if self.mesh and 'xla' in str(self.fc2.weight.device):
-      xs.mark_sharding(
-          self.fc2.weight, self.mesh, (1, 0), use_dynamo_custom_op=True)
+      xs.mark_sharding(self.fc2.weight, self.mesh, (1, 0))
     y = self.relu(self.fc1(x))
     z = self.fc2(y)
     return self.fc3(z)
@@ -183,52 +182,6 @@ class DynamoSpmdInferenceTest(test_xla_sharding_base.XlaShardingTest):
       os.environ['XLA_DYNAMO_INPUT_SHARDING_CHECK_THRESHOLD'] = saved_var
     else:
       del os.environ['XLA_DYNAMO_INPUT_SHARDING_CHECK_THRESHOLD']
-
-  def test_dynamo_spmd_mark_sharding_outside_of_compile(self):
-    device = xm.xla_device()
-    linear = SimpleLinear().to(device)
-    linear.eval()
-    xla_x = torch.randn(1, 128, device=device)
-    xs.mark_sharding(
-        linear.fc2.weight,
-        self._get_mesh((1, self.n_devices)), (1, 0),
-        use_dynamo_custom_op=True)
-    xla_res = linear(xla_x)
-    xm.mark_step()
-
-    dynamo_linear = torch.compile(linear, backend="openxla")
-    dynamo_res = dynamo_linear(xla_x)
-    torch.allclose(xla_res.cpu(), dynamo_res.cpu())
-
-    # Ensure that another run with same input does not trigger additional compilation
-    compile_count = met.metric_data('CompileTime')[0]
-    dynamo_res = dynamo_linear(xla_x)
-    self.assertEqual(met.metric_data('CompileTime')[0], compile_count)
-
-  # https://github.com/pytorch/xla/pull/6921#issuecomment-2062106737
-  @unittest.skip("Failing in CI")
-  def test_mark_sharding_inside_compile(self):
-    met.clear_counters()
-    device = xm.xla_device()
-    mesh = self._get_mesh((1, self.n_devices))
-
-    # Passing this `mesh` as a parameter to `SimpleLinear` will call the dynamo custom op
-    # variant of mark_sharding inside the forward function.
-    linear = SimpleLinear(mesh=mesh).to(device)
-    linear.eval()
-
-    xla_x = torch.randn(1, 128, device=device)
-    xla_res = linear(xla_x)
-    xm.mark_step()
-
-    dynamo_linear = torch.compile(linear, backend="openxla")
-    dynamo_res = dynamo_linear(xla_x)
-    torch.allclose(xla_res.cpu(), dynamo_res.cpu())
-
-    # Ensure that another run with same input does not trigger additional compilation
-    compile_count = met.metric_data('CompileTime')[0]
-    dynamo_res = dynamo_linear(xla_x)
-    self.assertEqual(met.metric_data('CompileTime')[0], compile_count)
 
   def test_dynamo_spmd_basic_with_dynamo_mark_sharding(self):
     device = xm.xla_device()


### PR DESCRIPTION
https://github.com/pytorch/xla/pulls?q=is%3Apr+is%3Aclosed removed `use_dynamo_custom_op` flag. We should've removed it from the unit tests as well. 

The unit tests `test_dynamo_spmd_mark_sharding_outside_of_compile` and `test_mark_sharding_inside_compile` can be removed, since we don't use the `use_dynamo_custom_op` flags anymore. 

The existing tests `test_dynamo_spmd_basic_with_dynamo_mark_sharding` and `test_dynamo_spmd_activation_sharding_with_dynamo_mark_sharding` are sufficient to test the dynamo mark_sharding custom op. 

Tests:
Passing locally:
```
(base) wonjoo@wonjoo-cpu:~/pytorch/xla$ python test/spmd/test_dynamo_spmd.py 
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1718408313.046367 2993774 cpu_client.cc:478] TfrtCpuClient created.
.s....s.
----------------------------------------------------------------------
Ran 8 tests in 1.093s

OK (skipped=2)
```