### PR TITLE
added argsort support

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -14,7 +14,6 @@ skiplist = {
     "__rpow__",
     "_segment_reduce",
     "_upsample_bilinear2d_aa",
-    "argsort",
     "as_strided",
     "as_strided_scatter",
     "baddbmm",

--- a/experimental/torch_xla2/torch_xla2/ops/jtorch.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jtorch.py
@@ -72,7 +72,7 @@ def _torch_angle(input):
 @register_function(torch.argsort)
 def _torch_argsort(input, dim=-1, descending=False, stable=False):
   expanded = False
-  if input == 0:
+  if input.ndim == 0:
     # for self of rank 0:
     # torch.any(x, 0), torch.any(x, -1) works;
     # torch.any(x, 1) throws out of bounds, so it's


### PR DESCRIPTION
Remove `argsort` from the skip list and fix the `test_ops.py` error failures.