### PR TITLE
Refactor `should_save` Method in Checkpoint Manager to Avoid Saving at Step 0

### DIFF
--- a/torch_xla/experimental/distributed_checkpoint/manager.py
+++ b/torch_xla/experimental/distributed_checkpoint/manager.py
@@ -251,7 +251,7 @@ class CheckpointManager:
           f"Preemption sync point reached at step {step}. Triggering a checkpoint."
       )
       preemption_detected = True
-    return step % self.save_interval == 0 or preemption_detected
+    return step % self.save_interval == self.save_interval - 1 or preemption_detected
 
   def save(self,
            step,


### PR DESCRIPTION
## Description

This pull request modifies the `should_save` method in the checkpoint manager to prevent saving at step 0. In the original implementation, the method would save at step 0 due to the condition `step % self.save_interval == 0`. The new condition, `step % self.save_interval == self.save_interval - 1`, ensures that saving occurs at the last step before a multiple of the save interval, thus avoiding a save at step 0.

### Detailed Changes
- **Original Condition:** `return step % self.save_interval == 0 or preemption_detected`
- **Modified Condition:** `return step % self.save_interval == self.save_interval - 1 or preemption_detected`

### Benefits
- **Avoid Initial Save:** This change prevents unnecessary saves at the very start of the process (step 0), which can be redundant or undesirable in certain workflows.
