### PR TITLE
Fix: Ensure checkpoint deletion only occurs on rank 0

### DIFF
--- a/torch_xla/experimental/distributed_checkpoint/manager.py
+++ b/torch_xla/experimental/distributed_checkpoint/manager.py
@@ -190,17 +190,18 @@ class CheckpointManager:
     return os.path.join(self.base_path, str(step))
 
   def _delete_chkpt_at_step(self, step):
-    path = self._get_path(step)
-    fs, raw_path = url_to_fs(path)
-    if fs.exists(raw_path):
-      fs.rm(raw_path, recursive=True)
+    if dist.get_rank(self.pg) == 0:
+      path = self._get_path(step)
+      fs, raw_path = url_to_fs(path)
+      if fs.exists(raw_path):
+        fs.rm(raw_path, recursive=True)
 
   def _release_oldest_checkpoints(self):
     """
     Delete oldest checkpoints until the number of tracked checkpoints is below
     self.max_to_keep. This operation is only execution on the rank 0 process.
     """
-    if dist.get_rank(self.pg) == 0 and self.max_to_keep > 0:
+    if self.max_to_keep > 0:
       while len(self._tracked_chkpts) > self.max_to_keep:
         oldest_chkpt = self._tracked_chkpts.popleft()
         self._delete_chkpt_at_step(oldest_chkpt.step)
@@ -220,8 +221,7 @@ class CheckpointManager:
     with self._save_mutex:
       path = self._get_path(step)
       # Delete any existing checkpoint at the current step.
-      if dist.get_rank(self.pg) == 0:
-        self._delete_chkpt_at_step(step)
+      self._delete_chkpt_at_step(step)
       dist_cp.save(
           state_dict=state_dict,
           storage_writer=FsspecWriter(

--- a/torch_xla/experimental/distributed_checkpoint/manager.py
+++ b/torch_xla/experimental/distributed_checkpoint/manager.py
@@ -220,7 +220,8 @@ class CheckpointManager:
     with self._save_mutex:
       path = self._get_path(step)
       # Delete any existing checkpoint at the current step.
-      self._delete_chkpt_at_step(step)
+      if dist.get_rank(self.pg) == 0:
+        self._delete_chkpt_at_step(step)
       dist_cp.save(
           state_dict=state_dict,
           storage_writer=FsspecWriter(


### PR DESCRIPTION
**Description:**

This pull request addresses an issue where checkpoint deletions were occurring on multiple ranks during distributed training, causing input/output errors. The update ensures that checkpoint deletions are only performed on rank 0 to prevent these errors.

**Error Trace:**

```
Traceback (most recent call last):
[rank23]:   File "/home/huzama/.local/lib/python3.10/site-packages/torch_xla/experimental/distributed_checkpoint/manager.py", line 270, in save
[rank23]:     self._save(step, state_dict)
[rank23]:   File "/home/huzama/.local/lib/python3.10/site-packages/torch_xla/experimental/distributed_checkpoint/manager.py", line 220, in _save
[rank23]:     self._delete_chkpt_at_step(step)
[rank23]:   File "/home/huzama/.local/lib/python3.10/site-packages/torch_xla/experimental/distributed_checkpoint/manager.py", line 193, in _delete_chkpt_at_step
[rank23]:     fs.rm(raw_path, recursive=True)
[rank23]:   File "/home/huzama/.local/lib/python3.10/site-packages/fsspec/implementations/local.py", line 185, in rm
[rank23]:     shutil.rmtree(p)
[rank23]:   File "/usr/lib/python3.10/shutil.py", line 731, in rmtree
[rank23]:     onerror(os.rmdir, path, sys.exc_info())
[rank23]:   File "/usr/lib/python3.10/shutil.py", line 729, in rmtree
[rank23]:     os.rmdir(path)
[rank23]: OSError: [Errno 5] Input/output error: 'PATH'
```

**Code Update:**

*Old Code:*
```python
self._delete_chkpt_at_step(step)
```

*New Code:*
```python
if dist.get_rank(self.pg) == 0:
    self._delete_chkpt_at_step(step)
```