### PR TITLE
[torch_xla2] Prototype of `torch.distributed` backend

### DIFF
--- a/.github/workflows/torch_xla2.yml
+++ b/.github/workflows/torch_xla2.yml
@@ -41,4 +41,4 @@ jobs:
         shell: bash
         run: |
           pytest test/
-          pytest -n 0 test_dist/
+          XLA_FLAGS=--xla_force_host_platform_device_count=4 pytest -n 0 test_dist/

--- a/.github/workflows/torch_xla2.yml
+++ b/.github/workflows/torch_xla2.yml
@@ -41,3 +41,4 @@ jobs:
         shell: bash
         run: |
           pytest test/
+          pytest -n 0 test_dist/

--- a/experimental/torch_xla2/test/test_distributed.py
+++ b/experimental/torch_xla2/test/test_distributed.py
@@ -1,0 +1,42 @@
+import os
+import jax
+import numpy as np
+
+import pytest
+import torch.distributed as dist
+import torch_xla2
+import torch_xla2.distributed
+
+
+@pytest.fixture(scope='module')
+def multi_cpu():
+  # TODO(wcromar): support other devices
+  jax.config.update('jax_platforms', 'cpu')
+  replicas = 4
+  os.environ["XLA_FLAGS"] = f"--xla_force_host_platform_device_count={replicas}"
+
+  os.environ["MASTER_ADDR"] = "localhost"
+  os.environ["MASTER_PORT"] = "12355"
+  dist.init_process_group(backend="jax", init_method="jax://")
+
+  yield jax.device_count()
+  dist.destroy_process_group()
+
+
+@pytest.mark.parametrize(('op', 'expected'), [
+  (dist.ReduceOp.SUM, sum(range(4))),
+  (dist.ReduceOp.AVG, sum(range(4)) / 4),
+  (dist.ReduceOp.MIN, 0),
+  (dist.ReduceOp.MAX, 3),
+])
+def test_all_reduce(op, expected, multi_cpu):
+  device_count = multi_cpu
+
+  def f(index):
+    dist.all_reduce(index, op)
+    return index
+
+  res = torch_xla2.distributed.spawn(f)
+
+  expected_tensors = [expected for _ in range(device_count)]
+  np.testing.assert_equal(res.numpy(), expected_tensors)

--- a/experimental/torch_xla2/test/test_distributed.py
+++ b/experimental/torch_xla2/test/test_distributed.py
@@ -3,6 +3,7 @@ import jax
 import numpy as np
 
 import pytest
+import torch
 import torch.distributed as dist
 import torch_xla2
 import torch_xla2.distributed
@@ -23,6 +24,23 @@ def multi_cpu():
   dist.destroy_process_group()
 
 
+def test_all_gather(multi_cpu):
+  device_count = multi_cpu
+
+  def f(index: torch_xla2.tensor.XLATensor2):
+    with torch_xla2.default_env():
+      tensor_list = [torch.tensor(0) for _ in range(device_count)]
+    dist.all_gather(tensor_list, index)
+    # TODO(wcromar): `spawn` is weird with multiple returns. Stack to return one
+    # result. This may not be a problem with `shmap`.
+    return torch.stack(tensor_list)
+
+  res = torch_xla2.distributed.spawn(f)
+
+  expected_tensors = [[0, 1, 2, 3] for _ in range(device_count)]
+  np.testing.assert_equal([r.numpy() for r in res], expected_tensors)
+
+
 @pytest.mark.parametrize(('op', 'expected'), [
   (dist.ReduceOp.SUM, sum(range(4))),
   (dist.ReduceOp.AVG, sum(range(4)) / 4),
@@ -40,3 +58,21 @@ def test_all_reduce(op, expected, multi_cpu):
 
   expected_tensors = [expected for _ in range(device_count)]
   np.testing.assert_equal(res.numpy(), expected_tensors)
+
+
+@pytest.mark.parametrize(('rank', 'expected'), [
+  (0, 0),
+  (2, 2),
+])
+def test_broadcast(rank, expected, multi_cpu):
+  device_count = multi_cpu
+
+  def f(index):
+    dist.broadcast(index, rank)
+    return index
+
+  res = torch_xla2.distributed.spawn(f)
+
+  expected_tensors = [expected for _ in range(device_count)]
+  np.testing.assert_equal(res.numpy(), expected_tensors)
+

--- a/experimental/torch_xla2/test_dist/README.md
+++ b/experimental/torch_xla2/test_dist/README.md
@@ -1,0 +1,4 @@
+This directory contains multi-accelerator tests that cannot be distributed with
+`pytest-xdist`.
+
+TODO: merge these into `tests/`

--- a/experimental/torch_xla2/test_dist/test_distributed.py
+++ b/experimental/torch_xla2/test_dist/test_distributed.py
@@ -11,11 +11,10 @@ import torch_xla2.distributed
 
 @pytest.fixture(scope="module")
 def multi_cpu():
-  # TODO(wcromar): support other devices
-  jax.config.update("jax_platforms", "cpu")
-  replicas = 4
-  os.environ["XLA_FLAGS"] = f"--xla_force_host_platform_device_count={replicas}"
-  assert jax.device_count() == 4
+  # TODO(wcromar): support other device counts
+  assert (
+    jax.device_count() == 4
+  ), "Set XLA_FLAGS=--xla_force_host_platform_device_count=4 if on CPU"
 
   os.environ["MASTER_ADDR"] = "localhost"
   os.environ["MASTER_PORT"] = "12355"

--- a/experimental/torch_xla2/torch_xla2/__init__.py
+++ b/experimental/torch_xla2/torch_xla2/__init__.py
@@ -3,6 +3,7 @@ import os
 import torch
 from torch.utils import _pytree as pytree
 from torch_xla2 import tensor
+from torch_xla2 import distributed  # noqa: F401
 
 
 __all__ = [

--- a/experimental/torch_xla2/torch_xla2/distributed.py
+++ b/experimental/torch_xla2/torch_xla2/distributed.py
@@ -1,0 +1,85 @@
+import datetime
+import os
+from typing import List, Optional
+
+import jax
+import torch
+import torch.distributed as dist
+from torch._C._distributed_c10d import ProcessGroup
+import torch_xla2
+import numpy as np
+
+
+class ProcessGroupJax(ProcessGroup):
+  def __init__(self, prefix_store, rank, size, timeout):
+    super().__init__(rank, size)
+    self.prefix_store = prefix_store  # reserved for future use.
+    self.timeout = timeout
+
+  def getBackendName(self):
+    return "jax"
+
+  def allreduce(
+    self,
+    tensors: List[torch.Tensor],
+    opts: dist.AllreduceOptions = ...,
+  ):
+    for t in tensors:
+      assert isinstance(t, torch_xla2.tensor.XLATensor2)
+      match opts.reduceOp:
+        case dist.ReduceOp.SUM:
+          res = jax.lax.psum(t._elem, axis_name="torch_dist")
+        case dist.ReduceOp.AVG:
+          res = jax.lax.pmean(t._elem, axis_name="torch_dist")
+        case dist.ReduceOp.MIN:
+          res = jax.lax.pmin(t._elem, axis_name="torch_dist")
+        case dist.ReduceOp.MAX:
+          res = jax.lax.pmax(t._elem, axis_name="torch_dist")
+        case _:
+          raise RuntimeError(f"Reduce op {opts.reduceOp} not implemented")
+
+      t._elem = res
+
+    fut = torch.futures.Future()
+    fut.set_result(tensors)
+    return torch._C._distributed_c10d._create_work_from_future(fut)
+
+
+dist.Backend.register_backend("jax", ProcessGroupJax)
+
+
+def jax_rendezvous_handler(
+  url: str, timeout: datetime.timedelta = ..., **kwargs
+):
+  # TODO(wcromar): jax.distributed.initialize(...) for multiprocess on GPU
+  # TODO(wcromar): Can we use the XLA coordinator as a Store? This isn't part
+  # of their public Python API
+  master_ip = os.environ["MASTER_ADDR"]
+  master_port = int(os.environ["MASTER_PORT"])
+  # TODO(wcromar): Use `torchrun`'s store if available
+  store = dist.TCPStore(
+    master_ip,
+    master_port,
+    jax.process_count(),
+    is_master=jax.process_index() == 0,
+  )
+
+  yield (store, jax.process_index(), jax.process_count())
+
+
+dist.register_rendezvous_handler("jax", jax_rendezvous_handler)
+
+
+# TODO(wcromar): types
+def spawn(f, args=(), env: Optional[torch_xla2.tensor.Environment] = None):
+  env = env or torch_xla2.default_env()
+
+  def jax_wrapper(index, jax_args):
+    index, args = env.j2t_iso([index, jax_args])
+    torch_outputs = f(index, *args)
+    return env.t2j_iso(torch_outputs)
+
+  jax_outputs = jax.pmap(jax_wrapper, axis_name="torch_dist")(
+    np.arange(jax.device_count()), env.t2j_iso(args)
+  )
+  return env.j2t_iso(jax_outputs)

--- a/experimental/torch_xla2/torch_xla2/distributed.py
+++ b/experimental/torch_xla2/torch_xla2/distributed.py
@@ -44,9 +44,7 @@ class ProcessGroupJax(ProcessGroup):
     assert isinstance(input_tensor, torch_xla2.tensor.XLATensor2)
     output = jax.lax.all_gather(input_tensor._elem, axis_name="torch_dist")
     output_size = jax.numpy.shape(output)[0]
-    # output_arrays = jnp.unstack(output)
 
-    # assert len(output_tensors) == len(output_arrays)
     assert len(output_tensors) == output_size
     for i, t in enumerate(output_tensors):
       assert isinstance(t, torch_xla2.tensor.XLATensor2)


### PR DESCRIPTION
Rough implementation of `torch.distributed` using `jax.lax` collective ops in a `ProcessGroup`. This API is very likely to change before any stable release to better support traceability.