### PR TITLE
Initialize benchmarks with device type.

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -308,7 +308,7 @@ class TorchBenchModel(BenchmarkModel):
     # torch.backends.__allow_nonbracketed_mutation_flag = True
 
     if self.should_initialize_on_xla():
-      device = str(self.benchmark_experiment.get_device())
+      device = "xla"
     else:
       # Initialize the model in the given accelerator first. If we are supposed
       # to run on XLA device, move it later. We do this for a couple of reasons:


### PR DESCRIPTION
This PR makes benchmark initialization more consistent. This is in line with https://github.com/pytorch/benchmark/pull/2292, which makes `moco` check for `xla` device for initializing its process group.

cc @miladm @vanbasten23 @zpcore 