### PR TITLE
Support eager mode for multi-process training

### DIFF
--- a/examples/eager/train_decoder_only_eager_multi_process.py
+++ b/examples/eager/train_decoder_only_eager_multi_process.py
@@ -1,0 +1,26 @@
+import sys
+import os
+example_folder = os.path.dirname(os.path.dirname(os.path.abspath(sys.argv[0])))
+sys.path.append(example_folder)
+from train_decoder_only_base import TrainDecoderOnlyBase
+
+import torch_xla.distributed.xla_multiprocessing as xmp
+import torch_xla.core.xla_model as xm
+
+
+class TrainDecoderXLADDP(TrainDecoderOnlyBase):
+
+  def run_optimizer(self):
+    # optimizer_step will call `optimizer.step()` and all_reduce the gradident
+    xm.optimizer_step(self.optimizer)
+
+
+def _mp_fn(index):
+  import torch_xla
+  torch_xla.experimental.eager_mode(True)
+  xla_ddp = TrainDecoderXLADDP()
+  xla_ddp.start_training()
+
+
+if __name__ == '__main__':
+  xmp.spawn(_mp_fn, args=())

--- a/examples/train_decoder_only_base.py
+++ b/examples/train_decoder_only_base.py
@@ -20,7 +20,7 @@ class TrainDecoderOnlyBase():
     self.config = DecoderOnlyConfig()
     self.batch_size = 16
     self.seq_len = 512
-    self.num_steps = 300
+    self.num_steps = 200
     self.num_epochs = 1
     self.train_dataset_len = 1200000  # Roughly the size of Imagenet dataset.
     # For the purpose of this example, we are going to use fake data.

--- a/test/eager/test_eager_all_reduce_in_place.py
+++ b/test/eager/test_eager_all_reduce_in_place.py
@@ -1,0 +1,40 @@
+import torch
+import torch_xla
+
+import torch_xla.core.xla_model as xm
+import torch_xla.debug
+import torch_xla.distributed.xla_multiprocessing as xmp
+import torch_xla.debug.metrics as met
+
+
+def _mp_fn(index):
+  import torch_xla
+  torch_xla.experimental.eager_mode(True)
+
+  device = torch_xla.device()
+
+  if xm.xla_device_hw(device) not in ('TPU', 'CUDA', 'NEURON'):
+    return
+
+  ordinal_tensor_1 = torch.tensor([index], dtype=torch.float).to(device)
+  ordinal_tensor_2 = torch.tensor([index], dtype=torch.int32).to(device)
+  xm.wait_device_ops()
+  met.clear_all()
+
+  # all_reduce with list of tensor as input will be a inplace op. This is
+  # used by the optimizer_step.
+  xm.all_reduce(xm.REDUCE_SUM, [ordinal_tensor_1, ordinal_tensor_2])
+
+  xm.wait_device_ops()
+  assert met.metric_data("EagerOpExecuteTime")[0] == 1
+
+  num_device = torch_xla.runtime.global_runtime_device_count()
+  expected_sum = (num_device - 1) * num_device / 2
+  expected_1 = torch.tensor([(expected_sum)], dtype=torch.float)
+  expected_2 = torch.tensor([(expected_sum)], dtype=torch.int32)
+  assert torch.allclose(expected_1, ordinal_tensor_1.cpu())
+  assert torch.allclose(expected_2, ordinal_tensor_2.cpu())
+
+
+if __name__ == '__main__':
+  xmp.spawn(_mp_fn, args=())

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -207,7 +207,7 @@ function run_xla_op_tests2 {
   run_test "$CDIR/eager/test_eager.py"
   run_test "$CDIR/eager/test_eager_with_xla_compile.py"
   run_test "$CDIR/eager/test_eager_with_torch_compile.py"
-  run_test "$CDIR/eager/test_eager_all_reduce_in_place.py.py"
+  run_test "$CDIR/eager/test_eager_all_reduce_in_place.py"
 }
 
 # All the new xla op tests should go to run_xla_op_tests3

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -207,6 +207,7 @@ function run_xla_op_tests2 {
   run_test "$CDIR/eager/test_eager.py"
   run_test "$CDIR/eager/test_eager_with_xla_compile.py"
   run_test "$CDIR/eager/test_eager_with_torch_compile.py"
+  run_test "$CDIR/eager/train_decoder_only_eager_multi_process.py"
 }
 
 # All the new xla op tests should go to run_xla_op_tests3

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -207,7 +207,7 @@ function run_xla_op_tests2 {
   run_test "$CDIR/eager/test_eager.py"
   run_test "$CDIR/eager/test_eager_with_xla_compile.py"
   run_test "$CDIR/eager/test_eager_with_torch_compile.py"
-  run_test "$CDIR/eager/train_decoder_only_eager_multi_process.py"
+  run_test "$CDIR/eager/test_eager_all_reduce_in_place.py.py"
 }
 
 # All the new xla op tests should go to run_xla_op_tests3

--- a/test/tpu/run_tests.sh
+++ b/test/tpu/run_tests.sh
@@ -43,4 +43,5 @@ TPU_VERSION=$(python -c "import sys; sys.path.remove(''); import torch_xla; prin
 if [[ -n "$TPU_VERSION" && "$TPU_VERSION" == "4" ]]; then
     python3 examples/eager/train_decoder_only_eager.py
     python3 examples/eager/train_decoder_only_eager_with_compile.py
+    python3 examples/eager/train_decoder_only_eager_multi_process.py
 fi

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -351,7 +351,8 @@ void XLATensor::SetIrValue(torch::lazy::Value ir_value, bool inplace) {
   data()->is_cloned = false;
 }
 
-void XLATensor::SetInPlaceIrValue(torch::lazy::Value ir_value) {
+void XLATensor::SetInPlaceIrValue(torch::lazy::Value ir_value,
+                                  bool delay_eager_executation) {
   auto xla_shape = shape();
   if (xla_shape.get().element_type() != GetXlaShape(ir_value).element_type()) {
     ir_value =
@@ -361,7 +362,7 @@ void XLATensor::SetInPlaceIrValue(torch::lazy::Value ir_value) {
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
 
   // in place update should also be triggered eagerly if configured
-  if (graph_executor->UseEagerMode()) {
+  if (graph_executor->UseEagerMode() && !delay_eager_executation) {
     std::vector<XLATensorPtr> xtensors({c10::make_intrusive<XLATensor>(*this)});
     graph_executor->ApplyEagerSync(xtensors);
   }

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -228,7 +228,8 @@ class XLATensor : public torch::lazy::LazyTensor {
   // TODO(alanwaketan): Reuse the upstream ones once Functionalization is done.
   torch::lazy::Value GetIrValue() const;
   void SetIrValue(torch::lazy::Value ir_value, bool inplace = true);
-  void SetInPlaceIrValue(torch::lazy::Value ir_value);
+  void SetInPlaceIrValue(torch::lazy::Value ir_value,
+                         bool delay_eager_executation = false);
 
   // TODO(alanwaketan): Reuse the upstream one once Functionalization is done.
   std::optional<at::Tensor> CurrentTensorData() const;


### PR DESCRIPTION
in place `all_reduce` is used for `optimizer_step` for data parallel training for multi-process. The HLO for
```
  ordinal_tensor_1 = torch.tensor([index], dtype=torch.float).to(device)
  ordinal_tensor_2 = torch.tensor([index], dtype=torch.int32).to(device)

  xm.all_reduce(xm.REDUCE_SUM, [ordinal_tensor_1, ordinal_tensor_2])
```
looks like
```
ENTRY %IrToHlo.27 (p0.1: f32[], p1.2: s32[1], p2.3: f32[1]) -> (f32[1], s32[1]) {
.......
  %all-reduce.12 = (s32[1]{0}, s32[]) all-reduce(s32[1]{0} %get-tuple-element.6, s32[] %get-tuple-element.7), replica_groups={}, constrain_layout=true, to_apply=%AddComputation.8, metadata={op_type="xla__cross_replica_sum" op_name="xla__cross_replica_sum" source_file="/workspaces/dk3/pytorch/xla/torch_xla/core/xla_model.py" source_line=501}
.....
  %get-tuple-element.24 = f32[1]{0} get-tuple-element((f32[1]{0}, f32[]) %all-reduce.23), index=0, metadata={op_type="xla__cross_replica_sum" op_name="xla__cross_replica_sum" source_file="/workspaces/dk3/pytorch/xla/torch_xla/core/xla_model.py" source_line=501}
  %get-tuple-element.13 = s32[1]{0} get-tuple-element((s32[1]{0}, s32[]) %all-reduce.12), index=0, metadata={op_type="xla__cross_replica_sum" op_name="xla__cross_replica_sum" source_file="/workspaces/dk3/pytorch/xla/torch_xla/core/xla_model.py" source_line=501}
  ROOT %tuple.26 = (f32[1]{0}, s32[1]{0}) tuple(f32[1]{0} %get-tuple-element.24, s32[1]{0} %get-tuple-element.13)
}
```

Note that in above HLO we have 2 output but we only `all_reduce` once. Without this change we will eagerly evaluate each output, which result in `all_rduce`  being compiled/execute twice which is not ideal. For ops like `all_reduce` that one ops has multiple outputs, it is better to group the execution and only execute once. 