### PR TITLE
Handle random seed for eager mode

### DIFF
--- a/test/eager/test_eager.py
+++ b/test/eager/test_eager.py
@@ -61,6 +61,21 @@ class Eager(unittest.TestCase):
     self.assertEqual(met.metric_data("EagerOpCompileTime")[0], 1)
     self.assertEqual(met.metric_data("EagerOpExecuteTime")[0], 1)
 
+  def test_eager_random_seed(self):
+    self.assertTrue(torch_xla.experimental.is_eager_mode())
+    device = torch_xla.device()
+
+    met.clear_all()
+    t1 = torch.randn(12, 13, device=device)
+    xm.wait_device_ops()
+    compile_count = met.metric_data("EagerOpCompileTime")[0]
+    t2 = torch.randn(12, 13, device=device)
+    xm.wait_device_ops()
+    new_compile_count = met.metric_data("EagerOpCompileTime")[0]
+    self.assertEqual(compile_count, new_compile_count)
+    # t1 and t2 should not be the same
+    self.assertFalse(torch.allclose(t1.cpu(), t2.cpu()))
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/test/eager/test_eager.py
+++ b/test/eager/test_eager.py
@@ -76,6 +76,19 @@ class Eager(unittest.TestCase):
     # t1 and t2 should not be the same
     self.assertFalse(torch.allclose(t1.cpu(), t2.cpu()))
 
+  def test_eager_set_random_seed(self):
+    self.assertTrue(torch_xla.experimental.is_eager_mode())
+    device = torch_xla.device()
+
+    old_seed = 1234
+    xm.set_rng_state(old_seed)
+    t1 = torch.randn(12, 13, device=device)
+    new_seed = xm.get_rng_state()
+    self.assertNotEqual(new_seed, old_seed)
+    xm.set_rng_state(old_seed)
+    t2 = torch.randn(12, 13, device=device)
+    self.assertTrue(torch.allclose(t1.cpu(), t2.cpu()))
+
 
 if __name__ == '__main__':
   test = unittest.main()


### PR DESCRIPTION
`seed_ir_value` was reset by `mark_step` but we don't call `mark_step` in eager mode. In eager mode it make more sense to manually rotate the `devctx->seed` and always create a new seed IR