### PR TITLE
tests for tpu-info CLI

### DIFF
--- a/test/tpu/run_tests.sh
+++ b/test/tpu/run_tests.sh
@@ -45,3 +45,10 @@ if [[ -n "$TPU_VERSION" && "$TPU_VERSION" == "4" ]]; then
     python3 examples/eager/train_decoder_only_eager_with_compile.py
     python3 examples/eager/train_decoder_only_eager_multi_process.py
 fi
+
+# Test `tpu-info` CLI compatibility
+# https://github.com/google/cloud-accelerator-diagnostics/tree/main/tpu_info
+pip install -U -r test/tpu/tpu_info/requirements.txt 'grpcio>=1.64.1'
+# TODO: remove `cd` when we switch to Python 3.11 and use `-P`
+cd ..
+python -m pytest -v xla/test/tpu/tpu_info/test_cli.py

--- a/test/tpu/run_tests.sh
+++ b/test/tpu/run_tests.sh
@@ -48,7 +48,5 @@ fi
 
 # Test `tpu-info` CLI compatibility
 # https://github.com/google/cloud-accelerator-diagnostics/tree/main/tpu_info
-pip install -U -r test/tpu/tpu_info/requirements.txt 'grpcio>=1.64.1'
-# TODO: remove `cd` when we switch to Python 3.11 and use `-P`
-cd ..
-python -m pytest -v xla/test/tpu/tpu_info/test_cli.py
+pip install -r test/tpu/tpu_info/requirements.txt
+python3 test/tpu/tpu_info/test_cli.py

--- a/test/tpu/tpu_info/requirements.txt
+++ b/test/tpu/tpu_info/requirements.txt
@@ -1,2 +1,2 @@
-pytest
 git+https://github.com/google/cloud-accelerator-diagnostics/#subdirectory=tpu_info
+'grpcio>=1.64.1'

--- a/test/tpu/tpu_info/requirements.txt
+++ b/test/tpu/tpu_info/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+git+https://github.com/google/cloud-accelerator-diagnostics/#subdirectory=tpu_info

--- a/test/tpu/tpu_info/requirements.txt
+++ b/test/tpu/tpu_info/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/google/cloud-accelerator-diagnostics/#subdirectory=tpu_info
-'grpcio>=1.64.1'
+grpcio>=1.64.1

--- a/test/tpu/tpu_info/test_cli.py
+++ b/test/tpu/tpu_info/test_cli.py
@@ -1,119 +1,124 @@
+import threading
+from absl.testing import absltest, parameterized
 import contextlib
 import multiprocessing
 import os
-import threading
 from typing import Dict, Optional
-import pytest
 import torch_xla as xla
 import torch_xla.runtime as xr
 import torch_xla.distributed.xla_multiprocessing as xmp
 from tpu_info import cli, device, metrics
 
 
-@pytest.fixture
-def local_tpus():
-  chip_type, num_chips = device.get_local_chips()
-  assert chip_type, "Expected local TPU chip"
-  yield chip_type, num_chips
+class TpuInfoCliTest(parameterized.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    xr.set_device_type("TPU")
+    chip_type, num_chips = device.get_local_chips()
+    assert chip_type is not None
+    cls.chip_type = chip_type
+    cls.num_chips = num_chips
+
+  def setUp(self):
+    os.environ.pop("TPU_RUNTIME_METRICS_PORTS", None)
+
+  def tearDown(self):
+    os.environ.pop("TPU_RUNTIME_METRICS_PORTS", None)
+
+  @staticmethod
+  def _init_tpu_and_wait(
+      # accept index as first arg to make xmp.spawn happy
+      index: int,
+      q: multiprocessing.Queue,
+      done: multiprocessing.Event,
+      env: Optional[Dict[str, str]] = None,
+  ):
+    if env:
+      os.environ.update(**env)
+    xla.device()
+    q.put(os.getpid())
+    done.wait()
+
+  @contextlib.contextmanager
+  def _torch_xla_process(self, extra_env: Dict[str, str]):
+    with multiprocessing.Manager() as m:
+      q = m.Queue()
+      done = m.Event()
+      env = {
+          "TPU_RUNTIME_METRICS_PORTS": "8431",
+      }
+      env.update(extra_env)
+      p = multiprocessing.Process(
+          target=self._init_tpu_and_wait, args=(0, q, done, env))
+      p.start()
+      pid = q.get(timeout=10.0)
+      with contextlib.ExitStack() as e:
+        e.callback(done.set)
+        yield pid
+      # Wait for process to exit before next test
+      p.join()
+
+  @parameterized.named_parameters([
+      ("all_chips", {}),
+      ("one_chip", {
+          "TPU_VISIBLE_CHIPS": "0",
+          "TPU_PROCESS_BOUNDS": "1,1,1",
+          "TPU_CHIPS_PER_PROCESS_BOUNDS": "1,1,1"
+      }),
+  ])
+  def test_single_process_e2e(self, extra_env):
+    with self._torch_xla_process(extra_env) as subprocess_pid:
+      owners = device.get_chip_owners()
+      for _, pid in owners.items():
+        self.assertEqual(pid, subprocess_pid)
+      usages = metrics.get_chip_usage(self.chip_type)
+      for u in usages:
+        self.assertGreater(u.total_memory, 0)
+        self.assertEqual(u.duty_cycle_pct, 0.0)
+        one_gb = 1 << 30
+        self.assertLess(u.memory_usage, one_gb)
+      # TODO: check output
+      cli.print_chip_info()
+
+  @contextlib.contextmanager
+  def _torch_xla_spawn(self):
+    with multiprocessing.Manager() as m:
+      q = m.Queue()
+      done = m.Event()
+      # TODO: This should get set automatically by libtpu
+      os.environ["TPU_RUNTIME_METRICS_PORTS"] = ",".join(
+          str(i) for i in range(8431, 8431 + self.num_chips))
+      # HACK: run xmp.spawn in a thread because `join` arg is not implemented
+      t = threading.Thread(
+          target=lambda: xmp.spawn(self._init_tpu_and_wait, args=(q, done)))
+      t.start()
+
+      # v2 and v3 may have duplicates due to multithreading
+      child_pids = set()
+      for _ in range(self.chip_type.value.accelerators_per_chip *
+                     self.num_chips):
+        child_pids.add(q.get(timeout=10.0))
+      with contextlib.ExitStack() as e:
+        e.callback(done.set)
+        yield child_pids
+
+      t.join()
+
+  def test_multiprocessing_e2e(self):
+    with self._torch_xla_spawn() as subprocess_pids:
+      owners = device.get_chip_owners()
+      self.assertSetEqual(
+          set(pid for _, pid in owners.items()), subprocess_pids)
+      usages = metrics.get_chip_usage(self.chip_type)
+      for u in usages:
+        self.assertGreater(u.total_memory, 0)
+        self.assertEqual(u.duty_cycle_pct, 0.0)
+        one_gb = 1 << 30
+        self.assertLess(u.memory_usage, one_gb)
+      # TODO: check output
+      cli.print_chip_info()
 
 
-@pytest.fixture(scope="module", autouse=True)
-def use_tpu():
-  xr.set_device_type("TPU")
-
-
-def _init_tpu_and_wait(
-    # accept index as first arg to make xmp.spawn happy
-    index: int,
-    q: multiprocessing.Queue,
-    done: multiprocessing.Event,
-    env: Optional[Dict[str, str]] = None,
-):
-  if env:
-    os.environ.update(**env)
-  xla.device()
-  q.put(os.getpid())
-  done.wait()
-
-
-@pytest.fixture(params=[
-    {},
-    {
-        "TPU_VISIBLE_CHIPS": "0",
-        "TPU_PROCESS_BOUNDS": "1,1,1",
-        "TPU_CHIPS_PER_PROCESS_BOUNDS": "1,1,1",
-    },
-])
-def torch_xla_process(request: Dict[str, str]):
-  extra_env = request.param
-  with multiprocessing.Manager() as m:
-    q = m.Queue()
-    done = m.Event()
-    env = {
-        "TPU_RUNTIME_METRICS_PORTS": "8431",
-    }
-    env.update(extra_env)
-    p = multiprocessing.Process(
-        target=_init_tpu_and_wait, args=(0, q, done, env))
-    p.start()
-    pid = q.get(timeout=10.0)
-    with contextlib.ExitStack() as e:
-      e.callback(done.set)
-      yield pid
-    # Wait for process to exit before next test
-    p.join()
-
-
-def test_single_process_e2e(torch_xla_process, local_tpus):
-  chip_type, _ = local_tpus
-  owners = device.get_chip_owners()
-  for _, pid in owners.items():
-    assert pid == torch_xla_process
-  usages = metrics.get_chip_usage(chip_type)
-  for u in usages:
-    assert u.total_memory > 0
-    assert u.duty_cycle_pct == 0.0
-    # There's a small amount of memory usage when libtpu is initialized
-    one_gb = 1 << 30
-    assert u.memory_usage < one_gb
-  # TODO: check output
-  cli.print_chip_info()
-
-
-@pytest.fixture
-def torch_xla_spawn(local_tpus):
-  chip_type, num_chips = local_tpus
-  with multiprocessing.Manager() as m:
-    q = m.Queue()
-    done = m.Event()
-    # TODO: This should get set automatically by libtpu
-    os.environ["TPU_RUNTIME_METRICS_PORTS"] = ",".join(
-        str(i) for i in range(8431, 8431 + num_chips))
-    # HACK: run xmp.spawn in a thread because `join` arg is not implemented
-    t = threading.Thread(
-        target=lambda: xmp.spawn(_init_tpu_and_wait, args=(q, done)))
-    t.start()
-    child_pids = set()
-    for _ in range(chip_type.value.accelerators_per_chip * num_chips):
-      child_pids.add(q.get(timeout=10.0))
-    with contextlib.ExitStack() as e:
-      e.callback(done.set)
-      yield child_pids
-    os.environ.pop("TPU_RUNTIME_METRICS_PORTS")
-    t.join()
-
-
-def test_multiprocessing_e2e(torch_xla_spawn, local_tpus):
-  chip_type, _ = local_tpus
-  child_pids = torch_xla_spawn
-  owners = device.get_chip_owners()
-  for _, pid in owners.items():
-    assert pid in child_pids
-  usages = metrics.get_chip_usage(chip_type)
-  for u in usages:
-    assert u.total_memory > 0
-    assert u.duty_cycle_pct == 0.0
-    one_gb = 1 << 30
-    assert u.memory_usage < one_gb
-  # TODO: check output
-  cli.print_chip_info()
+if __name__ == "__main__":
+  absltest.main()

--- a/test/tpu/tpu_info/test_cli.py
+++ b/test/tpu/tpu_info/test_cli.py
@@ -1,0 +1,119 @@
+import contextlib
+import multiprocessing
+import os
+import threading
+from typing import Dict, Optional
+import pytest
+import torch_xla as xla
+import torch_xla.runtime as xr
+import torch_xla.distributed.xla_multiprocessing as xmp
+from tpu_info import cli, device, metrics
+
+
+@pytest.fixture
+def local_tpus():
+  chip_type, num_chips = device.get_local_chips()
+  assert chip_type, "Expected local TPU chip"
+  yield chip_type, num_chips
+
+
+@pytest.fixture(scope="module", autouse=True)
+def use_tpu():
+  xr.set_device_type("TPU")
+
+
+def _init_tpu_and_wait(
+    # accept index as first arg to make xmp.spawn happy
+    index: int,
+    q: multiprocessing.Queue,
+    done: multiprocessing.Event,
+    env: Optional[Dict[str, str]] = None,
+):
+  if env:
+    os.environ.update(**env)
+  xla.device()
+  q.put(os.getpid())
+  done.wait()
+
+
+@pytest.fixture(params=[
+    {},
+    {
+        "TPU_VISIBLE_CHIPS": "0",
+        "TPU_PROCESS_BOUNDS": "1,1,1",
+        "TPU_CHIPS_PER_PROCESS_BOUNDS": "1,1,1",
+    },
+])
+def torch_xla_process(request: Dict[str, str]):
+  extra_env = request.param
+  with multiprocessing.Manager() as m:
+    q = m.Queue()
+    done = m.Event()
+    env = {
+        "TPU_RUNTIME_METRICS_PORTS": "8431",
+    }
+    env.update(extra_env)
+    p = multiprocessing.Process(
+        target=_init_tpu_and_wait, args=(0, q, done, env))
+    p.start()
+    pid = q.get(timeout=10.0)
+    with contextlib.ExitStack() as e:
+      e.callback(done.set)
+      yield pid
+    # Wait for process to exit before next test
+    p.join()
+
+
+def test_single_process_e2e(torch_xla_process, local_tpus):
+  chip_type, _ = local_tpus
+  owners = device.get_chip_owners()
+  for _, pid in owners.items():
+    assert pid == torch_xla_process
+  usages = metrics.get_chip_usage(chip_type)
+  for u in usages:
+    assert u.total_memory > 0
+    assert u.duty_cycle_pct == 0.0
+    # There's a small amount of memory usage when libtpu is initialized
+    one_gb = 1 << 30
+    assert u.memory_usage < one_gb
+  # TODO: check output
+  cli.print_chip_info()
+
+
+@pytest.fixture
+def torch_xla_spawn(local_tpus):
+  chip_type, num_chips = local_tpus
+  with multiprocessing.Manager() as m:
+    q = m.Queue()
+    done = m.Event()
+    # TODO: This should get set automatically by libtpu
+    os.environ["TPU_RUNTIME_METRICS_PORTS"] = ",".join(
+        str(i) for i in range(8431, 8431 + num_chips))
+    # HACK: run xmp.spawn in a thread because `join` arg is not implemented
+    t = threading.Thread(
+        target=lambda: xmp.spawn(_init_tpu_and_wait, args=(q, done)))
+    t.start()
+    child_pids = set()
+    for _ in range(chip_type.value.accelerators_per_chip * num_chips):
+      child_pids.add(q.get(timeout=10.0))
+    with contextlib.ExitStack() as e:
+      e.callback(done.set)
+      yield child_pids
+    os.environ.pop("TPU_RUNTIME_METRICS_PORTS")
+    t.join()
+
+
+def test_multiprocessing_e2e(torch_xla_spawn, local_tpus):
+  chip_type, _ = local_tpus
+  child_pids = torch_xla_spawn
+  owners = device.get_chip_owners()
+  for _, pid in owners.items():
+    assert pid in child_pids
+  usages = metrics.get_chip_usage(chip_type)
+  for u in usages:
+    assert u.total_memory > 0
+    assert u.duty_cycle_pct == 0.0
+    one_gb = 1 << 30
+    assert u.memory_usage < one_gb
+  # TODO: check output
+  cli.print_chip_info()


### PR DESCRIPTION
Adding a test in our repository because 1) I monitor the CI here and 2) I want to pull in `tpu-info` with `torch_xla[tpu]` by default in a release or two