### PR TITLE
Handle non persistent buffer in to_xla

### DIFF
--- a/experimental/torch_xla2/test/test_context.py
+++ b/experimental/torch_xla2/test/test_context.py
@@ -88,7 +88,6 @@ class TestContext(unittest.TestCase):
       def __init__(self):
         super().__init__()
         c = torch.rand(2)
-        self.register_parameter('p')
         self.register_buffer('c', c)
         self.register_buffer('c2', c, persistent=False)
 

--- a/experimental/torch_xla2/test/test_context.py
+++ b/experimental/torch_xla2/test/test_context.py
@@ -79,8 +79,30 @@ class TestContext(unittest.TestCase):
 
     # Values will be different, but still check device, layout, dtype, etc
     torch.testing.assert_close(
-        torch_xla2.tensor.j2t(x._elem),
-        torch_xla2.tensor.j2t(y._elem))
+        torch_xla2.tensor.j2t(x._elem), torch_xla2.tensor.j2t(y._elem))
+
+  def test_buffer(self):
+
+    class M(torch.nn.Module):
+
+      def __init__(self):
+        super().__init__()
+        c = torch.rand(2)
+        self.register_parameter('p')
+        self.register_buffer('c', c)
+        self.register_buffer('c2', c, persistent=False)
+
+    # Test context manager.
+    with xla_env:
+      m = M()
+      self.assertIsInstance(m.c, tensor.XLATensor2)
+      self.assertIsInstance(m.c2, tensor.XLATensor2)
+    # Test `to_xla`.
+    m = M()
+    m = xla_env.to_xla(m)
+    self.assertIsInstance(m.c, tensor.XLATensor2)
+    self.assertIsInstance(m.c2, tensor.XLATensor2)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/experimental/torch_xla2/torch_xla2/tensor.py
+++ b/experimental/torch_xla2/torch_xla2/tensor.py
@@ -339,6 +339,9 @@ class Environment(contextlib.ContextDecorator):
       if isinstance(val, torch.nn.Module):
         state_dict = self.to_xla(val.state_dict())
         val.load_state_dict(state_dict, assign=True)
+        # Non-persistent buffers are not in state_dict
+        for b_name, buffer in val.named_buffers():
+          setattr(val, b_name, self.to_xla(buffer))
         return val
       if isinstance(val, XLATensor2):
         return val


### PR DESCRIPTION
If there is a non-persistent buffer in `nn.Module`, it won't be included in `module.state_dict()`. The `to_xla` api only moves tensors in `state_dict` to xla device. Here we handle the non-persistent tensor in `to_xla` API.

Test:
- added unit test