### PR TITLE
Fix spmd reduce scatter python test

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1231,7 +1231,7 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
         f"reduce-scatter(f32[8,8]{{1,0}} %custom-call.2), channel_id=1, replica_groups={{{{{','.join([str(x) for x in self.device_ids])}}}}}, use_global_device_ids=true, dimensions={{0}}, to_apply=%AddComputation.3",
         hlo)
 
-    expected_x = torch.ones(8 // self.n_devices, 8) * 4
+    expected_x = torch.ones(8 // self.n_devices, 8) * self.n_devices
     self.assertTrue(torch.allclose(x.cpu(), expected_x))
 
   @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 4,
@@ -1252,7 +1252,7 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
         f"reduce-scatter(f32[8,8]{{1,0}} %custom-call.2), channel_id=1, replica_groups={{{{{','.join([str(x) for x in self.device_ids])}}}}}, use_global_device_ids=true, dimensions={{1}}, to_apply=%AddComputation.3",
         hlo)
 
-    expected_x = torch.ones(8, 8 // self.n_devices) * 4
+    expected_x = torch.ones(8, 8 // self.n_devices) * self.n_devices
     self.assertTrue(torch.allclose(x.cpu(), expected_x))
 
 


### PR DESCRIPTION
These tests were failing on v5e-8 with the following error:
```
$ python test/spmd/test_xla_sharding.py
.....................................................F
Actual: tensor([[8.],
        [8.],
        [8.],
        [8.],
        [8.],
        [8.],
        [8.],
        [8.]]) 
        
Expected: tensor([[4.],
        [4.],
        [4.],
        [4.],
        [4.],
        [4.],
        [4.],
        [4.]])
F........
======================================================================
FAIL: test_spmd_reduce_scatter (__main__.BasicXlaShardingTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/disks/bbahl/pytorch/xla/test/spmd/test_xla_sharding.py", line 1235, in test_spmd_reduce_scatter
    torch.testing.assert_close(x.cpu(), expected_x)
  File "/mnt/disks/bbahl/miniconda3/envs/torchnightly/lib/python3.10/site-packages/torch/testing/_comparison.py", line 1524, in assert_close
    raise error_metas[0].to_error(msg)
AssertionError: Tensor-likes are not close!

Mismatched elements: 8 / 8 (100.0%)
Greatest absolute difference: 4.0 at index (0, 0) (up to 1e-05 allowed)
Greatest relative difference: 1.0 at index (0, 0) (up to 1.3e-06 allowed)

======================================================================
FAIL: test_spmd_reduce_scatter_canonical_index (__main__.BasicXlaShardingTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/disks/bbahl/pytorch/xla/test/spmd/test_xla_sharding.py", line 1257, in test_spmd_reduce_scatter_canonical_index
    torch.testing.assert_close(x.cpu(), expected_x)
  File "/mnt/disks/bbahl/miniconda3/envs/torchnightly/lib/python3.10/site-packages/torch/testing/_comparison.py", line 1524, in assert_close
    raise error_metas[0].to_error(msg)
AssertionError: Tensor-likes are not close!

Mismatched elements: 8 / 8 (100.0%)
Greatest absolute difference: 4.0 at index (0, 0) (up to 1e-05 allowed)
Greatest relative difference: 1.0 at index (0, 0) (up to 1.3e-06 allowed)

----------------------------------------------------------------------
Ran 63 tests in 2.984s

FAILED (failures=2)
```

It seems like the content of the tensor should depend on the number of devices that we shard across.