### PR TITLE
[torch_xla2] Functional collectives

### DIFF
--- a/experimental/torch_xla2/test_dist/test_distributed.py
+++ b/experimental/torch_xla2/test_dist/test_distributed.py
@@ -104,7 +104,6 @@ def test_all_reduce_func(op, expected, multi_cpu):
   device_count = multi_cpu
 
   def f(index):
-    # TODO(wcromar): why do I need PG for this?
     return torch.distributed._functional_collectives.all_reduce(
       index, op, GROUP_NAME
     )

--- a/experimental/torch_xla2/torch_xla2/distributed.py
+++ b/experimental/torch_xla2/torch_xla2/distributed.py
@@ -28,13 +28,20 @@ class ProcessGroupJax(ProcessGroup):
 
   def __init__(self, prefix_store, rank, size, timeout):
     super().__init__(rank, size)
+    self._group_name = None
 
   def getBackendName(self):
     return "jax"
 
+  # TODO(wcromar): why doesn't default group name setter work?
+  # https://github.com/pytorch/pytorch/blob/7b1988f9222f3dec5cc2012afce84218199748ae/torch/csrc/distributed/c10d/ProcessGroup.cpp#L148-L152
+  def _set_group_name(self, name: str) -> None:
+    self._group_name = name
+
   @property
   def group_name(self):
-    return "torch_dist"
+    assert self._group_name
+    return self._group_name
 
   # def allgather(
   #   self,

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -101,7 +101,8 @@ def _c10d_broadcast(self, src: int, group_name: str):
 
 
 @op(torch.ops._c10d_functional.wait_tensor)
-def _wait_tensor(tensor):
+def _c10d_wait_tensor(tensor):
+  # Async tensor is aleady `wait`ed by dispatcher
   return tensor
 
 

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -68,44 +68,6 @@ def _handle_int64_trig(self, func):
   return res
 
 
-@op(torch.ops._c10d_functional.all_gather_into_tensor)
-def _c10d_all_gather(input, group_size: int, group_name: str):
-  return jax.lax.all_gather(input, "torch_dist")
-
-
-# TODO(wcromar): move c10d ops since they're not actually aten
-@op(torch.ops._c10d_functional.all_reduce)
-def _c10d_all_reduce(self, reduceOp: str, group_name: str):
-  match reduceOp:
-    case 'sum':
-      res = jax.lax.psum(self, axis_name="torch_dist")
-    case 'avg':
-      res = jax.lax.pmean(self, axis_name="torch_dist")
-    case 'min':
-      res = jax.lax.pmin(self, axis_name="torch_dist")
-    case 'max':
-      res = jax.lax.pmax(self, axis_name="torch_dist")
-    case _:
-      raise RuntimeError(f"Reduce op {reduceOp} not implemented")
-  return res
-
-
-@op(torch.ops._c10d_functional.broadcast)
-def _c10d_broadcast(self, src: int, group_name: str):
-  masked = jnp.where(
-      jax.lax.axis_index("torch_dist") == src,
-      self,
-      jnp.zeros_like(self),
-  )
-  return jax.lax.psum(masked, "torch_dist")
-
-
-@op(torch.ops._c10d_functional.wait_tensor)
-def _c10d_wait_tensor(tensor):
-  # Async tensor is aleady `wait`ed by dispatcher
-  return tensor
-
-
 @op(
   torch.ops.aten.view_copy,
   torch.ops.aten.view,

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -127,12 +127,6 @@ def _aten_add(x, y, *, alpha=1):
 
 @op(torch.ops.aten.copy_, torch.ops.aten.copy_.default, is_jax_function=False)
 def _aten_copy(x, y, memory_format=None):
-  # TODO(wcromar): does this make more sense in the dispatcher?
-  if isinstance(x, torch.distributed._functional_collectives.AsyncCollectiveTensor):
-    x = x.wait()
-  if isinstance(y, torch.distributed._functional_collectives.AsyncCollectiveTensor):
-    y = y.wait()
-
   x._elem = y._elem
   return x
 

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -105,13 +105,6 @@ def _wait_tensor(tensor):
   return tensor
 
 
-# TODO(wcromar): dispatch legacy collectives instead of using PG?
-# @functools.partial(ops_registry.register_torch_dispatch_op, torch.ops.c10d.allreduce_, is_jax_function=False)
-# def _legacy_all_reduce_inplace(tensors: List[torch.Tensor], group: dist.ProcessGroup, reduce_op: dist.ReduceOp, sparse_indices, timeout):
-#   print(reduce_op, dir(reduce_op), reduce_op._properties(), dist.ReduceOp(reduce_op))
-#   for t in tensors:
-#     t.copy_(_all_reduce(t, reduce_op.name, group.group_name))
-
 @op(
   torch.ops.aten.view_copy,
   torch.ops.aten.view,
@@ -348,19 +341,19 @@ def _aten_embedding(a, w, padding_idx=-1):
 
 
 #- func: _embedding_bag_forward_only(
-# Tensor weight, Tensor indices, Tensor offsets, bool scale_grad_by_freq=False, 
+# Tensor weight, Tensor indices, Tensor offsets, bool scale_grad_by_freq=False,
 # int mode=0, bool sparse=False, Tensor? per_sample_weights=None, bool include_last_offset=False, int padding_idx=-1) -> (Tensor, Tensor, Tensor, Tensor)
 @op(torch.ops.aten._embedding_bag)
 @op(torch.ops.aten._embedding_bag_forward_only)
 def _aten__embedding_bag(
-  weight, 
-  indices, 
-  offsets=None, 
-  scale_grad_by_freq=False, 
-  mode=0, 
-  sparse=False, 
-  per_sample_weights=None, 
-  include_last_offset=False, 
+  weight,
+  indices,
+  offsets=None,
+  scale_grad_by_freq=False,
+  mode=0,
+  sparse=False,
+  per_sample_weights=None,
+  include_last_offset=False,
   padding_idx=-1):
     """Jax implementation of the PyTorch _embedding_bag function.
 
@@ -408,7 +401,7 @@ def _aten__embedding_bag(
       output = segsum(embedded, offsets, reducer)
     else:
       output = reducer(embedded, axis=1)
-      
+
     # TODO: return output, offset2bag, bag_size, max_indices
     return output, None, None, None
 

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -412,12 +412,6 @@ def _aten_empty(sizes, *, dtype=None, **kwargs):
   return jnp.empty(sizes, dtype=dtype)
 
 
-@op(torch.ops.aten.empty_like)
-@op_base.convert_dtype()
-def _aten_empty_like(input, *, dtype=None, **kwargs):
-  return jnp.empty(input.size, dtype=dtype)
-
-
 @op(torch.ops.aten.index_put_)
 @op(torch.ops.aten.index_put)
 def _aten_index_put(self, indexes, values, accumulate=False):
@@ -2204,7 +2198,3 @@ def _aten_randint(
 @op(torch.ops.aten.dim, is_jax_function=False)
 def _aten_dim(self):
   return len(self.shape)
-
-@op(torch.ops.aten.equal)
-def _aten_equal(input, other):
-  return jnp.equal(input, other)

--- a/experimental/torch_xla2/torch_xla2/ops/jc10d.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jc10d.py
@@ -1,0 +1,52 @@
+import torch
+import jax
+import jax.numpy as jnp
+
+from torch_xla2.ops import ops_registry
+
+
+def op(*aten, **kwargs):
+  def inner(func):
+    for a in aten:
+      ops_registry.register_torch_dispatch_op(a, func, **kwargs)
+    return func
+
+  return inner
+
+
+@op(torch.ops._c10d_functional.all_gather_into_tensor)
+def _c10d_all_gather(input, group_size: int, group_name: str):
+  return jax.lax.all_gather(input, "torch_dist")
+
+
+# TODO(wcromar): move c10d ops since they're not actually aten
+@op(torch.ops._c10d_functional.all_reduce)
+def _c10d_all_reduce(self, reduceOp: str, group_name: str):
+  match reduceOp:
+    case "sum":
+      res = jax.lax.psum(self, axis_name="torch_dist")
+    case "avg":
+      res = jax.lax.pmean(self, axis_name="torch_dist")
+    case "min":
+      res = jax.lax.pmin(self, axis_name="torch_dist")
+    case "max":
+      res = jax.lax.pmax(self, axis_name="torch_dist")
+    case _:
+      raise RuntimeError(f"Reduce op {reduceOp} not implemented")
+  return res
+
+
+@op(torch.ops._c10d_functional.broadcast)
+def _c10d_broadcast(self, src: int, group_name: str):
+  masked = jnp.where(
+    jax.lax.axis_index("torch_dist") == src,
+    self,
+    jnp.zeros_like(self),
+  )
+  return jax.lax.psum(masked, "torch_dist")
+
+
+@op(torch.ops._c10d_functional.wait_tensor)
+def _c10d_wait_tensor(tensor):
+  # Async tensor is aleady `wait`ed by dispatcher
+  return tensor

--- a/experimental/torch_xla2/torch_xla2/ops/jc10d.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jc10d.py
@@ -19,7 +19,6 @@ def _c10d_all_gather(input, group_size: int, group_name: str):
   return jax.lax.all_gather(input, "torch_dist")
 
 
-# TODO(wcromar): move c10d ops since they're not actually aten
 @op(torch.ops._c10d_functional.all_reduce)
 def _c10d_all_reduce(self, reduceOp: str, group_name: str):
   match reduceOp:

--- a/experimental/torch_xla2/torch_xla2/tensor.py
+++ b/experimental/torch_xla2/torch_xla2/tensor.py
@@ -310,6 +310,10 @@ class Environment(contextlib.ContextDecorator):
             f'Operator with name {_name_of_func(func)} has no lowering')
 
         old_args, old_kwargs = args, kwargs
+        args, kwargs = torch_pytree.tree_map_only(
+            torch.distributed._functional_collectives.AsyncCollectiveTensor,
+            torch.distributed._functional_collectives.wait_tensor,
+            (args, kwargs))
         try:
           if op.is_jax_function:
             args, kwargs = self.t2j_iso((args, kwargs))

--- a/experimental/torch_xla2/torch_xla2/tensor.py
+++ b/experimental/torch_xla2/torch_xla2/tensor.py
@@ -223,7 +223,7 @@ class XLADispatchMode(torch_dispatch.TorchDispatchMode):
       if isinstance(func, torch._ops.OpOverloadPacket):
         with self:
           return func(*args, **kwargs)
-      if func.namespace not in ('aten', 'c10d', '_c10d_functional'):
+      if func.namespace not in ('aten', '_c10d_functional'):
         return func(*args, **kwargs)
       return self.env.dispatch(func, types, args, kwargs)
 

--- a/experimental/torch_xla2/torch_xla2/tensor.py
+++ b/experimental/torch_xla2/torch_xla2/tensor.py
@@ -261,7 +261,7 @@ class Environment(contextlib.ContextDecorator):
         self.config = configuration or config.Configuration()
 
     def load_ops(self):
-      from torch_xla2.ops import jaten, jtorch, ops_registry
+      from torch_xla2.ops import jaten, jtorch, jc10d, ops_registry
       self._ops.update(ops_registry.all_aten_ops)
       self._ops.update(ops_registry.all_torch_functions)
 


### PR DESCRIPTION

- Move collective op implementations out of `ProcessGroup` and into registered `__torch_dispatch__` ops.
- Rewrite ProcessGroup implementation using functional collectives
  -  `torch.distributed` dispatches to `c10d.*` (e.g. `torch.ops.c10d.allreduce_`) instead of the functional op directly. he signatures of `c10d.*` differ from `_c10d_functional.*_inplace` differ somewhat (str reduce op vs enum, tensor vs list of tensor), so we can't just reuse the exact same function.
  - When I tried to implement `c10d.*` directly, all non-tensor objects were wrapped in `ScriptObject`, causing a bunch of errors. I could not figure out how to unwrap them.
  - The default implementation of these ops is a wrapper around PG, e.g. https://github.com/pytorch/pytorch/blob/fdd0a7f9b4fb80c4d4870569909505a9beb6ccb3/torch/csrc/distributed/c10d/Ops.cpp#L162-L180
- Some functional collectives ignore the process group given a group name. Others look up e.g. the world size by the PG group name in the background (namely `all_gather`). It's unclear if that's the long-term intended behavior. Let's keep the ProcessGroup for now.

Aside from the traceable op implementations being cleaner, dynamo rewrites `torch.distributed` calls into their functional equivalents. E.g.

```
@torch.compile(backend=my_backend)
def cc(index):
  dist.all_reduce(index)
  return index
```

generates

```
opcode         name         target                                args                   kwargs
-------------  -----------  ------------------------------------  ---------------------  --------
placeholder    arg0_1       arg0_1                                ()                     {}
call_function  all_reduce   _c10d_functional.all_reduce.default   (arg0_1, 'sum', '0')   {}
call_function  wait_tensor  _c10d_functional.wait_tensor.default  (all_reduce,)          {}
call_function  copy         aten.copy.default                     (arg0_1, wait_tensor)  {}
output         output       output                                ((copy, copy),)        {}
```

cc @qihqi 

Depends on #7311