### PR TITLE
should_donate should not propagate to the output data

### DIFF
--- a/test/dynamo/test_dynamo_aliasing.py
+++ b/test/dynamo/test_dynamo_aliasing.py
@@ -123,6 +123,7 @@ class TestDynamoBufferDonationAliasing(unittest.TestCase):
     self.assertEqual(met.counter_value('XlaSetBufferDonation'), 1)
     dummy_inplace_add_compiled(input)
     torch.allclose(input_cloned.cpu() + 1, input.cpu())
+    self.assertFalse(torch_xla._XLAC._get_buffer_donation(input))
 
   def test_manual_buffer_donation_for_non_inplce_op(self):
     device = xm.xla_device()

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -1038,15 +1038,6 @@ void XLAGraphExecutor::ExtractIRAndPrepareXlaData_(
         runtime::GetComputationClient()->CreateDataPlaceholder(
             tensor_device.toString(), std::move(shape));
 
-    // If current IR is a device data, executing the graph will generate a new
-    // Data with the same value. In this case we want to inherit the buffer
-    // donation option from the old Data.
-    auto device_data = torch_xla::DeviceData::Cast(ir_value.node.get());
-    if (device_data && device_data->get_buffer_donation()) {
-      std::dynamic_pointer_cast<runtime::ComputationClient::Data>(handle)
-          ->set_should_donate_buffer(true);
-    }
-
     tensor_data_vec.push_back(handle);
     if (tensor->CurrentDataHandle() == nullptr && config.force_ltc_data) {
       tensor->AssignIrValue(torch::lazy::Value());


### PR DESCRIPTION
`torch.ops.xla.dynamo_set_buffer_donor_(input)` will set the buffer of the input tensor(we assume input is a XLAData) to be dondated. This is mostly used in the dynamo inference to set the big tensors(like kv cache) to be aliased with output. This is because in dynamo we can not infer the aliasing relationship directly.

Currently for
```
def fn_a(input):
  torch.ops.xla.dynamo_set_buffer_donor_(input)
  input += 1
  return input

def fn_b(input):
  input *= 100
  return input

a = torch.randn(5,5).to(torch_xla.device())
compiled_a = torch.compile(fn_a, backend="openxla")
compiled_b = torch.compile(fn_b, backend="openxla")

res_1 = compiled_a(input)
res_2 = compiled_b(res_1)
```

res_1's XLAData will also has the `should_donate_buffer` set to true, as a result, `compiled_b` will also donate the input buffer even it does not call `torch.ops.xla.dynamo_set_buffer_donor_`. I think this behavior is confusing and we should change it. 