### PR TITLE
separate PyTorch/XLA docs

### DIFF
--- a/docs/source/debug.rst
+++ b/docs/source/debug.rst
@@ -1,0 +1,1 @@
+.. mdinclude:: ../../TROUBLESHOOTING.md

--- a/docs/source/gpu.rst
+++ b/docs/source/gpu.rst
@@ -1,0 +1,1 @@
+.. mdinclude:: ../gpu.md

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -90,12 +90,3 @@ debug
 .. autofunction:: counter_value
 .. autofunction:: metric_names
 .. autofunction:: metric_data
-
-.. mdinclude:: ../../TROUBLESHOOTING.md
-.. mdinclude:: ../pjrt.md
-.. mdinclude:: ../dynamo.md
-.. mdinclude:: ../fsdp.md
-.. mdinclude:: ../ddp.md
-.. mdinclude:: ../gpu.md
-.. mdinclude:: ../spmd_basic.md
-.. mdinclude:: ../fsdpv2.md

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,3 +1,16 @@
+:github_url: https://github.com/pytorch/xla
+
+PyTorch/XLA documentation
+===================================
+PyTorch/XLA is a Python package that uses the XLA deep learning compiler to connect the PyTorch deep learning framework and Cloud TPUs.
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+   :caption: Docs
+
+   *
+
 .. mdinclude:: ../../API_GUIDE.md
 
 PyTorch/XLA API

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,6 +5,11 @@ PyTorch/XLA documentation
 PyTorch/XLA is a Python package that uses the XLA deep learning compiler to connect the PyTorch deep learning framework and Cloud TPUs.
 
 .. toctree::
+   :hidden:
+
+   self
+
+.. toctree::
    :glob:
    :maxdepth: 1
    :caption: Docs

--- a/docs/source/multi_process_distributed.rst
+++ b/docs/source/multi_process_distributed.rst
@@ -1,0 +1,2 @@
+.. mdinclude:: ../ddp.md
+.. mdinclude:: ../fsdp.md

--- a/docs/source/runtime.rst
+++ b/docs/source/runtime.rst
@@ -1,0 +1,1 @@
+.. mdinclude:: ../pjrt.md

--- a/docs/source/spmd.rst
+++ b/docs/source/spmd.rst
@@ -1,0 +1,4 @@
+.. mdinclude:: ../spmd_basic.md
+.. mdinclude:: ../fsdpv2.md
+.. mdinclude:: ../spmd_advanced.md
+.. mdinclude:: ../spmd_distributed_checkpoint.md

--- a/docs/source/torch_compile.rst
+++ b/docs/source/torch_compile.rst
@@ -1,0 +1,1 @@
+.. mdinclude:: ../dynamo.md


### PR DESCRIPTION
Tried to follow the same pattern as https://github.com/pytorch/pytorch/tree/90f6043368c59a4fbfbf1e0e4c3f347c5b3d6ef4/docs/source