### PR TITLE
[benchmarks] Fix `moco` initialization device.

### DIFF
--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -344,7 +344,8 @@ class TorchBenchModel(BenchmarkModel):
     #   1. Models don't expect 'tpu' as their device.
     #   2. 'moco' initializes a ProcessGroup, i.e. the backend depends on
     #      the given device
-    return self.is_accelerator_tpu() or self.model_name == "moco"
+    return self.is_accelerator_tpu() or (self.model_name == "moco" and
+                                         self.benchmark_experiment.xla)
 
   def is_inference(self):
     return self.benchmark_experiment.test == "eval"


### PR DESCRIPTION
This PR fixes the problem introduced in #7321, where we would initialize `moco` with `"xla"` device type, instead of the used accelerator.

**Problem:** this broke non-XLA benchmark runs
- Since we weren't checking for that, inductor started failing

**Solution:** check whether we are supposed to run on XLA

cc @miladm @JackCaoG @zpcore @qihqi 