### PR TITLE
Let TPU CI read from project GCS buckets

### DIFF
--- a/infra/terraform_modules/arc_v4_container_cluster/main.tf
+++ b/infra/terraform_modules/arc_v4_container_cluster/main.tf
@@ -61,7 +61,7 @@ resource "google_container_node_pool" "arc_v4_tpu_nodes" {
     oauth_scopes = [
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",
-      "	https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/devstorage.read_only",
     ]
     machine_type = "ct4p-hightpu-4t"
   }

--- a/infra/terraform_modules/arc_v4_container_cluster/main.tf
+++ b/infra/terraform_modules/arc_v4_container_cluster/main.tf
@@ -36,6 +36,7 @@ resource "google_container_node_pool" "arc_v4_cpu_nodes" {
     oauth_scopes = [
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/devstorage.read_only",
     ]
   }
 
@@ -60,6 +61,7 @@ resource "google_container_node_pool" "arc_v4_tpu_nodes" {
     oauth_scopes = [
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",
+      "	https://www.googleapis.com/auth/devstorage.read_only",
     ]
     machine_type = "ct4p-hightpu-4t"
   }

--- a/infra/tpu-pytorch/tpu_ci.tf
+++ b/infra/tpu-pytorch/tpu_ci.tf
@@ -5,7 +5,7 @@ module "v4_arc_cluster" {
   cpu_nodepool_name = "cpu-nodepool"
   cpu_node_count    = 1
   tpu_nodepool_name = "tpu-nodepool"
-  max_tpu_nodes     = 1
+  max_tpu_nodes     = 2
   github_repo_url   = "https://github.com/pytorch/xla"
   # Dockerfile for this image can be found at test/tpu/Dockerfile
   runner_image      = "gcr.io/tpu-pytorch/tpu-ci-runner:latest"


### PR DESCRIPTION
`tpu-pytorch` buckets were previously public, so the TPU CI cluster did not need this permission.

Piggyback change: let TPU CI scale up to 2 runners since more people are using the `tpuci` tag.

Terraform plan:

<details>

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.v4_arc_cluster.google_container_node_pool.arc_v4_cpu_nodes must be replaced
-/+ resource "google_container_node_pool" "arc_v4_cpu_nodes" {
      ~ id                          = "projects/tpu-pytorch/locations/us-central2/clusters/tpu-ci/nodePools/cpu-nodepool" -> (known after apply)
      ~ initial_node_count          = 1 -> (known after apply)
      ~ instance_group_urls         = [
          - "https://www.googleapis.com/compute/v1/projects/tpu-pytorch/zones/us-central2-d/instanceGroupManagers/gke-tpu-ci-cpu-nodepool-4498435a-grp",
          - "https://www.googleapis.com/compute/v1/projects/tpu-pytorch/zones/us-central2-b/instanceGroupManagers/gke-tpu-ci-cpu-nodepool-03ddbdc4-grp",
          - "https://www.googleapis.com/compute/v1/projects/tpu-pytorch/zones/us-central2-c/instanceGroupManagers/gke-tpu-ci-cpu-nodepool-a9d6fa96-grp",
        ] -> (known after apply)
      ~ managed_instance_group_urls = [
          - "https://www.googleapis.com/compute/v1/projects/tpu-pytorch/zones/us-central2-d/instanceGroups/gke-tpu-ci-cpu-nodepool-4498435a-grp",
          - "https://www.googleapis.com/compute/v1/projects/tpu-pytorch/zones/us-central2-b/instanceGroups/gke-tpu-ci-cpu-nodepool-03ddbdc4-grp",
          - "https://www.googleapis.com/compute/v1/projects/tpu-pytorch/zones/us-central2-c/instanceGroups/gke-tpu-ci-cpu-nodepool-a9d6fa96-grp",
        ] -> (known after apply)
      ~ max_pods_per_node           = 110 -> (known after apply)
        name                        = "cpu-nodepool"
      + name_prefix                 = (known after apply)
      ~ node_locations              = [
          - "us-central2-b",
          - "us-central2-c",
          - "us-central2-d",
        ] -> (known after apply)
      + operation                   = (known after apply)
      ~ version                     = "1.29.5-gke.1091000" -> (known after apply)
        # (4 unchanged attributes hidden)

      - network_config {
          - create_pod_range     = false -> null
          - enable_private_nodes = false -> null
          - pod_ipv4_cidr_block  = "10.24.0.0/14" -> null
          - pod_range            = "gke-tpu-ci-pods-a314d238" -> null
        }

      ~ node_config {
          ~ disk_size_gb                = 100 -> (known after apply)
          ~ disk_type                   = "pd-balanced" -> (known after apply)
          ~ effective_taints            = [] -> (known after apply)
          - enable_confidential_storage = false -> null
          ~ guest_accelerator           = [] -> (known after apply)
          ~ image_type                  = "COS_CONTAINERD" -> (known after apply)
          ~ labels                      = {} -> (known after apply)
          ~ local_ssd_count             = 0 -> (known after apply)
          ~ logging_variant             = "DEFAULT" -> (known after apply)
          ~ machine_type                = "n1-standard-1" -> (known after apply)
          ~ metadata                    = {
              - "disable-legacy-endpoints" = "true"
            } -> (known after apply)
          + min_cpu_platform            = (known after apply)
          ~ oauth_scopes                = [ # forces replacement
              + "https://www.googleapis.com/auth/devstorage.read_only",
                # (2 unchanged elements hidden)
            ]
          - resource_labels             = {} -> null
          - resource_manager_tags       = {} -> null
          ~ service_account             = "default" -> (known after apply)
          - tags                        = [] -> null
            # (4 unchanged attributes hidden)

          - shielded_instance_config {
              - enable_integrity_monitoring = true -> null
              - enable_secure_boot          = false -> null
            }
        }

      - upgrade_settings {
          - max_surge       = 1 -> null
          - max_unavailable = 0 -> null
          - strategy        = "SURGE" -> null
        }

        # (1 unchanged block hidden)
    }

  # module.v4_arc_cluster.google_container_node_pool.arc_v4_tpu_nodes must be replaced
-/+ resource "google_container_node_pool" "arc_v4_tpu_nodes" {
      ~ id                          = "projects/tpu-pytorch/locations/us-central2/clusters/tpu-ci/nodePools/tpu-nodepool" -> (known after apply)
      ~ instance_group_urls         = [
          - "https://www.googleapis.com/compute/v1/projects/tpu-pytorch/zones/us-central2-b/instanceGroupManagers/gke-tpu-ci-tpu-nodepool-18eadd46-grp",
        ] -> (known after apply)
      ~ managed_instance_group_urls = [
          - "https://www.googleapis.com/compute/v1/projects/tpu-pytorch/zones/us-central2-b/instanceGroups/gke-tpu-ci-tpu-nodepool-18eadd46-grp",
        ] -> (known after apply)
      ~ max_pods_per_node           = 110 -> (known after apply)
        name                        = "tpu-nodepool"
      + name_prefix                 = (known after apply)
      ~ node_count                  = 1 -> (known after apply)
      + operation                   = (known after apply)
      ~ version                     = "1.29.5-gke.1091000" -> (known after apply)
        # (5 unchanged attributes hidden)

      ~ autoscaling {
          - max_node_count       = 0 -> null
          - min_node_count       = 0 -> null
          ~ total_max_node_count = 1 -> 2
            # (2 unchanged attributes hidden)
        }

      - network_config {
          - create_pod_range     = false -> null
          - enable_private_nodes = false -> null
          - pod_ipv4_cidr_block  = "10.24.0.0/14" -> null
          - pod_range            = "gke-tpu-ci-pods-a314d238" -> null
        }

      ~ node_config {
          ~ disk_size_gb                = 100 -> (known after apply)
          ~ disk_type                   = "pd-balanced" -> (known after apply)
          ~ effective_taints            = [
              - {
                  - effect = "NO_SCHEDULE"
                  - key    = "google.com/tpu"
                  - value  = "present"
                },
            ] -> (known after apply)
          - enable_confidential_storage = false -> null
          ~ guest_accelerator           = [] -> (known after apply)
          ~ image_type                  = "COS_CONTAINERD" -> (known after apply)
          ~ labels                      = {} -> (known after apply)
          ~ local_ssd_count             = 0 -> (known after apply)
          ~ logging_variant             = "DEFAULT" -> (known after apply)
          ~ metadata                    = {
              - "disable-legacy-endpoints" = "true"
            } -> (known after apply)
          + min_cpu_platform            = (known after apply)
          ~ oauth_scopes                = [ # forces replacement
              + "\thttps://www.googleapis.com/auth/devstorage.read_only",
                # (2 unchanged elements hidden)
            ]
          - resource_labels             = {} -> null
          - resource_manager_tags       = {} -> null
          ~ service_account             = "default" -> (known after apply)
          - tags                        = [] -> null
            # (5 unchanged attributes hidden)

          - shielded_instance_config {
              - enable_integrity_monitoring = true -> null
              - enable_secure_boot          = false -> null
            }
        }

      - upgrade_settings {
          - max_surge       = 1 -> null
          - max_unavailable = 0 -> null
          - strategy        = "SURGE" -> null
        }

        # (1 unchanged block hidden)
    }

  # module.v4_arc_cluster.helm_release.arc_runner_set will be updated in-place
  ~ resource "helm_release" "arc_runner_set" {
        id                         = "v4-runner-set"
      ~ metadata                   = [
          - {
              - app_version = "0.8.3"
              - chart       = "gha-runner-scale-set"
              - name        = "v4-runner-set"
              - namespace   = "arc-runners"
              - revision    = 1
              - values      = jsonencode(
                    {
                      - githubConfigSecret = "github-pat"
                      - githubConfigUrl    = "https://github.com/pytorch/xla"
                      - maxRunners         = 1
                      - minRunners         = 1
                      - template           = {
                          - spec = {
                              - containers   = [
                                  - {
                                      - command   = [
                                          - "/home/runner/run.sh",
                                        ]
                                      - image     = "gcr.io/tpu-pytorch/tpu-ci-runner:latest"
                                      - name      = "runner"
                                      - resources = {
                                          - limits   = {
                                              - "google.com/tpu" = 4
                                            }
                                          - requests = {
                                              - "google.com/tpu" = 4
                                            }
                                        }
                                    },
                                ]
                              - nodeSelector = {
                                  - "cloud.google.com/gke-tpu-accelerator" = "tpu-v4-podslice"
                                  - "cloud.google.com/gke-tpu-topology"    = "2x2x1"
                                }
                            }
                        }
                    }
                )
              - version     = "0.8.3"
            },
        ] -> (known after apply)
        name                       = "v4-runner-set"
      ~ values                     = [
          ~ <<-EOT
                githubConfigUrl: https://github.com/pytorch/xla
                githubConfigSecret: github-pat
                minRunners: 1
              - maxRunners: 1
              + maxRunners: 2
                template:
                  spec:
                    containers:
                    - name: runner
                      image: gcr.io/tpu-pytorch/tpu-ci-runner:latest
                      command: ["/home/runner/run.sh"]
                      resources:
                        limits:
                          google.com/tpu: 4
                        requests:
                          google.com/tpu: 4
                    nodeSelector:
                      cloud.google.com/gke-tpu-accelerator: tpu-v4-podslice
                      cloud.google.com/gke-tpu-topology: 2x2x1
            EOT,
        ]
        # (25 unchanged attributes hidden)
    }

Plan: 2 to add, 1 to change, 2 to destroy.

──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

</details>