### PR TITLE
Update JAX version to fix TPU CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ base_dir = os.path.dirname(os.path.abspath(__file__))
 _date = '20240628'
 _libtpu_version = f'0.1.dev{_date}'
 _libtpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
-_jax_version = f'0.4.30.dev{_date}'
+_jax_version = f'0.4.31.dev{_date}'
 
 
 def _get_build_mode():


### PR DESCRIPTION
`4.30.dev20240628` doesn't exist

The minor version number was incremented to 31: https://storage.googleapis.com/jax-releases/nightly/jax/jax-0.4.31.dev20240628.tar.gz

The TPU CI is silently reinstalling `torch_xla` 2.3 from PyPI and failing for an unrelated reason.