### PR TITLE
Reland: `mul`: convert inputs to result type.

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2107,8 +2107,6 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     for xshape, i0shape, i1shape in cases[f2]:
       test(f2, xshape, (i0shape, i1shape))
 
-  @unittest.skipIf(
-      True, "skip since https://github.com/pytorch/xla/pull/7130 is reverted")
   def test_inplace_mul_scalar_different_dtype(self):
     # This tests whether the returned output data-type agrees on PyTorch
     # and XLA sides.

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -158,7 +158,7 @@ class OpConfig {
         inputs.begin(), inputs.end(), [](const at::Tensor& tensor) {
           return bridge::TryGetXlaTensor(tensor);
         });
-    XLA_CHECK(it != inputs_.end());
+    XLA_CHECK(it != inputs.end());
     // Transform the inputs into a list of XLATensorPtr.
     // For that, either get their corresponding XLATensorPtr, or use the found
     // XLA tensor's BackendDevice for creating a new one.


### PR DESCRIPTION
Fix: #7266 

This PR tries to re-land #7130, which was reverted due to regressions on XLA:TPU. On top of that, it also fixes a subtle bug that went under the radar. Although we couldn't find a minimal reproducer, internal CI for TPU was reportedly broken due to this PR.

 Therefore, the idea is to have this PR merged, and check the internal CI for TPU results.

cc @miladm @vanbasten23 @JackCaoG 