### PR TITLE
Move tensor constructors to `jaten`

### DIFF
--- a/experimental/torch_xla2/test/test_functions.py
+++ b/experimental/torch_xla2/test/test_functions.py
@@ -18,18 +18,6 @@ class TestTorchFunctions(parameterized.TestCase):
       ('tensor_empty', lambda: torch.tensor([],)),
       ('tensor_dtype', lambda: torch.tensor([[0.11111, 0.222222, 0.3333333]],
                                             dtype=torch.float64)),
-      ('ones_2d', lambda: torch.ones(2, 3)),
-      ('ones_1d', lambda: torch.ones(5)),
-      ('ones_1d_dtype', lambda: torch.ones(5, dtype=torch.float16)),
-      ('zeros_2d', lambda: torch.zeros(2, 3)),
-      ('zeros_1d', lambda: torch.zeros(5)),
-      ('zeros_1d_dtype', lambda: torch.zeros(5, dtype=torch.complex64)),
-      ('eye_3x3', lambda: torch.eye(3)),
-      ('eye_4x2', lambda: torch.eye(4, 2)),
-      ('eye_4x2_dtype', lambda: torch.eye(4, 2, dtype=torch.float16)),
-      ('full_2d', lambda: torch.full((2, 3), 3.141592)),
-      ('full_2d_dtype', lambda: torch.full(
-          (2, 3), 3.141592, dtype=torch.float16)),
   )
   def test_tensor_constructor(self, func: Callable[[], torch.Tensor]):
     expected = func()

--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -373,7 +373,6 @@ skiplist = {
     "erf",
     "exp",
     "expm1",
-    "eye",
     "fft.fftshift",
     "fft.ifftshift",
     "fill",
@@ -383,7 +382,6 @@ skiplist = {
     "flipud",
     "fmod",
     "frac",
-    "full",
     "gradient",
     "hsplit",
     "hstack",
@@ -437,7 +435,6 @@ skiplist = {
     "nn.functional.triplet_margin_loss",
     "nn.functional.triplet_margin_with_distance_loss",
     "nn.functional.upsample_bilinear",
-    "ones",
     "outer",
     "permute",
     "positive",
@@ -496,7 +493,6 @@ skiplist = {
     "view",
     "vsplit",
     "vstack",
-    "zeros",
 }
 
 # These inputs are themselves views

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -1,11 +1,10 @@
 """Torch ops implemented using jax."""
 
-import functools
 import sys
+from typing import Optional, Sequence
 
 import jax
 from jax import numpy as jnp
-from jax.experimental.sparse import BCOO
 
 import numpy as np
 import torch
@@ -298,19 +297,19 @@ def _aten_embedding(a, w, padding_idx=-1):
 
 
 #- func: _embedding_bag_forward_only(
-# Tensor weight, Tensor indices, Tensor offsets, bool scale_grad_by_freq=False, 
+# Tensor weight, Tensor indices, Tensor offsets, bool scale_grad_by_freq=False,
 # int mode=0, bool sparse=False, Tensor? per_sample_weights=None, bool include_last_offset=False, int padding_idx=-1) -> (Tensor, Tensor, Tensor, Tensor)
 @op(torch.ops.aten._embedding_bag)
 @op(torch.ops.aten._embedding_bag_forward_only)
 def _aten__embedding_bag(
-  weight, 
-  indices, 
-  offsets=None, 
-  scale_grad_by_freq=False, 
-  mode=0, 
-  sparse=False, 
-  per_sample_weights=None, 
-  include_last_offset=False, 
+  weight,
+  indices,
+  offsets=None,
+  scale_grad_by_freq=False,
+  mode=0,
+  sparse=False,
+  per_sample_weights=None,
+  include_last_offset=False,
   padding_idx=-1):
     """Jax implementation of the PyTorch _embedding_bag function.
 
@@ -358,7 +357,7 @@ def _aten__embedding_bag(
       output = segsum(embedded, offsets, reducer)
     else:
       output = reducer(embedded, axis=1)
-      
+
     # TODO: return output, offset2bag, bag_size, max_indices
     return output, None, None, None
 
@@ -408,8 +407,33 @@ def _aten__to_copy(self, **kwargs):
 
 @op(torch.ops.aten.empty)
 @op_base.convert_dtype()
-def _aten_empty(sizes, *, dtype=None, **kwargs):
-  return jnp.empty(sizes, dtype=dtype)
+def _aten_empty(size: Sequence[int], *, dtype=None, **kwargs):
+  return jnp.empty(size, dtype=dtype)
+
+
+@op(torch.ops.aten.ones)
+@op_base.convert_dtype()
+def _ones(size: Sequence[int], dtype=None, **kwargs):
+  return jnp.ones(size, dtype)
+
+
+@op(torch.ops.aten.zeros)
+@op_base.convert_dtype()
+def _zeros(size: Sequence[int], dtype=None, **kwargs):
+  return jnp.zeros(size, dtype)
+
+
+@op(torch.ops.aten.eye)
+@op_base.convert_dtype()
+def _eye(n: int, m: Optional[int] = None, *, dtype=None, **kwargs):
+  return jnp.eye(n, m, dtype=dtype)
+
+
+@op(torch.full)
+@op_base.convert_dtype()
+def _full(size: Sequence[int], fill_value, *, dtype=None, **kwargs):
+  # TODO: handle torch.Size
+  return jnp.full(size, fill_value, dtype=dtype)
 
 
 @op(torch.ops.aten.index_put_)

--- a/experimental/torch_xla2/torch_xla2/ops/jtorch.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jtorch.py
@@ -35,34 +35,10 @@ def _tensor(data, *, dtype=None, **kwargs):
       data, dtype=dtype or mappings.t2j_dtype(torch.get_default_dtype()))
 
 
-@register_function(torch.ones)
-@op_base.convert_dtype()
-def _ones(*size: int, dtype=None, **kwargs):
-  return jnp.ones(size, dtype)
-
-
-@register_function(torch.zeros)
-@op_base.convert_dtype()
-def _zeros(*size: int, dtype=None, **kwargs):
-  return jnp.zeros(size, dtype)
-
-
-@register_function(torch.eye)
-@op_base.convert_dtype()
-def _eye(n: int, m: Optional[int] = None, *, dtype=None, **kwargs):
-  return jnp.eye(n, m, dtype=dtype)
-
-
-@register_function(torch.full)
-@op_base.convert_dtype()
-def _full(size: Sequence[int], fill_value, *, dtype=None, **kwargs):
-  # TODO: handle torch.Size
-  return jnp.full(size, fill_value, dtype=dtype)
-
-
 @register_function(torch.allclose)
 def _aten_allclose(input, other, rtol=1e-05, atol=1e-08, equal_nan=False):
   return jnp.allclose(input, other, rtol, atol, equal_nan)
+
 
 @register_function(torch.angle)
 def _torch_angle(input):
@@ -81,7 +57,7 @@ def _torch_argsort(input, dim=-1, descending=False, stable=False):
     # behavior is the same as a jnp array of rank 1
     expanded = True
     input = jnp.expand_dims(input, 0)
-  res = jnp.argsort(input, axis=dim, descending=descending, 
+  res = jnp.argsort(input, axis=dim, descending=descending,
                      stable=stable)
   if expanded:
     res = res.squeeze()
@@ -94,7 +70,7 @@ def _einsum(equation, *operands):
 
 
 def _sdpa_reference(
-   query, key, value, attn_mask=None, 
+   query, key, value, attn_mask=None,
    dropout_p=0.0, is_causal=False, scale=None) -> torch.Tensor:
     L, S = query.size(-2), key.size(-2)
     scale_factor = 1 / np.sqrt(query.size(-1)) if scale is None else scale
@@ -141,19 +117,19 @@ def _tpu_flash_attention(query, key, value, env):
 
   if env.config.shmap_flash_attention:
     wrap_flash_attention = shard_map(
-      wrap_flash_attention, 
-      mesh=env._mesh, 
+      wrap_flash_attention,
+      mesh=env._mesh,
       in_specs=(fsdp_partition, fsdp_partition, fsdp_partition),
       out_specs=fsdp_partition ,
       check_rep=False,
     )
   #return flash_attn_mapped(query, key, value)
   return wrap_flash_attention(query, key, value)
-  
+
 
 @register_function(torch.nn.functional.scaled_dot_product_attention, is_jax_function=False, needs_env=True)
 def scaled_dot_product_attention(
-   query, key, value, attn_mask=None, 
+   query, key, value, attn_mask=None,
    dropout_p=0.0, is_causal=False, scale=None, env=None) -> torch.Tensor:
 
    if env.config.use_tpu_flash_attention:


### PR DESCRIPTION
Fixes bug where these functions didn't accept `List[int]` (only `int` positional args). Also enable their opinfo tests.

Removed corresponding tests in `test_functions` to de-duplicate with `test_ops`.

Removed some unused imports. Some formatting changes piggybacked on here. We should enable a formatter by default.