### PR TITLE
Early exit for clip_grad_norm_

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2043,6 +2043,12 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     self.assertEqual(xt.grad.dtype, torch.bfloat16)
     self.assertEqual(t.grad, xt.grad.cpu())
 
+  def test_clip_grad_norm_zero(self):
+    t = torch.rand(10, 10, dtype=torch.bfloat16)
+    xt = t.to(xm.xla_device())
+    result = torch.nn.utils.clip_grad_norm_(xt, 1.0)
+    self.assertTrue(torch.allclose(result, torch.tensor(0.)))
+
   def test_stack_different_types(self):
 
     def foo(t0, t1):

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2047,7 +2047,8 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     t = torch.rand(10, 10, dtype=torch.bfloat16)
     xt = t.to(xm.xla_device())
     result = torch.nn.utils.clip_grad_norm_(xt, 1.0)
-    self.assertTrue(torch.allclose(result, torch.tensor(0.)))
+    self.assertEqual(result.device.type, 'xla')
+    self.assertTrue(torch.allclose(result.cpu(), torch.tensor(0.)))
 
   def test_stack_different_types(self):
 

--- a/torch_xla/_patched_functions.py
+++ b/torch_xla/_patched_functions.py
@@ -32,7 +32,7 @@ def clip_grad_norm_(parameters: _tensor_or_tensors,
   max_norm = float(max_norm)
   norm_type = float(norm_type)
   if len(parameters) == 0:
-    return torch.tensor(0.)
+    return torch.tensor(0.).to("xla")
   dtype = parameters[0].grad.dtype
   device = parameters[0].grad.device
   if norm_type == inf:

--- a/torch_xla/_patched_functions.py
+++ b/torch_xla/_patched_functions.py
@@ -31,10 +31,10 @@ def clip_grad_norm_(parameters: _tensor_or_tensors,
   parameters = list(filter(lambda p: p.grad is not None, parameters))
   max_norm = float(max_norm)
   norm_type = float(norm_type)
+  if len(parameters) == 0:
+    return torch.tensor(0.)
   dtype = parameters[0].grad.dtype
   device = parameters[0].grad.device
-  if len(parameters) == 0:
-    return torch.tensor(0., dtype=dtype, device=device)
   if norm_type == inf:
     total_norm = max(p.grad.detach().abs().max() for p in parameters)
   else:


### PR DESCRIPTION
Summary:
Adds an early exit for clip_grad_norm_.

Test Plan:
PJRT_DEVICE=TPU python test/test_operations.py -v -k test_clip_grad_norm_