### PR TITLE
Update jax to a stable version(0.4.29) for r2.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ base_dir = os.path.dirname(os.path.abspath(__file__))
 _date = '20240612'
 _libtpu_version = f'0.1.dev{_date}'
 _libtpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
-_jax_version = f'0.4.30.dev{_date}'
+_jax_version = f'0.4.29'
 
 
 def _get_build_mode():


### PR DESCRIPTION
JAX nightly wheels are automatically deleted after a while. To avoid breaking pallas functionality, we need to depend on a stable JAX version.

0.4.29 release was created on June 10 and it is the closest to the openxla pin of June 12.