### PR TITLE
fix eager mode spmd module loading with fsdpv2

### DIFF
--- a/test/tpu/run_tests.sh
+++ b/test/tpu/run_tests.sh
@@ -26,6 +26,7 @@ python3 test/test_pallas.py
 python3 test/test_pallas_spmd.py
 python3 test/test_input_output_aliases.py
 python3 test/test_gmm.py
+python3 test/eager/test_eager_spmd.py
 python3 test/torch_distributed/test_torch_distributed_all_gather_xla_backend.py
 python3 test/torch_distributed/test_torch_distributed_all_reduce_xla_backend.py
 python3 test/torch_distributed/test_torch_distributed_multi_all_reduce_xla_backend.py


### PR DESCRIPTION
The problem is `module.to` is always a `empty` + `to_copy`. in eager mode `empty` is a `expand` and will be evaluated directly. However this evulation will result in a `replicated ` sharding spec. In `fsdpv2` code, we incorrectly believe this tensor is intentionally replicated and fsdpv2 won't shard it.