### PR TITLE
[Fori_loop] Update `randint` max range to Support `bool` dtype

### DIFF
--- a/torch_xla/experimental/fori_loop.py
+++ b/torch_xla/experimental/fori_loop.py
@@ -73,17 +73,15 @@ def _xla_while_loop(cond_fn,
   for carried_input in carried_inputs:
     device = carried_input.device
     fake_carried_inputs.append(
-        torch.randint(2, carried_input.size(),
-                      dtype=carried_input.dtype).to(device))
+        torch.empty(carried_input.size(), dtype=carried_input.dtype).to(device))
 
   #  ====== additional_inputs_list_cond ======
   fake_additiona_args = []
   for additional_input in additional_inputs:
     device = additional_input.device
     fake_additiona_args.append(
-        torch.randint(
-            2, additional_input.size(),
-            dtype=additional_input.dtype).to(device))
+        torch.empty(additional_input.size(),
+                    dtype=additional_input.dtype).to(device))
 
   #  ====== inputs_list ======
   #  specify body_fn_inputs/cond_fn_inputs, and add caught additional_inputs into fn_inputs

--- a/torch_xla/experimental/fori_loop.py
+++ b/torch_xla/experimental/fori_loop.py
@@ -73,7 +73,7 @@ def _xla_while_loop(cond_fn,
   for carried_input in carried_inputs:
     device = carried_input.device
     fake_carried_inputs.append(
-        torch.randint(10, carried_input.size(),
+        torch.randint(2, carried_input.size(),
                       dtype=carried_input.dtype).to(device))
 
   #  ====== additional_inputs_list_cond ======
@@ -82,7 +82,7 @@ def _xla_while_loop(cond_fn,
     device = additional_input.device
     fake_additiona_args.append(
         torch.randint(
-            10, additional_input.size(),
+            2, additional_input.size(),
             dtype=additional_input.dtype).to(device))
 
   #  ====== inputs_list ======


### PR DESCRIPTION
This pull request aims to address an issue related to the `randint` function's maximum range, which is currently set 10. When this range is used on tensors with a `bool` dtype, it results in the following runtime error:

```
RuntimeError: to - 1 is out of bounds for bool
```

By modifying the `randint` function's maximum range to 2, the code will be generalized and support tensors with `bool` dtype as well.

## Changes Made

The following lines have been modified to set the `randint` maximum range to 2:

https://github.com/pytorch/xla/blob/10a5130049db212d8ecaff00e2b5170fbbdb6e7a/torch_xla/experimental/fori_loop.py#L76

https://github.com/pytorch/xla/blob/10a5130049db212d8ecaff00e2b5170fbbdb6e7a/torch_xla/experimental/fori_loop.py#L84


## Additional Notes

From my understanding of the code, the maximum value of 10 is set arbitrarily. If the number 10 holds specific significance, we might need to find an alternative way to address this issue.



