### PR TITLE
Update `apt-get update` in upstream image build

### DIFF
--- a/.github/upstream/Dockerfile
+++ b/.github/upstream/Dockerfile
@@ -38,6 +38,8 @@ ENV CXX "${cxx}"
 # Whether to build for TPUVM mode
 ENV TPUVM_MODE "${tpuvm}"
 
+RUN apt-get update
+
 # Install clang as upstream CI forces clang
 RUN apt-get install -y clang
 # Install valgrind


### PR DESCRIPTION
Should fix

```
6 3.248 E: Failed to fetch http://deb.debian.org/debian/pool/main/g/glibc/libc6-i386_2.31-13%2bdeb11u8_amd64.deb  404  Not Found [IP: 146.75.34.132 80]
#6 3.248 E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```