### PR TITLE
Use torch_xla.experimental.compile for all examples

### DIFF
--- a/examples/eager/train_decoder_only_eager.py
+++ b/examples/eager/train_decoder_only_eager.py
@@ -6,7 +6,16 @@ from train_decoder_only_base import TrainDecoderOnlyBase
 
 import torch_xla
 
+
+class TrainDecoderOnlyEager(TrainDecoderOnlyBase):
+
+  def __init__(self):
+    super().__init__()
+    # We want to run the step fn eagerly.
+    self.compiled_step_fn = self.step_fn
+
+
 if __name__ == '__main__':
   torch_xla.experimental.eager_mode(True)
-  base = TrainDecoderOnlyBase()
+  base = TrainDecoderOnlyEager()
   base.start_training()

--- a/examples/eager/train_decoder_only_eager_multi_process.py
+++ b/examples/eager/train_decoder_only_eager_multi_process.py
@@ -10,6 +10,11 @@ import torch_xla.core.xla_model as xm
 
 class TrainDecoderXLADDP(TrainDecoderOnlyBase):
 
+  def __init__(self):
+    super().__init__()
+    # We want to run the step fn eagerly.
+    self.compiled_step_fn = self.step_fn
+
   def run_optimizer(self):
     # optimizer_step will call `optimizer.step()` and all_reduce the gradident
     xm.optimizer_step(self.optimizer)

--- a/examples/eager/train_decoder_only_eager_spmd_data_parallel.py
+++ b/examples/eager/train_decoder_only_eager_spmd_data_parallel.py
@@ -41,6 +41,7 @@ class TrainDecoderSpmdDDP(TrainDecoderOnlyBase):
         self.device,
         # Shard the input's batch dimension along the `data` axis, no sharding along other dimensions
         input_sharding=xs.ShardingSpec(mesh, ('data', None)))
+    self.compiled_step_fn = self.step_fn
 
 
 if __name__ == '__main__':

--- a/examples/eager/train_decoder_only_eager_with_compile.py
+++ b/examples/eager/train_decoder_only_eager_with_compile.py
@@ -6,16 +6,8 @@ from train_decoder_only_base import TrainDecoderOnlyBase
 
 import torch_xla
 
-
-class TrainDecoderOnlyEagerWithCompile(TrainDecoderOnlyBase):
-
-  def __init__(self):
-    super().__init__()
-    # step fn will be compiled and rest will be run eagerly.
-    self.step_fn = torch_xla.experimental.compile(self.step_fn)
-
-
 if __name__ == '__main__':
+  # The step fn will still be compiled, random input generation happens eagerly.
   torch_xla.experimental.eager_mode(True)
-  trainer = TrainDecoderOnlyEagerWithCompile()
+  trainer = TrainDecoderOnlyBase()
   trainer.start_training()

--- a/torch_xla/experimental/eager.py
+++ b/torch_xla/experimental/eager.py
@@ -40,8 +40,7 @@ def compile(func):
 
   @functools.wraps(func)  # Keep function's name, docstring, etc.
   def wrapper(*args, **kwargs):
-    # compile should only be called with
-    assert torch_xla._XLAC._get_use_eager_mode() == True
+    saved_eager_mode_status = torch_xla._XLAC._get_use_eager_mode()
     torch_xla._XLAC._set_use_eager_mode(False)
     # clear the pending graph if any
     torch_xla.sync()
@@ -54,7 +53,7 @@ def compile(func):
       # Handle exceptions (if needed)
       print(f"Error in target function: {e}")
       raise  # Re-raise the exception
-    torch_xla._XLAC._set_use_eager_mode(True)
+    torch_xla._XLAC._set_use_eager_mode(saved_eager_mode_status)
 
     return result
 

--- a/torch_xla/torch_xla.py
+++ b/torch_xla/torch_xla.py
@@ -67,13 +67,16 @@ def step():
   works with `xla.step` but does not follow best practices will become errors in
   future releases. See https://github.com/pytorch/xla/issues/6751 for context.
   """
+  saved_eager_mode_status = torch_xla._XLAC._get_use_eager_mode()
+  torch_xla._XLAC._set_use_eager_mode(False)
   # Clear pending operations
-  xm.mark_step()
+  sync()
 
   try:
     yield
   finally:
-    xm.mark_step()
+    sync()
+    torch_xla._XLAC._set_use_eager_mode(saved_eager_mode_status)
 
 
 def manual_seed(seed, device=None):


### PR DESCRIPTION
Here is my plan, @will-cromar let me know what you think

1. ask users to use `torch_xla.experimental.compile`(and torch_xla.step()) to wrap their step fn which will mark_step the outside region for them
2. ask users to turn on eager mode later

Pretty much we can stage the effort for this ux migration. For this to work I need to make `torch_xla.step` handles eager mode, I will do that in a follow up pr.