### PR TITLE
Update TPU ARC cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ torch_xla/csrc/version.cpp
 /docs/src/*
 
 # Local terraform state
-.terraform*
+.terraform
 
 
 # Build system temporary files

--- a/infra/terraform_modules/arc_v4_container_cluster/main.tf
+++ b/infra/terraform_modules/arc_v4_container_cluster/main.tf
@@ -73,7 +73,7 @@ resource "google_container_node_pool" "arc_v4_tpu_nodes" {
 
 resource "helm_release" "arc" {
   name             = "actions-runner-controller"
-  chart            = "oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller"
+  chart            = "oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controlle:0.9.3"
   namespace        = var.arc_namespace
   create_namespace = true
 }
@@ -83,7 +83,7 @@ resource "helm_release" "arc_runner_set" {
   depends_on = [
     helm_release.arc
   ]
-  chart            = "oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set"
+  chart            = "oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set:0.9.3"
   namespace        = var.runner_namespace
   create_namespace = true
 

--- a/infra/terraform_modules/arc_v4_container_cluster/main.tf
+++ b/infra/terraform_modules/arc_v4_container_cluster/main.tf
@@ -73,7 +73,7 @@ resource "google_container_node_pool" "arc_v4_tpu_nodes" {
 
 resource "helm_release" "arc" {
   name             = "actions-runner-controller"
-  chart            = "oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controlle:0.9.3"
+  chart            = "oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller:0.9.3"
   namespace        = var.arc_namespace
   create_namespace = true
 }

--- a/infra/tpu-pytorch/.terraform.lock.hcl
+++ b/infra/tpu-pytorch/.terraform.lock.hcl
@@ -1,0 +1,41 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.37.0"
+  constraints = ">= 4.52.0"
+  hashes = [
+    "h1:+0FfxQm8+OxXM6tDF8UCA2ir59Gel4oSnLoJoKkGCpc=",
+    "zh:00754c426ec8c2416d54904b25ebf3d831b5af4f02a20336d0a60d91897497d7",
+    "zh:0b4128affc12ace78d9cbd8aac308b992cc1829effba0ac761b4c3e9e37a36e2",
+    "zh:46afda4cdadc242b0a27acb181967b7a37768aa084c84593506490483fbdefd6",
+    "zh:4ad56e9d5ed5e05184bd0a23e17b6eb985c28e7ce23ce29fdf50daa5594ead69",
+    "zh:557b021f77bd97462b20519148f454158e6cf89eba5461ae6016568b317e1c87",
+    "zh:6552bb5e901e9fbcd95dc95b4e017dfd7c1eca465dd749f9c8afdc4ae2bf3213",
+    "zh:687347e31e69f2c4518abc057ad157ed4fd2b78e399b3a172bcab4277f7a235b",
+    "zh:a66bfc55856693fe82a81554abf7fd72b8ca2d56a08cb59c4769c15b1a1acea5",
+    "zh:a8b242c5aab000f2a27e934930a75656efb4a96fdb06a419b22ae0daffa6fba3",
+    "zh:da9e9b40d632f218a3e0bb88b8cf95b91485cee1eb2fd2a384d45c2619c36da4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fda7bd1578e4b40e9e2d0298c77b0ad9f4486abee8ad38755299dd4b06be54c7",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version = "2.14.0"
+  hashes = [
+    "h1:MCwlHF214XoAqJ11wR1SQuZmjJyAagKOqgSzl9hHrPg=",
+    "zh:087a475fda3649e4b6b9aeb5f21704972f5d85c10d0bf334289b0a1b8c1a5575",
+    "zh:1877991d976491d4e2a653a89491bd3b92123a00f442f15aa62caea8902677c7",
+    "zh:233d9e550b900be8bbf62871322964239bb4827b3500b77d7e2652a8bae6a106",
+    "zh:6ed09d405ade276dfc6ec591d113ca328ea3fe423405d4bc1116f7a06dfd86ec",
+    "zh:9039de4cbee5ae006d9cbf27f40f0a285feb02c3b00901535a1112853de55b5f",
+    "zh:aea6311b0f29edddefa21b8c7953314459caeace77d72d60588d1277f1723c54",
+    "zh:bd6a4fea3461c2751527f1c4e4c2c160e72f5b5a3b5cfbfe051adf61badd5ead",
+    "zh:c5f12a2ea4c3b62d9dd2d8f62c9918ef77b1f9dd4d6ccf1758a2a24139ab5319",
+    "zh:cd84d7258f263c3bd24138e7633b022451fdc1935a11e34932b63f71bbe6059f",
+    "zh:e637d01ee4dc2e5702d62c158399ab0d0ba3269e71f5db38db922ff05505ae2a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fbf9c9936ae547b75a81170b7bd20f72bc5538e015efcf7d12f822358d758f57",
+  ]
+}

--- a/test/tpu/Dockerfile
+++ b/test/tpu/Dockerfile
@@ -3,12 +3,12 @@ FROM us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:tpu as b
 # Replace value with the latest runner release version
 # source: https://github.com/actions/runner/releases
 # ex: 2.303.0
-ARG RUNNER_VERSION="2.316.1"
+ARG RUNNER_VERSION="2.317.0"
 ARG RUNNER_ARCH="x64"
 # Replace value with the latest runner-container-hooks release version
 # source: https://github.com/actions/runner-container-hooks/releases
 # ex: 0.3.1
-ARG RUNNER_CONTAINER_HOOKS_VERSION="0.6.0"
+ARG RUNNER_CONTAINER_HOOKS_VERSION="0.6.1"
 
 ARG USER=runner
 


### PR DESCRIPTION
Our TPU CI cluster stopped working. Let's try updating it.

- Add explicit version to helm charts (hopefully triggers redeploy :crossed_fingers:)
- Update versions of everything ARC
- Add lock file according to https://developer.hashicorp.com/terraform/language/files/dependency-lock

Terraform plan:

<details>

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.v4_arc_cluster.helm_release.arc will be updated in-place
  ~ resource "helm_release" "arc" {
      ~ chart                      = "oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller" -> "oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller:0.9.3"
        id                         = "actions-runner-controller"
      ~ metadata                   = [
          - {
              - app_version    = "0.8.3"
              - chart          = "gha-runner-scale-set-controller"
              - first_deployed = 1709750811
              - last_deployed  = 1709750811
              - name           = "actions-runner-controller"
              - namespace      = "arc-systems"
              - notes          = <<-EOT
                    Thank you for installing gha-runner-scale-set-controller.
                    
                    Your release is named actions-runner-controller.
                EOT
              - revision       = 1
              - values         = jsonencode({})
              - version        = "0.8.3"
            },
        ] -> (known after apply)
        name                       = "actions-runner-controller"
        # (24 unchanged attributes hidden)
    }

  # module.v4_arc_cluster.helm_release.arc_runner_set will be updated in-place
  ~ resource "helm_release" "arc_runner_set" {
      ~ chart                      = "oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set" -> "oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set:0.9.3"
        id                         = "v4-runner-set"
      ~ metadata                   = [
          - {
              - app_version    = "0.8.3"
              - chart          = "gha-runner-scale-set"
              - first_deployed = 1709750824
              - last_deployed  = 1719853788
              - name           = "v4-runner-set"
              - namespace      = "arc-runners"
              - notes          = <<-EOT
                    Thank you for installing gha-runner-scale-set.
                    
                    Your release is named v4-runner-set.
                EOT
              - revision       = 2
              - values         = jsonencode(
                    {
                      - githubConfigSecret = "github-pat"
                      - githubConfigUrl    = "https://github.com/pytorch/xla"
                      - maxRunners         = 2
                      - minRunners         = 1
                      - template           = {
                          - spec = {
                              - containers   = [
                                  - {
                                      - command   = [
                                          - "/home/runner/run.sh",
                                        ]
                                      - image     = "gcr.io/tpu-pytorch/tpu-ci-runner:latest"
                                      - name      = "runner"
                                      - resources = {
                                          - limits   = {
                                              - "google.com/tpu" = 4
                                            }
                                          - requests = {
                                              - "google.com/tpu" = 4
                                            }
                                        }
                                    },
                                ]
                              - nodeSelector = {
                                  - "cloud.google.com/gke-tpu-accelerator" = "tpu-v4-podslice"
                                  - "cloud.google.com/gke-tpu-topology"    = "2x2x1"
                                }
                            }
                        }
                    }
                )
              - version        = "0.8.3"
            },
        ] -> (known after apply)
        name                       = "v4-runner-set"
        # (25 unchanged attributes hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```

</details>