### PR TITLE
Fix helm version format in terraform

### DIFF
--- a/infra/terraform_modules/arc_v4_container_cluster/main.tf
+++ b/infra/terraform_modules/arc_v4_container_cluster/main.tf
@@ -73,7 +73,8 @@ resource "google_container_node_pool" "arc_v4_tpu_nodes" {
 
 resource "helm_release" "arc" {
   name             = "actions-runner-controller"
-  chart            = "oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller:0.9.3"
+  chart            = "oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller"
+  version          = "0.9.3"
   namespace        = var.arc_namespace
   create_namespace = true
 }
@@ -83,7 +84,8 @@ resource "helm_release" "arc_runner_set" {
   depends_on = [
     helm_release.arc
   ]
-  chart            = "oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set:0.9.3"
+  chart            = "oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set"
+  version          = "0.9.3"
   namespace        = var.runner_namespace
   create_namespace = true
 


### PR DESCRIPTION
Apparently the version tag goes in a separate field. Fixes this deployment failure:

```
module.v4_arc_cluster.helm_release.arc: Modifying... [id=actions-runner-controller]
Error: invalid_reference: invalid tag
  with module.v4_arc_cluster.helm_release.arc,
  on ../terraform_modules/arc_v4_container_cluster/main.tf line 74, in resource "helm_release" "arc":
  74: resource "helm_release" "arc" {
```

Tested: ran `terraform apply` already :shushing_face: 