### PR TITLE
add depreacated decorator

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -174,6 +174,7 @@ function run_xla_op_tests1 {
   run_test "$CDIR/test_python_ops.py"
   run_test "$CDIR/test_ops.py"
   run_test "$CDIR/test_metrics.py"
+  run_test "$CDIR/test_deprecation.py"
   run_test "$CDIR/dynamo/test_dynamo_integrations_util.py"
   run_test "$CDIR/dynamo/test_dynamo_aliasing.py"
   run_test "$CDIR/dynamo/test_dynamo.py"

--- a/test/test_deprecation.py
+++ b/test/test_deprecation.py
@@ -1,0 +1,55 @@
+import os
+import logging
+import io
+import unittest
+import importlib
+
+from unittest.mock import patch
+
+from torch_xla.experimental.deprecation import deprecated, mark_deprecated
+
+
+def old_function():
+  return False
+
+
+def new_function():
+  return True
+
+
+@mark_deprecated(new_function)
+def old_funtion_to_wrap():
+  return False
+
+
+class TestDepecation(unittest.TestCase):
+
+  def test_map_to_new_func(self):
+    this_module = importlib.import_module(__name__)
+    old_function = deprecated(this_module, this_module.new_function,
+                              "random_old_name")
+    with self.assertLogs(level='WARNING') as log:
+      result = old_function()
+      self.assertIn("random_old_name", log.output[0])
+      assert (result)
+
+  @patch('__main__.new_function')
+  def test_decorator(self, mock_new_function):
+    mock_new_function.__name__ = "new_name"
+    mock_new_function.return_value = True
+    with self.assertLogs(level='WARNING') as log:
+
+      @mark_deprecated(new_function)
+      def function_to_deprecate():
+        return False
+
+      result = function_to_deprecate()
+      assert (result)
+      self.assertIn("function_to_deprecate", log.output[0])
+      self.assertIn(mock_new_function.__name__, log.output[0])
+      mock_new_function.assert_called_once()
+
+
+if __name__ == '__main__':
+  test = unittest.main()
+  sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/test_deprecation.py
+++ b/test/test_deprecation.py
@@ -4,8 +4,6 @@ import io
 import unittest
 import importlib
 
-from unittest.mock import patch
-
 from torch_xla.experimental.deprecation import deprecated, mark_deprecated
 
 
@@ -15,11 +13,6 @@ def old_function():
 
 def new_function():
   return True
-
-
-@mark_deprecated(new_function)
-def old_funtion_to_wrap():
-  return False
 
 
 class TestDepecation(unittest.TestCase):
@@ -33,7 +26,7 @@ class TestDepecation(unittest.TestCase):
       self.assertIn("random_old_name", log.output[0])
       assert (result)
 
-  @patch('__main__.new_function')
+  @unittest.mock.patch('__main__.new_function')
   def test_decorator(self, mock_new_function):
     mock_new_function.__name__ = "new_name"
     mock_new_function.return_value = True

--- a/torch_xla/experimental/deprecation.py
+++ b/torch_xla/experimental/deprecation.py
@@ -25,8 +25,8 @@ def mark_deprecated(module, new: FN) -> FN:
   """Decorator to mark a function as deprecated and map to new function.
 
   Args:
-    module: current module of the deprecated function is in. Assume current module name is X, you can use `from . import X` and pass X here.
-    new: new function that we map to. Need to include the path the new functioin is in.
+    module: current module of the deprecated function that is in. Assume current module name is X, you can use `from . import X` and pass X here.
+    new: new function that we map to. Need to include the path the new function that is in.
 
   Returns:
     Wrapper of the new function.

--- a/torch_xla/experimental/deprecation.py
+++ b/torch_xla/experimental/deprecation.py
@@ -21,5 +21,34 @@ def deprecated(module, new: FN) -> FN:
   return wrapped
 
 
+def mark_deprecated(module, new: FN) -> FN:
+  """Decorator to mark a function as deprecated and map to new function.
+
+  Args:
+    module: current module of the deprecated function is in. Assume current module name is X, you can use `from . import X` and pass X here.
+    new: new function that we map to. Need to include the path the new functioin is in.
+
+  Returns:
+    Wrapper of the new function.
+  """
+  already_warned = [False]
+
+  def decorator(func):
+
+    @functools.wraps(new)
+    def wrapped(*args, **kwargs):
+      if not already_warned[0]:
+        logging.warning(
+            f'{module.__name__}.{func.__name__} is deprecated. Use {new.__module__}.{new.__name__} instead.'
+        )
+        already_warned[0] = True
+
+      return new(*args, **kwargs)
+
+    return wrapped
+
+  return decorator
+
+
 def register_deprecated(module, new: FN):
   setattr(module, new.__name__, deprecated(module, new))

--- a/torch_xla/experimental/deprecation.py
+++ b/torch_xla/experimental/deprecation.py
@@ -5,14 +5,15 @@ from typing import TypeVar
 FN = TypeVar('FN')
 
 
-def deprecated(module, new: FN) -> FN:
+def deprecated(module, new: FN, old_name=None) -> FN:
   already_warned = [False]
+  old_name = old_name or new.__name__
 
   @functools.wraps(new)
   def wrapped(*args, **kwargs):
     if not already_warned[0]:
       logging.warning(
-          f'{module.__name__}.{new.__name__} is deprecated. Use {new.__module__}.{new.__name__} instead.'
+          f'{module.__name__}.{old_name} is deprecated. Use {new.__module__}.{new.__name__} instead.'
       )
       already_warned[0] = True
 

--- a/torch_xla/experimental/deprecation.py
+++ b/torch_xla/experimental/deprecation.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import importlib
 from typing import TypeVar
 
 FN = TypeVar('FN')
@@ -22,7 +23,7 @@ def deprecated(module, new: FN, old_name=None) -> FN:
   return wrapped
 
 
-def mark_deprecated(module, new: FN) -> FN:
+def mark_deprecated(new: FN) -> FN:
   """Decorator to mark a function as deprecated and map to new function.
 
   Args:
@@ -34,7 +35,8 @@ def mark_deprecated(module, new: FN) -> FN:
   """
 
   def decorator(func):
-    return deprecated(module, new, old_name=func.__name__)
+    return deprecated(
+        importlib.import_module(func.__module__), new, old_name=func.__name__)
 
   return decorator
 

--- a/torch_xla/experimental/deprecation.py
+++ b/torch_xla/experimental/deprecation.py
@@ -32,21 +32,9 @@ def mark_deprecated(module, new: FN) -> FN:
   Returns:
     Wrapper of the new function.
   """
-  already_warned = [False]
 
   def decorator(func):
-
-    @functools.wraps(new)
-    def wrapped(*args, **kwargs):
-      if not already_warned[0]:
-        logging.warning(
-            f'{module.__name__}.{func.__name__} is deprecated. Use {new.__module__}.{new.__name__} instead.'
-        )
-        already_warned[0] = True
-
-      return new(*args, **kwargs)
-
-    return wrapped
+    return deprecated(module, new, old_name=func.__name__)
 
   return decorator
 


### PR DESCRIPTION
Introduce the `mark_deprecated` decorator to map deprecated function to the new function. The reason is that existing deprecated function only maps to function with the same name. It's impossible to map function like `xrt_world_size` to `world_size`.

Instead of passing old function to the deprecation wrapper, I think use the decorator above the old function is the most straightward.

Example to use:
```
import torch_xla
from torch_xla.experimental.deprecation import mark_deprecated

@mark_deprecated(torch_xla.runtime.world_size)
def xrt_world_size(defval=1):
  """Retrieves the number of devices which is taking part of the replication.

  Args:
    defval (int, optional): The default value to be returned in case there is no
      replication information available.
      Default: 1

  Returns:
    The number of devices which is taking part of the replication.
  """
  global _WORLD_SIZE
  if _WORLD_SIZE is not None:
    return _WORLD_SIZE

  return runtime.world_size()
```

Output:
```
>>> import torch_xla
>>> torch_xla.core.xla_model.xrt_world_size()
WARNING:root:torch_xla.core.xla_model.xrt_world_size is deprecated. Use torch_xla.runtime.world_size instead.
1
```