### PR TITLE
Unify the logics to check eager mode

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -600,7 +600,7 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     self.assertEqual(x.device.type, 'xla')
 
   def test_randperm(self):
-    x = torch.randperm(3, device=xm.xla_device())
+    x = torch.randperm(3, device=xm.xla_device(), dtype=torch.int32)
     self.assertEqual(x.device.type, 'xla')
 
   def test_randn_like(self):
@@ -2354,7 +2354,7 @@ class TestWaitDeviceOps(test_utils.XlaTestCase):
     xm.mark_step()
     xm.wait_device_ops()
     self.assertTrue("ExecuteTime" in met.metric_names() or
-                    "ExecuteChainedTime" in met.metric_names())
+                    "EagerOpExecuteTime" in met.metric_names())
 
 
 class TestDebuggingUtil(test_utils.XlaTestCase):

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -243,6 +243,10 @@ if os.getenv('XLA_REGISTER_INSTALLED_PLUGINS',
   plugins.use_dynamic_plugins()
   plugins.register_installed_plugins()
 
+if os.getenv('XLA_USE_EAGER_DEBUG_MODE', '0') == '1':
+  from .experimental import eager_mode
+  eager_mode(True)
+
 from .torch_xla import *
 
 # register all custom kenels and decomp by default

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -86,8 +86,7 @@ XLATensorPtr XLATensor::Create(
       XLATensor(std::move(ir_value), device, logical_element_type));
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   graph_executor->RegisterTensor(xtensor->data());
-  if ((UseEagerDebugMode() || graph_executor->UseEagerMode()) &&
-      !delay_eager_executation) {
+  if ((graph_executor->UseEagerMode()) && !delay_eager_executation) {
     std::vector<XLATensorPtr> xtensors({xtensor});
     graph_executor->ApplyEagerSync(xtensors);
   }
@@ -330,7 +329,8 @@ void XLATensor::SetXlaData(torch::lazy::BackendDataPtr handle, bool sync) {
   data()->is_cloned = false;
 }
 
-void XLATensor::SetIrValue(torch::lazy::Value ir_value, bool inplace) {
+void XLATensor::SetIrValue(torch::lazy::Value ir_value, bool inplace,
+                           bool delay_eager_executation) {
   data()->handle = nullptr;
   data()->tensor_data = std::nullopt;
   if (data()->view != nullptr && inplace) {
@@ -346,11 +346,15 @@ void XLATensor::SetIrValue(torch::lazy::Value ir_value, bool inplace) {
     AssignIrValue(std::move(ir_value));
     TryLimitGraphSize();
   }
-  if (UseEagerDebugMode() && ShouldSyncIrNode()) {
-    std::vector<XLATensorPtr> xtensors({c10::make_intrusive<XLATensor>(*this)});
-    XLAGraphExecutor::Get()->ApplyEagerSync(xtensors);
-  }
   data()->is_cloned = false;
+
+  XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
+  // Update should also be triggered eagerly if configured
+  if (graph_executor->UseEagerMode() && !delay_eager_executation &&
+      ShouldSyncIrNode()) {
+    std::vector<XLATensorPtr> xtensors({c10::make_intrusive<XLATensor>(*this)});
+    graph_executor->ApplyEagerSync(xtensors);
+  }
 }
 
 void XLATensor::SetInPlaceIrValue(torch::lazy::Value ir_value,
@@ -360,14 +364,7 @@ void XLATensor::SetInPlaceIrValue(torch::lazy::Value ir_value,
     ir_value =
         torch::lazy::MakeNode<Cast>(ir_value, xla_shape.get().element_type());
   }
-  SetIrValue(std::move(ir_value), /*inplace=*/true);
-  XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
-
-  // in place update should also be triggered eagerly if configured
-  if (graph_executor->UseEagerMode() && !delay_eager_executation) {
-    std::vector<XLATensorPtr> xtensors({c10::make_intrusive<XLATensor>(*this)});
-    graph_executor->ApplyEagerSync(xtensors);
-  }
+  SetIrValue(std::move(ir_value), /*inplace=*/true, delay_eager_executation);
 }
 
 void XLATensor::AssignIrValue(torch::lazy::Value ir_value) const {
@@ -659,12 +656,6 @@ void XLATensor::ApplyPendingGraph() {
     XLAGraphExecutor::Get()->SyncTensorsGraph(&tensors, {}, /*wait=*/true,
                                               /*sync_xla_data=*/false);
   }
-}
-
-bool XLATensor::UseEagerDebugMode() {
-  static const bool use_eager_debug_mode =
-      runtime::sys_util::GetEnvBool("XLA_USE_EAGER_DEBUG_MODE", false);
-  return use_eager_debug_mode;
 }
 
 bool XLATensor::ShouldSyncIrNode() {

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -86,7 +86,7 @@ XLATensorPtr XLATensor::Create(
       XLATensor(std::move(ir_value), device, logical_element_type));
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   graph_executor->RegisterTensor(xtensor->data());
-  if ((graph_executor->UseEagerMode()) && !delay_eager_executation) {
+  if (graph_executor->UseEagerMode() && !delay_eager_executation) {
     std::vector<XLATensorPtr> xtensors({xtensor});
     graph_executor->ApplyEagerSync(xtensors);
   }

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -231,7 +231,8 @@ class XLATensor : public torch::lazy::LazyTensor {
   // internal state of the object.
   // TODO(alanwaketan): Reuse the upstream ones once Functionalization is done.
   torch::lazy::Value GetIrValue() const;
-  void SetIrValue(torch::lazy::Value ir_value, bool inplace = true);
+  void SetIrValue(torch::lazy::Value ir_value, bool inplace = true,
+                  bool delay_eager_executation = false);
   void SetInPlaceIrValue(torch::lazy::Value ir_value,
                          bool delay_eager_executation = false);
 
@@ -333,8 +334,6 @@ class XLATensor : public torch::lazy::LazyTensor {
   torch::lazy::Value GetIrValueForTensor(
       const at::Tensor& tensor,
       const torch::lazy::BackendDevice& device) const final;
-
-  static bool UseEagerDebugMode();
 
   bool ShouldSyncIrNode();
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2035,9 +2035,9 @@ void max_out(XLATensorPtr& max, XLATensorPtr& max_values,
       torch::lazy::GetCanonicalDimensionIndex(dim, input->shape().get().rank());
   torch::lazy::NodePtr node = torch::lazy::MakeNode<MaxInDim>(
       input->GetIrValue(), canonical_dim, keepdim);
-  max->SetIrValue(torch::lazy::Value(node, 0),
+  max->SetIrValue(torch::lazy::Value(node, 0), /*inplace=*/true,
                   /*delay_eager_executation=*/true);
-  max_values->SetIrValue(torch::lazy::Value(node, 1),
+  max_values->SetIrValue(torch::lazy::Value(node, 1), /*inplace=*/true,
                          /*delay_eager_executation=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
@@ -2143,9 +2143,9 @@ void min_out(XLATensorPtr& min, XLATensorPtr& min_indices,
       torch::lazy::GetCanonicalDimensionIndex(dim, input->shape().get().rank());
   torch::lazy::NodePtr node = torch::lazy::MakeNode<MinInDim>(
       input->GetIrValue(), canonical_dim, keepdim);
-  min->SetIrValue(torch::lazy::Value(node, 0),
+  min->SetIrValue(torch::lazy::Value(node, 0), /*inplace=*/true,
                   /*delay_eager_executation=*/true);
-  min_indices->SetIrValue(torch::lazy::Value(node, 1),
+  min_indices->SetIrValue(torch::lazy::Value(node, 1), /*inplace=*/true,
                           /*delay_eager_executation=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
@@ -2296,13 +2296,13 @@ std::tuple<XLATensorPtr, XLATensorPtr, XLATensorPtr> native_batch_norm(
       running_mean->SetIrValue(
           torch::lazy::MakeNode<LinearInterpolation>(
               mean->GetIrValue(), running_mean->GetIrValue(), momentum),
-          /*delay_eager_executation=*/true);
+          /*inplace=*/true, /*delay_eager_executation=*/true);
     }
     if (running_var) {
       running_var->SetIrValue(
           torch::lazy::MakeNode<LinearInterpolation>(
               torch::lazy::Value(node, 2), running_var->GetIrValue(), momentum),
-          /*delay_eager_executation=*/true);
+          /*inplace=*/true, /*delay_eager_executation=*/true);
     }
   } else {
     at::Tensor at_input = bridge::AtenFromXlaTensor(input);


### PR DESCRIPTION
Prior to my eager mode changes, eager mode is a debug only mode that's controlled by the `XLA_USE_EAGER_DEBUG_MODE ` env var, now since we want to make it more offical I want to control it explictly with the API instead of the env var. @aws-rhsoln let me know what you think. Eventually I want to deprecate the env var(at least not call it debug mode).