### PR TITLE
Update OpenXLA pin as of 07172024

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,7 +50,7 @@ new_local_repository(
 #    curl -L https://github.com/openxla/xla/archive/<git hash>.tar.gz | sha256sum
 #    and update the sha256 with the result.
 
-xla_hash = 'db472b8c3d83bc27b3c67067802b9a37ef7542e3'
+xla_hash = '652f031d72accb9ffc4bd0050405e05b5261b30f'
 
 http_archive(
     name = "xla",

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ import build_util
 
 base_dir = os.path.dirname(os.path.abspath(__file__))
 
-_date = '20240711'
+_date = '20240718'
 _libtpu_version = f'0.1.dev{_date}'
 _libtpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
 _jax_version = f'0.4.31.dev{_date}'

--- a/torch_xla/csrc/runtime/ifrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.cc
@@ -637,7 +637,7 @@ int IfrtComputationClient::GetNumProcesses() const {
 const absl::flat_hash_map<
     std::string, torch_xla::runtime::ComputationClient::DeviceAttribute>
 IfrtComputationClient::GetDeviceAttributes(const std::string& device) {
-  return xla::ifrt::ToPjRtDeviceAttributeMap(
+  return xla::ifrt::ToPjRtAttributeMap(
       IfrtComputationClient::StringToIfrtDevice(device)->Attributes());
 }
 


### PR DESCRIPTION
Update OpenXLA pin as of 07172024

Fixes
- Rename ToPjRtDeviceAttributeMap to ToPjRtAttributeMap (https://github.com/openxla/xla/commit/dd77329b26c1d2e5986b6a733b07a527099aa765)

 