### PR TITLE
Build CUDA plugin before `torch` and `torch_xla` in nightly build

### DIFF
--- a/infra/ansible/Dockerfile
+++ b/infra/ansible/Dockerfile
@@ -8,6 +8,8 @@ RUN pip install ansible
 COPY . /ansible
 
 ARG ansible_vars
+# HACK: install build dependencies only, but skip build step
+RUN ansible-playbook -vvv playbook.yaml -e "stage=build" -e "${ansible_vars}" --tags "bazel,configure_env,install_deps"
 RUN ansible-playbook -vvv playbook.yaml -e "stage=build_plugin" -e "${ansible_vars}" 
 RUN ansible-playbook -vvv playbook.yaml -e "stage=build" -e "${ansible_vars}" --skip-tags=fetch_srcs,install_deps
 

--- a/infra/ansible/Dockerfile
+++ b/infra/ansible/Dockerfile
@@ -8,8 +8,8 @@ RUN pip install ansible
 COPY . /ansible
 
 ARG ansible_vars
-RUN ansible-playbook -vvv playbook.yaml -e "stage=build" -e "${ansible_vars}"
-RUN ansible-playbook -vvv playbook.yaml -e "stage=build_plugin" -e "${ansible_vars}" --skip-tags=fetch_srcs,install_deps
+RUN ansible-playbook -vvv playbook.yaml -e "stage=build_plugin" -e "${ansible_vars}" 
+RUN ansible-playbook -vvv playbook.yaml -e "stage=build" -e "${ansible_vars}" --skip-tags=fetch_srcs,install_deps
 
 FROM python:${python_version}-${debian_version} AS release
 


### PR DESCRIPTION
The nightly CUDA package build is failing with this error:

```
Step #2 - "build_xla_docker_image":       Error in repository_rule: invalid repository name '@pypi_torch_nightly+20240722_cp311_cp311_linux_x86_64_whl'
```

AFAICT this is happening because the `build_srcs` step is producing incorrectly-named wheels (see #7697). The GPU plugin build has zero dependency on PyTorch at all -- it builds completely separately in our CI. I believe it is unfortunately getting pulled in transitively through OpenXLAs build rules: https://github.com/pytorch/xla/blob/5ea4535f0699f366adb554183a65ebf7dc34a8be/WORKSPACE#L100

Move the plugin build to happen first as a temporary fix since there's no dependency between these steps.

Triggering the nightly build manually to see if this works