### PR TITLE
Re-implement and refactor the verifier.

### DIFF
--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -221,6 +221,9 @@ class BenchmarkExperiment:
     short_strs = map(to_short_string, self.to_dict().values())
     return "-".join(short_strs).replace(" ", "")
 
+  def is_cuda(self):
+    return self.accelerator == "cuda"
+
   def to_dict(self):
     d = OrderedDict()
     d["accelerator"] = self.accelerator

--- a/benchmarks/benchmark_model.py
+++ b/benchmarks/benchmark_model.py
@@ -59,17 +59,27 @@ class BenchmarkModel:
       self.optimizer = self.optimizer_class(self.module.parameters(), lr=0.01)
 
   def tolerance(self):
+    """Tolerance to be used by the verifier.
+    """
+    # Default value taken from: PyTorch
+    # Source: benchmarks/dynamo/torchbench.py
     return 1e-4
 
   def use_cosine_similarity(self):
+    """Whether the verifier should use cosine similarity for checking the result's accuracy.
+    """
+    # Default value taken from: PyTorch
+    # Source: benchmarks/dynamo/torchbench.py
     return False
 
   def conversion_dtype(self):
     return None
 
-  def prepare_for_experiment(self,
-                             dynamo_compilation_opts: Dict[str, str],
-                             force_dtype: Optional[torch.dtype] = None):
+  def prepare_for_experiment(
+      self,
+      dynamo_compilation_opts: Dict[str, str],
+      force_dtype: Optional[torch.dtype] = None,
+  ):
     self.device = self.benchmark_experiment.get_device()
 
     if force_dtype is None:
@@ -212,20 +222,30 @@ class ModelLoader:
   def get_benchmark_indices(self, length: int):
     start = self._args.partition_id * (length // self._args.total_partitions)
     end = ((self._args.partition_id + 1) *
-           (length // self._args.total_partitions)
-           if self._args.partition_id < self._args.total_partitions - 1 else
-           length)
+           (length // self._args.total_partitions) if self._args.partition_id
+           < self._args.total_partitions - 1 else length)
     return start, end
 
   def skip_model(self, model_name: str):
     return (not re.search("|".join(self._args.filter), model_name, re.I) or
             re.search("|".join(self._args.exclude), model_name, re.I))
 
-  def load_model(self,
-                 model_config: Dict[str, Any],
-                 benchmark_experiment: BenchmarkExperiment,
-                 dummy: bool = False,
-                 force_dtype: Optional[torch.dtype] = None) -> BenchmarkModel:
+  def load_model(
+      self,
+      model_config: Dict[str, Any],
+      benchmark_experiment: BenchmarkExperiment,
+      dummy: bool = False,
+      force_dtype: Optional[torch.dtype] = None,
+  ) -> BenchmarkModel:
+    """Loads the model.
+
+    Using both model and experiment configuration, this function will return an
+    instance of BenchmarkModel.
+
+    If specified, `force_dtype` will force the underlying model to be cast to
+    that data type. This is useful when running the verifier, where we force
+    float64 data-type for checking the accuracy.
+    """
     suite_name = self.suite_name
     model_name = model_config["model_name"]
     benchmark_model = self.benchmark_model_class(

--- a/benchmarks/benchmark_model.py
+++ b/benchmarks/benchmark_model.py
@@ -58,6 +58,11 @@ class BenchmarkModel:
       # optimizer to use. So only initialize it when there is none existing.
       self.optimizer = self.optimizer_class(self.module.parameters(), lr=0.01)
 
+  def skip_verifier(self):
+    """Returns whether the verifier should be skipped for this model.
+    """
+    return False
+
   def tolerance(self):
     """Tolerance to be used by the verifier.
     """

--- a/benchmarks/benchmark_model.py
+++ b/benchmarks/benchmark_model.py
@@ -9,7 +9,7 @@ from torch._dynamo.testing import collect_results
 from torch.utils import _pytree as pytree
 from util import cast_to_dtype, move_to_device
 from benchmark_experiment import BenchmarkExperiment
-from typing import Dict, Any, Sequence
+from typing import Any, Dict, Optional, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +57,12 @@ class BenchmarkModel:
       # For some special models, self.set_up() may have initialized an
       # optimizer to use. So only initialize it when there is none existing.
       self.optimizer = self.optimizer_class(self.module.parameters(), lr=0.01)
+
+  def tolerance(self):
+    return 1e-4
+
+  def use_cosine_similarity(self):
+    return False
 
   def conversion_dtype(self):
     return None

--- a/benchmarks/benchmark_model.py
+++ b/benchmarks/benchmark_model.py
@@ -227,8 +227,9 @@ class ModelLoader:
   def get_benchmark_indices(self, length: int):
     start = self._args.partition_id * (length // self._args.total_partitions)
     end = ((self._args.partition_id + 1) *
-           (length // self._args.total_partitions) if self._args.partition_id
-           < self._args.total_partitions - 1 else length)
+           (length // self._args.total_partitions)
+           if self._args.partition_id < self._args.total_partitions - 1 else
+           length)
     return start, end
 
   def skip_model(self, model_name: str):

--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -13,7 +13,7 @@ import torch
 import torch._dynamo.utils as dynamo_utils
 import tiers
 import typing
-from typing import Optional, Any, List, Dict, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 import torch_xla.debug.metrics as met
 from tqdm import tqdm
 from enum import Enum
@@ -22,12 +22,12 @@ from torch.profiler import profile, ProfilerActivity
 import copy
 from torch.autograd import DeviceType
 from benchmark_model import ModelLoader
-from verifier import VerificationCode, VerificationResult, verify
+from verifier import VerificationCode, verify
 from enum import Enum
 from torchbench_model import TorchBenchModelLoader
 from benchmark_model import BenchmarkModel
 from benchmark_experiment import ExperimentLoader, BenchmarkExperiment
-from util import move_to_device, randomize_input, reset_rng_state, us_to_s, ns_to_s, StrOrBool
+from util import cleanup, move_to_device, randomize_input, reset_rng_state, us_to_s, ns_to_s, StrOrBool
 
 import torch_xla.core.xla_model as xm
 import torch_xla.debug.profiler as xp
@@ -129,20 +129,18 @@ class ExperimentRunner:
         if (not self._args.no_skip and not self.model_loader.is_compatible(
             benchmark_model, benchmark_experiment)):
           logger.warning("SKIP incompatible model and experiment configs.")
-          self._save_results(benchmark_experiment.to_dict(),
-                             benchmark_model.to_dict(), {"error": "SKIP"})
+          self._save_results(
+              benchmark_experiment.to_dict(),
+              benchmark_model.to_dict(),
+              metrics={"error": "SKIP"},
+              verification_code=VerificationCode.VERIFIER_SKIPPED,
+          )
           continue
 
         # Compose child process environment.
         process_env = os.environ.copy()
         benchmark_experiment.update_process_env(process_env)
-        try:
-          benchmark_model.update_process_env(process_env)
-        except ValueError as e:
-          logger.error(f"ERROR preparing child env: {e}")
-          self._save_results(benchmark_experiment.to_dict(),
-                             benchmark_model.to_dict(), {"error": str(e)})
-          continue
+        benchmark_model.update_process_env(process_env)
 
         # Setup HLO dumps.
         if self._args.dump_hlo:
@@ -180,21 +178,37 @@ class ExperimentRunner:
         except subprocess.TimeoutExpired as e:
           self._fwd_captured_stdout_stderr(e.stdout, e.stderr)
           logger.error("TIMEOUT")
-          self._save_results(benchmark_experiment.to_dict(),
-                             benchmark_model.to_dict(), {"error": str(e)})
+          self._save_results(
+              benchmark_experiment.to_dict(),
+              benchmark_model.to_dict(),
+              metrics={"error": str(e)},
+              verification_code=VerificationCode.VERIFIER_SKIPPED_UNEXPECTEDLY,
+          )
         except subprocess.CalledProcessError as e:
           self._fwd_captured_stdout_stderr(e.stdout, e.stderr)
           logger.error("ERROR in subprocess")
-          self._save_results(benchmark_experiment.to_dict(),
-                             benchmark_model.to_dict(), {"error": e.stderr})
+          self._save_results(
+              benchmark_experiment.to_dict(),
+              benchmark_model.to_dict(),
+              metrics={"error": e.stderr},
+              verification_code=VerificationCode.VERIFIER_SKIPPED_UNEXPECTEDLY,
+          )
         except subprocess.SubprocessError as e:
           logger.error("ERROR when launching child process")
-          self._save_results(benchmark_experiment.to_dict(),
-                             benchmark_model.to_dict(), {"error": str(e)})
+          self._save_results(
+              benchmark_experiment.to_dict(),
+              benchmark_model.to_dict(),
+              metrics={"error": str(e)},
+              verification_code=VerificationCode.VERIFIER_SKIPPED_UNEXPECTEDLY,
+          )
         except ValueError as e:
           logger.error(f"ERROR {e}")
-          self._save_results(benchmark_experiment.to_dict(),
-                             benchmark_model.to_dict(), {"error": str(e)})
+          self._save_results(
+              benchmark_experiment.to_dict(),
+              benchmark_model.to_dict(),
+              metrics={"error": str(e)},
+              verification_code=VerificationCode.VERIFIER_SKIPPED_UNEXPECTEDLY,
+          )
 
   # TODO: Use `_unique_basename` instead.
   def _get_config_fingerprint(
@@ -255,29 +269,46 @@ class ExperimentRunner:
                                                    benchmark_experiment)
 
     # Repeat the experiment and accumulate metrics.
-    last_output = None
     with benchmark_model.pick_grad():
       accumulated_metrics = OrderedDict()
       for repeat_iteration in range(self._args.repeat):
-        metrics, last_output = self.run_once_and_gather_metrics(
-            benchmark_experiment, benchmark_model, experiment_config,
-            model_config, repeat_iteration)
+        metrics, _ = self.run_once_and_gather_metrics(benchmark_experiment,
+                                                      benchmark_model,
+                                                      experiment_config,
+                                                      model_config,
+                                                      repeat_iteration)
         for k, v in metrics.items():
           if k not in accumulated_metrics:
             accumulated_metrics[k] = []
           accumulated_metrics[k].append(v)
 
-    verify_res = verify(
-        last_output,
-        experiment_config,
-        model_config,
-        self.experiment_loader,
-        self.model_loader,
-        mean_rel_error_tolerance=0.02,  # allow max 2% difference w.r.t eager runtime
-        noop=not self._args.verify)
-    self._save_results(benchmark_experiment.to_dict(),
-                       benchmark_model.to_dict(), accumulated_metrics,
-                       verify_res)
+    # Save the dict representation before deleting them.
+    # This will be used later for saving the results.
+    experiment_dict = benchmark_experiment.to_dict()
+    model_dict = benchmark_model.to_dict()
+
+    # Save other model-specific configuration: tolerance and whether
+    # to use cosine similarity on accuracy checks.
+    tolerance = benchmark_model.tolerance()
+    use_cosine_similarity = benchmark_model.use_cosine_similarity()
+    skip_verifier = benchmark_model.skip_verifier()
+
+    # Delete the instantiated BenchmarkModel, so we can save memory
+    # for verifying the result.
+    del benchmark_model
+    cleanup(benchmark_experiment)
+
+    # Run the verifier iff:
+    #
+    #   1. We are running this script with --verify flag
+    #   2. It should not be skipped
+    if self._args.verify and not skip_verifier:
+      res = verify(self, experiment_config, model_config, tolerance,
+                   use_cosine_similarity)
+    else:
+      res = VerificationCode.SKIP_VERIFICATION
+
+    self._save_results(experiment_dict, model_dict, accumulated_metrics, res)
 
   def run_once_and_gather_metrics(
       self, benchmark_experiment: BenchmarkExperiment,
@@ -530,8 +561,8 @@ class ExperimentRunner:
       experiment_config: typing.OrderedDict[str, Optional[StrOrBool]],
       model_config: typing.OrderedDict[str, Optional[StrOrBool]],
       metrics: typing.OrderedDict[str, Any],
-      verification_result: Optional[VerificationResult] = VerificationResult(
-          VerificationCode.CANNOT_PROCEED_WITH_VERIFICATION)):
+      verification_code: VerificationCode,
+  ):
     results = OrderedDict()
     results["model"] = model_config
     results["experiment"] = experiment_config
@@ -539,8 +570,7 @@ class ExperimentRunner:
     results["iterations_per_run"] = self._args.iterations_per_run
     results["metrics"] = metrics
     results["timestamp"] = self._args.timestamp
-    results["verification_code"] = verification_result.result_code
-    results["verification_mean_rel_error"] = verification_result.mean_rel_error
+    results["verification_code"] = verification_code
     with open(self.output_file, mode="a", encoding="utf-8") as f:
       json.dump(results, f, ensure_ascii=False)
       f.write("\n")

--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -296,7 +296,7 @@ class ExperimentRunner:
     # Delete the instantiated BenchmarkModel, so we can save memory
     # for verifying the result.
     del benchmark_model
-    cleanup(benchmark_experiment)
+    cleanup(benchmark_experiment.is_cuda())
 
     # Run the verifier iff:
     #

--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -975,10 +975,10 @@ def parse_args(args=None):
       help="""If set, verifies the model output with PT Eager mode, and saves relative error to the output file."""
   )
   parser.add_argument(
-    "--verify-iterations",
-    type=int,
-    default=1,
-    help="Number of iterations to be run in the verification process.",
+      "--verify-iterations",
+      type=int,
+      default=1,
+      help="Number of iterations to be run in the verification process.",
   )
   parser.add_argument(
       "--no-skip",

--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -306,7 +306,7 @@ class ExperimentRunner:
       res = verify(self, experiment_config, model_config, tolerance,
                    use_cosine_similarity)
     else:
-      res = VerificationCode.SKIP_VERIFICATION
+      res = VerificationCode.VERIFIER_SKIPPED
 
     self._save_results(experiment_dict, model_dict, accumulated_metrics, res)
 

--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -975,6 +975,12 @@ def parse_args(args=None):
       help="""If set, verifies the model output with PT Eager mode, and saves relative error to the output file."""
   )
   parser.add_argument(
+    "--verify-iterations",
+    type=int,
+    default=1,
+    help="Number of iterations to be run in the verification process.",
+  )
+  parser.add_argument(
       "--no-skip",
       action="store_true",
       help="Do not skip any model.",

--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -356,6 +356,10 @@ class TorchBenchModel(BenchmarkModel):
     return self.is_accelerator_tpu() or (self.model_name == "moco" and
                                          self.benchmark_experiment.xla)
 
+  def skip_verifier(self):
+    return self.model_name in (config().accuracy.skip.large_models |
+                               config().accuracy.skip.eager_not_deterministic)
+
   def is_inference(self):
     return self.benchmark_experiment.test == "eval"
 

--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -279,7 +279,7 @@ class TorchBenchModel(BenchmarkModel):
       if self.is_accelerator_cuda() and not keep_model_data_on_cuda:
         self.module = self.module.to("cpu")
         self.example_inputs = move_to_device(self.example_inputs, "cpu")
-        cleanup(self.benchmark_experiment)
+        cleanup(self.is_accelerator_cuda())
 
     # Torchbench has quite different setup for yolov3, so directly passing
     # the right example_inputs
@@ -288,7 +288,7 @@ class TorchBenchModel(BenchmarkModel):
                                         384, 512),)
 
     del benchmark
-    cleanup(self.benchmark_experiment)
+    cleanup(self.is_accelerator_cuda())
 
   @functools.lru_cache(maxsize=1)
   def benchmark_cls(self):
@@ -367,7 +367,7 @@ class TorchBenchModel(BenchmarkModel):
     return self.benchmark_experiment.test == "train"
 
   def is_accelerator_cuda(self):
-    return self.benchmark_experiment.accelerator == "cuda"
+    return self.benchmark_experiment.is_cuda()
 
   def is_accelerator_tpu(self):
     return self.benchmark_experiment.accelerator == "tpu"

--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -462,6 +462,6 @@ class TorchBenchModel(BenchmarkModel):
     if self.model_name in config().detectron2_models:
       from detectron2.utils.events import EventStorage
       with EventStorage():
-        super().train(inputs, collect_full_output=collect_full_output)
+        return super().train(inputs, collect_full_output=collect_full_output)
     else:
-      super().train(inputs, collect_full_output=collect_full_output)
+      return super().train(inputs, collect_full_output=collect_full_output)

--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -18,7 +18,7 @@ import yaml
 from util import move_to_device, set_cwd, get_torchbench_test_name, find_near_file
 from benchmark_model import ModelLoader, BenchmarkModel
 from benchmark_experiment import BenchmarkExperiment
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, Optional, Sequence, Set, Union
 
 logger = logging.getLogger(__name__)
 
@@ -100,8 +100,35 @@ NEED_LARGER_CACHE = {
 }
 
 
+class _Config:
+
+  def __init__(self, inner: Dict[str, Any]) -> None:
+    self.inner = inner
+
+  def __getattr__(self, attr: str) -> Union["_Config", Set[str]]:
+    if attr not in self.inner:
+      raise AttributeError
+
+    value = self.inner[attr]
+
+    if isinstance(value, dict):
+      return _Config(value)
+
+    return value
+
+  def __contains__(self, item: str) -> bool:
+    return item in self.inner
+
+  def get(self, attr: str, default: Optional[Any] = None) -> Any:
+    if attr not in self.inner and default is None:
+      raise AttributeError
+    return self.inner.get(attr, default)
+
+
+# Parsed YAML configuration file.
+# Source @ PyTorch: benchmarks/dynamo/torchbench.yaml
 @functools.lru_cache(maxsize=1)
-def config_data():
+def config():
   """Retrieve the skip data in the PyTorch YAML file.
 
   Reads the YAML file in PyTorch's dynamo benchmarks directory, and transform
@@ -130,18 +157,7 @@ def config_data():
       return set(flatten(obj))
     return obj
 
-  return maybe_list_to_set(data)
-
-
-# List of models retrieved from the YAML configuration data.
-# File (inside PyTorch main repository): benchmarks/dynamo/torchbench.yaml
-DETECTRON2_MODELS = config_data()["detectron2_models"]
-
-FORCE_AMP_FOR_FP16_BF16_MODELS = config_data(
-)["dtype"]["force_amp_for_fp16_bf16_models"]
-
-FORCE_FP16_FOR_BF16_MODELS = config_data(
-)["dtype"]["force_fp16_for_bf16_models"]
+  return _Config(maybe_list_to_set(data))
 
 
 class TorchBenchModelLoader(ModelLoader):
@@ -185,25 +201,21 @@ class TorchBenchModelLoader(ModelLoader):
 
     return model_configs
 
-  @property
-  def skip(self):
-    return config_data()["skip"]
-
   def is_compatible(self, dummy_benchmark_model: BenchmarkModel,
                     benchmark_experiment: BenchmarkExperiment):
     name = dummy_benchmark_model.model_name
     test = get_torchbench_test_name(benchmark_experiment.test)
 
-    if name in self.skip["all"]:
+    if name in config().skip.all:
       return False
 
-    if name in self.skip["test"].get(test, {}):
+    if name in config().skip.test.get(test, {}):
       return False
 
-    if name in self.skip["device"].get(benchmark_experiment.accelerator, {}):
+    if name in config().skip.device.get(benchmark_experiment.accelerator, {}):
       return False
 
-    if name in self.skip["multiprocess"]:
+    if name in config().skip.multiprocess:
       # No support for multiprocess, yet. So, skip all benchmarks that
       # only work with it.
       return False
@@ -288,14 +300,10 @@ class TorchBenchModel(BenchmarkModel):
         logger.warning(f"Unable to import {module_src}.")
     return None
 
-  @property
-  def batch_size(self):
-    return config_data()["batch_size"]
-
   def load_benchmark(self):
     cant_change_batch_size = (
         not getattr(self.benchmark_cls(), "ALLOW_CUSTOMIZE_BSIZE", True) or
-        self.model_name in config_data()["dont_change_batch_size"])
+        self.model_name in config().dont_change_batch_size)
 
     if cant_change_batch_size:
       self.benchmark_experiment.batch_size = None
@@ -303,11 +311,9 @@ class TorchBenchModel(BenchmarkModel):
     batch_size = self.benchmark_experiment.batch_size
 
     if batch_size is None:
-      if self.is_training() and self.model_name in self.batch_size["training"]:
-        batch_size = self.batch_size["training"][self.model_name]
-      elif self.is_inference(
-      ) and self.model_name in self.batch_size["inference"]:
-        batch_size = self.batch_size["inference"][self.model_name]
+      test = get_torchbench_test_name(self.benchmark_experiment.test)
+      if self.model_name in config().batch_size.get(test, {}):
+        batch_size = config().batch_size.get(test).get(model_name)
 
     # workaround "RuntimeError: not allowed to set torch.backends.cudnn flags"
     # torch.backends.__allow_nonbracketed_mutation_flag = True
@@ -361,10 +367,27 @@ class TorchBenchModel(BenchmarkModel):
 
   def use_amp(self):
     return self.is_training(
-    ) or self.model_name in FORCE_AMP_FOR_FP16_BF16_MODELS
+    ) or self.model_name in config().dtype.force_amp_for_fp16_bf16_models
 
   def use_fp16(self):
-    return self.is_inference() and self.model_name in FORCE_FP16_FOR_BF16_MODELS
+    return self.is_inference(
+    ) and self.model_name in config().dtype.force_fp16_for_bf16_models
+
+  def tolerance(self):
+    if self.is_inference():
+      return 1e-2
+
+    if self.is_accelerator_cuda():
+      if self.model_name in config().tolerance.higher:
+        return 1e-3
+      if self.model_name in config().tolerance.even_higher:
+        return 8 * 1e-2
+      return 1e-3
+
+    return super().tolerance()
+
+  def use_cosine_similarity(self):
+    return self.model_name in config().tolerance.cosine
 
   def conversion_dtype(self):
     if self.is_training() or self.use_amp():
@@ -425,7 +448,7 @@ class TorchBenchModel(BenchmarkModel):
     raise NotImplementedError("Don't know how to reduce", type(pred))
 
   def train(self, inputs: Sequence[Any], collect_full_output: bool = False):
-    if self.model_name in DETECTRON2_MODELS:
+    if self.model_name in config().detectron2_models:
       from detectron2.utils.events import EventStorage
       with EventStorage():
         super().train(inputs, collect_full_output=collect_full_output)

--- a/benchmarks/torchbench_model.py
+++ b/benchmarks/torchbench_model.py
@@ -101,6 +101,17 @@ NEED_LARGER_CACHE = {
 
 
 class _Config:
+  """Helper class for easier access of the torchbench.yaml configuration.
+
+  This will wrap any mapping data-type, so that it's easier to access a
+  nested object. For example, instead of:
+
+  > config["skip"]["device"].get(benchmark_experiment.accelerator, {})
+
+  We can write:
+
+  > config().skip.device.get(benchmark_experiment.accelerator, {})
+  """
 
   def __init__(self, inner: Dict[str, Any]) -> None:
     self.inner = inner
@@ -358,14 +369,16 @@ class TorchBenchModel(BenchmarkModel):
     return self.benchmark_experiment.accelerator == "tpu"
 
   def use_amp(self):
-    return self.is_training(
-    ) or self.model_name in config().dtype.force_amp_for_fp16_bf16_models
+    return self.is_training() or self.model_name in config(
+    ).dtype.force_amp_for_fp16_bf16_models
 
   def use_fp16(self):
-    return self.is_inference(
-    ) and self.model_name in config().dtype.force_fp16_for_bf16_models
+    return self.is_inference() and self.model_name in config(
+    ).dtype.force_fp16_for_bf16_models
 
   def tolerance(self):
+    # Logic taken from: PyTorch
+    # Source: benchmarks/dynamo/torchbench.py
     if self.is_inference():
       return 1e-2
 
@@ -379,6 +392,8 @@ class TorchBenchModel(BenchmarkModel):
     return super().tolerance()
 
   def use_cosine_similarity(self):
+    # Logic taken from: PyTorch
+    # Source: benchmarks/dynamo/torchbench.py
     return self.model_name in config().tolerance.cosine
 
   def conversion_dtype(self):

--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -77,12 +77,14 @@ def move_to_device(item, device, torch_xla2: bool = False):
     move_to_device_func = lambda t: jax.device_put(
         torch_xla2.tensor.t2j(t), device)
   else:
+
     def move_to_device_func(tensor: torch.Tensor) -> torch.Tensor:
       # If `tensor` is an XLA tensor, first move it to CPU. We need to do
       # that if we want to move the tensor to, say, CUDA.
       if tensor.device.type == "xla":
         return tensor.cpu().to(device)
       return tensor.to(device)
+
   return pytree.tree_map_only(torch.Tensor, move_to_device_func, item)
 
 

--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -1,6 +1,7 @@
 import argparse
 from contextlib import contextmanager
 import functools
+import gc
 import logging
 import os
 from os.path import abspath, exists
@@ -182,3 +183,13 @@ def reset_rng_state(benchmark_experiment: "BenchmarkExperiment"):
   if benchmark_experiment.xla is not None and benchmark_experiment.torch_xla2 is None:
     device = benchmark_experiment.get_device()
     xm.set_rng_state(SEED, str(device))
+
+
+def cleanup(experiment: "BenchmarkExperiment"):
+  # Garbage-collect right now.
+  gc.collect()
+
+  # If we are using CUDA, clean-up its cache left-over.
+  if experiment.accelerator == "cuda" and torch.cuda.is_available():
+    torch.cuda.empty_cache()
+    torch.cuda.synchronize()

--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -77,7 +77,12 @@ def move_to_device(item, device, torch_xla2: bool = False):
     move_to_device_func = lambda t: jax.device_put(
         torch_xla2.tensor.t2j(t), device)
   else:
-    move_to_device_func = lambda t: t.to(device)
+    def move_to_device_func(tensor: torch.Tensor) -> torch.Tensor:
+      # If `tensor` is an XLA tensor, first move it to CPU. We need to do
+      # that if we want to move the tensor to, say, CUDA.
+      if tensor.device.type == "xla":
+        return tensor.cpu().to(device)
+      return tensor.to(device)
   return pytree.tree_map_only(torch.Tensor, move_to_device_func, item)
 
 

--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -185,11 +185,11 @@ def reset_rng_state(benchmark_experiment: "BenchmarkExperiment"):
     xm.set_rng_state(SEED, str(device))
 
 
-def cleanup(experiment: "BenchmarkExperiment"):
+def cleanup(cuda: bool = False):
   # Garbage-collect right now.
   gc.collect()
 
   # If we are using CUDA, clean-up its cache left-over.
-  if experiment.accelerator == "cuda" and torch.cuda.is_available():
+  if cuda and torch.cuda.is_available():
     torch.cuda.empty_cache()
     torch.cuda.synchronize()

--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -80,7 +80,7 @@ def move_to_device(item, device, torch_xla2: bool = False):
   return pytree.tree_map_only(torch.Tensor, move_to_device_func, item)
 
 
-def cast_to_dtype(item, dtype):
+def cast_to_dtype(item: Any, dtype: torch.dtype) -> Any:
   return pytree.tree_map_only(
       torch.Tensor,
       lambda t: t.to(dtype)
@@ -169,3 +169,16 @@ def find_near_file(names: str):
       if exists(path):
         return abspath(path)
   return None
+
+
+def reset_rng_state(benchmark_experiment: "BenchmarkExperiment"):
+  import numpy as np
+  import random
+  SEED = 1337
+  torch.manual_seed(SEED)
+  random.seed(SEED)
+  np.random.seed(SEED)
+  # TODO(piz): setup the rng state on jax for torch_xla2.
+  if benchmark_experiment.xla is not None and benchmark_experiment.torch_xla2 is None:
+    device = benchmark_experiment.get_device()
+    xm.set_rng_state(SEED, str(device))

--- a/benchmarks/verifier.py
+++ b/benchmarks/verifier.py
@@ -219,13 +219,19 @@ def _same(
   res = _collect(res)
   fp64_ref = _collect(fp64_ref)
 
-  # Find, at least, one tensor in `ref`, and grab its device.
+  # If there's a tensor in `ref`, then retrieve its device.
+  # Do the the same for `res`. They should agree on whether there should
+  # be a tensor in the output (i.e. both None or both not None).
   ref_device = _maybe_get_device(ref)
-  assert ref_device is not None, f"could not find any tensor in output {ref}"
+  res_device = _maybe_get_device(res)
+  assert not ((res_device is not None) ^ (ref_device is not None)), (
+      "the device found of (i) the result and (ii) the reference should be either: both None or both not None. "
+      f"Found: {res_device} (result) vs. {ref_device} (reference).")
 
-  # Then, move `res` to the found device, so that we have no errors when
-  # trying to call `allclose`.
-  res = move_to_device(res, ref_device)
+  if ref_device is not None:
+    # Then, move `res` to the found device, so that we have no errors when
+    # trying to call `allclose`.
+    res = move_to_device(res, ref_device)
 
   return torch._dynamo.utils.same(
       ref,

--- a/benchmarks/verifier.py
+++ b/benchmarks/verifier.py
@@ -109,7 +109,7 @@ def _run(
     model = runner.model_loader.load_model(
         model_config, experiment, force_dtype=force_dtype)
 
-    iterations = runner._args.iterations_per_run
+    iterations = runner._args.verify_iterations
     inputs = copy.deepcopy(model.example_inputs)
 
     def maybe_mark_step():

--- a/benchmarks/verifier.py
+++ b/benchmarks/verifier.py
@@ -6,8 +6,8 @@ from benchmark_experiment import ExperimentLoader
 from benchmark_model import ModelLoader
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Optional
-from util import Any, cleanup, reset_rng_state, StrOrBool
+from typing import Any, Callable, Dict, Optional
+from util import cleanup, reset_rng_state, StrOrBool
 
 logger = logging.getLogger(__name__)
 
@@ -139,8 +139,11 @@ def _run(
     maybe_synchronize()
     return output
   finally:
-    del model
-    cleanup(eager_benchmark_experiment)
+    if model is not None:
+      # Delete the model for saving up memory.
+      del model
+      # Clean-up CUDA as well.
+      cleanup(cuda=True)
 
 
 def _apply_eager_config(experiment):

--- a/benchmarks/verifier.py
+++ b/benchmarks/verifier.py
@@ -146,7 +146,6 @@ def _apply_eager_config(experiment):
   return experiment
 
 
-
 def _collect(out: Any) -> List[Any]:
   """Collect leaf objects into a nested list.
 
@@ -187,8 +186,6 @@ def _collect(out: Any) -> List[Any]:
   # name of this composite class.
   typename = type(out).__name__
   return [typename] + collect_impl(out)
-
-
 
 
 def _same(

--- a/benchmarks/verifier.py
+++ b/benchmarks/verifier.py
@@ -1,107 +1,146 @@
 import logging
 import torch
+import traceback
 
 from benchmark_experiment import ExperimentLoader
 from benchmark_model import ModelLoader
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from typing import Dict, Optional
+from util import Any, cleanup, reset_rng_state, StrOrBool
 
 logger = logging.getLogger(__name__)
 
 
 class VerificationCode(str, Enum):
+  # Verification passed accuracy check.
   PASS = 'PASS'
+  # Verification failed accuracy check.
   FAIL = 'FAIL',
+  # Eager execution failed.
+  EAGER_FAILED = 'EAGER_FAILED'
+  # Verifier failed, raising an exception.
+  VERIFIER_FAILED = 'VERIFIER_FAILED'
+  # Eager runs do not agree.
   NONDETERMINISTIC_EAGER_RUN = 'NONDETERMINISTIC_EAGER_RUN'
-  CANNOT_PROCEED_WITH_VERIFICATION = 'CANNOT_PROCEED_WITH_VERIFICATION'
-  NO_OUTPUT_PROVIDED = 'NO_OUTPUT_PROVIDED'
-  SKIP_VERIFICATION = 'SKIP_VERIFICATION'
-  VERIFICATION_FAILED = 'VERIFICATION_FAILED'
+  # Verifier skipped.
+  VERIFIER_SKIPPED = 'VERIFIER_SKIPPED'
+  # Verifier did not run. It was skipped, but due to an unexpected reason.
+  # Either an exception was raised or the process timeout.
+  VERIFIER_SKIPPED_UNEXPECTEDLY = 'VERIFIER_SKIPPED_UNEXPECTEDLY'
 
 
-@dataclass
-class VerificationResult:
-  result_code: VerificationCode
-  mean_rel_error: Optional[float] = None
+def verify(
+    runner: "ExperimentRunner",
+    experiment_config: Dict[str, Optional[StrOrBool]],
+    model_config: Dict[str, Optional[StrOrBool]],
+    tolerance: float,
+    use_cosine_similarity: bool,
+) -> VerificationCode:
+  """Verify the accuracy of the given experiment and model configurations.
 
-
-def verify(output: torch.Tensor,
-           experiment: dict,
-           model_config: dict,
-           experiment_loader: ExperimentLoader,
-           model_loader: ModelLoader,
-           mean_rel_error_tolerance: float,
-           noop: bool = False):
+  Both `tolerance` and `use_cosine_similarity` will be used when checking whether the
+  accuracy of the actual experiment is close to that of eager.
   """
-    Verify the mean relative error for `output` against eager runtime of the model.
-    If `mean_rel_error_tolerance` is less than the calculated mean relative error of
-    the output vs. eager run then the function returns `VerificationCode.FAIL`.
-    Otherwise, if the run is successful, `VerificationCode.PASS` is returned, along with calculated
-    mean relative error.
-
-    :param output: The tensor to compare eager runtime against.
-    :type fn: torch.Tensor
-    :param experiment: Experiment config of the `output` run.
-    :type experiment: dict
-    :param model_config: Model config of the `output` run.
-    :type model_config: dict
-    :param experiment_loader: Experiment loader module.
-    :type experiment_loader: ExperimentLoader
-    :param model_loader: Model loader module.
-    :type model_loader: ModelLoader
-    :param mean_rel_error_tolerance: Mean rel error tolerance to check against.
-    :type mean_rel_error_tolerance: float
-    :param noop: If set to true, function returns `SKIP_VERIFICATION` code.
-    :type noop: bool
-  """
-  if noop:
-    return VerificationResult(VerificationCode.SKIP_VERIFICATION)
-
-  if output is None:
-    return VerificationResult(VerificationCode.NO_OUTPUT_PROVIDED)
-
   try:
-    experiment = _apply_eager_config(experiment)
-    benchmark_experiment = experiment_loader.load_experiment(experiment)
-    model = model_loader.load_model(model_config, benchmark_experiment)
+    # 1. Run eager twice, so as to make sure the model actually outputs deterministic results.
+    try:
+      eager_output = _run(runner, experiment_config, model_config, eager=True)
+      additional_eager_output = _run(
+          runner, experiment_config, model_config, eager=True)
+    except:
+      traceback.print_exc()
+      return VerificationCode.EAGER_FAILED
 
-    eager_output = _run(model)
-    additional_eager_output = _run(model)
+    # If the results are not close, it might mean that this model is not deterministic.
+    # Therefore, we give up the verification process, entirely.
+    if not _same(eager_output, additional_eager_output):
+      return VerificationCode.NONDETERMINISTIC_EAGER_RUN
 
-    rel_err, close_res = _close_results(eager_output, additional_eager_output,
-                                        mean_rel_error_tolerance)
-    if not close_res:
-      return VerificationResult(VerificationCode.NONDETERMINISTIC_EAGER_RUN,
-                                rel_err)
+    # 2. Compute the output using float64 precision for increased precision. This should
+    #    help deciding whether the outputs of the actual experiment have acceptable accuracy.
+    eager_fp64_output = _run(
+        runner, experiment_config, model_config, force_fp64=True, eager=True)
 
-    eager_output = eager_output.to(device=output.device)
-    rel_err, close_res = _close_results(eager_output, output,
-                                        mean_rel_error_tolerance)
-    if close_res:
-      return VerificationResult(VerificationCode.PASS, rel_err)
-    else:
-      _log(eager_output, output)
-      return VerificationResult(VerificationCode.FAIL, rel_err)
-  except Exception as e:
-    logger.exception(e)
-    return VerificationResult(VerificationCode.VERIFICATION_FAILED)
+    # 3. Compute the output of the actual experiment.
+    output = _run(runner, experiment_config, model_config)
 
+    # Check whether the results computed by (3) are close to that of eager (1) by using
+    # the higher-precision output (2) and the given tolerance and cosine similarity.
+    if not _same(
+        eager_output,
+        output,
+        fp64_ref=eager_fp64_output,
+        cos_similarity=use_cosine_similarity,
+        tol=tolerance,
+    ):
+      return VerificationCode.FAIL
+  except:
+    traceback.print_exc()
+    return VerificationCode.VERIFIER_FAILED
 
-def _log(lhs, rhs):
-  logger.error('Output differs significantly.')
-  lhs = lhs.clone().to(device='cpu')
-  rhs = rhs.clone().to(device='cpu')
-
-  logger.error(f"lhs: {lhs}")
-  logger.error(f"rhs: {rhs}")
+  return VerificationCode.PASS
 
 
-def _run(model):
-  inputs = model.example_inputs
-  with model.pick_grad():
-    output = model.model_iter_fn(inputs)
-  return output
+def _run(
+    runner: "ExperimentRunner",
+    experiment_config: Dict[str, Optional[StrOrBool]],
+    model_config: Dict[str, Optional[StrOrBool]],
+    force_fp64: bool = False,
+    eager: bool = False,
+) -> Any:
+  """Runs a possibly modified experiment, returning the output of the model.
+
+  `force_fp64` loads the model by forcing float64 data-type.
+
+  `eager` modifies the experiment configuration, running it with PyTorch eager.
+  """
+  try:
+    reset_rng_state(experiment)
+
+    if eager:
+      experiment_config = _apply_eager_config(experiment_config)
+
+    experiment = runner.experiment_loader.load_experiment(experiment_config)
+    model = runner.model_loader.load_model(
+        model_config,
+        eager_benchmark_experiment,
+        force_dtype=torch.float64 if force_fp64 else None,
+    )
+
+    experiment, model = get_benchmark_model(
+        runner,
+        experiment_config,
+        model_config,
+        force_fp64=force_fp64,
+        eager=eager,
+    )
+
+    n = runner._args.iterations_per_run
+    inputs = copy.deepcopy(model.example_inputs)
+
+    def maybe_mark_step():
+      runner._mark_step(experiment)
+
+    def maybe_synchronize():
+      runner._synchronize(experiment)
+
+    maybe_mark_step()
+    maybe_synchronize()
+
+    with model.pick_grad():
+      for i in range(runner._args.iterations_per_run):
+        # Collect grad results only in the last run.
+        collect_full_output = i == n - 1
+        output = model.model_iter_fn(
+            inputs, collect_full_output=collect_full_output)
+        maybe_mark_step()
+
+    maybe_synchronize()
+    return output
+  finally:
+    del model
+    cleanup(eager_benchmark_experiment)
 
 
 def _apply_eager_config(experiment):
@@ -111,7 +150,19 @@ def _apply_eager_config(experiment):
   return experiment
 
 
-def _close_results(lhs, rhs, delta):
-  rel_error_tensor = torch.abs(rhs - lhs) / torch.abs(lhs)
-  mean_rel_error = (rel_error_tensor.sum() / lhs.numel()).item()
-  return mean_rel_error, (mean_rel_error < delta)
+def _same(
+    out1: Any,
+    out2: Any,
+    fp64_ref: Any = None,
+    cos_similarity: bool = False,
+    tol: float = 0,
+    equal_nan: bool = True,
+) -> bool:
+  return torch._dynamo.utils.same(
+      out1,
+      out2,
+      fp64_ref=fp64_ref,
+      cos_similarity=cos_similarity,
+      tol=tol,
+      equal_nan=equal_nan,
+  )


### PR DESCRIPTION
This PR re-implements the existing verifier, making the following improvements:

- Enabling the verification of more models on inference
    - Previously, it expected the models to return a single output tensor
- Enabling the verification of training
    - There was a plumbing bug in `TorchBenchModel.train`
    - Running training for a few iterations
- Model cleanup
    - Delete each used model so that we don't run out of memory on large models
- Use PyTorch functions for checking whether the accuracy is acceptable
    - Instead of using MRE, we use the [same thing PyTorch does](https://github.com/pytorch/pytorch/blob/69b1999586eb2df741e7fa4e37a8611818113bb0/torch/_dynamo/utils.py#L1361-L1373)

In order to do so, here's a summary of the changes:

- Introduce `BenchmarkModel` methods: `tolerance()`, `use_cosine_similarity`, and `skip_verifier()`
    - The logic is taken [from PyTorch](https://github.com/pytorch/pytorch/blob/69b1999586eb2df741e7fa4e37a8611818113bb0/benchmarks/dynamo/torchbench.py#L434-L447), which also uses _torchbench.yaml_
- Introduce `force_dtype` parameter when loading a model
    - So that we can run models on eager `fp64`
- More meaningful verification codes
- Move `reset_rng_state` and `cleanup` to _util.py_
- Change how we access the YAML configuration file, replacing the raw strings

cc @miladm @zpcore 