### PR TITLE
Optimize dynamo dynamic shape caching

### DIFF
--- a/test/dynamo/test_dynamo_dynamic_shape.py
+++ b/test/dynamo/test_dynamo_dynamic_shape.py
@@ -183,6 +183,24 @@ class DynamoDynamicShapeBasicTest(unittest.TestCase):
     self.assertEqual(met.metric_data('CompileTime')[0], 1)
     self.assertEqual(met.metric_data('ExecuteTime')[0], 1)
 
+  def test_dynamic_shape_no_retracing(self):
+    torch_xla.manual_seed(100)
+    device = torch_xla.device()
+    # model setup
+    dummy_linear, dummy_linear_xla, input, input_xla = self._get_linear_and_input(
+        10, 20, 20, device)
+    compiled_linear_xla = torch.compile(
+        dummy_linear_xla, backend="openxla", dynamic=True)
+    xm.wait_device_ops()
+    met.clear_all()
+
+    # first run
+    res = dummy_linear(input)
+    res_xla = compiled_linear_xla(input_xla)
+    # Dynamo execution should not trigger `CachedCompile` counter. If we do it likely
+    # means we retrace the same fx multiple times.
+    self.assertNotIn('CachedCompile', met.counter_names())
+
   def test_dynamic_shape_resnet18(self):
     device = torch_xla.device()
 

--- a/test/dynamo/test_dynamo_dynamic_shape.py
+++ b/test/dynamo/test_dynamo_dynamic_shape.py
@@ -184,18 +184,16 @@ class DynamoDynamicShapeBasicTest(unittest.TestCase):
     self.assertEqual(met.metric_data('ExecuteTime')[0], 1)
 
   def test_dynamic_shape_no_retracing(self):
-    torch_xla.manual_seed(100)
     device = torch_xla.device()
     # model setup
-    dummy_linear, dummy_linear_xla, input, input_xla = self._get_linear_and_input(
-        10, 20, 20, device)
+    _, dummy_linear_xla, _, input_xla = self._get_linear_and_input(
+        8, 10, 20, device)
     compiled_linear_xla = torch.compile(
         dummy_linear_xla, backend="openxla", dynamic=True)
     xm.wait_device_ops()
     met.clear_all()
 
     # first run
-    res = dummy_linear(input)
     res_xla = compiled_linear_xla(input_xla)
     # Dynamo execution should not trigger `CachedCompile` counter. If we do it likely
     # means we retrace the same fx multiple times.


### PR DESCRIPTION
When we do 
```
compiled_fn = torch.compile(fn, backend="openxla", dynamic=True)
# input1 and input2 are of different types
compiled_fn(input1)
compiled_fn(input2)
```

Dynamo will only trace the python bytecode once, but will pass input with different shapes to the same `optimized_mod `. The way we support the dynamic shape is to maintain a mapping between different input shapes to different xla graphs.

Currently there is an ineffiency that when we do 
```
# when `torch.compile`d function being called
extract_internal -> extract_graph_helper -> optimized_mod
```
we return the `optimized_mod` to pytorch to `replace` the existing function. However in this process we did not populate the map that maps input shapes to the graph hash. We do that when we 
```
optimized_mod (found that map is empty) -> extract_graph_helper
```
This is unnecessary, we should populate the mapping when we first time calling `extract_graph_helper`