### PR TITLE
[torch_xla2] Add decorator to promote int inputs

### DIFF
--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -55,27 +55,6 @@ def op(*aten, **kwargs):
 
   return inner
 
-def _handle_int64_trig(self, func):
-  target_type = None
-  # Torch's atanh returns f32 for int64 input
-  if self.dtype.name == 'int64':
-    target_type = jnp.dtype('float32')
-  res = func(self)
-  if target_type is not None:
-    res = res.astype(target_type)
-  return res
-
-
-def _handle_int64_to_int32_trig(func, args):
-  target_type = None
-  for i in range(len(args)):
-    if args[i].dtype.name == 'int64':
-      target_type = jnp.dtype('int32')
-    if target_type is not None:
-      args[i] = args[i].astype(target_type)
-  res = func(*args)
-  return res
-
 
 @op(
   torch.ops.aten.view_copy,
@@ -897,8 +876,9 @@ def _aten_argmin(self, dim=None, keepdim=False):
 
 
 @op(torch.ops.aten.sin)
+@op_base.promote_int_input
 def _aten_sin(x):
-  return _handle_int64_trig(x, jnp.sin)
+  return jnp.sin(x)
 
 
 @op(torch.ops.aten.sym_size)
@@ -1046,8 +1026,9 @@ def _aten_alias(self, *args):
 
 # aten.sinh
 @op(torch.ops.aten.sinh)
+@op_base.promote_int_input
 def _aten_sinh(self):
-  return _handle_int64_trig(self, jnp.sinh)
+  return jnp.sinh(self)
 
 
 # aten.native_layer_norm_backward
@@ -1079,8 +1060,9 @@ def _aten_native_layer_norm_backward(
 
 # aten.atanh
 @op(torch.ops.aten.atanh)
+@op_base.promote_int_input
 def _aten_atanh(self):
-  res = _handle_int64_trig(self, jnp.arctanh)
+  res = jnp.arctanh(self)
   return res
 
 
@@ -1121,20 +1103,23 @@ def _aten_sum(self, dim=None, keepdim=False, dtype=None):
 
 # aten.sqrt
 @op(torch.ops.aten.sqrt)
+@op_base.promote_int_input
 def _aten_sqrt(self):
-  return _handle_int64_trig(self, jnp.sqrt)
+  return jnp.sqrt(self)
 
 
 @op(torch.ops.aten.tan)
+@op_base.promote_int_input
 def _aten_tanh(self):
-  res = _handle_int64_trig(self, jnp.tan)
+  res = jnp.tan(self)
   return res
 
 
 # aten.tanh
 @op(torch.ops.aten.tanh)
+@op_base.promote_int_input
 def _aten_tanh(self):
-  res = _handle_int64_trig(self, jnp.tanh)
+  res = jnp.tanh(self)
   return res
 
 
@@ -1146,8 +1131,9 @@ def _aten_ceil(self):
 
 # aten.asin
 @op(torch.ops.aten.asin)
+@op_base.promote_int_input
 def _aten_asin(self):
-  res = _handle_int64_trig(self, jnp.arcsin)
+  res = jnp.arcsin(self)
   return res
 
 
@@ -1204,23 +1190,24 @@ def _aten_sign(x):
 
 # aten.sigmoid
 @op(torch.ops.aten.sigmoid)
+@op_base.promote_int_input
 def _aten_sigmoid(x):
-  if x.dtype in (jnp.int32, jnp.int64):
-    x = x.astype(jnp.float32)
   return jax.nn.sigmoid(x)
 
 
 # implement aten.asinh in jax
 @op(torch.ops.aten.asinh)
+@op_base.promote_int_input
 def _aten_asinh(self):
-  res = _handle_int64_trig(self, jnp.arcsinh)
+  res = jnp.arcsinh(self)
   return res
 
 
 # aten.atan
 @op(torch.ops.aten.atan)
+@op_base.promote_int_input
 def _aten_atan(self):
-  res = _handle_int64_trig(self, jnp.arctan)
+  res = jnp.arctan(self)
   return res
 
 
@@ -1244,8 +1231,9 @@ def _aten_scatter_reduce(input, dim, index, src, reduce, *, include_self=True):
 
 # aten.acos
 @op(torch.ops.aten.acos)
+@op_base.promote_int_input
 def _aten_acos(self):
-  return _handle_int64_trig(self, jnp.arccos)
+  return jnp.arccos(self)
 
 
 # aten.sym_storage_offset
@@ -1466,8 +1454,9 @@ def _aten_scatter(input, dim, index, src, reduce=None):
 
 # aten.acosh
 @op(torch.ops.aten.acosh)
+@op_base.promote_int_input
 def _aten_acosh(self):
-  return _handle_int64_trig(self, jnp.arccosh)
+  return jnp.arccosh(self)
 
 
 # aten.avg_pool2d_backward
@@ -1593,8 +1582,9 @@ def _aten_as_strided_scatter(x, src, sizes, strides, storage_offset):
 
 # aten.atan2
 @op(torch.ops.aten.atan2)
+@op_base.promote_int_input
 def _aten_atan2(input, other):
-  return _handle_int64_to_int32_trig(jnp.arctan2, [input, other])
+  return jnp.arctan2(input, other)
 
 
 # aten.bitwise_and
@@ -1676,14 +1666,16 @@ def _aten__pdist_forward(x, p=2):
 
 # aten.cos
 @op(torch.ops.aten.cos)
+@op_base.promote_int_input
 def _aten_cos(input):
-  return _handle_int64_trig(input, jnp.cos)
+  return jnp.cos(input)
 
 
 # aten.cosh
 @op(torch.ops.aten.cosh)
+@op_base.promote_int_input
 def _aten_cosh(input):
-  return _handle_int64_trig(input, jnp.cosh)
+  return jnp.cosh(input)
 
 
 # aten.diagonal
@@ -1700,9 +1692,8 @@ def _aten_eq(input1, input2):
 
 # aten.erf
 @op(torch.ops.aten.erf)
+@op_base.promote_int_input
 def _aten_erf(x):
-  if x.dtype in (jnp.int32, jnp.int64):
-    x = x.astype(jnp.float32)
   return jax.lax.erf(x)
 
 
@@ -1824,26 +1815,30 @@ def _aten_leaky_relu(x, negative_slope):
 
 # aten.log
 @op(torch.ops.aten.log)
+@op_base.promote_int_input
 def _aten_log(x):
-  return _handle_int64_trig(x, jnp.log)
+  return jnp.log(x)
 
 
 # aten.log10
 @op(torch.ops.aten.log10)
+@op_base.promote_int_input
 def _aten_log10(x):
-  return _handle_int64_trig(x, jnp.log10)
+  return jnp.log10(x)
 
 
 # aten.log1p
 @op(torch.ops.aten.log1p)
+@op_base.promote_int_input
 def _aten_log1p(x):
-  return _handle_int64_trig(x, jnp.log1p)
+  return jnp.log1p(x)
 
 
 # aten.log2
 @op(torch.ops.aten.log2)
+@op_base.promote_int_input
 def _aten_log2(x):
-  return _handle_int64_trig(x, jnp.log2)
+  return jnp.log2(x)
 
 
 # aten.logical_and

--- a/experimental/torch_xla2/torch_xla2/ops/op_base.py
+++ b/experimental/torch_xla2/torch_xla2/ops/op_base.py
@@ -41,8 +41,7 @@ def convert_dtype(use_default_dtype: bool = True):
     A decorator that wraps a JAX implementation of a torch function.
   """
 
-  def decorator(
-        func: Callable[Concatenate[..., torch.dtype, P], types.JaxValue]):
+  def decorator(func: types.TorchCallable):
     @functools.wraps(func)
     def wrapper(*args: P.args,
                 dtype: Optional[torch.dtype] = None,

--- a/experimental/torch_xla2/torch_xla2/ops/op_base.py
+++ b/experimental/torch_xla2/torch_xla2/ops/op_base.py
@@ -62,7 +62,7 @@ def promote_int_input(f: Callable[Concatenate[jax.Array, P], types.JaxValue]):
    @functools.wraps(f)
    def wrapper(x: jax.Array, *args: P.args, **kwargs: P.kwargs):
       if x.dtype in [jnp.int8, jnp.int16, jnp.int32, jnp.int64]:
-        x = x.astype(jnp.float32)
+        x = x.astype(mappings.t2j_dtype(torch.get_default_dtype()))
 
       return f(x, *args, **kwargs)
 


### PR DESCRIPTION
Several ops are expected to return a `float32` when recieving any int input, e.g.

```
>>> torch.sin(torch.tensor(1, dtype=torch.int8)).dtype
torch.float32
>>> torch.sin(torch.tensor(1, dtype=torch.int16)).dtype
torch.float32
>>> torch.sin(torch.tensor(1, dtype=torch.int64)).dtype
torch.float32
```

JAX has different type promotion rules, such as promoting int64 to float64. Wrap PyTorch's common type promotion rule in a decorator to make it more reusable.