### PR TITLE
Remove `tpuvm` dependency from r2.4 branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -313,8 +313,6 @@ setup(
         # pip install torch_xla[tpu] -f https://storage.googleapis.com/libtpu-releases/index.html
         'tpu': [f'libtpu-nightly=={_libtpu_version}'],
         # On nightly, install libtpu with `pip install torch_xla[tpuvm]`
-        # Remove from release branches since this is not allowed by PyPI.
-        'tpuvm': [f'libtpu-nightly @ {_libtpu_storage_path}'],
         # pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
         'pallas': [f'jaxlib=={_jax_version}', f'jax=={_jax_version}'],
     },


### PR DESCRIPTION
Otherwise we get this error:

```
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
         Can't have direct dependency: libtpu-nightly@                          
         https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-
         nightly/libtpu_nightly-0.1.dev20240612-py3-none-any.whl ; extra ==     
         "tpuvm". See https://packaging.python.org/specifications/core-metadata 
         for more information. 
```