### PR TITLE
Support fp8e5m2 dtype

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -184,6 +184,7 @@ function run_xla_op_tests1 {
   run_test "$CDIR/dynamo/test_graph_input_matcher.py"
   run_save_tensor_ir "$CDIR/dynamo/test_dynamo_graph_dump.py"
   run_test "$CDIR/test_data_type.py"
+  run_test "$CDIR/test_fp8.py"
   run_xla_ir_debug "$CDIR/test_env_var_mapper.py"
   run_xla_hlo_debug "$CDIR/test_env_var_mapper.py"
   run_xla_hlo_debug "$CDIR/stablehlo/test_stablehlo_save_load.py"

--- a/test/test_fp8.py
+++ b/test/test_fp8.py
@@ -1,0 +1,53 @@
+import os
+import re
+
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.utils.utils as xu
+import unittest
+
+
+class Fp8Test(unittest.TestCase):
+
+  def test_fp8(self):
+    device = torch_xla.device()
+    fp8_types = [torch.float8_e5m2]
+    for dtype in fp8_types:
+      t = torch.rand(2, 2).to(dtype)
+      xla_t = t.to(device)
+      torch_t = xla_t.cpu()
+      self.assertEqual(xla_t.dtype, dtype)
+      self.assertEqual(torch_t.dtype, dtype)
+      # Need to cast to float32 since allclose doesn't work with fp8.
+      self.assertTrue(
+          torch.allclose(t.to(torch.float32), torch_t.to(torch.float32)))
+
+  def test_fp8_matmul(self):
+    device = torch_xla.device()
+    fp8_types = [torch.float8_e5m2]
+    for dtype in fp8_types:
+      t = torch.rand(3, 2).to(dtype)
+      w = torch.rand(2, 5).to(dtype)
+      torch_matmul = torch.matmul(t, w)
+      xla_t = t.to(device)
+      xla_w = w.to(device)
+      xla_matmul = torch.matmul(xla_t, xla_w)
+      xla_matmul = xla_matmul.cpu()
+      # Need to cast to float32 since allclose doesn't work with fp8.
+      self.assertTrue(
+          torch.allclose(
+              xla_matmul.to(torch.float32), torch_matmul.to(torch.float32)))
+
+  def test_fp8_hlo(self):
+    device = torch_xla.device()
+    x = torch.randn((3, 5)).to(torch.float8_e5m2).to(device)
+    w = torch.randn((5, 8)).to(torch.float8_e5m2).to(device)
+    output = torch.matmul(x, w)
+    hlo = torch_xla._XLAC._get_xla_tensors_hlo([output])
+    self.assertTrue(re.search(r'f8e5m2.*dot.*f8e5m2.*f8e5m2', hlo) is not None)
+
+
+if __name__ == '__main__':
+  test = unittest.main()
+  sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/test_fp8.py
+++ b/test/test_fp8.py
@@ -3,8 +3,6 @@ import re
 
 import torch
 import torch_xla
-import torch_xla.core.xla_model as xm
-import torch_xla.utils.utils as xu
 import unittest
 
 

--- a/test/tpu/run_tests.sh
+++ b/test/tpu/run_tests.sh
@@ -15,6 +15,7 @@ python3 test/spmd/test_fsdp_v2.py
 XLA_EXPERIMENTAL=nonzero:masked_select:nms python3 test/ds/test_dynamic_shape_models.py -v
 XLA_EXPERIMENTAL=nonzero:masked_select:nms python3 test/ds/test_dynamic_shapes.py -v
 python3 test/test_autocast.py
+python3 test/test_fp8.py
 python3 test/test_grad_checkpoint.py
 python3 test/dynamo/test_dynamo.py
 python3 test/dynamo/test_dynamo_dynamic_shape.py

--- a/torch_xla/csrc/dtype.cpp
+++ b/torch_xla/csrc/dtype.cpp
@@ -9,6 +9,8 @@ at::ScalarType TorchTypeFromXlaType(xla::PrimitiveType xla_type) {
   switch (xla_type) {
     case xla::PrimitiveType::BF16:
       return at::ScalarType::BFloat16;
+    case xla::PrimitiveType::F8E5M2:
+      return at::ScalarType::Float8_e5m2;
     case xla::PrimitiveType::F16:
       return at::ScalarType::Half;
     case xla::PrimitiveType::F32:
@@ -49,6 +51,8 @@ xla::PrimitiveType XlaTypeFromTorchType(at::ScalarType scalar_type) {
       return xla::PrimitiveType::BF16;
     case at::ScalarType::Half:
       return xla::PrimitiveType::F16;
+    case at::ScalarType::Float8_e5m2:
+      return xla::PrimitiveType::F8E5M2;
     case at::ScalarType::Bool:
       return xla::PrimitiveType::PRED;
     case at::ScalarType::Byte:


### PR DESCRIPTION
Add support for `torch.fp8e5m2` dtype.

Right now `torch_xla/csrc/tensor_util.cpp` contains many duplicated codes, in the next PR I'll try to refactor it to make it cleaner.

The other fp8 variants and will be added in the following PRs

Test:
Added fp8 unit test

