### PR TITLE
Support `@xla.step` decorator without parentheses

### DIFF
--- a/test/test_devices.py
+++ b/test/test_devices.py
@@ -57,6 +57,24 @@ class TestDevices(parameterized.TestCase):
 
     self.assertEqual(met.counter_value('MarkStep'), 2)
 
+  def test_step_decorator(self):
+
+    @xla.step
+    def f():
+      torch.ones((3, 3), device=xla.device())
+
+    f()
+    self.assertEqual(met.counter_value('MarkStep'), 2)
+
+  @parameterized.parameters([True, False])
+  def test_step_decorator_eager(self, eager):
+
+    @xla.step(eager_mode=eager)
+    def f():
+      self.assertIs(xla._XLAC._get_use_eager_mode(), eager)
+
+    f()
+
   # Should roughly match example given in README
   def test_trivial_model(self):
 

--- a/test/test_devices.py
+++ b/test/test_devices.py
@@ -66,15 +66,6 @@ class TestDevices(parameterized.TestCase):
     f()
     self.assertEqual(met.counter_value('MarkStep'), 2)
 
-  @parameterized.parameters([True, False])
-  def test_step_decorator_eager(self, eager):
-
-    @xla.step(eager_mode=eager)
-    def f():
-      self.assertIs(xla._XLAC._get_use_eager_mode(), eager)
-
-    f()
-
   # Should roughly match example given in README
   def test_trivial_model(self):
 

--- a/torch_xla/torch_xla.py
+++ b/torch_xla/torch_xla.py
@@ -61,7 +61,7 @@ def sync():
   xm.mark_step()
 
 
-def step(f: Optional[Callable] = None, *, eager_mode=False):
+def step(f: Optional[Callable] = None):
   """Wraps code that should be dispatched to the runtime.
 
   Experimental: `xla.step` is still a work in progress. Some code that currently
@@ -72,7 +72,7 @@ def step(f: Optional[Callable] = None, *, eager_mode=False):
   @contextlib.contextmanager
   def _step():
     saved_eager_mode_status = torch_xla._XLAC._get_use_eager_mode()
-    torch_xla._XLAC._set_use_eager_mode(eager_mode)
+    torch_xla._XLAC._set_use_eager_mode(False)
     # Clear pending operations
     sync()
 

--- a/torch_xla/torch_xla.py
+++ b/torch_xla/torch_xla.py
@@ -1,5 +1,7 @@
+import collections
 import contextlib
-from typing import Callable, List, Tuple
+import functools
+from typing import Any, Callable, List, Optional, Tuple
 
 import torch
 import torch.distributed as dist
@@ -59,24 +61,38 @@ def sync():
   xm.mark_step()
 
 
-@contextlib.contextmanager
-def step():
+def step(f: Optional[Callable] = None, *, eager_mode=False):
   """Wraps code that should be dispatched to the runtime.
 
   Experimental: `xla.step` is still a work in progress. Some code that currently
   works with `xla.step` but does not follow best practices will become errors in
   future releases. See https://github.com/pytorch/xla/issues/6751 for context.
   """
-  saved_eager_mode_status = torch_xla._XLAC._get_use_eager_mode()
-  torch_xla._XLAC._set_use_eager_mode(False)
-  # Clear pending operations
-  sync()
 
-  try:
-    yield
-  finally:
+  @contextlib.contextmanager
+  def _step():
+    saved_eager_mode_status = torch_xla._XLAC._get_use_eager_mode()
+    torch_xla._XLAC._set_use_eager_mode(eager_mode)
+    # Clear pending operations
     sync()
-    torch_xla._XLAC._set_use_eager_mode(saved_eager_mode_status)
+
+    try:
+      yield
+    finally:
+      sync()
+      torch_xla._XLAC._set_use_eager_mode(saved_eager_mode_status)
+
+  # breakpoint()
+  if f:
+    # print(step)
+    return step()(f)
+
+  return _step()
+
+
+# @step.register
+# def _(f: collections.abc.Callable):
+#   return step(1)(f)
 
 
 def manual_seed(seed, device=None):

--- a/torch_xla/torch_xla.py
+++ b/torch_xla/torch_xla.py
@@ -82,17 +82,10 @@ def step(f: Optional[Callable] = None, *, eager_mode=False):
       sync()
       torch_xla._XLAC._set_use_eager_mode(saved_eager_mode_status)
 
-  # breakpoint()
   if f:
-    # print(step)
-    return step()(f)
+    return _step()(f)
 
   return _step()
-
-
-# @step.register
-# def _(f: collections.abc.Callable):
-#   return step(1)(f)
 
 
 def manual_seed(seed, device=None):

--- a/torch_xla/torch_xla.py
+++ b/torch_xla/torch_xla.py
@@ -82,10 +82,7 @@ def step(f: Optional[Callable] = None):
       sync()
       torch_xla._XLAC._set_use_eager_mode(saved_eager_mode_status)
 
-  if f:
-    return _step()(f)
-
-  return _step()
+  return _step() if not f else _step()(f)
 
 
 def manual_seed(seed, device=None):


### PR DESCRIPTION
Previously, you had to instantiate `step`:


```
@xla.step()
def f():
   pass
```

Now either option works:


```
@xla.step
def f():
   pass
```

Add explicit feature mode option to revert to old behavior.

Follow-up from #7642