### PR TITLE
Move fsdp autowrap test to v4 TPUCI only

### DIFF
--- a/test/tpu/run_tests.sh
+++ b/test/tpu/run_tests.sh
@@ -38,7 +38,6 @@ python3 test/torch_distributed/test_torch_distributed_reduce_scatter_xla_backend
 python3 examples/data_parallel/train_resnet_spmd_data_parallel.py
 python3 examples/data_parallel/train_resnet_xla_ddp.py
 python3 examples/fsdp/train_decoder_only_fsdp_v2.py
-python3 examples/fsdp/train_resnet_fsdp_auto_wrap.py
 python3 examples/train_resnet_amp.py
 
 # HACK: don't confuse local `torch_xla` folder with installed package
@@ -46,6 +45,7 @@ python3 examples/train_resnet_amp.py
 # Egaer tests will take more HBM, only run them on TPU v4 CI
 TPU_VERSION=$(python -c "import sys; sys.path.remove(''); import torch_xla; print(torch_xla._internal.tpu.version())")
 if [[ -n "$TPU_VERSION" && "$TPU_VERSION" == "4" ]]; then
+    python3 examples/fsdp/train_resnet_fsdp_auto_wrap.py
     python3 examples/eager/train_decoder_only_eager.py
     python3 examples/eager/train_decoder_only_eager_spmd_data_parallel.py
     python3 examples/eager/train_decoder_only_eager_with_compile.py

--- a/test/tpu/run_tests.sh
+++ b/test/tpu/run_tests.sh
@@ -18,7 +18,6 @@ python3 test/test_autocast.py
 python3 test/test_grad_checkpoint.py
 python3 test/dynamo/test_dynamo.py
 python3 test/dynamo/test_dynamo_dynamic_shape.py
-python3 test/dynamo/test_traceable_collectives.py
 python3 test/spmd/test_spmd_debugging.py
 XLA_PARAMETER_WRAPPING_THREADSHOLD=1 python test/spmd/test_spmd_parameter_wrapping.py
 python3 test/pjrt/test_dtypes.py
@@ -36,7 +35,6 @@ python3 test/torch_distributed/test_torch_distributed_reduce_scatter_xla_backend
 
 # run examples, each test should takes <2 minutes
 python3 examples/data_parallel/train_resnet_spmd_data_parallel.py
-python3 examples/data_parallel/train_resnet_xla_ddp.py
 python3 examples/fsdp/train_decoder_only_fsdp_v2.py
 python3 examples/train_resnet_amp.py
 
@@ -45,6 +43,8 @@ python3 examples/train_resnet_amp.py
 # Egaer tests will take more HBM, only run them on TPU v4 CI
 TPU_VERSION=$(python -c "import sys; sys.path.remove(''); import torch_xla; print(torch_xla._internal.tpu.version())")
 if [[ -n "$TPU_VERSION" && "$TPU_VERSION" == "4" ]]; then
+    python3 test/dynamo/test_traceable_collectives.py
+    python3 examples/data_parallel/train_resnet_xla_ddp.py
     python3 examples/fsdp/train_resnet_fsdp_auto_wrap.py
     python3 examples/eager/train_decoder_only_eager.py
     python3 examples/eager/train_decoder_only_eager_spmd_data_parallel.py


### PR DESCRIPTION
on v2 CPU it failed with 
```
Step #4 - "run_e2e_tests": + python3 examples/fsdp/train_resnet_fsdp_auto_wrap.py
Step #4 - "run_e2e_tests": consider using train_decoder_only_fsdp_v2.py instead to get better performance
Step #4 - "run_e2e_tests": WARNING:root:torch_xla.core.xla_model.parse_xla_device is deprecated. Use torch_xla._internal.utils.parse_xla_device instead.
Step #4 - "run_e2e_tests": WARNING:root:torch_xla.core.xla_model.parse_xla_device is deprecated. Use torch_xla._internal.utils.parse_xla_device instead.
Step #4 - "run_e2e_tests": WARNING:root:torch_xla.core.xla_model.parse_xla_device is deprecated. Use torch_xla._internal.utils.parse_xla_device instead.
Step #4 - "run_e2e_tests": WARNING:root:torch_xla.core.xla_model.parse_xla_device is deprecated. Use torch_xla._internal.utils.parse_xla_device instead.
Step #4 - "run_e2e_tests": WARNING:root:torch_xla.core.xla_model.global_ordinal is deprecated. Use torch_xla.runtime.global_ordinal instead.
Step #4 - "run_e2e_tests": WARNING:root:torch_xla.core.xla_model.global_ordinal is deprecated. Use torch_xla.runtime.global_ordinal instead.
Step #4 - "run_e2e_tests": WARNING:root:torch_xla.core.xla_model.global_ordinal is deprecated. Use torch_xla.runtime.global_ordinal instead.
Step #4 - "run_e2e_tests": WARNING:root:torch_xla.core.xla_model.global_ordinal is deprecated. Use torch_xla.runtime.global_ordinal instead.
Step #4 - "run_e2e_tests": ++ kubectl get pod/xla-test-job-bcdwd -o 'jsonpath={.status.containerStatuses[?(@.name=="xla-test")].state.terminated.exitCode}'
Step #4 - "run_e2e_tests": + exit 137
```

seems to suggest host oom