### PR TITLE
clean up deprecated

### DIFF
--- a/docs/ddp.md
+++ b/docs/ddp.md
@@ -22,7 +22,7 @@ device](../API_GUIDE.md#running-on-a-single-xla-device).
 1. Import xla specific distributed packages:
 
 ```
-import torch_xla.core.xla_model as xm
+import torch_xla.runtime as xr
 import torch_xla.distributed.xla_backend
 ```
 
@@ -35,7 +35,7 @@ dist.init_process_group("xla", rank=rank, world_size=world_size)
 3. Use xla specific APIs to get rank and world\_size if you need to.
 
 ```
-new_rank = xm.get_ordinal()
+new_rank = xr.global_ordinal()
 world_size = xr.world_size()
 ```
 
@@ -95,7 +95,7 @@ class ToyModel(nn.Module):
 
 def demo_basic(rank):
     # xla specific APIs to get rank, world_size.
-    new_rank = xm.get_ordinal()
+    new_rank = xr.global_ordinal()
     assert new_rank == rank
     world_size = xr.world_size()
 

--- a/docs/fsdp.md
+++ b/docs/fsdp.md
@@ -46,7 +46,7 @@ ckpt = {
     'shard_metadata': model.get_shard_metadata(),
     'optimizer': optimizer.state_dict(),
 }
-ckpt_path = f'/tmp/rank-{xm.get_ordinal()}-of-{xr.world_size()}.pth'
+ckpt_path = f'/tmp/rank-{xr.global_ordinal()}-of-{xr.world_size()}.pth'
 xm.save(ckpt, ckpt_path, master_only=False)
 ```
 * The checkpoint consolidation script can also be launched from the command line as follows.

--- a/docs/pjrt.md
+++ b/docs/pjrt.md
@@ -70,7 +70,7 @@ Sample diff from XRT to PJRT:
 
  def _mp_fn(index):
    device = xm.xla_device()
--  dist.init_process_group('xla', rank=xm.get_ordinal(), world_size=xr.world_size())
+-  dist.init_process_group('xla', rank=xr.global_ordinal(), world_size=xr.world_size())
 +  dist.init_process_group('xla', init_method='xla://')
 
    torch.manual_seed(42)

--- a/test/distributed_util.py
+++ b/test/distributed_util.py
@@ -91,7 +91,7 @@ def ddp_correctness(init_method: str = 'env://',
                     use_large_net: bool = False,
                     debug: bool = False):
   if init_method == 'env://':
-    rank = xm.get_ordinal()
+    rank = xr.global_ordinal()
     world_size = xr.world_size()
     dist.init_process_group(
         "xla", init_method=init_method, rank=rank, world_size=world_size)

--- a/test/pjrt/test_collective_ops_tpu.py
+++ b/test/pjrt/test_collective_ops_tpu.py
@@ -11,7 +11,7 @@ class TestCollectiveOpsTpu(parameterized.TestCase):
 
   @staticmethod
   def _broadcast(sync):
-    torch.manual_seed(xm.get_ordinal())
+    torch.manual_seed(xr.global_ordinal())
     device = xm.xla_device()
     model = nn.Linear(5, 5).to(device)
     if sync:
@@ -39,7 +39,8 @@ class TestCollectiveOpsTpu(parameterized.TestCase):
     device = xm.xla_device()
     # Prevent 0 and 1 from being converted to constants
     ordinal = xm.send_cpu_data_to_device(
-        torch.tensor(xm.get_ordinal(), dtype=torch.float32, requires_grad=True),
+        torch.tensor(
+            xr.global_ordinal(), dtype=torch.float32, requires_grad=True),
         device=device)
     out = xm.all_reduce(xm.REDUCE_SUM, ordinal, pin_layout=pin_layout)[0]
     assert out.requires_grad
@@ -58,7 +59,7 @@ class TestCollectiveOpsTpu(parameterized.TestCase):
   @staticmethod
   def _all_gather(pin_layout):
     device = xm.xla_device()
-    ordinal = torch.tensor([xm.get_ordinal()], device=device)
+    ordinal = torch.tensor([xr.global_ordinal()], device=device)
     out = xm.all_gather(ordinal, pin_layout=pin_layout)
     xm.mark_step()
 
@@ -105,7 +106,7 @@ class TestCollectiveOpsTpu(parameterized.TestCase):
     tensor = torch.cat(
         [
             -torch.arange(world_size, dtype=torch.float32).view(-1, 1, 1),
-            torch.ones(world_size, 1, 1) * xm.get_ordinal(),
+            torch.ones(world_size, 1, 1) * xr.global_ordinal(),
         ],
         dim=1,
     ).to(device)

--- a/test/pjrt/test_mesh_service.py
+++ b/test/pjrt/test_mesh_service.py
@@ -11,7 +11,7 @@ class PjRtMeshServiceTest(parameterized.TestCase):
 
   @staticmethod
   def _rendezvous_static_size():
-    payload = b'message %d' % xm.get_ordinal()
+    payload = b'message %d' % xr.global_ordinal()
     return xm.rendezvous("test rendezvous", payload)
 
   def test_rendezvous_static_size(self):
@@ -22,7 +22,7 @@ class PjRtMeshServiceTest(parameterized.TestCase):
 
   @staticmethod
   def _rendezvous_dynamic_size():
-    payload = b'message' * xm.get_ordinal()
+    payload = b'message' * xr.global_ordinal()
     return xm.rendezvous("test rendezvous", payload)
 
   def test_rendezvous_dynamic_size(self):
@@ -71,7 +71,7 @@ class PjRtMeshServiceTest(parameterized.TestCase):
 
   @staticmethod
   def _mesh_reduce():
-    return xm.mesh_reduce('test mesh reduce', xm.get_ordinal(), sum)
+    return xm.mesh_reduce('test mesh reduce', xr.global_ordinal(), sum)
 
   def test_mesh_reduce(self):
     results = pjrt.run_multiprocess(self._mesh_reduce)

--- a/test/pjrt/test_runtime.py
+++ b/test/pjrt/test_runtime.py
@@ -51,7 +51,7 @@ class TestExperimentalPjrt(parameterized.TestCase):
         xr.xla_device()
 
   def test_default_ordinals(self):
-    global_ordinal = xm.get_ordinal()
+    global_ordinal = xr.global_ordinal()
     self.assertEqual(global_ordinal, 0)
 
     local_ordinal = xm.get_local_ordinal()

--- a/test/pjrt/test_runtime_multi_gpu.py
+++ b/test/pjrt/test_runtime_multi_gpu.py
@@ -114,14 +114,14 @@ class TestExperimentalPjrtMultiGpu(parameterized.TestCase):
 
       @staticmethod
       def forward(ctx, x):
-        ordinal = xm.get_ordinal()
+        ordinal = xr.global_ordinal()
         ctx.forward_ordinal = ordinal
         return x
 
       @staticmethod
       def backward(ctx, grad_output):
         results['forward_ordinal'] = ctx.forward_ordinal
-        results['backward_ordinal'] = xm.get_ordinal()
+        results['backward_ordinal'] = xr.global_ordinal()
         results['device'] = str(xm.xla_device())
         return grad_output
 
@@ -165,7 +165,7 @@ class TestExperimentalPjrtMultiGpu(parameterized.TestCase):
 
   @staticmethod
   def _broadcast(sync):
-    torch.manual_seed(xm.get_ordinal())
+    torch.manual_seed(xr.global_ordinal())
     device = xm.xla_device()
     model = nn.Linear(5, 5).to(device)
     if sync:
@@ -189,7 +189,7 @@ class TestExperimentalPjrtMultiGpu(parameterized.TestCase):
   @staticmethod
   def _all_gather(pin_layout):
     device = xm.xla_device()
-    ordinal = torch.tensor([xm.get_ordinal()], device=device)
+    ordinal = torch.tensor([xr.global_ordinal()], device=device)
     out = xm.all_gather(ordinal, pin_layout=pin_layout)
     xm.mark_step()
 
@@ -237,7 +237,7 @@ class TestExperimentalPjrtMultiGpu(parameterized.TestCase):
     tensor = torch.cat(
         [
             -torch.arange(world_size, dtype=torch.float32).view(-1, 1, 1),
-            torch.ones(world_size, 1, 1) * xm.get_ordinal(),
+            torch.ones(world_size, 1, 1) * xr.global_ordinal(),
         ],
         dim=1,
     ).to(device)

--- a/test/pjrt/test_train_hf_transformer.py
+++ b/test/pjrt/test_train_hf_transformer.py
@@ -6,6 +6,7 @@ import torch
 from torch.optim import AdamW
 import evaluate
 import torch_xla.core.xla_model as xm
+import torch_xla.runtime as xr
 import torch_xla.debug.metrics as met
 import torch_xla.distributed.parallel_loader as pl
 import torch_xla.distributed.xla_multiprocessing as xmp
@@ -34,7 +35,7 @@ def finetune(rank, train_dataset, test_dataset, tokenizer, flags):
   train_sampler = torch.utils.data.distributed.DistributedSampler(
       train_dataset,
       num_replicas=xr.world_size(),
-      rank=xm.get_ordinal(),
+      rank=xr.global_ordinal(),
       shuffle=True)
 
   # Use thread safe random number generator with a consistent seed

--- a/test/spmd/test_xla_spmd_python_api_interaction.py
+++ b/test/spmd/test_xla_spmd_python_api_interaction.py
@@ -30,7 +30,7 @@ class BasicXMAPITest(test_xla_sharding_base.XlaShardingTest):
     self.assertEqual(xr.world_size(), 1)
 
   def test_get_ordinal(self):
-    self.assertEqual(xm.get_ordinal(), 0)
+    self.assertEqual(xr.global_ordinal(), 0)
 
   def test_get_local_ordinal(self):
     self.assertEqual(xm.get_local_ordinal(), 0)

--- a/test/test_mp_all_to_all.py
+++ b/test/test_mp_all_to_all.py
@@ -11,7 +11,7 @@ def _mp_fn(index):
   if xm.xla_device_hw(device) == 'TPU':
     slots_per_device = 4
     size = slots_per_device * xr.world_size()
-    ordinal = xm.get_ordinal()
+    ordinal = xr.global_ordinal()
     value = torch.tensor([ordinal] * size, dtype=torch.int32, device=device)
     result_tensor = xm.all_to_all(
         value,

--- a/test/test_mp_collective_permute.py
+++ b/test/test_mp_collective_permute.py
@@ -10,7 +10,7 @@ def _mp_fn(index):
   device = xm.xla_device()
   if xm.xla_device_hw(device) == 'TPU':
     world_size = xr.world_size()
-    ordinal = xm.get_ordinal()
+    ordinal = xr.global_ordinal()
     value = torch.tensor([ordinal] * 100, dtype=torch.int32, device=device)
     pairs = []
     for i in range(1, world_size):

--- a/test/test_mp_rendezvous.py
+++ b/test/test_mp_rendezvous.py
@@ -14,7 +14,7 @@ def _get_replica_group(index):
 
 
 def _mp_fn(index):
-  ordinal = xm.get_ordinal()
+  ordinal = xr.global_ordinal()
   print('Core {} waiting for rendezvous ...'.format(ordinal))
   replicas, gid = _get_replica_group(index)
   data = xm.rendezvous(

--- a/test/test_mp_sync_batch_norm.py
+++ b/test/test_mp_sync_batch_norm.py
@@ -26,7 +26,7 @@ def run_step(model: torch.nn.Module, batch: torch.Tensor) -> torch.Tensor:
     loss.backward()
     optimizer.step()
     split_size = batch.shape[0] // xr.world_size()
-    result = result.split(split_size, dim=0)[xm.get_ordinal()]
+    result = result.split(split_size, dim=0)[xr.global_ordinal()]
 
   return result
 

--- a/test/test_profile_mp_mnist.py
+++ b/test/test_profile_mp_mnist.py
@@ -108,14 +108,14 @@ def train_mnist(flags,
         sample_count=100000 // flags.batch_size // xr.world_size())
   else:
     train_dataset = datasets.MNIST(
-        os.path.join(flags.datadir, str(xm.get_ordinal())),
+        os.path.join(flags.datadir, str(xr.global_ordinal())),
         train=True,
         download=True,
         transform=transforms.Compose(
             [transforms.ToTensor(),
              transforms.Normalize((0.1307,), (0.3081,))]))
     test_dataset = datasets.MNIST(
-        os.path.join(flags.datadir, str(xm.get_ordinal())),
+        os.path.join(flags.datadir, str(xr.global_ordinal())),
         train=False,
         download=True,
         transform=transforms.Compose(
@@ -126,7 +126,7 @@ def train_mnist(flags,
       train_sampler = torch.utils.data.distributed.DistributedSampler(
           train_dataset,
           num_replicas=xr.world_size(),
-          rank=xm.get_ordinal(),
+          rank=xr.global_ordinal(),
           shuffle=True)
     train_loader = torch.utils.data.DataLoader(
         train_dataset,

--- a/test/test_train_mp_imagenet.py
+++ b/test/test_train_mp_imagenet.py
@@ -222,12 +222,12 @@ def train_imagenet():
       train_sampler = torch.utils.data.distributed.DistributedSampler(
           train_dataset,
           num_replicas=xr.world_size(),
-          rank=xm.get_ordinal(),
+          rank=xr.global_ordinal(),
           shuffle=True)
       test_sampler = torch.utils.data.distributed.DistributedSampler(
           test_dataset,
           num_replicas=xr.world_size(),
-          rank=xm.get_ordinal(),
+          rank=xr.global_ordinal(),
           shuffle=False)
     train_loader = torch.utils.data.DataLoader(
         train_dataset,

--- a/test/test_train_mp_imagenet_amp.py
+++ b/test/test_train_mp_imagenet_amp.py
@@ -171,12 +171,12 @@ def train_imagenet():
       train_sampler = torch.utils.data.distributed.DistributedSampler(
           train_dataset,
           num_replicas=xr.world_size(),
-          rank=xm.get_ordinal(),
+          rank=xr.global_ordinal(),
           shuffle=True)
       test_sampler = torch.utils.data.distributed.DistributedSampler(
           test_dataset,
           num_replicas=xr.world_size(),
-          rank=xm.get_ordinal(),
+          rank=xr.global_ordinal(),
           shuffle=False)
     train_loader = torch.utils.data.DataLoader(
         train_dataset,

--- a/test/test_train_mp_imagenet_fsdp.py
+++ b/test/test_train_mp_imagenet_fsdp.py
@@ -217,12 +217,12 @@ def train_imagenet():
       train_sampler = torch.utils.data.distributed.DistributedSampler(
           train_dataset,
           num_replicas=xr.world_size(),
-          rank=xm.get_ordinal(),
+          rank=xr.global_ordinal(),
           shuffle=True)
       test_sampler = torch.utils.data.distributed.DistributedSampler(
           test_dataset,
           num_replicas=xr.world_size(),
-          rank=xm.get_ordinal(),
+          rank=xr.global_ordinal(),
           shuffle=False)
     train_loader = torch.utils.data.DataLoader(
         train_dataset,

--- a/test/test_train_mp_mnist.py
+++ b/test/test_train_mp_mnist.py
@@ -94,14 +94,14 @@ def train_mnist(flags, **kwargs):
         sample_count=10000 // flags.batch_size // xr.world_size())
   else:
     train_dataset = datasets.MNIST(
-        os.path.join(flags.datadir, str(xm.get_ordinal())),
+        os.path.join(flags.datadir, str(xr.global_ordinal())),
         train=True,
         download=True,
         transform=transforms.Compose(
             [transforms.ToTensor(),
              transforms.Normalize((0.1307,), (0.3081,))]))
     test_dataset = datasets.MNIST(
-        os.path.join(flags.datadir, str(xm.get_ordinal())),
+        os.path.join(flags.datadir, str(xr.global_ordinal())),
         train=False,
         download=True,
         transform=transforms.Compose(
@@ -112,7 +112,7 @@ def train_mnist(flags, **kwargs):
       train_sampler = torch.utils.data.distributed.DistributedSampler(
           train_dataset,
           num_replicas=xr.world_size(),
-          rank=xm.get_ordinal(),
+          rank=xr.global_ordinal(),
           shuffle=True)
     train_loader = torch.utils.data.DataLoader(
         train_dataset,

--- a/test/test_train_mp_mnist_amp.py
+++ b/test/test_train_mp_mnist_amp.py
@@ -93,14 +93,14 @@ def train_mnist(flags, **kwargs):
         sample_count=10000 // flags.batch_size // xr.world_size())
   else:
     train_dataset = datasets.MNIST(
-        os.path.join(flags.datadir, str(xm.get_ordinal())),
+        os.path.join(flags.datadir, str(xr.global_ordinal())),
         train=True,
         download=True,
         transform=transforms.Compose(
             [transforms.ToTensor(),
              transforms.Normalize((0.1307,), (0.3081,))]))
     test_dataset = datasets.MNIST(
-        os.path.join(flags.datadir, str(xm.get_ordinal())),
+        os.path.join(flags.datadir, str(xr.global_ordinal())),
         train=False,
         download=True,
         transform=transforms.Compose(
@@ -111,7 +111,7 @@ def train_mnist(flags, **kwargs):
       train_sampler = torch.utils.data.distributed.DistributedSampler(
           train_dataset,
           num_replicas=xr.world_size(),
-          rank=xm.get_ordinal(),
+          rank=xr.global_ordinal(),
           shuffle=True)
     train_loader = torch.utils.data.DataLoader(
         train_dataset,

--- a/test/test_train_mp_mnist_fsdp_with_ckpt.py
+++ b/test/test_train_mp_mnist_fsdp_with_ckpt.py
@@ -128,14 +128,14 @@ def train_mnist(flags, **kwargs):
         sample_count=10000 // flags.batch_size // xr.world_size())
   else:
     train_dataset = datasets.MNIST(
-        os.path.join(flags.datadir, str(xm.get_ordinal())),
+        os.path.join(flags.datadir, str(xr.global_ordinal())),
         train=True,
         download=True,
         transform=transforms.Compose(
             [transforms.ToTensor(),
              transforms.Normalize((0.1307,), (0.3081,))]))
     test_dataset = datasets.MNIST(
-        os.path.join(flags.datadir, str(xm.get_ordinal())),
+        os.path.join(flags.datadir, str(xr.global_ordinal())),
         train=False,
         download=True,
         transform=transforms.Compose(
@@ -146,7 +146,7 @@ def train_mnist(flags, **kwargs):
       train_sampler = torch.utils.data.distributed.DistributedSampler(
           train_dataset,
           num_replicas=xr.world_size(),
-          rank=xm.get_ordinal(),
+          rank=xr.global_ordinal(),
           shuffle=True)
     train_loader = torch.utils.data.DataLoader(
         train_dataset,
@@ -282,7 +282,7 @@ def train_mnist(flags, **kwargs):
     # system (e.g. NFS) when running on a TPU pod.
 
     # Save the final model checkpoint
-    rank = xm.get_ordinal()
+    rank = xr.global_ordinal()
     world_size = xr.world_size()
     ckpt_path = f'{flags.ckpt_prefix}_rank-{rank:08d}-of-{world_size:08d}.pth'
     ckpt = {

--- a/test/test_train_mp_mnist_zero1.py
+++ b/test/test_train_mp_mnist_zero1.py
@@ -78,14 +78,14 @@ def train_mnist(flags, **kwargs):
         sample_count=10000 // flags.batch_size // xr.world_size())
   else:
     train_dataset = datasets.MNIST(
-        os.path.join(flags.datadir, str(xm.get_ordinal())),
+        os.path.join(flags.datadir, str(xr.global_ordinal())),
         train=True,
         download=True,
         transform=transforms.Compose(
             [transforms.ToTensor(),
              transforms.Normalize((0.1307,), (0.3081,))]))
     test_dataset = datasets.MNIST(
-        os.path.join(flags.datadir, str(xm.get_ordinal())),
+        os.path.join(flags.datadir, str(xr.global_ordinal())),
         train=False,
         download=True,
         transform=transforms.Compose(
@@ -96,7 +96,7 @@ def train_mnist(flags, **kwargs):
       train_sampler = torch.utils.data.distributed.DistributedSampler(
           train_dataset,
           num_replicas=xr.world_size(),
-          rank=xm.get_ordinal(),
+          rank=xr.global_ordinal(),
           shuffle=True)
     train_loader = torch.utils.data.DataLoader(
         train_dataset,

--- a/test/torch_distributed/test_torch_distributed_all_gather_xla_backend.py
+++ b/test/torch_distributed/test_torch_distributed_all_gather_xla_backend.py
@@ -13,7 +13,7 @@ def _mp_fn(index):
   device = xm.xla_device()
   if xm.xla_device_hw(device) in ('TPU', 'CUDA'):
     world_size = xr.world_size()
-    rank = xm.get_ordinal()
+    rank = xr.global_ordinal()
 
     dist.init_process_group('xla', init_method='xla://')
 

--- a/test/torch_distributed/test_torch_distributed_bucketed_all_reduce_xla_backend.py
+++ b/test/torch_distributed/test_torch_distributed_bucketed_all_reduce_xla_backend.py
@@ -3,6 +3,7 @@ import sys
 import torch
 import torch_xla
 import torch_xla.core.xla_model as xm
+import torch_xla.runtime as xr
 import torch_xla.distributed.xla_multiprocessing as xmp
 import torch_xla.distributed.xla_backend
 import torch.distributed as dist
@@ -11,7 +12,7 @@ import torch.distributed as dist
 def _mp_fn(index):
   device = xm.xla_device()
   if xm.xla_device_hw(device) in ('TPU', 'CUDA'):
-    world_size = xm.xrt_world_size()
+    world_size = xr.world_size()
     rank = xm.get_ordinal()
 
     dist.init_process_group(

--- a/test/torch_distributed/test_torch_distributed_bucketed_all_reduce_xla_backend.py
+++ b/test/torch_distributed/test_torch_distributed_bucketed_all_reduce_xla_backend.py
@@ -13,7 +13,7 @@ def _mp_fn(index):
   device = xm.xla_device()
   if xm.xla_device_hw(device) in ('TPU', 'CUDA'):
     world_size = xr.world_size()
-    rank = xm.get_ordinal()
+    rank = xr.global_ordinal()
 
     dist.init_process_group(
         'xla', init_method='xla://', world_size=world_size, rank=rank)

--- a/test/torch_distributed/test_torch_distributed_multi_all_reduce_xla_backend.py
+++ b/test/torch_distributed/test_torch_distributed_multi_all_reduce_xla_backend.py
@@ -13,7 +13,7 @@ def _mp_fn(index):
   device = xm.xla_device()
   if xm.xla_device_hw(device) in ('TPU', 'CUDA'):
     world_size = xr.world_size()
-    rank = xm.get_ordinal()
+    rank = xr.global_ordinal()
 
     dist.init_process_group('xla', init_method='xla://')
 

--- a/test/torch_distributed/test_torch_distributed_reduce_scatter_xla_backend.py
+++ b/test/torch_distributed/test_torch_distributed_reduce_scatter_xla_backend.py
@@ -13,7 +13,7 @@ def _mp_fn(index):
   device = xm.xla_device()
   if xm.xla_device_hw(device) in ('TPU', 'CUDA'):
     world_size = xr.world_size()
-    rank = xm.get_ordinal()
+    rank = xr.global_ordinal()
 
     dist.init_process_group('xla', init_method='xla://')
 

--- a/torch_xla/core/functions.py
+++ b/torch_xla/core/functions.py
@@ -58,7 +58,7 @@ class AllGather(torch.autograd.Function):
   @staticmethod
   def forward(ctx, input, dim):
     ctx.dim = dim
-    ctx.ordinal = xm.get_ordinal()
+    ctx.ordinal = xr.global_ordinal()
     ctx.world_size = xr.world_size()
     return xm.all_gather(input, dim=dim)
 
@@ -101,7 +101,7 @@ def distributed_mm(w, x, split=1):
   Returns:
     The result of the distributed matrix multiplication operation.
   """
-  ordinal = xm.get_ordinal()
+  ordinal = xr.global_ordinal()
   # w = N x Ko
   # WG = Ko * WORLD_SIZE
   # x = WG x M

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -199,7 +199,7 @@ def xla_replication_devices(local_devices):
   real_devices = xla_real_devices(local_devices)
   device_types = set()
   for device in real_devices:
-    xdev = parse_xla_device(device)
+    xdev = _utils.parse_xla_device(device)
     device_types.add(xdev[0])
   if len(device_types) != 1:
     # No replication if the device set spawns multiple device types.
@@ -216,13 +216,14 @@ def xla_replication_devices(local_devices):
   replication_devices = []
   for device in torch_xla._XLAC._xla_get_all_devices():
     # device is like 'CUDA:0'
-    xdev = parse_xla_device(device)
+    xdev = _utils.parse_xla_device(device)
     if not xdev:
       raise RuntimeError('Invalid device format: {}'.format(device))
     if xdev[0] == device_type:
       replication_devices.append(device)
   sorted_by_ordinal = sorted(
-      replication_devices, key=lambda device: parse_xla_device(device)[1])
+      replication_devices,
+      key=lambda device: _utils.parse_xla_device(device)[1])
   return sorted_by_ordinal
 
 

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -37,9 +37,14 @@ _DEVICE_CONTEXTS_LOCK = threading.Lock()
 XLA_LIB = Library("xla", "DEF")
 
 from . import xla_model as this_module
-xrt_world_size = deprecated(this_module, torch_xla.runtime.world_size)
-get_ordinal = deprecated(this_module, torch_xla.runtime.global_ordinal)
-parse_xla_device = deprecated(this_module, _utils.parse_xla_device)
+xrt_world_size = deprecated(this_module, torch_xla.runtime.world_size,
+                            'xrt_world_size() will be removed in release 2.6.')
+get_ordinal = deprecated(
+    this_module, torch_xla.runtime.global_ordinal,
+    'xla_model.get_ordinal() will be removed in release 2.6.')
+parse_xla_device = deprecated(
+    this_module, _utils.parse_xla_device,
+    'xla_model.parse_xla_device() will be removed in release 2.6.')
 
 
 class DeviceContext(object):

--- a/torch_xla/distributed/fsdp/utils.py
+++ b/torch_xla/distributed/fsdp/utils.py
@@ -2,6 +2,7 @@ from types import MethodType
 
 import torch
 import torch_xla.core.xla_model as xm
+import torch_xla.runtime as xr
 from torch_xla.utils.checkpoint import checkpoint
 
 
@@ -69,7 +70,7 @@ def dummy_reduce_scatter(reduce_type,
   assert shard_count == xr.world_size()
   full_size = input.size(scatter_dim)
   shard_size = full_size // xr.world_size()
-  begin = shard_size * xm.get_ordinal()
+  begin = shard_size * xr.global_ordinal()
   end = begin + shard_size
   slices = [None] * input.dim()
   slices[scatter_dim] = slice(begin, end)

--- a/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
+++ b/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
@@ -116,7 +116,7 @@ class XlaFullyShardedDataParallel(nn.Module):
               'shard_metadata': model.get_shard_metadata(),
               'optimizer': optimizer.state_dict(),
           }
-          ckpt_path = f'/tmp/rank-{xm.get_ordinal()}-of-{xr.world_size()}.pth'
+          ckpt_path = f'/tmp/rank-{xr.global_ordinal()}-of-{xr.world_size()}.pth'
           xm.save(ckpt, ckpt_path, master_only=False)
 
       When resuming training of an FSDP model from saved checkpoints, all
@@ -189,7 +189,7 @@ class XlaFullyShardedDataParallel(nn.Module):
       sharding_rank (int, Optional):
           The rank of this sharding instance. This must be specified if
           ``sharding_groups`` is provided. Otherwise it defaults to
-          ``xm.get_ordinal()``.
+          ``xr.global_ordinal()``.
       sharding_world_size (int, Optional):
           The world_size of this sharding instance. This must be specified if
           ``sharding_groups`` is provided. Otherwise it defaults to
@@ -427,7 +427,7 @@ class XlaFullyShardedDataParallel(nn.Module):
     # FSDP data parallelism with model parallelism (e.g. Megatron)
     self.sharding_groups = sharding_groups
     if sharding_groups is None:
-      self.rank = xm.get_ordinal()
+      self.rank = xr.global_ordinal()
       self.world_size = xr.world_size()
     else:
       if sharding_rank is None or sharding_world_size is None:

--- a/torch_xla/distributed/spmd/xla_sharding.py
+++ b/torch_xla/distributed/spmd/xla_sharding.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 import torch
 import torch_xla
 import torch_xla.core.xla_model as xm
-import torch_xla._internal.utils as iutils
+import torch_xla._internal.utils as _utils
 from torch_xla.distributed.spmd import XLAShardedTensor, XLAShard
 import torch_xla.runtime as xr
 
@@ -223,7 +223,7 @@ class HybridMesh(Mesh):
     mesh_shape = tuple([x * y for x, y in zip(ici_mesh_shape, dcn_mesh_shape)])
     self.device_attributes = xr.global_runtime_device_attributes()
     self.device_attributes.sort(
-        key=lambda attr: iutils.parse_xla_device(attr['name'])[1])
+        key=lambda attr: _utils.parse_xla_device(attr['name'])[1])
 
     if 'slice_index' in self.device_attributes[0] and np.prod(
         dcn_mesh_shape) == 1:

--- a/torch_xla/experimental/deprecation.py
+++ b/torch_xla/experimental/deprecation.py
@@ -1,21 +1,25 @@
 import functools
 import logging
 import importlib
-from typing import TypeVar
+from typing import Optional, TypeVar
 
 FN = TypeVar('FN')
 
 
-def deprecated(module, new: FN, old_name=None) -> FN:
+def deprecated(module,
+               new: FN,
+               old_name: Optional[str] = None,
+               extra_msg: Optional[str] = None) -> FN:
   already_warned = [False]
   old_name = old_name or new.__name__
 
   @functools.wraps(new)
   def wrapped(*args, **kwargs):
     if not already_warned[0]:
-      logging.warning(
-          f'{module.__name__}.{old_name} is deprecated. Use {new.__module__}.{new.__name__} instead.'
-      )
+      warning_msg = f'{module.__name__}.{old_name} is deprecated. Use {new.__module__}.{new.__name__} instead.'
+      if extra_msg:
+        warning_msg += f' {extra_msg}'
+      logging.warning(warning_msg)
       already_warned[0] = True
 
     return new(*args, **kwargs)
@@ -23,12 +27,12 @@ def deprecated(module, new: FN, old_name=None) -> FN:
   return wrapped
 
 
-def mark_deprecated(new: FN) -> FN:
+def mark_deprecated(new: FN, extra_msg: Optional[str] = None) -> FN:
   """Decorator to mark a function as deprecated and map to new function.
 
   Args:
-    module: current module of the deprecated function that is in. Assume current module name is X, you can use `from . import X` and pass X here.
     new: new function that we map to. Need to include the path the new function that is in.
+    extra_msg: extra message to include in the warning. For example, which release version will completely deprecate the function.
 
   Returns:
     Wrapper of the new function.
@@ -42,4 +46,4 @@ def mark_deprecated(new: FN) -> FN:
 
 
 def register_deprecated(module, new: FN):
-  setattr(module, new.__name__, deprecated(module, new))
+  setattr(module, new.__name__, deprecated(module, new), extra_msg)

--- a/torch_xla/runtime.py
+++ b/torch_xla/runtime.py
@@ -20,7 +20,7 @@ FN = TypeVar('FN')
 
 # Note [Dynamo WORLD_SIEZ and ORDINAL]
 # Belows are workaround to cache the ordinal and world_size such that
-# Dynamo won't do graph breaks when runtime.xrt_world_size() and runtime.global_ordinal() are called.
+# Dynamo won't do graph breaks when runtime.world_size() and runtime.global_ordinal() are called.
 _WORLD_SIZE = None
 _ORDINAL = None
 

--- a/torch_xla/test/test_utils.py
+++ b/torch_xla/test/test_utils.py
@@ -5,7 +5,7 @@ import sys
 import time
 import unittest
 
-import torch_xla.core.xla_model as xm
+import torch_xla.runtime as xr
 import torch_xla.debug.metrics as met
 import torch_xla.debug.metrics_compare_utils as mcu
 import torch_xla.utils.utils as xu
@@ -41,7 +41,7 @@ def mp_test(func):
 
 
 def _get_device_spec(device):
-  ordinal = xm.get_ordinal()
+  ordinal = xr.global_ordinal()
   return str(device) if ordinal < 0 else '{}/{}'.format(device, ordinal)
 
 


### PR DESCRIPTION
Some clean up fix related to deprecated APIs:

1. Do not use `parse_xla_device`, `xm.get_ordinal` and `xm.world_size` from deprecated functions internally.
2. Update ddp related doc to use `xr.global_ordinal`. E.g. ,https://pytorch.org/xla/master/multi_process_distributed.html
3. Update the deprecation message to involve the version related info as request by @miladm 