### PR TITLE
Disable open PJRT for xal2 if OS env disable flag is true

### DIFF
--- a/experimental/torch_xla2/torch_xla2/__init__.py
+++ b/experimental/torch_xla2/torch_xla2/__init__.py
@@ -22,7 +22,8 @@ try:
     f'ml_framework_name:PyTorch/XLA2;ml_framework_version:{"v0.0.1"}'
   )
   xla_bridge._clear_backends()
-  jax.devices()  # open PJRT  to see if it opens
+  if os.environ.get("disable_xla2_PJRT_test") != "true":
+    jax.devices()  # open PJRT  to see if it opens
 except RuntimeError:
   jax.config.update(
     'jax_pjrt_client_create_options', old_pjrt_options

--- a/experimental/torch_xla2/torch_xla2/__init__.py
+++ b/experimental/torch_xla2/torch_xla2/__init__.py
@@ -22,7 +22,7 @@ try:
     f'ml_framework_name:PyTorch/XLA2;ml_framework_version:{"v0.0.1"}'
   )
   xla_bridge._clear_backends()
-  if os.environ.get("disable_xla2_PJRT_test") != "true":
+  if os.environ.get("DISABLE_XLA2_PJRT_TEST") != "true":
     jax.devices()  # open PJRT  to see if it opens
 except RuntimeError:
   jax.config.update(


### PR DESCRIPTION
Add disable_xla2_PJRT_test to let engineer have flexibility to  turn off jax PIRT test. By default, it won't impact existing logic. 

**Background:**

In ray multiple cases, call jax devices both in head and workers caused exhausted TPU exception. There are 2 ways to fix it:

1.  xla2 init jax function part to a function and don't call it in init state, call the function after all the call inited 
2. have a flag to disable jax function call in jax __init__.py 


