### PR TITLE
Support fullgraph for torch_xla.compile

### DIFF
--- a/test/eager/test_eager_with_xla_compile.py
+++ b/test/eager/test_eager_with_xla_compile.py
@@ -20,6 +20,12 @@ class EagerWithXLACompileTest(unittest.TestCase):
   def dummy_cos_sin(self, tensor):
     return torch.cos(torch.sin(tensor))
 
+  def dummy_graph_break(self, t):
+    if t[0][0] > 0:
+      return torch.sin(t)
+    else:
+      return torch.cos(t)
+
   def test_eager_with_compile_basic(self):
     met.clear_all()
     self.assertTrue(torch_xla.experimental.is_eager_mode())
@@ -45,21 +51,34 @@ class EagerWithXLACompileTest(unittest.TestCase):
     # no egaer execution should happen inside this compiled graph
     self.assertNotIn("EagerOpExecuteTime", met.metric_names())
 
+  def test_eager_execute_compiled_multiple_times(self):
+    met.clear_all()
+    self.assertTrue(torch_xla.experimental.is_eager_mode())
+    device = torch_xla.device()
+    # this part happens eagerly
+    t1 = torch.randn(10, 5, device=device)
+    t1.add_(0.5)
+    compiled = torch_xla.compile(self.dummy_cos_sin)
+    res = compiled(compiled(t1))
+    self.assertTrue(
+        torch.allclose(res * 0.3,
+                       self.dummy_cos_sin(self.dummy_cos_sin(t1)) * 0.3))
+    xm.wait_device_ops()
+    self.assertEqual(met.metric_data("ExecuteTime")[0], 2)
 
-def test_eager_execute_compiled_multiple_times(self):
-  met.clear_all()
-  self.assertTrue(torch_xla.experimental.is_eager_mode())
-  device = torch_xla.device()
-  # this part happens eagerly
-  t1 = torch.randn(10, 5, device=device)
-  t1.add_(0.5)
-  compiled = torch_xla.compile(self.dummy_cos_sin)
-  res = compiled(compiled(t1))
-  self.assertTrue(
-      torch.allclose(res * 0.3,
-                     self.dummy_cos_sin(self.dummy_cos_sin(t1)) * 0.3))
-  xm.wait_device_ops()
-  self.assertEqual(met.metric_data("ExecuteTime")[0], 2)
+  def test_eager_with_compile_graph_break(self):
+    met.clear_all()
+    self.assertTrue(torch_xla.experimental.is_eager_mode())
+    device = torch_xla.device()
+    t1 = torch.randn(5, 5, device=device)
+
+    with self.assertRaises(Exception) as context:
+      t2_compiled = torch_xla.compile(
+          self.dummy_graph_break, full_graph=True)(
+              t1)
+    self.assertIn(
+        'Unexpected execution happens inside the compiled function, exiting',
+        context.exception.__str__())
 
 
 if __name__ == '__main__':

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2441,6 +2441,11 @@ void InitXlaModuleBindings(py::module m) {
   });
   m.def("_get_use_eager_mode",
         []() { return XLAGraphExecutor::Get()->UseEagerMode(); });
+  m.def("_set_allow_execution", [](bool allow_execution) {
+    XLAGraphExecutor::Get()->SetAllowExecution(allow_execution);
+  });
+  m.def("_get_allow_execution",
+        []() { return XLAGraphExecutor::Get()->AllowExecution(); });
   m.def("_replace_xla_tensor",
         [](at::Tensor& self, const at::Tensor& source) -> at::Tensor& {
           return XLANativeFunctions::set_(self, source);

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -192,6 +192,12 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
 
   bool UseEagerMode() { return use_eager_mode_; }
 
+  void SetAllowExecution(bool allow_execution) {
+    allow_execution_ = allow_execution;
+  }
+
+  bool AllowExecution() { return allow_execution_; }
+
  private:
   // This is just to group results from compile(). Since our computation is
   // different, we don't reuse the upstream CompilationResult.
@@ -367,6 +373,7 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
 
   ComputationCache* computation_cache_;
   bool use_eager_mode_ = false;
+  bool allow_execution_ = true;
 };
 
 }  // namespace torch_xla


### PR DESCRIPTION
with `torch_xla.compile(fn, full_graph=True)` we will output an error message when we see graph breaks(early access of the value of tensor or cpu fallback) inside the passed in `fn`