### PR TITLE
[benchmarks] Fix verifier error handling and OOM.

### DIFF
--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -184,7 +184,7 @@ class ExperimentRunner:
               benchmark_experiment.to_dict(),
               benchmark_model.to_dict(),
               metrics={"error": str(e)},
-              verification_code=VerificationCode.VERIFIER_SKIPPED_UNEXPECTEDLY,
+              verification_code=VerificationCode.VERIFIER_DIDNT_RUN,
           )
         except subprocess.CalledProcessError as e:
           self._fwd_captured_stdout_stderr(e.stdout, e.stderr)
@@ -193,7 +193,7 @@ class ExperimentRunner:
               benchmark_experiment.to_dict(),
               benchmark_model.to_dict(),
               metrics={"error": e.stderr},
-              verification_code=VerificationCode.VERIFIER_SKIPPED_UNEXPECTEDLY,
+              verification_code=VerificationCode.VERIFIER_DIDNT_RUN,
           )
         except subprocess.SubprocessError as e:
           logger.error("ERROR when launching child process")
@@ -201,7 +201,7 @@ class ExperimentRunner:
               benchmark_experiment.to_dict(),
               benchmark_model.to_dict(),
               metrics={"error": str(e)},
-              verification_code=VerificationCode.VERIFIER_SKIPPED_UNEXPECTEDLY,
+              verification_code=VerificationCode.VERIFIER_DIDNT_RUN,
           )
         except ValueError as e:
           logger.error(f"ERROR {e}")
@@ -209,7 +209,7 @@ class ExperimentRunner:
               benchmark_experiment.to_dict(),
               benchmark_model.to_dict(),
               metrics={"error": str(e)},
-              verification_code=VerificationCode.VERIFIER_SKIPPED_UNEXPECTEDLY,
+              verification_code=VerificationCode.VERIFIER_DIDNT_RUN,
           )
 
   # TODO: Use `_unique_basename` instead.

--- a/benchmarks/experiment_runner.py
+++ b/benchmarks/experiment_runner.py
@@ -275,7 +275,7 @@ class ExperimentRunner:
     verification_code = VerificationCode.VERIFIER_SKIPPED
 
     # Turn on CUDAGraphs if we are running inductor
-    if benchmark_experiment.is_inductor():
+    if experiment.is_inductor():
       from torch._inductor import config as inductor_config
       inductor_config.triton.cudagraphs = True
 

--- a/benchmarks/verifier.py
+++ b/benchmarks/verifier.py
@@ -20,15 +20,15 @@ class VerificationCode(str, Enum):
   FAIL = 'FAIL',
   # Eager execution failed.
   EAGER_FAILED = 'EAGER_FAILED'
-  # Verifier failed, raising an exception.
-  VERIFIER_FAILED = 'VERIFIER_FAILED'
+  # An exception was raised when running the verifier.
+  EXCEPTION_RAISED = 'EXCEPTION_RAISED'
   # Eager runs do not agree.
   NONDETERMINISTIC_EAGER_RUN = 'NONDETERMINISTIC_EAGER_RUN'
   # Verifier skipped.
   VERIFIER_SKIPPED = 'VERIFIER_SKIPPED'
   # Verifier did not run. It was skipped, but due to an unexpected reason.
   # Either an exception was raised or the process timeout.
-  VERIFIER_SKIPPED_UNEXPECTEDLY = 'VERIFIER_SKIPPED_UNEXPECTEDLY'
+  VERIFIER_DIDNT_RUN = 'VERIFIER_DIDNT_RUN'
 
 
 class VerificationException(Exception):
@@ -93,8 +93,8 @@ def verify(
     raise
   except Exception as e:
     # If anythin went wrong (other than an explicit VerificationException), raise
-    # a VerificationException with VERIFIER_FAILED code, while chaining the cause.
-    raise VerificationException(VerificationCode.VERIFIER_FAILED) from e
+    # a VerificationException with EXCEPTION_RAISED code, while chaining the cause.
+    raise VerificationException(VerificationCode.EXCEPTION_RAISED) from e
 
   return VerificationCode.PASS
 

--- a/benchmarks/verifier.py
+++ b/benchmarks/verifier.py
@@ -92,7 +92,7 @@ def verify(
   except VerificationException:
     raise
   except Exception as e:
-    # If anythin went wrong (other than an explicit VerificationException), raise
+    # If anything went wrong (other than an explicit VerificationException), raise
     # a VerificationException with EXCEPTION_RAISED code, while chaining the cause.
     raise VerificationException(VerificationCode.EXCEPTION_RAISED) from e
 


### PR DESCRIPTION
In summary, this PR:

- Skips the actual experiment when running the verifier, i.e. goes directly into the verifier code, instead of running the experiment first (the experiment is still run in the end of the verifier, though)
- Handles errors when running the model on `fp64`, turning cosine similarity verification ON on any exception
- Renames a few confusing `VerificationCode` enum names

cc @miladm @JackCaoG @zpcore 