### PR TITLE
fix libtpu name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ import build_util
 base_dir = os.path.dirname(os.path.abspath(__file__))
 
 _date = '20240726'
-_libtpu_version = f'0.1.dev{_date}+nightly'
+_libtpu_version = f'0.1.dev{_date}'
 _libtpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
 _jax_version = f'0.4.31.dev{_date}'
 
@@ -312,7 +312,7 @@ setup(
     extras_require={
         # On Cloud TPU VM install with:
         # pip install torch_xla[tpu] -f https://storage.googleapis.com/libtpu-releases/index.html
-        'tpu': [f'libtpu-nightly=={_libtpu_version}'],
+        'tpu': [f'libtpu-nightly=={_libtpu_version}+nightly'],
         # pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
         'pallas': [f'jaxlib=={_jax_version}', f'jax=={_jax_version}'],
     },

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ import build_util
 base_dir = os.path.dirname(os.path.abspath(__file__))
 
 _date = '20240726'
-_libtpu_version = f'0.1.dev{_date}'
+_libtpu_version = f'0.1.dev{_date}+nightly'
 _libtpu_storage_path = f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl'
 _jax_version = f'0.4.31.dev{_date}'
 


### PR DESCRIPTION
libtpu name got updated recently:
`0.1.dev20240726` --> `0.1.dev20240726+nightly`  

Below is the error we saw:
```
[2024-07-31, 14:25:02 UTC] {logging_mixin.py:150} INFO - Collecting libtpu-nightly==0.1.dev20240726
[2024-07-31, 14:25:02 UTC] {logging_mixin.py:150} INFO -   Downloading https://storage.googleapis.com/libtpu-nightly-releases/wheels/libtpu-nightly/libtpu_nightly-0.1.dev20240726%2Bnightly-py3-none-any.whl (119.2 MB)
[2024-07-31, 14:25:04 UTC] {logging_mixin.py:150} INFO -      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 119.2/119.2 MB 8.2 MB/s eta 0:00:00
[2024-07-31, 14:25:04 UTC] {logging_mixin.py:150} INFO - Discarding https://storage.googleapis.com/libtpu-nightly-releases/wheels/libtpu-nightly/libtpu_nightly-0.1.dev20240726%2Bnightly-py3-none-any.whl (from https://storage.googleapis.com/libtpu-releases/index.html): Requested libtpu-nightly==0.1.dev20240726 from https://storage.googleapis.com/libtpu-nightly-releases/wheels/libtpu-nightly/libtpu_nightly-0.1.dev20240726%2Bnightly-py3-none-any.whl (from torch_xla@ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-nightly-cp310-cp310-linux_x86_64.whl) has inconsistent version: filename has '0.1.dev20240726+nightly', but metadata has '0.1.dev20240726+default'
[2024-07-31, 14:25:04 UTC] {logging_mixin.py:150} WARNING - ERROR: Could not find a version that satisfies the requirement libtpu-nightly==0.1.dev20240726; extra == "tpu" (from torch-xla[tpu]) (from versions: 0.0.1, 0.1.dev20210615+nightly, 0.1.dev20210709+nightly, 0.1.dev20210809+nightly, 0.1.dev20210916+nightly, 0.1.dev20210917+nightly, 0.1.dev20210920+nightly, 0.1.dev20210921+nightly, 0.1.dev20210922+nightly, 0.1.dev20210923+nightly, 0.1.dev20210924+nightly, 0.1.dev20210925+nightly, 0.1.dev20210926+nightly, 0.1.dev20210927+nightly, 0.1.dev20210928+nightly, 0.1.dev20210929+nightly, 0.1.dev20210930+nightly, 0.1.dev20211001+nightly, 0.1.dev20211002+nightly, 0.1.dev20211003+nightly, 0.1.dev20211004+nightly, 0.1.dev20211005+nightly, 0.1.dev20211006+nightly, 0.1.dev20211007+nightly, 0.1.dev20211008+nightly, 0.1.dev20211009+nightly, 0.1.dev20211010+nightly, 0.1.dev20211011+nightly, 0.1.dev20211012+nightly, 0.1.dev20211013+nightly, 0.1.dev20211014+nightly, 0.1.dev20211015+nightly, 0.1.dev20211016+nightly, 0.1.dev20211017+nightly, 0.1.dev20211018+nig
[2024-07-31, 14:25:04 UTC] {logging_mixin.py:150} WARNING - htly, 0.1.dev20211019+nightly, 0.1.dev20211020+nightly, 0.1.dev20211022+nightly, 0.
```