### PR TITLE
Handle SPMD case inside of `ComputationClient::WaitDeviceOps`

### DIFF
--- a/torch_xla/csrc/runtime/computation_client.h
+++ b/torch_xla/csrc/runtime/computation_client.h
@@ -392,7 +392,7 @@ class ComputationClient {
 
   // Block until pass in devices' async operation are finished. If empty, all
   // the local devices will be waited for.
-  virtual void WaitDeviceOps(absl::Span<const std::string> devices) = 0;
+  virtual void WaitDeviceOps(absl::Span<const std::string> devices = {}) = 0;
 
   // Check whether the XlaCoordinator has been initialized.
   virtual bool CoordinatorInitialized() const = 0;

--- a/torch_xla/csrc/runtime/ifrt_computation_client.h
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.h
@@ -117,7 +117,7 @@ class IfrtComputationClient : public ComputationClient {
 
   std::shared_ptr<std::vector<std::string>> GetReplicationDevices() override;
 
-  void WaitDeviceOps(absl::Span<const std::string> devices) override;
+  void WaitDeviceOps(absl::Span<const std::string> devices = {}) override;
 
   std::map<std::string, Metric> GetMetrics() const override;
 

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -964,8 +964,11 @@ xla::PjRtDevice* PjRtComputationClient::StringToPjRtDevice(
 void PjRtComputationClient::WaitDeviceOps(
     absl::Span<const std::string> devices) {
   TF_VLOG(3) << "Waiting for " << absl::StrJoin(devices, ", ");
-  operation_manager_.WaitForDevices(devices.empty() ? GetLocalDevices()
-                                                    : devices);
+  operation_manager_.WaitForDevices(
+      devices.empty()
+          ? (UseVirtualDevice() ? std::vector<std::string>({spmd_device_str})
+                                : GetLocalDevices())
+          : devices);
 }
 
 std::map<std::string, Metric> PjRtComputationClient::GetMetrics() const {

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -135,7 +135,7 @@ class PjRtComputationClient : public ComputationClient {
 
   std::shared_ptr<std::vector<std::string>> GetReplicationDevices() override;
 
-  void WaitDeviceOps(absl::Span<const std::string> devices) override;
+  void WaitDeviceOps(absl::Span<const std::string> devices = {}) override;
 
   std::map<std::string, Metric> GetMetrics() const override;
 


### PR DESCRIPTION
Also pull `_xla_wait_device_ops` out into utility function that combines both `WaitDeviceOps`s so I can use it in #7793.