### PR TITLE
disable sdpa  amp

### DIFF
--- a/torch_xla/csrc/autocast_mode.cpp
+++ b/torch_xla/csrc/autocast_mode.cpp
@@ -48,7 +48,9 @@ TORCH_LIBRARY_IMPL(aten, AutocastXLA, m) {
   KERNEL_XLA(prelu, lower_precision_fp)
   KERNEL_XLA(relu, lower_precision_fp)
   KERNEL_XLA(max_pool2d, lower_precision_fp)
-  KERNEL_XLA(scaled_dot_product_attention, lower_precision_fp)
+  // Disable `scaled_dot_product_attention` for now since it causes
+  // undefined symbol with official torch whl.
+  // KERNEL_XLA(scaled_dot_product_attention, lower_precision_fp)
 
   // fp32 cast policy
   // Commented out ops are included in the AutoCastCPU Policy,


### PR DESCRIPTION
If we install torch_xla nightly whl along with official torch whl, we would hit the undefined symbol error
```
pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
pip install 'torch_xla[tpu] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-nightly-cp310-cp310-linux_x86_64.whl' -f https://storage.googleapis.com/libtpu-releases/index.html
```
```
>>> import torch_xla
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/disks/lsiyuan/torch-workspace/pytorch/xla/torch_xla/__init__.py", line 20, in <module>
    import _XLAC
ImportError: /mnt/disks/lsiyuan/torch-workspace/pytorch/xla/_XLAC.cpython-310-x86_64-linux-gnu.so: undefined symbol: _ZN2at4_ops28scaled_dot_product_attention4callERKNS_6TensorES4_S4_RKSt8optionalIS2_EdbS5_IdEb
``` 

Disabling the `scaled_dot_product_attention` in amp to avoid the issue, to unblock the functionality test suite.