### PR TITLE
Move `_xla_register_custom_call_target` implementation into `PjRtComputationClient`

### DIFF
--- a/torch_xla/csrc/BUILD
+++ b/torch_xla/csrc/BUILD
@@ -281,10 +281,6 @@ ptxla_cc_library(
         "@xla//xla/service:hlo_verifier",
         "@xla//xla/service:sharding_propagation",
         "@xla//xla/service/spmd:spmd_partitioner",
-        "@xla//xla/service:custom_call_target_registry",
-        "@xla//xla/pjrt/c:pjrt_c_api_hdrs",
-        "@xla//xla/pjrt/c:pjrt_c_api_wrapper_impl",
-        "@xla//xla/pjrt/c:pjrt_c_api_gpu_extension_hdrs",
     ],
 )
 

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -70,12 +70,8 @@
 #include "torch_xla/csrc/xla_sharding_util.h"
 #include "tsl/platform/env.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/pjrt/c/pjrt_c_api_gpu_extension.h"
-#include "xla/pjrt/c/pjrt_c_api_wrapper_impl.h"
 #include "xla/pjrt/distributed/distributed.h"
-#include "xla/pjrt/pjrt_api.h"
 #include "xla/python/profiler/internal/traceme_wrapper.h"
-#include "xla/service/custom_call_target_registry.h"
 #include "xla/service/hlo_parser.h"
 
 namespace torch_xla {
@@ -2490,59 +2486,12 @@ void InitXlaModuleBindings(py::module m) {
           return XlaCustomCall(inputs, payload, output_shapes, output_dtypes,
                                /*is_tpu=*/false);
         });
-  m.def("_xla_register_custom_call_target", [](const std::string& fn_name,
-                                               const py::capsule& function_ptr,
-                                               const std::string& platform) {
-    if (runtime::sys_util::GetEnvBool("XLA_USE_IFRT", false) ||
-        platform != "CUDA") {
-      XLA_ERROR() << "Custom call targets can only be registered for "
-                     "PJRT CUDA runtime."
-                  << std::endl;
-      return;
-    }
-    if (runtime::sys_util::GetEnvBool(runtime::env::kEnvPjrtDynamicPlugins,
-                                      false)) {
-      runtime::PjRtComputationClient* client =
-          dynamic_cast<runtime::PjRtComputationClient*>(
-              runtime::GetComputationClient());
-      if (!client) {
-        return;
-      }
-      const PJRT_Api* pjrt_api = client->GetPjRtCApiIfAvailable();
-      if (!pjrt_api) {
-        return;
-      }
-      // See openxla reference:
-      // https://github.com/openxla/xla/blob/b604c8d87df842002a7a8de79a434026329fbcb2/xla/pjrt/c/pjrt_c_api_gpu_test.cc#L414
-      const PJRT_Extension_Base* next =
-          reinterpret_cast<const PJRT_Extension_Base*>(
-              pjrt_api->extension_start);
-      while (next != nullptr &&
-             next->type !=
-                 PJRT_Extension_Type::PJRT_Extension_Type_Gpu_Custom_Call) {
-        next = next->next;
-      }
-      if (next == nullptr) {
-        return;
-      }
-      PJRT_Gpu_Register_Custom_Call_Args args;
-      args.struct_size = PJRT_Gpu_Register_Custom_Call_Args_STRUCT_SIZE;
-      args.function_name = fn_name.c_str();
-      args.function_name_size = fn_name.size();
-      args.api_version = 0;
-      args.custom_call_function =
-          reinterpret_cast<void*>(function_ptr.get_pointer());
-      PJRT_Error* error =
-          reinterpret_cast<const PJRT_Gpu_Custom_Call*>(next)->custom_call(
-              &args);
-      if (error) {
-        XLA_ERROR() << error->status << std::endl;
-      }
-    } else {
-      XLA_REGISTER_CUSTOM_CALL_TARGET_WITH_SYM(
-          fn_name, function_ptr.get_pointer(), platform);
-    }
-  });
+  m.def("_xla_register_custom_call_target",
+        [](const std::string& fn_name, const py::capsule& function_ptr,
+           const std::string& platform) {
+          runtime::GetComputationClient()->RegisterCustomCall(
+              fn_name, function_ptr.get_pointer(), platform);
+        });
   m.def("_set_xla_custom_op_name_prefix",
         [](const at::Tensor& input, const std::string& op_name_prefix,
            size_t max_call_stack_depth) -> bool {

--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -128,9 +128,12 @@ cc_library(
         "@xla//xla:shape_util",
         "@xla//xla/client:xla_computation",
         "@xla//xla/pjrt:pjrt_client",
+        "@xla//xla/pjrt/c:pjrt_c_api_gpu_extension_hdrs",
         "@xla//xla/pjrt/c:pjrt_c_api_hdrs",
+        "@xla//xla/pjrt/c:pjrt_c_api_wrapper_impl",
         "@xla//xla/pjrt:pjrt_c_api_client",
         "@xla//xla/pjrt/distributed",
+        "@xla//xla/service:custom_call_target_registry",
     ],
 )
 

--- a/torch_xla/csrc/runtime/computation_client.h
+++ b/torch_xla/csrc/runtime/computation_client.h
@@ -405,6 +405,10 @@ class ComputationClient {
   // Return the XlaCoordinator for the runtime.
   virtual XlaCoordinator& GetCoordinator() = 0;
 
+  virtual void RegisterCustomCall(const std::string& fn_name,
+                                  void* function_ptr,
+                                  const std::string& platform) = 0;
+
   // Utility API around the vector based Compile() API to compile a single
   // computation.
   ComputationPtr Compile(xla::XlaComputation computation,

--- a/torch_xla/csrc/runtime/ifrt_computation_client.h
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.h
@@ -150,6 +150,11 @@ class IfrtComputationClient : public ComputationClient {
     XLA_ERROR() << __FUNCTION__ << " not implemented";
   }
 
+  void RegisterCustomCall(const std::string& fn_name, void* function_ptr,
+                          const std::string& platform) override {
+    XLA_ERROR() << __FUNCTION__ << " not implemented";
+  };
+
  private:
   std::shared_ptr<xla::ifrt::PjRtClient> client_;
   std::unique_ptr<XlaCoordinator> coordinator_;

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -999,8 +999,7 @@ void PjRtComputationClient::RegisterCustomCall(const std::string& fn_name,
                                                const std::string& platform) {
   if (platform != "CUDA") {
     XLA_ERROR() << "Custom call targets can only be registered for "
-                   "PJRT CUDA runtime."
-                << std::endl;
+                   "PJRT CUDA runtime.";
     return;
   }
 
@@ -1032,7 +1031,7 @@ void PjRtComputationClient::RegisterCustomCall(const std::string& fn_name,
   PJRT_Error* error =
       reinterpret_cast<const PJRT_Gpu_Custom_Call*>(next)->custom_call(&args);
   if (error) {
-    XLA_ERROR() << error->status << std::endl;
+    XLA_ERROR() << error->status;
   }
 }
 

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -1019,9 +1019,7 @@ void PjRtComputationClient::RegisterCustomCall(const std::string& fn_name,
              PJRT_Extension_Type::PJRT_Extension_Type_Gpu_Custom_Call) {
     next = next->next;
   }
-  if (next == nullptr) {
-    return;
-  }
+  XLA_CHECK(next) << "Custom call extension not found";
   PJRT_Gpu_Register_Custom_Call_Args args;
   args.struct_size = PJRT_Gpu_Register_Custom_Call_Args_STRUCT_SIZE;
   args.function_name = fn_name.c_str();

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -153,7 +153,8 @@ class PjRtComputationClient : public ComputationClient {
   std::vector<std::string> PjRtDevicesToString(
       absl::Span<xla::PjRtDevice* const> devices) const;
 
-  const PJRT_Api* GetPjRtCApiIfAvailable() const;
+  void RegisterCustomCall(const std::string& fn_name, void* function_ptr,
+                          const std::string& platform) override;
 
  private:
   std::unique_ptr<xla::PjRtClient> client_;


### PR DESCRIPTION
This depends closely on implementation details of PjRtComputationClient, so move it behind `ComputationClient` API. IFRT remains unimplemented.