### PR TITLE
Allow user to pass a name to torch_xla.compile

### DIFF
--- a/examples/train_decoder_only_base.py
+++ b/examples/train_decoder_only_base.py
@@ -35,7 +35,8 @@ class TrainDecoderOnlyBase():
     self.optimizer = torch.optim.Adam(self.model.parameters(), lr=0.0001)
     self.loss_fn = nn.CrossEntropyLoss()
     # Compile the step fn
-    self.compiled_step_fn = torch_xla.compile(self.step_fn)
+    self.compiled_step_fn = torch_xla.compile(
+        self.step_fn, full_graph=True, name="decoder_step_fn")
 
   def _train_update(self, step, loss, tracker, epoch):
     print(f'epoch: {epoch}, step: {step}, loss: {loss}, rate: {tracker.rate()}')

--- a/examples/train_resnet_base.py
+++ b/examples/train_resnet_base.py
@@ -33,7 +33,8 @@ class TrainResNetBase():
     self.model = torchvision.models.resnet50().to(self.device)
     self.optimizer = optim.SGD(self.model.parameters(), weight_decay=1e-4)
     self.loss_fn = nn.CrossEntropyLoss()
-    self.compiled_step_fn = torch_xla.compile(self.step_fn)
+    self.compiled_step_fn = torch_xla.compile(
+        self.step_fn, full_graph=True, name="resnet_step_fn")
 
   def _train_update(self, step, loss, tracker, epoch):
     print(f'epoch: {epoch}, step: {step}, loss: {loss}, rate: {tracker.rate()}')

--- a/test/debug_tool/extract_debug_helper.py
+++ b/test/debug_tool/extract_debug_helper.py
@@ -1,4 +1,5 @@
 import os
+import re
 from typing import NamedTuple
 
 
@@ -23,6 +24,7 @@ def extract_compilation_cause(lines):
 
 
 class GraphInfo(NamedTuple):
+  name: str
   hash: str
   num_input: int
   num_output: int
@@ -38,14 +40,24 @@ class PostCompilationInfo(NamedTuple):
 
 def extract_graph_infos(lines):
   infos = []
+  graph_name = ""
   for i in range(len(lines)):
     if 'Graph Info' in lines[i].decode():
-      hash = lines[i + 1].decode().split('Graph Hash: ')[1].strip()
-      num_input = lines[i +
-                        2].decode().split('Number of Graph Inputs:')[1].strip()
-      num_output = lines[i + 3].decode().split(
-          'Number of Graph Outputs:')[1].strip()
-      infos.append(GraphInfo(hash, int(num_input), int(num_output)))
+      i += 1
+      if 'Graph Name' in lines[i].decode():
+        graph_name = re.search(r"\s* Analysis:\s*Graph Name:\s*(.+)",
+                               lines[i].decode()).group(1)
+        i += 1
+      hash = re.search(r"\s* Analysis:\s*Graph Hash:\s*(.+)",
+                       lines[i].decode()).group(1)
+      i += 1
+      num_input = re.search(r"\s* Analysis:\s*Number of Graph Inputs:\s*(.+)",
+                            lines[i].decode()).group(1)
+      i += 1
+      num_output = re.search(r"\s* Analysis:\s*Number of Graph Outputs:\s*(.+)",
+                             lines[i].decode()).group(1)
+      i += 1
+      infos.append(GraphInfo(graph_name, hash, int(num_input), int(num_output)))
 
   return infos
 

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2445,6 +2445,11 @@ void InitXlaModuleBindings(py::module m) {
   });
   m.def("_get_allow_execution",
         []() { return XLAGraphExecutor::Get()->AllowExecution(); });
+  m.def("_set_current_graph_name", [](std::string current_graph_name) {
+    XLAGraphExecutor::Get()->SetCurrentGraphName(current_graph_name);
+  });
+  m.def("_get_current_graph_name",
+        []() { return XLAGraphExecutor::Get()->CurrentGraphName(); });
   m.def("_replace_xla_tensor",
         [](at::Tensor& self, const at::Tensor& source) -> at::Tensor& {
           return XLANativeFunctions::set_(self, source);

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -1306,8 +1306,9 @@ XLAGraphExecutor::CompilationResult XLAGraphExecutor::Compile(
   static const size_t parameter_wrapping_threadshold =
       runtime::sys_util::GetEnvInt("XLA_PARAMETER_WRAPPING_THREADSHOLD", 3200);
   static const bool use_autosharding = ShardingUtil::GetAutoSharding();
-  LoweringContext lowering_ctx("SyncTensorsGraph", coll.device,
-                               po_data->post_order,
+  std::string graph_name =
+      (CurrentGraphName() != "") ? CurrentGraphName() : "SyncTensorsGraph";
+  LoweringContext lowering_ctx(graph_name, coll.device, po_data->post_order,
                                std::move(po_data->emission_map));
   for (auto ir_value : ir_values) {
     xla::XlaOp root = lowering_ctx.GetOutputOp(

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -198,6 +198,12 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
 
   bool AllowExecution() { return allow_execution_; }
 
+  void SetCurrentGraphName(std::string graph_name) {
+    current_graph_name_ = graph_name;
+  }
+
+  std::string CurrentGraphName() { return current_graph_name_; }
+
  private:
   // This is just to group results from compile(). Since our computation is
   // different, we don't reuse the upstream CompilationResult.
@@ -374,6 +380,7 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
   ComputationCache* computation_cache_;
   bool use_eager_mode_ = false;
   bool allow_execution_ = true;
+  std::string current_graph_name_ = "";
 };
 
 }  // namespace torch_xla

--- a/torch_xla/torch_xla.py
+++ b/torch_xla/torch_xla.py
@@ -135,9 +135,12 @@ def compile(f: Optional[Callable] = None,
     saved_current_graph_name = torch_xla._XLAC._get_current_graph_name()
     torch_xla._XLAC._set_use_eager_mode(False)
     if name != None:
-      torch_xla._XLAC._set_current_graph_name(name)
+      torch_xla._XLAC._set_current_graph_name(name + '_clear_pending')
     # Clear pending operations
     _clear_pending_ops_before_compile()
+
+    if name != None:
+      torch_xla._XLAC._set_current_graph_name(name)
 
     # if full_graph sets to true execution can not happen before the sync below
     torch_xla._XLAC._set_allow_execution(not full_graph)

--- a/torch_xla/torch_xla.py
+++ b/torch_xla/torch_xla.py
@@ -83,7 +83,9 @@ def step():
   return compile()
 
 
-def compile(f: Optional[Callable] = None, full_graph=False):
+def compile(f: Optional[Callable] = None,
+            full_graph: Optional[bool] = False,
+            name: Optional[str] = None):
   """
   Optimizes given model/function using torch_xla's LazyTensor tracing mode.
   PyTorch/XLA will trace the given function with given inputs and then generate
@@ -94,9 +96,12 @@ def compile(f: Optional[Callable] = None, full_graph=False):
   Args:
       model (Callable): Module/function to optimize, if not passed this function will
         act as a context manager.
-      full_graph (bool): Whether this compile should generate a single graph. If set to True
+      full_graph (Optional[bool]): Whether this compile should generate a single graph. If set to True
         and multiple graphs will be generated torch_xla will throw an error with debug info
         and exit.
+      name (Optional[name]): Name of the compiled program. The name of the function `f` will be used
+        if not specified. This name will be used in the `PT_XLA_DEBUG` messages as well as HLO/IR dump
+        file.
 
   Example::
 
@@ -114,6 +119,11 @@ def compile(f: Optional[Callable] = None, full_graph=False):
       with torch_xla.compile():
         res = foo2(x)
   """
+  if name == None and f:
+    if hasattr(f, '__name__'):
+      name = f.__name__
+    elif hasattr(f, '__str__'):
+      name = f.__str__()
 
   def _clear_pending_ops_before_compile():
     sync()
@@ -122,7 +132,11 @@ def compile(f: Optional[Callable] = None, full_graph=False):
   def _compile():
     saved_eager_mode_status = torch_xla._XLAC._get_use_eager_mode()
     saved_allow_execution = torch_xla._XLAC._get_allow_execution()
+    saved_current_graph_name = torch_xla._XLAC._get_current_graph_name()
     torch_xla._XLAC._set_use_eager_mode(False)
+    if name != None:
+      torch_xla._XLAC._set_current_graph_name(name)
+    # Clear pending operations
     _clear_pending_ops_before_compile()
 
     # if full_graph sets to true execution can not happen before the sync below
@@ -136,6 +150,7 @@ def compile(f: Optional[Callable] = None, full_graph=False):
       # execute the graph.
       sync()
       torch_xla._XLAC._set_use_eager_mode(saved_eager_mode_status)
+      torch_xla._XLAC._set_current_graph_name(saved_current_graph_name)
 
   return _compile() if not f else _compile()(f)
 


### PR DESCRIPTION
In this pr I allow user to pass a `name` to the `torch_xla.compiled` program. If `name` is not explictly passed we will use `fn`'s original name by default. I am having some issue to support this default name cases in 
```
@torch_xla.compile()
def my_f()
  return None
```
case because in this case `f` in `compile` is actually None. @will-cromar any ideas?

The name will be used in 3 places
1. `PT_XLA_DEBUG` output
2. `XLA_SAVE_TENSORS_FILE ` output
3. `XLA_FLAGS=--xla_dump_to=/tmp/xla_dump` output

For the 3rd case, output file name looks like
```
module_0000.SyncTensorsGraph.62.before_optimizations.txt
module_0002.SyncTensorsGraph.62.after_optimizations_before_buffer_assignment.txt
module_0015.dummy_clear_pending.60.before_optimizations.txt
module_0017.dummy_clear_pending.60.after_optimizations_before_buffer_assignment.txt
module_0027.dummy.44.after_optimizations_before_buffer_assignment.txt
module_0027.dummy.44.before_optimizations.txt
```
where `SyncTensorsGraph` is caused by the regualr `mark_step`.  `dummy_clear_pending` and `dummy` are caused by 
```
def dummy()
....

compiled = torch_xla.compile(dummy)
dummy()
```