### PR TITLE
torch::lazy::MakeNode -> torch_xla::MakeNode

### DIFF
--- a/CODEGEN_MIGRATION_GUIDE.md
+++ b/CODEGEN_MIGRATION_GUIDE.md
@@ -88,7 +88,7 @@ at::Tensor XLANativeFunctions::abs(const at::Tensor & self) {
 
   torch::lazy::NodePtr node = torch::lazy::ReuseNode<Abs>(lazy_self->GetIrValue());
   if (!node) {
-    node = torch::lazy::MakeNode<Abs>(lazy_self->GetIrValue());
+    node = torch_xla::MakeNode<Abs>(lazy_self->GetIrValue());
     CacheNode(node);
   }
 
@@ -107,7 +107,7 @@ Describing the generated code line by line:
 ```
   torch::lazy::NodePtr node = torch::lazy::ReuseNode<Abs>(lazy_self->GetIrValue());
   if (!node) {
-    node = torch::lazy::MakeNode<Abs>(lazy_self->GetIrValue());
+    node = torch_xla::MakeNode<Abs>(lazy_self->GetIrValue());
     CacheNode(node);
   }
 ```
@@ -191,7 +191,7 @@ Sometimes other IRNode uses the 'IRNode' you migrated. In this case you need to 
 to
 ```
   torch::lazy::NodePtr exp =
-      Pow(torch::lazy::MakeNode<Abs>(input, std::vector<torch::lazy::Shape>()),
+      Pow(torch_xla::MakeNode<Abs>(input, std::vector<torch::lazy::Shape>()),
           norm_exp);
 ```
 

--- a/codegen/lazy_tensor_generator.py
+++ b/codegen/lazy_tensor_generator.py
@@ -86,7 +86,7 @@ class GenXlaLazyNativeFuncDefinition(GenLazyNativeFuncDefinition):
     return f"""torch::lazy::NodePtr node = torch::lazy::ReuseNode<{schema.node_name}>({node_ctor_input_str});
       if (!node) {{
           {self.shape_inference(func, schema)}
-          node = torch::lazy::MakeNode<{schema.node_name}>({node_ctor_input_str});
+          node = torch_xla::MakeNode<{schema.node_name}>({node_ctor_input_str});
           CacheNode(node);
       }}
       """

--- a/test/cpp/cpp_test_util.cpp
+++ b/test/cpp/cpp_test_util.cpp
@@ -262,7 +262,7 @@ std::string GetTensorHloGraph(at::Tensor tensor) {
 torch::lazy::Value GetTensorIrValue(const at::Tensor& tensor,
                                     const torch::lazy::BackendDevice& device) {
   torch::lazy::BackendDataPtr data = TensorToXlaData(tensor, device);
-  return torch::lazy::MakeNode<DeviceData>(std::move(data));
+  return torch_xla::MakeNode<DeviceData>(std::move(data));
 }
 
 std::vector<torch_xla::runtime::ComputationClient::DataPtr> Execute(
@@ -415,7 +415,7 @@ torch::lazy::NodePtr CreateNonZeroNode2d(int64_t num_non_zero_element,
       torch::lazy::Value(ScalarOp(1.0, xla::F32), 0);
   std::vector<int64_t> target_size = {num_row, num_col};
   torch::lazy::NodePtr expand_node =
-      torch::lazy::MakeNode<Expand>(scalar_value, target_size);
+      torch_xla::MakeNode<Expand>(scalar_value, target_size);
   torch::lazy::Value expand_value = torch::lazy::Value(expand_node, 0);
   int64_t count = 0;
   int64_t i = 0;
@@ -424,7 +424,7 @@ torch::lazy::NodePtr CreateNonZeroNode2d(int64_t num_non_zero_element,
   while (count++ < num_non_zero_element) {
     std::vector<int64_t> base_indices = {i, j++};
     // Use Slice to do element update
-    torch::lazy::NodePtr slice_node = torch::lazy::MakeNode<UpdateSlice>(
+    torch::lazy::NodePtr slice_node = torch_xla::MakeNode<UpdateSlice>(
         slice_value, scalar_value_1, base_indices);
     slice_value = torch::lazy::Value(slice_node, 0);
     if (j == num_col) {
@@ -432,8 +432,7 @@ torch::lazy::NodePtr CreateNonZeroNode2d(int64_t num_non_zero_element,
       i++;
     }
   }
-  torch::lazy::NodePtr nonzero_node =
-      torch::lazy::MakeNode<NonZero>(slice_value);
+  torch::lazy::NodePtr nonzero_node = torch_xla::MakeNode<NonZero>(slice_value);
   return nonzero_node;
 }
 

--- a/test/cpp/test_ir.cpp
+++ b/test/cpp/test_ir.cpp
@@ -58,8 +58,8 @@ TEST_F(IrTest, TestSelectUnselect) {
 
     torch::lazy::Value v_a = GetTensorIrValue(a, device);
     torch::lazy::Value v_s =
-        torch::lazy::MakeNode<Select>(v_a, /*dim=*/1, /*start=*/3,
-                                      /*end=*/14, /*stride=*/3);
+        torch_xla::MakeNode<Select>(v_a, /*dim=*/1, /*start=*/3,
+                                    /*end=*/14, /*stride=*/3);
 
     auto results = ExecuteAndFetch({v_s}, device);
     at::Tensor b =
@@ -70,8 +70,8 @@ TEST_F(IrTest, TestSelectUnselect) {
     at::Tensor z = at::zeros_like(b);
     torch::lazy::Value v_z = GetTensorIrValue(z, device);
     torch::lazy::Value v_u =
-        torch::lazy::MakeNode<Unselect>(v_a, v_z, /*dim=*/1, /*start=*/3,
-                                        /*end=*/14, /*stride=*/3);
+        torch_xla::MakeNode<Unselect>(v_a, v_z, /*dim=*/1, /*start=*/3,
+                                      /*end=*/14, /*stride=*/3);
     results = ExecuteAndFetch({v_u}, device);
     // Fetch back the zeros.
     at::Tensor d = results.front().cpu().slice(/*dim=*/1, /*start=*/3,
@@ -107,9 +107,9 @@ TEST_F(IrTest, TestSizeNode) {
   torch::lazy::NodePtr scalar_node =
       ScalarOp(1.0, xla::ShapeUtil::MakeShape(xla::F32, {3, 4}));
   torch::lazy::NodePtr size_node_0 =
-      torch::lazy::MakeNode<SizeNode>(scalar_node, 0);
+      torch_xla::MakeNode<SizeNode>(scalar_node, 0);
   torch::lazy::NodePtr size_node_1 =
-      torch::lazy::MakeNode<SizeNode>(scalar_node, 1);
+      torch_xla::MakeNode<SizeNode>(scalar_node, 1);
   std::shared_ptr<torch::lazy::DimensionNode> dim_node_0 =
       std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node_0);
   std::shared_ptr<torch::lazy::DimensionNode> dim_node_1 =
@@ -141,10 +141,10 @@ TEST_F(IrTest, TestSizeNodeDynamic) {
       CreateNonZeroNode2d(num_non_zero_element, num_row, num_col);
 
   torch::lazy::NodePtr size_node_nonzero_0 =
-      torch::lazy::MakeNode<SizeNode>(nonzero_node, 0);
+      torch_xla::MakeNode<SizeNode>(nonzero_node, 0);
   EXPECT_EQ(size_node_nonzero_0->ToString(), "aten::size");
   torch::lazy::NodePtr size_node_nonzero_1 =
-      torch::lazy::MakeNode<SizeNode>(nonzero_node, 1);
+      torch_xla::MakeNode<SizeNode>(nonzero_node, 1);
   std::shared_ptr<torch::lazy::DimensionNode> dim_node_0 =
       std::dynamic_pointer_cast<torch::lazy::DimensionNode>(
           size_node_nonzero_0);
@@ -167,11 +167,11 @@ TEST_F(IrTest, TestSizeAddNode) {
   torch::lazy::NodePtr scalar_node =
       ScalarOp(1.0, xla::ShapeUtil::MakeShape(xla::F32, {3, 4}));
   torch::lazy::NodePtr size_node_0 =
-      torch::lazy::MakeNode<SizeNode>(scalar_node, 0);
+      torch_xla::MakeNode<SizeNode>(scalar_node, 0);
   torch::lazy::NodePtr size_node_1 =
-      torch::lazy::MakeNode<SizeNode>(scalar_node, 1);
+      torch_xla::MakeNode<SizeNode>(scalar_node, 1);
   torch::lazy::NodePtr size_node_add =
-      torch::lazy::MakeNode<SizeAdd>(size_node_0, size_node_1);
+      torch_xla::MakeNode<SizeAdd>(size_node_0, size_node_1);
   EXPECT_EQ(size_node_add->ToString(), "aten::size_add");
   std::shared_ptr<torch::lazy::DimensionNode> dim_node_add =
       std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node_add);
@@ -196,14 +196,14 @@ TEST_F(IrTest, TestSizeAddNodeDynamicOnSameTensor) {
 
   // static value = 100, dynamic value = 1
   torch::lazy::NodePtr size_node_nonzero_0 =
-      torch::lazy::MakeNode<SizeNode>(node_with_dynamism, 0);
+      torch_xla::MakeNode<SizeNode>(node_with_dynamism, 0);
   // static value = 2, dynamic value = 2
   torch::lazy::NodePtr size_node_nonzero_1 =
-      torch::lazy::MakeNode<SizeNode>(node_with_dynamism, 1);
+      torch_xla::MakeNode<SizeNode>(node_with_dynamism, 1);
 
-  torch::lazy::NodePtr node_add = torch::lazy::MakeNode<SizeAdd>(
-      torch::lazy::Value(size_node_nonzero_0, 0),
-      torch::lazy::Value(size_node_nonzero_1, 0));
+  torch::lazy::NodePtr node_add =
+      torch_xla::MakeNode<SizeAdd>(torch::lazy::Value(size_node_nonzero_0, 0),
+                                   torch::lazy::Value(size_node_nonzero_1, 0));
 
   std::shared_ptr<torch::lazy::DimensionNode> dim_node_add =
       std::dynamic_pointer_cast<torch::lazy::DimensionNode>(node_add);
@@ -226,14 +226,14 @@ TEST_F(IrTest, TestSizeAddNodeDynamicOnDifferentTensor) {
 
   // static value = 100, dynamic value = 1
   torch::lazy::NodePtr size_node_nonzero_0 =
-      torch::lazy::MakeNode<SizeNode>(node_with_dynamism_0, 0);
+      torch_xla::MakeNode<SizeNode>(node_with_dynamism_0, 0);
   // static value = 100, dynamic value = 1
   torch::lazy::NodePtr size_node_nonzero_1 =
-      torch::lazy::MakeNode<SizeNode>(node_with_dynamism_1, 0);
+      torch_xla::MakeNode<SizeNode>(node_with_dynamism_1, 0);
 
-  torch::lazy::NodePtr node_add = torch::lazy::MakeNode<SizeAdd>(
-      torch::lazy::Value(size_node_nonzero_0, 0),
-      torch::lazy::Value(size_node_nonzero_1, 0));
+  torch::lazy::NodePtr node_add =
+      torch_xla::MakeNode<SizeAdd>(torch::lazy::Value(size_node_nonzero_0, 0),
+                                   torch::lazy::Value(size_node_nonzero_1, 0));
 
   std::shared_ptr<torch::lazy::DimensionNode> dim_node_add =
       std::dynamic_pointer_cast<torch::lazy::DimensionNode>(node_add);
@@ -245,11 +245,11 @@ TEST_F(IrTest, TestSizeMulNode) {
   torch::lazy::NodePtr scalar_node =
       ScalarOp(1.0, xla::ShapeUtil::MakeShape(xla::F32, {3, 4}));
   torch::lazy::NodePtr size_node_0 =
-      torch::lazy::MakeNode<SizeNode>(scalar_node, 0);
+      torch_xla::MakeNode<SizeNode>(scalar_node, 0);
   torch::lazy::NodePtr size_node_1 =
-      torch::lazy::MakeNode<SizeNode>(scalar_node, 1);
+      torch_xla::MakeNode<SizeNode>(scalar_node, 1);
   torch::lazy::NodePtr size_node_mul =
-      torch::lazy::MakeNode<SizeMul>(size_node_0, size_node_1);
+      torch_xla::MakeNode<SizeMul>(size_node_0, size_node_1);
   EXPECT_EQ(size_node_mul->ToString(), "aten::size_mul");
   std::shared_ptr<torch::lazy::DimensionNode> dim_node_mul =
       std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node_mul);
@@ -274,14 +274,14 @@ TEST_F(IrTest, TestSizeMulNodeDynamic) {
 
   // static value = 100, dynamic value = 1
   torch::lazy::NodePtr size_node_nonzero_0 =
-      torch::lazy::MakeNode<SizeNode>(node_with_dynamism, 0);
+      torch_xla::MakeNode<SizeNode>(node_with_dynamism, 0);
   // static value = 2, dynamic value = 2
   torch::lazy::NodePtr size_node_nonzero_1 =
-      torch::lazy::MakeNode<SizeNode>(node_with_dynamism, 1);
+      torch_xla::MakeNode<SizeNode>(node_with_dynamism, 1);
 
-  torch::lazy::NodePtr node_mul = torch::lazy::MakeNode<SizeMul>(
-      torch::lazy::Value(size_node_nonzero_0, 0),
-      torch::lazy::Value(size_node_nonzero_1, 0));
+  torch::lazy::NodePtr node_mul =
+      torch_xla::MakeNode<SizeMul>(torch::lazy::Value(size_node_nonzero_0, 0),
+                                   torch::lazy::Value(size_node_nonzero_1, 0));
 
   std::shared_ptr<torch::lazy::DimensionNode> dim_node_mul =
       std::dynamic_pointer_cast<torch::lazy::DimensionNode>(node_mul);
@@ -293,11 +293,11 @@ TEST_F(IrTest, TestSizeDivNode) {
   torch::lazy::NodePtr scalar_node =
       ScalarOp(1.0, xla::ShapeUtil::MakeShape(xla::F32, {12, 5}));
   torch::lazy::NodePtr size_node_0 =
-      torch::lazy::MakeNode<SizeNode>(scalar_node, 0);
+      torch_xla::MakeNode<SizeNode>(scalar_node, 0);
   torch::lazy::NodePtr size_node_1 =
-      torch::lazy::MakeNode<SizeNode>(scalar_node, 1);
+      torch_xla::MakeNode<SizeNode>(scalar_node, 1);
   torch::lazy::NodePtr size_node_div =
-      torch::lazy::MakeNode<SizeDiv>(size_node_0, size_node_1);
+      torch_xla::MakeNode<SizeDiv>(size_node_0, size_node_1);
   EXPECT_EQ(size_node_div->ToString(), "aten::size_div");
   std::shared_ptr<torch::lazy::DimensionNode> dim_node_div =
       std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node_div);
@@ -322,14 +322,14 @@ TEST_F(IrTest, TestSizeDivNodeDynamic) {
 
   // static value = 100, dynamic value = 1
   torch::lazy::NodePtr size_node_nonzero_0 =
-      torch::lazy::MakeNode<SizeNode>(node_with_dynamism, 0);
+      torch_xla::MakeNode<SizeNode>(node_with_dynamism, 0);
   // static value = 2, dynamic value = 2
   torch::lazy::NodePtr size_node_nonzero_1 =
-      torch::lazy::MakeNode<SizeNode>(node_with_dynamism, 1);
+      torch_xla::MakeNode<SizeNode>(node_with_dynamism, 1);
 
-  torch::lazy::NodePtr node_div = torch::lazy::MakeNode<SizeDiv>(
-      torch::lazy::Value(size_node_nonzero_0, 0),
-      torch::lazy::Value(size_node_nonzero_1, 0));
+  torch::lazy::NodePtr node_div =
+      torch_xla::MakeNode<SizeDiv>(torch::lazy::Value(size_node_nonzero_0, 0),
+                                   torch::lazy::Value(size_node_nonzero_1, 0));
 
   std::shared_ptr<torch::lazy::DimensionNode> dim_node_div =
       std::dynamic_pointer_cast<torch::lazy::DimensionNode>(node_div);
@@ -342,19 +342,19 @@ TEST_F(IrTest, TestSizeDivNodeDynamicByZero) {
       torch::lazy::Value(ScalarOp(0.0, xla::F32), 0);
   std::vector<int64_t> target_size = {2, 2};
   torch::lazy::Value node = torch::lazy::Value(
-      torch::lazy::MakeNode<Expand>(scalar_value, target_size));
-  torch::lazy::NodePtr nonzero_node = torch::lazy::MakeNode<NonZero>(node);
+      torch_xla::MakeNode<Expand>(scalar_value, target_size));
+  torch::lazy::NodePtr nonzero_node = torch_xla::MakeNode<NonZero>(node);
 
   // static value = 4, dynamic value = 0
   torch::lazy::NodePtr size_node_nonzero_0 =
-      torch::lazy::MakeNode<SizeNode>(nonzero_node, 0);
+      torch_xla::MakeNode<SizeNode>(nonzero_node, 0);
   // static value = 2, dynamic value = 2
   torch::lazy::NodePtr size_node_nonzero_1 =
-      torch::lazy::MakeNode<SizeNode>(nonzero_node, 1);
+      torch_xla::MakeNode<SizeNode>(nonzero_node, 1);
 
-  torch::lazy::NodePtr node_div = torch::lazy::MakeNode<SizeDiv>(
-      torch::lazy::Value(size_node_nonzero_1, 0),
-      torch::lazy::Value(size_node_nonzero_0, 0));
+  torch::lazy::NodePtr node_div =
+      torch_xla::MakeNode<SizeDiv>(torch::lazy::Value(size_node_nonzero_1, 0),
+                                   torch::lazy::Value(size_node_nonzero_0, 0));
   std::shared_ptr<torch::lazy::DimensionNode> dim_node_div =
       std::dynamic_pointer_cast<torch::lazy::DimensionNode>(node_div);
 

--- a/test/cpp/test_symint.cpp
+++ b/test/cpp/test_symint.cpp
@@ -65,10 +65,10 @@ TEST(SymintTest, TestDynamicSymint) {
       torch::lazy::Value(ScalarOp(1.0, xla::F32), 0);
   std::vector<int64_t> target_size = {2, 3, 5};
   torch::lazy::NodePtr expand_node =
-      torch::lazy::MakeNode<Expand>(scalar_value, target_size);
+      torch_xla::MakeNode<Expand>(scalar_value, target_size);
   torch::lazy::Value expand_value = torch::lazy::Value(expand_node, 0);
   torch::lazy::NodePtr size_node =
-      torch::lazy::MakeNode<SizeNode>(expand_value, /*dim=*/0);
+      torch_xla::MakeNode<SizeNode>(expand_value, /*dim=*/0);
   // This is not a dynamic size from xla perspective but it is a symint that
   // wraps around a SizeNode instead of a scalar.
   c10::SymInt dynamic_symint = make_symint(size_node);
@@ -88,13 +88,13 @@ TEST(SymintTest, TestDynamicSymint) {
 }
 
 TEST(SymintTest, TestSizeConstant) {
-  torch::lazy::NodePtr sc10 = torch::lazy::MakeNode<SizeConstant>(10);
+  torch::lazy::NodePtr sc10 = torch_xla::MakeNode<SizeConstant>(10);
   EXPECT_EQ(torch_xla::DimCast(sc10)->getStaticValue(), 10);
   EXPECT_EQ(torch_xla::DimCast(sc10)->getDynamicValue(), 10);
-  torch::lazy::NodePtr sc15 = torch::lazy::MakeNode<SizeConstant>(15);
+  torch::lazy::NodePtr sc15 = torch_xla::MakeNode<SizeConstant>(15);
   EXPECT_EQ(torch_xla::DimCast(sc15)->getStaticValue(), 15);
   EXPECT_EQ(torch_xla::DimCast(sc15)->getDynamicValue(), 15);
-  torch::lazy::NodePtr add25 = torch::lazy::MakeNode<SizeAdd>(sc10, sc15);
+  torch::lazy::NodePtr add25 = torch_xla::MakeNode<SizeAdd>(sc10, sc15);
   EXPECT_EQ(torch_xla::DimCast(add25)->getStaticValue(), 25);
   EXPECT_EQ(torch_xla::DimCast(add25)->getDynamicValue(),
             torch_xla::DimCast(add25)->getStaticValue());
@@ -104,13 +104,13 @@ TEST(SymintTest, TestSizeConstant) {
 
   std::vector<int64_t> target_size = {9};
   torch::lazy::NodePtr expand_node =
-      torch::lazy::MakeNode<Expand>(scalar_value, target_size);
+      torch_xla::MakeNode<Expand>(scalar_value, target_size);
   torch::lazy::Value expand_value = torch::lazy::Value(expand_node, 0);
 
   torch::lazy::NodePtr size_node =
-      torch::lazy::MakeNode<SizeNode>(expand_value, /*dim=*/0);
+      torch_xla::MakeNode<SizeNode>(expand_value, /*dim=*/0);
 
-  torch::lazy::NodePtr add19 = torch::lazy::MakeNode<SizeAdd>(sc10, size_node);
+  torch::lazy::NodePtr add19 = torch_xla::MakeNode<SizeAdd>(sc10, size_node);
   EXPECT_EQ(torch_xla::DimCast(add19)->getStaticValue(), 19);
   EXPECT_EQ(torch_xla::DimCast(add19)->getDynamicValue(),
             torch_xla::DimCast(add19)->getStaticValue());
@@ -121,13 +121,13 @@ TEST(SymintTest, TestDynamicSymints) {
       torch::lazy::Value(ScalarOp(1.0, xla::F32), 0);
   std::vector<int64_t> target_size = {2, 3, 5};
   torch::lazy::NodePtr expand_node =
-      torch::lazy::MakeNode<Expand>(scalar_value, target_size);
+      torch_xla::MakeNode<Expand>(scalar_value, target_size);
   torch::lazy::Value expand_value = torch::lazy::Value(expand_node, 0);
   std::vector<c10::SymInt> dynamic_symints;
   std::vector<torch::lazy::NodePtr> size_nodes;
   for (int i = 0; i < 3; i++) {
     torch::lazy::NodePtr size_node =
-        torch::lazy::MakeNode<SizeNode>(expand_value, /*dim=*/i);
+        torch_xla::MakeNode<SizeNode>(expand_value, /*dim=*/i);
     size_nodes.push_back(size_node);
     // This is not a dynamic size from xla perspective but it is a symint that
     // wraps around a SizeNode instead of a scalar.
@@ -157,15 +157,15 @@ TEST(SymintTest, TestDynamicSymintArithmetic) {
 
   std::vector<int64_t> target_size = {10, 20, 30};
   torch::lazy::NodePtr expand_node =
-      torch::lazy::MakeNode<Expand>(scalar_value, target_size);
+      torch_xla::MakeNode<Expand>(scalar_value, target_size);
   torch::lazy::Value expand_value = torch::lazy::Value(expand_node, 0);
 
-  torch::lazy::NodePtr abs_node = torch::lazy::MakeNode<Abs>(expand_value);
-  torch::lazy::NodePtr relu_node = torch::lazy::MakeNode<Relu>(expand_value);
+  torch::lazy::NodePtr abs_node = torch_xla::MakeNode<Abs>(expand_value);
+  torch::lazy::NodePtr relu_node = torch_xla::MakeNode<Relu>(expand_value);
 
-  torch::lazy::NodePtr size_abs_node = torch::lazy::MakeNode<SizeNode>(
-      torch::lazy::Value{abs_node, 0}, /*dim=*/0);
-  torch::lazy::NodePtr size_relu_node = torch::lazy::MakeNode<SizeNode>(
+  torch::lazy::NodePtr size_abs_node =
+      torch_xla::MakeNode<SizeNode>(torch::lazy::Value{abs_node, 0}, /*dim=*/0);
+  torch::lazy::NodePtr size_relu_node = torch_xla::MakeNode<SizeNode>(
       torch::lazy::Value{relu_node, 0}, /*dim=*/0);
 
   c10::SymInt a = make_symint(size_abs_node);
@@ -207,11 +207,10 @@ TEST(SymintTest, TestDynamicSymintArithmetic) {
 TEST(SymintTest, TestXLASymNodeImplStr) {
   torch::lazy::Value scalar = torch::lazy::Value(ScalarOp(1.0, xla::F32), 0);
   std::vector<int64_t> shape = {2, 3, 4};
-  torch::lazy::NodePtr expand_node =
-      torch::lazy::MakeNode<Expand>(scalar, shape);
+  torch::lazy::NodePtr expand_node = torch_xla::MakeNode<Expand>(scalar, shape);
   torch::lazy::Value expand_value = torch::lazy::Value(expand_node, 0);
   torch::lazy::NodePtr size_node =
-      torch::lazy::MakeNode<SizeNode>(expand_value, 0);
+      torch_xla::MakeNode<SizeNode>(expand_value, 0);
   c10::SymNode symint_node =
       c10::make_intrusive<XLASymNodeImpl>(size_node, PyType::INT);
   ASSERT_EQ(symint_node.get()->str(), "<=2");

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -515,7 +515,7 @@ at::Tensor XLANativeFunctions::_adaptive_avg_pool3d(
   }
   auto common_device = torch_xla::bridge::GetXlaDevice(self);
   XLA_CHECK(common_device);
-  torch::lazy::NodePtr node = torch::lazy::MakeNode<AdaptiveAvgPool3d>(
+  torch::lazy::NodePtr node = torch_xla::MakeNode<AdaptiveAvgPool3d>(
       bridge::GetXlaTensor(self)->GetIrValue(),
       std::vector<int64_t>(output_size.begin(), output_size.end()));
   return torch_xla::bridge::AtenFromXlaTensor(
@@ -537,7 +537,7 @@ at::Tensor XLANativeFunctions::_adaptive_avg_pool3d_backward(
   }
   auto common_device = torch_xla::bridge::GetXlaDevice(grad_output, self);
   XLA_CHECK(common_device);
-  torch::lazy::NodePtr node = torch::lazy::MakeNode<AdaptiveAvgPool3dBackward>(
+  torch::lazy::NodePtr node = torch_xla::MakeNode<AdaptiveAvgPool3dBackward>(
       bridge::GetXlaTensor(grad_output)->GetIrValue(),
       bridge::GetXlaTensor(self)->GetIrValue());
 
@@ -1005,7 +1005,7 @@ at::Tensor XLANativeFunctions::as_strided_scatter(
   }
   auto mutated_view_ = bridge::GetXlaTensor(mutated_view);
   return bridge::AtenFromXlaTensor(
-      base_->CreateFrom(torch::lazy::MakeNode<AsStridedViewUpdate>(
+      base_->CreateFrom(torch_xla::MakeNode<AsStridedViewUpdate>(
           base_->GetIrValue(), mutated_view_->GetIrValue(),
           torch::lazy::ToVector<int64_t>(base_->shape().get().dimensions()),
           xstride, storage_offset.value_or(0))));
@@ -1017,8 +1017,8 @@ at::Tensor XLANativeFunctions::atan2(const at::Tensor& self,
   auto common_device = torch_xla::bridge::GetXlaDevice(self, other);
   XLA_CHECK(common_device);
   torch::lazy::NodePtr node =
-      torch::lazy::MakeNode<Atan2>(bridge::GetXlaTensor(self)->GetIrValue(),
-                                   bridge::GetXlaTensor(other)->GetIrValue());
+      torch_xla::MakeNode<Atan2>(bridge::GetXlaTensor(self)->GetIrValue(),
+                                 bridge::GetXlaTensor(other)->GetIrValue());
 
   return torch_xla::bridge::AtenFromXlaTensor(
       torch_xla::XLATensor::Create(std::move(node), *common_device));
@@ -1364,7 +1364,7 @@ at::Tensor XLANativeFunctions::diagonal_scatter(const at::Tensor& base,
   int64_t canonical_dim2 =
       torch::lazy::GetCanonicalDimensionIndex(dim2, base_rank);
   return bridge::AtenFromXlaTensor(
-      base_->CreateFrom(torch::lazy::MakeNode<DiagonalViewUpdate>(
+      base_->CreateFrom(torch_xla::MakeNode<DiagonalViewUpdate>(
           base_->GetIrValue(), mutated_view_->GetIrValue(), offset,
           canonical_dim1, canonical_dim2)));
 }
@@ -1881,7 +1881,7 @@ at::Tensor XLANativeFunctions::leaky_relu_backward(
   auto node_negative_slope =
       torch::lazy::LazyGraphExecutor::Get()->GetIrValueForScalarFromCodegen(
           negative_slope, *common_device);
-  torch::lazy::NodePtr node = torch::lazy::MakeNode<LeakyReluBackward>(
+  torch::lazy::NodePtr node = torch_xla::MakeNode<LeakyReluBackward>(
       bridge::GetXlaTensor(grad_output)->GetIrValue(),
       bridge::GetXlaTensor(self)->GetIrValue(), node_negative_slope,
       self_is_result);
@@ -1942,7 +1942,7 @@ std::tuple<at::Tensor, at::Tensor> XLANativeFunctions::linalg_inv_ex(
   auto common_device = torch_xla::bridge::GetXlaDevice(self);
   TORCH_INTERNAL_ASSERT(common_device);
   torch::lazy::NodePtr node =
-      torch::lazy::MakeNode<Inverse>(bridge::GetXlaTensor(self)->GetIrValue());
+      torch_xla::MakeNode<Inverse>(bridge::GetXlaTensor(self)->GetIrValue());
   auto result = torch_xla::XLATensor::Create(std::move(node), *common_device);
   auto info = tensor_methods::full_like(result, 0, result->GetDevice(),
                                         at::ScalarType::Int);
@@ -3192,7 +3192,7 @@ at::Tensor XLANativeFunctions::select_scatter(const at::Tensor& base,
   xla::Shape narrow_shape = base_tensor_shape;
   narrow_shape.set_dimensions(dim, 1);
   torch::lazy::NodePtr mutated_view_tensor_reshaped_node =
-      torch::lazy::MakeNode<ViewOp>(
+      torch_xla::MakeNode<ViewOp>(
           mutated_view_tensor->GetIrValue(),
           torch::lazy::ToVector<int64_t>(narrow_shape.dimensions()));
 
@@ -3201,7 +3201,7 @@ at::Tensor XLANativeFunctions::select_scatter(const at::Tensor& base,
       runtime::util::ToVector<int64_t>(base_tensor_shape.get().dimensions()),
       dim, index);
   return bridge::AtenFromXlaTensor(
-      base_tensor->CreateFrom(torch::lazy::MakeNode<UpdateSlice>(
+      base_tensor->CreateFrom(torch_xla::MakeNode<UpdateSlice>(
           base_tensor->GetIrValue(), mutated_view_tensor_reshaped_node,
           indices)));
 }
@@ -3266,7 +3266,7 @@ at::Tensor XLANativeFunctions::slice_scatter(
   step = std::min(step, end_val - start_val);
 
   return bridge::AtenFromXlaTensor(
-      base_->CreateFrom(torch::lazy::MakeNode<Unselect>(
+      base_->CreateFrom(torch_xla::MakeNode<Unselect>(
           base_->GetIrValue(), mutated_view_->GetIrValue(), dim, start_val,
           end_val, step)));
 }

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2063,7 +2063,7 @@ void InitXlaModuleBindings(py::module m) {
     auto shard_shape = xla::ShapeUtil::MakeShape(
         MakeXlaPrimitiveType(xtensor->dtype(), &(xtensor->GetDevice())),
         ShardingUtil::GetShardShape(sharding_spec));
-    auto output = xtensor->CreateFrom(torch::lazy::MakeNode<CustomSharding>(
+    auto output = xtensor->CreateFrom(torch_xla::MakeNode<CustomSharding>(
         xtensor->GetIrValue(), shard_shape,
         CustomSharding::Type::kSPMDFullToShardShape));
     output->SetShardingSpec(XLATensor::ShardingSpec(
@@ -2086,7 +2086,7 @@ void InitXlaModuleBindings(py::module m) {
                 reinterpret_cast<THPDtype*>(output_dtype.ptr())->scalar_type,
                 &(xtensor->GetDevice())),
             output_shape);
-        auto output = xtensor->CreateFrom(torch::lazy::MakeNode<CustomSharding>(
+        auto output = xtensor->CreateFrom(torch_xla::MakeNode<CustomSharding>(
             xtensor->GetIrValue(), full_shape,
             CustomSharding::Type::kSPMDShardToFullShape));
         output->SetShardingSpec(XLATensor::ShardingSpec(sharding, full_shape));

--- a/torch_xla/csrc/ir.h
+++ b/torch_xla/csrc/ir.h
@@ -35,6 +35,12 @@ template <typename T>
 using OutputMap =
     std::unordered_map<torch::lazy::Output, T, torch::lazy::Output::Hasher>;
 
+template <typename T, typename... Args>
+torch::lazy::NodePtr MakeNode(Args&&... args) {
+  torch::lazy::NodePtr res = std::make_shared<T>(std::forward<Args>(args)...);
+  return res;
+}
+
 // A node in the graph. Nodes for operations which requires extra data to be
 // stored for lowering, should inherit from this class and add operation
 // specific member there. For example, a constant might create a new

--- a/torch_xla/csrc/ir_builder.h
+++ b/torch_xla/csrc/ir_builder.h
@@ -22,25 +22,25 @@ namespace torch_xla {
 struct XLAIrBuilder : torch::lazy::IrBuilder {
   torch::lazy::NodePtr MakeDeviceData(
       const std::shared_ptr<torch::lazy::BackendData>& data) const override {
-    return torch::lazy::MakeNode<DeviceData>(data);
+    return torch_xla::MakeNode<DeviceData>(data);
   }
 
   torch::lazy::NodePtr MakeScalar(const at::Scalar& value,
                                   const at::ScalarType& type) const override {
-    return torch::lazy::MakeNode<Scalar>(
+    return torch_xla::MakeNode<Scalar>(
         value, MakeXlaPrimitiveType(type, bridge::GetDefaultDevice()));
   }
   torch::lazy::NodePtr MakeExpand(const torch::lazy::Value& input0,
                                   const std::vector<int64_t>& size,
                                   const bool& is_scalar_expand) const override {
     // TODO(JackCaoG): handle is_scalar_expand
-    return torch::lazy::MakeNode<Expand>(input0, size);
+    return torch_xla::MakeNode<Expand>(input0, size);
   }
   torch::lazy::NodePtr MakeCast(const torch::lazy::Value& input0,
                                 const at::ScalarType& dtype,
                                 const std::optional<at::ScalarType>& stype =
                                     std::nullopt) const override {
-    return torch::lazy::MakeNode<Cast>(input0, dtype, stype);
+    return torch_xla::MakeNode<Cast>(input0, dtype, stype);
   }
   torch::lazy::NodePtr MakeTensorList(
       const torch::lazy::OpList& inputs) const override {
@@ -55,26 +55,26 @@ struct XLAIrBuilder : torch::lazy::IrBuilder {
       const torch::lazy::hash_t& hash_seed =
           static_cast<uint32_t>(0x5a2d296e9)) const override {
     // TODO(JackCaoG): ltc generic op does not take lowering function
-    // return torch::lazy::MakeNode<Generic>(
+    // return torch_xla::MakeNode<Generic>(
     //     op, operands, MakeXlaShapeFromLazyShape(shape,
     //     *bridge::GetDefaultDevice()), num_outputs, hash_seed);
   }
 
   torch::lazy::NodePtr MakeSizeNode(const torch::lazy::Value& input,
                                     size_t dim) const override {
-    return torch::lazy::MakeNode<SizeNode>(input, dim);
+    return torch_xla::MakeNode<SizeNode>(input, dim);
   }
   torch::lazy::NodePtr MakeSizeAdd(const torch::lazy::Value& a,
                                    const torch::lazy::Value& b) const override {
-    return torch::lazy::MakeNode<SizeAdd>(a, b);
+    return torch_xla::MakeNode<SizeAdd>(a, b);
   }
   torch::lazy::NodePtr MakeSizeMul(const torch::lazy::Value& a,
                                    const torch::lazy::Value& b) const override {
-    return torch::lazy::MakeNode<SizeMul>(a, b);
+    return torch_xla::MakeNode<SizeMul>(a, b);
   }
   torch::lazy::NodePtr MakeSizeDiv(const torch::lazy::Value& a,
                                    const torch::lazy::Value& b) const override {
-    return torch::lazy::MakeNode<SizeDiv>(a, b);
+    return torch_xla::MakeNode<SizeDiv>(a, b);
   }
 };
 

--- a/torch_xla/csrc/ops/adam_optimizer_step.cpp
+++ b/torch_xla/csrc/ops/adam_optimizer_step.cpp
@@ -37,7 +37,7 @@ AdamOptimizerStep::AdamOptimizerStep(
 
 torch::lazy::NodePtr AdamOptimizerStep::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<AdamOptimizerStep>(
+  return torch_xla::MakeNode<AdamOptimizerStep>(
       operands.at(0), operands.at(1), operands.at(2), operands.at(3),
       operands.at(4), operands.at(5), operands.at(6), operands.at(7),
       operands.at(8), operands.at(9), operands.at(10), operands.at(11),

--- a/torch_xla/csrc/ops/adaptive_max_pool2d.cpp
+++ b/torch_xla/csrc/ops/adaptive_max_pool2d.cpp
@@ -31,7 +31,7 @@ AdaptiveMaxPool2d::AdaptiveMaxPool2d(const torch::lazy::Value& input,
 
 torch::lazy::NodePtr AdaptiveMaxPool2d::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<AdaptiveMaxPool2d>(operands.at(0), output_size_);
+  return torch_xla::MakeNode<AdaptiveMaxPool2d>(operands.at(0), output_size_);
 }
 
 XlaOpVector AdaptiveMaxPool2d::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/all_gather.cpp
+++ b/torch_xla/csrc/ops/all_gather.cpp
@@ -80,14 +80,14 @@ AllGatherCoalesced::AllGatherCoalesced(c10::ArrayRef<torch::lazy::Value> inputs,
       pin_layout_(pin_layout) {}
 
 torch::lazy::NodePtr AllGather::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<AllGather>(operands.at(0), operands.at(1), dim_,
-                                          shard_count_, groups_, pin_layout_);
+  return torch_xla::MakeNode<AllGather>(operands.at(0), operands.at(1), dim_,
+                                        shard_count_, groups_, pin_layout_);
 }
 
 torch::lazy::NodePtr AllGatherCoalesced::Clone(
     torch::lazy::OpList operands) const {
   std::vector<torch::lazy::Value> inputs(operands.begin(), operands.end() - 1);
-  return torch::lazy::MakeNode<AllGatherCoalesced>(
+  return torch_xla::MakeNode<AllGatherCoalesced>(
       inputs, operands.back(), dim_, shard_count_, groups_, pin_layout_);
 }
 

--- a/torch_xla/csrc/ops/all_reduce.cpp
+++ b/torch_xla/csrc/ops/all_reduce.cpp
@@ -54,9 +54,9 @@ AllReduce::AllReduce(AllReduceType reduce_type, torch::lazy::Value operand,
 torch::lazy::NodePtr AllReduce::Clone(torch::lazy::OpList operands) const {
   std::vector<torch::lazy::Value> operand_list(operands.begin(),
                                                operands.end() - 1);
-  return torch::lazy::MakeNode<AllReduce>(reduce_type_, operand_list,
-                                          operands.back(), scale_, groups_,
-                                          pin_layout_);
+  return torch_xla::MakeNode<AllReduce>(reduce_type_, operand_list,
+                                        operands.back(), scale_, groups_,
+                                        pin_layout_);
 }
 
 XlaOpVector AllReduce::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/all_to_all.cpp
+++ b/torch_xla/csrc/ops/all_to_all.cpp
@@ -47,9 +47,9 @@ AllToAll::AllToAll(const torch::lazy::Value& input,
       pin_layout_(pin_layout) {}
 
 torch::lazy::NodePtr AllToAll::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<AllToAll>(operands.at(0), operands.at(1),
-                                         split_dimension_, concat_dimension_,
-                                         split_count_, groups_, pin_layout_);
+  return torch_xla::MakeNode<AllToAll>(operands.at(0), operands.at(1),
+                                       split_dimension_, concat_dimension_,
+                                       split_count_, groups_, pin_layout_);
 }
 
 XlaOpVector AllToAll::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/amp_foreach_non_finite_check_and_unscale.cpp
+++ b/torch_xla/csrc/ops/amp_foreach_non_finite_check_and_unscale.cpp
@@ -47,7 +47,7 @@ torch::lazy::NodePtr AmpForachNonFiniteCheckAndUnscale::Clone(
   std::vector<torch::lazy::Value> operand_list(operands.begin(),
                                                operands.end() - 2);
   size_t sz = operand_list.size();
-  return torch::lazy::MakeNode<AmpForachNonFiniteCheckAndUnscale>(
+  return torch_xla::MakeNode<AmpForachNonFiniteCheckAndUnscale>(
       operand_list, operands[sz], operands[sz + 1]);
 }
 

--- a/torch_xla/csrc/ops/amp_update_scale.cpp
+++ b/torch_xla/csrc/ops/amp_update_scale.cpp
@@ -31,7 +31,7 @@ AmpUpdateScale::AmpUpdateScale(const torch::lazy::Value& current_scale,
       growth_interval_(growth_interval) {}
 
 torch::lazy::NodePtr AmpUpdateScale::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<AmpUpdateScale>(
+  return torch_xla::MakeNode<AmpUpdateScale>(
       operands[0], operands[1], operands[2], scale_growth_factor_,
       scale_backoff_factor_, growth_interval_);
 }

--- a/torch_xla/csrc/ops/as_strided.cpp
+++ b/torch_xla/csrc/ops/as_strided.cpp
@@ -65,8 +65,8 @@ std::string AsStrided::ToString() const {
 }
 
 torch::lazy::NodePtr AsStrided::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<AsStrided>(operands.at(0), size_, stride_,
-                                          storage_offset_);
+  return torch_xla::MakeNode<AsStrided>(operands.at(0), size_, stride_,
+                                        storage_offset_);
 }
 
 XlaOpVector AsStrided::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/as_strided_view_update.cpp
+++ b/torch_xla/csrc/ops/as_strided_view_update.cpp
@@ -66,7 +66,7 @@ std::string AsStridedViewUpdate::ToString() const {
 
 torch::lazy::NodePtr AsStridedViewUpdate::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<AsStridedViewUpdate>(
+  return torch_xla::MakeNode<AsStridedViewUpdate>(
       operands.at(0), operands.at(1), size_, stride_, storage_offset_);
 }
 

--- a/torch_xla/csrc/ops/avg_pool_nd.cpp
+++ b/torch_xla/csrc/ops/avg_pool_nd.cpp
@@ -68,9 +68,9 @@ AvgPoolNd::AvgPoolNd(const torch::lazy::Value& input, int64_t spatial_dim_count,
       divisor_override_(divisor_override) {}
 
 torch::lazy::NodePtr AvgPoolNd::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<AvgPoolNd>(operands.at(0), spatial_dim_count_,
-                                          kernel_size_, stride_, padding_,
-                                          ceil_mode_, count_include_pad_);
+  return torch_xla::MakeNode<AvgPoolNd>(operands.at(0), spatial_dim_count_,
+                                        kernel_size_, stride_, padding_,
+                                        ceil_mode_, count_include_pad_);
 }
 
 XlaOpVector AvgPoolNd::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/avg_pool_nd_backward.cpp
+++ b/torch_xla/csrc/ops/avg_pool_nd_backward.cpp
@@ -69,7 +69,7 @@ AvgPoolNdBackward::AvgPoolNdBackward(const torch::lazy::Value& grad_output,
 
 torch::lazy::NodePtr AvgPoolNdBackward::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<AvgPoolNdBackward>(
+  return torch_xla::MakeNode<AvgPoolNdBackward>(
       operands.at(0), operands.at(1), spatial_dim_count_, kernel_size_, stride_,
       padding_, ceil_mode_, count_include_pad_);
 }

--- a/torch_xla/csrc/ops/bernoulli.cpp
+++ b/torch_xla/csrc/ops/bernoulli.cpp
@@ -13,8 +13,8 @@ Bernoulli::Bernoulli(const torch::lazy::Value& probability,
               std::move(shape)) {}
 
 torch::lazy::NodePtr Bernoulli::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Bernoulli>(operands.at(0), operands.at(1),
-                                          xla_shape());
+  return torch_xla::MakeNode<Bernoulli>(operands.at(0), operands.at(1),
+                                        xla_shape());
 }
 
 XlaOpVector Bernoulli::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/cast.cpp
+++ b/torch_xla/csrc/ops/cast.cpp
@@ -44,8 +44,8 @@ Cast::Cast(const torch::lazy::Value& input, at::ScalarType dtype,
       stype_(stype) {}
 
 torch::lazy::NodePtr Cast::Clone(torch::lazy::OpList operands) const {
-  return dtype_ ? torch::lazy::MakeNode<Cast>(operands.at(0), *dtype_, stype_)
-                : torch::lazy::MakeNode<Cast>(operands.at(0), type_);
+  return dtype_ ? torch_xla::MakeNode<Cast>(operands.at(0), *dtype_, stype_)
+                : torch_xla::MakeNode<Cast>(operands.at(0), type_);
 }
 
 XlaOpVector Cast::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/cast_int4.cpp
+++ b/torch_xla/csrc/ops/cast_int4.cpp
@@ -23,7 +23,7 @@ CastInt4::CastInt4(const torch::lazy::Value& weight,
       int4_vals_(int4_vals) {}
 
 torch::lazy::NodePtr CastInt4::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<CastInt4>(operands.at(0), int4_vals_);
+  return torch_xla::MakeNode<CastInt4>(operands.at(0), int4_vals_);
 }
 
 XlaOpVector CastInt4::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/cat.cpp
+++ b/torch_xla/csrc/ops/cat.cpp
@@ -34,7 +34,7 @@ Cat::Cat(c10::ArrayRef<torch::lazy::Value> values, int64_t dim,
       dtype_(dtype) {}
 
 torch::lazy::NodePtr Cat::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Cat>(operands, dim_, dtype_);
+  return torch_xla::MakeNode<Cat>(operands, dim_, dtype_);
 }
 
 XlaOpVector Cat::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/cdist.cpp
+++ b/torch_xla/csrc/ops/cdist.cpp
@@ -36,9 +36,9 @@ CdistForward::CdistForward(const torch::lazy::Value& x1,
       use_chebyshev_(use_chebyshev) {}
 
 torch::lazy::NodePtr CdistForward::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<CdistForward>(operands.at(0), operands.at(1),
-                                             operands.at(2), use_hamming_,
-                                             use_chebyshev_);
+  return torch_xla::MakeNode<CdistForward>(operands.at(0), operands.at(1),
+                                           operands.at(2), use_hamming_,
+                                           use_chebyshev_);
 }
 
 XlaOpVector CdistForward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/collective_permute.cpp
+++ b/torch_xla/csrc/ops/collective_permute.cpp
@@ -33,8 +33,8 @@ CollectivePermute::CollectivePermute(
 
 torch::lazy::NodePtr CollectivePermute::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<CollectivePermute>(
-      operands.at(0), operands.at(1), source_target_pairs_);
+  return torch_xla::MakeNode<CollectivePermute>(operands.at(0), operands.at(1),
+                                                source_target_pairs_);
 }
 
 XlaOpVector CollectivePermute::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/constant.cpp
+++ b/torch_xla/csrc/ops/constant.cpp
@@ -27,7 +27,7 @@ std::string Constant::ToString() const {
 }
 
 torch::lazy::NodePtr Constant::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Constant>(value_.Clone());
+  return torch_xla::MakeNode<Constant>(value_.Clone());
 }
 
 XlaOpVector Constant::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/constant_pad_nd.cpp
+++ b/torch_xla/csrc/ops/constant_pad_nd.cpp
@@ -43,7 +43,7 @@ ConstantPadNd::ConstantPadNd(const torch::lazy::Value& input,
       value_(value) {}
 
 torch::lazy::NodePtr ConstantPadNd::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<ConstantPadNd>(operands.at(0), pad_, value_);
+  return torch_xla::MakeNode<ConstantPadNd>(operands.at(0), pad_, value_);
 }
 
 XlaOpVector ConstantPadNd::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/convolution_backward_overrideable.cpp
+++ b/torch_xla/csrc/ops/convolution_backward_overrideable.cpp
@@ -57,7 +57,7 @@ ConvolutionBackwardOverrideable::ConvolutionBackwardOverrideable(
 
 torch::lazy::NodePtr ConvolutionBackwardOverrideable::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<ConvolutionBackwardOverrideable>(
+  return torch_xla::MakeNode<ConvolutionBackwardOverrideable>(
       operands.at(0), operands.at(1), operands.at(2), stride_, padding_,
       dilation_, transposed_, output_padding_, groups_);
 }

--- a/torch_xla/csrc/ops/convolution_overrideable.cpp
+++ b/torch_xla/csrc/ops/convolution_overrideable.cpp
@@ -78,10 +78,10 @@ ConvolutionOverrideable::ConvolutionOverrideable(
 torch::lazy::NodePtr ConvolutionOverrideable::Clone(
     torch::lazy::OpList operands) const {
   return operands.size() == 3
-             ? torch::lazy::MakeNode<ConvolutionOverrideable>(
+             ? torch_xla::MakeNode<ConvolutionOverrideable>(
                    operands.at(0), operands.at(1), operands.at(2), stride_,
                    padding_, dilation_, transposed_, output_padding_, groups_)
-             : torch::lazy::MakeNode<ConvolutionOverrideable>(
+             : torch_xla::MakeNode<ConvolutionOverrideable>(
                    operands.at(0), operands.at(1), stride_, padding_, dilation_,
                    transposed_, output_padding_, groups_);
 }

--- a/torch_xla/csrc/ops/count_nonzero.cpp
+++ b/torch_xla/csrc/ops/count_nonzero.cpp
@@ -23,7 +23,7 @@ CountNonzero::CountNonzero(const torch::lazy::Value& input,
       dims_(dims) {}
 
 torch::lazy::NodePtr CountNonzero::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<CountNonzero>(operands.at(0), dims_);
+  return torch_xla::MakeNode<CountNonzero>(operands.at(0), dims_);
 }
 
 XlaOpVector CountNonzero::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/cumprod.cpp
+++ b/torch_xla/csrc/ops/cumprod.cpp
@@ -48,7 +48,7 @@ CumProd::CumProd(const torch::lazy::Value& input, int64_t dim,
       dtype_(dtype) {}
 
 torch::lazy::NodePtr CumProd::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<CumProd>(operands.at(0), dim_, dtype_);
+  return torch_xla::MakeNode<CumProd>(operands.at(0), dim_, dtype_);
 }
 
 XlaOpVector CumProd::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/cumsum.cpp
+++ b/torch_xla/csrc/ops/cumsum.cpp
@@ -47,7 +47,7 @@ CumSum::CumSum(const torch::lazy::Value& input, int64_t dim,
       dtype_(dtype) {}
 
 torch::lazy::NodePtr CumSum::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<CumSum>(operands.at(0), dim_, dtype_);
+  return torch_xla::MakeNode<CumSum>(operands.at(0), dim_, dtype_);
 }
 
 XlaOpVector CumSum::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/custom_call.cpp
+++ b/torch_xla/csrc/ops/custom_call.cpp
@@ -21,9 +21,9 @@ CustomCall::CustomCall(torch::lazy::OpList inputs,
       api_version_(api_version) {}
 
 torch::lazy::NodePtr CustomCall::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<CustomCall>(operands, call_target_,
-                                           this->xla_shape(), has_side_effect_,
-                                           backend_config_, api_version_);
+  return torch_xla::MakeNode<CustomCall>(operands, call_target_,
+                                         this->xla_shape(), has_side_effect_,
+                                         backend_config_, api_version_);
 }
 
 XlaOpVector CustomCall::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/custom_sharding.cpp
+++ b/torch_xla/csrc/ops/custom_sharding.cpp
@@ -27,8 +27,8 @@ CustomSharding::CustomSharding(const torch::lazy::Value& input,
       output_shape(output_shape) {}
 
 torch::lazy::NodePtr CustomSharding::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<CustomSharding>(operands.at(0), output_shape,
-                                               type);
+  return torch_xla::MakeNode<CustomSharding>(operands.at(0), output_shape,
+                                             type);
 }
 
 XlaOpVector CustomSharding::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/dequant_tensor.cpp
+++ b/torch_xla/csrc/ops/dequant_tensor.cpp
@@ -28,9 +28,9 @@ DequantizeTensor::DequantizeTensor(const torch::lazy::Value& input,
 
 torch::lazy::NodePtr DequantizeTensor::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<DequantizeTensor>(operands.at(0), scale_,
-                                                 zero_point_, quant_min_,
-                                                 quant_max_, dtype_, axis_);
+  return torch_xla::MakeNode<DequantizeTensor>(operands.at(0), scale_,
+                                               zero_point_, quant_min_,
+                                               quant_max_, dtype_, axis_);
 }
 
 XlaOpVector DequantizeTensor::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/device_data.cpp
+++ b/torch_xla/csrc/ops/device_data.cpp
@@ -32,7 +32,7 @@ std::string DeviceData::ToString() const {
 }
 
 torch::lazy::NodePtr DeviceData::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<DeviceData>(data_);
+  return torch_xla::MakeNode<DeviceData>(data_);
 }
 
 XlaOpVector DeviceData::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/diagonal.cpp
+++ b/torch_xla/csrc/ops/diagonal.cpp
@@ -22,7 +22,7 @@ Diagonal::Diagonal(const torch::lazy::Value& input, int64_t offset,
       dim2_(dim2) {}
 
 torch::lazy::NodePtr Diagonal::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Diagonal>(operands.at(0), offset_, dim1_, dim2_);
+  return torch_xla::MakeNode<Diagonal>(operands.at(0), offset_, dim1_, dim2_);
 }
 
 XlaOpVector Diagonal::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/diagonal_view_update.cpp
+++ b/torch_xla/csrc/ops/diagonal_view_update.cpp
@@ -18,8 +18,8 @@ DiagonalViewUpdate::DiagonalViewUpdate(const torch::lazy::Value& target,
 
 torch::lazy::NodePtr DiagonalViewUpdate::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<DiagonalViewUpdate>(
-      operands.at(0), operands.at(1), offset_, dim1_, dim2_);
+  return torch_xla::MakeNode<DiagonalViewUpdate>(operands.at(0), operands.at(1),
+                                                 offset_, dim1_, dim2_);
 }
 
 XlaOpVector DiagonalViewUpdate::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/discrete_uniform.cpp
+++ b/torch_xla/csrc/ops/discrete_uniform.cpp
@@ -18,8 +18,8 @@ DiscreteUniform::DiscreteUniform(const torch::lazy::Value& from,
 
 torch::lazy::NodePtr DiscreteUniform::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<DiscreteUniform>(operands.at(0), operands.at(1),
-                                                operands.at(2), xla_shape());
+  return torch_xla::MakeNode<DiscreteUniform>(operands.at(0), operands.at(1),
+                                              operands.at(2), xla_shape());
 }
 
 XlaOpVector DiscreteUniform::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/dynamic_expand.cpp
+++ b/torch_xla/csrc/ops/dynamic_expand.cpp
@@ -46,7 +46,7 @@ DynamicExpand::DynamicExpand(const torch::lazy::Value& input,
       target_index_(target_index) {}
 
 torch::lazy::NodePtr DynamicExpand::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<DynamicExpand>(
+  return torch_xla::MakeNode<DynamicExpand>(
       operands.at(0), size_, operands.at(1), src_index_, target_index_);
 }
 

--- a/torch_xla/csrc/ops/dynamic_ir.cpp
+++ b/torch_xla/csrc/ops/dynamic_ir.cpp
@@ -45,7 +45,7 @@ int64_t SizeNode::getDynamicValue() const {
     return runtime_size_;
   }
   torch::lazy::NodePtr cloned =
-      torch::lazy::MakeNode<SizeNode>(operands_[0], dim_);
+      torch_xla::MakeNode<SizeNode>(operands_[0], dim_);
   // Wrap the IR of SizeNode into a dummy tensor and execute/fetch the value
   // of this tensor. GetTensors will return a cpu at::Tensor so we can just
   // extract the value of it.

--- a/torch_xla/csrc/ops/dynamic_view.cpp
+++ b/torch_xla/csrc/ops/dynamic_view.cpp
@@ -44,9 +44,9 @@ DynamicView::DynamicView(const torch::lazy::Value& input,
       complete_output_shape_(NodeOutputShape(input, size)) {}
 
 torch::lazy::NodePtr DynamicView::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<DynamicView>(operands.at(0), size_,
-                                            operands.at(1), src_index_,
-                                            target_index_, mul_scaler_);
+  return torch_xla::MakeNode<DynamicView>(operands.at(0), size_, operands.at(1),
+                                          src_index_, target_index_,
+                                          mul_scaler_);
 }
 
 XlaOpVector DynamicView::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/einsum.cpp
+++ b/torch_xla/csrc/ops/einsum.cpp
@@ -26,7 +26,7 @@ xla::Shape NodeOutputShape(const torch::lazy::OpList& operands,
 }  // namespace
 
 torch::lazy::NodePtr Einsum::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Einsum>(operands, equation_);
+  return torch_xla::MakeNode<Einsum>(operands, equation_);
 }
 
 Einsum::Einsum(const torch::lazy::OpList& operands, const std::string equation)

--- a/torch_xla/csrc/ops/einsum_backward.cpp
+++ b/torch_xla/csrc/ops/einsum_backward.cpp
@@ -47,8 +47,7 @@ torch::lazy::NodePtr EinsumBackward::Clone(torch::lazy::OpList operands) const {
     inputs.push_back(operands.at(i));
   }
 
-  return torch::lazy::MakeNode<EinsumBackward>(operands.at(0), inputs,
-                                               equation_);
+  return torch_xla::MakeNode<EinsumBackward>(operands.at(0), inputs, equation_);
 }
 
 EinsumBackward::EinsumBackward(const torch::lazy::Value& grad_output,

--- a/torch_xla/csrc/ops/embedding_bag.cpp
+++ b/torch_xla/csrc/ops/embedding_bag.cpp
@@ -173,9 +173,9 @@ EmbeddingBag::EmbeddingBag(const torch::lazy::Value& weight,
       include_last_offset_(include_last_offset) {}
 
 torch::lazy::NodePtr EmbeddingBag::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<EmbeddingBag>(operands.at(0), operands.at(1),
-                                             operands.at(2), mode_,
-                                             operands.at(3), false);
+  return torch_xla::MakeNode<EmbeddingBag>(operands.at(0), operands.at(1),
+                                           operands.at(2), mode_,
+                                           operands.at(3), false);
 }
 
 XlaOpVector EmbeddingBag::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/expand.cpp
+++ b/torch_xla/csrc/ops/expand.cpp
@@ -27,7 +27,7 @@ Expand::Expand(const torch::lazy::Value& input, std::vector<int64_t> size)
       size_(std::move(size)) {}
 
 torch::lazy::NodePtr Expand::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Expand>(operands.at(0), size_);
+  return torch_xla::MakeNode<Expand>(operands.at(0), size_);
 }
 
 XlaOpVector Expand::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/exponential.cpp
+++ b/torch_xla/csrc/ops/exponential.cpp
@@ -13,8 +13,8 @@ Exponential::Exponential(const torch::lazy::Value& lambda,
               std::move(shape)) {}
 
 torch::lazy::NodePtr Exponential::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Exponential>(operands.at(0), operands.at(1),
-                                            xla_shape());
+  return torch_xla::MakeNode<Exponential>(operands.at(0), operands.at(1),
+                                          xla_shape());
 }
 
 XlaOpVector Exponential::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/flip.cpp
+++ b/torch_xla/csrc/ops/flip.cpp
@@ -11,7 +11,7 @@ Flip::Flip(const torch::lazy::Value& input, std::vector<int64_t> dims)
       dims_(std::move(dims)) {}
 
 torch::lazy::NodePtr Flip::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Flip>(operands.at(0), dims_);
+  return torch_xla::MakeNode<Flip>(operands.at(0), dims_);
 }
 
 XlaOpVector Flip::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/gather.cpp
+++ b/torch_xla/csrc/ops/gather.cpp
@@ -32,7 +32,7 @@ Gather::Gather(const torch::lazy::Value& input, int64_t dim,
       dim_(dim) {}
 
 torch::lazy::NodePtr Gather::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Gather>(operands.at(0), dim_, operands.at(1));
+  return torch_xla::MakeNode<Gather>(operands.at(0), dim_, operands.at(1));
 }
 
 XlaOpVector Gather::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/generic.cpp
+++ b/torch_xla/csrc/ops/generic.cpp
@@ -38,8 +38,8 @@ Generic::Generic(torch::lazy::OpKind op, xla::Shape shape, LowerFn lower_fn,
       hash_seed_(hash_seed) {}
 
 torch::lazy::NodePtr Generic::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Generic>(op(), operands, xla_shape(), lower_fn_,
-                                        num_outputs(), hash_seed_);
+  return torch_xla::MakeNode<Generic>(op(), operands, xla_shape(), lower_fn_,
+                                      num_outputs(), hash_seed_);
 }
 
 XlaOpVector Generic::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/generic_slice.cpp
+++ b/torch_xla/csrc/ops/generic_slice.cpp
@@ -33,8 +33,8 @@ GenericSlice::GenericSlice(const torch::lazy::Value& input,
       sizes_(sizes.begin(), sizes.end()) {}
 
 torch::lazy::NodePtr GenericSlice::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<GenericSlice>(operands.at(0), base_indices_,
-                                             sizes_);
+  return torch_xla::MakeNode<GenericSlice>(operands.at(0), base_indices_,
+                                           sizes_);
 }
 
 XlaOpVector GenericSlice::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/get_dimensions_size.cpp
+++ b/torch_xla/csrc/ops/get_dimensions_size.cpp
@@ -19,7 +19,7 @@ GetDimensionsSize::GetDimensionsSize(const torch::lazy::Value& input,
 
 torch::lazy::NodePtr GetDimensionsSize::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<GetDimensionsSize>(operands.at(0), dimensions_);
+  return torch_xla::MakeNode<GetDimensionsSize>(operands.at(0), dimensions_);
 }
 
 XlaOpVector GetDimensionsSize::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/gpu_custom_call.cpp
+++ b/torch_xla/csrc/ops/gpu_custom_call.cpp
@@ -15,7 +15,7 @@ GpuCustomCall::GpuCustomCall(torch::lazy::OpList inputs,
       payload_(payload) {}
 
 torch::lazy::NodePtr GpuCustomCall::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<GpuCustomCall>(operands, xla_shape(), payload_);
+  return torch_xla::MakeNode<GpuCustomCall>(operands, xla_shape(), payload_);
 }
 
 XlaOpVector GpuCustomCall::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/hardtanh_backward.cpp
+++ b/torch_xla/csrc/ops/hardtanh_backward.cpp
@@ -25,8 +25,8 @@ std::string HardtanhBackward::ToString() const {
 
 torch::lazy::NodePtr HardtanhBackward::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<HardtanhBackward>(operands.at(0), operands.at(1),
-                                                 min_val_, max_val_);
+  return torch_xla::MakeNode<HardtanhBackward>(operands.at(0), operands.at(1),
+                                               min_val_, max_val_);
 }
 
 XlaOpVector HardtanhBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/index_get.cpp
+++ b/torch_xla/csrc/ops/index_get.cpp
@@ -37,8 +37,8 @@ std::string IndexGet::ToString() const {
 }
 
 torch::lazy::NodePtr IndexGet::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<IndexGet>(operands.at(0), operands.at(1),
-                                         start_dim_);
+  return torch_xla::MakeNode<IndexGet>(operands.at(0), operands.at(1),
+                                       start_dim_);
 }
 
 XlaOpVector IndexGet::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/index_ops.cpp
+++ b/torch_xla/csrc/ops/index_ops.cpp
@@ -273,7 +273,7 @@ torch::lazy::Value EnsureRank1(const torch::lazy::Value& index) {
   const XlaNode* casted = dynamic_cast<const XlaNode*>(index.node.get());
   XLA_CHECK_LE(casted->xla_shape().rank(), 1);
   return casted->xla_shape().rank() == 0
-             ? torch::lazy::MakeNode<Expand>(index, std::vector<int64_t>{1})
+             ? torch_xla::MakeNode<Expand>(index, std::vector<int64_t>{1})
              : index;
 }
 
@@ -337,8 +337,8 @@ XLATensorPtr IndexByTensors(const XLATensorPtr& base,
   XLATensorPtr indices_nd =
       tensor_methods::stack(canonical_indices, indices_rank);
   return XLATensor::Create(
-      torch::lazy::MakeNode<IndexGet>(base->GetIrValue(),
-                                      indices_nd->GetIrValue(), start_dim),
+      torch_xla::MakeNode<IndexGet>(base->GetIrValue(),
+                                    indices_nd->GetIrValue(), start_dim),
       base->GetDevice(), base->dtype());
 }
 
@@ -355,10 +355,10 @@ torch::lazy::Value IndexPutByTensors(
   // single scatter.
   XLATensorPtr indices_nd =
       tensor_methods::stack(canonical_indices, indices_rank);
-  return torch::lazy::MakeNode<Permute>(
-      torch::lazy::MakeNode<IndexPut>(base->GetIrValue(),
-                                      indices_nd->GetIrValue(), start_dim,
-                                      values->GetIrValue(), accumulate),
+  return torch_xla::MakeNode<Permute>(
+      torch_xla::MakeNode<IndexPut>(base->GetIrValue(),
+                                    indices_nd->GetIrValue(), start_dim,
+                                    values->GetIrValue(), accumulate),
       torch::lazy::ToVector<int64_t>(result_permutation));
 }
 

--- a/torch_xla/csrc/ops/index_put.cpp
+++ b/torch_xla/csrc/ops/index_put.cpp
@@ -22,8 +22,8 @@ std::string IndexPut::ToString() const {
 }
 
 torch::lazy::NodePtr IndexPut::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<IndexPut>(
-      operands.at(0), operands.at(1), start_dim_, operands.at(2), accumulate_);
+  return torch_xla::MakeNode<IndexPut>(operands.at(0), operands.at(1),
+                                       start_dim_, operands.at(2), accumulate_);
 }
 
 XlaOpVector IndexPut::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/index_select.cpp
+++ b/torch_xla/csrc/ops/index_select.cpp
@@ -29,8 +29,7 @@ IndexSelect::IndexSelect(const torch::lazy::Value& input, int64_t dim,
       dim_(dim) {}
 
 torch::lazy::NodePtr IndexSelect::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<IndexSelect>(operands.at(0), dim_,
-                                            operands.at(1));
+  return torch_xla::MakeNode<IndexSelect>(operands.at(0), dim_, operands.at(1));
 }
 
 XlaOpVector IndexSelect::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/kth_value.cpp
+++ b/torch_xla/csrc/ops/kth_value.cpp
@@ -30,7 +30,7 @@ KthValue::KthValue(const torch::lazy::Value& input, int64_t k, int64_t dim,
       keepdim_(keepdim) {}
 
 torch::lazy::NodePtr KthValue::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<KthValue>(operands.at(0), k_, dim_, keepdim_);
+  return torch_xla::MakeNode<KthValue>(operands.at(0), k_, dim_, keepdim_);
 }
 
 XlaOpVector KthValue::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/linear_interpolation.cpp
+++ b/torch_xla/csrc/ops/linear_interpolation.cpp
@@ -15,8 +15,8 @@ LinearInterpolation::LinearInterpolation(const torch::lazy::Value& value,
 
 torch::lazy::NodePtr LinearInterpolation::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<LinearInterpolation>(operands.at(0),
-                                                    operands.at(1), alpha_);
+  return torch_xla::MakeNode<LinearInterpolation>(operands.at(0),
+                                                  operands.at(1), alpha_);
 }
 
 XlaOpVector LinearInterpolation::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/linspace.cpp
+++ b/torch_xla/csrc/ops/linspace.cpp
@@ -20,8 +20,7 @@ Linspace::Linspace(const torch::lazy::Value& start,
       steps_(steps) {}
 
 torch::lazy::NodePtr Linspace::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Linspace>(operands.at(0), operands.at(1),
-                                         steps_);
+  return torch_xla::MakeNode<Linspace>(operands.at(0), operands.at(1), steps_);
 }
 
 XlaOpVector Linspace::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/log_softmax_backward.cpp
+++ b/torch_xla/csrc/ops/log_softmax_backward.cpp
@@ -17,8 +17,8 @@ LogSoftmaxBackward::LogSoftmaxBackward(const torch::lazy::Value& grad_output,
 
 torch::lazy::NodePtr LogSoftmaxBackward::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<LogSoftmaxBackward>(operands.at(0),
-                                                   operands.at(1), dim_);
+  return torch_xla::MakeNode<LogSoftmaxBackward>(operands.at(0), operands.at(1),
+                                                 dim_);
 }
 
 XlaOpVector LogSoftmaxBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/logsumexp.cpp
+++ b/torch_xla/csrc/ops/logsumexp.cpp
@@ -37,8 +37,8 @@ Logsumexp::Logsumexp(const torch::lazy::Value& input,
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
 torch::lazy::NodePtr Logsumexp::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Logsumexp>(operands.at(0), dimensions_,
-                                          keep_reduced_dimensions_);
+  return torch_xla::MakeNode<Logsumexp>(operands.at(0), dimensions_,
+                                        keep_reduced_dimensions_);
 }
 
 XlaOpVector Logsumexp::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/mark_tensor.cpp
+++ b/torch_xla/csrc/ops/mark_tensor.cpp
@@ -14,7 +14,7 @@ MarkTensor::MarkTensor(const torch::lazy::Value& input, const std::string& info)
       info_(info) {}
 
 torch::lazy::NodePtr MarkTensor::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<MarkTensor>(operands.at(0), info_);
+  return torch_xla::MakeNode<MarkTensor>(operands.at(0), info_);
 }
 
 XlaOpVector MarkTensor::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/masked_scatter.cpp
+++ b/torch_xla/csrc/ops/masked_scatter.cpp
@@ -13,8 +13,8 @@ MaskedScatter::MaskedScatter(const torch::lazy::Value& input,
               /*num_outputs=*/1) {}
 
 torch::lazy::NodePtr MaskedScatter::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<MaskedScatter>(operands.at(0), operands.at(1),
-                                              operands.at(2));
+  return torch_xla::MakeNode<MaskedScatter>(operands.at(0), operands.at(1),
+                                            operands.at(2));
 }
 
 XlaOpVector MaskedScatter::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/masked_select.cpp
+++ b/torch_xla/csrc/ops/masked_select.cpp
@@ -28,7 +28,7 @@ MaskedSelect::MaskedSelect(const torch::lazy::Value& input,
               /*num_outputs=*/2) {}
 
 torch::lazy::NodePtr MaskedSelect::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<MaskedSelect>(operands.at(0), operands.at(1));
+  return torch_xla::MakeNode<MaskedSelect>(operands.at(0), operands.at(1));
 }
 
 XlaOpVector MaskedSelect::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/max_in_dim.cpp
+++ b/torch_xla/csrc/ops/max_in_dim.cpp
@@ -29,7 +29,7 @@ MaxInDim::MaxInDim(const torch::lazy::Value& input, int64_t dim, bool keepdim)
       keepdim_(keepdim) {}
 
 torch::lazy::NodePtr MaxInDim::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<MaxInDim>(operands.at(0), dim_, keepdim_);
+  return torch_xla::MakeNode<MaxInDim>(operands.at(0), dim_, keepdim_);
 }
 
 XlaOpVector MaxInDim::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/max_pool_nd.cpp
+++ b/torch_xla/csrc/ops/max_pool_nd.cpp
@@ -58,9 +58,9 @@ MaxPoolNd::MaxPoolNd(const torch::lazy::Value& input, int64_t spatial_dim_count,
       ceil_mode_(ceil_mode) {}
 
 torch::lazy::NodePtr MaxPoolNd::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<MaxPoolNd>(operands.at(0), spatial_dim_count_,
-                                          kernel_size_, stride_, padding_,
-                                          ceil_mode_);
+  return torch_xla::MakeNode<MaxPoolNd>(operands.at(0), spatial_dim_count_,
+                                        kernel_size_, stride_, padding_,
+                                        ceil_mode_);
 }
 
 XlaOpVector MaxPoolNd::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/max_pool_nd_backward.cpp
+++ b/torch_xla/csrc/ops/max_pool_nd_backward.cpp
@@ -61,7 +61,7 @@ MaxPoolNdBackward::MaxPoolNdBackward(
 
 torch::lazy::NodePtr MaxPoolNdBackward::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<MaxPoolNdBackward>(
+  return torch_xla::MakeNode<MaxPoolNdBackward>(
       operands.at(0), operands.at(1), spatial_dim_count_, kernel_size_, stride_,
       padding_, ceil_mode_);
 }

--- a/torch_xla/csrc/ops/max_unpool_nd.cpp
+++ b/torch_xla/csrc/ops/max_unpool_nd.cpp
@@ -44,8 +44,8 @@ MaxUnpoolNd::MaxUnpoolNd(const torch::lazy::Value& input,
       output_size_(std::move(output_size)) {}
 
 torch::lazy::NodePtr MaxUnpoolNd::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<MaxUnpoolNd>(operands.at(0), operands.at(1),
-                                            output_size_);
+  return torch_xla::MakeNode<MaxUnpoolNd>(operands.at(0), operands.at(1),
+                                          output_size_);
 }
 
 XlaOpVector MaxUnpoolNd::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/mean.cpp
+++ b/torch_xla/csrc/ops/mean.cpp
@@ -51,8 +51,8 @@ Mean::Mean(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
       dtype_(dtype) {}
 
 torch::lazy::NodePtr Mean::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Mean>(operands.at(0), dimensions_,
-                                     keep_reduced_dimensions_, dtype_);
+  return torch_xla::MakeNode<Mean>(operands.at(0), dimensions_,
+                                   keep_reduced_dimensions_, dtype_);
 }
 
 XlaOpVector Mean::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/min_in_dim.cpp
+++ b/torch_xla/csrc/ops/min_in_dim.cpp
@@ -29,7 +29,7 @@ MinInDim::MinInDim(const torch::lazy::Value& input, int64_t dim, bool keepdim)
       keepdim_(keepdim) {}
 
 torch::lazy::NodePtr MinInDim::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<MinInDim>(operands.at(0), dim_, keepdim_);
+  return torch_xla::MakeNode<MinInDim>(operands.at(0), dim_, keepdim_);
 }
 
 XlaOpVector MinInDim::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/mse_loss.cpp
+++ b/torch_xla/csrc/ops/mse_loss.cpp
@@ -34,8 +34,8 @@ MseLoss::MseLoss(const torch::lazy::Value& input,
       reduction_(reduction) {}
 
 torch::lazy::NodePtr MseLoss::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<MseLoss>(operands.at(0), operands.at(1),
-                                        reduction_);
+  return torch_xla::MakeNode<MseLoss>(operands.at(0), operands.at(1),
+                                      reduction_);
 }
 
 XlaOpVector MseLoss::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/mse_loss_backward.cpp
+++ b/torch_xla/csrc/ops/mse_loss_backward.cpp
@@ -43,8 +43,8 @@ MseLossBackward::MseLossBackward(const torch::lazy::Value& grad_output,
 
 torch::lazy::NodePtr MseLossBackward::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<MseLossBackward>(operands.at(0), operands.at(1),
-                                                operands.at(2), reduction_);
+  return torch_xla::MakeNode<MseLossBackward>(operands.at(0), operands.at(1),
+                                              operands.at(2), reduction_);
 }
 
 XlaOpVector MseLossBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/multinomial.cpp
+++ b/torch_xla/csrc/ops/multinomial.cpp
@@ -32,8 +32,8 @@ Multinomial::Multinomial(const torch::lazy::Value& input,
       replacement_(replacement) {}
 
 torch::lazy::NodePtr Multinomial::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Multinomial>(operands.at(0), operands.at(1),
-                                            num_samples_, replacement_);
+  return torch_xla::MakeNode<Multinomial>(operands.at(0), operands.at(1),
+                                          num_samples_, replacement_);
 }
 
 XlaOpVector Multinomial::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/native_batch_norm_backward.cpp
+++ b/torch_xla/csrc/ops/native_batch_norm_backward.cpp
@@ -48,7 +48,7 @@ NativeBatchNormBackward::NativeBatchNormBackward(
 
 torch::lazy::NodePtr NativeBatchNormBackward::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<NativeBatchNormBackward>(
+  return torch_xla::MakeNode<NativeBatchNormBackward>(
       operands.at(0), operands.at(1), operands.at(2), operands.at(3),
       operands.at(4), training_, eps_);
 }

--- a/torch_xla/csrc/ops/native_batch_norm_forward.cpp
+++ b/torch_xla/csrc/ops/native_batch_norm_forward.cpp
@@ -69,7 +69,7 @@ NativeBatchNormForward::NativeBatchNormForward(
 
 torch::lazy::NodePtr NativeBatchNormForward::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<NativeBatchNormForward>(
+  return torch_xla::MakeNode<NativeBatchNormForward>(
       operands.at(0), operands.at(1), operands.at(2), operands.at(3),
       operands.at(4), training_, eps_);
 }

--- a/torch_xla/csrc/ops/native_dropout.cpp
+++ b/torch_xla/csrc/ops/native_dropout.cpp
@@ -25,8 +25,8 @@ NativeDropout::NativeDropout(const torch::lazy::Value& input,
       train_(train) {}
 
 torch::lazy::NodePtr NativeDropout::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<NativeDropout>(operands.at(0), operands.at(1),
-                                              p_, train_);
+  return torch_xla::MakeNode<NativeDropout>(operands.at(0), operands.at(1), p_,
+                                            train_);
 }
 
 XlaOpVector NativeDropout::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/nll_loss.cpp
+++ b/torch_xla/csrc/ops/nll_loss.cpp
@@ -58,8 +58,8 @@ torch::lazy::NodePtr NllLoss::Clone(torch::lazy::OpList operands) const {
   if (operands.size() > 2) {
     weight = operands.at(2);
   }
-  return torch::lazy::MakeNode<NllLoss>(operands.at(0), operands.at(1), weight,
-                                        reduction_, ignore_index_);
+  return torch_xla::MakeNode<NllLoss>(operands.at(0), operands.at(1), weight,
+                                      reduction_, ignore_index_);
 }
 
 XlaOpVector NllLoss::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/nll_loss2d.cpp
+++ b/torch_xla/csrc/ops/nll_loss2d.cpp
@@ -58,8 +58,8 @@ torch::lazy::NodePtr NllLoss2d::Clone(torch::lazy::OpList operands) const {
   if (operands.size() > 2) {
     weight = operands.at(2);
   }
-  return torch::lazy::MakeNode<NllLoss2d>(operands.at(0), operands.at(1),
-                                          weight, reduction_, ignore_index_);
+  return torch_xla::MakeNode<NllLoss2d>(operands.at(0), operands.at(1), weight,
+                                        reduction_, ignore_index_);
 }
 
 XlaOpVector NllLoss2d::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/nll_loss2d_backward.cpp
+++ b/torch_xla/csrc/ops/nll_loss2d_backward.cpp
@@ -69,7 +69,7 @@ torch::lazy::NodePtr NllLoss2dBackward::Clone(
     weight = operands.at(3);
     total_weight = operands.at(4);
   }
-  return torch::lazy::MakeNode<NllLoss2dBackward>(
+  return torch_xla::MakeNode<NllLoss2dBackward>(
       operands.at(0), operands.at(1), operands.at(2), weight, total_weight,
       reduction_, ignore_index_);
 }

--- a/torch_xla/csrc/ops/nll_loss_backward.cpp
+++ b/torch_xla/csrc/ops/nll_loss_backward.cpp
@@ -69,7 +69,7 @@ torch::lazy::NodePtr NllLossBackward::Clone(
     weight = operands.at(3);
     total_weight = operands.at(4);
   }
-  return torch::lazy::MakeNode<NllLossBackward>(
+  return torch_xla::MakeNode<NllLossBackward>(
       operands.at(0), operands.at(1), operands.at(2), weight, total_weight,
       reduction_, ignore_index_);
 }

--- a/torch_xla/csrc/ops/nms.cpp
+++ b/torch_xla/csrc/ops/nms.cpp
@@ -32,8 +32,8 @@ Nms::Nms(const torch::lazy::Value& boxes, const torch::lazy::Value& scores,
           [&]() { return NodeOutputShape(boxes, scores, iou_threshold); }) {}
 
 torch::lazy::NodePtr Nms::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Nms>(operands.at(0), operands.at(1),
-                                    operands.at(2));
+  return torch_xla::MakeNode<Nms>(operands.at(0), operands.at(1),
+                                  operands.at(2));
 }
 
 XlaOpVector Nms::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/nonzero.cpp
+++ b/torch_xla/csrc/ops/nonzero.cpp
@@ -27,7 +27,7 @@ NonZero::NonZero(const torch::lazy::Value& input)
               /*num_outputs=*/2) {}
 
 torch::lazy::NodePtr NonZero::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<NonZero>(operands.at(0));
+  return torch_xla::MakeNode<NonZero>(operands.at(0));
 }
 
 XlaOpVector NonZero::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/normal.cpp
+++ b/torch_xla/csrc/ops/normal.cpp
@@ -13,8 +13,8 @@ Normal::Normal(const torch::lazy::Value& mean, const torch::lazy::Value& std,
               GetXlaShape(mean)) {}
 
 torch::lazy::NodePtr Normal::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Normal>(operands.at(0), operands.at(1),
-                                       operands.at(2));
+  return torch_xla::MakeNode<Normal>(operands.at(0), operands.at(1),
+                                     operands.at(2));
 }
 
 XlaOpVector Normal::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/not_supported.cpp
+++ b/torch_xla/csrc/ops/not_supported.cpp
@@ -12,7 +12,7 @@ NotSupported::NotSupported(std::string description, xla::Shape shape)
       description_(std::move(description)) {}
 
 torch::lazy::NodePtr NotSupported::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<NotSupported>(description_, xla_shape());
+  return torch_xla::MakeNode<NotSupported>(description_, xla_shape());
 }
 
 XlaOpVector NotSupported::Lower(LoweringContext* /* loctx */) const {

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -15,15 +15,15 @@ namespace torch_xla {
 
 inline torch::lazy::NodePtr ScalarOp(const at::Scalar& value,
                                      xla::Shape shape) {
-  return torch::lazy::MakeNode<Scalar>(value, std::move(shape));
+  return torch_xla::MakeNode<Scalar>(value, std::move(shape));
 }
 inline torch::lazy::NodePtr ScalarOp(const at::Scalar& value,
                                      xla::PrimitiveType type) {
-  return torch::lazy::MakeNode<Scalar>(value, type);
+  return torch_xla::MakeNode<Scalar>(value, type);
 }
 
 inline torch::lazy::NodePtr ConstantOp(xla::Literal value) {
-  return torch::lazy::MakeNode<Constant>(std::move(value));
+  return torch_xla::MakeNode<Constant>(std::move(value));
 }
 
 inline torch::lazy::NodePtr GenericOp(
@@ -31,9 +31,9 @@ inline torch::lazy::NodePtr GenericOp(
     xla::Shape shape, Generic::LowerFn lower_fn, size_t num_outputs = 1,
     // cast to uint32_t to avoid ambiguous constructor of uint128
     torch::lazy::hash_t hash_seed = (uint32_t)0x5a2d296e9) {
-  return torch::lazy::MakeNode<Generic>(std::move(op), operands,
-                                        std::move(shape), std::move(lower_fn),
-                                        num_outputs, hash_seed);
+  return torch_xla::MakeNode<Generic>(std::move(op), operands, std::move(shape),
+                                      std::move(lower_fn), num_outputs,
+                                      hash_seed);
 }
 
 inline torch::lazy::NodePtr GenericOp(
@@ -43,7 +43,7 @@ inline torch::lazy::NodePtr GenericOp(
     size_t num_outputs = 1,
     // cast to uint32_t to avoid ambiguous constructor of uint128
     torch::lazy::hash_t hash_seed = (uint32_t)0x5a2d296e9) {
-  return torch::lazy::MakeNode<Generic>(
+  return torch_xla::MakeNode<Generic>(
       std::move(op), operands, std::move(shapes), shape_fn, std::move(lower_fn),
       num_outputs, hash_seed);
 }
@@ -54,18 +54,18 @@ inline torch::lazy::NodePtr GenericOp(
     size_t num_outputs = 1,
     // cast to uint32_t to avoid ambiguous constructor of uint128
     torch::lazy::hash_t hash_seed = (uint32_t)0x5a2d296e9) {
-  return torch::lazy::MakeNode<Generic>(std::move(op), operands, shape_fn,
-                                        std::move(lower_fn), num_outputs,
-                                        hash_seed);
+  return torch_xla::MakeNode<Generic>(std::move(op), operands, shape_fn,
+                                      std::move(lower_fn), num_outputs,
+                                      hash_seed);
 }
 
 inline torch::lazy::NodePtr GenericOp(torch::lazy::OpKind op, xla::Shape shape,
                                       Generic::LowerFn lower_fn,
                                       size_t num_outputs,
                                       torch::lazy::hash_t hash_seed) {
-  return torch::lazy::MakeNode<Generic>(std::move(op), std::move(shape),
-                                        std::move(lower_fn), num_outputs,
-                                        hash_seed);
+  return torch_xla::MakeNode<Generic>(std::move(op), std::move(shape),
+                                      std::move(lower_fn), num_outputs,
+                                      hash_seed);
 }
 
 torch::lazy::NodePtr Cos(const torch::lazy::Value& input);

--- a/torch_xla/csrc/ops/optimization_barrier.cpp
+++ b/torch_xla/csrc/ops/optimization_barrier.cpp
@@ -26,7 +26,7 @@ OptimizationBarrier::OptimizationBarrier(const torch::lazy::OpList& inputs)
 
 torch::lazy::NodePtr OptimizationBarrier::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<OptimizationBarrier>(operands);
+  return torch_xla::MakeNode<OptimizationBarrier>(operands);
 }
 
 XlaOpVector OptimizationBarrier::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/permute.cpp
+++ b/torch_xla/csrc/ops/permute.cpp
@@ -28,7 +28,7 @@ Permute::Permute(const torch::lazy::Value& input, std::vector<int64_t> dims)
       dims_(std::move(dims)) {}
 
 torch::lazy::NodePtr Permute::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Permute>(operands.at(0), dims_);
+  return torch_xla::MakeNode<Permute>(operands.at(0), dims_);
 }
 
 XlaOpVector Permute::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/prod.cpp
+++ b/torch_xla/csrc/ops/prod.cpp
@@ -56,8 +56,8 @@ Prod::Prod(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
       dtype_(dtype) {}
 
 torch::lazy::NodePtr Prod::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Prod>(operands.at(0), dimensions_,
-                                     keep_reduced_dimensions_, dtype_);
+  return torch_xla::MakeNode<Prod>(operands.at(0), dimensions_,
+                                   keep_reduced_dimensions_, dtype_);
 }
 
 XlaOpVector Prod::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/put.cpp
+++ b/torch_xla/csrc/ops/put.cpp
@@ -13,8 +13,8 @@ Put::Put(const torch::lazy::Value& input, const torch::lazy::Value& index,
       accumulate_(accumulate) {}
 
 torch::lazy::NodePtr Put::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Put>(operands.at(0), operands.at(1),
-                                    operands.at(2), accumulate_);
+  return torch_xla::MakeNode<Put>(operands.at(0), operands.at(1),
+                                  operands.at(2), accumulate_);
 }
 
 XlaOpVector Put::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/qr.cpp
+++ b/torch_xla/csrc/ops/qr.cpp
@@ -47,7 +47,7 @@ QR::QR(const torch::lazy::Value& input, bool some)
       some_(some) {}
 
 torch::lazy::NodePtr QR::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<QR>(operands.at(0), some_);
+  return torch_xla::MakeNode<QR>(operands.at(0), some_);
 }
 
 XlaOpVector QR::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/quant_tensor.cpp
+++ b/torch_xla/csrc/ops/quant_tensor.cpp
@@ -28,9 +28,9 @@ QuantizeTensor::QuantizeTensor(const torch::lazy::Value& input,
       zero_point_(zero_point) {}
 
 torch::lazy::NodePtr QuantizeTensor::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<QuantizeTensor>(operands.at(0), scale_,
-                                               zero_point_, quant_min_,
-                                               quant_max_, dtype_, axis_);
+  return torch_xla::MakeNode<QuantizeTensor>(operands.at(0), scale_,
+                                             zero_point_, quant_min_,
+                                             quant_max_, dtype_, axis_);
 }
 
 XlaOpVector QuantizeTensor::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/recv.cpp
+++ b/torch_xla/csrc/ops/recv.cpp
@@ -33,7 +33,7 @@ Recv::Recv(const torch::lazy::Value& token, const xla::Shape& recv_shape,
       channel_id_(channel_id) {}
 
 torch::lazy::NodePtr Recv::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Recv>(operands.at(0), recv_shape_, channel_id_);
+  return torch_xla::MakeNode<Recv>(operands.at(0), recv_shape_, channel_id_);
 }
 
 XlaOpVector Recv::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/reduce_scatter.cpp
+++ b/torch_xla/csrc/ops/reduce_scatter.cpp
@@ -129,7 +129,7 @@ ReduceScatterCoalesced::ReduceScatterCoalesced(
       pin_layout_(pin_layout) {}
 
 torch::lazy::NodePtr ReduceScatter::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<ReduceScatter>(
+  return torch_xla::MakeNode<ReduceScatter>(
       reduce_type_, operands.at(0), operands.at(1), scale_, scatter_dim_,
       shard_count_, groups_, pin_layout_);
 }
@@ -137,7 +137,7 @@ torch::lazy::NodePtr ReduceScatter::Clone(torch::lazy::OpList operands) const {
 torch::lazy::NodePtr ReduceScatterCoalesced::Clone(
     torch::lazy::OpList operands) const {
   std::vector<torch::lazy::Value> inputs(operands.begin(), operands.end() - 1);
-  return torch::lazy::MakeNode<ReduceScatterCoalesced>(
+  return torch_xla::MakeNode<ReduceScatterCoalesced>(
       reduce_type_, inputs, operands.back(), scale_, scatter_dim_, shard_count_,
       groups_, pin_layout_);
 }

--- a/torch_xla/csrc/ops/reflection_pad2d.cpp
+++ b/torch_xla/csrc/ops/reflection_pad2d.cpp
@@ -29,7 +29,7 @@ ReflectionPad2d::ReflectionPad2d(const torch::lazy::Value& input,
 
 torch::lazy::NodePtr ReflectionPad2d::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<ReflectionPad2d>(operands.at(0), padding_);
+  return torch_xla::MakeNode<ReflectionPad2d>(operands.at(0), padding_);
 }
 
 XlaOpVector ReflectionPad2d::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/reflection_pad2d_backward.cpp
+++ b/torch_xla/csrc/ops/reflection_pad2d_backward.cpp
@@ -33,8 +33,8 @@ ReflectionPad2dBackward::ReflectionPad2dBackward(
 
 torch::lazy::NodePtr ReflectionPad2dBackward::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<ReflectionPad2dBackward>(
-      operands.at(0), operands.at(1), padding_);
+  return torch_xla::MakeNode<ReflectionPad2dBackward>(operands.at(0),
+                                                      operands.at(1), padding_);
 }
 
 XlaOpVector ReflectionPad2dBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/replication_pad.cpp
+++ b/torch_xla/csrc/ops/replication_pad.cpp
@@ -28,7 +28,7 @@ ReplicationPad::ReplicationPad(const torch::lazy::Value& input,
       padding_(std::move(padding)) {}
 
 torch::lazy::NodePtr ReplicationPad::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<ReplicationPad>(operands.at(0), padding_);
+  return torch_xla::MakeNode<ReplicationPad>(operands.at(0), padding_);
 }
 
 XlaOpVector ReplicationPad::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/replication_pad_backward.cpp
+++ b/torch_xla/csrc/ops/replication_pad_backward.cpp
@@ -33,8 +33,8 @@ ReplicationPadBackward::ReplicationPadBackward(
 
 torch::lazy::NodePtr ReplicationPadBackward::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<ReplicationPadBackward>(
-      operands.at(0), operands.at(1), padding_);
+  return torch_xla::MakeNode<ReplicationPadBackward>(operands.at(0),
+                                                     operands.at(1), padding_);
 }
 
 XlaOpVector ReplicationPadBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/resize.cpp
+++ b/torch_xla/csrc/ops/resize.cpp
@@ -23,7 +23,7 @@ Resize::Resize(const torch::lazy::Value& input, std::vector<int64_t> size)
       size_(std::move(size)) {}
 
 torch::lazy::NodePtr Resize::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Resize>(operands.at(0), size_);
+  return torch_xla::MakeNode<Resize>(operands.at(0), size_);
 }
 
 XlaOpVector Resize::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/roll.cpp
+++ b/torch_xla/csrc/ops/roll.cpp
@@ -12,7 +12,7 @@ Roll::Roll(const torch::lazy::Value& input, std::vector<int64_t> shifts,
       dims_(std::move(dims)) {}
 
 torch::lazy::NodePtr Roll::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Roll>(operands.at(0), shifts_, dims_);
+  return torch_xla::MakeNode<Roll>(operands.at(0), shifts_, dims_);
 }
 
 XlaOpVector Roll::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/rrelu_with_noise.cpp
+++ b/torch_xla/csrc/ops/rrelu_with_noise.cpp
@@ -22,8 +22,8 @@ RreluWithNoise::RreluWithNoise(const torch::lazy::Value& input,
       training_(training) {}
 
 torch::lazy::NodePtr RreluWithNoise::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<RreluWithNoise>(operands.at(0), operands.at(1),
-                                               lower_, upper_, training_);
+  return torch_xla::MakeNode<RreluWithNoise>(operands.at(0), operands.at(1),
+                                             lower_, upper_, training_);
 }
 
 XlaOpVector RreluWithNoise::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/rrelu_with_noise_backward.cpp
+++ b/torch_xla/csrc/ops/rrelu_with_noise_backward.cpp
@@ -21,7 +21,7 @@ RreluWithNoiseBackward::RreluWithNoiseBackward(
 
 torch::lazy::NodePtr RreluWithNoiseBackward::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<RreluWithNoiseBackward>(
+  return torch_xla::MakeNode<RreluWithNoiseBackward>(
       operands.at(0), operands.at(1), operands.at(2), lower_, upper_,
       training_);
 }

--- a/torch_xla/csrc/ops/scalar.cpp
+++ b/torch_xla/csrc/ops/scalar.cpp
@@ -28,7 +28,7 @@ std::string Scalar::ToString() const {
 }
 
 torch::lazy::NodePtr Scalar::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Scalar>(value_, xla_shape());
+  return torch_xla::MakeNode<Scalar>(value_, xla_shape());
 }
 
 XlaOpVector Scalar::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/scatter.cpp
+++ b/torch_xla/csrc/ops/scatter.cpp
@@ -14,8 +14,8 @@ Scatter::Scatter(const torch::lazy::Value& input,
       dim_(dim) {}
 
 torch::lazy::NodePtr Scatter::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Scatter>(operands.at(0), operands.at(1),
-                                        operands.at(2), dim_);
+  return torch_xla::MakeNode<Scatter>(operands.at(0), operands.at(1),
+                                      operands.at(2), dim_);
 }
 
 XlaOpVector Scatter::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/scatter_add.cpp
+++ b/torch_xla/csrc/ops/scatter_add.cpp
@@ -16,8 +16,8 @@ ScatterAdd::ScatterAdd(const torch::lazy::Value& input,
       dim_(dim) {}
 
 torch::lazy::NodePtr ScatterAdd::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<ScatterAdd>(operands.at(0), operands.at(1),
-                                           operands.at(2), dim_);
+  return torch_xla::MakeNode<ScatterAdd>(operands.at(0), operands.at(1),
+                                         operands.at(2), dim_);
 }
 
 XlaOpVector ScatterAdd::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/scatter_reduce.cpp
+++ b/torch_xla/csrc/ops/scatter_reduce.cpp
@@ -20,9 +20,9 @@ ScatterReduce::ScatterReduce(const torch::lazy::Value& input,
       dim_(dim) {}
 
 torch::lazy::NodePtr ScatterReduce::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<ScatterReduce>(operands.at(0), operands.at(1),
-                                              operands.at(2), reduce_,
-                                              include_self_, dim_);
+  return torch_xla::MakeNode<ScatterReduce>(operands.at(0), operands.at(1),
+                                            operands.at(2), reduce_,
+                                            include_self_, dim_);
 }
 
 XlaOpVector ScatterReduce::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/select.cpp
+++ b/torch_xla/csrc/ops/select.cpp
@@ -21,8 +21,8 @@ Select::Select(const torch::lazy::Value& input, int64_t dim, int64_t start,
       stride_(stride) {}
 
 torch::lazy::NodePtr Select::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Select>(operands.at(0), dim_, start_, end_,
-                                       stride_);
+  return torch_xla::MakeNode<Select>(operands.at(0), dim_, start_, end_,
+                                     stride_);
 }
 
 XlaOpVector Select::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/send.cpp
+++ b/torch_xla/csrc/ops/send.cpp
@@ -35,8 +35,7 @@ Send::Send(const torch::lazy::Value& input, const torch::lazy::Value& token,
       channel_id_(channel_id) {}
 
 torch::lazy::NodePtr Send::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Send>(operands.at(0), operands.at(1),
-                                     channel_id_);
+  return torch_xla::MakeNode<Send>(operands.at(0), operands.at(1), channel_id_);
 }
 
 XlaOpVector Send::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/sgd_optimizer_step.cpp
+++ b/torch_xla/csrc/ops/sgd_optimizer_step.cpp
@@ -35,7 +35,7 @@ SgdOptimizerStep::SgdOptimizerStep(
 
 torch::lazy::NodePtr SgdOptimizerStep::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<SgdOptimizerStep>(
+  return torch_xla::MakeNode<SgdOptimizerStep>(
       operands.at(0), operands.at(1), operands.at(2), operands.at(3),
       operands.at(4), operands.at(5), operands.at(6), operands.at(7),
       operands.at(8), use_weight_decay_, use_momentum_, use_nesterov_);

--- a/torch_xla/csrc/ops/softmax.cpp
+++ b/torch_xla/csrc/ops/softmax.cpp
@@ -39,7 +39,7 @@ Softmax::Softmax(const torch::lazy::Value& input, int64_t dim,
       dtype_(dtype) {}
 
 torch::lazy::NodePtr Softmax::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Softmax>(operands.at(0), dim_, dtype_);
+  return torch_xla::MakeNode<Softmax>(operands.at(0), dim_, dtype_);
 }
 
 XlaOpVector Softmax::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/softmax_backward.cpp
+++ b/torch_xla/csrc/ops/softmax_backward.cpp
@@ -16,8 +16,8 @@ SoftmaxBackward::SoftmaxBackward(const torch::lazy::Value& grad_output,
 
 torch::lazy::NodePtr SoftmaxBackward::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<SoftmaxBackward>(operands.at(0), operands.at(1),
-                                                dim_);
+  return torch_xla::MakeNode<SoftmaxBackward>(operands.at(0), operands.at(1),
+                                              dim_);
 }
 
 XlaOpVector SoftmaxBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/split.cpp
+++ b/torch_xla/csrc/ops/split.cpp
@@ -33,7 +33,7 @@ Split::Split(const torch::lazy::Value& input, std::vector<int64_t> split_sizes,
       dim_(dim) {}
 
 torch::lazy::NodePtr Split::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Split>(operands.at(0), split_sizes_, dim_);
+  return torch_xla::MakeNode<Split>(operands.at(0), split_sizes_, dim_);
 }
 
 XlaOpVector Split::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/squeeze.cpp
+++ b/torch_xla/csrc/ops/squeeze.cpp
@@ -35,7 +35,7 @@ Squeeze::Squeeze(const torch::lazy::Value& input, int dim)
       dim_(dim) {}
 
 torch::lazy::NodePtr Squeeze::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Squeeze>(operands.at(0), dim_);
+  return torch_xla::MakeNode<Squeeze>(operands.at(0), dim_);
 }
 
 XlaOpVector Squeeze::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/stack.cpp
+++ b/torch_xla/csrc/ops/stack.cpp
@@ -32,7 +32,7 @@ Stack::Stack(c10::ArrayRef<torch::lazy::Value> values, int64_t dim)
       dim_(dim) {}
 
 torch::lazy::NodePtr Stack::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Stack>(operands, dim_);
+  return torch_xla::MakeNode<Stack>(operands, dim_);
 }
 
 XlaOpVector Stack::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/std.cpp
+++ b/torch_xla/csrc/ops/std.cpp
@@ -36,8 +36,8 @@ Std::Std(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
       correction_(correction) {}
 
 torch::lazy::NodePtr Std::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Std>(operands.at(0), dimensions_,
-                                    keep_reduced_dimensions_, correction_);
+  return torch_xla::MakeNode<Std>(operands.at(0), dimensions_,
+                                  keep_reduced_dimensions_, correction_);
 }
 
 XlaOpVector Std::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/std_mean.cpp
+++ b/torch_xla/csrc/ops/std_mean.cpp
@@ -40,8 +40,8 @@ StdMean::StdMean(const torch::lazy::Value& input,
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
 torch::lazy::NodePtr StdMean::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<StdMean>(operands.at(0), dimensions_,
-                                        correction_, keep_reduced_dimensions_);
+  return torch_xla::MakeNode<StdMean>(operands.at(0), dimensions_, correction_,
+                                      keep_reduced_dimensions_);
 }
 
 XlaOpVector StdMean::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/sum.cpp
+++ b/torch_xla/csrc/ops/sum.cpp
@@ -50,8 +50,8 @@ Sum::Sum(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
       dtype_(dtype) {}
 
 torch::lazy::NodePtr Sum::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Sum>(operands.at(0), dimensions_,
-                                    keep_reduced_dimensions_, dtype_);
+  return torch_xla::MakeNode<Sum>(operands.at(0), dimensions_,
+                                  keep_reduced_dimensions_, dtype_);
 }
 
 XlaOpVector Sum::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/svd.cpp
+++ b/torch_xla/csrc/ops/svd.cpp
@@ -77,7 +77,7 @@ SVD::SVD(const torch::lazy::Value& input, bool some, bool compute_uv)
       compute_uv_(compute_uv) {}
 
 torch::lazy::NodePtr SVD::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<SVD>(operands.at(0), some_, compute_uv_);
+  return torch_xla::MakeNode<SVD>(operands.at(0), some_, compute_uv_);
 }
 
 XlaOpVector SVD::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/symeig.cpp
+++ b/torch_xla/csrc/ops/symeig.cpp
@@ -53,7 +53,7 @@ SymEig::SymEig(const torch::lazy::Value& input, bool eigenvectors, bool lower)
       lower_(lower) {}
 
 torch::lazy::NodePtr SymEig::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<SymEig>(operands.at(0), eigenvectors_, lower_);
+  return torch_xla::MakeNode<SymEig>(operands.at(0), eigenvectors_, lower_);
 }
 
 XlaOpVector SymEig::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/threshold.cpp
+++ b/torch_xla/csrc/ops/threshold.cpp
@@ -14,7 +14,7 @@ Threshold::Threshold(const torch::lazy::Value& input, float threshold,
       value_(value) {}
 
 torch::lazy::NodePtr Threshold::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Threshold>(operands.at(0), threshold_, value_);
+  return torch_xla::MakeNode<Threshold>(operands.at(0), threshold_, value_);
 }
 
 XlaOpVector Threshold::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/threshold_backward.cpp
+++ b/torch_xla/csrc/ops/threshold_backward.cpp
@@ -15,8 +15,8 @@ ThresholdBackward::ThresholdBackward(const torch::lazy::Value& grad_output,
 
 torch::lazy::NodePtr ThresholdBackward::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<ThresholdBackward>(operands.at(0),
-                                                  operands.at(1), threshold_);
+  return torch_xla::MakeNode<ThresholdBackward>(operands.at(0), operands.at(1),
+                                                threshold_);
 }
 
 XlaOpVector ThresholdBackward::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/topk.cpp
+++ b/torch_xla/csrc/ops/topk.cpp
@@ -36,8 +36,8 @@ TopK::TopK(const torch::lazy::Value& input, int64_t k, int64_t dim,
       stable_(stable) {}
 
 torch::lazy::NodePtr TopK::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<TopK>(operands.at(0), k_, dim_, largest_,
-                                     sorted_, stable_);
+  return torch_xla::MakeNode<TopK>(operands.at(0), k_, dim_, largest_, sorted_,
+                                   stable_);
 }
 
 XlaOpVector TopK::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/tpu_custom_call.cpp
+++ b/torch_xla/csrc/ops/tpu_custom_call.cpp
@@ -15,7 +15,7 @@ TpuCustomCall::TpuCustomCall(torch::lazy::OpList inputs,
       payload_(payload) {}
 
 torch::lazy::NodePtr TpuCustomCall::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<TpuCustomCall>(operands, xla_shape(), payload_);
+  return torch_xla::MakeNode<TpuCustomCall>(operands, xla_shape(), payload_);
 }
 
 XlaOpVector TpuCustomCall::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/triangular_solve.cpp
+++ b/torch_xla/csrc/ops/triangular_solve.cpp
@@ -88,9 +88,9 @@ TriangularSolve::TriangularSolve(const torch::lazy::Value& rhs,
 
 torch::lazy::NodePtr TriangularSolve::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<TriangularSolve>(operands.at(0), operands.at(1),
-                                                left_side_, lower_, transpose_,
-                                                unit_diagonal_);
+  return torch_xla::MakeNode<TriangularSolve>(operands.at(0), operands.at(1),
+                                              left_side_, lower_, transpose_,
+                                              unit_diagonal_);
 }
 
 XlaOpVector TriangularSolve::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/uniform.cpp
+++ b/torch_xla/csrc/ops/uniform.cpp
@@ -15,8 +15,8 @@ Uniform::Uniform(const torch::lazy::Value& from, const torch::lazy::Value& to,
               /*num_outputs=*/1, torch::lazy::Hash(rng_shape)) {}
 
 torch::lazy::NodePtr Uniform::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Uniform>(operands.at(0), operands.at(1),
-                                        operands.at(2), xla_shape());
+  return torch_xla::MakeNode<Uniform>(operands.at(0), operands.at(1),
+                                      operands.at(2), xla_shape());
 }
 
 XlaOpVector Uniform::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/unselect.cpp
+++ b/torch_xla/csrc/ops/unselect.cpp
@@ -20,8 +20,8 @@ Unselect::Unselect(const torch::lazy::Value& target,
       stride_(stride) {}
 
 torch::lazy::NodePtr Unselect::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Unselect>(operands.at(0), operands.at(1), dim_,
-                                         start_, end_, stride_);
+  return torch_xla::MakeNode<Unselect>(operands.at(0), operands.at(1), dim_,
+                                       start_, end_, stride_);
 }
 
 XlaOpVector Unselect::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/unsqueeze.cpp
+++ b/torch_xla/csrc/ops/unsqueeze.cpp
@@ -22,7 +22,7 @@ Unsqueeze::Unsqueeze(const torch::lazy::Value& input, int dim)
       dim_(dim) {}
 
 torch::lazy::NodePtr Unsqueeze::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Unsqueeze>(operands.at(0), dim_);
+  return torch_xla::MakeNode<Unsqueeze>(operands.at(0), dim_);
 }
 
 XlaOpVector Unsqueeze::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/update_slice.cpp
+++ b/torch_xla/csrc/ops/update_slice.cpp
@@ -33,8 +33,8 @@ UpdateSlice::UpdateSlice(const torch::lazy::Value& input,
       base_indices_(base_indices.begin(), base_indices.end()) {}
 
 torch::lazy::NodePtr UpdateSlice::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<UpdateSlice>(operands.at(0), operands.at(1),
-                                            base_indices_);
+  return torch_xla::MakeNode<UpdateSlice>(operands.at(0), operands.at(1),
+                                          base_indices_);
 }
 
 XlaOpVector UpdateSlice::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/upsample_bilinear2d.cpp
+++ b/torch_xla/csrc/ops/upsample_bilinear2d.cpp
@@ -22,8 +22,8 @@ UpsampleBilinear::UpsampleBilinear(const torch::lazy::Value& input,
 
 torch::lazy::NodePtr UpsampleBilinear::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<UpsampleBilinear>(operands.at(0), output_size_,
-                                                 align_corners_);
+  return torch_xla::MakeNode<UpsampleBilinear>(operands.at(0), output_size_,
+                                               align_corners_);
 }
 
 XlaOpVector UpsampleBilinear::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/upsample_bilinear2d_backward.cpp
+++ b/torch_xla/csrc/ops/upsample_bilinear2d_backward.cpp
@@ -24,7 +24,7 @@ UpsampleBilinearBackward::UpsampleBilinearBackward(
 
 torch::lazy::NodePtr UpsampleBilinearBackward::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<UpsampleBilinearBackward>(
+  return torch_xla::MakeNode<UpsampleBilinearBackward>(
       operands.at(0), output_size_, input_size_, align_corners_);
 }
 

--- a/torch_xla/csrc/ops/upsample_nearest2d.cpp
+++ b/torch_xla/csrc/ops/upsample_nearest2d.cpp
@@ -20,7 +20,7 @@ UpsampleNearest::UpsampleNearest(const torch::lazy::Value& input,
 
 torch::lazy::NodePtr UpsampleNearest::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<UpsampleNearest>(operands.at(0), output_size_);
+  return torch_xla::MakeNode<UpsampleNearest>(operands.at(0), output_size_);
 }
 
 XlaOpVector UpsampleNearest::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/upsample_nearest2d_backward.cpp
+++ b/torch_xla/csrc/ops/upsample_nearest2d_backward.cpp
@@ -22,7 +22,7 @@ UpsampleNearestBackward::UpsampleNearestBackward(
 
 torch::lazy::NodePtr UpsampleNearestBackward::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<UpsampleNearestBackward>(
+  return torch_xla::MakeNode<UpsampleNearestBackward>(
       operands.at(0), output_size_, input_size_);
 }
 

--- a/torch_xla/csrc/ops/user_computation.cpp
+++ b/torch_xla/csrc/ops/user_computation.cpp
@@ -22,7 +22,7 @@ UserComputation::UserComputation(
 
 torch::lazy::NodePtr UserComputation::Clone(
     torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<UserComputation>(op(), operands, computation_);
+  return torch_xla::MakeNode<UserComputation>(op(), operands, computation_);
 }
 
 XlaOpVector UserComputation::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/var.cpp
+++ b/torch_xla/csrc/ops/var.cpp
@@ -37,8 +37,8 @@ Var::Var(const torch::lazy::Value& input, std::vector<int64_t> dimensions,
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
 torch::lazy::NodePtr Var::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<Var>(operands.at(0), dimensions_, correction_,
-                                    keep_reduced_dimensions_);
+  return torch_xla::MakeNode<Var>(operands.at(0), dimensions_, correction_,
+                                  keep_reduced_dimensions_);
 }
 
 XlaOpVector Var::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/var_mean.cpp
+++ b/torch_xla/csrc/ops/var_mean.cpp
@@ -43,8 +43,8 @@ VarMean::VarMean(const torch::lazy::Value& input,
       keep_reduced_dimensions_(keep_reduced_dimensions) {}
 
 torch::lazy::NodePtr VarMean::Clone(torch::lazy::OpList operands) const {
-  return torch::lazy::MakeNode<VarMean>(operands.at(0), dimensions_,
-                                        correction_, keep_reduced_dimensions_);
+  return torch_xla::MakeNode<VarMean>(operands.at(0), dimensions_, correction_,
+                                      keep_reduced_dimensions_);
 }
 
 XlaOpVector VarMean::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -360,7 +360,7 @@ void XLATensor::SetInPlaceIrValue(torch::lazy::Value ir_value,
   auto xla_shape = shape();
   if (xla_shape.get().element_type() != GetXlaShape(ir_value).element_type()) {
     ir_value =
-        torch::lazy::MakeNode<Cast>(ir_value, xla_shape.get().element_type());
+        torch_xla::MakeNode<Cast>(ir_value, xla_shape.get().element_type());
   }
   SetIrValue(std::move(ir_value), /*inplace=*/true, delay_eager_executation);
 }
@@ -612,7 +612,7 @@ torch::lazy::Value XLATensor::MaybeCastIrValue(
   }
   if (logical_element_type &&
       RequiresRawTypeCasting(*logical_element_type, &device)) {
-    ir_value = torch::lazy::MakeNode<Cast>(ir_value, *logical_element_type);
+    ir_value = torch_xla::MakeNode<Cast>(ir_value, *logical_element_type);
   }
   return ir_value;
 }
@@ -673,7 +673,7 @@ c10::SymNode XLASymNodeImpl::add(const c10::SymNode& other) {
   auto p_other = dynamic_cast<XLASymNodeImpl*>(other.get());
   XLA_CHECK(is_int()) << __FUNCTION__ << " with non-int NYI";
   XLA_CHECK(p_other->is_int()) << __FUNCTION__ << " with non-int NYI";
-  auto n_add = torch::lazy::MakeNode<SizeAdd>(node(), p_other->node());
+  auto n_add = torch_xla::MakeNode<SizeAdd>(node(), p_other->node());
   return c10::make_intrusive<XLASymNodeImpl>(n_add, PyType::INT);
 }
 
@@ -685,7 +685,7 @@ c10::SymNode XLASymNodeImpl::sub(const c10::SymNode& other) {
   XLA_CHECK(is_int()) << __FUNCTION__ << " with non-int NYI";
   XLA_CHECK(p_other->is_int()) << __FUNCTION__ << " with non-int NYI";
   torch::lazy::NodePtr n_sub =
-      torch::lazy::MakeNode<SizeSub>(node(), p_other->node());
+      torch_xla::MakeNode<SizeSub>(node(), p_other->node());
   return c10::make_intrusive<XLASymNodeImpl>(n_sub, PyType::INT);
 }
 
@@ -693,8 +693,7 @@ c10::SymNode XLASymNodeImpl::mul(const c10::SymNode& other) {
   auto p_other = dynamic_cast<XLASymNodeImpl*>(other.get());
   XLA_CHECK(is_int()) << __FUNCTION__ << " with non-int NYI";
   XLA_CHECK(p_other->is_int()) << __FUNCTION__ << " with non-int NYI";
-  auto n_mul =
-      torch::lazy::MakeNode<torch_xla::SizeMul>(node(), p_other->node());
+  auto n_mul = torch_xla::MakeNode<torch_xla::SizeMul>(node(), p_other->node());
   return c10::make_intrusive<XLASymNodeImpl>(n_mul, PyType::INT);
 }
 
@@ -712,7 +711,7 @@ c10::SymNode XLASymNodeImpl::floordiv(const c10::SymNode& other) {
   auto p_other = dynamic_cast<XLASymNodeImpl*>(other.get());
   XLA_CHECK(is_int()) << __FUNCTION__ << " with non-int NYI";
   XLA_CHECK(p_other->is_int()) << __FUNCTION__ << " with non-int NYI";
-  auto n_div = torch::lazy::MakeNode<SizeDiv>(node(), p_other->node());
+  auto n_div = torch_xla::MakeNode<SizeDiv>(node(), p_other->node());
   return c10::make_intrusive<XLASymNodeImpl>(n_div, PyType::INT);
 }
 
@@ -723,7 +722,7 @@ c10::SymNode XLASymNodeImpl::mod(const c10::SymNode& other) {
   XLA_CHECK(is_int()) << __FUNCTION__ << " with non-int NYI";
   XLA_CHECK(p_other->is_int()) << __FUNCTION__ << " with non-int NYI";
   torch::lazy::NodePtr n_mod =
-      torch::lazy::MakeNode<SizeMod>(node(), p_other->node());
+      torch_xla::MakeNode<SizeMod>(node(), p_other->node());
   return c10::make_intrusive<XLASymNodeImpl>(n_mod, PyType::INT);
 }
 
@@ -731,7 +730,7 @@ c10::SymNode XLASymNodeImpl::eq(const c10::SymNode& other) {
   auto p_other = dynamic_cast<XLASymNodeImpl*>(other.get());
   XLA_CHECK(is_int()) << __FUNCTION__ << " with non-int NYI";
   XLA_CHECK(p_other->is_int()) << __FUNCTION__ << " with non-int NYI";
-  auto n_eq = torch::lazy::MakeNode<SizeEq>(node(), p_other->node());
+  auto n_eq = torch_xla::MakeNode<SizeEq>(node(), p_other->node());
   return c10::make_intrusive<XLASymNodeImpl>(n_eq, PyType::BOOL);
 }
 
@@ -740,7 +739,7 @@ c10::SymNode XLASymNodeImpl::ne(const c10::SymNode& other) {
   auto p_other = dynamic_cast<XLASymNodeImpl*>(other.get());
   XLA_CHECK(is_int()) << __FUNCTION__ << " with non-int NYI";
   XLA_CHECK(p_other->is_int()) << __FUNCTION__ << " with non-int NYI";
-  auto n_ne = torch::lazy::MakeNode<SizeNe>(node(), p_other->node());
+  auto n_ne = torch_xla::MakeNode<SizeNe>(node(), p_other->node());
   return c10::make_intrusive<XLASymNodeImpl>(n_ne, PyType::BOOL);
 }
 
@@ -749,7 +748,7 @@ c10::SymNode XLASymNodeImpl::gt(const c10::SymNode& other) {
   auto p_other = dynamic_cast<XLASymNodeImpl*>(other.get());
   XLA_CHECK(is_int()) << __FUNCTION__ << " with non-int NYI";
   XLA_CHECK(p_other->is_int()) << __FUNCTION__ << " with non-int NYI";
-  auto n_gt = torch::lazy::MakeNode<SizeGt>(node(), p_other->node());
+  auto n_gt = torch_xla::MakeNode<SizeGt>(node(), p_other->node());
   return c10::make_intrusive<XLASymNodeImpl>(n_gt, PyType::BOOL);
 }
 
@@ -758,7 +757,7 @@ c10::SymNode XLASymNodeImpl::lt(const c10::SymNode& other) {
   auto p_other = dynamic_cast<XLASymNodeImpl*>(other.get());
   XLA_CHECK(is_int()) << __FUNCTION__ << " with non-int NYI";
   XLA_CHECK(p_other->is_int()) << __FUNCTION__ << " with non-int NYI";
-  auto n_lt = torch::lazy::MakeNode<SizeLt>(node(), p_other->node());
+  auto n_lt = torch_xla::MakeNode<SizeLt>(node(), p_other->node());
   return c10::make_intrusive<XLASymNodeImpl>(n_lt, PyType::BOOL);
 }
 
@@ -772,7 +771,7 @@ c10::SymNode XLASymNodeImpl::ge(const c10::SymNode& other) {
   auto p_other = dynamic_cast<XLASymNodeImpl*>(other.get());
   XLA_CHECK(is_int()) << __FUNCTION__ << " with non-int NYI";
   XLA_CHECK(p_other->is_int()) << __FUNCTION__ << " with non-int NYI";
-  auto n_ge = torch::lazy::MakeNode<SizeGe>(node(), p_other->node());
+  auto n_ge = torch_xla::MakeNode<SizeGe>(node(), p_other->node());
   return c10::make_intrusive<XLASymNodeImpl>(n_ge, PyType::BOOL);
 }
 
@@ -806,20 +805,20 @@ c10::SymNode XLASymNodeImpl::sym_max(const c10::SymNode& other) {
 c10::SymNode XLASymNodeImpl::sym_or(const c10::SymNode& other) {
   auto a =
       guard_bool(__FILE__, __LINE__) || other->guard_bool(__FILE__, __LINE__);
-  auto cnst = torch::lazy::MakeNode<SizeConstant>(a);
+  auto cnst = torch_xla::MakeNode<SizeConstant>(a);
   return c10::make_intrusive<XLASymNodeImpl>(cnst, PyType::BOOL);
 }
 
 c10::SymNode XLASymNodeImpl::sym_and(const c10::SymNode& other) {
   auto a =
       guard_bool(__FILE__, __LINE__) && other->guard_bool(__FILE__, __LINE__);
-  auto cnst = torch::lazy::MakeNode<SizeConstant>(a);
+  auto cnst = torch_xla::MakeNode<SizeConstant>(a);
   return c10::make_intrusive<XLASymNodeImpl>(cnst, PyType::BOOL);
 }
 
 c10::SymNode XLASymNodeImpl::sym_not() {
   auto a = !guard_bool(__FILE__, __LINE__);
-  auto cnst = torch::lazy::MakeNode<SizeConstant>(a);
+  auto cnst = torch_xla::MakeNode<SizeConstant>(a);
   return c10::make_intrusive<XLASymNodeImpl>(cnst, PyType::BOOL);
 }
 
@@ -855,7 +854,7 @@ c10::SymNode XLASymNodeImpl::is_channels_last_strides_3d(
 // them to error only if poked.
 c10::SymNode XLASymNodeImpl::is_non_overlapping_and_dense(
     at::ArrayRef<c10::SymNode> sizes, at::ArrayRef<c10::SymNode> strides) {
-  auto error_node = torch::lazy::MakeNode<SizeError>();
+  auto error_node = torch_xla::MakeNode<SizeError>();
   return c10::make_intrusive<XLASymNodeImpl>(error_node, PyType::BOOL);
 }
 
@@ -870,7 +869,7 @@ c10::SymNode XLASymNodeImpl::sym_float() {
 }
 
 c10::SymNode XLASymNodeImpl::wrap_int(int64_t num) {
-  auto cnst = torch::lazy::MakeNode<SizeConstant>(num);
+  auto cnst = torch_xla::MakeNode<SizeConstant>(num);
   return c10::make_intrusive<XLASymNodeImpl>(cnst, PyType::INT);
 }
 
@@ -880,7 +879,7 @@ c10::SymNode XLASymNodeImpl::wrap_float(double num) {
 }
 
 c10::SymNode XLASymNodeImpl::wrap_bool(bool num) {
-  auto cnst = torch::lazy::MakeNode<SizeConstant>(num);
+  auto cnst = torch_xla::MakeNode<SizeConstant>(num);
   return c10::make_intrusive<XLASymNodeImpl>(cnst, PyType::BOOL);
 }
 

--- a/torch_xla/csrc/view.cpp
+++ b/torch_xla/csrc/view.cpp
@@ -31,33 +31,33 @@ torch::lazy::Value ApplyViewInfo(torch::lazy::Value ir_value,
                                  const ViewInfo& view_info) {
   switch (view_info.view_type) {
     case ViewInfo::Type::kSelect:
-      return torch::lazy::MakeNode<Select>(
+      return torch_xla::MakeNode<Select>(
           ir_value, view_info.select->dim, view_info.select->start,
           view_info.select->end, view_info.select->stride);
     case ViewInfo::Type::kNarrow:
-      return torch::lazy::MakeNode<GenericSlice>(ir_value, view_info.indices,
-                                                 view_info.shape.dimensions());
+      return torch_xla::MakeNode<GenericSlice>(ir_value, view_info.indices,
+                                               view_info.shape.dimensions());
     case ViewInfo::Type::kNoOp:
       return ir_value;
     case ViewInfo::Type::kPermute:
-      return torch::lazy::MakeNode<Permute>(ir_value, view_info.permutation);
+      return torch_xla::MakeNode<Permute>(ir_value, view_info.permutation);
     case ViewInfo::Type::kReshape:
-      return torch::lazy::MakeNode<ViewOp>(
+      return torch_xla::MakeNode<ViewOp>(
           ir_value,
           torch::lazy::ToVector<int64_t>(view_info.shape.dimensions()));
     case ViewInfo::Type::kResize:
-      return torch::lazy::MakeNode<Resize>(
+      return torch_xla::MakeNode<Resize>(
           ir_value,
           torch::lazy::ToVector<int64_t>(view_info.shape.dimensions()));
     case ViewInfo::Type::kAsStrided:
-      return torch::lazy::MakeNode<AsStrided>(
+      return torch_xla::MakeNode<AsStrided>(
           ir_value,
           torch::lazy::ToVector<int64_t>(view_info.shape.dimensions()),
           view_info.as_strided->stride, view_info.as_strided->offset);
     case ViewInfo::Type::kDiagonal:
-      return torch::lazy::MakeNode<Diagonal>(
-          ir_value, view_info.diagonal->offset, view_info.diagonal->dim1,
-          view_info.diagonal->dim2);
+      return torch_xla::MakeNode<Diagonal>(ir_value, view_info.diagonal->offset,
+                                           view_info.diagonal->dim1,
+                                           view_info.diagonal->dim2);
     default:
       XLA_ERROR() << "Invalid view type: "
                   << torch::lazy::GetEnumValue(view_info.view_type);
@@ -79,39 +79,39 @@ torch::lazy::Value ApplyUpdate(torch::lazy::Value ir_value,
     const ViewInfo& view_info = update_data.view_infos[i - 1];
     switch (view_info.view_type) {
       case ViewInfo::Type::kSelect:
-        result = torch::lazy::MakeNode<Unselect>(
+        result = torch_xla::MakeNode<Unselect>(
             tmp_values[i - 1], result, view_info.select->dim,
             view_info.select->start, view_info.select->end,
             view_info.select->stride);
         break;
       case ViewInfo::Type::kNarrow:
-        result = torch::lazy::MakeNode<UpdateSlice>(tmp_values[i - 1], result,
-                                                    view_info.indices);
+        result = torch_xla::MakeNode<UpdateSlice>(tmp_values[i - 1], result,
+                                                  view_info.indices);
         break;
       case ViewInfo::Type::kNoOp:
         break;
       case ViewInfo::Type::kPermute:
-        result = torch::lazy::MakeNode<Permute>(
+        result = torch_xla::MakeNode<Permute>(
             result, xla::InversePermutation(view_info.permutation));
         break;
       case ViewInfo::Type::kReshape:
-        result = torch::lazy::MakeNode<ViewOp>(
+        result = torch_xla::MakeNode<ViewOp>(
             result, torch::lazy::ToVector<int64_t>(
                         view_info.source_shape.dimensions()));
         break;
       case ViewInfo::Type::kResize:
-        result = torch::lazy::MakeNode<Resize>(
+        result = torch_xla::MakeNode<Resize>(
             result, torch::lazy::ToVector<int64_t>(
                         view_info.source_shape.dimensions()));
         break;
       case ViewInfo::Type::kAsStrided:
-        result = torch::lazy::MakeNode<AsStridedViewUpdate>(
+        result = torch_xla::MakeNode<AsStridedViewUpdate>(
             tmp_values[i - 1], result,
             torch::lazy::ToVector<int64_t>(view_info.source_shape.dimensions()),
             view_info.as_strided->stride, view_info.as_strided->offset);
         break;
       case ViewInfo::Type::kDiagonal:
-        result = torch::lazy::MakeNode<DiagonalViewUpdate>(
+        result = torch_xla::MakeNode<DiagonalViewUpdate>(
             tmp_values[i - 1], result, view_info.diagonal->offset,
             view_info.diagonal->dim1, view_info.diagonal->dim2);
         break;

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -70,7 +70,7 @@ torch::lazy::Value IrValueFromScalar(const at::Scalar& value,
                                      const torch::lazy::BackendDevice& device) {
   at::Tensor tensor = at::scalar_tensor(value, at::TensorOptions(scalar_type));
   torch::lazy::BackendDataPtr device_data = TensorToXlaData(tensor, device);
-  return torch::lazy::MakeNode<DeviceData>(std::move(device_data));
+  return torch_xla::MakeNode<DeviceData>(std::move(device_data));
 }
 
 bool ShouldSyncIrValue(const torch::lazy::Value& ir_value) {
@@ -183,7 +183,7 @@ XLAGraphExecutor::DeviceContextArena::GetBaseSeedData(
   at::Tensor tensor = at::scalar_tensor(MakeIntScalar(devctx->seed),
                                         at::TensorOptions(kSeedType));
   torch::lazy::BackendDataPtr device_data = TensorToXlaData(tensor, device);
-  devctx->seed_ir_value = torch::lazy::MakeNode<DeviceData>(device_data);
+  devctx->seed_ir_value = torch_xla::MakeNode<DeviceData>(device_data);
   devctx->running_seed = devctx->seed;
   return torch_xla::DeviceData::Cast(devctx->seed_ir_value.node.get())->data();
 }
@@ -236,7 +236,7 @@ torch::lazy::Value XLAGraphExecutor::DeviceContextArena::IrValueFromScalar(
     const torch::lazy::BackendDevice& device) {
   at::Tensor tensor = at::scalar_tensor(value, at::TensorOptions(scalar_type));
   torch::lazy::BackendDataPtr device_data = TensorToXlaData(tensor, device);
-  return torch::lazy::MakeNode<DeviceData>(std::move(device_data));
+  return torch_xla::MakeNode<DeviceData>(std::move(device_data));
 }
 
 XLAGraphExecutor::Async::Async(
@@ -276,7 +276,7 @@ torch::lazy::Value XLAGraphExecutor::GetDeviceDataIrValue(
   data->SetInfo(
       std::make_shared<torch::lazy::LazyGraphExecutor::DeviceDataInfo>(
           /*tensor_id=*/-1, /*read_only=*/true));
-  return torch::lazy::MakeNode<DeviceData>(std::move(data));
+  return torch_xla::MakeNode<DeviceData>(std::move(data));
 }
 
 torch::lazy::Value XLAGraphExecutor::GetIrValueForScalar(
@@ -300,7 +300,7 @@ torch::lazy::Value XLAGraphExecutor::GetIrValueForScalar(
     const torch::lazy::BackendDevice& device) {
   torch::lazy::Value ir_value = GetIrValueForScalar(value, type, device);
   if (!dimensions.empty()) {
-    ir_value = torch::lazy::MakeNode<Expand>(
+    ir_value = torch_xla::MakeNode<Expand>(
         ir_value, torch::lazy::ToVector<int64_t>(dimensions));
   }
   return ir_value;
@@ -311,7 +311,7 @@ torch::lazy::Value XLAGraphExecutor::GetIrValueForScalar(
     c10::SymIntArrayRef sym_size, const torch::lazy::BackendDevice& device) {
   torch::lazy::Value ir_value = GetIrValueForScalar(value, type, device);
   SymIntElements size_elements = SymIntElements(sym_size);
-  return torch::lazy::MakeNode<ExpandSymInt>(ir_value, size_elements);
+  return torch_xla::MakeNode<ExpandSymInt>(ir_value, size_elements);
 }
 
 torch::lazy::Value XLAGraphExecutor::GetIrValueForScalar(
@@ -343,7 +343,7 @@ torch::lazy::Value XLAGraphExecutor::GetIrValueForScalar(
           : shape.element_type();
   torch::lazy::Value ir_value =
       GetIrValueForScalar(value, primitive_type, device);
-  return torch::lazy::MakeNode<ExpandSymInt>(ir_value, size_elements);
+  return torch_xla::MakeNode<ExpandSymInt>(ir_value, size_elements);
 }
 
 torch::lazy::Value XLAGraphExecutor::GetRngSeed(


### PR DESCRIPTION
I am trying to implement the dynamic shape detection within a `torch_xla.compile` region, in order to do that I need to do some special handling after every IR Node is being created.

My first thought is to add this logic in `XlaNode` constructor but soon realize this will not work too well because
```
Permute::Permute(const torch::lazy::Value& input, std::vector<int64_t> dims)
    : XlaNode(
          torch::lazy::OpKind(at::aten::permute), {input},
          [&]() { return NodeOutputShape(input, dims); },
          /*num_outputs=*/1, torch::lazy::MHash(dims)),
      dims_(std::move(dims)) {}

torch::lazy::NodePtr Permute::Clone(torch::lazy::OpList operands) const {
  return torch::lazy::MakeNode<Permute>(operands.at(0), dims_);
}
```

XlaNode constructor will be called before the child class fully initialized. If I do `this->ToString()` it will actually call the parent class's ToString which is a bit annoying.

In this pr I replaced `torch::lazy::MakeNode` with the `torch_xla::MakeNode` so I can inject my debugging logic there.