### PR TITLE
Add F8E4M3FN support

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -150,6 +150,7 @@ function run_xla_op_tests {
   run_test "$CDIR/test_ops.py"
   run_test "$CDIR/test_metrics.py"
   run_test "$CDIR/test_zero1.py"
+  run_test "$CDIR/test_fp8.py"
   run_test "$CDIR/dynamo/test_dynamo_integrations_util.py"
   run_test "$CDIR/dynamo/test_dynamo.py"
   run_test "$CDIR/dynamo/test_bridge.py"

--- a/test/test_data_type.py
+++ b/test/test_data_type.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import torch
 import torch_xla

--- a/test/test_fp8.py
+++ b/test/test_fp8.py
@@ -1,0 +1,14 @@
+import unittest
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+
+class XlaDataTypeTest(unittest.TestCase):
+    def test_datatype_fp8e4m3fn(self):
+        t1 = torch.tensor([1.0, 2.0, 3.0], device=xm.xla_device())
+        t2 = torch.tensor([2.0, 3.0, 4.0], device=xm.xla_device())
+        t1 = t1.to(torch.float8_e4m3fn)
+        t2 = t2.to(torch.float8_e4m3fn)
+    
+        assert t1.dtype == torch.float8_e4m3fn
+        assert t2.dtype == torch.float8_e4m3fn

--- a/test/test_fp8.py
+++ b/test/test_fp8.py
@@ -3,12 +3,14 @@ import torch
 import torch_xla
 import torch_xla.core.xla_model as xm
 
+
 class XlaDataTypeTest(unittest.TestCase):
-    def test_datatype_fp8e4m3fn(self):
-        t1 = torch.tensor([1.0, 2.0, 3.0], device=xm.xla_device())
-        t2 = torch.tensor([2.0, 3.0, 4.0], device=xm.xla_device())
-        t1 = t1.to(torch.float8_e4m3fn)
-        t2 = t2.to(torch.float8_e4m3fn)
-    
-        assert t1.dtype == torch.float8_e4m3fn
-        assert t2.dtype == torch.float8_e4m3fn
+
+  def test_datatype_fp8e4m3fn(self):
+    t1 = torch.tensor([1.0, 2.0, 3.0], device=xm.xla_device())
+    t2 = torch.tensor([2.0, 3.0, 4.0], device=xm.xla_device())
+    t1 = t1.to(torch.float8_e4m3fn)
+    t2 = t2.to(torch.float8_e4m3fn)
+
+    assert t1.dtype == torch.float8_e4m3fn
+    assert t2.dtype == torch.float8_e4m3fn

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -143,6 +143,8 @@ xla::PrimitiveType XlaTypeFromTensorType(
       return xla::PrimitiveType::C64;
     case at::ScalarType::ComplexDouble:
       return xla::PrimitiveType::C128;
+    case at::ScalarType::Float8_e4m3fn:
+      return xla::PrimitiveType::F8E4M3FN;
     default:
       XLA_ERROR() << "Type not supported: " << scalar_type;
   }
@@ -1105,6 +1107,8 @@ at::ScalarType TensorTypeFromXlaType(xla::PrimitiveType xla_type) {
       return at::ScalarType::ComplexFloat;
     case xla::PrimitiveType::C128:
       return at::ScalarType::ComplexDouble;
+    case xla::PrimitiveType::F8E4M3FN:
+      return at::ScalarType::Float8_e4m3fn;
     default:
       XLA_ERROR() << "XLA type not supported: " << xla_type;
   }
@@ -1136,6 +1140,8 @@ xla::PrimitiveType TensorTypeToRawXlaType(at::ScalarType scalar_type) {
       return xla::PrimitiveType::C64;
     case at::ScalarType::ComplexDouble:
       return xla::PrimitiveType::C128;
+    case at::ScalarType::Float8_e4m3fn:
+      return xla::PrimitiveType::F8E4M3FN;
     default:
       XLA_ERROR() << "Type not supported: " << scalar_type;
   }
@@ -1212,6 +1218,8 @@ xla::PrimitiveType MakeXlaPrimitiveType(
       return GetDevicePrimitiveType(xla::PrimitiveType::C64, device);
     case at::ScalarType::ComplexDouble:
       return GetDevicePrimitiveType(xla::PrimitiveType::C128, device);
+    case at::ScalarType::Float8_e4m3fn:
+      return GetDevicePrimitiveType(xla::PrimitiveType::F8E4M3FN, device);
     default:
       XLA_ERROR() << "Type not supported: " << scalar_type;
   }


### PR DESCRIPTION
Add FP8 data type to torch_xla. 

### Notes

Prior to this change, the following code returns a `Type not supported` error: 
```
import torch
import torch_xla
import torch_xla.core.xla_model as xm
device = xm.xla_device()
example = torch.tensor([1.0, 2.0, 3.0, 4.0], device=device)
example = example.to(torch.float8_e4m3fn)
```

This change ensures that torch xla can process conversion to `float8_e4m3fn`

### Testing

1. Added unit tests.
2. Performed a manual test in Trn1 instance 
    1. Update the xla_git_rev in the package `KaenaTorchXlaBaseDockerImage (branch -> pt2.1)` 
    2. Ran the Dockerfile on Trn1 instance and tested that the above code snippet doesn't cause an error