### PR TITLE
Remove stale `cloud-tpu-client` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -290,7 +290,7 @@ setup(
     ],
     install_requires=[
         'absl-py>=1.0.0',
-        'cloud-tpu-client>=0.10.0',
+        'numpy',
         'pyyaml',
         # importlib.metadata backport required for PJRT plugin discovery prior
         # to Python 3.10


### PR DESCRIPTION
Removing `cloud-tpu-client` since we only used this for 2VM code (thanks @sagelywizard for catching this).

Adding explicit `numpy` dep because we import it all over the place.