### PR TITLE
Use local TPU log dir in CI

### DIFF
--- a/.github/workflows/_tpu_ci.yml
+++ b/.github/workflows/_tpu_ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run Tests
         env:
           PJRT_DEVICE: TPU
+          TPU_LOG_DIR: tpu_logs
         run: |
-          sudo chmod 777 /tmp/tpu_logs
           cd pytorch/xla
           test/tpu/run_tests.sh

--- a/.github/workflows/_tpu_ci.yml
+++ b/.github/workflows/_tpu_ci.yml
@@ -29,5 +29,6 @@ jobs:
         env:
           PJRT_DEVICE: TPU
         run: |
+          sudo chmod 777 /tmp/tpu_logs
           cd pytorch/xla
           test/tpu/run_tests.sh


### PR DESCRIPTION
Hopefully fixes this log spam: `Could not open the log file '/tmp/tpu_logs/tpu_driver.v4-runner-set-7q76q-runner-ndh9h.runner.log.INFO.20240806-180726.2021': Permission denied`