### PR TITLE
Initial pr to support dynamic shape detection

### DIFF
--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2447,6 +2447,11 @@ void InitXlaModuleBindings(py::module m) {
   });
   m.def("_get_current_graph_name",
         []() { return XLAGraphExecutor::Get()->CurrentGraphName(); });
+  m.def("_start_ds_detector_session", [](std::string name) {
+    DynamicShapeDetector::Get()->SetSessionName(name);
+  });
+  m.def("_end_ds_detector_session",
+        []() { return DynamicShapeDetector::Get()->EndSession(); });
   m.def("_replace_xla_tensor",
         [](at::Tensor& self, const at::Tensor& source) -> at::Tensor& {
           return XLANativeFunctions::set_(self, source);


### PR DESCRIPTION
The implementation in this pr is not ideal because it can only handle a single graph for a compiled program. This is usually too strict for the real world program because in training we usually at least have 2 graphs since in the step0 the optimizer state is not initialized. 

I think what I need to do next is to provide a `max_dynamic_graph_allowed` arguments and use a TRIE to keep tracked of all the IR being generated and when they diverage.