### PR TITLE
Fix input output alias for custom inplace ops

### DIFF
--- a/test/test_input_output_aliases.py
+++ b/test/test_input_output_aliases.py
@@ -41,6 +41,18 @@ class InputOutputAliasesTest(unittest.TestCase):
     torch.allclose(t1 - 1, t1_cloned)
     self.assertEqual(met.metric_data("InputOutputAliasCount")[1], 1.0)
 
+  def test_aliasing_across_custom_inplace(self):
+    xla_device = xm.xla_device()
+    met.clear_all()
+    t1 = torch.randn(4, 5).to(xla_device)
+    t1 *= t1
+    xm.mark_step()
+    self.assertEqual(met.metric_data("InputOutputAliasCount")[1], 1.0)
+    xm.optimization_barrier_([t1])
+    t1 *= 100
+    xm.mark_step()
+    self.assertEqual(met.metric_data("InputOutputAliasCount")[1], 2.0)
+
   def test_aliasing_across_mark_step(self):
     xla_device = xm.xla_device()
     met.clear_all()

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -387,6 +387,10 @@ torch::lazy::Value XLATensor::GetIrValue() const {
     // which wants the XLA data will still find it, w/out having to fetch it
     // via a computation client from-server call.
     AssignIrValue(CreateTensorNode(handle, /*read_only=*/false));
+    // CreateTensorNode will set the data info of the tensor to the current
+    // unique_id. Here the alias id needs to be updated so that input output
+    // alias can correctly work on the xla's custom inplace operation.
+    data()->alias_id = GetUniqueId();
     return data()->ir_value;
   }
   std::optional<at::Tensor> tensor_data = CurrentTensorData();


### PR DESCRIPTION
Fix the issue where the input output alias does not work when using custom inplace operations such as `xm.optimization_barrier_`. This issue mainly arises from custom inplace operations not updating the alias id with `_propagate_xla_data`, so it still uses the outdated alias id. This issue is very common in FSDP and can result in param not being alias.

Consider the case without this pr
```
t1 = torch.randn(4, 5).to(xla_device)  # Tensor ID 2, alias ID 2
t1 *= t1  # Tensor ID 3, alias ID 2
xm.mark_step()
xm.optimization_barrier_([t1]) # Tensor ID 3, alias ID 2
t1 *= 100 # Tensor ID 4, alias ID 2
```
In the second graph, the t1 cannot be aliased because the tensor id of t1 is 3, not 2.


with this pr
```
t1 = torch.randn(4, 5).to(xla_device)  # Tensor ID 2, alias ID 2
t1 *= t1  # Tensor ID 3, alias ID 2
xm.mark_step()
xm.optimization_barrier_([t1]) # Tensor ID 3, alias ID 3
t1 *= 100 # Tensor ID 4, alias ID 3
```
In the second graph, the t1 can be aliased because the output alias id and input tensor id of t1 are both 3.

https://github.com/pytorch/xla/blob/9fbd64acca5e831e9e51fdd0eec2bfbf5380a33c/torch_xla/csrc/xla_graph_executor.cpp#L1258-L1282. 
