### PR TITLE
Add fp8e4m3fn support

### DIFF
--- a/test/test_fp8.py
+++ b/test/test_fp8.py
@@ -4,46 +4,53 @@ import re
 import torch
 import torch_xla
 import unittest
+from absl.testing import parameterized
+
+device = torch_xla.device()
+
+dtype_parameters = [
+    torch.float8_e5m2,
+    torch.float8_e4m3fn,
+]
 
 
-class Fp8Test(unittest.TestCase):
+class Fp8Test(parameterized.TestCase):
 
-  def test_fp8(self):
-    device = torch_xla.device()
-    fp8_types = [torch.float8_e5m2]
-    for dtype in fp8_types:
-      t = torch.rand(2, 2).to(dtype)
-      xla_t = t.to(device)
-      torch_t = xla_t.cpu()
-      self.assertEqual(xla_t.dtype, dtype)
-      self.assertEqual(torch_t.dtype, dtype)
-      # Need to cast to float32 since allclose doesn't work with fp8.
-      self.assertTrue(
-          torch.allclose(t.to(torch.float32), torch_t.to(torch.float32)))
+  @parameterized.parameters(*dtype_parameters)
+  def test_fp8(self, dtype):
+    t = torch.rand(2, 2).to(dtype)
+    xla_t = t.to(device)
+    torch_t = xla_t.cpu()
+    self.assertEqual(xla_t.dtype, dtype)
+    self.assertEqual(torch_t.dtype, dtype)
+    # Need to cast to float32 since allclose doesn't work with fp8.
+    self.assertTrue(
+        torch.allclose(t.to(torch.float32), torch_t.to(torch.float32)))
 
-  def test_fp8_matmul(self):
-    device = torch_xla.device()
-    fp8_types = [torch.float8_e5m2]
-    for dtype in fp8_types:
-      t = torch.rand(3, 2).to(dtype)
-      w = torch.rand(2, 5).to(dtype)
-      torch_matmul = torch.matmul(t, w)
-      xla_t = t.to(device)
-      xla_w = w.to(device)
-      xla_matmul = torch.matmul(xla_t, xla_w)
-      xla_matmul = xla_matmul.cpu()
-      # Need to cast to float32 since allclose doesn't work with fp8.
-      self.assertTrue(
-          torch.allclose(
-              xla_matmul.to(torch.float32), torch_matmul.to(torch.float32)))
+  @parameterized.parameters(*dtype_parameters)
+  def test_fp8_matmul(self, dtype):
+    t = torch.rand(3, 2).to(dtype)
+    w = torch.rand(2, 5).to(dtype)
+    torch_matmul = torch.matmul(t, w)
+    xla_t = t.to(device)
+    xla_w = w.to(device)
+    xla_matmul = torch.matmul(xla_t, xla_w)
+    xla_matmul = xla_matmul.cpu()
+    # Need to cast to float32 since allclose doesn't work with fp8.
+    self.assertTrue(
+        torch.allclose(
+            xla_matmul.to(torch.float32), torch_matmul.to(torch.float32)))
 
-  def test_fp8_hlo(self):
-    device = torch_xla.device()
-    x = torch.randn((3, 5)).to(torch.float8_e5m2).to(device)
-    w = torch.randn((5, 8)).to(torch.float8_e5m2).to(device)
+  @parameterized.parameters(*dtype_parameters)
+  def test_fp8_hlo(self, dtype):
+    x = torch.randn((3, 5)).to(dtype).to(device)
+    w = torch.randn((5, 8)).to(dtype).to(device)
     output = torch.matmul(x, w)
     hlo = torch_xla._XLAC._get_xla_tensors_hlo([output])
-    self.assertTrue(re.search(r'f8e5m2.*dot.*f8e5m2.*f8e5m2', hlo) is not None)
+    exmy_str = str(dtype).split('_')[-1]
+    self.assertTrue(
+        re.search(rf'f8{exmy_str}.*dot.*f8{exmy_str}.*f8{exmy_str}', hlo)
+        is not None)
 
 
 if __name__ == '__main__':

--- a/torch_xla/csrc/dtype.cpp
+++ b/torch_xla/csrc/dtype.cpp
@@ -9,6 +9,8 @@ at::ScalarType TorchTypeFromXlaType(xla::PrimitiveType xla_type) {
   switch (xla_type) {
     case xla::PrimitiveType::BF16:
       return at::ScalarType::BFloat16;
+    case xla::PrimitiveType::F8E4M3FN:
+      return at::ScalarType::Float8_e4m3fn;
     case xla::PrimitiveType::F8E5M2:
       return at::ScalarType::Float8_e5m2;
     case xla::PrimitiveType::F16:
@@ -51,6 +53,8 @@ xla::PrimitiveType XlaTypeFromTorchType(at::ScalarType scalar_type) {
       return xla::PrimitiveType::BF16;
     case at::ScalarType::Half:
       return xla::PrimitiveType::F16;
+    case at::ScalarType::Float8_e4m3fn:
+      return xla::PrimitiveType::F8E4M3FN;
     case at::ScalarType::Float8_e5m2:
       return xla::PrimitiveType::F8E5M2;
     case at::ScalarType::Bool:

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -230,7 +230,6 @@ template <>
 struct NeedCast<tsl::float8_e5m2> {
   static constexpr bool value = true;
 };
-
 template <>
 struct NeedCast<at::Float8_e5m2> {
   static constexpr bool value = true;


### PR DESCRIPTION
follow up PR on https://github.com/pytorch/xla/pull/7740, add `fp8e4m3fn` support.

LLaMA 3.1 fp8 ckpt is in `fp8e4m3fn` format.

Test:
Added fp8 unit test