### PR TITLE
replace `jax.lax.convert_element_type` with `numpy.ndarray.astype`

### DIFF
--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -1577,11 +1577,11 @@ def _aten_arange(
   if dtype:
     dtype = mappings.t2j_dtype(dtype)
   if start and dtype:
-    start = start.astype(dtype) # np.ndarray.astype(start, dtype)
+    start = ((np.array([start, ])).astype(dtype))[0] # np.ndarray.astype(start, dtype)
   if end and dtype:
-    end = end.astype(dtype) # np.ndarray.astype(end, dtype)
+    end = ((np.array([end, ])).astype(dtype))[0] # np.ndarray.astype(end, dtype)
   if step and dtype:
-    step = step.astype(dtype) # np.ndarray.astype(step, dtype)
+    step = ((np.array([step, ])).astype(dtype))[0] # np.ndarray.astype(step, dtype)
   return jnp.arange(
     start,
     end,

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -1577,11 +1577,11 @@ def _aten_arange(
   if dtype:
     dtype = mappings.t2j_dtype(dtype)
   if start and dtype:
-    start = np.ndarray.astype(start, dtype)
+    start = start.astype(dtype) # np.ndarray.astype(start, dtype)
   if end and dtype:
-    end = np.ndarray.astype(end, dtype)
+    end = end.astype(dtype) # np.ndarray.astype(end, dtype)
   if step and dtype:
-    step = np.ndarray.astype(step, dtype)
+    step = step.astype(dtype) # np.ndarray.astype(step, dtype)
   return jnp.arange(
     start,
     end,

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -1577,11 +1577,11 @@ def _aten_arange(
   if dtype:
     dtype = mappings.t2j_dtype(dtype)
   if start and dtype:
-    start = jax.lax.convert_element_type(start, dtype)
+    start = np.ndarray.astype(start, dtype)
   if end and dtype:
-    end = jax.lax.convert_element_type(end, dtype)
+    end = np.ndarray.astype(end, dtype)
   if step and dtype:
-    step = jax.lax.convert_element_type(step, dtype)
+    step = np.ndarray.astype(step, dtype)
   return jnp.arange(
     start,
     end,


### PR DESCRIPTION
according to @will-cromar suggestion, replace `jax.lax.convert_element_type` with `numpy.ndarray.astype` to avoid tracer generated from `jax.lax.convert_element_type`