### PR TITLE
Pass local_world_size into neuron.initialize_env

### DIFF
--- a/torch_xla/_internal/neuron.py
+++ b/torch_xla/_internal/neuron.py
@@ -18,8 +18,9 @@ def num_local_processes() -> int:
   return num_processes
 
 
-def initialize_env(local_rank):
+def initialize_env(local_rank, local_world_size):
   os.environ["NEURON_PJRT_PROCESS_INDEX"] = str(local_rank)
+  assert (local_rank < local_world_size), "ERROR in initialize_env: PJRT_LOCAL_PROCESS_RANK is not less than PJRT_LOCAL_PROCESS_COUNT"
   os.environ["NEURON_RT_VISIBLE_CORES"] = str(local_rank)
 
 

--- a/torch_xla/_internal/neuron.py
+++ b/torch_xla/_internal/neuron.py
@@ -30,7 +30,7 @@ class NeuronPlugin(plugins.DevicePlugin):
     return os.environ.get("NEURON_LIBRARY_PATH", "libneuronpjrt.so")
 
   def configure_multiprocess(self, local_rank, local_world_size):
-    initialize_env(local_rank)
+    initialize_env(local_rank, local_world_size)
 
   def physical_chip_count(self):
     return num_local_processes()

--- a/torch_xla/_internal/neuron.py
+++ b/torch_xla/_internal/neuron.py
@@ -20,7 +20,9 @@ def num_local_processes() -> int:
 
 def initialize_env(local_rank, local_world_size):
   os.environ["NEURON_PJRT_PROCESS_INDEX"] = str(local_rank)
-  assert (local_rank < local_world_size), "ERROR in initialize_env: PJRT_LOCAL_PROCESS_RANK is not less than PJRT_LOCAL_PROCESS_COUNT"
+  assert (
+      local_rank < local_world_size
+  ), "ERROR in initialize_env: PJRT_LOCAL_PROCESS_RANK is not less than PJRT_LOCAL_PROCESS_COUNT"
   os.environ["NEURON_RT_VISIBLE_CORES"] = str(local_rank)
 
 

--- a/torch_xla/_internal/pjrt.py
+++ b/torch_xla/_internal/pjrt.py
@@ -116,7 +116,7 @@ def initialize_multiprocess(local_rank: int, local_world_size: int):
   elif runtime.device_type() == 'TPU':
     tpu.configure_topology(local_rank, local_world_size)
   elif runtime.device_type() == 'NEURON':
-    neuron.initialize_env(local_rank)
+    neuron.initialize_env(local_rank, local_world_size)
 
   devices = xm.get_xla_supported_devices()
   xm.set_replication(xm.xla_device(), devices)


### PR DESCRIPTION
Currently neuron.initialize_env doesn't know about local world size. This change would enable initialze_env to be aware of local world size so that it can check for errors and enable other checks that need world size.