### PR TITLE
Support `dist.all_gather` related collective ops

### DIFF
--- a/test/pjrt/test_collective_ops_tpu.py
+++ b/test/pjrt/test_collective_ops_tpu.py
@@ -225,7 +225,6 @@ class TestDistCollectiveOpsTpu(parameterized.TestCase):
         self._all_gather_into_tensor, use_dynamo=use_dynamo)
     w = xr.world_size()
     expected = torch.arange(w, dtype=torch.float)
-    expected = torch.tensor([0, 1, 2, 3], dtype=torch.float)
     for index, val in results.items():
       torch.allclose(val, expected)
 

--- a/test/pjrt/test_collective_ops_tpu.py
+++ b/test/pjrt/test_collective_ops_tpu.py
@@ -142,6 +142,11 @@ class TestXMCollectiveOpsTpu(parameterized.TestCase):
 # Test for collective ops from torch.distributed
 class TestDistCollectiveOpsTpu(parameterized.TestCase):
 
+  # TODO(zpcore): fix the openxla dynamo issue for inplace copy
+  @staticmethod
+  def my_compiler(gm: torch.fx.GraphModule, example_inputs: List[torch.Tensor]):
+    return gm.forward
+
   @staticmethod
   def _all_reduce(use_dynamo: bool):
     met.clear_all()

--- a/test/pjrt/test_collective_ops_tpu.py
+++ b/test/pjrt/test_collective_ops_tpu.py
@@ -233,28 +233,28 @@ class TestDistCollectiveOpsTpu(parameterized.TestCase):
     return pytree.tree_map(lambda x: x.cpu(), output)
 
   @parameterized.named_parameters(('dynamo', True), ('nondynamo', False))
-  @mock.patch.object(xr, 'world_size', return_value=tpu.num_local_processes())
-  def test_all_reduce(self, use_dynamo, mock_world_size):
+  def test_all_reduce(self, use_dynamo):
     results = pjrt.run_multiprocess(self._all_reduce, use_dynamo=use_dynamo)
-    expected = torch.tensor([sum(range(xr.world_size()))], dtype=torch.float)
+    expected = torch.tensor([sum(range(tpu.num_expected_global_devices()))],
+                            dtype=torch.float)
     for index, val in results.items():
       torch.testing.assert_close(val, expected)
 
   @parameterized.named_parameters(('dynamo', True), ('nondynamo', False))
-  @mock.patch.object(xr, 'world_size', return_value=tpu.num_local_processes())
-  def test_all_gather_into_tensor(self, use_dynamo, mock_world_size):
+  def test_all_gather_into_tensor(self, use_dynamo):
     results = pjrt.run_multiprocess(
         self._all_gather_into_tensor, use_dynamo=use_dynamo)
-    expected = torch.arange(xr.world_size(), dtype=torch.float).unsqueeze(0)
+    expected = torch.arange(
+        tpu.num_expected_global_devices(), dtype=torch.float).unsqueeze(0)
     for index, val in results.items():
       torch.testing.assert_close(val, expected)
 
   @parameterized.named_parameters(('dynamo', True), ('nondynamo', False))
-  @mock.patch.object(xr, 'world_size', return_value=tpu.num_local_processes())
-  def test_all_gather(self, use_dynamo, mock_world_size):
+  def test_all_gather(self, use_dynamo):
     results = pjrt.run_multiprocess(self._all_gather, use_dynamo=use_dynamo)
     expected = [
-        torch.tensor([i], dtype=torch.float) for i in range(xr.world_size())
+        torch.tensor([i], dtype=torch.float)
+        for i in range(tpu.num_expected_global_devices())
     ]
     for index, val in results.items():
       torch.testing.assert_close(val, expected)

--- a/test/pjrt/test_collective_ops_tpu.py
+++ b/test/pjrt/test_collective_ops_tpu.py
@@ -151,7 +151,7 @@ class TestDistCollectiveOpsTpu(parameterized.TestCase):
   def _all_reduce(use_dynamo: bool):
     met.clear_all()
 
-    def _dist_all_reduce(input):
+    def callable(input):
       dist.all_reduce(input, dist.ReduceOp.SUM)
       return input
 
@@ -163,8 +163,8 @@ class TestDistCollectiveOpsTpu(parameterized.TestCase):
     input = ordinal
 
     f = torch.compile(
-        _dist_all_reduce, backend=TestDistCollectiveOpsTpu.my_compiler
-    ) if use_dynamo else _dist_all_reduce
+        callable, backend=TestDistCollectiveOpsTpu.my_compiler
+    ) if use_dynamo else callable
     f(input)
     torch_xla.sync()
     if not use_dynamo:
@@ -178,7 +178,7 @@ class TestDistCollectiveOpsTpu(parameterized.TestCase):
   def _all_gather_into_tensor(use_dynamo: bool):
     met.clear_all()
 
-    def _dist_all_gather_into_tensor(output, input):
+    def callable(output, input):
       dist.all_gather_into_tensor(output_tensor, input, None)
       return output_tensor
 
@@ -190,9 +190,8 @@ class TestDistCollectiveOpsTpu(parameterized.TestCase):
     input = ordinal
     output_tensor = torch.empty((1, xr.world_size()), device=device)
     f = torch.compile(
-        _dist_all_gather_into_tensor,
-        backend=TestDistCollectiveOpsTpu.my_compiler
-    ) if use_dynamo else _dist_all_gather_into_tensor
+        callable, backend=TestDistCollectiveOpsTpu.my_compiler
+    ) if use_dynamo else callable
     f(output_tensor, input)
     torch_xla.sync()
     if not use_dynamo:
@@ -206,7 +205,7 @@ class TestDistCollectiveOpsTpu(parameterized.TestCase):
   def _all_gather(use_dynamo: bool):
     met.clear_all()
 
-    def _dist_allgather(input):
+    def callable(input):
       output_tensor = [
           torch.tensor([0], dtype=torch.float) for _ in range(xr.world_size())
       ]
@@ -220,8 +219,8 @@ class TestDistCollectiveOpsTpu(parameterized.TestCase):
                            device=device)
     input = ordinal
     f = torch.compile(
-        _dist_allgather, backend=TestDistCollectiveOpsTpu.my_compiler
-    ) if use_dynamo else _dist_allgather
+        callable, backend=TestDistCollectiveOpsTpu.my_compiler
+    ) if use_dynamo else callable
     output = f(input)
     torch_xla.sync()
     if not use_dynamo:

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -39,6 +39,7 @@ _DEVICE_CONTEXTS_LOCK = threading.Lock()
 XLA_LIB = Library("xla", "DEF")
 
 from . import xla_model as this_module
+
 xrt_world_size = deprecated(this_module, torch_xla.runtime.world_size,
                             'xrt_world_size() will be removed in release 2.6.')
 get_ordinal = deprecated(
@@ -464,7 +465,6 @@ def all_reduce(
     torch_xla._XLAC._xla_all_reduce_inplace(reduce_type, inputs, scale, groups,
                                             pin_layout)
     results = inputs
-
   return results[0] if isinstance(inputs, torch.Tensor) else results
 
 

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -298,6 +298,7 @@ void AllReduceInPlace(const std::string& reduce_type,
                       const std::vector<at::Tensor>& tensors, double scale,
                       const std::vector<std::vector<int64_t>>& replica_groups,
                       bool pin_layout) {
+  TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
   std::vector<XLATensorPtr> xtensors =
       GetXlaTensors(tensors, /*want_all=*/true);
   tensor_methods::all_reduce(xtensors, GetReduceType(reduce_type), scale,
@@ -308,6 +309,7 @@ at::Tensor AllReduce(const std::string& reduce_type, const at::Tensor& input,
                      double scale,
                      const std::vector<std::vector<int64_t>>& replica_groups,
                      bool pin_layout) {
+  TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
   auto result = tensor_methods::all_reduce(bridge::GetXlaTensor(input),
                                            GetReduceType(reduce_type), scale,
                                            replica_groups, pin_layout);
@@ -430,6 +432,7 @@ std::shared_ptr<torch::lazy::Value> ReduceScatterCoalescedOut(
 at::Tensor AllGather(const at::Tensor& input, int64_t dim, int64_t shard_count,
                      const std::vector<std::vector<int64_t>>& replica_groups,
                      bool pin_layout) {
+  TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
   auto result =
       tensor_methods::all_gather(bridge::GetXlaTensor(input), dim, shard_count,
                                  replica_groups, pin_layout);
@@ -441,6 +444,7 @@ std::shared_ptr<torch::lazy::Value> AllGatherOut(
     const std::shared_ptr<torch::lazy::Value>& token, int64_t dim,
     int64_t shard_count,
     const std::vector<std::vector<int64_t>>& replica_groups, bool pin_layout) {
+  TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
   XLATensorPtr out = bridge::GetXlaTensor(output);
   torch::lazy::Value new_token;
   new_token = tensor_methods::all_gather_out(out, bridge::GetXlaTensor(input),

--- a/torch_xla/distributed/xla_backend.py
+++ b/torch_xla/distributed/xla_backend.py
@@ -46,7 +46,7 @@ class ProcessGroupXla(ProcessGroup):
   def getBackendName(self):
     return 'xla'
 
-  # pytorch's progress group is unable to retrive the group size from python level. It should
+  # pytorch's process group is unable to retrive the group size from python level. It should
   # already been support in C++ level: https://github.com/pytorch/pytorch/blob/7b1988f9222f3dec5cc2012afce84218199748ae/torch/csrc/distributed/c10d/ProcessGroup.cpp#L148-L152
   # For now we manually set the group name property as a temporary solution.
   def _set_group_name(self, name: str) -> None:

--- a/torch_xla/distributed/xla_backend.py
+++ b/torch_xla/distributed/xla_backend.py
@@ -46,8 +46,7 @@ class ProcessGroupXla(ProcessGroup):
   def getBackendName(self):
     return 'xla'
 
-
-  # pytorch's progress group is unable to retrive the group size from python level. It should 
+  # pytorch's progress group is unable to retrive the group size from python level. It should
   # already been support in C++ level: https://github.com/pytorch/pytorch/blob/7b1988f9222f3dec5cc2012afce84218199748ae/torch/csrc/distributed/c10d/ProcessGroup.cpp#L148-L152
   # For now we manually set the group name property as a temporary solution.
   def _set_group_name(self, name: str) -> None:


### PR DESCRIPTION
Add dynamo/nondynamo support for `torch.distributed.all_reduce` and `torch.distributed.all_gather_into_tensor`.

Motivation: We want to deprecate the collective ops in xla_model.py and be consist with the torch.distributed.

Issue: dist.all_reduct doesn't work with dynamo openxla backend at this time.