### PR TITLE
Add Python binding for xla::DotGeneral

### DIFF
--- a/test/quantized_ops/test_dot_general.py
+++ b/test/quantized_ops/test_dot_general.py
@@ -1,0 +1,62 @@
+import os
+import re
+
+import torch
+import torch_xla
+import unittest
+
+device = torch_xla.device()
+
+torch.manual_seed(12345)
+
+
+class DotGeneralTest(unittest.TestCase):
+
+  def test_dot_general(self):
+    x = torch.rand(10, 3, 4).to(torch.bfloat16)
+    w = torch.rand(10, 4, 5).to(torch.bfloat16)
+    expected_out = torch.matmul(x, w)
+    xla_x = x.to(device)
+    xla_w = w.to(device)
+    xla_out = torch_xla._XLAC._xla_dot_general(xla_x, xla_w,
+                                               (([2], [1]), ([0], [0])))
+    self.assertTrue(torch.allclose(xla_out.cpu(), expected_out))
+
+  def test_dot_general_negative_dim(self):
+    x = torch.rand(10, 3, 4).to(torch.bfloat16)
+    w = torch.rand(10, 4, 5).to(torch.bfloat16)
+    expected_out = torch.matmul(x, w)
+    xla_x = x.to(device)
+    xla_w = w.to(device)
+    xla_out = torch_xla._XLAC._xla_dot_general(xla_x, xla_w,
+                                               (([-1], [-2]), ([0], [0])))
+    self.assertTrue(torch.allclose(xla_out.cpu(), expected_out))
+
+  def test_dot_general_linear(self):
+    x = torch.rand(10, 3, 4).to(torch.bfloat16)
+    w = torch.rand(5, 4).to(torch.bfloat16)
+    expected_out = torch.matmul(x, w.t())
+    xla_x = x.to(device)
+    xla_w = w.to(device)
+    xla_out = torch_xla._XLAC._xla_dot_general(xla_x, xla_w, (([2], [1]), ()))
+    self.assertTrue(torch.allclose(xla_out.cpu(), expected_out))
+
+  def test_dot_general_int32_dtype(self):
+    x = torch.randint(-15, 15, (10, 3, 4)).to(torch.int32)
+    w = torch.randint(-15, 15, (10, 4, 5)).to(torch.int32)
+    # Though the intention of the test is for: matmul(int8, int8)->int32
+    # Do not cast to int8 for eager, since torch only has matmul(int32, int32)->in32
+    # Casting to int8 would cause the result overflow.
+    expected_out = torch.matmul(x, w)
+    xla_x = x.to(torch.int8).to(device)
+    xla_w = w.to(torch.int8).to(device)
+    xla_out = torch_xla._XLAC._xla_dot_general(
+        xla_x,
+        xla_w, (([2], [1]), ([0], [0])),
+        preferred_element_type=torch.int32)
+    self.assertTrue(torch.allclose(xla_out.cpu(), expected_out))
+
+
+if __name__ == '__main__':
+  test = unittest.main()
+  sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -219,6 +219,7 @@ function run_xla_op_tests3 {
   run_test "$CDIR/stablehlo/test_stablehlo_compile.py"
   run_test "$CDIR/stablehlo/test_unbounded_dynamism.py"
   run_test "$CDIR/quantized_ops/test_quantized_matmul.py"
+  run_test "$CDIR/quantized_ops/test_dot_general.py"
   run_test "$CDIR/spmd/test_xla_sharding.py"
   run_test "$CDIR/spmd/test_xla_sharding_hlo.py"
   run_test "$CDIR/spmd/test_xla_virtual_device.py"

--- a/test/tpu/run_tests.sh
+++ b/test/tpu/run_tests.sh
@@ -33,7 +33,7 @@ python3 test/torch_distributed/test_torch_distributed_all_gather_xla_backend.py
 python3 test/torch_distributed/test_torch_distributed_all_reduce_xla_backend.py
 python3 test/torch_distributed/test_torch_distributed_multi_all_reduce_xla_backend.py
 python3 test/torch_distributed/test_torch_distributed_reduce_scatter_xla_backend.py
-python3 test/quantized_ops/test_dot_general.py"
+python3 test/quantized_ops/test_dot_general.py
 
 # run examples, each test should takes <2 minutes
 python3 examples/data_parallel/train_resnet_spmd_data_parallel.py

--- a/test/tpu/run_tests.sh
+++ b/test/tpu/run_tests.sh
@@ -33,6 +33,7 @@ python3 test/torch_distributed/test_torch_distributed_all_gather_xla_backend.py
 python3 test/torch_distributed/test_torch_distributed_all_reduce_xla_backend.py
 python3 test/torch_distributed/test_torch_distributed_multi_all_reduce_xla_backend.py
 python3 test/torch_distributed/test_torch_distributed_reduce_scatter_xla_backend.py
+python3 test/quantized_ops/test_dot_general.py"
 
 # run examples, each test should takes <2 minutes
 python3 examples/data_parallel/train_resnet_spmd_data_parallel.py

--- a/torch_xla/csrc/ops/dot_general.cpp
+++ b/torch_xla/csrc/ops/dot_general.cpp
@@ -1,0 +1,89 @@
+#include "torch_xla/csrc/ops/dot_general.h"
+
+#include <c10/core/ScalarType.h>
+#include <torch/csrc/lazy/core/tensor_util.h>
+
+#include "torch_xla/csrc/dtype.h"
+#include "torch_xla/csrc/lowering_context.h"
+#include "torch_xla/csrc/ops/infer_output_shape.h"
+#include "torch_xla/csrc/ops/xla_ops.h"
+
+namespace torch_xla {
+
+namespace {
+
+xla::XlaOp BuildDotGeneral(
+    const xla::XlaOp& lhs, const xla::XlaOp& rhs,
+    const std::vector<std::vector<int>>& dim_vectors,
+    std::optional<at::ScalarType> preferred_element_type) {
+  xla::DotDimensionNumbers dot_dim_numbers;
+  dot_dim_numbers.mutable_lhs_contracting_dimensions()->Add(
+      dim_vectors[0].begin(), dim_vectors[0].end());
+  dot_dim_numbers.mutable_rhs_contracting_dimensions()->Add(
+      dim_vectors[1].begin(), dim_vectors[1].end());
+  dot_dim_numbers.mutable_lhs_batch_dimensions()->Add(dim_vectors[2].begin(),
+                                                      dim_vectors[2].end());
+  dot_dim_numbers.mutable_rhs_batch_dimensions()->Add(dim_vectors[3].begin(),
+                                                      dim_vectors[3].end());
+  std::optional<xla::PrimitiveType> xla_preferred_element_type;
+  if (preferred_element_type.has_value()) {
+    xla_preferred_element_type =
+        XlaTypeFromTorchType(preferred_element_type.value());
+  }
+  return xla::DotGeneral(lhs, rhs, dot_dim_numbers,
+                         /*precision_config=*/nullptr,
+                         /*preferred_element_type=*/xla_preferred_element_type);
+}
+
+xla::Shape NodeOutputShape(
+    const torch::lazy::Value& lhs, const torch::lazy::Value& rhs,
+    const std::vector<std::vector<int>>& dim_vectors,
+    std::optional<at::ScalarType> preferred_element_type) {
+  auto lower_for_shape_fn =
+      [dim_vectors, preferred_element_type](
+          absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
+    XLA_CHECK(operands.size() == 2);
+    return BuildDotGeneral(operands[0], operands[1], dim_vectors,
+                           preferred_element_type);
+  };
+  return InferOutputShape({GetXlaShape(lhs), GetXlaShape(rhs)},
+                          lower_for_shape_fn);
+}
+
+}  // namespace
+
+DotGeneral::DotGeneral(const torch::lazy::Value& lhs,
+                       const torch::lazy::Value& rhs,
+                       const std::vector<std::vector<int>>& dim_vectors,
+                       std::optional<at::ScalarType> preferred_element_type)
+    : XlaNode(
+          xla_dot_general, {lhs, rhs},
+          [&]() {
+            return NodeOutputShape(lhs, rhs, dim_vectors,
+                                   preferred_element_type);
+          },
+          /*num_outputs=*/1,
+          torch::lazy::MHash(dim_vectors, preferred_element_type)),
+      dim_vectors_(dim_vectors),
+      preferred_element_type_(preferred_element_type) {}
+
+torch::lazy::NodePtr DotGeneral::Clone(torch::lazy::OpList operands) const {
+  return torch::lazy::MakeNode<DotGeneral>(
+      operands.at(0), operands.at(1), dim_vectors_, preferred_element_type_);
+}
+
+XlaOpVector DotGeneral::Lower(LoweringContext* loctx) const {
+  xla::XlaOp lhs = loctx->GetOutputOp(operand(0));
+  xla::XlaOp rhs = loctx->GetOutputOp(operand(1));
+  xla::XlaOp output =
+      BuildDotGeneral(lhs, rhs, dim_vectors_, preferred_element_type_);
+  return ReturnOp(output, loctx);
+}
+
+std::string DotGeneral::ToString() const {
+  std::stringstream ss;
+  ss << XlaNode::ToString() << ", preferred_element_type=";
+  return ss.str();
+}
+
+}  // namespace torch_xla

--- a/torch_xla/csrc/ops/dot_general.h
+++ b/torch_xla/csrc/ops/dot_general.h
@@ -1,0 +1,27 @@
+#ifndef XLA_TORCH_XLA_CSRC_OPS_DOT_GENERAL_H_
+#define XLA_TORCH_XLA_CSRC_OPS_DOT_GENERAL_H_
+
+#include "torch_xla/csrc/ir.h"
+
+namespace torch_xla {
+
+class DotGeneral : public XlaNode {
+ public:
+  DotGeneral(const torch::lazy::Value& lhs, const torch::lazy::Value& rhs,
+             const std::vector<std::vector<int>>& dim_vectors,
+             std::optional<at::ScalarType> preferred_element_type);
+
+  std::string ToString() const override;
+
+  torch::lazy::NodePtr Clone(torch::lazy::OpList operands) const override;
+
+  XlaOpVector Lower(LoweringContext* loctx) const override;
+
+ private:
+  std::vector<std::vector<int>> dim_vectors_;
+  std::optional<at::ScalarType> preferred_element_type_;
+};
+
+}  // namespace torch_xla
+
+#endif  // XLA_TORCH_XLA_CSRC_OPS_DOT_GENERAL_H_

--- a/torch_xla/csrc/ops/xla_ops.cpp
+++ b/torch_xla/csrc/ops/xla_ops.cpp
@@ -13,6 +13,7 @@ const OpKindWrapper xla_custom_call("xla::custom_call");
 const OpKindWrapper xla_device_data("xla::device_data");
 const OpKindWrapper xla_dequantize_tensor("xla::dequantize_tensor");
 const OpKindWrapper xla_diagonal_view_update("xla::diagonal_view_update");
+const OpKindWrapper xla_dot_general("xla::dot_general");
 const OpKindWrapper xla_dynamic_expand("xla::dynamic_expand");
 const OpKindWrapper xla_dynamic_view("xla::dynamic_view");
 const OpKindWrapper xla_einsum_backward("xla::einsum_backward");

--- a/torch_xla/csrc/ops/xla_ops.h
+++ b/torch_xla/csrc/ops/xla_ops.h
@@ -39,6 +39,7 @@ extern const OpKindWrapper xla_custom_call;
 extern const OpKindWrapper xla_device_data;
 extern const OpKindWrapper xla_dequantize_tensor;
 extern const OpKindWrapper xla_diagonal_view_update;
+extern const OpKindWrapper xla_dot_general;
 extern const OpKindWrapper xla_dynamic_expand;
 extern const OpKindWrapper xla_dynamic_view;
 extern const OpKindWrapper xla_einsum_backward;

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -384,6 +384,11 @@ XLATensorPtr div(
     std::optional<at::ScalarType> logical_element_type = std::nullopt);
 XLATensorPtr div(const XLATensorPtr& input, const at::Scalar& other);
 
+XLATensorPtr xla_dot_general(
+    const XLATensorPtr& lhs, const XLATensorPtr& rhs,
+    const std::vector<std::vector<int>>& dim_vectors,
+    std::optional<at::ScalarType> preferred_element_type);
+
 // A generalized contraction between tensors of arbitrary dimension defined by
 // the given equation and applied to the input tensors.
 XLATensorPtr einsum(const std::string& equation,


### PR DESCRIPTION
Add a python binding for `xla::DotGeneral`, the motivation is to represent the semantic of `matmul/einsum(dtype1, dtype2)->dtype3`, in which `dtype3` can be configurable. Now `torch.matmul` would always use the inferred output dtype.

Function signature is the same as [jax.lax.dot_general](https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.dot_general.html).

The only limitation is `precision` config is not supported, it can be extended easily if needed in the future.

Test:
Added unit tests