### PR TITLE
As_stride should aplly on input tensor, not the base tensor

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2704,6 +2704,8 @@ class TestGeneric(test_utils.XlaTestCase):
     self.assertEqual(xdata.batch_sizes.device, torch.device('cpu'))
     self.assertEqual(xdata.data.device, xla_device)
 
+  @skipIfFunctionalizationDisabled(
+      "https://github.com/pytorch/xla/pull/7864#issuecomment-2294034008")
   def test_as_strided_input_larger(self):
     size = (5, 5)
     device = xm.xla_device()

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1006,6 +1006,19 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     b = torch.ones([2, 2])
     self.runAtenTest((a, b), func)
 
+  def test_multi_view(self):
+
+    def func(x):
+      a1, b1 = x.chunk(2)
+      a2, b2 = x[0:1], x[1:2]
+      a3, b3 = x[0].unsqueeze(0), x[1].unsqueeze(0)
+      a4, b4 = x[0, None], x[1, None]
+      return a1.squeeze(), b1.squeeze(), a2.squeeze(), b2.squeeze(), a3.squeeze(
+      ), b3.squeeze(), a4.squeeze(), b4.squeeze()
+
+    x = torch.randn(size=[2])
+    self.runAtenTest(x, func)
+
   # TODO - upstream behavior has changed and results in expected DestroyXlaTensor
   # counter as of 11/13/2023. Re-enable after reviewing the change.
   # @skipIfFunctionalizationDisabled("metrics differ")

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -4167,15 +4167,13 @@ at::Tensor XLANativeFunctions::as_strided(
     const at::Tensor& self, at::IntArrayRef size, at::IntArrayRef stride,
     std::optional<int64_t> storage_offset) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
-  const auto& base = bridge::GetXlaTensor(self)->Base();
-  const auto& tensor = base.defined() ? base : self;
-  XLATensorPtr self_tensor = bridge::GetXlaTensor(tensor);
+  XLATensorPtr self_tensor = bridge::GetXlaTensor(self);
   auto xsize = XlaHelpers::I64List(size);
   auto xstride = XlaHelpers::I64List(stride);
   if (!AsStrided::StrideIsSupported(self_tensor->shape(), xsize, xstride,
                                     storage_offset.value_or(0))) {
     return at::native::call_fallback_fn<
-        &xla_fallback, ATEN_OP(as_strided)>::call(tensor, size, stride,
+        &xla_fallback, ATEN_OP(as_strided)>::call(self, size, stride,
                                                   storage_offset);
   }
   return bridge::AtenFromXlaTensor(tensor_methods::as_strided(


### PR DESCRIPTION
This should fix https://github.com/pytorch/xla/issues/7859

at least in the non-functionization case(in the FUNCTIONALIZATION case `as_strided_copy` will be call). the as_strided call should be applied on the input tensor, not the base tensor.


@bdhirsh Do you know when user do
```
x.view().as_strided()
```
in the FUNCTIONALIZATION and non-FUNCTIONALIZATION case, should the `as_strided` be applied on `x` or `x.view`? in the 

```
x = torch.randn(size=[2])
a1, b1 = x.chunk(2)
res = b1.seqeeze()
```
case without FUNCTIONALIZATION, I see that it is a `b1` is a
```
IR {
  %0 = f32[2]{0} xla::device_data(), xla_shape=f32[2]{0}
  %1 = f32[1]{0} xla::select(%0), xla_shape=f32[1]{0}, ROOT=0
}
```
and then `seqeeze` becomes a `as_strided`  with `[], []`. In this case `as_strided` should apply on `b1`, not the x. 