### PR TITLE
[torchxla2] Fix README venv setup

### DIFF
--- a/experimental/torch_xla2/README.md
+++ b/experimental/torch_xla2/README.md
@@ -39,7 +39,7 @@ Otherwise create a new environment from the command line.
 
 ```bash
 # Option 1: venv
-python -m venv create my_venv
+python -m venv my_venv
 source my_venv/bin/activate
 
 # Option 2: conda


### PR DESCRIPTION
python -m venv doesn't take a `create` position command, just a list of ENV_DIR to output to.