### PR TITLE
[developer] Add a script to automate building torch_xla

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,11 @@ We recommend you to use our prebuilt Docker image to start your development work
   # Output: xla:0
   ```
 
+**Subsequent builds**: after setting up the source checkouts and building them
+for the first time, you may find the need to build everything again after e.g.
+`git pull`. You can run `scripts/build_developer.sh` which will build PyTorch,
+TorchVision, and PyTorch/XLA according to the above.
+
 ### Manually build in Docker container
 
 * Setup Development Docker Image

--- a/scripts/build_developer.sh
+++ b/scripts/build_developer.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e  # Fail on any error.
+set -x  # Display commands being run.
+
+# Change to pytorch directory.
+cd "$(dirname "$(readlink -f "$0")")"
+cd ../../
+
+python3 setup.py bdist_wheel
+python3 setup.py install
+cd ..
+
+# Optionally install torchvision.
+if [ -d "vision" ]; then
+  cd vision
+  python3 setup.py develop
+fi
+
+cd ..
+cd pytorch/xla
+python3 setup.py develop
+
+# libtpu is needed to talk to the TPUs. If TPUs are not present,
+# installing this wouldn't hurt either.
+pip install torch_xla[tpu] -f https://storage.googleapis.com/libtpu-releases/index.html
+
+# Test that the library is installed correctly.
+python3 -c 'import torch_xla as xla; print(xla.device())'
+


### PR DESCRIPTION
This script replicates our CONTRIBUTING.md instructions. It builds PyTorch, TorchVision (optional), and PyTorch/XLA. Then it runs a test to verify the installation.

This is useful after git pulling all three repos.