### PR TITLE
Fix `norm` data-type when using AMP.

### DIFF
--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2486,8 +2486,14 @@ XLATensorPtr norm(const XLATensorPtr& input, const std::optional<at::Scalar>& p,
   if (!dtype) {
     dtype = input->dtype_optional();
   }
-  return input->CreateFrom(
-      Norm(input->GetIrValue(), p, dtype, canonical_dims, keepdim));
+  auto out = Norm(input->GetIrValue(), p, dtype, canonical_dims, keepdim);
+  if (dtype.has_value()) {
+    // The returned tensor is actually of type `dtype`. Therefore, it should not
+    // inherit the data-type from the input, when creating the XLATensor.
+    return input->CreateFrom(out, dtype);
+  } else {
+    return input->CreateFrom(out);
+  }
 }
 
 XLATensorPtr normal(double mean, const XLATensorPtr& std) {


### PR DESCRIPTION
This PR fixes the result of `norm` operation when using AMP.

The cast policy defined in [autocast_mode.cpp][1] for `norm.ScalarOpt_dim` is: `fp32_append_dtype`. Which means that it will forward the call to `norm.ScalarOpt_dim_dtype`, appending `at::kFloat` (i.e. `float32`) as its last argument. Such an argument represents the data-type of the result tensor.

Even though we were correctly lowering the operation so as to return a `float32` tensor, upon checking, the result tensor actually inherited its data-type from the input. The solution was to call `XLATensor::CreateFrom` with `at::kFloat` argument. The example below illustrates the problem:

```python
>>> x = torch.rand((10, 10), dtype=torch.float16, device="xla")
>>> with torch.cuda.amp.autocast(dtype=torch.float16):
        r = torch.norm(x, p=2, dim=1)

>>> r
# HLO representation shows it's returning a f32 tensor, though.
tensor(..., dtype=torch.float16)
```

cc @miladm @JackCaoG 

[1]: https://github.com/pytorch/pytorch/blob/5fab35d77c7d1db7dbb9d5c516254a510b4f4f64/aten/src/ATen/autocast_mode.cpp