### PR TITLE
DYNAMO RNG seed update optimization

### DIFF
--- a/torch_xla/core/dynamo_bridge.py
+++ b/torch_xla/core/dynamo_bridge.py
@@ -90,8 +90,10 @@ class GraphInputMatcher:
         # update random seed here to avoid random operations always return
         # the same result. The seed update logic is the same as `mark_step` in
         # https://github.com/pytorch/pytorch/blob/6af6b8f728426fb7551630e28148c0017fa501bc/torch/csrc/lazy/core/lazy_graph_executor.cpp#L144C18-L144C51
+        # Note: don't do `inp.item()` here since it will trigger a transferFromDevice
         xm.set_rng_state(
-            (1012031 + inp.item() * 7012063) % 18446744073709551615, str_device)
+            (1012031 + torch_xla._XLAC._xla_get_rng_seed() * 7012063) %
+            18446744073709551615, str_device)
       elif arg_idx is None:
         assert traced_xla_value is not None, "Traced Tensor cannot be None."
         inp = traced_xla_value


### PR DESCRIPTION
RNG seed had 2 forms in torch_xla, a xla tensor and a scalar. In the dynamo bridge case we want the tensor form for the execution but for the seed update we don't want to do `tensor.item()` since it will cause a `transferFromDevice`. We can directly access the scalar form of the rng seed