### PR TITLE
[torch_xla2] Add support for QR op

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -247,7 +247,6 @@ skiplist = {
     "polygamma",
     "prod",
     "put",
-    "qr",
     "quantile",
     "renorm",
     "repeat_interleave",

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -3094,3 +3094,12 @@ def _aten_conj_physical(self):
 @op(torch.ops.aten.log_sigmoid)
 def _aten_log_sigmoid(x):
   return jax.nn.log_sigmoid(x)
+
+@op(torch.ops.aten.linalg_qr)
+def _aten_linalg_qr(input, *args, **kwargs):
+  jax_mode = "reduced"
+  # torch bool param 'simple=True' corresponds to jax 'reduced' mode,
+  # and simple=False corresponds to jax 'complete' mode.
+  if kwargs.get("simple") is False:
+    jax_mode = "complete"
+  return jax.numpy.linalg.qr(input, mode=jax_mode)


### PR DESCRIPTION
This change adds support for QR matrix decomposition op in torch_xla2.

Note: the [op db](https://github.com/pytorch/xla/blob/ac7fd44f520d586c3d95fc929134c20946e60806/experimental/torch_xla2/test/test_ops.py#L5) used in the version of PyTorch being used in torch_xla2 tests is using [torch.qr](https://pytorch.org/docs/stable/generated/torch.qr.html) which is going to be deprecated and removed in a future release, so we need to support the newer [torch.linalg.qr](https://pytorch.org/docs/stable/generated/torch.linalg.qr.html#torch.linalg.qr) whose params align with [jax.numpy.linalg.qr](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.linalg.qr.html).