### PR TITLE
[torch_xla2] Fix `squeeze` operator

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -274,7 +274,6 @@ skiplist = {
     "special.scaled_modified_bessel_k1",
     "special.spherical_bessel_j0",
     "special.zeta",
-    "squeeze",
     "stft",
     "sub",
     "svd",

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -655,7 +655,7 @@ def _aten_squeeze_dim(self, dim):
     dim = [dim]
 
   # Check if the specified dimension has size 1
-  if all([self.shape[d] != 1 for d in dim]):
+  if (len(self.shape) == 0) or all([self.shape[d] != 1 for d in dim]):
     return self
 
   # Use slicing to remove the dimension if it is 1


### PR DESCRIPTION
Regarding `squeeze`, torch supports dim value [-1, 0] when a tensor shape is empty ([]). Make jaten.squeeze compatibile with such behavior.