### PR TITLE
Fix issues in f8e4m3fn support

### DIFF
--- a/test/test_fp8.py
+++ b/test/test_fp8.py
@@ -1,16 +1,41 @@
-import unittest
+import sys
+
 import torch
 import torch_xla
+import unittest
 import torch_xla.core.xla_model as xm
 
+device = xm.xla_device()
 
-class XlaDataTypeTest(unittest.TestCase):
 
-  def test_datatype_fp8e4m3fn(self):
-    t1 = torch.tensor([1.0, 2.0, 3.0], device=xm.xla_device())
-    t2 = torch.tensor([2.0, 3.0, 4.0], device=xm.xla_device())
-    t1 = t1.to(torch.float8_e4m3fn)
-    t2 = t2.to(torch.float8_e4m3fn)
+class Fp8Test(unittest.TestCase):
 
-    assert t1.dtype == torch.float8_e4m3fn
-    assert t2.dtype == torch.float8_e4m3fn
+  def test_fp8(self):
+    dtype = torch.float8_e4m3fn
+    t = torch.rand(2, 2).to(dtype)
+    xla_t = t.to(device)
+    torch_t = xla_t.cpu()
+    self.assertEqual(xla_t.dtype, dtype)
+    self.assertEqual(torch_t.dtype, dtype)
+    # Need to cast to float32 since allclose doesn't work with fp8.
+    self.assertTrue(
+        torch.allclose(t.to(torch.float32), torch_t.to(torch.float32)))
+
+  def test_fp8_matmul(self):
+    dtype = torch.float8_e4m3fn
+    t = torch.rand(3, 2).to(dtype)
+    w = torch.rand(2, 5).to(dtype)
+    torch_matmul = torch.matmul(t, w)
+    xla_t = t.to(device)
+    xla_w = w.to(device)
+    xla_matmul = torch.matmul(xla_t, xla_w)
+    xla_matmul = xla_matmul.cpu()
+    # Need to cast to float32 since allclose doesn't work with fp8.
+    self.assertTrue(
+        torch.allclose(
+            xla_matmul.to(torch.float32), torch_matmul.to(torch.float32)))
+
+
+if __name__ == '__main__':
+  test = unittest.main()
+  sys.exit(0 if test.result.wasSuccessful() else 1)


### PR DESCRIPTION
### Notes
* Fixed errors thrown on conversion to f8e4m3fn data type
    * `Unsupported scalar type`
    * `Tensor type not supported`
* Added unit test to check matrix multiplication
* Added main block to unit test
* Used code from f8e4m3fn support PR: https://github.com/pytorch/xla/pull/7842

### Testing
* Added and ran unit tests.