### PR TITLE
Fix the crash with copy op in dynamo

### DIFF
--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -99,6 +99,19 @@ class DynamoLTCInteractionTest(unittest.TestCase):
       xm.wait_device_ops()
       self.assertEqual(current_execute_time, met.metric_data('ExecuteTime')[0])
 
+  def test_copy_op(self):
+
+    def copy_a_to_b(a):
+      res = a.cos()
+      copy = torch.ops.aten.copy.default(a, res)
+      return copy
+
+    device = torch_xla.device()
+    compiled_copy = torch.compile(copy_a_to_b, backend="openxla")
+    a = torch.randn(2, 9).to(device)
+    res = compiled_copy(a)
+    self.assertTrue(torch.allclose(res, a))
+
 
 class DynamoProfilerTest(unittest.TestCase):
 

--- a/torch_xla/core/dynamo_bridge.py
+++ b/torch_xla/core/dynamo_bridge.py
@@ -207,7 +207,10 @@ class Deduper:
     deduped_ids = dict()
     deduped_list = []
     for item in origlist:
-      item_id = id(item)
+      if isinstance(item, torch.Tensor):
+        item_id = torch_xla._XLAC._unique_id_for_ir_and_data(item)
+      else:
+        item_id = id(item)
       if item_id not in deduped_ids:
         deduped_ids[item_id] = len(deduped_ids)
         deduped_list.append(item)

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2869,6 +2869,21 @@ void InitXlaModuleBindings(py::module m) {
     SetAllReduceToken(xla_device, nullptr);
   });
 
+  m.def(
+      "_unique_id_for_ir_and_data",
+      [](const at::Tensor& tensor) -> std::string {
+        XLATensorPtr xtensor = bridge::GetXlaTensor(tensor);
+        if (xtensor->CurrentIrValue()) {
+          torch::lazy::Value value = xtensor->CurrentIrValue();
+          return std::to_string((uintptr_t)value.node.get()) + ", " +
+                 std::to_string(value.index);
+        } else if (xtensor->CurrentDataHandle()) {
+          return std::to_string((uintptr_t)xtensor->CurrentDataHandle().get());
+        } else {
+          return std::to_string((uintptr_t)xtensor.get());
+        }
+      });
+
   m.def("_run_cached_graph",
         [](const std::string& hash_str,
            const std::vector<at::IValue>& graph_inputs)


### PR DESCRIPTION
We need to do a dedup for the dynamo output, for example in the case of
```
def f(a):
  a += 1
  return a
```
From dynamo bridge perspective there are 2 outputs.
1. input a has been inplace updated
2. return value a

However from XLA perspective there is only one output. In order to match these two thing we need a way to tell that 2 output are the same hence we need to dedup. In the test case I added, there is a `copy` op in the function we want to compile. In this case dynamo bridge failed to recognize copied tensor and the origional tensor are the same tensor hence the crash.