### PR TITLE
Add f8e5m2 support

### DIFF
--- a/test/test_fp8.py
+++ b/test/test_fp8.py
@@ -1,17 +1,24 @@
-import sys
+import os
+import re
 
 import torch
 import torch_xla
 import unittest
+from absl.testing import parameterized
 import torch_xla.core.xla_model as xm
 
 device = xm.xla_device()
 
+dtype_parameters = [
+    torch.float8_e5m2,
+    torch.float8_e4m3fn,
+]
 
-class Fp8Test(unittest.TestCase):
 
-  def test_fp8(self):
-    dtype = torch.float8_e4m3fn
+class Fp8Test(parameterized.TestCase):
+
+  @parameterized.parameters(*dtype_parameters)
+  def test_fp8(self, dtype):
     t = torch.rand(2, 2).to(dtype)
     xla_t = t.to(device)
     torch_t = xla_t.cpu()
@@ -21,8 +28,8 @@ class Fp8Test(unittest.TestCase):
     self.assertTrue(
         torch.allclose(t.to(torch.float32), torch_t.to(torch.float32)))
 
-  def test_fp8_matmul(self):
-    dtype = torch.float8_e4m3fn
+  @parameterized.parameters(*dtype_parameters)
+  def test_fp8_matmul(self, dtype):
     t = torch.rand(3, 2).to(dtype)
     w = torch.rand(2, 5).to(dtype)
     torch_matmul = torch.matmul(t, w)
@@ -34,6 +41,17 @@ class Fp8Test(unittest.TestCase):
     self.assertTrue(
         torch.allclose(
             xla_matmul.to(torch.float32), torch_matmul.to(torch.float32)))
+
+  @parameterized.parameters(*dtype_parameters)
+  def test_fp8_hlo(self, dtype):
+    x = torch.randn((3, 5)).to(dtype).to(device)
+    w = torch.randn((5, 8)).to(dtype).to(device)
+    output = torch.matmul(x, w)
+    hlo = torch_xla._XLAC._get_xla_tensors_hlo([output])
+    exmy_str = str(dtype).split('_')[-1]
+    self.assertTrue(
+        re.search(rf'f8{exmy_str}.*dot.*f8{exmy_str}.*f8{exmy_str}', hlo)
+        is not None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Notes

Previously, I created a PR to add support for F8E4M3FN: https://github.com/pytorch/xla/pull/7898

This extends the same code to add support for an additional FP8 data type: F8E5M2

Based my code changes on this CR: https://github.com/pytorch/xla/pull/7740 (Thanks @lsy323 for all FP8 code additions to mainline) 


### Testing

Added unit tests to cover f8e5m2
