### PR TITLE
fix dynamo inplace copy

### DIFF
--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -106,11 +106,14 @@ class DynamoLTCInteractionTest(unittest.TestCase):
       copy = torch.ops.aten.copy.default(a, res)
       return copy
 
+    met.clear_all()
     device = torch_xla.device()
     compiled_copy = torch.compile(copy_a_to_b, backend="openxla")
     a = torch.randn(2, 9).to(device)
     res = compiled_copy(a)
+    xm.wait_device_ops()
     self.assertTrue(torch.allclose(res, a))
+    self.assertEqual(1, met.metric_data('ExecuteTime')[0])
 
 
 class DynamoProfilerTest(unittest.TestCase):

--- a/test/pjrt/test_collective_ops_tpu.py
+++ b/test/pjrt/test_collective_ops_tpu.py
@@ -142,11 +142,6 @@ class TestXMCollectiveOpsTpu(parameterized.TestCase):
 # Test for collective ops from torch.distributed
 class TestDistCollectiveOpsTpu(parameterized.TestCase):
 
-  # TODO(zpcore): fix the openxla dynamo issue for inplace copy
-  @staticmethod
-  def my_compiler(gm: torch.fx.GraphModule, example_inputs: List[torch.Tensor]):
-    return gm.forward
-
   @staticmethod
   def _all_reduce(use_dynamo: bool):
     met.clear_all()
@@ -161,9 +156,7 @@ class TestDistCollectiveOpsTpu(parameterized.TestCase):
                          dtype=torch.float,
                          device=device)
 
-    f = torch.compile(
-        callable, backend=TestDistCollectiveOpsTpu.my_compiler
-    ) if use_dynamo else callable
+    f = torch.compile(callable, backend='openxla') if use_dynamo else callable
     f(input)
     torch_xla.sync()
     if not use_dynamo:


### PR DESCRIPTION
Fix inplace copy that extra mark_step will be conducted.

```
@torch.compile(backend='openxla')
def cc(arg0_1):
  x = torch.randn([1])
  copy = torch.ops.aten.copy.default(arg0_1, x)
  return copy
```