### PR TITLE
Double loader_prefetch_size and device_prefetch_size

### DIFF
--- a/torch_xla/distributed/parallel_loader.py
+++ b/torch_xla/distributed/parallel_loader.py
@@ -66,11 +66,11 @@ class ParallelLoader(object):
     loader_prefetch_size (int, optional): The max capacity of the queue used by
       the thread which is reading samples from the `loader`, to be processed by
       the worker threads which upload data to the devices.
-      Default: 8
+      Default: 16
     device_prefetch_size (int, optional): The max size of the per-device queues,
       where the worker threads deposit tensors which have already been sent to
       devices.
-      Default: 4
+      Default: 8
     host_to_device_transfer_threads (int, optional): The number of threads that
       work in parallel to transfer data from loader queue to device queue.
       Default: 1

--- a/torch_xla/distributed/parallel_loader.py
+++ b/torch_xla/distributed/parallel_loader.py
@@ -84,8 +84,8 @@ class ParallelLoader(object):
                devices,
                batchdim=0,
                batches_per_execution=1,
-               loader_prefetch_size=8,
-               device_prefetch_size=4,
+               loader_prefetch_size=16,
+               device_prefetch_size=8,
                host_to_device_transfer_threads=1,
                input_sharding=None):
     self._loader = loader


### PR DESCRIPTION
This doubles Model FLOPs Utilization (MFU) of Llama-7B training on `v5p-512` TPUs with global batch size 1024.