### PR TITLE
bring XLA_USE_BF16 and XLA_DOWNCAST_BF16 back for 2.5 release

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -87,6 +87,16 @@ function run_xla_ir_debug {
   XLA_IR_DEBUG=1 run_test "$@"
 }
 
+function run_use_bf16 {
+  echo "Running with XLA_USE_BF16: $@"
+  XLA_USE_BF16=1 run_test "$@"
+}
+
+function run_downcast_bf16 {
+  echo "Running with XLA_DOWNCAST_BF16: $@"
+  XLA_DOWNCAST_BF16=1 run_test "$@"
+}
+
 function run_xla_hlo_debug {
   echo "Running with XLA_IR_DEBUG: $@"
   XLA_HLO_DEBUG=1 run_test "$@"
@@ -185,6 +195,8 @@ function run_xla_op_tests1 {
   run_test "$CDIR/dynamo/test_dynamo_config.py"
   run_save_tensor_ir "$CDIR/dynamo/test_dynamo_graph_dump.py"
   run_test "$CDIR/test_data_type.py"
+  run_use_bf16 "$CDIR/test_data_type.py"
+  run_downcast_bf16 "$CDIR/test_data_type.py"
   run_test "$CDIR/test_fp8.py"
   run_xla_ir_debug "$CDIR/test_env_var_mapper.py"
   run_xla_hlo_debug "$CDIR/test_env_var_mapper.py"

--- a/test/test_data_type.py
+++ b/test/test_data_type.py
@@ -13,6 +13,41 @@ def check_env_flag(name, default=''):
 
 class XlaDataTypeTest(unittest.TestCase):
 
+  def test_datatype_f32(self):
+    t1 = torch.tensor([2.0, 3.0], dtype=torch.float, device=xm.xla_device())
+    t2 = torch.tensor([2.0, 3.0], dtype=torch.float, device=xm.xla_device())
+    t3 = torch.div(t1, t2, rounding_mode='floor')
+    assert t3.dtype == torch.float
+
+    hlo_text = torch_xla._XLAC._get_xla_tensors_text([t3])
+    device_data_hlo = hlo_text.split('\n')[1]
+    assert 'xla::device_data' in device_data_hlo, device_data_hlo
+    if check_env_flag('XLA_USE_BF16') or check_env_flag('XLA_DOWNCAST_BF16'):
+      assert 'bf16' in device_data_hlo, device_data_hlo
+    elif check_env_flag('XLA_USE_FP16') or check_env_flag('XLA_DOWNCAST_FP16'):
+      assert 'f16' in device_data_hlo, device_data_hlo
+    else:
+      assert 'f32' in device_data_hlo, device_data_hlo
+
+  def test_datatype_f64(self):
+    t1 = torch.tensor([2.0, 3.0], dtype=torch.double, device=xm.xla_device())
+    t2 = torch.tensor([2.0, 3.0], dtype=torch.double, device=xm.xla_device())
+    t3 = torch.div(t1, t2, rounding_mode='floor')
+    assert t3.dtype == torch.double
+
+    hlo_text = torch_xla._XLAC._get_xla_tensors_text([t3])
+    device_data_hlo = hlo_text.split('\n')[1]
+    assert 'xla::device_data' in device_data_hlo, device_data_hlo
+    if check_env_flag('XLA_USE_BF16'):
+      assert 'bf16' in device_data_hlo, device_data_hlo
+    elif check_env_flag('XLA_USE_FP16'):
+      assert 'f16' in device_data_hlo, device_data_hlo
+    elif check_env_flag('XLA_DOWNCAST_BF16') or check_env_flag(
+        'XLA_DOWNCAST_FP16'):
+      assert 'f32' in device_data_hlo, device_data_hlo
+    else:
+      assert 'f64' in device_data_hlo, device_data_hlo
+
   def test_module_to_dtype(self):
     device = torch_xla.device()
     linear = torch.nn.Linear(

--- a/torch_xla/__init__.py
+++ b/torch_xla/__init__.py
@@ -155,8 +155,7 @@ def _setup_tpu_vm_library_path() -> bool:
 
 def _check_deprecated_env_var():
   deprecated_env_vars = [
-      'XLA_USE_BF16', 'XLA_USE_FP16', 'XLA_DOWNCAST_BF16', 'XLA_DOWNCAST_FP16',
-      'XLA_USE_32BIT_LONG'
+      'XLA_USE_FP16', 'XLA_DOWNCAST_FP16', 'XLA_USE_32BIT_LONG'
   ]
   for env_var in deprecated_env_vars:
     if os.environ.get(env_var):

--- a/torch_xla/csrc/dtype.cpp
+++ b/torch_xla/csrc/dtype.cpp
@@ -5,6 +5,43 @@
 
 namespace torch_xla {
 
+namespace {
+
+bool ShouldUseBF16() {
+  bool use_bf16 = runtime::sys_util::GetEnvBool("XLA_USE_BF16", false);
+  if (use_bf16) {
+    std::cout
+        << "XLA_USE_BF16 will be deprecated after the 2.5 release, please "
+           "convert your model to bf16 directly\n";
+    TF_LOG(INFO) << "Using BF16 data type for floating point values";
+  }
+  return use_bf16;
+}
+
+bool ShouldDowncastToBF16() {
+  bool downcast_bf16 =
+      runtime::sys_util::GetEnvBool("XLA_DOWNCAST_BF16", false);
+  if (downcast_bf16) {
+    std::cout
+        << "XLA_DOWNCAST_BF16 will be deprecated after the 2.5 release, please "
+           "downcast your model directly\n";
+    TF_LOG(INFO) << "Downcasting floating point values, F64->F32, F32->BF16";
+  }
+  return downcast_bf16;
+}
+
+bool UseBF16() {
+  static bool use_bf16 = ShouldUseBF16();
+  return use_bf16;
+}
+
+bool DowncastBF16() {
+  static bool downcast_bf16 = ShouldDowncastToBF16();
+  return downcast_bf16;
+}
+
+}  // namespace
+
 at::ScalarType TorchTypeFromXlaType(xla::PrimitiveType xla_type) {
   switch (xla_type) {
     case xla::PrimitiveType::BF16:
@@ -89,12 +126,16 @@ xla::PrimitiveType MaybeDowncastToXlaDeviceType(
   XlaDeviceType hw_type = static_cast<XlaDeviceType>(device.type());
   switch (type) {
     case xla::PrimitiveType::F64:
-      if (hw_type == XlaDeviceType::NEURON) {
+      if (UseBF16()) {
+        return xla::PrimitiveType::BF16;
+      }
+      if (DowncastBF16() || hw_type == XlaDeviceType::NEURON) {
         return xla::PrimitiveType::F32;
       }
       return xla::PrimitiveType::F64;
     case xla::PrimitiveType::F32:
-      return xla::PrimitiveType::F32;
+      return UseBF16() || DowncastBF16() ? xla::PrimitiveType::BF16
+                                         : xla::PrimitiveType::F32;
     case xla::PrimitiveType::U16:
       return hw_type != XlaDeviceType::NEURON ? xla::PrimitiveType::U16
                                               : xla::PrimitiveType::U32;
@@ -122,11 +163,12 @@ at::ScalarType MaybeUpcastToHostTorchType(xla::PrimitiveType xla_type) {
   at::ScalarType scalar_type = TorchTypeFromXlaType(xla_type);
   switch (scalar_type) {
     case at::ScalarType::BFloat16:
-      return at::ScalarType::BFloat16;
+      return UseBF16() || DowncastBF16() ? at::ScalarType::Float
+                                         : at::ScalarType::BFloat16;
     case at::ScalarType::Half:
       return at::ScalarType::Half;
     case at::ScalarType::Float:
-      return at::ScalarType::Float;
+      return DowncastBF16() ? at::ScalarType::Double : at::ScalarType::Float;
     default:
       return scalar_type;
   }

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -13,6 +13,8 @@ from typing import Any, List, Callable, Optional, Tuple, Dict
 from torch.library import impl
 from torch_xla.core.xla_model import XLA_LIB
 
+_XLA_USE_BF16 = os.environ.get("XLA_USE_BF16", "0") == "1"
+
 
 def _extract_backend_config(
     module: "jaxlib.mlir._mlir_libs._mlir.ir.Module") -> Optional[str]:
@@ -60,7 +62,9 @@ def convert_torch_dtype_to_jax(dtype: torch.dtype) -> "jnp.dtype":
   # in the global scope which could cause problems for xmp.spawn.
   jax_import_guard()
   import jax.numpy as jnp
-
+  if _XLA_USE_BF16:
+    raise RuntimeError(
+        "Pallas kernel does not support XLA_USE_BF16, please unset the env var")
   if dtype == torch.float32:
     return jnp.float32
   elif dtype == torch.float64:


### PR DESCRIPTION
this per AWS request. @jeffhataws . I plan to revert this after the branch cut.

pr that remove these two env var in https://github.com/pytorch/xla/pull/7582