### PR TITLE
Ignore torch_xla2 on legacy TPU CI

### DIFF
--- a/infra/terraform_modules/build_trigger/build_trigger.tf
+++ b/infra/terraform_modules/build_trigger/build_trigger.tf
@@ -26,6 +26,7 @@ variable "trigger_on_push" {
     branch         = optional(string)
     tag            = optional(string)
     included_files = optional(list(string), [])
+    ignored_files  = optional(list(string), [])
   })
   default = null
 }
@@ -126,6 +127,7 @@ resource "google_cloudbuild_trigger" "trigger" {
   }
 
   included_files = var.trigger_on_push != null ? var.trigger_on_push.included_files : null
+  ignored_files = var.trigger_on_push != null ? var.trigger_on_push.ignored_files : null
 
   build {
     dynamic "step" {

--- a/infra/terraform_modules/xla_docker_build/variables.tf
+++ b/infra/terraform_modules/xla_docker_build/variables.tf
@@ -41,6 +41,7 @@ variable "trigger_on_push" {
     branch         = optional(string)
     tag            = optional(string)
     included_files = optional(list(string), [])
+    ignored_files  = optional(list(string), [])
   })
   default = null
 }

--- a/infra/tpu-pytorch/test_triggers.tf
+++ b/infra/tpu-pytorch/test_triggers.tf
@@ -3,7 +3,10 @@ module "tpu_e2e_tests" {
 
   trigger_name = "ci-tpu-test-trigger"
 
-  trigger_on_push = { branch = "master" }
+  trigger_on_push = {
+    branch = "master"
+    ignored_files = ["experimental/torch_xla2/**"]
+  }
   run_e2e_tests   = true
 
   image_name = "pytorch-xla-test"


### PR DESCRIPTION
Now that more PRs are going into `torch_xla2`, we are getting timeouts when the CI should be running on the main package.

Terraform plan

```
Terraform will perform the following actions:

  # module.tpu_e2e_tests.module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch/triggers/8e11b2bb-f1f1-4d48-ac05-315f16d15c5d"
      ~ ignored_files      = [
          + "experimental/torch_xla2/**",
        ]
        name               = "ci-tpu-test-trigger"
        tags               = []
        # (12 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```