### PR TITLE
Skip dynamo collective tests on TPU v2 CI

### DIFF
--- a/test/pjrt/test_collective_ops_tpu.py
+++ b/test/pjrt/test_collective_ops_tpu.py
@@ -139,11 +139,10 @@ class TestXMCollectiveOpsTpu(parameterized.TestCase):
                                              list(range(world_size))]])
 
 
-# Test for collective ops from torch.distributed
-@absltest.skipIf(
-    lambda: tpu.num_logical_cores_per_chip() >= 2,
-    "Dynamo not supported on TPU v2/v3")
+@absltest.skipIf(lambda: tpu.num_logical_cores_per_chip() >= 2,
+                 "Dynamo not supported on TPU v2/v3")
 class TestDistCollectiveOpsTpu(parameterized.TestCase):
+  """Test for collective ops from torch.distributed"""
 
   @staticmethod
   def _all_reduce(use_dynamo: bool):

--- a/test/pjrt/test_collective_ops_tpu.py
+++ b/test/pjrt/test_collective_ops_tpu.py
@@ -140,6 +140,9 @@ class TestXMCollectiveOpsTpu(parameterized.TestCase):
 
 
 # Test for collective ops from torch.distributed
+@absltest.skipIf(
+    lambda: tpu.num_logical_cores_per_chip() >= 2,
+    "Dynamo not supported on TPU v2/v3")
 class TestDistCollectiveOpsTpu(parameterized.TestCase):
 
   @staticmethod


### PR DESCRIPTION
Should fix test timeouts caused by `TestDistCollectiveOpsTpu.test_all_gather_dynamo`

![image](https://github.com/user-attachments/assets/9a077e54-f053-4ab6-849d-0428fd0fee98)
