### PR TITLE
Op Info tests `broadcast_tensors`, `count_nonzero`, `cov`, `cross`, and `equal`

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -40,7 +40,6 @@ skiplist = {
     "diff",
     "digamma",
     "dist",
-    "equal",
     "erfc",
     "erfinv",
     "expand",

--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -27,7 +27,6 @@ skiplist = {
     "cholesky_solve",
     "combinations",
     "complex",
-    "cov",
     "cross",
     "cummax",
     "cummin",

--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -16,7 +16,6 @@ skiplist = {
     "_upsample_bilinear2d_aa",
     "bincount", # NOTE: dtype for int input torch gives float. This is weird.
     "block_diag",
-    "broadcast_tensors",
     "bucketize",
     "byte",
     "cat",

--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -26,7 +26,6 @@ skiplist = {
     "cholesky_solve",
     "combinations",
     "complex",
-    "cross",
     "cummax",
     "cummin",
     "cumsum",

--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -26,8 +26,6 @@ skiplist = {
     "cholesky_solve",
     "combinations",
     "complex",
-    "cummax",
-    "cummin",
     "cumsum",
     "diag",
     "diag_embed",

--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -27,7 +27,6 @@ skiplist = {
     "cholesky_solve",
     "combinations",
     "complex",
-    "count_nonzero",
     "cov",
     "cross",
     "cummax",

--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -26,6 +26,8 @@ skiplist = {
     "cholesky_solve",
     "combinations",
     "complex",
+    "cummax",
+    "cummin",
     "cumsum",
     "diag",
     "diag_embed",

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -1725,6 +1725,10 @@ def _aten_broadcast_tensors(*tensors):
     res = tuple(i for i, (in_dim, out_dim) in enumerate(zip(input_shape, output_shape)))
     return res
 
+  # clean some function's previous wrap
+  if len(tensors)==1 and len(tensors[0])>=1 and isinstance(tensors[0][0], jax.Array):
+    tensors = tensors[0]
+
   # Get the shapes of all input tensors
   shapes = [t.shape for t in tensors]
   # Find the output shape by broadcasting all input shapes

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -924,7 +924,10 @@ def _aten_max_pool2d_with_indices(
 
 @op(torch.ops.aten.min)
 def _aten_min(x, axis=None):
-  return jnp.min(x, axis=axis), jnp.argmin(x, axis=axis).astype(jnp.int64)
+  if axis:
+    return jnp.min(x, axis=axis), jnp.argmin(x, axis=axis).astype(jnp.int64)
+  else:
+    return jnp.min(x, axis=axis)
 
 
 @op(torch.ops.aten.amin)

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -1760,6 +1760,13 @@ def _aten_eq(input1, input2):
   return input1 == input2
 
 
+# aten.equal
+@op(torch.ops.aten.equal, is_jax_function=False)
+def _aten_equal(input, other):
+  res = jnp.array_equal(input._elem, other._elem)
+  return bool(res)
+
+
 # aten.erf
 @op(torch.ops.aten.erf)
 @op_base.promote_int_input


### PR DESCRIPTION
enable torchxla2 ops `broadcast_tensors`, `count_nonzero`, `cov`, `cross`, and `equal`

fix https://github.com/pytorch/xla/issues/7394, `broadcast_tensors`
fix https://github.com/pytorch/xla/issues/7370, `count_nonzero`
fix https://github.com/pytorch/xla/issues/7371, `cov`
fix https://github.com/pytorch/xla/issues/7372, `cross`
fix https://github.com/pytorch/xla/issues/7408, `equal`