### PR TITLE
Remove numpy pin for upstream image

### DIFF
--- a/.github/upstream/install_conda.sh
+++ b/.github/upstream/install_conda.sh
@@ -30,7 +30,7 @@ function install_and_setup_conda() {
   conda update -y -n base conda
   conda install -y python=$PYTHON_VERSION
 
-  conda install -y nomkl numpy=1.18.5 pyyaml setuptools \
+  conda install -y nomkl numpy pyyaml setuptools \
     cffi typing tqdm coverage hypothesis dataclasses cython
 
   /usr/bin/yes | pip install mkl==2022.2.1


### PR DESCRIPTION
This numpy dates back to June 2020: https://pypi.org/project/numpy/1.18.5/

Currently causing the following error:

```
#23 396.7 Could not solve for environment specs
#23 396.7 The following packages are incompatible
#23 396.7 ├─ numpy 1.18.5**  is installable with the potential options
#23 396.7 │  ├─ numpy 1.18.5 would require
#23 396.7 │  │  └─ python >=3.6,<3.7.0a0 , which can be installed;
#23 396.7 │  ├─ numpy 1.18.5 would require
#23 396.7 │  │  └─ python >=3.7,<3.8.0a0 , which can be installed;
#23 396.7 │  └─ numpy 1.18.5 would require
#23 396.7 │     └─ python >=3.8,<3.9.0a0 , which can be installed;
#23 396.7 └─ pin-1 is not installable because it requires
#23 396.7    └─ python 3.10.* , which conflicts with any installable versions previously reported.
```