### PR TITLE
Run ansible release stage after local builds are installed

### DIFF
--- a/infra/ansible/e2e_tests.Dockerfile
+++ b/infra/ansible/e2e_tests.Dockerfile
@@ -17,10 +17,6 @@ WORKDIR /ansible
 RUN pip install ansible
 COPY . /ansible
 
-# Install runtime pip and apt dependencies.
-ARG ansible_vars
-RUN ansible-playbook -vvv playbook.yaml -e "stage=release" -e "${ansible_vars}" --tags "install_deps"
-
 # Copy test sources.
 RUN mkdir -p /src/pytorch/xla
 COPY --from=build /src/pytorch/xla/test /src/pytorch/xla/test
@@ -32,6 +28,10 @@ COPY --from=build /dist/*.whl ./
 
 RUN echo "Installing the following wheels" && ls *.whl
 RUN pip install *.whl
+
+# Install runtime pip and apt dependencies.
+ARG ansible_vars
+RUN ansible-playbook -vvv playbook.yaml -e "stage=release" -e "${ansible_vars}" --tags "install_deps"
 
 WORKDIR /
 

--- a/infra/ansible/e2e_tests.Dockerfile
+++ b/infra/ansible/e2e_tests.Dockerfile
@@ -13,9 +13,6 @@ RUN ansible-playbook -vvv playbook.yaml -e "stage=build" -e "${ansible_vars}"
 RUN ansible-playbook -vvv playbook.yaml -e "stage=build_plugin" -e "${ansible_vars}" --skip-tags=fetch_srcs,install_deps
 
 FROM python:${python_version}-${debian_version}
-WORKDIR /ansible
-RUN pip install ansible
-COPY . /ansible
 
 # Copy test sources.
 RUN mkdir -p /src/pytorch/xla
@@ -29,6 +26,9 @@ COPY --from=build /dist/*.whl ./
 RUN echo "Installing the following wheels" && ls *.whl
 RUN pip install *.whl
 
+WORKDIR /ansible
+RUN pip install ansible
+COPY . /ansible
 # Install runtime pip and apt dependencies.
 ARG ansible_vars
 RUN ansible-playbook -vvv playbook.yaml -e "stage=release" -e "${ansible_vars}" --tags "install_deps"

--- a/infra/tpu-pytorch/test_triggers.tf
+++ b/infra/tpu-pytorch/test_triggers.tf
@@ -33,6 +33,7 @@ module "tpu_e2e_tests" {
     # The commit ID associated with the triggered build. Substituted when
     # Cloud Build is triggered.
     xla_git_rev = "$COMMIT_SHA"
+    bundle_libtpu = "0"
   }
 
   # Substitutions used in the "run_e2e_tests" step, see

--- a/setup.py
+++ b/setup.py
@@ -292,6 +292,7 @@ setup(
         'absl-py>=1.0.0',
         'numpy',
         'pyyaml',
+        'requests',
         # importlib.metadata backport required for PJRT plugin discovery prior
         # to Python 3.10
         'importlib_metadata>=4.6;python_version<"3.10"',


### PR DESCRIPTION
The release stage installs `torch_xla[tpu]`, but we need this to correspond to the locally-built wheel and not the last release on PyPI so that it installs the right libtpu.

Unbundle libtpu so we don't install it twice.

Terraform plan:

<details>

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.tpu_e2e_tests.module.cloud_build.google_cloudbuild_trigger.trigger will be updated in-place
  ~ resource "google_cloudbuild_trigger" "trigger" {
        id                 = "projects/tpu-pytorch/triggers/8e11b2bb-f1f1-4d48-ac05-315f16d15c5d"
        name               = "ci-tpu-test-trigger"
        tags               = []
        # (13 unchanged attributes hidden)

      ~ build {
            tags          = []
            # (5 unchanged attributes hidden)

          ~ step {
              ~ args             = [
                    "-c",
                  ~ "docker build --progress=plain --network=cloudbuild -f=e2e_tests.Dockerfile . --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch/docker/pytorch-xla-test:$(echo $BUILD_ID)\" -t=local_image" -> "docker build --progress=plain --network=cloudbuild -f=e2e_tests.Dockerfile . --build-arg=python_version=3.10 --build-arg=ansible_vars='{\"accelerator\":\"tpu\",\"arch\":\"amd64\",\"bundle_libtpu\":\"0\",\"pytorch_git_rev\":\"main\",\"xla_git_rev\":\"$COMMIT_SHA\"}' -t=\"us-central1-docker.pkg.dev/tpu-pytorch/docker/pytorch-xla-test:$(echo $BUILD_ID)\" -t=local_image",
                ]
                id               = "build_pytorch-xla-test_docker_image"
                name             = "gcr.io/cloud-builders/docker"
                # (10 unchanged attributes hidden)
            }

            # (5 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

</details>