### PR TITLE
[torch_xla2] Fix type promotions by `aten::copy_` and `aten::rand_like`

### DIFF
--- a/experimental/torch_xla2/test/test_core_aten_ops.py
+++ b/experimental/torch_xla2/test/test_core_aten_ops.py
@@ -1,3 +1,4 @@
+import math
 import unittest
 
 import torch
@@ -4346,6 +4347,13 @@ class TestCoreAtenOps(unittest.TestCase):
     )
     kwargs = dict()
     run_export_and_compare(self, torch.ops.aten.copy_, args, kwargs, check_dtype=True)
+
+  def test_aten_rand_like(self):
+    args = (
+      torch.ones((3, 3), dtype=torch.bfloat16),
+    )
+    kwargs = dict()
+    run_export_and_compare(self, torch.ops.aten.rand_like, args, kwargs, atol=math.inf, check_dtype=True)
 
 
 if __name__ == "__main__":

--- a/experimental/torch_xla2/test/test_mutations.py
+++ b/experimental/torch_xla2/test/test_mutations.py
@@ -34,16 +34,6 @@ class TestMutations(TestCase):
       xt = torch_xla2.tensor.j2t(x._elem)
       self.assertEqual(xt, torch.tensor([4, 10, 18], dtype=torch.int32))
 
-  def test_div(self):
-    with self.env:
-      x = torch.tensor([1, 2, 3], dtype=torch.int32)
-      y = torch.tensor([4, 5, 6], dtype=torch.int32)
-
-      x.div_(y)
-      xt = torch_xla2.tensor.j2t(x._elem)
-      self.assertEqual(xt,
-                      torch.tensor([1. / 4, 2. / 5, 3. / 6], dtype=torch.float))
-
 
 if __name__ == '__main__':
   unittest.main()

--- a/experimental/torch_xla2/test_dist/test_distributed.py
+++ b/experimental/torch_xla2/test_dist/test_distributed.py
@@ -95,7 +95,7 @@ def test_all_reduce(op, expected, multi_cpu, process_group):
   ("op", "expected"),
   [
     ("sum", sum(range(4))),
-    ("avg", sum(range(4)) / 4),
+    ("avg", sum(range(4)) // 4),
     ("min", 0),
     ("max", 3),
   ],

--- a/experimental/torch_xla2/test_dist/test_distributed.py
+++ b/experimental/torch_xla2/test_dist/test_distributed.py
@@ -73,7 +73,7 @@ def test_all_gather_tensor_func(multi_cpu, process_group):
   ("op", "expected"),
   [
     (dist.ReduceOp.SUM, sum(range(4))),
-    (dist.ReduceOp.AVG, sum(range(4)) / 4),
+    (dist.ReduceOp.AVG, sum(range(4)) // 4),
     (dist.ReduceOp.MIN, 0),
     (dist.ReduceOp.MAX, 3),
   ],
@@ -95,7 +95,7 @@ def test_all_reduce(op, expected, multi_cpu, process_group):
   ("op", "expected"),
   [
     ("sum", sum(range(4))),
-    ("avg", sum(range(4)) // 4),
+    ("avg", sum(range(4)) / 4),
     ("min", 0),
     ("max", 3),
   ],

--- a/experimental/torch_xla2/torch_xla2/decompositions.py
+++ b/experimental/torch_xla2/torch_xla2/decompositions.py
@@ -100,7 +100,7 @@ _try_register(aten.bernoulli.default, bernoulli)
 
 
 def rand_like(self, **kwargs):
-    dtype = kwargs.get('dtype')
+    dtype = kwargs.get('dtype', self.dtype)
     return torch.rand(self.shape, dtype=dtype)
 
 def channel_shuffle(self, groups):

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -80,7 +80,7 @@ def _aten_add(x, y, *, alpha=1):
 
 @op(torch.ops.aten.copy_, torch.ops.aten.copy_.default, is_jax_function=False)
 def _aten_copy(x, y, memory_format=None):
-  x._elem = y._elem
+  x._elem = y._elem.astype(x._elem.dtype)
   return x
 
 


### PR DESCRIPTION
Ensure `copy_` doesn't modify the target tensor's dtype and add a test case. For example:

```
>>> import torch
>>> t1 = torch.ones((3, 3), dtype=torch.int32)
>>> t2 = torch.zeros((3, 3), dtype=torch.float32)
>>> t1.copy_(t2)
tensor([[0, 0, 0], # values are copied
        [0, 0, 0],
        [0, 0, 0]], dtype=torch.int32) # but dtype still int32
```

Remove a `div_` test case that doesn't match `torch` behavior, but relies on incorrect `copy_` behavior:

```
>>> import torch
>>> x = torch.tensor([1, 2, 3], dtype=torch.int32)
>>> y = torch.tensor([4, 5, 6], dtype=torch.int32)
>>> x.div_(y)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: result type Float can't be cast to the desired output type Int
```

Tweak a distributed test case that relied on `div_` casting dtypes.

`rand_like` was not propagating `dtype` at all.