### PR TITLE
Unpin `scipy` in upstream CI image

### DIFF
--- a/.github/upstream/install_conda.sh
+++ b/.github/upstream/install_conda.sh
@@ -45,7 +45,7 @@ function install_and_setup_conda() {
   /usr/bin/yes | pip install pandas
   /usr/bin/yes | pip install tabulate
   # Additional PyTorch requirements
-  /usr/bin/yes | pip install scikit-image scipy==1.6.3
+  /usr/bin/yes | pip install scikit-image scipy
   /usr/bin/yes | pip install boto3==1.16.34
   /usr/bin/yes | pip install mypy==0.812
   /usr/bin/yes | pip install psutil


### PR DESCRIPTION
Tested with a local build this time and it passes.

This version of scipy is ancient: https://pypi.org/project/scipy/1.6.3/