### PR TITLE
[torch_xla2] Fix the test of `cumsum`

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -32,7 +32,6 @@ skiplist = {
     "cross",
     "cummax",
     "cummin",
-    "cumsum",
     "diag",
     "diag_embed",
     "diagflat",

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -539,6 +539,8 @@ def _aten_ne(x, y):
 def _aten_cumsum(x, y, dtype=None):
   if dtype:
     dtype = mappings.t2j_dtype(dtype)
+  if not x.shape:
+    return x
   res = jnp.cumsum(x, y, dtype)
   return res
 


### PR DESCRIPTION
torch supports cumsum on scalar tensor but jnp does not.

resolve #7376 