### PR TITLE
Remove `TPU_LIBRARY_PATH` from legacy TPU CI

### DIFF
--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -46,8 +46,6 @@ spec:
       pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
 
       cd /src/pytorch/xla
-      # TODO: pallas test requires JAX, now we need to explicitly set TPU_LIBRARY_PATH for JAX, need a permanent fix.
-      TPU_LIBRARY_PATH=/usr/local/lib/python3.10/site-packages/torch_xla/lib/libtpu.so test/tpu/run_tests.sh
     volumeMounts:
     - mountPath: /dev/shm
       name: dshm


### PR DESCRIPTION
This is causing failures after setting `BUNDLE_LIBTPU=0` in this build:

```
Step #4 - "run_e2e_tests": + cd /src/pytorch/xla
Step #4 - "run_e2e_tests": + TPU_LIBRARY_PATH=/usr/local/lib/python3.10/site-packages/torch_xla/lib/libtpu.so
Step #4 - "run_e2e_tests": + test/tpu/run_tests.sh
Step #4 - "run_e2e_tests": + python3 test/test_operations.py -v
Step #4 - "run_e2e_tests": test_mp_decorator (__main__.MpDecoratorTest) ... [external/com_google_absl/absl/status/statusor.cc : 83] RAW: Attempting to fetch value instead of handling error INTERNAL: Failed to open /usr/local/lib/python3.10/site-packages/torch_xla/lib/libtpu.so: /usr/local/lib/python3.10/site-packages/torch_xla/lib/libtpu.so: cannot open shared object file: No such file or directory
Step #4 - "run_e2e_tests": test/tpu/run_tests.sh: line 5:    20 Aborted                 (core dumped) python3 test/test_operations.py -v
```

I'm not sure what this was originally supposed to do, but both PyTorch and JAX should find the `libtpu-nightly` package on their own now