### PR TITLE
Add Build Trigger for 2.5-rc1 release

### DIFF
--- a/infra/ansible/config/vars.yaml
+++ b/infra/ansible/config/vars.yaml
@@ -7,7 +7,7 @@ cuda_compute_capabilities: 7.0,7.5,8.0,9.0
 llvm_debian_repo: bullseye
 clang_version: 17
 # PyTorch and PyTorch/XLA wheel versions.
-package_version: 2.5.0
+package_version: 2.6.0
 # If set to true, wheels will be renamed to $WHEEL_NAME-nightly-cp38-cp38-linux_x86_64.whl.
 nightly_release: false
 # Whether to preinstall libtpu in the PyTorch/XLA wheel. Ignored for GPU build.

--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -1,4 +1,4 @@
-nightly_package_version = "2.5.0"
+nightly_package_version = "2.6.0"
 
 # Built once a day from master.
 nightly_builds = [

--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -35,6 +35,88 @@ nightly_builds = [
 versioned_builds = [
   # Remove libtpu from PyPI builds
   {
+    git_tag         = "v2.5.0-rc1"
+    package_version = "2.5.0-rc1"
+    pytorch_git_rev = "v2.5.0-rc1"
+    accelerator     = "tpu"
+    python_version  = "3.9"
+    bundle_libtpu   = "0"
+  },
+  {
+    git_tag         = "v2.5.0-rc1"
+    package_version = "2.5.0-rc1"
+    pytorch_git_rev = "v2.5.0-rc1"
+    accelerator     = "tpu"
+    python_version  = "3.10"
+    bundle_libtpu   = "0"
+  },
+  {
+    git_tag         = "v2.5.0-rc1"
+    package_version = "2.5.0-rc1"
+    pytorch_git_rev = "v2.5.0-rc1"
+    accelerator     = "tpu"
+    python_version  = "3.11"
+    bundle_libtpu   = "0"
+  },
+  # Bundle libtpu for Kaggle
+  {
+    git_tag         = "v2.5.0-rc1"
+    package_version = "2.5.0-rc1+libtpu"
+    pytorch_git_rev = "v2.5.0-rc1"
+    accelerator     = "tpu"
+    python_version  = "3.10"
+    bundle_libtpu   = "1"
+  },
+  {
+    git_tag         = "v2.5.0-rc1"
+    package_version = "2.5.0-rc1"
+    pytorch_git_rev = "v2.5.0-rc1"
+    accelerator     = "cuda"
+    cuda_version    = "12.1"
+    python_version  = "3.9"
+  },
+  {
+    git_tag         = "v2.5.0-rc1"
+    pytorch_git_rev = "v2.5.0-rc1"
+    package_version = "2.5.0-rc1"
+    accelerator     = "cuda"
+    cuda_version    = "12.1"
+    python_version  = "3.10"
+  },
+  {
+    git_tag         = "v2.5.0-rc1"
+    package_version = "2.5.0-rc1"
+    pytorch_git_rev = "v2.5.0-rc1"
+    accelerator     = "cuda"
+    cuda_version    = "12.1"
+    python_version  = "3.11"
+  },
+  {
+    git_tag         = "v2.5.0-rc1"
+    package_version = "2.5.0-rc1"
+    pytorch_git_rev = "v2.5.0-rc1"
+    accelerator     = "cuda"
+    cuda_version    = "12.4"
+    python_version  = "3.9"
+  },
+  {
+    git_tag         = "v2.5.0-rc1"
+    package_version = "2.5.0-rc1"
+    pytorch_git_rev = "v2.5.0-rc1"
+    accelerator     = "cuda"
+    cuda_version    = "12.4"
+    python_version  = "3.10"
+  },
+  {
+    git_tag         = "v2.5.0-rc1"
+    package_version = "2.5.0-rc1"
+    pytorch_git_rev = "v2.5.0-rc1"
+    accelerator     = "cuda"
+    cuda_version    = "12.4"
+    python_version  = "3.11"
+  },
+  # Remove libtpu from PyPI builds
+  {
     git_tag         = "v2.4.0"
     package_version = "2.4.0"
     pytorch_git_rev = "v2.4.0"

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ def get_git_head_sha(base_dir):
 
 
 def get_build_version(xla_git_sha):
-  version = os.getenv('TORCH_XLA_VERSION', '2.5.0')
+  version = os.getenv('TORCH_XLA_VERSION', '2.6.0')
   if build_util.check_env_flag('GIT_VERSIONED_XLA_BUILD', default='TRUE'):
     try:
       version += '+git' + xla_git_sha[:7]


### PR DESCRIPTION
add build trigger for 2.5-rc1 release, rc number would depends on upstream rc number

~merge this PR after upstream has added rc tag~ PyTorch has `v2.5.0-rc1` tag now

reference:
- update nightly version to 2.6.0: https://github.com/pytorch/xla/pull/6176
- update absible used version to 2.6.0: https://github.com/pytorch/xla/pull/6458
- update setup.py to next version 2.6.0: https://github.com/pytorch/xla/pull/6617