### PR TITLE
Fixed Masked norm op implementation

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -127,7 +127,6 @@ skiplist = {
     "masked.logsumexp",
     "masked.mean",
     "masked.median",
-    "masked.norm",
     "masked.normalize",
     "masked.prod",
     "masked_scatter",

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -595,7 +595,7 @@ def _aten_native_layer_norm(
   """
   if isinstance(normalized_shape, int):
     normalized_shape = [normalized_shape]
-  axis = [i for i, d in enumerate(input.shape) if d in normalized_shape]
+  axis = [len(input.shape) - i - 1 for i in range(len(normalized_shape))]
 
   # Calculate mean and standard deviation
   mean = jnp.mean(input, axis=axis, keepdims=True)


### PR DESCRIPTION
Fixes masked.norm op implementation and passes test_ops.py test after removing masked.norm from the skiplist.

Ref: #7510 
