### PR TITLE
duplicate for https://github.com/pytorch/xla/pull/7961

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -28,7 +28,7 @@ skiplist = {
     "complex",
     "cummax",
     "cummin",
-    "diag",
+    # "diag",
     "diag_embed",
     "diagflat",
     "diagonal_copy",

--- a/experimental/torch_xla2/torch_xla2/ops/jtorch.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jtorch.py
@@ -63,6 +63,10 @@ def _torch_argsort(input, dim=-1, descending=False, stable=False):
     res = res.squeeze()
   return res
 
+@register_function(torch.diag)
+def _diag(input, diagonal=0):
+  return jnp.diag(input, k=diagonal)
+
 @register_function(torch.einsum)
 def _einsum(equation, *operands):
   def get_params(*a):


### PR DESCRIPTION
duplicate PR for https://github.com/pytorch/xla/pull/7961

due to `matrix_exp` failed in https://github.com/pytorch/xla/pull/7961's CI, and `matrix_exp` is not decomponent-related with `diag`, so create this PR to do duplicate test