### PR TITLE
Update torchxla2 installation for torch on mac and others

### DIFF
--- a/experimental/torch_xla2/dev-requirements.txt
+++ b/experimental/torch_xla2/dev-requirements.txt
@@ -1,3 +1,4 @@
 -f https://download.pytorch.org/whl/torch
-torch==2.4.0+cpu
+torch==2.4.0; sys_platform == 'darwin'  # macOS
+torch==2.4.0+cpu; sys_platform != 'darwin' # Non-macOS (CPU-only), like on TPU
 ruff~=0.3.5


### PR DESCRIPTION
Update torchxla2 installation for torch on mac and others, due to MAC don't install torch+cpu, so split the torch verison to be installed for MAC env or not