### PR TITLE
Use a different str for device instead of meta

### DIFF
--- a/experimental/torch_xla2/README.md
+++ b/experimental/torch_xla2/README.md
@@ -131,6 +131,15 @@ with env:
   print(type(res))  # outputs XLATensor2
 ```
 
+You can also enable the environment globally with
+```python
+import torch_xla2
+
+torch_xla2.enable_globally() 
+```
+
+Then everything afterwards is run with XLA.
+
 ## What is happening behind the scene:
 
 When a torch op is executed inside of `env` context manager, we can swap out the 

--- a/experimental/torch_xla2/test/test_mutations.py
+++ b/experimental/torch_xla2/test/test_mutations.py
@@ -14,16 +14,14 @@ class TestMutations(TestCase):
       x = torch.tensor([1, 2, 3], dtype=torch.int32)
       y = torch.tensor([4, 5, 6], dtype=torch.int32)
       x.add_(y)
-      xt = torch_xla2.tensor.j2t(x._elem)
-      self.assertEqual(xt, torch.tensor([5, 7, 9], dtype=torch.int32))
+      self.assertEqual(x, torch.tensor([5, 7, 9], dtype=torch.int32))
 
   def test_sub(self):
     with self.env:
       x = torch.tensor([1, 2, 3], dtype=torch.int32)
       y = torch.tensor([4, 5, 6], dtype=torch.int32)
       x.sub_(y)
-      xt = torch_xla2.tensor.j2t(x._elem)
-      self.assertEqual(xt, torch.tensor([-3, -3, -3], dtype=torch.int32))
+      self.assertEqual(x, torch.tensor([-3, -3, -3], dtype=torch.int32))
 
   def test_mul(self):
     with self.env:
@@ -31,8 +29,7 @@ class TestMutations(TestCase):
       y = torch.tensor([4, 5, 6], dtype=torch.int32)
 
       x.mul_(y)
-      xt = torch_xla2.tensor.j2t(x._elem)
-      self.assertEqual(xt, torch.tensor([4, 10, 18], dtype=torch.int32))
+      self.assertEqual(x, torch.tensor([4, 10, 18], dtype=torch.int32))
 
 
 if __name__ == '__main__':

--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -391,6 +391,7 @@ class TestOpInfo(TestCase):
 
   def setUp(self):
     self.env = tensor.Environment()
+    torch.manual_seed(0)
 
   # Replaces all values in the input torch_tensor that are less than the given threshold
   # with the threshold value itself.

--- a/experimental/torch_xla2/torch_xla2/__init__.py
+++ b/experimental/torch_xla2/torch_xla2/__init__.py
@@ -11,6 +11,7 @@ VERSION = __version__
 __all__ = [
   'default_env',
   'extract_jax',
+  'enable_globally',
 ]
 
 from jax._src import xla_bridge
@@ -61,3 +62,22 @@ def extract_jax(mod: torch.nn.Module, env=None):
     return env.t2j_iso(res)
 
   return states, jax_func
+
+def enable_globally():
+  global env 
+  env = default_env().__enter__()
+  return env
+
+def disable_globally():
+  global env 
+  default_env().__exit__(None, None, None)
+
+
+torch.utils.rename_privateuse1_backend('jax')
+unsupported_dtype = [torch.quint8]
+torch.utils.generate_methods_for_privateuse1_backend(
+  for_tensor=True, for_module=True, for_storage=True, 
+  unsupported_dtype=unsupported_dtype)
+
+import jax
+torch._register_device_module('jax', jax)

--- a/experimental/torch_xla2/torch_xla2/config.py
+++ b/experimental/torch_xla2/torch_xla2/config.py
@@ -11,3 +11,7 @@ class Configuration:
     # Flash attention
     use_tpu_flash_attention: bool = False
     shmap_flash_attention: bool = False
+
+    # device
+    treat_cuda_as_jax_device: bool = True
+    use_torch_native_for_cpu_tensor: bool = False

--- a/experimental/torch_xla2/torch_xla2/interop.py
+++ b/experimental/torch_xla2/torch_xla2/interop.py
@@ -91,7 +91,7 @@ def _jax_view(t: TorchValue) -> JaxValue:
         assert isinstance(t, tensor.XLATensor2)
         return t.jax()
     if isinstance(t, type(torch.int32)):
-        return tensor.j2t_dtype(t)
+        return tensor.t2j_dtype(t)
 
     # torch.nn.Module needs special handling
     if not isinstance(t, torch.nn.Module) and callable(t):  # t is a TorchCallable

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -1645,7 +1645,6 @@ def _aten_arange(
   requires_grad=False,
   device=None,
   pin_memory=False,
-  **kwargs
 ):
   return jnp.arange(
     op_base.maybe_convert_constant_dtype(start, dtype),

--- a/experimental/torch_xla2/torch_xla2/ops/op_base.py
+++ b/experimental/torch_xla2/torch_xla2/ops/op_base.py
@@ -55,7 +55,10 @@ def convert_dtype(use_default_dtype: bool = True):
                 **kwargs: P.kwargs):
       if not dtype and use_default_dtype:
         dtype = torch.get_default_dtype()
-      jax_dtype = mappings.t2j_dtype(dtype)
+      if isinstance(dtype, torch.dtype):
+        jax_dtype = mappings.t2j_dtype(dtype)
+      else:
+        jax_dtype = dtype
 
       return func(*args, dtype=jax_dtype, **kwargs)
 


### PR DESCRIPTION
Implements this idea: https://github.com/pytorch/xla/pull/7705 but without the C++ piece.

We could use anything for the device (incl just a string: https://github.com/albanD/subclass_zoo/blob/main/new_device.py); however it's advantagous to use a torch.device with an existing registered key. (we could use 'xla:0' too). 

The caveat is that we need to capture tensor constructors in jtorch instead of jaten (like it used to be) because otherwise torch will check if such device module is loaded or not (example for capturing 'cuda').

fixes #7966