### PR TITLE
Remove contiguity assertion from `XLATensorImpl`.

### DIFF
--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -173,8 +173,8 @@ int64_t XLATensorImpl::numel_custom() const {
 }
 
 bool XLATensorImpl::is_contiguous_custom(at::MemoryFormat memory_format) const {
-  // Only check that the storage is already contiguous.
-  XLA_CHECK(is_contiguous_) << "Non-contiguous storage for XLA tensor";
+  // Storage is always contiguous, but the tensor metadata is_contiguous_ might
+  // be false due to the update in the functionalization layer..
   return true;
 }
 


### PR DESCRIPTION
This PR reflects the changes in the PyTorch PR https://github.com/pytorch/pytorch/pull/135237. Basically, it removes the contiguity assertion due to a possible metadata change in the functionalization kernel.

Specifically, at the end of each functionalization kernel, `at::functionalization::impl::set_sizes_strides_offset` is called. It modifies the metadata of the output tensors, so that they match the metadata of eager. Such a metadata update might set `TensorImpl::is_contiguous_` to false.

cc @miladm @JackCaoG @alanwaketan 