### PR TITLE
[benchmarks] Disallow `XRT` for XLA:CUDA.

### DIFF
--- a/benchmarks/benchmark_experiment.py
+++ b/benchmarks/benchmark_experiment.py
@@ -114,7 +114,8 @@ class ExperimentLoader:
       if cfg_xla is None:
         return False
     elif cfg_accelerator in ("cpu", "cuda"):
-      pass
+      if cfg_xla == "XRT":
+        return False
     else:
       raise NotImplementedError
 


### PR DESCRIPTION
This PR filters out "XRT" as an option for `xla` configuration on non-TPU experiments.

cc @miladm @zpcore 