### PR TITLE
Implement operations `cummax`, `cummin`

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -25,8 +25,6 @@ skiplist = {
     "cholesky_solve",
     "combinations",
     "complex",
-    "cummax",
-    "cummin",
     "diag_embed",
     "diagflat",
     "diagonal_copy",


### PR DESCRIPTION
The return type of pytorch cummax/cummin is tuple of two output tensors (values, indices).

However jax cummax/cummin does not return same result.

Implement this operation using `associative_scan` with running min/max reduce function.

resolves #7373 
resolves #7374 