### PR TITLE
[torchxla2] Op Info test for fft

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -36,24 +36,6 @@ skiplist = {
     "erfinv",
     "expand",
     "exponential",
-    "fft.fft2",
-    "fft.fft",
-    "fft.fftn",
-    "fft.hfft2",
-    "fft.hfft",
-    "fft.hfftn",
-    "fft.ifft2",
-    "fft.ifft",
-    "fft.ifftn",
-    "fft.ihfft2",
-    "fft.ihfft",
-    "fft.ihfftn",
-    "fft.irfft2",
-    "fft.irfft",
-    "fft.irfftn",
-    "fft.rfft2",
-    "fft.rfft",
-    "fft.rfftn",
     "floor_divide",
     "gather",
     "gcd",
@@ -370,6 +352,7 @@ class TestOpInfo(TestCase):
 
   def setUp(self):
     self.env = tensor.Environment()
+    #self.env.config.debug_accuracy_for_each_op = True 
     torch.manual_seed(0)
 
   # Replaces all values in the input torch_tensor that are less than the given threshold


### PR DESCRIPTION
Turns out, all fft ops decomposes to `_fft_c2c, _fft_r2c, and _fft_c2r`.

fixes #7414
fixes #7415
fixes #7416
fixes #7417
fixes #7418
fixes #7419
fixes #7420
fixes #7421
fixes #7422
fixes #7423
fixes #7424
fixes #7425
fixes #7426
fixes #7427
fixes #7428
fixes #7429
fixes #7430
fixes #7431