### PR TITLE
Implement empty_like in torch aten ops

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -31,7 +31,6 @@ skiplist = {
     "diagonal_scatter",
     "diff",
     "digamma",
-    "dist",
     "erfc",
     "erfinv",
     "expand",

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -331,6 +331,10 @@ def _aten_div(x, y, rounding_mode=""):
 def _aten_true_divide(x, y):
   return x / y
 
+@op(torch.ops.aten.dist)
+def _aten_dist(input, other, p=2):
+  diff = jnp.abs(jnp.subtract(input, other))
+  return _aten_linalg_vector_norm(diff, ord=p)
 
 @op(torch.ops.aten.bmm)
 def _aten_bmm(x, y):

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -460,6 +460,12 @@ def _aten_empty(size: Sequence[int], *, dtype=None, **kwargs):
   return jnp.empty(size, dtype=dtype)
 
 
+@op(torch.ops.aten.empty_like)
+@op_base.convert_dtype()
+def _aten_empty_like(input, *, dtype=None, **kwargs):
+  return jnp.empty_like(input, dtype=dtype)
+
+
 @op(torch.ops.aten.ones)
 @op_base.convert_dtype()
 def _ones(size: Sequence[int], dtype=None, **kwargs):


### PR DESCRIPTION
This op is not part of the skip list so no test count changes.
Fixes [#7386](https://github.com/pytorch/xla/issues/7386)

Did a quick verification by comparing outputs from torch and jax:
```
$a=torch.empty((2,3), dtype=torch.int32)
$print(torch.empty_like(a))
tensor([[88391536,    32347, 88390000],
        [   32347, 88391088,    32347]], dtype=torch.int32)

$b=jnp.empty((2,3), dtype=jnp.int32)
$jnp.empty_like(b)
Array([[0, 0, 0],
       [0, 0, 0]], dtype=int32)
```