### PR TITLE
Implement empty_like in torch aten ops

### DIFF
--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -462,6 +462,12 @@ def _aten_empty(size: Sequence[int], *, dtype=None, **kwargs):
   return jnp.empty(size, dtype=dtype)
 
 
+@op(torch.ops.aten.empty_like)
+@op_base.convert_dtype()
+def _aten_empty_like(input, *, dtype=None, **kwargs):
+  return jnp.empty_like(input, dtype=dtype)
+
+
 @op(torch.ops.aten.ones)
 @op_base.convert_dtype()
 def _ones(size: Sequence[int], dtype=None, **kwargs):


### PR DESCRIPTION
This op is not part of the skip list so no test count changes.
Fixes https://github.com/pytorch/xla/issues/7386

Did a quick verification by comparing outputs from torch and jax:
```
$a=torch.empty((2,3), dtype=torch.int32)
$print(torch.empty_like(a))
tensor([[88391536,    32347, 88390000],
        [   32347, 88391088,    32347]], dtype=torch.int32)

$b=jnp.empty((2,3), dtype=jnp.int32)
$jnp.empty_like(b)
Array([[0, 0, 0],
       [0, 0, 0]], dtype=int32)
```