### PR TITLE
Forward `XLATensorImpl::is_contiguous_custom` to `TensorImpl`.

### DIFF
--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -175,7 +175,7 @@ int64_t XLATensorImpl::numel_custom() const {
 bool XLATensorImpl::is_contiguous_custom(at::MemoryFormat memory_format) const {
   // Storage is always contiguous, but the tensor metadata is_contiguous_ might
   // be false due to the update in the functionalization layer..
-  return true;
+  return c10::TensorImpl::is_contiguous_custom(memory_format);
 }
 
 void XLATensorImpl::SetupSizeProperties() {


### PR DESCRIPTION
This PR fixes #7998. Instead of always returning true, we forward this call to the base class `TensorImpl::is_contiguous_custom()`.

The reason is that after https://github.com/pytorch/pytorch/pull/135498 is merged, XLA tensors' metadata might stop reflecting on the actual XLA storage. Which means that the tensors' strides might not always be contiguous. Whenever that happens, `tensor.is_contiguous()` call should be consistent with the tensors' strides.

cc @miladm @JackCaoG @alanwaketan 