### PR TITLE
[torch_xla2] Fix nn.functional.conv2d and conv3d

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -96,8 +96,6 @@ skiplist = {
     "nn.functional.avg_pool2d",
     "nn.functional.avg_pool3d",
     "nn.functional.bilinear",
-    "nn.functional.conv2d",
-    "nn.functional.conv3d",
     "nn.functional.conv_transpose1d",
     "nn.functional.conv_transpose2d",
     "nn.functional.conv_transpose3d",

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -799,7 +799,10 @@ def _aten_convolution(
   if transposed:
     raise NotImplementedError("Transposed convolution is not implemented.")
 
-  def make_padding(padding):
+  def make_padding(padding, num_spatial_dims):
+    # Expand single padding to pairs expected by jax
+    if len(padding) == 1 and len(padding) < num_spatial_dims:
+      padding *= num_spatial_dims
     return ((p, p) for p in padding)
 
   def create_default_conv_dimension_numbers(num_spatial_dims):
@@ -822,7 +825,7 @@ def _aten_convolution(
     input,
     weight,
     stride,
-    make_padding(padding),
+    make_padding(padding, len(stride)),
     lhs_dilation=(1,) * len(stride),
     rhs_dilation=dilation,
     dimension_numbers=create_default_conv_dimension_numbers(len(stride)),


### PR DESCRIPTION
Replicate PyTorch behavior when using single number padding. Ref: https://pytorch.org/docs/stable/generated/torch.nn.functional.conv2d.html#torch.nn.functional.conv2d