### PR TITLE
Check warning msg in second captured warning.

### DIFF
--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -754,7 +754,7 @@ class DynamoErrorMessageTest(unittest.TestCase):
       res = dynamo_resnet18_cpu(input)
       # there should be 18 paramters + 1 input
       self.assertGreater(len(w), 15)
-      self.assertIn('Found tensor with shape torch.Size', str(w[0].message))
+      self.assertIn('Found tensor with shape torch.Size', str(w[1].message))
     self.assertLessEqual(len(met.counter_names()), 1)
 
 


### PR DESCRIPTION
Pytorch will run this in CI and in PR https://github.com/pytorch/pytorch/pull/125888.
We are try to design some new APIs and this ut will trigger a warning since we are using old APIs here.

I do not have an xla at hand and I cannot reproduce it with my cpu device. From my understanding, the warning msg to be checked here should be able to be checked not only on the first warning. 
```
      # there should be 18 paramters + 1 input
      self.assertGreater(len(w), 15)
```
I wander shall we check it at the second warning msg. And no matter whether https://github.com/pytorch/pytorch/pull/125888 is merged, this change does not impact the functionality of this UT?