### PR TITLE
Implement `torch.ops.aten.embedding_renorm_`

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -96,7 +96,6 @@ skiplist = {
     "nn.functional.dropout3d",
     "nn.functional.dropout",
     "nn.functional.embedding_bag",
-    "nn.functional.embedding",
     "nn.functional.fractional_max_pool2d",
     "nn.functional.fractional_max_pool3d",
     "nn.functional.group_norm",


### PR DESCRIPTION
Add lowering `torch.ops.aten.embedding_renorm_` to support embedding. 