### PR TITLE
Remove linalg.matrix_rank from skiplist (#7497)

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -54,7 +54,6 @@ skiplist = {
     "linalg.lu_solve",
     "linalg.matrix_norm",
     "linalg.matrix_power",
-    "linalg.matrix_rank",
     "linalg.solve_ex",
     "linalg.solve_triangular",
     "linalg.svd",


### PR DESCRIPTION
After removing and running test_ops.py still all the tests passed.