### PR TITLE
Part 1: Introduce multi-node SPMD support for Neuron

### DIFF
--- a/torch_xla/runtime.py
+++ b/torch_xla/runtime.py
@@ -253,6 +253,15 @@ def use_spmd(auto: Optional[bool] = False):
     torch_xla._XLAC._xla_set_auto_sharding()
     os.environ["XLA_AUTO_SPMD"] = "1"
 
+  if device_type() == 'NEURON':
+    # In case of Neuron, reset the initialization environment to accommodate SPMD.
+    try:
+      from torch_neuronx.initialization import initialize
+
+      initialize()
+    except ImportError:
+      pass
+
 
 def is_spmd():
   """Returns if SPMD is set for execution."""


### PR DESCRIPTION
In this PR, we adapt to account for a new initialization path that supports multi-node SPMD in Neuron. In order to minimize this change, we retain the xla.init() API, but introduce a reinitialization for PJRT alone once SPMD is enabled. Since enabling SPMD follows the initial Neuron initialization, we require reconfiguring once this is enabled, and if the user did not explicitly set XLA_USE_SPMD (via is_spmd(), as it is currently recommended). Under the hood, both APIs will guarantee that the environment is correctly configured when SPMD is enabled.

In a follow-up, the reinitialization path is moved to torch-xla.