### PR TITLE
Raise error when minibatch is used in SPMD dataloading and per host b…

### DIFF
--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1365,7 +1365,7 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
             mesh, ('data', None, None, None), minibatch=True))
     with self.assertRaisesRegex(
         RuntimeError,
-        "When minibatch is configured, batch dimension of the tensor must be divisible by data mesh*"
+        "When minibatch is configured, batch dimension of the tensor must be divisible by local runtime device count*"
     ):
       data, _ = iter(train_device_loader).__next__()
 

--- a/test/spmd/test_xla_sharding.py
+++ b/test/spmd/test_xla_sharding.py
@@ -1311,6 +1311,8 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
     self.assertEqual(mesh_without_name.mesh_shape,
                      (xr.global_runtime_device_count(),))
 
+  @unittest.skipUnless(xr.global_runtime_device_count() > 1,
+                       "Multiple devices required for dataloader sharding test")
   def test_data_loader_with_sharding(self):
     device = torch_xla.device()
     mesh = xs.get_1d_mesh("data")
@@ -1328,8 +1330,11 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
     self.assertEqual(data.size(), torch.Size([8, 3, 64, 64]))
     self.assertEqual(
         torch_xla._XLAC._get_xla_sharding_spec(data),
-        f"{{devices=[{mesh.size()},1,1,1]0,1,2,3}}")
+        f"{{devices=[{mesh.size()},1,1,1]{','.join([str(i) for i in range(mesh.size())])}}}"
+    )
 
+  @unittest.skipUnless(xr.global_runtime_device_count() > 1,
+                       "Multiple devices required for dataloader sharding test")
   def test_data_loader_with_non_batch_size(self):
     device = torch_xla.device()
     mesh = xs.get_1d_mesh("data")
@@ -1347,8 +1352,11 @@ class BasicXlaShardingTest(test_xla_sharding_base.XlaShardingTest):
     self.assertEqual(data.size(), torch.Size([mesh.size() - 1, 3, 64, 64]))
     self.assertEqual(
         torch_xla._XLAC._get_xla_sharding_spec(data),
-        f"{{devices=[{mesh.size()},1,1,1]0,1,2,3}}")
+        f"{{devices=[{mesh.size()},1,1,1]{','.join([str(i) for i in range(mesh.size())])}}}"
+    )
 
+  @unittest.skipUnless(xr.global_runtime_device_count() > 1,
+                       "Multiple devices required for dataloader sharding test")
   def test_data_loader_with_non_batch_size_and_mini_batch(self):
     device = torch_xla.device()
     mesh = xs.get_1d_mesh("data")

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -1309,9 +1309,8 @@ def send_cpu_data_to_device(
                                               data_mesh_dim) != 0:
           raise RuntimeError(
               "When minibatch is configured, batch dimension of the tensor " +
-              "must be divisible by data mesh dimension.input data shape " + 
-              f"={tensor.size()}, mesh data dimension = {data_mesh_dim}"
-          )
+              "must be divisible by data mesh dimension.input data shape " +
+              f"={tensor.size()}, mesh data dimension = {data_mesh_dim}")
 
     xtensors = torch_xla._XLAC._xla_tensors_from_aten(tensors, devices,
                                                       shardings)

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -1299,6 +1299,20 @@ def send_cpu_data_to_device(
     shardings = None
     if input_sharding:
       shardings = [input_sharding.xla_spec(t) for t in tensors]
+    if input_sharding and input_sharding.minibatch:
+      # when minibatch is configured we must make sure batch dimension of
+      # the tensor is divisible by the data mesh dimension.
+      data_mesh_dim = input_sharding.mesh.mesh_shape[0]
+      for tensor, sharding in zip(tensors, shardings):
+        # assume batch dimension is 0
+        if sharding and tensor.dim() > 0 and (tensor.size()[0] %
+                                              data_mesh_dim) != 0:
+          raise RuntimeError(
+              "When minibatch is configured, batch dimension of the tensor " +
+              "must be divisible by data mesh dimension.input data shape " + 
+              f"={tensor.size()}, mesh data dimension = {data_mesh_dim}"
+          )
+
     xtensors = torch_xla._XLAC._xla_tensors_from_aten(tensors, devices,
                                                       shardings)
     return xtensors

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -1301,16 +1301,19 @@ def send_cpu_data_to_device(
       shardings = [input_sharding.xla_spec(t) for t in tensors]
     if input_sharding and input_sharding.minibatch:
       # when minibatch is configured we must make sure batch dimension of
-      # the tensor is divisible by the data mesh dimension.
-      data_mesh_dim = input_sharding.mesh.mesh_shape[0]
+      # the tensor is divisible by the local runtime device count.
       for tensor, sharding in zip(tensors, shardings):
         # assume batch dimension is 0
+        local_runtime_device_count = torch_xla.runtime.addressable_runtime_device_count(
+        )
         if sharding and tensor.dim() > 0 and (tensor.size()[0] %
-                                              data_mesh_dim) != 0:
+                                              local_runtime_device_count) != 0:
           raise RuntimeError(
               "When minibatch is configured, batch dimension of the tensor " +
-              "must be divisible by data mesh dimension.input data shape " +
-              f"={tensor.size()}, mesh data dimension = {data_mesh_dim}")
+              "must be divisible by local runtime device count.input data shape "
+              +
+              f"={tensor.size()}, local_runtime_device_count = {local_runtime_device_count}"
+          )
 
     xtensors = torch_xla._XLAC._xla_tensors_from_aten(tensors, devices,
                                                       shardings)

--- a/torch_xla/distributed/parallel_loader.py
+++ b/torch_xla/distributed/parallel_loader.py
@@ -7,8 +7,6 @@ import torch_xla.debug.profiler as xp
 import torch_xla.utils.keyd_queue as kq
 import torch_xla.utils.utils as xu
 import torch_xla.core.xla_model as xm
-import queue
-
 
 class PerDeviceQueue(object):
 

--- a/torch_xla/distributed/parallel_loader.py
+++ b/torch_xla/distributed/parallel_loader.py
@@ -8,6 +8,7 @@ import torch_xla.utils.keyd_queue as kq
 import torch_xla.utils.utils as xu
 import torch_xla.core.xla_model as xm
 
+
 class PerDeviceQueue(object):
 
   def __init__(self, device, loader_prefetch_size, device_prefetch_size):


### PR DESCRIPTION
…atch size is not divisble by data mesh

When `minibatch` is used in sharding spec, each device is loading it own part of the data and reassemble it during the runtime. 

Imagenine a case the mesh is (4,1) and the batch size we used is 3, each device will see a data like
```
(100,200,300,0)
(400,500,600,0)
```
and runtime will reassemble a incorrect final data.

If `mini batch` is not used it is OK, because each device will see
```
(100, 200, 300,400)
(500, 600, 0, 0)
```
and we will drop padding at the end.