### PR TITLE
Update cuda_deps.yaml for r2.5

### DIFF
--- a/infra/ansible/config/cuda_deps.yaml
+++ b/infra/ansible/config/cuda_deps.yaml
@@ -3,7 +3,7 @@
 cuda_deps:
   # List all libcudnn8 versions with `apt list -a libcudnn8`
   libcudnn:
-    "12.4": libcudnn-cuda-12=9.1.1.17-1
+    "12.4": libcudnn9-cuda-12=9.1.1.17-1
     "12.3": libcudnn9-cuda-12=9.0.0.312-1
     "12.1": libcudnn8=8.9.2.26-1+cuda12.1
     "12.0": libcudnn8=8.8.0.121-1+cuda12.0
@@ -11,7 +11,7 @@ cuda_deps:
     "11.7": libcudnn8=8.5.0.96-1+cuda11.7
     "11.2": libcudnn8=8.1.1.33-1+cuda11.2
   libcudnn-dev:
-    "12.4": libcudnn-dev-cuda-12=9.1.1.17-1
+    "12.4": libcudnn9-dev-cuda-12=9.1.1.17-1
     "12.3": libcudnn9-dev-cuda-12=9.0.0.312-1
     "12.1": libcudnn8-dev=8.9.2.26-1+cuda12.1
     "12.0": libcudnn8-dev=8.8.0.121-1+cuda12.0


### PR DESCRIPTION
nightly didn't build for cuda12.4 according to wheel build log;

for r2.5, we failed to build wheel with error `No package matching 'libcudnn-cuda-12' is available`, 

so update `libcudnn-cuda-12=9.1.1.17-1` to `libcudnn9-cuda-12=9.1.1.17-1` according to this link: https://forums.developer.nvidia.com/t/e-unable-to-locate-package-cudnn9-cuda-12/289970,

and we could found `libcudnn9-cuda-12` and `libcudnn9-dev-cuda-12` in [website](https://docs.nvidia.com/deeplearning/cudnn/latest/installation/linux.html#base-packages), and we didn't find `libcudnn-cuda-12` yet too