### PR TITLE
[test] update XLA commit to JAX 0.4.33 same one

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,7 +50,7 @@ new_local_repository(
 #    curl -L https://github.com/openxla/xla/archive/<git hash>.tar.gz | sha256sum
 #    and update the sha256 with the result.
 
-xla_hash = '32ebd694c4d0442e241d76324ff1a721831366b4'
+xla_hash = '720b2c53346660e95abbed7cf3309a8b85e979f9'
 
 http_archive(
     name = "xla",


### PR DESCRIPTION
update OpenXLA commit to JAX 0.4.33 used one: https://github.com/jax-ml/jax/blob/80e1c94de63e7f89667cdf35f38d8fe298e97a50/third_party/xla/workspace.bzl#L24C15-L24C55