### PR TITLE
Add diagonal_scatter aten ops

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -24,7 +24,6 @@ skiplist = {
     "cholesky_solve",
     "complex",
     "diagonal_copy",
-    "diagonal_scatter",
     "digamma",
     "exponential",
     "gcd",

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -2069,6 +2069,38 @@ def _aten_diagonal(input, offset=0, dim1=0, dim2=1):
   return jnp.diagonal(input, offset, dim1, dim2)
 
 
+def diag_indices_with_offset(input_shape, offset, dim1=0, dim2=1):
+    input_len = len(input_shape)
+    if dim1 == dim2 or not (0 <= dim1 < input_len and 0 <= dim2 < input_len):
+      raise ValueError("dim1 and dim2 must be different and in range [0, " + str(input_len-1)+ "]")
+
+    size1, size2 = input_shape[dim1], input_shape[dim2]
+    if offset >= 0:
+        indices1 = jnp.arange(min(size1, size2 - offset))
+        indices2 = jnp.arange(offset, offset + len(indices1))
+    else:
+        indices2 = jnp.arange(min(size1 + offset, size2 ))
+        indices1 = jnp.arange(-offset, -offset + len(indices2))
+    return [indices1, indices2]
+
+@op(torch.ops.aten.diagonal_scatter)
+def _aten_diagonal_scatter(input, src, offset=0, dim1=0, dim2=1):
+  indexes = diag_indices_with_offset(input.shape, offset, dim1, dim2)
+
+  if input.ndim == 2:
+    return input.at[tuple(indexes)].set(src)
+  else:
+    # src has the same shape as the output of jnp.diagonal(input, offset, dim1, dim2).
+    # Last dimension always contains the diagonal elements, while the preceding dimensions
+    # represent the "slices" or "planes" from which these diagonals are extracted.
+    # Thus, we alter input axes to match this assumption, write src and then move the axes
+    # back to the original state.
+    input = jnp.moveaxis(input, (dim1, dim2), (-2,-1))
+    multi_indexes = [slice(None)]*(input.ndim-2) + indexes
+    input = input.at[tuple(multi_indexes)].set(src)
+    return jnp.moveaxis(input, (-2,-1), (dim1, dim2))
+
+
 # aten.diagflat
 @op(torch.ops.aten.diagflat)
 def _aten_diagflat(input, offset=0):

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -2090,11 +2090,13 @@ def _aten_diagonal_scatter(input, src, offset=0, dim1=0, dim2=1):
   if input.ndim == 2:
     return input.at[tuple(indexes)].set(src)
   else:
-    # src has the same shape as the output of jnp.diagonal(input, offset, dim1, dim2).
-    # Last dimension always contains the diagonal elements, while the preceding dimensions
-    # represent the "slices" or "planes" from which these diagonals are extracted.
-    # Thus, we alter input axes to match this assumption, write src and then move the axes
-    # back to the original state.
+    # src has the same shape as the output of 
+    # jnp.diagonal(input, offset, dim1, dim2).
+    # Last dimension always contains the diagonal elements,
+    # while the preceding dimensions represent the "slices"
+    # from which these diagonals are extracted. Thus,
+    # we alter input axes to match this assumption, write src
+    # and then move the axes back to the original state.
     input = jnp.moveaxis(input, (dim1, dim2), (-2,-1))
     multi_indexes = [slice(None)]*(input.ndim-2) + indexes
     input = input.at[tuple(multi_indexes)].set(src)


### PR DESCRIPTION
Fixes [#7381](https://github.com/pytorch/xla/issues/7381). Passes 2 additional tests for diagonal_scatter.

There was no direct equivalent in JAX for this op. Initially considered using [jnp.diag_indices](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.diag_indices.html#jax-numpy-diag-indices) for generating diagonal indices but it does not account for offset and assumes square arrays which was not the case for some tests.

Additionally, added some logic for moving `input` axes since `diagonal` function makes certain ordering assumptions and moving `src` axes was not very straightforward. Added more details in comments.