### PR TITLE
Fix op info test for linalg.inv and linalg.inv_ex

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -29,8 +29,6 @@ skiplist = {
     "linalg.cholesky",
     "linalg.cholesky_ex",
     "linalg.det",
-    "linalg.inv",
-    "linalg.inv_ex",
     "linalg.ldl_factor",
     "linalg.ldl_factor_ex",
     "linalg.ldl_solve",

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -2366,7 +2366,6 @@ def _aten_linalg_eigh(A, UPLO='L'):
 
 @op(torch.ops.aten.linalg_inv_ex)
 def _aten_linalg_inv_ex(A):
-
   return jnp.linalg.inv(A), jnp.zeros(A.shape[:-2], jnp.int32)
 
 

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -2333,6 +2333,12 @@ def _aten_histc(input, bins=100, min=0, max=0):
   return hist
 
 
+# Used by some linalg functions to raise an exception
+# when check_errors == True. This is currently a no-op.
+@op(torch.ops.aten._linalg_check_errors)
+def _aten_linalg_check_errors(A, api_name, is_matrix):
+  ...
+
 @op(torch.ops.aten.hypot)
 def _aten_hypot(input, other):
   return jnp.hypot(input, other)
@@ -2357,6 +2363,11 @@ def _aten_linalg_eig(A):
 @op(torch.ops.aten._linalg_eigh)
 def _aten_linalg_eigh(A, UPLO='L'):
   return jnp.linalg.eigh(A, UPLO)
+
+@op(torch.ops.aten.linalg_inv_ex)
+def _aten_linalg_inv_ex(A):
+
+  return jnp.linalg.inv(A), jnp.zeros(A.shape[:-2], jnp.int32)
 
 
 @op(torch.ops.aten.linalg_lu)


### PR DESCRIPTION
Fix #7484
Fix #7485 

Note: An exception should be raised when `check_errors=True` which is currently ignored