### PR TITLE
Enabling log_normal tests

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -48,7 +48,6 @@ skiplist = {
     "linalg.tensorsolve",
     "linalg.vector_norm",
     "linspace",
-    "log_normal",
     "logspace",
     "lu",
     "lu_solve",
@@ -160,6 +159,7 @@ random_ops = {
   'nn.functional.feature_alpha_dropout',
   'cauchy',
   'exponential',
+  'log_normal',
 }
 
 atol_dict = {"matrix_exp": (2e-1, 2e-4), "linalg.pinv": (8e-1, 2e0), "linalg.eig": (2e0, 3e0), "linalg.eigh": (5e1, 3e0), "linalg.eigvalsh": (5e1, 3e0)}

--- a/experimental/torch_xla2/torch_xla2/decompositions.py
+++ b/experimental/torch_xla2/torch_xla2/decompositions.py
@@ -297,4 +297,5 @@ EXTRA_DECOMP = decomp.get_decompositions([
     torch.ops.aten.nll_loss2d_backward,
     torch.ops.aten.bernoulli_.Tensor,
     torch.ops.aten.bernoulli_.float,
+    torch.ops.aten.log_normal,
 ])

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -47,6 +47,7 @@ mutation_ops_to_functional = {
   torch.ops.aten.logical_not_: torch.ops.aten.logical_not,
   torch.ops.aten.unsqueeze_: torch.ops.aten.unsqueeze,
   torch.ops.aten.transpose_: torch.ops.aten.transpose,
+  torch.ops.aten.log_normal_: torch.ops.aten.log_normal,
 }
 
 


### PR DESCRIPTION
Enabling log_normal tests

* Use the existing log_normal decomposition
* Skip numerical comparision for the operation

ref: https://github.com/pytorch/xla/issues/7505#issuecomment-2403562005

fixes: https://github.com/pytorch/xla/issues/7505