### PR TITLE
Fixed tests for basic_gnn_edgecnn and basic_gnn_gcn

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -108,7 +108,6 @@ skiplist = {
     "unique",
     "unravel_index",
     "var_mean",
-    "argwhere",
     "nanmean",
     "nn.functional.upsample_bilinear",
     "randint",

--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -29,6 +29,8 @@ skiplist = {
     "linalg.cholesky",
     "linalg.cholesky_ex",
     "linalg.det",
+    "linalg.inv",
+    "linalg.inv_ex",
     "linalg.ldl_factor",
     "linalg.ldl_factor_ex",
     "linalg.ldl_solve",

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -2348,12 +2348,6 @@ def _aten_histc(input, bins=100, min=0, max=0):
   return hist
 
 
-# Used by some linalg functions to raise an exception
-# when check_errors == True. This is currently a no-op.
-@op(torch.ops.aten._linalg_check_errors)
-def _aten_linalg_check_errors(A, api_name, is_matrix):
-  ...
-
 @op(torch.ops.aten.hypot)
 def _aten_hypot(input, other):
   return jnp.hypot(input, other)
@@ -2378,10 +2372,6 @@ def _aten_linalg_eig(A):
 @op(torch.ops.aten._linalg_eigh)
 def _aten_linalg_eigh(A, UPLO='L'):
   return jnp.linalg.eigh(A, UPLO)
-
-@op(torch.ops.aten.linalg_inv_ex)
-def _aten_linalg_inv_ex(A):
-  return jnp.linalg.inv(A), jnp.zeros(A.shape[:-2], jnp.int32)
 
 
 @op(torch.ops.aten.linalg_lu)

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -2545,6 +2545,9 @@ def _aten_nextafter(input, other, *, out=None):
 # aten.nonzero
 @op(torch.ops.aten.nonzero)
 def _aten_nonzero(x):
+  if jnp.ndim(x) == 0: # when x is scalar, return torch.tensor([], size=(1, 0), dtype=torch.int64)
+    res = torch.empty(1, 0, dtype=torch.int64)
+    return jnp.array(res.numpy())
   index_tuple = jnp.nonzero(x)
   index_tuple = [jnp.expand_dims(p, -1) for p in index_tuple]
   return jnp.concatenate(index_tuple, axis=-1)

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -49,6 +49,8 @@ mutation_ops_to_functional = {
   torch.ops.aten.unsqueeze_: torch.ops.aten.unsqueeze,
   torch.ops.aten.transpose_: torch.ops.aten.transpose,
   torch.ops.aten.log_normal_: torch.ops.aten.log_normal,
+  torch.ops.aten.scatter_add_: torch.ops.aten.scatter_add,
+  torch.ops.aten.scatter_reduce_.two: torch.ops.aten.scatter_reduce,
 }
 
 


### PR DESCRIPTION
Fixes #8103 and #8104 by adding @op decorators to allow the tests to pass.