### PR TITLE
enable linalg.vector_norm tests

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -46,7 +46,6 @@ skiplist = {
     "linalg.svdvals",
     "linalg.tensorinv",
     "linalg.tensorsolve",
-    "linalg.vector_norm",
     "linspace",
     "log_normal",
     "logspace",

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -1290,7 +1290,8 @@ def _aten_linalg_vector_norm(self, ord=2, dim=None, keepdim=False, dtype=None):
   # Special cases (for efficiency and clarity)
   if ord == 0:
     if self.shape == ():
-      result = jnp.array(float(self != 0))
+      # float sets it to float64. set it back to input type
+      result = jnp.astype(jnp.array(float(self != 0)), self.dtype)
     else:
       result = _with_reduction_scalar(jnp.sum, jnp.where(self != 0, 1, 0), dim, keepdim)
 


### PR DESCRIPTION
enable linalg.vector_norm tests

* for ord==0 case typecast back to the input type

fixes: https://github.com/pytorch/xla/issues/7505
ref: https://github.com/pytorch/xla/issues/7505#issuecomment-2403832303