### PR TITLE
Fix op info test for linalg.inv and linalg.inv_ex

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -29,8 +29,6 @@ skiplist = {
     "linalg.cholesky",
     "linalg.cholesky_ex",
     "linalg.det",
-    "linalg.inv",
-    "linalg.inv_ex",
     "linalg.ldl_factor",
     "linalg.ldl_factor_ex",
     "linalg.ldl_solve",

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -4254,7 +4254,7 @@ def _aten_linalg_solve_triangular(a, b, *, upper=True, left=True, unitriangular=
 @op(torch.ops.aten.linalg_inv_ex)
 def _aten_linalg_inv_ex(a):
   ainv = jnp.linalg.inv(a)
-  info = jnp.array(0)
+  info = jnp.zeros(a.shape[:-2], jnp.int32)
   return ainv, info
 
 


### PR DESCRIPTION
Originally fixed in #8239 but reverted in #8252 due to test failures. Root cause was a conflicting lowering from #8251 implemented for `linalg.tensorinv`.