### PR TITLE
Set weights_only to False for xser.load

### DIFF
--- a/torch_xla/utils/serialization.py
+++ b/torch_xla/utils/serialization.py
@@ -84,7 +84,7 @@ def load(path):
   Returns:
     The loaded data.
   """
-  ref_data = torch.load(path)
+  ref_data = torch.load(path, weights_only=False)
   tensor_folder = _get_tensors_folder(path)
 
   def convert_fn(tensors):


### PR DESCRIPTION
should fix https://github.com/pytorch/xla/issues/7799

After https://github.com/pytorch/pytorch/pull/137602 the `weights_only` will default to True but it will fail this xla test.