### PR TITLE
Implement lu_unpack in jax

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -33,7 +33,6 @@ skiplist = {
     "linalg.matrix_norm",
     "linalg.matrix_power",
     "linalg.tensorsolve",
-    "lu_unpack",
     "masked.median",
     "max_pool2d_with_indices_backward",
     "nn.functional.adaptive_avg_pool3d",


### PR DESCRIPTION
Implement lu_unpack in jax

- For Lower and Upper matrices, use jnp.tril, jnp.triu
- Shape both triangle matrices and add 1's to the lower triangle to
  match the pytorch behavior
- For 2D permutation matrix start with an identity matrix and mutate it
  based on pivots
  - start with sequential indices and apply the pivot operations to it
  - finally use the pivoted indices to index the identity matrix to
    generate the final permutation matrix for that pivot.
- For 2D inputs and 1D pivot the above logic would work
- For >=3d inputs, we first reshape the inputs to become 3D and then
  call vmap along the first dim with the 2d logic for each 2d matrix

Fixes: #7507 