### PR TITLE
make 2.5 whl pypi compatible

### DIFF
--- a/infra/ansible/roles/build_srcs/tasks/main.yaml
+++ b/infra/ansible/roles/build_srcs/tasks/main.yaml
@@ -44,7 +44,7 @@
 
 - name: Build PyTorch/XLA
   ansible.builtin.command:
-    cmd: python setup.py bdist_wheel
+    cmd: python setup.py bdist_wheel -p manylinux_2_28_x86_64
     chdir: "{{ (src_root, 'pytorch/xla') | path_join }}"
   environment: "{{ env_vars }}"
 


### PR DESCRIPTION
Make 2.5 whl pypi compatible. We did this change for previous release. e.g. https://github.com/pytorch/xla/pull/7738