### PR TITLE
Fix support for `torch.var_mean`.

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -93,7 +93,6 @@ skiplist = {
     "unfold_copy",
     "unfold",
     "unravel_index",
-    "var_mean",
     "nanmean",
     "nn.functional.upsample_bilinear",
     "randint",

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -3028,6 +3028,12 @@ def _aten_to_dtype_layout(
 # Tensor self, int[1]? dim=None, *, Scalar? correction=None, bool keepdim=False
 @op(torch.ops.aten.var_mean.correction)
 def _aten_var_mean_correction(tensor, dim=None, correction=1, keepdim=False):
+  # The internal API technically has a default `correction` argument of `None`,
+  # but the public API has a default argument of 1. Therefore, we simply set our
+  # default argument to 1. However, since the argument is officially supposed to
+  # be nullable, we still need to check for `None` per the API contract.
+  if correction is None:
+    correction = 1
   mean = jnp.mean(tensor, dim, keepdims=keepdim)
   # TODO: Pass in the `mean=mean` argument once `jax.numpy.var` supports it.
   var = jnp.var(tensor, axis=dim, ddof=correction, keepdims=keepdim)

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -3027,11 +3027,11 @@ def _aten_to_dtype_layout(
 
 # Tensor self, int[1]? dim=None, *, Scalar? correction=None, bool keepdim=False
 @op(torch.ops.aten.var_mean.correction)
-def _aten_var_mean_correction(self, dim=None, correction=None, keepdim=False):
-  return (
-    jnp.var(self, axis=dim, ddof=correction, keepdims=keepdim),
-    jnp.mean(self, dim, keepdims=keepdim),
-  )
+def _aten_var_mean_correction(tensor, dim=None, correction=1, keepdim=False):
+  mean = jnp.mean(tensor, dim, keepdims=keepdim)
+  # TODO: Pass in the `mean=mean` argument once `jax.numpy.var` supports it.
+  var = jnp.var(tensor, axis=dim, ddof=correction, keepdims=keepdim)
+  return var, mean
 
 
 @op(torch.ops.aten.scalar_tensor)

--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -3034,7 +3034,7 @@ def _aten_var_mean_correction(tensor, dim=None, correction=1, keepdim=False):
   # be nullable, we still need to check for `None` per the API contract.
   if correction is None:
     correction = 1
-  mean = jnp.mean(tensor, dim, keepdims=keepdim)
+  mean = jnp.mean(tensor, axis=dim, keepdims=keepdim)
   # TODO: Pass in the `mean=mean` argument once `jax.numpy.var` supports it.
   var = jnp.var(tensor, axis=dim, ddof=correction, keepdims=keepdim)
   return var, mean


### PR DESCRIPTION
The default argument `correction=None` did not match the Torch API (default 1) and wasn't supported by the Jax API (where it's not nullable). Changing the default to 1 fixed the failing test case.

Issue: #7542