### PR TITLE
enable tensorsolve

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -32,7 +32,6 @@ skiplist = {
     "linalg.lu_solve",
     "linalg.matrix_norm",
     "linalg.matrix_power",
-    "linalg.tensorsolve",
     "masked.median",
     "max_pool2d_with_indices_backward",
     "nn.functional.adaptive_avg_pool3d",


### PR DESCRIPTION
Enable tensorsolve
- use jnp tensorsolve
- handle moving dims/axes and reshaping b before calling jnp variant

Fixes: #7505 