### PR TITLE
[torch_xla2] Fix TF SavedModel export, add test

### DIFF
--- a/.github/workflows/torch_xla2.yml
+++ b/.github/workflows/torch_xla2.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           pip install -r test-requirements.txt
           pip install -e .[cpu]
+          pip install tensorflow-cpu  # for TF integrations tests
       - name: Run tests
         working-directory: experimental/torch_xla2
         shell: bash

--- a/experimental/torch_xla2/test/test_tf_integration.py
+++ b/experimental/torch_xla2/test/test_tf_integration.py
@@ -29,20 +29,19 @@ class TfIntegrationTest(test_base.TestCase):
   def test_interpolate(self):
     """Simple model roundtripped through TF savedmodel"""
 
-    # Check Accuracy
+    # Create model
     arg = (torch.randn(3, 3, 200, 200),)
     pt_model = Interpolate()
 
+    # Export to SavedModel
     sm_path = os.path.join(self.create_tempdir(), "interpolate.savedmodel")
     tf_model = tf_integration.save_torch_module_as_tf_saved_model(
         pt_model, arg, sm_path)
-    print(tf_model)
-    loaded_model = tf.saved_model.load(sm_path)
 
+    # Reload SM and compare results with PT results
+    loaded_model = tf.saved_model.load(sm_path)
     pt_res = pt_model(*arg)
     tf_res = torch.tensor(loaded_model.f(*arg)[0].numpy())
-    print(pt_res)
-    print(tf_res)
     self.assertTrue(torch.allclose(pt_res, tf_res, atol=1e-4))
 
 

--- a/experimental/torch_xla2/test/test_tf_integration.py
+++ b/experimental/torch_xla2/test/test_tf_integration.py
@@ -1,0 +1,62 @@
+import os
+import jax
+import jax.export
+import tensorflow as tf
+import torch
+import torch.nn.functional as F
+import torch_xla2
+from torch_xla2 import tensor
+from torch_xla2 import tf_integration
+import torch_xla2.export
+from torch_xla2.ops import mappings
+from google3.testing.pybase import googletest as unittest
+
+
+class Interpolate(torch.nn.Module):
+
+  def forward(self, masks: torch.Tensor) -> torch.Tensor:
+    masks = F.interpolate(
+        masks,
+        size=(500, 500),
+        mode="bilinear",
+        align_corners=False,
+    )
+    return masks
+
+
+class TensorConstant(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  def forward(self, a):
+    return a / torch.tensor(3)
+
+
+class TfIntegrationTest(unittest.TestCase):
+
+  def setUp(self):
+    torch.manual_seed(0)
+
+  def test_interpolate(self):
+    """Simple model roundtripped through TF savedmodel"""
+
+    # Check Accuracy
+    arg = (torch.randn(3, 3, 200, 200),)
+    pt_model = Interpolate()
+
+    sm_path = os.path.join(self.create_tempdir(), "interpolate.savedmodel")
+    tf_model = tf_integration.save_torch_module_as_tf_saved_model(
+        pt_model, arg, sm_path)
+    print(tf_model)
+    loaded_model = tf.saved_model.load(sm_path)
+
+    pt_res = pt_model(*arg)
+    tf_res = torch.tensor(loaded_model.f(*arg)[0].numpy())
+    print(pt_res)
+    print(tf_res)
+    self.assertTrue(torch.allclose(pt_res, tf_res, atol=1e-4))
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/experimental/torch_xla2/test/test_tf_integration.py
+++ b/experimental/torch_xla2/test/test_tf_integration.py
@@ -38,8 +38,7 @@ class TfIntegrationTest(test_base.TestCase):
     # Export to SavedModel
     with tempfile.TemporaryDirectory() as tempdir:
       sm_path = os.path.join(tempdir, "interpolate.savedmodel")
-      tf_model = tf_integration.save_torch_module_as_tf_saved_model(
-          pt_model, arg, sm_path)
+      tf_integration.save_torch_module_as_tf_saved_model(pt_model, arg, sm_path)
 
       # Reload SM and compare results with PT results
       loaded_model = tf.saved_model.load(sm_path)

--- a/experimental/torch_xla2/test/test_tf_integration.py
+++ b/experimental/torch_xla2/test/test_tf_integration.py
@@ -1,15 +1,12 @@
-import os
 import jax
-import jax.export
+import os
 import tensorflow as tf
 import torch
 import torch.nn.functional as F
 import torch_xla2
-from torch_xla2 import tensor
+
 from torch_xla2 import tf_integration
-import torch_xla2.export
-from torch_xla2.ops import mappings
-from google3.testing.pybase import googletest as unittest
+from . import test_base
 
 
 class Interpolate(torch.nn.Module):
@@ -24,16 +21,7 @@ class Interpolate(torch.nn.Module):
     return masks
 
 
-class TensorConstant(torch.nn.Module):
-
-  def __init__(self):
-    super().__init__()
-
-  def forward(self, a):
-    return a / torch.tensor(3)
-
-
-class TfIntegrationTest(unittest.TestCase):
+class TfIntegrationTest(test_base.TestCase):
 
   def setUp(self):
     torch.manual_seed(0)
@@ -59,4 +47,4 @@ class TfIntegrationTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-  unittest.main()
+  test_base.main()


### PR DESCRIPTION
Fix for exporting to TF SavedModel as well as adding a test for it.

Somewhere along the line `export` was refactored, but the TF APIs were not refactored along with it. Not having a test made this too easy to do, the current issue is that `exported_program_to_jax_program` or `flatten_*` methods no longer exist.

Replacing using a `wrapped` function, let me know if you have ideas on a better way to do this, or if you think wrapping the weights is the proper way.

