### PR TITLE
[torch_xla2] Enable Background_Matting model by implement `aten::upsample_bilinear2d`

### DIFF
--- a/experimental/torch_xla2/torch_xla2/ops/jaten.py
+++ b/experimental/torch_xla2/torch_xla2/ops/jaten.py
@@ -357,6 +357,12 @@ def repeat_interleave(repeats, dim=0):
   return jnp.repeat(jnp.arange(repeats.shape[dim]), repeats)
 
 
+# aten.upsample_bilinear2d
+@op(torch.ops.aten.upsample_bilinear2d)
+def _aten_upsample_bilinear2d(x, output_size, align_corners=False, scale_h=None, scale_w=None):
+  return _aten_upsample_bilinear2d_aa(x, output_size=output_size, align_corners=align_corners, scale_factors=None, scales_h=scale_h, scales_w=scale_w)
+
+
 @op(torch.ops.aten.view_as_real)
 def _aten_view_as_real(x):
   real = jnp.real(x)


### PR DESCRIPTION
Enable `Background_Matting` model by implement `aten::upsample_bilinear2d`

passed locally:
```
(torchxla2) manfei@xxx:~/pytorch/xla/experimental/torch_xla2/run_torchbench$ JAX_PLATFORMS=cpu python models/Background_Matting.py
/home/manfei/miniconda3/envs/torchxla2/lib/python3.10/site-packages/torch/distributed/distributed_c10d.py:337: UserWarning: Device capability of jax unspecified, assuming `cpu` and `cuda`. Please specify it via the `devices` argument of `register_backend`.
  warnings.warn(
/home/manfei/pytorch/xla/experimental/torch_xla2/run_torchbench/benchmark/torchbenchmark/models/Background_Matting/networks.py:270: FutureWarning: `nn.init.xavier_uniform` is now deprecated in favor of `nn.init.xavier_uniform_`.
  init.xavier_uniform(m.weight, gain=np.sqrt(2))
/home/manfei/pytorch/xla/experimental/torch_xla2/run_torchbench/benchmark/torchbenchmark/models/Background_Matting/networks.py:273: FutureWarning: `nn.init.constant` is now deprecated in favor of `nn.init.constant_`.
  init.constant(m.bias, 0)
/home/manfei/pytorch/xla/experimental/torch_xla2/run_torchbench/benchmark/torchbenchmark/models/Background_Matting/networks.py:280: FutureWarning: `nn.init.normal` is now deprecated in favor of `nn.init.normal_`.
  init.normal(m.weight.data, 1.0, 0.2)
/home/manfei/pytorch/xla/experimental/torch_xla2/run_torchbench/benchmark/torchbenchmark/models/Background_Matting/networks.py:281: FutureWarning: `nn.init.constant` is now deprecated in favor of `nn.init.constant_`.
  init.constant(m.bias.data, 0.0)
(XLATensor2(<class 'jaxlib.xla_extension.ArrayImpl'> [[[[-0.21568626 -0.21568626 -0.21568626 ...  0.45098042  0.4431373
     0.4431373 ]
   [-0.19215685 -0.19215685 -0.19215685 ...  0.45098042  0.43529415
     0.4431373 ]
   [-0.19215685 -0.19215685 -0.19215685 ...  0.427451    0.427451
     0.4431373 ]
   ...
   [ 0.09803927  0.082353    0.09019613 ... -0.3960784  -0.41176468
    -0.41176468]
   [ 0.20784318  0.12156868  0.04313731 ... -0.41176468 -0.41176468
    -0.41960782]
   [-0.00392157 -0.05882353 -0.03529412 ... -0.41176468 -0.41176468
    -0.41176468]]

  [[-0.19215685 -0.19215685 -0.20784312 ...  0.3176471   0.30980396
     0.30980396]
   [-0.19215685 -0.19215685 -0.19999999 ...  0.3176471   0.30196083
     0.30980396]
   [-0.19215685 -0.19215685 -0.19999999 ...  0.2941177   0.2941177
     0.30980396]
   ...
   [ 0.0196079   0.02745104  0.06666672 ... -0.58431375 -0.58431375
    -0.5921569 ]
   [ 0.13725495  0.09803927  0.0196079  ... -0.58431375 -0.58431375
    -0.5921569 ]
   [-0.04313725 -0.08235294 -0.0745098  ... -0.58431375 -0.58431375
    -0.58431375]]

  [[-0.19215685 -0.19215685 -0.18431371 ...  0.1686275   0.16078436
     0.16078436]
   [-0.19215685 -0.19215685 -0.17647058 ...  0.16078436  0.15294123
     0.16078436]
   [-0.19215685 -0.19215685 -0.17647058 ...  0.14509809  0.14509809
     0.16078436]
   ...
   [ 0.05098045  0.07450986  0.10588241 ... -0.64705884 -0.654902
    -0.67058825]
   [ 0.17647064  0.14509809  0.09019613 ... -0.64705884 -0.64705884
    -0.654902  ]
   [-0.00392157 -0.01960784  0.00392163 ... -0.64705884 -0.64705884
    -0.64705884]]]]), XLATensor2(<class 'jaxlib.xla_extension.ArrayImpl'> [[[[-0.19999999 -0.19999999 -0.19999999 ...  0.427451    0.427451
     0.43529415]
   [-0.19215685 -0.19215685 -0.19215685 ...  0.427451    0.427451
     0.427451  ]
   [-0.19215685 -0.19215685 -0.19215685 ...  0.427451    0.427451
     0.427451  ]
   ...
   [ 0.06666672  0.07450986  0.10588241 ... -0.38823527 -0.38823527
    -0.3960784 ]
   [ 0.16078436  0.10588241  0.04313731 ... -0.3960784  -0.3960784
    -0.3960784 ]
   [-0.01960784 -0.05098039 -0.05098039 ... -0.3960784  -0.40392154
    -0.38823527]]

  [[-0.20784312 -0.21568626 -0.21568626 ...  0.30980396  0.3176471
     0.30980396]
   [-0.20784312 -0.20784312 -0.20784312 ...  0.30980396  0.30980396
     0.30980396]
   [-0.20784312 -0.20784312 -0.20784312 ...  0.30980396  0.30980396
     0.30980396]
   ...
   [ 0.02745104  0.05098045  0.082353   ... -0.5764706  -0.58431375
    -0.5921569 ]
   [ 0.12941182  0.082353    0.0196079  ... -0.5764706  -0.5764706
    -0.5764706 ]
   [-0.05098039 -0.08235294 -0.08235294 ... -0.5764706  -0.5764706
    -0.5764706 ]]

  [[-0.12941176 -0.1372549  -0.1372549  ...  0.20000005  0.20000005
     0.20000005]
   [-0.12941176 -0.12941176 -0.12941176 ...  0.20000005  0.20000005
     0.20000005]
   [-0.12941176 -0.12941176 -0.12941176 ...  0.20000005  0.20000005
     0.20000005]
   ...
   [ 0.11372554  0.13725495  0.1686275  ... -0.58431375 -0.58431375
    -0.5921569 ]
   [ 0.22352946  0.1686275   0.11372554 ... -0.5764706  -0.5764706
    -0.5764706 ]
   [ 0.05098045  0.0196079   0.02745104 ... -0.5764706  -0.5764706
    -0.5764706 ]]]]), XLATensor2(<class 'jaxlib.xla_extension.ArrayImpl'> [[[[-1. -1. -1. ... -1. -1. -1.]
   [-1. -1. -1. ... -1. -1. -1.]
   [-1. -1. -1. ... -1. -1. -1.]
   ...
   [-1. -1. -1. ... -1. -1. -1.]
   [-1. -1. -1. ... -1. -1. -1.]
   [-1. -1. -1. ... -1. -1. -1.]]]]), XLATensor2(<class 'jaxlib.xla_extension.ArrayImpl'> [[[[-0.19999999 -0.19999999 -0.19999999 ...  0.29264772  0.28889287
     0.28627455]
   [-0.19999999 -0.19999999 -0.19999999 ...  0.2919402   0.28627455
     0.28627455]
   [-0.19215685 -0.19215685 -0.19215685 ...  0.28627455  0.28627455
     0.28627455]
   ...
   [ 0.05248237  0.02929902  0.06207943 ... -0.60210663 -0.590799
    -0.60784316]
   [ 0.14400387  0.12012422  0.08317912 ... -0.58431375 -0.58431375
    -0.60165656]
   [-0.01149076 -0.04230678 -0.04817927 ... -0.58431375 -0.58431375
    -0.58431375]]

  [[-0.19999999 -0.19999999 -0.19999999 ...  0.27801085  0.27843142
     0.27843142]
   [-0.19481462 -0.19481462 -0.19481462 ...  0.27843142  0.27843142
     0.27843142]
   [-0.19215685 -0.19215685 -0.19215685 ...  0.2794844   0.27843142
     0.27843142]
   ...
   [ 0.04305303  0.04422045  0.07489741 ... -0.59435105 -0.590799
    -0.60784316]
   [ 0.14640117  0.12261903  0.06566548 ... -0.58431375 -0.58431375
    -0.60165656]
   [-0.0169701  -0.04858631 -0.05069846 ... -0.58431375 -0.58431375
    -0.58431375]]

  [[-0.20350033 -0.2008819  -0.19999999 ...  0.28095055  0.27843142
     0.27843142]
   [-0.19481462 -0.19481462 -0.19481462 ...  0.27843142  0.27843142
     0.27843142]
   [-0.19215685 -0.19215685 -0.19215685 ...  0.2794844   0.27843142
     0.27843142]
   ...
   [ 0.04691255  0.08000267  0.10057485 ... -0.5835514  -0.5858325
    -0.60784316]
   [ 0.125139    0.10910583  0.02721572 ... -0.58431375 -0.58431375
    -0.5894991 ]
   [-0.02679229 -0.04962903 -0.04531473 ... -0.58431375 -0.58431375
    -0.5850855 ]]

  [[-0.19215685 -0.19215685 -0.19215685 ...  0.27843142  0.27843142
     0.27843142]
   [-0.19215685 -0.19215685 -0.19215685 ...  0.27843142  0.27843142
     0.27843142]
   [-0.18431371 -0.18612897 -0.18962562 ...  0.27843142  0.27843142
     0.27843142]
   ...
   [ 0.03899288  0.06397271  0.1006211  ... -0.58579195 -0.5862898
    -0.60784316]
   [ 0.13311231  0.10546327  0.05417871 ... -0.58431375 -0.58431375
    -0.60165656]
   [-0.03463542 -0.05224746 -0.03480536 ... -0.58431375 -0.58431375
    -0.58431375]]]]))
Eager mode time 4.715176597004756
Eager max abs vs expected tensor(1.9488, grad_fn=<MaxBackward1>)
Jitted mode time 1.8627403649734333
Jitted max abs vs expected tensor(1.9488, grad_fn=<MaxBackward1>)
(torchxla2) manfei@xxx~/pytorch/xla/experimental/torch_xla2/run_torchbench$ 

```