### PR TITLE
Fixes issue #7774

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ GPUs](https://cloud.google.com/compute/docs/gpus/create-vm-with-gpus).
 ## Troubleshooting
 
 If PyTorch/XLA isn't performing as expected, see the [troubleshooting
-guide](TROUBLESHOOTING.md), which has suggestions for debugging and optimizing
+guide](docs/source/learn/troubleshoot.md), which has suggestions for debugging and optimizing
 your network(s).
 
 ## Providing Feedback

--- a/docs/source/perf/ddp.md
+++ b/docs/source/perf/ddp.md
@@ -77,8 +77,7 @@ import torch_xla.runtime as xr
 import torch_xla.distributed.xla_backend
 
 def setup(rank, world_size):
-    os.environ['MASTER_ADDR'] = 'localhost'
-    os.environ['MASTER_PORT'] = '12355'
+    os.environ['PJRT_DEVICE'] = 'TPU'
 
     # initialize the xla process group
     dist.init_process_group("xla", rank=rank, world_size=world_size)


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/7774. Replaces:

```
os.environ['MASTER_ADDR'] = 'localhost'
os.environ['MASTER_PORT'] = '12355'
```
with:
```
os.environ['PJRT_DEVICE'] = 'TPU'
```
in ddp.md. I found no other references to this code with the exception of pjrt.md where it shows a diff removing the code setting `MASTER_*` with `PJRT_DEVICE`