### PR TITLE
Fixing missing sharding_scheme param

### DIFF
--- a/torch_xla/distributed/zero_redundancy_optimizer.py
+++ b/torch_xla/distributed/zero_redundancy_optimizer.py
@@ -433,7 +433,7 @@ class ZeroRedundancyOptimizer(Optimizer):
 
     # All gather the new weights across the ranks and assign them to the full parameters
     if sharding_scheme is None:
-        sharding_scheme = self._get_sharding_scheme({})
+      sharding_scheme = self._get_sharding_scheme({})
     sharded_data = []
     for param_group, sharded_param_group in zip(
         self.param_groups, self.base_optimizer.param_groups):

--- a/torch_xla/distributed/zero_redundancy_optimizer.py
+++ b/torch_xla/distributed/zero_redundancy_optimizer.py
@@ -429,9 +429,11 @@ class ZeroRedundancyOptimizer(Optimizer):
     # sync back
     self._sync_param_groups(self.base_optimizer.param_groups, self.param_groups)
 
-  def allgather_weights_and_update_full_parameter(self, sharding_scheme):
+  def allgather_weights_and_update_full_parameter(self, sharding_scheme=None):
 
     # All gather the new weights across the ranks and assign them to the full parameters
+    if sharding_scheme is None:
+        sharding_scheme = self._get_sharding_scheme({})
     sharded_data = []
     for param_group, sharded_param_group in zip(
         self.param_groups, self.base_optimizer.param_groups):


### PR DESCRIPTION
### Change Summary:

- **Method Signature Updated**: The `sharding_scheme` parameter in `allgather_weights_and_update_full_parameter` is made optional by setting a default value of `None`.

  ```python
  # Original
  def allgather_weights_and_update_full_parameter(self, sharding_scheme):
      # method body

  # Change
  def allgather_weights_and_update_full_parameter(self, sharding_scheme=None):
      if sharding_scheme is None:
          sharding_scheme = self._get_sharding_scheme({})
      # method body
  ```

- **Issue Addressed**: This change fixes a bug where the `load_state_dict` method calls `allgather_weights_and_update_full_parameter` without providing a `sharding_scheme`, which would cause a `TypeError`.

  ```python
  # In both versions within load_state_dict
  self.allgather_weights_and_update_full_parameter()
  ```

### Impact:

- **Bug Fix**: By making `sharding_scheme` optional and handling the `None` case inside the method, the second version prevents the `TypeError` and ensures that `load_state_dict` functions correctly without requiring additional arguments.