### PR TITLE
XLA downcast for S64 and U64 for Neuron

### DIFF
--- a/torch_xla/csrc/dtype.cpp
+++ b/torch_xla/csrc/dtype.cpp
@@ -143,15 +143,11 @@ xla::PrimitiveType MaybeDowncastToXlaDeviceType(
       return CheckNeuronDevice(hw_type) ? xla::PrimitiveType::S32
                                         : xla::PrimitiveType::S16;
     case xla::PrimitiveType::S64:
-      if (CheckNeuronDevice(hw_type)) {
-        return xla::PrimitiveType::S32;
-      }
-      return xla::PrimitiveType::S64;
+      return CheckNeuronDevice(hw_type) ? xla::PrimitiveType::S32
+                                        : xla::PrimitiveType::S64;
     case xla::PrimitiveType::U64:
-      if (CheckNeuronDevice(hw_type)) {
-        return xla::PrimitiveType::U32;
-      }
-      return xla::PrimitiveType::U64;
+      return CheckNeuronDevice(hw_type) ? xla::PrimitiveType::U32
+                                        : xla::PrimitiveType::U64;
     case xla::PrimitiveType::C128:
       return xla::PrimitiveType::C128;
     default:

--- a/torch_xla/csrc/dtype.cpp
+++ b/torch_xla/csrc/dtype.cpp
@@ -143,8 +143,14 @@ xla::PrimitiveType MaybeDowncastToXlaDeviceType(
       return CheckNeuronDevice(hw_type) ? xla::PrimitiveType::S32
                                         : xla::PrimitiveType::S16;
     case xla::PrimitiveType::S64:
+      if (CheckNeuronDevice(hw_type)) {
+        return xla::PrimitiveType::S32;
+      }
       return xla::PrimitiveType::S64;
     case xla::PrimitiveType::U64:
+      if (CheckNeuronDevice(hw_type)) {
+        return xla::PrimitiveType::U32;
+      }
       return xla::PrimitiveType::U64;
     case xla::PrimitiveType::C128:
       return xla::PrimitiveType::C128;


### PR DESCRIPTION
This PR downcasts the S64 and U64 datatypes for Neuron devices, to prevent unsupported datatypes from being lowered to the compiler.