### PR TITLE
DLPack: fix test using PyTorch API.

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2993,8 +2993,7 @@ class TestDLPack(parameterized.TestCase):
   @onlyIfPJRTDeviceIsCUDA
   def test_dlpack_xla_to_pytorch_cuda_protocol_conversion(self):
     xla_t1 = torch.arange(5).to(xm.xla_device())
-    caps_t1 = torch.utils.dlpack.to_dlpack(xla_t1)
-    cuda_t1 = torch.utils.dlpack.from_dlpack(caps_t1)
+    cuda_t1 = torch.utils.dlpack.from_dlpack(xla_t1)
     self.assertEqual(cuda_t1.device.type, 'cuda')
     self.assertEqual(cuda_t1.device.index, xla_t1.device.index)
     cuda_t1[0] = cuda_t1[0] + 20


### PR DESCRIPTION
This PR fixes the test introduced in #7213, where it called PyTorch's `to_dlpack()` function before actually calling `from_dlpack()`. Meaning that both `Tensor.__dlpack__` and `Tensor.__dlpack_device__` functions weren't getting called, [which were the functions that that test was supposed to be testing](https://github.com/pytorch/pytorch/pull/138470).

This should be merged after https://github.com/pytorch/pytorch/pull/138470.

cc @JackCaoG @vanbasten23 @qihqi 