### PR TITLE
Make XLA tests export new IR compatible

### DIFF
--- a/test/stablehlo/test_export_fx_passes.py
+++ b/test/stablehlo/test_export_fx_passes.py
@@ -212,7 +212,8 @@ class ExportFxPassTest(unittest.TestCase):
     after_decomp_out = native_layer_norm_impl(*args)
     self.assertTrue(
         torch.allclose(before_decomp_out, after_decomp_out, atol=1e-6))
-    ep = export(m, args, dynamic_shapes=dynamic_shapes)
+    ep_training = export(m, args, dynamic_shapes=dynamic_shapes)
+    ep = ep.run_decompositions({})
     decompose_dynamic_native_layer_norm(ep.graph_module)
     ep.graph_module.recompile()
     self.assertFalse('aten.native_layer_norm' in ep.graph_module.code)

--- a/test/stablehlo/test_export_fx_passes.py
+++ b/test/stablehlo/test_export_fx_passes.py
@@ -213,7 +213,7 @@ class ExportFxPassTest(unittest.TestCase):
     self.assertTrue(
         torch.allclose(before_decomp_out, after_decomp_out, atol=1e-6))
     ep_training = export(m, args, dynamic_shapes=dynamic_shapes)
-    ep = ep.run_decompositions({})
+    ep = ep_training.run_decompositions({})
     decompose_dynamic_native_layer_norm(ep.graph_module)
     ep.graph_module.recompile()
     self.assertFalse('aten.native_layer_norm' in ep.graph_module.code)


### PR DESCRIPTION
In export, we are switching the output of torch.export to be non-functional pre-dispatch IR which means we will capture graph at even higher/more generic level. To reflect the old behaviour we need to run decompositions so that it is almost identical to the old export IR.