### PR TITLE
Support the case where query_len>context_len in the multi-queries paged attention.

### DIFF
--- a/test/test_tpu_paged_attention_kernel.py
+++ b/test/test_tpu_paged_attention_kernel.py
@@ -93,6 +93,17 @@ class PagedAttentionKernelTest(jtu.JaxTestCase):
   def setUp(self):
     super().setUp()
 
+  #   def test_paged_attention(
+  #       self,
+  #   ):
+  #     dtype = jnp.bfloat16
+  #     page_size=16
+  #     num_kv_heads = 8
+  #     q_kv_head_ratio = 4
+  #     head_dim = 256
+  #     num_queries_per_compute_block = 32
+  #     block_kv_size = 256
+
   @parameterized.product(
       dtype=(jnp.float32, jnp.bfloat16),
       page_size=(16, 32, 64),
@@ -218,7 +229,6 @@ class PagedAttentionKernelTest(jtu.JaxTestCase):
         jax.random.key(0), (batch_size,), 0, kv_seq_lens)
     for cur_effec_q_len, cur_kv_seq_len in zip(effective_q_lens, kv_seq_lens):
       assert cur_effec_q_len <= cur_kv_seq_len, f'The effective query len {cur_effec_q_len} should be less than or equal to the kv_len {cur_kv_seq_len} in the current sequence.'
-    # print(f'{kv_seq_lens=}, {effective_q_lens=}')
 
     pages_per_sequence = max_kv_len // page_size
     total_num_pages = batch_size * pages_per_sequence
@@ -272,7 +282,7 @@ class PagedAttentionKernelTest(jtu.JaxTestCase):
     else:
       self.fail(f'Unsupported dtype: {dtype}')
     for b in range(batch_size):
-      # N.B. For the output ([batch_size, query_len, num_q_heads, head_dim]) at query_len dim, all the value after the effective_q_len will be thrown away. The value after the effective_q_len may differ between the kernel and the ref impl because of the causal mask.
+      # N.B. For the output ([batch_size, query_len, num_q_heads, head_dim]) at query_len dim, all the value after the effective_q_len will be thrown away due to we padding the query seq len. The values after the effective_q_len may differ between the kernel and the ref impl because of the causal mask.
       effective_q_len = effective_q_lens[b]
       self.assertTrue(
           jnp.allclose(

--- a/test/test_tpu_paged_attention_kernel.py
+++ b/test/test_tpu_paged_attention_kernel.py
@@ -105,40 +105,30 @@ class PagedAttentionKernelTest(jtu.JaxTestCase):
 #     num_queries_per_compute_block = 32
 #     block_kv_size = 256
 
-#   @parameterized.product(
-#       dtype=(jnp.float32, jnp.bfloat16),
-#       page_size=(16, 32, 64),
-#       num_kv_heads=(1, 8),
-#       q_kv_head_ratio=(1, 4, 8),
-#       head_dim=(128, 256),
-#       num_queries_per_compute_block=(16, 32),
-#       block_kv_size=(128, 256),
-#   )
-#   def test_paged_attention(
-#       self,
-#       dtype,
-#       page_size,
-#       num_kv_heads,
-#       q_kv_head_ratio,
-#       head_dim,
-#       num_queries_per_compute_block,
-#       block_kv_size,
-#   ):
+  @parameterized.product(
+      dtype=(jnp.float32, jnp.bfloat16),
+      page_size=(16, 32, 64),
+      num_kv_heads=(1, 8),
+      q_kv_head_ratio=(1, 4, 8),
+      head_dim=(128, 256),
+      num_queries_per_compute_block=(16, 32),
+      block_kv_size=(128, 256),
+  )
   def test_paged_attention(
       self,
+      dtype,
+      page_size,
+      num_kv_heads,
+      q_kv_head_ratio,
+      head_dim,
+      num_queries_per_compute_block,
+      block_kv_size,
   ):
-    dtype = jnp.bfloat16
-    page_size=16
-    num_kv_heads = 8
-    q_kv_head_ratio = 4
-    head_dim = 256
-    num_queries_per_compute_block = 32
-    block_kv_size = 256
 
     max_kv_len = 2048
-    query_len = 33
+    query_len = 64
     kv_seq_lens = jax.random.randint(
-        jax.random.key(0), (3,), 32, max_kv_len)
+        jax.random.key(0), (3,), query_len, max_kv_len)
 
     assert query_len <= max_kv_len
     for cur_kv_seq in kv_seq_lens:

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -489,7 +489,7 @@ def _multi_queries_paged_attention_nonkernel(
     v_pages,  # [num_kv_heads, total_num_pages, page_size, head_size]
     lengths,  # seq_lengths, [batch_size]. nb batch_size = len(seq_lens), the effective kv_length.
     page_indices,  # [batch_size, pages_per_sequence]
-    effective_q_lens, # [batch_size], the effective q_length
+    effective_q_lens,  # [batch_size], the effective q_length
 ) -> torch.Tensor:  # [batch_size, query_len, num_heads, head_dim]
   print('Running the nonkernel version of multi-queries paged attention.')
   batch_size, query_len, num_query_heads, head_size = q.shape

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -489,7 +489,7 @@ def _multi_queries_paged_attention_nonkernel(
     v_pages,  # [num_kv_heads, total_num_pages, page_size, head_size]
     lengths,  # seq_lengths, [batch_size]. nb batch_size = len(seq_lens), the effective kv_length.
     page_indices,  # [batch_size, pages_per_sequence]
-    real_q_lens, # [batch_size], the effective q_length
+    effective_q_lens, # [batch_size], the effective q_length
 ) -> torch.Tensor:  # [batch_size, query_len, num_heads, head_dim]
   print('Running the nonkernel version of multi-queries paged attention.')
   batch_size, query_len, num_query_heads, head_size = q.shape
@@ -530,8 +530,8 @@ def _multi_queries_paged_attention_nonkernel(
                         k)  # [num_query_heads, query_len, kv_len]
     attn = attn.float()
     empty_mask = torch.ones(query_len, kv_len, device=attn.device)
-    real_q_len = real_q_lens[i]
-    mask = torch.triu(empty_mask, diagonal=kv_len - real_q_len + 1).bool()
+    effective_q_len = effective_q_lens[i]
+    mask = torch.triu(empty_mask, diagonal=kv_len - effective_q_lens + 1).bool()
     attn.masked_fill_(mask, float("-inf"))
     attn = torch.softmax(
         attn, dim=-1).to(v.dtype)  # [num_query_heads, query_len, kv_len]

--- a/torch_xla/experimental/pallas_kernels/multi_queries_paged_attention_kernel.py
+++ b/torch_xla/experimental/pallas_kernels/multi_queries_paged_attention_kernel.py
@@ -97,6 +97,7 @@ class MultiPageAsyncCopyDescriptor:
 def _flash_attention(
     q_head_idx_per_kv,  # scalar, ranges from 0 to num_query_heads_per_kv_head
     lengths_ref,  # [batch_size] jax.Array the length of each example
+    effective_q_lens_ref, # [batch_size] jax.Array the length of the effective query lengths
     # input
     q_ref,  # [1, num_q_heads_per_kv_head, num_queries_per_compute_block, head_dim]
     k,  # [pages_per_compute_block*page_size,head_dim]
@@ -148,7 +149,8 @@ def _flash_attention(
   q_index = q_blk_idx * num_queries_per_compute_block
   kv_index = kv_blk_idx * kv_seq_len_per_kv_compute_blk
   kv_len = lengths_ref[b]
-  row_ids = (kv_len - query_len) + q_index + jax.lax.broadcasted_iota(
+  effective_q_len = effective_q_lens_ref[b]
+  row_ids = (kv_len - effective_q_len) + q_index + jax.lax.broadcasted_iota(
       jnp.int32,
       (num_queries_per_compute_block, kv_seq_len_per_kv_compute_blk), 0)
   col_ids = kv_index + jax.lax.broadcasted_iota(
@@ -209,6 +211,7 @@ def paged_flash_attention_kernel(
     lengths_ref,  # [batch_size] jax.Array the length of each example
     # 1d vector, results from page_indices.reshape(-1) where originally page_indices.shape=[batch_size, pages_per_sequence]
     page_indices_ref,
+    effective_q_lens_ref, # [batch_size] jax.Array the length of the effective query lengths
     buffer_index_ref,
     step_ref,
     # At caller, q.shape=[batch_size, num_q_heads query_len, head_dim]
@@ -355,6 +358,7 @@ def paged_flash_attention_kernel(
       _flash_attention(
           q_head_idx,
           lengths_ref,
+          effective_q_lens_ref,
           q_ref,  # [1, num_q_heads_per_kv_head, num_queries_per_compute_block, head_dim]
           k,
           v,
@@ -394,6 +398,7 @@ def paged_attention(
     v_pages: jax.Array | quantization_utils.QuantizedTensor,
     lengths: jax.Array,
     page_indices: jax.Array,
+    effective_q_lens: jax.Array,
     *,
     mask_value: float = DEFAULT_MASK_VALUE,
     num_kv_pages_per_compute_block: int,
@@ -448,6 +453,8 @@ def paged_attention(
                      f" {head_dim} and {head_dim_k}.")
   if lengths.shape != (batch_size,):
     raise ValueError("`lengths` and `q` must have the same batch size")
+  if lengths.shape != effective_q_lens.shape:
+    raise ValueError("`lengths` and `effective_q_lens` must have the same size: batch_size")
   if batch_size_paged_indices != batch_size:
     raise ValueError("`page_indices` and `q` must have the same batch size")
   if lengths.dtype != jnp.int32:
@@ -470,6 +477,7 @@ def paged_attention(
         "Number of Q heads must be divisible by number of KV heads. Got"
         f" {num_q_heads} and {num_kv_heads}.")
   num_q_heads_per_kv_head = num_q_heads // num_kv_heads
+  
 
   # grid
   grid = (
@@ -576,7 +584,7 @@ def paged_attention(
           mask_value=mask_value,
           query_len=query_len),
       grid_spec=pltpu.PrefetchScalarGridSpec(
-          num_scalar_prefetch=4,
+          num_scalar_prefetch=5,
           in_specs=in_specs,
           out_specs=out_specs,
           grid=grid,
@@ -598,6 +606,7 @@ def paged_attention(
   outs = kernel(
       lengths,
       page_indices_1d,
+      effective_q_lens,
       buffer_index,
       step,
       q.astype(q_dtype_for_kernel_launch),


### PR DESCRIPTION
This PR support the case where query_len>context len. In reality, vLLM may pad the query_len (but not for the kv seq len). That means the query_len may be longer than the kv_len. This PR
- adds a test for the case where query_len>kv_len
- modified the kernel to add a effective_q_lens parameter
- modifies the ref impl to account for the effective_q_lens

Test plans:
- python pytorch/xla/test/test_pallas.py -v -k PallasTest.test_paged_attention_multi_queries_wrapper
- python pytorch/xla/test/test_tpu_paged_attention_kernel.py   2>&1 | tee ~/out.txt