### PR TITLE
Correct the cxx11_abi condition

### DIFF
--- a/infra/ansible/roles/build_srcs/tasks/main.yaml
+++ b/infra/ansible/roles/build_srcs/tasks/main.yaml
@@ -125,7 +125,7 @@
   loop:
     - { dir: "{{ (src_root, 'pytorch/dist') | path_join }}", prefix: "torch" }
     - { dir: "{{ (src_root, 'pytorch/xla/dist') | path_join }}", prefix: "torch_xla" }
-  when: cxx11_abi
+  when: cxx11_abi | int > 0
 
 - name: Copy wheels to /dist
   ansible.builtin.shell: "cp {{ item }}/*.whl /dist"
@@ -173,7 +173,7 @@
   args:
     executable: /bin/bash
     chdir: "/dist"
-  when: cxx11_abi
+  when: cxx11_abi | int > 0
 
 - name: Find Torchvision *.whl files in /dist
   ansible.builtin.find:


### PR DESCRIPTION
The cxx11_abi is a `string` variable that is either "0" or "1". Unfortunately, when specifying it in the `when:` ansible stanza, a string value of "0" may get interpreted as true. This causes our nightly wheels from Oct 28 to Nov 04 to be renamed with a "cxx11" suffix, regardless if they actually used C++11 ABI.