### PR TITLE
Add aten::lift_fresh to the exception list that converts input to torch tensor

### DIFF
--- a/experimental/torch_xla2/torch_xla2/tensor.py
+++ b/experimental/torch_xla2/torch_xla2/tensor.py
@@ -391,7 +391,7 @@ class Environment(contextlib.ContextDecorator):
       kwargs = kwargs or {}
       if func in TENSOR_CONSTRUCTORS:
         return self._handle_tensor_constructor(func, args, kwargs)
-      if func in (torch.Tensor.to, torch.ops.aten._to_copy, torch.ops.aten._to_copy.default):
+      if func in (torch.Tensor.to, torch.ops.aten.lift_fresh.default ,torch.ops.aten._to_copy, torch.ops.aten._to_copy.default):
         return self._torch_Tensor_to(args, kwargs)
 
       # If the func doesn't act on XLATensor2, and is not a tensor constructor,


### PR DESCRIPTION
This was causing fastNLP_BERT model to fail.

https://github.com/fastnlp/fastNLP/blob/4e95989e973f59b2ecb7f718647257e8b6fea0c7/fastNLP/embeddings/bert_embedding.py#L427 

```
467                word_pieces[i, 1:word_pieces_lengths[i] + 1] = torch.LongTensor(word_pieces_i)
```

`torch.LongTensor` was returning a `torch.Tensor` instead of XLA Array.

Debugging the call trace 
```
DISPATCH: aten::lift_fresh
 FUNCTION: aten::lift_fresh
```

fixes: https://github.com/pytorch/xla/issues/8126
