### PR TITLE
Improve some typing annotations

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -135,7 +135,7 @@ def is_master_ordinal(local: bool = True) -> bool:
   return ordinal == 0
 
 
-def master_print(*args: Tuple[Any, ...],
+def master_print(*args: Any,
                  fd: TextIO = sys.stdout,
                  local: bool = False,
                  flush: bool = False):
@@ -984,7 +984,7 @@ def reduce_scatter_bucketized(reduce_type: str,
 
 
 def add_step_closure(closure: Callable[..., Any],
-                     args: Tuple[Any] = (),
+                     args: Tuple[Any, ...] = (),
                      run_async: bool = False):
   """Adds a closure to the list of the ones to be run at the end of the step.
 

--- a/torch_xla/distributed/spmd/xla_sharding.py
+++ b/torch_xla/distributed/spmd/xla_sharding.py
@@ -575,7 +575,8 @@ def disable_manual_sharding(t: Union[torch.Tensor, XLAShardedTensor],
 
 def mark_sharding(
     t: Union[torch.Tensor, XLAShardedTensor], mesh: Mesh,
-    partition_spec: Tuple[Union[Tuple, int, str, None]]) -> XLAShardedTensor:
+    partition_spec: Tuple[Union[Tuple, int, str, None],
+                          ...]) -> XLAShardedTensor:
   """
     Annotates the tensor provided with XLA partition spec. Internally,
     it annotates the corresponding XLATensor as sharded for the XLA SpmdPartitioner pass.


### PR DESCRIPTION
`Tuple[T]` means a tuple of 1 element of type `T`. These annotations actually wanted to say a tuple of N elements of type `T`. The right incantation for that is `Tuple[T, ...]`.