### PR TITLE
Fix XLA type of the view_as_real

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -793,6 +793,28 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     xla_a = t.to(xla_device).sgn()
     self.assertEqual(a.data, xla_a.data.cpu())
 
+  def test_view_as_real_c64(self):
+    xla_device = torch_xla.device()
+    x = torch.randn(4, dtype=torch.cfloat, device=xla_device)
+    real = torch.view_as_real(x)
+    self.assertEqual(real.dtype, torch.float32)
+    # XLA type of the real needs to be f32 as well
+    self.assertIn("f32[4,2]", torch_xla._XLAC._get_xla_tensor_debug_info(real))
+    # HLO generated needs to have type f32 as well
+    self.assertIn("f32[4,2]",
+                  torch_xla._XLAC._get_xla_tensors_text([real]).split('\n')[-3])
+
+  def test_view_as_real_c128(self):
+    xla_device = torch_xla.device()
+    x = torch.randn(4, dtype=torch.cdouble, device=xla_device)
+    real = torch.view_as_real(x)
+    self.assertEqual(real.dtype, torch.float64)
+    # XLA type of the real needs to be f32 as well
+    self.assertIn("f64[4,2]", torch_xla._XLAC._get_xla_tensor_debug_info(real))
+    # HLO generated needs to have type f32 as well
+    self.assertIn("f64[4,2]",
+                  torch_xla._XLAC._get_xla_tensors_text([real]).split('\n')[-3])
+
   def test_index_put(self):
     xla_device = xm.xla_device()
     a = torch.tensor([1, 1, 1, 1]).to(xla_device).to(dtype=torch.float32)

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -793,6 +793,7 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     xla_a = t.to(xla_device).sgn()
     self.assertEqual(a.data, xla_a.data.cpu())
 
+  @skipIfFunctionalizationDisabled("view_as_real unsupported")
   def test_view_as_real_c64(self):
     xla_device = torch_xla.device()
     x = torch.randn(4, dtype=torch.cfloat, device=xla_device)
@@ -804,6 +805,7 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     self.assertIn("f32[4,2]",
                   torch_xla._XLAC._get_xla_tensors_text([real]).split('\n')[-3])
 
+  @skipIfFunctionalizationDisabled("view_as_real unsupported")
   def test_view_as_real_c128(self):
     xla_device = torch_xla.device()
     x = torch.randn(4, dtype=torch.cdouble, device=xla_device)

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -3567,7 +3567,7 @@ XLATensorPtr view_as_complex_copy(const XLATensorPtr& input) {
 
 XLATensorPtr view_as_real_copy(const XLATensorPtr& input) {
   return input->CreateFrom(ViewAsRealCopy(input->GetIrValue()),
-                           at::ScalarType::Float);
+                           /*logical_element_type=*/std::nullopt);
 }
 
 XLATensorPtr var(const XLATensorPtr& input, std::vector<int64_t> dimensions,


### PR DESCRIPTION
`ViewAsComplexCopy ` has the same issue, I will fix it in a follow up.

`view_as_real(c64)` should return a tensor with XLA type and torch type f32. In the old lowering, the result type was incorrectly set as the input type. The result looks OK because we also overwrite the `torch.dtype` in `tensor_methods.cpp` but that's the wrong way to handling it. 