### PR TITLE
Revert S64 and U64 type change for Neuron device due to hardcoded dtype checks in torch-xla

### DIFF
--- a/torch_xla/csrc/dtype.cpp
+++ b/torch_xla/csrc/dtype.cpp
@@ -143,11 +143,9 @@ xla::PrimitiveType MaybeDowncastToXlaDeviceType(
       return CheckNeuronDevice(hw_type) ? xla::PrimitiveType::S32
                                         : xla::PrimitiveType::S16;
     case xla::PrimitiveType::S64:
-      return CheckNeuronDevice(hw_type) ? xla::PrimitiveType::S32
-                                        : xla::PrimitiveType::S64;
+      return xla::PrimitiveType::S64;
     case xla::PrimitiveType::U64:
-      return CheckNeuronDevice(hw_type) ? xla::PrimitiveType::U32
-                                        : xla::PrimitiveType::U64;
+      return xla::PrimitiveType::U64;
     case xla::PrimitiveType::C128:
       return xla::PrimitiveType::C128;
     default:


### PR DESCRIPTION
An earlier [PR 8347](https://github.com/pytorch/xla/pull/8347) implemented downcasting for 64-bit ops for Neuron devices. However, due to few hardcoded dtype checks in torch-xla (in [tensor_ops](https://github.com/pytorch/xla/blob/5a4641b4434d3122085b34fe4d9e0a29aa85cb41/torch_xla/csrc/tensor_ops.cpp#L200) and [index_ops](https://github.com/pytorch/xla/blob/c4f2771849e0827badf934500d29cedc83d73b8d/torch_xla/csrc/ops/index_ops.cpp#L368)), this change needs to be reverted to unblock compilation failure. 

Since this change was only implemented for Neuron devices, it (or rather reverting it) would not have any impact on others.