### PR TITLE
norm and pca_lowrank op info test from issue #7528

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -85,10 +85,10 @@ skiplist = {
     "nn.functional.upsample_nearest",
     "nonzero",
     "nonzero_static",
-    "norm",
+    #"norm",
     "normal",
     "ormqr",
-    "pca_lowrank",
+    #"pca_lowrank",
     "pinverse",
     "polar",
     "polygamma",
@@ -156,14 +156,14 @@ atol_dict = {"linalg.eig": (2e0, 3e0),
              "linalg.eigvalsh": (5e1, 3e0),
              "linalg.pinv": (8e-1, 2e0),
              "linalg.svd": (1e0, 1e0),
-             "matrix_exp": (2e-1, 2e-4)}
+             "matrix_exp": (2e-1, 2e-4),
+             "pca_lowrank" :(1e-6, 1e-5) }
 
 def diff_output(testcase, output1, output2, rtol, atol, equal_nan=True, check_output=True):
   if isinstance(output1, torch.Tensor):
     testcase.assertIsInstance(output2, torch.Tensor)
     output2_cpu = output2.detach().cpu()
     if output1.layout != torch.strided:
-      # We only compare dense tensors. We dont currently support sparse tensors
       output1 = output1.to_dense()
     if check_output:
       torch.testing.assert_close(


### PR DESCRIPTION
Added norm and pca_lowrank implementations for op test, however currently the lowarnk_pca test fails because of :

FAILED test/test_ops.py::TestOpInfoCPU::test_reference_eager_pca_lowrank_cpu_float32 - AssertionError: Tensor-likes are not close!

Upon checking with debug print statements, I saw that the only case it doesn't match is because of sign ambiguity here:

```
        [-0.7316],
        [ 0.4821],
        [ 0.4043],
        [ 0.0912]])
Got: tensor([[ 0.2460],
        [ 0.7316],
        [-0.4821],
        [-0.4043],
        [-0.0912]])
Absolute difference: tensor([[0.4920],
        [1.4632],
        [0.9642],
        [0.8087],
        [0.1823]])
Relative difference: tensor([[2.0000],
        [2.0000],
        [2.0000],
        [2.0000],
        [2.0000]])
```

That is the only fix remaining, and then it should be good to go.