### PR TITLE
Reenable the distributed checkpointing test

### DIFF
--- a/test/tpu/run_tests.sh
+++ b/test/tpu/run_tests.sh
@@ -8,8 +8,7 @@ python3 test/pjrt/test_collective_ops_tpu.py
 python3 test/spmd/test_mp_input_sharding.py
 python3 test/spmd/test_xla_sharding.py
 python3 test/spmd/test_xla_virtual_device.py
-# TODO(JackCaoG): to reenable
-# python3 test/spmd/test_xla_distributed_checkpoint.py
+python3 test/spmd/test_xla_distributed_checkpoint.py
 python3 test/spmd/test_train_spmd_linear_model.py
 python3 test/spmd/test_xla_spmd_python_api_interaction.py
 python3 test/spmd/test_xla_auto_sharding.py


### PR DESCRIPTION
This is follow up of https://github.com/pytorch/xla/pull/8386.

In the previous pr I found that someone during fallback the pytorch will try to update an existing XLATensor with a CPU tesnor with different shape. In that case we need to remove the sharding spec otherwise there will be a shape mismatch. However I found that in the distributed point we will swap the existing XLATensor with the cpu tensor and it seems like we want to keep the sharding spec.

@jonb377 one concern I have is that test only test the single host, I felt like if it is a actual multi-host case the CPU tensor withh have different shape(sharded)  than the shardingspec? I am not sure if we have such test somewhere. Even if we clear the shardingspec after a `torch_xla.sync()` the tensor will be moved to the device, but most likely replicated. I am a bit worried if I am breaking the distributed checkpointing here.