### PR TITLE
Support S32/U32 indices for BWD embedding & Neuron implicit downcast

### DIFF
--- a/test/neuron/run_tests.sh
+++ b/test/neuron/run_tests.sh
@@ -231,6 +231,7 @@ function run_xla_op_tests3 {
   run_test "$CDIR/test_devices.py"
 
   run_test "$CDIR/neuron/test_neuron_utils.py"
+  run_test "$CDIR/neuron/test_neuron_data_types.py"
 
   #python3 examples/data_parallel/train_resnet_xla_ddp.py # compiler error
   #python3 examples/fsdp/train_resnet_fsdp_auto_wrap.py

--- a/test/neuron/run_tests.sh
+++ b/test/neuron/run_tests.sh
@@ -230,15 +230,18 @@ function run_xla_op_tests3 {
   run_test "$CDIR/test_persistent_cache.py"
   run_test "$CDIR/test_devices.py"
 
-  run_test "$CDIR/neuron/test_neuron_utils.py"
-  run_test "$CDIR/neuron/test_neuron_data_types.py"
-
   #python3 examples/data_parallel/train_resnet_xla_ddp.py # compiler error
   #python3 examples/fsdp/train_resnet_fsdp_auto_wrap.py
   #python3 examples/eager/train_decoder_only_eager.py # OOM
   #python3 examples/eager/train_decoder_only_eager_spmd_data_parallel.py # compiler err due to f64
   PJRT_DEVICE=NEURON NEURONCORE_NUM_DEVICES=1 python3 examples/eager/train_decoder_only_eager_with_compile.py # nan loss expected?
   PJRT_DEVICE=NEURON NEURONCORE_NUM_DEVICES=1 python3 examples/eager/train_decoder_only_eager_multi_process.py
+}
+
+# Neuron specific tests
+function run_xla_neuron_tests {
+  run_test "$CDIR/neuron/test_neuron_utils.py"
+  run_test "$CDIR/neuron/test_neuron_data_types.py"
 }
 
 #######################################################################################
@@ -248,6 +251,7 @@ function run_op_tests {
   run_xla_op_tests1
   run_xla_op_tests2
   run_xla_op_tests3
+  run_xla_neuron_tests
 }
 
 function run_mp_op_tests {
@@ -292,6 +296,9 @@ function run_tests {
   elif [[ "$RUN_XLA_OP_TESTS3" == "xla_op3" ]]; then
     echo "Running xla op tests..."
     run_xla_op_tests3
+  elif [[ "$RUN_XLA_NEURON_TESTS" == "xla_neuron" ]]; then
+    echo "Running xla neuron tests..."
+    run_xla_neuron_tests
   elif [[ "$RUN_TORCH_MP_OP_TESTS" == "torch_mp_op" ]]; then
     echo "Running torch op tests..."
     #run_torch_op_tests
@@ -308,6 +315,9 @@ function run_tests {
     #fi
     if [[ "$XLA_SKIP_MP_OP_TESTS" != "1" ]]; then
       run_mp_op_tests
+    fi
+    if [[ "$XLA_SKIP_NEURON_TESTS" != "1" ]]; then
+      run_xla_neuron_tests
     fi
   fi
 }

--- a/test/neuron/test_neuron_data_types.py
+++ b/test/neuron/test_neuron_data_types.py
@@ -1,0 +1,74 @@
+import os
+import sys
+
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+import unittest
+
+
+class NeuronXlaDataTypeTest(unittest.TestCase):
+
+  def _test_datatypes(self, dtype, op_xla_dtype, op):
+    t1 = torch.tensor([2, 3], dtype=dtype, device=xm.xla_device())
+    t2 = torch.tensor([2, 3], dtype=dtype, device=xm.xla_device())
+
+    t3 = op(t1, t2)
+
+    self.assertEqual(t3.dtype, dtype)
+
+    hlo_text = torch_xla._XLAC._get_xla_tensors_text([t3])
+    device_data_hlo = hlo_text.split('\n')[1]
+    self.assertIn('xla::device_data', device_data_hlo)
+    self.assertIn(op_xla_dtype, device_data_hlo)
+
+  def test_datatypes(self):
+    test_cases = [(torch.float, "f32", torch.floor_divide),
+                  (torch.double, "f32", torch.floor_divide),
+                  (torch.int16, "s32", torch.add),
+                  (torch.int32, "s32", torch.add),
+                  (torch.int64, "s32", torch.add),
+                  (torch.uint16, "u32", torch.add),
+                  (torch.uint32, "u32", torch.add),
+                  (torch.uint64, "u32", torch.add)]
+
+    for dtype, op_xla_dtype, op in test_cases:
+      with self.subTest(dtype=dtype, op_xla_dtype=op_xla_dtype, op=op):
+        self._test_datatypes(dtype, op_xla_dtype, op)
+
+
+class NeuronXlaDataTypeBF16Test(unittest.TestCase):
+
+  def setUp(self):
+    self.original_env = os.environ.get("XLA_USE_BF16")
+    os.environ["XLA_USE_BF16"] = '1'
+
+  def tearDown(self):
+    if self.original_env is None:
+      del os.environ["XLA_USE_BF16"]
+    else:
+      os.environ["XLA_USE_BF16"] = self.original_env
+
+  def _test_datatypes_use_bf16(self, input_dtype):
+    t1 = torch.tensor([2, 3], dtype=input_dtype, device=xm.xla_device())
+    t2 = torch.tensor([2, 3], dtype=input_dtype, device=xm.xla_device())
+
+    t3 = torch.floor_divide(t1, t2)
+
+    self.assertEqual(t3.dtype, input_dtype)
+
+    hlo_text = torch_xla._XLAC._get_xla_tensors_text([t3])
+    device_data_hlo = hlo_text.split('\n')[1]
+    self.assertIn('xla::device_data', device_data_hlo)
+    self.assertIn('bf16', device_data_hlo)
+
+  def test_datatypes_use_bf16_double(self):
+    self._test_datatypes_use_bf16(torch.double)
+
+  def test_datatypes_use_bf16_float(self):
+    self._test_datatypes_use_bf16(torch.float)
+
+
+if __name__ == '__main__':
+  test = unittest.main()
+  sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/torch_xla/csrc/dtype.cpp
+++ b/torch_xla/csrc/dtype.cpp
@@ -143,9 +143,11 @@ xla::PrimitiveType MaybeDowncastToXlaDeviceType(
       return CheckNeuronDevice(hw_type) ? xla::PrimitiveType::S32
                                         : xla::PrimitiveType::S16;
     case xla::PrimitiveType::S64:
-      return xla::PrimitiveType::S64;
+      return CheckNeuronDevice(hw_type) ? xla::PrimitiveType::S32
+                                        : xla::PrimitiveType::S64;
     case xla::PrimitiveType::U64:
-      return xla::PrimitiveType::U64;
+      return CheckNeuronDevice(hw_type) ? xla::PrimitiveType::U32
+                                        : xla::PrimitiveType::U64;
     case xla::PrimitiveType::C128:
       return xla::PrimitiveType::C128;
     default:

--- a/torch_xla/csrc/tensor_ops.cpp
+++ b/torch_xla/csrc/tensor_ops.cpp
@@ -196,8 +196,8 @@ XLATensorPtr EmbeddingDenseBackward(const XLATensorPtr& grad_output,
                                     const XLATensorPtr& indices,
                                     int64_t num_weights, int64_t padding_idx,
                                     bool scale_grad_by_freq) {
-  XLA_CHECK_EQ(indices->dtype(), at::ScalarType::Long)
-      << "Embedding indices are expected to be of scalar type Long";
+  XLA_CHECK(indices->dtype() == at::ScalarType::Long ||
+            indices->dtype() == at::ScalarType::Int);
   auto indices_shape_ref = indices->shape();
   // The weight must be of rank 2, which means the rank of grad_output is one
   // more than the indices.
@@ -245,7 +245,8 @@ XLATensorPtr EmbeddingDenseBackward(const XLATensorPtr& grad_output,
 XLATensorPtr Embedding(const XLATensorPtr& weight,
                        const XLATensorPtr& indices) {
   XLA_CHECK_EQ(weight->shape().get().rank(), 2);
-  XLA_CHECK(indices->dtype() == at::kLong || indices->dtype() == at::kInt);
+  XLA_CHECK(indices->dtype() == at::ScalarType::Long ||
+            indices->dtype() == at::ScalarType::Int);
 
   if (indices->shape().get().rank() == 1) {
     return tensor_methods::index_select(weight, 0, indices);


### PR DESCRIPTION
In this PR, we extend embedding tensor operations to allow S32 indices. This follows suits with other operations, in order to add flexibility and potentially performance benefits for accelerator backends. Reference for embedding dense bwd: https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/Embedding.cpp#L117

In addition, we also re-introduce the implicit downcasting for Neuron S64/U64 types, since the Neuron compiler does not support 64 bits.

There is an ongoing effort to further extend this requirement to other tensor operations involving indices: https://github.com/pytorch/pytorch/pull/142160. Once this is resolved, we adapt it on XLA as well.