### PR TITLE
Update torch_xla wheels to have the suffix +cxx11 instead of .cxx11

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,11 @@ pip3 install torch==2.6.0.dev20241028+cpu.cxx11.abi --index-url https://download
 pip3 install https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.6.0.dev20241028.cxx11-cp310-cp310-linux_x86_64.whl
 ```
 
+**As of 12/11/2024, the torch_xla C++11 ABI wheel is named differently and can be installed as follows:**
+```
+pip3 install https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.6.0.dev20241211+cxx11-cp310-cp310-linux_x86_64.whl
+```
+
 The torch wheel version `2.6.0.dev20241028+cpu.cxx11.abi` can be found at https://download.pytorch.org/whl/nightly/torch/.
 
 <details>

--- a/infra/ansible/roles/build_srcs/tasks/main.yaml
+++ b/infra/ansible/roles/build_srcs/tasks/main.yaml
@@ -144,13 +144,17 @@
     #
     # we want to rename it to
     #
-    # torch_xla-2.5.0.dev20240819.cxx11-cp310-cp310-linux_x86_64.whl
-    # torch_xla-2.4.0.cxx11-cp311-cp311-manylinux_2_28_x86_64.whl
+    # torch_xla-2.5.0.dev20240819+cxx11-cp310-cp310-linux_x86_64.whl
+    # torch_xla-2.4.0+cxx11-cp311-cp311-manylinux_2_28_x86_64.whl
     # torch-2.5.0+libtpu.cxx11-cp310-cp310-linux_x86_64.whl
-    # torch-2.5.0.cxx11-cp311-cp311-linux_x86_64.whl
+    # torch-2.5.0+cxx11-cp311-cp311-linux_x86_64.whl
     #
-    # essentially adding .cxx11 before the -cp39, -cp310, -cp311 etc identifiers.
-    rename -v "s/^(.+?)(-cp\d+)/\1.cxx11\2/" *.whl
+    # essentially adding +cxx11 before the -cp39, -cp310, -cp311 etc identifiers.
+    if [[ "$f" == *"+libtpu"* ]]; then
+      rename -v "s/^(.+?)(-cp\d+)/\1.cxx11\2/" *.whl
+    else
+      rename -v "s/^(.+?)(-cp\d+)/\1+cxx11\2/" *.whl
+    fi
   args:
     executable: /bin/bash
     chdir: "/tmp/staging-wheels"


### PR DESCRIPTION
Currently while running 
```pip3 install https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.6.0.dev20241028.cxx11-cp310-cp310-linux_x86_64.whl```
 I get this error 
```ERROR: Invalid requirement: 'torch-xla==2.6.0.dev20241209.cxx11': Expected end or semicolon (after version specifier) torch-xla==2.6.0.dev20241209.cxx11```

Renaming the wheels to this format fixes it.