### PR TITLE
Modify the deprecation plan for XLA_USE_BF16

### DIFF
--- a/torch_xla/csrc/dtype.cpp
+++ b/torch_xla/csrc/dtype.cpp
@@ -11,7 +11,7 @@ bool ShouldUseBF16() {
   bool use_bf16 = runtime::sys_util::GetEnvBool("XLA_USE_BF16", false);
   if (use_bf16) {
     std::cout
-        << "XLA_USE_BF16 will be deprecated after the 2.5 release, please "
+        << "XLA_USE_BF16 will be deprecated after the 2.6 release, please "
            "convert your model to bf16 directly\n";
     TF_LOG(INFO) << "Using BF16 data type for floating point values";
   }
@@ -23,7 +23,7 @@ bool ShouldDowncastToBF16() {
       runtime::sys_util::GetEnvBool("XLA_DOWNCAST_BF16", false);
   if (downcast_bf16) {
     std::cout
-        << "XLA_DOWNCAST_BF16 will be deprecated after the 2.5 release, please "
+        << "XLA_DOWNCAST_BF16 will be deprecated after the 2.6 release, please "
            "downcast your model directly\n";
     TF_LOG(INFO) << "Downcasting floating point values, F64->F32, F32->BF16";
   }


### PR DESCRIPTION
The deprecation plan did not take place for 2.6, so extending the deprecation warning for 2.7. This was a planned item in the 2.5 release from https://github.com/pytorch/xla/pull/7582, after it was brought back https://github.com/pytorch/xla/pull/7945. We should check if those dependencies still hold, and go ahead with removing it.
cc: @tengyifei @ManfeiBai @miladm @jeffhataws 