### PR TITLE
Reenable OpInfo tests.

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -12,11 +12,14 @@ import torch_xla2
 
 skiplist = {
     "_segment_reduce",
+    "_unsafe_masked_index_put_accumulate",
     "bincount", # NOTE: dtype for int input torch gives float. This is weird.
     "byte",
     "cat",
     "cholesky_solve",
+    "cov",
     "diagonal_copy",
+    "gather",
     "geqrf",
     "histogram", # hard op: AssertionError: Tensor-likes are not close!
     "histogramdd", # TypeError: histogram requires ndarray or scalar arguments, got <class 'list'> at position 1.
@@ -44,6 +47,7 @@ skiplist = {
     "normal",
     "ormqr",
     "pca_lowrank",
+    "scatter",
     "searchsorted",
     "special.airy_ai",
     "special.scaled_modified_bessel_k0",
@@ -229,7 +233,7 @@ class TestOpInfo(TestCase):
                              ignore_indices=ignore_index)
 
 
-instantiate_device_type_tests(TestOpInfo, globals(), only_for='cpu')
+instantiate_device_type_tests(TestOpInfo, globals(), only_for={'cpu'})
 
 if __name__ == '__main__':
   unittest.main()

--- a/experimental/torch_xla2/torch_xla2/ops/mappings.py
+++ b/experimental/torch_xla2/torch_xla2/ops/mappings.py
@@ -19,8 +19,7 @@ def t2j(t):
     t = t.contiguous()
 
   try:
-    dl = torchdl.to_dlpack(t)
-    res = jaxdl.from_dlpack(dl)
+    res = jaxdl.from_dlpack(t)
   except Exception:
     # https://github.com/google/jax/issues/7657
     # https://github.com/google/jax/issues/17784


### PR DESCRIPTION
When we updated torch version to 2.6, one behavior of test_ops changed.

This line `instantiate_device_type_tests(TestOpInfo, globals(), only_for='cpu')` now treats only_for argument as iteratable instead of one string. so 'cpu' is split into ['c', 'p', 'u']; and this test did not run.

Running `pytest test/test_ops.py` gives

```
(xla2) hanq@hanq-compile-2:/mnt/hanq/pytorch/xla/experimental/torch_xla2$ pytest test/test_ops.py
/mnt/hanq/miniconda3/envs/xla2/lib/python3.10/site-packages/pytest_benchmark/logger.py:46: PytestBenchmarkWarning: Benchmarks are automatically disabled because xdist plugin is active.Benchmarks cannot be performed reliably in a parallelized environment.
  warner(PytestBenchmarkWarning(text))
=================================== test session starts ====================================
platform linux -- Python 3.10.14, pytest-8.3.2, pluggy-1.5.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /mnt/hanq/pytorch/xla/experimental/torch_xla2
configfile: pyproject.toml
plugins: benchmark-4.0.0, hydra-core-1.3.2, xdist-3.6.1
56 workers [0 items]

===================================== warnings summary =====================================
../../../../miniconda3/envs/xla2/lib/python3.10/site-packages/torch/distributed/distributed_c10d.py:335: 56 warnings
  /mnt/hanq/miniconda3/envs/xla2/lib/python3.10/site-packages/torch/distributed/distributed_c10d.py:335: UserWarning: Device capability of jax unspecified, assuming `cpu` and `cuda`. Please specify it via the `devices` argument of `register_backend`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================== 56 warnings in 9.02s ===================================
(xla2)
hanq@hanq-compile-2:/mnt/hanq/pytorch/xla/experimental/torch_xla2$`
```
which shows 0 test ran.

After this change:

```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================= short test summary info ==================================
FAILED test/test_ops.py::TestOpInfoCPU::test_reference_eager__unsafe_masked_index_put_accumulate_cpu_int64 - AssertionError: Tensor-likes are not close!
FAILED test/test_ops.py::TestOpInfoCPU::test_reference_eager_cov_cpu_int64 - AssertionError: Tensor-likes are not close!
FAILED test/test_ops.py::TestOpInfoCPU::test_reference_eager__unsafe_masked_index_put_accumulate_cpu_float32 - AssertionError: Tensor-likes are not close!
FAILED test/test_ops.py::TestOpInfoCPU::test_reference_eager_cov_cpu_float32 - AssertionError: Tensor-likes are not close!
FAILED test/test_ops.py::TestOpInfoCPU::test_reference_eager_gather_cpu_float32 - IndexError: Too many indices: 1-dimensional array indexed with 2 regular indices.
FAILED test/test_ops.py::TestOpInfoCPU::test_reference_eager_gather_cpu_int64 - IndexError: Too many indices: 1-dimensional array indexed with 2 regular indices.
FAILED test/test_ops.py::TestOpInfoCPU::test_reference_eager_nn_functional_multi_head_attention_forward_cpu_float32 - AssertionError: Tensor-likes are not close!
FAILED test/test_ops.py::TestOpInfoCPU::test_reference_eager_scatter_cpu_int64 - AssertionError: Scalars are not close!
================ 8 failed, 1019 passed, 25 skipped, 100 warnings in 37.20s =================
(xla2) hanq@hanq-compile-2:/mnt/hanq/pytorch/xla/experimental/torch_xla2$ pytest test/test_ops.py
```
There are 8 extra test failures, presumably regressions introduced when this test was no longer running.

This PR reenable this test and mark the failing ones as skipped to stop further regression.