### PR TITLE
[scan] use device_parameter_id_tensor_mapping

### DIFF
--- a/torch_xla/experimental/scan.py
+++ b/torch_xla/experimental/scan.py
@@ -521,7 +521,8 @@ def _scan_impl_flat(fn,
     builder.add_param(val)
 
   # Detect hoisted variables.
-  hoisted_vars: Dict[int, torch.Tensor] = fn_ctx.parameter_id_tensor_mapping()
+  hoisted_vars: Dict[
+      int, torch.Tensor] = fn_ctx.device_parameter_id_tensor_mapping()
   for v in itertools.chain(fake_carry, fake_x):
     param_id = fn_ctx.tensor_parameter_id(v)
     if param_id != -1:


### PR DESCRIPTION
Previously scan uses `parameter_id_tensor_mapping` to fetch tensors hoisted to HLO parameters e.g. the fn being scanned may create additional tensors while its running. `parameter_id_tensor_mapping` will fetch those tensors back to host as XLA literals and create new tensors wrapping those, resulting in additional host RAM usage.

PR #8460 added `device_parameter_id_tensor_mapping` that returns the actual device backed tensors instead of another copy. So we'll use that and test that this avoids host transfers.