### PR TITLE
[torch_xla2] Fix reenabled op info tests

### DIFF
--- a/experimental/torch_xla2/test/test_ops.py
+++ b/experimental/torch_xla2/test/test_ops.py
@@ -12,14 +12,11 @@ import torch_xla2
 
 skiplist = {
     "_segment_reduce",
-    "_unsafe_masked_index_put_accumulate",
     "bincount", # NOTE: dtype for int input torch gives float. This is weird.
     "byte",
     "cat",
     "cholesky_solve",
-    "cov",
     "diagonal_copy",
-    "gather",
     "geqrf",
     "histogram", # hard op: AssertionError: Tensor-likes are not close!
     "histogramdd", # TypeError: histogram requires ndarray or scalar arguments, got <class 'list'> at position 1.
@@ -44,7 +41,6 @@ skiplist = {
     "normal",
     "ormqr",
     "pca_lowrank",
-    "scatter",
     "searchsorted",
     "special.airy_ai",
     "special.scaled_modified_bessel_k0",
@@ -96,7 +92,8 @@ random_ops = {
   'nn.functional.dropout',
 }
 
-atol_dict = {"linalg.eig": (2e0, 3e0),
+atol_dict = {"cov": (2e-1, 2e-4),
+             "linalg.eig": (2e0, 3e0),
              "linalg.eigh": (5e1, 3e0),
              "linalg.eigvalsh": (5e1, 3e0),
              "linalg.pinv": (8e-1, 2e0),


### PR DESCRIPTION
Fix tests exempted from #8519 

`cov` differences are small and seem attributable to propagation of floating point error:
```
output1 = tensor([[ 597.1039,  465.1288],
        [ 465.1288, 1623.2740]])
output2 = tensor([[ 597.0955,  465.1222],
        [ 465.1222, 1623.2511]]), rtol = 1e-05, atol = 0.001, equal_nan = True
```