### PR TITLE
Always run TPU tests on new PRs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -103,8 +103,7 @@ jobs:
     name: "TPU tests"
     uses: ./.github/workflows/_tpu_ci.yml
     needs: build-torch-xla
-    # Only run this for HEAD and releases
-    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'tpuci')
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
 
   push-docs:
     name: "Build docs"


### PR DESCRIPTION
so far, we only run TPU tests on PRs with the `tpuci` label

the problem is this label is easily forgotten and also sometimes it doesn't work for some reason