### PR TITLE
[scan] Reduce memory usage

### DIFF
--- a/test/scan/test_scan_spmd.py
+++ b/test/scan/test_scan_spmd.py
@@ -25,7 +25,7 @@ class ScanSpmdTest(unittest.TestCase):
     """This test uses `scan` to implement `torch.cumsum`."""
 
     def fn(carry, x):
-      new_carry = carry + x
+      new_carry = torch.sin(carry + x)
       y = new_carry
       return new_carry, y
 


### PR DESCRIPTION
This change optimizes the memory usage of scan by turning some copies into aliases. Specifically, it optimizes intermediate activations which are aliases of inputs. This is a common occurrence.

In principle, we could have `forward` return all the intermediate activations, including those that are aliases to an input tensor. However, those inputs will then be duplicated as part of the output of a `scan` call, because we want to save all activations during the forward pass of a `scan`. The XLA compiler can't optimize away this duplication likely because they're behind a DynamicSlice + DynamicUpdateSlice, so we end up doubling the memory usage from those inputs.

To reduce memory usage, we can have `forward` return the activations that don't alias to inputs, called `partial_activations`. The autograd implementation of `scan` will call `alias_input` to add back activations that are aliases of input tensors outside of a scan, turning the partial activations back to full activations.