### PR TITLE
Port infra from `tpu-pytorch` to `tpu-pytorch-releases` and multi TPU support

### DIFF
--- a/.github/ci.md
+++ b/.github/ci.md
@@ -57,7 +57,7 @@ For the C++ test groups in either case, the test binaries are pre-built during t
 
 The TPU CI runs only a subset of our tests due to capacity constraints, defined in `_tpu_ci.yml` `test/tpu/run_tests.sh`. The runners themselves are containers in GKE managed by [ARC](https://github.com/actions/actions-runner-controller). The container image is also based on our dev images, with some changes for ARC compatibility. The Dockerfile for this image lives in `test/tpu/Dockerfile`.
 
-The actual ARC cluster is defined in Terraform at `infra/tpu-pytorch/tpu_ci.yml`.
+The actual ARC cluster is defined in Terraform at `infra/tpu-pytorch-releases/tpu_ci.yml`.
 
 ### Reproducing test failures
 
@@ -95,7 +95,7 @@ If the TPU CI won't run, try to debug using the following steps:
 On your cloudtop:
 
 ```
-gcloud config set project tpu-pytorch
+gcloud config set project tpu-pytorch-releases
 gcloud container clusters get-credentials tpu-ci --location=us-central2
 ```
 

--- a/.github/workflows/_tpu_ci.yml
+++ b/.github/workflows/_tpu_ci.yml
@@ -12,7 +12,8 @@ on:
 jobs:
   tpu-test:
     # Use dynamic runner based on TPU version
-    runs-on: ${{ inputs.runner-label }}-runner-set
+    name: TPU ${{ inputs.tpu-version }} Tests
+    runs-on: ${{ inputs.runner-label }}
     steps:
       - name: Checkout actions
         uses: actions/checkout@v4
@@ -41,7 +42,7 @@ jobs:
       - name: Run Tests
         env:
           PJRT_DEVICE: TPU
-          TPU_LOG_DIR: tpu_logs
+          TPU_LOG_DIR: tpu_logs/${{ inputs.tpu-version }}
           TPU_VERSION: ${{ inputs.tpu-version }}
         run: |
           cd pytorch/xla

--- a/.github/workflows/_tpu_ci.yml
+++ b/.github/workflows/_tpu_ci.yml
@@ -1,9 +1,18 @@
 name: TPU Integration Test
 on:
   workflow_call:
+    inputs:
+      tpu-version:
+        required: true
+        type: string
+      runner-label:
+        required: true
+        type: string
+
 jobs:
   tpu-test:
-    runs-on: v4-runner-set
+    # Use dynamic runner based on TPU version
+    runs-on: ${{ inputs.runner-label }}-runner-set
     steps:
       - name: Checkout actions
         uses: actions/checkout@v4
@@ -11,26 +20,29 @@ jobs:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
+      
       - name: Setup
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
           wheels-artifact: torch-xla-wheels
+      
       - name: Install test dependencies
         shell: bash
         run: |
-          # TODO: Add these in setup.py
           pip install --upgrade pip
           pip install fsspec
           pip install rich
-          # Jax nightly is needed for pallas tests.
+          # Jax nightly is needed for pallas tests
           pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
           pip install torch_xla[tpu] -f https://storage.googleapis.com/libtpu-wheels/index.html -f https://storage.googleapis.com/libtpu-releases/index.html
           pip install --upgrade protobuf
+
       - name: Run Tests
         env:
           PJRT_DEVICE: TPU
           TPU_LOG_DIR: tpu_logs
+          TPU_VERSION: ${{ inputs.tpu-version }}
         run: |
           cd pytorch/xla
           test/tpu/run_tests.sh

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -104,6 +104,13 @@ jobs:
     uses: ./.github/workflows/_tpu_ci.yml
     needs: build-torch-xla
     if: github.event_name == 'push' || github.event_name == 'pull_request'
+    strategy:
+      matrix:
+        tpu-version: ['v4', 'v5p', 'v6e']
+      fail-fast: false  # Continue running other TPU versions if one fails
+    with:
+      tpu-version: ${{ matrix.tpu-version }}
+      runner-label: ${{ format('tpu-{0}', matrix.tpu-version) }}
 
   push-docs:
     name: "Build docs"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -100,7 +100,7 @@ jobs:
       torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
 
   test-tpu:
-    name: "TPU tests"
+    name: TPU tests (${{ matrix.tpu-version }})
     uses: ./.github/workflows/_tpu_ci.yml
     needs: build-torch-xla
     if: github.event_name == 'push' || github.event_name == 'pull_request'
@@ -108,9 +108,10 @@ jobs:
       matrix:
         tpu-version: ['v4', 'v5p', 'v6e']
       fail-fast: false  # Continue running other TPU versions if one fails
+      max-parallel: 3
     with:
       tpu-version: ${{ matrix.tpu-version }}
-      runner-label: ${{ format('tpu-{0}', matrix.tpu-version) }}
+      runner-label: tpu-${{ matrix.tpu-version }}-runner-set
 
   push-docs:
     name: "Build docs"

--- a/benchmarks/run_benchmark.sh
+++ b/benchmarks/run_benchmark.sh
@@ -35,7 +35,7 @@ shift $(($OPTIND - 1))
 
 # func for test after ssh to VM, create container and execute in container
 function benchmarking_in_container {
-  sudo docker pull gcr.io/tpu-pytorch/xla:nightly_3.8_cuda_11.8
+  sudo docker pull gcr.io/tpu-pytorch-releases/xla:nightly_3.8_cuda_11.8
   sudo apt-get install -y apt-transport-https ca-certificates curl gnupg-agent    software-properties-common
   nvidia-smi
   distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
@@ -43,7 +43,7 @@ function benchmarking_in_container {
   curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
   sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
   sudo systemctl restart docker
-  sudo docker run --gpus all -it -d gcr.io/tpu-pytorch/xla:nightly_3.8_cuda_11.8 bin/bash
+  sudo docker run --gpus all -it -d gcr.io/tpu-pytorch-releases/xla:nightly_3.8_cuda_11.8 bin/bash
   sudo docker exec -it $(sudo docker ps | awk 'NR==2 { print $1 }') /bin/bash
   # install torchbench
   cd ~

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -1,5 +1,5 @@
 # Cloud Build Configuration which:
-# (1) Builds, tests, and pushes gcr.io/tpu-pytorch/xla image
+# (1) Builds, tests, and pushes gcr.io/tpu-pytorch-releases/xla image
 # (2) Collects and stores torch and torch_xla wheels
 steps:
 - name: 'gcr.io/cloud-builders/docker'
@@ -16,20 +16,20 @@ steps:
           '--build-arg', 'cuda_compute=${_CUDA_COMPUTE}',
           '--build-arg', 'xla_branch=${_GITHUB_XLA_BRANCH}',
           '--build-arg', 'examle_branch=${_GITHUB_EXAMPLE_BRANCH}',
-          '-t', 'gcr.io/tpu-pytorch/xla:${_IMAGE_NAME}',
+          '-t', 'gcr.io/tpu-pytorch-releases/xla:${_IMAGE_NAME}',
           '-f', 'docker/Dockerfile', '.'
         ]
   timeout: 14400s
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: bash
-  args: ['-c', 'docker tag gcr.io/tpu-pytorch/xla:${_IMAGE_NAME} gcr.io/tpu-pytorch/xla:${_IMAGE_NAME}_$(date -u +%Y%m%d)']
-- name: 'gcr.io/tpu-pytorch/xla:${_IMAGE_NAME}'
+  args: ['-c', 'docker tag gcr.io/tpu-pytorch-releases/xla:${_IMAGE_NAME} gcr.io/tpu-pytorch-releases/xla:${_IMAGE_NAME}_$(date -u +%Y%m%d)']
+- name: 'gcr.io/tpu-pytorch-releases/xla:${_IMAGE_NAME}'
   entrypoint: bash
   args: ['-c', 'source /pytorch/xla/docker/common.sh && run_deployment_tests']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', '--all-tags', 'gcr.io/tpu-pytorch/xla']
+  args: ['push', '--all-tags', 'gcr.io/tpu-pytorch-releases/xla']
   timeout: 2700s
-- name: 'gcr.io/tpu-pytorch/xla:${_IMAGE_NAME}'
+- name: 'gcr.io/tpu-pytorch-releases/xla:${_IMAGE_NAME}'
   entrypoint: 'bash'
   args: ['-c', 'source /pytorch/xla/docker/common.sh && collect_wheels ${_RELEASE_VERSION}']
 
@@ -48,12 +48,12 @@ substitutions:
     _GITHUB_EXAMPLE_BRANCH: 'master'
 options:
     pool:
-      name: 'projects/tpu-pytorch/locations/us-central1/workerPools/wheel_build'
+      name: 'projects/tpu-pytorch-releases/locations/us-central1/workerPools/wheel_build'
     dynamic_substitutions: true
     substitution_option: 'ALLOW_LOOSE'
 timeout: 32000s
 artifacts:
   objects:
     # CUDA wheels exported under `wheels/cuda/<cuda_version>`
-    location: 'gs://tpu-pytorch/wheels/$_UPLOAD_SUBDIR'
+    location: 'gs://tpu-pytorch-releases/wheels/$_UPLOAD_SUBDIR'
     paths: ['/**/*.whl']

--- a/docker/debug_cloudbuild.yaml
+++ b/docker/debug_cloudbuild.yaml
@@ -1,5 +1,5 @@
 # Cloud Build Configuration which:
-# Builds and pushes gcr.io/tpu-pytorch/xla_debug image.
+# Builds and pushes gcr.io/tpu-pytorch-releases/xla_debug image.
 steps:
 - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
   args: ['bash', 'docker/debug_image_cleanup.sh']
@@ -11,16 +11,16 @@ steps:
           '--build-arg', 'python_version=${_PYTHON_VERSION}',
           '--build-arg', 'cloud_build=true',
           '--build-arg', 'release_version=${_RELEASE_VERSION}',
-          '-t', 'gcr.io/tpu-pytorch/xla_debug:${_TAG_NAME}',
-          '--cache-from', 'gcr.io/tpu-pytorch/xla_debug:nightly_3.6',
+          '-t', 'gcr.io/tpu-pytorch-releases/xla_debug:${_TAG_NAME}',
+          '--cache-from', 'gcr.io/tpu-pytorch-releases/xla_debug:nightly_3.6',
           '-f', 'docker/Dockerfile', '.'
         ]
   timeout: 14400s
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: bash
-  args: ['-c', 'docker tag gcr.io/tpu-pytorch/xla_debug:${_TAG_NAME} gcr.io/tpu-pytorch/xla_debug:${_TAG_NAME}_$(date -u +%Y%m%d_%H_%M)']
+  args: ['-c', 'docker tag gcr.io/tpu-pytorch-releases/xla_debug:${_TAG_NAME} gcr.io/tpu-pytorch-releases/xla_debug:${_TAG_NAME}_$(date -u +%Y%m%d_%H_%M)']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'gcr.io/tpu-pytorch/xla_debug']
+  args: ['push', 'gcr.io/tpu-pytorch-releases/xla_debug']
   timeout: 1800s
 
 options:

--- a/docker/debug_image_cleanup.sh
+++ b/docker/debug_image_cleanup.sh
@@ -1,4 +1,4 @@
-IMAGE="gcr.io/tpu-pytorch/xla_debug"
+IMAGE="gcr.io/tpu-pytorch-releases/xla_debug"
 DATE=$(date --date='-90 days' +"%Y-%m-%dT%H:%M:%S")
 
 for digest in $(gcloud container images list-tags ${IMAGE} --limit=999999 --sort-by=TIMESTAMP --filter="timestamp.datetime < '${DATE}'" --format='get(digest)'); do

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 # Explicitly source bashrc even when running commands directly.
 # Since commands run as a separate subshell, we need to source manually.
-# ex. docker run -it gcr.io/tpu-pytorch/xla:nightly bash ...
+# ex. docker run -it gcr.io/tpu-pytorch-releases/xla:nightly bash ...
 # The above will not source bashrc without entrypoint.
 source ~/.bashrc
 

--- a/infra/terraform_modules/arc_v5p_container_cluster/arc-values.yaml
+++ b/infra/terraform_modules/arc_v5p_container_cluster/arc-values.yaml
@@ -1,0 +1,18 @@
+githubConfigUrl: ${github_repo_url}
+githubConfigSecret: github-pat
+minRunners: 1
+maxRunners: ${max_tpu_nodes}
+template:
+  spec:
+    containers:
+    - name: runner
+      image: ${runner_image}
+      command: ["/home/runner/run.sh"]
+      resources:
+        limits:
+          google.com/tpu: 4
+        requests:
+          google.com/tpu: 4
+    nodeSelector:
+      cloud.google.com/gke-tpu-accelerator: tpu-v5p-slice
+      cloud.google.com/gke-tpu-topology: 2x2x1

--- a/infra/terraform_modules/arc_v5p_container_cluster/main.tf
+++ b/infra/terraform_modules/arc_v5p_container_cluster/main.tf
@@ -1,0 +1,99 @@
+provider "google" {
+  project = var.project_id
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = "https://${google_container_cluster.arc_v5p_cluster.endpoint}"
+    token                  = data.google_client_config.default.access_token
+    cluster_ca_certificate = base64decode(google_container_cluster.arc_v5p_cluster.master_auth.0.cluster_ca_certificate)
+  }
+}
+
+data "google_client_config" "default" {}
+
+resource "google_container_cluster" "arc_v5p_cluster" {
+  name     = var.cluster_name
+  location = "us-central2"
+
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  release_channel {
+    channel = "RAPID"
+  }
+
+  min_master_version = 1.28
+}
+
+resource "google_container_node_pool" "arc_v5p_cpu_nodes" {
+  name       = var.cpu_nodepool_name
+  location   = "us-central2"
+  cluster    = google_container_cluster.arc_v5p_cluster.name
+  node_count = var.cpu_node_count
+
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+    ]
+  }
+
+  management {
+    auto_upgrade = true
+    auto_repair  = true
+  }
+}
+
+resource "google_container_node_pool" "arc_v5p_tpu_nodes" {
+  name               = var.tpu_nodepool_name
+  location           = "us-central2"
+  node_locations     = ["us-central2-b"]
+  cluster            = google_container_cluster.arc_v5p_cluster.name
+  initial_node_count = 1
+  autoscaling {
+    total_min_node_count = 1
+    total_max_node_count = var.max_tpu_nodes
+    location_policy      = "ANY"
+  }
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+    ]
+    machine_type = "ct5p-hightpu-4t"
+  }
+  management {
+    auto_upgrade = true
+    auto_repair  = true
+  }
+}
+
+resource "helm_release" "arc" {
+  name             = "actions-runner-controller"
+  chart            = "oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller"
+  version          = "0.9.3"
+  namespace        = var.arc_namespace
+  create_namespace = true
+}
+
+resource "helm_release" "arc_runner_set" {
+  name = "v5p-runner-set"
+  depends_on = [
+    helm_release.arc
+  ]
+  chart            = "oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set"
+  version          = "0.9.3"
+  namespace        = var.runner_namespace
+  create_namespace = true
+
+  values = [
+    templatefile("../terraform_modules/arc_v5p_container_cluster/arc-values.yaml", {
+      github_repo_url = var.github_repo_url
+      max_tpu_nodes   = var.max_tpu_nodes
+      runner_image    = var.runner_image
+    })
+  ]
+}

--- a/infra/terraform_modules/arc_v5p_container_cluster/variables.tf
+++ b/infra/terraform_modules/arc_v5p_container_cluster/variables.tf
@@ -1,0 +1,51 @@
+variable "cluster_name" {
+  description = "Name of the Container Cluster containing the v5p node pool"
+  type        = string
+}
+
+variable "cpu_nodepool_name" {
+  description = "Name of the CPU Nodepool"
+  type        = string
+}
+
+variable "cpu_node_count" {
+  description = "Number of CPU nodes"
+  type        = number
+}
+
+variable "tpu_nodepool_name" {
+  description = "Name of the TPU Nodepool"
+  type        = string
+}
+
+variable "max_tpu_nodes" {
+  description = "Maximum number of TPU nodes and runners"
+  type        = number
+}
+
+variable "arc_namespace" {
+  description = "The namespace where ARC will reside"
+  default     = "arc-systems"
+  type        = string
+}
+
+variable "runner_namespace" {
+  description = "The namespace where the ARC runners will reside"
+  default     = "arc-runners"
+  type        = string
+}
+
+variable "github_repo_url" {
+  description = "The full URL of the repository which will be utilizing the self-hosted runners in ARC"
+  type        = string
+}
+
+variable "project_id" {
+  description = "The project ID"
+  type        = string
+}
+
+variable "runner_image" {
+  description = "The Docker image used in the self-hosted runner"
+  type        = string
+}

--- a/infra/terraform_modules/arc_v6e_container_cluster/arc-values.yaml
+++ b/infra/terraform_modules/arc_v6e_container_cluster/arc-values.yaml
@@ -1,0 +1,18 @@
+githubConfigUrl: ${github_repo_url}
+githubConfigSecret: github-pat
+minRunners: 1
+maxRunners: ${max_tpu_nodes}
+template:
+  spec:
+    containers:
+    - name: runner
+      image: ${runner_image}
+      command: ["/home/runner/run.sh"]
+      resources:
+        limits:
+          google.com/tpu: 4
+        requests:
+          google.com/tpu: 4
+    nodeSelector:
+      cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
+      cloud.google.com/gke-tpu-topology: 2x2

--- a/infra/terraform_modules/arc_v6e_container_cluster/main.tf
+++ b/infra/terraform_modules/arc_v6e_container_cluster/main.tf
@@ -1,0 +1,99 @@
+provider "google" {
+  project = var.project_id
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = "https://${google_container_cluster.arc_v6e_cluster.endpoint}"
+    token                  = data.google_client_config.default.access_token
+    cluster_ca_certificate = base64decode(google_container_cluster.arc_v6e_cluster.master_auth.0.cluster_ca_certificate)
+  }
+}
+
+data "google_client_config" "default" {}
+
+resource "google_container_cluster" "arc_v6e_cluster" {
+  name     = var.cluster_name
+  location = "us-central2"
+
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  release_channel {
+    channel = "RAPID"
+  }
+
+  min_master_version = 1.28
+}
+
+resource "google_container_node_pool" "arc_v6e_cpu_nodes" {
+  name       = var.cpu_nodepool_name
+  location   = "us-central2"
+  cluster    = google_container_cluster.arc_v6e_cluster.name
+  node_count = var.cpu_node_count
+
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+    ]
+  }
+
+  management {
+    auto_upgrade = true
+    auto_repair  = true
+  }
+}
+
+resource "google_container_node_pool" "arc_v6e_tpu_nodes" {
+  name               = var.tpu_nodepool_name
+  location           = "us-central2"
+  node_locations     = ["us-central2-b"]
+  cluster            = google_container_cluster.arc_v6e_cluster.name
+  initial_node_count = 1
+  autoscaling {
+    total_min_node_count = 1
+    total_max_node_count = var.max_tpu_nodes
+    location_policy      = "ANY"
+  }
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+    ]
+    machine_type = "ct6e-standard-4t"
+  }
+  management {
+    auto_upgrade = true
+    auto_repair  = true
+  }
+}
+
+resource "helm_release" "arc" {
+  name             = "actions-runner-controller"
+  chart            = "oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller"
+  version          = "0.9.3"
+  namespace        = var.arc_namespace
+  create_namespace = true
+}
+
+resource "helm_release" "arc_runner_set" {
+  name = "v6e-runner-set"
+  depends_on = [
+    helm_release.arc
+  ]
+  chart            = "oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set"
+  version          = "0.9.3"
+  namespace        = var.runner_namespace
+  create_namespace = true
+
+  values = [
+    templatefile("../terraform_modules/arc_v6e_container_cluster/arc-values.yaml", {
+      github_repo_url = var.github_repo_url
+      max_tpu_nodes   = var.max_tpu_nodes
+      runner_image    = var.runner_image
+    })
+  ]
+}

--- a/infra/terraform_modules/arc_v6e_container_cluster/variables.tf
+++ b/infra/terraform_modules/arc_v6e_container_cluster/variables.tf
@@ -1,0 +1,51 @@
+variable "cluster_name" {
+  description = "Name of the Container Cluster containing the v6e node pool"
+  type        = string
+}
+
+variable "cpu_nodepool_name" {
+  description = "Name of the CPU Nodepool"
+  type        = string
+}
+
+variable "cpu_node_count" {
+  description = "Number of CPU nodes"
+  type        = number
+}
+
+variable "tpu_nodepool_name" {
+  description = "Name of the TPU Nodepool"
+  type        = string
+}
+
+variable "max_tpu_nodes" {
+  description = "Maximum number of TPU nodes and runners"
+  type        = number
+}
+
+variable "arc_namespace" {
+  description = "The namespace where ARC will reside"
+  default     = "arc-systems"
+  type        = string
+}
+
+variable "runner_namespace" {
+  description = "The namespace where the ARC runners will reside"
+  default     = "arc-runners"
+  type        = string
+}
+
+variable "github_repo_url" {
+  description = "The full URL of the repository which will be utilizing the self-hosted runners in ARC"
+  type        = string
+}
+
+variable "project_id" {
+  description = "The project ID"
+  type        = string
+}
+
+variable "runner_image" {
+  description = "The Docker image used in the self-hosted runner"
+  type        = string
+}

--- a/infra/tpu-pytorch-releases/.terraform.lock.hcl
+++ b/infra/tpu-pytorch-releases/.terraform.lock.hcl
@@ -20,3 +20,22 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:fe789dc52fc029c18e92db0efb3b013d15679b81c1ab633fa69b3eacde9842ac",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version = "2.17.0"
+  hashes = [
+    "h1:K5FEjxvDnxb1JF1kG1xr8J3pNGxoaR3Z0IBG9Csm/Is=",
+    "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
+    "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
+    "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
+    "zh:3956187ec239f4045975b35e8c30741f701aa494c386aaa04ebabffe7749f81c",
+    "zh:66a9686d92a6b3ec43de3ca3fde60ef3d89fb76259ed3313ca4eb9bb8c13b7dd",
+    "zh:88644260090aa621e7e8083585c468c8dd5e09a3c01a432fb05da5c4623af940",
+    "zh:a248f650d174a883b32c5b94f9e725f4057e623b00f171936dcdcc840fad0b3e",
+    "zh:aa498c1f1ab93be5c8fbf6d48af51dc6ef0f10b2ea88d67bcb9f02d1d80d3930",
+    "zh:bf01e0f2ec2468c53596e027d376532a2d30feb72b0b5b810334d043109ae32f",
+    "zh:c46fa84cc8388e5ca87eb575a534ebcf68819c5a5724142998b487cb11246654",
+    "zh:d0c0f15ffc115c0965cbfe5c81f18c2e114113e7a1e6829f6bfd879ce5744fbb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/tpu-pytorch-releases/iam.auto.tfvars
+++ b/infra/tpu-pytorch-releases/iam.auto.tfvars
@@ -5,3 +5,10 @@ project_admins = [
 
 cloudbuild_editors = [
 ]
+
+project_remote_build_writers = [
+  "group:cloud-tpus-dev-team@twosync.google.com",
+  "user:pytorchxla-general@google.com",
+  # tpu-pytorch-releases project: default Service Account for running Cloud Build jobs.
+  "serviceAccount:1001674285173@cloudbuild.gserviceaccount.com"
+]

--- a/infra/tpu-pytorch-releases/iam.tf
+++ b/infra/tpu-pytorch-releases/iam.tf
@@ -33,3 +33,35 @@ resource "google_project_iam_member" "cloudbuild_editor" {
   role    = "roles/cloudbuild.builds.editor"
   member  = each.value
 }
+
+resource "google_project_iam_custom_role" "remote_bazel_role" {
+  role_id     = "remoteBuildWriterRole"
+  title       = "Remote Build Writer"
+  description = "For running remote bazel builds and read/write from remote cache on GCP."
+  stage       = "ALPHA"
+  permissions = [
+    "remotebuildexecution.actions.create",
+    "remotebuildexecution.actions.get",
+    "remotebuildexecution.actions.set",
+    "remotebuildexecution.blobs.create",
+    "remotebuildexecution.blobs.get",
+    "remotebuildexecution.logstreams.create",
+    "remotebuildexecution.logstreams.get",
+    "remotebuildexecution.logstreams.update",
+  ]
+}
+
+data "google_project" "project" {}
+
+variable "project_remote_build_writers" {
+  type    = list(string)
+  default = []
+}
+
+resource "google_project_iam_member" "project_remote_build_writers" {
+  for_each = toset(var.project_remote_build_writers)
+
+  project = data.google_project.project.project_id
+  role    = google_project_iam_custom_role.remote_bazel_role.id
+  member  = each.value
+}

--- a/infra/tpu-pytorch-releases/iam.tf
+++ b/infra/tpu-pytorch-releases/iam.tf
@@ -51,8 +51,6 @@ resource "google_project_iam_custom_role" "remote_bazel_role" {
   ]
 }
 
-data "google_project" "project" {}
-
 variable "project_remote_build_writers" {
   type    = list(string)
   default = []

--- a/infra/tpu-pytorch-releases/infra_triggers.tf
+++ b/infra/tpu-pytorch-releases/infra_triggers.tf
@@ -6,4 +6,5 @@ module "terraform_apply" {
   config_directory = "infra/tpu-pytorch-releases"
 
   worker_pool_id = module.worker_pool.id
+  location       = "global"
 }

--- a/infra/tpu-pytorch-releases/test_triggers.tf
+++ b/infra/tpu-pytorch-releases/test_triggers.tf
@@ -1,0 +1,50 @@
+module "tpu_e2e_tests" {
+  source = "../terraform_modules/xla_docker_build"
+
+  trigger_name = "ci-tpu-test-trigger"
+
+  trigger_on_push = {
+    branch = "master"
+    ignored_files = ["experimental/torch_xla2/**"]
+  }
+  run_e2e_tests   = true
+
+  image_name = "pytorch-xla-test"
+  image_tags = [
+    # $BUILD_ID is a GCB variable, not a bash variable.
+    # See https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values#using_default_substitutions.
+    "$BUILD_ID",
+  ]
+  dockerfile = "e2e_tests.Dockerfile"
+  description = join(" ", [
+    "Run e2e TPU tests on an image built from master branch.",
+    "Trigger managed by Terraform setup in",
+    "infra/tpu-pytorch-releases/test_triggers.tf.",
+  ])
+
+  build_args = {
+    python_version = "3.10"
+  }
+
+  ansible_vars = {
+    arch            = "amd64"
+    accelerator     = "tpu"
+    pytorch_git_rev = "main"
+    # The commit ID associated with the triggered build. Substituted when
+    # Cloud Build is triggered.
+    xla_git_rev = "$COMMIT_SHA"
+    bundle_libtpu = "0"
+  }
+
+  # Substitutions used in the "run_e2e_tests" step, see
+  # infra/terraform_modules/xla_docker_build/xla_docker_build.tf.
+  substitutions = {
+    _CLUSTER_NAME = "tpu-cluster"
+    _CLUSTER_ZONE = "europe-west4-a"
+  }
+
+  docker_repo_url = module.docker_registry.url
+  worker_pool_id  = module.worker_pool.id
+  timeout_minutes = 4 * 60
+  location        = "global"
+}

--- a/infra/tpu-pytorch-releases/tpu_ci.tf
+++ b/infra/tpu-pytorch-releases/tpu_ci.tf
@@ -1,0 +1,48 @@
+# This Terraform configuration manages CI/CD infrastructure for PyTorch/XLA testing
+# across multiple TPU hardware generations (v4, v5p, v6e). It creates:
+# - Separate GKE clusters for each TPU version
+# - Node pools with both CPU and TPU nodes
+# - GitHub Actions runner configuration for automated testing
+# - Custom CI runner container deployment
+# 
+# The infrastructure is used to run automated tests for the pytorch/xla repository
+# ensuring compatibility and performance across TPU generations.
+
+module "v4_arc_cluster" {
+  source            = "../terraform_modules/arc_v4_container_cluster"
+  project_id        = "tpu-pytorch-releases"
+  cluster_name      = "tpu-ci"
+  cpu_nodepool_name = "cpu-nodepool"
+  cpu_node_count    = 1
+  tpu_nodepool_name = "tpu-nodepool"
+  max_tpu_nodes     = 4
+  github_repo_url   = "https://github.com/pytorch/xla"
+  # Dockerfile for this image can be found at test/tpu/Dockerfile
+  runner_image      = "gcr.io/tpu-pytorch-releases/tpu-ci-runner:latest"
+}
+
+module "v5p_arc_cluster" {
+  source            = "../terraform_modules/arc_v5p_container_cluster"
+  project_id        = "tpu-pytorch-releases"
+  cluster_name      = "tpu-ci"
+  cpu_nodepool_name = "cpu-nodepool"
+  cpu_node_count    = 1
+  tpu_nodepool_name = "tpu-nodepool"
+  max_tpu_nodes     = 4
+  github_repo_url   = "https://github.com/pytorch/xla"
+  # Dockerfile for this image can be found at test/tpu/Dockerfile
+  runner_image      = "gcr.io/tpu-pytorch-releases/tpu-ci-runner:latest"
+}
+
+module "v6e_arc_cluster" {
+  source            = "../terraform_modules/arc_v6e_container_cluster"
+  project_id        = "tpu-pytorch-releases"
+  cluster_name      = "tpu-ci"
+  cpu_nodepool_name = "cpu-nodepool"
+  cpu_node_count    = 1
+  tpu_nodepool_name = "tpu-nodepool"
+  max_tpu_nodes     = 4
+  github_repo_url   = "https://github.com/pytorch/xla"
+  # Dockerfile for this image can be found at test/tpu/Dockerfile
+  runner_image      = "gcr.io/tpu-pytorch-releases/tpu-ci-runner:latest"
+}

--- a/infra/tpu-pytorch/iam.auto.tfvars
+++ b/infra/tpu-pytorch/iam.auto.tfvars
@@ -1,7 +1,38 @@
 project_remote_build_writers = [
   "group:cloud-tpus-dev-team@twosync.google.com",
-  "user:mlewko@google.com",
-  "user:goranpetrovic@google.com",
+  "user:pytorchxla-general@google.com",
   # tpu-pytorch-releases project: default Service Account for running Cloud Build jobs.
   "serviceAccount:1001674285173@cloudbuild.gserviceaccount.com"
+]
+
+cloudbuild_editors = [
+  "user:pytorchxla-general@google.com",
+]
+
+artifact_registry_administrators = [
+  "user:pytorchxla-general@google.com",
+]
+
+bigquery_admins = [
+  "user:pytorchxla-general@google.com",
+]
+
+compute_admins = [
+  "user:pytorchxla-general@google.com",
+]
+
+remote_bazel = [
+  "user:pytorchxla-general@google.com",
+]
+
+role_viewers = [
+  "user:pytorchxla-general@google.com",
+]
+
+storage_admins = [
+  "user:pytorchxla-general@google.com",
+]
+
+tpu_admins = [
+  "user:pytorchxla-general@google.com",
 ]

--- a/infra/tpu-pytorch/infra_triggers.tf
+++ b/infra/tpu-pytorch/infra_triggers.tf
@@ -3,7 +3,7 @@ module "terraform_apply" {
 
   included_files    = ["infra/**"]
   branch           = "master"
-  config_directory = "infra/tpu-pytorch"
+  config_directory = "infra/tpu-pytorch-releases"
 
   worker_pool_id = module.worker_pool.id
   location       = "global"

--- a/infra/tpu-pytorch/tpu_ci.tf
+++ b/infra/tpu-pytorch/tpu_ci.tf
@@ -1,6 +1,6 @@
 module "v4_arc_cluster" {
   source            = "../terraform_modules/arc_v4_container_cluster"
-  project_id        = "tpu-pytorch"
+  project_id        = "tpu-pytorch-releases"
   cluster_name      = "tpu-ci"
   cpu_nodepool_name = "cpu-nodepool"
   cpu_node_count    = 1
@@ -8,5 +8,5 @@ module "v4_arc_cluster" {
   max_tpu_nodes     = 2
   github_repo_url   = "https://github.com/pytorch/xla"
   # Dockerfile for this image can be found at test/tpu/Dockerfile
-  runner_image      = "gcr.io/tpu-pytorch/tpu-ci-runner:latest"
+  runner_image      = "gcr.io/tpu-pytorch-releases/tpu-ci-runner:latest"
 }

--- a/scripts/update_torch_wheels.sh
+++ b/scripts/update_torch_wheels.sh
@@ -2,7 +2,7 @@
 set -e
 set -x
 
-DIST_BUCKET="gs://tpu-pytorch/wheels"
+DIST_BUCKET="gs://tpu-pytorch-releases/wheels"
 TORCH_WHEEL="torch-nightly-cp36-cp36m-linux_x86_64.whl"
 TORCH_XLA_WHEEL="torch_xla-nightly-cp36-cp36m-linux_x86_64.whl"
 TORCHVISION_WHEEL="torchvision-nightly-cp36-cp36m-linux_x86_64.whl"


### PR DESCRIPTION
### Summary of update:
1. Port infra from tpu-pytorch to tpu-pytorch-releases;
2. Support v4, v5p, v6e in CI run;
3. Update IAM role using tf config.


-----
**DO NOT MERGE!!**  until TPU capacity is ready in `tpu-pytorch-releases`

**DO NOT TERRAFORM APPLY** IAM role config in infra/tpu-pytorch/iam.auto.tfvars as we still have bunch of compute service account in `tpu-pytorch` project.