### PR TITLE
Prepare to make rc6 wheel

### DIFF
--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -52,52 +52,52 @@ nightly_builds = [
 versioned_builds = [
   # Remove libtpu from PyPI builds, pre-C++11 ABI builds
   {
-    git_tag         = "v2.6.0-rc5"
-    package_version = "2.6.0-rc5"
-    pytorch_git_rev = "v2.6.0-rc5"
+    git_tag         = "v2.6.0-rc6"
+    package_version = "2.6.0-rc6"
+    pytorch_git_rev = "v2.6.0-rc6"
     accelerator     = "tpu"
     python_version  = "3.9"
     bundle_libtpu   = "0"
   },
   {
-    git_tag         = "v2.6.0-rc5"
-    package_version = "2.6.0-rc5"
-    pytorch_git_rev = "v2.6.0-rc5"
+    git_tag         = "v2.6.0-rc6"
+    package_version = "2.6.0-rc6"
+    pytorch_git_rev = "v2.6.0-rc6"
     accelerator     = "tpu"
     python_version  = "3.10"
     bundle_libtpu   = "0"
   },
   {
-    git_tag         = "v2.6.0-rc5"
-    package_version = "2.6.0-rc5"
-    pytorch_git_rev = "v2.6.0-rc5"
+    git_tag         = "v2.6.0-rc6"
+    package_version = "2.6.0-rc6"
+    pytorch_git_rev = "v2.6.0-rc6"
     accelerator     = "tpu"
     python_version  = "3.11"
     bundle_libtpu   = "0"
   },
   # Remove libtpu from PyPI builds, C++11 ABI builds
   {
-    git_tag         = "v2.6.0-rc5"
-    package_version = "2.6.0-rc5"
-    pytorch_git_rev = "v2.6.0-rc5"
+    git_tag         = "v2.6.0-rc6"
+    package_version = "2.6.0-rc6"
+    pytorch_git_rev = "v2.6.0-rc6"
     accelerator     = "tpu"
     python_version  = "3.9"
     bundle_libtpu   = "0"
     cxx11_abi       = "1"
   },
   {
-    git_tag         = "v2.6.0-rc5"
-    package_version = "2.6.0-rc5"
-    pytorch_git_rev = "v2.6.0-rc5"
+    git_tag         = "v2.6.0-rc6"
+    package_version = "2.6.0-rc6"
+    pytorch_git_rev = "v2.6.0-rc6"
     accelerator     = "tpu"
     python_version  = "3.10"
     bundle_libtpu   = "0"
     cxx11_abi       = "1"
   },
   {
-    git_tag         = "v2.6.0-rc5"
-    package_version = "2.6.0-rc5"
-    pytorch_git_rev = "v2.6.0-rc5"
+    git_tag         = "v2.6.0-rc6"
+    package_version = "2.6.0-rc6"
+    pytorch_git_rev = "v2.6.0-rc6"
     accelerator     = "tpu"
     python_version  = "3.11"
     bundle_libtpu   = "0"
@@ -105,9 +105,9 @@ versioned_builds = [
   }, 
   # Bundle libtpu for Kaggle
   {
-    git_tag         = "v2.6.0-rc5"
-    package_version = "2.6.0-rc5+libtpu"
-    pytorch_git_rev = "v2.6.0-rc5"
+    git_tag         = "v2.6.0-rc6"
+    package_version = "2.6.0-rc6+libtpu"
+    pytorch_git_rev = "v2.6.0-rc6"
     accelerator     = "tpu"
     python_version  = "3.10"
     bundle_libtpu   = "1"


### PR DESCRIPTION
PyTorch upstream has tagged rc6: https://github.com/pytorch/pytorch/tree/v2.6.0-rc6

Update CI to pull rc6.

After this commit, I'll add an rc6 tag and run tests.