### PR TITLE
Prepare to create 2.6.0rc8 builds

### DIFF
--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -52,24 +52,24 @@ nightly_builds = [
 versioned_builds = [
   # Remove libtpu from PyPI builds, pre-C++11 ABI builds
   {
-    git_tag         = "v2.6.0-rc7"
-    package_version = "2.6.0-rc7"
+    git_tag         = "v2.6.0-rc8"
+    package_version = "2.6.0-rc8"
     pytorch_git_rev = "v2.6.0-rc7"
     accelerator     = "tpu"
     python_version  = "3.9"
     bundle_libtpu   = "0"
   },
   {
-    git_tag         = "v2.6.0-rc7"
-    package_version = "2.6.0-rc7"
+    git_tag         = "v2.6.0-rc8"
+    package_version = "2.6.0-rc8"
     pytorch_git_rev = "v2.6.0-rc7"
     accelerator     = "tpu"
     python_version  = "3.10"
     bundle_libtpu   = "0"
   },
   {
-    git_tag         = "v2.6.0-rc7"
-    package_version = "2.6.0-rc7"
+    git_tag         = "v2.6.0-rc8"
+    package_version = "2.6.0-rc8"
     pytorch_git_rev = "v2.6.0-rc7"
     accelerator     = "tpu"
     python_version  = "3.11"
@@ -77,8 +77,8 @@ versioned_builds = [
   },
   # Remove libtpu from PyPI builds, C++11 ABI builds
   {
-    git_tag         = "v2.6.0-rc7"
-    package_version = "2.6.0-rc7"
+    git_tag         = "v2.6.0-rc8"
+    package_version = "2.6.0-rc8"
     pytorch_git_rev = "v2.6.0-rc7"
     accelerator     = "tpu"
     python_version  = "3.9"
@@ -86,8 +86,8 @@ versioned_builds = [
     cxx11_abi       = "1"
   },
   {
-    git_tag         = "v2.6.0-rc7"
-    package_version = "2.6.0-rc7"
+    git_tag         = "v2.6.0-rc8"
+    package_version = "2.6.0-rc8"
     pytorch_git_rev = "v2.6.0-rc7"
     accelerator     = "tpu"
     python_version  = "3.10"
@@ -95,8 +95,8 @@ versioned_builds = [
     cxx11_abi       = "1"
   },
   {
-    git_tag         = "v2.6.0-rc7"
-    package_version = "2.6.0-rc7"
+    git_tag         = "v2.6.0-rc8"
+    package_version = "2.6.0-rc8"
     pytorch_git_rev = "v2.6.0-rc7"
     accelerator     = "tpu"
     python_version  = "3.11"
@@ -105,8 +105,8 @@ versioned_builds = [
   }, 
   # Bundle libtpu for Kaggle
   {
-    git_tag         = "v2.6.0-rc7"
-    package_version = "2.6.0-rc7+libtpu"
+    git_tag         = "v2.6.0-rc8"
+    package_version = "2.6.0-rc8+libtpu"
     pytorch_git_rev = "v2.6.0-rc7"
     accelerator     = "tpu"
     python_version  = "3.10"


### PR DESCRIPTION
Note that PyTorch only has up to rc7.