### PR TITLE
Make partition_spec as tuple to fix issue #8522

### DIFF
--- a/torch_xla/experimental/spmd_fully_sharded_data_parallel.py
+++ b/torch_xla/experimental/spmd_fully_sharded_data_parallel.py
@@ -20,7 +20,7 @@ def _prepare_spmd_partition_spec(param,
   partition_spec = [None] * len(shape)
   # Skip scalar tensors and it replicated.
   if len(partition_spec) == 0:
-    return partition_spec
+    return tuple(partition_spec)
 
   # Shard the 0th dimension of the parameter according to the
   # fsdp axis of the mesh, if shard_maximal is not specified.


### PR DESCRIPTION
make partition_spec as tuple in case any scalar exists in model's parameters or intermediate outputs #8522 