### PR TITLE
Improve the nprocs value error message to be actionable

### DIFF
--- a/torch_xla/_internal/pjrt.py
+++ b/torch_xla/_internal/pjrt.py
@@ -207,7 +207,7 @@ def spawn(fn: Callable,
     return _run_singleprocess(spawn_fn)
   elif nprocs is not None:
     raise ValueError(
-        'Unsupported nprocs (%d). Please use the environment variable for the hardware you are using (X_NUM_DEVICES where X is CPU, GPU, TPU, NEURONCORE, etc).'
+        'Unsupported nprocs (%d). Please use nprocs=1 or None (default). If None, spawn will use all available devices. Use the environment variable X_NUM_DEVICES (where X is CPU, GPU, TPU, NEURONCORE, etc) to limit the number of devices used.'
         % nprocs)
 
   run_multiprocess(spawn_fn, start_method=start_method)


### PR DESCRIPTION
Cherry-pick of PR: https://github.com/pytorch/xla/pull/8622/files
Reason: In earlier torch-xla versions nprocs != 1 or None was ignored. In 2.6 we make it a value error. However the message was not clear. This change improve the messaging to be more clear and actionable.  It would be good to cherry-pick, as customers will start to see errors when nprocs not equal to 1 or None (whereas before 2.6 there was a warning only).
