### PR TITLE
`cummax`: fix 0-sized dimension reduction.

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2370,6 +2370,20 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     self.assertEqual(out.dtype, out_xla.dtype)
     self.assertEqual(out.cpu(), out_xla.cpu(), prec=1e-4)
 
+  def test_cummax_0_sized_dimension(self):
+    # Test cummax on dim=2 (a 0-sized dimension).
+    #
+    # Make sure we are not crashing, here. Instead, we should return a tuple of
+    # empty tensors, just like PyTorch.
+
+    dim = 2
+    a = torch.rand(5, 5, 0, 5)
+
+    expected = torch.cummax(a, dim)
+    actual = torch.cummax(a.to(xm.xla_device()), dim)
+
+    self.assertEqual(actual, expected)
+
 
 class MNISTComparator(nn.Module):
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1329,7 +1329,8 @@ std::tuple<XLATensorPtr, XLATensorPtr> cummax(const XLATensorPtr& input,
     return std::make_tuple(input->Create(val, input->GetDevice()),
                            input->Create(idx, input->GetDevice()));
   }
-  torch::lazy::NodePtr node = torch_xla::MakeNode<CumMax>(input->GetIrValue(), canonical_dim);
+  torch::lazy::NodePtr node =
+      torch_xla::MakeNode<CumMax>(input->GetIrValue(), canonical_dim);
   XLATensorPtr t_value = input->CreateFrom(torch::lazy::Value(node, 0),
                                            /*delay_eager_executation=*/true);
   XLATensorPtr t_index =


### PR DESCRIPTION
Fix: #8610 

This PR adds a guard when tracing `cummax`, so as to short-cut whenever we are trying to run this operation on a 0-sized dimension.

I believe adding the fix to the tracing would be better, since we don't actually need to lower to return empty tensors (shapes are static). Therefore, we end-up with one less computation.

cc @miladm