### PR TITLE
[torchax][distributed] Use local device for default jax device

### DIFF
--- a/torchax/torchax/tensor.py
+++ b/torchax/torchax/tensor.py
@@ -304,7 +304,7 @@ class Environment(contextlib.ContextDecorator):
       
       if device == 'cpu':
         return jax.devices('cpu')[0]
-      return jax.devices()[0]
+      return jax.local_devices()[0]
 
 
     def load_ops(self):


### PR DESCRIPTION
Because `jax.devices()` returns global devices, in multi-host setup, the `TPU:0` is not addressable by all host. Use `jax.local_devices()[0]` as the default jax device to make it work on multi-host