### PR TITLE
[CI] Fix torchbench setup failure

### DIFF
--- a/test/benchmarks/run_torchbench_tests.sh
+++ b/test/benchmarks/run_torchbench_tests.sh
@@ -58,6 +58,7 @@ function install_torchbench_models() {
   git clone --quiet https://github.com/pytorch/benchmark.git "$TORCHBENCH_DIR"
   cd $TORCHBENCH_DIR
   git checkout $torchbench_commit_hash
+  pip install -r requirements.txt
 
   for model in "${TORCHBENCH_MODELS[@]}"; do
       echo "Installing model: $model"


### PR DESCRIPTION
Similar to https://github.com/GoogleCloudPlatform/ml-auto-solutions/pull/581, install `requirements.txt` for torchbench to fix ci failure.