### PR TITLE
Fix a bug in flash attention where kv_seq_len should divide block_k_major.

### DIFF
--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -245,6 +245,21 @@ class PallasTest(parameterized.TestCase):
   @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 3,
                    "This test only works on TPUv3+.")
   @with_jax_high_precision
+  def test_flash_attention_wrapper_kv_and_ab_padding(self):
+    from torch_xla.experimental.custom_kernel import flash_attention
+
+    q = torch.randn(1, 2, 513, 4).to("xla")
+    k = torch.randn(1, 2, 513, 4).to("xla")
+    v = torch.randn(1, 2, 513, 4).to("xla")
+    ab = torch.randn(1,2, 513, 513).to("xla")
+
+    o = flash_attention(q, k, v, ab)
+    expected_o = self._attention(q, k, v, ab)
+    self.assertTrue(torch.allclose(o.cpu(), expected_o.cpu(), atol=1e-05))
+
+  @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 3,
+                   "This test only works on TPUv3+.")
+  @with_jax_high_precision
   def test_flash_attention_wrapper_with_dynamo(self):
     from torch_xla.experimental.custom_kernel import flash_attention
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -41,10 +41,10 @@ class PallasTest(parameterized.TestCase):
   # therefore we use != instead of ==.
   def _make_attention_mask_from_segment_ids(self, q_segment_ids,
                                             kv_segment_ids):
-    return q_segment_ids.view(q_segment_ids.shape[0], 1, q_segment_ids.shape[1],
-                              1) != kv_segment_ids.view(kv_segment_ids.shape[0],
-                                                        1, 1,
-                                                        kv_segment_ids.shape[1])
+    return q_segment_ids.view(q_segment_ids.shape[0], 1,
+                              q_segment_ids.shape[1], 1) != kv_segment_ids.view(
+                                  kv_segment_ids.shape[0], 1, 1,
+                                  kv_segment_ids.shape[1])
 
   def _attention(self, q, k, v, *, attn_mask=None, ab=None):
     attn_weight = q @ k.transpose(-2, -1)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -41,10 +41,10 @@ class PallasTest(parameterized.TestCase):
   # therefore we use != instead of ==.
   def _make_attention_mask_from_segment_ids(self, q_segment_ids,
                                             kv_segment_ids):
-    return q_segment_ids.view(q_segment_ids.shape[0], 1,
-                              q_segment_ids.shape[1], 1) != kv_segment_ids.view(
-                                  kv_segment_ids.shape[0], 1, 1,
-                                  kv_segment_ids.shape[1])
+    return q_segment_ids.view(q_segment_ids.shape[0], 1, q_segment_ids.shape[1],
+                              1) != kv_segment_ids.view(kv_segment_ids.shape[0],
+                                                        1, 1,
+                                                        kv_segment_ids.shape[1])
 
   def _attention(self, q, k, v, *, attn_mask=None, ab=None):
     attn_weight = q @ k.transpose(-2, -1)
@@ -251,7 +251,7 @@ class PallasTest(parameterized.TestCase):
     q = torch.randn(1, 2, 513, 4).to("xla")
     k = torch.randn(1, 2, 513, 4).to("xla")
     v = torch.randn(1, 2, 513, 4).to("xla")
-    ab = torch.randn(1,2, 513, 513).to("xla")
+    ab = torch.randn(1, 2, 513, 513).to("xla")
 
     o = flash_attention(q, k, v, ab=ab)
     expected_o = self._attention(q, k, v, ab=ab)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -253,8 +253,8 @@ class PallasTest(parameterized.TestCase):
     v = torch.randn(1, 2, 513, 4).to("xla")
     ab = torch.randn(1,2, 513, 513).to("xla")
 
-    o = flash_attention(q, k, v, ab)
-    expected_o = self._attention(q, k, v, ab)
+    o = flash_attention(q, k, v, ab=ab)
+    expected_o = self._attention(q, k, v, ab=ab)
     self.assertTrue(torch.allclose(o.cpu(), expected_o.cpu(), atol=1e-05))
 
   @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 3,

--- a/test/test_pallas_spmd.py
+++ b/test/test_pallas_spmd.py
@@ -89,12 +89,12 @@ class PallasTest(unittest.TestCase):
     v = torch.randn(4, 2, 513, 4).to("xla")
     ab = torch.randn(4, 2, 513, 513).to("xla")
 
-    o = flash_attention(q, k, v, ab, partition_spec=range(n_devices))
+    o = flash_attention(q, k, v, ab=ab, partition_spec=range(n_devices))
     self.assertEqual( 
         torch_xla._XLAC._get_xla_sharding_spec(o),
         f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
 
-    expected_o = self._attention(q, k, v, ab)
+    expected_o = self._attention(q, k, v, ab=ab)
     self.assertTrue(torch.allclose(o.cpu(), expected_o.cpu(), atol=1e-05))
 
   @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 3,

--- a/test/test_pallas_spmd.py
+++ b/test/test_pallas_spmd.py
@@ -80,6 +80,26 @@ class PallasTest(unittest.TestCase):
   @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 3,
                    "This test only works on TPUv3+.")
   @with_jax_high_precision
+  def test_flash_attention_spmd_data_parallel_kv_and_ab_padding(self):
+    n_devices = xr.global_runtime_device_count()
+    xs.set_global_mesh(xs.Mesh(range(n_devices), (n_devices, 1, 1, 1)))
+
+    q = torch.randn(4, 2, 513, 4).to("xla")
+    k = torch.randn(4, 2, 513, 4).to("xla")
+    v = torch.randn(4, 2, 513, 4).to("xla")
+    ab = torch.randn(4, 2, 513, 513).to("xla")
+
+    o = flash_attention(q, k, v, ab, partition_spec=range(n_devices))
+    self.assertEqual( 
+        torch_xla._XLAC._get_xla_sharding_spec(o),
+        f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
+
+    expected_o = self._attention(q, k, v, ab)
+    self.assertTrue(torch.allclose(o.cpu(), expected_o.cpu(), atol=1e-05))
+
+  @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 3,
+                   "This test only works on TPUv3+.")
+  @with_jax_high_precision
   def test_flash_attention_backward_spmd_data_parallel(self):
     n_devices = xr.global_runtime_device_count()
     xs.set_global_mesh(xs.Mesh(range(n_devices), (n_devices, 1, 1, 1)))

--- a/test/test_pallas_spmd.py
+++ b/test/test_pallas_spmd.py
@@ -41,10 +41,10 @@ class PallasTest(unittest.TestCase):
   # therefore we use != instead of ==.
   def _make_attention_mask_from_segment_ids(self, q_segment_ids,
                                             kv_segment_ids):
-    return q_segment_ids.view(q_segment_ids.shape[0], 1,
-                              q_segment_ids.shape[1], 1) != kv_segment_ids.view(
-                                  kv_segment_ids.shape[0], 1, 1,
-                                  kv_segment_ids.shape[1])
+    return q_segment_ids.view(q_segment_ids.shape[0], 1, q_segment_ids.shape[1],
+                              1) != kv_segment_ids.view(kv_segment_ids.shape[0],
+                                                        1, 1,
+                                                        kv_segment_ids.shape[1])
 
   def _attention(self, q, k, v, *, attn_mask=None, ab=None):
     attn_weight = q @ k.transpose(-2, -1)
@@ -90,7 +90,7 @@ class PallasTest(unittest.TestCase):
     ab = torch.randn(4, 2, 513, 513).to("xla")
 
     o = flash_attention(q, k, v, ab=ab, partition_spec=range(n_devices))
-    self.assertEqual( 
+    self.assertEqual(
         torch_xla._XLAC._get_xla_sharding_spec(o),
         f"{{devices=[{n_devices},1,1,1]0,1,2,3}}")
 

--- a/test/test_pallas_spmd.py
+++ b/test/test_pallas_spmd.py
@@ -41,10 +41,10 @@ class PallasTest(unittest.TestCase):
   # therefore we use != instead of ==.
   def _make_attention_mask_from_segment_ids(self, q_segment_ids,
                                             kv_segment_ids):
-    return q_segment_ids.view(q_segment_ids.shape[0], 1, q_segment_ids.shape[1],
-                              1) != kv_segment_ids.view(kv_segment_ids.shape[0],
-                                                        1, 1,
-                                                        kv_segment_ids.shape[1])
+    return q_segment_ids.view(q_segment_ids.shape[0], 1,
+                              q_segment_ids.shape[1], 1) != kv_segment_ids.view(
+                                  kv_segment_ids.shape[0], 1, 1,
+                                  kv_segment_ids.shape[1])
 
   def _attention(self, q, k, v, *, attn_mask=None, ab=None):
     attn_weight = q @ k.transpose(-2, -1)

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -282,12 +282,13 @@ def fa_custom_forward(
     block_k_major = min(FlashAttention.DEFAULT_BLOCK_SIZES["block_k_major"],
                         k.shape[2])
     block_k = min(FlashAttention.DEFAULT_BLOCK_SIZES["block_k"], k.shape[2])
-    k, k_pad_size = _pad_to_block_size(
-        k, max(block_k_major, block_k), 2, padding_minus_inf=True)
+    k, k_pad_size = _pad_to_block_size(k, max(block_k_major, block_k), 2)
     if k_pad_size > 0:
       v, _ = _pad_to_block_size(v, max(block_k_major, block_k), 2)
-      if ab is not None:
-        ab, _ = _pad_to_block_size(ab, max(block_k_major, block_k), 3)
+      if ab is None:
+        ab = torch.zeros((q.shape[0], q.shape[1], q.shape[2], q.shape[2]))
+      ab, _ = _pad_to_block_size(
+          ab, max(block_k_major, block_k), 3, padding_minus_inf=True)
 
     # We can't directly use flash_attention as we need to override the save_residuals flag which returns
     # l and m that is needed for the backward. Then we lose all the shape checks.

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -279,16 +279,15 @@ def fa_custom_forward(
     segment_ids, q_segment_ids_fa, kv_segment_ids_fa = FlashAttention.prepare_segment_ids(
         q_segment_ids, kv_segment_ids)
 
-    block_k_major = min(FlashAttention.DEFAULT_BLOCK_SIZES["block_k_major"], k.shape[2])
+    block_k_major = min(FlashAttention.DEFAULT_BLOCK_SIZES["block_k_major"],
+                        k.shape[2])
     block_k = min(FlashAttention.DEFAULT_BLOCK_SIZES["block_k"], k.shape[2])
-    k_padded, k_pad_size = _pad_to_block_size(k, max(block_k_major, block_k), 2)
-    v_padded = None
-    ab_padded = None
+    k, k_pad_size = _pad_to_block_size(k, max(block_k_major, block_k), 2)
     if k_pad_size > 0:
-      v_padded, _ = _pad_to_block_size(v, max(block_k_major, block_k), 2)
+      v, _ = _pad_to_block_size(v, max(block_k_major, block_k), 2)
       if ab is not None:
-        ab_padded, _ = _pad_to_block_size(ab, max(block_k_major, block_k), 2)
-    
+        ab, _ = _pad_to_block_size(ab, max(block_k_major, block_k), 3)
+
     # We can't directly use flash_attention as we need to override the save_residuals flag which returns
     # l and m that is needed for the backward. Then we lose all the shape checks.
     # TODO: replicate the shape checks on flash_attention.
@@ -296,9 +295,9 @@ def fa_custom_forward(
     payload, _ = trace_pallas(
         _flash_attention_impl,
         q,
-        k_padded if k_pad_size > 0 else k,
-        v_padded if k_pad_size > 0 else v,
-        ab_padded if k_pad_size > 0 and ab is not None else ab,
+        k,
+        v,
+        ab,
         segment_ids,
         save_residuals,
         causal,
@@ -312,9 +311,9 @@ def fa_custom_forward(
         use_cache=True,
     )
 
-    args = [q, k_padded if k_pad_size > 0 else k, v_padded if k_pad_size > 0 else v]
+    args = [q, k, v]
     if ab is not None:
-      args += [ab_padded if k_pad_size > 0 else ab]
+      args += [ab]
     if segment_ids is not None:
       args += [q_segment_ids_fa, kv_segment_ids_fa]
     o = torch_xla._XLAC._xla_tpu_custom_call(args, payload, shapes, dtypes)
@@ -346,17 +345,20 @@ def fa_custom_forward(
   outs = [o] + [full_q, full_k, full_v, l, m, full_ab]
   return tuple(outs)
 
-def _pad_to_block_size(tensor: torch.Tensor, block_size: int, dim: int) -> Tuple[torch.Tensor, int]:
+
+def _pad_to_block_size(tensor: torch.Tensor, block_size: int,
+                       dim: int) -> Tuple[torch.Tensor, int]:
   size = tensor.shape[dim]
   if size % block_size == 0:
     return tensor, 0
-    
+
   pad_size = block_size - (size % block_size)
   pad_shape = list(tensor.shape)
   pad_shape[dim] = pad_size
   padding = torch.zeros(pad_shape, dtype=tensor.dtype, device=tensor.device)
   padded = torch.cat([tensor, padding], dim=dim)
   return padded, pad_size
+
 
 @custom_op("xla::fa_custom_backward", mutates_args=())
 def fa_custom_backward(


### PR DESCRIPTION
When generating images with flash attention on TPU, a bug occurs with the following error message:
```
2025-02-04 07:29:15,292 - execution.py:398 - ERROR - !!! Exception during processing !!! kv_seq_len=4992 should be divisible by block_k_major=512
2025-02-04 07:29:15,295 - execution.py:399 - ERROR - Traceback (most recent call last):
  File "/app/execution.py", line 329, in execute
    output_data, output_ui, has_subgraph = get_output_data(obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/execution.py", line 203, in get_output_data
    return_values = _map_node_over_list(obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/execution.py", line 175, in _map_node_over_list
    process_inputs(input_dict, i)
  File "/app/execution.py", line 164, in process_inputs
    results.append(getattr(obj, func)(**inputs))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/custom_nodes/TLDiffnode/nodes_flux.py", line 293, in sample
    latents_or_images = pipeline(**params)[0]
                        ^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/app/diffusers/src/diffusers/pipelines/flux/pipeline_flux.py", line 907, in __call__
    noise_pred = self.transformer(
                 ^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1747, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/diffusers/src/diffusers/models/transformers/transformer_flux.py", line 545, in forward
    encoder_hidden_states, hidden_states = block(
                                           ^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1747, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/diffusers/src/diffusers/models/transformers/transformer_flux.py", line 187, in forward
    attention_outputs = self.attn(
                        ^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1747, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/diffusers/src/diffusers/models/attention_processor.py", line 594, in forward
    return self.processor(
           ^^^^^^^^^^^^^^^
  File "/app/diffusers/src/diffusers/models/attention_processor.py", line 3508, in __call__
    hidden_states = flash_attention(query, key, value, causal=False)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch_xla/experimental/custom_kernel.py", line 515, in flash_attention
    return FlashAttention.apply(q, k, v, causal, q_segment_ids, kv_segment_ids,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/autograd/function.py", line 575, in apply
    return super().apply(*args, **kwargs)  # type: ignore[misc]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch_xla/experimental/custom_kernel.py", line 307, in forward
    payload, _ = trace_pallas(
                 ^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch_xla/experimental/custom_kernel.py", line 139, in trace_pallas
    ir = jax.jit(
         ^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/jax/experimental/pallas/ops/tpu/flash_attention.py", line 621, in _flash_attention_impl
    _verify_block("block_k_major", "kv_seq_len", block_k_major, kv_seq_len)
  File "/opt/conda/lib/python3.11/site-packages/jax/experimental/pallas/ops/tpu/flash_attention.py", line 1741, in _verify_block
    raise ValueError(
ValueError: kv_seq_len=4992 should be divisible by block_k_major=512
--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.
```
# Cause:
This bug happens when the image resolution is not divisible by 512 on at least one side. Specifically, the sequence length (kv_seq_len) should be divisible by the block size (block_k_major, which is 512) for the flash attention mechanism to work correctly. In the error above, kv_seq_len=4992 is not divisible by 512, leading to this exception.

# Solution:
To resolve this issue, we need to pad the k, v, and ab vectors to ensure that their lengths are divisible by the block sizes. 