### PR TITLE
fixed the type miss match issue with symint in SPMD regime and dynamo

### DIFF
--- a/torch_xla/_dynamo/dynamo_bridge.py
+++ b/torch_xla/_dynamo/dynamo_bridge.py
@@ -581,7 +581,7 @@ def extract_internal(xla_model: torch.fx.GraphModule):
       # we will skip checking the input sharding since it can be expensive.
       if skip_checking_input_sharding_threashold > 0:
         if torch_xla._XLAC._get_xla_sharding_specs(
-            args) != xla_args_sharding_spec:
+            xla_args_tensor_only) != xla_args_sharding_spec:
           # update the xla_args with the input with new sharding and retrace
           xla_model.xla_args = args
           (xla_args_sharding_spec, args_and_out_copy, graph_hash,


### PR DESCRIPTION
In an edge case to enable SPMD with vLLM - I faced an issue where `symints` are added to the `xla_args` when mark_dynamic is called on particular tensors - this leads to graph creation failure as `torch_xla._XLAC._get_xla_sharding_specs` only accepts [`vector<at::Tensor>`](https://github.com/maxwillzq/xla/blob/e22c9ce169ebfe50f4f583970dfe395519dfcbf8/torch_xla/csrc/init_python_bindings.cpp#L1476) therefore this PR changes the `args` which might contain symints to `xla_args_tensor_only` which was defined a [few lines above](https://github.com/hosseinsarshar/xla/blob/9cc39b04ba1ad3c2569ac2b4745809c6f2258dab/torch_xla/_dynamo/dynamo_bridge.py#L540C5-L540C25).



cc @qihqi 