### PR TITLE
Added pow to autocast policy and unit test

### DIFF
--- a/test/test_autocast_xla.py
+++ b/test/test_autocast_xla.py
@@ -93,6 +93,15 @@ class TestAutocastXla(unittest.TestCase):
       self.assertRegex(hlo, r".*dot.*bf16")
       self.assertNotRegex(hlo, r".*dot.*f32")
 
+    def test_pow(self):
+        data = torch.randn(16, 20).to(torch.bfloat16).to(device)
+
+        with torch.autocast("xla"):
+            output=data.pow(2)
+            hlo = torch_xla._XLAC._get_xla_tensors_hlo([output])
+        
+            self.assertRegex(hlo, r".*convert.*f32.*convert.*bf16")
+            self.assertRegex(hlo, r".*power.*f32.*power.*f32")
 
 if __name__ == "__main__":
   unittest.main()

--- a/test/test_autocast_xla.py
+++ b/test/test_autocast_xla.py
@@ -94,14 +94,15 @@ class TestAutocastXla(unittest.TestCase):
       self.assertNotRegex(hlo, r".*dot.*f32")
 
     def test_pow(self):
-        data = torch.randn(16, 20).to(torch.bfloat16).to(device)
+      data = torch.randn(16, 20).to(torch.bfloat16).to(device)
 
-        with torch.autocast("xla"):
-            output=data.pow(2)
-            hlo = torch_xla._XLAC._get_xla_tensors_hlo([output])
-        
-            self.assertRegex(hlo, r".*convert.*f32.*convert.*bf16")
-            self.assertRegex(hlo, r".*power.*f32.*power.*f32")
+      with torch.autocast("xla"):
+        output = data.pow(2)
+        hlo = torch_xla._XLAC._get_xla_tensors_hlo([output])
+
+        self.assertRegex(hlo, r".*convert.*f32.*convert.*bf16")
+        self.assertRegex(hlo, r".*power.*f32.*power.*f32")
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/torch_xla/csrc/autocast_mode.cpp
+++ b/torch_xla/csrc/autocast_mode.cpp
@@ -65,6 +65,7 @@ TORCH_LIBRARY_IMPL(aten, AutocastXLA, m) {
   KERNEL_XLA(binary_cross_entropy, fp32)
   // KERNEL_XLA(grid_sampler, fp32)
   // KERNEL_XLA(polar, fp32)
+  KERNEL_XLA2(pow, Tensor_Scalar, fp32)
   KERNEL_XLA(prod, fp32)
   KERNEL_XLA2(prod, dim_int, fp32)
   KERNEL_XLA2(prod, dim_Dimname, fp32)


### PR DESCRIPTION
Pow is a non linear operation and must be done in higher precision i.e. FP32. 

Before this CR:
```
import torch
import torch_xla.core.xla_model as xm
input=torch.rand((5,5), dtype=torch.bfloat16).to(xm.xla_device())
with torch.autocast("xla"):
    output=input.pow(2) // this should happen in FP32
xm.mark_step()
```
```

HloModule SyncTensorsGraph.6, entry_computation_layout={(bf16[5,5]{1,0})->(bf16[5,5]{1,0})}

ENTRY %SyncTensorsGraph.6 (p0.2: bf16[5,5]) -> (bf16[5,5]) {
  %p0.2 = bf16[5,5]{1,0} parameter(0), frontend_attributes={neff_input_names="input0"}, metadata={op_type="xla__device_data" op_name="xla__device_data" source_file="/shared/avizon/avi_trial_exps/test.py" source_line=4}
  %multiply = bf16[5,5]{1,0} multiply(bf16[5,5]{1,0} %p0.2, bf16[5,5]{1,0} %p0.2), metadata={op_type="aten__pow" op_name="aten__pow" source_file="/shared/avizon/avi_trial_exps/test.py" source_line=7}
  ROOT %tuple.5 = (bf16[5,5]{1,0}) tuple(bf16[5,5]{1,0} %multiply), frontend_attributes={neff_output_names="output0"}
}

//Its happening in BF16, which is wrong
```


after the CR:
```
HloModule SyncTensorsGraph.7, entry_computation_layout={(bf16[5,5]{1,0})->(f32[5,5]{1,0})}

ENTRY %SyncTensorsGraph.7 (p0.2: bf16[5,5]) -> (f32[5,5]) {
  %p0.2 = bf16[5,5]{1,0} parameter(0), frontend_attributes={neff_input_names="input0"}, metadata={op_type="xla__device_data" op_name="xla__device_data" source_file="/shared/avizon/avi_trial_exps/test.py" source_line=4}
  %convert.3 = f32[5,5]{1,0} convert(bf16[5,5]{1,0} %p0.2), metadata={op_type="xla__cast" op_name="xla__cast" source_file="/shared/avizon/avi_trial_exps/test.py" source_line=7}
  %multiply = f32[5,5]{1,0} multiply(f32[5,5]{1,0} %convert.3, f32[5,5]{1,0} %convert.3), metadata={op_type="aten__pow" op_name="aten__pow" source_file="/shared/avizon/avi_trial_exps/test.py" source_line=7}
  ROOT %tuple.6 = (f32[5,5]{1,0}) tuple(f32[5,5]{1,0} %multiply), frontend_attributes={neff_output_names="output0"}
}

//The inputs have been upcasted
```