### PR TITLE
Lower `_conj_copy` and `alias` operation.

### DIFF
--- a/codegen/xla_native_functions.yaml
+++ b/codegen/xla_native_functions.yaml
@@ -26,6 +26,7 @@ full_codegen:
   - clamp.Tensor
   - clamp_max.Tensor
   - clamp_min.Tensor
+  - _conj_copy
   - cos
   - cosh
   - elu

--- a/codegen/xla_native_functions.yaml
+++ b/codegen/xla_native_functions.yaml
@@ -139,6 +139,7 @@ supported:
   - add.Scalar
   - add.Tensor
   - addmm
+  - alias
   - alias_copy
   - arange.start_out
   - as_strided_copy

--- a/test/cpp/test_aten_xla_tensor_2.cpp
+++ b/test/cpp/test_aten_xla_tensor_2.cpp
@@ -2420,6 +2420,26 @@ TEST_F(AtenXlaTensorTest, TestAcoshInPlace) {
   ExpectCounterChanged("xla::acosh", cpp_test::GetIgnoredCounters());
 }
 
+TEST_F(AtenXlaTensorTest, TestAlias) {
+  torch::Tensor a = torch::rand({2, 2}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor b = torch::alias(a);
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_a = CopyToDevice(a, device);
+    torch::Tensor xla_b = torch::alias(xla_a);
+    AllClose(b, xla_b, /*rtol=*/1e-3, /*atol=*/0e-5);
+  });
+}
+
+TEST_F(AtenXlaTensorTest, TestConj) {
+  torch::Tensor a = torch::rand({2, 2}, torch::TensorOptions(torch::kComplexFloat));
+  torch::Tensor b = torch::conj(a);
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_a = CopyToDevice(a, device);
+    torch::Tensor xla_b = torch::conj(xla_a);
+    AllClose(b, xla_b, /*rtol=*/1e-3, /*atol=*/0e-5);
+  });
+}
+
 TEST_F(AtenXlaTensorTest, TestCos) {
   torch::Tensor a = torch::rand({2, 2}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::cos(a);

--- a/test/cpp/test_aten_xla_tensor_2.cpp
+++ b/test/cpp/test_aten_xla_tensor_2.cpp
@@ -2431,7 +2431,8 @@ TEST_F(AtenXlaTensorTest, TestAlias) {
 }
 
 TEST_F(AtenXlaTensorTest, TestConj) {
-  torch::Tensor a = torch::rand({2, 2}, torch::TensorOptions(torch::kComplexFloat));
+  torch::Tensor a =
+      torch::rand({2, 2}, torch::TensorOptions(torch::kComplexFloat));
   torch::Tensor b = torch::conj(a);
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor xla_a = CopyToDevice(a, device);

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2384,6 +2384,16 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
 
     self.assertEqual(actual, expected)
 
+  def test_conj_no_fallback(self):
+    met.clear_all()
+
+    tensor = torch.tensor([1 + 2j])
+    expected = torch.conj(tensor)
+    actual = torch.conj(tensor.to(xm.xla_device()))
+
+    self.assertEqual(actual, expected)
+    self.assertEqual(len(met.executed_fallback_ops()), 0)
+
 
 class MNISTComparator(nn.Module):
 

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2396,8 +2396,11 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     actual = run("cpu")
     expected = run(xm.xla_device())
 
-    self.assertEqual(met.executed_fallback_ops(), [], message="expected no fallback operations.")
-    self.assertEqual(actual, expected.cpu(), message="XLA results should match CPU results.")
+    self.assertEqual(
+        met.executed_fallback_ops(), [],
+        message="expected no fallback operations.")
+    self.assertEqual(
+        actual, expected.cpu(), message="XLA results should match CPU results.")
 
 
 class MNISTComparator(nn.Module):

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2387,11 +2387,14 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
   def test_conj_no_fallback(self):
     met.clear_all()
 
-    tensor = torch.tensor([1 + 2j])
-    expected = torch.conj(tensor)
-    actual = torch.conj(tensor.to(xm.xla_device()))
+    def run(device):
+      tensor = torch.tensor([1 + 2j], device=device)
+      return torch.conj(tensor)
 
-    self.assertEqual(actual, expected)
+    actual = run("cpu")
+    expected = run(xm.xla_device())
+
+    self.assertEqual(actual, expected.cpu())
     self.assertEqual(len(met.executed_fallback_ops()), 0)
 
 

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2384,18 +2384,20 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
 
     self.assertEqual(actual, expected)
 
-  def test_conj_no_fallback(self):
+  def test_conj(self):
+    # Leave the factory out of the fallback count.
+    tensor = torch.rand(2, 2, dtype=torch.complex64)
+
     met.clear_all()
 
     def run(device):
-      tensor = torch.tensor([1 + 2j], device=device)
-      return torch.conj(tensor)
+      return torch.conj(tensor.to(device))
 
     actual = run("cpu")
     expected = run(xm.xla_device())
 
-    self.assertEqual(actual, expected.cpu())
-    self.assertEqual(len(met.executed_fallback_ops()), 0)
+    self.assertEqual(met.executed_fallback_ops(), [], message="expected no fallback operations.")
+    self.assertEqual(actual, expected.cpu(), message="XLA results should match CPU results.")
 
 
 class MNISTComparator(nn.Module):

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1338,8 +1338,12 @@ at::Tensor XLANativeFunctions::clone(
     const at::Tensor& self,
     std::optional<at::MemoryFormat> /* memory_format */) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
-  return bridge::AtenFromXlaTensor(tensor_methods::clone(
-      bridge::GetXlaTensor(self), /* is_conj= */ self.is_conj()));
+  auto tensor = bridge::GetXlaTensor(self);
+  if (self.is_conj()) {
+    // Materialize the conjugate if necessary.
+    tensor = tensor_methods::conj(tensor);
+  }
+  return bridge::AtenFromXlaTensor(tensor_methods::clone(tensor));
 }
 
 at::Tensor XLANativeFunctions::constant_pad_nd(const at::Tensor& self,

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -863,10 +863,15 @@ at::Tensor XLANativeFunctions::addmm(const at::Tensor& self,
                             /*bias=*/bridge::GetXlaTensor(self)));
 }
 
-at::Tensor XLANativeFunctions::alias_copy(const at::Tensor& self) {
+at::Tensor XLANativeFunctions::alias(const at::Tensor& self) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
   return bridge::AtenFromXlaTensor(
       tensor_methods::alias(bridge::GetXlaTensor(self)));
+}
+
+at::Tensor XLANativeFunctions::alias_copy(const at::Tensor& self) {
+  TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
+  return alias(self);
 }
 
 at::Tensor& XLANativeFunctions::arange_out(const at::Scalar& start,
@@ -1333,8 +1338,8 @@ at::Tensor XLANativeFunctions::clone(
     const at::Tensor& self,
     std::optional<at::MemoryFormat> /* memory_format */) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
-  return bridge::AtenFromXlaTensor(
-      tensor_methods::clone(bridge::GetXlaTensor(self)));
+  return bridge::AtenFromXlaTensor(tensor_methods::clone(
+      bridge::GetXlaTensor(self), /* is_conj= */ self.is_conj()));
 }
 
 at::Tensor XLANativeFunctions::constant_pad_nd(const at::Tensor& self,

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -342,6 +342,11 @@ torch_xla::XlaOpVector ClampMinTensor::Lower(LoweringContext* loctx) const {
   return ReturnOp(xla::Max(xla_input, xla_other), loctx);
 }
 
+torch_xla::XlaOpVector ConjCopy::Lower(LoweringContext* loctx) const {
+  xla::XlaOp input = loctx->GetOutputOp(operand(0));
+  return ReturnOp(xla::Conj(input), loctx);
+}
+
 torch_xla::XlaOpVector Cos::Lower(LoweringContext* loctx) const {
   xla::XlaOp xla_input = loctx->GetOutputOp(operand(0));
   if (xla::primitive_util::IsIntegralType(XlaHelpers::TypeOfXlaOp(xla_input))) {

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -424,6 +424,10 @@ xla::Shape ClampMinTensorOutputShape(const torch::lazy::Value& input,
                           lower_for_shape_fn);
 }
 
+xla::Shape ConjCopyOutputShape(const torch::lazy::Value& input) {
+  return GetXlaShape(input);
+}
+
 xla::Shape CosOutputShape(const torch::lazy::Value& input) {
   xla::Shape result_shape = GetXlaShape(input);
   if (xla::primitive_util::IsIntegralType(result_shape.element_type())) {

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -108,6 +108,8 @@ xla::Shape ClampMaxTensorOutputShape(const torch::lazy::Value& input,
 xla::Shape ClampMinTensorOutputShape(const torch::lazy::Value& input,
                                      const torch::lazy::Value& target);
 
+xla::Shape ConjCopyOutputShape(const torch::lazy::Value& input);
+
 xla::Shape CosOutputShape(const torch::lazy::Value& input);
 
 xla::Shape CoshOutputShape(const torch::lazy::Value& input);

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1229,17 +1229,18 @@ XLATensorPtr clamp(const XLATensorPtr& input,
       Clamp(input->GetIrValue(), min_max.min, min_max.max));
 }
 
-XLATensorPtr clone(const XLATensorPtr& input, bool is_conj) {
-  torch::lazy::Value ir = input->GetIrValue();
-  if (is_conj) {
-    ir = torch::lazy::Value(torch_xla::MakeNode<ConjCopy>(ir));
-  }
-  XLATensorPtr cloned = input->CreateFrom(ir);
+XLATensorPtr clone(const XLATensorPtr& input) {
+  XLATensorPtr cloned = input->CreateFrom(input->GetIrValue());
   if (input->sharding_spec() != nullptr) {
     cloned->SetShardingSpec(*input->sharding_spec());
   }
   cloned->data()->is_cloned = true;
   return cloned;
+}
+
+XLATensorPtr conj(const XLATensorPtr& input) {
+  auto ir = input->GetIrValue();
+  return input->CreateFrom(torch_xla::MakeNode<ConjCopy>(ir));
 }
 
 XLATensorPtr constant_pad_nd(const XLATensorPtr& input,

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1229,8 +1229,12 @@ XLATensorPtr clamp(const XLATensorPtr& input,
       Clamp(input->GetIrValue(), min_max.min, min_max.max));
 }
 
-XLATensorPtr clone(const XLATensorPtr& input) {
-  XLATensorPtr cloned = input->CreateFrom(input->GetIrValue());
+XLATensorPtr clone(const XLATensorPtr& input, bool is_conj) {
+  torch::lazy::Value ir = input->GetIrValue();
+  if (is_conj) {
+    ir = torch::lazy::Value(torch_xla::MakeNode<ConjCopy>(ir));
+  }
+  XLATensorPtr cloned = input->CreateFrom(ir);
   if (input->sharding_spec() != nullptr) {
     cloned->SetShardingSpec(*input->sharding_spec());
   }

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -325,7 +325,7 @@ XLATensorPtr clamp(const XLATensorPtr& input,
                    const std::optional<at::Tensor>& min,
                    const std::optional<at::Tensor>& max);
 
-XLATensorPtr clone(const XLATensorPtr& input);
+XLATensorPtr clone(const XLATensorPtr& input, bool is_conj);
 
 // Pad with the given value and size specified by the given list of low and
 // high paddings.

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -325,7 +325,9 @@ XLATensorPtr clamp(const XLATensorPtr& input,
                    const std::optional<at::Tensor>& min,
                    const std::optional<at::Tensor>& max);
 
-XLATensorPtr clone(const XLATensorPtr& input, bool is_conj);
+XLATensorPtr clone(const XLATensorPtr& input);
+
+XLATensorPtr conj(const XLATensorPtr& input);
 
 // Pad with the given value and size specified by the given list of low and
 // high paddings.


### PR DESCRIPTION
Fix: #3070 

This PR adds a lowering for `_conj_copy`. This operation is called by `torch.conj`, and  was being executed using the fallback path. With this PR, `torch.conj` and its decomposed functions do not fallback. 