### PR TITLE
Add missing NeuronPlugin configure_single_process function

### DIFF
--- a/torch_xla/_internal/neuron.py
+++ b/torch_xla/_internal/neuron.py
@@ -116,5 +116,8 @@ class NeuronPlugin(plugins.DevicePlugin):
   def configure_multiprocess(self, local_rank, local_world_size):
     initialize_env(local_rank, local_world_size)
 
+  def configure_single_process(self):
+    initialize_env(0, 1)
+
   def physical_chip_count(self):
     return num_local_processes()


### PR DESCRIPTION
Currently, Neuron plugin is missing configure_single_process function for xmp.spawn/xla.launch with nproc=1, so we get ImplementedError unless this function is patched via torch-neuronx. This change makes it so that we don't have to patch for 2.7.