### PR TITLE
Include the alias ID in GetXLATensorDebugInfo

### DIFF
--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -623,6 +623,7 @@ std::string GetXLATensorDebugInfo(const at::Tensor& tensor) {
   std::stringstream ss;
   ss << "XLATensor {\n";
   ss << "TensorID: " << xtensor->GetUniqueId() << "\n";
+  ss << "AliasID: " << xtensor->data()->alias_id << "\n";
   ss << "Device: " << xtensor->GetDevice() << "\n";
   ss << "XLA Shape: " << xtensor->shape().get().ToString() << "\n";
 


### PR DESCRIPTION
Simple PR to extend `GetXLATensorDebugInfo` to include the alias ID, e.g.:

```
## At the start:

TensorID: 816
AliasID: 816
Device: SPMD:0
XLA Shape: f32[4096,2,14336]
ShardingSpec: {devices=[1,1,32]0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31}
IR: None
XLAShardedData: 
  Data Device: SPMD:0
  Data Shape: f32[4096,2,14336]
  OpSharding: {devices=[1,1,32]0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31}
  NumShards: 0
Tensor on host: None
}

## Before mark_step:

TensorID: 1396
AliasID: 816
Device: SPMD:0
XLA Shape: f32[4096,2,14336]
ShardingSpec: {devices=[1,1,32]0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31}
IR: [] xla::custom_sharding, location=_gradient_accumulation@gradient_accumulation.py:402, xla_shape=f32[4096,2,14336]{2,1,0}, dynamic_dims: (), Sharding
XLAData: None
Tensor on host: None
}

## After mark_step:

TensorID: 1396
AliasID: 1396
Device: SPMD:0
XLA Shape: f32[4096,2,14336]
ShardingSpec: {devices=[1,1,32]0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31}
IR: None
XLAShardedData: 
  Data Device: SPMD:0
  Data Shape: f32[4096,2,14336]
  OpSharding: {devices=[1,1,32]0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31}
  NumShards: 32
Tensor on host: None
}
```

This can help understand whether the alias ID is retained across different debug information at separate points (e.g. at the start, and prior to mark step) when functionalization is enabled.

Simultaneously, it also gives us more debugging when looking into OpenXLA Dynamo compilation (dynamo bridging).