### PR TITLE
Bump CUDNN version in docker image.

### DIFF
--- a/infra/ansible/config/cuda_deps.yaml
+++ b/infra/ansible/config/cuda_deps.yaml
@@ -11,8 +11,8 @@ cuda_deps:
     "11.7": libcudnn8=8.5.0.96-1+cuda11.7
     "11.2": libcudnn8=8.1.1.33-1+cuda11.2
   libcudnn-dev:
-    "12.4": libcudnn-dev-cuda-12=9.1.1.17-1
-    "12.3": libcudnn9-dev-cuda-12=9.0.0.312-1
+    "12.4": libcudnn9-dev-cuda-12=9.1.1.17-1
+    "12.3": libcudnn9-dev-cuda-12=9.1.1.17-1
     "12.1": libcudnn8-dev=8.9.2.26-1+cuda12.1
     "12.0": libcudnn8-dev=8.8.0.121-1+cuda12.0
     "11.8": libcudnn8-dev=8.7.0.84-1+cuda11.8

--- a/infra/ansible/config/cuda_deps.yaml
+++ b/infra/ansible/config/cuda_deps.yaml
@@ -3,8 +3,8 @@
 cuda_deps:
   # List all libcudnn8 versions with `apt list -a libcudnn8`
   libcudnn:
-    "12.4": libcudnn-cuda-12=9.1.1.17-1
-    "12.3": libcudnn9-cuda-12=9.0.0.312-1
+    "12.4": libcudnn9-cuda-12=9.1.1.17-1
+    "12.3": libcudnn9-cuda-12=9.1.1.17-1
     "12.1": libcudnn8=8.9.2.26-1+cuda12.1
     "12.0": libcudnn8=8.8.0.121-1+cuda12.0
     "11.8": libcudnn8=8.7.0.84-1+cuda11.8


### PR DESCRIPTION
This PR bumps up the CUDNN version in docker images for CUDA 12.3. This change is needed for the hermetic CUDA transition PR (#8665).

**Problem:** currently, we are using CUDNN 9.0.0. However, hermetic CUDA does not support that version ([log](https://github.com/pytorch/xla/actions/runs/13390397071/job/37396625144?pr=8665)):

```
Error in fail: The supported CUDNN versions are 
["8.6", "8.9.4.25", "8.9.6", "8.9.7.29", "9.1.1", "9.2.0", "9.2.1", "9.3.0",
 "9.4.0", "9.5.0", "9.5.1", "9.6.0", "9.7.0", "9.7.1"]. 
Please provide a supported version in HERMETIC_CUDNN_VERSION environment variable
or add JSON URL for CUDNN version=9.0.0.
```

**Solution:** in this PR, we bump the CUDNN version to 9.1.1.