### PR TITLE
Extend buffer donation aliasing APIs

### DIFF
--- a/test/dynamo/test_dynamo_aliasing.py
+++ b/test/dynamo/test_dynamo_aliasing.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 
 import torch

--- a/test/neuron/run_tests.sh
+++ b/test/neuron/run_tests.sh
@@ -218,6 +218,7 @@ function run_xla_op_tests3 {
   run_test "$CDIR/spmd/test_fsdp_v2.py"
   run_test "$CDIR/test_operations_hlo.py" "$@" --verbosity=$VERBOSITY
   run_test "$CDIR/test_input_output_aliases.py"
+  run_test_without_functionalization "$CDIR/test_input_output_aliases.py"
   run_test "$CDIR/test_torch_distributed_xla_backend.py"
   run_torchrun "$CDIR/pjrt/test_torchrun.py"
   run_test "$CDIR/test_persistent_cache.py"

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -238,6 +238,7 @@ function run_xla_op_tests3 {
   run_save_tensor_hlo run_test "$CDIR/spmd/test_spmd_lowering_context.py"
   run_test "$CDIR/test_operations_hlo.py" "$@" --verbosity=$VERBOSITY
   run_test "$CDIR/test_input_output_aliases.py"
+  run_test_without_functionalization "$CDIR/test_input_output_aliases.py"
   run_test "$CDIR/test_torch_distributed_xla_backend.py"
   run_torchrun "$CDIR/pjrt/test_torchrun.py"
   run_test "$CDIR/test_persistent_cache.py"

--- a/torch_xla/_dynamo/dynamo_bridge.py
+++ b/torch_xla/_dynamo/dynamo_bridge.py
@@ -36,13 +36,13 @@ ptxla_debug = int(os.environ.get('PT_XLA_DEBUG', '0')) == 1
 
 @contextmanager
 def alias_with_buffer_donor_config(should_alias: bool = True):
-  saved_config = torch_xla._XLAC._xla_get_should_alias_with_buffer_donor_config(
+  saved_config = torch_xla._XLAC._xla_get_enable_alias_with_buffer_donor_config(
   )
-  torch_xla._XLAC._xla_set_should_alias_with_buffer_donor_config(should_alias)
+  torch_xla._XLAC._xla_set_enable_alias_with_buffer_donor_config(should_alias)
   try:
     yield saved_config
   finally:
-    torch_xla._XLAC._xla_set_should_alias_with_buffer_donor_config(saved_config)
+    torch_xla._XLAC._xla_set_enable_alias_with_buffer_donor_config(saved_config)
 
 
 @dataclasses.dataclass

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1906,14 +1906,15 @@ void InitXlaModuleBindings(py::module m) {
       [](const std::string& device) { return GetRngSeed(device); },
       py::arg("device") = "");
   m.def(
-      "_xla_set_should_alias_with_buffer_donor_config",
-      [](bool should_alias, const std::string& device_str) {
+      "_xla_set_enable_alias_with_buffer_donor_config",
+      [](bool enable_user_config_alias, const std::string& device_str) {
         torch::lazy::BackendDevice device = GetDeviceOrCurrent(device_str);
-        XLAGraphExecutor::Get()->SetAliasWithBufferDonorConfig(should_alias);
+        XLAGraphExecutor::Get()->SetAliasWithBufferDonorConfig(
+            enable_user_config_alias);
       },
-      py::arg("should_alias") = false, py::arg("device") = "");
+      py::arg("enable_user_config_alias") = false, py::arg("device") = "");
   m.def(
-      "_xla_get_should_alias_with_buffer_donor_config",
+      "_xla_get_enable_alias_with_buffer_donor_config",
       [](const std::string& device_str) {
         torch::lazy::BackendDevice device = GetDeviceOrCurrent(device_str);
         return XLAGraphExecutor::Get()->GetAliasWithBufferDonorConfig();
@@ -2737,19 +2738,19 @@ void InitXlaModuleBindings(py::module m) {
 
   // This api will set the `should_donate_buffer_` field in the
   // ComputationClient::Data. This api is currently only useful if you are
-  // running with `torch.compile`. Buffer assocaited with data with
-  // `should_donate_buffer_` set to true will be donated to the output, You
-  // should only use this api if
-  // 1. You are using torch.compile
-  // 2. You will inplace update a tensor in the `torch.compiled` function(so the
-  //    currnet buffer can be donated after compuation)
+  // running with `torch.compile`. The buffer associated with the data has
+  // `should_donate_buffer_` set to true will be donated to the output. This
+  // can be used if:
+  // 1. You are using torch.compile, and there is an inplace udpate of a tensor
+  //    so that the current buffer can be donated after computation.
+  // 2. You want to explicitly donate a tensor because it is not necessary
+  //    after the current computation.
+  // Note that donated buffers can not be used after being donated.
   m.def("_set_buffer_donation",
-        [](at::Tensor& input, bool should_donate) -> bool {
-          XLATensorPtr xtensor = bridge::GetXlaTensor(input);
+        [](at::Tensor& tensor, bool should_donate) -> bool {
+          XLATensorPtr xtensor = bridge::GetXlaTensor(tensor);
           bool buffer_donation_updated = false;
-          if (!xtensor) {
-            // input tensor is not a XLATensor, return here.
-          } else if (xtensor->CurrentDataHandle() != nullptr) {
+          if (xtensor->CurrentDataHandle() != nullptr) {
             auto data =
                 std::dynamic_pointer_cast<runtime::ComputationClient::Data>(
                     xtensor->CurrentDataHandle());

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -95,8 +95,7 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
   torch::lazy::BackendDataPtr GetBaseSeedData(
       const torch::lazy::BackendDevice& device);
 
-  void SetAliasWithBufferDonorConfig(bool should_alias);
-
+  void SetAliasWithBufferDonorConfig(bool enable_alias);
   bool GetAliasWithBufferDonorConfig();
 
   // Dumps the XLA HLO text of the computation accumulated in the graph which is
@@ -240,13 +239,10 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
     torch::lazy::BackendDataPtr GetBaseSeedData(
         const torch::lazy::BackendDevice& device);
 
-    void SetAliasWithBufferDonorConfig(bool should_alias) {
-      should_alias_with_buffer_donor = should_alias;
+    void SetAliasWithBufferDonorConfig(bool enable_alias) {
+      enable_user_config_aliasing = enable_alias;
     }
-
-    bool GetAliasWithBufferDonorConfig() {
-      return should_alias_with_buffer_donor;
-    }
+    bool GetAliasWithBufferDonorConfig() { return enable_user_config_aliasing; }
 
     void SaveGraphAsString(
         torch::lazy::hash_t hash, absl::Span<const XLATensorPtr> tensors,
@@ -276,7 +272,7 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
     torch::lazy::Value IrValueFromScalar(
         const at::Scalar& value, at::ScalarType scalar_type,
         const torch::lazy::BackendDevice& device) final;
-    bool should_alias_with_buffer_donor = false;
+    bool enable_user_config_aliasing = false;
   };
 
   XLAGraphExecutor() = default;


### PR DESCRIPTION
Enables https://github.com/pytorch/xla/issues/8711. In particular, it alleviates the fallback aliasing logic for user config. Previously, it would only be applied if auto LTC did not infer any needed aliasing which is a semantically suboptimal surface area. In this PR, we modify this behavior to always accommodate explicitly donated buffers, working simultaneously with LTC, IF enabled.

In this PR, it is out of scope to address the per-device concerns associated with having global (DeviceArenaContext) metadata for all the devices with respect to aliasing and other dynamo execution -specific logic.