### PR TITLE
Introduce apply_xla_patch_to_nn_linear and test that in a scan

### DIFF
--- a/test/scan/test_scan_spmd.py
+++ b/test/scan/test_scan_spmd.py
@@ -1,9 +1,14 @@
+from copy import deepcopy
 import sys
+import re
 import unittest
 
 import torch
 import torch_xla
+import torch.nn as nn
+from torch_xla.distributed.spmd.xla_sharding import apply_xla_patch_to_nn_linear
 from torch_xla.experimental.scan import scan
+from torch_xla.experimental.scan_layers import scan_layers
 from torch_xla.distributed.spmd import mark_sharding, set_global_mesh, get_1d_mesh
 import torch_xla.runtime as xr
 
@@ -53,6 +58,84 @@ class ScanSpmdTest(unittest.TestCase):
       self.assertIn('OpSharding: {'
                     f'devices=[1,{N}]0,',
                     torch_xla._XLAC._get_xla_tensor_debug_info(tensor))
+
+  @unittest.skipUnless(xr.global_runtime_device_count() >= 4,
+                       "Multiple devices required")
+  def test_scan_xla_patched_linear(self):
+    """
+    When we use scan to trace `XLAPatchedLinear` layers, the lowered HLO should
+    consist of einsum instead of reshapes and transposes. This is important for
+    sharding constraint propagation.
+    """
+
+    # Create a model with a few linear layers.
+    class MyModel(nn.Module):
+
+      def __init__(self):
+        super().__init__()
+        self.layers = nn.Sequential(*[nn.Linear(128, 128) for _ in range(4)])
+        self.use_scan = True
+
+      def forward(self, x: torch.Tensor):
+        if self.use_scan:
+          return scan_layers(self.layers, x)
+        else:
+          return self.layers(x)
+
+    model = MyModel().to('xla')
+    # High dimensional input whose last dim is the contraction dim.
+    torch_xla.manual_seed(42)
+    x = torch.randn((3, 4, 5, 128), device='xla')
+    torch_xla.sync()
+
+    # If we trace the `nn.Linear` without applying the einsum patch, the lowered
+    # HLO will contain a `dot` operation where the input is flattened to 2D:
+    # the `3, 4, 5, 128` shape is flattened to `60, 128`. This destroys any sharding
+    # constraint applied to the first 3 dims.
+    self.check_dots_in_model(
+        model, x, expect_pattern=r'%dot\.\d+ = f32\[60,128\]')
+
+    # Once we patch the `nn.Linear` modules to use `einsum` and ensure that einsum is
+    # lowered without getting unnecessarily decomposed, the HLO should contain a
+    # `dot` operation that preserves the high dimensional structure. In turn, the
+    # compiler will be able to preserve the sharding constraints on those dimensions.
+    model = apply_xla_patch_to_nn_linear(model)
+    self.check_dots_in_model(
+        model, x, expect_pattern=r'%dot\.\d+ = f32\[3,4,5,128\]')
+
+    # Finally, test the numerics against an eager CPU impl.
+    x = x.bfloat16()
+    model = model.bfloat16()
+    model_cpu = MyModel().bfloat16()
+    model_cpu.load_state_dict(model.state_dict())
+    model_cpu.to('cpu')
+    model_cpu.use_scan = False
+    torch_xla.sync()
+    y_cpu = model_cpu(x.cpu())
+    y_xla = model(x)
+
+    torch_xla.sync()
+    torch.testing.assert_close(y_cpu, y_xla.cpu())
+
+  def check_dots_in_model(self, model, x, expect_pattern):
+    # Trace the model to get the HLO.
+    y = model(x)
+    hlo_text: str = torch_xla._XLAC._get_xla_tensors_hlo([y])
+
+    count = self.count_regex(hlo_text, expect_pattern)
+    assert count == 0 or count == 1, f"count = {count}"
+
+    if count == 1:
+      # This is the expected case.
+      pass
+    else:
+      raise RuntimeError(
+          f"""Expected `nn.Linear` lowering to contain `{expect_pattern}`. Full HLO:
+{hlo_text}
+""")
+
+  def count_regex(self, hlo_text, regex_str):
+    return len(re.findall(regex_str, hlo_text))
 
 
 if __name__ == '__main__':

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1848,6 +1848,16 @@ void InitXlaModuleBindings(py::module m) {
         });
   m.def("_xla_optimization_barrier_",
         [](std::vector<at::Tensor>& inputs) { OptimizationBarrier_(inputs); });
+  // TODO(https://github.com/pytorch/xla/issues/8713): torch.einsum is getting
+  // decomposed when inside a custom op. This C++ op is an escape hatch to call
+  // XLA einsum without going through torch.einsum. We should remove this
+  // operation when the linked bug is fixed.
+  m.def("_xla_einsum",
+        [](const std::string& equation, const std::vector<at::Tensor>& inputs) {
+          std::vector<XLATensorPtr> xla_tensors = bridge::GetXlaTensors(inputs);
+          XLATensorPtr output = tensor_methods::einsum(equation, xla_tensors);
+          return bridge::AtenFromXlaTensor(output);
+        });
   m.def("_xla_set_default_device", [](const std::string& device) {
     return SetCurrentThreadDevice(device);
   });


### PR DESCRIPTION
In order to propagate sharding annotations in 2D sharding, linear layers should be implemented with einsum instead of tranposes/reshapes. Additionally, they need to continue to function inside scan/scan_layers.

For this to work we need three pieces:

- I added a `apply_xla_patch_to_nn_linear` function to replace the implementation of `nn.Linear` with einsum (calling XLAPatchedLinear).
- The XLAPatchedLinear implementation should be wrapped in torch custom ops. That's because AOTAutograd used by scan will decompose all einsums into transposes/reshapes, unless we use `@custom_op` to mark a function as opaque to AOTAutograd.
- Even after wrapping them with `@custom_op`, the einsum is still decomposed into transposes/reshapes due to
https://github.com/pytorch/xla/issues/8713. That's a bug/PyTorch limitation. To workaround this, I added a `_xla_einsum` C++ function that directly builds an einsum given XLA tensors, skipping over any PyTorch dispatcher complexity.

Added a test that demonstrates how `nn.Linear` layers by default flattens any non-contracting dims, and how we could avoid that with `apply_xla_patch_to_nn_linear`.