### PR TITLE
Add padding ragged paged attention test

### DIFF
--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -67,6 +67,7 @@ def ref_ragged_paged_attention(
 
     attn = jnp.einsum("qhd,khd->hqk", q, k)
     attn = attn.astype('float32')
+    #print(f'xw32 jax ref line70 {attn=}')
     q_span = (cur_kv_len - cur_q_len) + jax.lax.broadcasted_iota(
         jnp.int32, (cur_q_len, cur_kv_len), 0)
     kv_span = jax.lax.broadcasted_iota(jnp.int32, (cur_q_len, cur_kv_len), 1)
@@ -81,9 +82,11 @@ def ref_ragged_paged_attention(
     outputs.append(out)
     start_idx += cur_q_len
 
+  # print(f'xw32 jax ref line85 {jnp.concatenate(outputs, axis=0)=}')
   if actual_num_tokens < outputs_maybe_padded.shape[0]:
     num_tokens_diff = outputs_maybe_padded.shape[0] - actual_num_tokens
     outputs.append(jnp.zeros((num_tokens_diff, num_q_heads, head_dim)).astype(outputs[0].dtype))
+  print(f'xw32 jax ref line89 {jnp.concatenate(outputs, axis=0)=}')
   return jnp.concatenate(outputs, axis=0)
 
 def with_jax_high_precision(func):

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -20,75 +20,6 @@ if xr.device_type() == 'TPU':
   import jax.numpy as jnp
   from jax.experimental import pallas as pl
 
-# xw32: delete it
-def ref_ragged_paged_attention(
-    queries: jax.Array,  # [num_tokens, num_q_heads, head_dim]
-    k_pages: jax.Array,  # [num_kv_heads, total_num_pages, page_size, head_dim]
-    v_pages: jax.Array,  # [num_kv_heads, total_num_pages, page_size, head_dim]
-    kv_lens: jax.Array,  # i32[num_tokens]
-    page_indices: jax.Array,  # i32[num_tokens, pages_per_sequence]
-    cu_q_lens: jax.Array,  # i32[num_tokens + 1]
-    num_seqs: int,
-):
-  num_kv_heads, _, page_size, head_dim = k_pages.shape
-  num_q_heads = queries.shape[1]
-  assert num_q_heads % num_kv_heads == 0, "num_q_heads % num_kv_heads !=0."
-  num_query_per_kv = num_q_heads // num_kv_heads
-  start_idx = 0
-
-  outputs_maybe_padded = jnp.zeros_like(queries)
-  actual_num_tokens = cu_q_lens[num_seqs]
-  outputs = []
-  for i in range(num_seqs):
-    cur_q_len = cu_q_lens[i + 1] - cu_q_lens[i]
-    q = queries[start_idx:start_idx +
-                cur_q_len]  # [cur_q_len, num_q_heads, head_dim]
-
-    cur_kv_len = kv_lens[i]
-    num_pages = (cur_kv_len + page_size - 1) // page_size
-    page_indices_to_use = page_indices[i, :num_pages]
-    k = k_pages[:,
-                page_indices_to_use, :, :]  # [num_kv_heads, page_indices_to_use, page_size, head_dim]
-    k = jnp.permute_dims(
-        k, (1, 2, 0,
-            3))  #   [page_indices_to_use, page_size, num_kv_heads, head_dim]
-    k = jnp.reshape(
-        k, (-1, num_kv_heads, head_dim))  #   [kv_len, num_kv_heads, head_dim]
-    k = k[:cur_kv_len]  # [cur_kv_lens, num_kv_heads, head_dim]
-
-    v = v_pages[:, page_indices_to_use, :, :]
-    v = jnp.permute_dims(v, (1, 2, 0, 3))
-    v = jnp.reshape(v, (-1, num_kv_heads, head_dim))
-    v = v[:cur_kv_len]  # [cur_kv_lens, num_kv_heads, head_dim]
-
-    if num_query_per_kv != 1:
-      k = jnp.repeat(k, num_query_per_kv, axis=1)
-      v = jnp.repeat(v, num_query_per_kv, axis=1)
-
-    attn = jnp.einsum("qhd,khd->hqk", q, k)
-    attn = attn.astype('float32')
-    #print(f'xw32 jax ref line70 {attn=}')
-    q_span = (cur_kv_len - cur_q_len) + jax.lax.broadcasted_iota(
-        jnp.int32, (cur_q_len, cur_kv_len), 0)
-    kv_span = jax.lax.broadcasted_iota(jnp.int32, (cur_q_len, cur_kv_len), 1)
-    # Use the same DEFAULT_MASK_VALUE as in the kernel instead of float("-inf") so that the kernel can match the ref implement better.
-    mask = jnp.where(q_span < kv_span, float("-inf"), 0.)
-    with jax.numpy_rank_promotion("allow"):
-      attn = attn + mask
-    attn = jax.nn.softmax(attn, axis=-1).astype(v.dtype)
-    out = jnp.einsum("hqk,khd->qhd", attn,
-                     v)  # [cur_q_len, num_q_heads, head_dim]
-
-    outputs.append(out)
-    start_idx += cur_q_len
-
-  # print(f'xw32 jax ref line85 {jnp.concatenate(outputs, axis=0)=}')
-  if actual_num_tokens < outputs_maybe_padded.shape[0]:
-    num_tokens_diff = outputs_maybe_padded.shape[0] - actual_num_tokens
-    outputs.append(jnp.zeros((num_tokens_diff, num_q_heads, head_dim)).astype(outputs[0].dtype))
-  print(f'xw32 jax ref line89 {jnp.concatenate(outputs, axis=0)=}')
-  return jnp.concatenate(outputs, axis=0)
-
 def with_jax_high_precision(func):
 
   def wrapper(*args, **kwargs):
@@ -874,11 +805,6 @@ class PallasTest(parameterized.TestCase):
     nonkernel_output_cpu = nonkernel_output.cpu()
     self.assertEqual(kernel_output_cpu.shape, nonkernel_output_cpu.shape)
     self.assertEqual(kernel_output_cpu.dtype, nonkernel_output_cpu.dtype)
-    print(
-        f'Output max diff: {torch.max(torch.abs(kernel_output_cpu - nonkernel_output_cpu))}')
-    print(
-        f'Output mean diff: {torch.mean(torch.abs(kernel_output_cpu - nonkernel_output_cpu))}'
-    )
 
     q_jax = jnp.array(q.numpy(), dtype=jnp.float32)
     k_pages_jax = jnp.array(k_pages.numpy(), dtype=jnp.float32)
@@ -902,59 +828,23 @@ class PallasTest(parameterized.TestCase):
                 num_queries_per_block=num_queries_per_block,
             )[1]))
     jax_kernel_output_cpu = jax_kernel_output.cpu()
-    jax_nonkernel_output = torch.from_numpy(
-        np.array(
-            ref_ragged_paged_attention(
-                q_jax,
-                k_pages_jax,
-                v_pages_jax,
-                kv_lens_jax,
-                page_indices_jax,
-                cu_q_lens_jax,
-                num_seqs=num_seqs,
-            )))
-    jax_nonkernel_output_cpu = jax_nonkernel_output.cpu()
-    print(
-        f'jax_kernel vs torch_kernel Output max diff: {torch.max(torch.abs(kernel_output_cpu - jax_kernel_output_cpu))}')
-    print(
-        f'jax_kernel vs torch_kernel Output mean diff: {torch.mean(torch.abs(kernel_output_cpu - jax_kernel_output_cpu))}'
-    )
-    print(
-        f'jax_kernel vs nonkernel_output_cpu Output max diff: {torch.max(torch.abs(nonkernel_output_cpu - jax_kernel_output_cpu))}')
-    print(
-        f'jax_kernel vs nonkernel_output_cpu Output mean diff: {torch.mean(torch.abs(nonkernel_output_cpu - jax_kernel_output_cpu))}'
-    )
 
 
     if pad_num_q_tokens:
       actual_num_q_tokens = cu_q_lens[num_seqs]
-      print(
-          f'Output max diff: {torch.max(torch.abs(kernel_output_cpu[:actual_num_q_tokens] - nonkernel_output_cpu[:actual_num_q_tokens]))}')
-      print(
-          f'Output mean diff: {torch.mean(torch.abs(kernel_output_cpu[:actual_num_q_tokens] - nonkernel_output_cpu[:actual_num_q_tokens]))}'
-      )
-      print(
-          f'jax_kernel vs torch_kernel Output max diff: {torch.max(torch.abs(kernel_output_cpu[:actual_num_q_tokens] - jax_kernel_output_cpu[:actual_num_q_tokens]))}')
-      print(
-          f'jax_kernel vs torch_kernel Output mean diff: {torch.mean(torch.abs(kernel_output_cpu[:actual_num_q_tokens] - jax_kernel_output_cpu[:actual_num_q_tokens]))}'
-      )
-      print(
-          f'jax_kernel vs nonkernel_output_cpu Output max diff: {torch.max(torch.abs(nonkernel_output_cpu[:actual_num_q_tokens] - jax_kernel_output_cpu[:actual_num_q_tokens]))}')
-      print(
-          f'jax_kernel vs nonkernel_output_cpu Output mean diff: {torch.mean(torch.abs(nonkernel_output_cpu[:actual_num_q_tokens] - jax_kernel_output_cpu[:actual_num_q_tokens]))}'
-      )
-      print(
-          f'jax_nonkernel_output_cpu vs nonkernel_output_cpu Output max diff: {torch.max(torch.abs(nonkernel_output_cpu[:actual_num_q_tokens] - jax_nonkernel_output_cpu[:actual_num_q_tokens]))}')
-      print(
-          f'jax_nonkernel_output_cpu vs nonkernel_output_cpu Output mean diff: {torch.mean(torch.abs(nonkernel_output_cpu[:actual_num_q_tokens] - jax_nonkernel_output_cpu[:actual_num_q_tokens]))}'
-      )
       self.assertTrue(
           torch.allclose(
               kernel_output_cpu[:actual_num_q_tokens], nonkernel_output_cpu[:actual_num_q_tokens], atol=2e-1, rtol=1e-2))
+      self.assertTrue(
+          torch.allclose(
+              kernel_output_cpu[:actual_num_q_tokens], jax_kernel_output_cpu[:actual_num_q_tokens], atol=2e-1, rtol=1e-2))
     else:
       self.assertTrue(
           torch.allclose(
               kernel_output_cpu, nonkernel_output_cpu, atol=2e-1, rtol=1e-2))
+      self.assertTrue(
+          torch.allclose(
+              kernel_output_cpu, jax_kernel_output_cpu, atol=2e-1, rtol=1e-2))
     
   @unittest.skipIf(xr.device_type() != 'TPU' or tpu.version() < 4,
                    "This test only works on TPUv4+.")

--- a/test/test_ragged_paged_attention_kernel.py
+++ b/test/test_ragged_paged_attention_kernel.py
@@ -30,8 +30,6 @@ def _ref_ragged_paged_attention(
   num_query_per_kv = num_q_heads // num_kv_heads
   start_idx = 0
 
-  outputs_maybe_padded = jnp.zeros_like(queries)
-  actual_num_tokens = cu_q_lens[num_seqs]
   outputs: List[jax.Array] = []
   for i in range(num_seqs):
     cur_q_len = cu_q_lens[i + 1] - cu_q_lens[i]
@@ -75,8 +73,10 @@ def _ref_ragged_paged_attention(
     outputs.append(out)
     start_idx += cur_q_len
 
-  if actual_num_tokens < outputs_maybe_padded.shape[0]:
-    num_tokens_diff = outputs_maybe_padded.shape[0] - actual_num_tokens
+  maybe_padded_num_q_tokens = queries.shape[0]
+  actual_num_tokens = cu_q_lens[num_seqs]
+  if actual_num_tokens < maybe_padded_num_q_tokens:
+    num_tokens_diff = maybe_padded_num_q_tokens - actual_num_tokens
     outputs.append(jnp.zeros((num_tokens_diff, num_q_heads, head_dim)).astype(outputs[0].dtype))
   return jnp.concatenate(outputs, axis=0)
 

--- a/test/test_ragged_paged_attention_kernel.py
+++ b/test/test_ragged_paged_attention_kernel.py
@@ -77,7 +77,9 @@ def _ref_ragged_paged_attention(
   actual_num_tokens = cu_q_lens[num_seqs]
   if actual_num_tokens < maybe_padded_num_q_tokens:
     num_tokens_diff = maybe_padded_num_q_tokens - actual_num_tokens
-    outputs.append(jnp.zeros((num_tokens_diff, num_q_heads, head_dim)).astype(outputs[0].dtype))
+    outputs.append(
+        jnp.zeros(
+            (num_tokens_diff, num_q_heads, head_dim)).astype(outputs[0].dtype))
   return jnp.concatenate(outputs, axis=0)
 
 
@@ -107,7 +109,9 @@ class RaggedPagedAttentionKernelTest(parameterized.TestCase):
     query_lens = [seq_len[0] for seq_len in seq_lens]
     actual_num_q_tokens = sum(query_lens)
     # Caller(eg vLLM) may decide to pad the num_q_tokens.
-    num_q_tokens = self._round_up_closest_multiple_of(actual_num_q_tokens, num_queries_per_block) if pad_num_q_tokens else actual_num_q_tokens
+    num_q_tokens = self._round_up_closest_multiple_of(
+        actual_num_q_tokens,
+        num_queries_per_block) if pad_num_q_tokens else actual_num_q_tokens
     kv_lens = jnp.array([seq_len[1] for seq_len in seq_lens])
     num_q_heads = num_heads[0]
     num_kv_heads = num_heads[1]
@@ -194,11 +198,14 @@ class RaggedPagedAttentionKernelTest(parameterized.TestCase):
       self.fail(f'Unsupported dtype: {dtype}')
     if pad_num_q_tokens:
       self.assertTrue(
-          jnp.allclose(actual_output[:actual_num_q_tokens], expected_output[:actual_num_q_tokens], atol=atol, rtol=rtol))
+          jnp.allclose(
+              actual_output[:actual_num_q_tokens],
+              expected_output[:actual_num_q_tokens],
+              atol=atol,
+              rtol=rtol))
     else:
       self.assertTrue(
           jnp.allclose(actual_output, expected_output, atol=atol, rtol=rtol))
-
 
   def _round_up_closest_multiple_of(self, x, base):
     return (x + base - 1) // base * base
@@ -270,19 +277,19 @@ class RaggedPagedAttentionKernelTest(parameterized.TestCase):
       num_queries_per_block=[16, 64, 128],
   )
   def test_paged_attention_varlen_with_padding_comprehensive(
-    self,
-    num_heads: Tuple[int, int],
-    head_dim: int,
-    dtype,
-    page_size: int,
-    num_pages: int,
-    num_queries_per_block: int,
+      self,
+      num_heads: Tuple[int, int],
+      head_dim: int,
+      dtype,
+      page_size: int,
+      num_pages: int,
+      num_queries_per_block: int,
   ):
     if jtu.is_device_tpu(version=4) and head_dim == 256 and page_size == 32:
       self.skipTest(
           "TPU v4 has small VMEM. It will run into VMEM OOM. Skip the test.")
     # If num_queries_per_block is 128, then num_tokens will be pad 6 to be the smallest multiple of 128.
-    seq_lens=[(1, 1328), (5, 18), (500, 563)]
+    seq_lens = [(1, 1328), (5, 18), (500, 563)]
     self._verify_ragged_paged_attention(
         seq_lens,
         num_heads,
@@ -294,7 +301,6 @@ class RaggedPagedAttentionKernelTest(parameterized.TestCase):
         num_kv_pages_per_block=128,
         pad_num_q_tokens=True,
     )
-
 
   def test_paged_attention_mix_prefill_and_decode1(self,):
     # assuming q_blk_size=128

--- a/test/test_ragged_paged_attention_kernel.py
+++ b/test/test_ragged_paged_attention_kernel.py
@@ -230,13 +230,12 @@ class RaggedPagedAttentionKernelTest(parameterized.TestCase):
 
   @parameterized.product(
       seq_lens=[[(1, 1328), (5, 18), (506, 563)]],
-      num_heads=[(4, 4), (8, 2)],
+      num_heads=[(4, 4), (4, 2)],
       head_dim=[128, 256],
       dtype=(jnp.float32, jnp.bfloat16),
       page_size=[16, 32],
       num_pages=[32768, 2048],
       num_queries_per_block=[16, 64, 128],
-      num_kv_pages_per_block=[128, 256],
   )
   def test_paged_attention_varlen_comprehensive(
       self,
@@ -247,7 +246,6 @@ class RaggedPagedAttentionKernelTest(parameterized.TestCase):
       page_size: int,
       num_pages: int,
       num_queries_per_block: int,
-      num_kv_pages_per_block: int,
   ):
     if jtu.is_device_tpu(version=4) and head_dim == 256 and page_size == 32:
       self.skipTest(
@@ -260,17 +258,16 @@ class RaggedPagedAttentionKernelTest(parameterized.TestCase):
         dtype,
         num_pages,
         num_queries_per_block=num_queries_per_block,
-        num_kv_pages_per_block=num_kv_pages_per_block,
+        num_kv_pages_per_block=128,
     )
 
   @parameterized.product(
-      num_heads=[(4, 4), (8, 2)],
+      num_heads=[(4, 4), (4, 2)],
       head_dim=[128, 256],
       dtype=(jnp.float32, jnp.bfloat16),
       page_size=[16, 32],
       num_pages=[32768, 2048],
       num_queries_per_block=[16, 64, 128],
-      num_kv_pages_per_block=[128, 256],
   )
   def test_paged_attention_varlen_with_padding_comprehensive(
     self,
@@ -280,7 +277,6 @@ class RaggedPagedAttentionKernelTest(parameterized.TestCase):
     page_size: int,
     num_pages: int,
     num_queries_per_block: int,
-    num_kv_pages_per_block: int,
   ):
     if jtu.is_device_tpu(version=4) and head_dim == 256 and page_size == 32:
       self.skipTest(
@@ -295,7 +291,7 @@ class RaggedPagedAttentionKernelTest(parameterized.TestCase):
         dtype,
         num_pages,
         num_queries_per_block=num_queries_per_block,
-        num_kv_pages_per_block=num_kv_pages_per_block,
+        num_kv_pages_per_block=128,
         pad_num_q_tokens=True,
     )
 

--- a/test/test_ragged_paged_attention_kernel.py
+++ b/test/test_ragged_paged_attention_kernel.py
@@ -1,15 +1,15 @@
 from typing import List, Optional, Tuple
+import sys
+import unittest
 
-from absl.testing import absltest
 from absl.testing import parameterized
+from absl.testing import absltest
 import jax
 from jax._src import test_util as jtu
 from jax.experimental.pallas.ops.tpu.paged_attention import quantization_utils
 from torch_xla.experimental.pallas_kernels.ragged_paged_attention_kernel import ragged_paged_attention, make_sequence_metadata, DEFAULT_MASK_VALUE
 import jax.numpy as jnp
 import numpy as np
-
-jax.config.parse_flags_with_absl()
 
 ATOL_FP32 = 2e-1
 
@@ -29,6 +29,9 @@ def _ref_ragged_paged_attention(
   assert num_q_heads % num_kv_heads == 0, "num_q_heads % num_kv_heads !=0."
   num_query_per_kv = num_q_heads // num_kv_heads
   start_idx = 0
+
+  outputs_maybe_padded = jnp.zeros_like(queries)
+  actual_num_tokens = cu_q_lens[num_seqs]
   outputs: List[jax.Array] = []
   for i in range(num_seqs):
     cur_q_len = cu_q_lens[i + 1] - cu_q_lens[i]
@@ -72,11 +75,13 @@ def _ref_ragged_paged_attention(
     outputs.append(out)
     start_idx += cur_q_len
 
+  if actual_num_tokens < outputs_maybe_padded.shape[0]:
+    num_tokens_diff = outputs_maybe_padded.shape[0] - actual_num_tokens
+    outputs.append(jnp.zeros((num_tokens_diff, num_q_heads, head_dim)).astype(outputs[0].dtype))
   return jnp.concatenate(outputs, axis=0)
 
 
-@jtu.with_config(jax_numpy_dtype_promotion="standard")
-class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
+class RaggedPagedAttentionKernelTest(parameterized.TestCase):
 
   def _verify_ragged_paged_attention(
       self,
@@ -88,6 +93,7 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
       num_pages,
       num_kv_pages_per_block=128,
       num_queries_per_block=128,
+      pad_num_q_tokens=False,
   ):
     num_seqs = len(seq_lens)
     # Make sure the q_len is no longer than the kv_len. For example,
@@ -99,7 +105,9 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
       assert cur_q_len <= cur_kv_len, f"cur_q_len must be less than or equal to cur_kv_len. Got {cur_q_len} and {cur_kv_len}"
 
     query_lens = [seq_len[0] for seq_len in seq_lens]
-    num_q_tokens = sum(query_lens)
+    actual_num_q_tokens = sum(query_lens)
+    # Caller(eg vLLM) may decide to pad the num_q_tokens.
+    num_q_tokens = self._round_up_closest_multiple_of(actual_num_q_tokens, num_queries_per_block) if pad_num_q_tokens else actual_num_q_tokens
     kv_lens = jnp.array([seq_len[1] for seq_len in seq_lens])
     num_q_heads = num_heads[0]
     num_kv_heads = num_heads[1]
@@ -115,6 +123,8 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
         k3, (num_kv_heads, num_pages, page_size, head_dim), dtype=dtype)
 
     # Create a kv_lens: i32[num_tokens]
+    # Only the first num_seqs of kv_lens_with_paddings are meaningful
+    # [num_seqs:num_q_tokens] are padded value and are meaningless.
     kv_lens_with_paddings = [0] * num_q_tokens
     for i in range(num_seqs):
       kv_lens_with_paddings[i] = kv_lens[i]
@@ -182,8 +192,13 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
       rtol = 1e-1
     else:
       self.fail(f'Unsupported dtype: {dtype}')
-    self.assertTrue(
-        jnp.allclose(actual_output, expected_output, atol=atol, rtol=rtol))
+    if pad_num_q_tokens:
+      self.assertTrue(
+          jnp.allclose(actual_output[:actual_num_q_tokens], expected_output[:actual_num_q_tokens], atol=atol, rtol=rtol))
+    else:
+      self.assertTrue(
+          jnp.allclose(actual_output, expected_output, atol=atol, rtol=rtol))
+
 
   def _round_up_closest_multiple_of(self, x, base):
     return (x + base - 1) // base * base
@@ -215,11 +230,13 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
 
   @parameterized.product(
       seq_lens=[[(1, 1328), (5, 18), (506, 563)]],
-      num_heads=[(4, 4), (8, 2), (16, 2)],
+      num_heads=[(4, 4), (8, 2)],
       head_dim=[128, 256],
       dtype=(jnp.float32, jnp.bfloat16),
       page_size=[16, 32],
       num_pages=[32768, 2048],
+      num_queries_per_block=[16, 64, 128],
+      num_kv_pages_per_block=[128, 256],
   )
   def test_paged_attention_varlen_comprehensive(
       self,
@@ -229,6 +246,8 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
       dtype,
       page_size: int,
       num_pages: int,
+      num_queries_per_block: int,
+      num_kv_pages_per_block: int,
   ):
     if jtu.is_device_tpu(version=4) and head_dim == 256 and page_size == 32:
       self.skipTest(
@@ -240,8 +259,46 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
         page_size,
         dtype,
         num_pages,
-        num_queries_per_block=64,
+        num_queries_per_block=num_queries_per_block,
+        num_kv_pages_per_block=num_kv_pages_per_block,
     )
+
+  @parameterized.product(
+      num_heads=[(4, 4), (8, 2)],
+      head_dim=[128, 256],
+      dtype=(jnp.float32, jnp.bfloat16),
+      page_size=[16, 32],
+      num_pages=[32768, 2048],
+      num_queries_per_block=[16, 64, 128],
+      num_kv_pages_per_block=[128, 256],
+  )
+  def test_paged_attention_varlen_with_padding_comprehensive(
+    self,
+    num_heads: Tuple[int, int],
+    head_dim: int,
+    dtype,
+    page_size: int,
+    num_pages: int,
+    num_queries_per_block: int,
+    num_kv_pages_per_block: int,
+  ):
+    if jtu.is_device_tpu(version=4) and head_dim == 256 and page_size == 32:
+      self.skipTest(
+          "TPU v4 has small VMEM. It will run into VMEM OOM. Skip the test.")
+    # If num_queries_per_block is 128, then num_tokens will be pad 6 to be the smallest multiple of 128.
+    seq_lens=[(1, 1328), (5, 18), (500, 563)]
+    self._verify_ragged_paged_attention(
+        seq_lens,
+        num_heads,
+        head_dim,
+        page_size,
+        dtype,
+        num_pages,
+        num_queries_per_block=num_queries_per_block,
+        num_kv_pages_per_block=num_kv_pages_per_block,
+        pad_num_q_tokens=True,
+    )
+
 
   def test_paged_attention_mix_prefill_and_decode1(self,):
     # assuming q_blk_size=128
@@ -442,4 +499,5 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
 
 
 if __name__ == "__main__":
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  test = unittest.main()
+  sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -766,7 +766,10 @@ def _ragged_paged_attention_nonkernel(
   actual_num_tokens = cu_q_lens[num_seqs]
   if actual_num_tokens < maybe_padded_num_q_tokens:
     num_tokens_diff = maybe_padded_num_q_tokens - actual_num_tokens
-    outputs.append(torch.zeros((num_tokens_diff, num_q_heads, head_dim), dtype=queries[0].dtype, device=queries.device))
+    outputs.append(
+        torch.zeros((num_tokens_diff, num_q_heads, head_dim),
+                    dtype=queries[0].dtype,
+                    device=queries.device))
   return torch.cat(outputs, dim=0)  # [num_tokens, num_query_heads, head_dim]
 
 

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -718,7 +718,6 @@ def _ragged_paged_attention_nonkernel(
 
   outputs: List[torch.Tensor] = []
   for i in range(num_seqs):
-    # import pdb; pdb.set_trace()
     cur_q_len = cu_q_lens[i + 1] - cu_q_lens[i]
     q = queries[start_idx:start_idx +
                 cur_q_len]  # [cur_q_len, num_q_heads, head_dim]

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -716,6 +716,7 @@ def _ragged_paged_attention_nonkernel(
   kv_lens = kv_lens.cpu()
   page_indices = page_indices.cpu()
 
+  padded_output = torch.zeros_like(queries)
   outputs: List[torch.Tensor] = []
   for i in range(num_seqs):
     cur_q_len = cu_q_lens[i + 1] - cu_q_lens[i]
@@ -762,7 +763,9 @@ def _ragged_paged_attention_nonkernel(
     start_idx += cur_q_len
 
   output = torch.cat(outputs, dim=0)  # [num_tokens, num_query_heads, head_dim]
-  return output
+  actual_num_tokens = output.shape[0]
+  padded_output[:actual_num_tokens] = output
+  return padded_output
 
 
 @requires_jax

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -719,6 +719,7 @@ def _ragged_paged_attention_nonkernel(
   padded_output = torch.zeros_like(queries)
   outputs: List[torch.Tensor] = []
   for i in range(num_seqs):
+    # import pdb; pdb.set_trace()
     cur_q_len = cu_q_lens[i + 1] - cu_q_lens[i]
     q = queries[start_idx:start_idx +
                 cur_q_len]  # [cur_q_len, num_q_heads, head_dim]
@@ -752,6 +753,7 @@ def _ragged_paged_attention_nonkernel(
     attn = torch.einsum("qhd,khd->hqk", q,
                         k)  # [num_query_heads, cur_q_len, kv_len]
     attn = attn.float()
+    #print(f'xw32 torch ref line756 {attn=}')
     empty_mask = torch.ones(cur_q_len, cur_kv_len, device=attn.device)
     mask = torch.triu(empty_mask, diagonal=cur_kv_len - cur_q_len + 1).bool()
     attn.masked_fill_(mask, float("-inf"))
@@ -763,8 +765,11 @@ def _ragged_paged_attention_nonkernel(
     start_idx += cur_q_len
 
   output = torch.cat(outputs, dim=0)  # [num_tokens, num_query_heads, head_dim]
+  # print(f'xw32 torch ref line768 {output=}')
   actual_num_tokens = output.shape[0]
+  import pdb; pdb.set_trace()
   padded_output[:actual_num_tokens] = output
+  print(f'xw32 torch ref line771 {padded_output=}')
   return padded_output
 
 


### PR DESCRIPTION
In reality, the caller (eg vLLM) may pad the query matrix on the num_tokens dimension when it calls the ragged paged attention. This PR
- adds the test cases for such scenario.
- update the reference impl for such case.

Test plans:
- python pytorch/xla/test/test_pallas.py -v -k  PallasTest.test_ragged_ 2>&1 | tee out.txt
- python pytorch/xla/test/test_ragged_paged_attention_kernel.py -k comprehensive 2>&1 | tee out.txt