### PR TITLE
Enable default buffer donation for gradient accumulation

### DIFF
--- a/torch_xla/_dynamo/dynamo_bridge.py
+++ b/torch_xla/_dynamo/dynamo_bridge.py
@@ -1,15 +1,11 @@
-import copy
 import dataclasses
 import operator
 import warnings
 
-import functools
 import itertools
 import os
-import time
 from typing import Any, Dict, List, Set, Tuple, Union
 from numbers import Number
-from contextlib import contextmanager
 from collections import deque
 
 import torch
@@ -28,21 +24,11 @@ import torch_xla.debug.metrics as metrics
 import torch_xla.core.xla_env_vars as xenv
 import torch_xla.runtime as xr
 import torch_xla.utils.utils as xu
+from torch_xla.utils.buffer_donor_context import alias_with_buffer_donor_config
 import torch_xla.utils.dlpack as torch_xla_dlpack
 
 dynamo_debug = int(os.environ.get('XLA_DYNAMO_DEBUG', '0')) == 1
 ptxla_debug = int(os.environ.get('PT_XLA_DEBUG', '0')) == 1
-
-
-@contextmanager
-def alias_with_buffer_donor_config(should_alias: bool = True):
-  saved_config = torch_xla._XLAC._xla_get_enable_alias_with_buffer_donor_config(
-  )
-  torch_xla._XLAC._xla_set_enable_alias_with_buffer_donor_config(should_alias)
-  try:
-    yield saved_config
-  finally:
-    torch_xla._XLAC._xla_set_enable_alias_with_buffer_donor_config(saved_config)
 
 
 @dataclasses.dataclass

--- a/torch_xla/experimental/gradient_accumulation.py
+++ b/torch_xla/experimental/gradient_accumulation.py
@@ -2,8 +2,9 @@ import torch
 import torch_xla
 import torch_xla.core.xla_builder as xb
 
-from typing import Any, Callable, Sequence, Tuple, Optional, List, Dict
 from dataclasses import dataclass
+from typing import Any, Callable, Sequence, Tuple, Optional, List, Dict
+import warnings
 
 
 @dataclass(frozen=True)
@@ -378,20 +379,32 @@ def _gradient_accumulation(accumulation_steps, train_step, iterable_tensors,
     return (iteri, loss, *iterable_tensors, *carried_tensors, *params,
             *acc_grads)
 
+  if not torch_xla._XLAC._xla_get_enable_alias_with_buffer_donor_config():
+    warnings.warn(
+        'Buffer donation is currently not enabled for gradient accumulation '
+        'The resulting computed gradients will be unaliased from the initial '
+        'gradient tensors. In order to donate and discard the former gradient '
+        'tensors, consider enabling `_xla_set_enable_alias_with_buffer_donor_config(True)`'
+    )
+
   init_grads = []
   # Initialize the gradients to zero.
   for param in model_parameters:
     if not param.requires_grad:
       continue
-    if param.grad is not None:
-      grad = param.grad
-    else:
-      grad = torch.zeros(param.size()).to(param.device).requires_grad_(False)
-      param_sharding = torch_xla._XLAC._get_xla_op_sharding(param)
+    if param.grad is None:
+      param.grad = torch.zeros(param.size()).to(
+          param.device).requires_grad_(False)
+      param_sharding = torch_xla._XLAC._get_xla_op_sharding(param.grad)
       if param_sharding:
         # Match the gradient sharding to the parameter's.
-        torch_xla._XLAC._xla_mark_sharding(grad, param_sharding)
-    init_grads.append(grad)
+        torch_xla._XLAC._xla_mark_sharding(param.grad, param_sharding)
+
+    # Ensure that the input or pre-initialized gradient tensors can be donated
+    # after reassigned to the respective model parameters. If the buffer donor
+    # is not enabled, then this is a no-op.
+    torch_xla._XLAC._set_buffer_donation(param.grad, True)
+    init_grads.append(param.grad)
 
   # Apply gradients to parameters
   result = _gradient_accumulation_impl(context, body_fn, iterable_tensors,

--- a/torch_xla/utils/buffer_donor_context.py
+++ b/torch_xla/utils/buffer_donor_context.py
@@ -1,0 +1,14 @@
+from contextlib import contextmanager
+
+import torch_xla
+
+
+@contextmanager
+def alias_with_buffer_donor_config(should_alias: bool = True):
+  saved_config = torch_xla._XLAC._xla_get_enable_alias_with_buffer_donor_config(
+  )
+  torch_xla._XLAC._xla_set_enable_alias_with_buffer_donor_config(should_alias)
+  try:
+    yield saved_config
+  finally:
+    torch_xla._XLAC._xla_set_enable_alias_with_buffer_donor_config(saved_config)


### PR DESCRIPTION
Follow-up to https://github.com/pytorch/xla/pull/8721 (https://github.com/pytorch/xla/issues/8711), we extend the intended buffer donation behavior to the experimental gradient accumulation API.

The current implementation relies on torch.autograd.grad + lowering context, which does not support in-place mutation of the parameter model gradients (which are inputs). Hence, since we're re-assigning the parameter gradients to a different aliasing ID (computed with autograd), we will be inevitably unaliasing the gradient input to the graph and the resulting one.

Unfortunately, the buffer donation (user) config is disabled by default, so we currently warn users about this behavior. If we can alleviate the constraint of retaining aliasing and supporting in-place mutation of the inputs, we can remove the built-in donation from the API.

Note: An additional commit to decouple/separate the context manager for the buffer donation config, so it can be easily reused on the application code.