### PR TITLE
Manually register einsum on xla

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -249,11 +249,12 @@ function run_xla_op_tests3 {
   run_test "$CDIR/test_persistent_cache.py"
   run_test "$CDIR/test_devices.py"
   run_device_detection_test "$CDIR/test_gpu_device_detection.py"
+  run_test "$CDIR/test_manual_xla_registration.py"
   # NOTE: this line below is testing export and don't care about GPU
   PJRT_DEVICE=CPU CPU_NUM_DEVICES=1 run_coverage "$CDIR/test_core_aten_ops.py"
   run_test "$CDIR/test_pallas.py"
   run_xla_ir_hlo_debug run_test "$CDIR/test_user_computation_debug_cache.py"
-  
+
   # Test examples
   run_test "$CDIR/../examples/scan/scan_examples.py"
 

--- a/test/test_manual_xla_registration.py
+++ b/test/test_manual_xla_registration.py
@@ -30,9 +30,8 @@ class OperationLowered(unittest.TestCase):
       with self.subTest(f=f):
         ir = is_einsum_lowered(lambda a, b: f('...n,mn->...m', a, b))
 
-        self.assertIn(
-            "einsum", ir,
-            "Expected einsum to be in ir from it being lowered")
+        self.assertIn("einsum", ir,
+                      "Expected einsum to be in ir from it being lowered")
         self.assertNotIn(
             "permute", ir,
             "Expected no permute to be in ir from it being lowered")
@@ -44,9 +43,8 @@ class OperationLowered(unittest.TestCase):
     self.assertNotIn(
         "einsum", ir,
         "Expected no einsum to be in ir from it not being lowered")
-    self.assertIn(
-        "permute", ir,
-        "Expected permute to be in ir from it not being lowered")
+    self.assertIn("permute", ir,
+                  "Expected permute to be in ir from it not being lowered")
 
 
 if __name__ == '__main__':

--- a/test/test_manual_xla_registration.py
+++ b/test/test_manual_xla_registration.py
@@ -14,6 +14,7 @@ import time
 def custom_einsum(function: str, input: Tensor, weight: Tensor):
   return torch.einsum(function, input, weight)
 
+
 def is_einsum_lowered(func):
   X = torch.zeros(3, 5, requires_grad=False, device='xla')
   Y = torch.zeros(5, 7, requires_grad=False, device='xla')
@@ -35,6 +36,7 @@ class OperationLowered(unittest.TestCase):
     self.assertFalse(
         is_einsum_lowered(lambda a, b: torch.einsum('ab,bc->ab', a, b)),
         "Operation lowered as expected")
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/test/test_manual_xla_registration.py
+++ b/test/test_manual_xla_registration.py
@@ -1,0 +1,33 @@
+import sys
+import unittest
+import torch
+from torch import Tensor
+from torch.library import custom_op
+import torch_xla
+import time
+
+@custom_op("xla::custom_linear_with_einsum", schema="(Tensor input, Tensor weight) -> Tensor", mutates_args=())
+def custom_linear_with_einsum(input: Tensor, weight: Tensor):
+    return torch.einsum('...n,mn->...m', input, weight)
+
+def test_lowering(func):
+  X = torch.zeros(3, 3, requires_grad=False, device='xla')
+  Y = torch.zeros(3, 3, requires_grad=False, device='xla')
+
+  out = func(X, Y)
+  time.sleep(2)
+  ir = torch_xla._XLAC._get_xla_tensors_text([out])
+  return 'einsum' in ir
+
+class OperationLowered(unittest.TestCase):
+  def test_einsum_registration(self):
+    self.assertTrue(test_lowering(lambda a, b: torch.einsum('...n,mn->...m', a, b)),
+                    "Operation not lowered as expected")
+
+  def test_einsum_custom_registration(self):
+    self.assertTrue(test_lowering(lambda a, b: custom_linear_with_einsum(a, b)),
+                    "Operation not lowered as expected")
+
+if __name__ == '__main__':
+  test = unittest.main()
+  sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/test_manual_xla_registration.py
+++ b/test/test_manual_xla_registration.py
@@ -39,11 +39,9 @@ class OperationLowered(unittest.TestCase):
     # 'ab,bc->ab' won't be lowered becaused it cannot be backpropagated
     ir = is_einsum_lowered(lambda a, b: torch.einsum('ab,bc->ab', a, b))
 
-    self.assertNotIn(
-                    "einsum", ir,
+    self.assertNotIn("einsum", ir,
                     "Expected no einsum to be in ir from it not being lowered")
-    self.assertIn(
-                  "permute", ir,
+    self.assertIn("permute", ir,
                   "Expected permute to be in ir from it not being lowered")
 
 

--- a/test/test_manual_xla_registration.py
+++ b/test/test_manual_xla_registration.py
@@ -4,7 +4,6 @@ import torch
 from torch import Tensor
 from torch.library import custom_op
 import torch_xla
-import time
 
 
 @custom_op(

--- a/test/test_manual_xla_registration.py
+++ b/test/test_manual_xla_registration.py
@@ -6,27 +6,32 @@ from torch.library import custom_op
 import torch_xla
 import time
 
-@custom_op("xla::custom_linear_with_einsum", schema="(Tensor input, Tensor weight) -> Tensor", mutates_args=())
-def custom_linear_with_einsum(input: Tensor, weight: Tensor):
-    return torch.einsum('...n,mn->...m', input, weight)
+@custom_op(
+    "xla::custom_einsum",
+    schema="(str function, Tensor input, Tensor weight) -> Tensor",
+    mutates_args=())
+def custom_einsum(function: str, input: Tensor, weight: Tensor):
+    return torch.einsum(function, input, weight)
 
-def test_lowering(func):
-  X = torch.zeros(3, 3, requires_grad=False, device='xla')
-  Y = torch.zeros(3, 3, requires_grad=False, device='xla')
+def is_einsum_lowered(func):
+  X = torch.zeros(3, 5, requires_grad=False, device='xla')
+  Y = torch.zeros(5, 7, requires_grad=False, device='xla')
 
   out = func(X, Y)
-  time.sleep(2)
   ir = torch_xla._XLAC._get_xla_tensors_text([out])
   return 'einsum' in ir
 
 class OperationLowered(unittest.TestCase):
-  def test_einsum_registration(self):
-    self.assertTrue(test_lowering(lambda a, b: torch.einsum('...n,mn->...m', a, b)),
-                    "Operation not lowered as expected")
+  def test_einsum_lowered(self):
+    for f in [torch.einsum, custom_einsum]:
+      self.assertTrue(
+        is_einsum_lowered(lambda a, b: f('...n,mn->...m', a, b)),
+        "Operation not lowered as expected")
 
-  def test_einsum_custom_registration(self):
-    self.assertTrue(test_lowering(lambda a, b: custom_linear_with_einsum(a, b)),
-                    "Operation not lowered as expected")
+  def test_einsum_not_lowered(self):
+    self.assertFalse(
+      is_einsum_lowered(lambda a, b: torch.einsum('ab,bc->ab', a, b)),
+      "Operation lowered as expected")
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/test/test_manual_xla_registration.py
+++ b/test/test_manual_xla_registration.py
@@ -30,12 +30,12 @@ class OperationLowered(unittest.TestCase):
     for f in [torch.einsum, custom_einsum]:
       self.assertTrue(
           is_einsum_lowered(lambda a, b: f('...n,mn->...m', a, b)),
-          "Operation not lowered as expected")
+          "Operation not lowered; expected operation to be lowered")
 
   def test_einsum_not_lowered(self):
     self.assertFalse(
         is_einsum_lowered(lambda a, b: torch.einsum('ab,bc->ab', a, b)),
-        "Operation lowered as expected")
+        "Operation lowered; expected operation to not be lowered")
 
 
 if __name__ == '__main__':

--- a/test/test_manual_xla_registration.py
+++ b/test/test_manual_xla_registration.py
@@ -30,19 +30,23 @@ class OperationLowered(unittest.TestCase):
       with self.subTest(f=f):
         ir = is_einsum_lowered(lambda a, b: f('...n,mn->...m', a, b))
 
-        self.assertIn("einsum", ir,
-                      "Expected einsum to be in ir from it being lowered")
-        self.assertNotIn("permute", ir,
-                      "Expected no permute to be in ir from it being lowered")
+        self.assertIn(
+            "einsum", ir,
+            "Expected einsum to be in ir from it being lowered")
+        self.assertNotIn(
+            "permute", ir,
+            "Expected no permute to be in ir from it being lowered")
 
   def test_einsum_not_lowered(self):
     # 'ab,bc->ab' won't be lowered becaused it cannot be backpropagated
     ir = is_einsum_lowered(lambda a, b: torch.einsum('ab,bc->ab', a, b))
 
-    self.assertNotIn("einsum", ir,
-                    "Expected no einsum to be in ir from it not being lowered")
-    self.assertIn("permute", ir,
-                  "Expected permute to be in ir from it not being lowered")
+    self.assertNotIn(
+        "einsum", ir,
+        "Expected no einsum to be in ir from it not being lowered")
+    self.assertIn(
+        "permute", ir,
+        "Expected permute to be in ir from it not being lowered")
 
 
 if __name__ == '__main__':

--- a/test/test_manual_xla_registration.py
+++ b/test/test_manual_xla_registration.py
@@ -6,12 +6,13 @@ from torch.library import custom_op
 import torch_xla
 import time
 
+
 @custom_op(
     "xla::custom_einsum",
     schema="(str function, Tensor input, Tensor weight) -> Tensor",
     mutates_args=())
 def custom_einsum(function: str, input: Tensor, weight: Tensor):
-    return torch.einsum(function, input, weight)
+  return torch.einsum(function, input, weight)
 
 def is_einsum_lowered(func):
   X = torch.zeros(3, 5, requires_grad=False, device='xla')
@@ -21,17 +22,19 @@ def is_einsum_lowered(func):
   ir = torch_xla._XLAC._get_xla_tensors_text([out])
   return 'einsum' in ir
 
+
 class OperationLowered(unittest.TestCase):
+
   def test_einsum_lowered(self):
     for f in [torch.einsum, custom_einsum]:
       self.assertTrue(
-        is_einsum_lowered(lambda a, b: f('...n,mn->...m', a, b)),
-        "Operation not lowered as expected")
+          is_einsum_lowered(lambda a, b: f('...n,mn->...m', a, b)),
+          "Operation not lowered as expected")
 
   def test_einsum_not_lowered(self):
     self.assertFalse(
-      is_einsum_lowered(lambda a, b: torch.einsum('ab,bc->ab', a, b)),
-      "Operation lowered as expected")
+        is_einsum_lowered(lambda a, b: torch.einsum('ab,bc->ab', a, b)),
+        "Operation lowered as expected")
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/test/test_manual_xla_registration.py
+++ b/test/test_manual_xla_registration.py
@@ -31,18 +31,20 @@ class OperationLowered(unittest.TestCase):
         ir = is_einsum_lowered(lambda a, b: f('...n,mn->...m', a, b))
 
         self.assertIn("einsum", ir,
-            "Expected einsum to be in ir from it being lowered")
+                      "Expected einsum to be in ir from it being lowered")
         self.assertNotIn("permute", ir,
-            "Expected no permute to be in ir from it being lowered")
+                      "Expected no permute to be in ir from it being lowered")
 
   def test_einsum_not_lowered(self):
     # 'ab,bc->ab' won't be lowered becaused it cannot be backpropagated
     ir = is_einsum_lowered(lambda a, b: torch.einsum('ab,bc->ab', a, b))
 
-    self.assertNotIn("einsum", ir,
-          "Expected no einsum to be in ir from it not being lowered")
-    self.assertIn("permute", ir,
-          "Expected permute to be in ir from it not being lowered")
+    self.assertNotIn(
+                    "einsum", ir,
+                    "Expected no einsum to be in ir from it not being lowered")
+    self.assertIn(
+                  "permute", ir,
+                  "Expected permute to be in ir from it not being lowered")
 
 
 if __name__ == '__main__':

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1867,17 +1867,6 @@ void InitXlaModuleBindings(py::module m) {
   m.def("_xla_optimization_barrier_",
         [](std::vector<at::Tensor>& inputs) { OptimizationBarrier_(inputs); });
 
-  // TODO(https://github.com/pytorch/xla/issues/8713): torch.einsum is getting
-  // decomposed when inside a custom op. This C++ op is an escape hatch to call
-  // XLA einsum without going through torch.einsum. We should remove this
-  // operation when the linked bug is fixed.
-  m.def("_xla_einsum",
-        [](const std::string& equation, const std::vector<at::Tensor>& inputs) {
-          std::vector<XLATensorPtr> xla_tensors = bridge::GetXlaTensors(inputs);
-          XLATensorPtr output = tensor_methods::einsum(equation, xla_tensors);
-          return bridge::AtenFromXlaTensor(output);
-        });
-
   // Creates a placeholder tensor that does not hold any device buffer.
   // This is primarily useful for staging out the HLO of a user computation.
   // Accessing the value of the tensor will panic.

--- a/torch_xla/csrc/xla_manual_registration.cpp
+++ b/torch_xla/csrc/xla_manual_registration.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
+#include "torch_xla/csrc/XLANativeFunctions.h"
 #include "torch_xla/csrc/aten_fallback.h"
 #include "torch_xla/csrc/aten_xla_bridge.h"
 #include "torch_xla/csrc/debug_util.h"
@@ -47,6 +48,12 @@ at::Tensor nms_kernel(const at::Tensor& boxes, const at::Tensor& scores,
 
 TORCH_LIBRARY_IMPL(torchvision, XLA, m) {
   m.impl(TORCH_SELECTIVE_NAME("torchvision::nms"), TORCH_FN(nms_kernel));
+}
+
+// Register generated XLANativeFunctions::einsum as aten::einsum for XLA key.
+// This utilizes the implementation from `xla/torch_xla/csrc/aten_xla_type.cpp`.
+TORCH_LIBRARY_IMPL(aten, XLA, m) {
+  m.impl("aten::einsum", TORCH_FN(XLANativeFunctions::einsum));
 }
 
 }  // namespace manual

--- a/torch_xla/distributed/spmd/xla_sharding.py
+++ b/torch_xla/distributed/spmd/xla_sharding.py
@@ -704,17 +704,17 @@ def _einsum_linear_backward(grad_output: Tensor, input: Tensor, weight: Tensor,
     grad_input = grad_weight = grad_bias = None
 
     if needs_input_grad_input:
-      grad_input = torch.einsum('...m,mn->...n', grad_output, weight)
+      grad_input = torch.einsum('...m,mn->...n', grad_output, weight).clone()
     else:
       grad_input = None
 
     if needs_input_grad_weight:
-      grad_weight = torch.einsum('...m,...n->mn', grad_output, input)
+      grad_weight = torch.einsum('...m,...n->mn', grad_output, input).clone()
     else:
       grad_weight = None
 
     if bias is not None and needs_input_grad_bias:
-      grad_bias = torch.einsum('...m->m', grad_output)
+      grad_bias = torch.einsum('...m->m', grad_output).clone()
     else:
       grad_bias = None
 

--- a/torch_xla/distributed/spmd/xla_sharding.py
+++ b/torch_xla/distributed/spmd/xla_sharding.py
@@ -691,29 +691,29 @@ def _einsum_linear_forward_fake(input: Tensor, weight: Tensor,
   return product
 
 
-def _einsum_linear_backward_operation(grad_output: Tensor, input: Tensor, weight: Tensor,
-                            bias: Optional[Tensor],
-                            needs_input_grad_input: bool,
-                            needs_input_grad_weight: bool,
-                            needs_input_grad_bias: bool):
-    grad_input = grad_weight = grad_bias = None
+def _einsum_linear_backward_operation(grad_output: Tensor, input: Tensor,
+                                      weight: Tensor, bias: Optional[Tensor],
+                                      needs_input_grad_input: bool,
+                                      needs_input_grad_weight: bool,
+                                      needs_input_grad_bias: bool):
+  grad_input = grad_weight = grad_bias = None
 
-    if needs_input_grad_input:
-      grad_input = torch.einsum('...m,mn->...n', grad_output, weight).clone()
-    else:
-      grad_input = None
+  if needs_input_grad_input:
+    grad_input = torch.einsum('...m,mn->...n', grad_output, weight).clone()
+  else:
+    grad_input = None
 
-    if needs_input_grad_weight:
-      grad_weight = torch.einsum('...m,...n->mn', grad_output, input).clone()
-    else:
-      grad_weight = None
+  if needs_input_grad_weight:
+    grad_weight = torch.einsum('...m,...n->mn', grad_output, input).clone()
+  else:
+    grad_weight = None
 
-    if bias is not None and needs_input_grad_bias:
-      grad_bias = torch.einsum('...m->m', grad_output).clone()
-    else:
-      grad_bias = None
+  if bias is not None and needs_input_grad_bias:
+    grad_bias = torch.einsum('...m->m', grad_output).clone()
+  else:
+    grad_bias = None
 
-    return grad_input, grad_weight, grad_bias
+  return grad_input, grad_weight, grad_bias
 
 @custom_op(
     "xla::einsum_linear_backward",
@@ -726,8 +726,9 @@ def _einsum_linear_backward(grad_output: Tensor, input: Tensor, weight: Tensor,
                             needs_input_grad_bias: bool):
   with xp.Trace('einsum_linear_backward'):
     return _einsum_linear_backward_operation(grad_output, input, weight, bias,
-                            needs_input_grad_input, needs_input_grad_weight,
-                            needs_input_grad_bias)
+                                            needs_input_grad_input,
+                                            needs_input_grad_weight,
+                                            needs_input_grad_bias)
 
 
 @_einsum_linear_backward.register_fake
@@ -738,8 +739,9 @@ def _einsum_linear_backward_fake(grad_output: Tensor, input: Tensor,
                                  needs_input_grad_bias: bool):
 
   return _einsum_linear_backward_operation(grad_output, input, weight, bias,
-                            needs_input_grad_input, needs_input_grad_weight,
-                            needs_input_grad_bias)
+                                          needs_input_grad_input,
+                                          needs_input_grad_weight,
+                                          needs_input_grad_bias)
 
 
 # Now define the XLAPatchedLinear function that uses the custom ops

--- a/torch_xla/distributed/spmd/xla_sharding.py
+++ b/torch_xla/distributed/spmd/xla_sharding.py
@@ -708,17 +708,17 @@ def _einsum_linear_backward(grad_output: Tensor, input: Tensor, weight: Tensor,
     grad_input = grad_weight = grad_bias = None
 
     if needs_input_grad_input:
-      grad_input = torch.einsum('...m,mn->...n', (grad_output, weight))
+      grad_input = torch.einsum('...m,mn->...n', grad_output, weight)
     else:
       grad_input = None
 
     if needs_input_grad_weight:
-      grad_weight = torch.einsum('...m,...n->mn', (grad_output, input))
+      grad_weight = torch.einsum('...m,...n->mn', grad_output, input)
     else:
       grad_weight = None
 
     if bias is not None and needs_input_grad_bias:
-      grad_bias = torch.einsum('...m->m', (grad_output,))
+      grad_bias = torch.einsum('...m->m', grad_output)
     else:
       grad_bias = None
 

--- a/torch_xla/distributed/spmd/xla_sharding.py
+++ b/torch_xla/distributed/spmd/xla_sharding.py
@@ -715,6 +715,7 @@ def _einsum_linear_backward_operation(grad_output: Tensor, input: Tensor,
 
   return grad_input, grad_weight, grad_bias
 
+
 @custom_op(
     "xla::einsum_linear_backward",
     schema="(Tensor grad_output, Tensor input, Tensor weight, Tensor? bias, bool needs_input_grad_input, bool needs_input_grad_weight, bool needs_input_grad_bias) -> (Tensor, Tensor, Tensor)",
@@ -726,9 +727,9 @@ def _einsum_linear_backward(grad_output: Tensor, input: Tensor, weight: Tensor,
                             needs_input_grad_bias: bool):
   with xp.Trace('einsum_linear_backward'):
     return _einsum_linear_backward_operation(grad_output, input, weight, bias,
-                                            needs_input_grad_input,
-                                            needs_input_grad_weight,
-                                            needs_input_grad_bias)
+                                             needs_input_grad_input,
+                                             needs_input_grad_weight,
+                                             needs_input_grad_bias)
 
 
 @_einsum_linear_backward.register_fake
@@ -739,9 +740,9 @@ def _einsum_linear_backward_fake(grad_output: Tensor, input: Tensor,
                                  needs_input_grad_bias: bool):
 
   return _einsum_linear_backward_operation(grad_output, input, weight, bias,
-                                          needs_input_grad_input,
-                                          needs_input_grad_weight,
-                                          needs_input_grad_bias)
+                                           needs_input_grad_input,
+                                           needs_input_grad_weight,
+                                           needs_input_grad_bias)
 
 
 # Now define the XLAPatchedLinear function that uses the custom ops

--- a/torch_xla/distributed/spmd/xla_sharding.py
+++ b/torch_xla/distributed/spmd/xla_sharding.py
@@ -680,7 +680,7 @@ def _einsum_linear_forward(input: Tensor, weight: Tensor,
     # decomposed when inside a custom op. This C++ op is an escape hatch to call
     # XLA einsum without going through torch.einsum. We should remove this
     # _einsum escape hatch when the linked bug is fixed.
-    product = torch_xla._XLAC._xla_einsum('...n,mn->...m', (input, weight))
+    product = torch.einsum('...n,mn->...m', (input, weight))
     if bias is not None:
       return product + bias
     return product
@@ -708,19 +708,17 @@ def _einsum_linear_backward(grad_output: Tensor, input: Tensor, weight: Tensor,
     grad_input = grad_weight = grad_bias = None
 
     if needs_input_grad_input:
-      grad_input = torch_xla._XLAC._xla_einsum('...m,mn->...n',
-                                               (grad_output, weight))
+      grad_input = torch.einsum('...m,mn->...n', (grad_output, weight))
     else:
       grad_input = None
 
     if needs_input_grad_weight:
-      grad_weight = torch_xla._XLAC._xla_einsum('...m,...n->mn',
-                                                (grad_output, input))
+      grad_weight = torch.einsum('...m,...n->mn', (grad_output, input))
     else:
       grad_weight = None
 
     if bias is not None and needs_input_grad_bias:
-      grad_bias = torch_xla._XLAC._xla_einsum('...m->m', (grad_output,))
+      grad_bias = torch.einsum('...m->m', (grad_output,))
     else:
       grad_bias = None
 
@@ -765,8 +763,8 @@ class XLAPatchedLinear(torch.autograd.Function):
   autocast context, when autocast is enabled.
   torch.get_autocast_dtype() fetches datatype for ops run in autocast [2], with the specified device (here, 'xla').
 
-  References: 
-  [1] https://pytorch.org/docs/stable/notes/amp_examples.html#functions-with-multiple-inputs-or-autocastable-ops 
+  References:
+  [1] https://pytorch.org/docs/stable/notes/amp_examples.html#functions-with-multiple-inputs-or-autocastable-ops
   [2] https://github.com/pytorch/pytorch/blob/2cc01cc6d3ad2aff47e8460667ba654b2e4c9f21/torch/amp/autocast_mode.py#L500
 
   TODO (alanwaketan): Let's patch it on the dispatcher level.
@@ -1260,8 +1258,8 @@ class MarkShardingFunction(torch.autograd.Function):
   Usage:
   new_tensor = MarkShardingFunction.apply(tensor, mesh, ('axis_1', 'axis_2'))
 
-  This is required to guide GSPMD sharding propagation better during the 
-  backward pass as during complicated workloads the compiler can introduce extra 
+  This is required to guide GSPMD sharding propagation better during the
+  backward pass as during complicated workloads the compiler can introduce extra
   collectives that can hurt performance.
   """
 

--- a/torch_xla/distributed/spmd/xla_sharding.py
+++ b/torch_xla/distributed/spmd/xla_sharding.py
@@ -676,11 +676,7 @@ class ShardingSpec:
 def _einsum_linear_forward(input: Tensor, weight: Tensor,
                            bias: Optional[Tensor]):
   with xp.Trace('einsum_linear_forward'):
-    # TODO(https://github.com/pytorch/xla/issues/8713): torch.einsum is getting
-    # decomposed when inside a custom op. This C++ op is an escape hatch to call
-    # XLA einsum without going through torch.einsum. We should remove this
-    # _einsum escape hatch when the linked bug is fixed.
-    product = torch.einsum('...n,mn->...m', (input, weight))
+    product = torch.einsum('...n,mn->...m', input, weight)
     if bias is not None:
       return product + bias
     return product


### PR DESCRIPTION
Do manual registration of XLANativeFunctions::einsum for XLA.

This is necessary because currently PyTorch overwrites the key AutogradXLA registration with a its XLA key registration. While ideally we would be able to resolve this problem, this work around resolves the issue from our end. It is also not possible to use full code generation due to https://github.com/pytorch/xla/pull/8739.

This manual registration relies on the `XLANativeFunctions::einsum` function from `xla/torch_xla/csrc/aten_xla_type.cpp`.

Originally being worked on https://github.com/pytorch/xla/pull/8787. Abandoned due to conflicts being complex enough starting a new PR made more sense.