### PR TITLE
Re-enable triton tests.

### DIFF
--- a/test/test_triton.py
+++ b/test/test_triton.py
@@ -242,8 +242,6 @@ def _attn_fwd(
   tl.store(O_block_ptr, acc.to(Out.type.element_ty))
 
 
-# Ref: https://github.com/pytorch/xla/pull/8593
-@skipIfCUDA("GPU CI is failing")
 class TritonTest(unittest.TestCase):
 
   @unittest.skipIf(xr.device_type() != 'CUDA', "This test only works on GPU.")


### PR DESCRIPTION
Partial Fix: #8706

This PR modifies the experimental triton support, in order to support newer versions of triton. This is necessary because PyTorch uses a newer triton version (with the old triton versions it would error when inductor was imported).

These changes allow us to re-enable the `test_triton.py` test in CI.