### PR TITLE
[torchax] Fix functional.max_pool

### DIFF
--- a/torchax/test/test_ops.py
+++ b/torchax/test/test_ops.py
@@ -34,9 +34,6 @@ skiplist = {
     "nn.functional.embedding_bag",
     "nn.functional.fractional_max_pool2d",
     "nn.functional.fractional_max_pool3d",
-    "nn.functional.max_pool1d",
-    "nn.functional.max_pool2d",
-    "nn.functional.max_pool3d",
     "nn.functional.multi_head_attention_forward",
     "normal",
     "ormqr",
@@ -207,7 +204,7 @@ class TestOpInfo(TestCase):
         continue
       check_output = op.name not in random_ops
 
-      #print("[DEBUG] sample_input: ", sample_input)
+      # print("[DEBUG] sample_input: ", sample_input)
 
       # TODO: this is a workaround to skip int64 cast for linspace
       # reference: https://github.com/pytorch/xla/issues/7505#issuecomment-2400895692 and subsequent comments


### PR DESCRIPTION
Fix #8086.

Also possibly related to #8241.

To summarize the changes to max pool:
1. Dilation now correctly accounted for, including in padding calculation following the formula for output shape from [here](https://pytorch.org/docs/stable/generated/torch.nn.MaxPool2d.html)
2. Default stride is equal to kernel size
3. Indices are computed per-batch instead of across the entire input
4. Ties break towards higher indices (i.e. pick the higher index if there is more than 1 max value in a window). This is arbitrary but matches Torch's behavior on CPU.