### PR TITLE
Fix jax_env_context

### DIFF
--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -161,7 +161,8 @@ def _extract_backend_config(
 @contextmanager
 def _jax_env_context():
   try:
-    previous_skip_megascale_env = os.environ.get('SKIP_MEGASCALE_PJRT_CLIENT', None)
+    previous_skip_megascale_env = os.environ.get('SKIP_MEGASCALE_PJRT_CLIENT',
+                                                 None)
     os.environ['SKIP_MEGASCALE_PJRT_CLIENT'] = 'true'
     yield
   finally:

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -161,10 +161,14 @@ def _extract_backend_config(
 @contextmanager
 def _jax_env_context():
   try:
+    previous_skip_megascale_env = os.environ.get('SKIP_MEGASCALE_PJRT_CLIENT', None)
     os.environ['SKIP_MEGASCALE_PJRT_CLIENT'] = 'true'
     yield
   finally:
-    os.environ.pop('SKIP_MEGASCALE_PJRT_CLIENT', None)
+    if previous_skip_megascale_env:
+      os.environ['SKIP_MEGASCALE_PJRT_CLIENT'] = previous_skip_megascale_env
+    else:
+      os.environ.pop('SKIP_MEGASCALE_PJRT_CLIENT', None)
 
 
 def requires_jax(func: Callable) -> Callable:


### PR DESCRIPTION
Set SKIP_MEGASCALE_PJRT_CLIENT to the original environment variable before entering jax_env_context