### PR TITLE
Remove xla_mark_sharding_dynamo_custom_op

### DIFF
--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2265,35 +2265,6 @@ void InitXlaModuleBindings(py::module m) {
         output->SetShardingSpec(XLATensor::ShardingSpec(sharding, full_shape));
         return bridge::AtenFromXlaTensor(output);
       });
-  m.def("_xla_mark_sharding_dynamo_custom_op",
-        [](const at::Tensor& input, const py::list& tile_assignment,
-           const py::list& group_assignment, const py::list& replication_groups,
-           int sharding_type) {
-          c10::List<at::IntArrayRef> tile_assignment_list =
-              c10::List<at::IntArrayRef>();
-          for (auto t : tile_assignment) {
-            tile_assignment_list.push_back(
-                at::IntArrayRef(t.cast<std::vector<int64_t>>()));
-          }
-
-          c10::List<at::IntArrayRef> group_assignment_list =
-              c10::List<at::IntArrayRef>();
-          for (auto t : group_assignment) {
-            group_assignment_list.push_back(
-                at::IntArrayRef(t.cast<std::vector<int64_t>>()));
-          }
-
-          c10::List<at::IntArrayRef> replication_groups_list =
-              c10::List<at::IntArrayRef>();
-          for (auto t : replication_groups) {
-            replication_groups_list.push_back(
-                at::IntArrayRef(t.cast<std::vector<int64_t>>()));
-          }
-
-          ShardingUtil::XlaMarkShardingDynamoCustomOp(
-              input, tile_assignment_list, group_assignment_list,
-              replication_groups_list, sharding_type);
-        });
   m.def("_xla_clear_sharding", [](const at::Tensor& input) {
     XLATensorPtr xtensor = bridge::GetXlaTensor(input);
     xtensor->ClearShardingSpec();

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2265,7 +2265,7 @@ void InitXlaModuleBindings(py::module m) {
         output->SetShardingSpec(XLATensor::ShardingSpec(sharding, full_shape));
         return bridge::AtenFromXlaTensor(output);
       });
-  m.def("_xla_clear_sharding", [](const at::Tensor& input2) {
+  m.def("_xla_clear_sharding", [](const at::Tensor& input) {
     XLATensorPtr xtensor = bridge::GetXlaTensor(input);
     xtensor->ClearShardingSpec();
   });

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2265,7 +2265,7 @@ void InitXlaModuleBindings(py::module m) {
         output->SetShardingSpec(XLATensor::ShardingSpec(sharding, full_shape));
         return bridge::AtenFromXlaTensor(output);
       });
-  m.def("_xla_clear_sharding", [](const at::Tensor& input) {
+  m.def("_xla_clear_sharding", [](const at::Tensor& input2) {
     XLATensorPtr xtensor = bridge::GetXlaTensor(input);
     xtensor->ClearShardingSpec();
   });

--- a/torch_xla/csrc/xla_sharding_util.h
+++ b/torch_xla/csrc/xla_sharding_util.h
@@ -144,13 +144,6 @@ class ShardingUtil {
 
   static void SetAutoSharding();
   static bool GetAutoSharding();
-
-  //////////////////////////// Dynamo Integration ////////////////////////////
-
-  static void XlaMarkShardingDynamoCustomOp(
-      const at::Tensor& input, c10::List<at::IntArrayRef> tile_assignment,
-      c10::List<at::IntArrayRef> group_assignment,
-      c10::List<at::IntArrayRef> replication_groups, int64_t sharding_type);
 };
 
 }  // namespace torch_xla


### PR DESCRIPTION
AFAIK this is never used anywhere. There's a `torch.ops.xla.dynamo_mark_sharding` Python function that seems to be the way to mark sharding under dynamo.