### PR TITLE
Fix for triton pin update.

### DIFF
--- a/torch_xla/experimental/triton.py
+++ b/torch_xla/experimental/triton.py
@@ -147,8 +147,9 @@ def _spec_and_divisible_by_16(fn, i, arg):
 # Taken from: https://github.com/triton-lang/triton/blob/da40a1e984bf57c4708daf603eb427442025f99b/python/triton/runtime/jit.py#L187-L198
 # Newer triton versions removed this function.
 def _spec_and_equals_1(fn, i, arg):
-  return (i in fn.do_not_specialize and not isinstance(arg, bool) and
-          isinstance(arg, int) and arg == 1)
+  if i in fn.do_not_specialize:
+    return False
+  return not isinstance(arg, bool) and isinstance(arg, int) and arg == 1
 
 
 def triton_kernel_call_lowering(

--- a/torch_xla/experimental/triton.py
+++ b/torch_xla/experimental/triton.py
@@ -137,7 +137,7 @@ def _spec_and_divisible_by_16(fn, i, arg):
     return False
 
   if hasattr(arg, "data_ptr"):
-    return arg.data_ptr % 16 == 0
+    return arg.data_ptr() % 16 == 0
   if isinstance(arg, int):
     return arg % 16 == 0
 

--- a/torch_xla/experimental/triton.py
+++ b/torch_xla/experimental/triton.py
@@ -135,24 +135,20 @@ def get_or_create_triton_kernel(
 def _spec_and_divisible_by_16(fn, i, arg):
   if i in fn.do_not_specialize:
     return False
-  
+
   if hasattr(arg, "data_ptr"):
     return arg.data_ptr % 16 == 0
   if isinstance(arg, int):
     return arg % 16 == 0
-  
+
   return arg is None
 
 
 # Taken from: https://github.com/triton-lang/triton/blob/da40a1e984bf57c4708daf603eb427442025f99b/python/triton/runtime/jit.py#L187-L198
 # Newer triton versions removed this function.
 def _spec_and_equals_1(fn, i, arg):
-  return (
-      i in fn.do_not_specialize
-      and not isinstance(arg, bool)
-      and isinstance(arg, int)
-      and arg == 1
-  )
+  return (i in fn.do_not_specialize and not isinstance(arg, bool) and
+          isinstance(arg, int) and arg == 1)
 
 
 def triton_kernel_call_lowering(


### PR DESCRIPTION
Fix: #8820

Recently, PyTorch updated its triton pin https://github.com/pytorch/pytorch/pull/148971, making it so our triton tests fail. This PR makes the necessary modifications for accommodating the pin update.

In summary, this PR creates 2 functions `spec_and_divisible_by_16` and `spec_and_equals_1` which are copied from [the former `JITFunction._get_config()` function](https://github.com/triton-lang/triton/blob/da40a1e984bf57c4708daf603eb427442025f99b/python/triton/runtime/jit.py#L187-L198). That function (and their analogous versions) was removed from the recent versions of triton.

cc @bhavya01 