### PR TITLE
Adapt Neuron data type tests

### DIFF
--- a/test/neuron/test_neuron_data_types.py
+++ b/test/neuron/test_neuron_data_types.py
@@ -1,4 +1,3 @@
-import os
 import sys
 
 import torch
@@ -18,9 +17,12 @@ class NeuronXlaDataTypeTest(unittest.TestCase):
     self.assertEqual(t3.dtype, dtype)
 
     hlo_text = torch_xla._XLAC._get_xla_tensors_text([t3])
-    device_data_hlo = hlo_text.split('\n')[1]
-    self.assertIn('xla::device_data', device_data_hlo)
-    self.assertIn(op_xla_dtype, device_data_hlo)
+    device_data_irs = [
+        line for line in hlo_text.split('\n') if 'xla::device_data' in line
+    ]
+    self.assertEqual(len(device_data_irs), 2)
+    for device_data_ir in device_data_irs:
+      self.assertIn(op_xla_dtype, device_data_ir)
 
   def test_datatypes(self):
     test_cases = [(torch.float, "f32", torch.floor_divide),
@@ -35,38 +37,6 @@ class NeuronXlaDataTypeTest(unittest.TestCase):
     for dtype, op_xla_dtype, op in test_cases:
       with self.subTest(dtype=dtype, op_xla_dtype=op_xla_dtype, op=op):
         self._test_datatypes(dtype, op_xla_dtype, op)
-
-
-class NeuronXlaDataTypeBF16Test(unittest.TestCase):
-
-  def setUp(self):
-    self.original_env = os.environ.get("XLA_USE_BF16")
-    os.environ["XLA_USE_BF16"] = '1'
-
-  def tearDown(self):
-    if self.original_env is None:
-      del os.environ["XLA_USE_BF16"]
-    else:
-      os.environ["XLA_USE_BF16"] = self.original_env
-
-  def _test_datatypes_use_bf16(self, input_dtype):
-    t1 = torch.tensor([2, 3], dtype=input_dtype, device=xm.xla_device())
-    t2 = torch.tensor([2, 3], dtype=input_dtype, device=xm.xla_device())
-
-    t3 = torch.floor_divide(t1, t2)
-
-    self.assertEqual(t3.dtype, input_dtype)
-
-    hlo_text = torch_xla._XLAC._get_xla_tensors_text([t3])
-    device_data_hlo = hlo_text.split('\n')[1]
-    self.assertIn('xla::device_data', device_data_hlo)
-    self.assertIn('bf16', device_data_hlo)
-
-  def test_datatypes_use_bf16_double(self):
-    self._test_datatypes_use_bf16(torch.double)
-
-  def test_datatypes_use_bf16_float(self):
-    self._test_datatypes_use_bf16(torch.float)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In this PR, we make the assertions over the expected data type for Neuron tests more robust, and remove the BF16 tests, as I have already migrated, added additional coverage and generalized these to work for any device in a prior PR (https://github.com/pytorch/xla/blame/master/test/test_data_type.py#L31).

```
PJRT_DEVICE=NEURON, dtype=torch.float32, op_xla_dtype=f32, op=<built-in method floor_divide of type object at 0x7f31a081fec0>
PJRT_DEVICE=NEURON, dtype=torch.float64, op_xla_dtype=f32, op=<built-in method floor_divide of type object at 0x7f31a081fec0>
PJRT_DEVICE=NEURON, dtype=torch.int16, op_xla_dtype=s32, op=<built-in method add of type object at 0x7f31a081fec0>
PJRT_DEVICE=NEURON, dtype=torch.int32, op_xla_dtype=s32, op=<built-in method add of type object at 0x7f31a081fec0>
PJRT_DEVICE=NEURON, dtype=torch.int64, op_xla_dtype=s64, op=<built-in method add of type object at 0x7f31a081fec0>
PJRT_DEVICE=NEURON, dtype=torch.uint16, op_xla_dtype=u32, op=<built-in method add of type object at 0x7f31a081fec0>
PJRT_DEVICE=NEURON, dtype=torch.uint32, op_xla_dtype=u32, op=<built-in method add of type object at 0x7f31a081fec0>
PJRT_DEVICE=NEURON, dtype=torch.uint64, op_xla_dtype=u64, op=<built-in method add of type object at 0x7f31a081fec0>
.
----------------------------------------------------------------------
Ran 1 test in 9.655s

OK
```