### PR TITLE
8727 create a site map or centralize links in readme

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -10,3 +10,4 @@ assignees: ''
 ## 📚 Documentation
 
 <!-- A clear and concise description of what content is an issue. -->
+<!-- If you create new docs, consider adding them to https://github.com/pytorch/xla/blob/master/README.md#github-doc-map -->

--- a/README.md
+++ b/README.md
@@ -104,6 +104,22 @@ PyTorch/XLA remains an open-source project and we welcome contributions from the
 community to help maintain and improve the project. To contribute, please start
 with the [contributors guide](https://github.com/pytorch/xla/blob/master/CONTRIBUTING.md).
 
+## Github Doc Map
+
+Our github contains many useful docs on working with different aspects of PyTorch XLA, here is a list of useful docs spread around our repository:
+
+- [docs/source/perf](https://github.com/pytorch/xla/tree/master/docs/source/perf): documentation on performance spefic aspects of PyTorch/XLA such as: `AMP`, `DDP`, `Dynamo`, Fori loop, `FSDP`, quantization, recompilation, and `SPMD`
+- [docs/source/accelerators](https://github.com/pytorch/xla/tree/master/docs/source/accelerators): references to `GPU` and `TPU` accelerator documents.
+- [docs/source/features](https://github.com/pytorch/xla/tree/master/docs/source/features): documentation on distributed torch, pallas, scan, stable hlo, and triton.
+- [docs/source/contribute](https://github.com/pytorch/xla/tree/master/docs/source/contribute): documents on setting up PyTorch for development, and guides for lowering operations.
+- PJRT plugins:
+  - [CPU](https://github.com/pytorch/xla/blob/master/plugins/cpu/README.md)
+  - [CUDA](https://github.com/pytorch/xla/blob/master/plugins/cuda/README.md)
+- [torchax/docs](https://github.com/pytorch/xla/tree/master/torchax/docs): torchax documents
+  - [torchax/examples](https://github.com/pytorch/xla/tree/master/torchax/examples): torchax examples
+- [docs/source/learn](https://github.com/pytorch/xla/tree/master/docs/source/learn): docs for learning concepts associated with XLA, troubleshooting, pjrt, eager mode, and dynamic shape.
+
+
 ## Getting Started
 
 To update your existing training loop, make the following changes:


### PR DESCRIPTION
Add Github Doc Map to our initial README to make finding docs easier to new users.

I am also adding a note about it on our "Documentation" to bring attention to this section in the future for people creating new docs.