### PR TITLE
install jax dependency by default to unblock pytorch ci

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -87,6 +87,13 @@ function install_deps_pytorch_xla() {
   # XLA build requires Bazel
   # We use bazelisk to avoid updating Bazel version manually.
   sudo npm install -g @bazel/bazelisk
+
+  # Install JAX dependency since a few tests depend on it.
+  pip install 'torch_xla[pallas]' \
+  -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html \
+  -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
+  pip install xla/torchax
+
   # Only unlink if file exists
   if [[ -e /usr/bin/bazel ]]; then
     sudo unlink /usr/bin/bazel

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -128,12 +128,6 @@ jobs:
           set -x
 
           pip install expecttest unittest-xml-reporting
-          pip install torch_xla[pallas] \
-            -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html \
-            -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-          
-          # Install torchax
-          pip install pytorch/xla/torchax
 
           if [[ ! -z "$RUN_BENCHMARK_TESTS" ]]; then
             pip install -r pytorch/xla/benchmarks/requirements.txt

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -128,7 +128,12 @@ jobs:
           set -x
 
           pip install expecttest unittest-xml-reporting
-
+          pip install torch_xla[pallas] \
+            -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html \
+            -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
+          
+          # Install torchax
+          pip install pytorch/xla/torchax
           if [[ ! -z "$RUN_BENCHMARK_TESTS" ]]; then
             pip install -r pytorch/xla/benchmarks/requirements.txt
           fi

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -134,6 +134,7 @@ jobs:
           
           # Install torchax
           pip install pytorch/xla/torchax
+
           if [[ ! -z "$RUN_BENCHMARK_TESTS" ]]; then
             pip install -r pytorch/xla/benchmarks/requirements.txt
           fi


### PR DESCRIPTION
PyTorch CI is failing when they run XLA test: [https://hud.pytorch.org/failure?name=pull+%2F+linux-focal-py3_9-clang9-xla+%2F+test+[…]tures=%5B%22test_call_jax_pytree%22%2C%22TestJaxInterop%22%5D](https://hud.pytorch.org/failure?name=pull+%2F+linux-focal-py3_9-clang9-xla+%2F+test+%28xla%2C+1%2C+1%2C+lf.linux.12xlarge%29&jobName=linux-focal-py3_9-clang9-xla+%2F+test+%28xla%2C+1%2C+1%2C+lf.linux.12xlarge%29&failureCaptures=%5B%22test_call_jax_pytree%22%2C%22TestJaxInterop%22%5D). 

They are running the jax related test but didn't install the jax dependencies as we did in https://github.com/pytorch/xla/pull/8781/files.

In Pytorch CI, they use the xla pin and install the package dependency in https://github.com/pytorch/pytorch/blob/afa1eda901b81fa6ce1afe651d3c2da53fa92440/.ci/pytorch/test.sh#L1188. So we only need to make an update from our side.