### PR TITLE
Avoid destorying the cluster

### DIFF
--- a/infra/terraform_modules/arc_v4_container_cluster/main.tf
+++ b/infra/terraform_modules/arc_v4_container_cluster/main.tf
@@ -17,7 +17,7 @@ resource "google_container_cluster" "arc_v4_cluster" {
   location = "us-central2"
 
   remove_default_node_pool = true
-  initial_node_count       = var.min_tpu_nodes
+  initial_node_count       = 1
 
   release_channel {
     channel = "RAPID"


### PR DESCRIPTION
By keeping the inital_node_count unchanged as before https://github.com/pytorch/xla/commit/6a93dcfbc4764f8f503eaa480222ddc10da0f04e, terraform should not attempt to destroy the cluster and fail.