### PR TITLE
Add lowering for `bitwise_right_shift`.

### DIFF
--- a/codegen/xla_native_functions.yaml
+++ b/codegen/xla_native_functions.yaml
@@ -30,6 +30,7 @@ full_codegen:
   - binary_cross_entropy_backward
   - bitwise_not
   - bitwise_left_shift.Tensor
+  - bitwise_right_shift.Tensor
   - ceil
   - cholesky
   - clamp.Tensor

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2411,6 +2411,11 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     t2 = torch.randint(0, 10, (2,))
     self._test_no_fallback(torch.bitwise_left_shift, (t1, t2))
 
+  def test_bitwise_right_shift_no_fallback(self):
+    t1 = torch.randint(0, 10, (2, 2))
+    t2 = torch.randint(0, 10, (2,))
+    self._test_no_fallback(torch.bitwise_right_shift, (t1, t2))
+
 
 class MNISTComparator(nn.Module):
 

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -371,8 +371,8 @@ xla::Shape BitwiseLeftShiftTensorOutputShape(const torch::lazy::Value& input,
 xla::Shape BitwiseRightShiftTensorOutputShape(const torch::lazy::Value& input,
                                               const torch::lazy::Value& other) {
   return InferBinaryOpShape(input, other, [](xla::XlaOp one, xla::XlaOp two) {
-    return xla::ShiftRightArithmetic(one, two,
-                                     XlaHelpers::getBroadcastDimensions(one, two));
+    return xla::ShiftRightArithmetic(
+        one, two, XlaHelpers::getBroadcastDimensions(one, two));
   });
 }
 

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -368,6 +368,14 @@ xla::Shape BitwiseLeftShiftTensorOutputShape(const torch::lazy::Value& input,
   });
 }
 
+xla::Shape BitwiseRightShiftTensorOutputShape(const torch::lazy::Value& input,
+                                              const torch::lazy::Value& other) {
+  return InferBinaryOpShape(input, other, [](xla::XlaOp one, xla::XlaOp two) {
+    return xla::ShiftRightArithmetic(one, two,
+                                     XlaHelpers::getBroadcastDimensions(one, two));
+  });
+}
+
 xla::Shape CeilOutputShape(const torch::lazy::Value& input) {
   return GetXlaShape(input);
 }

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -96,6 +96,9 @@ xla::Shape BitwiseXorTensorOutputShape(const torch::lazy::Value& input,
 xla::Shape BitwiseLeftShiftTensorOutputShape(const torch::lazy::Value& input,
                                              const torch::lazy::Value& other);
 
+xla::Shape BitwiseRightShiftTensorOutputShape(const torch::lazy::Value& input,
+                                              const torch::lazy::Value& other);
+
 xla::Shape CeilOutputShape(const torch::lazy::Value& input);
 
 xla::Shape CholeskyOutputShape(const torch::lazy::Value& input,


### PR DESCRIPTION
This PR lowers `torch.bitwise_right_shift` operation. It introduces the following changes:

- Add `bitwise_right_shift.Tensor` to `full_codegen` section of _native_functions.yaml_
- Introduce the corresponding `*OuputShape()` and `*::Lower()` functions
- Add test confirming that we don't fallback 