### PR TITLE
fix CPP test build failure in upstream

### DIFF
--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -434,6 +434,7 @@ cc_test(
         ":util",
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",
+        "@tsl//tsl/platform:errors",
     ],
 )
 


### PR DESCRIPTION

PyTorch CI cpp test build failed with the following error:
```
[0m/var/lib/jenkins/workspace/xla/torch_xla/csrc/runtime/BUILD:429:8: Compiling torch_xla/csrc/runtime/util_test.cc failed: undeclared inclusion(s) in rule '//torch_xla/csrc/runtime:util_test':this rule is missing dependency declarations for the following files included by 'torch_xla/csrc/runtime/util_test.cc':  'external/tsl/tsl/platform/errors.h'
```

[Failure link](https://github.com/pytorch/pytorch/actions/runs/13958763842/job/39139474015?pr=149381).

One thing I don't understand is that why the failure is not happening in our side. Make the fix to quickly unblock PyTorch CI.