### PR TITLE
Cache HLO in xb.call_jax and support non-tensor args

### DIFF
--- a/torch_xla/core/xla_builder.py
+++ b/torch_xla/core/xla_builder.py
@@ -925,6 +925,7 @@ def jax_func_to_xla_computation(jax_func, args, kwargs, name=None):
 
 def _jax_to_hlo_cache_get_or_insert(jax_func, sample_inputs: tuple[Any, ...],
                                     input_tree_spec, get_hlo):
+  global _JAX_TO_HLO_CACHE
   # Use two layers of dictionary lookup.
   # The first layer uses the `jax_func`, which is only weakly referenced.
   # The second layer uses the sample inputs and the tree spec, which is strongly referenced.

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -160,6 +160,7 @@ def _extract_backend_config(
 
 @contextmanager
 def _jax_env_context():
+  # TODO(b/374631442): Get rid of this hack.
   try:
     previous_skip_megascale_env = os.environ.get('SKIP_MEGASCALE_PJRT_CLIENT',
                                                  None)


### PR DESCRIPTION
The main purpose is to replace the clunky manual XlaComputation object caching at
https://github.com/AI-Hypercomputer/torchprime/blob/b0bd47e3c732c56e75d8d2b315f05e06d485dd22/torchprime/torch_xla_models/experimental/custom_kernel.py#L16, and just write `xb.call_jax(some_jax_func)` and simply avoid repeated tracing there.

We can't reuse the tracing cache in `jax.jit` because we jit a wrapper and not `jax_func`. Also `as_serialized_hlo_module_proto` has overhead itself and it would be nice to avoid calling that repeatedly.

Also we improve `xb.call_jax` to support non-tensor arguments. These arguments are passed from `xb.call_jax` to the JAX function unchanged. They are considered "static arguments" and will be baked into the HLO.

Because they are considered static args, we'll re-trace the jax function whenever their values change.

Fixes https://github.com/pytorch/xla/issues/8795.