### PR TITLE
Add sliding window and logit soft capping to ragged paged attention kernel.

### DIFF
--- a/test/test_ragged_paged_attention_kernel_v2.py
+++ b/test/test_ragged_paged_attention_kernel_v2.py
@@ -23,7 +23,7 @@ def ceil_div(x, a):
 @jtu.with_config(jax_numpy_dtype_promotion="standard")
 class PagedAttentionKernelTest(jtu.JaxTestCase):
 
-  def _test_ragged_paged_attention(
+  def test_ragged_paged_attention(
       self,
       seq_lens,  # List[(q_len, kv_len)]
       num_heads,  # [num_q_heads, num_kv_heads]
@@ -68,12 +68,12 @@ class PagedAttentionKernelTest(jtu.JaxTestCase):
     )
     k_pages = jax.random.normal(
         k1,
-        (num_pages, page_size, num_kv_heads, head_dim),
+        (num_pages, page_size, num_kv_heads * head_dim),
         dtype=dtype,
     )
     v_pages = jax.random.normal(
         k2,
-        (num_pages, page_size, num_kv_heads, head_dim),
+        (num_pages, page_size, num_kv_heads * head_dim),
         dtype=dtype,
     )
     page_indices = jax.random.randint(

--- a/test/test_ragged_paged_attention_kernel_v2.py
+++ b/test/test_ragged_paged_attention_kernel_v2.py
@@ -1,0 +1,417 @@
+import random
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+from jax._src import test_util as jtu
+from torch_xla.experimental.pallas_kernels.ragged_paged_attention_v2 import (
+    ragged_paged_attention,
+    ref_ragged_paged_attention,
+    validate_inputs_on_runtime,
+)
+import jax.numpy as jnp
+
+
+jax.config.parse_flags_with_absl()
+
+
+def ceil_div(x, a):
+  assert a != 0
+  return (x + a - 1) // a
+
+
+@jtu.with_config(jax_numpy_dtype_promotion="standard")
+class PagedAttentionKernelTest(jtu.JaxTestCase):
+
+  def _test_ragged_paged_attention(
+      self,
+      seq_lens,  # List[(q_len, kv_len)]
+      num_heads,  # [num_q_heads, num_kv_heads]
+      head_dim,
+      page_size,
+      dtype,
+      num_pages,
+      *,
+      num_kv_pages_per_block=8,
+      num_queries_per_block=64,
+      vmem_limit_bytes=32 * 1024 * 1024,
+      max_num_batched_tokens=512,
+      max_num_seq=8,
+      sliding_window: int | None = None,
+      soft_cap: float | None = None,
+  ):
+    if not jtu.is_device_tpu_at_least(version=4):
+      self.skipTest("Expect TPUv4+")
+    cu_q_lens = [0]
+    kv_lens = []
+    for q_len, kv_len in seq_lens:
+      assert q_len <= kv_len
+      cu_q_lens.append(cu_q_lens[-1] + q_len)
+      kv_lens.append(kv_len)
+
+    max_num_batched_tokens = max(cu_q_lens[-1], max_num_batched_tokens)
+    max_num_seq = max(len(seq_lens), max_num_seq)
+    max_kv_len = max(kv_lens)
+    pages_per_seq = ceil_div(max_kv_len, page_size)
+    num_q_heads, num_kv_heads = num_heads
+
+    cu_q_lens = jnp.array(cu_q_lens, dtype=jnp.int32)
+    kv_lens = jnp.array(kv_lens, dtype=jnp.int32)
+    cu_q_lens = jnp.pad(cu_q_lens, (0, max_num_seq + 1 - cu_q_lens.shape[0]))
+    kv_lens = jnp.pad(kv_lens, (0, max_num_seq - kv_lens.shape[0]))
+    prng_key = jax.random.key(1234)
+    k0, k1, k2, k3 = jax.random.split(prng_key, 4)
+    q = jax.random.normal(
+        k0,
+        (max_num_batched_tokens, num_q_heads, head_dim),
+        dtype=dtype,
+    )
+    k_pages = jax.random.normal(
+        k1,
+        (num_pages, page_size, num_kv_heads, head_dim),
+        dtype=dtype,
+    )
+    v_pages = jax.random.normal(
+        k2,
+        (num_pages, page_size, num_kv_heads, head_dim),
+        dtype=dtype,
+    )
+    page_indices = jax.random.randint(
+        k3, (max_num_seq, pages_per_seq), 0, num_pages, dtype=jnp.int32
+    )
+
+    num_seqs = jnp.array([len(seq_lens)], dtype=jnp.int32)
+
+    validate_inputs_on_runtime(
+        q,
+        k_pages,
+        v_pages,
+        kv_lens,
+        page_indices,
+        cu_q_lens,
+        num_seqs,
+        sliding_window=sliding_window,
+        soft_cap=soft_cap,
+    )
+
+    actual_num_q_tokens = cu_q_lens[num_seqs[0]]
+    output = ragged_paged_attention(
+        q,
+        k_pages,
+        v_pages,
+        kv_lens,
+        page_indices,
+        cu_q_lens,
+        num_seqs=num_seqs,
+        num_kv_pages_per_block=num_kv_pages_per_block,
+        num_queries_per_block=num_queries_per_block,
+        vmem_limit_bytes=vmem_limit_bytes,
+        sliding_window=sliding_window,
+        soft_cap=soft_cap,
+    )[: actual_num_q_tokens]
+
+    expected = ref_ragged_paged_attention(
+        q,
+        k_pages,
+        v_pages,
+        kv_lens,
+        page_indices,
+        cu_q_lens,
+        num_seqs=num_seqs,
+        sliding_window=sliding_window,
+        soft_cap=soft_cap,
+    )
+    tols = {
+        "float32": 0.15,
+        "bfloat16": 0.2,
+    }
+    tol = tols[jnp.dtype(dtype).name]
+    self.assertAllClose(output, expected, atol=tol, rtol=tol)
+
+  @parameterized.product(
+      dtype=[jnp.float32, jnp.bfloat16],
+  )
+  def test_ragged_paged_attention_basic(self, dtype):
+    seq_lens = [(192, 328), (128, 180), (64, 255)]
+    num_heads = (32, 8)
+    head_dim = 128
+    page_size = 16
+    num_pages = 1000
+
+    self._test_ragged_paged_attention(
+        seq_lens,
+        num_heads,
+        head_dim,
+        page_size,
+        dtype,
+        num_pages,
+    )
+
+  @parameterized.product(
+      dtype=[jnp.float32, jnp.bfloat16],
+  )
+  def test_ragged_paged_attention_decode_only(self, dtype):
+    seq_lens = [
+        (1, 18),
+        (1, 129),
+        (1, 597),
+        (1, 122),
+        (1, 64),
+        (1, 322),
+        (1, 463),
+        (1, 181),
+        (1, 1107),
+        (1, 123),
+        (1, 31),
+        (1, 18),
+        (1, 1229),
+        (1, 229),
+        (1, 87),
+        (1, 1328),
+    ]
+    num_heads = (32, 8)
+    head_dim = 128
+    page_size = 16
+    num_pages = 1000
+
+    self._test_ragged_paged_attention(
+        seq_lens,
+        num_heads,
+        head_dim,
+        page_size,
+        dtype,
+        num_pages,
+    )
+
+  @parameterized.product(
+      dtype=[jnp.float32, jnp.bfloat16],
+  )
+  def test_ragged_paged_attention_prefill_only(self, dtype):
+    seq_lens = [
+        (5, 18),
+        (15, 129),
+        (120, 597),
+        (100, 122),
+        (21, 64),
+        (32, 322),
+        (251, 463),
+        (40, 181),
+        (64, 1107),
+        (99, 123),
+        (10, 31),
+        (5, 18),
+        (3, 1229),
+        (120, 229),
+        (9, 87),
+        (2, 1328),
+    ]
+    num_heads = (32, 8)
+    head_dim = 128
+    page_size = 16
+    num_pages = 1000
+
+    self._test_ragged_paged_attention(
+        seq_lens,
+        num_heads,
+        head_dim,
+        page_size,
+        dtype,
+        num_pages,
+    )
+
+  @parameterized.product(
+      dtype=[jnp.float32, jnp.bfloat16],
+  )
+  def test_ragged_paged_attention_mixed(self, dtype):
+    seq_lens = [
+        (5, 18),
+        (1, 129),
+        (120, 597),
+        (1, 122),
+        (1, 64),
+        (32, 322),
+        (251, 463),
+        (1, 181),
+        (1, 1107),
+        (99, 123),
+        (1, 31),
+        (5, 18),
+        (3, 1229),
+        (117, 229),
+        (1, 87),
+        (1, 1328),
+    ]
+    num_heads = (32, 8)
+    head_dim = 128
+    page_size = 16
+    num_pages = 1000
+
+    self._test_ragged_paged_attention(
+        seq_lens,
+        num_heads,
+        head_dim,
+        page_size,
+        dtype,
+        num_pages,
+    )
+
+  @parameterized.product(
+      num_seqs=[1, 5, 16],
+      # TODO(jevinjiang): Support more num_heads!
+      num_heads=[(32, 8), (32, 16), (12, 2), (4, 4)],
+      dtype=[jnp.float32, jnp.bfloat16],
+      num_kv_pages_per_block=[4, 8],
+      num_queries_per_block=[32, 64],
+  )
+  def test_ragged_paged_attention_complex(
+      self,
+      num_seqs,
+      num_heads,
+      dtype,
+      num_kv_pages_per_block,
+      num_queries_per_block,
+  ):
+    seq_lens = []
+    for _ in range(num_seqs):
+      q_len = random.randint(1, 100)
+      kv_len = q_len + random.randint(0, 50)
+      seq_lens.append((q_len, kv_len))
+    # TODO(jevinjiang): Support non-128 head_dim!
+    head_dim = 128
+    page_size = 16
+    num_pages = 1000
+
+    self._test_ragged_paged_attention(
+        seq_lens,
+        num_heads,
+        head_dim,
+        page_size,
+        dtype,
+        num_pages,
+        num_kv_pages_per_block=num_kv_pages_per_block,
+        num_queries_per_block=num_queries_per_block,
+    )
+
+  @parameterized.product(
+      num_kv_pages_per_block=[4, 8],
+      num_queries_per_block=[32, 64],
+      sliding_window=[None, 5, 128],
+  )
+  def test_ragged_paged_attention_sliding_window(
+      self,
+      num_kv_pages_per_block,
+      num_queries_per_block,
+      sliding_window: int | None,
+  ):
+    num_seqs = 5
+    num_heads = (4, 4)
+    dtype = jnp.float32
+    seq_lens = []
+    for _ in range(num_seqs):
+      q_len = random.randint(1, 100)
+      kv_len = q_len + random.randint(0, 50)
+      seq_lens.append((q_len, kv_len))
+    # TODO(jevinjiang): Support non-128 head_dim!
+    head_dim = 128
+    page_size = 16
+    num_pages = 1000
+
+    self._test_ragged_paged_attention(
+        seq_lens,
+        num_heads,
+        head_dim,
+        page_size,
+        dtype,
+        num_pages,
+        num_kv_pages_per_block=num_kv_pages_per_block,
+        num_queries_per_block=num_queries_per_block,
+        sliding_window=sliding_window,
+    )
+
+  @parameterized.product(
+      num_kv_pages_per_block=[4, 8],
+      num_queries_per_block=[32, 64],
+      soft_cap=[None, 50.0],
+  )
+  def test_ragged_paged_attention_logit_soft_capping(
+      self,
+      num_kv_pages_per_block,
+      num_queries_per_block,
+      soft_cap: float | None,
+  ):
+    num_heads = (12, 2)
+    num_seqs = 2
+    dtype = jnp.float32
+    seq_lens = []
+    for _ in range(num_seqs):
+      q_len = random.randint(1, 100)
+      kv_len = q_len + random.randint(0, 50)
+      seq_lens.append((q_len, kv_len))
+    head_dim = 128
+    page_size = 16
+    num_pages = 1000
+
+    self._test_ragged_paged_attention(
+        seq_lens,
+        num_heads,
+        head_dim,
+        page_size,
+        dtype,
+        num_pages,
+        num_kv_pages_per_block=num_kv_pages_per_block,
+        num_queries_per_block=num_queries_per_block,
+        soft_cap=soft_cap,
+    )
+
+  def test_ragged_paged_attention_sliding_window_should_be_positive(self):
+    dtype = jnp.float32
+    seq_lens = [(192, 328), (128, 180), (64, 255)]
+    num_heads = (32, 8)
+    head_dim = 128
+    page_size = 16
+    num_pages = 1000
+
+    with self.assertRaisesRegex(ValueError, "must be positive"):
+      self._test_ragged_paged_attention(
+          seq_lens,
+          num_heads,
+          head_dim,
+          page_size,
+          dtype,
+          num_pages,
+          sliding_window=0,
+      )
+
+    with self.assertRaisesRegex(ValueError, "must be positive"):
+      self._test_ragged_paged_attention(
+          seq_lens,
+          num_heads,
+          head_dim,
+          page_size,
+          dtype,
+          num_pages,
+          sliding_window=-1,
+      )
+
+  def test_ragged_paged_attention_soft_cap_cannot_be_zero(self):
+    dtype = jnp.float32
+    seq_lens = [(192, 328), (128, 180), (64, 255)]
+    num_heads = (32, 8)
+    head_dim = 128
+    page_size = 16
+    num_pages = 1000
+
+    with self.assertRaisesRegex(ValueError, "must not be 0.0"):
+      self._test_ragged_paged_attention(
+          seq_lens,
+          num_heads,
+          head_dim,
+          page_size,
+          dtype,
+          num_pages,
+          soft_cap=0.0,
+      )
+
+
+if __name__ == "__main__":
+  absltest.main(testLoader=jtu.JaxTestLoader())

--- a/test/test_ragged_paged_attention_kernel_v2.py
+++ b/test/test_ragged_paged_attention_kernel_v2.py
@@ -22,7 +22,7 @@ def ceil_div(x, a):
 @jtu.with_config(jax_numpy_dtype_promotion="standard")
 class PagedAttentionKernelTest(jtu.JaxTestCase):
 
-  def test_ragged_paged_attention(
+  def _test_ragged_paged_attention(
       self,
       seq_lens,  # List[(q_len, kv_len)]
       num_heads,  # [num_q_heads, num_kv_heads]

--- a/test/test_ragged_paged_attention_kernel_v2.py
+++ b/test/test_ragged_paged_attention_kernel_v2.py
@@ -11,7 +11,6 @@ from torch_xla.experimental.pallas_kernels.ragged_paged_attention_v2 import (
 )
 import jax.numpy as jnp
 
-
 jax.config.parse_flags_with_absl()
 
 
@@ -77,8 +76,7 @@ class PagedAttentionKernelTest(jtu.JaxTestCase):
         dtype=dtype,
     )
     page_indices = jax.random.randint(
-        k3, (max_num_seq, pages_per_seq), 0, num_pages, dtype=jnp.int32
-    )
+        k3, (max_num_seq, pages_per_seq), 0, num_pages, dtype=jnp.int32)
 
     num_seqs = jnp.array([len(seq_lens)], dtype=jnp.int32)
 
@@ -108,7 +106,7 @@ class PagedAttentionKernelTest(jtu.JaxTestCase):
         vmem_limit_bytes=vmem_limit_bytes,
         sliding_window=sliding_window,
         soft_cap=soft_cap,
-    )[: actual_num_q_tokens]
+    )[:actual_num_q_tokens]
 
     expected = ref_ragged_paged_attention(
         q,
@@ -129,8 +127,7 @@ class PagedAttentionKernelTest(jtu.JaxTestCase):
     self.assertAllClose(output, expected, atol=tol, rtol=tol)
 
   @parameterized.product(
-      dtype=[jnp.float32, jnp.bfloat16],
-  )
+      dtype=[jnp.float32, jnp.bfloat16],)
   def test_ragged_paged_attention_basic(self, dtype):
     seq_lens = [(192, 328), (128, 180), (64, 255)]
     num_heads = (32, 8)
@@ -148,8 +145,7 @@ class PagedAttentionKernelTest(jtu.JaxTestCase):
     )
 
   @parameterized.product(
-      dtype=[jnp.float32, jnp.bfloat16],
-  )
+      dtype=[jnp.float32, jnp.bfloat16],)
   def test_ragged_paged_attention_decode_only(self, dtype):
     seq_lens = [
         (1, 18),
@@ -184,8 +180,7 @@ class PagedAttentionKernelTest(jtu.JaxTestCase):
     )
 
   @parameterized.product(
-      dtype=[jnp.float32, jnp.bfloat16],
-  )
+      dtype=[jnp.float32, jnp.bfloat16],)
   def test_ragged_paged_attention_prefill_only(self, dtype):
     seq_lens = [
         (5, 18),
@@ -220,8 +215,7 @@ class PagedAttentionKernelTest(jtu.JaxTestCase):
     )
 
   @parameterized.product(
-      dtype=[jnp.float32, jnp.bfloat16],
-  )
+      dtype=[jnp.float32, jnp.bfloat16],)
   def test_ragged_paged_attention_mixed(self, dtype):
     seq_lens = [
         (5, 18),

--- a/torch_xla/experimental/pallas_kernels/ragged_paged_attention_v2.py
+++ b/torch_xla/experimental/pallas_kernels/ragged_paged_attention_v2.py
@@ -78,6 +78,7 @@ def ref_ragged_paged_attention(
     num_seqs: jax.Array,  # i32[1],
     *,
     sm_scale: float = 1.0,
+    sliding_window: int | None = None,
     mask_value: float = DEFAULT_MASK_VALUE,
 ):
   check_inputs_shapes(queries, k_pages, v_pages, kv_lens, page_indices,
@@ -104,7 +105,10 @@ def ref_ragged_paged_attention(
     q_span = (kv_len - q_len) + jax.lax.broadcasted_iota(
         jnp.int32, attn.shape, 1)
     kv_span = jax.lax.broadcasted_iota(jnp.int32, attn.shape, 2)
-    attn += jnp.where(q_span < kv_span, mask_value, 0.0)
+    mask = q_span < kv_span
+    if sliding_window is not None:
+      mask = jnp.logical_or(mask, q_span - sliding_window >= kv_span)
+    attn += jnp.where(mask, mask_value, 0.0)
     attn = jax.nn.softmax(attn, axis=-1).astype(v.dtype)
     out = jnp.einsum("hqk,khd->qhd", attn, v).astype(queries.dtype)
     outputs.append(out)
@@ -121,6 +125,7 @@ def validate_inputs_on_runtime(
     page_indices: jax.Array,  # i32[max_num_seqs, pages_per_seq]
     cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
     num_seqs,  # i32[1]
+    sliding_window: int | None = None,
 ):
   check_inputs_shapes(q, k_pages, v_pages, kv_lens, page_indices, cu_q_lens,
                       num_seqs)
@@ -145,6 +150,8 @@ def validate_inputs_on_runtime(
     if q_len > kv_len:
       raise ValueError(
           f"{q_len=} must be less or equal to {kv_len=} at sequence {i}.")
+  if sliding_window is not None and sliding_window <= 0:
+    raise ValueError(f"{sliding_window=} must be positive.")
 
 
 # Expect to run these checks during compile time.
@@ -212,6 +219,7 @@ def ragged_paged_attention_kernel(
     m_ref,  # [num_kv_heads_per_blk, num_q_per_blk * num_q_heads_per_kv_head, 128]
     *,
     sm_scale: float,
+    sliding_window: int | None = None,
     mask_value: float,
 ):
   num_q_per_blk, num_q_heads_per_blk, head_dim = q_ref.shape
@@ -392,6 +400,9 @@ def ragged_paged_attention_kernel(
           1,
       )
       causal_mask = row_ids < col_ids
+      if sliding_window is not None:
+        causal_mask = jnp.logical_or(causal_mask,
+                                     row_ids - sliding_window>=col_ids)
       qk += jnp.where(causal_mask, mask_value, 0.0)
       m_curr = jnp.max(qk, axis=1, keepdims=True)
       s_curr = jnp.exp(qk - m_curr)
@@ -553,6 +564,7 @@ def get_min_q_heads_per_blk(num_q_heads, q_dtype, num_q_heads_per_kv_head):
         "num_kv_pages_per_block",
         "num_queries_per_block",
         "vmem_limit_bytes",
+        "sliding_window",
     ],
 )
 def ragged_paged_attention(
@@ -565,6 +577,7 @@ def ragged_paged_attention(
     num_seqs: jax.Array,  # i32[1]
     *,
     sm_scale: float = 1.0,
+    sliding_window: int | None = None,
     mask_value: float = DEFAULT_MASK_VALUE,
     num_kv_pages_per_block: int = 16,
     num_queries_per_block: int = 128,
@@ -583,6 +596,7 @@ def ragged_paged_attention(
       kv_lens, only the first num_seqs+1 values are valid.
     num_seqs: the dynamic number of sequences.
     sm_scale: the softmax scale which will be applied to the Q@K^T.
+    sliding_window: the sliding window size for the attention.
     mask_value: mask value for causal mask.
     num_kv_pages_per_block: number of kv pages to be processed in one flash
       attention block in the pallas kernel.
@@ -655,6 +669,7 @@ def ragged_paged_attention(
       functools.partial(
           ragged_paged_attention_kernel,
           sm_scale=sm_scale,
+          sliding_window=sliding_window,
           mask_value=mask_value,
       ),
       grid_spec=pltpu.PrefetchScalarGridSpec(

--- a/torch_xla/experimental/pallas_kernels/ragged_paged_attention_v2.py
+++ b/torch_xla/experimental/pallas_kernels/ragged_paged_attention_v2.py
@@ -409,7 +409,7 @@ def ragged_paged_attention_kernel(
       causal_mask = row_ids < col_ids
       if sliding_window is not None:
         causal_mask = jnp.logical_or(causal_mask,
-                                     row_ids - sliding_window>=col_ids)
+                                     row_ids - sliding_window >= col_ids)
       if soft_cap is not None:
         qk = soft_cap * jnp.tanh(qk / soft_cap)
       qk += jnp.where(causal_mask, mask_value, 0.0)


### PR DESCRIPTION
Migrate the sliding window and logit soft capping from https://github.com/jax-ml/jax/blob/main/jax/experimental/pallas/ops/tpu/ragged_paged_attention.py. 

cc @miladm, @bythew3i
