### PR TITLE
Include torchax in torch_xla

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -115,9 +115,6 @@ function install_post_deps_pytorch_xla() {
   pip install 'torch_xla[pallas]' \
   -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html \
   -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-
-  # TODO(https://github.com/pytorch/xla/issues/8831): Remove this when torchax is part of torch_xla.
-  pip install xla/torchax
 }
 
 function build_torch_xla() {

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -106,10 +106,10 @@ function install_pre_deps_pytorch_xla() {
 }
 
 
+# TODO(https://github.com/pytorch/xla/issues/8934): Remove PyTorch usage of this function, then
+# remove this function from the script.
 function install_post_deps_pytorch_xla() {
-  # Install dependencies after we built torch_xla. This is due to installing
-  # those packages can potentially trigger `pip install torch_xla` if torch_xla
-  # is not detected in the system.
+  true
 }
 
 function build_torch_xla() {

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -110,11 +110,6 @@ function install_post_deps_pytorch_xla() {
   # Install dependencies after we built torch_xla. This is due to installing
   # those packages can potentially trigger `pip install torch_xla` if torch_xla
   # is not detected in the system.
-
-  # Install JAX dependency since a few tests depend on it.
-  pip install 'torch_xla[pallas]' \
-  -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html \
-  -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
 }
 
 function build_torch_xla() {

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -128,10 +128,7 @@ jobs:
           set -x
 
           pip install expecttest unittest-xml-reporting
-          pip install torch_xla[pallas] \
-            -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html \
-            -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-          
+
           if [[ ! -z "$RUN_BENCHMARK_TESTS" ]]; then
             pip install -r pytorch/xla/benchmarks/requirements.txt
           fi

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -132,10 +132,6 @@ jobs:
             -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html \
             -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
           
-          # Install torchax
-          # TODO(https://github.com/pytorch/xla/issues/8831): Remove this when torchax is part of torch_xla.
-          pip install pytorch/xla/torchax
-
           if [[ ! -z "$RUN_BENCHMARK_TESTS" ]]; then
             pip install -r pytorch/xla/benchmarks/requirements.txt
           fi

--- a/.github/workflows/_test_requiring_torch_cuda.yml
+++ b/.github/workflows/_test_requiring_torch_cuda.yml
@@ -91,6 +91,7 @@ jobs:
         shell: bash
         run: |
           set -x
+          # TODO: Add these in setup.py. In fact, add this to setup.py of plugins/cuda first.
           pip install -U --pre jax jaxlib "jax-cuda12-plugin[with_cuda]" jax-cuda12-pjrt -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
         if: ${{ matrix.run_triton_tests }}
       - name: Install Triton

--- a/.github/workflows/_test_requiring_torch_cuda.yml
+++ b/.github/workflows/_test_requiring_torch_cuda.yml
@@ -91,7 +91,6 @@ jobs:
         shell: bash
         run: |
           set -x
-          # TODO: Add these in setup.py. In fact, add this to setup.py of plugins/cuda first.
           pip install -U --pre jax jaxlib "jax-cuda12-plugin[with_cuda]" jax-cuda12-pjrt -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
         if: ${{ matrix.run_triton_tests }}
       - name: Install Triton

--- a/.github/workflows/_test_requiring_torch_cuda.yml
+++ b/.github/workflows/_test_requiring_torch_cuda.yml
@@ -91,9 +91,7 @@ jobs:
         shell: bash
         run: |
           set -x
-          pip install -U --pre jaxlib -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-          pip install -U --pre jax-cuda12-pjrt jax-cuda12-plugin -f https://storage.googleapis.com/jax-releases/jax_cuda_plugin_nightly_releases.html
-          pip install -U --pre jax -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
+          pip install -U --pre jax jaxlib "jax-cuda12-plugin[with_cuda]" jax-cuda12-pjrt -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
         if: ${{ matrix.run_triton_tests }}
       - name: Install Triton
         shell: bash

--- a/.github/workflows/_tpu_ci.yml
+++ b/.github/workflows/_tpu_ci.yml
@@ -27,10 +27,6 @@ jobs:
           pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
           pip install torch_xla[tpu] -f https://storage.googleapis.com/libtpu-wheels/index.html -f https://storage.googleapis.com/libtpu-releases/index.html
           pip install --upgrade protobuf
-
-          # torchax is needed for call_jax tests.
-          # TODO(https://github.com/pytorch/xla/issues/8831): Remove this when torchax is part of torch_xla.
-          pip install pytorch/xla/torchax
       - name: Run Tests
         env:
           PJRT_DEVICE: TPU

--- a/.github/workflows/_tpu_ci.yml
+++ b/.github/workflows/_tpu_ci.yml
@@ -23,8 +23,7 @@ jobs:
           pip install --upgrade pip
           pip install fsspec
           pip install rich
-          # Jax nightly is needed for pallas tests.
-          pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
+          # libtpu is needed for pallas tests.
           pip install torch_xla[tpu] -f https://storage.googleapis.com/libtpu-wheels/index.html -f https://storage.googleapis.com/libtpu-releases/index.html
           pip install --upgrade protobuf
       - name: Run Tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4,16 +4,10 @@ on:
     branches:
       - master
       - r[0-9]+.[0-9]+
-    paths-ignore:
-      - 'experimental/**'
-      - 'torchax/**'
   push:
     branches:
       - master
       - r[0-9]+.[0-9]+
-    paths-ignore:
-      - 'experimental/**'
-      - 'torchax/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/torch_xla2.yml
+++ b/.github/workflows/torch_xla2.yml
@@ -3,14 +3,10 @@ on:
     branches:
       - master
       - r[0-9]+.[0-9]+
-    paths:
-      - 'torchax/**'
   push:
     branches:
       - master
       - r[0-9]+.[0-9]+
-    paths:
-      - 'torchax/**'
   workflow_dispatch:
 
 concurrency:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,10 +87,6 @@ using either VS Code or a local container:
   pip install torch_xla[tpu] \
     -f https://storage.googleapis.com/libtpu-wheels/index.html \
     -f https://storage.googleapis.com/libtpu-releases/index.html
-  # Optional: if you're using custom kernels, install pallas dependencies
-  pip install torch_xla[pallas] \
-    -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html \
-    -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
   ```
 
 * If you are running on a TPU VM, ensure `torch` and `torch_xla` were built and 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,6 @@ To install PyTorch/XLA stable build in a new TPU VM:
 pip install torch~=2.6.0 'torch_xla[tpu]~=2.6.0' \
   -f https://storage.googleapis.com/libtpu-releases/index.html \
   -f https://storage.googleapis.com/libtpu-wheels/index.html
-
-# Optional: if you're using custom kernels, install pallas dependencies
-pip install 'torch_xla[pallas]' \
-  -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html \
-  -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
 ```
 
 To install PyTorch/XLA nightly build in a new TPU VM:
@@ -43,11 +38,6 @@ pip install --pre torch torchvision --index-url https://download.pytorch.org/whl
 pip install 'torch_xla[tpu] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev-cp310-cp310-linux_x86_64.whl' \
   -f https://storage.googleapis.com/libtpu-releases/index.html \
   -f https://storage.googleapis.com/libtpu-wheels/index.html
-
-# Optional: if you're using custom kernels, install pallas dependencies
-pip install 'torch_xla[pallas]' \
-  -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html \
-  -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
 ```
 
 ### C++11 ABI builds

--- a/docs/source/features/pallas.md
+++ b/docs/source/features/pallas.md
@@ -104,12 +104,8 @@ for effective memory management with KV cache.
 ## Dependencies
 
 The Pallas integration depends on JAX to function. However, not every
-JAX version is compatible with your installed PyTorch/XLA. To install
-the proper JAX:
-
-``` bash
-pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-```
+JAX version is compatible with your installed PyTorch/XLA. PyTorch/XLA therefore
+pins specific versions of JAX in its setup script.
 
 ## Write your own Pallas kernels
 

--- a/docs/source/features/pallas.md
+++ b/docs/source/features/pallas.md
@@ -104,8 +104,12 @@ for effective memory management with KV cache.
 ## Dependencies
 
 The Pallas integration depends on JAX to function. However, not every
-JAX version is compatible with your installed PyTorch/XLA. PyTorch/XLA therefore
-pins specific versions of JAX in its setup script.
+JAX version is compatible with your installed PyTorch/XLA. To install
+the proper JAX:
+
+``` bash
+pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
+```
 
 ## Write your own Pallas kernels
 

--- a/scripts/build_developer.sh
+++ b/scripts/build_developer.sh
@@ -40,10 +40,5 @@ pip install torch_xla[tpu] \
   -f https://storage.googleapis.com/libtpu-wheels/index.html \
   -f https://storage.googleapis.com/libtpu-releases/index.html
 
-# Install Pallas dependencies
-pip install torch_xla[pallas] \
-  -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html \
-  -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-
 # Test that the library is installed correctly.
 python3 -c 'import torch_xla; print(torch_xla.devices()); import torchax; torchax.enable_globally()'

--- a/scripts/build_developer.sh
+++ b/scripts/build_developer.sh
@@ -26,11 +26,12 @@ fi
 
 # Install torch_xla
 cd pytorch/xla
-pip uninstall torch_xla -y
+pip uninstall torch_xla torchax torch_xla2 -y
 
-# Optional: build the wheel.
+# Build the wheel too, which is useful for other testing purposes.
 python3 setup.py bdist_wheel
 
+# Link the source files for local development.
 python3 setup.py develop
 
 # libtpu is needed to talk to the TPUs. If TPUs are not present,
@@ -45,4 +46,4 @@ pip install torch_xla[pallas] \
   -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
 
 # Test that the library is installed correctly.
-python3 -c 'import torch_xla as xla; print(xla.device())'
+python3 -c 'import torch_xla; import torchax; print(torch_xla.device())'

--- a/scripts/build_developer.sh
+++ b/scripts/build_developer.sh
@@ -21,7 +21,7 @@ cd ..
 if [ -d "vision" ]; then
   cd vision
   python3 setup.py develop
-  cd .. 
+  cd ..
 fi
 
 # Install torch_xla
@@ -46,4 +46,4 @@ pip install torch_xla[pallas] \
   -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
 
 # Test that the library is installed correctly.
-python3 -c 'import torch_xla; import torchax; print(torch_xla.device())'
+python3 -c 'import torch_xla; print(torch_xla.devices()); import torchax; torchax.enable_globally()'

--- a/setup.py
+++ b/setup.py
@@ -369,6 +369,9 @@ setup(
         # importlib.metadata backport required for PJRT plugin discovery prior
         # to Python 3.10
         'importlib_metadata>=4.6;python_version<"3.10"',
+        # Some torch operations are lowered to HLO via JAX.
+        f'jaxlib=={_jaxlib_version}',
+        f'jax=={_jax_version}',
     ],
     package_data={
         'torch_xla': ['lib/*.so*',],
@@ -390,6 +393,8 @@ setup(
             f'libtpu=={_libtpu_version}',
             'tpu-info',
         ],
+        # As of https://github.com/pytorch/xla/pull/8895, jax is always a dependency of torch_xla.
+        # However, this no-op extras_require entrypoint is left here for backwards compatibility.
         # pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
         'pallas': [f'jaxlib=={_jaxlib_version}', f'jax=={_jax_version}'],
     },

--- a/setup.py
+++ b/setup.py
@@ -272,6 +272,16 @@ cwd = os.path.dirname(os.path.abspath(__file__))
 with open(os.path.join(cwd, "README.md"), encoding="utf-8") as f:
   long_description = f.read()
 
+# Finds torch_xla and its subpackages
+packages_to_include = find_packages(include=['torch_xla*'])
+# Explicitly add torchax
+packages_to_include.append('torchax')
+
+# Map the top-level 'torchax' package name to its source location
+torchax_dir = os.path.join(cwd, 'torchax')
+package_dir_mapping = {'torch_xla': os.path.join(cwd, 'torch_xla')}
+package_dir_mapping['torchax'] = os.path.join(torchax_dir, 'torchax')
+
 setup(
     name=os.environ.get('TORCH_XLA_PACKAGE_NAME', 'torch_xla'),
     version=version,
@@ -297,7 +307,8 @@ setup(
         "Programming Language :: Python :: 3",
     ],
     python_requires=">=3.8.0",
-    packages=find_packages(include=['torch_xla*']),
+    packages=packages_to_include,
+    package_dir=package_dir_mapping,
     ext_modules=[
         BazelExtension('//:_XLAC.so'),
         BazelExtension('//:_XLAC_cuda_functions.so'),

--- a/setup.py
+++ b/setup.py
@@ -269,7 +269,7 @@ with open(os.path.join(cwd, "README.md"), encoding="utf-8") as f:
 # Finds torch_xla and its subpackages
 packages_to_include = find_packages(include=['torch_xla*'])
 # Explicitly add torchax
-packages_to_include.append('torchax')
+packages_to_include.extend(find_packages(where='torchax', include=['torchax*']))
 
 # Map the top-level 'torchax' package name to its source location
 torchax_dir = os.path.join(cwd, 'torchax')

--- a/test/tpu/xla_test_job.yaml
+++ b/test/tpu/xla_test_job.yaml
@@ -43,7 +43,6 @@ spec:
     - |
       pip install expecttest==0.1.6
       pip install rich
-      pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
 
       cd /src/pytorch/xla
     volumeMounts:

--- a/torchax/README.md
+++ b/torchax/README.md
@@ -1,7 +1,7 @@
 # torchax: Running PyTorch on TPU
 
-**torchax!** is a backend for PyTorch, allowing users to run
-PyTorch on Google CloudTPUs. **torchax!** is also a library for providing
+**torchax** is a backend for PyTorch, allowing users to run
+PyTorch on Google CloudTPUs. **torchax** is also a library for providing
 graph-level interoperability between PyTorch and Jax.
 
 This means, with **torchax** you can:
@@ -133,7 +133,7 @@ Then, a `jax` device will be available to use
 
 ```python
 inputs = torch.randn(3, 3, 28, 28, device='jax')
-m = MyModel()
+m = MyModel().to('jax')
 res = m(inputs)
 print(type(res))  # outputs torchax.tensor.Tensor
 ```
@@ -220,6 +220,7 @@ then the subsequent computation with inputs of same shape will be fast.
 
 # Citation:
 
+```
 @software{torchax,
   author = {Han Qi, Chun-nien Chan, Will Cromar, Manfei Bai, Kevin Gleanson},
   title = {torchax: PyTorch on TPU and Jax interoperability},
@@ -227,6 +228,7 @@ then the subsequent computation with inputs of same shape will be fast.
   version = {0.0.4},
   date = {2025-02-24},
 }
+```
 
 # Maintainers & Contributors:
 
@@ -238,6 +240,7 @@ fellow Googlers using [Google's 20% project policy](https://ebsedu.org/blog/goog
 
 Here is the full list of contributors by 2025-02-25.
 
+```
 Han Qi (qihqi), Pytorch / XLA
 Manfei Bai (manfeibai), Pytorch / XLA
 Will Cromar (will-cromar), Meta
@@ -274,3 +277,4 @@ Jim Lin (jimlinntu), Google(20%)
 Fanhai Lu (FanhaiLu1), Google Cloud
 DeWitt Clinton (dewitt), Google PyTorch
 Aman Gupta (aman2930) , Google(20%)
+```

--- a/torchax/pyproject.toml
+++ b/torchax/pyproject.toml
@@ -41,7 +41,7 @@ path = "torchax/__init__.py"
 
 [project.optional-dependencies]
 cpu = ["jax[cpu]>=0.4.30", "jax[cpu]"]
-# Add libtpu index `-f https://storage.googleapis.com/libtpu-releases/index.html`
+# Add libtpu index `-f https://storage.googleapis.com/libtpu-wheels/index.html -f https://storage.googleapis.com/libtpu-releases/index.html`
 tpu = ["jax[cpu]>=0.4.30", "jax[tpu]"]
 cuda = ["jax[cpu]>=0.4.30", "jax[cuda12]"]
 odml = ["jax[cpu]>=0.4.30", "jax[cpu]"]


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/8831

This PR changes the `torch_xla` build such that `torchax` is automatically included, instead of being a separate install.

This motivation is to support features like https://github.com/pytorch/xla/pull/8893 and others that use `xb.call_jax` and requires `torchax`. Instead of yelling at the user to install `torchax`, it's easier to just install it for them.

Because `torchax` uses `jax`, we'll just automatically install `jax` all the time. As a result, I removed all the `pip install torch_xla[pallas]` and `pip install torchax` commands from our CI scripts in this repo.

This PR should be backwards compatible because any existing standalone `torchax` installs will be overwritten to use the copy from `torch_xla`, and any `pip install torch_xla[pallas]` commands will become no-op instead of failing.
