### PR TITLE
Remove dynamic grid

### DIFF
--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -669,10 +669,6 @@ class PallasTest(parameterized.TestCase):
     page_indices_xla = page_indices.to("xla")
     cu_q_lens_xla = cu_q_lens.to("xla")
     num_seqs_xla = torch.tensor([num_seqs], dtype=torch.int32).to("xla")
-    sliding_window = sliding_window
-    soft_cap = soft_cap
-    # Test mask_value
-    mask_value = None
 
     if use_dynamo:
 
@@ -686,7 +682,6 @@ class PallasTest(parameterized.TestCase):
           sm_scale=sm_scale,
           sliding_window=sliding_window,
           soft_cap=soft_cap,
-          mask_value=mask_value,
           use_kernel=True,
           num_kv_pages_per_block=num_kv_pages_per_block,
           num_queries_per_block=num_queries_per_block,
@@ -701,7 +696,6 @@ class PallasTest(parameterized.TestCase):
             sm_scale=sm_scale,
             sliding_window=sliding_window,
             soft_cap=soft_cap,
-            mask_value=mask_value,
             use_kernel=use_kernel,
             num_kv_pages_per_block=num_kv_pages_per_block,
             num_queries_per_block=num_queries_per_block,
@@ -722,7 +716,6 @@ class PallasTest(parameterized.TestCase):
         sm_scale=sm_scale,
         sliding_window=sliding_window,
         soft_cap=soft_cap,
-        mask_value=mask_value,
         use_kernel=True,
         num_kv_pages_per_block=num_kv_pages_per_block,
         num_queries_per_block=num_queries_per_block,
@@ -738,7 +731,6 @@ class PallasTest(parameterized.TestCase):
         sm_scale=sm_scale,
         sliding_window=sliding_window,
         soft_cap=soft_cap,
-        mask_value=mask_value,
         use_kernel=False,
     )
 
@@ -778,7 +770,6 @@ class PallasTest(parameterized.TestCase):
                 sm_scale=sm_scale,
                 sliding_window=sliding_window,
                 soft_cap=soft_cap,
-                mask_value=mask_value,
             )[:cu_q_lens[num_seqs]].astype(jnp.float32))).to(dtype)
     jax_kernel_output_cpu = jax_kernel_output.cpu()
 

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -1015,14 +1015,8 @@ def ragged_paged_attention(
   )
 
   seq_buf_idx = torch.tensor([0, 0], dtype=torch.int32).to("xla")
-  num_q_blks = torch.tensor(
-      [(cu_q_lens[num_seqs[0]] + num_queries_per_block - 1) //
-       num_queries_per_block],
-      dtype=torch.int32).to("xla")
-
   output = torch_xla._XLAC._xla_tpu_custom_call(
       [
-          num_q_blks,  # dynamic grid
           kv_lens,
           page_indices,
           cu_q_lens,

--- a/torch_xla/experimental/pallas_kernels/ragged_paged_attention_v2.py
+++ b/torch_xla/experimental/pallas_kernels/ragged_paged_attention_v2.py
@@ -295,7 +295,9 @@ def ragged_paged_attention_kernel(
 
   def is_cur_q_blk_needed(q_states):
     done, cur_seq_idx, _ = q_states
-    return jnp.logical_and(done == 0, cur_seq_idx < num_seqs)
+    should_run = jnp.logical_and(q_len_start < cu_q_lens_ref[num_seqs],
+                                 cur_seq_idx < num_seqs)
+    return jnp.logical_and(done == 0, should_run)
 
   def compute_with_cur_q_blk(q_states):
     done, cur_seq_idx, cur_buf_idx = q_states
@@ -640,14 +642,14 @@ def ragged_paged_attention(
   check_inputs_shapes(q, kv_pages, kv_lens, page_indices, cu_q_lens, num_seqs)
   if mask_value is None:
     mask_value = DEFAULT_MASK_VALUE
-  _, num_q_heads, head_dim = q.shape
+  num_q, num_q_heads, head_dim = q.shape
   _, page_size, num_combined_kv_heads, _ = kv_pages.shape
   assert num_combined_kv_heads % 2 == 0
   num_kv_heads = num_combined_kv_heads // 2
   num_q_per_blk = num_queries_per_block
   num_kv_pages_per_blk = num_kv_pages_per_block
   num_q_heads_per_kv_head = num_q_heads // num_kv_heads
-  num_q_blks = cdiv(cu_q_lens[num_seqs[0]], num_q_per_blk)
+  num_q_blks = cdiv(num_q, num_q_per_blk)
   num_q_heads_per_blk, num_combined_kv_heads_per_blk = get_min_heads_per_blk(
       num_q_heads, num_combined_kv_heads, q.dtype, kv_pages.dtype)
   assert num_combined_kv_heads_per_blk % 2 == 0


### PR DESCRIPTION
The call site of the kernel probably did not check the `cu_q_lens[num_seqs[0]]` (AKA the actual total num batched q len) is <= `max_num_batched_tokens`. This could cause hang if we use dynamic grid in kernel.

**We should consider adding runtime validation before calling the kernel to prevent cases like this.**
For now, we just roll back the dynamic grid change to make the integration work.

Tested:
```
python test/test_pallas.py -v -k PallasTest.test_ragged_paged_attention_wrapper
```