### PR TITLE
[Build] Pin cmake to build PyTorch

### DIFF
--- a/infra/ansible/config/pip.yaml
+++ b/infra/ansible/config/pip.yaml
@@ -6,7 +6,7 @@ pip:
       - astunparse
       - cffi
       - cloud-tpu-client
-      - cmake
+      - cmake==3.31.6
       - coverage
       - dataclasses
       - expecttest==0.1.3


### PR DESCRIPTION
Upstream build failed with latest cmake version (4.0.0) Pin the same version as upstream now https://github.com/pytorch/pytorch/pull/150158