### PR TITLE
Lower `isneginf()`.

### DIFF
--- a/codegen/xla_native_functions.yaml
+++ b/codegen/xla_native_functions.yaml
@@ -62,6 +62,7 @@ full_codegen:
   - hardswish_backward
   - inverse
   - isnan
+  - isneginf
   - leaky_relu
   - le.Scalar
   - le.Tensor

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2416,6 +2416,14 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     t2 = torch.randint(0, 10, (2,))
     self._test_no_fallback(torch.bitwise_right_shift, (t1, t2))
 
+  def test_isneginf_no_fallback(self):
+    t = torch.rand(10)
+    # Scale the tensor elements.
+    t = t * 100_000
+    # Convert to a lower precision data-type so as to get a few infs.
+    t = t.to(torch.float16)
+    self._test_no_fallback(torch.isneginf, (t,))
+
 
 class MNISTComparator(nn.Module):
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -127,6 +127,7 @@ allowed_opinfo = get_allowed_ops_map(
     AllowedOpInfoEntry('imag'),
     AllowedOpInfoEntry('inverse'),
     AllowedOpInfoEntry('isin'),
+    AllowedOpInfoEntry('isneginf'),
     AllowedOpInfoEntry('le'),
     AllowedOpInfoEntry('linalg.cholesky'),
     AllowedOpInfoEntry('linalg.cholesky_ex'),

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -13,6 +13,7 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 #include "xla/client/lib/math.h"
 #include "xla/client/lib/matrix.h"
+#include "xla/hlo/builder/lib/constants.h"
 #include "xla/hlo/builder/lib/logdet.h"
 
 namespace torch_xla {
@@ -562,6 +563,12 @@ torch_xla::XlaOpVector Isnan::Lower(LoweringContext* loctx) const {
     xla_input = xla::ConvertElementType(xla_input, xla::PrimitiveType::F32);
   }
   return ReturnOp(xla::IsNan(xla_input), loctx);
+}
+
+torch_xla::XlaOpVector Isneginf::Lower(LoweringContext* loctx) const {
+  xla::XlaOp input = loctx->GetOutputOp(operand(0));
+  /*return ReturnOp(xla::Eq(input, xla::MinValue(input.builder(), XlaHelpers::TypeOfXlaOp(input))), loctx);*/
+  return ReturnOp(input, loctx);
 }
 
 torch_xla::XlaOpVector LeakyRelu::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -567,8 +567,9 @@ torch_xla::XlaOpVector Isnan::Lower(LoweringContext* loctx) const {
 
 torch_xla::XlaOpVector Isneginf::Lower(LoweringContext* loctx) const {
   xla::XlaOp input = loctx->GetOutputOp(operand(0));
-  /*return ReturnOp(xla::Eq(input, xla::MinValue(input.builder(), XlaHelpers::TypeOfXlaOp(input))), loctx);*/
-  return ReturnOp(input, loctx);
+  return ReturnOp(xla::Eq(input, xla::MinValue(input.builder(),
+                                               XlaHelpers::TypeOfXlaOp(input))),
+                  loctx);
 }
 
 torch_xla::XlaOpVector LeakyRelu::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -606,6 +606,12 @@ xla::Shape IsnanOutputShape(const torch::lazy::Value& input) {
   return isnan_shape;
 }
 
+xla::Shape IsneginfOutputShape(const torch::lazy::Value& input) {
+  xla::Shape shape(GetXlaShape(input));
+  shape.set_element_type(xla::PRED);
+  return shape;
+}
+
 xla::Shape LeakyReluOutputShape(const torch::lazy::Value& input,
                                 const torch::lazy::Value& negative_slope) {
   auto lower_for_shape_fn =

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -180,6 +180,8 @@ xla::Shape InverseOutputShape(const torch::lazy::Value& input);
 
 xla::Shape IsnanOutputShape(const torch::lazy::Value& input);
 
+xla::Shape IsneginfOutputShape(const torch::lazy::Value& input);
+
 xla::Shape LeakyReluOutputShape(const torch::lazy::Value& input,
                                 const torch::lazy::Value& negative_slope);
 


### PR DESCRIPTION
Fix: #8746

This PR adds a lowering for `isneginf()` operation. This change should address the one introduced in https://github.com/pytorch/pytorch/pull/139763, where this call was introduced to `scaled_dot_product_attention`. This should avoid a fallback operation, which also might improve performance.