### PR TITLE
Use f32 scratch for output so we only need to transfer output with desired dtype back to HBM.

### DIFF
--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -997,9 +997,9 @@ def ragged_paged_attention(
           q.shape
       ],
       [  # output dtype
-          torch.float32,
+          q.dtype,
       ])
-  return output[0].to(q.dtype)
+  return output[0]
 
 
 def _multi_queries_paged_attention_nonkernel(

--- a/torch_xla/experimental/pallas_kernels/ragged_paged_attention_v2.py
+++ b/torch_xla/experimental/pallas_kernels/ragged_paged_attention_v2.py
@@ -315,7 +315,9 @@ def ragged_paged_attention_kernel(
 
   def is_cur_q_blk_needed(q_states):
     done, cur_seq_idx, _ = q_states
-    return jnp.logical_and(done == 0, cur_seq_idx < num_seqs)
+    should_run = jnp.logical_and(q_len_start < cu_q_lens_ref[num_seqs],
+                                 cur_seq_idx < num_seqs)
+    return jnp.logical_and(done == 0, should_run)
 
   def compute_with_cur_q_blk(q_states):
     done, cur_seq_idx, cur_buf_idx = q_states
@@ -680,14 +682,14 @@ def ragged_paged_attention(
   validate_static_inputs(q, kv_pages, kv_lens, page_indices, cu_q_lens, num_seqs, sliding_window, soft_cap)
   if mask_value is None:
     mask_value = DEFAULT_MASK_VALUE
-  _, num_q_heads, head_dim = q.shape
+  num_q, num_q_heads, head_dim = q.shape
   _, page_size, num_combined_kv_heads, _ = kv_pages.shape
   assert num_combined_kv_heads % 2 == 0
   num_kv_heads = num_combined_kv_heads // 2
   num_q_per_blk = num_queries_per_block
   num_kv_pages_per_blk = num_kv_pages_per_block
   num_q_heads_per_kv_head = num_q_heads // num_kv_heads
-  num_q_blks = cdiv(cu_q_lens[num_seqs[0]], num_q_per_blk)
+  num_q_blks = cdiv(num_q, num_q_per_blk)
   num_q_heads_per_blk, num_combined_kv_heads_per_blk = get_min_heads_per_blk(
       num_q_heads, num_combined_kv_heads, q.dtype, kv_pages.dtype
   )

--- a/torch_xla/experimental/pallas_kernels/ragged_paged_attention_v2.py
+++ b/torch_xla/experimental/pallas_kernels/ragged_paged_attention_v2.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """TPU-Friendly Ragged Paged Attention kernel.
 
 This kernel offers a highly optimized implementation of ragged paged attention,
@@ -47,14 +48,16 @@ class MultiPageAsyncCopyDescriptor:
     # a bunch of if-ops. Check the performance when we have benchmarking setup.
     for i in range(vmem_buf.shape[0]):
       page_idx = kv_pages_start + i
-      page_idx = jax.lax.select(page_idx < pages_per_seq, page_idx,
-                                pages_per_seq - 1)
+      page_idx = jax.lax.select(
+          page_idx < pages_per_seq, page_idx, pages_per_seq - 1
+      )
       self._async_copies.append(
           pltpu.make_async_copy(
               pages_hbm_ref.at[page_indices_ref[seq_id, page_idx]],
               vmem_buf.at[i],
               sem,
-          ))
+          )
+      )
 
   def start(self):
     """Starts the async copies."""
@@ -69,8 +72,7 @@ class MultiPageAsyncCopyDescriptor:
 
 def ref_ragged_paged_attention(
     queries: jax.Array,  # [max_num_batched_tokens, num_q_heads, head_dim]
-    kv_pages: jax.
-    Array,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]
+    kv_pages: jax.Array,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]
     kv_lens: jax.Array,  # i32[max_num_seqs]
     page_indices: jax.Array,  # i32[max_num_seqs, pages_per_seq]
     cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
@@ -81,8 +83,9 @@ def ref_ragged_paged_attention(
     soft_cap: float | None = None,
     mask_value: float | None = DEFAULT_MASK_VALUE,
 ):
-  check_inputs_shapes(queries, kv_pages, kv_lens, page_indices, cu_q_lens,
-                      num_seqs)
+  validate_static_inputs(
+      queries, kv_pages, kv_lens, page_indices, cu_q_lens, num_seqs, sliding_window, soft_cap
+  )
   if mask_value is None:
     mask_value = DEFAULT_MASK_VALUE
   _, _, num_combined_kv_heads, head_dim = kv_pages.shape
@@ -99,16 +102,19 @@ def ref_ragged_paged_attention(
     kv_len = kv_lens[i]
     indices = page_indices[i]
     q = queries[q_start:q_end]
-    k = kv_pages[indices, :, 0::2, :].reshape(-1, num_kv_heads,
-                                              head_dim)[:kv_len]
-    v = kv_pages[indices, :, 1::2, :].reshape(-1, num_kv_heads,
-                                              head_dim)[:kv_len]
+    k = kv_pages[indices, :, 0::2, :].reshape(-1, num_kv_heads, head_dim)[
+        :kv_len
+    ]
+    v = kv_pages[indices, :, 1::2, :].reshape(-1, num_kv_heads, head_dim)[
+        :kv_len
+    ]
     k = jnp.repeat(k, num_query_per_kv, axis=1)
     v = jnp.repeat(v, num_query_per_kv, axis=1)
     attn = jnp.einsum("qhd,khd->hqk", q, k, preferred_element_type=jnp.float32)
     attn *= sm_scale
     q_span = (kv_len - q_len) + jax.lax.broadcasted_iota(
-        jnp.int32, attn.shape, 1)
+        jnp.int32, attn.shape, 1
+    )
     kv_span = jax.lax.broadcasted_iota(jnp.int32, attn.shape, 2)
     mask = q_span < kv_span
     if sliding_window is not None:
@@ -124,10 +130,9 @@ def ref_ragged_paged_attention(
 
 
 # Expect to run these checkes during runtime.
-def validate_inputs_on_runtime(
+def validate_dynamic_inputs(
     q: jax.Array,  # [max_num_batched_tokens, num_q_heads, head_dim]
-    kv_pages: jax.
-    Array,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]
+    kv_pages: jax.Array,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]
     kv_lens: jax.Array,  # i32[max_num_seqs]
     page_indices: jax.Array,  # i32[max_num_seqs, pages_per_seq]
     cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
@@ -135,7 +140,7 @@ def validate_inputs_on_runtime(
     sliding_window: int | None = None,
     soft_cap: float | None = None,
 ):
-  check_inputs_shapes(q, kv_pages, kv_lens, page_indices, cu_q_lens, num_seqs)
+  validate_static_inputs(q, kv_pages, kv_lens, page_indices, cu_q_lens, num_seqs, sliding_window, soft_cap)
   max_num_batched_tokens = q.shape[0]
   page_size = kv_pages.shape[1]
   max_num_seqs, pages_per_seq = page_indices.shape
@@ -146,32 +151,32 @@ def validate_inputs_on_runtime(
   if pages_per_seq < min_pages_per_seq:
     raise ValueError(
         f"{pages_per_seq=} must be greater or equal to"
-        f" {min_pages_per_seq=} given {max_kv_len=} and {page_size=}.")
+        f" {min_pages_per_seq=} given {max_kv_len=} and {page_size=}."
+    )
   if cu_q_lens[num_seqs[0]] > max_num_batched_tokens:
     raise ValueError(
         f"Total q tokens {cu_q_lens[num_seqs[0]]} must be less or equal to"
-        f" {max_num_batched_tokens=}.")
+        f" {max_num_batched_tokens=}."
+    )
   for i in range(num_seqs[0]):
     q_len = cu_q_lens[i + 1] - cu_q_lens[i]
     kv_len = kv_lens[i]
     if q_len > kv_len:
       raise ValueError(
-          f"{q_len=} must be less or equal to {kv_len=} at sequence {i}.")
-  if sliding_window is not None and sliding_window <= 0:
-    raise ValueError(f"{sliding_window=} must be positive.")
-  if soft_cap is not None and soft_cap == 0.0:
-    raise ValueError(f"{soft_cap=} must not be 0.0.")
+          f"{q_len=} must be less or equal to {kv_len=} at sequence {i}."
+      )
 
 
 # Expect to run these checks during compile time.
-def check_inputs_shapes(
+def validate_static_inputs(
     q: jax.Array,  # [max_num_batched_tokens, num_q_heads, head_dim]
-    kv_pages: jax.
-    Array,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]
+    kv_pages: jax.Array,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]
     kv_lens: jax.Array,  # i32[max_num_seqs]
     page_indices: jax.Array,  # i32[max_num_seqs, pages_per_seq]
     cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
     num_seqs,  # i32[1]
+    sliding_window: int | None = None,
+    soft_cap: float | None = None,
 ):
   _, num_q_heads, head_dim = q.shape
   _, _, num_combined_kv_heads, head_dim_k = kv_pages.shape
@@ -182,22 +187,34 @@ def check_inputs_shapes(
     raise ValueError(f"{num_seqs.shape=} must be (1,)")
   if head_dim_k != head_dim:
     raise ValueError(
-        f"Q head_dim {head_dim} must be the same as that of K/V {head_dim_k}.")
+        f"Q head_dim {head_dim} must be the same as that of K/V {head_dim_k}."
+    )
   if kv_lens.shape != (max_num_seqs,):
-    raise ValueError(f"Expected {kv_lens.shape=} to be ({max_num_seqs},) where"
-                     " `max_num_seqs` is `page_indices.shape[0]`.")
+    raise ValueError(
+        f"Expected {kv_lens.shape=} to be ({max_num_seqs},) where"
+        " `max_num_seqs` is `page_indices.shape[0]`."
+    )
   if cu_q_lens.shape != (max_num_seqs + 1,):
     raise ValueError(
         f"Expected {cu_q_lens.shape=} to be ({max_num_seqs + 1},)  where"
-        " `max_num_seqs` is `page_indices.shape[0]`.")
-  if (kv_lens.dtype != jnp.int32 or page_indices.dtype != jnp.int32 or
-      cu_q_lens.dtype != jnp.int32):
+        " `max_num_seqs` is `page_indices.shape[0]`."
+    )
+  if (
+      kv_lens.dtype != jnp.int32
+      or page_indices.dtype != jnp.int32
+      or cu_q_lens.dtype != jnp.int32
+  ):
     raise ValueError(
         "The dtype of `kv_lens`, `page_indices`, and `cu_q_lens` must be"
         f" int32. Got {kv_lens.dtype=}, {page_indices.dtype=},"
-        f" {cu_q_lens.dtype=}.")
+        f" {cu_q_lens.dtype=}."
+    )
   if num_q_heads % num_kv_heads != 0:
     raise ValueError(f"{num_q_heads=} must be divisible by {num_kv_heads=}")
+  if sliding_window is not None and sliding_window <= 0:
+    raise ValueError(f"{sliding_window=} must be positive.")
+  if soft_cap is not None and soft_cap == 0.0:
+    raise ValueError(f"{soft_cap=} must not be 0.0.")
 
 
 def ragged_paged_attention_kernel(
@@ -218,6 +235,7 @@ def ragged_paged_attention_kernel(
     sems,  # [2, 2]
     l_ref,  # [num_kv_heads_per_blk, num_q_per_blk * num_q_heads_per_kv_head, 128]
     m_ref,  # [num_kv_heads_per_blk, num_q_per_blk * num_q_heads_per_kv_head, 128]
+    acc_ref,  # [num_q_per_blk, num_q_heads_per_blk, head_dim]
     *,
     sm_scale: float,
     sliding_window: int | None = None,
@@ -229,7 +247,8 @@ def ragged_paged_attention_kernel(
   num_q_per_blk, num_q_heads_per_blk, head_dim = q_ref.shape
   num_seqs = num_seqs_ref[0]
   _, num_kv_pages_per_blk, page_size, num_combined_kv_heads_per_blk, _ = (
-      kv_bufs.shape)
+      kv_bufs.shape
+  )
   num_kv_heads_per_blk = num_combined_kv_heads_per_blk // 2
   num_kv_per_blk = num_kv_pages_per_blk * page_size
   num_q_heads_per_kv_head = num_q_heads_per_blk // num_kv_heads_per_blk
@@ -243,14 +262,15 @@ def ragged_paged_attention_kernel(
   q_len_start = q_blk_idx * num_q_per_blk
   q_len_end = q_len_start + num_q_per_blk
 
-  def create_kv_async_copy_descriptors(heads_blk_idx, seq_idx, kv_blk_idx,
-                                       buf_idx):
+  def create_kv_async_copy_descriptors(
+      heads_blk_idx, seq_idx, kv_blk_idx, buf_idx
+  ):
     offset = (seq_idx, kv_blk_idx * num_kv_pages_per_blk)
     heads_start = heads_blk_idx * num_combined_kv_heads_per_blk
     async_copy_kv = MultiPageAsyncCopyDescriptor(
-        kv_pages_hbm_ref.at[:, :,
-                            pl.ds(heads_start, num_combined_kv_heads_per_blk
-                                 ), :],
+        kv_pages_hbm_ref.at[
+            :, :, pl.ds(heads_start, num_combined_kv_heads_per_blk), :
+        ],
         kv_bufs.at[buf_idx],
         sems.at[buf_idx],
         page_indices_ref,
@@ -288,16 +308,14 @@ def ragged_paged_attention_kernel(
 
   @pl.when(heads_blk_idx + q_blk_idx == 0)
   def prefetch_first_kv_blk():
-    async_copy_kv = create_kv_async_copy_descriptors(heads_blk_idx,
-                                                     init_seq_idx, 0,
-                                                     init_buf_idx)
+    async_copy_kv = create_kv_async_copy_descriptors(
+        heads_blk_idx, init_seq_idx, 0, init_buf_idx
+    )
     async_copy_kv.start()
 
   def is_cur_q_blk_needed(q_states):
     done, cur_seq_idx, _ = q_states
-    should_run = jnp.logical_and(q_len_start < cu_q_lens_ref[num_seqs],
-                                 cur_seq_idx < num_seqs)
-    return jnp.logical_and(done == 0, should_run)
+    return jnp.logical_and(done == 0, cur_seq_idx < num_seqs)
 
   def compute_with_cur_q_blk(q_states):
     done, cur_seq_idx, cur_buf_idx = q_states
@@ -306,8 +324,9 @@ def ragged_paged_attention_kernel(
     q_len = q_end - q_start
     kv_len = kv_lens_ref[cur_seq_idx]
 
-    def get_next_prefetch_ids(heads_blk_idx, cur_seq_idx, kv_blk_idx,
-                              cur_buf_idx):
+    def get_next_prefetch_ids(
+        heads_blk_idx, cur_seq_idx, kv_blk_idx, cur_buf_idx
+    ):
       next_kv_blk_idx = kv_blk_idx + 1
       is_last_kv_blk = next_kv_blk_idx * num_kv_per_blk >= kv_len
       next_kv_blk_idx = lax.select(
@@ -341,7 +360,7 @@ def ragged_paged_attention_kernel(
         v,  # [num_kv_per_blk, head_dim]
         head_l_ref,  # [num_q_per_blk * num_q_heads_per_kv_head, 128]
         head_m_ref,  # [num_q_per_blk * num_q_heads_per_kv_head, 128]
-        head_o_ref,  # [num_q_per_blk, num_q_heads_per_kv_head, head_dim]
+        head_acc_ref,  # [num_q_per_blk, num_q_heads_per_kv_head, head_dim]
         *,
         kv_blk_idx,
     ):
@@ -362,7 +381,7 @@ def ragged_paged_attention_kernel(
           num_q_per_blk * num_q_heads_per_kv_head,
           128,
       )
-      assert head_o_ref.shape == (
+      assert head_acc_ref.shape == (
           num_q_per_blk,
           num_q_heads_per_kv_head,
           head_dim,
@@ -372,12 +391,12 @@ def ragged_paged_attention_kernel(
       def masked_store(ref, val, start, end, group=1):
         iota = lax.broadcasted_iota(jnp.int32, ref.shape, 0) // group
         mask = jnp.logical_and(iota >= start, iota < end)
-        pl.store(
-            ref, idx=tuple(slice(None) for _ in ref.shape), val=val, mask=mask)
+        pl.store(ref, idx=tuple(slice(None) for _ in ref.shape), val=val, mask=mask)
 
       qk = (
-          jnp.einsum("nd,md->nm", q, k, preferred_element_type=jnp.float32) *
-          sm_scale)
+          jnp.einsum("nd,md->nm", q, k, preferred_element_type=jnp.float32)
+          * sm_scale
+      )
       store_start = jnp.maximum(q_start - q_len_start, 0)
       store_end = jnp.minimum(q_end - q_len_start, num_q_per_blk)
 
@@ -398,18 +417,23 @@ def ragged_paged_attention_kernel(
             num_q_heads_per_kv_head,
         )
         masked_store(
-            head_o_ref,
-            jnp.zeros_like(head_o_ref),
+            head_acc_ref,
+            jnp.zeros_like(head_acc_ref),
             store_start,
             store_end,
         )
 
-      row_ids = ((kv_len - q_len) + q_len_start - q_start +
-                 jax.lax.broadcasted_iota(
-                     jnp.int32,
-                     (num_q_per_blk * num_q_heads_per_kv_head, num_kv_per_blk),
-                     0,
-                 ) // num_q_heads_per_kv_head)
+      row_ids = (
+          (kv_len - q_len)
+          + q_len_start
+          - q_start
+          + jax.lax.broadcasted_iota(
+              jnp.int32,
+              (num_q_per_blk * num_q_heads_per_kv_head, num_kv_per_blk),
+              0,
+          )
+          // num_q_heads_per_kv_head
+      )
       col_ids = kv_len_start + jax.lax.broadcasted_iota(
           jnp.int32,
           (num_q_per_blk * num_q_heads_per_kv_head, num_kv_per_blk),
@@ -428,12 +452,14 @@ def ragged_paged_attention_kernel(
       lm_store_shape = head_m_ref.shape
       m_curr = jnp.broadcast_to(m_curr, lm_store_shape)
       l_curr = jnp.broadcast_to(
-          s_curr.sum(axis=1, keepdims=True), lm_store_shape)
+          s_curr.sum(axis=1, keepdims=True), lm_store_shape
+      )
       m_prev = head_m_ref[...]
       l_prev = head_l_ref[...]
       m_next = jnp.maximum(m_prev, m_curr)
-      masked_store(head_m_ref, m_next, store_start, store_end,
-                   num_q_heads_per_kv_head)
+      masked_store(
+          head_m_ref, m_next, store_start, store_end, num_q_heads_per_kv_head
+      )
       alpha = jnp.exp(m_prev - m_next)
       beta = jnp.exp(m_curr - m_next)
       l_alpha = alpha * l_prev
@@ -454,20 +480,21 @@ def ragged_paged_attention_kernel(
         assert arr.shape[0] == shape[0]
         assert shape[1] % arr.shape[1] == 0
         # no-op concatenation.
-        return jnp.concatenate([arr for _ in range(shape[1] // arr.shape[1])],
-                               axis=1)
+        return jnp.concatenate(
+            [arr for _ in range(shape[1] // arr.shape[1])], axis=1
+        )
 
-      o_curr = head_o_ref[...].reshape(-1, head_dim)
+      o_curr = head_acc_ref[...].reshape(-1, head_dim)
       l_alpha = broadcast_to_shape(l_alpha, qkv.shape)
       beta = broadcast_to_shape(beta, qkv.shape)
       l_next_safe = broadcast_to_shape(l_next_safe, qkv.shape)
       out = lax.div(
           l_alpha * o_curr + beta * qkv,
           l_next_safe,
-      ).astype(head_o_ref.dtype)
+      )
       masked_store(
-          head_o_ref,
-          out.reshape(head_o_ref.shape),
+          head_acc_ref,
+          out.reshape(head_acc_ref.shape),
           store_start,
           store_end,
       )
@@ -479,8 +506,10 @@ def ragged_paged_attention_kernel(
     def compute_with_kv_blk_in_cur_seq(kv_states):
       kv_blk_idx, cur_buf_idx = kv_states
       next_heads_blk_idx, next_seq_idx, next_kv_blk_idx, next_buf_idx = (
-          get_next_prefetch_ids(heads_blk_idx, cur_seq_idx, kv_blk_idx,
-                                cur_buf_idx))
+          get_next_prefetch_ids(
+              heads_blk_idx, cur_seq_idx, kv_blk_idx, cur_buf_idx
+          )
+      )
 
       @pl.when(next_heads_blk_idx < num_heads_blks)
       def prefetch_next_kv_blk():
@@ -488,11 +517,13 @@ def ragged_paged_attention_kernel(
         # TODO(jevinjiang): only fetch effective dynamic size to hold kv_len and
         # DMA to fixed size buffer!
         next_async_copy_kv = create_kv_async_copy_descriptors(
-            next_heads_blk_idx, next_seq_idx, next_kv_blk_idx, next_buf_idx)
+            next_heads_blk_idx, next_seq_idx, next_kv_blk_idx, next_buf_idx
+        )
         next_async_copy_kv.start()
 
       cur_async_copy_kv = create_kv_async_copy_descriptors(
-          heads_blk_idx, cur_seq_idx, kv_blk_idx, cur_buf_idx)
+          heads_blk_idx, cur_seq_idx, kv_blk_idx, cur_buf_idx
+      )
       kv_ref = cur_async_copy_kv.wait().reshape(
           num_kv_pages_per_blk * page_size * num_combined_kv_heads_per_blk,
           head_dim,
@@ -501,19 +532,22 @@ def ragged_paged_attention_kernel(
         q_head_idx = kv_head_idx * num_q_heads_per_kv_head
         # TODO(jevinjiang): extra handlig for packed type that can start at
         # unaligned position!
-        q = fold_on_2nd_minor(q_ref[:, q_head_idx:q_head_idx +
-                                    num_q_heads_per_kv_head, :])
-        k = strided_load_kv(kv_ref, kv_head_idx * 2,
-                            num_combined_kv_heads_per_blk)
-        v = strided_load_kv(kv_ref, kv_head_idx * 2 + 1,
-                            num_combined_kv_heads_per_blk)
+        q = fold_on_2nd_minor(
+            q_ref[:, q_head_idx : q_head_idx + num_q_heads_per_kv_head, :]
+        )
+        k = strided_load_kv(
+            kv_ref, kv_head_idx * 2, num_combined_kv_heads_per_blk
+        )
+        v = strided_load_kv(
+            kv_ref, kv_head_idx * 2 + 1, num_combined_kv_heads_per_blk
+        )
         flash_attention(
             q,
             k,
             v,
             l_ref.at[kv_head_idx],
             m_ref.at[kv_head_idx],
-            o_ref.at[:, q_head_idx:q_head_idx + num_q_heads_per_kv_head, :],
+            acc_ref.at[:, q_head_idx : q_head_idx + num_q_heads_per_kv_head, :],
             kv_blk_idx=kv_blk_idx,
         )
       return kv_blk_idx + 1, next_buf_idx
@@ -535,6 +569,7 @@ def ragged_paged_attention_kernel(
   # Reset seq_idx for next kv_heads_blk if run out of seqs!
   seq_buf_idx_ref[0] = lax.select(seq_idx < num_seqs, seq_idx, 0)
   seq_buf_idx_ref[1] = buf_idx
+  o_ref[...] = acc_ref[...].astype(q_ref.dtype)
 
 
 def cdiv(a, b):
@@ -554,8 +589,9 @@ def get_dtype_packing(dtype):
   raise ValueError(f"Not implemented: unsupported {dtype=}")
 
 
-def get_min_heads_per_blk(num_q_heads, num_combined_kv_heads, q_dtype,
-                          kv_dtype):
+def get_min_heads_per_blk(
+    num_q_heads, num_combined_kv_heads, q_dtype, kv_dtype
+):
   q_packing = get_dtype_packing(q_dtype)
   kv_packing = get_dtype_packing(kv_dtype)
 
@@ -578,8 +614,10 @@ def get_min_heads_per_blk(num_q_heads, num_combined_kv_heads, q_dtype,
   # second minor tiling is not on.
   max_combined_kv_tiling = 8 * kv_packing
   min_combined_kv_heads = (
-      max_combined_kv_tiling if num_combined_kv_heads %
-      max_combined_kv_tiling == 0 else num_combined_kv_heads)
+      max_combined_kv_tiling
+      if num_combined_kv_heads % max_combined_kv_tiling == 0
+      else num_combined_kv_heads
+  )
   min_q_heads = min_combined_kv_heads // 2 * ratio
   if can_be_xla_fully_tiled(min_q_heads, q_packing):
     return min_q_heads, min_combined_kv_heads
@@ -601,8 +639,7 @@ def get_min_heads_per_blk(num_q_heads, num_combined_kv_heads, q_dtype,
 def ragged_paged_attention(
     q: jax.Array,  # [max_num_batched_tokens, num_q_heads, head_dim]
     # TODO(jevinjiang): create a write_to_kv_cache kernel!
-    kv_pages: jax.
-    Array,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]
+    kv_pages: jax.Array,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]
     kv_lens: jax.Array,  # i32[max_num_seqs]
     page_indices: jax.Array,  # i32[max_num_seqs, pages_per_seq]
     cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
@@ -629,6 +666,7 @@ def ragged_paged_attention(
     num_seqs: the dynamic number of sequences.
     sm_scale: the softmax scale which will be applied to the Q@K^T.
     sliding_window: the sliding window size for the attention.
+    soft_cap: the logit soft cap for the attention.
     mask_value: mask value for causal mask.
     num_kv_pages_per_block: number of kv pages to be processed in one flash
       attention block in the pallas kernel.
@@ -639,19 +677,20 @@ def ragged_paged_attention(
   Returns:
     The output of the attention.
   """
-  check_inputs_shapes(q, kv_pages, kv_lens, page_indices, cu_q_lens, num_seqs)
+  validate_static_inputs(q, kv_pages, kv_lens, page_indices, cu_q_lens, num_seqs, sliding_window, soft_cap)
   if mask_value is None:
     mask_value = DEFAULT_MASK_VALUE
-  num_q, num_q_heads, head_dim = q.shape
+  _, num_q_heads, head_dim = q.shape
   _, page_size, num_combined_kv_heads, _ = kv_pages.shape
   assert num_combined_kv_heads % 2 == 0
   num_kv_heads = num_combined_kv_heads // 2
   num_q_per_blk = num_queries_per_block
   num_kv_pages_per_blk = num_kv_pages_per_block
   num_q_heads_per_kv_head = num_q_heads // num_kv_heads
-  num_q_blks = cdiv(num_q, num_q_per_blk)
+  num_q_blks = cdiv(cu_q_lens[num_seqs[0]], num_q_per_blk)
   num_q_heads_per_blk, num_combined_kv_heads_per_blk = get_min_heads_per_blk(
-      num_q_heads, num_combined_kv_heads, q.dtype, kv_pages.dtype)
+      num_q_heads, num_combined_kv_heads, q.dtype, kv_pages.dtype
+  )
   assert num_combined_kv_heads_per_blk % 2 == 0
   num_kv_heads_per_blk = num_combined_kv_heads_per_blk // 2
   assert num_q_heads_per_blk % num_q_heads_per_kv_head == 0
@@ -676,6 +715,10 @@ def ragged_paged_attention(
       (num_kv_heads_per_blk, num_q_per_blk * num_q_heads_per_kv_head, 128),
       jnp.float32,
   )
+  acc_scratch = pltpu.VMEM(
+      (num_q_per_blk, num_q_heads_per_blk, head_dim),
+      jnp.float32,
+  )
   double_buf_scratch = pltpu.VMEM(
       (
           2,  # For double buffering during DMA copies.
@@ -691,6 +734,7 @@ def ragged_paged_attention(
       pltpu.SemaphoreType.DMA((2,)),  # Semaphores for double buffers.
       lm_scratch,  # l_ref
       lm_scratch,  # m_ref
+      acc_scratch,
   ]
   scalar_prefetches = (
       kv_lens,
@@ -721,10 +765,8 @@ def ragged_paged_attention(
           ),
           vmem_limit_bytes=vmem_limit_bytes,
       ),
-      out_shape=jax.ShapeDtypeStruct(shape=q.shape, dtype=jnp.float32),
+      out_shape=jax.ShapeDtypeStruct(shape=q.shape, dtype=q.dtype),
       name="ragged_paged_attention_kernel",
   )
 
-  # TODO(jevinjiang): Use f32 acc scratch for output! So we only need
-  # to transfer output with desired dtype back to HBM.
-  return kernel(*scalar_prefetches, q, kv_pages).astype(q.dtype)
+  return kernel(*scalar_prefetches, q, kv_pages)

--- a/torch_xla/experimental/pallas_kernels/ragged_paged_attention_v2.py
+++ b/torch_xla/experimental/pallas_kernels/ragged_paged_attention_v2.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """TPU-Friendly Ragged Paged Attention kernel.
 
 This kernel offers a highly optimized implementation of ragged paged attention,
@@ -48,16 +47,14 @@ class MultiPageAsyncCopyDescriptor:
     # a bunch of if-ops. Check the performance when we have benchmarking setup.
     for i in range(vmem_buf.shape[0]):
       page_idx = kv_pages_start + i
-      page_idx = jax.lax.select(
-          page_idx < pages_per_seq, page_idx, pages_per_seq - 1
-      )
+      page_idx = jax.lax.select(page_idx < pages_per_seq, page_idx,
+                                pages_per_seq - 1)
       self._async_copies.append(
           pltpu.make_async_copy(
               pages_hbm_ref.at[page_indices_ref[seq_id, page_idx]],
               vmem_buf.at[i],
               sem,
-          )
-      )
+          ))
 
   def start(self):
     """Starts the async copies."""
@@ -72,7 +69,8 @@ class MultiPageAsyncCopyDescriptor:
 
 def ref_ragged_paged_attention(
     queries: jax.Array,  # [max_num_batched_tokens, num_q_heads, head_dim]
-    kv_pages: jax.Array,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]
+    kv_pages: jax.
+    Array,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]
     kv_lens: jax.Array,  # i32[max_num_seqs]
     page_indices: jax.Array,  # i32[max_num_seqs, pages_per_seq]
     cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
@@ -83,9 +81,8 @@ def ref_ragged_paged_attention(
     soft_cap: float | None = None,
     mask_value: float | None = DEFAULT_MASK_VALUE,
 ):
-  validate_static_inputs(
-      queries, kv_pages, kv_lens, page_indices, cu_q_lens, num_seqs, sliding_window, soft_cap
-  )
+  validate_static_inputs(queries, kv_pages, kv_lens, page_indices, cu_q_lens,
+                         num_seqs, sliding_window, soft_cap)
   if mask_value is None:
     mask_value = DEFAULT_MASK_VALUE
   _, _, num_combined_kv_heads, head_dim = kv_pages.shape
@@ -102,19 +99,16 @@ def ref_ragged_paged_attention(
     kv_len = kv_lens[i]
     indices = page_indices[i]
     q = queries[q_start:q_end]
-    k = kv_pages[indices, :, 0::2, :].reshape(-1, num_kv_heads, head_dim)[
-        :kv_len
-    ]
-    v = kv_pages[indices, :, 1::2, :].reshape(-1, num_kv_heads, head_dim)[
-        :kv_len
-    ]
+    k = kv_pages[indices, :, 0::2, :].reshape(-1, num_kv_heads,
+                                              head_dim)[:kv_len]
+    v = kv_pages[indices, :, 1::2, :].reshape(-1, num_kv_heads,
+                                              head_dim)[:kv_len]
     k = jnp.repeat(k, num_query_per_kv, axis=1)
     v = jnp.repeat(v, num_query_per_kv, axis=1)
     attn = jnp.einsum("qhd,khd->hqk", q, k, preferred_element_type=jnp.float32)
     attn *= sm_scale
     q_span = (kv_len - q_len) + jax.lax.broadcasted_iota(
-        jnp.int32, attn.shape, 1
-    )
+        jnp.int32, attn.shape, 1)
     kv_span = jax.lax.broadcasted_iota(jnp.int32, attn.shape, 2)
     mask = q_span < kv_span
     if sliding_window is not None:
@@ -132,7 +126,8 @@ def ref_ragged_paged_attention(
 # Expect to run these checkes during runtime.
 def validate_dynamic_inputs(
     q: jax.Array,  # [max_num_batched_tokens, num_q_heads, head_dim]
-    kv_pages: jax.Array,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]
+    kv_pages: jax.
+    Array,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]
     kv_lens: jax.Array,  # i32[max_num_seqs]
     page_indices: jax.Array,  # i32[max_num_seqs, pages_per_seq]
     cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
@@ -140,7 +135,8 @@ def validate_dynamic_inputs(
     sliding_window: int | None = None,
     soft_cap: float | None = None,
 ):
-  validate_static_inputs(q, kv_pages, kv_lens, page_indices, cu_q_lens, num_seqs, sliding_window, soft_cap)
+  validate_static_inputs(q, kv_pages, kv_lens, page_indices, cu_q_lens,
+                         num_seqs, sliding_window, soft_cap)
   max_num_batched_tokens = q.shape[0]
   page_size = kv_pages.shape[1]
   max_num_seqs, pages_per_seq = page_indices.shape
@@ -151,26 +147,24 @@ def validate_dynamic_inputs(
   if pages_per_seq < min_pages_per_seq:
     raise ValueError(
         f"{pages_per_seq=} must be greater or equal to"
-        f" {min_pages_per_seq=} given {max_kv_len=} and {page_size=}."
-    )
+        f" {min_pages_per_seq=} given {max_kv_len=} and {page_size=}.")
   if cu_q_lens[num_seqs[0]] > max_num_batched_tokens:
     raise ValueError(
         f"Total q tokens {cu_q_lens[num_seqs[0]]} must be less or equal to"
-        f" {max_num_batched_tokens=}."
-    )
+        f" {max_num_batched_tokens=}.")
   for i in range(num_seqs[0]):
     q_len = cu_q_lens[i + 1] - cu_q_lens[i]
     kv_len = kv_lens[i]
     if q_len > kv_len:
       raise ValueError(
-          f"{q_len=} must be less or equal to {kv_len=} at sequence {i}."
-      )
+          f"{q_len=} must be less or equal to {kv_len=} at sequence {i}.")
 
 
 # Expect to run these checks during compile time.
 def validate_static_inputs(
     q: jax.Array,  # [max_num_batched_tokens, num_q_heads, head_dim]
-    kv_pages: jax.Array,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]
+    kv_pages: jax.
+    Array,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]
     kv_lens: jax.Array,  # i32[max_num_seqs]
     page_indices: jax.Array,  # i32[max_num_seqs, pages_per_seq]
     cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
@@ -187,28 +181,20 @@ def validate_static_inputs(
     raise ValueError(f"{num_seqs.shape=} must be (1,)")
   if head_dim_k != head_dim:
     raise ValueError(
-        f"Q head_dim {head_dim} must be the same as that of K/V {head_dim_k}."
-    )
+        f"Q head_dim {head_dim} must be the same as that of K/V {head_dim_k}.")
   if kv_lens.shape != (max_num_seqs,):
-    raise ValueError(
-        f"Expected {kv_lens.shape=} to be ({max_num_seqs},) where"
-        " `max_num_seqs` is `page_indices.shape[0]`."
-    )
+    raise ValueError(f"Expected {kv_lens.shape=} to be ({max_num_seqs},) where"
+                     " `max_num_seqs` is `page_indices.shape[0]`.")
   if cu_q_lens.shape != (max_num_seqs + 1,):
     raise ValueError(
         f"Expected {cu_q_lens.shape=} to be ({max_num_seqs + 1},)  where"
-        " `max_num_seqs` is `page_indices.shape[0]`."
-    )
-  if (
-      kv_lens.dtype != jnp.int32
-      or page_indices.dtype != jnp.int32
-      or cu_q_lens.dtype != jnp.int32
-  ):
+        " `max_num_seqs` is `page_indices.shape[0]`.")
+  if (kv_lens.dtype != jnp.int32 or page_indices.dtype != jnp.int32 or
+      cu_q_lens.dtype != jnp.int32):
     raise ValueError(
         "The dtype of `kv_lens`, `page_indices`, and `cu_q_lens` must be"
         f" int32. Got {kv_lens.dtype=}, {page_indices.dtype=},"
-        f" {cu_q_lens.dtype=}."
-    )
+        f" {cu_q_lens.dtype=}.")
   if num_q_heads % num_kv_heads != 0:
     raise ValueError(f"{num_q_heads=} must be divisible by {num_kv_heads=}")
   if sliding_window is not None and sliding_window <= 0:
@@ -247,8 +233,7 @@ def ragged_paged_attention_kernel(
   num_q_per_blk, num_q_heads_per_blk, head_dim = q_ref.shape
   num_seqs = num_seqs_ref[0]
   _, num_kv_pages_per_blk, page_size, num_combined_kv_heads_per_blk, _ = (
-      kv_bufs.shape
-  )
+      kv_bufs.shape)
   num_kv_heads_per_blk = num_combined_kv_heads_per_blk // 2
   num_kv_per_blk = num_kv_pages_per_blk * page_size
   num_q_heads_per_kv_head = num_q_heads_per_blk // num_kv_heads_per_blk
@@ -262,15 +247,14 @@ def ragged_paged_attention_kernel(
   q_len_start = q_blk_idx * num_q_per_blk
   q_len_end = q_len_start + num_q_per_blk
 
-  def create_kv_async_copy_descriptors(
-      heads_blk_idx, seq_idx, kv_blk_idx, buf_idx
-  ):
+  def create_kv_async_copy_descriptors(heads_blk_idx, seq_idx, kv_blk_idx,
+                                       buf_idx):
     offset = (seq_idx, kv_blk_idx * num_kv_pages_per_blk)
     heads_start = heads_blk_idx * num_combined_kv_heads_per_blk
     async_copy_kv = MultiPageAsyncCopyDescriptor(
-        kv_pages_hbm_ref.at[
-            :, :, pl.ds(heads_start, num_combined_kv_heads_per_blk), :
-        ],
+        kv_pages_hbm_ref.at[:, :,
+                            pl.ds(heads_start, num_combined_kv_heads_per_blk
+                                 ), :],
         kv_bufs.at[buf_idx],
         sems.at[buf_idx],
         page_indices_ref,
@@ -308,9 +292,9 @@ def ragged_paged_attention_kernel(
 
   @pl.when(heads_blk_idx + q_blk_idx == 0)
   def prefetch_first_kv_blk():
-    async_copy_kv = create_kv_async_copy_descriptors(
-        heads_blk_idx, init_seq_idx, 0, init_buf_idx
-    )
+    async_copy_kv = create_kv_async_copy_descriptors(heads_blk_idx,
+                                                     init_seq_idx, 0,
+                                                     init_buf_idx)
     async_copy_kv.start()
 
   def is_cur_q_blk_needed(q_states):
@@ -326,9 +310,8 @@ def ragged_paged_attention_kernel(
     q_len = q_end - q_start
     kv_len = kv_lens_ref[cur_seq_idx]
 
-    def get_next_prefetch_ids(
-        heads_blk_idx, cur_seq_idx, kv_blk_idx, cur_buf_idx
-    ):
+    def get_next_prefetch_ids(heads_blk_idx, cur_seq_idx, kv_blk_idx,
+                              cur_buf_idx):
       next_kv_blk_idx = kv_blk_idx + 1
       is_last_kv_blk = next_kv_blk_idx * num_kv_per_blk >= kv_len
       next_kv_blk_idx = lax.select(
@@ -393,12 +376,12 @@ def ragged_paged_attention_kernel(
       def masked_store(ref, val, start, end, group=1):
         iota = lax.broadcasted_iota(jnp.int32, ref.shape, 0) // group
         mask = jnp.logical_and(iota >= start, iota < end)
-        pl.store(ref, idx=tuple(slice(None) for _ in ref.shape), val=val, mask=mask)
+        pl.store(
+            ref, idx=tuple(slice(None) for _ in ref.shape), val=val, mask=mask)
 
       qk = (
-          jnp.einsum("nd,md->nm", q, k, preferred_element_type=jnp.float32)
-          * sm_scale
-      )
+          jnp.einsum("nd,md->nm", q, k, preferred_element_type=jnp.float32) *
+          sm_scale)
       store_start = jnp.maximum(q_start - q_len_start, 0)
       store_end = jnp.minimum(q_end - q_len_start, num_q_per_blk)
 
@@ -425,17 +408,12 @@ def ragged_paged_attention_kernel(
             store_end,
         )
 
-      row_ids = (
-          (kv_len - q_len)
-          + q_len_start
-          - q_start
-          + jax.lax.broadcasted_iota(
-              jnp.int32,
-              (num_q_per_blk * num_q_heads_per_kv_head, num_kv_per_blk),
-              0,
-          )
-          // num_q_heads_per_kv_head
-      )
+      row_ids = ((kv_len - q_len) + q_len_start - q_start +
+                 jax.lax.broadcasted_iota(
+                     jnp.int32,
+                     (num_q_per_blk * num_q_heads_per_kv_head, num_kv_per_blk),
+                     0,
+                 ) // num_q_heads_per_kv_head)
       col_ids = kv_len_start + jax.lax.broadcasted_iota(
           jnp.int32,
           (num_q_per_blk * num_q_heads_per_kv_head, num_kv_per_blk),
@@ -454,14 +432,12 @@ def ragged_paged_attention_kernel(
       lm_store_shape = head_m_ref.shape
       m_curr = jnp.broadcast_to(m_curr, lm_store_shape)
       l_curr = jnp.broadcast_to(
-          s_curr.sum(axis=1, keepdims=True), lm_store_shape
-      )
+          s_curr.sum(axis=1, keepdims=True), lm_store_shape)
       m_prev = head_m_ref[...]
       l_prev = head_l_ref[...]
       m_next = jnp.maximum(m_prev, m_curr)
-      masked_store(
-          head_m_ref, m_next, store_start, store_end, num_q_heads_per_kv_head
-      )
+      masked_store(head_m_ref, m_next, store_start, store_end,
+                   num_q_heads_per_kv_head)
       alpha = jnp.exp(m_prev - m_next)
       beta = jnp.exp(m_curr - m_next)
       l_alpha = alpha * l_prev
@@ -482,9 +458,8 @@ def ragged_paged_attention_kernel(
         assert arr.shape[0] == shape[0]
         assert shape[1] % arr.shape[1] == 0
         # no-op concatenation.
-        return jnp.concatenate(
-            [arr for _ in range(shape[1] // arr.shape[1])], axis=1
-        )
+        return jnp.concatenate([arr for _ in range(shape[1] // arr.shape[1])],
+                               axis=1)
 
       o_curr = head_acc_ref[...].reshape(-1, head_dim)
       l_alpha = broadcast_to_shape(l_alpha, qkv.shape)
@@ -508,10 +483,8 @@ def ragged_paged_attention_kernel(
     def compute_with_kv_blk_in_cur_seq(kv_states):
       kv_blk_idx, cur_buf_idx = kv_states
       next_heads_blk_idx, next_seq_idx, next_kv_blk_idx, next_buf_idx = (
-          get_next_prefetch_ids(
-              heads_blk_idx, cur_seq_idx, kv_blk_idx, cur_buf_idx
-          )
-      )
+          get_next_prefetch_ids(heads_blk_idx, cur_seq_idx, kv_blk_idx,
+                                cur_buf_idx))
 
       @pl.when(next_heads_blk_idx < num_heads_blks)
       def prefetch_next_kv_blk():
@@ -519,13 +492,11 @@ def ragged_paged_attention_kernel(
         # TODO(jevinjiang): only fetch effective dynamic size to hold kv_len and
         # DMA to fixed size buffer!
         next_async_copy_kv = create_kv_async_copy_descriptors(
-            next_heads_blk_idx, next_seq_idx, next_kv_blk_idx, next_buf_idx
-        )
+            next_heads_blk_idx, next_seq_idx, next_kv_blk_idx, next_buf_idx)
         next_async_copy_kv.start()
 
       cur_async_copy_kv = create_kv_async_copy_descriptors(
-          heads_blk_idx, cur_seq_idx, kv_blk_idx, cur_buf_idx
-      )
+          heads_blk_idx, cur_seq_idx, kv_blk_idx, cur_buf_idx)
       kv_ref = cur_async_copy_kv.wait().reshape(
           num_kv_pages_per_blk * page_size * num_combined_kv_heads_per_blk,
           head_dim,
@@ -534,22 +505,19 @@ def ragged_paged_attention_kernel(
         q_head_idx = kv_head_idx * num_q_heads_per_kv_head
         # TODO(jevinjiang): extra handlig for packed type that can start at
         # unaligned position!
-        q = fold_on_2nd_minor(
-            q_ref[:, q_head_idx : q_head_idx + num_q_heads_per_kv_head, :]
-        )
-        k = strided_load_kv(
-            kv_ref, kv_head_idx * 2, num_combined_kv_heads_per_blk
-        )
-        v = strided_load_kv(
-            kv_ref, kv_head_idx * 2 + 1, num_combined_kv_heads_per_blk
-        )
+        q = fold_on_2nd_minor(q_ref[:, q_head_idx:q_head_idx +
+                                    num_q_heads_per_kv_head, :])
+        k = strided_load_kv(kv_ref, kv_head_idx * 2,
+                            num_combined_kv_heads_per_blk)
+        v = strided_load_kv(kv_ref, kv_head_idx * 2 + 1,
+                            num_combined_kv_heads_per_blk)
         flash_attention(
             q,
             k,
             v,
             l_ref.at[kv_head_idx],
             m_ref.at[kv_head_idx],
-            acc_ref.at[:, q_head_idx : q_head_idx + num_q_heads_per_kv_head, :],
+            acc_ref.at[:, q_head_idx:q_head_idx + num_q_heads_per_kv_head, :],
             kv_blk_idx=kv_blk_idx,
         )
       return kv_blk_idx + 1, next_buf_idx
@@ -591,9 +559,8 @@ def get_dtype_packing(dtype):
   raise ValueError(f"Not implemented: unsupported {dtype=}")
 
 
-def get_min_heads_per_blk(
-    num_q_heads, num_combined_kv_heads, q_dtype, kv_dtype
-):
+def get_min_heads_per_blk(num_q_heads, num_combined_kv_heads, q_dtype,
+                          kv_dtype):
   q_packing = get_dtype_packing(q_dtype)
   kv_packing = get_dtype_packing(kv_dtype)
 
@@ -616,10 +583,8 @@ def get_min_heads_per_blk(
   # second minor tiling is not on.
   max_combined_kv_tiling = 8 * kv_packing
   min_combined_kv_heads = (
-      max_combined_kv_tiling
-      if num_combined_kv_heads % max_combined_kv_tiling == 0
-      else num_combined_kv_heads
-  )
+      max_combined_kv_tiling if num_combined_kv_heads %
+      max_combined_kv_tiling == 0 else num_combined_kv_heads)
   min_q_heads = min_combined_kv_heads // 2 * ratio
   if can_be_xla_fully_tiled(min_q_heads, q_packing):
     return min_q_heads, min_combined_kv_heads
@@ -641,7 +606,8 @@ def get_min_heads_per_blk(
 def ragged_paged_attention(
     q: jax.Array,  # [max_num_batched_tokens, num_q_heads, head_dim]
     # TODO(jevinjiang): create a write_to_kv_cache kernel!
-    kv_pages: jax.Array,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]
+    kv_pages: jax.
+    Array,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]
     kv_lens: jax.Array,  # i32[max_num_seqs]
     page_indices: jax.Array,  # i32[max_num_seqs, pages_per_seq]
     cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
@@ -679,7 +645,8 @@ def ragged_paged_attention(
   Returns:
     The output of the attention.
   """
-  validate_static_inputs(q, kv_pages, kv_lens, page_indices, cu_q_lens, num_seqs, sliding_window, soft_cap)
+  validate_static_inputs(q, kv_pages, kv_lens, page_indices, cu_q_lens,
+                         num_seqs, sliding_window, soft_cap)
   if mask_value is None:
     mask_value = DEFAULT_MASK_VALUE
   num_q, num_q_heads, head_dim = q.shape
@@ -691,8 +658,7 @@ def ragged_paged_attention(
   num_q_heads_per_kv_head = num_q_heads // num_kv_heads
   num_q_blks = cdiv(num_q, num_q_per_blk)
   num_q_heads_per_blk, num_combined_kv_heads_per_blk = get_min_heads_per_blk(
-      num_q_heads, num_combined_kv_heads, q.dtype, kv_pages.dtype
-  )
+      num_q_heads, num_combined_kv_heads, q.dtype, kv_pages.dtype)
   assert num_combined_kv_heads_per_blk % 2 == 0
   num_kv_heads_per_blk = num_combined_kv_heads_per_blk // 2
   assert num_q_heads_per_blk % num_q_heads_per_kv_head == 0


### PR DESCRIPTION
Make the kernel code in-sync by migrating https://github.com/jax-ml/jax/commit/b719ac00c63ebb74766e7be3b142c046213a18ec.