### PR TITLE
[CherryPick] Lower `isneginf()`.

### DIFF
--- a/codegen/xla_native_functions.yaml
+++ b/codegen/xla_native_functions.yaml
@@ -51,6 +51,7 @@ full_codegen:
   - hardswish_backward
   - inverse
   - isnan
+  - isneginf
   - leaky_relu
   - le.Scalar
   - le.Tensor

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -35,6 +35,7 @@ from torch.testing._internal.common_dtype import (
     all_types_and_complex_and,
     all_types_and,
 )
+import torch.utils._pytree as pytree
 import torch_xla
 import torch_xla.core.xla_builder as xb
 import torch_xla.core.xla_op_registry as xor

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2370,6 +2370,31 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     self.assertEqual(out.dtype, out_xla.dtype)
     self.assertEqual(out.cpu(), out_xla.cpu(), prec=1e-4)
 
+  def _test_no_fallback(self, runf, args):
+    met.clear_all()
+
+    def run(device):
+      args_ = pytree.tree_map_only(torch.Tensor,
+                                   lambda t: t.clone().detach().to(device),
+                                   args)
+      return runf(*args_)
+
+    actual = run("cpu")
+    expected = run(xm.xla_device())
+
+    self.assertFalse(
+        met.executed_fallback_ops(), msg="expected no fallback operations.")
+    self.assertEqual(
+        actual, expected.cpu(), message="XLA results should match CPU results.")
+
+  def test_isneginf_no_fallback(self):
+    t = torch.rand(10)
+    # Scale the tensor elements.
+    t = t * 100_000
+    # Convert to a lower precision data-type so as to get a few infs.
+    t = t.to(torch.float16)
+    self._test_no_fallback(torch.isneginf, (t,))
+
 
 class MNISTComparator(nn.Module):
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -128,6 +128,7 @@ allowed_opinfo = get_allowed_ops_map(
     AllowedOpInfoEntry('imag'),
     AllowedOpInfoEntry('inverse'),
     AllowedOpInfoEntry('isin'),
+    AllowedOpInfoEntry('isneginf'),
     AllowedOpInfoEntry('le'),
     AllowedOpInfoEntry('linalg.cholesky'),
     AllowedOpInfoEntry('linalg.cholesky_ex'),

--- a/torch_xla/csrc/ops/ops_lower_fn.cpp
+++ b/torch_xla/csrc/ops/ops_lower_fn.cpp
@@ -13,6 +13,7 @@
 #include "torch_xla/csrc/xla_lower_util.h"
 #include "xla/client/lib/math.h"
 #include "xla/client/lib/matrix.h"
+#include "xla/hlo/builder/lib/constants.h"
 #include "xla/hlo/builder/lib/logdet.h"
 
 namespace torch_xla {
@@ -524,6 +525,13 @@ torch_xla::XlaOpVector Isnan::Lower(LoweringContext* loctx) const {
     xla_input = xla::ConvertElementType(xla_input, xla::PrimitiveType::F32);
   }
   return ReturnOp(xla::IsNan(xla_input), loctx);
+}
+
+torch_xla::XlaOpVector Isneginf::Lower(LoweringContext* loctx) const {
+  xla::XlaOp input = loctx->GetOutputOp(operand(0));
+  return ReturnOp(xla::Eq(input, xla::MinValue(input.builder(),
+                                               XlaHelpers::TypeOfXlaOp(input))),
+                  loctx);
 }
 
 torch_xla::XlaOpVector LeakyRelu::Lower(LoweringContext* loctx) const {

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.cpp
@@ -586,6 +586,12 @@ xla::Shape IsnanOutputShape(const torch::lazy::Value& input) {
   return isnan_shape;
 }
 
+xla::Shape IsneginfOutputShape(const torch::lazy::Value& input) {
+  xla::Shape shape(GetXlaShape(input));
+  shape.set_element_type(xla::PRED);
+  return shape;
+}
+
 xla::Shape LeakyReluOutputShape(const torch::lazy::Value& input,
                                 const torch::lazy::Value& negative_slope) {
   auto lower_for_shape_fn =

--- a/torch_xla/csrc/ops/ops_xla_shape_fn.h
+++ b/torch_xla/csrc/ops/ops_xla_shape_fn.h
@@ -172,6 +172,8 @@ xla::Shape InverseOutputShape(const torch::lazy::Value& input);
 
 xla::Shape IsnanOutputShape(const torch::lazy::Value& input);
 
+xla::Shape IsneginfOutputShape(const torch::lazy::Value& input);
+
 xla::Shape LeakyReluOutputShape(const torch::lazy::Value& input,
                                 const torch::lazy::Value& negative_slope);
 


### PR DESCRIPTION
This PR cherry-picks #8912 onto release 2.6.