### PR TITLE
Remove deprecated typing module in ansible flow

### DIFF
--- a/infra/ansible/config/pip.yaml
+++ b/infra/ansible/config/pip.yaml
@@ -26,7 +26,6 @@ pip:
       - tensorboard
       - tensorboardX
       - tqdm
-      - typing
       - typing_extensions
       - sympy
       - yapf==0.30.0


### PR DESCRIPTION
Remove deprecated typing module (it's built into Python now).