### PR TITLE
@assume_pure

### DIFF
--- a/docs/source/perf/assume_pure.md
+++ b/docs/source/perf/assume_pure.md
@@ -1,0 +1,131 @@
+# Use `@assume_pure` to speed up lazy tensor tracing
+
+This document guides how to use `torch_xla.experimental.assume_pure` to eliminate
+lazy tensor tracing overhead. See [this blog post][lazy-tensor] for a primer on
+how lazy tensor tracing (operation recording) works.
+
+## Background and motivation
+
+PyTorch/XLA's lazy tensor tracing ensures correct execution by recording an
+operation graph (lazy tensor IR) when running PyTorch operations. However, for
+complex models, this tracing overhead can exceed the execution time of the
+graph, leading to performance bottlenecks. When training a model, the layers in
+the model must be re-traced on every training step. That's because in the limit,
+there's no guarantee that the layers will do the same thing in different
+training steps. As an extreme example, a layer's `forward()` function may call
+`math.random()` and decide what code to run based on the roll of a dice.
+
+However, this re-tracing errs on the conservative side too much. In many cases,
+the layers in your model do exactly the same thing when given the same input
+tensor shapes, and they will return the same output if given the same input.
+
+Taking advantage of this, `@assume_pure` can be placed on PyTorch/XLA functions
+and easily eliminate lazy tensor tracing overhead. If you have a
+[pure function][pure-function] that operates on XLA tensors, that function can be
+decorated with `@assume_pure` and will only be traced once for each unique input
+tensor shape and dtype combinations. PyTorch/XLA will cache the traced
+computation instead of repeatedly tracing the same operations.
+
+## How to use `@assume_pure`
+
+### Using `@assume_pure` with a function
+
+If you know your function is pure, simply decorate it with `@assume_pure`:
+
+```py
+import torch
+import torch_xla
+from torch_xla.experimental.assume_pure import assume_pure
+
+@assume_pure
+def do_some_math(
+    # You can pass any number of XLA tensors.
+    a: torch.Tensor,
+    b: torch.Tensor,
+
+    # Non-tensor arguments are also supported, and passing different values will
+    # trigger re-tracing and caching more computations.
+    c: int,
+):
+    # Evaluate some pure expressions.
+    return a @ b + c
+
+# Simulate a training loop.
+# Even if we run this function ten times, it will only be traced once.
+for i in range(10):
+    v = do_some_math(
+        torch.tensor([1.0], device='xla'),
+        torch.tensor([2.0], device='xla'),
+        c=42,
+    )
+    print(v)
+```
+
+### Using `@assume_pure` with a `nn.Module`
+
+If you have a pure `nn.Module` i.e. its `forward` behavior only depends on the
+input arguments and the model parameters, we can use `torch.func.functional_call`
+to convert the module into a pure function and pass that to `assume_pure`:
+
+```python
+import torch
+import torch.nn as nn
+from torch.func import functional_call
+from torch_xla.experimental.assume_pure import assume_pure
+
+class MyModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(10, 10)
+    def forward(self, x):
+        return self.linear(x)
+
+# Create module and move to XLA device
+module = MyModule()
+module = module.to('xla')
+
+# Convert module's forward pass into a pure function
+pure_forward = lambda params, buffers, x: functional_call(module, (params, buffers), (x,))
+
+# Wrap the pure function with @assume_pure
+cached_forward = assume_pure(pure_forward)
+
+# Simulate a training loop
+# Even if we run the model ten times, its forward function will only be traced once.
+params = dict(module.named_parameters())
+buffers = dict(module.named_buffers())
+for i in range(10):
+    x = torch.randn(5, 10, device='xla')
+    y = cached_forward(params, buffers, x)
+    print(y)
+```
+
+## Benchmarks
+
+The unit tests contain a benchmark that traces an example 100 layer decoder-only
+language model:
+
+```sh
+~/pytorch/xla
+❯ TESTBRIDGE_TEST_ONLY=test_trace_transformer_with_spda_attention python3 test/test_assume_pure.py --benchmark_iterations 100
+[...]
+No `@assume_pure` time: 140.1342 ms
+`@assume_pure` time: 24.1658 ms
+```
+
+We can see that the version with `@assume_pure` is much faster.
+
+Importantly, the `@assume_pure` running time does not scale with increasing
+complexity inside the model. That's because we only trace the model once, paying
+a fixed up-front cost, and then later runs will reuse the cached XLA computation.
+
+## Limitations
+
+Currently, all operations in a function wrapped with `@assume_pure` must be
+PyTorch upstream operations (e.g. `torch.einsum`, `torch.sin`, ...). More
+PyTorch/XLA operations (e.g. `mark_sharding`) will be supported in the future.
+
+<!-- xrefs -->
+
+[lazy-tensor]: https://pytorch.org/blog/understanding-lazytensor-system-performance-with-pytorch-xla-on-cloud-tpu/
+[pure-function]: https://en.wikipedia.org/wiki/Pure_function

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -211,6 +211,7 @@ function run_xla_op_tests2 {
   run_test "$CDIR/test_callback.py"
   XLA_USE_SPMD=1 run_test "$CDIR/test_callback.py"
   run_test "$CDIR/test_jax_interop.py"
+  run_test "$CDIR/test_assume_pure.py"
 }
 
 # All the new xla op tests should go to run_xla_op_tests3

--- a/test/test_assume_pure.py
+++ b/test/test_assume_pure.py
@@ -49,7 +49,7 @@ class TestAssumePure(absltest.TestCase):
     # Assert
     expected = torch.sin(torch.ones(3, 3) @ torch.ones(3, 3))
     torch.testing.assert_close(actual, expected, check_device=False)
-    
+
   @unittest.skipUnless(xr.global_runtime_device_count() >= 2,
                        "Multiple devices required")
   def test_assume_pure_other_xla_devices(self):
@@ -89,7 +89,8 @@ class TestAssumePure(absltest.TestCase):
     expected = model(torch.ones(3, 3).to('xla'))
     torch.testing.assert_close(actual, expected, check_device=False)
 
-  @unittest.skipIf(xr.device_type() == 'TPU', "Bug: https://github.com/pytorch/xla/issues/8974")
+  @unittest.skipIf(xr.device_type() == 'TPU',
+                   "Bug: https://github.com/pytorch/xla/issues/8974")
   def test_assume_pure_complex_module(self):
     """Test a module comprising of some linear, conv, and relu layers."""
 
@@ -126,7 +127,8 @@ class TestAssumePure(absltest.TestCase):
 
     # Act: call module in a pure way.
     orig_output = orig_model(orig_x)
-    pure_call = lambda params, x: torch.func.functional_call(pure_model, params, x)
+    pure_call = lambda params, x: torch.func.functional_call(
+        pure_model, params, x)
     pure_output = assume_pure(pure_call)(pure_params, pure_x)
     torch_xla.sync()
 
@@ -212,7 +214,8 @@ class TestAssumePure(absltest.TestCase):
     assert_gradients_close(self, a_pure, a_orig)
     assert_gradients_close(self, b_pure, b_orig)
 
-  @unittest.skipIf(xr.device_type() == 'TPU', "Bug: https://github.com/pytorch/xla/issues/8975")
+  @unittest.skipIf(xr.device_type() == 'TPU',
+                   "Bug: https://github.com/pytorch/xla/issues/8975")
   def test_assume_pure_einsum_grads(self):
     """Tests einsum with all inputs requiring gradients."""
 

--- a/test/test_assume_pure.py
+++ b/test/test_assume_pure.py
@@ -1,0 +1,298 @@
+from absl.testing import absltest
+
+import torch
+import torch.nn as nn
+import torch_xla  # Required for XLA device and sync
+from torch_xla.experimental.assume_pure import assume_pure
+import torch_xla.core.xla_model as xm  # For xm.xla_device() and xm.mark_step() / sync()
+import torch_xla.core.xla_builder as xb
+from torch_xla._internal.jax_workarounds import jax_import_guard
+
+
+# Helper function to compare gradients, handling None cases
+def assert_gradients_close(test_case, tensor1, tensor2):
+  grad1 = tensor1.grad
+  grad2 = tensor2.grad
+  if grad1 is None and grad2 is None:
+    return  # Both are None, which is expected if requires_grad=False or disconnected
+  elif grad1 is None or grad2 is None:
+    test_case.fail(
+        f"Gradient mismatch: one is None, the other is not. Grad1: {grad1}, Grad2: {grad2}"
+    )
+  else:
+    # Use xm.save / xm.load if tensors might be on different devices after grad computation,
+    # though typically they should stay on XLA. assert_close handles this check_device=False.
+    torch.testing.assert_close(
+        grad1,
+        grad2,
+        msg=lambda s: f"Gradients do not match {s}",
+        check_device=False)
+
+
+class TestJaxInterop(absltest.TestCase):
+
+  def setUp(self):
+    # Ensure we're using the XLA device for tests
+    self.device = xm.xla_device()
+
+  def test_assume_pure_basic(self):
+
+    @assume_pure
+    def simple_torch_function(a, b):
+      return torch.sin(a @ b)
+
+    a = torch.ones((3, 3), device='xla', requires_grad=True)
+    o = simple_torch_function(a, a)
+    o.sum().backward()
+
+    torch_xla.sync()
+    torch.testing.assert_close(
+        o, torch.sin(torch.ones(3, 3) @ torch.ones(3, 3)), check_device=False)
+
+  def test_assume_pure_module(self):
+    model = nn.Linear(3, 3).to('xla')
+
+    @assume_pure
+    def simple_torch_function(params, x):
+      return torch.func.functional_call(model, params, x)
+
+    a = torch.ones((3, 3), device='xla', requires_grad=True)
+    o = simple_torch_function(dict(model.named_parameters()), a)
+    o.sum().backward()
+
+    torch_xla.sync()
+
+    torch.testing.assert_close(
+        o, model(torch.ones(3, 3).to('xla')), check_device=False)
+
+  def test_assume_pure_avoid_retracing_avoid_rejit(self):
+    starting_lowerings = xb._jax_to_hlo_cache_num_misses()
+    trace_counter = 0
+
+    @assume_pure
+    def simple_torch_function(a, b):
+      nonlocal trace_counter
+      trace_counter += 1
+      return torch.sin(a @ b)
+
+    # Simulate a training loop.
+    for _ in range(5):
+      a = torch.ones((3, 3), device='xla', requires_grad=True)
+      o = simple_torch_function(a, a)
+      o.sum().backward()
+      torch_xla.sync()
+
+    ending_lowerings = xb._jax_to_hlo_cache_num_misses()
+
+    # Check that we only trace once.
+    self.assertEqual(trace_counter, 1)
+
+    # Check that we only lower to HLO twice (once for forward, once for backward).
+    self.assertEqual(ending_lowerings - starting_lowerings, 2)
+
+  def test_assume_pure_matmul_grads(self):
+    """Tests matmul with all inputs requiring gradients."""
+
+    # Define original and decorated functions
+    def original_matmul(a, b):
+      return a @ b
+
+    @assume_pure
+    def decorated_matmul(a, b):
+      # Note: The function wrapped by assume_pure should ideally use torch ops
+      # that have XLA lowering support for efficiency, which matmul does.
+      return a @ b
+
+    # Prepare inputs (cloned for independent grad computation)
+    a_orig = torch.randn(4, 5, device=self.device, requires_grad=True)
+    b_orig = torch.randn(5, 3, device=self.device, requires_grad=True)
+    a_dec = a_orig.clone().detach().requires_grad_(True)
+    b_dec = b_orig.clone().detach().requires_grad_(True)
+
+    # --- Forward Pass ---
+    output_orig = original_matmul(a_orig, b_orig)
+    output_dec = decorated_matmul(a_dec, b_dec)
+
+    # Check forward pass equivalence
+    torch.testing.assert_close(
+        output_orig,
+        output_dec,
+        msg="Forward outputs do not match",
+        check_device=False)
+
+    # --- Backward Pass ---
+    loss_orig = output_orig.sum()
+    loss_dec = output_dec.sum()
+
+    loss_orig.backward()
+    loss_dec.backward()
+    xm.mark_step()  # Use mark_step or sync to ensure computations complete
+
+    # Check gradients
+    assert_gradients_close(self, a_orig, a_dec)
+    assert_gradients_close(self, b_orig, b_dec)
+
+  def test_assume_pure_einsum_grads(self):
+    """Tests einsum with all inputs requiring gradients."""
+
+    def original_einsum(x, y):
+      return torch.einsum('bij,bjk->bik', x, y)
+
+    @assume_pure
+    def decorated_einsum(x, y):
+      return torch.einsum('bij,bjk->bik', x, y)
+
+    # Prepare inputs
+    x_orig = torch.randn(2, 3, 4, device=self.device, requires_grad=True)
+    y_orig = torch.randn(2, 4, 5, device=self.device, requires_grad=True)
+    x_dec = x_orig.clone().detach().requires_grad_(True)
+    y_dec = y_orig.clone().detach().requires_grad_(True)
+
+    # --- Forward Pass ---
+    output_orig = original_einsum(x_orig, y_orig)
+    output_dec = decorated_einsum(x_dec, y_dec)
+    torch.testing.assert_close(
+        output_orig,
+        output_dec,
+        msg="Forward outputs do not match",
+        check_device=False)
+
+    # --- Backward Pass ---
+    output_orig.sum().backward()
+    output_dec.sum().backward()
+    xm.mark_step()
+
+    # Check gradients
+    assert_gradients_close(self, x_orig, x_dec)
+    assert_gradients_close(self, y_orig, y_dec)
+
+  def test_assume_pure_partial_grads_args(self):
+    """Tests a function where only some positional inputs require gradients."""
+
+    def original_func(a, b, c):  # a, c require grad; b does not
+      return a * torch.tanh(b) + c**2
+
+    @assume_pure
+    def decorated_func(a, b, c):
+      return a * torch.tanh(b) + c**2
+
+    # Prepare inputs
+    torch_xla.manual_seed(42)
+    a_orig = torch.randn(
+        3, 3, device=self.device, requires_grad=True, dtype=torch.bfloat16)
+    b_orig = torch.randn(
+        3, 3, device=self.device, requires_grad=False,
+        dtype=torch.bfloat16)  # No grad for b
+    c_orig = torch.randn(
+        3, 3, device=self.device, requires_grad=True, dtype=torch.bfloat16)
+
+    a_dec = a_orig.clone().detach().requires_grad_(True)
+    b_dec = b_orig.clone().detach().requires_grad_(False)  # Match requires_grad
+    c_dec = c_orig.clone().detach().requires_grad_(True)
+
+    # --- Forward Pass ---
+    output_orig = original_func(a_orig, b_orig, c_orig)
+    output_dec = decorated_func(a_dec, b_dec, c_dec)
+    torch.testing.assert_close(
+        output_orig,
+        output_dec,
+        msg="Forward outputs do not match",
+        check_device=False)
+
+    # --- Backward Pass ---
+    output_orig.sum().backward()
+    output_dec.sum().backward()
+    xm.mark_step()
+
+    # Check gradients
+    assert_gradients_close(self, a_orig, a_dec)
+    assert_gradients_close(self, b_orig, b_dec)  # Should both be None
+    assert_gradients_close(self, c_orig, c_dec)
+
+    self.assertIsNone(b_orig.grad, "b_orig should not have grad")
+    self.assertIsNone(b_dec.grad, "b_dec should not have grad")
+
+  def test_assume_pure_partial_grads_kwargs(self):
+    """Tests a function where inputs requiring gradients are passed via kwargs."""
+
+    def original_func(x, *, factor,
+                      bias):  # x, bias require grad; factor does not
+      # factor is a non-tensor kwarg, bias is a tensor kwarg
+      return x * factor + bias
+
+    @assume_pure
+    def decorated_func(x, *, factor, bias):
+      return x * factor + bias
+
+    # Prepare inputs
+    x_orig = torch.randn(3, 3, device=self.device, requires_grad=True)
+    bias_orig = torch.randn(3, 3, device=self.device, requires_grad=True)
+    factor_val = 2.5  # Non-tensor kwarg
+
+    x_dec = x_orig.clone().detach().requires_grad_(True)
+    bias_dec = bias_orig.clone().detach().requires_grad_(True)
+
+    # --- Forward Pass ---
+    output_orig = original_func(x_orig, factor=factor_val, bias=bias_orig)
+    output_dec = decorated_func(x_dec, factor=factor_val, bias=bias_dec)
+    torch.testing.assert_close(
+        output_orig,
+        output_dec,
+        msg="Forward outputs do not match",
+        check_device=False)
+
+    # --- Backward Pass ---
+    output_orig.sum().backward()
+    output_dec.sum().backward()
+    xm.mark_step()
+
+    # Check gradients
+    assert_gradients_close(self, x_orig, x_dec)
+    assert_gradients_close(self, bias_orig, bias_dec)
+    # Factor is not a tensor, so it won't have a .grad attribute
+
+  def test_assume_pure_no_grads_needed(self):
+    """Tests a function where no inputs require gradients."""
+
+    def original_func(a, b):
+      return torch.cos(a) + torch.sin(b)
+
+    @assume_pure
+    def decorated_func(a, b):
+      return torch.cos(a) + torch.sin(b)
+
+    # Prepare inputs
+    a_orig = torch.randn(3, 3, device=self.device, requires_grad=False)
+    b_orig = torch.randn(3, 3, device=self.device, requires_grad=False)
+    a_dec = a_orig.clone().detach().requires_grad_(False)
+    b_dec = b_orig.clone().detach().requires_grad_(False)
+
+    # --- Forward Pass ---
+    output_orig = original_func(a_orig, b_orig)
+    output_dec = decorated_func(a_dec, b_dec)
+    torch.testing.assert_close(
+        output_orig,
+        output_dec,
+        msg="Forward outputs do not match",
+        check_device=False)
+
+    # --- Backward Pass (Optional Check) ---
+    # Cannot call backward if output doesn't require grad
+    self.assertFalse(output_orig.requires_grad)
+    self.assertFalse(output_dec.requires_grad)
+
+    # Explicitly check grads are None
+    self.assertIsNone(a_orig.grad)
+    self.assertIsNone(b_orig.grad)
+    self.assertIsNone(a_dec.grad)
+    self.assertIsNone(b_dec.grad)
+
+
+if __name__ == "__main__":
+  torch.set_default_dtype(torch.float32)
+  torch.manual_seed(42)
+  torch_xla._XLAC._xla_set_mat_mul_precision('highest')
+  jax_import_guard()
+  import torchax
+  torchax.enable_accuracy_mode()
+  absltest.main()

--- a/test/test_assume_pure.py
+++ b/test/test_assume_pure.py
@@ -87,8 +87,7 @@ class TestJaxInterop(absltest.TestCase):
     orig_params = dict(orig_model.named_parameters())
     pure_model = deepcopy(orig_model)
     pure_params = dict(pure_model.named_parameters())
-    orig_x = torch.ones((5, 3, 3, 3), device='xla',
-                        requires_grad=True).to('xla')
+    orig_x = torch.ones((5, 3, 3, 3), device='xla', requires_grad=True)
     pure_x = orig_x.clone().detach().requires_grad_(True)
     torch_xla.sync()
 

--- a/test/tpu/run_tests.sh
+++ b/test/tpu/run_tests.sh
@@ -36,6 +36,7 @@ python3 "$TEST_CDIR/scan/test_scan_spmd.py"
 python3 "$TEST_CDIR/scan/test_scan_pallas.py"
 python3 "$TEST_CDIR/scan/test_scan_layers.py"
 python3 "$TEST_CDIR/test_gru.py"
+python3 "$TEST_CDIR/test_assume_pure.py"
 python3 "$TEST_CDIR/test_as_stride_use_slice.py"
 run_xla_hlo_debug python3 "$TEST_CDIR/scan/test_scan_debug.py"
 python3 "$TEST_CDIR/test_pallas.py" -v

--- a/torch_xla/core/xla_builder.py
+++ b/torch_xla/core/xla_builder.py
@@ -872,15 +872,13 @@ def jax_func_to_xla_computation(jax_func, args, kwargs, name=None):
     import torchax.ops.mappings as mappings
 
     flattened_inputs, spec = jax.tree.flatten((args, kwargs))
+    xla_device = torch_xla.device()  # this is expensive so do it once
 
     def abstractify(a):  # make a pytree leaf abstract
-      import jax
-      import torch_xla
       if a is None:
         return None
       if isinstance(a, torch.Tensor):
-        assert a.device == torch_xla.device(
-        ), f"Inputs must be XLA tensors. Got {a.device}"
+        assert a.device == xla_device, f"Inputs must be XLA tensors. Got {a.device}"
         return jax.ShapeDtypeStruct(a.shape, mappings.t2j_dtype(a.dtype))
       return a
 

--- a/torch_xla/core/xla_builder.py
+++ b/torch_xla/core/xla_builder.py
@@ -872,13 +872,12 @@ def jax_func_to_xla_computation(jax_func, args, kwargs, name=None):
     import torchax.ops.mappings as mappings
 
     flattened_inputs, spec = jax.tree.flatten((args, kwargs))
-    xla_device = torch_xla.device()  # this is expensive so do it once
 
     def abstractify(a):  # make a pytree leaf abstract
       if a is None:
         return None
       if isinstance(a, torch.Tensor):
-        assert a.device == xla_device, f"Inputs must be XLA tensors. Got {a.device}"
+        assert a.device.type == 'xla', f"Inputs must be XLA tensors. Got {a.device}"
         return jax.ShapeDtypeStruct(a.shape, mappings.t2j_dtype(a.dtype))
       return a
 

--- a/torch_xla/experimental/assume_pure.py
+++ b/torch_xla/experimental/assume_pure.py
@@ -14,11 +14,11 @@ def assume_pure(fn):
   Returns a new function that will only be traced once for each unique
   input tensor shapes or non-tensor input argument values. This is useful
   for removing Lazy Tensor tracing overhead.
+  
+  The decorated function must be pure (i.e. no side-effects, behavior
+  only depends on inputs).
 
   Limitations:
-
-  - The decorated function must be pure (i.e. no side-effects, behavior
-    only depends on inputs).
   - The decorated function can only use upstream PyTorch operators e.g.
     `torch.einsum`, `torch.nn.functional.layer_norm`. Custom PyTorch/XLA
     operations such as `mark_sharding` are not supported. This limitation

--- a/torch_xla/experimental/assume_pure.py
+++ b/torch_xla/experimental/assume_pure.py
@@ -1,8 +1,5 @@
 import torch
 
-from inspect import signature
-from functools import wraps
-
 from torch_xla._internal.jax_workarounds import requires_jax
 import torch_xla.core.xla_builder as xb
 
@@ -33,89 +30,9 @@ def j2t_autograd(fn):
   """Given a JAX function, returns a PyTorch autograd function implemented with `jax.vjp(fn)`.
 
   It wraps `fn` with `jax.vjp` to compute both the output and residuals (intermediate
-  activations). The wrapped function is then jitted via `xb.call_jax` and integrated into
+  activations). The wrapped function is then run via `call_jax` and integrated into
   the PyTorch autograd framework by saving the residuals into the context object.
   """
+  import torchax.interop
+  return torchax.interop.j2t_autograd(fn, call_jax=lambda fn, *args: xb.call_jax(fn, args))
 
-  @wraps(fn)
-  def inner(*args, **kwargs):
-    from jax.tree_util import tree_flatten, tree_unflatten
-    from jax.util import safe_zip
-
-    class JaxFun(torch.autograd.Function):
-
-      @staticmethod
-      def forward(ctx, tree_def, *flat_inputs):
-        # Reconstruct the original args and kwargs
-        args, kwargs = tree_unflatten(tree_def, flat_inputs)
-
-        # Execute the JAX computation
-        # Pass the reconstructed args/kwargs tuple as the primal
-        y, fun_vjp = xb.call_jax(
-            _jax_forward, args=(
-                fn,
-                (args, kwargs),
-            ))
-
-        # Save necessary information for backward
-        # Flatten the vjp function. `vjp_spec` contains a jaxpr for the backward pass.
-        # `residuals` contains the tensors needed for the backward pass.`
-        residuals, vjp_spec = tree_flatten(fun_vjp)
-        ctx.vjp_spec = vjp_spec
-        ctx.save_for_backward(*residuals)
-
-        return y
-
-      @staticmethod
-      def backward(ctx, *grad_out):
-        assert len(grad_out) > 0
-        grad_out = grad_out if len(grad_out) > 1 else grad_out[0]
-
-        input_grads_structured = xb.call_jax(
-            _jax_backward, args=(ctx.vjp_spec, ctx.saved_tensors, grad_out))
-
-        # Flatten the gradients to match the flat inputs to forward
-        flat_input_grads, _ = tree_flatten(input_grads_structured)
-
-        # Construct the gradient tuple to be returned.
-        # It needs to match the inputs to forward: (tree_def, *flat_inputs)
-        # The first gradient (for tree_def) is None.
-        # The subsequent gradients correspond to flat_inputs.
-        # We need to put a None for inputs that did not require gradients.
-        final_grads = [None]
-        for needs_grad, grad in safe_zip(ctx.needs_input_grad[1:],
-                                         flat_input_grads):
-          final_grads.append(grad if needs_grad else None)
-
-        return tuple(final_grads)
-
-    sig = signature(fn)
-    bound = sig.bind(*args, **kwargs)
-    bound.apply_defaults()
-    flat_args_kwargs, tree_def = tree_flatten((bound.args, bound.kwargs))
-    return JaxFun.apply(tree_def, *flat_args_kwargs)
-
-  return inner
-
-
-def _jax_forward(fn, primals):
-  """JAX function to compute output and vjp function.
-
-  primals should be a tuple (args, kwargs).
-  """
-  import jax
-
-  def fn_wrapper(a, kw):
-    return fn(*a, **kw)
-
-  return jax.vjp(fn_wrapper, *primals)
-
-
-def _jax_backward(vjp_spec, saved_tensors, grad_out):
-  """JAX function to compute input gradients.
-
-  Unflattening `saved_tensors` with `vjp_spec` should restore the original vjp function.
-  """
-  from jax.tree_util import tree_unflatten
-  fun_vjp = tree_unflatten(vjp_spec, saved_tensors)
-  return fun_vjp(grad_out)

--- a/torch_xla/experimental/assume_pure.py
+++ b/torch_xla/experimental/assume_pure.py
@@ -1,0 +1,125 @@
+import torch
+
+from inspect import signature
+from functools import wraps
+
+from torch_xla._internal.jax_workarounds import requires_jax
+import torch_xla.core.xla_builder as xb
+
+
+@requires_jax
+def assume_pure(fn):
+  """Decorates a pure PyTorch/XLA function to skip expensive re-tracing.
+
+  Returns a new function that will only be traced once for each unique
+  input tensor shapes or non-tensor input argument values. This is useful
+  for removing Lazy Tensor tracing overhead.
+
+  The decorated function must be pure (i.e. no side-effects).
+  """
+  from torchax.interop import jax_view
+  return _jax2torch(jax_view(fn))
+
+
+# Define the JAX function to compute value and vjp
+def _jax_forward(fn, primals):
+  import jax
+
+  # Prepare the function call for jax.vjp
+  # jax.vjp expects positional primals. We wrap fn to accept args, kwargs.
+  def fn_wrapper(a, kw):
+    return fn(*a, **kw)
+
+  # primals will be (args_rec, kwargs_rec)
+  return jax.vjp(fn_wrapper, *primals)  # Unpack primals here
+
+
+def _jax_backward(vjp_spec, saved_tensors, grad_args):
+  from jax.tree_util import tree_unflatten
+  fun_vjp = tree_unflatten(vjp_spec, saved_tensors)
+  return fun_vjp(grad_args)
+
+
+def _jax2torch(fn):
+
+  @wraps(fn)
+  def inner(*args, **kwargs):
+    from jax.tree_util import tree_flatten, tree_unflatten
+
+    class JaxFun(torch.autograd.Function):
+
+      @staticmethod
+      def forward(ctx, tree_def, *flat_args_kwargs_values):
+        # Note: flat_args_kwargs_values contains the *values* from the flattened structure
+
+        # Reconstruct the original args and kwargs inside forward
+        args_rec, kwargs_rec = tree_unflatten(tree_def, flat_args_kwargs_values)
+
+        # Execute the JAX computation
+        # Pass the reconstructed args/kwargs tuple as the primal
+        y_, fun_vjp = xb.call_jax(
+            _jax_forward, args=(
+                fn,
+                (args_rec, kwargs_rec),
+            ))
+
+        # Save necessary information for backward
+        # Flatten the vjp function (may contain tensors/non-tensors)
+        residuals, vjp_spec = tree_flatten(fun_vjp)
+
+        # Save only tensors needed for backward (the residuals)
+        # Autograd automatically gives None gradients for non-tensor inputs.
+        # We need the vjp_spec (non-tensor) and tree_def for reconstruction.
+        ctx.vjp_spec = vjp_spec
+        ctx.tree_def = tree_def  # Need tree_def to structure gradients in backward
+        # Save residuals which might be tensors needed by the VJP function
+        ctx.save_for_backward(*residuals)
+
+        # Return the results (potentially nested structure)
+        # The user expects the original output structure of fn
+        return y_
+
+      @staticmethod
+      def backward(ctx, *grad_args):
+        assert len(grad_args) > 0
+        grad_args = grad_args if len(grad_args) > 1 else grad_args[0]
+
+        input_grads_structured = xb.call_jax(
+            _jax_backward, args=(ctx.vjp_spec, ctx.saved_tensors, grad_args))
+
+        # Flatten the gradients to match the flat inputs to forward
+        flat_input_grads, _ = tree_flatten(input_grads_structured)
+
+        # Construct the gradient tuple for autograd.
+        # It needs to match the inputs to forward: (tree_def, *flat_args_kwargs_values)
+        # The first gradient (for tree_def) is None.
+        # The following gradients correspond to flat_args_kwargs_values.
+        # We need to return None for inputs that did not require gradients.
+        final_grads = [None]  # Gradient for tree_def is None
+        input_grad_iter = iter(flat_input_grads)
+        for i, needs_grad in enumerate(
+            ctx.needs_input_grad[1:]):  # Skip ctx for tree_def
+          if needs_grad:
+            # This input leaf required grad, so JAX should have computed one
+            try:
+              grad = next(input_grad_iter)
+              final_grads.append(grad)
+            except StopIteration:
+              # Should not happen if JAX computed grads for all required inputs
+              raise ValueError(
+                  "Warning: Mismatch between required grads and JAX output grads."
+              ) from None
+          else:
+            # This input leaf did not require grad
+            final_grads.append(None)
+            grad = next(input_grad_iter)
+
+        return tuple(final_grads)
+
+    sig = signature(fn)
+    bound = sig.bind(*args, **kwargs)
+    bound.apply_defaults()
+    flat_args_kwargs, tree_def = tree_flatten((bound.args, bound.kwargs))
+    return JaxFun.apply(tree_def, *flat_args_kwargs)
+
+  return inner

--- a/torch_xla/experimental/assume_pure.py
+++ b/torch_xla/experimental/assume_pure.py
@@ -1,5 +1,3 @@
-import torch
-
 from torch_xla._internal.jax_workarounds import requires_jax
 import torch_xla.core.xla_builder as xb
 
@@ -34,5 +32,5 @@ def j2t_autograd(fn):
   the PyTorch autograd framework by saving the residuals into the context object.
   """
   import torchax.interop
-  return torchax.interop.j2t_autograd(fn, call_jax=lambda fn, *args: xb.call_jax(fn, args))
-
+  return torchax.interop.j2t_autograd(
+      fn, call_jax=lambda fn, *args: xb.call_jax(fn, args))

--- a/torchax/torchax/interop.py
+++ b/torchax/torchax/interop.py
@@ -1,6 +1,8 @@
 import copy
 import functools
 import torch
+from inspect import signature
+from functools import wraps
 from torch.nn.utils import stateless as torch_stateless
 import jax
 import jax.numpy as jnp
@@ -178,6 +180,99 @@ def call_torch(torch_func: TorchCallable, *args: JaxValue, **kwargs: JaxValue) -
     with torchax.default_env():
         res: TorchValue = torch_func(*args, **kwargs)
     return jax_view(res)
+
+
+def j2t_autograd(fn, call_jax=call_jax):
+    """Given a JAX function, returns a PyTorch autograd function implemented with `jax.vjp(fn)`.
+
+    It wraps `fn` with `jax.vjp` to compute both the output and residuals (intermediate
+    activations). The wrapped function is then run via `call_jax` and integrated into
+    the PyTorch autograd framework by saving the residuals into the context object.
+    """
+
+    @wraps(fn)
+    def inner(*args, **kwargs):
+        from jax.tree_util import tree_flatten, tree_unflatten
+        from jax.util import safe_zip
+
+        class JaxFun(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, tree_def, *flat_inputs):
+                # Reconstruct the original args and kwargs
+                args, kwargs = tree_unflatten(tree_def, flat_inputs)
+
+                # Execute the JAX computation
+                # Pass the reconstructed args/kwargs tuple as the primal
+                y, fun_vjp = call_jax(
+                    _jax_forward,
+                    fn,
+                    (args, kwargs),
+                )
+
+                # Save necessary information for backward
+                # Flatten the vjp function. `vjp_spec` contains a jaxpr for the backward pass.
+                # `residuals` contains the tensors needed for the backward pass.`
+                residuals, vjp_spec = tree_flatten(fun_vjp)
+                ctx.vjp_spec = vjp_spec
+                ctx.save_for_backward(*residuals)
+
+                return y
+
+            @staticmethod
+            def backward(ctx, *grad_out):
+                assert len(grad_out) > 0
+                grad_out = grad_out if len(grad_out) > 1 else grad_out[0]
+
+                input_grads_structured = call_jax(
+                    _jax_backward, ctx.vjp_spec, ctx.saved_tensors, grad_out
+                )
+
+                # Flatten the gradients to match the flat inputs to forward
+                flat_input_grads, _ = tree_flatten(input_grads_structured)
+
+                # Construct the gradient tuple to be returned.
+                # It needs to match the inputs to forward: (tree_def, *flat_inputs)
+                # The first gradient (for tree_def) is None.
+                # The subsequent gradients correspond to flat_inputs.
+                # We need to put a None for inputs that did not require gradients.
+                final_grads = [None]
+                for needs_grad, grad in safe_zip(
+                    ctx.needs_input_grad[1:], flat_input_grads
+                ):
+                    final_grads.append(grad if needs_grad else None)
+
+                return tuple(final_grads)
+
+        sig = signature(fn)
+        bound = sig.bind(*args, **kwargs)
+        bound.apply_defaults()
+        flat_args_kwargs, tree_def = tree_flatten((bound.args, bound.kwargs))
+        return JaxFun.apply(tree_def, *flat_args_kwargs)
+
+    return inner
+
+
+def _jax_forward(fn, primals):
+  """JAX function to compute output and vjp function.
+
+  primals should be a tuple (args, kwargs).
+  """
+  import jax
+
+  def fn_wrapper(a, kw):
+    return fn(*a, **kw)
+
+  return jax.vjp(fn_wrapper, *primals)
+
+
+def _jax_backward(vjp_spec, saved_tensors, grad_out):
+  """JAX function to compute input gradients.
+
+  Unflattening `saved_tensors` with `vjp_spec` should restore the original vjp function.
+  """
+  from jax.tree_util import tree_unflatten
+  fun_vjp = tree_unflatten(vjp_spec, saved_tensors)
+  return fun_vjp(grad_out)
 
 
 fori_loop = torch_view(jax.lax.fori_loop)


### PR DESCRIPTION
Fixes #8805.

We introduce a decorator, `@assume_pure`, that can be placed on PyTorch/XLA functions and easily eliminate lazy tensor tracing overhead. If you have a pure function that only uses torch upstream ops, that function can be decorated with `@assume_pure` and will only be traced once for each unique input tensor shape combinations.

## Design

`@assume_pure` brings together three pieces of existing technologies:

- `jax.vjp`, which takes a JAX function and gives you the autograd forward and backward pass
- `torchax`, which converts a pure PyTorch function to a JAX function
- `xb.call_jax`, which can call any JAX function from PyTorch/XLA and integrate it into the HLO graph

It works by:

- Use `torchax.interop.jax_view` to obtain a JAX function from the input PyTorch function
- Use `jax.vjp` to get the forward and backward pass
- Return a `torch.autograd.Function` instance, where the forward implementation is `xb.call_jax(forward_pass)`, and the backward implementation is `xb.call_jax(backward_pass)`, respectively.

The core logic is actually just a single line:

```python
def assume_pure(fn):
  from torchax.interop import jax_view
  return j2t_autograd(jax_view(fn))
```

### How is the HLO cached

`xb.call_jax` caches the HLO if all the input shapes/dtypes and non-tensor arguments are the same.

Therefore, subsequent `xb.call_jax` will just reuse the cached HLO instead of retracing.

The same kind of caching happens in both the forward and backward pass.

Different from the jax wrapper we used in `splash_attention`, the `j2t_autograd` function saves the residuals (intermediate activations) during the forward pass and reuses them during the backward by plugging those into the `vjp_fun` again. This means it won't force a rematerialization (rerun the fwd) during the backward.

## Alternatives

Instead of `jax.vjp` we could also use AOTAutograd to get the forward and backward pass. However, AOTAutograd has a number of downsides:

- It does more than just getting the backward. It also forcefully decomposes all operations into the "aten" op set. Decomposing operations will negatively impact performance, especially in the case of einsum.
- There is no straightforward path to support profiler trace spans. In contrast, in the proposed approach we could translate `xp.Trace(...)` to `jax.named_scope(...)`.
- Supporting custom operations such as pallas kernels will be cumbersome. We'll need to wrap every kernel into a PyTorch custom operator in order for AOTAutograd to not crash on those functions. In contrast, in the proposed approach we could augment our pallas kernels to directly jump into JAX when the input tensor is a torchax tensor.

Instead of `assume_pure`, we could also use `torch.compile` to cache the XLA executable of the compiled function and skip the lazy tensor tracing. However, `torch.compile` has its own downsides:

- `torch.compile` itself uses AOTAutograd and will suffer from the decomposition and customer operations issues etc.
- `torch.compile` has a general perception of "either it works, or debugging will be complicated", which has been corroborated by experiments by people in the PyTorch/XLA team. See PyTorch team members' own recommendation [1]. In contrast, `@assume_pure` has very simple rules for determining if it will work: if your function is pure, then it works.
- `torch.compile` will graph break when entering and leaving the compiled region. In contrast, `@assume_pure` can avoid tracing overhead without even breaking the graph. The cached HLO is inlined into the overall HLO.

## Benchmarks

I tested tracing an example 100 layer decoder-only model:

```sh
~/pytorch/xla
❯ TESTBRIDGE_TEST_ONLY=test_trace_transformer_with_spda_attention python3 test/test_assume_pure.py --benchmark_iterations 100
[...]
No `@assume_pure` time: 140.1342 ms
`@assume_pure` time: 24.1658 ms
```

Importantly, the `@assume_pure` does not scale with increasing complexity inside the model. That's because we only trace the model once, paying a fixed up-front cost, and then later runs will reuse the cached XLA computation object.

Anecdotally, @bhavya01 reported saving >200ms tracing time in an SDXL experiment. That's very significant since each training step is sub-1 second.

[1]: https://docs.google.com/document/d/1y5CRfMLdwEoF1nTk9q8qEu1mgMUuUtvhklPKJ2emLU8/edit?tab=t.0
