### PR TITLE
Avoid re-computing computation hashes (#8976)

### DIFF
--- a/torch_xla/csrc/debug_util.cpp
+++ b/torch_xla/csrc/debug_util.cpp
@@ -19,6 +19,7 @@
 #include "torch_xla/csrc/ir_dump_util.h"
 #include "torch_xla/csrc/runtime/debug_macros.h"
 #include "torch_xla/csrc/runtime/sys_util.h"
+#include "torch_xla/csrc/runtime/xla_util.h"
 #include "torch_xla/csrc/xla_graph_executor.h"
 
 namespace torch_xla {
@@ -431,9 +432,20 @@ void DebugUtil::post_compilation_analysis(
     return;
   }
 
+  std::stringstream ss;
+  // This can be used to verify the hash of the underlying computation proto.
+  // Note that for UserComputation computations, the protobuf is factored in
+  // the graph hash.
+  std::string serialized_computation =
+      ConsumeValue(runtime::util::GetDeterministicSerializedModuleProto(
+          computation->computation().proto()));
+  ss << "\n"
+     << "Computation hash: "
+     << torch::lazy::HashToString(torch::lazy::Hash(serialized_computation))
+     << "\n";
+
   constexpr std::string_view debug_output_prefix =
       "Post Compilation Analysis: ";
-  std::stringstream ss;
   ss << "\n"
      << debug_output_prefix
      << "======================================================================"

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -1210,13 +1210,7 @@ XLAGraphExecutor::LookupCachedCompile(const torch::lazy::hash_t& hash) {
     TORCH_LAZY_COUNTER("UncachedCompile", 1);
     return nullptr;
   }
-  std::string serialized_computation =
-      ConsumeValue(runtime::util::GetDeterministicSerializedModuleProto(
-          cached_computation->computation->computation().proto()));
-  TF_VLOG(5) << "Graph hash " << torch::lazy::HashToString(hash)
-             << " is computation hash "
-             << torch::lazy::HashToString(
-                    torch::lazy::Hash(serialized_computation));
+  TF_VLOG(5) << "Graph hash: " << torch::lazy::HashToString(hash);
   TORCH_LAZY_COUNTER("CachedCompile", 1);
   return cached_computation;
 }
@@ -1474,14 +1468,7 @@ XLAGraphExecutor::CompilationResult XLAGraphExecutor::Compile(
              << coll.device << " done!";
   TF_VLOG(5) << "Compiled program shape "
              << computations.front()->program_shape().ToString() << std::endl;
-  std::string serialized_computation =
-      ConsumeValue(runtime::util::GetDeterministicSerializedModuleProto(
-          computations.front()->computation().proto()));
-  TF_VLOG(5) << "Graph hash " << torch::lazy::HashToString(coll.hash)
-             << " is computation hash "
-             << torch::lazy::HashToString(
-                    torch::lazy::Hash(serialized_computation));
-
+  TF_VLOG(5) << "Graph hash: " << torch::lazy::HashToString(coll.hash);
   if (use_autosharding) {
     const xla::HloModuleProto& computation_proto =
         computations.front()->computation().proto();


### PR DESCRIPTION
Currently, we are recomputing the hash of the underlying computation for every hash lookup, as a mere logging in two places. For small models where tracing is not negligible, this can have a small impact - particularly since we deserialize the protobuf deterministically (requiring the ordering of unordered dictionary/map entries). The logging was unchanged, but the underlying deserialization logic is relatively slower, in order to guarantee deterministic hashes for user computations. C++'s evaluates stream operators eagerly, so the impact is there with or without the logging levels. We recently saw ~10% throughput impact for small BERT/Llama models.

Note that this is only used to provide an unique hash string for which a hash key maps to. The actual hash of the protobuf is only meaningful for UserComputation computations, where it is factored in the hash key. In all other cases, it is unnecessary and serves as an unique (debug) identifier, and the user can still verify the mapping for any given graph hash key when enabling `post_compilation_analysis`.

We see this during hash lookup, which is evaluated every time. We also see it in `Compile`, though it is there only for the very first computation (across all instances). The user can still access the computation proto hash by enabling `PT_XLA_DEBUG`.

e.g. for BERT HF pretraining (20 steps) - 48 metrics with 27 samples each, the collective tracing of each hash computation metric is as follows:
```
- Average Rate: ~1.98 operations/second
- Most rates fall between 1.4-2.5 ops/second with a few outliers
- Highest Rate: 7.26772 ops/second (outlier)
- Lowest Rate: ~1.42 ops/second

- Typical p50 (median) latency per op: ~8-9 microseconds
- Typical p95 latency per op: ~450-500 microseconds
- Typical p99 latency per op: ~500-600 microseconds
```
