### PR TITLE
scan-based GRU falls back to nn.GRU when `bidirectional` is true.

### DIFF
--- a/torch_xla/experimental/gru.py
+++ b/torch_xla/experimental/gru.py
@@ -1,6 +1,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import logging
 from torch.nn.utils.rnn import PackedSequence
 from typing import overload
 
@@ -58,6 +59,15 @@ class GRU(nn.GRU):
   - Only supports inputs in the `(seq, batch, feature)` format (i.e. `batch_first = False`).
 
   """
+
+  def __new__(cls, *args, **kwargs):
+    if ('bidirectional' in kwargs and kwargs['bidirectional'] == True):
+      logging.warning(
+          "Scan-based GRU only supports unidirectional GRU. (bidirectional = False) "
+          "Scan-based GRU falls back to the default nn.GRU implementation instead."
+      )
+      return nn.GRU(*args, **kwargs)
+    return super().__new__(cls)
 
   @overload
   def __init__(


### PR DESCRIPTION
This change makes scan-based GRU implementation to fall back to the standard pytorch GRU when `bidirectional` is true. scan-based GRU will not support `bidirectional` unless there is enough demand. for details: https://github.com/pytorch/xla/issues/8860