### PR TITLE
fix libtpu path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,10 @@ base_dir = os.path.dirname(os.path.abspath(__file__))
 USE_NIGHTLY = True  # whether to use nightly or stable libtpu and jax
 
 _date = '20250406'
-_libtpu_version = '0.0.13'
+# The postfix can be changed when the version is updated. Check
+# https://storage.googleapis.com/libtpu-wheels/index.html for detailed
+# versioning.
+_libtpu_version = '0.0.13-py3-none-manylinux_2_31_x86_64'
 _jax_version = '0.5.4'
 _jaxlib_version = '0.5.4'
 
@@ -82,7 +85,10 @@ if USE_NIGHTLY:
   _libtpu_wheel_name += f".dev{_date}+nightly"
   _libtpu_storage_directory = 'libtpu-nightly-releases'
 
-_libtpu_storage_path = f'https://storage.googleapis.com/{_libtpu_storage_directory}/wheels/libtpu/{_libtpu_wheel_name}-py3-none-linux_x86_64.whl'
+if USE_NIGHTLY:
+  _libtpu_storage_path = f'https://storage.googleapis.com/{_libtpu_storage_directory}/wheels/libtpu/{_libtpu_wheel_name}-py3-none-linux_x86_64.whl'
+else:
+  _libtpu_storage_path = f'https://storage.googleapis.com/{_libtpu_storage_directory}/wheels/libtpu/{_libtpu_wheel_name}.whl'
 
 
 def _get_build_mode():

--- a/setup.py
+++ b/setup.py
@@ -73,20 +73,18 @@ _libtpu_version = '0.0.13'
 _jax_version = '0.5.4'
 _jaxlib_version = '0.5.4'
 
-_libtpu_wheel_name = f'libtpu-{_libtpu_version}'
-_libtpu_storage_directory = 'libtpu-lts-releases'
-
 if USE_NIGHTLY:
   _libtpu_version += f'.dev{_date}'
   _jax_version += f'.dev{_date}'
   _jaxlib_version += f'.dev{_date}'
-  _libtpu_wheel_name += f'.dev{_date}+nightly-py3-none-linux_x86_64'
+  _libtpu_wheel_name = f'libtpu-{_libtpu_version}.dev{_date}+nightly-py3-none-linux_x86_64'
   _libtpu_storage_directory = 'libtpu-nightly-releases'
 else:
   # The postfix can be changed when the version is updated. Check
   # https://storage.googleapis.com/libtpu-wheels/index.html for correct
   # versioning.
-  _libtpu_wheel_name += '-py3-none-manylinux_2_31_x86_64'
+  _libtpu_wheel_name = 'libtpu-{_libtpu_version}-py3-none-manylinux_2_31_x86_64'
+  _libtpu_storage_directory = 'libtpu-lts-releases'
 
 if USE_NIGHTLY:
   _libtpu_storage_path = f'https://storage.googleapis.com/{_libtpu_storage_directory}/wheels/libtpu/{_libtpu_wheel_name}.whl'

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,6 @@ _jax_version = '0.5.4'
 _jaxlib_version = '0.5.4'
 
 if USE_NIGHTLY:
-  _libtpu_version += f'.dev{_date}'
   _jax_version += f'.dev{_date}'
   _jaxlib_version += f'.dev{_date}'
   _libtpu_wheel_name = f'libtpu-{_libtpu_version}.dev{_date}+nightly-py3-none-linux_x86_64'

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ else:
   # The postfix can be changed when the version is updated. Check
   # https://storage.googleapis.com/libtpu-wheels/index.html for correct
   # versioning.
-  _libtpu_wheel_name = 'libtpu-{_libtpu_version}-py3-none-manylinux_2_31_x86_64'
+  _libtpu_wheel_name = f'libtpu-{_libtpu_version}-py3-none-manylinux_2_31_x86_64'
   _libtpu_storage_directory = 'libtpu-lts-releases'
 
 _libtpu_storage_path = f'https://storage.googleapis.com/{_libtpu_storage_directory}/wheels/libtpu/{_libtpu_wheel_name}.whl'

--- a/setup.py
+++ b/setup.py
@@ -85,10 +85,7 @@ else:
   _libtpu_wheel_name = 'libtpu-{_libtpu_version}-py3-none-manylinux_2_31_x86_64'
   _libtpu_storage_directory = 'libtpu-lts-releases'
 
-if USE_NIGHTLY:
-  _libtpu_storage_path = f'https://storage.googleapis.com/{_libtpu_storage_directory}/wheels/libtpu/{_libtpu_wheel_name}.whl'
-else:
-  _libtpu_storage_path = f'https://storage.googleapis.com/{_libtpu_storage_directory}/wheels/libtpu/{_libtpu_wheel_name}.whl'
+_libtpu_storage_path = f'https://storage.googleapis.com/{_libtpu_storage_directory}/wheels/libtpu/{_libtpu_wheel_name}.whl'
 
 
 def _get_build_mode():

--- a/setup.py
+++ b/setup.py
@@ -68,10 +68,8 @@ base_dir = os.path.dirname(os.path.abspath(__file__))
 USE_NIGHTLY = True  # whether to use nightly or stable libtpu and jax
 
 _date = '20250406'
-# The postfix can be changed when the version is updated. Check
-# https://storage.googleapis.com/libtpu-wheels/index.html for detailed
-# versioning.
-_libtpu_version = '0.0.13-py3-none-manylinux_2_31_x86_64'
+
+_libtpu_version = '0.0.13'
 _jax_version = '0.5.4'
 _jaxlib_version = '0.5.4'
 
@@ -79,14 +77,19 @@ _libtpu_wheel_name = f'libtpu-{_libtpu_version}'
 _libtpu_storage_directory = 'libtpu-lts-releases'
 
 if USE_NIGHTLY:
-  _libtpu_version += f".dev{_date}"
-  _jax_version += f".dev{_date}"
-  _jaxlib_version += f".dev{_date}"
-  _libtpu_wheel_name += f".dev{_date}+nightly"
+  _libtpu_version += f'.dev{_date}'
+  _jax_version += f'.dev{_date}'
+  _jaxlib_version += f'.dev{_date}'
+  _libtpu_wheel_name += f'.dev{_date}+nightly-py3-none-linux_x86_64'
   _libtpu_storage_directory = 'libtpu-nightly-releases'
+else:
+  # The postfix can be changed when the version is updated. Check
+  # https://storage.googleapis.com/libtpu-wheels/index.html for correct
+  # versioning.
+  _libtpu_wheel_name += '-py3-none-manylinux_2_31_x86_64'
 
 if USE_NIGHTLY:
-  _libtpu_storage_path = f'https://storage.googleapis.com/{_libtpu_storage_directory}/wheels/libtpu/{_libtpu_wheel_name}-py3-none-linux_x86_64.whl'
+  _libtpu_storage_path = f'https://storage.googleapis.com/{_libtpu_storage_directory}/wheels/libtpu/{_libtpu_wheel_name}.whl'
 else:
   _libtpu_storage_path = f'https://storage.googleapis.com/{_libtpu_storage_directory}/wheels/libtpu/{_libtpu_wheel_name}.whl'
 


### PR DESCRIPTION
libtpu release wheel naming doesn't follow the trailing `-py3-none-linux_x86_64.whl`. It should be something like `-py3-none-manylinux_2_31_x86_64` and the number `2_31` is subject to change. So I encode the naming into `_libtpu_version`.

Check https://storage.googleapis.com/libtpu-wheels/index.html for detailed naming.