### PR TITLE
Remove unnecessary registries for 2.7 install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@ started:
 To install PyTorch/XLA stable build in a new TPU VM:
 
 ```sh
-pip install torch~=2.6.0 'torch_xla[tpu]~=2.6.0' \
-  -f https://storage.googleapis.com/libtpu-releases/index.html \
-  -f https://storage.googleapis.com/libtpu-wheels/index.html
+pip install torch~=2.7.0 'torch_xla[tpu]~=2.7.0'
 
 # Optional: if you're using custom kernels, install pallas dependencies
 pip install 'torch_xla[pallas]' \


### PR DESCRIPTION
It looks like we already got rid of the libtpu-nightly cleanup package in the 2.7 stable branch. Here we remove those `-f` flags in the README too.

We'll need to make a similar change in the README.md of the master branch at a later time when 2.7 is released.

TESTED:

```sh
wget https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.7.0rc5-cp311-cp311-linux_x86_64.whl
pip install torch_xla-2.7.0rc5-cp311-cp311-linux_x86_64.whl 'torch_xla[tpu]'
# No extra registries needed here!
```