### PR TITLE
Fix broken link to GPU docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ TorchVision, and PyTorch/XLA.
 
 ### Additional steps for GPU
 
-Please refer to this [guide](https://github.com/pytorch/xla/blob/master/docs/gpu.md#develop-pytorchxla-on-a-gpu-instance-build-pytorchxla-from-source-with-gpu-support).
+Please refer to this [guide](https://github.com/pytorch/xla/blob/master/README.md#gpu-plugin).
 
 ## Before Submitting A Pull Request:
 


### PR DESCRIPTION
I noticed that the doc was linking to an outdated link. The closest GPU related documentation I found that matches the original [gpu.md](https://github.com/pytorch/xla/blob/07d0823f2c33e83673787d53dc4c3e5bdf292449/docs/gpu.md#L5) is the [README.md](https://github.com/pytorch/xla/blob/master/README.md#gpu-plugin).

Please help double check if this is the right doc to link! Thanks.