### PR TITLE
Add `clang` link to `PATH`.

### DIFF
--- a/infra/ansible/config/apt.yaml
+++ b/infra/ansible/config/apt.yaml
@@ -14,7 +14,7 @@ apt:
       - vim
       - wget
       - clang-format
-      - clang-17
+      - clang-{{ clang_version }}
       - gcc-10
       - g++-10
       - lcov

--- a/infra/ansible/playbook.yaml
+++ b/infra/ansible/playbook.yaml
@@ -66,6 +66,8 @@
             pip.pkgs_nodeps[stage + '_' + arch] | default([], true) +
             pip.pkgs_nodeps[stage + '_' + accelerator] | default([], true)
           }}"
+
+        llvm_path: "/usr/lib/llvm-{{ clang_version }}/bin"
       tags: install_deps
 
     - role: fetch_srcs

--- a/infra/ansible/roles/install_deps/tasks/main.yaml
+++ b/infra/ansible/roles/install_deps/tasks/main.yaml
@@ -34,3 +34,9 @@
   ansible.builtin.pip:
     name: "{{ pip_pkgs_nodeps }}"
     extra_args: "--no-deps"
+
+- name: Install Clang Alternatives
+  command: update-alternatives --install /usr/bin/{{ item }} {{ item }} {{ llvm_path }}/{{ item }} 100
+  loop:
+    - clang
+    - clang++


### PR DESCRIPTION
This PR install the `clang` and `clang++` alternative links using `update-alternatives`. This is so we don't need to specify a the Clang version inside `bazelrc` in #8665. Therefore, instead of setting `CC=/usr/lib/llvm-17/bin/clang`, we can just set `CC=clang`.