### PR TITLE
Extend device data node binding API to not clone specified input tensors

### DIFF
--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -2877,50 +2877,69 @@ void InitXlaModuleBindings(py::module m) {
   // -------------Dynamo Integration API Start-------------------------
   /*
    * Return tensor ids and at::tensors for all DeviceData nodes that is needed
-   * to compute the value of tensors.
+   * to compute the value of tensors. Note that all DeviceData nodes return a
+   * clone of the tensor. In case the user provides a list of uncloned tensors,
+   * then the API will ensure that any captured tensor that is included in this
+   * list does not clone the XLA tensor. This ensures that uses of the resulting
+   * tensor values can be correctly aliased, as the tensor retains the original
+   * tensor IDs.
    */
-  m.def("_get_tensors_xla_device_data_node",
-        [](const std::vector<at::Tensor>& tensors)
-            -> std::pair<std::vector<int64_t>, std::vector<at::IValue>> {
-          std::vector<int64_t> tensor_ids;
-          std::vector<at::IValue> ivalues;
-          std::vector<const torch::lazy::Node*> roots;
-          for (const at::Tensor& tensor : tensors) {
-            auto xtensor = bridge::TryGetXlaTensor(tensor);
-            if (xtensor) {
-              roots.push_back(xtensor->GetIrValue().node.get());
-            }
+  m.def(
+      "_get_tensors_xla_device_data_node",
+      [](const std::vector<at::Tensor>& output_tensors,
+         const std::vector<at::Tensor>& uncloned_tensors)
+          -> std::pair<std::vector<int64_t>, std::vector<at::IValue>> {
+        std::vector<const torch::lazy::Node*> roots;
+        for (const at::Tensor& tensor : output_tensors) {
+          auto xtensor = bridge::TryGetXlaTensor(tensor);
+          if (xtensor) {
+            roots.push_back(xtensor->GetIrValue().node.get());
           }
-          auto post_order = torch::lazy::Util::ComputePostOrder(roots);
-          std::unordered_set<torch::lazy::BackendData::Handle> data_handles;
+        }
 
-          for (const torch::lazy::Node* nodeptr : post_order) {
-            const auto backend_data =
-                torch::lazy::getBackend()->GetComputationDataFromNode(nodeptr);
-            if (!backend_data) {
-              continue;
-            }
+        std::unordered_map<int64_t, at::Tensor> uncloned_tensor_map;
+        uncloned_tensor_map.reserve(uncloned_tensors.size());
+        for (const at::Tensor& tensor : uncloned_tensors) {
+          int64_t tensor_id = GetTensorId(tensor);
+          uncloned_tensor_map[tensor_id] = tensor;
+        }
 
-            // Dedup by handle
-            torch::lazy::BackendData::Handle handle = backend_data->GetHandle();
-            if (!data_handles.insert(handle).second) {
-              continue;
-            }
-            auto* infoptr =
-                static_cast<torch::lazy::LazyGraphExecutor::DeviceDataInfo*>(
-                    backend_data->info());
-            if (infoptr) {
-              tensor_ids.push_back(infoptr->tensor_id);
-            } else {
-              // TODO(JackCaoG): Make sure this device data is actually seed.
-              tensor_ids.push_back(seed_info_id);
-            }
+        auto post_order = torch::lazy::Util::ComputePostOrder(roots);
+        std::unordered_set<torch::lazy::BackendData::Handle> data_handles;
+
+        std::vector<int64_t> tensor_ids;
+        std::vector<at::IValue> ivalues;
+        for (const torch::lazy::Node* nodeptr : post_order) {
+          const auto backend_data =
+              torch::lazy::getBackend()->GetComputationDataFromNode(nodeptr);
+          if (!backend_data) {
+            continue;
+          }
+
+          // Dedup by handle
+          torch::lazy::BackendData::Handle handle = backend_data->GetHandle();
+          if (!data_handles.insert(handle).second) {
+            continue;
+          }
+          auto* infoptr =
+              static_cast<torch::lazy::LazyGraphExecutor::DeviceDataInfo*>(
+                  backend_data->info());
+
+          // TODO(JackCaoG): Make sure this device data is actually seed.
+          int64_t tensor_id = infoptr ? infoptr->tensor_id : seed_info_id;
+          tensor_ids.push_back(tensor_id);
+          if (uncloned_tensor_map.find(tensor_id) !=
+              uncloned_tensor_map.end()) {
+            ivalues.emplace_back(uncloned_tensor_map[tensor_id]);
+          } else {
             at::Tensor tensor = bridge::AtenFromXlaTensor(
                 torch_xla::XLATensor::Create(backend_data));
             ivalues.emplace_back(tensor);
           }
-          return std::make_pair(tensor_ids, ivalues);
-        });
+        }
+        return std::make_pair(tensor_ids, ivalues);
+      },
+      py::arg("output_tensors"), py::arg("uncloned_tensors") = py::list());
 
   m.def("_get_seed_info_id", []() -> int64_t { return seed_info_id; });
 


### PR DESCRIPTION


In this PR, we extend the `_get_tensors_xla_device_data_node` binding API to return the same tensor values for a given set of specified unmutated tensor inputs. It currently returns a list of tensors that capture the XLATensor values of the graph inputs. However, these tensors end up creating new ATen tensors, which are effectively clones of the original tensors.

https://github.com/pytorch/xla/blob/c4b45a969789e93e9f2a3067e0d5a85f74f1216f/torch_xla/csrc/init_python_bindings.cpp#L2919

This makes it so that these are not eligible to be aliased at the step barrier. Instead, we extend the API to allow users to specify the list of known input tensors, such that if graph input matches one of those inputs, then the same ATen tensor is returned back to the user as instead of returning a clone.

```
>>> t4 = torch.tensor(50).to(device)
>>> t5 = t4 + 10
>>> t6 = t5 * 20
>>> [torch_xla._XLAC._xla_get_tensor_id(x) for x in [t4, t5, t6]]
[8, 10, 12]
>>> results_with_input = torch_xla._XLAC._get_tensors_xla_device_data_node([t4, t5, t6], [t4])
>>> [torch_xla._XLAC._xla_get_tensor_id(x) for x in results_with_input[1]]
[8, 18, 19]
>>> results_without_input = torch_xla._XLAC._get_tensors_xla_device_data_node([t4, t5, t6], [])
>>> [torch_xla._XLAC._xla_get_tensor_id(x) for x in results_without_input[1]]
[20, 21, 22]
```

The input tensors are kept as optional, ensuring that the API change is backwards compatible.

cc: @mcuiaws