### PR TITLE
Assert on empty PJRT buffers

### DIFF
--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -738,6 +738,9 @@ PjRtComputationClient::ExecuteComputation(
   for (auto& argument : arguments) {
     const PjRtData* pjrt_data = dynamic_cast<PjRtData*>(argument.get());
 
+    XLA_CHECK(pjrt_data->buffer != nullptr)
+        << "There is no buffer associated with the PjRt data for the "
+        << "device: " << pjrt_device->DebugString();
     XLA_CHECK(pjrt_device == pjrt_data->buffer->device())
         << "The device currently being used : " << pjrt_device->DebugString()
         << " is different from the device where the buffer resides: "


### PR DESCRIPTION
Simple CR to avoid a segmentation fault when there are placeholder tensors involved when attempting to de-reference the device from the buffer.