### PR TITLE
Disable running slow CI for doc-only changes

### DIFF
--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -18,9 +18,9 @@ on:
         default: 120
       has_code_changes:
         required: false
-        type: boolean
+        type: string
         description: Whether to run full workflow or not
-        default: true
+        default: 'true'
     secrets:
       gcloud-service-key:
         required: true
@@ -37,31 +37,31 @@ jobs:
       BAZEL_REMOTE_CACHE: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout actions
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
           cuda: true
       - name: Build
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         shell: bash
         run: |
           cd pytorch/xla/infra/ansible
           ansible-playbook playbook.yaml -vvv -e "stage=build_plugin arch=amd64 accelerator=cuda cuda_compute_capabilities=5.2,7.5,8.6 src_root=${GITHUB_WORKSPACE} cache_suffix=-ci" --skip-tags=fetch_srcs,install_deps
       - name: Upload wheel
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: cuda-plugin
           path: /dist/*.whl
       - name: Report no code changes
-        if: ${{ !inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'false'
         run: |
           echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -22,6 +22,7 @@ on:
         description: Secret to access Bazel build cache
 jobs:
   build:
+    needs: [check_code_changes]
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     container:
@@ -32,23 +33,31 @@ jobs:
       BAZEL_REMOTE_CACHE: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout actions
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
           cuda: true
       - name: Build
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         shell: bash
         run: |
           cd pytorch/xla/infra/ansible
           ansible-playbook playbook.yaml -vvv -e "stage=build_plugin arch=amd64 accelerator=cuda cuda_compute_capabilities=5.2,7.5,8.6 src_root=${GITHUB_WORKSPACE} cache_suffix=-ci" --skip-tags=fetch_srcs,install_deps
       - name: Upload wheel
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: cuda-plugin
           path: /dist/*.whl
+      - name: Report no code changes
+        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        run: |
+          echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -37,31 +37,31 @@ jobs:
       BAZEL_REMOTE_CACHE: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout actions
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
           cuda: true
       - name: Build
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         shell: bash
         run: |
           cd pytorch/xla/infra/ansible
           ansible-playbook playbook.yaml -vvv -e "stage=build_plugin arch=amd64 accelerator=cuda cuda_compute_capabilities=5.2,7.5,8.6 src_root=${GITHUB_WORKSPACE} cache_suffix=-ci" --skip-tags=fetch_srcs,install_deps
       - name: Upload wheel
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: cuda-plugin
           path: /dist/*.whl
       - name: Report no code changes
-        if: ${{ inputs.has_code_changes == 'false' }}
+        if: inputs.has_code_changes == 'false'
         run: |
           echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -37,31 +37,31 @@ jobs:
       BAZEL_REMOTE_CACHE: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout actions
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
           cuda: true
       - name: Build
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         shell: bash
         run: |
           cd pytorch/xla/infra/ansible
           ansible-playbook playbook.yaml -vvv -e "stage=build_plugin arch=amd64 accelerator=cuda cuda_compute_capabilities=5.2,7.5,8.6 src_root=${GITHUB_WORKSPACE} cache_suffix=-ci" --skip-tags=fetch_srcs,install_deps
       - name: Upload wheel
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: cuda-plugin
           path: /dist/*.whl
       - name: Report no code changes
-        if: ${{ inputs.has_code_changes }} == 'false'
+        if: ${{ inputs.has_code_changes == 'false' }}
         run: |
           echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -21,6 +21,14 @@ on:
         required: true
         description: Secret to access Bazel build cache
 jobs:
+  check_code_changes:
+    name: Check Code Changes
+    uses: ./.github/workflows/_check_code_changes.yml
+    with:
+      event_name: ${{ github.event_name }}
+      # For pull_request, use PR's base and head. For push, use event's before and sha.
+      base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+      head_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
   build:
     needs: [check_code_changes]
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -16,21 +16,17 @@ on:
         type: number
         description: Timeout in minutes for the build job
         default: 120
+      has_code_changes:
+        required: false
+        type: boolean
+        description: Whether to run full workflow or not
+        default: true
     secrets:
       gcloud-service-key:
         required: true
         description: Secret to access Bazel build cache
 jobs:
-  check_code_changes:
-    name: Check Code Changes
-    uses: ./.github/workflows/_check_code_changes.yml
-    with:
-      event_name: ${{ github.event_name }}
-      # For pull_request, use PR's base and head. For push, use event's before and sha.
-      base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-      head_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
   build:
-    needs: [check_code_changes]
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     container:
@@ -41,31 +37,31 @@ jobs:
       BAZEL_REMOTE_CACHE: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout actions
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
           cuda: true
       - name: Build
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         shell: bash
         run: |
           cd pytorch/xla/infra/ansible
           ansible-playbook playbook.yaml -vvv -e "stage=build_plugin arch=amd64 accelerator=cuda cuda_compute_capabilities=5.2,7.5,8.6 src_root=${GITHUB_WORKSPACE} cache_suffix=-ci" --skip-tags=fetch_srcs,install_deps
       - name: Upload wheel
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         uses: actions/upload-artifact@v4
         with:
           name: cuda-plugin
           path: /dist/*.whl
       - name: Report no code changes
-        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        if: ${{ !inputs.has_code_changes }}
         run: |
           echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_build_torch_with_cuda.yml
+++ b/.github/workflows/_build_torch_with_cuda.yml
@@ -38,31 +38,31 @@ jobs:
       MAX_JOBS: 24
     steps:
       - name: Checkout actions
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
           cuda: true
       - name: Build PyTorch with CUDA enabled
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         shell: bash
         run: |
           cd pytorch
           python setup.py bdist_wheel
       - name: Upload wheel
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: torch-with-cuda
           path: pytorch/dist/*.whl
       - name: Report no code changes
-        if: ${{ inputs.has_code_changes }} == 'false'
+        if: ${{ inputs.has_code_changes == 'false' }}
         run: |
           echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_build_torch_with_cuda.yml
+++ b/.github/workflows/_build_torch_with_cuda.yml
@@ -20,17 +20,13 @@ on:
         type: number
         description: Timeout in minutes for the build job
         default: 120
+      has_code_changes:
+        required: false
+        type: boolean
+        description: Whether to run full workflow or not
+        default: true
 jobs:
-  check_code_changes:
-    name: Check Code Changes
-    uses: ./.github/workflows/_check_code_changes.yml
-    with:
-      event_name: ${{ github.event_name }}
-      # For pull_request, use PR's base and head. For push, use event's before and sha.
-      base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-      head_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
   build:
-    needs: [check_code_changes]
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     container:
@@ -42,31 +38,31 @@ jobs:
       MAX_JOBS: 24
     steps:
       - name: Checkout actions
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
           cuda: true
       - name: Build PyTorch with CUDA enabled
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         shell: bash
         run: |
           cd pytorch
           python setup.py bdist_wheel
       - name: Upload wheel
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         uses: actions/upload-artifact@v4
         with:
           name: torch-with-cuda
           path: pytorch/dist/*.whl
       - name: Report no code changes
-        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        if: ${{ !inputs.has_code_changes }}
         run: |
           echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_build_torch_with_cuda.yml
+++ b/.github/workflows/_build_torch_with_cuda.yml
@@ -22,9 +22,9 @@ on:
         default: 120
       has_code_changes:
         required: false
-        type: boolean
+        type: string
         description: Whether to run full workflow or not
-        default: true
+        default: 'true'
 jobs:
   build:
     runs-on: ${{ inputs.runner }}
@@ -38,31 +38,31 @@ jobs:
       MAX_JOBS: 24
     steps:
       - name: Checkout actions
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
           cuda: true
       - name: Build PyTorch with CUDA enabled
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         shell: bash
         run: |
           cd pytorch
           python setup.py bdist_wheel
       - name: Upload wheel
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: torch-with-cuda
           path: pytorch/dist/*.whl
       - name: Report no code changes
-        if: ${{ !inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'false'
         run: |
           echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_build_torch_with_cuda.yml
+++ b/.github/workflows/_build_torch_with_cuda.yml
@@ -38,31 +38,31 @@ jobs:
       MAX_JOBS: 24
     steps:
       - name: Checkout actions
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
           cuda: true
       - name: Build PyTorch with CUDA enabled
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         shell: bash
         run: |
           cd pytorch
           python setup.py bdist_wheel
       - name: Upload wheel
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: torch-with-cuda
           path: pytorch/dist/*.whl
       - name: Report no code changes
-        if: ${{ inputs.has_code_changes == 'false' }}
+        if: inputs.has_code_changes == 'false'
         run: |
           echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_build_torch_with_cuda.yml
+++ b/.github/workflows/_build_torch_with_cuda.yml
@@ -21,7 +21,16 @@ on:
         description: Timeout in minutes for the build job
         default: 120
 jobs:
+  check_code_changes:
+    name: Check Code Changes
+    uses: ./.github/workflows/_check_code_changes.yml
+    with:
+      event_name: ${{ github.event_name }}
+      # For pull_request, use PR's base and head. For push, use event's before and sha.
+      base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+      head_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
   build:
+    needs: [check_code_changes]
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     container:
@@ -33,23 +42,31 @@ jobs:
       MAX_JOBS: 24
     steps:
       - name: Checkout actions
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
           cuda: true
       - name: Build PyTorch with CUDA enabled
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         shell: bash
         run: |
           cd pytorch
           python setup.py bdist_wheel
       - name: Upload wheel
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: torch-with-cuda
           path: pytorch/dist/*.whl
+      - name: Report no code changes
+        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        run: |
+          echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_build_torch_xla.yml
+++ b/.github/workflows/_build_torch_xla.yml
@@ -20,21 +20,17 @@ on:
         type: number
         description: Timeout in minutes for the build job
         default: 120
+      has_code_changes:
+        required: false
+        type: boolean
+        description: Whether to run full workflow or not
+        default: true
     secrets:
       gcloud-service-key:
         required: true
         description: Secret to access Bazel build cache
 jobs:
-  check_code_changes:
-    name: Check Code Changes
-    uses: ./.github/workflows/_check_code_changes.yml
-    with:
-      event_name: ${{ github.event_name }}
-      # For pull_request, use PR's base and head. For push, use event's before and sha.
-      base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-      head_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
   build:
-    needs: [check_code_changes]
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     container:
@@ -48,37 +44,37 @@ jobs:
       # Need to check out local composite actions before using them
       # https://github.com/orgs/community/discussions/11771
       - name: Checkout actions
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
       - name: Build
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         shell: bash
         run: |
           cd pytorch/xla/infra/ansible
           ansible-playbook playbook.yaml -vvv -e "stage=build arch=amd64 accelerator=tpu src_root=${GITHUB_WORKSPACE} bundle_libtpu=0 build_cpp_tests=1 git_versioned_xla_build=1 cache_suffix=-ci" --skip-tags=fetch_srcs,install_deps
       - name: Upload wheel
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         uses: actions/upload-artifact@v4
         with:
           name: torch-xla-wheels
           path: /dist/*.whl
       - name: Upload CPP test binaries
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         uses: actions/upload-artifact@v4
         with:
           name: cpp-test-bin
           path: /tmp/test/bin
       - name: Report no code changes
-        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        if: ${{ !inputs.has_code_changes }}
         run: |
           echo "No code changes were detected that require running the full test suite."
 

--- a/.github/workflows/_build_torch_xla.yml
+++ b/.github/workflows/_build_torch_xla.yml
@@ -25,6 +25,14 @@ on:
         required: true
         description: Secret to access Bazel build cache
 jobs:
+  check_code_changes:
+    name: Check Code Changes
+    uses: ./.github/workflows/_check_code_changes.yml
+    with:
+      event_name: ${{ github.event_name }}
+      # For pull_request, use PR's base and head. For push, use event's before and sha.
+      base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+      head_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
   build:
     needs: [check_code_changes]
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/_build_torch_xla.yml
+++ b/.github/workflows/_build_torch_xla.yml
@@ -44,37 +44,37 @@ jobs:
       # Need to check out local composite actions before using them
       # https://github.com/orgs/community/discussions/11771
       - name: Checkout actions
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
       - name: Build
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         shell: bash
         run: |
           cd pytorch/xla/infra/ansible
           ansible-playbook playbook.yaml -vvv -e "stage=build arch=amd64 accelerator=tpu src_root=${GITHUB_WORKSPACE} bundle_libtpu=0 build_cpp_tests=1 git_versioned_xla_build=1 cache_suffix=-ci" --skip-tags=fetch_srcs,install_deps
       - name: Upload wheel
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: torch-xla-wheels
           path: /dist/*.whl
       - name: Upload CPP test binaries
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: cpp-test-bin
           path: /tmp/test/bin
       - name: Report no code changes
-        if: ${{ inputs.has_code_changes == 'false' }}
+        if: inputs.has_code_changes == 'false'
         run: |
           echo "No code changes were detected that require running the full test suite."
 

--- a/.github/workflows/_build_torch_xla.yml
+++ b/.github/workflows/_build_torch_xla.yml
@@ -26,6 +26,7 @@ on:
         description: Secret to access Bazel build cache
 jobs:
   build:
+    needs: [check_code_changes]
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     container:
@@ -39,27 +40,37 @@ jobs:
       # Need to check out local composite actions before using them
       # https://github.com/orgs/community/discussions/11771
       - name: Checkout actions
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
       - name: Build
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         shell: bash
         run: |
           cd pytorch/xla/infra/ansible
           ansible-playbook playbook.yaml -vvv -e "stage=build arch=amd64 accelerator=tpu src_root=${GITHUB_WORKSPACE} bundle_libtpu=0 build_cpp_tests=1 git_versioned_xla_build=1 cache_suffix=-ci" --skip-tags=fetch_srcs,install_deps
       - name: Upload wheel
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: torch-xla-wheels
           path: /dist/*.whl
       - name: Upload CPP test binaries
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: cpp-test-bin
           path: /tmp/test/bin
+      - name: Report no code changes
+        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        run: |
+          echo "No code changes were detected that require running the full test suite."
+

--- a/.github/workflows/_build_torch_xla.yml
+++ b/.github/workflows/_build_torch_xla.yml
@@ -44,37 +44,37 @@ jobs:
       # Need to check out local composite actions before using them
       # https://github.com/orgs/community/discussions/11771
       - name: Checkout actions
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
       - name: Build
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         shell: bash
         run: |
           cd pytorch/xla/infra/ansible
           ansible-playbook playbook.yaml -vvv -e "stage=build arch=amd64 accelerator=tpu src_root=${GITHUB_WORKSPACE} bundle_libtpu=0 build_cpp_tests=1 git_versioned_xla_build=1 cache_suffix=-ci" --skip-tags=fetch_srcs,install_deps
       - name: Upload wheel
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: torch-xla-wheels
           path: /dist/*.whl
       - name: Upload CPP test binaries
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: cpp-test-bin
           path: /tmp/test/bin
       - name: Report no code changes
-        if: ${{ inputs.has_code_changes }} == 'false'
+        if: ${{ inputs.has_code_changes == 'false' }}
         run: |
           echo "No code changes were detected that require running the full test suite."
 

--- a/.github/workflows/_build_torch_xla.yml
+++ b/.github/workflows/_build_torch_xla.yml
@@ -22,9 +22,9 @@ on:
         default: 120
       has_code_changes:
         required: false
-        type: boolean
+        type: string
         description: Whether to run full workflow or not
-        default: true
+        default: 'true'
     secrets:
       gcloud-service-key:
         required: true
@@ -44,37 +44,37 @@ jobs:
       # Need to check out local composite actions before using them
       # https://github.com/orgs/community/discussions/11771
       - name: Checkout actions
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
       - name: Build
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         shell: bash
         run: |
           cd pytorch/xla/infra/ansible
           ansible-playbook playbook.yaml -vvv -e "stage=build arch=amd64 accelerator=tpu src_root=${GITHUB_WORKSPACE} bundle_libtpu=0 build_cpp_tests=1 git_versioned_xla_build=1 cache_suffix=-ci" --skip-tags=fetch_srcs,install_deps
       - name: Upload wheel
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: torch-xla-wheels
           path: /dist/*.whl
       - name: Upload CPP test binaries
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: cpp-test-bin
           path: /tmp/test/bin
       - name: Report no code changes
-        if: ${{ !inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'false'
         run: |
           echo "No code changes were detected that require running the full test suite."
 

--- a/.github/workflows/_check_code_changes.yml
+++ b/.github/workflows/_check_code_changes.yml
@@ -1,0 +1,73 @@
+name: Check Code Changes
+
+on:
+  workflow_call:
+    inputs:
+      event_name:
+        required: true
+        type: string
+      base_sha:
+        required: true
+        type: string
+      head_sha:
+        required: true
+        type: string
+    outputs:
+      has_code_changes:
+        description: "True if non-markdown code files were changed or event is workflow_dispatch/schedule, false otherwise."
+        value: ${{ jobs.check_files.outputs.has_code_changes }}
+
+jobs:
+  check_files:
+    runs-on: ubuntu-latest
+    outputs:
+      has_code_changes: ${{ steps.perform_check.outputs.has_code_changes }}
+    steps:
+      - name: Checkout code for diff (if needed)
+        # Checkout only if a diff is actually needed
+        if: inputs.event_name != 'workflow_dispatch' && inputs.event_name != 'schedule'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required to get history for diff
+
+      - name: Perform file content check
+        id: perform_check
+        run: |
+          # Handle workflow_dispatch and schedule events first
+          if [[ "${{ inputs.event_name }}" == "workflow_dispatch" || "${{ inputs.event_name }}" == "schedule" ]]; then
+            echo "Event is ${{ inputs.event_name }}. Assuming code changes or full run needed."
+            echo "has_code_changes=true" >> "$GITHUB_OUTPUT"
+            exit 0 # Exit early, no diff needed
+          fi
+
+          # Proceed with diff-based checks for other events (e.g., pull_request, push)
+          echo "Performing file check. Base SHA: ${{ inputs.base_sha }}, Head SHA: ${{ inputs.head_sha }}"
+
+          # Handle initial push (base SHA is all zeros)
+          if [[ "${{ inputs.base_sha }}" == "0000000000000000000000000000000000000000" ]]; then
+            echo "Initial push (base SHA is zeros). Assuming code changes."
+            echo "has_code_changes=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Handle cases where base and head are the same (e.g., re-run on a specific commit)
+          if [[ "${{ inputs.base_sha }}" == "${{ inputs.head_sha }}" ]]; then
+            echo "Base SHA is the same as Head SHA. No file changes. Assuming no code changes for skipping purposes."
+            echo "has_code_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # If we reach here, checkout step should have run and we need to perform a diff
+          git diff --name-only --no-renames ${{ inputs.base_sha }} ${{ inputs.head_sha }} > changed_files.txt
+
+          echo "Changed files (between ${{ inputs.base_sha }} and ${{ inputs.head_sha }}):"
+          cat changed_files.txt
+
+          if grep -q -v -E '\.md$' changed_files.txt; then
+            echo "Non-markdown changes detected."
+            echo "has_code_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Only markdown changes detected or no changes found in diff."
+            echo "has_code_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash

--- a/.github/workflows/_check_code_changes.yml
+++ b/.github/workflows/_check_code_changes.yml
@@ -6,9 +6,13 @@ on:
       event_name:
         required: true
         type: string
+      # For pull_request, base_sha is github.event.pull_request.base.sha (target branch tip)
+      # For push, base_sha is github.event.before
       base_sha:
         required: true
         type: string
+      # For pull_request, head_sha is github.event.pull_request.head.sha (PR branch tip)
+      # For push, head_sha is github.sha
       head_sha:
         required: true
         type: string
@@ -28,11 +32,19 @@ jobs:
         if: inputs.event_name != 'workflow_dispatch' && inputs.event_name != 'schedule'
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Required to get history for diff
+          # Fetch all history for all branches and tags.
+          # This is necessary for `git diff A...B` (three-dot diff) to find the merge base
+          # and correctly diff PR changes against the point where it diverged.
+          # It's also needed for `git diff A B` if A and B are far apart.
+          fetch-depth: 0
 
       - name: Perform file content check
         id: perform_check
         run: |
+          echo "Event Name: ${{ inputs.event_name }}"
+          echo "Base SHA input (for PR: target branch; for Push: before SHA): ${{ inputs.base_sha }}"
+          echo "Head SHA input (for PR: PR head; for Push: current SHA): ${{ inputs.head_sha }}"
+
           # Handle workflow_dispatch and schedule events first
           if [[ "${{ inputs.event_name }}" == "workflow_dispatch" || "${{ inputs.event_name }}" == "schedule" ]]; then
             echo "Event is ${{ inputs.event_name }}. Assuming code changes or full run needed."
@@ -40,34 +52,60 @@ jobs:
             exit 0 # Exit early, no diff needed
           fi
 
-          # Proceed with diff-based checks for other events (e.g., pull_request, push)
-          echo "Performing file check. Base SHA: ${{ inputs.base_sha }}, Head SHA: ${{ inputs.head_sha }}"
-
           # Handle initial push (base SHA is all zeros)
+          # For an initial push, all files in the head_sha are considered "changed" (new).
           if [[ "${{ inputs.base_sha }}" == "0000000000000000000000000000000000000000" ]]; then
             echo "Initial push (base SHA is zeros). Assuming code changes."
+            # We can list all files in the current commit (inputs.head_sha) if needed,
+            # but for simplicity, just assuming code changes is often sufficient.
+            # To be precise, one could do: git ls-tree -r --name-only ${{ inputs.head_sha }} > changed_files.txt
+            # And then apply the markdown filter. For now, we'll assume changes.
             echo "has_code_changes=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Handle cases where base and head are the same (e.g., re-run on a specific commit)
+          # Handle cases where base and head are the same (e.g., re-run on a specific commit, or a push with no new commits)
+          # This can happen if a workflow is re-run, or if a branch is pushed without new commits (e.g., force push to same SHA).
           if [[ "${{ inputs.base_sha }}" == "${{ inputs.head_sha }}" ]]; then
             echo "Base SHA is the same as Head SHA. No file changes. Assuming no code changes for skipping purposes."
             echo "has_code_changes=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # If we reach here, checkout step should have run and we need to perform a diff
-          git diff --name-only --no-renames ${{ inputs.base_sha }} ${{ inputs.head_sha }} > changed_files.txt
+          # Ensure SHAs are valid before attempting diff
+          # (git rev-parse --verify will exit with non-zero if SHA is not found)
+          git rev-parse --verify ${{ inputs.base_sha }}^{commit} >/dev/null 2>&1 || { echo "Error: Base SHA ${{ inputs.base_sha }} not found or invalid."; exit 1; }
+          git rev-parse --verify ${{ inputs.head_sha }}^{commit} >/dev/null 2>&1 || { echo "Error: Head SHA ${{ inputs.head_sha }} not found or invalid."; exit 1; }
 
-          echo "Changed files (between ${{ inputs.base_sha }} and ${{ inputs.head_sha }}):"
+
+          # Determine the diff command based on the event type
+          if [[ "${{ inputs.event_name }}" == "pull_request" ]]; then
+            # For pull requests, use three-dot diff (A...B).
+            # This shows changes on the PR branch (inputs.head_sha)
+            # since it diverged from the target branch (inputs.base_sha).
+            # inputs.base_sha is github.event.pull_request.base.sha
+            # inputs.head_sha is github.event.pull_request.head.sha
+            echo "Pull Request: Diffing ${{ inputs.base_sha }}...${{ inputs.head_sha }}"
+            git diff --name-only --no-renames ${{ inputs.base_sha }}...${{ inputs.head_sha }} > changed_files.txt
+          else # For 'push' and potentially other events not explicitly handled above
+            # For pushes, use two-dot diff (A B).
+            # inputs.base_sha is github.event.before
+            # inputs.head_sha is github.sha
+            echo "Push or other event: Diffing ${{ inputs.base_sha }} ${{ inputs.head_sha }}"
+            git diff --name-only --no-renames ${{ inputs.base_sha }} ${{ inputs.head_sha }} > changed_files.txt
+          fi
+
+          echo "Changed files:"
           cat changed_files.txt
 
-          if grep -q -v -E '\.md$' changed_files.txt; then
-            echo "Code changes detected."
+          if [ ! -s changed_files.txt ]; then # Check if changed_files.txt is empty
+            echo "No files changed in the diff."
+            echo "has_code_changes=false" >> "$GITHUB_OUTPUT"
+          elif grep -q -v -E '\.md$' changed_files.txt; then
+            echo "Non-markdown code changes detected."
             echo "has_code_changes=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Only markdown changes detected or no changes found in diff."
+            echo "Only markdown changes detected or no non-markdown changes found in diff."
             echo "has_code_changes=false" >> "$GITHUB_OUTPUT"
           fi
         shell: bash

--- a/.github/workflows/_check_code_changes.yml
+++ b/.github/workflows/_check_code_changes.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   check_files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       has_code_changes: ${{ steps.perform_check.outputs.has_code_changes }}
     steps:

--- a/.github/workflows/_check_code_changes.yml
+++ b/.github/workflows/_check_code_changes.yml
@@ -64,7 +64,7 @@ jobs:
           cat changed_files.txt
 
           if grep -q -v -E '\.md$' changed_files.txt; then
-            echo "Non-markdown changes detected."
+            echo "Code changes detected."
             echo "has_code_changes=true" >> "$GITHUB_OUTPUT"
           else
             echo "Only markdown changes detected or no changes found in diff."

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -11,20 +11,16 @@ on:
         type: string
         description: Runner type for the test
         default: linux.4xlarge
+      has_code_changes:
+        required: false
+        type: boolean
+        description: Whether to run full workflow or not
+        default: true
     secrets:
       torchxla-bot-token:
         required: true
 jobs:
-  check_code_changes:
-    name: Check Code Changes
-    uses: ./.github/workflows/_check_code_changes.yml
-    with:
-      event_name: ${{ github.event_name }}
-      # For pull_request, use PR's base and head. For push, use event's before and sha.
-      base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-      head_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
   build-docs:
-    needs: [check_code_changes]
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     container:
@@ -33,52 +29,50 @@ jobs:
       BRANCH_NAME: ${{ github.ref_name }}
     steps:
     - name: Fetch wheels
-      if: needs.check_code_changes.outputs.has_code_changes == 'true'
+      if: ${{ inputs.has_code_changes }}
       uses: actions/download-artifact@v4
       with:
         name: torch-xla-wheels
         path: /tmp/wheels/
     - name: Install wheels
-      if: needs.check_code_changes.outputs.has_code_changes == 'true'
+      if: ${{ inputs.has_code_changes }}
       shell: bash
       run: |
         pip install /tmp/wheels/*.whl
     - name: Checkout PyTorch/XLA Repo
-      if: needs.check_code_changes.outputs.has_code_changes == 'true'
+      if: ${{ inputs.has_code_changes }}
       uses: actions/checkout@v4
       with:
         path: pytorch/xla
     - name: Build docs
-      if: needs.check_code_changes.outputs.has_code_changes == 'true'
+      if: ${{ inputs.has_code_changes }}
       shell: bash
       run: |
         cd pytorch/xla/docs
         pip install -r requirements.txt
         sphinx-build -b html source build
     - name: Checkout GitHub Pages
-      if: needs.check_code_changes.outputs.has_code_changes == 'true'
+      if: ${{ inputs.has_code_changes }}
       uses: actions/checkout@v4
       with:
         path: gh-pages
         ref: gh-pages
         token: ${{ github.event_name == 'push' && secrets.torchxla-bot-token || github.token }}
     - name: Merge changes
-      if: needs.check_code_changes.outputs.has_code_changes == 'true'
+      if: ${{ inputs.has_code_changes }}
       shell: bash
       run: |
         subdir=${{ env.BRANCH_NAME == 'master' && 'master' || format('{0}/{1}', 'release', env.BRANCH_NAME) }}
         mkdir -p gh-pages/$subdir
         cp -fR pytorch/xla/docs/build/* gh-pages/$subdir
     - name: Upload preview as artifact
-      if: needs.check_code_changes.outputs.has_code_changes == 'true'
+      if: ${{ inputs.has_code_changes }}
       uses: actions/upload-artifact@v4
       with:
         name: github-pages
         path: pytorch/xla/docs/build/
     - name: Deploy
-      if: >
-        needs.check_code_changes.outputs.has_code_changes == 'true' &&
-        github.event_name == 'push'
+      if: ${{ inputs.has_code_changes }} && github.event_name == 'push'
       shell: bash
       run: |
         cd gh-pages
@@ -88,6 +82,6 @@ jobs:
         git diff --cached --exit-code || git commit -m "Update doc from commit ${{ github.sha }}"
         git push origin gh-pages
     - name: Report no code changes
-      if: needs.check_code_changes.outputs.has_code_changes == 'false'
+      if: ${{ !inputs.has_code_changes }}
       run: |
         echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -16,6 +16,7 @@ on:
         required: true
 jobs:
   build-docs:
+    needs: [check_code_changes]
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     container:
@@ -24,42 +25,50 @@ jobs:
       BRANCH_NAME: ${{ github.ref_name }}
     steps:
     - name: Fetch wheels
+      if: needs.check_code_changes.outputs.has_code_changes == 'true'
       uses: actions/download-artifact@v4
       with:
         name: torch-xla-wheels
         path: /tmp/wheels/
     - name: Install wheels
+      if: needs.check_code_changes.outputs.has_code_changes == 'true'
       shell: bash
       run: |
         pip install /tmp/wheels/*.whl
     - name: Checkout PyTorch/XLA Repo
+      if: needs.check_code_changes.outputs.has_code_changes == 'true'
       uses: actions/checkout@v4
       with:
         path: pytorch/xla
     - name: Build docs
+      if: needs.check_code_changes.outputs.has_code_changes == 'true'
       shell: bash
       run: |
         cd pytorch/xla/docs
         pip install -r requirements.txt
         sphinx-build -b html source build
     - name: Checkout GitHub Pages
+      if: needs.check_code_changes.outputs.has_code_changes == 'true'
       uses: actions/checkout@v4
       with:
         path: gh-pages
         ref: gh-pages
         token: ${{ github.event_name == 'push' && secrets.torchxla-bot-token || github.token }}
     - name: Merge changes
+      if: needs.check_code_changes.outputs.has_code_changes == 'true'
       shell: bash
       run: |
         subdir=${{ env.BRANCH_NAME == 'master' && 'master' || format('{0}/{1}', 'release', env.BRANCH_NAME) }}
         mkdir -p gh-pages/$subdir
         cp -fR pytorch/xla/docs/build/* gh-pages/$subdir
     - name: Upload preview as artifact
+      if: needs.check_code_changes.outputs.has_code_changes == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: github-pages
         path: pytorch/xla/docs/build/
     - name: Deploy
+      if: needs.check_code_changes.outputs.has_code_changes == 'true'
       shell: bash
       run: |
         cd gh-pages
@@ -69,3 +78,7 @@ jobs:
         git diff --cached --exit-code || git commit -m "Update doc from commit ${{ github.sha }}"
         git push origin gh-pages
       if: github.event_name == 'push'
+    - name: Report no code changes
+      if: needs.check_code_changes.outputs.has_code_changes == 'false'
+      run: |
+        echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -29,50 +29,50 @@ jobs:
       BRANCH_NAME: ${{ github.ref_name }}
     steps:
     - name: Fetch wheels
-      if: ${{ inputs.has_code_changes }} == 'true'
+      if: ${{ inputs.has_code_changes == 'true' }}
       uses: actions/download-artifact@v4
       with:
         name: torch-xla-wheels
         path: /tmp/wheels/
     - name: Install wheels
-      if: ${{ inputs.has_code_changes }} == 'true'
+      if: ${{ inputs.has_code_changes == 'true' }}
       shell: bash
       run: |
         pip install /tmp/wheels/*.whl
     - name: Checkout PyTorch/XLA Repo
-      if: ${{ inputs.has_code_changes }} == 'true'
+      if: ${{ inputs.has_code_changes == 'true' }}
       uses: actions/checkout@v4
       with:
         path: pytorch/xla
     - name: Build docs
-      if: ${{ inputs.has_code_changes }} == 'true'
+      if: ${{ inputs.has_code_changes == 'true' }}
       shell: bash
       run: |
         cd pytorch/xla/docs
         pip install -r requirements.txt
         sphinx-build -b html source build
     - name: Checkout GitHub Pages
-      if: ${{ inputs.has_code_changes }} == 'true'
+      if: ${{ inputs.has_code_changes == 'true' }}
       uses: actions/checkout@v4
       with:
         path: gh-pages
         ref: gh-pages
         token: ${{ github.event_name == 'push' && secrets.torchxla-bot-token || github.token }}
     - name: Merge changes
-      if: ${{ inputs.has_code_changes }} == 'true'
+      if: ${{ inputs.has_code_changes == 'true' }}
       shell: bash
       run: |
         subdir=${{ env.BRANCH_NAME == 'master' && 'master' || format('{0}/{1}', 'release', env.BRANCH_NAME) }}
         mkdir -p gh-pages/$subdir
         cp -fR pytorch/xla/docs/build/* gh-pages/$subdir
     - name: Upload preview as artifact
-      if: ${{ inputs.has_code_changes }} == 'true'
+      if: ${{ inputs.has_code_changes == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: github-pages
         path: pytorch/xla/docs/build/
     - name: Deploy
-      if: ${{ inputs.has_code_changes }} == 'true' && github.event_name == 'push'
+      if: ${{ inputs.has_code_changes == 'true' }} && github.event_name == 'push'
       shell: bash
       run: |
         cd gh-pages
@@ -82,6 +82,6 @@ jobs:
         git diff --cached --exit-code || git commit -m "Update doc from commit ${{ github.sha }}"
         git push origin gh-pages
     - name: Report no code changes
-      if: ${{ inputs.has_code_changes }} == 'false'
+      if: ${{ inputs.has_code_changes == 'false' }}
       run: |
         echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -13,9 +13,9 @@ on:
         default: linux.4xlarge
       has_code_changes:
         required: false
-        type: boolean
+        type: string
         description: Whether to run full workflow or not
-        default: true
+        default: 'true'
     secrets:
       torchxla-bot-token:
         required: true
@@ -29,50 +29,50 @@ jobs:
       BRANCH_NAME: ${{ github.ref_name }}
     steps:
     - name: Fetch wheels
-      if: ${{ inputs.has_code_changes }}
+      if: ${{ inputs.has_code_changes }} == 'true'
       uses: actions/download-artifact@v4
       with:
         name: torch-xla-wheels
         path: /tmp/wheels/
     - name: Install wheels
-      if: ${{ inputs.has_code_changes }}
+      if: ${{ inputs.has_code_changes }} == 'true'
       shell: bash
       run: |
         pip install /tmp/wheels/*.whl
     - name: Checkout PyTorch/XLA Repo
-      if: ${{ inputs.has_code_changes }}
+      if: ${{ inputs.has_code_changes }} == 'true'
       uses: actions/checkout@v4
       with:
         path: pytorch/xla
     - name: Build docs
-      if: ${{ inputs.has_code_changes }}
+      if: ${{ inputs.has_code_changes }} == 'true'
       shell: bash
       run: |
         cd pytorch/xla/docs
         pip install -r requirements.txt
         sphinx-build -b html source build
     - name: Checkout GitHub Pages
-      if: ${{ inputs.has_code_changes }}
+      if: ${{ inputs.has_code_changes }} == 'true'
       uses: actions/checkout@v4
       with:
         path: gh-pages
         ref: gh-pages
         token: ${{ github.event_name == 'push' && secrets.torchxla-bot-token || github.token }}
     - name: Merge changes
-      if: ${{ inputs.has_code_changes }}
+      if: ${{ inputs.has_code_changes }} == 'true'
       shell: bash
       run: |
         subdir=${{ env.BRANCH_NAME == 'master' && 'master' || format('{0}/{1}', 'release', env.BRANCH_NAME) }}
         mkdir -p gh-pages/$subdir
         cp -fR pytorch/xla/docs/build/* gh-pages/$subdir
     - name: Upload preview as artifact
-      if: ${{ inputs.has_code_changes }}
+      if: ${{ inputs.has_code_changes }} == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: github-pages
         path: pytorch/xla/docs/build/
     - name: Deploy
-      if: ${{ inputs.has_code_changes }} && github.event_name == 'push'
+      if: ${{ inputs.has_code_changes }} == 'true' && github.event_name == 'push'
       shell: bash
       run: |
         cd gh-pages
@@ -82,6 +82,6 @@ jobs:
         git diff --cached --exit-code || git commit -m "Update doc from commit ${{ github.sha }}"
         git push origin gh-pages
     - name: Report no code changes
-      if: ${{ !inputs.has_code_changes }}
+      if: ${{ inputs.has_code_changes }} == 'false'
       run: |
         echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -29,50 +29,50 @@ jobs:
       BRANCH_NAME: ${{ github.ref_name }}
     steps:
     - name: Fetch wheels
-      if: ${{ inputs.has_code_changes == 'true' }}
+      if: inputs.has_code_changes == 'true'
       uses: actions/download-artifact@v4
       with:
         name: torch-xla-wheels
         path: /tmp/wheels/
     - name: Install wheels
-      if: ${{ inputs.has_code_changes == 'true' }}
+      if: inputs.has_code_changes == 'true'
       shell: bash
       run: |
         pip install /tmp/wheels/*.whl
     - name: Checkout PyTorch/XLA Repo
-      if: ${{ inputs.has_code_changes == 'true' }}
+      if: inputs.has_code_changes == 'true'
       uses: actions/checkout@v4
       with:
         path: pytorch/xla
     - name: Build docs
-      if: ${{ inputs.has_code_changes == 'true' }}
+      if: inputs.has_code_changes == 'true'
       shell: bash
       run: |
         cd pytorch/xla/docs
         pip install -r requirements.txt
         sphinx-build -b html source build
     - name: Checkout GitHub Pages
-      if: ${{ inputs.has_code_changes == 'true' }}
+      if: inputs.has_code_changes == 'true'
       uses: actions/checkout@v4
       with:
         path: gh-pages
         ref: gh-pages
         token: ${{ github.event_name == 'push' && secrets.torchxla-bot-token || github.token }}
     - name: Merge changes
-      if: ${{ inputs.has_code_changes == 'true' }}
+      if: inputs.has_code_changes == 'true'
       shell: bash
       run: |
         subdir=${{ env.BRANCH_NAME == 'master' && 'master' || format('{0}/{1}', 'release', env.BRANCH_NAME) }}
         mkdir -p gh-pages/$subdir
         cp -fR pytorch/xla/docs/build/* gh-pages/$subdir
     - name: Upload preview as artifact
-      if: ${{ inputs.has_code_changes == 'true' }}
+      if: inputs.has_code_changes == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: github-pages
         path: pytorch/xla/docs/build/
     - name: Deploy
-      if: ${{ inputs.has_code_changes == 'true' }} && github.event_name == 'push'
+      if: inputs.has_code_changes == 'true' && github.event_name == 'push'
       shell: bash
       run: |
         cd gh-pages
@@ -82,6 +82,6 @@ jobs:
         git diff --cached --exit-code || git commit -m "Update doc from commit ${{ github.sha }}"
         git push origin gh-pages
     - name: Report no code changes
-      if: ${{ inputs.has_code_changes == 'false' }}
+      if: inputs.has_code_changes == 'false'
       run: |
         echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -15,6 +15,14 @@ on:
       torchxla-bot-token:
         required: true
 jobs:
+  check_code_changes:
+    name: Check Code Changes
+    uses: ./.github/workflows/_check_code_changes.yml
+    with:
+      event_name: ${{ github.event_name }}
+      # For pull_request, use PR's base and head. For push, use event's before and sha.
+      base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+      head_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
   build-docs:
     needs: [check_code_changes]
     runs-on: ubuntu-24.04

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -76,7 +76,9 @@ jobs:
         name: github-pages
         path: pytorch/xla/docs/build/
     - name: Deploy
-      if: needs.check_code_changes.outputs.has_code_changes == 'true'
+      if: >
+        needs.check_code_changes.outputs.has_code_changes == 'true' &&
+        github.event_name == 'push'
       shell: bash
       run: |
         cd gh-pages
@@ -85,7 +87,6 @@ jobs:
         git add . -v
         git diff --cached --exit-code || git commit -m "Update doc from commit ${{ github.sha }}"
         git push origin gh-pages
-      if: github.event_name == 'push'
     - name: Report no code changes
       if: needs.check_code_changes.outputs.has_code_changes == 'false'
       run: |

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -82,14 +82,14 @@ jobs:
       BAZEL_REMOTE_CACHE: 1
     steps:
       - name: Checkout actions
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
@@ -97,7 +97,7 @@ jobs:
           wheels-artifact: torch-xla-wheels
           cuda-plugin-artifact: ${{ inputs.install-cuda-plugin && 'cuda-plugin' || null }}
       - name: Fetch CPP test binaries
-        if: ${{ inputs.has_code_changes }} == 'true' && ${{ matrix.run_cpp_tests }}
+        if: ${{ inputs.has_code_changes == 'true' }} && ${{ matrix.run_cpp_tests }}
         uses: actions/download-artifact@v4
         with:
           name: cpp-test-bin
@@ -105,34 +105,34 @@ jobs:
       # GitHub Actions doesn't preserve executable permissions
       # https://github.com/actions/download-artifact?tab=readme-ov-file#permission-loss
       - name: Set CPP test permissions
-        if: ${{ inputs.has_code_changes }} == 'true' && ${{ matrix.run_cpp_tests }}
+        if: ${{ inputs.has_code_changes == 'true' }} && ${{ matrix.run_cpp_tests }}
         run: |
           chmod +x /tmp/test/bin/*
           ls -l /tmp/test/bin
       - name: Check GPU
-        if: ${{ inputs.has_code_changes }} == 'true' && ${{ inputs.install-cuda-plugin }}
+        if: ${{ inputs.has_code_changes == 'true' }} && ${{ inputs.install-cuda-plugin }}
         run: nvidia-smi
       - name: Install test deps
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         shell: bash
         run: |
           # TODO: Add these in setup.py
           pip install fsspec
           pip install rich
       - name: Checkout PyTorch Repo
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         uses: actions/checkout@v4
         with:
           repository: pytorch/pytorch
           path: pytorch
           ref: ${{ inputs.torch-commit }}
       - name: Checkout PyTorch/XLA Repo
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         uses: actions/checkout@v4
         with:
           path: pytorch/xla
       - name: Extra CI deps
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         shell: bash
         run: |
           set -x
@@ -143,11 +143,11 @@ jobs:
             pip install -r pytorch/xla/benchmarks/requirements.txt
           fi
       - name: Test
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         shell: bash
         run: pytorch/xla/.github/scripts/run_tests.sh pytorch/ pytorch/xla/ $USE_COVERAGE
       - name: Upload coverage results
-        if: ${{ inputs.has_code_changes }} == 'true' && ${{ inputs.collect-coverage }}
+        if: ${{ inputs.has_code_changes == 'true' }} && ${{ inputs.collect-coverage }}
         shell: bash
         env:
           CIRCLE_WORKFLOW_ID: ${{ github.run_id }}
@@ -192,6 +192,6 @@ jobs:
               fi
             fi
       - name: Report no code changes
-        if: ${{ inputs.has_code_changes }} == 'false'
+        if: ${{ inputs.has_code_changes == 'false' }}
         run: |
           echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -102,24 +102,27 @@ jobs:
           wheels-artifact: torch-xla-wheels
           cuda-plugin-artifact: ${{ inputs.install-cuda-plugin && 'cuda-plugin' || null }}
       - name: Fetch CPP test binaries
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: >
+          needs.check_code_changes.outputs.has_code_changes == 'true' &&
+          ${{ matrix.run_cpp_tests }}
         uses: actions/download-artifact@v4
         with:
           name: cpp-test-bin
           path: /tmp/test/bin
-        if: ${{ matrix.run_cpp_tests }}
       # GitHub Actions doesn't preserve executable permissions
       # https://github.com/actions/download-artifact?tab=readme-ov-file#permission-loss
       - name: Set CPP test permissions
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: >
+          needs.check_code_changes.outputs.has_code_changes == 'true' &&
+          ${{ matrix.run_cpp_tests }}
         run: |
           chmod +x /tmp/test/bin/*
           ls -l /tmp/test/bin
-        if: ${{ matrix.run_cpp_tests }}
       - name: Check GPU
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: >
+          needs.check_code_changes.outputs.has_code_changes == 'true' &&
+          ${{ inputs.install-cuda-plugin }}
         run: nvidia-smi
-        if: ${{ inputs.install-cuda-plugin }}
       - name: Install test deps
         if: needs.check_code_changes.outputs.has_code_changes == 'true'
         shell: bash
@@ -155,8 +158,9 @@ jobs:
         shell: bash
         run: pytorch/xla/.github/scripts/run_tests.sh pytorch/ pytorch/xla/ $USE_COVERAGE
       - name: Upload coverage results
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
-        if: ${{ inputs.collect-coverage }}
+        if: >
+            needs.check_code_changes.outputs.has_code_changes == 'true' &&
+            ${{ inputs.collect-coverage }}
         shell: bash
         env:
           CIRCLE_WORKFLOW_ID: ${{ github.run_id }}

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -32,22 +32,17 @@ on:
           required: true
           type: string
           description: torch-commit
-
+      has_code_changes:
+        required: false
+        type: boolean
+        description: Whether to run full workflow or not
+        default: true
     secrets:
       gcloud-service-key:
         required: true
         description: Secret to access Bazel build cache
 jobs:
-  check_code_changes:
-    name: Check Code Changes
-    uses: ./.github/workflows/_check_code_changes.yml
-    with:
-      event_name: ${{ github.event_name }}
-      # For pull_request, use PR's base and head. For push, use event's before and sha.
-      base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-      head_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
   test:
-    needs: [check_code_changes]
     runs-on: ${{ inputs.runner }}
     container:
       image: ${{ inputs.dev-image }}
@@ -87,14 +82,14 @@ jobs:
       BAZEL_REMOTE_CACHE: 1
     steps:
       - name: Checkout actions
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
@@ -102,9 +97,7 @@ jobs:
           wheels-artifact: torch-xla-wheels
           cuda-plugin-artifact: ${{ inputs.install-cuda-plugin && 'cuda-plugin' || null }}
       - name: Fetch CPP test binaries
-        if: >
-          needs.check_code_changes.outputs.has_code_changes == 'true' &&
-          ${{ matrix.run_cpp_tests }}
+        if: ${{ inputs.has_code_changes }} && ${{ matrix.run_cpp_tests }}
         uses: actions/download-artifact@v4
         with:
           name: cpp-test-bin
@@ -112,38 +105,34 @@ jobs:
       # GitHub Actions doesn't preserve executable permissions
       # https://github.com/actions/download-artifact?tab=readme-ov-file#permission-loss
       - name: Set CPP test permissions
-        if: >
-          needs.check_code_changes.outputs.has_code_changes == 'true' &&
-          ${{ matrix.run_cpp_tests }}
+        if: ${{ inputs.has_code_changes }} && ${{ matrix.run_cpp_tests }}
         run: |
           chmod +x /tmp/test/bin/*
           ls -l /tmp/test/bin
       - name: Check GPU
-        if: >
-          needs.check_code_changes.outputs.has_code_changes == 'true' &&
-          ${{ inputs.install-cuda-plugin }}
+        if: ${{ inputs.has_code_changes }} && ${{ inputs.install-cuda-plugin }}
         run: nvidia-smi
       - name: Install test deps
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         shell: bash
         run: |
           # TODO: Add these in setup.py
           pip install fsspec
           pip install rich
       - name: Checkout PyTorch Repo
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         uses: actions/checkout@v4
         with:
           repository: pytorch/pytorch
           path: pytorch
           ref: ${{ inputs.torch-commit }}
       - name: Checkout PyTorch/XLA Repo
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         uses: actions/checkout@v4
         with:
           path: pytorch/xla
       - name: Extra CI deps
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         shell: bash
         run: |
           set -x
@@ -154,13 +143,11 @@ jobs:
             pip install -r pytorch/xla/benchmarks/requirements.txt
           fi
       - name: Test
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         shell: bash
         run: pytorch/xla/.github/scripts/run_tests.sh pytorch/ pytorch/xla/ $USE_COVERAGE
       - name: Upload coverage results
-        if: >
-            needs.check_code_changes.outputs.has_code_changes == 'true' &&
-            ${{ inputs.collect-coverage }}
+        if: ${{ inputs.has_code_changes }} && ${{ inputs.collect-coverage }}
         shell: bash
         env:
           CIRCLE_WORKFLOW_ID: ${{ github.run_id }}
@@ -205,6 +192,6 @@ jobs:
               fi
             fi
       - name: Report no code changes
-        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        if: ${{ !inputs.has_code_changes }}
         run: |
           echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -38,6 +38,14 @@ on:
         required: true
         description: Secret to access Bazel build cache
 jobs:
+  check_code_changes:
+    name: Check Code Changes
+    uses: ./.github/workflows/_check_code_changes.yml
+    with:
+      event_name: ${{ github.event_name }}
+      # For pull_request, use PR's base and head. For push, use event's before and sha.
+      base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+      head_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
   test:
     needs: [check_code_changes]
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     container:
       image: ${{ inputs.dev-image }}
-      options: "${{ inputs.install-cuda-plugin && '--gpus all' || '' }} --shm-size 16g"
+      options: "${{ inputs.install-cuda-plugin == true && '--gpus all' || '' }} --shm-size 16g"
     strategy:
       fail-fast: false
       matrix:
@@ -82,14 +82,14 @@ jobs:
       BAZEL_REMOTE_CACHE: 1
     steps:
       - name: Checkout actions
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
@@ -97,7 +97,7 @@ jobs:
           wheels-artifact: torch-xla-wheels
           cuda-plugin-artifact: ${{ inputs.install-cuda-plugin && 'cuda-plugin' || null }}
       - name: Fetch CPP test binaries
-        if: ${{ inputs.has_code_changes == 'true' }} && ${{ matrix.run_cpp_tests }}
+        if: inputs.has_code_changes == 'true' && matrix.run_cpp_tests
         uses: actions/download-artifact@v4
         with:
           name: cpp-test-bin
@@ -105,34 +105,34 @@ jobs:
       # GitHub Actions doesn't preserve executable permissions
       # https://github.com/actions/download-artifact?tab=readme-ov-file#permission-loss
       - name: Set CPP test permissions
-        if: ${{ inputs.has_code_changes == 'true' }} && ${{ matrix.run_cpp_tests }}
+        if: inputs.has_code_changes == 'true' && matrix.run_cpp_tests
         run: |
           chmod +x /tmp/test/bin/*
           ls -l /tmp/test/bin
       - name: Check GPU
-        if: ${{ inputs.has_code_changes == 'true' }} && ${{ inputs.install-cuda-plugin }}
+        if: inputs.has_code_changes == 'true' && inputs.install-cuda-plugin
         run: nvidia-smi
       - name: Install test deps
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         shell: bash
         run: |
           # TODO: Add these in setup.py
           pip install fsspec
           pip install rich
       - name: Checkout PyTorch Repo
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         uses: actions/checkout@v4
         with:
           repository: pytorch/pytorch
           path: pytorch
           ref: ${{ inputs.torch-commit }}
       - name: Checkout PyTorch/XLA Repo
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         uses: actions/checkout@v4
         with:
           path: pytorch/xla
       - name: Extra CI deps
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         shell: bash
         run: |
           set -x
@@ -143,11 +143,11 @@ jobs:
             pip install -r pytorch/xla/benchmarks/requirements.txt
           fi
       - name: Test
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         shell: bash
         run: pytorch/xla/.github/scripts/run_tests.sh pytorch/ pytorch/xla/ $USE_COVERAGE
       - name: Upload coverage results
-        if: ${{ inputs.has_code_changes == 'true' }} && ${{ inputs.collect-coverage }}
+        if: inputs.has_code_changes == 'true' && inputs.collect-coverage
         shell: bash
         env:
           CIRCLE_WORKFLOW_ID: ${{ github.run_id }}
@@ -192,6 +192,6 @@ jobs:
               fi
             fi
       - name: Report no code changes
-        if: ${{ inputs.has_code_changes == 'false' }}
+        if: inputs.has_code_changes == 'false'
         run: |
           echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -34,9 +34,9 @@ on:
           description: torch-commit
       has_code_changes:
         required: false
-        type: boolean
+        type: string
         description: Whether to run full workflow or not
-        default: true
+        default: 'true'
     secrets:
       gcloud-service-key:
         required: true
@@ -82,14 +82,14 @@ jobs:
       BAZEL_REMOTE_CACHE: 1
     steps:
       - name: Checkout actions
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
@@ -97,7 +97,7 @@ jobs:
           wheels-artifact: torch-xla-wheels
           cuda-plugin-artifact: ${{ inputs.install-cuda-plugin && 'cuda-plugin' || null }}
       - name: Fetch CPP test binaries
-        if: ${{ inputs.has_code_changes }} && ${{ matrix.run_cpp_tests }}
+        if: ${{ inputs.has_code_changes }} == 'true' && ${{ matrix.run_cpp_tests }}
         uses: actions/download-artifact@v4
         with:
           name: cpp-test-bin
@@ -105,34 +105,34 @@ jobs:
       # GitHub Actions doesn't preserve executable permissions
       # https://github.com/actions/download-artifact?tab=readme-ov-file#permission-loss
       - name: Set CPP test permissions
-        if: ${{ inputs.has_code_changes }} && ${{ matrix.run_cpp_tests }}
+        if: ${{ inputs.has_code_changes }} == 'true' && ${{ matrix.run_cpp_tests }}
         run: |
           chmod +x /tmp/test/bin/*
           ls -l /tmp/test/bin
       - name: Check GPU
-        if: ${{ inputs.has_code_changes }} && ${{ inputs.install-cuda-plugin }}
+        if: ${{ inputs.has_code_changes }} == 'true' && ${{ inputs.install-cuda-plugin }}
         run: nvidia-smi
       - name: Install test deps
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         shell: bash
         run: |
           # TODO: Add these in setup.py
           pip install fsspec
           pip install rich
       - name: Checkout PyTorch Repo
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         uses: actions/checkout@v4
         with:
           repository: pytorch/pytorch
           path: pytorch
           ref: ${{ inputs.torch-commit }}
       - name: Checkout PyTorch/XLA Repo
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         uses: actions/checkout@v4
         with:
           path: pytorch/xla
       - name: Extra CI deps
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         shell: bash
         run: |
           set -x
@@ -143,11 +143,11 @@ jobs:
             pip install -r pytorch/xla/benchmarks/requirements.txt
           fi
       - name: Test
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         shell: bash
         run: pytorch/xla/.github/scripts/run_tests.sh pytorch/ pytorch/xla/ $USE_COVERAGE
       - name: Upload coverage results
-        if: ${{ inputs.has_code_changes }} && ${{ inputs.collect-coverage }}
+        if: ${{ inputs.has_code_changes }} == 'true' && ${{ inputs.collect-coverage }}
         shell: bash
         env:
           CIRCLE_WORKFLOW_ID: ${{ github.run_id }}
@@ -192,6 +192,6 @@ jobs:
               fi
             fi
       - name: Report no code changes
-        if: ${{ !inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'false'
         run: |
           echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -39,6 +39,7 @@ on:
         description: Secret to access Bazel build cache
 jobs:
   test:
+    needs: [check_code_changes]
     runs-on: ${{ inputs.runner }}
     container:
       image: ${{ inputs.dev-image }}
@@ -78,12 +79,14 @@ jobs:
       BAZEL_REMOTE_CACHE: 1
     steps:
       - name: Checkout actions
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
@@ -91,6 +94,7 @@ jobs:
           wheels-artifact: torch-xla-wheels
           cuda-plugin-artifact: ${{ inputs.install-cuda-plugin && 'cuda-plugin' || null }}
       - name: Fetch CPP test binaries
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: actions/download-artifact@v4
         with:
           name: cpp-test-bin
@@ -99,30 +103,36 @@ jobs:
       # GitHub Actions doesn't preserve executable permissions
       # https://github.com/actions/download-artifact?tab=readme-ov-file#permission-loss
       - name: Set CPP test permissions
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         run: |
           chmod +x /tmp/test/bin/*
           ls -l /tmp/test/bin
         if: ${{ matrix.run_cpp_tests }}
       - name: Check GPU
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         run: nvidia-smi
         if: ${{ inputs.install-cuda-plugin }}
       - name: Install test deps
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         shell: bash
         run: |
           # TODO: Add these in setup.py
           pip install fsspec
           pip install rich
       - name: Checkout PyTorch Repo
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: actions/checkout@v4
         with:
           repository: pytorch/pytorch
           path: pytorch
           ref: ${{ inputs.torch-commit }}
       - name: Checkout PyTorch/XLA Repo
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: actions/checkout@v4
         with:
           path: pytorch/xla
       - name: Extra CI deps
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         shell: bash
         run: |
           set -x
@@ -133,9 +143,11 @@ jobs:
             pip install -r pytorch/xla/benchmarks/requirements.txt
           fi
       - name: Test
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         shell: bash
         run: pytorch/xla/.github/scripts/run_tests.sh pytorch/ pytorch/xla/ $USE_COVERAGE
       - name: Upload coverage results
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         if: ${{ inputs.collect-coverage }}
         shell: bash
         env:
@@ -180,3 +192,7 @@ jobs:
                 gsutil cp inc_metadata.json gs://ng3-metrics/ng3-pytorchxla-coverage/incremental/pytorchxla/${CIRCLE_WORKFLOW_ID}/metadata.json
               fi
             fi
+      - name: Report no code changes
+        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        run: |
+          echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_test_requiring_torch_cuda.yml
+++ b/.github/workflows/_test_requiring_torch_cuda.yml
@@ -103,12 +103,13 @@ jobs:
         with:
           path: pytorch/xla
       - name: Extra CI deps
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: >
+          needs.check_code_changes.outputs.has_code_changes == 'true'
+          ${{ matrix.run_triton_tests }}
         shell: bash
         run: |
           set -x
           pip install -U --pre jax jaxlib "jax-cuda12-plugin[with_cuda]" jax-cuda12-pjrt -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
-        if: ${{ matrix.run_triton_tests }}
       - name: Install Triton
         if: needs.check_code_changes.outputs.has_code_changes == 'true'
         shell: bash
@@ -116,19 +117,21 @@ jobs:
           cd pytorch
           make triton
       - name: Python Tests
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: >
+          needs.check_code_changes.outputs.has_code_changes == 'true' &&
+          ${{ matrix.run_python_tests }}
         shell: bash
         run: |
           set -xue
           PJRT_DEVICE=CUDA python pytorch/xla/test/test_operations.py -v
           PJRT_DEVICE=CUDA python pytorch/xla/test/dynamo/test_dynamo.py -v
-        if: ${{ matrix.run_python_tests }}
       - name: Triton Tests
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: >
+          needs.check_code_changes.outputs.has_code_changes == 'true' &&
+          ${{ matrix.run_triton_tests }}
         shell: bash
         run: |
           PJRT_DEVICE=CUDA TRITON_PTXAS_PATH=/usr/local/cuda-12.3/bin/ptxas python pytorch/xla/test/test_triton.py
-        if: ${{ matrix.run_triton_tests }}
       - name: Report no code changes
         if: needs.check_code_changes.outputs.has_code_changes == 'false'
         run: |

--- a/.github/workflows/_test_requiring_torch_cuda.yml
+++ b/.github/workflows/_test_requiring_torch_cuda.yml
@@ -29,9 +29,9 @@ on:
         description: torch-commit
       has_code_changes:
         required: false
-        type: boolean
+        type: string
         description: Whether to run full workflow or not
-        default: true
+        default: 'true'
 jobs:
   test:
     container:
@@ -52,14 +52,14 @@ jobs:
       BAZEL_REMOTE_CACHE: 1
     steps:
       - name: Checkout actions
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
@@ -68,10 +68,10 @@ jobs:
           cuda-plugin-artifact: cuda-plugin
           cuda-torch-artifact: torch-with-cuda
       - name: Check GPU
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         run: nvidia-smi
       - name: Install wheels
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         shell: bash
         run: |
           pip install /tmp/wheels/*.whl
@@ -86,42 +86,42 @@ jobs:
           python -c "import torch; assert torch.cuda.is_available()"
           echo "CUDA is available for PyTorch."
       - name: Checkout PyTorch Repo
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         uses: actions/checkout@v4
         with:
           repository: pytorch/pytorch
           path: pytorch
           ref: ${{ inputs.torch-commit }}
       - name: Checkout PyTorch/XLA Repo
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         uses: actions/checkout@v4
         with:
           path: pytorch/xla
       - name: Extra CI deps
-        if: ${{ inputs.has_code_changes }} && ${{ matrix.run_triton_tests }}
+        if: ${{ inputs.has_code_changes }} == 'true' && ${{ matrix.run_triton_tests }}
         shell: bash
         run: |
           set -x
           pip install -U --pre jax jaxlib "jax-cuda12-plugin[with_cuda]" jax-cuda12-pjrt -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
       - name: Install Triton
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         shell: bash
         run: |
           cd pytorch
           make triton
       - name: Python Tests
-        if: ${{ inputs.has_code_changes }} && ${{ matrix.run_python_tests }}
+        if: ${{ inputs.has_code_changes }} == 'true' && ${{ matrix.run_python_tests }}
         shell: bash
         run: |
           set -xue
           PJRT_DEVICE=CUDA python pytorch/xla/test/test_operations.py -v
           PJRT_DEVICE=CUDA python pytorch/xla/test/dynamo/test_dynamo.py -v
       - name: Triton Tests
-        if: ${{ inputs.has_code_changes }} && ${{ matrix.run_triton_tests }}
+        if: ${{ inputs.has_code_changes }} == 'true' && ${{ matrix.run_triton_tests }}
         shell: bash
         run: |
           PJRT_DEVICE=CUDA TRITON_PTXAS_PATH=/usr/local/cuda-12.3/bin/ptxas python pytorch/xla/test/test_triton.py
       - name: Report no code changes
-        if: ${{ !inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'false'
         run: |
           echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_test_requiring_torch_cuda.yml
+++ b/.github/workflows/_test_requiring_torch_cuda.yml
@@ -52,14 +52,14 @@ jobs:
       BAZEL_REMOTE_CACHE: 1
     steps:
       - name: Checkout actions
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
@@ -68,10 +68,10 @@ jobs:
           cuda-plugin-artifact: cuda-plugin
           cuda-torch-artifact: torch-with-cuda
       - name: Check GPU
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         run: nvidia-smi
       - name: Install wheels
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         shell: bash
         run: |
           pip install /tmp/wheels/*.whl
@@ -86,42 +86,42 @@ jobs:
           python -c "import torch; assert torch.cuda.is_available()"
           echo "CUDA is available for PyTorch."
       - name: Checkout PyTorch Repo
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         uses: actions/checkout@v4
         with:
           repository: pytorch/pytorch
           path: pytorch
           ref: ${{ inputs.torch-commit }}
       - name: Checkout PyTorch/XLA Repo
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         uses: actions/checkout@v4
         with:
           path: pytorch/xla
       - name: Extra CI deps
-        if: ${{ inputs.has_code_changes }} == 'true' && ${{ matrix.run_triton_tests }}
+        if: ${{ inputs.has_code_changes == 'true' }} && ${{ matrix.run_triton_tests }}
         shell: bash
         run: |
           set -x
           pip install -U --pre jax jaxlib "jax-cuda12-plugin[with_cuda]" jax-cuda12-pjrt -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
       - name: Install Triton
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         shell: bash
         run: |
           cd pytorch
           make triton
       - name: Python Tests
-        if: ${{ inputs.has_code_changes }} == 'true' && ${{ matrix.run_python_tests }}
+        if: ${{ inputs.has_code_changes == 'true' }} && ${{ matrix.run_python_tests }}
         shell: bash
         run: |
           set -xue
           PJRT_DEVICE=CUDA python pytorch/xla/test/test_operations.py -v
           PJRT_DEVICE=CUDA python pytorch/xla/test/dynamo/test_dynamo.py -v
       - name: Triton Tests
-        if: ${{ inputs.has_code_changes }} == 'true' && ${{ matrix.run_triton_tests }}
+        if: ${{ inputs.has_code_changes == 'true' }} && ${{ matrix.run_triton_tests }}
         shell: bash
         run: |
           PJRT_DEVICE=CUDA TRITON_PTXAS_PATH=/usr/local/cuda-12.3/bin/ptxas python pytorch/xla/test/test_triton.py
       - name: Report no code changes
-        if: ${{ inputs.has_code_changes }} == 'false'
+        if: ${{ inputs.has_code_changes == 'false' }}
         run: |
           echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_test_requiring_torch_cuda.yml
+++ b/.github/workflows/_test_requiring_torch_cuda.yml
@@ -29,7 +29,16 @@ on:
         description: torch-commit
 
 jobs:
+  check_code_changes:
+    name: Check Code Changes
+    uses: ./.github/workflows/_check_code_changes.yml
+    with:
+      event_name: ${{ github.event_name }}
+      # For pull_request, use PR's base and head. For push, use event's before and sha.
+      base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+      head_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
   test:
+    needs: [check_code_changes]
     container:
       image: ${{ inputs.dev-image }}
       options: "--gpus all --shm-size 16g"
@@ -48,12 +57,14 @@ jobs:
       BAZEL_REMOTE_CACHE: 1
     steps:
       - name: Checkout actions
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
@@ -62,8 +73,10 @@ jobs:
           cuda-plugin-artifact: cuda-plugin
           cuda-torch-artifact: torch-with-cuda
       - name: Check GPU
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         run: nvidia-smi
       - name: Install wheels
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         shell: bash
         run: |
           pip install /tmp/wheels/*.whl
@@ -78,27 +91,32 @@ jobs:
           python -c "import torch; assert torch.cuda.is_available()"
           echo "CUDA is available for PyTorch."
       - name: Checkout PyTorch Repo
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: actions/checkout@v4
         with:
           repository: pytorch/pytorch
           path: pytorch
           ref: ${{ inputs.torch-commit }}
       - name: Checkout PyTorch/XLA Repo
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: actions/checkout@v4
         with:
           path: pytorch/xla
       - name: Extra CI deps
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         shell: bash
         run: |
           set -x
           pip install -U --pre jax jaxlib "jax-cuda12-plugin[with_cuda]" jax-cuda12-pjrt -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
         if: ${{ matrix.run_triton_tests }}
       - name: Install Triton
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         shell: bash
         run: |
           cd pytorch
           make triton
       - name: Python Tests
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         shell: bash
         run: |
           set -xue
@@ -106,7 +124,12 @@ jobs:
           PJRT_DEVICE=CUDA python pytorch/xla/test/dynamo/test_dynamo.py -v
         if: ${{ matrix.run_python_tests }}
       - name: Triton Tests
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         shell: bash
         run: |
           PJRT_DEVICE=CUDA TRITON_PTXAS_PATH=/usr/local/cuda-12.3/bin/ptxas python pytorch/xla/test/test_triton.py
         if: ${{ matrix.run_triton_tests }}
+      - name: Report no code changes
+        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        run: |
+          echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_test_requiring_torch_cuda.yml
+++ b/.github/workflows/_test_requiring_torch_cuda.yml
@@ -52,14 +52,14 @@ jobs:
       BAZEL_REMOTE_CACHE: 1
     steps:
       - name: Checkout actions
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
@@ -68,10 +68,10 @@ jobs:
           cuda-plugin-artifact: cuda-plugin
           cuda-torch-artifact: torch-with-cuda
       - name: Check GPU
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         run: nvidia-smi
       - name: Install wheels
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         shell: bash
         run: |
           pip install /tmp/wheels/*.whl
@@ -86,42 +86,42 @@ jobs:
           python -c "import torch; assert torch.cuda.is_available()"
           echo "CUDA is available for PyTorch."
       - name: Checkout PyTorch Repo
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         uses: actions/checkout@v4
         with:
           repository: pytorch/pytorch
           path: pytorch
           ref: ${{ inputs.torch-commit }}
       - name: Checkout PyTorch/XLA Repo
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         uses: actions/checkout@v4
         with:
           path: pytorch/xla
       - name: Extra CI deps
-        if: ${{ inputs.has_code_changes == 'true' }} && ${{ matrix.run_triton_tests }}
+        if: inputs.has_code_changes == 'true' && matrix.run_triton_tests
         shell: bash
         run: |
           set -x
           pip install -U --pre jax jaxlib "jax-cuda12-plugin[with_cuda]" jax-cuda12-pjrt -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
       - name: Install Triton
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         shell: bash
         run: |
           cd pytorch
           make triton
       - name: Python Tests
-        if: ${{ inputs.has_code_changes == 'true' }} && ${{ matrix.run_python_tests }}
+        if: inputs.has_code_changes == 'true' && matrix.run_python_tests
         shell: bash
         run: |
           set -xue
           PJRT_DEVICE=CUDA python pytorch/xla/test/test_operations.py -v
           PJRT_DEVICE=CUDA python pytorch/xla/test/dynamo/test_dynamo.py -v
       - name: Triton Tests
-        if: ${{ inputs.has_code_changes == 'true' }} && ${{ matrix.run_triton_tests }}
+        if: inputs.has_code_changes == 'true' && matrix.run_triton_tests
         shell: bash
         run: |
           PJRT_DEVICE=CUDA TRITON_PTXAS_PATH=/usr/local/cuda-12.3/bin/ptxas python pytorch/xla/test/test_triton.py
       - name: Report no code changes
-        if: ${{ inputs.has_code_changes == 'false' }}
+        if: inputs.has_code_changes == 'false'
         run: |
           echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_test_requiring_torch_cuda.yml
+++ b/.github/workflows/_test_requiring_torch_cuda.yml
@@ -27,18 +27,13 @@ on:
         required: true
         type: string
         description: torch-commit
-
+      has_code_changes:
+        required: false
+        type: boolean
+        description: Whether to run full workflow or not
+        default: true
 jobs:
-  check_code_changes:
-    name: Check Code Changes
-    uses: ./.github/workflows/_check_code_changes.yml
-    with:
-      event_name: ${{ github.event_name }}
-      # For pull_request, use PR's base and head. For push, use event's before and sha.
-      base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-      head_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
   test:
-    needs: [check_code_changes]
     container:
       image: ${{ inputs.dev-image }}
       options: "--gpus all --shm-size 16g"
@@ -57,14 +52,14 @@ jobs:
       BAZEL_REMOTE_CACHE: 1
     steps:
       - name: Checkout actions
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
@@ -73,10 +68,10 @@ jobs:
           cuda-plugin-artifact: cuda-plugin
           cuda-torch-artifact: torch-with-cuda
       - name: Check GPU
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         run: nvidia-smi
       - name: Install wheels
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         shell: bash
         run: |
           pip install /tmp/wheels/*.whl
@@ -91,48 +86,42 @@ jobs:
           python -c "import torch; assert torch.cuda.is_available()"
           echo "CUDA is available for PyTorch."
       - name: Checkout PyTorch Repo
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         uses: actions/checkout@v4
         with:
           repository: pytorch/pytorch
           path: pytorch
           ref: ${{ inputs.torch-commit }}
       - name: Checkout PyTorch/XLA Repo
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         uses: actions/checkout@v4
         with:
           path: pytorch/xla
       - name: Extra CI deps
-        if: >
-          needs.check_code_changes.outputs.has_code_changes == 'true'
-          ${{ matrix.run_triton_tests }}
+        if: ${{ inputs.has_code_changes }} && ${{ matrix.run_triton_tests }}
         shell: bash
         run: |
           set -x
           pip install -U --pre jax jaxlib "jax-cuda12-plugin[with_cuda]" jax-cuda12-pjrt -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
       - name: Install Triton
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         shell: bash
         run: |
           cd pytorch
           make triton
       - name: Python Tests
-        if: >
-          needs.check_code_changes.outputs.has_code_changes == 'true' &&
-          ${{ matrix.run_python_tests }}
+        if: ${{ inputs.has_code_changes }} && ${{ matrix.run_python_tests }}
         shell: bash
         run: |
           set -xue
           PJRT_DEVICE=CUDA python pytorch/xla/test/test_operations.py -v
           PJRT_DEVICE=CUDA python pytorch/xla/test/dynamo/test_dynamo.py -v
       - name: Triton Tests
-        if: >
-          needs.check_code_changes.outputs.has_code_changes == 'true' &&
-          ${{ matrix.run_triton_tests }}
+        if: ${{ inputs.has_code_changes }} && ${{ matrix.run_triton_tests }}
         shell: bash
         run: |
           PJRT_DEVICE=CUDA TRITON_PTXAS_PATH=/usr/local/cuda-12.3/bin/ptxas python pytorch/xla/test/test_triton.py
       - name: Report no code changes
-        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        if: ${{ !inputs.has_code_changes }}
         run: |
           echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_tpu_ci.yml
+++ b/.github/workflows/_tpu_ci.yml
@@ -9,29 +9,29 @@ on:
         default: 120
       has_code_changes:
         required: false
-        type: boolean
+        type: string
         description: Whether to run full workflow or not
-        default: true
+        default: 'true'
 jobs:
   tpu-test:
     runs-on: v4-runner-set
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Checkout actions
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
           wheels-artifact: torch-xla-wheels
       - name: Install test dependencies
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         shell: bash
         run: |
           # TODO: Add these in setup.py
@@ -42,7 +42,7 @@ jobs:
           pip install torch_xla[tpu] -f https://storage.googleapis.com/libtpu-wheels/index.html -f https://storage.googleapis.com/libtpu-releases/index.html
           pip install --upgrade protobuf
       - name: Run Tests
-        if: ${{ inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'true'
         env:
           PJRT_DEVICE: TPU
           TPU_LOG_DIR: tpu_logs
@@ -50,6 +50,6 @@ jobs:
           cd pytorch/xla
           test/tpu/run_tests.sh
       - name: Report no code changes
-        if: ${{ !inputs.has_code_changes }}
+        if: ${{ inputs.has_code_changes }} == 'false'
         run: |
           echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_tpu_ci.yml
+++ b/.github/workflows/_tpu_ci.yml
@@ -18,20 +18,20 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Checkout actions
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
           wheels-artifact: torch-xla-wheels
       - name: Install test dependencies
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         shell: bash
         run: |
           # TODO: Add these in setup.py
@@ -42,7 +42,7 @@ jobs:
           pip install torch_xla[tpu] -f https://storage.googleapis.com/libtpu-wheels/index.html -f https://storage.googleapis.com/libtpu-releases/index.html
           pip install --upgrade protobuf
       - name: Run Tests
-        if: ${{ inputs.has_code_changes }} == 'true'
+        if: ${{ inputs.has_code_changes == 'true' }}
         env:
           PJRT_DEVICE: TPU
           TPU_LOG_DIR: tpu_logs
@@ -50,6 +50,6 @@ jobs:
           cd pytorch/xla
           test/tpu/run_tests.sh
       - name: Report no code changes
-        if: ${{ inputs.has_code_changes }} == 'false'
+        if: ${{ inputs.has_code_changes == 'false' }}
         run: |
           echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_tpu_ci.yml
+++ b/.github/workflows/_tpu_ci.yml
@@ -7,35 +7,31 @@ on:
         type: number
         description: Timeout in minutes for the job run
         default: 120
+      has_code_changes:
+        required: false
+        type: boolean
+        description: Whether to run full workflow or not
+        default: true
 jobs:
-  check_code_changes:
-    name: Check Code Changes
-    uses: ./.github/workflows/_check_code_changes.yml
-    with:
-      event_name: ${{ github.event_name }}
-      # For pull_request, use PR's base and head. For push, use event's before and sha.
-      base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-      head_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
   tpu-test:
-    needs: [check_code_changes]
     runs-on: v4-runner-set
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Checkout actions
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
           wheels-artifact: torch-xla-wheels
       - name: Install test dependencies
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         shell: bash
         run: |
           # TODO: Add these in setup.py
@@ -46,7 +42,7 @@ jobs:
           pip install torch_xla[tpu] -f https://storage.googleapis.com/libtpu-wheels/index.html -f https://storage.googleapis.com/libtpu-releases/index.html
           pip install --upgrade protobuf
       - name: Run Tests
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        if: ${{ inputs.has_code_changes }}
         env:
           PJRT_DEVICE: TPU
           TPU_LOG_DIR: tpu_logs
@@ -54,6 +50,6 @@ jobs:
           cd pytorch/xla
           test/tpu/run_tests.sh
       - name: Report no code changes
-        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        if: ${{ !inputs.has_code_changes }}
         run: |
           echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_tpu_ci.yml
+++ b/.github/workflows/_tpu_ci.yml
@@ -8,22 +8,34 @@ on:
         description: Timeout in minutes for the job run
         default: 120
 jobs:
+  check_code_changes:
+    name: Check Code Changes
+    uses: ./.github/workflows/_check_code_changes.yml
+    with:
+      event_name: ${{ github.event_name }}
+      # For pull_request, use PR's base and head. For push, use event's before and sha.
+      base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+      head_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
   tpu-test:
+    needs: [check_code_changes]
     runs-on: v4-runner-set
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Checkout actions
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
           wheels-artifact: torch-xla-wheels
       - name: Install test dependencies
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         shell: bash
         run: |
           # TODO: Add these in setup.py
@@ -34,9 +46,14 @@ jobs:
           pip install torch_xla[tpu] -f https://storage.googleapis.com/libtpu-wheels/index.html -f https://storage.googleapis.com/libtpu-releases/index.html
           pip install --upgrade protobuf
       - name: Run Tests
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         env:
           PJRT_DEVICE: TPU
           TPU_LOG_DIR: tpu_logs
         run: |
           cd pytorch/xla
           test/tpu/run_tests.sh
+      - name: Report no code changes
+        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        run: |
+          echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/_tpu_ci.yml
+++ b/.github/workflows/_tpu_ci.yml
@@ -18,20 +18,20 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Checkout actions
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/workflows/setup
           path: .actions
       - name: Setup
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         uses: ./.actions/.github/workflows/setup
         with:
           torch-commit: ${{ inputs.torch-commit }}
           wheels-artifact: torch-xla-wheels
       - name: Install test dependencies
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         shell: bash
         run: |
           # TODO: Add these in setup.py
@@ -42,7 +42,7 @@ jobs:
           pip install torch_xla[tpu] -f https://storage.googleapis.com/libtpu-wheels/index.html -f https://storage.googleapis.com/libtpu-releases/index.html
           pip install --upgrade protobuf
       - name: Run Tests
-        if: ${{ inputs.has_code_changes == 'true' }}
+        if: inputs.has_code_changes == 'true'
         env:
           PJRT_DEVICE: TPU
           TPU_LOG_DIR: tpu_logs
@@ -50,6 +50,6 @@ jobs:
           cd pytorch/xla
           test/tpu/run_tests.sh
       - name: Report no code changes
-        if: ${{ inputs.has_code_changes == 'false' }}
+        if: inputs.has_code_changes == 'false'
         run: |
           echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - master
       - r[0-9]+.[0-9]+
+    paths-ignore:
+      - '**.md' # Ignore any file ending with .md in any directory
   push:
     branches:
       - master

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - master
       - r[0-9]+.[0-9]+
-    paths-ignore:
-      - '**.md' # Ignore any file ending with .md in any directory
   push:
     branches:
       - master
@@ -17,9 +15,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check_code_changes:
+    name: Check Code Changes
+    uses: ./.github/workflows/_check_code_changes.yml
+    with:
+      event_name: ${{ github.event_name }}
+      # For pull_request, use PR's base and head. For push, use event's before and sha.
+      base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+      head_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
   get-torch-commit:
     runs-on: ubuntu-24.04
+    needs: [check_code_changes]
+    # Only run if code changes detected
+    if: needs.check_code_changes.outputs.has_code_changes == 'true'
     outputs:
       torch_commit: ${{ steps.commit.outputs.torch_commit }}
     steps:
@@ -31,7 +40,9 @@ jobs:
   build-torch-xla:
     name: "Build PyTorch/XLA"
     uses: ./.github/workflows/_build_torch_xla.yml
-    needs: get-torch-commit
+    needs: [check_code_changes, get-torch-commit]
+    # Only run if code changes detected
+    if: needs.check_code_changes.outputs.has_code_changes == 'true'
     with:
       dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
       torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
@@ -42,7 +53,9 @@ jobs:
   build-torch-with-cuda:
     name: "Build PyTorch with CUDA"
     uses: ./.github/workflows/_build_torch_with_cuda.yml
-    needs: get-torch-commit
+    needs: [check_code_changes, get-torch-commit]
+    # Only run if code changes detected
+    if: needs.check_code_changes.outputs.has_code_changes == 'true'
     with:
       # TODO: bump CUDA version to either 12.4 or 12.6 (supported by PyTorch).
       # Ref: https://github.com/pytorch/xla/issues/8700
@@ -55,6 +68,9 @@ jobs:
   build-cuda-plugin:
     name: "Build XLA CUDA plugin"
     uses: ./.github/workflows/_build_plugin.yml
+    needs: [check_code_changes]
+    # Only run if code changes detected
+    if: needs.check_code_changes.outputs.has_code_changes == 'true'
     with:
       dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
     secrets:
@@ -63,7 +79,9 @@ jobs:
   test-python-cpu:
     name: "CPU tests"
     uses: ./.github/workflows/_test.yml
-    needs: [build-torch-xla, get-torch-commit]
+    needs: [build-torch-xla, check_code_changes, get-torch-commit]
+    # Only run if code changes detected
+    if: needs.check_code_changes.outputs.has_code_changes == 'true'
     with:
       dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
       timeout-minutes: 120
@@ -75,7 +93,9 @@ jobs:
   test-cuda:
     name: "GPU tests"
     uses: ./.github/workflows/_test.yml
-    needs: [build-torch-xla, build-cuda-plugin, get-torch-commit]
+    needs: [build-torch-xla, build-cuda-plugin, check_code_changes, get-torch-commit]
+    # Only run if code changes detected
+    if: needs.check_code_changes.outputs.has_code_changes == 'true'
     with:
       dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
       runner: linux.g4dn.12xlarge.nvidia.gpu
@@ -89,7 +109,9 @@ jobs:
   test-cuda-with-pytorch-cuda-enabled:
     name: "GPU tests requiring torch CUDA"
     uses: ./.github/workflows/_test_requiring_torch_cuda.yml
-    needs: [build-torch-with-cuda, build-torch-xla, build-cuda-plugin, get-torch-commit]
+    needs: [build-torch-with-cuda, build-torch-xla, build-cuda-plugin, check_code_changes, get-torch-commit]
+    # Only run if code changes detected
+    if: needs.check_code_changes.outputs.has_code_changes == 'true'
     with:
       dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
       runner: linux.8xlarge.nvidia.gpu
@@ -100,10 +122,13 @@ jobs:
   test-tpu:
     name: "TPU tests"
     uses: ./.github/workflows/_tpu_ci.yml
-    needs: build-torch-xla
+    needs: [build-torch-xla, check_code_changes]
+    # Only run if code changes detected
+    if: >
+      (github.event_name == 'push' || github.event_name == 'pull_request') &&
+      needs.check_code_changes.outputs.has_code_changes == 'true'
     with:
       timeout-minutes: 300
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
 
   push-docs:
     name: "Build docs"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,22 +42,14 @@ jobs:
 
   build-torch-xla:
     name: "Build PyTorch/XLA"
-    needs: [check_code_changes, get-torch-commit]
-    runs-on: ubuntu-24.04
+    uses: ./.github/workflows/_build_torch_xla.yml
+    needs: get-torch-commit
+    with:
+      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
+      torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
+      timeout-minutes: 240
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
-    steps:
-      - name: Build PyTorch/XLA
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
-        uses: ./.github/workflows/_build_torch_xla.yml
-        with:
-          dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
-          torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
-          timeout-minutes: 240
-      - name: Report no code changes
-        if: needs.check_code_changes.outputs.has_code_changes == 'false'
-        run: |
-          echo "No code changes were detected that require running the full test suite."
 
   build-torch-with-cuda:
     name: "Build PyTorch with CUDA"
@@ -79,62 +71,37 @@ jobs:
 
   build-cuda-plugin:
     name: "Build XLA CUDA plugin"
-    needs: [check_code_changes]
-    runs-on: ubuntu-24.04
+    uses: ./.github/workflows/_build_plugin.yml
+    with:
+      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
-    steps:
-      - name: Build XLA CUDA plugin
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
-        uses: ./.github/workflows/_build_plugin.yml
-        with:
-          dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
-      - name: Report no code changes
-        if: needs.check_code_changes.outputs.has_code_changes == 'false'
-        run: |
-          echo "No code changes were detected that require running the full test suite."
 
   test-python-cpu:
     name: "CPU tests"
-    needs: [build-torch-xla, check_code_changes, get-torch-commit]
-    runs-on: ubuntu-24.04
+    uses: ./.github/workflows/_test.yml
+    needs: [build-torch-xla, get-torch-commit]
+    with:
+      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
+      timeout-minutes: 120
+      collect-coverage: false
+      torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
-    steps:
-      - name: Run CPU tests
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
-        uses: ./.github/workflows/_test.yml
-        with:
-          dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
-          timeout-minutes: 120
-          collect-coverage: false
-          torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
-      - name: Report no code changes
-        if: needs.check_code_changes.outputs.has_code_changes == 'false'
-        run: |
-          echo "No code changes were detected that require running the full test suite."
 
   test-cuda:
     name: "GPU tests"
-    needs: [build-torch-xla, build-cuda-plugin, check_code_changes, get-torch-commit]
-    runs-on: ubuntu-24.04
+    uses: ./.github/workflows/_test.yml
+    needs: [build-torch-xla, build-cuda-plugin, get-torch-commit]
+    with:
+      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
+      runner: linux.g4dn.12xlarge.nvidia.gpu
+      timeout-minutes: 300
+      collect-coverage: false
+      install-cuda-plugin: true
+      torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
-    steps:
-      - name: Run GPU tests
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
-        uses: ./.github/workflows/_test.yml
-        with:
-          dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
-          runner: linux.g4dn.12xlarge.nvidia.gpu
-          timeout-minutes: 300
-          collect-coverage: false
-          install-cuda-plugin: true
-          torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
-      - name: Report no code changes
-        if: needs.check_code_changes.outputs.has_code_changes == 'false'
-        run: |
-          echo "No code changes were detected that require running the full test suite."
 
   test-cuda-with-pytorch-cuda-enabled:
     name: "GPU tests requiring torch CUDA"
@@ -176,17 +143,9 @@ jobs:
 
   push-docs:
     name: "Build docs"
-    needs: [build-torch-xla, check_code_changes]
-    runs-on: ubuntu-24.04
+    uses: ./.github/workflows/_docs.yml
+    needs: build-torch-xla
+    with:
+      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
     secrets:
       torchxla-bot-token: ${{ secrets.TORCH_XLA_BOT_TOKEN }}
-    steps:
-      - name: Build and push docs
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
-        uses: ./.github/workflows/_docs.yml
-        with:
-          dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
-      - name: Report no code changes
-        if: needs.check_code_changes.outputs.has_code_changes == 'false'
-        run: |
-          echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -53,21 +53,16 @@ jobs:
 
   build-torch-with-cuda:
     name: "Build PyTorch with CUDA"
-    needs: [check_code_changes, get-torch-commit]
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Build PyTorch with CUDA
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
-        uses: ./.github/workflows/_build_torch_with_cuda.yml
-        with:
-          dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
-          torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
-          runner: linux.24xlarge
-          timeout-minutes: 120
-      - name: Report no code changes
-        if: needs.check_code_changes.outputs.has_code_changes == 'false'
-        run: |
-          echo "No code changes were detected that require running the full test suite."
+    uses: ./.github/workflows/_build_torch_with_cuda.yml
+    needs: get-torch-commit
+    with:
+      # TODO: bump CUDA version to either 12.4 or 12.6 (supported by PyTorch).
+      # Ref: https://github.com/pytorch/xla/issues/8700
+      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
+      torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
+      # note that to build a torch wheel with CUDA enabled, we do not need a GPU runner.
+      runner: linux.24xlarge
+      timeout-minutes: 120
 
   build-cuda-plugin:
     name: "Build XLA CUDA plugin"
@@ -105,41 +100,22 @@ jobs:
 
   test-cuda-with-pytorch-cuda-enabled:
     name: "GPU tests requiring torch CUDA"
-    needs: [build-torch-with-cuda, build-torch-xla, build-cuda-plugin, check_code_changes, get-torch-commit]
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Run GPU tests requiring torch CUDA
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
-        uses: ./.github/workflows/_test_requiring_torch_cuda.yml
-        with:
-          dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
-          runner: linux.8xlarge.nvidia.gpu
-          timeout-minutes: 300
-          collect-coverage: false
-          torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
-      - name: Report no code changes
-        if: needs.check_code_changes.outputs.has_code_changes == 'false'
-        run: |
-          echo "No code changes were detected that require running the full test suite."
+    uses: ./.github/workflows/_test_requiring_torch_cuda.yml
+    needs: [build-torch-with-cuda, build-torch-xla, build-cuda-plugin, get-torch-commit]
+    with:
+      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
+      runner: linux.8xlarge.nvidia.gpu
+      timeout-minutes: 300
+      collect-coverage: false
+      torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
 
   test-tpu:
     name: "TPU tests"
-    needs: [build-torch-xla, check_code_changes]
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Run TPU tests
-        if: >
-            (github.event_name == 'push' || github.event_name == 'pull_request') &&
-            needs.check_code_changes.outputs.has_code_changes == 'true'
-        uses: ./.github/workflows/_tpu_ci.yml
-        with:
-          timeout-minutes: 300
-      - name: Report no code changes
-        if: >
-          !((github.event_name == 'push' || github.event_name == 'pull_request') &&
-            needs.check_code_changes.outputs.has_code_changes == 'true')
-        run: |
-          echo "No code changes were detected that require running the full test suite."
+    uses: ./.github/workflows/_tpu_ci.yml
+    needs: build-torch-xla
+    with:
+      timeout-minutes: 300
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
 
   push-docs:
     name: "Build docs"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,31 +15,47 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check_code_changes:
+    name: Check Code Changes
+    uses: ./.github/workflows/_check_code_changes.yml
+    with:
+      event_name: ${{ github.event_name }}
+      # For pull_request, use PR's base and head. For push, use event's before and sha.
+      base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+      head_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
   get-torch-commit:
+    needs: [check_code_changes]
     runs-on: ubuntu-24.04
     outputs:
       torch_commit: ${{ steps.commit.outputs.torch_commit }}
     steps:
       - name: Get latest torch commit
         id: commit
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         run: |
           echo "torch_commit=$(git ls-remote https://github.com/pytorch/pytorch.git HEAD | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+      - name: Report no code changes
+        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        run: |
+          echo "No code changes were detected that require running the full test suite."
 
   build-torch-xla:
     name: "Build PyTorch/XLA"
     uses: ./.github/workflows/_build_torch_xla.yml
-    needs: get-torch-commit
+    needs: [check_code_changes, get-torch-commit]
     with:
       dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
       torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
       timeout-minutes: 240
+      has_code_changes: ${{ needs.check_code_changes.outputs.has_code_changes }}
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
 
   build-torch-with-cuda:
     name: "Build PyTorch with CUDA"
     uses: ./.github/workflows/_build_torch_with_cuda.yml
-    needs: get-torch-commit
+    needs: [check_code_changes, get-torch-commit]
     with:
       # TODO: bump CUDA version to either 12.4 or 12.6 (supported by PyTorch).
       # Ref: https://github.com/pytorch/xla/issues/8700
@@ -48,31 +64,35 @@ jobs:
       # note that to build a torch wheel with CUDA enabled, we do not need a GPU runner.
       runner: linux.24xlarge
       timeout-minutes: 120
+      has_code_changes: ${{ needs.check_code_changes.outputs.has_code_changes }}
 
   build-cuda-plugin:
     name: "Build XLA CUDA plugin"
     uses: ./.github/workflows/_build_plugin.yml
+    needs: [check_code_changes]
     with:
       dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
+      has_code_changes: ${{ needs.check_code_changes.outputs.has_code_changes }}
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
 
   test-python-cpu:
     name: "CPU tests"
     uses: ./.github/workflows/_test.yml
-    needs: [build-torch-xla, get-torch-commit]
+    needs: [build-torch-xla, check_code_changes, get-torch-commit]
     with:
       dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
       timeout-minutes: 120
       collect-coverage: false
       torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
+      has_code_changes: ${{ needs.check_code_changes.outputs.has_code_changes }}
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
 
   test-cuda:
     name: "GPU tests"
     uses: ./.github/workflows/_test.yml
-    needs: [build-torch-xla, build-cuda-plugin, get-torch-commit]
+    needs: [build-torch-xla, build-cuda-plugin, check_code_changes, get-torch-commit]
     with:
       dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
       runner: linux.g4dn.12xlarge.nvidia.gpu
@@ -80,26 +100,29 @@ jobs:
       collect-coverage: false
       install-cuda-plugin: true
       torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
+      has_code_changes: ${{ needs.check_code_changes.outputs.has_code_changes }}
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
 
   test-cuda-with-pytorch-cuda-enabled:
     name: "GPU tests requiring torch CUDA"
     uses: ./.github/workflows/_test_requiring_torch_cuda.yml
-    needs: [build-torch-with-cuda, build-torch-xla, build-cuda-plugin, get-torch-commit]
+    needs: [build-torch-with-cuda, build-torch-xla, build-cuda-plugin, check_code_changes, get-torch-commit]
     with:
       dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
       runner: linux.8xlarge.nvidia.gpu
       timeout-minutes: 300
       collect-coverage: false
       torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
+      has_code_changes: ${{ needs.check_code_changes.outputs.has_code_changes }}
 
   test-tpu:
     name: "TPU tests"
     uses: ./.github/workflows/_tpu_ci.yml
-    needs: build-torch-xla
+    needs: [build-torch-xla, check_code_changes]
     with:
       timeout-minutes: 300
+      has_code_changes: ${{ needs.check_code_changes.outputs.has_code_changes }}
     if: github.event_name == 'push' || github.event_name == 'pull_request'
 
   push-docs:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -44,6 +44,8 @@ jobs:
     name: "Build PyTorch/XLA"
     needs: [check_code_changes, get-torch-commit]
     runs-on: ubuntu-24.04
+    secrets:
+      gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
     steps:
       - name: Build PyTorch/XLA
         if: needs.check_code_changes.outputs.has_code_changes == 'true'
@@ -52,8 +54,6 @@ jobs:
           dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
           torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
           timeout-minutes: 240
-        secrets:
-          gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
       - name: Report no code changes
         if: needs.check_code_changes.outputs.has_code_changes == 'false'
         run: |
@@ -81,14 +81,14 @@ jobs:
     name: "Build XLA CUDA plugin"
     needs: [check_code_changes]
     runs-on: ubuntu-24.04
+    secrets:
+      gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
     steps:
       - name: Build XLA CUDA plugin
         if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: ./.github/workflows/_build_plugin.yml
         with:
           dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
-        secrets:
-          gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
       - name: Report no code changes
         if: needs.check_code_changes.outputs.has_code_changes == 'false'
         run: |
@@ -98,6 +98,8 @@ jobs:
     name: "CPU tests"
     needs: [build-torch-xla, check_code_changes, get-torch-commit]
     runs-on: ubuntu-24.04
+    secrets:
+      gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
     steps:
       - name: Run CPU tests
         if: needs.check_code_changes.outputs.has_code_changes == 'true'
@@ -107,8 +109,6 @@ jobs:
           timeout-minutes: 120
           collect-coverage: false
           torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
-        secrets:
-          gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
       - name: Report no code changes
         if: needs.check_code_changes.outputs.has_code_changes == 'false'
         run: |
@@ -118,6 +118,8 @@ jobs:
     name: "GPU tests"
     needs: [build-torch-xla, build-cuda-plugin, check_code_changes, get-torch-commit]
     runs-on: ubuntu-24.04
+    secrets:
+      gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
     steps:
       - name: Run GPU tests
         if: needs.check_code_changes.outputs.has_code_changes == 'true'
@@ -129,8 +131,6 @@ jobs:
           collect-coverage: false
           install-cuda-plugin: true
           torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
-        secrets:
-          gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
       - name: Report no code changes
         if: needs.check_code_changes.outputs.has_code_changes == 'false'
         run: |
@@ -178,14 +178,14 @@ jobs:
     name: "Build docs"
     needs: [build-torch-xla, check_code_changes]
     runs-on: ubuntu-24.04
+    secrets:
+      torchxla-bot-token: ${{ secrets.TORCH_XLA_BOT_TOKEN }}
     steps:
       - name: Build and push docs
         if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: ./.github/workflows/_docs.yml
         with:
           dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
-        secrets:
-          torchxla-bot-token: ${{ secrets.TORCH_XLA_BOT_TOKEN }}
       - name: Report no code changes
         if: needs.check_code_changes.outputs.has_code_changes == 'false'
         run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -27,114 +27,166 @@ jobs:
   get-torch-commit:
     runs-on: ubuntu-24.04
     needs: [check_code_changes]
-    # Only run if code changes detected
-    if: needs.check_code_changes.outputs.has_code_changes == 'true'
     outputs:
       torch_commit: ${{ steps.commit.outputs.torch_commit }}
     steps:
-      - id: commit
-        name: Get latest torch commit
+      - name: Get latest torch commit
+        id: commit
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         run: |
           echo "torch_commit=$(git ls-remote https://github.com/pytorch/pytorch.git HEAD | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+      - name: Report no code changes
+        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        run: |
+          echo "No code changes were detected that require running the full test suite."
 
   build-torch-xla:
     name: "Build PyTorch/XLA"
     uses: ./.github/workflows/_build_torch_xla.yml
     needs: [check_code_changes, get-torch-commit]
-    # Only run if code changes detected
-    if: needs.check_code_changes.outputs.has_code_changes == 'true'
-    with:
-      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
-      torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
-      timeout-minutes: 240
-    secrets:
-      gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
+    steps:
+      - name: Build PyTorch/XLA
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        uses: ./.github/workflows/_build_torch_xla.yml
+        with:
+          dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
+          torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
+          timeout-minutes: 240
+        secrets:
+          gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
+      - name: Report no code changes
+        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        run: |
+          echo "No code changes were detected that require running the full test suite."
 
   build-torch-with-cuda:
     name: "Build PyTorch with CUDA"
-    uses: ./.github/workflows/_build_torch_with_cuda.yml
     needs: [check_code_changes, get-torch-commit]
-    # Only run if code changes detected
-    if: needs.check_code_changes.outputs.has_code_changes == 'true'
-    with:
-      # TODO: bump CUDA version to either 12.4 or 12.6 (supported by PyTorch).
-      # Ref: https://github.com/pytorch/xla/issues/8700
-      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
-      torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
-      # note that to build a torch wheel with CUDA enabled, we do not need a GPU runner.
-      runner: linux.24xlarge
-      timeout-minutes: 120
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Build PyTorch with CUDA
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        uses: ./.github/workflows/_build_torch_with_cuda.yml
+        with:
+          dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
+          torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
+          runner: linux.24xlarge
+          timeout-minutes: 120
+      - name: Report no code changes
+        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        run: |
+          echo "No code changes were detected that require running the full test suite."
 
   build-cuda-plugin:
     name: "Build XLA CUDA plugin"
-    uses: ./.github/workflows/_build_plugin.yml
     needs: [check_code_changes]
-    # Only run if code changes detected
-    if: needs.check_code_changes.outputs.has_code_changes == 'true'
-    with:
-      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
-    secrets:
-      gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Build XLA CUDA plugin
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        uses: ./.github/workflows/_build_plugin.yml
+        with:
+          dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
+        secrets:
+          gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
+      - name: Report no code changes
+        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        run: |
+          echo "No code changes were detected that require running the full test suite."
 
   test-python-cpu:
     name: "CPU tests"
-    uses: ./.github/workflows/_test.yml
     needs: [build-torch-xla, check_code_changes, get-torch-commit]
-    # Only run if code changes detected
-    if: needs.check_code_changes.outputs.has_code_changes == 'true'
-    with:
-      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
-      timeout-minutes: 120
-      collect-coverage: false
-      torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
-    secrets:
-      gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Run CPU tests
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        uses: ./.github/workflows/_test.yml
+        with:
+          dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
+          timeout-minutes: 120
+          collect-coverage: false
+          torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
+        secrets:
+          gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
+      - name: Report no code changes
+        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        run: |
+          echo "No code changes were detected that require running the full test suite."
 
   test-cuda:
     name: "GPU tests"
-    uses: ./.github/workflows/_test.yml
     needs: [build-torch-xla, build-cuda-plugin, check_code_changes, get-torch-commit]
-    # Only run if code changes detected
-    if: needs.check_code_changes.outputs.has_code_changes == 'true'
-    with:
-      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
-      runner: linux.g4dn.12xlarge.nvidia.gpu
-      timeout-minutes: 300
-      collect-coverage: false
-      install-cuda-plugin: true
-      torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
-    secrets:
-      gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Run GPU tests
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        uses: ./.github/workflows/_test.yml
+        with:
+          dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
+          runner: linux.g4dn.12xlarge.nvidia.gpu
+          timeout-minutes: 300
+          collect-coverage: false
+          install-cuda-plugin: true
+          torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
+        secrets:
+          gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}
+      - name: Report no code changes
+        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        run: |
+          echo "No code changes were detected that require running the full test suite."
 
   test-cuda-with-pytorch-cuda-enabled:
     name: "GPU tests requiring torch CUDA"
-    uses: ./.github/workflows/_test_requiring_torch_cuda.yml
     needs: [build-torch-with-cuda, build-torch-xla, build-cuda-plugin, check_code_changes, get-torch-commit]
-    # Only run if code changes detected
-    if: needs.check_code_changes.outputs.has_code_changes == 'true'
-    with:
-      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
-      runner: linux.8xlarge.nvidia.gpu
-      timeout-minutes: 300
-      collect-coverage: false
-      torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Run GPU tests requiring torch CUDA
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        uses: ./.github/workflows/_test_requiring_torch_cuda.yml
+        with:
+          dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_cuda_12.3
+          runner: linux.8xlarge.nvidia.gpu
+          timeout-minutes: 300
+          collect-coverage: false
+          torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
+      - name: Report no code changes
+        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        run: |
+          echo "No code changes were detected that require running the full test suite."
 
   test-tpu:
     name: "TPU tests"
-    uses: ./.github/workflows/_tpu_ci.yml
     needs: [build-torch-xla, check_code_changes]
-    # Only run if code changes detected
-    if: >
-      (github.event_name == 'push' || github.event_name == 'pull_request') &&
-      needs.check_code_changes.outputs.has_code_changes == 'true'
-    with:
-      timeout-minutes: 300
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Run TPU tests
+        if: >
+            (github.event_name == 'push' || github.event_name == 'pull_request') &&
+            needs.check_code_changes.outputs.has_code_changes == 'true'
+        uses: ./.github/workflows/_tpu_ci.yml
+        with:
+          timeout-minutes: 300
+      - name: Report no code changes
+        if: >
+          !((github.event_name == 'push' || github.event_name == 'pull_request') &&
+            needs.check_code_changes.outputs.has_code_changes == 'true')
+        run: |
+          echo "No code changes were detected that require running the full test suite."
 
   push-docs:
     name: "Build docs"
-    uses: ./.github/workflows/_docs.yml
-    needs: build-torch-xla
-    with:
-      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
-    secrets:
-      torchxla-bot-token: ${{ secrets.TORCH_XLA_BOT_TOKEN }}
+    needs: [build-torch-xla, check_code_changes]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Build and push docs
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
+        uses: ./.github/workflows/_docs.yml
+        with:
+          dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
+        secrets:
+          torchxla-bot-token: ${{ secrets.TORCH_XLA_BOT_TOKEN }}
+      - name: Report no code changes
+        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        run: |
+          echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,7 +42,6 @@ jobs:
 
   build-torch-xla:
     name: "Build PyTorch/XLA"
-    uses: ./.github/workflows/_build_torch_xla.yml
     needs: [check_code_changes, get-torch-commit]
     steps:
       - name: Build PyTorch/XLA

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -25,8 +25,8 @@ jobs:
       head_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
   get-torch-commit:
-    runs-on: ubuntu-24.04
     needs: [check_code_changes]
+    runs-on: ubuntu-24.04
     outputs:
       torch_commit: ${{ steps.commit.outputs.torch_commit }}
     steps:
@@ -43,6 +43,7 @@ jobs:
   build-torch-xla:
     name: "Build PyTorch/XLA"
     needs: [check_code_changes, get-torch-commit]
+    runs-on: ubuntu-24.04
     steps:
       - name: Build PyTorch/XLA
         if: needs.check_code_changes.outputs.has_code_changes == 'true'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,30 +15,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check_code_changes:
-    name: Check Code Changes
-    uses: ./.github/workflows/_check_code_changes.yml
-    with:
-      event_name: ${{ github.event_name }}
-      # For pull_request, use PR's base and head. For push, use event's before and sha.
-      base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-      head_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-
   get-torch-commit:
-    needs: [check_code_changes]
     runs-on: ubuntu-24.04
     outputs:
       torch_commit: ${{ steps.commit.outputs.torch_commit }}
     steps:
       - name: Get latest torch commit
         id: commit
-        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         run: |
           echo "torch_commit=$(git ls-remote https://github.com/pytorch/pytorch.git HEAD | awk '{print $1}')" >> "$GITHUB_OUTPUT"
-      - name: Report no code changes
-        if: needs.check_code_changes.outputs.has_code_changes == 'false'
-        run: |
-          echo "No code changes were detected that require running the full test suite."
 
   build-torch-xla:
     name: "Build PyTorch/XLA"

--- a/.github/workflows/lintercheck.yml
+++ b/.github/workflows/lintercheck.yml
@@ -8,8 +8,19 @@ on:
       - r[0-9]+.[0-9]+
 
 jobs:
+  check_code_changes:
+    name: Check Code Changes
+    uses: ./.github/workflows/_check_code_changes.yml
+    with:
+      event_name: ${{ github.event_name }}
+      # For pull_request, use PR's base and head. For push, use event's before and sha.
+      base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+      head_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
   linter_check:
     runs-on: ubuntu-24.04
+    needs: [check_code_changes]
+    # Only run if code changes detected
+    if: needs.check_code_changes.outputs.has_code_changes == 'true'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/lintercheck.yml
+++ b/.github/workflows/lintercheck.yml
@@ -19,12 +19,12 @@ jobs:
   linter_check:
     runs-on: ubuntu-24.04
     needs: [check_code_changes]
-    # Only run if code changes detected
-    if: needs.check_code_changes.outputs.has_code_changes == 'true'
     steps:
       - name: Checkout repo
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: actions/checkout@v3
       - name: Setup Python
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
@@ -32,7 +32,9 @@ jobs:
       - run: pip install yapf==0.40.2  # N.B.: keep in sync with `torchax/dev-requirements.txt`, `infra/ansible/config/pip.yaml`
 
       - name: Check no TORCH_PIN
-        if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
+        if: >
+          (github.event_name == 'push' && github.event.ref == 'refs/heads/master') &&
+          needs.check_code_changes.outputs.has_code_changes == 'true'
         shell: bash
         run: |
           TORCH_PIN=./.torch_pin
@@ -43,6 +45,7 @@ jobs:
             echo "No ${TORCH_PIN} found, safe to land..."
           fi
       - name: Run clang-format
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         shell: bash
         env:
           CLANG_FORMAT: clang-format-16
@@ -68,6 +71,7 @@ jobs:
             echo "PASSED C++ format"
           fi
       - name: Run yapf
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         shell: bash
         run: |
           git_status=$(git status --porcelain)
@@ -88,3 +92,7 @@ jobs:
           else
             echo "PASSED Python format"
           fi
+      - name: Report no code changes
+        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        run: |
+          echo "No code changes were detected that require running the full test suite."

--- a/.github/workflows/torchax.yml
+++ b/.github/workflows/torchax.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - master
       - r[0-9]+.[0-9]+
+    paths-ignore:
+      - '**.md' # Ignore any file ending with .md in any directory
   push:
     branches:
       - master

--- a/.github/workflows/torchax.yml
+++ b/.github/workflows/torchax.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - master
       - r[0-9]+.[0-9]+
-    paths-ignore:
-      - '**.md' # Ignore any file ending with .md in any directory
   push:
     branches:
       - master
@@ -17,8 +15,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check_code_changes:
+    name: Check Code Changes
+    uses: ./.github/workflows/_check_code_changes.yml
+    with:
+      event_name: ${{ github.event_name }}
+      # For pull_request, use PR's base and head. For push, use event's before and sha.
+      base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+      head_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
   torchax-cpu:
     runs-on: ubuntu-24.04
+    needs: [check_code_changes]
+    # Only run if code changes detected
+    if: needs.check_code_changes.outputs.has_code_changes == 'true'
     strategy:
       matrix:
         python-version: ['3.10']

--- a/.github/workflows/torchax.yml
+++ b/.github/workflows/torchax.yml
@@ -26,28 +26,30 @@ jobs:
   torchax-cpu:
     runs-on: ubuntu-24.04
     needs: [check_code_changes]
-    # Only run if code changes detected
-    if: needs.check_code_changes.outputs.has_code_changes == 'true'
     strategy:
       matrix:
         python-version: ['3.10']
     steps:
       - name: Checkout repo
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             torchax
       - name: Setup Python
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         shell: bash
         working-directory: torchax
         run: |
           pip install -r test-requirements.txt
           pip install -e .[cpu]
       - name: Run tests
+        if: needs.check_code_changes.outputs.has_code_changes == 'true'
         working-directory: torchax
         shell: bash
         run: |
@@ -70,3 +72,8 @@ jobs:
           pytest test/test_view.py
           pytest test/test_util.py
           XLA_FLAGS=--xla_force_host_platform_device_count=4 pytest -n 0 test_dist/
+          echo "Tests completed."
+      - name: Report no code changes
+        if: needs.check_code_changes.outputs.has_code_changes == 'false'
+        run: |
+          echo "No code changes were detected that require running the full test suite."


### PR DESCRIPTION
While getting #9065 reviewed, I noticed that we're running expensive (and long) CI even for no-op changes like removing trailing whitespaces from markdown files.

Note that this only skips CI when the entire PR only consists of markdown changes. Removing the CI for comments are more difficult. However, this is a step in the right direction to save some resources and enable merging PRs faster.

fixes #9073