### PR TITLE
Replace implementation of `xla_torch.sync()` to `xm.mark_step()`

### DIFF
--- a/test/debug_tool/test_mp_pt_xla_debug.py
+++ b/test/debug_tool/test_mp_pt_xla_debug.py
@@ -19,7 +19,7 @@ def _mp_fn(index):
   device = xm.xla_device()
   t1 = torch.randn(10, 10, device=device)
   t2 = t1 * 100
-  xm.mark_step()
+  torch_xla.sync()
   xm.wait_device_ops()
 
   if index == 0:
@@ -31,7 +31,7 @@ def _mp_fn(index):
       frames = extract_python_frames(lines)
     # only the local master process should dump the execution analysis
     assert (len(causes) == 1)
-    assert ('user mark_step' in causes[0])
+    assert ('user sync' in causes[0])
     assert (len(frames) == 3)
     max_frame = os.getenv('PT_XLA_DEBUG_MAX_FRAME', 8)
     # Additonal lines are

--- a/test/debug_tool/test_pt_xla_debug.py
+++ b/test/debug_tool/test_pt_xla_debug.py
@@ -177,10 +177,18 @@ class PtXLADebugTest(unittest.TestCase):
 
     if self.debug_level > 1:
       self.assertEqual(len(executation_causes), 2)
+      self.assertIn(
+          'torch_xla.compile clear the pending graph prior calling the target function',
+          executation_causes[0])
+      self.assertIn('torch_xla.compile\n', executation_causes[1])
     else:
       self.assertEqual(len(execution_causes), 0)
 
     self.assertEqual(len(compilation_causes), 2)
+    self.assertIn(
+        'torch_xla.compile clear the pending graph prior calling the target function',
+        compilation_causes[0])
+    self.assertIn('torch_xla.compile\n', compilation_causes[1])
 
     if self.debug_level > 1:
       # one graph info from compilation, one from execution, hash should match

--- a/test/debug_tool/test_pt_xla_debug.py
+++ b/test/debug_tool/test_pt_xla_debug.py
@@ -126,7 +126,7 @@ class PtXLADebugTest(unittest.TestCase):
 
     if self.debug_level > 1:
       self.assertEqual(len(execution_causes), 2)
-      self.assertIn('mark_step when dynamo processing input graphs',
+      self.assertIn('sync when dynamo processing input graphs',
                     execution_causes[0])
       self.assertIn('dynamo is executing a compiled program',
                     execution_causes[1])
@@ -266,7 +266,7 @@ class PtXLADebugTest(unittest.TestCase):
     if self.debug_level > 1:
       self.assertEqual(len(execution_causes), batch_size)
       for cause in execution_causes:
-        self.assertIn('mark_step in parallel loader at step end', cause)
+        self.assertIn('sync in parallel loader at step end', cause)
     else:
       self.assertEqual(len(execution_causes), 0)
 

--- a/test/debug_tool/test_pt_xla_debug.py
+++ b/test/debug_tool/test_pt_xla_debug.py
@@ -29,21 +29,21 @@ class PtXLADebugTest(unittest.TestCase):
       assert False, "This test should be run with PT_XLA_DEBUG_FILE"
     open(cls.debug_file_name, 'w').close()
 
-  def test_eager_mark_step(self):
+  def test_eager_sync(self):
     with torch_xla.experimental.eager_mode_context(True):
       device = xm.xla_device()
       t1 = torch.randn(5, 9, device=device)
-      xm.mark_step()
+      torch_xla.sync()
       with open(self.debug_file_name, 'rb') as f:
         lines = f.readlines()
       # We expect PT_XLA_BUDEG not to output anything under the eager mode
       self.assertEqual(len(lines), 0)
       open(self.debug_file_name, 'w').close()
 
-  def test_user_mark_step(self):
+  def test_user_sync(self):
     device = xm.xla_device()
     t1 = torch.randn(2, 2, device=device)
-    xm.mark_step()
+    torch_xla.sync()
     with open(self.debug_file_name, 'rb') as f:
       lines = f.readlines()
       execution_causes = extract_execution_cause(lines)
@@ -59,13 +59,13 @@ class PtXLADebugTest(unittest.TestCase):
     self.assertIn('GB', post_compilation_infos[0].program_size)
 
     if self.debug_level > 1:
-      self.assertEqual(len(execution_causes), 1)
-      self.assertIn('user mark_step', execution_causes[0])
+      self.assertEqual(len(executation_causes), 1)
+      self.assertIn('user sync', executation_causes[0])
     else:
       self.assertEqual(len(execution_causes), 0)
 
     self.assertEqual(len(compilation_causes), 1)
-    self.assertIn('user mark_step', compilation_causes[0])
+    self.assertIn('user sync', compilation_causes[0])
 
     if self.debug_level > 1:
       self.assertEqual(len(graph_infos), 2)
@@ -90,13 +90,12 @@ class PtXLADebugTest(unittest.TestCase):
 
     if self.debug_level > 1:
       self.assertEqual(len(causes), 1)
-      self.assertIn('mark_step when exiting a profiler StepTrace region',
-                    causes[0])
+      self.assertIn('sync when exiting a profiler StepTrace region', causes[0])
     else:
       self.assertEqual(len(causes), 0)
 
     self.assertEqual(len(compilation_causes), 1)
-    self.assertIn('mark_step when exiting a profiler StepTrace region',
+    self.assertIn('sync when exiting a profiler StepTrace region',
                   compilation_causes[0])
 
     if self.debug_level > 1:
@@ -126,16 +125,16 @@ class PtXLADebugTest(unittest.TestCase):
       graph_infos = extract_graph_infos(lines)
 
     if self.debug_level > 1:
-      self.assertEqual(len(execution_causes), 2)
+      self.assertEqual(len(executation_causes), 2)
       self.assertIn('mark_step when dynamo processing input graphs',
-                    execution_causes[0])
+                    executation_causes[0])
       self.assertIn('dynamo is executing a compiled program',
                     execution_causes[1])
     else:
       self.assertEqual(len(execution_causes), 0)
 
     self.assertEqual(len(compilation_causes), 2)
-    self.assertIn('mark_step when dynamo processing input graphs',
+    self.assertIn('sync when dynamo processing input graphs',
                   compilation_causes[0])
     self.assertIn('dynamo is compiling a FX graph to HLO',
                   compilation_causes[1])
@@ -265,16 +264,15 @@ class PtXLADebugTest(unittest.TestCase):
       graph_infos = extract_graph_infos(lines)
 
     if self.debug_level > 1:
-      self.assertEqual(len(execution_causes), batch_size)
-      for cause in execution_causes:
+      self.assertEqual(len(executation_causes), batch_size)
+      for cause in executation_causes:
         self.assertIn('mark_step in parallel loader at step end', cause)
     else:
       self.assertEqual(len(execution_causes), 0)
 
     # We should only compile once.
     self.assertEqual(len(compilation_causes), 1)
-    self.assertIn('mark_step in parallel loader at step end',
-                  compilation_causes[0])
+    self.assertIn('sync in parallel loader at step end', compilation_causes[0])
 
     if self.debug_level > 1:
       self.assertEqual(len(graph_infos), batch_size + 1)
@@ -317,7 +315,7 @@ class PtXLADebugTest(unittest.TestCase):
   def test_frame(self):
     device = xm.xla_device()
     t1 = torch.randn(6, 6, device=device)
-    xm.mark_step()
+    torch_xla.sync()
     with open(self.debug_file_name, 'rb') as f:
       lines = f.readlines()
       frames = extract_python_frames(lines)
@@ -336,8 +334,8 @@ class PtXLADebugTest(unittest.TestCase):
     # second frame will be empty from the post-compilation-analysis
     if self.debug_level > 1:
       self.assertEqual(len(frames[2].split('\n')), max_frame + 3)
-    # Check mark_step is the first frame
-    self.assertIn('mark_step', frames[0].split('\n')[1])
+    # Check sync is the first frame
+    self.assertIn('sync', frames[0].split('\n')[1])
 
     open(self.debug_file_name, 'w').close()
 

--- a/test/debug_tool/test_pt_xla_debug.py
+++ b/test/debug_tool/test_pt_xla_debug.py
@@ -176,19 +176,11 @@ class PtXLADebugTest(unittest.TestCase):
       graph_infos = extract_graph_infos(lines)
 
     if self.debug_level > 1:
-      self.assertEqual(len(execution_causes), 2)
-      self.assertIn(
-          'torch_xla.compile clear the pending graph prior calling the target function',
-          execution_causes[0])
-      self.assertIn('torch_xla.compile\n', execution_causes[1])
+      self.assertEqual(len(executation_causes), 2)
     else:
       self.assertEqual(len(execution_causes), 0)
 
     self.assertEqual(len(compilation_causes), 2)
-    self.assertIn(
-        'torch_xla.compile clear the pending graph prior calling the target function',
-        compilation_causes[0])
-    self.assertIn('torch_xla.compile\n', compilation_causes[1])
 
     if self.debug_level > 1:
       # one graph info from compilation, one from execution, hash should match

--- a/test/debug_tool/test_pt_xla_debug.py
+++ b/test/debug_tool/test_pt_xla_debug.py
@@ -59,8 +59,8 @@ class PtXLADebugTest(unittest.TestCase):
     self.assertIn('GB', post_compilation_infos[0].program_size)
 
     if self.debug_level > 1:
-      self.assertEqual(len(executation_causes), 1)
-      self.assertIn('user sync', executation_causes[0])
+      self.assertEqual(len(execution_causes), 1)
+      self.assertIn('user sync', execution_causes[0])
     else:
       self.assertEqual(len(execution_causes), 0)
 
@@ -125,9 +125,9 @@ class PtXLADebugTest(unittest.TestCase):
       graph_infos = extract_graph_infos(lines)
 
     if self.debug_level > 1:
-      self.assertEqual(len(executation_causes), 2)
+      self.assertEqual(len(execution_causes), 2)
       self.assertIn('mark_step when dynamo processing input graphs',
-                    executation_causes[0])
+                    execution_causes[0])
       self.assertIn('dynamo is executing a compiled program',
                     execution_causes[1])
     else:
@@ -175,11 +175,11 @@ class PtXLADebugTest(unittest.TestCase):
       graph_infos = extract_graph_infos(lines)
 
     if self.debug_level > 1:
-      self.assertEqual(len(executation_causes), 2)
+      self.assertEqual(len(execution_causes), 2)
       self.assertIn(
           'torch_xla.compile clear the pending graph prior calling the target function',
-          executation_causes[0])
-      self.assertIn('torch_xla.compile\n', executation_causes[1])
+          execution_causes[0])
+      self.assertIn('torch_xla.compile\n', execution_causes[1])
     else:
       self.assertEqual(len(execution_causes), 0)
 
@@ -264,8 +264,8 @@ class PtXLADebugTest(unittest.TestCase):
       graph_infos = extract_graph_infos(lines)
 
     if self.debug_level > 1:
-      self.assertEqual(len(executation_causes), batch_size)
-      for cause in executation_causes:
+      self.assertEqual(len(execution_causes), batch_size)
+      for cause in execution_causes:
         self.assertIn('mark_step in parallel loader at step end', cause)
     else:
       self.assertEqual(len(execution_causes), 0)

--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -763,7 +763,8 @@ class DynamoErrorMessageTest(parameterized.TestCase):
       res = dynamo_resnet18_cpu(input)
       # there should be 18 paramters + 1 input
       self.assertGreater(len(w), 15)
-      self.assertIn('Found tensor with shape torch.Size', str(w[0].message))
+      # TODO(gunhyun): revert back when mark_step deprecation is complete
+      self.assertIn('Found tensor with shape torch.Size', str(w[1].message))
     self.assertLessEqual(len(met.counter_names()), 1)
 
 

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -1053,9 +1053,9 @@ def _run_step_closures() -> DeviceContext:
   return devctx
 
 
-@deprecated("Use torch_xla.sync instead")
+# @deprecated("Use torch_xla.sync instead")
 def mark_step(wait: bool = False, reset_scope: bool = True):
-  torch_xla(wait, reset_scope)
+  torch_xla.sync(wait, reset_scope)
 
 
 # TODO(lsy323): When `tensors` is empty, the some intermediate tensors will also be

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -15,6 +15,8 @@ import torch.nn.functional as F
 import torch.optim as optim
 import torch_xla
 from torch_xla import runtime
+from torch_xla.experimental.deprecation import mark_deprecated
+from typing_extensions import deprecated
 import torch_xla.core.xla_env_vars as xenv
 import torch_xla.debug.metrics_saver as ms
 import torch_xla.utils.utils as xu
@@ -1051,23 +1053,9 @@ def _run_step_closures() -> DeviceContext:
   return devctx
 
 
+@deprecated("Use torch_xla.sync instead")
 def mark_step(wait: bool = False, reset_scope: bool = True):
-  if xu.getenv_as('XLA_EMIT_STEPLOG', bool, False):
-    print(
-        'torch_xla.core.xla_model::mark_step\n',
-        end='',
-        file=sys.stderr,
-        flush=True)
-  torch_xla._XLAC._xla_step_marker(
-      torch_xla._XLAC._xla_get_default_device(), [],
-      wait=xu.getenv_as('XLA_SYNC_WAIT', bool, wait),
-      reset_scope=reset_scope)
-  # Only emit metrics from the first local device index, to avoid emitting the
-  # same values from different threads.
-  if is_master_ordinal():
-    ms.save_metrics()
-  devctx = _run_step_closures()
-  torch_xla._XLAC._set_all_reduce_token(devctx.device, None)
+  torch_xla(wait, reset_scope)
 
 
 # TODO(lsy323): When `tensors` is empty, the some intermediate tensors will also be

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -1052,6 +1052,8 @@ def _run_step_closures() -> DeviceContext:
 
 
 def mark_step(wait: bool = False, reset_scope: bool = True):
+  # NOTE: `torch_xla.sync()` from `torch_xla.py` depends on the implementation
+  # of this function. Please keep the implementation of both functions in sync.
   if xu.getenv_as('XLA_EMIT_STEPLOG', bool, False):
     print(
         'torch_xla.core.xla_model::mark_step\n',

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -15,7 +15,6 @@ import torch.nn.functional as F
 import torch.optim as optim
 import torch_xla
 from torch_xla import runtime
-from torch_xla.experimental.deprecation import mark_deprecated
 from typing_extensions import deprecated
 import torch_xla.core.xla_env_vars as xenv
 import torch_xla.debug.metrics_saver as ms
@@ -1053,7 +1052,7 @@ def _run_step_closures() -> DeviceContext:
   return devctx
 
 
-# @deprecated("Use torch_xla.sync instead")
+@deprecated("Use torch_xla.sync instead")
 def mark_step(wait: bool = False, reset_scope: bool = True):
   torch_xla.sync(wait, reset_scope)
 

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -1052,8 +1052,6 @@ def _run_step_closures() -> DeviceContext:
 
 
 def mark_step(wait: bool = False, reset_scope: bool = True):
-  # NOTE: `torch_xla.sync()` from `torch_xla.py` depends on the implementation
-  # of this function. Please keep the implementation of both functions in sync.
   if xu.getenv_as('XLA_EMIT_STEPLOG', bool, False):
     print(
         'torch_xla.core.xla_model::mark_step\n',

--- a/torch_xla/csrc/debug_util.cpp
+++ b/torch_xla/csrc/debug_util.cpp
@@ -326,32 +326,41 @@ void DebugUtil::analyze_graph_execution_python_frame(
   } else if (frames[0].function == "mark_step" ||
              (frames[0].function == "sync" &&
               endsWith(frames[0].file, "torch_xla.py"))) {
-    bool called_by_mark_step =
-        frames[0].function == "sync" && frames[1].function == "mark_step";
-    // mark_step internally calls sync leading to one extra call stack, so shift
-    // the frame index by 1.
-    int i = called_by_mark_step ? 2 : 1;
-    if (frames[i].function == "next" &&
-        endsWith(frames[i].file, "parallel_loader.py")) {
-      ss << debug_output_prefix << "  sync in parallel loader at step end\n";
-    } else if (frames[i].function == "__exit__" &&
-               endsWith(frames[i].file, "profiler.py")) {
-      ss << debug_output_prefix
-         << "  sync when exiting a profiler StepTrace region\n";
-    } else if ((frames[i].function == "extract_compiled_graph_helper" ||
-                frames[i].function == "extract_internal") &&
-               endsWith(frames[i].file, "dynamo_bridge.py")) {
-      ss << debug_output_prefix
-         << "  sync when dynamo processing input graphs\n";
-    } else if (frames[i].function == "_compile" &&
-               endsWith(frames[i].file, "torch_xla.py")) {
-      ss << debug_output_prefix << "  torch_xla.compile\n";
-    } else if (frames[i].function == "_clear_pending_ops_before_compile" &&
-               endsWith(frames[i].file, "torch_xla.py")) {
-      ss << debug_output_prefix
-         << "  torch_xla.compile clear the pending graph prior calling the "
-            "target function\n";
-    } else {
+    // TODO: the deprecation warning of mark_step adds extra call stack,
+    // shifting the frames by a certain amount. To mitigate this, we look for
+    // the function from top of stack until we find one. Once mark_step is fully
+    // deprecated, we should revert this change back.
+    int idx = 1;
+    for (; idx < frames.size(); ++idx) {
+      if (frames[idx].function == "next" &&
+          endsWith(frames[idx].file, "parallel_loader.py")) {
+        ss << debug_output_prefix << "  sync in parallel loader at step end\n";
+        break;
+      } else if (frames[idx].function == "__exit__" &&
+                 endsWith(frames[idx].file, "profiler.py")) {
+        ss << debug_output_prefix
+           << "  sync when exiting a profiler StepTrace region\n";
+        break;
+      } else if ((frames[idx].function == "extract_compiled_graph_helper" ||
+                  frames[idx].function == "extract_internal") &&
+                 endsWith(frames[idx].file, "dynamo_bridge.py")) {
+        ss << debug_output_prefix
+           << "  sync when dynamo processing input graphs\n";
+        break;
+      } else if (frames[idx].function == "_compile" &&
+                 endsWith(frames[idx].file, "torch_xla.py")) {
+        ss << debug_output_prefix << "  torch_xla.compile\n";
+        break;
+      } else if (frames[idx].function == "_clear_pending_ops_before_compile" &&
+                 endsWith(frames[idx].file, "torch_xla.py")) {
+        ss << debug_output_prefix
+           << "  torch_xla.compile clear the pending graph prior calling the "
+              "target function\n";
+        break;
+      }
+    }
+    // function not found in frame
+    if (idx == frames.size()) {
       ss << debug_output_prefix << "  user sync\n";
     }
   } else if (frames[0].function == "extract_graph_helper" &&

--- a/torch_xla/torch_xla.py
+++ b/torch_xla/torch_xla.py
@@ -74,8 +74,8 @@ def sync(wait: bool = False, reset_scope: bool = True):
       reset_scope=reset_scope)
   # Only emit metrics from the first local device index, to avoid emitting the
   # same values from different threads.
-  if is_master_ordinal():
-    ms.save_metrics()
+  if xm.is_master_ordinal():
+    xm.ms.save_metrics()
   devctx = xm._run_step_closures()
   torch_xla._XLAC._set_all_reduce_token(devctx.device, None)
 

--- a/torch_xla/torch_xla.py
+++ b/torch_xla/torch_xla.py
@@ -66,7 +66,18 @@ def sync(wait: bool = False, reset_scope: bool = True):
     wait (bool): whether to block the current process until the execution finished.
     reset_scope (bool): whether to reset the torch::lazy::ScopeContext of the IR Nodes.
   """
-  xm.mark_step(wait, reset_scope)
+  if xu.getenv_as('XLA_EMIT_STEPLOG', bool, False):
+    print('torch_xla.torch_xla::sync\n', end='', file=sys.stderr, flush=True)
+  torch_xla._XLAC._xla_step_marker(
+      torch_xla._XLAC._xla_get_default_device(), [],
+      wait=xu.getenv_as('XLA_SYNC_WAIT', bool, wait),
+      reset_scope=reset_scope)
+  # Only emit metrics from the first local device index, to avoid emitting the
+  # same values from different threads.
+  if is_master_ordinal():
+    ms.save_metrics()
+  devctx = xm._run_step_closures()
+  torch_xla._XLAC._set_all_reduce_token(devctx.device, None)
 
 
 def step():

--- a/torch_xla/torch_xla.py
+++ b/torch_xla/torch_xla.py
@@ -66,20 +66,7 @@ def sync(wait: bool = False, reset_scope: bool = True):
     wait (bool): whether to block the current process until the execution finished.
     reset_scope (bool): whether to reset the torch::lazy::ScopeContext of the IR Nodes.
   """
-  # NOTE: the implementation below is an exact copy from `xm.mark_step()` from
-  # `torch_xla/core/xla_model.py` except the print statement content below.
-  if xu.getenv_as('XLA_EMIT_STEPLOG', bool, False):
-    print('torch_xla.torch_xla::sync\n', end='', file=sys.stderr, flush=True)
-  torch_xla._XLAC._xla_step_marker(
-      torch_xla._XLAC._xla_get_default_device(), [],
-      wait=xu.getenv_as('XLA_SYNC_WAIT', bool, wait),
-      reset_scope=reset_scope)
-  # Only emit metrics from the first local device index, to avoid emitting the
-  # same values from different threads.
-  if xm.is_master_ordinal():
-    xm.ms.save_metrics()
-  devctx = xm._run_step_closures()
-  torch_xla._XLAC._set_all_reduce_token(devctx.device, None)
+  xm.mark_step(wait, reset_scope)
 
 
 def step():

--- a/torch_xla/torch_xla.py
+++ b/torch_xla/torch_xla.py
@@ -66,6 +66,8 @@ def sync(wait: bool = False, reset_scope: bool = True):
     wait (bool): whether to block the current process until the execution finished.
     reset_scope (bool): whether to reset the torch::lazy::ScopeContext of the IR Nodes.
   """
+  # NOTE: the implementation below is an exact copy from `xm.mark_step()` from
+  # `torch_xla/core/xla_model.py` except the print statement content below.
   if xu.getenv_as('XLA_EMIT_STEPLOG', bool, False):
     print('torch_xla.torch_xla::sync\n', end='', file=sys.stderr, flush=True)
   torch_xla._XLAC._xla_step_marker(


### PR DESCRIPTION
PyTorch/XLA team recommends using `xla_torch.sync()` over `xm.mark_step()` for newer releases and expect the implementation to be the same, so `sync` simply calls `xm.mark_step()`.

#8862