### PR TITLE
Upgrade sccache to v0.10.0 in upstream docker image

### DIFF
--- a/.github/upstream/Dockerfile
+++ b/.github/upstream/Dockerfile
@@ -59,7 +59,7 @@ ENV RUSTUP_HOME /opt/rustup
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN . $CARGO_HOME/env && \
-    git clone --recursive https://github.com/pytorch/sccache.git && \
+    git clone --recursive https://github.com/mozilla/sccache.git -b v0.10.0 && \
     cd sccache && \
     cargo install --path . && \
     cd .. && \

--- a/.github/workflows/build_upstream_image.yml
+++ b/.github/workflows/build_upstream_image.yml
@@ -1,12 +1,6 @@
 name: Build upstream image
 on:
   push:
-    branches:
-      - master
-      - r[0-9]+.[0-9]+
-    paths-ignore:
-      - 'experimental/**'
-      - 'torchax/**'
   workflow_dispatch:
 jobs:
   build:
@@ -28,7 +22,7 @@ jobs:
       - name: Build Docker image
         shell: bash
         run: |
-          docker build -t "${ECR_DOCKER_IMAGE_BASE}:v1.3-lite" .github/upstream
+          docker build -t "${ECR_DOCKER_IMAGE_BASE}:v1.3-lite-test-new-sccache" .github/upstream
       - name: Stage image to ECR
         shell: bash
         run: |
@@ -38,4 +32,4 @@ jobs:
             # if image layers are not present in the repo.
             # Note: disable the following line while testing a new image, so we do not
             # push to the upstream.
-            docker push "${ECR_DOCKER_IMAGE_BASE}:v1.3-lite"
+            docker push "${ECR_DOCKER_IMAGE_BASE}:v1.3-lite-test-new-sccache"

--- a/.github/workflows/build_upstream_image.yml
+++ b/.github/workflows/build_upstream_image.yml
@@ -7,7 +7,6 @@ on:
     paths-ignore:
       - 'experimental/**'
       - 'torchax/**'
-  pull_request:
   workflow_dispatch:
 jobs:
   build:
@@ -29,7 +28,7 @@ jobs:
       - name: Build Docker image
         shell: bash
         run: |
-          docker build -t "${ECR_DOCKER_IMAGE_BASE}:v1.3-lite-test-new-sccache" .github/upstream
+          docker build -t "${ECR_DOCKER_IMAGE_BASE}:v1.3-lite" .github/upstream
       - name: Stage image to ECR
         shell: bash
         run: |
@@ -39,4 +38,4 @@ jobs:
             # if image layers are not present in the repo.
             # Note: disable the following line while testing a new image, so we do not
             # push to the upstream.
-            docker push "${ECR_DOCKER_IMAGE_BASE}:v1.3-lite-test-new-sccache"
+            docker push "${ECR_DOCKER_IMAGE_BASE}:v1.3-lite"

--- a/.github/workflows/build_upstream_image.yml
+++ b/.github/workflows/build_upstream_image.yml
@@ -1,6 +1,13 @@
 name: Build upstream image
 on:
   push:
+    branches:
+      - master
+      - r[0-9]+.[0-9]+
+    paths-ignore:
+      - 'experimental/**'
+      - 'torchax/**'
+  pull_request:
   workflow_dispatch:
 jobs:
   build:


### PR DESCRIPTION
pytorch/pytorch has started using the original sccache repo instead of our fork, so switch xla to do this too

The fork is really old, and (I think) had changes to enable sccache with nvcc but upstream sccache handles nvcc now.  nvcc is also not relevant for the pytorch xla build/test CI.  It is also having trouble writing to s3 so there are no cache hits, meaning the build in pytorch/pytorch CI takes >1 hr
