### PR TITLE
Fix typo `executation` -> `execution`

### DIFF
--- a/docs/source/learn/troubleshoot.md
+++ b/docs/source/learn/troubleshoot.md
@@ -147,7 +147,7 @@ region](https://github.com/pytorch/xla/blob/fe4af0080af07f78ca2b614dd91b71885a3b
 access(often due to logging) the value of a tensor before the
 `mark_step`.
 
-The executation caused by 1-4 are expected, and we want to avoid 5 by
+The execution caused by 1-4 are expected, and we want to avoid 5 by
 either reduce the frequency of accessing tensor values or manually add a
 `mark_step` before accessing.
 

--- a/test/debug_tool/test_mp_pt_xla_debug.py
+++ b/test/debug_tool/test_mp_pt_xla_debug.py
@@ -29,7 +29,7 @@ def _mp_fn(index):
       lines = f.readlines()
       causes = extract_execution_cause(lines)
       frames = extract_python_frames(lines)
-    # only the local master process should dump the executation analysis
+    # only the local master process should dump the execution analysis
     assert (len(causes) == 1)
     assert ('user mark_step' in causes[0])
     assert (len(frames) == 3)

--- a/test/debug_tool/test_pt_xla_debug.py
+++ b/test/debug_tool/test_pt_xla_debug.py
@@ -46,7 +46,7 @@ class PtXLADebugTest(unittest.TestCase):
     xm.mark_step()
     with open(self.debug_file_name, 'rb') as f:
       lines = f.readlines()
-      executation_causes = extract_execution_cause(lines)
+      execution_causes = extract_execution_cause(lines)
       compilation_causes = extract_compilation_cause(lines)
       graph_infos = extract_graph_infos(lines)
       post_compilation_infos = extract_post_compilation_analysis(lines)
@@ -59,10 +59,10 @@ class PtXLADebugTest(unittest.TestCase):
     self.assertIn('GB', post_compilation_infos[0].program_size)
 
     if self.debug_level > 1:
-      self.assertEqual(len(executation_causes), 1)
-      self.assertIn('user mark_step', executation_causes[0])
+      self.assertEqual(len(execution_causes), 1)
+      self.assertIn('user mark_step', execution_causes[0])
     else:
-      self.assertEqual(len(executation_causes), 0)
+      self.assertEqual(len(execution_causes), 0)
 
     self.assertEqual(len(compilation_causes), 1)
     self.assertIn('user mark_step', compilation_causes[0])
@@ -121,18 +121,18 @@ class PtXLADebugTest(unittest.TestCase):
     res = compiled(t1)
     with open(self.debug_file_name, 'rb') as f:
       lines = f.readlines()
-      executation_causes = extract_execution_cause(lines)
+      execution_causes = extract_execution_cause(lines)
       compilation_causes = extract_compilation_cause(lines)
       graph_infos = extract_graph_infos(lines)
 
     if self.debug_level > 1:
-      self.assertEqual(len(executation_causes), 2)
+      self.assertEqual(len(execution_causes), 2)
       self.assertIn('mark_step when dynamo processing input graphs',
-                    executation_causes[0])
+                    execution_causes[0])
       self.assertIn('dynamo is executing a compiled program',
-                    executation_causes[1])
+                    execution_causes[1])
     else:
-      self.assertEqual(len(executation_causes), 0)
+      self.assertEqual(len(execution_causes), 0)
 
     self.assertEqual(len(compilation_causes), 2)
     self.assertIn('mark_step when dynamo processing input graphs',
@@ -171,18 +171,18 @@ class PtXLADebugTest(unittest.TestCase):
     res = compiled(t1)
     with open(self.debug_file_name, 'rb') as f:
       lines = f.readlines()
-      executation_causes = extract_execution_cause(lines)
+      execution_causes = extract_execution_cause(lines)
       compilation_causes = extract_compilation_cause(lines)
       graph_infos = extract_graph_infos(lines)
 
     if self.debug_level > 1:
-      self.assertEqual(len(executation_causes), 2)
+      self.assertEqual(len(execution_causes), 2)
       self.assertIn(
           'torch_xla.compile clear the pending graph prior calling the target function',
-          executation_causes[0])
-      self.assertIn('torch_xla.compile\n', executation_causes[1])
+          execution_causes[0])
+      self.assertIn('torch_xla.compile\n', execution_causes[1])
     else:
-      self.assertEqual(len(executation_causes), 0)
+      self.assertEqual(len(execution_causes), 0)
 
     self.assertEqual(len(compilation_causes), 2)
     self.assertIn(
@@ -219,7 +219,7 @@ class PtXLADebugTest(unittest.TestCase):
     res = compiled(t1)
     with open(self.debug_file_name, 'rb') as f:
       lines = f.readlines()
-      executation_causes = extract_execution_cause(lines)
+      execution_causes = extract_execution_cause(lines)
       compilation_causes = extract_compilation_cause(lines)
       graph_infos = extract_graph_infos(lines)
 
@@ -260,16 +260,16 @@ class PtXLADebugTest(unittest.TestCase):
 
     with open(self.debug_file_name, 'rb') as f:
       lines = f.readlines()
-      executation_causes = extract_execution_cause(lines)
+      execution_causes = extract_execution_cause(lines)
       compilation_causes = extract_compilation_cause(lines)
       graph_infos = extract_graph_infos(lines)
 
     if self.debug_level > 1:
-      self.assertEqual(len(executation_causes), batch_size)
-      for cause in executation_causes:
+      self.assertEqual(len(execution_causes), batch_size)
+      for cause in execution_causes:
         self.assertIn('mark_step in parallel loader at step end', cause)
     else:
-      self.assertEqual(len(executation_causes), 0)
+      self.assertEqual(len(execution_causes), 0)
 
     # We should only compile once.
     self.assertEqual(len(compilation_causes), 1)
@@ -292,18 +292,18 @@ class PtXLADebugTest(unittest.TestCase):
     print(t1)
     with open(self.debug_file_name, 'rb') as f:
       lines = f.readlines()
-      executation_causes = extract_execution_cause(lines)
+      execution_causes = extract_execution_cause(lines)
       compilation_causes = extract_compilation_cause(lines)
       graph_infos = extract_graph_infos(lines)
 
     if self.debug_level > 1:
-      self.assertEqual(len(executation_causes), 1)
+      self.assertEqual(len(execution_causes), 1)
       self.assertIn('user code trying to access tensor value',
-                    executation_causes[0])
+                    execution_causes[0])
       # one graph info from compilation, one from execution, hash should match
       self.assertEqual(graph_infos[0].hash, graph_infos[1].hash)
     else:
-      self.assertEqual(len(executation_causes), 0)
+      self.assertEqual(len(execution_causes), 0)
 
     self.assertEqual(len(compilation_causes), 1)
     self.assertIn('user code trying to access tensor value',

--- a/test/dynamo/test_dynamo.py
+++ b/test/dynamo/test_dynamo.py
@@ -472,7 +472,7 @@ class DynamoCpuFallbackTest(parameterized.TestCase):
     xla_dynamo_res_3 = dynamo_fn(t_xla * 3)
     cpu_res_3 = fn_fallback(t * 3)
     self.assertTrue(torch.allclose(cpu_res_3, xla_dynamo_res_3.cpu()))
-    # Compilation and executation are caused by `t * 3`
+    # Compilation and execution are caused by `t * 3`
     self.assertEqual(met.metric_data('CompileTime')[0], 1)
     self.assertEqual(met.metric_data('ExecuteTime')[0], 1)
 
@@ -503,7 +503,7 @@ class DynamoCpuFallbackTest(parameterized.TestCase):
     met.clear_all()
     xla_dynamo_res_2 = dynamo_fn(t_xla)
     self.assertTrue(torch.allclose(cpu_res, xla_dynamo_res_2.cpu()))
-    # We don't expect any new compilations. There will be 2 new executations
+    # We don't expect any new compilations. There will be 2 new executions
     # since there is a fallback in the middle.
     self.assertEqual(met.metric_data('CompileTime'), None)
     self.assertEqual(met.metric_data('ExecuteTime')[0], 2)

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1833,7 +1833,7 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
     self.assertEqual(met.metric_data("TransferToDeviceTime")[0], 4)
 
   @skipOnEagerDebug
-  def test_print_executation(self):
+  def test_print_execution(self):
     xla_device = xm.xla_device()
     xm.mark_step()
     xm.wait_device_ops()

--- a/torch_xla/csrc/debug_util.cpp
+++ b/torch_xla/csrc/debug_util.cpp
@@ -267,7 +267,7 @@ void DebugUtil::analyze_graph_execution_python_frame(
   static const int64_t max_frame_count =
       runtime::sys_util::GetEnvInt("PT_XLA_DEBUG_MAX_FRAME", 8);
 
-  constexpr std::string_view executation_output_prefix = "Execution Analysis: ";
+  constexpr std::string_view execution_output_prefix = "Execution Analysis: ";
   constexpr std::string_view compilation_output_prefix =
       "Compilation Analysis: ";
   constexpr std::string_view unexpected_execution_prefix =
@@ -299,7 +299,7 @@ void DebugUtil::analyze_graph_execution_python_frame(
       unexpected_execution ? unexpected_execution_prefix
       : (source == GraphAnalysisSource::Compilation)
           ? compilation_output_prefix
-          : executation_output_prefix;
+          : execution_output_prefix;
   // TODO: Make this configurable.
   std::vector<torch::lazy::SourceLocation> frames =
       torch::lazy::GetPythonFrames();
@@ -319,7 +319,7 @@ void DebugUtil::analyze_graph_execution_python_frame(
      << ((source == GraphAnalysisSource::Compilation) ? "Compilation Cause\n"
                                                       : "Execution Cause\n");
   if (source == GraphAnalysisSource::DynamoExecution) {
-    // when executation is from dynamo compiled graph, the python stack will not
+    // when execution is from dynamo compiled graph, the python stack will not
     // show any dynamo related python file since frame is already replaced. We
     // can either analyze the C++ call stack or rely on caller to pass a boolean
     // variable.

--- a/torch_xla/csrc/debug_util.cpp
+++ b/torch_xla/csrc/debug_util.cpp
@@ -297,9 +297,8 @@ void DebugUtil::analyze_graph_execution_python_frame(
 
   std::string_view debug_output_prefix =
       unexpected_execution ? unexpected_execution_prefix
-      : (source == GraphAnalysisSource::Compilation)
-          ? compilation_output_prefix
-          : execution_output_prefix;
+      : (source == GraphAnalysisSource::Compilation) ? compilation_output_prefix
+                                                     : execution_output_prefix;
   // TODO: Make this configurable.
   std::vector<torch::lazy::SourceLocation> frames =
       torch::lazy::GetPythonFrames();

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -81,12 +81,12 @@ XLATensorPtr XLATensor::Create(
 XLATensorPtr XLATensor::Create(
     torch::lazy::Value ir_value, const torch::lazy::BackendDevice& device,
     std::optional<at::ScalarType> logical_element_type,
-    bool delay_eager_executation) {
+    bool delay_eager_execution) {
   XLATensorPtr xtensor = c10::make_intrusive<XLATensor>(
       XLATensor(std::move(ir_value), device, logical_element_type));
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   graph_executor->RegisterTensor(xtensor->data());
-  if (graph_executor->UseEagerMode() && !delay_eager_executation) {
+  if (graph_executor->UseEagerMode() && !delay_eager_execution) {
     std::vector<XLATensorPtr> xtensors({xtensor});
     graph_executor->ApplyEagerSync(xtensors);
   }
@@ -329,7 +329,7 @@ void XLATensor::SetXlaData(torch::lazy::BackendDataPtr handle, bool sync) {
 }
 
 void XLATensor::SetIrValue(torch::lazy::Value ir_value, bool inplace,
-                           bool delay_eager_executation) {
+                           bool delay_eager_execution) {
   data()->handle = nullptr;
   data()->tensor_data = std::nullopt;
   if (data()->view != nullptr && inplace) {
@@ -348,7 +348,7 @@ void XLATensor::SetIrValue(torch::lazy::Value ir_value, bool inplace,
 
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   // Update should also be triggered eagerly if configured
-  if (graph_executor->UseEagerMode() && !delay_eager_executation &&
+  if (graph_executor->UseEagerMode() && !delay_eager_execution &&
       ShouldSyncIrNode()) {
     std::vector<XLATensorPtr> xtensors({c10::make_intrusive<XLATensor>(*this)});
     graph_executor->ApplyEagerSync(xtensors);
@@ -356,13 +356,13 @@ void XLATensor::SetIrValue(torch::lazy::Value ir_value, bool inplace,
 }
 
 void XLATensor::SetInPlaceIrValue(torch::lazy::Value ir_value,
-                                  bool delay_eager_executation) {
+                                  bool delay_eager_execution) {
   auto xla_shape = shape();
   if (xla_shape.get().element_type() != GetXlaShape(ir_value).element_type()) {
     ir_value =
         torch_xla::MakeNode<Cast>(ir_value, xla_shape.get().element_type());
   }
-  SetIrValue(std::move(ir_value), /*inplace=*/true, delay_eager_executation);
+  SetIrValue(std::move(ir_value), /*inplace=*/true, delay_eager_execution);
 }
 
 void XLATensor::AssignIrValue(torch::lazy::Value ir_value) const {
@@ -637,31 +637,31 @@ torch::lazy::Value XLATensor::MaybeCastIrValue(
 }
 
 XLATensorPtr XLATensor::CreateFrom(torch::lazy::Value ir_value,
-                                   bool delay_eager_executation) const {
+                                   bool delay_eager_execution) const {
   ir_value = MaybeCastIrValue(std::move(ir_value), GetDevice(),
                               /*logical_element_type=*/std::nullopt);
   return Create(std::move(ir_value), GetDevice(), dtype_optional(),
-                delay_eager_executation);
+                delay_eager_execution);
 }
 
 XLATensorPtr XLATensor::CreateFrom(
     torch::lazy::Value ir_value,
     std::optional<at::ScalarType> logical_element_type_opt,
-    bool delay_eager_executation) const {
+    bool delay_eager_execution) const {
   ir_value = MaybeCastIrValue(std::move(ir_value), GetDevice(),
                               logical_element_type_opt);
   return Create(std::move(ir_value), GetDevice(), logical_element_type_opt,
-                delay_eager_executation);
+                delay_eager_execution);
 }
 
 XLATensorPtr XLATensor::CreateFrom(torch::lazy::Value ir_value,
                                    const torch::lazy::BackendDevice& device,
                                    at::ScalarType logical_element_type,
-                                   bool delay_eager_executation) const {
+                                   bool delay_eager_execution) const {
   ir_value =
       MaybeCastIrValue(std::move(ir_value), device, logical_element_type);
   return Create(std::move(ir_value), device, logical_element_type,
-                delay_eager_executation);
+                delay_eager_execution);
 }
 
 void XLATensor::ApplyPendingGraph() {

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -157,22 +157,22 @@ class XLATensor : public torch::lazy::LazyTensor {
   static XLATensorPtr Create(
       torch::lazy::Value ir_value, const torch::lazy::BackendDevice& device,
       std::optional<at::ScalarType> logical_element_type = std::nullopt,
-      bool delay_eager_executation = false);
+      bool delay_eager_execution = false);
   static XLATensorPtr Create(std::shared_ptr<Data> data);
 
   // Create a new XLA tensor with the same metadata of the input tensor (with
   // possible overrides), and the new IR value.
   XLATensorPtr CreateFrom(torch::lazy::Value ir_value,
-                          bool delay_eager_executation = false) const;
+                          bool delay_eager_execution = false) const;
   XLATensorPtr CreateFrom(
       torch::lazy::Value ir_value,
       std::optional<at::ScalarType> logical_element_type_opt,
-      bool delay_eager_executation = false) const;
+      bool delay_eager_execution = false) const;
   // TODO: We should remove this one once MaybeCastIrValue is no longer needed.
   XLATensorPtr CreateFrom(torch::lazy::Value ir_value,
                           const torch::lazy::BackendDevice& device,
                           at::ScalarType logical_element_type,
-                          bool delay_eager_executation = false) const;
+                          bool delay_eager_execution = false) const;
 
   // The default ctor previously created a null LazyTensor (one with no 'data'
   // obj). Creating a null XLATensor is no longer possible, since the same can
@@ -232,9 +232,9 @@ class XLATensor : public torch::lazy::LazyTensor {
   // TODO(alanwaketan): Reuse the upstream ones once Functionalization is done.
   torch::lazy::Value GetIrValue() const;
   void SetIrValue(torch::lazy::Value ir_value, bool inplace = true,
-                  bool delay_eager_executation = false);
+                  bool delay_eager_execution = false);
   void SetInPlaceIrValue(torch::lazy::Value ir_value,
-                         bool delay_eager_executation = false);
+                         bool delay_eager_execution = false);
 
   // TODO(alanwaketan): Reuse the upstream one once Functionalization is done.
   std::optional<at::Tensor> CurrentTensorData() const;

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -376,7 +376,7 @@ void all_reduce(const std::vector<XLATensorPtr>& inputs,
     // In eager mode we don't want to execute the IR for each tensor because
     // that will execute the `all_reduce` x times.
     inputs[i]->SetInPlaceIrValue(torch::lazy::Value(node, i),
-                                 /*delay_eager_executation=*/true);
+                                 /*delay_eager_execution=*/true);
   }
 
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
@@ -596,7 +596,7 @@ std::vector<XLATensorPtr> custom_call(
   for (size_t i = 0; i < output_shapes.size(); ++i) {
     outputs.push_back(inputs[0]->CreateFrom(torch::lazy::Value(node, i),
                                             output_dtypes[i],
-                                            /*delay_eager_executation=*/true));
+                                            /*delay_eager_execution=*/true));
   }
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
@@ -661,7 +661,7 @@ std::vector<XLATensorPtr> gpu_custom_call(
   for (size_t i = 0; i < output_shapes.size(); ++i) {
     outputs.push_back(inputs[0]->CreateFrom(torch::lazy::Value(node, i),
                                             output_dtypes[i],
-                                            /*delay_eager_executation=*/true));
+                                            /*delay_eager_execution=*/true));
   }
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
@@ -700,7 +700,7 @@ std::vector<XLATensorPtr> tpu_custom_call(
   for (size_t i = 0; i < output_shapes.size(); ++i) {
     outputs.push_back(inputs[0]->CreateFrom(torch::lazy::Value(node, i),
                                             output_dtypes[i],
-                                            /*delay_eager_executation=*/true));
+                                            /*delay_eager_execution=*/true));
   }
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
@@ -758,11 +758,11 @@ void sgd_optimizer_step_(const XLATensorPtr& found_inf, XLATensorPtr& step,
       /*use_weight_decay=*/weight_decay != 0,
       /*use_momentum=*/momentum != 0, /*use_nesterov=*/nesterov);
   step->SetInPlaceIrValue(torch::lazy::Value(node, 0),
-                          /*delay_eager_executation=*/true);
+                          /*delay_eager_execution=*/true);
   param->SetInPlaceIrValue(torch::lazy::Value(node, 1),
-                           /*delay_eager_executation=*/true);
+                           /*delay_eager_execution=*/true);
   buf->SetInPlaceIrValue(torch::lazy::Value(node, 2),
-                         /*delay_eager_executation=*/true);
+                         /*delay_eager_execution=*/true);
 
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
@@ -800,16 +800,16 @@ void adam_optimizer_step_(const XLATensorPtr& found_inf, XLATensorPtr& step,
       /*use_weight_decay=*/weight_decay != 0,
       /*use_amsgrad=*/amsgrad, /*use_adamw=*/use_adamw);
   step->SetInPlaceIrValue(torch::lazy::Value(node, 0),
-                          /*delay_eager_executation=*/true);
+                          /*delay_eager_execution=*/true);
   param->SetInPlaceIrValue(torch::lazy::Value(node, 1),
-                           /*delay_eager_executation=*/true);
+                           /*delay_eager_execution=*/true);
   exp_avg->SetInPlaceIrValue(torch::lazy::Value(node, 2),
-                             /*delay_eager_executation=*/true);
+                             /*delay_eager_execution=*/true);
   exp_avg_sq->SetInPlaceIrValue(torch::lazy::Value(node, 3),
-                                /*delay_eager_executation=*/true);
+                                /*delay_eager_execution=*/true);
   if (amsgrad) {
     max_exp_avg_sq->SetInPlaceIrValue(torch::lazy::Value(node, 4),
-                                      /*delay_eager_executation=*/true);
+                                      /*delay_eager_execution=*/true);
   }
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
@@ -887,10 +887,10 @@ std::tuple<XLATensorPtr, XLATensorPtr> adaptive_max_pool2d(
   torch::lazy::NodePtr node =
       torch_xla::MakeNode<AdaptiveMaxPool2d>(input->GetIrValue(), output_size);
   XLATensorPtr out = input->CreateFrom(torch::lazy::Value(node, 0),
-                                       /*delay_eager_executation=*/true);
+                                       /*delay_eager_execution=*/true);
   XLATensorPtr indices =
       input->CreateFrom(torch::lazy::Value(node, 1), at::ScalarType::Long,
-                        /*delay_eager_executation=*/true);
+                        /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the `adaptive_max_pool2d` and in one hlo
@@ -931,10 +931,10 @@ void _amp_foreach_non_finite_check_and_unscale_(std::vector<XLATensorPtr> self,
           inputs, found_inf->GetIrValue(), new_inv_scale->GetIrValue());
   for (size_t i = 0; i < self.size(); ++i) {
     self[i]->SetInPlaceIrValue(torch::lazy::Value(node, i),
-                               /*delay_eager_executation=*/true);
+                               /*delay_eager_execution=*/true);
   }
   found_inf->SetInPlaceIrValue(torch::lazy::Value(node, self.size()),
-                               /*delay_eager_executation=*/true);
+                               /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the
@@ -955,9 +955,9 @@ void _amp_update_scale_(XLATensorPtr& current_scale,
       found_inf->GetIrValue(), scale_growth_factor, scale_backoff_factor,
       growth_interval);
   growth_tracker->SetInPlaceIrValue(torch::lazy::Value(node, 1),
-                                    /*delay_eager_executation=*/true);
+                                    /*delay_eager_execution=*/true);
   current_scale->SetInPlaceIrValue(torch::lazy::Value(node, 0),
-                                   /*delay_eager_executation=*/true);
+                                   /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the `_amp_update_scale_` and in one hlo
@@ -1293,11 +1293,11 @@ convolution_backward_overrideable(
           std::move(stride), std::move(padding), std::move(dilation),
           transposed, std::move(output_padding), groups);
   XLATensorPtr grad_input = out_backprop->CreateFrom(
-      torch::lazy::Value(node, 0), /*delay_eager_executation=*/true);
+      torch::lazy::Value(node, 0), /*delay_eager_execution=*/true);
   XLATensorPtr grad_weight = out_backprop->CreateFrom(
-      torch::lazy::Value(node, 1), /*delay_eager_executation=*/true);
+      torch::lazy::Value(node, 1), /*delay_eager_execution=*/true);
   XLATensorPtr grad_bias = out_backprop->CreateFrom(
-      torch::lazy::Value(node, 2), /*delay_eager_executation=*/true);
+      torch::lazy::Value(node, 2), /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the `convolution_backward_overrideable` and
@@ -1342,10 +1342,10 @@ std::tuple<XLATensorPtr, XLATensorPtr> cummax(const XLATensorPtr& input,
   torch::lazy::NodePtr node =
       torch_xla::MakeNode<CumMax>(input->GetIrValue(), canonical_dim);
   XLATensorPtr t_value = input->CreateFrom(torch::lazy::Value(node, 0),
-                                           /*delay_eager_executation=*/true);
+                                           /*delay_eager_execution=*/true);
   XLATensorPtr t_index =
       input->CreateFrom(torch::lazy::Value(node, 1), at::ScalarType::Long,
-                        /*delay_eager_executation=*/true);
+                        /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the `kthvalue` and in one hlo
@@ -1537,9 +1537,9 @@ std::tuple<XLATensorPtr, XLATensorPtr> einsum_backward(
 
   if (node->num_outputs() == 2) {
     XLATensorPtr t1 = grad_output->CreateFrom(torch::lazy::Value(node, 0),
-                                              /*delay_eager_executation=*/true);
+                                              /*delay_eager_execution=*/true);
     XLATensorPtr t2 = grad_output->CreateFrom(torch::lazy::Value(node, 1),
-                                              /*delay_eager_executation=*/true);
+                                              /*delay_eager_execution=*/true);
     XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
     if (graph_executor->UseEagerMode()) {
       // Execute the HLO that will run the `einsum_backward` and in one hlo
@@ -1593,13 +1593,13 @@ embedding_bag(const XLATensorPtr& weight, const XLATensorPtr& indices,
       per_sample_weights->GetIrValue(), include_last_offset);
 
   XLATensorPtr t1 = weight->CreateFrom(torch::lazy::Value(node, 0),
-                                       /*delay_eager_executation=*/true);
+                                       /*delay_eager_execution=*/true);
   XLATensorPtr t2 = weight->CreateFrom(torch::lazy::Value(node, 1),
-                                       /*delay_eager_executation=*/true);
+                                       /*delay_eager_execution=*/true);
   XLATensorPtr t3 = weight->CreateFrom(torch::lazy::Value(node, 2),
-                                       /*delay_eager_executation=*/true);
+                                       /*delay_eager_execution=*/true);
   XLATensorPtr t4 = weight->CreateFrom(torch::lazy::Value(node, 3),
-                                       /*delay_eager_executation=*/true);
+                                       /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the `embedding_bag` and in one hlo
@@ -1888,10 +1888,10 @@ std::tuple<XLATensorPtr, XLATensorPtr> kthvalue(const XLATensorPtr& input,
           dim, input->shape().get().dimensions_size()),
       keepdim);
   XLATensorPtr t1 = input->CreateFrom(torch::lazy::Value(node, 0),
-                                      /*delay_eager_executation=*/true);
+                                      /*delay_eager_execution=*/true);
   XLATensorPtr t2 =
       input->CreateFrom(torch::lazy::Value(node, 1), at::ScalarType::Long,
-                        /*delay_eager_executation=*/true);
+                        /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the `kthvalue` and in one hlo
@@ -2113,10 +2113,10 @@ std::tuple<XLATensorPtr, XLATensorPtr> max(const XLATensorPtr& input,
   torch::lazy::NodePtr node = torch_xla::MakeNode<MaxInDim>(
       input->GetIrValue(), canonical_dim, keepdim);
   XLATensorPtr t1 = input->CreateFrom(torch::lazy::Value(node, 0),
-                                      /*delay_eager_executation=*/true);
+                                      /*delay_eager_execution=*/true);
   XLATensorPtr t2 =
       input->CreateFrom(torch::lazy::Value(node, 1), at::ScalarType::Long,
-                        /*delay_eager_executation=*/true);
+                        /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the `max` and in one hlo
@@ -2133,9 +2133,9 @@ void max_out(XLATensorPtr& max, XLATensorPtr& max_values,
   torch::lazy::NodePtr node = torch_xla::MakeNode<MaxInDim>(
       input->GetIrValue(), canonical_dim, keepdim);
   max->SetIrValue(torch::lazy::Value(node, 0), /*inplace=*/true,
-                  /*delay_eager_executation=*/true);
+                  /*delay_eager_execution=*/true);
   max_values->SetIrValue(torch::lazy::Value(node, 1), /*inplace=*/true,
-                         /*delay_eager_executation=*/true);
+                         /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the `max_out` and in one hlo
@@ -2156,10 +2156,10 @@ std::tuple<XLATensorPtr, XLATensorPtr> max_pool_nd(
       std::move(stride), std::move(padding), ceil_mode);
 
   XLATensorPtr t1 = input->CreateFrom(torch::lazy::Value(node, 0),
-                                      /*delay_eager_executation=*/true);
+                                      /*delay_eager_execution=*/true);
   XLATensorPtr t2 =
       input->CreateFrom(torch::lazy::Value(node, 1), at::ScalarType::Long,
-                        /*delay_eager_executation=*/true);
+                        /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the `max_pool_nd` and in one hlo
@@ -2221,10 +2221,10 @@ std::tuple<XLATensorPtr, XLATensorPtr> min(const XLATensorPtr& input,
   torch::lazy::NodePtr node = torch_xla::MakeNode<MinInDim>(
       input->GetIrValue(), canonical_dim, keepdim);
   XLATensorPtr t1 = input->CreateFrom(torch::lazy::Value(node, 0),
-                                      /*delay_eager_executation=*/true);
+                                      /*delay_eager_execution=*/true);
   XLATensorPtr t2 =
       input->CreateFrom(torch::lazy::Value(node, 1), at::ScalarType::Long,
-                        /*delay_eager_executation=*/true);
+                        /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the `min` and in one hlo
@@ -2241,9 +2241,9 @@ void min_out(XLATensorPtr& min, XLATensorPtr& min_indices,
   torch::lazy::NodePtr node = torch_xla::MakeNode<MinInDim>(
       input->GetIrValue(), canonical_dim, keepdim);
   min->SetIrValue(torch::lazy::Value(node, 0), /*inplace=*/true,
-                  /*delay_eager_executation=*/true);
+                  /*delay_eager_execution=*/true);
   min_indices->SetIrValue(torch::lazy::Value(node, 1), /*inplace=*/true,
-                          /*delay_eager_executation=*/true);
+                          /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the `min_out` and in one hlo
@@ -2382,26 +2382,26 @@ std::tuple<XLATensorPtr, XLATensorPtr, XLATensorPtr> native_batch_norm(
       input->GetIrValue(), weight_value, bias_value, running_mean_value,
       running_var_value, training, eps);
   XLATensorPtr output = input->CreateFrom(torch::lazy::Value(node, 0),
-                                          /*delay_eager_executation=*/true);
+                                          /*delay_eager_execution=*/true);
   XLATensorPtr mean;
   XLATensorPtr variance_inverse;
   if (training) {
     mean = input->CreateFrom(torch::lazy::Value(node, 1),
-                             /*delay_eager_executation=*/true);
+                             /*delay_eager_execution=*/true);
     variance_inverse = input->CreateFrom(torch::lazy::Value(node, 3),
-                                         /*delay_eager_executation=*/true);
+                                         /*delay_eager_execution=*/true);
     if (running_mean) {
       running_mean->SetIrValue(
           torch_xla::MakeNode<LinearInterpolation>(
               mean->GetIrValue(), running_mean->GetIrValue(), momentum),
-          /*inplace=*/true, /*delay_eager_executation=*/true);
+          /*inplace=*/true, /*delay_eager_execution=*/true);
     }
     if (running_var) {
       running_var->SetIrValue(
           torch_xla::MakeNode<LinearInterpolation>(
               torch::lazy::Value(node, 2), running_var->GetIrValue(), momentum),
           /*inplace=*/true,
-          /*delay_eager_executation=*/true);
+          /*delay_eager_execution=*/true);
     }
   } else {
     at::Tensor at_input = bridge::AtenFromXlaTensor(input);
@@ -2440,11 +2440,11 @@ std::tuple<XLATensorPtr, XLATensorPtr, XLATensorPtr> native_batch_norm_backward(
       grad_out->GetIrValue(), input->GetIrValue(), weight_value,
       save_mean->GetIrValue(), save_invstd->GetIrValue(), training, eps);
   XLATensorPtr grad_input = input->CreateFrom(torch::lazy::Value(node, 0),
-                                              /*delay_eager_executation=*/true);
+                                              /*delay_eager_execution=*/true);
   XLATensorPtr grad_weight = input->CreateFrom(
-      torch::lazy::Value(node, 1), /*delay_eager_executation=*/true);
+      torch::lazy::Value(node, 1), /*delay_eager_execution=*/true);
   XLATensorPtr grad_bias = input->CreateFrom(torch::lazy::Value(node, 2),
-                                             /*delay_eager_executation=*/true);
+                                             /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the `native_batch_norm_backward` and in
@@ -2463,10 +2463,10 @@ std::tuple<XLATensorPtr, XLATensorPtr> native_dropout(
       input->GetIrValue(),
       XLAGraphExecutor::Get()->GetRngSeed(input->GetDevice()), p, train);
   XLATensorPtr t1 = input->CreateFrom(torch::lazy::Value(node, 0),
-                                      /*delay_eager_executation=*/true);
+                                      /*delay_eager_execution=*/true);
   XLATensorPtr t2 =
       input->CreateFrom(torch::lazy::Value(node, 1), at::ScalarType::Bool,
-                        /*delay_eager_executation=*/true);
+                        /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the `native_dropout` and in one hlo
@@ -2677,9 +2677,9 @@ std::tuple<XLATensorPtr, XLATensorPtr> prelu_backward(
   torch::lazy::NodePtr node = PreluBackward(
       grad->GetIrValue(), input->GetIrValue(), weight->GetIrValue());
   XLATensorPtr t1 = input->CreateFrom(torch::lazy::Value(node, 0),
-                                      /*delay_eager_executation=*/true);
+                                      /*delay_eager_execution=*/true);
   XLATensorPtr t2 = input->CreateFrom(torch::lazy::Value(node, 1),
-                                      /*delay_eager_executation=*/true);
+                                      /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the `prelu_backward` and in one hlo
@@ -2717,9 +2717,9 @@ std::tuple<XLATensorPtr, XLATensorPtr> qr(const XLATensorPtr& input,
   torch::lazy::NodePtr node =
       torch_xla::MakeNode<QR>(input->GetIrValue(), some);
   XLATensorPtr t1 = input->CreateFrom(torch::lazy::Value(node, 0),
-                                      /*delay_eager_executation=*/true);
+                                      /*delay_eager_execution=*/true);
   XLATensorPtr t2 = input->CreateFrom(torch::lazy::Value(node, 1),
-                                      /*delay_eager_executation=*/true);
+                                      /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the `qr` and in one hlo
@@ -3135,9 +3135,9 @@ std::tuple<XLATensorPtr, XLATensorPtr> eigh(const XLATensorPtr& input,
 std::tuple<XLATensorPtr, XLATensorPtr> slogdet(const XLATensorPtr& input) {
   torch::lazy::NodePtr node = SLogDet(input->GetIrValue());
   XLATensorPtr t1 = input->CreateFrom(torch::lazy::Value(node, 0),
-                                      /*delay_eager_executation=*/true);
+                                      /*delay_eager_execution=*/true);
   XLATensorPtr t2 = input->CreateFrom(torch::lazy::Value(node, 1),
-                                      /*delay_eager_executation=*/true);
+                                      /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the `slogdet` and in one hlo
@@ -3300,9 +3300,9 @@ std::tuple<XLATensorPtr, XLATensorPtr> std_mean(const XLATensorPtr& input,
           input->shape().get().dimensions_size()),
       correction, keep_reduced_dimensions);
   XLATensorPtr t1 = input->CreateFrom(torch::lazy::Value(node, 0),
-                                      /*delay_eager_executation=*/true);
+                                      /*delay_eager_execution=*/true);
   XLATensorPtr t2 = input->CreateFrom(torch::lazy::Value(node, 1),
-                                      /*delay_eager_executation=*/true);
+                                      /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the `std_mean` and in one hlo
@@ -3374,11 +3374,11 @@ std::tuple<XLATensorPtr, XLATensorPtr, XLATensorPtr> svd(
   torch::lazy::NodePtr node =
       torch_xla::MakeNode<SVD>(input->GetIrValue(), some, compute_uv);
   XLATensorPtr t1 = input->CreateFrom(torch::lazy::Value(node, 0),
-                                      /*delay_eager_executation=*/true);
+                                      /*delay_eager_execution=*/true);
   XLATensorPtr t2 = input->CreateFrom(torch::lazy::Value(node, 1),
-                                      /*delay_eager_executation=*/true);
+                                      /*delay_eager_execution=*/true);
   XLATensorPtr t3 = input->CreateFrom(torch::lazy::Value(node, 2),
-                                      /*delay_eager_executation=*/true);
+                                      /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the `svd` and in one hlo
@@ -3436,10 +3436,10 @@ std::tuple<XLATensorPtr, XLATensorPtr> topk(const XLATensorPtr& input,
           dim, input->shape().get().dimensions_size()),
       largest, sorted, stable);
   XLATensorPtr t1 = input->CreateFrom(torch::lazy::Value(node, 0),
-                                      /*delay_eager_executation=*/true);
+                                      /*delay_eager_execution=*/true);
   XLATensorPtr t2 =
       input->CreateFrom(torch::lazy::Value(node, 1), at::ScalarType::Long,
-                        /*delay_eager_executation=*/true);
+                        /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the `topk` and in one hlo
@@ -3504,9 +3504,9 @@ std::tuple<XLATensorPtr, XLATensorPtr> triangular_solve(
       rhs->GetIrValue(), lhs->GetIrValue(), left_side, !upper, transpose,
       unitriangular);
   XLATensorPtr t1 = rhs->CreateFrom(torch::lazy::Value(node, 0),
-                                    /*delay_eager_executation=*/true);
+                                    /*delay_eager_execution=*/true);
   XLATensorPtr t2 = rhs->CreateFrom(torch::lazy::Value(node, 1),
-                                    /*delay_eager_executation=*/true);
+                                    /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the `triangular_solve` and in one hlo
@@ -3663,9 +3663,9 @@ std::tuple<XLATensorPtr, XLATensorPtr> var_mean(const XLATensorPtr& input,
           input->shape().get().dimensions_size()),
       correction, keep_reduced_dimensions);
   XLATensorPtr t1 = input->CreateFrom(torch::lazy::Value(node, 0),
-                                      /*delay_eager_executation=*/true);
+                                      /*delay_eager_execution=*/true);
   XLATensorPtr t2 = input->CreateFrom(torch::lazy::Value(node, 1),
-                                      /*delay_eager_executation=*/true);
+                                      /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();
   if (graph_executor->UseEagerMode()) {
     // Execute the HLO that will run the `var_mean` and in one hlo

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2441,8 +2441,8 @@ std::tuple<XLATensorPtr, XLATensorPtr, XLATensorPtr> native_batch_norm_backward(
       save_mean->GetIrValue(), save_invstd->GetIrValue(), training, eps);
   XLATensorPtr grad_input = input->CreateFrom(torch::lazy::Value(node, 0),
                                               /*delay_eager_execution=*/true);
-  XLATensorPtr grad_weight = input->CreateFrom(
-      torch::lazy::Value(node, 1), /*delay_eager_execution=*/true);
+  XLATensorPtr grad_weight = input->CreateFrom(torch::lazy::Value(node, 1),
+                                               /*delay_eager_execution=*/true);
   XLATensorPtr grad_bias = input->CreateFrom(torch::lazy::Value(node, 2),
                                              /*delay_eager_execution=*/true);
   XLAGraphExecutor* graph_executor = XLAGraphExecutor::Get();

--- a/torch_xla/experimental/eager.py
+++ b/torch_xla/experimental/eager.py
@@ -6,7 +6,7 @@ import logging
 
 
 def eager_mode(enable: bool):
-  """Configure torch_xla's default executation mode.
+  """Configure torch_xla's default execution mode.
 
   Under eager mode only functions that was `torch_xla.compile`d will be
   traced and compiled. Other torch ops will be executed eagerly.


### PR DESCRIPTION
fixes: #9108