### PR TITLE
[benchmarks] Fix run single config command error

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -85,7 +85,7 @@ python xla/benchmarks/experiment_runner.py \
     --suite-name=torchbench \
     --progress-bar  \
     --model-config='{"model_name":"BERT_pytorch"}' \
-    --experiment-config='{"accelerator":"cuda","xla":"PJRT","xla_flags":null,"dynamo":"openxla","torch_xla2":null,"test":"train","keep_model_data_on_cuda":"false"}' \
+    --experiment-config='{"accelerator":"cuda","xla":"PJRT","xla_flags":null,"dynamo":"openxla","torch_xla2":null,"test":"train","keep_model_data_on_cuda":false,"enable_functionalization":false}' \
     --repeat 1
 ```
 


### PR DESCRIPTION
## Problem
The README in `benchmarks` have some errors in the command of running single configuration.

1. `enable_functionalization` is a required arg, but not present in the command.
2. `"false"` should not have the double quotes. `json.loads` would read it as a string.

## Fix

This PR adds `enable_functionalization` to the command and removed the double quotes for the `"false"` values in the args.