### PR TITLE
get master ip address for neuron device

### DIFF
--- a/torch_xla/_internal/neuron.py
+++ b/torch_xla/_internal/neuron.py
@@ -37,6 +37,11 @@ def set_rt_root_comm_id():
     os.environ['NEURON_RT_ROOT_COMM_ID'] = '{}:{}'.format(root_addr, root_port)
 
 
+def get_master_worker_ip():
+  root_addr = os.environ.get('MASTER_ADDR', 'localhost')
+  return root_addr
+
+
 def set_envvar_defaults():
   os.environ.setdefault('ALLREDUCE_GRADIENTS_BUCKET_SIZE_MB', '50')
 

--- a/torch_xla/runtime.py
+++ b/torch_xla/runtime.py
@@ -10,6 +10,7 @@ import torch_xla
 import torch_xla.core.xla_env_vars as xenv
 import torch_xla.core.xla_model as xm
 import torch_xla.utils.utils as xu
+import torch_xla._internal.neuron as neuron
 import torch_xla._internal.utils as _utils
 import torch_xla._internal.tpu as tpu
 from torch_xla.experimental import plugins
@@ -277,6 +278,8 @@ def get_master_ip() -> str:
     master worker's IP address as a string."""
   if device_type() == 'TPU':
     return tpu.discover_master_worker_ip()
+  elif device_type() == "NEURON":
+    return neuron.get_master_worker_ip()
   raise RuntimeError(f'IP discovery not supported for device: {device_type()}')
 
 


### PR DESCRIPTION
[distributed checkpointing](https://github.com/pytorch/xla/blob/5e723dea7e1a284bdb49b4dbaa46506acfc38200/torch_xla/experimental/distributed_checkpoint/manager.py#L165) currently does not work for neuron device since runtime is not able to get master worker ip address.