### PR TITLE
Test torchax on Python 3.10 - 3.12

### DIFF
--- a/.github/workflows/torchax.yml
+++ b/.github/workflows/torchax.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.10', '3.11', '3.12']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/torchax/test-requirements.txt
+++ b/torchax/test-requirements.txt
@@ -1,10 +1,10 @@
 -r dev-requirements.txt
-absl-py
-immutabledict
-pytest
-pytest-xdist
-pytest-forked
-sentencepiece
-expecttest
-optax
-tensorflow
+absl-py==2.2.2
+immutabledict==4.2.1
+pytest==8.3.5
+pytest-xdist==3.6.1
+pytest-forked==1.6.0
+sentencepiece==0.2.0
+expecttest==0.3.0
+optax==0.2.4
+tensorflow==2.19.0


### PR DESCRIPTION
Because why not.

Why not 3.13? Because TensorFlow.

Also pin test package versions to improve determinism.