### PR TITLE
Silence distributed warning

### DIFF
--- a/torchax/torchax/distributed.py
+++ b/torchax/torchax/distributed.py
@@ -100,7 +100,7 @@ class ProcessGroupJax(ProcessGroup):
     return self._work(tensors)
 
 
-dist.Backend.register_backend("jax", ProcessGroupJax)
+dist.Backend.register_backend("jax", ProcessGroupJax, devices=["jax"])
 
 
 def jax_rendezvous_handler(url: str,


### PR DESCRIPTION
The "jax" distributed backend only supports "jax" devices.

Gets rid of this warning:

```
/usr/local/lib/python3.10/site-packages/torch/distributed/distributed_c10d.py:351: UserWarning: Device capability of jax unspecified, assuming `cpu` and `cuda`. Please specify it via the `devices` argument of `register_backend`.
  warnings.warn(
```