### PR TITLE
Re-land: Add `clang` link to PATH.

### DIFF
--- a/infra/ansible/config/apt.yaml
+++ b/infra/ansible/config/apt.yaml
@@ -14,7 +14,7 @@ apt:
       - vim
       - wget
       - clang-format
-      - clang-17
+      - clang-{{ clang_version }}
       - gcc-10
       - g++-10
       - lcov

--- a/infra/ansible/playbook.yaml
+++ b/infra/ansible/playbook.yaml
@@ -66,6 +66,8 @@
             pip.pkgs_nodeps[stage + '_' + arch] | default([], true) +
             pip.pkgs_nodeps[stage + '_' + accelerator] | default([], true)
           }}"
+
+        llvm_path: "/usr/lib/llvm-{{ clang_version }}/bin"
       tags: install_deps
 
     - role: fetch_srcs

--- a/infra/ansible/playbook.yaml
+++ b/infra/ansible/playbook.yaml
@@ -41,6 +41,7 @@
 
     - role: install_deps
       vars:
+        stage: "{{ stage }}"
         apt_keys: "{{ apt.signing_keys }}"
 
         # If a variable (like `apt.pkgs.common`) is defined, but not set to

--- a/infra/ansible/roles/install_deps/tasks/main.yaml
+++ b/infra/ansible/roles/install_deps/tasks/main.yaml
@@ -40,3 +40,4 @@
   loop:
     - clang
     - clang++
+  when: stage == "build"

--- a/infra/ansible/roles/install_deps/tasks/main.yaml
+++ b/infra/ansible/roles/install_deps/tasks/main.yaml
@@ -34,3 +34,9 @@
   ansible.builtin.pip:
     name: "{{ pip_pkgs_nodeps }}"
     extra_args: "--no-deps"
+
+- name: Install Clang Alternatives
+  command: update-alternatives --install /usr/bin/{{ item }} {{ item }} {{ llvm_path }}/{{ item }} 100
+  loop:
+    - clang
+    - clang++


### PR DESCRIPTION
This PR tries to re-land #9053.

**Problem:** the old PR always tried to create the `clang` link by using `update-alternatives`. However, `clang-17` is only installed when `stage=build`.

**Solution:** condition this step on `stage == build`.