### PR TITLE
Ensure that all of PyTorch/XLA C++ is compiled with exceptions enabled.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,6 +24,9 @@ build -c opt
 
 build --config=short_logs
 
+# PyTorch/XLA uses exceptions to communicate with Python.
+build --copt=-fexceptions
+
 # Force GCC because clang/bazel has issues.
 build --action_env=CC=gcc
 build --action_env=CXX=g++

--- a/bazel/rules_def.bzl
+++ b/bazel/rules_def.bzl
@@ -26,7 +26,6 @@ def ptxla_cc_test(
         linkstatic = True,
         copts = copts + [
             "-isystemexternal/torch",  # Required for system includes.
-            "-fexceptions",  # Required for testing crashes.
         ],
         deps = deps + [
             "@pybind11//:pybind11_embed",  # libpython


### PR DESCRIPTION
For https://github.com/pytorch/xla/issues/9145

Currently we only use `-fexceptions` for tests. We should use it for all C++ compilation to avoid undefined behavior.

#usability