### PR TITLE
Update XLA to a 2025/5/13 revision.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -44,9 +44,9 @@ new_local_repository(
 
 ############################# OpenXLA Setup ###############################
 
-# To build PyTorch/XLA with OpenXLA to a new revision, update following xla_hash to
-# the openxla git commit hash.
-xla_hash = '509f93bf49818a9998c0929fbe57fd0baed3ede9'
+# To build PyTorch/XLA with a new revison of OpenXLA, update the xla_hash to
+# the openxla git commit hash and note the date of the commit.
+xla_hash = '37b580d0dd7b52e611430d33424159719e363ffc'  # Committed on 2025/5/13.
 
 http_archive(
     name = "xla",

--- a/torch_xla/csrc/runtime/ifrt_computation_client.cpp
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.cpp
@@ -430,7 +430,7 @@ std::vector<xla::Literal> IfrtComputationClient::TransferFromDevice(
   std::vector<xla::Literal> literals;
   literals.reserve(handles.size());
   int64_t total_size = 0;
-  for (auto handle : handles) {
+  for (const auto& handle : handles) {
     // Use XLA replication to reassemble the sharded data. If input handle
     // is not sharded, then it is a no-op.
     auto ifrt_data = std::dynamic_pointer_cast<IfrtData>(handle);
@@ -501,9 +501,9 @@ std::vector<ComputationClient::ComputationPtr> IfrtComputationClient::Compile(
         mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
     torch_xla::ConvertHloToStableHlo(instance.computation.mutable_proto(),
                                      &mlir_module);
-    std::unique_ptr<xla::ifrt::LoadedExecutable> executable =
+    std::shared_ptr<xla::ifrt::LoadedExecutable> executable =
         ConsumeValue(client_->GetDefaultCompiler()->Compile(
-            std::make_unique<xla::ifrt::HloProgram>(std::move(mlir_module)),
+            std::make_unique<xla::ifrt::HloProgram>(mlir_module),
             std::make_unique<xla::ifrt::XlaCompileOptions>(compile_options,
                                                            devices_list)));
     StableHloCompileCounter()->AddValue(1);

--- a/torch_xla/csrc/runtime/ifrt_computation_client.h
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.h
@@ -253,13 +253,13 @@ class IfrtComputationClient : public ComputationClient {
   struct IfrtComputation : public Computation {
     IfrtComputation(xla::XlaComputation computation,
                     std::vector<std::string> devices,
-                    std::unique_ptr<xla::ifrt::LoadedExecutable> executable)
+                    std::shared_ptr<xla::ifrt::LoadedExecutable> executable)
         : Computation(std::move(computation), std::move(devices)),
           executable(std::move(executable)) {
       output_shardings_ = this->executable->GetOutputShardings();
     }
 
-    std::unique_ptr<xla::ifrt::LoadedExecutable> executable;
+    std::shared_ptr<xla::ifrt::LoadedExecutable> executable;
     std::optional<std::vector<xla::OpSharding>> output_shardings_;
   };
 };


### PR DESCRIPTION
For https://github.com/pytorch/xla/issues/9061.

We need [the patch](https://github.com/openxla/xla/commit/a9a2de85316fd9fd232f3ed89fef19ce7ffa7a9e) in the new XLA revision so that we can compile PyTorch/XLA using clang later.

We have to change `unique_ptr` to `shared_ptr` in a few places to match the latest XLA interface.
