### PR TITLE
Fix a clang compilation error.

### DIFF
--- a/torch_xla/csrc/helpers.cpp
+++ b/torch_xla/csrc/helpers.cpp
@@ -6,7 +6,6 @@
 #include <iterator>
 #include <limits>
 
-#include "absl/status/status.h"
 #include "absl/strings/str_join.h"
 #include "torch_xla/csrc/convert_ops.h"
 #include "torch_xla/csrc/dtype.h"
@@ -1043,11 +1042,9 @@ absl::StatusOr<xla::XlaComputation> XlaHelpers::WrapXlaComputation(
   xla::XlaOp orig_result = xla::Call(&builder, computation, inner_params);
 
   // Rebuild aliasing.
-  if (buffer_donor_indices.size() > 0) {
-    for (size_t i : buffer_donor_indices) {
-      builder.AddBufferDonor(/*param_number=*/0,
-                             /*param_index=*/xla::ShapeIndex({i}));
-    }
+  for (const int64_t i : buffer_donor_indices) {
+    builder.AddBufferDonor(/*param_number=*/0,
+                           /*param_index=*/xla::ShapeIndex({i}));
   }
 
   return builder.Build(orig_result);


### PR DESCRIPTION
For https://github.com/pytorch/xla/issues/9061.

The code generates a warning-as-error (narrowing from `size_t` to `int64_t`) when compiled with Clang. Rewrite the code to avoid this error.