### PR TITLE
fix: reload the param groups in optimizer

### DIFF
--- a/torch_xla/distributed/zero_redundancy_optimizer.py
+++ b/torch_xla/distributed/zero_redundancy_optimizer.py
@@ -519,6 +519,7 @@ class ZeroRedundancyOptimizer(Optimizer):
 
     tmp = self.base_optimizer.state_dict()
     tmp['state'] = base_state
+    tmp['param_groups'] = state_dict['param_groups']
     self.base_optimizer.load_state_dict(tmp)
     if 'sharded_master_weights' in state_dict:
       master_weights = state_dict['sharded_master_weights']


### PR DESCRIPTION
The code currently only reloads the "state" in the base optimizer, however if there is a change in the param_groups, that is not updated when reloading from the checkpoint. The base optimizer also needs to take in the "param_groups" from the loaded checkpoint.