### PR TITLE
test: add test_xla_graph_execution to test flags (_set_allow_execution with PT_XLA_DEBUG_LEVEL)

### DIFF
--- a/test/neuron/run_tests.sh
+++ b/test/neuron/run_tests.sh
@@ -106,6 +106,11 @@ function run_pt_xla_debug_level1 {
   PT_XLA_DEBUG_LEVEL=1 PT_XLA_DEBUG_FILE="/tmp/pt_xla_debug.txt" run_test "$@"
 }
 
+function run_pt_xla_debug_level2 {
+  echo "Running in save tensor file mode: $@"
+  PT_XLA_DEBUG_LEVEL=2 PT_XLA_DEBUG_FILE="/tmp/pt_xla_debug.txt" run_test "$@"
+}
+
 function run_torchrun {
   PJRT_DEVICE=NEURON torchrun --nnodes 1 --nproc-per-node 2 $@
 }
@@ -141,6 +146,8 @@ function run_xla_op_tests1 {
   #run_test_without_functionalization "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_pt_xla_debug "$CDIR/debug_tool/test_pt_xla_debug.py"
   run_pt_xla_debug_level1 "$CDIR/debug_tool/test_pt_xla_debug.py"
+  run_test "$CDIR/test_xla_graph_execution.py"
+  run_pt_xla_debug_level2 "$CDIR/test_xla_graph_execution.py"
   run_test "$CDIR/test_async_closures.py"
   run_test "$CDIR/test_hlo_metadata.py"
   #run_test "$CDIR/test_profiler.py"

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -151,6 +151,7 @@ function run_xla_op_tests1 {
   run_dynamic "$CDIR/ds/test_dynamic_shape_models.py" "$@" --verbosity=$VERBOSITY
   run_eager_debug  "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_test "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  run_test "$CDIR/test_xla_graph_execution.py" "$@" --verbosity=$VERBOSITY
   run_test_without_functionalization "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_pt_xla_debug "$CDIR/debug_tool/test_pt_xla_debug.py"
   run_pt_xla_debug_level1 "$CDIR/debug_tool/test_pt_xla_debug.py"

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -115,6 +115,11 @@ function run_pt_xla_debug_level1 {
   PT_XLA_DEBUG_LEVEL=1 PT_XLA_DEBUG_FILE="/tmp/pt_xla_debug.txt" run_test "$@"
 }
 
+function run_pt_xla_debug_level2 {
+  echo "Running in save tensor file mode: $@"
+  PT_XLA_DEBUG_LEVEL=2 PT_XLA_DEBUG_FILE="/tmp/pt_xla_debug.txt" run_test "$@"
+}
+
 function run_torchrun {
   if [ -x "$(command -v nvidia-smi)" ] && [ "$XLA_CUDA" != "0" ]; then
     echo "Running torchrun test for GPU $@"
@@ -151,7 +156,7 @@ function run_xla_op_tests1 {
   run_dynamic "$CDIR/ds/test_dynamic_shape_models.py" "$@" --verbosity=$VERBOSITY
   run_eager_debug  "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_test "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
-  run_test "$CDIR/test_xla_graph_execution.py" "$@" --verbosity=$VERBOSITY
+  run_pt_xla_debug_level2 "$CDIR/test_xla_graph_execution.py" "$@" --verbosity=$VERBOSITY
   run_test_without_functionalization "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_pt_xla_debug "$CDIR/debug_tool/test_pt_xla_debug.py"
   run_pt_xla_debug_level1 "$CDIR/debug_tool/test_pt_xla_debug.py"

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -156,6 +156,7 @@ function run_xla_op_tests1 {
   run_dynamic "$CDIR/ds/test_dynamic_shape_models.py" "$@" --verbosity=$VERBOSITY
   run_eager_debug  "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_test "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  run_test "$CDIR/test_xla_graph_execution.py" "$@" --verbosity=$VERBOSITY
   run_pt_xla_debug_level2 "$CDIR/test_xla_graph_execution.py" "$@" --verbosity=$VERBOSITY
   run_test_without_functionalization "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_pt_xla_debug "$CDIR/debug_tool/test_pt_xla_debug.py"

--- a/test/test_xla_graph_execution.py
+++ b/test/test_xla_graph_execution.py
@@ -10,7 +10,6 @@ import torch_xla.core.xla_model as xm
 import torch_xla.utils.utils as xu
 import unittest
 import test_utils
-import time
 
 parser = argparse.ArgumentParser(add_help=False)
 parser.add_argument('--verbosity', type=int, default=0)
@@ -18,56 +17,28 @@ FLAGS, leftovers = parser.parse_known_args()
 sys.argv = [sys.argv[0]] + leftovers
 print(FLAGS)
 
-XLA_DISABLE_FUNCTIONALIZATION = bool(
-    os.environ.get('XLA_DISABLE_FUNCTIONALIZATION', False))
-
 
 class TestXlaGraphExecution(test_utils.XlaTestCase):
 
-  def test_graph_execution_disabled(self):
-    # Test xla_debug_level = 0
-    print("Test xla debug level disabled.")
+  def test_graph_execution_allowed(self):
+    # Test graph execution allowed
     torch_xla._XLAC._set_allow_execution(True)
-    os.environ['PT_XLA_DEBUG_LEVEL'] = '0'
-    start_time = time.time()
     x = torch.ones(2, device=xm.xla_device())
     self.assertEqual(x[0], 1.0)  # This should trigger the checking
-
-    print("--- %s seconds ---" % (time.time() - start_time))
     del x
 
-  def test_graph_execution_warning(self):
-    # Test xla_debug_level = 2 (with WARNING)
-    print("Test xla debug level enabled.")
-    torch_xla._XLAC._set_allow_execution(True)
-    os.environ['PT_XLA_DEBUG_LEVEL'] = '2'
-    start_time = time.time()
-    x = torch.ones(2, device=xm.xla_device())
-    self.assertEqual(x[0], 1.0)  # This should trigger the checking
-    print("--- %s seconds ---" % (time.time() - start_time))
-    del x
-
-  def test_graph_execution_error(self):
-    # Test ERROR level
-    print(
-        "Test check level as runtime error with warning messages before that.")
+  def test_graph_execution_disallowed_with_error(self):
+    # Test ERROR when graph execution is not allowed
+    print("Trigger runtime error for unexpected graph execution")
     torch_xla._XLAC._set_allow_execution(
         False)  # this flag disallows graph execution
-    start_time = time.time()
     x = torch.ones(2, device=xm.xla_device())
     with self.assertRaises(RuntimeError) as e:
       self.assertEqual(x[0], 1.0)  # This should trigger the checking
-    print("--- %s seconds ---" % (time.time() - start_time))
     del x
-    print(
-        "--- Timers are added for reference. However, the 1st test runs slower due to memory initialization ---"
-    )
 
 
 if __name__ == '__main__':
-  torch.set_default_dtype(torch.float32)
-  torch.manual_seed(42)
-  torch_xla._XLAC._xla_set_mat_mul_precision('highest')
   test = unittest.main(verbosity=FLAGS.verbosity, exit=False)
   if xu.getenv_as('METRICS_DEBUG', bool, defval=False):
     print(met.metrics_report())

--- a/test/test_xla_graph_execution.py
+++ b/test/test_xla_graph_execution.py
@@ -7,7 +7,6 @@ import sys
 import torch
 import torch_xla
 import torch_xla.core.xla_model as xm
-import torch_xla.utils.utils as xu
 import unittest
 import test_utils
 
@@ -21,7 +20,6 @@ print(FLAGS)
 class TestXlaGraphExecution(test_utils.XlaTestCase):
 
   def test_graph_execution_allowed(self):
-    # Test graph execution allowed
     torch_xla._XLAC._set_allow_execution(True)
     x = torch.ones(2, device=xm.xla_device())
     self.assertEqual(x[0], 1.0)  # This should trigger the checking
@@ -29,17 +27,18 @@ class TestXlaGraphExecution(test_utils.XlaTestCase):
 
   def test_graph_execution_disallowed_with_error(self):
     # Test ERROR when graph execution is not allowed
-    print("Trigger runtime error for unexpected graph execution")
+    # Trigger runtime error for unexpected graph execution
     torch_xla._XLAC._set_allow_execution(
         False)  # this flag disallows graph execution
     x = torch.ones(2, device=xm.xla_device())
     with self.assertRaises(RuntimeError) as e:
       self.assertEqual(x[0], 1.0)  # This should trigger the checking
+    self.assertIn(
+        "Unexpected execution happens inside the compiled function, exiting",
+        str(e.exception))
     del x
 
 
 if __name__ == '__main__':
   test = unittest.main(verbosity=FLAGS.verbosity, exit=False)
-  if xu.getenv_as('METRICS_DEBUG', bool, defval=False):
-    print(met.metrics_report())
   sys.exit(0 if test.result.wasSuccessful() else 1)

--- a/test/tpu/run_tests.sh
+++ b/test/tpu/run_tests.sh
@@ -12,6 +12,7 @@ source "${TEST_CDIR}/utils/run_tests_utils.sh"
 (cd $TEST_CDIR && python3 -m unittest test_mat_mul_precision.TestMatMulPrecision.test_all)
 python3 "$TEST_CDIR/test_mat_mul_precision_get_and_set.py"
 python3 "$TEST_CDIR/test_operations.py" -v
+python3 "$TEST_CDIR/test_xla_graph_execution.py" -v
 python3 "$TEST_CDIR/pjrt/test_runtime_tpu.py"
 python3 "$TEST_CDIR/pjrt/test_collective_ops_tpu.py"
 python3 "$TEST_CDIR/spmd/test_mp_input_sharding.py"


### PR DESCRIPTION
Following up on the https://github.com/pytorch/xla/pull/9057, the flag is useful to catch unexpected graph execution during model tracing.

###  Example usage:
```python
# 1) print warning messages when tensor sync happens
import os
os.environ['PT_XLA_DEBUG_LEVEL'] = '2'

# 2) error out when tensor sync happens
import torch_xla
torch_xla._XLAC._set_allow_execution(False)  # this flag disallows graph execution
```

### This enhancement helps developers:
The team saw issues when we use the tensor value for if-else statement.
For example,
```python 
def forward(self, tensor):
  if tensor[0] == 1:
     return tensor
  else:
     return tensor * 2
```
The example above can compile and run. However, it may make the developers to believe the tensors can be evaluated on the fly, leading to unexpected behaviors.
With the flags used during graph tracing, we can
1. Identify potential code path issue in XLA graph execution and prevent the users from using tensor values in the graph
1. Debug and trace tensor synchronization issues more effectively