### PR TITLE
configurable number of thread for dcp

### DIFF
--- a/torch_xla/experimental/distributed_checkpoint/manager.py
+++ b/torch_xla/experimental/distributed_checkpoint/manager.py
@@ -107,6 +107,7 @@ class CheckpointManager:
                save_interval: int,
                max_to_keep: Optional[int] = 0,
                max_pending_async: Optional[int] = 1,
+               num_of_threads: Optional[int] = 1,
                process_group: dist.ProcessGroup = None,
                chkpt_on_preemption: bool = True):
     """
@@ -127,6 +128,8 @@ class CheckpointManager:
             slow down the active checkpoint.
             Default: 1, which only allows a single async checkpoint to be
             pending at a time.
+      number_of_threads: Number of concurrent threads for writing checkpoint to
+            file system.
       process_group: The process group to use when coordinating the checkpoint.
             Default: None, in which case a subgroup of the default process
             group will be created.
@@ -142,6 +145,7 @@ class CheckpointManager:
     self.base_path = os.path.join(path, '')  # Ensure the base path ends in '/'
     self.save_interval = save_interval
     self.max_to_keep = max_to_keep
+    self.num_of_threads = num_of_threads
     self.chkpt_on_preemption = chkpt_on_preemption
 
     # Create a new group if none is provided
@@ -226,6 +230,7 @@ class CheckpointManager:
           state_dict=state_dict,
           storage_writer=FsspecWriter(
               path,
+              thread_count=self.num_of_threads,
               per_thread_copy_ahead=0,
           ),
           planner=xc.SPMDSavePlanner(),


### PR DESCRIPTION
DCP [FileSystemWritter](https://github.com/pytorch/pytorch/blob/1f4f4a61c20cc108bdf2b84495a1ae4b0c4a8f0c/torch/distributed/checkpoint/filesystem.py#L891) provides a [thread_count](https://github.com/pytorch/pytorch/blob/1f4f4a61c20cc108bdf2b84495a1ae4b0c4a8f0c/torch/distributed/checkpoint/filesystem.py#L910) parameter which allows us to save checkpoints using [concurrent](https://github.com/pytorch/pytorch/blob/1f4f4a61c20cc108bdf2b84495a1ae4b0c4a8f0c/torch/distributed/checkpoint/filesystem.py#L646) threads, but [CheckpointManager](https://github.com/pytorch/xla/blob/f39434abf4a3e1ddd7c6645f495c054b1e4ec714/torch_xla/experimental/distributed_checkpoint/manager.py#L40) is not exposing this param