### PR TITLE
Make 2 more run_tests.sh support test selection

### DIFF
--- a/benchmarks/run_benchmark.sh
+++ b/benchmarks/run_benchmark.sh
@@ -5,7 +5,7 @@ LOGFILE=/tmp/benchmark_test.log
 
 # Note [Keep Going]
 #
-# Set the `CONTINUE_ON_ERROR` flag to `true` to make the CI tests continue on error.
+# Set the `CONTINUE_ON_ERROR` flag to `1` to make the CI tests continue on error.
 # This will allow you to see all the failures on your PR, not stopping with the first
 # test failure like the default behavior.
 CONTINUE_ON_ERROR="${CONTINUE_ON_ERROR:-0}"

--- a/test/benchmarks/run_tests.sh
+++ b/test/benchmarks/run_tests.sh
@@ -9,7 +9,7 @@ export PYTHONPATH=$PYTHONPATH:$CDIR/../../benchmarks/
 
 # Note [Keep Going]
 #
-# Set the `CONTINUE_ON_ERROR` flag to `true` to make the CI tests continue on error.
+# Set the `CONTINUE_ON_ERROR` flag to `1` to make the CI tests continue on error.
 # This will allow you to see all the failures on your PR, not stopping with the first
 # test failure like the default behavior.
 CONTINUE_ON_ERROR="${CONTINUE_ON_ERROR:-0}"

--- a/test/benchmarks/run_torchbench_tests.sh
+++ b/test/benchmarks/run_torchbench_tests.sh
@@ -14,7 +14,7 @@ TORCHBENCH_DIR=$PYTORCH_DIR/benchmark
 
 # Note [Keep Going]
 #
-# Set the `CONTINUE_ON_ERROR` flag to `true` to make the CI tests continue on error.
+# Set the `CONTINUE_ON_ERROR` flag to `1` to make the CI tests continue on error.
 # This will allow you to see all the failures on your PR, not stopping with the first
 # test failure like the default behavior.
 CONTINUE_ON_ERROR="${CONTINUE_ON_ERROR:-0}"

--- a/test/neuron/run_tests.sh
+++ b/test/neuron/run_tests.sh
@@ -31,6 +31,9 @@ TORCH_XLA_DIR=$(cd ~; dirname "$(python -c 'import torch_xla; print(torch_xla.__
 COVERAGE_FILE="$CDIR/../.coverage"
 
 function run_coverage {
+  if ! test_is_selected "$1"; then
+    return
+  fi
   if [ "${USE_COVERAGE:-0}" != "0" ]; then
     coverage run --source="$TORCH_XLA_DIR" -p "$@"
   else
@@ -39,61 +42,97 @@ function run_coverage {
 }
 
 function run_test {
+  if ! test_is_selected "$1"; then
+    return
+  fi
   echo "Running in PjRt runtime: $@"
   PJRT_DEVICE=NEURON NEURON_NUM_DEVICES=1 run_coverage "$@"
 }
 
 function run_test_without_functionalization {
+  if ! test_is_selected "$1"; then
+    return
+  fi
   echo "Running with XLA_DISABLE_FUNCTIONALIZATION: $@"
   XLA_DISABLE_FUNCTIONALIZATION=1 run_test "$@"
 }
 
 function run_xla_ir_debug {
+  if ! test_is_selected "$1"; then
+    return
+  fi
   echo "Running with XLA_IR_DEBUG: $@"
   XLA_IR_DEBUG=1 run_test "$@"
 }
 
 function run_use_bf16 {
+  if ! test_is_selected "$1"; then
+    return
+  fi
   echo "Running with XLA_USE_BF16: $@"
   XLA_USE_BF16=1 run_test "$@"
 }
 
 function run_downcast_bf16 {
+  if ! test_is_selected "$1"; then
+    return
+  fi
   echo "Running with XLA_DOWNCAST_BF16: $@"
   XLA_DOWNCAST_BF16=1 run_test "$@"
 }
 
 function run_xla_hlo_debug {
+  if ! test_is_selected "$1"; then
+    return
+  fi
   echo "Running with XLA_IR_DEBUG: $@"
   XLA_HLO_DEBUG=1 run_test "$@"
 }
 
 function run_dynamic {
+  if ! test_is_selected "$1"; then
+    return
+  fi
   echo "Running in DynamicShape mode: $@"
   XLA_EXPERIMENTAL="nonzero:masked_select:masked_scatter:nms" run_test "$@"
 }
 
 function run_eager_debug {
+  if ! test_is_selected "$1"; then
+    return
+  fi
   echo "Running in Eager Debug mode: $@"
   XLA_USE_EAGER_DEBUG_MODE=1 run_test "$@"
 }
 
 function run_pt_xla_debug {
+  if ! test_is_selected "$1"; then
+    return
+  fi
   echo "Running in save tensor file mode: $@"
   PT_XLA_DEBUG=1 PT_XLA_DEBUG_FILE="/tmp/pt_xla_debug.txt" run_test "$@"
 }
 
 function run_pt_xla_debug_level1 {
+  if ! test_is_selected "$1"; then
+    return
+  fi
   echo "Running in save tensor file mode: $@"
   PT_XLA_DEBUG_LEVEL=1 PT_XLA_DEBUG_FILE="/tmp/pt_xla_debug.txt" run_test "$@"
 }
 
 function run_pt_xla_debug_level2 {
+  if ! test_is_selected "$1"; then
+    return
+  fi
   echo "Running in save tensor file mode: $@"
   PT_XLA_DEBUG_LEVEL=2 PT_XLA_DEBUG_FILE="/tmp/pt_xla_debug.txt" run_test "$@"
 }
 
 function run_torchrun {
+  if ! test_is_selected "$1"; then
+    return
+  fi
   PJRT_DEVICE=NEURON torchrun --nnodes 1 --nproc-per-node 2 $@
 }
 
@@ -306,6 +345,8 @@ function run_tests {
     fi
   fi
 }
+
+set_test_filter $@
 
 if [ "$LOGFILE" != "" ]; then
   run_tests 2>&1 | tee $LOGFILE

--- a/test/neuron/run_tests.sh
+++ b/test/neuron/run_tests.sh
@@ -1,42 +1,24 @@
 #!/bin/bash
 set -exo pipefail
 CDIR="$(cd "$(dirname "$0")"/../ ; pwd -P)"
-LOGFILE=/tmp/pytorch_py_test.log
-MAX_GRAPH_SIZE=500
-GRAPH_CHECK_FREQUENCY=100
-VERBOSITY=2
 
 # Utils file
 source "${CDIR}/utils/run_tests_utils.sh"
 
+parse_options_to_vars $@
+
+# Consume the parsed commandline arguments.
+shift $(($OPTIND - 1))
+
 # Note [Keep Going]
 #
-# Set the `CONTINUE_ON_ERROR` flag to `true` to make the CI tests continue on error.
+# Set the `CONTINUE_ON_ERROR` flag to `1` to make the CI tests continue on error.
 # This will allow you to see all the failures on your PR, not stopping with the first
 # test failure like the default behavior.
 CONTINUE_ON_ERROR="${CONTINUE_ON_ERROR:-0}"
 if [[ "$CONTINUE_ON_ERROR" == "1" ]]; then
   set +e
 fi
-
-while getopts 'LM:C:V:' OPTION
-do
-  case $OPTION in
-    L)
-      LOGFILE=
-      ;;
-    M)
-      MAX_GRAPH_SIZE=$OPTARG
-      ;;
-    C)
-      GRAPH_CHECK_FREQUENCY=$OPTARG
-      ;;
-    V)
-      VERBOSITY=$OPTARG
-      ;;
-  esac
-done
-shift $(($OPTIND - 1))
 
 export TRIM_GRAPH_SIZE=$MAX_GRAPH_SIZE
 export TRIM_GRAPH_CHECK_FREQUENCY=$GRAPH_CHECK_FREQUENCY

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -7,44 +7,9 @@ CDIR="$(cd "$(dirname "$0")" ; pwd -P)"
 # Import utilities.
 source "${CDIR}/utils/run_tests_utils.sh"
 
-# Default option values. Can be overridden via commandline flags.
-LOGFILE=/tmp/pytorch_py_test.log
-MAX_GRAPH_SIZE=500
-GRAPH_CHECK_FREQUENCY=100
-VERBOSITY=2
+parse_options_to_vars $@
 
-# Parse commandline flags:
-#   -L
-#      disable writing to the log file at $LOGFILE.
-#   -M max_graph_size
-#   -C graph_check_frequency
-#   -V verbosity
-#   -h
-#      print the help string
-while getopts 'LM:C:V:h' OPTION
-do
-  case $OPTION in
-    L)
-      LOGFILE=
-      ;;
-    M)
-      MAX_GRAPH_SIZE=$OPTARG
-      ;;
-    C)
-      GRAPH_CHECK_FREQUENCY=$OPTARG
-      ;;
-    V)
-      VERBOSITY=$OPTARG
-      ;;
-    h)
-      echo -e "Usage: $0 TEST_FILTER...\nwhere TEST_FILTERs are globs match .py test files. If no test filter is provided, runs all tests."
-      exit 0
-      ;;
-    \?)  # This catches all invalid options.
-      echo "ERROR: Invalid commandline flag."
-      exit 1
-  esac
-done
+# Consume the parsed commandline arguments.
 shift $(($OPTIND - 1))
 
 # Set the `CONTINUE_ON_ERROR` flag to `1` to make the CI tests continue on error.

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -2,7 +2,10 @@
 set -exo pipefail
 
 # Absolute path to the directory of this script.
-CDIR="$(cd "$(dirname "$0")" ; pwd -P)"
+CDIR="$(
+  cd "$(dirname "$0")"
+  pwd -P
+)"
 
 # Import utilities.
 source "${CDIR}/utils/run_tests_utils.sh"
@@ -27,34 +30,11 @@ export PYTORCH_TEST_WITH_SLOW=1
 export XLA_DUMP_FATAL_STACK=1
 export CPU_NUM_DEVICES=4
 
-TORCH_XLA_DIR=$(cd ~; dirname "$(python -c 'import torch_xla; print(torch_xla.__file__)')")
+TORCH_XLA_DIR=$(
+  cd ~
+  dirname "$(python -c 'import torch_xla; print(torch_xla.__file__)')"
+)
 COVERAGE_FILE="$CDIR/../.coverage"
-
-# Given $1 as a (possibly not normalized) test filepath, returns successfully
-# if it matches any of the space-separated globs $_TEST_FILTER. If
-# $_TEST_FILTER is empty, returns successfully. 
-function test_is_selected {
-  if [[ -z "$_TEST_FILTER" ]]; then
-    return 0  # success
-  fi
-
-  # _TEST_FILTER is a space-separate list of globs. Loop through the
-  # list elements.
-  for _FILTER in $_TEST_FILTER; do
-    # realpath normalizes the paths (e.g. resolving `..` and relative paths)
-    # so that they can be compared.
-    case `realpath $1` in
-      `realpath $_FILTER`)
-        return 0  # success
-        ;;
-      *)
-        # No match
-        ;;
-    esac
-  done
-
-  return 1  # failure
-}
 
 function run_coverage {
   if ! test_is_selected "$1"; then
@@ -195,7 +175,7 @@ function run_xla_op_tests1 {
   run_dynamic "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_dynamic "$CDIR/ds/test_dynamic_shapes.py"
   run_dynamic "$CDIR/ds/test_dynamic_shape_models.py" "$@" --verbosity=$VERBOSITY
-  run_eager_debug  "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  run_eager_debug "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_test "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_test "$CDIR/test_xla_graph_execution.py" "$@" --verbosity=$VERBOSITY
   run_pt_xla_debug_level2 "$CDIR/test_xla_graph_execution.py" "$@" --verbosity=$VERBOSITY
@@ -228,7 +208,7 @@ function run_xla_op_tests1 {
   run_test "$CDIR/test_python_ops.py"
   run_test "$CDIR/test_ops.py"
   run_test "$CDIR/test_metrics.py"
-  if [ -f "/tmp/metrics.txt" ] ; then
+  if [ -f "/tmp/metrics.txt" ]; then
     rm /tmp/metrics.txt
   fi
   XLA_METRICS_FILE=/tmp/metrics.txt run_test "$CDIR/test_metrics.py"
@@ -336,7 +316,7 @@ function run_xla_op_tests3 {
     # Please keep PJRT_DEVICE and GPU_NUM_DEVICES explicit in the following test commands.
     echo "single-host-single-process"
     PJRT_DEVICE=CUDA GPU_NUM_DEVICES=1 python3 test/test_train_mp_imagenet.py --fake_data --batch_size=16 --num_epochs=1 --num_cores=1 --num_steps=25 --model=resnet18
-    PJRT_DEVICE=CUDA torchrun --nnodes=1 --node_rank=0 --nproc_per_node=1 test/test_train_mp_imagenet.py --fake_data --pjrt_distributed --batch_size=16 --num_epochs=1  --num_steps=25 --model=resnet18
+    PJRT_DEVICE=CUDA torchrun --nnodes=1 --node_rank=0 --nproc_per_node=1 test/test_train_mp_imagenet.py --fake_data --pjrt_distributed --batch_size=16 --num_epochs=1 --num_steps=25 --model=resnet18
 
     echo "single-host-multi-process"
     num_devices=$(nvidia-smi --list-gpus | wc -l)
@@ -453,16 +433,7 @@ function run_tests {
   fi
 }
 
-if [[ $# -ge 1 ]]; then
-  # There are positional arguments - set $_TEST_FILTER to them.
-  _TEST_FILTER=$@
-  # Sometimes a test may fail even if it doesn't match _TEST_FILTER. Therefore,
-  # we need to set this to be able to get to the test(s) we want to run.
-  CONTINUE_ON_ERROR=1
-else
-  # No positional argument - run all tests.
-  _TEST_FILTER=""
-fi
+set_test_filter $@
 
 if [ "$LOGFILE" != "" ]; then
   run_tests 2>&1 | tee $LOGFILE

--- a/test/tpu/run_tests.sh
+++ b/test/tpu/run_tests.sh
@@ -1,95 +1,129 @@
 #!/bin/bash
 set -xue
-CDIR="$(cd "$(dirname "$0")" ; pwd -P)"
+
+# Absolute path to the directory of this script.
+CDIR="$(
+    cd "$(dirname "$0")"
+    pwd -P
+)"
+
+# Absolute path to the test/ directory.
 TEST_CDIR="$(dirname "$CDIR")"
 
 source "${TEST_CDIR}/utils/run_tests_utils.sh"
 
+while getopts 'h' OPTION
+do
+case $OPTION in
+    h)
+    echo -e "Usage: $0 TEST_FILTER...\nwhere TEST_FILTERs are globs match .py test files. If no test filter is provided, runs all tests."
+    exit 0
+    ;;
+    \?)  # This catches all invalid options.
+    echo "ERROR: Invalid commandline flag."
+    exit 1
+esac
+done
+
+# Consume the parsed commandline arguments.
+shift $(($OPTIND - 1))
+
+set_test_filter $@
+
+function run_test {
+  if ! test_is_selected "$1"; then
+    return
+  fi
+  python3 "$@"
+}
+
 # TODO: merge with other run_tests
-(cd $TEST_CDIR && python3 -m unittest test_mat_mul_precision.TestMatMulPrecision.test_high)
-(cd $TEST_CDIR && python3 -m unittest test_mat_mul_precision.TestMatMulPrecision.test_default)
-(cd $TEST_CDIR && python3 -m unittest test_mat_mul_precision.TestMatMulPrecision.test_highest)
-(cd $TEST_CDIR && python3 -m unittest test_mat_mul_precision.TestMatMulPrecision.test_all)
-python3 "$TEST_CDIR/test_mat_mul_precision_get_and_set.py"
-python3 "$TEST_CDIR/test_operations.py" -v
-python3 "$TEST_CDIR/test_xla_graph_execution.py" -v
-python3 "$TEST_CDIR/pjrt/test_runtime_tpu.py"
-python3 "$TEST_CDIR/pjrt/test_collective_ops_tpu.py"
-python3 "$TEST_CDIR/spmd/test_mp_input_sharding.py"
-python3 "$TEST_CDIR/test_mp_collective_matmul.py"
-run_save_tensor_hlo python3 "$TEST_CDIR/spmd/test_spmd_lowering_context.py"
-python3 "$TEST_CDIR/spmd/test_xla_sharding.py"
-python3 "$TEST_CDIR/spmd/test_xla_virtual_device.py"
-python3 "$TEST_CDIR/spmd/test_xla_distributed_checkpoint.py"
-python3 "$TEST_CDIR/spmd/test_train_spmd_linear_model.py"
-python3 "$TEST_CDIR/spmd/test_xla_spmd_python_api_interaction.py"
-python3 "$TEST_CDIR/spmd/test_xla_auto_sharding.py"
-python3 "$TEST_CDIR/spmd/test_fsdp_v2.py"
-python3 "$TEST_CDIR/test_gradient_accumulation.py"
-XLA_EXPERIMENTAL=nonzero:masked_select:nms python3 "$TEST_CDIR/ds/test_dynamic_shape_models.py" -v
-python3 "$TEST_CDIR/test_autocast.py"
-python3 "$TEST_CDIR/test_fp8.py"
-python3 "$TEST_CDIR/test_grad_checkpoint.py"
-python3 "$TEST_CDIR/test_grad_checkpoint.py" "$@" --test_autocast
-python3 "$TEST_CDIR/dynamo/test_dynamo.py"
-python3 "$TEST_CDIR/dynamo/test_dynamo_dynamic_shape.py"
-python3 "$TEST_CDIR/spmd/test_spmd_debugging.py"
-XLA_PARAMETER_WRAPPING_THREADSHOLD=1 python3 "$TEST_CDIR/spmd/test_spmd_parameter_wrapping.py"
-python3 "$TEST_CDIR/pjrt/test_dtypes.py"
-python3 "$TEST_CDIR/pjrt/test_dynamic_plugin_tpu.py"
-python3 "$TEST_CDIR/test_while_loop.py"
-python3 "$TEST_CDIR/scan/test_scan.py"
-python3 "$TEST_CDIR/scan/test_scan_spmd.py"
-python3 "$TEST_CDIR/scan/test_scan_pallas.py"
-python3 "$TEST_CDIR/scan/test_scan_layers.py"
-python3 "$TEST_CDIR/test_gru.py"
-python3 "$TEST_CDIR/test_assume_pure.py"
-python3 "$TEST_CDIR/test_assume_pure_spmd.py"
-python3 "$TEST_CDIR/test_as_stride_use_slice.py"
-run_xla_hlo_debug python3 "$TEST_CDIR/scan/test_scan_debug.py"
-python3 "$TEST_CDIR/test_pallas.py" -v
-python3 "$TEST_CDIR/test_pallas_spmd.py"
-XLA_DISABLE_FUNCTIONALIZATION=1 python3 "$TEST_CDIR/test_pallas_spmd.py"
-python3 "$TEST_CDIR/test_splash_attention.py"
-python3 "$TEST_CDIR/test_profiler_session.py"
-python3 "$TEST_CDIR/test_multi_queries_paged_attention_kernel.py"
-python3 "$TEST_CDIR/test_ragged_paged_attention_kernel.py"
-python3 "$TEST_CDIR/test_input_output_aliases.py"
-python3 "$TEST_CDIR/test_gmm.py"
-python3 "$TEST_CDIR/eager/test_eager_spmd.py"
-python3 "$TEST_CDIR/torch_distributed/test_torch_distributed_all_gather_xla_backend.py"
-python3 "$TEST_CDIR/torch_distributed/test_torch_distributed_all_reduce_xla_backend.py"
-python3 "$TEST_CDIR/torch_distributed/test_torch_distributed_multi_all_reduce_xla_backend.py"
-python3 "$TEST_CDIR/torch_distributed/test_torch_distributed_reduce_scatter_xla_backend.py"
-python3 "$TEST_CDIR/quantized_ops/test_dot_general.py"
-run_xla_ir_hlo_debug python3 "$TEST_CDIR/test_user_computation_debug_cache.py"
-python3 "$TEST_CDIR/test_data_type.py"
-python3 "$TEST_CDIR/test_compilation_cache_utils.py"
+if test_is_selected $TEST_CDIR/test_mat_mul_precision.py; then
+  (cd $TEST_CDIR && python3 -m unittest test_mat_mul_precision.TestMatMulPrecision.test_high)
+  (cd $TEST_CDIR && python3 -m unittest test_mat_mul_precision.TestMatMulPrecision.test_default)
+  (cd $TEST_CDIR && python3 -m unittest test_mat_mul_precision.TestMatMulPrecision.test_highest)
+  (cd $TEST_CDIR && python3 -m unittest test_mat_mul_precision.TestMatMulPrecision.test_all)
+fi
+run_test "$TEST_CDIR/test_mat_mul_precision_get_and_set.py"
+run_test "$TEST_CDIR/test_operations.py" -v
+run_test "$TEST_CDIR/test_xla_graph_execution.py" -v
+run_test "$TEST_CDIR/pjrt/test_runtime_tpu.py"
+run_test "$TEST_CDIR/pjrt/test_collective_ops_tpu.py"
+run_test "$TEST_CDIR/spmd/test_mp_input_sharding.py"
+run_test "$TEST_CDIR/test_mp_collective_matmul.py"
+run_save_tensor_hlo run_test "$TEST_CDIR/spmd/test_spmd_lowering_context.py"
+run_test "$TEST_CDIR/spmd/test_xla_sharding.py"
+run_test "$TEST_CDIR/spmd/test_xla_virtual_device.py"
+run_test "$TEST_CDIR/spmd/test_xla_distributed_checkpoint.py"
+run_test "$TEST_CDIR/spmd/test_train_spmd_linear_model.py"
+run_test "$TEST_CDIR/spmd/test_xla_spmd_python_api_interaction.py"
+run_test "$TEST_CDIR/spmd/test_xla_auto_sharding.py"
+run_test "$TEST_CDIR/spmd/test_fsdp_v2.py"
+run_test "$TEST_CDIR/test_gradient_accumulation.py"
+XLA_EXPERIMENTAL=nonzero:masked_select:nms run_test "$TEST_CDIR/ds/test_dynamic_shape_models.py" -v
+run_test "$TEST_CDIR/test_autocast.py"
+run_test "$TEST_CDIR/test_fp8.py"
+run_test "$TEST_CDIR/test_grad_checkpoint.py"
+run_test "$TEST_CDIR/test_grad_checkpoint.py" "$@" --test_autocast
+run_test "$TEST_CDIR/dynamo/test_dynamo.py"
+run_test "$TEST_CDIR/dynamo/test_dynamo_dynamic_shape.py"
+run_test "$TEST_CDIR/spmd/test_spmd_debugging.py"
+XLA_PARAMETER_WRAPPING_THREADSHOLD=1 run_test "$TEST_CDIR/spmd/test_spmd_parameter_wrapping.py"
+run_test "$TEST_CDIR/pjrt/test_dtypes.py"
+run_test "$TEST_CDIR/pjrt/test_dynamic_plugin_tpu.py"
+run_test "$TEST_CDIR/test_while_loop.py"
+run_test "$TEST_CDIR/scan/test_scan.py"
+run_test "$TEST_CDIR/scan/test_scan_spmd.py"
+run_test "$TEST_CDIR/scan/test_scan_pallas.py"
+run_test "$TEST_CDIR/scan/test_scan_layers.py"
+run_test "$TEST_CDIR/test_gru.py"
+run_test "$TEST_CDIR/test_assume_pure.py"
+run_test "$TEST_CDIR/test_assume_pure_spmd.py"
+run_test "$TEST_CDIR/test_as_stride_use_slice.py"
+run_xla_hlo_debug run_test "$TEST_CDIR/scan/test_scan_debug.py"
+run_test "$TEST_CDIR/test_pallas.py" -v
+run_test "$TEST_CDIR/test_pallas_spmd.py"
+XLA_DISABLE_FUNCTIONALIZATION=1 run_test "$TEST_CDIR/test_pallas_spmd.py"
+run_test "$TEST_CDIR/test_splash_attention.py"
+run_test "$TEST_CDIR/test_profiler_session.py"
+run_test "$TEST_CDIR/test_multi_queries_paged_attention_kernel.py"
+run_test "$TEST_CDIR/test_ragged_paged_attention_kernel.py"
+run_test "$TEST_CDIR/test_input_output_aliases.py"
+run_test "$TEST_CDIR/test_gmm.py"
+run_test "$TEST_CDIR/eager/test_eager_spmd.py"
+run_test "$TEST_CDIR/torch_distributed/test_torch_distributed_all_gather_xla_backend.py"
+run_test "$TEST_CDIR/torch_distributed/test_torch_distributed_all_reduce_xla_backend.py"
+run_test "$TEST_CDIR/torch_distributed/test_torch_distributed_multi_all_reduce_xla_backend.py"
+run_test "$TEST_CDIR/torch_distributed/test_torch_distributed_reduce_scatter_xla_backend.py"
+run_test "$TEST_CDIR/quantized_ops/test_dot_general.py"
+run_xla_ir_hlo_debug run_test "$TEST_CDIR/test_user_computation_debug_cache.py"
+run_test "$TEST_CDIR/test_data_type.py"
+run_test "$TEST_CDIR/test_compilation_cache_utils.py"
 
 # run examples, each test should takes <2 minutes
-python3 "$TEST_CDIR/../examples/data_parallel/train_resnet_spmd_data_parallel.py"
-python3 "$TEST_CDIR/../examples/fsdp/train_decoder_only_fsdp_v2.py"
-python3 "$TEST_CDIR/../examples/train_resnet_amp.py"
-python3 "$TEST_CDIR/../examples/train_decoder_only_base.py"
-python3 "$TEST_CDIR/../examples/train_decoder_only_base.py" scan.decoder_with_scan.DecoderWithScan \
-    --num-steps 30  # TODO(https://github.com/pytorch/xla/issues/8632): Reduce scan tracing overhead
+run_test "$TEST_CDIR/../examples/data_parallel/train_resnet_spmd_data_parallel.py"
+run_test "$TEST_CDIR/../examples/fsdp/train_decoder_only_fsdp_v2.py"
+run_test "$TEST_CDIR/../examples/train_resnet_amp.py"
+run_test "$TEST_CDIR/../examples/train_decoder_only_base.py"
+run_test "$TEST_CDIR/../examples/train_decoder_only_base.py" scan.decoder_with_scan.DecoderWithScan \
+    --num-steps 30 # TODO(https://github.com/pytorch/xla/issues/8632): Reduce scan tracing overhead
 
 # HACK: don't confuse local `torch_xla` folder with installed package
 # Python 3.11 has the permanent fix: https://stackoverflow.com/a/73636559
 # Egaer tests will take more HBM, only run them on TPU v4 CI
 TPU_VERSION=$(python -c "import sys; sys.path.remove(''); import torch_xla; print(torch_xla._internal.tpu.version())")
 if [[ -n "$TPU_VERSION" && "$TPU_VERSION" == "4" ]]; then
-    python3 "$TEST_CDIR/dynamo/test_traceable_collectives.py"
-    python3 "$TEST_CDIR/../examples/data_parallel/train_resnet_xla_ddp.py"
-    python3 "$TEST_CDIR/../examples/fsdp/train_resnet_fsdp_auto_wrap.py"
-    python3 "$TEST_CDIR/../examples/eager/train_decoder_only_eager.py"
-    python3 "$TEST_CDIR/../examples/eager/train_decoder_only_eager_spmd_data_parallel.py"
-    python3 "$TEST_CDIR/../examples/eager/train_decoder_only_eager_with_compile.py"
-    python3 "$TEST_CDIR/../examples/eager/train_decoder_only_eager_multi_process.py"
-    XLA_EXPERIMENTAL=nonzero:masked_select:nms python3 "$TEST_CDIR/ds/test_dynamic_shapes.py" -v
+    run_test "$TEST_CDIR/dynamo/test_traceable_collectives.py"
+    run_test "$TEST_CDIR/../examples/data_parallel/train_resnet_xla_ddp.py"
+    run_test "$TEST_CDIR/../examples/fsdp/train_resnet_fsdp_auto_wrap.py"
+    run_test "$TEST_CDIR/../examples/eager/train_decoder_only_eager.py"
+    run_test "$TEST_CDIR/../examples/eager/train_decoder_only_eager_spmd_data_parallel.py"
+    run_test "$TEST_CDIR/../examples/eager/train_decoder_only_eager_with_compile.py"
+    run_test "$TEST_CDIR/../examples/eager/train_decoder_only_eager_multi_process.py"
+    XLA_EXPERIMENTAL=nonzero:masked_select:nms run_test "$TEST_CDIR/ds/test_dynamic_shapes.py" -v
 fi
 
 if [[ -n "$TPU_VERSION" && "$TPU_VERSION" != "6" ]]; then
     # Test `tpu-info` CLI compatibility
-    python3 "$CDIR/tpu_info/test_cli.py"
+    run_test "$CDIR/tpu_info/test_cli.py"
 fi

--- a/test/utils/run_tests_utils.sh
+++ b/test/utils/run_tests_utils.sh
@@ -43,6 +43,46 @@ function parse_options_to_vars {
   done
 }
 
+# Given $1 as a (possibly not normalized) test filepath, returns successfully
+# if it matches any of the space-separated globs $_TEST_FILTER. If
+# $_TEST_FILTER is empty, returns successfully.
+function test_is_selected {
+  if [[ -z "$_TEST_FILTER" ]]; then
+    return 0 # success
+  fi
+
+  # _TEST_FILTER is a space-separate list of globs. Loop through the
+  # list elements.
+  for _FILTER in $_TEST_FILTER; do
+    # realpath normalizes the paths (e.g. resolving `..` and relative paths)
+    # so that they can be compared.
+    case $(realpath $1) in
+    $(realpath $_FILTER))
+      return 0 # success
+      ;;
+    *)
+      # No match
+      ;;
+    esac
+  done
+
+  return 1 # failure
+}
+
+# Sets $_TEST_FILTER based on the commandline arguments.
+function set_test_filter {
+  if [[ $# -ge 1 ]]; then
+    # There are positional arguments - set $_TEST_FILTER to them.
+    _TEST_FILTER=$@
+    # Sometimes a test may fail even if it doesn't match _TEST_FILTER. Therefore,
+    # we need to set this to be able to get to the test(s) we want to run.
+    CONTINUE_ON_ERROR=1
+  else
+    # No positional argument - run all tests.
+    _TEST_FILTER=""
+  fi
+}
+
 # Run a test with tensor saving enabled, using a specified graph format. The
 # graph dump files are cleaned after the test. In case the test crashes, the
 # file is retained.

--- a/test/utils/run_tests_utils.sh
+++ b/test/utils/run_tests_utils.sh
@@ -1,6 +1,48 @@
 #!/bin/bash
 set -exo pipefail
 
+# Parses the commandline flags and sets correponding environment variables.
+function parse_options_to_vars {
+  # Default option values. Can be overridden via commandline flags.
+  LOGFILE=/tmp/pytorch_py_test.log
+  MAX_GRAPH_SIZE=500
+  GRAPH_CHECK_FREQUENCY=100
+  VERBOSITY=2
+
+  # Parse commandline flags:
+  #   -L
+  #      disable writing to the log file at $LOGFILE.
+  #   -M max_graph_size
+  #   -C graph_check_frequency
+  #   -V verbosity
+  #   -h
+  #      print the help string
+  while getopts 'LM:C:V:h' OPTION
+  do
+    case $OPTION in
+      L)
+        LOGFILE=
+        ;;
+      M)
+        MAX_GRAPH_SIZE=$OPTARG
+        ;;
+      C)
+        GRAPH_CHECK_FREQUENCY=$OPTARG
+        ;;
+      V)
+        VERBOSITY=$OPTARG
+        ;;
+      h)
+        echo -e "Usage: $0 TEST_FILTER...\nwhere TEST_FILTERs are globs match .py test files. If no test filter is provided, runs all tests."
+        exit 0
+        ;;
+      \?)  # This catches all invalid options.
+        echo "ERROR: Invalid commandline flag."
+        exit 1
+    esac
+  done
+}
+
 # Run a test with tensor saving enabled, using a specified graph format. The
 # graph dump files are cleaned after the test. In case the test crashes, the
 # file is retained.


### PR DESCRIPTION
Closes: https://github.com/pytorch/xla/issues/9185

Make `test/tpu/run_tests.sh` and `test/neuron/run_tests.sh` support `-h` (for printing the usage) and test selection, consistent with `test/run_tests.sh`.

Also refactors to reduce code duplication.

Also fix mistakes in comments.