### PR TITLE
[torchax]: JittableModule statedict handling

### DIFF
--- a/torchax/test/test_statedict.py
+++ b/torchax/test/test_statedict.py
@@ -1,36 +1,54 @@
-
-    
 import unittest
 import torch
 from torch.utils import _pytree as pytree
 
-from torchax import (
-    interop,
-    mesh_util,
-    tensor
-)
+from torchax import (interop, mesh_util, tensor)
 
 
 class Model(torch.nn.Module):
-    def __init__(self):
-        super(Model, self).__init__()
-        self.linear = torch.nn.Linear(10, 5)
 
-    def forward(self, x):
-        return self.linear(x)
-    
+  def __init__(self):
+    super(Model, self).__init__()
+    self.linear = torch.nn.Linear(10, 5)
+
+  def forward(self, x):
+    return self.linear(x)
+
+
+mesh = mesh_util.Mesh.fsdp_mesh()
+model = interop.JittableModule(mesh.initialize_model_sharded(Model, ()))
+
 
 class TestTensorStateDict(unittest.TestCase):
-    def test_load_statedict(self):
-        mesh = mesh_util.Mesh.fsdp_mesh()
-        model = mesh.initialize_model_sharded(Model, ())
-        model = interop.JittableModule(model)        
-        state_dict = model.cpu_state_dict()
-        is_xla_tensor = pytree.tree_map(
-            lambda t: isinstance(t, tensor.Tensor),
-            state_dict
-        )
-        assert not any(is_xla_tensor.values()), "State dict should not contain XLA tensors"
+
+  def test_get_statedict(self):
+    state_dict_cpu = model.cpu_state_dict()
+    is_xla_tensor = pytree.tree_map(lambda t: isinstance(t, tensor.Tensor),
+                                    state_dict_cpu)
+    assert not any(
+        is_xla_tensor.values()), "State dict should not contain XLA tensors"
+
+  def test_load_statedict(self):
+    state_dict_cpu = model.cpu_state_dict()
+    state_dict_cpu = pytree.tree_map(torch.zeros_like, state_dict_cpu)
+    model.load_state_dict(state_dict_cpu)
+    is_zeros = pytree.tree_map(lambda t: torch.equal(t, torch.zeros_like(t)),
+                               state_dict_cpu)
+    assert all(is_zeros.values()), "State dict should be zeros"
+
+  def test_load_statedict_partial(self):
+    state_dict_cpu = model.cpu_state_dict()
+    del state_dict_cpu['_model.linear.bias']
+    state_dict_cpu = pytree.tree_map(torch.ones_like, state_dict_cpu)
+    key_check = model.load_state_dict(state_dict_cpu, strict=False)
+    assert key_check.missing_keys == [
+        '_model.linear.bias'
+    ], "Missing keys should be '_model.linear.bias'"
+    linear_weight = model.state_dict()['_model.linear.weight']
+    assert torch.equal(
+        linear_weight,
+        torch.ones_like(linear_weight)), "Linear weight should be ones"
+
 
 if __name__ == '__main__':
-    unittest.main()
+  unittest.main()

--- a/torchax/test/test_statedict.py
+++ b/torchax/test/test_statedict.py
@@ -1,0 +1,36 @@
+
+    
+import unittest
+import torch
+from torch.utils import _pytree as pytree
+
+from torchax import (
+    interop,
+    mesh_util,
+    tensor
+)
+
+
+class Model(torch.nn.Module):
+    def __init__(self):
+        super(Model, self).__init__()
+        self.linear = torch.nn.Linear(10, 5)
+
+    def forward(self, x):
+        return self.linear(x)
+    
+
+class TestTensorStateDict(unittest.TestCase):
+    def test_load_statedict(self):
+        mesh = mesh_util.Mesh.fsdp_mesh()
+        model = mesh.initialize_model_sharded(Model, ())
+        model = interop.JittableModule(model)        
+        state_dict = model.cpu_state_dict()
+        is_xla_tensor = pytree.tree_map(
+            lambda t: isinstance(t, tensor.Tensor),
+            state_dict
+        )
+        assert not any(is_xla_tensor.values()), "State dict should not contain XLA tensors"
+
+if __name__ == '__main__':
+    unittest.main()

--- a/torchax/torchax/interop.py
+++ b/torchax/torchax/interop.py
@@ -125,6 +125,14 @@ class JittableModule(torch.nn.Module):
       return jitted(self.params, self.buffers, *args, **kwargs)
 
     self._jitted[key] = call
+    
+  def cpu_state_dict(self, *args, **kwargs):
+    state_dict = super().state_dict(*args, **kwargs)
+    state_dict = pytree.tree_map(
+      lambda t: t.cpu(),
+      state_dict
+    )
+    return state_dict
 
 
 class CompileMixin:


### PR DESCRIPTION
torchax aims to improve seamless interoperability between torch and jax

one of the parts in torch training pipeline revolves around storing and loading statedict (checkpoints)

most of the objects revolving torch checkpoints expect a (non nested) dict containing weight name and it's value (in either CPU or GPU device)

since torchax tensors are held in jax container, torch checkpointers cannot easily handle it

this changes forces JittableModule to convert state_dict() functions (both load and get), making it seamless to the user when he wants to extract the statdict prior to saving it as a checkpoint