### PR TITLE
Clean up env var usages in run_tests.sh scripts.

### DIFF
--- a/test/neuron/run_tests.sh
+++ b/test/neuron/run_tests.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -exo pipefail
-CDIR="$(cd "$(dirname "$0")"/../ ; pwd -P)"
+_TEST_DIR="$(cd "$(dirname "$0")"/../ ; pwd -P)"
 
 # Utils file
-source "${CDIR}/utils/run_tests_utils.sh"
+source "${_TEST_DIR}/utils/run_tests_utils.sh"
 
 parse_options_to_vars $@
 
@@ -20,15 +20,13 @@ if [[ "$CONTINUE_ON_ERROR" == "1" ]]; then
   set +e
 fi
 
-export TRIM_GRAPH_SIZE=$MAX_GRAPH_SIZE
-export TRIM_GRAPH_CHECK_FREQUENCY=$GRAPH_CHECK_FREQUENCY
-export TORCH_TEST_DEVICES="$CDIR/pytorch_test_base.py"
+export TORCH_TEST_DEVICES="$_TEST_DIR/pytorch_test_base.py"
 export PYTORCH_TEST_WITH_SLOW=1
 export XLA_DUMP_FATAL_STACK=1
 export CPU_NUM_DEVICES=4
 
-TORCH_XLA_DIR=$(cd ~; dirname "$(python -c 'import torch_xla; print(torch_xla.__file__)')")
-COVERAGE_FILE="$CDIR/../.coverage"
+_TORCH_XLA_DIR=$(cd ~; dirname "$(python -c 'import torch_xla; print(torch_xla.__file__)')")
+COVERAGE_FILE="$_TEST_DIR/../.coverage"
 
 function run_coverage {
   if ! test_is_selected "$1"; then
@@ -137,20 +135,20 @@ function run_torchrun {
 }
 
 function run_torch_op_tests {
-  run_dynamic "$CDIR/../../test/test_view_ops.py" "$@" -v TestViewOpsXLA
-  run_test_without_functionalization "$CDIR/../../test/test_view_ops.py" "$@" -v TestViewOpsXLA
-  run_test "$CDIR/../../test/test_torch.py" "$@" -v TestTorchDeviceTypeXLA
-  run_dynamic "$CDIR/../../test/test_torch.py" "$@" -v TestDevicePrecisionXLA
-  run_test "$CDIR/../../test/test_torch.py" "$@" -v TestTensorDeviceOpsXLA
-  run_test "$CDIR/../../test/test_indexing.py" "$@" -v TestIndexingXLA
-  run_test "$CDIR/../../test/test_indexing.py" "$@" -v NumpyTestsXLA
-  # run_dynamic "$CDIR/../../test/test_nn.py" "$@" -v TestNNDeviceTypeXLA
-  run_dynamic "$CDIR/../../test/nn/test_dropout.py" "$@" -v TestDropoutNNDeviceTypeXLA
-  run_dynamic "$CDIR/../../test/nn/test_pooling.py" "$@" -v TestPoolingNNDeviceTypeXLA
-  run_dynamic "$CDIR/../../test/nn/test_embedding.py" "$@" -v TestEmbeddingNNDeviceTypeXLA
-  run_dynamic "$CDIR/../../test/nn/test_convolution.py" "$@" -v TestConvolutionNNDeviceTypeXLA
-  run_dynamic "$CDIR/../../test/nn/test_multihead_attention.py" "$@" -v TestMultiheadAttentionNNDeviceTypeXLA
-  run_dynamic "$CDIR/../../test/test_type_promotion.py" "$@" -v TestTypePromotionXLA
+  run_dynamic "$_TEST_DIR/../../test/test_view_ops.py" "$@" -v TestViewOpsXLA
+  run_test_without_functionalization "$_TEST_DIR/../../test/test_view_ops.py" "$@" -v TestViewOpsXLA
+  run_test "$_TEST_DIR/../../test/test_torch.py" "$@" -v TestTorchDeviceTypeXLA
+  run_dynamic "$_TEST_DIR/../../test/test_torch.py" "$@" -v TestDevicePrecisionXLA
+  run_test "$_TEST_DIR/../../test/test_torch.py" "$@" -v TestTensorDeviceOpsXLA
+  run_test "$_TEST_DIR/../../test/test_indexing.py" "$@" -v TestIndexingXLA
+  run_test "$_TEST_DIR/../../test/test_indexing.py" "$@" -v NumpyTestsXLA
+  # run_dynamic "$_TEST_DIR/../../test/test_nn.py" "$@" -v TestNNDeviceTypeXLA
+  run_dynamic "$_TEST_DIR/../../test/nn/test_dropout.py" "$@" -v TestDropoutNNDeviceTypeXLA
+  run_dynamic "$_TEST_DIR/../../test/nn/test_pooling.py" "$@" -v TestPoolingNNDeviceTypeXLA
+  run_dynamic "$_TEST_DIR/../../test/nn/test_embedding.py" "$@" -v TestEmbeddingNNDeviceTypeXLA
+  run_dynamic "$_TEST_DIR/../../test/nn/test_convolution.py" "$@" -v TestConvolutionNNDeviceTypeXLA
+  run_dynamic "$_TEST_DIR/../../test/nn/test_multihead_attention.py" "$@" -v TestMultiheadAttentionNNDeviceTypeXLA
+  run_dynamic "$_TEST_DIR/../../test/test_type_promotion.py" "$@" -v TestTypePromotionXLA
 }
 
 #######################################################################################
@@ -159,100 +157,100 @@ function run_torch_op_tests {
 
 # DO NOT MODIFY
 function run_xla_op_tests1 {
-  #run_dynamic "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
-  #run_dynamic "$CDIR/ds/test_dynamic_shapes.py"
-  #run_dynamic "$CDIR/ds/test_dynamic_shape_models.py" "$@" --verbosity=$VERBOSITY
-  #run_eager_debug  "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
-  #run_test "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
-  #run_test_without_functionalization "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
-  run_pt_xla_debug "$CDIR/debug_tool/test_pt_xla_debug.py"
-  run_pt_xla_debug_level1 "$CDIR/debug_tool/test_pt_xla_debug.py"
-  run_test "$CDIR/test_xla_graph_execution.py"
-  run_pt_xla_debug_level2 "$CDIR/test_xla_graph_execution.py"
-  run_test "$CDIR/test_async_closures.py"
-  run_test "$CDIR/test_hlo_metadata.py"
-  #run_test "$CDIR/test_profiler.py"
-  run_test "$CDIR/pjrt/test_runtime.py"
-  #NEURONCORE_NUM_DEVICES=2 python "$CDIR/pjrt/test_ddp.py"
-  run_test "$CDIR/pjrt/test_mesh_service.py"
-  #run_test "$CDIR/test_python_ops.py"
-  #run_test "$CDIR/test_ops.py"
-  run_test "$CDIR/test_metrics.py"
-  run_test "$CDIR/test_deprecation.py"
-  run_test "$CDIR/dynamo/test_dynamo_integrations_util.py"
-  #run_test "$CDIR/dynamo/test_dynamo_aliasing.py"
-  run_test "$CDIR/dynamo/test_dynamo.py"
-  run_test "$CDIR/dynamo/test_dynamo_dynamic_shape.py"
-  run_test "$CDIR/dynamo/test_bridge.py"
-  run_test "$CDIR/dynamo/test_num_output.py"
-  run_test "$CDIR/dynamo/test_graph_input_matcher.py"
-  run_test "$CDIR/dynamo/test_dynamo_config.py"
-  run_save_tensor_ir run_test "$CDIR/dynamo/test_dynamo_graph_dump.py"
-  run_test "$CDIR/test_data_type.py"
-  #run_test "$CDIR/test_fp8.py"
-  run_xla_ir_debug "$CDIR/test_env_var_mapper.py"
-  run_xla_hlo_debug "$CDIR/test_env_var_mapper.py"
-  run_xla_hlo_debug "$CDIR/stablehlo/test_stablehlo_save_load.py"
-  run_save_tensor_ir run_test "$CDIR/spmd/test_spmd_graph_dump.py"
-  run_save_tensor_hlo run_test "$CDIR/spmd/test_spmd_graph_dump.py"
-  run_test "$CDIR/test_gradient_accumulation.py"
+  #run_dynamic "$_TEST_DIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  #run_dynamic "$_TEST_DIR/ds/test_dynamic_shapes.py"
+  #run_dynamic "$_TEST_DIR/ds/test_dynamic_shape_models.py" "$@" --verbosity=$VERBOSITY
+  #run_eager_debug  "$_TEST_DIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  #run_test "$_TEST_DIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  #run_test_without_functionalization "$_TEST_DIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  run_pt_xla_debug "$_TEST_DIR/debug_tool/test_pt_xla_debug.py"
+  run_pt_xla_debug_level1 "$_TEST_DIR/debug_tool/test_pt_xla_debug.py"
+  run_test "$_TEST_DIR/test_xla_graph_execution.py"
+  run_pt_xla_debug_level2 "$_TEST_DIR/test_xla_graph_execution.py"
+  run_test "$_TEST_DIR/test_async_closures.py"
+  run_test "$_TEST_DIR/test_hlo_metadata.py"
+  #run_test "$_TEST_DIR/test_profiler.py"
+  run_test "$_TEST_DIR/pjrt/test_runtime.py"
+  #NEURONCORE_NUM_DEVICES=2 python "$_TEST_DIR/pjrt/test_ddp.py"
+  run_test "$_TEST_DIR/pjrt/test_mesh_service.py"
+  #run_test "$_TEST_DIR/test_python_ops.py"
+  #run_test "$_TEST_DIR/test_ops.py"
+  run_test "$_TEST_DIR/test_metrics.py"
+  run_test "$_TEST_DIR/test_deprecation.py"
+  run_test "$_TEST_DIR/dynamo/test_dynamo_integrations_util.py"
+  #run_test "$_TEST_DIR/dynamo/test_dynamo_aliasing.py"
+  run_test "$_TEST_DIR/dynamo/test_dynamo.py"
+  run_test "$_TEST_DIR/dynamo/test_dynamo_dynamic_shape.py"
+  run_test "$_TEST_DIR/dynamo/test_bridge.py"
+  run_test "$_TEST_DIR/dynamo/test_num_output.py"
+  run_test "$_TEST_DIR/dynamo/test_graph_input_matcher.py"
+  run_test "$_TEST_DIR/dynamo/test_dynamo_config.py"
+  run_save_tensor_ir run_test "$_TEST_DIR/dynamo/test_dynamo_graph_dump.py"
+  run_test "$_TEST_DIR/test_data_type.py"
+  #run_test "$_TEST_DIR/test_fp8.py"
+  run_xla_ir_debug "$_TEST_DIR/test_env_var_mapper.py"
+  run_xla_hlo_debug "$_TEST_DIR/test_env_var_mapper.py"
+  run_xla_hlo_debug "$_TEST_DIR/stablehlo/test_stablehlo_save_load.py"
+  run_save_tensor_ir run_test "$_TEST_DIR/spmd/test_spmd_graph_dump.py"
+  run_save_tensor_hlo run_test "$_TEST_DIR/spmd/test_spmd_graph_dump.py"
+  run_test "$_TEST_DIR/test_gradient_accumulation.py"
 }
 
 function run_xla_op_tests2 {
-  run_test "$CDIR/pjrt/test_dtypes.py"
-  #run_test "$CDIR/test_while_loop.py"
-  run_test "$CDIR/scan/test_scan.py"
-  run_xla_hlo_debug "$CDIR/scan/test_scan_debug.py"
-  run_test "$CDIR/test_autocast.py"
-  run_test "$CDIR/test_grad_checkpoint.py"
-  run_test "$CDIR/test_grad_checkpoint.py" "$@" --test_autocast
-  #run_test "$CDIR/eager/test_eager.py"
-  run_test "$CDIR/eager/test_eager_with_xla_compile.py"
-  run_test "$CDIR/eager/test_eager_with_torch_compile.py"
-  #run_test "$CDIR/eager/test_eager_all_reduce_in_place.py"
-  run_test "$CDIR/eager/test_eager_spmd.py"
-  run_test "$CDIR/test_callback.py"
-  XLA_USE_SPMD=1 run_test "$CDIR/test_callback.py"
+  run_test "$_TEST_DIR/pjrt/test_dtypes.py"
+  #run_test "$_TEST_DIR/test_while_loop.py"
+  run_test "$_TEST_DIR/scan/test_scan.py"
+  run_xla_hlo_debug "$_TEST_DIR/scan/test_scan_debug.py"
+  run_test "$_TEST_DIR/test_autocast.py"
+  run_test "$_TEST_DIR/test_grad_checkpoint.py"
+  run_test "$_TEST_DIR/test_grad_checkpoint.py" "$@" --test_autocast
+  #run_test "$_TEST_DIR/eager/test_eager.py"
+  run_test "$_TEST_DIR/eager/test_eager_with_xla_compile.py"
+  run_test "$_TEST_DIR/eager/test_eager_with_torch_compile.py"
+  #run_test "$_TEST_DIR/eager/test_eager_all_reduce_in_place.py"
+  run_test "$_TEST_DIR/eager/test_eager_spmd.py"
+  run_test "$_TEST_DIR/test_callback.py"
+  XLA_USE_SPMD=1 run_test "$_TEST_DIR/test_callback.py"
 }
 
 # All the new xla op tests should go to run_xla_op_tests3
 function run_xla_op_tests3 {
   # TODO(qihqi): this test require tensorflow to run. need to setup separate
   #     CI with tf.
-  run_test "$CDIR/stablehlo/test_exports.py"
-  run_test "$CDIR/stablehlo/test_export_fx_passes.py"
-  run_test "$CDIR/stablehlo/test_implicit_broadcasting.py"
-  run_test "$CDIR/stablehlo/test_composite.py"
-  run_test "$CDIR/stablehlo/test_pt2e_qdq.py"
-  run_test "$CDIR/stablehlo/test_stablehlo_custom_call.py"
-  #run_xla_hlo_debug "$CDIR/stablehlo/test_stablehlo_inference.py"
-  #=run_test "$CDIR/stablehlo/test_stablehlo_compile.py"
-  run_test "$CDIR/stablehlo/test_unbounded_dynamism.py"
-  #run_test "$CDIR/quantized_ops/test_quantized_matmul.py"
-  #run_test "$CDIR/quantized_ops/test_dot_general.py"
-  #run_test "$CDIR/spmd/test_xla_sharding.py"
-  run_test "$CDIR/spmd/test_xla_sharding_hlo.py"
-  #run_test "$CDIR/spmd/test_xla_virtual_device.py"
-  #run_test "$CDIR/spmd/test_dynamo_spmd.py"
-  run_test "$CDIR/spmd/test_spmd_debugging.py"
-  #=run_test "$CDIR/spmd/test_xla_distributed_checkpoint.py"
-  run_test "$CDIR/spmd/test_xla_spmd_python_api_interaction.py"
-  #run_test "$CDIR/spmd/test_dtensor_integration.py"
-  #run_test "$CDIR/spmd/test_dtensor_integration2.py"
-  run_test "$CDIR/spmd/test_xla_auto_sharding.py"
-  #run_test "$CDIR/spmd/test_spmd_parameter_wrapping.py"
-  run_test "$CDIR/spmd/test_train_spmd_linear_model.py"
-  run_test "$CDIR/spmd/test_xla_spmd_python_api_interaction.py"
-  run_test "$CDIR/spmd/test_xla_auto_sharding.py"
-  run_test "$CDIR/spmd/test_fsdp_v2.py"
-  run_test "$CDIR/test_operations_hlo.py" "$@" --verbosity=$VERBOSITY
-  run_test "$CDIR/test_input_output_aliases.py"
-  run_test_without_functionalization "$CDIR/test_input_output_aliases.py"
-  run_test "$CDIR/test_torch_distributed_xla_backend.py"
-  run_torchrun "$CDIR/pjrt/test_torchrun.py"
-  run_test "$CDIR/test_persistent_cache.py"
-  run_test "$CDIR/test_devices.py"
-  run_xla_ir_hlo_debug run_test "$CDIR/test_user_computation_debug_cache.py"
+  run_test "$_TEST_DIR/stablehlo/test_exports.py"
+  run_test "$_TEST_DIR/stablehlo/test_export_fx_passes.py"
+  run_test "$_TEST_DIR/stablehlo/test_implicit_broadcasting.py"
+  run_test "$_TEST_DIR/stablehlo/test_composite.py"
+  run_test "$_TEST_DIR/stablehlo/test_pt2e_qdq.py"
+  run_test "$_TEST_DIR/stablehlo/test_stablehlo_custom_call.py"
+  #run_xla_hlo_debug "$_TEST_DIR/stablehlo/test_stablehlo_inference.py"
+  #=run_test "$_TEST_DIR/stablehlo/test_stablehlo_compile.py"
+  run_test "$_TEST_DIR/stablehlo/test_unbounded_dynamism.py"
+  #run_test "$_TEST_DIR/quantized_ops/test_quantized_matmul.py"
+  #run_test "$_TEST_DIR/quantized_ops/test_dot_general.py"
+  #run_test "$_TEST_DIR/spmd/test_xla_sharding.py"
+  run_test "$_TEST_DIR/spmd/test_xla_sharding_hlo.py"
+  #run_test "$_TEST_DIR/spmd/test_xla_virtual_device.py"
+  #run_test "$_TEST_DIR/spmd/test_dynamo_spmd.py"
+  run_test "$_TEST_DIR/spmd/test_spmd_debugging.py"
+  #=run_test "$_TEST_DIR/spmd/test_xla_distributed_checkpoint.py"
+  run_test "$_TEST_DIR/spmd/test_xla_spmd_python_api_interaction.py"
+  #run_test "$_TEST_DIR/spmd/test_dtensor_integration.py"
+  #run_test "$_TEST_DIR/spmd/test_dtensor_integration2.py"
+  run_test "$_TEST_DIR/spmd/test_xla_auto_sharding.py"
+  #run_test "$_TEST_DIR/spmd/test_spmd_parameter_wrapping.py"
+  run_test "$_TEST_DIR/spmd/test_train_spmd_linear_model.py"
+  run_test "$_TEST_DIR/spmd/test_xla_spmd_python_api_interaction.py"
+  run_test "$_TEST_DIR/spmd/test_xla_auto_sharding.py"
+  run_test "$_TEST_DIR/spmd/test_fsdp_v2.py"
+  run_test "$_TEST_DIR/test_operations_hlo.py" "$@" --verbosity=$VERBOSITY
+  run_test "$_TEST_DIR/test_input_output_aliases.py"
+  run_test_without_functionalization "$_TEST_DIR/test_input_output_aliases.py"
+  run_test "$_TEST_DIR/test_torch_distributed_xla_backend.py"
+  run_torchrun "$_TEST_DIR/pjrt/test_torchrun.py"
+  run_test "$_TEST_DIR/test_persistent_cache.py"
+  run_test "$_TEST_DIR/test_devices.py"
+  run_xla_ir_hlo_debug run_test "$_TEST_DIR/test_user_computation_debug_cache.py"
 
   #python3 examples/data_parallel/train_resnet_xla_ddp.py # compiler error
   #python3 examples/fsdp/train_resnet_fsdp_auto_wrap.py
@@ -264,8 +262,8 @@ function run_xla_op_tests3 {
 
 # Neuron specific tests
 function run_xla_neuron_tests {
-  run_test "$CDIR/neuron/test_neuron_utils.py"
-  run_test "$CDIR/neuron/test_neuron_data_types.py"
+  run_test "$_TEST_DIR/neuron/test_neuron_utils.py"
+  run_test "$_TEST_DIR/neuron/test_neuron_data_types.py"
 }
 
 #######################################################################################
@@ -279,34 +277,34 @@ function run_op_tests {
 }
 
 function run_mp_op_tests {
-  run_test "$CDIR/test_mp_replication.py"
-  #run_test "$CDIR/test_mp_all_to_all.py"
-  PJRT_DEVICE=NEURON NEURONCORE_NUM_DEVICES=8 run_test "$CDIR/test_mp_collective_permute.py"
-  #run_test "$CDIR/test_mp_all_gather.py"  # "wrong reductions"?
-  run_test "$CDIR/test_mp_reduce_scatter.py"
-  run_test "$CDIR/test_zero1.py"
-  run_test "$CDIR/test_mp_distributed_mm.py"
-  run_test "$CDIR/test_mp_save.py"
-  run_test "$CDIR/test_mp_mesh_reduce.py"
-  run_test "$CDIR/test_mp_sync_batch_norm.py"
+  run_test "$_TEST_DIR/test_mp_replication.py"
+  #run_test "$_TEST_DIR/test_mp_all_to_all.py"
+  PJRT_DEVICE=NEURON NEURONCORE_NUM_DEVICES=8 run_test "$_TEST_DIR/test_mp_collective_permute.py"
+  #run_test "$_TEST_DIR/test_mp_all_gather.py"  # "wrong reductions"?
+  run_test "$_TEST_DIR/test_mp_reduce_scatter.py"
+  run_test "$_TEST_DIR/test_zero1.py"
+  run_test "$_TEST_DIR/test_mp_distributed_mm.py"
+  run_test "$_TEST_DIR/test_mp_save.py"
+  run_test "$_TEST_DIR/test_mp_mesh_reduce.py"
+  run_test "$_TEST_DIR/test_mp_sync_batch_norm.py"
   # TODO(JackCaoG): enable this
-  run_test "$CDIR/dynamo/test_traceable_collectives.py"
-  run_test "$CDIR/test_fsdp_auto_wrap.py"
-  # run_torchrun "$CDIR/test_mp_early_exit.py"
-  run_pt_xla_debug "$CDIR/debug_tool/test_mp_pt_xla_debug.py"
-  run_test "$CDIR/torch_distributed/test_torch_distributed_all_gather_xla_backend.py"
-  run_test "$CDIR/torch_distributed/test_torch_distributed_all_reduce_xla_backend.py"
-  #run_test "$CDIR/torch_distributed/test_torch_distributed_bucketed_all_reduce_xla_backend.py" # crash without NEURONCORE_NUM_DEVICES=2
-  run_test "$CDIR/torch_distributed/test_torch_distributed_multi_all_reduce_xla_backend.py"
-  run_test "$CDIR/torch_distributed/test_torch_distributed_reduce_scatter_xla_backend.py"
-  run_test "$CDIR/torch_distributed/test_ddp.py"
-  #run_test "$CDIR/torch_distributed/test_torch_distributed_fsdp_meta.py" # crash without NEURONCORE_NUM_DEVICES=2
-  PJRT_DEVICE=NEURON NEURONCORE_NUM_DEVICES=2 python3 $CDIR/torch_distributed/test_torch_distributed_all_gather_xla_backend.py
-  PJRT_DEVICE=NEURON NEURONCORE_NUM_DEVICES=2 python3 $CDIR/torch_distributed/test_torch_distributed_all_reduce_xla_backend.py
-  PJRT_DEVICE=NEURON NEURONCORE_NUM_DEVICES=2 python3 $CDIR/torch_distributed/test_torch_distributed_bucketed_all_reduce_xla_backend.py
-  PJRT_DEVICE=NEURON NEURONCORE_NUM_DEVICES=2 python3 $CDIR/torch_distributed/test_torch_distributed_multi_all_reduce_xla_backend.py
-  PJRT_DEVICE=NEURON NEURONCORE_NUM_DEVICES=2 python3 $CDIR/torch_distributed/test_torch_distributed_reduce_scatter_xla_backend.py
-  PJRT_DEVICE=NEURON NEURONCORE_NUM_DEVICES=2 python3 $CDIR/torch_distributed/test_torch_distributed_fsdp_meta.py
+  run_test "$_TEST_DIR/dynamo/test_traceable_collectives.py"
+  run_test "$_TEST_DIR/test_fsdp_auto_wrap.py"
+  # run_torchrun "$_TEST_DIR/test_mp_early_exit.py"
+  run_pt_xla_debug "$_TEST_DIR/debug_tool/test_mp_pt_xla_debug.py"
+  run_test "$_TEST_DIR/torch_distributed/test_torch_distributed_all_gather_xla_backend.py"
+  run_test "$_TEST_DIR/torch_distributed/test_torch_distributed_all_reduce_xla_backend.py"
+  #run_test "$_TEST_DIR/torch_distributed/test_torch_distributed_bucketed_all_reduce_xla_backend.py" # crash without NEURONCORE_NUM_DEVICES=2
+  run_test "$_TEST_DIR/torch_distributed/test_torch_distributed_multi_all_reduce_xla_backend.py"
+  run_test "$_TEST_DIR/torch_distributed/test_torch_distributed_reduce_scatter_xla_backend.py"
+  run_test "$_TEST_DIR/torch_distributed/test_ddp.py"
+  #run_test "$_TEST_DIR/torch_distributed/test_torch_distributed_fsdp_meta.py" # crash without NEURONCORE_NUM_DEVICES=2
+  PJRT_DEVICE=NEURON NEURONCORE_NUM_DEVICES=2 python3 $_TEST_DIR/torch_distributed/test_torch_distributed_all_gather_xla_backend.py
+  PJRT_DEVICE=NEURON NEURONCORE_NUM_DEVICES=2 python3 $_TEST_DIR/torch_distributed/test_torch_distributed_all_reduce_xla_backend.py
+  PJRT_DEVICE=NEURON NEURONCORE_NUM_DEVICES=2 python3 $_TEST_DIR/torch_distributed/test_torch_distributed_bucketed_all_reduce_xla_backend.py
+  PJRT_DEVICE=NEURON NEURONCORE_NUM_DEVICES=2 python3 $_TEST_DIR/torch_distributed/test_torch_distributed_multi_all_reduce_xla_backend.py
+  PJRT_DEVICE=NEURON NEURONCORE_NUM_DEVICES=2 python3 $_TEST_DIR/torch_distributed/test_torch_distributed_reduce_scatter_xla_backend.py
+  PJRT_DEVICE=NEURON NEURONCORE_NUM_DEVICES=2 python3 $_TEST_DIR/torch_distributed/test_torch_distributed_fsdp_meta.py
 }
 
 function run_tests {

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -2,13 +2,13 @@
 set -exo pipefail
 
 # Absolute path to the directory of this script.
-CDIR="$(
+_TEST_DIR="$(
   cd "$(dirname "$0")"
   pwd -P
 )"
 
 # Import utilities.
-source "${CDIR}/utils/run_tests_utils.sh"
+source "${_TEST_DIR}/utils/run_tests_utils.sh"
 
 parse_options_to_vars $@
 
@@ -23,25 +23,23 @@ if [[ "$CONTINUE_ON_ERROR" == "1" ]]; then
   set +e
 fi
 
-export TRIM_GRAPH_SIZE=$MAX_GRAPH_SIZE
-export TRIM_GRAPH_CHECK_FREQUENCY=$GRAPH_CHECK_FREQUENCY
-export TORCH_TEST_DEVICES="$CDIR/pytorch_test_base.py"
+export TORCH_TEST_DEVICES="$_TEST_DIR/pytorch_test_base.py"
 export PYTORCH_TEST_WITH_SLOW=1
 export XLA_DUMP_FATAL_STACK=1
 export CPU_NUM_DEVICES=4
 
-TORCH_XLA_DIR=$(
+_TORCH_XLA_DIR=$(
   cd ~
   dirname "$(python -c 'import torch_xla; print(torch_xla.__file__)')"
 )
-COVERAGE_FILE="$CDIR/../.coverage"
+COVERAGE_FILE="$_TEST_DIR/../.coverage"
 
 function run_coverage {
   if ! test_is_selected "$1"; then
     return
   fi
   if [ "${USE_COVERAGE:-0}" != "0" ]; then
-    coverage run --source="$TORCH_XLA_DIR" -p "$@"
+    coverage run --source="$_TORCH_XLA_DIR" -p "$@"
   else
     python3 "$@"
   fi
@@ -150,20 +148,20 @@ function run_torchrun {
 }
 
 function run_torch_op_tests {
-  run_dynamic "$CDIR/../../test/test_view_ops.py" "$@" -v TestViewOpsXLA
-  run_test_without_functionalization "$CDIR/../../test/test_view_ops.py" "$@" -v TestViewOpsXLA
-  run_test "$CDIR/../../test/test_torch.py" "$@" -v TestTorchDeviceTypeXLA
-  run_dynamic "$CDIR/../../test/test_torch.py" "$@" -v TestDevicePrecisionXLA
-  run_test "$CDIR/../../test/test_torch.py" "$@" -v TestTensorDeviceOpsXLA
-  run_test "$CDIR/../../test/test_indexing.py" "$@" -v TestIndexingXLA
-  run_test "$CDIR/../../test/test_indexing.py" "$@" -v NumpyTestsXLA
-  # run_dynamic "$CDIR/../../test/test_nn.py" "$@" -v TestNNDeviceTypeXLA
-  run_dynamic "$CDIR/../../test/nn/test_dropout.py" "$@" -v TestDropoutNNDeviceTypeXLA
-  run_dynamic "$CDIR/../../test/nn/test_pooling.py" "$@" -v TestPoolingNNDeviceTypeXLA
-  run_dynamic "$CDIR/../../test/nn/test_embedding.py" "$@" -v TestEmbeddingNNDeviceTypeXLA
-  run_dynamic "$CDIR/../../test/nn/test_convolution.py" "$@" -v TestConvolutionNNDeviceTypeXLA
-  run_dynamic "$CDIR/../../test/nn/test_multihead_attention.py" "$@" -v TestMultiheadAttentionNNDeviceTypeXLA
-  run_dynamic "$CDIR/../../test/test_type_promotion.py" "$@" -v TestTypePromotionXLA
+  run_dynamic "$_TEST_DIR/../../test/test_view_ops.py" "$@" -v TestViewOpsXLA
+  run_test_without_functionalization "$_TEST_DIR/../../test/test_view_ops.py" "$@" -v TestViewOpsXLA
+  run_test "$_TEST_DIR/../../test/test_torch.py" "$@" -v TestTorchDeviceTypeXLA
+  run_dynamic "$_TEST_DIR/../../test/test_torch.py" "$@" -v TestDevicePrecisionXLA
+  run_test "$_TEST_DIR/../../test/test_torch.py" "$@" -v TestTensorDeviceOpsXLA
+  run_test "$_TEST_DIR/../../test/test_indexing.py" "$@" -v TestIndexingXLA
+  run_test "$_TEST_DIR/../../test/test_indexing.py" "$@" -v NumpyTestsXLA
+  # run_dynamic "$_TEST_DIR/../../test/test_nn.py" "$@" -v TestNNDeviceTypeXLA
+  run_dynamic "$_TEST_DIR/../../test/nn/test_dropout.py" "$@" -v TestDropoutNNDeviceTypeXLA
+  run_dynamic "$_TEST_DIR/../../test/nn/test_pooling.py" "$@" -v TestPoolingNNDeviceTypeXLA
+  run_dynamic "$_TEST_DIR/../../test/nn/test_embedding.py" "$@" -v TestEmbeddingNNDeviceTypeXLA
+  run_dynamic "$_TEST_DIR/../../test/nn/test_convolution.py" "$@" -v TestConvolutionNNDeviceTypeXLA
+  run_dynamic "$_TEST_DIR/../../test/nn/test_multihead_attention.py" "$@" -v TestMultiheadAttentionNNDeviceTypeXLA
+  run_dynamic "$_TEST_DIR/../../test/test_type_promotion.py" "$@" -v TestTypePromotionXLA
 }
 
 #######################################################################################
@@ -172,144 +170,144 @@ function run_torch_op_tests {
 
 # DO NOT MODIFY
 function run_xla_op_tests1 {
-  run_dynamic "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
-  run_dynamic "$CDIR/ds/test_dynamic_shapes.py"
-  run_dynamic "$CDIR/ds/test_dynamic_shape_models.py" "$@" --verbosity=$VERBOSITY
-  run_eager_debug "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
-  run_test "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
-  run_test "$CDIR/test_xla_graph_execution.py" "$@" --verbosity=$VERBOSITY
-  run_pt_xla_debug_level2 "$CDIR/test_xla_graph_execution.py" "$@" --verbosity=$VERBOSITY
-  run_test_without_functionalization "$CDIR/test_operations.py" "$@" --verbosity=$VERBOSITY
-  run_pt_xla_debug "$CDIR/debug_tool/test_pt_xla_debug.py"
-  run_pt_xla_debug_level1 "$CDIR/debug_tool/test_pt_xla_debug.py"
-  run_test "$CDIR/test_async_closures.py"
-  run_test "$CDIR/test_hlo_metadata.py"
+  run_dynamic "$_TEST_DIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  run_dynamic "$_TEST_DIR/ds/test_dynamic_shapes.py"
+  run_dynamic "$_TEST_DIR/ds/test_dynamic_shape_models.py" "$@" --verbosity=$VERBOSITY
+  run_eager_debug "$_TEST_DIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  run_test "$_TEST_DIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  run_test "$_TEST_DIR/test_xla_graph_execution.py" "$@" --verbosity=$VERBOSITY
+  run_pt_xla_debug_level2 "$_TEST_DIR/test_xla_graph_execution.py" "$@" --verbosity=$VERBOSITY
+  run_test_without_functionalization "$_TEST_DIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  run_pt_xla_debug "$_TEST_DIR/debug_tool/test_pt_xla_debug.py"
+  run_pt_xla_debug_level1 "$_TEST_DIR/debug_tool/test_pt_xla_debug.py"
+  run_test "$_TEST_DIR/test_async_closures.py"
+  run_test "$_TEST_DIR/test_hlo_metadata.py"
   # TODO(https://github.com/pytorch/xla/issues/8796): Re-enable this test
-  # run_test "$CDIR/test_profiler.py"
-  run_test "$CDIR/test_profiler_session.py"
-  run_test "$CDIR/pjrt/test_runtime.py"
-  run_test "$CDIR/pjrt/test_runtime_single_proc_gpu.py"
+  # run_test "$_TEST_DIR/test_profiler.py"
+  run_test "$_TEST_DIR/test_profiler_session.py"
+  run_test "$_TEST_DIR/pjrt/test_runtime.py"
+  run_test "$_TEST_DIR/pjrt/test_runtime_single_proc_gpu.py"
 
   # TODO(https://github.com/pytorch/xla/issues/9066): GPU testing disabled to unblock pin update.
   # Re-enable this test on GPU.
-  # run_test "$CDIR/pjrt/test_runtime_multi_gpu.py"
+  # run_test "$_TEST_DIR/pjrt/test_runtime_multi_gpu.py"
 
-  run_test "$CDIR/pjrt/test_runtime_multi_cpu.py"
-  run_test "$CDIR/pjrt/test_internal_tpu.py"
-
-  # TODO(https://github.com/pytorch/xla/issues/9066): GPU testing disabled to unblock pin update.
-  # Re-enable this test on GPU.
-  PJRT_DEVICE=CPU XLA_CUDA=0 run_test "$CDIR/pjrt/test_ddp.py"
+  run_test "$_TEST_DIR/pjrt/test_runtime_multi_cpu.py"
+  run_test "$_TEST_DIR/pjrt/test_internal_tpu.py"
 
   # TODO(https://github.com/pytorch/xla/issues/9066): GPU testing disabled to unblock pin update.
   # Re-enable this test on GPU.
-  PJRT_DEVICE=CPU XLA_CUDA=0 run_test "$CDIR/pjrt/test_mesh_service.py"
+  PJRT_DEVICE=CPU XLA_CUDA=0 run_test "$_TEST_DIR/pjrt/test_ddp.py"
 
-  run_test "$CDIR/test_python_ops.py"
-  run_test "$CDIR/test_ops.py"
-  run_test "$CDIR/test_metrics.py"
+  # TODO(https://github.com/pytorch/xla/issues/9066): GPU testing disabled to unblock pin update.
+  # Re-enable this test on GPU.
+  PJRT_DEVICE=CPU XLA_CUDA=0 run_test "$_TEST_DIR/pjrt/test_mesh_service.py"
+
+  run_test "$_TEST_DIR/test_python_ops.py"
+  run_test "$_TEST_DIR/test_ops.py"
+  run_test "$_TEST_DIR/test_metrics.py"
   if [ -f "/tmp/metrics.txt" ]; then
     rm /tmp/metrics.txt
   fi
-  XLA_METRICS_FILE=/tmp/metrics.txt run_test "$CDIR/test_metrics.py"
-  run_test "$CDIR/test_deprecation.py"
-  run_test "$CDIR/dynamo/test_dynamo_integrations_util.py"
-  run_test "$CDIR/dynamo/test_dynamo_aliasing.py"
-  run_test "$CDIR/dynamo/test_dynamo.py"
-  run_test "$CDIR/dynamo/test_dynamo_dynamic_shape.py"
-  run_test "$CDIR/dynamo/test_bridge.py"
-  run_test "$CDIR/dynamo/test_num_output.py"
-  run_test "$CDIR/dynamo/test_graph_input_matcher.py"
-  run_test "$CDIR/dynamo/test_dynamo_config.py"
-  run_save_tensor_ir run_test "$CDIR/dynamo/test_dynamo_graph_dump.py"
-  run_test "$CDIR/test_data_type.py"
-  run_test "$CDIR/test_fp8.py"
-  run_xla_ir_debug run_test "$CDIR/test_env_var_mapper.py"
-  run_xla_hlo_debug run_test "$CDIR/test_env_var_mapper.py"
-  run_xla_hlo_debug run_test "$CDIR/stablehlo/test_stablehlo_save_load.py"
-  run_save_tensor_ir run_test "$CDIR/spmd/test_spmd_graph_dump.py"
-  run_save_tensor_hlo run_test "$CDIR/spmd/test_spmd_graph_dump.py"
+  XLA_METRICS_FILE=/tmp/metrics.txt run_test "$_TEST_DIR/test_metrics.py"
+  run_test "$_TEST_DIR/test_deprecation.py"
+  run_test "$_TEST_DIR/dynamo/test_dynamo_integrations_util.py"
+  run_test "$_TEST_DIR/dynamo/test_dynamo_aliasing.py"
+  run_test "$_TEST_DIR/dynamo/test_dynamo.py"
+  run_test "$_TEST_DIR/dynamo/test_dynamo_dynamic_shape.py"
+  run_test "$_TEST_DIR/dynamo/test_bridge.py"
+  run_test "$_TEST_DIR/dynamo/test_num_output.py"
+  run_test "$_TEST_DIR/dynamo/test_graph_input_matcher.py"
+  run_test "$_TEST_DIR/dynamo/test_dynamo_config.py"
+  run_save_tensor_ir run_test "$_TEST_DIR/dynamo/test_dynamo_graph_dump.py"
+  run_test "$_TEST_DIR/test_data_type.py"
+  run_test "$_TEST_DIR/test_fp8.py"
+  run_xla_ir_debug run_test "$_TEST_DIR/test_env_var_mapper.py"
+  run_xla_hlo_debug run_test "$_TEST_DIR/test_env_var_mapper.py"
+  run_xla_hlo_debug run_test "$_TEST_DIR/stablehlo/test_stablehlo_save_load.py"
+  run_save_tensor_ir run_test "$_TEST_DIR/spmd/test_spmd_graph_dump.py"
+  run_save_tensor_hlo run_test "$_TEST_DIR/spmd/test_spmd_graph_dump.py"
 }
 
 function run_xla_op_tests2 {
-  run_test "$CDIR/pjrt/test_dtypes.py"
-  run_test "$CDIR/test_while_loop.py"
-  run_test "$CDIR/scan/test_scan.py"
-  run_test "$CDIR/scan/test_scan_spmd.py"
-  run_test "$CDIR/scan/test_scan_layers.py"
-  run_test "$CDIR/test_gru.py"
-  run_test "$CDIR/test_as_stride_use_slice.py"
-  run_test "$CDIR/test_placeholder.py"
-  run_xla_hlo_debug run_test "$CDIR/scan/test_scan_debug.py"
-  run_test "$CDIR/test_autocast.py"
-  run_test "$CDIR/eager/test_eager.py"
-  run_test "$CDIR/eager/test_eager_with_xla_compile.py"
-  run_test "$CDIR/eager/test_eager_with_torch_compile.py"
+  run_test "$_TEST_DIR/pjrt/test_dtypes.py"
+  run_test "$_TEST_DIR/test_while_loop.py"
+  run_test "$_TEST_DIR/scan/test_scan.py"
+  run_test "$_TEST_DIR/scan/test_scan_spmd.py"
+  run_test "$_TEST_DIR/scan/test_scan_layers.py"
+  run_test "$_TEST_DIR/test_gru.py"
+  run_test "$_TEST_DIR/test_as_stride_use_slice.py"
+  run_test "$_TEST_DIR/test_placeholder.py"
+  run_xla_hlo_debug run_test "$_TEST_DIR/scan/test_scan_debug.py"
+  run_test "$_TEST_DIR/test_autocast.py"
+  run_test "$_TEST_DIR/eager/test_eager.py"
+  run_test "$_TEST_DIR/eager/test_eager_with_xla_compile.py"
+  run_test "$_TEST_DIR/eager/test_eager_with_torch_compile.py"
 
   # TODO(https://github.com/pytorch/xla/issues/9066): GPU testing disabled to unblock pin update.
   # Re-enable this test on GPU.
-  PJRT_DEVICE=CPU XLA_CUDA=0 run_test "$CDIR/eager/test_eager_all_reduce_in_place.py"
+  PJRT_DEVICE=CPU XLA_CUDA=0 run_test "$_TEST_DIR/eager/test_eager_all_reduce_in_place.py"
 
-  run_test "$CDIR/eager/test_eager_spmd.py"
-  run_test "$CDIR/test_callback.py"
-  XLA_USE_SPMD=1 run_test "$CDIR/test_callback.py"
-  run_test "$CDIR/test_jax_interop.py"
-  run_test "$CDIR/test_assume_pure.py"
-  run_test "$CDIR/test_assume_pure_spmd.py"
-  run_test "$CDIR/test_assume_pure_torch.py"
+  run_test "$_TEST_DIR/eager/test_eager_spmd.py"
+  run_test "$_TEST_DIR/test_callback.py"
+  XLA_USE_SPMD=1 run_test "$_TEST_DIR/test_callback.py"
+  run_test "$_TEST_DIR/test_jax_interop.py"
+  run_test "$_TEST_DIR/test_assume_pure.py"
+  run_test "$_TEST_DIR/test_assume_pure_spmd.py"
+  run_test "$_TEST_DIR/test_assume_pure_torch.py"
 }
 
 # All the new xla op tests should go to run_xla_op_tests3
 function run_xla_op_tests3 {
   # TODO(qihqi): this test require tensorflow to run. need to setup separate
   #     CI with tf.
-  run_test "$CDIR/stablehlo/test_exports.py"
-  run_test "$CDIR/stablehlo/test_export_fx_passes.py"
-  run_test "$CDIR/stablehlo/test_implicit_broadcasting.py"
-  run_test "$CDIR/stablehlo/test_composite.py"
-  run_test "$CDIR/stablehlo/test_pt2e_qdq.py"
-  run_test "$CDIR/stablehlo/test_stablehlo_custom_call.py"
-  run_xla_hlo_debug run_test "$CDIR/stablehlo/test_stablehlo_inference.py"
-  run_test "$CDIR/stablehlo/test_stablehlo_compile.py"
-  run_test "$CDIR/stablehlo/test_unbounded_dynamism.py"
-  run_test "$CDIR/quantized_ops/test_quantized_matmul.py"
-  run_test "$CDIR/quantized_ops/test_dot_general.py"
-  run_test "$CDIR/spmd/test_xla_sharding.py"
-  run_test "$CDIR/spmd/test_xla_sharding_hlo.py"
-  run_test "$CDIR/spmd/test_xla_virtual_device.py"
-  run_test "$CDIR/spmd/test_dynamo_spmd.py"
-  run_test "$CDIR/spmd/test_spmd_debugging.py"
-  run_test "$CDIR/spmd/test_xla_distributed_checkpoint.py"
-  run_test "$CDIR/spmd/test_xla_spmd_python_api_interaction.py"
-  run_test "$CDIR/spmd/test_dtensor_integration.py"
-  run_test "$CDIR/spmd/test_dtensor_integration2.py"
-  run_test "$CDIR/spmd/test_xla_auto_sharding.py"
-  run_test "$CDIR/spmd/test_spmd_parameter_wrapping.py"
-  run_test "$CDIR/spmd/test_mp_input_sharding.py"
-  run_test "$CDIR/spmd/test_train_spmd_linear_model.py" "$@" --skip-gradient-checkpointing
-  run_test "$CDIR/test_gradient_accumulation.py"
-  run_save_tensor_hlo run_test "$CDIR/spmd/test_spmd_lowering_context.py"
-  run_test "$CDIR/test_operations_hlo.py" "$@" --verbosity=$VERBOSITY
-  run_test "$CDIR/test_input_output_aliases.py"
-  run_test_without_functionalization "$CDIR/test_input_output_aliases.py"
-  run_test "$CDIR/test_torch_distributed_xla_backend.py"
+  run_test "$_TEST_DIR/stablehlo/test_exports.py"
+  run_test "$_TEST_DIR/stablehlo/test_export_fx_passes.py"
+  run_test "$_TEST_DIR/stablehlo/test_implicit_broadcasting.py"
+  run_test "$_TEST_DIR/stablehlo/test_composite.py"
+  run_test "$_TEST_DIR/stablehlo/test_pt2e_qdq.py"
+  run_test "$_TEST_DIR/stablehlo/test_stablehlo_custom_call.py"
+  run_xla_hlo_debug run_test "$_TEST_DIR/stablehlo/test_stablehlo_inference.py"
+  run_test "$_TEST_DIR/stablehlo/test_stablehlo_compile.py"
+  run_test "$_TEST_DIR/stablehlo/test_unbounded_dynamism.py"
+  run_test "$_TEST_DIR/quantized_ops/test_quantized_matmul.py"
+  run_test "$_TEST_DIR/quantized_ops/test_dot_general.py"
+  run_test "$_TEST_DIR/spmd/test_xla_sharding.py"
+  run_test "$_TEST_DIR/spmd/test_xla_sharding_hlo.py"
+  run_test "$_TEST_DIR/spmd/test_xla_virtual_device.py"
+  run_test "$_TEST_DIR/spmd/test_dynamo_spmd.py"
+  run_test "$_TEST_DIR/spmd/test_spmd_debugging.py"
+  run_test "$_TEST_DIR/spmd/test_xla_distributed_checkpoint.py"
+  run_test "$_TEST_DIR/spmd/test_xla_spmd_python_api_interaction.py"
+  run_test "$_TEST_DIR/spmd/test_dtensor_integration.py"
+  run_test "$_TEST_DIR/spmd/test_dtensor_integration2.py"
+  run_test "$_TEST_DIR/spmd/test_xla_auto_sharding.py"
+  run_test "$_TEST_DIR/spmd/test_spmd_parameter_wrapping.py"
+  run_test "$_TEST_DIR/spmd/test_mp_input_sharding.py"
+  run_test "$_TEST_DIR/spmd/test_train_spmd_linear_model.py" "$@" --skip-gradient-checkpointing
+  run_test "$_TEST_DIR/test_gradient_accumulation.py"
+  run_save_tensor_hlo run_test "$_TEST_DIR/spmd/test_spmd_lowering_context.py"
+  run_test "$_TEST_DIR/test_operations_hlo.py" "$@" --verbosity=$VERBOSITY
+  run_test "$_TEST_DIR/test_input_output_aliases.py"
+  run_test_without_functionalization "$_TEST_DIR/test_input_output_aliases.py"
+  run_test "$_TEST_DIR/test_torch_distributed_xla_backend.py"
 
   # TODO(https://github.com/pytorch/xla/issues/9066): GPU testing disabled to unblock pin update.
   # Re-enable this test on GPU.
-  PJRT_DEVICE=CPU XLA_CUDA=0 run_torchrun "$CDIR/pjrt/test_torchrun.py"
+  PJRT_DEVICE=CPU XLA_CUDA=0 run_torchrun "$_TEST_DIR/pjrt/test_torchrun.py"
 
-  run_test "$CDIR/test_compilation_cache_utils.py"
-  run_test "$CDIR/test_persistent_cache.py"
-  run_test "$CDIR/test_devices.py"
-  run_device_detection_test "$CDIR/test_gpu_device_detection.py"
-  run_test "$CDIR/test_manual_xla_registration.py"
+  run_test "$_TEST_DIR/test_compilation_cache_utils.py"
+  run_test "$_TEST_DIR/test_persistent_cache.py"
+  run_test "$_TEST_DIR/test_devices.py"
+  run_device_detection_test "$_TEST_DIR/test_gpu_device_detection.py"
+  run_test "$_TEST_DIR/test_manual_xla_registration.py"
   # NOTE: this line below is testing export and don't care about GPU
-  PJRT_DEVICE=CPU CPU_NUM_DEVICES=1 run_coverage "$CDIR/test_core_aten_ops.py"
-  run_test "$CDIR/test_pallas.py"
-  run_xla_ir_hlo_debug run_test "$CDIR/test_user_computation_debug_cache.py"
+  PJRT_DEVICE=CPU CPU_NUM_DEVICES=1 run_coverage "$_TEST_DIR/test_core_aten_ops.py"
+  run_test "$_TEST_DIR/test_pallas.py"
+  run_xla_ir_hlo_debug run_test "$_TEST_DIR/test_user_computation_debug_cache.py"
 
   # Test examples
-  run_test "$CDIR/../examples/scan/scan_examples.py"
+  run_test "$_TEST_DIR/../examples/scan/scan_examples.py"
 
   # CUDA tests
   if [ -x "$(command -v nvidia-smi)" ]; then
@@ -375,28 +373,28 @@ function run_op_tests {
 }
 
 function run_mp_op_tests {
-  run_test "$CDIR/test_mp_replication.py"
-  run_test "$CDIR/test_mp_all_to_all.py"
-  run_test "$CDIR/test_mp_collective_permute.py"
-  run_test "$CDIR/test_mp_all_gather.py"
-  run_test "$CDIR/test_mp_reduce_scatter.py"
-  run_test "$CDIR/test_zero1.py"
-  run_test "$CDIR/test_mp_distributed_mm.py"
-  run_test "$CDIR/test_mp_save.py"
-  run_test "$CDIR/test_mp_mesh_reduce.py"
-  run_test "$CDIR/test_mp_sync_batch_norm.py"
+  run_test "$_TEST_DIR/test_mp_replication.py"
+  run_test "$_TEST_DIR/test_mp_all_to_all.py"
+  run_test "$_TEST_DIR/test_mp_collective_permute.py"
+  run_test "$_TEST_DIR/test_mp_all_gather.py"
+  run_test "$_TEST_DIR/test_mp_reduce_scatter.py"
+  run_test "$_TEST_DIR/test_zero1.py"
+  run_test "$_TEST_DIR/test_mp_distributed_mm.py"
+  run_test "$_TEST_DIR/test_mp_save.py"
+  run_test "$_TEST_DIR/test_mp_mesh_reduce.py"
+  run_test "$_TEST_DIR/test_mp_sync_batch_norm.py"
   # TODO(JackCaoG): enable this
-  run_test "$CDIR/dynamo/test_traceable_collectives.py"
-  run_test "$CDIR/test_fsdp_auto_wrap.py"
-  # run_torchrun "$CDIR/test_mp_early_exit.py"
-  run_pt_xla_debug "$CDIR/debug_tool/test_mp_pt_xla_debug.py"
-  run_test "$CDIR/torch_distributed/test_torch_distributed_all_gather_xla_backend.py"
-  run_test "$CDIR/torch_distributed/test_torch_distributed_all_reduce_xla_backend.py"
-  run_test "$CDIR/torch_distributed/test_torch_distributed_bucketed_all_reduce_xla_backend.py"
-  run_test "$CDIR/torch_distributed/test_torch_distributed_multi_all_reduce_xla_backend.py"
-  run_test "$CDIR/torch_distributed/test_torch_distributed_reduce_scatter_xla_backend.py"
-  run_test "$CDIR/torch_distributed/test_ddp.py"
-  run_test "$CDIR/torch_distributed/test_torch_distributed_fsdp_meta.py"
+  run_test "$_TEST_DIR/dynamo/test_traceable_collectives.py"
+  run_test "$_TEST_DIR/test_fsdp_auto_wrap.py"
+  # run_torchrun "$_TEST_DIR/test_mp_early_exit.py"
+  run_pt_xla_debug "$_TEST_DIR/debug_tool/test_mp_pt_xla_debug.py"
+  run_test "$_TEST_DIR/torch_distributed/test_torch_distributed_all_gather_xla_backend.py"
+  run_test "$_TEST_DIR/torch_distributed/test_torch_distributed_all_reduce_xla_backend.py"
+  run_test "$_TEST_DIR/torch_distributed/test_torch_distributed_bucketed_all_reduce_xla_backend.py"
+  run_test "$_TEST_DIR/torch_distributed/test_torch_distributed_multi_all_reduce_xla_backend.py"
+  run_test "$_TEST_DIR/torch_distributed/test_torch_distributed_reduce_scatter_xla_backend.py"
+  run_test "$_TEST_DIR/torch_distributed/test_ddp.py"
+  run_test "$_TEST_DIR/torch_distributed/test_torch_distributed_fsdp_meta.py"
 }
 
 function run_tests {

--- a/test/tpu/run_tests.sh
+++ b/test/tpu/run_tests.sh
@@ -2,15 +2,15 @@
 set -xue
 
 # Absolute path to the directory of this script.
-CDIR="$(
+_TPU_DIR="$(
     cd "$(dirname "$0")"
     pwd -P
 )"
 
 # Absolute path to the test/ directory.
-TEST_CDIR="$(dirname "$CDIR")"
+_TEST_DIR="$(dirname "$_TPU_DIR")"
 
-source "${TEST_CDIR}/utils/run_tests_utils.sh"
+source "${_TEST_DIR}/utils/run_tests_utils.sh"
 
 while getopts 'h' OPTION
 do
@@ -38,72 +38,72 @@ function run_test {
 }
 
 # TODO: merge with other run_tests
-if test_is_selected $TEST_CDIR/test_mat_mul_precision.py; then
-  (cd $TEST_CDIR && python3 -m unittest test_mat_mul_precision.TestMatMulPrecision.test_high)
-  (cd $TEST_CDIR && python3 -m unittest test_mat_mul_precision.TestMatMulPrecision.test_default)
-  (cd $TEST_CDIR && python3 -m unittest test_mat_mul_precision.TestMatMulPrecision.test_highest)
-  (cd $TEST_CDIR && python3 -m unittest test_mat_mul_precision.TestMatMulPrecision.test_all)
+if test_is_selected $_TEST_DIR/test_mat_mul_precision.py; then
+  (cd $_TEST_DIR && python3 -m unittest test_mat_mul_precision.TestMatMulPrecision.test_high)
+  (cd $_TEST_DIR && python3 -m unittest test_mat_mul_precision.TestMatMulPrecision.test_default)
+  (cd $_TEST_DIR && python3 -m unittest test_mat_mul_precision.TestMatMulPrecision.test_highest)
+  (cd $_TEST_DIR && python3 -m unittest test_mat_mul_precision.TestMatMulPrecision.test_all)
 fi
-run_test "$TEST_CDIR/test_mat_mul_precision_get_and_set.py"
-run_test "$TEST_CDIR/test_operations.py" -v
-run_test "$TEST_CDIR/test_xla_graph_execution.py" -v
-run_test "$TEST_CDIR/pjrt/test_runtime_tpu.py"
-run_test "$TEST_CDIR/pjrt/test_collective_ops_tpu.py"
-run_test "$TEST_CDIR/spmd/test_mp_input_sharding.py"
-run_test "$TEST_CDIR/test_mp_collective_matmul.py"
-run_save_tensor_hlo run_test "$TEST_CDIR/spmd/test_spmd_lowering_context.py"
-run_test "$TEST_CDIR/spmd/test_xla_sharding.py"
-run_test "$TEST_CDIR/spmd/test_xla_virtual_device.py"
-run_test "$TEST_CDIR/spmd/test_xla_distributed_checkpoint.py"
-run_test "$TEST_CDIR/spmd/test_train_spmd_linear_model.py"
-run_test "$TEST_CDIR/spmd/test_xla_spmd_python_api_interaction.py"
-run_test "$TEST_CDIR/spmd/test_xla_auto_sharding.py"
-run_test "$TEST_CDIR/spmd/test_fsdp_v2.py"
-run_test "$TEST_CDIR/test_gradient_accumulation.py"
-XLA_EXPERIMENTAL=nonzero:masked_select:nms run_test "$TEST_CDIR/ds/test_dynamic_shape_models.py" -v
-run_test "$TEST_CDIR/test_autocast.py"
-run_test "$TEST_CDIR/test_fp8.py"
-run_test "$TEST_CDIR/test_grad_checkpoint.py"
-run_test "$TEST_CDIR/test_grad_checkpoint.py" "$@" --test_autocast
-run_test "$TEST_CDIR/dynamo/test_dynamo.py"
-run_test "$TEST_CDIR/dynamo/test_dynamo_dynamic_shape.py"
-run_test "$TEST_CDIR/spmd/test_spmd_debugging.py"
-XLA_PARAMETER_WRAPPING_THREADSHOLD=1 run_test "$TEST_CDIR/spmd/test_spmd_parameter_wrapping.py"
-run_test "$TEST_CDIR/pjrt/test_dtypes.py"
-run_test "$TEST_CDIR/pjrt/test_dynamic_plugin_tpu.py"
-run_test "$TEST_CDIR/test_while_loop.py"
-run_test "$TEST_CDIR/scan/test_scan.py"
-run_test "$TEST_CDIR/scan/test_scan_spmd.py"
-run_test "$TEST_CDIR/scan/test_scan_pallas.py"
-run_test "$TEST_CDIR/scan/test_scan_layers.py"
-run_test "$TEST_CDIR/test_gru.py"
-run_test "$TEST_CDIR/test_assume_pure.py"
-run_test "$TEST_CDIR/test_assume_pure_spmd.py"
-run_test "$TEST_CDIR/test_as_stride_use_slice.py"
-run_xla_hlo_debug run_test "$TEST_CDIR/scan/test_scan_debug.py"
-run_test "$TEST_CDIR/test_pallas.py" -v
-run_test "$TEST_CDIR/test_pallas_spmd.py"
-XLA_DISABLE_FUNCTIONALIZATION=1 run_test "$TEST_CDIR/test_pallas_spmd.py"
-run_test "$TEST_CDIR/test_splash_attention.py"
-run_test "$TEST_CDIR/test_profiler_session.py"
-run_test "$TEST_CDIR/test_input_output_aliases.py"
-run_test "$TEST_CDIR/test_gmm.py"
-run_test "$TEST_CDIR/eager/test_eager_spmd.py"
-run_test "$TEST_CDIR/torch_distributed/test_torch_distributed_all_gather_xla_backend.py"
-run_test "$TEST_CDIR/torch_distributed/test_torch_distributed_all_reduce_xla_backend.py"
-run_test "$TEST_CDIR/torch_distributed/test_torch_distributed_multi_all_reduce_xla_backend.py"
-run_test "$TEST_CDIR/torch_distributed/test_torch_distributed_reduce_scatter_xla_backend.py"
-run_test "$TEST_CDIR/quantized_ops/test_dot_general.py"
-run_xla_ir_hlo_debug run_test "$TEST_CDIR/test_user_computation_debug_cache.py"
-run_test "$TEST_CDIR/test_data_type.py"
-run_test "$TEST_CDIR/test_compilation_cache_utils.py"
+run_test "$_TEST_DIR/test_mat_mul_precision_get_and_set.py"
+run_test "$_TEST_DIR/test_operations.py" -v
+run_test "$_TEST_DIR/test_xla_graph_execution.py" -v
+run_test "$_TEST_DIR/pjrt/test_runtime_tpu.py"
+run_test "$_TEST_DIR/pjrt/test_collective_ops_tpu.py"
+run_test "$_TEST_DIR/spmd/test_mp_input_sharding.py"
+run_test "$_TEST_DIR/test_mp_collective_matmul.py"
+run_save_tensor_hlo run_test "$_TEST_DIR/spmd/test_spmd_lowering_context.py"
+run_test "$_TEST_DIR/spmd/test_xla_sharding.py"
+run_test "$_TEST_DIR/spmd/test_xla_virtual_device.py"
+run_test "$_TEST_DIR/spmd/test_xla_distributed_checkpoint.py"
+run_test "$_TEST_DIR/spmd/test_train_spmd_linear_model.py"
+run_test "$_TEST_DIR/spmd/test_xla_spmd_python_api_interaction.py"
+run_test "$_TEST_DIR/spmd/test_xla_auto_sharding.py"
+run_test "$_TEST_DIR/spmd/test_fsdp_v2.py"
+run_test "$_TEST_DIR/test_gradient_accumulation.py"
+XLA_EXPERIMENTAL=nonzero:masked_select:nms run_test "$_TEST_DIR/ds/test_dynamic_shape_models.py" -v
+run_test "$_TEST_DIR/test_autocast.py"
+run_test "$_TEST_DIR/test_fp8.py"
+run_test "$_TEST_DIR/test_grad_checkpoint.py"
+run_test "$_TEST_DIR/test_grad_checkpoint.py" "$@" --test_autocast
+run_test "$_TEST_DIR/dynamo/test_dynamo.py"
+run_test "$_TEST_DIR/dynamo/test_dynamo_dynamic_shape.py"
+run_test "$_TEST_DIR/spmd/test_spmd_debugging.py"
+XLA_PARAMETER_WRAPPING_THREADSHOLD=1 run_test "$_TEST_DIR/spmd/test_spmd_parameter_wrapping.py"
+run_test "$_TEST_DIR/pjrt/test_dtypes.py"
+run_test "$_TEST_DIR/pjrt/test_dynamic_plugin_tpu.py"
+run_test "$_TEST_DIR/test_while_loop.py"
+run_test "$_TEST_DIR/scan/test_scan.py"
+run_test "$_TEST_DIR/scan/test_scan_spmd.py"
+run_test "$_TEST_DIR/scan/test_scan_pallas.py"
+run_test "$_TEST_DIR/scan/test_scan_layers.py"
+run_test "$_TEST_DIR/test_gru.py"
+run_test "$_TEST_DIR/test_assume_pure.py"
+run_test "$_TEST_DIR/test_assume_pure_spmd.py"
+run_test "$_TEST_DIR/test_as_stride_use_slice.py"
+run_xla_hlo_debug run_test "$_TEST_DIR/scan/test_scan_debug.py"
+run_test "$_TEST_DIR/test_pallas.py" -v
+run_test "$_TEST_DIR/test_pallas_spmd.py"
+XLA_DISABLE_FUNCTIONALIZATION=1 run_test "$_TEST_DIR/test_pallas_spmd.py"
+run_test "$_TEST_DIR/test_splash_attention.py"
+run_test "$_TEST_DIR/test_profiler_session.py"
+run_test "$_TEST_DIR/test_input_output_aliases.py"
+run_test "$_TEST_DIR/test_gmm.py"
+run_test "$_TEST_DIR/eager/test_eager_spmd.py"
+run_test "$_TEST_DIR/torch_distributed/test_torch_distributed_all_gather_xla_backend.py"
+run_test "$_TEST_DIR/torch_distributed/test_torch_distributed_all_reduce_xla_backend.py"
+run_test "$_TEST_DIR/torch_distributed/test_torch_distributed_multi_all_reduce_xla_backend.py"
+run_test "$_TEST_DIR/torch_distributed/test_torch_distributed_reduce_scatter_xla_backend.py"
+run_test "$_TEST_DIR/quantized_ops/test_dot_general.py"
+run_xla_ir_hlo_debug run_test "$_TEST_DIR/test_user_computation_debug_cache.py"
+run_test "$_TEST_DIR/test_data_type.py"
+run_test "$_TEST_DIR/test_compilation_cache_utils.py"
 
 # run examples, each test should takes <2 minutes
-run_test "$TEST_CDIR/../examples/data_parallel/train_resnet_spmd_data_parallel.py"
-run_test "$TEST_CDIR/../examples/fsdp/train_decoder_only_fsdp_v2.py"
-run_test "$TEST_CDIR/../examples/train_resnet_amp.py"
-run_test "$TEST_CDIR/../examples/train_decoder_only_base.py"
-run_test "$TEST_CDIR/../examples/train_decoder_only_base.py" scan.decoder_with_scan.DecoderWithScan \
+run_test "$_TEST_DIR/../examples/data_parallel/train_resnet_spmd_data_parallel.py"
+run_test "$_TEST_DIR/../examples/fsdp/train_decoder_only_fsdp_v2.py"
+run_test "$_TEST_DIR/../examples/train_resnet_amp.py"
+run_test "$_TEST_DIR/../examples/train_decoder_only_base.py"
+run_test "$_TEST_DIR/../examples/train_decoder_only_base.py" scan.decoder_with_scan.DecoderWithScan \
     --num-steps 30 # TODO(https://github.com/pytorch/xla/issues/8632): Reduce scan tracing overhead
 
 # HACK: don't confuse local `torch_xla` folder with installed package
@@ -111,17 +111,17 @@ run_test "$TEST_CDIR/../examples/train_decoder_only_base.py" scan.decoder_with_s
 # Egaer tests will take more HBM, only run them on TPU v4 CI
 TPU_VERSION=$(python -c "import sys; sys.path.remove(''); import torch_xla; print(torch_xla._internal.tpu.version())")
 if [[ -n "$TPU_VERSION" && "$TPU_VERSION" == "4" ]]; then
-    run_test "$TEST_CDIR/dynamo/test_traceable_collectives.py"
-    run_test "$TEST_CDIR/../examples/data_parallel/train_resnet_xla_ddp.py"
-    run_test "$TEST_CDIR/../examples/fsdp/train_resnet_fsdp_auto_wrap.py"
-    run_test "$TEST_CDIR/../examples/eager/train_decoder_only_eager.py"
-    run_test "$TEST_CDIR/../examples/eager/train_decoder_only_eager_spmd_data_parallel.py"
-    run_test "$TEST_CDIR/../examples/eager/train_decoder_only_eager_with_compile.py"
-    run_test "$TEST_CDIR/../examples/eager/train_decoder_only_eager_multi_process.py"
-    XLA_EXPERIMENTAL=nonzero:masked_select:nms run_test "$TEST_CDIR/ds/test_dynamic_shapes.py" -v
+    run_test "$_TEST_DIR/dynamo/test_traceable_collectives.py"
+    run_test "$_TEST_DIR/../examples/data_parallel/train_resnet_xla_ddp.py"
+    run_test "$_TEST_DIR/../examples/fsdp/train_resnet_fsdp_auto_wrap.py"
+    run_test "$_TEST_DIR/../examples/eager/train_decoder_only_eager.py"
+    run_test "$_TEST_DIR/../examples/eager/train_decoder_only_eager_spmd_data_parallel.py"
+    run_test "$_TEST_DIR/../examples/eager/train_decoder_only_eager_with_compile.py"
+    run_test "$_TEST_DIR/../examples/eager/train_decoder_only_eager_multi_process.py"
+    XLA_EXPERIMENTAL=nonzero:masked_select:nms run_test "$_TEST_DIR/ds/test_dynamic_shapes.py" -v
 fi
 
 if [[ -n "$TPU_VERSION" && "$TPU_VERSION" != "6" ]]; then
     # Test `tpu-info` CLI compatibility
-    run_test "$CDIR/tpu_info/test_cli.py"
+    run_test "$_TPU_DIR/tpu_info/test_cli.py"
 fi

--- a/test/utils/run_tests_utils.sh
+++ b/test/utils/run_tests_utils.sh
@@ -5,29 +5,19 @@ set -exo pipefail
 function parse_options_to_vars {
   # Default option values. Can be overridden via commandline flags.
   LOGFILE=/tmp/pytorch_py_test.log
-  MAX_GRAPH_SIZE=500
-  GRAPH_CHECK_FREQUENCY=100
   VERBOSITY=2
 
   # Parse commandline flags:
   #   -L
   #      disable writing to the log file at $LOGFILE.
-  #   -M max_graph_size
-  #   -C graph_check_frequency
   #   -V verbosity
   #   -h
   #      print the help string
-  while getopts 'LM:C:V:h' OPTION
+  while getopts 'LV:h' OPTION
   do
     case $OPTION in
       L)
         LOGFILE=
-        ;;
-      M)
-        MAX_GRAPH_SIZE=$OPTARG
-        ;;
-      C)
-        GRAPH_CHECK_FREQUENCY=$OPTARG
         ;;
       V)
         VERBOSITY=$OPTARG


### PR DESCRIPTION
- Add a `_` prefix to internal env vars to avoid clashing with public env vars.
- Remove unused `TRIM_GRAPH_SIZE` and `TRIM_GRAPH_CHECK_FREQUENCY` env vars (the features they control were removed in https://github.com/pytorch/xla/pull/7725).