### PR TITLE
Improve CI build speed by letting bazel decide how many worker threads to have

### DIFF
--- a/.github/workflows/_build_plugin.yml
+++ b/.github/workflows/_build_plugin.yml
@@ -33,7 +33,7 @@ jobs:
       image: ${{ inputs.dev-image }}
     env:
       GCLOUD_SERVICE_KEY: ${{ secrets.gcloud-service-key }}
-      BAZEL_JOBS: 16
+      BAZEL_JOBS: ''  # Let bazel decide the parallelism based on the number of CPUs.
       BAZEL_REMOTE_CACHE: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout actions

--- a/.github/workflows/_build_torch_xla.yml
+++ b/.github/workflows/_build_torch_xla.yml
@@ -38,7 +38,7 @@ jobs:
     env:
       GCLOUD_SERVICE_KEY: ${{ secrets.gcloud-service-key }}
       BAZEL_REMOTE_CACHE: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
-      BAZEL_JOBS: 16
+      BAZEL_JOBS: ''  # Let bazel decide the parallelism based on the number of CPUs.
       BUILD_CPP_TESTS: 1
     steps:
       # Need to check out local composite actions before using them

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -78,7 +78,7 @@ jobs:
       RUN_TORCH_MP_OP_TESTS: ${{ matrix.run_torch_mp_op_tests }}
       RUN_CPP_TESTS1: ${{ matrix.run_cpp_tests1 }}
       RUN_CPP_TESTS2: ${{ matrix.run_cpp_tests2 }}
-      BAZEL_JOBS: '' # Let bazel decide the parallelism based on the number of CPUs.
+      BAZEL_JOBS: ''  # Let bazel decide the parallelism based on the number of CPUs.
       BAZEL_REMOTE_CACHE: 1
     steps:
       - name: Checkout actions

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -78,7 +78,7 @@ jobs:
       RUN_TORCH_MP_OP_TESTS: ${{ matrix.run_torch_mp_op_tests }}
       RUN_CPP_TESTS1: ${{ matrix.run_cpp_tests1 }}
       RUN_CPP_TESTS2: ${{ matrix.run_cpp_tests2 }}
-      BAZEL_JOBS: 16
+      BAZEL_JOBS: ''  # Let bazel decide the parallelism based on the number of CPUs.
       BAZEL_REMOTE_CACHE: 1
     steps:
       - name: Checkout actions

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -78,7 +78,7 @@ jobs:
       RUN_TORCH_MP_OP_TESTS: ${{ matrix.run_torch_mp_op_tests }}
       RUN_CPP_TESTS1: ${{ matrix.run_cpp_tests1 }}
       RUN_CPP_TESTS2: ${{ matrix.run_cpp_tests2 }}
-      BAZEL_JOBS: ''  # Let bazel decide the parallelism based on the number of CPUs.
+      BAZEL_JOBS: '' # Let bazel decide the parallelism based on the number of CPUs.
       BAZEL_REMOTE_CACHE: 1
     steps:
       - name: Checkout actions

--- a/.github/workflows/_test_requiring_torch_cuda.yml
+++ b/.github/workflows/_test_requiring_torch_cuda.yml
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     env:
       USE_COVERAGE: ${{ inputs.collect-coverage && '1' || '0' }}
-      BAZEL_JOBS: 16
+      BAZEL_JOBS: ''  # Let bazel decide the parallelism based on the number of CPUs.
       BAZEL_REMOTE_CACHE: 1
     steps:
       - name: Checkout actions

--- a/.github/workflows/build_upstream_image.yml
+++ b/.github/workflows/build_upstream_image.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 30
     env:
       ECR_DOCKER_IMAGE_BASE: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/xla_base
-      BAZEL_JOBS: 16
+      BAZEL_JOBS: ''  # Let bazel decide the parallelism based on the number of CPUs.
     steps:
       # See https://github.com/actions/checkout/issues/1014#issuecomment-1906802802
       - name: Clean up workspace


### PR DESCRIPTION
We hard-code the number of bazel worker threads to 16 in the CI. However, our CI workers have 48 CPUs and 96 GB RAM. We are severely underutilizing our workers.

By removing the hard-coded value, we allow bazel to decide how many worker threads to launch, based on the available CPUs. This reduces the overall build time from 2h5m to 1h42m, a 23m reduction (22% speed-up).

In particular, it reduces the build times for the following jobs on the critical path:

- Build XLA CUDA plugin / build: 40m37s => 26m43s
- Build PyTorch/XLA / build: 1h18m42s => 56m10s

The other jobs are not noticeably affected by this change (some of them don't use bazel, and some may have a different bottleneck).

I also tried hard-coding the number of worker threads to 32 or 48, and the results are slightly slower than not setting the number of worker threads.