### PR TITLE
[torchax] Fixes test for kthvalue pytorch/xla#7458

### DIFF
--- a/torchax/test/test_ops.py
+++ b/torchax/test/test_ops.py
@@ -20,7 +20,6 @@ skiplist = {
     "histogram",  # hard op: AssertionError: Tensor-likes are not close!
     "histogramdd",  # TypeError: histogram requires ndarray or scalar arguments, got <class 'list'> at position 1.
     "index_reduce",
-    "kthvalue",
     "linalg.ldl_solve",
     "max_pool2d_with_indices_backward",
     "nn.functional.adaptive_max_pool1d",
@@ -176,7 +175,7 @@ ops_to_test = [
 # Sort related ops should ignore index;
 # For example: sort( [1, 0, 0]) -> [0, 0, 1]
 # the correct index can be [1, 2, 0] or [2, 1, 0]
-should_ignore_indexes = {"topk", "mode"}
+should_ignore_indexes = {"topk", "mode", "kthvalue"}
 
 
 class TestOpInfo(TestCase):

--- a/torchax/torchax/ops/jaten.py
+++ b/torchax/torchax/ops/jaten.py
@@ -5452,3 +5452,18 @@ def linear(input, weight, bias=None):
   if bias is not None:
     res += bias
   return res
+
+@op(torch.ops.aten.kthvalue)
+def kthvalue(input, k, dim=None, keepdim=False, *, out=None):
+  if input.ndim == 0:
+    return input, jnp.array(0)
+  dimension = -1
+  if dim:
+    dimension = dim
+  if dimension < 0:
+    dimension = dimension + input.ndim
+  values = jax.lax.index_in_dim(jnp.partition(input, k-1, dimension), k-1, dimension, keepdim)
+  b = jnp.argpartition(input, k-1, dimension).astype('int64')
+  indices = jax.lax.index_in_dim(b, k-1, dimension, keepdim)
+  return values, indices
+


### PR DESCRIPTION
Implemented kthvalue op by JAX and enabled the test.