### PR TITLE
Delete unused tracing functions from `ops.cpp`.

### DIFF
--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -887,6 +887,16 @@ torch::lazy::NodePtr Softplus(const torch::lazy::Value& input,
                    std::move(lower_fn));
 }
 
+torch::lazy::NodePtr Selu(const torch::lazy::Value& input) {
+  auto lower_fn = [](const XlaNode& node,
+                     LoweringContext* loctx) -> XlaOpVector {
+    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
+    return node.ReturnOp(BuildSelu(xla_input), loctx);
+  };
+  return GenericOp(torch::lazy::OpKind(at::aten::selu), {input},
+                   GetXlaShape(input), std::move(lower_fn));
+}
+
 torch::lazy::NodePtr ViewAsComplexCopy(const torch::lazy::Value& input) {
   auto lower_fn = [](const XlaNode& node,
                      LoweringContext* loctx) -> XlaOpVector {

--- a/torch_xla/csrc/ops/ops.cpp
+++ b/torch_xla/csrc/ops/ops.cpp
@@ -116,26 +116,6 @@ torch::lazy::NodePtr Logit(const torch::lazy::Value& input,
                    torch::lazy::MHash(eps));
 }
 
-torch::lazy::NodePtr SgnOp(const torch::lazy::Value& input) {
-  auto lower_fn = [](const XlaNode& node,
-                     LoweringContext* loctx) -> XlaOpVector {
-    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
-    return node.ReturnOp(BuildSgn(xla_input), loctx);
-  };
-  return GenericOp(torch::lazy::OpKind(at::aten::sgn), {input},
-                   GetXlaShape(input), std::move(lower_fn));
-}
-
-torch::lazy::NodePtr SignOp(const torch::lazy::Value& input) {
-  auto lower_fn = [](const XlaNode& node,
-                     LoweringContext* loctx) -> XlaOpVector {
-    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
-    return node.ReturnOp(BuildSign(xla_input), loctx);
-  };
-  return GenericOp(torch::lazy::OpKind(at::aten::sign), {input},
-                   GetXlaShape(input), std::move(lower_fn));
-}
-
 torch::lazy::NodePtr Prelu(const torch::lazy::Value& input,
                            const torch::lazy::Value& weight) {
   auto lower_fn = [](const XlaNode& node,
@@ -167,57 +147,6 @@ torch::lazy::NodePtr PreluBackward(const torch::lazy::Value& grad,
       {grad, input, weight},
       xla::ShapeUtil::MakeTupleShape({GetXlaShape(grad), GetXlaShape(input)}),
       std::move(lower_fn), /*num_outputs=*/2);
-}
-
-torch::lazy::NodePtr LogSigmoid(const torch::lazy::Value& input) {
-  auto lower_fn = [](const XlaNode& node,
-                     LoweringContext* loctx) -> XlaOpVector {
-    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
-    return node.ReturnOps(BuildLogSigmoid(xla_input), loctx);
-  };
-  return GenericOp(torch::lazy::OpKind(at::aten::log_sigmoid), {input},
-                   GetXlaShape(input), std::move(lower_fn), /*num_outputs=*/2);
-}
-
-torch::lazy::NodePtr SiLU(const torch::lazy::Value& input) {
-  auto lower_fn = [](const XlaNode& node,
-                     LoweringContext* loctx) -> XlaOpVector {
-    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
-    return node.ReturnOp(xla_input * BuildSigmoid(xla_input), loctx);
-  };
-  return GenericOp(torch::lazy::OpKind(at::aten::silu), {input},
-                   GetXlaShape(input), std::move(lower_fn));
-}
-
-torch::lazy::NodePtr SiLUBackward(const torch::lazy::Value& grad_output,
-                                  const torch::lazy::Value& input) {
-  auto lower_fn = [](const XlaNode& node,
-                     LoweringContext* loctx) -> XlaOpVector {
-    xla::XlaOp xla_grad_output = loctx->GetOutputOp(node.operand(0));
-    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(1));
-    return node.ReturnOp(BuildSiLUBackward(xla_grad_output, xla_input), loctx);
-  };
-  auto lower_for_shape_fn =
-      [](absl::Span<const xla::XlaOp> operands) -> xla::XlaOp {
-    return BuildSiLUBackward(operands[0], operands[1]);
-  };
-  return GenericOp(
-      torch::lazy::OpKind(at::aten::silu_backward), {grad_output, input},
-      [&]() {
-        return InferOutputShape({GetXlaShape(grad_output), GetXlaShape(input)},
-                                lower_for_shape_fn);
-      },
-      std::move(lower_fn));
-}
-
-torch::lazy::NodePtr Sigmoid(const torch::lazy::Value& input) {
-  auto lower_fn = [](const XlaNode& node,
-                     LoweringContext* loctx) -> XlaOpVector {
-    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
-    return node.ReturnOp(BuildSigmoid(xla_input), loctx);
-  };
-  return GenericOp(torch::lazy::OpKind(at::aten::sigmoid), {input},
-                   GetXlaShape(input), std::move(lower_fn));
 }
 
 torch::lazy::NodePtr SigmoidBackward(const torch::lazy::Value& grad_output,
@@ -956,16 +885,6 @@ torch::lazy::NodePtr Softplus(const torch::lazy::Value& input,
   return GenericOp(torch::lazy::OpKind(at::aten::softplus),
                    {input, beta, threshold}, GetXlaShape(input),
                    std::move(lower_fn));
-}
-
-torch::lazy::NodePtr Selu(const torch::lazy::Value& input) {
-  auto lower_fn = [](const XlaNode& node,
-                     LoweringContext* loctx) -> XlaOpVector {
-    xla::XlaOp xla_input = loctx->GetOutputOp(node.operand(0));
-    return node.ReturnOp(BuildSelu(xla_input), loctx);
-  };
-  return GenericOp(torch::lazy::OpKind(at::aten::selu), {input},
-                   GetXlaShape(input), std::move(lower_fn));
 }
 
 torch::lazy::NodePtr ViewAsComplexCopy(const torch::lazy::Value& input) {

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -232,6 +232,8 @@ torch::lazy::NodePtr Softplus(const torch::lazy::Value& input,
                               const torch::lazy::Value& beta,
                               const torch::lazy::Value& threshold);
 
+torch::lazy::NodePtr Selu(const torch::lazy::Value& input);
+
 torch::lazy::NodePtr ViewAsComplexCopy(const torch::lazy::Value& input);
 
 torch::lazy::NodePtr ViewAsRealCopy(const torch::lazy::Value& input);

--- a/torch_xla/csrc/ops/ops.h
+++ b/torch_xla/csrc/ops/ops.h
@@ -80,10 +80,6 @@ torch::lazy::NodePtr Tan(const torch::lazy::Value& input);
 
 torch::lazy::NodePtr Neg(const torch::lazy::Value& input);
 
-torch::lazy::NodePtr SgnOp(const torch::lazy::Value& input);
-
-torch::lazy::NodePtr SignOp(const torch::lazy::Value& input);
-
 torch::lazy::NodePtr Min(const torch::lazy::Value& input,
                          const torch::lazy::Value& other);
 
@@ -113,15 +109,6 @@ torch::lazy::NodePtr Pow(const torch::lazy::Value& input,
 
 torch::lazy::NodePtr Fmod(const torch::lazy::Value& dividend,
                           const torch::lazy::Value& divisor);
-
-torch::lazy::NodePtr LogSigmoid(const torch::lazy::Value& input);
-
-torch::lazy::NodePtr Sigmoid(const torch::lazy::Value& input);
-
-torch::lazy::NodePtr SiLU(const torch::lazy::Value& input);
-
-torch::lazy::NodePtr SiLUBackward(const torch::lazy::Value& grad_output,
-                                  const torch::lazy::Value& input);
 
 torch::lazy::NodePtr SigmoidBackward(const torch::lazy::Value& grad_output,
                                      const torch::lazy::Value& output);
@@ -244,8 +231,6 @@ torch::lazy::NodePtr SLogDet(const torch::lazy::Value& input);
 torch::lazy::NodePtr Softplus(const torch::lazy::Value& input,
                               const torch::lazy::Value& beta,
                               const torch::lazy::Value& threshold);
-
-torch::lazy::NodePtr Selu(const torch::lazy::Value& input);
 
 torch::lazy::NodePtr ViewAsComplexCopy(const torch::lazy::Value& input);
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -3066,6 +3066,10 @@ XLATensorPtr select(const XLATensorPtr& input, int64_t dim, int64_t index) {
   return tensor_ops::Select(input, dim, index);
 }
 
+void selu_(XLATensorPtr& input) {
+  input->SetInPlaceIrValue(Selu(input->GetIrValue()));
+}
+
 XLATensorPtr sigmoid_backward(const XLATensorPtr& grad_output,
                               const XLATensorPtr& output) {
   return grad_output->CreateFrom(

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -2000,11 +2000,6 @@ XLATensorPtr log_base(const XLATensorPtr& input, torch::lazy::OpKind op,
       std::nullopt);
 }
 
-XLATensorPtr log_sigmoid(const XLATensorPtr& input) {
-  torch::lazy::NodePtr node = LogSigmoid(input->GetIrValue());
-  return input->CreateFrom(torch::lazy::Value(node, 0));
-}
-
 XLATensorPtr log_softmax(const XLATensorPtr& input, int64_t dim,
                          std::optional<at::ScalarType> dtype,
                          std::vector<torch::lazy::Shape>&& shapes) {
@@ -3069,14 +3064,6 @@ XLATensorPtr scatter_reduce(const XLATensorPtr& input, int64_t dim,
 
 XLATensorPtr select(const XLATensorPtr& input, int64_t dim, int64_t index) {
   return tensor_ops::Select(input, dim, index);
-}
-
-void selu_(XLATensorPtr& input) {
-  input->SetInPlaceIrValue(Selu(input->GetIrValue()));
-}
-
-XLATensorPtr sigmoid(const XLATensorPtr& input) {
-  return input->CreateFrom(Sigmoid(input->GetIrValue()));
 }
 
 XLATensorPtr sigmoid_backward(const XLATensorPtr& grad_output,

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -862,6 +862,7 @@ XLATensorPtr scatter_reduce(const XLATensorPtr& input, int64_t dim,
 
 XLATensorPtr select(const XLATensorPtr& input, int64_t dim, int64_t index);
 
+void selu_(XLATensorPtr& input);
 XLATensorPtr silu(const XLATensorPtr& input);
 XLATensorPtr silu_backward(XLATensorPtr& grad_output, XLATensorPtr& input);
 XLATensorPtr sigmoid_backward(const XLATensorPtr& grad_output,

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -574,8 +574,6 @@ XLATensorPtr logit(const XLATensorPtr& input, std::optional<double> eps);
 XLATensorPtr log_base(const XLATensorPtr& input, torch::lazy::OpKind op,
                       double base);
 
-XLATensorPtr log_sigmoid(const XLATensorPtr& input);
-
 XLATensorPtr log_softmax(const XLATensorPtr& input, int64_t dim,
                          std::optional<at::ScalarType> dtype,
                          std::vector<torch::lazy::Shape>&& shapes);
@@ -864,11 +862,8 @@ XLATensorPtr scatter_reduce(const XLATensorPtr& input, int64_t dim,
 
 XLATensorPtr select(const XLATensorPtr& input, int64_t dim, int64_t index);
 
-void selu_(XLATensorPtr& input);
-
 XLATensorPtr silu(const XLATensorPtr& input);
 XLATensorPtr silu_backward(XLATensorPtr& grad_output, XLATensorPtr& input);
-XLATensorPtr sigmoid(const XLATensorPtr& input);
 XLATensorPtr sigmoid_backward(const XLATensorPtr& grad_output,
                               const XLATensorPtr& output);
 


### PR DESCRIPTION
This PR deletes a handful of unused tracing functions for the following operations. They are operations that are being full-codegen'd, but weren't deleted at that time. Note that a few of them were being used on unused tracing functions inside `tensor_methods.cpp`. Those were also deleted.

- `SgnOp` and `SignOp`
    - Full codegen migration: #3577
    - Mistakenly re-introduced: #3572
- `LogSigmoid`
    - Introduced: #3539
    - Full codegen migration: #3743
- `SiLU`
    - Introduced: #2721
    - Full codegen migration: #3780
- `SiLUBackward`
    - Introduced: #3195
    - Full codegen migration: #3780
- `SeLU`
    - Introduced: #3547
    - Full codegen migration: #3780
- `Sigmoid`
    - Introduced: 6a73deb057e63b8d7d15ed96aba7dc6f5ae4aabd (no PR record)
    - Full codegen migration: #6342