### PR TITLE
Fix unspecified behavior on custom calls.

### DIFF
--- a/torch_xla/csrc/ops/custom_call.cpp
+++ b/torch_xla/csrc/ops/custom_call.cpp
@@ -13,7 +13,7 @@ CustomCall::CustomCall(
     xla::Shape output_shape, bool has_side_effect,
     const std::string& backend_config, const int api_version,
     const std::unordered_map<std::string, std::string>& frontend_attributes)
-    : XlaNode(xla_custom_call, inputs, std::move(output_shape),
+    : XlaNode(xla_custom_call, inputs, output_shape,
               /*num_outputs=*/output_shape.tuple_shapes_size(),
               torch::lazy::MHash(call_target)),
       call_target_(call_target),

--- a/torch_xla/csrc/ops/gpu_custom_call.cpp
+++ b/torch_xla/csrc/ops/gpu_custom_call.cpp
@@ -9,7 +9,7 @@ namespace torch_xla {
 GpuCustomCall::GpuCustomCall(torch::lazy::OpList inputs,
                              xla::Shape output_shape,
                              const std::string& payload)
-    : XlaNode(xla_gpu_custom_call, inputs, std::move(output_shape),
+    : XlaNode(xla_gpu_custom_call, inputs, output_shape,
               /*num_outputs=*/output_shape.tuple_shapes_size(),
               torch::lazy::MHash(payload)),
       payload_(payload) {}

--- a/torch_xla/csrc/ops/tpu_custom_call.cpp
+++ b/torch_xla/csrc/ops/tpu_custom_call.cpp
@@ -9,7 +9,7 @@ namespace torch_xla {
 TpuCustomCall::TpuCustomCall(torch::lazy::OpList inputs,
                              xla::Shape output_shape,
                              const std::string& payload)
-    : XlaNode(xla_tpu_custom_call, inputs, std::move(output_shape),
+    : XlaNode(xla_tpu_custom_call, inputs, output_shape,
               /*num_outputs=*/output_shape.tuple_shapes_size(),
               torch::lazy::MHash(payload)),
       payload_(payload) {}


### PR DESCRIPTION
Compiling PyTorch/XLA with clang surfaced a few C++ unspecified/undefined behavior: use of a moved value. See example below for `CustomCall` (the same applies for GPU and TPU variants):

```c++
CustomCall::CustomCall(
    torch::lazy::OpList inputs, const std::string& call_target,
    xla::Shape output_shape, bool has_side_effect,
    const std::string& backend_config, const int api_version,
    const std::unordered_map<std::string, std::string>& frontend_attributes)
    : XlaNode(xla_custom_call, inputs, std::move(output_shape) /* <============ MOVED! */,
              /*num_outputs=*/output_shape.tuple_shapes_size() /* <============ USED! */,
              torch::lazy::MHash(call_target)),
      call_target_(call_target),
      has_side_effect_(has_side_effect),
      backend_config_(backend_config),
      api_version_(api_version),
      frontend_attributes_(frontend_attributes) {}
```

As far as I understand it, there's no guarantee on the order of argument evaluation, i.e. it's unspecified. Therefore this move might lead to an undefined/incorrect behavior where we use a moved value.