### PR TITLE
Run `test_collective_permute.py` on TPU CI.

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -379,7 +379,6 @@ function run_op_tests {
 function run_mp_op_tests {
   run_test "$_TEST_DIR/test_mp_replication.py"
   run_test "$_TEST_DIR/test_mp_all_to_all.py"
-  run_test "$_TEST_DIR/test_mp_collective_permute.py"
   run_test "$_TEST_DIR/test_mp_all_gather.py"
   run_test "$_TEST_DIR/test_mp_reduce_scatter.py"
   run_test "$_TEST_DIR/test_zero1.py"

--- a/test/tpu/run_tests.sh
+++ b/test/tpu/run_tests.sh
@@ -49,6 +49,7 @@ run_test "$_TEST_DIR/test_operations.py" -v
 run_test "$_TEST_DIR/test_xla_graph_execution.py" -v
 run_test "$_TEST_DIR/pjrt/test_runtime_tpu.py"
 run_test "$_TEST_DIR/pjrt/test_collective_ops_tpu.py"
+run_test "$_TEST_DIR/test_mp_collective_permute.py"
 run_test "$_TEST_DIR/spmd/test_mp_input_sharding.py"
 run_test "$_TEST_DIR/test_mp_collective_matmul.py"
 run_save_tensor_hlo run_test "$_TEST_DIR/spmd/test_spmd_lowering_context.py"


### PR DESCRIPTION
Since its creation, `test_collective_permute.py` only runs on either TPU or NEURON. However, at some point, TPU tests were moved somewhere else without this one. Meanwhile, this test was left running on both CPU and GPU CI, even though it doesn't actually tests anything because, again, it only does so on TPU or NEURON devices.

This PR removes `test_collective_permute.py` from CPU and GPU CI, and moves it to TPU CI.