### PR TITLE
Optimize build_developer.sh for the common workflow.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,8 +193,11 @@ commands on your Linux machine directly, outside of the container.
 
 **Subsequent builds**: after building the packages from source code for the
 first time, you may need to build everything again, for example, after a
-`git pull`. You can run `scripts/build_developer.sh` which will rebuild PyTorch,
-TorchVision, and PyTorch/XLA.
+`git pull`. You can:
+
+- run `scripts/build_developer.sh -b pytorch` to rebuild PyTorch, TorchVision,
+  and PyTorch/XLA,
+- run `scripts/build_developer.sh` to rebuild PyTorch/XLA only.
 
 ### Manually build in Docker container
 

--- a/scripts/build_developer.sh
+++ b/scripts/build_developer.sh
@@ -1,31 +1,78 @@
 #!/bin/bash
 
-set -e  # Fail on any error.
-set -x  # Display commands being run.
+# This script rebuilds torch_xla (including torchax). It can also rebuild
+# pytorch and torchvision if requested. To see the usage, run it with the
+# -h flag.
 
-# Change to pytorch directory.
-cd "$(dirname "$(readlink -f "$0")")"
-cd ../../
+set -e # Fail on any error.
 
-# First remove any left over old wheels
-# and old installation
-pip uninstall torch -y
-python3 setup.py clean
+# Absolute path to the directory of this script.
+_SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
-# Install pytorch
-python3 setup.py bdist_wheel
-python3 setup.py install
-cd ..
+# Which project to start the build from. We assume that the project
+# dependencies are: pytorch <= vision <= torch_xla. By default,
+# we assume that the user is working on torch_xla and there's
+# no need to rebuild pytorch or vision. However, the user can override
+# the "base" project using the -b flag.
+_BUILD_BASE=torch_xla
 
-# Optionally install torchvision.
-if [ -d "vision" ]; then
-  cd vision
-  python3 setup.py develop
-  cd ..
+# Parse commandline flags.
+while getopts 'b:ht' OPTION; do
+  case $OPTION in
+  b)
+    _BUILD_BASE=$OPTARG
+    # Validate _BUILD_BASE.
+    case "$_BUILD_BASE" in
+    "pytorch" | "vision" | "torch_xla") ;;
+    *)
+      echo "ERROR: Invalid <base_project>: $_BUILD_BASE. Must be one of pytorch, vision, or torch_xla."
+      exit 1
+      ;;
+    esac
+    ;;
+  h)
+    echo "Usage: $0 [-b <base_project>] [-t]"
+    echo "where"
+    echo "  -b <base_project> selects which project to start the build from. <base_project> be pytorch, vision, or torch_xla (the default)."
+    echo "  -t checks that the torch_xla and torchax libraries are built and installed successfully."
+    exit 0
+    ;;
+  t)
+    _TEST_INSTALL=1
+    ;;
+  \?) # This catches all invalid options.
+    exit 1 ;;
+  esac
+done
+
+set -x # Display commands being run.
+
+# Rebuild pytorch if _BUILD_BASE is pytorch.
+if [ "$_BUILD_BASE" == "pytorch" ]; then
+  # Change to the pytorch directory.
+  cd $_SCRIPT_DIR/../..
+
+  # Remove any leftover old wheels and old installation.
+  pip uninstall torch -y
+  python3 setup.py clean
+
+  # Install pytorch
+  python3 setup.py bdist_wheel
+  python3 setup.py install
 fi
 
-# Install torch_xla
-cd pytorch/xla
+# Rebuild torchvision if _BUILD_BASE is pytorch or vision.
+if [ "$_BUILD_BASE" == "pytorch" ] || [ "$_BUILD_BASE" == "vision" ]; then
+  _VISION_DIR=$_SCRIPT_DIR/../../vision
+  if [ -d $_VISION_DIR ]; then
+    cd $_VISION_DIR
+    python3 setup.py develop
+  fi
+fi
+
+# Rebuild torch_xla.
+
+cd $_SCRIPT_DIR/..
 pip uninstall torch_xla torchax torch_xla2 -y
 
 # Build the wheel too, which is useful for other testing purposes.
@@ -40,5 +87,7 @@ pip install torch_xla[tpu] \
   -f https://storage.googleapis.com/libtpu-wheels/index.html \
   -f https://storage.googleapis.com/libtpu-releases/index.html
 
-# Test that the library is installed correctly.
-python3 -c 'import torch_xla; print(torch_xla.devices()); import torchax; torchax.enable_globally()'
+if [ "$_TEST_INSTALL" == "1" ]; then
+  # Test that the libraries are installed correctly.
+  python3 -c 'import torch_xla; print(torch_xla.devices()); import torchax; torchax.enable_globally()'
+fi


### PR DESCRIPTION
Since a pytorch-xla developer most likely is changing pytorch-xla itself (as opposed to pytorch or torchvision), we should optimize for the workflow of rebuilding pytorch-xla.

- Make `build_developer.sh` rebuild pytorch-xla only by default.
- Allow the developer to select rebuilding pytorch and/or torchvision as well using the `-b pytorch` and `-b vision` flags.
- Skip the testing of library installation by default (for some reason, this step takes 7+ minutes for me and eventually fails). Allow the developer to select this testing using the `-t` flag.

Also document how to use the script in `CONTRIBUTING.md`.