### PR TITLE
Convert some XLA_CHECKs to fatal errors.

### DIFF
--- a/torch_xla/csrc/BUILD
+++ b/torch_xla/csrc/BUILD
@@ -130,6 +130,7 @@ ptxla_cc_library(
         "//torch_xla/csrc/runtime:stablehlo_helper",
         "//torch_xla/csrc/runtime:xla_util",
         "@com_google_absl//absl/hash",
+        "@com_google_absl//absl/log:absl_log",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:optional",

--- a/torch_xla/csrc/ops/dynamic_ir.h
+++ b/torch_xla/csrc/ops/dynamic_ir.h
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/log/absl_log.h"
 #include "torch/csrc/lazy/core/dynamic_ir.h"
 #include "torch_xla/csrc/ir.h"
 #include "torch_xla/csrc/ops/scalar.h"
@@ -202,11 +203,11 @@ class SizeError : public XlaNode, public torch::lazy::DimensionNode {
   SizeError();
   int64_t getDynamicValue() const override;
   int64_t getStaticValue() const override {
-    XLA_CHECK(false) << "SizeError shouldn't be called.";
+    ABSL_LOG(FATAL) << "SizeError shouldn't be called.";
     return -1;
   }
   bool isSymbolic() const override {
-    XLA_CHECK(false) << "SizeError shouldn't be called.";
+    ABSL_LOG(FATAL) << "SizeError shouldn't be called.";
     return true;
   }
   std::string ToString() const override;

--- a/torch_xla/csrc/ops/dynamic_ir.h
+++ b/torch_xla/csrc/ops/dynamic_ir.h
@@ -203,11 +203,11 @@ class SizeError : public XlaNode, public torch::lazy::DimensionNode {
   SizeError();
   int64_t getDynamicValue() const override;
   int64_t getStaticValue() const override {
-    ABSL_LOG(FATAL) << "SizeError shouldn't be called.";
+    ABSL_LOG(FATAL) << "SizeError::getStaticValue() shouldn't be called.";
     return -1;
   }
   bool isSymbolic() const override {
-    ABSL_LOG(FATAL) << "SizeError shouldn't be called.";
+    ABSL_LOG(FATAL) << "SizeError::isSymbolic() shouldn't be called.";
     return true;
   }
   std::string ToString() const override;


### PR DESCRIPTION
These 2 `XLA_CHECK`s indicate programmer errors, so we should crash instead of throwing an exception.

This PR is meant as a proof that we can use absl check/log marcros in PyTorch/XLA. Note that absl provides two sets of macros with the same behavior but different spellings (one with the `ABSL_` prefix and one without). We choose the set with the `ABSL_` prefix as:

- The macros without the `ABSL_` prefix are often defined by other packages (e.g. Caffe). We may get clashing definitions if both absl and Caffe headers are included.
- The `ABSL_` prefix makes it very clear where the macros are from.