### PR TITLE
[torchax] Support View in 'jax_view'

### DIFF
--- a/torchax/torchax/interop.py
+++ b/torchax/torchax/interop.py
@@ -179,7 +179,7 @@ def _jax_view(t: TorchValue) -> JaxValue:
   # t is an object from torch land
   # view it as-if it's a jax land object
   if isinstance(t, torch.Tensor):
-    assert isinstance(t, tensor.Tensor), type(t)
+    assert isinstance(t, tensor.Tensor) or isinstance(t, tensor.View), type(t)
     return t.jax()
   if isinstance(t, type(torch.int32)):
     return tensor.t2j_dtype(t)


### PR DESCRIPTION
Ideally, `View` in torchax should inherit `Tensor`. So that we don't need to modify all type check in the codebase to check for `View`. I attempted that but hit circular dependency between `view.py` and `tensor.py`, and I couldn't fix that in a short time.  

This is a quick fix to make `jax_view` work on `View`, under the current implementation. This is to unblock the vLLM x torchax work.

cc @wenxindongwork @qihqi 