### PR TITLE
dynamo_bridge.py: convert tuple to list before none_remover is called

### DIFF
--- a/torch_xla/_dynamo/dynamo_bridge.py
+++ b/torch_xla/_dynamo/dynamo_bridge.py
@@ -400,6 +400,9 @@ def extract_graph_helper(xla_model: torch.fx.GraphModule,
   if not isinstance(xla_out, (tuple, list)):
     xla_out = (xla_out,)
 
+  if isinstance(xla_out, tuple):
+    xla_out = list(xla_out)
+
   none_remover = NoneRemover()
   xla_out = none_remover.remove_nones(xla_out)
 


### PR DESCRIPTION
None remover only works on a list, but the xla_out passed to it can be a tuple. Therefore convert tuple to list before calling none_remover on it.