### PR TITLE
Add a script to update local/forked repos to match upstream

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -338,7 +338,7 @@ or by manually running `git` commands.
 This is the easiest way to update the forked repos. Please run the following
 commands on your Linux machine (not inside the dev container).
 
-First, create a `git sync` alias to run the `scripts/git_sync.py` script
+First, create a `git sync-main` alias to run the `scripts/git_sync.py` script
 (you only need to do it once):
 
 ```bash
@@ -350,13 +350,13 @@ After that, you can (in the `$WORKSPACE_DIR/pytorch/xla` directory) run:
 
 ```bash
 # Update the pytorch/xla repo.
-git sync
+git sync-main
 # Update the vision and pytorch/xla repos.
-git sync -b vision
+git sync-main -b vision
 # Update the pytorch, vision, and pytorch/xla repos.
-git sync -b pytorch
+git sync-main -b pytorch
 # See the usage of the command.
-git sync -h
+git sync-main -h
 ```
 
 ### Running git Manually

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -338,12 +338,12 @@ or by manually running `git` commands.
 This is the easiest way to update the forked repos. Please run the following
 commands on your Linux machine (not inside the dev container).
 
-First, create a `git sync-main` alias to run the `scripts/git_sync.py` script
+First, create a `git sync-main` alias to run the `scripts/git_sync_main.py` script
 (you only need to do it once):
 
 ```bash
 cd $WORKSPACE_DIR/pytorch/xla
-git config alias.sync '!scripts/git_sync.py'
+git config alias.sync-main '!scripts/git_sync_main.py'
 ```
 
 After that, you can (in the `$WORKSPACE_DIR/pytorch/xla` directory) run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -330,9 +330,39 @@ the PR.
 ## Updating Forked Repos
 
 From time to time, you'll need to bring your forked repos up to date with
-the original (aka upstream) repos. You can do this one repo at a time
-by running the following commands on your Linux machine (not inside the
-dev container).
+the original (aka upstream) repos. You can do this either by using a
+convenience script, or by manually running `git` commands.
+
+### Using the Convenience Script
+
+This is the easiest way to update the forked repos. Please run the following
+commands on your Linux machine (not inside the dev container).
+
+First, create a `git sync` alias to run the `scripts/git_sync.py` script
+(you only need to do it once):
+
+```bash
+cd $WORKSPACE_DIR/pytorch/xla
+git config alias.sync '!scripts/git_sync.py'
+```
+
+After that, you can (in the `$WORKSPACE_DIR/pytorch/xla` directory) run:
+
+```bash
+# Update the pytorch/xla repo.
+git sync
+# Update the vision and pytorch/xla repos.
+git sync -b vision
+# Update the pytorch, vision, and pytorch/xla repos.
+git sync -b pytorch
+# See the usage of the command.
+git sync -h
+```
+
+### Running git Manually
+
+You can also update the forked repos step by step, by running the following
+commands on your Linux machine (not inside the dev container).
 
 First, for the `pytorch` repo:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -330,8 +330,8 @@ the PR.
 ## Updating Forked Repos
 
 From time to time, you'll need to bring your forked repos up to date with
-the original (aka upstream) repos. You can do this either by using a
-convenience script, or by manually running `git` commands.
+the upstream repos. You can do this either by using a convenience script,
+or by manually running `git` commands.
 
 ### Using the Convenience Script
 

--- a/scripts/git_sync.py
+++ b/scripts/git_sync.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Updates the local git repos to match upstream repos.
+
+For convenience, you can set up a `git sync` alias to run this script by:
+
+  git config alias.sync '!scripts/git_sync.py'
+
+(you only need to do this once).
+"""
+
+import argparse
+import logging
+import os
+import platform
+import re
+import sys
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Names of the repos.
+_PYTORCH_REPO = 'pytorch'
+_VISION_REPO = 'vision'
+_TORCH_XLA_REPO = 'torch_xla'
+
+# Roots of the local repos.
+_PTXLA_DIR = os.path.abspath(os.path.dirname(__file__) + '/..')
+_PYTORCH_DIR = os.path.abspath(_PTXLA_DIR + '/..')
+_VISION_DIR = os.path.abspath(_PYTORCH_DIR + '/../vision')
+
+# Path of this script, relative to the torch_xla repo root.
+_SCRIPT_REL_PATH = os.path.abspath(__file__)[len(_PTXLA_DIR) + 1:]
+
+
+def sync_repo(repo: str) -> bool:
+  """Updates the default branch of the local pytorch repo to match upstream.
+  
+  Args:
+    repo: The repo to sync. Must be one of "pytorch", "vision", and "torch_xla".
+
+  Returns:
+    True if the local pytorch repo was successfully updated, False otherwise.
+  """
+
+  logger.info(f'Syncing the {repo} repo...')
+
+  # Change to the repo root directory.
+  os.chdir(_PYTORCH_DIR if repo == _PYTORCH_REPO else _VISION_DIR if repo ==
+           _VISION_REPO else _PTXLA_DIR)
+
+  # If there are uncommited changes, ask the user to commit/stash them and
+  # retry.
+  status = os.system('git status --porcelain')
+  if status != 0:
+    logger.error(
+        f'The local {repo} repo has uncommited changes. Please commit or stash them and retry.'
+    )
+    return False
+
+  # If there are untracked files, ask the user to commit/stash them and retry.
+  untracked_files = os.popen(
+      'git ls-files --others --exclude-standard').read().strip().split('\n')
+  if untracked_files:
+    logger.error(
+        f'The local {repo} repo has untracked files ({", ".join(sorted(untracked_files))}). Do you want to commit/stash them and retry?'
+    )
+    return False
+
+  # Check out the default branch.
+  default_branch = 'master' if repo == _TORCH_XLA_REPO else 'main'
+  if os.system(f'git checkout {default_branch}') != 0:
+    logger.error(
+        f'Failed to checkout the {default_branch} branch of the {repo} repo.')
+    return False
+
+  # Make sure the remotes are set up correctly:
+  #
+  # - There must be an "origin" remote, pointing to where the local repo is
+  #   cloned from. This can be either the official repo but a fork made by
+  #   the user.
+  # - If the user created the local repo by cloning their own fork, there
+  #   must also be an "upstream" remote pointing to the official repo. In
+  #   this case, "origin" would point to the user's fork.
+  remotes = os.popen('git remote').read().strip().split('\n')
+  if 'origin' not in remotes:
+    logger.error(
+        f'No remote named "origin" found for the local {repo} repo. Please add one and retry.'
+    )
+    return False
+
+  # Which remote is the official repo?
+  official_repo_remote = 'upstream' if 'upstream' in remotes else 'origin'
+
+  # Pull the latest changes from the official repo.
+  if os.system(f'git pull {official_repo_remote} {default_branch}') != 0:
+    logger.error(
+        f'Failed to pull the latest changes from the "{official_repo_remote}" remote of the {repo} repo.'
+    )
+    return False
+
+  # If the user used a fork to create this local repo, push the changes to
+  # the fork to make it in sync with the official repo.
+  if official_repo_remote != 'origin':
+    logger.info(
+        f'Pushing the changes to the "origin" remote of the {repo} repo. Please touch the security key when prompted...'
+    )
+    if os.system(f'git push origin {default_branch}') != 0:
+      logger.error(
+          'Failed to push the changes to the "origin" remote of the {repo} repo.'
+      )
+      return False
+
+  logger.info(
+      f'Successfully updated the {default_branch} branch of the {repo} repo to match upstream.'
+  )
+  return True
+
+
+def main() -> None:
+  logging.basicConfig(level=logging.INFO)
+
+  # Abort if the user is root.
+  if os.geteuid() == 0:
+    logger.error(
+        'Please do not run this script as root (e.g. inside the dev container), as it will mess up the git permissions. Run it outside of the dev container instead.'
+    )
+    sys.exit(1)
+
+  arg_parser = argparse.ArgumentParser(
+      prog=_SCRIPT_REL_PATH, description=__doc__)
+  arg_parser.add_argument(
+      '--base_repo',
+      '-b',
+      type=str,
+      choices=(_PYTORCH_REPO, _VISION_REPO, _TORCH_XLA_REPO),
+      default=_TORCH_XLA_REPO,
+      help='sync the given repo and all repos that depend on it; the default is torch_xla',
+  )
+
+  args = arg_parser.parse_args()
+
+  failed = False
+  if args.base_repo == _PYTORCH_REPO:
+    if not sync_repo(_PYTORCH_REPO):
+      failed = True
+
+  if args.base_repo in (_PYTORCH_REPO, _VISION_REPO):
+    if os.path.isdir(_VISION_DIR) and not sync_repo(_VISION_REPO):
+      failed = True
+
+  if not sync_repo(_TORCH_XLA_REPO):
+    failed = True
+
+  if failed:
+    logger.error('Failed to sync some repos.')
+    sys.exit(1)
+
+  logger.info('All repos synced successfully.')
+
+
+if __name__ == '__main__':
+  main()

--- a/scripts/git_sync.py
+++ b/scripts/git_sync.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Updates the local git repos to match upstream repos.
+"""Updates the default branches of local git repos to match upstream.
 
 For convenience, you can set up a `git sync` alias to run this script by:
 
@@ -11,10 +11,7 @@ For convenience, you can set up a `git sync` alias to run this script by:
 import argparse
 import logging
 import os
-import platform
-import re
 import sys
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -48,83 +45,99 @@ def sync_repo(repo: str) -> bool:
   os.chdir(_PYTORCH_DIR if repo == _PYTORCH_REPO else _VISION_DIR if repo ==
            _VISION_REPO else _PTXLA_DIR)
 
-  # If there are uncommited changes, ask the user to commit/stash them and
-  # retry.
-  status = os.system('git status --porcelain')
-  if status != 0:
+  # It's unsafe to sync the repo if there are uncommited changes or untracked files.
+  uncommitted_changes = os.popen('git status --porcelain').read().strip()
+  if uncommitted_changes:
     logger.error(
-        f'The local {repo} repo has uncommited changes. Please commit or stash them and retry.'
-    )
+        f'The local {repo} repo has uncommited changes (\n'
+        f'{uncommitted_changes}\n). Please commit or stash them and retry.')
     return False
-
-  # If there are untracked files, ask the user to commit/stash them and retry.
   untracked_files = os.popen(
-      'git ls-files --others --exclude-standard').read().strip().split('\n')
-  untracked_files = ', '.join(sorted(untracked_files))
+      'git ls-files --others --exclude-standard').read().strip()
   if untracked_files:
     logger.error(
-        f'The local {repo} repo has untracked files ({untracked_files}). Do you want to commit/stash them and retry?'
-    )
+        f'The local {repo} repo has untracked files (\n'
+        f'{untracked_files}\n). Do you want to commit/stash them and retry?')
     return False
 
-  # Check out the default branch.
-  default_branch = 'master' if repo == _TORCH_XLA_REPO else 'main'
-  if os.system(f'git checkout {default_branch}') != 0:
-    logger.error(
-        f'Failed to checkout the {default_branch} branch of the {repo} repo.')
-    return False
+  # Remember which branch is currently checked out, so that we can switch back
+  # to it after updating the default branch.
+  orig_branch = os.popen('git branch --show-current').read().strip()
 
-  # Make sure the remotes are set up correctly:
-  #
-  # - There must be an "origin" remote, pointing to where the local repo is
-  #   cloned from. This can be either the official repo but a fork made by
-  #   the user.
-  # - If the user created the local repo by cloning their own fork, there
-  #   must also be an "upstream" remote pointing to the official repo. In
-  #   this case, "origin" would point to the user's fork.
-  remotes = os.popen('git remote').read().strip().split('\n')
-  if 'origin' not in remotes:
-    logger.error(
-        f'No remote named "origin" found for the local {repo} repo. Please add one and retry.'
-    )
-    return False
+  def sync_default_branch() -> bool:
+    """Updates the default branch of the local repo to match upstream.
+    
+    Returns:
+      True if the default branch was successfully updated, False otherwise.
+    """
 
-  # Which remote is the official repo?
-  official_repo_remote = 'upstream' if 'upstream' in remotes else 'origin'
-
-  # Pull the latest changes from the official repo.
-  if os.system(f'git pull {official_repo_remote} {default_branch}') != 0:
-    logger.error(
-        f'Failed to pull the latest changes from the "{official_repo_remote}" remote of the {repo} repo.'
-    )
-    return False
-
-  # If the user used a fork to create this local repo, push the changes to
-  # the fork to make it in sync with the official repo.
-  if official_repo_remote != 'origin':
-    logger.info(
-        f'Pushing the changes to the "origin" remote of the {repo} repo. Please touch the security key when prompted...'
-    )
-    if os.system(f'git push origin {default_branch}') != 0:
+    # Check out the default branch.
+    default_branch = 'master' if repo == _TORCH_XLA_REPO else 'main'
+    if os.system(f'git checkout {default_branch}') != 0:
       logger.error(
-          'Failed to push the changes to the "origin" remote of the {repo} repo.'
+          f'Failed to checkout the {default_branch} branch of the {repo} repo.')
+      return False
+
+    # Make sure the remotes are set up correctly:
+    #
+    # - There must be an "origin" remote, pointing to where the local repo is
+    #   cloned from. This can be either the official repo but a fork made by
+    #   the user.
+    # - If the user created the local repo by cloning their own fork, there
+    #   must also be an "upstream" remote pointing to the official repo. In
+    #   this case, "origin" would point to the user's fork.
+    remotes = os.popen('git remote').read().strip().split('\n')
+    if 'origin' not in remotes:
+      logger.error(
+          f'No remote named "origin" found for the local {repo} repo. Please add one and retry.'
       )
       return False
 
-  logger.info(
-      f'Successfully updated the {default_branch} branch of the {repo} repo to match upstream.'
-  )
-  return True
+    official_repo_remote = 'upstream' if 'upstream' in remotes else 'origin'
+
+    # Pull the latest changes from the official repo.
+    if os.system(f'git pull {official_repo_remote} {default_branch}') != 0:
+      logger.error(
+          f'Failed to pull the latest changes from the "{official_repo_remote}" remote of the {repo} repo.'
+      )
+      return False
+
+    # If the user used a fork to create this local repo, push the changes to
+    # the fork to make it in sync with the official repo.
+    if official_repo_remote != 'origin':
+      logger.info(
+          f'Pushing the changes to the "origin" remote of the {repo} repo. Please touch the security key when prompted...'
+      )
+      if os.system(f'git push origin {default_branch}') != 0:
+        logger.error(
+            'Failed to push the changes to the "origin" remote of the {repo} repo.'
+        )
+        return False
+
+    return True
+
+  success = sync_default_branch()
+
+  # Switch back to the originally checked out branch.
+  if os.system(f'git checkout {orig_branch}') != 0:
+    logger.error(
+        f'Failed to checkout the {orig_branch} branch of the {repo} repo.')
+    success = False
+
+  if success:
+    logger.info(
+        f'Successfully updated the default branch of the {repo} repo to match upstream.'
+    )
+  return success
 
 
 def main() -> None:
   logging.basicConfig(level=logging.INFO)
 
-  # Abort if the user is root.
-  if os.geteuid() == 0:
-    logger.error(
-        'Please do not run this script as root (e.g. inside the dev container), as it will mess up the git permissions. Run it outside of the dev container instead.'
-    )
+  if os.geteuid() == 0:  # The user is root.
+    logger.error('Please do not run this script as root (e.g. inside the dev '
+                 'container), as it will mess up the git permissions. Run it '
+                 'outside of the dev container instead.')
     sys.exit(1)
 
   arg_parser = argparse.ArgumentParser(
@@ -135,24 +148,26 @@ def main() -> None:
       type=str,
       choices=(_PYTORCH_REPO, _VISION_REPO, _TORCH_XLA_REPO),
       default=_TORCH_XLA_REPO,
-      help='sync the given repo and all repos that depend on it; the default is torch_xla',
+      help=('sync the given repo and all repos that depend on it; '
+            'the default is torch_xla'),
   )
 
   args = arg_parser.parse_args()
 
-  failed = False
+  success = True
   if args.base_repo == _PYTORCH_REPO:
     if not sync_repo(_PYTORCH_REPO):
-      failed = True
+      success = False
 
   if args.base_repo in (_PYTORCH_REPO, _VISION_REPO):
+    # The torchvision repo is optional, so skip it if it doesn't exist.
     if os.path.isdir(_VISION_DIR) and not sync_repo(_VISION_REPO):
-      failed = True
+      success = False
 
   if not sync_repo(_TORCH_XLA_REPO):
-    failed = True
+    success = False
 
-  if failed:
+  if not success:
     logger.error('Failed to sync some repos.')
     sys.exit(1)
 

--- a/scripts/git_sync.py
+++ b/scripts/git_sync.py
@@ -60,9 +60,10 @@ def sync_repo(repo: str) -> bool:
   # If there are untracked files, ask the user to commit/stash them and retry.
   untracked_files = os.popen(
       'git ls-files --others --exclude-standard').read().strip().split('\n')
+  untracked_files = ', '.join(sorted(untracked_files))
   if untracked_files:
     logger.error(
-        f'The local {repo} repo has untracked files ({", ".join(sorted(untracked_files))}). Do you want to commit/stash them and retry?'
+        f'The local {repo} repo has untracked files ({untracked_files}). Do you want to commit/stash them and retry?'
     )
     return False
 

--- a/scripts/git_sync.py
+++ b/scripts/git_sync.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
-"""Updates the default branches of local git repos to match upstream.
+"""Updates the default branches of local and forked repos to match upstream.
 
-For convenience, you can set up a `git sync` alias to run this script by:
+Before using this script for the first time, please set up a `git sync` alias
+by running this once:
 
   git config alias.sync '!scripts/git_sync.py'
-
-(you only need to do this once).
 """
 
 import argparse
@@ -24,9 +23,6 @@ _TORCH_XLA_REPO = 'torch_xla'
 _PTXLA_DIR = os.path.abspath(os.path.dirname(__file__) + '/..')
 _PYTORCH_DIR = os.path.abspath(_PTXLA_DIR + '/..')
 _VISION_DIR = os.path.abspath(_PYTORCH_DIR + '/../vision')
-
-# Path of this script, relative to the torch_xla repo root.
-_SCRIPT_REL_PATH = os.path.abspath(__file__)[len(_PTXLA_DIR) + 1:]
 
 
 def sync_repo(repo: str) -> bool:
@@ -106,7 +102,7 @@ def sync_repo(repo: str) -> bool:
     # the fork to make it in sync with the official repo.
     if official_repo_remote != 'origin':
       logger.info(
-          f'Pushing the changes to the "origin" remote of the {repo} repo. Please touch the security key when prompted...'
+          f'Pushing the changes to the "origin" remote of the {repo} repo...'
       )
       if os.system(f'git push origin {default_branch}') != 0:
         logger.error(
@@ -141,7 +137,7 @@ def main() -> None:
     sys.exit(1)
 
   arg_parser = argparse.ArgumentParser(
-      prog=_SCRIPT_REL_PATH, description=__doc__)
+      prog='git sync', description=__doc__)
   arg_parser.add_argument(
       '--base_repo',
       '-b',

--- a/scripts/git_sync_main.py
+++ b/scripts/git_sync_main.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Updates the default branches of local and forked repos to match upstream.
 
-Before using this script for the first time, please set up a `git sync` alias
+Before using this script for the first time, please set up a `git sync-main` alias
 by running this once:
 
-  git config alias.sync '!scripts/git_sync.py'
+  git config alias.sync-main '!scripts/git_sync_main.py'
 """
 
 import argparse
@@ -137,7 +137,7 @@ def main() -> None:
     sys.exit(1)
 
   arg_parser = argparse.ArgumentParser(
-      prog='git sync', description=__doc__)
+      prog='git sync-main', description=__doc__)
   arg_parser.add_argument(
       '--base_repo',
       '-b',

--- a/scripts/git_sync_main.py
+++ b/scripts/git_sync_main.py
@@ -102,8 +102,7 @@ def sync_repo(repo: str) -> bool:
     # the fork to make it in sync with the official repo.
     if official_repo_remote != 'origin':
       logger.info(
-          f'Pushing the changes to the "origin" remote of the {repo} repo...'
-      )
+          f'Pushing the changes to the "origin" remote of the {repo} repo...')
       if os.system(f'git push origin {default_branch}') != 0:
         logger.error(
             'Failed to push the changes to the "origin" remote of the {repo} repo.'


### PR DESCRIPTION
Closes: https://github.com/pytorch/xla/issues/9285

This makes it easy to perform the common task of updating the main/master branches of local/forked repos to match upstream.

Usage:

One-time set-up:

```
git config alias.sync-main '!scripts/git_sync_main.py'
```

Then:

```bash
# Update the pytorch/xla repo.
git sync-main
# Update the vision and pytorch/xla repos.
git sync-main -b vision
# Update the pytorch, vision, and pytorch/xla repos.
git sync-main -b pytorch
# See the usage of the command.
git sync-main -h
```
