### PR TITLE
Add a script to automatically format C++/Python files upon `git push`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -425,3 +425,15 @@ git rebase upstream/master
 # update the PR.
 git push --force-with-lease origin your-branch-name
 ```
+
+## Fixing Git Metadata File Permissions
+
+Normally we run `git` commands outside of the dev container. If we run
+a mutating `git` command inside the dev container, it may change the owner
+of some files inside the `.git` directory to `root`, which will prevent us from
+running `git` commands outside of the dev container. To fix this, run the
+following commands *outside of the dev container* to fix the file owners:
+
+```Shell
+sudo chown -R $USER .git
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,9 +251,9 @@ If your PR touches the C++ source files, please run the following command before
 
 ```Shell
 # How to install: sudo apt install clang-format-11
-# If your PR only changes foo.cpp, run the following in xla/ folder
+# If your PR only changes foo.cpp, run the following in the xla/ folder.
 clang-format-11 -i -style=file /PATH/TO/foo.cpp
-# To format all cpp files, run the following in xla/ folder
+# To format all cpp files, run the following in the xla/ folder.
 find -name '*.cpp' -o -name '*.h' -o -name '*.cc' | xargs clang-format-11 -i -style=file
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,30 +241,35 @@ Please refer to this [guide](https://github.com/pytorch/xla/blob/master/plugins/
 
 ## Before Creating a Pull Request
 
-In `pytorch/xla` repo we enforce coding style for both C++ and Python files. Please try to format
-your code before creating a pull request.
+In `pytorch/xla` repo we enforce coding style for both C++ and Python files.
+Specifically, we use `clang-format-11` with a customized style config to format
+C++, and `yapf` (specially version 0.40.2) with a customized style config
+to format Python. Please ensure that your change is formatted properly before
+sending out a PR.
 
-### C++ Style Guide
+The easiest way to do this is to set up a `git push` hook to automatically
+format changed or added C++ and Python files before pushing:
 
-`pytorch/xla` uses `clang-format-11` with a customized style config.
-If your PR touches the C++ source files, please run the following command before submitting a PR.
-
+First, install the necessary tools if needed:
 ```Shell
-# How to install: sudo apt install clang-format-11
-# If your PR only changes foo.cpp, run the following in the xla/ folder.
-clang-format-11 -i -style=file /PATH/TO/foo.cpp
-# To format all cpp files, run the following in the xla/ folder.
-find -name '*.cpp' -o -name '*.h' -o -name '*.cc' | xargs clang-format-11 -i -style=file
+cd $WORKSPACE_DIR/pytorch/xla
+# If clang-format-11 is not yet installed...
+sudo apt install clang-format-11
+# If yapf 0.40.2 is not yet installed...
+pip install yapf==0.40.2
 ```
 
-### Python Style Guide
-
-`pytorch/xla` uses `yapf`(specially version 0.40.2 in case it's not backward compatible) with a customized style config.
-If your PR touches the Python source files, please run the following command before submitting a PR.
-
+Then, set up the git push hook:
 ```Shell
-# How to install: pip install yapf==0.40.2
-yapf --recursive -i *.py test/ scripts/ torch_xla/ benchmarks/ torchax/
+scripts/git_fix.py --set_git_push_hook
+```
+
+Now, whenever you run `git push`, the C++ and Python files will be
+automatically formatted according to our style guide.
+
+You can also format the files manually by running
+```Shell
+scripts/git_fix.py
 ```
 
 ### Running the Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,25 +212,25 @@ first time, you may need to build everything again, for example, after a
 
 * Clone the _PyTorch_ repo as per [instructions](https://github.com/pytorch/pytorch#from-source).
 
-  ```Shell
+  ```shell
   git clone --recursive https://github.com/pytorch/pytorch
   cd pytorch/
   ```
 
 * Clone the _PyTorch/XLA_ repo:
 
-  ```Shell
+  ```shell
   git clone --recursive https://github.com/pytorch/xla.git
   ```
 
 * Build PyTorch
-  ```Shell
+  ```shell
   # pytorch/xla requires pytorch wheel to be presented under pytorch/dist
   python setup.py bdist_wheel
   python setup.py develop
   ```
 * Build PyTorch/XLA
-  ```Shell
+  ```shell
   cd xla/
   python setup.py develop
   ```
@@ -251,7 +251,7 @@ The easiest way to do this is to set up a `git push` hook to automatically
 format changed or added C++ and Python files before pushing:
 
 First, install the necessary tools if needed:
-```Shell
+```shell
 cd $WORKSPACE_DIR/pytorch/xla
 # If clang-format-11 is not yet installed...
 sudo apt install clang-format-11
@@ -260,7 +260,7 @@ pip install yapf==0.40.2
 ```
 
 Then, set up the git push hook:
-```Shell
+```shell
 scripts/git_fix.py --set_git_push_hook
 ```
 
@@ -268,7 +268,7 @@ Now, whenever you run `git push`, the C++ and Python files will be
 automatically formatted according to our style guide.
 
 You can also format the files manually by running
-```Shell
+```shell
 scripts/git_fix.py
 ```
 
@@ -278,19 +278,19 @@ To run the tests, follow __one__ of the options below:
 
 * Run on local CPU:
 
-  ```Shell
+  ```shell
   export PJRT_DEVICE=CPU
   ```
 
 * Run on Cloud TPU:
 
-  ```Shell
+  ```shell
   export PJRT_DEVICE=TPU
   ```
 
 * Run on GPU:
 
-  ```Shell
+  ```shell
   export PJRT_DEVICE=CUDA GPU_NUM_DEVICES=${NUM_GPU}
   ```
 
@@ -434,6 +434,6 @@ of some files inside the `.git` directory to `root`, which will prevent us from
 running `git` commands outside of the dev container. To fix this, run the
 following commands *outside of the dev container* to fix the file owners:
 
-```Shell
+```shell
 sudo chown -R $USER .git
 ```

--- a/scripts/git_fix.py
+++ b/scripts/git_fix.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Fixes the format of locally changed git files.
+"""
+
+import logging
+import os
+import re
+import sys
+from typing import Optional
+
+# Root of the PyTorch/XLA repo.
+_PTXLA_DIR = os.path.abspath(os.path.dirname(__file__) + '/..')
+
+logger = logging.getLogger(__name__)
+
+
+def get_uncommitted_changed_added_files() -> set[str]:
+  """Gets the list of changed or added files that are not committed yet.
+
+  This includes untracked files (i.e. newly created files not added to git yet).
+  """
+
+  # Run `git status --porcelain | grep -E '^(M|A|\?\?)\s' | awk '{print $NF}'` to get the list.
+  # How this works:
+  #   - git status --porcelain : print the changed files prefixed by their statuses.
+  #   - grep -E '^(M|A|\?\?)\s' : find changed (M), added (A), or untracked (??) files.
+  #   - awk '{print $NF}' : print the last field of each line, which is the file path.
+  files = os.popen(
+      'git status --porcelain | grep -E \'^(M|A|\?\?)\s\' | awk \'{print $NF}\''
+  ).read().strip().split('\n')
+  if '' in files:
+    files.remove('')
+  return set(files)
+
+
+def get_cplusplus_files(files: set[str]) -> set[str]:
+  """Filters the given list of files and returns the C++ files."""
+
+  return {
+      f for f in files
+      if os.path.splitext(f)[1] in ('.cc', '.h', '.cpp', '.cxx')
+  }
+
+
+def get_python_files(files: set[str]) -> set[str]:
+  """Filters the given list of files and returns the Python files."""
+
+  return {f for f in files if os.path.splitext(f)[1] == '.py'}
+
+
+def main() -> None:
+  logging.basicConfig(level=logging.INFO)
+
+  os.chdir(_PTXLA_DIR)
+  files = get_uncommitted_changed_added_files()
+
+  # We don't use `fix_cplusplus_files(...) and fix_python_files(...)` as we
+  # don't want shortcircuiting.
+  success = fix_cplusplus_files(get_cplusplus_files(files))
+  if not fix_python_files(get_python_files(files)):
+    success = False
+
+  if not success:
+    sys.exit(1)
+
+
+if __name__ == '__main__':
+  main()

--- a/scripts/git_fix.py
+++ b/scripts/git_fix.py
@@ -2,35 +2,34 @@
 """Fixes the format of locally changed git files.
 """
 
-import logging
 import os
 import re
 import sys
-from typing import Optional
 
 # Root of the PyTorch/XLA repo.
 _PTXLA_DIR = os.path.abspath(os.path.dirname(__file__) + '/..')
 
-logger = logging.getLogger(__name__)
+# Names of CLIs for formatting files.
+_CLANG_FORMAT = 'clang-format-11'
+_YAPF = 'yapf'
 
 
 def get_uncommitted_changed_added_files() -> set[str]:
   """Gets the list of changed or added files that are not committed yet.
 
-  This includes untracked files (i.e. newly created files not added to git yet).
+  This includes untracked files (i.e. newly created files not added to git
+  yet).
   """
 
-  # Run `git status --porcelain | grep -E '^(M|A|\?\?)\s' | awk '{print $NF}'` to get the list.
-  # How this works:
-  #   - git status --porcelain : print the changed files prefixed by their statuses.
-  #   - grep -E '^(M|A|\?\?)\s' : find changed (M), added (A), or untracked (??) files.
-  #   - awk '{print $NF}' : print the last field of each line, which is the file path.
-  files = os.popen(
-      'git status --porcelain | grep -E \'^(M|A|\?\?)\s\' | awk \'{print $NF}\''
-  ).read().strip().split('\n')
-  if '' in files:
-    files.remove('')
-  return set(files)
+  # Each line is a filepath prefixed by its status.
+  lines = os.popen('git status --porcelain').read().strip().split('\n')
+  files = set()
+  for line in lines:
+    # Find changed (M), added (A), or untracked (??) files.
+    if re.match(r'^\s*(M|A|\?\?)\s', line):
+      # The last field of the line is the filepath.
+      files.add(line.split()[-1])
+  return files
 
 
 def get_cplusplus_files(files: set[str]) -> set[str]:
@@ -48,16 +47,90 @@ def get_python_files(files: set[str]) -> set[str]:
   return {f for f in files if os.path.splitext(f)[1] == '.py'}
 
 
-def main() -> None:
-  logging.basicConfig(level=logging.INFO)
+def tool_is_installed(file_type: str, tool: str) -> bool:
+  """Checks if the given tool is installed.
 
+  Args:
+    file_type: The type of the file (e.g. C++, python).
+    tool: The name of the tool.
+
+  Returns:
+    True if the tool is already installed.  
+  """
+
+  # Is the tool already installed?
+  if os.system(f'which {tool} > /dev/null') == 0:
+    return True
+
+  print(
+      f'WARNING: {tool} is not installed. It\'s needed for formatting '
+      f'{file_type} files. Please install it and retry.',
+      file=sys.stderr)
+  return False
+
+
+def format_files(file_type: str, tool: str, format_command: str,
+                 files: set[str]) -> bool:
+  """Fixes the formatting of the given files.
+  
+  Args:
+    file_type: The type of the file (e.g. C++, python).    
+    tool: The name of the tool.
+    format_command: The command to format the files.
+    files: The files to format.
+  Returns:
+    True if the formatting was successful.
+  """
+
+  if not files:
+    return True
+
+  if not tool_is_installed(file_type, tool):
+    return False
+
+  command = f'{format_command} {" ".join(files)}'
+  if os.system(command) == 0:
+    print(
+        f'Successfully formatted {file_type} files:\n' +
+        '\n'.join(sorted('  ' + f for f in files)),
+        file=sys.stderr)
+    return True
+
+  print(
+      f'WARNING: Failed to format {file_type} files via command: {command}',
+      file=sys.stderr)
+  return False
+
+
+def format_cplusplus_files(files: set[str]) -> bool:
+  """Fixes the formatting of the given C++ files.
+  
+  Returns:
+    True if the formatting was successful.
+  """
+
+  return format_files('C++', _CLANG_FORMAT, f'{_CLANG_FORMAT} -i -style=file',
+                      files)
+
+
+def format_python_files(files: set[str]) -> bool:
+  """Fixes the formatting of the given Python files.
+
+  Returns:
+    True if the formatting was successful.
+  """
+
+  return format_files('python', _YAPF, f'{_YAPF} -i', files)
+
+
+def main() -> None:
   os.chdir(_PTXLA_DIR)
   files = get_uncommitted_changed_added_files()
 
-  # We don't use `fix_cplusplus_files(...) and fix_python_files(...)` as we
-  # don't want shortcircuiting.
-  success = fix_cplusplus_files(get_cplusplus_files(files))
-  if not fix_python_files(get_python_files(files)):
+  # We don't use `format_cplusplus_files(...) and format_python_files(...)` as
+  # we don't want shortcircuiting.
+  success = format_cplusplus_files(get_cplusplus_files(files))
+  if not format_python_files(get_python_files(files)):
     success = False
 
   if not success:

--- a/scripts/git_fix.py
+++ b/scripts/git_fix.py
@@ -32,6 +32,28 @@ def get_uncommitted_changed_added_files() -> set[str]:
   return files
 
 
+def get_committed_changed_added_files() -> set[str]:
+  """Gets the list of changed or added files that are committed locally.
+   
+  These are the files that are committed in the local branch but not jyet
+  merged to the origin/master branch.
+  """
+
+  # Each line is a filepath.
+  lines = os.popen(
+      # --name-only : include filepaths only in the output.
+      # --diff-filter=AM : include only added (A) or modified (M) files.
+      # --no-renames : if a file is renamed, treat it as a deleted file and
+      #     an added file, so that the added file will be included in the
+      #     result.
+      # origin/master...HEAD : compare the local branch HEAD with
+      #     origin/master, showing changes that exist on your local branch
+      #     but not on origin/master.
+      'git diff --name-only --diff-filter=AM --no-renames origin/master...HEAD'
+  ).read().strip().split('\n')
+  return set(lines)
+
+
 def get_cplusplus_files(files: set[str]) -> set[str]:
   """Filters the given list of files and returns the C++ files."""
 
@@ -125,7 +147,8 @@ def format_python_files(files: set[str]) -> bool:
 
 def main() -> None:
   os.chdir(_PTXLA_DIR)
-  files = get_uncommitted_changed_added_files()
+  files = get_uncommitted_changed_added_files(
+  ) | get_committed_changed_added_files()
 
   # We don't use `format_cplusplus_files(...) and format_python_files(...)` as
   # we don't want shortcircuiting.

--- a/scripts/git_fix.py
+++ b/scripts/git_fix.py
@@ -170,17 +170,21 @@ def set_git_push_hook() -> bool:
       print('Skipping git pre-push hook setup.', file=sys.stderr)
       return False
 
-  # Write the current script to the git pre-push hook.
+  # Create a git pre-push hook to run this script.
   with open(_GIT_PRE_PUSH_HOOK_PATH, 'w') as f:
     f.write(f'''#!/bin/bash
 # This hook is automatically set by `{_SCRIPT_PATH } --set_git_push_hook`.)
-{_SCRIPT_PATH}
+# We ignore any errors, as file formatting is best effort.
+{_SCRIPT_PATH} || true
 ''')
+
+  # Make the hook executable.
+  os.system(f'chmod +x {_GIT_PRE_PUSH_HOOK_PATH}')
+  return True
 
 
 def main() -> None:
-  arg_parser = argparse.ArgumentParser(
-      prog=_SCRIPT_PATH, description=__doc__)
+  arg_parser = argparse.ArgumentParser(prog=_SCRIPT_PATH, description=__doc__)
   arg_parser.add_argument(
       '--set_git_push_hook',
       action='store_true',

--- a/scripts/git_fix.py
+++ b/scripts/git_fix.py
@@ -147,8 +147,9 @@ def format_python_files(files: set[str]) -> bool:
 
 def main() -> None:
   os.chdir(_PTXLA_DIR)
-  files = get_uncommitted_changed_added_files(
-  ) | get_committed_changed_added_files()
+  files = (
+      get_uncommitted_changed_added_files() |
+      get_committed_changed_added_files())
 
   # We don't use `format_cplusplus_files(...) and format_python_files(...)` as
   # we don't want shortcircuiting.

--- a/test/cpp/metrics_snapshot.cpp
+++ b/test/cpp/metrics_snapshot.cpp
@@ -24,7 +24,7 @@ MetricsSnapshot::MetricsSnapshot() {
     counters_map_.emplace(name, counter->Value());
   }
 
-  // See NOTE: [TORCH_LAZY_COUNTER v.s. XLA_COUNTER].
+  // See NOTE: [TORCH_LAZY_COUNTER v.s. XLA_COUNTER]..
   for (auto& name : torch::lazy::GetCounterNames()) {
     auto* counter = torch::lazy::GetCounter(name);
     counters_map_.emplace(name, counter->Value());

--- a/test/cpp/metrics_snapshot.cpp
+++ b/test/cpp/metrics_snapshot.cpp
@@ -24,7 +24,7 @@ MetricsSnapshot::MetricsSnapshot() {
     counters_map_.emplace(name, counter->Value());
   }
 
-  // See NOTE: [TORCH_LAZY_COUNTER v.s. XLA_COUNTER]..
+  // See NOTE: [TORCH_LAZY_COUNTER v.s. XLA_COUNTER].
   for (auto& name : torch::lazy::GetCounterNames()) {
     auto* counter = torch::lazy::GetCounter(name);
     counters_map_.emplace(name, counter->Value());


### PR DESCRIPTION
Closes: https://github.com/pytorch/xla/issues/9268

With this PR, one can run
```
scripts/git_fix.py --set_git_push_hook
```
once to set up auto pre-push file formatting. I.e. afterwards, whenever one runs `git push`, the changed/added C++ and Python files will be automatically formatted. The developer no longer needs to remember the command line for formatting files.

One can also manually format the changed/added C++ and Python files by running
```
scripts/git_fix.py
```
directly.