### PR TITLE
Deprecate XLA:CUDA: add warning on initialization.

### DIFF
--- a/torch_xla/csrc/runtime/pjrt_registry.cpp
+++ b/torch_xla/csrc/runtime/pjrt_registry.cpp
@@ -148,6 +148,10 @@ InitializePjRt(const std::string& device_type) {
   } else if (device_type == "TPU_LEGACY") {
     XLA_ERROR() << "TPU_LEGACY client is no longer available.";
   } else if (device_type == "CUDA") {
+    TF_LOG(WARNING)
+        << "The XLA:CUDA device is deprecated in release 2.8. "
+        << "Future releases might remove XLA:CUDA support entirely. "
+        << "Use the PyTorch native CUDA backend, instead.";
     TF_VLOG(1) << "Initializing PjRt GPU client...";
     bool async = sys_util::GetEnvBool(env::kEnvPjrtAsyncGpuClient, true);
     int local_process_rank = sys_util::GetEnvInt(env::kEnvPjRtLocalRank, 0);


### PR DESCRIPTION
This PR starts the XLA:CUDA deprecation process by issuing a warning whenever we initialize the CUDA PjRt client.

```python
>>> torch_xla.device()
2025-06-05 15:31:31.225748: W torch_xla/csrc/runtime/pjrt_registry.cpp:151] The XLA:CUDA device is deprecated in release 2.8. Future releases might remove XLA:CUDA support entirely. Use the PyTorch native CUDA backend, instead.
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1749137491.307757   53448 se_gpu_pjrt_client.cc:1101] Using BFC allocator.
I0000 00:00:1749137491.307890   53448 gpu_helpers.cc:136] XLA backend allocating 12632997888 bytes on device 0 for BFCAllocator.
I0000 00:00:1749137491.308026   53448 gpu_helpers.cc:177] XLA backend will use up to 4210999296 bytes on device 0 for CollectiveBFCAllocator.
I0000 00:00:1749137491.319481   53448 cuda_dnn.cc:529] Loaded cuDNN version 90000
device(type='xla', index=0)
```