### PR TITLE
Merge cpp_tests1 and cpp_tests2 into single shard

### DIFF
--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -202,7 +202,7 @@ function run_torch_xla_tests() {
   export PYTORCH_TESTING_DEVICE_ONLY_FOR="xla"
   export CXX_ABI=$(python -c "import torch;print(int(torch._C._GLIBCXX_USE_CXX11_ABI))")
 
-  if [[ -z "$RUN_BENCHMARK_TESTS" && -z "$RUN_CPP_TESTS1" && -z "$RUN_CPP_TESTS2" && -z "$RUN_PYTHON_TESTS" ]]; then
+  if [[ -z "$RUN_BENCHMARK_TESTS" && -z "$RUN_CPP_TESTS1" && -z "$RUN_PYTHON_TESTS" ]]; then
     run_torch_xla_python_tests $PYTORCH_DIR $XLA_DIR $USE_COVERAGE
     run_torch_xla_cpp_tests $PYTORCH_DIR $XLA_DIR $USE_COVERAGE
     run_torch_xla_benchmark_tests $XLA_DIR

--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -44,10 +44,10 @@ function run_torch_xla_cpp_tests() {
                "test_aten_xla_tensor_2"
                "test_aten_xla_tensor_3"
                "test_aten_xla_tensor_4"
-               "pjrt_computation_client_test")
+               "pjrt_computation_client_test"
                # Disable IFRT test as it currently crashes
                #"ifrt_computation_client_test")
-  test_names2=("test_aten_xla_tensor_5"
+               "test_aten_xla_tensor_5"
                "test_aten_xla_tensor_6"
                "test_ir"
                "test_lazy"
@@ -58,10 +58,6 @@ function run_torch_xla_cpp_tests() {
                "test_xla_sharding")
   if [[ "$RUN_CPP_TESTS1" == "cpp_tests1" ]]; then
     test_names=("${test_names1[@]}")
-  elif [[ "$RUN_CPP_TESTS2" == "cpp_tests2" ]]; then
-    test_names=("${test_names2[@]}")
-  else
-    test_names=("${test_names1[@]}" "${test_names2[@]}")
   fi
 
   for name in "${test_names[@]}"; do
@@ -95,7 +91,7 @@ fi
 export PYTORCH_TESTING_DEVICE_ONLY_FOR="xla"
 export CXX_ABI=$(python -c "import torch;print(int(torch._C._GLIBCXX_USE_CXX11_ABI))")
 
-if [[ -z "$RUN_BENCHMARK_TESTS" && -z "$RUN_CPP_TESTS1" && -z "$RUN_CPP_TESTS2" && -z "$RUN_PYTHON_TESTS" ]]; then
+if [[ -z "$RUN_BENCHMARK_TESTS" && -z "$RUN_CPP_TESTS1" && -z "$RUN_PYTHON_TESTS" ]]; then
   run_torch_xla_python_tests $XLA_DIR $USE_COVERAGE
   run_torch_xla_cpp_tests $XLA_DIR $USE_COVERAGE
   run_torch_xla_benchmark_tests $XLA_DIR

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -67,8 +67,6 @@ jobs:
             run_torch_mp_op_tests: 'torch_mp_op'
           - run_cpp_tests: 'cpp_tests'
             run_cpp_tests1: 'cpp_tests1'
-          - run_cpp_tests: 'cpp_tests'
-            run_cpp_tests2: 'cpp_tests2'
     timeout-minutes: ${{ inputs.timeout-minutes }}
     env:
       GCLOUD_SERVICE_KEY: ${{ secrets.gcloud-service-key }}
@@ -83,7 +81,6 @@ jobs:
       RUN_XLA_OP_TESTS5: ${{ matrix.run_xla_op_tests5 }}
       RUN_TORCH_MP_OP_TESTS: ${{ matrix.run_torch_mp_op_tests }}
       RUN_CPP_TESTS1: ${{ matrix.run_cpp_tests1 }}
-      RUN_CPP_TESTS2: ${{ matrix.run_cpp_tests2 }}
       BAZEL_JOBS: ''  # Let bazel decide the parallelism based on the number of CPUs.
       BAZEL_REMOTE_CACHE: 1
     steps:
@@ -160,7 +157,7 @@ jobs:
           CIRCLE_BUILD_NUM: ${{ github.run_number }}
           BENCHMARK_TEST_NAME: ${{ env.RUN_BENCHMARK_TESTS }}
           PYTHON_TEST_NAME: ${{ env.RUN_PYTHON_TESTS }}${{ env.RUN_XLA_OP_TESTS1 }}${{ env.RUN_XLA_OP_TESTS2 }}${{ env.RUN_XLA_OP_TESTS3 }}${{ env.RUN_XLA_OP_TESTS4 }}${{ env.RUN_XLA_OP_TESTS5 }}${{ env.RUN_TORCH_MP_OP_TESTS }}
-          CPP_TEST_NAME: ${{ env.RUN_CPP_TESTS1 }}${{ env.RUN_CPP_TESTS2 }}
+          CPP_TEST_NAME: ${{ env.RUN_CPP_TESTS1 }}
         run: |
             # TODO(yeounoh) collect coverage report as needed.
             if [ -n "${BENCHMARK_TEST_NAME}" ]; then

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -90,9 +90,8 @@ if [[ "$RUN_CPP_TESTS1" == "cpp_tests1" ]]; then
   test_names=("test_aten_xla_tensor_1"
               "test_aten_xla_tensor_2"
               "test_aten_xla_tensor_3"
-              "test_aten_xla_tensor_4")
-elif [[ "$RUN_CPP_TESTS2" == "cpp_tests2" ]]; then
-  test_names=("test_aten_xla_tensor_5"
+              "test_aten_xla_tensor_4"
+              "test_aten_xla_tensor_5"
               "test_aten_xla_tensor_6"
               "test_ir"
               "test_lazy"


### PR DESCRIPTION
The extra split is not necessary since the combined test time is shorter than the longest running CPU tests.