### PR TITLE
Pin update 06052025

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,7 +46,7 @@ new_local_repository(
 
 # To build PyTorch/XLA with a new revison of OpenXLA, update the xla_hash to
 # the openxla git commit hash and note the date of the commit.
-xla_hash = '2087703fd6b6476e773bd45d6e5b9efb7b7c153e'  # Committed on 2025-05-30.
+xla_hash = 'd4576615b3bd3644567da60202faf19b485b52f9'  # Committed on 2025-06-05.
 
 http_archive(
     name = "xla",

--- a/setup.py
+++ b/setup.py
@@ -108,8 +108,8 @@ base_dir = os.path.dirname(os.path.abspath(__file__))
 
 USE_NIGHTLY = True  # Whether to use nightly or stable libtpu and JAX.
 
-_libtpu_version = '0.0.16'
-_libtpu_date = '20250530'
+_libtpu_version = '0.0.17'
+_libtpu_date = '20250605'
 
 _jax_version = '0.6.1'
 _jaxlib_version = '0.6.1'

--- a/torch_xla/csrc/runtime/pjrt_registry.cpp
+++ b/torch_xla/csrc/runtime/pjrt_registry.cpp
@@ -129,7 +129,7 @@ InitializePjRt(const std::string& device_type) {
     TF_VLOG(1) << "Initializing PjRt CPU client...";
     bool async = sys_util::GetEnvBool(env::kEnvPjrtAsyncCpuClient, true);
     int cpu_device_count = sys_util::GetEnvInt(env::kEnvNumCpu, 1);
-    client = std::move(xla::GetTfrtCpuClient(async, cpu_device_count).value());
+    client = std::move(xla::GetPjRtCpuClient(async, cpu_device_count).value());
   } else if (device_type == "TPU") {
     TF_VLOG(1) << "Initializing TFRT TPU client...";
     // Init the absl logging to avoid the log spam.


### PR DESCRIPTION
TfrtCpuClient is replaced by PjrtCpuClient in https://github.com/openxla/xla/pull/27399

Jax date is being updated in https://github.com/pytorch/xla/pull/9296 

Still Trying to figure out a way to get jax wheels from the new url https://github.com/pytorch/xla/blob/master/scripts/update_deps.py#L39