### PR TITLE
cleanup: remove defunct --distinct_host_configuration flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -225,9 +225,6 @@ build --noincompatible_remove_legacy_whole_archive
 # cc_shared_library ensures no library is linked statically more than once.
 build --experimental_link_static_libraries_once=false
 
-# On linux, don't cross compile by default
-build:linux --distinct_host_configuration=false
-
 # Do not risk cache corruption. See:
 # https://github.com/bazelbuild/bazel/issues/3360
 build:linux --experimental_guard_against_concurrent_changes


### PR DESCRIPTION
This --distinct_host_configuration flag is a no-op in Bazel 6 and higher and removed
in more recent Bazel versions.