### PR TITLE
Fix race condition in runAtenTest

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -392,7 +392,8 @@ class XlaTestCase(unittest.TestCase):
     ]
     cpu_results = xu.as_list(fn(*cpu_tensors))
     xla_results = xu.as_list(fn(*xla_tensors))
-    self.compareResults(cpu_results, xla_results, rel_err=rel_err, abs_err=abs_err)
+    self.compareResults(
+        cpu_results, xla_results, rel_err=rel_err, abs_err=abs_err)
 
 
 @contextmanager

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -386,12 +386,13 @@ class XlaTestCase(unittest.TestCase):
     if device is None:
       device = torch_xla.device()
     tensors = xu.as_list(tensors)
+    cpu_tensors = [t.clone() for t in tensors]
     xla_tensors = [
         x.to(device).detach().requires_grad_(x.requires_grad) for x in tensors
     ]
-    results = xu.as_list(fn(*tensors))
+    cpu_results = xu.as_list(fn(*cpu_tensors))
     xla_results = xu.as_list(fn(*xla_tensors))
-    self.compareResults(results, xla_results, rel_err=rel_err, abs_err=abs_err)
+    self.compareResults(cpu_results, xla_results, rel_err=rel_err, abs_err=abs_err)
 
 
 @contextmanager

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -386,7 +386,9 @@ class XlaTestCase(unittest.TestCase):
     if device is None:
       device = torch_xla.device()
     tensors = xu.as_list(tensors)
-    cpu_tensors = [t.clone() for t in tensors]
+    cpu_tensors = [
+        t.clone().detach().requires_grad_(t.requires_grad) for t in tensors
+    ]
     xla_tensors = [
         x.to(device).detach().requires_grad_(x.requires_grad) for x in tensors
     ]


### PR DESCRIPTION
The logic in runAtenTest has a race condition that can trigger if the "x.to(device)" is delayed, such as by acquiring a lock on the XLA device. In this case, the host-to-XLA device transfer may not start until after the test function has executed on the host CPU.

For test functions which mutate their inputs, such as test_diagonal_write_transposed_r3, this can result in the test `fn` being applied twice; once from the invocation of `fn(*tensors)` on CPU, and then a second time from the invocation of `fn(*xla_tensors)`. Empirically, this happens at a rate of approximately 0.03% (about 1 in 3000 executions).

Adding a full clone on the CPU before calling the test function ensures that the CPU invocation and the XLA invocation will not interfere even if they execute in a different order, eliminating the race condition. This was verified by 1 million successful sequential executions of test_diagonal_write_transposed_r3.