### PR TITLE
Support trace_me and xp.Trace in assume_pure

### DIFF
--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -9,7 +9,6 @@ import torch.nn.functional as F
 from torch.ao.quantization.utils import determine_qparams
 
 import torch_xla
-import torch_xla.core.xla_model as xm
 from torch_xla import runtime as xr
 from torch_xla._internal import tpu
 
@@ -26,6 +25,7 @@ if xr.device_type() == 'TPU':
 def with_jax_high_precision(func):
 
   def wrapper(*args, **kwargs):
+    import jax
     jax.config.update('jax_default_matmul_precision', "highest")
     try:
       result = func(*args, **kwargs)

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -868,7 +868,7 @@ def flash_attention(
                               sm_scale, ab, partition_spec, mesh)
 
 
-# This function should only be called and excuted on runtime.
+# This function should only be called and executed on runtime.
 def _ragged_paged_attention_runtime_check(
     q,  # [max_num_batched_tokens, num_q_heads, head_dim]
     kv_pages,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]


### PR DESCRIPTION
This way the HLO staged out by `@assume_pure` and torchax will contain name scopes pushed by `xp.Trace`.

Also reduce the flakiness of `test/test_profiler.py`.