### PR TITLE
Extend build_developer.sh and git_sync_main.py with a -a flag.

### DIFF
--- a/scripts/build_developer.sh
+++ b/scripts/build_developer.sh
@@ -17,8 +17,11 @@ _SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 _BUILD_BASE=torch_xla
 
 # Parse commandline flags.
-while getopts 'b:ht' OPTION; do
+while getopts 'ab:ht' OPTION; do
   case $OPTION in
+  a)
+    _BUILD_BASE="pytorch"
+    ;;
   b)
     _BUILD_BASE=$OPTARG
     # Validate _BUILD_BASE.
@@ -31,9 +34,10 @@ while getopts 'b:ht' OPTION; do
     esac
     ;;
   h)
-    echo "Usage: $0 [-b <base_project>] [-t]"
+    echo "Usage: $0 [-b <base_project>] [-a] [-t]"
     echo "where"
     echo "  -b <base_project> selects which project to start the build from. <base_project> be pytorch, vision, or torch_xla (the default)."
+    echo "  -a (short for -b pytorch) builds all projects."
     echo "  -t checks that the torch_xla and torchax libraries are built and installed successfully."
     exit 0
     ;;

--- a/scripts/git_sync_main.py
+++ b/scripts/git_sync_main.py
@@ -146,24 +146,36 @@ def main() -> None:
       help=('sync the given repo and all repos that depend on it; '
             'the default is torch_xla'),
   )
+  arg_parser.add_argument(
+      '--all',
+      '-a',
+      action='store_true',
+      help=('sync all repos (pytorch, vision, and torch_xla); shorthand for '
+            '--base_repo pytorch'),
+  )
 
   args = arg_parser.parse_args()
 
-  success = True
-  if args.base_repo == _PYTORCH_REPO:
-    if not sync_repo(_PYTORCH_REPO):
-      success = False
+  sync_pytorch = args.all or args.base_repo == _PYTORCH_REPO
+  sync_vision = sync_pytorch or args.base_repo == _VISION_REPO
 
-  if args.base_repo in (_PYTORCH_REPO, _VISION_REPO):
-    # The torchvision repo is optional, so skip it if it doesn't exist.
-    if os.path.isdir(_VISION_DIR) and not sync_repo(_VISION_REPO):
-      success = False
+  failed_repos: list[str] = []
+  if sync_pytorch and not sync_repo(_PYTORCH_REPO):
+    failed_repos.append(_PYTORCH_REPO)
+
+  if (
+      sync_vision and
+      # The torchvision repo is optional, so skip it if it doesn't exist.
+      os.path.isdir(_VISION_DIR) and not sync_repo(_VISION_REPO)):
+    failed_repos.append(_VISION_REPO)
 
   if not sync_repo(_TORCH_XLA_REPO):
-    success = False
+      failed_repos.append(_TORCH_XLA_REPO)
 
-  if not success:
-    logger.error('Failed to sync some repos.')
+  # Print the failed repos last, so that the error is not buried in
+  # the middle of the messages.
+  if failed_repos:
+    logger.error(f'Failed to sync repos: {", ".join(failed_repos)}.')
     sys.exit(1)
 
   logger.info('All repos synced successfully.')

--- a/scripts/git_sync_main.py
+++ b/scripts/git_sync_main.py
@@ -163,14 +163,13 @@ def main() -> None:
   if sync_pytorch and not sync_repo(_PYTORCH_REPO):
     failed_repos.append(_PYTORCH_REPO)
 
-  if (
-      sync_vision and
+  if (sync_vision and
       # The torchvision repo is optional, so skip it if it doesn't exist.
       os.path.isdir(_VISION_DIR) and not sync_repo(_VISION_REPO)):
     failed_repos.append(_VISION_REPO)
 
   if not sync_repo(_TORCH_XLA_REPO):
-      failed_repos.append(_TORCH_XLA_REPO)
+    failed_repos.append(_TORCH_XLA_REPO)
 
   # Print the failed repos last, so that the error is not buried in
   # the middle of the messages.


### PR DESCRIPTION
It's a common use case to sync/build all 3 projects (pytorch, vision, and torch_xla). Add a `-a` (all) flag for `build_developer.sh` and `git_sync_main.py` to simply the usage (so that the developer doesn't have to type `-b pytorch`).