### PR TITLE
Update submodules whenever we switch branches.

### DIFF
--- a/scripts/git_sync_main.py
+++ b/scripts/git_sync_main.py
@@ -133,7 +133,6 @@ def sync_repo(repo: str) -> bool:
         f'Failed to checkout the {orig_branch} branch of the {repo} repo.')
     success = False
 
-
   # Update the submodules to avoid outdated submodules showing up as uncommited
   # changes. We need to do this to be safe whenever we switch to a new branch.
   if os.system('git submodule update --init --recursive') != 0:


### PR DESCRIPTION
Git submodules don't interact well with branches. In particular, when we `git checkout` a branch, the submodules in the repo won't automatically update to match the new branch's status. This often leads to the submodules showing up as changed, messing up the git status.

To be safe, we should update the submodules whenever we switch branches. This PR makes `git_sync_main.py` do this.