### PR TITLE
Split _ops and _decomps.

### DIFF
--- a/torchax/test/test_libraries.py
+++ b/torchax/test/test_libraries.py
@@ -6,7 +6,6 @@ import torchax
 import torchax.export
 from torchax.ops import jaten
 from torchax.ops import jlibrary
-
 # Create a `mylib` library which has a basic SDPA op.
 m = Library("mylib", "DEF")
 m.define("scaled_dot_product_attention(Tensor q, Tensor k, Tensor v) -> Tensor")

--- a/torchax/test/test_ops.py
+++ b/torchax/test/test_ops.py
@@ -188,7 +188,6 @@ class TestOpInfo(TestCase):
     torchax.enable_accuracy_mode()
     #self.env.config.debug_accuracy_for_each_op = True
     self.env.config.debug_print_each_op = True
-    self.env.config.debug_print_each_op_operands = True
     torch.manual_seed(0)
     self.old_var = self.env.config.use_torch_native_for_cpu_tensor
     self.env.config.use_torch_native_for_cpu_tensor = False

--- a/torchax/test/test_ops.py
+++ b/torchax/test/test_ops.py
@@ -143,26 +143,26 @@ def run_export_and_compare(testcase,
           (sample_input.input, sample_input.args, sample_input.kwargs))
       with testcase.env:
         res2 = func(input2, *args2, **kwargs2)
-      res2 = pytree.tree_map_only(tensor.Tensor, lambda t: t.torch(), res2)
-      with testcase.subTest("torchax_diff:" + str(atol)):
-        if ignore_indices and isinstance(res, tuple) and len(res) == 2:
-          diff_output(
-              testcase,
-              res[0],
-              res2[0],
-              atol=atol,
-              rtol=rtol,
-              equal_nan=equal_nan,
-              check_output=check_output)
-        else:
-          diff_output(
-              testcase,
-              res,
-              res2,
-              atol=atol,
-              rtol=rtol,
-              equal_nan=equal_nan,
-              check_output=check_output)
+        res2 = pytree.tree_map_only(tensor.Tensor, lambda t: t.torch(), res2)
+        with testcase.subTest("torchax_diff:" + str(atol)):
+          if ignore_indices and isinstance(res, tuple) and len(res) == 2:
+            diff_output(
+                testcase,
+                res[0],
+                res2[0],
+                atol=atol,
+                rtol=rtol,
+                equal_nan=equal_nan,
+                check_output=check_output)
+          else:
+            diff_output(
+                testcase,
+                res,
+                res2,
+                atol=atol,
+                rtol=rtol,
+                equal_nan=equal_nan,
+                check_output=check_output)
 
 
 ops_to_test = [

--- a/torchax/test_dist/test_distributed.py
+++ b/torchax/test_dist/test_distributed.py
@@ -79,17 +79,17 @@ def test_all_gather_tensor_func(multi_cpu, process_group):
     ],
 )
 def test_all_reduce(op, expected, multi_cpu, process_group):
-    device_count = multi_cpu
+  device_count = multi_cpu
 
-    def f(index):
-      with torchax.default_env():
-        dist.all_reduce(index, op)
-        return index
+  def f(index):
+    with torchax.default_env():
+      dist.all_reduce(index, op)
+      return index
 
-    res = torchax.distributed.spawn(f)
+  res = torchax.distributed.spawn(f)
 
-    expected_tensors = [expected for _ in range(device_count)]
-    np.testing.assert_equal(res.numpy(), expected_tensors)
+  expected_tensors = [expected for _ in range(device_count)]
+  np.testing.assert_equal(res.numpy(), expected_tensors)
 
 
 @pytest.mark.parametrize(

--- a/torchax/torchax/decompositions.py
+++ b/torchax/torchax/decompositions.py
@@ -131,7 +131,7 @@ _try_register(aten.rand_like, rand_like)
 
 
 def bernoulli_float(self, p=0.5):
-  return self.bernoulli_(torch.tensor(p))
+  return self.bernoulli_(p)
 
 
 _try_register(aten.bernoulli_.float, bernoulli_float)

--- a/torchax/torchax/ops/jaten.py
+++ b/torchax/torchax/ops/jaten.py
@@ -5571,10 +5571,10 @@ mutation_needs_env = {
     torch.ops.aten.bernoulli_.float,
 }
 
-for op, mutation in mutation_ops_to_functional.items():
+for operator, mutation in mutation_ops_to_functional.items():
   ops_registry.register_torch_dispatch_op(
-      op,
+      operator,
       mutation,
       is_jax_function=False,
       is_view_op=True,
-      needs_env=(op in mutation_needs_env))
+      needs_env=(operator in mutation_needs_env))

--- a/torchax/torchax/ops/jaten.py
+++ b/torchax/torchax/ops/jaten.py
@@ -23,58 +23,6 @@ all_ops = {}
 # list all Aten ops from pytorch that does mutation
 # and need to be implemented in jax
 
-mutation_ops_to_functional = {
-    torch.ops.aten.add_: torch.ops.aten.add,
-    torch.ops.aten.sub_: torch.ops.aten.sub,
-    torch.ops.aten.mul_: torch.ops.aten.mul,
-    torch.ops.aten.div_: torch.ops.aten.div,
-    torch.ops.aten.pow_: torch.ops.aten.pow,
-    torch.ops.aten.lt_: torch.ops.aten.lt,
-    torch.ops.aten.le_: torch.ops.aten.le,
-    torch.ops.aten.gt_: torch.ops.aten.gt,
-    torch.ops.aten.ge_: torch.ops.aten.ge,
-    torch.ops.aten.eq_: torch.ops.aten.eq,
-    torch.ops.aten.ne_: torch.ops.aten.ne,
-    torch.ops.aten.bernoulli_: torch.ops.aten.bernoulli.p,
-    torch.ops.aten.geometric_: torch.ops.aten.geometric,
-    torch.ops.aten.normal_: torch.ops.aten.normal,
-    torch.ops.aten.random_: torch.ops.aten.uniform,
-    torch.ops.aten.uniform_: torch.ops.aten.uniform,
-    torch.ops.aten.relu_: torch.ops.aten.relu,
-    # squeeze_ is expected to change tensor's shape. So replace with new value
-    torch.ops.aten.squeeze_: (torch.ops.aten.squeeze, True),
-    torch.ops.aten.sqrt_: torch.ops.aten.sqrt,
-    torch.ops.aten.clamp_: torch.ops.aten.clamp,
-    torch.ops.aten.clamp_min_: torch.ops.aten.clamp_min,
-    torch.ops.aten.sigmoid_: torch.ops.aten.sigmoid,
-    torch.ops.aten.tanh_: torch.ops.aten.tanh,
-    torch.ops.aten.ceil_: torch.ops.aten.ceil,
-    torch.ops.aten.logical_not_: torch.ops.aten.logical_not,
-    torch.ops.aten.unsqueeze_: torch.ops.aten.unsqueeze,
-    torch.ops.aten.transpose_: torch.ops.aten.transpose,
-    torch.ops.aten.log_normal_: torch.ops.aten.log_normal,
-    torch.ops.aten.scatter_add_: torch.ops.aten.scatter_add,
-    torch.ops.aten.scatter_reduce_.two: torch.ops.aten.scatter_reduce,
-    torch.ops.aten.scatter_: torch.ops.aten.scatter,
-    torch.ops.aten.bitwise_or_: torch.ops.aten.bitwise_or,
-}
-
-# Note: tuple comparisons work intuitively, e.g. `_jax_version >= (0, 4, 32)`.
-_jax_version = tuple(int(v) for v in jax.version._version.split("."))
-
-
-def make_mutation(op):
-  if type(mutation_ops_to_functional[op]) is tuple:
-    return op_base.InplaceOp(
-        mutation_ops_to_functional[op][0],
-        replace=mutation_ops_to_functional[op][1],
-        position_to_mutate=0)
-  return op_base.InplaceOp(mutation_ops_to_functional[op], position_to_mutate=0)
-
-
-for op in mutation_ops_to_functional.keys():
-  ops_registry.register_torch_dispatch_op(
-      op, make_mutation(op), is_jax_function=False, is_view_op=True)
 
 
 def op(*aten, **kwargs):
@@ -162,14 +110,20 @@ def _aten_trunc(x):
 
 @op(torch.ops.aten.index_copy)
 def _aten_index_copy(x, dim, indexes, source):
+  if x.ndim == 0:
+    return source
+  if x.ndim == 1:
+    source = jnp.squeeze(source)
   # return jax.lax.scatter(x, index, dim)
+  if dim < 0:
+    dim = dim + x.ndim
   dims = []
   for i in range(len(x.shape)):
     if i == dim:
       dims.append(indexes)
     else:
       dims.append(slice(None, None, None))
-  return x.at[dim].set(source)
+  return x.at[tuple(dims)].set(source)
 
 
 # aten.cauchy_
@@ -404,7 +358,7 @@ def _aten_transpose(x, dim0, dim1):
 
 
 @op(torch.ops.aten.triu)
-def _aten_triu(m, k):
+def _aten_triu(m, k=0):
   return jnp.triu(m, k)
 
 
@@ -740,15 +694,15 @@ def _aten__to_copy(self, **kwargs):
 
 
 @op(torch.ops.aten.empty)
-@op_base.convert_dtype()
+@op_base.convert_dtype(use_default_dtype=False)
 def _aten_empty(size: Sequence[int], *, dtype=None, **kwargs):
   return jnp.empty(size, dtype=dtype)
 
 
 @op(torch.ops.aten.empty_like)
-@op_base.convert_dtype()
+@op_base.convert_dtype(use_default_dtype=False)
 def _aten_empty_like(input, *, dtype=None, **kwargs):
-  return jnp.empty_like(input, dtype=dtype)
+  return jnp.empty_like(input, dtype)
 
 
 @op(torch.ops.aten.ones)
@@ -1202,7 +1156,6 @@ def _aten__native_batch_norm_legit(input, weight, bias, running_mean,
   """
   reduction_dims = [0] + list(range(2, input.ndim))
   reshape_dims = [1, -1] + [1] * (input.ndim - 2)
-
   if training:
     # Calculate batch mean and variance
     mean = jnp.mean(input, axis=reduction_dims, keepdims=True)
@@ -1215,9 +1168,7 @@ def _aten__native_batch_norm_legit(input, weight, bias, running_mean,
     saved_rstd = jnp.squeeze(rstd, reduction_dims)
   else:
     rstd = jax.lax.rsqrt(running_var.reshape(reshape_dims) + eps)
-    saved_mean = jnp.array(
-        [], dtype=input.dtype
-    )  # No need to calculate batch statistics in inference mode
+    saved_mean = jnp.array([], dtype=input.dtype)  # No need to calculate batch statistics in inference mode
     saved_rstd = jnp.array([], dtype=input.dtype)
 
   # Normalize
@@ -1919,39 +1870,6 @@ def _aten_acos(self):
 @op(torch.ops.aten.gt)
 def _aten_gt(self, other):
   return self > other
-
-
-# aten.pixel_shuffle
-@op(torch.ops.aten.pixel_shuffle)
-def _aten_pixel_shuffle(x, upscale_factor):
-  """PixelShuffle implementation in JAX.
-
-  Args:
-    x: Input tensor. Typically a feature map.
-    upscale_factor: Integer by which to upscale the spatial dimensions.
-
-  Returns:
-    Tensor after PixelShuffle operation.
-  """
-
-  batch_size, channels, height, width = x.shape
-
-  if channels % (upscale_factor**2) != 0:
-    raise ValueError(
-        "Number of channels must be divisible by the square of the upscale factor."
-    )
-
-  new_channels = channels // (upscale_factor**2)
-  new_height = height * upscale_factor
-  new_width = width * upscale_factor
-
-  x = x.reshape(batch_size, new_channels, upscale_factor, upscale_factor,
-                height, width)
-  x = jnp.transpose(x,
-                    (0, 1, 2, 4, 3, 5))  # Move channels to spatial dimensions
-  x = x.reshape(batch_size, new_channels, new_height, new_width)
-
-  return x
 
 
 # aten.sym_stride
@@ -2811,7 +2729,8 @@ def _aten_lgamma(input, *, out=None):
 
 @op(torch.ops.aten.mvlgamma)
 def _aten_mvlgamma(input, p, *, out=None):
-  return jax.scipy.special.multigammaln(input, d)
+  input = input.astype(mappings.t2j_dtype(torch.get_default_dtype()))
+  return jax.scipy.special.multigammaln(input, p)
 
 
 @op(torch.ops.aten.linalg_eig)
@@ -3625,8 +3544,9 @@ def _randn(
   return res
 
 
-@op(torch.ops.aten.bernoulli.p, needs_env=True)
-def _bernoulli(
+@op(torch.ops.aten.bernoulli.p, 
+    needs_env=True)
+def _aten_bernoulli(
     self,
     p=0.5,
     *,
@@ -4935,7 +4855,12 @@ def _aten_flatten(x, start_dim=0, end_dim=-1):
 
 @op(torch.ops.aten.new_empty)
 def _new_empty(self, size, **kwargs):
-  return jnp.empty(size)
+  dtype = kwargs.get('dtype')
+  if dtype is not None:
+    dtype = mappings.t2j_dtype(dtype)
+  else:
+    dtype = self.dtype
+  return jnp.empty(size, dtype=dtype)
 
 
 @op(torch.ops.aten.new_empty_strided)
@@ -5517,3 +5442,97 @@ def kthvalue(input, k, dim=None, keepdim=False, *, out=None):
       jnp.argpartition(input, k - 1, dimension).astype('int64'), k - 1,
       dimension, keepdim)
   return values, indices
+
+
+@op(torch.ops.aten.take)
+def _aten_take(self, index):
+  return self.flatten()[index]
+
+# func: pad(Tensor self, SymInt[] pad, str mode="constant", float? value=None) -> Tensor
+@op(torch.ops.aten.pad)
+def _aten_pad(self, pad, mode='constant', value=None):
+  if not isinstance(pad, (tuple, list)) or len(pad) % 2 != 0:
+      raise ValueError("Padding must be a sequence of even length.")
+
+  num_dims = self.ndim
+  if len(pad) > 2 * num_dims:
+      raise ValueError(f"Padding sequence length ({len(pad)}) exceeds 2 * number of dimensions ({2 * num_dims}).")
+
+  # JAX's pad function expects padding for each dimension as a tuple of (low, high)
+  # We need to reverse the pad sequence and group them for JAX.
+  # pad = [p_l0, p_r0, p_l1, p_r1, ...]
+  # becomes ((..., ..., (p_l1, p_r1), (p_l0, p_r0)))
+  jax_pad_width = []
+  # Iterate in reverse pairs
+  for i in range(len(pad) // 2):
+      jax_pad_width.append((pad[(2 * i)], pad[(2 * i + 1)]))
+
+  # Pad any leading dimensions with (0, 0) if the pad sequence is shorter
+  # than the number of dimensions.
+  for _ in range(num_dims - len(pad) // 2):
+      jax_pad_width.append((0, 0))
+
+  # Reverse the jax_pad_width list to match the dimension order
+  jax_pad_width.reverse()
+
+  if mode == "constant":
+      if value is None:
+        value = 0.0
+      return jnp.pad(self, pad_width=jax_pad_width, mode="constant", constant_values=value)
+  elif mode == "reflect":
+      return jnp.pad(self, pad_width=jax_pad_width, mode="reflect")
+  elif mode == "edge":
+      return jnp.pad(self, pad_width=jax_pad_width, mode="edge")
+  else:
+      raise ValueError(f"Unsupported padding mode: {mode}. Expected 'constant', 'reflect', or 'edge'.")
+
+
+mutation_ops_to_functional = {
+    torch.ops.aten.add_: op_base.InplaceOp( torch.ops.aten.add),
+    torch.ops.aten.sub_: op_base.InplaceOp( torch.ops.aten.sub),
+    torch.ops.aten.mul_: op_base.InplaceOp( torch.ops.aten.mul),
+    torch.ops.aten.div_: op_base.InplaceOp( torch.ops.aten.div),
+    torch.ops.aten.pow_: op_base.InplaceOp( torch.ops.aten.pow),
+    torch.ops.aten.lt_: op_base.InplaceOp( torch.ops.aten.lt),
+    torch.ops.aten.le_: op_base.InplaceOp( torch.ops.aten.le),
+    torch.ops.aten.gt_: op_base.InplaceOp( torch.ops.aten.gt),
+    torch.ops.aten.ge_: op_base.InplaceOp( torch.ops.aten.ge),
+    torch.ops.aten.eq_: op_base.InplaceOp( torch.ops.aten.eq),
+    torch.ops.aten.ne_: op_base.InplaceOp( torch.ops.aten.ne),
+    torch.ops.aten.bernoulli_: op_base.InplaceOp( torch.ops.aten.bernoulli.p),
+    torch.ops.aten.bernoulli_.float: op_base.InplaceOp(_aten_bernoulli, is_jax_func=True),
+    torch.ops.aten.geometric_: op_base.InplaceOp( torch.ops.aten.geometric),
+    torch.ops.aten.normal_: op_base.InplaceOp( torch.ops.aten.normal),
+    torch.ops.aten.random_: op_base.InplaceOp( torch.ops.aten.uniform),
+    torch.ops.aten.uniform_: op_base.InplaceOp( torch.ops.aten.uniform),
+    torch.ops.aten.relu_: op_base.InplaceOp( torch.ops.aten.relu),
+    # squeeze_ is expected to change tensor's shape. So replace with new value
+    torch.ops.aten.squeeze_: op_base.InplaceOp( torch.ops.aten.squeeze, True),
+    torch.ops.aten.sqrt_: op_base.InplaceOp( torch.ops.aten.sqrt),
+    torch.ops.aten.clamp_: op_base.InplaceOp( torch.ops.aten.clamp),
+    torch.ops.aten.clamp_min_: op_base.InplaceOp( torch.ops.aten.clamp_min),
+    torch.ops.aten.sigmoid_: op_base.InplaceOp( torch.ops.aten.sigmoid),
+    torch.ops.aten.tanh_: op_base.InplaceOp( torch.ops.aten.tanh),
+    torch.ops.aten.ceil_: op_base.InplaceOp( torch.ops.aten.ceil),
+    torch.ops.aten.logical_not_: op_base.InplaceOp( torch.ops.aten.logical_not),
+    torch.ops.aten.unsqueeze_: op_base.InplaceOp( torch.ops.aten.unsqueeze),
+    torch.ops.aten.transpose_: op_base.InplaceOp( torch.ops.aten.transpose),
+    torch.ops.aten.log_normal_: op_base.InplaceOp( torch.ops.aten.log_normal),
+    torch.ops.aten.scatter_add_: op_base.InplaceOp( torch.ops.aten.scatter_add),
+    torch.ops.aten.scatter_reduce_.two: op_base.InplaceOp( torch.ops.aten.scatter_reduce),
+    torch.ops.aten.scatter_: op_base.InplaceOp( torch.ops.aten.scatter),
+    torch.ops.aten.bitwise_or_: op_base.InplaceOp( torch.ops.aten.bitwise_or),
+}
+
+# Note: tuple comparisons work intuitively, e.g. `_jax_version >= (0, 4, 32)`.
+_jax_version = tuple(int(v) for v in jax.version._version.split("."))
+
+mutation_needs_env = {
+  torch.ops.aten.bernoulli_, 
+  torch.ops.aten.bernoulli_.float, 
+}
+
+
+for op, mutation in mutation_ops_to_functional.items():
+  ops_registry.register_torch_dispatch_op(
+      op, mutation, is_jax_function=False, is_view_op=True, needs_env=(op in mutation_needs_env))

--- a/torchax/torchax/ops/jaten.py
+++ b/torchax/torchax/ops/jaten.py
@@ -16,7 +16,6 @@ from torchax.ops import op_base, mappings
 from torchax import interop
 from torchax.ops import jax_reimplement
 from torchax.view import View
-from torchax.tensor import Tensor
 # Keys are OpOverload, value is a callable that takes
 # Tensor
 all_ops = {}
@@ -820,8 +819,8 @@ def split_with_sizes(x, sizes, dim=0):
     A list of sub-arrays.
   """
   if isinstance(sizes, int):
-    # split equal size
-    new_sizes = [sizes] * (x.shape[dim] // sizes)
+    # split equal size, round up
+    new_sizes = [sizes] * (-(-x.shape[dim] // sizes))
     sizes = new_sizes
   rank = x.ndim
   splits = np.cumsum(sizes)  # Cumulative sum for split points
@@ -1179,7 +1178,7 @@ def _aten_convolution(
 
 
 # _native_batch_norm_legit(Tensor input, Tensor? weight, Tensor? bias, Tensor(a!) running_mean, Tensor(b!) running_var, bool training, float momentum, float eps)
-@op(torch.ops.aten._native_batch_norm_legit)
+@op(torch.ops.aten._native_batch_norm_legit.default)
 def _aten__native_batch_norm_legit(input, weight, bias, running_mean,
                                    running_var, training, momentum, eps):
   """JAX implementation of batch normalization with optional parameters.
@@ -2565,6 +2564,11 @@ def _aten_cos(input):
 @op_base.promote_int_input
 def _aten_cosh(input):
   return jnp.cosh(input)
+
+  
+@op(torch.ops.aten.diag)
+def _aten_diag(input, diagonal=0):
+  return jnp.diag(input, diagonal)
 
 
 # aten.diagonal

--- a/torchax/torchax/ops/jaten.py
+++ b/torchax/torchax/ops/jaten.py
@@ -20,9 +20,6 @@ from torchax.view import View
 # Tensor
 all_ops = {}
 
-# list all Aten ops from pytorch that does mutation
-# and need to be implemented in jax
-
 
 def op(*aten, **kwargs):
 

--- a/torchax/torchax/ops/op_base.py
+++ b/torchax/torchax/ops/op_base.py
@@ -13,7 +13,11 @@ from typing import Callable, Optional, ParamSpec, Concatenate
 
 class InplaceOp:
 
-  def __init__(self, functional_op, replace=False, position_to_mutate=0, is_jax_func=False):
+  def __init__(self,
+               functional_op,
+               replace=False,
+               position_to_mutate=0,
+               is_jax_func=False):
     self.functional = functional_op
     self.replace = replace
     self.position_to_mutate = position_to_mutate
@@ -35,7 +39,7 @@ class InplaceOp:
       new_value = env.j2t_iso(new_value_jax)
     else:
       new_value = self.functional(view_value, *args[1:], **kwargs)
-    
+
     if isinstance(to_mutate, View):
       to_mutate.update(new_value)
     else:

--- a/torchax/torchax/ops/op_base.py
+++ b/torchax/torchax/ops/op_base.py
@@ -13,27 +13,36 @@ from typing import Callable, Optional, ParamSpec, Concatenate
 
 class InplaceOp:
 
-  def __init__(self, functional_op, replace=False, position_to_mutate=0):
+  def __init__(self, functional_op, replace=False, position_to_mutate=0, is_jax_func=False):
     self.functional = functional_op
     self.replace = replace
     self.position_to_mutate = position_to_mutate
+    self.is_jax_func = is_jax_func
 
   def __call__(self, *args, **kwargs):
-    to_mutate = args[0]
+    to_mutate = args[self.position_to_mutate]
+    view_value = to_mutate
     if isinstance(to_mutate, View):
       view_value = to_mutate.torch()
       # Convert the target View to a Tensor, and
       # leave the rest args as is. If other args are
       # also View, they will be converted to tensors
       # in the self.functional dispatch.
+    env = view_value._env
+    if self.is_jax_func:
+      view_value, args, kwargs = env.t2j_iso((view_value, args, kwargs))
+      new_value_jax = self.functional(view_value, *args[1:], **kwargs)
+      new_value = env.j2t_iso(new_value_jax)
+    else:
       new_value = self.functional(view_value, *args[1:], **kwargs)
+    
+    if isinstance(to_mutate, View):
       to_mutate.update(new_value)
-      return to_mutate
     else:
       if self.replace:
-        to_mutate._elem = self.functional(*args, **kwargs)._elem
+        to_mutate._elem = new_value._elem
       else:
-        to_mutate.copy_(self.functional(*args, **kwargs))
+        to_mutate.copy_(new_value)
     return to_mutate
 
 

--- a/torchax/torchax/tensor.py
+++ b/torchax/torchax/tensor.py
@@ -374,7 +374,7 @@ class Environment(contextlib.ContextDecorator):
     from torchax.decompositions import DECOMPOSITIONS, MUTABLE_DECOMPOSITION
 
     for k, v in DECOMPOSITIONS.items():
-      if k not in self._ops:
+      if k not in self._decomps:
         self._decomps[k] = ops_registry.Operator(
             k,
             v,

--- a/torchax/torchax/tensor.py
+++ b/torchax/torchax/tensor.py
@@ -123,9 +123,10 @@ class Tensor(torch.Tensor):
 
   @classmethod
   def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
-    raise AssertionError('torchax Tensors can only do math within torchax environment.'
-                         'Please wrap your code with `with torchax.defautl_env()` or '
-                         'call torchax.enable_globally() before.')
+    raise AssertionError(
+        'torchax Tensors can only do math within torchax environment.'
+        'Please wrap your code with `with torchax.defautl_env()` or '
+        'call torchax.enable_globally() before.')
 
   def detach(self):
     return Tensor(jax.lax.stop_gradient(self.jax()), self._env)
@@ -363,12 +364,11 @@ class Environment(contextlib.ContextDecorator):
   def load_ops(self):
     from torchax.ops import jaten, jtorch, jc10d, jtorchvision_nms
 
-    for k, v in itertools.chain(
-        ops_registry.all_aten_ops.items(), 
-        ops_registry.all_torch_functions.items()):
+    for k, v in itertools.chain(ops_registry.all_aten_ops.items(),
+                                ops_registry.all_torch_functions.items()):
       if v.is_jax_function:
         self._ops[k] = v
-      else: 
+      else:
         self._decomps[k] = v
 
     from torchax.decompositions import DECOMPOSITIONS, MUTABLE_DECOMPOSITION
@@ -424,7 +424,7 @@ class Environment(contextlib.ContextDecorator):
         with mode_utils.no_dispatch(), torch._C.DisableTorchFunction():
           the_tensor = the_tensor.to(new_dtype)
 
-      if new_device is None: ## device is None means don't change device
+      if new_device is None:  ## device is None means don't change device
         return the_tensor
 
       jax_device = self.get_as_jax_device(new_device)
@@ -518,7 +518,6 @@ class Environment(contextlib.ContextDecorator):
           torch.distributed._functional_collectives.wait_tensor,
           (args, kwargs),
       )
-
 
       try:
         if not op.is_view_op:

--- a/torchax/torchax/tensor.py
+++ b/torchax/torchax/tensor.py
@@ -127,8 +127,8 @@ class Tensor(torch.Tensor):
     if func == torch.ops._c10d_functional.wait_tensor.default:
       return args[0]._env.dispatch(func, types, args, kwargs)
     raise AssertionError(
-        'torchax Tensors can only do math within torchax environment.'
-        'Please wrap your code with `with torchax.defautl_env()` or '
+        'torchax Tensors can only do math within the torchax environment.'
+        'Please wrap your code with `with torchax.default_env()` or '
         'call torchax.enable_globally() before.')
 
   def detach(self):

--- a/torchax/torchax/view.py
+++ b/torchax/torchax/view.py
@@ -332,7 +332,10 @@ class View(torch.Tensor):
       args: Tuple[Any, ...] = (),
       kwargs: Optional[dict] = None,
   ) -> Any:
-    assert False
+    raise AssertionError(
+        'torchax Tensors can only do math within the torchax environment.'
+        'Please wrap your code with `with torchax.default_env()` or '
+        'call torchax.enable_globally() before.')
 
   def create_sub_view(self, view_info: ViewInfo) -> "View":
     """

--- a/torchax/torchax/view.py
+++ b/torchax/torchax/view.py
@@ -332,17 +332,7 @@ class View(torch.Tensor):
       args: Tuple[Any, ...] = (),
       kwargs: Optional[dict] = None,
   ) -> Any:
-    from torchax.tensor import Tensor
-
-    env = None
-    for arg in torch_pytree.arg_tree_leaves(*args, **(kwargs or {})):
-      if isinstance(arg, Tensor) or isinstance(arg, View):
-        env = arg._env
-        break
-
-    with env:
-      res = func(*args, **(kwargs or {}))
-      return res
+    assert False
 
   def create_sub_view(self, view_info: ViewInfo) -> "View":
     """


### PR DESCRIPTION
We use _ops as jax implementation of a aten op of torch function. And we use _decomps as aten op implementation written in terms of other aten ops.

Splitting this has implication on the order of op resolution:

For an ATen op (OpOverload):
1. if the same op itself is found, then it is used
2. if not, we lookup by `op.overloadpacket` for a catch all. 
decomps often registered for op overload, so 1. will find a decomp despite there is a jax impl for the overloadpacket.

So previously, many jax impl are not used at all. So we are not testing those.
This change make it prefer jax impl; and only if the op and overload packet are not found we go through decomposition.