### PR TITLE
Refactor call_jax to allow implementing ops in python

### DIFF
--- a/test/test_python_backend.py
+++ b/test/test_python_backend.py
@@ -1,0 +1,50 @@
+import unittest
+import torch
+from torch_xla.core import xla_builder
+
+
+class PythonBackendTest(unittest.TestCase):
+
+  def test_flatten_func(self):
+
+    def func_that_takes_dict_and_list(nested_dict, nested_list):
+      return nested_dict['a']['b'] + nested_list[2][3]
+
+    dict1 = {'a': {'b': 5}}
+    list1 = [0, 0, [0, 0, 0, 5]]
+
+    expected = func_that_takes_dict_and_list(dict1, list1)
+
+    flattened = xla_builder.FlattenedInputFunc(func_that_takes_dict_and_list)
+
+    actual = flattened.postprocess(
+        flattened.flat_call(flattened.preprocess((dict1, list1))))
+
+    self.assertEqual(expected, actual)
+
+    dict2 = {'a': {'b': 5, 'c': 7}}
+    list2 = [0, 0, [0, 0, 0, 5, 6]]
+
+    expected2 = func_that_takes_dict_and_list(dict1, list1)
+    actual2 = flattened.postprocess(
+        flattened.flat_call(flattened.preprocess((dict2, list2))))
+    self.assertEqual(expected2, actual2)
+
+  def test_xla_callable(self):
+
+    def add(a, b):
+      return xla_builder.Op.sin(a) + b
+
+    xla_func = xla_builder.XlaCallable(add)
+
+    a = torch.randn(2, 2, device='xla')
+    b = torch.randn(2, 2, device='xla')
+    res = xla_func(a, b)
+
+    expected = torch.sin(a.cpu()) + b.cpu()
+
+    self.assertTrue(torch.allclose(expected, res.cpu()))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/torch_xla/core/xla_builder.py
+++ b/torch_xla/core/xla_builder.py
@@ -5,6 +5,8 @@ import torch
 import torch_xla
 from torch.utils._pytree import tree_flatten
 from torch_xla._internal.jax_workarounds import jax_env_context, jax_import_guard, requires_jax, maybe_get_torchax
+import torch_xla.debug.profiler as xp
+import abc
 
 
 class Type:
@@ -815,7 +817,6 @@ def create_computation(name, fn, shapes, **kwargs):
   for shape in shapes:
     p = mkparam(builder, len(params), shape)
     params.append(p)
-
   root = fn(*params, **kwargs)
   return root.build(name)
 
@@ -828,57 +829,115 @@ def get_computation_hlo(computation):
   return torch_xla._XLAC._xla_computation_text(computation)
 
 
-class XlaComputation:
+def xla_computation_as_func(computation, name=None):
+  name = name or "xla::computation"
+  if not '::' in name:
+    name = 'xla::' + name
 
-  def __init__(self, name: str, computation: torch_xla._XLAC.XlaComputation,
-               pick_tensor_args, out_spec):
-    """
-    Creates an XlaComputation object wrapping an HLO module.
+  def fn(input_tensors):
+    result = torch_xla._XLAC._xla_user_computation(name, input_tensors,
+                                                   computation)
+    return result
 
-    Args:
-      name: a string name for debugging.
-      computation: a `torch_xla._XLAC.XlaComputation` object that executes an HLO module.
-      pick_tensor_args: a function that takes in a list of inputs and returns a list of
-        tensors to be passed to the computation.
-      out_spec: a pytree spec for the output of the computation.
-    """
-    self.computation = computation
-    self.name = name
-    self.pick_tensor_args = pick_tensor_args
-    self.out_spec = out_spec
-
-  @requires_jax
-  def __call__(self, input_list):
-    input_tensors = self.pick_tensor_args(input_list)
-    result = torch_xla._XLAC._xla_user_computation(f'xla::call_jax_{self.name}',
-                                                   input_tensors,
-                                                   self.computation)
-    assert isinstance(result, list)
-    import jax.tree_util
-    return jax.tree_util.tree_unflatten(self.out_spec, result)
+  return fn
 
 
-def jax_func_to_xla_computation(jax_func, args, kwargs, name=None):
-  if name is None:
-    name = 'jax_func_' + jax_func.__name__
+class FlattenedInputFunc:
+  """Wraps a Python function to provide an interface for calling it with
+  flattened PyTorch tensor arguments and handling flattened outputs.
 
-  # If we don't do this before calling jax, any torch_xla operation will hang.
-  jax_import_guard()
+  This class splits the call to the original function into 3 methods:
+  1. preprocess
+  2. flat_call
+  3. propost_process
+  
+  The invariant to hold is:
+  ```
+    flattened = FlattenedInputFunc(orig_function, sample_args, sample_kwargs)
+    orig_function(*sample_args, **sample_kwargs) == flattend.post_process(
+        flattend.flat_call(
+          flattened.preprocess(
+              sample_args, sample_kwargs)))
+  ```
 
-  # Prevent JAX from discovering MegaScale devices a second time. If we don't do this,
-  # then the MegaScale device discovery will hang.
-  with jax_env_context():
-    import jax
-    tx = maybe_get_torchax()
+  This class is useful for integrating functions with complex, nested argument
+  structures (pytrees) into systems that expect inputs and outputs as flat
+  lists of tensors, such as certain JAX transformations or model serving
+  frameworks.
 
-    flattened_inputs, spec = jax.tree.flatten((args, kwargs))
+  The structure of the inputs is determined from `sample_args` and
+  `sample_kwargs` provided during initialization. Non-tensor arguments
+  from these samples are stored and automatically re-inserted when the
+  function is called with new tensor inputs.
+  """
 
-    def convert_arg_to_jax(a):
-      if a is None:
-        return None
-      elif isinstance(a, torch.dtype):
-        return tx.ops.mappings.t2j_dtype(a)
-      return a
+  def __init__(self, orig_func):
+    self.tx = maybe_get_torchax()
+    self.orig_func = orig_func
+    self.non_tensors = None
+    self.in_spec = None
+    self.out_spec = None
+    # This is used to mark position of tensor inputs
+    self._sentinel = object()
+
+  def preprocess(self, args, kwargs=None):
+    with jax_env_context():
+      import jax
+      kwargs = kwargs or {}
+      flattened_inputs, spec = jax.tree.flatten((args, kwargs))
+      tensors = tuple(
+          a for a in flattened_inputs if isinstance(a, torch.Tensor))
+      self.non_tensors = tuple(
+          self._sentinel if isinstance(a, torch.Tensor) else a
+          for a in flattened_inputs)
+      # Note: saving the non_tensors and in_spec here
+      # because flat_call needs to take those as closure, not as inputs
+      # flat_call is meant to be processed by, say, jax.jit.
+      self.in_spec = spec
+      return tensors
+
+  def flat_call(self, flat_input):
+    with jax_env_context():
+      import jax
+      assert self.in_spec is not None, 'flat call only makes sense after preprocess is called'
+
+      # Put the tensor input and the non tensor input together
+      new_flattened = list(self.non_tensors)
+      tensor_args_iter = iter(flat_input)
+      for i in range(len(new_flattened)):
+        if new_flattened[i] is self._sentinel:
+          new_flattened[i] = next(tensor_args_iter)
+
+      args, kwargs = jax.tree.unflatten(self.in_spec, new_flattened)
+      res = self.orig_func(*args, **kwargs)
+      flattened_out, spec = jax.tree.flatten(res)
+      self.out_spec = spec
+      return flattened_out
+
+  def postprocess(self, res_flattened):
+    with jax_env_context():
+      import jax
+      assert self.out_spec is not None, 'post process only makes sense after flat_call is called'
+      res = jax.tree.unflatten(self.out_spec, res_flattened)
+      return res
+
+
+class CompiledCallableWithCache(abc.ABC):
+  """This class is meant to be subclassed.
+  
+  Given a function that can create shape-specialized computations
+  one can treat it as a shape-generic computations if one accepts that
+  shape changes will trigger recompile.
+  
+  This class captures this idea by having a cache for shapes.
+  the function that specializes are "passed in" via subclassing.
+  """
+
+  def __init__(self, flat_input_func: FlattenedInputFunc):
+    self._cache = {}
+    self._flat_input_func = flat_input_func
+
+  def __call__(self, *args, **kwargs):
 
     def abstractify(a):  # make a pytree leaf abstract
       if a is None:
@@ -888,91 +947,84 @@ def jax_func_to_xla_computation(jax_func, args, kwargs, name=None):
         return jax.ShapeDtypeStruct(a.shape, tx.ops.mappings.t2j_dtype(a.dtype))
       return a
 
-    flattened_inputs = list(convert_arg_to_jax(a) for a in flattened_inputs)
-    sample_inputs = tuple(abstractify(a) for a in flattened_inputs)
+    tensor_input_flattened = self._flat_input_func.preprocess(args, kwargs)
 
-    # Pick out the non-static args.
-    # Consider anything that is not a `jax.ShapeDtypeStruct` as a static arg.
-    def pick_tensor_args(flattened_args) -> list[torch.Tensor]:
-      tensor_args = []
-      for i in range(len(sample_inputs)):
-        if isinstance(sample_inputs[i], jax.ShapeDtypeStruct):
-          tensor_args.append(flattened_args[i])
-      return tensor_args
+    abstract_inputs = tuple((a.shape, a.dtype) if a is not None else a
+                            for a in tensor_input_flattened)
 
-    sample_tensor_args = pick_tensor_args(sample_inputs)
-    traced_out_spec = []
+    cache_key = hash((abstract_inputs, tuple(self._flat_input_func.non_tensors),
+                      self._flat_input_func.in_spec))
 
-    # This function only takes in tensor arguments and only returns tensor arguments
-    # because its signature must match the signature of the HLO module lowered from JAX,
-    # allowing us to wrap it in an XLA user computation.
-    def fn(*tensor_args):
-      # Go from a list of tensor args to the full list of flattened arguments,
-      # by referencing the original flattened inputs.
-      new_flattened = copy(flattened_inputs)
-      tensor_args_iter = iter(tensor_args)
-      for i in range(len(sample_inputs)):
-        if isinstance(sample_inputs[i], jax.ShapeDtypeStruct):
-          new_flattened[i] = next(tensor_args_iter)
-      args, kwargs = jax.tree.unflatten(spec, new_flattened)
-      # `out` could be a pytree, and we need to turn it into a flat list.
-      out = jax_func(*args, **kwargs)
-      # Obtain the tree spec to be used by `XlaComputation` to unflatten the output
-      # lazy tensors later.
-      assert len(traced_out_spec) == 0, "fn can only be traced once"
-      out_flat, out_spec = jax.tree.flatten(out)
-      traced_out_spec.append(out_spec)
-      return out_flat
+    if cache_key not in self._cache:
+      self._cache[cache_key] = self.especialize(tensor_input_flattened)
 
-    def get_xla_computation():
-      import torch_xla.debug.profiler as xp
-      # If we see this trace span in the profiler, we'll know that there's a cache miss.
-      with xp.Trace('jax_to_xla_computation'):
-        lowered = jax.jit(fn, keep_unused=True).lower(*sample_tensor_args)
-        hlo_ir = lowered.compiler_ir('hlo')
-        assert len(traced_out_spec) == 1, \
-            "fn must be traced to obtain the output tree spec"
-        spec = traced_out_spec[0]
-        # Get a protobuf representation of the HLO. `as_serialized_hlo_module_proto` is
-        # mentioned at https://github.com/jax-ml/jax/discussions/22266
-        hlo_module = hlo_ir.as_serialized_hlo_module_proto()  # type: ignore
-        computation = computation_from_module_proto(name, hlo_module)
-        return computation, spec
+    flat_callable = self._cache[cache_key]
 
-    computation, out_spec = _jax_to_xla_computation_cache_get_or_insert(
-        jax_func, sample_inputs, spec, get_xla_computation)
-    return XlaComputation(name, computation, pick_tensor_args, out_spec)
+    output = flat_callable(tensor_input_flattened)
+    return self._flat_input_func.postprocess(output)
+
+  @abc.abstractmethod
+  def especialize(self, sample_flat_args):
+    pass
 
 
-def _jax_to_xla_computation_cache_get_or_insert(jax_func,
-                                                sample_inputs: tuple[Any, ...],
-                                                input_tree_spec,
-                                                get_xla_computation):
-  from jax._src import config
-  global _JAX_TO_XLA_COMPUTATION_CACHE
-  # Use three layers of dictionary lookup.
-  # The first layer uses the `config.trace_context()`, which is strongly referenced.
-  # The second layer uses the `jax_func`, which is weakly referenced.
-  # The third layer uses the sample inputs and the tree spec, which is strongly referenced.
-  config_context_dict = _JAX_TO_XLA_COMPUTATION_CACHE.setdefault(
-      config.trace_context(), WeakKeyDictionary())
-  inner_dict = config_context_dict.setdefault(jax_func, {})
-  if (sample_inputs, input_tree_spec) in inner_dict:
-    return inner_dict[(sample_inputs, input_tree_spec)]
-  else:
-    hlo = get_xla_computation()
-    _JAX_TO_XLA_COMPUTATION_CACHE[config.trace_context()][jax_func][(
-        sample_inputs, input_tree_spec)] = hlo
-    return hlo
+class JaxCallable(CompiledCallableWithCache):
+
+  def __init__(self, jax_func):
+    super().__init__(FlattenedInputFunc(jax_func))
+
+  def especialize(self, sample_flat_args):
+    import jax
+    tx = maybe_get_torchax()
+    sample_flat_args = tuple(
+        jax.ShapeDtypeStruct(a.shape, tx.ops.mappings.t2j_dtype(a.dtype)
+                            ) if a is not None else None
+        for a in sample_flat_args)
+    with xp.Trace('jax_to_xla_computation'):
+      lowered = jax.jit(
+          self._flat_input_func.flat_call,
+          keep_unused=True).lower(sample_flat_args)
+      hlo_ir = lowered.compiler_ir('hlo')
+      # Get a protobuf representation of the HLO. `as_serialized_hlo_module_proto` is
+      # mentioned at https://github.com/jax-ml/jax/discussions/22266
+      hlo_module = hlo_ir.as_serialized_hlo_module_proto()  # type: ignore
+      computation = computation_from_module_proto('jax_callable', hlo_module)
+      return xla_computation_as_func(computation, 'jax_func')
+
+
+class XlaCallable(CompiledCallableWithCache):
+  """
+  
+  """
+
+  def __init__(self, xla_func):
+    """xla_func is a function that takes XlaOp as the placeholder and expresses
+    math using xla builder python API above
+    """
+    super().__init__(FlattenedInputFunc(xla_func))
+
+  def especialize(self, sample_flat_args):
+    sample_args_shapes = tuple(
+        Shape.create(Op.from_torch_type(a.dtype), a.shape)
+        for a in sample_flat_args)
+
+    with xp.Trace('jax_to_xla_computation'):
+      name = 'xla::computation'
+      builder = create_builder(name)
+      params = []
+      for a in sample_flat_args:
+        p = mkparam(builder, len(params),
+                    mkshape(Op.from_torch_type(a.dtype), a.shape))
+        params.append(p)
+      root = Op.tuple(self._flat_input_func.flat_call(params))
+      computation = root.build(name)
+      return xla_computation_as_func(computation, name)
 
 
 def _jax_to_xla_computation_cache_elements() -> int:
   size = 0
-  for jax_config in _JAX_TO_XLA_COMPUTATION_CACHE:
-    config_dict = _JAX_TO_XLA_COMPUTATION_CACHE[jax_config]
-    for jax_func in config_dict:
-      inner_dict = config_dict[jax_func]
-      size += len(inner_dict)
+  for func in _JAX_TO_XLA_COMPUTATION_CACHE.values():
+    size += len(func._cache)
   return size
 
 
@@ -983,7 +1035,8 @@ _JAX_TO_XLA_COMPUTATION_CACHE = {}
 def call_jax(jax_func,
              args: tuple[Any, ...],
              kwargs: Optional[dict[str, Any]] = None,
-             name=None):
+             name=None,
+             override_hash=None):
   """
   Call a JAX function `jax_func` with the given `args` and `kwargs` that may contain
   XLA tensors.
@@ -1025,14 +1078,20 @@ def call_jax(jax_func,
   A common mistake is defining `jax_func` as a local function, e.g. during a training step.
   """
   import jax
-  kwargs = kwargs or {}
-  flattened, _spec = jax.tree.flatten((args, kwargs))
-  tx = maybe_get_torchax()
-  if tx is not None and any(isinstance(a, tx.tensor.Tensor) for a in flattened):
-    return tx.interop.call_jax(jax_func, *args, **kwargs)
+  from jax._src import config
 
-  xla_computation = jax_func_to_xla_computation(jax_func, args, kwargs, name)
-  return xla_computation(flattened)
+  hash_key = (override_hash or hash(jax_func), config.trace_context())
+  if hash_key not in _JAX_TO_XLA_COMPUTATION_CACHE:
+    _JAX_TO_XLA_COMPUTATION_CACHE[hash_key] = JaxCallable(jax_func)
+
+  wrapped_jax_callable = _JAX_TO_XLA_COMPUTATION_CACHE[hash_key]
+  kwargs = kwargs or {}
+  return wrapped_jax_callable(*args, **kwargs)
+
+
+# decorator
+def jax_func_as_torch_callable(fn):
+  return JaxCallable(fn)
 
 
 def create_placeholder_tensor(shape, dtype):

--- a/torch_xla/experimental/assume_pure.py
+++ b/torch_xla/experimental/assume_pure.py
@@ -44,6 +44,9 @@ def j2t_autograd(fn):
   the PyTorch autograd framework by saving the residuals into the context object.
   """
   import torchax.interop
+  # When j2t_autograd calls call_jax, the first arg is vjp, and the second
+  # arg is the actual function. So we want the hash key to be based on the second
+  # arg.
   return torchax.interop.j2t_autograd(
       fn, call_jax=lambda fn, *args: xb.call_jax(fn, args))
 


### PR DESCRIPTION
This PR introduces FlattenedInputFunc abstraction, which is an refactor of `jax_func_to_xla_computation` exposing the closures insides of it as methods.

FlattenedInputFunc itself splits a function into 3 components. (preprocess, flat_call, postprocess); among them, flat_call will take a single flattened list/tuple as input ans returns a flattened list as output. The way to think of it is to treat it as a triplet of functions, that are expected to be called in this exact order. The inner function has no restrictions, it can be a jax function, an function that takes and returns XlaOps or any other.

The above splitting is useful because compiling a function to xla will have to be a flat function.

Then, I abstracted the cache management to be something that any FlattenedInputFunc can share, as long as we know how to "especialize" or create shape specialized functions.

With this refactor, JaxCallable will replace previous capability on call_jax, and XlaCallable can call into Python functions using xla_builder API directly.