### PR TITLE
Support torch.distributed.scatter collective

### DIFF
--- a/test/pjrt/test_collective_ops_tpu.py
+++ b/test/pjrt/test_collective_ops_tpu.py
@@ -109,12 +109,14 @@ class TestXMCollectiveOpsTpu(parameterized.TestCase):
     device = torch_xla.device()
     world_size = xr.world_size()
     if xr.global_ordinal() == 0:
-      tensors = [torch.tensor([i], device=device, dtype=torch.float) for i in range(world_size)]
+      tensors = [
+          torch.tensor([i], device=device, dtype=torch.float)
+          for i in range(world_size)
+      ]
     else:
       tensors = None
-    output_tensor = torch.tensor([-1], device=device)
+    output_tensor = torch.tensor([-1], dtype=torch.float, device=device)
     dist.scatter(output_tensor, tensors, src=0)
-    torch_xla.sync()
     return output_tensor.cpu()
 
   def test_scatter(self):

--- a/torch_xla/distributed/xla_backend.py
+++ b/torch_xla/distributed/xla_backend.py
@@ -232,7 +232,9 @@ class ProcessGroupXla(ProcessGroup):
   def gather(self, *args):
     raise NotImplementedError
 
-  def scatter(self, output_tensor_list: list[torch.Tensor], input_tensors_list: list[list[torch.Tensor]], opts: ScatterOptions):
+  def scatter(self, output_tensor_list: list[torch.Tensor],
+              input_tensors_list: list[list[torch.Tensor]],
+              opts: ScatterOptions):
     output_tensor = output_tensor_list[0]
     if xr.global_ordinal() == opts.rootRank:
       input_tensors = input_tensors_list[0]
@@ -242,7 +244,6 @@ class ProcessGroupXla(ProcessGroup):
     rs_opts = ReduceScatterOptions()
     rs_opts.reduceOp = dist.ReduceOp.SUM
     return self.reduce_scatter([output_tensor], [input_tensors], rs_opts)
-
 
   # Dummy channel id maker. Different backend (TPU, GPU, etc) should replace
   # the maker with their specific one. See unit test in


### PR DESCRIPTION
#9315 

XLA doesn't have a Scatter op but we can put dummy tensor lists on the non-source rank and use reduce_scatter