### PR TITLE
Torchax: Allow reuse of the jittable procedure with different functio…

### DIFF
--- a/torchax/torchax/interop.py
+++ b/torchax/torchax/interop.py
@@ -96,18 +96,21 @@ class JittableModule(torch.nn.Module):
       res = getattr(self._model, method_name)(*args, **kwargs)
     return res
 
-  def forward(self, *args, **kwargs):
-    if 'forward' not in self._jitted:
+  def jittable_call(self, method_name: str, *args, **kwargs):
+    if method_name not in self._jitted:
       jitted = jax_jit(
-          functools.partial(self.functional_call, 'forward'),
+          functools.partial(self.functional_call, method_name),
           kwargs_for_jax_jit=self._extra_jit_args,
       )
 
       def jitted_forward(*args, **kwargs):
         return jitted(self.params, self.buffers, *args, **kwargs)
 
-      self._jitted['forward'] = jitted_forward
-    return self._jitted['forward'](*args, **kwargs)
+      self._jitted[method_name] = jitted_forward
+    return self._jitted[method_name](*args, **kwargs)
+
+  def forward(self, *args, **kwargs):
+    return self.jittable_call('forward', *args, **kwargs)
 
   def __getattr__(self, key):
     if key == '_model':


### PR DESCRIPTION
Torchax exposes an API named JittableMoudle

JittableModule will accept an existing model and wrap it's forward function with torchax jittable call, making it seamless for the user to wrap torch models via torchax

this PR aims to expose not just the forward function, but any function the user chooses, with the help of inheritance