### PR TITLE
Torchax: JittableModule isinstance to work with encapsulated model

### DIFF
--- a/torchax/test/test_jittable_module.py
+++ b/torchax/test/test_jittable_module.py
@@ -1,0 +1,39 @@
+import unittest
+from torchax import interop
+import torch
+
+
+class MyAwesomeModel(torch.nn.Module):
+  pass
+
+
+class EvenMoreAwesomeModel(torch.nn.Module):
+  pass
+
+
+class JittableModuleTest(unittest.TestCase):
+
+  def test_isinstance_works(self):
+
+    # Export and check for composite operations
+    model = MyAwesomeModel()
+    jittable_module = interop.JittableModule(model)
+
+    # jittable_module should remain an instance of MyAwesomeModel logicailly
+    assert isinstance(jittable_module, MyAwesomeModel)
+
+  def test_isinstance_does_not_mix(self):
+
+    # Export and check for composite operations
+    JittableAwesomeModel = interop.JittableModule(MyAwesomeModel())
+    JittableMoreAwesomeModel = interop.JittableModule(EvenMoreAwesomeModel())
+
+    # jittable_module should remain an instance of MyAwesomeModel logicailly
+    assert isinstance(JittableAwesomeModel, MyAwesomeModel)
+    assert not isinstance(JittableAwesomeModel, EvenMoreAwesomeModel)
+    assert isinstance(JittableMoreAwesomeModel, EvenMoreAwesomeModel)
+    assert not isinstance(JittableMoreAwesomeModel, MyAwesomeModel)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/torchax/torchax/interop.py
+++ b/torchax/torchax/interop.py
@@ -81,6 +81,12 @@ class JittableModule(torch.nn.Module):
           for extra_keys in v[1:]:
             del self.params[extra_keys]
 
+  @property
+  def __class__(self):
+    # Lie about the class type so that
+    # isinstance(jittable_module, self._model.__class__) works
+    return self._model.__class__
+
   def __call__(self, *args, **kwargs):
     return self.forward(*args, **kwargs)
 


### PR DESCRIPTION
Torchax exposes an API named JittableMoudle

JittableModule will accept an existing model and wrap it using encapsulation

this makes isinstance(jittable_module, WrappedFunctionClass) not work

this PR aims to fix that