### PR TITLE
Wrap def_static to enable warning reporting in static python functions.

### DIFF
--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -106,7 +106,7 @@ class PythonScope : public Scope {
     using ParameterTypes =
         typename c10::guts::infer_function_traits<Func>::type::parameter_types;
     PythonFunctionBinder<FunctionKind::kInit, ParameterTypes, Extra...>::Bind(
-        *this, "", std::forward<Func>(f), extra...);
+        *this, /*name=*/"", std::forward<Func>(f), extra...);
     return *this;
   }
 
@@ -146,6 +146,7 @@ class PythonScope : public Scope {
   struct PythonFunctionBinder<kind, c10::guts::typelist::typelist<Args...>,
                               Extra...> {
     // Binds a python function with the given name in the given scope.
+    // When scope is kInit, the name is ignored.
     template <typename F>
     static void Bind(Scope& scope, const char* const name, F&& f,
                      const Extra&... extra) {


### PR DESCRIPTION
This makes `def_static`'s behavior consistent with `def` and `def_init` in `PythonScope`.

Also make a small style improvement: make `seed_info_id` `constexpr` and rename it to indicate that it's a constant.