### PR TITLE
ErrorHandling: make `GetComputationClient()` return `StatusOr<T>` type. 

### DIFF
--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -45,6 +45,7 @@ function run_torch_xla_cpp_tests() {
                "test_aten_xla_tensor_3"
                "test_aten_xla_tensor_4"
                "pjrt_computation_client_test"
+               "runtime_test"
                # Disable IFRT test as it currently crashes
                #"ifrt_computation_client_test")
                "test_aten_xla_tensor_5"

--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -45,7 +45,6 @@ function run_torch_xla_cpp_tests() {
                "test_aten_xla_tensor_3"
                "test_aten_xla_tensor_4"
                "pjrt_computation_client_test"
-               "runtime_test"
                # Disable IFRT test as it currently crashes
                #"ifrt_computation_client_test")
                "test_aten_xla_tensor_5"
@@ -54,6 +53,7 @@ function run_torch_xla_cpp_tests() {
                "test_lazy"
                "test_replication"
                "test_tensor"
+               "test_runtime"
                # disable test_xla_backend_intf since it is flaky on upstream
                #"test_xla_backend_intf"
                "test_xla_sharding")

--- a/BUILD
+++ b/BUILD
@@ -77,7 +77,7 @@ test_suite(
         "//test/cpp:test_replication",
         "//test/cpp:test_tensor",
         "//test/cpp:test_xla_sharding",
-        "//torch_xla/csrc/runtime:runtime_test",
+        "//test/cpp:test_runtime",
         "//torch_xla/csrc/runtime:pjrt_computation_client_test",
         # "//torch_xla/csrc/runtime:ifrt_computation_client_test",
     ],

--- a/BUILD
+++ b/BUILD
@@ -77,6 +77,7 @@ test_suite(
         "//test/cpp:test_replication",
         "//test/cpp:test_tensor",
         "//test/cpp:test_xla_sharding",
+        "//torch_xla/csrc/runtime:runtime_test",
         "//torch_xla/csrc/runtime:pjrt_computation_client_test",
         # "//torch_xla/csrc/runtime:ifrt_computation_client_test",
     ],

--- a/test/cpp/BUILD
+++ b/test/cpp/BUILD
@@ -149,3 +149,12 @@ ptxla_cc_test(
     )
     for test in glob(["test_aten_xla_tensor*cpp"])
 ]
+
+ptxla_cc_test(
+    name = "test_runtime",
+    srcs = ["test_runtime.cpp"],
+    deps = [
+        "//torch_xla/csrc/runtime:runtime",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/test/cpp/cpp_test_util.cpp
+++ b/test/cpp/cpp_test_util.cpp
@@ -225,14 +225,14 @@ void WithAllDevices(
     std::vector<torch::lazy::BackendDevice> devices;
     std::vector<torch::lazy::BackendDevice> all_devices;
     for (const auto& device_str :
-         torch_xla::runtime::GetComputationClient()->GetLocalDevices()) {
+         torch_xla::runtime::GetComputationClientOrDie()->GetLocalDevices()) {
       torch::lazy::BackendDevice device = ParseDeviceString(device_str);
       if (device.type() == device_type.type) {
         devices.push_back(device);
       }
     }
     for (const auto& device_str :
-         torch_xla::runtime::GetComputationClient()->GetAllDevices()) {
+         torch_xla::runtime::GetComputationClientOrDie()->GetAllDevices()) {
       torch::lazy::BackendDevice device = ParseDeviceString(device_str);
       if (device.type() == device_type.type) {
         all_devices.push_back(device);
@@ -283,17 +283,17 @@ std::vector<torch_xla::runtime::ComputationClient::DataPtr> Execute(
   std::vector<torch_xla::runtime::ComputationClient::CompileInstance> instances;
   instances.push_back(
       {std::move(computation), device.toString(),
-       torch_xla::runtime::GetComputationClient()->GetCompilationDevices(
+       torch_xla::runtime::GetComputationClientOrDie()->GetCompilationDevices(
            device.toString(), {}),
        &shape});
 
   std::vector<
       std::shared_ptr<torch_xla::runtime::ComputationClient::Computation>>
-      computations = torch_xla::runtime::GetComputationClient()->Compile(
+      computations = torch_xla::runtime::GetComputationClientOrDie()->Compile(
           std::move(instances));
 
   torch_xla::runtime::ComputationClient::ExecuteComputationOptions options;
-  return torch_xla::runtime::GetComputationClient()->ExecuteComputation(
+  return torch_xla::runtime::GetComputationClientOrDie()->ExecuteComputation(
       *computations.front(), UnwrapXlaData(lowering_ctx.GetParametersData()),
       device.toString(), options);
 }
@@ -302,7 +302,7 @@ std::vector<at::Tensor> Fetch(
     absl::Span<const torch_xla::runtime::ComputationClient::DataPtr>
         device_data) {
   std::vector<xla::Literal> literals =
-      torch_xla::runtime::GetComputationClient()->TransferFromDevice(
+      torch_xla::runtime::GetComputationClientOrDie()->TransferFromDevice(
           device_data);
   std::vector<at::Tensor> tensors;
   for (auto& literal : literals) {

--- a/test/cpp/run_tests.sh
+++ b/test/cpp/run_tests.sh
@@ -99,7 +99,8 @@ if [[ "$RUN_CPP_TESTS" == "cpp_tests" ]]; then
               "test_tensor"
               # disable test_xla_backend_intf since it is flaky on upstream
               #"test_xla_backend_intf"
-              "test_xla_sharding")
+              "test_xla_sharding"
+              "test_runtime")
 fi
 for name in "${test_names[@]}"; do
   echo "Running $name cpp test..."

--- a/test/cpp/test_replication.cpp
+++ b/test/cpp/test_replication.cpp
@@ -48,7 +48,7 @@ void TestSingleReplication(
   }
   std::vector<torch_xla::runtime::ComputationClient::ComputationPtr>
       compiled_computations =
-          torch_xla::runtime::GetComputationClient()->Compile(
+          torch_xla::runtime::GetComputationClientOrDie()->Compile(
               std::move(instances));
 
   std::vector<at::Tensor> tensors;
@@ -65,7 +65,7 @@ void TestSingleReplication(
   for (size_t i = 0; i < device_strings.size(); ++i) {
     auto executor = [&, i]() {
       results[i] =
-          torch_xla::runtime::GetComputationClient()->ExecuteComputation(
+          torch_xla::runtime::GetComputationClientOrDie()->ExecuteComputation(
               *compiled_computations[i],
               {std::dynamic_pointer_cast<
                   torch_xla::runtime::ComputationClient::Data>(
@@ -79,7 +79,7 @@ void TestSingleReplication(
 
   for (size_t i = 0; i < results.size(); ++i) {
     std::vector<xla::Literal> literals =
-        torch_xla::runtime::GetComputationClient()->TransferFromDevice(
+        torch_xla::runtime::GetComputationClientOrDie()->TransferFromDevice(
             results[i]);
     ASSERT_EQ(literals.size(), 1);
 

--- a/test/cpp/test_runtime.cpp
+++ b/test/cpp/test_runtime.cpp
@@ -5,7 +5,7 @@
 namespace torch_xla::runtime {
 
 TEST(RuntimeTest, NullComputationClient) {
-  auto client = GetComputationClientIfInitialized();
+  auto* client = GetComputationClientIfInitialized();
   EXPECT_EQ(client, nullptr);
 }
 
@@ -19,13 +19,13 @@ TEST(RuntimeTest, GetComputationClientSuccess) {
   // Check all the APIs return the same valid ComputationClient.
 
   client = GetComputationClientOrDie();
-  EXPECT_NE(client, nullptr);
+  ASSERT_NE(client, nullptr);
 
   auto status = GetComputationClient();
-  EXPECT_TRUE(status.ok());
-  EXPECT_EQ(client, status.value());
+  ASSERT_TRUE(status.ok());
 
-  EXPECT_EQ(client, GetComputationClientIfInitialized());
+  EXPECT_EQ(status.value(), client);
+  EXPECT_EQ(GetComputationClientIfInitialized(), client);
 }
 
 }  // namespace torch_xla::runtime

--- a/test/cpp/test_runtime.cpp
+++ b/test/cpp/test_runtime.cpp
@@ -1,6 +1,6 @@
-#include "torch_xla/csrc/runtime/runtime.h"
-
 #include <gtest/gtest.h>
+
+#include "torch_xla/csrc/runtime/runtime.h"
 
 namespace torch_xla::runtime {
 

--- a/test/cpp/test_runtime.cpp
+++ b/test/cpp/test_runtime.cpp
@@ -4,12 +4,7 @@
 
 namespace torch_xla::runtime {
 
-TEST(RuntimeTest, NullComputationClient) {
-  auto* client = GetComputationClientIfInitialized();
-  EXPECT_EQ(client, nullptr);
-}
-
-TEST(RuntimeTest, GetComputationClientSuccess) {
+TEST(RuntimeTest, ComputationClientInitialization) {
   ComputationClient* client;
 
   client = GetComputationClientIfInitialized();

--- a/test/cpp/test_xla_sharding.cpp
+++ b/test/cpp/test_xla_sharding.cpp
@@ -339,7 +339,8 @@ TEST_F(XLAShardingTest, CreateTensorsData) {
         std::dynamic_pointer_cast<torch_xla::runtime::ComputationClient::Data>(
             tensors_data[0]);
     std::vector<torch_xla::runtime::ComputationClient::DataPtr> shards =
-        torch_xla::runtime::GetComputationClientOrDie()->GetDataShards(xla_data);
+        torch_xla::runtime::GetComputationClientOrDie()->GetDataShards(
+            xla_data);
     EXPECT_EQ(shards.size(), n_devices);
     EXPECT_TRUE(xla::Shape::Equal().IgnoreLayout()(xla_data->shape(),
                                                    shards[0]->shape()));

--- a/test/cpp/test_xla_sharding.cpp
+++ b/test/cpp/test_xla_sharding.cpp
@@ -332,14 +332,14 @@ TEST_F(XLAShardingTest, CreateTensorsData) {
       CreateTensorsData(tensors, shardings, devices);
 
   int64_t n_devices =
-      torch_xla::runtime::GetComputationClient()->GetLocalDevices().size();
+      torch_xla::runtime::GetComputationClientOrDie()->GetLocalDevices().size();
   if (n_devices > 1) {
     // null sharding is treated as replicated.
     auto xla_data =
         std::dynamic_pointer_cast<torch_xla::runtime::ComputationClient::Data>(
             tensors_data[0]);
     std::vector<torch_xla::runtime::ComputationClient::DataPtr> shards =
-        torch_xla::runtime::GetComputationClient()->GetDataShards(xla_data);
+        torch_xla::runtime::GetComputationClientOrDie()->GetDataShards(xla_data);
     EXPECT_EQ(shards.size(), n_devices);
     EXPECT_TRUE(xla::Shape::Equal().IgnoreLayout()(xla_data->shape(),
                                                    shards[0]->shape()));
@@ -349,7 +349,7 @@ TEST_F(XLAShardingTest, CreateTensorsData) {
     auto sharded_xla_data =
         std::dynamic_pointer_cast<torch_xla::runtime::ComputationClient::Data>(
             tensors_data[1]);
-    shards = torch_xla::runtime::GetComputationClient()->GetDataShards(
+    shards = torch_xla::runtime::GetComputationClientOrDie()->GetDataShards(
         sharded_xla_data);
     EXPECT_EQ(shards.size(), n_devices);
     EXPECT_TRUE(xla::Shape::Equal().IgnoreLayout()(sharded_xla_data->shape(),
@@ -360,7 +360,7 @@ TEST_F(XLAShardingTest, CreateTensorsData) {
     sharded_xla_data =
         std::dynamic_pointer_cast<torch_xla::runtime::ComputationClient::Data>(
             tensors_data[2]);
-    shards = torch_xla::runtime::GetComputationClient()->GetDataShards(
+    shards = torch_xla::runtime::GetComputationClientOrDie()->GetDataShards(
         sharded_xla_data);
     EXPECT_EQ(shards.size(), n_devices);
     EXPECT_TRUE(xla::Shape::Equal().IgnoreLayout()(sharded_xla_data->shape(),
@@ -372,7 +372,7 @@ TEST_F(XLAShardingTest, CreateTensorsData) {
 TEST_F(XLAShardingTest, PrepareOutputShardingPropagation) {
   xla::Shape shape = xla::ShapeUtil::MakeShape(xla::PrimitiveType::F32, {4, 4});
   int64_t n_devices =
-      torch_xla::runtime::GetComputationClient()->GetLocalDevices().size();
+      torch_xla::runtime::GetComputationClientOrDie()->GetLocalDevices().size();
   xla::Array<int64_t> tile_assignment({1, n_devices});
   tile_assignment.FillIota(0);
   xla::OpSharding tiled = xla::HloSharding::Tile(tile_assignment).ToProto();
@@ -395,7 +395,7 @@ TEST_F(XLAShardingTest, PrepareOutputShardingPropagation) {
 
   std::vector<
       std::shared_ptr<torch_xla::runtime::ComputationClient::Computation>>
-      computations = torch_xla::runtime::GetComputationClient()->Compile(
+      computations = torch_xla::runtime::GetComputationClientOrDie()->Compile(
           std::move(instances));
   torch_xla::runtime::ComputationClient::ComputationPtr computation =
       std::make_shared<torch_xla::runtime::ComputationClient::Computation>(
@@ -403,7 +403,7 @@ TEST_F(XLAShardingTest, PrepareOutputShardingPropagation) {
 
   // Prepare output sharding propagation, expect a sharded output placeholder.
   std::vector<XLATensorPtr> tensors{XLATensor::Create(
-      torch_xla::runtime::GetComputationClient()->CreateDataPlaceholder(
+      torch_xla::runtime::GetComputationClientOrDie()->CreateDataPlaceholder(
           bridge::GetDefaultDevice()->toString(), std::move(shape)))};
   std::vector<torch::lazy::BackendDataPtr> data_placeholders;
   std::vector<XLATensor::ShardingSpecPtr> sharding_specs;

--- a/torch_xla/csrc/aten_fallback.cpp
+++ b/torch_xla/csrc/aten_fallback.cpp
@@ -77,7 +77,7 @@ bool UseOpenXLAFallbackOnCUDA(const c10::OperatorHandle& op) {
   //      support running OpenXLA fallback operations on CUDA if the current
   //      PyTorch/XLA DeviceType is not CUDA.
   bool device_is_cuda =
-      runtime::GetComputationClient()->GetDeviceType().getType() ==
+      runtime::GetComputationClientOrDie()->GetDeviceType().getType() ==
       XlaDeviceType::CUDA;
 
   //   3. PyTorch must have been compiled with CUDA support. Otherwise, our

--- a/torch_xla/csrc/aten_xla_bridge.cpp
+++ b/torch_xla/csrc/aten_xla_bridge.cpp
@@ -366,8 +366,9 @@ std::string ToXlaString(const c10::Device& device) {
 
 const torch::lazy::BackendDevice* GetDefaultDevice() {
   static std::string default_device_spec =
-      UseVirtualDevice() ? "SPMD:0"
-                         : runtime::GetComputationClientOrDie()->GetDefaultDevice();
+      UseVirtualDevice()
+          ? "SPMD:0"
+          : runtime::GetComputationClientOrDie()->GetDefaultDevice();
   XLA_CHECK(!default_device_spec.empty());
   static const torch::lazy::BackendDevice default_device =
       ParseDeviceString(default_device_spec);

--- a/torch_xla/csrc/aten_xla_bridge.cpp
+++ b/torch_xla/csrc/aten_xla_bridge.cpp
@@ -56,7 +56,7 @@ class AtenXlaDeviceMapper {
       devices_ordinals_[devices_.back()] = 0;
     } else {
       for (auto& device_str :
-           torch_xla::runtime::GetComputationClient()->GetLocalDevices()) {
+           torch_xla::runtime::GetComputationClientOrDie()->GetLocalDevices()) {
         devices_.emplace_back(ParseDeviceString(device_str));
         devices_ordinals_[devices_.back()] = devices_.size() - 1;
       }
@@ -367,7 +367,7 @@ std::string ToXlaString(const c10::Device& device) {
 const torch::lazy::BackendDevice* GetDefaultDevice() {
   static std::string default_device_spec =
       UseVirtualDevice() ? "SPMD:0"
-                         : runtime::GetComputationClient()->GetDefaultDevice();
+                         : runtime::GetComputationClientOrDie()->GetDefaultDevice();
   XLA_CHECK(!default_device_spec.empty());
   static const torch::lazy::BackendDevice default_device =
       ParseDeviceString(default_device_spec);

--- a/torch_xla/csrc/cross_replica_reduces.cpp
+++ b/torch_xla/csrc/cross_replica_reduces.cpp
@@ -332,7 +332,7 @@ at::Tensor all_to_all_single(const at::Tensor& input,
   bool pin_layout = false;
   const torch::lazy::Value& token =
       GetAllReduceToken(bridge::GetCurrentDevice());
-  int64_t split_count = runtime::GetComputationClient()->GetAllDevices().size();
+  int64_t split_count = runtime::GetComputationClientOrDie()->GetAllDevices().size();
   std::vector<int64_t> all_groups(split_count);
   std::iota(all_groups.begin(), all_groups.end(), 0);
 

--- a/torch_xla/csrc/cross_replica_reduces.cpp
+++ b/torch_xla/csrc/cross_replica_reduces.cpp
@@ -332,7 +332,8 @@ at::Tensor all_to_all_single(const at::Tensor& input,
   bool pin_layout = false;
   const torch::lazy::Value& token =
       GetAllReduceToken(bridge::GetCurrentDevice());
-  int64_t split_count = runtime::GetComputationClientOrDie()->GetAllDevices().size();
+  int64_t split_count =
+      runtime::GetComputationClientOrDie()->GetAllDevices().size();
   std::vector<int64_t> all_groups(split_count);
   std::iota(all_groups.begin(), all_groups.end(), 0);
 

--- a/torch_xla/csrc/dl_convertor.cpp
+++ b/torch_xla/csrc/dl_convertor.cpp
@@ -122,7 +122,7 @@ DLManagedTensor* toDLPack(const at::Tensor& input) {
       << "Could not extract a valid data handle from the input tensor";
 
   std::shared_ptr<xla::PjRtBuffer> pjrt_buffer =
-      runtime::GetComputationClient()->GetPjRtBuffer(handle);
+      runtime::GetComputationClientOrDie()->GetPjRtBuffer(handle);
   XLA_CHECK(pjrt_buffer != nullptr) << "Could not get a valid pjrt_buffer";
 
   XLA_CHECK(!pjrt_buffer->IsTuple())
@@ -168,14 +168,14 @@ DLManagedTensor* toDLPack(const at::Tensor& input) {
 absl::StatusOr<xla::PjRtDevice*> DeviceForDLDevice(const DLDevice& context) {
   switch (context.device_type) {
     case DLDeviceType::kDLCPU:
-      XLA_CHECK_EQ(runtime::GetComputationClient()->GetPlatformID(),
+      XLA_CHECK_EQ(runtime::GetComputationClientOrDie()->GetPlatformID(),
                    xla::CpuId());
-      return runtime::GetComputationClient()->LookupAddressableDevice(
+      return runtime::GetComputationClientOrDie()->LookupAddressableDevice(
           context.device_id);
     case DLDeviceType::kDLCUDA:
-      XLA_CHECK_EQ(runtime::GetComputationClient()->GetPlatformID(),
+      XLA_CHECK_EQ(runtime::GetComputationClientOrDie()->GetPlatformID(),
                    xla::CudaId());
-      return runtime::GetComputationClient()->LookupAddressableDevice(
+      return runtime::GetComputationClientOrDie()->LookupAddressableDevice(
           context.device_id);
     default:
       return tsl::errors::InvalidArgument(
@@ -335,7 +335,7 @@ at::Tensor fromDLPack(DLManagedTensor* dlmt) {
 
   runtime::ComputationClient::DataPtr data =
       runtime::PjRtComputationClient::CreateData(
-          runtime::GetComputationClient()->PjRtDeviceToString(device), shape,
+          runtime::GetComputationClientOrDie()->PjRtDeviceToString(device), shape,
           std::move(pjrt_buffer.value()));
 
   at::ScalarType tensor_type = at::toScalarType(dlmt->dl_tensor.dtype);

--- a/torch_xla/csrc/dl_convertor.cpp
+++ b/torch_xla/csrc/dl_convertor.cpp
@@ -335,8 +335,8 @@ at::Tensor fromDLPack(DLManagedTensor* dlmt) {
 
   runtime::ComputationClient::DataPtr data =
       runtime::PjRtComputationClient::CreateData(
-          runtime::GetComputationClientOrDie()->PjRtDeviceToString(device), shape,
-          std::move(pjrt_buffer.value()));
+          runtime::GetComputationClientOrDie()->PjRtDeviceToString(device),
+          shape, std::move(pjrt_buffer.value()));
 
   at::ScalarType tensor_type = at::toScalarType(dlmt->dl_tensor.dtype);
   XLATensorPtr xla_tensor = XLATensor::Create(data, tensor_type);

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1696,7 +1696,7 @@ void InitXlaModuleBindings(py::module m) {
            })
       .def("_init_computation_client",
            []() {
-             ConsumeAndMaybeThrow(runtime::status::GetComputationClient());
+             ConsumeAndMaybeThrow(runtime::GetComputationClient());
            })
       .def("_xla_get_device_hw_type",
            [](const at::Tensor& tensor) {

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -180,10 +180,7 @@ static void ConsumeAndMaybeThrow(absl::Status status) {
 
 template <class T>
 static T ConsumeAndMaybeThrow(absl::StatusOr<T> status) {
-  if (status.ok()) {
-    return std::move(status.value());
-  }
-  ConsumeAndMaybeThrow(status.status());
+  return std::move(status.value());
 }
 
 struct NoGilSection {

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1698,8 +1698,7 @@ void InitXlaModuleBindings(py::module m) {
            })
       .def("_init_computation_client",
            []() {
-             auto status = runtime::status::GetComputationClient();
-             ConsumeAndMaybeThrow(status);
+             ConsumeAndMaybeThrow(runtime::status::GetComputationClient());
            })
       .def("_xla_get_device_hw_type",
            [](const at::Tensor& tensor) {

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -180,6 +180,7 @@ static void ConsumeAndMaybeThrow(absl::Status status) {
 
 template <class T>
 static T ConsumeAndMaybeThrow(absl::StatusOr<T> status) {
+  ConsumeAndMaybeThrow(status.status());
   return std::move(status.value());
 }
 

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -3166,33 +3166,35 @@ void InitXlaModuleBindings(py::module m) {
                }
                XLA_ERROR() << "Could not get buffer for tensor";
              }
-             runtime::GetComputationClientOrDie()->OnReadyCallback(data, callback);
+             runtime::GetComputationClientOrDie()->OnReadyCallback(data,
+                                                                   callback);
            })
-      .def(
-          "_unsafe_buffer_pointer",
-          [](const at::Tensor& input) -> std::uintptr_t {
-            XLATensorPtr xtensor = bridge::GetXlaTensor(input);
-            XLA_CHECK(xtensor) << "The input is not an XLA tensor.";
-            if (xtensor->CurrentDataHandle() != nullptr) {
-              std::shared_ptr<runtime::ComputationClient::Data> data =
-                  std::dynamic_pointer_cast<runtime::ComputationClient::Data>(
-                      xtensor->CurrentDataHandle());
-              return runtime::GetComputationClientOrDie()->UnsafeBufferPointer(data);
-            } else if (xtensor->CurrentIrValue().node != nullptr) {
-              DeviceData* device_data =
-                  DeviceData::Cast(xtensor->CurrentIrValue().node.get());
-              if (device_data != nullptr) {
-                torch::lazy::BackendDataPtr data = device_data->data();
-                return runtime::GetComputationClientOrDie()->UnsafeBufferPointer(
-                    UnwrapXlaData(data));
-              } else {
-                XLA_ERROR() << "Could not get the buffer pointer for XLATensor "
-                               "with IR that's not DeviceData";
-              }
-            }
-            XLA_ERROR() << "Could not get the buffer pointer for XLATensor "
-                           "without a data handle or an IR.";
-          })
+      .def("_unsafe_buffer_pointer",
+           [](const at::Tensor& input) -> std::uintptr_t {
+             XLATensorPtr xtensor = bridge::GetXlaTensor(input);
+             XLA_CHECK(xtensor) << "The input is not an XLA tensor.";
+             if (xtensor->CurrentDataHandle() != nullptr) {
+               std::shared_ptr<runtime::ComputationClient::Data> data =
+                   std::dynamic_pointer_cast<runtime::ComputationClient::Data>(
+                       xtensor->CurrentDataHandle());
+               return runtime::GetComputationClientOrDie()->UnsafeBufferPointer(
+                   data);
+             } else if (xtensor->CurrentIrValue().node != nullptr) {
+               DeviceData* device_data =
+                   DeviceData::Cast(xtensor->CurrentIrValue().node.get());
+               if (device_data != nullptr) {
+                 torch::lazy::BackendDataPtr data = device_data->data();
+                 return runtime::GetComputationClientOrDie()
+                     ->UnsafeBufferPointer(UnwrapXlaData(data));
+               } else {
+                 XLA_ERROR()
+                     << "Could not get the buffer pointer for XLATensor "
+                        "with IR that's not DeviceData";
+               }
+             }
+             XLA_ERROR() << "Could not get the buffer pointer for XLATensor "
+                            "without a data handle or an IR.";
+           })
       .def(
           // from an XLA tensor to a PyCapsule.
           // When consuming the PyCapsule, we should synchronize

--- a/torch_xla/csrc/ir_dump_util.cpp
+++ b/torch_xla/csrc/ir_dump_util.cpp
@@ -273,11 +273,12 @@ std::string DumpUtil::ToHlo(c10::ArrayRef<torch::lazy::Value> values,
         ConsumeValue(computation.GetProgramShape()).result(),
         static_cast<XlaDeviceType>(device.type()));
     std::vector<runtime::ComputationClient::CompileInstance> instances;
-    instances.push_back({std::move(computation), device.toString(),
-                         runtime::GetComputationClientOrDie()->GetCompilationDevices(
-                             device.toString(), {}),
-                         &shape,
-                         /*parameter_is_tupled_arguments=*/false, is_sharded});
+    instances.push_back(
+        {std::move(computation), device.toString(),
+         runtime::GetComputationClientOrDie()->GetCompilationDevices(
+             device.toString(), {}),
+         &shape,
+         /*parameter_is_tupled_arguments=*/false, is_sharded});
     std::vector<std::shared_ptr<runtime::ComputationClient::Computation>>
         computations =
             runtime::GetComputationClientOrDie()->Compile(std::move(instances));

--- a/torch_xla/csrc/ir_dump_util.cpp
+++ b/torch_xla/csrc/ir_dump_util.cpp
@@ -274,13 +274,13 @@ std::string DumpUtil::ToHlo(c10::ArrayRef<torch::lazy::Value> values,
         static_cast<XlaDeviceType>(device.type()));
     std::vector<runtime::ComputationClient::CompileInstance> instances;
     instances.push_back({std::move(computation), device.toString(),
-                         runtime::GetComputationClient()->GetCompilationDevices(
+                         runtime::GetComputationClientOrDie()->GetCompilationDevices(
                              device.toString(), {}),
                          &shape,
                          /*parameter_is_tupled_arguments=*/false, is_sharded});
     std::vector<std::shared_ptr<runtime::ComputationClient::Computation>>
         computations =
-            runtime::GetComputationClient()->Compile(std::move(instances));
+            runtime::GetComputationClientOrDie()->Compile(std::move(instances));
     computation = std::move(computations[0]->move_computation());
   }
 

--- a/torch_xla/csrc/ops/device_data.cpp
+++ b/torch_xla/csrc/ops/device_data.cpp
@@ -17,7 +17,7 @@ DeviceData::DeviceData(std::shared_ptr<torch::lazy::BackendData> data)
               /*hash_seed=*/(uint32_t)101),
       data_(std::move(data)) {
   std::optional<xla::OpSharding> op_sharding =
-      torch_xla::runtime::GetComputationClient()->GetDataSharding(
+      torch_xla::runtime::GetComputationClientOrDie()->GetDataSharding(
           std::dynamic_pointer_cast<runtime::ComputationClient::Data>(data_));
   if (op_sharding.has_value()) {
     // DeviceData Node only has 1 output.

--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -24,6 +24,7 @@ cc_library(
         ":env_vars",
         ":ifrt_computation_client",
         ":pjrt_computation_client",
+        "@com_google_absl//absl/log:absl_check",
         "@tsl//tsl/platform:stacktrace",
     ],
 )

--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -524,12 +524,3 @@ ptxla_cc_test(
 #         "@xla//xla/tools:hlo_module_loader",
 #     ],
 # )
-
-ptxla_cc_test(
-    name = "runtime_test",
-    srcs = ["runtime_test.cpp"],
-    deps = [
-        ":runtime",
-        "@tsl//tsl/platform:test_main",
-    ],
-)

--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -524,3 +524,12 @@ ptxla_cc_test(
 #         "@xla//xla/tools:hlo_module_loader",
 #     ],
 # )
+
+ptxla_cc_test(
+    name = "runtime_test",
+    srcs = ["runtime_test.cpp"],
+    deps = [
+        ":runtime",
+        "@tsl//tsl/platform:test_main",
+    ],
+)

--- a/torch_xla/csrc/runtime/runtime.cpp
+++ b/torch_xla/csrc/runtime/runtime.cpp
@@ -24,7 +24,7 @@ InitializeComputationClient() {
   // Ref: https://github.com/pytorch/xla/pull/8267
   //
   // static bool use_ifrt = sys_util::GetEnvBool("XLA_USE_IFRT", false);
-  static const bool use_ifrt = false;
+  const bool use_ifrt = false;
   if (sys_util::GetEnvString(env::kEnvPjRtDevice, "") != "") {
     auto* client =
         (use_ifrt)

--- a/torch_xla/csrc/runtime/runtime.cpp
+++ b/torch_xla/csrc/runtime/runtime.cpp
@@ -31,6 +31,7 @@ InitializeComputationClient() {
             ? static_cast<ComputationClient*>(new IfrtComputationClient())
             : static_cast<ComputationClient*>(new PjRtComputationClient());
     g_computation_client_initialized = true;
+    ABSL_CHECK(client);
     return client;
   } else {
     return absl::FailedPreconditionError("$PJRT_DEVICE is not set.");
@@ -46,14 +47,7 @@ absl::StatusOr<ComputationClient * absl_nonnull> GetComputationClient() {
   static auto& maybe_client =
       *new absl::StatusOr<ComputationClient * absl_nonnull>(
           InitializeComputationClient());
-
-  if (!maybe_client.ok()) {
-    return maybe_client.status();
-  }
-
-  auto* client = maybe_client.value();
-  ABSL_CHECK(client);
-  return client;
+  return maybe_client;
 }
 
 ComputationClient* absl_nonnull GetComputationClientOrDie() {

--- a/torch_xla/csrc/runtime/runtime.cpp
+++ b/torch_xla/csrc/runtime/runtime.cpp
@@ -12,7 +12,8 @@ namespace torch_xla::runtime {
 
 std::atomic<bool> g_computation_client_initialized(false);
 
-static absl::StatusOr<std::unique_ptr<ComputationClient>> InitializeComputationClient() {
+static absl::StatusOr<std::unique_ptr<ComputationClient>>
+InitializeComputationClient() {
   if (sys_util::GetEnvBool("XLA_DUMP_FATAL_STACK", false)) {
     tsl::testing::InstallStacktraceHandler();
   }
@@ -71,7 +72,8 @@ ComputationClient* GetComputationClientOrDie() {
 }
 
 ComputationClient* GetComputationClientIfInitialized() {
-  return g_computation_client_initialized ? GetComputationClientOrDie() : nullptr;
+  return g_computation_client_initialized ? GetComputationClientOrDie()
+                                          : nullptr;
 }
 
 }  // namespace torch_xla::runtime

--- a/torch_xla/csrc/runtime/runtime.cpp
+++ b/torch_xla/csrc/runtime/runtime.cpp
@@ -12,8 +12,8 @@ namespace torch_xla::runtime {
 
 std::atomic<bool> g_computation_client_initialized(false);
 
-// Creates a new instance of a `ComputationClient` (e.g. `PjRtComputationClient`),
-// and initializes the computation client
+// Creates a new instance of a `ComputationClient` (e.g.
+// `PjRtComputationClient`), and initializes the computation client
 static absl::StatusOr<absl_nonnull std::unique_ptr<ComputationClient>>
 InitializeComputationClient() {
   if (sys_util::GetEnvBool("XLA_DUMP_FATAL_STACK", false)) {
@@ -22,9 +22,11 @@ InitializeComputationClient() {
 
   std::unique_ptr<ComputationClient> client;
 
-  // Disable IFRT right now as it currently crashes.
+  // TODO: enable IFRT once it's not crashing anymore.
+  // Ref: https://github.com/pytorch/xla/pull/8267
+  //
   // static bool use_ifrt = sys_util::GetEnvBool("XLA_USE_IFRT", false);
-  static bool use_ifrt = false;
+  static const bool use_ifrt = false;
   if (sys_util::GetEnvString(env::kEnvPjRtDevice, "") != "") {
     if (use_ifrt) {
       client = std::make_unique<IfrtComputationClient>();
@@ -40,7 +42,8 @@ InitializeComputationClient() {
 }
 
 absl::StatusOr<ComputationClient*> GetComputationClient() {
-  static absl::StatusOr<absl_nonnull std::unique_ptr<ComputationClient>> maybeClient = InitializeComputationClient();
+  static absl::StatusOr<absl_nonnull std::unique_ptr<ComputationClient>>
+      maybeClient = InitializeComputationClient();
 
   if (!maybeClient.ok()) {
     return maybeClient.status();

--- a/torch_xla/csrc/runtime/runtime.cpp
+++ b/torch_xla/csrc/runtime/runtime.cpp
@@ -12,8 +12,6 @@ namespace torch_xla::runtime {
 
 std::atomic<bool> g_computation_client_initialized(false);
 
-namespace status {
-
 static absl::StatusOr<std::unique_ptr<ComputationClient>> InitializeComputationClient() {
   if (sys_util::GetEnvBool("XLA_DUMP_FATAL_STACK", false)) {
     tsl::testing::InstallStacktraceHandler();
@@ -59,8 +57,8 @@ absl::StatusOr<ComputationClient*> GetComputationClient() {
 
 }  // namespace status
 
-ComputationClient* GetComputationClient() {
-  auto client = status::GetComputationClient();
+ComputationClient* GetComputationClientOrDie() {
+  auto client = GetComputationClient();
 
   // In order to be backward compatible, we call `XLA_CHECK()`, which throws an
   // exception.
@@ -73,7 +71,7 @@ ComputationClient* GetComputationClient() {
 }
 
 ComputationClient* GetComputationClientIfInitialized() {
-  return g_computation_client_initialized ? GetComputationClient() : nullptr;
+  return g_computation_client_initialized ? GetComputationClientOrDie() : nullptr;
 }
 
 }  // namespace torch_xla::runtime

--- a/torch_xla/csrc/runtime/runtime.cpp
+++ b/torch_xla/csrc/runtime/runtime.cpp
@@ -31,7 +31,6 @@ InitializeComputationClient() {
             ? static_cast<ComputationClient*>(new IfrtComputationClient())
             : static_cast<ComputationClient*>(new PjRtComputationClient());
     g_computation_client_initialized = true;
-    ABSL_CHECK(client);
     return client;
   } else {
     return absl::FailedPreconditionError("$PJRT_DEVICE is not set.");

--- a/torch_xla/csrc/runtime/runtime.h
+++ b/torch_xla/csrc/runtime/runtime.h
@@ -6,7 +6,7 @@
 namespace torch_xla::runtime {
 
 // Returns the ComputationClient singleton.
-absl::StatusOr<ComputationClient* absl_nonnull> GetComputationClient();
+absl::StatusOr<ComputationClient * absl_nonnull> GetComputationClient();
 
 ABSL_DEPRECATED(
     "Use status::GetComputationClient(), instead. "

--- a/torch_xla/csrc/runtime/runtime.h
+++ b/torch_xla/csrc/runtime/runtime.h
@@ -3,10 +3,19 @@
 
 #include "torch_xla/csrc/runtime/computation_client.h"
 
-namespace torch_xla {
-namespace runtime {
+namespace torch_xla::runtime {
+namespace status {
 
 // Returns the ComputationClient singleton.
+absl::StatusOr<ComputationClient*> GetComputationClient();
+
+}
+
+ABSL_DEPRECATED(
+    "Use status::GetComputationClient(), instead. "
+    "This function throws an exception on error, instead of "
+    "actually handling the StatusOr return value, which is "
+    "safer.")
 ComputationClient* GetComputationClient();
 
 ComputationClient* GetComputationClientIfInitialized();
@@ -15,7 +24,6 @@ ComputationClient* GetComputationClientIfInitialized();
 // being stopped.
 void RunLocalService(uint64_t service_port);
 
-}  // namespace runtime
-}  // namespace torch_xla
+}  // namespace torch_xla::runtime
 
 #endif

--- a/torch_xla/csrc/runtime/runtime.h
+++ b/torch_xla/csrc/runtime/runtime.h
@@ -6,15 +6,18 @@
 namespace torch_xla::runtime {
 
 // Returns the ComputationClient singleton.
-absl::StatusOr<ComputationClient*> GetComputationClient();
+absl::StatusOr<ComputationClient* absl_nonnull> GetComputationClient();
 
 ABSL_DEPRECATED(
     "Use status::GetComputationClient(), instead. "
     "This function throws an exception on error, instead of "
     "actually handling the StatusOr return value, which is "
     "safer.")
-ComputationClient* GetComputationClientOrDie();
+ComputationClient* absl_nonnull GetComputationClientOrDie();
 
+// Returns the ComputationClient singleton, if successfully initialized.
+// Returns a nullptr, if the ComputationClient wasn't initialized yet, or
+// if there was an error on initialization.
 ComputationClient* GetComputationClientIfInitialized();
 
 // Run the XRT local service, this will block the caller unitl the server

--- a/torch_xla/csrc/runtime/runtime.h
+++ b/torch_xla/csrc/runtime/runtime.h
@@ -4,19 +4,16 @@
 #include "torch_xla/csrc/runtime/computation_client.h"
 
 namespace torch_xla::runtime {
-namespace status {
 
 // Returns the ComputationClient singleton.
 absl::StatusOr<ComputationClient*> GetComputationClient();
-
-}
 
 ABSL_DEPRECATED(
     "Use status::GetComputationClient(), instead. "
     "This function throws an exception on error, instead of "
     "actually handling the StatusOr return value, which is "
     "safer.")
-ComputationClient* GetComputationClient();
+ComputationClient* GetComputationClientOrDie();
 
 ComputationClient* GetComputationClientIfInitialized();
 

--- a/torch_xla/csrc/runtime/runtime_test.cpp
+++ b/torch_xla/csrc/runtime/runtime_test.cpp
@@ -1,0 +1,31 @@
+#include "torch_xla/csrc/runtime/runtime.h"
+
+#include <gtest/gtest.h>
+
+namespace torch_xla::runtime {
+
+TEST(RuntimeTest, NullComputationClient) {
+  auto client = GetComputationClientIfInitialized();
+  EXPECT_EQ(client, nullptr);
+}
+
+TEST(RuntimeTest, GetComputationClientSuccess) {
+  ComputationClient* client;
+
+  client = GetComputationClientIfInitialized();
+  EXPECT_EQ(client, nullptr);
+
+  // Initialize the ComputationClient.
+  // Check all the APIs return the same valid ComputationClient.
+
+  client = GetComputationClientOrDie();
+  EXPECT_NE(client, nullptr);
+
+  auto status = GetComputationClient();
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(client, status.value());
+
+  EXPECT_EQ(client, GetComputationClientIfInitialized());
+}
+
+}  // namespace torch_xla::runtime

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -870,8 +870,8 @@ std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
     } else {
       source_tensors.push_back(std::make_shared<runtime::AtenSource>(
           tensors[i], std::move(shape), devices[i]));
-      new_handles =
-          runtime::GetComputationClientOrDie()->TransferToDevice(source_tensors);
+      new_handles = runtime::GetComputationClientOrDie()->TransferToDevice(
+          source_tensors);
     }
     handles.insert(handles.end(), new_handles.begin(), new_handles.end());
   }

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -553,7 +553,7 @@ torch::lazy::BackendDataPtr TensorToXlaData(
     // The tensor is bypassing the virtual device, so it should be replicated
     // to all devices.
     std::vector<std::string> local_devices =
-        runtime::GetComputationClient()->GetLocalDevices();
+        runtime::GetComputationClientOrDie()->GetLocalDevices();
     auto replicated_data =
         std::vector<at::Tensor>(local_devices.size(), tensor);
     return ShardingUtil::CreateShardedData(replicated_data, local_devices,
@@ -565,7 +565,7 @@ torch::lazy::BackendDataPtr TensorToXlaData(
       std::make_shared<runtime::AtenSource>(tensor, shape, device.toString()));
 
   auto handles =
-      runtime::GetComputationClient()->TransferToDevice(source_tensors);
+      runtime::GetComputationClientOrDie()->TransferToDevice(source_tensors);
   XLA_CHECK_EQ(handles.size(), 1);
   return handles.front();
 }
@@ -813,7 +813,7 @@ std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
         << "can't mix virtual device and real device.";
 
     std::vector<std::string> local_devices =
-        runtime::GetComputationClient()->GetLocalDevices();
+        runtime::GetComputationClientOrDie()->GetLocalDevices();
     std::vector<runtime::ComputationClient::DataPtr> handles;
     for (size_t i = 0; i < tensors.size(); ++i) {
       auto device = ParseDeviceString(devices[i]);
@@ -834,7 +834,7 @@ std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
         tensors[i], std::move(shape), devices[i]));
   }
   return WrapXlaData(
-      runtime::GetComputationClient()->TransferToDevice(source_tensors));
+      runtime::GetComputationClientOrDie()->TransferToDevice(source_tensors));
 }
 
 std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
@@ -858,7 +858,7 @@ std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
       // global ordinals (e.g. ["TPU:4", "TPU:5", "TPU:6", "TPU:7"]).
 
       std::vector<std::string> local_devices =
-          runtime::GetComputationClient()->GetLocalDevices();
+          runtime::GetComputationClientOrDie()->GetLocalDevices();
       // Shards the input tensors with padding, to split evenly.
       // The execution requires consistent shard sizes, and the zero-padded
       // values should be ignored.
@@ -871,7 +871,7 @@ std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
       source_tensors.push_back(std::make_shared<runtime::AtenSource>(
           tensors[i], std::move(shape), devices[i]));
       new_handles =
-          runtime::GetComputationClient()->TransferToDevice(source_tensors);
+          runtime::GetComputationClientOrDie()->TransferToDevice(source_tensors);
     }
     handles.insert(handles.end(), new_handles.begin(), new_handles.end());
   }
@@ -909,7 +909,7 @@ std::vector<xla::Literal> ReleaseGilAndTransferData(
     save = PyEval_SaveThread();
   }
   std::vector<xla::Literal> literals =
-      runtime::GetComputationClient()->TransferFromDevice(
+      runtime::GetComputationClientOrDie()->TransferFromDevice(
           UnwrapXlaData(xla_data));
   if (save) {
     PyEval_RestoreThread(save);

--- a/torch_xla/csrc/xla_backend_impl.cpp
+++ b/torch_xla/csrc/xla_backend_impl.cpp
@@ -27,7 +27,7 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
       // bridge::GetDefaultDevice will trigger the runtime device init, should
       // not do it during class init time.
       default_device_type_ = std::make_shared<DeviceType>(
-          runtime::GetComputationClient()->GetDeviceType());
+          runtime::GetComputationClientOrDie()->GetDeviceType());
       default_device_type_inited_ = true;
     }
     return true;
@@ -75,7 +75,7 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
       const torch::lazy::BackendDevice& device,
       const torch::lazy::Shape& shape) const override {
     xla::Shape xla_shape = MakeXlaShapeFromLazyShape(shape, device);
-    return runtime::GetComputationClient()->CreateDataPlaceholder(
+    return runtime::GetComputationClientOrDie()->CreateDataPlaceholder(
         device.toString(), std::move(xla_shape));
   }
 
@@ -117,7 +117,7 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
   std::vector<std::string> GetCompilationDevices(
       const std::string& device,
       c10::ArrayRef<std::string> devices) const override {
-    return runtime::GetComputationClient()->GetCompilationDevices(device,
+    return runtime::GetComputationClientOrDie()->GetCompilationDevices(device,
                                                                   devices);
   }
 
@@ -152,7 +152,7 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
           {current_device.toString()}, &output_shapes.back()));
     }
     std::vector<std::shared_ptr<runtime::ComputationClient::Computation>>
-        client_computations = runtime::GetComputationClient()->Compile(
+        client_computations = runtime::GetComputationClientOrDie()->Compile(
             std::move(compile_instances));
     return {client_computations.begin(), client_computations.end()};
   }
@@ -162,7 +162,7 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
       c10::ArrayRef<torch::lazy::BackendDataPtr> arguments,
       const torch::lazy::BackendDevice& device) const override {
     std::vector<runtime::ComputationClient::DataPtr> results =
-        runtime::GetComputationClient()->ExecuteComputation(
+        runtime::GetComputationClientOrDie()->ExecuteComputation(
             *std::dynamic_pointer_cast<runtime::ComputationClient::Computation>(
                 computation),
             UnwrapXlaData(arguments), device.toString());

--- a/torch_xla/csrc/xla_backend_impl.cpp
+++ b/torch_xla/csrc/xla_backend_impl.cpp
@@ -118,7 +118,7 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
       const std::string& device,
       c10::ArrayRef<std::string> devices) const override {
     return runtime::GetComputationClientOrDie()->GetCompilationDevices(device,
-                                                                  devices);
+                                                                       devices);
   }
 
   std::vector<torch::lazy::ComputationPtr> Compile(

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -1433,10 +1433,11 @@ XLAGraphExecutor::CompilationResult XLAGraphExecutor::Compile(
       program_shape.result(), static_cast<XlaDeviceType>(coll.device.type()));
 
   std::vector<runtime::ComputationClient::CompileInstance> instances;
-  instances.push_back({std::move(computation), coll.device.toString(),
-                       runtime::GetComputationClientOrDie()->GetCompilationDevices(
-                           coll.device.toString(), devices),
-                       &shape, should_wrap_parameter, is_sharded});
+  instances.push_back(
+      {std::move(computation), coll.device.toString(),
+       runtime::GetComputationClientOrDie()->GetCompilationDevices(
+           coll.device.toString(), devices),
+       &shape, should_wrap_parameter, is_sharded});
   instances.front().eager_mode = UseEagerMode();
   if (use_autosharding) {
     TF_VLOG(5) << "use_auto_spmd_partitioning is set.";

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -521,7 +521,7 @@ std::vector<torch::lazy::BackendDataPtr> ShardingUtil::CreateShardedPlaceholder(
     // hold the corresponding computation results for both sharding &
     // replication.
     auto sharded_data_placeholder =
-        runtime::GetComputationClient()->CreateDataPlaceholder(
+        runtime::GetComputationClientOrDie()->CreateDataPlaceholder(
             GetVirtualDevice().toString(), sharding_specs[i]->shape,
             sharding_specs[i]->sharding);
 
@@ -563,7 +563,7 @@ void ShardingUtil::PrepareOutputShardingPropagation(
     // hold the corresponding computation results for both sharding &
     // replication.
     auto sharded_data_placeholder =
-        runtime::GetComputationClient()->CreateDataPlaceholder(
+        runtime::GetComputationClientOrDie()->CreateDataPlaceholder(
             GetVirtualDevice().toString(), (*sharding_specs)[i]->shape,
             (*sharding_specs)[i]->sharding);
 
@@ -609,7 +609,7 @@ runtime::ComputationClient::DataPtr ShardingUtil::CreateShardedData(
     source_tensors.push_back(std::make_shared<runtime::AtenSource>(
         local_shards[j], shard_shape, devices[j]));
   }
-  return runtime::GetComputationClient()->TransferShardsToDevice(
+  return runtime::GetComputationClientOrDie()->TransferShardsToDevice(
       source_tensors, GetVirtualDevice().toString(), global_shape, sharding);
 }
 
@@ -625,7 +625,7 @@ std::vector<int64_t> ShardingUtil::GetAutoShardingMesh() {
       total_devices *= i;
     }
     XLA_CHECK_EQ(total_devices,
-                 runtime::GetComputationClient()->GetAllDevices().size())
+                 runtime::GetComputationClientOrDie()->GetAllDevices().size())
         << "Invalid auto-sharding mesh_shape: "
         << absl::StrJoin(mesh_shape, ",");
   }
@@ -640,7 +640,7 @@ std::vector<int64_t> ShardingUtil::GetAutoShardingMeshIds(
   // as the auto-sharding pass takes only one arrangement for now.
   // TODO(yeounoh) this was not necessary before; replace if this can be done
   // during the auto-sharding pass.
-  int64_t n_devices = runtime::GetComputationClient()->GetAllDevices().size();
+  int64_t n_devices = runtime::GetComputationClientOrDie()->GetAllDevices().size();
   std::vector<int64_t> device_mesh_ids = std::vector<int64_t>(n_devices);
   std::iota(device_mesh_ids.begin(), device_mesh_ids.end(), 0);
 
@@ -736,11 +736,11 @@ void ShardingUtil::ReshardParameters(
   bool group_sharding =
       runtime::sys_util::GetEnvBool("XLA_AUTO_USE_GROUP_SHARDING", true);
   if (group_sharding) {
-    outputs = WrapXlaData(runtime::GetComputationClient()->ReshardData(
+    outputs = WrapXlaData(runtime::GetComputationClientOrDie()->ReshardData(
         data_to_reshard, shardings_to_reshard));
   } else {
     for (int i = 0; i < data_to_reshard.size(); ++i) {
-      auto output = WrapXlaData(runtime::GetComputationClient()->ReshardData(
+      auto output = WrapXlaData(runtime::GetComputationClientOrDie()->ReshardData(
           {data_to_reshard[i]}, {shardings_to_reshard[i]}));
       outputs.insert(outputs.end(), output.begin(), output.end());
     }

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -640,7 +640,8 @@ std::vector<int64_t> ShardingUtil::GetAutoShardingMeshIds(
   // as the auto-sharding pass takes only one arrangement for now.
   // TODO(yeounoh) this was not necessary before; replace if this can be done
   // during the auto-sharding pass.
-  int64_t n_devices = runtime::GetComputationClientOrDie()->GetAllDevices().size();
+  int64_t n_devices =
+      runtime::GetComputationClientOrDie()->GetAllDevices().size();
   std::vector<int64_t> device_mesh_ids = std::vector<int64_t>(n_devices);
   std::iota(device_mesh_ids.begin(), device_mesh_ids.end(), 0);
 
@@ -740,8 +741,9 @@ void ShardingUtil::ReshardParameters(
         data_to_reshard, shardings_to_reshard));
   } else {
     for (int i = 0; i < data_to_reshard.size(); ++i) {
-      auto output = WrapXlaData(runtime::GetComputationClientOrDie()->ReshardData(
-          {data_to_reshard[i]}, {shardings_to_reshard[i]}));
+      auto output =
+          WrapXlaData(runtime::GetComputationClientOrDie()->ReshardData(
+              {data_to_reshard[i]}, {shardings_to_reshard[i]}));
       outputs.insert(outputs.end(), output.begin(), output.end());
     }
   }


### PR DESCRIPTION
Ref: #9339 

This PR creates a new version of `GetComputationClient()` that returns a `StatusOr<T>` type for better error handling. Since this function is frequently used in the codebase, its old version remains, but annotated with `ABSL_DEPRECATED()` (following #9381 example) and renamed to `GetComputationClientOrDie()`. The new version is created with the old name. Summarizing:

- Old `GetComputationClient()` is renamed to `GetComputationClientOrDie()`
- New `torch_xla::runtime::status::GetComputationClient()` function that returns `StatusOr<T>` type
- The old version remains, and calls the new function. It uses `XLA_CHECK()` for throwing an error on non-ok status, maintaining its old behavior
- New `ConsumeAndMaybeThrow()` function for throwing errors if non-ok status reach the Python API boundary