### PR TITLE
Prepare for pytorch tensor impl change in is_contiguous_custom

### DIFF
--- a/torch_xla/csrc/tensor_impl.cpp
+++ b/torch_xla/csrc/tensor_impl.cpp
@@ -178,6 +178,13 @@ bool XLATensorImpl::is_contiguous_custom(at::MemoryFormat memory_format) const {
   return true;
 }
 
+c10::SymBool XLATensorImpl::sym_is_contiguous_custom(
+    at::MemoryFormat memory_format) const {
+  // Storage is always contiguous, but the tensor metadata is_contiguous_ might
+  // be false due to the update in the functionalization layer..
+  return true;
+}
+
 void XLATensorImpl::SetupSizeProperties() {
   size_t generation = tensor_->generation();
   if (generation != generation_) {

--- a/torch_xla/csrc/tensor_impl.h
+++ b/torch_xla/csrc/tensor_impl.h
@@ -51,7 +51,10 @@ class XLATensorImpl : public c10::TensorImpl {
 
   int64_t numel_custom() const override;
 
-  bool is_contiguous_custom(at::MemoryFormat memory_format) const override;
+  // TODO add override once https://github.com/pytorch/pytorch/pull/155590 lands
+  // and remove is_contiguous_custom.
+  bool is_contiguous_custom(at::MemoryFormat memory_format) const;
+  c10::SymBool sym_is_contiguous_custom(at::MemoryFormat memory_format) const;
 
   const at::Storage& storage() const override;
 


### PR DESCRIPTION
in this PR https://github.com/pytorch/pytorch/pull/155590 we do the following changes to the tesnor impl API 
1) bool is_contiguous_custom does not need to overriden by other classes anymore 
2) we add SymBool sym_is_contiguous_custom. 

I am trying to avoid breaking pytorch test, want to land this, then land https://github.com/pytorch/pytorch/pull/155590, then come back here and clean up this .
