### PR TITLE
Optimize w8a8 quantized matmul kernel

### DIFF
--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -978,7 +978,7 @@ class PallasTest(parameterized.TestCase):
       dtype=[torch.bfloat16, torch.float32],
       bs=[256, 512],
       n_input_features=[256, 512],
-      n_output_features=[256, 512],
+      n_output_features=[256],
       quantize_activation=[True],
       use_dynamo=[True, False],
   )

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -937,8 +937,8 @@ class PallasTest(parameterized.TestCase):
         quantize_activation=quantize_activation,
     ).cpu()
 
-    print(f'Output max diff: {torch.max(torch.abs(expected - actual))}')
-    print(f'Output mean diff: {torch.mean(torch.abs(expected - actual))}')
+    # print(f'Output max diff: {torch.max(torch.abs(expected - actual))}')
+    # print(f'Output mean diff: {torch.mean(torch.abs(expected - actual))}')
     rel_error = self._compute_rel_error(expected, actual)
 
     self.assertEqual(actual.shape, expected.shape)

--- a/test/test_quantized_matmul_pallas_kernel.py
+++ b/test/test_quantized_matmul_pallas_kernel.py
@@ -128,7 +128,8 @@ class QuantizedMatmulKernelTest(jtu.JaxTestCase):
         break
     expected_block_sizes = TUNED_BLOCK_SIZES[key0]
     _, bs, n_output_features, n_input_features, activation_dtype, quantize_activation = key0
-    actual_block_sizes = get_tuned_block_sizes(TUNED_BLOCK_SIZES, bs, n_output_features,
+    actual_block_sizes = get_tuned_block_sizes(TUNED_BLOCK_SIZES, bs,
+                                               n_output_features,
                                                n_input_features,
                                                activation_dtype,
                                                quantize_activation)

--- a/test/test_quantized_matmul_pallas_kernel.py
+++ b/test/test_quantized_matmul_pallas_kernel.py
@@ -7,6 +7,7 @@ from absl.testing import parameterized
 import jax
 from jax._src import test_util as jtu
 from torch_xla.experimental.pallas_kernels.quantized_matmul_kernel import (
+    quantize_array,
     quantized_matmul_int8,
     get_tuned_block_sizes,
     TUNED_BLOCK_SIZES,
@@ -17,7 +18,7 @@ import numpy as np
 jax.config.parse_flags_with_absl()
 
 
-def quantize_array(x, n_bits: int = 8, dim: int = -1):
+def quantize_array_ref(x, n_bits: int = 8, dim: int = -1):
   max_val = jnp.max(jnp.abs(x), axis=dim, keepdims=True)
   int_min = -2**(n_bits - 1)
   int_max = 2**(n_bits - 1) - 1
@@ -54,7 +55,7 @@ class QuantizedMatmulKernelTest(jtu.JaxTestCase):
         k1, (n_output_features, n_input_features), dtype=dtype)
     x_copy = x.copy()
     w_copy = w.copy()
-    q_w, scalar_w = quantize_array(w)
+    q_w, scalar_w = quantize_array_ref(w)  # scalar_w: [n_output_features, 1]
     scalar_w = jnp.squeeze(scalar_w)
     assert scalar_w.shape == (n_output_features,)
 
@@ -68,6 +69,12 @@ class QuantizedMatmulKernelTest(jtu.JaxTestCase):
         in_block_size=in_block_size).block_until_ready()
     expected = jax.lax.dot_general(
         x_copy, w_copy, dimension_numbers=(((1,), (1,)), ((), ())))
+    
+    # print(
+    #     f'Output max diff: {jnp.max(jnp.abs(expected - output))}')
+    # print(
+    #     f'Output mean diff: {jnp.mean(jnp.abs(expected - output))}'
+    # )
 
     self.assertEqual(output.dtype, expected.dtype)
     self.assertEqual(output.shape, expected.shape)
@@ -77,43 +84,51 @@ class QuantizedMatmulKernelTest(jtu.JaxTestCase):
       dtype=[jnp.bfloat16, jnp.float32],
       bs=[128, 256, 512],
       n_input_features=[128, 256, 512],
-      n_output_features=[128, 256, 512],
+  )
+  def test_quantize_tensor(self, dtype, bs, n_input_features):
+    prng_key = jax.random.key(1234)
+    k0, k1 = jax.random.split(prng_key, 2)
+    x = jax.random.normal(k0, (bs, n_input_features), dtype=dtype)
+    x_copy = x.copy()
+    actual_q_x, actual_scalar = quantize_array(x, vmem_limit_bytes=64*1024*1024)
+    expected_q_x, expected_scalar = quantize_array_ref(x_copy)
+
+    self.assertEqual(actual_q_x.dtype, expected_q_x.dtype)
+    self.assertEqual(actual_scalar.dtype, expected_scalar.dtype)
+    self.assertAllClose(actual_q_x, expected_q_x, atol=1.01)
+    self.assertAllClose(actual_scalar, expected_scalar)
+
+  @parameterized.product(
+      dtype=[jnp.bfloat16, jnp.float32],
+      bs=[16, 256, 512],
+      n_input_features=[256, 512],
+      n_output_features=[256, 512],
       quantize_activation=[True],
+      batch_block_size=[128, 256],
+      out_block_size=[128, 256],
+      in_block_size=[128, 256],
   )
   def test_quantized_matmul_various_input_shapes(self, dtype, bs,
                                                  n_input_features,
                                                  n_output_features,
-                                                 quantize_activation):
+                                                 quantize_activation,
+                                                 batch_block_size,
+                                                 out_block_size,
+                                                 in_block_size,
+                                                 ):
+    if n_output_features < out_block_size:
+      self.skipTest('Not implemented for n_output_features < out_block_size.')
+    if n_input_features < in_block_size:
+      self.skipTest('Not implemented for n_input_features < in_block_size.')
     self._test_quantized_matmul(
         dtype,
         bs,
         n_input_features,
         n_output_features,
         quantize_activation=quantize_activation,
-        batch_block_size=128,
-        out_block_size=128,
-        in_block_size=128)
-
-  @parameterized.product(
-      dtype=[jnp.bfloat16, jnp.float32],
-      bs=[64, 192],
-      n_input_features=[64, 192],
-      n_output_features=[64, 192],
-      quantize_activation=[True],
-  )
-  def test_quantized_matmul_unaligned_input_shapes(self, dtype, bs,
-                                                   n_input_features,
-                                                   n_output_features,
-                                                   quantize_activation):
-    self._test_quantized_matmul(
-        dtype,
-        bs,
-        n_input_features,
-        n_output_features,
-        quantize_activation=quantize_activation,
-        batch_block_size=128,
-        out_block_size=128,
-        in_block_size=128)
+        batch_block_size=batch_block_size,
+        out_block_size=out_block_size,
+        in_block_size=in_block_size)
 
   @patch(
       'torch_xla.experimental.pallas_kernels.quantized_matmul_kernel.get_tpu_version'
@@ -134,23 +149,24 @@ class QuantizedMatmulKernelTest(jtu.JaxTestCase):
                                                quantize_activation)
     assert actual_block_sizes == expected_block_sizes, f"Expected block sizes {expected_block_sizes}, but got {actual_block_sizes} for key {key0}"
 
-  @parameterized.product(
-      dtype=[jnp.bfloat16],
-      bs=[16],
-      n_input_features=[128, 256],
-      n_output_features=[128, 256],
-      quantize_activation=[True],
-  )
-  def test_quantized_matmul_use_tuned_block_sizes(self, dtype, bs,
-                                                  n_input_features,
-                                                  n_output_features,
-                                                  quantize_activation):
-    self._test_quantized_matmul(
-        dtype,
-        bs,
-        n_input_features,
-        n_output_features,
-        quantize_activation=quantize_activation)
+# TODO(xw32): delete it
+#   @parameterized.product(
+#       dtype=[jnp.bfloat16],
+#       bs=[16],
+#       n_input_features=[128, 256],
+#       n_output_features=[128, 256],
+#       quantize_activation=[True],
+#   )
+#   def test_quantized_matmul_use_tuned_block_sizes(self, dtype, bs,
+#                                                   n_input_features,
+#                                                   n_output_features,
+#                                                   quantize_activation):
+#     self._test_quantized_matmul(
+#         dtype,
+#         bs,
+#         n_input_features,
+#         n_output_features,
+#         quantize_activation=quantize_activation)
 
 
 if __name__ == "__main__":

--- a/test/test_quantized_matmul_pallas_kernel.py
+++ b/test/test_quantized_matmul_pallas_kernel.py
@@ -7,7 +7,6 @@ from absl.testing import parameterized
 import jax
 from jax._src import test_util as jtu
 from torch_xla.experimental.pallas_kernels.quantized_matmul_kernel import (
-    quantize_array,
     quantized_matmul_int8,
     get_tuned_block_sizes,
     TUNED_BLOCK_SIZES,
@@ -18,7 +17,7 @@ import numpy as np
 jax.config.parse_flags_with_absl()
 
 
-def quantize_array_ref(x, n_bits: int = 8, dim: int = -1):
+def quantize_array(x, n_bits: int = 8, dim: int = -1):
   max_val = jnp.max(jnp.abs(x), axis=dim, keepdims=True)
   int_min = -2**(n_bits - 1)
   int_max = 2**(n_bits - 1) - 1
@@ -55,7 +54,7 @@ class QuantizedMatmulKernelTest(jtu.JaxTestCase):
         k1, (n_output_features, n_input_features), dtype=dtype)
     x_copy = x.copy()
     w_copy = w.copy()
-    q_w, scalar_w = quantize_array_ref(w)  # scalar_w: [n_output_features, 1]
+    q_w, scalar_w = quantize_array(w)
     scalar_w = jnp.squeeze(scalar_w)
     assert scalar_w.shape == (n_output_features,)
 
@@ -69,12 +68,6 @@ class QuantizedMatmulKernelTest(jtu.JaxTestCase):
         in_block_size=in_block_size).block_until_ready()
     expected = jax.lax.dot_general(
         x_copy, w_copy, dimension_numbers=(((1,), (1,)), ((), ())))
-    
-    # print(
-    #     f'Output max diff: {jnp.max(jnp.abs(expected - output))}')
-    # print(
-    #     f'Output mean diff: {jnp.mean(jnp.abs(expected - output))}'
-    # )
 
     self.assertEqual(output.dtype, expected.dtype)
     self.assertEqual(output.shape, expected.shape)
@@ -84,51 +77,43 @@ class QuantizedMatmulKernelTest(jtu.JaxTestCase):
       dtype=[jnp.bfloat16, jnp.float32],
       bs=[128, 256, 512],
       n_input_features=[128, 256, 512],
-  )
-  def test_quantize_tensor(self, dtype, bs, n_input_features):
-    prng_key = jax.random.key(1234)
-    k0, k1 = jax.random.split(prng_key, 2)
-    x = jax.random.normal(k0, (bs, n_input_features), dtype=dtype)
-    x_copy = x.copy()
-    actual_q_x, actual_scalar = quantize_array(x, vmem_limit_bytes=64*1024*1024)
-    expected_q_x, expected_scalar = quantize_array_ref(x_copy)
-
-    self.assertEqual(actual_q_x.dtype, expected_q_x.dtype)
-    self.assertEqual(actual_scalar.dtype, expected_scalar.dtype)
-    self.assertAllClose(actual_q_x, expected_q_x, atol=1.01)
-    self.assertAllClose(actual_scalar, expected_scalar)
-
-  @parameterized.product(
-      dtype=[jnp.bfloat16, jnp.float32],
-      bs=[16, 256, 512],
-      n_input_features=[256, 512],
-      n_output_features=[256, 512],
+      n_output_features=[128, 256, 512],
       quantize_activation=[True],
-      batch_block_size=[128, 256],
-      out_block_size=[128, 256],
-      in_block_size=[128, 256],
   )
   def test_quantized_matmul_various_input_shapes(self, dtype, bs,
                                                  n_input_features,
                                                  n_output_features,
-                                                 quantize_activation,
-                                                 batch_block_size,
-                                                 out_block_size,
-                                                 in_block_size,
-                                                 ):
-    if n_output_features < out_block_size:
-      self.skipTest('Not implemented for n_output_features < out_block_size.')
-    if n_input_features < in_block_size:
-      self.skipTest('Not implemented for n_input_features < in_block_size.')
+                                                 quantize_activation):
     self._test_quantized_matmul(
         dtype,
         bs,
         n_input_features,
         n_output_features,
         quantize_activation=quantize_activation,
-        batch_block_size=batch_block_size,
-        out_block_size=out_block_size,
-        in_block_size=in_block_size)
+        batch_block_size=128,
+        out_block_size=128,
+        in_block_size=128)
+
+  @parameterized.product(
+      dtype=[jnp.bfloat16, jnp.float32],
+      bs=[64, 192],
+      n_input_features=[64, 192],
+      n_output_features=[64, 192],
+      quantize_activation=[True],
+  )
+  def test_quantized_matmul_unaligned_input_shapes(self, dtype, bs,
+                                                   n_input_features,
+                                                   n_output_features,
+                                                   quantize_activation):
+    self._test_quantized_matmul(
+        dtype,
+        bs,
+        n_input_features,
+        n_output_features,
+        quantize_activation=quantize_activation,
+        batch_block_size=128,
+        out_block_size=128,
+        in_block_size=128)
 
   @patch(
       'torch_xla.experimental.pallas_kernels.quantized_matmul_kernel.get_tpu_version'
@@ -143,30 +128,34 @@ class QuantizedMatmulKernelTest(jtu.JaxTestCase):
         break
     expected_block_sizes = TUNED_BLOCK_SIZES[key0]
     _, bs, n_output_features, n_input_features, activation_dtype, quantize_activation = key0
-    actual_block_sizes = get_tuned_block_sizes(bs, n_output_features,
+    actual_block_sizes = get_tuned_block_sizes(TUNED_BLOCK_SIZES, bs, n_output_features,
                                                n_input_features,
                                                activation_dtype,
                                                quantize_activation)
     assert actual_block_sizes == expected_block_sizes, f"Expected block sizes {expected_block_sizes}, but got {actual_block_sizes} for key {key0}"
 
-# TODO(xw32): delete it
-#   @parameterized.product(
-#       dtype=[jnp.bfloat16],
-#       bs=[16],
-#       n_input_features=[128, 256],
-#       n_output_features=[128, 256],
-#       quantize_activation=[True],
-#   )
-#   def test_quantized_matmul_use_tuned_block_sizes(self, dtype, bs,
-#                                                   n_input_features,
-#                                                   n_output_features,
-#                                                   quantize_activation):
-#     self._test_quantized_matmul(
-#         dtype,
-#         bs,
-#         n_input_features,
-#         n_output_features,
-#         quantize_activation=quantize_activation)
+  @parameterized.product(
+      dtype=[jnp.bfloat16],
+      bs=[16],
+      n_input_features=[128, 256],
+      n_output_features=[128, 256],
+      quantize_activation=[True],
+  )
+  def test_quantized_matmul_use_tuned_block_sizes(self, dtype, bs,
+                                                  n_input_features,
+                                                  n_output_features,
+                                                  quantize_activation):
+    with self.assertRaises(AssertionError):
+      self._test_quantized_matmul(
+          dtype,
+          bs,
+          n_input_features,
+          n_output_features,
+          quantize_activation=quantize_activation,
+          batch_block_size=None,
+          out_block_size=None,
+          in_block_size=None,
+      )
 
 
 if __name__ == "__main__":

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -1076,15 +1076,17 @@ def quantized_matmul_int8(
     vmem_limit_bytes: int | None = 64 * 1024 * 1024,
 ) -> torch.Tensor:
   from torch_xla.experimental.pallas_kernels.quantized_matmul_kernel import (
-    quantized_matmul_int8,
-    get_tuned_block_sizes,
-    TUNED_BLOCK_SIZES,
+      quantized_matmul_int8,
+      get_tuned_block_sizes,
+      TUNED_BLOCK_SIZES,
   )
   bs, n_in_features = x.shape
   n_out_features, _ = w.shape
   jax_dtype = convert_torch_dtype_to_jax(x.dtype)
   import jax.numpy as jnp
-  batch_block_size, out_block_size, in_block_size = get_tuned_block_sizes(TUNED_BLOCK_SIZES, bs, n_out_features, n_in_features, jnp.dtype(jax_dtype).name, quantize_activation)
+  batch_block_size, out_block_size, in_block_size = get_tuned_block_sizes(
+      TUNED_BLOCK_SIZES, bs, n_out_features, n_in_features,
+      jnp.dtype(jax_dtype).name, quantize_activation)
   if batch_block_size is not None and out_block_size is not None and in_block_size is not None:
     return xb.call_jax(
         quantized_matmul_int8, (x, w, scalar), {
@@ -1097,8 +1099,8 @@ def quantized_matmul_int8(
             "vmem_limit_bytes": vmem_limit_bytes
         })
   from torch_xla.experimental.xla_quantized_matmul import quantized_matmul_xla
-  return quantized_matmul_xla(x, w_int, scaler, zero_point=zero_point, quant_block_size=quant_block_size, quantize_activation=quantize_activation)
-
+  return quantized_matmul_xla(
+      x, w, scalar, quantize_activation=quantize_activation)
 
 
 def _multi_queries_paged_attention_nonkernel(

--- a/torch_xla/experimental/custom_kernel.py
+++ b/torch_xla/experimental/custom_kernel.py
@@ -1075,17 +1075,30 @@ def quantized_matmul_int8(
     in_block_size: int | None = None,
     vmem_limit_bytes: int | None = 64 * 1024 * 1024,
 ) -> torch.Tensor:
-  from torch_xla.experimental.pallas_kernels.quantized_matmul_kernel import quantized_matmul_int8
-  return xb.call_jax(
-      quantized_matmul_int8, (x, w, scalar), {
-          "zero_point": zero_point,
-          "quant_block_size": quant_block_size,
-          "quantize_activation": quantize_activation,
-          "batch_block_size": batch_block_size,
-          "out_block_size": out_block_size,
-          "in_block_size": in_block_size,
-          "vmem_limit_bytes": vmem_limit_bytes
-      })
+  from torch_xla.experimental.pallas_kernels.quantized_matmul_kernel import (
+    quantized_matmul_int8,
+    get_tuned_block_sizes,
+    TUNED_BLOCK_SIZES,
+  )
+  bs, n_in_features = x.shape
+  n_out_features, _ = w.shape
+  jax_dtype = convert_torch_dtype_to_jax(x.dtype)
+  import jax.numpy as jnp
+  batch_block_size, out_block_size, in_block_size = get_tuned_block_sizes(TUNED_BLOCK_SIZES, bs, n_out_features, n_in_features, jnp.dtype(jax_dtype).name, quantize_activation)
+  if batch_block_size is not None and out_block_size is not None and in_block_size is not None:
+    return xb.call_jax(
+        quantized_matmul_int8, (x, w, scalar), {
+            "zero_point": zero_point,
+            "quant_block_size": quant_block_size,
+            "quantize_activation": quantize_activation,
+            "batch_block_size": batch_block_size,
+            "out_block_size": out_block_size,
+            "in_block_size": in_block_size,
+            "vmem_limit_bytes": vmem_limit_bytes
+        })
+  from torch_xla.experimental.xla_quantized_matmul import quantized_matmul_xla
+  return quantized_matmul_xla(x, w_int, scaler, zero_point=zero_point, quant_block_size=quant_block_size, quantize_activation=quantize_activation)
+
 
 
 def _multi_queries_paged_attention_nonkernel(

--- a/torch_xla/experimental/pallas_kernels/quantized_matmul_kernel.py
+++ b/torch_xla/experimental/pallas_kernels/quantized_matmul_kernel.py
@@ -194,15 +194,12 @@ def quantized_matmul_int8(
 ):
   assert zero_point is None, "Not implemented: zero_point is not supported."
   assert quant_block_size is None, "Not implemented: quant_block_size is not supported."
+  assert batch_block_size is not None and out_block_size is not None and in_block_size is not None
 
-  orig_bs, orig_in_features = x.shape
-  orig_out_features, _ = w.shape
-  if batch_block_size is None or out_block_size is None or in_block_size is None:
-    batch_block_size, out_block_size, in_block_size = get_tuned_block_sizes(TUNED_BLOCK_SIZES, orig_bs, orig_out_features, orig_in_features, jnp.dtype(x.dtype).name, quantize_activation)
-    
+  bs = x.shape[0]
   orig_batch_block_size = batch_block_size
-  if orig_bs < 128:
-    batch_block_size = orig_bs
+  if bs < 128:
+    batch_block_size = bs
 
   assert x.shape[1] == w.shape[
       1], f"x.shape[1] ({x.shape[1]}) must be equal to w.shape[1] ({w.shape[1]})"

--- a/torch_xla/experimental/pallas_kernels/quantized_matmul_kernel.py
+++ b/torch_xla/experimental/pallas_kernels/quantized_matmul_kernel.py
@@ -341,8 +341,9 @@ def get_tuned_block_sizes(block_table, batch_size, n_output_features, n_input_fe
   """
   key = (get_tpu_version(), batch_size, n_output_features, n_input_features,
          activation_dtype, quantize_activation)
-  if key not in block_table:
-    raise ValueError(
-        f"Block sizes not found for key {key}. Available keys: {list(block_table.keys())}"
-    )
+  # TODO(xw32): delete it
+  # if key not in block_table:
+  #   raise ValueError(
+  #       f"Block sizes not found for key {key}. Available keys: {list(block_table.keys())}"
+  #   )
   return block_table.get(key, (128, 128, 128))

--- a/torch_xla/experimental/pallas_kernels/quantized_matmul_kernel.py
+++ b/torch_xla/experimental/pallas_kernels/quantized_matmul_kernel.py
@@ -324,21 +324,25 @@ def get_tpu_version() -> int:
   return int(kind[-1])
 
 
-def get_tuned_block_sizes(batch_size, n_output_features, n_input_features,
+def get_tuned_block_sizes(block_table, batch_size, n_output_features, n_input_features,
                           activation_dtype, quantize_activation):
   """
     Retrieve the tuned block sizes for the given parameters.
-    
+
     Args:
         batch_size (int): The batch size.
         n_output_features (int): The number of output features.
         n_input_features (int): The number of input features.
         activation_dtype (str): The data type of the activation ('bfloat16' or 'float32').
         quantize_activation (bool): Whether to quantize the activation.
-        
+
     Returns:
         tuple: A tuple containing the batch_block_size, out_block_size, and in_block_size.
-    """
+  """
   key = (get_tpu_version(), batch_size, n_output_features, n_input_features,
          activation_dtype, quantize_activation)
-  return TUNED_BLOCK_SIZES.get(key, (128, 128, 128))
+  if key not in block_table:
+    raise ValueError(
+        f"Block sizes not found for key {key}. Available keys: {list(block_table.keys())}"
+    )
+  return block_table.get(key, (128, 128, 128))

--- a/torch_xla/experimental/pallas_kernels/quantized_matmul_kernel.py
+++ b/torch_xla/experimental/pallas_kernels/quantized_matmul_kernel.py
@@ -7,167 +7,84 @@ from jax.experimental.pallas import tpu as pltpu
 import jax.numpy as jnp
 
 
-NUM_LANES = 128
-NUM_SUBLANES = 8
-
-def _broadcast_to_shape(arr, shape, broadcast_dim):
-  if arr.shape == shape:
-    return arr
-  assert len(arr.shape) == len(shape)
-  assert len(shape) == 2
-  assert broadcast_dim in [0, 1]
-
-  non_broadcast_dim = 0 if broadcast_dim == 1 else 1
-  assert arr.shape[non_broadcast_dim] == shape[non_broadcast_dim]
-  assert shape[broadcast_dim] % arr.shape[broadcast_dim] == 0
-  # no-op concatenation.
-  return jnp.concatenate(
-      [arr for _ in range(shape[broadcast_dim] // arr.shape[broadcast_dim])], axis=broadcast_dim
-  )
-
-def quantize_array_kernel(x_ref, out_ref, scale_ref, *, quant_dtype, quant_nbits):
-  x = x_ref[...].astype(jnp.float32)
-  max_val = jnp.max(jnp.abs(x), axis=-1, keepdims=True)
-  int_min = -2**(quant_nbits - 1)
-  int_max = 2**(quant_nbits - 1) - 1
-  scale = max_val / int_max
-  x_int = jnp.clip(jnp.round((x / scale).astype(jnp.float32)), int_min, int_max).astype(quant_dtype)
-
-  out_ref[...] = x_int
-  scale_ref[...] = scale.astype(x_ref.dtype)
-
-def quantize_array(
-    x: jax.Array,  # [m, n]
-    vmem_limit_bytes,
+def _quantize_array(
+    x: jax.Array,  # [bs_block_size, in_block_size]
+    x_abs_max_val: jax.Array,  # [1, bs_block_size]
 ):
-  quant_dtype = jnp.int8
-  quant_nbits = 8
-  m, n = x.shape
-  
-  def within_vmem_limit(m_block_size, n, orig_dtype, vmem_limit_bytes):
-    return 2*(2*m_block_size * n + m_block_size)*orig_dtype.itemsize <= vmem_limit_bytes
-  
-  def find_m_block_size(x, vmem_limit_bytes):
-    m, n = x.shape
-    for m_block_size in [1024, 512, 256]:
-      if m % m_block_size == 0 and within_vmem_limit(m_block_size, n, x.dtype, vmem_limit_bytes):
-        return m_block_size
-    if not within_vmem_limit(m, n, x.dtype, vmem_limit_bytes):
-      raise ValueError(f"Cannot find m_block_size for {x.shape=} with vmem_limit_bytes={vmem_limit_bytes}")
-    return m
-  bm = find_m_block_size(x, vmem_limit_bytes)
+  n_bits = 8
+  int_min = -2**(n_bits - 1)
+  int_max = 2**(n_bits - 1) - 1
+  scale = (x_abs_max_val / int_max).T  # [bs_block_size, 1]
+  # Need to explicitly cast to f32 because Mosaic can't directly jnp.round a
+  # bf16 array.
+  # It seems x/0 in Pallas generates inf/-inf instead of an exception.
+  x_int = jnp.clip(
+      jnp.round((x / scale).astype(jnp.float32)), int_min,
+      int_max).astype(jnp.int8)
+  return x_int, scale.astype(x.dtype)
 
-  input_spec = pl.BlockSpec((bm, n), lambda i: (i, 0))
-  scale_spec = pl.BlockSpec((bm, 1), lambda i: (i, 0))
-  output_shape = jax.ShapeDtypeStruct((m, n), dtype=quant_dtype)
-  scale_shape = jax.ShapeDtypeStruct((m, 1), dtype=x.dtype)
-  kernel = pl.pallas_call(
-      functools.partial(
-          quantize_array_kernel,
-          quant_dtype=quant_dtype,
-          quant_nbits=quant_nbits,
-      ),
-      grid_spec=pltpu.PrefetchScalarGridSpec(
-          num_scalar_prefetch=0,
-          in_specs=[
-              input_spec,
-          ],
-          out_specs=[
-              input_spec,
-              scale_spec,
-          ],
-          grid=(m // bm,),
-      ),
-      out_shape=(output_shape, scale_shape),
-      compiler_params=pltpu.TPUCompilerParams(
-          dimension_semantics=("parallel",),
-          vmem_limit_bytes=vmem_limit_bytes,
-      ),
-  )
 
-  return kernel(x)
-
-def w8a8_matmul_kernel(x_ref, x_scalar_ref, w_ref, w_scalar_ref, out_ref, acc_ref, *, x_orig_dtype, batch_block_size, out_block_size, in_block_size):
+def matmul_kernel(
+    x_ref,  # (batch_block_size, in_block_size)
+    w_ref,  # (out_block_size, in_block_size)
+    scalar_ref,  # (1, out_block_size)
+    x_abs_max_val,  # (1, batch_block_size)
+    out_ref,  # (batch_block_size, out_block_size)
+    acc_ref,  # (batch_block_size, out_block_size)
+    *,
+    quantize_activation,
+    batch_block_size,
+    out_block_size,
+    in_block_size,
+):
   bs_idx, out_idx, in_idx = pl.program_id(0), pl.program_id(1), pl.program_id(2)
   nsteps = pl.num_programs(2)
-  
+  x_ref_dtype = x_ref.dtype
+  assert x_ref.shape == (batch_block_size,
+                         in_block_size), "x_ref shape is not correct"
+  assert w_ref.shape == (out_block_size,
+                         in_block_size), "w_ref shape is not correct"
+  assert scalar_ref.shape == (1,
+                              out_block_size), "scalar_ref shape is not correct"
+  assert x_abs_max_val.shape == (
+      1, batch_block_size), "x_max_val shape is not correct"
+  assert out_ref.shape == (batch_block_size,
+                           out_block_size), "out_ref shape is not correct"
+  assert acc_ref.shape == (batch_block_size,
+                           out_block_size), "acc_ref shape is not correct"
+
   @pl.when(in_idx == 0)
   def _():
     acc_ref[...] = jnp.zeros_like(acc_ref)
 
-  x = x_ref[...]
-  w = w_ref[...]
-  acc_ref[...] += jax.lax.dot_general(
-      x,
-      w,
-      (((1,), (1,)), ((), ())),
-      preferred_element_type=jnp.int32,
-  )
+  if quantize_activation:
+    x, x_scale = _quantize_array(x_ref[...], x_abs_max_val[...])
+    acc_ref[...] += jax.lax.dot_general(
+        x,
+        w_ref[...],
+        (((1,), (1,)), ((), ())),
+        preferred_element_type=jnp.int32,
+    )
+  else:
+    acc_ref[...] += jax.lax.dot_general(
+        x_ref[...],
+        w_ref[...],
+        (((1,), (1,)), ((), ())),
+    )
 
   @pl.when(in_idx == nsteps - 1)
   def _():
-    acc = acc_ref[...]  # [batch_block_size, out_block_size]
-    w_scalar = w_scalar_ref[...]  # [NUM_SUBLANES, out_block_size]
-    acc *= _broadcast_to_shape(w_scalar, acc.shape, broadcast_dim=0)
-    x_scalar = x_scalar_ref[...]  # [batch_block_size, NUM_LANES]
-    acc *= _broadcast_to_shape(x_scalar, acc.shape, broadcast_dim=1)
-    out_ref[...] = acc.astype(x_orig_dtype)
+    acc = acc_ref[...]
+    scalar = scalar_ref[...]
+    acc *= scalar
+    if quantize_activation:
+      acc *= x_scale
+    out_ref[...] = acc.astype(x_ref_dtype)
 
-def w8a8_matmul(
-    x: jax.Array,  # [bs, n_input_features]
-    x_scalar: jax.Array,  # [bs, 1]
-    w: jax.Array,  # [n_output_features, n_input_features]
-    w_scalar: jax.Array,  # [1, n_output_features]
-    x_orig_dtype,
-    batch_block_size,
-    out_block_size,
-    in_block_size,
-    vmem_limit_bytes,
-):
-  assert x.dtype == jnp.int8, f"x.dtype ({x.dtype}) must be int8"
-  assert w.dtype == jnp.int8, f"w.dtype ({w.dtype}) must be int8"
 
-  bs, n_input_features = x.shape
-  n_output_features, _ = w.shape
-  x_scalar = jnp.broadcast_to(x_scalar, (x_scalar.shape[0], NUM_LANES))
-  w_scalar = jnp.broadcast_to(w_scalar, (NUM_SUBLANES, w_scalar.shape[1]))
+def _next_multiple(x, multiple):
+  return ((x + multiple - 1) // multiple) * multiple
 
-  acc_dtype = jnp.int32
-  kernel = pl.pallas_call(
-      functools.partial(
-          w8a8_matmul_kernel,
-          x_orig_dtype=x_orig_dtype,
-          batch_block_size=batch_block_size,
-          out_block_size=out_block_size,
-          in_block_size=in_block_size),
-      grid_spec=pltpu.PrefetchScalarGridSpec(
-          num_scalar_prefetch=0,
-          in_specs=[
-              pl.BlockSpec((batch_block_size, in_block_size), lambda b, o, i:
-                           (b, i)),  # x
-              pl.BlockSpec((batch_block_size, NUM_LANES), lambda b, o, i:
-                           (b, 0)),  # x_scalar
-              pl.BlockSpec((out_block_size, in_block_size), lambda b, o, i:
-                           (o, i)),  # w
-              pl.BlockSpec((NUM_SUBLANES, out_block_size), lambda b, o, i:
-                           (0, o)),  # w_scalar
-          ],
-          out_specs=pl.BlockSpec((batch_block_size, out_block_size),
-                                 lambda b, o, i: (b, o)),
-          scratch_shapes=[
-              pltpu.VMEM((batch_block_size, out_block_size), acc_dtype)
-          ],
-          grid=(bs // batch_block_size,
-                n_output_features // out_block_size,
-                n_input_features // in_block_size),
-      ),
-      out_shape=jax.ShapeDtypeStruct((bs, n_output_features), x_orig_dtype),
-      compiler_params=pltpu.TPUCompilerParams(
-          dimension_semantics=("parallel", "parallel", "arbitrary"),
-          vmem_limit_bytes=vmem_limit_bytes,
-      ),
-  )
-  return kernel(x, x_scalar, w, w_scalar)
 
 @functools.partial(
     jax.jit,
@@ -196,15 +113,40 @@ def quantized_matmul_int8(
   assert quant_block_size is None, "Not implemented: quant_block_size is not supported."
   assert batch_block_size is not None and out_block_size is not None and in_block_size is not None
 
-  bs = x.shape[0]
-  orig_batch_block_size = batch_block_size
-  if bs < 128:
-    batch_block_size = bs
+  # x_max_val cannot be [bs, 128] where 128 is the minormost dimension of the vreg because it'll be costly to store
+  # [bs_block_size, 128] in VMEM ([bs_balock_size, 1:] will be padding).
+  # We need the global max values to be computed before the kernel.
+  x_abs_max_val = jnp.max(jnp.abs(x), axis=-1, keepdims=False)  # [bs]
+  x_abs_max_val = jnp.expand_dims(x_abs_max_val, axis=0)  # [1, bs]
+  assert x_abs_max_val.shape == (1, x.shape[0])
+
+  orig_bs, orig_in_features = x.shape
+  orig_out_features, _ = w.shape
+
+  padded_bs = _next_multiple(orig_bs, batch_block_size)
+  if orig_bs < padded_bs:
+    x = jnp.pad(x, ((0, padded_bs - orig_bs), (0, 0)))
+    x_abs_max_val = jnp.pad(x_abs_max_val, ((0, 0), (0, padded_bs - orig_bs)))
+  padded_out_features = _next_multiple(orig_out_features, out_block_size)
+  if orig_out_features < padded_out_features:
+    w = jnp.pad(w, ((0, padded_out_features - orig_out_features), (0, 0)))
+    scalar = jnp.pad(scalar, (0, padded_out_features - orig_out_features))
+  padded_in_features = _next_multiple(orig_in_features, in_block_size)
+  if orig_in_features < padded_in_features:
+    x = jnp.pad(x, ((0, 0), (0, padded_in_features - orig_in_features)))
+    w = jnp.pad(w, ((0, 0), (0, padded_in_features - orig_in_features)))
+
+  if scalar.dtype != jnp.float32:
+    scalar = scalar.astype(jnp.float32)
+  scalar = jnp.expand_dims(scalar, axis=0)  # [1, n_output_features]
 
   assert x.shape[1] == w.shape[
       1], f"x.shape[1] ({x.shape[1]}) must be equal to w.shape[1] ({w.shape[1]})"
   assert w.shape[0] == scalar.shape[
-      0], f"w.shape[0] ({w.shape[0]}) must be equal to scalar.shape[0] ({scalar.shape[0]})"
+      1], f"w.shape[0] ({w.shape[0]}) must be equal to scalar.shape[1] ({scalar.shape[1]})"
+  assert x_abs_max_val.shape == (
+      1, x.shape[0]
+  ), f"x_max_val.shape ({x_abs_max_val.shape}) must be equal to (1, x.shape[0]) ({1, {x.shape[0]}})"
   assert x.shape[
       0] % batch_block_size == 0, f"x.shape[0] ({x.shape[0]}) must be a multiple of block size ({batch_block_size})"
   assert w.shape[
@@ -212,21 +154,49 @@ def quantized_matmul_int8(
   assert x.shape[
       1] % in_block_size == 0, f"x.shape[1] ({x.shape[1]}) must be a multiple of block size ({in_block_size})"
 
-  x_orig_dtype = x.dtype
-  x_int, x_scalar = quantize_array(x, vmem_limit_bytes)
-  assert x_int.dtype == jnp.int8, f"x_int.dtype ({x_int.dtype}) must be int8"
-  assert w.dtype == jnp.int8, f"w.dtype ({w.dtype}) must be int8"
+  acc_dtype = jnp.int32 if quantize_activation else x.dtype
+  kernel = pl.pallas_call(
+      functools.partial(
+          matmul_kernel,
+          quantize_activation=quantize_activation,
+          batch_block_size=batch_block_size,
+          out_block_size=out_block_size,
+          in_block_size=in_block_size),
+      grid_spec=pltpu.PrefetchScalarGridSpec(
+          num_scalar_prefetch=0,
+          in_specs=[
+              pl.BlockSpec((batch_block_size, in_block_size), lambda b, o, i:
+                           (b, i)),
+              pl.BlockSpec((out_block_size, in_block_size), lambda b, o, i:
+                           (o, i)),
+              pl.BlockSpec((1, out_block_size), lambda b, o, i:
+                           (0, o)),  # scalar
+              pl.BlockSpec((1, batch_block_size), lambda b, o, i:
+                           (0, b)),  # x_abs_max_val
+          ],
+          out_specs=pl.BlockSpec((batch_block_size, out_block_size),
+                                 lambda b, o, i: (b, o)),
+          scratch_shapes=[
+              pltpu.VMEM((batch_block_size, out_block_size), acc_dtype)
+          ],
+          grid=(padded_bs // batch_block_size,
+                padded_out_features // out_block_size,
+                padded_in_features // in_block_size),
+      ),
+      out_shape=jax.ShapeDtypeStruct((padded_bs, padded_out_features), x.dtype),
+      compiler_params=pltpu.TPUCompilerParams(
+          dimension_semantics=("parallel", "parallel", "arbitrary"),
+          vmem_limit_bytes=vmem_limit_bytes,
+      ),
+  )
 
-  if scalar.dtype != jnp.float32:
-    scalar = scalar.astype(jnp.float32)
-  scalar = jnp.expand_dims(scalar, axis=0)  # [1, n_output_features]
-
-  kernel_name = f'quantized_matmul_int8_{orig_batch_block_size}_{out_block_size}_{in_block_size}'
+  kernel_name = f'quantized_matmul_int8_{batch_block_size}_{out_block_size}_{in_block_size}'
   # The named_scope is used for autotune. Different block sizes only impact the
   # pallas_call.
   with jax.named_scope(kernel_name):
-    out = w8a8_matmul(x_int, x_scalar, w, scalar, x_orig_dtype, batch_block_size, out_block_size, in_block_size, vmem_limit_bytes)
-  return out
+    out = kernel(x, w, scalar, x_abs_max_val)
+
+  return out[:orig_bs, :orig_out_features]
 
 
 # Below are tuned block sizes.
@@ -243,68 +213,68 @@ def quantized_matmul_int8(
 #    - out_block_size
 #    - in_block_size
 TUNED_BLOCK_SIZES = {
-    (6, 1024, 1280, 8192, 'bfloat16', True): (512, 1280, 8192),
-    (6, 1024, 28672, 4096, 'bfloat16', True): (1024, 1792, 4096),
-    (6, 1024, 4096, 14336, 'bfloat16', True): (1024, 256, 14336),
-    (6, 1024, 4096, 4096, 'bfloat16', True): (1024, 512, 4096),
-    (6, 1024, 6144, 4096, 'bfloat16', True): (1024, 768, 4096),
-    (6, 1024, 7168, 8192, 'bfloat16', True): (1024, 256, 8192),
-    (6, 1024, 8192, 1024, 'bfloat16', True): (1024, 4096, 1024),
-    (6, 1024, 8192, 3584, 'bfloat16', True): (1024, 1024, 3584),
-    (6, 128, 1280, 8192, 'bfloat16', True): (128, 256, 8192),
-    (6, 128, 28672, 4096, 'bfloat16', True): (128, 512, 4096),
-    (6, 128, 4096, 14336, 'bfloat16', True): (128, 256, 14336),
+    (6, 1024, 1280, 8192, 'bfloat16', True): (1024, 1280, 2048),
+    (6, 1024, 28672, 4096, 'bfloat16', True): (1024, 3584, 4096),
+    (6, 1024, 4096, 14336, 'bfloat16', True): (1024, 4096, 2048),
+    (6, 1024, 4096, 4096, 'bfloat16', True): (1024, 1024, 4096),
+    (6, 1024, 6144, 4096, 'bfloat16', True): (1024, 1536, 4096),
+    (6, 1024, 7168, 8192, 'bfloat16', True): (1024, 1792, 8192),
+    (6, 1024, 8192, 1024, 'bfloat16', True): (256, 8192, 1024),
+    (6, 1024, 8192, 3584, 'bfloat16', True): (1024, 2048, 3584),
+    (6, 128, 1280, 8192, 'bfloat16', True): (128, 1280, 2048),
+    (6, 128, 28672, 4096, 'bfloat16', True): (128, 1024, 4096),
+    (6, 128, 4096, 14336, 'bfloat16', True): (128, 1024, 3584),
     (6, 128, 4096, 4096, 'bfloat16', True): (128, 512, 4096),
-    (6, 128, 6144, 4096, 'bfloat16', True): (128, 512, 4096),
-    (6, 128, 7168, 8192, 'bfloat16', True): (128, 256, 8192),
+    (6, 128, 6144, 4096, 'bfloat16', True): (128, 768, 4096),
+    (6, 128, 7168, 8192, 'bfloat16', True): (128, 896, 4096),
     (6, 128, 8192, 1024, 'bfloat16', True): (128, 2048, 1024),
-    (6, 128, 8192, 3584, 'bfloat16', True): (128, 512, 3584),
+    (6, 128, 8192, 3584, 'bfloat16', True): (128, 1024, 3584),
     (6, 16, 1280, 8192, 'bfloat16', True): (128, 1280, 2048),
-    (6, 16, 28672, 4096, 'bfloat16', True): (128, 512, 4096),
-    (6, 16, 4096, 14336, 'bfloat16', True): (128, 1024, 2048),
+    (6, 16, 28672, 4096, 'bfloat16', True): (128, 1024, 4096),
+    (6, 16, 4096, 14336, 'bfloat16', True): (128, 1024, 3584),
     (6, 16, 4096, 4096, 'bfloat16', True): (128, 512, 4096),
-    (6, 16, 6144, 4096, 'bfloat16', True): (128, 512, 4096),
-    (6, 16, 7168, 8192, 'bfloat16', True): (128, 256, 8192),
+    (6, 16, 6144, 4096, 'bfloat16', True): (128, 768, 4096),
+    (6, 16, 7168, 8192, 'bfloat16', True): (128, 896, 4096),
     (6, 16, 8192, 1024, 'bfloat16', True): (128, 2048, 1024),
-    (6, 16, 8192, 3584, 'bfloat16', True): (128, 4096, 896),
+    (6, 16, 8192, 3584, 'bfloat16', True): (128, 1024, 3584),
     (6, 2048, 1280, 8192, 'bfloat16', True): (512, 1280, 8192),
-    (6, 2048, 28672, 4096, 'bfloat16', True): (2048, 1024, 4096),
-    (6, 2048, 4096, 14336, 'bfloat16', True): (2048, 512, 14336),
-    (6, 2048, 4096, 4096, 'bfloat16', True): (256, 4096, 4096),
-    (6, 2048, 6144, 4096, 'bfloat16', True): (2048, 256, 4096),
-    (6, 2048, 7168, 8192, 'bfloat16', True): (2048, 512, 8192),
+    (6, 2048, 28672, 4096, 'bfloat16', True): (1024, 4096, 4096),
+    (6, 2048, 4096, 14336, 'bfloat16', True): (1024, 4096, 2048),
+    (6, 2048, 4096, 4096, 'bfloat16', True): (1024, 2048, 4096),
+    (6, 2048, 6144, 4096, 'bfloat16', True): (1024, 3072, 4096),
+    (6, 2048, 7168, 8192, 'bfloat16', True): (1024, 1792, 8192),
     (6, 2048, 8192, 1024, 'bfloat16', True): (256, 8192, 1024),
-    (6, 2048, 8192, 3584, 'bfloat16', True): (1024, 512, 3584),
-    (6, 256, 1280, 8192, 'bfloat16', True): (256, 256, 8192),
-    (6, 256, 28672, 4096, 'bfloat16', True): (256, 3584, 2048),
+    (6, 2048, 8192, 3584, 'bfloat16', True): (1024, 2048, 3584),
+    (6, 256, 1280, 8192, 'bfloat16', True): (256, 1280, 2048),
+    (6, 256, 28672, 4096, 'bfloat16', True): (256, 1792, 4096),
     (6, 256, 4096, 14336, 'bfloat16', True): (256, 1024, 3584),
-    (6, 256, 4096, 4096, 'bfloat16', True): (256, 512, 4096),
-    (6, 256, 6144, 4096, 'bfloat16', True): (256, 768, 4096),
-    (6, 256, 7168, 8192, 'bfloat16', True): (256, 512, 8192),
-    (6, 256, 8192, 1024, 'bfloat16', True): (256, 2048, 1024),
+    (6, 256, 4096, 4096, 'bfloat16', True): (256, 1024, 4096),
+    (6, 256, 6144, 4096, 'bfloat16', True): (256, 1024, 4096),
+    (6, 256, 7168, 8192, 'bfloat16', True): (256, 1024, 4096),
+    (6, 256, 8192, 1024, 'bfloat16', True): (256, 4096, 1024),
     (6, 256, 8192, 3584, 'bfloat16', True): (256, 1024, 3584),
     (6, 32, 1280, 8192, 'bfloat16', True): (128, 1280, 2048),
-    (6, 32, 28672, 4096, 'bfloat16', True): (128, 512, 4096),
+    (6, 32, 28672, 4096, 'bfloat16', True): (128, 1024, 4096),
     (6, 32, 4096, 14336, 'bfloat16', True): (128, 1024, 3584),
     (6, 32, 4096, 4096, 'bfloat16', True): (128, 512, 4096),
-    (6, 32, 6144, 4096, 'bfloat16', True): (128, 1536, 2048),
-    (6, 32, 7168, 8192, 'bfloat16', True): (128, 256, 8192),
+    (6, 32, 6144, 4096, 'bfloat16', True): (128, 768, 4096),
+    (6, 32, 7168, 8192, 'bfloat16', True): (128, 896, 4096),
     (6, 32, 8192, 1024, 'bfloat16', True): (128, 2048, 1024),
     (6, 32, 8192, 3584, 'bfloat16', True): (128, 1024, 3584),
-    (6, 512, 1280, 8192, 'bfloat16', True): (512, 256, 8192),
-    (6, 512, 28672, 4096, 'bfloat16', True): (512, 4096, 4096),
-    (6, 512, 4096, 14336, 'bfloat16', True): (512, 256, 14336),
+    (6, 512, 1280, 8192, 'bfloat16', True): (512, 1280, 2048),
+    (6, 512, 28672, 4096, 'bfloat16', True): (512, 3584, 4096),
+    (6, 512, 4096, 14336, 'bfloat16', True): (512, 4096, 1792),
     (6, 512, 4096, 4096, 'bfloat16', True): (512, 1024, 4096),
     (6, 512, 6144, 4096, 'bfloat16', True): (512, 1024, 4096),
-    (6, 512, 7168, 8192, 'bfloat16', True): (512, 512, 8192),
+    (6, 512, 7168, 8192, 'bfloat16', True): (512, 1024, 8192),
     (6, 512, 8192, 1024, 'bfloat16', True): (512, 4096, 1024),
     (6, 512, 8192, 3584, 'bfloat16', True): (512, 2048, 3584),
-    (6, 64, 1280, 8192, 'bfloat16', True): (128, 256, 8192),
-    (6, 64, 28672, 4096, 'bfloat16', True): (128, 512, 4096),
+    (6, 64, 1280, 8192, 'bfloat16', True): (128, 1280, 2048),
+    (6, 64, 28672, 4096, 'bfloat16', True): (128, 1024, 4096),
     (6, 64, 4096, 14336, 'bfloat16', True): (128, 512, 7168),
-    (6, 64, 4096, 4096, 'bfloat16', True): (128, 512, 4096),
-    (6, 64, 6144, 4096, 'bfloat16', True): (128, 512, 4096),
-    (6, 64, 7168, 8192, 'bfloat16', True): (128, 256, 8192),
+    (6, 64, 4096, 4096, 'bfloat16', True): (128, 1024, 4096),
+    (6, 64, 6144, 4096, 'bfloat16', True): (128, 768, 4096),
+    (6, 64, 7168, 8192, 'bfloat16', True): (128, 896, 4096),
     (6, 64, 8192, 1024, 'bfloat16', True): (128, 2048, 1024),
     (6, 64, 8192, 3584, 'bfloat16', True): (128, 1024, 3584),
 }

--- a/torch_xla/experimental/pallas_kernels/quantized_matmul_kernel.py
+++ b/torch_xla/experimental/pallas_kernels/quantized_matmul_kernel.py
@@ -291,8 +291,9 @@ def get_tpu_version() -> int:
   return int(kind[-1])
 
 
-def get_tuned_block_sizes(block_table, batch_size, n_output_features, n_input_features,
-                          activation_dtype, quantize_activation):
+def get_tuned_block_sizes(block_table, batch_size, n_output_features,
+                          n_input_features, activation_dtype,
+                          quantize_activation):
   """
     Retrieve the tuned block sizes for the given parameters.
 
@@ -308,9 +309,4 @@ def get_tuned_block_sizes(block_table, batch_size, n_output_features, n_input_fe
   """
   key = (get_tpu_version(), batch_size, n_output_features, n_input_features,
          activation_dtype, quantize_activation)
-  # TODO(xw32): delete it
-  # if key not in block_table:
-  #   raise ValueError(
-  #       f"Block sizes not found for key {key}. Available keys: {list(block_table.keys())}"
-  #   )
-  return block_table.get(key, (128, 128, 128))
+  return block_table.get(key, (None, None, None))


### PR DESCRIPTION
This PR 
- updated the block table.
- fall back to xla w8a8 quantized matmul if the block sizes are not found.

Test plan:
- pytest pytorch/xla/test/test_quantized_matmul_pallas_kernel.py -s
- python pytorch/xla/test/test_pallas.py -k test_quantized_matmul_int8