### PR TITLE
Install libtpu directly instead of torch_xla[tpu]

### DIFF
--- a/infra/ansible/config/pip.yaml
+++ b/infra/ansible/config/pip.yaml
@@ -44,7 +44,7 @@ pip:
       - mkl-include
 
     release_tpu:
-      - torch_xla[tpu]
+      - libtpu
 
   # Packages that will be installed with the `--nodeps` flag.
   pkgs_nodeps:


### PR DESCRIPTION
This is the list of packages that is installed in a dev container. 

When supporting a new python version for torch_xla, trying to install torch_xla[tpu] in the devcontainer creates a circular dependency where torch_xla for that python version already needs to exist. To break the circular dependency, we can directly install the latest libtpu stable version instead of using torch_xla[tpu]