### PR TITLE
Change update_deps script so that latest stable version can be pulled instead of latest nightly

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,7 +46,7 @@ new_local_repository(
 
 # To build PyTorch/XLA with a new revison of OpenXLA, update the xla_hash to
 # the openxla git commit hash and note the date of the commit.
-xla_hash = '9084478fa71d7661ad9b4c95f24107b53c8a4709'  # Committed on 2025-06-17.
+xla_hash = '3d5ece64321630dade7ff733ae1353fc3c83d9cc'  # Committed on 2025-06-17.
 
 http_archive(
     name = "xla",

--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -393,13 +393,9 @@ def update_libtpu(target_date: str | None = None) -> bool:
     setup_lines = f.readlines()
 
   # Update the lines for specifying the libtpu version.
-  found_use_nightly, found_libtpu_version, found_libtpu_date, found_libtpu_wheel = False, False, False, False
+  found_libtpu_version, found_libtpu_date, found_libtpu_wheel = False, False, False
   for i, line in enumerate(setup_lines):
-    if re.match(r'USE_NIGHTLY\s*=', line):
-      found_use_nightly = True
-      # If target_date is None, we are in nightly mode.
-      setup_lines[i] = f"USE_NIGHTLY = {target_date is None}\n"
-    elif re.match(r'_libtpu_version\s*=', line):
+    if re.match(r'_libtpu_version\s*=', line):
       found_libtpu_version = True
       setup_lines[i] = f"_libtpu_version = '{version}'\n"
     elif re.match(r'_libtpu_date\s*=', line):
@@ -415,8 +411,6 @@ def update_libtpu(target_date: str | None = None) -> bool:
             "_libtpu_wheel_name = f'libtpu-{_libtpu_version}.dev{_libtpu_date}+nightly-"
             + suffix + "_{platform_machine}'\n")
 
-  if not found_use_nightly:
-    logger.error('Could not find USE_NIGHTLY in setup.py.')
   if not found_libtpu_version:
     logger.error('Could not find _libtpu_version in setup.py.')
   if not found_libtpu_date:
@@ -427,7 +421,7 @@ def update_libtpu(target_date: str | None = None) -> bool:
   with open(_SETUP_PATH, 'w') as f:
     f.writelines(setup_lines)
 
-  success = found_use_nightly and found_libtpu_version and found_libtpu_date and found_libtpu_wheel
+  success = found_libtpu_version and found_libtpu_date and found_libtpu_wheel
   if success:
     logger.info('Updated the libtpu version in setup.py.')
   return success
@@ -456,12 +450,9 @@ def update_jax(use_nightly: bool) -> bool:
     setup_lines = f.readlines()
 
   # Update the lines for specifying jax/jaxlib versions.
-  found_use_nightly, found_jax_version, found_jaxlib_version, found_jax_date = False, False, False, False
+  found_jax_version, found_jaxlib_version, found_jax_date = False, False, False
   for i, line in enumerate(setup_lines):
-    if re.match(r'USE_NIGHTLY\s*=', line):
-      found_use_nightly = True
-      setup_lines[i] = f"USE_NIGHTLY = {use_nightly}\n"
-    elif re.match(r'_jax_version\s*=', line):
+    if re.match(r'_jax_version\s*=', line):
       found_jax_version = True
       setup_lines[i] = f"_jax_version = '{jax_version}'\n"
     elif re.match(r'_jaxlib_version\s*=', line):
@@ -471,8 +462,6 @@ def update_jax(use_nightly: bool) -> bool:
       found_jax_date = True
       setup_lines[i] = f"_jax_date = '{date}'  # Date for jax and jaxlib.\n"
 
-  if not found_use_nightly:
-    logger.error('Could not find USE_NIGHTLY in setup.py.')
   if not found_jax_version:
     logger.error('Could not find _jax_version in setup.py.')
   if not found_jaxlib_version:
@@ -483,7 +472,7 @@ def update_jax(use_nightly: bool) -> bool:
   with open(_SETUP_PATH, 'w') as f:
     f.writelines(setup_lines)
 
-  success = found_use_nightly and found_jax_version and found_jaxlib_version and found_jax_date
+  success = found_jax_version and found_jaxlib_version and found_jax_date
   if success:
     logger.info('Updated the jax/jaxlib versions in setup.py.')
   return success

--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -4,12 +4,12 @@
 Usage:
 
   scripts/update_deps.py
-  scripts/update_deps.py --use_nightly
+  scripts/update_deps.py --use_latest
 
     By default, updates to the latest stable JAX release and its corresponding
     OpenXLA and libtpu versions.
 
-    With --use_nightly, updates to the latest nightly builds of OpenXLA,
+    With --use_latest, updates to the latest nightly builds of OpenXLA,
     libtpu, and JAX.
 """
 
@@ -427,13 +427,13 @@ def update_libtpu(target_date: str | None = None) -> bool:
   return success
 
 
-def update_jax(use_nightly: bool) -> bool:
+def update_jax(use_latest: bool) -> bool:
   """Updates the jax/jaxlib versions in setup.py.
 
   Returns:
     True if the setup.py file was updated, False otherwise.
   """
-  if use_nightly:
+  if use_latest:
     result = find_latest_jax_nightly()
     if not result:
       return False
@@ -484,18 +484,18 @@ def main() -> None:
   parser = argparse.ArgumentParser(
       description="Updates third party dependencies.")
   parser.add_argument(
-      '--use_nightly',
+      '--use_latest',
       action='store_true',
       default=False,
       help='Update to latest nightly versions instead of latest stable versions.'
   )
   args = parser.parse_args()
 
-  if args.use_nightly:
+  if args.use_latest:
     logger.info('Updating to latest nightly versions...')
     openxla_updated = update_openxla()
     libtpu_updated = update_libtpu()
-    jax_updated = update_jax(use_nightly=True)
+    jax_updated = update_jax(use_latest=True)
     if not (openxla_updated and libtpu_updated and jax_updated):
       sys.exit(1)
   else:
@@ -512,7 +512,7 @@ def main() -> None:
     openxla_updated = update_openxla(xla_commit)
     libtpu_updated = update_libtpu(
         target_date=jax_release_date.replace('-', ''))
-    jax_updated = update_jax(use_nightly=False)
+    jax_updated = update_jax(use_latest=False)
     if not (openxla_updated and libtpu_updated and jax_updated):
       sys.exit(1)
 

--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -4,23 +4,24 @@
 Usage:
 
   scripts/update_deps.py
+  scripts/update_deps.py --use_nightly
 
-    updates the versions of OpenXLA, libtpu, and JAX as used in
-    PyTorch/XLA. In particular, it:
+    By default, updates to the latest stable JAX release and its corresponding
+    OpenXLA and libtpu versions.
 
-    - updates OpenXLA to the latest commit,
-    - updates libtpu to the latest nightly build, and
-    - updates JAX to the latest nightly build.
+    With --use_nightly, updates to the latest nightly builds of OpenXLA,
+    libtpu, and JAX.
 """
 
+import argparse
+import json
 import logging
 import os
 import platform
 import re
 import sys
-from typing import Optional
-from html.parser import HTMLParser
 import urllib.request
+from html.parser import HTMLParser
 
 logger = logging.getLogger(__name__)
 
@@ -107,34 +108,85 @@ def clean_tmp_dir() -> None:
   os.system(f'mkdir -p {_TMP_DIR}')
 
 
-def get_last_xla_commit_and_date() -> tuple[str, str]:
-  """Finds the latest commit in the master branch of https://github.com/openxla/xla.
+def get_xla_commit_and_date(commit: str | None = None) -> tuple[str, str]:
+  """Find a date, commit pair from https://github.com/openxla/xla.
+  If commit is specified, use that commit.
+  If no commit is specified take the latest commit from main.
 
   Returns:
-    A tuple of the latest commit SHA and its date (YYYY-MM-DD).
+    A tuple of the commit SHA and its date (YYYY-MM-DD).
   """
 
-  # Get the latest commit in the master branch of openxla.
   clean_tmp_dir()
-  os.system(
-      f'git clone --depth=1 https://github.com/openxla/xla {_TMP_DIR}/xla')
-  commit = os.popen(f'cd {_TMP_DIR}/xla && git rev-parse HEAD').read().strip()
+  if commit is None:
+    # Clone the repository to a depth of 1 (just the main branch).
+    os.system(
+        f'git clone --depth=1 https://github.com/openxla/xla {_TMP_DIR}/xla')
+    commit = os.popen(f'cd {_TMP_DIR}/xla && git rev-parse HEAD').read().strip()
+    date = os.popen(
+        f'cd {_TMP_DIR}/xla && git show -s --format=%cd --date=short {commit}'
+    ).read().strip()
+    logger.info(f'Found latest XLA commit {commit} on date {date}')
+  else:
+    # Clone the repository history, but no blobs to save space.
+    os.system(
+        f'git clone --bare --filter=blob:none https://github.com/openxla/xla.git {_TMP_DIR}/xla.git'
+    )
+    date = os.popen(
+        f'git --git-dir={_TMP_DIR}/xla.git show -s --format=%cd --date=short {commit}'
+    ).read().strip()
+    if not date:
+      logging.error(f"Unable to local XLA commit {commit}")
+    logger.info(f'Given XLA commit {commit}, determined date {date}')
 
-  # Get the date of the commit, in the format of YYYY-MM-DD.
-  date = os.popen(
-      f'cd {_TMP_DIR}/xla && git show -s --format=%cd --date=short {commit}'
-  ).read().strip()
   return commit, date
 
 
-def update_openxla() -> bool:
-  """Updates the OpenXLA version in the WORKSPACE file to the latest commit.
+def get_latest_stable_jax_info() -> tuple[str, str, str] | None:
+  """Gets info about the latest stable JAX release from GitHub.
+
+  Returns:
+    A tuple of (JAX version, JAX release date, XLA commit hash).
+  """
+  url = 'https://api.github.com/repos/google/jax/releases/latest'
+  try:
+    with urllib.request.urlopen(url) as response:
+      data = json.loads(response.read().decode())
+  except Exception as e:
+    logger.error(f'Failed to fetch {url}: {e}')
+    return None
+
+  tag_name = data['tag_name']  # e.g., "jax-v0.4.28"
+  jax_version = tag_name.replace('jax-v', '')  # e.g., "0.4.28"
+
+  published_at = data['published_at']  # e.g., "2024-04-26T22:58:34Z"
+  release_date = published_at.split('T')[0]  # e.g., "2024-04-26"
+
+  # The XLA commit is in third_party/xla/workspace.bzl in the JAX repo.
+  workspace_bzl_url = f'https://raw.githubusercontent.com/google/jax/{tag_name}/third_party/xla/workspace.bzl'
+  try:
+    with urllib.request.urlopen(workspace_bzl_url) as response:
+      workspace_content = response.read().decode()
+  except Exception as e:
+    logger.error(f'Failed to fetch {workspace_bzl_url}: {e}')
+    return None
+
+  match = re.search(r'XLA_COMMIT = "([a-f0-9]{40})"', workspace_content)
+  if not match:
+    logger.error(f'Could not find XLA_COMMIT in {workspace_bzl_url}.')
+    return None
+  xla_commit = match.group(1)
+
+  return jax_version, release_date, xla_commit
+
+
+def update_openxla(commit: str | None = None) -> bool:
+  """Updates the OpenXLA version in the WORKSPACE file.
 
   Returns:
     True if the WORKSPACE file was updated, False otherwise.
   """
-
-  commit, date = get_last_xla_commit_and_date()
+  commit, date = get_xla_commit_and_date(commit=commit)
 
   with open(_WORKSPACE_PATH, 'r') as f:
     ws_lines = f.readlines()
@@ -158,14 +210,18 @@ def update_openxla() -> bool:
   return True
 
 
-def find_latest_nightly(html_lines: list[str],
-                        build_re: str) -> Optional[tuple[str, str, str]]:
+def find_latest_nightly(
+    html_lines: list[str],
+    build_re: str,
+    target_date: str | None = None) -> tuple[str, str, str] | None:
   """Finds the latest nightly build from the list of HTML lines.
 
   Args:
     html_lines: A list of HTML lines to search for the nightly build.
     build_re: A regular expression for matching the nightly build line.
       It must have 3 capture groups: the version, the date, and the name suffix.
+    target_date: If specified, find the latest build on or before this date
+      (YYYYMMDD). Otherwise, find the latest build overall.
 
   Returns:
     A tuple of the version, date, and suffix of the latest nightly build,
@@ -180,7 +236,10 @@ def find_latest_nightly(html_lines: list[str],
     if m:
       found_build = True
       version, date, suffix = m.groups()
-      if date > latest_date:
+      if target_date is None:
+        if date > latest_date:
+          latest_version, latest_date, latest_suffix = version, date, suffix
+      elif date <= target_date and date > latest_date:
         latest_version, latest_date, latest_suffix = version, date, suffix
 
   if found_build:
@@ -189,8 +248,12 @@ def find_latest_nightly(html_lines: list[str],
   return None
 
 
-def find_latest_libtpu_nightly() -> Optional[tuple[str, str, str]]:
-  """Finds the latest libtpu nightly build for the current platform.
+def find_libtpu_build(
+    target_date: str | None = None) -> tuple[str, str, str] | None:
+  """Finds a libtpu nightly build for the current platform.
+
+  Args:
+    target_date: If specified, find build for this date. Otherwise, find latest.
 
   Returns:
     A tuple of the version, date, and suffix of the latest libtpu nightly build,
@@ -209,7 +272,7 @@ def find_latest_libtpu_nightly() -> Optional[tuple[str, str, str]]:
   return find_latest_nightly(
       html_lines,
       r'.*<a href=.*?>libtpu/libtpu-(.*?)\.dev(\d{8})\+nightly-(.*?)_' +
-      _PLATFORM + r'\.whl</a>')
+      _PLATFORM + r'\.whl</a>', target_date)
 
 
 def fetch_pep503_page(url: str) -> list[tuple[str, str]]:
@@ -233,7 +296,7 @@ def fetch_pep503_page(url: str) -> list[tuple[str, str]]:
     return []
 
 
-def find_latest_jax_nightly() -> Optional[tuple[str, str, str]]:
+def find_latest_jax_nightly() -> tuple[str, str, str] | None:
   """Finds the latest JAX nightly build using the new package index.
 
   Returns:
@@ -309,15 +372,19 @@ def find_latest_jax_nightly() -> Optional[tuple[str, str, str]]:
   return latest_jax_version, latest_jaxlib_version, latest_jax_date
 
 
-def update_libtpu() -> bool:
-  """Updates the libtpu version in setup.py to the latest nightly build.
+def update_libtpu(target_date: str | None = None) -> bool:
+  """Updates the libtpu version in setup.py.
 
   Returns:
     True if the setup.py file was updated, False otherwise.
   """
 
-  result = find_latest_libtpu_nightly()
+  result = find_libtpu_build(target_date)
   if not result:
+    if target_date:
+      logger.error(f'Could not find libtpu build for date {target_date}.')
+    else:
+      logger.error('Could not find latest libtpu nightly build.')
     return False
 
   version, date, suffix = result
@@ -326,9 +393,13 @@ def update_libtpu() -> bool:
     setup_lines = f.readlines()
 
   # Update the lines for specifying the libtpu version.
-  found_libtpu_version, found_libtpu_date, found_libtpu_wheel = False, False, False
+  found_use_nightly, found_libtpu_version, found_libtpu_date, found_libtpu_wheel = False, False, False, False
   for i, line in enumerate(setup_lines):
-    if re.match(r'_libtpu_version\s*=', line):
+    if re.match(r'USE_NIGHTLY\s*=', line):
+      found_use_nightly = True
+      # If target_date is None, we are in nightly mode.
+      setup_lines[i] = f"USE_NIGHTLY = {target_date is None}\n"
+    elif re.match(r'_libtpu_version\s*=', line):
       found_libtpu_version = True
       setup_lines[i] = f"_libtpu_version = '{version}'\n"
     elif re.match(r'_libtpu_date\s*=', line):
@@ -344,6 +415,8 @@ def update_libtpu() -> bool:
             "_libtpu_wheel_name = f'libtpu-{_libtpu_version}.dev{_libtpu_date}+nightly-"
             + suffix + "_{platform_machine}'\n")
 
+  if not found_use_nightly:
+    logger.error('Could not find USE_NIGHTLY in setup.py.')
   if not found_libtpu_version:
     logger.error('Could not find _libtpu_version in setup.py.')
   if not found_libtpu_date:
@@ -354,32 +427,41 @@ def update_libtpu() -> bool:
   with open(_SETUP_PATH, 'w') as f:
     f.writelines(setup_lines)
 
-  success = found_libtpu_version and found_libtpu_date and found_libtpu_wheel
+  success = found_use_nightly and found_libtpu_version and found_libtpu_date and found_libtpu_wheel
   if success:
     logger.info('Updated the libtpu version in setup.py.')
   return success
 
 
-def update_jax() -> bool:
-  """Updates the jax/jaxlib versions in setup.py to the latest nightly build.
+def update_jax(use_nightly: bool) -> bool:
+  """Updates the jax/jaxlib versions in setup.py.
 
   Returns:
     True if the setup.py file was updated, False otherwise.
   """
-
-  result = find_latest_jax_nightly()
-  if not result:
-    return False
-
-  jax_version, jaxlib_version, date = result
+  if use_nightly:
+    result = find_latest_jax_nightly()
+    if not result:
+      return False
+    jax_version, jaxlib_version, date = result
+  else:
+    jax_info = get_latest_stable_jax_info()
+    if not jax_info:
+      return False
+    jax_version, release_date, _ = jax_info
+    jaxlib_version = jax_version
+    date = release_date.replace('-', '')
 
   with open(_SETUP_PATH, 'r') as f:
     setup_lines = f.readlines()
 
   # Update the lines for specifying jax/jaxlib versions.
-  found_jax_version, found_jaxlib_version, found_jax_date = False, False, False
+  found_use_nightly, found_jax_version, found_jaxlib_version, found_jax_date = False, False, False, False
   for i, line in enumerate(setup_lines):
-    if re.match(r'_jax_version\s*=', line):
+    if re.match(r'USE_NIGHTLY\s*=', line):
+      found_use_nightly = True
+      setup_lines[i] = f"USE_NIGHTLY = {use_nightly}\n"
+    elif re.match(r'_jax_version\s*=', line):
       found_jax_version = True
       setup_lines[i] = f"_jax_version = '{jax_version}'\n"
     elif re.match(r'_jaxlib_version\s*=', line):
@@ -389,6 +471,8 @@ def update_jax() -> bool:
       found_jax_date = True
       setup_lines[i] = f"_jax_date = '{date}'  # Date for jax and jaxlib.\n"
 
+  if not found_use_nightly:
+    logger.error('Could not find USE_NIGHTLY in setup.py.')
   if not found_jax_version:
     logger.error('Could not find _jax_version in setup.py.')
   if not found_jaxlib_version:
@@ -399,7 +483,7 @@ def update_jax() -> bool:
   with open(_SETUP_PATH, 'w') as f:
     f.writelines(setup_lines)
 
-  success = found_jax_version and found_jaxlib_version and found_jax_date
+  success = found_use_nightly and found_jax_version and found_jaxlib_version and found_jax_date
   if success:
     logger.info('Updated the jax/jaxlib versions in setup.py.')
   return success
@@ -408,12 +492,40 @@ def update_jax() -> bool:
 def main() -> None:
   logging.basicConfig(level=logging.INFO)
 
-  openxla_updated = update_openxla()
-  libtpu_updated = update_libtpu()
-  jax_updated = update_jax()
+  parser = argparse.ArgumentParser(
+      description="Updates third party dependencies.")
+  parser.add_argument(
+      '--use_nightly',
+      action='store_true',
+      default=False,
+      help='Update to latest nightly versions instead of latest stable versions.'
+  )
+  args = parser.parse_args()
 
-  if not (openxla_updated and libtpu_updated and jax_updated):
-    sys.exit(1)
+  if args.use_nightly:
+    logger.info('Updating to latest nightly versions...')
+    openxla_updated = update_openxla()
+    libtpu_updated = update_libtpu()
+    jax_updated = update_jax(use_nightly=True)
+    if not (openxla_updated and libtpu_updated and jax_updated):
+      sys.exit(1)
+  else:
+    logger.info('Updating to latest stable versions...')
+    jax_info = get_latest_stable_jax_info()
+    if not jax_info:
+      sys.exit(1)
+
+    jax_version, jax_release_date, xla_commit = jax_info
+    logger.info(
+        f'Found latest stable JAX release {jax_version} from {jax_release_date}, with XLA commit {xla_commit}'
+    )
+
+    openxla_updated = update_openxla(xla_commit)
+    libtpu_updated = update_libtpu(
+        target_date=jax_release_date.replace('-', ''))
+    jax_updated = update_jax(use_nightly=False)
+    if not (openxla_updated and libtpu_updated and jax_updated):
+      sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,9 @@ base_dir = os.path.dirname(os.path.abspath(__file__))
 # 4. After the local build succeeds, create a PR and wait for the CI result. Fix
 #    CI errors as needed until all required checks pass.
 
-USE_NIGHTLY = True  # Whether to use nightly or stable libtpu and JAX.
+# Whether to use nightly or stable libtpu and JAX.
+# Automatically modified when update_deps script is run.
+USE_NIGHTLY = False
 
 _libtpu_version = '0.0.18'
 _libtpu_date = '20250617'

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ base_dir = os.path.dirname(os.path.abspath(__file__))
 # 4. After the local build succeeds, create a PR and wait for the CI result. Fix
 #    CI errors as needed until all required checks pass.
 
-USE_NIGHTLY = False  # Whether to use nightly or stable libtpu and JAX.
+USE_NIGHTLY = True  # Whether to use nightly or stable libtpu and JAX.
 
 _libtpu_version = '0.0.18'
 _libtpu_date = '20250617'

--- a/setup.py
+++ b/setup.py
@@ -106,9 +106,7 @@ base_dir = os.path.dirname(os.path.abspath(__file__))
 # 4. After the local build succeeds, create a PR and wait for the CI result. Fix
 #    CI errors as needed until all required checks pass.
 
-# Whether to use nightly or stable libtpu and JAX.
-# Automatically modified when update_deps script is run.
-USE_NIGHTLY = False
+USE_NIGHTLY = False  # Whether to use nightly or stable libtpu and JAX.
 
 _libtpu_version = '0.0.18'
 _libtpu_date = '20250617'


### PR DESCRIPTION
Given the decision to sync with a stable release, modifies the update_deps.py script to optionally determine the latest release of Jax and get the corresponding openxla hash and libtpu version.

Running the script changes the XLA hash from [9084478](https://github.com/openxla/xla/commit/9084478) to [3d5ece6](https://github.com/openxla/xla/commit/3d5ece6). The latter is the [XLA commit pinned by Jax 0.6.2](https://github.com/jax-ml/jax/blob/jax-v0.6.2/third_party/xla/workspace.bzl#L24), which is what we want. The former was the last commit on the day of the release. In this case they both work, but it's a nice verification that this script can get us a more compatible version with less effort.

Note that setup.py has a `USE_NIGHTLY` bool which, if False, will pull jax and jaxlib using their version numbers instead of pulling the corresponding nightly from the package registries. This seems like a change we want to make but doing so in this case [fails](https://github.com/pytorch/xla/actions/runs/15982768273/job/45082671345) with
```
ImportError: /home/runner/.local/lib/python3.10/site-packages/_XLAC.cpython-310-x86_64-linux-gnu.so: undefined symbol: _ZNK3c1010TensorImpl35is_non_overlapping_and_dense_customEv
```

This failure is because we are missing symbol `sym_is_non_overlapping_and_dense_custom`, introduced [a few days ago here](https://github.com/pytorch/pytorch/commit/2c76f31221e117b217b8a6a96a5405f626d2218a). So we're using an older, stable version of pytorch. I don't understand why this is the case, based on setup.py. But in the meantime I keep `USE_NIGHTLY` as True. This means we're still technically pulling a nightly version, but it's the nightly built from the most recent stable Jax version.