### PR TITLE
Update CI docker images to use 3.12

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -45,7 +45,7 @@ jobs:
     uses: ./.github/workflows/_build_torch_xla.yml
     needs: [check_code_changes, get-torch-commit]
     with:
-      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
+      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.12_tpuvm
       torch-commit: ${{needs.get-torch-commit.outputs.torch_commit}}
       timeout-minutes: 45  # Takes ~20m as of 2025/5/30.
       has_code_changes: ${{ needs.check_code_changes.outputs.has_code_changes }}
@@ -58,7 +58,7 @@ jobs:
     uses: ./.github/workflows/_test.yml
     needs: [build-torch-xla, check_code_changes, get-torch-commit]
     with:
-      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
+      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.12_tpuvm
       timeout-minutes: 45  # Takes ~26m as of 2025/5/30.
       collect-coverage: false
       runner: linux.24xlarge
@@ -92,6 +92,6 @@ jobs:
     needs: build-torch-xla
     if: github.event_name == 'push'
     with:
-      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.10_tpuvm
+      dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.12_tpuvm
     secrets:
       torchxla-bot-token: ${{ secrets.TORCH_XLA_BOT_TOKEN }}

--- a/infra/tpu-pytorch-releases/dev_images.auto.tfvars
+++ b/infra/tpu-pytorch-releases/dev_images.auto.tfvars
@@ -6,7 +6,7 @@ dev_images = [
   },
   {
     accelerator = "tpu"
-    extra_tags  = ["tpu"]
+    extra_tags  = ["tpu_312"]
     python_version = "3.12"
   },
   {

--- a/infra/tpu-pytorch-releases/dev_images.auto.tfvars
+++ b/infra/tpu-pytorch-releases/dev_images.auto.tfvars
@@ -1,12 +1,11 @@
 dev_images = [
   {
     accelerator = "tpu"
-    extra_tags  = ["tpu"]
     python_version = "3.10"
   },
   {
     accelerator = "tpu"
-    extra_tags  = ["tpu_312"]
+    extra_tags  = ["tpu"]
     python_version = "3.12"
   },
   {


### PR DESCRIPTION
This is expected to break the TPU CI temporarily as the TPU runners use the docker image with `tpu` tag which currently corresponds to 3.10 image. 

After this change is submitted, it will take around 10mins for `tpu` tag to point to 3.12 image which should fix the CI