### PR TITLE
Error Handling: replace `XLA_CHECK_OK()` with status functions.

### DIFF
--- a/torch_xla/csrc/BUILD
+++ b/torch_xla/csrc/BUILD
@@ -132,6 +132,7 @@ ptxla_cc_library(
         "//torch_xla/csrc/runtime:stablehlo_helper",
         "//torch_xla/csrc/runtime:xla_util",
         "@com_google_absl//absl/hash",
+        "@com_google_absl//absl/log:absl_check",
         "@com_google_absl//absl/log:absl_log",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",

--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -401,6 +401,7 @@ cc_library(
     hdrs = ["tensor_source.h"],
     deps = [
         ":debug_macros",
+        "//torch_xla/csrc:status",
         "@torch//:headers",
         "@xla//xla:literal",
         "@xla//xla:shape_util",

--- a/torch_xla/csrc/runtime/tensor_source.h
+++ b/torch_xla/csrc/runtime/tensor_source.h
@@ -4,10 +4,13 @@
 #include <ATen/Tensor.h>
 #include <torch/csrc/lazy/core/metrics.h>
 
+#include <string>
+#include <utility>
 #include <vector>
 
 #include "torch_xla/csrc/dtype.h"
 #include "torch_xla/csrc/runtime/debug_macros.h"
+#include "torch_xla/csrc/status.h"
 #include "xla/literal.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
@@ -18,7 +21,7 @@ namespace runtime {
 // Owns a contiguous block of data with the shape and layout matching `shape()`.
 class TensorSource {
  public:
-  TensorSource(std::string device) : device_(std::move(device)){};
+  TensorSource(std::string device) : device_(std::move(device)) {}
 
   virtual const void* data() const = 0;
 
@@ -28,7 +31,7 @@ class TensorSource {
 
   virtual std::vector<int64_t> byte_strides() const {
     std::vector<int64_t> byte_strides(shape().dimensions_size());
-    XLA_CHECK_OK(
+    MaybeThrow(
         xla::ShapeUtil::ByteStrides(shape(), absl::MakeSpan(byte_strides)));
     return byte_strides;
   }


### PR DESCRIPTION
This PR introduces the following changes:

1. Replaces the existing `XLA_CHECK_OK()` macro with `MaybeThrow()` and `GetValueOrThrow()` functions
2. Replaces `XLA_CHECK*()` with `ABSL_CHECK*()` macro calls.

These changes improve error handling by not crashing when non-ok status values are returned (1), and by crashing on internal errors (2).