### PR TITLE
Partially disable tpu-info CLI tests

### DIFF
--- a/test/tpu/tpu_info/test_cli.py
+++ b/test/tpu/tpu_info/test_cli.py
@@ -68,8 +68,10 @@ class TpuInfoCliTest(parameterized.TestCase):
         self.assertEqual(u.duty_cycle_pct, 0.0)
         one_gb = 1 << 30
         self.assertLess(u.memory_usage, one_gb)
-      # TODO: check output
-      cli.print_chip_info()
+      # # TODO: check output
+      # TODO(https://github.com/pytorch/xla/issues/9462): Uncomment after
+      # libtpu is fixed for python 3.12
+      # cli.print_chip_info()
 
   @contextlib.contextmanager
   def _torch_xla_spawn(self):
@@ -105,7 +107,9 @@ class TpuInfoCliTest(parameterized.TestCase):
         one_gb = 1 << 30
         self.assertLess(u.memory_usage, one_gb)
       # TODO: check output
-      cli.print_chip_info()
+      # TODO(https://github.com/pytorch/xla/issues/9462): Uncomment after
+      # libtpu is fixed for python 3.12
+      # cli.print_chip_info()
 
 
 if __name__ == "__main__":

--- a/test/tpu/tpu_info/test_cli.py
+++ b/test/tpu/tpu_info/test_cli.py
@@ -68,7 +68,6 @@ class TpuInfoCliTest(parameterized.TestCase):
         self.assertEqual(u.duty_cycle_pct, 0.0)
         one_gb = 1 << 30
         self.assertLess(u.memory_usage, one_gb)
-      # # TODO: check output
       # TODO(https://github.com/pytorch/xla/issues/9462): Uncomment after
       # libtpu is fixed for python 3.12
       # cli.print_chip_info()
@@ -106,7 +105,6 @@ class TpuInfoCliTest(parameterized.TestCase):
         self.assertEqual(u.duty_cycle_pct, 0.0)
         one_gb = 1 << 30
         self.assertLess(u.memory_usage, one_gb)
-      # TODO: check output
       # TODO(https://github.com/pytorch/xla/issues/9462): Uncomment after
       # libtpu is fixed for python 3.12
       # cli.print_chip_info()


### PR DESCRIPTION
`cli.print_chip_info()` causes a segfault in python 3.12. This is caused by libtpu import.

Commenting out this part of the test till libtpu is fixed. An issue has been created for the libtpu team.