### PR TITLE
Remove duplicate artifact creation for 2.8.0-rc1

### DIFF
--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -3,63 +3,6 @@ manual_nightly_builds = [
 ]
 
 manual_versioned_builds = [
-
-
-  {
-    git_tag         = "v2.8.0-rc1"
-    package_version = "2.8.0-rc1"
-    pytorch_git_rev = "v2.8.0-rc1"
-    accelerator     = "tpu"
-    python_version  = "3.11"
-    bundle_libtpu   = "0"
-    cxx11_abi       = "1"
-  },
-  {
-    git_tag         = "v2.8.0-rc1"
-    package_version = "2.8.0-rc1"
-    pytorch_git_rev = "v2.8.0-rc1"
-    accelerator     = "tpu"
-    python_version  = "3.12"
-    bundle_libtpu   = "0"
-    cxx11_abi       = "1"
-  },
-  {
-    git_tag         = "v2.8.0-rc1"
-    package_version = "2.8.0-rc1"
-    pytorch_git_rev = "v2.8.0-rc1"
-    accelerator     = "tpu"
-    python_version  = "3.13"
-    bundle_libtpu   = "0"
-    cxx11_abi       = "1"
-  },
-  {
-    git_tag         = "v2.8.0-rc1"
-    package_version = "2.8.0-rc1"
-    pytorch_git_rev = "v2.8.0-rc1"
-    accelerator     = "cuda"
-    cuda_version    = "12.6"
-    python_version  = "3.11"
-    cxx11_abi       = "1"
-  },
-  {
-    git_tag         = "v2.8.0-rc1"
-    package_version = "2.8.0-rc1"
-    pytorch_git_rev = "v2.8.0-rc1"
-    accelerator     = "cuda"
-    cuda_version    = "12.6"
-    python_version  = "3.12"
-    cxx11_abi       = "1"
-  },
-  {
-    git_tag         = "v2.8.0-rc1"
-    package_version = "2.8.0-rc1"
-    pytorch_git_rev = "v2.8.0-rc1"
-    accelerator     = "cuda"
-    cuda_version    = "12.6"
-    python_version  = "3.13"
-    cxx11_abi       = "1"
-  },
-
   {
     git_tag         = "v2.7.0"
     package_version = "2.7.0"


### PR DESCRIPTION
2 change I previously made are conflicting with each other: https://github.com/pytorch/xla/pull/9425 and https://github.com/pytorch/xla/pull/9461.

Both are creating wheels with the same name. https://github.com/pytorch/xla/pull/9425 are more to the old way we would generate test versions. Now with the method used in https://github.com/pytorch/xla/pull/9461, we want to only do the changes in https://github.com/pytorch/xla/pull/9425 when we are ready to publish the final release version.