### PR TITLE
Update TPU CI with latest docker container

### DIFF
--- a/infra/tpu-pytorch/tpu_ci.tf
+++ b/infra/tpu-pytorch/tpu_ci.tf
@@ -9,6 +9,5 @@ module "v4_arc_cluster" {
   max_tpu_nodes     = 32
   github_repo_url   = "https://github.com/pytorch/xla"
   # Dockerfile for this image can be found at test/tpu/Dockerfile
-  # TODO(https://github.com/pytorch/xla/issues/8946): Update latest tag
-  runner_image      = "gcr.io/tpu-pytorch/tpu-ci-runner:test"
+  runner_image      = "gcr.io/tpu-pytorch/tpu-ci-runner:latest"
 }

--- a/test/tpu/Dockerfile
+++ b/test/tpu/Dockerfile
@@ -3,12 +3,12 @@ FROM us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:tpu as b
 # Replace value with the latest runner release version
 # source: https://github.com/actions/runner/releases
 # ex: 2.303.0
-ARG RUNNER_VERSION="2.323.0"
+ARG RUNNER_VERSION="2.326.0"
 ARG RUNNER_ARCH="x64"
 # Replace value with the latest runner-container-hooks release version
 # source: https://github.com/actions/runner-container-hooks/releases
 # ex: 0.3.1
-ARG RUNNER_CONTAINER_HOOKS_VERSION="0.6.2"
+ARG RUNNER_CONTAINER_HOOKS_VERSION="0.7.0"
 
 ARG USER=runner
 


### PR DESCRIPTION
Updated TPU CI dockerfile with latest ARC runner versions from https://github.com/actions/runner/releases and https://github.com/actions/runner-container-hooks/releases

Built a new docker image with 
```
cd test/tpu
docker build -t tpu-runner .
```