### PR TITLE
Update Setuptools version in build dependencies.

### DIFF
--- a/infra/ansible/config/pip.yaml
+++ b/infra/ansible/config/pip.yaml
@@ -21,7 +21,7 @@ pip:
       - oauth2client
       - pyyaml
       - requests
-      - setuptools
+      - setuptools>=80.0.0
       - six
       - tensorboard
       - tensorboardX


### PR DESCRIPTION
3.11 nightly builds are failing because the setuptools package version is too old.

While installing the setuptools package here, we need to explicitly state a newer version. Otherwise, it just uses the default in python3.11 docker

<img width="1992" height="596" alt="image" src="https://github.com/user-attachments/assets/7997e148-f6fd-4aef-b7ae-e4c07dd935a9" />
