### PR TITLE
Error Handling: return status value when loading PjRt dynamic plugin.

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -227,6 +227,7 @@ function run_xla_op_tests2 {
   run_test "$_TEST_DIR/test_assume_pure_spmd.py"
   run_test "$_TEST_DIR/test_assume_pure_torch.py"
   run_test "$_TEST_DIR/test_dynamic_shapes_detector.py"
+  run_test "$_TEST_DIR/test_runtime_client_initialization_error.py"
 }
 
 function run_xla_op_tests3 {

--- a/test/test_runtime_client_initialization_error.py
+++ b/test/test_runtime_client_initialization_error.py
@@ -1,0 +1,35 @@
+import os
+import torch_xla
+import torch_xla.core.xla_env_vars as xenv
+import unittest
+
+
+class TestClientInitializationError(unittest.TestCase):
+
+  def test(self):
+
+    def initialize_client(device):
+      os.environ[xenv.PJRT_DEVICE] = device
+
+      # The message does not change!
+      # After the first call with DUMMY_DEVICE, all other calls will have
+      # "DUMMY_DEVICE" in their message.
+      message = (
+          f"No PjRtPlugin registered for: DUMMY_DEVICE. "
+          f"Make sure the environment variable {xenv.PJRT_DEVICE} is set "
+          "to a correct device name.")
+
+      with self.assertRaisesRegex(RuntimeError, expected_regex=message):
+        torch_xla._XLAC._init_computation_client()
+
+    # Run the initialization function the first time, ending up in an
+    # exception thrown.
+    initialize_client("DUMMY_DEVICE")
+
+    # Even if the device exists, this call should fail, since the result
+    # of the first call is cached.
+    initialize_client("CPU")
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
This PR **improves error handling** for `PjRtPlugin` and `ComputationClient` initialization. It provides **better error messages** and prevents repeated error reporting. A new test has been added for dynamic `PjRtPlugin` registration error.

### Key Changes

- `GetPjRtPlugin()` function returns a `FailedPreconditionError()` if no `PjRtPlugin` was registered to the current `PJRT_DEVICE` with a better error message
- `g_computation_client_initialized` variable is only set if the `ComputationClient` is successfully initialized
    - Avoids showing the same error on `_XLAC._prepare_to_exit()` function
- Unwrapping the `StatusOr<T>` value in `GetComputationClientOrDie()` function by using `GetValueOrThrow()` function, instead of `.value()`
    - Avoids the error message prefix: `Bad StatusOr access: INVALID_ARGUMENT`
    - Centralizes error message with stacktraces in PR #9492 
- Added test for checking the computation client initialization error due to unregistered dynamic `PjRtPlugin`