### PR TITLE
Fix extract_all_buffers

### DIFF
--- a/torchax/test/test_interop.py
+++ b/torchax/test/test_interop.py
@@ -48,10 +48,17 @@ class InteropTest(unittest.TestCase):
         self.m1 = Child()
 
     m = ModuleWithUnregisteredTensor()
-    params, buffers = interop.extract_all_buffers(m)
+    params, buffers = interop.extract_all_buffers(m, remove_duplicate=False)
     self.assertEqual(set(params.keys()), {'a.weight', 'a.bias', 'b', 'e', 'f'})
     self.assertEqual(set(buffers.keys()), {'c', 'c2'})
+    interop.set_all_buffers(m, {'a.weight': torch.tensor([0.0])},
+                            {'m1.x': torch.tensor([0.0])})
+    self.assertEqual(m.a.weight.item(), 0)
+    self.assertEqual(m.m1.x.item(), 0)
 
+    params, buffers = interop.extract_all_buffers(m, remove_duplicate=True)
+    self.assertEqual(set(params.keys()), {'a.weight', 'a.bias', 'b', 'f'})
+    self.assertEqual(set(buffers.keys()), {'c'})
     interop.set_all_buffers(m, {'a.weight': torch.tensor([0.0])},
                             {'m1.x': torch.tensor([0.0])})
     self.assertEqual(m.a.weight.item(), 0)

--- a/torchax/torchax/interop.py
+++ b/torchax/torchax/interop.py
@@ -17,13 +17,13 @@ import torchax
 from torchax.types import JaxValue, TorchValue, JaxCallable, TorchCallable
 
 
-def extract_all_buffers(m: torch.nn.Module):
+def extract_all_buffers(m: torch.nn.Module, remove_duplicate=True):
   params = {}
   buffers = {}
 
-  for name, param in m.named_parameters(recurse=True, remove_duplicate=False):
+  for name, param in m.named_parameters(recurse=True, remove_duplicate=remove_duplicate):
     params[name] = param
-  for name, buf in m.named_buffers(recurse=True, remove_duplicate=False):
+  for name, buf in m.named_buffers(recurse=True, remove_duplicate=remove_duplicate):
     buffers[name] = buf
 
   return params, buffers


### PR DESCRIPTION
Problem: I think the current `extract_all_buffers` doesn't extract the correct parameters and buffers. For example:

1. In my uLLM workload, I have a torch.nn.Module m. Before calling `extract_all_buffers(m: torch.nn.Module)`, my module `m` looks like:
```
[name for name, _ in m.named_parameters()]=['vllm_model.model.embed_tokens.weight', 'vllm_model.model.layers.0.self_attn.qkv_proj.base_layer.weight', 'vllm_model.model.layers.0.self_attn.qkv_proj.base_layer.bias', 'vllm_model.model.layers.0.self_attn.o_proj.base_layer.weight', 'vllm_model.model.layers.0.mlp.gate_up_proj.base_layer.weight', 'vllm_model.model.layers.0.mlp.down_proj.base_layer.weight', 'vllm_model.model.layers.0.input_layernorm.weight', 'vllm_model.model.layers.0.post_attention_layernorm.weight',...]

[name for name, _ in m.named_buffers()]=['vllm_model.model.layers.0.self_attn.rotary_emb.cos_sin_cache']
```
2. After calling `extract_all_buffers`, the return value params and buffers look like
```
[name for name in params.keys()]: ['vllm_model.model.layers.0.self_attn.qkv_proj.bias', 'vllm_model.model.layers.0.self_attn.qkv_proj.base_layer.bias', 'vllm_model.model.layers.0.input_layernorm.weight', 'vllm_model.model.layers.0.post_attention_layernorm.weight', ...]

[name for name in buffers.keys()]: ['vllm_model.model.embed_tokens.weight', 'vllm_model.model.layers.0.self_attn.qkv_proj.weight', 'vllm_model.model.layers.0.self_attn.qkv_proj.base_layer.weight', 'vllm_model.model.layers.0.self_attn.o_proj.weight', 'vllm_model.model.layers.0.self_attn.o_proj.base_layer.weight', 'vllm_model.model.layers.0.self_attn.rotary_emb.cos_sin_cache', 'vllm_model.model.layers.0.self_attn.attn._k_scale', 'vllm_model.model.layers.0.self_attn.attn._prob_scale', 'vllm_model.model.layers.0.self_attn.attn._q_scale', 'vllm_model.model.layers.0.self_attn.attn._v_scale', 'vllm_model.model.layers.0.self_attn.attn.k_range', 'vllm_model.model.layers.0.self_attn.attn.q_range', 'vllm_model.model.layers.0.self_attn.attn.v_range', 'vllm_model.model.layers.0.mlp.gate_up_proj.weight', 'vllm_model.model.layers.0.mlp.gate_up_proj.base_layer.weight', 'vllm_model.model.layers.0.mlp.down_proj.weight', 'vllm_model.model.layers.0.mlp.down_proj.base_layer.weight', ...]
```

3. This doesn't look right. Before the call, there are 7 params and 1 buffer corresponding to `vllm_model.model.layers.0`. However, after the call, there are  4 params and 16 buffers corresponding to `vllm_model.model.layers.0`. In particular, 'vllm_model.model.layers.0.self_attn.qkv_proj.weight' shouldn't appear in the return buffers; `vllm_model.model.layers.0.self_attn.qkv_proj.base_layer.weight` should have appear in the return params value but it hasn't.