### PR TITLE
Introduce PlatformVersion bindings

### DIFF
--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1706,6 +1706,10 @@ void InitXlaModuleBindings(py::module m) {
               return runtime::GetComputationClientOrDie()->GetLocalDevices();
             }
            })
+      .def("_xla_get_platform_version",
+           []() {
+              return runtime::GetComputationClientOrDie()->GetPlatformVersion();
+           })
       .def("_get_stream_for_cuda_device",
            [](const int device_id) {
             return runtime::GetComputationClientOrDie()->GetCudaStreamForDevice(

--- a/torch_xla/csrc/runtime/computation_client.h
+++ b/torch_xla/csrc/runtime/computation_client.h
@@ -379,6 +379,8 @@ class ComputationClient {
 
   virtual size_t GetNumDevices() const = 0;
 
+  virtual std::string GetPlatformVersion() const = 0;
+
   virtual std::vector<std::string> GetLocalDevices() const = 0;
 
   virtual std::vector<std::string> GetAllDevices() const = 0;

--- a/torch_xla/csrc/runtime/ifrt_computation_client.cpp
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.cpp
@@ -656,6 +656,10 @@ std::vector<std::string> IfrtComputationClient::GetAllDevices() const {
   return IfrtDevicesToString(client_->devices());
 }
 
+std::string IfrtComputationClient::GetPlatformVersion() const {
+  return client_->platform_version();
+}
+
 int IfrtComputationClient::GetNumProcesses() const {
   int max_process_index = client_->process_index();
   for (auto* device : client_->devices()) {

--- a/torch_xla/csrc/runtime/ifrt_computation_client.h
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.h
@@ -118,6 +118,8 @@ class IfrtComputationClient : public ComputationClient {
 
   std::vector<std::string> GetAllDevices() const override;
 
+  std::string GetPlatformVersion() const override;
+
   int GetProcessIndex() const override { return client_->process_index(); };
 
   int GetNumProcesses() const override;

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cpp
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cpp
@@ -959,6 +959,10 @@ std::vector<std::string> PjRtComputationClient::GetAllDevices() const {
   return PjRtDevicesToString(client_->devices());
 }
 
+std::string PjRtComputationClient::GetPlatformVersion() const {
+  return client_->platform_version();
+}
+
 int PjRtComputationClient::GetNumProcesses() const {
   int max_process_index = client_->process_index();
   for (auto* device : client_->devices()) {

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -133,6 +133,8 @@ class PjRtComputationClient : public ComputationClient {
 
   std::vector<std::string> GetAllDevices() const override;
 
+  std::string GetPlatformVersion() const override;
+
   torch::lazy::hash_t HashCompilationEnv() override;
 
   int GetProcessIndex() const override { return client_->process_index(); };


### PR DESCRIPTION
Expose the platform version from the C API PJRT Client as a binding, particularly platform version.

https://github.com/openxla/xla/blob/eda2aa3826c71df9c947e66eefdda2caa1fab71e/xla/pjrt/pjrt_client.h#L555