### PR TITLE
Make torch_xla package PEP 561 compliant

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -484,8 +484,10 @@ setup(
         *_get_jax_install_requirements(),
     ],
     package_data={
-        'torch_xla': ['lib/*.so*','py.typed',],
-    },
+        'torch_xla': [
+            'lib/*.so*',
+            'py.typed',
+        ],    },
     entry_points={
         'console_scripts': [
             'stablehlo-to-saved-model = torch_xla.tf_saved_model_integration:main'

--- a/setup.py
+++ b/setup.py
@@ -487,7 +487,8 @@ setup(
         'torch_xla': [
             'lib/*.so*',
             'py.typed',
-        ],    },
+        ],
+    },
     entry_points={
         'console_scripts': [
             'stablehlo-to-saved-model = torch_xla.tf_saved_model_integration:main'

--- a/setup.py
+++ b/setup.py
@@ -484,7 +484,7 @@ setup(
         *_get_jax_install_requirements(),
     ],
     package_data={
-        'torch_xla': ['lib/*.so*',],
+        'torch_xla': ['lib/*.so*','py.typed',],
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
The repo seems to be using type hints very thoroghly, this PR adds changes to make the package PEP 561 compliant:

https://peps.python.org/pep-0561/

This avoids errors like the following when using mypy:
```bash
infinity_emb/inference/loading_strategy.py:13: error: Cannot find implementation or library stub for module named "torch_xla"  [import-not-found]
```

Torch package does the [same](https://github.com/pytorch/pytorch/blob/8e07c9870d07c5a318ab21bb16b3fa27576851e6/setup.py#L1288)