### PR TITLE
Deduplicate `GetXlaTensors()` function.

### DIFF
--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -278,12 +278,13 @@ static std::vector<XLATensorPtr> CollectXlaTensors(
     const std::vector<at::Tensor>& tensors) {
   std::vector<XLATensorPtr> xtensors;
   for (auto& tensor : tensors) {
-    auto xla_tensor_state = bridge::GetXlaTensor(tensor);
-    if (xla_tensor_state.ok()) {
+    auto xla_tensor_status = bridge::GetXlaTensor(tensor);
+    if (xla_tensor_status.ok()) {
       // Insert only those that can be successfully retrieved.
-      xtensors.push_back(std::move(xla_tensor_state).value());
+      xtensors.push_back(std::move(xla_tensor_status).value());
     }
   }
+  return xtensors;
 }
 
 bool IsNonDeviceDataIR(const at::Tensor& tensor) {


### PR DESCRIPTION
This PR deduplicates `GetXlaTensors()`. 
Previously, there were 2 functions in the repository with the same name, similar functionality, different signature:

_init_python_bindings.cpp_

```c++
std::vector<XLATensorPtr> GetXlaTensors(const std::vector<at::Tensor>& tensors,
                                        bool want_all);
```

_aten_xla_bridge.h_

```c++
absl::StatusOr<std::vector<absl_nonnull XLATensorPtr>> GetXlaTensors(
    const at::ITensorListRef& tensors);
```

- if `want_all=true`, it behaved similarly to `GetXlaTensors()`
- otherwise, it collected all XLA tensors from the given list of tensors
- the function in _init_python_bindings.cpp_ lived under an anonymous namespace, not used anywhere else

-----

Therefore, this PR introduces the following key changes:

- Replaces all _init_python_bindings.cpp_ `GetXlaTensors(..., /* want_all= */ true)` call sites with `GetValueOrThrow(bridge::GetXlaTensors(...))`
- Rename _init_python_bindings.cpp_ `GetXlaTensors()` to `CollectXlaTensors()`, avoiding functions with different semantics to have the same name
- Re-define `CollectXlaTensors()` to have only the `want_all=false` behavior, removing `want_all` flag from the function parameters