### PR TITLE
Improve error message of functions related to `GetXlaTensor()`.

### DIFF
--- a/test/dynamo/test_dynamo_integrations_util.py
+++ b/test/dynamo/test_dynamo_integrations_util.py
@@ -84,6 +84,18 @@ class PybindTest(unittest.TestCase):
     xla_out_2 = xla_dummy_model(xla_input)
     assert (hash == torch_xla._XLAC._get_graph_hash([xla_out_2]))
 
+  def test_get_graph_hash_raises_error_on_non_xla_tensor(self):
+    tensors = [
+        torch.rand(10, device=torch_xla.device()),
+        torch.rand(10),
+        torch.rand(10, device=torch_xla.device()),
+    ]
+    error_message = (
+        "Expected all tensors in the given list to be XLA tensors. "
+        "Element at index 1 is not an XLA tensor. Got: torch.FloatTensor")
+    with self.assertRaisesRegex(RuntimeError, expected_regex=error_message):
+      torch_xla._XLAC._get_graph_hash(tensors)
+
   def test_clear_pending_irs(self):
     xla_device = torch_xla.device()
     torch_xla.sync()

--- a/test/dynamo/test_dynamo_integrations_util.py
+++ b/test/dynamo/test_dynamo_integrations_util.py
@@ -84,18 +84,6 @@ class PybindTest(unittest.TestCase):
     xla_out_2 = xla_dummy_model(xla_input)
     assert (hash == torch_xla._XLAC._get_graph_hash([xla_out_2]))
 
-  def test_get_graph_hash_raises_error_on_non_xla_tensor(self):
-    tensors = [
-        torch.rand(10, device=torch_xla.device()),
-        torch.rand(10),
-        torch.rand(10, device=torch_xla.device()),
-    ]
-    error_message = (
-        "Expected all tensors in the given list to be XLA tensors. "
-        "Element at index 1 is not an XLA tensor. Got: torch.FloatTensor")
-    with self.assertRaisesRegex(RuntimeError, expected_regex=error_message):
-      torch_xla._XLAC._get_graph_hash(tensors)
-
   def test_clear_pending_irs(self):
     xla_device = torch_xla.device()
     torch_xla.sync()

--- a/test/quantized_ops/test_dot_general.py
+++ b/test/quantized_ops/test_dot_general.py
@@ -56,6 +56,13 @@ class DotGeneralTest(unittest.TestCase):
         preferred_element_type=torch.int32)
     self.assertTrue(torch.allclose(xla_out.cpu(), expected_out))
 
+  def test_raises_error_on_non_xla_tensor(self):
+    lhs = torch.rand(10, 3, 4, dtype=torch.bfloat16)
+    rhs = torch.rand(10, 4, 5, dtype=torch.bfloat16, device="xla")
+    error_message = r"Expected input tensor `lhs` to be an actual XLA tensor. Got: CPUBFloat16Type"
+    with self.assertRaisesRegex(RuntimeError, expected_regex=error_message):
+      torch_xla._XLAC._xla_dot_general(lhs, rhs, (([2], [1]), ([0], [0])))
+
 
 if __name__ == '__main__':
   test = unittest.main()

--- a/torch_xla/csrc/BUILD
+++ b/torch_xla/csrc/BUILD
@@ -280,6 +280,7 @@ ptxla_cc_library(
         "//torch_xla/csrc/runtime:xla_coordinator",
         "//torch_xla/csrc/runtime:xla_util",
         "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/log:absl_check",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/types:variant",

--- a/torch_xla/csrc/aten_xla_bridge.h
+++ b/torch_xla/csrc/aten_xla_bridge.h
@@ -59,14 +59,14 @@ absl::StatusOr<absl_nonnull XLATensorPtr> GetXlaTensor(
 absl::StatusOr<std::vector<absl_nonnull XLATensorPtr>> GetXlaTensors(
     const at::ITensorListRef& tensors);
 
-// Retrieve the underlying `XLATensorPtr` from `tensor`.
+// Retrieves the underlying `XLATensorPtr` from `tensor`.
 //
 // If `tensor` is not an actual XLA tensor, this function will craft a
 // specialized error message for PyTorch operations or Python API
 // functions, i.e. functions where the parameter name makes sense for
 // the end user.
 absl::StatusOr<absl_nonnull XLATensorPtr> GetInputXlaTensor(
-    const at::Tensor& tensor, const std::string_view param);
+    const at::Tensor& tensor, std::string_view param);
 
 bool IsXlaTensor(const at::Tensor& tensor);
 

--- a/torch_xla/csrc/aten_xla_bridge.h
+++ b/torch_xla/csrc/aten_xla_bridge.h
@@ -59,6 +59,15 @@ absl::StatusOr<absl_nonnull XLATensorPtr> GetXlaTensor(
 absl::StatusOr<std::vector<absl_nonnull XLATensorPtr>> GetXlaTensors(
     const at::ITensorListRef& tensors);
 
+// Retrieve the underlying `XLATensorPtr` from `tensor`.
+//
+// If `tensor` is not an actual XLA tensor, this function will craft a
+// specialized error message for PyTorch operations or Python API
+// functions, i.e. functions where the parameter name makes sense for
+// the end user.
+absl::StatusOr<absl_nonnull XLATensorPtr> GetInputXlaTensor(
+    const at::Tensor& tensor, const std::string_view param);
+
 bool IsXlaTensor(const at::Tensor& tensor);
 
 // Replaces the XLA tensor embedded within `tensor`'s XLA TensorImpl with

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -88,6 +88,8 @@ namespace {
 
 constexpr int64_t kSeedInfoId = -127389;
 
+// Traits related to the return type of the lambda function that wraps the
+// actual implementation inside PythonScope.
 template <class T>
 struct LambdaReturnTypeTrait {
   using Type = T;

--- a/torch_xla/csrc/status.cpp
+++ b/torch_xla/csrc/status.cpp
@@ -119,9 +119,13 @@ static std::string MaybeGetMessageWithLineBreak(const absl::Status& status) {
              : std::string(status.message());
 }
 
+std::string BuildStatusErrorMessage(const absl::Status& status) {
+  return absl::StrCat(MaybeGetMessageWithLineBreak(status),
+                      GetFormattedStatusPropagationTrace(status));
+}
+
 void MaybeThrow(const absl::Status& status) {
-  TORCH_CHECK(status.ok(), MaybeGetMessageWithLineBreak(status),
-              GetFormattedStatusPropagationTrace(status));
+  TORCH_CHECK(status.ok(), BuildStatusErrorMessage(status));
 }
 
 void GetValueOrThrow(const absl::Status& status) { MaybeThrow(status); }

--- a/torch_xla/csrc/status.cpp
+++ b/torch_xla/csrc/status.cpp
@@ -124,4 +124,8 @@ void MaybeThrow(const absl::Status& status) {
               GetFormattedStatusPropagationTrace(status));
 }
 
+void GetValueOrThrow(const absl::Status& status) {
+  MaybeThrow(status);
+}
+
 }  // namespace torch_xla

--- a/torch_xla/csrc/status.cpp
+++ b/torch_xla/csrc/status.cpp
@@ -124,8 +124,6 @@ void MaybeThrow(const absl::Status& status) {
               GetFormattedStatusPropagationTrace(status));
 }
 
-void GetValueOrThrow(const absl::Status& status) {
-  MaybeThrow(status);
-}
+void GetValueOrThrow(const absl::Status& status) { MaybeThrow(status); }
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/status.h
+++ b/torch_xla/csrc/status.h
@@ -200,6 +200,9 @@ T GetValueOrThrow(absl::StatusOr<T>&& status) {
   return std::move(status).value();
 }
 
+// `GetValueOrThrow` overload for `Status`.
+void GetValueOrThrow(const absl::Status& status);
+
 }  // namespace torch_xla
 
 #endif  // XLA_TORCH_XLA_CSRC_STATUS_H_

--- a/torch_xla/csrc/status.h
+++ b/torch_xla/csrc/status.h
@@ -174,6 +174,17 @@ absl::Status MaybeWithNewMessage(const absl::Status& status, const char* file,
 
 }  // namespace status_internal
 
+// Builds the complete error message for the given `status`.
+//
+// If `TORCH_SHOW_CPP_STACKTRACES` is enabled, returns the concatenation of
+// `status.message()` with its inner status propagation trace.
+//
+// TODO(ysiraichi): this call does not append the C++ stacktrace, which,
+// ideally, should. It can be done by not using `TORCH_CHECK()` macro directly
+// in `MaybeThrow()`, but using PyTorch `c10::get_lazy_backtrace()`
+// (at c10/util/Backtrace.h).
+std::string BuildStatusErrorMessage(const absl::Status& status);
+
 // Maybe throws an exception if `status` has a non-ok code.
 //
 // Ideally, this function should be used only used in the project's


### PR DESCRIPTION
This PR refactors functions related to `GetXlaTensor()`, improving error message, and propagating status. These changes should make errors more actionable from users perspective. Additionally, this PR also allows Python API bound functions to returns status values. 

**Key Changes:**

- Add `GetValueOrThrow(Status)` overload, so that we can call `GetValueOrThrow` for both `Status` ans `StatusOr<T>` return values
- Properly handle status return types when binding Python functions, i.e. allow calls like`scope.def(..., [](...) -> absl::Status { ... })`
    - Calls `GetValueOrThrow()` in the resulting status, returning void
    - Lambda source information correctly appear in the status propagation trace
- Modify error messages of:
    - `GetXlaTensorImpl()`: assumes less context, with a more detailed error message
    - `GetXlaTensor()`: more meaningful, and higher level message
    - `GetXlaTensors()`: more information, such as the index of the non-XLA tensor
    - `ReplaceXlaTensor()`: reworded
- Create `GetInputXlaTensor()` for returning errors with more context
    - This should be used instead of calling `GetXlaTensor()`, specifically for inputs that directly come from the user
- Refactor 2 Python API implementation, as example:
    - `_xla_dot_general`: calling `GetInputXlaTensor()` on its tensor inputs
    - `_get_graph_hash`: calling `GetXlaTensors()` instead of an explicit loop with the same semantic

**Update (Aug 4):**

- Created `BuildStatusErrorMessage(const absl::Status&)`, in order to get the error message, and status propagation trace when crashing on a `ABSL_CHECK()` call.
    - Leaving the C++ stacktrace for future work
- Removed test for `_get_graph_hash`, since it crashes, now
- Added better error messages for `ReplaceTensor` functions
