### PR TITLE
Support torch.nn.functional.one_hot

### DIFF
--- a/torchax/torchax/ops/jtorch.py
+++ b/torchax/torchax/ops/jtorch.py
@@ -179,6 +179,11 @@ def _tpu_flash_attention(query, key, value, env):
   return wrap_flash_attention(query, key, value)
 
 
+@register_function(torch.nn.functional.one_hot)
+def one_hot(tensor, num_classes=-1):
+  return jax.nn.one_hot(tensor, num_classes)
+
+
 @register_function(torch.nn.functional.pad)
 def pad(tensor, pad, mode="constant", value=None):
   # For padding modes that have different names between Torch and NumPy, this

--- a/torchax/torchax/ops/jtorch.py
+++ b/torchax/torchax/ops/jtorch.py
@@ -181,7 +181,9 @@ def _tpu_flash_attention(query, key, value, env):
 
 @register_function(torch.nn.functional.one_hot)
 def one_hot(tensor, num_classes=-1):
-  return jax.nn.one_hot(tensor, num_classes)
+  if num_classes == -1:
+    num_classes = jnp.max(tensor) + 1
+  return jax.nn.one_hot(tensor, num_classes).astype(jnp.int64)
 
 
 @register_function(torch.nn.functional.pad)


### PR DESCRIPTION
Without this change, running the below commands
```
import torch
import torchax
torchax.enable_globally()

T=1024  # Total number of tokens
D=2048  # hidden_size
L=128  # lora_rank
N=16  # num_loras

loras=torch.randn((N, L, D), dtype=torch.float32, device='jax')
idxs=torch.randint(0, N, (T,), dtype=torch.long, device='jax')
torch.nn.functional.one_hot(idxs, loras.shape[0])
```
would fail with
```
>>> torch.nn.functional.one_hot(idxs, loras.shape[0])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/disks/persist/github/xla/torchax/torchax/tensor.py", line 247, in __torch_function__
    return func(*args, **(kwargs or {}))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: one_hot is only applicable to index tensor of type LongTensor.
```

With the fix, the torch.nn.functional.one_hot succeeds:
```
>>> torch.nn.functional.one_hot(idxs, loras.shape[0])
Tensor(<class 'jaxlib._jax.ArrayImpl'> [[0. 0. 0. ... 0. 0. 0.]
 [0. 0. 0. ... 0. 1. 0.]
 [0. 0. 0. ... 0. 0. 0.]
 ...
 [0. 0. 0. ... 0. 0. 0.]
 [0. 0. 0. ... 0. 0. 0.]
 [0. 0. 0. ... 0. 0. 1.]])
```

Test plan: `pytest -n 0 -s -vv test/test_ops.py -k test_reference_eager_nn_functional_one_hot_cpu_int64`