### PR TITLE
Update torchbench pin location.

### DIFF
--- a/test/benchmarks/run_torchbench_tests.sh
+++ b/test/benchmarks/run_torchbench_tests.sh
@@ -54,7 +54,7 @@ function install_package() {
 function install_torchbench_models() {
   pushd $CDIR
 
-  torchbench_commit_hash=$(cat $PYTORCH_DIR/.github/ci_commit_pins/torchbench.txt)
+  torchbench_commit_hash=$(cat $PYTORCH_DIR/.ci/docker/ci_commit_pins/torchbench.txt)
   git clone --quiet https://github.com/pytorch/benchmark.git "$TORCHBENCH_DIR"
   cd $TORCHBENCH_DIR
   git checkout $torchbench_commit_hash


### PR DESCRIPTION
This PR addresses the recent change on PyTorch upstream https://github.com/pytorch/pytorch/pull/159300 that moved the torchbench pin to another location within the project.

From: `.github/ci_commit_pin/torchbench.txt`
To: `.ci/docker/ci_commit_pin/torchbench.txt`

This change should fix the CI failures of `benchmark_tests`.