### PR TITLE
Error Handling: make `XLATensor::Create()` return status type.

### DIFF
--- a/test/cpp/test_tensor.cpp
+++ b/test/cpp/test_tensor.cpp
@@ -101,8 +101,8 @@ TEST_F(TensorTest, TestAdd) {
   at::Tensor c = a.add(b, 1.0);
 
   ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-    XLATensorPtr dev_a = XLATensor::Create(a, device);
-    XLATensorPtr dev_b = XLATensor::Create(b, device);
+    XLATensorPtr dev_a = GetValueOrThrow(XLATensor::Create(a, device));
+    XLATensorPtr dev_b = GetValueOrThrow(XLATensor::Create(b, device));
     XLATensorPtr dev_c = tensor_methods::add(dev_a, dev_b, 1.0);
 
     AllClose(c, dev_c);
@@ -121,8 +121,8 @@ TEST_F(TensorTest, TestIntegerAdd) {
           at::isIntegralType(type) ? at::Scalar(int64_t(1)) : at::Scalar(1.0);
       at::Tensor c = a.add(b, one);
 
-      XLATensorPtr dev_a = XLATensor::Create(a, device);
-      XLATensorPtr dev_b = XLATensor::Create(b, device);
+      XLATensorPtr dev_a = GetValueOrThrow(XLATensor::Create(a, device));
+      XLATensorPtr dev_b = GetValueOrThrow(XLATensor::Create(b, device));
       XLATensorPtr dev_c = tensor_methods::add(dev_a, dev_b, one);
 
       EXPECT_TRUE(EqualValuesNoElementTypeCheck(
@@ -135,7 +135,7 @@ TEST_F(TensorTest, TestSize) {
   at::Tensor input = at::rand({2, 1, 4, 6}, at::TensorOptions(at::kFloat));
   int rank = input.dim();
   ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-    XLATensorPtr dev_input = XLATensor::Create(input, device);
+    XLATensorPtr dev_input = GetValueOrThrow(XLATensor::Create(input, device));
     for (int dim = -rank; dim < rank; ++dim) {
       EXPECT_EQ(input.size(dim), dev_input->size(dim));
     }
@@ -151,8 +151,10 @@ TEST_F(TensorTest, TestRrelu) {
       at::Tensor noise = at::zeros_like(input);
       at::Tensor output =
           at::rrelu_with_noise(input, noise, lower, upper, training);
-      XLATensorPtr dev_input = XLATensor::Create(input, device);
-      XLATensorPtr dev_noise = XLATensor::Create(noise, device);
+      XLATensorPtr dev_input =
+          GetValueOrThrow(XLATensor::Create(input, device));
+      XLATensorPtr dev_noise =
+          GetValueOrThrow(XLATensor::Create(noise, device));
       XLATensorPtr dev_outputs = tensor_methods::rrelu_with_noise(
           dev_input, dev_noise, lower, upper, training);
       AllClose(output, dev_outputs);
@@ -167,7 +169,7 @@ TEST_F(TensorTest, TestThreshold) {
   float value = 20;
   at::Tensor output = at::threshold(input, threshold, value);
   ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-    XLATensorPtr dev_input = XLATensor::Create(input, device);
+    XLATensorPtr dev_input = GetValueOrThrow(XLATensor::Create(input, device));
     XLATensorPtr dev_output =
         tensor_methods::threshold(dev_input, threshold, value);
     AllClose(output, dev_output);
@@ -185,9 +187,10 @@ TEST_F(TensorTest, TestAddMatMul) {
   at::Tensor bias = at::rand({labels}, at::TensorOptions(at::kFloat));
   at::Tensor output = at::addmm(bias, input, weight);
   ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-    XLATensorPtr dev_input = XLATensor::Create(input, device);
-    XLATensorPtr dev_weight = XLATensor::Create(weight, device);
-    XLATensorPtr dev_bias = XLATensor::Create(bias, device);
+    XLATensorPtr dev_input = GetValueOrThrow(XLATensor::Create(input, device));
+    XLATensorPtr dev_weight =
+        GetValueOrThrow(XLATensor::Create(weight, device));
+    XLATensorPtr dev_bias = GetValueOrThrow(XLATensor::Create(bias, device));
     XLATensorPtr dev_output =
         tensor_methods::addmm(dev_input, dev_weight, dev_bias);
     AllClose(output, dev_output);
@@ -198,7 +201,7 @@ TEST_F(TensorTest, TestTranspose) {
   at::Tensor input = at::rand({2, 3}, at::TensorOptions(at::kFloat));
   at::Tensor output = at::transpose(input, 0, 1);
   ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-    XLATensorPtr dev_input = XLATensor::Create(input, device);
+    XLATensorPtr dev_input = GetValueOrThrow(XLATensor::Create(input, device));
     XLATensorPtr dev_output = tensor_methods::transpose(dev_input, 0, 1);
     AllClose(output, dev_output);
   });
@@ -208,7 +211,7 @@ TEST_F(TensorTest, TestView) {
   at::Tensor input = at::rand({32, 20, 4, 4}, at::TensorOptions(at::kFloat));
   at::Tensor output = input.view({-1, 320});
   ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-    XLATensorPtr dev_input = XLATensor::Create(input, device);
+    XLATensorPtr dev_input = GetValueOrThrow(XLATensor::Create(input, device));
     XLATensorPtr dev_output = tensor_methods::view(dev_input, {-1, 320});
     AllClose(output, dev_output);
   });
@@ -289,7 +292,8 @@ TEST_F(TensorTest, TestMaxPool2D) {
                          /*padding=*/{padding, padding}, /*dilation=*/{1, 1},
                          /*ceil_mode=*/false);
       ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-        XLATensorPtr dev_input = XLATensor::Create(input, device);
+        XLATensorPtr dev_input =
+            GetValueOrThrow(XLATensor::Create(input, device));
         auto dev_output = tensor_methods::max_pool_nd(
             dev_input,
             /*spatial_dim_count=*/2,
@@ -313,7 +317,8 @@ TEST_F(TensorTest, TestMaxPool2DNonSquare) {
           /*padding=*/{padding, padding + 1}, /*dilation=*/{1, 1},
           /*ceil_mode=*/false);
       ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-        XLATensorPtr dev_input = XLATensor::Create(input, device);
+        XLATensorPtr dev_input =
+            GetValueOrThrow(XLATensor::Create(input, device));
         auto dev_output = tensor_methods::max_pool_nd(
             dev_input,
             /*spatial_dim_count=*/2,
@@ -341,7 +346,8 @@ TEST_F(TensorTest, TestAvgPool2D) {
                            /*ceil_mode=*/false, count_include_pad,
                            /*divisor_override=*/std::nullopt);
         ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-          XLATensorPtr dev_input = XLATensor::Create(input, device);
+          XLATensorPtr dev_input =
+              GetValueOrThrow(XLATensor::Create(input, device));
           XLATensorPtr dev_output = tensor_methods::avg_pool_nd(
               dev_input,
               /*spatial_dim_count=*/2,
@@ -371,7 +377,8 @@ TEST_F(TensorTest, TestAvgPool2DNonSquare) {
             /*count_include_pad=*/count_include_pad,
             /*divisor_override=*/std::nullopt);
         ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-          XLATensorPtr dev_input = XLATensor::Create(input, device);
+          XLATensorPtr dev_input =
+              GetValueOrThrow(XLATensor::Create(input, device));
           XLATensorPtr dev_output = tensor_methods::avg_pool_nd(
               dev_input,
               /*spatial_dim_count=*/2,
@@ -409,15 +416,20 @@ TEST_F(TensorTest, TestBatchNorm1D) {
           /*running_mean=*/running_mean, /*running_var=*/running_var,
           /*training=*/training, /*momentum=*/momentum, /*eps=*/eps);
       ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-        XLATensorPtr xla_input = XLATensor::Create(input, device);
-        XLATensorPtr xla_weight = undef_weight_bias
-                                      ? XLATensorPtr()
-                                      : XLATensor::Create(weight, device);
-        XLATensorPtr xla_bias = undef_weight_bias
-                                    ? XLATensorPtr()
-                                    : XLATensor::Create(bias, device);
-        XLATensorPtr xla_running_mean = XLATensor::Create(running_mean, device);
-        XLATensorPtr xla_running_var = XLATensor::Create(running_var, device);
+        XLATensorPtr xla_input =
+            GetValueOrThrow(XLATensor::Create(input, device));
+        XLATensorPtr xla_weight =
+            undef_weight_bias
+                ? XLATensorPtr()
+                : GetValueOrThrow(XLATensor::Create(weight, device));
+        XLATensorPtr xla_bias =
+            undef_weight_bias
+                ? XLATensorPtr()
+                : GetValueOrThrow(XLATensor::Create(bias, device));
+        XLATensorPtr xla_running_mean =
+            GetValueOrThrow(XLATensor::Create(running_mean, device));
+        XLATensorPtr xla_running_var =
+            GetValueOrThrow(XLATensor::Create(running_var, device));
         auto xla_output = tensor_methods::native_batch_norm(
             /*input=*/xla_input, /*weight=*/xla_weight, /*bias=*/xla_bias,
             /*running_mean=*/xla_running_mean, /*running_var=*/xla_running_var,
@@ -474,11 +486,14 @@ TEST_F(TensorTest, TestConv2D) {
                     /*output_padding=*/{output_padding, output_padding},
                     /*groups=*/groups, false, false, false);
                 ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-                  XLATensorPtr dev_input = XLATensor::Create(input, device);
-                  XLATensorPtr dev_weight = XLATensor::Create(weight, device);
+                  XLATensorPtr dev_input =
+                      GetValueOrThrow(XLATensor::Create(input, device));
+                  XLATensorPtr dev_weight =
+                      GetValueOrThrow(XLATensor::Create(weight, device));
                   XLATensorPtr dev_output;
                   if (with_bias) {
-                    XLATensorPtr dev_bias = XLATensor::Create(bias, device);
+                    XLATensorPtr dev_bias =
+                        GetValueOrThrow(XLATensor::Create(bias, device));
                     dev_output = tensor_methods::convolution_overrideable(
                         dev_input, dev_weight, dev_bias,
                         /*stride=*/{stride, stride},
@@ -543,11 +558,14 @@ TEST_F(TensorTest, TestConv2DNonSquare) {
                     /*groups=*/groups, false, false, false);
 
                 ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-                  XLATensorPtr dev_input = XLATensor::Create(input, device);
-                  XLATensorPtr dev_weight = XLATensor::Create(weight, device);
+                  XLATensorPtr dev_input =
+                      GetValueOrThrow(XLATensor::Create(input, device));
+                  XLATensorPtr dev_weight =
+                      GetValueOrThrow(XLATensor::Create(weight, device));
                   XLATensorPtr dev_output;
                   if (with_bias) {
-                    XLATensorPtr dev_bias = XLATensor::Create(bias, device);
+                    XLATensorPtr dev_bias =
+                        GetValueOrThrow(XLATensor::Create(bias, device));
                     dev_output = tensor_methods::convolution_overrideable(
                         dev_input, dev_weight, dev_bias,
                         /*stride=*/{stride, stride + 1},
@@ -616,11 +634,14 @@ TEST_F(TensorTest, TestConv3D) {
                     {output_padding, output_padding, output_padding},
                     /*groups=*/groups, false, false, false);
                 ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-                  XLATensorPtr dev_input = XLATensor::Create(input, device);
-                  XLATensorPtr dev_weight = XLATensor::Create(weight, device);
+                  XLATensorPtr dev_input =
+                      GetValueOrThrow(XLATensor::Create(input, device));
+                  XLATensorPtr dev_weight =
+                      GetValueOrThrow(XLATensor::Create(weight, device));
                   XLATensorPtr dev_output;
                   if (with_bias) {
-                    XLATensorPtr dev_bias = XLATensor::Create(bias, device);
+                    XLATensorPtr dev_bias =
+                        GetValueOrThrow(XLATensor::Create(bias, device));
                     dev_output = tensor_methods::convolution_overrideable(
                         dev_input, dev_weight, dev_bias,
                         /*stride=*/{stride, stride, stride},
@@ -688,10 +709,14 @@ TEST_F(TensorTest, TestConv3D) {
 //                     {output_padding, output_padding + 1, output_padding},
 //                     /*groups=*/groups, false, false, false);
 //                 ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-//                   XLATensorPtr dev_input = XLATensor::Create(input, device);
-//                   XLATensorPtr dev_weight = XLATensor::Create(weight,
-//                   device); XLATensorPtr dev_output; if (with_bias) {
-//                     XLATensorPtr dev_bias = XLATensor::Create(bias, device);
+//                   XLATensorPtr dev_input =
+//                   GetValueOrThrow(XLATensor::Create(input, device));
+//                   XLATensorPtr dev_weight =
+//                   GetValueOrThrow(XLATensor::Create(weight, device);
+//                   XLATensorPtr dev_output;
+//                   if (with_bias) {
+//                     XLATensorPtr dev_bias =
+//                     GetValueOrThrow(XLATensor::Create(bias, device));
 //                     dev_output = tensor_methods::convolution_overrideable(
 //                         dev_input, dev_weight, dev_bias,
 //                         /*stride=*/{stride, stride + 1, stride + 1},

--- a/torch_xla/csrc/aten_xla_bridge.cpp
+++ b/torch_xla/csrc/aten_xla_bridge.cpp
@@ -160,8 +160,9 @@ XLATensorPtr GetOrCreateXlaTensor(const at::Tensor& tensor,
   }
 
   auto xtensor = GetXlaTensor(tensor);
-  return xtensor.ok() ? xtensor.value()
-                      : XLATensor::Create(inner_tensor, device);
+  return xtensor.ok()
+             ? xtensor.value()
+             : GetValueOrThrow(XLATensor::Create(inner_tensor, device));
 }
 
 XLATensorPtr GetOrCreateXlaTensor(const std::optional<at::Tensor>& tensor,
@@ -452,7 +453,8 @@ at::Tensor CreateXlaTensor(
     at::Tensor tensor,
     const std::optional<torch::lazy::BackendDevice>& device) {
   if (tensor.defined() && device) {
-    XLATensorPtr xla_tensor = XLATensor::Create(std::move(tensor), *device);
+    XLATensorPtr xla_tensor =
+        GetValueOrThrow(XLATensor::Create(std::move(tensor), *device));
     tensor = AtenFromXlaTensor(xla_tensor);
   }
   return tensor;

--- a/torch_xla/csrc/tensor.cpp
+++ b/torch_xla/csrc/tensor.cpp
@@ -61,9 +61,15 @@ bool CanApplySharding(const XLATensor::ShardingSpecPtr sharding) {
 
 XLATensor::Data::~Data() { XLAGraphExecutor::Get()->UnregisterTensor(this); }
 
-XLATensorPtr XLATensor::Create(const at::Tensor& tensor,
-                               const torch::lazy::BackendDevice& device) {
-  XLA_CHECK_EQ(tensor.device().type(), at::kCPU);
+absl::StatusOr<absl_nonnull XLATensorPtr> XLATensor::Create(
+    const at::Tensor& tensor, const torch::lazy::BackendDevice& device) {
+  if (!tensor.is_cpu()) {
+    return XLA_ERROR_WITH_LOCATION(absl::InvalidArgumentError(absl::StrCat(
+        "Could not create an XLATensor out of the provided tensor. Expected "
+        "tensor data to be on CPU. Got: ",
+        c10::DeviceTypeName(tensor.device().type()),
+        ". Consider moving the tensor to CPU.")));
+  }
   XLATensorPtr xtensor =
       c10::make_intrusive<XLATensor>(XLATensor(tensor, device));
   XLAGraphExecutor::Get()->RegisterTensor(xtensor->data());
@@ -621,7 +627,7 @@ std::vector<XLATensorPtr> XLATensor::MakeOutputTensors(
 XLATensorPtr XLATensor::CopyTensorToDevice(
     const torch::lazy::BackendDevice& device) {
   // TODO: This can be optimized via proper XRT/XLA computation.
-  return Create(ToTensor(/*detached=*/true), device);
+  return GetValueOrThrow(Create(ToTensor(/*detached=*/true), device));
 }
 
 torch::lazy::Value XLATensor::MaybeCastIrValue(

--- a/torch_xla/csrc/tensor.h
+++ b/torch_xla/csrc/tensor.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 
+#include "absl/base/nullability.h"
 #include "torch_xla/csrc/runtime/util.h"
 #include "torch_xla/csrc/view.h"
 
@@ -149,8 +150,8 @@ class XLATensor : public torch::lazy::LazyTensor {
     bool is_cloned = false;
   };
 
-  static XLATensorPtr Create(const at::Tensor& tensor,
-                             const torch::lazy::BackendDevice& device);
+  static absl::StatusOr<absl_nonnull XLATensorPtr> Create(
+      const at::Tensor& tensor, const torch::lazy::BackendDevice& device);
   static XLATensorPtr Create(
       torch::lazy::BackendDataPtr handle,
       std::optional<at::ScalarType> logical_element_type = std::nullopt);

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -1336,8 +1336,9 @@ std::tuple<XLATensorPtr, XLATensorPtr> cummax(const XLATensorPtr& input,
     at::Tensor val =
         at::empty(shape_, at::TensorOptions().dtype(input->dtype()));
     at::Tensor idx = at::empty(shape_, at::TensorOptions().dtype(at::kLong));
-    return std::make_tuple(input->Create(val, input->GetDevice()),
-                           input->Create(idx, input->GetDevice()));
+    return std::make_tuple(
+        GetValueOrThrow(XLATensor::Create(val, input->GetDevice())),
+        GetValueOrThrow(XLATensor::Create(idx, input->GetDevice())));
   }
   torch::lazy::NodePtr node =
       torch_xla::MakeNode<CumMax>(input->GetIrValue(), canonical_dim);


### PR DESCRIPTION
This PR updates the signature of `XLATensor::Create()` to return a **status type**, enabling better error handling. Specifically, it introduces a new error case: attempting to create an `XLATensor` with a **non-CPU tensor** will now return an `InvalidArgumentError`.

**Key Changes:**

- Change the signature of `XLATensor::Create()` (when tensor data is given), returning a status type for error handling
    - There are other overloads that were left as is, since they don't (directly) fail at this moment
- Return an `InvalidArgumentError` when trying to create an `XLATensor` with a non-CPU tensor
- Update the calls to `XLATensor::Create()`, wrapping them with `GetValueOrThrow()`

**Example:**

```python
a = torch.rand(5, device="xla")
b = torch.rand(5, device="cuda")
torch.add(a, b)
```

**Before:**

```python
Traceback (most recent call last):
  File "test.py", line 9, in test
    torch.add(a, b)
RuntimeError: Check failed: tensor.device().type() == at::kCPU (cuda vs. cpu) (at torch_xla/csrc/tensor.cpp:66)
*** Begin stack trace ***
        tsl::CurrentStackTrace[abi:cxx11]()
        torch_xla::runtime::internal::ErrorGenerator::operator&(std::ostream const&) const
        torch_xla::XLATensor::Create(at::Tensor const&, torch::lazy::BackendDevice const&)
        torch_xla::bridge::GetOrCreateXlaTensor(at::Tensor const&, torch::lazy::BackendDevice const&)

        torch_xla::XLANativeFunctions::add(at::Tensor const&, at::Tensor const&, c10::Scalar const&)

        c10::BoxedKernel::callBoxed(c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*) const
        c10::KernelFunction::callBoxed(c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*) const
        c10::Dispatcher::callBoxed(c10::OperatorHandle const&, std::vector<c10::IValue, std::allocator<c10::IValue> >*) const



        c10::BoxedKernel::callBoxed(c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*) const


        at::_ops::add_Tensor::redispatch(c10::DispatchKeySet, at::Tensor const&, at::Tensor const&, c10::Scalar const&)





        at::_ops::add_Tensor::call(at::Tensor const&, at::Tensor const&, c10::Scalar const&)
        at::Tensor::add(at::Tensor const&, c10::Scalar const&) const



        _PyObject_MakeTpCall
        _PyEval_EvalFrameDefault
        PyEval_EvalCode



        _PyRun_SimpleFileObject
        _PyRun_AnyFileObject
        Py_RunMain
        Py_BytesMain
        __libc_start_main
        _start
*** End stack trace ***
```

**After:**

```python
Traceback (most recent call last):
  File "test.py", line 9, in test
    torch.add(a, b)
RuntimeError: Could not create an XLATensor out of the provided tensor. Expected tensor data to be on CPU. Got: CUDA. Consider moving the tensor to CPU.

Status Propagation Trace:
    From: Create at torch_xla/csrc/tensor.cpp:67 (error: Could not create an XLATensor out of the provided tensor. Expected tensor data to be on CPU. Got: CUDA. Consider moving the tensor to CPU.)

Exception raised from MaybeThrow at torch_xla/csrc/status.cpp:123 (most recent call first):
C++ CapturedTraceback:
#4 std::enable_if<is_invocable_r_v<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, THPModule_initExtension(_object*, _object*)::{lambda()#1}&>, std::enable_if>::type std::__invoke_r<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, THPModule_initExtension(_object*, _object*)::{lambda()#1}&>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocato
r<char> >&&, (THPModule_initExtension(_object*, _object*)::{lambda()#1}&)...) from /usr/include/c++/10/bits/invoke.h:115
#5 std::_Function_handler<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > (), THPModule_initExtension(_object*, _object*)::{lambda()#1}>::_M_invoke(std::_Any_data const&) from /usr/include/c++/10/bits/std_function.h:292
#6 std::function<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > ()>::operator()() const from /usr/include/c++/10/bits/std_function.h:622
#7 c10::SetStackTraceFetcher(std::function<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > ()>)::{lambda()#1}::operator()() const from /home/ysiraichi/pytorch/build/../c10/util/Logging.cpp:42
#8 std::shared_ptr<c10::PrecomputedLazyValue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > std::__invoke_impl<std::shared_ptr<c10::PrecomputedLazyValue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, c10::SetStackTraceFetcher(std::function<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > ()>)::{lambda()#1}&>(std::__inv
oke_other, c10::SetStackTraceFetcher(std::function<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > ()>)::{lambda()#1}&) from /usr/include/c++/10/bits/invoke.h:60
#9 std::enable_if<is_invocable_r_v<std::shared_ptr<c10::LazyValue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > const>, c10::SetStackTraceFetcher(std::function<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > ()>)::{lambda()#1}&>, std::enable_if>::type std::__invoke_r<std::shared_ptr<c10::LazyValue<std::__cxx11::basic_string<char, std::char_traits<char>, st
d::allocator<char> > > const>, c10::SetStackTraceFetcher(std::function<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > ()>)::{lambda()#1}&>(std::shared_ptr<c10::LazyValue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > const>&&, (c10::SetStackTraceFetcher(std::function<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > ()>)::{lam
bda()#1}&)...) from /usr/include/c++/10/bits/invoke.h:113
#10 std::_Function_handler<std::shared_ptr<c10::LazyValue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > const> (), c10::SetStackTraceFetcher(std::function<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > ()>)::{lambda()#1}>::_M_invoke(std::_Any_data const&) from /usr/include/c++/10/bits/std_function.h:292
#11 std::function<std::shared_ptr<c10::LazyValue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > const> ()>::operator()() const from /usr/include/c++/10/bits/std_function.h:622
#12 c10::(anonymous namespace)::PyTorchStyleBacktrace::PyTorchStyleBacktrace(c10::SourceLocation) from /home/ysiraichi/pytorch/build/../c10/util/Logging.cpp:92
#13 void __gnu_cxx::new_allocator<c10::(anonymous namespace)::PyTorchStyleBacktrace>::construct<c10::(anonymous namespace)::PyTorchStyleBacktrace, c10::SourceLocation&>(c10::(anonymous namespace)::PyTorchStyleBacktrace*, c10::SourceLocation&) from /usr/include/c++/10/ext/new_allocator.h:150
#14 void std::allocator_traits<std::allocator<c10::(anonymous namespace)::PyTorchStyleBacktrace> >::construct<c10::(anonymous namespace)::PyTorchStyleBacktrace, c10::SourceLocation&>(std::allocator<c10::(anonymous namespace)::PyTorchStyleBacktrace>&, c10::(anonymous namespace)::PyTorchStyleBacktrace*, c10::SourceLocation&) from /usr/include/c++/10/bits/alloc_traits.h:512
#15 std::_Sp_counted_ptr_inplace<c10::(anonymous namespace)::PyTorchStyleBacktrace, std::allocator<c10::(anonymous namespace)::PyTorchStyleBacktrace>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<c10::SourceLocation&>(std::allocator<c10::(anonymous namespace)::PyTorchStyleBacktrace>, c10::SourceLocation&) from /usr/include/c++/10/bits/shared_ptr_base.h:551
#16 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<c10::(anonymous namespace)::PyTorchStyleBacktrace, std::allocator<c10::(anonymous namespace)::PyTorchStyleBacktrace>, c10::SourceLocation&>(c10::(anonymous namespace)::PyTorchStyleBacktrace*&, std::_Sp_alloc_shared_tag<std::allocator<c10::(anonymous namespace)::PyTorchStyleBacktrace> >, c10::SourceLocation&) from /usr/include/c++/10/bits/shared_ptr_base.h:
682
#17 std::__shared_ptr<c10::(anonymous namespace)::PyTorchStyleBacktrace, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<c10::(anonymous namespace)::PyTorchStyleBacktrace>, c10::SourceLocation&>(std::_Sp_alloc_shared_tag<std::allocator<c10::(anonymous namespace)::PyTorchStyleBacktrace> >, c10::SourceLocation&) from /usr/include/c++/10/bits/shared_ptr_base.h:1371
#18 std::shared_ptr<c10::(anonymous namespace)::PyTorchStyleBacktrace>::shared_ptr<std::allocator<c10::(anonymous namespace)::PyTorchStyleBacktrace>, c10::SourceLocation&>(std::_Sp_alloc_shared_tag<std::allocator<c10::(anonymous namespace)::PyTorchStyleBacktrace> >, c10::SourceLocation&) from /usr/include/c++/10/bits/shared_ptr.h:408
#19 std::shared_ptr<c10::(anonymous namespace)::PyTorchStyleBacktrace> std::allocate_shared<c10::(anonymous namespace)::PyTorchStyleBacktrace, std::allocator<c10::(anonymous namespace)::PyTorchStyleBacktrace>, c10::SourceLocation&>(std::allocator<c10::(anonymous namespace)::PyTorchStyleBacktrace> const&, c10::SourceLocation&) from /usr/include/c++/10/bits/shared_ptr.h:860
#20 std::shared_ptr<c10::(anonymous namespace)::PyTorchStyleBacktrace> std::make_shared<c10::(anonymous namespace)::PyTorchStyleBacktrace, c10::SourceLocation&>(c10::SourceLocation&) from /usr/include/c++/10/bits/shared_ptr.h:876
#21 c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) from /home/ysiraichi/pytorch/build/../c10/util/Logging.cpp:114
#22 c10::detail::torchCheckFail(char const*, char const*, unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) from /home/ysiraichi/pytorch/build/../c10/util/Exception.cpp:106
#23 torch_xla::MaybeThrow(absl::lts_20230802::Status const&) from ??:0
#24 torch_xla::bridge::GetOrCreateXlaTensor(at::Tensor const&, torch::lazy::BackendDevice const&) from ??:0
#25 torch_xla::(anonymous namespace)::GetBinaryOperands(at::Tensor const&, at::Tensor const&) from aten_xla_type.cpp:0
#26 torch_xla::XLANativeFunctions::add(at::Tensor const&, at::Tensor const&, c10::Scalar const&) from ??:0
#27 c10::impl::make_boxed_from_unboxed_functor<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (at::Tensor const&, at::Tensor const&, c10::Scalar const&), &at::(anonymous namespace)::(anonymous namespace)::wrapper_XLA_Tensor_add>, at::Tensor, c10::guts::typelist::typelist<at::Tensor const&, at::Tensor const&, c10::Scalar const&> >, false>::call(c10::OperatorKernel*, c10::OperatorHandl
e const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*) from RegisterXLA.cpp:0
#28 c10::BoxedKernel::callBoxed(c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*) const from /home/ysiraichi/pytorch/build/../aten/src/ATen/core/boxing/BoxedKernel_impl.h:48
#29 c10::KernelFunction::callBoxed(c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*) const from /home/ysiraichi/pytorch/build/../aten/src/ATen/core/boxing/KernelFunction_impl.h:64
#30 c10::Dispatcher::callBoxed(c10::OperatorHandle const&, std::vector<c10::IValue, std::allocator<c10::IValue> >*) const from /home/ysiraichi/pytorch/build/../aten/src/ATen/core/dispatch/Dispatcher.h:877
#31 c10::OperatorHandle::callBoxed(std::vector<c10::IValue, std::allocator<c10::IValue> >*) const from /home/ysiraichi/pytorch/build/../aten/src/ATen/core/dispatch/Dispatcher.h:527
#32 (anonymous namespace)::functionalizeFallback(c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*) from /home/ysiraichi/pytorch/build/../aten/src/ATen/FunctionalizeFallbackKernel.cpp:98
#33 void c10::BoxedKernel::make_boxed_function<&(anonymous namespace)::functionalizeFallback>(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*) from /home/ysiraichi/pytorch/build/../aten/src/ATen/FunctionalizeFallbackKernel.cpp:350
#34 c10::BoxedKernel::callBoxed(c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*) const from /home/ysiraichi/pytorch/build/../aten/src/ATen/core/boxing/BoxedKernel_impl.h:48
#35 c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&, at::Tensor const&, c10::Scalar const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&, at::Tensor const&, c10::Scalar const&) from /home/ysiraichi/pytorch/build/../aten/src/ATen/core/boxing/impl/boxing.h:247
#36 at::Tensor c10::KernelFunction::call<at::Tensor, at::Tensor const&, at::Tensor const&, c10::Scalar const&>(c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&, at::Tensor const&, c10::Scalar const&) const from /home/ysiraichi/pytorch/build/../aten/src/ATen/core/boxing/KernelFunction_impl.h:157
#37 c10::TypedOperatorHandle<at::Tensor (at::Tensor const&, at::Tensor const&, c10::Scalar const&)>::redispatch(c10::DispatchKeySet, at::Tensor const&, at::Tensor const&, c10::Scalar const&) const from /home/ysiraichi/pytorch/build/../aten/src/ATen/core/dispatch/Dispatcher.h:613
#38 at::redispatch::add(c10::DispatchKeySet, at::Tensor const&, at::Tensor const&, c10::Scalar const&) from /home/ysiraichi/pytorch/build/aten/src/ATen/RedispatchFunctions.h:612
#39 torch::autograd::VariableType::(anonymous namespace)::add_Tensor(c10::DispatchKeySet, at::Tensor const&, at::Tensor const&, c10::Scalar const&)::{lambda()#1}::operator()() const from /home/ysiraichi/pytorch/build/../torch/csrc/autograd/generated/VariableType_2.cpp:6543
#40 torch::autograd::VariableType::(anonymous namespace)::add_Tensor(c10::DispatchKeySet, at::Tensor const&, at::Tensor const&, c10::Scalar const&) from /home/ysiraichi/pytorch/build/../torch/csrc/autograd/generated/VariableType_2.cpp:6544
#41 c10::impl::wrap_kernel_functor_unboxed_<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&, at::Tensor const&, c10::Scalar const&), &torch::autograd::VariableType::(anonymous namespace)::add_Tensor>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&, at::Tensor const&, c10::Scalar const&> >, at::Tensor (c10::Dispa
tchKeySet, at::Tensor const&, at::Tensor const&, c10::Scalar const&)>::call(c10::OperatorKernel*, c10::DispatchKeySet, at::Tensor const&, at::Tensor const&, c10::Scalar const&) from /home/ysiraichi/pytorch/build/../aten/src/ATen/core/boxing/impl/WrapFunctionIntoFunctor.h:17
#42 at::Tensor c10::callUnboxedKernelFunction<at::Tensor, at::Tensor const&, at::Tensor const&, c10::Scalar const&>(void*, c10::OperatorKernel*, c10::DispatchKeySet, at::Tensor const&, at::Tensor const&, c10::Scalar const&) from /home/ysiraichi/pytorch/build/../aten/src/ATen/core/boxing/KernelFunction_impl.h:76
#43 at::Tensor c10::KernelFunction::call<at::Tensor, at::Tensor const&, at::Tensor const&, c10::Scalar const&>(c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&, at::Tensor const&, c10::Scalar const&) const from /home/ysiraichi/pytorch/build/../aten/src/ATen/core/boxing/KernelFunction_impl.h:149
#44 at::Tensor::add(at::Tensor const&, c10::Scalar const&) const from /home/ysiraichi/pytorch/build/aten/src/ATen/core/TensorBody.h:1669
#45 torch::autograd::THPVariable_add(_object*, _object*, _object*)::{lambda(at::Tensor const&, at::Tensor const&, c10::Scalar const&)#3}::operator()(at::Tensor const&, at::Tensor const&, c10::Scalar const&) const from /home/ysiraichi/pytorch/build/../torch/csrc/autograd/generated/python_torch_functions_2.cpp:1461
#46 torch::autograd::THPVariable_add(_object*, _object*, _object*) from /home/ysiraichi/pytorch/build/../torch/csrc/autograd/generated/python_torch_functions_2.cpp:1463
#47 cfunction_call from /usr/src/python/Objects/methodobject.c:537
#48 _PyObject_MakeTpCall from /usr/src/python/Objects/call.c:240
#49 _PyEval_EvalFrameDefault from /usr/src/python/Python/bytecodes.c:2715
#50 PyEval_EvalCode from /usr/src/python/Python/ceval.c:580
#51 run_eval_code_obj from /usr/src/python/Python/pythonrun.c:1757
#52 run_mod from /usr/src/python/Python/pythonrun.c:1778
#53 pyrun_file from /usr/src/python/Python/pythonrun.c:1674
#54 _PyRun_SimpleFileObject from /usr/src/python/Python/pythonrun.c:459
#55 _PyRun_AnyFileObject from /usr/src/python/Python/pythonrun.c:78
#56 pymain_run_file_obj from /usr/src/python/Modules/main.c:361
#57 Py_BytesMain from /usr/src/python/Modules/main.c:768
#58 __libc_start_main from ./csu/../csu/libc-start.c:308
#59 _start from ??:0
```

_Note: it wasn't possible to create a test for reproducing this error, since we don't have any GPU CI anymore._