### PR TITLE
Add triggers for release 2.8.0

### DIFF
--- a/infra/tpu-pytorch-releases/artifacts.auto.tfvars
+++ b/infra/tpu-pytorch-releases/artifacts.auto.tfvars
@@ -4,6 +4,51 @@ manual_nightly_builds = [
 
 manual_versioned_builds = [
   {
+    git_tag         = "v2.8.0"
+    package_version = "2.8.0"
+    pytorch_git_rev = "v2.8.0"
+    accelerator     = "tpu"
+    python_version  = "3.10"
+    bundle_libtpu   = "0"
+    cxx11_abi       = "1"
+  },
+  {
+    git_tag         = "v2.8.0"
+    package_version = "2.8.0"
+    pytorch_git_rev = "v2.8.0"
+    accelerator     = "tpu"
+    python_version  = "3.10"
+    bundle_libtpu   = "1"
+    cxx11_abi       = "1"
+  },
+  {
+    git_tag         = "v2.8.0"
+    package_version = "2.8.0"
+    pytorch_git_rev = "v2.8.0"
+    accelerator     = "tpu"
+    python_version  = "3.11"
+    bundle_libtpu   = "0"
+    cxx11_abi       = "1"
+  },
+  {
+    git_tag         = "v2.8.0"
+    package_version = "2.8.0"
+    pytorch_git_rev = "v2.8.0"
+    accelerator     = "tpu"
+    python_version  = "3.12"
+    bundle_libtpu   = "0"
+    cxx11_abi       = "1"
+  },
+  {
+    git_tag         = "v2.8.0"
+    package_version = "2.8.0"
+    pytorch_git_rev = "v2.8.0"
+    accelerator     = "tpu"
+    python_version  = "3.13"
+    bundle_libtpu   = "0"
+    cxx11_abi       = "1"
+  },
+  {
     git_tag         = "v2.7.0"
     package_version = "2.7.0"
     pytorch_git_rev = "v2.7.0"


### PR DESCRIPTION
This contains torch_xla release triggers for python version 3.10 to 3.13 only for tpu. 