### PR TITLE
Refactor the status error message builder.

### DIFF
--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -3378,13 +3378,16 @@ void InitXlaModuleBindings(py::module m) {
              absl::StatusOr<std::vector<absl_nonnull XLATensorPtr>>
                  xtensors_status = bridge::GetXlaTensors(tensors);
              ABSL_CHECK(xtensors_status.ok())
-                 << "_get_graph_hash(): error retrieving the XLA tensors from "
-                 << "the given tensor arguments. "
+                 << "\n\n"
+                 << "Internal Error:\n"
+                 << "    _get_graph_hash(): error retrieving the XLA tensors "
+                    "from the given tensor arguments. "
                  << "This is a bug! Please, open an issue in the PyTorch/XLA "
                  << "GitHub repository: https://github.com/pytorch/xla"
-                 << std::endl
-                 << "Status Error: "
-                 << BuildStatusErrorMessage(xtensors_status.status());
+                 << "\n\n"
+                 << "Status Error:\n"
+                 << "    " << BuildStatusErrorMessage(xtensors_status.status())
+                 << "\n";
              std::vector<absl_nonnull XLATensorPtr> xtensors =
                  xtensors_status.value();
              torch::lazy::hash_t hash =

--- a/torch_xla/csrc/status.h
+++ b/torch_xla/csrc/status.h
@@ -179,10 +179,7 @@ absl::Status MaybeWithNewMessage(const absl::Status& status, const char* file,
 // If `TORCH_SHOW_CPP_STACKTRACES` is enabled, returns the concatenation of
 // `status.message()` with its inner status propagation trace.
 //
-// TODO(ysiraichi): this call does not append the C++ stacktrace, which,
-// ideally, should. It can be done by not using `TORCH_CHECK()` macro directly
-// in `MaybeThrow()`, but using PyTorch `c10::get_lazy_backtrace()`
-// (at c10/util/Backtrace.h).
+// It doesn't add a trailing line break.
 std::string BuildStatusErrorMessage(const absl::Status& status);
 
 // Maybe throws an exception if `status` has a non-ok code.


### PR DESCRIPTION
This PR refactors `BuildStatusErrorMessage` function, so it's easier to use in other places besides in the `MaybeThrow()` implementation. For example, when crashing on a status value.

As a practical example, I used it to better show the error information when `_get_graph_hash()` crashes:

**`TORCH_SHOW_CPP_STACKTRACES=0`**

```python
#################################################################
# Before this PR
F0000 00:00:1754594604.459119   30334 init_python_bindings.cpp:3380] Check failed: xtensors_status.ok() _get_graph_hash(): error retrieving the XLA tensors from the given tensor arguments. This is a bug! Please, open an issue in the PyTorch/XLA GitHub repository: https://github.com/pytorch/xla
Status Error: Expected all tensors in the given list to be XLA tensors. Element at index 0 is not an XLA tensor. Got: CPUFloatType
*** Check failure stack trace: ***
    @     0x7497ef2a1159  absl::lts_20230802::log_internal::LogMessageFatal::~LogMessageFatal()
    @     0x7497e3b6bdb8  torch_xla::(anonymous namespace)::InitXlaModuleBindings()::{lambda()#172}::operator()()
    @     0x7497e4225946  pybind11::cpp_function::initialize<>()::{lambda()#3}::_FUN()
    @     0x7497e4204f51  pybind11::cpp_function::dispatcher()
    @     0x74998357aa2e  cfunction_call
Aborted (core dumped)

#################################################################
# After this PR
F0000 00:00:1754593291.250543   19765 init_python_bindings.cpp:3380] Check failed: xtensors_status.ok()

Internal Error:
    _get_graph_hash(): error retrieving the XLA tensors from the given tensor arguments. This is a bug! Please, open an issue in the PyTorch/XLA GitHub repository: https://github.com/pytorch/xla

Status Error:
    Expected all tensors in the given list to be XLA tensors. Element at index 0 is not an XLA tensor. Got: CPUFloatType

*** Check failure stack trace: ***
    @     0x7d80ecea7059  absl::lts_20230802::log_internal::LogMessageFatal::~LogMessageFatal()
    @     0x7d80e176bd76  torch_xla::(anonymous namespace)::InitXlaModuleBindings()::{lambda()#172}::operator()()
    @     0x7d80e1e25276  pybind11::cpp_function::initialize<>()::{lambda()#3}::_FUN()
    @     0x7d80e1e04891  pybind11::cpp_function::dispatcher()
    @     0x7d82acf59a2e  cfunction_call
Aborted (core dumped)
```

**`TORCH_SHOW_CPP_STACKTRACES=1`**

```python
#################################################################
# Before this PR
F0000 00:00:1754594644.896688   30382 init_python_bindings.cpp:3380] Check failed: xtensors_status.ok() _get_graph_hash(): error retrieving the XLA tensors from the given tensor arguments. This is a bug! Please, open an issue in the PyTorch/XLA GitHub repository: https://github.com/pytorch/xla
Status Error: Expected all tensors in the given list to be XLA tensors. Element at index 0 is not an XLA tensor. Got: CPUFloatType

Status Propagation Trace:
    From: GetXlaTensorImpl at torch_xla/csrc/aten_xla_bridge.cpp:88 (error: Failed retrieving the inner XLATensorImpl* from CPUFloatType. It's likely that `tensor` is not an actual XLA tensor, i.e. it wasn't created inside PyTorch/XLA.)
    From: GetXlaTensor at torch_xla/csrc/aten_xla_bridge.cpp:106 (error: Expected XLA tensor. Got: CPUFloatType)
    From: GetXlaTensors at torch_xla/csrc/aten_xla_bridge.cpp:118 (error: Expected all tensors in the given list to be XLA tensors. Element at index 0 is not an XLA tensor. Got: CPUFloatType)

*** Check failure stack trace: ***
    @     0x788d52ca1159  absl::lts_20230802::log_internal::LogMessageFatal::~LogMessageFatal()
    @     0x788d4756bdb8  torch_xla::(anonymous namespace)::InitXlaModuleBindings()::{lambda()#172}::operator()()
    @     0x788d47c25946  pybind11::cpp_function::initialize<>()::{lambda()#3}::_FUN()
    @     0x788d47c04f51  pybind11::cpp_function::dispatcher()
    @     0x788ee6f96a2e  cfunction_call
Aborted (core dumped)

#################################################################
# After this PR
F0000 00:00:1754593329.264671   19813 init_python_bindings.cpp:3380] Check failed: xtensors_status.ok()

Internal Error:
    _get_graph_hash(): error retrieving the XLA tensors from the given tensor arguments. This is a bug! Please, open an issue in the PyTorch/XLA GitHub repository: https://github.com/pytorch/xla

Status Error:
    Expected all tensors in the given list to be XLA tensors. Element at index 0 is not an XLA tensor. Got: CPUFloatType

Status Propagation Trace:
    From: GetXlaTensorImpl at torch_xla/csrc/aten_xla_bridge.cpp:88 (error: Failed retrieving the inner XLATensorImpl* from CPUFloatType. It's likely that `tensor` is not an actual XLA tensor, i.e. it wasn't created inside PyTorch/XLA.)
    From: GetXlaTensor at torch_xla/csrc/aten_xla_bridge.cpp:106 (error: Expected XLA tensor. Got: CPUFloatType)
    From: GetXlaTensors at torch_xla/csrc/aten_xla_bridge.cpp:118 (error: Expected all tensors in the given list to be XLA tensors. Element at index 0 is not an XLA tensor. Got: CPUFloatType)

*** Check failure stack trace: ***
    @     0x73a6bcea7059  absl::lts_20230802::log_internal::LogMessageFatal::~LogMessageFatal()
    @     0x73a6b176bd76  torch_xla::(anonymous namespace)::InitXlaModuleBindings()::{lambda()#172}::operator()()
    @     0x73a6b1e25276  pybind11::cpp_function::initialize<>()::{lambda()#3}::_FUN()
    @     0x73a6b1e04891  pybind11::cpp_function::dispatcher()
    @     0x73a86de37a2e  cfunction_call
Aborted (core dumped)
```