### PR TITLE
Add flags for size optimization

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,8 +20,6 @@ build --define=no_ignite_support=true
 
 build --define=grpc_no_ares=true
 
-build -c opt
-
 build --config=short_logs
 
 # PyTorch/XLA uses exceptions to communicate with Python.
@@ -252,6 +250,13 @@ build:linux --copt="-Wswitch"
 build:linux --copt="-Werror=switch"
 # Required for building with clang
 build:linux --copt="-Wno-error=unused-but-set-variable"
+build:linux --copt="-Os"
+build:linux --copt="-falign-functions"
+build:linux --copt="-falign-jumps"
+build:linux --copt="-falign-labels"
+build:linux --copt="-falign-loops"
+build:linux --copt="-freorder-blocks-algorithm=stc"
+build:linux --copt="-DNDEBUG"
 
 # Only include debug info for files not under XLA.
 build:dbg -c dbg


### PR DESCRIPTION
https://bazel.build/docs/user-manual#build-semantics shows that `bazel build -c opt` is the same as `bazel build --copt="-O2" --copt="-DNDEBUG"`

Instead, we optimize for size by using `bazel build --copt="-Os"`. This uses most of `-O2` optimization except the ones list here:
```
-falign-functions  -falign-jumps
-falign-labels  -falign-loops
-fprefetch-loop-arrays  -freorder-blocks-algorithm=stc
```
Out of these `-fprefetch-loop-arrays` doesn't work with `-Os`. All others work without increasing the wheel size. The final wheel size after this change is 84MB.

Reference: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html