### PR TITLE
`cat`: improve error handling and error messages.

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1314,9 +1314,10 @@ at::Tensor XLANativeFunctions::bmm(const at::Tensor& self,
 at::Tensor XLANativeFunctions::cat(const at::ITensorListRef& tensors,
                                    int64_t dim) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
-  return bridge::AtenFromXlaTensor(
-      tensor_methods::cat(GetValueOrThrow(bridge::GetXlaTensors(tensors)), dim,
-                          at::native::result_type(tensors)));
+  auto xtensors = GetValueOrThrow(bridge::GetXlaTensors(tensors));
+  auto result = GetValueOrThrow(
+      tensor_methods::cat(xtensors, dim, at::native::result_type(tensors)));
+  return bridge::AtenFromXlaTensor(result);
 }
 
 at::Tensor XLANativeFunctions::celu(const at::Tensor& self,

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -1,6 +1,7 @@
 #ifndef XLA_TORCH_XLA_CSRC_TENSOR_METHODS_H_
 #define XLA_TORCH_XLA_CSRC_TENSOR_METHODS_H_
 
+#include "absl/base/nullability.h"
 #include "torch_xla/csrc/cross_replica_reduces.h"
 #include "torch_xla/csrc/ops/custom_sharding.h"
 #include "torch_xla/csrc/runtime/computation_client.h"
@@ -307,8 +308,8 @@ XLATensorPtr bmm(const XLATensorPtr& batch1, const XLATensorPtr& batch2);
 std::vector<XLATensorPtr> broadcast_tensors(
     absl::Span<const XLATensorPtr> tensors);
 
-XLATensorPtr cat(absl::Span<const XLATensorPtr> tensors, int64_t dim,
-                 at::ScalarType dtype);
+absl::StatusOr<absl_nonnull XLATensorPtr> cat(
+    absl::Span<const XLATensorPtr> tensors, int64_t dim, at::ScalarType dtype);
 
 XLATensorPtr cdist_forward(const XLATensorPtr& x1, const XLATensorPtr& x2,
                            double p);


### PR DESCRIPTION
This PR refactors the `tensor_methods::cat` implementation by improving its error message, and returning a status type value.

**Key Changes:**

- Make `tensor_methods::cat` return `StatusOr<absl_nonnull XLATensorPtr>`
- Improve error message on incompatible tensor shapes
- Crash on `torch.cat` with no tensors

**Before:**

```python
Traceback (most recent call last):
  File "scratch.py", line 8, in <module>
    print(torch.cat([x, y]))
          ^^^^^^^^^^^^^^^^^
RuntimeError: Check failed: xla::ShapeUtil::CompatibleIgnoringElementType(shapes.back(), tensor_shape): f32[1]{0} vs. f32[4]{0} (at torch_xla/csrc/tensor_methods.cpp:1185)

Exception raised from operator& at torch_xla/csrc/runtime/tf_logging.cpp:26 (most recent call first):
```

**After:** 

```python
Traceback (most recent call last):
  File "scratch.py", line 8, in <module>
    print(torch.cat([x, y]))
          ^^^^^^^^^^^^^^^^^
RuntimeError: cat(): cannot concatenate tensors of shape f32[1,1] with f32[9,4] at dimension 0. Expected shapes to be equal (except at dimension 0) or that either of them was a 1D empty tensor of size (0,).

Status Propagation Trace:
    From: cat at torch_xla/csrc/tensor_methods.cpp:1190 (error: cat(): cannot concatenate tensors of shape f32[1,1] with f32[9,4] at dimension 0. Expected shapes to be equal (except at dimension 0) or that either of them was a 1D empty tensor of size (0,).)

Exception raised from MaybeThrow at torch_xla/csrc/status.cpp:128 (most recent call first):
```