### PR TITLE
`flip`: improve error handling and error messages.

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2497,6 +2497,20 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
           "'trunc', 'floor', or be left unspecified.")
       self.assertEqual(str(e), expected_error)
 
+  def test_flip_raises_error_on_duplicated_dims(self):
+    a = torch.rand(2, 2, 2, 2, device=torch_xla.device())
+    dims = [0, 0, 0, 1, 2, 3, -1]
+    dims_suggestion = [0, 1, 2, 3]
+
+    try:
+      torch.flip(a, dims=dims)
+    except RuntimeError as e:
+      expected_error = (
+          "flip(): expected each dimension to appear at most once. Found "
+          "dimensions: 0 (3 times), 3 (2 times). Consider changing dims "
+          f"from {dims} to {dims_suggestion}.")
+      self.assertEqual(str(e), expected_error)
+
 
 class MNISTComparator(nn.Module):
 

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1804,8 +1804,10 @@ at::Tensor& XLANativeFunctions::fill_(at::Tensor& self,
 at::Tensor XLANativeFunctions::flip(const at::Tensor& self,
                                     at::IntArrayRef dims) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
-  return bridge::AtenFromXlaTensor(tensor_methods::flip(
-      GetValueOrThrow(bridge::GetXlaTensor(self)), XlaHelpers::I64List(dims)));
+  auto xself = GetValueOrThrow(bridge::GetXlaTensor(self));
+  auto output =
+      GetValueOrThrow(tensor_methods::flip(xself, XlaHelpers::I64List(dims)));
+  return bridge::AtenFromXlaTensor(std::move(output));
 }
 
 at::Tensor XLANativeFunctions::floor_divide(const at::Tensor& self,

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -450,7 +450,8 @@ void eye_out(XLATensorPtr& out, int64_t lines, int64_t cols);
 void fill_(XLATensorPtr& input, const at::Scalar& value);
 
 // Flips (reverses) the values in the dimensions of the input tensor.
-XLATensorPtr flip(const XLATensorPtr& input, absl::Span<const int64_t> dims);
+absl::StatusOr<absl_nonnull XLATensorPtr> flip(const XLATensorPtr& input,
+                                               absl::Span<const int64_t> dims);
 
 XLATensorPtr fmod(
     const XLATensorPtr& input, const XLATensorPtr& other,


### PR DESCRIPTION
This PR refactors the `tensor_methods::flip` implementation by improving its error message, and returning a status type value.

**Key Changes:**

- Make `tensor_methods::flip` return `StatusOr<absl_nonnull XLATensorPtr>`
- Improve error message on incompatible tensor shapes

**Example:**

```python
dims = [0, 0, 0, 1, 2, 3, -1]
a = torch.rand(2, 2, 2, 2, device="xla")
print(torch.flip(a, dims=dims))
```

**Before:**

```python
Traceback (most recent call last):
  File "scratch.py", line 8, in <module>
    print(torch.flip(a, dims=dims))
          ^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Check failed: unique_dims.size() == dimensions.size() (4 vs. 7) (at torch_xla/csrc/tensor_methods.cpp:1675)

Exception raised from operator& at torch_xla/csrc/runtime/tf_logging.cpp:26 (most recent call first):
```

**After:** 

```python
Traceback (most recent call last):
  File "scratch.py", line 8, in <module>
    print(torch.flip(a, dims=dims))
          ^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: flip(): expected each dimension to appear at most once. Found dimensions: 0 (3 times), 3 (2 times). Consider changing dims from [0, 0, 0, 1, 2, 3, -1] to [0, 1, 2, 3].

Status Propagation Trace:
    From: flip at torch_xla/csrc/tensor_methods.cpp:1704 (error: flip(): expected each dimension to appear at most once. Found dimensions: 0 (3 times), 3 (2 times). Consider changing dims from [0, 0, 0, 1, 2, 3, -1] to [0, 1, 2, 3].)

Exception raised from MaybeThrow at torch_xla/csrc/status.cpp:128 (most recent call first):
```