### PR TITLE
Run torchprime CI only when the pull requests have torchprimeci label

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -83,7 +83,7 @@ jobs:
     with:
       timeout-minutes: 100
       has_code_changes: ${{ needs.check_code_changes.outputs.has_code_changes }}
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: contains(github.event.pull_request.labels.*.name, 'torchprimeci')
     secrets: inherit
 
   push-docs:


### PR DESCRIPTION
This has been failing for a long time