### PR TITLE
Generalize crash message for non-ok status.

### DIFF
--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -3377,17 +3377,9 @@ void InitXlaModuleBindings(py::module m) {
            [](const std::vector<at::Tensor>& tensors) -> py::bytes {
              absl::StatusOr<std::vector<absl_nonnull XLATensorPtr>>
                  xtensors_status = bridge::GetXlaTensors(tensors);
-             ABSL_CHECK(xtensors_status.ok())
-                 << "\n\n"
-                 << "Internal Error:\n"
-                 << "    _get_graph_hash(): error retrieving the XLA tensors "
-                    "from the given tensor arguments. "
-                 << "This is a bug! Please, open an issue in the PyTorch/XLA "
-                 << "GitHub repository: https://github.com/pytorch/xla"
-                 << "\n\n"
-                 << "Status Error:\n"
-                 << "    " << BuildStatusErrorMessage(xtensors_status.status())
-                 << "\n";
+             XLA_CHECK_OK(xtensors_status,
+                          "_get_graph_hash(): error retrieving the XLA tensors "
+                          "from the given tensor arguments.");
              std::vector<absl_nonnull XLATensorPtr> xtensors =
                  xtensors_status.value();
              torch::lazy::hash_t hash =

--- a/torch_xla/csrc/runtime/debug_macros.h
+++ b/torch_xla/csrc/runtime/debug_macros.h
@@ -28,7 +28,6 @@
 // unnecessary or undesirable.
 #define XLA_ERROR() TF_ERROR_STREAM()
 #define XLA_CHECK(c) TF_CHECK(c)
-#define XLA_CHECK_OK(c) TF_CHECK_OK(c)
 #define XLA_CHECK_EQ(a, b) TF_CHECK_EQ(a, b)
 #define XLA_CHECK_NE(a, b) TF_CHECK_NE(a, b)
 #define XLA_CHECK_LE(a, b) TF_CHECK_LE(a, b)

--- a/torch_xla/csrc/status.cpp
+++ b/torch_xla/csrc/status.cpp
@@ -126,6 +126,10 @@ void GetValueOrThrow(const absl::Status& status) { MaybeThrow(status); }
 
 void OkOrDie(const absl::Status& status, const char* file, const int32_t line,
              const char* function, std::string_view message) {
+  if (status.ok()) {
+    return;
+  }
+
   std::ostringstream oss;
   oss << "\n\n"
       << "Internal Error:\n";

--- a/torch_xla/csrc/status.cpp
+++ b/torch_xla/csrc/status.cpp
@@ -124,4 +124,26 @@ void MaybeThrow(const absl::Status& status) {
 
 void GetValueOrThrow(const absl::Status& status) { MaybeThrow(status); }
 
+void OkOrDie(const absl::Status& status, const char* file, const int32_t line,
+             const char* function, std::string_view message) {
+  std::ostringstream oss;
+  oss << "\n\n"
+      << "Internal Error:\n";
+
+  if (!message.empty()) {
+    oss << "    " << message << "\n";
+  }
+
+  oss << "    This is a bug! Please, open an issue in the PyTorch/XLA "
+      << "GitHub repository: https://github.com/pytorch/xla"
+      << "\n\n"
+      << "Status Error:\n"
+      << "    "
+      << BuildStatusErrorMessage(
+             status_internal::MaybeWithNewMessage(status, file, line, function))
+      << "\n";
+
+  ABSL_CHECK(status.ok()) << oss.str();
+}
+
 }  // namespace torch_xla


### PR DESCRIPTION
This PR introduces a macro and a function, generalizing the crash report on non-ok status. This should be used whenever a non-ok status represents an internal error, i.e. something that the user has no control over.

**Key Changes:**
- Created `OkOrDie()` function for crashing on non-ok status with source location information
- Updated `XLA_CHECK_OK()` macro definition (moved to _status.h_), for calling `OkOrDie()` with the appropriate source location
- Updated `_get_graph_hash()` implementation to call `XLA_CHECK_OK()` instead of crafting a report with `ABSL_CHECK()` directly