### PR TITLE
`random_`: improve error handling and error messages.

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2554,6 +2554,33 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
           "However, that's not true on dimensions [0, 2].")
       self.assertEqual(str(e), expected_error)
 
+  def test_random__raises_error_on_empty_interval(self):
+    a = torch.empty(10, device=torch_xla.device())
+    from_ = 3
+    to_ = 1
+
+    try:
+      a.random_(from_, to_)
+    except RuntimeError as e:
+      expected_error = (
+          f"random_(): expected `from` ({from_}) to be smaller than "
+          f"`to` ({to_}).")
+      self.assertEqual(str(e), expected_error)
+
+  def test_random__raises_error_on_value_out_of_type_value_range(self):
+    a = torch.empty(10, device=torch_xla.device(), dtype=torch.float16)
+    from_ = 3
+    to_ = 65504 + 1
+
+    try:
+      a.random_(from_, to_)
+    except RuntimeError as e:
+      expected_error = (
+          f"random_(): expected `to` to be within the range "
+          f"[-65504, 65504]. However got value {to_}, which is greater "
+          "than the upper bound.")
+      self.assertEqual(str(e), expected_error)
+
 
 class MNISTComparator(nn.Module):
 

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -776,7 +776,7 @@ void put_(XLATensorPtr& input, const XLATensorPtr& index,
 
 std::tuple<XLATensorPtr, XLATensorPtr> qr(const XLATensorPtr& input, bool some);
 
-void random_(XLATensorPtr& input, int64_t from, int64_t to);
+absl::Status random_(XLATensorPtr& input, int64_t from, int64_t to);
 
 XLATensorPtr randperm(int64_t n, const torch::lazy::BackendDevice& device,
                       at::ScalarType scalar_type);


### PR DESCRIPTION
This PR refactors the `random_` operation implementation by improving its error message, and returning a status type value.

**Key Changes:**

- Make `tensor_methods::random_` return `Status`
- Replace `CheckRangeValues` by `CheckValueWithinTypeRange`, and make it return `Status`
- Refactor `XLANativeFunctions::random_` overloads to handle the status values
- Improve error messages

**Example:**

```python
tensor = torch.empty(10, device=torch_xla.device())
from_ = 3
to_ = 1
tensor.random_(from_, to_)
```

**Before:**

```python
Traceback (most recent call last):
  File "example.py", line 7, in <module>
    tensor.random_(from_, to_)
RuntimeError: Check failed: from <= to_val (3 vs. 1) (at torch_xla/csrc/aten_xla_type.cpp:3031)

Exception raised from operator& at torch_xla/csrc/runtime/tf_logging.cpp:26 (most recent call first):
```

**After:** 

```python
Traceback (most recent call last):
  File "example.py", line 7, in <module>
    tensor.random_(from_, to_)
RuntimeError: random_(): expected `from` (3) to be smaller than `to` (1).

Status Propagation Trace:
    From: random_ at torch_xla/csrc/tensor_methods.cpp:2870 (error: random_(): expected `from` (3) to be smaller than `to` (1).)

Exception raised from OkOrThrow at torch_xla/csrc/status.cpp:121 (most recent call first):
```