### PR TITLE
Create new macros for throwing status errors.

### DIFF
--- a/test/cpp/test_status_common.h
+++ b/test/cpp/test_status_common.h
@@ -80,8 +80,10 @@ class StatusTest : public testing::TestWithParam<CppStacktracesMode> {
 namespace cpp_test {
 
 // Prefix of the C++ stacktrace PyTorch adds to the error message.
-constexpr inline char kTorchCppStacktracePrefix[] =
+constexpr inline char kTorchCppStacktracePrefixDeprecated[] =
     "Exception raised from OkOrThrow at torch_xla/csrc/status.cpp:";
+constexpr inline char kTorchCppStacktracePrefix[] =
+    "Exception raised from ThrowStatusError at torch_xla/csrc/status.cpp:";
 
 constexpr inline char kNewMessage[] = "New test error message";
 constexpr inline char kMessage[] = "Test error message";
@@ -113,7 +115,7 @@ TEST_P(StatusTest, OkOrThrowWithErrorStatus) {
     if (IsShowCppStacktracesMode()) {
       EXPECT_THAT(std::string_view(error.what()),
                   ::testing::StartsWith(absl::StrCat(
-                      kMessage, "\n\n", kTorchCppStacktracePrefix)));
+                      kMessage, "\n\n", kTorchCppStacktracePrefixDeprecated)));
     } else {
       EXPECT_EQ(std::string_view(error.what_without_backtrace()),
                 std::string_view(kMessage));
@@ -136,7 +138,7 @@ TEST_P(StatusTest, GetValueOrThrowWithErrorStatusOr) {
     if (IsShowCppStacktracesMode()) {
       EXPECT_THAT(std::string_view(error.what()),
                   ::testing::StartsWith(absl::StrCat(
-                      kMessage, "\n\n", kTorchCppStacktracePrefix)));
+                      kMessage, "\n\n", kTorchCppStacktracePrefixDeprecated)));
     } else {
       EXPECT_EQ(std::string_view(error.what_without_backtrace()),
                 std::string_view(kMessage));
@@ -387,6 +389,132 @@ TEST_P(StatusTest, OkOrThrowWithErrorPropagationWithNewMessage) {
           << errline1 << " (error: " << kNewMessage << ")";
       oss << kEntryPrefix << "From: operator() at " << __FILE__ << ":"
           << errline2;
+      oss << "\n\n";
+      oss << kTorchCppStacktracePrefixDeprecated;
+      EXPECT_THAT(std::string_view(error.what()),
+                  ::testing::StartsWith(oss.str()));
+    } else {
+      EXPECT_EQ(std::string_view(error.what_without_backtrace()),
+                std::string_view(kNewMessage));
+    }
+  }
+}
+
+TEST_P(StatusTest, MacroThrowIfErrorWithErrorPropagationWithNewMessage) {
+  int32_t errline0 = __LINE__ + 2;
+  auto innerfn = [&]() -> absl::Status {
+    return XLA_ERROR_WITH_LOCATION(absl::InvalidArgumentError(kMessage));
+  };
+
+  int32_t errline1 = __LINE__ + 2;
+  auto midfn = [&]() -> absl::Status {
+    XLA_RETURN_IF_ERROR(innerfn(), kNewMessage);
+    return absl::OkStatus();
+  };
+
+  int32_t errline2 = __LINE__ + 2;
+  auto outerfn = [&]() -> absl::Status {
+    XLA_RETURN_IF_ERROR(midfn());
+    return absl::OkStatus();
+  };
+
+  int32_t errline3 = __LINE__ + 2;
+  try {
+    XLA_THROW_IF_ERROR(outerfn());
+    FAIL() << "Expected `XLA_THROW_IF_ERROR(outerfn())` to throw.";
+  } catch (const c10::Error& error) {
+    if (IsShowCppStacktracesMode()) {
+      // clang-format off
+      //
+      // Expected Error Message Prefix
+      // =============================
+      //
+      // New test error kMessage
+      //
+      // Status Propagation Stacktrace:
+      //     From: operator() at ./test/cpp/test_status_common.h:334 (error: Test error kMessage)
+      //     From: operator() at ./test/cpp/test_status_common.h:339 (error: New test error kMessage)
+      //     From: operator() at ./test/cpp/test_status_common.h:345
+      //     From: TestBody at ./test/cpp/test_status_common.h:350
+      //
+      // C++ Stacktrace:
+      //
+      // clang-format on
+      std::ostringstream oss;
+      oss << kNewMessage;
+      oss << "\n\n";
+      oss << "Status Propagation Trace:";
+      oss << kEntryPrefix << "From: operator() at " << __FILE__ << ":"
+          << errline0 << " (error: " << kMessage << ")";
+      oss << kEntryPrefix << "From: operator() at " << __FILE__ << ":"
+          << errline1 << " (error: " << kNewMessage << ")";
+      oss << kEntryPrefix << "From: operator() at " << __FILE__ << ":"
+          << errline2;
+      oss << kEntryPrefix << "From: TestBody at " << __FILE__ << ":"
+          << errline3;
+      oss << "\n\n";
+      oss << kTorchCppStacktracePrefix;
+      EXPECT_THAT(std::string_view(error.what()),
+                  ::testing::StartsWith(oss.str()));
+    } else {
+      EXPECT_EQ(std::string_view(error.what_without_backtrace()),
+                std::string_view(kNewMessage));
+    }
+  }
+}
+
+TEST_P(StatusTest, MacroAssignOrThrowWithErrorPropagationWithNewMessage) {
+  int32_t errline0 = __LINE__ + 2;
+  auto innerfn = [&]() -> absl::Status {
+    return XLA_ERROR_WITH_LOCATION(absl::InvalidArgumentError(kMessage));
+  };
+
+  int32_t errline1 = __LINE__ + 2;
+  auto midfn = [&]() -> absl::Status {
+    XLA_RETURN_IF_ERROR(innerfn(), kNewMessage);
+    return absl::OkStatus();
+  };
+
+  int32_t errline2 = __LINE__ + 2;
+  auto outerfn = [&]() -> absl::StatusOr<int> {
+    XLA_RETURN_IF_ERROR(midfn());
+    return 42;
+  };
+
+  int32_t errline3 = __LINE__ + 2;
+  try {
+    XLA_ASSIGN_OR_THROW(int ret, outerfn());
+    FAIL() << "Expected `XLA_ASSIGN_OR_THROW(int ret, outerfn())` to throw.";
+  } catch (const c10::Error& error) {
+    if (IsShowCppStacktracesMode()) {
+      // clang-format off
+      //
+      // Expected Error Message Prefix
+      // =============================
+      //
+      // New test error kMessage
+      //
+      // Status Propagation Stacktrace:
+      //     From: operator() at ./test/cpp/test_status_common.h:393 (error: Test error kMessage)
+      //     From: operator() at ./test/cpp/test_status_common.h:398 (error: New test error kMessage)
+      //     From: operator() at ./test/cpp/test_status_common.h:404
+      //     From: TestBody at ./test/cpp/test_status_common.h:410
+      //
+      // C++ Stacktrace:
+      //
+      // clang-format on
+      std::ostringstream oss;
+      oss << kNewMessage;
+      oss << "\n\n";
+      oss << "Status Propagation Trace:";
+      oss << kEntryPrefix << "From: operator() at " << __FILE__ << ":"
+          << errline0 << " (error: " << kMessage << ")";
+      oss << kEntryPrefix << "From: operator() at " << __FILE__ << ":"
+          << errline1 << " (error: " << kNewMessage << ")";
+      oss << kEntryPrefix << "From: operator() at " << __FILE__ << ":"
+          << errline2;
+      oss << kEntryPrefix << "From: TestBody at " << __FILE__ << ":"
+          << errline3;
       oss << "\n\n";
       oss << kTorchCppStacktracePrefix;
       EXPECT_THAT(std::string_view(error.what()),

--- a/torch_xla/csrc/status.cpp
+++ b/torch_xla/csrc/status.cpp
@@ -118,6 +118,17 @@ static std::string LineBreakIfCppStacktracesEnabled() {
   return torch::get_cpp_stacktraces_enabled() ? "\n" : "";
 }
 
+void status_internal::ThrowStatusError(const absl::Status& status,
+                                       const char* file, const int32_t line,
+                                       const char* function,
+                                       std::string_view message) {
+  ABSL_CHECK(!status.ok());
+  absl::Status new_status = status_internal::MaybeWithNewMessage(
+      status, file, line, function, message);
+  TORCH_CHECK(false, absl::StrCat(BuildStatusErrorMessage(new_status),
+                                  LineBreakIfCppStacktracesEnabled()));
+}
+
 void OkOrThrow(const absl::Status& status) {
   TORCH_CHECK(status.ok(), absl::StrCat(BuildStatusErrorMessage(status),
                                         LineBreakIfCppStacktracesEnabled()));

--- a/torch_xla/csrc/status.h
+++ b/torch_xla/csrc/status.h
@@ -62,30 +62,56 @@ constexpr char kStatusPropagationTraceKey[] =
 #define XLA_STATUS_VAR_ XLA_CONCAT_(status_, __LINE__)
 
 // Provides a flexible way to handle error checking with optional message
-// modification. It evaluates `expr`, checks if it's OK, and either:
-//   1. Returns early with an error status
-//   2. Proceeds with the given `then` block if successful
-#define XLA_RETURN_IF_ERROR_IMPL_(expr, var, then, ...)                   \
-  auto var = (expr);                                                      \
-  if (!var.ok()) {                                                        \
-    return ::torch_xla::status_internal::MaybeWithNewMessage(             \
-        ::torch_xla::status_internal::GetStatus(var), __FILE__, __LINE__, \
-        __FUNCTION__, ##__VA_ARGS__);                                     \
-  }                                                                       \
-  then
+// modification. It evaluates `expr`, and:
+//
+//   1. Runs the `on_error` block, if the returned status is an error
+//   2. Runs the `on_success` block, otherwise
+//
+#define XLA_PROCESS_STATUS_IMPL_(on_error, on_success, expr, var, ...) \
+  auto var = (expr);                                                   \
+  if (!var.ok()) {                                                     \
+    on_error(var, ##__VA_ARGS__);                                      \
+  }                                                                    \
+  on_success
 
-// Propagates `rexpr`, in case it's a non-ok status.
+// `on_error` implementation for propagating the status `var`.
 //
-// Example:
+// This macro wraps `var` (error status returned) into a new status, adding
+// source location information to the status propagation trace if
+// `TORCH_SHOW_CPP_STACKTRACES` is set. And then, returns the newly created
+// status.
 //
-//     XLA_RETURN_IF_ERROR(
-//         FnThatReturnsStatus(),
-//         "New error message."
-//     );
+// It should be only used as parameter to `XLA_PROCESS_STATUS_IMPL_` macro
+// defined above.
 //
-// If the function call results in an ok status, execution continues. Otherwise,
-// we early return a non-ok status. Then, if `TORCH_SHOW_CPP_STACKTRACES` is
-// set, the error shown will be:
+#define XLA_PROPAGATE_STATUS_IMPL_(var, ...)                            \
+  return ::torch_xla::status_internal::MaybeWithNewMessage(             \
+      ::torch_xla::status_internal::GetStatus(var), __FILE__, __LINE__, \
+      __FUNCTION__, ##__VA_ARGS__)
+
+// `on_error` implementation for throwing an exception with the status `var`.
+//
+// This macro wraps `var` (error status returned) into a new status, adding
+// source location information to the status propagation trace if
+// `TORCH_SHOW_CPP_STACKTRACES` is set. And then, throws an exception using the
+// `ThrowStatusError()` function.
+//
+// It should be only used as parameter to `XLA_PROCESS_STATUS_IMPL_` macro
+// defined above.
+//
+#define XLA_THROW_STATUS_IMPL_(var, ...)                                \
+  ::torch_xla::status_internal::ThrowStatusError(                       \
+      ::torch_xla::status_internal::GetStatus(var), __FILE__, __LINE__, \
+      __FUNCTION__, ##__VA_ARGS__)
+
+// Macro implementation for processing an `absl::Status` value. This is the core
+// definition of `XLA_*_IF_ERROR()` macros that, given that `rexpr` is an error
+// status, either throws or returns (i.e. propagates) a newly created status
+// with source location information.
+//
+// If `rexpr` results in an ok status, execution continues. Otherwise, we run
+// `on_error`. Then, if `TORCH_SHOW_CPP_STACKTRACES` is set, the error shown
+// will be:
 //
 //     RuntimeError: New error message.
 //
@@ -95,18 +121,61 @@ constexpr char kStatusPropagationTraceKey[] =
 //       ...
 //       From: <cpp-source-file>:<line> (error: New error message.)
 //
-#define XLA_RETURN_IF_ERROR(rexpr, ...)                                  \
-  do {                                                                   \
-    XLA_RETURN_IF_ERROR_IMPL_(rexpr, XLA_STATUS_VAR_, {}, ##__VA_ARGS__) \
+#define XLA_DO_IF_ERROR_IMPL_(on_error, rexpr, ...)                 \
+  do {                                                              \
+    XLA_PROCESS_STATUS_IMPL_(on_error, /* on_success= */ {}, rexpr, \
+                             XLA_STATUS_VAR_, ##__VA_ARGS__)        \
   } while (false)
 
-// Propagates `rexpr`, in case it's a non-ok status. Otherwise, assign
-// its result to `lhs`.
+// If `rexpr` returns a non-ok status, this macro propagates the returned status
+// by early-returning a, possibly, new status with source location information.
+// Otherwise, continues execution.
+//
+// Example:
+//
+//     XLA_RETURN_IF_ERROR(
+//         FnThatReturnsStatus(),
+//         "New error message."
+//     );
+//
+#define XLA_RETURN_IF_ERROR(rexpr, ...) \
+  XLA_DO_IF_ERROR_IMPL_(XLA_PROPAGATE_STATUS_IMPL_, rexpr, ##__VA_ARGS__)
+
+// If `rexpr` returns a non-ok status, this macro throws an exception with the
+// returned status, possibly, wrapped by a new status with source location
+// information. Otherwise, continues execution.
+//
+// Example:
+//
+//     XLA_THROW_IF_ERROR(
+//         FnThatReturnsStatus(),
+//         "New error message."
+//     );
+//
+#define XLA_THROW_IF_ERROR(rexpr, ...) \
+  XLA_DO_IF_ERROR_IMPL_(XLA_THROW_STATUS_IMPL_, rexpr, ##__VA_ARGS__)
+
+// Macro implementation for processing an `absl::Status` value. This is the core
+// definition of `XLA_ASSIGN_OR_*()` macros that, given that `rexpr` is an error
+// status, either throws or returns (i.e. propagates) a newly created status
+// with source location information.
+//
+// If `rexpr` results in an ok status, we assign the value held by the status
+// returned by `rexpr` to `lhs`. Otherwise, we run `on_error`.
 //
 // Note 1: `lhs` might be a variable declarate, e.g:
 //
 // Note 2: this macro will be replaced by multiple statements that live on
-//         the scope it was called (see XLA_RETURN_IF_ERROR_IMPL).
+//         the scope it was called (see `XLA_PROCESS_STATUS_IMPL_`).
+//
+#define XLA_ASSIGN_OR_DO_IMPL_(on_error, lhs, rexpr, ...)                   \
+  XLA_PROCESS_STATUS_IMPL_(                                                 \
+      on_error, /* on_success= */ lhs = std::move(XLA_STATUS_VAR_).value(), \
+      rexpr, XLA_STATUS_VAR_, ##__VA_ARGS__)
+
+// If `rexpr` returns a non-ok status, this macro propagates the returned status
+// by early-returning a, possibly, new status with source location information.
+// Otherwise, assigns `rexpr` to `lhs`.
 //
 // Example:
 //
@@ -116,16 +185,23 @@ constexpr char kStatusPropagationTraceKey[] =
 //         "New error message."
 //     );
 //
-// If the function call results in an ok status, execution continues with
-// `result` set to `ret.value()`, where `ret` is the returned value of the
-// function. Otherwise, we early return a non-ok status. Then, if
-// `TORCH_SHOW_CPP_STACKTRACES` is set, the error shown will be similar to
-// the one above.
+#define XLA_ASSIGN_OR_RETURN(lhs, rexpr, ...) \
+  XLA_ASSIGN_OR_DO_IMPL_(XLA_PROPAGATE_STATUS_IMPL_, lhs, rexpr, ##__VA_ARGS__)
+
+// If `rexpr` returns a non-ok status, this macro throws an exception with the
+// returned status, possibly, wrapped by a new status with source location
+// information. Otherwise, assigns `rexpr` to `lhs`.
 //
-#define XLA_ASSIGN_OR_RETURN(lhs, rexpr, ...)                         \
-  XLA_RETURN_IF_ERROR_IMPL_(rexpr, XLA_STATUS_VAR_,                   \
-                            lhs = std::move(XLA_STATUS_VAR_).value(), \
-                            ##__VA_ARGS__)
+// Example:
+//
+//     XLA_ASSIGN_OR_THROW(
+//         int result,
+//         FnThatReturnsStatus(),
+//         "New error message."
+//     );
+//
+#define XLA_ASSIGN_OR_THROW(lhs, rexpr, ...) \
+  XLA_ASSIGN_OR_DO_IMPL_(XLA_THROW_STATUS_IMPL_, lhs, rexpr, ##__VA_ARGS__)
 
 // Crashes if `status` is not an ok status.
 //
@@ -190,6 +266,18 @@ const absl::Status& GetStatus(const absl::StatusOr<T>& status) {
 absl::Status MaybeWithNewMessage(const absl::Status& status, const char* file,
                                  int32_t line, const char* function,
                                  std::string_view new_message = "");
+
+// Throws an exception from the given `status`
+//
+// This function wraps `status` within a new status, with the current source
+// location information added to its status propagation trace payload.
+//
+// Then, it throws an exception by using the `TORCH_CHECK(false)` macro, which
+// also displays the C++ stacktrace at the end, if `TORCH_SHOW_CPP_STACKTRACES`
+// is set.
+void ThrowStatusError(const absl::Status& status, const char* file,
+                      const int32_t line, const char* function,
+                      std::string_view message = "");
 
 // Checks that `status` is an ok status.
 //


### PR DESCRIPTION
Follow-up: #9580 

This PR introduces 2 new macros for throwing status errors: `XLA_THROW_IF_ERROR()`, and `XLA_ASSIGN_OR_THROW()`. These macros are analogous to the already existing `XLA_RETURN_IF_ERROR()` and `XLA_ASSIGN_OR_RETURN()`, where instead of propagating (i.e. returning) error status, they throw an exception with the given error status. 

**Key Changes:**

- (_status.h_ and _status.cpp_) New function: `ThrowStatusError(...)` 
- (_status.h_) Refactors the implementation of the existing macros, so as to use its definition for all of the aforementioned macros
    - `XLA_PROCESS_STATUS_IMPL_(...)` : core implementation of those macros.
    - `XLA_PROPAGATE_STATUS_IMPL_(var, ...)`: propagates the given status `var`.
    - `XLA_THROW_STATUS_IMPL_(...)`: calls the newly added `ThrowStatusError()` function, which throws an exception
    - `XLA_DO_IF_ERROR_IMPL_(...)`: core implementation of `XLA_*_IF_ERROR()` macros
        - `XLA_RETURN_IF_ERROR(...)`: combines `XLA_DO_IF_ERROR_IMPL_` with `XLA_PROPAGATE_STATUS_IMPL_`
        - `XLA_THROW_IF_ERROR(...)`: combines `XLA_DO_IF_ERROR_IMPL_` with `XLA_THROW_STATUS_IMPL_`
    - `XLA_ASSIGN_OR_DO_IMPL_(...)`: core implementation of `XLA_ASSIGN_OR_*()` macros
        - `XLA_ASSIGN_OR_RETURN(...)`: combines `XLA_ASSIGN_OR_DO_IMPL_` with `XLA_PROPAGATE_STATUS_IMPL_`
        - `XLA_ASSGIN_OR_THROW(...)`: combines `XLA_ASSIGN_OR_DO_IMPL_` with `XLA_THROW_STATUS_IMPL_`
- (_test_status_common.h_) Add one test for each of the 2 new public macros