### PR TITLE
`test`: Use new macros for throwing exceptions.

### DIFF
--- a/test/cpp/cpp_test_util.cpp
+++ b/test/cpp/cpp_test_util.cpp
@@ -246,17 +246,17 @@ void WithAllDevices(
 }
 
 std::string GetTensorTextGraph(at::Tensor tensor) {
-  XLATensorPtr xtensor = GetValueOrThrow(bridge::GetXlaTensor(tensor));
+  XLA_ASSIGN_OR_THROW(XLATensorPtr xtensor, bridge::GetXlaTensor(tensor));
   return DumpUtil::ToText({xtensor->GetIrValue().node.get()});
 }
 
 std::string GetTensorDotGraph(at::Tensor tensor) {
-  XLATensorPtr xtensor = GetValueOrThrow(bridge::GetXlaTensor(tensor));
+  XLA_ASSIGN_OR_THROW(XLATensorPtr xtensor, bridge::GetXlaTensor(tensor));
   return DumpUtil::ToDot({xtensor->GetIrValue().node.get()});
 }
 
 std::string GetTensorHloGraph(at::Tensor tensor) {
-  XLATensorPtr xtensor = GetValueOrThrow(bridge::GetXlaTensor(tensor));
+  XLA_ASSIGN_OR_THROW(XLATensorPtr xtensor, bridge::GetXlaTensor(tensor));
   return DumpUtil::ToHlo({xtensor->GetIrValue()}, xtensor->GetDevice());
 }
 
@@ -276,9 +276,9 @@ std::vector<torch_xla::runtime::ComputationClient::DataPtr> Execute(
     lowering_ctx.AddResult(root);
   }
 
-  xla::XlaComputation computation = GetValueOrThrow(lowering_ctx.BuildXla());
-  xla::ProgramShape program_shape =
-      GetValueOrThrow(computation.GetProgramShape());
+  XLA_ASSIGN_OR_THROW(xla::XlaComputation computation, lowering_ctx.BuildXla());
+  XLA_ASSIGN_OR_THROW(xla::ProgramShape program_shape,
+                      computation.GetProgramShape());
   xla::Shape shape = MakeShapeWithDeviceLayout(
       program_shape.result(), static_cast<XlaDeviceType>(device.type()));
 
@@ -295,17 +295,20 @@ std::vector<torch_xla::runtime::ComputationClient::DataPtr> Execute(
           std::move(instances));
 
   torch_xla::runtime::ComputationClient::ExecuteComputationOptions options;
-  return GetValueOrThrow(
+  XLA_ASSIGN_OR_THROW(
+      std::vector<runtime::ComputationClient::DataPtr> outputs,
       torch_xla::runtime::GetComputationClientOrDie()->ExecuteComputation(
           *computations.front(),
           UnwrapXlaData(lowering_ctx.GetParametersData()), device.toString(),
           options));
+  return outputs;
 }
 
 std::vector<at::Tensor> Fetch(
     absl::Span<const torch_xla::runtime::ComputationClient::DataPtr>
         device_data) {
-  std::vector<xla::Literal> literals = GetValueOrThrow(
+  XLA_ASSIGN_OR_THROW(
+      std::vector<xla::Literal> literals,
       runtime::GetComputationClientOrDie()->TransferFromDevice(device_data));
   std::vector<at::Tensor> tensors;
   for (auto& literal : literals) {

--- a/test/cpp/test_aten_xla_tensor_1.cpp
+++ b/test/cpp/test_aten_xla_tensor_1.cpp
@@ -27,7 +27,7 @@ TEST_F(AtenXlaTensorTest, TestStorage) {
   torch::Tensor a = torch::tensor({0.0});
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor xla_a = CopyToDevice(a, device);
-    XLATensorPtr xla_tensor_a = GetValueOrThrow(bridge::GetXlaTensor(xla_a));
+    XLA_ASSIGN_OR_THROW(XLATensorPtr xla_tensor_a, bridge::GetXlaTensor(xla_a));
     EXPECT_EQ(xla_a.device(), xla_tensor_a->Storage().device());
     AllClose(a, xla_a);
   });

--- a/test/cpp/test_tensor.cpp
+++ b/test/cpp/test_tensor.cpp
@@ -101,8 +101,8 @@ TEST_F(TensorTest, TestAdd) {
   at::Tensor c = a.add(b, 1.0);
 
   ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-    XLATensorPtr dev_a = GetValueOrThrow(XLATensor::Create(a, device));
-    XLATensorPtr dev_b = GetValueOrThrow(XLATensor::Create(b, device));
+    XLA_ASSIGN_OR_THROW(XLATensorPtr dev_a, XLATensor::Create(a, device));
+    XLA_ASSIGN_OR_THROW(XLATensorPtr dev_b, XLATensor::Create(b, device));
     XLATensorPtr dev_c = tensor_methods::add(dev_a, dev_b, 1.0);
 
     AllClose(c, dev_c);
@@ -121,8 +121,8 @@ TEST_F(TensorTest, TestIntegerAdd) {
           at::isIntegralType(type) ? at::Scalar(int64_t(1)) : at::Scalar(1.0);
       at::Tensor c = a.add(b, one);
 
-      XLATensorPtr dev_a = GetValueOrThrow(XLATensor::Create(a, device));
-      XLATensorPtr dev_b = GetValueOrThrow(XLATensor::Create(b, device));
+      XLA_ASSIGN_OR_THROW(XLATensorPtr dev_a, XLATensor::Create(a, device));
+      XLA_ASSIGN_OR_THROW(XLATensorPtr dev_b, XLATensor::Create(b, device));
       XLATensorPtr dev_c = tensor_methods::add(dev_a, dev_b, one);
 
       EXPECT_TRUE(EqualValuesNoElementTypeCheck(
@@ -135,7 +135,8 @@ TEST_F(TensorTest, TestSize) {
   at::Tensor input = at::rand({2, 1, 4, 6}, at::TensorOptions(at::kFloat));
   int rank = input.dim();
   ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-    XLATensorPtr dev_input = GetValueOrThrow(XLATensor::Create(input, device));
+    XLA_ASSIGN_OR_THROW(XLATensorPtr dev_input,
+                        XLATensor::Create(input, device));
     for (int dim = -rank; dim < rank; ++dim) {
       EXPECT_EQ(input.size(dim), dev_input->size(dim));
     }
@@ -151,10 +152,10 @@ TEST_F(TensorTest, TestRrelu) {
       at::Tensor noise = at::zeros_like(input);
       at::Tensor output =
           at::rrelu_with_noise(input, noise, lower, upper, training);
-      XLATensorPtr dev_input =
-          GetValueOrThrow(XLATensor::Create(input, device));
-      XLATensorPtr dev_noise =
-          GetValueOrThrow(XLATensor::Create(noise, device));
+      XLA_ASSIGN_OR_THROW(XLATensorPtr dev_input,
+                          XLATensor::Create(input, device));
+      XLA_ASSIGN_OR_THROW(XLATensorPtr dev_noise,
+                          XLATensor::Create(noise, device));
       XLATensorPtr dev_outputs = tensor_methods::rrelu_with_noise(
           dev_input, dev_noise, lower, upper, training);
       AllClose(output, dev_outputs);
@@ -169,7 +170,8 @@ TEST_F(TensorTest, TestThreshold) {
   float value = 20;
   at::Tensor output = at::threshold(input, threshold, value);
   ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-    XLATensorPtr dev_input = GetValueOrThrow(XLATensor::Create(input, device));
+    XLA_ASSIGN_OR_THROW(XLATensorPtr dev_input,
+                        XLATensor::Create(input, device));
     XLATensorPtr dev_output =
         tensor_methods::threshold(dev_input, threshold, value);
     AllClose(output, dev_output);
@@ -187,10 +189,11 @@ TEST_F(TensorTest, TestAddMatMul) {
   at::Tensor bias = at::rand({labels}, at::TensorOptions(at::kFloat));
   at::Tensor output = at::addmm(bias, input, weight);
   ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-    XLATensorPtr dev_input = GetValueOrThrow(XLATensor::Create(input, device));
-    XLATensorPtr dev_weight =
-        GetValueOrThrow(XLATensor::Create(weight, device));
-    XLATensorPtr dev_bias = GetValueOrThrow(XLATensor::Create(bias, device));
+    XLA_ASSIGN_OR_THROW(XLATensorPtr dev_input,
+                        XLATensor::Create(input, device));
+    XLA_ASSIGN_OR_THROW(XLATensorPtr dev_weight,
+                        XLATensor::Create(weight, device));
+    XLA_ASSIGN_OR_THROW(XLATensorPtr dev_bias, XLATensor::Create(bias, device));
     XLATensorPtr dev_output =
         tensor_methods::addmm(dev_input, dev_weight, dev_bias);
     AllClose(output, dev_output);
@@ -201,7 +204,8 @@ TEST_F(TensorTest, TestTranspose) {
   at::Tensor input = at::rand({2, 3}, at::TensorOptions(at::kFloat));
   at::Tensor output = at::transpose(input, 0, 1);
   ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-    XLATensorPtr dev_input = GetValueOrThrow(XLATensor::Create(input, device));
+    XLA_ASSIGN_OR_THROW(XLATensorPtr dev_input,
+                        XLATensor::Create(input, device));
     XLATensorPtr dev_output = tensor_methods::transpose(dev_input, 0, 1);
     AllClose(output, dev_output);
   });
@@ -211,7 +215,8 @@ TEST_F(TensorTest, TestView) {
   at::Tensor input = at::rand({32, 20, 4, 4}, at::TensorOptions(at::kFloat));
   at::Tensor output = input.view({-1, 320});
   ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-    XLATensorPtr dev_input = GetValueOrThrow(XLATensor::Create(input, device));
+    XLA_ASSIGN_OR_THROW(XLATensorPtr dev_input,
+                        XLATensor::Create(input, device));
     XLATensorPtr dev_output = tensor_methods::view(dev_input, {-1, 320});
     AllClose(output, dev_output);
   });
@@ -292,8 +297,8 @@ TEST_F(TensorTest, TestMaxPool2D) {
                          /*padding=*/{padding, padding}, /*dilation=*/{1, 1},
                          /*ceil_mode=*/false);
       ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-        XLATensorPtr dev_input =
-            GetValueOrThrow(XLATensor::Create(input, device));
+        XLA_ASSIGN_OR_THROW(XLATensorPtr dev_input,
+                            XLATensor::Create(input, device));
         auto dev_output = tensor_methods::max_pool_nd(
             dev_input,
             /*spatial_dim_count=*/2,
@@ -317,8 +322,8 @@ TEST_F(TensorTest, TestMaxPool2DNonSquare) {
           /*padding=*/{padding, padding + 1}, /*dilation=*/{1, 1},
           /*ceil_mode=*/false);
       ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-        XLATensorPtr dev_input =
-            GetValueOrThrow(XLATensor::Create(input, device));
+        XLA_ASSIGN_OR_THROW(XLATensorPtr dev_input,
+                            XLATensor::Create(input, device));
         auto dev_output = tensor_methods::max_pool_nd(
             dev_input,
             /*spatial_dim_count=*/2,
@@ -346,8 +351,8 @@ TEST_F(TensorTest, TestAvgPool2D) {
                            /*ceil_mode=*/false, count_include_pad,
                            /*divisor_override=*/std::nullopt);
         ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-          XLATensorPtr dev_input =
-              GetValueOrThrow(XLATensor::Create(input, device));
+          XLA_ASSIGN_OR_THROW(XLATensorPtr dev_input,
+                              XLATensor::Create(input, device));
           XLATensorPtr dev_output = tensor_methods::avg_pool_nd(
               dev_input,
               /*spatial_dim_count=*/2,
@@ -377,8 +382,8 @@ TEST_F(TensorTest, TestAvgPool2DNonSquare) {
             /*count_include_pad=*/count_include_pad,
             /*divisor_override=*/std::nullopt);
         ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-          XLATensorPtr dev_input =
-              GetValueOrThrow(XLATensor::Create(input, device));
+          XLA_ASSIGN_OR_THROW(XLATensorPtr dev_input,
+                              XLATensor::Create(input, device));
           XLATensorPtr dev_output = tensor_methods::avg_pool_nd(
               dev_input,
               /*spatial_dim_count=*/2,
@@ -416,20 +421,20 @@ TEST_F(TensorTest, TestBatchNorm1D) {
           /*running_mean=*/running_mean, /*running_var=*/running_var,
           /*training=*/training, /*momentum=*/momentum, /*eps=*/eps);
       ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-        XLATensorPtr xla_input =
-            GetValueOrThrow(XLATensor::Create(input, device));
-        XLATensorPtr xla_weight =
-            undef_weight_bias
-                ? XLATensorPtr()
-                : GetValueOrThrow(XLATensor::Create(weight, device));
-        XLATensorPtr xla_bias =
-            undef_weight_bias
-                ? XLATensorPtr()
-                : GetValueOrThrow(XLATensor::Create(bias, device));
-        XLATensorPtr xla_running_mean =
-            GetValueOrThrow(XLATensor::Create(running_mean, device));
-        XLATensorPtr xla_running_var =
-            GetValueOrThrow(XLATensor::Create(running_var, device));
+        XLA_ASSIGN_OR_THROW(XLATensorPtr xla_input,
+                            XLATensor::Create(input, device));
+        XLATensorPtr xla_weight;
+        if (!undef_weight_bias) {
+          XLA_ASSIGN_OR_THROW(xla_weight, XLATensor::Create(weight, device));
+        }
+        XLATensorPtr xla_bias;
+        if (!undef_weight_bias) {
+          XLA_ASSIGN_OR_THROW(xla_bias, XLATensor::Create(bias, device));
+        }
+        XLA_ASSIGN_OR_THROW(XLATensorPtr xla_running_mean,
+                            XLATensor::Create(running_mean, device));
+        XLA_ASSIGN_OR_THROW(XLATensorPtr xla_running_var,
+                            XLATensor::Create(running_var, device));
         auto xla_output = tensor_methods::native_batch_norm(
             /*input=*/xla_input, /*weight=*/xla_weight, /*bias=*/xla_bias,
             /*running_mean=*/xla_running_mean, /*running_var=*/xla_running_var,
@@ -486,14 +491,14 @@ TEST_F(TensorTest, TestConv2D) {
                     /*output_padding=*/{output_padding, output_padding},
                     /*groups=*/groups, false, false, false);
                 ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-                  XLATensorPtr dev_input =
-                      GetValueOrThrow(XLATensor::Create(input, device));
-                  XLATensorPtr dev_weight =
-                      GetValueOrThrow(XLATensor::Create(weight, device));
+                  XLA_ASSIGN_OR_THROW(XLATensorPtr dev_input,
+                                      XLATensor::Create(input, device));
+                  XLA_ASSIGN_OR_THROW(XLATensorPtr dev_weight,
+                                      XLATensor::Create(weight, device));
                   XLATensorPtr dev_output;
                   if (with_bias) {
-                    XLATensorPtr dev_bias =
-                        GetValueOrThrow(XLATensor::Create(bias, device));
+                    XLA_ASSIGN_OR_THROW(XLATensorPtr dev_bias,
+                                        XLATensor::Create(bias, device));
                     dev_output = tensor_methods::convolution_overrideable(
                         dev_input, dev_weight, dev_bias,
                         /*stride=*/{stride, stride},
@@ -558,14 +563,14 @@ TEST_F(TensorTest, TestConv2DNonSquare) {
                     /*groups=*/groups, false, false, false);
 
                 ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-                  XLATensorPtr dev_input =
-                      GetValueOrThrow(XLATensor::Create(input, device));
-                  XLATensorPtr dev_weight =
-                      GetValueOrThrow(XLATensor::Create(weight, device));
+                  XLA_ASSIGN_OR_THROW(XLATensorPtr dev_input,
+                                      XLATensor::Create(input, device));
+                  XLA_ASSIGN_OR_THROW(XLATensorPtr dev_weight,
+                                      XLATensor::Create(weight, device));
                   XLATensorPtr dev_output;
                   if (with_bias) {
-                    XLATensorPtr dev_bias =
-                        GetValueOrThrow(XLATensor::Create(bias, device));
+                    XLA_ASSIGN_OR_THROW(XLATensorPtr dev_bias,
+                                        XLATensor::Create(bias, device));
                     dev_output = tensor_methods::convolution_overrideable(
                         dev_input, dev_weight, dev_bias,
                         /*stride=*/{stride, stride + 1},
@@ -634,14 +639,14 @@ TEST_F(TensorTest, TestConv3D) {
                     {output_padding, output_padding, output_padding},
                     /*groups=*/groups, false, false, false);
                 ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-                  XLATensorPtr dev_input =
-                      GetValueOrThrow(XLATensor::Create(input, device));
-                  XLATensorPtr dev_weight =
-                      GetValueOrThrow(XLATensor::Create(weight, device));
+                  XLA_ASSIGN_OR_THROW(XLATensorPtr dev_input,
+                                      XLATensor::Create(input, device));
+                  XLA_ASSIGN_OR_THROW(XLATensorPtr dev_weight,
+                                      XLATensor::Create(weight, device));
                   XLATensorPtr dev_output;
                   if (with_bias) {
-                    XLATensorPtr dev_bias =
-                        GetValueOrThrow(XLATensor::Create(bias, device));
+                    XLA_ASSIGN_OR_THROW(XLATensorPtr dev_bias,
+                                        XLATensor::Create(bias, device));
                     dev_output = tensor_methods::convolution_overrideable(
                         dev_input, dev_weight, dev_bias,
                         /*stride=*/{stride, stride, stride},
@@ -709,15 +714,14 @@ TEST_F(TensorTest, TestConv3D) {
 //                     {output_padding, output_padding + 1, output_padding},
 //                     /*groups=*/groups, false, false, false);
 //                 ForEachDevice([&](const torch::lazy::BackendDevice& device) {
-//                   XLATensorPtr dev_input =
-//                   GetValueOrThrow(XLATensor::Create(input, device));
-//                   XLATensorPtr dev_weight =
-//                   GetValueOrThrow(XLATensor::Create(weight, device);
-//                   XLATensorPtr dev_output;
-//                   if (with_bias) {
-//                     XLATensorPtr dev_bias =
-//                     GetValueOrThrow(XLATensor::Create(bias, device));
-//                     dev_output = tensor_methods::convolution_overrideable(
+//                   XLA_ASSIGN_OR_THROW(XLATensorPtr dev_input,
+//                   XLATensor::Create(input, device));
+//                   XLA_ASSIGN_OR_THROW(XLATensorPtr dev_weight,
+//                   XLATensor::Create(weight, device)); XLATensorPtr
+//                   dev_output; if (with_bias) {
+//                     XLA_ASSIGN_OR_THROW(XLATensorPtr dev_bias,
+//                     XLATensor::Create(bias, device)); dev_output =
+//                     tensor_methods::convolution_overrideable(
 //                         dev_input, dev_weight, dev_bias,
 //                         /*stride=*/{stride, stride + 1, stride + 1},
 //                         /*padding=*/{padding, padding + 1, padding + 1},

--- a/test/cpp/test_xla_backend_intf.cpp
+++ b/test/cpp/test_xla_backend_intf.cpp
@@ -53,7 +53,8 @@ xla::XlaComputation CreateAddComputation(const xla::Shape& shape) {
   xla::XlaOp x = xla::Parameter(&builder, 0, shape, "x");
   xla::XlaOp y = xla::Parameter(&builder, 1, shape, "y");
   xla::XlaOp sum = xla::Add(x, y);
-  return GetValueOrThrow(builder.Build());
+  XLA_ASSIGN_OR_THROW(xla::XlaComputation add_computation, builder.Build());
+  return add_computation;
 }
 
 TEST(XLABackendTest, TestE2E) {

--- a/test/cpp/test_xla_sharding.cpp
+++ b/test/cpp/test_xla_sharding.cpp
@@ -28,8 +28,8 @@ namespace {
 bool XlaDataValuesEqual(torch::lazy::BackendDataPtr a,
                         torch::lazy::BackendDataPtr b,
                         at::ScalarType element_type) {
-  std::vector<at::Tensor> tensors =
-      GetValueOrThrow(XlaDataToTensors({a, b}, {element_type, element_type}));
+  XLA_ASSIGN_OR_THROW(std::vector<at::Tensor> tensors,
+                      XlaDataToTensors({a, b}, {element_type, element_type}));
   return TensorCompare(tensors[0], tensors[1]);
 }
 }  // namespace
@@ -385,8 +385,8 @@ TEST_F(XLAShardingTest, PrepareOutputShardingPropagation) {
   auto x = xla::Parameter(&b, 0, shape, "p0");
   b.ClearSharding();
   auto y = xla::Add(x, xla::ConstantR0<float>(&b, 3));
-  xla::XlaComputation xla_computation =
-      GetValueOrThrow(b.Build(/*remove_dynamic_dimensions=*/false));
+  XLA_ASSIGN_OR_THROW(xla::XlaComputation xla_computation,
+                      b.Build(/*remove_dynamic_dimensions=*/false));
   std::vector<torch_xla::runtime::ComputationClient::CompileInstance> instances;
   instances.push_back({std::move(xla_computation),
                        bridge::GetDefaultDevice()->toString(),


### PR DESCRIPTION
Follow-up: #9588 and #9580
Target: `test` directory

In summary, this PR:

- Replaces all calls to `OkOrThrow()` and `GetValueOrThrow()` (that throws an exception without source location information of the *"throw-site"*) with the macros `XLA_THROW_IF_ERROR()` and `XLA_ASSIGN_OR_THROW()`.
- Corresponds to the fine-grained set of PRs that came from breaking down PR #9580
- Focuses on the `test` directory, replacing every use (except for the ones in _test_status_common.h_) of those, now deprecated, functions by the newly introduced macros.