### PR TITLE
`runtime`: Use new macros for throwing exceptions.

### DIFF
--- a/torch_xla/csrc/runtime/computation_client.h
+++ b/torch_xla/csrc/runtime/computation_client.h
@@ -116,9 +116,9 @@ class ComputationClient {
         : name_(name),
           computation_(std::move(computation)),
           devices_(std::move(devices)) {
-      program_shape_ = GetValueOrThrow(computation_.GetProgramShape());
+      XLA_ASSIGN_OR_THROW(program_shape_, computation_.GetProgramShape());
       const xla::HloModuleProto& proto = computation_.proto();
-      hash_ = GetValueOrThrow(ComputeHash(proto, name));
+      XLA_ASSIGN_OR_THROW(hash_, ComputeHash(proto, name));
     }
 
     Computation(std::string name, xla::XlaComputation computation,
@@ -191,7 +191,8 @@ class ComputationClient {
 
     const std::string to_string() const override {
       xla::HloModuleConfig hlo_config(program_shape());
-      std::unique_ptr<xla::HloModule> module = GetValueOrThrow(
+      XLA_ASSIGN_OR_THROW(
+          std::unique_ptr<xla::HloModule> module,
           xla::HloModule::CreateFromProto(computation().proto(), hlo_config));
       return module->ToString();
     }

--- a/torch_xla/csrc/runtime/ifrt_computation_client.cpp
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.cpp
@@ -177,7 +177,8 @@ void IfrtComputationClient::InitializeCoordinator(int global_rank,
                                                   std::string port) {
   XLA_CHECK(coordinator_ == nullptr)
       << "Can only initialize the XlaCoordinator once.";
-  coordinator_ = GetValueOrThrow(
+  XLA_ASSIGN_OR_THROW(
+      coordinator_,
       XlaCoordinator::Create(global_rank, world_size, master_addr, port));
 }
 
@@ -395,10 +396,10 @@ tsl::RCReference<xla::ifrt::Array> IfrtComputationClient::ReplicateShardedData(
   auto instruction = XlaBuilderFriend::GetInstruction(y);
   *instruction->mutable_sharding() = xla::HloSharding::Replicate().ToProto();
 
-  xla::XlaComputation computation =
-      GetValueOrThrow(builder.Build(/*remove_dynamic_dimensions=*/false));
-  xla::ProgramShape program_shape =
-      GetValueOrThrow(computation.GetProgramShape());
+  XLA_ASSIGN_OR_THROW(xla::XlaComputation computation,
+                      builder.Build(/*remove_dynamic_dimensions=*/false));
+  XLA_ASSIGN_OR_THROW(xla::ProgramShape program_shape,
+                      computation.GetProgramShape());
 
   std::string device = GetDefaultDevice();
   std::vector<torch_xla::runtime::ComputationClient::CompileInstance> instances;
@@ -417,8 +418,9 @@ tsl::RCReference<xla::ifrt::Array> IfrtComputationClient::ReplicateShardedData(
   torch_xla::runtime::ComputationClient::ExecuteReplicatedOptions
       execute_options;
 
-  auto sharded_results = GetValueOrThrow(ExecuteReplicated(
-      *computations.front(), {{handle}}, GetLocalDevices(), execute_options));
+  XLA_ASSIGN_OR_THROW(std::vector<ComputationClient::DataPtr> sharded_results,
+                      ExecuteReplicated(*computations.front(), {{handle}},
+                                        GetLocalDevices(), execute_options));
   auto replicated_output =
       std::dynamic_pointer_cast<IfrtData>(sharded_results[0])
           ->buffer->FullyReplicatedShard(
@@ -516,14 +518,17 @@ std::vector<ComputationClient::ComputationPtr> IfrtComputationClient::Compile(
         mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
     torch_xla::ConvertHloToStableHlo(instance.computation.mutable_proto(),
                                      &mlir_module);
-    std::shared_ptr<xla::ifrt::LoadedExecutable> executable =
-        GetValueOrThrow(client_->GetDefaultCompiler()->CompileAndLoad(
+    XLA_ASSIGN_OR_THROW(
+        std::shared_ptr<xla::ifrt::LoadedExecutable> executable,
+        client_->GetDefaultCompiler()->CompileAndLoad(
             std::make_unique<xla::ifrt::HloProgram>(mlir_module),
             std::make_unique<xla::ifrt::XlaCompileOptions>(compile_options,
                                                            devices_list)));
     StableHloCompileCounter()->AddValue(1);
 
-    const auto& hlo_modules = GetValueOrThrow(executable->GetHloModules());
+    XLA_ASSIGN_OR_THROW(
+        const std::vector<std::shared_ptr<xla::HloModule>>& hlo_modules,
+        executable->GetHloModules());
 
     std::shared_ptr<IfrtComputation> ifrt_computation =
         std::make_shared<IfrtComputation>(

--- a/torch_xla/csrc/runtime/ifrt_computation_client_test.cpp
+++ b/torch_xla/csrc/runtime/ifrt_computation_client_test.cpp
@@ -36,7 +36,8 @@ absl::StatusOr<xla::XlaComputation> MakeComputation() {
 TEST(PjRtComputationClientTest, Init) {
   // Get a CPU client.
   tsl::setenv("PJRT_DEVICE", "CPU", true);
-  auto client = GetValueOrThrow(IfrtComputationClient::Create());
+  XLA_ASSIGN_OR_THROW(std::unique_ptr<IfrtComputationClient> client,
+                      IfrtComputationClient::Create());
   std::string device = client->GetDefaultDevice();
 
   // Compose a computation.
@@ -64,14 +65,16 @@ TEST(PjRtComputationClientTest, Init) {
       std::make_shared<LiteralSource>(std::move(literal_y), device)};
 
   // Execute the graph.
-  std::vector<ComputationClient::DataPtr> results =
-      GetValueOrThrow(client->ExecuteReplicated(
+  XLA_ASSIGN_OR_THROW(
+      std::vector<ComputationClient::DataPtr> results,
+      client->ExecuteReplicated(
           *computations[0], client->TransferToDevice(absl::MakeConstSpan(args)),
           {device}, options));
 
   // Copy the output from device back to host and assert correctness..
   ASSERT_EQ(results.size(), 1);
-  auto result_literals = GetValueOrThrow(client->TransferFromDevice(results));
+  XLA_ASSIGN_OR_THROW(std::vector<xla::Literal> result_literals,
+                      client->TransferFromDevice(results));
   ASSERT_THAT(result_literals, ::testing::SizeIs(1));
   EXPECT_TRUE(xla::LiteralTestUtil::Equal(
       xla::LiteralUtil::CreateR2<float>({{6.0f, 8.0f}, {10.0f, 12.0f}}),

--- a/torch_xla/csrc/runtime/pjrt_computation_client_test.cpp
+++ b/torch_xla/csrc/runtime/pjrt_computation_client_test.cpp
@@ -25,7 +25,7 @@ class PjRtComputationClientTest : public ::testing::Test {
   PjRtComputationClientTest() {
     // Get a CPU client.
     tsl::setenv("PJRT_DEVICE", "CPU", true);
-    client_ = GetValueOrThrow(PjRtComputationClient::Create());
+    XLA_ASSIGN_OR_THROW(client_, PjRtComputationClient::Create());
     device_ = client_->GetDefaultDevice();
   }
 
@@ -114,15 +114,16 @@ TEST_F(PjRtComputationClientTest, Init) {
       std::make_shared<LiteralSource>(std::move(literal_y), device_)};
 
   // Execute the graph.
-  std::vector<ComputationClient::DataPtr> results =
-      GetValueOrThrow(client_->ExecuteComputation(
-          *computations[0],
-          client_->TransferToDevice(absl::MakeConstSpan(args)), device_,
-          options));
+  XLA_ASSIGN_OR_THROW(std::vector<ComputationClient::DataPtr> results,
+                      client_->ExecuteComputation(
+                          *computations[0],
+                          client_->TransferToDevice(absl::MakeConstSpan(args)),
+                          device_, options));
 
   // Copy the output from device back to host and assert correctness.
   ASSERT_EQ(results.size(), 1);
-  auto result_literals = GetValueOrThrow(client_->TransferFromDevice(results));
+  XLA_ASSIGN_OR_THROW(std::vector<xla::Literal> result_literals,
+                      client_->TransferFromDevice(results));
   ASSERT_THAT(result_literals, ::testing::SizeIs(1));
   EXPECT_TRUE(xla::LiteralTestUtil::Equal(
       xla::LiteralUtil::CreateR2<float>({{6.0f, 8.0f}, {10.0f, 12.0f}}),

--- a/torch_xla/csrc/runtime/runtime.cpp
+++ b/torch_xla/csrc/runtime/runtime.cpp
@@ -61,7 +61,8 @@ const absl::StatusOr<ComputationClient * absl_nonnull>& GetComputationClient() {
 }
 
 ComputationClient* absl_nonnull GetComputationClientOrDie() {
-  return GetValueOrThrow(GetComputationClient());
+  XLA_ASSIGN_OR_THROW(ComputationClient * client, GetComputationClient());
+  return client;
 }
 
 ComputationClient* GetComputationClientIfInitialized() {

--- a/torch_xla/csrc/runtime/tensor_source.h
+++ b/torch_xla/csrc/runtime/tensor_source.h
@@ -31,7 +31,7 @@ class TensorSource {
 
   virtual std::vector<int64_t> byte_strides() const {
     std::vector<int64_t> byte_strides(shape().dimensions_size());
-    OkOrThrow(
+    XLA_THROW_IF_ERROR(
         xla::ShapeUtil::ByteStrides(shape(), absl::MakeSpan(byte_strides)));
     return byte_strides;
   }

--- a/torch_xla/csrc/runtime/xla_util_test.cpp
+++ b/torch_xla/csrc/runtime/xla_util_test.cpp
@@ -121,10 +121,10 @@ TEST(XlaUtilTest, XlaToHlo) {
 
 TEST(XlaUtilTest, TestDeterministicModuleProtoSerializationEmptyProto) {
   xla::HloModuleProto empty_proto;
-  auto result =
-      GetValueOrThrow(GetDeterministicSerializedModuleProto(empty_proto));
+  XLA_ASSIGN_OR_THROW(std::string serialized_result,
+                      GetDeterministicSerializedModuleProto(empty_proto));
   // Verify that the result is an empty string
-  EXPECT_TRUE(result.empty());
+  EXPECT_TRUE(serialized_result.empty());
 }
 
 TEST(XlaUtilTest, TestDeterministicModuleProtoSerialization) {
@@ -250,7 +250,8 @@ TEST(XlaUtilTest, TestDeterministicModuleProtoSerialization) {
         }
       }
     }
-    std::string serialized_proto = GetValueOrThrow(
+    XLA_ASSIGN_OR_THROW(
+        std::string serialized_proto,
         GetDeterministicSerializedModuleProto(hlo_module_proto));
     return torch::lazy::Hash(serialized_proto);
   };


### PR DESCRIPTION
Follow-up: #9588 and #9580
Target: `torch_xla/csrc/runtime` directory

In summary, this PR:

- Replaces all calls to `OkOrThrow()` and `GetValueOrThrow()` (that throws an exception without source location information of the *"throw-site"*) with the macros `XLA_THROW_IF_ERROR()` and `XLA_ASSIGN_OR_THROW()`.
- Corresponds to the fine-grained set of PRs that came from breaking down PR #9580
- Focuses on the `torch_xla/csrc/runtime` directory, replacing every use of those, now deprecated, functions by the newly introduced macros.