### PR TITLE
Remove functions that throw status error.

### DIFF
--- a/torch_xla/csrc/status.cpp
+++ b/torch_xla/csrc/status.cpp
@@ -129,13 +129,6 @@ void status_internal::ThrowStatusError(const absl::Status& status,
                                   LineBreakIfCppStacktracesEnabled()));
 }
 
-void OkOrThrow(const absl::Status& status) {
-  TORCH_CHECK(status.ok(), absl::StrCat(BuildStatusErrorMessage(status),
-                                        LineBreakIfCppStacktracesEnabled()));
-}
-
-void GetValueOrThrow(const absl::Status& status) { OkOrThrow(status); }
-
 void status_internal::OkOrDie(const absl::Status& status, const char* file,
                               const int32_t line, const char* function,
                               std::string_view message) {

--- a/torch_xla/csrc/status.h
+++ b/torch_xla/csrc/status.h
@@ -297,35 +297,6 @@ void OkOrDie(const absl::Status& status, const char* file, const int32_t line,
 // It doesn't add a trailing line break.
 std::string BuildStatusErrorMessage(const absl::Status& status);
 
-// Throws an exception if `status` has a non-ok code.
-//
-// Ideally, this function should be used only used in the project's
-// boundary, e.g. when we need to throw an exception for the user to see.
-void OkOrThrow(const absl::Status& status);
-
-// Either returns the value `status` holds, if it's an ok-status, or throw an
-// exception from its error status.
-template <class T>
-T& GetValueOrThrow(absl::StatusOr<T>& status) {
-  OkOrThrow(status.status());
-  return status.value();
-}
-
-template <class T>
-const T& GetValueOrThrow(const absl::StatusOr<T>& status) {
-  OkOrThrow(status.status());
-  return status.value();
-}
-
-template <class T>
-T GetValueOrThrow(absl::StatusOr<T>&& status) {
-  OkOrThrow(status.status());
-  return std::move(status).value();
-}
-
-// `GetValueOrThrow` overload for `Status`.
-void GetValueOrThrow(const absl::Status& status);
-
 }  // namespace torch_xla
 
 #endif  // XLA_TORCH_XLA_CSRC_STATUS_H_


### PR DESCRIPTION
Follow-up: #9580

This PR finalizes the work that started with #9580 for replacing `OkOrThrow()` and `GetValueOrThrow()` in favor of the macros introduced in #9588 (which were also part of that work). In summary, is the last one after:

- #9580: initial work that was broken down into the PRs below
- #9588: actual first PR merged
- #9590 
- #9591 
- #9592
- #9593
- #9594
- #9595
- #9596 
- #9602: last PR

**Key Changes:**

- (`test/cpp/test_status_common.h`) Remove tests for `OkOrThrow()` and `GetValueOrThrow()`
- (`torch_xla/csrc/status.{h,cpp}`) Remove the implementation of those functions    