### PR TITLE
Replace `GetComputationClientOrDie()` with `GetComputationClient()` (part 1).

### DIFF
--- a/test/cpp/cpp_test_util.cpp
+++ b/test/cpp/cpp_test_util.cpp
@@ -222,7 +222,7 @@ void WithAllDevices(
     const std::function<void(const std::vector<torch::lazy::BackendDevice>&,
                              const std::vector<torch::lazy::BackendDevice>&)>&
         devfn) {
-  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                       runtime::GetComputationClient());
   for (auto device_type : device_types) {
     std::vector<torch::lazy::BackendDevice> devices;
@@ -280,7 +280,7 @@ std::vector<torch_xla::runtime::ComputationClient::DataPtr> Execute(
   XLA_ASSIGN_OR_THROW(xla::XlaComputation computation, lowering_ctx.BuildXla());
   XLA_ASSIGN_OR_THROW(xla::ProgramShape program_shape,
                       computation.GetProgramShape());
-  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                       runtime::GetComputationClient());
   xla::Shape shape = MakeShapeWithDeviceLayout(
       program_shape.result(), static_cast<XlaDeviceType>(device.type()));
@@ -306,7 +306,7 @@ std::vector<torch_xla::runtime::ComputationClient::DataPtr> Execute(
 std::vector<at::Tensor> Fetch(
     absl::Span<const torch_xla::runtime::ComputationClient::DataPtr>
         device_data) {
-  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                       runtime::GetComputationClient());
   XLA_ASSIGN_OR_THROW(std::vector<xla::Literal> literals,
                       client->TransferFromDevice(device_data));

--- a/test/cpp/cpp_test_util.cpp
+++ b/test/cpp/cpp_test_util.cpp
@@ -222,18 +222,19 @@ void WithAllDevices(
     const std::function<void(const std::vector<torch::lazy::BackendDevice>&,
                              const std::vector<torch::lazy::BackendDevice>&)>&
         devfn) {
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                      runtime::GetComputationClient());
   for (auto device_type : device_types) {
     std::vector<torch::lazy::BackendDevice> devices;
     std::vector<torch::lazy::BackendDevice> all_devices;
-    for (const auto& device_str :
-         torch_xla::runtime::GetComputationClientOrDie()->GetLocalDevices()) {
+
+    for (const auto& device_str : client->GetLocalDevices()) {
       torch::lazy::BackendDevice device = ParseDeviceString(device_str);
       if (device.type() == device_type.type) {
         devices.push_back(device);
       }
     }
-    for (const auto& device_str :
-         torch_xla::runtime::GetComputationClientOrDie()->GetAllDevices()) {
+    for (const auto& device_str : client->GetAllDevices()) {
       torch::lazy::BackendDevice device = ParseDeviceString(device_str);
       if (device.type() == device_type.type) {
         all_devices.push_back(device);
@@ -279,37 +280,36 @@ std::vector<torch_xla::runtime::ComputationClient::DataPtr> Execute(
   XLA_ASSIGN_OR_THROW(xla::XlaComputation computation, lowering_ctx.BuildXla());
   XLA_ASSIGN_OR_THROW(xla::ProgramShape program_shape,
                       computation.GetProgramShape());
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                      runtime::GetComputationClient());
   xla::Shape shape = MakeShapeWithDeviceLayout(
       program_shape.result(), static_cast<XlaDeviceType>(device.type()));
 
   std::vector<torch_xla::runtime::ComputationClient::CompileInstance> instances;
-  instances.push_back(
-      {std::move(computation), device.toString(),
-       torch_xla::runtime::GetComputationClientOrDie()->GetCompilationDevices(
-           device.toString(), {}),
-       &shape});
+  instances.push_back({std::move(computation), device.toString(),
+                       client->GetCompilationDevices(device.toString(), {}),
+                       &shape});
 
   std::vector<
       std::shared_ptr<torch_xla::runtime::ComputationClient::Computation>>
-      computations = torch_xla::runtime::GetComputationClientOrDie()->Compile(
-          std::move(instances));
+      computations = client->Compile(std::move(instances));
 
   torch_xla::runtime::ComputationClient::ExecuteComputationOptions options;
-  XLA_ASSIGN_OR_THROW(
-      std::vector<runtime::ComputationClient::DataPtr> outputs,
-      torch_xla::runtime::GetComputationClientOrDie()->ExecuteComputation(
-          *computations.front(),
-          UnwrapXlaData(lowering_ctx.GetParametersData()), device.toString(),
-          options));
+  XLA_ASSIGN_OR_THROW(std::vector<runtime::ComputationClient::DataPtr> outputs,
+                      client->ExecuteComputation(
+                          *computations.front(),
+                          UnwrapXlaData(lowering_ctx.GetParametersData()),
+                          device.toString(), options));
   return outputs;
 }
 
 std::vector<at::Tensor> Fetch(
     absl::Span<const torch_xla::runtime::ComputationClient::DataPtr>
         device_data) {
-  XLA_ASSIGN_OR_THROW(
-      std::vector<xla::Literal> literals,
-      runtime::GetComputationClientOrDie()->TransferFromDevice(device_data));
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                      runtime::GetComputationClient());
+  XLA_ASSIGN_OR_THROW(std::vector<xla::Literal> literals,
+                      client->TransferFromDevice(device_data));
   std::vector<at::Tensor> tensors;
   for (auto& literal : literals) {
     tensors.push_back(MakeTensorFromXlaLiteral(

--- a/test/cpp/test_replication.cpp
+++ b/test/cpp/test_replication.cpp
@@ -48,7 +48,7 @@ void TestSingleReplication(
     instances.emplace_back(CreateCrsComputation(shape), device_str,
                            all_device_strings, &shape);
   }
-  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                       runtime::GetComputationClient());
   std::vector<torch_xla::runtime::ComputationClient::ComputationPtr>
       compiled_computations = client->Compile(std::move(instances));

--- a/test/cpp/test_replication.cpp
+++ b/test/cpp/test_replication.cpp
@@ -48,10 +48,10 @@ void TestSingleReplication(
     instances.emplace_back(CreateCrsComputation(shape), device_str,
                            all_device_strings, &shape);
   }
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                      runtime::GetComputationClient());
   std::vector<torch_xla::runtime::ComputationClient::ComputationPtr>
-      compiled_computations =
-          torch_xla::runtime::GetComputationClientOrDie()->Compile(
-              std::move(instances));
+      compiled_computations = client->Compile(std::move(instances));
 
   std::vector<at::Tensor> tensors;
   for (size_t i = 0; i < device_strings.size(); ++i) {
@@ -66,14 +66,13 @@ void TestSingleReplication(
   torch_xla::runtime::ComputationClient::ExecuteComputationOptions exec_options;
   for (size_t i = 0; i < device_strings.size(); ++i) {
     auto executor = [&, i]() {
-      XLA_ASSIGN_OR_THROW(
-          results[i],
-          torch_xla::runtime::GetComputationClientOrDie()->ExecuteComputation(
-              *compiled_computations[i],
-              {std::dynamic_pointer_cast<
-                  torch_xla::runtime::ComputationClient::Data>(
-                  tensors_data[i])},
-              device_strings[i], exec_options));
+      XLA_ASSIGN_OR_THROW(results[i],
+                          client->ExecuteComputation(
+                              *compiled_computations[i],
+                              {std::dynamic_pointer_cast<
+                                  torch_xla::runtime::ComputationClient::Data>(
+                                  tensors_data[i])},
+                              device_strings[i], exec_options));
       counter.DecrementCount();
     };
     torch_xla::thread::Schedule(std::move(executor));
@@ -81,9 +80,8 @@ void TestSingleReplication(
   counter.Wait();
 
   for (size_t i = 0; i < results.size(); ++i) {
-    XLA_ASSIGN_OR_THROW(
-        std::vector<xla::Literal> literals,
-        runtime::GetComputationClientOrDie()->TransferFromDevice(results[i]));
+    XLA_ASSIGN_OR_THROW(std::vector<xla::Literal> literals,
+                        client->TransferFromDevice(results[i]));
     ASSERT_EQ(literals.size(), 1);
 
     // The result must be the original tensor value, multiplied by the number of

--- a/test/cpp/test_runtime.cpp
+++ b/test/cpp/test_runtime.cpp
@@ -13,9 +13,6 @@ TEST(RuntimeTest, ComputationClientInitialization) {
   // Initialize the ComputationClient.
   // Check all the APIs return the same valid ComputationClient.
 
-  client = GetComputationClientOrDie();
-  ASSERT_NE(client, nullptr);
-
   auto status = GetComputationClient();
   ASSERT_TRUE(status.ok());
 

--- a/test/cpp/test_runtime.cpp
+++ b/test/cpp/test_runtime.cpp
@@ -16,7 +16,7 @@ TEST(RuntimeTest, ComputationClientInitialization) {
   auto status = GetComputationClient();
   ASSERT_TRUE(status.ok());
 
-  EXPECT_EQ(status.value(), client);
+  client = status.value();
   EXPECT_EQ(GetComputationClientIfInitialized(), client);
 }
 

--- a/test/cpp/test_xla_sharding.cpp
+++ b/test/cpp/test_xla_sharding.cpp
@@ -332,16 +332,16 @@ TEST_F(XLAShardingTest, CreateTensorsData) {
   std::vector<torch::lazy::BackendDataPtr> tensors_data =
       CreateTensorsData(tensors, shardings, devices);
 
-  int64_t n_devices =
-      torch_xla::runtime::GetComputationClientOrDie()->GetLocalDevices().size();
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                      runtime::GetComputationClient());
+  int64_t n_devices = client->GetLocalDevices().size();
   if (n_devices > 1) {
     // null sharding is treated as replicated.
     auto xla_data =
         std::dynamic_pointer_cast<torch_xla::runtime::ComputationClient::Data>(
             tensors_data[0]);
     std::vector<torch_xla::runtime::ComputationClient::DataPtr> shards =
-        torch_xla::runtime::GetComputationClientOrDie()->GetDataShards(
-            xla_data);
+        client->GetDataShards(xla_data);
     EXPECT_EQ(shards.size(), n_devices);
     EXPECT_TRUE(xla::Shape::Equal().IgnoreLayout()(xla_data->shape(),
                                                    shards[0]->shape()));
@@ -351,8 +351,7 @@ TEST_F(XLAShardingTest, CreateTensorsData) {
     auto sharded_xla_data =
         std::dynamic_pointer_cast<torch_xla::runtime::ComputationClient::Data>(
             tensors_data[1]);
-    shards = torch_xla::runtime::GetComputationClientOrDie()->GetDataShards(
-        sharded_xla_data);
+    shards = client->GetDataShards(sharded_xla_data);
     EXPECT_EQ(shards.size(), n_devices);
     EXPECT_TRUE(xla::Shape::Equal().IgnoreLayout()(sharded_xla_data->shape(),
                                                    shards[0]->shape()));
@@ -362,8 +361,7 @@ TEST_F(XLAShardingTest, CreateTensorsData) {
     sharded_xla_data =
         std::dynamic_pointer_cast<torch_xla::runtime::ComputationClient::Data>(
             tensors_data[2]);
-    shards = torch_xla::runtime::GetComputationClientOrDie()->GetDataShards(
-        sharded_xla_data);
+    shards = client->GetDataShards(sharded_xla_data);
     EXPECT_EQ(shards.size(), n_devices);
     EXPECT_TRUE(xla::Shape::Equal().IgnoreLayout()(sharded_xla_data->shape(),
                                                    shards[0]->shape()));
@@ -373,8 +371,9 @@ TEST_F(XLAShardingTest, CreateTensorsData) {
 
 TEST_F(XLAShardingTest, PrepareOutputShardingPropagation) {
   xla::Shape shape = xla::ShapeUtil::MakeShape(xla::PrimitiveType::F32, {4, 4});
-  int64_t n_devices =
-      torch_xla::runtime::GetComputationClientOrDie()->GetLocalDevices().size();
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                      runtime::GetComputationClient());
+  int64_t n_devices = client->GetLocalDevices().size();
   xla::Array<int64_t> tile_assignment({1, n_devices});
   tile_assignment.FillIota(0);
   xla::OpSharding tiled = xla::HloSharding::Tile(tile_assignment).ToProto();
@@ -397,15 +396,14 @@ TEST_F(XLAShardingTest, PrepareOutputShardingPropagation) {
 
   std::vector<
       std::shared_ptr<torch_xla::runtime::ComputationClient::Computation>>
-      computations = torch_xla::runtime::GetComputationClientOrDie()->Compile(
-          std::move(instances));
+      computations = client->Compile(std::move(instances));
   torch_xla::runtime::ComputationClient::ComputationPtr computation =
       std::make_shared<torch_xla::runtime::ComputationClient::Computation>(
           "add", std::move(computations[0]->move_computation()));
 
   // Prepare output sharding propagation, expect a sharded output placeholder.
-  std::vector<XLATensorPtr> tensors{XLATensor::Create(
-      torch_xla::runtime::GetComputationClientOrDie()->CreateDataPlaceholder(
+  std::vector<XLATensorPtr> tensors{
+      XLATensor::Create(client->CreateDataPlaceholder(
           bridge::GetDefaultDevice()->toString(), std::move(shape)))};
   std::vector<torch::lazy::BackendDataPtr> data_placeholders;
   std::vector<XLATensor::ShardingSpecPtr> sharding_specs;

--- a/test/cpp/test_xla_sharding.cpp
+++ b/test/cpp/test_xla_sharding.cpp
@@ -332,7 +332,7 @@ TEST_F(XLAShardingTest, CreateTensorsData) {
   std::vector<torch::lazy::BackendDataPtr> tensors_data =
       CreateTensorsData(tensors, shardings, devices);
 
-  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                       runtime::GetComputationClient());
   int64_t n_devices = client->GetLocalDevices().size();
   if (n_devices > 1) {
@@ -371,7 +371,7 @@ TEST_F(XLAShardingTest, CreateTensorsData) {
 
 TEST_F(XLAShardingTest, PrepareOutputShardingPropagation) {
   xla::Shape shape = xla::ShapeUtil::MakeShape(xla::PrimitiveType::F32, {4, 4});
-  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                       runtime::GetComputationClient());
   int64_t n_devices = client->GetLocalDevices().size();
   xla::Array<int64_t> tile_assignment({1, n_devices});

--- a/torch_xla/csrc/tensor_util.cpp
+++ b/torch_xla/csrc/tensor_util.cpp
@@ -551,7 +551,7 @@ torch::lazy::BackendDataPtr TensorToXlaData(
     const torch::lazy::BackendDevice& device) {
   TORCH_LAZY_TIMED("TensorToData");
 
-  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                       runtime::GetComputationClient());
 
   if (static_cast<XlaDeviceType>(device.type()) == XlaDeviceType::SPMD) {
@@ -808,7 +808,7 @@ std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
     return {};
   }
 
-  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                       runtime::GetComputationClient());
 
   // CreateTensorsData should be implicitly replicated to all devices.
@@ -849,7 +849,7 @@ std::vector<torch::lazy::BackendDataPtr> CreateTensorsData(
   XLA_CHECK_EQ(tensors.size(), shardings.size());
   XLA_CHECK_EQ(tensors.size(), devices.size());
 
-  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                       runtime::GetComputationClient());
 
   std::vector<runtime::ComputationClient::DataPtr> handles;
@@ -914,8 +914,8 @@ absl::StatusOr<std::vector<xla::Literal>> ReleaseGilAndTransferData(
     save = PyEval_SaveThread();
   }
 
-  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
-                      runtime::GetComputationClient());
+  XLA_ASSIGN_OR_RETURN(runtime::ComputationClient * absl_nonnull const client,
+                       runtime::GetComputationClient());
   XLA_ASSIGN_OR_RETURN(std::vector<xla::Literal> literals,
                        client->TransferFromDevice(UnwrapXlaData(xla_data)));
 

--- a/torch_xla/csrc/xla_backend_impl.cpp
+++ b/torch_xla/csrc/xla_backend_impl.cpp
@@ -28,8 +28,9 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
     if (!default_device_type_inited_) {
       // bridge::GetDefaultDevice will trigger the runtime device init, should
       // not do it during class init time.
-      XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
-                          runtime::GetComputationClient());
+      XLA_ASSIGN_OR_THROW(
+          runtime::ComputationClient * absl_nonnull const client,
+          runtime::GetComputationClient());
       default_device_type_ =
           std::make_shared<DeviceType>(client->GetDeviceType());
       default_device_type_inited_ = true;

--- a/torch_xla/csrc/xla_backend_impl.cpp
+++ b/torch_xla/csrc/xla_backend_impl.cpp
@@ -28,8 +28,10 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
     if (!default_device_type_inited_) {
       // bridge::GetDefaultDevice will trigger the runtime device init, should
       // not do it during class init time.
-      default_device_type_ = std::make_shared<DeviceType>(
-          runtime::GetComputationClientOrDie()->GetDeviceType());
+      XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                          runtime::GetComputationClient());
+      default_device_type_ =
+          std::make_shared<DeviceType>(client->GetDeviceType());
       default_device_type_inited_ = true;
     }
     return true;
@@ -77,8 +79,10 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
       const torch::lazy::BackendDevice& device,
       const torch::lazy::Shape& shape) const override {
     xla::Shape xla_shape = MakeXlaShapeFromLazyShape(shape, device);
-    return runtime::GetComputationClientOrDie()->CreateDataPlaceholder(
-        device.toString(), std::move(xla_shape));
+    XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                        runtime::GetComputationClient());
+    return client->CreateDataPlaceholder(device.toString(),
+                                         std::move(xla_shape));
   }
 
   torch::lazy::BackendDataPtr GetComputationDataFromNode(
@@ -121,8 +125,9 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
   std::vector<std::string> GetCompilationDevices(
       const std::string& device,
       c10::ArrayRef<std::string> devices) const override {
-    return runtime::GetComputationClientOrDie()->GetCompilationDevices(device,
-                                                                       devices);
+    XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                        runtime::GetComputationClient());
+    return client->GetCompilationDevices(device, devices);
   }
 
   std::vector<torch::lazy::ComputationPtr> Compile(
@@ -155,9 +160,10 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
           torch_xla_computation->get_device_string(),
           {current_device.toString()}, &output_shapes.back()));
     }
+    XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                        runtime::GetComputationClient());
     std::vector<std::shared_ptr<runtime::ComputationClient::Computation>>
-        client_computations = runtime::GetComputationClientOrDie()->Compile(
-            std::move(compile_instances));
+        client_computations = client->Compile(std::move(compile_instances));
     return {client_computations.begin(), client_computations.end()};
   }
 
@@ -165,9 +171,11 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
       torch::lazy::ComputationPtr computation,
       c10::ArrayRef<torch::lazy::BackendDataPtr> arguments,
       const torch::lazy::BackendDevice& device) const override {
+    XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                        runtime::GetComputationClient());
     XLA_ASSIGN_OR_THROW(
         std::vector<runtime::ComputationClient::DataPtr> results,
-        runtime::GetComputationClientOrDie()->ExecuteComputation(
+        client->ExecuteComputation(
             *std::dynamic_pointer_cast<runtime::ComputationClient::Computation>(
                 computation),
             UnwrapXlaData(arguments), device.toString()));

--- a/torch_xla/csrc/xla_backend_impl.cpp
+++ b/torch_xla/csrc/xla_backend_impl.cpp
@@ -28,7 +28,7 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
     if (!default_device_type_inited_) {
       // bridge::GetDefaultDevice will trigger the runtime device init, should
       // not do it during class init time.
-      XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+      XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                           runtime::GetComputationClient());
       default_device_type_ =
           std::make_shared<DeviceType>(client->GetDeviceType());
@@ -79,7 +79,7 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
       const torch::lazy::BackendDevice& device,
       const torch::lazy::Shape& shape) const override {
     xla::Shape xla_shape = MakeXlaShapeFromLazyShape(shape, device);
-    XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+    XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                         runtime::GetComputationClient());
     return client->CreateDataPlaceholder(device.toString(),
                                          std::move(xla_shape));
@@ -125,7 +125,7 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
   std::vector<std::string> GetCompilationDevices(
       const std::string& device,
       c10::ArrayRef<std::string> devices) const override {
-    XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+    XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                         runtime::GetComputationClient());
     return client->GetCompilationDevices(device, devices);
   }
@@ -160,7 +160,7 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
           torch_xla_computation->get_device_string(),
           {current_device.toString()}, &output_shapes.back()));
     }
-    XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+    XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                         runtime::GetComputationClient());
     std::vector<std::shared_ptr<runtime::ComputationClient::Computation>>
         client_computations = client->Compile(std::move(compile_instances));
@@ -171,7 +171,7 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
       torch::lazy::ComputationPtr computation,
       c10::ArrayRef<torch::lazy::BackendDataPtr> arguments,
       const torch::lazy::BackendDevice& device) const override {
-    XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+    XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                         runtime::GetComputationClient());
     XLA_ASSIGN_OR_THROW(
         std::vector<runtime::ComputationClient::DataPtr> results,

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -90,13 +90,13 @@ XLAGraphExecutor::ComputationCache* CreateComputationCache() {
     auto serialize_fn =
         [](XLAGraphExecutor::ComputationCache::TypePtr computation)
         -> std::string {
-      XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+      XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                           runtime::GetComputationClient());
       return client->SerializeComputation(computation->computation);
     };
     auto deserialize_fn = [](std::string serialization)
         -> XLAGraphExecutor::ComputationCache::TypePtr {
-      XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+      XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                           runtime::GetComputationClient());
       runtime::ComputationClient::ComputationPtr computation =
           client->DeserializeComputation(serialization);
@@ -471,7 +471,7 @@ void XLAGraphExecutor::WaitDeviceOps(absl::Span<const std::string> devices) {
     if (UseVirtualDevice()) {
       wait_devices.insert(ParseDeviceString("SPMD:0"));
     } else {
-      XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+      XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                           runtime::GetComputationClient());
       for (auto& device_str : client->GetLocalDevices()) {
         wait_devices.insert(ParseDeviceString(device_str));
@@ -587,7 +587,7 @@ XLAGraphExecutor::ComputationCache* XLAGraphExecutor::GetComputationCache() {
 void XLAGraphExecutor::ClearPendingIrs(
     std::vector<XLATensorPtr> tensors,
     const torch::lazy::BackendDevice& device) {
-  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                       runtime::GetComputationClient());
   std::unordered_set<int64_t> tensor_ids;
   for (size_t i = 0; i < tensors.size(); ++i) {
@@ -642,7 +642,7 @@ XLAGraphExecutor::SyncTensorCollection XLAGraphExecutor::CollectSyncTensors(
   // Ensure that the compilation environment and git revisions are reflected
   // in the hash, so that different versions of the code can produce different
   // hashes for the same graph.
-  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                       runtime::GetComputationClient());
   MergeHash(
       {client->HashCompilationEnv(), torch::lazy::StringHash(TORCH_GITREV),
@@ -785,7 +785,7 @@ XLAGraphExecutor::ExecuteComputationWithBarrier(
     placeholders =
         ShardingUtil::CreateShardedPlaceholder(output_sharding_hash[hash]);
   } else {
-    XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+    XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                         runtime::GetComputationClient());
     for (const xla::Shape& shape : *output_shapes) {
       torch::lazy::BackendDataPtr handle =
@@ -847,7 +847,7 @@ XLAGraphExecutor::ExecuteComputationWithBarrier(
       std::vector<torch::lazy::BackendDataPtr> results;
       if (async->cached_computation->is_sharded) {
         // TODO(JackCaoG): handle eager mode
-        XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+        XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                             runtime::GetComputationClient());
         std::vector<std::string> devices = client->GetLocalDevices();
         runtime::ComputationClient::ExecuteReplicatedOptions execute_options;
@@ -925,7 +925,7 @@ std::vector<torch::lazy::BackendDataPtr> XLAGraphExecutor::ExecuteStablehlo(
   xla::Shape shape = MakeShapeWithDeviceLayout(
       program_shape.result(), static_cast<XlaDeviceType>(device.type()));
 
-  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                       runtime::GetComputationClient());
   std::vector<runtime::ComputationClient::CompileInstance> instances;
   instances.emplace_back(std::move(computation), device.toString(),
@@ -1050,7 +1050,7 @@ void XLAGraphExecutor::ExtractIRAndPrepareXlaData_(
                                   tsl::profiler::TraceMeLevel::kInfo);
   ir_values.reserve(indices.size());
   tensor_data_vec.reserve(indices.size());
-  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                       runtime::GetComputationClient());
   for (auto index : indices) {
     XLATensorPtr& tensor = (*tensors)[index];
@@ -1121,7 +1121,7 @@ XLAGraphExecutor::ScheduleSyncTensorsGraph(
     try {
       std::vector<torch::lazy::BackendDataPtr> results;
       // Execute replicated if the compiled computation is partitioned.
-      XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+      XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                           runtime::GetComputationClient());
       if (async->cached_computation->is_sharded) {
         std::vector<std::string> devices = client->GetLocalDevices();
@@ -1451,7 +1451,7 @@ XLAGraphExecutor::CompilationResult XLAGraphExecutor::Compile(
   xla::Shape shape = MakeShapeWithDeviceLayout(
       program_shape.result(), static_cast<XlaDeviceType>(coll.device.type()));
 
-  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                       runtime::GetComputationClient());
   std::vector<runtime::ComputationClient::CompileInstance> instances;
   instances.push_back(

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -90,14 +90,16 @@ XLAGraphExecutor::ComputationCache* CreateComputationCache() {
     auto serialize_fn =
         [](XLAGraphExecutor::ComputationCache::TypePtr computation)
         -> std::string {
-      return runtime::GetComputationClientOrDie()->SerializeComputation(
-          computation->computation);
+      XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                          runtime::GetComputationClient());
+      return client->SerializeComputation(computation->computation);
     };
     auto deserialize_fn = [](std::string serialization)
         -> XLAGraphExecutor::ComputationCache::TypePtr {
+      XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                          runtime::GetComputationClient());
       runtime::ComputationClient::ComputationPtr computation =
-          runtime::GetComputationClientOrDie()->DeserializeComputation(
-              serialization);
+          client->DeserializeComputation(serialization);
       if (!computation) return nullptr;
       return std::make_shared<XLAGraphExecutor::CachedComputation>(
           computation, /*is_sharded=*/UseVirtualDevice());
@@ -469,8 +471,9 @@ void XLAGraphExecutor::WaitDeviceOps(absl::Span<const std::string> devices) {
     if (UseVirtualDevice()) {
       wait_devices.insert(ParseDeviceString("SPMD:0"));
     } else {
-      for (auto& device_str :
-           runtime::GetComputationClientOrDie()->GetLocalDevices()) {
+      XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                          runtime::GetComputationClient());
+      for (auto& device_str : client->GetLocalDevices()) {
         wait_devices.insert(ParseDeviceString(device_str));
       }
     }
@@ -584,6 +587,8 @@ XLAGraphExecutor::ComputationCache* XLAGraphExecutor::GetComputationCache() {
 void XLAGraphExecutor::ClearPendingIrs(
     std::vector<XLATensorPtr> tensors,
     const torch::lazy::BackendDevice& device) {
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                      runtime::GetComputationClient());
   std::unordered_set<int64_t> tensor_ids;
   for (size_t i = 0; i < tensors.size(); ++i) {
     if (tensor_ids.insert(tensors[i]->GetUniqueId()).second &&
@@ -598,9 +603,8 @@ void XLAGraphExecutor::ClearPendingIrs(
         } else {
           xla::Shape shape = MakeShapeWithDeviceLayout(
               tensors[i]->shape(), static_cast<XlaDeviceType>(device.type()));
-          torch::lazy::BackendDataPtr handle =
-              runtime::GetComputationClientOrDie()->CreateDataPlaceholder(
-                  device.toString(), std::move(shape));
+          torch::lazy::BackendDataPtr handle = client->CreateDataPlaceholder(
+              device.toString(), std::move(shape));
           tensors[i]->data()->handle = handle;
           TF_VLOG(4) << "Replacing the IR " << ir_value.node.get()->ToString()
                      << " of Tensor with ID " << tensors[i]->GetUniqueId()
@@ -638,10 +642,12 @@ XLAGraphExecutor::SyncTensorCollection XLAGraphExecutor::CollectSyncTensors(
   // Ensure that the compilation environment and git revisions are reflected
   // in the hash, so that different versions of the code can produce different
   // hashes for the same graph.
-  MergeHash({runtime::GetComputationClientOrDie()->HashCompilationEnv(),
-             torch::lazy::StringHash(TORCH_GITREV),
-             torch::lazy::StringHash(XLA_GITREV)},
-            &coll.hash);
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                      runtime::GetComputationClient());
+  MergeHash(
+      {client->HashCompilationEnv(), torch::lazy::StringHash(TORCH_GITREV),
+       torch::lazy::StringHash(XLA_GITREV)},
+      &coll.hash);
   coll.config = config;
   coll.device = *unique_device;
   coll.indices.reserve(tensors.size());
@@ -779,10 +785,11 @@ XLAGraphExecutor::ExecuteComputationWithBarrier(
     placeholders =
         ShardingUtil::CreateShardedPlaceholder(output_sharding_hash[hash]);
   } else {
+    XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                        runtime::GetComputationClient());
     for (const xla::Shape& shape : *output_shapes) {
       torch::lazy::BackendDataPtr handle =
-          runtime::GetComputationClientOrDie()->CreateDataPlaceholder(
-              device.toString(), std::move(shape));
+          client->CreateDataPlaceholder(device.toString(), std::move(shape));
       placeholders.push_back(handle);
     }
   }
@@ -840,18 +847,18 @@ XLAGraphExecutor::ExecuteComputationWithBarrier(
       std::vector<torch::lazy::BackendDataPtr> results;
       if (async->cached_computation->is_sharded) {
         // TODO(JackCaoG): handle eager mode
-        std::vector<std::string> devices =
-            runtime::GetComputationClientOrDie()->GetLocalDevices();
+        XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                            runtime::GetComputationClient());
+        std::vector<std::string> devices = client->GetLocalDevices();
         runtime::ComputationClient::ExecuteReplicatedOptions execute_options;
         // OutputHandler creates sharded data for sharded
         // tensor results. Both sharded and unsharded results should be
         // "Assign"ed to the corresponding data placeholders.
         XLA_ASSIGN_OR_THROW(
             std::vector<runtime::ComputationClient::DataPtr> outputs,
-            runtime::GetComputationClientOrDie()->ExecuteReplicated(
-                *async->cached_computation->computation,
-                UnwrapXlaData(async->parameters_data), devices,
-                execute_options));
+            client->ExecuteReplicated(*async->cached_computation->computation,
+                                      UnwrapXlaData(async->parameters_data),
+                                      devices, execute_options));
         results = WrapXlaData(outputs);
         TF_VLOG(3) << "Executing Dynamo IR sharded graph hash "
                    << torch::lazy::HashToString(hash) << " on devices "
@@ -918,16 +925,15 @@ std::vector<torch::lazy::BackendDataPtr> XLAGraphExecutor::ExecuteStablehlo(
   xla::Shape shape = MakeShapeWithDeviceLayout(
       program_shape.result(), static_cast<XlaDeviceType>(device.type()));
 
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                      runtime::GetComputationClient());
   std::vector<runtime::ComputationClient::CompileInstance> instances;
-  instances.emplace_back(
-      std::move(computation), device.toString(),
-      runtime::GetComputationClientOrDie()->GetCompilationDevices(
-          device.toString(),
-          runtime::GetComputationClientOrDie()->GetLocalDevices()),
-      &shape);
+  instances.emplace_back(std::move(computation), device.toString(),
+                         client->GetCompilationDevices(
+                             device.toString(), client->GetLocalDevices()),
+                         &shape);
   std::vector<std::shared_ptr<runtime::ComputationClient::Computation>>
-      computations =
-          runtime::GetComputationClientOrDie()->Compile(std::move(instances));
+      computations = client->Compile(std::move(instances));
 
   std::vector<torch::lazy::BackendDataPtr> arguments;
   {
@@ -948,8 +954,8 @@ std::vector<torch::lazy::BackendDataPtr> XLAGraphExecutor::ExecuteStablehlo(
 
   XLA_ASSIGN_OR_THROW(
       std::vector<runtime::ComputationClient::DataPtr> result_data,
-      runtime::GetComputationClientOrDie()->ExecuteComputation(
-          *computations[0], UnwrapXlaData(arguments), device.toString()));
+      client->ExecuteComputation(*computations[0], UnwrapXlaData(arguments),
+                                 device.toString()));
 
   return WrapXlaData(result_data);
 }
@@ -1044,6 +1050,8 @@ void XLAGraphExecutor::ExtractIRAndPrepareXlaData_(
                                   tsl::profiler::TraceMeLevel::kInfo);
   ir_values.reserve(indices.size());
   tensor_data_vec.reserve(indices.size());
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                      runtime::GetComputationClient());
   for (auto index : indices) {
     XLATensorPtr& tensor = (*tensors)[index];
     torch::lazy::Value ir_value = tensor->CurrentIrValue();
@@ -1051,9 +1059,8 @@ void XLAGraphExecutor::ExtractIRAndPrepareXlaData_(
     const torch::lazy::BackendDevice& tensor_device = tensor->GetDevice();
     xla::Shape shape = MakeShapeWithDeviceLayout(
         tensor->shape(), static_cast<XlaDeviceType>(tensor_device.type()));
-    torch::lazy::BackendDataPtr handle =
-        runtime::GetComputationClientOrDie()->CreateDataPlaceholder(
-            tensor_device.toString(), std::move(shape));
+    torch::lazy::BackendDataPtr handle = client->CreateDataPlaceholder(
+        tensor_device.toString(), std::move(shape));
 
     tensor_data_vec.push_back(handle);
     if (tensor->CurrentDataHandle() == nullptr && config.force_ltc_data) {
@@ -1114,9 +1121,10 @@ XLAGraphExecutor::ScheduleSyncTensorsGraph(
     try {
       std::vector<torch::lazy::BackendDataPtr> results;
       // Execute replicated if the compiled computation is partitioned.
+      XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                          runtime::GetComputationClient());
       if (async->cached_computation->is_sharded) {
-        std::vector<std::string> devices =
-            runtime::GetComputationClientOrDie()->GetLocalDevices();
+        std::vector<std::string> devices = client->GetLocalDevices();
         runtime::ComputationClient::ExecuteReplicatedOptions execute_options;
         TF_VLOG(3) << "Executing IR graph hash "
                    << torch::lazy::HashToString(hash)
@@ -1126,10 +1134,9 @@ XLAGraphExecutor::ScheduleSyncTensorsGraph(
         // "Assign"ed to the corresponding data placeholders.
         XLA_ASSIGN_OR_THROW(
             std::vector<runtime::ComputationClient::DataPtr> outputs,
-            runtime::GetComputationClientOrDie()->ExecuteReplicated(
-                *async->cached_computation->computation,
-                UnwrapXlaData(async->parameters_data), devices,
-                execute_options));
+            client->ExecuteReplicated(*async->cached_computation->computation,
+                                      UnwrapXlaData(async->parameters_data),
+                                      devices, execute_options));
         results = WrapXlaData(outputs);
         TORCH_LAZY_COUNTER("ExecuteReplicated", 1);
         TF_VLOG(3) << "Executing IR graph hash "
@@ -1142,11 +1149,11 @@ XLAGraphExecutor::ScheduleSyncTensorsGraph(
                    << async->device << " ...";
         XLA_ASSIGN_OR_THROW(
             std::vector<runtime::ComputationClient::DataPtr> outputs,
-            runtime::GetComputationClientOrDie()->ExecuteComputation(
-                *async->cached_computation->computation,
-                UnwrapXlaData(async->parameters_data), async->device.toString(),
-                {/*explode_tuple=*/true,
-                 /*eager_mode=*/use_eager_mode}));
+            client->ExecuteComputation(*async->cached_computation->computation,
+                                       UnwrapXlaData(async->parameters_data),
+                                       async->device.toString(),
+                                       {/*explode_tuple=*/true,
+                                        /*eager_mode=*/use_eager_mode}));
         results = WrapXlaData(outputs);
         TORCH_LAZY_COUNTER("ExecuteComputation", 1);
         TF_VLOG(3) << "Executing IR graph hash "
@@ -1444,12 +1451,13 @@ XLAGraphExecutor::CompilationResult XLAGraphExecutor::Compile(
   xla::Shape shape = MakeShapeWithDeviceLayout(
       program_shape.result(), static_cast<XlaDeviceType>(coll.device.type()));
 
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                      runtime::GetComputationClient());
   std::vector<runtime::ComputationClient::CompileInstance> instances;
   instances.push_back(
       {std::move(computation), coll.device.toString(),
-       runtime::GetComputationClientOrDie()->GetCompilationDevices(
-           coll.device.toString(), devices),
-       &shape, should_wrap_parameter, is_sharded});
+       client->GetCompilationDevices(coll.device.toString(), devices), &shape,
+       should_wrap_parameter, is_sharded});
   instances.front().eager_mode = UseEagerMode();
   if (use_autosharding) {
     TF_VLOG(5) << "use_auto_spmd_partitioning is set.";
@@ -1480,8 +1488,7 @@ XLAGraphExecutor::CompilationResult XLAGraphExecutor::Compile(
              << torch::lazy::HashToString(coll.hash) << " on device "
              << coll.device << " ...";
   std::vector<std::shared_ptr<runtime::ComputationClient::Computation>>
-      computations =
-          runtime::GetComputationClientOrDie()->Compile(std::move(instances));
+      computations = client->Compile(std::move(instances));
   DebugUtil::post_compilation_analysis(computations[0]);
   TF_VLOG(3) << "Compiling IR graph hash "
              << torch::lazy::HashToString(coll.hash) << " on device "

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -90,14 +90,16 @@ XLAGraphExecutor::ComputationCache* CreateComputationCache() {
     auto serialize_fn =
         [](XLAGraphExecutor::ComputationCache::TypePtr computation)
         -> std::string {
-      XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
-                          runtime::GetComputationClient());
+      XLA_ASSIGN_OR_THROW(
+          runtime::ComputationClient * absl_nonnull const client,
+          runtime::GetComputationClient());
       return client->SerializeComputation(computation->computation);
     };
     auto deserialize_fn = [](std::string serialization)
         -> XLAGraphExecutor::ComputationCache::TypePtr {
-      XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
-                          runtime::GetComputationClient());
+      XLA_ASSIGN_OR_THROW(
+          runtime::ComputationClient * absl_nonnull const client,
+          runtime::GetComputationClient());
       runtime::ComputationClient::ComputationPtr computation =
           client->DeserializeComputation(serialization);
       if (!computation) return nullptr;
@@ -471,8 +473,9 @@ void XLAGraphExecutor::WaitDeviceOps(absl::Span<const std::string> devices) {
     if (UseVirtualDevice()) {
       wait_devices.insert(ParseDeviceString("SPMD:0"));
     } else {
-      XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
-                          runtime::GetComputationClient());
+      XLA_ASSIGN_OR_THROW(
+          runtime::ComputationClient * absl_nonnull const client,
+          runtime::GetComputationClient());
       for (auto& device_str : client->GetLocalDevices()) {
         wait_devices.insert(ParseDeviceString(device_str));
       }
@@ -847,8 +850,9 @@ XLAGraphExecutor::ExecuteComputationWithBarrier(
       std::vector<torch::lazy::BackendDataPtr> results;
       if (async->cached_computation->is_sharded) {
         // TODO(JackCaoG): handle eager mode
-        XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
-                            runtime::GetComputationClient());
+        XLA_ASSIGN_OR_THROW(
+            runtime::ComputationClient * absl_nonnull const client,
+            runtime::GetComputationClient());
         std::vector<std::string> devices = client->GetLocalDevices();
         runtime::ComputationClient::ExecuteReplicatedOptions execute_options;
         // OutputHandler creates sharded data for sharded
@@ -1121,8 +1125,9 @@ XLAGraphExecutor::ScheduleSyncTensorsGraph(
     try {
       std::vector<torch::lazy::BackendDataPtr> results;
       // Execute replicated if the compiled computation is partitioned.
-      XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
-                          runtime::GetComputationClient());
+      XLA_ASSIGN_OR_THROW(
+          runtime::ComputationClient * absl_nonnull const client,
+          runtime::GetComputationClient());
       if (async->cached_computation->is_sharded) {
         std::vector<std::string> devices = client->GetLocalDevices();
         runtime::ComputationClient::ExecuteReplicatedOptions execute_options;

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -516,7 +516,7 @@ std::vector<torch::lazy::BackendDataPtr> ShardingUtil::CreateShardedPlaceholder(
     const std::vector<XLATensor::ShardingSpecPtr>& sharding_specs) {
   std::vector<torch::lazy::BackendDataPtr> placeholders;
   placeholders.reserve(sharding_specs.size());
-  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                       runtime::GetComputationClient());
   for (int i = 0; i < sharding_specs.size(); ++i) {
     // Create sharded data placeholder, this will be used to
@@ -552,7 +552,7 @@ void ShardingUtil::PrepareOutputShardingPropagation(
       << "Expected size: " << indices.size()
       << ", actual size: " << new_sharding_specs.size();
 
-  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                       runtime::GetComputationClient());
   for (int i = 0; i < indices.size(); ++i) {
     auto xtensor = (*tensors)[indices[i]];
@@ -611,7 +611,7 @@ runtime::ComputationClient::DataPtr ShardingUtil::CreateShardedData(
     source_tensors.push_back(std::make_shared<runtime::AtenSource>(
         local_shards[j], shard_shape, devices[j]));
   }
-  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                       runtime::GetComputationClient());
   return client->TransferShardsToDevice(
       source_tensors, GetVirtualDevice().toString(), global_shape, sharding);
@@ -628,7 +628,7 @@ std::vector<int64_t> ShardingUtil::GetAutoShardingMesh() {
     for (auto i : mesh_shape) {
       total_devices *= i;
     }
-    XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+    XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                         runtime::GetComputationClient());
     XLA_CHECK_EQ(total_devices, client->GetAllDevices().size())
         << "Invalid auto-sharding mesh_shape: "
@@ -645,7 +645,7 @@ std::vector<int64_t> ShardingUtil::GetAutoShardingMeshIds(
   // as the auto-sharding pass takes only one arrangement for now.
   // TODO(yeounoh) this was not necessary before; replace if this can be done
   // during the auto-sharding pass.
-  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                       runtime::GetComputationClient());
   int64_t n_devices = client->GetAllDevices().size();
   std::vector<int64_t> device_mesh_ids = std::vector<int64_t>(n_devices);
@@ -742,7 +742,7 @@ void ShardingUtil::ReshardParameters(
   // more-granular control over the peak memory consumption.
   bool group_sharding =
       runtime::sys_util::GetEnvBool("XLA_AUTO_USE_GROUP_SHARDING", true);
-  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull const client,
                       runtime::GetComputationClient());
   if (group_sharding) {
     outputs =

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -516,14 +516,15 @@ std::vector<torch::lazy::BackendDataPtr> ShardingUtil::CreateShardedPlaceholder(
     const std::vector<XLATensor::ShardingSpecPtr>& sharding_specs) {
   std::vector<torch::lazy::BackendDataPtr> placeholders;
   placeholders.reserve(sharding_specs.size());
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                      runtime::GetComputationClient());
   for (int i = 0; i < sharding_specs.size(); ++i) {
     // Create sharded data placeholder, this will be used to
     // hold the corresponding computation results for both sharding &
     // replication.
-    auto sharded_data_placeholder =
-        runtime::GetComputationClientOrDie()->CreateDataPlaceholder(
-            GetVirtualDevice().toString(), sharding_specs[i]->shape,
-            sharding_specs[i]->sharding);
+    auto sharded_data_placeholder = client->CreateDataPlaceholder(
+        GetVirtualDevice().toString(), sharding_specs[i]->shape,
+        sharding_specs[i]->sharding);
 
     // Register the sharded data placeholder to the tensor and its node.
     placeholders.push_back(sharded_data_placeholder);
@@ -551,6 +552,8 @@ void ShardingUtil::PrepareOutputShardingPropagation(
       << "Expected size: " << indices.size()
       << ", actual size: " << new_sharding_specs.size();
 
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                      runtime::GetComputationClient());
   for (int i = 0; i < indices.size(); ++i) {
     auto xtensor = (*tensors)[indices[i]];
     (*sharding_specs)[i] = new_sharding_specs[i];
@@ -562,10 +565,9 @@ void ShardingUtil::PrepareOutputShardingPropagation(
     // Create sharded data placeholder, this will be used to
     // hold the corresponding computation results for both sharding &
     // replication.
-    auto sharded_data_placeholder =
-        runtime::GetComputationClientOrDie()->CreateDataPlaceholder(
-            GetVirtualDevice().toString(), (*sharding_specs)[i]->shape,
-            (*sharding_specs)[i]->sharding);
+    auto sharded_data_placeholder = client->CreateDataPlaceholder(
+        GetVirtualDevice().toString(), (*sharding_specs)[i]->shape,
+        (*sharding_specs)[i]->sharding);
 
     // Register the sharded data placeholder to the tensor and its node.
     (*data_placeholders)[i] = sharded_data_placeholder;
@@ -609,7 +611,9 @@ runtime::ComputationClient::DataPtr ShardingUtil::CreateShardedData(
     source_tensors.push_back(std::make_shared<runtime::AtenSource>(
         local_shards[j], shard_shape, devices[j]));
   }
-  return runtime::GetComputationClientOrDie()->TransferShardsToDevice(
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                      runtime::GetComputationClient());
+  return client->TransferShardsToDevice(
       source_tensors, GetVirtualDevice().toString(), global_shape, sharding);
 }
 
@@ -624,8 +628,9 @@ std::vector<int64_t> ShardingUtil::GetAutoShardingMesh() {
     for (auto i : mesh_shape) {
       total_devices *= i;
     }
-    XLA_CHECK_EQ(total_devices,
-                 runtime::GetComputationClientOrDie()->GetAllDevices().size())
+    XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                        runtime::GetComputationClient());
+    XLA_CHECK_EQ(total_devices, client->GetAllDevices().size())
         << "Invalid auto-sharding mesh_shape: "
         << absl::StrJoin(mesh_shape, ",");
   }
@@ -640,8 +645,9 @@ std::vector<int64_t> ShardingUtil::GetAutoShardingMeshIds(
   // as the auto-sharding pass takes only one arrangement for now.
   // TODO(yeounoh) this was not necessary before; replace if this can be done
   // during the auto-sharding pass.
-  int64_t n_devices =
-      runtime::GetComputationClientOrDie()->GetAllDevices().size();
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                      runtime::GetComputationClient());
+  int64_t n_devices = client->GetAllDevices().size();
   std::vector<int64_t> device_mesh_ids = std::vector<int64_t>(n_devices);
   std::iota(device_mesh_ids.begin(), device_mesh_ids.end(), 0);
 
@@ -736,14 +742,15 @@ void ShardingUtil::ReshardParameters(
   // more-granular control over the peak memory consumption.
   bool group_sharding =
       runtime::sys_util::GetEnvBool("XLA_AUTO_USE_GROUP_SHARDING", true);
+  XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
+                      runtime::GetComputationClient());
   if (group_sharding) {
-    outputs = WrapXlaData(runtime::GetComputationClientOrDie()->ReshardData(
-        data_to_reshard, shardings_to_reshard));
+    outputs =
+        WrapXlaData(client->ReshardData(data_to_reshard, shardings_to_reshard));
   } else {
     for (int i = 0; i < data_to_reshard.size(); ++i) {
-      auto output =
-          WrapXlaData(runtime::GetComputationClientOrDie()->ReshardData(
-              {data_to_reshard[i]}, {shardings_to_reshard[i]}));
+      auto output = WrapXlaData(
+          client->ReshardData({data_to_reshard[i]}, {shardings_to_reshard[i]}));
       outputs.insert(outputs.end(), output.begin(), output.end());
     }
   }


### PR DESCRIPTION
This PR replaces calls of the deprecated function `GetComputationClientOrDie()` with calls to the `GetComputationClient()` function. The difference between them is that the former throws an exception on error, while the latter returns an status object.

In general, this PR applies the following replacement pattern:
- Create a new `ComputationClient*` variable using `XLA_ASSIGN_OR_THROW()` macro
- Replaces all `GetComputationClientOrDie()` with the new variable

```c++
/* Before */
runtime::ComputationClient::ComputationPtr computation =
    runtime::GetComputationClientOrDie()->DeserializeComputation(
    serialization);

/* After */
XLA_ASSIGN_OR_THROW(runtime::ComputationClient * absl_nonnull client,
                    runtime::GetComputationClient());
runtime::ComputationClient::ComputationPtr computation =
    client->DeserializeComputation(serialization);
```

_Note: this is the part 1 out of 2 PRs. Together, they will phase out `GetComputationClientOrDie()` function_