### PR TITLE
`roll: improve error handling and error messages.

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2531,6 +2531,44 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
           "tensor (8).")
       self.assertEqual(str(e), expected_error)
 
+  def test_roll_raises_error_on_empty_shifts(self):
+    device = torch_xla.device()
+    a = torch.rand(2, 2, 2, device=device)
+    shifts = []
+
+    try:
+      torch.roll(a, shifts)
+    except RuntimeError as e:
+      expected_error = "roll(): expected `shifts` to have at least 1 element."
+      self.assertEqual(str(e), expected_error)
+
+  def test_roll_raises_error_on_shifts_with_empty_dims(self):
+    device = torch_xla.device()
+    a = torch.rand(2, 2, 2, device=device)
+    shifts = [2, 2]
+
+    try:
+      torch.roll(a, shifts)
+    except RuntimeError as e:
+      expected_error = (
+          "roll(): expected `shifts` [2, 2] (size=2) to have exactly 1 element "
+          "when `dims` is empty.")
+      self.assertEqual(str(e), expected_error)
+
+  def test_roll_raises_error_on_mismatched_dims_and_shifts(self):
+    device = torch_xla.device()
+    a = torch.rand(2, 2, 2, device=device)
+    shifts = [2, 2]
+    dims = [0]
+
+    try:
+      torch.roll(a, shifts, dims)
+    except RuntimeError as e:
+      expected_error = (
+          "roll(): expected `dims` [0] (size=1) to match the size of `shifts` "
+          "[2, 2] (size=2).")
+      self.assertEqual(str(e), expected_error)
+
 
 class MNISTComparator(nn.Module):
 

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -17,8 +17,8 @@
 #include <mutex>
 #include <optional>
 
+#include "absl/base/nullability.h"
 #include "absl/log/absl_check.h"
-#include "status.h"
 #include "torch/csrc/lazy/core/helpers.h"
 #include "torch/csrc/lazy/core/shape_inference.h"
 #include "torch/csrc/lazy/core/tensor_util.h"
@@ -3317,9 +3317,13 @@ at::Tensor XLANativeFunctions::roll(const at::Tensor& self,
                                     at::IntArrayRef shifts,
                                     at::IntArrayRef dims) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
-  XLA_ASSIGN_OR_THROW(XLATensorPtr xla_self, bridge::GetXlaTensor(self));
-  return bridge::AtenFromXlaTensor(tensor_methods::roll(
-      xla_self, XlaHelpers::I64List(shifts), XlaHelpers::I64List(dims)));
+  XLA_ASSIGN_OR_THROW(absl_nonnull XLATensorPtr xla_self,
+                      bridge::GetXlaTensor(self));
+  XLA_ASSIGN_OR_THROW(
+      absl_nonnull XLATensorPtr output,
+      tensor_methods::roll(xla_self, XlaHelpers::I64List(shifts),
+                           XlaHelpers::I64List(dims)));
+  return bridge::AtenFromXlaTensor(std::move(output));
 }
 
 at::Tensor XLANativeFunctions::rrelu_with_noise(

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -821,8 +821,9 @@ XLATensorPtr replication_pad3d_backward(const XLATensorPtr& grad_output,
 
 void resize_(XLATensorPtr& input, std::vector<int64_t> size);
 
-XLATensorPtr roll(const XLATensorPtr& input, absl::Span<const int64_t> shifts,
-                  absl::Span<const int64_t> dims);
+absl::StatusOr<absl_nonnull XLATensorPtr> roll(
+    const absl_nonnull XLATensorPtr& input, absl::Span<const int64_t> shifts,
+    absl::Span<const int64_t> dims);
 
 XLATensorPtr rrelu_with_noise(const XLATensorPtr& input, XLATensorPtr& noise,
                               const at::Scalar& lower, const at::Scalar& upper,


### PR DESCRIPTION
This PR refactors the `roll` operation implementation by improving its error message, and returning a status type value.

**Key Changes:**

- Make `tensor_methods::roll` return `StatusOr<XLATensorPtr>`
- Improve error messages and error handling
    - Create `CheckRollShiftsRequired` and `CheckRollDimsAndShiftsAreCompatible` functions

## Example 1: empty `shifts` argument

```python
a = torch.arange(8, device=device).view(2, 2, 2)
shifts = []
```

**Before:**

```python
Traceback (most recent call last):
  File "examples/roll.py", line 24, in <module>
    torch.roll(a, shifts)
RuntimeError: Check failed: 0 < shifts.size() (0 vs. 0)`shifts` required (at torch_xla/csrc/tensor_methods.cpp:3057)

Exception raised from operator& at torch_xla/csrc/runtime/tf_logging.cpp:26 (most recent call first):
```

**After:** 

```python
Traceback (most recent call last):
  File "examples/roll.py", line 24, in <module>
    torch.roll(a, shifts)
RuntimeError: roll(): expected `shifts` to have at least 1 element.

Status Propagation Trace:
    From: roll at torch_xla/csrc/tensor_methods.cpp:3086
    From: roll at torch_xla/csrc/aten_xla_type.cpp:3322

Exception raised from ThrowStatusError at torch_xla/csrc/status.cpp:128 (most recent call first):
```

## Example 2: multiple `shifts` arguments with empty `dims`

```python
a = torch.arange(8, device=device).view(2, 2, 2)
shifts = [1, 1]
```

**Before:**

```python
tensor([[[7, 0],
         [1, 2]],

        [[3, 4],
         [5, 6]]], device='xla:0')
```

**After:** 

```python
Traceback (most recent call last):
  File "examples/roll.py", line 24, in <module>
    torch.roll(a, shifts)
RuntimeError: roll(): expected `shifts` [1, 1] (size=2) to have exactly 1 element when `dims` is empty.

Status Propagation Trace:
    From: roll at torch_xla/csrc/tensor_methods.cpp:3087
    From: roll at torch_xla/csrc/aten_xla_type.cpp:3322

Exception raised from ThrowStatusError at torch_xla/csrc/status.cpp:128 (most recent call first):
```

## Example 3: 

```python
a = torch.arange(8, device=device).view(2, 2, 2)
shifts = [1, 1]
dims = [0, 1, 2]
```

**Before:**

```python
Traceback (most recent call last):
  File "examples/roll.py", line 24, in <module>
    torch.roll(a, shifts, dims)
RuntimeError: Check failed: shifts.size() == dims.size() (2 vs. 3)shifts and dimensions must align. shifts: 2, dims:3 (at torch_xla/csrc/tensor_methods.cpp:3059)

Exception raised from operator& at torch_xla/csrc/runtime/tf_logging.cpp:26 (most recent call first):
```

**After:** 

```python
Traceback (most recent call last):
  File "examples/roll.py", line 24, in <module>
    torch.roll(a, shifts, dims)
RuntimeError: roll(): expected `dims` [0, 1, 2] (size=3) to match the size of `shifts` [1, 1] (size=2).

Status Propagation Trace:
    From: roll at torch_xla/csrc/tensor_methods.cpp:3087
    From: roll at torch_xla/csrc/aten_xla_type.cpp:3322

Exception raised from ThrowStatusError at torch_xla/csrc/status.cpp:128 (most recent call first):
```