### PR TITLE
`stack`: improve error handling and error messages.

### DIFF
--- a/torch_xla/csrc/ops/index_ops.cpp
+++ b/torch_xla/csrc/ops/index_ops.cpp
@@ -339,8 +339,8 @@ XLATensorPtr IndexByTensors(const XLATensorPtr& base,
       canonical_indices.front()->shape().get().dimensions_size();
   // Stack the indices to allow the whole multi-indexing to be dispatched with a
   // single gather.
-  XLATensorPtr indices_nd =
-      tensor_methods::stack(canonical_indices, indices_rank);
+  XLA_ASSIGN_OR_THROW(absl_nonnull XLATensorPtr indices_nd,
+                      tensor_methods::stack(canonical_indices, indices_rank));
   return XLATensor::Create(
       torch_xla::MakeNode<IndexGet>(base->GetIrValue(),
                                     indices_nd->GetIrValue(), start_dim),
@@ -356,11 +356,11 @@ torch::lazy::Value IndexPutByTensors(
   }
   auto canonical_indices = WrapIndicesOnce(base, indices, start_dim);
   int64_t indices_rank =
-      canonical_indices.front()->shape().get().dimensions_size();
+      canonical_indices.front()->shape().get().dimensions().size();
   // Stack the indices to allow the whole multi-indexing to be dispatched with a
   // single scatter.
-  XLATensorPtr indices_nd =
-      tensor_methods::stack(canonical_indices, indices_rank);
+  XLA_ASSIGN_OR_THROW(absl_nonnull XLATensorPtr indices_nd,
+                      tensor_methods::stack(canonical_indices, indices_rank));
   return torch_xla::MakeNode<Permute>(
       torch_xla::MakeNode<IndexPut>(base->GetIrValue(),
                                     indices_nd->GetIrValue(), start_dim,

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -926,7 +926,8 @@ XLATensorPtr squeeze(const XLATensorPtr& input, std::vector<int64_t> dims);
 void squeeze_(XLATensorPtr& input);
 void squeeze_(XLATensorPtr& input, int64_t dim);
 
-XLATensorPtr stack(absl::Span<const XLATensorPtr> tensors, int64_t dim);
+absl::StatusOr<absl_nonnull XLATensorPtr> stack(
+    absl::Span<const absl_nonnull XLATensorPtr> tensors, int64_t dim);
 
 XLATensorPtr std(const XLATensorPtr& input, std::vector<int64_t> dimensions,
                  bool keep_reduced_dimensions, double correction);

--- a/torch_xla/csrc/tensor_ops.cpp
+++ b/torch_xla/csrc/tensor_ops.cpp
@@ -62,7 +62,9 @@ XLATensorPtr Cross(const XLATensorPtr& input, const XLATensorPtr& other,
   XLATensorPtr s3 = tensor_methods::sub(tensor_methods::mul(u1, v2),
                                         tensor_methods::mul(u2, v1), one);
   // Stack the terms into one result tensor.
-  return tensor_methods::stack({s1, s2, s3}, canonical_dim);
+  XLA_ASSIGN_OR_THROW(absl_nonnull XLATensorPtr output,
+                      tensor_methods::stack({s1, s2, s3}, canonical_dim));
+  return output;
 }
 
 XLATensorPtr MakeMatrixWithDiagonal(const XLATensorPtr& input,


### PR DESCRIPTION
This PR refactors the `stack` operation implementation by improving its error message, and returning a status type value.

**Key Changes:**

- `tensor_methods::stack` returns `StatusOr<XLATensorPtr>`
- Improve error messages and error handling
    - Create `CheckStackAtLeastOneTensor` function