### PR TITLE
Upgrade build infra to use debian-12 and gcc-11

### DIFF
--- a/infra/ansible/config/apt.yaml
+++ b/infra/ansible/config/apt.yaml
@@ -15,8 +15,8 @@ apt:
       - wget
       - clang-format
       - clang-{{ clang_version }}
-      - gcc-10
-      - g++-10
+      - gcc-11
+      - g++-11
       - lcov
       - less
 

--- a/infra/ansible/config/env.yaml
+++ b/infra/ansible/config/env.yaml
@@ -3,8 +3,8 @@
 release_env:
   common:
     # Force GCC because clang/bazel has issues.
-    CC: gcc-10
-    CXX: g++-10
+    CC: gcc-11
+    CXX: g++-11
     # CC: "clang-{{ clang_version }}"
     # CXX: "clang++-{{ clang_version }}"
     LD_LIBRARY_PATH: "$LD_LIBRARY_PATH:/usr/local/lib"
@@ -20,8 +20,8 @@ build_env:
     # Set explicitly to 0 as setup.py defaults this flag to true if unset.
     BUILD_CPP_TESTS: "{{ build_cpp_tests }}"
     # Force GCC because clang/bazel has issues.
-    CC: gcc-10
-    CXX: g++-10
+    CC: gcc-11
+    CXX: g++-11
     PYTORCH_BUILD_NUMBER: 1
     TORCH_XLA_VERSION: "{{ package_version }}"
     PYTORCH_BUILD_VERSION: "{{ package_version }}"

--- a/infra/ansible/config/vars.yaml
+++ b/infra/ansible/config/vars.yaml
@@ -1,5 +1,5 @@
 # Used for fetching clang from the right repo, see apt.yaml.
-llvm_debian_repo: bullseye
+llvm_debian_repo: bookworm
 clang_version: 17
 # PyTorch and PyTorch/XLA wheel versions.
 package_version: 2.9.0

--- a/infra/ansible/development.Dockerfile
+++ b/infra/ansible/development.Dockerfile
@@ -2,7 +2,7 @@
 # The built image contains all required pip and apt packages for building and
 # running PyTorch and PyTorch/XLA. The image doesn't contain any source code.
 ARG python_version=3.8
-ARG debian_version=bullseye
+ARG debian_version=bookworm
 
 FROM python:${python_version}-${debian_version}
 

--- a/infra/ansible/e2e_tests.Dockerfile
+++ b/infra/ansible/e2e_tests.Dockerfile
@@ -1,5 +1,5 @@
 ARG python_version=3.8
-ARG debian_version=bullseye
+ARG debian_version=bookworm
 
 FROM python:${python_version}-${debian_version} AS build
 


### PR DESCRIPTION
Similar to https://github.com/pytorch/xla/pull/5451

Our build infra is pretty outdated and simple changes like https://github.com/pytorch/pytorch/pull/162217 broke the pytorch build in the XLA repo. This change will help us run smoothly in future