### PR TITLE
`uniform_`: improve error handling and error messages.

### DIFF
--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -2531,6 +2531,19 @@ class TestAtenXlaTensor(test_utils.XlaTestCase):
           "tensor (8).")
       self.assertEqual(str(e), expected_error)
 
+  def test_uniform__raises_error_on_invalid_range(self):
+    device = torch_xla.device()
+    a = torch.empty(5, 5, device=device)
+    from_ = 5.
+    to_ = 2.
+
+    try:
+      a.uniform_(from_, to_)
+    except RuntimeError as e:
+      expected_error = (
+          "uniform_(): expected `from` (5) to be smaller or equal `to` (2).")
+      self.assertEqual(str(e), expected_error)
+
 
 class MNISTComparator(nn.Module):
 

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -3905,8 +3905,9 @@ at::Tensor& XLANativeFunctions::uniform_(
     return at::native::call_fallback_fn<&xla_fallback, ATEN_OP(uniform_)>::call(
         self, from, to, generator);
   }
-  XLA_ASSIGN_OR_THROW(XLATensorPtr xla_self, bridge::GetXlaTensor(self));
-  tensor_methods::uniform_(xla_self, from, to);
+  XLA_ASSIGN_OR_THROW(absl_nonnull XLATensorPtr xla_self,
+                      bridge::GetXlaTensor(self));
+  XLA_THROW_IF_ERROR(tensor_methods::uniform_(xla_self, from, to));
   return self;
 }
 

--- a/torch_xla/csrc/tensor_methods.cpp
+++ b/torch_xla/csrc/tensor_methods.cpp
@@ -14,6 +14,7 @@
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
+#include "status.h"
 #include "torch_xla/csrc/LazyIr.h"
 #include "torch_xla/csrc/aten_xla_bridge.h"
 #include "torch_xla/csrc/data_ops.h"
@@ -502,6 +503,15 @@ absl::Status CheckMMMatrixSizesAreCompatible(const XLATensorPtr& mat1,
         shape1.dimensions(1),
         ") to be equal the size of dimension 0 of the second input tensor (",
         shape2.dimensions(0), ").")));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status CheckUniformRangeIsValid(double from, double to) {
+  if (from > to) {
+    return XLA_ERROR_WITH_LOCATION(absl::InvalidArgumentError(
+        absl::StrCat("uniform_(): expected `from` (", from,
+                     ") to be smaller or equal `to` (", to, ").")));
   }
   return absl::OkStatus();
 }
@@ -3653,15 +3663,16 @@ std::vector<XLATensorPtr> unbind(const XLATensorPtr& input, int64_t dim) {
   return slices;
 }
 
-void uniform_(XLATensorPtr& input, double from, double to) {
-  XLA_CHECK_LE(from, to);
-  auto input_shape = input->shape();
+absl::Status uniform_(XLATensorPtr& input, double from, double to) {
+  XLA_RETURN_IF_ERROR(CheckUniformRangeIsValid(from, to));
+  xla::Shape input_shape = input->shape();
   input->SetInPlaceIrValue(torch_xla::MakeNode<Uniform>(
       XLAGraphExecutor::Get()->GetIrValueForScalar(
-          from, input_shape.get().element_type(), input->GetDevice()),
+          from, input_shape.element_type(), input->GetDevice()),
       XLAGraphExecutor::Get()->GetIrValueForScalar(
-          to, input_shape.get().element_type(), input->GetDevice()),
+          to, input_shape.element_type(), input->GetDevice()),
       XLAGraphExecutor::Get()->GetRngSeed(input->GetDevice()), input_shape));
+  return absl::OkStatus();
 }
 
 XLATensorPtr unsqueeze(const XLATensorPtr& input, int64_t dim) {

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -986,7 +986,7 @@ std::tuple<XLATensorPtr, XLATensorPtr> triangular_solve(
 // removed.
 std::vector<XLATensorPtr> unbind(const XLATensorPtr& input, int64_t dim);
 
-void uniform_(XLATensorPtr& input, double from, double to);
+absl::Status uniform_(XLATensorPtr& input, double from, double to);
 
 // Insert a dimension of size one at the specified position.
 XLATensorPtr unsqueeze(const XLATensorPtr& input, int64_t dim);


### PR DESCRIPTION
This PR refactors the `uniform_` operation implementation by improving its error message, and returning a status type value.

**Key Changes:**

- Make `tensor_methods::uniform_` return `Status`
- Improve error messages and error handling
    - Add `CheckUniformRangeIsValid` function

## Example

```python
a = torch.empty( 2, 2, device="xla")
a.uniform_(5, 2)
```

**Before:**

```python
Traceback (most recent call last):
  File "examples/uniform.py", line 6, in <module>
    a.uniform_(5, 2)
RuntimeError: Check failed: from <= to (5 vs. 2) (at torch_xla/csrc/tensor_methods.cpp:3673)

Exception raised from operator& at torch_xla/csrc/runtime/tf_logging.cpp:26 (most recent call first):
```

**After:** 

```python
Traceback (most recent call last):
  File "examples/uniform.py", line 6, in <module>
    a.uniform_(5, 2)
RuntimeError: uniform_(): expected `from` (5) to be smaller or equal `to` (2).

Status Propagation Trace:
    From: CheckUniformRangeIsValid at torch_xla/csrc/tensor_methods.cpp:3659 (error: uniform_(): expected argument `from` (5) to be smaller or equal argument `to` (2).)
    From: uniform_ at torch_xla/csrc/tensor_methods.cpp:3667
    From: uniform_ at torch_xla/csrc/aten_xla_type.cpp:3910

Exception raised from ThrowStatusError at torch_xla/csrc/status.cpp:128 (most recent call first):
```
