### PR TITLE
Add destructor for XLAGraphExecutor to free resource

### DIFF
--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -124,6 +124,11 @@ XLAGraphExecutor::ComputationCache* CreateComputationCache() {
 
 }  // namespace
 
+XLAGraphExecutor::~XLAGraphExecutor() {
+  computation_cache_->Clear();
+  delete computation_cache_;
+}
+
 auto XLAGraphExecutor::DeviceContextArena::Get() -> DeviceContextArena* {
   static DeviceContextArena* arena = new DeviceContextArena();
   return arena;

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -31,6 +31,8 @@ namespace torch_xla {
 
 class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
  public:
+  ~XLAGraphExecutor();
+
   static XLAGraphExecutor* Get();
 
   // Override to use our own DeviceContextArena.


### PR DESCRIPTION
This PR is to add a destructor for `XLAGraphExecutor`, to trigger the destructor of PJRT class `Executable`/`LoadedExecutable`. This helps to do some special works (e.g. clear disk) when the PJRT program is over.

## Backgroud
The PJRT plugins may want to do some special operations when the `Executable`/`LoadedExecutable` is destructed, but in Torch-XLA, the `Executable`/`LoadedExecutable` will never be destructed since a raw pointer [`computation_cache_`](https://github.com/pytorch/xla/blob/master/torch_xla/csrc/xla_graph_executor.h#L404) has stored these objects and is never released:
* The raw pointer `computation_cache_` is created in [`CreateComputationCache()`](https://github.com/pytorch/xla/blob/master/torch_xla/csrc/xla_graph_executor.cpp#L82)
* The PJRT `Executable`/`LoadedExecutable` is added to `computation_cache_` in https://github.com/pytorch/xla/blob/master/torch_xla/csrc/xla_graph_executor.cpp#L1595
* The foo class `XLAGraphExecutor` is used as a global static instance and will never clear or delete this pointer

## Detail
Add a destructor for `XLAGraphExecutor`, to clear and delete this raw pointer.