### PR TITLE
Fix `test_ops_error_message.py` and run it on CI.

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -150,6 +150,7 @@ function run_xla_op_tests1 {
   run_dynamic "$_TEST_DIR/ds/test_dynamic_shape_models.py" "$@" --verbosity=$VERBOSITY
   run_eager_debug "$_TEST_DIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_test "$_TEST_DIR/test_operations.py" "$@" --verbosity=$VERBOSITY
+  run_test "$_TEST_DIR/test_ops_error_message.py" "$@" --verbosity=$VERBOSITY
   run_test "$_TEST_DIR/test_xla_graph_execution.py" "$@" --verbosity=$VERBOSITY
   run_pt_xla_debug_level2 "$_TEST_DIR/test_xla_graph_execution.py" "$@" --verbosity=$VERBOSITY
   run_test_without_functionalization "$_TEST_DIR/test_operations.py" "$@" --verbosity=$VERBOSITY

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -150,7 +150,7 @@ function run_xla_op_tests1 {
   run_dynamic "$_TEST_DIR/ds/test_dynamic_shape_models.py" "$@" --verbosity=$VERBOSITY
   run_eager_debug "$_TEST_DIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_test "$_TEST_DIR/test_operations.py" "$@" --verbosity=$VERBOSITY
-  run_test "$_TEST_DIR/test_ops_error_message.py" "$@" --verbosity=$VERBOSITY
+  run_test "$_TEST_DIR/test_ops_error_message.py"
   run_test "$_TEST_DIR/test_xla_graph_execution.py" "$@" --verbosity=$VERBOSITY
   run_pt_xla_debug_level2 "$_TEST_DIR/test_xla_graph_execution.py" "$@" --verbosity=$VERBOSITY
   run_test_without_functionalization "$_TEST_DIR/test_operations.py" "$@" --verbosity=$VERBOSITY

--- a/test/test_ops_error_message.py
+++ b/test/test_ops_error_message.py
@@ -6,7 +6,7 @@ import unittest
 
 
 def onlyOnCPU(fn):
-  accelerator = os.environ.get("PJRT_DEVICE").lower()
+  accelerator = os.environ.get("PJRT_DEVICE", "").lower()
   return unittest.skipIf(accelerator != "cpu", "PJRT_DEVICE=CPU required")(fn)
 
 
@@ -179,3 +179,7 @@ class TestOpsErrorMessage(expecttest.TestCase):
         callable=test,
         expect="""mm(): cannot matrix-multiply tensors f32[2,5] and f32[8,2]. Expected the size of dimension 1 of the first input tensor (5) to be equal the size of dimension 0 of the second input tensor (8)."""
     )
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/test/test_ops_error_message.py
+++ b/test/test_ops_error_message.py
@@ -158,7 +158,7 @@ class TestOpsErrorMessage(expecttest.TestCase):
     b = torch.rand(2, 2, device=device)
 
     def test():
-      torch.mm(a, b)
+      return torch.mm(a, b)
 
     self.assertExpectedRaisesInline(
         exc_type=RuntimeError,
@@ -172,7 +172,7 @@ class TestOpsErrorMessage(expecttest.TestCase):
     b = torch.rand(8, 2, device=device)
 
     def test():
-      torch.mm(a, b)
+      return torch.mm(a, b)
 
     self.assertExpectedRaisesInline(
         exc_type=RuntimeError,


### PR DESCRIPTION
This PR fixes #9622, which extracted error messages checks out of `test_operations.py` into `test_ops_error_message.py`. There were a few problems with that PR, namely:

- `unittest.main()` wasn't being run: although calling `python -m pytest` runs it automatically, running it without the `pytest` module did nothing
- `onlyOnCPU()` would error if `PJRT_DEVICE` environment variable wasn't set
- `test_ops_error_message.py` wasn't being run on CI

This PR fixes all the aforementioned PRs.