### PR TITLE
`bmm`: improve error handling and error messages.

### DIFF
--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -1254,11 +1254,16 @@ at::Tensor XLANativeFunctions::baddbmm(const at::Tensor& self,
                                        const at::Scalar& beta,
                                        const at::Scalar& alpha) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
-  XLA_ASSIGN_OR_THROW(XLATensorPtr xla_self, bridge::GetXlaTensor(self));
-  XLA_ASSIGN_OR_THROW(XLATensorPtr xla_batch1, bridge::GetXlaTensor(batch1));
-  XLA_ASSIGN_OR_THROW(XLATensorPtr xla_batch2, bridge::GetXlaTensor(batch2));
-  return bridge::AtenFromXlaTensor(
+  XLA_ASSIGN_OR_THROW(absl_nonnull XLATensorPtr xla_self,
+                      bridge::GetXlaTensor(self));
+  XLA_ASSIGN_OR_THROW(absl_nonnull XLATensorPtr xla_batch1,
+                      bridge::GetXlaTensor(batch1));
+  XLA_ASSIGN_OR_THROW(absl_nonnull XLATensorPtr xla_batch2,
+                      bridge::GetXlaTensor(batch2));
+  XLA_ASSIGN_OR_THROW(
+      absl_nonnull XLATensorPtr output,
       tensor_methods::baddbmm(xla_self, xla_batch1, xla_batch2, beta, alpha));
+  return bridge::AtenFromXlaTensor(std::move(output));
 }
 
 at::Tensor XLANativeFunctions::bernoulli(
@@ -1338,9 +1343,13 @@ at::Tensor XLANativeFunctions::bitwise_xor(const at::Tensor& self,
 at::Tensor XLANativeFunctions::bmm(const at::Tensor& self,
                                    const at::Tensor& mat2) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
-  XLA_ASSIGN_OR_THROW(XLATensorPtr xla_self, bridge::GetXlaTensor(self));
-  XLA_ASSIGN_OR_THROW(XLATensorPtr xla_mat2, bridge::GetXlaTensor(mat2));
-  return bridge::AtenFromXlaTensor(tensor_methods::bmm(xla_self, xla_mat2));
+  XLA_ASSIGN_OR_THROW(absl_nonnull XLATensorPtr xla_self,
+                      bridge::GetXlaTensor(self));
+  XLA_ASSIGN_OR_THROW(absl_nonnull XLATensorPtr xla_mat2,
+                      bridge::GetXlaTensor(mat2));
+  XLA_ASSIGN_OR_THROW(absl_nonnull XLATensorPtr output,
+                      tensor_methods::bmm(xla_self, xla_mat2));
+  return bridge::AtenFromXlaTensor(std::move(output));
 }
 
 at::Tensor XLANativeFunctions::cat(const at::ITensorListRef& tensors,

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -272,9 +272,11 @@ XLATensorPtr avg_pool_nd_backward(const XLATensorPtr& out_backprop,
                                   std::vector<int64_t> padding, bool ceil_mode,
                                   bool count_include_pad);
 
-XLATensorPtr baddbmm(const XLATensorPtr& input, const XLATensorPtr& batch1,
-                     const XLATensorPtr& batch2, const at::Scalar& beta,
-                     const at::Scalar& alpha);
+absl::StatusOr<absl_nonnull XLATensorPtr> baddbmm(const XLATensorPtr& input,
+                                                  const XLATensorPtr& batch1,
+                                                  const XLATensorPtr& batch2,
+                                                  const at::Scalar& beta,
+                                                  const at::Scalar& alpha);
 
 XLATensorPtr bernoulli(const XLATensorPtr& input, double probability);
 XLATensorPtr bernoulli(const XLATensorPtr& input);
@@ -297,7 +299,8 @@ XLATensorPtr bitwise_xor(const XLATensorPtr& input, const XLATensorPtr& other);
 // Batch matrix multiplication. Both tensors must be 3D, the batch size must
 // match and the remaining two dimensions must be compatible for matrix
 // multiplication.
-XLATensorPtr bmm(const XLATensorPtr& batch1, const XLATensorPtr& batch2);
+absl::StatusOr<absl_nonnull XLATensorPtr> bmm(const XLATensorPtr& input,
+                                              const XLATensorPtr& mat2);
 
 // Broadcasts the given tensors according to broadcasting semantics.
 std::vector<XLATensorPtr> broadcast_tensors(


### PR DESCRIPTION
This PR refactors the `bmm` operation implementation by improving its error message, and returning a status type value.

**Key Changes:**

- Make `tensor_methods::bmm` return `StatusOr<XLATensorPtr>`
- Improve error messages and error handling
    - Remove `CheckBmmDimension`, `CheckDimensionSize`, and `CheckRank`
    - Create new `CheckBmmInputsAreValid`, and `CheckInputIs3DTensor` functions

## Example 1: not a 3D tensor

```python
a = torch.rand(2, 3, device=device)
b = torch.rand(2, 3, 3, device=device)
torch.bmm(a, b)
```

<details>
<summary>Comparison</summary>

**Before:**

```python
Traceback (most recent call last):
  File "examples/bmm.py", line 39, in <module>
    torch.bmm(a, b)
RuntimeError: Check failed: actual_rank == expected_rank (2 vs. 3)Expected 3-dimensional tensor, but got 2-dimensional tensor for argument #1 'batch1' (while checking arguments for bmm) (at torch_xla/csrc/tensor_methods.cpp:200)

Exception raised from operator& at torch_xla/csrc/runtime/tf_logging.cpp:26 (most recent call first):
```

**After:** 

```python
Traceback (most recent call last):
  File "examples/bmm.py", line 39, in <module>
    torch.bmm(a, b)
RuntimeError: bmm(): expected `input` f32[2,3] (a 2D tensor), the 1st input tensor, to be a 3D tensor.

Status Propagation Trace:
    From: CheckInputIs3DTensor at torch_xla/csrc/tensor_methods.cpp:492 (error: bmm(): expected `input` f32[2,3] (a 2D tensor), the 1st input tensor, to be a 3D tensor.)
    From: CheckBMMInputsAreValid at torch_xla/csrc/tensor_methods.cpp:503
    From: bmm at torch_xla/csrc/tensor_methods.cpp:1300
    From: bmm at torch_xla/csrc/aten_xla_type.cpp:1349

Exception raised from ThrowStatusError at torch_xla/csrc/status.cpp:128 (most recent call first):
```

</details>

## Example 2: batch dimension size don't match

```python
a = torch.rand(2, 3, 4, device=device)
b = torch.rand(4, 4, 3, device=device)
torch.bmm(a, b)
```

<details>
<summary>Comparison</summary>

**Before:**

```python
Traceback (most recent call last):
  File "examples/bmm.py", line 39, in <module>
    torch.bmm(a, b)
RuntimeError: Check failed: t->size(dim) == expected_size (4 vs. 2)Expected tensor to have size 2 at dimension 0, but got size 4 for argument #2 'batch2' (while checking arguments for bmm) (at torch_xla/csrc/tensor_methods.cpp:218)

Exception raised from operator& at torch_xla/csrc/runtime/tf_logging.cpp:26 (most recent call first):
```

**After:** 

```python
Traceback (most recent call last):
  File "examples/bmm.py", line 39, in <module>
    torch.bmm(a, b)
RuntimeError: bmm(): expected the size of the batch dimension (i.e. dimension 0) of `input` f32[2,3,4] (batch dimension size: 2), the 1st input tensor, to be the same as the size of the batch dimension of `mat2` f32[4,4,3] (batch dimension size: 4), the 2nd input tensor.

Status Propagation Trace:
    From: CheckBMMInputsAreValid at torch_xla/csrc/tensor_methods.cpp:507 (error: bmm(): expected the size of the batch dimension (i.e. dimension 0) of `input` f32[2,3,4] (batch dimension size: 2), the 1st input tensor, to be the same as the size of the batch dimension of `mat2` f32[4,4,3] (batch dimension size: 4), the 2nd input tensor.)
    From: bmm at torch_xla/csrc/tensor_methods.cpp:1300
    From: bmm at torch_xla/csrc/aten_xla_type.cpp:1349

Exception raised from ThrowStatusError at torch_xla/csrc/status.cpp:128 (most recent call first):
```

</details>

## Example 3: invalid shapes

```python
a = torch.rand(2, 3, 4, device=device)
b = torch.rand(2, 2, 3, device=device)
torch.bmm(a, b)
```

<details>
<summary>Comparison</summary>

**Before:**

```python
Traceback (most recent call last):
  File "examples/bmm.py", line 39, in <module>
    torch.bmm(a, b)
RuntimeError: Check failed: t->size(dim) == expected_size (2 vs. 4)Expected tensor to have size 4 at dimension 1, but got size 2 for argument #2 'batch2' (while checking arguments for bmm) (at torch_xla/csrc/tensor_methods.cpp:218)

Exception raised from operator& at torch_xla/csrc/runtime/tf_logging.cpp:26 (most recent call first):
```

**After:** 

```python
Traceback (most recent call last):
  File "examples/bmm.py", line 39, in <module>
    torch.bmm(a, b)
RuntimeError: bmm(): cannot apply batch matrix-multiplication to `input` f32[2,3,4], the 1st input tensor, and to `mat2` f32[2,2,3], the 2nd input tensor. Expected the size of dimension 2 of `input` (4) to be equal the size of dimension 1 of `mat2` (2).

Status Propagation Trace:
    From: CheckBMMInputsAreValid at torch_xla/csrc/tensor_methods.cpp:519 (error: bmm(): cannot apply batch matrix-multiplication to `input` f32[2,3,4], the 1st input tensor, and to `mat2` f32[2,2,3], the 2nd input tensor. Expected the size of dimension 2 of `input` (4) to be equal the size of dimension 1 of `mat2` (2).)
    From: bmm at torch_xla/csrc/tensor_methods.cpp:1300
    From: bmm at torch_xla/csrc/aten_xla_type.cpp:1349

Exception raised from ThrowStatusError at torch_xla/csrc/status.cpp:128 (most recent call first):
```

</details>
