### PR TITLE
`expand`: improve error handling and error messages.

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -151,6 +151,7 @@ function run_xla_op_tests1 {
   run_eager_debug "$_TEST_DIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_test "$_TEST_DIR/test_operations.py" "$@" --verbosity=$VERBOSITY
   run_test "$_TEST_DIR/test_ops_error_message.py"
+  run_test "$_TEST_DIR/test_ops_error_message_functionalization_disabled.py"
   run_test "$_TEST_DIR/test_xla_graph_execution.py" "$@" --verbosity=$VERBOSITY
   run_pt_xla_debug_level2 "$_TEST_DIR/test_xla_graph_execution.py" "$@" --verbosity=$VERBOSITY
   run_test_without_functionalization "$_TEST_DIR/test_operations.py" "$@" --verbosity=$VERBOSITY

--- a/test/test_ops_error_message_functionalization_disabled.py
+++ b/test/test_ops_error_message_functionalization_disabled.py
@@ -1,4 +1,5 @@
 import os
+
 os.environ["XLA_DISABLE_FUNCTIONALIZATION"] = "1"
 
 import expecttest

--- a/test/test_ops_error_message_functionalization_disabled.py
+++ b/test/test_ops_error_message_functionalization_disabled.py
@@ -1,0 +1,42 @@
+import os
+os.environ["XLA_DISABLE_FUNCTIONALIZATION"] = "1"
+
+import expecttest
+import torch
+import torch_xla
+import unittest
+
+
+class TestOpsErrorMessageFunctionalizationDisabled(expecttest.TestCase):
+
+  def test_expand_raises_error_on_higher_rank_tensor(self):
+    device = torch_xla.device()
+    a = torch.rand(1, 1, 2, 3, device=device)
+    sizes = [-1, 3]
+
+    def test():
+      return a.expand(sizes)
+
+    self.assertExpectedRaisesInline(
+        exc_type=RuntimeError,
+        callable=test,
+        expect="""expand(): expected the `input` tensor f32[1,1,2,3] (rank: 4) to have a rank smaller or equal to the given `sizes` [-1, 3] (rank: 2)."""
+    )
+
+  def test_expand_raises_error_on_size_mismatch(self):
+    device = torch_xla.device()
+    a = torch.rand(1, 1, 2, 3, device=device)
+    sizes = [1, 1, 1, 3]
+
+    def test():
+      return a.expand(sizes)
+
+    self.assertExpectedRaisesInline(
+        exc_type=RuntimeError,
+        callable=test,
+        expect="""expand(): expected dimension 2 of the given `sizes` [1, 1, 1, 3] (1) to be -1, or equal to the size of the `input` tensor f32[1,1,2,3] at dimension 2 (2)."""
+    )
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -24,6 +24,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "absl/base/nullability.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/absl_check.h"
 #include "absl/strings/str_cat.h"
@@ -451,15 +452,18 @@ at::Tensor AllReduce(const std::string& reduce_type, const at::Tensor& input,
 }
 
 at::Tensor DynamicExpand(const at::Tensor& input,
-                         const std::vector<int64_t>& size,
+                         const std::vector<int64_t>& sizes,
                          const at::Tensor& src_tensor, int src_dim,
                          int target_dim) {
-  XLA_ASSIGN_OR_THROW(XLATensorPtr xla_input, bridge::GetXlaTensor(input));
-  XLA_ASSIGN_OR_THROW(XLATensorPtr xla_src_tensor,
+  XLA_ASSIGN_OR_THROW(absl_nonnull XLATensorPtr xla_input,
+                      bridge::GetXlaTensor(input));
+  XLA_ASSIGN_OR_THROW(absl_nonnull XLATensorPtr xla_src_tensor,
                       bridge::GetXlaTensor(src_tensor));
-  XLATensorPtr result = tensor_methods::dynamic_expand(
-      xla_input, size, xla_src_tensor, src_dim, target_dim);
-  return bridge::AtenFromXlaTensor(std::move(result));
+  XLA_ASSIGN_OR_THROW(
+      absl_nonnull XLATensorPtr output,
+      tensor_methods::dynamic_expand(xla_input, sizes, xla_src_tensor, src_dim,
+                                     target_dim));
+  return bridge::AtenFromXlaTensor(std::move(output));
 }
 
 at::Tensor DynamicView(const at::Tensor& input,

--- a/torch_xla/csrc/tensor_methods.h
+++ b/torch_xla/csrc/tensor_methods.h
@@ -2,6 +2,7 @@
 #define XLA_TORCH_XLA_CSRC_TENSOR_METHODS_H_
 
 #include "absl/base/nullability.h"
+#include "absl/types/span.h"
 #include "torch_xla/csrc/cross_replica_reduces.h"
 #include "torch_xla/csrc/ops/custom_sharding.h"
 #include "torch_xla/csrc/runtime/computation_client.h"
@@ -158,10 +159,9 @@ XLATensorPtr cast_int4(const XLATensorPtr& weight,
 // Dynamic Reshape ops here.
 //////////////////////////////////////////////////////////////////////////////
 
-XLATensorPtr dynamic_expand(const XLATensorPtr& input,
-                            const std::vector<int64_t>& size,
-                            const XLATensorPtr& src_tensor, int src_dim,
-                            int target_dim);
+absl::StatusOr<absl_nonnull XLATensorPtr> dynamic_expand(
+    const XLATensorPtr& input, const absl::Span<const int64_t> sizes,
+    const XLATensorPtr& src_tensor, int src_dim, int target_dim);
 
 XLATensorPtr dynamic_view(const XLATensorPtr& input,
                           const std::vector<int64_t>& size,
@@ -427,7 +427,8 @@ XLATensorPtr eq(const XLATensorPtr& input, const XLATensorPtr& other);
 
 XLATensorPtr exp(const XLATensorPtr& input);
 
-XLATensorPtr expand(const XLATensorPtr& input, std::vector<int64_t> size);
+absl::StatusOr<absl_nonnull XLATensorPtr> expand(
+    const XLATensorPtr& input, const absl::Span<const int64_t> sizes);
 
 XLATensorPtr expand_symint(const XLATensorPtr& input,
                            c10::SymIntArrayRef sym_size);

--- a/torch_xla/csrc/tensor_ops.cpp
+++ b/torch_xla/csrc/tensor_ops.cpp
@@ -238,9 +238,9 @@ XLATensorPtr EmbeddingDenseBackward(const XLATensorPtr& grad_output,
   // padding_idx.
   XLATensorPtr skip_padding = tensor_methods::unsqueeze(
       tensor_methods::ne(indices_rank1, padding_idx), 1);
-  skip_padding = tensor_methods::expand(
+  XLA_ASSIGN_OR_THROW(
       skip_padding,
-      torch::lazy::ToVector<int64_t>(grad->shape().get().dimensions()));
+      tensor_methods::expand(skip_padding, grad->shape().get().dimensions()));
   XLATensorPtr zero_grad =
       tensor_methods::full_like(grad, 0, grad->GetDevice(), grad->dtype());
   return tensor_methods::index_put(


### PR DESCRIPTION
This PR refactors the `expand` operation implementation by improving its error message, and returning a status type value.

**Key Changes:**

- Make `tensor_methods::expand` return `StatusOr<XLATensorPtr>`
- Improve error messages and error handling
    - Create new `CheckExpandValidRank` for checking the input and the given sizes' rank 
    - Modified `GetExpandDimensions`, calling the check function above, and also checking whether input and sizes corresponding dimensions are valid

## Example 1: input rank is larger

```python
a = torch.rand(1, 1, 2, 3, device=device)
sizes = [-1, 3]
a.expand(sizes)
```

<details>
<summary>Comparison</summary>

**Before:**

```python
Traceback (most recent call last):
  File "examples/expand.py", line 30, in <module>
    a.expand(sizes)
RuntimeError: Check failed: shape.dimensions_size() <= dimensions.size() (4 vs. 2)f32[1,1,2,3]{3,2,1,0} (at torch_xla/csrc/tensor_methods.cpp:217)

Exception raised from operator& at torch_xla/csrc/runtime/tf_logging.cpp:26 (most recent call first):
```

**After:** 

```python
Traceback (most recent call last):
  File "examples/expand.py", line 30, in <module>
    a.expand(sizes)
RuntimeError: expand(): expected the `input` tensor f32[1,1,2,3] (rank: 4) to have a rank smaller or equal to the given `sizes` [-1, 2] (rank: 2).

Status Propagation Trace:
    From: CheckExpandValidRank at torch_xla/csrc/tensor_methods.cpp:246 (error: expand(): expected the `input` tensor f32[1,1,2,3] (rank: 4) to have a rank smaller or equal to the given `sizes` [-1, 2] (rank: 2).)
    From: GetExpandDimensions at torch_xla/csrc/tensor_methods.cpp:257
    From: expand at torch_xla/csrc/tensor_methods.cpp:1789
    From: expand_symint at torch_xla/csrc/aten_xla_type.cpp:4565

Exception raised from ThrowStatusError at torch_xla/csrc/status.cpp:128 (most recent call first):
```

</details>

## Example 2: dimension size mismatch

```python
a = torch.rand(1, 1, 2, 3, device=device)
sizes = [1, 1, 1, 3]
a.expand(sizes)
```

<details>
<summary>Comparison</summary>

**Before:**

```python
Traceback (most recent call last):
  File "examples/expand.py", line 30, in <module>
    a.expand(sizes)
RuntimeError: Input dimension should be either 1 or equal to the output dimension it is broadcasting into; the 3th operand dimension is 2, the 3th output dimension is 1.

Status Propagation Trace:
    From: ShapeOfXlaOp at torch_xla/csrc/shape_helper.cpp:9

Exception raised from ThrowStatusError at torch_xla/csrc/status.cpp:128 (most recent call first):
```

**After:** 

```python
Traceback (most recent call last):
  File "examples/expand.py", line 30, in <module>
    a.expand(sizes)
RuntimeError: expand(): expected dimension 3 of the given `sizes` [2, 1, 1, 1, 3] (1) to be -1, or equal to the size of the `input` tensor f32[1,1,2,3] at dimension 2 (2).

Status Propagation Trace:
    From: GetExpandDimensions at torch_xla/csrc/tensor_methods.cpp:270 (error: expand(): expected dimension 3 of the given `sizes` [2, 1, 1, 1, 3] (1) to be -1, or equal to the size of the `input` tensor f32[1,1,2,3] at dimension 2 (2).)
    From: expand at torch_xla/csrc/tensor_methods.cpp:1789
    From: expand_symint at torch_xla/csrc/aten_xla_type.cpp:4565

Exception raised from ThrowStatusError at torch_xla/csrc/status.cpp:128 (most recent call first):
```

</details>