### PR TITLE
Skip failing C++ test.

### DIFF
--- a/test/cpp/test_aten_xla_tensor_1.cpp
+++ b/test/cpp/test_aten_xla_tensor_1.cpp
@@ -356,6 +356,9 @@ TEST_F(AtenXlaTensorTest, TestSiLU) {
 }
 
 TEST_F(AtenXlaTensorTest, TestSiLUBackward) {
+  GTEST_SKIP()
+    << "failing due to PyTorch upstream changes. "
+    << "See: https://github.com/pytorch/xla/issues/9651.";
   auto testfn = [&](const std::vector<torch::Tensor>& inputs) -> torch::Tensor {
     return torch::silu(inputs[0]);
   };


### PR DESCRIPTION
This PR implements the first step in #9651: skips the failing C++ test.