### PR TITLE
Accept conda channels' ToS when building the upstream docker image.

### DIFF
--- a/.github/upstream/install_conda.sh
+++ b/.github/upstream/install_conda.sh
@@ -27,6 +27,10 @@ function install_and_setup_conda() {
   fi
   export CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 
+  # Accept Conda channel ToS.
+  conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
+  conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
+
   conda update -y -n base conda
   conda install -y python=$PYTHON_VERSION
 


### PR DESCRIPTION
This PR should fix [the error](https://github.com/pytorch/xla/actions/runs/18161391171/job/51692786522) we've been getting when trying to build the upstream image. It simply adds to the `install_conda.sh` script what `conda` suggests us to do:

```
#23 12.71 CondaToSNonInteractiveError: Terms of Service have not been accepted for the following channels. Please accept or remove them before proceeding:
#23 12.71     - https://repo.anaconda.com/pkgs/main
#23 12.71     - https://repo.anaconda.com/pkgs/r
#23 12.71 
#23 12.71 To accept these channels' Terms of Service, run the following commands:
#23 12.71     conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
#23 12.71     conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
#23 12.71 
#23 12.71 For information on safely removing channels from your conda configuration,
#23 12.71 please see the official documentation:
#23 12.71 
#23 12.71     https://www.anaconda.com/docs/tools/working-with-conda/channels
``` 