### PR TITLE
Bump Python version of `ci-tpu-test-trigger` to 3.12.

### DIFF
--- a/infra/tpu-pytorch/test_triggers.tf
+++ b/infra/tpu-pytorch/test_triggers.tf
@@ -23,7 +23,7 @@ module "tpu_e2e_tests" {
   ])
 
   build_args = {
-    python_version = "3.10"
+    python_version = "3.12"
   }
 
   ansible_vars = {


### PR DESCRIPTION
`ci-tpu-test-trigger` was failing with:

```
Downloading https://us-python.pkg.dev/ml-oss-artifacts-published/jax/meson-python/meson_python-0.18.0-py3-none-any.whl
    ...
    meson-python: error: The package requires Python version >=3.11, running on 3.10.18
```