### PR TITLE
Accept conda channels' ToS with environment variable.

### DIFF
--- a/.github/upstream/install_conda.sh
+++ b/.github/upstream/install_conda.sh
@@ -27,9 +27,9 @@ function install_and_setup_conda() {
   fi
   export CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 
-  # Accept Conda channel ToS.
-  conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
-  conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
+  # Accept Conda channels' ToS automatically.
+  # Ref: https://github.com/pytorch/pytorch/issues/158438#issuecomment-3084935777
+  export CONDA_PLUGINS_AUTO_ACCEPT_TOS="yes"
 
   conda update -y -n base conda
   conda install -y python=$PYTHON_VERSION


### PR DESCRIPTION
Follow-up: #9661 

Apparently, we need to accept the ToS of those same channels, again ([link](https://github.com/pytorch/xla/actions/runs/18172128014/job/51729124142)). Instead, I'm using the `CONDA_PLUGINS_AUTO_ACCEPT_TOS` environment variable, documented [here](https://github.com/pytorch/pytorch/issues/158438#issuecomment-3084935777).
