### PR TITLE
Remove python 3.9 wheels and update terraform PyTorch/XLA release version to 2.9

### DIFF
--- a/infra/tpu-pytorch-releases/artifacts_builds.tf
+++ b/infra/tpu-pytorch-releases/artifacts_builds.tf
@@ -1,11 +1,11 @@
 ########## Begin section for release and nightly ########
 # Define common configuration parameters for 2.8 release and nightly
 locals {
-  tpu_python_versions = ["3.9", "3.10", "3.11", "3.12", "3.13"]
-  release_git_tag         = "v2.8.0-rc5"
-  release_package_version = "2.8.0-rc5"
-  release_pytorch_git_rev = "v2.8.0-rc8"
-  nightly_package_version = "2.9.0"
+  tpu_python_versions = ["3.10", "3.11", "3.12", "3.13"]
+  release_git_tag         = "v2.9.0-rc1"
+  release_package_version = "2.9.0-rc1"
+  release_pytorch_git_rev = "v2.9.0-rc5"
+  nightly_package_version = "2.10.0"
 
   # Built once a day from master
   generated_nightly_builds = concat(


### PR DESCRIPTION
Remove  build wheels for Python 3.9