### PR TITLE
Support manylinux build for r2.9.

### DIFF
--- a/infra/ansible/roles/build_srcs/tasks/main.yaml
+++ b/infra/ansible/roles/build_srcs/tasks/main.yaml
@@ -43,7 +43,7 @@
 
 - name: Build PyTorch/XLA
   ansible.builtin.command:
-    cmd: python setup.py bdist_wheel
+    cmd: python setup.py bdist_wheel -p manylinux_2_28_x86_64
     chdir: "{{ (src_root, 'pytorch/xla') | path_join }}"
   environment: "{{ env_vars }}"
 


### PR DESCRIPTION
Using the `manylinux_2_28_x86_64` tag guarantees that the built wheel works for any linux distribution with glibc version >= 2.28

If this is not used, then the built wheel is not guaranteed to work on linux distributions other than what the build infra uses.

See [manylinux](https://github.com/pypa/manylinux?tab=readme-ov-file) for more details