### PR TITLE
Ensuring PJRT Client destroy/destructor is called

### DIFF
--- a/torch_xla/csrc/runtime/runtime.cpp
+++ b/torch_xla/csrc/runtime/runtime.cpp
@@ -17,7 +17,7 @@ static std::atomic<bool> g_computation_client_initialized(false);
 // Creates a new instance of a `ComputationClient` (e.g.
 // `PjRtComputationClient`), and initializes the computation client.
 // Can only be called when g_computation_client_initialized is false.
-static absl::StatusOr<ComputationClient * absl_nonnull>
+static absl::StatusOr<std::unique_ptr<ComputationClient>>
 InitializeComputationClient() {
   if (sys_util::GetEnvBool("XLA_DUMP_FATAL_STACK", false)) {
     tsl::testing::InstallStacktraceHandler();
@@ -46,7 +46,7 @@ InitializeComputationClient() {
   // Set only if we actually successfully initialized a client.
   g_computation_client_initialized = true;
 
-  return client.release();
+  return client;
 }
 
 const absl::StatusOr<ComputationClient * absl_nonnull>& GetComputationClient() {
@@ -55,9 +55,20 @@ const absl::StatusOr<ComputationClient * absl_nonnull>& GetComputationClient() {
   // Since we only allow a single initialization, as soon as this function is
   // called, we store the initialization result in this trivially destructible
   // reference.
-  static const auto& maybe_client =
-      *new absl::StatusOr<ComputationClient*>(InitializeComputationClient());
-  return maybe_client;
+  static absl::StatusOr<std::unique_ptr<ComputationClient>> init_result =
+      InitializeComputationClient();
+
+  static absl::StatusOr<ComputationClient* absl_nonnull> maybeClient = []() {
+    if (init_result.ok()) {
+      return absl::StatusOr<ComputationClient * absl_nonnull>(
+          init_result.value().get());
+    } else {
+      // Return the same error from initialization
+      return absl::StatusOr<ComputationClient * absl_nonnull>(
+          init_result.status());
+    }
+  }();
+  return maybeClient;
 }
 
 ComputationClient* GetComputationClientIfInitialized() {

--- a/torch_xla/csrc/runtime/runtime.cpp
+++ b/torch_xla/csrc/runtime/runtime.cpp
@@ -58,17 +58,16 @@ const absl::StatusOr<ComputationClient * absl_nonnull>& GetComputationClient() {
   static absl::StatusOr<std::unique_ptr<ComputationClient>> init_result =
       InitializeComputationClient();
 
-  static absl::StatusOr<ComputationClient* absl_nonnull> maybeClient = []() {
+  static absl::StatusOr<ComputationClient* absl_nonnull> maybe_client = []() {
     if (init_result.ok()) {
       return absl::StatusOr<ComputationClient * absl_nonnull>(
           init_result.value().get());
     } else {
-      // Return the same error from initialization
       return absl::StatusOr<ComputationClient * absl_nonnull>(
           init_result.status());
     }
   }();
-  return maybeClient;
+  return maybe_client;
 }
 
 ComputationClient* GetComputationClientIfInitialized() {


### PR DESCRIPTION
Re-introducing a static unique_ptr to manage the lifecycle of PjRtComputationClient, ensuring that the destructor / destory method of PJRT Client is called. 

After running the reproduction steps mentioned in #9669 and including this change, I have manually confirmed that that PJRT Client destructor is called
```
ubuntu@ip-[redacted]:~$ export TF_CPP_MIN_LOG_LEVEL=0; export TF_CPP_VMODULE="cpu_client=1"; export NEURON_RT_LOG_LEVEL=DEBUG; export PJRT_DEVICE=CPU
(aws_neuronx_venv_pytorch_2_8) ubuntu@ip-172-31-59-9:~$ python -c "import torch_xla; device=torch_xla.device()"
WARNING:root:MASTER_ADDR environment variable is not set, defaulting to localhost
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1759797507.812598  222797 cpu_client.cc:311] PjRtCpuClient created.
I0000 00:00:1759797508.238195  222797 cpu_client.cc:314] PjRtCpuClient destroyed.
```