### PR TITLE
Fix `push-docs` CI for `push` events without code changes.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,7 +42,14 @@ jobs:
     with:
       dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.12_tpuvm
       timeout-minutes: 45  # Takes ~20m as of 2025/5/30.
-      has_code_changes: ${{ needs.check_code_changes.outputs.has_code_changes }}
+      # We should build PyTorch and PyTorch/XLA if:
+      #   1. There are code changes.
+      #   2. This is a `push` event to `master` or release branches.
+      #
+      # The reason for (2) is that `push-docs` job below is run precisely on (2) condition.
+      # In order for it (the `push-docs` job) to be successful, it needs to install the PyTorch
+      # and PyTorch/XLA wheels. Therefore, we need to build their wheels by running this job.
+      has_code_changes: ${{ (needs.check_code_changes.outputs.has_code_changes == 'true' || github.event_name == 'push') && 'true' || 'false' }}
       runner: linux.24xlarge
     secrets:
       gcloud-service-key: ${{ secrets.GCLOUD_SERVICE_KEY }}


### PR DESCRIPTION
This PR fixes the error found in [this `push-docs` CI run][1] for a `push` event on `master` branch.

**What happened:**
- `push-docs` failed because it couldn't find the `torch-xla-wheels` artifact
- The `torch-xla-wheels` artifact wasn't uploaded because its upload and the dependent build step are coditioned by `inputs.has_code_changes == 'true'`

**Solution:**
- Build PyTorch and PyTorch/XLA on every `push` event, since that's also when `push-docs` runs

_Note: `push-docs` job actually needs to install both PyTorch and PyTorch/XLA, otherwise it can't retrieve the docstrings that we rely on to build the documentation._

[1]: https://github.com/pytorch/xla/actions/runs/18698514731/job/53322086395