### PR TITLE
Increase CI build timeout.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,8 +41,7 @@ jobs:
     needs: [check_code_changes]
     with:
       dev-image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/development:3.12_tpuvm
-      # Test change for triggering build timeout.
-      timeout-minutes: 45  # Takes ~20m as of 2025/5/30.
+      timeout-minutes: 50  # Takes ~50m as of 2025/10/28 (without the remote cache).
       # We should build PyTorch and PyTorch/XLA if:
       #   1. There are code changes.
       #   2. This is a `push` event to `master` or release branches.


### PR DESCRIPTION
PRs from external repositories are timeouting on `_build_torch_xla.yml` workflow. That's because in those cases, [the remote cache is disabled][1]. In such cases, [the fixed 45 minutes][2] is not enough anymore. See, for example, PR #9682 that fails due to this timeout.

Here's my plan to address this issue:

- Bump the timeout by 5 minutes (this PR)
- Create a disk-cache using GitHub cache actions for reducing build time on PRs from external repositories (see [#9659][3] for more information)

This PR will go through the following steps:

- [x] Reproduce the CI build timeout 
- [x] Bump the timeout by 5 minutes

[1]: https://github.com/pytorch/xla/blob/df6798dfb931ce7c7fe5bed2447cd1092a5981af/.github/workflows/_build_torch_xla.yml#L36
[2]: https://github.com/pytorch/xla/blob/df6798dfb931ce7c7fe5bed2447cd1092a5981af/.github/workflows/build_and_test.yml#L44
[3]: https://github.com/pytorch/xla/pull/9659