### PR TITLE
Revert "mul: remove opmath cast sequence (pytorch#9663)"

### DIFF
--- a/test/test_operations_hlo.py
+++ b/test/test_operations_hlo.py
@@ -67,22 +67,6 @@ class TestOperationsHlo(unittest.TestCase):
     hlo_text = torch_xla._XLAC._get_xla_tensors_hlo([b])
     assert 'u8' in hlo_text
 
-  def test_bfloat16_mul_upcast(self):
-    a = torch.rand(5, 5, dtype=torch.bfloat16).to('xla')
-    b = torch.rand(5, 5, dtype=torch.bfloat16).to('xla')
-    c = a * b
-    hlo_text = torch_xla._XLAC._get_xla_tensors_hlo([c])
-    # Check that the output is not upcasted to float32
-    assert 'f32' in hlo_text
-
-  def test_bfloat16_float32_mul_upcast(self):
-    a = torch.rand(5, 5, dtype=torch.bfloat16).to('xla')
-    b = torch.rand(5, 5, dtype=torch.float32).to('xla')
-    c = a * b
-    hlo_text = torch_xla._XLAC._get_xla_tensors_hlo([c])
-    # Check that the output is upcasted to float32
-    assert 'f32' in hlo_text
-
 
 if __name__ == '__main__':
   torch.set_default_dtype(torch.float32)

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2529,26 +2529,14 @@ at::Tensor XLANativeFunctions::mse_loss_backward(const at::Tensor& grad_output,
 at::Tensor XLANativeFunctions::mul(const at::Tensor& self,
                                    const at::Tensor& other) {
   TORCH_LAZY_FN_COUNTER_TIMED_TRACING("xla::");
-
-  // Check device type to determine if we need opmathtype for mixed-precision
-  XLA_ASSIGN_OR_THROW(XLATensorPtr xla_self, bridge::GetXlaTensor(self));
-  XlaDeviceType hw_type =
-      static_cast<XlaDeviceType>(xla_self->GetDevice().type());
-
-  auto config =
-      OpConfig([](const XLAInputVector& inputs, at::ScalarType dtype) {
-        return tensor_methods::mul(inputs[0], inputs[1], dtype);
-      })
-          .add_input(self)
-          .add_input(other)
-          .cast_inputs_to_common_dtype();
-
-  // Only use opmathtype for CPU or Neuron backend
-  if (hw_type == XlaDeviceType::CPU || hw_type == XlaDeviceType::NEURON) {
-    config.use_opmathtype_for_compute();
-  }
-
-  return config.run();
+  using FnType = XLATensorPtr(const XLATensorPtr&, const XLATensorPtr&,
+                              std::optional<at::ScalarType>);
+  return OpConfig::From(static_cast<FnType*>(tensor_methods::mul))
+      .add_input(self)
+      .add_input(other)
+      .cast_inputs_to_common_dtype()
+      .use_opmathtype_for_compute()
+      .run();
 }
 
 at::Tensor XLANativeFunctions::mul(const at::Tensor& self,


### PR DESCRIPTION
Commit 2a9138a removed `.use_opmathtype_for_compute()` from element-wise 'mul' operation, this breaks mixed-precision accumulation behavior expected by the Neuron compiler that traces/compile on CPU and later execute the binary on neuron hardwares, causing significant accuracy degradation in:

- Llama 3.1 70B models (16.7% throughput drop, accuracy failures)
- Mixtral 8x22B models (accuracy test failures)
- Other transformer models using mixed-precision compilation

Reverts: commit 2a9138a, other changes are result of rebase from r2.9
Fixes: Model accuracy failures with mixed-precision accumulation https://github.com/pytorch/xla/issues/9699
