### PR TITLE
Remove `fmtlib` explicit dependency.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,12 +42,6 @@ new_local_repository(
     path = PYTORCH_LOCAL_DIR,
 )
 
-new_local_repository(
-    name = "fmt",
-    build_file = "//bazel:fmt.BUILD",
-    path = PYTORCH_LOCAL_DIR + "/third_party/fmt",
-)
-
 ############################# OpenXLA Setup ###############################
 
 # To build PyTorch/XLA with a new revison of OpenXLA, update the xla_hash to

--- a/bazel/fmt.BUILD
+++ b/bazel/fmt.BUILD
@@ -1,9 +1,0 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
-cc_library(
-    name = "fmt",
-    hdrs = glob(["include/fmt/*.h",]),
-    defines = ["FMT_HEADER_ONLY=1"],
-    includes = ["include"],
-    visibility = ["//visibility:public"],
-)

--- a/bazel/torch.BUILD
+++ b/bazel/torch.BUILD
@@ -10,9 +10,6 @@ cc_library(
         ["torch/include/**/*.h"],
         ["torch/include/google/protobuf/**/*.h"],
     ),
-    deps = [
-        "@fmt",
-    ],
     strip_include_prefix = "torch/include",
 )
 


### PR DESCRIPTION
This PR removes the temporary fmtlib dependency introduced in #9650 (see issue #9653).

As explained [in this comment][1], the dependency was only added to work around a build issue that should have been fixed upstream in PyTorch. Before the `fmtlib` version bump to 12 in PyTorch (pytorch/pytorch#163441), `fmtlib` headers were exported by default. After the bump, they stopped being exported, which caused the issue.

That behavior has since been fixed in PyTorch (pytorch/pytorch#164139), so we can safely remove the explicit fmtlib dependency.

[1]: https://github.com/pytorch/xla/pull/9650#pullrequestreview-3264207974
