### PR TITLE
Replace device parsing by `GetVirtualDevice()` function call.

### DIFF
--- a/torch_xla/csrc/aten_xla_bridge.cpp
+++ b/torch_xla/csrc/aten_xla_bridge.cpp
@@ -47,14 +47,14 @@ class AtenXlaDeviceMapper {
         return;
       }
     }
-    devices_.emplace_back(ParseDeviceString("SPMD:0"));
+    devices_.emplace_back(GetVirtualDevice());
     devices_ordinals_[devices_.back()] = 0;
   }
 
  private:
   AtenXlaDeviceMapper() {
     if (UseVirtualDevice()) {
-      devices_.emplace_back(ParseDeviceString("SPMD:0"));
+      devices_.emplace_back(GetVirtualDevice());
       devices_ordinals_[devices_.back()] = 0;
     } else {
       XLA_ASSIGN_OR_THROW(

--- a/torch_xla/csrc/device.cpp
+++ b/torch_xla/csrc/device.cpp
@@ -74,7 +74,8 @@ torch::lazy::BackendDevice ParseDeviceString(const std::string& device_spec) {
 }
 
 torch::lazy::BackendDevice GetVirtualDevice() {
-  return ParseDeviceString("SPMD:0");
+  return torch::lazy::BackendDevice(
+      std::make_shared<DeviceType>(XlaDeviceType::SPMD), 0);
 }
 
 bool ShouldUseVirtualDevice() {

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1733,8 +1733,7 @@ void InitXlaModuleBindings(py::module m) {
                 bridge::GetCurrentDevice();
             std::vector<XLATensorPtr> xtensors =
                 XLAGraphExecutor::Get()->GetLiveTensors(&current_device);
-            torch::lazy::BackendDevice spmd_device =
-                ParseDeviceString("SPMD:0");
+            torch::lazy::BackendDevice spmd_device = GetVirtualDevice();
             for (auto xtensor : xtensors) {
               XlaDeviceType xla_device_type =
                   static_cast<XlaDeviceType>(xtensor->GetDevice().type());

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -471,7 +471,7 @@ void XLAGraphExecutor::WaitDeviceOps(absl::Span<const std::string> devices) {
     }
   } else {
     if (UseVirtualDevice()) {
-      wait_devices.insert(ParseDeviceString("SPMD:0"));
+      wait_devices.insert(GetVirtualDevice());
     } else {
       XLA_ASSIGN_OR_THROW(
           runtime::ComputationClient * absl_nonnull const client,


### PR DESCRIPTION
This PR avoids parsing `SPMD:0` every time by calling `GetVirtualDevice()` instead of the parsing function. It also avoids calling the parsing function inside `GetVirtualDevice()`, creating a new instance directly.

**Key Changes:**

1. `GetVirtualDevice()` simply creates a new `BackendDevice` of `SPMD` type
2. Replaced the multiple calls to `ParseDeviceString("SPMD:0")` by `GetVirtualDevice()`