### PR TITLE
Remove deprecated `GetDefaultDevice()`.

### DIFF
--- a/test/cpp/cpp_test_util.cpp
+++ b/test/cpp/cpp_test_util.cpp
@@ -154,7 +154,8 @@ bool EqualValuesNoElementTypeCheck(at::Tensor tensor1, at::Tensor tensor2) {
 void ForEachDevice(
     absl::Span<const DeviceType> device_types,
     const std::function<void(const torch::lazy::BackendDevice&)>& devfn) {
-  const torch::lazy::BackendDevice* default_device = bridge::GetDefaultDevice();
+  XLA_ASSIGN_OR_THROW(const torch::lazy::BackendDevice* default_device,
+                      bridge::GetDefaultDevice());
   if (device_types.empty() ||
       std::find_if(device_types.begin(), device_types.end(),
                    [&](const DeviceType device_type) {
@@ -169,7 +170,8 @@ void ForEachDevice(
 
 void ForEachDevice(absl::Span<const DeviceType> device_types,
                    const std::function<void(const torch::Device&)>& devfn) {
-  const torch::lazy::BackendDevice* default_device = bridge::GetDefaultDevice();
+  XLA_ASSIGN_OR_THROW(const torch::lazy::BackendDevice* default_device,
+                      bridge::GetDefaultDevice());
   if (device_types.empty() ||
       std::find_if(device_types.begin(), device_types.end(),
                    [&](const DeviceType device_type) {

--- a/test/cpp/test_aten_xla_tensor_5.cpp
+++ b/test/cpp/test_aten_xla_tensor_5.cpp
@@ -1422,8 +1422,9 @@ TEST_F(AtenXlaTensorTest, TestAvgPool3DNoBatch) {
 }
 
 TEST_F(AtenXlaTensorTest, TestAdaptiveMaxPool2D) {
-  XlaDeviceType hw_type =
-      static_cast<XlaDeviceType>(bridge::GetDefaultDevice()->type());
+  XLA_ASSIGN_OR_THROW(const torch::lazy::BackendDevice* default_device,
+                      bridge::GetDefaultDevice());
+  XlaDeviceType hw_type = static_cast<XlaDeviceType>(default_device->type());
   // skip this test until the tile mismatch bug is fixed.
   if (hw_type == XlaDeviceType::TPU) {
     return;
@@ -1455,8 +1456,9 @@ TEST_F(AtenXlaTensorTest, TestAdaptiveMaxPool2D) {
 TEST_F(AtenXlaTensorTest, TestAdaptiveMaxPool2DBackward) {
   GTEST_SKIP() << "failing due to PyTorch upstream changes. "
                << "See: https://github.com/pytorch/xla/issues/9651.";
-  XlaDeviceType hw_type =
-      static_cast<XlaDeviceType>(bridge::GetDefaultDevice()->type());
+  XLA_ASSIGN_OR_THROW(const torch::lazy::BackendDevice* default_device,
+                      bridge::GetDefaultDevice());
+  XlaDeviceType hw_type = static_cast<XlaDeviceType>(default_device->type());
   // skip this test until the tile mismatch bug is fixed.
   if (hw_type == XlaDeviceType::TPU) {
     return;

--- a/test/cpp/test_aten_xla_tensor_6.cpp
+++ b/test/cpp/test_aten_xla_tensor_6.cpp
@@ -943,8 +943,9 @@ TEST_F(AtenXlaTensorTest, TestEmbeddingBackward) {
 }
 
 TEST_F(AtenXlaTensorTest, TestAmpUpdateScale) {
-  XlaDeviceType hw_type =
-      static_cast<XlaDeviceType>(bridge::GetDefaultDevice()->type());
+  XLA_ASSIGN_OR_THROW(const torch::lazy::BackendDevice* default_device,
+                      bridge::GetDefaultDevice());
+  XlaDeviceType hw_type = static_cast<XlaDeviceType>(default_device->type());
   if (hw_type != XlaDeviceType::CPU) {
     return;
   }

--- a/torch_xla/csrc/aten_xla_bridge.cpp
+++ b/torch_xla/csrc/aten_xla_bridge.cpp
@@ -419,14 +419,8 @@ InitializeDefaultBackendDevice() {
   return new torch::lazy::BackendDevice(device);
 }
 
-const torch::lazy::BackendDevice* absl_nonnull GetDefaultDevice() {
-  XLA_ASSIGN_OR_THROW(const torch::lazy::BackendDevice* absl_nonnull device,
-                      SafeGetDefaultDevice());
-  return device;
-}
-
 const absl::StatusOr<torch::lazy::BackendDevice * absl_nonnull>&
-SafeGetDefaultDevice() {
+GetDefaultDevice() {
   static absl::StatusOr<torch::lazy::BackendDevice* absl_nonnull>&
       default_backend_device =
           *new absl::StatusOr<torch::lazy::BackendDevice * absl_nonnull>(
@@ -435,12 +429,16 @@ SafeGetDefaultDevice() {
 }
 
 c10::Device AtenDefaultDevice() {
-  return XlaDeviceToAtenDevice(*GetDefaultDevice());
+  XLA_ASSIGN_OR_THROW(const torch::lazy::BackendDevice* default_device,
+                      bridge::GetDefaultDevice());
+  return XlaDeviceToAtenDevice(*default_device);
 }
 
 torch::lazy::BackendDevice GetCurrentDevice() {
   if (!g_current_device) {
-    g_current_device = *GetDefaultDevice();
+    XLA_ASSIGN_OR_THROW(const torch::lazy::BackendDevice* default_device,
+                        bridge::GetDefaultDevice());
+    g_current_device = *default_device;
   }
   return *g_current_device;
 }

--- a/torch_xla/csrc/aten_xla_bridge.h
+++ b/torch_xla/csrc/aten_xla_bridge.h
@@ -30,11 +30,12 @@ namespace bridge {
 // A StatusOr type fulfills only (2), so we can't use it there. In order
 // to do so, we have to change upstream accordingly.
 //
-ABSL_DEPRECATED(
+[[deprecated(
     "Use GetXlaTensor(), instead. "
     "This function returns an null-initialized `XLATensorPtr`, instead of "
-    "propagating errors with StatusOr values.")
-XLATensorPtr TryGetXlaTensor(const at::Tensor& tensor);
+    "propagating errors with StatusOr values.")]]  //
+XLATensorPtr
+TryGetXlaTensor(const at::Tensor& tensor);
 
 // Retrieves the underlying `XLATensorPtr` from `tensor`.
 //
@@ -144,16 +145,11 @@ c10::Device XlaDeviceToAtenDevice(const torch::lazy::BackendDevice& device);
 
 std::string ToXlaString(const c10::Device& device);
 
-[[deprecated(
-    "Use SafeGetDefaultDevice for better error handling.")]] const torch::lazy::
-    BackendDevice* absl_nonnull
-    GetDefaultDevice();
-
 // Returns the default `BackendDevice`.
 // This function returns an error if the `ComputationClient` wasn't correctly
 // initialized.
 const absl::StatusOr<torch::lazy::BackendDevice * absl_nonnull>&
-SafeGetDefaultDevice();
+GetDefaultDevice();
 
 c10::Device AtenDefaultDevice();
 

--- a/torch_xla/csrc/ir_builder.h
+++ b/torch_xla/csrc/ir_builder.h
@@ -27,8 +27,10 @@ struct XLAIrBuilder : torch::lazy::IrBuilder {
 
   torch::lazy::NodePtr MakeScalar(const at::Scalar& value,
                                   const at::ScalarType& type) const override {
+    XLA_ASSIGN_OR_THROW(const torch::lazy::BackendDevice* default_device,
+                        bridge::GetDefaultDevice());
     return torch_xla::MakeNode<Scalar>(
-        value, MakeXlaPrimitiveType(type, bridge::GetDefaultDevice()));
+        value, MakeXlaPrimitiveType(type, default_device));
   }
   torch::lazy::NodePtr MakeExpand(const torch::lazy::Value& input0,
                                   const std::vector<int64_t>& size,

--- a/torch_xla/csrc/ops/dynamic_ir.cpp
+++ b/torch_xla/csrc/ops/dynamic_ir.cpp
@@ -50,8 +50,10 @@ int64_t SizeNode::getDynamicValue() const {
   // Wrap the IR of SizeNode into a dummy tensor and execute/fetch the value
   // of this tensor. GetTensors will return a cpu at::Tensor so we can just
   // extract the value of it.
-  std::vector<XLATensorPtr> dummy_size_tensors = {XLATensor::Create(
-      cloned, *bridge::GetDefaultDevice(), at::ScalarType::Long)};
+  XLA_ASSIGN_OR_THROW(const torch::lazy::BackendDevice* default_device,
+                      bridge::GetDefaultDevice());
+  std::vector<XLATensorPtr> dummy_size_tensors = {
+      XLATensor::Create(cloned, *default_device, at::ScalarType::Long)};
   std::vector<at::Tensor> res =
       XLAGraphExecutor::Get()->GetTensors(&dummy_size_tensors);
   runtime_size_ = res[0].item().toInt();

--- a/torch_xla/csrc/xla_backend_impl.cpp
+++ b/torch_xla/csrc/xla_backend_impl.cpp
@@ -42,8 +42,9 @@ class XlaBackendImpl : public torch::lazy::BackendImplInterface {
     if (!default_device_ordinal_inited_) {
       // bridge::GetDefaultDevice will trigger the runtime device init, should
       // not do it during class init time.
-      torch::lazy::BackendDevice default_device = *bridge::GetDefaultDevice();
-      default_device_ordinal_ = default_device.ordinal();
+      XLA_ASSIGN_OR_THROW(const torch::lazy::BackendDevice* default_device,
+                          bridge::GetDefaultDevice());
+      default_device_ordinal_ = default_device->ordinal();
       default_device_ordinal_inited_ = true;
     }
     return true;


### PR DESCRIPTION
This PR removes the deprecated `GetDefaultDevice()`, and renames `SafeGetDefaultDevice()`, removing its `Safe` prefix. Then, it also adapts all `GetDefaultDevice()` call sites, so as to handle the returned status-like instance appropriately.

**Key Changes:**

- Remove the deprecated `GetDefaultDevice()`
- Rename `SafeGetDefaultDevice()` to `GetDefaultDevice()`
- Handle the returned status-like instance of all `GetDefaultDevice()` call sites
- Use `[[deprecated(...)]]` instead of `ABSL_DEPRECATED` for `TryGetXlaTensor()` function