### PR TITLE
Make a function wrapper for _get_xla_sharding_specs

### DIFF
--- a/torch_xla/_dynamo/dynamo_bridge.py
+++ b/torch_xla/_dynamo/dynamo_bridge.py
@@ -25,6 +25,7 @@ import torch_xla.core.xla_env_vars as xenv
 import torch_xla.runtime as xr
 import torch_xla.utils.utils as xu
 from torch_xla.utils.buffer_donor_context import alias_with_buffer_donor_config
+from torch_xla.distributed.spmd.xla_sharding import get_xla_sharding_specs
 import torch_xla.utils.dlpack as torch_xla_dlpack
 
 dynamo_debug = int(os.environ.get('XLA_DYNAMO_DEBUG', '0')) == 1
@@ -339,8 +340,7 @@ def extract_graph_helper(xla_model: torch.fx.GraphModule,
   }
 
   if xr.is_spmd():
-    xla_args_sharding_spec = torch_xla._XLAC._get_xla_sharding_specs(
-        xla_args_tensor_only)
+    xla_args_sharding_spec = get_xla_sharding_specs(xla_args_tensor_only)
   else:
     xla_args_sharding_spec = ()
 
@@ -531,7 +531,7 @@ def extract_internal(xla_model: torch.fx.GraphModule):
       # if the input sharding was the same for skip_checking_input_sharding_threashold times
       # we will skip checking the input sharding since it can be expensive.
       if skip_checking_input_sharding_threashold > 0:
-        if torch_xla._XLAC._get_xla_sharding_specs(
+        if get_xla_sharding_specs(
             xla_args_tensor_only) != xla_args_sharding_spec:
           # update the xla_args with the input with new sharding and retrace
           xla_model.xla_args = args

--- a/torch_xla/distributed/spmd/xla_sharding.py
+++ b/torch_xla/distributed/spmd/xla_sharding.py
@@ -847,10 +847,32 @@ def clear_sharding(t: Union[torch.Tensor, XLAShardedTensor]) -> torch.Tensor:
   return t
 
 
+def get_xla_sharding_specs(tensors: list) -> list:
+  """
+  Returns XLA sharding specs for the given tensors, normalizing unsharded
+  tensors to '{replicated}'.
+
+  Unsharded tensors have an empty sharding spec, but after dispatch they are
+  annotated as '{replicated}'. Without normalization, the empty spec and the
+  post-dispatch replicated spec would differ under equality comparison, causing
+  unnecessary graph retracing on every step.
+
+  Args:
+    tensors (list[torch.Tensor]): XLA tensors to query sharding specs for.
+
+  Returns:
+    list[str]: HLO sharding spec strings, one per tensor. Unsharded tensors
+      are returned as '{replicated}'.
+  """
+  return [
+      s if s else "{replicated}"
+      for s in torch_xla._XLAC._get_xla_sharding_specs(tensors)
+  ]
+
+
 def wrap_as_sharded_tensor(t: Union[torch.Tensor, XLAShardedTensor],
                            mesh_shape=None,
                            partition_spec=None) -> XLAShardedTensor:
-  # pass along mesh and partition spec information
   if not isinstance(t, XLAShardedTensor):
     # Create a new XLAShardedTensor
     return XLAShardedTensor(

--- a/torch_xla/distributed/spmd/xla_sharding.py
+++ b/torch_xla/distributed/spmd/xla_sharding.py
@@ -873,6 +873,7 @@ def get_xla_sharding_specs(tensors: list) -> list:
 def wrap_as_sharded_tensor(t: Union[torch.Tensor, XLAShardedTensor],
                            mesh_shape=None,
                            partition_spec=None) -> XLAShardedTensor:
+  # pass along mesh and partition spec information
   if not isinstance(t, XLAShardedTensor):
     # Create a new XLAShardedTensor
     return XLAShardedTensor(


### PR DESCRIPTION
When running multichip models with SPMD, dynamo retraces the graph on every step due to an inconsistency in how unsharded tensors are represented. `_get_xla_sharding_specs` returns "" for tensors with no explicit sharding annotation, but in `xla_sharding_util.cpp`, when building sharded data for tensors whose sharding_spec is nullptr, the runtime assigns `xla::HloSharding::Replicate()`, so after the first dispatch those tensors carry a {replicated} annotation. On the next step, `_get_xla_sharding_specs` still returns "" for the inputs, but `xla_args_sharding_spec` now holds {replicated} from the previous capture, and the inequality `"" != "{replicated}"` is detected as a sharding change, triggering a retrace every step. 

This is fixed by adding a `get_xla_sharding_specs` wrapper in `torch_xla/distributed/spmd/xla_sharding.py` that normalizes empty sharding specs to {replicated}, ensuring the spec captured at trace time is consistent with what the runtime assigns post-dispatch.

For more information and repro, please see: https://github.com/pytorch/xla/issues/9755#issuecomment-4063484331