### PR TITLE
Fix composite pass missing captured values in ops with nested regions

### DIFF
--- a/torch_xla/csrc/runtime/stablehlo_composite_helper.cpp
+++ b/torch_xla/csrc/runtime/stablehlo_composite_helper.cpp
@@ -428,8 +428,7 @@ class BuildStableHLOCompositePass : public mlir::OperationPass<mlir::ModuleOp> {
         for (mlir::Value value : captured) {
           mlir::Operation* def_op = value.getDefiningOp();
           if (def_op == nullptr) {
-            arg_pos_setvec.insert(
-                {value, std::numeric_limits<int64_t>::max()});
+            arg_pos_setvec.insert({value, std::numeric_limits<int64_t>::max()});
           } else if (llvm::isa<mlir::stablehlo::ConstantOp>(def_op)) {
             impl_ops_setvec.insert(def_op);
           } else {

--- a/torch_xla/csrc/runtime/stablehlo_composite_helper.cpp
+++ b/torch_xla/csrc/runtime/stablehlo_composite_helper.cpp
@@ -10,6 +10,7 @@
 #include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/RegionUtils.h"
 #include "single_include/nlohmann/json.hpp"
 #include "stablehlo/dialect/StablehloOps.h"
 
@@ -416,6 +417,24 @@ class BuildStableHLOCompositePass : public mlir::OperationPass<mlir::ModuleOp> {
           impl_ops_setvec.insert(def_op);
         } else {
           processing.push_back(def_op);
+        }
+      }
+      // Also collect values used inside nested regions (e.g., reduce body)
+      // that are defined in the parent function. These are not captured by
+      // getOperands() but need to be included in the composite.
+      for (mlir::Region& region : curr_op->getRegions()) {
+        llvm::SetVector<mlir::Value> captured;
+        mlir::getUsedValuesDefinedAbove(region, region, captured);
+        for (mlir::Value value : captured) {
+          mlir::Operation* def_op = value.getDefiningOp();
+          if (def_op == nullptr) {
+            arg_pos_setvec.insert(
+                {value, std::numeric_limits<int64_t>::max()});
+          } else if (llvm::isa<mlir::stablehlo::ConstantOp>(def_op)) {
+            impl_ops_setvec.insert(def_op);
+          } else {
+            processing.push_back(def_op);
+          }
         }
       }
     }


### PR DESCRIPTION
### Problem

The `BuildStableHLOCompositePass` performs a reverse graph traversal from output boundary markers to input boundary markers to collect all ops that belong to a composite. The traversal followed `op->getOperands()` to discover dependencies, but this only captures values passed directly to an op, and it misses values that are used inside nested regions (e.g., the body of a `stablehlo.reduce`) but defined in the parent function.
                                                                                                                                                                                                                                                      
This caused the generated composite impl function to reference values that were never included as arguments or cloned ops, leading to invalid MLIR.                                                                                                 

### Fix                                                                                                                                                                                                                                                 
                                                            
After processing each op's direct operands, the traversal now also inspects all nested regions using `mlir::getUsedValuesDefinedAbove()` ([mlir doc](https://mlir.llvm.org/doxygen/namespacemlir.html#a98f08e970a346cd42559db87f97f0b91)) to find captured values. These are handled with the same logic as direct operands:                           
  - Block arguments added as composite arguments          
  - Constants included in the impl function body                                                                                                                                                                                                    
  - Other ops added to the traversal worklist