### PR TITLE
ci: declare workflow-level `contents: read` on 3 workflows

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   check_code_changes:
     name: Check Code Changes

--- a/.github/workflows/build_upstream_image.yml
+++ b/.github/workflows/build_upstream_image.yml
@@ -8,6 +8,10 @@ on:
       - 'experimental/**'
       - 'torchax/**'
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: linux.12xlarge

--- a/.github/workflows/lintercheck.yml
+++ b/.github/workflows/lintercheck.yml
@@ -7,6 +7,9 @@ on:
         tags:
             - r[0-9]+.[0-9]+
 
+permissions:
+  contents: read
+
 jobs:
     check_code_changes:
         name: Check Code Changes


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 3 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `openxla_pin_update_weekly.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.